### PR TITLE
FIX: [droid] Crash after regaining focus (fixes #13455)

### DIFF
--- a/xbmc/windowing/egl/EGLNativeType.h
+++ b/xbmc/windowing/egl/EGLNativeType.h
@@ -145,5 +145,5 @@ public:
 
 protected:
   XBNativeDisplayType  m_nativeDisplay;
-  XBNativeWindowType   m_nativeWindow;
+  mutable XBNativeWindowType   m_nativeWindow;
 };

--- a/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAndroid.cpp
@@ -78,6 +78,7 @@ bool CEGLNativeTypeAndroid::GetNativeWindow(XBNativeWindowType **nativeWindow) c
 {
   if (!nativeWindow)
     return false;
+  m_nativeWindow = CXBMCApp::GetNativeWindow();
   *nativeWindow = (XBNativeWindowType*) &m_nativeWindow;
   return true;
 }


### PR DESCRIPTION
The crash is due to the fact that the native window is destroyed by android when xbmc loses the focus, and a new one is created when focus is regained.

However, the obsolete native window is still used when recreating the EGL surface -> crash

I know the "mutable" is ugly and I expect comments on how to best implement the fix... ;)
