### PR TITLE
change DVD/VIDEO_TS/VIDEO_TS.IFO folder handling to mimic DVD.iso

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2881,11 +2881,11 @@ CStdString CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) co
     strFile = CMultiPathDirectory::GetFirstPath(m_strPath);
 
   if (IsOpticalMediaFile())
-  { // optical media files should be treated like folders
-    useFolder = true;
+  { // optical media folders should be treated like a file
+//    useFolder = true;
     strFile = GetLocalMetadataPath();
   }
-  else if (useFolder)
+  if (useFolder)
     strFile = URIUtils::GetDirectory(strFile);
 
   if (strFile.empty()) // empty filepath -> nothing to find
@@ -3047,7 +3047,7 @@ CStdString CFileItem::GetLocalFanart() const
 
   return "";
 }
-
+// only called if IsOpticalMediaFile
 CStdString CFileItem::GetLocalMetadataPath() const
 {
   if (m_bIsFolder && !IsFileFolder())
@@ -3061,6 +3061,7 @@ CStdString CFileItem::GetLocalMetadataPath() const
   { // go back up another one
     parent = URIUtils::GetParentPath(parent);
   }
+  URIUtils::RemoveSlashAtEnd(parent);
   return parent;
 }
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2457,7 +2457,7 @@ void CFileItemList::StackFolders()
             item->m_bIsFolder = false;
             item->SetPath(dvdPath);
             item->SetLabel2("");
-            item->SetLabelPreformated(true);
+//            item->SetLabelPreformated(true);
             m_sortMethod = SORT_METHOD_NONE; /* sorting is now broken */
           }
         }
@@ -2939,9 +2939,9 @@ CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
 
   if (IsOpticalMediaFile())
-    return GetLocalMetadataPath();
+    strMovieName = GetLocalMetadataPath();
 
-  if ((!m_bIsFolder || URIUtils::IsInArchive(m_strPath)) && bUseFolderNames)
+  if ((!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || IsOpticalMediaFile()) && bUseFolderNames)
   {
     CStdString name2(strMovieName);
     URIUtils::GetParentPath(name2,strMovieName);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2800,6 +2800,14 @@ CStdString CFileItem::GetTBNFile() const
   if (m_bIsFolder && !IsFileFolder())
     URIUtils::RemoveSlashAtEnd(strFile);
 
+  CLog::Log(LOGDEBUG, "mike: GetTBNFile %s", strFile.c_str());
+  if (IsOpticalMediaFile())
+  {
+      strFile = URIUtils::GetParentPath(URIUtils::GetParentPath(strFile));
+      URIUtils::RemoveSlashAtEnd(strFile);
+      CLog::Log(LOGDEBUG, "mike: GetTBNFile DVD tbn file %s", strFile.c_str());
+  }
+
   if (!strFile.IsEmpty())
   {
     if (m_bIsFolder && !IsFileFolder())

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2883,7 +2883,7 @@ CStdString CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) co
   if (IsOpticalMediaFile())
   { // optical media folders should be treated like a file
 //    useFolder = true;
-    strFile = GetLocalMetadataPath();
+    strFile = GetOpticalFolderPath();
   }
   if (useFolder)
     strFile = URIUtils::GetDirectory(strFile);
@@ -2947,7 +2947,7 @@ CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
 
   if (IsOpticalMediaFile())
-    strMovieName = GetLocalMetadataPath();
+    strMovieName = GetOpticalFolderPath();
 
   if ((!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || IsOpticalMediaFile()) && bUseFolderNames)
   {
@@ -3019,7 +3019,7 @@ CStdString CFileItem::GetLocalFanart() const
   if (IsOpticalMediaFile())
   { // grab from the optical media parent folder as well
     CFileItemList moreItems;
-    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+    CDirectory::GetDirectory(GetOpticalFolderPath(), moreItems, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
     items.Append(moreItems);
   }
 
@@ -3048,7 +3048,7 @@ CStdString CFileItem::GetLocalFanart() const
   return "";
 }
 // only called if IsOpticalMediaFile
-CStdString CFileItem::GetLocalMetadataPath() const
+CStdString CFileItem::GetOpticalFolderPath() const
 {
   if (m_bIsFolder && !IsFileFolder())
     return m_strPath;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -321,7 +321,7 @@ public:
 
      \sa URIUtils::GetParentPath
    */
-  CStdString GetLocalMetadataPath() const;
+  CStdString GetOpticalFolderPath() const;
 
   // finds a matching local trailer file
   CStdString FindTrailer() const;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8238,11 +8238,6 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
         {
           CStdString nfoFile(URIUtils::ReplaceExtension(item.GetTBNFile(), ".nfo"));
 
-          if (item.IsOpticalMediaFile())
-          {
-            nfoFile = URIUtils::GetParentFolderURI(nfoFile, true);
-          }
-
           if (overwrite || !CFile::Exists(nfoFile, false))
           {
             if(!xmlDoc.SaveFile(nfoFile))
@@ -8619,7 +8614,13 @@ void CVideoDatabase::ExportActorThumbs(const CStdString &strDir, const CVideoInf
   CStdString strPath(strDir);
   if (singleFiles)
   {
-    strPath = URIUtils::AddFileToFolder(tag.m_strPath, ".actors");
+    strPath = tag.m_strPath;
+    CStdString dirName;
+    CUtil::GetDirectoryName(strPath, dirName);
+    if (dirName.Equals( "VIDEO_TS" ) || dirName.Equals( "BDMV" ) )
+        strPath = URIUtils::GetParentPath(URIUtils::GetParentPath(strPath));
+    CLog::Log(LOGDEBUG, "mike: export actor thumbs '%s' %s %s %s", strPath.c_str(), tag.m_strPath.c_str(), tag.m_basePath.c_str(), dirName.c_str());
+    strPath = URIUtils::AddFileToFolder(strPath, ".actors");
     if (!CDirectory::Exists(strPath))
     {
       CDirectory::Create(strPath);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1251,7 +1251,9 @@ namespace VIDEO
 
     // parent folder to apply the thumb to and to search for local actor thumbs
     CStdString parentDir = GetParentDir(*pItem);
-    if (g_guiSettings.GetBool("videolibrary.actorthumbs"))
+    if (pItem->IsOpticalMediaFile())
+      parentDir = URIUtils::GetParentPath(pItem->GetLocalMetadataPath());
+  if (g_guiSettings.GetBool("videolibrary.actorthumbs"))
       FetchActorThumbs(movieDetails.m_cast, actorArtPath.empty() ? parentDir : actorArtPath);
     if (bApplyToDir)
       ApplyThumbToFolder(parentDir, art["thumb"]);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1550,6 +1550,19 @@ namespace VIDEO
       {
         CFileItem parentDirectory(item->GetLocalMetadataPath(), true);
         nfoFile = GetnfoFile(&parentDirectory, true);
+        if (nfoFile.IsEmpty())
+        {
+          if (bGrabAny)
+            nfoFile = URIUtils::AddFileToFolder(URIUtils::GetParentPath(parentDirectory.GetPath()), "movie.nfo");
+          if (!CFile::Exists(nfoFile) )
+            nfoFile.clear();
+          nfoFile = parentDirectory.GetPath();
+          URIUtils::RemoveSlashAtEnd(nfoFile);
+          nfoFile = URIUtils::ReplaceExtension(nfoFile, ".nfo");
+
+          if (!nfoFile.IsEmpty())
+            return nfoFile;
+        }
       }
     }
     // folders (or stacked dvds) can take any nfo file if there's a unique one

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1252,7 +1252,7 @@ namespace VIDEO
     // parent folder to apply the thumb to and to search for local actor thumbs
     CStdString parentDir = GetParentDir(*pItem);
     if (pItem->IsOpticalMediaFile())
-      parentDir = URIUtils::GetParentPath(pItem->GetLocalMetadataPath());
+      parentDir = URIUtils::GetParentPath(pItem->GetOpticalFolderPath());
   if (g_guiSettings.GetBool("videolibrary.actorthumbs"))
       FetchActorThumbs(movieDetails.m_cast, actorArtPath.empty() ? parentDir : actorArtPath);
     if (bApplyToDir)
@@ -1550,7 +1550,7 @@ namespace VIDEO
 
       if (nfoFile.IsEmpty() && item->IsOpticalMediaFile())
       {
-        CFileItem parentDirectory(item->GetLocalMetadataPath(), true);
+        CFileItem parentDirectory(item->GetOpticalFolderPath(), true);
         nfoFile = GetnfoFile(&parentDirectory, true);
         if (nfoFile.IsEmpty())
         {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -436,7 +436,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
     CFileItemPtr pItem = items[i];
     CFileItemPtr match;
     if (!content.IsEmpty()) /* optical media will be stacked down, so it's path won't match the base path */
-      match = dbItems.Get(pItem->IsOpticalMediaFile() ? pItem->GetLocalMetadataPath() : pItem->GetPath());
+      match = dbItems.Get(pItem->IsOpticalMediaFile() ? pItem->GetOpticalFolderPath() : pItem->GetPath());
     if (match)
     {
       pItem->UpdateInfo(*match, replaceLabels);


### PR DESCRIPTION
This change makes a folder movie/DVD/VIDEO_TS/VIDEO_TS.IFO act as if it were movie/DVD.iso.
the commits are

1) when scraping the movie name is either DVD or movie depending on "movies in folders" option
2)nfos are first searched in movie/DVD/VIDEO_TS/ and DVD for historical compatability then
   movie.nfo and then DVD.nfo
3)saving tbns (possibly not needed) and nfos as DVD.nfo
4) saving/loading the new artwork in the movie folder as well as the .actor directory
5) rename GetLocalMetadataPath to GetOpticalFolderPath for clarity.

This change makes it much more consistent from a user point of view and allows movies with multiple DVDs. I'm sure there must be some way (without making them iso's), but I don't know how.

While there is little reason today to not have iso (historically there was the windows file size limit),  I and quite a few other people still have large volumes of DVD folders
