### PR TITLE
dvdplayer: avoid short screen flicker caused by unnecessary reconfigure ...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1004,7 +1004,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
    || m_output.height != pPicture->iHeight
    || m_output.dwidth != pPicture->iDisplayWidth
    || m_output.dheight != pPicture->iDisplayHeight
-   || m_output.framerate != config_framerate
+   || (!m_bFpsInvalid && fmod(m_output.framerate, config_framerate) != 0.0 )
    || m_output.color_format != (unsigned int)pPicture->format
    || m_output.extended_format != pPicture->extended_format
    || ( m_output.color_matrix != pPicture->color_matrix && pPicture->color_matrix != 0 ) // don't reconfigure on unspecified
@@ -1149,7 +1149,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
     m_output.height = pPicture->iHeight;
     m_output.dwidth = pPicture->iDisplayWidth;
     m_output.dheight = pPicture->iDisplayHeight;
-    m_output.framerate = config_framerate;
+    m_output.framerate = config_framerate == 0.0 ? g_graphicsContext.GetFPS() : config_framerate;
     m_output.color_format = pPicture->format;
     m_output.extended_format = pPicture->extended_format;
     m_output.color_matrix = pPicture->color_matrix;


### PR DESCRIPTION
This avoids unnecessary flicker caused by reconfiguring of renderer. This happened in particular for PVR streams which have invalid fps at startup or when e.g. de-interlacing was switched on/off and player has calculated a new frame rate.
