### PR TITLE
Guiepggrid improvements

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -723,12 +723,13 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
 
       /* Create Ruler items */
       CDateTime ruler; ruler.SetFromUTCDateTime(m_gridStart);
+      CDateTime rulerEnd; rulerEnd.SetFromUTCDateTime(m_gridEnd);
       CDateTimeSpan unit(0, 0, m_rulerUnit * MINSPERBLOCK, 0);
       CGUIListItemPtr rulerItem(new CFileItem(ruler.GetAsLocalizedDate(true, true)));
       rulerItem->SetProperty("DateLabel", true);
       m_rulerItems.push_back(rulerItem);
 
-      for (; ruler < m_gridEnd; ruler += unit)
+      for (; ruler < rulerEnd; ruler += unit)
       {
         CGUIListItemPtr rulerItem(new CFileItem(ruler.GetAsLocalizedTime("", false)));
         rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true, true));

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -879,7 +879,7 @@ void CGUIEPGGridContainer::UpdateItems()
   m_channels = (int)m_epgItemsPtr.size();
   m_item = GetItem(m_channelCursor);
   if (m_item)
-    m_blockCursor = GetBlock(m_item->item, m_channelCursor);
+    SetBlock(GetBlock(m_item->item, m_channelCursor));
 
   SetInvalid();
 }
@@ -979,7 +979,7 @@ bool CGUIEPGGridContainer::MoveProgrammes(bool direction)
     {
       // this is not first item on page
       m_item = GetPrevItem(m_channelCursor);
-      m_blockCursor = GetBlock(m_item->item, m_channelCursor);
+      SetBlock(GetBlock(m_item->item, m_channelCursor));
     }
     else if (m_blockCursor <= 0 && m_blockOffset)
     {
@@ -1028,7 +1028,7 @@ bool CGUIEPGGridContainer::MoveProgrammes(bool direction)
     {
       // this is not last item on page
       m_item = GetNextItem(m_channelCursor);
-      m_blockCursor = GetBlock(m_item->item, m_channelCursor);
+      SetBlock(GetBlock(m_item->item, m_channelCursor));
     }
     else if ((m_blockOffset != m_blocks - m_blocksPerPage) && m_blocks > m_blocksPerPage)
     {
@@ -1175,7 +1175,7 @@ void CGUIEPGGridContainer::SetChannel(int channel)
     m_item          = GetItem(channel);
     if (m_item)
     {
-      m_blockCursor   = GetBlock(m_item->item, channel);
+      SetBlock(GetBlock(m_item->item, channel));
       m_channelCursor = channel;
     }
     return;
@@ -1186,13 +1186,18 @@ void CGUIEPGGridContainer::SetChannel(int channel)
   if (m_item)
   {
     m_channelCursor = channel;
-    m_blockCursor   = GetBlock(m_item->item, m_channelCursor);
+    SetBlock(GetBlock(m_item->item, m_channelCursor));
   }
 }
 
 void CGUIEPGGridContainer::SetBlock(int block)
 {
-  m_blockCursor = block;
+  if (block < 0)
+    m_blockCursor = 0;
+  else if (block > m_blocksPerPage)
+    m_blockCursor = m_blocksPerPage;
+  else
+    m_blockCursor = block;
   m_item        = GetItem(m_channelCursor);
 }
 


### PR DESCRIPTION
I know (and all of you probably to) that the current GUIEPGGridContainer implementation is far from ideal. But until someone will do a full rework we should try to fix some main issues.

Here are two commits:
1.) The first one fixes the problem with ruler items not being generated at the end if the selected timezone isn't UTC
2.) The second one replaces direct m_blockCursor changes with the default setter. And I also edited the setter to prevent the m_blockCursor being set out of screen bounds (between 0 and m_blocksPerPage). This prevents the cursor from getting out of the screen when moving up/down in the timeline and crossing a long show which exceeds the screen bounds.
