### PR TITLE
FIX: TV shows quick path mixup

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -224,6 +224,8 @@ CStdString CGUIWindowVideoNav::GetQuickpathName(const CStdString& strPath) const
     return "TvShowYears";
   else if (strPath.Equals("videodb://2/4/"))
     return "TvShowActors";
+  else if (strPath.Equals("videodb://2/5/"))
+    return "TvShowStudios";
   else if (strPath.Equals("videodb://2/9/"))
     return "TvShowTags";
   else if (strPath.Equals("videodb://2/"))


### PR DESCRIPTION
Unless mistaken (and according to VideoDatabase.cpp:7561), videodb://2/5 is Tv Shows by director, not studios (although studios would make much more sense ;) )
