### PR TITLE
fixed: ffmpeg tscc codec needs bits_per_coded_sample passed from the dem...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -263,6 +263,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   // if we don't do this, then some codecs seem to fail.
   m_pCodecContext->coded_height = hints.height;
   m_pCodecContext->coded_width = hints.width;
+  m_pCodecContext->bits_per_coded_sample = hints.bitsperpixel;
 
   if( hints.extradata && hints.extrasize > 0 )
   {

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -162,6 +162,7 @@ public:
     bForcedAspect = false;
     type = STREAM_VIDEO;
     iOrientation = 0;
+    iBitsPerPixel = 0;
   }
 
   virtual ~CDemuxStreamVideo() {}
@@ -176,6 +177,7 @@ public:
   bool bPTSInvalid; // pts cannot be trusted (avi's).
   bool bForcedAspect; // aspect is forced from container
   int iOrientation; // orientation of the video in degress counter clockwise
+  int iBitsPerPixel;
 };
 
 class CDemuxStreamAudio : public CDemuxStream

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1010,6 +1010,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
         st->iLevel = pStream->codec->level;
         st->iProfile = pStream->codec->profile;
         st->iOrientation = 0;
+        st->iBitsPerPixel = pStream->codec->bits_per_coded_sample;
 
         AVDictionaryEntry *rtag = m_dllAvUtil.av_dict_get(pStream->metadata, "rotate", NULL, 0);
         if (rtag) 

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
@@ -59,6 +59,7 @@ void CDVDStreamInfo::Clear()
   profile  = 0;
   ptsinvalid = false;
   forced_aspect = false;
+  bitsperpixel = 0;
 
   channels   = 0;
   samplerate = 0;
@@ -96,6 +97,7 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
   ||  profile  != right.profile
   ||  ptsinvalid != right.ptsinvalid
   ||  forced_aspect != right.forced_aspect
+  ||  bitsperpixel != right.bitsperpixel
   ||  vfr      != right.vfr) return false;
 
   // AUDIO
@@ -152,6 +154,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   ptsinvalid = right.ptsinvalid;
   forced_aspect = right.forced_aspect;
   orientation = right.orientation;
+  bitsperpixel = right.bitsperpixel;
 
   // AUDIO
   channels      = right.channels;
@@ -202,6 +205,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     ptsinvalid = stream->bPTSInvalid;
     forced_aspect = stream->bForcedAspect;
     orientation = stream->iOrientation;
+    bitsperpixel = stream->iBitsPerPixel;
   }
   else if(  right.type == STREAM_SUBTITLE )
   {

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.h
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.h
@@ -77,6 +77,7 @@ public:
   bool ptsinvalid;  // pts cannot be trusted (avi's).
   bool forced_aspect; // aspect is forced from container
   int orientation; // orientation of the video in degress counter clockwise
+  int bitsperpixel;
 
   // AUDIO
   int channels;


### PR DESCRIPTION
...uxer, see decode_init() in libavcodec/tscc.c, fixes #10159
