### PR TITLE
fixed: Scraping of (movie) titles with dots in it did not work

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -488,7 +488,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
 {
   // prepare parameters for URL creation
   CStdString sTitle, sTitleYear, sYear;
-  CUtil::CleanString(sMovie, sTitle, sTitleYear, sYear, true/*fRemoveExt*/, fFirst);
+  CUtil::CleanString(sMovie, sTitle, sTitleYear, sYear, true/*fRemoveExt*/, !fFirst);
 
   if (!fFirst || Content() == CONTENT_MUSICVIDEOS)
     sTitle.Replace("-"," ");


### PR DESCRIPTION
This fixes the scraping of movie titles like "S.W.A.T.".  Without it, the scraper will return unusable results.

I'm not sure whether this is the best approach, but for now it was the only way I could think of.
