### PR TITLE
fix: GUI freezes when cancelling update library

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -355,7 +355,7 @@ void CMusicInfoScanner::Stop()
   if (m_bCanInterrupt)
     m_musicDatabase.Interupt();
 
-  StopThread();
+  StopThread(false);
 }
 
 static void OnDirectoryScanned(const CStdString& strDirectory)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1863,7 +1863,7 @@ namespace VIDEO
     MOVIELIST movielist;
     CVideoInfoDownloader imdb(scraper);
     int returncode = imdb.FindMovie(videoName, movielist, progress);
-    if (returncode < 0 || (returncode == 0 && !DownloadFailed(progress)))
+    if (returncode < 0 || (returncode == 0 && (m_bStop || !DownloadFailed(progress))))
     { // scraper reported an error, or we had an error and user wants to cancel the scan
       m_bStop = true;
       return -1; // cancelled

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -189,7 +189,7 @@ namespace VIDEO
     if (m_bCanInterrupt)
       m_database.Interupt();
 
-    StopThread();
+    StopThread(false);
   }
 
   void CVideoInfoScanner::CleanDatabase(CGUIDialogProgressBarHandle* handle /*= NULL */, const set<int>* paths /*= NULL */, bool showProgress /*= true */)


### PR DESCRIPTION
First commit is fix for http://trac.xbmc.org/ticket/13535 (issue described in my comment on trac ticket). It doesn't change CVideo/MusicInfoScanner::IsScanning() as it relies on dedicated CVideo/MusicInfoScanner::m_bRunning flag and not on CThread::m_bStop flag.

Second commit will just disable showing "download failed" dialog after we stopped scanner (not pretty but as CVideoInfoScanner::DownloadFailed is static so not much could be done without code shuffling)
