### PR TITLE
fix excess disk activity caused by repeated and without reason epg updates

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -500,10 +500,6 @@ bool CEpg::Update(const time_t start, const time_t end, int iUpdateTime, bool bF
   /* get the last update time from the database */
   CDateTime lastScanTime = GetLastScanTime();
 
-  /* force an update for TV channels when we don't have any data every 60 seconds */
-  if (m_tags.empty() && !bUpdate && ChannelID() > 0 && !Channel()->IsRadio())
-    iUpdateTime = 60;
-
   if (!bForceUpdate)
   {
     /* check if we have to update */


### PR DESCRIPTION
partially revert 730b9477, so that EPG data is _not_ updated every five minutes for channels with no EPG data.

causes too much disk activity without a significant reason (as explained here:
https://github.com/xbmc/xbmc/commit/730b9477fac17352d80e8e49b641c7f858366a78#commitcomment-2229415)
