### PR TITLE
fix: reset resume point after playing items via the playlist player

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -299,6 +299,10 @@ bool CPlayListPlayer::Play(int iSong, bool bAutoPlay /* = false */, bool bPlayPr
     }
   }
 
+  // reset the start offset of this item
+  if (item->m_lStartOffset == STARTOFFSET_RESUME)
+    item->m_lStartOffset = 0;
+
   // TODO - move the above failure logic and the below success logic
   //        to callbacks instead so we don't rely on the return value
   //        of PlayFile()


### PR DESCRIPTION
So that when they repeat the start at the beginning. fixes #12811.

Not hugely keen on the fix, but can't think of a better way around it.  The idea is to fix repeat plays in the playlist (e.g. when repeat is set to ALL or ONE) and the item is first played by resuming from a resume offset.  The user expects it to start back at the start if repeat is enabled, so we have to clear out the resume offset.
