### PR TITLE
fix: only remount optical disks on device change

### DIFF
--- a/xbmc/storage/linux/UDisksProvider.cpp
+++ b/xbmc/storage/linux/UDisksProvider.cpp
@@ -360,8 +360,9 @@ void CUDisksProvider::DeviceChanged(const char *object, IStorageEventsCallback *
   else
   {
     bool mounted = device->m_isMounted;
-
-    if (!mounted && g_advancedSettings.m_handleMounting)
+    /* make sure to not silently remount ejected usb thumb drives
+       that user wants to eject, but make sure to mount blurays */
+    if (!mounted && g_advancedSettings.m_handleMounting && device->m_isOptical)
       device->Mount();
 
     device->Update();


### PR DESCRIPTION
This should fix secure removal of usb thumb drives.

For the history:
In order to fix http://trac.xbmc.org/ticket/13449 which was introduced by https://github.com/xbmc/xbmc/commit/03edbe498bcdf285b2285bcc68f075f2cdfa2cc3 to fix http://trac.xbmc.org/ticket/11184

I ported over the openelec workaround from here: https://github.com/OpenELEC/OpenELEC.tv/blob/2c7ebd624682e10cc247f68aab6184d90c70ae5e/packages/mediacenter/xbmc/patches/xbmc-11.0.1-984-do-not-remount-non-optical-devices-in-DeviceChanged-event.patch
