### PR TITLE
Art fallback fixes, and don't save show/album/season art for seasons/songs/episodes

### DIFF
--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -119,24 +119,21 @@ void CGUIListItem::SetArt(const std::string &type, const std::string &url)
   }
 }
 
-void CGUIListItem::SetArt(const ArtMap &art, bool setFallback /* = true */)
+void CGUIListItem::SetArt(const ArtMap &art)
 {
   m_art = art;
-  // ensure that the fallback "thumb" is available
-  if (setFallback && m_art.find("thumb") == m_art.end())
-  {
-    if (HasArt("poster"))
-      m_art["thumb"] = m_art["poster"];
-    else if (HasArt("banner"))
-      m_art["thumb"] = m_art["banner"];
-  }
-  
   SetInvalid();
+}
+
+void CGUIListItem::SetArtFallback(const std::string &from, const std::string &to)
+{
+  m_artFallbacks[from] = to;
 }
 
 void CGUIListItem::ClearArt()
 {
   m_art.clear();
+  m_artFallbacks.clear();
 }
 
 void CGUIListItem::AppendArt(const ArtMap &art)
@@ -150,6 +147,13 @@ std::string CGUIListItem::GetArt(const std::string &type) const
   ArtMap::const_iterator i = m_art.find(type);
   if (i != m_art.end())
     return i->second;
+  i = m_artFallbacks.find(type);
+  if (i != m_artFallbacks.end())
+  {
+    ArtMap::const_iterator j = m_art.find(i->second);
+    if (j != m_art.end())
+      return j->second;
+  }
   return "";
 }
 
@@ -160,8 +164,7 @@ const CGUIListItem::ArtMap &CGUIListItem::GetArt() const
 
 bool CGUIListItem::HasArt(const std::string &type) const
 {
-  ArtMap::const_iterator i = m_art.find(type);
-  return (i != m_art.end() && !i->second.empty());
+  return !GetArt(type).empty();
 }
 
 void CGUIListItem::SetIconImage(const CStdString& strIcon)
@@ -244,6 +247,7 @@ const CGUIListItem& CGUIListItem::operator =(const CGUIListItem& item)
   m_bIsFolder = item.m_bIsFolder;
   m_mapProperties = item.m_mapProperties;
   m_art = item.m_art;
+  m_artFallbacks = item.m_artFallbacks;
   SetInvalid();
   return *this;
 }
@@ -267,6 +271,12 @@ void CGUIListItem::Archive(CArchive &ar)
     }
     ar << (int)m_art.size();
     for (ArtMap::const_iterator i = m_art.begin(); i != m_art.end(); i++)
+    {
+      ar << i->first;
+      ar << i->second;
+    }
+    ar << (int)m_artFallbacks.size();
+    for (ArtMap::const_iterator i = m_artFallbacks.begin(); i != m_artFallbacks.end(); i++)
     {
       ar << i->first;
       ar << i->second;
@@ -302,6 +312,14 @@ void CGUIListItem::Archive(CArchive &ar)
       ar >> key;
       ar >> value;
       m_art.insert(make_pair(key, value));
+    }
+    ar >> mapSize;
+    for (int i = 0; i < mapSize; i++)
+    {
+      std::string key, value;
+      ar >> key;
+      ar >> value;
+      m_artFallbacks.insert(make_pair(key, value));
     }
   }
 }

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -136,10 +136,10 @@ void CGUIListItem::ClearArt()
   m_artFallbacks.clear();
 }
 
-void CGUIListItem::AppendArt(const ArtMap &art)
+void CGUIListItem::AppendArt(const ArtMap &art, const std::string &prefix)
 {
   for (ArtMap::const_iterator i = art.begin(); i != art.end(); ++i)
-    SetArt(i->first, i->second);
+    SetArt(prefix.empty() ? i->first : prefix + '.' + i->first, i->second);
 }
 
 std::string CGUIListItem::GetArt(const std::string &type) const

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -134,6 +134,11 @@ void CGUIListItem::SetArt(const ArtMap &art, bool setFallback /* = true */)
   SetInvalid();
 }
 
+void CGUIListItem::ClearArt()
+{
+  m_art.clear();
+}
+
 void CGUIListItem::AppendArt(const ArtMap &art)
 {
   for (ArtMap::const_iterator i = art.begin(); i != art.end(); ++i)
@@ -320,7 +325,7 @@ void CGUIListItem::Serialize(CVariant &value)
 void CGUIListItem::FreeIcons()
 {
   FreeMemory();
-  m_art.clear();
+  ClearArt();
   m_strIcon = "";
   SetInvalid();
 }

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -96,6 +96,11 @@ public:
    */
   void AppendArt(const ArtMap &art);
 
+  /*! \brief clear art on an item
+   \sa SetArt
+   */
+  void ClearArt();
+
   /*! \brief Get a particular art type for an item
    \param type type of art to fetch.
    \return the art URL, if available, else empty.

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -91,9 +91,10 @@ public:
 
   /*! \brief append artwork to an item
    \param art a type:url map for artwork
+   \param prefix a prefix for the art, if applicable.
    \sa GetArt
    */
-  void AppendArt(const ArtMap &art);
+  void AppendArt(const ArtMap &art, const std::string &prefix = "");
 
   /*! \brief set a fallback image for art
    \param from the type to fallback from

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -85,16 +85,22 @@ public:
 
   /*! \brief set artwork for an item
    \param art a type:url map for artwork
-   \param setFallback whether to set the "thumb" fallback, defaults to true.
    \sa GetArt
    */
-  void SetArt(const ArtMap &art, bool setFallback = true);
+  void SetArt(const ArtMap &art);
 
   /*! \brief append artwork to an item
    \param art a type:url map for artwork
    \sa GetArt
    */
   void AppendArt(const ArtMap &art);
+
+  /*! \brief set a fallback image for art
+   \param from the type to fallback from
+   \param to the type to fallback to
+   \sa SetArt
+   */
+  void SetArtFallback(const std::string &from, const std::string &to);
 
   /*! \brief clear art on an item
    \sa SetArt
@@ -191,6 +197,7 @@ private:
   CStdString m_strLabel;      // text of column1
 
   ArtMap m_art;
+  ArtMap m_artFallbacks;
 };
 #endif
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5151,6 +5151,10 @@ void CMusicDatabase::SetArtForItem(int mediaId, const string &mediaType, const s
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
+    // don't set <foo>.<bar> art types - these are derivative types from parent items
+    if (artType.find('.') != string::npos)
+      return;
+
     CStdString sql = PrepareSQL("SELECT art_id FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
     m_pDS->query(sql.c_str());
     if (!m_pDS->eof())

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -80,7 +80,10 @@ bool CMusicThumbLoader::LoadItem(CFileItem* pItem)
       {
         string fanart = m_database->GetArtForItem(idArtist, "artist", "fanart");
         if (!fanart.empty())
-          pItem->SetArt("fanart", fanart);
+        {
+          pItem->SetArt("artist.fanart", fanart);
+          pItem->SetArtFallback("fanart", "artist.fanart");
+        }
       }
       m_database->Close();
     }
@@ -127,11 +130,18 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
       if (i != m_albumArt.end())
       {
         item.AppendArt(i->second, "album");
+        for (map<string, string>::const_iterator j = i->second.begin(); j != i->second.end(); ++j)
+          item.SetArtFallback(j->first, "album." + j->first);
       }
     }
     if (tag.GetType() == "song" || tag.GetType() == "album")
     { // fanart from the artist
-      item.SetArt("fanart", m_database->GetArtistArtForItem(tag.GetDatabaseId(), tag.GetType(), "fanart"));
+      string fanart = m_database->GetArtistArtForItem(tag.GetDatabaseId(), tag.GetType(), "fanart");
+      if (!fanart.empty())
+      {
+        item.SetArt("artist.fanart", fanart);
+        item.SetArtFallback("fanart", "artist.fanart");
+      }
     }
     m_database->Close();
   }

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -119,13 +119,14 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
     else if (tag.GetType() == "song")
     { // no art for the song, try the album
       ArtCache::const_iterator i = m_albumArt.find(tag.GetAlbumId());
-      if (i != m_albumArt.end())
-        item.SetArt(i->second);
-      else
+      if (i == m_albumArt.end())
       {
-        if (m_database->GetArtForItem(tag.GetAlbumId(), "album", artwork))
-          item.SetArt(artwork);
-        m_albumArt.insert(make_pair(tag.GetAlbumId(), artwork));
+        m_database->GetArtForItem(tag.GetAlbumId(), "album", artwork);
+        i = m_albumArt.insert(make_pair(tag.GetAlbumId(), artwork)).first;
+      }
+      if (i != m_albumArt.end())
+      {
+        item.AppendArt(i->second, "album");
       }
     }
     if (tag.GetType() == "song" || tag.GetType() == "album")

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3568,6 +3568,10 @@ void CVideoDatabase::SetArtForItem(int mediaId, const string &mediaType, const s
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
+    // don't set <foo>.<bar> art types - these are derivative types from parent items
+    if (artType.find('.') != string::npos)
+      return;
+
     CStdString sql = PrepareSQL("SELECT art_id FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
     m_pDS->query(sql.c_str());
     if (!m_pDS->eof())

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1239,7 +1239,7 @@ namespace VIDEO
     for (CGUIListItem::ArtMap::const_iterator i = art.begin(); i != art.end(); ++i)
       CTextureCache::Get().BackgroundCacheImage(i->second);
 
-    pItem->SetArt(art, false); // don't set fallbacks
+    pItem->SetArt(art);
 
     // parent folder to apply the thumb to and to search for local actor thumbs
     CStdString parentDir = GetParentDir(*pItem);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -339,23 +339,15 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     if (!item.HasArt("fanart") && tag.m_iIdShow >= 0)
     {
       ArtCache::const_iterator i = m_showArt.find(tag.m_iIdShow);
-      if (i != m_showArt.end())
-        item.AppendArt(i->second);
-      else
+      if (i == m_showArt.end())
       {
-        map<string, string> showArt, cacheArt;
-        if (m_database->GetArtForItem(tag.m_iIdShow, "tvshow", showArt))
-        {
-          for (CGUIListItem::ArtMap::iterator i = showArt.begin(); i != showArt.end(); ++i)
-          {
-            if (i->first == "fanart")
-              cacheArt.insert(*i);
-            else
-              cacheArt.insert(make_pair("tvshow." + i->first, i->second));
-          }
-          item.AppendArt(cacheArt);
-        }
-        m_showArt.insert(make_pair(tag.m_iIdShow, cacheArt));
+        map<string, string> showArt;
+        m_database->GetArtForItem(tag.m_iIdShow, "tvshow", showArt);
+        i = m_showArt.insert(make_pair(tag.m_iIdShow, showArt)).first;
+      }
+      if (i != m_showArt.end())
+      {
+        item.AppendArt(i->second, "tvshow");
       }
     }
     m_database->Close();

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -348,6 +348,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
       if (i != m_showArt.end())
       {
         item.AppendArt(i->second, "tvshow");
+        item.SetArtFallback("fanart", "tvshow.fanart");
       }
     }
     m_database->Close();

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -248,7 +248,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
         artwork.insert(make_pair(type, art));
       }
     }
-    pItem->SetArt(artwork);
+    SetArt(*pItem, artwork);
   }
 
   // thumbnails are special-cased due to auto-generation
@@ -298,6 +298,18 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
   return true;
 }
 
+void CVideoThumbLoader::SetArt(CFileItem &item, const map<string, string> &artwork)
+{
+  item.SetArt(artwork);
+  if (artwork.find("thumb") == artwork.end())
+  { // set fallback for "thumb"
+    if (artwork.find("poster") != artwork.end())
+      item.SetArtFallback("thumb", "poster");
+    else if (artwork.find("poster") != artwork.end())
+      item.SetArtFallback("thumb", "banner");
+  }
+}
+
 bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
 {
   CVideoInfoTag &tag = *item.GetVideoInfoTag();
@@ -306,7 +318,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     map<string, string> artwork;
     m_database->Open();
     if (m_database->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
-      item.SetArt(artwork);
+      SetArt(item, artwork);
     else if (tag.m_type == "artist")
     { // we retrieve music video art from the music database (no backward compat)
       CMusicDatabase database;

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -121,6 +121,8 @@ protected:
   virtual void OnLoaderStart();
   virtual void OnLoaderFinish();
 
+  void SetArt(CFileItem &item, const std::map<std::string, std::string> &artwork);
+
   IStreamDetailsObserver *m_pStreamDetailsObs;
   CVideoDatabase *m_database;
   typedef std::map<int, std::map<std::string, std::string> > ArtCache;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -847,7 +847,7 @@ void CGUIDialogVideoInfo::PlayTrailer()
   *item.GetVideoInfoTag() = *m_movieItem->GetVideoInfoTag();
   item.GetVideoInfoTag()->m_streamDetails.Reset();
   item.GetVideoInfoTag()->m_strTitle.Format("%s (%s)",m_movieItem->GetVideoInfoTag()->m_strTitle.c_str(),g_localizeStrings.Get(20410));
-  item.SetArt("thumb", m_movieItem->GetArt("thumb"));
+  item.SetArt(m_movieItem->GetArt());
   item.GetVideoInfoTag()->m_iDbId = -1;
   item.GetVideoInfoTag()->m_iFileId = -1;
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -733,15 +733,7 @@ void CGUIDialogVideoInfo::OnGetArt()
     db.Close();
   }
   CUtil::DeleteVideoDatabaseDirectoryCache(); // to get them new thumbs to show
-  // update the art - we need to call the map version of SetArt to force
-  // the thumb image to update in the case it's a fallback image
-  map<string, string> itemArt(m_movieItem->GetArt());
-  if (currentArt.find("thumb") == currentArt.end())
-  { // no "thumb" image, so make sure we reset the thumb fallback
-    itemArt.erase("thumb");
-  }
-  itemArt[type] = newThumb;
-  m_movieItem->SetArt(itemArt);
+  m_movieItem->SetArt(type, newThumb);
   if (m_movieItem->HasProperty("set_folder_thumb"))
   { // have a folder thumb to set as well
     VIDEO::CVideoInfoScanner::ApplyThumbToFolder(m_movieItem->GetProperty("set_folder_thumb").asString(), newThumb);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -288,7 +288,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
   {
     if (item.GetVideoInfoTag()->m_type == "season")
     { // clear out the art - we're really grabbing the info on the show here
-      item.SetArt(map<string, string>());
+      item.ClearArt();
     }
     item.SetPath(item.GetVideoInfoTag()->GetPath());
   }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -294,11 +294,13 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
         if (m_database.GetArtForItem(details.m_iDbId, details.m_type, art))
         {
           items.AppendArt(art, "tvshow");
+          items.SetArtFallback("fanart", "tvshow.fanart");
           if (node == NODE_TYPE_SEASONS)
-          {
-            CFileItem showItem;
-            showItem.SetArt(art);
-            items.SetArt("thumb", showItem.GetArt("thumb"));
+          { // set an art fallback for "thumb"
+            if (items.HasArt("tvshow.poster"))
+              items.SetArtFallback("thumb", "tvshow.poster");
+            else if (items.HasArt("tvshow.banner"))
+              items.SetArtFallback("thumb", "tvshow.banner");
           }
         }
 
@@ -319,10 +321,12 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
           CGUIListItem::ArtMap seasonArt;
           if (m_database.GetArtForItem(seasonID, "season", seasonArt))
           {
-            items.AppendArt(seasonArt, "season");
-            CFileItem seasonItem;
-            seasonItem.SetArt(seasonArt);
-            items.SetArt("thumb", seasonItem.GetArt("thumb"));
+            items.AppendArt(art, "season");
+            // set an art fallback for "thumb"
+            if (items.HasArt("season.poster"))
+              items.SetArtFallback("thumb", "season.poster");
+            else if (items.HasArt("season.banner"))
+              items.SetArtFallback("thumb", "season.banner");
           }
         }
         else

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -293,13 +293,7 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
         map<string, string> art;
         if (m_database.GetArtForItem(details.m_iDbId, details.m_type, art))
         {
-          for (CGUIListItem::ArtMap::iterator i = art.begin(); i != art.end(); ++i)
-          {
-            if (i->first == "fanart")
-              items.SetArt(i->first, i->second);
-            else
-              items.SetArt("tvshow." + i->first, i->second);
-          }
+          items.AppendArt(art, "tvshow");
           if (node == NODE_TYPE_SEASONS)
           {
             CFileItem showItem;
@@ -325,8 +319,7 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
           CGUIListItem::ArtMap seasonArt;
           if (m_database.GetArtForItem(seasonID, "season", seasonArt))
           {
-            for (CGUIListItem::ArtMap::iterator i = art.begin(); i != art.end(); ++i)
-              items.SetArt("season." + i->first, i->second);
+            items.AppendArt(seasonArt, "season");
             CFileItem seasonItem;
             seasonItem.SetArt(seasonArt);
             items.SetArt("thumb", seasonItem.GetArt("thumb"));


### PR DESCRIPTION
With the ability for JSON-RPC to set art for items, there's the possibility of art such as "tvshow.poster" to be set at the episode level.  We don't want this, as otherwise that particular episode will always have that tvshow poster, even after the user changes the tvshow poster.  This will pollute the database with entries that then need to be manually changed one by one via Choose Art.

To fix this, we store all parent art using the <parent>.<type> pattern.  e.g. fanart for tvshows is tvshow.fanart.  This still allows season-specific fanart to be used (they can just specify fanart at the season level) and, indeed, even episode-specific if that's appropriate.

To pull this off, we need the normal generic ListItem.Art(fanart) to drop back to the appropriate art.  Thus, we generalise the fallback already available for ListItem.Art(thumb) to allow other fallbacks.  It happens at fetch time, as otherwise the art map is populated with these items that can't be eliminated.

Tested with old skins and all fallbacks working.  Tested with new skins and all fallbacks working.

@Montellese, @MartijnKaijser the change is subtle, but it will mean that you'll no longer retrieve "fanart" and "thumb" at the episode or season level, unless they're set at that level.  You'll instead retrieve "tvshow.fanart".  Same with songs/albums - you'll get artist.fanart and probably also album.thumb rather than thumb at the song level.
