### PR TITLE
Advanced Library Filtering: add a delay of 500ms before triggering the live filter for text and range filters

### DIFF
--- a/project/VS2010Express/XbmcThreads.vcxproj
+++ b/project/VS2010Express/XbmcThreads.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="..\..\xbmc\threads\Atomics.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Event.cpp" />
     <ClCompile Include="..\..\xbmc\threads\LockFree.cpp" />
+    <ClCompile Include="..\..\xbmc\threads\Timer.cpp" />
     <ClInclude Include="..\..\xbmc\threads\platform\ThreadImpl.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\ThreadImpl.cpp" />
     <ClInclude Include="..\..\xbmc\threads\platform\ThreadImpl.cpp" />
@@ -22,6 +23,7 @@
     <ClCompile Include="..\..\xbmc\threads\platform\win\Win32Exception.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Thread.cpp" />
+    <ClInclude Include="..\..\xbmc\threads\Timer.h" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\threads\Atomics.h" />

--- a/project/VS2010Express/XbmcThreads.vcxproj.filters
+++ b/project/VS2010Express/XbmcThreads.vcxproj.filters
@@ -12,6 +12,7 @@
     <ClCompile Include="..\..\xbmc\threads\platform\win\Win32Exception.cpp">
       <Filter>platform\win</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\threads\Timer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\threads\Atomics.h" />
@@ -63,6 +64,7 @@
     <ClInclude Include="..\..\xbmc\threads\platform\win\Win32Exception.h">
       <Filter>platform\win</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\threads\Timer.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="platform">

--- a/xbmc/dialogs/GUIDialogMediaFilter.h
+++ b/xbmc/dialogs/GUIDialogMediaFilter.h
@@ -26,12 +26,13 @@
 #include "dbwrappers/Database.h"
 #include "playlists/SmartPlayList.h"
 #include "settings/GUIDialogSettings.h"
+#include "threads/Timer.h"
 #include "utils/DatabaseUtils.h"
 #include "utils/StdString.h"
 
 class CFileItemList;
 
-class CGUIDialogMediaFilter : public CGUIDialogSettings
+class CGUIDialogMediaFilter : public CGUIDialogSettings, protected ITimerCallback
 {
 public:
   CGUIDialogMediaFilter();
@@ -59,15 +60,17 @@ protected:
   virtual void SetupPage();
   virtual void OnSettingChanged(SettingInfo &setting);
 
+  virtual void OnTimeout();
+
   void Reset();
   bool SetPath(const std::string &path);
   void UpdateControls();
+  void TriggerFilter() const;
 
   void OnBrowse(const Filter &filter, CFileItemList &items, bool countOnly = false);
   CSmartPlaylistRule* AddRule(Field field, CSmartPlaylistRule::SEARCH_OPERATOR ruleOperator = CSmartPlaylistRule::OPERATOR_CONTAINS);
   void DeleteRule(Field field);
   void GetRange(const Filter &filter, float &min, float &interval, float &max, RANGEFORMATFUNCTION &formatFunction);
-
   bool GetMinMax(const CStdString &table, const CStdString &field, float &min, float &max, const CDatabase::Filter &filter = CDatabase::Filter());
 
   static CStdString RangeAsFloat(float valueLower, float valueUpper, float minimum);
@@ -79,4 +82,5 @@ protected:
   std::string m_mediaType;
   CSmartPlaylist *m_filter;
   std::map<uint32_t, Filter> m_filters;
+  CTimer *m_delayTimer;
 };

--- a/xbmc/threads/Timer.h
+++ b/xbmc/threads/Timer.h
@@ -38,6 +38,7 @@ public:
 
   bool Start(uint32_t timeout, bool interval = false);
   bool Stop(bool wait = false);
+  bool Restart();
 
   bool IsRunning() const { return CThread::IsRunning(); }
 


### PR DESCRIPTION
As discussed in https://github.com/xbmc/xbmc/pull/1648 these changes use CTimer to trigger a 500ms delay on every change of value in a text or range filter which allows the user to do further changes before the filter is triggered. On not so powerful machines the filter, which basically reloads the whole list and filters the matching items, can take some time to finish so triggering the filter after every change in a range or text filter can make it rather unusable. I just tried 500ms and the delay didn't feel odd or anything.

This delay only applies to the live filter and not to updating the controls of the filter dialog which means that we will still update all the controls after every change. This could probably be done with a delay as well if necessary.

This would need the changes to the Xcode project files as well if deemed Frodo-material.
