### PR TITLE
close CGUIDialogFooInfo dialogs on ACTION_SHOW_INFO (fixes #13139)

### DIFF
--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -121,6 +121,16 @@ default:
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogAddonInfo::OnAction(const CAction &action)
+{
+  if (action.GetID() == ACTION_SHOW_INFO)
+  {
+    Close();
+    return true;
+  }
+  return CGUIDialog::OnAction(action);
+}
+
 void CGUIDialogAddonInfo::OnInitWindow()
 {
   UpdateControls();

--- a/xbmc/addons/GUIDialogAddonInfo.h
+++ b/xbmc/addons/GUIDialogAddonInfo.h
@@ -31,7 +31,8 @@ class CGUIDialogAddonInfo :
 public:
   CGUIDialogAddonInfo(void);
   virtual ~CGUIDialogAddonInfo(void);
-  bool OnMessage(CGUIMessage& message);
+  virtual bool OnMessage(CGUIMessage& message);
+  virtual bool OnAction(const CAction &action);
   
   virtual CFileItemPtr GetCurrentListItem(int offset = 0) { return m_item; }
   virtual bool HasListItems() const { return true; }

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -145,6 +145,16 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogMusicInfo::OnAction(const CAction &action)
+{
+  if (action.GetID() == ACTION_SHOW_INFO)
+  {
+    Close();
+    return true;
+  }
+  return CGUIDialog::OnAction(action);
+}
+
 void CGUIDialogMusicInfo::SetAlbum(const CAlbum& album, const CStdString &path)
 {
   m_album = album;

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -35,6 +35,7 @@ public:
   CGUIDialogMusicInfo(void);
   virtual ~CGUIDialogMusicInfo(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual bool OnAction(const CAction &action);
   void SetAlbum(const CAlbum& album, const CStdString &path);
   void SetArtist(const CArtist& artist, const CStdString &path);
   bool NeedRefresh() const;

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -142,6 +142,11 @@ bool CGUIDialogSongInfo::OnAction(const CAction &action)
       SetRating(rating - 1);
     return true;
   }
+  else if (action.GetID() == ACTION_SHOW_INFO)
+  {
+    Close();
+    return true;
+  }
   return CGUIDialog::OnAction(action);
 }
 

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -67,6 +67,10 @@ bool CGUIDialogPictureInfo::OnAction(const CAction& action)
         return pWindow->OnAction(action);
       }
       break;
+
+    case ACTION_SHOW_INFO:
+      Close();
+      return true;
   };
   return CGUIDialog::OnAction(action);
 }

--- a/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
@@ -30,3 +30,13 @@ CGUIDialogFullScreenInfo::~CGUIDialogFullScreenInfo(void)
 {
 }
 
+bool CGUIDialogFullScreenInfo::OnAction(const CAction &action)
+{
+  if (action.GetID() == ACTION_SHOW_INFO)
+  {
+    Close();
+    return true;
+  }
+  return CGUIDialog::OnAction(action);
+}
+

--- a/xbmc/video/dialogs/GUIDialogFullScreenInfo.h
+++ b/xbmc/video/dialogs/GUIDialogFullScreenInfo.h
@@ -28,5 +28,6 @@ class CGUIDialogFullScreenInfo :
 public:
   CGUIDialogFullScreenInfo(void);
   virtual ~CGUIDialogFullScreenInfo(void);
+  virtual bool OnAction(const CAction &action);
 };
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -222,6 +222,16 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogVideoInfo::OnAction(const CAction &action)
+{
+  if (action.GetID() == ACTION_SHOW_INFO)
+  {
+    Close();
+    return true;
+  }
+  return CGUIDialog::OnAction(action);
+}
+
 void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
 {
   *m_movieItem = *item;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -30,6 +30,7 @@ public:
   CGUIDialogVideoInfo(void);
   virtual ~CGUIDialogVideoInfo(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual bool OnAction(const CAction &action);
   void SetMovie(const CFileItem *item);
   bool NeedRefresh() const;
   bool RefreshAll() const;


### PR DESCRIPTION
When executing ACTION_SHOW_INFO (by pressing "I" or the "Info" button on a remote) while residing on a media item we open the media-specific info dialog. Thanks to keyboard.xml and remote.xml xbmc also closes those dialogs again when pressing the same button but this time using ACTION_BACK. In JSON-RPC the method Input.Info() triggers the execution of ACTION_SHOW_INFO but obviously JSON-RPC doesn't (and shouldn't) know/care about the GUI state so it doesn't know that it should send ACTION_BACK when the dialog is already open. This behaviour makes it hard for remote clients to offer the same functionality as with a keyboard or a physical remote.

These changes add handling for ACTION_SHOW_INFO in OnAction() to close the dialog when it's already open. There's a bug report for it on http://trac.xbmc.org/ticket/13139 but I could understand if it's not considered a bug in XBMC. So @cptspiff the decision is up to you.
