### PR TITLE
[rbp] Always use the aspect ratio from file.

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -702,11 +702,8 @@ bool OMXPlayerVideo::OpenDecoder()
     CLog::Log(LOGINFO, "OMXPlayerVideo::OpenDecoder : Invalid framerate %d, using forced 25fps and just trust timestamps\n", (int)m_fFrameRate);
     m_fFrameRate = 25;
   }
-  // use aspect in stream if available
-  if (m_hints.forced_aspect)
-    m_fForcedAspectRatio = m_hints.aspect;
-  else
-    m_fForcedAspectRatio = 0.0;
+  // use aspect in stream always
+  m_fForcedAspectRatio = m_hints.aspect;
 
   m_av_clock->Lock();
   m_av_clock->OMXStop(false);


### PR DESCRIPTION
Fixes files that have m_hints.forced_aspect=0, but m_hints.aspect=16.0f/9.0f.
