### PR TITLE
AE + Alsa fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -1041,7 +1041,7 @@ void CSoftAE::Run()
         delete m_sink;
         m_sink = NULL;
       }
-      if (!m_playingStreams.empty() || !m_playing_sounds.empty() || !m_sounds.empty())
+      if (!m_playingStreams.empty() || !m_playing_sounds.empty())
         m_softSuspend = false;
       m_wake.WaitMSec(SOFTAE_IDLE_WAIT_MSEC);
     }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -489,9 +489,6 @@ unsigned int CAESinkALSA::AddPackets(uint8_t *data, unsigned int frames, bool ha
   if (!m_pcm)
     return 0;
 
-  if (snd_pcm_state(m_pcm) == SND_PCM_STATE_PREPARED)
-    snd_pcm_start(m_pcm);
-
   int ret;
 
   ret = snd_pcm_avail(m_pcm);
@@ -519,6 +516,9 @@ unsigned int CAESinkALSA::AddPackets(uint8_t *data, unsigned int frames, bool ha
       ret = 0;
     }
   }
+
+  if ( ret > 0 && snd_pcm_state(m_pcm) == SND_PCM_STATE_PREPARED)
+    snd_pcm_start(m_pcm);
 
   return ret;
 }


### PR DESCRIPTION
2 small changes that make a big difference for the Alsa sink.

The first addresses my comments here: https://github.com/xbmc/xbmc/commit/e0a9d07e18d2578702e3ed158e006d3544d2a232#commitcomment-2184522

The second fixes a problem with Alsa init where there's nothing in the buffer when we start. We must ensure that we have a period or two in the buffer before starting playback.

Tested and seems happy on Pivos.
