### PR TITLE
[pvr] cleanup some actions/functions that the base classes take care of

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -144,7 +144,7 @@
       <t mod="ctrl">ActivateWindowAndFocus(MyPVR, 32,0, 11,0)</t>  <!-- MCE Live TV  -->
       <t mod="ctrl,shift">ActivateWindow(MyPVR)</t>                <!-- MCE My TV -->
       <a mod="ctrl">ActivateWindowAndFocus(MyPVR, 33,0, 12,0)</a>  <!-- MCE My Radio -->
-      <!-- MCE keypresses without an obvious use in XBMC --->
+      <!-- MCE keypresses without an obvious use in XBMC -->
       <u mod="ctrl">Notification(MCEKeypress, DVD subtitle, 3)</u>
       <a mod="ctrl,shift">Notification(MCEKeypress, DVD audio, 3)</a>
     </keyboard>

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
@@ -49,12 +49,7 @@ CGUIDialogPeripheralManager::~CGUIDialogPeripheralManager(void)
 bool CGUIDialogPeripheralManager::OnAction(const CAction &action)
 {
   int iActionId = action.GetID();
-  if (iActionId == ACTION_PREVIOUS_MENU || iActionId == ACTION_PARENT_DIR)
-  {
-    Close();
-    return true;
-  }
-  else if (GetFocusedControlID() == CONTROL_LIST &&
+  if (GetFocusedControlID() == CONTROL_LIST &&
       (iActionId == ACTION_MOVE_DOWN || iActionId == ACTION_MOVE_UP ||
        iActionId == ACTION_PAGE_DOWN || iActionId == ACTION_PAGE_UP))
   {

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -72,19 +72,6 @@ CGUIDialogPVRChannelManager::~CGUIDialogPVRChannelManager(void)
   delete m_channelItems;
 }
 
-bool CGUIDialogPVRChannelManager::OnActionClose(const CAction &action)
-{
-  bool bReturn(false);
-  int iActionId = action.GetID();
-  if (iActionId == ACTION_PREVIOUS_MENU || iActionId == ACTION_PARENT_DIR)
-  {
-    Close();
-    bReturn = true;
-  }
-
-  return bReturn;
-}
-
 bool CGUIDialogPVRChannelManager::OnActionMove(const CAction &action)
 {
   bool bReturn(false);
@@ -142,9 +129,8 @@ bool CGUIDialogPVRChannelManager::OnActionMove(const CAction &action)
 
 bool CGUIDialogPVRChannelManager::OnAction(const CAction& action)
 {
-  return OnActionClose(action) ||
-      OnActionMove(action) ||
-      CGUIDialog::OnAction(action);
+  return OnActionMove(action) ||
+         CGUIDialog::OnAction(action);
 }
 
 bool CGUIDialogPVRChannelManager::OnMessageInit(CGUIMessage &message)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -42,7 +42,6 @@ namespace PVR
     virtual bool OnPopupMenu(int iItem);
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
 
-    virtual bool OnActionClose(const CAction &action);
     virtual bool OnActionMove(const CAction &action);
 
     virtual bool OnMessageInit(CGUIMessage &message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.cpp
@@ -34,17 +34,6 @@ CGUIDialogPVRCutterOSD::~CGUIDialogPVRCutterOSD()
 {
 }
 
-bool CGUIDialogPVRCutterOSD::OnAction(const CAction& action)
-{
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_PARENT_DIR)
-  {
-    Close();
-    return true;
-  }
-
-  return CGUIDialog::OnAction(action);
-}
-
 bool CGUIDialogPVRCutterOSD::OnMessage(CGUIMessage& message)
 {
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.cpp
@@ -33,18 +33,3 @@ CGUIDialogPVRCutterOSD::CGUIDialogPVRCutterOSD()
 CGUIDialogPVRCutterOSD::~CGUIDialogPVRCutterOSD()
 {
 }
-
-bool CGUIDialogPVRCutterOSD::OnMessage(CGUIMessage& message)
-{
-  return CGUIDialog::OnMessage(message);
-}
-
-void CGUIDialogPVRCutterOSD::OnInitWindow()
-{
-  CGUIDialog::OnInitWindow();
-}
-
-void CGUIDialogPVRCutterOSD::OnDeinitWindow(int nextWindowID)
-{
-  CGUIDialog::OnDeinitWindow(nextWindowID);
-}

--- a/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.h
@@ -28,8 +28,5 @@ namespace PVR
   public:
     CGUIDialogPVRCutterOSD(void);
     virtual ~CGUIDialogPVRCutterOSD(void);
-    virtual bool OnMessage(CGUIMessage& message);
-    virtual void OnInitWindow();
-    virtual void OnDeinitWindow(int nextWindowID);
   };
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRCutterOSD.h
@@ -29,7 +29,6 @@ namespace PVR
     CGUIDialogPVRCutterOSD(void);
     virtual ~CGUIDialogPVRCutterOSD(void);
     virtual bool OnMessage(CGUIMessage& message);
-    virtual bool OnAction(const CAction& action);
     virtual void OnInitWindow();
     virtual void OnDeinitWindow(int nextWindowID);
   };

--- a/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.cpp
@@ -39,18 +39,3 @@ CGUIDialogPVRDirectorOSD::CGUIDialogPVRDirectorOSD()
 CGUIDialogPVRDirectorOSD::~CGUIDialogPVRDirectorOSD()
 {
 }
-
-bool CGUIDialogPVRDirectorOSD::OnMessage(CGUIMessage& message)
-{
-  return CGUIDialog::OnMessage(message);
-}
-
-void CGUIDialogPVRDirectorOSD::OnInitWindow()
-{
-  CGUIDialog::OnInitWindow();
-}
-
-void CGUIDialogPVRDirectorOSD::OnDeinitWindow(int nextWindowID)
-{
-  CGUIDialog::OnDeinitWindow(nextWindowID);
-}

--- a/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.cpp
@@ -40,17 +40,6 @@ CGUIDialogPVRDirectorOSD::~CGUIDialogPVRDirectorOSD()
 {
 }
 
-bool CGUIDialogPVRDirectorOSD::OnAction(const CAction& action)
-{
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_PARENT_DIR)
-  {
-    Close();
-    return true;
-  }
-
-  return CGUIDialog::OnAction(action);
-}
-
 bool CGUIDialogPVRDirectorOSD::OnMessage(CGUIMessage& message)
 {
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.h
@@ -29,7 +29,6 @@ namespace PVR
     CGUIDialogPVRDirectorOSD(void);
     virtual ~CGUIDialogPVRDirectorOSD(void);
     virtual bool OnMessage(CGUIMessage& message);
-    virtual bool OnAction(const CAction& action);
     virtual void OnInitWindow();
     virtual void OnDeinitWindow(int nextWindowID);
   };

--- a/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRDirectorOSD.h
@@ -28,8 +28,5 @@ namespace PVR
   public:
     CGUIDialogPVRDirectorOSD(void);
     virtual ~CGUIDialogPVRDirectorOSD(void);
-    virtual bool OnMessage(CGUIMessage& message);
-    virtual void OnInitWindow();
-    virtual void OnDeinitWindow(int nextWindowID);
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -197,7 +197,6 @@ bool CGUIWindowPVRCommon::OnAction(const CAction &action)
   bool bReturn = false;
 
   if (action.GetID() == ACTION_NAV_BACK ||
-      action.GetID() == ACTION_PARENT_DIR ||
       action.GetID() == ACTION_PREVIOUS_MENU)
   {
     g_windowManager.PreviousWindow();

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -158,7 +158,7 @@ bool CGUIWindowPVRRecordings::OnAction(const CAction &action)
   {
     if (m_parent->m_vecItems->GetPath() != "pvr://recordings/")
       m_parent->GoParentFolder();
-    else
+    else if (action.GetID() == ACTION_NAV_BACK)
       g_windowManager.PreviousWindow();
 
     return true;


### PR DESCRIPTION
Reasonably straight forward cleanup.  The main important bit is making sure ACTION_PARENT_DIR only does what it's supposed to do.

It needs runtime testing (no pvr here), but I don't anticipate issues.

@opdenkamp to review.
