### PR TITLE
in Files mode sorting by file ends up sorting by filename which leads to

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -503,7 +503,8 @@ void CVideoInfoTag::ToSortable(SortItem& sortable)
   sortable[FieldTime] = m_strRuntime;
   sortable[FieldFilename] = m_strFile;
   sortable[FieldMPAA] = m_strMPAARating;
-  sortable[FieldPath] = m_strFileNameAndPath;
+//  sortable[FieldPath] = m_strFileNameAndPath;
+  sortable[FieldPath] = m_basePath;
   sortable[FieldSortTitle] = m_strSortTitle;
   sortable[FieldTvShowStatus] = m_strStatus;
   sortable[FieldProductionCode] = m_strProductionCode;

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -503,8 +503,10 @@ void CVideoInfoTag::ToSortable(SortItem& sortable)
   sortable[FieldTime] = m_strRuntime;
   sortable[FieldFilename] = m_strFile;
   sortable[FieldMPAA] = m_strMPAARating;
-//  sortable[FieldPath] = m_strFileNameAndPath;
-  sortable[FieldPath] = m_basePath;
+  if (!m_basePath.IsEmpty())
+    sortable[FieldPath] = m_basePath;
+  else if (!m_strFileNameAndPath.IsEmpty())
+    sortable[FieldPath] = m_strFileNameAndPath;
   sortable[FieldSortTitle] = m_strSortTitle;
   sortable[FieldTvShowStatus] = m_strStatus;
   sortable[FieldProductionCode] = m_strProductionCode;


### PR DESCRIPTION
unexpected results when using DVD foders or movies in Folders.
while browsing folder movies the sort order will be (with the last two in random order)

movies/moviename3/avideo.avi
movies/moviename1/video.avi
movies/moviename2/video.avi

This patch fixes that and one gets the expected order of
movies/moviename1/video.avi
movies/moviename2/video.avi
movies/moviename3/avideo.avi
see http://forum.xbmc.org/showthread.php?tid=143834 for some discussion

I haven't investigated yet, but things are even stranger now as the name of the set the video belongs to has been appended to the filename so if the movie was part of a set it would sort by the set name
