### PR TITLE
[cec] libCEC 2.0.0 support

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1456,9 +1456,9 @@ if test "x$use_libcec" != "xno"; then
   # libcec is dyloaded, so we need to check for its headers and link any depends.
   if test "x$use_libcec" != "xno"; then
     if test "x$use_libcec" != "xauto"; then
-      PKG_CHECK_MODULES([CEC],[libcec >= 1.8.0],,[use_libcec="no";AC_MSG_ERROR($libcec_disabled)])
+      PKG_CHECK_MODULES([CEC],[libcec >= 2.0.0],,[use_libcec="no";AC_MSG_ERROR($libcec_disabled)])
     else
-      PKG_CHECK_MODULES([CEC],[libcec >= 1.8.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
+      PKG_CHECK_MODULES([CEC],[libcec >= 2.0.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
     fi
 
     if test "x$use_libcec" != "xno"; then

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -10927,11 +10927,7 @@ msgctxt "#36012"
 msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
-msgctxt "#36013"
-msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-#empty string with id 36014
+#empty strings from id 36013 to 36014
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -11035,5 +11031,9 @@ msgstr ""
 
 msgctxt "#36039"
 msgid "TV and AVR device (explicit)"
+msgstr ""
+
+msgctxt "#36040"
+msgid "Unsupported libCEC interface version. %x is lower than the version XBMC supports (%x)"
 msgstr ""
 

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11033,3 +11033,7 @@ msgctxt "#36038"
 msgid "Amplifier / AVR device"
 msgstr ""
 
+msgctxt "#36039"
+msgid "TV and AVR device (explicit)"
+msgstr ""
+

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -10876,7 +10876,7 @@ msgid "Product ID"
 msgstr ""
 
 #empty strings from id 35505 to 35999
-
+#: xbmc/peripherals/devices/PeripheralCecAdapter.cpp
 msgctxt "#36000"
 msgid "Pulse-Eight CEC adapter"
 msgstr ""
@@ -11023,3 +11023,13 @@ msgstr ""
 msgctxt "#36036"
 msgid "On start/stop"
 msgstr ""
+
+#: xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+msgctxt "#36037"
+msgid "TV"
+msgstr ""
+
+msgctxt "#36038"
+msgid "Amplifier / AVR device"
+msgstr ""
+

--- a/lib/libcec/Makefile
+++ b/lib/libcec/Makefile
@@ -7,7 +7,7 @@
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.8.1
+VERSION=2.0.0
 SOURCE=$(LIBNAME)-$(VERSION)
 
 # download location and format

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec-1.8.1.zip                  http://mirrors.xbmc.org/build-deps/win32/
+libcec-2.0.0.zip                  http://mirrors.xbmc.org/build-deps/win32/

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -40,9 +40,9 @@
     <setting key="send_inactive_source" type="bool" value="1" label="36025" order="8" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="9" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" order="10" />
-    <setting key="physical_address" type="string" label="36021" value="0" order="11" />
+    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="11" />
     <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="12" />
-    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="13" />
+    <setting key="physical_address" type="string" label="36021" value="0" order="13" />
     <setting key="port" type="string" value="" label="36022" order="14" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -12,12 +12,12 @@
   <peripheral vendor_product="2708:1001" bus="rpi" name="Raspberry Pi CEC Adapter" mapTo="cec">
     <setting key="enabled" type="bool" value="1" label="305" order="1" />
     <setting key="activate_source" type="bool" value="1" label="36020" order="2" />
-    <setting key="wake_devices" type="string" value="0" label="36007" order="3" />
-    <setting key="standby_devices" type="string" value="0" label="36008" order="4" />
-    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="5" />
-    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="6" lvalues="36028|13005|13011" />
-    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="7" />
-    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="8" />
+    <setting key="wake_devices" type="enum" value="36037" label="36007" lvalues="36037|36038|36039|231" order="3" />
+    <setting key="standby_devices" type="enum" value="36037" label="36008" lvalues="36037|36038|36039|231" order="4" />
+    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
+    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="7" />
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="7" lvalues="36028|13005|13011" />
+    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="8" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="9" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
@@ -27,17 +27,19 @@
     <setting key="cec_hdmi_port" type="int" value="1" label="36015" configurable="0" />
     <setting key="connected_device" type="int" label="36019" value="0" configurable="0" />
     <setting key="port" type="string" value="" label="36022" configurable="0" />
+    <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
+    <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
   </peripheral>
 
   <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">
     <setting key="enabled" type="bool" value="1" label="305" order="1" />
     <setting key="activate_source" type="bool" value="1" label="36020" order="2" />
-    <setting key="wake_devices" type="string" value="0" label="36007" order="3" />
-    <setting key="standby_devices" type="string" value="0" label="36008" order="4" />
-    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="5" />
-    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="6" lvalues="36028|13005|13011" />
-    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="7" />
-    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="8" />
+    <setting key="wake_devices" type="enum" value="36037" label="36007" lvalues="36037|36038|36039|231" order="3" />
+    <setting key="standby_devices" type="enum" value="36037" label="36008" lvalues="36037|36038|36039|231" order="4" />
+    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
+    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="7" lvalues="36028|13005|13011" />
+    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="8" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="9" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" order="10" />
     <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="11" />
@@ -48,6 +50,8 @@
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="XBMC" configurable="0" />
     <setting key="device_type" type="int" value="1" configurable="0" />
+    <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
+    <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
   </peripheral>
 
   <peripheral vendor_product="15C2:32,15C2:33,15C2:34,15C2:35,15C2:36,15C2:37,15C2:38,15C2:39,15C2:3A,15C2:3B,15C2:3C,15C2:3D,15C2:3E,15C2:3F,15C2:41,15C2:42,15C2:43,15C2:44,15C2:45,15C2:46" bus="usb" name="iMON HID device" mapTo="imon">

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -29,6 +29,7 @@
     <setting key="port" type="string" value="" label="36022" configurable="0" />
     <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
     <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
+    <setting key="double_tap_timeout_ms" type="int" min="0" value="2000" configurable="0" />
   </peripheral>
 
   <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">
@@ -52,6 +53,7 @@
     <setting key="device_type" type="int" value="1" configurable="0" />
     <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
     <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
+    <setting key="double_tap_timeout_ms" type="int" min="0" value="2000" configurable="0" />
   </peripheral>
 
   <peripheral vendor_product="15C2:32,15C2:33,15C2:34,15C2:35,15C2:36,15C2:37,15C2:38,15C2:39,15C2:3A,15C2:3B,15C2:3C,15C2:3D,15C2:3E,15C2:3F,15C2:41,15C2:42,15C2:43,15C2:44,15C2:45,15C2:46" bus="usb" name="iMON HID device" mapTo="imon">

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -3,7 +3,7 @@ include ../config.site.mk
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.8.1
+VERSION=2.0.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1384,6 +1384,9 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
   int iStandbyAction(GetSettingInt("standby_pc_on_tv_standby"));
   m_configuration.bPowerOffOnStandby = iStandbyAction == 13011 ? 1 : 0;
   m_configuration.bShutdownOnStandby = iStandbyAction == 13005 ? 1 : 0;
+
+  // double tap prevention timeout in ms
+  m_configuration.iDoubleTapTimeoutMs = GetSettingInt("double_tap_timeout_ms");
 }
 
 void CPeripheralCecAdapter::ReadLogicalAddresses(const CStdString &strString, cec_logical_addresses &addresses)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -232,11 +232,11 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
     if (m_configuration.serverVersion < CEC_LIB_SUPPORTED_VERSION)
     {
       /* unsupported libcec version */
-      CLog::Log(LOGERROR, g_localizeStrings.Get(36013).c_str(), m_cecAdapter ? m_configuration.serverVersion : -1, CEC_LIB_SUPPORTED_VERSION);
+      CLog::Log(LOGERROR, g_localizeStrings.Get(36040).c_str(), m_cecAdapter ? m_configuration.serverVersion : -1, CEC_LIB_SUPPORTED_VERSION);
 
       // display warning: incompatible libCEC
       CStdString strMessage;
-      strMessage.Format(g_localizeStrings.Get(36013).c_str(), m_cecAdapter ? m_configuration.serverVersion : -1, CEC_LIB_SUPPORTED_VERSION);
+      strMessage.Format(g_localizeStrings.Get(36040).c_str(), m_cecAdapter ? m_configuration.serverVersion : -1, CEC_LIB_SUPPORTED_VERSION);
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000), strMessage);
       m_bError = true;
       if (m_cecAdapter)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -51,6 +51,9 @@ using namespace std;
 #define VOLUME_CHANGE_TIMEOUT     250
 #define VOLUME_REFRESH_TIMEOUT    100
 
+#define LOCALISED_ID_TV           36037
+#define LOCALISED_ID_AVR          36038
+
 class DllLibCECInterface
 {
 public:
@@ -1226,7 +1229,7 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
 
   // set the connected device
   m_configuration.baseDevice = config.baseDevice;
-  bChanged |= SetSetting("connected_device", (int)config.baseDevice);
+  bChanged |= SetSetting("connected_device", config.baseDevice == CECDEVICE_AUDIOSYSTEM ? LOCALISED_ID_AVR : LOCALISED_ID_TV);
 
   // set the HDMI port number
   m_configuration.iHDMIPort = config.iHDMIPort;
@@ -1328,9 +1331,10 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
 
   // set the connected device
   int iConnectedDevice = GetSettingInt("connected_device");
-  if (iConnectedDevice == CECDEVICE_TV ||
-      iConnectedDevice == CECDEVICE_AUDIOSYSTEM)
-    m_configuration.baseDevice = (cec_logical_address)iConnectedDevice;
+  if (iConnectedDevice == LOCALISED_ID_AVR)
+    m_configuration.baseDevice = CECDEVICE_AUDIOSYSTEM;
+  else if (iConnectedDevice == LOCALISED_ID_TV)
+    m_configuration.baseDevice = CECDEVICE_TV;
 
   // set the HDMI port number
   int iHDMIPort = GetSettingInt("cec_hdmi_port");

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -119,12 +119,12 @@ namespace PERIPHERALS
     void SetConfigurationFromLibCEC(const CEC::libcec_configuration &config);
     void SetVersionInfo(const CEC::libcec_configuration &configuration);
     static void ReadLogicalAddresses(const CStdString &strString, CEC::cec_logical_addresses &addresses);
-    static int CecKeyPress(void *cbParam, const CEC::cec_keypress &key);
+    static int CecKeyPress(void *cbParam, const CEC::cec_keypress key);
     void PushCecKeypress(const CecButtonPress &key);
-    static int CecLogMessage(void *cbParam, const CEC::cec_log_message &message);
-    static int CecCommand(void *cbParam, const CEC::cec_command &command);
-    static int CecConfiguration(void *cbParam, const CEC::libcec_configuration &config);
-    static int CecAlert(void *cbParam, const CEC::libcec_alert alert, const CEC::libcec_parameter &data);
+    static int CecLogMessage(void *cbParam, const CEC::cec_log_message message);
+    static int CecCommand(void *cbParam, const CEC::cec_command command);
+    static int CecConfiguration(void *cbParam, const CEC::libcec_configuration config);
+    static int CecAlert(void *cbParam, const CEC::libcec_alert alert, const CEC::libcec_parameter data);
     static void CecSourceActivated(void *param, const CEC::cec_logical_address address, const uint8_t activated);
     bool IsRunning(void) const;
     void ReopenConnection(void);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -119,6 +119,8 @@ namespace PERIPHERALS
     void SetConfigurationFromLibCEC(const CEC::libcec_configuration &config);
     void SetVersionInfo(const CEC::libcec_configuration &configuration);
     static void ReadLogicalAddresses(const CStdString &strString, CEC::cec_logical_addresses &addresses);
+    static void ReadLogicalAddresses(int iLocalisedId, CEC::cec_logical_addresses &addresses);
+    bool WriteLogicalAddresses(const CEC::cec_logical_addresses& addresses, const std::string& strSettingName, const std::string& strAdvancedSettingName);
     static int CecKeyPress(void *cbParam, const CEC::cec_keypress key);
     void PushCecKeypress(const CecButtonPress &key);
     static int CecLogMessage(void *cbParam, const CEC::cec_log_message message);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -141,6 +141,8 @@ namespace PERIPHERALS
     static bool FindConfigLocation(CStdString &strString);
     static bool TranslateComPort(CStdString &strPort);
 
+    void ResetMembers(void);
+
     DllLibCEC*                        m_dll;
     CEC::ICECAdapter*                 m_cecAdapter;
     bool                              m_bStarted;


### PR DESCRIPTION
Bit late to the party, but there was a little hold up.
This bumps libCEC to 2.0.0. This is a major version bump, as deprecated methods (that XBMC was no longer using anymore anyway) were removed, and there were some minor fixups in the headers to fix plain C compilation. The changes for XBMC are only minor, see b45b9a47c13719ad0b57f2776a1789e558d63325, but it's still a breaking API change.

Full changelog can be found here: https://github.com/Pulse-Eight/libcec/blob/release/ChangeLog

Then some cleanups of the code:
- commits 3f48f5b477f352ce53b798db4e3f275be21adca4 and 2dd4bf3fae24f7b23c5d188ef1dc93de52815fcf simplify the peripheral settings, by replacing the strings with logical addresses by enum values. The old settings can still be defined by a user in the .xml file for the adapter (wake_devices_advanced + standby_devices_advanced).
- rest are minor cleanups, and a hidden setting to change the new double tap prevention timeout in libCEC.

I know it's late, but I'd like to see this included in Frodo, as this is a breaking API change, even though it's minor, and it's needed to fix C compilation. It also cleans up things that were used during early development and that were still floating around in the headers, including some very nasty ifdefs because of accidental breakage cause the official Windows and Linux Eden builds were using different API versions, and users who just upgraded libcec.dll/.so ran into crashes.

Deps will be uploaded shortly (unless someone beats me)
