### PR TITLE
[droid] - add pvraddons to depends

### DIFF
--- a/tools/android/depends/Makefile.in
+++ b/tools/android/depends/Makefile.in
@@ -13,7 +13,7 @@ SUBDIRS = \
 	python26-native python26 samba alsa-lib libcdio afpfs-ng libshairport \
 	libplist libcec libbluray boost tinyxml dummy-libxbmc libsdl \
 	liblzo2-native libjpeg-turbo-native libpng-native tiff-native libsdl_image rpl \
-	libamplayer libssh taglib swig-native pcre-native
+	libamplayer libssh taglib swig-native pcre-native xbmc-pvr-addons
 
 .PHONY: buildtools $(BUILDTOOLS) subdirs $(SUBDIRS) arm
 
@@ -62,6 +62,7 @@ libssh: openssl cmake rpl
 taglib: cmake
 swig-native: buildtools pcre-native
 pcre-native: buildtools
+xbmc-pvr-addons: buildtools
 
 
 X86OVERRIDES=XBMC_OVERRIDE_HOST=i686-android-linux XBMC_OVERRIDE_TOOLCHAIN=$(XBMC_X86_TOOLCHAIN)

--- a/tools/android/depends/xbmc-pvr-addons/Makefile
+++ b/tools/android/depends/xbmc-pvr-addons/Makefile
@@ -1,0 +1,49 @@
+include ../Makefile.include
+DEPS= ../Makefile.include Makefile
+
+XBMC_ADDONSDIR=../../../../addons
+
+# lib name, version
+LIBNAME=xbmc-pvr-addons
+VERSION=a6693d02b670a5f0a35c7e41d62250869a9e76b7
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+
+# configuration settings
+CONFIGURE=./configure --prefix=$(PREFIX) --host=$(HOST)
+
+LIBDYLIB=$(PLATFORM)/addons/pvr.demo/.libs/libpvrdemo-addon.dylib
+
+all: $(LIBDYLIB) .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	git clone git://github.com/opdenkamp/xbmc-pvr-addons.git $(PLATFORM)
+	cd $(PLATFORM); git archive --format=tar --prefix=$(SOURCE)/ $(VERSION) | gzip -9 > $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	$(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); ./bootstrap
+	cd $(PLATFORM); $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	make -C $(PLATFORM)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	for ADDON in `find $(PLATFORM)/addons -type d -name "pvr.*"`; do \
+	  ADDON=`basename $$ADDON` ; \
+	  mkdir -p $(XBMC_ADDONSDIR)/$$ADDON ; \
+	  cp -PRf $(PLATFORM)/addons/$$ADDON/addon/* $(XBMC_ADDONSDIR)/$$ADDON ; \
+	  cp -Pf $(PLATFORM)/addons/$$ADDON/*.pvr $(XBMC_ADDONSDIR)/$$ADDON ; \
+	done
+	make -C $(PLATFORM) install
+	touch .installed-$(PLATFORM)
+
+clean:
+	make -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+	rm -f $(TARBALLS_LOCATION)/$(ARCHIVE)
+

--- a/tools/android/packaging/Makefile
+++ b/tools/android/packaging/Makefile
@@ -54,6 +54,7 @@ extras: libs
 	rm -rf xbmc/assets/python2.6/lib/
 	mkdir -p xbmc/assets xbmc/res xbmc/assets/python2.6/lib/
 	cp -rfp $(PREFIX)/share/xbmc/* ./xbmc/assets
+	cpr -rfp $(PREFIX)/lib/xbmc/addons/* ./xbmc/assets/addons
 	find `pwd`/xbmc/assets/system/ -name "*.so" -exec rm {} \;
 	find `pwd`/xbmc/assets/addons/skin.*/media/* -depth -not -iname "Textures.xbt" -exec rm -rf {} \;
 	cp -rfp $(PREFIX)/lib/python2.6 xbmc/assets/python2.6/lib/


### PR DESCRIPTION
Basically what the title says. I'm not sure if this will work on android. IIRC the libs need the ".so" extension or so? But maybe you can use this as a base.

Its based on darwin depends

@TheUni RFC
