### PR TITLE
FIX: regenerate auto-thumb if not present

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -250,30 +250,38 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
   }
 
   // thumbnails are special-cased due to auto-generation
-  if (!pItem->HasArt("thumb") && !pItem->m_bIsFolder && pItem->IsVideo())
+  if (!pItem->m_bIsFolder && pItem->IsVideo())
   {
-    // create unique thumb for auto generated thumbs
-    CStdString thumbURL = GetEmbeddedThumbURL(*pItem);
-    if (CTextureCache::Get().HasCachedImage(thumbURL))
-    {
-      CTextureCache::Get().BackgroundCacheImage(thumbURL);
-      pItem->SetProperty("HasAutoThumb", true);
-      pItem->SetProperty("AutoThumbImage", thumbURL);
-      pItem->SetArt("thumb", thumbURL);
-    }
-    else if (g_guiSettings.GetBool("myvideos.extractthumb") &&
-             g_guiSettings.GetBool("myvideos.extractflags"))
-    {
-      CFileItem item(*pItem);
-      CStdString path(item.GetPath());
-      if (URIUtils::IsInRAR(item.GetPath()))
-        SetupRarOptions(item,path);
+    // An auto-generated thumb may have been cached on a different device - check we have it here 
+    CStdString url = pItem->GetArt("thumb");
+    if (url.compare(0, 14, "image://video@") == 0 && !CTextureCache::Get().HasCachedImage(url))
+      pItem->SetArt("thumb", "");
 
-      CThumbExtractor* extract = new CThumbExtractor(item, path, true, thumbURL);
-      AddJob(extract);
+    if (!pItem->HasArt("thumb"))
+    {
+      // create unique thumb for auto generated thumbs
+      CStdString thumbURL = GetEmbeddedThumbURL(*pItem);
+      if (CTextureCache::Get().HasCachedImage(thumbURL))
+      {
+        CTextureCache::Get().BackgroundCacheImage(thumbURL);
+        pItem->SetProperty("HasAutoThumb", true);
+        pItem->SetProperty("AutoThumbImage", thumbURL);
+        pItem->SetArt("thumb", thumbURL);
+      }
+      else if (g_guiSettings.GetBool("myvideos.extractthumb") &&
+        g_guiSettings.GetBool("myvideos.extractflags"))
+      {
+        CFileItem item(*pItem);
+        CStdString path(item.GetPath());
+        if (URIUtils::IsInRAR(item.GetPath()))
+          SetupRarOptions(item,path);
 
-      m_database->Close();
-      return true;
+        CThumbExtractor* extract = new CThumbExtractor(item, path, true, thumbURL);
+        AddJob(extract);
+
+        m_database->Close();
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
This is related to http://forum.xbmc.org/showthread.php?tid=142395&page=2 and https://github.com/xbmc/xbmc/commit/086c0eb90348771767587d3adb49c82bc9571327.

On a multi-homed environment, the above fix is problematic. You ought to regenerate the auto-generated thumbs if not present, presumably because they were generated on another system.
