### PR TITLE
webserver: make VFS handler more secure

### DIFF
--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -116,5 +116,22 @@ public:
   static bool ProtocolHasParentInHostname(const CStdString& prot);
   static bool ProtocolHasEncodedHostname(const CStdString& prot);
   static bool ProtocolHasEncodedFilename(const CStdString& prot);
+
+  /*!
+   \brief Cleans up the given path by resolving "." and ".."
+   and returns it.
+
+   This methods goes through the given path and removes any "."
+   (as it states "this directory") and resolves any ".." by
+   removing the previous directory from the path. This is done
+   for file paths and host names (in case of VFS paths).
+
+   \param path Path to be cleaned up
+   \return Actual path without any "." or ".."
+   */
+  static std::string GetRealPath(const std::string &path);
+
+private:
+  static std::string resolvePath(const std::string &path);
 };
 

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -491,3 +491,62 @@ TEST_F(TestURIUtils, ProtocolHasEncodedFilename)
   EXPECT_TRUE(URIUtils::ProtocolHasEncodedFilename("rss"));
   EXPECT_TRUE(URIUtils::ProtocolHasEncodedFilename("davs"));
 }
+
+TEST_F(TestURIUtils, GetRealPath)
+{
+  std::string ref;
+  
+  ref = "/path/to/file/";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
+  
+  ref = "path/to/file";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("../path/to/file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("./path/to/file").c_str());
+
+  ref = "/path/to/file";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/path/to/./file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/./path/to/./file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/path/to/some/../file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/../path/to/some/../file").c_str());
+
+  ref = "/path/to";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("/path/to/some/../file/..").c_str());
+
+#ifdef TARGET_WINDOWS
+  ref = "\\\\path\\to\\file\\";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
+  
+  ref = "path\\to\\file";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("..\\path\\to\\file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(".\\path\\to\\file").c_str());
+
+  ref = "\\\\path\\to\\file";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\path\\to\\.\\file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\.\\path/to\\.\\file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\path\\to\\some\\..\\file").c_str());
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\..\\path\\to\\some\\..\\file").c_str());
+
+  ref = "\\\\path\\to";
+  EXPECT_STREQ(ref.c_str(), URIUtils::GetRealPath("\\\\path\\to\\some\\..\\file\\..").c_str());
+#endif
+
+  // test rar/zip paths
+  ref = "rar://%2fpath%2fto%2frar/subpath/to/file";
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
+  
+  // test rar/zip paths
+  ref = "rar://%2fpath%2fto%2frar/subpath/to/file";
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/../subpath/to/file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/./subpath/to/file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/subpath/to/./file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/subpath/to/some/../file").c_str());
+  
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2f.%2frar/subpath/to/file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2fsome%2f..%2frar/subpath/to/file").c_str());
+
+  // test rar/zip path in rar/zip path
+  ref ="zip://rar%3A%2F%2F%252Fpath%252Fto%252Frar%2Fpath%2Fto%2Fzip/subpath/to/file";
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://rar%3A%2F%2F%252Fpath%252Fto%252Fsome%252F..%252Frar%2Fpath%2Fto%2Fsome%2F..%2Fzip/subpath/to/some/../file").c_str());
+}


### PR DESCRIPTION
These commits are meant to make the VFS handler of xbmc's webserver more secure. Currently it allows to access any file which xbmc can reach through its VFS including files like /etc/passwd etc because the only check that is made is whether the file exists or not.

With these commits every requested VFS path will be checked against the list of user-specified sources. If the path does not point to a file within a (sub-)directory of one of those sources a HTTP 401 (Unauthorized) error is returned. For this to work I had to write a method which would take care of ".." etc in paths because otherwise it would be possible to do something like

```
/path/to/source/../../../etc/passwd
```

and still access any file. I don't think the implementation is optimal but I couldn't find an existing method that does the same so I wrote URIUtils::GetRealPath() (and I also wrote a unit test for it).

IMO this is the best way to make the VFS handler more secure (short of ripping it out which I plan to do once there is a better way to access media files through the webserver). If someone adds the root path as a source it's his own fault. And if someone adds a symlink to the root directory (or somewhere else) in one of his source directories it's his own problem as well.
