### PR TITLE
Fix CCurlFile::Get()

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -732,18 +732,20 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
 
 bool CCurlFile::Post(const CStdString& strURL, const CStdString& strPostData, CStdString& strHTML)
 {
-  return Service(strURL, strPostData, strHTML);
+  m_postdata = strPostData;
+  m_postdataset = true;
+  return Service(strURL, strHTML);
 }
 
 bool CCurlFile::Get(const CStdString& strURL, CStdString& strHTML)
 {
-  return Service(strURL, "", strHTML);
+  m_postdata = "";
+  m_postdataset = false;
+  return Service(strURL, strHTML);
 }
 
-bool CCurlFile::Service(const CStdString& strURL, const CStdString& strPostData, CStdString& strHTML)
+bool CCurlFile::Service(const CStdString& strURL, CStdString& strHTML)
 {
-  m_postdata = strPostData;
-  m_postdataset = true;
   if (Open(strURL))
   {
     if (ReadData(strHTML))

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -123,7 +123,7 @@ namespace XFILE
       void SetCommonOptions(CReadState* state);
       void SetRequestHeaders(CReadState* state);
       void SetCorrectHeaders(CReadState* state);
-      bool Service(const CStdString& strURL, const CStdString& strPostData, CStdString& strHTML);
+      bool Service(const CStdString& strURL, CStdString& strHTML);
 
     protected:
       CReadState*     m_state;


### PR DESCRIPTION
This fixes CCurlFile::Get() by moving the explicit initialisation of the request pre-conditions (used by CCurlFile::Open()) to CCurlFile::Post() resp. CCurlFile::Get()

See issues with PR #1650.
