### PR TITLE
pvr: Read recording's last played position from field in PVR_RECORDING

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -285,6 +285,7 @@ extern "C" {
     int    iGenreType;                                    /*!< @brief (optional) genre type */
     int    iGenreSubType;                                 /*!< @brief (optional) genre sub type */
     int    iPlayCount;                                    /*!< @brief (optional) play count of this recording on the client */
+    int    iLastPlayedPosition;                           /*!< @brief (optional) last played position of this recording on the client */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -187,6 +187,7 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording &xbmcRecording, PV
   addonRecording.iDuration      = xbmcRecording.GetDuration();
   addonRecording.iPriority      = xbmcRecording.m_iPriority;
   addonRecording.iLifetime      = xbmcRecording.m_iLifetime;
+  addonRecording.iPlayCount     = xbmcRecording.m_iRecPlayCount;
   strncpy(addonRecording.strDirectory, xbmcRecording.m_strDirectory.c_str(), sizeof(addonRecording.strDirectory) - 1);
   strncpy(addonRecording.strStreamURL, xbmcRecording.m_strStreamURL.c_str(), sizeof(addonRecording.strStreamURL) - 1);
   strncpy(addonRecording.strIconPath, xbmcRecording.m_strIconPath.c_str(), sizeof(addonRecording.strIconPath) - 1);

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -187,7 +187,8 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording &xbmcRecording, PV
   addonRecording.iDuration      = xbmcRecording.GetDuration();
   addonRecording.iPriority      = xbmcRecording.m_iPriority;
   addonRecording.iLifetime      = xbmcRecording.m_iLifetime;
-  addonRecording.iPlayCount     = xbmcRecording.m_iRecPlayCount;
+  addonRecording.iPlayCount     = xbmcRecording.m_playCount;
+  addonRecording.iLastPlayedPosition = (int)xbmcRecording.m_resumePoint.timeInSeconds;
   strncpy(addonRecording.strDirectory, xbmcRecording.m_strDirectory.c_str(), sizeof(addonRecording.strDirectory) - 1);
   strncpy(addonRecording.strStreamURL, xbmcRecording.m_strStreamURL.c_str(), sizeof(addonRecording.strStreamURL) - 1);
   strncpy(addonRecording.strIconPath, xbmcRecording.m_strIconPath.c_str(), sizeof(addonRecording.strIconPath) - 1);

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -178,16 +178,16 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording &xbmcRecording, PV
 
   memset(&addonRecording, 0, sizeof(addonRecording));
 
-  addonRecording.recordingTime  = recTime - g_advancedSettings.m_iPVRTimeCorrection;
+  addonRecording.recordingTime       = recTime - g_advancedSettings.m_iPVRTimeCorrection;
   strncpy(addonRecording.strRecordingId, xbmcRecording.m_strRecordingId.c_str(), sizeof(addonRecording.strRecordingId) - 1);
   strncpy(addonRecording.strTitle, xbmcRecording.m_strTitle.c_str(), sizeof(addonRecording.strTitle) - 1);
   strncpy(addonRecording.strPlotOutline, xbmcRecording.m_strPlotOutline.c_str(), sizeof(addonRecording.strPlotOutline) - 1);
   strncpy(addonRecording.strPlot, xbmcRecording.m_strPlot.c_str(), sizeof(addonRecording.strPlot) - 1);
   strncpy(addonRecording.strChannelName, xbmcRecording.m_strChannelName.c_str(), sizeof(addonRecording.strChannelName) - 1);
-  addonRecording.iDuration      = xbmcRecording.GetDuration();
-  addonRecording.iPriority      = xbmcRecording.m_iPriority;
-  addonRecording.iLifetime      = xbmcRecording.m_iLifetime;
-  addonRecording.iPlayCount     = xbmcRecording.m_playCount;
+  addonRecording.iDuration           = xbmcRecording.GetDuration();
+  addonRecording.iPriority           = xbmcRecording.m_iPriority;
+  addonRecording.iLifetime           = xbmcRecording.m_iLifetime;
+  addonRecording.iPlayCount          = xbmcRecording.m_playCount;
   addonRecording.iLastPlayedPosition = (int)xbmcRecording.m_resumePoint.timeInSeconds;
   strncpy(addonRecording.strDirectory, xbmcRecording.m_strDirectory.c_str(), sizeof(addonRecording.strDirectory) - 1);
   strncpy(addonRecording.strStreamURL, xbmcRecording.m_strStreamURL.c_str(), sizeof(addonRecording.strStreamURL) - 1);

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -42,25 +42,25 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
 {
   Reset();
 
-  m_strRecordingId    = recording.strRecordingId;
-  m_strTitle          = recording.strTitle;
-  m_iClientId         = iClientId;
-  m_recordingTime     = recording.recordingTime + g_advancedSettings.m_iPVRTimeCorrection;
-  m_duration          = CDateTimeSpan(0, 0, recording.iDuration / 60, recording.iDuration % 60);
-  m_iPriority         = recording.iPriority;
-  m_iLifetime         = recording.iLifetime;
-  m_strDirectory      = recording.strDirectory;
-  m_strPlot           = recording.strPlot;
-  m_strPlotOutline    = recording.strPlotOutline;
-  m_strStreamURL      = recording.strStreamURL;
-  m_strChannelName    = recording.strChannelName;
-  m_genre             = StringUtils::Split(CEpg::ConvertGenreIdToString(recording.iGenreType, recording.iGenreSubType), g_advancedSettings.m_videoItemSeparator);
-  m_playCount         = recording.iPlayCount;
-  m_resumePoint.timeInSeconds = recording.iLastPlayedPosition;
+  m_strRecordingId                 = recording.strRecordingId;
+  m_strTitle                       = recording.strTitle;
+  m_iClientId                      = iClientId;
+  m_recordingTime                  = recording.recordingTime + g_advancedSettings.m_iPVRTimeCorrection;
+  m_duration                       = CDateTimeSpan(0, 0, recording.iDuration / 60, recording.iDuration % 60);
+  m_iPriority                      = recording.iPriority;
+  m_iLifetime                      = recording.iLifetime;
+  m_strDirectory                   = recording.strDirectory;
+  m_strPlot                        = recording.strPlot;
+  m_strPlotOutline                 = recording.strPlotOutline;
+  m_strStreamURL                   = recording.strStreamURL;
+  m_strChannelName                 = recording.strChannelName;
+  m_genre                          = StringUtils::Split(CEpg::ConvertGenreIdToString(recording.iGenreType, recording.iGenreSubType), g_advancedSettings.m_videoItemSeparator);
+  m_playCount                      = recording.iPlayCount;
+  m_resumePoint.timeInSeconds      = recording.iLastPlayedPosition;
   m_resumePoint.totalTimeInSeconds = recording.iDuration;
-  m_strIconPath       = recording.strIconPath;
-  m_strThumbnailPath  = recording.strThumbnailPath;
-  m_strFanartPath     = recording.strFanartPath;
+  m_strIconPath                    = recording.strIconPath;
+  m_strThumbnailPath               = recording.strThumbnailPath;
+  m_strFanartPath                  = recording.strFanartPath;
 }
 
 bool CPVRRecording::operator ==(const CPVRRecording& right) const


### PR DESCRIPTION
@opdenkamp @Red-F: This is the follow-up on the discussion in #1452

I've added the field iLastPlayedPosition to PVR_RECORDING. 
The value in this field is used for showing the resume indicators in the recordings view.
Instead of calling GetLastPlayedPosition for every single recording.

This fixes the high load times of the recording view. Now it's usable again even with a high number of recordings.

When working on this, I recognized that I forgot to add playCount to WriteClientRecordingInfo. e97116b takes care of this.

Cheers,
Christian
