### PR TITLE
Ignore /boot partition while getting a list of local media sources

### DIFF
--- a/xbmc/storage/linux/UDisksProvider.cpp
+++ b/xbmc/storage/linux/UDisksProvider.cpp
@@ -154,7 +154,8 @@ CMediaSource CUDiskDevice::ToMediaShare()
 
 bool CUDiskDevice::IsApproved()
 {
-  return (m_isFileSystem && m_isMounted && m_UDI.length() > 0 && (m_FileSystem.length() > 0 && !m_FileSystem.Equals("swap")) && !m_MountPath.Equals("/")) || m_isOptical;
+  return (m_isFileSystem && m_isMounted && m_UDI.length() > 0 && (m_FileSystem.length() > 0 && !m_FileSystem.Equals("swap")) 
+      && !m_MountPath.Equals("/") && !m_MountPath.Equals("/boot")) || m_isOptical;
 }
 
 #define BOOL2SZ(b) ((b) ? "true" : "false")


### PR DESCRIPTION
Raspbmc has a /boot partition that shows up in the media sources list as "0.1 GB Drive". This changeset prevents the partition from appearing in the list. I have made the change only for udisks.
