### PR TITLE
Modify RSS Ticker to Pause Scroll during Mouseover

### DIFF
--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -40,6 +40,7 @@ CGUIRSSControl::CGUIRSSControl(int parentID, int controlID, float posX, float po
 
   m_pReader = NULL;
   m_rtl = false;
+  m_stopped = false;
   ControlType = GUICONTROL_RSS;
 }
 
@@ -52,6 +53,7 @@ CGUIRSSControl::CGUIRSSControl(const CGUIRSSControl &from)
   m_strRSSTags = from.m_strRSSTags;
   m_pReader = NULL;
   m_rtl = from.m_rtl;
+  m_stopped = from.m_stopped;
   ControlType = GUICONTROL_RSS;
 }
 
@@ -71,6 +73,16 @@ void CGUIRSSControl::SetUrls(const vector<string> &vecUrl, bool rtl)
     m_scrollInfo.pixelSpeed *= -1;
   else if (m_scrollInfo.pixelSpeed < 0 && !rtl)
     m_scrollInfo.pixelSpeed *= -1;
+}
+
+void CGUIRSSControl::OnFocus()
+{
+  m_stopped = true;
+}
+
+void CGUIRSSControl::OnUnFocus()
+{
+  m_stopped = false;
 }
 
 void CGUIRSSControl::SetIntervals(const vector<int>& vecIntervals)
@@ -130,6 +142,12 @@ void CGUIRSSControl::Render()
       colors.push_back(m_label.textColor);
       colors.push_back(m_headlineColor);
       colors.push_back(m_channelColor);
+
+      if ( m_stopped )
+        m_scrollInfo.SetSpeed(0);
+      else
+        m_scrollInfo.SetSpeed(m_label.scrollSpeed);
+
       m_label.font->DrawScrollingText(m_posX, m_posY, colors, m_label.shadowColor, m_feed, 0, m_width, m_scrollInfo);
     }
 

--- a/xbmc/guilib/GUIRSSControl.h
+++ b/xbmc/guilib/GUIRSSControl.h
@@ -62,11 +62,14 @@ public:
   virtual void Render();
   virtual void OnFeedUpdate(const vecText &feed);
   virtual void OnFeedRelease();
-  virtual bool CanFocus() const { return false; };
+  virtual bool CanFocus() const { return true; };
   virtual CRect CalcRenderRegion() const;
 
   void SetIntervals(const std::vector<int>& vecIntervals);
   void SetUrls(const std::vector<std::string>& vecUrl, bool rtl);
+
+  virtual void OnFocus();
+  virtual void OnUnFocus();
 
 protected:
   virtual bool UpdateColors();
@@ -86,5 +89,6 @@ protected:
   std::vector<int> m_vecIntervals;
   bool m_rtl;
   CScrollInfo m_scrollInfo;
+  bool m_stopped;
 };
 #endif


### PR DESCRIPTION
It is likely common for users to either modify a skin or install a particular skin that takes advantage of multiple RSS feed sets. In addition, users may modify their skin to allow multiple RSS feeds to run at various speeds.

At times, a user may wish to momentarily pause the RSS ticker to read a particularly long news headline. This modification allows the user to easily pause the RSS ticker simply by placing the mouse over the ticker itself. When the user wishes for the ticker to start scrolling again, they can simply move the mouse away from the ticker.

[I'm sure there was a way to do this without having to close the original pull request, but I'm still learning git... please forgive me.]
