### PR TITLE
[paplayer] - when player is paused - don't process streams but just yield...

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -463,6 +463,13 @@ void PAPlayer::Process()
 
     double delay  = 100.0;
     double buffer = 100.0;
+    
+    if (IsPaused())
+    {
+      CThread::Sleep(10);
+      continue;
+    }
+    
     ProcessStreams(delay, buffer);
 
     double watermark = buffer * 0.5;


### PR DESCRIPTION
... cpu to other threads.

The following problem exists on osx and ios (was not able to reproduce this on linux).

On all audio codecs in paplayer which get decoded via ffmpeg (dvdplayercodec) when pausing a track it might happen that it just unpauses itself and skips to the next track.

The following stuff is going on when this happens:
1. During pause the paplayer still loops in his threadloop and processes its streams
2. In ProcessStream it calls si->m_decoder.ReadSamples(PACKET_SIZE) and queues more data
3. In some circumstances (not always - but mostly when i start XBMC and start the music tracks for the first time) this leads to some sort of read error in https://github.com/xbmc/xbmc/blob/master/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp#L660 (result is  a big negative number which i couldn't assign to any specific error code).
4. This leads to the flush and to the fact returning NULL
5. Returning NULL is treated as EOF in the upper layers
6. EOF is now processed by the paplayer which is still paused. He queues the next track and resumes it. (gui is still in paused state because paplayer does this on his own with out telling anyone).

I know that pausing paplayer in the way i propose in this PR will stop filling the buffers during pause. But hey this is audio - every crappy wlan should get this through the air with out the need of a big cache.

I also know that the core issue might lay much deeper (maybe even in ffmpeg or a compile issue on osx/ios). But we need a fix for frodo - and i'm already done again with that paplayer stuff (i can't stand it more then 3 hours in a row ;) ).

ping to @elupus @gnif @davilla
