### PR TITLE
[fix] Deadlock on exit with Monitor scripts, plus Gil handling refactor

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		DFAB04C113F8385F00B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB04BF13F8385F00B70BFB /* InertialScrollingHandler.cpp */; };
 		DFAB4C0F15FCCB4300E1BAF6 /* TagLibVFSStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB4C0B15FCCB4300E1BAF6 /* TagLibVFSStream.cpp */; };
 		DFAB4C1015FCCB4300E1BAF6 /* TagLoaderTagLib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB4C0D15FCCB4300E1BAF6 /* TagLoaderTagLib.cpp */; };
+		DFB02E0816629E1900F37752 /* PyContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB02E0616629E1900F37752 /* PyContext.cpp */; };
 		DFB25D00163D3DA9006C4A48 /* Addon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD02E15FCE62E00E10810 /* Addon.cpp */; };
 		DFB25D01163D3DA9006C4A48 /* AddonCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD03215FCE62E00E10810 /* AddonCallback.cpp */; };
 		DFB25D02163D3DA9006C4A48 /* AddonClass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD03615FCE62E00E10810 /* AddonClass.cpp */; };
@@ -1404,6 +1405,8 @@
 		DFAB4C0C15FCCB4300E1BAF6 /* TagLibVFSStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLibVFSStream.h; sourceTree = "<group>"; };
 		DFAB4C0D15FCCB4300E1BAF6 /* TagLoaderTagLib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TagLoaderTagLib.cpp; sourceTree = "<group>"; };
 		DFAB4C0E15FCCB4300E1BAF6 /* TagLoaderTagLib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLoaderTagLib.h; sourceTree = "<group>"; };
+		DFB02E0616629E1900F37752 /* PyContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PyContext.cpp; path = python/PyContext.cpp; sourceTree = "<group>"; };
+		DFB02E0716629E1900F37752 /* PyContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PyContext.h; path = python/PyContext.h; sourceTree = "<group>"; };
 		DFB6628B15376810006B8FF1 /* AEAudioFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEAudioFormat.h; sourceTree = "<group>"; };
 		DFB6628C15376810006B8FF1 /* AEFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AEFactory.cpp; sourceTree = "<group>"; };
 		DFB6628D15376810006B8FF1 /* AEFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFactory.h; sourceTree = "<group>"; };
@@ -3446,6 +3449,8 @@
 				F502C099160F420700C96C76 /* CallbackHandler.h */,
 				F502C09A160F420700C96C76 /* LanguageHook.cpp */,
 				F502C09B160F420700C96C76 /* LanguageHook.h */,
+				DFB02E0616629E1900F37752 /* PyContext.cpp */,
+				DFB02E0716629E1900F37752 /* PyContext.h */,
 				F502C09C160F421600C96C76 /* swig.cpp */,
 				F502C09D160F421600C96C76 /* swig.h */,
 				F502C09E160F421600C96C76 /* XBPython.cpp */,
@@ -7649,6 +7654,7 @@
 				DF402A97164462FC001C56B8 /* XBPyThread.cpp in Sources */,
 				F5EDC4A91651A75700B852D8 /* GroupUtils.cpp in Sources */,
 				7C7CEB4B165629BF0059C9EB /* AELimiter.cpp in Sources */,
+				DFB02E0816629E1900F37752 /* PyContext.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		DFAB04B013F8383300B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB04AE13F8383300B70BFB /* InertialScrollingHandler.cpp */; };
 		DFAB4BE615FCCA5000E1BAF6 /* TagLibVFSStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB4BE215FCCA5000E1BAF6 /* TagLibVFSStream.cpp */; };
 		DFAB4BE715FCCA5000E1BAF6 /* TagLoaderTagLib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB4BE415FCCA5000E1BAF6 /* TagLoaderTagLib.cpp */; };
+		DFB02DFB16629DF200F37752 /* PyContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB02DF916629DF200F37752 /* PyContext.cpp */; };
 		DFB25CB1163D3A04006C4A48 /* Addon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD10415FCE71000E10810 /* Addon.cpp */; };
 		DFB25CB2163D3A04006C4A48 /* AddonCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD10815FCE71000E10810 /* AddonCallback.cpp */; };
 		DFB25CB3163D3A04006C4A48 /* AddonClass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD10C15FCE71000E10810 /* AddonClass.cpp */; };
@@ -1407,6 +1408,8 @@
 		DFAB4BE315FCCA5000E1BAF6 /* TagLibVFSStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLibVFSStream.h; sourceTree = "<group>"; };
 		DFAB4BE415FCCA5000E1BAF6 /* TagLoaderTagLib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TagLoaderTagLib.cpp; sourceTree = "<group>"; };
 		DFAB4BE515FCCA5000E1BAF6 /* TagLoaderTagLib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLoaderTagLib.h; sourceTree = "<group>"; };
+		DFB02DF916629DF200F37752 /* PyContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PyContext.cpp; path = python/PyContext.cpp; sourceTree = "<group>"; };
+		DFB02DFA16629DF200F37752 /* PyContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PyContext.h; path = python/PyContext.h; sourceTree = "<group>"; };
 		DFB6620515376791006B8FF1 /* AEAudioFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEAudioFormat.h; sourceTree = "<group>"; };
 		DFB6620615376791006B8FF1 /* AEFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AEFactory.cpp; sourceTree = "<group>"; };
 		DFB6620715376791006B8FF1 /* AEFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFactory.h; sourceTree = "<group>"; };
@@ -3450,6 +3453,8 @@
 				F502C05C160F416F00C96C76 /* CallbackHandler.h */,
 				F502C05D160F416F00C96C76 /* LanguageHook.cpp */,
 				F502C05E160F416F00C96C76 /* LanguageHook.h */,
+				DFB02DF916629DF200F37752 /* PyContext.cpp */,
+				DFB02DFA16629DF200F37752 /* PyContext.h */,
 				F502C076160F417B00C96C76 /* swig.cpp */,
 				F502C077160F417B00C96C76 /* swig.h */,
 				F502C078160F417B00C96C76 /* XBPython.cpp */,
@@ -7674,6 +7679,7 @@
 				DF402A85164462C3001C56B8 /* XBPyThread.cpp in Sources */,
 				F5EDC4A61651A74300B852D8 /* GroupUtils.cpp in Sources */,
 				7C7CEB5F165629F90059C9EB /* AELimiter.cpp in Sources */,
+				DFB02DFB16629DF200F37752 /* PyContext.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -438,6 +438,7 @@
 		DF98D98C1434F47D00A6EBE1 /* SkinVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF98D98A1434F47D00A6EBE1 /* SkinVariable.cpp */; };
 		DF9A71EE1639C8F6005ECB2E /* HTTPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF9A71EC1639C8F6005ECB2E /* HTTPFile.cpp */; };
 		DFAB049813F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */; };
+		DFB02DEA16629DBA00F37752 /* PyContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB02DE816629DBA00F37752 /* PyContext.cpp */; };
 		DFB0F472161B747500D744F4 /* AddonsOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB0F470161B747500D744F4 /* AddonsOperations.cpp */; };
 		DFB15B2215F8FB8100CDF0DE /* SDLMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFB15B2115F8FB8100CDF0DE /* SDLMain.mm */; };
 		DFB25D2F163D4743006C4A48 /* Addon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD17C15FCE77900E10810 /* Addon.cpp */; };
@@ -1996,6 +1997,8 @@
 		DF9A71ED1639C8F6005ECB2E /* HTTPFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPFile.h; sourceTree = "<group>"; };
 		DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InertialScrollingHandler.cpp; sourceTree = "<group>"; };
 		DFAB049713F8376700B70BFB /* InertialScrollingHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InertialScrollingHandler.h; sourceTree = "<group>"; };
+		DFB02DE816629DBA00F37752 /* PyContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PyContext.cpp; path = python/PyContext.cpp; sourceTree = "<group>"; };
+		DFB02DE916629DBA00F37752 /* PyContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PyContext.h; path = python/PyContext.h; sourceTree = "<group>"; };
 		DFB0F470161B747500D744F4 /* AddonsOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddonsOperations.cpp; sourceTree = "<group>"; };
 		DFB0F471161B747500D744F4 /* AddonsOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddonsOperations.h; sourceTree = "<group>"; };
 		DFB15B2015F8FB8100CDF0DE /* SDLMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLMain.h; sourceTree = "<group>"; };
@@ -4469,6 +4472,8 @@
 				F502BFDB160F34B900C96C76 /* CallbackHandler.h */,
 				F502BFE4160F34DC00C96C76 /* LanguageHook.cpp */,
 				F502BFE5160F34DC00C96C76 /* LanguageHook.h */,
+				DFB02DE816629DBA00F37752 /* PyContext.cpp */,
+				DFB02DE916629DBA00F37752 /* PyContext.h */,
 				F502BFF0160F36AD00C96C76 /* swig.cpp */,
 				F502BFF1160F36AD00C96C76 /* swig.h */,
 				F502BFE6160F34FE00C96C76 /* XBPython.cpp */,
@@ -7706,6 +7711,7 @@
 				DF402A67164461B9001C56B8 /* XBPyThread.cpp in Sources */,
 				F5EDC48C1651A6F900B852D8 /* GroupUtils.cpp in Sources */,
 				7C7CEAF1165629530059C9EB /* AELimiter.cpp in Sources */,
+				DFB02DEA16629DBA00F37752 /* PyContext.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -756,6 +756,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\generated\AddonModuleXbmcplugin.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\generated\AddonModuleXbmcvfs.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\LanguageHook.cpp" />
+    <ClCompile Include="..\..\xbmc\interfaces\python\PyContext.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\swig.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\test\TestSwig.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">true</ExcludedFromBuild>
@@ -1077,6 +1078,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\python\CallbackHandler.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\LanguageHook.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\preamble.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\PyContext.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\pythreadstate.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\swig.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\XBPython.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2951,6 +2951,9 @@
     <ClCompile Include="..\..\xbmc\utils\test\TestUrlOptions.cpp">
       <Filter>utils\test</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\PyContext.cpp">
+      <Filter>interfaces\python</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5763,6 +5766,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\AudioEngine\Utils\AELimiter.h">
       <Filter>cores\AudioEngine\Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\python\PyContext.h">
+      <Filter>interfaces\python</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/interfaces/python/LanguageHook.cpp
+++ b/xbmc/interfaces/python/LanguageHook.cpp
@@ -25,6 +25,7 @@
 
 #include "interfaces/legacy/AddonUtils.h"
 #include "utils/GlobalsHandling.h"
+#include "PyContext.h"
 
 namespace XBMCAddon
 {
@@ -39,12 +40,6 @@ namespace XBMCAddon
     // vtab instantiation
     LanguageHook::~LanguageHook() { }
 
-    struct MutableInteger
-    {
-      MutableInteger() : value(0) {}
-      int value;
-    };
-
     void LanguageHook::makePendingCalls()
     {
       PythonCallbackHandler::makePendingCalls();
@@ -53,59 +48,13 @@ namespace XBMCAddon
     void LanguageHook::delayedCallOpen()
     {
       TRACE;
-
-      // TODO: add a check for null of _save. If it's not null there's 
-      //  a problem.
-
-      MutableInteger* count = tlsCount.get();
-      if (count == NULL)
-      {
-        count = new MutableInteger();
-        tlsCount.set(count);
-      }
-
-      // increment the count
-      count->value++;
-      int curlevel = count->value;
-      if (curlevel == 1)
-      {
-        PyThreadState* _save;
-        // this macro sets _save
-        Py_UNBLOCK_THREADS
-        pyThreadStateTls.set(_save);
-      }
+      PyGILLock::releaseGil();
     }
 
     void LanguageHook::delayedCallClose()
     {
       TRACE;
-
-      // here we ASSUME that the open was called.
-      MutableInteger* count = tlsCount.get();
-      count->value--;
-      int curlevel = count->value;
-
-      // this is a hack but ...
-      if (curlevel < 0)
-      {
-        CLog::Log(LOGERROR, "PythonCallbackHandler delay has closed more than opened");
-        count->value = 0;
-      }
-
-      if (curlevel == 0)
-      {
-        PyThreadState* _save = pyThreadStateTls.get();
-        if (_save != NULL)
-        {
-          Py_BLOCK_THREADS
-        }
-        _save = NULL;
-        pyThreadStateTls.set(_save);
-
-        // clear the tlsCount
-        tlsCount.set(NULL);
-        delete count;
-      }
+      PyGILLock::acquireGil();
     }
 
     LanguageHook* LanguageHook::getInstance() 

--- a/xbmc/interfaces/python/LanguageHook.h
+++ b/xbmc/interfaces/python/LanguageHook.h
@@ -47,8 +47,6 @@ namespace XBMCAddon
     {
       LanguageHook() : XBMCAddon::LanguageHook("Python::LanguageHook")  {  }
 
-      XbmcThreads::ThreadLocal<PyThreadState> pyThreadStateTls;
-      XbmcThreads::ThreadLocal<MutableInteger> tlsCount;
     public:
 
       virtual ~LanguageHook();

--- a/xbmc/interfaces/python/Makefile.in
+++ b/xbmc/interfaces/python/Makefile.in
@@ -14,7 +14,7 @@ all: $(LIB)
 include ../../../codegenerator.mk
 
 SRCS=	CallbackHandler.cpp LanguageHook.cpp \
-	XBPyThread.cpp XBPython.cpp swig.cpp \
+	XBPyThread.cpp XBPython.cpp swig.cpp PyContext.cpp \
 	$(GENERATED)
 
 INCLUDES += @PYTHON_CPPFLAGS@

--- a/xbmc/interfaces/python/PyContext.cpp
+++ b/xbmc/interfaces/python/PyContext.cpp
@@ -1,0 +1,115 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <Python.h>
+
+#include "PyContext.h"
+#include "threads/ThreadLocal.h"
+#include "utils/log.h"
+
+namespace XBMCAddon
+{
+  namespace Python
+  {
+    struct PyContextState
+    {
+      inline PyContextState() : value(0), state(NULL), gilReleasedDepth(0) {}
+
+      int value;
+      PyThreadState* state;
+      int gilReleasedDepth;
+    };
+
+    static XbmcThreads::ThreadLocal<PyContextState> tlsPyContextState;
+
+    PyContext::PyContext() 
+    {
+      PyContextState* cur = tlsPyContextState.get();
+      if (cur == NULL)
+      {
+        cur = new PyContextState();
+        tlsPyContextState.set(cur);
+      }
+
+      // increment the count
+      cur->value++;
+    }
+
+    PyContext::~PyContext()
+    {
+      // here we ASSUME that the constructor was called.
+      PyContextState* cur = tlsPyContextState.get();
+      cur->value--;
+      int curlevel = cur->value;
+
+      // this is a hack but ...
+      if (curlevel < 0)
+      {
+        CLog::Log(LOGERROR, "FATAL: PyContext closed more than opened");
+        curlevel = cur->value = 0;
+      }
+
+      if (curlevel == 0)
+      {
+        // clear the tlsPyContextState
+        tlsPyContextState.set(NULL);
+        delete cur;
+      }
+    }
+
+    void PyGILLock::releaseGil()
+    {
+      PyContextState* cur = tlsPyContextState.get();
+      if (cur) // this means we're within the python context
+      {
+        if (cur->gilReleasedDepth == 0) // true if we are at the outermost
+        {
+          PyThreadState* _save;
+          // this macro sets _save
+          {
+            Py_UNBLOCK_THREADS
+          }
+          cur->state = _save;
+        }
+        cur->gilReleasedDepth++; // the first time this goes to 1
+      }
+    }
+
+    void PyGILLock::acquireGil()
+    {
+      PyContextState* cur = tlsPyContextState.get(); // this must be non-null given we released the Gil in the constructor
+      if (cur) // we're within a PyContext
+      {
+        // decrement the depth and make sure we're in the right place.
+        cur->gilReleasedDepth--;
+        if (cur->gilReleasedDepth == 0) // are we back to zero?
+        {
+          PyThreadState* _save = cur->state;
+          // This macros uses _save
+          {
+            Py_BLOCK_THREADS
+          }
+          cur->state = NULL; // clear the state to indicate we've reacquired the gil
+        }
+      }
+    }
+  }
+}

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -488,8 +488,9 @@ Helper.getInsertNodes(module, 'begin').each { %>${Helper.unescape(it)}<% }
 
 #include <Python.h>
 #include <string>
-#include "interfaces/python/LanguageHook.h"
-#include "interfaces/python/swig.h"
+#include "LanguageHook.h"
+#include "swig.h"
+#include "PyContext.h"
 
 <%
 Helper.getInsertNodes(module, 'header').each { %>${Helper.unescape(it)}<% }
@@ -563,6 +564,7 @@ namespace PythonBindings
         ${Helper.getOutConversion(param.@type,'result',it,['result' : 'py' + param.@name, 'api' : param.@name])}<%
         }
 %>
+        XBMCAddon::Python::PyContext pyContext;
         PyObject_CallMethod(self,(char*)"${Helper.callingName(it)}",(char*)"(${paramFormatStr})"<%
           params.each {
              %>, py${it.@name} <%

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -488,9 +488,9 @@ Helper.getInsertNodes(module, 'begin').each { %>${Helper.unescape(it)}<% }
 
 #include <Python.h>
 #include <string>
-#include "LanguageHook.h"
-#include "swig.h"
-#include "PyContext.h"
+#include "interfaces/python/LanguageHook.h"
+#include "interfaces/python/swig.h"
+#include "interfaces/python/PyContext.h"
 
 <%
 Helper.getInsertNodes(module, 'header').each { %>${Helper.unescape(it)}<% }

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -51,7 +51,7 @@
 #include "interfaces/python/pythreadstate.h"
 #include "interfaces/python/swig.h"
 #include "utils/CharsetConverter.h"
-
+#include "PyContext.h"
 
 #ifdef _WIN32
 extern "C" FILE *fopen_utf8(const char *_Filename, const char *_Mode);
@@ -266,6 +266,7 @@ void XBPyThread::Process()
           CLog::Log(LOGDEBUG,"Instantiating addon using automatically obtained id of \"%s\" dependent on version %s of the xbmc.python api",addon->ID().c_str(),version.c_str());
         }
         Py_DECREF(f);
+        XBMCAddon::Python::PyContext pycontext; // this is a guard class that marks this callstack as being in a python context
         PyRun_FileExFlags(fp, CSpecialProtocol::TranslatePath(m_source).c_str(), m_Py_file_input, moduleDict, moduleDict,1,NULL);
       }
       else


### PR DESCRIPTION
Gil handling is more flexible now and use of the DelayedCallGuard is not so tempermental. Also added the DelayedCallGuard to the Montior destructor.

There's 2 new files here so I need an xcode + windows project update.

Though this is a fix it also contains a moderate refactor of the Gil handling in python and so I wanted a quick review.

Thanks
