### PR TITLE
 [pvr] Update internal naming of PVR items for better library integration (updated)

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2919,6 +2919,15 @@ CStdString CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
   if (IsLabelPreformated())
     return GetLabel();
 
+  if (m_pvrRecordingInfoTag)
+    return m_pvrRecordingInfoTag->m_strTitle;
+  else if (CUtil::IsTVRecording(m_strPath))
+  {
+    CStdString title = CPVRRecording::GetTitleFromURL(m_strPath);
+    if (!title.IsEmpty())
+      return title;
+  }
+
   CStdString strMovieName = GetBaseMoviePath(bUseFolderNames);
 
   if (URIUtils::IsStack(strMovieName))

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -24,6 +24,8 @@
 #include "PVRRecordings.h"
 #include "pvr/addons/PVRClients.h"
 #include "utils/StringUtils.h"
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
 
 #include "epg/Epg.h"
 
@@ -241,13 +243,15 @@ void CPVRRecording::UpdatePath(void)
   {
     CStdString strTitle(m_strTitle);
     CStdString strDatetime(m_recordingTime.GetAsSaveString());
-    strTitle.Replace('/','-');
-    strTitle.Remove('?');
+    CStdString strDirectory;
+    CStdString strChannel;
+    strTitle.Replace('/',' ');
 
-    if (m_strDirectory != StringUtils::EmptyString)
-      m_strFileNameAndPath.Format("pvr://recordings/%s/%s/%s.pvr", m_strDirectory.c_str(), strDatetime.c_str(), strTitle.c_str());
-    else
-      m_strFileNameAndPath.Format("pvr://recordings/%s/%s.pvr", strDatetime.c_str(), strTitle.c_str());
+    if (!m_strDirectory.IsEmpty())
+      strDirectory.Format("%s/", m_strDirectory.c_str());
+    if (!m_strChannelName.IsEmpty())
+      strChannel.Format(" (%s)", m_strChannelName.c_str());
+    m_strFileNameAndPath.Format("pvr://recordings/%s%s, TV%s, %s.pvr", strDirectory.c_str(), strTitle.c_str(), strChannel.c_str(), strDatetime.c_str());
   }
 }
 
@@ -257,4 +261,16 @@ const CDateTime &CPVRRecording::RecordingTimeAsLocalTime(void) const
   tmp.SetFromUTCDateTime(m_recordingTime);
 
   return tmp;
+}
+
+CStdString CPVRRecording::GetTitleFromURL(const CStdString &url)
+{
+  CRegExp reg(true);
+  if (reg.RegComp("pvr://recordings/(.*/)*(.*), TV( \\(.*\\))?, "
+      "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9].pvr"))
+  {
+    if (reg.RegFind(url.c_str()) >= 0)
+      return reg.GetReplaceString("\\2");
+  }
+  return StringUtils::EmptyString;
 }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -125,6 +125,13 @@ namespace PVR
     void SetRecordingTimeFromUTC(CDateTime &recordingTime) { m_recordingTime = recordingTime; }
     void SetRecordingTimeFromLocalTime(CDateTime &recordingTime) { m_recordingTime = recordingTime.GetAsUTCDateTime(); }
 
+    /*!
+     * @brief Retrieve the recording title from the URL path
+     * @param url the URL for the recording
+     * @return Title of the recording
+     */
+    static CStdString GetTitleFromURL(const CStdString &url);
+
   private:
     CDateTime m_recordingTime; /*!< start time of the recording */
 


### PR DESCRIPTION
Change the internal path of PVR items to the following style
<code>pvr://recordings/<path>/<title>, TV (<channel>), <date>_<time>.pvr</code>

Updated version of #1728, see discussion there.
