### PR TITLE
allow 'faster' movement in sliders

### DIFF
--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -166,9 +166,19 @@ bool CGUISliderControl::OnAction(const CAction &action)
     Move(-1);
     return true;
 
+  case ACTION_PAGE_DOWN:
+    // go DOWN 10 increments
+    Move(-10);
+    return true;
+
   case ACTION_MOVE_RIGHT:
     //case ACTION_OSD_SHOW_VALUE_PLUS:
     Move(1);
+    return true;
+
+  case ACTION_PAGE_UP:
+    // go UP 10 increments
+    Move(10);
     return true;
 
   case ACTION_SELECT_ITEM:


### PR DESCRIPTION
Ever since the new advanced filtering UI I'm annoyed with the sliders. They are slow and difficult to use because of the small steps (1 year at a time, or 0.1 rating at a time)... I have come up with a simple solution, which is to allow the sliders to jump 10 steps at a time.

The question I still have is related to which keys should be used for this, and right now I can't think of anything else than PgUp and PgDn for the big steps. I tried it and it works beautifully, this is a great usability improvment. 

I'm not sure though about any side effects on GUI (like in different skins).

So before merging, I'd like your input.

Including
@montellese
@jmarshallnz
