### PR TITLE
FIX: No update path for pre-frodo scrapped thumb url without "aspect" attribute

### DIFF
--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -313,7 +313,7 @@ void CScraperUrl::GetThumbURLs(std::vector<CStdString> &thumbs, const std::strin
 {
   for (vector<SUrlEntry>::const_iterator iter = m_url.begin(); iter != m_url.end(); ++iter)
   {
-    if (iter->m_aspect == type || type.empty() || type == "thumb")
+    if (iter->m_aspect == type || type.empty() || type == "thumb" || iter->m_aspect.empty())
     {
       if ((iter->m_type == CScraperUrl::URL_TYPE_GENERAL && season == -1)
        || (iter->m_type == CScraperUrl::URL_TYPE_SEASON && iter->m_season == season))


### PR DESCRIPTION
I don't if it is a conscious decision or an oversight, but the thumb url's scrapped pre-frodo with no "aspect" attribute will never show up in the art chooser.

This patch makes so that they are _always_ shown.

Reasoning is that not showing them will, at best, induce unnecessary rescrap and, at worst, induce tickets/forum discussions/bad rep
