### PR TITLE
[AE][ALSA] Fix support for cards with hardware mixer

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -66,6 +66,8 @@ static unsigned int ALSASampleRateList[] =
   0
 };
 
+AEDeviceInfoList DeviceInfoList;
+
 CAESinkALSA::CAESinkALSA() :
   m_pcm(NULL)
 {
@@ -131,6 +133,7 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
 {
   m_initDevice = device;
   m_initFormat = format;
+  bool hwMixer = false;
 
   /* if we are raw, correct the data format */
   if (AE_IS_RAW(format.m_dataFormat))
@@ -181,9 +184,18 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
       || snd_config_get_integer(dmixRateConf, &dmixRate) < 0)
     dmixRate = 48000; /* assume default */
 
+  /* check if device has a harware mixer */
+  for (AEDeviceInfoList::iterator itl = DeviceInfoList.begin(); itl != DeviceInfoList.end(); ++itl)
+  {
+    if (itl->m_deviceName == device)
+    {
+      hwMixer = itl->m_hwMixer;
+      break;
+    }
+  }
 
   /* Prefer dmix for non-passthrough stereo when sample rate matches */
-  if (!OpenPCMDevice(device, AESParams, m_channelLayout.Count(), &m_pcm, config, format.m_sampleRate == (unsigned int) dmixRate && !m_passthrough))
+  if (!OpenPCMDevice(device, AESParams, m_channelLayout.Count(), &m_pcm, config, (format.m_sampleRate == (unsigned int) dmixRate && !m_passthrough) || hwMixer))
   {
     CLog::Log(LOGERROR, "CAESinkALSA::Initialize - failed to initialize device \"%s\"", device.c_str());
     snd_config_delete(config);
@@ -875,6 +887,8 @@ std::string CAESinkALSA::GetParamFromName(const std::string &name, const std::st
 
 void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &device, const std::string &description, snd_config_t *config)
 {
+  DeviceInfoList = list;
+
   snd_pcm_t *pcmhandle = NULL;
   if (!OpenPCMDevice(device, "", ALSA_MAX_CHANNELS, &pcmhandle, config, false))
     return;
@@ -1041,6 +1055,9 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
       break;
     }
   }
+
+  /* detect the available subdevices count, for harware mixer > 1 */
+  info.m_hwMixer = snd_pcm_info_get_subdevices_count(pcminfo) > 1;
 
   if (device == "default" && channels == 2)
   {

--- a/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
@@ -30,6 +30,7 @@ CAEDeviceInfo::operator std::string()
   ss << "m_displayNameExtra: " << m_displayNameExtra << '\n';
   ss << "m_deviceType      : " << DeviceTypeToString(m_deviceType) + '\n';
   ss << "m_channels        : " << (std::string)m_channels << '\n';
+  ss << "m_hwMixer         : " << m_hwMixer << '\n';
 
   ss << "m_sampleRates     : ";
   for (AESampleRateList::iterator itt = m_sampleRates.begin(); itt != m_sampleRates.end(); ++itt)

--- a/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.h
@@ -45,6 +45,7 @@ public:
   std::string       m_displayNameExtra;	/* additional display name info, ie, monitor name from ELD */
   enum AEDeviceType m_deviceType;	/* the device type, PCM, IEC958 or HDMI */
   CAEChannelInfo    m_channels;		/* the channels the device is capable of rendering */
+  bool              m_hwMixer;		/* determine whether device has a harware mixer */
   AESampleRateList  m_sampleRates;	/* the samplerates the device is capable of rendering */
   AEDataFormatList  m_dataFormats;	/* the dataformats the device is capable of rendering */
 


### PR DESCRIPTION
Cards with hardware mixer doesn't need to use dmix at all.
Old behavior leads to problem with playing non 48kHz audio on
multispeaker configuration.
On Audigy wrong device was opened according to frequency:
44.1kHz: front:CARD=Audigy,DEV=0
48.0kHz: sysdefault:CARD=Audigy

This patch enables check for hardware mixer availability and
open PCM device with taking it into account.

More information: http://trac.xbmc.org/ticket/13381
