### PR TITLE
[json-rpc] check add-on art existence using CFile::Exists()

### DIFF
--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -26,10 +26,12 @@
 #include "addons/PluginSource.h"
 #include "ApplicationMessenger.h"
 #include "TextureCache.h"
+#include "filesystem/File.h"
 
 using namespace std;
 using namespace JSONRPC;
 using namespace ADDON;
+using namespace XFILE;
 
 JSONRPC_STATUS CAddonsOperations::GetAddons(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -220,12 +222,11 @@ void CAddonsOperations::FillDetails(AddonPtr addon, const CVariant& fields, CVar
     else if (field == "fanart" || field == "thumbnail")
     {
       CStdString url = addonInfo[field].asString();
+      // We need to check the existence of fanart and thumbnails as the addon simply
+      // holds where the art will be, not whether it exists.
       bool needsRecaching;
       CStdString image = CTextureCache::Get().CheckCachedImage(url, false, needsRecaching);
-      if (image.empty())
-        image = CTextureCache::Get().CacheImage(url);
-
-      if (!image.empty())
+      if (!image.empty() || CFile::Exists(url))
         object[field] = CTextureCache::Get().GetWrappedImageURL(url);
       else
         object[field] = "";


### PR DESCRIPTION
rather than caching the art (it'll be cached on request if needed).

Removes the silly logging about unable to find fanart.

@Montellese to sign off.  @MartijnKaijser this probably affects the widgets script (as that's what is causing the logging, right?)
