### PR TITLE
asap/xasm: Fix broken if statement and support building with older versions of gdc

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2120,7 +2120,7 @@ else
 fi
 
 if test "$use_asap" = "yes"; then
-  AC_CHECK_PROG(HAVE_GDC,gdc,"yes","no")
+  AC_CHECK_PROGS(HAVE_GDC,gdc-4.4 gdc-4.3 gdc,"no")
   if test "$HAVE_GDC" = "no"; then
     AC_MSG_ERROR($missing_program);
   fi

--- a/lib/asap/Makefile.in
+++ b/lib/asap/Makefile.in
@@ -73,7 +73,7 @@ mads/mads: force
 	make -C mads
 
 xasm/xasm: force
-	make -C xasm
+	make -C xasm GDC=@HAVE_GDC@
 
 players/cmc.obx: players/cmc.asx xasm/xasm
 	$(XASM) -d CM3=0 -o $@ players/cmc.asx

--- a/lib/asap/xasm/Makefile
+++ b/lib/asap/xasm/Makefile
@@ -5,14 +5,15 @@ ASCIIDOC_POSTPROCESS = perl -pi.bak -e "s/527bbd;/20a0a0;/;END{unlink '$@.bak'}"
 ASCIIDOC_VALIDATE = xmllint --valid --noout --nonet $@
 RM = rm -f
 ZIP = 7z a -mx=9 -tzip $@
+GDC ?= gdc
 
 all: xasm
 
 xasm.o: xasm.d
-	gdc -c -o xasm.o -O2 $<
+	$(GDC) -c -o xasm.o -O2 $<
 
 xasm: xasm.o
-	gdc -o xasm xasm.o
+	$(GDC) -o xasm xasm.o
 
 xasm.html: xasm.1.txt
 	$(ASCIIDOC) -d manpage $<

--- a/lib/asap/xasm/xasm.d
+++ b/lib/asap/xasm/xasm.d
@@ -548,7 +548,7 @@ int operatorShiftLeft(int a, int b) {
 	if (b < 0) {
 		return operatorShiftRight(a, -b);
 	}
-	if (a != 0 & b >= 32) {
+	if (a != 0 && b >= 32) {
 		throw new AssemblyError("Arithmetic overflow");
 	}
 	long r = cast(long) a << b;


### PR DESCRIPTION
This fixes a broken if statement in xasm.d and supports building with older versions of gdc as it will not compile with 4.6.
http://trac.xbmc.org/ticket/12633
