### PR TITLE
Fix replaying of videos containing one PCR wrap.

### DIFF
--- a/lib/ffmpeg/libavformat/avformat.h
+++ b/lib/ffmpeg/libavformat/avformat.h
@@ -1234,6 +1234,15 @@ typedef struct AVFormatContext {
     /* av_seek_frame() support */
     int64_t data_offset; /**< offset of the first packet */
 #endif
+
+    /**
+     * Mask for the timestamp, defines the maximum value in each
+     * video format. Added to support PCR wrapping in MPEG TS.
+     * Should be set in read_header of input format. Default is
+     * 0x7FFFFFFFFFFFFFFF.
+     */
+    int64_t timestamp_mask;
+
 } AVFormatContext;
 
 typedef struct AVPacketList {

--- a/lib/ffmpeg/libavformat/mpegts.c
+++ b/lib/ffmpeg/libavformat/mpegts.c
@@ -1979,6 +1979,9 @@ static int mpegts_read_header(AVFormatContext *s,
     int len;
     int64_t pos;
 
+    /* set the MPEG TS specific timestamp mask */
+    s->timestamp_mask = TS_PCR_MASK;
+
     /* read the first 8192 bytes to get packet size */
     pos = avio_tell(pb);
     len = avio_read(pb, buf, sizeof(buf));

--- a/lib/ffmpeg/libavformat/mpegts.h
+++ b/lib/ffmpeg/libavformat/mpegts.h
@@ -58,6 +58,8 @@
 #define STREAM_TYPE_AUDIO_AC3       0x81
 #define STREAM_TYPE_AUDIO_DTS       0x8a
 
+#define TS_PCR_MASK    INT64_C(0x00000001FFFFFFFF)
+
 typedef struct MpegTSContext MpegTSContext;
 
 MpegTSContext *ff_mpegts_parse_open(AVFormatContext *s);

--- a/lib/ffmpeg/libavutil/avutil.h
+++ b/lib/ffmpeg/libavutil/avutil.h
@@ -280,6 +280,12 @@ const char *av_get_media_type_string(enum AVMediaType media_type);
 #define AV_NOPTS_VALUE          INT64_C(0x8000000000000000)
 
 /**
+ * @brief Default mask for valid timestamp values
+ */
+
+#define AV_PTS_MASK             INT64_C(0x7FFFFFFFFFFFFFFF)
+
+/**
  * Internal time base represented as integer
  */
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -609,17 +609,23 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   // we don't care for having a completly exact timestamp anyway
   double timestamp = (double)pts * num  / den;
   double starttime = 0.0f;
+  double timestamp_wrap = 0.0f;
 
   // for dvd's we need the original time
   if(dynamic_cast<CDVDInputStream::IMenus*>(m_pInput))
     starttime = dynamic_cast<CDVDInputStream::IMenus*>(m_pInput)->GetTimeStampCorrection() / DVD_TIME_BASE;
   else if (m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
+  {
     starttime = (double)m_pFormatContext->start_time / AV_TIME_BASE;
+    timestamp_wrap = (double)(m_pFormatContext->timestamp_mask) * num / den;
+  }
 
   if(timestamp > starttime)
     timestamp -= starttime;
   else if( timestamp + 0.1f > starttime )
     timestamp = 0;
+  else if( timestamp < starttime)
+    timestamp += timestamp_wrap - starttime;
 
   return timestamp*DVD_TIME_BASE;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2030,6 +2030,8 @@ void CDVDPlayer::HandleMessages()
         double start = DVD_NOPTS_VALUE;
 
         int time = msg.GetRestore() ? (int)m_Edl.RestoreCutTime(msg.GetTime()) : msg.GetTime();
+        if(time < 0)
+          time = 0;
         CLog::Log(LOGDEBUG, "demuxer seek to: %d", time);
         if (m_pDemuxer && m_pDemuxer->SeekTime(time, msg.GetBackward(), &start))
         {


### PR DESCRIPTION
In the current version trick speed and jumping in TS files will not work, if they contain a PCR wrap. Instead replay stops immediately. This will affect about 1 of 10 TV recordings (the TS PCR timer will overflow every 26 hours).

In the attached code this issue is fixed for one single PCR wrap, so every typical TV recording should work now.

To get it working, some changes in the ffmpeg library were necessary. I have found some discussion concerning the PCR wrap and ffmpeg on the net, but it does not seem, that there is any related work in progress.

Code is tested on Linux with numerous TV recordings and some other file formats.
