### PR TITLE
fixed problem with streams that update display time (DVD,BluRay), fixes smallstepback

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPacket.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPacket.h
@@ -33,4 +33,5 @@
   double pts; // pts in DVD_TIME_BASE
   double dts; // dts in DVD_TIME_BASE
   double duration; // duration in DVD_TIME_BASE if available
+  int time;   // time as determined by input stream or -1 otherwise
 } DemuxPacket;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1234,6 +1234,11 @@ void CDVDPlayer::Process()
 
     // it's a valid data packet, reset error counter
     m_errorCount = 0;
+    CDVDInputStream::IDisplayTime* pDisplayTime = dynamic_cast<CDVDInputStream::IDisplayTime*>(m_pInputStream);
+    if (pDisplayTime && pDisplayTime->GetTotalTime() > 0)
+      pPacket->time = pDisplayTime->GetTime();
+    else
+      pPacket->time = -1;
 
     // check so that none of our streams has become invalid
     if (!IsValidStream(m_CurrentAudio)    && m_dvdPlayerAudio.IsStalled())    CloseAudioStream(true);
@@ -3803,10 +3808,16 @@ void CDVDPlayer::UpdatePlayState(double timeout)
 
   SPlayerState state(m_State);
 
+  if( m_dvdPlayerVideo.GetCurrentPts() != DVD_NOPTS_VALUE)
+    state.dts = m_dvdPlayerVideo.GetCurrentPts();
+  else if( m_dvdPlayerAudio.GetCurrentPts() != DVD_NOPTS_VALUE)
+    state.dts = m_dvdPlayerAudio.GetCurrentPts();
+/*
   if     (m_CurrentVideo.dts != DVD_NOPTS_VALUE)
     state.dts = m_CurrentVideo.dts;
   else if(m_CurrentAudio.dts != DVD_NOPTS_VALUE)
     state.dts = m_CurrentAudio.dts;
+*/
   else
     state.dts = m_clock.GetClock();
 
@@ -3833,7 +3844,8 @@ void CDVDPlayer::UpdatePlayState(double timeout)
     CDVDInputStream::IDisplayTime* pDisplayTime = dynamic_cast<CDVDInputStream::IDisplayTime*>(m_pInputStream);
     if (pDisplayTime && pDisplayTime->GetTotalTime() > 0)
     {
-      state.time       = pDisplayTime->GetTime();
+      if( m_dvdPlayerVideo.GetCurrentTime() > 0 )
+        state.time = m_dvdPlayerVideo.GetCurrentTime();
       state.time_total = pDisplayTime->GetTotalTime();
     }
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -147,6 +147,7 @@ CDVDPlayerVideo::CDVDPlayerVideo( CDVDClock* pClock
   m_messageQueue.SetMaxTimeSize(8.0);
   g_dvdPerformanceCounter.EnableVideoQueue(&m_messageQueue);
 
+  m_iCurrentTime = -1;
   m_iCurrentPts = DVD_NOPTS_VALUE;
   m_iDroppedFrames = 0;
   m_fFrameRate = 25;
@@ -302,6 +303,7 @@ void CDVDPlayerVideo::OnStartup()
   m_crop.x1 = m_crop.x2 = 0.0f;
   m_crop.y1 = m_crop.y2 = 0.0f;
 
+  m_iCurrentTime = -1;
   m_iCurrentPts = DVD_NOPTS_VALUE;
   m_FlipTimeStamp = m_pClock->GetAbsoluteClock();
 
@@ -484,6 +486,8 @@ void CDVDPlayerVideo::Process()
       DemuxPacket* pPacket = ((CDVDMsgDemuxerPacket*)pMsg)->GetPacket();
       bool bPacketDrop     = ((CDVDMsgDemuxerPacket*)pMsg)->GetPacketDrop();
 
+      if( pPacket->time != -1 )
+        m_iCurrentTime = pPacket->time;
       if (m_stalled)
       {
         CLog::Log(LOGINFO, "CDVDPlayerVideo - Stillframe left, switching to normal playback");

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -88,6 +88,7 @@ public:
 
   bool InitializedOutputDevice();
 
+  int     GetCurrentTime()                         { return m_iCurrentTime; }
   double GetCurrentPts()                           { return m_iCurrentPts; }
   int    GetPullupCorrection()                     { return m_pullupCorrection.GetPatternLength(); }
 
@@ -124,6 +125,7 @@ protected:
   CDVDMessageQueue m_messageQueue;
   CDVDMessageQueue& m_messageParent;
 
+  int m_iCurrentTime;    // time of last packet displayed
   double m_iCurrentPts; // last pts displayed
   double m_iVideoDelay;
   double m_iSubtitleDelay;


### PR DESCRIPTION
Time is updated from stream (in the case of DVD and Bluray) when read as opposed to when displayed so they are aprox 7/8 secs fast (because of the cache)

patch tags the packets with the stream time and the player updates its idea of time when it displays a packet.
