### PR TITLE
added Skin.HasFontTheme() condition

### DIFF
--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -230,7 +230,7 @@
 		<control type="group">
 			<posx>0</posx>
 			<posy>350</posy>
-			<visible>Control.IsVisible(509) + Skin.HasSetting(View509HideInfo)]</visible>
+			<visible>Control.IsVisible(509) + Skin.HasSetting(View509HideInfo)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="image">
 				<posx>0</posx>


### PR DESCRIPTION
This commits adds a Skin.HasFontTheme() condition.
Main reason I added this was that some fonts have a different y-alignment and cannot be exchanged 1:1 with other fonts by using different fontsets. with this new condtion we can solve this.
