### PR TITLE
FIX: [droid] Do not define XBMC_TEMP, thus moving temp to user folder, thus external storage if avail

### DIFF
--- a/xbmc/android/activity/android_main.cpp
+++ b/xbmc/android/activity/android_main.cpp
@@ -84,7 +84,6 @@ void setup_env(struct android_app* state)
   
   // Get the path to the temp/cache directory
   char cacheDir[PATH_MAX] = {0};
-  char tempDir[PATH_MAX] = {0};
   jmethodID midActivityGetCacheDir = env->GetMethodID(cActivity, "getCacheDir", "()Ljava/io/File;");
   jobject oCacheDir = env->CallObjectMethod(oActivity, midActivityGetCacheDir);
 
@@ -95,13 +94,9 @@ void setup_env(struct android_app* state)
   jstring sCachePath = (jstring)env->CallObjectMethod(oCacheDir, midFileGetAbsolutePath);
   temp = env->GetStringUTFChars(sCachePath, NULL);
   strcpy(cacheDir, temp);
-  strcpy(tempDir, temp);
   env->ReleaseStringUTFChars(sCachePath, temp);
   env->DeleteLocalRef(sCachePath);
   env->DeleteLocalRef(oCacheDir);
-
-  strcat(tempDir, "/temp");
-  setenv("XBMC_TEMP", tempDir, 0);
 
   strcat(cacheDir, "/apk");
 


### PR DESCRIPTION
Main goal is to move xbmc.log to user folder, so that it is accessible.

Still a FIX, IMO, because:
1) temp, i.e. ever-changing files, should not be put on internal flash if possible.
2) this aligns droid with the other 'nix platforms
