### PR TITLE
Font fixes for various things

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -238,15 +238,21 @@ bool CGUIFontTTFBase::Load(const CStdString& strFilename, float height, float as
   m_cellHeight = std::max<unsigned int>(m_face->bbox.yMax - m_face->bbox.yMin, m_face->ascender - m_face->descender);
   m_cellBaseLine = std::max<unsigned int>(m_face->bbox.yMax, m_face->ascender);
 
+  /*
+   add on the strength of any border - we do this in non-bordered cases
+   as bordered fonts are done by first rendering the border and then the
+   main font - thus m_cellBaseLine needs to align in both cases
+   */
+  FT_Pos strength = FT_MulFix( m_face->units_per_EM, m_face->size->metrics.y_scale) / 12;
+  if (strength < 128)
+    strength = 128;
+
+  m_cellHeight += 2 * strength;
+  m_cellBaseLine += strength;
+
   if (border)
   {
     m_stroker = g_freeTypeLibrary.GetStroker();
-
-    FT_Pos strength = FT_MulFix( m_face->units_per_EM, m_face->size->metrics.y_scale) / 12;
-    if (strength < 128)
-      strength = 128;
-    m_cellHeight += 2*strength;
-
     if (m_stroker)
       FT_Stroker_Set(m_stroker, strength, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0);
   }

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -447,9 +447,11 @@ float CGUIFontTTFBase::GetLineHeight(float lineSpacing) const
   return 0.0f;
 }
 
+unsigned int CGUIFontTTFBase::spacing_between_characters_in_texture = 1;
+
 unsigned int CGUIFontTTFBase::GetTextureLineHeight() const
 {
-  return m_cellHeight + 2;
+  return m_cellHeight + spacing_between_characters_in_texture;
 }
 
 CGUIFontTTFBase::Character* CGUIFontTTFBase::GetCharacter(character_t chr)
@@ -633,7 +635,7 @@ bool CGUIFontTTFBase::CacheCharacter(wchar_t letter, uint32_t style, Character *
     unsigned int y2 = min(y1 + bitmap.rows, m_textureHeight);
     CopyCharToTexture(bitGlyph, x1, y1, x2, y2);
   }
-  m_posX += 1 + (unsigned short)max(ch->right - ch->left + ch->offsetX, ch->advance);
+  m_posX += spacing_between_characters_in_texture + (unsigned short)max(ch->right - ch->left + ch->offsetX, ch->advance);
   m_numChars++;
 
   m_textureScaleX = 1.0f / m_textureWidth;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -605,7 +605,7 @@ bool CGUIFontTTFBase::CacheCharacter(wchar_t letter, uint32_t style, Character *
   // set the character in our table
   ch->letterAndStyle = (style << 16) | letter;
   ch->offsetX = (short)bitGlyph->left;
-  ch->offsetY = (short)max((short)m_cellBaseLine - bitGlyph->top, 0);
+  ch->offsetY = (short)m_cellBaseLine - bitGlyph->top;
   ch->left = (float)m_posX + ch->offsetX;
   ch->top = (float)m_posY + ch->offsetY;
   ch->right = ch->left + bitmap.width;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -235,7 +235,6 @@ bool CGUIFontTTFBase::Load(const CStdString& strFilename, float height, float as
     return false;
 
   // grab the maximum cell height and width
-  unsigned int m_cellWidth = m_face->bbox.xMax - m_face->bbox.xMin;
   m_cellHeight = std::max<unsigned int>(m_face->bbox.yMax - m_face->bbox.yMin, m_face->ascender - m_face->descender);
   m_cellBaseLine = std::max<unsigned int>(m_face->bbox.yMax, m_face->ascender);
 
@@ -252,12 +251,8 @@ bool CGUIFontTTFBase::Load(const CStdString& strFilename, float height, float as
       FT_Stroker_Set(m_stroker, strength, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0);
   }
 
-
   unsigned int ydpi = g_freeTypeLibrary.GetDPI();
-  unsigned int xdpi = (unsigned int)MathUtils::round_int(ydpi * aspect);
 
-  m_cellWidth *= (unsigned int)(height * xdpi);
-  m_cellWidth /= (72 * m_face->units_per_EM);
 
   m_cellHeight *= (unsigned int)(height * ydpi);
   m_cellHeight /= (72 * m_face->units_per_EM);
@@ -266,11 +261,10 @@ bool CGUIFontTTFBase::Load(const CStdString& strFilename, float height, float as
   m_cellBaseLine /= (72 * m_face->units_per_EM);
 
   // increment for good measure to give space in our texture
-  m_cellWidth++;
   m_cellBaseLine++;
 
-//  CLog::Log(LOGDEBUG, "%s Scaled size of font %s (%f): width = %i, height = %i, lineheight = %li",
-//    __FUNCTION__, strFilename.c_str(), height, m_cellWidth, m_cellHeight, m_face->size->metrics.height / 64);
+//  CLog::Log(LOGDEBUG, "%s Scaled size of font %s (%f): height = %i, lineheight = %li",
+//    __FUNCTION__, strFilename.c_str(), height, m_cellHeight, m_face->size->metrics.height / 64);
 
   m_height = height;
 

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -263,9 +263,6 @@ bool CGUIFontTTFBase::Load(const CStdString& strFilename, float height, float as
   // increment for good measure to give space in our texture
   m_cellBaseLine++;
 
-//  CLog::Log(LOGDEBUG, "%s Scaled size of font %s (%f): height = %i, lineheight = %li",
-//    __FUNCTION__, strFilename.c_str(), height, m_cellHeight, m_face->size->metrics.height / 64);
-
   m_height = height;
 
   delete(m_texture);

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -615,7 +615,12 @@ bool CGUIFontTTFBase::CacheCharacter(wchar_t letter, uint32_t style, Character *
   // we need only render if we actually have some pixels
   if (bitmap.width * bitmap.rows)
   {
-    CopyCharToTexture(bitGlyph, ch);
+    // ensure our rect will stay inside the texture (it *should* but we need to be certain)
+    unsigned int x1 = max(m_posX + ch->offsetX, 0);
+    unsigned int y1 = max(m_posY + ch->offsetY, 0);
+    unsigned int x2 = min(x1 + bitmap.width, m_textureWidth);
+    unsigned int y2 = min(y1 + bitmap.rows, m_textureHeight);
+    CopyCharToTexture(bitGlyph, x1, y1, x2, y2);
   }
   m_posX += 1 + (unsigned short)max(ch->right - ch->left + ch->offsetX, ch->advance);
   m_numChars++;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -84,7 +84,7 @@ public:
     if (FT_New_Face( m_library, CSpecialProtocol::TranslatePath(filename).c_str(), 0, &face ))
       return NULL;
 
-    unsigned int ydpi = GetDPI();
+    unsigned int ydpi = 72; // 72 points to the inch is the freetype default
     unsigned int xdpi = (unsigned int)MathUtils::round_int(ydpi * aspect);
 
     // we set our screen res currently to 96dpi in both directions (windows default)
@@ -123,11 +123,6 @@ public:
     assert(stroker);
     FT_Stroker_Done(stroker);
   }
-
-  unsigned int GetDPI() const
-  {
-    return 72; // default dpi, matches what XPR fonts used to use for sizing
-  };
 
 private:
   FT_Library   m_library;
@@ -275,8 +270,7 @@ bool CGUIFontTTFBase::Load(const CStdString& strFilename, float height, float as
   }
 
   // scale to pixel sizing, rounding so that maximal extent is obtained
-  unsigned int ydpi = g_freeTypeLibrary.GetDPI();
-  float scaler  = height * ydpi / (72 * m_face->units_per_EM);
+  float scaler  = height / m_face->units_per_EM;
   cellDescender = MathUtils::round_int(cellDescender * scaler - 0.5f);   // round down
   cellAscender  = MathUtils::round_int(cellAscender  * scaler + 0.5f);   // round up
 

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -112,7 +112,7 @@ protected:
   void ClearCharacterCache();
 
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight) = 0;
-  virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, Character *ch) = 0;
+  virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2) = 0;
   virtual void DeleteHardwareTexture() = 0;
 
   // modifying glyphs

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -126,6 +126,11 @@ protected:
   int m_posX;                        // current position in the texture
   int m_posY;
 
+  /*! \brief the height of each line in the texture.
+   Accounts for spacing between lines to avoid characters overlapping.
+   */
+  unsigned int GetTextureLineHeight() const;
+
   color_t m_color;
 
   Character *m_char;                 // our characters

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -130,6 +130,7 @@ protected:
    Accounts for spacing between lines to avoid characters overlapping.
    */
   unsigned int GetTextureLineHeight() const;
+  static unsigned int spacing_between_characters_in_texture;
 
   color_t m_color;
 

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -259,7 +259,7 @@ CBaseTexture* CGUIFontTTFDX::ReallocTexture(unsigned int& newHeight)
   return pNewTexture;
 }
 
-bool CGUIFontTTFDX::CopyCharToTexture(FT_BitmapGlyph bitGlyph, Character* ch)
+bool CGUIFontTTFDX::CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2)
 {
   FT_Bitmap bitmap = bitGlyph->bitmap;
 
@@ -271,12 +271,8 @@ bool CGUIFontTTFDX::CopyCharToTexture(FT_BitmapGlyph bitGlyph, Character* ch)
     texture->GetSurfaceLevel(0, &target);
 
   RECT sourcerect = { 0, 0, bitmap.width, bitmap.rows };
-  RECT targetrect;
-  targetrect.top = m_posY + ch->offsetY;
-  targetrect.left = m_posX + bitGlyph->left;
-  targetrect.bottom = targetrect.top + bitmap.rows;
-  targetrect.right = targetrect.left + bitmap.width;
-  
+  RECT targetrect = { x1, y1, x2, y2 };
+
   HRESULT hr = D3DXLoadSurfaceFromMemory( target, NULL, &targetrect,
                                           bitmap.buffer, D3DFMT_LIN_A8, bitmap.pitch, NULL, &sourcerect,
                                           D3DX_FILTER_NONE, 0x00000000);

--- a/xbmc/guilib/GUIFontTTFDX.h
+++ b/xbmc/guilib/GUIFontTTFDX.h
@@ -46,7 +46,7 @@ public:
 
 protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);
-  virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, Character *ch);
+  virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2);
   virtual void DeleteHardwareTexture();
   CD3DTexture *m_speedupTexture;  // extra texture to speed up reallocations when the main texture is in d3dpool_default.
                                   // that's the typical situation of Windows Vista and above.

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -201,16 +201,16 @@ CBaseTexture* CGUIFontTTFGL::ReallocTexture(unsigned int& newHeight)
   return newTexture;
 }
 
-bool CGUIFontTTFGL::CopyCharToTexture(FT_BitmapGlyph bitGlyph, Character* ch)
+bool CGUIFontTTFGL::CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2)
 {
   FT_Bitmap bitmap = bitGlyph->bitmap;
 
   unsigned char* source = (unsigned char*) bitmap.buffer;
-  unsigned char* target = (unsigned char*) m_texture->GetPixels() + (m_posY + ch->offsetY) * m_texture->GetPitch() + m_posX + bitGlyph->left;
+  unsigned char* target = (unsigned char*) m_texture->GetPixels() + y1 * m_texture->GetPitch() + x1;
 
-  for (int y = 0; y < bitmap.rows; y++)
+  for (unsigned int y = y1; y < y2; y++)
   {
-    memcpy(target, source, bitmap.width);
+    memcpy(target, source, x2-x1);
     source += bitmap.width;
     target += m_texture->GetPitch();
   }

--- a/xbmc/guilib/GUIFontTTFGL.h
+++ b/xbmc/guilib/GUIFontTTFGL.h
@@ -46,7 +46,7 @@ public:
 
 protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);
-  virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, Character *ch);
+  virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2);
   virtual void DeleteHardwareTexture();
 
 };


### PR DESCRIPTION
The primary intention of this is to fix #11015, an issue where a font is just the right size that it defies our (lack of) checking for texture bounds, leading to DirectX not doing the transfer of a letter to the texture. GL would have had issues as well, involving writing to memory that (potentially) doesn't exist.

The secondary intention is to fix #10549, where we don't align outlined fonts correctly, thus causing the border texture to be incorrect for some characters.  In fixing this, we must align the baselines between fonts, which essentially means a slight change in vertical alignment for all labels that don't align centrally.  From a quick look at a couple of skins I didn't notice anything out of place, but skinners should look more careful (basically any label control that isn't centered vertically).

EDIT: Also fixes #11855.

Lastly, there's various cleanups to make the code (hopefully) clearer to others.
