### PR TITLE
Log database version to logfile

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -547,6 +547,8 @@ bool CDatabase::UpdateVersion(const CStdString &dbName)
     CLog::Log(LOGERROR, "Can't open the database %s as it is a NEWER version than what we were expecting?", dbName.c_str());
     return false;
   }
+  else 
+    CLog::Log(LOGNOTICE, "Running database version %s", dbName.c_str());
   return true;
 }
 


### PR DESCRIPTION
As the database version is revamped, it can be tricky to keep different xbmc builds synchronized via a MySQL database since different versions of the xbmc database do not talk to each other. By logging this version number to the log file (it currently is not), it is easily accessible to the average user w/o needing to execute sql queries
