### PR TITLE
media library: fix regressions due to advanced library filtering

### DIFF
--- a/xbmc/DbUrl.cpp
+++ b/xbmc/DbUrl.cpp
@@ -70,6 +70,74 @@ void CDbUrl::AppendPath(const std::string &subPath)
   m_url.SetFileName(URIUtils::AddFileToFolder(m_url.GetFileName(), subPath));
 }
 
+void CDbUrl::AddOption(const std::string &key, const char *value)
+{
+  if (!validateOption(key, value))
+    return;
+  
+  CUrlOptions::AddOption(key, value);
+  updateOptions();
+}
+
+void CDbUrl::AddOption(const std::string &key, const std::string &value)
+{
+  if (!validateOption(key, value))
+    return;
+  
+  CUrlOptions::AddOption(key, value);
+  updateOptions();
+}
+
+void CDbUrl::AddOption(const std::string &key, int value)
+{
+  if (!validateOption(key, value))
+    return;
+  
+  CUrlOptions::AddOption(key, value);
+  updateOptions();
+}
+
+void CDbUrl::AddOption(const std::string &key, float value)
+{
+  if (!validateOption(key, value))
+    return;
+  
+  CUrlOptions::AddOption(key, value);
+  updateOptions();
+}
+
+void CDbUrl::AddOption(const std::string &key, double value)
+{
+  if (!validateOption(key, value))
+    return;
+  
+  CUrlOptions::AddOption(key, value);
+  updateOptions();
+}
+
+void CDbUrl::AddOption(const std::string &key, bool value)
+{
+  if (!validateOption(key, value))
+    return;
+  
+  CUrlOptions::AddOption(key, value);
+  updateOptions();
+}
+
+void CDbUrl::AddOptions(const std::string &options)
+{
+  CUrlOptions::AddOptions(options);
+  updateOptions();  
+}
+
+bool CDbUrl::validateOption(const std::string &key, const CVariant &value)
+{
+  if (key.empty())
+    return false;
+
+  return true;
+}
+
 void CDbUrl::updateOptions()
 {
   // Update the options string in the CURL object

--- a/xbmc/DbUrl.h
+++ b/xbmc/DbUrl.h
@@ -39,16 +39,17 @@ public:
   const std::string& GetType() const { return m_type; }
   void AppendPath(const std::string &subPath);
 
-  virtual void AddOption(const std::string &key, const char *value) { CUrlOptions::AddOption(key, value); updateOptions(); }
-  virtual void AddOption(const std::string &key, const std::string &value) { CUrlOptions::AddOption(key, value); updateOptions(); }
-  virtual void AddOption(const std::string &key, int value) { CUrlOptions::AddOption(key, value); updateOptions(); }
-  virtual void AddOption(const std::string &key, float value) { CUrlOptions::AddOption(key, value); updateOptions(); }
-  virtual void AddOption(const std::string &key, double value) { CUrlOptions::AddOption(key, value); updateOptions(); }
-  virtual void AddOption(const std::string &key, bool value) { CUrlOptions::AddOption(key, value); updateOptions(); }
-  virtual void AddOptions(const std::string &options) { CUrlOptions::AddOptions(options); updateOptions(); }
+  virtual void AddOption(const std::string &key, const char *value);
+  virtual void AddOption(const std::string &key, const std::string &value);
+  virtual void AddOption(const std::string &key, int value);
+  virtual void AddOption(const std::string &key, float value);
+  virtual void AddOption(const std::string &key, double value);
+  virtual void AddOption(const std::string &key, bool value);
+  virtual void AddOptions(const std::string &options);
 
 protected:
   virtual bool parse() = 0;
+  virtual bool validateOption(const std::string &key, const CVariant &value);
   
   CURL m_url;
   std::string m_type;

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -208,6 +208,7 @@ void CURL::Parse(const CStdString& strURL1)
       else
         m_strOptions = strURL.substr(iOptions);
       iEnd = iOptions;
+      m_options.AddOptions(m_strOptions);
     }
   }
 
@@ -383,11 +384,13 @@ void CURL::SetProtocol(const CStdString& strProtocol)
 void CURL::SetOptions(const CStdString& strOptions)
 {
   m_strOptions.Empty();
+  m_options.Clear();
   if( strOptions.length() > 0)
   {
     if( strOptions[0] == '?' || strOptions[0] == '#' || strOptions[0] == ';' || strOptions.Find("xml") >=0 )
     {
       m_strOptions = strOptions;
+      m_options.AddOptions(m_strOptions);
     }
     else
       CLog::Log(LOGWARNING, "%s - Invalid options specified for url %s", __FUNCTION__, strOptions.c_str());
@@ -759,3 +762,45 @@ CStdString CURL::TranslateProtocol(const CStdString& prot)
   return prot;
 }
 
+void CURL::GetOptions(std::map<CStdString, CStdString> &options) const
+{
+  CUrlOptions::UrlOptions optionsMap = m_options.GetOptions();
+  for (CUrlOptions::UrlOptions::const_iterator option = optionsMap.begin(); option != optionsMap.end(); option++)
+    options[option->first] = option->second.asString();
+}
+
+bool CURL::HasOption(const CStdString &key) const
+{
+  return m_options.HasOption(key);
+}
+
+bool CURL::GetOption(const CStdString &key, CStdString &value) const
+{
+  CVariant valueObj;
+  if (!m_options.GetOption(key, valueObj))
+    return false;
+
+  value = valueObj.asString();
+  return true;
+}
+
+CStdString CURL::GetOption(const CStdString &key) const
+{
+  CStdString value;
+  if (!GetOption(key, value))
+    return "";
+
+  return value;
+}
+
+void CURL::SetOption(const CStdString &key, const CStdString &value)
+{
+  m_options.AddOption(key, value);
+  SetOptions(m_options.GetOptionsString(true));
+}
+
+void CURL::RemoveOption(const CStdString &key)
+{
+  m_options.AddOption(key, "");
+  SetOptions(m_options.GetOptionsString(true));
+}

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -20,6 +20,7 @@
  */
 
 #include "utils/StdString.h"
+#include "utils/UrlOptions.h"
 
 #ifdef _WIN32
 #undef SetPort // WIN32INCLUDES this is defined as SetPortA in WinSpool.h which is being included _somewhere_
@@ -74,6 +75,13 @@ public:
   static std::string Encode(const std::string& strURLData);
   static CStdString TranslateProtocol(const CStdString& prot);
 
+  void GetOptions(std::map<CStdString, CStdString> &options) const;
+  bool HasOption(const CStdString &key) const;
+  bool GetOption(const CStdString &key, CStdString &value) const;
+  CStdString GetOption(const CStdString &key) const;
+  void SetOption(const CStdString &key, const CStdString &value);
+  void RemoveOption(const CStdString &key);
+
 protected:
   int m_iPort;
   CStdString m_strHostName;
@@ -86,4 +94,5 @@ protected:
   CStdString m_strFileType;
   CStdString m_strOptions;
   CStdString m_strProtocolOptions;
+  CUrlOptions m_options;
 };

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -351,12 +351,12 @@ void CGUIWindowAddonBrowser::SetItemLabel2(CFileItemPtr item)
   item->SetLabelPreformated(true);
 }
 
-bool CGUIWindowAddonBrowser::Update(const CStdString &strDirectory)
+bool CGUIWindowAddonBrowser::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
-  if (!CGUIMediaWindow::Update(strDirectory))
+  if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
 
   m_thumbLoader.Load(*m_vecItems);

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -63,7 +63,7 @@ protected:
   virtual bool OnClick(int iItem);
   virtual void UpdateButtons();
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
-  virtual bool Update(const CStdString &strDirectory);
+  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
   virtual CStdString GetStartFolder(const CStdString &dir);
 private:
   CProgramThumbLoader m_thumbLoader;

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -27,6 +27,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "music/MusicDatabase.h"
 #include "playlists/SmartPlayList.h"
+#include "utils/log.h"
 #include "utils/MathUtils.h"
 #include "video/VideoDatabase.h"
 
@@ -586,7 +587,10 @@ void CGUIDialogMediaFilter::Reset()
 bool CGUIDialogMediaFilter::SetPath(const std::string &path)
 {
   if (path.empty() || m_filter == NULL)
+  {
+    CLog::Log(LOGWARNING, "CGUIDialogMediaFilter::SetPath(%s): invalid path or filter", path.c_str());
     return false;
+  }
 
   delete m_dbUrl;
   bool video = false;
@@ -598,12 +602,18 @@ bool CGUIDialogMediaFilter::SetPath(const std::string &path)
   else if (path.find("musicdb://") == 0)
     m_dbUrl = new CMusicDbUrl();
   else
+  {
+    CLog::Log(LOGWARNING, "CGUIDialogMediaFilter::SetPath(%s): invalid path (neither videodb:// nor musicdb://)", path.c_str());
     return false;
+  }
 
   if (!m_dbUrl->FromString(path) ||
      (video && m_dbUrl->GetType() != "movies" && m_dbUrl->GetType() != "tvshows" && m_dbUrl->GetType() != "episodes" && m_dbUrl->GetType() != "musicvideos") ||
      (!video && m_dbUrl->GetType() != "artists" && m_dbUrl->GetType() != "albums" && m_dbUrl->GetType() != "songs"))
+  {
+    CLog::Log(LOGWARNING, "CGUIDialogMediaFilter::SetPath(%s): invalid media type", path.c_str());
     return false;
+  }
 
   // remove "filter" option
   if (m_dbUrl->HasOption("filter"))

--- a/xbmc/filesystem/DirectoryHistory.cpp
+++ b/xbmc/filesystem/DirectoryHistory.cpp
@@ -70,37 +70,36 @@ const CStdString& CDirectoryHistory::GetSelectedItem(const CStdString& strDirect
 
 void CDirectoryHistory::AddPath(const CStdString& strPath)
 {
-  if ((m_vecPathHistory.size() == 0) || m_vecPathHistory.back() != strPath)
-  {
-    m_vecPathHistory.push_back(strPath);
-  }
+  if (!m_vecPathHistory.empty() && m_vecPathHistory.back().m_strPath == strPath)
+    return;
+
+  CPathHistoryItem item;
+  item.m_strPath = strPath;
+  m_vecPathHistory.push_back(item);
 }
 
 void CDirectoryHistory::AddPathFront(const CStdString& strPath)
 {
-  m_vecPathHistory.insert(m_vecPathHistory.begin(), strPath);
+  CPathHistoryItem item;
+  item.m_strPath = strPath;
+  m_vecPathHistory.insert(m_vecPathHistory.begin(), item);
 }
 
 CStdString CDirectoryHistory::GetParentPath()
 {
-  CStdString strParent;
-  if (m_vecPathHistory.size() > 0)
-  {
-    strParent = m_vecPathHistory.back();
-  }
+  if (m_vecPathHistory.empty())
+    return StringUtils::EmptyString;
 
-  return strParent;
+  return m_vecPathHistory.back().m_strPath;
 }
 
 CStdString CDirectoryHistory::RemoveParentPath()
 {
-  CStdString strParent;
-  if (m_vecPathHistory.size() > 0)
-  {
-    strParent = m_vecPathHistory.back();
-    m_vecPathHistory.pop_back();
-  }
+  if (m_vecPathHistory.empty())
+    return StringUtils::EmptyString;
 
+  CStdString strParent = GetParentPath();
+  m_vecPathHistory.pop_back();
   return strParent;
 }
 
@@ -112,13 +111,9 @@ void CDirectoryHistory::ClearPathHistory()
 void CDirectoryHistory::DumpPathHistory()
 {
   // debug log
-  CStdString strTemp;
   CLog::Log(LOGDEBUG,"Current m_vecPathHistory:");
   for (int i = 0; i < (int)m_vecPathHistory.size(); ++i)
-  {
-    strTemp.Format("%02i.[%s]", i, m_vecPathHistory[i]);
-    CLog::Log(LOGDEBUG, "  %s", strTemp.c_str());
-  }
+    CLog::Log(LOGDEBUG, "  %02i.[%s]", i, m_vecPathHistory[i].m_strPath.c_str());
 }
 
 CStdString CDirectoryHistory::preparePath(const CStdString &strDirectory, bool tolower /* = true */)

--- a/xbmc/filesystem/DirectoryHistory.cpp
+++ b/xbmc/filesystem/DirectoryHistory.cpp
@@ -25,6 +25,14 @@
 
 using namespace std;
 
+const CStdString& CDirectoryHistory::CPathHistoryItem::GetPath(bool filter /* = false */) const
+{
+  if (filter && !m_strFilterPath.empty())
+    return m_strFilterPath;
+
+  return m_strPath;
+}
+
 CDirectoryHistory::~CDirectoryHistory()
 {
   m_vecHistory.clear();
@@ -68,37 +76,39 @@ const CStdString& CDirectoryHistory::GetSelectedItem(const CStdString& strDirect
   return StringUtils::EmptyString;
 }
 
-void CDirectoryHistory::AddPath(const CStdString& strPath)
+void CDirectoryHistory::AddPath(const CStdString& strPath, const CStdString &strFilterPath /* = "" */)
 {
   if (!m_vecPathHistory.empty() && m_vecPathHistory.back().m_strPath == strPath)
     return;
 
   CPathHistoryItem item;
   item.m_strPath = strPath;
+  item.m_strFilterPath = strFilterPath;
   m_vecPathHistory.push_back(item);
 }
 
-void CDirectoryHistory::AddPathFront(const CStdString& strPath)
+void CDirectoryHistory::AddPathFront(const CStdString& strPath, const CStdString &strFilterPath /* = "" */)
 {
   CPathHistoryItem item;
   item.m_strPath = strPath;
+  item.m_strFilterPath = strFilterPath;
   m_vecPathHistory.insert(m_vecPathHistory.begin(), item);
 }
 
-CStdString CDirectoryHistory::GetParentPath()
+CStdString CDirectoryHistory::GetParentPath(bool filter /* = false */)
 {
   if (m_vecPathHistory.empty())
     return StringUtils::EmptyString;
 
-  return m_vecPathHistory.back().m_strPath;
+  return m_vecPathHistory.back().GetPath(filter);
 }
 
-CStdString CDirectoryHistory::RemoveParentPath()
+CStdString CDirectoryHistory::RemoveParentPath(bool filter /* = false */)
 {
   if (m_vecPathHistory.empty())
     return StringUtils::EmptyString;
 
-  CStdString strParent = GetParentPath();
+  CStdString strParent = GetParentPath(filter);
   m_vecPathHistory.pop_back();
   return strParent;
 }
@@ -113,7 +123,7 @@ void CDirectoryHistory::DumpPathHistory()
   // debug log
   CLog::Log(LOGDEBUG,"Current m_vecPathHistory:");
   for (int i = 0; i < (int)m_vecPathHistory.size(); ++i)
-    CLog::Log(LOGDEBUG, "  %02i.[%s]", i, m_vecPathHistory[i].m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "  %02i.[%s; %s]", i, m_vecPathHistory[i].m_strPath.c_str(), m_vecPathHistory[i].m_strFilterPath.c_str());
 }
 
 CStdString CDirectoryHistory::preparePath(const CStdString &strDirectory, bool tolower /* = true */)

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -34,6 +34,15 @@ public:
     CStdString m_strItem;
     CStdString m_strDirectory;
   };
+
+  class CPathHistoryItem
+  {
+  public:
+    CPathHistoryItem() { }
+    virtual ~CPathHistoryItem() { }
+
+    CStdString m_strPath;
+  };
   
   CDirectoryHistory() { }
   virtual ~CDirectoryHistory();
@@ -48,10 +57,11 @@ public:
   CStdString RemoveParentPath();
   void ClearPathHistory();
   void DumpPathHistory();
+
 private:
   static CStdString preparePath(const CStdString &strDirectory, bool tolower = true);
   
   typedef std::map<CStdString, CHistoryItem> HistoryMap;
   HistoryMap m_vecHistory;
-  std::vector<CStdString> m_vecPathHistory; ///< History of traversed directories
+  std::vector<CPathHistoryItem> m_vecPathHistory; ///< History of traversed directories
 };

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include <map>
+
 #include "utils/StdString.h"
 
 class CDirectoryHistory
@@ -32,7 +34,8 @@ public:
     CStdString m_strItem;
     CStdString m_strDirectory;
   };
-  CDirectoryHistory();
+  
+  CDirectoryHistory() { }
   virtual ~CDirectoryHistory();
 
   void SetSelectedItem(const CStdString& strSelectedItem, const CStdString& strDirectory);
@@ -46,7 +49,9 @@ public:
   void ClearPathHistory();
   void DumpPathHistory();
 private:
-  std::vector<CHistoryItem> m_vecHistory;
+  static CStdString preparePath(const CStdString &strDirectory, bool tolower = true);
+  
+  typedef std::map<CStdString, CHistoryItem> HistoryMap;
+  HistoryMap m_vecHistory;
   std::vector<CStdString> m_vecPathHistory; ///< History of traversed directories
-  CStdString m_strNull;
 };

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -41,7 +41,10 @@ public:
     CPathHistoryItem() { }
     virtual ~CPathHistoryItem() { }
 
+    const CStdString& GetPath(bool filter = false) const;
+
     CStdString m_strPath;
+    CStdString m_strFilterPath;
   };
   
   CDirectoryHistory() { }
@@ -51,10 +54,10 @@ public:
   const CStdString& GetSelectedItem(const CStdString& strDirectory) const;
   void RemoveSelectedItem(const CStdString& strDirectory);
 
-  void AddPath(const CStdString& strPath);
-  void AddPathFront(const CStdString& strPath);
-  CStdString GetParentPath();
-  CStdString RemoveParentPath();
+  void AddPath(const CStdString& strPath, const CStdString &m_strFilterPath = "");
+  void AddPathFront(const CStdString& strPath, const CStdString &m_strFilterPath = "");
+  CStdString GetParentPath(bool filter = false);
+  CStdString RemoveParentPath(bool filter = false);
   void ClearPathHistory();
   void DumpPathHistory();
 

--- a/xbmc/filesystem/HDHomeRunFile.cpp
+++ b/xbmc/filesystem/HDHomeRunFile.cpp
@@ -32,36 +32,6 @@
 using namespace XFILE;
 using namespace std;
 
-class CUrlOptions
-  : public map<CStdString, CStdString>
-{
-public:
-  CUrlOptions(const CStdString& data)
-  {
-    vector<CStdString> options;
-    CUtil::Tokenize(data, options, "&");
-    for(vector<CStdString>::iterator it = options.begin();it != options.end(); it++)
-    {
-      CStdString name, value;
-      size_t pos = it->find_first_of('=');
-      if(pos != CStdString::npos)
-      {
-        name = it->substr(0, pos);
-        value = it->substr(pos+1);
-      }
-      else
-      {
-        name = *it;
-        value = "";
-      }
-
-      CURL::Decode(name);
-      CURL::Decode(value);
-      insert(value_type(name, value));
-    }
-  }
-};
-
 // -------------------------------------------
 // ------------------ File -------------------
 // -------------------------------------------
@@ -126,14 +96,11 @@ bool CHomeRunFile::Open(const CURL &url)
 
   m_pdll->device_set_tuner_from_str(m_device, url.GetFileName().c_str());
 
-  CUrlOptions options(url.GetOptions().Mid(1));
-  CUrlOptions::iterator it;
+  if(url.HasOption("channel"))
+    m_pdll->device_set_tuner_channel(m_device, url.GetOption("channel").c_str());
 
-  if( (it = options.find("channel")) != options.end() )
-    m_pdll->device_set_tuner_channel(m_device, it->second.c_str());
-
-  if( (it = options.find("program")) != options.end() )
-    m_pdll->device_set_tuner_program(m_device, it->second.c_str());
+  if(url.HasOption("program"))
+    m_pdll->device_set_tuner_program(m_device, url.GetOption("program").c_str());
 
   // start streaming from selected device and tuner
   if( m_pdll->device_stream_start(m_device) <= 0 )

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -31,6 +31,8 @@
 #include "settings/GUISettings.h"
 #include "utils/URIUtils.h"
 
+#define PROPERTY_PATH_DB            "path.db"
+
 namespace XFILE
 {
   CSmartPlaylistDirectory::CSmartPlaylistDirectory()
@@ -111,15 +113,13 @@ namespace XFILE
         
         CDatabase::Filter dbfilter;
         success = db.GetSortedVideos(mediaType, videoUrl.ToString(), sorting, items, dbfilter, true);
+        db.Close();
 
         // if we retrieve a list of episodes and we didn't receive
         // a pre-defined base path, we need to fix it
         if (strBaseDir.empty() && mediaType == MediaTypeEpisode)
-        {
           videoUrl.AppendPath("-1/-1/");
-          items.SetPath(videoUrl.ToString());
-        }
-        db.Close();
+        items.SetProperty(PROPERTY_PATH_DB, videoUrl.ToString());
       }
     }
     else if (playlist.GetType().Equals("albums"))
@@ -142,8 +142,9 @@ namespace XFILE
 
         CDatabase::Filter dbfilter;
         success = db.GetAlbumsByWhere(musicUrl.ToString(), dbfilter, items, sorting);
-        items.SetContent("albums");
         db.Close();
+        items.SetContent("albums");
+        items.SetProperty(PROPERTY_PATH_DB, musicUrl.ToString());
       }
     }
     else if (playlist.GetType().Equals("artists"))
@@ -166,8 +167,9 @@ namespace XFILE
 
         CDatabase::Filter dbfilter;
         success = db.GetArtistsNav(musicUrl.ToString(), items, !g_guiSettings.GetBool("musiclibrary.showcompilationartists"), -1, -1, -1, dbfilter, sorting);
-        items.SetContent("artists");
         db.Close();
+        items.SetContent("artists");
+        items.SetProperty(PROPERTY_PATH_DB, musicUrl.ToString());
       }
     }
 
@@ -195,8 +197,9 @@ namespace XFILE
 
         CDatabase::Filter dbfilter;
         success = db.GetSongsByWhere(musicUrl.ToString(), dbfilter, items, sorting);
-        items.SetContent("songs");
         db.Close();
+        items.SetContent("songs");
+        items.SetProperty(PROPERTY_PATH_DB, musicUrl.ToString());
       }
     }
     if (playlist.GetType().Equals("musicvideos") || playlist.GetType().Equals("mixed"))
@@ -233,6 +236,7 @@ namespace XFILE
           else
             items.SetContent("musicvideos");
         }
+        items.SetProperty(PROPERTY_PATH_DB, videoUrl.ToString());
       }
     }
     items.SetLabel(playlist.GetName());

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2744,8 +2744,6 @@ bool CMusicDatabase::GetCommonNav(const CStdString &strBaseDir, const CStdString
     CMusicDbUrl musicUrl;
     if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, musicUrl))
       return false;
-
-    items.SetPath(musicUrl.ToString());
     
     strSQL = PrepareSQL(strSQL, !extFilter.fields.empty() ? extFilter.fields.c_str() : labelField.c_str());
     
@@ -2893,8 +2891,6 @@ bool CMusicDatabase::GetArtistsByWhere(const CStdString& strBaseDir, const Filte
     CStdString strSQLExtra;
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
-
-    items.SetPath(musicUrl.ToString());
 
     // Apply the limiting directly here if there's no special sorting but limiting
     if (extFilter.limit.empty() &&
@@ -3089,8 +3085,6 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const Filter &f
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
-    items.SetPath(musicUrl.ToString());
-
     // Apply the limiting directly here if there's no special sorting but limiting
     if (extFilter.limit.empty() &&
         sortDescription.sortBy == SortByNone &&
@@ -3203,8 +3197,6 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const Filter &fi
     CStdString strSQLExtra;
     if (!BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
-
-    items.SetPath(musicUrl.ToString());
 
     // Apply the limiting directly here if there's no special sorting but limiting
     if (extFilter.limit.empty() &&
@@ -5383,7 +5375,7 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
       return false;
 
     // check if the filter playlist matches the item type
-    if (xsp.GetType() != "artists"|| xsp.GetType()  == type)
+    if (xsp.GetType() != "artists" || xsp.GetType()  == type)
     {
       std::set<CStdString> playlists;
       filter.AppendWhere(xsp.GetWhereClause(*this, playlists));

--- a/xbmc/music/MusicDbUrl.cpp
+++ b/xbmc/music/MusicDbUrl.cpp
@@ -19,6 +19,7 @@
 
 #include "MusicDbUrl.h"
 #include "filesystem/MusicDatabaseDirectory.h"
+#include "playlists/SmartPlayList.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -147,4 +148,25 @@ bool CMusicDbUrl::parse()
     AddOption("year", (int)queryParams.GetYear());
 
   return true;
+}
+
+bool CMusicDbUrl::validateOption(const std::string &key, const CVariant &value)
+{
+  if (!CDbUrl::validateOption(key, value))
+    return false;
+  
+  // if the value is empty it will remove the option which is ok
+  // otherwise we only care about the "filter" option here
+  if (value.empty() || !StringUtils::EqualsNoCase(key, "filter"))
+    return true;
+
+  if (!value.isString())
+    return false;
+
+  CSmartPlaylist xspFilter;
+  if (!xspFilter.LoadFromJson(value.asString()))
+    return false;
+
+  // check if the filter playlist matches the item type
+  return xspFilter.GetType() == m_type;
 }

--- a/xbmc/music/MusicDbUrl.h
+++ b/xbmc/music/MusicDbUrl.h
@@ -30,4 +30,5 @@ public:
 
 protected:
   virtual bool parse();
+  virtual bool validateOption(const std::string &key, const CVariant &value);
 };

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -72,7 +72,8 @@ protected:
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual CStdString GetStartFolder(const CStdString &dir);
 
-  virtual bool CheckFilterAdvanced(CFileItemList &items);
+  virtual bool CheckFilterAdvanced(CFileItemList &items) const;
+  virtual bool CanContainFilter(const CStdString &strDirectory) const;
 
   // new methods
   virtual void PlayItem(int iItem);

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -265,12 +265,12 @@ bool CGUIWindowMusicNav::OnClick(int iItem)
   return CGUIWindowMusicBase::OnClick(iItem);
 }
 
-bool CGUIWindowMusicNav::Update(const CStdString &strDirectory)
+bool CGUIWindowMusicNav::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
-  if (CGUIWindowMusicBase::Update(strDirectory))
+  if (CGUIWindowMusicBase::Update(strDirectory, updateFilterPath))
   {
     m_thumbLoader.Load(*m_unfilteredItems);
     return true;

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -40,7 +40,7 @@ public:
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
   // override base class methods
-  virtual bool Update(const CStdString &strDirectory);
+  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
   virtual void PlayItem(int iItem);

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -479,12 +479,12 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
   }
 }
 
-bool CGUIWindowMusicPlayList::Update(const CStdString& strDirectory)
+bool CGUIWindowMusicPlayList::Update(const CStdString& strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_musicInfoLoader.IsLoading())
     m_musicInfoLoader.StopThread();
 
-  if (!CGUIWindowMusicBase::Update(strDirectory))
+  if (!CGUIWindowMusicBase::Update(strDirectory, updateFilterPath))
     return false;
 
   if (m_vecItems->GetContent().IsEmpty())

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.h
@@ -40,7 +40,7 @@ protected:
   virtual void GoParentFolder() {};
   virtual void UpdateButtons();
   virtual void OnItemLoaded(CFileItem* pItem);
-  virtual bool Update(const CStdString& strDirectory);
+  virtual bool Update(const CStdString& strDirectory, bool updateFilterPath = true);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   void OnMove(int iItem, int iAction);

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -215,12 +215,12 @@ void CGUIWindowMusicPlaylistEditor::OnQueueItem(int iItem)
   AppendToPlaylist(newItems);
 }
 
-bool CGUIWindowMusicPlaylistEditor::Update(const CStdString &strDirectory)
+bool CGUIWindowMusicPlaylistEditor::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
-  if (!CGUIMediaWindow::Update(strDirectory))
+  if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
 
   m_vecItems->SetContent("files");

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
@@ -37,7 +37,7 @@ protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
-  virtual bool Update(const CStdString &strDirectory);
+  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -461,12 +461,12 @@ void CGUIWindowMusicSongs::PlayItem(int iItem)
     CGUIWindowMusicBase::PlayItem(iItem);
 }
 
-bool CGUIWindowMusicSongs::Update(const CStdString &strDirectory)
+bool CGUIWindowMusicSongs::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
-  if (!CGUIMediaWindow::Update(strDirectory))
+  if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
 
   if (m_vecItems->GetContent().IsEmpty())

--- a/xbmc/music/windows/GUIWindowMusicSongs.h
+++ b/xbmc/music/windows/GUIWindowMusicSongs.h
@@ -36,7 +36,7 @@ protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
-  virtual bool Update(const CStdString &strDirectory);
+  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -256,12 +256,12 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
     m_dlgProgress->Close();
 }
 
-bool CGUIWindowPictures::Update(const CStdString &strDirectory)
+bool CGUIWindowPictures::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
-  if (!CGUIMediaWindow::Update(strDirectory))
+  if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
 
   m_vecItems->SetArt("thumb", "");

--- a/xbmc/pictures/GUIWindowPictures.h
+++ b/xbmc/pictures/GUIWindowPictures.h
@@ -41,7 +41,7 @@ protected:
   virtual bool OnClick(int iItem);
   virtual void UpdateButtons();
   virtual void OnPrepareFileItems(CFileItemList& items);
-  virtual bool Update(const CStdString &strDirectory);
+  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual CStdString GetStartFolder(const CStdString &dir);

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -146,12 +146,12 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   return CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowPrograms::Update(const CStdString &strDirectory)
+bool CGUIWindowPrograms::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
-  if (!CGUIMediaWindow::Update(strDirectory))
+  if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
 
   m_thumbLoader.Load(*m_vecItems);

--- a/xbmc/programs/GUIWindowPrograms.h
+++ b/xbmc/programs/GUIWindowPrograms.h
@@ -34,7 +34,7 @@ public:
   virtual void OnInfo(int iItem);
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
-  virtual bool Update(const CStdString& strDirectory);
+  virtual bool Update(const CStdString& strDirectory, bool updateFilterPath = true);
   virtual bool OnPlayMedia(int iItem);
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);

--- a/xbmc/utils/UrlOptions.cpp
+++ b/xbmc/utils/UrlOptions.cpp
@@ -26,9 +26,11 @@
 using namespace std;
 
 CUrlOptions::CUrlOptions()
+  : m_strLead("?")
 { }
 
 CUrlOptions::CUrlOptions(const std::string &options)
+  : m_strLead("?")
 {
   AddOptions(options);
 }
@@ -36,7 +38,7 @@ CUrlOptions::CUrlOptions(const std::string &options)
 CUrlOptions::~CUrlOptions()
 { }
 
-std::string CUrlOptions::GetOptionsString() const
+std::string CUrlOptions::GetOptionsString(bool withLeadingSeperator /* = false */) const
 {
   std::string options;
   for (UrlOptions::const_iterator opt = m_options.begin(); opt != m_options.end(); opt++)
@@ -46,6 +48,9 @@ std::string CUrlOptions::GetOptionsString() const
 
     options += CURL::Encode(opt->first) + "=" + CURL::Encode(opt->second.asString());
   }
+
+  if (withLeadingSeperator && !options.empty())
+    options = m_strLead + options;
 
   return options;
 }
@@ -109,9 +114,14 @@ void CUrlOptions::AddOptions(const std::string &options)
 
   string strOptions = options;
 
-  // remove leading ? if present
-  if (strOptions.at(0) == '?')
+  // remove leading ?, # or ; if present
+  if (strOptions.at(0) == '?' || strOptions.at(0) == '#' || strOptions.at(0) == ';')
+  {
+    m_strLead = strOptions.at(0);
     strOptions.erase(0, 1);
+  }
+  else
+    m_strLead = "?";
 
   // split the options by & and process them one by one
   vector<string> optionList = StringUtils::Split(strOptions, "&");
@@ -139,7 +149,7 @@ void CUrlOptions::AddOptions(const CUrlOptions &options)
   m_options.insert(options.m_options.begin(), options.m_options.end());
 }
 
-bool CUrlOptions::HasOption(const std::string &key)
+bool CUrlOptions::HasOption(const std::string &key) const
 {
   if (key.empty())
     return false;
@@ -147,7 +157,7 @@ bool CUrlOptions::HasOption(const std::string &key)
   return m_options.find(key) != m_options.end();
 }
 
-bool CUrlOptions::GetOption(const std::string &key, CVariant &value)
+bool CUrlOptions::GetOption(const std::string &key, CVariant &value) const
 {
   if (key.empty())
     return false;

--- a/xbmc/utils/UrlOptions.h
+++ b/xbmc/utils/UrlOptions.h
@@ -32,8 +32,10 @@ public:
   CUrlOptions(const std::string &options);
   virtual ~CUrlOptions();
 
+  virtual void Clear() { m_options.clear(); }
+
   virtual const UrlOptions& GetOptions() const { return m_options; }
-  virtual std::string GetOptionsString() const;
+  virtual std::string GetOptionsString(bool withLeadingSeperator = false) const;
 
   virtual void AddOption(const std::string &key, const char *value);
   virtual void AddOption(const std::string &key, const std::string &value);
@@ -44,9 +46,10 @@ public:
   virtual void AddOptions(const std::string &options);
   virtual void AddOptions(const CUrlOptions &options);
 
-  virtual bool HasOption(const std::string &key);
-  virtual bool GetOption(const std::string &key, CVariant &value);
+  virtual bool HasOption(const std::string &key) const;
+  virtual bool GetOption(const std::string &key, CVariant &value) const;
 
 protected:
   UrlOptions m_options;
+  std::string m_strLead;
 };

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5461,8 +5461,6 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
     if (!BuildSQL(strBaseDir, strSQL, filter, strSQL, videoUrl))
       return false;
 
-    items.SetPath(videoUrl.ToString());
-
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
       return iRowsFound == 0;
@@ -5747,8 +5745,6 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter
     if (!CDatabase::BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
 
-    items.SetPath(videoUrl.ToString());
-
     // Apply the limiting directly here if there's no special sorting but limiting
     if (extFilter.limit.empty() &&
         sorting.sortBy == SortByNone &&
@@ -5871,8 +5867,6 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filte
     SortDescription sorting = sortDescription;
     if (!BuildSQL(strBaseDir, strSQLExtra, extFilter, strSQLExtra, videoUrl, sorting))
       return false;
-
-    items.SetPath(videoUrl.ToString());
 
     // Apply the limiting directly here if there's no special sorting but limiting
       if (extFilter.limit.empty() &&
@@ -6192,8 +6186,6 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filt
     SortDescription sorting = sortDescription;
     if (!BuildSQL(strBaseDir, strSQLExtra, extFilter, strSQLExtra, videoUrl, sorting))
       return false;
-
-    items.SetPath(videoUrl.ToString());
 
     // Apply the limiting directly here if there's no special sorting but limiting
     if (extFilter.limit.empty() &&
@@ -7046,8 +7038,6 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filt
     SortDescription sorting = sortDescription;
     if (!BuildSQL(baseDir, strSQLExtra, extFilter, strSQLExtra, videoUrl, sorting))
       return false;
-
-    items.SetPath(videoUrl.ToString());
 
     // Apply the limiting directly here if there's no special sorting but limiting
     if (extFilter.limit.empty() &&

--- a/xbmc/video/VideoDbUrl.cpp
+++ b/xbmc/video/VideoDbUrl.cpp
@@ -19,6 +19,7 @@
 
 #include "VideoDbUrl.h"
 #include "filesystem/VideoDatabaseDirectory.h"
+#include "playlists/SmartPlayList.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -186,4 +187,26 @@ bool CVideoDbUrl::parse()
     AddOption("year", (int)queryParams.GetYear());
 
   return true;
+}
+
+bool CVideoDbUrl::validateOption(const std::string &key, const CVariant &value)
+{
+  if (!CDbUrl::validateOption(key, value))
+    return false;
+
+  // if the value is empty it will remove the option which is ok
+  // otherwise we only care about the "filter" option here
+  if (value.empty() || !StringUtils::EqualsNoCase(key, "filter"))
+    return true;
+
+  if (!value.isString())
+    return false;
+
+  CSmartPlaylist xspFilter;
+  if (!xspFilter.LoadFromJson(value.asString()))
+    return false;
+  
+  // check if the filter playlist matches the item type
+  return (xspFilter.GetType() == m_itemType ||
+         (xspFilter.GetType() == "movies" && m_itemType == "sets"));
 }

--- a/xbmc/video/VideoDbUrl.h
+++ b/xbmc/video/VideoDbUrl.h
@@ -30,6 +30,7 @@ public:
 
 protected:
   virtual bool parse();
+  virtual bool validateOption(const std::string &key, const CVariant &value);
 
 private:
   std::string m_itemType;

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -85,12 +85,13 @@ protected:
   void OnScan(const CStdString& strPath, bool scanAll = false);
   virtual void OnInitWindow();
   virtual void UpdateButtons();
-  virtual bool Update(const CStdString &strDirectory);
+  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
   virtual void OnItemLoaded(CFileItem* pItem) {};
   virtual void OnPrepareFileItems(CFileItemList &items);
 
-  virtual bool CheckFilterAdvanced(CFileItemList &items);
+  virtual bool CheckFilterAdvanced(CFileItemList &items) const;
+  virtual bool CanContainFilter(const CStdString &strDirectory) const;
 
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   void GetNonContextButtons(int itemNumber, CContextButtons &buttons);

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -69,8 +69,16 @@ protected:
   virtual void FormatItemLabels(CFileItemList &items, const LABEL_MASKS &labelMasks);
   virtual void UpdateButtons();
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
-  virtual bool Update(const CStdString &strDirectory);
-  /* \brief Refreshes the current list by retrieving the lists's path
+  /*! \brief Retrieves the items from the given path and updates the list
+   \param strDirectory The path to the directory to get the items from
+   \param updateFilterPath Whether to update the filter path in m_strFilterPath or not
+   \return true if the list was sucessfully updated otherwise false
+   \sa GetDirectory
+   \sa m_vecItems
+   \sa m_strFilterPath
+   */
+  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
+  /*! \brief Refreshes the current list by retrieving the lists's path
    \return true if the list was successfully refreshed otherwise false
    \sa Update
    \sa GetDirectory
@@ -80,10 +88,19 @@ protected:
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual void OnFinalizeFileItems(CFileItemList &items);
 
-  void ClearFileItems(bool itemsOnly = false);
+  void ClearFileItems();
   virtual void SortItems(CFileItemList &items);
 
-  virtual bool CheckFilterAdvanced(CFileItemList &items) { return false; }
+  /*! \brief Check if the given list can be advance filtered or not
+   \param items List of items to check
+   \return true if the list can be advance filtered otherwise false
+   */
+  virtual bool CheckFilterAdvanced(CFileItemList &items) const { return false; }
+  /*! \brief Check if the given path can contain a "filter" parameter
+   \param strDirectory Path to check
+   \return true if the given path can contain a "filter" parameter otherwise false
+   */
+  virtual bool CanContainFilter(const CStdString &strDirectory) const { return false; }
   virtual bool Filter();
 
   /* \brief Called on response to a GUI_MSG_FILTER_ITEMS message
@@ -129,6 +146,13 @@ protected:
    \return the resulting path */
   virtual CStdString GetStartFolder(const CStdString &url);
 
+  /*! \brief Utility method to remove the given parameter from a path/URL
+   \param strDirectory Path/URL from which to remove the given parameter
+   \param strParameter Parameter to remove from the given path/URL
+   \return Path/URL without the given parameter
+   */
+  static CStdString RemoveParameterFromPath(const CStdString &strDirectory, const CStdString &strParameter);
+
   XFILE::CVirtualDirectory m_rootDir;
   CGUIViewControl m_viewControl;
 
@@ -145,5 +169,17 @@ protected:
 
   CSmartPlaylist m_filter;
   bool m_canFilterAdvanced;
-  bool m_itemsLoaded;
+  /*! \brief Contains the path used for filtering (including any active filter)
+
+   When Update() is called with a path to e.g. a smartplaylist or
+   a library node filter, that "original" path will be stored in
+   m_vecItems->m_strPath. But the path used by XBMC to retrieve
+   those items from the database (Videodb:// or musicdb://)
+   is stored in this member variable to still have access to it
+   because it is used for filtering by appending the currently active
+   filter as a "filter" parameter to the filter path/URL.
+
+   \sa Update
+   */
+  CStdString m_strFilterPath;
 };


### PR DESCRIPTION
In the current implementation, upon retrieving a list of items in CGUIMediaWindow::Update() we overwrite the path passed in as a parameter with the path assigned to the new CFileItemList instance (the real path) because we need the real path for the advanced library filtering. This results in loss of important information because the original path is used in many places (e.g. getting the right CGUIViewState implementation). But for advanced filtering to work we need to also be able to access the real path containing the active filter as a JSON representation in the "filter" URL parameter which allows to pass an active filter down to a sub-directory and also to return back to a filtered list from a sub-directory.
To avoid overwriting the original path used to retrieve the list of items we store the real path in a new member variable m_strRealPath instead and also store the real path of a list in the current path history to be able to return to the filtered list from a sub-directory.

The first commit is just an optimization and has nothing to do with the fix but I thought I'd clean it up while I'm in CDirectoryHistory anyway. The third commit is just for convenience because I was sick of writing the same code in different places (i.e. check if the path contains a "filter" parameter and remove it if present).
The last commit contains the main changes which solves the regressions currently present in mainline (e.g. http://trac.xbmc.org/ticket/13422) and partly reverts some of the fixes I committed in the last few days because they are not needed anymore. But it still needs a solution for the problem described (and solved) in #1631.
