### PR TITLE
[UPnP] ignore any requested sort critera, instead use XBMC GUIViewState defaults

### DIFF
--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -558,19 +558,12 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
             items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
         } else {
             CDirectory::GetDirectory((const char*)parent_id, items);
-            if(!SortItems(items, sort_criteria))
-              DefaultSortItems(items);
+            DefaultSortItems(items);
         }
 
         if (items.CacheToDiscAlways() || (items.CacheToDiscIfSlow() && (XbmcThreads::SystemClockMillis() - time) > 1000 )) {
             items.Save();
         }
-    }
-    else {
-      // the file list was cached, but this request may use a different
-      // sort_criteria
-      if (SortItems(items, sort_criteria))
-        items.Save();
     }
 
     // Don't pass parent_id if action is Search not BrowseDirectChildren, as


### PR DESCRIPTION
From looking at user's logs on the forums, some devices routinely pass an 'incorrect' sort method in requests. e.g. sort by title requested for Recently Added nodes. Or sort by date for every node. Until we are modifying our behaviour on a client by client basis, it's best to just ignore the requested method and sort using our defaults.
