### PR TITLE
FindNextFile returns error in Linux on bad symlink causing short Dir read

### DIFF
--- a/xbmc/linux/XFileUtils.cpp
+++ b/xbmc/linux/XFileUtils.cpp
@@ -141,46 +141,46 @@ BOOL   FindNextFile(HANDLE hHandle, LPWIN32_FIND_DATA lpFindData)
 
   while ((unsigned int) hHandle->m_nFindFileIterator < hHandle->m_FindFileResults.size())
   {
-  CStdString strFileName = hHandle->m_FindFileResults[hHandle->m_nFindFileIterator++];
-  CStdString strFileNameTest = hHandle->m_FindFileDir + strFileName;
+    CStdString strFileName = hHandle->m_FindFileResults[hHandle->m_nFindFileIterator++];
+    CStdString strFileNameTest = hHandle->m_FindFileDir + strFileName;
 
-  if (IsAliasShortcut(strFileNameTest))
-    TranslateAliasShortcut(strFileNameTest);
+    if (IsAliasShortcut(strFileNameTest))
+      TranslateAliasShortcut(strFileNameTest);
 
-  struct stat64 fileStat;
-  memset(&fileStat, 0, sizeof(fileStat));
+    struct stat64 fileStat;
+    memset(&fileStat, 0, sizeof(fileStat));
 
-  if (stat64(strFileNameTest, &fileStat) == -1)
-    continue;
+    if (stat64(strFileNameTest, &fileStat) == -1)
+      continue;
 
-  bool bIsDir = false;
-  if (S_ISDIR(fileStat.st_mode))
-  {
-    bIsDir = true;
-  }
+    bool bIsDir = false;
+    if (S_ISDIR(fileStat.st_mode))
+    {
+      bIsDir = true;
+    }
 
-  memset(lpFindData,0,sizeof(WIN32_FIND_DATA));
+    memset(lpFindData,0,sizeof(WIN32_FIND_DATA));
 
-  lpFindData->dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
-  strcpy(lpFindData->cFileName, strFileName.c_str());
+    lpFindData->dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
+    strcpy(lpFindData->cFileName, strFileName.c_str());
 
-  if (bIsDir)
-    lpFindData->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
+    if (bIsDir)
+      lpFindData->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
 
-  if (strFileName[0] == '.')
-    lpFindData->dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;
+    if (strFileName[0] == '.')
+      lpFindData->dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;
 
-  if (access(strFileName, R_OK) == 0 && access(strFileName, W_OK) != 0)
-    lpFindData->dwFileAttributes |= FILE_ATTRIBUTE_READONLY;
+    if (access(strFileName, R_OK) == 0 && access(strFileName, W_OK) != 0)
+      lpFindData->dwFileAttributes |= FILE_ATTRIBUTE_READONLY;
 
-  TimeTToFileTime(fileStat.st_ctime, &lpFindData->ftCreationTime);
-  TimeTToFileTime(fileStat.st_atime, &lpFindData->ftLastAccessTime);
-  TimeTToFileTime(fileStat.st_mtime, &lpFindData->ftLastWriteTime);
+    TimeTToFileTime(fileStat.st_ctime, &lpFindData->ftCreationTime);
+    TimeTToFileTime(fileStat.st_atime, &lpFindData->ftLastAccessTime);
+    TimeTToFileTime(fileStat.st_mtime, &lpFindData->ftLastWriteTime);
 
-  lpFindData->nFileSizeHigh = (DWORD)(fileStat.st_size >> 32);
-  lpFindData->nFileSizeLow =  (DWORD)fileStat.st_size;
+    lpFindData->nFileSizeHigh = (DWORD)(fileStat.st_size >> 32);
+    lpFindData->nFileSizeLow =  (DWORD)fileStat.st_size;
 
-  return TRUE;
+    return TRUE;
   }
   return FALSE;
 }


### PR DESCRIPTION
In the linux implementation of  FindNextFile in linux/XFileUtils.cpp, FindNextFile will fail (return error) if the "next" file is a broken symbolic link. this has the (unintended I'm sure) effect of cutting directories entries short. If the first entry in directory is a broken symbolic link then FindFirstFile returns a handle, gives no indication of a problem and returns a partially populated LPWIN32_FIND_DATA structure.

Not being a Windows programmer and the documentation is not clear on what windows will do in this situation, someone need to check on it. If Windows has the same problem then this fix should probably be abandoned and a wrapper around FindNextFile and FindFirstFile created to do the same thing (but for all implementations presumably)

Note: this will also occur on insufficient permissions getting to a target of a symlink
