### PR TITLE
Metadata

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -80,10 +80,11 @@
 
 #define PLT_FILTER_MASK_LONGDESCRIPTION             0x04000000
 #define PLT_FILTER_MASK_ICON                        0x08000000
+#define PLT_FILTER_MASK_RATING                      0x10000000
 
-#define PLT_FILTER_MASK_TOC                         0x10000000
-#define PLT_FILTER_MASK_SEARCHCLASS                 0x20000000
-#define PLT_FILTER_MASK_REFID                       0x40000000
+#define PLT_FILTER_MASK_TOC                         0x20000000
+#define PLT_FILTER_MASK_SEARCHCLASS                 0x40000000
+#define PLT_FILTER_MASK_REFID                       0x80000000
 
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
@@ -99,6 +100,7 @@
 #define PLT_FILTER_FIELD_DESCRIPTION                "dc:description"
 #define PLT_FILTER_FIELD_LONGDESCRIPTION            "upnp:longDescription"
 #define PLT_FILTER_FIELD_ICON                       "upnp:icon"
+#define PLT_FILTER_FIELD_RATING                     "upnp:rating"
 #define PLT_FILTER_FIELD_ORIGINALTRACK              "upnp:originalTrackNumber"
 #define PLT_FILTER_FIELD_PROGRAMTITLE               "upnp:programTitle"
 #define PLT_FILTER_FIELD_SERIESTITLE                "upnp:seriesTitle"

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -61,28 +61,29 @@
 #define PLT_FILTER_MASK_ORIGINALTRACK               0x00000100
 #define PLT_FILTER_MASK_ACTOR                       0x00000200
 #define PLT_FILTER_MASK_AUTHOR                      0x00000400
-#define PLT_FILTER_MASK_DATE                        0x00000800
-#define PLT_FILTER_MASK_PROGRAMTITLE                0x00001000
-#define PLT_FILTER_MASK_SERIESTITLE                 0x00002000
-#define PLT_FILTER_MASK_EPISODE                     0x00004000
-#define PLT_FILTER_MASK_TITLE                       0x00008000
+#define PLT_FILTER_MASK_DIRECTOR                    0x00000800
+#define PLT_FILTER_MASK_DATE                        0x00001000
+#define PLT_FILTER_MASK_PROGRAMTITLE                0x00002000
+#define PLT_FILTER_MASK_SERIESTITLE                 0x00004000
+#define PLT_FILTER_MASK_EPISODE                     0x00008000
+#define PLT_FILTER_MASK_TITLE                       0x00010000
 
-#define PLT_FILTER_MASK_RES                         0x00010000
-#define PLT_FILTER_MASK_RES_DURATION                0x00020000
-#define PLT_FILTER_MASK_RES_SIZE                    0x00040000
-#define PLT_FILTER_MASK_RES_PROTECTION              0x00080000
-#define PLT_FILTER_MASK_RES_RESOLUTION              0x00100000
-#define PLT_FILTER_MASK_RES_BITRATE                 0x00200000
-#define PLT_FILTER_MASK_RES_BITSPERSAMPLE           0x00400000
-#define PLT_FILTER_MASK_RES_NRAUDIOCHANNELS			0x00800000
-#define PLT_FILTER_MASK_RES_SAMPLEFREQUENCY			0x01000000
+#define PLT_FILTER_MASK_RES                         0x00020000
+#define PLT_FILTER_MASK_RES_DURATION                0x00040000
+#define PLT_FILTER_MASK_RES_SIZE                    0x00080000
+#define PLT_FILTER_MASK_RES_PROTECTION              0x00100000
+#define PLT_FILTER_MASK_RES_RESOLUTION              0x00200000
+#define PLT_FILTER_MASK_RES_BITRATE                 0x00400000
+#define PLT_FILTER_MASK_RES_BITSPERSAMPLE           0x00800000
+#define PLT_FILTER_MASK_RES_NRAUDIOCHANNELS         0x01000000
+#define PLT_FILTER_MASK_RES_SAMPLEFREQUENCY         0x02000000
 
-#define PLT_FILTER_MASK_LONGDESCRIPTION             0x02000000
-#define PLT_FILTER_MASK_ICON                        0x04000000
+#define PLT_FILTER_MASK_LONGDESCRIPTION             0x04000000
+#define PLT_FILTER_MASK_ICON                        0x08000000
 
-#define PLT_FILTER_MASK_TOC							0x02000000
-#define PLT_FILTER_MASK_SEARCHCLASS					0x04000000
-#define PLT_FILTER_MASK_REFID                       0x08000000
+#define PLT_FILTER_MASK_TOC                         0x10000000
+#define PLT_FILTER_MASK_SEARCHCLASS                 0x20000000
+#define PLT_FILTER_MASK_REFID                       0x40000000
 
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
@@ -90,6 +91,7 @@
 #define PLT_FILTER_FIELD_ARTIST                     "upnp:artist"
 #define PLT_FILTER_FIELD_ACTOR                      "upnp:actor"
 #define PLT_FILTER_FIELD_AUTHOR                     "upnp:author"
+#define PLT_FILTER_FIELD_DIRECTOR                   "upnp:director"
 #define PLT_FILTER_FIELD_ALBUM                      "upnp:album"
 #define PLT_FILTER_FIELD_GENRE                      "upnp:genre"
 #define PLT_FILTER_FIELD_ALBUMARTURI                "upnp:albumArtURI"

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -183,6 +183,9 @@ PLT_MediaObject::Reset()
     m_ExtraInfo.artist_discography_uri = "";
 
     m_MiscInfo.original_track_number = 0;
+    m_MiscInfo.last_position         = 0;
+    m_MiscInfo.last_time             = "";
+    m_MiscInfo.play_count            = -1;
     m_MiscInfo.dvdregioncode		 = 0;
     m_MiscInfo.toc					 = "";
     m_MiscInfo.user_annotation		 = "";
@@ -315,6 +318,27 @@ PLT_MediaObject::ToDidl(NPT_UInt32 mask, NPT_String& didl)
         didl += "<upnp:originalTrackNumber>";
         didl += NPT_String::FromInteger(m_MiscInfo.original_track_number);
         didl += "</upnp:originalTrackNumber>";
+    }
+
+    // last playback position
+    if (m_MiscInfo.last_position > 0) {
+        didl += "<upnp:lastPlaybackPosition>";
+        didl += NPT_String::FromInteger(m_MiscInfo.last_position);
+        didl += "</upnp:lastPlaybackPosition>";
+    }
+
+    // last playback datetime
+    if (!m_MiscInfo.last_time.IsEmpty()) {
+        didl += "<upnp:lastPlaybackTime>";
+        PLT_Didl::AppendXmlEscape(didl, m_MiscInfo.last_time);
+        didl += "</upnp:lastPlaybackTime>";
+    }
+
+    // playcount
+    if (m_MiscInfo.play_count > -1) {
+        didl += "<upnp:playbackCount>";
+        didl += NPT_String::FromInteger(m_MiscInfo.play_count);
+        didl += "</upnp:playbackCount>";
     }
 
     // program title
@@ -510,6 +534,25 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
     PLT_XmlHelper::GetChildText(entry, "originalTrackNumber", str, didl_namespace_upnp);
     if (NPT_FAILED(str.ToInteger(value))) value = 0;
     m_MiscInfo.original_track_number = value;
+
+    PLT_XmlHelper::GetChildText(entry, "lastPlaybackPosition", str, didl_namespace_upnp);
+    if (NPT_FAILED(str.ToInteger(value))) value = 0;
+    m_MiscInfo.last_position = value;
+
+    PLT_XmlHelper::GetChildText(entry, "lastPlaybackTime", m_MiscInfo.last_time, didl_namespace_dc, 256);
+    NPT_String parsed_last_time;
+    for (int format=0; format<=NPT_DateTime::FORMAT_RFC_1036; format++) {
+        NPT_DateTime date;
+        if (NPT_SUCCEEDED(date.FromString(m_MiscInfo.last_time, (NPT_DateTime::Format)format))) {
+            parsed_last_time = date.ToString((NPT_DateTime::Format)format);
+            break;
+        }
+    }
+    m_MiscInfo.last_time = parsed_last_time;
+
+    PLT_XmlHelper::GetChildText(entry, "playbackCount", str, didl_namespace_upnp);
+    if (NPT_FAILED(str.ToInteger(value))) value = -1;
+    m_MiscInfo.play_count = value;
 
     children.Clear();
     PLT_XmlHelper::GetChildren(entry, children, "res");

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -253,6 +253,11 @@ PLT_MediaObject::ToDidl(NPT_UInt32 mask, NPT_String& didl)
         m_People.authors.ToDidl(didl, "author");
     }
     
+    // director
+    if (mask & PLT_FILTER_MASK_DIRECTOR) {
+        m_People.directors.ToDidl(didl, "director");
+    }
+
     // album
     if ((mask & PLT_FILTER_MASK_ALBUM) && !m_Affiliation.album.IsEmpty()) {
         didl += "<upnp:album>";
@@ -489,14 +494,21 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
     m_Title = m_Title.SubString(0, 256);    
     m_ObjectClass.type =  m_ObjectClass.type.SubString(0, 256);
 
+    children.Clear();
     PLT_XmlHelper::GetChildren(entry, children, "artist", didl_namespace_upnp);
     m_People.artists.FromDidl(children);
     
+    children.Clear();
     PLT_XmlHelper::GetChildren(entry, children, "author", didl_namespace_upnp);
     m_People.authors.FromDidl(children);
     
+    children.Clear();
     PLT_XmlHelper::GetChildren(entry, children, "actors", didl_namespace_upnp);
     m_People.actors.FromDidl(children);
+
+    children.Clear();
+    PLT_XmlHelper::GetChildren(entry, children, "director", didl_namespace_upnp);
+    m_People.directors.FromDidl(children);
 
     PLT_XmlHelper::GetChildText(entry, "album", m_Affiliation.album, didl_namespace_upnp, 256);
     PLT_XmlHelper::GetChildText(entry, "programTitle", m_Recorded.program_title, didl_namespace_upnp);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -318,6 +318,13 @@ PLT_MediaObject::ToDidl(NPT_UInt32 mask, NPT_String& didl)
         didl += "</upnp:icon>";
     }
 
+    // rating
+    if ((mask & PLT_FILTER_MASK_RATING) && !m_Description.rating.IsEmpty()) {
+        didl += "<upnp:rating>";
+        PLT_Didl::AppendXmlEscape(didl, m_Description.rating);
+        didl += "</upnp:rating>";
+    }
+
     // original track number
     if ((mask & PLT_FILTER_MASK_ORIGINALTRACK) && m_MiscInfo.original_track_number > 0) {
         didl += "<upnp:originalTrackNumber>";
@@ -529,6 +536,7 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
     PLT_XmlHelper::GetChildText(entry, "description", m_Description.description, didl_namespace_dc);
     PLT_XmlHelper::GetChildText(entry, "longDescription", m_Description.long_description, didl_namespace_upnp);
     PLT_XmlHelper::GetChildText(entry, "icon", m_Description.icon_uri, didl_namespace_upnp);
+    PLT_XmlHelper::GetChildText(entry, "rating", m_Description.rating, didl_namespace_upnp);
 	PLT_XmlHelper::GetChildText(entry, "toc", m_MiscInfo.toc, didl_namespace_upnp);
     
     // album arts

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -91,7 +91,7 @@ typedef struct {
     PLT_PersonRoles actors;
     PLT_PersonRoles authors;
     NPT_String      producer; //TODO: can be multiple
-    NPT_String      director; //TODO: can be multiple
+    PLT_PersonRoles directors;
     NPT_String      publisher; //TODO: can be multiple
     NPT_String      contributor; // should match m_Creator (dc:creator) //TODO: can be multiple
 } PLT_PeopleInfo;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -130,6 +130,9 @@ typedef struct {
     NPT_UInt32 original_track_number;
     NPT_String toc;
     NPT_String user_annotation; //TODO: can be multiple
+    NPT_UInt32 last_position;
+    NPT_String last_time;
+    NPT_Int32  play_count;
 } PLT_MiscInfo;
 
 typedef struct {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
@@ -202,8 +202,8 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_BrowseDataReference& browse_data,
                                  const char*              object_id, 
                                  NPT_Int32                index, 
                                  NPT_Int32                count,
-                                 bool                     browse_metadata,
                                  const char*              filter, 
+                                 bool                     browse_metadata,
                                  const char*              sort)
 {
     NPT_Result res;
@@ -236,7 +236,8 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_DeviceDataReference&      device,
                                  PLT_MediaObjectListReference& list,
                                  bool                          metadata, /* = false */
                                  NPT_Int32                     start, /* = 0 */
-                                 NPT_Cardinal                  max_results /* = 0 */)
+                                 NPT_Cardinal                  max_results, /* = 0 */
+                                 const char*                   filter)
 {
     NPT_Result res = NPT_FAILURE;
     NPT_Int32  index = start;
@@ -263,6 +264,7 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_DeviceDataReference&      device,
             (const char*)object_id,
             index,
             metadata?1:30, // DLNA recommendations for browsing children is no more than 30 at a time
+            filter,
             metadata);		
         NPT_CHECK_LABEL_WARNING(res, done);
         

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -106,7 +106,8 @@ public:
                           PLT_MediaObjectListReference& list,
                           bool                          metadata = false,
                           NPT_Int32                     start = 0,
-                          NPT_Cardinal                  max_results = 0); // 0 means all
+                          NPT_Cardinal                  max_results = 0,
+                          const char*                   filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author,searchable,childCount"); // explicitely specify res otherwise WMP won't return a URL!
 
     const NPT_Lock<PLT_DeviceMap>& GetMediaServersMap() const { return m_MediaServers; }
     bool IsCached(const char* uuid, const char* object_id);
@@ -117,8 +118,8 @@ protected:
                           const char*              object_id,
                           NPT_Int32                index, 
                           NPT_Int32                count,
+                          const char*              filter,
                           bool                     browse_metadata = false,
-                          const char*              filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author,searchable,childCount", // explicitely specify res otherwise WMP won't return a URL!
                           const char*              sort = "");
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);

--- a/xbmc/filesystem/NptXbmcFile.cpp
+++ b/xbmc/filesystem/NptXbmcFile.cpp
@@ -321,13 +321,6 @@ NPT_XbmcFile::Open(NPT_File::OpenMode mode)
 
         bool result;
         CURL* url = new CURL(name);
-        /* path is not fully qualified so assume it's relative to home dir */
-        if (url->GetFileName().IsEmpty()) {
-            delete url;
-            CStdString homepath;
-            CUtil::GetHomePath(homepath);
-            url = new CURL(homepath + "/" + name);
-        }
 
         // compute mode
         if (mode & NPT_FILE_OPEN_MODE_WRITE) {

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -472,6 +472,10 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
                     break;
                 }
             }
+            // HACK set the watched overlay, as this will not be set later due to
+            // content set on file item list
+            if (pItem->IsVideo())
+              pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_playCount > 0);
             items.Add(pItem);
 
             ++entry;

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -477,10 +477,24 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
                     break;
                 }
             }
-            // HACK set the watched overlay, as this will not be set later due to
+            // set the watched overlay, as this will not be set later due to
             // content set on file item list
-            if (pItem->IsVideo())
-              pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_playCount > 0);
+            if (pItem->HasVideoInfoTag()) {
+                int episodes = pItem->GetVideoInfoTag()->m_iEpisode;
+                int played   = pItem->GetVideoInfoTag()->m_playCount;
+                const std::string& type = pItem->GetVideoInfoTag()->m_type;
+                bool watched(false);
+                if (type == "tvshow" || type == "season") {
+                    pItem->SetProperty("totalepisodes", episodes);
+                    pItem->SetProperty("numepisodes", episodes);
+                    pItem->SetProperty("watchedepisodes", played);
+                    pItem->SetProperty("unwatchedepisodes", episodes - played);
+                    watched = (episodes && played == episodes);
+                }
+                else if (type == "episode")
+                    watched = played;
+                pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, watched);
+            }
             items.Add(pItem);
 
             ++entry;

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -355,10 +355,15 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
         }
 #endif
 
+
+        // Browse and wait for result
+        PLT_MediaObjectListReference list;
+        NPT_Result res;
+        // we want all properties, so send empty filter
+        res = upnp->m_MediaBrowser->BrowseSync(device, object_id, list, false, 0, 0, "");
+
         // if error, return now, the device could have gone away
         // this will make us go back to the sources list
-        PLT_MediaObjectListReference list;
-        NPT_Result res = upnp->m_MediaBrowser->BrowseSync(device, object_id, list);
         if (NPT_FAILED(res)) goto failure;
 
         // empty list is ok

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -206,6 +206,9 @@ PopulateObjectFromTag(CMusicInfoTag&         tag,
     if (object.m_ReferenceID == object.m_ObjectID)
         object.m_ReferenceID = "";
 
+    object.m_MiscInfo.last_time = tag.GetLastPlayed().GetAsLocalizedDate();
+    object.m_MiscInfo.play_count = tag.GetPlayCount();
+
     if (resource) resource->m_Duration = tag.GetDuration();
 
     return NPT_SUCCESS;
@@ -271,6 +274,9 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
 
     object.m_Description.description = tag.m_strTagLine;
     object.m_Description.long_description = tag.m_strPlot;
+    object.m_MiscInfo.last_position = tag.m_resumePoint.timeInSeconds;
+    object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsLocalizedDate();
+    object.m_MiscInfo.play_count = tag.m_playCount;
     if (resource) resource->m_Duration = tag.m_streamDetails.GetVideoDuration();
     if (resource) resource->m_Resolution = NPT_String::FromInteger(tag.m_streamDetails.GetVideoWidth()) + "x" + NPT_String::FromInteger(tag.m_streamDetails.GetVideoHeight());
 
@@ -574,6 +580,10 @@ PopulateTagFromObject(CMusicInfoTag&          tag,
         tag.SetGenre((const char*) *it);
 
     tag.SetAlbum((const char*)object.m_Affiliation.album);
+    CDateTime last;
+    last.SetFromDateString((const char*)object.m_MiscInfo.last_time);
+    tag.SetLastPlayed(last);
+    tag.SetPlayCount(object.m_MiscInfo.play_count);
     if(resource)
         tag.SetDuration(resource->m_Duration);
     tag.SetLoaded();
@@ -616,9 +626,18 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     tag.m_strTagLine  = object.m_Description.description;
     tag.m_strPlot     = object.m_Description.long_description;
     tag.m_strShowTitle = object.m_Recorded.series_title;
+    tag.m_lastPlayed.SetFromDateString((const char*)object.m_MiscInfo.last_time);
+    tag.m_playCount = object.m_MiscInfo.play_count;
 
     if(resource)
+    {
       tag.m_strRuntime.Format("%d",resource->m_Duration);
+      if (object.m_MiscInfo.last_position > 0 )
+      {
+        tag.m_resumePoint.totalTimeInSeconds = resource->m_Duration;
+        tag.m_resumePoint.timeInSeconds = object.m_MiscInfo.last_position;
+      }
+    }
     return NPT_SUCCESS;
 }
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -280,6 +280,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
 
     object.m_Description.description = tag.m_strTagLine;
     object.m_Description.long_description = tag.m_strPlot;
+    object.m_Description.rating = tag.m_strMPAARating;
     object.m_MiscInfo.last_position = tag.m_resumePoint.timeInSeconds;
     object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsLocalizedDate();
     object.m_MiscInfo.play_count = tag.m_playCount;
@@ -650,6 +651,7 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
       tag.m_writingCredits.push_back(object.m_People.authors.GetItem(index)->name.GetChars());
     tag.m_strTagLine  = object.m_Description.description;
     tag.m_strPlot     = object.m_Description.long_description;
+    tag.m_strMPAARating = object.m_Description.rating;
     tag.m_strShowTitle = object.m_Recorded.series_title;
     tag.m_lastPlayed.SetFromDateString((const char*)object.m_MiscInfo.last_time);
     tag.m_playCount = object.m_MiscInfo.play_count;

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -210,7 +210,7 @@ PopulateObjectFromTag(CMusicInfoTag&         tag,
     if (object.m_ReferenceID == object.m_ObjectID)
         object.m_ReferenceID = "";
 
-    object.m_MiscInfo.last_time = tag.GetLastPlayed().GetAsLocalizedDate();
+    object.m_MiscInfo.last_time = tag.GetLastPlayed().GetAsDBDate();
     object.m_MiscInfo.play_count = tag.GetPlayCount();
 
     if (resource) resource->m_Duration = tag.GetDuration();
@@ -254,7 +254,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
           int season = tag.m_iSeason > 1 ? tag.m_iSeason : 1;
           object.m_Recorded.episode_number = season * 100 + tag.m_iEpisode;
           object.m_Title = object.m_Recorded.series_title + " - " + object.m_Recorded.program_title;
-          object.m_Date = tag.m_firstAired.GetAsLocalizedDate();
+          object.m_Date = tag.m_firstAired.GetAsDBDate();
           if(tag.m_iSeason != -1)
               object.m_ReferenceID = NPT_String::Format("videodb://2/0/%i", tag.m_iDbId);
         }
@@ -283,7 +283,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     object.m_Description.long_description = tag.m_strPlot;
     object.m_Description.rating = tag.m_strMPAARating;
     object.m_MiscInfo.last_position = tag.m_resumePoint.timeInSeconds;
-    object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsLocalizedDate();
+    object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsDBDate();
     object.m_MiscInfo.play_count = tag.m_playCount;
     if (resource) {
         if (tag.HasStreamDetails()) {
@@ -370,7 +370,7 @@ BuildObject(CFileItem&                    item,
 
         // set date
         if (object->m_Date.IsEmpty() && item.m_dateTime.IsValid()) {
-            object->m_Date = item.m_dateTime.GetAsLocalizedDate();
+            object->m_Date = item.m_dateTime.GetAsDBDate();
         }
 
         if (upnp_server) {
@@ -479,7 +479,7 @@ BuildObject(CFileItem&                    item,
                   if(!tag.m_firstAired.IsValid() && tag.m_iYear)
                     container->m_Date = NPT_String::FromInteger(tag.m_iYear) + "-01-01";
                   else
-                    container->m_Date = tag.m_firstAired.GetAsLocalizedDate();
+                    container->m_Date = tag.m_premiered.GetAsDBDate();
 
                   for (unsigned int index = 0; index < tag.m_genre.size(); index++)
                     container->m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -346,11 +346,6 @@ BuildObject(const CFileItem&              item,
 
         // Set the resource file size
         resource.m_Size = item.m_dwSize;
-        if (resource.m_Size == 0) {
-            struct __stat64 info;
-            if(CFile::Stat((const char*)file_path, &info) == 0 && info.st_size >= 0)
-              resource.m_Size = info.st_size;
-        }
         if(resource.m_Size == 0)
           resource.m_Size = (NPT_LargeSize)-1;
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -272,7 +272,9 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
         object.m_People.actors.Add(it->strName.c_str(), it->strRole.c_str());
     }
 
-    object.m_People.director = StringUtils::Join(tag.m_director, g_advancedSettings.m_videoItemSeparator);
+    for (unsigned int index = 0; index < tag.m_director.size(); index++)
+      object.m_People.directors.Add(tag.m_director[index].c_str());
+
     for (unsigned int index = 0; index < tag.m_writingCredits.size(); index++)
       object.m_People.authors.Add(tag.m_writingCredits[index].c_str());
 
@@ -486,7 +488,8 @@ BuildObject(CFileItem&                    item,
                       container->m_People.actors.Add(it->strName.c_str(), it->strRole.c_str());
                   }
 
-                  container->m_People.director = StringUtils::Join(tag.m_director, g_advancedSettings.m_videoItemSeparator);;
+                  for (unsigned int index = 0; index < tag.m_director.size(); index++)
+                    container->m_People.directors.Add(tag.m_director[index].c_str());
                   for (unsigned int index = 0; index < tag.m_writingCredits.size(); index++)
                     container->m_People.authors.Add(tag.m_writingCredits[index].c_str());
 
@@ -641,7 +644,10 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     tag.m_iYear       = date.GetYear();
     for (unsigned int index = 0; index < object.m_Affiliation.genres.GetItemCount(); index++)
       tag.m_genre.push_back(object.m_Affiliation.genres.GetItem(index)->GetChars());
-    tag.m_director = StringUtils::Split((CStdString)object.m_People.director, g_advancedSettings.m_videoItemSeparator);
+    for (unsigned int index = 0; index < object.m_People.directors.GetItemCount(); index++)
+      tag.m_director.push_back(object.m_People.directors.GetItem(index)->name.GetChars());
+    for (unsigned int index = 0; index < object.m_People.authors.GetItemCount(); index++)
+      tag.m_writingCredits.push_back(object.m_People.authors.GetItem(index)->name.GetChars());
     tag.m_strTagLine  = object.m_Description.description;
     tag.m_strPlot     = object.m_Description.long_description;
     tag.m_strShowTitle = object.m_Recorded.series_title;

--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -21,9 +21,11 @@
 #include "system.h"
 #include "utils/StdString.h"
 #include "NptTypes.h"
+#include "NptReferences.h"
 
 class CUPnPServer;
 class CFileItem;
+class CThumbLoader;
 class PLT_HttpRequestContext;
 class PLT_MediaItemResource;
 class PLT_MediaObject;
@@ -78,9 +80,10 @@ namespace UPNP
                                           PLT_MediaItemResource* resource,
                                           EClientQuirks          quirks);
 
-  PLT_MediaObject* BuildObject(const CFileItem&              item,
+  PLT_MediaObject* BuildObject(CFileItem&              item,
                                       NPT_String&                   file_path,
                                       bool                          with_count,
+                                      NPT_Reference<CThumbLoader>&  thumb_loader,
                                       const PLT_HttpRequestContext* context = NULL,
                                       CUPnPServer*                  upnp_server = NULL);
 

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -10,6 +10,9 @@
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
 #include "settings/Settings.h"
+#include "TextureCache.h"
+#include "ThumbLoader.h"
+#include "URL.h"
 #include "utils/URIUtils.h"
 
 namespace UPNP
@@ -119,7 +122,7 @@ CUPnPRenderer::SetupServices()
 |   CUPnPRenderer::ProcessHttpRequest
 +---------------------------------------------------------------------*/
 NPT_Result
-CUPnPRenderer::ProcessHttpRequest(NPT_HttpRequest&              request,
+CUPnPRenderer::ProcessHttpGetRequest(NPT_HttpRequest&              request,
                                   const NPT_HttpRequestContext& context,
                                   NPT_HttpResponse&             response)
 {
@@ -129,7 +132,7 @@ CUPnPRenderer::ProcessHttpRequest(NPT_HttpRequest&              request,
     NPT_String  protocol   = request.GetProtocol();
     NPT_HttpUrl url        = request.GetUrl();
 
-    if (url.GetPath() == "/thumb.jpg") {
+    if (url.GetPath() == "/thumb") {
         NPT_HttpUrlQuery query(url.GetQuery());
         NPT_String filepath = query.GetField("path");
         if (!filepath.IsEmpty()) {
@@ -143,20 +146,14 @@ CUPnPRenderer::ProcessHttpRequest(NPT_HttpRequest&              request,
                 return NPT_SUCCESS;
             }
 
-            // ensure that the request's path is a valid thumb path
-            if (URIUtils::IsRemote(filepath.GetChars()) ||
-                !filepath.StartsWith(g_settings.GetUserDataFolder())) {
-                response.SetStatus(404, "Not Found");
-                return NPT_SUCCESS;
-            }
-
             // prevent hackers from accessing files outside of our root
             if ((filepath.Find("/..") >= 0) || (filepath.Find("\\..") >=0)) {
                 return NPT_FAILURE;
             }
 
             // open the file
-            NPT_File file(filepath);
+            CStdString path = CURL::Decode((const char*) filepath);
+            NPT_File file(path.c_str());
             NPT_Result result = file.Open(NPT_FILE_OPEN_MODE_READ);
             if (NPT_FAILED(result)) {
                 response.SetStatus(404, "Not Found");
@@ -285,12 +282,22 @@ NPT_Result
 CUPnPRenderer::GetMetadata(NPT_String& meta)
 {
     NPT_Result res = NPT_FAILURE;
-    const CFileItem &item = g_application.CurrentFileItem();
+    CFileItem item(g_application.CurrentFileItem());
     NPT_String file_path, tmp;
-    PLT_MediaObject* object = BuildObject(item, file_path, false);
+
+    // we pass an empty CThumbLoader reference, as it can't be used
+    // without CUPnPServer enabled
+    NPT_Reference<CThumbLoader> thumb_loader;
+    PLT_MediaObject* object = BuildObject(item, file_path, false, thumb_loader, false);
     if (object) {
-        // fetch the path to the thumbnail
-        CStdString thumb = g_infoManager.GetImage(MUSICPLAYER_COVER, -1); //TODO: Only audio for now
+        // fetch the item's artwork
+        CStdString thumb;
+        if (object->m_ObjectClass.type == "object.item.audioItem.musicTrack")
+            thumb = g_infoManager.GetImage(MUSICPLAYER_COVER, -1);
+        else
+            thumb = g_infoManager.GetImage(VIDEOPLAYER_COVER, -1);
+
+        thumb = CTextureCache::GetWrappedImageURL(thumb);
 
         NPT_String ip;
         if (g_application.getNetwork().GetFirstConnectedInterface()) {
@@ -303,9 +310,15 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
 	art.uri = NPT_HttpUrl(
             ip,
             m_URLDescription.GetPort(),
-            "/thumb.jpg",
+            "/thumb",
             query.ToString()).ToString();
-        art.dlna_profile = "JPEG_TN";
+        // Set DLNA profileID by extension, defaulting to JPEG.
+        NPT_String ext = URIUtils::GetExtension(item.GetArt("thumb")).c_str();
+        if (strcmp(ext, ".png") == 0) {
+            art.dlna_profile = "PNG_TN";
+        } else {
+            art.dlna_profile = "JPEG_TN";
+        }
 	object->m_ExtraInfo.album_arts.Add(art);
 
         res = PLT_Didl::ToDidl(*object, "*", tmp);

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -286,7 +286,7 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
 {
     NPT_Result res = NPT_FAILURE;
     const CFileItem &item = g_application.CurrentFileItem();
-    NPT_String file_path;
+    NPT_String file_path, tmp;
     PLT_MediaObject* object = BuildObject(item, file_path, false);
     if (object) {
         // fetch the path to the thumbnail
@@ -308,7 +308,8 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
         art.dlna_profile = "JPEG_TN";
 	object->m_ExtraInfo.album_arts.Add(art);
 
-        res = PLT_Didl::ToDidl(*object, "*", meta);
+        res = PLT_Didl::ToDidl(*object, "*", tmp);
+        meta = didl_header + tmp + didl_footer;
         delete object;
     }
     return res;

--- a/xbmc/network/upnp/UPnPRenderer.h
+++ b/xbmc/network/upnp/UPnPRenderer.h
@@ -40,9 +40,9 @@ public:
     void UpdateState();
 
     // Http server handler
-    virtual NPT_Result ProcessHttpRequest(NPT_HttpRequest&              request,
-                                          const NPT_HttpRequestContext& context,
-                                          NPT_HttpResponse&             response);
+    virtual NPT_Result ProcessHttpGetRequest(NPT_HttpRequest&              request,
+                                             const NPT_HttpRequestContext& context,
+                                             NPT_HttpResponse&             response);
 
     // AVTransport methods
     virtual NPT_Result OnNext(PLT_ActionReference& action);

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -75,6 +75,7 @@ PLT_MediaObject*
 CUPnPServer::Build(CFileItemPtr                  item,
                    bool                          with_count,
                    const PLT_HttpRequestContext& context,
+                   NPT_Reference<CThumbLoader>&  thumb_loader,
                    const char*                   parent_id /* = NULL */)
 {
     PLT_MediaObject* object = NULL;
@@ -117,9 +118,6 @@ CUPnPServer::Build(CFileItemPtr                  item,
             } else {
                 if (!item->HasMusicInfoTag())
                     item->LoadMusicTag();
-
-                if (!item->HasArt("thumb") )
-                    item->SetArt("thumb", CThumbLoader::GetCachedImage(*item, "thumb"));
 
                 if (item->GetLabel().IsEmpty()) {
                     /* if no label try to grab it from node type */
@@ -164,14 +162,11 @@ CUPnPServer::Build(CFileItemPtr                  item,
                         item->SetLabelPreformated(true);
                     }
                 }
-
-                if (!item->HasArt("thumb") )
-                    item->SetArt("thumb", CThumbLoader::GetCachedImage(*item, "thumb"));
             }
         }
 
         // not a virtual path directory, new system
-        object = BuildObject(*item.get(), file_path, with_count, &context, this);
+        object = BuildObject(*item.get(), file_path, with_count, thumb_loader, &context, this);
 
         // set parent id if passed, otherwise it should have been determined
         if (object && parent_id) {
@@ -188,6 +183,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
         if (object->m_ParentID == "virtualpath://upnproot/")
             object->m_ParentID = "0";
     }
+
     return object;
 
 failure:
@@ -243,6 +239,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
     NPT_String                     id = TranslateWMPObjectId(object_id);
     vector<CStdString>             paths;
     CFileItemPtr                   item;
+    NPT_Reference<CThumbLoader>    thumb_loader;
 
     CLog::Log(LOGINFO, "Received UPnP Browse Metadata request for object '%s'", (const char*)object_id);
 
@@ -253,7 +250,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
             item.reset(new CFileItem((const char*)id, true));
             item->SetLabel("Root");
             item->SetLabelPreformated(true);
-            object = Build(item, true, context);
+            object = Build(item, true, context, thumb_loader);
         } else {
             return NPT_FAILURE;
         }
@@ -272,7 +269,16 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
 //        }
 //#endif
 
-        object = Build(item, true, context, parent.empty()?NULL:parent.c_str());
+        if (item->IsVideoDb()) {
+            thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
+        }
+        else if (item->IsMusicDb()) {
+            thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
+        }
+        if (!thumb_loader.IsNull()) {
+            thumb_loader->Initialize();
+        }
+        object = Build(item, true, context, thumb_loader, parent.empty()?NULL:parent.c_str());
     }
 
     if (object.IsNull()) {
@@ -390,6 +396,21 @@ CUPnPServer::BuildResponse(PLT_ActionReference&          action,
         starting_index,
         requested_count);
 
+    // we will reuse this ThumbLoader for all items
+    NPT_Reference<CThumbLoader> thumb_loader;
+
+    // this isn't ideal, just grabbing first item to identify the content type
+    // of this FileItemList, but there's no other option
+    if (!items.IsEmpty() && items.Get(0)->HasVideoInfoTag()) {
+        thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
+    }
+    else if (!items.IsEmpty() && items.Get(0)->HasMusicInfoTag()) {
+        thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
+    }
+    if (!thumb_loader.IsNull()) {
+        thumb_loader->Initialize();
+    }
+
     // won't return more than UPNP_MAX_RETURNED_ITEMS items at a time to keep things smooth
     // 0 requested means as many as possible
     NPT_UInt32 max_count  = (requested_count == 0)?m_MaxReturnedItems:min((unsigned long)requested_count, (unsigned long)m_MaxReturnedItems);
@@ -399,7 +420,7 @@ CUPnPServer::BuildResponse(PLT_ActionReference&          action,
     NPT_String didl = didl_header;
     PLT_MediaObjectReference object;
     for (unsigned long i=starting_index; i<stop_index; ++i) {
-        object = Build(items[i], true, context, parent_id);
+        object = Build(items[i], true, context, thumb_loader, parent_id);
         if (object.IsNull()) {
             continue;
         }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -105,7 +105,10 @@ CUPnPServer::Build(CFileItemPtr                  item,
             goto failure;
         }
 
-    } else {
+    } else if (path.StartsWith("addons://"))
+        // don't serve addon listings for now
+        goto failure;
+      else {
         // db path handling
         NPT_String file_path, share_name;
         file_path = item->GetPath();
@@ -128,8 +131,8 @@ CUPnPServer::Build(CFileItemPtr                  item,
                     }
                 }
             }
-        } else if (file_path.StartsWith("videodb://")) {
-            if (path == "videodb://" ) {
+        } else if (file_path.StartsWith("library://") || file_path.StartsWith("videodb://")) {
+            if (path == "library://video" ) {
                 item->SetLabel("Video Library");
                 item->SetLabelPreformated(true);
             } else {
@@ -200,7 +203,7 @@ static NPT_String TranslateWMPObjectId(NPT_String id)
         id = "virtualpath://upnproot/";
     } else if (id == "15") {
         // Xbox 360 asking for videos
-        id = "videodb://";
+        id = "library://video";
     } else if (id == "16") {
         // Xbox 360 asking for photos
     } else if (id == "107") {
@@ -338,7 +341,7 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
             items.Add(item);
 
             // video library
-            item.reset(new CFileItem("videodb://", true));
+            item.reset(new CFileItem("library://video", true));
             item->SetLabel("Video Library");
             item->SetLabelPreformated(true);
             items.Add(item);

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -151,6 +151,13 @@ CUPnPServer::Build(CFileItemPtr                  item,
                         db.GetTvShowInfo((const char*)path, *item->GetVideoInfoTag(), params.GetTvShowId());
                 }
 
+                if (item->GetVideoInfoTag()->m_type == "tvshow" || item->GetVideoInfoTag()->m_type == "season") {
+                    // for tvshows and seasons, iEpisode and playCount are
+                    // invalid
+                    item->GetVideoInfoTag()->m_iEpisode = item->GetProperty("totalepisodes").asInteger();
+                    item->GetVideoInfoTag()->m_playCount = item->GetProperty("watchedepisodes").asInteger();
+                }
+
                 // try to grab title from tag
                 if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_strTitle.IsEmpty()) {
                     item->SetLabel(item->GetVideoInfoTag()->m_strTitle);

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -21,6 +21,7 @@
 #include "PltMediaConnect.h"
 #include "FileItem.h"
 
+class CThumbLoader;
 class PLT_MediaObject;
 class PLT_HttpRequestContext;
 
@@ -92,6 +93,7 @@ private:
     PLT_MediaObject* Build(CFileItemPtr                  item,
                            bool                          with_count,
                            const PLT_HttpRequestContext& context,
+                           NPT_Reference<CThumbLoader>&  thumbLoader,
                            const char*                   parent_id = NULL);
     NPT_Result       BuildResponse(PLT_ActionReference&          action,
                                    CFileItemList&                items,

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3642,6 +3642,7 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, map<int, string> &seasonArt)
 
     for (vector< pair<int,int> >::const_iterator i = seasons.begin(); i != seasons.end(); ++i)
       seasonArt.insert(make_pair(i->second,GetArtForItem(i->first, "season", "thumb")));
+    return true;
   }
   catch (...)
   {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5424,10 +5424,10 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
 
     CStdString strSQL = PrepareSQL("SELECT episodeview.c%02d, "
                                           "path.strPath, "
-                                          "tvshowview.c%02d, tvshowview.c%02d, tvshowview.c%02d, tvshowview.c%02d, "
+                                          "tvshowview.c%02d, tvshowview.c%02d, tvshowview.c%02d, tvshowview.c%02d, tvshowview.c%02d, tvshowview.c%02d, "
                                           "seasons.idSeason, "
                                           "count(1), count(files.playCount) "
-                                          "FROM episodeview ", VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA);
+                                          "FROM episodeview ", VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_PLOT, VIDEODB_ID_TV_PREMIERED, VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA);
     
     Filter filter;
     filter.join = PrepareSQL("JOIN tvshowview ON tvshowview.idShow = episodeview.idShow "
@@ -5458,10 +5458,12 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
     if (iRowsFound <= 0)
       return iRowsFound == 0;
 
-    // show titles, studios and mpaa ratings will be the same
+    // show titles, plots, day of premiere, studios and mpaa ratings will be the same
     CStdString showTitle = m_pDS->fv(2).get_asString();
-    CStdString showStudio = m_pDS->fv(4).get_asString();
-    CStdString showMPAARating = m_pDS->fv(5).get_asString();
+    CStdString showPlot = m_pDS->fv(3).get_asString();
+    CStdString showPremiered = m_pDS->fv(4).get_asString();
+    CStdString showStudio = m_pDS->fv(6).get_asString();
+    CStdString showMPAARating = m_pDS->fv(7).get_asString();
 
     if (g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
@@ -5481,10 +5483,10 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         {
           CSeason season;
           season.path = m_pDS->fv(1).get_asString();
-          season.genre = StringUtils::Split(m_pDS->fv(3).get_asString(), g_advancedSettings.m_videoItemSeparator);
-          season.id = m_pDS->fv(6).get_asInt();
-          season.numEpisodes = m_pDS->fv(7).get_asInt();
-          season.numWatched = m_pDS->fv(8).get_asInt();
+          season.genre = StringUtils::Split(m_pDS->fv(5).get_asString(), g_advancedSettings.m_videoItemSeparator);
+          season.id = m_pDS->fv(8).get_asInt();
+          season.numEpisodes = m_pDS->fv(9).get_asInt();
+          season.numWatched = m_pDS->fv(10).get_asInt();
           mapSeasons.insert(make_pair(iSeason, season));
         }
         m_pDS->next();
@@ -5517,6 +5519,8 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->GetVideoInfoTag()->m_strMPAARating = showMPAARating;
         pItem->GetVideoInfoTag()->m_iIdShow = idShow;
         pItem->GetVideoInfoTag()->m_strShowTitle = showTitle;
+        pItem->GetVideoInfoTag()->m_strPlot = showPlot;
+        pItem->GetVideoInfoTag()->m_premiered.SetFromDBDate(showPremiered);
         pItem->GetVideoInfoTag()->m_iEpisode = it->second.numEpisodes;
         pItem->SetProperty("totalepisodes", it->second.numEpisodes);
         pItem->SetProperty("numepisodes", it->second.numEpisodes); // will be changed later to reflect watchmode setting
@@ -5548,16 +5552,18 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->m_bIsFolder=true;
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iSeason = iSeason;
-        pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv(6).get_asInt();
+        pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv(8).get_asInt();
         pItem->GetVideoInfoTag()->m_type = "season";
         pItem->GetVideoInfoTag()->m_strPath = m_pDS->fv(1).get_asString();
-        pItem->GetVideoInfoTag()->m_genre = StringUtils::Split(m_pDS->fv(3).get_asString(), g_advancedSettings.m_videoItemSeparator);
+        pItem->GetVideoInfoTag()->m_genre = StringUtils::Split(m_pDS->fv(5).get_asString(), g_advancedSettings.m_videoItemSeparator);
         pItem->GetVideoInfoTag()->m_studio = StringUtils::Split(showStudio, g_advancedSettings.m_videoItemSeparator);
         pItem->GetVideoInfoTag()->m_strMPAARating = showMPAARating;
         pItem->GetVideoInfoTag()->m_iIdShow = idShow;
         pItem->GetVideoInfoTag()->m_strShowTitle = showTitle;
-        int totalEpisodes = m_pDS->fv(7).get_asInt();
-        int watchedEpisodes = m_pDS->fv(8).get_asInt();
+        pItem->GetVideoInfoTag()->m_strPlot = showPlot;
+        pItem->GetVideoInfoTag()->m_premiered.SetFromDBDate(showPremiered);
+        int totalEpisodes = m_pDS->fv(9).get_asInt();
+        int watchedEpisodes = m_pDS->fv(10).get_asInt();
         pItem->GetVideoInfoTag()->m_iEpisode = totalEpisodes;
         pItem->SetProperty("totalepisodes", totalEpisodes);
         pItem->SetProperty("numepisodes", totalEpisodes); // will be changed later to reflect watchmode setting


### PR DESCRIPTION
This is a load of commits which make the metadata available to upnp clients as rich as the inbuilt library views. 

Fixes include: tv show season artwork, playcounts, resume points, watched status, correct director/actor info, missing dates.

I know it's late, but this was a total PITA to get my head round the season numbering and the lack of some metainfo in particular video db nodes.
