### PR TITLE
faster scrolling in smaller lists

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -303,9 +303,12 @@ bool CGUIBaseContainer::OnAction(const CAction &action)
         float speed = std::min(1.0f, (float)(action.GetHoldTime() - HOLD_TIME_START) / (HOLD_TIME_END - HOLD_TIME_START));
         unsigned int frameDuration = std::min(CTimeUtils::GetFrameTime() - m_lastHoldTime, 50u); // max 20fps
 
-        // scrollrate is minimum 10 items/sec and timed to take around 10 seconds
-        // with ramp up (num_rows/7 items per second max speed) to traverse a long list
-        m_scrollItemsPerFrame += std::max(0.01f*(float)frameDuration, (float)(speed * 0.00015f * GetRows() * frameDuration));
+        // maximal scroll rate is at least 30 items per second, and at most (item_rows/7) items per second
+        //  i.e. timed to take 7 seconds to traverse the list at full speed.
+        // minimal scroll rate is at least 10 items per second
+        float maxSpeed = std::max(frameDuration * 0.001f * 30, frameDuration * 0.001f * GetRows() / 7);
+        float minSpeed = frameDuration * 0.001f * 10;
+        m_scrollItemsPerFrame += std::max(minSpeed, speed*maxSpeed); // accelerate to max speed
         m_lastHoldTime = CTimeUtils::GetFrameTime();
 
         if(m_scrollItemsPerFrame < 1.0f)//not enough hold time accumulated for one step


### PR DESCRIPTION
Faster scrolling, particularly in lists whose length is under about 70 or so, where previously the max speed was around 10 items per second, which is a bit on the slow side.  It's now 30 items per second at full speed (and minimum 10 items per second during ramp-up).

I've also clarified the comments (which were correct, though perhaps not obviously so from the code) and made the code more explicit - please let me know if I can make these even more obvious if it's not understandable.

Doing as a PR because, while this works perfectly for me, I can't test on other systems and don't want to cause too much churn in master.

Works fine on win32 and OSX with the keyboard, which correctly reports held status.  If a remote isn't reporting held status, then it won't even get to this code, so the problem is elsewhere.

@davilla, @Memphiz, @cptspiff I believe you've commented on speed before.
