### PR TITLE
don't group movies into sets in files view

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1849,8 +1849,9 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
   CQueryParams params;
   CVideoDatabaseDirectory dir;
   dir.GetQueryParams(items.GetPath(), params);
+  VIDEODATABASEDIRECTORY::NODE_TYPE nodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_strFilterPath);
   if (items.GetContent().Equals("movies") && params.GetSetId() <= 0 &&
-      CVideoDatabaseDirectory::GetDirectoryChildType(items.GetPath()) != NODE_TYPE_RECENTLY_ADDED_MOVIES &&
+      nodeType == NODE_TYPE_TITLE_MOVIES &&
       g_guiSettings.GetBool("videolibrary.groupmoviesets"))
   {
     CFileItemList groupedItems;


### PR DESCRIPTION
Title says it all. Currently we group movie items listed in files view into sets which is probably not what people using files view (I don't so I don't really know) want.
