### PR TITLE
[droid] PVR 1.6 bump.

### DIFF
--- a/tools/android/depends/xbmc-pvr-addons/Makefile
+++ b/tools/android/depends/xbmc-pvr-addons/Makefile
@@ -2,15 +2,19 @@ include ../Makefile.include
 DEPS= ../Makefile.include Makefile
 
 LIBNAME=xbmc-pvr-addons
-VERSION=ef09a31abc3e67778d91583dd05ce8455865b2d6
+VERSION=f8c651821b9920cad32f25ac7b313f61e2ecfc4a
 GIT_DIR=$(TARBALLS_LOCATION)/$(LIBNAME).git
 BASE_URL=git://github.com/opdenkamp/$(LIBNAME).git
 DYLIB=$(PLATFORM)/addons/pvr.demo/.libs/libpvrdemo-addon.so
 #tell git to use the addons repo rather than xbmc's repo
 export GIT_DIR
 export GIT_WORK_TREE=$(PLATFORM)
+
+#mysql_config is remarkably useless. Help configure find the right one.
+export MYSQL_CONFIG=$(PREFIX)/bin/mysql_config
+
 # configuration settings
-CONFIGURE=./configure --prefix=$(PREFIX) --host=$(HOST)
+CONFIGURE=./configure --prefix=$(PREFIX) --host=$(HOST) --enable-addons-with-dependencies
 
 all: .installed-$(PLATFORM)
 


### PR DESCRIPTION
@opdenkamp: These are the only changes necessary for the 1.6 bump for android. They now have zero-known build-issues, so we're on par with desktop (excluding runtime issues ;)
