### PR TITLE
smartplaylists: make "title" field browseable (again)

### DIFF
--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -30,6 +30,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
+#include "utils/LabelFormatter.h"
 
 #define CONTROL_FIELD           15
 #define CONTROL_OPERATOR        16
@@ -213,10 +214,40 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     videodatabase.GetWritersNav(basePath, items, type);
     iLabel = 20417;
   }
-  else if (m_rule.m_field == FieldTvShowTitle)
+  else if (m_rule.m_field == FieldTvShowTitle ||
+          (m_type.Equals("tvshows") && m_rule.m_field == FieldTitle))
   {
-    videodatabase.GetTvShowsNav("videodb://2/2/",items);
+    videodatabase.GetTvShowsNav(basePath + "2/", items);
     iLabel = 20343;
+  }
+  else if (m_rule.m_field == FieldTitle)
+  {
+    if (m_type.Equals("songs"))
+    {
+      database.GetSongsNav("musicdb://4/", items, -1, -1, -1);
+      iLabel = 134;
+    }
+    else if (m_type.Equals("movies"))
+    {
+      videodatabase.GetMoviesNav(basePath + "2/", items);
+      iLabel = 20342;
+    }
+    else if (m_type.Equals("episodes"))
+    {
+      videodatabase.GetEpisodesNav(basePath + "2/-1/-1/", items);
+      // we need to replace the db label (<season>x<episode> <title>) with the title only
+      CLabelFormatter format("%T", "");
+      for (int i = 0; i < items.Size(); i++)
+        format.FormatLabel(items[i].get());
+      iLabel = 20360;
+    }
+    else if (m_type.Equals("musicvideos"))
+    {
+      videodatabase.GetMusicVideosNav(basePath + "2/", items);
+      iLabel = 20389;
+    }
+    else
+      assert(false);
   }
   else if (m_rule.m_field == FieldPlaylist)
   {

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -62,7 +62,7 @@ static const translateField fields[] = {
   { "styles",            FieldStyles,                  SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,       176 },
   { "type",              FieldAlbumType,               SortByAlbumType,                CSmartPlaylistRule::TEXT_FIELD,       564 },
   { "label",             FieldMusicLabel,              SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,       21899 },
-  { "title",             FieldTitle,                   SortByTitle,                    CSmartPlaylistRule::TEXT_FIELD,       556 },
+  { "title",             FieldTitle,                   SortByTitle,                    CSmartPlaylistRule::BROWSEABLE_FIELD, 556 },
   { "sorttitle",         FieldSortTitle,               SortBySortTitle,                CSmartPlaylistRule::TEXT_FIELD,       556 },
   { "year",              FieldYear,                    SortByYear,                     CSmartPlaylistRule::BROWSEABLE_NUMERIC_FIELD, 562 },
   { "time",              FieldTime,                    SortByTime,                     CSmartPlaylistRule::SECONDS_FIELD,    180 },


### PR DESCRIPTION
This makes the "title" field in a smartplaylist browseable again (was brought up in the forum). I probably accidentally removed that functionality in my GSoC work. IMO this makes perfect sense for movies, tvshows and musicvideos. Whether it makes sense for episodes and songs is disputable but I went with the "consistent" approach and implemented it for all of them. For episodes I had to add a workaround because the videodb returns episode items with a "<season>x<episode> <label>" label which obviously won't match anything in the database when directly used. Therefore I have to replace all the episode labels with the title from the video info tag.

The only not-so-nice effect is that if there are e.g. multiple episodes called "Pilot" they appear multiple times in the browseable list.

If requested I don't have any objections to remove browseable support for songs and episodes.
