### PR TITLE
configure: pass --enable-external-ffmpeg down to pvr-addons, when building them intree

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2730,11 +2730,15 @@ XB_CONFIG_MODULE([lib/gtest], [
 ], [$SKIP_CONFIG_GTEST])
 
 XB_CONFIG_MODULE([pvr-addons], [
+   if test "$USE_EXTERNAL_FFMPEG" = 1; then
+      PVR_EXT_FFMPEG="--enable-external-ffmpeg"
+   fi
   ./configure \
     --prefix="${prefix}" \
     --host=$host_alias \
     --build=$build_alias \
     --target=$target_alias \
+    $PVR_EXT_FFMPEG \
     CC="$CC" \
     CXX="$CXX" \
     CFLAGS="$CFLAGS" \


### PR DESCRIPTION
Since pvr-addons can now be built with external ffmpeg, it makes sense to pass the flag to pvr-addons too, if xbmc is built with external libs/ffmpeg.

tested on linux. 
