### PR TITLE
fixed, aq/vq starvation on low resource platforms when parsing video content with multiple audio/subtitle streams

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1100,9 +1100,9 @@ void CDVDPlayer::Process()
       continue;
     }
 
-    // always yield to players if they have data
-    if((m_dvdPlayerAudio.HasData() || m_CurrentAudio.id < 0)
-    && (m_dvdPlayerVideo.HasData() || m_CurrentVideo.id < 0))
+    // always yield to players if they have data levels > 50 percent
+    if((m_dvdPlayerAudio.GetLevel() > 50 || m_CurrentAudio.id < 0)
+    && (m_dvdPlayerVideo.GetLevel() > 50 || m_CurrentVideo.id < 0))
       Sleep(0);
 
     DemuxPacket* pPacket = NULL;


### PR DESCRIPTION
Found/fixed playing a raw decrypted bluray via USB on single core arm CPU. 75 percent is arbitrary, the idea is to skip the yield when queue's are filling or are below 75 percent. This gives dvdplayer/demux thread more CPU time to processes demuxing video content with multiple audio/subtitle streams.
