### PR TITLE
pvr: Fixed adding new timers

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -363,8 +363,14 @@ void CGUIDialogPVRTimerSettings::OnOkay()
 {
   m_cancelled = false;
   CPVRTimerInfoTag* tag = m_timerItem->GetPVRTimerInfoTag();
-  if (tag->m_strTitle == g_localizeStrings.Get(19056))
-    tag->m_strTitle = g_PVRChannelGroups->GetByUniqueID(tag->m_iClientChannelUid, tag->m_iClientId)->ChannelName();
+
+  // Set the timer's title to the channel name if it's 'New Timer' or empty
+  if (tag->m_strTitle == g_localizeStrings.Get(19056) || tag->m_strTitle.IsEmpty())
+  {
+    CPVRChannelPtr channel = g_PVRChannelGroups->GetByUniqueID(tag->m_iClientChannelUid, tag->m_iClientId);
+    if (channel)
+      tag->m_strTitle = channel->ChannelName();
+  }
 
   if (m_bTimerActive)
     tag->m_state = PVR_TIMER_STATE_SCHEDULED;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -262,6 +262,9 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(SettingInfo &setting)
       tag->m_iClientId         = channel->GetPVRChannelInfoTag()->ClientID();
       tag->m_bIsRadio          = channel->GetPVRChannelInfoTag()->IsRadio();
       tag->m_iChannelNumber    = channel->GetPVRChannelInfoTag()->ChannelNumber();
+
+      // Update channel pointer from above values
+      tag->UpdateChannel();
     }
   }
   else if (setting.id == CONTROL_TMR_DAY && m_tmp_day > 10)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -42,7 +42,7 @@ using namespace EPG;
 
 CPVRTimerInfoTag::CPVRTimerInfoTag(void)
 {
-  m_strTitle           = StringUtils::EmptyString;
+  m_strTitle           = g_localizeStrings.Get(19056); // New Timer
   m_strDirectory       = "/";
   m_strSummary         = StringUtils::EmptyString;
   m_iClientId          = g_PVRClients->GetFirstConnectedClientID();

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -516,7 +516,11 @@ bool CPVRTimers::InstantTimer(const CPVRChannel &channel)
 bool CPVRTimers::AddTimer(const CPVRTimerInfoTag &item)
 {
   if (!item.m_channel)
+  {
+    CLog::Log(LOGERROR, "PVRTimers - %s - no channel given", __FUNCTION__);
+    CGUIDialogOK::ShowAndGetInput(19033,0,19109,0); // Couldn't save timer
     return false;
+  }
 
   if (!g_PVRClients->SupportsTimers(item.m_iClientId))
   {


### PR DESCRIPTION
This fixes the issue, that it is not possible to create new manual timers
by the timer view's 'Add Timer' button.

When creating such a timer, PVRTImerInfoTag's m_channel was not updated
and the timer therefore silently discarded in CPVRTimers::AddTimer().

Also I fixed the code that replaces the string 'New Timer' with the timer's channel name.
The timer's title was not initialized with 'New Timer' and it crashed when no channel was set.
