### PR TITLE
Implement file copy from "videodb://" source and refine target filenames

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -567,6 +567,7 @@
     <ClCompile Include="..\..\xbmc\filesystem\VideoDatabaseDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\FileSystem\VideoDatabaseDirectory\DirectoryNodeCountry.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\VideoDatabaseDirectory\DirectoryNodeTags.cpp" />
+    <ClCompile Include="..\..\xbmc\filesystem\VideoDatabaseFile.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\windows\WINFileSMB.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\windows\WINSMBDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\VirtualDirectory.cpp" />
@@ -1017,6 +1018,7 @@
     <ClInclude Include="..\..\xbmc\DbUrl.h" />
     <ClInclude Include="..\..\xbmc\filesystem\ImageFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\VideoDatabaseDirectory\DirectoryNodeTags.h" />
+    <ClInclude Include="..\..\xbmc\filesystem\VideoDatabaseFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINFileSMB.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINSMBDirectory.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIKeyboard.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2933,6 +2933,9 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxBXA.cpp">
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\filesystem\VideoDatabaseFile.cpp">
+      <Filter>filesystem</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5733,6 +5736,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\Screenshot.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\filesystem\VideoDatabaseFile.h">
+      <Filter>filesystem</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -82,6 +82,7 @@
 #include "PipesManager.h"
 #include "PipeFile.h"
 #include "MusicDatabaseFile.h"
+#include "VideoDatabaseFile.h"
 #include "SpecialProtocolFile.h"
 #include "MultiPathFile.h"
 #include "TuxBoxFile.h"
@@ -128,7 +129,7 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
 #endif
   }
   else if (strProtocol == "musicdb") return new CMusicDatabaseFile();
-  else if (strProtocol == "videodb") return NULL;
+  else if (strProtocol == "videodb") return new CVideoDatabaseFile();
   else if (strProtocol == "special") return new CSpecialProtocolFile();
   else if (strProtocol == "multipath") return new CMultiPathFile();
   else if (strProtocol == "image") return new CImageFile();

--- a/xbmc/filesystem/Makefile.in
+++ b/xbmc/filesystem/Makefile.in
@@ -82,6 +82,7 @@ SRCS += udf25.cpp
 SRCS += UDFDirectory.cpp
 SRCS += UDFFile.cpp
 SRCS += VideoDatabaseDirectory.cpp
+SRCS += VideoDatabaseFile.cpp
 SRCS += VirtualDirectory.cpp
 SRCS += VTPDirectory.cpp
 SRCS += VTPFile.cpp

--- a/xbmc/filesystem/VideoDatabaseFile.cpp
+++ b/xbmc/filesystem/VideoDatabaseFile.cpp
@@ -1,0 +1,121 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "VideoDatabaseFile.h"
+#include "video/VideoDatabase.h"
+#include "URL.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+#include <sys/stat.h>
+
+using namespace XFILE;
+
+CVideoDatabaseFile::CVideoDatabaseFile(void)
+{
+}
+
+CVideoDatabaseFile::~CVideoDatabaseFile(void)
+{
+  Close();
+}
+
+CStdString CVideoDatabaseFile::TranslateUrl(const CURL& url)
+{
+  CVideoDatabase videoDatabase;
+  if (!videoDatabase.Open())
+    return "";
+
+  CStdString strPath;
+  URIUtils::GetDirectory(url.Get(), strPath);
+  CStdString strFileName=URIUtils::GetFileName(url.Get());
+  CStdString strExtension;
+  URIUtils::GetExtension(strFileName, strExtension);
+  URIUtils::RemoveExtension(strFileName);
+
+  if (!StringUtils::IsNaturalNumber(strFileName))
+    return "";
+  long idFile=atol(strFileName.c_str());
+
+  CStdStringArray pathElem;
+  StringUtils::SplitString(strPath, "/", pathElem);
+  if (pathElem.size() == 0)
+    return "";
+  if (!StringUtils::IsNaturalNumber(pathElem.at(2)))
+    return "";
+  long type=atol(pathElem.at(2).c_str());
+  switch (type) {
+  case 4:
+    type = 1;
+    break;
+  case 5:
+    type = 4;
+    break;
+  case 6:
+    type = 3;
+    break;
+  }
+
+  CStdString realFilename;
+  videoDatabase.GetFilePathById(idFile, realFilename, (VIDEODB_CONTENT_TYPE)type);
+
+  return realFilename;
+}
+
+bool CVideoDatabaseFile::Open(const CURL& url)
+{
+  return m_file.Open(TranslateUrl(url));
+}
+
+bool CVideoDatabaseFile::Exists(const CURL& url)
+{
+  return !TranslateUrl(url).IsEmpty();
+}
+
+int CVideoDatabaseFile::Stat(const CURL& url, struct __stat64* buffer)
+{
+  return m_file.Stat(TranslateUrl(url), buffer);
+}
+
+unsigned int CVideoDatabaseFile::Read(void* lpBuf, int64_t uiBufSize)
+{
+  return m_file.Read(lpBuf, uiBufSize);
+}
+
+int64_t CVideoDatabaseFile::Seek(int64_t iFilePosition, int iWhence /*=SEEK_SET*/)
+{
+  return m_file.Seek(iFilePosition, iWhence);
+}
+
+void CVideoDatabaseFile::Close()
+{
+  m_file.Close();
+}
+
+int64_t CVideoDatabaseFile::GetPosition()
+{
+  return m_file.GetPosition();
+}
+
+int64_t CVideoDatabaseFile::GetLength()
+{
+  return m_file.GetLength();
+}
+

--- a/xbmc/filesystem/VideoDatabaseFile.h
+++ b/xbmc/filesystem/VideoDatabaseFile.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "IFile.h"
+#include "File.h"
+
+namespace XFILE
+{
+class CVideoDatabaseFile : public IFile
+{
+public:
+  CVideoDatabaseFile(void);
+  virtual ~CVideoDatabaseFile(void);
+  virtual bool Open(const CURL& url);
+  virtual bool Exists(const CURL& url);
+  virtual int Stat(const CURL& url, struct __stat64* buffer);
+
+  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
+  virtual void Close();
+  virtual int64_t GetPosition();
+  virtual int64_t GetLength();
+
+  static CStdString TranslateUrl(const CURL& url);
+protected:
+  CFile m_file;
+};
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5686,7 +5686,9 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter
         CFileItemPtr pItem(new CFileItem(movie));
 
         CVideoDbUrl itemUrl = videoUrl;
-        CStdString path; path.Format("%ld", movie.m_iDbId);
+        CStdString strFileName = record->at(VIDEODB_DETAILS_MOVIE_FILE).get_asString();
+        CStdString strExt = URIUtils::GetExtension(strFileName);
+        CStdString path; path.Format("%ld%s", movie.m_iDbId,strExt.c_str());
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
@@ -6105,11 +6107,13 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filt
         int idEpisode = record->at(0).get_asInt();
 
         CVideoDbUrl itemUrl = videoUrl;
+        CStdString strFileName = record->at(VIDEODB_DETAILS_EPISODE_FILE).get_asString();
+        CStdString strExt = URIUtils::GetExtension(strFileName);
         CStdString path;
         if (appendFullShowPath)
-          path.Format("%ld/%ld/%ld", record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_ID).get_asInt(), movie.m_iSeason, idEpisode);
+          path.Format("%ld/%ld/%ld%s", record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_ID).get_asInt(), movie.m_iSeason, idEpisode, strExt.c_str());
         else
-          path.Format("%ld", idEpisode);
+          path.Format("%ld%s", idEpisode, strExt.c_str());
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
@@ -6859,10 +6863,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const CStdString& strSearch, CFileIte
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d,musicvideo.c%02d,path.strPath from musicvideo,files,path where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_ALBUM,VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_ALBUM,strSearch.c_str());
-    else
-      strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d,musicvideo.c%02d from musicvideo where musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_ALBUM,VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_ALBUM,strSearch.c_str());
+    strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d,musicvideo.c%02d,path.strPath,files.strFilename from musicvideo,files,path where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_ALBUM,VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_ALBUM,strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -6875,8 +6876,10 @@ void CVideoDatabase::GetMusicVideosByAlbum(const CStdString& strSearch, CFileIte
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()+" - "+m_pDS->fv(2).get_asString()));
+      CStdString strFileName = m_pDS->fv("files.strFilename").get_asString();
+      CStdString strExt = URIUtils::GetExtension(strFileName);
       CStdString strDir;
-      strDir.Format("3/2/%ld",m_pDS->fv("musicvideo.idMVideo").get_asInt());
+      strDir.Format("3/2/%ld%s",m_pDS->fv("musicvideo.idMVideo").get_asInt(),strExt.c_str());
 
       pItem->SetPath("videodb://"+ strDir);
       pItem->m_bIsFolder=false;
@@ -6949,9 +6952,11 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filt
           g_passwordManager.IsDatabasePathUnlocked(musicvideo.m_strPath, g_settings.m_videoSources))
       {
         CFileItemPtr item(new CFileItem(musicvideo));
+        CStdString strFileName = record->at(VIDEODB_DETAILS_MUSICVIDEO_FILE).get_asString();
+        CStdString strExt = URIUtils::GetExtension(strFileName);
 
         CVideoDbUrl itemUrl = videoUrl;
-        CStdString path; path.Format("%ld", record->at(0).get_asInt());
+        CStdString path; path.Format("%ld%s", record->at(0).get_asInt(), strExt.c_str());
         itemUrl.AppendPath(path);
         item->SetPath(itemUrl.ToString());
 
@@ -7030,7 +7035,9 @@ bool CVideoDatabase::GetRandomMusicVideo(CFileItem* item, int& idSong, const CSt
       return false;
     }
     *item->GetVideoInfoTag() = GetDetailsForMusicVideo(m_pDS);
-    CStdString path; path.Format("videodb://3/2/%ld",item->GetVideoInfoTag()->m_iDbId);
+    CStdString strFileName = m_pDS->fv("strFilename").get_asString();
+    CStdString strExt = URIUtils::GetExtension(strFileName);
+    CStdString path; path.Format("videodb://3/2/%ld%s",item->GetVideoInfoTag()->m_iDbId,strExt.c_str());
     item->SetPath(path);
     idSong = m_pDS->fv("idMVideo").get_asInt();
     item->SetLabel(item->GetVideoInfoTag()->m_strTitle);
@@ -7098,10 +7105,7 @@ void CVideoDatabase::GetMoviesByName(const CStdString& strSearch, CFileItemList&
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select movie.idMovie,movie.c%02d,path.strPath, movie.idSet from movie,files,path where files.idFile=movie.idFile and files.idPath=path.idPath and movie.c%02d like '%%%s%%'",VIDEODB_ID_TITLE,VIDEODB_ID_TITLE,strSearch.c_str());
-    else
-      strSQL = PrepareSQL("select movie.idMovie,movie.c%02d, movie.idSet from movie where movie.c%02d like '%%%s%%'",VIDEODB_ID_TITLE,VIDEODB_ID_TITLE,strSearch.c_str());
+    strSQL = PrepareSQL("select movie.idMovie,movie.c%02d,path.strPath,files.strFilename, movie.idSet from movie,files,path where files.idFile=movie.idFile and files.idPath=path.idPath and movie.c%02d like '%%%s%%'",VIDEODB_ID_TITLE,VIDEODB_ID_TITLE,strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7117,10 +7121,12 @@ void CVideoDatabase::GetMoviesByName(const CStdString& strSearch, CFileItemList&
       int setId = m_pDS->fv("movie.idSet").get_asInt();
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
       CStdString path;
-      if (setId <= 0)
-        path.Format("videodb://1/2/%i", movieId);
+      CStdString strFileName = m_pDS->fv("files.strFilename").get_asString();
+      CStdString strExt = URIUtils::GetExtension(strFileName);
+       if (setId <= 0)
+        path.Format("videodb://1/2/%i%s", movieId, strExt.c_str());
       else
-        path.Format("videodb://1/7/%i/%i", setId, movieId);
+        path.Format("videodb://1/7/%i/%i%s", setId, movieId, strExt.c_str());
       pItem->SetPath(path);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
@@ -7185,10 +7191,7 @@ void CVideoDatabase::GetEpisodesByName(const CStdString& strSearch, CFileItemLis
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select episode.idEpisode,episode.c%02d,episode.c%02d,episode.idShow,tvshow.c%02d,path.strPath from episode,files,path,tvshow where files.idFile=episode.idFile and episode.idShow=tvshow.idShow and files.idPath=path.idPath and episode.c%02d like '%%%s%%'",VIDEODB_ID_EPISODE_TITLE,VIDEODB_ID_EPISODE_SEASON,VIDEODB_ID_TV_TITLE,VIDEODB_ID_EPISODE_TITLE,strSearch.c_str());
-    else
-      strSQL = PrepareSQL("select episode.idEpisode,episode.c%02d,episode.c%02d,episode.idShow,tvshow.c%02d from episode,tvshow where tvshow.idShow=episode.idShow and episode.c%02d like '%%%s%%'",VIDEODB_ID_EPISODE_TITLE,VIDEODB_ID_EPISODE_SEASON,VIDEODB_ID_TV_TITLE,VIDEODB_ID_EPISODE_TITLE,strSearch.c_str());
+    strSQL = PrepareSQL("select episode.idEpisode,episode.c%02d,episode.c%02d,episode.idShow,tvshow.c%02d,path.strPath,files.strFilename from episode,files,path,tvshow where files.idFile=episode.idFile and episode.idShow=tvshow.idShow and files.idPath=path.idPath and episode.c%02d like '%%%s%%'",VIDEODB_ID_EPISODE_TITLE,VIDEODB_ID_EPISODE_SEASON,VIDEODB_ID_TV_TITLE,VIDEODB_ID_EPISODE_TITLE,strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7201,7 +7204,9 @@ void CVideoDatabase::GetEpisodesByName(const CStdString& strSearch, CFileItemLis
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()+" ("+m_pDS->fv(4).get_asString()+")"));
-      CStdString path; path.Format("videodb://2/2/%ld/%ld/%ld",m_pDS->fv("episode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt());
+      CStdString strFileName = m_pDS->fv("files.strFilename").get_asString();
+      CStdString strExt = URIUtils::GetExtension(strFileName);
+       CStdString path; path.Format("videodb://2/2/%ld/%ld/%ld%s",m_pDS->fv("episode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt(),strExt.c_str());
       pItem->SetPath(path);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
@@ -7228,10 +7233,7 @@ void CVideoDatabase::GetMusicVideosByName(const CStdString& strSearch, CFileItem
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d,path.strPath from musicvideo,files,path where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_TITLE,strSearch.c_str());
-    else
-      strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d from musicvideo where musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_TITLE,strSearch.c_str());
+    strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d,path.strPath,files.strFilename from musicvideo,files,path where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_TITLE,strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7244,8 +7246,10 @@ void CVideoDatabase::GetMusicVideosByName(const CStdString& strSearch, CFileItem
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strFileName = m_pDS->fv("files.strFilename").get_asString();
+      CStdString strExt = URIUtils::GetExtension(strFileName);
       CStdString strDir;
-      strDir.Format("3/2/%ld",m_pDS->fv("musicvideo.idMVideo").get_asInt());
+      strDir.Format("3/2/%ld%s",m_pDS->fv("musicvideo.idMVideo").get_asInt(),strExt.c_str());
 
       pItem->SetPath("videodb://"+ strDir);
       pItem->m_bIsFolder=false;
@@ -7276,10 +7280,7 @@ void CVideoDatabase::GetEpisodesByPlot(const CStdString& strSearch, CFileItemLis
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select episode.idEpisode,episode.c%02d,episode.c%02d,episode.idShow,tvshow.c%02d,path.strPath from episode,files,path,tvshow where files.idFile=episode.idFile and files.idPath=path.idPath and tvshow.idShow=episode.idShow and episode.c%02d like '%%%s%%'",VIDEODB_ID_EPISODE_TITLE,VIDEODB_ID_EPISODE_SEASON,VIDEODB_ID_TV_TITLE,VIDEODB_ID_EPISODE_PLOT,strSearch.c_str());
-    else
-      strSQL = PrepareSQL("select episode.idEpisode,episode.c%02d,episode.c%02d,episode.idShow,tvshow.c%02d from episode,tvshow where tvshow.idShow=episode.idShow and episode.c%02d like '%%%s%%'",VIDEODB_ID_EPISODE_TITLE,VIDEODB_ID_EPISODE_SEASON,VIDEODB_ID_TV_TITLE,VIDEODB_ID_EPISODE_PLOT,strSearch.c_str());
+    strSQL = PrepareSQL("select episode.idEpisode,episode.c%02d,episode.c%02d,episode.idShow,tvshow.c%02d,path.strPath,files.strFilename from episode,files,path,tvshow where files.idFile=episode.idFile and files.idPath=path.idPath and tvshow.idShow=episode.idShow and episode.c%02d like '%%%s%%'",VIDEODB_ID_EPISODE_TITLE,VIDEODB_ID_EPISODE_SEASON,VIDEODB_ID_TV_TITLE,VIDEODB_ID_EPISODE_PLOT,strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7292,7 +7293,9 @@ void CVideoDatabase::GetEpisodesByPlot(const CStdString& strSearch, CFileItemLis
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()+" ("+m_pDS->fv(4).get_asString()+")"));
-      CStdString path; path.Format("videodb://2/2/%ld/%ld/%ld",m_pDS->fv("episode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt());
+      CStdString strFileName = m_pDS->fv("files.strFilename").get_asString();
+      CStdString strExt = URIUtils::GetExtension(strFileName);
+      CStdString path; path.Format("videodb://2/2/%ld/%ld/%ld%s",m_pDS->fv("episode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt(),strExt.c_str());
       pItem->SetPath(path);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
@@ -7315,11 +7318,7 @@ void CVideoDatabase::GetMoviesByPlot(const CStdString& strSearch, CFileItemList&
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select movie.idMovie, movie.c%02d, path.strPath from movie,files,path where files.idFile=movie.idFile and files.idPath=path.idPath and (movie.c%02d like '%%%s%%' or movie.c%02d like '%%%s%%' or movie.c%02d like '%%%s%%')",VIDEODB_ID_TITLE,VIDEODB_ID_PLOT,strSearch.c_str(),VIDEODB_ID_PLOTOUTLINE,strSearch.c_str(),VIDEODB_ID_TAGLINE,strSearch.c_str());
-    else
-      strSQL = PrepareSQL("select movie.idMovie, movie.c%02d from movie where (movie.c%02d like '%%%s%%' or movie.c%02d like '%%%s%%' or movie.c%02d like '%%%s%%')",VIDEODB_ID_TITLE,VIDEODB_ID_PLOT,strSearch.c_str(),VIDEODB_ID_PLOTOUTLINE,strSearch.c_str(),VIDEODB_ID_TAGLINE,strSearch.c_str());
-
+    strSQL = PrepareSQL("select movie.idMovie, movie.c%02d, path.strPath, files.strFilename from movie,files,path where files.idFile=movie.idFile and files.idPath=path.idPath and (movie.c%02d like '%%%s%%' or movie.c%02d like '%%%s%%' or movie.c%02d like '%%%s%%')",VIDEODB_ID_TITLE,VIDEODB_ID_PLOT,strSearch.c_str(),VIDEODB_ID_PLOTOUTLINE,strSearch.c_str(),VIDEODB_ID_TAGLINE,strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7332,7 +7331,9 @@ void CVideoDatabase::GetMoviesByPlot(const CStdString& strSearch, CFileItemList&
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
-      CStdString path; path.Format("videodb://1/2/%ld", m_pDS->fv(0).get_asInt());
+      CStdString strFileName = m_pDS->fv("files.strFilename").get_asString();
+      CStdString strExt = URIUtils::GetExtension(strFileName);
+      CStdString path; path.Format("videodb://1/2/%ld%s", m_pDS->fv(0).get_asInt(),strExt.c_str());
       pItem->SetPath(path);
       pItem->m_bIsFolder=false;
 


### PR DESCRIPTION
This is still quite experimental and would like to receive comments about it.

The main point is to be able to copy, in the file browser, from a videodb:// source to a "hard" destination.
The use case being to be able to export files from the database for mobile use, being android, rpi or other, even non-xbmc.

Main points of attention:
1) To align with the music database, I've added the extension to the "videodb://" url's. 
This is not stricto sensu mandatory, but I think it is, both for consistency with the music db and with the url concept, a good idea.
Obviously, it is quite dangerous and is likely to break any piece of code assuming a videodb url without extension. Any hint on where this is likely to break is welcome.
2) The concept of exporting a video file for "mobile" xbmc usage would ideally also require to export the .nfo/.tbn and implementation of the "mythical" nfo only scrapping.

Thanks for giving feedback
