### PR TITLE
Prevent crash when audio does not initialise correctly.

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -595,6 +595,7 @@ void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
     if (FAILED(hr))
     {
       CLog::Log(LOGERROR, __FUNCTION__": Activate device failed (%s)", WASAPIErrToStr(hr));
+      goto failed;
     }
 
     //hr = pClient->GetMixFormat(&pwfxex);


### PR DESCRIPTION
If a crash happens during a RenderManager callback the audio system is not cleaned up and next time xbmc starts it crashes without this change.

Looking at the possible failure scenarios of the audio system initialisation it's quite possible that other failures are not being handled correctly in the 'failed' block.

Suggest splitting the function up into a bunch of other smaller functions.
