### PR TITLE
fixed: audiooutput.normalizelevels is reversed, for now just invert the ...

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AERemap.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AERemap.cpp
@@ -193,7 +193,8 @@ bool CAERemap::Initialize(CAEChannelInfo input, CAEChannelInfo output, bool fina
     normalize = true;
   else
   {
-    normalize = g_guiSettings.GetBool("audiooutput.normalizelevels");
+    //FIXME: guisetting is reversed, change the setting name after frodo
+    normalize = !g_guiSettings.GetBool("audiooutput.normalizelevels");
     CLog::Log(LOGDEBUG, "AERemap: Downmix normalization is %s", (normalize ? "enabled" : "disabled"));
   }
 


### PR DESCRIPTION
...bool, after frodo the setting name will be changed
