### PR TITLE
[gui] added colordiffuse attribute on texture definition

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -254,6 +254,7 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
   const char *flipY = pNode->Attribute("flipy");
   if (flipY && strcmpi(flipY, "true") == 0) image.orientation = 3 - image.orientation;  // either 3 or 2
   image.diffuse = pNode->Attribute("diffuse");
+  image.diffuseColor.Parse(pNode->Attribute("colordiffuse"), 0);
   const char *background = pNode->Attribute("background");
   if (background && strnicmp(background, "true", 4) == 0)
     image.useLarge = true;

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -46,6 +46,7 @@ CTextureInfo& CTextureInfo::operator=(const CTextureInfo &right)
   diffuse = right.diffuse;
   filename = right.filename;
   useLarge = right.useLarge;
+  diffuseColor = right.diffuseColor;
 
   return *this;
 }
@@ -174,8 +175,12 @@ void CGUITextureBase::Render()
 
   // set our draw color
   #define MIX_ALPHA(a,c) (((a * (c >> 24)) / 255) << 24) | (c & 0x00ffffff)
-  color_t color = m_diffuseColor;
-  if (m_alpha != 0xFF) color = MIX_ALPHA(m_alpha, m_diffuseColor);
+
+  // diffuse color
+  color_t color = (m_info.diffuseColor) ? m_info.diffuseColor : m_diffuseColor;
+  if (m_alpha != 0xFF)
+	  color = MIX_ALPHA(m_alpha, color);
+
   color = g_graphicsContext.MergeAlpha(color);
 
   // setup our renderer
@@ -543,6 +548,7 @@ bool CGUITextureBase::SetDiffuseColor(color_t color)
 {
   bool changed = m_diffuseColor != color;
   m_diffuseColor = color;
+  changed |= m_info.diffuseColor.Update();
   return changed;
 }
 

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -31,6 +31,7 @@
 #include "TextureManager.h"
 #include "Geometry.h"
 #include "system.h" // HAS_GL, HAS_DX, etc
+#include "GUIInfoTypes.h"
 
 typedef uint32_t color_t;
 
@@ -74,10 +75,11 @@ public:
   CTextureInfo(const CStdString &file);
   CTextureInfo& operator=(const CTextureInfo &right);
   bool       useLarge;
-  CRect      border;      // scaled  - unneeded if we get rid of scale on load
-  int        orientation; // orientation of the texture (0 - 7 == EXIForientation - 1)
-  CStdString diffuse;     // diffuse overlay texture
-  CStdString filename;    // main texture file
+  CRect      border;          // scaled  - unneeded if we get rid of scale on load
+  int        orientation;     // orientation of the texture (0 - 7 == EXIForientation - 1)
+  CStdString diffuse;         // diffuse overlay texture
+  CGUIInfoColor diffuseColor; // diffuse color
+  CStdString filename;        // main texture file
 };
 
 class CGUITextureBase


### PR DESCRIPTION
This PR adds color diffuse attribute for texture definitions.

It's based on the PR #268 and gets rid of the borderdiffuse attribute. also it don't override m_diffuseColor as @jmarshallnz has suggested.

Example:

```
<texture colordiffuse="FFFFAAFF">texture.png</texture>
<texture colordiffuse="$VAR[colordiffuse]">texture.png</texture>
<texture colordiffuse="$INFO[colordiffuse]">texture.png</texture>
```

Works for all texture controls, for example textureradioon, textureradiooff, texturefocus, texturenofocus etc.
