### PR TITLE
ADD: [droid] disable keyguard in addition to wakelock

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([xbmc], [12.0b2], [http://trac.xbmc.org])
+AC_INIT([xbmc], [12.0b3], [http://trac.xbmc.org])
 AC_CONFIG_HEADERS([xbmc/config.h])
 AH_TOP([#pragma once])
 m4_include([m4/ax_python_devel.m4])

--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.xbmc.xbmc"
-    android:versionCode="1"
-    android:versionName="1.0" >
+    android:versionCode="2"
+    android:versionName="12.0-BETA3" >
 
     <!-- This is the platform API where NativeActivity was introduced. -->
     <uses-sdk android:minSdkVersion="9" />

--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -12,7 +12,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.GET_TASKS" />
-	
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
+
     <application android:icon="@drawable/ic_launcher" android:debuggable="true" android:label="@string/app_name" android:hasCode="true">
         <activity
             android:name=".Splash"

--- a/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh
+++ b/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh
@@ -45,7 +45,7 @@ fi
 PACKAGE=org.xbmc.xbmc-atv2
 
 VERSION=12.0
-REVISION=0~beta2
+REVISION=0~beta3
 ARCHIVE=${PACKAGE}_${VERSION}-${REVISION}_iphoneos-arm.deb
 
 echo Creating $PACKAGE package version $VERSION revision $REVISION

--- a/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh
+++ b/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh
@@ -46,7 +46,7 @@ fi
 PACKAGE=org.xbmc.xbmc-ios
 
 VERSION=12.0
-REVISION=0~beta2
+REVISION=0~beta3
 ARCHIVE=${PACKAGE}_${VERSION}-${REVISION}_iphoneos-arm.deb
 
 echo Creating $PACKAGE package version $VERSION revision $REVISION

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -504,7 +504,7 @@ namespace INFO
 
 #define VERSION_MAJOR 12
 #define VERSION_MINOR 0
-#define VERSION_TAG "-BETA2"
+#define VERSION_TAG "-BETA3"
 
 #define LISTITEM_START              35000
 #define LISTITEM_THUMB              (LISTITEM_START)

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -60,7 +60,7 @@ ANativeActivity *CXBMCApp::m_activity = NULL;
 ANativeWindow* CXBMCApp::m_window = NULL;
 
 CXBMCApp::CXBMCApp(ANativeActivity *nativeActivity)
-  : m_wakeLock(NULL)
+  : m_wakeLock(NULL), m_keyguardLock(NULL)
 {
   m_activity = nativeActivity;
   
@@ -98,6 +98,7 @@ ActivityResult CXBMCApp::onActivate()
   {
     case Uninitialized:
       acquireWakeLock();
+      disableKeyguard();
       
       pthread_attr_t attr;
       pthread_attr_init(&attr);
@@ -113,7 +114,8 @@ ActivityResult CXBMCApp::onActivate()
       
     case Paused:
       acquireWakeLock();
-      
+      disableKeyguard();
+
       XBMC_SetupDisplay();
       XBMC_Pause(false);
       setAppState(Rendering);
@@ -213,6 +215,7 @@ void CXBMCApp::onDestroyWindow()
     XBMC_DestroyDisplay();
     setAppState(Paused);
     releaseWakeLock();
+    reenableKeyguard();
   }
 }
 
@@ -321,6 +324,89 @@ void CXBMCApp::releaseWakeLock()
   DetachCurrentThread();
 }
 
+bool CXBMCApp::getKeyguardLock(JNIEnv *env)
+{
+  android_printf("%s", __PRETTY_FUNCTION__);
+  if (m_activity == NULL)
+  {
+    android_printf("  missing activity => unable to use KeyLocks");
+    return false;
+  }
+
+  if (env == NULL)
+    return false;
+
+  if (m_keyguardLock == NULL)
+  {
+    jobject oActivity = m_activity->clazz;
+    jclass cActivity = env->GetObjectClass(oActivity);
+
+    // get the wake lock
+    jmethodID midActivityGetSystemService = env->GetMethodID(cActivity, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+    jstring sKeyguardService = env->NewStringUTF("keyguard"); // KEYGUARD_SERVICE
+    jobject oKeyguardManager = env->CallObjectMethod(oActivity, midActivityGetSystemService, sKeyguardService);
+
+    jclass cKeyguardManager = env->GetObjectClass(oKeyguardManager);
+    jmethodID midKeyguardLock = env->GetMethodID(cKeyguardManager, "newKeyguardLock", "(Ljava/lang/String;)Landroid/app/KeyguardManager$KeyguardLock;");
+    jstring sXbmcPackage = env->NewStringUTF("org.xbmc.xbmc");
+    jobject oKeyguardLock = env->CallObjectMethod(oKeyguardManager, midKeyguardLock, sXbmcPackage);
+    m_keyguardLock = env->NewGlobalRef(oKeyguardLock);
+
+    env->DeleteLocalRef(oKeyguardLock);
+    env->DeleteLocalRef(cKeyguardManager);
+    env->DeleteLocalRef(oKeyguardManager);
+    env->DeleteLocalRef(sKeyguardService);
+    env->DeleteLocalRef(sXbmcPackage);
+    env->DeleteLocalRef(cActivity);
+  }
+
+  return m_keyguardLock != NULL;
+}
+
+void CXBMCApp::reenableKeyguard()
+{
+  if (m_activity == NULL)
+    return;
+
+  JNIEnv *env = NULL;
+  AttachCurrentThread(&env);
+
+  if (!getKeyguardLock(env))
+  {
+    android_printf("%s: unable to acquire a KeyguardLock");
+    return;
+  }
+
+  jclass cKeyguardLock = env->GetObjectClass(m_keyguardLock);
+  jmethodID midKeyguardLockenable = env->GetMethodID(cKeyguardLock, "reenableKeyguard", "()V");
+  env->CallVoidMethod(m_keyguardLock, midKeyguardLockenable);
+  env->DeleteLocalRef(cKeyguardLock);
+
+  DetachCurrentThread();
+}
+
+void CXBMCApp::disableKeyguard()
+{
+  if (m_activity == NULL)
+    return;
+
+  JNIEnv *env = NULL;
+  AttachCurrentThread(&env);
+
+  if (!getKeyguardLock(env))
+  {
+    android_printf("%s: unable to acquire a KeyguardLock");
+    return;
+  }
+
+  jclass cKeyguardLock = env->GetObjectClass(m_keyguardLock);
+  jmethodID midKeyguardLockdisable = env->GetMethodID(cKeyguardLock, "disableKeyguard", "()V");
+  env->CallVoidMethod(m_keyguardLock, midKeyguardLockdisable);
+  env->DeleteLocalRef(cKeyguardLock);
+
+  DetachCurrentThread();
+}
+
 void CXBMCApp::run()
 {
     int status = 0;
@@ -378,6 +464,14 @@ void CXBMCApp::stop()
     
     env->DeleteGlobalRef(m_wakeLock);
     m_wakeLock = NULL;
+  }
+  if (m_keyguardLock != NULL && m_activity != NULL)
+  {
+    JNIEnv *env = NULL;
+    m_activity->vm->AttachCurrentThread(&env, NULL);
+    
+    env->DeleteGlobalRef(m_keyguardLock);
+    m_keyguardLock = NULL;
   }
 }
 

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -111,11 +111,15 @@ private:
   bool getWakeLock(JNIEnv *env);
   void acquireWakeLock();
   void releaseWakeLock();
+  bool getKeyguardLock(JNIEnv *env);
+  void reenableKeyguard();
+  void disableKeyguard();
   void run();
   void stop();
 
   static ANativeActivity *m_activity;
   jobject m_wakeLock;
+  jobject m_keyguardLock;
   
   typedef enum {
     // XBMC_Initialize hasn't been executed yet

--- a/xbmc/osx/Info.plist
+++ b/xbmc/osx/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>XBMC</string>
 	<key>CFBundleGetInfoString</key>
-	<string>12.0.beta2</string>
+	<string>12.0.beta3</string>
 	<key>CFBundleIconFile</key>
 	<string>xbmc.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>12.0.beta2</string>
+	<string>12.0.beta3</string>
 	<key>CFBundleVersion</key>
 	<string>r####</string>
 	<key>CFBundleSignature</key>

--- a/xbmc/win32/XBMC_PC.rc
+++ b/xbmc/win32/XBMC_PC.rc
@@ -71,12 +71,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Team XBMC"
             VALUE "FileDescription", "XBMC"
-            VALUE "FileVersion", "12.0-BETA2"
+            VALUE "FileVersion", "12.0-BETA3"
             VALUE "InternalName", "XBMC.exe"
             VALUE "LegalCopyright", "Copyright (c) Team XBMC.  All rights reserved."
             VALUE "OriginalFilename", "XBMC.exe"
             VALUE "ProductName", "XBMC for Windows"
-            VALUE "ProductVersion", "12.0-BETA2"
+            VALUE "ProductVersion", "12.0-BETA3"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
This allows to disable the keyguard, allowing, e.g. to shut down the display when listening to music and to return directly to xbmc without going thru the lock screen.

It is a matter of taste, really, but as a wake lock is implemented, this one seems logical, too
