### PR TITLE
settings: update videoscreen.screenmode value when updating to Frodo

### DIFF
--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -1383,6 +1383,17 @@ void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = fa
     }
   }
 
+  // and fix the videoscreen.screenmode if necessary
+  std::string screenmode = GetString("videoscreen.screenmode");
+  // in Eden there was no character ("i" or "p") indicating interlaced/progressive
+  // at the end so we just add a "p" and assume progressive
+  if (screenmode.size() == 20)
+  {
+    screenmode += "p";
+    SetString("videoscreen.screenmode", screenmode.c_str());
+    updated = true;
+  }
+
   // Get hardware based stuff...
   CLog::Log(LOGNOTICE, "Getting hardware information now...");
   // FIXME: Check if the hardware supports it (if possible ;)


### PR DESCRIPTION
Found another setting that doesn't update properly from Eden to Frodo: videoscreen.screenmode. As it is used for screen and resolution selection we should try to update the old (Eden) value. All that has changed in Frodo is that we add a "p" or an "i" at the end to indicate progressive or interlaced. So it's pretty easy to detect the update because the length of the value of videoscreen.screenmode goes from 20 to 21. This simply adds a "p" at the end to make the value compatible with Frodo (otherwise it completely falls back to RES_DESKTOP). Another option would be to change the implementation of CGUISettings::GetResFromString() to be able to handle values with or without the progressive/interlaced indicator.

Let me know which approach you prefer. I don't think there's a way to actually make an educated guess about progressive or interlaced at the time we load the GUI settings because the windowing system is initialized later so we can't just use whatever e.g. RES_DESKTOP uses.
