### PR TITLE
settings: improve migration of audio output settings from (pre-)Eden to Frodo

### DIFF
--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -197,6 +197,32 @@ void CAEFactory::EnumerateOutputDevices(AEDeviceList &devices, bool passthrough)
     AE->EnumerateOutputDevices(devices, passthrough);
 }
 
+void CAEFactory::VerifyOutputDevice(std::string &device, bool passthrough)
+{
+  AEDeviceList devices;
+  EnumerateOutputDevices(devices, passthrough);
+  std::string firstDevice;
+
+  for (AEDeviceList::const_iterator deviceIt = devices.begin(); deviceIt != devices.end(); deviceIt++)
+  {
+    std::string currentDevice = deviceIt->second;
+    /* remember the first device so we can default to it if required */
+    if (firstDevice.empty())
+      firstDevice = deviceIt->second;
+
+    if (deviceIt->second == device)
+      return;
+    else if (deviceIt->first == device)
+    {
+      device = deviceIt->second;
+      return;
+    }
+  }
+
+  /* if the device wasnt found, set it to the first viable output */
+  device = firstDevice;
+}
+
 std::string CAEFactory::GetDefaultDevice(bool passthrough)
 {
   if(AE)

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -46,6 +46,7 @@ public:
   static void SetSoundMode(const int mode);
   static void OnSettingsChange(std::string setting);
   static void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough);
+  static void VerifyOutputDevice(std::string &device, bool passthrough);
   static std::string GetDefaultDevice(bool passthrough);
   static bool SupportsRaw();
   static void SetMute(const bool enabled);

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
@@ -142,7 +142,7 @@ bool CCoreAudioAE::OpenCoreAudio(unsigned int sampleRate, bool forceRaw,
   // on iOS devices we set fixed to two channels.
   m_stdChLayout = AE_CH_LAYOUT_2_0;
 #if defined(TARGET_DARWIN_OSX)
-  switch (g_guiSettings.GetInt("audiooutput.channellayout"))
+  switch (g_guiSettings.GetInt("audiooutput.channels"))
   {
     default:
     case  0: m_stdChLayout = AE_CH_LAYOUT_2_0; break; /* do not allow 1_0 output */
@@ -310,7 +310,7 @@ void CCoreAudioAE::OnSettingsChange(const std::string& setting)
       setting == "audiooutput.mode"              ||
       setting == "audiooutput.ac3passthrough"    ||
       setting == "audiooutput.dtspassthrough"    ||
-      setting == "audiooutput.channellayout"     ||
+      setting == "audiooutput.channels"     ||
       setting == "audiooutput.multichannellpcm")
   {
     // only reinit the engine if we not

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.cpp
@@ -92,7 +92,7 @@ bool CCoreAudioAEHALOSX::InitializePCM(ICoreAudioSource *pSource, AEAudioFormat 
   if (!m_audioGraph)
     return false;
 
-  AudioChannelLayoutTag layout = g_LayoutMap[ g_guiSettings.GetInt("audiooutput.channellayout") ];
+  AudioChannelLayoutTag layout = g_LayoutMap[ g_guiSettings.GetInt("audiooutput.channels") ];
   // force optical/coax to 2.0 output channels
   if (!m_Passthrough && g_guiSettings.GetInt("audiooutput.mode") == AUDIO_IEC958)
     layout = g_LayoutMap[1];

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -524,7 +524,7 @@ void CSoftAE::OnSettingsChange(const std::string& setting)
       setting == "audiooutput.passthroughaac"    ||
       setting == "audiooutput.truehdpassthrough" ||
       setting == "audiooutput.dtshdpassthrough"  ||
-      setting == "audiooutput.channellayout"     ||
+      setting == "audiooutput.channels"     ||
       setting == "audiooutput.useexclusivemode"  ||
       setting == "audiooutput.multichannellpcm"  ||
       setting == "audiooutput.stereoupmix")
@@ -553,7 +553,7 @@ void CSoftAE::LoadSettings()
 
   /* load the configuration */
   m_stdChLayout = AE_CH_LAYOUT_2_0;
-  switch (g_guiSettings.GetInt("audiooutput.channellayout"))
+  switch (g_guiSettings.GetInt("audiooutput.channels"))
   {
     default:
     case  0: m_stdChLayout = AE_CH_LAYOUT_2_0; break; /* dont alow 1_0 output */

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -470,7 +470,7 @@ void CGUISettings::Initialize()
   map<int,int> channelLayout;
   for(int layout = AE_CH_LAYOUT_2_0; layout < AE_CH_LAYOUT_MAX; ++layout)
     channelLayout.insert(make_pair(34100+layout, layout));
-  AddInt(ao, "audiooutput.channellayout", 34100, AE_CH_LAYOUT_2_0, channelLayout, SPIN_CONTROL_TEXT);
+  AddInt(ao, "audiooutput.channels", 34100, AE_CH_LAYOUT_2_0, channelLayout, SPIN_CONTROL_TEXT);
   AddBool(ao, "audiooutput.normalizelevels", 346, true);
   AddBool(ao, "audiooutput.stereoupmix", 252, false);
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -1354,10 +1354,35 @@ void CGUISettings::GetSettingsGroup(CSettingsCategory* cat, vecSettings &setting
 
 void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = false */)
 { // load our stuff...
+  bool updated = false;
+
   for (mapIter it = settingsMap.begin(); it != settingsMap.end(); it++)
   {
     LoadFromXML(pRootElement, it, hideSettings);
   }
+
+  // check if we are updating to Frodo and need to update from
+  // audiooutput.channellayout to audiooutput.channels
+  TiXmlNode *channelNode = pRootElement->FirstChild("audiooutput");
+  if (channelNode != NULL)
+  {
+    channelNode = channelNode->FirstChild("channellayout");
+    CSettingInt* channels = (CSettingInt*)GetSetting("audiooutput.channels");
+    if (channelNode != NULL && channelNode->FirstChild() != NULL && channels != NULL)
+    {
+      channels->FromString(channelNode->FirstChild()->ValueStr());
+      if (channels->GetData() < AE_CH_LAYOUT_MAX - 1)
+        channels->SetData(channels->GetData() + 1);
+
+      // let's just reset the audiodevice settings as well
+      std::string audiodevice = GetString("audiooutput.audiodevice");
+      CAEFactory::VerifyOutputDevice(audiodevice, false);
+      SetString("audiooutput.audiodevice", audiodevice.c_str());
+
+      updated = true;
+    }
+  }
+
   // Get hardware based stuff...
   CLog::Log(LOGNOTICE, "Getting hardware information now...");
   // FIXME: Check if the hardware supports it (if possible ;)
@@ -1401,6 +1426,7 @@ void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = fa
     {
       timezone = g_timezone.GetOSConfiguredTimezone();
       SetString("locale.timezone", timezone);
+      updated = true;
     }
     g_timezone.SetTimezone(timezone);
   }
@@ -1417,6 +1443,9 @@ void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = fa
     g_langInfo.SetSubtitleLanguage(streamLanguage);
   else
     g_langInfo.SetSubtitleLanguage("");
+
+  if (updated)
+    g_settings.Save();
 }
 
 void CGUISettings::LoadFromXML(TiXmlElement *pRootElement, mapIter &it, bool advanced /* = false */)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2910,8 +2910,11 @@ void CGUIWindowSettingsCategory::FillInAudioDevices(CSetting* pSetting, bool Pas
   if (selectedValue < 0)
   {
     CLog::Log(LOGWARNING, "Failed to find previously selected audio sink");
-    pControl->AddLabel(currentDevice, numberSinks);
-    pControl->SetValue(numberSinks);
+    pControl->SetValue(0);
+    if (!Passthrough)
+      ((CSettingString*)pSetting)->SetData(m_AnalogAudioSinkMap[pControl->GetCurrentLabel()]);
+    else
+      ((CSettingString*)pSetting)->SetData(m_DigitalAudioSinkMap[pControl->GetCurrentLabel()]);
   }
   else
     pControl->SetValue(selectedValue);


### PR DESCRIPTION
These commits improve the migration of the audiooutput settings from (pre-)Eden to Frodo by replacing audiooutput.channellayout with audiooutput.channels (the meaning of the values have changed) and uses an existance check on audiooutput.channellayout to realize that we are performing an update to Frodo. That way we can actually migrate the value from audiooutput.channellayout to audiooutput.channels and also reset the value of audiooutput.audiodevice to its default value because that value is not migrateable either (at least not on win32).

There's also a fix in CGUIWindowSettingsCategory which currently shows the old value in the list of choices for audiooutput.audiodevice. IMO presenting the user with a non-existing and wrong option to choose from is a very bad idea as there's no indication in the GUI that this value is invalid.
