### PR TITLE
silently cancel screensaver alarmclock

### DIFF
--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -45,7 +45,7 @@ bool CScreenSaver::CreateScreenSaver()
   if (URIUtils::GetExtension(LibPath()).Equals(".py", false))
   {
     // Don't allow a previously-scheduled alarm to kill our new screensaver
-    g_alarmClock.Stop(PYTHON_ALARM);
+    g_alarmClock.Stop(PYTHON_ALARM, true);
 
     if (!g_pythonParser.StopScript(LibPath()))
       g_pythonParser.evalFile(LibPath(), AddonPtr(new CScreenSaver(Props())));


### PR DESCRIPTION
for python screensavers, we silently start an alarmclock in order to kill the screensaver (if needed).

we should silently cancel the alarmclock as well.
this pr takes care of that.
