### PR TITLE
extend ClearSkinString() range

### DIFF
--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -51,7 +51,7 @@ CStdString CLocalizeStrings::ToUTF8(const CStdString& strEncoding, const CStdStr
 void CLocalizeStrings::ClearSkinStrings()
 {
   // clear the skin strings
-  Clear(31000, 31999);
+  Clear(31000, 46000);
 }
 
 bool CLocalizeStrings::LoadSkinStrings(const CStdString& path, const CStdString& language)


### PR DESCRIPTION
atm when switching between skins some strange localization issues can occur where labels from the previous skin can take over labels of the skin which got loaded.
i looked through some skins and checked in which  skin id range they are using.
xperience and nox go up to 45xxx  so i took 46000 as the upper range limit.

if this has any downside i´d also happily adjust the labels inside the skin to use only 31xxx. this would be the quicker way though^^
