### PR TITLE
bluray iso playback selection dialog

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -38,22 +38,6 @@
 using namespace std;
 using namespace XFILE;
 
-static bool is_udf_iso_path(const char* filename)
-{
-  bool bResult = false;
-
-  const char* ptr = strcasestr(filename, ".iso");
-  if(ptr)
-  {
-    ptr += strlen(".iso");
-    if(*ptr == '/' && strlen(++ptr) > 0)
-    {
-      bResult = true;
-    }
-  }
-  return bResult;
-}
-
 void DllLibbluray::file_close(BD_FILE_H *file)
 {
   if (file)
@@ -98,8 +82,9 @@ BD_FILE_H * DllLibbluray::file_open(const char* filename, const char *mode)
     BD_FILE_H *file = new BD_FILE_H;
 
     CStdString strFilename(filename);
-
-    if(is_udf_iso_path(filename))
+    CStdString strExtension(URIUtils::GetExtension(filename));
+    if(strExtension == ".iso"
+    || strExtension == ".img")
     {
       CURL::Encode(strFilename);
       strFilename.Format("udf://%s", strFilename);
@@ -173,12 +158,6 @@ BD_DIR_H *DllLibbluray::dir_open(const char* dirname)
     SDirState *st = new SDirState();
 
     CStdString strDirname(dirname);
-    if(is_udf_iso_path(dirname))
-    {
-      CURL::Encode(strDirname);
-      strDirname.Format("udf://%s", strDirname);
-      CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - Opening udf dir %s...", strDirname.c_str());
-    }
 
     if(!CDirectory::GetDirectory(strDirname, st->list))
     {

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -26,6 +26,7 @@
 #include "LangInfo.h"
 #include "utils/log.h"
 #include "guilib/Geometry.h"
+#include "URIUtils.h"
 #if defined(TARGET_DARWIN)
 #include "CocoaInterface.h"
 #endif
@@ -63,7 +64,6 @@ CDVDInputStreamNavigator::~CDVDInputStreamNavigator()
 
 bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& content)
 {
-  char* strDVDFile;
   m_icurrentGroupId = 0;
   if (!CDVDInputStream::Open(strFile, "video/x-dvd-mpeg"))
     return false;
@@ -78,38 +78,29 @@ bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& cont
   // libdvdcss fails if the file path contains VIDEO_TS.IFO or VIDEO_TS/VIDEO_TS.IFO
   // libdvdnav is still able to play without, so strip them.
 
-  // stripping only works 100% correctly for absolute paths.
-  // relative paths are not expected here and wouldn't make sense, so it's safe to assume we'll have
-  // at least one path separator character.
-
-  strDVDFile = strdup(strFile);
-  int len = strlen(strDVDFile);
-
-  if(len >= 13  // +1 on purpose, to include a separator char before the searched string
-  && strncasecmp(strDVDFile + len - 12, "VIDEO_TS.IFO", 12) == 0)
-    strDVDFile[len - 13] = '\0';
-
-  len = strlen(strDVDFile);
-  if(len >= 9  // +1 on purpose, to include a separator char before the searched string
-  && strncasecmp(strDVDFile + len - 8, "VIDEO_TS", 8) == 0)
-    strDVDFile[len - 9] = '\0';
+  CStdString path = strFile;
+  if(URIUtils::GetFileName(path) == "VIDEO_TS.IFO")
+    path = URIUtils::GetParentPath(path);
+  URIUtils::RemoveSlashAtEnd(path);
+  if(URIUtils::GetFileName(path) == "VIDEO_TS")
+    path = URIUtils::GetParentPath(path);
+  URIUtils::RemoveSlashAtEnd(path);
 
 #if defined(TARGET_DARWIN_OSX)
   // if physical DVDs, libdvdnav wants "/dev/rdiskN" device name for OSX,
   // strDVDFile will get realloc'ed and replaced IF this is a physical DVD.
-  strDVDFile = Cocoa_MountPoint2DeviceName(strDVDFile);
+  char* strDVDFile = Cocoa_MountPoint2DeviceName(strdup(path.c_str()));
+  path = strDVDFile;
+  free(strDVDFile);
 #endif
 
   // open up the DVD device
-  if (m_dll.dvdnav_open(&m_dvdnav, strDVDFile) != DVDNAV_STATUS_OK)
+  if (m_dll.dvdnav_open(&m_dvdnav, path.c_str()) != DVDNAV_STATUS_OK)
   {
-    free(strDVDFile);
-
     CLog::Log(LOGERROR,"Error on dvdnav_open\n");
     Close();
     return false;
   }
-  free(strDVDFile);
 
   int region = g_guiSettings.GetInt("dvds.playerregion");
   int mask = 0;

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -38,15 +38,26 @@ CUDFDirectory::~CUDFDirectory(void)
 bool CUDFDirectory::GetDirectory(const CStdString& strPath,
                                  CFileItemList &items)
 {
-  CStdString strRoot = strPath;
+  CStdString strRoot, strSub;
+  CURL url;
+  if(strPath.Left(6) == "udf://")
+  {
+    url.Parse(strPath);
+    CURL url(strPath);
+  }
+  else
+  {
+    url.SetProtocol("udf");
+    url.SetHostName(strPath);
+  }
+  strRoot  = url.Get();
+  strSub   = url.GetFileName();
+
   URIUtils::AddSlashAtEnd(strRoot);
-
-  CURL url(strPath);
-
-  CStdString strDirectory = url.GetHostName();
+  URIUtils::AddSlashAtEnd(strSub);
 
   udf25 udfIsoReader;
-  udf_dir_t *dirp = udfIsoReader.OpenDir(strDirectory);
+  udf_dir_t *dirp = udfIsoReader.OpenDir(url.GetHostName(), strSub);
 
   if (dirp == NULL)
     return false;

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -44,7 +44,6 @@ bool CUDFDirectory::GetDirectory(const CStdString& strPath,
   CURL url(strPath);
 
   CStdString strDirectory = url.GetHostName();
-  CURL::Decode(strDirectory);
 
   udf25 udfIsoReader;
   udf_dir_t *dirp = udfIsoReader.OpenDir(strDirectory);

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -50,8 +50,6 @@ bool CUDFFile::Open(const CURL& url)
 {
   CStdString strFName = url.GetHostName();
 
-  CURL::Decode(strFName);
-
   m_hFile = m_udfIsoReaderLocal.OpenFile((char*)strFName.c_str());
   if (m_hFile == INVALID_HANDLE_VALUE)
   {

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -48,9 +48,7 @@ CUDFFile::~CUDFFile()
 //*********************************************************************************************
 bool CUDFFile::Open(const CURL& url)
 {
-  CStdString strFName = url.GetHostName();
-
-  m_hFile = m_udfIsoReaderLocal.OpenFile((char*)strFName.c_str());
+  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetHostName(), url.GetFileName());
   if (m_hFile == INVALID_HANDLE_VALUE)
   {
     m_bOpened = false;
@@ -104,29 +102,18 @@ int64_t CUDFFile::GetPosition()
 
 bool CUDFFile::Exists(const CURL& url)
 {
-  string strFName = "\\";
-  strFName += url.GetFileName();
-  for (int i = 0; i < (int)strFName.size(); ++i )
-  {
-    if (strFName[i] == '/') strFName[i] = '\\';
-  }
-  m_hFile = m_udfIsoReaderLocal.OpenFile((char*)strFName.c_str());
+  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetHostName(), url.GetFileName());
   if (m_hFile == INVALID_HANDLE_VALUE)
     return false;
 
   m_udfIsoReaderLocal.CloseFile(m_hFile);
+  m_hFile = INVALID_HANDLE_VALUE;
   return true;
 }
 
 int CUDFFile::Stat(const CURL& url, struct __stat64* buffer)
 {
-  string strFName = "\\";
-  strFName += url.GetFileName();
-  for (int i = 0; i < (int)strFName.size(); ++i )
-  {
-    if (strFName[i] == '/') strFName[i] = '\\';
-  }
-  m_hFile = m_udfIsoReaderLocal.OpenFile((char*)strFName.c_str());
+  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetHostName(), url.GetFileName());
   if (m_hFile != INVALID_HANDLE_VALUE)
   {
     buffer->st_size = m_udfIsoReaderLocal.GetFileSize(m_hFile);

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -464,28 +464,6 @@ uint64_t DVDFileSeekForce(BD_FILE bdfile, uint64_t offset, int64_t force_size)
   return offset;
 }
 
-int UDFSplitIsoFile(const char *fullFilename, char* iso, char* file)
-{
-  const char* filename = strcasestr(fullFilename, ".iso");
-  if(!filename)
-    return -1;
-
-  filename += strlen(".iso");
-  if(*filename != '/')
-    return -1;
-
-  size_t size = strlen(filename);
-  memcpy(file, filename, size);
-  file[size] = 0;
-
-  size = filename - fullFilename;
-  memcpy(iso, fullFilename,  filename - fullFilename);
-  iso[size] = 0;
-
-  return 0;
-}
-
-
 int udf25::UDFScanDirX( udf_dir_t *dirp )
 {
   char filename[ MAX_UDF_FILE_NAME_LEN ];
@@ -1190,15 +1168,11 @@ UDF_FILE udf25::UDFFindFile( const char* filename, uint64_t *filesize )
   return result;
 }
 
-HANDLE udf25::OpenFile( const char* fullFilename )
+HANDLE udf25::OpenFile( const char* isoname, const char* filename )
 {
   uint64_t filesize;
   UDF_FILE file = NULL;
   BD_FILE bdfile = NULL;
-  char isoname[256], filename[256];
-
-  if(UDFSplitIsoFile(fullFilename, isoname, filename) !=0 )
-    return INVALID_HANDLE_VALUE;
 
   m_fp = file_open(isoname);
   if(m_fp)
@@ -1338,12 +1312,12 @@ int64_t udf25::GetFilePosition(HANDLE hFile)
   return bdfile->seek_pos;
 }
 
-udf_dir_t *udf25::OpenDir( const char *subdir )
+udf_dir_t *udf25::OpenDir(  const char *isofile, const char *subdir )
 {
   udf_dir_t *result;
   BD_FILE bd_file;
 
-  bd_file = (BD_FILE)OpenFile(subdir);
+  bd_file = (BD_FILE)OpenFile(isofile, subdir);
 
   if (bd_file == (BD_FILE)INVALID_HANDLE_VALUE)
   {

--- a/xbmc/filesystem/udf25.h
+++ b/xbmc/filesystem/udf25.h
@@ -183,11 +183,11 @@ public:
   int64_t GetFileSize(HANDLE hFile);
   int64_t GetFilePosition(HANDLE hFile);
   int64_t Seek(HANDLE hFile, int64_t lOffset, int whence);
-  HANDLE OpenFile( const char* filename );
+  HANDLE OpenFile(  const char *isofile, const char* filename );
   long ReadFile(HANDLE fd, unsigned char *pBuffer, long lSize);
   void CloseFile(HANDLE hFile);
 
-  udf_dir_t *OpenDir( const char *subdir );
+  udf_dir_t *OpenDir( const char *isofile, const char *subdir );
   udf_dirent_t *ReadDir( udf_dir_t *dirp );
   int CloseDir( udf_dir_t *dirp );
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -231,7 +231,8 @@ bool URIUtils::ProtocolHasParentInHostname(const CStdString& prot)
 {
   return prot.Equals("zip")
       || prot.Equals("rar")
-      || prot.Equals("bluray");
+      || prot.Equals("bluray")
+      || prot.Equals("udf");
 }
 
 bool URIUtils::ProtocolHasEncodedHostname(const CStdString& prot)

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -72,6 +72,7 @@
 #include "utils/EdenVideoArtUpdater.h"
 #include "GUIInfoManager.h"
 #include "utils/GroupUtils.h"
+#include "File.h"
 
 using namespace std;
 using namespace XFILE;
@@ -1073,6 +1074,22 @@ bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item)
     }
   }
 
+  CStdString ext = URIUtils::GetExtension(item->GetPath());
+  ext.ToLower();
+  if (ext == ".iso" ||  ext == ".img")
+  {
+    CURL url2("udf://");
+    url2.SetHostName(item->GetPath());
+    url2.SetFileName("BDMV/index.bdmv");
+    if (CFile::Exists(url2.Get()))
+    {
+      url2.SetFileName("");
+
+      CURL url("bluray://");
+      url.SetHostName(url2.Get());
+      return ShowPlaySelection(item, url.Get());
+    }
+  }
   return true;
 }
 


### PR DESCRIPTION
This should resolve the discrepancy between how .iso and bluray folders behaved when you startup playback. Previously starting index.bdmv would show a selection dialog to select what to play, but starting a .iso would always start longest track.

Now it should display selection for iso images as well
