### PR TITLE
[pvr] Fix incorrect log-line which may confuse addon authors

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -896,7 +896,7 @@ int64_t CPVRClient::GetStreamLength(void)
   else if (IsPlayingRecording())
   {
     try { return m_pStruct->LengthRecordedStream(); }
-    catch (exception &e) { LogException(e, "PositionRecordedStream()"); }
+    catch (exception &e) { LogException(e, "LengthRecordedStream()"); }
   }
   return -EINVAL;
 }


### PR DESCRIPTION
The log-message should state that there is a problem with the LengthRecordedStream-call, not the PositionRecordedStream-call. 
