### PR TITLE
[Fix] Option for auto login of a specific selected user profile

### DIFF
--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -56,6 +56,7 @@
 #define PROFILES_FILE     "special://masterprofile/profiles.xml"
 
 #define XML_PROFILES      "profiles"
+#define XML_AUTO_LOGIN    "autologin"
 #define XML_LAST_LOADED   "lastloaded"
 #define XML_LOGIN_SCREEN  "useloginscreen"
 #define XML_NEXTID        "nextIdProfile"
@@ -67,7 +68,7 @@ using namespace XFILE;
 static CProfile EmptyProfile;
 
 CProfilesManager::CProfilesManager()
-  : m_usingLoginScreen(false), m_lastUsedProfile(0),
+  : m_usingLoginScreen(false), m_autoLoginProfile(-1), m_lastUsedProfile(0),
     m_currentProfile(0), m_nextProfileId(0)
 { }
 
@@ -137,6 +138,7 @@ bool CProfilesManager::Load(const std::string &file)
       {
         XMLUtils::GetUInt(rootElement, XML_LAST_LOADED, m_lastUsedProfile);
         XMLUtils::GetBoolean(rootElement, XML_LOGIN_SCREEN, m_usingLoginScreen);
+        XMLUtils::GetInt(rootElement, XML_AUTO_LOGIN, m_autoLoginProfile);
         XMLUtils::GetInt(rootElement, XML_NEXTID, m_nextProfileId);
         
         CStdString defaultDir("special://home/userdata");
@@ -178,6 +180,12 @@ bool CProfilesManager::Load(const std::string &file)
 
   m_currentProfile = m_lastUsedProfile;
 
+  // check the validity of the auto login profile index
+  if (m_autoLoginProfile < -1 || m_autoLoginProfile >= (int)m_profiles.size())
+    m_autoLoginProfile = -1;
+  else if (m_autoLoginProfile >= 0)
+    m_currentProfile = m_autoLoginProfile;
+
   // the login screen runs as the master profile, so if we're using this, we need to ensure
   // we switch to the master profile
   if (m_usingLoginScreen)
@@ -203,6 +211,7 @@ bool CProfilesManager::Save(const std::string &file) const
 
   XMLUtils::SetInt(pRoot, XML_LAST_LOADED, m_currentProfile);
   XMLUtils::SetBoolean(pRoot, XML_LOGIN_SCREEN, m_usingLoginScreen);
+  XMLUtils::SetInt(pRoot, XML_AUTO_LOGIN, m_autoLoginProfile);
   XMLUtils::SetInt(pRoot, XML_NEXTID, m_nextProfileId);      
 
   for (vector<CProfile>::const_iterator profile = m_profiles.begin(); profile != m_profiles.end(); profile++)

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -164,6 +164,7 @@ protected:
 private:
   std::vector<CProfile> m_profiles;
   bool m_usingLoginScreen;
+  int m_autoLoginProfile;
   uint32_t m_lastUsedProfile;
   uint32_t m_currentProfile;
   int m_nextProfileId; // for tracking the next available id to give to a new profile to ensure id's are not re-used


### PR DESCRIPTION
According to the [Milestone 11.0](http://trac.xbmc.org/milestone/11.0)  release notes, it should be possible to select  a specific profile for auto login. However, this feature is missing.

This pull request adds this function as it is described in the patch of Trac [#10708](http://trac.xbmc.org/ticket/10708). At the moment only the first part is implemented:
"1. This patch comes in three parts. The first part adds <autologin></autologin> to profiles.xml. It defaults to a blank string (logs in the most recent user, like before). If you change this to an integer, XBMC will load that profile."

If this fix is accepted, I will add the other two patches as well (exposing this new setting to the skin and adding support for it in Confluence).

Note that the code is by bruing. I do not want to take credit for it.
