### PR TITLE
fix and improve updating of recentlyadded

### DIFF
--- a/xbmc/windows/GUIWindowHome.h
+++ b/xbmc/windows/GUIWindowHome.h
@@ -45,4 +45,5 @@ private:
 
   bool m_recentlyAddedRunning;
   int m_cumulativeUpdateFlag;
+  bool m_dbUpdating;
 };


### PR DESCRIPTION
This fixes and improves the update logic for recentlyadded items in CGUIWindowHome. As we now have both OnScanStarted/OnScanFinished and OnCleanStarted/OnCleanFinished announcements we can easily determine whether an OnUpdate/OnRemove announcement is part of a library update/clean or not. Therefore we can skip any of these announcements during a library update/clean to avoid constantly reloading the recentlyadded items and only do the reloading at the end of a library update/clean or whenever an item is updated/removed outside of a library update/clean.

The current logic does not reload the recentlyadded items when receiving an OnRemove so removing an item which is part of the recentlyadded list will not trigger an update and therefore the item is still shown on the home screen (which is definitely a bug) which is remedied by these changes.
