### PR TITLE
pvr: Fix crash when opening Channels OSD while playing non PVR video

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -64,8 +64,11 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     {
-      g_PVRManager.SetPlayingGroup(m_group);
-      SetLastSelectedItem(m_group->GroupID());
+      if (m_group)
+      {
+        g_PVRManager.SetPlayingGroup(m_group);
+        SetLastSelectedItem(m_group->GroupID());
+      }
       Clear();
     }
     break;


### PR DESCRIPTION
This fixes a crash when trying to open the channels OSD
while playing a normal (non PVR) video.

This can accidentally happen for example when having a button
mapping to XBMC.ActivateWindow(PVROSDChannels) in FullscreenVideo.

The call to Close() in https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp#L78 brings us into GUI_MSG_WINDOW_DEINIT where m_group is NULL.
