### PR TITLE
[rbp] Request an extra picture when enabling deinterlace

### DIFF
--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -420,6 +420,21 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool deinterlace, b
     return false;
   }
 
+  if (m_deinterlace)
+  {
+    // the deinterlace component requires 3 additional video buffers in addition to the DPB (this is normally 2).
+    OMX_PARAM_U32TYPE extra_buffers;
+    OMX_INIT_STRUCTURE(extra_buffers);
+    extra_buffers.nU32 = 3;
+
+    omx_err = m_omx_decoder.SetParameter(OMX_IndexParamBrcmExtraBuffers, &extra_buffers);
+    if(omx_err != OMX_ErrorNone)
+    {
+      CLog::Log(LOGERROR, "COMXVideo::Open error OMX_IndexParamBrcmExtraBuffers omx_err(0x%08x)\n", omx_err);
+      return false;
+    }
+  }
+
   if(NaluFormatStartCodes(hints.codec, m_extradata, m_extrasize))
   {
     OMX_NALSTREAMFORMATTYPE nalStreamFormat;


### PR DESCRIPTION
Request an extra picture buffer when enabling deinterlace which can avoid a decoder hang
It fixes the "Doctors" chip from here:
https://www.dropbox.com/s/8yx0aafaxaktumg/1080iTSSamples.zip
