### PR TITLE
videodb: allow deletion of smartplaylists

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1606,7 +1606,8 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
       return;
   }
 
-  if (g_guiSettings.GetBool("filelists.allowfiledeletion") &&
+  if ((g_guiSettings.GetBool("filelists.allowfiledeletion") ||
+       m_vecItems->GetPath().Equals("special://videoplaylists/")) &&
       CUtil::SupportsWriteFileOperations(item->GetPath()))
     CFileUtils::DeleteItem(item);
 }


### PR DESCRIPTION
This restores the functionality to be able to delete video smartplaylists independent of the value of the "filelists.allowfiledeletion" setting. IMO for any files that the user creates through xbmc it should also be possible to delete them through xbmc.

This only needs to change for video smartplaylists as the behaviour never changed for music smartplaylists.
