### PR TITLE
NFSDirectory.cpp must include limits.h

### DIFF
--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -35,6 +35,7 @@
 #include "threads/SingleLock.h"
 using namespace XFILE;
 using namespace std;
+#include <limits.h>
 #include <nfsc/libnfs-raw-mount.h>
 #include <nfsc/libnfs-raw-nfs.h>
 


### PR DESCRIPTION
While debugging an issue with libnfs, it turned out that NFSDirectory.cpp relies on the inclusion of limits.h by other, most probably rpc-related header files.

nfslib is on its way to drop dependencies to external rpc symbols (s. https://github.com/sahlberg/libnfs/issues/24), and thus doesn't inlcude such headers any longer.

Since NFSDirectory.cpp uses MAX_PATH, which comes from limits.h, limits.h has to be properly included. Backwards compatibility should not be affected by this change.
