### PR TITLE
[AE] drop AE_FMT_LPCM from non-CoreAudio builds

### DIFF
--- a/xbmc/cores/AudioEngine/AEAudioFormat.h
+++ b/xbmc/cores/AudioEngine/AEAudioFormat.h
@@ -59,7 +59,9 @@ enum AEDataFormat
   AE_FMT_EAC3,
   AE_FMT_TRUEHD,
   AE_FMT_DTSHD,
-  AE_FMT_LPCM,
+#ifdef TARGET_DARWIN
+  AE_FMT_LPCM, /* used for the CoreAudio-specific multichannel hog mode; data is identical to AE_FMT_FLOAT */
+#endif
 
   AE_FMT_MAX
 };

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -757,8 +757,6 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
       wfxex.Format.nBlockAlign          = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
       wfxex.Format.nAvgBytesPerSec      = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
 
-      bool hasLpcm = false;
-
       // Try with KSAUDIO_SPEAKER_DIRECTOUT
       for (unsigned int k = WASAPI_SPEAKER_COUNT; k > 0; k--)
       {
@@ -769,11 +767,6 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
         hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
         if (SUCCEEDED(hr))
         {
-          if (k > 3) // Add only multichannel LPCM
-          {
-            deviceInfo.m_dataFormats.push_back(AE_FMT_LPCM);
-            hasLpcm = true;
-          }
           break;
         }
       }
@@ -788,11 +781,6 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
         hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
         if (SUCCEEDED(hr))
         {
-          if ( !hasLpcm && k > 3) // Add only multichannel LPCM
-          {
-            deviceInfo.m_dataFormats.push_back(AE_FMT_LPCM);
-            hasLpcm = true;
-          }
           break;
         }
       }
@@ -810,11 +798,6 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
         {
           if ( deviceChannels.Count() < nmbOfCh)
             deviceChannels = layoutsList[i];
-          if ( !hasLpcm && nmbOfCh > 3) // Add only multichannel LPCM
-          {
-            deviceInfo.m_dataFormats.push_back(AE_FMT_LPCM);
-            hasLpcm = true;
-          }
         }
       }
       pClient->Release();

--- a/xbmc/cores/AudioEngine/Utils/AEELDParser.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEELDParser.cpp
@@ -194,7 +194,6 @@ void CAEELDParser::Parse(const uint8_t *data, size_t length, CAEDeviceInfo& info
       case CEA_861_FORMAT_DTS  : fmt = AE_FMT_DTS   ; break;
       case CEA_861_FORMAT_DTSHD: fmt = AE_FMT_DTSHD ; break;
       case CEA_861_FORMAT_EAC3 : fmt = AE_FMT_EAC3  ; break;
-      case CEA_861_FORMAT_LPCM : fmt = AE_FMT_LPCM  ; break;
       case CEA_861_FORMAT_MLP  : fmt = AE_FMT_TRUEHD; break;
     }
 

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -106,7 +106,9 @@ const unsigned int CAEUtil::DataFormatToBits(const enum AEDataFormat dataFormat)
     16,                  /* EAC3   */
     16,                  /* TRUEHD */
     16,                  /* DTS-HD */
+#ifdef TARGET_DARWIN
     32                   /* LPCM   */
+#endif
   };
 
   return formats[dataFormat];
@@ -148,7 +150,9 @@ const char* CAEUtil::DataFormatToStr(const enum AEDataFormat dataFormat)
     "AE_FMT_EAC3",
     "AE_FMT_TRUEHD",
     "AE_FMT_DTSHD",
+#ifdef TARGET_DARWIN
     "AE_FMT_LPCM"
+#endif
   };
 
   return formats[dataFormat];

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -173,13 +173,17 @@ int CDVDAudioCodecFFmpeg::Decode(BYTE* pData, int iSize)
     m_iBuffered += iBytesUsed;
   else
     m_iBuffered = 0;
-    
+
+#ifdef TARGET_DARWIN
   if(m_bLpcmMode)
     ConvertToFloat();
+#endif
 
   return iBytesUsed;
 }
 
+#ifdef TARGET_DARWIN
+// used by the CoreAudio-specific "LPCM hog mode"
 void CDVDAudioCodecFFmpeg::ConvertToFloat()
 {
   if(m_pCodecContext->sample_fmt != AV_SAMPLE_FMT_FLT && m_iBufferSize1 > 0)
@@ -217,6 +221,7 @@ void CDVDAudioCodecFFmpeg::ConvertToFloat()
     m_iBufferSize2 = len * m_dllAvUtil.av_get_bytes_per_sample(AV_SAMPLE_FMT_FLT);
   }
 }
+#endif
 
 int CDVDAudioCodecFFmpeg::GetData(BYTE** dst)
 {
@@ -264,11 +269,13 @@ int CDVDAudioCodecFFmpeg::GetEncodedSampleRate()
 
 enum AEDataFormat CDVDAudioCodecFFmpeg::GetDataFormat()
 {
+#if TARGET_DARWIN
   if(m_bLpcmMode)
   {
     return AE_FMT_LPCM;
   }
   else
+#endif
   {
     switch(m_pCodecContext->sample_fmt)
     {


### PR DESCRIPTION
While looking at AudioEngine I got confused by AE_FMT_LPCM and what it is used for. Turns out it actually seems to only be used as a hack on CoreAudio to enable a "hog" mode needed for multichannel (for some reason this is used instead of looking directly at the channel count).

To avoid future confusion, this will make AE_FMT_LPCM depend on TARGET_DARWIN. I guess one other alternative would be to simply rename it to something that clearly indicates its purpose.

Detailed commit message below:

AE has a separate AEDataFormat AE_FMT_LPCM for multichannel PCM audio.
However, the data content is actually the same as AE_FMT_FLOAT, and
AE_FMT_LPCM is only used by CoreAudioAE.

CoreAudio uses the AE_FMT_FLOAT <=> AE_FMT_LPCM differentation to enter
a special "hog" mode, which is reportedly needed for multichannel HDMI
playback on CoreAudio. AE_FMT_LPCM mode is entered on CoreAudio systems
instead of AE_FMT_FLOAT (or other regular modes) when the multichannel
LPCM playback option is enabled in audio settings and the output device
type is HDMI.

Since AE_FMT_LPCM has no meaning outside CoreAudio, clearly mark it as
CoreAudio specific by making it conditional on TARGET_DARWIN, to avoid
confusion regarding the actual use case of that format type.

AE_FMT_LPCM is currently also added in device enumeration to
m_dataFormats on ALSA devices when the HDMI sink EDID contains a Short
Audio Descriptor with audio code 1 (LPCM). However, that makes no sense,
since the audio code simply means that the device accepts PCM input,
which all HDMI audio devices have to (obviously) support according to
the specification. Also, AESinkWASAPI adds AE_FMT_LPCM to m_dataFormats
for devices with 4+ channels, which is pointless as there is a separate
m_channelLayout member in AEAudioFormat for this purpose.
Both of these can be safely removed since m_dataFormats is used for
debug log purposes only (any actual users should use m_channelLayout
instead, which works with all sinks).

In the future CoreAudio could probably be changed to enter hog mode
based on the stream channel count directly, in order to avoid having a
special CoreAudio-specific format and related code in general
AudioEngine part.
