### PR TITLE
[addons] change current xbmc.foo version number to x.y.z 

### DIFF
--- a/addons/xbmc.addon/addon.xml
+++ b/addons/xbmc.addon/addon.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.addon" version="12.0" provider-name="Team XBMC">
+<addon id="xbmc.addon" version="12.0.0" provider-name="Team XBMC">
+  <backwards-compatibility abi="12.0"/>
   <requires>
-    <import addon="xbmc.core" version="0.1"/>
+    <import addon="xbmc.core" version="0.1.0"/>
   </requires>
   <extension-point id="metadata" schema="metadata.xsd"/>
   <extension-point id="repository" schema="repository.xsd"/>

--- a/addons/xbmc.core/addon.xml
+++ b/addons/xbmc.core/addon.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.core" version="0.1" provider-name="Team XBMC">
+<addon id="xbmc.core" version="0.1.0" provider-name="Team XBMC">
+  <backwards-compatibility abi="0.1"/>
   <requires>
     <c-pluff version="0.1"/>
   </requires>

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.gui" version="4.0.0" provider-name="Team XBMC">
+  <backwards-compatibility abi="4.00"/>
   <requires>
-    <import addon="xbmc.core" version="0.1"/>
+    <import addon="xbmc.core" version="0.1.0"/>
   </requires>
   <extension-point id="skin" schema="skin.xsd"/>
   <extension-point id="webinterface" schema="webinterface.xsd"/>

--- a/addons/xbmc.json/addon.xml
+++ b/addons/xbmc.json/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.json" version="6.0.0" provider-name="Team XBMC">
   <requires>
-    <import addon="xbmc.core" version="0.1"/>
+    <import addon="xbmc.core" version="0.1.0"/>
   </requires>
 </addon>

--- a/addons/xbmc.metadata/addon.xml
+++ b/addons/xbmc.metadata/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.metadata" version="2.1" provider-name="Team XBMC">
+<addon id="xbmc.metadata" version="2.1.0" provider-name="Team XBMC">
   <backwards-compatibility abi="1.0"/>
   <requires>
-    <import addon="xbmc.core" version="0.1"/>
+    <import addon="xbmc.core" version="0.1.0"/>
   </requires>
   <extension-point id="scraper.albums" schema="scraper.xsd"/>
   <extension-point id="scraper.artists" schema="scraper.xsd"/>

--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.python" version="2.1" provider-name="Team XBMC">
+<addon id="xbmc.python" version="2.1.0" provider-name="Team XBMC">
   <backwards-compatibility abi="1.0"/>
   <requires>
-    <import addon="xbmc.core" version="0.1"/>
+    <import addon="xbmc.core" version="0.1.0"/>
   </requires>
   <extension-point id="script" schema="script.xsd"/>
   <extension-point id="subtitles" schema="script.xsd"/>


### PR DESCRIPTION
and add abi backwards fallback to x.y to prevent broken addons

Recent changes done in PR1879 and in combination with version logic caused some problems with skins/addons to be marked broken.

Like skins depended on addon.gui=4.00 and we had addon.gui=4.0.0
Since 4.00 is smaller that 4.0.0 they were marked broken.

To prevent this I added the abi backwards to the old version and changed the version numbers to the x.y.z versioning scheme.

This way we don't need to change version logic and  can use the abi tag in the future as well
