### PR TITLE
trac #13606 (Tuxbox not working for Enigma1 since Frodo Beta1)

### DIFF
--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -295,6 +295,12 @@ bool CTuxBoxUtil::ParseChannels(TiXmlElement *root, CFileItemList &items, CURL &
           CStdString strItemName = pIt->FirstChild()->Value();
 
           pIt = pNode->FirstChild("reference");
+
+          // Workaround for the url encode in strFilter so the compare in the next IF works fine.
+          strFilter.Replace("%3a",":");
+  			  strFilter.Replace("%2f","/");
+				  strFilter.Replace("&submode=4","");
+          
           if (strFilter.Equals(pIt->FirstChild()->Value()))
           {
             pIt = pNode->FirstChild("service");


### PR DESCRIPTION
Workaround for the missing channels on tuxbox protocol using Enigma1.
Tested on 3x dm500s.
