### PR TITLE
build: try to code-gen during bootstrap

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -109,6 +109,16 @@
 		DF33C2A415509C1B0046CDCB /* XbmcContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF33C2A215509C1B0046CDCB /* XbmcContext.cpp */; };
 		DF33C2AE15509C5A0046CDCB /* ilog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF33C2AB15509C5A0046CDCB /* ilog.cpp */; };
 		DF34890913FD96390026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34890713FD96390026A711 /* GUIAction.cpp */; };
+		DF402A8E164462FC001C56B8 /* AddonModuleXbmc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD01615FCE5C600E10810 /* AddonModuleXbmc.cpp */; };
+		DF402A8F164462FC001C56B8 /* AddonModuleXbmcaddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD01A15FCE5C600E10810 /* AddonModuleXbmcaddon.cpp */; };
+		DF402A90164462FC001C56B8 /* AddonModuleXbmcgui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD01E15FCE5C600E10810 /* AddonModuleXbmcgui.cpp */; };
+		DF402A91164462FC001C56B8 /* AddonModuleXbmcplugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD02215FCE5C600E10810 /* AddonModuleXbmcplugin.cpp */; };
+		DF402A92164462FC001C56B8 /* AddonModuleXbmcvfs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD02615FCE5C600E10810 /* AddonModuleXbmcvfs.cpp */; };
+		DF402A93164462FC001C56B8 /* CallbackHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C098160F420700C96C76 /* CallbackHandler.cpp */; };
+		DF402A94164462FC001C56B8 /* LanguageHook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C09A160F420700C96C76 /* LanguageHook.cpp */; };
+		DF402A95164462FC001C56B8 /* swig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C09C160F421600C96C76 /* swig.cpp */; };
+		DF402A96164462FC001C56B8 /* XBPython.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C09E160F421600C96C76 /* XBPython.cpp */; };
+		DF402A97164462FC001C56B8 /* XBPyThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C0A0160F421600C96C76 /* XBPyThread.cpp */; };
 		DF4485351400651B0069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485321400651B0069344B /* PipesManager.cpp */; };
 		DF4485381400654A0069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485361400654A0069344B /* AirTunesServer.cpp */; };
 		DF527780151BAFD600B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527777151BAFD600B5B63B /* WebSocket.cpp */; };
@@ -233,7 +243,6 @@
 		DFFD594F1506B6300088DE4B /* IOSEAGLView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFFD594C1506B6300088DE4B /* IOSEAGLView.mm */; };
 		DFFEFBDB151606CB001294DC /* IOSScreenManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFFEFBDA151606CB001294DC /* IOSScreenManager.mm */; };
 		DFFEFC2215160927001294DC /* IOSExternalTouchController.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFFEFC2115160927001294DC /* IOSExternalTouchController.mm */; };
-		F502C0C4160F422A00C96C76 /* python_binding.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F502C0C2160F422A00C96C76 /* python_binding.a */; };
 		F54D9E8E12B71457006870F9 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F54D9E8D12B71457006870F9 /* CoreAudio.framework */; };
 		F56B15FB12CD6922009B4C96 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B15FA12CD6922009B4C96 /* CoreVideo.framework */; };
 		F56B15FD12CD6930009B4C96 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B15FC12CD6930009B4C96 /* AudioToolbox.framework */; };
@@ -1516,7 +1525,6 @@
 		F502C09F160F421600C96C76 /* XBPython.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XBPython.h; path = python/XBPython.h; sourceTree = "<group>"; };
 		F502C0A0160F421600C96C76 /* XBPyThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = XBPyThread.cpp; path = python/XBPyThread.cpp; sourceTree = "<group>"; };
 		F502C0A1160F421600C96C76 /* XBPyThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XBPyThread.h; path = python/XBPyThread.h; sourceTree = "<group>"; };
-		F502C0C2160F422A00C96C76 /* python_binding.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = python_binding.a; path = xbmc/interfaces/python/python_binding.a; sourceTree = "<group>"; };
 		F54D9E8D12B71457006870F9 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		F558F66813AFE7F300631E12 /* Condition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Condition.h; sourceTree = "<group>"; };
 		F558F66E13AFE81500631E12 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
@@ -3251,7 +3259,6 @@
 				F56B161B12CD69DB009B4C96 /* ImageIO.framework in Frameworks */,
 				4D5D2E131301753F006ABC13 /* CFNetwork.framework in Frameworks */,
 				18404DFD1396C44F00863BBA /* SlingboxLib.a in Frameworks */,
-				F502C0C4160F422A00C96C76 /* python_binding.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3428,11 +3435,11 @@
 		DF1AD01415FCE5AF00E10810 /* python */ = {
 			isa = PBXGroup;
 			children = (
+				DF1AD01515FCE5C600E10810 /* generated */,
 				F502C098160F420700C96C76 /* CallbackHandler.cpp */,
 				F502C099160F420700C96C76 /* CallbackHandler.h */,
 				F502C09A160F420700C96C76 /* LanguageHook.cpp */,
 				F502C09B160F420700C96C76 /* LanguageHook.h */,
-				DF1AD01515FCE5C600E10810 /* generated */,
 				F502C09C160F421600C96C76 /* swig.cpp */,
 				F502C09D160F421600C96C76 /* swig.h */,
 				F502C09E160F421600C96C76 /* XBPython.cpp */,
@@ -6374,7 +6381,6 @@
 				F589AE7D12890BEF00D8079E /* libsquish.a */,
 				F589AE8012890BEF00D8079E /* libxdaap.a */,
 				18404DFC1396C44F00863BBA /* SlingboxLib.a */,
-				F502C0C2160F422A00C96C76 /* python_binding.a */,
 			);
 			name = "Internal Libs";
 			sourceTree = "<group>";
@@ -6598,7 +6604,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$ACTION\" = build ] ; then\nmake -C ${SRCROOT}/xbmc/interfaces/python\nfi";
+			shellScript = "if [ \"$ACTION\" = build ] ; then\nmake -f ${SRCROOT}/codegenerator.mk\nfi";
 		};
 		F589B48B128A696700D8079E /* copy root files */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -7621,6 +7627,16 @@
 				DFB25D17163D3DA9006C4A48 /* WindowDialog.cpp in Sources */,
 				DFB25D18163D3DA9006C4A48 /* WindowDialogMixin.cpp in Sources */,
 				DFB25D19163D3DA9006C4A48 /* WindowXML.cpp in Sources */,
+				DF402A8E164462FC001C56B8 /* AddonModuleXbmc.cpp in Sources */,
+				DF402A8F164462FC001C56B8 /* AddonModuleXbmcaddon.cpp in Sources */,
+				DF402A90164462FC001C56B8 /* AddonModuleXbmcgui.cpp in Sources */,
+				DF402A91164462FC001C56B8 /* AddonModuleXbmcplugin.cpp in Sources */,
+				DF402A92164462FC001C56B8 /* AddonModuleXbmcvfs.cpp in Sources */,
+				DF402A93164462FC001C56B8 /* CallbackHandler.cpp in Sources */,
+				DF402A94164462FC001C56B8 /* LanguageHook.cpp in Sources */,
+				DF402A95164462FC001C56B8 /* swig.cpp in Sources */,
+				DF402A96164462FC001C56B8 /* XBPython.cpp in Sources */,
+				DF402A97164462FC001C56B8 /* XBPyThread.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -110,6 +110,16 @@
 		DF2E329415509B2C000F5772 /* XbmcContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF2E329215509B2C000F5772 /* XbmcContext.cpp */; };
 		DF33C29415509BF50046CDCB /* ilog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF33C29115509BF50046CDCB /* ilog.cpp */; };
 		DF3488F813FD961A0026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF3488F613FD961A0026A711 /* GUIAction.cpp */; };
+		DF402A7C164462C3001C56B8 /* AddonModuleXbmc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFF615FCE57C00E10810 /* AddonModuleXbmc.cpp */; };
+		DF402A7D164462C3001C56B8 /* AddonModuleXbmcaddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFFA15FCE57C00E10810 /* AddonModuleXbmcaddon.cpp */; };
+		DF402A7E164462C3001C56B8 /* AddonModuleXbmcgui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFFE15FCE57C00E10810 /* AddonModuleXbmcgui.cpp */; };
+		DF402A7F164462C3001C56B8 /* AddonModuleXbmcplugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD00215FCE57C00E10810 /* AddonModuleXbmcplugin.cpp */; };
+		DF402A80164462C3001C56B8 /* AddonModuleXbmcvfs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD00615FCE57C00E10810 /* AddonModuleXbmcvfs.cpp */; };
+		DF402A81164462C3001C56B8 /* CallbackHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C05B160F416F00C96C76 /* CallbackHandler.cpp */; };
+		DF402A82164462C3001C56B8 /* LanguageHook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C05D160F416F00C96C76 /* LanguageHook.cpp */; };
+		DF402A83164462C3001C56B8 /* swig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C076160F417B00C96C76 /* swig.cpp */; };
+		DF402A84164462C3001C56B8 /* XBPython.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C078160F417B00C96C76 /* XBPython.cpp */; };
+		DF402A85164462C3001C56B8 /* XBPyThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502C07A160F417B00C96C76 /* XBPyThread.cpp */; };
 		DF448572140065E10069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44856F140065E10069344B /* PipesManager.cpp */; };
 		DF4485751400662D0069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485731400662D0069344B /* AirTunesServer.cpp */; };
 		DF527757151BAF8200B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52774E151BAF8200B5B63B /* WebSocket.cpp */; };
@@ -238,7 +248,6 @@
 		DFFD59401506B5B10088DE4B /* IOSEAGLView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFFD593F1506B5B10088DE4B /* IOSEAGLView.mm */; };
 		DFFEFBEE15160739001294DC /* IOSScreenManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFFEFBED15160739001294DC /* IOSScreenManager.mm */; };
 		DFFEFC0415160808001294DC /* IOSExternalTouchController.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFFEFC0315160808001294DC /* IOSExternalTouchController.mm */; };
-		F502C080160F419400C96C76 /* python_binding.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F502C07E160F419400C96C76 /* python_binding.a */; };
 		F56B143412CAF279009B4C96 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B143312CAF279009B4C96 /* CoreVideo.framework */; };
 		F56B14A512CAF523009B4C96 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B14A412CAF523009B4C96 /* AudioToolbox.framework */; };
 		F56B15D512CD67A9009B4C96 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B15D412CD67A9009B4C96 /* CoreGraphics.framework */; };
@@ -1527,7 +1536,6 @@
 		F502C079160F417B00C96C76 /* XBPython.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XBPython.h; path = python/XBPython.h; sourceTree = "<group>"; };
 		F502C07A160F417B00C96C76 /* XBPyThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = XBPyThread.cpp; path = python/XBPyThread.cpp; sourceTree = "<group>"; };
 		F502C07B160F417B00C96C76 /* XBPyThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XBPyThread.h; path = python/XBPyThread.h; sourceTree = "<group>"; };
-		F502C07E160F419400C96C76 /* python_binding.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = python_binding.a; path = xbmc/interfaces/python/python_binding.a; sourceTree = "<group>"; };
 		F558F60613AFDC1700631E12 /* Condition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Condition.h; sourceTree = "<group>"; };
 		F558F61013AFDC3000631E12 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
 		F56B143312CAF279009B4C96 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
@@ -3256,7 +3264,6 @@
 				F56C8C12131F4811000AD0F6 /* librtv.a in Frameworks */,
 				F56C8C14131F4811000AD0F6 /* libxdaap.a in Frameworks */,
 				18404DD31396C3D200863BBA /* SlingboxLib.a in Frameworks */,
-				F502C080160F419400C96C76 /* python_binding.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3432,11 +3439,11 @@
 		DF1ACFF415FCE56C00E10810 /* python */ = {
 			isa = PBXGroup;
 			children = (
+				DF1ACFF515FCE57C00E10810 /* generated */,
 				F502C05B160F416F00C96C76 /* CallbackHandler.cpp */,
 				F502C05C160F416F00C96C76 /* CallbackHandler.h */,
 				F502C05D160F416F00C96C76 /* LanguageHook.cpp */,
 				F502C05E160F416F00C96C76 /* LanguageHook.h */,
-				DF1ACFF515FCE57C00E10810 /* generated */,
 				F502C076160F417B00C96C76 /* swig.cpp */,
 				F502C077160F417B00C96C76 /* swig.h */,
 				F502C078160F417B00C96C76 /* XBPython.cpp */,
@@ -6383,7 +6390,6 @@
 				F56C8C0D131F4811000AD0F6 /* libsquish.a */,
 				F56C8C10131F4811000AD0F6 /* libxdaap.a */,
 				18404DD21396C3D200863BBA /* SlingboxLib.a */,
-				F502C07E160F419400C96C76 /* python_binding.a */,
 			);
 			name = "Internal Libs";
 			sourceTree = "<group>";
@@ -6621,7 +6627,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$ACTION\" = build ] ; then\nmake -C ${SRCROOT}/xbmc/interfaces/python\nfi";
+			shellScript = "if [ \"$ACTION\" = build ] ; then\nmake -f ${SRCROOT}/codegenerator.mk\nfi";
 		};
 		F589B48B128A696700D8079E /* copy root files */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -7646,6 +7652,16 @@
 				DFB25CC8163D3A04006C4A48 /* WindowDialog.cpp in Sources */,
 				DFB25CC9163D3A04006C4A48 /* WindowDialogMixin.cpp in Sources */,
 				DFB25CCA163D3A04006C4A48 /* WindowXML.cpp in Sources */,
+				DF402A7C164462C3001C56B8 /* AddonModuleXbmc.cpp in Sources */,
+				DF402A7D164462C3001C56B8 /* AddonModuleXbmcaddon.cpp in Sources */,
+				DF402A7E164462C3001C56B8 /* AddonModuleXbmcgui.cpp in Sources */,
+				DF402A7F164462C3001C56B8 /* AddonModuleXbmcplugin.cpp in Sources */,
+				DF402A80164462C3001C56B8 /* AddonModuleXbmcvfs.cpp in Sources */,
+				DF402A81164462C3001C56B8 /* CallbackHandler.cpp in Sources */,
+				DF402A82164462C3001C56B8 /* LanguageHook.cpp in Sources */,
+				DF402A83164462C3001C56B8 /* swig.cpp in Sources */,
+				DF402A84164462C3001C56B8 /* XBPython.cpp in Sources */,
+				DF402A85164462C3001C56B8 /* XBPyThread.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -383,6 +383,16 @@
 		DF3488E713FD958F0026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF3488E513FD958F0026A711 /* GUIAction.cpp */; };
 		DF34892A13FD9C780026A711 /* AirPlayServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34892813FD9C780026A711 /* AirPlayServer.cpp */; };
 		DF34898213FDAAF60026A711 /* HttpParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34898113FDAAF60026A711 /* HttpParser.cpp */; };
+		DF402A581644613B001C56B8 /* AddonModuleXbmc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFD115FCE50700E10810 /* AddonModuleXbmc.cpp */; };
+		DF402A591644613B001C56B8 /* AddonModuleXbmcaddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFD515FCE50700E10810 /* AddonModuleXbmcaddon.cpp */; };
+		DF402A5A1644613B001C56B8 /* AddonModuleXbmcgui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFD915FCE50700E10810 /* AddonModuleXbmcgui.cpp */; };
+		DF402A5B1644613B001C56B8 /* AddonModuleXbmcplugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFDD15FCE50700E10810 /* AddonModuleXbmcplugin.cpp */; };
+		DF402A5C1644613B001C56B8 /* AddonModuleXbmcvfs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1ACFE115FCE50700E10810 /* AddonModuleXbmcvfs.cpp */; };
+		DF402A63164461B0001C56B8 /* CallbackHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502BFDA160F34B900C96C76 /* CallbackHandler.cpp */; };
+		DF402A64164461B9001C56B8 /* LanguageHook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502BFE4160F34DC00C96C76 /* LanguageHook.cpp */; };
+		DF402A65164461B9001C56B8 /* swig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502BFF0160F36AD00C96C76 /* swig.cpp */; };
+		DF402A66164461B9001C56B8 /* XBPython.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502BFE6160F34FE00C96C76 /* XBPython.cpp */; };
+		DF402A67164461B9001C56B8 /* XBPyThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F502BFE8160F34FE00C96C76 /* XBPyThread.cpp */; };
 		DF448457140048A60069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF448455140048A60069344B /* AirTunesServer.cpp */; };
 		DF44845E140048C80069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44845B140048C80069344B /* PipesManager.cpp */; };
 		DF5276E1151BAEDA00B5B63B /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769A151BAEDA00B5B63B /* Base64.cpp */; };
@@ -903,7 +913,6 @@
 		E4E91BB80E7F7338001F0546 /* NptXbmcFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4E91BB70E7F7338001F0546 /* NptXbmcFile.cpp */; };
 		EC720A8F155091BB00FFD782 /* ilog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC720A8D155091BB00FFD782 /* ilog.cpp */; };
 		EC720A9D1550927000FFD782 /* XbmcContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC720A9B1550927000FFD782 /* XbmcContext.cpp */; };
-		F502C02A160F394F00C96C76 /* python_binding.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F502C029160F394F00C96C76 /* python_binding.a */; };
 		F506297A0E57B9680066625A /* MultiPathFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50629780E57B9680066625A /* MultiPathFile.cpp */; };
 		F50FDC5A119B4B2C00C8B8CD /* GUIDialogTextViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FDC59119B4B2C00C8B8CD /* GUIDialogTextViewer.cpp */; };
 		F50FE04A11A3410300C8B8CD /* EncoderFlac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FE04811A3410300C8B8CD /* EncoderFlac.cpp */; };
@@ -2996,7 +3005,6 @@
 		F502BFE9160F34FE00C96C76 /* XBPyThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XBPyThread.h; path = python/XBPyThread.h; sourceTree = "<group>"; };
 		F502BFF0160F36AD00C96C76 /* swig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = swig.cpp; path = python/swig.cpp; sourceTree = "<group>"; };
 		F502BFF1160F36AD00C96C76 /* swig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = swig.h; path = python/swig.h; sourceTree = "<group>"; };
-		F502C029160F394F00C96C76 /* python_binding.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = python_binding.a; path = xbmc/interfaces/python/python_binding.a; sourceTree = "<group>"; };
 		F50629780E57B9680066625A /* MultiPathFile.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = MultiPathFile.cpp; sourceTree = "<group>"; };
 		F50629790E57B9680066625A /* MultiPathFile.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = MultiPathFile.h; sourceTree = "<group>"; };
 		F50FDC58119B4B2C00C8B8CD /* GUIDialogTextViewer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogTextViewer.h; sourceTree = "<group>"; };
@@ -3290,7 +3298,6 @@
 				F59879080FBAA0C3008EF4FB /* QuartzCore.framework in Frameworks */,
 				F52A733D1560BC34005B1A0B /* CoreFoundation.framework in Frameworks */,
 				DFBE805115F7D75700D7D102 /* SystemConfiguration.framework in Frameworks */,
-				F502C02A160F394F00C96C76 /* python_binding.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4451,11 +4458,11 @@
 		DF1ACFE815FCE53900E10810 /* python */ = {
 			isa = PBXGroup;
 			children = (
+				DF1ACFD015FCE50700E10810 /* generated */,
 				F502BFDA160F34B900C96C76 /* CallbackHandler.cpp */,
 				F502BFDB160F34B900C96C76 /* CallbackHandler.h */,
 				F502BFE4160F34DC00C96C76 /* LanguageHook.cpp */,
 				F502BFE5160F34DC00C96C76 /* LanguageHook.h */,
-				DF1ACFD015FCE50700E10810 /* generated */,
 				F502BFF0160F36AD00C96C76 /* swig.cpp */,
 				F502BFF1160F36AD00C96C76 /* swig.h */,
 				F502BFE6160F34FE00C96C76 /* XBPython.cpp */,
@@ -6277,7 +6284,6 @@
 				43352CED1071634600706B8A /* libsquish.a */,
 				E38E25680D2639F100618676 /* libxdaap.a */,
 				18404DA51396C31B00863BBA /* SlingboxLib.a */,
-				F502C029160F394F00C96C76 /* python_binding.a */,
 			);
 			name = "internal libs";
 			sourceTree = "<group>";
@@ -6666,7 +6672,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$ACTION\" = build ] ; then\nmake -C ${SRCROOT}/xbmc/interfaces/python\nfi";
+			shellScript = "if [ \"$ACTION\" = build ] ; then\nmake -f ${SRCROOT}/codegenerator.mk\nfi";
 		};
 		F5DEC3580E6DEBB2005A4E24 /* copy root files */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -7678,6 +7684,16 @@
 				DFB25D46163D4743006C4A48 /* WindowDialog.cpp in Sources */,
 				DFB25D47163D4743006C4A48 /* WindowDialogMixin.cpp in Sources */,
 				DFB25D48163D4743006C4A48 /* WindowXML.cpp in Sources */,
+				DF402A581644613B001C56B8 /* AddonModuleXbmc.cpp in Sources */,
+				DF402A591644613B001C56B8 /* AddonModuleXbmcaddon.cpp in Sources */,
+				DF402A5A1644613B001C56B8 /* AddonModuleXbmcgui.cpp in Sources */,
+				DF402A5B1644613B001C56B8 /* AddonModuleXbmcplugin.cpp in Sources */,
+				DF402A5C1644613B001C56B8 /* AddonModuleXbmcvfs.cpp in Sources */,
+				DF402A63164461B0001C56B8 /* CallbackHandler.cpp in Sources */,
+				DF402A64164461B9001C56B8 /* LanguageHook.cpp in Sources */,
+				DF402A65164461B9001C56B8 /* swig.cpp in Sources */,
+				DF402A66164461B9001C56B8 /* XBPython.cpp in Sources */,
+				DF402A67164461B9001C56B8 /* XBPyThread.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/bootstrap
+++ b/bootstrap
@@ -1,2 +1,3 @@
 #!/bin/sh
 BOOTSTRAP_STANDALONE=1 make -f bootstrap.mk
+BOOTSTRAP_STANDALONE=1 make -f codegenerator.mk

--- a/codegenerator.mk
+++ b/codegenerator.mk
@@ -1,0 +1,60 @@
+TOPDIR ?= .
+INTERFACES_DIR ?= xbmc/interfaces
+
+JAVA ?= $(shell which java)
+ifeq ($(JAVA),)
+JAVA = java-not-found
+endif
+
+SWIG ?= $(shell which swig)
+ifeq ($(SWIG),)
+SWIG = swig-not-found
+endif
+
+DOXYGEN ?= $(shell which doxygen)
+ifeq ($(DOXYGEN),)
+DOXYGEN = doxygen-not-found
+else
+DOXY_XML_PATH=$(GENDIR)/doxygenxml
+endif
+
+GENDIR = $(INTERFACES_DIR)/python/generated
+GROOVY_DIR = $(TOPDIR)/lib/groovy
+
+GENERATED =  $(GENDIR)/AddonModuleXbmc.cpp
+GENERATED += $(GENDIR)/AddonModuleXbmcgui.cpp
+GENERATED += $(GENDIR)/AddonModuleXbmcplugin.cpp
+GENERATED += $(GENDIR)/AddonModuleXbmcaddon.cpp
+GENERATED += $(GENDIR)/AddonModuleXbmcvfs.cpp
+
+vpath %.i $(INTERFACES_DIR)/swig
+
+$(GENDIR)/%.cpp: $(GENDIR)/%.xml $(JAVA) $(SWIG) $(DOXY_XML_PATH)
+	$(JAVA) -cp "$(GROOVY_DIR)/groovy-all-1.8.4.jar:$(GROOVY_DIR)/commons-lang-2.6.jar:$(TOPDIR)/tools/codegenerator:$(INTERFACES_DIR)/python" \
+          groovy.ui.GroovyMain $(TOPDIR)/tools/codegenerator/Generator.groovy $< $(INTERFACES_DIR)/python/PythonSwig.cpp.template $@ $(DOXY_XML_PATH)
+	rm $<
+
+$(GENDIR)/%.xml: %.i $(SWIG) $(JAVA)
+	mkdir -p $(GENDIR)
+	$(SWIG) -w401 -c++ -o $@ -xml -I$(TOPDIR)/xbmc -xmllang python $<
+
+codegenerated: $(DOXYGEN) $(SWIG) $(JAVA) $(GENERATED)
+
+$(DOXY_XML_PATH): $(SWIG) $(JAVA)
+	cd $(INTERFACES_DIR)/python; ($(DOXYGEN) Doxyfile > /dev/null) 2>&1 | grep -v " warning: "
+	touch $@
+
+$(DOXYGEN):
+	@echo "Warning: No doxygen installed. The Api will not have any docstrings."
+	mkdir -p $(GENDIR)/doxygenxml
+
+$(JAVA):
+	@echo Java not found, it will be used if found after configure.
+	@echo This is not necessarily an error.
+	@false
+
+$(SWIG):
+	@echo Swig not found, it will be used if found after configure.
+	@echo This is not necessarily an error.
+	@false
+

--- a/xbmc/interfaces/python/Makefile.in
+++ b/xbmc/interfaces/python/Makefile.in
@@ -1,61 +1,25 @@
 INCLUDES=-I../../.. -I. -I../../ -I../../linux -I../../../guilib -I.
 
-INTERFACES = AddonModuleXbmc.i
-INTERFACES += AddonModuleXbmcgui.i
-INTERFACES += AddonModuleXbmcplugin.i
-INTERFACES += AddonModuleXbmcaddon.i
-INTERFACES += AddonModuleXbmcvfs.i
+ifeq (@USE_DOXYGEN@,1)
+DOXYGEN=@DOXYGEN_EXE@
+endif
 
-GENDIR = generated
+TOPDIR = @abs_top_srcdir@
+INTERFACES_DIR = @abs_top_srcdir@/xbmc/interfaces
+JAVA=@JAVA_EXE@
+SWIG=@SWIG_EXE@
+LIB=python_binding.a
+all: $(LIB)
 
-GENERATED = $(patsubst %.i,$(GENDIR)/%.cpp,$(INTERFACES))
-
-GENERATOR=@abs_top_srcdir@/tools/codegenerator
+include ../../../codegenerator.mk
 
 SRCS=	CallbackHandler.cpp LanguageHook.cpp \
 	XBPyThread.cpp XBPython.cpp swig.cpp \
 	$(GENERATED)
 
-SWIG_INTERFACE_DIR=../swig
-
-ifeq (@USE_DOXYGEN@,1)
-DOXY_XML_PATH=$(GENDIR)/doxygenxml
-else
-DOXY_XML_PATH=
-endif
-
-SWIG_INC += -I@abs_top_srcdir@/xbmc
-INCLUDES += @PYTHON_CPPFLAGS@ $(SWIG_INC)
-
-CLEAN_FILES=$(GENDIR)
-
-LIB=python_binding.a
-
-CXXFLAGS+= -DSWIGRUNTIME_DEBUG -DSTATIC_LINKED
-
-# This prevents the removal of the intermediate files. Without
-#  this target the make will re-reun the generator a second time
-#  without any changes.
-.SECONDARY:
+INCLUDES += @PYTHON_CPPFLAGS@
+.SECONDARY: $(GENERATED)
 
 include ../../../Makefile.include
 -include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))
 
-$(GENDIR)/dummy: ../legacy/*.h
-	mkdir -p $(GENDIR)
-	touch $(GENDIR)/dummy
-
-$(GENDIR)/doxygenxml/dummy: $(GENDIR)/dummy ./Doxyfile
-ifeq (@USE_DOXYGEN@,1)
-	(@DOXYGEN_EXE@ > /dev/null) 2>&1 | grep -v " warning: "
-else
-	echo "Warning: No doxygen installed. The Api will not have any docstrings."
-	mkdir -p $(GENDIR)/doxygenxml
-endif
-	touch $(GENDIR)/doxygenxml/dummy
-
-$(GENDIR)/%.xml: $(SWIG_INTERFACE_DIR)/%.i $(GENDIR)/dummy $(GENDIR)/doxygenxml/dummy
-	@SWIG_EXE@ -w401 -c++ -outdir $(GENDIR) -o $@ -xml $(SWIG_INC) -xmllang python $<
-
-$(GENDIR)/%.cpp: $(GENDIR)/%.xml
-	@JAVA_EXE@ -cp "../../../lib/groovy/groovy-all-1.8.4.jar:../../../lib/groovy/commons-lang-2.6.jar:$(GENERATOR):./" groovy.ui.GroovyMain $(GENERATOR)/Generator.groovy $< PythonSwig.cpp.template $@ $(DOXY_XML_PATH)


### PR DESCRIPTION
This allows us to create a completely bootstrapped tarball that does not
require java or swig as build-deps.

Ping @montellese. Anything needed for win32? The only change is that the .cpp's now may/may not exist on a clean checkout.

Ping @memphiz: Mind giving this a go on osx/ios?
