### PR TITLE
Replace system-wide iMON setting with per-device setting

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11224,12 +11224,14 @@ msgctxt "#35100"
 msgid "Enable joystick and gamepad support"
 msgstr ""
 
-#: xbmc/settings/GUISettings.cpp
-msgctxt "#35101"
-msgid "Disable joystick when iMON is present"
+#empty string with id 35101
+
+#: system/peripherals.xml
+msgctxt "#35102"
+msgid "Disable joystick when device is present"
 msgstr ""
 
-#empty strings from id 35102 to 35499
+#empty strings from id 35103 to 35499
 
 msgctxt "#35500"
 msgid "Location"

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -57,6 +57,7 @@
   </peripheral>
 
   <peripheral vendor_product="15C2:32,15C2:33,15C2:34,15C2:35,15C2:36,15C2:37,15C2:38,15C2:39,15C2:3A,15C2:3B,15C2:3C,15C2:3D,15C2:3E,15C2:3F,15C2:41,15C2:42,15C2:43,15C2:44,15C2:45,15C2:46" bus="usb" name="iMON HID device" mapTo="imon">
-    <setting key="do_not_use_custom_keymap" type="bool" value="1" label="35009" order="1" configurable="0"/>
+    <setting key="do_not_use_custom_keymap" type="bool" value="1" label="35009" configurable="0"/>
+    <setting key="disable_winjoystick" type="bool" value="1" label="35102" order="1" />
   </peripheral>
 </peripherals>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1396,7 +1396,7 @@ bool CApplication::Initialize()
 
 #ifdef HAS_SDL_JOYSTICK
   g_Joystick.SetEnabled(g_guiSettings.GetBool("input.enablejoystick") &&
-                    (CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0 || !g_guiSettings.GetBool("input.disablejoystickwithimon")) );
+                    CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0 );
 #endif
 
   return true;

--- a/xbmc/peripherals/devices/PeripheralImon.h
+++ b/xbmc/peripherals/devices/PeripheralImon.h
@@ -29,14 +29,17 @@ namespace PERIPHERALS
     CPeripheralImon(const PeripheralType type, const PeripheralBusType busType, const CStdString &strLocation, const CStdString &strDeviceName, int iVendorId, int iProductId);
     virtual ~CPeripheralImon(void) {}
     virtual bool InitialiseFeature(const PeripheralFeature feature);
+    virtual void OnSettingChanged(const CStdString &strChangedSetting);
     virtual void OnDeviceRemoved();
+    virtual void AddSetting(const CStdString &strKey, const CSetting *setting);
     inline bool IsImonConflictsWithDInput() 
-    { return m_ImonConflictsWithDInput;}
+    { return m_bImonConflictsWithDInput;}
     static inline long GetCountOfImonsConflictWithDInput()
-    { return m_CountOfImonsConflictWithDInput; }
+    { return m_lCountOfImonsConflictWithDInput; }
     static void ActionOnImonConflict(bool deviceInserted = true);
+
   private:
-    bool m_ImonConflictsWithDInput;
-    static volatile long m_CountOfImonsConflictWithDInput;
+    bool m_bImonConflictsWithDInput;
+    static volatile long m_lCountOfImonsConflictWithDInput;
   };
 }

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -546,8 +546,6 @@ void CGUISettings::Initialize()
 #endif
 #if defined(HAS_SDL_JOYSTICK)
   AddBool(in, "input.enablejoystick", 35100, true);
-  AddBool(in, "input.disablejoystickwithimon", 35101, true);
-  GetSetting("input.disablejoystickwithimon")->SetVisible(false);
 #endif
 
   CSettingsCategory* net = AddCategory(SETTINGS_SYSTEM, "network", 798);

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1016,6 +1016,12 @@ void CGUIWindowSettingsCategory::UpdateSettings()
       if (pControl)
         pControl->SetEnabled(g_peripherals.GetNumberOfPeripherals() > 0);
     }
+    else if (strSetting.Equals("input.enablejoystick"))
+    {
+      CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
+      if (pControl)
+        pControl->SetEnabled(CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
+    }
   }
 
   g_guiSettings.SetChanged();
@@ -1061,6 +1067,8 @@ void CGUIWindowSettingsCategory::OnClick(CBaseSettingControl *pSettingControl)
     CGUIDialogPeripheralManager *dialog = (CGUIDialogPeripheralManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PERIPHERAL_MANAGER);
     if (dialog)
       dialog->DoModal();
+    // refresh settings
+    UpdateSettings();
     return;
   }
 
@@ -1442,11 +1450,11 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
   {
     g_Mouse.SetEnabled(g_guiSettings.GetBool("input.enablemouse"));
   }
-  else if (strSetting.Equals("input.enablejoystick") || strSetting.Equals("input.disablejoystickwithimon"))
+  else if (strSetting.Equals("input.enablejoystick"))
   {
 #if defined(HAS_SDL_JOYSTICK)
     g_Joystick.SetEnabled(g_guiSettings.GetBool("input.enablejoystick")  
-        && (CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0 || !g_guiSettings.GetBool("input.disablejoystickwithimon")) );
+        && CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
 #endif
   }
   else if (strSetting.Equals("videoscreen.screen"))


### PR DESCRIPTION
Addition for #1189
Allow user to set each iMON device as compatible/incompatible with direct input/joystick (this depends on firmware and can't be detected).
When joystick is disabled by iMON presence, disable manual on/off switch in GUI as non-functional (automatic joystick disable have priority over global joystick switch so disabled switch directly indicate disable of joystick).
This way should be clearer for user as user will not try to on/off joystick without any effect.
