### PR TITLE
jsonrpc: two fixes

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -75,14 +75,8 @@ CFileItem::CFileItem(const CSong& song)
   m_pvrTimerInfoTag = NULL;
   m_pictureInfoTag = NULL;
   Reset();
-  SetLabel(song.strTitle);
-  m_strPath = song.strFileName;
-  GetMusicInfoTag()->SetSong(song);
-  m_lStartOffset = song.iStartOffset;
-  m_lStartPartNumber = 1;
-  SetProperty("item_start", song.iStartOffset);
-  m_lEndOffset = song.iEndOffset;
-  SetArt("thumb", song.strThumb);
+
+  SetFromSong(song);
 }
 
 CFileItem::CFileItem(const CStdString &path, const CAlbum& album)
@@ -95,14 +89,10 @@ CFileItem::CFileItem(const CStdString &path, const CAlbum& album)
   m_pvrTimerInfoTag = NULL;
   m_pictureInfoTag = NULL;
   Reset();
-  SetLabel(album.strAlbum);
+
   m_strPath = path;
-  m_bIsFolder = true;
-  m_strLabel2 = StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator);
   URIUtils::AddSlashAtEnd(m_strPath);
-  GetMusicInfoTag()->SetAlbum(album);
-  m_bIsAlbum = true;
-  CMusicDatabase::SetPropertiesFromAlbum(*this,album);
+  SetFromAlbum(album);
 }
 
 CFileItem::CFileItem(const CMusicInfoTag& music)
@@ -132,21 +122,8 @@ CFileItem::CFileItem(const CVideoInfoTag& movie)
   m_pvrTimerInfoTag = NULL;
   m_pictureInfoTag = NULL;
   Reset();
-  SetLabel(movie.m_strTitle);
-  if (movie.m_strFileNameAndPath.IsEmpty())
-  {
-    m_strPath = movie.m_strPath;
-    URIUtils::AddSlashAtEnd(m_strPath);
-    m_bIsFolder = true;
-  }
-  else
-  {
-    m_strPath = movie.m_strFileNameAndPath;
-    m_bIsFolder = false;
-  }
-  *GetVideoInfoTag() = movie;
-  if (movie.m_iSeason == 0) SetProperty("isspecial", "true");
-  FillInDefaultIcon();
+
+  SetFromVideoInfoTag(movie);
 }
 
 CFileItem::CFileItem(const CEpgInfoTag& tag)
@@ -1472,6 +1449,49 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
   if (!item.GetIconImage().IsEmpty())
     SetIconImage(item.GetIconImage());
   AppendProperties(item);
+}
+
+void CFileItem::SetFromVideoInfoTag(const CVideoInfoTag &video)
+{
+  SetLabel(video.m_strTitle);
+  if (video.m_strFileNameAndPath.IsEmpty())
+  {
+    m_strPath = video.m_strPath;
+    URIUtils::AddSlashAtEnd(m_strPath);
+    m_bIsFolder = true;
+  }
+  else
+  {
+    m_strPath = video.m_strFileNameAndPath;
+    m_bIsFolder = false;
+  }
+  
+  *GetVideoInfoTag() = video;
+  if (video.m_iSeason == 0)
+    SetProperty("isspecial", "true");
+  FillInDefaultIcon();
+}
+
+void CFileItem::SetFromAlbum(const CAlbum &album)
+{
+  SetLabel(album.strAlbum);
+  m_bIsFolder = true;
+  m_strLabel2 = StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator);
+  GetMusicInfoTag()->SetAlbum(album);
+  m_bIsAlbum = true;
+  CMusicDatabase::SetPropertiesFromAlbum(*this,album);
+}
+
+void CFileItem::SetFromSong(const CSong &song)
+{
+  SetLabel(song.strTitle);
+  m_strPath = song.strFileName;
+  GetMusicInfoTag()->SetSong(song);
+  m_lStartOffset = song.iStartOffset;
+  m_lStartPartNumber = 1;
+  SetProperty("item_start", song.iStartOffset);
+  m_lEndOffset = song.iEndOffset;
+  SetArt("thumb", song.strThumb);
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -352,6 +352,24 @@ public:
 
   bool IsAlbum() const;
 
+  /*! \brief Sets details using the information from the CVideoInfoTag object
+   Sets the videoinfotag and uses its information to set the label and path.
+   \param video video details to use and set
+   */
+  void SetFromVideoInfoTag(const CVideoInfoTag &video);
+  /*! \brief Sets details using the information from the CAlbum object
+   Sets the album in the music info tag and uses its information to set the
+   label and album-specific properties.
+   \param album album details to use and set
+   */
+  void SetFromAlbum(const CAlbum &album);
+  /*! \brief Sets details using the information from the CSong object
+   Sets the song in the music info tag and uses its information to set the
+   label, path, song-specific properties and artwork.
+   \param song song details to use and set
+   */
+  void SetFromSong(const CSong &song);
+
   bool m_bIsShareOrDrive;    ///< is this a root share/drive
   int m_iDriveType;     ///< If \e m_bIsShareOrDrive is \e true, use to get the share type. Types see: CMediaSource::m_iDriveType
   CDateTime m_dateTime;             ///< file creation date & time

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -533,7 +533,7 @@ bool CAudioLibrary::FillFileItem(const CStdString &strFilename, CFileItem &item)
     if (!musicdatabase.GetAlbumInfo(albumid, album, NULL))
       return false;
 
-    item = CFileItem(strFilename, album);
+    item.SetFromAlbum(album);
   }
   else
   {
@@ -541,7 +541,7 @@ bool CAudioLibrary::FillFileItem(const CStdString &strFilename, CFileItem &item)
     if (!musicdatabase.GetSongByFileName(strFilename, song))
       return false;
 
-    item = CFileItem(song);
+    item.SetFromSong(song);
   }
 
   return true;

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -140,11 +140,6 @@ JSONRPC_STATUS CFileOperations::GetDirectory(const CStdString &method, ITranspor
         CFileItem fileItem;
         if (FillFileItem(items[i], fileItem, media))
         {
-          fileItem.m_bIsFolder = items[i]->m_bIsFolder;
-          fileItem.m_dateTime = items[i]->m_dateTime;
-          fileItem.m_dwSize = items[i]->m_dwSize;
-          fileItem.SetMimeType(items[i]->GetMimeType());
-
           if (items[i]->m_bIsFolder)
             filteredDirectories.Add(CFileItemPtr(new CFileItem(fileItem)));
           else
@@ -271,6 +266,9 @@ bool CFileOperations::FillFileItem(const CFileItemPtr &originalItem, CFileItem &
   if (originalItem.get() == NULL)
     return false;
 
+  // copy all the available details
+  item = *originalItem;
+
   bool status = false;
   CStdString strFilename = originalItem->GetPath();
   if (!strFilename.empty() && (CDirectory::Exists(strFilename) || CFile::Exists(strFilename)))
@@ -302,8 +300,9 @@ bool CFileOperations::FillFileItem(const CFileItemPtr &originalItem, CFileItem &
         if (label.empty())
           return false;
 
-        item = CFileItem(strFilename, isDir);
         item.SetLabel(label);
+        item.SetPath(strFilename);
+        item.m_bIsFolder = isDir;
       }
       else
         item = *originalItem.get();

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -699,7 +699,7 @@ bool CVideoLibrary::FillFileItem(const CStdString &strFilename, CFileItem &item)
   if (!videodatabase.LoadVideoInfo(strFilename, details))
     return false;
 
-  item = CFileItem(details);
+  item.SetFromVideoInfoTag(details);
   return true;
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1849,7 +1849,7 @@ bool CVideoDatabase::GetFileInfo(const CStdString& strFilenameAndPath, CVideoInf
 
     CStdString sql = PrepareSQL("SELECT * FROM files "
                                 "JOIN path ON path.idPath = files.idPath "
-                                "JOIN bookmark ON bookmark.idFile = files.idFile AND bookmark.type = %i "
+                                "LEFT JOIN bookmark ON bookmark.idFile = files.idFile AND bookmark.type = %i "
                                 "WHERE files.idFile = %i", CBookmark::RESUME, idFile);
     if (!m_pDS->query(sql.c_str()))
       return false;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1525,23 +1525,14 @@ void CVideoDatabase::AddCountryToMovie(int idMovie, int idCountry)
 //********************************************************************************************************************************
 bool CVideoDatabase::LoadVideoInfo(const CStdString& strFilenameAndPath, CVideoInfoTag& details)
 {
-  if (GetMovieInfo(strFilenameAndPath, details))
-  {
-    CLog::Log(LOGDEBUG,"%s, got movie info!", __FUNCTION__);
-    CLog::Log(LOGDEBUG,"  Title = %s", details.m_strTitle.c_str());
-  }
-  else if (GetEpisodeInfo(strFilenameAndPath, details))
-  {
-    CLog::Log(LOGDEBUG,"%s, got episode info!", __FUNCTION__);
-    CLog::Log(LOGDEBUG,"  Title = %s", details.m_strTitle.c_str());
-  }
-  else if (GetMusicVideoInfo(strFilenameAndPath, details))
-  {
-    CLog::Log(LOGDEBUG,"%s, got music video info!", __FUNCTION__);
-    CLog::Log(LOGDEBUG,"  Title = %s", details.m_strTitle.c_str());
-  }
-  else if (GetFileInfo(strFilenameAndPath, details))
-    CLog::Log(LOGDEBUG,"%s, got file info!", __FUNCTION__);
+  if (!GetMovieInfo(strFilenameAndPath, details))
+    return false;
+  if (!GetEpisodeInfo(strFilenameAndPath, details))
+    return false;
+  if (!GetMusicVideoInfo(strFilenameAndPath, details))
+    return false;
+  if (!GetFileInfo(strFilenameAndPath, details))
+    return false;
 
   return !details.IsEmpty();
 }


### PR DESCRIPTION
These commits contain two fixes:
- The first commit fixes http://trac.xbmc.org/ticket/13343. The SQL query in CVideoDatabase::GetFileInfo() was not correct i.e. it only worked if the file being looked up also had a resume point set.
- The other commits fix issues where information like "size" or "mimetype" were overwritten when using Files.GetDirectory or Files.GetFileDetails through JSON-RPC in case where there is media-specific metadata available because we simply created a new CFileItem object instead of updating the existing one which already contained certain valid information.
