### PR TITLE
ensure that paused jobs don't get stuck on the top of the jobqueue

### DIFF
--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -258,17 +258,14 @@ CJob *CJobManager::PopJob()
   {
     if (m_jobQueue[priority].size() && m_processing.size() < GetMaxWorkers(CJob::PRIORITY(priority)))
     {
-      CWorkItem job = m_jobQueue[priority].front();
-
       // skip adding any paused types
-      if (priority <= CJob::PRIORITY_LOW)
-      {
-        std::vector<std::string>::iterator i = find(m_pausedTypes.begin(), m_pausedTypes.end(), job.m_job->GetType());
-        if (i != m_pausedTypes.end())
-          return NULL;
-      }
+      if (!SkipPausedJobs((CJob::PRIORITY)priority))
+        return NULL;
 
+      // pop the job off the queue
+      CWorkItem job = m_jobQueue[priority].front();
       m_jobQueue[priority].pop_front();
+
       // add to the processing vector
       m_processing.push_back(job);
       job.m_job->m_callback = this;
@@ -300,6 +297,31 @@ bool CJobManager::IsPaused(const std::string &pausedType)
   CSingleLock lock(m_section);
   std::vector<std::string>::iterator i = find(m_pausedTypes.begin(), m_pausedTypes.end(), pausedType);
   return (i != m_pausedTypes.end());
+}
+
+bool CJobManager::SkipPausedJobs(CJob::PRIORITY priority)
+{
+  if (priority > CJob::PRIORITY_LOW)
+    return true;
+
+  // find the first unpaused job
+  JobQueue::iterator first_job = m_jobQueue[priority].begin();
+  for (; first_job != m_jobQueue[priority].end(); ++first_job)
+  {
+    std::vector<std::string>::iterator i = find(m_pausedTypes.begin(), m_pausedTypes.end(), first_job->m_job->GetType());
+    if (i == m_pausedTypes.end())
+      break; // found a job that can be performed
+  }
+  if (first_job == m_jobQueue[priority].end())
+    return false; // no jobs ready to go
+
+  // shunt all the paused ones to the back of the queue
+  for (JobQueue::iterator i = m_jobQueue[priority].begin(); i != first_job; i++)
+  {
+    m_jobQueue[priority].push_back(*i);
+    m_jobQueue[priority].pop_front();
+  }
+  return true;
 }
 
 int CJobManager::IsProcessing(const std::string &pausedType)

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -304,6 +304,14 @@ private:
   void RemoveWorker(const CJobWorker *worker);
   unsigned int GetMaxWorkers(CJob::PRIORITY priority) const;
 
+  /*! \brief skips over any paused jobs of given priority.
+   Moves any paused jobs at the front of the queue to the back of the
+   queue, allowing unpaused jobs to continue processing.
+   \param priority the priority queue to consider.
+   \return true if an unpaused job is available, false if no unpaused jobs are available.
+   */
+  bool SkipPausedJobs(CJob::PRIORITY priority);
+
   unsigned int m_jobCounter;
 
   typedef std::deque<CWorkItem>    JobQueue;


### PR DESCRIPTION
Scenario is as follows:
1. Most jobs sent to the job manager are of low priority.
2. The low priority queue has a feature whereby we can pause a particular job type to stop it being processed.
3. We use number 2 for the "mediaflags" jobs - they're paused on playback start, and unpaused on playback stop or end.
4. Other jobs such as the save file state job are also low priority.
5. On playback of video from the UI, we typically have a bunch of mediaflag jobs queued up, so these are in the queue and paused.
6. User plays a new file (via webinterface/remote) which triggers the save file job being added to the queue.
7. The save job is never got to while playback continues, as the thumbjob is on top and still paused.
8. User gets confused that the item they were in the process of playing doesn't have a resume point set (yet).

Fix tested as working.  Code isn't particularly pretty.  Suggestions welcome.
