### PR TITLE
[dvdinputstream] - remove any "|option" options from the strFileName whi...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DVDInputStream.h"
+#include "URL.h"
 
 CDVDInputStream::CDVDInputStream(DVDStreamType streamType)
 {
@@ -31,7 +32,13 @@ CDVDInputStream::~CDVDInputStream()
 
 bool CDVDInputStream::Open(const char* strFile, const std::string &content)
 {
-  m_strFileName = strFile;
+  CURL url = CURL(strFile);
+
+  // get rid of any |option parameters which might have sneaked in here
+  // those are only handled by our curl impl.
+  url.SetProtocolOptions("");
+  m_strFileName = url.Get();
+
   m_content = content;
   return true;
 }


### PR DESCRIPTION
...ch might have sneaked in (since some m3u8 urls are now handled by inputstreamffmpeg). Those options should only hit our curlfile impl - others can't do anything with the suffixed options and will fail.

This fixes playback of http urls handled by inputstreamffmpeg which might have attached options. (user-agent for example).

Frodo food - not sure if this is the right way to fix it - but we need that fix.
