### PR TITLE
FIX: Allow both prepend and append in advancedsettings "tvshowmatching"

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1066,52 +1066,58 @@ void CAdvancedSettings::Clear()
 
 void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_TVSHOWLIST& settings)
 {
-  int iAction = 0; // overwrite
-  // for backward compatibility
-  const char* szAppend = pRootElement->Attribute("append");
-  if ((szAppend && stricmp(szAppend, "yes") == 0))
-    iAction = 1;
-  // action takes precedence if both attributes exist
-  const char* szAction = pRootElement->Attribute("action");
-  if (szAction)
+  TiXmlElement *pElement = pRootElement;
+  while (pElement)
   {
-    iAction = 0; // overwrite
-    if (stricmp(szAction, "append") == 0)
-      iAction = 1; // append
-    else if (stricmp(szAction, "prepend") == 0)
-      iAction = 2; // prepend
-  }
-  if (iAction == 0)
-    settings.clear();
-  TiXmlNode* pRegExp = pRootElement->FirstChild("regexp");
-  int i = 0;
-  while (pRegExp)
-  {
-    if (pRegExp->FirstChild())
+    int iAction = 0; // overwrite
+    // for backward compatibility
+    const char* szAppend = pElement->Attribute("append");
+    if ((szAppend && stricmp(szAppend, "yes") == 0))
+      iAction = 1;
+    // action takes precedence if both attributes exist
+    const char* szAction = pElement->Attribute("action");
+    if (szAction)
     {
-      bool bByDate = false;
-      int iDefaultSeason = 1;
-      if (pRegExp->ToElement())
-      {
-        CStdString byDate = pRegExp->ToElement()->Attribute("bydate");
-        if(byDate && stricmp(byDate, "true") == 0)
-        {
-          bByDate = true;
-        }
-        CStdString defaultSeason = pRegExp->ToElement()->Attribute("defaultseason");
-        if(!defaultSeason.empty())
-        {
-          iDefaultSeason = atoi(defaultSeason.c_str());
-        }
-      }
-      CStdString regExp = pRegExp->FirstChild()->Value();
-      regExp.MakeLower();
-      if (iAction == 2)
-        settings.insert(settings.begin() + i++, 1, TVShowRegexp(bByDate,regExp,iDefaultSeason));
-      else
-        settings.push_back(TVShowRegexp(bByDate,regExp,iDefaultSeason));
+      iAction = 0; // overwrite
+      if (stricmp(szAction, "append") == 0)
+        iAction = 1; // append
+      else if (stricmp(szAction, "prepend") == 0)
+        iAction = 2; // prepend
     }
-    pRegExp = pRegExp->NextSibling("regexp");
+    if (iAction == 0)
+      settings.clear();
+    TiXmlNode* pRegExp = pElement->FirstChild("regexp");
+    int i = 0;
+    while (pRegExp)
+    {
+      if (pRegExp->FirstChild())
+      {
+        bool bByDate = false;
+        int iDefaultSeason = 1;
+        if (pRegExp->ToElement())
+        {
+          CStdString byDate = pRegExp->ToElement()->Attribute("bydate");
+          if(byDate && stricmp(byDate, "true") == 0)
+          {
+            bByDate = true;
+          }
+          CStdString defaultSeason = pRegExp->ToElement()->Attribute("defaultseason");
+          if(!defaultSeason.empty())
+          {
+            iDefaultSeason = atoi(defaultSeason.c_str());
+          }
+        }
+        CStdString regExp = pRegExp->FirstChild()->Value();
+        regExp.MakeLower();
+        if (iAction == 2)
+          settings.insert(settings.begin() + i++, 1, TVShowRegexp(bByDate,regExp,iDefaultSeason));
+        else
+          settings.push_back(TVShowRegexp(bByDate,regExp,iDefaultSeason));
+      }
+      pRegExp = pRegExp->NextSibling("regexp");
+    }
+
+    pElement = pElement->NextSiblingElement(pRootElement->Value());
   }
 }
 


### PR DESCRIPTION
Not sure whether this actually is a fix, change or feature.

It always seemed logical to me to be able to do both appends and prepends in lists of regexps in advancedsettings, and the wiki is not clear regarding this.

Nowadays, the additional lists are silently dropped.

[EDIT] Definitely a fix, as only "tvshowmatching" has this issue.
