### PR TITLE
[AE] set PulseAudio latency defined in <palatency> under <audio> section in advancedsettings.xml. add channel map for PulseAudio.

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -46,6 +46,7 @@ CAdvancedSettings::CAdvancedSettings()
 void CAdvancedSettings::Initialize()
 {
   m_audioHeadRoom = 0;
+  m_audioPALatency = 0;
   m_ac3Gain = 12.0f;
   m_audioApplyDrc = true;
   m_dvdplayerIgnoreDTSinWAV = false;
@@ -370,6 +371,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   {
     XMLUtils::GetFloat(pElement, "ac3downmixgain", m_ac3Gain, -96.0f, 96.0f);
     XMLUtils::GetInt(pElement, "headroom", m_audioHeadRoom, 0, 12);
+    XMLUtils::GetInt(pElement, "palatency", m_audioPALatency,1,10000);
     XMLUtils::GetString(pElement, "defaultplayer", m_audioDefaultPlayer);
     // 101 on purpose - can be used to never automark as watched
     XMLUtils::GetFloat(pElement, "playcountminimumpercent", m_audioPlayCountMinimumPercent, 0.0f, 101.0f);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -99,6 +99,7 @@ class CAdvancedSettings
     static void GetCustomExtensions(TiXmlElement *pRootElement, CStdString& extensions);
 
     int m_audioHeadRoom;
+    int m_audioPALatency;
     float m_ac3Gain;
     CStdString m_audioDefaultPlayer;
     float m_audioPlayCountMinimumPercent;


### PR DESCRIPTION
Trac ticket
http://trac.xbmc.org/ticket/13591

The purpose of this patch is to reduce the pulseaudio latency between xbmc and pulseaudio server. The current target latency is hard coded to 100ms in that patch which should be fine for local playback but will be good if one could specify using advancedsettings.xml.
