### PR TITLE
Storing of TVDB Episode ID

### DIFF
--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -480,7 +480,7 @@ namespace JSONRPC
                   "\"firstaired\", \"playcount\", \"runtime\", \"director\","
                   "\"productioncode\", \"season\", \"episode\", \"originaltitle\","
                   "\"showtitle\", \"cast\", \"streamdetails\", \"lastplayed\", \"fanart\","
-                  "\"thumbnail\", \"file\", \"resume\", \"tvshowid\", \"dateadded\" ]"
+                  "\"thumbnail\", \"file\", \"resume\", \"tvshowid\", \"dateadded\", \"uniqueid\" ]"
       "}"
     "}",
     "\"Video.Fields.MusicVideo\": {"
@@ -661,6 +661,7 @@ namespace JSONRPC
         "\"productioncode\": { \"type\": \"string\" },"
         "\"season\": { \"type\": \"integer\" },"
         "\"episode\": { \"type\": \"integer\" },"
+        "\"uniqueid\": { \"type\": \"object\", \"additionalProperties\": { \"type\": \"string\", \"minLength\": 1 } },"
         "\"originaltitle\": { \"type\": \"string\" },"
         "\"showtitle\": { \"type\": \"string\" },"
         "\"cast\": { \"$ref\": \"Video.Cast\" },"

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -453,7 +453,7 @@
                 "firstaired", "playcount", "runtime", "director",
                 "productioncode", "season", "episode", "originaltitle",
                 "showtitle", "cast", "streamdetails", "lastplayed", "fanart",
-                "thumbnail", "file", "resume", "tvshowid", "dateadded" ]
+                "thumbnail", "file", "resume", "tvshowid", "dateadded", "uniqueid" ]
     }
   },
   "Video.Fields.MusicVideo": {
@@ -634,6 +634,7 @@
       "productioncode": { "type": "string" },
       "season": { "type": "integer" },
       "episode": { "type": "integer" },
+      "uniqueid": { "type": "object", "additionalProperties": { "type": "string", "minLength": 1 } },
       "originaltitle": { "type": "string" },
       "showtitle": { "type": "string" },
       "cast": { "$ref": "Video.Cast" },

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -252,6 +252,7 @@ std::string DatabaseUtils::GetField(Field field, MediaType mediaType, DatabaseQu
     else if (field == FieldDirector) result.Format("episodeview.c%02d", VIDEODB_ID_EPISODE_DIRECTOR);
     else if (field == FieldSeason) result.Format("episodeview.c%02d", VIDEODB_ID_EPISODE_SEASON);
     else if (field == FieldEpisodeNumber) result.Format("episodeview.c%02d", VIDEODB_ID_EPISODE_EPISODE);
+    else if (field == FieldUniqueId) result.Format("episodeview.c%02d", VIDEODB_ID_EPISODE_UNIQUEID);
     else if (field == FieldEpisodeNumberSpecialSort) result.Format("episodeview.c%02d", VIDEODB_ID_EPISODE_SORTEPISODE);
     else if (field == FieldSeasonSpecialSort) result.Format("episodeview.c%02d", VIDEODB_ID_EPISODE_SORTSEASON);
     else if (field == FieldFilename) return "episodeview.strFilename";
@@ -430,6 +431,7 @@ int DatabaseUtils::GetFieldIndex(Field field, MediaType mediaType)
     else if (field == FieldDirector) index = VIDEODB_ID_EPISODE_DIRECTOR;
     else if (field == FieldSeason) index = VIDEODB_ID_EPISODE_SEASON;
     else if (field == FieldEpisodeNumber) index = VIDEODB_ID_EPISODE_EPISODE;
+    else if (field == FieldUniqueId) index = VIDEODB_ID_EPISODE_UNIQUEID;
     else if (field == FieldEpisodeNumberSpecialSort) index = VIDEODB_ID_EPISODE_SORTEPISODE;
     else if (field == FieldSeasonSpecialSort) index = VIDEODB_ID_EPISODE_SORTSEASON;
     else if (field == FieldFilename) return VIDEODB_DETAILS_EPISODE_FILE;

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -92,6 +92,7 @@ typedef enum {
   FieldWriter,
   FieldAirDate,
   FieldEpisodeNumber,
+  FieldUniqueId,
   FieldSeason,
   FieldEpisodeNumberSpecialSort,
   FieldSeasonSpecialSort,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -259,6 +259,7 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_EPISODE_BOOKMARK = 17,
   VIDEODB_ID_EPISODE_BASEPATH = 18,
   VIDEODB_ID_EPISODE_PARENTPATHID = 19,
+  VIDEODB_ID_EPISODE_UNIQUEID = 20,
   VIDEODB_ID_EPISODE_MAX
 } VIDEODB_EPISODE_IDS;
 
@@ -283,7 +284,8 @@ const struct SDbTableOffsets DbEpisodeOffsets[] =
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iSpecialSortEpisode) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iBookmarkId) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
-  { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) }
+  { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) },
+  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strUniqueId) }
 };
 
 typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -70,6 +70,7 @@ void CVideoInfoTag::Reset()
   m_iYear = 0;
   m_iSeason = -1;
   m_iEpisode = -1;
+  m_strUniqueId.clear();
   m_iSpecialSortSeason = -1;
   m_iSpecialSortEpisode = -1;
   m_fRating = 0.0f;
@@ -120,6 +121,7 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathIn
   {
     XMLUtils::SetInt(movie, "season", m_iSeason);
     XMLUtils::SetInt(movie, "episode", m_iEpisode);
+    XMLUtils::SetString(movie, "uniqueid", m_strUniqueId);
     XMLUtils::SetInt(movie, "displayseason",m_iSpecialSortSeason);
     XMLUtils::SetInt(movie, "displayepisode",m_iSpecialSortEpisode);
   }
@@ -314,6 +316,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << m_iYear;
     ar << m_iSeason;
     ar << m_iEpisode;
+    ar << m_strUniqueId;
     ar << m_fRating;
     ar << m_iDbId;
     ar << m_iFileId;
@@ -391,6 +394,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_iYear;
     ar >> m_iSeason;
     ar >> m_iEpisode;
+    ar >> m_strUniqueId;
     ar >> m_fRating;
     ar >> m_iDbId;
     ar >> m_iFileId;
@@ -464,6 +468,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["year"] = m_iYear;
   value["season"] = m_iSeason;
   value["episode"] = m_iEpisode;
+  value["uniqueid"]["unknown"] = m_strUniqueId;
   value["rating"] = m_fRating;
   value["dbid"] = m_iDbId;
   value["fileid"] = m_iFileId;
@@ -570,6 +575,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   XMLUtils::GetInt(movie, "season", m_iSeason);
   XMLUtils::GetInt(movie, "episode", m_iEpisode);
   XMLUtils::GetInt(movie, "track", m_iTrack);
+  XMLUtils::GetString(movie, "uniqueid", m_strUniqueId);
   XMLUtils::GetInt(movie, "displayseason", m_iSpecialSortSeason);
   XMLUtils::GetInt(movie, "displayepisode", m_iSpecialSortEpisode);
   int after=0;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -120,6 +120,7 @@ public:
   int m_iYear;
   int m_iSeason;
   int m_iEpisode;
+  CStdString m_strUniqueId;
   int m_iDbId;
   int m_iFileId;
   int m_iSpecialSortSeason;


### PR DESCRIPTION
Following on from talking to myself http://forum.xbmc.org/showthread.php?tid=131803

Episodes can be in aired, DVD or absolute order. With this PR it's now easier to identify the episode. This helps with external sites like trakt but should also help with updating the information of an episode.
