### PR TITLE
jsonrpc: fix "type" being set to "song" for non-music items

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -283,12 +283,11 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
       {
         if (item->HasPVRChannelInfoTag())
           object["type"] = "channel";
-        else if (item->HasMusicInfoTag())
+        else if (item->HasMusicInfoTag() && !item->GetMusicInfoTag()->GetType().empty())
         {
-          if (item->m_bIsFolder && item->IsAlbum())
-            object["type"] = "album";
-          else
-            object["type"] = "song";
+          std::string type = item->GetMusicInfoTag()->GetType();
+          if (type == "album" || type == "song")
+            object["type"] = type;
         }
         else if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_type.empty())
         {


### PR DESCRIPTION
Logical following of :

https://github.com/xbmc/xbmc/commit/69f4aca95ff53915dab44bffb3ac73a7ab272d36

But for music this time
