### PR TITLE
added visible tag for TV show label

### DIFF
--- a/addons/skin.confluence/720p/SkinSettings.xml
+++ b/addons/skin.confluence/720p/SkinSettings.xml
@@ -293,6 +293,7 @@
 						<shadowcolor>black</shadowcolor>
 						<align>left</align>
 						<aligny>center</aligny>
+						<visible>System.HasAddon(script.tvtunes)</visible>
 					</control>
 					<control type="radiobutton" id="115">
 						<width>750</width>


### PR DESCRIPTION
The TVTunes button has
System.HasAddon(script.tvtunes)
as visible condition

The label for TV shows above does not...
If 
!System.HasAddon(script.tvtunes)
then there are two labels underneath ech other...
That way it is more clean...

mad-max
