### PR TITLE
[pvr] don't start PVRmanager on initialization if login screen is used, ...

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1333,8 +1333,6 @@ bool CApplication::Initialize()
         return false;
     }
 
-    StartPVRManager();
-
     if (g_advancedSettings.m_splashImage)
       SAFE_DELETE(m_splash);
 
@@ -1354,6 +1352,7 @@ bool CApplication::Initialize()
       CJSONRPC::Initialize();
 #endif
       ADDON::CAddonMgr::Get().StartServices(false);
+      StartPVRManager();
       g_windowManager.ActivateWindow(g_SkinInfo->GetFirstWindow());
     }
 


### PR DESCRIPTION
...because loading a profile will trigger a second startup of the PVRmanger. Thus first startup is wasted time/resources and sometimes conflicts with the second startup if first startup is still in progress, or user selects a profile without PVR or a different PVR backend.
