### PR TITLE
[json] - move the initialisation of json-rpc from loadprofile into netwo...

### DIFF
--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -28,6 +28,9 @@
 #include "utils/log.h"
 #include "guilib/LocalizeStrings.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#ifdef HAS_JSONRPC
+#include "interfaces/json-rpc/JSONRPC.h"
+#endif
 
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -284,6 +287,11 @@ void CNetwork::StartServices()
 #ifdef HAS_TIME_SERVER
   g_application.StartTimeServer();
 #endif
+
+#ifdef HAS_JSONRPC
+  JSONRPC::CJSONRPC::Initialize();
+#endif
+
 #ifdef HAS_WEB_SERVER
   if (!g_application.StartWebServer())
     CGUIDialogKaiToast::QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33101), g_localizeStrings.Get(33100));

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -29,9 +29,6 @@
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
 #endif
-#ifdef HAS_JSONRPC
-#include "interfaces/json-rpc/JSONRPC.h"
-#endif
 #include "interfaces/Builtins.h"
 #include "utils/Weather.h"
 #include "network/Network.h"
@@ -298,10 +295,6 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   g_weatherManager.Refresh();
 #ifdef HAS_PYTHON
   g_pythonParser.m_bLogin = true;
-#endif
-
-#ifdef HAS_JSONRPC
-  JSONRPC::CJSONRPC::Initialize();
 #endif
 
   // start services which should run on login 


### PR DESCRIPTION
...rk.startservices. This fixes the problem that json-rpc is not available during the login dialog in multi user environments.

@Montellese ftw :)
