### PR TITLE
Correct french translation

### DIFF
--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -8068,7 +8068,7 @@ msgstr "ce chemin de la médiathèque ?"
 
 msgctxt "#20342"
 msgid "Movies"
-msgstr "Retirer le clip musical de la Médiathèque"
+msgstr "Films"
 
 msgctxt "#20343"
 msgid "TV shows"


### PR DESCRIPTION
September translations update introduce a mistake for the french language. This fix it.
