### PR TITLE
[locale] OSX is built with 'generic' support for stdc++ locale().

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -156,8 +156,8 @@ void CLangInfo::CRegion::SetGlobalLocale()
   // decimal separator is changed depending of the current language
   // (ie. "," in French or Dutch instead of "."). This breaks atof() and
   // others similar functions.
-#if defined(__FreeBSD__)
-  // on FreeBSD libstdc++ is compiled with "generic" locale support
+#if defined(__FreeBSD__) || defined(TARGET_DARWIN_OSX)
+  // on FreeBSD and darwin libstdc++ is compiled with "generic" locale support
   if (setlocale(LC_COLLATE, strLocale.c_str()) == NULL
   || setlocale(LC_CTYPE, strLocale.c_str()) == NULL)
   {


### PR DESCRIPTION
Fixes issues with unicode characters not uppercasing (e.g. the 'Videos' label in French on Confluence home screen).

This may well apply to iOS as well - need a test there thanks @Memphiz, @amet, @davilla.

Further, there's apparently an issue on OpenElec as well @sraue but it may be related to something else.  Make sure that the locale is correctly being set (e.g. make sure the exception isn't being thrown).

There may also be issues on Linux.  I've verified win32 (where I originally fixed this fault quite some time ago) and on OSX.
