### PR TITLE
fixed - re-initialise the add-on manager when loading a new profile

### DIFF
--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -72,6 +72,7 @@ namespace ADDON
   {
   public:
     static CAddonMgr &Get();
+    bool ReInit() { DeInit(); return Init(); }
     bool Init();
     void DeInit();
 

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -295,6 +295,9 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
     g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
   }
 
+  // reload the add-ons, or we will first load all add-ons from the master account without checking disabled status
+  ADDON::CAddonMgr::Get().ReInit();
+
   g_weatherManager.Refresh();
 #ifdef HAS_PYTHON
   g_pythonParser.m_bLogin = true;


### PR DESCRIPTION
or we will first load all add-ons from the master profile, then switch profiles and then the disabled status in the database for that profile doesn't match the status in the add-on manager

see http://trac.xbmc.org/ticket/13447
