### PR TITLE
pvr: fix pause seek for recordings which use pvr input stream

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -541,7 +541,7 @@ bool CPVRClients::CanPauseStream(void) const
 
   if (GetPlayingClient(client))
   {
-    return client->CanPauseStream();
+    return m_bIsPlayingRecording || client->CanPauseStream();
   }
 
   return false;
@@ -553,7 +553,7 @@ bool CPVRClients::CanSeekStream(void) const
 
   if (GetPlayingClient(client))
   {
-    return client->CanSeekStream();
+    return m_bIsPlayingRecording || client->CanSeekStream();
   }
 
   return false;


### PR DESCRIPTION
recordings are always navigable. This broke with introduction of the "timeshift" methods 
