### PR TITLE
Upnp cache notify

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8215,7 +8215,9 @@ msgctxt "#20187"
 msgid "UPnP"
 msgstr ""
 
-#empty string with id 20188
+msgctxt "#20188"
+msgid "Announce library updates via UPnP"
+msgstr ""
 
 msgctxt "#20189"
 msgid "Enable auto scrolling for plot & review"

--- a/lib/libUPnP/Platinum/Source/Core/PltService.cpp
+++ b/lib/libUPnP/Platinum/Source/Core/PltService.cpp
@@ -460,14 +460,14 @@ PLT_Service::IsSubscribable()
 |   PLT_Service::SetStateVariable
 +---------------------------------------------------------------------*/
 NPT_Result
-PLT_Service::SetStateVariable(const char* name, const char* value)
+PLT_Service::SetStateVariable(const char* name, const char* value, const bool clearonsend /*=false*/)
 {
     PLT_StateVariable* stateVariable = NULL;
     NPT_ContainerFind(m_StateVars, PLT_StateVariableNameFinder(name), stateVariable);
     if (stateVariable == NULL)
         return NPT_FAILURE;
 
-    return stateVariable->SetValue(value);
+    return stateVariable->SetValue(value, clearonsend);
 }
 
 /*----------------------------------------------------------------------
@@ -838,6 +838,13 @@ PLT_Service::NotifyChanged()
         delete sub;
     }
 
+    // some state variables must be cleared immediatly after sending
+    iter = vars_ready.GetFirstItem();
+    while (iter) {
+      PLT_StateVariable* var = *iter;
+      var->OnSendCompleted();
+      ++iter;
+    }
     return NPT_SUCCESS;
 }
 

--- a/lib/libUPnP/Platinum/Source/Core/PltService.h
+++ b/lib/libUPnP/Platinum/Source/Core/PltService.h
@@ -216,8 +216,9 @@ public:
      when necessary.
      @param name state variable name
      @param value new State Variable value.
+     @param clearonsend whether the State Variable should clear immediatly in ::OnSendingCompleted
      */
-    NPT_Result SetStateVariable(const char* name, const char* value);
+    NPT_Result SetStateVariable(const char* name, const char* value, const bool clearonsend = false);
     
     /**
      Certain state variables notifications must not be sent faster than a certain 

--- a/lib/libUPnP/Platinum/Source/Core/PltStateVariable.cpp
+++ b/lib/libUPnP/Platinum/Source/Core/PltStateVariable.cpp
@@ -48,7 +48,8 @@ NPT_SET_LOCAL_LOGGER("platinum.core.statevariable")
 PLT_StateVariable::PLT_StateVariable(PLT_Service* service) : 
     m_Service(service), 
     m_AllowedValueRange(NULL),
-    m_IsSendingEventsIndirectly(true)
+    m_IsSendingEventsIndirectly(true),
+    m_ShouldClearOnSend(false)
 {
 }
 
@@ -145,7 +146,7 @@ PLT_StateVariable::SetRate(NPT_TimeInterval rate)
 |   PLT_StateVariable::SetValue
 +---------------------------------------------------------------------*/
 NPT_Result
-PLT_StateVariable::SetValue(const char* value)
+PLT_StateVariable::SetValue(const char* value, const bool clearonsend /*=false*/)
 {
     if (value == NULL) {
         return NPT_FAILURE;
@@ -159,6 +160,7 @@ PLT_StateVariable::SetValue(const char* value)
         }
 
         m_Value = value;
+        m_ShouldClearOnSend = clearonsend;
         m_Service->AddChanged(this); 
     }
 
@@ -180,6 +182,16 @@ PLT_StateVariable::IsReadyToPublish()
     }
 
     return false;
+}
+
+/*----------------------------------------------------------------------
+|   PLT_StateVariable::OnSendCompleted
++---------------------------------------------------------------------*/
+void
+PLT_StateVariable::OnSendCompleted()
+{
+  if(m_ShouldClearOnSend)
+      m_Value = m_DefaultValue;
 }
 
 /*----------------------------------------------------------------------

--- a/lib/libUPnP/Platinum/Source/Core/PltStateVariable.h
+++ b/lib/libUPnP/Platinum/Source/Core/PltStateVariable.h
@@ -115,8 +115,9 @@ public:
      it is an allowed value. Once the value is validated, it is marked for eventing by
      calling the PLT_Service AddChanged function.
      @param value new state variable value. Can be a comma separated list of values.
+     @param clearonsend whether the statevariable should be cleared immediatly after sending
      */
-    NPT_Result SetValue(const char* value);
+    NPT_Result SetValue(const char* value, const bool clearonsend = false);
     
     /**
      Validate the new value of the state variable.
@@ -173,6 +174,12 @@ protected:
     bool IsReadyToPublish();
     
     /**
+     * If this statevariable should clear after sending to all subscribers, clears the value without
+     * eventing the change
+     */
+    void OnSendCompleted();
+
+    /**
      Serialize the state variable into xml.
      */
 	NPT_Result Serialize(NPT_XmlElementNode& node);
@@ -189,6 +196,7 @@ protected:
     NPT_String              m_DefaultValue;
     bool                    m_IsSendingEvents;
     bool                    m_IsSendingEventsIndirectly;
+    bool                    m_ShouldClearOnSend;
     NPT_TimeInterval        m_Rate;
     NPT_TimeStamp           m_LastEvent;
     NPT_Array<NPT_String*>  m_AllowedValues;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4024,6 +4024,10 @@ bool CMusicDatabase::RemoveSongsFromPath(const CStdString &path1, CSongMap &song
 
       m_pDS->close();
 
+      //TODO: move this below the m_pDS->exec block, once UPnP doesn't rely on this anymore
+      for (unsigned int i = 0; i < ids.size(); i++)
+        AnnounceRemove("song", ids[i]);
+
       // and delete all songs, and anything linked to them
       sql = "delete from song where idSong in " + songIds;
       m_pDS->exec(sql.c_str());
@@ -4034,8 +4038,6 @@ bool CMusicDatabase::RemoveSongsFromPath(const CStdString &path1, CSongMap &song
       sql = "delete from karaokedata where idSong in " + songIds;
       m_pDS->exec(sql.c_str());
 
-      for (unsigned int i = 0; i < ids.size(); i++)
-        AnnounceRemove("song", ids[i]);
     }
     // and remove the path as well (it'll be re-added later on with the new hash if it's non-empty)
     sql = "delete from path" + where;

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -183,6 +183,7 @@ public:
             path += "/";
         }
 
+        CLog::Log(LOGDEBUG, "UPNP: notfified container update %s", (const char*)path);
         CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
         message.SetStringParam(path.GetChars());
         g_windowManager.SendThreadMessage(message);

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -10,6 +10,7 @@
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "guilib/Key.h"
 #include "music/tags/MusicInfoTag.h"
+#include "settings/GUISettings.h"
 #include "utils/log.h"
 #include "utils/md5.h"
 #include "utils/StringUtils.h"
@@ -129,7 +130,7 @@ CUPnPServer::PropagateUpdates()
     string buffer;
     map<string,pair<bool, unsigned long> >::iterator itr;
 
-    if (m_scanning)
+    if (m_scanning || !g_guiSettings.GetBool("services.upnpannounce"))
         return;
 
     NPT_CHECK_LABEL(FindServiceById("urn:upnp-org:serviceId:ContentDirectory", service), failed);

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -19,6 +19,7 @@
  *
  */
 #include "PltMediaConnect.h"
+#include "interfaces/IAnnouncer.h"
 #include "FileItem.h"
 
 class PLT_MediaObject;
@@ -28,13 +29,13 @@ namespace UPNP
 {
 
 class CUPnPServer : public PLT_MediaConnect,
-                    public PLT_FileMediaConnectDelegate
+                    public PLT_FileMediaConnectDelegate,
+                    public ANNOUNCEMENT::IAnnouncer
 {
 public:
-    CUPnPServer(const char* friendly_name, const char* uuid = NULL, int port = 0) :
-        PLT_MediaConnect(friendly_name, false, uuid, port),
-        PLT_FileMediaConnectDelegate("/", "/") {
-    }
+    CUPnPServer(const char* friendly_name, const char* uuid = NULL, int port = 0);
+    ~CUPnPServer();
+    virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
 
     // PLT_MediaServer methods
     virtual NPT_Result OnBrowseMetadata(PLT_ActionReference&          action,
@@ -89,6 +90,10 @@ public:
 
 
 private:
+    void OnScanCompleted(int type);
+    void UpdateContainer(const std::string& id);
+    void PropagateUpdates();
+
     PLT_MediaObject* Build(CFileItemPtr                  item,
                            bool                          with_count,
                            const PLT_HttpRequestContext& context,
@@ -115,6 +120,8 @@ private:
     NPT_Mutex                       m_FileMutex;
     NPT_Map<NPT_String, NPT_String> m_FileMap;
 
+    std::map<std::string, std::pair<bool, unsigned long> > m_UpdateIDs;
+    bool m_scanning;
 public:
     // class members
     static NPT_UInt32 m_MaxReturnedItems;

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -829,6 +829,7 @@ void CGUISettings::Initialize()
 
   CSettingsCategory* srvUpnp = AddCategory(SETTINGS_SERVICE, "upnp", 20187);
   AddBool(srvUpnp, "services.upnpserver", 21360, false);
+  AddBool(srvUpnp, "services.upnpannounce", 20188, true);
   AddBool(srvUpnp, "services.upnprenderer", 21881, false);
 
 #ifdef HAS_WEB_SERVER

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -737,6 +737,11 @@ void CGUIWindowSettingsCategory::UpdateSettings()
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
       if (pControl) pControl->SetEnabled(g_guiSettings.GetBool("services.esenabled"));
     }
+    else if (strSetting.Equals("services.upnpannounce"))
+    {
+      CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
+      pControl->SetEnabled(g_guiSettings.GetBool("services.upnpserver"));
+    }
     else if (strSetting.Equals("audiocds.quality"))
     { // only visible if we are doing non-WAV ripping
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2730,13 +2730,15 @@ void CVideoDatabase::DeleteMovie(const CStdString& strFilenameAndPath, bool bKee
       m_pDS->exec(strSQL.c_str());
     }
 
+    //TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore
+    if (!bKeepId)
+      AnnounceRemove("movie", idMovie);
+
     CStdString strPath, strFileName;
     SplitPath(strFilenameAndPath,strPath,strFileName);
     InvalidatePathHash(strPath);
     CommitTransaction();
 
-    if (!bKeepId)
-      AnnounceRemove("movie", idMovie);
   }
   catch (...)
   {
@@ -2800,12 +2802,14 @@ void CVideoDatabase::DeleteTvShow(const CStdString& strPath, bool bKeepId /* = f
       m_pDS->exec(strSQL.c_str());
     }
 
+    //TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore
+    if (!bKeepId)
+      AnnounceRemove("tvshow", idTvShow);
+
     InvalidatePathHash(strPath);
 
     CommitTransaction();
 
-    if (!bKeepId)
-      AnnounceRemove("tvshow", idTvShow);
   }
   catch (...)
   {
@@ -2839,6 +2843,10 @@ void CVideoDatabase::DeleteEpisode(const CStdString& strFilenameAndPath, int idE
       }
     }
 
+    //TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore
+    if (!bKeepId)
+      AnnounceRemove("episode", idEpisode);
+
     CStdString strSQL;
     strSQL=PrepareSQL("delete from actorlinkepisode where idEpisode=%i", idEpisode);
     m_pDS->exec(strSQL.c_str());
@@ -2861,8 +2869,6 @@ void CVideoDatabase::DeleteEpisode(const CStdString& strFilenameAndPath, int idE
       m_pDS->exec(strSQL.c_str());
     }
 
-    if (!bKeepId)
-      AnnounceRemove("episode", idEpisode);
   }
   catch (...)
   {
@@ -2921,13 +2927,15 @@ void CVideoDatabase::DeleteMusicVideo(const CStdString& strFilenameAndPath, bool
       m_pDS->exec(strSQL.c_str());
     }
 
+    //TODO: move this below CommitTransaction() once UPnP doesn't rely on this anymore
+    if (!bKeepId)
+      AnnounceRemove("musicvideo", idMVideo);
+
     CStdString strPath, strFileName;
     SplitPath(strFilenameAndPath,strPath,strFileName);
     InvalidatePathHash(strPath);
     CommitTransaction();
 
-    if (!bKeepId)
-      AnnounceRemove("musicvideo", idMVideo);
   }
   catch (...)
   {


### PR DESCRIPTION
This should hopefully go in to - as it stands we never tell clients that items have been updated. They must restart XBMC in order to get a refreshed listing.

This is a ContentDirectory:1 compliant (though not particularly efficient) way of handling this.

Everytime an item is updated and announced, we increment the container's updateid and set a modified bit. Then we update the ContainerUpdateIDs statevariable in Platinum. Clients are then notified.

ContentDirectory:3 has a better way to achieve this - only updating the actual object's metadata, not the entire container but that is a lot more work to achieve.

Users can disable this if they find it annoying (enabled by default).

We should look at the list of which containers are updated for particular events (ie VideoDb scan), MusicItem being updated, as currently every item is updated after a play event - and therefore the Songs / Movies container is updated - which is a performance nightmare. These are to be found in CUPnPServer::Announce and UPNP::audio_containers UPNP::video_containers. There is probably a happy medium to be found.

I'm also going to add a commit which adds a context menu entry (Refresh Listing) to UPNP listings, for the case where  user has disabled announcements from XBMC. (NB: that as it stands, updates from other devices are respected).
