### PR TITLE
[ffmpeg/armv6] fixed #13414 broken ac3 on armv6

### DIFF
--- a/lib/ffmpeg/libavcodec/arm/ac3dsp_armv6.S
+++ b/lib/ffmpeg/libavcodec/arm/ac3dsp_armv6.S
@@ -34,24 +34,23 @@ function ff_ac3_bit_alloc_calc_bap_armv6, export=1
         add             r0,  r0,  r4,  lsl #1           @ mask + band
         add             r4,  lr,  r4
         add             r7,  r7,  r2                    @ bap + start
-        ldrb            r10, [r4], #1
 1:
         ldrsh           r9,  [r0], #2                   @ mask[band]
         mov             r8,  #0xff0
         sub             r9,  r9,  r12                   @   - snr_offset
-        mov             r11, r10
-        ldrb            r10, [r4], #1                   @ band_start_tab[band++]
+        ldrb            r10, [r4, #1]!                  @ band_start_tab[++band]
         subs            r9,  r9,  r5                    @   - floor
         it              lt
         movlt           r9,  #0
         cmp             r10, r3                         @   - end
         and             r9,  r9,  r8, lsl #1            @   & 0x1fe0
         ite             gt
-        subgt           r8,  r3,  r11
-        suble           r8,  r10, r11
+        subgt           r8,  r3,  r2
+        suble           r8,  r10, r2
+        mov             r2,  r10
         add             r9,  r9,  r5                    @   + floor => m
         tst             r8,  #1
-        add             r2,  r7,  r8
+        add             r11, r7,  r8
         bne             3f
         b               5f
 2:
@@ -65,9 +64,9 @@ function ff_ac3_bit_alloc_calc_bap_armv6, export=1
         ldrb            lr,  [r6, lr]
         strb            r8,  [r7], #1                   @ bap[bin]
         strb            lr,  [r7], #1
-5:      cmp             r7,  r2
+5:      cmp             r7,  r11
         blo             2b
-        cmp             r3,  r11
+        cmp             r3,  r10
         bgt             1b
         pop             {r4-r11,pc}
 3:

--- a/lib/ffmpeg/patches/0033-ARM-ac3-fix-ac3_bit_alloc_calc_bap_armv6.patch
+++ b/lib/ffmpeg/patches/0033-ARM-ac3-fix-ac3_bit_alloc_calc_bap_armv6.patch
@@ -1,0 +1,62 @@
+From cd2f98f365dfd83f0debac030413e57a73c7ecd5 Mon Sep 17 00:00:00 2001
+From: Mans Rullgard <mans@mansr.com>
+Date: Wed, 1 Feb 2012 22:25:10 +0000
+Subject: [PATCH] ARM: ac3: fix ac3_bit_alloc_calc_bap_armv6
+
+This function was broken when the start bin was not at the start
+of a band.
+
+Signed-off-by: Mans Rullgard <mans@mansr.com>
+---
+ libavcodec/arm/ac3dsp_armv6.S |   15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/arm/ac3dsp_armv6.S b/libavcodec/arm/ac3dsp_armv6.S
+index b6aee86..df8bfba 100644
+--- a/libavcodec/arm/ac3dsp_armv6.S
++++ b/libavcodec/arm/ac3dsp_armv6.S
+@@ -34,24 +34,23 @@ function ff_ac3_bit_alloc_calc_bap_armv6, export=1
+         add             r0,  r0,  r4,  lsl #1           @ mask + band
+         add             r4,  lr,  r4
+         add             r7,  r7,  r2                    @ bap + start
+-        ldrb            r10, [r4], #1
+ 1:
+         ldrsh           r9,  [r0], #2                   @ mask[band]
+         mov             r8,  #0xff0
+         sub             r9,  r9,  r12                   @   - snr_offset
+-        mov             r11, r10
+-        ldrb            r10, [r4], #1                   @ band_start_tab[band++]
++        ldrb            r10, [r4, #1]!                  @ band_start_tab[++band]
+         subs            r9,  r9,  r5                    @   - floor
+         it              lt
+         movlt           r9,  #0
+         cmp             r10, r3                         @   - end
+         and             r9,  r9,  r8, lsl #1            @   & 0x1fe0
+         ite             gt
+-        subgt           r8,  r3,  r11
+-        suble           r8,  r10, r11
++        subgt           r8,  r3,  r2
++        suble           r8,  r10, r2
++        mov             r2,  r10
+         add             r9,  r9,  r5                    @   + floor => m
+         tst             r8,  #1
+-        add             r2,  r7,  r8
++        add             r11, r7,  r8
+         bne             3f
+         b               5f
+ 2:
+@@ -65,9 +64,9 @@ function ff_ac3_bit_alloc_calc_bap_armv6, export=1
+         ldrb            lr,  [r6, lr]
+         strb            r8,  [r7], #1                   @ bap[bin]
+         strb            lr,  [r7], #1
+-5:      cmp             r7,  r2
++5:      cmp             r7,  r11
+         blo             2b
+-        cmp             r3,  r11
++        cmp             r3,  r10
+         bgt             1b
+         pop             {r4-r11,pc}
+ 3:
+-- 
+1.7.10.4
+


### PR DESCRIPTION
backported ffmpeg commit cd2f98f365dfd83f0debac030413e57a73c7ecd5 which fixes ac3 on armv6

20:21:47 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] exponent out-of-range
20:21:47 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] error decoding the audio block
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] exponent out-of-range
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] error decoding the audio block
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] exponent out-of-range
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] error decoding the audio block
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] exponent out-of-range
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] error decoding the audio block
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] exponent out-of-range
20:21:48 T:1403229280   ERROR: ffmpeg[53A39460]: [ac3] error decoding the audio block

This log was observed on a RaspberryPI which is armv6.
