### PR TITLE
music visualisation/osd: handle ACTION_SHOW_OSD

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -130,7 +130,7 @@
       <Y>XBMC.ActivateWindow(VisualisationPresetList)</Y>
       <black>CodecInfo</black>
       <white>Info</white>
-      <start>XBMC.ActivateWindow(MusicOSD)</start>
+      <start>OSD</start>
       <back>LockPreset</back>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>

--- a/system/keymaps/joystick.AppleRemote.xml
+++ b/system/keymaps/joystick.AppleRemote.xml
@@ -119,7 +119,7 @@
       <button id="4">SkipNext</button>
       <button id="5">Pause</button>
       <button id="6">Fullscreen</button>
-      <button id="7">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="7">OSD</button>
       <button id="8">Stop</button>
       <!-- SwipeLeft  -->      <button id="80">SkipPrevious</button>
       <!-- SwipeRight -->      <button id="81">SkipNext</button>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -188,7 +188,7 @@
       <!-- minus      	-->      <button id="2">DecreaseRating</button>
       <!-- left       	-->      <button id="3">PreviousPreset</button>
       <!-- right      	-->      <button id="4">NextPreset</button>
-      <!-- menu       	-->      <button id="6">XBMC.ActivateWindow(MusicOSD)</button>
+      <!-- menu       	-->      <button id="6">OSD</button>
       <!-- Prev		-->      <button id="32">LockPreset</button>
       <!-- Info  	-->      <button id="31">Info</button>
       <!-- F8		-->      <button id="96">XBMC.ActivateWindow(VisualisationPresetList)</button>

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -71,7 +71,7 @@
       <button id="4">XBMC.ActivateWindow(VisualisationPresetList)</button>
       <button id="5">Rewind</button>
       <button id="6">FastForward</button>
-      <button id="10">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="10">OSD</button>
 
       <hat    id="1" position="left">SkipPrevious</hat>
       <hat    id="1" position="right">SkipNext</hat>

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -128,7 +128,7 @@
       <button id="3">CodecInfo</button>
       <button id="5">XBMC.ActivateWindow(VisualisationPresetList)</button>
       <button id="6">Info</button>
-      <button id="9">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="9">OSD</button>
       <button id="13">NextPreset</button>
       <button id="14">SkipNext</button>
       <button id="15">PreviousPreset</button>

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -158,7 +158,7 @@
       <button id="3">CodecInfo</button>
       <button id="5">XBMC.ActivateWindow(VisualisationPresetList)</button>
       <button id="6">Info</button>
-      <button id="9">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="9">OSD</button>
       <button id="13">NextPreset</button>
       <button id="14">SkipNext</button>
       <button id="15">PreviousPreset</button>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -67,7 +67,7 @@
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>
       <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="4">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="4">OSD</button>
       <button id="1">Info</button>
       <button id="2">Play</button>
       <button id="3">Stop</button>

--- a/system/keymaps/joystick.WiiRemote.xml
+++ b/system/keymaps/joystick.WiiRemote.xml
@@ -111,7 +111,7 @@
       <button id="2">Stop</button>
       <button id="3">SkipNext</button>
       <button id="4">SkipPrevious</button>
-      <button id="5">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="5">OSD</button>
       <button id="6">Info</button>
       <button id="8">XBMC.ActivateWindow(music)</button>
       <button id="10">IncreaseRating</button>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -269,9 +269,9 @@
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
-      <return>ActivateWindow(MusicOSD)</return>
-      <enter>ActivateWindow(MusicOSD)</enter>
-      <m>ActivateWindow(MusicOSD)</m>
+      <return>OSD</return>
+      <enter>OSD</enter>
+      <m>OSD</m>
       <i>Info</i>
       <p>ActivateWindow(VisualisationPresetList)</p>
       <v>ActivateWindow(VisualisationSettings)</v>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -191,8 +191,8 @@
       <back>LockPreset</back>
       <title>CodecInfo</title>
       <select>XBMC.ActivateWindow(VisualisationPresetList)</select>
-      <menu>XBMC.ActivateWindow(MusicOSD)</menu>
-      <start>XBMC.ActivateWindow(MusicOSD)</start>
+      <menu>OSD</menu>
+      <start>OSD</start>
       <info>Info</info>
       <guide>XBMC.ActivateWindow(PVROSDGuide)</guide>
       <playlist>XBMC.ActivateWindow(PVROSDChannels)</playlist>

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -68,6 +68,21 @@ bool CGUIDialogMusicOSD::OnMessage(CGUIMessage &message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogMusicOSD::OnAction(const CAction &action)
+{
+  switch (action.GetID())
+  {
+  case ACTION_SHOW_OSD:
+    Close();
+    return true;
+
+  default:
+    break;
+  }
+
+  return CGUIDialog::OnAction(action);
+}
+
 void CGUIDialogMusicOSD::FrameMove()
 {
   if (m_autoClosing)

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.h
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.h
@@ -29,5 +29,6 @@ public:
   CGUIDialogMusicOSD(void);
   virtual ~CGUIDialogMusicOSD(void);
   virtual bool OnMessage(CGUIMessage &message);
+  virtual bool OnAction(const CAction &action);
   virtual void FrameMove();
 };

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -63,6 +63,10 @@ bool CGUIWindowVisualisation::OnAction(const CAction &action)
     }
     break;
 
+  case ACTION_SHOW_OSD:
+    g_windowManager.ActivateWindow(WINDOW_DIALOG_MUSIC_OSD);
+    return true;
+
   case ACTION_SHOW_GUI:
     // save the settings
     g_settings.Save();


### PR DESCRIPTION
This adds support for handling ACTION_SHOW_OSD directly in CGUIWindowVisualisation and CGUIDialogMusicOSD and allows to use "OSD" instead of "ActivateWindow(MusicOSD)" in the keymaps. Furthermore it fixes the JSON-RPC method Input.ShowOSD and therefore http://trac.xbmc.org/ticket/13475.
