### PR TITLE
always allow gui playback info

### DIFF
--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -63,7 +63,7 @@
 				<posy>285</posy>
 				<height>30</height>
 				<width>1000</width>
-				<label>$INFO[MusicPlayer.Title]</label>
+				<label>$INFO[Player.Title]</label>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font13_title</font>
@@ -254,7 +254,7 @@
 					<posy>285</posy>
 					<height>30</height>
 					<width>1000</width>
-					<label>$INFO[VideoPlayer.Title]</label>
+					<label>$INFO[Player.Title]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font13_title</font>
@@ -307,7 +307,7 @@
 					<posy>285</posy>
 					<height>30</height>
 					<width>1000</width>
-					<label>$INFO[VideoPlayer.Title]</label>
+					<label>$INFO[Player.Title]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font13_title</font>
@@ -360,7 +360,7 @@
 					<posy>285</posy>
 					<height>30</height>
 					<width>1000</width>
-					<label>$INFO[VideoPlayer.Title]$INFO[VideoPlayer.Year,[COLOR=grey] (,)[/COLOR]]</label>
+					<label>$INFO[Player.Title]$INFO[VideoPlayer.Year,[COLOR=grey] (,)[/COLOR]]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font13_title</font>
@@ -413,7 +413,7 @@
 					<posy>285</posy>
 					<height>30</height>
 					<width>1000</width>
-					<label>$INFO[VideoPlayer.Title]</label>
+					<label>$INFO[Player.Title]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font13_title</font>

--- a/addons/skin.confluence/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence/720p/MusicVisualisation.xml
@@ -133,7 +133,7 @@
 						<font>font30</font>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[MusicPlayer.Title]</label>
+						<label>$INFO[Player.Title]</label>
 						<textcolor>orange</textcolor>
 						<scroll>true</scroll>
 					</control>

--- a/addons/skin.confluence/720p/MyPVR.xml
+++ b/addons/skin.confluence/720p/MyPVR.xml
@@ -93,7 +93,7 @@
 				<textcolor>grey2</textcolor>
 				<align>center</align>
 				<aligny>center</aligny>
-				<label>$INFO[VideoPlayer.Title]</label>
+				<label>$INFO[Player.Title]</label>
 				<visible>Player.HasVideo</visible>
 			</control>
 			<!-- control type="visualisation">

--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -190,7 +190,7 @@
 						<font>font30</font>
 						<align>left</align>
 						<aligny>center</aligny>
-						<label>$INFO[VideoPlayer.Title]</label>
+						<label>$INFO[Player.Title]</label>
 						<textcolor>orange</textcolor>
 						<scroll>true</scroll>
 					</control>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -588,7 +588,7 @@
 			<textcolor>blue</textcolor>
 			<align>center</align>
 			<aligny>center</aligny>
-			<visible>[Player.HasAudio | Player.HasVideo]</visible>
+			<visible>Player.HasMedia</visible>
 			<include>VisibleFadeEffect</include>
 		</control>
 		<control type="button" id="610">
@@ -681,7 +681,7 @@
 			</control>
 		</control>
 		<control type="group" id="9005">
-			<visible>[Player.HasAudio | Player.HasVideo]</visible>
+			<visible>Player.HasMedia</visible>
 			<visible>!VideoPlayer.Content(LiveTV)</visible>
 			<include>VisibleFadeEffect</include>
 			<width>250</width>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -253,7 +253,7 @@
 				<posy>53r</posy>
 				<width>700</width>
 				<height>20</height>
-				<label>$INFO[MusicPlayer.Title]$INFO[VideoPlayer.Title] - ([COLOR=blue]$INFO[Player.Time] / $INFO[Player.Duration,][/COLOR])</label>
+				<label>$INFO[Player.Title] - ([COLOR=blue]$INFO[Player.Time] / $INFO[Player.Duration,][/COLOR])</label>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font12</font>
@@ -397,7 +397,7 @@
 			<posy>43</posy>
 			<height>30</height>
 			<width>325</width>
-			<label>$INFO[MusicPlayer.Title]</label>
+			<label>$INFO[Player.Title]</label>
 			<align>left</align>
 			<aligny>center</aligny>
 			<font>font13_title</font>
@@ -515,7 +515,7 @@
 			<posy>43</posy>
 			<height>30</height>
 			<width>325</width>
-			<label>$INFO[VideoPlayer.Title]</label>
+			<label>$INFO[Player.Title]</label>
 			<align>left</align>
 			<aligny>center</aligny>
 			<font>font13_title</font>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4407,7 +4407,7 @@ void CApplication::UpdateFileState()
   }
   else
   {
-    if (IsPlayingVideo() || IsPlayingAudio())
+    if (IsPlaying())
     {
       if (m_progressTrackingItem->GetPath() == "")
       {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3473,7 +3473,7 @@ CStdString CGUIInfoManager::GetPlaylistLabel(int item) const
 
 CStdString CGUIInfoManager::GetMusicLabel(int item)
 {
-  if (!g_application.IsPlayingAudio() || !m_currentFile->HasMusicInfoTag()) return "";
+  if (!g_application.IsPlaying() || !m_currentFile->HasMusicInfoTag()) return "";
   switch (item)
   {
   case MUSICPLAYER_PLAYLISTLEN:
@@ -3552,7 +3552,8 @@ CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
   switch (info)
   {
   case MUSICPLAYER_TITLE:
-    return GetLabel(PLAYER_TITLE);
+    if(g_application.IsPlayingAudio())
+      return GetLabel(PLAYER_TITLE);
     break;
   case MUSICPLAYER_ALBUM:
     if (tag.GetAlbum().size()) { return tag.GetAlbum(); }
@@ -3625,12 +3626,13 @@ CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
 
 CStdString CGUIInfoManager::GetVideoLabel(int item)
 {
-  if (!g_application.IsPlayingVideo())
+  if (!g_application.IsPlaying())
     return "";
 
   if (item == VIDEOPLAYER_TITLE)
   {
-    return GetLabel(PLAYER_TITLE);
+    if(g_application.IsPlayingVideo())
+       return GetLabel(PLAYER_TITLE);
   }
   else if (item == VIDEOPLAYER_PLAYLISTLEN)
   {
@@ -3860,7 +3862,7 @@ CStdString CGUIInfoManager::GetCurrentPlayTime(TIME_FORMAT format) const
 {
   if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
     format = TIME_FORMAT_HH_MM_SS;
-  if (g_application.IsPlayingAudio() || g_application.IsPlayingVideo())
+  if (g_application.IsPlaying())
     return StringUtils::SecondsToTimeString((int)(GetPlayTime()/1000), format);
   return "";
 }
@@ -3890,7 +3892,7 @@ CStdString CGUIInfoManager::GetCurrentPlayTimeRemaining(TIME_FORMAT format) cons
   if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
     format = TIME_FORMAT_HH_MM_SS;
   int timeRemaining = GetPlayTimeRemaining();
-  if (timeRemaining && (g_application.IsPlayingAudio() || g_application.IsPlayingVideo()))
+  if (timeRemaining && g_application.IsPlaying())
     return StringUtils::SecondsToTimeString(timeRemaining, format);
   return "";
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -182,6 +182,7 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "showtime",         PLAYER_SHOWTIME },
                                   { "showcodec",        PLAYER_SHOWCODEC },
                                   { "showinfo",         PLAYER_SHOWINFO },
+                                  { "title",            PLAYER_TITLE },
                                   { "muted",            PLAYER_MUTED },
                                   { "hasduration",      PLAYER_HASDURATION },
                                   { "passthrough",      PLAYER_PASSTHROUGH },
@@ -1375,6 +1376,39 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
       if (URIUtils::IsInArchive(strLabel))
         strLabel = URIUtils::GetParentPath(strLabel);
       strLabel = URIUtils::GetParentPath(strLabel);
+    }
+    break;
+  case PLAYER_TITLE:
+    {
+      if(m_currentFile)
+      {
+        if (m_currentFile->HasPVRChannelInfoTag())
+        {
+          CEpgInfoTag tag;
+          return m_currentFile->GetPVRChannelInfoTag()->GetEPGNow(tag) ?
+                   tag.Title() :
+                   g_guiSettings.GetBool("epg.hidenoinfoavailable") ?
+                     StringUtils::EmptyString :
+                     g_localizeStrings.Get(19055); // no information available
+        }
+        if (m_currentFile->HasPVRRecordingInfoTag() && !m_currentFile->GetPVRRecordingInfoTag()->m_strTitle.IsEmpty())
+          return m_currentFile->GetPVRRecordingInfoTag()->m_strTitle;
+        if (m_currentFile->HasVideoInfoTag() && !m_currentFile->GetVideoInfoTag()->m_strTitle.IsEmpty())
+          return m_currentFile->GetVideoInfoTag()->m_strTitle;
+        if (m_currentFile->HasMusicInfoTag() && !m_currentFile->GetMusicInfoTag()->GetTitle().IsEmpty())
+          return m_currentFile->GetMusicInfoTag()->GetTitle();
+        // don't have the title, so use dvdplayer, label, or drop down to title from path
+        if (g_application.m_pPlayer && !g_application.m_pPlayer->GetPlayingTitle().IsEmpty())
+          return g_application.m_pPlayer->GetPlayingTitle();
+        if (!m_currentFile->GetLabel().IsEmpty())
+          return m_currentFile->GetLabel();
+        return CUtil::GetTitleFromPath(m_currentFile->GetPath());
+      }
+      else
+      {
+        if (g_application.m_pPlayer && !g_application.m_pPlayer->GetPlayingTitle().IsEmpty())
+          return g_application.m_pPlayer->GetPlayingTitle();
+      }
     }
     break;
   case MUSICPLAYER_TITLE:
@@ -3518,7 +3552,7 @@ CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
   switch (info)
   {
   case MUSICPLAYER_TITLE:
-    if (tag.GetTitle().size()) { return tag.GetTitle(); }
+    return GetLabel(PLAYER_TITLE);
     break;
   case MUSICPLAYER_ALBUM:
     if (tag.GetAlbum().size()) { return tag.GetAlbum(); }
@@ -3596,25 +3630,7 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
 
   if (item == VIDEOPLAYER_TITLE)
   {
-    if (m_currentFile->HasPVRChannelInfoTag())
-    {
-      CEpgInfoTag tag;
-      return m_currentFile->GetPVRChannelInfoTag()->GetEPGNow(tag) ?
-          tag.Title() :
-          g_guiSettings.GetBool("epg.hidenoinfoavailable") ?
-              StringUtils::EmptyString :
-              g_localizeStrings.Get(19055); // no information available
-    }
-    if (m_currentFile->HasPVRRecordingInfoTag() && !m_currentFile->GetPVRRecordingInfoTag()->m_strTitle.IsEmpty())
-      return m_currentFile->GetPVRRecordingInfoTag()->m_strTitle;
-    if (m_currentFile->HasVideoInfoTag() && !m_currentFile->GetVideoInfoTag()->m_strTitle.IsEmpty())
-      return m_currentFile->GetVideoInfoTag()->m_strTitle;
-    // don't have the title, so use dvdplayer, label, or drop down to title from path
-    if (!g_application.m_pPlayer->GetPlayingTitle().IsEmpty())
-      return g_application.m_pPlayer->GetPlayingTitle();
-    if (!m_currentFile->GetLabel().IsEmpty())
-      return m_currentFile->GetLabel();
-    return CUtil::GetTitleFromPath(m_currentFile->GetPath());
+    return GetLabel(PLAYER_TITLE);
   }
   else if (item == VIDEOPLAYER_PLAYLISTLEN)
   {

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -107,6 +107,7 @@ namespace INFO
 #define PLAYER_CAN_PAUSE             50
 #define PLAYER_CAN_SEEK              51
 #define PLAYER_START_TIME            52
+#define PLAYER_TITLE                 53
 
 #define WEATHER_CONDITIONS          100
 #define WEATHER_TEMPERATURE         101


### PR DESCRIPTION
This series avoids the limit on gui infolabels based on if we are playing music or video, or any at all. It is partly a prep for the UPNP player. But it also should simplify the fixes for not loosing gui overlays while switching channels in pvr.
