### PR TITLE
[cec] bump to libCEC 2.0.2

### DIFF
--- a/lib/libcec/Makefile
+++ b/lib/libcec/Makefile
@@ -7,7 +7,7 @@
 
 # lib name, version
 LIBNAME=libcec
-VERSION=2.0.0
+VERSION=2.0.2
 SOURCE=$(LIBNAME)-$(VERSION)
 
 # download location and format

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec-2.0.0.zip                  http://mirrors.xbmc.org/build-deps/win32/
+libcec-2.0.2.zip                  http://mirrors.xbmc.org/build-deps/win32/

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -3,7 +3,7 @@ include ../config.site.mk
 
 # lib name, version
 LIBNAME=libcec
-VERSION=2.0.0
+VERSION=2.0.2
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
fixes some issues that were reported by users (such as @gimli in #1623 and @olympia ;-))
no new features, fixes only.

full changelog can be found here: https://github.com/Pulse-Eight/libcec/blob/release/ChangeLog

deps for darwin and windows have been uploaded
