### PR TITLE
[PVR] Change keyboard.xml to PVR related MCE key combinations

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -135,16 +135,16 @@
       <f10>VolumeUp</f10>                 <!-- MCE Vol up -->
       <f9>VolumeDown</f9>                 <!-- MCE Vol down -->
       <f8>Mute</f8>                       <!-- MCE mute -->
-      <g mod="ctrl">OSD</g>               <!-- MCE Guide -->
+      <g mod="ctrl">ActivateWindowAndFocus(MyPVR, 31,0, 10,0)</g>  <!-- MCE Guide -->
       <m mod="ctrl">ActivateWindow(music)</m>    <!-- MCE My music -->
       <i mod="ctrl">ActivateWindow(pictures)</i> <!-- MCE My pictures -->
       <e mod="ctrl">ActivateWindow(video)</e>    <!-- MCE videos -->
-      <m mod="ctrl,shift">PlayerControl(ShowVideoMenu)</m> <!-- MCE DVD menu -->
-      <!-- MCE keypresses without an obvious use in XBMC -->
-      <o mod="ctrl">Notification(MCEKeypress, Recorded TV, 3)</o>
-      <t mod="ctrl">Notification(MCEKeypress, Live TV, 3)</t>
-      <t mod="ctrl,shift">Notification(MCEKeypress, My TV, 3)</t>
-      <a mod="ctrl">Notification(MCEKeypress, Radio, 3)</a>
+      <m mod="ctrl,shift">PlayerControl(ShowVideoMenu)</m>         <!-- MCE DVD menu -->
+      <o mod="ctrl">ActivateWindowAndFocus(MyPVR, 34,0, 13,0)</o>  <!-- MCE Recorded TV -->
+      <t mod="ctrl">ActivateWindowAndFocus(MyPVR, 32,0, 11,0)</t>  <!-- MCE Live TV  -->
+      <t mod="ctrl,shift">ActivateWindow(MyPVR)</t>                <!-- MCE My TV -->
+      <a mod="ctrl">ActivateWindowAndFocus(MyPVR, 33,0, 12,0)</a>  <!-- MCE My Radio -->
+      <!-- MCE keypresses without an obvious use in XBMC --->
       <u mod="ctrl">Notification(MCEKeypress, DVD subtitle, 3)</u>
       <a mod="ctrl,shift">Notification(MCEKeypress, DVD audio, 3)</a>
     </keyboard>


### PR DESCRIPTION
The default keyboard.xml only contained notifications for several MCE key combinations. Since the integration of PVR, some of these key combinations can be mapped to relevant PVR functions. 

These mappings are similar to the mappings in remote.xml, apart from the <ctrl-g>, which opens the EPG window in MCE, instead of the OSD window. 
