### PR TITLE
videodb: translate filenames/paths from to not URL encode -_.!()

### DIFF
--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -40,24 +40,13 @@ namespace XFILE
   bool CStackDirectory::GetDirectory(const CStdString& strPath, CFileItemList& items)
   {
     items.Clear();
-    // format is:
-    // stack://file1 , file2 , file3 , file4
-    // filenames with commas are double escaped (ie replaced with ,,), thus the " , " separator used.
-    //CStdString folder, file;
-    //URIUtils::Split(strPath, folder, file);
-    // split files on the single comma
     CStdStringArray files;
-    StringUtils::SplitString(strPath, " , ", files);
-    if (files.empty())
+    if (!GetPaths(strPath, files))
       return false;   // error in path
-    // remove "stack://" from the folder
+
     for (unsigned int i = 0; i < files.size(); i++)
     {
       CStdString file = files[i];
-      if (i == 0)
-        file = file.Mid(8);
-      // replace double comma's with single ones.
-      file.Replace(",,", ",");
       CFileItemPtr item(new CFileItem(file));
       //URIUtils::AddFileToFolder(folder, file, item->GetPath());
       item->SetPath(file);
@@ -183,6 +172,27 @@ namespace XFILE
     URIUtils::AddFileToFolder(folder, file, path);
 
     return path;
+  }
+
+  bool CStackDirectory::GetPaths(const CStdString& strPath, vector<CStdString>& vecPaths)
+  {
+    // format is:
+    // stack://file1 , file2 , file3 , file4
+    // filenames with commas are double escaped (ie replaced with ,,), thus the " , " separator used.
+    CStdString path = strPath;
+    // remove stack:// from the beginning
+    path = path.Mid(8);
+    
+    vecPaths.clear();
+    StringUtils::SplitString(path, " , ", vecPaths);
+    if (vecPaths.empty())
+      return false;
+
+    // because " , " is used as a seperator any "," in the real paths are double escaped
+    for (vector<CStdString>::iterator itPath = vecPaths.begin(); itPath != vecPaths.end(); itPath++)
+      itPath->Replace(",,", ",");
+
+    return true;
   }
 
   CStdString CStackDirectory::ConstructStackPath(const CFileItemList &items, const vector<int> &stack)

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -35,7 +35,8 @@ namespace XFILE
     static CStdString GetStackedTitlePath(const CStdString &strPath);
     static CStdString GetStackedTitlePath(const CStdString &strPath, VECCREGEXP& RegExps);
     static CStdString GetFirstStackedFile(const CStdString &strPath);
-    CStdString ConstructStackPath(const CFileItemList& items, const std::vector<int> &stack);
-    bool ConstructStackPath(const std::vector<CStdString> &paths, CStdString &stackedPath);
+    static bool GetPaths(const CStdString& strPath, std::vector<CStdString>& vecPaths);
+    static CStdString ConstructStackPath(const CFileItemList& items, const std::vector<int> &stack);
+    static bool ConstructStackPath(const std::vector<CStdString> &paths, CStdString &stackedPath);
   };
 }

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -278,7 +278,7 @@ protected:
   std::map<CStdString, CAlbum> m_albumCache;
 
   virtual bool CreateTables();
-  virtual int GetMinVersion() const { return 29; };
+  virtual int GetMinVersion() const { return 30; };
   const char *GetBaseDBName() const { return "MyMusic"; };
 
   int AddSong(const CSong& song, bool bCheck = true, int idAlbum = -1);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -134,6 +134,18 @@ public:
    */
   static std::string GetRealPath(const std::string &path);
 
+  /*!
+   \brief Updates the URL encoded hostname of the given path
+
+   This method must only be used to update paths encoded with
+   the old (Eden) URL encoding implementation to the new (Frodo)
+   URL encoding implementation (which does not URL encode -_.!().
+
+   \param strFilename Path to update
+   \return True if the path has been updated/changed otherwise false
+   */
+  static bool UpdateUrlEncoding(std::string &strFilename);
+
 private:
   static std::string resolvePath(const std::string &path);
 };

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -550,3 +550,30 @@ TEST_F(TestURIUtils, GetRealPath)
   ref ="zip://rar%3A%2F%2F%252Fpath%252Fto%252Frar%2Fpath%2Fto%2Fzip/subpath/to/file";
   EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://rar%3A%2F%2F%252Fpath%252Fto%252Fsome%252F..%252Frar%2Fpath%2Fto%2Fsome%2F..%2Fzip/subpath/to/some/../file").c_str());
 }
+
+TEST_F(TestURIUtils, UpdateUrlEncoding)
+{
+  std::string oldUrl = "stack://rar://%2fpath%2fto%2farchive%2fsome%2darchive%2dfile%2eCD1%2erar/video.avi , rar://%2fpath%2fto%2farchive%2fsome%2darchive%2dfile%2eCD2%2erar/video.avi";
+  std::string newUrl = "stack://rar://%2fpath%2fto%2farchive%2fsome-archive-file.CD1.rar/video.avi , rar://%2fpath%2fto%2farchive%2fsome-archive-file.CD2.rar/video.avi";
+
+  EXPECT_TRUE(URIUtils::UpdateUrlEncoding(oldUrl));
+  EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());
+
+  oldUrl = "rar://%2fpath%2fto%2farchive%2fsome%2darchive%2efile%2erar/video.avi";
+  newUrl = "rar://%2fpath%2fto%2farchive%2fsome-archive.file.rar/video.avi";
+  
+  EXPECT_TRUE(URIUtils::UpdateUrlEncoding(oldUrl));
+  EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());
+  
+  oldUrl = "/path/to/some/long%2dnamed%2efile";
+  newUrl = "/path/to/some/long%2dnamed%2efile";
+  
+  EXPECT_FALSE(URIUtils::UpdateUrlEncoding(oldUrl));
+  EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());
+  
+  oldUrl = "/path/to/some/long-named.file";
+  newUrl = "/path/to/some/long-named.file";
+  
+  EXPECT_FALSE(URIUtils::UpdateUrlEncoding(oldUrl));
+  EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());
+}

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -804,7 +804,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 70; };
+  virtual int GetMinVersion() const { return 71; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 


### PR DESCRIPTION
This fixes the issue described in http://trac.xbmc.org/ticket/13433 which have been caused by https://github.com/xbmc/xbmc/commit/982f4e258f0324b6716ab35de1de9cdfc233e8bb which changed our URL encoding logic to no longer URL encode -_.!(). This results in xbmc considering files with these special characters somewhere in the file name as new files because the file path we have stored in the database still has those characters in URL encoded form.
These commits go through the "files" table in the video database and updates them to follow the new URL encoding logic. I also added a unit test to make sure the new method URIUtils::UpdateUrlEncoding() works properly.

AFAIK this can only happen to paths stored in the "files" table and not in the "path" table but feel free to prove me wrong. I'm also not sure if this also is an issue in the music database.
