### PR TITLE
Only use valid CDateTime objects for pvr wakeup command

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -275,16 +275,19 @@ bool CPVRManager::SetWakeupCommand(void)
   {
     time_t iWakeupTime;
     const CDateTime nextEvent = m_timers->GetNextEventTime();
-    nextEvent.GetAsTime(iWakeupTime);
-
-    CStdString strExecCommand;
-    strExecCommand.Format("%s %d", strWakeupCommand, iWakeupTime);
-
-    const int iReturn = system(strExecCommand.c_str());
-    if (iReturn != 0)
-      CLog::Log(LOGERROR, "%s - failed to execute wakeup command '%s': %s (%d)", __FUNCTION__, strExecCommand.c_str(), strerror(iReturn), iReturn);
-
-    return iReturn == 0;
+    if (nextEvent.IsValid())
+    {
+      nextEvent.GetAsTime(iWakeupTime);
+        
+      CStdString strExecCommand;
+      strExecCommand.Format("%s %d", strWakeupCommand, iWakeupTime);
+        
+      const int iReturn = system(strExecCommand.c_str());
+      if (iReturn != 0)
+        CLog::Log(LOGERROR, "%s - failed to execute wakeup command '%s': %s (%d)", __FUNCTION__, strExecCommand.c_str(), strerror(iReturn), iReturn);
+        
+      return iReturn == 0;
+    }
   }
 
   return false;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -685,7 +685,7 @@ CDateTime CPVRTimers::GetNextEventTime(void) const
       const CDateTimeSpan oneDay(1,0,0,0);
       dailywakeuptime += oneDay;
     }
-    if (dailywakeuptime < wakeuptime)
+    if (!wakeuptime.IsValid() || dailywakeuptime < wakeuptime)
       wakeuptime = dailywakeuptime;
   }
 


### PR DESCRIPTION
This commit fixes the problem where daily wakeup never happens if there are no recordings scheduled (the daily wakeup time is compared with an invalid time object). The problem is also described in the forums: http://forum.xbmc.org/showthread.php?tid=145674

I also added a validation check for the datetime object before calling the wakeup script.
