### PR TITLE
custom library node cleanup

### DIFF
--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -172,7 +172,7 @@ bool CLibraryDirectory::Exists(const char* strPath)
 CStdString CLibraryDirectory::GetNode(const CStdString &path)
 {
   CURL url(path);
-  CStdString libDir = URIUtils::AddFileToFolder(g_settings.GetDatabaseFolder(), url.GetHostName() + "/");
+  CStdString libDir = URIUtils::AddFileToFolder(g_settings.GetLibraryFolder(), url.GetHostName() + "/");
   if (!CDirectory::Exists(libDir))
     libDir = URIUtils::AddFileToFolder("special://xbmc/system/library/", url.GetHostName() + "/");
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -1746,6 +1746,17 @@ CStdString CSettings::GetBookmarksThumbFolder() const
   return folder;
 }
 
+CStdString CSettings::GetLibraryFolder() const
+{
+  CStdString folder;
+  if (GetCurrentProfile().hasDatabases())
+    URIUtils::AddFileToFolder(GetProfileUserDataFolder(), "library", folder);
+  else
+    URIUtils::AddFileToFolder(GetUserDataFolder(), "library", folder);
+
+  return folder;
+}
+
 CStdString CSettings::GetSourcesFile() const
 {
   CStdString folder;
@@ -1844,6 +1855,7 @@ void CSettings::CreateProfileFolders()
   }
   CDirectory::Create("special://profile/addon_data");
   CDirectory::Create("special://profile/keymaps");
+  CDirectory::Create(GetLibraryFolder());
 }
 
 static CProfile emptyProfile;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -342,6 +342,7 @@ public:
   CStdString GetThumbnailsFolder() const;
   CStdString GetVideoThumbFolder() const;
   CStdString GetBookmarksThumbFolder() const;
+  CStdString GetLibraryFolder() const;
   CStdString GetSourcesFile() const;
 
   CStdString GetSettingsFile() const;


### PR DESCRIPTION
This PR contains two commits which cleanup/improve the behaviour of custom (video) library node handling:
- Allow user-defined custom library nodes in <profile>/userdata/library instead of <profile>/userdata/Database which is absolutely not the right place to put these XML files.
- When showing the list of custom library nodes merge the list of pre-defined (and shipped) library nodes and user-defined library nodes. In case of duplicates (based on filename) only the user-defined library node will be listed. Furthermore if there are duplicates and the user-defined library node is empty, neither the pre-defined nor the user-defined (which is empty anyway) node will be shown.

I consider the first commit a fix (because the current path doesn't make sense) and the second commit a usability improvement. Therefore I'd be willing to remove the second commit from this PR.
