### PR TITLE
media library: only allow "new" items after filtering into a list if they were part of a previously listed movie set

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1843,6 +1843,27 @@ bool CGUIWindowVideoBase::CanContainFilter(const CStdString &strDirectory) const
   return StringUtils::StartsWith(strDirectory, "videodb://");
 }
 
+bool CGUIWindowVideoBase::CheckFilteredItem(const CFileItemPtr &item, const CFileItemList &items) const
+{
+  // the only additional items that are valid in a filtered list are items
+  // that were previously part of a movie set
+  if (!CanContainFilter(m_strFilterPath) || !item->HasVideoInfoTag() ||
+      item->GetVideoInfoTag()->m_type != "movie" || item->GetVideoInfoTag()->m_iSetId <= 0)
+    return false;
+
+  int setId = item->GetVideoInfoTag()->m_iSetId;
+
+  for (int i = 0; i < items.Size(); i++)
+  {
+    const CFileItemPtr &origItem = items[i];
+    if (origItem->HasVideoInfoTag() && origItem->GetVideoInfoTag()->m_type == "set" &&
+        origItem->GetVideoInfoTag()->m_iDbId == setId)
+      return true;
+  }
+
+  return false;
+}
+
 void CGUIWindowVideoBase::AddToDatabase(int iItem)
 {
   if (iItem < 0 || iItem >= m_vecItems->Size())

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -91,6 +91,7 @@ protected:
   virtual void OnPrepareFileItems(CFileItemList &items);
 
   virtual bool CheckFilterAdvanced(CFileItemList &items) const;
+  virtual bool CheckFilteredItem(const CFileItemPtr &item, const CFileItemList &items) const;
   virtual bool CanContainFilter(const CStdString &strDirectory) const;
 
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1815,10 +1815,24 @@ bool CGUIMediaWindow::GetAdvanceFilteredItems(CFileItemList &items, bool &hasNew
     }
   }
 
+  /* TODO: This code is only needed because movie sets
+   have to be handled differently than other media items.
+   During filtering a movie set can be reduced to a single
+   movie which then replaces the previously listed movie set
+   but hasn't been part of the original list. It can be
+   removed once movie sets are grouped dynamically after
+   applying any filter.
+   */
   if (resultItems.Size() > 0)
   {
-    filteredItems.Append(resultItems);
-    hasNewItems = true;
+    for (int i = 0; i < resultItems.Size(); i++)
+    {
+      if (CheckFilteredItem(resultItems[i], items))
+      {
+        filteredItems.Add(resultItems[i]);
+        hasNewItems = true;
+      }
+    }
   }
 
   items.ClearItems();

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -124,6 +124,20 @@ protected:
   \sa GetFilteredItems
   */
   virtual bool GetAdvanceFilteredItems(CFileItemList &items, bool &hasNewItems);
+  /* \brief Check whether the given item should be part of the filtered list based
+            on the unfiltered list
+
+   This method is only called for items which are not part of the unfiltered list
+   and therefore need to go through an extra check to figure out if it should
+   really be part of the filtered list.
+   It is currently only needed for movie sets and can be removed once movie sets
+   are being grouped outside of CVideoDatabase.
+   
+   \param item The filtered item to check
+   \param items The unfiltered list of items
+   \return True if the filtered item should be part of the filtered list otherwise false
+   */
+  virtual bool CheckFilteredItem(const CFileItemPtr &item, const CFileItemList &items) const { return true; }
 
   // check for a disc or connection
   virtual bool HaveDiscOrConnection(const CStdString& strPath, int iDriveType);


### PR DESCRIPTION
Up until now when the user is in a list and starts a filter and that filter happens to return items that were not part of the original list, we just appended those items to the list. The only use case where this can actually happen is if the unfiltered list contains movie sets and the applied filter reduces that set down to a single movie from within that set. That movie is a valid item for the active filter but not part of the unfiltered list.
Blindly adding all the additional items to the end of the list results in odd behaviour when e.g. in "Recently Added Movies" where we only list 25 movies. Applying a filter will result in filtering through all the items (not just the available 25) and appending all the new ones to the list.

With this change we check every new/unknown item against all the items in the unfiltered list and see if it was part of a previously listed set. To be future-proof I've introduced a new virtual method in CGUIMediaWindow which can be overriden by whatever class inherits CGUIMediaWindow. For the use case of movies in a set CGUIWindowVideoBase does this.
