### PR TITLE
jsonrpc: add "content" parameter to Addons.GetAddons and properly implement virtual addon types

### DIFF
--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -23,6 +23,7 @@
 #include "JSONUtils.h"
 #include "addons/AddonManager.h"
 #include "addons/AddonDatabase.h"
+#include "addons/PluginSource.h"
 #include "ApplicationMessenger.h"
 #include "TextureCache.h"
 
@@ -32,36 +33,81 @@ using namespace ADDON;
 
 JSONRPC_STATUS CAddonsOperations::GetAddons(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
+  vector<TYPE> addonTypes;
   TYPE addonType = TranslateType(parameterObject["type"].asString());
+  CPluginSource::Content content = CPluginSource::Translate(parameterObject["content"].asString());
   CVariant enabled = parameterObject["enabled"];
-  VECADDONS addons;
-  if (addonType == ADDON_UNKNOWN)
+
+  // ignore the "content" parameter if the type is specified but not a plugin or script
+  if (addonType != ADDON_UNKNOWN && addonType != ADDON_PLUGIN && addonType != ADDON_SCRIPT)
+    content = CPluginSource::UNKNOWN;
+
+  if (addonType >= ADDON_VIDEO && addonType <= ADDON_EXECUTABLE)
   {
-    if (!enabled.isBoolean())
+    addonTypes.push_back(ADDON_PLUGIN);
+    addonTypes.push_back(ADDON_SCRIPT);
+
+    switch (addonType)
     {
-      CAddonMgr::Get().GetAllAddons(addons, false);
-      CAddonMgr::Get().GetAllAddons(addons, true);
+    case ADDON_VIDEO:
+      content = CPluginSource::VIDEO;
+      break;
+    case ADDON_AUDIO:
+      content = CPluginSource::AUDIO;
+      break;
+    case ADDON_IMAGE:
+      content = CPluginSource::IMAGE;
+      break;
+    case ADDON_EXECUTABLE:
+      content = CPluginSource::EXECUTABLE;
+      break;
+
+    default:
+      break;
     }
-    else
-      CAddonMgr::Get().GetAllAddons(addons, enabled.asBoolean());
   }
   else
+    addonTypes.push_back(addonType);
+
+  VECADDONS addons;
+  for (vector<TYPE>::const_iterator typeIt = addonTypes.begin(); typeIt != addonTypes.end(); typeIt++)
   {
-    if (!enabled.isBoolean())
+    VECADDONS typeAddons;
+    if (*typeIt == ADDON_UNKNOWN)
     {
-      CAddonMgr::Get().GetAddons(addonType, addons, false);
-      VECADDONS enabledAddons;
-      CAddonMgr::Get().GetAddons(addonType, enabledAddons, true);
-      addons.insert(addons.begin(), enabledAddons.begin(), enabledAddons.end());
+      if (!enabled.isBoolean())
+      {
+        CAddonMgr::Get().GetAllAddons(typeAddons, false);
+        CAddonMgr::Get().GetAllAddons(typeAddons, true);
+      }
+      else
+        CAddonMgr::Get().GetAllAddons(typeAddons, enabled.asBoolean());
     }
     else
-      CAddonMgr::Get().GetAddons(addonType, addons, enabled.asBoolean());
+    {
+      if (!enabled.isBoolean())
+      {
+        CAddonMgr::Get().GetAddons(*typeIt, typeAddons, false);
+        VECADDONS enabledAddons;
+        CAddonMgr::Get().GetAddons(*typeIt, enabledAddons, true);
+        typeAddons.insert(typeAddons.end(), enabledAddons.begin(), enabledAddons.end());
+      }
+      else
+        CAddonMgr::Get().GetAddons(*typeIt, typeAddons, enabled.asBoolean());
+    }
+
+    addons.insert(addons.end(), typeAddons.begin(), typeAddons.end());
   }
 
   // remove library addons
   for (int index = 0; index < (int)addons.size(); index++)
   {
-    if (addons.at(index)->Type() <= ADDON_UNKNOWN || addons.at(index)->Type() >= ADDON_VIZ_LIBRARY)
+    PluginPtr plugin;
+    if (content != CPluginSource::UNKNOWN)
+      plugin = boost::dynamic_pointer_cast<CPluginSource>(addons.at(index));
+
+    if ((addons.at(index)->Type() <= ADDON_UNKNOWN || addons.at(index)->Type() >= ADDON_VIZ_LIBRARY) ||
+       ((content != CPluginSource::UNKNOWN && plugin == NULL) || (plugin != NULL && !plugin->Provides(content))))
     {
       addons.erase(addons.begin() + index);
       index--;

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -1019,6 +1019,11 @@ namespace JSONRPC
                 "\"xbmc.addon.video\", \"xbmc.addon.audio\", \"xbmc.addon.image\", \"xbmc.addon.executable\", \"xbmc.service\" ],"
       "\"default\": \"unknown\""
     "}",
+    "\"Addon.Content\": {"
+      "\"type\": \"string\","
+      "\"enum\": [ \"unknown\", \"video\", \"audio\", \"image\", \"executable\" ],"
+      "\"default\": \"unknown\""
+    "}",
     "\"Addon.Fields\": {"
       "\"extends\": \"Item.Fields.Base\","
       "\"items\": { \"type\": \"string\","
@@ -2606,6 +2611,7 @@ namespace JSONRPC
       "\"permission\": \"ReadData\","
       "\"params\": ["
         "{ \"name\": \"type\", \"$ref\": \"Addon.Types\" },"
+        "{ \"name\": \"content\", \"$ref\": \"Addon.Content\", \"description\": \"Content provided by the addon. Only considered for plugins and scripts.\" },"
         "{ \"name\": \"enabled\", \"type\": [ { \"type\": \"boolean\" }, { \"type\": \"string\", \"enum\": [ \"all\" ] } ], \"default\": \"all\" },"
         "{ \"name\": \"properties\", \"$ref\": \"Addon.Fields\" },"
         "{ \"name\": \"limits\", \"$ref\": \"List.Limits\" }"

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -1480,6 +1480,7 @@
     "permission": "ReadData",
     "params": [
       { "name": "type", "$ref": "Addon.Types" },
+      { "name": "content", "$ref": "Addon.Content", "description": "Content provided by the addon. Only considered for plugins and scripts." },
       { "name": "enabled", "type": [ { "type": "boolean" }, { "type": "string", "enum": [ "all" ] } ], "default": "all" },
       { "name": "properties", "$ref": "Addon.Fields" },
       { "name": "limits", "$ref": "List.Limits" }

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -992,6 +992,11 @@
               "xbmc.addon.video", "xbmc.addon.audio", "xbmc.addon.image", "xbmc.addon.executable", "xbmc.service" ],
     "default": "unknown"
   },
+  "Addon.Content": {
+    "type": "string",
+    "enum": [ "unknown", "video", "audio", "image", "executable" ],
+    "default": "unknown"
+  },
   "Addon.Fields": {
     "extends": "Item.Fields.Base",
     "items": { "type": "string",


### PR DESCRIPTION
This adds a "content" parameter to Addons.GetAddons which allows to filter addons by the content they provide (only works for plugins and scripts and is ignored for everything else). Furthermore the virtual addon types xbmc.addon.video/audio/image/extecutable are properly implemented by retrieving all script and plugin addons and then filtering them by the respective content.
