### PR TITLE
[droid] Check external storage state before using it

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -558,12 +558,18 @@ void CXBMCApp::SetupEnv()
   setenv("XBMC_HOME", (cacheDir + "/apk/assets").c_str(), 0);
 
   std::string externalDir;
-  CJNIFile androidPath = getExternalFilesDir("");
-  if (!androidPath)
-    androidPath = getDir("org.xbmc.xbmc", 1);
-
-  if (androidPath)
-    externalDir = androidPath.getAbsolutePath();
+  std::string mountedState = CJNIEnvironment::getExternalStorageState();
+  bool mounted = mountedState == "mounted";
+    
+  if (mounted)
+  {
+    CJNIFile androidPath = getExternalFilesDir("");
+    if (!androidPath)
+      androidPath = getDir("org.xbmc.xbmc", 1);
+      
+    if (androidPath)
+      externalDir = androidPath.getAbsolutePath();
+  }
 
   if (!externalDir.empty())
     setenv("HOME", externalDir.c_str(), 0);


### PR DESCRIPTION
I have some Android boxes which provide an writeable external storage path (into RAM?) even if there is no external media mounted. As a result XBMC looses all it's data after a reboot.

This commit adds a check for external storage state mounted before trying to get the path. This fixes the problem on my boxes. Tested with and without an SD card.
