### PR TITLE
fix taglib include path, use what pkg-config provides

### DIFF
--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -23,7 +23,7 @@
 #include "filesystem/File.h"
 #include "utils/StdString.h"
 #include "utils/log.h"
-#include <taglib/tiostream.h>
+#include <tiostream.h>
 
 using namespace XFILE;
 using namespace TagLib;

--- a/xbmc/music/tags/TagLibVFSStream.h
+++ b/xbmc/music/tags/TagLibVFSStream.h
@@ -21,7 +21,7 @@
  */
 #include "filesystem/File.h"
 #include "utils/StdString.h"
-#include <taglib/tiostream.h>
+#include <tiostream.h>
 
 using namespace XFILE;
 using namespace TagLib;

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -23,21 +23,21 @@
 
 #include <vector>
 
-#include <taglib/id3v1tag.h>
-#include <taglib/id3v2tag.h>
-#include <taglib/apetag.h>
-#include <taglib/xiphcomment.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
+#include <apetag.h>
+#include <xiphcomment.h>
 
-#include <taglib/textidentificationframe.h>
-#include <taglib/uniquefileidentifierframe.h>
-#include <taglib/popularimeterframe.h>
-#include <taglib/commentsframe.h>
-#include <taglib/unsynchronizedlyricsframe.h>
-#include <taglib/attachedpictureframe.h>
+#include <textidentificationframe.h>
+#include <uniquefileidentifierframe.h>
+#include <popularimeterframe.h>
+#include <commentsframe.h>
+#include <unsynchronizedlyricsframe.h>
+#include <attachedpictureframe.h>
 
 #undef byte
-#include <taglib/tstring.h>
-#include <taglib/tpropertymap.h>
+#include <tstring.h>
+#include <tpropertymap.h>
 
 #include "TagLibVFSStream.h"
 #include "MusicInfoTag.h"

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -21,28 +21,28 @@
  */
 
 #undef byte
-#include <taglib/aifffile.h>
-#include <taglib/apefile.h>
-#include <taglib/asffile.h>
-#include <taglib/flacfile.h>
-#include <taglib/itfile.h>
-#include <taglib/modfile.h>
-#include <taglib/mpcfile.h>
-#include <taglib/mp4file.h>
-#include <taglib/mpegfile.h>
-#include <taglib/oggfile.h>
-#include <taglib/oggflacfile.h>
-#include <taglib/rifffile.h>
-#include <taglib/speexfile.h>
-#include <taglib/s3mfile.h>
-#include <taglib/trueaudiofile.h>
-#include <taglib/vorbisfile.h>
-#include <taglib/wavpackfile.h>
-#include <taglib/xmfile.h>
+#include <aifffile.h>
+#include <apefile.h>
+#include <asffile.h>
+#include <flacfile.h>
+#include <itfile.h>
+#include <modfile.h>
+#include <mpcfile.h>
+#include <mp4file.h>
+#include <mpegfile.h>
+#include <oggfile.h>
+#include <oggflacfile.h>
+#include <rifffile.h>
+#include <speexfile.h>
+#include <s3mfile.h>
+#include <trueaudiofile.h>
+#include <vorbisfile.h>
+#include <wavpackfile.h>
+#include <xmfile.h>
 
-#include <taglib/id3v2tag.h>
-#include <taglib/xiphcomment.h>
-#include <taglib/mp4tag.h>
+#include <id3v2tag.h>
+#include <xiphcomment.h>
+#include <mp4tag.h>
 #include "TagLibVFSStream.h"
 
 namespace MUSIC_INFO

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -30,7 +30,7 @@
 
 #ifdef HAS_DVD_DRIVE
 
-#include <taglib/id3v1genres.h>
+#include <id3v1genres.h>
 #include "cddb.h"
 #include "network/DNSNameCache.h"
 #include "music/tags/Id3Tag.h"


### PR DESCRIPTION
currently xbmc only compiles if taglib 1.8 includes are found in a default location (/usr/include/taglib /usr/local/include/taglib) although pkg-config is used to query the correct Libs and CFLAGS.

the taglib.pc file defines:
   Libs:  $taglib_install_prefix/lib 
   Cflags: $taglib_install_prefix/include/taglib

now using 
# include <taglib/somefile.h> translates to $taglib_install_prefix/include/taglib/taglib/somefile.h, which is wrong.

This PR allows building with taglib installed in arbitrary locations, as long as pkg-config finds it. (e.g. by setting PKG_CONFIG_PATH)

tested on linux
