### PR TITLE
[AE] Allow sink to decide how or if it can be suspended

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -120,6 +120,8 @@ private:
   bool SetupEncoder(AEAudioFormat &format);
   void Deinitialize();
 
+  inline void ProcessSuspend(); /* enter suspend state if nothing to play and sink allows */
+
   inline void GetDeviceFriendlyName(std::string &device);
 
   IAESink *GetSink(AEAudioFormat &desiredFormat, bool passthrough, std::string &device);
@@ -133,9 +135,10 @@ private:
   bool m_stereoUpmix;
 
   /* internal vars */
-  bool             m_running, m_reOpen, m_isSuspended;
-  bool             m_softSuspend;      /* latches after last stream or sound played for timer below */
-  unsigned int     m_softSuspendTimer; /* time in milliseconds to hold sink open before soft suspend */
+  bool             m_running, m_reOpen;
+  bool             m_isSuspended;      /* engine suspended by external function to release audio context */
+  bool             m_softSuspend;      /* latches after last stream or sound played for timer below for idle */
+  unsigned int     m_softSuspendTimer; /* time in milliseconds to hold sink open before soft suspend for idle */
   CEvent           m_reOpenEvent;
   CEvent           m_wake;
 

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -87,5 +87,17 @@ public:
     This method sets the volume control, volume ranges from 0.0 to 1.0.
   */
   virtual void  SetVolume(float volume) {};
+
+  /*
+    Requests sink to prepare itself for a suspend state
+    @return false if sink cannot be suspended
+  */
+  virtual bool SoftSuspend() {return true;};
+
+  /*
+    Notify sink to prepare to resume processing after suspend state
+    @return false if sink must be reinitialized
+  */
+  virtual bool SoftResume() {return true;};
 };
 

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -92,12 +92,12 @@ public:
     Requests sink to prepare itself for a suspend state
     @return false if sink cannot be suspended
   */
-  virtual bool SoftSuspend() {return true;};
+  virtual bool SoftSuspend() {return false;};
 
   /*
     Notify sink to prepare to resume processing after suspend state
     @return false if sink must be reinitialized
   */
-  virtual bool SoftResume() {return true;};
+  virtual bool SoftResume() {return false;};
 };
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -489,9 +489,6 @@ unsigned int CAESinkALSA::AddPackets(uint8_t *data, unsigned int frames, bool ha
   if (!m_pcm)
     return 0;
 
-  if (snd_pcm_state(m_pcm) == SND_PCM_STATE_PREPARED)
-    snd_pcm_start(m_pcm);
-
   int ret;
 
   ret = snd_pcm_avail(m_pcm);
@@ -519,6 +516,9 @@ unsigned int CAESinkALSA::AddPackets(uint8_t *data, unsigned int frames, bool ha
       ret = 0;
     }
   }
+
+  if ( ret > 0 && snd_pcm_state(m_pcm) == SND_PCM_STATE_PREPARED)
+    snd_pcm_start(m_pcm);
 
   return ret;
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -331,7 +331,8 @@ void CAESinkWASAPI::Deinitialize()
   {
     try
     {
-    m_pAudioClient->Stop();
+    m_pAudioClient->Stop();  //stop the audio output
+    m_pAudioClient->Reset(); //flush buffer and reset audio clock stream position
     }
     catch (...)
     {
@@ -535,6 +536,27 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t *data, unsigned int frames, bool 
   }
 
   return NumFramesRequested;
+}
+
+bool CAESinkWASAPI::SoftSuspend()
+{
+  /* Sink has been asked to suspend output - we release audio   */
+  /* device as we are in exclusive mode and thus allow external */
+  /* audio sources to play. This requires us to reinitialize    */
+  /* on resume.                                                 */
+
+  Deinitialize();
+
+  return true;
+}
+
+bool CAESinkWASAPI::SoftResume()
+{
+  /* Sink asked to resume output. To release audio device in    */
+  /* exclusive mode we release the device context and therefore */
+  /* must reinitialize. Return false to force re-init by engine */
+
+  return false;
 }
 
 void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -43,6 +43,8 @@ public:
     virtual double       GetCacheTime                ();
     virtual double       GetCacheTotal               ();
     virtual unsigned int AddPackets                  (uint8_t *data, unsigned int frames, bool hasAudio);
+    virtual bool         SoftSuspend                 ();
+    virtual bool         SoftResume                  ();
     static  void         EnumerateDevicesEx          (AEDeviceInfoList &deviceInfoList);
 private:
     bool         InitializeExclusive(AEAudioFormat &format);
@@ -70,6 +72,7 @@ private:
 
     bool                m_running;
     bool                m_initialized;
+    bool                m_isSuspended;    /* sink is in a suspended state - release audio device */
     bool                m_isDirty;        /* sink output failed - needs re-init or new device */
 
     unsigned int        m_uiBufferLen;    /* wasapi endpoint buffer size, in frames */


### PR DESCRIPTION
Abstract softSuspend/Resume to sink to let it pre-process or decline a Suspend state.

This replaces previous behaviour of destroying the sink on suspend and allows the sink to shitdown gracefully or decline, as well as force a re-init on Resume if required.

Moved suspend/resume code to inline function to clean up SoftAE::Run() and added better comments

Written in light of reported issue with ALSA and Droid sinks on suspend. WASAPI has been implemented here - other platform help requested!
