### PR TITLE
Work around dimmer not working in Linux.

### DIFF
--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -164,10 +164,9 @@ void CGUITextureGL::DrawQuad(const CRect &rect, color_t color, CBaseTexture *tex
   glTexEnvf(GL_TEXTURE_ENV, GL_OPERAND1_RGB, GL_SRC_COLOR);
   VerifyGLState();
 
-  glBegin(GL_QUADS);
-
   glColor4ub((GLubyte)GET_R(color), (GLubyte)GET_G(color), (GLubyte)GET_B(color), (GLubyte)GET_A(color));
 
+  glBegin(GL_QUADS);
   CRect coords = texCoords ? *texCoords : CRect(0.0f, 0.0f, 1.0f, 1.0f);
   glTexCoord2f(coords.x1, coords.y1);
   glVertex3f(rect.x1, rect.y1, 0);
@@ -179,6 +178,9 @@ void CGUITextureGL::DrawQuad(const CRect &rect, color_t color, CBaseTexture *tex
   glVertex3f(rect.x1, rect.y2, 0);
 
   glEnd();
+
+  glColor4ub(255, 255, 255, 255);
+
   if (texture)
     glDisable(GL_TEXTURE_2D);
 }


### PR DESCRIPTION
Fix the dimmer not appearing in Linux.

This works around the dimmer not appearing.  This requires two changes: 1: make no glColor call between glBegin/glEnd, and 2: make an extra glColor call after glEnd.

This feels like a driver bug; it's not clear why this draw call has trouble but regular CGUITextureGL drawing doesn't (which does almost exactly the same thing), and I'm not seeing any other artifacts in normal use.

Note that the color sent to the second glColor4ub call doesn't matter; it's not actually used.  However, it does have to be a glColor call; calling eg. glTexCoord does not work.

Also note that the bug is not causing the quad to be drawn with the wrong color; it's causing it not to be drawn at all.  This can be checked by disabling GL_BLEND; if the quad was being drawn with the wrong color it would show up, but it doesn't draw at all.

So, this isn't a great workaround since it's dart-throwing without knowing why it works, or what else it might affect, but I'm out of steam on this bug for the weekend, and this workaround at least lets me not worry burn-in for the time being.  I'll help with testing if anybody wants to try to track this down but can't repro the bug.

Bug reproduces on Debian testing:

OpenGL vendor string: Tungsten Graphics, Inc
OpenGL renderer string: Mesa DRI Intel(R) Sandybridge Mobile
OpenGL version string: 3.0 Mesa 8.0.4
00:02.0 VGA compatible controller: Intel Corporation 2nd Generation Core Processor Family Integrated Graphics Controller (rev 09)
Linux htpc 3.2.0-3-amd64 #1 SMP Mon Jul 23 02:45:17 UTC 2012 x86_64 GNU/Linux

Package: libgl1-mesa-glx
Source: mesa
Version: 8.0.4-2
