### PR TITLE
pvr: fix double internal channel group loading during startup

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -242,11 +242,14 @@ bool CPVRChannelGroups::LoadUserDefinedChannelGroups(void)
   // load group members
   for (std::vector<CPVRChannelGroupPtr>::iterator it = m_groups.begin(); it != m_groups.end(); it++)
   {
-    (*it)->Load();
+    // load only user defined groups, as internal group is already loaded
+    if (!(*it)->IsInternalGroup()) {
+      (*it)->Load();
 
-    // remove empty groups when sync with backend is enabled
-    if (bSyncWithBackends && !(*it)->IsInternalGroup() && (*it)->Size() == 0)
-      emptyGroups.push_back(*it);
+      // remove empty groups when sync with backend is enabled
+      if (bSyncWithBackends && (*it)->Size() == 0)
+        emptyGroups.push_back(*it);
+    }
   }
 
   for (std::vector<CPVRChannelGroupPtr>::iterator it = emptyGroups.begin(); it != emptyGroups.end(); it++)


### PR DESCRIPTION
Load was being called on all groups in CPVRChannelGroups::LoadUserDefinedChannelGroups, even internal groups (which were already loaded), which caused double loading of the internal groups.
Should considerably cut down initial loading time (especially for installations with many channels)
