### PR TITLE
epg: new advanced setting that overrides the user defined EPG update int...

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -500,9 +500,9 @@ bool CEpg::Update(const time_t start, const time_t end, int iUpdateTime, bool bF
   /* get the last update time from the database */
   CDateTime lastScanTime = GetLastScanTime();
 
-  /* force an update for TV channels when we don't have any data every 60 seconds */
+  /* enforce advanced settings update interval override for TV Channels with no EPG data */
   if (m_tags.empty() && !bUpdate && ChannelID() > 0 && !Channel()->IsRadio())
-    iUpdateTime = 60;
+    iUpdateTime = g_advancedSettings.m_bEpgUpdateEmptyTagsInterval;
 
   if (!bForceUpdate)
   {

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -237,6 +237,7 @@ void CAdvancedSettings::Initialize()
   m_iEpgCleanupInterval = 900;     /* remove old entries from the EPG every 15 minutes */
   m_iEpgActiveTagCheckInterval = 60; /* check for updated active tags every minute */
   m_iEpgRetryInterruptedUpdateInterval = 30; /* retry an interrupted epg update after 30 seconds */
+  m_bEpgUpdateEmptyTagsInterval = 60; /* override user selectable EPG update interval for empty EPG tags */
   m_bEpgDisplayUpdatePopup = true; /* display a progress popup while updating EPG data from clients */
   m_bEpgDisplayIncrementalUpdatePopup = false; /* also display a progress popup while doing incremental EPG updates */
 
@@ -796,6 +797,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "cleanupinterval", m_iEpgCleanupInterval);
     XMLUtils::GetInt(pElement, "activetagcheckinterval", m_iEpgActiveTagCheckInterval);
     XMLUtils::GetInt(pElement, "retryinterruptedupdateinterval", m_iEpgRetryInterruptedUpdateInterval);
+    XMLUtils::GetInt(pElement, "updateemptytagsinterval", m_bEpgUpdateEmptyTagsInterval);
     XMLUtils::GetBoolean(pElement, "displayupdatepopup", m_bEpgDisplayUpdatePopup);
     XMLUtils::GetBoolean(pElement, "displayincrementalupdatepopup", m_bEpgDisplayIncrementalUpdatePopup);
   }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -276,6 +276,7 @@ class CAdvancedSettings
     int m_iEpgCleanupInterval;      // seconds
     int m_iEpgActiveTagCheckInterval; // seconds
     int m_iEpgRetryInterruptedUpdateInterval; // seconds
+    int m_bEpgUpdateEmptyTagsInterval; // seconds
     bool m_bEpgDisplayUpdatePopup;
     bool m_bEpgDisplayIncrementalUpdatePopup;
 


### PR DESCRIPTION
...erval for TV channels that have no EPG data (defaults to 1 minute)
