### PR TITLE
[ASS] - fixed display of time overlapping ass subs

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
@@ -230,8 +230,13 @@ void CDVDPlayerSubtitle::Process(double pts)
       return;
 
     CDVDOverlay* pOverlay = m_pSubtitleFileParser->Parse(pts);
-    if (pOverlay)
-      m_pOverlayContainer->Add(pOverlay);
+    // add all overlays which fit the pts
+    while(pOverlay)
+    {
+      if (pOverlay)
+        m_pOverlayContainer->Add(pOverlay);
+      pOverlay = m_pSubtitleFileParser->Parse(pts);
+    }
 
     m_lastPts = pts;
   }


### PR DESCRIPTION
This fixes the display of multiple ASS subtitle texts which are overlapping in time.

Example subfile here:

http://pastebin.com/qWSTbvJ8

This is how it looks now (b0rked):

https://www.youtube.com/watch?v=kUiFHHhYO6c

And this is how it looks with this fix:

https://www.youtube.com/watch?v=hXDJhNOUlOQ

Not quiet sure if this fix is correct though. @elupus one more for the queue ;)

The issue was reported here:

http://forum.xbmc.org/showthread.php?tid=141266&pid=1199684#pid1199684
