### PR TITLE
[pvr] add missing channel up/down key bindings in remaining keymap files

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -109,6 +109,14 @@
       <dpaddown>BigStepBack</dpaddown>
     </gamepad>
   </FullscreenVideo>
+  <FullscreenLiveTV>
+    <gamepad>
+      <dpadleft>PreviousChannelGroup</dpadleft>
+      <dpadright>NextChannelGroup</dpadright>
+      <dpadup>ChannelUp</dpadup>
+      <dpaddown>ChannelDown</dpaddown>
+    </gamepad>
+  </FullscreenLiveTV>
   <FullscreenInfo>
     <gamepad>
       <start>OSD</start>

--- a/system/keymaps/joystick.AppleRemote.xml
+++ b/system/keymaps/joystick.AppleRemote.xml
@@ -111,6 +111,14 @@
       <!-- FlickDown  -->      <button id="88">BigStepBack</button>
     </joystick>
   </FullscreenVideo>
+  <FullscreenLiveTV>
+    <joystick name="AppleRemote">
+      <button id="3">ChannelDown</button>
+      <button id="4">ChannelUp</button>
+      <!-- pageup     -->      <button id="13">ChannelUp</button>
+      <!-- pagedown   -->      <button id="14">ChannelDown</button>
+    </joystick>
+  </FullscreenLiveTV>
   <Visualisation>
     <joystick name="AppleRemote">
       <button id="1">VolumeUp</button>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -172,6 +172,14 @@
       <!-- F6		-->      <button id="94">ShowSubtitles</button>
     </joystick>
   </FullscreenVideo>
+  <FullscreenLiveTV>
+    <joystick name="Harmony">
+      <!-- up       	-->      <button id="1">ChannelUp</button>
+      <!-- down      	-->      <button id="2">ChannelDown</button>
+      <!-- left       	-->      <button id="3">PreviousChannelGroup</button>
+      <!-- right      	-->      <button id="4">NextChannelGroup</button>
+    </joystick>
+  </FullscreenLiveTV>
   <FullscreenInfo>
     <joystick name="Harmony">
       <!-- Info  	-->      <button id="31">Back</button>

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -63,6 +63,16 @@
     </joystick>
   </FullscreenVideo>
 
+  <FullscreenLiveTV>
+    <joystick name="Logitech Logitech Cordless RumblePad 2">
+      <altname>Logitech Cordless RumblePad 2</altname>
+      <hat    id="1" position="left">PreviousChannelGroup</hat>
+      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="up">ChannelUp</hat>
+      <hat    id="1" position="down">ChannelDown</hat>
+    </joystick>
+  </FullscreenLiveTV>
+
   <Visualisation>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -175,6 +175,22 @@
       <axis limit="0" id="6">AnalogFastForward</axis>
     </joystick>
   </FullscreenVideo>
+  <FullscreenLiveTV>
+    <joystick name="Xbox 360 Wireless Receiver">
+      <altname>Controller (Gamepad for Xbox 360)</altname>
+      <altname>Controller (XBOX 360 For Windows)</altname>
+      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
+      <altname>Controller (Xbox wireless receiver for windows)</altname>
+      <altname>XBOX 360 For Windows (Controller)</altname>
+      <altname>XBOX 360 For Windows</altname>
+      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
+      <altname>Xbox wireless receiver for windows (Controller)</altname>
+      <button id="11">ChannelUp</button>
+      <button id="12">ChannelDown</button>
+      <button id="13">PreviousChannelGroup</button>
+      <button id="14">NextChannelGroup</button>
+    </joystick>
+  </FullscreenLiveTV>
   <FullscreenInfo>
     <joystick name="Xbox 360 Wireless Receiver">
       <altname>Controller (Gamepad for Xbox 360)</altname>

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -128,6 +128,17 @@
       <axis limit="0" id="6">AnalogFastForward</axis>
     </joystick>
   </FullscreenVideo>
+  <FullscreenLiveTV>
+    <joystick name="Microsoft Xbox Controller S">
+      <altname>Mad Catz MicroCON</altname>
+      <altname>Logitech Xbox Cordless Controller</altname>
+      <altname>Microsoft X-Box pad (Japan)</altname> 
+      <button id="13">ChannelUp</button>
+      <button id="14">NextChannelGroup</button>
+      <button id="15">ChannelDown</button>
+      <button id="16">PreviousChannelGroup</button>
+    </joystick>
+  </FullscreenLiveTV>
   <FullscreenInfo>
     <joystick name="Microsoft Xbox Controller S">
       <altname>Mad Catz MicroCON</altname>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -101,7 +101,16 @@
       <hat    id="1" position="down">BigStepBack</hat>
     </joystick>
   </FullscreenVideo>
-  
+
+  <FullscreenLiveTV>
+    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
+      <hat    id="1" position="left">PreviousChannelGroup</hat>
+      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="up">ChannelUp</hat>
+      <hat    id="1" position="down">ChannelDown</hat>
+    </joystick>
+  </FullscreenLiveTV>
+
   <VideoOSD>
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>

--- a/system/keymaps/joystick.WiiRemote.xml
+++ b/system/keymaps/joystick.WiiRemote.xml
@@ -100,6 +100,12 @@
       <button id="11">AspectRatio</button>
     </joystick>
   </FullscreenVideo>
+  <FullscreenLiveTV>
+    <joystick name="WiiRemote">
+      <button id="3">ChannelDown</button>
+      <button id="4">ChannelUp</button>
+    </joystick>
+  </FullscreenLiveTV>
   <FullscreenInfo>
     <joystick name="WiiRemote">
       <button id="5">CodecInfo</button>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -508,6 +508,14 @@
       <back>Close</back>
     </remote>
   </Favourites>
+  <FullscreenLiveTV>
+    <remote>
+      <left>PreviousChannelGroup</left>
+      <right>NextChannelGroup</right>
+      <up>ChannelUp</up>
+      <down>ChannelDown</down>
+    </remote>
+  </FullscreenLiveTV>
   <PVROSDChannels>
     <remote>
       <back>Close</back>


### PR DESCRIPTION
This PR adds the key binding for channel up/down in FullscreenLiveTV to the rest of the shipped keymap files after 108c19c. Note that was not able to test any of those keymaps (that's why they where not part of the initial PR) but I gave my best to find proper mappings for each controller.
