### PR TITLE
Added configurable clamp gui to display limits feature

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -287,6 +287,12 @@ void CAdvancedSettings::Initialize()
 #endif
 
   m_bgInfoLoaderMaxThreads = 5;
+  
+#if defined(TARGET_RASPBERRY_PI)
+  m_clampGUILimitWidth = 1280;
+  m_clampGUILimitHeight = 720;
+#endif
+
 
   m_iPVRTimeCorrection             = 0;
   m_iPVRInfoToggleInterval         = 3000;
@@ -970,6 +976,28 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
 
   XMLUtils::GetInt(pRootElement, "bginfoloadermaxthreads", m_bgInfoLoaderMaxThreads);
   m_bgInfoLoaderMaxThreads = std::max(1, m_bgInfoLoaderMaxThreads);
+  
+#if defined(TARGET_RASPBERRY_PI)
+  if (!XMLUtils::GetInt(pRootElement, "clampguilimitwidth", m_clampGUILimitWidth)) 
+    m_clampGUILimitWidth = 1280;
+    
+  if (m_clampGUILimitWidth < 320)
+    // clamp to vhs resolution
+    m_clampGUILimitWidth = 320;
+  else if (m_clampGUILimitWidth > 3840)
+    // clamp to 4k (uhd) resolution
+    m_clampGUILimitWidth = 3840;
+
+  if (!XMLUtils::GetInt(pRootElement, "clampguilimitheight", m_clampGUILimitHeight)) 
+    m_clampGUILimitHeight = 720;
+
+  if (m_clampGUILimitHeight < 240)
+    // clamp to vhs resolution
+    m_clampGUILimitHeight = 240;
+  else if (m_clampGUILimitHeight > 2160)
+    // clamp to 4k (uhd) resolution
+    m_clampGUILimitHeight = 2160;
+#endif
 
   TiXmlElement *pPVR = pRootElement->FirstChildElement("pvr");
   if (pPVR)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -326,6 +326,12 @@ class CAdvancedSettings
     CStdString m_cpuTempCmd;
     CStdString m_gpuTempCmd;
     int m_bgInfoLoaderMaxThreads;
+    
+#if defined(TARGET_RASPBERRY_PI)
+    /* display resolution clamping for windowing */
+    int m_clampGUILimitWidth;
+    int m_clampGUILimitHeight;
+#endif
 
     /* PVR/TV related advanced settings */
     int m_iPVRTimeCorrection;     /*!< @brief correct all times (epg tags, timer tags, recording tags) by this amount of minutes. defaults to 0. */

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 #include "guilib/gui3d.h"
 #include "linux/DllBCM.h"
+#include "settings/AdvancedSettings.h"
 
 #ifndef __VIDEOCORE4__
 #define __VIDEOCORE4__
@@ -554,7 +555,8 @@ void CEGLNativeTypeRaspberryPI::CallbackTvServiceCallback(void *userdata, uint32
 
 bool CEGLNativeTypeRaspberryPI::ClampToGUIDisplayLimits(int &width, int &height)
 {
-  const int max_width = 1280, max_height = 720;
+  int max_width = g_advancedSettings.m_clampGUILimitWidth;
+  int max_height = g_advancedSettings.m_clampGUILimitHeight;
   float ar = (float)width/(float)height;
   // bigger than maximum, so need to clamp
   if (width > max_width || height > max_height) {


### PR DESCRIPTION
Added the feature to set gui clamp limits on raspberry pi platform through advancedsettings.xml configuration file.
Default behaviour without advancedsettings is still 1280x720.
The configuration entries are "clampguilimitwidth" and "clampguilimitheight".
Allowed resolutions are between 320x240(vhs) and 3840x2160 (uhd, 4k) right now.
I will update the wiki entry too if request gets applied.
