### PR TITLE
FIX: Video metadata disappears from files mode view after Clean Library

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7920,7 +7920,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     }
 
     CLog::Log(LOGDEBUG, "%s: Cleaning paths that don't exist and have content set...", __FUNCTION__);
-    sql = "select * from path where strContent != ''";
+    sql = "select * from path where not (strContent='' and strSettings='' and strHash='' and exclude!=1)";
     m_pDS->query(sql.c_str());
     CStdString strIds;
     while (!m_pDS->eof())
@@ -8018,7 +8018,14 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     }
 
     CLog::Log(LOGDEBUG, "%s: Cleaning path table", __FUNCTION__);
-    sql = "delete from path where idPath not in (select distinct idPath from files) and idPath not in (select distinct idPath from tvshowlinkpath) and strContent=''";
+    sql.Format("delete from path where strContent='' and strSettings='' and strHash='' and exclude!=1 "
+                                  "and idPath not in (select distinct idPath from files) "
+                                  "and idPath not in (select distinct idPath from tvshowlinkpath) "
+                                  "and idPath not in (select distinct c%02d from movie) "
+                                  "and idPath not in (select distinct c%02d from tvshow) "
+                                  "and idPath not in (select distinct c%02d from episode) "
+                                  "and idPath not in (select distinct c%02d from musicvideo)"
+                , VIDEODB_ID_PARENTPATHID, VIDEODB_ID_TV_PARENTPATHID, VIDEODB_ID_EPISODE_PARENTPATHID, VIDEODB_ID_MUSICVIDEO_PARENTPATHID );
     m_pDS->exec(sql.c_str());
 
     CLog::Log(LOGDEBUG, "%s: Cleaning genre table", __FUNCTION__);


### PR DESCRIPTION
This is a problem with Eden as well.

If you have a file structure like

movies/b-movies/movie1/video.avi
movies/b-movies/movie2/video.avi

I.e. intermediate directories between the movie name and the source, then the current clean library will remove them from the paths table (in this case movies/b-movies) and the movies will have an invalid parentPathId and no video information will be displayed in views like Confluence media view.
Also if a video path was excluded, that would also disappear after a clean library (because there is no content set in the path entry)

I have tested (at least at the moment (a week ago?) any changes to any of the scraper settings (such as recurse, no update) result in the content being set.

Unfortunately the code doesn't clean enough. It really should remove all paths that are unreachable from a source or a sub directory of a path that has been excluded.  While I have a bunch of these I imagine under normal circumstances this would not be a problem as users would not generally be moving their libraries around while still leaving old copies in existence, so I left it out as it didn't seem to be worth the effort.
