### PR TITLE
Bug fix and enhance CleanString

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -276,7 +276,7 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
       continue;
     }
     int j=0;
-    if ((j=reTags.RegFind(strFileName.c_str())) > 0)
+    if ((j=reTags.RegFind(strTitleAndYear.c_str())) > 0)
       strTitleAndYear = strTitleAndYear.Mid(0, j);
   }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -275,9 +275,9 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
       CLog::Log(LOGERROR, "%s: Invalid string clean RegExp:'%s'", __FUNCTION__, regexps[i].c_str());
       continue;
     }
-    int j=0;
-    if ((j=reTags.RegFind(strFileName.c_str())) > 0)
-      strTitleAndYear = strTitleAndYear.Mid(0, j);
+    int j = reTags.RegFind(strTitleAndYear.c_str());
+    if (j >= 0 && strTitleAndYear.size() != reTags.GetFindLen())
+      strTitleAndYear = (j!=0) ? strTitleAndYear.Mid(0, j): strTitleAndYear.Mid(reTags.GetFindLen());
   }
 
   // final cleanup - special characters used instead of spaces:

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -275,8 +275,8 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
       CLog::Log(LOGERROR, "%s: Invalid string clean RegExp:'%s'", __FUNCTION__, regexps[i].c_str());
       continue;
     }
-    int j=0;
-    if ((j=reTags.RegFind(strTitleAndYear.c_str())) > 0)
+    int j = reTags.RegFind(strTitleAndYear.c_str());
+    if (j > 0 && strTitleAndYear.size() != reTags.GetFindLen())
       strTitleAndYear = strTitleAndYear.Mid(0, j);
   }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -276,8 +276,8 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
       continue;
     }
     int j = reTags.RegFind(strTitleAndYear.c_str());
-    if (j > 0 && strTitleAndYear.size() != reTags.GetFindLen())
-      strTitleAndYear = strTitleAndYear.Mid(0, j);
+    if (reTags.GetFindLen() && strTitleAndYear.size() != reTags.GetFindLen())
+      strTitleAndYear = (j!=0) ? strTitleAndYear.Mid(0, j): strTitleAndYear.Mid(reTags.GetFindLen());
   }
 
   // final cleanup - special characters used instead of spaces:
@@ -1389,6 +1389,114 @@ void CUtil::DeleteDirectoryCache(const CStdString &prefix)
   }
 }
 
+bool CUtil::SetSysDateTimeYear(int iYear, int iMonth, int iDay, int iHour, int iMinute)
+{
+  TIME_ZONE_INFORMATION tziNew;
+  SYSTEMTIME CurTime;
+  SYSTEMTIME NewTime;
+  GetLocalTime(&CurTime);
+  GetLocalTime(&NewTime);
+  int iRescBiases, iHourUTC;
+  int iMinuteNew;
+
+  DWORD dwRet = GetTimeZoneInformation(&tziNew);  // Get TimeZone Informations
+  float iGMTZone = (float(tziNew.Bias)/(60));     // Calc's the GMT Time
+
+  CLog::Log(LOGDEBUG, "------------ TimeZone -------------");
+  CLog::Log(LOGDEBUG, "-      GMT Zone: GMT %.1f",iGMTZone);
+  CLog::Log(LOGDEBUG, "-          Bias: %lu minutes",tziNew.Bias);
+  CLog::Log(LOGDEBUG, "-  DaylightBias: %lu",tziNew.DaylightBias);
+  CLog::Log(LOGDEBUG, "-  StandardBias: %lu",tziNew.StandardBias);
+
+  switch (dwRet)
+  {
+    case TIME_ZONE_ID_STANDARD:
+      {
+        iRescBiases   = tziNew.Bias + tziNew.StandardBias;
+        CLog::Log(LOGDEBUG, "-   Timezone ID: 1, Standart");
+      }
+      break;
+    case TIME_ZONE_ID_DAYLIGHT:
+      {
+        iRescBiases   = tziNew.Bias + tziNew.StandardBias + tziNew.DaylightBias;
+        CLog::Log(LOGDEBUG, "-   Timezone ID: 2, Daylight");
+      }
+      break;
+    case TIME_ZONE_ID_UNKNOWN:
+      {
+        iRescBiases   = tziNew.Bias + tziNew.StandardBias;
+        CLog::Log(LOGDEBUG, "-   Timezone ID: 0, Unknown");
+      }
+      break;
+    case TIME_ZONE_ID_INVALID:
+      {
+        iRescBiases   = tziNew.Bias + tziNew.StandardBias;
+        CLog::Log(LOGDEBUG, "-   Timezone ID: Invalid");
+      }
+      break;
+    default:
+      iRescBiases   = tziNew.Bias + tziNew.StandardBias;
+  }
+    CLog::Log(LOGDEBUG, "--------------- END ---------------");
+
+  // Calculation
+  iHourUTC = GMTZoneCalc(iRescBiases, iHour, iMinute, iMinuteNew);
+  iMinute = iMinuteNew;
+  if(iHourUTC <0)
+  {
+    iDay = iDay - 1;
+    iHourUTC =iHourUTC + 24;
+  }
+  if(iHourUTC >23)
+  {
+    iDay = iDay + 1;
+    iHourUTC =iHourUTC - 24;
+  }
+
+  // Set the New-,Detected Time Values to System Time!
+  NewTime.wYear     = (WORD)iYear;
+  NewTime.wMonth    = (WORD)iMonth;
+  NewTime.wDay      = (WORD)iDay;
+  NewTime.wHour     = (WORD)iHourUTC;
+  NewTime.wMinute   = (WORD)iMinute;
+
+  FILETIME stNewTime, stCurTime;
+  SystemTimeToFileTime(&NewTime, &stNewTime);
+  SystemTimeToFileTime(&CurTime, &stCurTime);
+  return false;
+}
+int CUtil::GMTZoneCalc(int iRescBiases, int iHour, int iMinute, int &iMinuteNew)
+{
+  int iHourUTC, iTemp;
+  iMinuteNew = iMinute;
+  iTemp = iRescBiases/60;
+
+  if (iRescBiases == 0 )return iHour;   // GMT Zone 0, no need calculate
+  if (iRescBiases > 0)
+    iHourUTC = iHour + abs(iTemp);
+  else
+    iHourUTC = iHour - abs(iTemp);
+
+  if ((iTemp*60) != iRescBiases)
+  {
+    if (iRescBiases > 0)
+      iMinuteNew = iMinute + abs(iTemp*60 - iRescBiases);
+    else
+      iMinuteNew = iMinute - abs(iTemp*60 - iRescBiases);
+
+    if (iMinuteNew >= 60)
+    {
+      iMinuteNew = iMinuteNew -60;
+      iHourUTC = iHourUTC + 1;
+    }
+    else if (iMinuteNew < 0)
+    {
+      iMinuteNew = iMinuteNew +60;
+      iHourUTC = iHourUTC - 1;
+    }
+  }
+  return iHourUTC;
+}
 
 void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, bool bUseFileDirectories)
 {

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -275,9 +275,9 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
       CLog::Log(LOGERROR, "%s: Invalid string clean RegExp:'%s'", __FUNCTION__, regexps[i].c_str());
       continue;
     }
-    int j = reTags.RegFind(strTitleAndYear.c_str());
-    if (j >= 0 && strTitleAndYear.size() != reTags.GetFindLen())
-      strTitleAndYear = (j!=0) ? strTitleAndYear.Mid(0, j): strTitleAndYear.Mid(reTags.GetFindLen());
+    int j=0;
+    if ((j=reTags.RegFind(strFileName.c_str())) > 0)
+      strTitleAndYear = strTitleAndYear.Mid(0, j);
   }
 
   // final cleanup - special characters used instead of spaces:


### PR DESCRIPTION
BUG
the RE was done against strFileName, but the replace was done with strTitleAndYear
which was ok unless CleanDateTime tried to remove something from the front of strFileName
Enhancements
Allow CleanString to match starting at the front and remove only the match
Prevent cleanStrings from matching entire filename

The enhancements should be guaranteed to be backward compatable as they only come into effect if the old version would have returned an empty string
