### PR TITLE
cache timezone bias

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -872,9 +872,15 @@ void CDateTime::SetFromUTCDateTime(const CDateTime &dateTime)
   m_state = tmp.m_state;
 }
 
+static bool bGotTimezoneBias = false;
+
+void CDateTime::ResetTimezoneBias(void)
+{
+  bGotTimezoneBias = false;
+}
+
 CDateTimeSpan CDateTime::GetTimezoneBias(void)
 {
-  static bool bGotTimezoneBias = false;
   static CDateTimeSpan timezoneBias;
 
   if (!bGotTimezoneBias)

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -282,22 +282,8 @@ CDateTime CDateTime::GetCurrentDateTime()
 
 CDateTime CDateTime::GetUTCDateTime()
 {
-  TIME_ZONE_INFORMATION tz;
-
   CDateTime time(GetCurrentDateTime());
-  switch(GetTimeZoneInformation(&tz))
-  {
-    case TIME_ZONE_ID_DAYLIGHT:
-        time += CDateTimeSpan(0, 0, tz.Bias + tz.DaylightBias, 0);
-        break;
-    case TIME_ZONE_ID_STANDARD:
-        time += CDateTimeSpan(0, 0, tz.Bias + tz.StandardBias, 0);
-        break;
-    case TIME_ZONE_ID_UNKNOWN:
-        time += CDateTimeSpan(0, 0, tz.Bias, 0);
-        break;
-  }
-
+  time += GetTimezoneBias();
   return time;
 }
 
@@ -879,24 +865,37 @@ CStdString CDateTime::GetAsSaveString() const
 
 void CDateTime::SetFromUTCDateTime(const CDateTime &dateTime)
 {
-  TIME_ZONE_INFORMATION tz;
   CDateTime tmp(dateTime);
-
-  switch(GetTimeZoneInformation(&tz))
-  {
-    case TIME_ZONE_ID_DAYLIGHT:
-        tmp -= CDateTimeSpan(0, 0, tz.Bias + tz.DaylightBias, 0);
-        break;
-    case TIME_ZONE_ID_STANDARD:
-        tmp -= CDateTimeSpan(0, 0, tz.Bias + tz.StandardBias, 0);
-        break;
-    case TIME_ZONE_ID_UNKNOWN:
-        tmp -= CDateTimeSpan(0, 0, tz.Bias, 0);
-        break;
-  }
+  tmp -= GetTimezoneBias();
 
   m_time = tmp.m_time;
   m_state = tmp.m_state;
+}
+
+CDateTimeSpan CDateTime::GetTimezoneBias(void)
+{
+  static bool bGotTimezoneBias = false;
+  static CDateTimeSpan timezoneBias;
+
+  if (!bGotTimezoneBias)
+  {
+    bGotTimezoneBias = true;
+    TIME_ZONE_INFORMATION tz;
+    switch(GetTimeZoneInformation(&tz))
+    {
+      case TIME_ZONE_ID_DAYLIGHT:
+        timezoneBias = CDateTimeSpan(0, 0, tz.Bias + tz.DaylightBias, 0);
+        break;
+      case TIME_ZONE_ID_STANDARD:
+        timezoneBias = CDateTimeSpan(0, 0, tz.Bias + tz.StandardBias, 0);
+        break;
+      case TIME_ZONE_ID_UNKNOWN:
+        timezoneBias = CDateTimeSpan(0, 0, tz.Bias, 0);
+        break;
+    }
+  }
+
+  return timezoneBias;
 }
 
 void CDateTime::SetFromUTCDateTime(const time_t &dateTime)
@@ -1328,22 +1327,8 @@ CStdString CDateTime::GetAsLocalizedDateTime(bool longDate/*=false*/, bool withS
 
 CDateTime CDateTime::GetAsUTCDateTime() const
 {
-  TIME_ZONE_INFORMATION tz;
-
   CDateTime time(m_time);
-  switch(GetTimeZoneInformation(&tz))
-  {
-    case TIME_ZONE_ID_DAYLIGHT:
-        time += CDateTimeSpan(0, 0, tz.Bias + tz.DaylightBias, 0);
-        break;
-    case TIME_ZONE_ID_STANDARD:
-        time += CDateTimeSpan(0, 0, tz.Bias + tz.StandardBias, 0);
-        break;
-    case TIME_ZONE_ID_UNKNOWN:
-        time += CDateTimeSpan(0, 0, tz.Bias, 0);
-        break;
-  }
-
+  time += GetTimezoneBias();
   return time;
 }
 

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -196,6 +196,7 @@ public:
   void SetValid(bool yesNo);
   bool IsValid() const;
 
+  static void ResetTimezoneBias(void);
   static CDateTimeSpan GetTimezoneBias(void);
 
 private:

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -196,6 +196,8 @@ public:
   void SetValid(bool yesNo);
   bool IsValid() const;
 
+  static CDateTimeSpan GetTimezoneBias(void);
+
 private:
   bool ToFileTime(const SYSTEMTIME& time, FILETIME& fileTime) const;
   bool ToFileTime(const time_t& time, FILETIME& fileTime) const;

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1880,6 +1880,8 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
 
     CGUISpinControlEx *tzControl = (CGUISpinControlEx *)GetControl(GetSetting("locale.timezone")->GetID());
     g_guiSettings.SetString("locale.timezone", tzControl->GetLabel().c_str());
+
+    CDateTime::ResetTimezoneBias();
   }
   else  if (strSetting.Equals("locale.timezone"))
   {
@@ -1889,6 +1891,8 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
 
      tzControl = (CGUISpinControlEx *)GetControl(GetSetting("locale.timezonecountry")->GetID());
      g_guiSettings.SetString("locale.timezonecountry", tzControl->GetLabel().c_str());
+
+     CDateTime::ResetTimezoneBias();
   }
 #endif
   else if (strSetting.Equals("lookandfeel.skinzoom"))
@@ -1908,12 +1912,18 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
   {
     if (g_PVRManager.CheckParentalPIN(g_localizeStrings.Get(19262).c_str()) &&
         CGUIDialogYesNo::ShowAndGetInput(19098, 19186, 750, 0))
+    {
+      CDateTime::ResetTimezoneBias();
       g_PVRManager.ResetDatabase();
+    }
   }
   else if (strSetting.Equals("epg.resetepg"))
   {
     if (CGUIDialogYesNo::ShowAndGetInput(19098, 19188, 750, 0))
+    {
+      CDateTime::ResetTimezoneBias();
       g_PVRManager.ResetEPG();
+    }
   }
   else if (strSetting.Equals("pvrmanager.channelscan") && g_PVRManager.IsStarted())
   {


### PR DESCRIPTION
because GetTimeZoneInformation() is slow. speeds up things like the recordings list.
