### PR TITLE
[pvr] Fixed warning 'file cannot be played' when selecting a recording folder

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -670,6 +670,11 @@ bool CGUIWindowPVRCommon::PlayRecording(CFileItem *item, bool bPlayMinimized /* 
 
 bool CGUIWindowPVRCommon::PlayFile(CFileItem *item, bool bPlayMinimized /* = false */)
 {
+  if (item->m_bIsFolder)
+  {
+    return false;
+  }
+
   if (item->GetPath() == g_application.CurrentFile())
   {
     CGUIMessage msg(GUI_MSG_FULLSCREEN, 0, m_parent->GetID());


### PR DESCRIPTION
This PR fixes the issue in the recordings list. Currently when pressing OK on a recording folder (like '\* All Recordings') you get a warning dialog 'recording can't be played'. 

The issue was introduced by 2680e87f3aa35b1235dc2dc784f20df8290b5a46.
See also http://trac.xbmc.org/ticket/13383.
