### PR TITLE
Fix tracebacks for python api bindings.

### DIFF
--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -70,7 +70,7 @@ Helper.setup(classes,
      * call.
      */
     [ 
-      'String' : 'if (${slarg}) PyXBMCGetUnicodeString(${api},${slarg},false,"${api}","${method.@name}");',
+      'String' : 'if (${slarg}) if(!PyXBMCGetUnicodeString(${api},${slarg},false,"${api}","${method.@name}")) return NULL;',
       (Pattern.compile('''(p.){0,1}std::vector<\\(.*\\)>''')) : new File('typemaps/python.vector.intm'),
       (Pattern.compile('''(p.){0,1}Tuple(3){0,1}<\\(.*\\)>''')) : new File('typemaps/python.Tuple.intm'),
       // I shouldn't need both of these but my parser doesn't resolve namespaces within


### PR DESCRIPTION
Return NULL if the return value of PyXBMCGetUnicodeString indicates an
error.  This change is used when parsing arguments from API function calls from python scripts.

Previously, PyXBMCGetUnicodeString would set an error, but the called function would not return NULL. By not returning NULL, the exception would not be raised in the python code. Only when the python script finished execution would the error state get checked. Then, by the time PyErr_Fetch is called, the stack is incorrect.

I tested this in a few places, but am still relatively new to this code, so let me know your thoughts.
