### PR TITLE
pvr: Sort recordings view by date as default

### DIFF
--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -40,6 +40,9 @@ CGUIViewStatePVR::CGUIViewStatePVR(const CFileItemList& items) :
     AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // FileName, Size | Foldername, Size
     AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
     AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
+
+    // Sort recordings view by date as default
+    SetSortMethod(SORT_METHOD_DATE);
   }
 
   LoadViewState(items.GetPath(), ActiveView == PVR_WINDOW_UNKNOWN ? WINDOW_PVR : WINDOW_PVR + 100 - ActiveView );


### PR DESCRIPTION
@opdenkamp: as discussed, this sorts the recording view by date as default

For date's the default order is descending (most recent recording on top):
https://github.com/xbmc/xbmc/blob/master/xbmc/GUIViewState.cpp#L164

Cheers,
Christian
