### PR TITLE
[PVR] Change channelswitching through OSD to be consistent with channel

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -302,9 +302,9 @@ bool CPVRClients::SwitchChannel(const CPVRChannel &channel)
       // stream URL should always be opened as a new file
       !channel.StreamURL().IsEmpty() || !currentChannel->StreamURL().IsEmpty())
   {
-    CloseStream();
     if (channel.StreamURL().IsEmpty())
     {
+      CloseStream();
       bSwitchSuccessful = OpenStream(channel, true);
     }
     else


### PR DESCRIPTION
switching in other parts of the code

Previously, the channel switching from the OSD dialog didn't check if  there was a URL linked to the channel. If this is the case, the switching uses the PlayFile call. This is now consistent with the code in GUIWindowPVRCommon.
