### PR TITLE
[droid] Workaround crash on startup on Jellybean 4.2

### DIFF
--- a/docs/README.android
+++ b/docs/README.android
@@ -55,7 +55,11 @@ can be downloaded from http://www.crystax.net/en/android/ndk
 [NOTICE] Compiling XBMC for Android requires at least Crystax Android NDK
          Revision 7b. Crystax Android NDK Revision 7 and earlier do not work
          properly for our cause. The corresponding Crystax NDK version
-         is android-ndk-r7-crystax-5. Do not use the standard Android NDK.
+         is android-ndk-r7-crystax-5.beta3 Do not use the standard Android NDK.
+
+[NOTICE] We previously used android-ndk-r7-crystax-5.beta2, but it produced
+         binaries that would NOT run on Jellybean 4.2. At this time,
+         android-ndk-r7-crystax-5.beta3 is required.
          
 After downloading the SDK and NDK extract the files contained in the
 archives to your harddisk.


### PR DESCRIPTION
Updated: Rather than the previously proposed link-script change, we should instead move to the crystax ndk where this has been fixed. All we really need to do is update our documentation to make the requirement clear, and update the buildbot (which has already been done).

So there's really nothing to do here, but it would be nice to get a confirmation that all is good before updating the docs.
