### PR TITLE
Remove struct sepisode

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -46,6 +46,7 @@
 using namespace std;
 using namespace XFILE;
 using namespace MUSIC_GRABBER;
+using namespace VIDEO;
 
 namespace ADDON
 {

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -126,7 +126,7 @@ public:
     const CStdString &sAlbum, const CStdString &sArtist = "");
   std::vector<MUSIC_GRABBER::CMusicArtistInfo> FindArtist(
     XFILE::CCurlFile &fcurl, const CStdString &sArtist);
-  EPISODELIST GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl);
+  VIDEO::EPISODELIST GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl);
 
   bool GetVideoDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl,
     bool fMovie/*else episode*/, CVideoInfoTag &video);

--- a/xbmc/video/Episode.h
+++ b/xbmc/video/Episode.h
@@ -1,19 +1,26 @@
 #pragma once
 #include "utils/ScraperUrl.h"
+#include "XBDateTime.h"
 
 // single episode information
+namespace VIDEO
+{
 struct EPISODE
 {
+  bool isFolder;
   int iSeason;
   int iEpisode;
   int iSubepisode;
+  std::string strPath;
+  std::string strTitle;
   CDateTime cDate;
   CScraperUrl cScraperUrl;
-  EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0)
+  EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0, bool Folder = false)
   {
     iSeason = Season;
     iEpisode = Episode;
     iSubepisode = Subepisode;
+    isFolder = Folder;
   }
   bool operator==(const struct EPISODE& rhs)
   {
@@ -24,4 +31,5 @@ struct EPISODE
 };
 
 typedef std::vector<EPISODE> EPISODELIST;
+}
 

--- a/xbmc/video/Episode.h
+++ b/xbmc/video/Episode.h
@@ -5,31 +5,31 @@
 // single episode information
 namespace VIDEO
 {
-struct EPISODE
-{
-  bool isFolder;
-  int iSeason;
-  int iEpisode;
-  int iSubepisode;
-  std::string strPath;
-  std::string strTitle;
-  CDateTime cDate;
-  CScraperUrl cScraperUrl;
-  EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0, bool Folder = false)
+  struct EPISODE
   {
-    iSeason = Season;
-    iEpisode = Episode;
-    iSubepisode = Subepisode;
-    isFolder = Folder;
-  }
-  bool operator==(const struct EPISODE& rhs)
-  {
-    return (iSeason == rhs.iSeason &&
-            iEpisode == rhs.iEpisode &&
-            iSubepisode == rhs.iSubepisode);
-  }
-};
+    bool        isFolder;
+    int         iSeason;
+    int         iEpisode;
+    int         iSubepisode;
+    std::string strPath;
+    std::string strTitle;
+    CDateTime   cDate;
+    CScraperUrl cScraperUrl;
+    EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0, bool Folder = false)
+    {
+      iSeason     = Season;
+      iEpisode    = Episode;
+      iSubepisode = Subepisode;
+      isFolder    = Folder;
+    }
+    bool operator==(const struct EPISODE& rhs)
+    {
+      return (iSeason     == rhs.iSeason  &&
+              iEpisode    == rhs.iEpisode &&
+              iSubepisode == rhs.iSubepisode);
+    }
+  };
 
-typedef std::vector<EPISODE> EPISODELIST;
+  typedef std::vector<EPISODE> EPISODELIST;
 }
 

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -31,6 +31,7 @@
 #include "utils/URIUtils.h"
 
 using namespace std;
+using namespace VIDEO;
 
 #ifndef __GNUC__
 #pragma warning (disable:4018)

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -66,15 +66,15 @@ protected:
                       GET_EPISODE_LIST = 3,
                       GET_EPISODE_DETAILS = 4 };
 
-  XFILE::CCurlFile* m_http;
-  CStdString        m_strMovie;
-  MOVIELIST         m_movieList;
-  CVideoInfoTag     m_movieDetails;
-  CScraperUrl       m_url;
-  VIDEO::EPISODELIST       m_episode;
-  LOOKUP_STATE      m_state;
-  int               m_found;
-  ADDON::ScraperPtr m_info;
+  XFILE::CCurlFile*   m_http;
+  CStdString          m_strMovie;
+  MOVIELIST           m_movieList;
+  CVideoInfoTag       m_movieDetails;
+  CScraperUrl         m_url;
+  VIDEO::EPISODELIST  m_episode;
+  LOOKUP_STATE        m_state;
+  int                 m_found;
+  ADDON::ScraperPtr   m_info;
 
   // threaded stuff
   void Process();

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -55,7 +55,7 @@ public:
   int FindMovie(const CStdString& strMovie, MOVIELIST& movielist, CGUIDialogProgress *pProgress = NULL);
   bool GetDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
   bool GetEpisodeDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
-  bool GetEpisodeList(const CScraperUrl& url, EPISODELIST& details, CGUIDialogProgress *pProgress = NULL);
+  bool GetEpisodeList(const CScraperUrl& url, VIDEO::EPISODELIST& details, CGUIDialogProgress *pProgress = NULL);
 
   static void ShowErrorDialog(const ADDON::CScraperError &sce);
 
@@ -71,7 +71,7 @@ protected:
   MOVIELIST         m_movieList;
   CVideoInfoTag     m_movieDetails;
   CScraperUrl       m_url;
-  EPISODELIST       m_episode;
+  VIDEO::EPISODELIST       m_episode;
   LOOKUP_STATE      m_state;
   int               m_found;
   ADDON::ScraperPtr m_info;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -22,7 +22,6 @@
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
 #include "NfoFile.h"
-#include "XBDateTime.h"
 
 class CRegExp;
 
@@ -37,19 +36,6 @@ namespace VIDEO
     bool noupdate;          /* exclude from update library function */
     bool exclude;           /* exclude this path from scraping */
   } SScanSettings;
-
-  typedef struct SEpisode
-  {
-    CStdString strPath;
-    CStdString strTitle;
-    int iSeason;
-    int iEpisode;
-    int iSubepisode;
-    bool isFolder;
-    CDateTime cDate;
-  } SEpisode;
-
-  typedef std::vector<SEpisode> EPISODES;
 
   enum SCAN_STATE { PREPARING = 0, REMOVING_OLD, CLEANING_UP_DATABASE, FETCHING_MOVIE_INFO, FETCHING_MUSICVIDEO_INFO, FETCHING_TVSHOW_INFO, COMPRESSING_DATABASE, WRITING_CHANGES };
 
@@ -177,14 +163,14 @@ namespace VIDEO
      \param defaultSeason Season to use if not found in reg.
      \return true on success (2 matches), false on failure (fewer than 2 matches)
      */
-    bool GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo, int defaultSeason);
+    bool GetEpisodeAndSeasonFromRegExp(CRegExp &reg, EPISODE &episodeInfo, int defaultSeason);
 
     /*! \brief Extract episode air-date from a processed regexp
      \param reg Regular expression object with at least 3 matches
      \param episodeInfo Episode information to fill in.
      \return true on success (3 matches), false on failure (fewer than 3 matches)
      */
-    bool GetAirDateFromRegExp(CRegExp &reg, SEpisode &episodeInfo);
+    bool GetAirDateFromRegExp(CRegExp &reg, EPISODE &episodeInfo);
 
     /*! \brief Fetch thumbs for actors
      Updates each actor with their thumb (local or online)
@@ -225,11 +211,11 @@ namespace VIDEO
      \return INFO_ERROR on failure, INFO_CANCELLED on cancellation,
      INFO_NOT_FOUND if an episode isn't found, or INFO_ADDED if all episodes are added.
      */
-    INFO_RET OnProcessSeriesFolder(EPISODES& files, const ADDON::ScraperPtr &scraper, bool useLocal, int idShow, const CStdString& strShowTitle, CGUIDialogProgress* pDlgProgress = NULL);
+    INFO_RET OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, int idShow, const CStdString& strShowTitle, CGUIDialogProgress* pDlgProgress = NULL);
 
-    void EnumerateSeriesFolder(CFileItem* item, EPISODES& episodeList);
-    bool EnumerateEpisodeItem(const CFileItemPtr item, EPISODES& episodeList);
-    bool ProcessItemByVideoInfoTag(const CFileItemPtr item, EPISODES &episodeList);
+    void EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList);
+    bool EnumerateEpisodeItem(const CFileItemPtr item, EPISODELIST& episodeList);
+    bool ProcessItemByVideoInfoTag(const CFileItemPtr item, EPISODELIST &episodeList);
 
     CStdString GetnfoFile(CFileItem *item, bool bGrabAny=false) const;
 


### PR DESCRIPTION
This removes struct SEpisode as it is more or less dupe code with struct
EPISODE.  EPISODE has wider reach, so SEpisode dies. Instances of
SEpisode were replaced with EPISODE and their vector equivalents,
EPISODES and EPISODELIST respectively, app wide.
