### PR TITLE
[libshairport] - add patch for fixing fallback from ipv6 to ipv4 (needed...

### DIFF
--- a/lib/libshairport/011_fix_ipv4_fallback.patch
+++ b/lib/libshairport/011_fix_ipv4_fallback.patch
@@ -1,0 +1,10 @@
+--- src/socketlib.c	2012-07-14 22:49:30.000000000 +0200
++++ src/socketlib.c	2012-10-08 21:55:51.000000000 +0200
+@@ -118,6 +118,7 @@
+ 
+   int tEnable = 1;
+   setsockopt(tSock, SOL_SOCKET, SO_REUSEADDR, &tEnable, sizeof (tEnable));
++  server_addr->ai_addr->sa_family = server_addr->ai_family; // ensure that server_addr has same famliy than the socket
+   if (bind(tSock, server_addr->ai_addr, server_addr->ai_addrlen) < 0)
+   {
+     close(tSock);

--- a/lib/libshairport/Makefile
+++ b/lib/libshairport/Makefile
@@ -46,6 +46,7 @@ $(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(SOURCE); patch -p0 < ../008-add-missing-libs.patch
 	cd $(SOURCE); patch -p0 < ../009_fix_ipv6.patch
 	cd $(SOURCE); patch -p0 < ../010_handle_metadata.patch
+	cd $(SOURCE); patch -p0 < ../011_fix_ipv4_fallback.patch
 	cd $(SOURCE); autoreconf -vif
 	cd $(SOURCE); $(CONFIGURE)
 

--- a/tools/android/depends/libshairport/011_fix_ipv4_fallback.patch
+++ b/tools/android/depends/libshairport/011_fix_ipv4_fallback.patch
@@ -1,0 +1,10 @@
+--- src/socketlib.c	2012-07-14 22:49:30.000000000 +0200
++++ src/socketlib.c	2012-10-08 21:55:51.000000000 +0200
+@@ -118,6 +118,7 @@
+ 
+   int tEnable = 1;
+   setsockopt(tSock, SOL_SOCKET, SO_REUSEADDR, &tEnable, sizeof (tEnable));
++  server_addr->ai_addr->sa_family = server_addr->ai_family; // ensure that server_addr has same famliy than the socket
+   if (bind(tSock, server_addr->ai_addr, server_addr->ai_addrlen) < 0)
+   {
+     close(tSock);

--- a/tools/android/depends/libshairport/Makefile
+++ b/tools/android/depends/libshairport/Makefile
@@ -34,6 +34,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../008-add-missing-libs.patch
 	cd $(PLATFORM); patch -p0 < ../009_fix_ipv6.patch
 	cd $(PLATFORM); patch -p0 < ../010_handle_metadata.patch
+	cd $(PLATFORM); patch -p0 < ../011_fix_ipv4_fallback.patch
 	cd $(PLATFORM); patch -p0 < ../android.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)

--- a/tools/darwin/depends/libshairport/011_fix_ipv4_fallback.patch
+++ b/tools/darwin/depends/libshairport/011_fix_ipv4_fallback.patch
@@ -1,0 +1,10 @@
+--- src/socketlib.c	2012-07-14 22:49:30.000000000 +0200
++++ src/socketlib.c	2012-10-08 21:55:51.000000000 +0200
+@@ -118,6 +118,7 @@
+ 
+   int tEnable = 1;
+   setsockopt(tSock, SOL_SOCKET, SO_REUSEADDR, &tEnable, sizeof (tEnable));
++  server_addr->ai_addr->sa_family = server_addr->ai_family; // ensure that server_addr has same famliy than the socket
+   if (bind(tSock, server_addr->ai_addr, server_addr->ai_addrlen) < 0)
+   {
+     close(tSock);

--- a/tools/darwin/depends/libshairport/Makefile
+++ b/tools/darwin/depends/libshairport/Makefile
@@ -32,6 +32,7 @@ $(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(SOURCE); patch -p0 < ../008-add-missing-libs.patch
 	cd $(SOURCE); patch -p0 < ../009_fix_ipv6.patch
 	cd $(SOURCE); patch -p0 < ../010_handle_metadata.patch
+	cd $(SOURCE); patch -p0 < ../011_fix_ipv4_fallback.patch
 	cd $(SOURCE); autoreconf -vif
 	cd $(SOURCE); $(CONFIGURE)
 

--- a/tools/rbp/depends/libshairport/011_fix_ipv4_fallback.patch
+++ b/tools/rbp/depends/libshairport/011_fix_ipv4_fallback.patch
@@ -1,0 +1,10 @@
+--- src/socketlib.c	2012-07-14 22:49:30.000000000 +0200
++++ src/socketlib.c	2012-10-08 21:55:51.000000000 +0200
+@@ -118,6 +118,7 @@
+ 
+   int tEnable = 1;
+   setsockopt(tSock, SOL_SOCKET, SO_REUSEADDR, &tEnable, sizeof (tEnable));
++  server_addr->ai_addr->sa_family = server_addr->ai_family; // ensure that server_addr has same famliy than the socket
+   if (bind(tSock, server_addr->ai_addr, server_addr->ai_addrlen) < 0)
+   {
+     close(tSock);

--- a/tools/rbp/depends/libshairport/Makefile
+++ b/tools/rbp/depends/libshairport/Makefile
@@ -30,8 +30,9 @@ $(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(SOURCE); patch -p0 < ../006_no_printf.patch
 	cd $(SOURCE); patch -p0 < ../007_fix_syslog_defines.patch
 	cd $(SOURCE); patch -p0 < ../008-add-missing-libs.patch
-	#cd $(SOURCE); patch -p0 < ../009_fix_ipv6.patch
+	cd $(SOURCE); patch -p0 < ../009_fix_ipv6.patch
 	cd $(SOURCE); patch -p0 < ../010_handle_metadata.patch
+	cd $(SOURCE); patch -p0 < ../011_fix_ipv4_fallback.patch
 	cd $(SOURCE); autoreconf -vif
 	cd $(SOURCE); $(CONFIGURE)
 


### PR DESCRIPTION
... where AF_INET6 is defined at buildtime - but ipv6 is not available at runtime - rbpi and openelec on fusion for example) - thx to ribbon10

@gimli could you give this a shot on rbpi before i merge?

with http://wiki.xbmc.org/index.php?title=Userdata/advancedsettings.xml#.3Cenableairtunesdebuglog.3E

you should see somthing like

"20:20:37 T:140102717941568  DEBUG: AIRTUNES: Failed to create ipv6 socket. Trying ipv4"

in the log and it should work.
