### PR TITLE
Resort and extend startup log information

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -656,6 +656,13 @@ bool CApplication::Create()
               g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (compiler %i). Platform: %s", g_infoManager.GetVersion().c_str(), __DATE__, _MSC_VER, g_sysinfo.GetKernelVersion().c_str());
+#endif
+#if defined(_DEBUG)
+  CLog::Log(LOGINFO, "Using Debug XBMC build");
+#elif defined(NDEBUG)
+  CLog::Log(LOGINFO, "Using Release XBMC build");
+#endif
+#if defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, g_cpuInfo.getCPUModel().c_str());
   CLog::Log(LOGNOTICE, CWIN32Util::GetResInfoString());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -643,13 +643,17 @@ bool CApplication::Create()
 
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
 #if defined(TARGET_DARWIN_OSX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: Darwin OSX (%s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: Darwin OSX (%s)", 
+              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_DARWIN_IOS)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: Darwin iOS (%s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: Darwin iOS (%s)",
+              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_FREEBSD)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: FreeBSD (%s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: FreeBSD (%s)",
+              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_POSIX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: Linux (%s, %s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: Linux (%s, %s)",
+              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (compiler %i). Platform: %s", g_infoManager.GetVersion().c_str(), __DATE__, _MSC_VER, g_sysinfo.GetKernelVersion().c_str());
   CLog::Log(LOGNOTICE, g_cpuInfo.getCPUModel().c_str());

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -643,19 +643,19 @@ bool CApplication::Create()
 
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
 #if defined(TARGET_DARWIN_OSX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: Darwin OSX (%s)", 
-              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: Darwin OSX (%s)", 
+              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_DARWIN_IOS)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: Darwin iOS (%s)",
-              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: Darwin iOS (%s)",
+              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_FREEBSD)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: FreeBSD (%s)",
-              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: FreeBSD (%s)",
+              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_POSIX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (GCC version %i.%i.%i). Platform: Linux (%s, %s)",
-              g_infoManager.GetVersion().c_str(), __DATE__, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: Linux (%s, %s)",
+              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_WINDOWS)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (compiler %i). Platform: %s", g_infoManager.GetVersion().c_str(), __DATE__, _MSC_VER, g_sysinfo.GetKernelVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (MSVC version %i). Platform: %s", g_infoManager.GetVersion().c_str(), _MSC_VER, g_sysinfo.GetKernelVersion().c_str());
 #endif
 #if defined(_DEBUG)
   CLog::Log(LOGINFO, "Using Debug XBMC build");

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -643,15 +643,15 @@ bool CApplication::Create()
 
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
 #if defined(TARGET_DARWIN_OSX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Platform: Darwin OSX (%s). Built on %s", g_infoManager.GetVersion().c_str(), g_sysinfo.GetUnameVersion().c_str(), __DATE__);
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: Darwin OSX (%s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_DARWIN_IOS)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Platform: Darwin iOS (%s). Built on %s", g_infoManager.GetVersion().c_str(), g_sysinfo.GetUnameVersion().c_str(), __DATE__);
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: Darwin iOS (%s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_FREEBSD)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Platform: FreeBSD (%s). Built on %s", g_infoManager.GetVersion().c_str(), g_sysinfo.GetUnameVersion().c_str(), __DATE__);
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: FreeBSD (%s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_POSIX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Platform: Linux (%s, %s). Built on %s", g_infoManager.GetVersion().c_str(), g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str(), __DATE__);
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s. Platform: Linux (%s, %s)", g_infoManager.GetVersion().c_str(), __DATE__, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_WINDOWS)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Platform: %s. Built on %s (compiler %i)", g_infoManager.GetVersion().c_str(), g_sysinfo.GetKernelVersion().c_str(), __DATE__, _MSC_VER);
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on %s (compiler %i). Platform: %s", g_infoManager.GetVersion().c_str(), __DATE__, _MSC_VER, g_sysinfo.GetKernelVersion().c_str());
   CLog::Log(LOGNOTICE, g_cpuInfo.getCPUModel().c_str());
   CLog::Log(LOGNOTICE, CWIN32Util::GetResInfoString());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -663,8 +663,8 @@ bool CApplication::Create()
   CLog::Log(LOGINFO, "Using Release XBMC build");
 #endif
 #if defined(TARGET_WINDOWS)
-  CLog::Log(LOGNOTICE, g_cpuInfo.getCPUModel().c_str());
-  CLog::Log(LOGNOTICE, CWIN32Util::GetResInfoString());
+  CLog::Log(LOGNOTICE, "%s", g_cpuInfo.getCPUModel().c_str());
+  CLog::Log(LOGNOTICE, "%s", CWIN32Util::GetResInfoString().c_str());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");
   CLog::Log(LOGNOTICE, "Aero is %s", (g_sysinfo.IsAeroDisabled() == true) ? "disabled" : "enabled");
 #endif


### PR DESCRIPTION
- Resort XBMC information (from "XBMC ... . Platform... build..." to "XBMC ... build... Platform... " )
- Add compiler information to log
- Add debug/release information to log
