### PR TITLE
Smaller movement radius for touch (replaces #1304)

### DIFF
--- a/xbmc/android/activity/AndroidTouch.cpp
+++ b/xbmc/android/activity/AndroidTouch.cpp
@@ -24,11 +24,9 @@
 #include "windowing/WinEvents.h"
 #include "ApplicationMessenger.h"
 
-CAndroidTouch::CAndroidTouch(uint32_t dpi) : m_dpi(dpi)
+CAndroidTouch::CAndroidTouch() : m_dpi(160)
 {
   CTouchInput::Get().RegisterHandler(this);
-  if (!m_dpi)
-    m_dpi = 160; // sensible default
 }
 
 CAndroidTouch::~CAndroidTouch()
@@ -160,6 +158,12 @@ void CAndroidTouch::OnZoomPinch(float centerX, float centerY, float zoomFactor)
 void CAndroidTouch::OnRotate(float centerX, float centerY, float angle)
 {
   XBMC_TouchGesture(ACTION_GESTURE_ROTATE, centerX, centerY, angle, 0);
+}
+
+void CAndroidTouch::setDPI(uint32_t dpi)
+{
+  if (dpi != 0)
+    m_dpi = dpi;
 }
 
 void CAndroidTouch::XBMC_Touch(uint8_t type, uint8_t button, uint16_t x, uint16_t y)

--- a/xbmc/android/activity/AndroidTouch.cpp
+++ b/xbmc/android/activity/AndroidTouch.cpp
@@ -24,9 +24,11 @@
 #include "windowing/WinEvents.h"
 #include "ApplicationMessenger.h"
 
-CAndroidTouch::CAndroidTouch()
+CAndroidTouch::CAndroidTouch(uint32_t dpi) : m_dpi(dpi)
 {
   CTouchInput::Get().RegisterHandler(this);
+  if (!m_dpi)
+    m_dpi = 160; // sensible default
 }
 
 CAndroidTouch::~CAndroidTouch()

--- a/xbmc/android/activity/AndroidTouch.cpp
+++ b/xbmc/android/activity/AndroidTouch.cpp
@@ -81,13 +81,13 @@ bool CAndroidTouch::onTouchEvent(AInputEvent* event)
 
   float x = AMotionEvent_getX(event, touchPointer);
   float y = AMotionEvent_getY(event, touchPointer);
-  float size = AMotionEvent_getTouchMinor(event, touchPointer);
+  float size = m_dpi / 16.0f;
   int64_t time = AMotionEvent_getEventTime(event);
 
   // first update all touch pointers
   for (unsigned int pointer = 0; pointer < numPointers; pointer++)
     CTouchInput::Get().Update(pointer, AMotionEvent_getX(event, pointer), AMotionEvent_getY(event, pointer),
-    AMotionEvent_getEventTime(event), AMotionEvent_getTouchMinor(event, pointer));
+    AMotionEvent_getEventTime(event), m_dpi / 16.0f);
 
   // now send the event
   return CTouchInput::Get().Handle(touchEvent, x, y, time, touchPointer, size);

--- a/xbmc/android/activity/AndroidTouch.h
+++ b/xbmc/android/activity/AndroidTouch.h
@@ -27,7 +27,7 @@ class CAndroidTouch : protected ITouchHandler
 {
 
 public:
-  CAndroidTouch(uint32_t dpi = 0);
+  CAndroidTouch();
   virtual ~CAndroidTouch();
   bool onTouchEvent(AInputEvent* event);
 
@@ -45,6 +45,8 @@ protected:
   virtual void OnSingleLongPress(float x, float y);
   virtual void OnZoomPinch(float centerX, float centerY, float zoomFactor);
   virtual void OnRotate(float centerX, float centerY, float angle);
+
+  virtual void setDPI(uint32_t dpi);
 
 private:
   void XBMC_Touch(uint8_t type, uint8_t button, uint16_t x, uint16_t y);

--- a/xbmc/android/activity/AndroidTouch.h
+++ b/xbmc/android/activity/AndroidTouch.h
@@ -27,7 +27,7 @@ class CAndroidTouch : protected ITouchHandler
 {
 
 public:
-  CAndroidTouch();
+  CAndroidTouch(uint32_t dpi = 0);
   virtual ~CAndroidTouch();
   bool onTouchEvent(AInputEvent* event);
 
@@ -49,4 +49,6 @@ protected:
 private:
   void XBMC_Touch(uint8_t type, uint8_t button, uint16_t x, uint16_t y);
   void XBMC_TouchGesture(int32_t action, float posX, float posY, float offsetX, float offsetY);
+
+  uint32_t m_dpi;
 };

--- a/xbmc/android/activity/EventLoop.cpp
+++ b/xbmc/android/activity/EventLoop.cpp
@@ -96,6 +96,9 @@ void CEventLoop::processActivity(int32_t command)
     case APP_CMD_INIT_WINDOW:
       // The window is being shown, get it ready.
       m_activityHandler->onCreateWindow(m_application->window);
+
+      // set the proper DPI value
+      m_inputHandler->setDPI(CXBMCApp::GetDPI());
       break;
 
     case APP_CMD_WINDOW_RESIZED:

--- a/xbmc/android/activity/IInputHandler.h
+++ b/xbmc/android/activity/IInputHandler.h
@@ -24,4 +24,7 @@
 #include "AndroidMouse.h"
 
 class IInputHandler : public CAndroidTouch, public CAndroidKey, public CAndroidMouse
-{};
+{
+public:
+  IInputHandler(uint32_t dpi) : CAndroidTouch(dpi), CAndroidKey(), CAndroidMouse() {}
+};

--- a/xbmc/android/activity/IInputHandler.h
+++ b/xbmc/android/activity/IInputHandler.h
@@ -26,5 +26,7 @@
 class IInputHandler : public CAndroidTouch, public CAndroidKey, public CAndroidMouse
 {
 public:
-  IInputHandler(uint32_t dpi) : CAndroidTouch(dpi), CAndroidKey(), CAndroidMouse() {}
+  IInputHandler() : CAndroidTouch(), CAndroidKey(), CAndroidMouse() {}
+
+  virtual void setDPI(uint32_t dpi) { CAndroidTouch::setDPI(dpi); }
 };

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include <android/native_window.h>
+#include <android/configuration.h>
 #include <jni.h>
 
 #include "XBMCApp.h"
@@ -445,6 +446,21 @@ int CXBMCApp::android_printf(const char *format, ...)
   int result = __android_log_vprint(ANDROID_LOG_VERBOSE, "XBMC", format, args);
   va_end(args);
   return result;
+}
+
+int CXBMCApp::GetDPI()
+{
+  if (m_activity == NULL || m_activity->assetManager == NULL)
+    return 0;
+
+  // grab DPI from the current configuration - this is approximate
+  // but should be close enough for what we need
+  AConfiguration *config = AConfiguration_new();
+  AConfiguration_fromAssetManager(config, m_activity->assetManager);
+  int dpi = AConfiguration_getDensity(config);
+  AConfiguration_delete(config);
+
+  return dpi;
 }
 
 bool CXBMCApp::ListApplications(vector<androidPackage> *applications)

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -96,6 +96,7 @@ public:
   static bool GetExternalStorage(std::string &path, const std::string &type = "");
   static bool GetStorageUsage(const std::string &path, std::string &usage);
 
+  static int GetDPI();
 protected:
   // limit who can access AttachCurrentThread/DetachCurrentThread
   friend class CAESinkAUDIOTRACK;

--- a/xbmc/android/activity/android_main.cpp
+++ b/xbmc/android/activity/android_main.cpp
@@ -166,9 +166,11 @@ extern void android_main(struct android_app* state)
   setup_env(state);
   CEventLoop eventLoop(state);
   CXBMCApp xbmcApp(state->activity);
-  IInputHandler inputHandler;
   if (xbmcApp.isValid())
+  {
+    IInputHandler inputHandler(xbmcApp.GetDPI());
     eventLoop.run(xbmcApp, inputHandler);
+  }
   else
     CXBMCApp::android_printf("android_main: setup failed");
 

--- a/xbmc/android/activity/android_main.cpp
+++ b/xbmc/android/activity/android_main.cpp
@@ -168,7 +168,7 @@ extern void android_main(struct android_app* state)
   CXBMCApp xbmcApp(state->activity);
   if (xbmcApp.isValid())
   {
-    IInputHandler inputHandler(xbmcApp.GetDPI());
+    IInputHandler inputHandler;
     eventLoop.run(xbmcApp, inputHandler);
   }
   else


### PR DESCRIPTION
This replaces #1304 from jmarshall as he asked me to make the necessary adjustments (see df47b87) to only set the DPI value after having received a valid window object.
