### PR TITLE
pvr: Fixed search dialog

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -95,21 +95,22 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
 
 void CGUIDialogPVRGuideSearch::UpdateGroupsSpin(void)
 {
-  CFileItemList groups;
   CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_GROUPS);
   if (!pSpin)
     return;
 
+  std::vector<CPVRChannelGroupPtr> group;
+  std::vector<CPVRChannelGroupPtr>::const_iterator it;
+
   /* tv groups */
-  g_PVRChannelGroups->GetTV()->GetGroupList(&groups);
-  for (int iGroupPtr = 0; iGroupPtr < groups.Size(); iGroupPtr++)
-    pSpin->AddLabel(groups[iGroupPtr]->GetLabel(), atoi(groups[iGroupPtr]->GetPath()));
+  group = g_PVRChannelGroups->GetTV()->GetMembers();
+  for (it = group.begin(); it != group.end(); ++it)
+    pSpin->AddLabel((*it)->GroupName(), (*it)->GroupID());
 
   /* radio groups */
-  groups.ClearItems();
-  g_PVRChannelGroups->GetRadio()->GetGroupList(&groups);
-  for (int iGroupPtr = 0; iGroupPtr < groups.Size(); iGroupPtr++)
-    pSpin->AddLabel(groups[iGroupPtr]->GetLabel(), atoi(groups[iGroupPtr]->GetPath()));
+  group = g_PVRChannelGroups->GetRadio()->GetMembers();
+  for (it = group.begin(); it != group.end(); ++it)
+    pSpin->AddLabel((*it)->GroupName(), (*it)->GroupID());
 
   pSpin->SetValue(m_searchFilter->m_iChannelGroup);
 }


### PR DESCRIPTION
The guide based search was not working correctly because of incorrect
spinner values for the channel group.

Before the spinner values for the channel group were created by a call to atoi:

```
atoi("channels/tv/2/")
```

This returned 0 for all channel groups.

The new code uses a call to GroupID().
