### PR TITLE
[PVR] Add timeshift support (requires backend support)

### DIFF
--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -449,14 +449,14 @@
 			<onleft>9000</onleft>
 			<onright>9000</onright>
 			<onup>20</onup>
-			<ondown>608</ondown>
+			<ondown>609</ondown>
 			<visible>false</visible>
 		</control>
 		<control type="group">
 			<description>Controls for currently playing media</description>
 			<posx>545r</posx>
 			<posy>370</posy>
-			<animation effect="slide" start="0,0" end="365,0" time="300" condition="!Player.HasMedia">conditional</animation>
+			<animation effect="slide" start="0,0" end="395,0" time="300" condition="!Player.HasMedia">conditional</animation>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 				<effect type="fade" start="0" end="100" time="300" />
@@ -473,9 +473,9 @@
 				<height>35</height>
 				<colordiffuse>CCFFFFFF</colordiffuse>
 				<texture flipy="true" border="0,5,0,0" flipx="true">HomeSubEnd.png</texture>
-				<animation effect="slide" start="0,0" end="145,0" time="0" condition="!System.HasAddon(script.globalsearch)">Conditional</animation>
+				<animation effect="slide" start="0,0" end="115,0" time="0" condition="!System.HasAddon(script.globalsearch)">Conditional</animation>
 			</control>
-			<control type="radiobutton" id="608">
+			<control type="radiobutton" id="609">
 				<colordiffuse>CCFFFFFF</colordiffuse>
 				<description>Global Search</description>
 				<posx>35</posx>
@@ -496,14 +496,14 @@
 				<onclick>RunScript(script.globalsearch)</onclick>
 				<textureradiofocus>icon_search.png</textureradiofocus>
 				<textureradionofocus>icon_search.png</textureradionofocus>
-				<onleft>607</onleft>
+				<onleft>608</onleft>
 				<onright>601</onright>
 				<onup>9003</onup>
 				<ondown>9000</ondown>
 				<visible>System.HasAddon(script.globalsearch)</visible>
 			</control>
 			<control type="group" id="600">
-				<posx>180</posx>
+				<posx>150</posx>
 				<onup>9003</onup>
 				<ondown>9000</ondown>
 				<defaultcontrol>-</defaultcontrol>
@@ -512,7 +512,7 @@
 					<description>Background image</description>
 					<posx>0</posx>
 					<posy>0</posy>
-					<width>205</width>
+					<width>235</width>
 					<height>35</height>
 					<texture flipy="true" border="0,5,0,0">HomeSubNF.png</texture>
 					<colordiffuse>CCFFFFFF</colordiffuse>
@@ -527,7 +527,7 @@
 						<label>-</label>
 						<texturefocus>OSDPrevTrackFO.png</texturefocus>
 						<texturenofocus>OSDPrevTrackNF.png</texturenofocus>
-						<onleft>608</onleft>
+						<onleft>609</onleft>
 						<onright>602</onright>
 						<onup>9003</onup>
 						<ondown>9000</ondown>
@@ -602,10 +602,14 @@
 						<texturefocus>OSDNextTrackFO.png</texturefocus>
 						<texturenofocus>OSDNextTrackNF.png</texturenofocus>
 						<onleft>605</onleft>
-						<onright>607</onright>
+						<onright>608</onright>
 						<onup>9003</onup>
 						<ondown>9000</ondown>
 						<onclick>XBMC.PlayerControl(Next)</onclick>
+					</control>
+					<control type="button" id="607">
+						<description>Fake Button to fix Player Controls Navigation</description>
+						<visible>false</visible>
 					</control>
 				</control>
 				<control type="group" id="600">
@@ -618,7 +622,7 @@
 						<label>-</label>
 						<texturefocus>OSDChannelUPFO.png</texturefocus>
 						<texturenofocus>OSDChannelUPNF.png</texturenofocus>
-						<onleft>608</onleft>
+						<onleft>609</onleft>
 						<onright>602</onright>
 						<onup>9003</onup>
 						<ondown>9000</ondown>
@@ -638,15 +642,50 @@
 						<ondown>9000</ondown>
 						<onclick>XBMC.PlayerControl(Next)</onclick>
 					</control>
-					<control type="button" id="603">
+					<control type="togglebutton" id="603">
 						<posx>70</posx>
+						<posy>2</posy>
+						<width>30</width>
+						<height>30</height>
+						<label>-</label>
+						<texturefocus>OSDPauseFO.png</texturefocus>
+						<texturenofocus>OSDPauseNF.png</texturenofocus>
+						<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
+						<alttexturefocus>OSDPlayFO.png</alttexturefocus>
+						<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
+						<onleft>602</onleft>
+						<onright>604</onright>
+						<onup>9003</onup>
+						<ondown>9000</ondown>
+						<onclick>XBMC.PlayerControl(Play)</onclick>
+						<enable>Player.PauseEnabled</enable>
+						<animation effect="fade" start="100" end="30" time="100" condition="!Player.PauseEnabled">Conditional</animation>
+					</control>
+					<control type="button" id="604">
+						<posx>100</posx>
+						<posy>2</posy>
+						<width>30</width>
+						<height>30</height>
+						<label>-</label>
+						<texturefocus>OSDRewindFO.png</texturefocus>
+						<texturenofocus>OSDRewindNF.png</texturenofocus>
+						<onleft>603</onleft>
+						<onright>605</onright>
+						<onup>9003</onup>
+						<ondown>9000</ondown>
+						<onclick>XBMC.PlayerControl(Rewind)</onclick>
+						<enable>Player.SeekEnabled</enable>
+						<animation effect="fade" start="100" end="30" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+					</control>
+					<control type="button" id="605">
+						<posx>130</posx>
 						<posy>2</posy>
 						<width>30</width>
 						<height>30</height>
 						<label>-</label>
 						<texturefocus>OSDStopFO.png</texturefocus>
 						<texturenofocus>OSDStopNF.png</texturenofocus>
-						<onleft>602</onleft>
+						<onleft>604</onleft>
 						<onright>606</onright>
 						<onup>9003</onup>
 						<ondown>9000</ondown>
@@ -654,22 +693,38 @@
 						<onclick>XBMC.PlayerControl(Stop)</onclick>
 					</control>
 					<control type="button" id="606">
-						<posx>130</posx>
+						<posx>160</posx>
+						<posy>2</posy>
+						<width>30</width>
+						<height>30</height>
+						<label>-</label>
+						<texturefocus>OSDForwardFO.png</texturefocus>
+						<texturenofocus>OSDForwardNF.png</texturenofocus>
+						<onleft>605</onleft>
+						<onright>607</onright>
+						<onup>9003</onup>
+						<ondown>9000</ondown>
+						<onclick>XBMC.PlayerControl(Forward)</onclick>
+						<enable>Player.SeekEnabled</enable>
+						<animation effect="fade" start="100" end="30" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+					</control>
+					<control type="button" id="607">
+						<posx>190</posx>
 						<posy>2</posy>
 						<width>30</width>
 						<height>30</height>
 						<label>-</label>
 						<texturefocus>OSDRecordOffFO.png</texturefocus>
 						<texturenofocus>OSDRecordOffNF.png</texturenofocus>
-						<onleft>603</onleft>
-						<onright>607</onright>
+						<onleft>606</onleft>
+						<onright>608</onright>
 						<onup>9003</onup>
 						<ondown>9000</ondown>
 						<onclick>XBMC.PlayerControl(record)</onclick>
 					</control>
 				</control>
 			</control>
-			<control type="radiobutton" id="607">
+			<control type="radiobutton" id="608">
 				<colordiffuse>CCFFFFFF</colordiffuse>
 				<description>Go to fullscreen Playback</description>
 				<posx>385</posx>
@@ -690,8 +745,8 @@
 				<onclick>fullscreen</onclick>
 				<textureradiofocus>GoFullscreen.png</textureradiofocus>
 				<textureradionofocus>GoFullscreen.png</textureradionofocus>
-				<onleft>606</onleft>
-				<onright>608</onright>
+				<onleft>607</onleft>
+				<onright>609</onright>
 				<onup>9003</onup>
 				<ondown>9000</ondown>
 				<enable>Player.HasMedia</enable>
@@ -790,7 +845,7 @@
 				<height>60</height>
 				<onleft>9000</onleft>
 				<onright>9000</onright>
-				<onup condition="System.HasAddon(script.globalsearch)">608</onup>
+				<onup condition="System.HasAddon(script.globalsearch)">609</onup>
 				<onup condition="!System.HasAddon(script.globalsearch)">603</onup>
 				<ondown>9001</ondown>
 				<pagecontrol>-</pagecontrol>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -183,8 +183,25 @@
 				<ondown>1000</ondown>
 				<onclick>PlayerControl(Next)</onclick>
 			</control>
-			<control type="togglebutton" id="602">
+			<control type="button" id="602">
 				<posx>110</posx>
+				<posy>0</posy>
+				<width>55</width>
+				<height>55</height>
+				<label>31354</label>
+				<font>-</font>
+				<texturefocus>OSDRewindFO.png</texturefocus>
+				<texturenofocus>OSDRewindNF.png</texturenofocus>
+				<onleft>601</onleft>
+				<onright>603</onright>
+				<onup>1000</onup>
+				<ondown>1000</ondown>
+				<onclick>PlayerControl(Rewind)</onclick>
+				<enable>Player.SeekEnabled</enable>
+				<animation effect="fade" start="100" end="50" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+			</control>
+			<control type="togglebutton" id="603">
+				<posx>165</posx>
 				<posy>0</posy>
 				<width>55</width>
 				<height>55</height>
@@ -196,15 +213,16 @@
 				<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
 				<alttexturefocus>OSDPlayFO.png</alttexturefocus>
 				<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
-				<onleft>601</onleft>
-				<onright>603</onright>
+				<onleft>602</onleft>
+				<onright>604</onright>
 				<onup>1000</onup>
 				<ondown>1000</ondown>
 				<onclick>PlayerControl(Play)</onclick>
-				<visible>False</visible>
+				<enable>Player.PauseEnabled</enable>
+				<animation effect="fade" start="100" end="50" time="100" condition="!Player.PauseEnabled">Conditional</animation>
 			</control>
-			<control type="button" id="603">
-				<posx>165</posx>
+			<control type="button" id="604">
+				<posx>220</posx>
 				<posy>0</posy>
 				<width>55</width>
 				<height>55</height>
@@ -213,14 +231,31 @@
 				<font>-</font>
 				<texturefocus>OSDStopFO.png</texturefocus>
 				<texturenofocus>OSDStopNF.png</texturenofocus>
-				<onleft>602</onleft>
-				<onright>604</onright>
+				<onleft>603</onleft>
+				<onright>605</onright>
 				<onup>1000</onup>
 				<ondown>1000</ondown>
 				<onclick>PlayerControl(Stop)</onclick>
 			</control>
-			<control type="button" id="604">
-				<posx>220</posx>
+			<control type="button" id="605">
+				<posx>275</posx>
+				<posy>0</posy>
+				<width>55</width>
+				<height>55</height>
+				<label>31353</label>
+				<font>-</font>
+				<texturefocus>OSDForwardFO.png</texturefocus>
+				<texturenofocus>OSDForwardNF.png</texturenofocus>
+				<onleft>604</onleft>
+				<onright>606</onright>
+				<onup>1000</onup>
+				<ondown>1000</ondown>
+				<onclick>PlayerControl(Forward)</onclick>
+				<enable>Player.SeekEnabled</enable>
+				<animation effect="fade" start="100" end="50" time="100" condition="!Player.SeekEnabled">Conditional</animation>
+			</control>
+			<control type="button" id="606">
+				<posx>330</posx>
 				<posy>0</posy>
 				<width>55</width>
 				<height>55</height>
@@ -228,15 +263,15 @@
 				<font>-</font>
 				<texturefocus>OSDChannelListFO.png</texturefocus>
 				<texturenofocus>OSDChannelListNF.png</texturenofocus>
-				<onleft>603</onleft>
-				<onright>605</onright>
+				<onleft>605</onleft>
+				<onright>607</onright>
 				<onup>1000</onup>
 				<ondown>1000</ondown>
 				<onclick>ActivateWindow(PVROSDChannels)</onclick>
 				<onclick>Dialog.Close(VideoOSD)</onclick>
 			</control>
-			<control type="button" id="605">
-				<posx>275</posx>
+			<control type="button" id="607">
+				<posx>385</posx>
 				<posy>0</posy>
 				<width>55</width>
 				<height>55</height>
@@ -244,17 +279,17 @@
 				<font>-</font>
 				<texturefocus>OSDepgFO.png</texturefocus>
 				<texturenofocus>OSDepgNF.png</texturenofocus>
-				<onleft>604</onleft>
+				<onleft>606</onleft>
 				<onright>701</onright>
 				<onup>1000</onup>
 				<ondown>1000</ondown>
 				<onclick>ActivateWindow(PVROSDGuide)</onclick>
 				<onclick>Dialog.Close(VideoOSD)</onclick>
 			</control>
-			<control type="label" id="606">
-				<posx>330</posx>
+			<control type="label" id="608">
+				<posx>440</posx>
 				<posy>0</posy>
-				<width>385</width>
+				<width>275</width>
 				<height>55</height>
 				<label>$INFO[VideoPlayer.NextTitle,$LOCALIZE[209]: ]</label>
 				<align>center</align>
@@ -374,7 +409,7 @@
 				<font>-</font>
 				<texturefocus>OSDTeleTextFO.png</texturefocus>
 				<texturenofocus>OSDTeleTextNF.png</texturenofocus>
-				<onleft>605</onleft>
+				<onleft>607</onleft>
 				<onright>702</onright>
 				<onup>1000</onup>
 				<ondown>1000</ondown>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -588,7 +588,7 @@
 		</control>
 		<control type="group" id="9006">
 			<width>250</width>
-			<height>45</height>
+			<height>90</height>
 			<visible>VideoPlayer.Content(LiveTV)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="button" id="600">
@@ -597,29 +597,38 @@
 				<width>39</width>
 				<height>39</height>
 				<label>-</label>
-				<texturefocus>OSDChannelUPFO.png</texturefocus>
-				<texturenofocus>OSDChannelUPNF.png</texturenofocus>
+				<texturefocus>OSDRewindFO.png</texturefocus>
+				<texturenofocus>OSDRewindNF.png</texturenofocus>
 				<onleft>50</onleft>
 				<onright>601</onright>
 				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>XBMC.PlayerControl(Previous)</onclick>
+				<ondown>605</ondown>
+				<onback>50</onback>
+				<onclick>XBMC.PlayerControl(Rewind)</onclick>
+				<enable>Player.SeekEnabled</enable>
+				<animation effect="fade" start="100" end="30" time="100" condition="!Player.SeekEnabled">Conditional</animation>
 			</control>
-			<control type="button" id="601">
+			<control type="togglebutton" id="601">
 				<posx>60</posx>
 				<posy>2</posy>
 				<width>39</width>
 				<height>39</height>
 				<label>-</label>
-				<texturefocus>OSDChannelDownFO.png</texturefocus>
-				<texturenofocus>OSDChannelDownNF.png</texturenofocus>
+				<texturefocus>OSDPauseFO.png</texturefocus>
+				<texturenofocus>OSDPauseNF.png</texturenofocus>
+				<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
+				<alttexturefocus>OSDPlayFO.png</alttexturefocus>
+				<alttexturenofocus>OSDPlayNF.png</alttexturenofocus>
 				<onleft>600</onleft>
-				<onright>603</onright>
+				<onright>602</onright>
 				<onup>610</onup>
-				<ondown>611</ondown>
-				<onclick>XBMC.PlayerControl(Next)</onclick>
-			</control>
-			<control type="button" id="603">
+				<ondown>606</ondown>
+				<onback>50</onback>
+				<onclick>XBMC.PlayerControl(Play)</onclick>
+				<enable>Player.PauseEnabled</enable>
+				<animation effect="fade" start="100" end="30" time="100" condition="!Player.PauseEnabled">Conditional</animation>
+			</control>			
+			<control type="button" id="602">
 				<posx>100</posx>
 				<posy>2</posy>
 				<width>39</width>
@@ -628,11 +637,29 @@
 				<texturefocus>OSDStopFO.png</texturefocus>
 				<texturenofocus>OSDStopNF.png</texturenofocus>
 				<onleft>601</onleft>
-				<onright>604</onright>
+				<onright>603</onright>
 				<onup>610</onup>
-				<ondown>611</ondown>
+				<ondown>606</ondown>
+				<onback>50</onback>
 				<onclick>down</onclick>
 				<onclick>XBMC.PlayerControl(Stop)</onclick>
+			</control>
+			<control type="button" id="603">
+				<posx>140</posx>
+				<posy>2</posy>
+				<width>39</width>
+				<height>39</height>
+				<label>-</label>
+				<texturefocus>OSDForwardFO.png</texturefocus>
+				<texturenofocus>OSDForwardNF.png</texturenofocus>
+				<onleft>602</onleft>
+				<onright>604</onright>
+				<onup>610</onup>
+				<ondown>606</ondown>
+				<onback>50</onback>
+				<onclick>XBMC.PlayerControl(Forward)</onclick>
+				<enable>Player.SeekEnabled</enable>
+				<animation effect="fade" start="100" end="30" time="100" condition="!Player.SeekEnabled">Conditional</animation>
 			</control>
 			<control type="button" id="604">
 				<posx>180</posx>
@@ -643,12 +670,43 @@
 				<texturefocus>OSDRecordOffFO.png</texturefocus>
 				<texturenofocus>OSDRecordOffNF.png</texturenofocus>
 				<onleft>603</onleft>
-				<onright>50</onright>
+				<onright>605</onright>
 				<onup>610</onup>
-				<ondown>611</ondown>
+				<ondown>606</ondown>
+				<onback>50</onback>
 				<onclick>XBMC.PlayerControl(record)</onclick>
 				<enable>Player.CanRecord</enable>
 				<animation effect="fade" start="100" end="30" time="100" condition="!Player.CanRecord">Conditional</animation>
+			</control>
+			<control type="button" id="605">
+				<posx>20</posx>
+				<posy>42</posy>
+				<width>39</width>
+				<height>39</height>
+				<label>-</label>
+				<texturefocus>OSDChannelUPFO.png</texturefocus>
+				<texturenofocus>OSDChannelUPNF.png</texturenofocus>
+				<onleft>604</onleft>
+				<onright>606</onright>
+				<onup>600</onup>
+				<ondown>611</ondown>
+				<onback>50</onback>
+				<onclick>XBMC.PlayerControl(Previous)</onclick>
+			</control>
+			<control type="button" id="606">
+				<posx>60</posx>
+				<posy>42</posy>
+				<width>39</width>
+				<height>39</height>
+				<label>-</label>
+				<texturefocus>OSDChannelDownFO.png</texturefocus>
+				<texturenofocus>OSDChannelDownNF.png</texturenofocus>
+				<onleft>605</onleft>
+				<onright>50</onright>
+				<onup>601</onup>
+				<ondown>611</ondown>
+				<onback>50</onback>
+				<onclick>XBMC.PlayerControl(Next)</onclick>
 			</control>
 		</control>
 		<control type="group" id="9005">

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2762,7 +2762,7 @@ bool CApplication::OnAction(const CAction &action)
     return true;
   }
 
-  if (IsPlaying() && !CurrentFileItem().IsLiveTV())
+  if (IsPlaying())
   {
     // pause : pauses current audio song
     if (action.GetID() == ACTION_PAUSE && m_iPlaySpeed == 1)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -195,7 +195,9 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "chaptername",      PLAYER_CHAPTERNAME },
                                   { "starrating",       PLAYER_STAR_RATING },
                                   { "folderpath",       PLAYER_PATH },
-                                  { "filenameandpath",  PLAYER_FILEPATH }};
+                                  { "filenameandpath",  PLAYER_FILEPATH },
+                                  { "pauseenabled",     PLAYER_CAN_PAUSE },
+                                  { "seekenabled",      PLAYER_CAN_SEEK }};
 
 const infomap player_param[] =   {{ "property",         PLAYER_ITEM_PROPERTY }};
 
@@ -2291,6 +2293,12 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       break;
     case PLAYER_CAN_RECORD:
       bReturn = g_application.m_pPlayer->CanRecord();
+      break;
+    case PLAYER_CAN_PAUSE:
+      bReturn = g_application.m_pPlayer->CanPause();
+      break;
+    case PLAYER_CAN_SEEK:
+      bReturn = g_application.m_pPlayer->CanSeek();
       break;
     case PLAYER_RECORDING:
       bReturn = g_application.m_pPlayer->IsRecording();

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -104,6 +104,8 @@ namespace INFO
 #define PLAYER_SEEKOFFSET            47
 #define PLAYER_PROGRESS_CACHE        48
 #define PLAYER_ITEM_PROPERTY         49
+#define PLAYER_CAN_PAUSE             50
+#define PLAYER_CAN_SEEK              51
 
 #define WEATHER_CONDITIONS          100
 #define WEATHER_TEMPERATURE         101

--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -513,6 +513,25 @@ extern "C"
   unsigned int GetChannelSwitchDelay(void);
 
   /*!
+   * Check if the backend support pausing the currently playing stream
+   * This will enable/disable the pause button in XBMC based on the return value
+   * @return false if the PVR addon/backend does not support pausing, true if possible
+   */
+  bool CanPauseStream();
+
+  /*!
+   * Check if the backend supports seeking for the currently playing stream
+   * This will enable/disable the rewind/forward buttons in XBMC based on the return value
+   * @return false if the PVR addon/backend does not support seeking, true if possible
+   */
+  bool CanSeekStream();
+
+  /*!
+   * @brief Notify the pvr addon that XBMC (un)paused the currently playing stream
+   */
+  void PauseStream(bool bPaused);
+
+  /*!
    * Called by XBMC to assign the function pointers of this add-on to pClient.
    * @param pClient The struct to assign the function pointers to.
    */
@@ -568,6 +587,9 @@ extern "C"
     pClient->SignalStatus                   = SignalStatus;
     pClient->GetLiveStreamURL               = GetLiveStreamURL;
     pClient->GetChannelSwitchDelay          = GetChannelSwitchDelay;
+    pClient->CanPauseStream                 = CanPauseStream;
+    pClient->PauseStream                    = PauseStream;
+    pClient->CanSeekStream                  = CanSeekStream;
 
     pClient->OpenRecordedStream             = OpenRecordedStream;
     pClient->CloseRecordedStream            = CloseRecordedStream;

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -72,10 +72,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "1.4.0"
+#define XBMC_PVR_API_VERSION "1.5.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "1.4.0"
+#define XBMC_PVR_MIN_API_VERSION "1.5.0"
 
 #ifdef __cplusplus
 extern "C" {
@@ -329,6 +329,9 @@ extern "C" {
     void         (__cdecl* DemuxFlush)(void);
     DemuxPacket* (__cdecl* DemuxRead)(void);
     unsigned int (__cdecl* GetChannelSwitchDelay)(void);
+    bool         (__cdecl* CanPauseStream)(void);
+    void         (__cdecl* PauseStream)(bool);
+    bool         (__cdecl* CanSeekStream)(void);
   } PVRClient;
 
 #ifdef __cplusplus

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -84,6 +84,7 @@ public:
   virtual void OnNothingToQueueNotify() {}
   virtual bool CloseFile(){ return true;}
   virtual bool IsPlaying() const { return false;}
+  virtual bool CanPause() { return true; };
   virtual void Pause() = 0;
   virtual bool IsPaused() const = 0;
   virtual bool HasVideo() const = 0;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -71,6 +71,8 @@ public:
     virtual bool CanRecord() = 0;
     virtual bool IsRecording() = 0;
     virtual bool Record(bool bOnOff) = 0;
+    virtual bool CanPause() = 0;
+    virtual bool CanSeek() = 0;
   };
 
   class IDisplayTime

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.h
@@ -53,6 +53,9 @@ public:
   bool            IsRecording()       { return false; }
   bool            Record(bool bOnOff) { return false; }
 
+  bool            CanPause()          { return false; }
+  bool            CanSeek()           { return false; }
+
   int             GetTotalTime();
   int             GetTime();
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -352,6 +352,21 @@ bool CDVDInputStreamPVRManager::Record(bool bOnOff)
   return false;
 }
 
+bool CDVDInputStreamPVRManager::CanPause()
+{
+  return g_PVRClients->CanPauseStream();
+}
+
+bool CDVDInputStreamPVRManager::CanSeek()
+{
+  return g_PVRClients->CanSeekStream();
+}
+
+void CDVDInputStreamPVRManager::Pause(bool bPaused)
+{
+  g_PVRClients->PauseStream(bPaused);
+}
+
 CStdString CDVDInputStreamPVRManager::GetInputFormat()
 {
   if (!m_pOtherStream && g_PVRManager.IsStarted())

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -65,6 +65,9 @@ public:
   bool            CanRecord();
   bool            IsRecording();
   bool            Record(bool bOnOff);
+  bool            CanSeek();
+  bool            CanPause();
+  void            Pause(bool bPaused);
 
   bool            UpdateItem(CFileItem& item);
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamTV.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamTV.h
@@ -60,6 +60,9 @@ public:
   bool            IsRecording();
   bool            Record(bool bOnOff);
 
+  bool            CanPause() { return false; };
+  bool            CanSeek() { return false; };
+
   bool            UpdateItem(CFileItem& item);
 
 protected:

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -195,6 +195,7 @@ public:
   virtual void GetVideoAspectRatio(float& fAR)                  { fAR = m_dvdPlayerVideo.GetAspectRatio(); }
   virtual bool CanRecord();
   virtual bool IsRecording();
+  virtual bool CanPause();
   virtual bool Record(bool bOnOff);
   virtual void SetAVDelay(float fValue = 0.0f);
   virtual float GetAVDelay();
@@ -415,6 +416,8 @@ protected:
       chapter_count = 0;
       canrecord     = false;
       recording     = false;
+      canpause      = false;
+      canseek       = false;
       demux_video   = "";
       demux_audio   = "";
       cache_bytes   = 0;
@@ -438,6 +441,9 @@ protected:
 
     bool canrecord;           // can input stream record
     bool recording;           // are we currently recording
+
+    bool canpause;            // pvr: can pause the current playing item
+    bool canseek;             // pvr: can seek in the current playing item
 
     std::string demux_video;
     std::string demux_audio;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -357,6 +357,11 @@ namespace PVR
     int64_t GetStreamLength(void);
 
     /*!
+     * @brief (Un)Pause a stream
+     */
+    void PauseStream(bool bPaused);
+
+    /*!
      * @return The channel number on the server of the live stream that's currently being read.
      */
     int GetCurrentClientChannel(void);
@@ -381,6 +386,16 @@ namespace PVR
      * @return The requested URL.
      */
     CStdString GetLiveStreamURL(const CPVRChannel &channel);
+
+    /*!
+     * @brief Check whether PVR backend supports pausing the currently playing stream
+     */
+    bool CanPauseStream(void) const;
+
+    /*!
+     * @brief Check whether PVR backend supports seeking for the currently playing stream
+     */
+    bool CanSeekStream(void) const;
 
     //@}
     /** @name PVR recording stream methods */
@@ -558,5 +573,7 @@ namespace PVR
     bool           m_bIsPlayingRecording;
     CPVRRecording  m_playingRecording;
     ADDON::AddonVersion m_apiVersion;
+    bool           m_bCanPauseStream;
+    bool           m_bCanSeekStream;
   };
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -535,6 +535,30 @@ bool CPVRClients::CanRecordInstantly(void)
       currentChannel->CanRecord();
 }
 
+bool CPVRClients::CanPauseStream(void) const
+{
+  PVR_CLIENT client;
+
+  if (GetPlayingClient(client))
+  {
+    return client->CanPauseStream();
+  }
+
+  return false;
+}
+
+bool CPVRClients::CanSeekStream(void) const
+{
+  PVR_CLIENT client;
+
+  if (GetPlayingClient(client))
+  {
+    return client->CanSeekStream();
+  }
+
+  return false;
+}
+
 PVR_ERROR CPVRClients::GetEPGForChannel(const CPVRChannel &channel, CEpg *epg, time_t start, time_t end)
 {
   PVR_ERROR error(PVR_ERROR_UNKNOWN);
@@ -1258,6 +1282,13 @@ int64_t CPVRClients::GetStreamPosition(void)
   if (GetPlayingClient(client))
     return client->GetStreamPosition();
   return -EINVAL;
+}
+
+void CPVRClients::PauseStream(bool bPaused)
+{
+  PVR_CLIENT client;
+  if (GetPlayingClient(client))
+    client->PauseStream(bPaused);
 }
 
 CStdString CPVRClients::GetCurrentInputFormat(void) const

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -212,6 +212,21 @@ namespace PVR
     void CloseStream(void);
 
     /*!
+     * @brief (Un)Pause a PVR stream (only called when timeshifting is supported)
+     */
+    void PauseStream(bool bPaused);
+
+    /*!
+     * @brief Check whether it is possible to pause the currently playing livetv or recording stream
+     */
+    bool CanPauseStream(void) const;
+
+    /*!
+     * @brief Check whether it is possible to seek the currently playing livetv or recording stream
+     */
+    bool CanSeekStream(void) const;
+
+    /*!
      * @brief Get the properties of the current playing stream content.
      * @return A pointer to the properties or NULL if no stream is playing.
      */


### PR DESCRIPTION
This PR extends the PVR API to allow pause, rewind and forward of LiveTV streams if the backend supports it.

A PVR addon can tell XBMC for each individual backend channel whether it supports timeshifting for this channel or not.
XBMC will enable the corresponding buttons if the selected channel can timeshift.

Summary of the changes:
- Confluence skin extended with extra buttons
- PVR API extended with PauseLiveStream() and PauseRecordedStream() functions to tell the PVR addon that XBMC paused playback. This can be used by the pvr addon to pause for example a RTSP stream.
- PVR channel updated with a CanTimeshift property
