### PR TITLE
JSON-RPC: add "art" property to retrieve the full artwork map

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -18,7 +18,9 @@
  *
  */
 
+#include <map>
 #include <string.h>
+
 #include "FileItemHandler.h"
 #include "PlaylistOperations.h"
 #include "AudioLibrary.h"
@@ -81,6 +83,19 @@ bool CFileItemHandler::GetField(const std::string &field, const CVariant &info, 
     if (item->HasProperty("artist_" + field))
     {
       result[field] = item->GetProperty("artist_" + field);
+      return true;
+    }
+
+    if (field == "art")
+    {
+      if (thumbLoader != NULL && item->GetArt().size() <= 0 && !fetchedArt &&
+        ((item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iDbId > -1) || (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetDatabaseId() > -1)))
+      {
+        thumbLoader->FillLibraryArt(*item);
+        fetchedArt = true;
+      }
+
+      result["art"] = item->GetArt();
       return true;
     }
     

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -70,6 +70,10 @@ namespace JSONRPC
         "{ \"type\": \"string\", \"enum\": [ \"toggle\" ], \"required\": true }"
       "]"
     "}",
+    "\"Global.String.NotEmpty\": {"
+      "\"type\": \"string\","
+      "\"minLength\": 1"
+    "}",
     "\"Configuration.Notifications\": {"
       "\"type\": \"object\","
       "\"properties\": {"
@@ -327,6 +331,16 @@ namespace JSONRPC
         "\"thumbnail\": { \"type\": \"string\" }"
       "}"
     "}",
+    "\"Media.Artwork\": {"
+      "\"type\": \"object\","
+      "\"properties\": {"
+        "\"thumb\": { \"$ref\": \"Global.String.NotEmpty\" },"
+        "\"poster\": { \"$ref\": \"Global.String.NotEmpty\" },"
+        "\"banner\": { \"$ref\": \"Global.String.NotEmpty\" },"
+        "\"fanart\": { \"$ref\": \"Global.String.NotEmpty\" }"
+      "},"
+      "\"additionalProperties\": { \"$ref\": \"Global.String.NotEmpty\" }"
+    "}",
     "\"Library.Fields.Genre\": {"
       "\"extends\": \"Item.Fields.Base\","
       "\"items\": { \"type\": \"string\", \"enum\": [ \"title\", \"thumbnail\" ] }"
@@ -444,13 +458,13 @@ namespace JSONRPC
                   "\"playcount\", \"writer\", \"studio\", \"mpaa\", \"cast\", \"country\","
                   "\"imdbnumber\", \"runtime\", \"set\", \"showlink\", \"streamdetails\","
                   "\"top250\", \"votes\", \"fanart\", \"thumbnail\", \"file\", \"sorttitle\","
-                  "\"resume\", \"setid\", \"dateadded\", \"tag\" ]"
+                  "\"resume\", \"setid\", \"dateadded\", \"tag\", \"art\" ]"
       "}"
     "}",
     "\"Video.Fields.MovieSet\": {"
       "\"extends\": \"Item.Fields.Base\","
       "\"items\": { \"type\": \"string\","
-        "\"enum\": [ \"title\", \"playcount\", \"fanart\", \"thumbnail\" ]"
+        "\"enum\": [ \"title\", \"playcount\", \"fanart\", \"thumbnail\", \"art\" ]"
       "}"
     "}",
     "\"Video.Fields.TVShow\": {"
@@ -462,14 +476,14 @@ namespace JSONRPC
                   "\"imdbnumber\", \"premiered\", \"votes\", \"lastplayed\","
                   "\"fanart\", \"thumbnail\", \"file\", \"originaltitle\","
                   "\"sorttitle\", \"episodeguide\", \"season\", \"watchedepisodes\","
-                  "\"dateadded\", \"tag\", \"lastplayed\" ]"
+                  "\"dateadded\", \"tag\", \"lastplayed\", \"art\" ]"
       "}"
     "}",
     "\"Video.Fields.Season\": {"
       "\"extends\": \"Item.Fields.Base\","
       "\"items\": { \"type\": \"string\","
         "\"enum\": [ \"season\", \"showtitle\", \"playcount\", \"episode\", \"fanart\", \"thumbnail\", \"tvshowid\","
-                  "\"watchedepisodes\" ]"
+                  "\"watchedepisodes\", \"art\" ]"
       "}"
     "}",
     "\"Video.Fields.Episode\": {"
@@ -480,7 +494,8 @@ namespace JSONRPC
                   "\"firstaired\", \"playcount\", \"runtime\", \"director\","
                   "\"productioncode\", \"season\", \"episode\", \"originaltitle\","
                   "\"showtitle\", \"cast\", \"streamdetails\", \"lastplayed\", \"fanart\","
-                  "\"thumbnail\", \"file\", \"resume\", \"tvshowid\", \"dateadded\", \"uniqueid\" ]"
+                  "\"thumbnail\", \"file\", \"resume\", \"tvshowid\", \"dateadded\","
+                  "\"uniqueid\", \"art\" ]"
       "}"
     "}",
     "\"Video.Fields.MusicVideo\": {"
@@ -489,7 +504,8 @@ namespace JSONRPC
         "\"enum\": [ \"title\", \"playcount\", \"runtime\", \"director\","
                   "\"studio\", \"year\", \"plot\", \"album\", \"artist\","
                   "\"genre\", \"track\", \"streamdetails\", \"lastplayed\","
-                  "\"fanart\", \"thumbnail\", \"file\", \"resume\", \"dateadded\", \"tag\" ]"
+                  "\"fanart\", \"thumbnail\", \"file\", \"resume\", \"dateadded\","
+                  "\"tag\", \"art\" ]"
       "}"
     "}",
     "\"Video.Cast\": {"
@@ -550,7 +566,8 @@ namespace JSONRPC
     "\"Video.Details.Base\": {"
       "\"extends\": \"Media.Details.Base\","
       "\"properties\": {"
-        "\"playcount\": { \"type\": \"integer\" }"
+        "\"playcount\": { \"type\": \"integer\" },"
+        "\"art\": { \"$ref\": \"Media.Artwork\" }"
       "}"
     "}",
     "\"Video.Details.Media\": {"
@@ -934,7 +951,7 @@ namespace JSONRPC
                   "\"runtime\", \"set\", \"showlink\", \"streamdetails\", \"top250\", \"votes\","
                   "\"firstaired\", \"season\", \"episode\", \"showtitle\", \"thumbnail\", \"file\","
                   "\"resume\", \"artistid\", \"albumid\", \"tvshowid\", \"setid\", \"watchedepisodes\","
-                  "\"disc\", \"tag\" ]"
+                  "\"disc\", \"tag\", \"art\" ]"
       "}"
     "}",
     "\"List.Item.All\": {"

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -2411,7 +2411,8 @@ namespace JSONRPC
         "{ \"name\": \"showlink\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null },"
         "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" },"
-        "{ \"name\": \"tag\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null }"
+        "{ \"name\": \"tag\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null },"
+        "{ \"name\": \"art\", \"type\": [ \"null\", { \"$ref\": \"Media.Artwork\", \"required\": true } ], \"default\": null }"
       "],"
       "\"returns\": \"string\""
     "}",
@@ -2438,7 +2439,8 @@ namespace JSONRPC
         "{ \"name\": \"episodeguide\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" },"
-        "{ \"name\": \"tag\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null }"
+        "{ \"name\": \"tag\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null },"
+        "{ \"name\": \"art\", \"type\": [ \"null\", { \"$ref\": \"Media.Artwork\", \"required\": true } ], \"default\": null }"
       "],"
       "\"returns\": \"string\""
     "}",
@@ -2464,7 +2466,8 @@ namespace JSONRPC
         "{ \"name\": \"episode\", \"$ref\": \"Optional.Integer\" },"
         "{ \"name\": \"originaltitle\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
-        "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" }"
+        "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"art\", \"type\": [ \"null\", { \"$ref\": \"Media.Artwork\", \"required\": true } ], \"default\": null }"
       "],"
       "\"returns\": \"string\""
     "}",
@@ -2489,7 +2492,8 @@ namespace JSONRPC
         "{ \"name\": \"lastplayed\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" },"
-        "{ \"name\": \"tag\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null }"
+        "{ \"name\": \"tag\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null },"
+        "{ \"name\": \"art\", \"type\": [ \"null\", { \"$ref\": \"Media.Artwork\", \"required\": true } ], \"default\": null }"
       "],"
       "\"returns\": \"string\""
     "}",

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -935,4 +935,13 @@ void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTa
     artwork["fanart"] = parameterObject["fanart"].asString();
   if (ParameterNotNull(parameterObject, "tag"))
     CopyStringArray(parameterObject["tag"], details.m_tags);
+  if (ParameterNotNull(parameterObject, "art"))
+  {
+    CVariant art = parameterObject["art"];
+    for (CVariant::const_iterator_map artIt = art.begin_map(); artIt != art.end_map(); artIt++)
+    {
+      if (!artIt->second.asString().empty())
+        artwork[artIt->first] = artIt->second.asString();
+    }
+  }
 }

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -1261,7 +1261,8 @@
       { "name": "showlink", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null },
       { "name": "thumbnail", "$ref": "Optional.String" },
       { "name": "fanart", "$ref": "Optional.String" },
-      { "name": "tag", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null }
+      { "name": "tag", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null },
+      { "name": "art", "type": [ "null", { "$ref": "Media.Artwork", "required": true } ], "default": null }
     ],
     "returns": "string"
   },
@@ -1288,7 +1289,8 @@
       { "name": "episodeguide", "$ref": "Optional.String" },
       { "name": "thumbnail", "$ref": "Optional.String" },
       { "name": "fanart", "$ref": "Optional.String" },
-      { "name": "tag", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null }
+      { "name": "tag", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null },
+      { "name": "art", "type": [ "null", { "$ref": "Media.Artwork", "required": true } ], "default": null }
     ],
     "returns": "string"
   },
@@ -1314,7 +1316,8 @@
       { "name": "episode", "$ref": "Optional.Integer" },
       { "name": "originaltitle", "$ref": "Optional.String" },
       { "name": "thumbnail", "$ref": "Optional.String" },
-      { "name": "fanart", "$ref": "Optional.String" }
+      { "name": "fanart", "$ref": "Optional.String" },
+      { "name": "art", "type": [ "null", { "$ref": "Media.Artwork", "required": true } ], "default": null }
     ],
     "returns": "string"
   },
@@ -1339,7 +1342,8 @@
       { "name": "lastplayed", "$ref": "Optional.String" },
       { "name": "thumbnail", "$ref": "Optional.String" },
       { "name": "fanart", "$ref": "Optional.String" },
-      { "name": "tag", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null }
+      { "name": "tag", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null },
+      { "name": "art", "type": [ "null", { "$ref": "Media.Artwork", "required": true } ], "default": null }
     ],
     "returns": "string"
   },

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -43,6 +43,10 @@
       { "type": "string", "enum": [ "toggle" ], "required": true }
     ]
   },
+  "Global.String.NotEmpty": {
+    "type": "string",
+    "minLength": 1
+  },
   "Configuration.Notifications": {
     "type": "object",
     "properties": {
@@ -300,6 +304,16 @@
       "thumbnail": { "type": "string" }
     }
   },
+  "Media.Artwork": {
+    "type": "object",
+    "properties": {
+      "thumb": { "$ref": "Global.String.NotEmpty" },
+      "poster": { "$ref": "Global.String.NotEmpty" },
+      "banner": { "$ref": "Global.String.NotEmpty" },
+      "fanart": { "$ref": "Global.String.NotEmpty" }
+    },
+    "additionalProperties": { "$ref": "Global.String.NotEmpty" }
+  },
   "Library.Fields.Genre": {
     "extends": "Item.Fields.Base",
     "items": { "type": "string", "enum": [ "title", "thumbnail" ] }
@@ -417,13 +431,13 @@
                 "playcount", "writer", "studio", "mpaa", "cast", "country",
                 "imdbnumber", "runtime", "set", "showlink", "streamdetails",
                 "top250", "votes", "fanart", "thumbnail", "file", "sorttitle",
-                "resume", "setid", "dateadded", "tag" ]
+                "resume", "setid", "dateadded", "tag", "art" ]
     }
   },
   "Video.Fields.MovieSet": {
     "extends": "Item.Fields.Base",
     "items": { "type": "string",
-      "enum": [ "title", "playcount", "fanart", "thumbnail" ]
+      "enum": [ "title", "playcount", "fanart", "thumbnail", "art" ]
     }
   },
   "Video.Fields.TVShow": {
@@ -435,14 +449,14 @@
                 "imdbnumber", "premiered", "votes", "lastplayed",
                 "fanart", "thumbnail", "file", "originaltitle",
                 "sorttitle", "episodeguide", "season", "watchedepisodes",
-                "dateadded", "tag", "lastplayed" ]
+                "dateadded", "tag", "lastplayed", "art" ]
     }
   },
   "Video.Fields.Season": {
     "extends": "Item.Fields.Base",
     "items": { "type": "string",
       "enum": [ "season", "showtitle", "playcount", "episode", "fanart", "thumbnail", "tvshowid",
-                "watchedepisodes" ]
+                "watchedepisodes", "art" ]
     }
   },
   "Video.Fields.Episode": {
@@ -453,7 +467,8 @@
                 "firstaired", "playcount", "runtime", "director",
                 "productioncode", "season", "episode", "originaltitle",
                 "showtitle", "cast", "streamdetails", "lastplayed", "fanart",
-                "thumbnail", "file", "resume", "tvshowid", "dateadded", "uniqueid" ]
+                "thumbnail", "file", "resume", "tvshowid", "dateadded",
+                "uniqueid", "art" ]
     }
   },
   "Video.Fields.MusicVideo": {
@@ -462,7 +477,8 @@
       "enum": [ "title", "playcount", "runtime", "director",
                 "studio", "year", "plot", "album", "artist",
                 "genre", "track", "streamdetails", "lastplayed",
-                "fanart", "thumbnail", "file", "resume", "dateadded", "tag" ]
+                "fanart", "thumbnail", "file", "resume", "dateadded",
+                "tag", "art" ]
     }
   },
   "Video.Cast": {
@@ -523,7 +539,8 @@
   "Video.Details.Base": {
     "extends": "Media.Details.Base",
     "properties": {
-      "playcount": { "type": "integer" }
+      "playcount": { "type": "integer" },
+      "art": { "$ref": "Media.Artwork" }
     }
   },
   "Video.Details.Media": {
@@ -907,7 +924,7 @@
                 "runtime", "set", "showlink", "streamdetails", "top250", "votes",
                 "firstaired", "season", "episode", "showtitle", "thumbnail", "file",
                 "resume", "artistid", "albumid", "tvshowid", "setid", "watchedepisodes",
-                "disc", "tag" ]
+                "disc", "tag", "art" ]
     }
   },
   "List.Item.All": {

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -233,6 +233,20 @@ CVariant::CVariant(const std::vector<std::string> &strArray)
     m_data.array->push_back(strArray.at(index));
 }
 
+CVariant::CVariant(const std::map<std::string, std::string> &strMap)
+{
+  m_type = VariantTypeObject;
+  m_data.map = new VariantMap;
+  for (std::map<std::string, std::string>::const_iterator it = strMap.begin(); it != strMap.end(); it++)
+    m_data.map->insert(make_pair(it->first, CVariant(it->second)));
+}
+
+CVariant::CVariant(const std::map<std::string, CVariant> &variantMap)
+{
+  m_type = VariantTypeObject;
+  m_data.map = new VariantMap(variantMap.begin(), variantMap.end());
+}
+
 CVariant::CVariant(const CVariant &variant)
 {
   m_type = VariantTypeNull;

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -63,6 +63,8 @@ public:
   CVariant(const wchar_t *str, unsigned int length);
   CVariant(const std::wstring &str);
   CVariant(const std::vector<std::string> &strArray);
+  CVariant(const std::map<std::string, std::string> &strMap);
+  CVariant(const std::map<std::string, CVariant> &variantMap);
   CVariant(const CVariant &variant);
   ~CVariant();
 

--- a/xbmc/utils/test/TestVariant.cpp
+++ b/xbmc/utils/test/TestVariant.cpp
@@ -137,6 +137,31 @@ TEST(TestVariant, VariantTypeNull)
   EXPECT_EQ(CVariant::VariantTypeNull, a.type());
 }
 
+TEST(TestVariant, VariantFromMap)
+{
+  std::map<std::string, std::string> strMap;
+  strMap["key"] = "value";
+  CVariant a = strMap;
+  
+  EXPECT_TRUE(a.isObject());
+  EXPECT_TRUE(a.size() == 1);
+  EXPECT_EQ(CVariant::VariantTypeObject, a.type());
+  EXPECT_TRUE(a.isMember("key"));
+  EXPECT_TRUE(a["key"].isString());
+  EXPECT_STREQ(a["key"].asString().c_str(), "value");
+  
+  std::map<std::string, CVariant> variantMap;
+  variantMap["key"] = CVariant("value");
+  CVariant b = variantMap;
+  
+  EXPECT_TRUE(b.isObject());
+  EXPECT_TRUE(b.size() == 1);
+  EXPECT_EQ(CVariant::VariantTypeObject, b.type());
+  EXPECT_TRUE(b.isMember("key"));
+  EXPECT_TRUE(b["key"].isString());
+  EXPECT_STREQ(b["key"].asString().c_str(), "value");
+}
+
 TEST(TestVariant, operatorTest)
 {
   std::vector<std::string> strarray;


### PR DESCRIPTION
After @jmarshallnz's work on supporting multiple artwork simultaneously this adds an "art" property to VideoLibrary.GetFoo and VideoLibrary.SetFooDetails methods which allows to both retrieve and set/change the artwork values. There's no real sanity checking on the name of an artwork but as we want to support arbitrary artwork types in the future it doesn't make much sense.
