### PR TITLE
drop the videodb:// forced caching

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -369,10 +369,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
 
 bool CDirectoryNode::CanCache() const
 {
-  //  Only cache the directorys in the root
-  //NODE_TYPE childnode=GetChildType();
-  //NODE_TYPE node=GetType();
-
-  // something should probably be cached
-  return true;//(childnode==NODE_TYPE_TITLE_MOVIES || childnode==NODE_TYPE_EPISODES || childnode == NODE_TYPE_SEASONS || childnode == NODE_TYPE_TITLE_TVSHOWS);
+  // no caching is required - the list is cached in CGUIMediaWindow::GetDirectory
+  // if it was slow to fetch anyway.
+  return false;
 }


### PR DESCRIPTION
It hurts more than it helps.  Caching is already done at the window level for slow listings.  Music library hasn't had this in effect for several years.  Lastly, it wasn't even in effect in Eden due to the callback from the video thumb loader flushing it out all the time:

https://github.com/xbmc/xbmc/blob/Eden/xbmc/video/windows/GUIWindowVideoNav.cpp#L275

Fixes issues such as #13466, along with a bunch of others reported on forums.
