### PR TITLE
bump to libCEC 2.0.3

### DIFF
--- a/lib/libcec/Makefile
+++ b/lib/libcec/Makefile
@@ -7,7 +7,7 @@
 
 # lib name, version
 LIBNAME=libcec
-VERSION=2.0.2
+VERSION=2.0.3
 SOURCE=$(LIBNAME)-$(VERSION)
 
 # download location and format

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec-2.0.2.zip                  http://mirrors.xbmc.org/build-deps/win32/
+libcec-2.0.3.zip                  http://mirrors.xbmc.org/build-deps/win32/

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -150,7 +150,7 @@
       <back>SmallStepBack</back>
       <menu>OSD</menu>
       <start>OSD</start>
-      <select>AspectRatio</select>
+      <select>OSD</select>
       <title>CodecInfo</title>
       <info>Info</info>
       <guide>XBMC.ActivateWindow(PVROSDGuide)</guide>

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -3,7 +3,7 @@ include ../config.site.mk
 
 # lib name, version
 LIBNAME=libcec
-VERSION=2.0.2
+VERSION=2.0.3
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -933,6 +933,8 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress &key)
     PushCecKeypress(xbmcKey);
     break;
   case CEC_USER_CONTROL_CODE_POWER:
+  case CEC_USER_CONTROL_CODE_POWER_TOGGLE_FUNCTION:
+  case CEC_USER_CONTROL_CODE_POWER_OFF_FUNCTION:
     xbmcKey.iButton = XINPUT_IR_REMOTE_POWER;
     PushCecKeypress(xbmcKey);
     break;
@@ -945,6 +947,8 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress &key)
     PushCecKeypress(xbmcKey);
     break;
   case CEC_USER_CONTROL_CODE_MUTE:
+  case CEC_USER_CONTROL_CODE_MUTE_FUNCTION:
+  case CEC_USER_CONTROL_CODE_RESTORE_VOLUME_FUNCTION:
     xbmcKey.iButton = XINPUT_IR_REMOTE_MUTE;
     PushCecKeypress(xbmcKey);
     break;
@@ -1089,14 +1093,10 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress &key)
   case CEC_USER_CONTROL_CODE_RECORD_FUNCTION:
   case CEC_USER_CONTROL_CODE_PAUSE_RECORD_FUNCTION:
   case CEC_USER_CONTROL_CODE_STOP_FUNCTION:
-  case CEC_USER_CONTROL_CODE_MUTE_FUNCTION:
-  case CEC_USER_CONTROL_CODE_RESTORE_VOLUME_FUNCTION:
   case CEC_USER_CONTROL_CODE_TUNE_FUNCTION:
   case CEC_USER_CONTROL_CODE_SELECT_MEDIA_FUNCTION:
   case CEC_USER_CONTROL_CODE_SELECT_AV_INPUT_FUNCTION:
   case CEC_USER_CONTROL_CODE_SELECT_AUDIO_INPUT_FUNCTION:
-  case CEC_USER_CONTROL_CODE_POWER_TOGGLE_FUNCTION:
-  case CEC_USER_CONTROL_CODE_POWER_OFF_FUNCTION:
   case CEC_USER_CONTROL_CODE_F5:
   case CEC_USER_CONTROL_CODE_UNKNOWN:
   default:


### PR DESCRIPTION
again, fixes only. changelog can be found here: https://github.com/Pulse-Eight/libcec/blob/release/ChangeLog

3385a7e changes a key in remote.xml so the OSD can be accessed easier

deps have been uploaded for windows and os-x
