### PR TITLE
[python] extend xbmcvfs with listdirWithDetails

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -61,6 +61,11 @@ namespace XBMCAddon
         item->SetPath(path);
     }
 
+    ListItem::ListItem(const CFileItem& item2): AddonClass("ListItem")
+    {
+      item.reset(new CFileItem(item2));
+    }
+
     ListItem::~ListItem()
     {
       item.reset();

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -54,6 +54,9 @@ namespace XBMCAddon
                const String& iconImage = emptyString,
                const String& thumbnailImage = emptyString,
                const String& path = emptyString);
+#ifndef SWIG
+      ListItem(const CFileItem& item2);
+#endif
       virtual ~ListItem();
 
       static inline ListItem* fromString(const String& str) 

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -21,6 +21,7 @@
 
 #include "ModuleXbmcvfs.h"
 #include "LanguageHook.h"
+#include "ListItem.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
 #include "utils/FileUtils.h"
@@ -107,6 +108,21 @@ namespace XBMCAddon
         }
       }
 
+      return ret;
+    }
+    
+    xbmcgui::ListItemList listDirWithDetails(const String& path)
+    {
+      CFileItemList items;
+      CStdString strSource = path;
+      XFILE::CDirectory::GetDirectory(strSource, items);
+      
+      xbmcgui::ListItemList ret;
+      
+      for (int i=0; i < items.Size(); i++)
+      {
+        ret.push_back(new xbmcgui::ListItem(*items[i]));
+      }
       return ret;
     }
   }

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.h
@@ -23,6 +23,7 @@
 
 #include "AddonString.h"
 #include "Tuple.h"
+#include "ListItem.h"
 #include <vector>
 
 namespace XBMCAddon
@@ -116,6 +117,16 @@ namespace XBMCAddon
      *  - dirs, files = xbmcvfs.listdir(path)
      */
     Tuple<std::vector<String>, std::vector<String> > listdir(const String& path);
+
+    /**
+     * listdirWithDetails(path) -- lists content of a folder as ListItemList.
+     *
+     * path        : folder
+     *
+     * example:
+     *  - ListItemList = xbmcvfs.listdirWithDetails(path)
+     */
+     xbmcgui::ListItemList listDirWithDetails(const String& path);
   }
 }
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
@@ -73,5 +73,14 @@ using namespace xbmcvfs;
 %include "interfaces/legacy/File.h"
 
 %rename ("delete") XBMCAddon::xbmcvfs::deleteFile;
+
+namespace XBMCAddon
+{
+  namespace xbmcgui
+  {
+    typedef std::vector<ListItem*> ListItemList;
+  }
+}
+
 %include "interfaces/legacy/ModuleXbmcvfs.h"
 


### PR DESCRIPTION
[python] extend xbmcvfs with listdirWithDetails to provide a list of directories and files with full path(listdir only has folder and file names)

something went wrong with #1451 not sure why, here is a new one
