### PR TITLE
[pvr] better usability while selecting channel groups within channel osd

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -23,6 +23,7 @@
 #include "GUIViewControl.h"
 #include "utils/Observer.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
+#include <map>
 
 class CFileItemList;
 
@@ -53,6 +54,9 @@ namespace PVR
 
   private:
     CPVRChannelGroupPtr m_group;
+    std::map<int,int> m_groupSelectedItems;
+    void SetLastSelectedItem(int iGroupID);
+    int GetLastSelectedItem(int iGroupID) const;
   };
 }
 


### PR DESCRIPTION
After a month of using the channel group selection within channel osd the current behavior is not very consistent and user-friendly.

Currently when you select a new group it selects the same item position of the old within the new group (ex. group A item position 35 switch to group B item position 35). If the group does not contain as many items it selects the last position in the list. if you switch back to group A it selects the item position of group B. so it jumps from 35 group A to 15 group B and back to 15 group A.

This PR always selects the first item on new groups. It's consitent and user-friendly, because it starts from top and then you can go down. (same behavoir like in neutrino, enigma etc.)
