### PR TITLE
Make sure TXT records are in same order as setup on mdns announce

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1514,7 +1514,7 @@ bool CApplication::StartWebServer()
     bool started = false;
     if (m_WebServer.Start(webPort, g_guiSettings.GetString("services.webserverusername"), g_guiSettings.GetString("services.webserverpassword")))
     {
-      std::map<std::string, std::string> txt;
+      std::vector<std::pair<std::string, std::string> > txt;
       started = true;
       // publish web frontend and API services
 #ifdef HAS_WEB_INTERFACE
@@ -1564,19 +1564,19 @@ bool CApplication::StartAirplayServer()
     if (CAirPlayServer::StartServer(listenPort, true))
     {
       CAirPlayServer::SetCredentials(usePassword, password);
-      std::map<std::string, std::string> txt;
+      std::vector<std::pair<std::string, std::string> > txt;
       CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
       if (iface)
       {
-        txt["deviceid"] = iface->GetMacAddress();
+        txt.push_back(std::make_pair("deviceid", iface->GetMacAddress()));
       }
       else
       {
-        txt["deviceid"] = "FF:FF:FF:FF:FF:F2";
+        txt.push_back(std::make_pair("deviceid", "FF:FF:FF:FF:FF:F2"));
       }
-      txt["features"] = "0x77";
-      txt["model"] = "AppleTV2,1";
-      txt["srcvers"] = AIRPLAY_SERVER_VERSION_STR;
+      txt.push_back(std::make_pair("features", "0x77"));
+      txt.push_back(std::make_pair("model", "AppleTV2,1"));
+      txt.push_back(std::make_pair("srcvers", AIRPLAY_SERVER_VERSION_STR));
       CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME), listenPort, txt);
       ret = true;
     }
@@ -1620,7 +1620,7 @@ bool CApplication::StartJSONRPCServer()
   {
     if (CTCPServer::StartServer(g_advancedSettings.m_jsonTcpPort, g_guiSettings.GetBool("services.esallinterfaces")))
     {
-      std::map<std::string, std::string> txt;
+      std::vector<std::pair<std::string, std::string> > txt;
       CZeroconf::GetInstance()->PublishService("servers.jsonrpc-tpc", "_xbmc-jsonrpc._tcp", g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME), g_advancedSettings.m_jsonTcpPort, txt);
       return true;
     }

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -503,22 +503,22 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
     CStdString appName;
     appName.Format("%s@%s", m_macAddress.c_str(), g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME).c_str());
 
-    std::map<std::string, std::string> txt;
-    txt["cn"] = "0,1";
-    txt["ch"] = "2";
-    txt["ek"] = "1";
-    txt["et"] = "0,1";
-    txt["sv"] = "false";
-    txt["tp"] = "UDP";
-    txt["sm"] = "false";
-    txt["ss"] = "16";
-    txt["sr"] = "44100";
-    txt["pw"] = "false";
-    txt["vn"] = "3";
-    txt["da"] = "true";
-    txt["vs"] = "130.14";
-    txt["md"] = "0,1,2";
-    txt["txtvers"] = "1";
+    std::vector<std::pair<std::string, std::string> > txt;
+    txt.push_back(std::make_pair("txtvers",  "1"));
+    txt.push_back(std::make_pair("cn", "0,1"));
+    txt.push_back(std::make_pair("ch", "2"));
+    txt.push_back(std::make_pair("ek", "1"));
+    txt.push_back(std::make_pair("et", "0,1"));
+    txt.push_back(std::make_pair("sv", "false"));
+    txt.push_back(std::make_pair("tp",  "UDP"));
+    txt.push_back(std::make_pair("sm",  "false"));
+    txt.push_back(std::make_pair("ss",  "16"));
+    txt.push_back(std::make_pair("sr",  "44100"));
+    txt.push_back(std::make_pair("pw",  "false"));
+    txt.push_back(std::make_pair("vn",  "3"));
+    txt.push_back(std::make_pair("da",  "true"));
+    txt.push_back(std::make_pair("vs",  "130.14"));
+    txt.push_back(std::make_pair("md",  "0,1,2"));
 
     CZeroconf::GetInstance()->PublishService("servers.airtunes", "_raop._tcp", appName, port, txt);
   }

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -155,7 +155,7 @@ void CEventServer::Run()
   CAddress any_addr;
   CSocketListener listener;
   int packetSize = 0;
-  std::map<std::string, std::string> txt;  
+  std::vector<std::pair<std::string, std::string> > txt;
 
   CLog::Log(LOGNOTICE, "ES: Starting UDP Event server on %s:%d", any_addr.Address(), m_iPort);
 

--- a/xbmc/network/Zeroconf.cpp
+++ b/xbmc/network/Zeroconf.cpp
@@ -43,7 +43,7 @@
 //should be optimized away
 class CZeroconfDummy : public CZeroconf
 {
-  virtual bool doPublishService(const std::string&, const std::string&, const std::string&, unsigned int, std::map<std::string, std::string>)
+  virtual bool doPublishService(const std::string&, const std::string&, const std::string&, unsigned int, const std::vector<std::pair<std::string, std::string> >&)
   {
     return false;
   }
@@ -68,7 +68,7 @@ bool CZeroconf::PublishService(const std::string& fcr_identifier,
                                const std::string& fcr_type,
                                const std::string& fcr_name,
                                unsigned int f_port,
-                               std::map<std::string, std::string> txt)
+                               const std::vector<std::pair<std::string, std::string> >& txt)
 {
   CSingleLock lock(*mp_crit_sec);
   CZeroconf::PublishInfo info = {fcr_type, fcr_name, f_port, txt};

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <map>
+#include <vector>
 #include "utils/Job.h"
 
 class CCriticalSection;
@@ -49,7 +50,7 @@ public:
                       const std::string& fcr_type,
                       const std::string& fcr_name,
                       unsigned int f_port,
-                      std::map<std::string, std::string> txt);
+                      const std::vector<std::pair<std::string, std::string> >& txt);
 
   ///removes the specified service
   ///returns false if fcr_identifier does not exist
@@ -86,7 +87,7 @@ protected:
                                 const std::string& fcr_type,
                                 const std::string& fcr_name,
                                 unsigned int f_port,
-                                std::map<std::string, std::string> txt) = 0;
+                                const std::vector<std::pair<std::string, std::string> >& txt) = 0;
   //removes the service if published
   virtual bool doRemoveService(const std::string& fcr_ident) = 0;
 
@@ -107,7 +108,7 @@ private:
     std::string type;
     std::string name;
     unsigned int port;
-    std::map<std::string, std::string> txt;
+    std::vector<std::pair<std::string, std::string> > txt;
   };
 
   //protects data

--- a/xbmc/network/linux/ZeroconfAvahi.cpp
+++ b/xbmc/network/linux/ZeroconfAvahi.cpp
@@ -131,7 +131,7 @@ bool CZeroconfAvahi::doPublishService(const std::string& fcr_identifier,
                               const std::string& fcr_type,
                               const std::string& fcr_name,
                               unsigned int f_port,
-                              std::map<std::string, std::string> txt)
+                              const std::vector<std::pair<std::string, std::string> >&  txt)
 {
   CLog::Log(LOGDEBUG, "CZeroconfAvahi::doPublishService identifier: %s type: %s name:%s port:%i", fcr_identifier.c_str(), fcr_type.c_str(), fcr_name.c_str(), f_port);
 
@@ -145,7 +145,7 @@ bool CZeroconfAvahi::doPublishService(const std::string& fcr_identifier,
 
   //txt records to AvahiStringList
   AvahiStringList *txtList = NULL;
-  for(std::map<std::string, std::string>::iterator it=txt.begin(); it!=txt.end(); it++)
+  for(std::vector<std::pair<std::string, std::string> >::const_iterator it=txt.begin(); it!=txt.end(); it++)
   {
     txtList = avahi_string_list_add_pair(txtList, it->first.c_str(), it->second.c_str());
   }

--- a/xbmc/network/linux/ZeroconfAvahi.h
+++ b/xbmc/network/linux/ZeroconfAvahi.h
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <map>
+#include <vector>
 #include <string>
 #include "network/Zeroconf.h"
 
@@ -47,7 +48,7 @@ protected:
                                 const std::string& fcr_type,
                                 const std::string& fcr_name,
                                 unsigned int f_port,
-                                std::map<std::string, std::string> txt);
+                                const std::vector<std::pair<std::string, std::string> >& txt);
 
   virtual bool doRemoveService(const std::string& fcr_ident);
 

--- a/xbmc/network/osx/ZeroconfOSX.cpp
+++ b/xbmc/network/osx/ZeroconfOSX.cpp
@@ -44,7 +44,7 @@ bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
                       const std::string& fcr_type,
                       const std::string& fcr_name,
                       unsigned int f_port,
-                      std::map<std::string, std::string> txt)
+                      const std::vector<std::pair<std::string, std::string> >& txt)
 {
   CLog::Log(LOGDEBUG, "CZeroconfOSX::doPublishService identifier: %s type: %s name:%s port:%i", fcr_identifier.c_str(),
             fcr_type.c_str(), fcr_name.c_str(), f_port);
@@ -74,7 +74,7 @@ bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
     //txt map to dictionary
     CFDataRef txtData = NULL;
     CFMutableDictionaryRef txtDict = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-    for(std::map<std::string, std::string>::const_iterator it = txt.begin(); it != txt.end(); ++it)
+    for(std::vector<std::pair<std::string, std::string> >::const_iterator it = txt.begin(); it != txt.end(); ++it)
     {
       CFStringRef key = CFStringCreateWithCString (NULL,
                                                    it->first.c_str(),

--- a/xbmc/network/osx/ZeroconfOSX.cpp
+++ b/xbmc/network/osx/ZeroconfOSX.cpp
@@ -38,6 +38,11 @@ CZeroconfOSX::~CZeroconfOSX()
   doStop();
 }
 
+CFHashCode CFHashNullVersion (CFTypeRef cf)
+{
+  return 0;
+}
+
 
 //methods to implement for concrete implementations
 bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
@@ -71,9 +76,13 @@ bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
   //add txt records
   if(!txt.empty())
   {
+
+    CFDictionaryKeyCallBacks key_cb = kCFTypeDictionaryKeyCallBacks;
+    key_cb.hash = CFHashNullVersion;
+
     //txt map to dictionary
     CFDataRef txtData = NULL;
-    CFMutableDictionaryRef txtDict = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFMutableDictionaryRef txtDict = CFDictionaryCreateMutable(NULL, 0, &key_cb, &kCFTypeDictionaryValueCallBacks);
     for(std::vector<std::pair<std::string, std::string> >::const_iterator it = txt.begin(); it != txt.end(); ++it)
     {
       CFStringRef key = CFStringCreateWithCString (NULL,

--- a/xbmc/network/osx/ZeroconfOSX.h
+++ b/xbmc/network/osx/ZeroconfOSX.h
@@ -20,6 +20,7 @@
  */
 
 #include <memory>
+#include <vector>
 
 #include "network/Zeroconf.h"
 #include "threads/CriticalSection.h"
@@ -42,7 +43,7 @@ protected:
                         const std::string& fcr_type,
                         const std::string& fcr_name,
                         unsigned int f_port,
-                        std::map<std::string, std::string> txt);
+                        const std::vector<std::pair<std::string, std::string> >& txt);
 
   bool doRemoveService(const std::string& fcr_ident);
 

--- a/xbmc/network/windows/ZeroconfWIN.cpp
+++ b/xbmc/network/windows/ZeroconfWIN.cpp
@@ -62,7 +62,7 @@ bool CZeroconfWIN::doPublishService(const std::string& fcr_identifier,
                       const std::string& fcr_type,
                       const std::string& fcr_name,
                       unsigned int f_port,
-                      std::map<std::string, std::string> txt)
+                      const std::vector<std::pair<std::string, std::string> >& txt)
 {
   DNSServiceRef netService = NULL;
   TXTRecordRef txtRecord;
@@ -87,7 +87,7 @@ bool CZeroconfWIN::doPublishService(const std::string& fcr_identifier,
   //add txt records
   if(!txt.empty())
   {
-    for(std::map<std::string, std::string>::const_iterator it = txt.begin(); it != txt.end(); ++it)
+    for(std::vector<std::pair<std::string, std::string> >::const_iterator it = txt.begin(); it != txt.end(); ++it)
     {
       CLog::Log(LOGDEBUG, "ZeroconfWIN: key:%s, value:%s",it->first.c_str(),it->second.c_str());
       uint8_t txtLen = (uint8_t)strlen(it->second.c_str());

--- a/xbmc/network/windows/ZeroconfWIN.h
+++ b/xbmc/network/windows/ZeroconfWIN.h
@@ -36,7 +36,7 @@ protected:
                         const std::string& fcr_type,
                         const std::string& fcr_name,
                         unsigned int f_port,
-                        std::map<std::string, std::string> txt);
+                        const std::vector<std::pair<std::string, std::string> >& txt);
 
   bool doRemoveService(const std::string& fcr_ident);
 


### PR DESCRIPTION
The txtvers record in TXT records is often required to be the first record. So allow this in our API.
