### PR TITLE
media library: fix refreshing of item lists

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -937,6 +937,9 @@ bool CFileItem::IsFileFolder() const
 
 bool CFileItem::IsSmartPlayList() const
 {
+  if (HasProperty("library.smartplaylist") && GetProperty("library.smartplaylist").asBoolean())
+    return true;
+
   CStdString strExtension;
   URIUtils::GetExtension(m_strPath, strExtension);
   strExtension.ToLower();

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -103,7 +103,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
       {
         g_settings.m_bAddonForeignFilter = !g_settings.m_bAddonForeignFilter;
         g_settings.Save();
-        Update(m_vecItems->GetPath());
+        Refresh();
         return true;
       }
       else if (m_viewControl.HasControl(iControl))  // list/thumb control
@@ -234,7 +234,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
                                            g_localizeStrings.Get(24066),""))
       {
         if (CAddonInstaller::Get().Cancel(item->GetProperty("Addon.ID").asString()))
-          Update(m_vecItems->GetPath());
+          Refresh();
       }
       return true;
     }

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -47,7 +47,11 @@ namespace XFILE
     CSmartPlaylist playlist;
     if (!playlist.Load(strPath))
       return false;
-    return GetDirectory(playlist, items);
+    bool result = GetDirectory(playlist, items);
+    if (result)
+      items.SetProperty("library.smartplaylist", true);
+    
+    return result;
   }
   
   bool CSmartPlaylistDirectory::GetDirectory(const CSmartPlaylist &playlist, CFileItemList& items, const CStdString &strBaseDir /* = "" */, bool filter /* = false */)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -153,12 +153,10 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
     }
     break;
 
-    // update the display
-    case GUI_MSG_SCAN_FINISHED:
-    case GUI_MSG_REFRESH_THUMBS:
-    {
-      Update(m_vecItems->GetPath());
-    }
+  // update the display
+  case GUI_MSG_SCAN_FINISHED:
+  case GUI_MSG_REFRESH_THUMBS:
+    Refresh();
     break;
 
   case GUI_MSG_CLICKED:
@@ -412,7 +410,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CArtist& artist, const CStdString
       if (!pDlgArtistInfo->NeedRefresh())
       {
         if (pDlgArtistInfo->HasUpdatedThumb())
-          Update(m_vecItems->GetPath());
+          Refresh();
 
         return;
       }
@@ -458,7 +456,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CArtist& artist, const CStdString
           UpdateThumb(artistInfo, path);
 */
         // just update for now
-        Update(m_vecItems->GetPath());
+        Refresh();
         if (pDlgArtistInfo->NeedRefresh())
         {
           m_musicdatabase.DeleteArtistInfo(artistInfo.idArtist);
@@ -581,10 +579,7 @@ void CGUIWindowMusicBase::ShowSongInfo(CFileItem* pItem)
     dialog->SetSong(pItem);
     dialog->DoModal(GetID());
     if (dialog->NeedsUpdate())
-    { // update our file list
-      m_vecItems->RemoveDiscCache(GetID());
-      Update(m_vecItems->GetPath());
-    }
+      Refresh(true); // update our file list
   }
 }
 
@@ -956,10 +951,7 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     {
       CStdString playlist = item->IsSmartPlayList() ? item->GetPath() : m_vecItems->GetPath(); // save path as activatewindow will destroy our items
       if (CGUIDialogSmartPlaylistEditor::EditPlaylist(playlist, "music"))
-      { // need to update
-        m_vecItems->RemoveDiscCache(GetID());
-        Update(m_vecItems->GetPath());
-      }
+        Refresh(true); // need to update
       return true;
     }
 
@@ -1002,16 +994,14 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     if (CLastFmManager::GetInstance()->Unban(*item->GetMusicInfoTag()))
     {
       g_directoryCache.ClearDirectory(m_vecItems->GetPath());
-      m_vecItems->RemoveDiscCache(GetID());
-      Update(m_vecItems->GetPath());
+      Refresh(true);
     }
     return true;
   case CONTEXT_BUTTON_LASTFM_UNLOVE_ITEM:
     if (CLastFmManager::GetInstance()->Unlove(*item->GetMusicInfoTag()))
     {
       g_directoryCache.ClearDirectory(m_vecItems->GetPath());
-      m_vecItems->RemoveDiscCache(GetID());
-      Update(m_vecItems->GetPath());
+      Refresh(true);
     }
     return true;
   default:
@@ -1256,8 +1246,7 @@ void CGUIWindowMusicBase::UpdateThumb(const CAlbum &album, const CStdString &pat
   // more than just our thumbnaias changed
   // TODO: Ideally this would only be done when needed - at the moment we appear to be
   //       doing this for every lookup, possibly twice (see ShowAlbumInfo)
-  m_vecItems->RemoveDiscCache(GetID());
-  Update(m_vecItems->GetPath());
+  Refresh(true);
 
   //  Do we have to autoswitch to the thumb control?
   m_guiState.reset(CGUIViewState::GetViewState(GetID(), *m_vecItems));

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -574,7 +574,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         *item = CFileItem(artist);
         item->SetPath(path);
         CGUIWindowMusicBase::OnContextButton(itemNumber,button);
-        Update(m_vecItems->GetPath());
+        Refresh();
         m_viewControl.SetSelectedItem(itemNumber);
         return true;
       }
@@ -591,7 +591,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         *item = CFileItem(path,album);
         item->SetPath(path);
         CGUIWindowMusicBase::OnContextButton(itemNumber,button);
-        Update(m_vecItems->GetPath());
+        Refresh();
         m_viewControl.SetSelectedItem(itemNumber);
         return true;
       }
@@ -603,7 +603,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         {
           ADDON::ScraperPtr info;
           pWindow->OnInfo(item.get(),info);
-          Update(m_vecItems->GetPath());
+          Refresh();
         }
       }
       return true;
@@ -652,19 +652,19 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_MARK_WATCHED:
     CGUIWindowVideoBase::MarkWatched(item,true);
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->GetPath());
+    Refresh();
     return true;
 
   case CONTEXT_BUTTON_MARK_UNWATCHED:
     CGUIWindowVideoBase::MarkWatched(item,false);
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->GetPath());
+    Refresh();
     return true;
 
   case CONTEXT_BUTTON_RENAME:
     CGUIWindowVideoBase::UpdateVideoTitle(item.get());
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->GetPath());
+    Refresh();
     return true;
 
   case CONTEXT_BUTTON_DELETE:
@@ -678,7 +678,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CGUIWindowVideoNav::DeleteItem(item.get());
       CUtil::DeleteVideoDatabaseDirectoryCache();
     }
-    Update(m_vecItems->GetPath());
+    Refresh();
     return true;
 
   case CONTEXT_BUTTON_SET_CONTENT:

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -80,9 +80,8 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
   case GUI_MSG_PLAYLIST_CHANGED:
     {
       // global playlist changed outside playlist window
-      m_vecItems->RemoveDiscCache(GetID());
       UpdateButtons();
-      Update(m_vecItems->GetPath());
+      Refresh(true);
 
       if (m_viewControl.HasControl(m_iLastControl) && m_vecItems->Size() <= 0)
       {
@@ -141,7 +140,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
           g_settings.m_bMyMusicPlaylistShuffle = g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC);
           g_settings.Save();
           UpdateButtons();
-          Update(m_vecItems->GetPath());
+          Refresh();
         }
       }
       else if (iControl == CONTROL_BTNSAVE)
@@ -271,7 +270,7 @@ bool CGUIWindowMusicPlayList::MoveCurrentPlayListItem(int iItem, int iAction, bo
     }
 
     if (bUpdate)
-      Update(m_vecItems->GetPath());
+      Refresh();
     return true;
   }
 
@@ -319,7 +318,7 @@ void CGUIWindowMusicPlayList::SavePlayList()
     }
     CLog::Log(LOGDEBUG, "Saving music playlist: [%s]", strPath.c_str());
     playlist.Save(strPath);
-    Update(m_vecItems->GetPath()); // need to update
+    Refresh(); // need to update
   }
 }
 
@@ -332,7 +331,7 @@ void CGUIWindowMusicPlayList::ClearPlayList()
     g_playlistPlayer.Reset();
     g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
   }
-  Update(m_vecItems->GetPath());
+  Refresh();
   SET_CONTROL_FOCUS(CONTROL_BTNVIEWASICONS, 0);
 }
 
@@ -347,7 +346,7 @@ void CGUIWindowMusicPlayList::RemovePlayListItem(int iItem)
 
   g_playlistPlayer.Remove(PLAYLIST_MUSIC, iItem);
 
-  Update(m_vecItems->GetPath());
+  Refresh();
 
   if (m_vecItems->Size() <= 0)
   {
@@ -643,7 +642,7 @@ void CGUIWindowMusicPlayList::MoveItem(int iStart, int iDest)
     else
       break;
   }
-  Update(m_vecItems->GetPath());
+  Refresh();
 
   if (bRestart)
     m_musicInfoLoader.Load(*m_vecItems);

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -95,9 +95,7 @@ bool CGUIWindowMusicSongs::OnMessage(CGUIMessage& message)
         CStdString strParent;
         URIUtils::GetParentPath(directory.GetPath(), strParent);
         if (directory.GetPath() == m_vecItems->GetPath() || strParent == m_vecItems->GetPath())
-        {
-          Update(m_vecItems->GetPath());
-        }
+          Refresh();
       }
     }
     break;
@@ -420,7 +418,7 @@ bool CGUIWindowMusicSongs::OnContextButton(int itemNumber, CONTEXT_BUTTON button
 
   case CONTEXT_BUTTON_CDDB:
     if (m_musicdatabase.LookupCDDBInfo(true))
-      Update(m_vecItems->GetPath());
+      Refresh();
     return true;
 
   case CONTEXT_BUTTON_DELETE:

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -322,7 +322,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
       g_windowManager.GetActiveWindow() == WINDOW_VIDEO_NAV)) // since we can be called from the music library we need this check
   {
     int itemNumber = m_viewControl.GetSelectedItem();
-    Update(m_vecItems->GetPath());
+    Refresh();
     m_viewControl.SetSelectedItem(itemNumber);
   }
 }
@@ -1410,10 +1410,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     {
       CStdString playlist = m_vecItems->Get(itemNumber)->IsSmartPlayList() ? m_vecItems->Get(itemNumber)->GetPath() : m_vecItems->GetPath(); // save path as activatewindow will destroy our items
       if (CGUIDialogSmartPlaylistEditor::EditPlaylist(playlist, "video"))
-      { // need to update
-        m_vecItems->RemoveDiscCache(GetID());
-        Update(m_vecItems->GetPath());
-      }
+        Refresh(true); // need to update
       return true;
     }
   case CONTEXT_BUTTON_RENAME:
@@ -1426,13 +1423,13 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       m_viewControl.SetSelectedItem(newSelection);
 
       CUtil::DeleteVideoDatabaseDirectoryCache();
-      Update(m_vecItems->GetPath());
+      Refresh();
       return true;
     }
   case CONTEXT_BUTTON_MARK_UNWATCHED:
     MarkWatched(item,false);
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->GetPath());
+    Refresh();
     return true;
   case CONTEXT_BUTTON_PLAY_AND_QUEUE:
     return OnPlayAndQueueMedia(item);
@@ -1579,8 +1576,7 @@ void CGUIWindowVideoBase::OnDeleteItem(int iItem)
 
   OnDeleteItem(m_vecItems->Get(iItem));
 
-  m_vecItems->RemoveDiscCache(GetID());
-  Update(m_vecItems->GetPath());
+  Refresh(true);
   m_viewControl.SetSelectedItem(iItem);
 }
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -188,10 +188,8 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
     // update the display
     case GUI_MSG_SCAN_FINISHED:
     case GUI_MSG_REFRESH_THUMBS:
-    {
-      Update(m_vecItems->GetPath());
-    }
-    break;
+      Refresh();
+      break;
   }
   return CGUIWindowVideoBase::OnMessage(message);
 }
@@ -1083,7 +1081,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     {
       OnUnAssignContent(item->GetPath(),20375,20340,20341);
     }
-    Update(m_vecItems->GetPath());
+    Refresh();
     return true;
   }
   switch (button)
@@ -1091,7 +1089,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_EDIT:
     UpdateVideoTitle(item.get());
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->GetPath());
+    Refresh();
     return true;
 
   case CONTEXT_BUTTON_SET_SEASON_THUMB:
@@ -1229,7 +1227,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CUtil::DeleteVideoDatabaseDirectoryCache();
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
       g_windowManager.SendMessage(msg);
-      Update(m_vecItems->GetPath());
+      Refresh();
 
       return true;
     }
@@ -1274,7 +1272,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       // clear view cache and reload images
       CUtil::DeleteVideoDatabaseDirectoryCache();
 
-      Update(m_vecItems->GetPath());
+      Refresh();
       return true;
     }
   case CONTEXT_BUTTON_TAGS_ADD_ITEMS:
@@ -1349,7 +1347,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_UNLINK_MOVIE:
     {
       OnLinkMovieToTvShow(itemNumber, true);
-      Update(m_vecItems->GetPath());
+      Refresh();
       return true;
     }
   case CONTEXT_BUTTON_LINK_MOVIE:
@@ -1395,7 +1393,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       m_database.DeleteBookMarkForEpisode(*m_vecItems->Get(itemNumber)->GetVideoInfoTag());
       m_database.Close();
       CUtil::DeleteVideoDatabaseDirectoryCache();
-      Update(m_vecItems->GetPath());
+      Refresh();
       return true;
     }
 
@@ -1473,8 +1471,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
       return true;
 
     // update list
-    m_vecItems->RemoveDiscCache(GetID());
-    Update(m_vecItems->GetPath());
+    Refresh(true);
     m_viewControl.SetSelectedItem(iItem);
     return true;
   }
@@ -1524,8 +1521,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
       }
     }
 
-    m_vecItems->RemoveDiscCache(GetID());
-    Update(m_vecItems->GetPath());
+    Refresh(true);
     return true;
   }
 

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -76,9 +76,8 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
   case GUI_MSG_PLAYLIST_CHANGED:
     {
       // global playlist changed outside playlist window
-      m_vecItems->RemoveDiscCache(GetID());
       UpdateButtons();
-      Update(m_vecItems->GetPath());
+      Refresh(true);
 
       if (m_viewControl.HasControl(m_iLastControl) && m_vecItems->Size() <= 0)
       {
@@ -130,7 +129,7 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
           g_settings.m_bMyVideoPlaylistShuffle = g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO);
           g_settings.Save();
           UpdateButtons();
-          Update(m_vecItems->GetPath());
+          Refresh();
         }
       }
       else if (iControl == CONTROL_BTNSAVE)
@@ -252,7 +251,7 @@ bool CGUIWindowVideoPlaylist::MoveCurrentPlayListItem(int iItem, int iAction, bo
     }
 
     if (bUpdate)
-      Update(m_vecItems->GetPath());
+      Refresh();
     return true;
   }
 
@@ -345,7 +344,7 @@ void CGUIWindowVideoPlaylist::RemovePlayListItem(int iItem)
 
   g_playlistPlayer.Remove(PLAYLIST_VIDEO, iItem);
 
-  Update(m_vecItems->GetPath());
+  Refresh();
 
   if (m_vecItems->Size() <= 0)
   {
@@ -505,7 +504,7 @@ void CGUIWindowVideoPlaylist::MoveItem(int iStart, int iDest)
     else
       break;
   }
-  Update(m_vecItems->GetPath());
+  Refresh();
 }
 
 void CGUIWindowVideoPlaylist::MarkPlaying()

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -566,10 +566,13 @@ void CGUIMediaWindow::UpdateButtons()
     SET_CONTROL_LABEL2(CONTROL_BTN_FILTER, GetProperty("filter").asString());
 }
 
-void CGUIMediaWindow::ClearFileItems()
+void CGUIMediaWindow::ClearFileItems(bool itemsOnly /* = false */)
 {
   m_viewControl.Clear();
-  m_vecItems->Clear(); // will clean up everything
+  if (itemsOnly)
+    m_vecItems->ClearItems();
+  else
+    m_vecItems->Clear();
   m_unfilteredItems->Clear();
 }
 
@@ -724,9 +727,10 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
       GetDirectoryHistoryString(pItem.get(), strSelectedItem);
     }
   }
+
+  bool refresh = strDirectory == m_vecItems->GetPath();
   
   CStdString strCurrentDirectory = m_vecItems->GetPath();
-
   m_history.SetSelectedItem(strSelectedItem, strCurrentDirectory);
 
   CFileItemList items;
@@ -750,10 +754,13 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
 
   if (items.GetLabel().IsEmpty())
     items.SetLabel(CUtil::GetTitleFromPath(items.GetPath(), true));
-
-  ClearFileItems();
-  m_vecItems->Copy(items);
-
+  
+  ClearFileItems(refresh);
+  if (refresh)
+    m_vecItems->Append(items);
+  else
+    m_vecItems->Copy(items);
+    
   // if we're getting the root source listing
   // make sure the path history is clean
   if (strDirectory.IsEmpty())

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -80,7 +80,7 @@ protected:
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual void OnFinalizeFileItems(CFileItemList &items);
 
-  void ClearFileItems();
+  void ClearFileItems(bool itemsOnly = false);
   virtual void SortItems(CFileItemList &items);
 
   virtual bool CheckFilterAdvanced(CFileItemList &items) { return false; }

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -70,6 +70,12 @@ protected:
   virtual void UpdateButtons();
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
   virtual bool Update(const CStdString &strDirectory);
+  /* \brief Refreshes the current list by retrieving the lists's path
+   \return true if the list was successfully refreshed otherwise false
+   \sa Update
+   \sa GetDirectory
+   */
+  virtual bool Refresh(bool clearCache = false);
   virtual void FormatAndSort(CFileItemList &items);
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual void OnFinalizeFileItems(CFileItemList &items);


### PR DESCRIPTION
The first commit is just convenience and I'll remove it from the PR if requested because it isn't really part of the fix.

The other two commits fix two issues:
- when refreshing (i.e. the path doesn't change) a list of items we almost completely replace CGUIMediaWindow::m_vecItems with the new CFileItemList instance and therefore we loose any details like custom properties added to a CFileItemList instance. Specifically this affects lists based on custom library nodes in the video library which use the filter functionality. We set a property "library.filter" on the resulting CFileItemList to know in CGUIMediaWindow that we need to select a specific CGUIViewState which also contains the "Sort by Playlist" option. Once the list is refreshed (e.g. after marking an item as watched) we loose that property and therefore change the CGUIViewState implementation we use and the sorting/presentation of the list can change.
- since we need the videodb:// and musicdb:// paths to be able to do the advanced filtering, we override the m_strPath value of a CFileItemList coming from a smartplaylist file (foo/bar.xsp) with the actual database-specific path upon retrieving the list from the database. This results in checks for CFileItem::IsSmartPlaylist() to not work properly anymore because it looks for a ".xsp" extension but the path now is e.g. "videodb://2/2?xsp=foobar". Similar to the "library.filter" property this can be solved by adding a "library.smartplaylist" property to the CFileItemList and extending CFileItem::IsSmartPlaylist() to also take that custom property into account. This (in combination with the other commit) fixes http://trac.xbmc.org/ticket/13412
