### PR TITLE
jsonrpc: optimize handling of properties requested by the client

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.h
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include <set>
+
 #include "JSONRPC.h"
 #include "JSONUtils.h"
 #include "FileItem.h"
@@ -30,13 +32,15 @@ namespace JSONRPC
   class CFileItemHandler : public CJSONUtils
   {
   protected:
-    static void FillDetails(ISerializable* info, CFileItemPtr item, const CVariant& fields, CVariant &result, CThumbLoader *thumbLoader = NULL);
+    static void FillDetails(const ISerializable *info, const CFileItemPtr &item, std::set<std::string> &fields, CVariant &result, CThumbLoader *thumbLoader = NULL);
     static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool sortLimit = true);
     static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, int size, bool sortLimit = true);
     static void HandleFileItem(const char *ID, bool allowFile, const char *resultname, CFileItemPtr item, const CVariant &parameterObject, const CVariant &validFields, CVariant &result, bool append = true, CThumbLoader *thumbLoader = NULL);
+    static void HandleFileItem(const char *ID, bool allowFile, const char *resultname, CFileItemPtr item, const CVariant &parameterObject, const std::set<std::string> &validFields, CVariant &result, bool append = true, CThumbLoader *thumbLoader = NULL);
 
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
   private:
     static void Sort(CFileItemList &items, const CVariant& parameterObject);
+    static bool GetField(const std::string &field, const CVariant &info, const CFileItemPtr &item, CVariant &result, bool &fetchedArt, CThumbLoader *thumbLoader = NULL);
   };
 }


### PR DESCRIPTION
Up until now FillDetails, which contains a loop to go through all the properties requested by the client in a request has been called at least twice (once for the CFileItem and once for the CFooInfoTag) for every media item matching the client's request. With n items and m properties this resulted in n \* 2 \* m loops which can result in longer response times. By removing the already matched properties from the list of requested properties we get down to n \* m loops. Especially for "expensive" properties like "thumbnail" and "fanart" which require additional SQL queries avoiding doing the same work twice which can have a huge impact.
In addition moving the logic to retrieve any requested properties directly from the serialization of the media item instead of first checking and handling any special cases results in additional speed-up by not having to do the extra string comparisons and map-lookups required for the special cases.

I mainly put this up as a PR (it's actually more of a fix) because I don't like all the

```
fields.erase(field);
continue;
```

and thought maybe someone has an idea for this. The only thing I could come up with was replacing those lines with a goto but I hope there's another solution.
