### PR TITLE
RFC: Who is scraping

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8726,7 +8726,27 @@ msgctxt "#20316"
 msgid "Sort by: ID"
 msgstr ""
 
-#empty strings from id 20317 to 20323
+msgctxt "#20317"
+msgid "Scanning movies using %s"
+msgstr ""
+
+msgctxt "#20318"
+msgid "Scanning music videos using %s"
+msgstr ""
+
+msgctxt "#20319"
+msgid "Scanning tvshows using %s"
+msgstr ""
+
+msgctxt "#20320"
+msgid "Scanning artists using %s"
+msgstr ""
+
+msgctxt "#20321"
+msgid "Scanning albums using %s"
+msgstr ""
+
+#empty strings from id 20322 to 20323
 
 msgctxt "#20324"
 msgid "Play part..."

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -165,8 +165,6 @@ void CMusicInfoScanner::Process()
     bool bCanceled;
     if (m_scanType == 1) // load album info
     {
-      if (m_handle)
-        m_handle->SetTitle(g_localizeStrings.Get(21885));
       int iCurrentItem = 1;
       for (set<CAlbum>::iterator it=m_albumsToScan.begin();it != m_albumsToScan.end();++it)
       {
@@ -185,9 +183,6 @@ void CMusicInfoScanner::Process()
     }
     if (m_scanType == 2) // load artist info
     {
-      if (m_handle)
-        m_handle->SetTitle(g_localizeStrings.Get(21886));
-
       int iCurrentItem=1;
       for (set<CArtist>::iterator it=m_artistsToScan.begin();it != m_artistsToScan.end();++it)
       {
@@ -918,7 +913,7 @@ bool CMusicInfoScanner::DownloadAlbumInfo(const CStdString& strPath, const CStdS
 
   if (m_handle)
   {
-    m_handle->SetTitle(g_localizeStrings.Get(21885));
+    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20321), info->Name().c_str()));
     m_handle->SetText(strArtist+" - "+strAlbum);
   }
 
@@ -1152,7 +1147,7 @@ bool CMusicInfoScanner::DownloadArtistInfo(const CStdString& strPath, const CStd
 
   if (m_handle)
   {
-    m_handle->SetTitle(g_localizeStrings.Get(21886));
+    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20320), info->Name().c_str()));
     m_handle->SetText(strArtist);
   }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -249,8 +249,8 @@ namespace VIDEO
     {
       if (m_handle)
       {
-        int str = content == CONTENT_MOVIES ? 20374:20408;
-        m_handle->SetTitle(g_localizeStrings.Get(str));
+        int str = content == CONTENT_MOVIES ? 20317:20318;
+        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str), info->Name().c_str()));
       }
 
       CStdString fastHash = GetFastHash(strDirectory);
@@ -294,7 +294,7 @@ namespace VIDEO
     else if (content == CONTENT_TVSHOWS)
     {
       if (m_handle)
-        m_handle->SetTitle(g_localizeStrings.Get(20409));
+        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319), info->Name().c_str()));
 
       if (foundDirectly && !settings.parent_name_root)
       {


### PR DESCRIPTION
I've had some requests from a couple of the websites we have a close relationship with (i.e. default scraper sites) to help highlighting the source of the data.

This PR has 3 separate ideas.
1. Add the name of the website we're scraping during scan.  This is the least impact (5 strings to translate).
2. Add an icon for the scraper during scan. This would ideally be combined with skin changes.
3. Add icon + name to music and video information dialogs.

The second I don't think works very well (but I've left it in for completeness) and the last requires quite a bit of thought for skinners, and in some senses is a guess, rather than being accurate (.nfo files override default scraper etc).

Thus, if we want to (slightly) improve things, the first one is the only option for Frodo.
