### PR TITLE
addons: use the extension-point's version if no minversion (i.e. no <backwards-compatibility> tag) is specified when checking imported extension-points

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -32,6 +32,7 @@
 #include "freebsd/FreeBSDGNUReplacements.h"
 #endif
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "URL.h"
 #include <vector>
@@ -313,6 +314,13 @@ AddonPtr CAddon::Clone(const AddonPtr &self) const
 
 bool CAddon::MeetsVersion(const AddonVersion &version) const
 {
+  // if the addon is one of xbmc's extension point definitions (addonid starts with "xbmc.")
+  // and the minversion is "0.0.0" i.e. no <backwards-compatibility> tag has been specified
+  // we need to assume that the current version is not backwards-compatible and therefore check against the actual version
+  if (StringUtils::StartsWith(m_props.id, "xbmc.") &&
+     (strlen(m_props.minversion.c_str()) == 0 || StringUtils::EqualsNoCase(m_props.minversion.c_str(), "0.0.0")))
+    return m_props.version == version;
+
   return m_props.minversion <= version && version <= m_props.version;
 }
 


### PR DESCRIPTION
This is a different approach to solve the problem I first tried to solve with f2596aac4d791f45985b42103fd3737e65b96fb0 which was reverted because it affected all plugins and not just xbmc's addon extension-points. The only real way to figure out whether an addon is an addon or an extension-point is to look for "xbmc." at the beginning of the addon's ID.
