### PR TITLE
Fix ActivateWindowAndFocus window history behaviour

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -374,7 +374,7 @@ int CBuiltins::Execute(const CStdString& execString)
         CBuiltins::Execute("Quit");
 #endif
       vector<CStdString> dummy;
-      g_windowManager.ActivateWindow(iWindow, dummy, !execute.Equals("activatewindow"));
+      g_windowManager.ActivateWindow(iWindow, dummy, false);
 
       unsigned int iPtr = 1;
       while (params.size() > iPtr + 1)


### PR DESCRIPTION
`ActivateWindow` does add the window to the history stack, as opposed to `ReplaceWindow`. Due to a copy-paste error `ActivateWindowAndFocus` works incorrectly as it replaces the window, not adding it to the window history stack as suggested by the name.
