### PR TITLE
Final part of the egl refactor, back-ends control egl includes

### DIFF
--- a/xbmc/windowing/egl/EGLNativeType.h
+++ b/xbmc/windowing/egl/EGLNativeType.h
@@ -20,9 +20,11 @@
  *
  */
 
-#include <EGL/egl.h>
 #include "guilib/Resolution.h"
 #include "EGLQuirks.h"
+
+typedef void* XBNativeDisplayType;
+typedef void* XBNativeWindowType;
 
 /*!
 This class provides extra functionality on top of EGL in order to facilitate
@@ -99,10 +101,10 @@ public:
   virtual bool  CreateNativeWindow() = 0;
 
 /*! \brief Returns the current Native Display */
-  virtual bool  GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const = 0;
+  virtual bool  GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const = 0;
 
 /*! \brief Returns the current Native Window */
-  virtual bool  GetNativeWindow(EGLNativeWindowType **nativeWindow) const = 0;
+  virtual bool  GetNativeWindow(XBNativeWindowType **nativeWindow) const = 0;
 
 /*! \brief Destroy the Native Window
 
@@ -142,6 +144,6 @@ public:
   virtual bool  ShowWindow(bool show) = 0;
 
 protected:
-  EGLNativeDisplayType m_nativeDisplay;
-  EGLNativeWindowType  m_nativeWindow;
+  XBNativeDisplayType  m_nativeDisplay;
+  XBNativeWindowType   m_nativeWindow;
 };

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -80,12 +80,16 @@ bool CEGLNativeTypeAmlogic::CreateNativeWindow()
 
 bool CEGLNativeTypeAmlogic::GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const
 {
+  if (!nativeDisplay)
+    return false;
   *nativeDisplay = (XBNativeDisplayType*) &m_nativeDisplay;
   return true;
 }
 
 bool CEGLNativeTypeAmlogic::GetNativeWindow(XBNativeWindowType **nativeWindow) const
 {
+  if (!nativeWindow)
+    return false;
   *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
   return true;
 }

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -17,6 +17,7 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
+#include <EGL/egl.h>
 #include "EGLNativeTypeAmlogic.h"
 #include <stdlib.h>
 #include <linux/fb.h>
@@ -64,9 +65,13 @@ bool CEGLNativeTypeAmlogic::CreateNativeDisplay()
 bool CEGLNativeTypeAmlogic::CreateNativeWindow()
 {
 #if defined(_FBDEV_WINDOW_H_)
-  m_nativeWindow = new fbdev_window;
-  m_nativeWindow->width = 1280;
-  m_nativeWindow->height = 720;
+  fbdev_window *nativeWindow = new fbdev_window;
+  if (!nativeWindow)
+    return false;
+
+  nativeWindow->width = 1280;
+  nativeWindow->height = 720;
+  m_nativeWindow = nativeWindow;
   return true;
 #else
   return false;
@@ -75,13 +80,13 @@ bool CEGLNativeTypeAmlogic::CreateNativeWindow()
 
 bool CEGLNativeTypeAmlogic::GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const
 {
-  *nativeDisplay = (EGLNativeDisplayType*) &m_nativeDisplay;
+  *nativeDisplay = (XBNativeDisplayType*) &m_nativeDisplay;
   return true;
 }
 
-bool CEGLNativeTypeAmlogic::GetNativeWindow(EGLNativeWindowType **nativeWindow) const
+bool CEGLNativeTypeAmlogic::GetNativeWindow(XBNativeWindowType **nativeWindow) const
 {
-  *nativeWindow = (EGLNativeWindowType*) &m_nativeWindow;
+  *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
   return true;
 }
 

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
@@ -34,8 +34,8 @@ public:
 
   virtual bool  CreateNativeDisplay();
   virtual bool  CreateNativeWindow();
-  virtual bool  GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const;
-  virtual bool  GetNativeWindow(EGLNativeWindowType **nativeWindow) const;
+  virtual bool  GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const;
+  virtual bool  GetNativeWindow(XBNativeWindowType **nativeWindow) const;
 
   virtual bool  DestroyNativeWindow();
   virtual bool  DestroyNativeDisplay();

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "system.h"
+#include <EGL/egl.h>
 #include "EGLNativeTypeAndroid.h"
 #include "utils/log.h"
 #include "guilib/gui3d.h"
@@ -65,15 +66,15 @@ bool CEGLNativeTypeAndroid::CreateNativeWindow()
 #endif
 }  
 
-bool CEGLNativeTypeAndroid::GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const
+bool CEGLNativeTypeAndroid::GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const
 {
-  *nativeDisplay = (EGLNativeDisplayType*) &m_nativeDisplay;
+  *nativeDisplay = (XBNativeDisplayType*) &m_nativeDisplay;
   return true;
 }
 
-bool CEGLNativeTypeAndroid::GetNativeWindow(EGLNativeWindowType **nativeWindow) const
+bool CEGLNativeTypeAndroid::GetNativeWindow(XBNativeWindowType **nativeWindow) const
 {
-  *nativeWindow = (EGLNativeWindowType*) &m_nativeWindow;
+  *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
   return true;
 }
 
@@ -90,10 +91,10 @@ bool CEGLNativeTypeAndroid::DestroyNativeWindow()
 bool CEGLNativeTypeAndroid::GetNativeResolution(RESOLUTION_INFO *res) const
 {
 #if defined(TARGET_ANDROID)
-  ANativeWindow_acquire(m_nativeWindow);
-  res->iWidth = ANativeWindow_getWidth(m_nativeWindow);
-  res->iHeight= ANativeWindow_getHeight(m_nativeWindow);
-  ANativeWindow_release(m_nativeWindow);
+  ANativeWindow_acquire((EGLNativeWindowType)m_nativeWindow);
+  res->iWidth = ANativeWindow_getWidth((EGLNativeWindowType)m_nativeWindow);
+  res->iHeight= ANativeWindow_getHeight((EGLNativeWindowType)m_nativeWindow);
+  ANativeWindow_release((EGLNativeWindowType)m_nativeWindow);
 
   res->fRefreshRate = 60;
   res->dwFlags= D3DPRESENTFLAG_PROGRESSIVE;

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
@@ -68,12 +68,16 @@ bool CEGLNativeTypeAndroid::CreateNativeWindow()
 
 bool CEGLNativeTypeAndroid::GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const
 {
+  if (!nativeDisplay)
+    return false;
   *nativeDisplay = (XBNativeDisplayType*) &m_nativeDisplay;
   return true;
 }
 
 bool CEGLNativeTypeAndroid::GetNativeWindow(XBNativeWindowType **nativeWindow) const
 {
+  if (!nativeWindow)
+    return false;
   *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
   return true;
 }

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.h
@@ -34,8 +34,8 @@ public:
 
   virtual bool  CreateNativeDisplay();
   virtual bool  CreateNativeWindow();
-  virtual bool  GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const;
-  virtual bool  GetNativeWindow(EGLNativeWindowType **nativeWindow) const;
+  virtual bool  GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const;
+  virtual bool  GetNativeWindow(XBNativeWindowType **nativeWindow) const;
 
   virtual bool  DestroyNativeWindow();
   virtual bool  DestroyNativeDisplay();

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -19,6 +19,7 @@
  */
 #include "system.h"
 
+#include <EGL/egl.h>
 #include "EGLNativeTypeRaspberryPI.h"
 #include "utils/log.h"
 #include "guilib/gui3d.h"
@@ -133,16 +134,16 @@ bool CEGLNativeTypeRaspberryPI::CreateNativeWindow()
 #endif
 }
 
-bool CEGLNativeTypeRaspberryPI::GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const
+bool CEGLNativeTypeRaspberryPI::GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const
 {
-  *nativeDisplay = (EGLNativeDisplayType*) &m_nativeDisplay;
+  *nativeDisplay = (XBNativeDisplayType*) &m_nativeDisplay;
   return true;
 }
 
-bool CEGLNativeTypeRaspberryPI::GetNativeWindow(EGLNativeWindowType **nativeWindow) const
+bool CEGLNativeTypeRaspberryPI::GetNativeWindow(XBNativeDisplayType **nativeWindow) const
 {
-  *nativeWindow = (EGLNativeWindowType*) &m_nativeWindow;
   DLOG("CEGLNativeTypeRaspberryPI::GetNativeWindow\n");
+  *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
   return true;
 }  
 

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -136,6 +136,8 @@ bool CEGLNativeTypeRaspberryPI::CreateNativeWindow()
 
 bool CEGLNativeTypeRaspberryPI::GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const
 {
+  if (!nativeDisplay)
+    return false;
   *nativeDisplay = (XBNativeDisplayType*) &m_nativeDisplay;
   return true;
 }
@@ -143,6 +145,8 @@ bool CEGLNativeTypeRaspberryPI::GetNativeDisplay(XBNativeDisplayType **nativeDis
 bool CEGLNativeTypeRaspberryPI::GetNativeWindow(XBNativeDisplayType **nativeWindow) const
 {
   DLOG("CEGLNativeTypeRaspberryPI::GetNativeWindow\n");
+  if (!nativeWindow)
+    return false;
   *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
   return true;
 }  

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
@@ -21,7 +21,10 @@
  */
 
 #include "EGLNativeType.h"
+#if defined(TARGET_RASPBERRY_PI)
 #include <semaphore.h>
+#include <bcm_host.h>
+#endif
 
 class DllBcmHost;
 class CEGLNativeTypeRaspberryPI : public CEGLNativeType
@@ -37,8 +40,8 @@ public:
 
   virtual bool  CreateNativeDisplay();
   virtual bool  CreateNativeWindow();
-  virtual bool  GetNativeDisplay(EGLNativeDisplayType **nativeDisplay) const;
-  virtual bool  GetNativeWindow(EGLNativeWindowType **nativeWindow) const;
+  virtual bool  GetNativeDisplay(XBNativeDisplayType **nativeDisplay) const;
+  virtual bool  GetNativeWindow(XBNativeWindowType **nativeWindow) const;
 
   virtual bool  DestroyNativeWindow();
   virtual bool  DestroyNativeDisplay();

--- a/xbmc/windowing/egl/EGLWrapper.cpp
+++ b/xbmc/windowing/egl/EGLWrapper.cpp
@@ -191,7 +191,7 @@ bool CEGLWrapper::InitDisplay(EGLDisplay *display)
   //nativeDisplay can be (and usually is) NULL. Don't use if(nativeDisplay) as a test!
   EGLint status;
   EGLNativeDisplayType *nativeDisplay = NULL;
-  if (!m_nativeTypes->GetNativeDisplay(&nativeDisplay))
+  if (!m_nativeTypes->GetNativeDisplay((XBNativeDisplayType**)&nativeDisplay))
     return false;
 
   *display = eglGetDisplay(*nativeDisplay);
@@ -263,7 +263,7 @@ bool CEGLWrapper::CreateSurface(EGLDisplay display, EGLConfig config, EGLSurface
     return false;
 
   EGLNativeWindowType *nativeWindow=NULL;
-  if (!m_nativeTypes->GetNativeWindow(&nativeWindow))
+  if (!m_nativeTypes->GetNativeWindow((XBNativeWindowType**)&nativeWindow))
     return false;
 
   *surface = eglCreateWindowSurface(display, config, *nativeWindow, NULL);

--- a/xbmc/windowing/egl/EGLWrapper.h
+++ b/xbmc/windowing/egl/EGLWrapper.h
@@ -21,6 +21,7 @@
  */
 
 #include "guilib/Resolution.h"
+#include <EGL/egl.h>
 class CEGLNativeType;
 class CEGLWrapper
 {


### PR DESCRIPTION
egl: force each implementation to include egl, allowing them to choose the native defines for the individual implementation. this should be a no-op, only a build/include restructure.

run-time tested on aml and android.
build-tested on rbp.

@cptspiff: I'd call this a finalizing of the previous egl refactor than something new, but I defer to your judgement, so I won't be hitting the button.
