### PR TITLE
Added ability to overwrite current content in Numeric Dialog

### DIFF
--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -48,6 +48,7 @@ CGUIDialogNumeric::CGUIDialogNumeric(void)
   m_block = 0;
   memset(&m_datetime, 0, sizeof(SYSTEMTIME));
   m_dirty = false;
+  m_bOverWrite = false;
   m_loadType = KEEP_IN_MEMORY;
 }
 
@@ -208,7 +209,11 @@ void CGUIDialogNumeric::OnBackSpace()
   if (m_mode == INPUT_NUMBER || m_mode == INPUT_PASSWORD)
   { // just go back one character
     if (!m_number.IsEmpty())
+    {
       m_number.Delete(m_number.GetLength() - 1);
+      if(m_bOverWrite)
+        m_dirty = true;
+    }
   }
   else if (m_mode == INPUT_IP_ADDRESS)
   {
@@ -342,7 +347,18 @@ void CGUIDialogNumeric::OnNumber(unsigned int num)
 
   if (m_mode == INPUT_NUMBER || m_mode == INPUT_PASSWORD)
   {
-    m_number += num + '0';
+    if (m_bOverWrite)
+    {
+      if (m_dirty)
+        m_number += num + '0';
+      else
+      {
+        m_number = num + '0';
+        m_dirty = true;
+      }
+    }
+    else
+      m_number += num + '0';
   }
   else if (m_mode == INPUT_TIME)
   {
@@ -509,7 +525,7 @@ void CGUIDialogNumeric::OnNumber(unsigned int num)
   }
 }
 
-void CGUIDialogNumeric::SetMode(INPUT_MODE mode, void *initial)
+void CGUIDialogNumeric::SetMode(INPUT_MODE mode, void *initial, bool bOverWrite = true)
 {
   m_mode = mode;
   m_block = 0;
@@ -542,7 +558,10 @@ void CGUIDialogNumeric::SetMode(INPUT_MODE mode, void *initial)
     }
   }
   else if (m_mode == INPUT_NUMBER || m_mode == INPUT_PASSWORD)
+  {
+    m_bOverWrite = bOverWrite;
     m_number = *(CStdString *)initial;
+  }
 }
 
 void CGUIDialogNumeric::SetMode(INPUT_MODE mode, const CStdString &initial)

--- a/xbmc/dialogs/GUIDialogNumeric.h
+++ b/xbmc/dialogs/GUIDialogNumeric.h
@@ -42,7 +42,7 @@ public:
   static bool ShowAndVerifyInput(CStdString& strPassword, const CStdString& strHeading, bool bGetUserInput);
 
   void SetHeading(const CStdString &strHeading);
-  void SetMode(INPUT_MODE mode, void *initial);
+  void SetMode(INPUT_MODE mode, void *initial, bool bOverWrite /* = true */);
   void SetMode(INPUT_MODE mode, const CStdString &initial);
   void GetOutput(void *output) const;
   CStdString GetOutput() const;
@@ -74,5 +74,6 @@ protected:
   unsigned int m_block;             // for time, date, and IP methods.
   unsigned int m_lastblock;
   bool m_dirty;                     // true if the current block has been changed.
+  bool m_bOverWrite;                // true rewrites current value
   CStdString m_number;              ///< for number or password input
 };


### PR DESCRIPTION
Currently if you want to change, let's say a port for HTTP proxy server in settings, via Numeric Dialog, you have to delete current port number before entering new one.
This PR add ability to set overwrite mode.

By setting pDialog->SetMode(INPUT_NUMBER, string, true) current content will be overwritten.

I added bool bOverWrite to CGUIDialogNumeric::SetMode function. Currenty it is set to true. This means that every Numeric Dialog will overwrite current value, by setting it to false, the Numeric Dialog will behave as normal.
