### PR TITLE
FIX: python screensavers by passing action

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2394,6 +2394,9 @@ bool CApplication::OnKey(const CKey& key)
   // allow some keys to be processed while the screensaver is active
   if (WakeUpScreenSaverAndDPMS(processKey) && !processKey)
   {
+    // pass action to python screensaver window if present
+    if (iWin == WINDOW_SCREENSAVER)
+      OnAction(action);
     CLog::Log(LOGDEBUG, "%s: %s pressed, screen saver/dpms woken up", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str());
     return true;
   }


### PR DESCRIPTION
This PR should fix python script screensavers hanging and not reacting to onScreensaverDeactivated events until they are killed by XBMC.

I don't know if this is the right way to solve this, so please chime in, if you know a better solution.

Now to detail the problem:
Python script screensavers are implemented as WindowXMLDialogs. For a basic addon zip see the PR #1072 by dersphere.

On running this test script as screensaver and pressing a single key or doing only a slight mouse move I get the above mentionend behaviour.
Debug Log:

```
...
18:43:21 T:4608   DEBUG: CApplication::OnKey: down (f081) pressed, screen saver/dpms woken up
18:43:26 T:4608    INFO: Stopping script with id: 1
18:43:31 T:4608   ERROR: XBPyThread::stop - script didn't stop in 5 seconds - let's kill it
18:43:31 T:5408  NOTICE: 3 ExitMonitor: onScreensaverDeactivated sending exit_callback
18:43:31 T:5408  NOTICE: 4 Screensaver: Exit requested
18:43:31 T:4608   DEBUG: ------ Window Deinit (C:\Users\Michael\AppData\Roaming\XBMC\addons\script.screensaver.test\resources\skins\default\720p\script-Python Screensaver TEST-main.xml) ------
18:43:31 T:5408  NOTICE: 5 Python Screensaver Exited
18:43:31 T:5408    INFO: Scriptresult: Success
...
```

Doing two fast key presses or mouse moves gives this:

```
...
18:49:05 T:4608   DEBUG: CApplication::OnKey: space (f020) pressed, screen saver/dpms woken up
18:49:06 T:4608   DEBUG: Keyboard: scancode: 39, sym: 0020, unicode: 0020, modifier: 0
18:49:06 T:4608   DEBUG: CApplication::OnKey: space (f020) pressed, action is Pause
18:49:06 T:1688  NOTICE: 3 ExitMonitor: onScreensaverDeactivated sending exit_callback
18:49:06 T:1688  NOTICE: 4 Screensaver: Exit requested
...
```

The onScreensaverDeactivated is triggered immediately. No need for XBMC to kill the script.

I found this is related to this code in XBMCs onKey handler:

```
// allow some keys to be processed while the screensaver is active
if (WakeUpScreenSaverAndDPMS(processKey) && !processKey)
{
  CLog::Log(LOGDEBUG, "%s: %s pressed, screen saver/dpms woken up", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str());
  return true;
}
```

The return true prevents the onAction handler to be called. And this seems to make the script hang.

Uncommenting it solves the problem but breaks internal screensavers, as they would pass all keys to xbmc. So pressing space to wake the screensaver would also unpause a video.

I found that calling the onAction if a screensaver window is present solves both problems (see my code within the PR).

Debug Log afterwards will look like this:

```
...
19:10:42 T:704   DEBUG: CApplication::OnKey: down (f081) pressed, screen saver/dpms woken up
19:10:42 T:1248  NOTICE: 3 ExitMonitor: onScreensaverDeactivated sending exit_callback
19:10:42 T:1248  NOTICE: 4 Screensaver: Exit requested
19:10:42 T:704   DEBUG: ------ Window Deinit (C:\Users\Michael\AppData\Roaming\XBMC\addons\script.screensaver.test\resources\skins\default\720p\script-Python Screensaver TEST-main.xml) ------
19:10:42 T:1248  NOTICE: 5 Python Screensaver Exited
19:10:42 T:1248    INFO: Scriptresult: Success
19:10:42 T:1248    INFO: Python script stopped
...
```

I have the feeling there are two screensaver windows open. A XBMC one and the one supplied by a script that hinder each other. Again I ask for help. If you know a better solution for this problem please tell me and/or contribute the
code to fix it.
