### PR TITLE
[cec] bump to libCEC 2.0.5

### DIFF
--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec-2.0.3.zip                  http://mirrors.xbmc.org/build-deps/win32/
+libcec-2.0.5.zip                  http://mirrors.xbmc.org/build-deps/win32/

--- a/tools/android/depends/libcec/Makefile
+++ b/tools/android/depends/libcec/Makefile
@@ -3,7 +3,7 @@ DEPS= ../Makefile.include android.patch Makefile
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.5.2
+VERSION=2.0.5
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
@@ -11,7 +11,7 @@ ARCHIVE=$(SOURCE).tar.gz
 CONFIGURE=./configure --prefix=$(PREFIX) --host=$(HOST) \
           ac_cv_search_dlopen=yes
 
-LIBDYLIB=$(PLATFORM)/src/lib/.libs/libcec.so.1.0.5
+LIBDYLIB=$(PLATFORM)/src/lib/.libs/libcec.so.2.0.0
 
 all: .installed-$(PLATFORM)
 

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -3,7 +3,7 @@ include ../config.site.mk
 
 # lib name, version
 LIBNAME=libcec
-VERSION=2.0.3
+VERSION=2.0.5
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -379,13 +379,12 @@ bool CPeripheralCecAdapter::OpenConnection(void)
     libcec_configuration config;
     if (m_cecAdapter->GetCurrentConfiguration(&config))
     {
-      // send wakeup commands
-      if (!config.wakeDevices.IsEmpty())
-        m_cecAdapter->PowerOnDevices(CECDEVICE_BROADCAST);
-
-      // make xbmc the active source
-      if (config.bActivateSource == 1)
-        m_cecAdapter->SetActiveSource();
+      // wake devices
+      for (uint8_t iDevice = CECDEVICE_TV; iDevice < CECDEVICE_BROADCAST; iDevice++)
+      {
+        if ((config.bActivateSource == 0 || iDevice != CECDEVICE_TV) && config.wakeDevices.IsSet((cec_logical_address)iDevice))
+          m_cecAdapter->PowerOnDevices((cec_logical_address)iDevice);
+      }
 
       // update the local configuration
       CSingleLock lock(m_critSection);


### PR DESCRIPTION
bumps libCEC to 2.0.5 for android + darwin + win32.
deps have been uploaded to the mirror.

libCEC 2.0.5 for ubuntu should be pulled from Pulse-Eight's PPA. it's been uploaded, and launchpad will start building it in 15 minutes, but this PR can be merged without it.

changelog can be found here: https://github.com/Pulse-Eight/libcec/blob/master/ChangeLog
