### PR TITLE
Fix PVR addons get enabled alltogether when found the first time

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -632,6 +632,14 @@ bool CAddonDatabase::BreakAddon(const CStdString &addonID, const CStdString& rea
   return false;
 }
 
+bool CAddonDatabase::HasAddon(const CStdString &addonID)
+{
+  CStdString strWhereClause = PrepareSQL("addonID = '%s'", addonID.c_str());
+  CStdString strHasAddon = GetSingleValue("addon", "id", strWhereClause);
+  
+  return !strHasAddon.IsEmpty();
+}
+
 bool CAddonDatabase::IsAddonDisabled(const CStdString &addonID)
 {
   try

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -67,6 +67,11 @@ public:
    \sa IsAddonDisabled, HasDisabledAddons */
   bool DisableAddon(const CStdString &addonID, bool disable = true);
 
+  /*! \brief Checks if an addon is in the database.
+   \param addonID id of the addon to be checked
+   \return true if addon is in database, false if addon is not in database yet */
+  bool HasAddon(const CStdString &addonID);
+  
   /*! \brief Check whether an addon has been disabled via DisableAddon.
    \param addonID id of the addon to check
    \return true if the addon is disabled, false otherwise

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1039,6 +1039,17 @@ bool CPVRClients::UpdateAddons(void)
     CSingleLock lock(m_critSection);
     m_addons = addons;
   }
+  
+  // handle "new" addons which aren't yet in the db - these have to be added first
+  for (unsigned iClientPtr = 0; iClientPtr < m_addons.size(); iClientPtr++)
+  {
+    const AddonPtr clientAddon = m_addons.at(iClientPtr);
+  
+    if (!m_addonDb.HasAddon(clientAddon->ID()))
+    {
+      m_addonDb.AddAddon(clientAddon, -1);
+    }
+  }
 
   if ((!bReturn || addons.size() == 0) && !m_bNoAddonWarningDisplayed &&
       !CAddonMgr::Get().HasAddons(ADDON_PVRDLL, false) &&


### PR DESCRIPTION
This PR fixes the issue where all PVR addons get enabled/started when they are detected the first time.

The Problem is as follows. PVR addons get enabled when they are not in the disabled table in the AddonDB. That is true for all new addons (they are not found in the disabled DB and therefore treated as enabled). Also the CAddon object initialises his own "m_enabled" member to true - this doesn't help here too.

So the problem is that only the disabled table is used for PVR addons (they are never added to the normal addon table).

In AddAddon of AddonDatabase there is already a special case for PVR addons. Say get added to the disabled table automatically when added (which is correct - PVR addons need to be configured after adding - so they should be disabled by default).

This PR fixes this problem by adding a new method called "HasAddon" to AddonDatabase. It checks if a given addon is already in the addon - table. 

For PVR addons in UpdateAddons (on startup) we now check if the addon is already in the DB. If its not we add it (and therefore disabling it too). That prevents the mass enabling of addons and on the first start (with no enabled addons) also shows the "PVR has to be configured" message.

Since we have enabled PVR addons on the buildbot for osx i would like to have this fix in before alpha6 gets tagged. So ETA 5 days.

ping @davilla @jmarshallnz @opdenkamp
