### PR TITLE
Show PVR recordings view after replaying a PVR item.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -207,7 +207,7 @@ void CGUIWindowPVRChannels::UpdateData(bool bUpdateSelectedFile /* = true */)
   CPVRChannelGroupPtr selectedGroup = SelectedGroup();
 
   m_iSelected = m_parent->m_viewControl.GetSelectedItem();
-  m_parent->m_viewControl.Clear();
+  ShowBusyItem();
   m_parent->m_vecItems->Clear();
   m_parent->m_viewControl.SetCurrentView(m_iControlList);
 

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -869,3 +869,16 @@ bool CGUIWindowPVRCommon::OnContextButtonFind(CFileItem *item, CONTEXT_BUTTON bu
 
   return bReturn;
 }
+
+void CGUIWindowPVRCommon::ShowBusyItem(void)
+{
+  // FIXME: display a temporary entry so that the list can keep its focus
+  // busy_items has to be static, because m_viewControl holds the pointer to it
+  static CFileItemList busy_items;
+  if (busy_items.IsEmpty())
+  {
+    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(1040)));
+    busy_items.AddFront(pItem, 0);
+  }
+  m_parent->m_viewControl.SetItems(busy_items);
+}

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -190,6 +190,7 @@ bool CGUIWindowPVRCommon::OnMessageFocus(CGUIMessage &message)
 void CGUIWindowPVRCommon::OnWindowUnload(void)
 {
   m_iSelected = m_parent->m_viewControl.GetSelectedItem();
+  m_history = m_parent->m_history;
 }
 
 bool CGUIWindowPVRCommon::OnAction(const CAction &action)

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.h
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.h
@@ -119,6 +119,7 @@ namespace PVR
     virtual bool UpdateEpgForChannel(CFileItem *item);
     virtual bool ShowTimerSettings(CFileItem *item);
     virtual bool ShowNewTimerDialog(void);
+    virtual void ShowBusyItem(void);
 
     virtual bool OnContextButtonMenuHooks(CFileItem *item, CONTEXT_BUTTON button);
     virtual bool OnContextButtonSortAsc(CFileItem *item, CONTEXT_BUTTON button);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -270,7 +270,7 @@ void CGUIWindowPVRGuide::UpdateData(bool bUpdateSelectedFile /* = true */)
 
   /* lock the graphics context while updating */
   CSingleLock graphicsLock(g_graphicsContext);
-  m_parent->m_viewControl.Clear();
+  ShowBusyItem();
   m_parent->m_vecItems->Clear();
 
   if (m_iGuideView == GUIDE_VIEW_CHANNEL)

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -208,7 +208,7 @@ void CGUIWindowPVRRecordings::UpdateData(bool bUpdateSelectedFile /* = true */)
   else
     m_strSelectedPath = m_parent->m_vecItems->GetPath();
 
-  m_parent->m_viewControl.Clear();
+  ShowBusyItem();
   m_parent->m_vecItems->Clear();
   m_parent->m_viewControl.SetCurrentView(m_iControlList);
   m_parent->m_vecItems->SetPath(m_strSelectedPath);

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -101,7 +101,7 @@ void CGUIWindowPVRSearch::UpdateData(bool bUpdateSelectedFile /* = true */)
   CSingleLock graphicsLock(g_graphicsContext);
 
   m_iSelected = m_parent->m_viewControl.GetSelectedItem();
-  m_parent->m_viewControl.Clear();
+  ShowBusyItem();
   m_parent->m_vecItems->Clear();
   m_parent->m_viewControl.SetCurrentView(m_iControlList);
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -105,7 +105,7 @@ void CGUIWindowPVRTimers::UpdateData(bool bUpdateSelectedFile /* = true */)
   CSingleLock graphicsLock(g_graphicsContext);
 
   m_iSelected = m_parent->m_viewControl.GetSelectedItem();
-  m_parent->m_viewControl.Clear();
+  ShowBusyItem();
   m_parent->m_vecItems->Clear();
   m_parent->m_viewControl.SetCurrentView(m_iControlList);
   m_parent->m_vecItems->SetPath("pvr://timers/");


### PR DESCRIPTION
Currently after playing a PVR item, some undefined view will be displayed (a mixture of channels and recordings view). This happens because the renderer will set the focus to the default button (TV channels) during the items list update, since the list is empty at this time and cannot have the focus. I have fixed this by displaying the (translated) string "searching..." while the update is in progress. Furthermore the history is saved, if the a PVR view is closed, so that it is restored, when the view is opened again.
