### PR TITLE
[rbp] Speed, quality and reliability fixes for images.

### DIFF
--- a/xbmc/cores/omxplayer/OMXImage.h
+++ b/xbmc/cores/omxplayer/OMXImage.h
@@ -46,7 +46,6 @@ public:
   // Required overrides
   void Close(void);
   bool ClampLimits(unsigned int &width, unsigned int &height);
-  void SetHardwareSizeLimits();
   bool ReadFile(const CStdString& inputFile);
   bool IsProgressive() { return m_progressive; };
   bool IsAlpha() { return m_alpha; };
@@ -60,7 +59,7 @@ public:
   unsigned long GetImageSize() { return m_image_size; };
   OMX_IMAGE_CODINGTYPE GetCompressionFormat() { return m_omx_image.eCompressionFormat; };
   bool Decode(unsigned int width, unsigned int height);
-  bool Encode(unsigned char *buffer, int size, unsigned int width, unsigned int height);
+  bool Encode(unsigned char *buffer, int size, unsigned int width, unsigned int height, unsigned int pitch);
   unsigned int GetDecodedWidth() { return (unsigned int)m_decoded_format.format.image.nFrameWidth; };
   unsigned int GetDecodedHeight() { return (unsigned int)m_decoded_format.format.image.nFrameHeight; };
   unsigned int GetDecodedStride() { return (unsigned int)m_decoded_format.format.image.nStride; };
@@ -80,6 +79,7 @@ public:
   bool CreateThumbnailFromSurface(unsigned char* buffer, unsigned int width, unsigned int height, 
       unsigned int format, unsigned int pitch, const CStdString& destFile);
 protected:
+  bool HandlePortSettingChange(unsigned int resize_width, unsigned int resize_height);
   uint8_t           *m_image_buffer;
   bool              m_is_open;
   unsigned long     m_image_size;

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -226,13 +226,7 @@ bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned 
 
     if(omx_image.ReadFile(texturePath))
     {
-      unsigned int width = omx_image.GetWidth();
-      unsigned int height = omx_image.GetHeight();
-
-      // We restict textures to the maximum size. This is a workaround for the PI memory limitation
-      omx_image.ClampLimits(width, height);
-
-      if(omx_image.Decode(width, height))
+      if(omx_image.Decode(omx_image.GetWidth(), omx_image.GetHeight()))
       {
         Allocate(omx_image.GetDecodedWidth(), omx_image.GetDecodedHeight(), XB_FMT_A8R8G8B8);
 
@@ -286,6 +280,8 @@ bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned 
         omx_image.Close();
       }
     }
+    // this limits the sizes of jpegs we failed to decode
+    omx_image.ClampLimits(maxWidth, maxHeight);
   }
 #endif
   if (URIUtils::GetExtension(texturePath).Equals(".dds"))

--- a/xbmc/linux/OMXCore.cpp
+++ b/xbmc/linux/OMXCore.cpp
@@ -998,7 +998,8 @@ OMX_ERRORTYPE COMXCoreComponent::WaitForEvent(OMX_EVENTTYPE eventType, long time
     int retcode = pthread_cond_timedwait(&m_omx_event_cond, &m_omx_event_mutex, &endtime);
     if (retcode != 0) 
     {
-      CLog::Log(LOGERROR, "COMXCoreComponent::WaitForEvent %s wait event 0x%08x timeout %ld\n",
+      if (timeout > 0)
+        CLog::Log(LOGERROR, "COMXCoreComponent::WaitForEvent %s wait event 0x%08x timeout %ld\n",
                           m_componentName.c_str(), (int)eventType, timeout);
       pthread_mutex_unlock(&m_omx_event_mutex);
       return OMX_ErrorMax;


### PR DESCRIPTION
fixes a couple of bugs in the jpeg header parsing, which would sometimes get incorrect dimensions or no dimension.
It avoids the resize to a multiple of 16 of decoded jpegs which causes blurring and subtle aspect ratio erros.
It avoids a pitch mangling alloc and copy on the jpeg encode path.
The jpeg decoder now handles the port settings changes event properly which can fix an OMX error case.
An updated start.elf is required which supports the non-multiple of 16 pitches in openmax.
