### PR TITLE
pvr: only update channel IconPath if the comparison channel IconPath is ...

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -212,7 +212,7 @@ bool CPVRChannel::UpdateFromClient(const CPVRChannel &channel)
   CSingleLock lock(m_critSection);
   if (m_strChannelName.IsEmpty())
     SetChannelName(channel.ClientChannelName());
-  if (m_strIconPath.IsEmpty()||(!m_strIconPath.Equals(channel.IconPath()) && !IsUserSetIcon()))
+  if (m_strIconPath.IsEmpty()||(!channel.IconPath().IsEmpty() && !m_strIconPath.Equals(channel.IconPath()) && !IsUserSetIcon()))
     SetIconPath(channel.IconPath());
 
   return m_bChanged;


### PR DESCRIPTION
...not empty (extra check).

This avoids persisting unchanged channels that have their icons set automatically in XBMC but do not have an icon set in the backend.
Speeds up initial channel loading time, since only _actually_ changed channels are persisted (compared to the current behavior which is all channels with an icon + changed channels)
