### PR TITLE
removed bAsync param from Observable::NotifyObservers()

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3877,7 +3877,7 @@ void CGUIInfoManager::SetCurrentItem(CFileItem &item)
     SetCurrentMovie(item);
 
   SetChanged();
-  NotifyObservers(ObservableMessageCurrentItem, true);
+  NotifyObservers(ObservableMessageCurrentItem);
 }
 
 void CGUIInfoManager::SetCurrentAlbumThumb(const CStdString thumbFileName)

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -113,7 +113,7 @@ void CEpgContainer::Clear(bool bClearDb /* = false */)
   }
 
   SetChanged();
-  NotifyObservers(ObservableMessageEpgContainer, true);
+  NotifyObservers(ObservableMessageEpgContainer);
 
   if (bThreadRunning)
     Start();
@@ -517,7 +517,7 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   if (iUpdatedTables > 0)
   {
     SetChanged();
-    NotifyObservers(ObservableMessageEpgContainer, true);
+    NotifyObservers(ObservableMessageEpgContainer);
   }
 
   CSingleLock lock(m_critSection);
@@ -610,7 +610,7 @@ bool CEpgContainer::CheckPlayingEvents(void)
     if (bFoundChanges)
     {
       SetChanged();
-      NotifyObservers(ObservableMessageEpgActiveItem, true);
+      NotifyObservers(ObservableMessageEpgActiveItem);
     }
 
     /* pvr tags always start on the full minute */

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -251,7 +251,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers)
     SetChanged();
     lock.Leave();
 
-    NotifyObservers(bAddedOrDeleted ? ObservableMessageTimersReset : ObservableMessageTimers, false);
+    NotifyObservers(bAddedOrDeleted ? ObservableMessageTimersReset : ObservableMessageTimers);
 
     if (g_guiSettings.GetBool("pvrrecord.timernotifications"))
     {

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1024,7 +1024,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
   }
 
   g_guiSettings.SetChanged();
-  g_guiSettings.NotifyObservers(ObservableMessageGuiSettings, true);
+  g_guiSettings.NotifyObservers(ObservableMessageGuiSettings);
 }
 
 void CGUIWindowSettingsCategory::OnClick(CBaseSettingControl *pSettingControl)

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -21,7 +21,6 @@
  */
 
 #include "threads/CriticalSection.h"
-#include "interfaces/AnnouncementManager.h"
 
 class Observable;
 class ObservableMessageJob;
@@ -86,7 +85,7 @@ protected:
   CCriticalSection          m_obsCritSection;  /*!< mutex */
 };
 
-class Observable : public ANNOUNCEMENT::IAnnouncer
+class Observable
 {
   friend class ObservableMessageJob;
 
@@ -115,9 +114,8 @@ public:
   /*!
    * @brief Send a message to all observers when m_bObservableChanged is true.
    * @param message The message to send.
-   * @param bAsync True to send the message async, using the jobmanager.
    */
-  virtual void NotifyObservers(const ObservableMessage message = ObservableMessageNone, bool bAsync = false);
+  virtual void NotifyObservers(const ObservableMessage message = ObservableMessageNone);
 
   /*!
    * @brief Mark an observable changed.
@@ -132,8 +130,6 @@ public:
    */
   virtual bool IsObserving(const Observer &obs) const;
 
-  virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
-
 protected:
   /*!
    * @brief Send a message to all observer when m_bObservableChanged is true.
@@ -145,5 +141,4 @@ protected:
   bool                    m_bObservableChanged; /*!< true when the observable is marked as changed, false otherwise */
   std::vector<Observer *> m_observers;          /*!< all observers */
   CCriticalSection        m_obsCritSection;     /*!< mutex */
-  bool                    m_bAsyncAllowed;      /*!< true when async messages are allowed, false otherwise */
 };


### PR DESCRIPTION
the announcementmanager hack that disables this when xbmc shuts down (so it doesn't try to use deleted stuff) could lead to deadlocks if an observable is created by something in Announce(), and it should be done properly if and when we need this instead
