### PR TITLE
[Confluence] fix wrong description for services button

### DIFF
--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -159,7 +159,7 @@
 					</item>
 					<item id="8">
 						<label>14036</label>
-						<label2>31409</label2>
+						<label2>31410</label2>
 						<onclick>ActivateWindow(ServiceSettings)</onclick>
 						<icon>-</icon>
 					</item>


### PR DESCRIPTION
the 'Services' button on the Settings screen displays the description for 'Live TV' settings.
this commit fixes that issue.
