### PR TITLE
Restore possibility to type in the value field of a smartplaylist rule for browsable fields

### DIFF
--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -298,7 +298,7 @@ void CGUIDialogMediaFilter::CreateSettings()
       {
         CStdString *values = new CStdString();
         if (filter.rule != NULL && filter.rule->m_parameter.size() > 0)
-          *values = filter.rule->GetLocalizedParameter(m_mediaType);
+          *values = filter.rule->GetParameter();
         filter.data = values;
 
         AddButton(filter.field, filter.label);
@@ -461,7 +461,7 @@ void CGUIDialogMediaFilter::OnSettingChanged(SettingInfo &setting)
         for (int index = 0; index < items.Size(); index++)
           filter.rule->m_parameter.push_back(items[index]->GetLabel());
 
-        *(CStdString *)filter.data = filter.rule->GetLocalizedParameter(m_mediaType);
+        *(CStdString *)filter.data = filter.rule->GetParameter();
       }
       else
       {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -271,7 +271,7 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
     if (m_playlist.m_ruleCombination.m_rules[i].m_field == FieldNone)
       item->SetLabel(g_localizeStrings.Get(21423));
     else
-      item->SetLabel(m_playlist.m_ruleCombination.m_rules[i].GetLocalizedRule(m_playlist.GetType()));
+      item->SetLabel(m_playlist.m_ruleCombination.m_rules[i].GetLocalizedRule());
     m_ruleLabels->Add(item);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_RULE_LIST, 0, 0, m_ruleLabels);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -253,7 +253,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     }
     g_mediaManager.GetLocalDrives(sources);
     
-    CStdString path = m_rule.GetLocalizedParameter(m_type);
+    CStdString path = m_rule.GetParameter();
     CGUIDialogFileBrowser::ShowAndGetDirectory(sources, g_localizeStrings.Get(657), path, false);
     if (m_rule.m_parameter.size() > 0)
       m_rule.m_parameter.clear();
@@ -402,7 +402,7 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   m_rule.m_operator = (CSmartPlaylistRule::SEARCH_OPERATOR)selected.GetParam1();
 
   // update the parameter edit control appropriately
-  SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetLocalizedParameter(m_type));
+  SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetParameter());
   CGUIEditControl::INPUT_TYPE type = CGUIEditControl::INPUT_TYPE_TEXT;
   CSmartPlaylistRule::FIELD_TYPE fieldType = CSmartPlaylistRule::GetFieldType(m_rule.m_field);
   switch (fieldType)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -68,14 +68,11 @@ bool CGUIDialogSmartPlaylistRule::OnMessage(CGUIMessage& message)
         OnOK();
       else if (iControl == CONTROL_CANCEL)
         OnCancel();
-      else if (iControl == CONTROL_VALUE && CSmartPlaylistRule::GetFieldType(m_rule.m_field) != CSmartPlaylistRule::BROWSEABLE_FIELD)
+      else if (iControl == CONTROL_VALUE)
       {
         CStdString parameter;
         OnEditChanged(iControl, parameter);
-        m_rule.m_parameter.clear();
-
-        if (!parameter.empty())
-          m_rule.m_parameter.push_back(parameter);
+        m_rule.SetParameter(parameter);
       }
       else if (iControl == CONTROL_OPERATOR)
         OnOperator();
@@ -408,8 +405,6 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   switch (fieldType)
   {
   case CSmartPlaylistRule::BROWSEABLE_FIELD:
-    type = CGUIEditControl::INPUT_TYPE_READONLY;
-    break;
   case CSmartPlaylistRule::TEXT_FIELD:
   case CSmartPlaylistRule::PLAYLIST_FIELD:
   case CSmartPlaylistRule::TEXTIN_FIELD:

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -629,6 +629,17 @@ CStdString CSmartPlaylistRule::GetParameter() const
   return StringUtils::JoinString(m_parameter, " / ");
 }
 
+void CSmartPlaylistRule::SetParameter(const CStdString &value)
+{
+  m_parameter.clear();
+  StringUtils::SplitString(value, " / ", m_parameter);
+}
+
+void CSmartPlaylistRule::SetParameter(const std::vector<CStdString> &values)
+{
+  m_parameter.assign(values.begin(), values.end());
+}
+
 CStdString CSmartPlaylistRule::GetVideoResolutionQuery(const CStdString &parameter) const
 {
   CStdString retVal(" in (select distinct idFile from streamdetails where iVideoWidth ");

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -617,14 +617,14 @@ CStdString CSmartPlaylistRule::GetLocalizedOperator(SEARCH_OPERATOR oper)
   return g_localizeStrings.Get(16018);
 }
 
-CStdString CSmartPlaylistRule::GetLocalizedRule(const CStdString &type) const
+CStdString CSmartPlaylistRule::GetLocalizedRule() const
 {
   CStdString rule;
-  rule.Format("%s %s %s", GetLocalizedField(m_field).c_str(), GetLocalizedOperator(m_operator).c_str(), GetLocalizedParameter(type).c_str());
+  rule.Format("%s %s %s", GetLocalizedField(m_field).c_str(), GetLocalizedOperator(m_operator).c_str(), GetParameter().c_str());
   return rule;
 }
 
-CStdString CSmartPlaylistRule::GetLocalizedParameter(const CStdString &type) const
+CStdString CSmartPlaylistRule::GetParameter() const
 {
   return StringUtils::JoinString(m_parameter, " / ");
 }

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -94,8 +94,8 @@ public:
   static std::vector<SortBy>  GetOrders(const CStdString &type);
   static FIELD_TYPE           GetFieldType(Field field);
 
-  CStdString                  GetLocalizedRule(const CStdString &type) const;
-  CStdString                  GetLocalizedParameter(const CStdString &type) const;
+  CStdString                  GetLocalizedRule() const;
+  CStdString                  GetParameter() const;
 
   Field                       m_field;
   SEARCH_OPERATOR             m_operator;

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -96,6 +96,8 @@ public:
 
   CStdString                  GetLocalizedRule() const;
   CStdString                  GetParameter() const;
+  void                        SetParameter(const CStdString &value);
+  void                        SetParameter(const std::vector<CStdString> &values);
 
   Field                       m_field;
   SEARCH_OPERATOR             m_operator;


### PR DESCRIPTION
During GSoC I extended smartplaylist rules to support implicit ORing within a single rule and field. For that I added the possibility to select multiple values from the list of possible values for a browsable field. Out of caution I removed the possibility to manually type into the value control of a browsable field because the user needs to follow a certain syntax to be able to specify multiple values which result in implicit ORing.
While this makes sense for operators like "is" and "is not" it doesn't make any senses for "starts with", "ends with", "contains" and "does not contain" where the user usually doesn't provide a fully matching value. Therefore we need to allow manual typing in the value control.

These changes add that functionality back. The syntax to define multiple values for implicit ORing is to seperate the values by " / " (the spaces are mandatory because some scrapers e.g. provide genres like "Thriller/Suspense"). If the user has manually typed a value which does not match any actual value and then uses the "Browse" button to view a list of available values, none of the values is pre-selected and selecting a value from the list results in the loss of the previously entered value.
