### PR TITLE
Fix filters

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -92,6 +92,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_ARTIST;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_ACTOR, len, true) == 0) {
             mask |= PLT_FILTER_MASK_ACTOR;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_DIRECTOR, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_DIRECTOR;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_AUTHOR, len, true) == 0) {
             mask |= PLT_FILTER_MASK_AUTHOR;       
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_DATE, len, true) == 0) {
@@ -105,6 +107,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_ALBUMARTURI;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_DESCRIPTION, len, true) == 0) {
             mask |= PLT_FILTER_MASK_DESCRIPTION;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_LONGDESCRIPTION, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_LONGDESCRIPTION;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_ORIGINALTRACK, len, true) == 0) {
             mask |= PLT_FILTER_MASK_ORIGINALTRACK;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_SEARCHABLE, len, true) == 0) {
@@ -123,6 +127,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_SERIESTITLE;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_EPISODE, len, true) == 0) {
             mask |= PLT_FILTER_MASK_EPISODE;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RATING, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_RATING;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES, len, true) == 0) {
             mask |= PLT_FILTER_MASK_RES;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES_DURATION, len, true) == 0 ||

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -171,6 +171,7 @@ PLT_MediaObject::Reset()
     m_People.actors.Clear();
     m_People.artists.Clear();    
     m_People.authors.Clear();
+    m_People.directors.Clear();
 
     m_Affiliation.album     = "";
     m_Affiliation.genres.Clear();

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
@@ -202,8 +202,8 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_BrowseDataReference& browse_data,
                                  const char*              object_id, 
                                  NPT_Int32                index, 
                                  NPT_Int32                count,
-                                 const char*              filter, 
                                  bool                     browse_metadata,
+                                 const char*              filter, 
                                  const char*              sort)
 {
     NPT_Result res;
@@ -236,8 +236,7 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_DeviceDataReference&      device,
                                  PLT_MediaObjectListReference& list,
                                  bool                          metadata, /* = false */
                                  NPT_Int32                     start, /* = 0 */
-                                 NPT_Cardinal                  max_results, /* = 0 */
-                                 const char*                   filter)
+                                 NPT_Cardinal                  max_results /* = 0 */)
 {
     NPT_Result res = NPT_FAILURE;
     NPT_Int32  index = start;
@@ -264,7 +263,6 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_DeviceDataReference&      device,
             (const char*)object_id,
             index,
             metadata?1:200, // DLNA recommendations for browsing children is no more than 30 at a time
-            filter,
             metadata);		
         NPT_CHECK_LABEL_WARNING(res, done);
         

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -118,7 +118,7 @@ protected:
                           NPT_Int32                index, 
                           NPT_Int32                count,
                           bool                     browse_metadata = false,
-                          const char*              filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author,searchable,childCount", // explicitely specify res otherwise WMP won't return a URL!
+                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,searchable,childCount", // explicitely specify res otherwise WMP won't return a URL!
                           const char*              sort = "");
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -106,8 +106,7 @@ public:
                           PLT_MediaObjectListReference& list,
                           bool                          metadata = false,
                           NPT_Int32                     start = 0,
-                          NPT_Cardinal                  max_results = 0,
-                          const char*                   filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author,searchable,childCount"); // explicitely specify res otherwise WMP won't return a URL!
+                          NPT_Cardinal                  max_results = 0); // 0 means all
 
     const NPT_Lock<PLT_DeviceMap>& GetMediaServersMap() const { return m_MediaServers; }
     bool IsCached(const char* uuid, const char* object_id);
@@ -118,8 +117,8 @@ protected:
                           const char*              object_id,
                           NPT_Int32                index, 
                           NPT_Int32                count,
-                          const char*              filter,
                           bool                     browse_metadata = false,
+                          const char*              filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author,searchable,childCount", // explicitely specify res otherwise WMP won't return a URL!
                           const char*              sort = "");
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -355,15 +355,10 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
         }
 #endif
 
-
-        // Browse and wait for result
-        PLT_MediaObjectListReference list;
-        NPT_Result res;
-        // we want all properties, so send empty filter
-        res = upnp->m_MediaBrowser->BrowseSync(device, object_id, list, false, 0, 0, "");
-
         // if error, return now, the device could have gone away
         // this will make us go back to the sources list
+        PLT_MediaObjectListReference list;
+        NPT_Result res = upnp->m_MediaBrowser->BrowseSync(device, object_id, list);
         if (NPT_FAILED(res)) goto failure;
 
         // empty list is ok


### PR DESCRIPTION
A few weeks ago I changed our requests to servers to request all properties (filtering by "*"), this was to make sure XBMC <-> XBMC transfers included all the metadata we needed.

this however will break browsing some servers such as WMP.

The proper fix is here, I didn't do this originally as I hadn't noticed the missing lines in PltDidl.cpp

Hopefully this can go in as a fix
