### PR TITLE
[UPnP] increase number of requested items per iteration. gives 2-3 times...

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
@@ -263,7 +263,7 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_DeviceDataReference&      device,
             device,
             (const char*)object_id,
             index,
-            metadata?1:30, // DLNA recommendations for browsing children is no more than 30 at a time
+            metadata?1:200, // DLNA recommendations for browsing children is no more than 30 at a time
             filter,
             metadata);		
         NPT_CHECK_LABEL_WARNING(res, done);


### PR DESCRIPTION
... speed up.

Currently we browse for max 30 items at a time. Apparantly that's what DLNA recommends, the other clients I'm testing use between 100 & 200.

Testing this with a HEAD xbmc server & an eden server - gives the following results

Browse Actors (1700 items) - 14 seconds vs 35.
Browse MovieTitles(180) - 1.5 seconds vs 4.
Browse Albums(690) 4 seconds vs 9.

bumping from 30 to 200 might seem farcical, but this is the only way to get a reasonable speedup from the Actors node.

If we just want a speed up from Movies & songs, then something like 100 also gives us the same speedup.

As we're now resetting the cache on updates - this is pretty important.
