### PR TITLE
[LCD] Feature/Enhancement: Support special/extra icons on SoundGraph iMon and Futaba mdm166a displays

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -348,6 +348,11 @@ public:
     return m_bTestMode;
   }
 
+  float GetNavigationIdleTime()
+  {
+    return NavigationIdleTime();
+  }
+
   bool IsPresentFrame();
 
   void Minimize();

--- a/xbmc/linux/Makefile.in
+++ b/xbmc/linux/Makefile.in
@@ -11,6 +11,8 @@ SRCS += PosixMountProvider.cpp
 SRCS += XFileUtils.cpp
 SRCS += XHandle.cpp
 SRCS += XLCDproc.cpp
+SRCS += XLCDproc_imon.cpp
+SRCS += XLCDproc_mdm166a.cpp
 SRCS += XMemUtils.cpp
 SRCS += XTimeUtils.cpp
 

--- a/xbmc/linux/XLCDproc.h
+++ b/xbmc/linux/XLCDproc.h
@@ -45,10 +45,54 @@ public:
   bool         SendLCDd(const CStdString &command);
   void         ReadAndFlushSocket();
 
+  // Handlers for icon-handling sub-instances
+  bool         SendIconStatesToDisplay();
+  void         HandleStop();
+
+  void         SetIconMovie(bool on);
+  void         SetIconMusic(bool on);
+  void         SetIconWeather(bool on);
+  void         SetIconTV(bool on);
+  void         SetIconPhoto(bool on);
+  void         SetIconResolution(LCD_RESOLUTION_INDICATOR resolution);
+  void         SetProgressBar1(double progress);
+  void         SetProgressBar2(double progress);
+  void         SetProgressBar3(double progress);
+  void         SetProgressBar4(double progress);
+  void         SetIconMute(bool on);
+  void         SetIconPlaying(bool on);
+  void         SetIconPause(bool on);
+  void         SetIconRepeat(bool on);
+  void         SetIconShuffle(bool on);
+  void         SetIconAlarm(bool on);
+  void         SetIconRecord(bool on);
+  void         SetIconVolume(bool on);
+  void         SetIconTime(bool on);
+  void         SetIconSPDIF(bool on);
+  void         SetIconDiscIn(bool on);
+  void         SetIconSource(bool on);
+  void         SetIconFit(bool on);
+  void         SetIconSCR1(bool on);
+  void         SetIconSCR2(bool on);
+  void         SetIconMPEG(bool on);
+  void         SetIconDIVX(bool on);
+  void         SetIconXVID(bool on);
+  void         SetIconWMV(bool on);
+  void         SetIconMPGA(bool on);
+  void         SetIconAC3(bool on);
+  void         SetIconDTS(bool on);
+  void         SetIconVWMA(bool on);
+  void         SetIconMP3(bool on);
+  void         SetIconOGG(bool on);
+  void         SetIconAWMA(bool on);
+  void         SetIconWAV(bool on);
+  void         SetIconAudioChannels(int channels);
+
 protected:
   virtual void Process();
   virtual void SetLine(int iLine, const CStdString& strLine);
   bool         Connect();
+  void         RecognizeAndSetIconDriver();
   void         CloseSocket();
   unsigned int m_iColumns;        // display columns for each line
   unsigned int m_iRows;           // total number of rows
@@ -66,6 +110,9 @@ private:
   int          m_lastInitAttempt;
   int          m_initRetryInterval;
   bool         m_used; //set to false when trying to connect has failed
+
+  XLCDproc     *m_lcdprocIconDevice;
+  unsigned int m_iCharsetTab;
 };
 
 #endif

--- a/xbmc/linux/XLCDproc_imon.cpp
+++ b/xbmc/linux/XLCDproc_imon.cpp
@@ -1,0 +1,465 @@
+#ifndef __XLCDPROC_IMON_CPP__
+#define __XLCDPROC_IMON_CPP__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "XLCDproc_imon.h"
+#include "../utils/log.h"
+
+XLCDproc_imon::XLCDproc_imon(int m_localsockfd)
+{
+  // initialize class variables
+  outputValue = 0;
+  outputValueProgressBars = 0;
+  outputValueOld = 1; // for correct icon-initialization this needs to be different to the actual value
+  outputValueProgressBarsOld = 1; // for correct icon-initialization this needs to be different to the actual value
+
+  m_sockfd = m_localsockfd;
+
+  m_outputTimer.StartZero();
+}
+
+XLCDproc_imon::~XLCDproc_imon(void)
+{
+}
+
+bool XLCDproc_imon::SendIconStatesToDisplay()
+{
+  CStdString cmd;
+
+  if (outputValue != outputValueOld || isOutputValuesTurn())
+  {
+    // A tweak for the imon-lcd-driver: There is no icon for this bit.
+    // Needed because the driver sets ALL symbols (icons and progress bars) to "off", if there is an outputValue == 0
+    outputValue |= 1 << 30;
+    outputValueOld = outputValue;
+    cmd.Format("output %d\n", outputValue);
+  }
+  else if (outputValueProgressBars != outputValueProgressBarsOld || isOutputValuesTurn())
+  {
+    outputValueProgressBarsOld = outputValueProgressBars;
+    cmd.Format("output %d\n", outputValueProgressBars);
+  }
+  else
+  {
+    return true;
+  }
+
+  ResetModeIcons();
+
+  if (write(m_sockfd, cmd.c_str(), cmd.size()) < 0)
+  {
+    CLog::Log(
+        LOGERROR,
+        "XLCDproc::%s - Unable to write 'outputValue' to socket, LCDd not running?",
+        __FUNCTION__);
+
+    return false;
+  }
+
+  return true;
+}
+
+void XLCDproc_imon::HandleStop(void)
+{
+  CStdString clearcmd = "";
+
+  // clear any icons
+  outputValue = 0;
+
+  clearcmd.Format("output %d\n", outputValue);
+
+  if (write(m_sockfd, clearcmd.c_str(), clearcmd.size()) < 0)
+    CLog::Log(LOGERROR, "XLCDproc::%s - Unable to write to socket", __FUNCTION__);
+
+  usleep(100000); // we have to wait a bit until the message has been sent to the display
+}
+
+void XLCDproc_imon::ResetModeIcons(void)
+{
+  outputValue &= ~(7 << IMON_OUTPUT_TOP_ROW); // reset entire row
+  outputValue &= ~(7 << IMON_OUTPUT_BL_ICONS); // reset entire row
+  outputValue &= ~(7 << IMON_OUTPUT_BM_ICONS); // reset entire row
+  outputValue &= ~(7 << IMON_OUTPUT_BR_ICONS); // reset entire row
+  outputValue &= ~(3 << IMON_OUTPUT_SPKR); // reset entire block
+}
+
+void XLCDproc_imon::SetIconMovie(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDproc_imon::SetIconMusic(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDproc_imon::SetIconWeather(bool on)
+{
+  if (on)
+    outputValue |= 7 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(7 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDproc_imon::SetIconTV(bool on)
+{
+  if (on)
+    outputValue |= 5 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(5 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDproc_imon::SetIconPhoto(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDproc_imon::SetIconResolution(ILCD::LCD_RESOLUTION_INDICATOR resolution)
+{
+  // reset both icons to avoid that they may be lit at the same time
+  outputValue &= ~(1 << IMON_OUTPUT_TV);
+  outputValue &= ~(1 << IMON_OUTPUT_HDTV);
+
+  if (resolution == LCD_RESOLUTION_INDICATOR_SD)
+    outputValue |= 1 << IMON_OUTPUT_TV;
+  else if (resolution == LCD_RESOLUTION_INDICATOR_HD)
+    outputValue |= 1 << IMON_OUTPUT_HDTV;
+}
+
+void XLCDproc_imon::SetProgressBar1(double progress)
+{
+  outputValueProgressBars = TopProgressBar(
+    outputValueProgressBars, progress);
+}
+
+void XLCDproc_imon::SetProgressBar2(double progress)
+{
+  outputValueProgressBars = BottomProgressBar(
+    outputValueProgressBars, progress);
+}
+
+void XLCDproc_imon::SetProgressBar3(double progress)
+{
+  outputValueProgressBars = TopLine(
+    outputValueProgressBars, progress);
+}
+
+void XLCDproc_imon::SetProgressBar4(double progress)
+{
+  outputValueProgressBars = BottomLine(
+    outputValueProgressBars, progress);
+}
+
+inline int XLCDproc_imon::TopProgressBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x00000FC0;
+  oldValue |= ((int) (32 * (newValue / 100)) << 6) & 0x00000FC0;
+  oldValue |= 1 << IMON_OUTPUT_PBARS;
+  return oldValue;
+}
+
+inline int XLCDproc_imon::BottomProgressBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x00FC0000;
+  oldValue |= ((int) (32 * (newValue / 100)) << 18) & 0x00FC0000;
+  oldValue |= 1 << IMON_OUTPUT_PBARS;
+  return oldValue;
+}
+
+inline int XLCDproc_imon::TopLine(int oldValue, double newValue)
+{
+  oldValue &= ~0x0000003F;
+  oldValue |= ((int) (32 * (newValue / 100)) << 0) & 0x0000003F;
+  oldValue |= 1 << IMON_OUTPUT_PBARS;
+  return oldValue;
+}
+
+inline int XLCDproc_imon::BottomLine(int oldValue, double newValue)
+{
+  oldValue &= ~0x0003F000;
+  oldValue |= ((int) (32 * (newValue / 100)) << 12) & 0x0003F000;
+  oldValue |= 1 << IMON_OUTPUT_PBARS;
+  return oldValue;
+}
+
+bool XLCDproc_imon::isOutputValuesTurn()
+{
+  if (m_outputTimer.GetElapsedMilliseconds() > 1000)
+  {
+    m_outputTimer.Reset();
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+void XLCDproc_imon::SetIconMute(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_imon::SetIconPlaying(bool on)
+{
+  if (on)
+  {
+    outputValue |= 1 << IMON_OUTPUT_DISC;
+  }
+  else
+  {
+    outputValue &= ~(1 << IMON_OUTPUT_DISC);
+  }
+}
+
+void XLCDproc_imon::SetIconPause(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_imon::SetIconRepeat(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_REP;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_REP);
+}
+
+void XLCDproc_imon::SetIconShuffle(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SFL;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SFL);
+}
+
+void XLCDproc_imon::SetIconAlarm(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_ALARM;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_ALARM);
+}
+
+void XLCDproc_imon::SetIconRecord(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_REC;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_REC);
+}
+
+void XLCDproc_imon::SetIconVolume(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_VOL;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_VOL);
+}
+
+void XLCDproc_imon::SetIconTime(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_TIME;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_TIME);
+}
+
+void XLCDproc_imon::SetIconSPDIF(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SPDIF;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SPDIF);
+}
+
+void XLCDproc_imon::SetIconDiscIn(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_DISK_IN;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_DISK_IN);
+}
+
+void XLCDproc_imon::SetIconSource(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SRC;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SRC);
+}
+
+void XLCDproc_imon::SetIconFit(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_FIT;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_FIT);
+}
+
+void XLCDproc_imon::SetIconSCR1(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SCR1;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SCR1);
+}
+
+void XLCDproc_imon::SetIconSCR2(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SCR2;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SCR2);
+}
+
+// codec icons - video: video stream format ###################################
+void XLCDproc_imon::SetIconMPEG(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_BL_ICONS);
+}
+
+void XLCDproc_imon::SetIconDIVX(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_BL_ICONS);
+}
+
+void XLCDproc_imon::SetIconXVID(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_BL_ICONS);
+}
+
+void XLCDproc_imon::SetIconWMV(bool on)
+{
+  if (on)
+    outputValue |= 4 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(4 << IMON_OUTPUT_BL_ICONS);
+}
+// codec icons - video: audio stream format #################################
+void XLCDproc_imon::SetIconMPGA(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_BM_ICONS);
+}
+
+void XLCDproc_imon::SetIconAC3(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_BM_ICONS);
+}
+
+void XLCDproc_imon::SetIconDTS(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_BM_ICONS);
+}
+
+void XLCDproc_imon::SetIconVWMA(bool on)
+{
+  if (on)
+    outputValue |= 4 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(4 << IMON_OUTPUT_BM_ICONS);
+}
+// codec icons - audio format ###############################################
+void XLCDproc_imon::SetIconMP3(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDproc_imon::SetIconOGG(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDproc_imon::SetIconAWMA(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDproc_imon::SetIconWAV(bool on)
+{
+  if (on)
+    outputValue |= 4 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(4 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDproc_imon::SetIconAudioChannels(int channels)
+{
+  switch (channels)
+  {
+  case 1:
+  case 2:
+  case 3:
+    outputValue |= 1 << IMON_OUTPUT_SPKR;
+    break;
+  case 5:
+  case 6:
+    outputValue |= 2 << IMON_OUTPUT_SPKR;
+    break;
+  case 7:
+  case 8:
+    outputValue |= 3 << IMON_OUTPUT_SPKR;
+    break;
+  default:
+    outputValue &= ~(3 << IMON_OUTPUT_SPKR);
+    break;
+  }
+}
+
+#endif // __XLCDPROC_IMON_CPP__

--- a/xbmc/linux/XLCDproc_imon.h
+++ b/xbmc/linux/XLCDproc_imon.h
@@ -1,0 +1,165 @@
+#ifndef __XLCDPROC_IMON_H__
+#define __XLCDPROC_IMON_H__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "../utils/LCD.h"
+#include "XLCDproc.h"
+#include "../utils/Stopwatch.h"
+
+#define IMON_OUTPUT_DISC        0
+#define IMON_OUTPUT_TOP_ROW     1
+#define IMON_OUTPUT_SPKR        4
+#define IMON_OUTPUT_SPDIF       6
+#define IMON_OUTPUT_SRC         7
+#define IMON_OUTPUT_FIT         8
+#define IMON_OUTPUT_TV          9
+#define IMON_OUTPUT_HDTV        10
+#define IMON_OUTPUT_SCR1        11
+#define IMON_OUTPUT_SCR2        12
+#define IMON_OUTPUT_BR_ICONS    13
+#define IMON_OUTPUT_BM_ICONS    16
+#define IMON_OUTPUT_BL_ICONS    19
+#define IMON_OUTPUT_VOL         22
+#define IMON_OUTPUT_TIME        23
+#define IMON_OUTPUT_ALARM       24
+#define IMON_OUTPUT_REC         25
+#define IMON_OUTPUT_REP         26
+#define IMON_OUTPUT_SFL         27
+#define IMON_OUTPUT_PBARS       28
+#define IMON_OUTPUT_DISK_IN     29
+
+/**
+ * Sets the "output state" for the device. We use this to control the icons around the outside the
+ * display. The bits in \c outputValue correspond to the icons as follows:
+ *
+ * Bit     : Icon/Function
+ * 0       : disc icon (0=off, 1='spin') , if Toprow==4, use CD-animation, else use "HDD-recording-animation"
+ * 1,2,3   : top row (0=none, 1=music, 2=movie, 3=photo, 4=CD/DVD, 5=TV, 6=Web, 7=News/Weather)
+ * 4,5     : 'speaker' icons (0=off, 1=L+R, 2=5.1ch, 3=7.1ch)
+ * 6       : S/PDIF icon
+ * 7       : 'SRC'
+ * 8       : 'FIT'
+ * 9       : 'TV'
+ * 10      : 'HDTV'
+ * 11      : 'SRC1'
+ * 12      : 'SRC2'
+ * 13,14,15: bottom-right icons (0=off, 1=MP3, 2=OGG, 3=WMA, 4=WAV)
+ * 16,17,18: bottom-middle icons (0=off, 1=MPG, 2=AC3, 3=DTS, 4=WMA)
+ * 19,20,21: bottom-left icons (0=off, 1=MPG, 2=DIVX, 3=XVID, 4=WMV)
+ * 22      : 'VOL' (volume)
+ * 23      : 'TIME'
+ * 24      : 'ALARM'
+ * 25      : 'REC' (recording)
+ * 26      : 'REP' (repeat)
+ * 27      : 'SFL' (shuffle)
+ * 28      : Abuse this for progress bars (if set to 1), lower bits represent
+ *               the length (6 bits each: P|6xTP|6xTL|6xBL|6xBP with P = bit 28,
+ *               TP=Top Progress, TL = Top Line, BL = Bottom Line, BP = Bottom Progress).
+ *               If bit 28 is set to 1, lower bits are interpreted as
+ *               lengths; otherwise setting the symbols as usual.
+ *               0 <= length <= 32, bars extend from left to right.
+ *               length > 32, bars extend from right to left, length is counted
+ *               from 32 up (i.e. 35 means a length of 3).
+ *
+ *     Remember: There are two kinds of calls!
+ *               With bit 28 set to 1: Set all bars (leaving the symbols as is),
+ *               with bit 28 set to 0: Set the symbols (leaving the bars as is).
+ *     Beware:   TODO: May become a race condition, if both calls are executed
+ *                     before the display gets updated. Keep this in mind in your
+ *                     client-code.
+ * 29      : 'disc-in icon' - half ellipsoid under the disc symbols (0=off, 1=on)
+ */
+
+class XLCDproc_imon: public XLCDproc
+{
+public:
+  XLCDproc_imon(int m_localsockfd);
+  virtual ~XLCDproc_imon(void);
+
+  // States whether this device sends the icon-information by itself.
+  // Returns true, if the caller does not have to care about sending the information.
+  virtual bool SendIconStatesToDisplay();
+  virtual void HandleStop(void);
+
+  virtual void SetIconMovie(bool on);
+  virtual void SetIconMusic(bool on);
+  virtual void SetIconWeather(bool on);
+  virtual void SetIconTV(bool on);
+  virtual void SetIconPhoto(bool on);
+  virtual void SetIconResolution(ILCD::LCD_RESOLUTION_INDICATOR resolution);
+  virtual void SetProgressBar1(double progress); // range from 0 - 100
+  virtual void SetProgressBar2(double progress); // range from 0 - 100
+  virtual void SetProgressBar3(double progress); // range from 0 - 100
+  virtual void SetProgressBar4(double progress); // range from 0 - 100
+  virtual void SetIconMute(bool on);
+  virtual void SetIconPlaying(bool on);
+  virtual void SetIconPause(bool on);
+  virtual void SetIconRepeat(bool on);
+  virtual void SetIconShuffle(bool on);
+  virtual void SetIconAlarm(bool on);
+  virtual void SetIconRecord(bool on);
+  virtual void SetIconVolume(bool on);
+  virtual void SetIconTime(bool on);
+  virtual void SetIconSPDIF(bool on);
+  virtual void SetIconDiscIn(bool on);
+  virtual void SetIconSource(bool on);
+  virtual void SetIconFit(bool on);
+  virtual void SetIconSCR1(bool on);
+  virtual void SetIconSCR2(bool on);
+
+  // codec icons - video: video stream format
+  virtual void SetIconMPEG(bool on);
+  virtual void SetIconDIVX(bool on);
+  virtual void SetIconXVID(bool on);
+  virtual void SetIconWMV(bool on);
+  // codec icons - video: audio stream format
+  virtual void SetIconMPGA(bool on);
+  virtual void SetIconAC3(bool on);
+  virtual void SetIconDTS(bool on);
+  virtual void SetIconVWMA(bool on);
+  // codec icons - audio format
+  virtual void SetIconMP3(bool on);
+  virtual void SetIconOGG(bool on);
+  virtual void SetIconAWMA(bool on);
+  virtual void SetIconWAV(bool on);
+
+  virtual void SetIconAudioChannels(int channels);
+
+private:
+  CStopWatch m_outputTimer;
+
+  virtual void ResetModeIcons(void);
+
+  int TopProgressBar(int oldValue, double newValue);
+  int BottomProgressBar(int oldValue, double newValue);
+  int TopLine(int oldValue, double newValue);
+  int BottomLine(int oldValue, double newValue);
+  bool isOutputValuesTurn();
+
+  int outputValue;
+  int outputValueProgressBars;
+  int outputValueOld;
+  int outputValueProgressBarsOld;
+};
+
+#endif // __XLCDPROC_IMON_H__

--- a/xbmc/linux/XLCDproc_mdm166a.cpp
+++ b/xbmc/linux/XLCDproc_mdm166a.cpp
@@ -1,0 +1,323 @@
+#ifndef __XLCDPROC_MDM166A_CPP__
+#define __XLCDPROC_MDM166A_CPP__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "XLCDproc_mdm166a.h"
+#include "../utils/log.h"
+
+XLCDproc_mdm166a::XLCDproc_mdm166a(int m_localsockfd)
+{
+  outputValue = 0;
+  outputValueOld = 1; // for correct icon-initialization this needs to be different to the actual value
+
+  m_sockfd = m_localsockfd;
+}
+
+XLCDproc_mdm166a::~XLCDproc_mdm166a(void)
+{
+}
+
+bool XLCDproc_mdm166a::SendIconStatesToDisplay()
+{
+  CStdString cmd;
+
+  if (outputValue != outputValueOld)
+  {
+    outputValueOld = outputValue;
+    cmd.Format("output %d\n", outputValue);
+  }
+  else
+    return true;
+
+  ResetModeIcons();
+
+  if (write(m_sockfd, cmd.c_str(), cmd.size()) < 0)
+  {
+    CLog::Log(
+        LOGERROR,
+        "XLCDproc::%s - Unable to write 'outputValue' to socket, LCDd not running?",
+        __FUNCTION__);
+
+    return false;
+  }
+
+  return true;
+}
+
+void XLCDproc_mdm166a::HandleStop(void)
+{
+  CStdString clearcmd = "";
+
+  // clear any icons
+  outputValue = 0;
+
+  clearcmd.Format("output %d\n", outputValue);
+
+  if (write(m_sockfd, clearcmd.c_str(), clearcmd.size()) < 0)
+    CLog::Log(LOGERROR, "XLCDproc::%s - Unable to write to socket", __FUNCTION__);
+
+  usleep(100000); // we have to wait a bit until the message has been sent to the display
+}
+
+void XLCDproc_mdm166a::ResetModeIcons(void)
+{
+  outputValue &= ~(3 << MDM166A_OUTPUT_WLAN_STR); // reset entire block
+}
+
+void XLCDproc_mdm166a::SetIconMovie(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconMusic(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconWeather(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconTV(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconPhoto(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconResolution(ILCD::LCD_RESOLUTION_INDICATOR resolution)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetProgressBar1(double progress)
+{
+  outputValue = progressBar(outputValue, progress);
+}
+
+void XLCDproc_mdm166a::SetProgressBar2(double progress)
+{
+  outputValue = volumeBar(outputValue, progress);
+}
+
+inline int XLCDproc_mdm166a::volumeBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x1F00;
+  oldValue |= ((int) (28 * (newValue / 100)) << MDM166A_OUTPUT_VOLUME) & 0x1F00;
+  return oldValue;
+}
+
+inline int XLCDproc_mdm166a::progressBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x3F8000;
+  oldValue |= ((int) (96 * (newValue / 100)) << MDM166A_OUTPUT_PROGRESS) & 0x3F8000;
+  return oldValue;
+}
+
+void XLCDproc_mdm166a::SetIconMute(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_MUTE;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_MUTE);
+}
+
+void XLCDproc_mdm166a::SetIconPlaying(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_PLAY;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_PLAY);
+}
+
+void XLCDproc_mdm166a::SetIconPause(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_PAUSE;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_PAUSE);
+}
+
+void XLCDproc_mdm166a::SetIconRepeat(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconShuffle(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconAlarm(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_ALARM;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_ALARM);
+}
+
+void XLCDproc_mdm166a::SetIconRecord(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_REC;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_REC);
+}
+
+void XLCDproc_mdm166a::SetIconVolume(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_VOL;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_VOL);
+}
+
+void XLCDproc_mdm166a::SetIconTime(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconSPDIF(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_WLAN_ANT;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_WLAN_ANT);
+}
+
+void XLCDproc_mdm166a::SetIconDiscIn(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconSource(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconFit(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconSCR1(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconSCR2(bool on)
+{
+  // icon not supported by display
+}
+
+// codec icons - video: video stream format ###################################
+void XLCDproc_mdm166a::SetIconMPEG(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconDIVX(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconXVID(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconWMV(bool on)
+{
+  // icon not supported by display
+}
+
+// codec icons - video: audio stream format #################################
+void XLCDproc_mdm166a::SetIconMPGA(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconAC3(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconDTS(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconVWMA(bool on)
+{
+  // icon not supported by display
+}
+
+// codec icons - audio format ###############################################
+void XLCDproc_mdm166a::SetIconMP3(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconOGG(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconAWMA(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconWAV(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDproc_mdm166a::SetIconAudioChannels(int channels)
+{
+  switch (channels)
+  {
+  case 1:
+  case 2:
+  case 3:
+    outputValue |= 1 << MDM166A_OUTPUT_WLAN_STR;
+    break;
+  case 5:
+  case 6:
+    outputValue |= 2 << MDM166A_OUTPUT_WLAN_STR;
+    break;
+  case 7:
+  case 8:
+    outputValue |= 3 << MDM166A_OUTPUT_WLAN_STR;
+    break;
+  default:
+    outputValue &= ~(3 << MDM166A_OUTPUT_WLAN_STR);
+    break;
+  }
+}
+
+#endif // __XLCDPROC_MDM166A_CPP__

--- a/xbmc/linux/XLCDproc_mdm166a.h
+++ b/xbmc/linux/XLCDproc_mdm166a.h
@@ -1,0 +1,121 @@
+#ifndef __XLCDPROC_MDM166A_H__
+#define __XLCDPROC_MDM166A_H__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "../utils/LCD.h"
+#include "XLCDproc.h"
+#include "../utils/Stopwatch.h"
+
+#define MDM166A_OUTPUT_PLAY     0
+#define MDM166A_OUTPUT_PAUSE    1
+#define MDM166A_OUTPUT_REC      2
+#define MDM166A_OUTPUT_ALARM    3
+#define MDM166A_OUTPUT_AT       4
+#define MDM166A_OUTPUT_MUTE     5
+#define MDM166A_OUTPUT_WLAN_ANT 6
+#define MDM166A_OUTPUT_VOL      7
+#define MDM166A_OUTPUT_VOLUME   8
+#define MDM166A_OUTPUT_WLAN_STR 13
+#define MDM166A_OUTPUT_PROGRESS 15
+
+/**
+ * Sets the "output state" for the device. We use this to control the icons around the outside the
+ * display. The bits in \c outputValue correspond to the icons as follows:
+ *
+ * Bit     : Icon/Function
+ * 0       : Play
+ * 1       : Pause
+ * 2       : Record
+ * 3       : Message
+ * 4       : @ (in the envelope (=Message symbol))
+ * 5       : Mute
+ * 6       : WLAN tower
+ * 7       : Volume (the word "Vol.")
+ * 8...12  : Volume value (which may be 0-28)
+ * 13...14 : WLAN signal strength (which may be 0-3)
+ */
+
+class XLCDproc_mdm166a: public XLCDproc
+{
+public:
+  XLCDproc_mdm166a(int m_localsockfd);
+  virtual ~XLCDproc_mdm166a(void);
+
+  // States whether this device sends the icon-information by itself.
+  // Returns true, if the caller does not have to care about sending the information.
+  virtual bool SendIconStatesToDisplay();
+  virtual void HandleStop(void);
+
+  virtual void SetIconMovie(bool on);
+  virtual void SetIconMusic(bool on);
+  virtual void SetIconWeather(bool on);
+  virtual void SetIconTV(bool on);
+  virtual void SetIconPhoto(bool on);
+  virtual void SetIconResolution(ILCD::LCD_RESOLUTION_INDICATOR resolution);
+  virtual void SetProgressBar1(double progress); // range from 0 - 100
+  virtual void SetProgressBar2(double progress); // range from 0 - 100
+  virtual void SetIconMute(bool on);
+  virtual void SetIconPlaying(bool on);
+  virtual void SetIconPause(bool on);
+  virtual void SetIconRepeat(bool on);
+  virtual void SetIconShuffle(bool on);
+  virtual void SetIconAlarm(bool on);
+  virtual void SetIconRecord(bool on);
+  virtual void SetIconVolume(bool on);
+  virtual void SetIconTime(bool on);
+  virtual void SetIconSPDIF(bool on);
+  virtual void SetIconDiscIn(bool on);
+  virtual void SetIconSource(bool on);
+  virtual void SetIconFit(bool on);
+  virtual void SetIconSCR1(bool on);
+  virtual void SetIconSCR2(bool on);
+
+  // codec icons - video: video stream format
+  virtual void SetIconMPEG(bool on);
+  virtual void SetIconDIVX(bool on);
+  virtual void SetIconXVID(bool on);
+  virtual void SetIconWMV(bool on);
+  // codec icons - video: audio stream format
+  virtual void SetIconMPGA(bool on);
+  virtual void SetIconAC3(bool on);
+  virtual void SetIconDTS(bool on);
+  virtual void SetIconVWMA(bool on);
+  // codec icons - audio format
+  virtual void SetIconMP3(bool on);
+  virtual void SetIconOGG(bool on);
+  virtual void SetIconAWMA(bool on);
+  virtual void SetIconWAV(bool on);
+
+  virtual void SetIconAudioChannels(int channels);
+
+private:
+  virtual void ResetModeIcons(void);
+
+  int volumeBar(int oldValue, double newValue);
+  int progressBar(int oldValue, double newValue);
+
+  int outputValue;
+  int outputValueOld;
+};
+
+#endif // __XLCDPROC_MDM166A_H__

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -131,6 +131,10 @@ void CAdvancedSettings::Initialize()
   m_lcdDimOnScreenSave = false;
   m_lcdScrolldelay = 1;
   m_lcdHostName = "localhost";
+  m_lcdProgressBar1 = "progress";
+  m_lcdProgressBar2 = "volume";
+  m_lcdProgressBar3 = "none";
+  m_lcdProgressBar4 = "none";
 
   m_songInfoDuration = 10;
 
@@ -677,6 +681,10 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "dimonscreensave", m_lcdDimOnScreenSave);
     XMLUtils::GetInt(pElement, "scrolldelay", m_lcdScrolldelay, -8, 8);
     XMLUtils::GetString(pElement, "hostname", m_lcdHostName);
+    XMLUtils::GetString(pElement, "progressbar1", m_lcdProgressBar1);
+    XMLUtils::GetString(pElement, "progressbar2", m_lcdProgressBar2);
+    XMLUtils::GetString(pElement, "progressbar3", m_lcdProgressBar3);
+    XMLUtils::GetString(pElement, "progressbar4", m_lcdProgressBar4);
   }
   pElement = pRootElement->FirstChildElement("network");
   if (pElement)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -177,6 +177,10 @@ class CAdvancedSettings
     bool m_lcdDimOnScreenSave;
     int m_lcdScrolldelay;
     CStdString m_lcdHostName;
+    CStdString m_lcdProgressBar1;
+    CStdString m_lcdProgressBar2;
+    CStdString m_lcdProgressBar3;
+    CStdString m_lcdProgressBar4;
 
     int m_songInfoDuration;
     int m_logLevel;

--- a/xbmc/utils/LCD.cpp
+++ b/xbmc/utils/LCD.cpp
@@ -25,17 +25,26 @@
 #include "log.h"
 #include "XMLUtils.h"
 
-using namespace std;
+// required for icon state retrieval and display
+#include "Application.h"
+#include "../guilib/GUIWindowManager.h"
+#include "../GUIInfoManager.h"
+#include "../pvr/PVRManager.h"
+#include "../storage/MediaManager.h"
+#include "StreamDetails.h"
 
-void ILCD::StringToLCDCharSet(CStdString& strText)
+using namespace std;
+using namespace PVR;
+
+void ILCD::StringToLCDCharSet(CStdString& strText, unsigned int iCharsetTab)
 {
 
-  //0 = HD44780, 1=KS0073
+  //0 = HD44780, 1=KS0073, 2 = Soundgraph iMon/mdm166a
   unsigned int iLCDContr = 0;
   //the timeline is using blocks
   //a block is used at address 0xA0, smallBlocks at address 0xAC-0xAF
 
-  unsigned char LCD[2][256] = {
+  unsigned char LCD[3][256] = {
                                 { //HD44780 charset ROM code A00
                                   0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
                                   0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
@@ -72,11 +81,33 @@ void ILCD::StringToLCDCharSet(CStdString& strText)
                                   0x44, 0x5d, 0x4f, 0xe0, 0xec, 0x4f, 0x5c, 0x78, 0xab, 0xee, 0xe5, 0xee, 0x5e, 0xe6, 0x20, 0xbe,
                                   0x7f, 0xe7, 0xaf, 0xaf, 0x7b, 0xaf, 0xbd, 0xc8, 0xa4, 0xa5, 0xc7, 0x65, 0xa7, 0xe8, 0x69, 0x69,
                                   0x6f, 0x7d, 0xa8, 0xe9, 0xed, 0x6f, 0x7c, 0x25, 0xac, 0xa6, 0xea, 0xef, 0x7e, 0xeb, 0x70, 0x79
+                                },
+
+                                { //Soundgraph iMon-LCD / Targa MDM166A VFD (play-icons are mapped, others not yet)
+                                  0x00, 0x01, 0x12, 0x16, 0x15, 0x10, 0x11, 0x12, 0x14, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+                                  0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+                                  0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+                                  0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+                                  0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
+                                  0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,
+                                  0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f,
+                                  0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+                                  0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,
+                                  0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f,
+                                  0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0x8c, 0x8a, 0x89, 0x88, 0x87, // Custom characters??? Should be here?
+                                  0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
+                                  0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+                                  0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf,
+                                  0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef,
+                                  0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
                                 }
                               };
 
   unsigned char cLCD;
   int iSize = (int)strText.size();
+
+  if (iCharsetTab < 3)
+    iLCDContr = iCharsetTab;
 
   for (int i = 0; i < iSize; ++i)
   {
@@ -504,6 +535,8 @@ void ILCD::Render(LCD_MODE mode)
   // fill remainder with empty space
   while (outLine < 4)
     SetLine(outLine++, "");
+
+  RenderIcons();
 }
 
 void ILCD::DisableOnPlayback(bool playingVideo, bool playingAudio)
@@ -511,4 +544,399 @@ void ILCD::DisableOnPlayback(bool playingVideo, bool playingAudio)
   if ((playingVideo && (m_disableOnPlay & DISABLE_ON_PLAY_VIDEO)) ||
       (playingAudio && (m_disableOnPlay & DISABLE_ON_PLAY_MUSIC)))
     SetBackLight(0);
+}
+
+void ILCD::RenderIcons()
+{
+  static bool rendericons = false;
+
+  SetIconMovie(false);
+  SetIconMusic(false);
+  SetIconTV(false);
+  SetIconPhoto(false);
+  SetIconDiscIn(false);
+  SetIconSource(false);
+  SetIconFit(false);
+
+  if (g_application.GetNavigationIdleTime() > 0.1)
+  {
+    rendericons = true;
+  }
+
+  if ((!m_bStop) && (rendericons))
+  {
+    if (g_application.IsPlayingVideo() && g_application.m_pPlayer)
+    {
+      SetLCDPlayingState(true);
+
+      if (g_PVRManager.TranslateBoolInfo(PVR_IS_PLAYING_TV))
+      {
+        SetIconTV(true);
+      }
+      else
+      { // playing e.g. a video
+        SetIconMovie(true);
+      }
+
+      if (g_application.m_pPlayer->GetPictureWidth() <= 720)
+      {
+        SetIconResolution(LCD_RESOLUTION_INDICATOR_SD);
+      }
+      else
+      {
+        SetIconResolution(LCD_RESOLUTION_INDICATOR_HD);
+      }
+
+      int iResolution = g_graphicsContext.GetVideoResolution();
+
+      // tolerate 10% difference from current resolution to state that it is "in original resolution"
+      if (    (g_application.m_pPlayer->GetPictureWidth() <= g_settings.m_ResInfo[iResolution].iWidth + ((g_settings.m_ResInfo[iResolution].iWidth)*0.1))
+           && (g_application.m_pPlayer->GetPictureWidth() >= g_settings.m_ResInfo[iResolution].iWidth - ((g_settings.m_ResInfo[iResolution].iWidth)*0.1)) )
+      {
+        SetIconSource(true);
+      }
+      else
+      {
+        SetIconFit(true);
+      }
+    }
+    else if (g_application.IsPlayingAudio() && g_application.m_pPlayer)
+    {
+      SetLCDPlayingState(true);
+      SetIconMusic(true);
+
+    }
+    else
+    {
+      SetLCDPlayingState(false);
+      SetIconResolution(LCD_RESOLUTION_INDICATOR_NONE);
+
+      if (g_windowManager.GetActiveWindow() == WINDOW_WEATHER)
+      {
+        SetIconWeather(true);
+      }
+      else if (    (g_windowManager.GetActiveWindow() >=  WINDOW_PVR           )
+                && (g_windowManager.GetActiveWindow() <  (WINDOW_PVR+100)      )
+              )
+      {
+        SetIconTV(true);
+      }
+      else if (    (g_windowManager.GetActiveWindow() == WINDOW_VIDEOS         )
+                || (g_windowManager.GetActiveWindow() == WINDOW_VIDEO_FILES    )
+                || (g_windowManager.GetActiveWindow() == WINDOW_VIDEO_NAV      )
+                || (g_windowManager.GetActiveWindow() == WINDOW_VIDEO_PLAYLIST )
+              )
+      {
+        SetIconMovie(true);
+      }
+      else if (    (g_windowManager.GetActiveWindow() == WINDOW_MUSIC                 )
+                || (g_windowManager.GetActiveWindow() == WINDOW_MUSIC_PLAYLIST        )
+                || (g_windowManager.GetActiveWindow() == WINDOW_MUSIC_FILES           )
+                || (g_windowManager.GetActiveWindow() == WINDOW_MUSIC_NAV             )
+                || (g_windowManager.GetActiveWindow() == WINDOW_MUSIC_PLAYLIST_EDITOR )
+              )
+      {
+        SetIconMusic(true);
+      }
+      else if (g_windowManager.GetActiveWindow() == WINDOW_PICTURES)
+      {
+        SetIconPhoto(true);
+      }
+    }
+
+    SetCodecInformationIcons();
+
+    if (g_application.GetVolume() == 0)
+    {
+      SetIconMute(true);
+    }
+    else
+    {
+      SetIconMute(false);
+    }
+
+    if (g_application.IsPaused())
+    {
+      SetIconPause(true);
+    }
+    else
+    {
+      SetIconPause(false);
+    }
+
+    // Set the volume icon accordingly
+    if (g_windowManager.IsWindowActive(WINDOW_DIALOG_VOLUME_BAR))
+    {
+      SetIconVolume(true);
+    }
+    else
+    {
+      SetIconVolume(false);
+    }
+
+    // Set the alarm icon accordingly - if a pop-up is displayed
+    if (g_windowManager.IsWindowActive(WINDOW_DIALOG_KAI_TOAST))
+    {
+      SetIconAlarm(true);
+    }
+    else
+    {
+      SetIconAlarm(false);
+    }
+
+    // Set the record icon accordingly
+    if ((g_application.m_pPlayer != NULL && g_application.m_pPlayer->IsRecording()) || g_PVRManager.TranslateBoolInfo(PVR_IS_RECORDING))
+    {
+      SetIconRecord(true);
+    }
+    else
+    {
+      SetIconRecord(false);
+    }
+
+    // Set the repeat icon accordingly
+    if (    (g_playlistPlayer.GetRepeat(g_playlistPlayer.GetCurrentPlaylist()) == PLAYLIST::REPEAT_ALL)
+         || (g_playlistPlayer.GetRepeat(g_playlistPlayer.GetCurrentPlaylist()) == PLAYLIST::REPEAT_ONE)
+       )
+    {
+      SetIconRepeat(true);
+    }
+    else
+    {
+      SetIconRepeat(false);
+    }
+
+    // Set the shuffle icon accordingly
+    if (g_playlistPlayer.IsShuffled(g_playlistPlayer.GetCurrentPlaylist()))
+    {
+      SetIconShuffle(true);
+    }
+    else
+    {
+      SetIconShuffle(false);
+    }
+
+    // Set the time icon accordingly
+    if ((!g_application.IsPlaying() && g_application.GetNavigationIdleTime() >= 5) && g_application.IsInScreenSaver())
+    {
+      SetIconTime(true);
+    }
+    else
+    {
+      SetIconTime(false);
+    }
+
+    if (g_mediaManager.IsDiscInDrive()) {
+      SetIconDiscIn(true);
+    }
+
+    // Set the SCR1/2 icons accordingly
+    SetIconSCR1(false);
+    SetIconSCR2(false);
+  }
+
+  SendIconStatesToDisplay();
+}
+
+void ILCD::SetCodecInformationIcons()
+{
+  if (g_application.IsPlaying() && g_application.m_pPlayer)
+  {
+    if (g_application.m_pPlayer->IsPassthrough())
+    {
+      SetIconSPDIF(true);
+    }
+    else
+    {
+      SetIconSPDIF(false);
+    }
+
+    if (g_application.IsPlayingVideo())
+    {
+      CStdString videoCodec = g_application.m_pPlayer->GetVideoCodecName();
+      //CLog::Log(LOGDEBUG, "XLCDproc::%s - Videocodec = '%s'", __FUNCTION__, videoCodec.c_str());
+      if (    (videoCodec.CompareNoCase("mpg")         == 0)
+           || (videoCodec.CompareNoCase("mpeg")        == 0)
+           || (videoCodec.CompareNoCase("mpeg2video")  == 0)
+           || (videoCodec.CompareNoCase("h264")        == 0)
+           || (videoCodec.CompareNoCase("x264")        == 0)
+           || (videoCodec.CompareNoCase("mpeg4")       == 0)
+           || (g_PVRManager.TranslateBoolInfo(PVR_IS_PLAYING_TV))
+         )
+      { //g_application.m_pPlayer->GetVideoCodecName() returns "" in TV-mode, so we have to cheat a bit
+        SetIconMPEG(true);
+      }
+      else if (    (videoCodec.CompareNoCase("divx") == 0)
+                || (videoCodec.CompareNoCase("dx50") == 0)
+                || (videoCodec.CompareNoCase("div3") == 0)
+              )
+      {
+        SetIconDIVX(true);
+      }
+      else if (videoCodec.CompareNoCase("xvid")      == 0)
+      {
+        SetIconXVID(true);
+      }
+      else if (videoCodec.CompareNoCase("wmv")       == 0)
+      {
+        SetIconWMV(true);
+      }
+    }
+
+    CStdString audioCodec = g_application.m_pPlayer->GetAudioCodecName();
+    //CLog::Log(LOGDEBUG, "XLCDproc::%s - Audiocodec = '%s'", __FUNCTION__, audioCodec.c_str());
+    if (    (audioCodec.CompareNoCase("mpga")        == 0)
+         || (audioCodec.CompareNoCase("mp2")         == 0)
+       )
+    {
+      SetIconMPGA(true);
+    }
+    else if (    (audioCodec.CompareNoCase("ac3")    == 0)
+              || (audioCodec.CompareNoCase("truehd") == 0)
+            )
+    {
+      SetIconAC3(true);
+    }
+    else if (    (audioCodec.CompareNoCase("dts")      == 0)
+              || (audioCodec.CompareNoCase("dtshd_ma") == 0)
+              || (audioCodec.CompareNoCase("dca")      == 0)
+            )
+    {
+      SetIconDTS(true);
+    }
+    else if (audioCodec.CompareNoCase("mp3")         == 0)
+    {
+      SetIconMP3(true);
+    }
+    else if (    (audioCodec.CompareNoCase("ogg")    == 0)
+              || (audioCodec.CompareNoCase("vorbis") == 0)
+            )
+    {
+      SetIconOGG(true);
+    }
+    else if (    (audioCodec.CompareNoCase("wma")    == 0)
+              || (audioCodec.CompareNoCase("wmav2")  == 0)
+            )
+    {
+      if (g_application.IsPlayingVideo())
+      {
+        SetIconVWMA(true);
+      }
+      else if (g_application.IsPlayingAudio())
+      {
+        SetIconAWMA(true);
+      }
+    }
+    else if (    (audioCodec.CompareNoCase("wav")    == 0)
+              || (audioCodec.Find("pcm")             >= 0)
+            )
+    {
+      SetIconWAV(true);
+    }
+
+    CStreamDetails streamDetails;
+
+    if (g_application.m_pPlayer->GetStreamDetails(streamDetails)) {
+      SetIconAudioChannels(streamDetails.GetAudioChannels());
+    }
+    else if (!audioCodec.IsEmpty()) {
+      SetIconAudioChannels(2); // Let's assume stereo if there is audio being played but no stream details are available (e.g. while playing music)
+    }
+  }
+  else {
+    ResetCodecIcons();
+  }
+}
+
+void ILCD::ResetCodecIcons()
+{
+  SetIconSPDIF(false);
+
+  SetIconMPEG(false);
+  SetIconDIVX(false);
+  SetIconXVID(false);
+  SetIconWMV(false);
+
+  SetIconMPGA(false);
+  SetIconAC3(false);
+  SetIconDTS(false);
+  SetIconMP3(false);
+
+  SetIconOGG(false);
+  SetIconVWMA(false);
+  SetIconAWMA(false);
+  SetIconWAV(false);
+}
+
+void ILCD::SetLCDPlayingState(bool on)
+{
+  SetIconPlaying(on);
+
+  if (g_advancedSettings.m_lcdProgressBar1 == "progress")
+  {
+    SetProgressBar1((on) ? g_application.GetPercentage() : 0.0);
+  }
+  else if (g_advancedSettings.m_lcdProgressBar1 == "volume")
+  {
+    SetProgressBar1(g_application.GetVolume());
+  }
+  else if (g_advancedSettings.m_lcdProgressBar1 == "menu")
+  {
+    SetProgressBar1((on) ? 0.0 : 100.0);
+  }
+  else
+  {
+    SetProgressBar1(0.0);
+  }
+
+  if (g_advancedSettings.m_lcdProgressBar2 == "progress")
+  {
+    SetProgressBar2((on) ? g_application.GetPercentage() : 0.0);
+  }
+  else if (g_advancedSettings.m_lcdProgressBar2 == "volume")
+  {
+    SetProgressBar2(g_application.GetVolume());
+  }
+  else if (g_advancedSettings.m_lcdProgressBar2 == "menu")
+  {
+    SetProgressBar2((on) ? 0.0 : 100.0);
+  }
+  else
+  {
+    SetProgressBar2(0.0);
+  }
+
+  if (g_advancedSettings.m_lcdProgressBar3 == "progress")
+  {
+    SetProgressBar3((on) ? g_application.GetPercentage() : 0.0);
+  }
+  else if (g_advancedSettings.m_lcdProgressBar3 == "volume")
+  {
+    SetProgressBar3(g_application.GetVolume());
+  }
+  else if (g_advancedSettings.m_lcdProgressBar3 == "menu")
+  {
+    SetProgressBar3((on) ? 0.0 : 100.0);
+  }
+  else
+  {
+    SetProgressBar3(0.0);
+  }
+
+  if (g_advancedSettings.m_lcdProgressBar4 == "progress")
+  {
+    SetProgressBar4((on) ? g_application.GetPercentage() : 0.0);
+  }
+  else if (g_advancedSettings.m_lcdProgressBar4 == "volume")
+  {
+    SetProgressBar4(g_application.GetVolume());
+  }
+  else if (g_advancedSettings.m_lcdProgressBar4 == "menu")
+  {
+    SetProgressBar4((on) ? 0.0 : 100.0);
+  }
+  else
+  {
+    SetProgressBar4(0.0);
+  }
 }

--- a/xbmc/utils/LCD.h
+++ b/xbmc/utils/LCD.h
@@ -52,6 +52,16 @@ public:
                         CUSTOM_CHARSET_BIGCHAR,
                         CUSTOM_CHARSET_MAX
                 };
+  enum LCD_RESOLUTION_INDICATOR {
+                        LCD_RESOLUTION_INDICATOR_NONE = 0,
+                        LCD_RESOLUTION_INDICATOR_SD,
+                        LCD_RESOLUTION_INDICATOR_HD
+                };
+  enum LCD_CHARSET_CONVTABS {
+                        LCD_CHARSET_TAB_HD44780 = 0,
+                        LCD_CHARSET_TAB_KS0073 = 1,
+                        LCD_CHARSET_TAB_IMONMDM = 2
+                };
   virtual void Initialize();
   virtual bool IsConnected();
   virtual void Stop() = 0;
@@ -74,14 +84,63 @@ public:
           m_eCurrentCharset(CUSTOM_CHARSET_DEFAULT) {}
 protected:
   virtual void Process() = 0;
-  void StringToLCDCharSet(CStdString& strText);
+  void StringToLCDCharSet(CStdString& strText, unsigned int iCharsetTab);
   unsigned char GetLCDCharsetCharacter( UINT _nCharacter, int _nCharset=-1);
   void LoadMode(TiXmlNode *node, LCD_MODE mode);
+
+  virtual bool SendIconStatesToDisplay(void) = 0;
+  virtual void SetIconMovie(bool on) = 0;
+  virtual void SetIconMusic(bool on) = 0;
+  virtual void SetIconWeather(bool on) = 0;
+  virtual void SetIconTV(bool on) = 0;
+  virtual void SetIconPhoto(bool on) = 0;
+  virtual void SetIconResolution(LCD_RESOLUTION_INDICATOR resolution) = 0;
+  virtual void SetProgressBar1(double progress) = 0;
+  virtual void SetProgressBar2(double progress) = 0;
+  virtual void SetProgressBar3(double progress) = 0;
+  virtual void SetProgressBar4(double progress) = 0;
+  virtual void SetIconMute(bool on) = 0;
+  virtual void SetIconPlaying(bool on) = 0;
+  virtual void SetIconPause(bool on) = 0;
+  virtual void SetIconRepeat(bool on) = 0;
+  virtual void SetIconShuffle(bool on) = 0;
+  virtual void SetIconAlarm(bool on) = 0;
+  virtual void SetIconRecord(bool on) = 0;
+  virtual void SetIconVolume(bool on) = 0;
+  virtual void SetIconTime(bool on) = 0;
+  virtual void SetIconSPDIF(bool on) = 0;
+  virtual void SetIconDiscIn(bool on) = 0;
+  virtual void SetIconSource(bool on) = 0;
+  virtual void SetIconFit(bool on) = 0;
+  virtual void SetIconSCR1(bool on) = 0;
+  virtual void SetIconSCR2(bool on) = 0;
+  // codec icons - video: video stream format
+  virtual void SetIconMPEG(bool on) = 0;
+  virtual void SetIconDIVX(bool on) = 0;
+  virtual void SetIconXVID(bool on) = 0;
+  virtual void SetIconWMV(bool on) = 0;
+  // codec icons - video: audio stream format
+  virtual void SetIconMPGA(bool on) = 0;
+  virtual void SetIconAC3(bool on) = 0;
+  virtual void SetIconDTS(bool on) = 0;
+  virtual void SetIconVWMA(bool on) = 0;
+  // codec icons - audio format
+  virtual void SetIconMP3(bool on) = 0;
+  virtual void SetIconOGG(bool on) = 0;
+  virtual void SetIconAWMA(bool on) = 0;
+  virtual void SetIconWAV(bool on) = 0;
+
+  virtual void SetIconAudioChannels(int channels) = 0;
 
 private:
   int m_disableOnPlay;
 
   std::vector<CGUIInfoLabel> m_lcdMode[LCD_MODE_MAX];
   UINT m_eCurrentCharset;
+
+  void RenderIcons();
+  void SetCodecInformationIcons();
+  void ResetCodecIcons();
+  void SetLCDPlayingState(bool on);
 };
 extern ILCD* g_lcd;


### PR DESCRIPTION
This PR adds support for the special extra icons surrounding the text area on SoundGraph iMon LCD's and Futaba mdm166a VFD's by evaluating modes and codecs from currently playing media and sending matching control messages down the LCDproc pipe.

Preamble: After finding out the next merge period will be the last one before Frodo feature freeze, and basicly having this stuff (which works and does what it should perfectly at least since Dharma for more than two years now) sitting in a separate branch, kept uptodate and tweaked here and there from time to time, this might be interesting for buyers of SoundGraph/Futaba displays or Antec Fusion Remote HTPC-Cases (the display type is factory-mounted in some other cases, too).

To get an idea on what this effectively does, I've set up a crude webpage showing off the enhancement - see http://www.eth0.cc/xbmc-imon/ (apologizing for my crappy cellphone camera).

Users with matching hardware (displays) don't have to configure anything, everything will be autodetected and set up without any need to touch configuration vars. This will also satisfy many users asking for ways to make the special symbols display something, and fully replaces all floating-around Perl pseudodaemon hacks/scripts getting data via XBMC's Webserver.

While I've maintained this functionality at least since Eden-betas and applied changes & improvements here and there, it must be noted that the original code first appeared at http://www.vdr-portal.de/board60-linux/board62-software/board95-xbmc/89740-announce-icons-beim-imon-lcd-und-mdm166a-spectrum-analyzer-f%C3%BCr-lcdproc/ (german language!) and was posted by user "theonlychriss", who also created the now closed Trac Ticket#8981. He however happily agreed with me to put this up onto GitHub and finally PR this to mainline.

The squashed commit at first seems to touch several things (smaller commits may be reviewed via https://github.com/herrnst/xbmc/compare/master...imonlcd), but it mostly "just" adds two low-level interfaces for the two display types, an autodetection routine with proper "Icon device" attachment, and determination of current modes and codecs.

Although surely more elegant ways of handling these things exist, at least adding support for more hardware with similar features is as easy as duplicating the lowlevel-implementation, change things for the hardware and finally add the hardware to the autodetection.

As mentioned earlier, this thing has developed to a very stable shape over time and is used on "production" systems for a long time. It should not interfere with other display types, but very likely needs verification. Platform-wise, linux only.

Note: This PR/commit conflicts with PR#1429 (both touch nearby lines, no conflicts behavior-wise), so if both become merge candidates, the latter needs a quick rebase. While knowing this ain't good, I made this PR with the soon-being-reached deadlines in mind.
