### PR TITLE
[PVR] timer conflict support

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7135,7 +7135,23 @@ msgctxt "#19274"
 msgid "Please visit xbmc.org/pvr to learn more."
 msgstr ""
 
-#empty strings from id 19275 to 19498
+msgctxt "#19275"
+msgid "Conflict warning"
+msgstr ""
+
+msgctxt "#19276"
+msgid "Conflict error"
+msgstr ""
+
+msgctxt "#19277"
+msgid "Recording conflict"
+msgstr ""
+
+msgctxt "#19278"
+msgid "Recording error"
+msgstr ""
+
+#empty strings from id 19279 to 19498
 
 msgctxt "#19499"
 msgid "Other/Unknown"

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -72,10 +72,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "1.4.0"
+#define XBMC_PVR_API_VERSION "1.5.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "1.4.0"
+#define XBMC_PVR_MIN_API_VERSION "1.5.0"
 
 #ifdef __cplusplus
 extern "C" {
@@ -103,12 +103,15 @@ extern "C" {
    */
   typedef enum
   {
-    PVR_TIMER_STATE_NEW       = 0, /*!< @brief a new, unsaved timer */
-    PVR_TIMER_STATE_SCHEDULED = 1, /*!< @brief the timer is scheduled for recording */
-    PVR_TIMER_STATE_RECORDING = 2, /*!< @brief the timer is currently recordings */
-    PVR_TIMER_STATE_COMPLETED = 3, /*!< @brief the recording completed successfully */
-    PVR_TIMER_STATE_ABORTED   = 4, /*!< @brief recording started, but was aborted */
-    PVR_TIMER_STATE_CANCELLED = 5  /*!< @brief the timer was scheduled, but was canceled */
+    PVR_TIMER_STATE_NEW          = 0, /*!< @brief a new, unsaved timer */
+    PVR_TIMER_STATE_SCHEDULED    = 1, /*!< @brief the timer is scheduled for recording */
+    PVR_TIMER_STATE_RECORDING    = 2, /*!< @brief the timer is currently recordings */
+    PVR_TIMER_STATE_COMPLETED    = 3, /*!< @brief the recording completed successfully */
+    PVR_TIMER_STATE_ABORTED      = 4, /*!< @brief recording started, but was aborted */
+    PVR_TIMER_STATE_CANCELLED    = 5, /*!< @brief the timer was scheduled, but was canceled */
+    PVR_TIMER_STATE_CONFLICT_OK  = 6, /*!< @brief the scheduled timer conflicts with another one, but will be recorded */
+    PVR_TIMER_STATE_CONFLICT_NOK = 7, /*!< @brief the scheduled timer conflicts with another one and won't be recorded */
+    PVR_TIMER_STATE_ERROR        = 8  /*!< @brief the timer is scheduled, but can't be recorded for some reason */
   } PVR_TIMER_STATE;
 
   /*!

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -241,6 +241,12 @@ CStdString CPVRTimerInfoTag::GetStatus() const
     strReturn = g_localizeStrings.Get(13106);
   else if (m_state == PVR_TIMER_STATE_RECORDING)
     strReturn = g_localizeStrings.Get(19162);
+  else if (m_state == PVR_TIMER_STATE_CONFLICT_OK)
+    strReturn = g_localizeStrings.Get(19275);
+  else if (m_state == PVR_TIMER_STATE_CONFLICT_NOK)	
+    strReturn = g_localizeStrings.Get(19276);	
+  else if (m_state == PVR_TIMER_STATE_ERROR)
+    strReturn = g_localizeStrings.Get(257);
 
   return strReturn;
 }
@@ -522,6 +528,13 @@ void CPVRTimerInfoTag::GetNotificationText(CStdString &strText) const
     break;
   case PVR_TIMER_STATE_COMPLETED:
     strText.Format("%s: '%s'", g_localizeStrings.Get(19227), m_strTitle.c_str());
+    break;
+  case PVR_TIMER_STATE_CONFLICT_OK:	
+  case PVR_TIMER_STATE_CONFLICT_NOK:	
+    strText.Format("%s: '%s'", g_localizeStrings.Get(19277), m_strTitle.c_str());
+    break;
+  case PVR_TIMER_STATE_ERROR:
+    strText.Format("%s: '%s'", g_localizeStrings.Get(19278), m_strTitle.c_str());
     break;
   default:
     break;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -98,7 +98,15 @@ namespace PVR
 
     void UpdateEpgEvent(bool bClear = false);
 
-    bool IsActive(void) const { return m_state == PVR_TIMER_STATE_SCHEDULED || m_state == PVR_TIMER_STATE_RECORDING; }
+    bool IsActive(void) const 
+    { 	
+      return m_state == PVR_TIMER_STATE_SCHEDULED 
+        || m_state == PVR_TIMER_STATE_RECORDING
+        || m_state == PVR_TIMER_STATE_CONFLICT_OK
+        || m_state == PVR_TIMER_STATE_CONFLICT_NOK
+        || m_state == PVR_TIMER_STATE_ERROR;
+    }
+
     bool IsRecording(void) const { return m_state == PVR_TIMER_STATE_RECORDING; }
 
     CDateTime StartAsUTC(void) const;


### PR DESCRIPTION
This PR adds the possibility to  show wich timers are in conflict and therefore won't be able to record.

I have not tested this very well yet as I'm only at home in the weekend, but want to get this in before feature freeze. 
