### PR TITLE
[pvr] Add more complete seek and speed contro for supporting PVR demuxers

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -532,6 +532,23 @@ extern "C"
   void PauseStream(bool bPaused);
 
   /*!
+   * Notify the pvr addon/demuxer that XBMC wishes to seek the stream by time
+   * @param time The absolute time since stream start
+   * @param backwards True to seek to keyframe BEFORE time, else AFTER
+   * @param startpts can be updated to point to where display should start
+   * @return True if the seek operation was possible
+   * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
+   */
+  bool SeekTime(int time, bool backwards, double *startpts);
+
+  /*!
+   * Notify the pvr addon/demuxer that XBMC wishes to change playback speed
+   * @param speed The requested playback speed
+   * @remarks Optional, and only used if addon has its own demuxer.
+   */
+  void SetSpeed(int speed);
+
+  /*!
    * Called by XBMC to assign the function pointers of this add-on to pClient.
    * @param pClient The struct to assign the function pointers to.
    */
@@ -590,6 +607,8 @@ extern "C"
     pClient->CanPauseStream                 = CanPauseStream;
     pClient->PauseStream                    = PauseStream;
     pClient->CanSeekStream                  = CanSeekStream;
+    pClient->SeekTime                       = SeekTime;
+    pClient->SetSpeed                       = SetSpeed;
 
     pClient->OpenRecordedStream             = OpenRecordedStream;
     pClient->CloseRecordedStream            = CloseRecordedStream;

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -335,6 +335,8 @@ extern "C" {
     bool         (__cdecl* CanPauseStream)(void);
     void         (__cdecl* PauseStream)(bool);
     bool         (__cdecl* CanSeekStream)(void);
+    bool         (__cdecl* SeekTime)(int, bool, double*);
+    void         (__cdecl* SetSpeed)(int);
   } PVRClient;
 
 #ifdef __cplusplus

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -475,3 +475,16 @@ void CDVDDemuxPVRClient::GetStreamCodecName(int iStreamId, CStdString &strName)
       strName = "eac3";
   }
 }
+
+bool CDVDDemuxPVRClient::SeekTime(int timems, bool backwards, double *startpts)
+{
+  if (m_pInput)
+    return m_pvrClient->SeekTime(timems, backwards, startpts);
+  return false;
+}
+
+void CDVDDemuxPVRClient::SetSpeed ( int speed )
+{
+  if (m_pInput)
+    m_pvrClient->SetSpeed(speed);
+}

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
@@ -107,8 +107,8 @@ public:
   void Abort();
   void Flush();
   DemuxPacket* Read();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) { return false; }
-  void SetSpeed(int iSpeed) {};
+  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
+  void SetSpeed(int iSpeed);
   int GetStreamLength() { return 0; }
   CDemuxStream* GetStream(int iStreamId);
   int GetNrOfStreams();

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -871,6 +871,16 @@ int64_t CPVRClient::SeekStream(int64_t iFilePosition, int iWhence/* = SEEK_SET*/
   return -EINVAL;
 }
 
+bool CPVRClient::SeekTime(int time, bool backwards, double *startpts)
+{
+  if (IsPlaying())
+  {
+    try { return m_pStruct->SeekTime(time, backwards, startpts); }
+    catch (exception &e) { LogException(e, "SeekTime()"); }
+  }
+  return false;
+}
+
 int64_t CPVRClient::GetStreamPosition(void)
 {
   if (IsPlayingLiveStream())
@@ -1323,6 +1333,15 @@ void CPVRClient::PauseStream(bool bPaused)
   {
     try { m_pStruct->PauseStream(bPaused); }
     catch (exception &e) { LogException(e, "PauseStream()"); }
+  }
+}
+
+void CPVRClient::SetSpeed(int speed)
+{
+  if (IsPlaying())
+  {
+    try { m_pStruct->SetSpeed(speed); }
+    catch (exception &e) { LogException(e, "SetSpeed()"); }
   }
 }
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -397,6 +397,23 @@ namespace PVR
      */
     bool CanSeekStream(void) const;
 
+    /*!
+     * Notify the pvr addon/demuxer that XBMC wishes to seek the stream by time
+     * @param time The absolute time since stream start
+     * @param backwards True to seek to keyframe BEFORE time, else AFTER
+     * @param startpts can be updated to point to where display should start
+     * @return True if the seek operation was possible
+     * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
+     */
+    bool SeekTime(int time, bool backwards, double *startpts);
+
+    /*!
+     * Notify the pvr addon/demuxer that XBMC wishes to change playback speed
+     * @param speed The requested playback speed
+     * @remarks Optional, and only used if addon has its own demuxer.
+     */
+    void SetSpeed(int speed);
+
     //@}
     /** @name PVR recording stream methods */
     //@{


### PR DESCRIPTION
Allow the SetSpeed and SeekTime internal demuxer methods to be passed directly to PVR addon's that include their own demuxer and can support these methods.
