### PR TITLE
Fix hardcoded center of some settings controls

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -692,7 +692,6 @@ void CGUIDialogAddonSettings::CreateControls()
       {
         pControl = new CGUIButtonControl(*pOriginalButton);
         if (!pControl) return;
-        ((CGUIButtonControl *)pControl)->SettingsCategorySetTextAlign(XBFONT_CENTER_Y);
         ((CGUIButtonControl *)pControl)->SetLabel(label);
         if (id)
         {

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -301,11 +301,6 @@ void CGUIButtonControl::PythonSetDisabledColor(color_t disabledColor)
   m_label.GetLabelInfo().disabledColor = disabledColor;
 }
 
-void CGUIButtonControl::SettingsCategorySetTextAlign(uint32_t align)
-{
-  m_label.SetAlign(align);
-}
-
 void CGUIButtonControl::OnClick()
 {
   // Save values, as the click message may deactivate the window

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -72,8 +72,6 @@ public:
   void PythonSetLabel(const CStdString &strFont, const std::string &strText, color_t textColor, color_t shadowColor, color_t focusedColor);
   void PythonSetDisabledColor(color_t disabledColor);
 
-  void SettingsCategorySetTextAlign(uint32_t align);
-
   virtual void OnClick();
   bool HasClickActions() { return m_clickActions.HasActionsMeetingCondition(); };
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1171,7 +1171,6 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   }
   else if (type == CGUIControl::GUICONTROL_SETTINGS_SLIDER)
   {
-    labelInfo.align |= XBFONT_CENTER_Y;    // always center text vertically
     control = new CGUISettingsSliderControl(
       parentID, id, posX, posY, width, height, sliderWidth, sliderHeight, textureFocus, textureNoFocus,
       textureBar, textureNib, textureNibFocus, labelInfo, SPIN_CONTROL_TYPE_TEXT);

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -25,7 +25,7 @@ CGUISettingsSliderControl::CGUISettingsSliderControl(int parentID, int controlID
     , m_buttonControl(parentID, controlID, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo)
     , m_label(posX, posY, width, height, labelInfo)
 {
-  m_label.SetAlign(XBFONT_CENTER_Y | XBFONT_RIGHT);  
+  m_label.SetAlign((labelInfo.align & XBFONT_CENTER_Y) | XBFONT_RIGHT);  
   ControlType = GUICONTROL_SETTINGS_SLIDER;
 }
 
@@ -60,7 +60,7 @@ void CGUISettingsSliderControl::ProcessText()
 {
   bool changed = false;
 
-  changed |= m_label.SetMaxRect(m_buttonControl.GetXPosition(), m_posY, m_posX - m_buttonControl.GetXPosition(), m_height);
+  changed |= m_label.SetMaxRect(m_buttonControl.GetXPosition(), m_buttonControl.GetYPosition(), m_posX - m_buttonControl.GetXPosition(), m_buttonControl.GetHeight());
   changed |= m_label.SetText(CGUISliderControl::GetDescription());
   if (IsDisabled())
     changed |= m_label.SetColor(CGUILabel::COLOR_DISABLED);

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -461,9 +461,9 @@ void CGUISpinControl::Render()
     bool arrowsOnRight(0 != (m_label.GetLabelInfo().align & (XBFONT_RIGHT | XBFONT_CENTER_X)));
 
     if (arrowsOnRight)
-      RenderText(m_posX - space - textWidth, textWidth);
+      RenderText(m_posX - space - textWidth, m_posY, textWidth, m_height);
     else
-      RenderText(m_posX + m_imgspinDown.GetWidth() + m_imgspinUp.GetWidth() + space, textWidth);
+      RenderText(m_posX + m_imgspinDown.GetWidth() + m_imgspinUp.GetWidth() + space, m_posY, textWidth, m_height);
 
     // set our hit rectangle for MouseOver events
     m_hitRect = m_label.GetRenderRect();
@@ -471,9 +471,9 @@ void CGUISpinControl::Render()
   CGUIControl::Render();
 }
 
-void CGUISpinControl::RenderText(float posX, float width)
+void CGUISpinControl::RenderText(float posX, float posY, float width, float height)
 {
-  m_label.SetMaxRect(posX, m_posY, width, m_height);
+  m_label.SetMaxRect(posX, posY, width, height);
   m_label.SetColor(GetTextColor());
   m_label.Render();
 }

--- a/xbmc/guilib/GUISpinControl.h
+++ b/xbmc/guilib/GUISpinControl.h
@@ -92,9 +92,11 @@ protected:
   virtual bool UpdateColors();
   /*! \brief Render the spinner text
    \param posX position of the left edge of the text
+   \param posY positing of the top edge of the text
    \param width width of the text
+   \param height height of the text
    */
-  virtual void RenderText(float posX, float width);
+  virtual void RenderText(float posX, float posY, float width, float height);
   CGUILabel::COLOR GetTextColor() const;
   void PageUp();
   void PageDown();

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -148,11 +148,11 @@ void CGUISpinControlEx::SetSpinPosition(float spinPosX)
   SetPosition(m_buttonControl.GetXPosition(), m_buttonControl.GetYPosition());
 }
 
-void CGUISpinControlEx::RenderText(float posX, float width)
+void CGUISpinControlEx::RenderText(float posX, float posY, float width, float height)
 {
   const float spaceWidth = 10;
   // check our limits from the button control
   float x = std::max(m_buttonControl.m_label.GetRenderRect().x2 + spaceWidth, posX);
   m_label.SetScrolling(HasFocus());
-  CGUISpinControl::RenderText(x, width + posX - x);
+  CGUISpinControl::RenderText(x, m_buttonControl.GetYPosition(), width + posX - x, m_buttonControl.GetHeight());
 }

--- a/xbmc/guilib/GUISpinControlEx.h
+++ b/xbmc/guilib/GUISpinControlEx.h
@@ -64,7 +64,7 @@ public:
 
   void SetItemInvalid(bool invalid);
 protected:
-  virtual void RenderText(float posX, float width);
+  virtual void RenderText(float posX, float posY, float width, float height);
   virtual bool UpdateColors();
   CGUIButtonControl m_buttonControl;
   float m_spinPosX;

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2063,7 +2063,6 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
   {
     pControl = new CGUIEditControl(*m_pOriginalEdit);
     if (!pControl) return NULL;
-    ((CGUIEditControl *)pControl)->SettingsCategorySetTextAlign(XBFONT_CENTER_Y);
     ((CGUIEditControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
     pSettingControl = new CEditSettingControl((CGUIEditControl *)pControl, iControlID, pSetting);
@@ -2072,7 +2071,6 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
   {
     pControl = new CGUIButtonControl(*m_pOriginalButton);
     if (!pControl) return NULL;
-    ((CGUIButtonControl *)pControl)->SettingsCategorySetTextAlign(XBFONT_CENTER_Y);
     ((CGUIButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
     pSettingControl = new CButtonSettingControl((CGUIButtonControl *)pControl, iControlID, pSetting);


### PR DESCRIPTION
There are some hardcoded alignment to vertically center some labels.  This removes it.

For post-Frodo.
