### PR TITLE
Extend Event Server to better emulate keyboard presses

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3181,53 +3181,60 @@ bool CApplication::ProcessEventServer(float frameTime)
   es = CEventServer::GetInstance();
   if (!es || !es->Running() || es->GetNumberOfClients()==0)
     return false;
-  unsigned int wKeyID = es->GetButtonCode(joystickName, isAxis, fAmount);
+  EVENTCLIENT::EC_button buttonSent = es->GetButtonCode(joystickName, isAxis, fAmount);
 
-  if (wKeyID)
+  if (buttonSent.keycode | buttonSent.unicode)
   {
     if (joystickName.length() > 0)
     {
       if (isAxis == true)
       {
         if (fabs(fAmount) >= 0.08)
-          m_lastAxisMap[joystickName][wKeyID] = fAmount;
+          m_lastAxisMap[joystickName][buttonSent.keycode] = fAmount;
         else
-          m_lastAxisMap[joystickName].erase(wKeyID);
+          m_lastAxisMap[joystickName].erase(buttonSent.keycode);
       }
 
-      return ProcessJoystickEvent(joystickName, wKeyID, isAxis, fAmount);
+      return ProcessJoystickEvent(joystickName, buttonSent.keycode, isAxis, fAmount);
     }
     else
     {
       CKey key;
-      if (wKeyID & ES_FLAG_UNICODE)
+      if (buttonSent.unicode)
       {
-        key = CKey((uint8_t)0, wKeyID & ~ES_FLAG_UNICODE, 0, 0, 0);
+        XBMC_keysym keyPressed;
+        keyPressed.scancode = 0;
+        keyPressed.sym = (XBMCKey)buttonSent.keycode;
+        keyPressed.unicode = buttonSent.unicode;
+        keyPressed.mod = (XBMCMod) buttonSent.modifier;
+        key = g_Keyboard.ProcessKeyDown(keyPressed);
+        g_Keyboard.ProcessKeyUp();
         return OnKey(key);
       }
-
-      if(wKeyID == KEY_BUTTON_LEFT_ANALOG_TRIGGER)
-        key = CKey(wKeyID, (BYTE)(255*fAmount), 0, 0.0, 0.0, 0.0, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_RIGHT_ANALOG_TRIGGER)
-        key = CKey(wKeyID, 0, (BYTE)(255*fAmount), 0.0, 0.0, 0.0, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_LEFT_THUMB_STICK_LEFT)
-        key = CKey(wKeyID, 0, 0, -fAmount, 0.0, 0.0, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_LEFT_THUMB_STICK_RIGHT)
-        key = CKey(wKeyID, 0, 0,  fAmount, 0.0, 0.0, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_LEFT_THUMB_STICK_UP)
-        key = CKey(wKeyID, 0, 0, 0.0,  fAmount, 0.0, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_LEFT_THUMB_STICK_DOWN)
-        key = CKey(wKeyID, 0, 0, 0.0, -fAmount, 0.0, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_RIGHT_THUMB_STICK_LEFT)
-        key = CKey(wKeyID, 0, 0, 0.0, 0.0, -fAmount, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_RIGHT_THUMB_STICK_RIGHT)
-        key = CKey(wKeyID, 0, 0, 0.0, 0.0,  fAmount, 0.0, frameTime);
-      else if(wKeyID == KEY_BUTTON_RIGHT_THUMB_STICK_UP)
-        key = CKey(wKeyID, 0, 0, 0.0, 0.0, 0.0,  fAmount, frameTime);
-      else if(wKeyID == KEY_BUTTON_RIGHT_THUMB_STICK_DOWN)
-        key = CKey(wKeyID, 0, 0, 0.0, 0.0, 0.0, -fAmount, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_LEFT_ANALOG_TRIGGER)
+        key = CKey(buttonSent.keycode, (BYTE)(255*fAmount), 0, 0.0, 0.0, 0.0, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_RIGHT_ANALOG_TRIGGER)
+        key = CKey(buttonSent.keycode, 0, (BYTE)(255*fAmount), 0.0, 0.0, 0.0, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_LEFT_THUMB_STICK_LEFT)
+        key = CKey(buttonSent.keycode, 0, 0, -fAmount, 0.0, 0.0, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_LEFT_THUMB_STICK_RIGHT)
+        key = CKey(buttonSent.keycode, 0, 0,  fAmount, 0.0, 0.0, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_LEFT_THUMB_STICK_UP)
+        key = CKey(buttonSent.keycode, 0, 0, 0.0,  fAmount, 0.0, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_LEFT_THUMB_STICK_DOWN)
+        key = CKey(buttonSent.keycode, 0, 0, 0.0, -fAmount, 0.0, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_RIGHT_THUMB_STICK_LEFT)
+        key = CKey(buttonSent.keycode, 0, 0, 0.0, 0.0, -fAmount, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_RIGHT_THUMB_STICK_RIGHT)
+        key = CKey(buttonSent.keycode, 0, 0, 0.0, 0.0,  fAmount, 0.0, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_RIGHT_THUMB_STICK_UP)
+        key = CKey(buttonSent.keycode, 0, 0, 0.0, 0.0, 0.0,  fAmount, frameTime);
+      else if(buttonSent.keycode == KEY_BUTTON_RIGHT_THUMB_STICK_DOWN)
+        key = CKey(buttonSent.keycode, 0, 0, 0.0, 0.0, 0.0, -fAmount, frameTime);
+      else if(buttonSent.modifier != 0)
+        key = CKey(buttonSent.keycode,0,0,buttonSent.modifier,0);
       else
-        key = CKey(wKeyID);
+        key = CKey(buttonSent.keycode);
       key.SetFromService(true);
       return OnKey(key);
     }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3231,8 +3231,6 @@ bool CApplication::ProcessEventServer(float frameTime)
         key = CKey(buttonSent.keycode, 0, 0, 0.0, 0.0, 0.0,  fAmount, frameTime);
       else if(buttonSent.keycode == KEY_BUTTON_RIGHT_THUMB_STICK_DOWN)
         key = CKey(buttonSent.keycode, 0, 0, 0.0, 0.0, 0.0, -fAmount, frameTime);
-      else if(buttonSent.modifier != 0)
-        key = CKey(buttonSent.keycode,0,0,buttonSent.modifier,0);
       else
         key = CKey(buttonSent.keycode);
       key.SetFromService(true);

--- a/xbmc/guilib/Key.cpp
+++ b/xbmc/guilib/Key.cpp
@@ -45,7 +45,14 @@ CKey::CKey(uint32_t buttonCode, uint8_t leftTrigger, uint8_t rightTrigger, float
         //Pass the modifier and key press information when sent from an EventServer Client
         m_modifiers = buttonCode & (MODIFIER_ALT | MODIFIER_CTRL | MODIFIER_RALT | MODIFIER_SHIFT | MODIFIER_SUPER);
         if(((buttonCode & KEY_ASCII)==KEY_ASCII))
+        {
             m_ascii = buttonCode & 0xFF;
+            //Convert Lowercase ascii to uppercase for VKey
+            if(0x61 <= m_ascii && m_ascii <= 0x7a)
+                m_vkey = buttonCode & ~0x20;//Get rid of bit
+            else
+                m_vkey = buttonCode & 0xFF;
+        }
         else
             m_vkey = buttonCode & 0xFF;
   }
@@ -174,9 +181,11 @@ float CKey::GetRepeat() const
 
 void CKey::SetFromService(bool fromService)
 {
-  if (fromService && (m_buttonCode & KEY_ASCII))
-    m_unicode = m_buttonCode - KEY_ASCII;
-    
+  if (fromService && (m_buttonCode & KEY_ASCII)) {
+    m_unicode = m_buttonCode & (unsigned short)~KEY_ASCII;
+    if(0x61 <= m_ascii && m_ascii <= 0x7a)
+        m_buttonCode &= ~0x20; //Need to get rid of this bit for correct processing in OnKey
+  }
   m_fromService = fromService;
 }
 

--- a/xbmc/guilib/Key.cpp
+++ b/xbmc/guilib/Key.cpp
@@ -40,6 +40,15 @@ CKey::CKey(uint32_t buttonCode, uint8_t leftTrigger, uint8_t rightTrigger, float
   m_rightThumbX = rightThumbX;
   m_rightThumbY = rightThumbY;
   m_repeat = repeat;
+  if(((buttonCode & KEY_ASCII)==KEY_ASCII) || ((buttonCode & KEY_VKEY)==KEY_VKEY))
+    {
+        //Pass the modifier and key press information when sent from an EventServer Client
+        m_modifiers = buttonCode & (MODIFIER_ALT | MODIFIER_CTRL | MODIFIER_RALT | MODIFIER_SHIFT | MODIFIER_SUPER);
+        if(((buttonCode & KEY_ASCII)==KEY_ASCII))
+            m_ascii = buttonCode & 0xFF;
+        else
+            m_vkey = buttonCode & 0xFF;
+  }
 }
 
 CKey::CKey(uint32_t buttonCode, unsigned int held)

--- a/xbmc/guilib/Key.cpp
+++ b/xbmc/guilib/Key.cpp
@@ -40,22 +40,6 @@ CKey::CKey(uint32_t buttonCode, uint8_t leftTrigger, uint8_t rightTrigger, float
   m_rightThumbX = rightThumbX;
   m_rightThumbY = rightThumbY;
   m_repeat = repeat;
-  if(((buttonCode & KEY_ASCII)==KEY_ASCII) || ((buttonCode & KEY_VKEY)==KEY_VKEY))
-    {
-        //Pass the modifier and key press information when sent from an EventServer Client
-        m_modifiers = buttonCode & (MODIFIER_ALT | MODIFIER_CTRL | MODIFIER_RALT | MODIFIER_SHIFT | MODIFIER_SUPER);
-        if(((buttonCode & KEY_ASCII)==KEY_ASCII))
-        {
-            m_ascii = buttonCode & 0xFF;
-            //Convert Lowercase ascii to uppercase for VKey
-            if(0x61 <= m_ascii && m_ascii <= 0x7a)
-                m_vkey = buttonCode & ~0x20;//Get rid of bit
-            else
-                m_vkey = buttonCode & 0xFF;
-        }
-        else
-            m_vkey = buttonCode & 0xFF;
-  }
 }
 
 CKey::CKey(uint32_t buttonCode, unsigned int held)
@@ -181,11 +165,9 @@ float CKey::GetRepeat() const
 
 void CKey::SetFromService(bool fromService)
 {
-  if (fromService && (m_buttonCode & KEY_ASCII)) {
-    m_unicode = m_buttonCode & (unsigned short)~KEY_ASCII;
-    if(0x61 <= m_ascii && m_ascii <= 0x7a)
-        m_buttonCode &= ~0x20; //Need to get rid of this bit for correct processing in OnKey
-  }
+  if (fromService && (m_buttonCode & KEY_ASCII))
+    m_unicode = m_buttonCode - KEY_ASCII;
+    
   m_fromService = fromService;
 }
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1241,6 +1241,26 @@ uint32_t CButtonTranslator::TranslateKeyboardString(const char *szButton)
   return buttonCode;
 }
 
+uint32_t CButtonTranslator::TranslateKeyboardStringToKeysym(const char *szButton)
+{
+  uint32_t buttonCode = 0;
+  XBMCKEYTABLE keytable;
+  
+  // Look up the key name
+  if (KeyTableLookupName(szButton, &keytable))
+  {
+    buttonCode = (XBMCKey)keytable.sym;
+  }
+  
+  // The lookup failed i.e. the key name wasn't found
+  else
+  {
+    CLog::Log(LOGERROR, "Keyboard Translator: Can't find button %s", szButton);
+  }
+  
+  return buttonCode;
+}
+
 uint32_t CButtonTranslator::TranslateKeyboardButton(TiXmlElement *pButton)
 {
   uint32_t button_id = 0;

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -112,6 +112,7 @@ private:
   static uint32_t TranslateUniversalRemoteString(const char *szButton);
 
   static uint32_t TranslateKeyboardString(const char *szButton);
+  static uint32_t TranslateKeyboardStringToKeysym(const char *szButton);
   static uint32_t TranslateKeyboardButton(TiXmlElement *pButton);
 
   static uint32_t TranslateMouseCommand(const char *szButton);

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -126,7 +126,11 @@ const CKey CKeyboardStat::ProcessKeyDown(XBMC_keysym& keysym)
     // values.
     if (keytable.unicode == 0 && unicode != 0)
       unicode = 0;
-    else if (keysym.unicode > 32 && keysym.unicode < 128)
+    // If we get a key and need to populate the unicode value (e.g. from the event server)
+    else if (unicode == KEY_INVALID) 
+        unicode = keytable.unicode;
+      
+    if (unicode > 32 && unicode < 128)
       ascii = unicode & 0x7f;
   }
 

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -234,7 +234,7 @@ bool CEventClient::ProcessPacket(CEventPacket *packet)
     break;
 
   case PT_BUTTON:
-    valid = OnPacketBUTTON(packet);
+    valid = OnPacketBUTTON(packet,false);
     break;
 
   case PT_MOUSE:
@@ -256,7 +256,11 @@ bool CEventClient::ProcessPacket(CEventPacket *packet)
   case PT_ACTION:
     valid = OnPacketACTION(packet);
     break;
-
+          
+  case PT_BUTTON_EXTENDED:
+    valid = OnPacketBUTTON(packet,true);
+    break;
+          
   default:
     CLog::Log(LOGDEBUG, "ES: Got Unknown Packet");
     break;
@@ -359,20 +363,29 @@ bool CEventClient::OnPacketBYE(CEventPacket *packet)
   return true;
 }
 
-bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
+bool CEventClient::OnPacketBUTTON(CEventPacket *packet, bool extended)
 {
   unsigned char *payload = (unsigned char *)packet->Payload();
   int psize = (int)packet->PayloadSize();
 
   string map, button;
   unsigned short flags;
-  unsigned short bcode;
+  unsigned int bcode;
   unsigned short amount;
 
   // parse the button code
-  if (!ParseUInt16(payload, psize, bcode))
-    return false;
-
+  if(!extended)
+  {
+      unsigned short bcode_tmp;
+      if (!ParseUInt16(payload, psize, bcode_tmp))
+          return false;
+      bcode = bcode_tmp;
+  }
+  else
+  {
+      if (!ParseUInt32(payload, psize, bcode))
+          return false;
+  }
   // parse flags
   if (!ParseUInt16(payload, psize, flags))
     return false;

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -73,7 +73,7 @@ void CEventButtonState::Load()
       if ( m_mapName.compare("KB") == 0 ) // standard keyboard map
       {
         m_iKeyCode = CButtonTranslator::TranslateKeyboardStringToKeysym( m_buttonName.c_str() );
-        m_unicode = 0xFDD0;
+        m_unicode = KEY_INVALID;
       }
       else if  ( m_mapName.compare("XG") == 0 ) // xbox gamepad map
       {
@@ -416,7 +416,7 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet, bool extended)
     unicode = bcode;
   else if(flags & PTB_SDL)
   {
-    unicode = 0xFDD0;
+    unicode = KEY_INVALID;
     keycode = bcode;
   }
   else

--- a/xbmc/network/EventClient.h
+++ b/xbmc/network/EventClient.h
@@ -34,8 +34,12 @@
 namespace EVENTCLIENT
 {
 
-  #define ES_FLAG_UNICODE    0x80000000 // new 16bit key flag to support real unicode over EventServer
-
+  typedef struct EC_button {
+    unsigned int keycode;
+    unsigned short modifier;
+    unsigned int unicode;
+  } EC_button;
+    
   class CEventAction
   {
   public:
@@ -59,6 +63,8 @@ namespace EVENTCLIENT
     CEventButtonState()
     {
       m_iKeyCode   = 0;
+      m_modifiers = 0;
+      m_unicode = 0;
       m_mapName    = "";
       m_buttonName = "";
       m_fAmount    = 0.0f;
@@ -71,6 +77,8 @@ namespace EVENTCLIENT
     }
 
     CEventButtonState(unsigned int iKeyCode,
+                      unsigned short modifiers,
+                      unsigned int unicode,
                       std::string mapName,
                       std::string buttonName,
                       float fAmount,
@@ -80,6 +88,8 @@ namespace EVENTCLIENT
       )
     {
       m_iKeyCode   = iKeyCode;
+      m_modifiers = modifiers;
+      m_unicode    = unicode;
       m_buttonName = buttonName;
       m_mapName    = mapName;
       m_fAmount    = fAmount;
@@ -99,12 +109,16 @@ namespace EVENTCLIENT
     int  ControllerNumber() const { return m_iControllerNumber; }
     bool Axis() const { return m_bAxis; }
     unsigned int KeyCode() const { return m_iKeyCode; }
+    unsigned short Modifiers() const { return m_modifiers; }
+    unsigned int Unicode() const { return m_unicode; }
     float Amount() const  { return m_fAmount; }
     void Load();
     const std::string& JoystickName() const { return m_joystickName; }
 
     // data
     unsigned int      m_iKeyCode;
+    unsigned short    m_modifiers;
+    unsigned int      m_unicode;
     unsigned short    m_iControllerNumber;
     std::string       m_buttonName;
     std::string       m_mapName;
@@ -191,7 +205,7 @@ namespace EVENTCLIENT
     void FreePacketQueues();
 
     // return event states
-    unsigned int GetButtonCode(std::string& strMapName, bool& isAxis, float& amount);
+    EC_button GetButtonCode(std::string& strMapName, bool& isAxis, float& amount);
 
     // update mouse position
     bool GetMousePos(float& x, float& y);

--- a/xbmc/network/EventClient.h
+++ b/xbmc/network/EventClient.h
@@ -202,7 +202,7 @@ namespace EVENTCLIENT
     // packet handlers
     virtual bool OnPacketHELO(EVENTPACKET::CEventPacket *packet);
     virtual bool OnPacketBYE(EVENTPACKET::CEventPacket *packet);
-    virtual bool OnPacketBUTTON(EVENTPACKET::CEventPacket *packet);
+    virtual bool OnPacketBUTTON(EVENTPACKET::CEventPacket *packet, bool extended);
     virtual bool OnPacketMOUSE(EVENTPACKET::CEventPacket *packet);
     virtual bool OnPacketNOTIFICATION(EVENTPACKET::CEventPacket *packet);
     virtual bool OnPacketLOG(EVENTPACKET::CEventPacket *packet);

--- a/xbmc/network/EventPacket.h
+++ b/xbmc/network/EventPacket.h
@@ -205,7 +205,7 @@ namespace EVENTPACKET
     /************************************************************************/
     /* Payload format                                                       */
     /* %d - button code                                                     */
-    /* %i - button modifiers - only codes 0x01 ("KB"), 0x200, 0x400         */
+    /* %i - button modifiers - used with flags 0x01 ("KB"), 0x200, 0x400    */
     /* %i - flags 0x01 => use button map/name instead of code               */
     /*            0x02 => btn down                                          */
     /*            0x04 => btn up                                            */

--- a/xbmc/network/EventPacket.h
+++ b/xbmc/network/EventPacket.h
@@ -88,7 +88,8 @@ namespace EVENTPACKET
     PTB_VKEY       = 0x40,
     PTB_AXIS       = 0x80,
     PTB_AXISSINGLE = 0x100,
-    PTB_UNICODE    = 0x200
+    PTB_UNICODE    = 0x200,
+    PTB_SDL        = 0x400
   };
 
   enum MouseFlags
@@ -133,6 +134,9 @@ namespace EVENTPACKET
     /*            0x20 => do not repeat                                     */
     /*            0x40 => virtual key                                       */
     /*            0x80 => axis key                                          */
+    /*            0x100 => SingleAxis key                                   */
+    /*            0x200 => Unicode key                                      */
+    /*            0x400 => XBMC SDL Key                                     */
     /* %i - amount ( 0 => 65k maps to -1 => 1 )                             */
     /* %s - device map (case sensitive and required if flags & 0x01)        */
     /*      "KB" - Standard keyboard map                                    */
@@ -201,6 +205,7 @@ namespace EVENTPACKET
     /************************************************************************/
     /* Payload format                                                       */
     /* %d - button code                                                     */
+    /* %i - button modifiers                                                */
     /* %i - flags 0x01 => use button map/name instead of code               */
     /*            0x02 => btn down                                          */
     /*            0x04 => btn up                                            */
@@ -209,9 +214,12 @@ namespace EVENTPACKET
     /*            0x20 => do not repeat                                     */
     /*            0x40 => virtual key                                       */
     /*            0x80 => axis key                                          */
+    /*            0x100 => SingleAxis key                                   */
+    /*            0x200 => Unicode key (Uses SDLmod values for modifiers)   */
+    /*            0x400 => XBMC SDL Key (Uses SDLmod values for modifiers)  */
     /* %i - amount ( 0 => 65k maps to -1 => 1 )                             */
     /* %s - device map (case sensitive and required if flags & 0x01)        */
-    /*      "KB" - Standard keyboard map                                    */
+    /*      "KB" - Standard keyboard map (Uses SDLmod values for modifiers) */
     /*      "XG" - Xbox Gamepad                                             */
     /*      "R1" - Xbox Remote                                              */
     /*      "R2" - Xbox Universal Remote                                    */

--- a/xbmc/network/EventPacket.h
+++ b/xbmc/network/EventPacket.h
@@ -189,12 +189,41 @@ namespace EVENTPACKET
     /* %c - log type                                                        */
     /* %s - message                                                         */
     /************************************************************************/
+      
     PT_ACTION        = 0x0A,
     /************************************************************************/
     /* Payload format                                                       */
     /* %c - action type                                                     */
     /* %s - action message                                                  */
     /************************************************************************/
+      
+    PT_BUTTON_EXTENDED        = 0x0B,
+    /************************************************************************/
+    /* Payload format                                                       */
+    /* %d - button code                                                     */
+    /* %i - flags 0x01 => use button map/name instead of code               */
+    /*            0x02 => btn down                                          */
+    /*            0x04 => btn up                                            */
+    /*            0x08 => use amount                                        */
+    /*            0x10 => queue event                                       */
+    /*            0x20 => do not repeat                                     */
+    /*            0x40 => virtual key                                       */
+    /*            0x80 => axis key                                          */
+    /* %i - amount ( 0 => 65k maps to -1 => 1 )                             */
+    /* %s - device map (case sensitive and required if flags & 0x01)        */
+    /*      "KB" - Standard keyboard map                                    */
+    /*      "XG" - Xbox Gamepad                                             */
+    /*      "R1" - Xbox Remote                                              */
+    /*      "R2" - Xbox Universal Remote                                    */
+    /*      "LI:devicename" -  valid LIRC device map where 'devicename'     */
+    /*                         is the actual name of the LIRC device        */
+    /*      "JS<num>:joyname" -  valid Joystick device map where            */
+    /*                           'joyname'  is the name specified in        */
+    /*                           the keymap. JS only supports button code   */
+    /*                           and not button name currently (!0x01).     */
+    /* %s - button name (required if flags & 0x01)                          */
+    /************************************************************************/
+      
     PT_DEBUG         = 0xFF,
     /************************************************************************/
     /* Payload format:                                                      */

--- a/xbmc/network/EventPacket.h
+++ b/xbmc/network/EventPacket.h
@@ -205,7 +205,7 @@ namespace EVENTPACKET
     /************************************************************************/
     /* Payload format                                                       */
     /* %d - button code                                                     */
-    /* %i - button modifiers                                                */
+    /* %i - button modifiers - only codes 0x01 ("KB"), 0x200, 0x400         */
     /* %i - flags 0x01 => use button map/name instead of code               */
     /*            0x02 => btn down                                          */
     /*            0x04 => btn up                                            */

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -363,16 +363,16 @@ bool CEventServer::ExecuteNextAction()
   return false;
 }
 
-unsigned int CEventServer::GetButtonCode(std::string& strMapName, bool& isAxis, float& fAmount)
+EC_button CEventServer::GetButtonCode(std::string& strMapName, bool& isAxis, float& fAmount)
 {
   CSingleLock lock(m_critSection);
   map<unsigned long, CEventClient*>::iterator iter = m_clients.begin();
-  unsigned int bcode = 0;
+  EC_button bcode;
 
   while (iter != m_clients.end())
   {
     bcode = iter->second->GetButtonCode(strMapName, isAxis, fAmount);
-    if (bcode)
+    if (bcode.keycode | bcode.unicode)
       return bcode;
     iter++;
   }

--- a/xbmc/network/EventServer.h
+++ b/xbmc/network/EventServer.h
@@ -63,7 +63,7 @@ namespace EVENTSERVER
     void StopServer(bool bWait);
 
     // get events
-    unsigned int GetButtonCode(std::string& strMapName, bool& isAxis, float& amount);
+    EVENTCLIENT::EC_button GetButtonCode(std::string& strMapName, bool& isAxis, float& amount);
     bool ExecuteNextAction();
     bool GetMousePos(float &x, float &y);
     int GetNumberOfClients();


### PR DESCRIPTION
1) Implemented a new extended button packet in the event server to allow modifier keys to be sent.
    -> Old button packet (PT_BUTTON) left unmodified for backward compatibility
    -> New button backet (PT_BUTTON_EXTENDED) changes button code to 4 bytes instead of 2 bytes

2) Added additional logic to Key.cpp class to populate the m_vkey, m_ascii, and m_modifiers fields of the CKey class when an ASCII or VKEY is sent over the event server.

Taken together, these changes allow emulated keyboard presses to be sent over the event server to XBMC (and to be correctly handled).

These changes should have little to no impact on existing event server clients as it preserves the old functionality of the event server.
 -> Exception: If an event client is sending an ASCII encoded value (has the flag 0xf100) between 0x61 and 0x7a and expecting it to be handled as a VKEY (flag 0xf000) instead (corresponding to numberpad operations) it will fail as this patch will change the lowercase ascii value to the correct VKey value (which corresponds to the uppercase equivalent ascii value). This shouldn't be a problem, however, as all the event server client would need to do is correct their implementation is to send the correct flag (0xf000) instead of the incorrect flag (0xf100). 
