### PR TITLE
RFC: [pvr] Fix problems with multiple PVR Addons running at the same time

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -205,9 +205,33 @@ namespace ADDON
         dlsym(m_libXBMC_addon, "XBMC_get_file_chunk_size");
       if (XBMC_get_file_chunk_size == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
+      XBMC_file_exists = (bool (*)(void* HANDLE, void* CB, const char *strFileName, bool bUseCache))
+        dlsym(m_libXBMC_addon, "XBMC_file_exists");
+      if (XBMC_file_exists == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_stat_file = (int (*)(void* HANDLE, void* CB, const char *strFileName, struct __stat64* buffer))
+        dlsym(m_libXBMC_addon, "XBMC_stat_file");
+      if (XBMC_stat_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_delete_file = (bool (*)(void* HANDLE, void* CB, const char *strFileName))
+        dlsym(m_libXBMC_addon, "XBMC_delete_file");
+      if (XBMC_delete_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
       XBMC_can_open_directory = (bool (*)(void* HANDLE, void* CB, const char* strURL))
         dlsym(m_libXBMC_addon, "XBMC_can_open_directory");
       if (XBMC_can_open_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_create_directory = (bool (*)(void* HANDLE, void* CB, const char* strPath))
+        dlsym(m_libXBMC_addon, "XBMC_create_directory");
+      if (XBMC_create_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_directory_exists = (bool (*)(void* HANDLE, void* CB, const char* strPath))
+        dlsym(m_libXBMC_addon, "XBMC_directory_exists");
+      if (XBMC_directory_exists == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_remove_directory = (bool (*)(void* HANDLE, void* CB, const char* strPath))
+        dlsym(m_libXBMC_addon, "XBMC_remove_directory");
+      if (XBMC_remove_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
       m_Callbacks = XBMC_register_me(m_Handle);
       return m_Callbacks != NULL;
@@ -413,6 +437,38 @@ namespace ADDON
     }
 
     /*!
+     * @brief Check if a file exists.
+     * @param strFileName The filename to check.
+     * @param bUseCache Check in file cache.
+     * @return true if the file exists false otherwise.
+     */
+    bool FileExists(const char *strFileName, bool bUseCache)
+    {
+      return XBMC_file_exists(m_Handle, m_Callbacks, strFileName, bUseCache);
+    }
+
+    /*!
+     * @brief Reads file status.
+     * @param strFileName The filename to read the status from.
+     * @param buffer The file status is written into this buffer.
+     * @return The file status was successfully read.
+     */
+    int StatFile(const char *strFileName, struct __stat64* buffer)
+    {
+      return XBMC_stat_file(m_Handle, m_Callbacks, strFileName, buffer);
+    }
+
+    /*!
+     * @brief Deletes a file.
+     * @param strFileName The filename to delete.
+     * @return The file was successfully deleted.
+     */
+    bool DeleteFile(const char *strFileName)
+    {
+      return XBMC_delete_file(m_Handle, m_Callbacks, strFileName);
+    }
+
+    /*!
      * @brief Checks whether a directory can be opened.
      * @param strUrl The URL of the directory to check.
      * @return True when it can be opened, false otherwise.
@@ -420,6 +476,36 @@ namespace ADDON
     bool CanOpenDirectory(const char* strUrl)
     {
       return XBMC_can_open_directory(m_Handle, m_Callbacks, strUrl);
+    }
+
+    /*!
+     * @brief Creates a directory.
+     * @param strPath Path to the directory.
+     * @return True when it was created, false otherwise.
+     */
+    bool CreateDirectory(const char *strPath)
+    {
+      return XBMC_create_directory(m_Handle, m_Callbacks, strPath);
+    }
+
+    /*!
+     * @brief Checks if a directory exists.
+     * @param strPath Path to the directory.
+     * @return True when it exists, false otherwise.
+     */
+    bool DirectoryExists(const char *strPath)
+    {
+      return XBMC_directory_exists(m_Handle, m_Callbacks, strPath);
+    }
+
+    /*!
+     * @brief Removes a directory.
+     * @param strPath Path to the directory.
+     * @return True when it was removed, false otherwise.
+     */
+    bool RemoveDirectory(const char *strPath)
+    {
+      return XBMC_remove_directory(m_Handle, m_Callbacks, strPath);
     }
 
   protected:
@@ -443,7 +529,13 @@ namespace ADDON
     int64_t (*XBMC_get_file_length)(void *HANDLE, void* CB, void* file);
     void (*XBMC_close_file)(void *HANDLE, void* CB, void* file);
     int (*XBMC_get_file_chunk_size)(void *HANDLE, void* CB, void* file);
+    bool (*XBMC_file_exists)(void *HANDLE, void* CB, const char *strFileName, bool bUseCache);
+    int (*XBMC_stat_file)(void *HANDLE, void* CB, const char *strFileName, struct __stat64* buffer);
+    bool (*XBMC_delete_file)(void *HANDLE, void* CB, const char *strFileName);
     bool (*XBMC_can_open_directory)(void *HANDLE, void* CB, const char* strURL);
+    bool (*XBMC_create_directory)(void *HANDLE, void* CB, const char* strPath);
+    bool (*XBMC_directory_exists)(void *HANDLE, void* CB, const char* strPath);
+    bool (*XBMC_remove_directory)(void *HANDLE, void* CB, const char* strPath);
 
   private:
     void *m_libXBMC_addon;

--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdarg.h>
 
 #ifdef _WIN32                   // windows
 #include "dlfcn-win32.h"
@@ -104,7 +105,7 @@ namespace ADDON
     {
       if (m_libXBMC_addon)
       {
-        XBMC_unregister_me();
+        XBMC_unregister_me(m_Handle, m_Callbacks);
         dlclose(m_libXBMC_addon);
       }
     }
@@ -124,91 +125,92 @@ namespace ADDON
         return false;
       }
 
-      XBMC_register_me   = (int (*)(void *HANDLE))
+      XBMC_register_me = (void* (*)(void *HANDLE))
         dlsym(m_libXBMC_addon, "XBMC_register_me");
-      if (XBMC_register_me == NULL)   { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_register_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      XBMC_unregister_me = (void (*)())
+      XBMC_unregister_me = (void (*)(void* HANDLE, void* CB))
         dlsym(m_libXBMC_addon, "XBMC_unregister_me");
       if (XBMC_unregister_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      Log                = (void (*)(const addon_log_t loglevel, const char *format, ... ))
+      XBMC_log = (void (*)(void* HANDLE, void* CB, const addon_log_t loglevel, const char *msg))
         dlsym(m_libXBMC_addon, "XBMC_log");
-      if (Log == NULL)                { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_log == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      GetSetting         = (bool (*)(const char* settingName, void *settingValue))
+      XBMC_get_setting = (bool (*)(void* HANDLE, void* CB, const char* settingName, void *settingValue))
         dlsym(m_libXBMC_addon, "XBMC_get_setting");
-      if (GetSetting == NULL)         { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_get_setting == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      QueueNotification  = (void (*)(const queue_msg_t loglevel, const char *format, ... ))
+      XBMC_queue_notification = (void (*)(void* HANDLE, void* CB, const queue_msg_t loglevel, const char *msg))
         dlsym(m_libXBMC_addon, "XBMC_queue_notification");
-      if (QueueNotification == NULL)  { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_queue_notification == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      UnknownToUTF8      = (void (*)(std::string &str))
+      XBMC_unknown_to_utf8 = (void (*)(void* HANDLE, void* CB, std::string &str))
         dlsym(m_libXBMC_addon, "XBMC_unknown_to_utf8");
-      if (UnknownToUTF8 == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_unknown_to_utf8 == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      GetLocalizedString = (const char* (*)(int dwCode))
+      XBMC_get_localized_string = (const char* (*)(void* HANDLE, void* CB, int dwCode))
         dlsym(m_libXBMC_addon, "XBMC_get_localized_string");
-      if (GetLocalizedString == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_get_localized_string == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      GetDVDMenuLanguage = (const char* (*)())
+      XBMC_get_dvd_menu_language = (const char* (*)(void* HANDLE, void* CB))
         dlsym(m_libXBMC_addon, "XBMC_get_dvd_menu_language");
-      if (GetDVDMenuLanguage == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_get_dvd_menu_language == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      OpenFile = (void* (*)(const char* strFileName, unsigned int flags))
+      XBMC_open_file = (void* (*)(void* HANDLE, void* CB, const char* strFileName, unsigned int flags))
         dlsym(m_libXBMC_addon, "XBMC_open_file");
-      if (OpenFile == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_open_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      OpenFileForWrite = (void* (*)(const char* strFileName, bool bOverWrite))
+      XBMC_open_file_for_write = (void* (*)(void* HANDLE, void* CB, const char* strFileName, bool bOverWrite))
         dlsym(m_libXBMC_addon, "XBMC_open_file_for_write");
-      if (OpenFileForWrite == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_open_file_for_write == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      ReadFile = (unsigned int (*)(void* file, void* lpBuf, int64_t uiBufSize))
+      XBMC_read_file = (unsigned int (*)(void* HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize))
         dlsym(m_libXBMC_addon, "XBMC_read_file");
-      if (ReadFile == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_read_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      ReadFileString = (bool (*)(void* file, char *szLine, int iLineLength))
+      XBMC_read_file_string = (bool (*)(void* HANDLE, void* CB, void* file, char *szLine, int iLineLength))
         dlsym(m_libXBMC_addon, "XBMC_read_file_string");
-      if (ReadFileString == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_read_file_string == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      WriteFile = (int (*)(void* file, const void* lpBuf, int64_t uiBufSize))
+      XBMC_write_file = (int (*)(void* HANDLE, void* CB, void* file, const void* lpBuf, int64_t uiBufSize))
         dlsym(m_libXBMC_addon, "XBMC_write_file");
-      if (WriteFile == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_write_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      FlushFile = (void (*)(void* file))
+      XBMC_flush_file = (void (*)(void* HANDLE, void* CB, void* file))
         dlsym(m_libXBMC_addon, "XBMC_flush_file");
-      if (FlushFile == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_flush_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      SeekFile = (int64_t (*)(void* file, int64_t iFilePosition, int iWhence))
+      XBMC_seek_file = (int64_t (*)(void* HANDLE, void* CB, void* file, int64_t iFilePosition, int iWhence))
         dlsym(m_libXBMC_addon, "XBMC_seek_file");
-      if (SeekFile == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_seek_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      TruncateFile = (int (*)(void* file, int64_t iSize))
+      XBMC_truncate_file = (int (*)(void* HANDLE, void* CB, void* file, int64_t iSize))
         dlsym(m_libXBMC_addon, "XBMC_truncate_file");
-      if (TruncateFile == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_truncate_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      GetFilePosition = (int64_t (*)(void* file))
+      XBMC_get_file_position = (int64_t (*)(void* HANDLE, void* CB, void* file))
         dlsym(m_libXBMC_addon, "XBMC_get_file_position");
-      if (GetFilePosition == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_get_file_position == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      GetFileLength = (int64_t (*)(void* file))
+      XBMC_get_file_length = (int64_t (*)(void* HANDLE, void* CB, void* file))
         dlsym(m_libXBMC_addon, "XBMC_get_file_length");
-      if (GetFileLength == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_get_file_length == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      CloseFile = (void (*)(void* file))
+      XBMC_close_file = (void (*)(void* HANDLE, void* CB, void* file))
         dlsym(m_libXBMC_addon, "XBMC_close_file");
-      if (CloseFile == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_close_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      GetFileChunkSize = (int (*)(void* file))
+      XBMC_get_file_chunk_size = (int (*)(void* HANDLE, void* CB, void* file))
         dlsym(m_libXBMC_addon, "XBMC_get_file_chunk_size");
-      if (GetFileChunkSize == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_get_file_chunk_size == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      CanOpenDirectory = (bool (*)(const char* strURL))
+      XBMC_can_open_directory = (bool (*)(void* HANDLE, void* CB, const char* strURL))
         dlsym(m_libXBMC_addon, "XBMC_can_open_directory");
-      if (CanOpenDirectory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+      if (XBMC_can_open_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      return XBMC_register_me(m_Handle) > 0;
+      m_Callbacks = XBMC_register_me(m_Handle);
+      return m_Callbacks != NULL;
     }
 
     /*!
@@ -216,7 +218,15 @@ namespace ADDON
      * @param loglevel The log level of the message.
      * @param format The format of the message to pass to XBMC.
      */
-    void (*Log)(const addon_log_t loglevel, const char *format, ... );
+    void Log(const addon_log_t loglevel, const char *format, ... )
+    {
+      char buffer[16384];
+      va_list args;
+      va_start (args, format);
+      vsprintf (buffer, format, args);
+      va_end (args);
+      return XBMC_log(m_Handle, m_Callbacks, loglevel, buffer);
+    }
 
     /*!
      * @brief Get a settings value for this add-on.
@@ -224,34 +234,54 @@ namespace ADDON
      * @param settingValue The value.
      * @return True if the settings was fetched successfully, false otherwise.
      */
-    bool (*GetSetting)(const char* settingName, void *settingValue);
+    bool GetSetting(const char* settingName, void *settingValue)
+    {
+      return XBMC_get_setting(m_Handle, m_Callbacks, settingName, settingValue);
+    }
 
     /*!
      * @brief Queue a notification in the GUI.
      * @param type The message type.
      * @param format The format of the message to pass to display in XBMC.
      */
-    void (*QueueNotification)(const queue_msg_t type, const char *format, ... );
+    void QueueNotification(const queue_msg_t type, const char *format, ... )
+    {
+      char buffer[16384];
+      va_list args;
+      va_start (args, format);
+      vsprintf (buffer, format, args);
+      va_end (args);
+      return XBMC_queue_notification(m_Handle, m_Callbacks, type, buffer);
+    }
 
     /*!
      * @brief Translate a string with an unknown encoding to UTF8.
      * @param sourceDest The string to translate.
      */
-    void (*UnknownToUTF8)(std::string &str);
+    void UnknownToUTF8(std::string &str)
+    {
+      return XBMC_unknown_to_utf8(m_Handle, m_Callbacks, str);
+    }
 
     /*!
      * @brief Get a localised message.
      * @param dwCode The code of the message to get.
      * @return The message. Needs to be freed when done.
      */
-    const char* (*GetLocalizedString)(int dwCode);
+    const char* GetLocalizedString(int dwCode)
+    {
+      return XBMC_get_localized_string(m_Handle, m_Callbacks, dwCode);
+    }
 
 
     /*!
      * @brief Get the DVD menu language.
      * @return The language. Needs to be freed when done.
      */
-    const char* (*GetDVDMenuLanguage)();
+    const char* GetDVDMenuLanguage()
+    {
+      return XBMC_get_dvd_menu_language(m_Handle, m_Callbacks);
+    }
 
     /*!
      * @brief Open the file with filename via XBMC's CFile. Needs to be closed by calling CloseFile() when done.
@@ -259,7 +289,10 @@ namespace ADDON
      * @param flags The flags to pass. Documented in XBMC's File.h
      * @return A handle for the file, or NULL if it couldn't be opened.
      */
-    void* (*OpenFile)(const char* strFileName, unsigned int flags);
+    void* OpenFile(const char* strFileName, unsigned int flags)
+    {
+      return XBMC_open_file(m_Handle, m_Callbacks, strFileName, flags);
+    }
 
     /*!
      * @brief Open the file with filename via XBMC's CFile in write mode. Needs to be closed by calling CloseFile() when done.
@@ -267,7 +300,10 @@ namespace ADDON
      * @param bOverWrite True to overwrite, false otherwise.
      * @return A handle for the file, or NULL if it couldn't be opened.
      */
-    void* (*OpenFileForWrite)(const char* strFileName, bool bOverWrite);
+    void* OpenFileForWrite(const char* strFileName, bool bOverWrite)
+    {
+      return XBMC_open_file_for_write(m_Handle, m_Callbacks, strFileName, bOverWrite);
+    }
 
     /*!
      * @brief Read from an open file.
@@ -276,7 +312,10 @@ namespace ADDON
      * @param uiBufSize The size of the buffer.
      * @return Number of bytes read.
      */
-    unsigned int (*ReadFile)(void* file, void* lpBuf, int64_t uiBufSize);
+    unsigned int ReadFile(void* file, void* lpBuf, int64_t uiBufSize)
+    {
+      return XBMC_read_file(m_Handle, m_Callbacks, file, lpBuf, uiBufSize);
+    }
 
     /*!
      * @brief Read a string from an open file.
@@ -285,7 +324,10 @@ namespace ADDON
      * @param iLineLength The size of the buffer.
      * @return True when a line was read, false otherwise.
      */
-    bool (*ReadFileString)(void* file, char *szLine, int iLineLength);
+    bool ReadFileString(void* file, char *szLine, int iLineLength)
+    {
+      return XBMC_read_file_string(m_Handle, m_Callbacks, file, szLine, iLineLength);
+    }
 
     /*!
      * @brief Write to a file opened in write mode.
@@ -294,13 +336,19 @@ namespace ADDON
      * @param uiBufSize Size of the data to write.
      * @return The number of bytes read.
      */
-    int (*WriteFile)(void* file, const void* lpBuf, int64_t uiBufSize);
+    int WriteFile(void* file, const void* lpBuf, int64_t uiBufSize)
+    {
+      return XBMC_write_file(m_Handle, m_Callbacks, file, lpBuf, uiBufSize);
+    }
 
     /*!
      * @brief Flush buffered data.
      * @param file The file handle to flush the data for.
      */
-    void (*FlushFile)(void* file);
+    void FlushFile(void* file)
+    {
+       return XBMC_flush_file(m_Handle, m_Callbacks, file);
+    }
 
     /*!
      * @brief Seek in an open file.
@@ -309,7 +357,10 @@ namespace ADDON
      * @param iWhence Seek argument. See stdio.h for possible values.
      * @return The new position.
      */
-    int64_t (*SeekFile)(void* file, int64_t iFilePosition, int iWhence);
+    int64_t SeekFile(void* file, int64_t iFilePosition, int iWhence)
+    {
+      return XBMC_seek_file(m_Handle, m_Callbacks, file, iFilePosition, iWhence);
+    }
 
     /*!
      * @brief Truncate a file to the requested size.
@@ -317,49 +368,87 @@ namespace ADDON
      * @param iSize The new max size.
      * @return New size?
      */
-    int (*TruncateFile)(void* file, int64_t iSize);
+    int TruncateFile(void* file, int64_t iSize)
+    {
+      return XBMC_truncate_file(m_Handle, m_Callbacks, file, iSize);
+    }
 
     /*!
      * @brief The current position in an open file.
      * @param file The file handle to get the position for.
      * @return The requested position.
      */
-    int64_t (*GetFilePosition)(void* file);
+    int64_t GetFilePosition(void* file)
+    {
+      return XBMC_get_file_position(m_Handle, m_Callbacks, file);
+    }
 
     /*!
      * @brief Get the file size of an open file.
      * @param file The file to get the size for.
      * @return The requested size.
      */
-    int64_t (*GetFileLength)(void* file);
+    int64_t GetFileLength(void* file)
+    {
+      return XBMC_get_file_length(m_Handle, m_Callbacks, file);
+    }
 
     /*!
      * @brief Close an open file.
      * @param file The file handle to close.
      */
-    void (*CloseFile)(void* file);
+    void CloseFile(void* file)
+    {
+      return XBMC_close_file(m_Handle, m_Callbacks, file);
+    }
 
     /*!
      * @brief Get the chunk size for an open file.
      * @param file the file handle to get the size for.
      * @return The requested size.
      */
-    int (*GetFileChunkSize)(void* file);
+    int GetFileChunkSize(void* file)
+    {
+      return XBMC_get_file_chunk_size(m_Handle, m_Callbacks, file);
+    }
 
     /*!
      * @brief Checks whether a directory can be opened.
      * @param strUrl The URL of the directory to check.
      * @return True when it can be opened, false otherwise.
      */
-    bool (*CanOpenDirectory)(const char* strUrl);
+    bool CanOpenDirectory(const char* strUrl)
+    {
+      return XBMC_can_open_directory(m_Handle, m_Callbacks, strUrl);
+    }
 
   protected:
-    int (*XBMC_register_me)(void *HANDLE);
-    void (*XBMC_unregister_me)();
+    void* (*XBMC_register_me)(void *HANDLE);
+    void (*XBMC_unregister_me)(void *HANDLE, void* CB);
+    void (*XBMC_log)(void *HANDLE, void* CB, const addon_log_t loglevel, const char *msg);
+    bool (*XBMC_get_setting)(void *HANDLE, void* CB, const char* settingName, void *settingValue);
+    void (*XBMC_queue_notification)(void *HANDLE, void* CB, const queue_msg_t type, const char *msg);
+    void (*XBMC_unknown_to_utf8)(void *HANDLE, void* CB, std::string &str);
+    const char* (*XBMC_get_localized_string)(void *HANDLE, void* CB, int dwCode);
+    const char* (*XBMC_get_dvd_menu_language)(void *HANDLE, void* CB);
+    void* (*XBMC_open_file)(void *HANDLE, void* CB, const char* strFileName, unsigned int flags);
+    void* (*XBMC_open_file_for_write)(void *HANDLE, void* CB, const char* strFileName, bool bOverWrite);
+    unsigned int (*XBMC_read_file)(void *HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize);
+    bool (*XBMC_read_file_string)(void *HANDLE, void* CB, void* file, char *szLine, int iLineLength);
+    int (*XBMC_write_file)(void *HANDLE, void* CB, void* file, const void* lpBuf, int64_t uiBufSize);
+    void (*XBMC_flush_file)(void *HANDLE, void* CB, void* file);
+    int64_t (*XBMC_seek_file)(void *HANDLE, void* CB, void* file, int64_t iFilePosition, int iWhence);
+    int (*XBMC_truncate_file)(void *HANDLE, void* CB, void* file, int64_t iSize);
+    int64_t (*XBMC_get_file_position)(void *HANDLE, void* CB, void* file);
+    int64_t (*XBMC_get_file_length)(void *HANDLE, void* CB, void* file);
+    void (*XBMC_close_file)(void *HANDLE, void* CB, void* file);
+    int (*XBMC_get_file_chunk_size)(void *HANDLE, void* CB, void* file);
+    bool (*XBMC_can_open_directory)(void *HANDLE, void* CB, const char* strURL);
 
   private:
     void *m_libXBMC_addon;
     void *m_Handle;
+    void *m_Callbacks;
     struct cb_array
     {
       const char* libPath;

--- a/addons/library.xbmc.gui/libXBMC_gui.h
+++ b/addons/library.xbmc.gui/libXBMC_gui.h
@@ -56,7 +56,7 @@ public:
   {
     if (m_libXBMC_gui)
     {
-      GUI_unregister_me();
+      GUI_unregister_me(m_Handle, m_Callbacks);
       dlclose(m_libXBMC_gui);
     }
   }
@@ -76,101 +76,177 @@ public:
       return false;
     }
 
-    GUI_register_me         = (int (*)(void *HANDLE))
+    GUI_register_me = (void* (*)(void *HANDLE))
       dlsym(m_libXBMC_gui, "GUI_register_me");
-    if (GUI_register_me == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_register_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    GUI_unregister_me       = (void (*)())
+    GUI_unregister_me = (void (*)(void *HANDLE, void *CB))
       dlsym(m_libXBMC_gui, "GUI_unregister_me");
-    if (GUI_unregister_me == NULL)    { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_unregister_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Lock                    = (void (*)())
+    GUI_lock = (void (*)(void *HANDLE, void *CB))
       dlsym(m_libXBMC_gui, "GUI_lock");
-    if (Lock == NULL)                 { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_lock == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Unlock                  = (void (*)())
+    GUI_unlock = (void (*)(void *HANDLE, void *CB))
       dlsym(m_libXBMC_gui, "GUI_unlock");
-    if (Unlock == NULL)               { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_unlock == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    GetScreenHeight         = (int (*)())
+    GUI_get_screen_height = (int (*)(void *HANDLE, void *CB))
       dlsym(m_libXBMC_gui, "GUI_get_screen_height");
-    if (GetScreenHeight == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_get_screen_height == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    GetScreenWidth          = (int (*)())
+    GUI_get_screen_width = (int (*)(void *HANDLE, void *CB))
       dlsym(m_libXBMC_gui, "GUI_get_screen_width");
-    if (GetScreenWidth == NULL)       { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_get_screen_width == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    GetVideoResolution      = (int (*)())
+    GUI_get_video_resolution = (int (*)(void *HANDLE, void *CB))
       dlsym(m_libXBMC_gui, "GUI_get_video_resolution");
-    if (GetVideoResolution == NULL)   { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_get_video_resolution == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Window_create           = (CAddonGUIWindow* (*)(const char *xmlFilename, const char *defaultSkin, bool forceFallback, bool asDialog))
+    GUI_Window_create = (CAddonGUIWindow* (*)(void *HANDLE, void *CB, const char *xmlFilename, const char *defaultSkin, bool forceFallback, bool asDialog))
       dlsym(m_libXBMC_gui, "GUI_Window_create");
-    if (Window_create == NULL)        { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_Window_create == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Window_destroy          = (void (*)(CAddonGUIWindow* p))
+    GUI_Window_destroy = (void (*)(CAddonGUIWindow* p))
       dlsym(m_libXBMC_gui, "GUI_Window_destroy");
-    if (Window_destroy == NULL)       { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_Window_destroy == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Control_getSpin         = (CAddonGUISpinControl* (*)(CAddonGUIWindow *window, int controlId))
+    GUI_control_get_spin = (CAddonGUISpinControl* (*)(void *HANDLE, void *CB, CAddonGUIWindow *window, int controlId))
       dlsym(m_libXBMC_gui, "GUI_control_get_spin");
-    if (Control_getSpin == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_control_get_spin == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Control_releaseSpin     = (void (*)(CAddonGUISpinControl* p))
+    GUI_control_release_spin = (void (*)(CAddonGUISpinControl* p))
       dlsym(m_libXBMC_gui, "GUI_control_release_spin");
-    if (Control_releaseSpin == NULL)  { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_control_release_spin == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Control_getRadioButton  = (CAddonGUIRadioButton* (*)(CAddonGUIWindow *window, int controlId))
+    GUI_control_get_radiobutton  = (CAddonGUIRadioButton* (*)(void *HANDLE, void *CB, CAddonGUIWindow *window, int controlId))
       dlsym(m_libXBMC_gui, "GUI_control_get_radiobutton");
-    if (Control_getRadioButton == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_control_get_radiobutton == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Control_releaseRadioButton = (void (*)(CAddonGUIRadioButton* p))
+    GUI_control_release_radiobutton = (void (*)(CAddonGUIRadioButton* p))
       dlsym(m_libXBMC_gui, "GUI_control_release_radiobutton");
-    if (Control_releaseRadioButton == NULL)  { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_control_release_radiobutton == NULL)  { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Control_getProgress     = (CAddonGUIProgressControl* (*)(CAddonGUIWindow *window, int controlId))
+    GUI_control_get_progress     = (CAddonGUIProgressControl* (*)(void *HANDLE, void *CB, CAddonGUIWindow *window, int controlId))
       dlsym(m_libXBMC_gui, "GUI_control_get_progress");
-    if (Control_getProgress == NULL)  { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_control_get_progress == NULL)  { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Control_releaseProgress = (void (*)(CAddonGUIProgressControl* p))
+    GUI_control_release_progress = (void (*)(CAddonGUIProgressControl* p))
       dlsym(m_libXBMC_gui, "GUI_control_release_progress");
-    if (Control_releaseProgress == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_control_release_progress == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    ListItem_create         = (CAddonListItem* (*)(const char *label, const char *label2, const char *iconImage, const char *thumbnailImage, const char *path))
+    GUI_ListItem_create = (CAddonListItem* (*)(void *HANDLE, void *CB, const char *label, const char *label2, const char *iconImage, const char *thumbnailImage, const char *path))
       dlsym(m_libXBMC_gui, "GUI_ListItem_create");
-    if (ListItem_create == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_ListItem_create == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    ListItem_destroy        = (void (*)(CAddonListItem* p))
+    GUI_ListItem_destroy = (void (*)(CAddonListItem* p))
       dlsym(m_libXBMC_gui, "GUI_ListItem_destroy");
-    if (ListItem_destroy == NULL)     { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (GUI_ListItem_destroy == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
 
-    return GUI_register_me(m_Handle) > 0;
+    m_Callbacks = GUI_register_me(m_Handle);
+    return m_Callbacks != NULL;
   }
 
-  void (*Lock)();
-  void (*Unlock)();
-  int (*GetScreenHeight)();
-  int (*GetScreenWidth)();
-  int (*GetVideoResolution)();
-  CAddonGUIWindow* (*Window_create)(const char *xmlFilename, const char *defaultSkin, bool forceFallback, bool asDialog);
-  void (*Window_destroy)(CAddonGUIWindow* p);
-  CAddonGUISpinControl* (*Control_getSpin)(CAddonGUIWindow *window, int controlId);
-  void (*Control_releaseSpin)(CAddonGUISpinControl* p);
-  CAddonGUIRadioButton* (*Control_getRadioButton)(CAddonGUIWindow *window, int controlId);
-  void (*Control_releaseRadioButton)(CAddonGUIRadioButton* p);
-  CAddonGUIProgressControl* (*Control_getProgress)(CAddonGUIWindow *window, int controlId);
-  void (*Control_releaseProgress)(CAddonGUIProgressControl* p);
-  CAddonListItem* (*ListItem_create)(const char *label, const char *label2, const char *iconImage, const char *thumbnailImage, const char *path);
-  void (*ListItem_destroy)(CAddonListItem* p);
+  void Lock()
+  {
+    return GUI_lock(m_Handle, m_Callbacks);
+  }
+
+  void Unlock()
+  {
+    return GUI_unlock(m_Handle, m_Callbacks);
+  }
+
+  int GetScreenHeight()
+  {
+    return GUI_get_screen_height(m_Handle, m_Callbacks);
+  }
+
+  int GetScreenWidth()
+  {
+    return GUI_get_screen_width(m_Handle, m_Callbacks);
+  }
+
+  int GetVideoResolution()
+  {
+    return GUI_get_video_resolution(m_Handle, m_Callbacks);
+  }
+
+  CAddonGUIWindow* Window_create(const char *xmlFilename, const char *defaultSkin, bool forceFallback, bool asDialog)
+  {
+    return GUI_Window_create(m_Handle, m_Callbacks, xmlFilename, defaultSkin, forceFallback, asDialog);
+  }
+
+  void Window_destroy(CAddonGUIWindow* p)
+  {
+    return GUI_Window_destroy(p);
+  }
+
+  CAddonGUISpinControl* Control_getSpin(CAddonGUIWindow *window, int controlId)
+  {
+    return GUI_control_get_spin(m_Handle, m_Callbacks, window, controlId);
+  }
+
+  void Control_releaseSpin(CAddonGUISpinControl* p)
+  {
+    return GUI_control_release_spin(p);
+  }
+
+  CAddonGUIRadioButton* Control_getRadioButton(CAddonGUIWindow *window, int controlId)
+  {
+    return GUI_control_get_radiobutton(m_Handle, m_Callbacks, window, controlId);
+  }
+
+  void Control_releaseRadioButton(CAddonGUIRadioButton* p)
+  {
+    return GUI_control_release_radiobutton(p);
+  }
+
+  CAddonGUIProgressControl* Control_getProgress(CAddonGUIWindow *window, int controlId)
+  {
+    return GUI_control_get_progress(m_Handle, m_Callbacks, window, controlId);
+  }
+
+  void Control_releaseProgress(CAddonGUIProgressControl* p)
+  {
+    return GUI_control_release_progress(p);
+  }
+
+  CAddonListItem* ListItem_create(const char *label, const char *label2, const char *iconImage, const char *thumbnailImage, const char *path)
+  {
+    return GUI_ListItem_create(m_Handle, m_Callbacks, label, label2, iconImage, thumbnailImage, path);
+  }
+
+  void ListItem_destroy(CAddonListItem* p)
+  {
+    return GUI_ListItem_destroy(p);
+  }
 
 protected:
-  int (*GUI_register_me)(void *HANDLE);
-  void (*GUI_unregister_me)();
+  void* (*GUI_register_me)(void *HANDLE);
+  void (*GUI_unregister_me)(void *HANDLE, void* CB);
+  void (*GUI_lock)(void *HANDLE, void* CB);
+  void (*GUI_unlock)(void *HANDLE, void* CB);
+  int (*GUI_get_screen_height)(void *HANDLE, void* CB);
+  int (*GUI_get_screen_width)(void *HANDLE, void* CB);
+  int (*GUI_get_video_resolution)(void *HANDLE, void* CB);
+  CAddonGUIWindow* (*GUI_Window_create)(void *HANDLE, void* CB, const char *xmlFilename, const char *defaultSkin, bool forceFallback, bool asDialog);
+  void (*GUI_Window_destroy)(CAddonGUIWindow* p);
+  CAddonGUISpinControl* (*GUI_control_get_spin)(void *HANDLE, void* CB, CAddonGUIWindow *window, int controlId);
+  void (*GUI_control_release_spin)(CAddonGUISpinControl* p);
+  CAddonGUIRadioButton* (*GUI_control_get_radiobutton)(void *HANDLE, void* CB, CAddonGUIWindow *window, int controlId);
+  void (*GUI_control_release_radiobutton)(CAddonGUIRadioButton* p);
+  CAddonGUIProgressControl* (*GUI_control_get_progress)(void *HANDLE, void* CB, CAddonGUIWindow *window, int controlId);
+  void (*GUI_control_release_progress)(CAddonGUIProgressControl* p);
+  CAddonListItem* (*GUI_ListItem_create)(void *HANDLE, void* CB, const char *label, const char *label2, const char *iconImage, const char *thumbnailImage, const char *path);
+  void (*GUI_ListItem_destroy)(CAddonListItem* p);
 
 private:
   void *m_libXBMC_gui;
   void *m_Handle;
+  void *m_Callbacks;
   struct cb_array
   {
     const char* libPath;
@@ -180,7 +256,7 @@ private:
 class CAddonGUISpinControl
 {
 public:
-  CAddonGUISpinControl(CAddonGUIWindow *window, int controlId);
+  CAddonGUISpinControl(void *hdl, void *cb, CAddonGUIWindow *window, int controlId);
   virtual ~CAddonGUISpinControl(void) {}
 
   virtual void SetVisible(bool yesNo);
@@ -194,13 +270,15 @@ private:
   CAddonGUIWindow *m_Window;
   int         m_ControlId;
   GUIHANDLE   m_SpinHandle;
+  void *m_Handle;
+  void *m_cb;
 };
 
 class CAddonGUIRadioButton
 {
 public:
-  CAddonGUIRadioButton(CAddonGUIWindow *window, int controlId);
-  ~CAddonGUIRadioButton() {}
+  CAddonGUIRadioButton(void *hdl, void *cb, CAddonGUIWindow *window, int controlId);
+  virtual ~CAddonGUIRadioButton() {}
 
   virtual void SetVisible(bool yesNo);
   virtual void SetText(const char *label);
@@ -211,12 +289,14 @@ private:
   CAddonGUIWindow *m_Window;
   int         m_ControlId;
   GUIHANDLE   m_ButtonHandle;
+  void *m_Handle;
+  void *m_cb;
 };
 
 class CAddonGUIProgressControl
 {
 public:
-  CAddonGUIProgressControl(CAddonGUIWindow *window, int controlId);
+  CAddonGUIProgressControl(void *hdl, void *cb, CAddonGUIWindow *window, int controlId);
   virtual ~CAddonGUIProgressControl(void) {}
 
   virtual void SetPercentage(float fPercent);
@@ -229,6 +309,8 @@ private:
   CAddonGUIWindow *m_Window;
   int         m_ControlId;
   GUIHANDLE   m_ProgressHandle;
+  void *m_Handle;
+  void *m_cb;
 };
 
 class CAddonListItem
@@ -236,7 +318,7 @@ class CAddonListItem
 friend class CAddonGUIWindow;
 
 public:
-  CAddonListItem(const char *label, const char *label2, const char *iconImage, const char *thumbnailImage, const char *path);
+  CAddonListItem(void *hdl, void *cb, const char *label, const char *label2, const char *iconImage, const char *thumbnailImage, const char *path);
   virtual ~CAddonListItem(void) {}
 
   virtual const char  *GetLabel();
@@ -254,6 +336,8 @@ public:
 //    {(char*)"isSelected();
 protected:
   GUIHANDLE   m_ListItemHandle;
+  void *m_Handle;
+  void *m_cb;
 };
 
 class CAddonGUIWindow
@@ -263,8 +347,8 @@ friend class CAddonGUIRadioButton;
 friend class CAddonGUIProgressControl;
 
 public:
-  CAddonGUIWindow(const char *xmlFilename, const char *defaultSkin, bool forceFallback, bool asDialog);
-  ~CAddonGUIWindow();
+  CAddonGUIWindow(void *hdl, void *cb, const char *xmlFilename, const char *defaultSkin, bool forceFallback, bool asDialog);
+  virtual ~CAddonGUIWindow();
 
   virtual bool         Show();
   virtual void         Close();
@@ -305,5 +389,6 @@ public:
 
 protected:
   GUIHANDLE m_WindowHandle;
+  void *m_Handle;
+  void *m_cb;
 };
-

--- a/addons/library.xbmc.pvr/libXBMC_pvr.h
+++ b/addons/library.xbmc.pvr/libXBMC_pvr.h
@@ -49,7 +49,7 @@ public:
   {
     if (m_libXBMC_pvr)
     {
-      PVR_unregister_me();
+      PVR_unregister_me(m_Handle, m_Callbacks);
       dlclose(m_libXBMC_pvr);
     }
   }
@@ -69,99 +69,172 @@ public:
       return false;
     }
 
-    PVR_register_me         = (int (*)(void *HANDLE))
+    PVR_register_me = (void* (*)(void *HANDLE))
       dlsym(m_libXBMC_pvr, "PVR_register_me");
-    if (PVR_register_me == NULL)      { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_register_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    PVR_unregister_me       = (void (*)())
+    PVR_unregister_me = (void (*)(void* HANDLE, void* CB))
       dlsym(m_libXBMC_pvr, "PVR_unregister_me");
-    if (PVR_unregister_me == NULL)    { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_unregister_me == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TransferEpgEntry        = (void (*)(const ADDON_HANDLE handle, const EPG_TAG *epgentry))
+    PVR_transfer_epg_entry = (void (*)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const EPG_TAG *epgentry))
       dlsym(m_libXBMC_pvr, "PVR_transfer_epg_entry");
-    if (TransferEpgEntry == NULL)       { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_transfer_epg_entry == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TransferChannelEntry    = (void (*)(const ADDON_HANDLE handle, const PVR_CHANNEL *chan))
+    PVR_transfer_channel_entry = (void (*)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_CHANNEL *chan))
       dlsym(m_libXBMC_pvr, "PVR_transfer_channel_entry");
-    if (TransferChannelEntry == NULL)   { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_transfer_channel_entry == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TransferTimerEntry      = (void (*)(const ADDON_HANDLE handle, const PVR_TIMER *timer))
+    PVR_transfer_timer_entry = (void (*)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_TIMER *timer))
       dlsym(m_libXBMC_pvr, "PVR_transfer_timer_entry");
-    if (TransferTimerEntry == NULL)     { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_transfer_timer_entry == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TransferRecordingEntry  = (void (*)(const ADDON_HANDLE handle, const PVR_RECORDING *recording))
+    PVR_transfer_recording_entry = (void (*)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_RECORDING *recording))
       dlsym(m_libXBMC_pvr, "PVR_transfer_recording_entry");
-    if (TransferRecordingEntry == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_transfer_recording_entry == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    AddMenuHook             = (void (*)(PVR_MENUHOOK *hook))
+    PVR_add_menu_hook = (void (*)(void* HANDLE, void* CB, PVR_MENUHOOK *hook))
       dlsym(m_libXBMC_pvr, "PVR_add_menu_hook");
-    if (AddMenuHook == NULL)            { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_add_menu_hook == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    Recording               = (void (*)(const char *Name, const char *FileName, bool On))
+    PVR_recording = (void (*)(void* HANDLE, void* CB, const char *Name, const char *FileName, bool On))
       dlsym(m_libXBMC_pvr, "PVR_recording");
-    if (Recording == NULL)              { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_recording == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TriggerTimerUpdate      = (void (*)())
+    PVR_trigger_timer_update = (void (*)(void* HANDLE, void* CB))
       dlsym(m_libXBMC_pvr, "PVR_trigger_timer_update");
-    if (TriggerTimerUpdate == NULL)     { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_trigger_timer_update == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TriggerRecordingUpdate  = (void (*)())
+    PVR_trigger_recording_update = (void (*)(void* HANDLE, void* CB))
       dlsym(m_libXBMC_pvr, "PVR_trigger_recording_update");
-    if (TriggerRecordingUpdate == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_trigger_recording_update == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TriggerChannelUpdate  = (void (*)())
+    PVR_trigger_channel_update = (void (*)(void* HANDLE, void* CB))
       dlsym(m_libXBMC_pvr, "PVR_trigger_channel_update");
-    if (TriggerChannelUpdate == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_trigger_channel_update == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TriggerChannelGroupsUpdate  = (void (*)())
+    PVR_trigger_channel_groups_update = (void (*)(void* HANDLE, void* CB))
       dlsym(m_libXBMC_pvr, "PVR_trigger_channel_groups_update");
-    if (TriggerChannelGroupsUpdate == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_trigger_channel_groups_update == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TransferChannelGroup  = (void (*)(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group))
+    PVR_transfer_channel_group  = (void (*)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group))
       dlsym(m_libXBMC_pvr, "PVR_transfer_channel_group");
-    if (TransferChannelGroup == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_transfer_channel_group == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    TransferChannelGroupMember  = (void (*)(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member))
+    PVR_transfer_channel_group_member = (void (*)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member))
       dlsym(m_libXBMC_pvr, "PVR_transfer_channel_group_member");
-    if (TransferChannelGroupMember == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_transfer_channel_group_member == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
 #ifdef USE_DEMUX
-    FreeDemuxPacket         = (void (*)(DemuxPacket* pPacket))
+    PVR_free_demux_packet = (void (*)(void* HANDLE, void* CB, DemuxPacket* pPacket))
       dlsym(m_libXBMC_pvr, "PVR_free_demux_packet");
-    if (FreeDemuxPacket == NULL)        { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_free_demux_packet == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-    AllocateDemuxPacket     = (DemuxPacket* (*)(int iDataSize))
+    PVR_allocate_demux_packet = (DemuxPacket* (*)(void* HANDLE, void* CB, int iDataSize))
       dlsym(m_libXBMC_pvr, "PVR_allocate_demux_packet");
-    if (AllocateDemuxPacket == NULL)    { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+    if (PVR_allocate_demux_packet == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 #endif
 
-    return PVR_register_me(m_Handle) > 0;
+    m_Callbacks = PVR_register_me(m_Handle);
+    return m_Callbacks != NULL;
   }
 
-  void (*TransferEpgEntry)(const ADDON_HANDLE handle, const EPG_TAG *epgentry);
-  void (*TransferChannelEntry)(const ADDON_HANDLE handle, const PVR_CHANNEL *chan);
-  void (*TransferTimerEntry)(const ADDON_HANDLE handle, const PVR_TIMER *timer);
-  void (*TransferRecordingEntry)(const ADDON_HANDLE handle, const PVR_RECORDING *recording);
-  void (*AddMenuHook)(PVR_MENUHOOK *hook);
-  void (*Recording)(const char *Name, const char *FileName, bool On);
-  void (*TriggerTimerUpdate)();
-  void (*TriggerRecordingUpdate)();
-  void (*TriggerChannelUpdate)();
-  void (*TriggerChannelGroupsUpdate)();
-  void (*TransferChannelGroup)(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group);
-  void (*TransferChannelGroupMember)(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member);
+  void TransferEpgEntry(const ADDON_HANDLE handle, const EPG_TAG *epgentry)
+  {
+    return PVR_transfer_epg_entry(m_Handle, m_Callbacks, handle, epgentry);
+  }
+
+  void TransferChannelEntry(const ADDON_HANDLE handle, const PVR_CHANNEL *chan)
+  {
+    return PVR_transfer_channel_entry(m_Handle, m_Callbacks, handle, chan);
+  }
+
+  void TransferTimerEntry(const ADDON_HANDLE handle, const PVR_TIMER *timer)
+  {
+    return PVR_transfer_timer_entry(m_Handle, m_Callbacks, handle, timer);
+  }
+
+  void TransferRecordingEntry(const ADDON_HANDLE handle, const PVR_RECORDING *recording)
+  {
+    return PVR_transfer_recording_entry(m_Handle, m_Callbacks, handle, recording);
+  }
+
+  void AddMenuHook(PVR_MENUHOOK *hook)
+  {
+    return PVR_add_menu_hook(m_Handle, m_Callbacks, hook);
+  }
+
+  void Recording(const char *Name, const char *FileName, bool On)
+  {
+    return PVR_recording(m_Handle, m_Callbacks, Name, FileName, On);
+  }
+
+  void TriggerTimerUpdate()
+  {
+    return PVR_trigger_timer_update(m_Handle, m_Callbacks);
+  }
+
+  void TriggerRecordingUpdate()
+  {
+    return PVR_trigger_recording_update(m_Handle, m_Callbacks);
+  }
+
+  void TriggerChannelUpdate()
+  {
+    return PVR_trigger_channel_update(m_Handle, m_Callbacks);
+  }
+
+  void TriggerChannelGroupsUpdate()
+  {
+    return PVR_trigger_channel_groups_update(m_Handle, m_Callbacks);
+  }
+
+  void TransferChannelGroup(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group)
+  {
+    return PVR_transfer_channel_group(m_Handle, m_Callbacks, handle, group);
+  }
+
+  void TransferChannelGroupMember(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member)
+  {
+    return PVR_transfer_channel_group_member(m_Handle, m_Callbacks, handle, member);
+  }
+
 #ifdef USE_DEMUX
-  void (*FreeDemuxPacket)(DemuxPacket* pPacket);
-  DemuxPacket* (*AllocateDemuxPacket)(int iDataSize);
+  void FreeDemuxPacket(DemuxPacket* pPacket)
+  {
+    return PVR_free_demux_packet(m_Handle, m_Callbacks, pPacket);
+  }
+
+  DemuxPacket* AllocateDemuxPacket(int iDataSize)
+  {
+    return PVR_allocate_demux_packet(m_Handle, m_Callbacks, iDataSize);
+  }
 #endif
 
 protected:
-  int (*PVR_register_me)(void *HANDLE);
-  void (*PVR_unregister_me)();
+  void* (*PVR_register_me)(void *HANDLE);
+  void (*PVR_unregister_me)(void* HANDLE, void* CB);
+  void (*PVR_transfer_epg_entry)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const EPG_TAG *epgentry);
+  void (*PVR_transfer_channel_entry)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_CHANNEL *chan);
+  void (*PVR_transfer_timer_entry)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_TIMER *timer);
+  void (*PVR_transfer_recording_entry)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_RECORDING *recording);
+  void (*PVR_add_menu_hook)(void* HANDLE, void* CB, PVR_MENUHOOK *hook);
+  void (*PVR_recording)(void* HANDLE, void* CB, const char *Name, const char *FileName, bool On);
+  void (*PVR_trigger_channel_update)(void* HANDLE, void* CB);
+  void (*PVR_trigger_channel_groups_update)(void* HANDLE, void* CB);
+  void (*PVR_trigger_timer_update)(void* HANDLE, void* CB);
+  void (*PVR_trigger_recording_update)(void* HANDLE, void* CB);
+  void (*PVR_transfer_channel_group)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group);
+  void (*PVR_transfer_channel_group_member)(void* HANDLE, void* CB, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member);
+#ifdef USE_DEMUX
+  void (*PVR_free_demux_packet)(void* HANDLE, void* CB, DemuxPacket* pPacket);
+  DemuxPacket* (*PVR_allocate_demux_packet)(void* HANDLE, void* CB, int iDataSize);
+#endif
 
 private:
   void *m_libXBMC_pvr;
   void *m_Handle;
+  void *m_Callbacks;
   struct cb_array
   {
     const char* libPath;

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -206,12 +206,60 @@ DLLEXPORT int XBMC_get_file_chunk_size(void *hdl, void* cb, void* file)
   return ((CB_AddOnLib*)cb)->GetFileChunkSize(((AddonCB*)hdl)->addonData, file);
 }
 
+DLLEXPORT bool XBMC_file_exists(void *hdl, void* cb, const char *strFileName, bool bUseCache)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->FileExists(((AddonCB*)hdl)->addonData, strFileName, bUseCache);
+}
+
+DLLEXPORT int XBMC_stat_file(void *hdl, void* cb, const char *strFileName, struct ::__stat64* buffer)
+{
+  if (cb == NULL)
+    return -1;
+
+  return ((CB_AddOnLib*)cb)->StatFile(((AddonCB*)hdl)->addonData, strFileName, buffer);
+}
+
+DLLEXPORT bool XBMC_delete_file(void *hdl, void* cb, const char *strFileName)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->DeleteFile(((AddonCB*)hdl)->addonData, strFileName);
+}
+
 DLLEXPORT bool XBMC_can_open_directory(void *hdl, void* cb, const char* strURL)
 {
   if (cb == NULL)
     return 0;
 
   return ((CB_AddOnLib*)cb)->CanOpenDirectory(((AddonCB*)hdl)->addonData, strURL);
+}
+
+DLLEXPORT bool XBMC_create_directory(void *hdl, void* cb, const char *strPath)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->CreateDirectory(((AddonCB*)hdl)->addonData, strPath);
+}
+
+DLLEXPORT bool XBMC_directory_exists(void *hdl, void* cb, const char *strPath)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->DirectoryExists(((AddonCB*)hdl)->addonData, strPath);
+}
+
+DLLEXPORT bool XBMC_remove_directory(void *hdl, void* cb, const char *strPath)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->RemoveDirectory(((AddonCB*)hdl)->addonData, strPath);
 }
 
 };

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -37,196 +37,181 @@
 using namespace std;
 using namespace ADDON;
 
-AddonCB *m_Handle = NULL;
-CB_AddOnLib *m_cb = NULL;
-
 extern "C"
 {
 
-DLLEXPORT int XBMC_register_me(void *hdl)
+DLLEXPORT void* XBMC_register_me(void *hdl)
 {
+  CB_AddOnLib *cb = NULL;
   if (!hdl)
     fprintf(stderr, "libXBMC_addon-ERROR: XBMC_register_me is called with NULL handle !!!\n");
   else
   {
-    m_Handle = (AddonCB*) hdl;
-    m_cb     = m_Handle->AddOnLib_RegisterMe(m_Handle->addonData);
-    if (!m_cb)
+    cb = ((AddonCB*)hdl)->AddOnLib_RegisterMe(((AddonCB*)hdl)->addonData);
+    if (!cb)
       fprintf(stderr, "libXBMC_addon-ERROR: XBMC_register_me can't get callback table from XBMC !!!\n");
-    else
-      return 1;
   }
-  return 0;
+  return cb;
 }
 
-DLLEXPORT void XBMC_unregister_me()
+DLLEXPORT void XBMC_unregister_me(void *hdl, void* cb)
 {
-  if (m_Handle && m_cb)
-    m_Handle->AddOnLib_UnRegisterMe(m_Handle->addonData, m_cb);
+  if (hdl && cb)
+    ((AddonCB*)hdl)->AddOnLib_UnRegisterMe(((AddonCB*)hdl)->addonData, ((CB_AddOnLib*)cb));
 }
 
-DLLEXPORT void XBMC_log(const addon_log_t loglevel, const char *format, ... )
+DLLEXPORT void XBMC_log(void *hdl, void* cb, const addon_log_t loglevel, const char *msg)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  char buffer[16384];
-  va_list args;
-  va_start (args, format);
-  vsprintf (buffer, format, args);
-  va_end (args);
-  m_cb->Log(m_Handle->addonData, loglevel, buffer);
+  ((CB_AddOnLib*)cb)->Log(((AddonCB*)hdl)->addonData, loglevel, msg);
 }
 
-DLLEXPORT bool XBMC_get_setting(const char* settingName, void *settingValue)
+DLLEXPORT bool XBMC_get_setting(void *hdl, void* cb, const char* settingName, void *settingValue)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return false;
 
-  return m_cb->GetSetting(m_Handle->addonData, settingName, settingValue);
+  return ((CB_AddOnLib*)cb)->GetSetting(((AddonCB*)hdl)->addonData, settingName, settingValue);
 }
 
-DLLEXPORT void XBMC_queue_notification(const queue_msg_t type, const char *format, ... )
+DLLEXPORT void XBMC_queue_notification(void *hdl, void* cb, const queue_msg_t type, const char *msg)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  char buffer[16384];
-  va_list args;
-  va_start (args, format);
-  vsprintf (buffer, format, args);
-  va_end (args);
-  m_cb->QueueNotification(m_Handle->addonData, type, buffer);
+  ((CB_AddOnLib*)cb)->QueueNotification(((AddonCB*)hdl)->addonData, type, msg);
 }
 
-DLLEXPORT void XBMC_unknown_to_utf8(string &str)
+DLLEXPORT void XBMC_unknown_to_utf8(void *hdl, void* cb, string &str)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  string buffer = m_cb->UnknownToUTF8(str.c_str());
+  string buffer = ((CB_AddOnLib*)cb)->UnknownToUTF8(str.c_str());
   str = buffer;
 }
 
-DLLEXPORT const char* XBMC_get_localized_string(int dwCode)
+DLLEXPORT const char* XBMC_get_localized_string(void *hdl, void* cb, int dwCode)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return "";
 
-  return m_cb->GetLocalizedString(m_Handle->addonData, dwCode);
+  return ((CB_AddOnLib*)cb)->GetLocalizedString(((AddonCB*)hdl)->addonData, dwCode);
 }
 
-DLLEXPORT const char* XBMC_get_dvd_menu_language()
+DLLEXPORT const char* XBMC_get_dvd_menu_language(void *hdl, void* cb)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return "";
 
-  string buffer = m_cb->GetDVDMenuLanguage(m_Handle->addonData);
+  string buffer = ((CB_AddOnLib*)cb)->GetDVDMenuLanguage(((AddonCB*)hdl)->addonData);
   return strdup(buffer.c_str());
 }
 
-DLLEXPORT void* XBMC_open_file(const char* strFileName, unsigned int flags)
+DLLEXPORT void* XBMC_open_file(void *hdl, void* cb, const char* strFileName, unsigned int flags)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return NULL;
 
-  return m_cb->OpenFile(m_Handle->addonData, strFileName, flags);
+  return ((CB_AddOnLib*)cb)->OpenFile(((AddonCB*)hdl)->addonData, strFileName, flags);
 }
 
-DLLEXPORT void* XBMC_open_file_for_write(const char* strFileName, bool bOverWrite)
+DLLEXPORT void* XBMC_open_file_for_write(void *hdl, void* cb, const char* strFileName, bool bOverWrite)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return NULL;
 
-  return m_cb->OpenFileForWrite(m_Handle->addonData, strFileName, bOverWrite);
+  return ((CB_AddOnLib*)cb)->OpenFileForWrite(((AddonCB*)hdl)->addonData, strFileName, bOverWrite);
 }
 
-DLLEXPORT unsigned int XBMC_read_file(void* file, void* lpBuf, int64_t uiBufSize)
+DLLEXPORT unsigned int XBMC_read_file(void *hdl, void* cb, void* file, void* lpBuf, int64_t uiBufSize)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return 0;
 
-  return m_cb->ReadFile(m_Handle->addonData, file, lpBuf, uiBufSize);
+  return ((CB_AddOnLib*)cb)->ReadFile(((AddonCB*)hdl)->addonData, file, lpBuf, uiBufSize);
 }
 
-DLLEXPORT bool XBMC_read_file_string(void* file, char *szLine, int iLineLength)
+DLLEXPORT bool XBMC_read_file_string(void *hdl, void* cb, void* file, char *szLine, int iLineLength)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return false;
 
-  return m_cb->ReadFileString(m_Handle->addonData, file, szLine, iLineLength);
+  return ((CB_AddOnLib*)cb)->ReadFileString(((AddonCB*)hdl)->addonData, file, szLine, iLineLength);
 }
 
-DLLEXPORT int XBMC_write_file(void* file, const void* lpBuf, int64_t uiBufSize)
+DLLEXPORT int XBMC_write_file(void *hdl, void* cb, void* file, const void* lpBuf, int64_t uiBufSize)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return false;
 
-  return m_cb->WriteFile(m_Handle->addonData, file, lpBuf, uiBufSize);
+  return ((CB_AddOnLib*)cb)->WriteFile(((AddonCB*)hdl)->addonData, file, lpBuf, uiBufSize);
 }
 
-DLLEXPORT void XBMC_flush_file(void* file)
+DLLEXPORT void XBMC_flush_file(void *hdl, void* cb, void* file)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->FlushFile(m_Handle->addonData, file);
+  ((CB_AddOnLib*)cb)->FlushFile(((AddonCB*)hdl)->addonData, file);
 }
 
-DLLEXPORT int64_t XBMC_seek_file(void* file, int64_t iFilePosition, int iWhence)
+DLLEXPORT int64_t XBMC_seek_file(void *hdl, void* cb, void* file, int64_t iFilePosition, int iWhence)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return 0;
 
-  return m_cb->SeekFile(m_Handle->addonData, file, iFilePosition, iWhence);
+  return ((CB_AddOnLib*)cb)->SeekFile(((AddonCB*)hdl)->addonData, file, iFilePosition, iWhence);
 }
 
-DLLEXPORT int XBMC_truncate_file(void* file, int64_t iSize)
+DLLEXPORT int XBMC_truncate_file(void *hdl, void* cb, void* file, int64_t iSize)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return 0;
 
-  return m_cb->TruncateFile(m_Handle->addonData, file, iSize);
+  return ((CB_AddOnLib*)cb)->TruncateFile(((AddonCB*)hdl)->addonData, file, iSize);
 }
 
-DLLEXPORT int64_t XBMC_get_file_position(void* file)
+DLLEXPORT int64_t XBMC_get_file_position(void *hdl, void* cb, void* file)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return 0;
 
-  return m_cb->GetFilePosition(m_Handle->addonData, file);
+  return ((CB_AddOnLib*)cb)->GetFilePosition(((AddonCB*)hdl)->addonData, file);
 }
 
-DLLEXPORT int64_t XBMC_get_file_length(void* file)
+DLLEXPORT int64_t XBMC_get_file_length(void *hdl, void* cb, void* file)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return 0;
 
-  return m_cb->GetFileLength(m_Handle->addonData, file);
+  return ((CB_AddOnLib*)cb)->GetFileLength(((AddonCB*)hdl)->addonData, file);
 }
 
-DLLEXPORT void XBMC_close_file(void* file)
+DLLEXPORT void XBMC_close_file(void *hdl, void* cb, void* file)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->CloseFile(m_Handle->addonData, file);
+  ((CB_AddOnLib*)cb)->CloseFile(((AddonCB*)hdl)->addonData, file);
 }
 
-DLLEXPORT int64_t XBMC_get_file_chunk_size(void* file)
+DLLEXPORT int64_t XBMC_get_file_chunk_size(void *hdl, void* cb, void* file)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return 0;
 
-  return m_cb->GetFileChunkSize(m_Handle->addonData, file);
+  return ((CB_AddOnLib*)cb)->GetFileChunkSize(((AddonCB*)hdl)->addonData, file);
 }
 
-DLLEXPORT bool XBMC_can_open_directory(const char* strURL)
+DLLEXPORT bool XBMC_can_open_directory(void *hdl, void* cb, const char* strURL)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return 0;
 
-  return m_cb->CanOpenDirectory(m_Handle->addonData, strURL);
+  return ((CB_AddOnLib*)cb)->CanOpenDirectory(((AddonCB*)hdl)->addonData, strURL);
 }
 
 };

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -198,7 +198,7 @@ DLLEXPORT void XBMC_close_file(void *hdl, void* cb, void* file)
   ((CB_AddOnLib*)cb)->CloseFile(((AddonCB*)hdl)->addonData, file);
 }
 
-DLLEXPORT int64_t XBMC_get_file_chunk_size(void *hdl, void* cb, void* file)
+DLLEXPORT int XBMC_get_file_chunk_size(void *hdl, void* cb, void* file)
 {
   if (cb == NULL)
     return 0;

--- a/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj
+++ b/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj
@@ -59,6 +59,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\..\..\..\addons\library.xbmc.addon\$(ProjectName).dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/lib/addons/library.xbmc.gui/project/VS2010Express/libXBMC_gui.vcxproj
+++ b/lib/addons/library.xbmc.gui/project/VS2010Express/libXBMC_gui.vcxproj
@@ -59,6 +59,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\..\..\..\addons\library.xbmc.gui\$(ProjectName).dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
+++ b/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
@@ -38,144 +38,139 @@
 
 using namespace std;
 
-AddonCB *m_Handle = NULL;
-CB_PVRLib *m_cb   = NULL;
-
 extern "C"
 {
 
-DLLEXPORT int PVR_register_me(void *hdl)
+DLLEXPORT void* PVR_register_me(void *hdl)
 {
+  CB_PVRLib *cb = NULL;
   if (!hdl)
     fprintf(stderr, "libXBMC_pvr-ERROR: PVRLib_register_me is called with NULL handle !!!\n");
   else
   {
-    m_Handle = (AddonCB*) hdl;
-    m_cb     = m_Handle->PVRLib_RegisterMe(m_Handle->addonData);
-    if (!m_cb)
+    cb = ((AddonCB*)hdl)->PVRLib_RegisterMe(((AddonCB*)hdl)->addonData);
+    if (!cb)
       fprintf(stderr, "libXBMC_pvr-ERROR: PVRLib_register_me can't get callback table from XBMC !!!\n");
-    else
-      return 1;
   }
-  return 0;
+  return cb;
 }
 
-DLLEXPORT void PVR_unregister_me()
+DLLEXPORT void PVR_unregister_me(void *hdl, void* cb)
 {
-  if (m_Handle && m_cb)
-    m_Handle->PVRLib_UnRegisterMe(m_Handle->addonData, m_cb);
+  if (hdl && cb)
+    ((AddonCB*)hdl)->PVRLib_UnRegisterMe(((AddonCB*)hdl)->addonData, (CB_PVRLib*)cb);
 }
 
-DLLEXPORT void PVR_transfer_epg_entry(const ADDON_HANDLE handle, const EPG_TAG *epgentry)
+DLLEXPORT void PVR_transfer_epg_entry(void *hdl, void* cb, const ADDON_HANDLE handle, const EPG_TAG *epgentry)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TransferEpgEntry(m_Handle->addonData, handle, epgentry);
+  ((CB_PVRLib*)cb)->TransferEpgEntry(((AddonCB*)hdl)->addonData, handle, epgentry);
 }
 
-DLLEXPORT void PVR_transfer_channel_entry(const ADDON_HANDLE handle, const PVR_CHANNEL *chan)
+DLLEXPORT void PVR_transfer_channel_entry(void *hdl, void* cb, const ADDON_HANDLE handle, const PVR_CHANNEL *chan)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TransferChannelEntry(m_Handle->addonData, handle, chan);
+  ((CB_PVRLib*)cb)->TransferChannelEntry(((AddonCB*)hdl)->addonData, handle, chan);
 }
 
-DLLEXPORT void PVR_transfer_timer_entry(const ADDON_HANDLE handle, const PVR_TIMER *timer)
+DLLEXPORT void PVR_transfer_timer_entry(void *hdl, void* cb, const ADDON_HANDLE handle, const PVR_TIMER *timer)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TransferTimerEntry(m_Handle->addonData, handle, timer);
+  ((CB_PVRLib*)cb)->TransferTimerEntry(((AddonCB*)hdl)->addonData, handle, timer);
 }
 
-DLLEXPORT void PVR_transfer_recording_entry(const ADDON_HANDLE handle, const PVR_RECORDING *recording)
+DLLEXPORT void PVR_transfer_recording_entry(void *hdl, void* cb, const ADDON_HANDLE handle, const PVR_RECORDING *recording)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TransferRecordingEntry(m_Handle->addonData, handle, recording);
+  ((CB_PVRLib*)cb)->TransferRecordingEntry(((AddonCB*)hdl)->addonData, handle, recording);
 }
 
-DLLEXPORT void PVR_add_menu_hook(PVR_MENUHOOK *hook)
+DLLEXPORT void PVR_add_menu_hook(void *hdl, void* cb, PVR_MENUHOOK *hook)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->AddMenuHook(m_Handle->addonData, hook);
+  ((CB_PVRLib*)cb)->AddMenuHook(((AddonCB*)hdl)->addonData, hook);
 }
 
-DLLEXPORT void PVR_recording(const char *Name, const char *FileName, bool On)
+DLLEXPORT void PVR_recording(void *hdl, void* cb, const char *Name, const char *FileName, bool On)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->Recording(m_Handle->addonData, Name, FileName, On);
+  ((CB_PVRLib*)cb)->Recording(((AddonCB*)hdl)->addonData, Name, FileName, On);
 }
 
-DLLEXPORT void PVR_trigger_channel_update()
+DLLEXPORT void PVR_trigger_channel_update(void *hdl, void* cb)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TriggerChannelUpdate(m_Handle->addonData);
+  ((CB_PVRLib*)cb)->TriggerChannelUpdate(((AddonCB*)hdl)->addonData);
 }
 
-DLLEXPORT void PVR_trigger_channel_groups_update()
+DLLEXPORT void PVR_trigger_channel_groups_update(void *hdl, void* cb)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TriggerChannelGroupsUpdate(m_Handle->addonData);
+  ((CB_PVRLib*)cb)->TriggerChannelGroupsUpdate(((AddonCB*)hdl)->addonData);
 }
 
-DLLEXPORT void PVR_trigger_timer_update()
+DLLEXPORT void PVR_trigger_timer_update(void *hdl, void* cb)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TriggerTimerUpdate(m_Handle->addonData);
+  ((CB_PVRLib*)cb)->TriggerTimerUpdate(((AddonCB*)hdl)->addonData);
 }
 
-DLLEXPORT void PVR_trigger_recording_update()
+DLLEXPORT void PVR_trigger_recording_update(void *hdl, void* cb)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TriggerRecordingUpdate(m_Handle->addonData);
+  ((CB_PVRLib*)cb)->TriggerRecordingUpdate(((AddonCB*)hdl)->addonData);
 }
 
-DLLEXPORT void PVR_free_demux_packet(DemuxPacket* pPacket)
+DLLEXPORT void PVR_free_demux_packet(void *hdl, void* cb, DemuxPacket* pPacket)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->FreeDemuxPacket(m_Handle->addonData, pPacket);
+  ((CB_PVRLib*)cb)->FreeDemuxPacket(((AddonCB*)hdl)->addonData, pPacket);
 }
 
-DLLEXPORT DemuxPacket* PVR_allocate_demux_packet(int iDataSize)
+DLLEXPORT DemuxPacket* PVR_allocate_demux_packet(void *hdl, void* cb, int iDataSize)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return NULL;
 
-  return m_cb->AllocateDemuxPacket(m_Handle->addonData, iDataSize);
+  return ((CB_PVRLib*)cb)->AllocateDemuxPacket(((AddonCB*)hdl)->addonData, iDataSize);
 }
 
-DLLEXPORT void PVR_transfer_channel_group(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group)
+DLLEXPORT void PVR_transfer_channel_group(void *hdl, void* cb, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TransferChannelGroup(m_Handle->addonData, handle, group);
+  ((CB_PVRLib*)cb)->TransferChannelGroup(((AddonCB*)hdl)->addonData, handle, group);
 }
 
-DLLEXPORT void PVR_transfer_channel_group_member(const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member)
+DLLEXPORT void PVR_transfer_channel_group_member(void *hdl, void* cb, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member)
 {
-  if (m_cb == NULL)
+  if (cb == NULL)
     return;
 
-  m_cb->TransferChannelGroupMember(m_Handle->addonData, handle, member);
+  ((CB_PVRLib*)cb)->TransferChannelGroupMember(((AddonCB*)hdl)->addonData, handle, member);
 }
 
 };

--- a/lib/addons/library.xbmc.pvr/project/VS2010Express/libXBMC_pvr.vcxproj
+++ b/lib/addons/library.xbmc.pvr/project/VS2010Express/libXBMC_pvr.vcxproj
@@ -59,6 +59,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\..\..\..\addons\library.xbmc.pvr\$(ProjectName).dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -43,7 +43,13 @@ typedef int64_t (*AddOnGetFilePosition)(const void* addonData, void* file);
 typedef int64_t (*AddOnGetFileLength)(const void* addonData, void* file);
 typedef void (*AddOnCloseFile)(const void* addonData, void* file);
 typedef int (*AddOnGetFileChunkSize)(const void* addonData, void* file);
+typedef bool (*AddOnFileExists)(const void* addonData, const char *strFileName, bool bUseCache);
+typedef int (*AddOnStatFile)(const void* addonData, const char *strFileName, struct __stat64* buffer);
+typedef bool (*AddOnDeleteFile)(const void* addonData, const char *strFileName);
 typedef bool (*AddOnCanOpenDirectory)(const void* addonData, const char* strURL);
+typedef bool (*AddOnCreateDirectory)(const void* addonData, const char *strPath);
+typedef bool (*AddOnDirectoryExists)(const void* addonData, const char *strPath);
+typedef bool (*AddOnRemoveDirectory)(const void* addonData, const char *strPath);
 
 typedef struct CB_AddOn
 {
@@ -66,7 +72,13 @@ typedef struct CB_AddOn
   AddOnGetFileLength      GetFileLength;
   AddOnCloseFile          CloseFile;
   AddOnGetFileChunkSize   GetFileChunkSize;
+  AddOnFileExists         FileExists;
+  AddOnStatFile           StatFile;
+  AddOnDeleteFile         DeleteFile;
   AddOnCanOpenDirectory   CanOpenDirectory;
+  AddOnCreateDirectory    CreateDirectory;
+  AddOnDirectoryExists    DirectoryExists;
+  AddOnRemoveDirectory    RemoveDirectory;
 } CB_AddOnLib;
 
 typedef void (*GUILock)();

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -59,8 +59,14 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->GetFileLength      = GetFileLength;
   m_callbacks->CloseFile          = CloseFile;
   m_callbacks->GetFileChunkSize   = GetFileChunkSize;
+  m_callbacks->FileExists         = FileExists;
+  m_callbacks->StatFile           = StatFile;
+  m_callbacks->DeleteFile         = DeleteFile;
 
   m_callbacks->CanOpenDirectory   = CanOpenDirectory;
+  m_callbacks->CreateDirectory    = CreateDirectory;
+  m_callbacks->DirectoryExists    = DirectoryExists;
+  m_callbacks->RemoveDirectory    = RemoveDirectory;
 }
 
 CAddonCallbacksAddon::~CAddonCallbacksAddon()
@@ -426,6 +432,33 @@ int CAddonCallbacksAddon::GetFileChunkSize(const void* addonData, void* file)
   return cfile->GetChunkSize();
 }
 
+bool CAddonCallbacksAddon::FileExists(const void* addonData, const char *strFileName, bool bUseCache)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return false;
+
+  return CFile::Exists(strFileName, bUseCache);
+}
+
+int CAddonCallbacksAddon::StatFile(const void* addonData, const char *strFileName, struct __stat64* buffer)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return -1;
+
+  return CFile::Stat(strFileName, buffer);
+}
+
+bool CAddonCallbacksAddon::DeleteFile(const void* addonData, const char *strFileName)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return false;
+
+  return CFile::Delete(strFileName);
+}
+
 bool CAddonCallbacksAddon::CanOpenDirectory(const void* addonData, const char* strURL)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
@@ -434,6 +467,39 @@ bool CAddonCallbacksAddon::CanOpenDirectory(const void* addonData, const char* s
 
   CFileItemList items;
   return CDirectory::GetDirectory(strURL, items);
+}
+
+bool CAddonCallbacksAddon::CreateDirectory(const void* addonData, const char *strPath)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return false;
+
+  return CDirectory::Create(strPath);
+}
+
+bool CAddonCallbacksAddon::DirectoryExists(const void* addonData, const char *strPath)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return false;
+
+  return CDirectory::Exists(strPath);
+}
+
+bool CAddonCallbacksAddon::RemoveDirectory(const void* addonData, const char *strPath)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
+  if (!helper)
+    return false;
+
+  // Empty directory
+  CFileItemList fileItems;
+  CDirectory::GetDirectory(strPath, fileItems);
+  for (int i = 0; i < fileItems.Size(); ++i)
+    CFile::Delete(fileItems.Get(i)->GetPath());
+
+  return CDirectory::Remove(strPath);
 }
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -55,7 +55,13 @@ public:
   static int64_t GetFileLength(const void* addonData, void* file);
   static void CloseFile(const void* addonData, void* file);
   static int GetFileChunkSize(const void* addonData, void* file);
+  static bool FileExists(const void* addonData, const char *strFileName, bool bUseCache);
+  static int StatFile(const void* addonData, const char *strFileName, struct __stat64* buffer);
+  static bool DeleteFile(const void* addonData, const char *strFileName);
   static bool CanOpenDirectory(const void* addonData, const char* strURL);
+  static bool CreateDirectory(const void* addonData, const char *strPath);
+  static bool DirectoryExists(const void* addonData, const char *strPath);
+  static bool RemoveDirectory(const void* addonData, const char *strPath);
 
 private:
   CB_AddOnLib  *m_callbacks; /*!< callback addresses */


### PR DESCRIPTION
Currently, running different PVR addons simultaneously leads into unspecified behavior.
For example recordings are loaded from all plugins, but you can only play some.

The issue is described here: http://trac.xbmc.org/ticket/13353
In short: The shared libraries that are loaded by the addons (libXBMC_addon, libXBMC_pvr, libXBMC_gui) use global variables (m_Handle, m_cb) that are overriden each time a plugin loads.

I started to work on one possible solution: Getting rid of those global variables, and passing them as function parameter in all exported functions.
The API that the addons call, doesn't not change because I store the handles as class members.

@opdenkamp: I'd like to get some feedback on this. Is this the proper approach or any easier fix that I just fail to see?
You were using void\* as handles in the .h file. Is there a specific reason or is it better to include the header / forward declare the handles?
