### PR TITLE
pvr: Fixed playback of recordings without stream url

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -617,7 +617,10 @@ bool CGUIWindowPVRCommon::PlayRecording(CFileItem *item, bool bPlayMinimized /* 
 
   CStdString stream = item->GetPVRRecordingInfoTag()->m_strStreamURL;
   if (stream == "")
-    return false;
+  {
+    CApplicationMessenger::Get().PlayFile(*item, false);
+    return true;
+  }
 
   /* Isolate the folder from the filename */
   size_t found = stream.find_last_of("/");


### PR DESCRIPTION
Currently, the playback of recordings via the context menu is broken for recordings without a stream url.
This PR makes sure that the playback of all recordings is triggered by CGUIWindowPVRCommon::PlayRecording and makes sure that recordings also play from the context menu.

Right now the playback is started by a later call to OnSelect in CGUIMediaWindow::OnMessage. Which does only work when clicking/selecting a recording directly, but not via the context menu.

Let me know if this fix is appropriate.
Thanks,
Christian
