### PR TITLE
make ffmpeg demuxer observe pmt changes

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -104,7 +104,10 @@ public:
     flags = FLAG_NONE;
   }
 
-  virtual ~CDemuxStream() {}
+  virtual ~CDemuxStream()
+  {
+    delete [] ExtraData;
+  }
 
   virtual void GetStreamInfo(std::string& strInfo)
   {
@@ -127,7 +130,7 @@ public:
 
   int iDuration; // in mseconds
   void* pPrivate; // private pointer for the demuxer
-  void* ExtraData; // extra data for codec to use
+  uint8_t*     ExtraData; // extra data for codec to use
   unsigned int ExtraSize; // size of extra data
 
   char language[4]; // ISO 639 3-letter language code (empty string if undefined)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -102,6 +102,7 @@ public:
     disabled = false;
     changes = 0;
     flags = FLAG_NONE;
+    orig_type = 0;
   }
 
   virtual ~CDemuxStream()
@@ -137,6 +138,8 @@ public:
   bool disabled; // set when stream is disabled. (when no decoder exists)
 
   int  changes; // increment on change which player may need to know about
+
+  int orig_type; // type of origininal source
 
   enum EFlags
   { FLAG_NONE     = 0x0000 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1086,10 +1086,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
     // since dvdplayer uses the pointer to know
     // if something changed in the demuxer
     if (old)
-    {
-      if( old->ExtraData ) delete[] (BYTE*)(old->ExtraData);
       delete old;
-    }
 
     // generic stuff
     if (pStream->duration != (int64_t)AV_NOPTS_VALUE) m_streams[iId]->iDuration = (int)((pStream->duration / AV_TIME_BASE) & 0xFFFFFFFF);

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -937,6 +937,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
   AVStream* pStream = m_pFormatContext->streams[iId];
   if (pStream)
   {
+    CDemuxStream* stream = NULL;
     CDemuxStream* old = GetStream(iId);
 
     switch (pStream->codec->codec_type)
@@ -944,7 +945,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
     case AVMEDIA_TYPE_AUDIO:
       {
         CDemuxStreamAudioFFmpeg* st = new CDemuxStreamAudioFFmpeg(this, pStream);
-        m_streams[iId] = st;
+        stream = st;
         st->iChannels = pStream->codec->channels;
         st->iSampleRate = pStream->codec->sample_rate;
         st->iBlockAlign = pStream->codec->block_align;
@@ -959,7 +960,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
     case AVMEDIA_TYPE_VIDEO:
       {
         CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(this, pStream);
-        m_streams[iId] = st;
+        stream = st;
         if(strcmp(m_pFormatContext->iformat->name, "flv") == 0)
           st->bVFR = true;
         else
@@ -1023,8 +1024,8 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
       }
     case AVMEDIA_TYPE_DATA:
       {
-        m_streams[iId] = new CDemuxStream();
-        m_streams[iId]->type = STREAM_DATA;
+        stream = new CDemuxStream();
+        stream->type = STREAM_DATA;
         break;
       }
     case AVMEDIA_TYPE_SUBTITLE:
@@ -1032,14 +1033,14 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
         if (pStream->codec->codec_id == CODEC_ID_DVB_TELETEXT && g_guiSettings.GetBool("videoplayer.teletextenabled"))
         {
           CDemuxStreamTeletext* st = new CDemuxStreamTeletext();
-          m_streams[iId] = st;
-          m_streams[iId]->type = STREAM_TELETEXT;
+          stream = st;
+          stream->type = STREAM_TELETEXT;
           break;
         }
         else
         {
           CDemuxStreamSubtitleFFmpeg* st = new CDemuxStreamSubtitleFFmpeg(this, pStream);
-          m_streams[iId] = st;
+          stream = st;
 	    
           if(m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0))
             st->m_description = m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0)->value;
@@ -1070,14 +1071,14 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
             file.Close();
           }
         }
-        m_streams[iId] = new CDemuxStream();
-        m_streams[iId]->type = STREAM_NONE;
+        stream = new CDemuxStream();
+        stream->type = STREAM_NONE;
         break;
       }
     default:
       {
-        m_streams[iId] = new CDemuxStream();
-        m_streams[iId]->type = STREAM_NONE;
+        stream = new CDemuxStream();
+        stream->type = STREAM_NONE;
         break;
       }
     }
@@ -1089,9 +1090,9 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
       delete old;
 
     // generic stuff
-    if (pStream->duration != (int64_t)AV_NOPTS_VALUE) m_streams[iId]->iDuration = (int)((pStream->duration / AV_TIME_BASE) & 0xFFFFFFFF);
+    if (pStream->duration != (int64_t)AV_NOPTS_VALUE)
+      stream->iDuration = (int)((pStream->duration / AV_TIME_BASE) & 0xFFFFFFFF);
 
-    CDemuxStream* stream = GetStream(iId);
     stream->codec = pStream->codec->codec_id;
     stream->codec_fourcc = pStream->codec->codec_tag;
     stream->profile = pStream->codec->profile;
@@ -1146,6 +1147,8 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
     }
     else
       stream->iPhysicalId = pStream->id;
+
+    m_streams[iId] = stream;
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -122,12 +122,15 @@ protected:
 
   int ReadFrame(AVPacket *packet);
   void AddStream(int iId);
+  void AddStream(int iId, CDemuxStream* stream);
+  CDemuxStream* GetStreamInternal(int iStreamId);
 
   double ConvertTimestamp(int64_t pts, int den, int num);
   void UpdateCurrentPTS();
 
   CCriticalSection m_critSection;
   std::map<int, CDemuxStream*> m_streams;
+  std::vector<std::map<int, CDemuxStream*>::iterator> m_stream_index;
 
   AVIOContext* m_ioContext;
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -28,6 +28,8 @@
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 
+#include <map>
+
 class CDVDDemuxFFmpeg;
 
 class CDemuxStreamVideoFFmpeg
@@ -125,8 +127,7 @@ protected:
   void UpdateCurrentPTS();
 
   CCriticalSection m_critSection;
-  #define MAX_STREAMS 100
-  CDemuxStream* m_streams[MAX_STREAMS]; // maximum number of streams that ffmpeg can handle
+  std::map<int, CDemuxStream*> m_streams;
 
   AVIOContext* m_ioContext;
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -124,9 +124,12 @@ protected:
   void AddStream(int iId);
   void AddStream(int iId, CDemuxStream* stream);
   CDemuxStream* GetStreamInternal(int iStreamId);
+  void CreateStreams(unsigned int program = UINT_MAX);
+  void DisposeStreams();
 
   double ConvertTimestamp(int64_t pts, int den, int num);
   void UpdateCurrentPTS();
+  bool IsProgramChange();
 
   CCriticalSection m_critSection;
   std::map<int, CDemuxStream*> m_streams;
@@ -145,5 +148,13 @@ protected:
   unsigned m_program;
   XbmcThreads::EndTime  m_timeout;
 
+  // Due to limitations of ffmpeg, we only can detect a program change
+  // with a packet. This struct saves the packet for the next read and
+  // signals STREAMCHANGE to player
+  struct
+  {
+    AVPacket pkt;       // packet ffmpeg returned
+    int      result;    // result from av_read_packet
+  }m_pkt;
 };
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -136,12 +136,7 @@ void CDVDDemuxPVRClient::Dispose()
 {
   for (int i = 0; i < MAX_STREAMS; i++)
   {
-    if (m_streams[i])
-    {
-      if (m_streams[i]->ExtraData)
-        delete[] (BYTE*)(m_streams[i]->ExtraData);
-      delete m_streams[i];
-    }
+    delete m_streams[i];
     m_streams[i] = NULL;
   }
 
@@ -154,11 +149,6 @@ void CDVDDemuxPVRClient::DisposeStream(int iStreamId)
 {
   if (iStreamId < 0 || iStreamId >= MAX_STREAMS)
     return;
-  if (m_streams[iStreamId]->ExtraData)
-  {
-    delete[] (uint8_t*)m_streams[iStreamId]->ExtraData;
-    m_streams[iStreamId]->ExtraData = NULL;
-  }
   delete m_streams[iStreamId];
   m_streams[iStreamId] = NULL;
 }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -28,6 +28,8 @@
 #include "DVDClock.h"
 #include "DVDSubtitles/DVDSubtitleStream.h"
 
+#include <string.h>
+
 using namespace std;
 
 CDVDDemuxVobsub::CDVDDemuxVobsub()
@@ -112,7 +114,8 @@ bool CDVDDemuxVobsub::Open(const string& filename, const string& subfilename)
   for(unsigned i=0;i<m_Streams.size();i++)
   {
     m_Streams[i]->ExtraSize = state.extra.length()+1;
-    m_Streams[i]->ExtraData = strdup(state.extra.c_str());
+    m_Streams[i]->ExtraData = new uint8_t[m_Streams[i]->ExtraSize];
+    strcpy((char*)m_Streams[i]->ExtraData, state.extra.c_str());
   }
 
   return true;


### PR DESCRIPTION
@elupus
I have borrowed the idea of registering a callback for pmt changes from mythtv. Streams which are not in the current pmt are set inactive in order to be ignored by OpenDefaultStreams.
I tested with vdr recordings which have a pat/pmt before every GOP. pvr clients which use this demuxer need to send  pat/pmt at least when there are changes.
