### PR TITLE
allow skin.setpath to take a second parameter of the path to search

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1193,6 +1193,19 @@ int CBuiltins::Execute(const CStdString& execString)
     else // execute.Equals("skin.setpath"))
     {
       g_mediaManager.GetNetworkLocations(localShares);
+      if (params.size() > 1)
+      {
+        value = params[1];
+        URIUtils::AddSlashAtEnd(value);
+        bool bIsSource;
+        if (CUtil::GetMatchingSource(value,localShares,bIsSource) < 0) // path is outside shares - add it as a separate one
+        {
+          CMediaSource share;
+          share.strName = g_localizeStrings.Get(13278);
+          share.strPath = value;
+          localShares.push_back(share);
+        }
+      }
       if (CGUIDialogFileBrowser::ShowAndGetDirectory(localShares, g_localizeStrings.Get(1031), value))
         g_settings.SetSkinString(string, value);
     }


### PR DESCRIPTION
Simple one.  This allows skinners to make buttons on home point to the users' library://video/ nodes.
