### PR TITLE
[Art] Add the item/video path to the "browse for art" dialog

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11415,3 +11415,7 @@ msgstr ""
 msgctxt "#36040"
 msgid "Unsupported libCEC interface version. %x is lower than the version XBMC supports (%x)"
 msgstr ""
+
+msgctxt "#36041"
+msgid "* Item folder"
+msgstr ""

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -243,6 +243,15 @@ CStdString CMultiPathDirectory::ConstructMultiPath(const vector<CStdString> &vec
   return newPath;
 }
 
+CStdString CMultiPathDirectory::ConstructMultiPath(const std::set<CStdString> &setPaths)
+{
+  CStdString newPath = "multipath://";
+  for (std::set<CStdString>::const_iterator path = setPaths.begin(); path != setPaths.end(); ++path)
+    AddToMultiPath(newPath, *path);
+
+  return newPath;
+}
+
 void CMultiPathDirectory::MergeItems(CFileItemList &items)
 {
   CLog::Log(LOGDEBUG, "CMultiPathDirectory::MergeItems, items = %i", (int)items.Size());

--- a/xbmc/filesystem/MultiPathDirectory.h
+++ b/xbmc/filesystem/MultiPathDirectory.h
@@ -20,6 +20,7 @@
  */
 
 #include "IDirectory.h"
+#include <set>
 
 namespace XFILE
 {
@@ -38,6 +39,7 @@ public:
   static bool GetPaths(const CStdString& strPath, std::vector<CStdString>& vecPaths);
   static bool HasPath(const CStdString& strPath, const CStdString& strPathToFind);
   static CStdString ConstructMultiPath(const std::vector<CStdString> &vecPaths);
+  static CStdString ConstructMultiPath(const std::set<CStdString> &setPaths);
 
 private:
   void MergeItems(CFileItemList &items);

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -26,6 +26,8 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "video/VideoInfoTag.h"
+#include "utils/URIUtils.h"
+#include "filesystem/MultiPathDirectory.h"
 
 using namespace std;
 
@@ -77,6 +79,7 @@ bool GroupUtils::Group(GroupBy groupBy, const CFileItemList &items, CFileItemLis
 
       int ratings = 0;
       int iWatched = 0; // have all the movies been played at least once?
+      std::set<CStdString> pathSet;
       for (std::set<CFileItemPtr>::const_iterator movie = set->second.begin(); movie != set->second.end(); movie++)
       {
         CVideoInfoTag* movieInfo = (*movie)->GetVideoInfoTag();
@@ -103,7 +106,15 @@ bool GroupUtils::Group(GroupBy groupBy, const CFileItemList &items, CFileItemLis
         setInfo->m_playCount += movieInfo->m_playCount;
         if (movieInfo->m_playCount > 0)
           iWatched++;
+
+        //accumulate the path for a multipath construction
+        CFileItem video(movieInfo->m_basePath, false);
+        if (video.IsVideo())
+          pathSet.insert(URIUtils::GetParentPath(movieInfo->m_basePath));
+        else
+          pathSet.insert(movieInfo->m_basePath);
       }
+      setInfo->m_basePath = XFILE::CMultiPathDirectory::ConstructMultiPath(pathSet);
 
       if (ratings > 1)
         pItem->GetVideoInfoTag()->m_fRating /= ratings;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -47,6 +47,7 @@
 #include "music/MusicDatabase.h"
 #include "URL.h"
 #include "video/VideoThumbLoader.h"
+#include "filesystem/Directory.h"
 
 using namespace std;
 using namespace XFILE;
@@ -703,6 +704,7 @@ void CGUIDialogVideoInfo::OnGetArt()
 
   CStdString result;
   VECSOURCES sources(g_settings.m_videoSources);
+  AddItemPathToFileBrowserSources(sources, *m_movieItem);
   g_mediaManager.GetLocalDrives(sources);
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result))
     return;   // user cancelled
@@ -798,6 +800,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
 
   CStdString result;
   VECSOURCES sources(g_settings.m_videoSources);
+  AddItemPathToFileBrowserSources(sources, item);
   g_mediaManager.GetLocalDrives(sources);
   bool flip=false;
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(20437), result, &flip, 20445) || result.Equals("fanart://Current"))
@@ -875,4 +878,28 @@ void CGUIDialogVideoInfo::SetLabel(int iControl, const CStdString &strLabel)
 std::string CGUIDialogVideoInfo::GetThumbnail() const
 {
   return m_movieItem->GetArt("thumb");
+}
+
+void CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item)
+{
+  if (!item.HasVideoInfoTag())
+    return;
+
+  CStdString itemDir = item.GetVideoInfoTag()->m_basePath;
+
+  //season
+  if (itemDir.IsEmpty())
+    itemDir = item.GetVideoInfoTag()->GetPath();
+
+  CFileItem itemTmp(itemDir, false);
+  if (itemTmp.IsVideo())
+    itemDir = URIUtils::GetParentPath(itemDir);
+
+  if (!itemDir.IsEmpty() && CDirectory::Exists(itemDir))
+  {
+    CMediaSource itemSource;
+    itemSource.strName = g_localizeStrings.Get(36041);
+    itemSource.strPath = itemDir;
+    sources.push_back(itemSource);
+  }
 }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -42,6 +42,7 @@ public:
   virtual bool HasListItems() const { return true; };
 
   static std::string ChooseArtType(const CFileItem &item, std::map<std::string, std::string> &currentArt);
+  static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
 protected:
   virtual void OnInitWindow();
   void Update();

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1207,6 +1207,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       VECSOURCES sources=g_settings.m_videoSources;
       g_mediaManager.GetLocalDrives(sources);
       CStdString result;
+      CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(sources, *item);
       if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources,
                                                   g_localizeStrings.Get(13511), result))
       {
@@ -1404,6 +1405,7 @@ void CGUIWindowVideoNav::OnChooseFanart(const CFileItem &videoItem)
   CStdString result;
   VECSOURCES sources(g_settings.m_videoSources);
   g_mediaManager.GetLocalDrives(sources);
+  CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(sources, item);
   bool flip=false;
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(20437), result, &flip, 20445) || result.Equals("fanart://Current"))
     return;


### PR DESCRIPTION
This PR adds the path of an item to the "browse for art" dialog. It includes TV Shows (first path), seasons, episodes, movies, sets (multipath).

In the majority of cases art files are stored in the video/item path, e.g., if the "Artwork Downloader" is used. So this may save a lot of clicks.
