### PR TITLE
fix crash when using Container.NumItems infolabel with epggrid control

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1571,7 +1571,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
       {
         const CGUIControl *control = window->GetControl(window->GetViewContainerID());
         if (control && control->IsContainer())
-          strLabel = ((CGUIBaseContainer *)control)->GetLabel();
+          strLabel = ((IGUIContainer *)control)->GetLabel();
       }
       break;
     }
@@ -2500,7 +2500,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
       {
         const CGUIControl *control = window->GetControl(data1);
         if (control && control->IsContainer())
-          item = ((CGUIBaseContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()).get();
+          item = ((IGUIContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()).get();
       }
     }
     if (item) // If we got a valid item, do the lookup
@@ -2784,7 +2784,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
             const CGUIControl *control = window->GetControl(info.GetData1());
             if (control && control->IsContainer())
             {
-              CFileItemPtr item = boost::static_pointer_cast<CFileItem>(((CGUIBaseContainer *)control)->GetListItem(0));
+              CFileItemPtr item = boost::static_pointer_cast<CFileItem>(((IGUIContainer *)control)->GetListItem(0));
               if (item && item->m_iprogramCount == info.GetData2())  // programcount used to store item id
                 bReturn = true;
             }
@@ -2898,7 +2898,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const GUIInfo &info, int conte
     {
       const CGUIControl *control = window->GetControl(data1);
       if (control && control->IsContainer())
-        item = boost::static_pointer_cast<CFileItem>(((CGUIBaseContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
+        item = boost::static_pointer_cast<CFileItem>(((IGUIContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
     }
 
     if (item) // If we got a valid item, do the lookup
@@ -2941,7 +2941,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     {
       const CGUIControl *control = window->GetControl(data1);
       if (control && control->IsContainer())
-        item = boost::static_pointer_cast<CFileItem>(((CGUIBaseContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
+        item = boost::static_pointer_cast<CFileItem>(((IGUIContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
     }
 
     if (item) // If we got a valid item, do the lookup
@@ -3038,7 +3038,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     if (control)
     {
       if (control->IsContainer())
-        return ((CGUIBaseContainer *)control)->GetLabel(info.m_info);
+        return ((IGUIContainer *)control)->GetLabel(info.m_info);
       else if (control->GetControlType() == CGUIControl::GUICONTROL_TEXTBOX)
         return ((CGUITextBox *)control)->GetLabel(info.m_info);
     }

--- a/xbmc/GUIViewControl.cpp
+++ b/xbmc/GUIViewControl.cpp
@@ -125,7 +125,7 @@ void CGUIViewControl::SetCurrentView(int viewMode, bool bRefresh /* = false */)
 
   // Update our view control only if we are not in the TV Window
   if (m_parentWindow != WINDOW_PVR)
-    UpdateViewAsControl(((CGUIBaseContainer *)pNewView)->GetLabel());
+    UpdateViewAsControl(((IGUIContainer *)pNewView)->GetLabel());
 }
 
 void CGUIViewControl::SetItems(CFileItemList &items)
@@ -240,11 +240,11 @@ int CGUIViewControl::GetCurrentControl() const
 // returns the number-th view's viewmode (type and id)
 int CGUIViewControl::GetViewModeNumber(int number) const
 {
-  CGUIBaseContainer *nextView = NULL;
+  IGUIContainer *nextView = NULL;
   if (number >= 0 && number < (int)m_visibleViews.size())
-    nextView = (CGUIBaseContainer *)m_visibleViews[number];
+    nextView = (IGUIContainer *)m_visibleViews[number];
   else if (m_visibleViews.size())
-    nextView = (CGUIBaseContainer *)m_visibleViews[0];
+    nextView = (IGUIContainer *)m_visibleViews[0];
   if (nextView)
     return (nextView->GetType() << 16) | nextView->GetID();
   return 0;  // no view modes :(
@@ -254,7 +254,7 @@ int CGUIViewControl::GetViewModeByID(int id) const
 {
   for (unsigned int i = 0; i < m_visibleViews.size(); ++i)
   {
-    CGUIBaseContainer *view = (CGUIBaseContainer *)m_visibleViews[i];
+    IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
     if (view->GetID() == id)
       return (view->GetType() << 16) | view->GetID();
   }
@@ -269,7 +269,7 @@ int CGUIViewControl::GetNextViewMode(int direction) const
 
   int viewNumber = (m_currentView + direction) % (int)m_visibleViews.size();
   if (viewNumber < 0) viewNumber += m_visibleViews.size();
-  CGUIBaseContainer *nextView = (CGUIBaseContainer *)m_visibleViews[viewNumber];
+  IGUIContainer *nextView = (IGUIContainer *)m_visibleViews[viewNumber];
   return (nextView->GetType() << 16) | nextView->GetID();
 }
 
@@ -286,7 +286,7 @@ int CGUIViewControl::GetView(VIEW_TYPE type, int id) const
 {
   for (int i = 0; i < (int)m_visibleViews.size(); i++)
   {
-    CGUIBaseContainer *view = (CGUIBaseContainer *)m_visibleViews[i];
+    IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
     if ((type == VIEW_TYPE_NONE || type == view->GetType()) && (!id || view->GetID() == id))
       return i;
   }
@@ -300,7 +300,7 @@ void CGUIViewControl::UpdateViewAsControl(const CStdString &viewLabel)
   g_windowManager.SendMessage(msg);
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
   {
-    CGUIBaseContainer *view = (CGUIBaseContainer *)m_visibleViews[i];
+    IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
     CGUIMessage msg(GUI_MSG_LABEL_ADD, m_parentWindow, m_viewAsControl, i);
     CStdString label;
     label.Format(g_localizeStrings.Get(534).c_str(), view->GetLabel().c_str()); // View: %s

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1331,14 +1331,6 @@ int CGUIEPGGridContainer::GetSelectedItem() const
   return 0;
 }
 
-CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset) const
-{
-  if (!m_epgItemsPtr.size())
-    return CGUIListItemPtr();
-
-  return m_item->item;
-}
-
 CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset, unsigned int flag) const
 {
   if (!m_channelItems.size())

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -46,7 +46,7 @@ using namespace std;
 CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width,
                                            float height, ORIENTATION orientation, int scrollTime,
                                            int preloadItems, int timeBlocks, int rulerUnit)
-    : CGUIControl(parentID, controlID, posX, posY, width, height)
+    : IGUIContainer(parentID, controlID, posX, posY, width, height)
 {
   ControlType             = GUICONTAINER_EPGGRID;
   m_blocksPerPage         = timeBlocks;
@@ -1337,6 +1337,52 @@ CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset) const
     return CGUIListItemPtr();
 
   return m_item->item;
+}
+
+CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset, unsigned int flag) const
+{
+  if (!m_channelItems.size())
+    return CGUIListItemPtr();
+
+  int item = m_channelCursor + m_channelOffset + offset;
+  if (flag & INFOFLAG_LISTITEM_POSITION)
+    item = (int)(m_channelScrollOffset / m_channelLayout->Size(VERTICAL));
+
+  if (flag & INFOFLAG_LISTITEM_WRAP)
+  {
+    item %= (int)m_channelItems.size();
+    if (item < 0) item += m_channelItems.size();
+    return m_channelItems[item];
+  }
+  else
+  {
+    if (item >= 0 && item < (int)m_channelItems.size())
+      return m_channelItems[item];
+  }
+  return CGUIListItemPtr();
+}
+
+CStdString CGUIEPGGridContainer::GetLabel(int info) const
+{
+  CStdString label;
+  switch (info)
+  {
+  case CONTAINER_NUM_PAGES:
+    label.Format("%u", (m_channels + m_channelsPerPage - 1) / m_channelsPerPage);
+    break;
+  case CONTAINER_CURRENT_PAGE:
+    label.Format("%u", 1 + (m_channelCursor + m_channelOffset) / m_channelsPerPage );
+    break;
+  case CONTAINER_POSITION:
+    label.Format("%i", 1 + m_channelCursor + m_channelOffset);
+    break;
+  case CONTAINER_NUM_ITEMS:
+    label.Format("%u", m_channels);
+    break;
+  default:
+      break;
+  }
+  return label;
 }
 
 GridItemsPtr *CGUIEPGGridContainer::GetClosestItem(const int &channel)

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -24,6 +24,7 @@
 #include "FileItem.h"
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
+#include "guilib/GUIBaseContainer.h"
 
 namespace PVR
 {
@@ -42,7 +43,7 @@ namespace EPG
     float height;
   };
 
-  class CGUIEPGGridContainer : public CGUIControl
+  class CGUIEPGGridContainer : public IGUIContainer
   {
   friend class PVR::CGUIWindowPVRGuide;
 
@@ -77,8 +78,9 @@ namespace EPG
     void LoadLayout(TiXmlElement *layout);
     void LoadContent(TiXmlElement *content);
 
-    virtual bool IsContainer() const { return true; };
     CGUIListItemPtr GetListItem(int offset) const;
+    virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
+    virtual CStdString GetLabel(int info) const;
 
     virtual int  CorrectOffset(int offset, int cursor) const;
 

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -78,7 +78,6 @@ namespace EPG
     void LoadLayout(TiXmlElement *layout);
     void LoadContent(TiXmlElement *content);
 
-    CGUIListItemPtr GetListItem(int offset) const;
     virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
     virtual CStdString GetLabel(int info) const;
 

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -39,8 +39,20 @@ using namespace std;
 #define SCROLLING_GAP   200U
 #define SCROLLING_THRESHOLD 300U
 
+
+IGUIContainer::IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height)
+  : CGUIControl(parentID, controlID, posX, posY, width, height)
+{
+}
+
+void IGUIContainer::SetType(VIEW_TYPE type, const CStdString &label)
+{
+  m_type = type;
+  m_label = label;
+}
+
 CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)
-    : CGUIControl(parentID, controlID, posX, posY, width, height)
+    : IGUIContainer(parentID, controlID, posX, posY, width, height)
     , m_scroller(scroller)
 {
   m_cursor = 0;
@@ -1066,12 +1078,6 @@ void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items, b
 void CGUIBaseContainer::SetRenderOffset(const CPoint &offset)
 {
   m_renderOffset = offset;
-}
-
-void CGUIBaseContainer::SetType(VIEW_TYPE type, const CStdString &label)
-{
-  m_type = type;
-  m_label = label;
 }
 
 void CGUIBaseContainer::FreeMemory(int keepStart, int keepEnd)

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -37,7 +37,24 @@ typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
  \brief
  */
 
-class CGUIBaseContainer : public CGUIControl
+class IGUIContainer : public CGUIControl
+{
+protected:
+  VIEW_TYPE m_type;
+  CStdString m_label;
+public:
+  IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height);
+  virtual bool IsContainer() const { return true; };
+
+  VIEW_TYPE GetType() const { return m_type; };
+  const CStdString &GetLabel() const { return m_label; };
+  void SetType(VIEW_TYPE type, const CStdString &label);
+
+  virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const = 0;
+  virtual CStdString GetLabel(int info) const                                  = 0;
+};
+
+class CGUIBaseContainer : public IGUIContainer
 {
 public:
   CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
@@ -74,15 +91,10 @@ public:
   void LoadContent(TiXmlElement *content);
   void SetDefaultControl(int id, bool always) { m_staticDefaultItem = id; m_staticDefaultAlways = always; };
 
-  VIEW_TYPE GetType() const { return m_type; };
-  const CStdString &GetLabel() const { return m_label; };
-  void SetType(VIEW_TYPE type, const CStdString &label);
-
-  virtual bool IsContainer() const { return true; };
-  CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
+  virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
 
   virtual bool GetCondition(int condition, int data) const;
-  CStdString GetLabel(int info) const;
+  virtual CStdString GetLabel(int info) const;
 
   void SetStaticContent(const std::vector<CGUIListItemPtr> &items, bool forceUpdate = true);
   
@@ -157,9 +169,6 @@ protected:
   void UpdateScrollOffset(unsigned int currentTime);
 
   CScroller m_scroller;
-
-  VIEW_TYPE m_type;
-  CStdString m_label;
 
   bool m_staticContent;
   bool m_staticDefaultAlways;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1247,6 +1247,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     control = new CGUIEPGGridContainer(parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems, timeBlocks, rulerUnit);
     ((CGUIEPGGridContainer *)control)->LoadLayout(pControlNode);
     ((CGUIEPGGridContainer *)control)->SetRenderOffset(offset);
+    ((CGUIEPGGridContainer *)control)->SetType(viewType, viewLabel);
   }
   else if (type == CGUIControl::GUICONTAINER_FIXEDLIST)
   {

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2766,7 +2766,7 @@ void CGUIWindowSettingsCategory::FillInViewModes(CSetting *pSetting, int windowI
     window->Initialize();
     for (int i = 50; i < 60; i++)
     {
-      CGUIBaseContainer *control = (CGUIBaseContainer *)window->GetControl(i);
+      IGUIContainer *control = (IGUIContainer *)window->GetControl(i);
       if (control)
       {
         int type = (control->GetType() << 16) | i;


### PR DESCRIPTION
There is crash when we cast CGUIEpgGridContainer control to CGUIBaseContainer in info manager to get values of Container.\* or ListItem.\* infolabels for epggrid control. This PR adds common IGUIContainer class to be used by info manager and view control that both CGUIBaseContainer and CGUIEpgGridContainer subclass from. I implemented some infolabels in CGUIEpgGridContainer (Container.\* booleans are missing for now - will just return false, but won't crash)

Issue was reported in http://forum.xbmc.org/showthread.php?tid=145029
