### PR TITLE
[win32] AE: change default sink to DirectSound (over WASAPI)

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -140,9 +140,9 @@ IAESink *CAESinkFactory::Create(std::string &device, AEAudioFormat &desiredForma
 void CAESinkFactory::EnumerateEx(AESinkInfoList &list)
 {
 #if defined(TARGET_WINDOWS)
+  ENUMERATE_SINK(DirectSound);
   if (g_sysinfo.IsVistaOrHigher() && !g_advancedSettings.m_audioForceDirectSound)
     ENUMERATE_SINK(WASAPI);
-  ENUMERATE_SINK(DirectSound);
 #elif defined(TARGET_ANDROID)
     ENUMERATE_SINK(AUDIOTRACK);
 #elif defined(TARGET_LINUX) || defined(TARGET_FREEBSD)


### PR DESCRIPTION
This changes the default audio output sink on win32 from WASAPI to DirectSound as a lot of Frodo Beta 1 users have reported problems after updating from Eden (see e.g. http://forum.xbmc.org/showthread.php?tid=145239&pid=1241534#pid1241534). For some of them WASAPI didn't work at all and for some of them changing to DirectSound and back to WASAPI solved their issues. But for all that reported back after my suggestion to DirectSound, that at least worked (see http://forum.xbmc.org/showthread.php?tid=145239&pid=1241567#pid1241567 which is the same user as in the link above).

So there's certainly an issue somewhere in the WASAPI code but I don't know anything about that and IMO it is more important to have a default value that works for everyone than to have a default value that provides more features but causes problems.
