### PR TITLE
media library: avoid empty listings after an update/refresh by going one level up in the hierarchy

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -3348,7 +3348,17 @@ msgctxt "#2050"
 msgid "Runtime"
 msgstr ""
 
-#empty strings from id 2051 to 2099
+#empty strings from id 2051 to 2079
+
+msgctxt "#2080"
+msgid "Empty list"
+msgstr ""
+
+msgctxt "#2081"
+msgid "Went back to parent list because the active list has been emptied"
+msgstr ""
+
+#empty strings from id 2082 to 2099
 
 msgctxt "#2100"
 msgid "Script failed! : %s"

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -64,6 +64,7 @@
 #include "interfaces/python/XBPython.h"
 #endif
 #include "interfaces/Builtins.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogMediaFilter.h"
 #include "filesystem/SmartPlaylistDirectory.h"
 #if defined(TARGET_ANDROID)
@@ -866,7 +867,24 @@ bool CGUIMediaWindow::Refresh(bool clearCache /* = false */)
   if (clearCache)
     m_vecItems->RemoveDiscCache(GetID());
 
-  return Update(strCurrentDirectory);
+  // get the original number of items
+  int oldCount = m_filter.IsEmpty() ? m_vecItems->Size() : m_unfilteredItems->Size();
+  if (!Update(strCurrentDirectory))
+    return false;
+
+  // check if we previously had at least 1 item
+  // in the list and whether it now went down to 0
+  // if there are no more items to show after the update
+  // we go one level up in the hierachry to not show an
+  // empty list
+  if (oldCount > 0 &&
+     (m_filter.IsEmpty() ? m_vecItems->Size() : m_unfilteredItems->Size()) <= 0)
+  {
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(2080), g_localizeStrings.Get(2081));
+    GoParentFolder();
+  }
+
+  return true;
 }
 
 // \brief This function will be called by Update() before the
@@ -1128,7 +1146,15 @@ void CGUIMediaWindow::GoParentFolder()
   // if vector is not empty, pop parent
   // if vector is empty, parent is root source listing
   strParent = m_history.RemoveParentPath();
-  Update(strParent);
+  if (!Update(strParent))
+    return;
+
+  // No items to show so go another level up
+  if (!m_vecItems->GetPath().empty() && (m_filter.IsEmpty() ? m_vecItems->Size() : m_unfilteredItems->Size()) <= 0)
+  {
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(2080), g_localizeStrings.Get(2081));
+    GoParentFolder();
+  }
 }
 
 // \brief Override the function to change the default behavior on how


### PR DESCRIPTION
This is a fix for something that has bugged me ever since I use XBMC. When I'm e.g. in the tvshow view and have "Hide Watched" enabled and there's only a single episode left in a season (or the whole show) and I either watch that episode or mark it as watched, the item is removed from the list leaving me with an empty view. With this change we go to the parent folder until we find a list that is not empty. It also solves the problem described in #634 but in a more general approach (i.e. not tvshow/season specific).

A few notes:
- This does not apply when "Show parent folder items" is enabled because then the list is not empty. I wasn't sure how to handle this so I'm open to suggestions but I'm sure 50% of the people want it this way and the other 50% the other way ;-)
- This does not apply if the list is already empty when opening it.
- This does not apply when a filter is active i.e. when the user specifies filter conditions that have no match, the list will be empty but we will stay in the same list/view/window.
