### PR TITLE
[Confluence] Record button is missing the label id

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
@@ -211,7 +211,7 @@
 					<control type="button" id="6">
 						<description>Record</description>
 						<include>ButtonInfoDialogsCommonValues</include>
-						<label>-</label>
+						<label>264</label>
 					</control>
 					<control type="button" id="7">
 						<description>OK</description>


### PR DESCRIPTION
As topic says

![](http://img.photobucket.com/albums/v295/_A600/xbmc/record.png)
