### PR TITLE
Fix possible crash in text editor dialog

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -144,11 +144,11 @@ bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
     uint8_t b = action.GetID() & 0xFF;
     if (b == XBMCVK_HOME)
     {
-      MoveCursor(-GetCursorPos());
+      SetCursorPos(0);
     }
     else if (b == XBMCVK_END)
     {
-      MoveCursor(m_strEdit.GetLength() - GetCursorPos());
+      SetCursorPos(m_strEdit.GetLength());
     }
     else if (b == XBMCVK_LEFT)
     {
@@ -286,7 +286,7 @@ void CGUIDialogKeyboardGeneric::SetText(const CStdString& aTextString)
   m_strEdit.Empty();
   g_charsetConverter.utf8ToW(aTextString, m_strEdit);
   UpdateLabel();
-  MoveCursor(m_strEdit.size());
+  SetCursorPos(m_strEdit.size());
 }
 
 CStdString CGUIDialogKeyboardGeneric::GetText() const
@@ -539,10 +539,15 @@ void CGUIDialogKeyboardGeneric::OnDeinitWindow(int nextWindowID)
 
 void CGUIDialogKeyboardGeneric::MoveCursor(int iAmount)
 {
+  SetCursorPos(GetCursorPos() + iAmount);
+}
+
+void CGUIDialogKeyboardGeneric::SetCursorPos(int iPos)
+{
   CGUILabelControl* pEdit = ((CGUILabelControl*)GetControl(CTL_LABEL_EDIT));
   if (pEdit)
   {
-    pEdit->SetCursorPos(pEdit->GetCursorPos() + iAmount);
+    pEdit->SetCursorPos(iPos);
   }
 }
 

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.h
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.h
@@ -52,6 +52,7 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void SetControlLabel(int id, const CStdString &label);
     void OnShift();
     void MoveCursor(int iAmount);
+    void SetCursorPos(int iPos);
     int GetCursorPos() const;
     void OnSymbols();
     void OnIPAddress();

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -49,7 +49,9 @@ void CGUILabelControl::ShowCursor(bool bShow)
 
 void CGUILabelControl::SetCursorPos(int iPos)
 {
-  CStdString label = m_infoLabel.GetLabel(m_parentID);
+  CStdString labelUTF8 = m_infoLabel.GetLabel(m_parentID);
+  CStdStringW label;
+  g_charsetConverter.utf8ToW(labelUTF8, label);
   if (iPos > (int)label.length()) iPos = label.length();
   if (iPos < 0) iPos = 0;
 


### PR DESCRIPTION
When the text dialog is displayed more than once, it remembers the cursor position. As <code>CGUIDialogKeyboardGeneric::SetText</code> only moves the cursor by the string length, it will end up behind the end of the string. <code>CGUILabelControl::SetCursorPos</code> will correct the position, but for umlauts (ä, ö, ü, etc.) and similar characters CStdString gives the wrong string length. Pressing backspace then will lead to an exception, which is caught in the main loop. After the catch some portions of the application are deleted too early, so it will end up in an segmentation fault.

Therefore I applied the following fixes:
1. Convert the string to wide string in <code>CGUILabelControl::SetCursorPos</code>, to get proper length.
2. Set the cursor position directly for absolute positions, so that the position set in <code>CGUIDialogKeyboardGeneric::SetText</code> is already correct.

I also fixed the segmentation fault issue. Calling <code>CApplication::Stop()</code> in the <code>catch(...)</code> seemed safe to me, but I did not have a deeper look yet.
