### PR TITLE
Use RSS channel image if the RSS item doesn't have one

### DIFF
--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -629,6 +629,11 @@ bool CRSSDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
     ParseItem(item.get(), child, path);
 
     item->SetProperty("isrss", "1");
+    // Use channel image if item doesn't have one
+    if(item->GetThumbnailImage().IsEmpty() && !items.GetThumbnailImage().IsEmpty())
+    {
+      item->SetThumbnailImage(items.GetThumbnailImage());
+    }
 
     if (!item->GetPath().IsEmpty())
       items.Add(item);


### PR DESCRIPTION
Just a simple PR to add support for using the thumbnail from the RSS channel element for all items that doesn't have an image.
