### PR TITLE
[Fix] Add missing audiochannels rule to PlayerSelectionRule.cpp

### DIFF
--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -129,6 +129,12 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, VECPLAYERCORES &vec
     CStreamDetails streamDetails = item.GetVideoInfoTag()->m_streamDetails;
 
     if (CompileRegExp(m_audioCodec, regExp) && !MatchesRegExp(streamDetails.GetAudioCodec(), regExp)) return;
+    
+    std::stringstream itoa;
+    itoa << streamDetails.GetAudioChannels();
+    CStdString audioChannelsstr = itoa.str();
+
+    if (CompileRegExp(m_audioChannels, regExp) && !MatchesRegExp(audioChannelsstr, regExp)) return;
 
     if (CompileRegExp(m_videoCodec, regExp) && !MatchesRegExp(streamDetails.GetVideoCodec(), regExp)) return;
 


### PR DESCRIPTION
This adds the missing test against the audiochannels rule in PlayerSelectionRule.cpp.  Fixes http://trac.xbmc.org/ticket/13536

I wasn't entirely sure what the best way to convert an integer to a string was, so I just copied this code from CSFTPSessionManager::CreateSession (which was about the only place I could find that already did it).
