### PR TITLE
pvr: Added API function GetRecordingEdl

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -284,6 +284,16 @@ extern "C"
   */
   int GetRecordingLastPlayedPosition(const PVR_RECORDING& recording);
 
+  /*!
+  * Retrieve the edit decision list (EDL) of a recording on the backend.
+  * @param recording The recording.
+  * @param edl out: The function has to write the EDL list into this array.
+  * @param size in: The maximum size of the EDL, out: the actual size of the EDL.
+  * @return PVR_ERROR_NO_ERROR if the EDL was successfully read.
+  * @remarks Required if bSupportsRecordingEdl is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
+  */
+  PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY edl[], int *size);
+
   //@}
   /** @name PVR timer methods
    *  @remarks Only used by XBMC is bSupportsTimers is set to true.
@@ -586,6 +596,7 @@ extern "C"
     pClient->SetRecordingPlayCount          = SetRecordingPlayCount;
     pClient->SetRecordingLastPlayedPosition = SetRecordingLastPlayedPosition;
     pClient->GetRecordingLastPlayedPosition = GetRecordingLastPlayedPosition;
+    pClient->GetRecordingEdl                = GetRecordingEdl;
 
     pClient->GetTimersAmount                = GetTimersAmount;
     pClient->GetTimers                      = GetTimers;

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -33,6 +33,7 @@
 #endif
 #endif
 #include <string.h>
+#include <stdint.h>
 
 #include "xbmc_addon_types.h"
 #include "xbmc_epg_types.h"
@@ -67,6 +68,7 @@ struct DemuxPacket;
 #define PVR_ADDON_URL_STRING_LENGTH          1024
 #define PVR_ADDON_DESC_STRING_LENGTH         1024
 #define PVR_ADDON_INPUT_FORMAT_STRING_LENGTH 32
+#define PVR_ADDON_EDL_LENGTH                 32
 
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20
@@ -154,6 +156,7 @@ extern "C" {
     bool bSupportsRecordingFolders;     /*!< @brief true if the backend supports timers / recordings in folders. */
     bool bSupportsRecordingPlayCount;   /*!< @brief true if the backend supports play count for recordings. */
     bool bSupportsLastPlayedPosition;   /*!< @brief true if the backend supports store/retrieve of last played position for recordings. */
+    bool bSupportsRecordingEdl;         /*!< @brief true if the backend supports retrieving an edit decision list for recordings. */
   } ATTRIBUTE_PACKED PVR_ADDON_CAPABILITIES;
 
   /*!
@@ -288,6 +291,24 @@ extern "C" {
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!
+   * @brief Edit definition list (EDL)
+   */
+  typedef enum
+  {
+    PVR_EDL_TYPE_CUT      = 0, /*!< @brief cut (completly remove content) */
+    PVR_EDL_TYPE_MUTE     = 1, /*!< @brief mute audio */
+    PVR_EDL_TYPE_SCENE    = 2, /*!< @brief scene markers (chapter seeking) */
+    PVR_EDL_TYPE_COMBREAK = 3  /*!< @brief commercial breaks */
+  } PVR_EDL_TYPE;
+
+  typedef struct PVR_EDL_ENTRY
+  {
+    int64_t start;     // ms
+    int64_t end;       // ms
+    PVR_EDL_TYPE type;
+  } ATTRIBUTE_PACKED PVR_EDL_ENTRY;
+
+  /*!
    * @brief Structure to transfer the methods from xbmc_pvr_dll.h to XBMC
    */
   typedef struct PVRClient
@@ -320,6 +341,7 @@ extern "C" {
     PVR_ERROR    (__cdecl* SetRecordingPlayCount)(const PVR_RECORDING&, int);
     PVR_ERROR    (__cdecl* SetRecordingLastPlayedPosition)(const PVR_RECORDING&, int);
     int          (__cdecl* GetRecordingLastPlayedPosition)(const PVR_RECORDING&);
+    PVR_ERROR    (__cdecl* GetRecordingEdl)(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*);
     int          (__cdecl* GetTimersAmount)(void);
     PVR_ERROR    (__cdecl* GetTimers)(ADDON_HANDLE);
     PVR_ERROR    (__cdecl* AddTimer)(const PVR_TIMER&);

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -28,6 +28,8 @@
 #include "utils/XBMCTinyXML.h"
 #include "PlatformDefs.h"
 #include "URL.h"
+#include "pvr/recordings/PVRRecordings.h"
+#include "pvr/PVRManager.h"
 
 extern "C"
 {
@@ -147,6 +149,17 @@ bool CEdl::ReadEditDecisionLists(const CStdString& strMovie, const float fFrameR
     CLog::Log(LOGDEBUG, "%s - Checking for cut list within MythTV for: %s", __FUNCTION__,
               strMovie.c_str());
     bFound |= ReadMythCutList(strMovie, fFramesPerSecond);
+  }
+
+  /*
+   * PVR Recordings
+   */
+  else if (URIUtils::IsPVRRecording(strMovie))
+  {
+    CLog::Log(LOGDEBUG, "%s - Checking for edit decision list (EDL) for PVR recording: %s",
+      __FUNCTION__, strMovie.c_str());
+
+    bFound = ReadPvr(strMovie);
   }
 
   if (bFound)
@@ -580,6 +593,71 @@ bool CEdl::ReadBeyondTV(const CStdString& strMovie)
               beyondTVFilename.c_str());
     return false;
   }
+}
+
+bool CEdl::ReadPvr(const CStdString &strMovie)
+{
+  if (!PVR::g_PVRManager.IsStarted())
+  {
+    CLog::Log(LOGERROR, "%s - PVR Manager not started, cannot read Edl for %s", __FUNCTION__, strMovie.c_str());
+    return false;
+  }
+
+  CFileItemPtr tag =  PVR::g_PVRRecordings->GetByPath(strMovie);
+  if (tag && tag->HasPVRRecordingInfoTag())
+  {
+    CLog::Log(LOGDEBUG, "%s - Reading Edl for recording: %s", __FUNCTION__, tag->GetPVRRecordingInfoTag()->m_strTitle.c_str());
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s - Unable to find PVR recording: %s", __FUNCTION__, strMovie.c_str());
+    return false;
+  }
+
+  std::vector<PVR_EDL_ENTRY> edl = tag->GetPVRRecordingInfoTag()->GetEdl();
+  std::vector<PVR_EDL_ENTRY>::const_iterator it;
+  for (it = edl.begin(); it != edl.end(); ++it)
+  {
+    Cut cut;
+    cut.start = it->start;
+    cut.end = it->end;
+
+    switch (it->type)
+    {
+    case PVR_EDL_TYPE_CUT:
+      cut.action = CUT;
+      break;
+    case PVR_EDL_TYPE_MUTE:
+      cut.action = MUTE;
+      break;
+    case PVR_EDL_TYPE_SCENE:
+      //cut.action = SCENE;
+      //break;
+      CLog::Log(LOGINFO, "%s - Ignoring entry of type SCENE", __FUNCTION__);
+      continue;
+    case PVR_EDL_TYPE_COMBREAK:
+      cut.action = COMM_BREAK;
+      break;
+    default:
+      CLog::Log(LOGINFO, "%s - Ignoring entry of unknown type: %d", __FUNCTION__, it->type);
+      continue;
+    }
+
+    if (AddCut(cut))
+    {
+      CLog::Log(LOGDEBUG, "%s - Added break [%s - %s] found in PVRRecording for: %s.",
+        __FUNCTION__, MillisecondsToTimeString(cut.start).c_str(),
+        MillisecondsToTimeString(cut.end).c_str(), strMovie.c_str());
+    }
+    else
+    {
+      CLog::Log(LOGERROR, "%s - Invalid break [%s - %s] found in PVRRecording for: %s. Continuing anyway.",
+        __FUNCTION__, MillisecondsToTimeString(cut.start).c_str(),
+        MillisecondsToTimeString(cut.end).c_str(), strMovie.c_str());
+    }
+  }
+
+ return !edl.empty();
 }
 
 bool CEdl::AddCut(Cut& cut)

--- a/xbmc/cores/dvdplayer/Edl.h
+++ b/xbmc/cores/dvdplayer/Edl.h
@@ -74,6 +74,7 @@ private:
   bool ReadComskip(const CStdString& strMovie, const float fFramesPerSecond);
   bool ReadVideoReDo(const CStdString& strMovie);
   bool ReadBeyondTV(const CStdString& strMovie);
+  bool ReadPvr(const CStdString& strMovie);
   bool ReadMythCommBreakList(const CStdString& strMovie, const float fFramesPerSecond);
   bool ReadMythCutList(const CStdString& strMovie, const float fFramesPerSecond);
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -699,6 +699,40 @@ int CPVRClient::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
   return iReturn;
 }
 
+std::vector<PVR_EDL_ENTRY> CPVRClient::GetRecordingEdl(const CPVRRecording &recording)
+{
+  std::vector<PVR_EDL_ENTRY> edl;
+  if (!m_bReadyToUse)
+    return edl;
+
+  if (!m_addonCapabilities.bSupportsRecordingEdl)
+    return edl;
+
+  try
+  {
+    PVR_RECORDING tag;
+    WriteClientRecordingInfo(recording, tag);
+
+    PVR_EDL_ENTRY edl_array[PVR_ADDON_EDL_LENGTH];
+    int size = PVR_ADDON_EDL_LENGTH;
+    PVR_ERROR retval = m_pStruct->GetRecordingEdl(tag, edl_array, &size);
+    if (retval == PVR_ERROR_NO_ERROR)
+    {
+      edl.reserve(size);
+      for (int i = 0; i < size; ++i)
+      {
+        edl.push_back(edl_array[i]);
+      }
+    }
+  }
+  catch (exception &e)
+  {
+    LogException(e, __FUNCTION__);
+  }
+
+  return edl;
+}
+
 int CPVRClient::GetTimersAmount(void)
 {
   int iReturn(-EINVAL);
@@ -1154,6 +1188,11 @@ bool CPVRClient::SupportsRecordingFolders(void) const
 bool CPVRClient::SupportsRecordingPlayCount(void) const
 {
   return m_addonCapabilities.bSupportsRecordingPlayCount;
+}
+
+bool CPVRClient::SupportsRecordingEdl(void) const
+{
+  return m_addonCapabilities.bSupportsRecordingEdl;
 }
 
 bool CPVRClient::SupportsTimers(void) const

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -267,6 +267,13 @@ namespace PVR
     */
     int GetRecordingLastPlayedPosition(const CPVRRecording &recording);
 
+    /*!
+    * @brief Retrieve the edit decision list (EDL) from the backend.
+    * @param recording The recording.
+    * @return The edit decision list (empty on error).
+    */
+    std::vector<PVR_EDL_ENTRY> GetRecordingEdl(const CPVRRecording &recording);
+
     //@}
     /** @name PVR timer methods */
     //@{
@@ -460,6 +467,7 @@ namespace PVR
     bool SupportsRecordings(void) const;
     bool SupportsRecordingFolders(void) const;
     bool SupportsRecordingPlayCount(void) const;
+    bool SupportsRecordingEdl(void) const;
     bool SupportsTimers(void) const;
     bool SupportsTV(void) const;
     bool HandlesDemuxing(void) const;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -531,6 +531,17 @@ bool CPVRClients::SetRecordingPlayCount(const CPVRRecording &recording, int coun
   return *error == PVR_ERROR_NO_ERROR;
 }
 
+std::vector<PVR_EDL_ENTRY> CPVRClients::GetRecordingEdl(const CPVRRecording &recording)
+{
+  PVR_CLIENT client;
+  if (GetConnectedClient(recording.m_iClientId, client) && client->SupportsRecordingEdl())
+    return client->GetRecordingEdl(recording);
+  else
+    CLog::Log(LOGERROR, "PVR - %s - client %d does not support getting Edl", __FUNCTION__, recording.m_iClientId);
+
+  return std::vector<PVR_EDL_ENTRY>();
+}
+
 bool CPVRClients::IsRecordingOnPlayingChannel(void) const
 {
   CPVRChannelPtr currentChannel;
@@ -1218,6 +1229,12 @@ bool CPVRClients::SupportsRecordingPlayCount(int iClientId) const
 {
   PVR_CLIENT client;
   return GetConnectedClient(iClientId, client) && client->SupportsRecordingPlayCount();
+}
+
+bool CPVRClients::SupportsRecordingEdl(int iClientId) const
+{
+  PVR_CLIENT client;
+  return GetConnectedClient(iClientId, client) && client->SupportsRecordingEdl();
 }
 
 bool CPVRClients::SupportsTimers(int iClientId) const

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -427,6 +427,13 @@ namespace PVR
     int GetRecordingLastPlayedPosition(const CPVRRecording &recording);
 
     /*!
+    * @brief Retrieve the edit decision list (EDL) from the backend.
+    * @param recording The recording.
+    * @return The edit decision list (empty on error).
+    */
+    std::vector<PVR_EDL_ENTRY> GetRecordingEdl(const CPVRRecording &recording);
+
+    /*!
      * @brief Check whether there is an active recording on the current channel.
      * @return True if there is, false otherwise.
      */
@@ -546,6 +553,7 @@ namespace PVR
     bool SupportsRadio(int iClientId) const;
     bool SupportsRecordingFolders(int iClientId) const;
     bool SupportsRecordingPlayCount(int iClientId) const;
+    bool SupportsRecordingEdl(int iClientId) const;
     bool SupportsTimers(int iClientId) const;
     bool SupportsTV(int iClientId) const;
     bool HandlesDemuxing(int iClientId) const;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -212,6 +212,15 @@ int CPVRRecording::GetLastPlayedPosition() const
   return rc;
 }
 
+std::vector<PVR_EDL_ENTRY> CPVRRecording::GetEdl() const
+{
+  if (g_PVRClients->SupportsRecordingEdl(m_iClientId))
+  {
+    return g_PVRClients->GetRecordingEdl(*this);
+  }
+  return std::vector<PVR_EDL_ENTRY>();
+}
+
 void CPVRRecording::DisplayError(PVR_ERROR err) const
 {
   if (err == PVR_ERROR_SERVER_ERROR)

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -114,6 +114,12 @@ namespace PVR
     int GetLastPlayedPosition() const;
 
     /*!
+     * @brief Retrieve the edit decision list (EDL) of a recording on the backend.
+     * @return The edit decision list (empty on error)
+     */
+    std::vector<PVR_EDL_ENTRY> GetEdl() const;
+
+    /*!
      * @brief Get the resume point and play count from the server (if supported) or the database
      * @param bookmark The bookmark to update
      */


### PR DESCRIPTION
@dteirney: This will be probably of interest to you

This PR extends the PVR API with the function GetRecordingEdl to retreive edit decision lists from the backend.

In addition DVDPlayer's EDL class has been adapted to read the EDL from the backend for recordings.

A sample implementation for the MythTV PVR addon can be found here:
https://github.com/fetzerch/xbmc-pvr-addons/commit/3c6738a9837636b1b649fee7a87778a9f576c250
