### PR TITLE
[fix] Screensavers on OSX

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2714,10 +2714,15 @@ XB_CONFIG_MODULE([xbmc/visualizations/Goom/goom2k4-0],[
 ], [$DISABLE_GOOM])
 
 XB_CONFIG_MODULE([xbmc/screensavers/rsxs-0.9/], [
+  if test "$host_vendor" = "apple"; then
+    TEMPCFLAGS="${CFLAGS} -fgnu89-inline";
+  else
+    TEMPCFLAGS="$CFLAGS";
+  fi
   ./configure \
     CC="$CC" \
     CXX="$CXX" \
-    CFLAGS="$CFLAGS" \ 
+    CFLAGS="$TEMPCFLAGS" \ 
     CXXFLAGS="$CXXFLAGS" \
     `if test "$host_vendor" = "apple"; then echo --x-includes=/usr/X11/include --x-libraries=/usr/X11/lib; fi` \
     --prefix="${prefix}" --includedir="${includedir}" --libdir="${libdir}" --datadir="${datadir}" \

--- a/tools/darwin/depends/libpng/Makefile
+++ b/tools/darwin/depends/libpng/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.include
 
 # lib name, version
 LIBNAME=libpng
-VERSION=1.2.38
+VERSION=1.5.13
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/tools/darwin/depends/libsdl_image/Makefile
+++ b/tools/darwin/depends/libsdl_image/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.include
 
 # lib name, version
 LIBNAME=SDL_image
-VERSION=1.2.7
+VERSION=1.2.12
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/tools/darwin/depends/xbmc/Makefile
+++ b/tools/darwin/depends/xbmc/Makefile
@@ -14,7 +14,6 @@ export PATH:=$(TOOLCHAIN)/bin:$(PREFIX)/bin:$(PATH)
 CONFIGURE=./configure --prefix=$(PREFIX) \
   --enable-upnp \
   --enable-gtest \
-  --disable-rsxs \
   PKG_CONFIG_PATH=$(PREFIX)/lib/pkgconfig \
   PYTHON=$(PREFIX)/bin/python
 


### PR DESCRIPTION
as the title says, this fixes screensavers on OSX. We need to bump SDL_Image and libPNG to get it to build but I havent seen any issues on osx after doing it.

 I haven't tested on ios/ATV2, so if anyone can try that would be great.

if anyone has better idea how to do below, I am all ears ...

https://github.com/amet/xbmc/commit/5a6f1fa5f8e65fe38ad1e10f8f2cfddb9299d2b3#L0R2716

``` c++

if test "$host_vendor" = "apple"; then
  TEMPCFLAGS="${CFLAGS} -fgnu89-inline";
else
  TEMPCFLAGS="$CFLAGS";
fi 
```

amet
