### PR TITLE
FIX: Taglib: Problem reading embedded covers

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -365,10 +365,9 @@ bool CTagLoaderTagLib::ParseID3v2Tag(ID3v2::Tag *id3v2, EmbeddedArt *art, CMusic
     {
       string      mime =             pictures[i]->mimeType().toCString();
       TagLib::uint size =            pictures[i]->picture().size();
-      uint8_t*    data  = (uint8_t*) pictures[i]->picture().data();
       tag.SetCoverArtInfo(size, mime);
       if (art)
-        art->set(data, size, mime);
+        art->set((const uint8_t*)pictures[i]->picture().data(), size, mime);
       
       // Stop after we find the first picture for now.
       break;


### PR DESCRIPTION
I've noticed taglib couldn't read the music covers.

So, I've build taglib myself and tested with MinGW and have _empirically_ found out that this patch solves the problem.

I thinks the fix is due to using the "const" version of ID3v2::AttachedPictureFrame::picture()->data() rather than the non-const one, which does a "detach()", but I'm not sure.
