### PR TITLE
Make CFileItem find the mimetime for a PVR Channel

### DIFF
--- a/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj
+++ b/lib/addons/library.xbmc.addon/project/VS2010Express/libXBMC_addon.vcxproj
@@ -59,6 +59,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\..\..\..\addons\library.xbmc.addon\$(ProjectName).dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/lib/addons/library.xbmc.gui/project/VS2010Express/libXBMC_gui.vcxproj
+++ b/lib/addons/library.xbmc.gui/project/VS2010Express/libXBMC_gui.vcxproj
@@ -59,6 +59,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\..\..\..\addons\library.xbmc.gui\$(ProjectName).dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/lib/addons/library.xbmc.pvr/project/VS2010Express/libXBMC_pvr.vcxproj
+++ b/lib/addons/library.xbmc.pvr/project/VS2010Express/libXBMC_pvr.vcxproj
@@ -59,6 +59,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\..\..\..\addons\library.xbmc.pvr\$(ProjectName).dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1377,6 +1377,8 @@ const CStdString& CFileItem::GetMimeType(bool lookup /*= true*/) const
 
     if( m_bIsFolder )
       m_ref = "x-directory/normal";
+    else if( m_pvrChannelInfoTag )
+      m_ref = m_pvrChannelInfoTag->InputFormat().Trim();
     else if( m_strPath.Left(8).Equals("shout://")
           || m_strPath.Left(7).Equals("http://")
           || m_strPath.Left(8).Equals("https://"))


### PR DESCRIPTION
Just a small check missing in FileItem.cpp CFileItem::GetMimeType.
I also fixed/changed the three libXBMC projects, they did not build debug infos when in debug mode, no idea why the diff is that big, i just changed a single setting in each project.
