### PR TITLE
Fix JSONRPC GetArtistDetails to return required artist field

### DIFF
--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -117,7 +117,7 @@ JSONRPC_STATUS CAudioLibrary::GetArtistDetails(const CStdString &method, ITransp
     param["properties"] = CVariant(CVariant::VariantTypeArray);
   param["properties"].append("artist");
 
-  HandleFileItem("artistid", false, "artistdetails", items[0], parameterObject, param["properties"], result, false);
+  HandleFileItem("artistid", false, "artistdetails", items[0], param, param["properties"], result, false);
   return OK;
 }
 


### PR DESCRIPTION
The GetArtistDetails method in JSONRPC wasn't return the artist field as it was looking at the original parameterObject that didn't have that field added. I switched it to the cooked field list and it works properly.
