### PR TITLE
[pvr] improved channel group selection within channel osd

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -22,6 +22,7 @@
 #include "guilib/GUIDialog.h"
 #include "GUIViewControl.h"
 #include "utils/Observer.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 
 class CFileItemList;
 
@@ -43,10 +44,15 @@ namespace PVR
     void ShowInfo(int item);
     void Clear();
     void Update();
+    void Update(bool selectPlayingChannel);
+    CPVRChannelGroupPtr GetPlayingGroup();
     CGUIControl *GetFirstFocusableControl(int id);
 
     CFileItemList    *m_vecItems;
     CGUIViewControl   m_viewControl;
+
+  private:
+    CPVRChannelGroupPtr m_group;
   };
 }
 


### PR DESCRIPTION
This PR improves the channel group selection within the channel osd.
It prevents that the playing channel group is changed, if no channel is selected.

Currently if you open the channel osd and select a different group then close the channel osd, this group is set as the playing group.

A few days ago i've created a branch ;) ... so this is the  new PR for #1416.
