### PR TITLE
CGUIWindow::Initialize fixes/changes

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -701,6 +701,11 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
   return SendControlMessage(message);
 }
 
+bool CGUIWindow::NeedXMLReload()
+{
+  return !m_windowLoaded || g_infoManager.ConditionsChangedValues(m_xmlIncludeConditions);
+}
+
 void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
 {
   CSingleLock lock(g_graphicsContext);
@@ -710,19 +715,12 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   start = CurrentHostCounter();
 #endif
   // use forceLoad to determine if xml file needs loading
-  forceLoad |= (m_loadType == LOAD_EVERY_TIME);
-
-  // if window is loaded (not cleared before) and we aren't forced to load
-  // we will have to load it only if include conditions values were changed
-  if (m_windowLoaded && !forceLoad)
-    forceLoad = g_infoManager.ConditionsChangedValues(m_xmlIncludeConditions);
+  forceLoad |= NeedXMLReload() || (m_loadType == LOAD_EVERY_TIME);
 
   // if window is loaded and load is forced we have to free window resources first
   if (m_windowLoaded && forceLoad)
     FreeResources(true);
 
-  // load skin xml file only if we are forced to load or window isn't loaded yet
-  forceLoad |= !m_windowLoaded;
   if (forceLoad)
   {
     CStdString xmlFile = GetProperty("xmlfile").asString();
@@ -786,10 +784,13 @@ bool CGUIWindow::Initialize()
 {
   if (!g_windowManager.Initialized())
     return false;     // can't load if we have no skin yet
-  if(m_windowLoaded)
+  if(!NeedXMLReload())
     return true;
   if(g_application.IsCurrentThread())
-    return Load(GetProperty("xmlfile").asString());
+  {
+    AllocResources();
+    return m_windowLoaded;
+  }
   else
   {
     CGUIMessage msg(GUI_MSG_WINDOW_LOAD, 0, 0);

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -787,16 +787,15 @@ bool CGUIWindow::Initialize()
   if(!NeedXMLReload())
     return true;
   if(g_application.IsCurrentThread())
-  {
     AllocResources();
-    return m_windowLoaded;
-  }
   else
   {
+    // if not app thread, send gui msg via app messenger
+    // and wait for results, so windowLoaded flag would be updated
     CGUIMessage msg(GUI_MSG_WINDOW_LOAD, 0, 0);
-    g_windowManager.SendThreadMessage(msg, GetID());
+    CApplicationMessenger::Get().SendGUIMessage(msg, GetID(), true);
   }
-  return true;
+  return m_windowLoaded;
 }
 
 void CGUIWindow::SetInitialVisibility()

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -194,6 +194,10 @@ protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool LoadXML(const CStdString& strPath, const CStdString &strLowerPath);  ///< Loads from the given file
   bool Load(TiXmlElement *pRootElement);                 ///< Loads from the given XML root element
+  /*! \brief Check if XML file needs (re)loading
+   XML file has to be (re)loaded when window is not loaded or include conditions values were changed
+   */
+  bool NeedXMLReload();
   virtual void LoadAdditionalTags(TiXmlElement *root) {}; ///< Load additional information from the XML document
 
   virtual void SetDefaults();


### PR DESCRIPTION
First commit fixes context menu dialogs with conditional includes not showing context buttons (as Initialize didn't realize that include conditions are changed and report window as ready, when it's not and it will be loaded later when we show window - that is after we setup context buttons) - Here's forum topic about it http://forum.xbmc.org/showthread.php?tid=142506&pid=1211421#pid1211421

Second commit makes sure we return proper value if called not from app thread.
