### PR TITLE
recentlyadded: make sure to show the same list independent of the entry point

### DIFF
--- a/system/library/video/recentlyaddedepisodes.xml
+++ b/system/library/video/recentlyaddedepisodes.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="11" type="filter" visible="Library.HasContent(TVShows)">
+<node order="11" type="folder" visible="Library.HasContent(TVShows)">
   <label>20387</label>
   <icon>DefaultRecentlyAddedEpisodes.png</icon>
-  <content>episodes</content>
-  <order direction="descending">dateadded</order>
-  <limit>25</limit>
+  <path>videodb://5</path>
 </node>

--- a/system/library/video/recentlyaddedmovies.xml
+++ b/system/library/video/recentlyaddedmovies.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="10" type="filter" visible="Library.HasContent(Movies)">
+<node order="10" type="folder" visible="Library.HasContent(Movies)">
   <label>20386</label>
   <icon>DefaultRecentlyAddedMovies.png</icon>
-  <content>movies</content>
-  <order direction="descending">dateadded</order>
-  <limit>25</limit>
+  <path>videodb://4</path>
 </node>

--- a/system/library/video/recentlyaddedmusicvideos.xml
+++ b/system/library/video/recentlyaddedmusicvideos.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="12" type="filter" visible="Library.HasContent(MusicVideos)">
+<node order="12" type="folder" visible="Library.HasContent(MusicVideos)">
   <label>20390</label>
   <icon>DefaultRecentlyAddedMusicVideos.png</icon>
-  <content>musicvideos</content>
-  <order direction="descending">dateadded</order>
-  <limit>25</limit>
+  <path>videodb://6</path>
 </node>

--- a/system/library/video_flat/recentlyaddedepisodes.xml
+++ b/system/library/video_flat/recentlyaddedepisodes.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="11" type="filter" visible="Library.HasContent(TVShows)">
+<node order="11" type="folder" visible="Library.HasContent(TVShows)">
   <label>20387</label>
   <icon>DefaultRecentlyAddedEpisodes.png</icon>
-  <content>episodes</content>
-  <order direction="descending">dateadded</order>
-  <limit>25</limit>
+  <path>videodb://5</path>
 </node>

--- a/system/library/video_flat/recentlyaddedmovies.xml
+++ b/system/library/video_flat/recentlyaddedmovies.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="10" type="filter" visible="Library.HasContent(Movies)">
+<node order="10" type="folder" visible="Library.HasContent(Movies)">
   <label>20386</label>
   <icon>DefaultRecentlyAddedMovies.png</icon>
-  <content>movies</content>
-  <order direction="descending">dateadded</order>
-  <limit>25</limit>
+  <path>videodb://4</path>
 </node>

--- a/system/library/video_flat/recentlyaddedmusicvideos.xml
+++ b/system/library/video_flat/recentlyaddedmusicvideos.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="12" type="filter" visible="Library.HasContent(MusicVideos)">
+<node order="12" type="folder" visible="Library.HasContent(MusicVideos)">
   <label>20390</label>
   <icon>DefaultRecentlyAddedMusicVideos.png</icon>
-  <content>musicvideos</content>
-  <order direction="descending">dateadded</order>
-  <limit>25</limit>
+  <path>videodb://6</path>
 </node>

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -209,6 +209,7 @@ void CAdvancedSettings::Initialize()
 
   m_bVideoLibraryHideAllItems = false;
   m_bVideoLibraryAllItemsOnBottom = false;
+  m_iVideoLibraryRecentlyAddedItems = 25;
   m_bVideoLibraryHideEmptySeries = false;
   m_bVideoLibraryCleanOnUpdate = false;
   m_bVideoLibraryExportAutoThumbs = false;
@@ -641,6 +642,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   {
     XMLUtils::GetBoolean(pElement, "hideallitems", m_bVideoLibraryHideAllItems);
     XMLUtils::GetBoolean(pElement, "allitemsonbottom", m_bVideoLibraryAllItemsOnBottom);
+    XMLUtils::GetInt(pElement, "recentlyaddeditems", m_iVideoLibraryRecentlyAddedItems, 1, INT_MAX);
     XMLUtils::GetBoolean(pElement, "hideemptyseries", m_bVideoLibraryHideEmptySeries);
     XMLUtils::GetBoolean(pElement, "cleanonupdate", m_bVideoLibraryCleanOnUpdate);
     XMLUtils::GetString(pElement, "itemseparator", m_videoItemSeparator);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -245,6 +245,7 @@ class CAdvancedSettings
 
     bool m_bVideoLibraryHideAllItems;
     bool m_bVideoLibraryAllItemsOnBottom;
+    int m_iVideoLibraryRecentlyAddedItems;
     bool m_bVideoLibraryHideEmptySeries;
     bool m_bVideoLibraryCleanOnUpdate;
     bool m_bVideoLibraryExportAutoThumbs;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6362,7 +6362,7 @@ bool CVideoDatabase::GetRecentlyAddedMoviesNav(const CStdString& strBaseDir, CFi
 {
   Filter filter;
   filter.order = "dateAdded desc, idMovie desc";
-  filter.limit = PrepareSQL("%u", limit ? limit : 25);
+  filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
   return GetMoviesByWhere(strBaseDir, filter, items);
 }
 
@@ -6370,7 +6370,7 @@ bool CVideoDatabase::GetRecentlyAddedEpisodesNav(const CStdString& strBaseDir, C
 {
   Filter filter;
   filter.order = "dateAdded desc, idEpisode desc";
-  filter.limit = PrepareSQL("%u", limit ? limit : 25);
+  filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
   return GetEpisodesByWhere(strBaseDir, filter, items, false);
 }
 
@@ -6378,7 +6378,7 @@ bool CVideoDatabase::GetRecentlyAddedMusicVideosNav(const CStdString& strBaseDir
 {
   Filter filter;
   filter.order = "dateAdded desc, idMVideo desc";
-  filter.limit = PrepareSQL("%u", limit ? limit : 25);
+  filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
   return GetMusicVideosByWhere(strBaseDir, filter, items);
 }
 


### PR DESCRIPTION
Right now there are two ways to get a list of recently added items.
- Through a videodb:// URL (e.g. videodb://4/ for movies) and ultimately through CVideoDatabase::GetRecentlyAddedFoo() which is just an SQL query with an ORDER BY and a LIMIT clause.
- Through Videos -> Library -> Recently Added Foo which depends on the custom videolibrary nodes available as xml files in system/library/video*/recentlyaddedfoo.xml. Currently these are implemented as smartplaylists with a limit and a sort rule.

The problem is that depending on whether "Group movies into sets" is enabled or not, these two approaches result in different resulting lists (the videodb:// URL entry point doesn't group into sets whereas the smartplaylist does depending on the GUI setting). To make the behaviour of Recently Added listings the same independent of the entry point we need to revert part of 3fc04bc4a273b9acf05fa8e6f6e4fc001fd1f8c8 (to get the "recentlyaddeditems" advancedsetting back) and f9cc7405138191075f267b100c27082f5efe7480.

This makes #1692 obsolete for now as it becomes a pure new feature and not a fix for the current inconsistency.
