### PR TITLE
fixed: AE suspending was broken resulting in it resuming/suspending over...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -1041,7 +1041,7 @@ void CSoftAE::Run()
         delete m_sink;
         m_sink = NULL;
       }
-      if (!m_playingStreams.empty() || !m_playing_sounds.empty() || m_sounds.empty())
+      if (!m_playingStreams.empty() || !m_playing_sounds.empty() || !m_sounds.empty())
         m_softSuspend = false;
       m_wake.WaitMSec(SOFTAE_IDLE_WAIT_MSEC);
     }


### PR DESCRIPTION
... and over again (fixes ticket #13508)

As we don't seem to be getting anywhere with PR1548, I made a seperate PR to at least fix this issue for Frodo as in its current state AE suspending is borked and causes wasting cpu cycles on embedded platforms like RPI.
