### PR TITLE
media library: switch to the playlist view matching the currently active view

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2868,9 +2868,9 @@ bool CApplication::OnAction(const CAction &action)
   if (action.GetID() == ACTION_SHOW_PLAYLIST)
   {
     int iPlaylist = g_playlistPlayer.GetCurrentPlaylist();
-    if (iPlaylist == PLAYLIST_VIDEO)
+    if (iPlaylist == PLAYLIST_VIDEO && !g_windowManager.GetActiveWindow() == WINDOW_VIDEO_PLAYLIST)
       g_windowManager.ActivateWindow(WINDOW_VIDEO_PLAYLIST);
-    else if (iPlaylist == PLAYLIST_MUSIC)
+    else if (iPlaylist == PLAYLIST_MUSIC && !g_windowManager.GetActiveWindow() == WINDOW_MUSIC_PLAYLIST)
       g_windowManager.ActivateWindow(WINDOW_MUSIC_PLAYLIST);
     return true;
   }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -235,6 +235,21 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
   return CGUIMediaWindow::OnMessage(message);
 }
 
+bool CGUIWindowMusicBase::OnAction(const CAction &action)
+{
+  if (action.GetID() == ACTION_SHOW_PLAYLIST)
+  {
+    if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC ||
+        g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size() > 0)
+    {
+      g_windowManager.ActivateWindow(WINDOW_MUSIC_PLAYLIST);
+      return true;
+    }
+  }
+
+  return CGUIMediaWindow::OnAction(action);
+}
+
 void CGUIWindowMusicBase::OnInfoAll(int iItem, bool bCurrent, bool refresh)
 {
   CMusicDatabaseDirectory dir;

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -46,6 +46,7 @@ public:
   CGUIWindowMusicBase(int id, const CStdString &xmlFile);
   virtual ~CGUIWindowMusicBase(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual bool OnAction(const CAction &action);
   virtual bool OnBack(int actionID);
 
   void OnInfo(CFileItem *pItem, bool bShowInfo = false);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -106,6 +106,15 @@ bool CGUIWindowVideoBase::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_SCAN_ITEM)
     return OnContextButton(m_viewControl.GetSelectedItem(),CONTEXT_BUTTON_SCAN);
+  else if (action.GetID() == ACTION_SHOW_PLAYLIST)
+  {
+    if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO ||
+        g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO).size() > 0)
+    {
+      g_windowManager.ActivateWindow(WINDOW_VIDEO_PLAYLIST);
+      return true;
+    }
+  }
 
   return CGUIMediaWindow::OnAction(action);
 }


### PR DESCRIPTION
This fixes http://trac.xbmc.org/ticket/12891 (not being able to use the "Space" key to get back to the video playlist view after stopping playback of a video) but it contains a slight change in behaviour: Up until now when pressing "Space" in the video view while playing some music, we'd jump to the music playlist screen (independent of whether there are items in the video playlist). With this we always jump to the video playlist when being in a video view and if the video playlist contains at least one item. Likewise we always jump to the music playlist when being in a music view and if the music playlist contains at least one item.

The question is whether this change in behaviour makes sense and is acceptable or not?

The cause of this problem is that we set the current playlist to none before we start playing a file from a video view (because playback doesn't go through the playlist player). Therefore after stopping playback there's no active playlist anymore.
