### PR TITLE
Changed: [Confluence] Made the PVR window use the common background code...

### DIFF
--- a/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
@@ -41,14 +41,15 @@
 			<width>1280</width>
 			<height>720</height>
 			<texture>special://skin/backgrounds/media-overlay.jpg</texture>
-			<visible>Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)</visible>
+			<visible>[Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)] + ![Window.IsVisible(PVR) + [Control.IsVisible(11) | Control.IsVisible(12)]]</visible>
+			<include>VisibleFadeEffect</include>
 		</control>
 		<control type="visualisation">
 			<posx>0</posx>
 			<posy>0</posy>
 			<width>1280</width>
 			<height>720</height>
-			<visible>Player.HasAudio + !Skin.HasSetting(ShowBackgroundVis)</visible>
+			<visible>Player.HasAudio + !Skin.HasSetting(ShowBackgroundVis) + ![Window.IsVisible(PVR) + [Control.IsVisible(11) | Control.IsVisible(12)]]</visible>
 			<visible>!SubString(Window(videolibrary).Property(TvTunesIsAlive),True)</visible>
 		</control>
 		<control type="videowindow">
@@ -56,7 +57,7 @@
 			<posy>0</posy>
 			<width>1280</width>
 			<height>720</height>
-			<visible>Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)</visible>
+			<visible>Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo) + ![Window.IsVisible(PVR) + [Control.IsVisible(11) | Control.IsVisible(12)]]</visible>
 		</control>
 		<control type="image">
 			<posx>0</posx>

--- a/addons/skin.confluence/720p/MyPVR.xml
+++ b/addons/skin.confluence/720p/MyPVR.xml
@@ -2,53 +2,7 @@
 	<defaultcontrol>32</defaultcontrol>
 	<allowoverlay>no</allowoverlay>
 	<controls>
-		<control type="image">
-			<description>Normal Default Background Image</description>
-			<posx>0</posx>
-			<posy>0</posy>
-			<width>1280</width>
-			<height>720</height>
-			<aspectratio>scale</aspectratio>
-			<texture>$INFO[Skin.CurrentTheme,special://skin/backgrounds/,.jpg]</texture>
-			<visible>![Skin.HasSetting(UseCustomBackground) + !IsEmpty(Skin.String(CustomBackgroundPath))]</visible>
-			<include>VisibleFadeEffect</include>
-		</control>
-		<control type="image">
-			<description>User Set Background Image</description>
-			<posx>0</posx>
-			<posy>0</posy>
-			<width>1280</width>
-			<height>720</height>
-			<aspectratio>scale</aspectratio>
-			<texture>$INFO[Skin.String(CustomBackgroundPath)]</texture>
-			<visible>Skin.HasSetting(UseCustomBackground) + !IsEmpty(Skin.String(CustomBackgroundPath))</visible>
-			<include>VisibleFadeEffect</include>
-		</control>
-		<control type="group">
-			<visible>!Control.IsVisible(11) + !Control.IsVisible(12)</visible>
-			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
-				<width>1280</width>
-				<height>720</height>
-				<texture>special://skin/backgrounds/media-overlay.png</texture>
-				<visible>Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)</visible>
-			</control>
-			<control type="visualisation">
-				<posx>0</posx>
-				<posy>0</posy>
-				<width>1280</width>
-				<height>720</height>
-				<visible>Player.HasAudio + !Skin.HasSetting(ShowBackgroundVis)</visible>
-			</control>
-			<control type="videowindow">
-				<posx>0</posx>
-				<posy>0</posy>
-				<width>1280</width>
-				<height>720</height>
-				<visible>Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)</visible>
-			</control>
-		</control>
+		<include>CommonBackground</include>
 		<include>ContentPanelBackgroundsPVR</include>
 		<include>MainWindowMouseButtons</include>
 		<control type="image">


### PR DESCRIPTION
... so it can use fanart for the background

This basically just needs a quick check too make sure that the video and vis background doesn't vanish anywhere else (other windows) but the "TV Channels" and  " Radio Channels" sections in the pvr window

Also replaces this pull request https://github.com/xbmc/xbmc/pull/1494
