### PR TITLE
jsonrpc: force media item refresh after changing an item's details (fixes #13173)

### DIFF
--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -390,6 +390,7 @@ JSONRPC_STATUS CAudioLibrary::SetArtistDetails(const CStdString &method, ITransp
   if (musicdatabase.SetArtistInfo(id, artist) <= 0)
     return InternalError;
 
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 
@@ -432,6 +433,7 @@ JSONRPC_STATUS CAudioLibrary::SetAlbumDetails(const CStdString &method, ITranspo
   if (musicdatabase.SetAlbumInfo(id, album, songs) <= 0)
     return InternalError;
 
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 
@@ -481,6 +483,7 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const CStdString &method, ITranspor
   if (musicdatabase.UpdateSong(song, id) <= 0)
     return InternalError;
 
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -21,6 +21,9 @@
 
 #include "IClient.h"
 #include "ITransportLayer.h"
+#include "FileItem.h"
+#include "GUIUserMessages.h"
+#include "guilib/GUIWindowManager.h"
 #include "interfaces/IAnnouncer.h"
 #include "utils/StdString.h"
 #include "utils/Variant.h"
@@ -155,4 +158,13 @@ namespace JSONRPC
 
     return ReadData;
   }
+
+  class CJSONRPCUtils
+  {
+  public:
+    static inline void NotifyItemUpdated()
+    {
+      g_windowManager.SendThreadMessage(CGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE, g_windowManager.GetActiveWindow()));
+    }
+  };
 }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -507,6 +507,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const CStdString &method, ITranspo
     videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
   }
 
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 
@@ -544,6 +545,7 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const CStdString &method, ITransp
     videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
   }
 
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 
@@ -589,6 +591,7 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const CStdString &method, ITrans
     videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
   }
 
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 
@@ -627,6 +630,7 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const CStdString &method, ITr
     videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
   }
 
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 
@@ -860,6 +864,8 @@ JSONRPC_STATUS CVideoLibrary::RemoveVideo(const CVariant &parameterObject)
     videodatabase.DeleteEpisode((int)parameterObject["episodeid"].asInteger());
   else if (parameterObject.isMember("musicvideoid"))
     videodatabase.DeleteMusicVideo((int)parameterObject["musicvideoid"].asInteger());
+
+  CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
 }
 


### PR DESCRIPTION
As already briefly discussed on IRC with @cptspiff and @jmarshallnz this is the hammer approach to fixing http://trac.xbmc.org/ticket/13173. The better approach would be to only update the item that has changed but there are some problems with that. We don't have the original CFileItem object used in the GUI listing that needs to be updated. This can be worked around by retrieving the full "equivalent" CFileItem object from the database but that instance won't have all the additional info that e.g. the CVideoThumbLoader loads in the background of a GUI listing. So updating that item with the newly retrieved one could result in missing artwork or streamdetails or whatever is retrieved asynchronously.

The best approach would be to provide information on which fields/properties/values to update because JSON-RPC know which properties have changed. But that would require quite a bit of extra logic (which I'll try to implement but is most likely out of scope for Frodo).
