### PR TITLE
teletext: fixes #13515 transparent background issue on Windows systems

### DIFF
--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -36,10 +36,22 @@
 #ifdef HAS_SDL
 #include <SDL/SDL_stdinc.h>
 #else
-#define SDL_memset4(dst, val, len) memset(dst, val, (len)*4)
-#define SDL_memcpy4(dst, src, len) memcpy(dst, src, (len)*4)
-#define SDL_memcpy4(dst, src, len) memcpy(dst, src, (len)*4)
-#define SDL_memset4(dst, val, len) memset(dst, val, (len)*4)
+#define SDL_memset4(dst, val, len)		\
+do {						\
+	uint32_t _count = (len);		\
+	uint32_t _n = (_count + 3) / 4;		\
+	uint32_t *_p = static_cast<uint32_t *>(dst);	\
+	uint32_t _val = (val);			\
+	if (len == 0) break;			\
+        switch (_count % 4) {			\
+        case 0: do {    *_p++ = _val;		\
+        case 3:         *_p++ = _val;		\
+        case 2:         *_p++ = _val;		\
+        case 1:         *_p++ = _val;		\
+		} while ( --_n );		\
+	}					\
+} while(0)
+#define SDL_memcpy4(dst, src, len) memcpy(dst, src, (len) << 2)
 #endif
 
 using namespace std;


### PR DESCRIPTION
@opdenkamp: This pull request fixes

http://trac.xbmc.org/ticket/13515

This regression was introduced in commit 424a4d98877a1da4f7d33e006504c2830225fb71: the removal of SDL for Windows.
This removed the HAS_SDL define and it turns out that the replacement SDL_memset4 define behaves different than the one from the SDL_stdinc.h header
This change implements the SDL_memset4 replacement to match the SDL original.
