### PR TITLE
Fix: focus staying in middle of list in CGUIDialogSelect and CGUIWindowSettingsCategory

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -330,8 +330,8 @@ void CGUIDialogSelect::OnInitWindow()
   SetupButton();
   CGUIDialogBoxBase::OnInitWindow();
 
-  if (m_iSelected >= 0)
-    m_viewControl.SetSelectedItem(m_iSelected);
+  // if m_iSelected < 0 focus first item
+  m_viewControl.SetSelectedItem(std::max(m_iSelected, 0));
 }
 
 void CGUIDialogSelect::OnWindowUnload()

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -645,6 +645,7 @@ void CGUIControlGroup::ClearAll()
     CGUIControl *control = *it;
     delete control;
   }
+  m_focusedControl = 0;
   m_children.clear();
   m_lookup.clear();
   SetInvalid();


### PR DESCRIPTION
1. DialogSelect: fixes focus staying on same item when we show dialog next time
2. fixes focus staying in middle of setting list when jumping through setting tabs
