### PR TITLE
AE: don't disable devices - as detection does not work reliable

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -952,20 +952,13 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
 
             if (badHDMI)
             {
-              /* only trust badHDMI (= unconnected or non-existent port) on Intel
-               * and NVIDIA where it has been confirmed to work, show the empty
-               * port on other systems */
-              if (info.m_displayName.compare(0, 9, "HDA Intel") == 0 || info.m_displayName.compare(0, 10, "HDA NVidia") == 0)
-              {
-                /* unconnected HDMI port */
-                CLog::Log(LOGDEBUG, "CAESinkALSA - Skipping HDMI device \"%s\" as it has no ELD data", device.c_str());
-                snd_pcm_close(pcmhandle);
-                return;
-              }
-              else
-              {
-                CLog::Log(LOGDEBUG, "CAESinkALSA - HDMI device \"%s\" may be unconnected (no ELD data)", device.c_str());
-              }
+              /* 
+               * Warn about disconnected devices, but keep them enabled 
+               * Detection can go wrong on Intel, Nvidia and on all 
+               * AMD (fglrx) hardware, so it is not safe to close those
+               * handles
+               */
+              CLog::Log(LOGDEBUG, "CAESinkALSA - HDMI device \"%s\" may be unconnected (no ELD data)", device.c_str());
             }
           }
           else


### PR DESCRIPTION
This fixes at least two problems:

a) The detection goes wrong on some Intel and nvidia devices. Those users end up with non working HDMI Audio. AMD cards were whitelisted since a long time, as they report always disconnected.

b) If a user boots with his (probably faulty) receiver powered off. He cannot reactivate the HDMI output later, as it is only scanned on startup. Many users boot with TV and AVR off, so end up with no audio.

There are probably better solutions to this. It should not introduce regressions, but it should make audio work for users with the described problems.
