### PR TITLE
Unify handling of key mappings accross different input devices

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2398,34 +2398,7 @@ bool CApplication::OnKey(const CKey& key)
     return true;
   }
 
-  if (iWin == WINDOW_DIALOG_FULLSCREEN_INFO)
-  { // fullscreen info dialog - special case
-
-    if (!key.IsAnalogButton())
-      CLog::Log(LOGDEBUG, "%s: %s pressed, trying fullscreen info action %s", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetName().c_str());
-
-    if (OnAction(action))
-      return true;
-
-    // fallthrough to the main window
-    iWin = WINDOW_FULLSCREEN_VIDEO;
-  }
-
-  if (iWin == WINDOW_FULLSCREEN_LIVETV)
-  {
-    // check for PVR specific keymaps in only the LIVETV window (no fallback)
-    action = CButtonTranslator::GetInstance().GetAction(iWin, key, false);
-
-    // if no PVR specific action/mapping is found, fall back to FULLSCREEN_VIDEO
-    if (action.GetID() == 0)
-      iWin = WINDOW_FULLSCREEN_VIDEO;
-  }
-
-  if (iWin == WINDOW_FULLSCREEN_VIDEO)
-  {
-    action = CButtonTranslator::GetInstance().GetAction(iWin, key);
-  }
-  else
+  if (iWin != WINDOW_FULLSCREEN_VIDEO)
   {
     // current active window isnt the fullscreen window
     // just use corresponding section from keymap.xml

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2471,12 +2471,8 @@ bool CApplication::OnKey(const CKey& key)
         return true;
       // failed to handle the keyboard action, drop down through to standard action
     }
-    if (key.GetFromService())
-    {
-      if (key.GetButtonCode() != KEY_INVALID)
-        action = CButtonTranslator::GetInstance().GetAction(iWin, key);
-    }
-    else
+
+    if (key.GetButtonCode() != KEY_INVALID)
       action = CButtonTranslator::GetInstance().GetAction(iWin, key);
   }
   if (!key.IsAnalogButton())
@@ -5828,4 +5824,6 @@ CPerformanceStats &CApplication::GetPerformanceStats()
   return m_perfStats;
 }
 #endif
+
+
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3073,12 +3073,8 @@ bool CApplication::ProcessMouse()
     return true;
 
   // Retrieve the corresponding action
-  int iWin;
+  int iWin = GetActiveWindowID();
   CKey key(mousecommand | KEY_MOUSE, (unsigned int) 0);
-  if (g_windowManager.HasModalDialog())
-    iWin = g_windowManager.GetTopMostModalDialogID() & WINDOW_ID_MASK;
-  else
-    iWin = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
   CAction mouseaction = CButtonTranslator::GetInstance().GetAction(iWin, key);
 
   // If we couldn't find an action return false to indicate we have not

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -447,6 +447,7 @@ protected:
   bool ProcessEventServer(float frameTime);
   bool ProcessPeripherals(float frameTime);
   bool ProcessJoystickEvent(const std::string& joystickName, int button, bool isAxis, float fAmount, unsigned int holdTime = 0);
+  bool ExecuteInputAction(CAction action);
   int  GetActiveWindowID(void);
 
   float NavigationIdleTime();

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -787,23 +787,23 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
   }
 }
 
-bool CButtonTranslator::TranslateJoystickString(int window, const char* szDevice, int id, short inputType, int& action, CStdString& strAction, bool &fullrange)
+bool CButtonTranslator::TranslateJoystickString(int window, const char* szDevice, int id, short inputType, int& actionID, CStdString& strAction, bool &fullrange, bool fallback)
 {
-  bool found = false;
+  fullrange = false;
 
+  // resolve the correct JoystickMap
   map<string, JoystickMap>::iterator it;
   map<string, JoystickMap> *jmap;
 
-  fullrange = false;
   if (inputType == JACTIVE_AXIS)
     jmap = &m_joystickAxisMap;
   else if (inputType == JACTIVE_BUTTON)
     jmap = &m_joystickButtonMap;
   else if (inputType == JACTIVE_HAT)
-  	jmap = &m_joystickHatMap;
+    jmap = &m_joystickHatMap;
   else
   {
-    CLog::Log(LOGERROR, "Error reading joystick input type");
+    CLog::Log(LOGERROR, "Error reading joystick input type '%i'", (int) inputType);
     return false;
   }
 
@@ -812,73 +812,63 @@ bool CButtonTranslator::TranslateJoystickString(int window, const char* szDevice
     return false;
 
   JoystickMap wmap = it->second;
-  JoystickMap::iterator it2;
+
+  // try to get the action from the current window
+  actionID = GetActionCode(window, wmap, strAction, fullrange);
+
+  // if it's invalid, try to get it from a fallback window or the global map
+  if (actionID == 0 && fallback) {
+    int fallbackWindow = GetFallbackWindow(window);
+    if (fallbackWindow > -1)
+      actionID = GetActionCode(fallbackWindow, wmap, strAction, fullrange);
+    // still no valid actionID? use global map
+    if (actionID == 0)
+      actionID = GetActionCode(-1, wmap, strAction, fullrange);
+  }
+
+  return (actionID > 0);
+}
+
+/*
+ * Translates a joystick input to an action code
+ */
+int CButtonTranslator::GetActionCode(int window, const JoystickMap &wmap, CStdString &strAction, bool &fullrange) const
+{
+  JoystickMap::const_iterator it = wmap.find(window);
   map<int, string> windowbmap;
-  map<int, string> globalbmap;
-  map<int, string>::iterator it3;
+  map<int, string>::iterator it2;
+  int action = 0;
+  bool found = false;
 
-  it2 = wmap.find(window);
+  if (it == wmap.end())
+    return action;
 
-  // first try local window map
-  if (it2!=wmap.end())
+  windowbmap = it->second;
+  it2 = windowbmap.find(id);
+  if (it2 != windowbmap.end())
   {
-    windowbmap = it2->second;
-    it3 = windowbmap.find(id);
-    if (it3 != windowbmap.end())
-    {
-      strAction = (it3->second).c_str();
-      found = true;
-    }
-    it3 = windowbmap.find(abs(id)|0xFFFF0000);
-    if (it3 != windowbmap.end())
-    {
-      strAction = (it3->second).c_str();
-      found = true;
-      fullrange = true;
-    }
-    // Hats joystick
-    it3 = windowbmap.find(id|0xFFF00000);
-    if (it3 != windowbmap.end())
-    {
-      strAction = (it3->second).c_str();
-      found = true;
-    }
+    strAction = (it2->second).c_str();
+    found = true;
   }
 
-  // if not found, try global map
-  if (!found)
+  it2 = windowbmap.find(abs(id)|0xFFFF0000);
+  if (it2 != windowbmap.end())
   {
-    it2 = wmap.find(-1);
-    if (it2 != wmap.end())
-    {
-      globalbmap = it2->second;
-      it3 = globalbmap.find(id);
-      if (it3 != globalbmap.end())
-      {
-        strAction = (it3->second).c_str();
-        found = true;
-      }
-      it3 = globalbmap.find(abs(id)|0xFFFF0000);
-      if (it3 != globalbmap.end())
-      {
-        strAction = (it3->second).c_str();
-        found = true;
-        fullrange = true;
-      }
-      it3 = globalbmap.find(id|0xFFF00000);
-      if (it3 != globalbmap.end())
-      {
-        strAction = (it3->second).c_str();
-        found = true;
-      }
-    }
+    strAction = (it2->second).c_str();
+    found = true;
+    fullrange = true;
   }
 
-  // translated found action
+  // Hats joystick
+  it2 = windowbmap.find(id|0xFFF00000);
+  if (it2 != windowbmap.end())
+    strAction = (it2->second).c_str();
+    found = true;
+  }
+
   if (found)
-    return TranslateActionString(strAction.c_str(), action);
-
-  return false;
+    TranslateActionString(strAction.c_str(), action);
+  return action;
 }
 #endif
 
@@ -921,19 +911,22 @@ CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
     int fallbackWindow = GetFallbackWindow(window);
     if (fallbackWindow > -1)
     {
-      actionID = GetActionCode( fallbackWindow, key, strAction);
+      actionID = GetActionCode(fallbackWindow, key, strAction);
       if (!key.IsAnalogButton())
         CLog::Log(LOGDEBUG, "%s: %i pressed in window %s, no mapping found, trying to find a fallback action in window %s", __FUNCTION__, (int) key.GetButtonCode(), TranslateWindow(window).c_str(), TranslateWindow(fallbackWindow).c_str());
     }
     // still no valid actionID? use global map
     if (actionID == 0)
-      actionID = GetActionCode( -1, key, strAction);
+      actionID = GetActionCode(-1, key, strAction);
   }
   // Now fill our action structure
   CAction action(actionID, strAction, key);
   return action;
 }
 
+/*
+ * Translates a keyboard input to an action code
+ */
 int CButtonTranslator::GetActionCode(int window, const CKey &key, CStdString &strAction) const
 {
   uint32_t code = key.GetButtonCode();

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -106,6 +106,7 @@ private:
   std::list<CStdString> m_deviceList;
 
   int GetActionCode(int window, const CKey &key, CStdString &strAction) const;
+  int GetFallbackWindow(int windowID);
 
   static uint32_t TranslateGamepadString(const char *szButton);
   static uint32_t TranslateRemoteString(const char *szButton);

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -93,8 +93,9 @@ public:
 #endif
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
   bool TranslateJoystickString(int window, const char* szDevice, int id,
-                               short inputType, int& action, CStdString& strAction,
-                               bool &fullrange);
+                               short inputType, int& actionID, CStdString& strAction,
+                               bool &fullrange,
+                               bool fallback = true);
 #endif
 
 private:
@@ -106,6 +107,7 @@ private:
   std::list<CStdString> m_deviceList;
 
   int GetActionCode(int window, const CKey &key, CStdString &strAction) const;
+  int GetActionCode(int window, const JoystickMap &wmap, CStdString &strAction, bool &fullrange) const
   int GetFallbackWindow(int windowID);
 
   static uint32_t TranslateGamepadString(const char *szButton);


### PR DESCRIPTION
Currently, key input (=keyboard, remotes, services), joystick and gamepad use their own logic to process input signals and map them to actions. While joystick and gamepad already use CApplication::GetActiveWindowID() to resolve the windowID to use for keymapping/action lookup, the very same logic of this method is duplicated in CApplication::OnKey() which is used for key input handling. This PR removes the code duplication in CApplication::OnKey() and adds currently missing logic from OnKey() (like virtual FULLSCREEN_LIVETV window) to GetActiveWindowID(). By doing this, some extended logic for fallback keymapping that is currently used by the windows FULLSCREEN_LIVETV and DIALOG_FULLSCREEN_INFO has been moved from CApplication to the ButtonTranslator in a more generic and easily extendable way which makes it available for all input devices.

The changes in this PR fix the currently present bug that the <FullscreenLiveTV> PVR keymappings couldn't be used by all input devices, as reported by users in the forum: http://forum.xbmc.org/showthread.php?tid=144205&page=5
