### PR TITLE
Gles fixes for texture rendering

### DIFF
--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -80,13 +80,13 @@ void CGUITextureGLES::Begin(color_t color)
   }
   else
   {
-    if ( hasAlpha )
+    if (m_col[0][0] == 255 && m_col[0][1] == 255 && m_col[0][2] == 255 && m_col[0][3] == 255)
     {
-      g_Windowing.EnableGUIShader(SM_TEXTURE);
+      g_Windowing.EnableGUIShader(SM_TEXTURE_NOBLEND);
     }
     else
     {
-      g_Windowing.EnableGUIShader(SM_TEXTURE_NOBLEND);
+      g_Windowing.EnableGUIShader(SM_TEXTURE);
     }
   }
 

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -75,8 +75,6 @@ void CGUITextureGLES::Begin(color_t color)
     GLint tex1Loc = g_Windowing.GUIShaderGetCoord1();
     glVertexAttribPointer(tex1Loc, 2, GL_FLOAT, 0, 0, m_tex1);
     glEnableVertexAttribArray(tex1Loc);
-
-    hasAlpha = true;
   }
   else
   {


### PR DESCRIPTION
This fixes two things:
1. The SM_TEXTURE_NOBLEND shader is guishader_frag_texture_noblend.glsl which ignores the diffusecolor.  Thus, we should use this shader only if the diffuse color is not 0xffffffff.
2. We should apply blending only if hasAlpha is true.  In the multi-texture case we currently always set hasAlpha true, regardless of whether it is needed.

Both need testing on a GLES system.  Ideally with a skin that uses diffusecolor with an unblended texture, such as Immersive: http://forum.xbmc.org/showthread.php?tid=139712  In addition, the reflected, blended textures in Confluence should ofcourse stay working (simple test for the hasAlpha change).
