### PR TITLE
don't blindly add slashes at the end of sources. fixes #13550

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -357,7 +357,8 @@ CFileItem::CFileItem(const CMediaSource& share)
   m_bIsFolder = true;
   m_bIsShareOrDrive = true;
   m_strPath = share.strPath;
-  URIUtils::AddSlashAtEnd(m_strPath);
+  if (!IsRSS()) // no slash at end for rss feeds
+    URIUtils::AddSlashAtEnd(m_strPath);
   CStdString label = share.strName;
   if (!share.strStatus.IsEmpty())
     label.Format("%s (%s)", share.strName.c_str(), share.strStatus.c_str());

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -74,7 +74,6 @@ void CMediaSource::FromNameAndPaths(const CStdString &category, const CStdString
     m_iDriveType = SOURCE_TYPE_UNKNOWN;
   // check - convert to url and back again to make sure strPath is accurate
   // in terms of what we expect
-  URIUtils::AddSlashAtEnd(strPath);
   strPath = CURL(strPath).Get();
 }
 

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -366,7 +366,6 @@ void CGUIDialogMediaSource::OnPath(int item)
 
   CStdString path(m_paths->Get(item)->GetPath());
   CGUIKeyboardFactory::ShowAndGetInput(path, g_localizeStrings.Get(1021), false);
-  URIUtils::AddSlashAtEnd(path);
   m_paths->Get(item)->SetPath(path);
 
   if (!m_bNameChanged || m_name.IsEmpty())


### PR DESCRIPTION
This theoretically shouldn't break anything, seeing as we add slashes pretty much anywhere we can at the moment.

I've restricted the change to just hit rss feeds as targetting the ticket.

@elupus would appreciate your comment.
