### PR TITLE
Correction of a big mistranslation

### DIFF
--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -8068,7 +8068,7 @@ msgstr "ce chemin de la médiathèque ?"
 
 msgctxt "#20342"
 msgid "Movies"
-msgstr "Retirer le clip musical de la Médiathèque"
+msgstr "Films"
 
 msgctxt "#20343"
 msgid "TV shows"


### PR DESCRIPTION
**Movies** is simply translated to **Films** in French, not to **Retirer le clip de la médiathèque**
