### PR TITLE
custom library nodes: allow optional <path> tag in filter nodes

### DIFF
--- a/system/library/video/recentlyaddedepisodes.xml
+++ b/system/library/video/recentlyaddedepisodes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="11" type="filter" visible="Library.HasContent(TVShows)">
   <label>20387</label>
+  <path>videodb://5/</path>
   <icon>DefaultRecentlyAddedEpisodes.png</icon>
   <content>episodes</content>
   <order direction="descending">dateadded</order>

--- a/system/library/video/recentlyaddedmovies.xml
+++ b/system/library/video/recentlyaddedmovies.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="10" type="filter" visible="Library.HasContent(Movies)">
   <label>20386</label>
+  <path>videodb://4/</path>
   <icon>DefaultRecentlyAddedMovies.png</icon>
   <content>movies</content>
   <order direction="descending">dateadded</order>

--- a/system/library/video/recentlyaddedmusicvideos.xml
+++ b/system/library/video/recentlyaddedmusicvideos.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="12" type="filter" visible="Library.HasContent(MusicVideos)">
   <label>20390</label>
+  <path>videodb://6/</path>
   <icon>DefaultRecentlyAddedMusicVideos.png</icon>
   <content>musicvideos</content>
   <order direction="descending">dateadded</order>

--- a/system/library/video_flat/recentlyaddedepisodes.xml
+++ b/system/library/video_flat/recentlyaddedepisodes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="11" type="filter" visible="Library.HasContent(TVShows)">
   <label>20387</label>
+  <path>videodb://5/</path>
   <icon>DefaultRecentlyAddedEpisodes.png</icon>
   <content>episodes</content>
   <order direction="descending">dateadded</order>

--- a/system/library/video_flat/recentlyaddedmovies.xml
+++ b/system/library/video_flat/recentlyaddedmovies.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="10" type="filter" visible="Library.HasContent(Movies)">
   <label>20386</label>
+  <path>videodb://4/</path>
   <icon>DefaultRecentlyAddedMovies.png</icon>
   <content>movies</content>
   <order direction="descending">dateadded</order>

--- a/system/library/video_flat/recentlyaddedmusicvideos.xml
+++ b/system/library/video_flat/recentlyaddedmusicvideos.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="12" type="filter" visible="Library.HasContent(MusicVideos)">
   <label>20390</label>
+  <path>videodb://6/</path>
   <icon>DefaultRecentlyAddedMusicVideos.png</icon>
   <content>musicvideos</content>
   <order direction="descending">dateadded</order>

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -75,6 +75,12 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
             CSmartPlaylistDirectory::GetDirectory(playlist, items))
         {
           items.SetProperty("library.filter", "true");
+
+          CStdString path;
+          XMLUtils::GetPath(node, "path", path);
+          if (!path.empty())
+            items.SetPath(path);
+          
           return true;
         }
       }


### PR DESCRIPTION
@jmarshallnz this is more of a work around than a proper fix.

The problem is that since we switched the recentlyadded XML nodes to a filter and therefore doing the retrieval through CSmartPlaylistDirectory and not through CVideoDatabaseDirectory as before we get a different path for the list of items (e.g. videodb://2/2/-1/-1/ instead of videodb://5/ for recently added episodes) which results in the media window logic picking the "wrong" GUI view state. The recentlyadded-specific GUI view state doesn't allow any extra sorting whereas the media-specific GUI view states allow sorting and don't contain the Sort By Playlist functionality which results in the list of recently added items being re-sorted (By Name by default) after retrieval and not being in the proper order anymore.

With this fix we retrieve the <path> tag also for filter nodes (if it's set) and assign it to the list of items. This will still result in going through CSmartPlaylistDirectory instead of CVideoDatabaseDirectory but the media windows logic will be able to determine the proper GUI view state based on the path of the items.

Let me know if anyone has another idea/approach to solve this problem.
