### PR TITLE
Pvr channel moving

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -287,7 +287,7 @@ bool CDatabase::QueueInsertQuery(const CStdString &strQuery)
 
 bool CDatabase::CommitInsertQueries()
 {
-  bool bReturn = false;
+  bool bReturn = true;
 
   if (m_bMultiWrite)
   {
@@ -296,10 +296,10 @@ bool CDatabase::CommitInsertQueries()
       m_bMultiWrite = false;
       m_pDS2->post();
       m_pDS2->clear_insert_sql();
-      bReturn = true;
     }
     catch(...)
     {
+      bReturn = false;
       CLog::Log(LOGERROR, "%s - failed to execute queries",
           __FUNCTION__);
     }

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -763,7 +763,10 @@ bool CPVRDatabase::PersistChannels(CPVRChannelGroup &group)
       bReturn &= Persist(*member.channel, m_sqlite || !member.channel->IsNew());
     }
   }
-  return CommitInsertQueries();
+
+  bReturn &= CommitInsertQueries();
+
+  return bReturn;
 }
 
 bool CPVRDatabase::PersistGroupMembers(CPVRChannelGroup &group)

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -182,6 +182,9 @@ bool CPVRChannelGroup::MoveChannel(unsigned int iOldChannelNumber, unsigned int 
   bool bReturn(false);
   CSingleLock lock(m_critSection);
 
+  /* make sure the list is sorted by channel number */
+  SortByChannelNumber();
+
   /* old channel number out of range */
   if (iOldChannelNumber > m_members.size())
     return bReturn;
@@ -196,7 +199,7 @@ bool CPVRChannelGroup::MoveChannel(unsigned int iOldChannelNumber, unsigned int 
   m_members.insert(m_members.begin() + iNewChannelNumber - 1, entry);
 
   /* renumber the list */
-  SortAndRenumber();
+  Renumber();
 
   m_bChanged = true;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -190,6 +190,9 @@ bool CPVRChannelGroup::MoveChannel(unsigned int iOldChannelNumber, unsigned int 
     return bReturn;
 
   /* new channel number out of range */
+  if (iNewChannelNumber < 1)
+    return bReturn;
+
   if (iNewChannelNumber > m_members.size())
     iNewChannelNumber = m_members.size();
 


### PR DESCRIPTION
The first commit fixes persisting of channel group members if there is no need to persist channels (e.g. when moving channels). Without this CommitInsertQueries() would return false and PersistGroupMembers() would not even be called.

The second commit reverts the changes of f679b31 inside CPVRChannelGroup::MoveChannel()... I am open to suggestions here if you want a different solution.
