### PR TITLE
FIX: Crash when generating thumbnails (at least with mysql on Windows)

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -408,7 +408,16 @@ void CVideoThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* jo
     CVideoInfoTag* info = loader->m_item.GetVideoInfoTag();
 
     if (loader->m_thumb && info->m_iDbId > 0 && !info->m_type.empty())
-      m_database->SetArtForItem(info->m_iDbId, info->m_type, "thumb", loader->m_item.GetArt("thumb"));
+    {
+      // This runs in a different thread than the CVideoThumbLoader object.
+      CVideoDatabase db;
+      if (db.Open())
+      {
+        db.SetArtForItem(info->m_iDbId, info->m_type, "thumb", loader->m_item.GetArt("thumb"));
+        db.Close();
+      }
+
+    }
 
     if (m_pStreamDetailsObs)
       m_pStreamDetailsObs->OnStreamDetails(info->m_streamDetails, info->m_strFileNameAndPath, info->m_iFileId);


### PR DESCRIPTION
This solves a crash I was having when generating thumbnails with a mysql on Windows setup.

I don't know whether this also happens on other platforms or with sqlite, but IMO creating a database per thread is anyway a good practice...
