### PR TITLE
[LinuxRendererGLES] - Don't let RENDER_BYPASS clear out the whole screen

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -415,12 +415,21 @@ void CLinuxRendererGLES::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
     if (m_RenderUpdateCallBackFn)
       (*m_RenderUpdateCallBackFn)(m_RenderUpdateCallBackCtx, m_sourceRect, m_destRect);
 
+    RESOLUTION res = GetResolution();
+    int iWidth = g_settings.m_ResInfo[res].iWidth;
+    int iHeight = g_settings.m_ResInfo[res].iHeight;
+
     g_graphicsContext.BeginPaint();
 
+    glScissor(m_destRect.x1, 
+              iHeight - m_destRect.y2, 
+              m_destRect.x2 - m_destRect.x1, 
+              m_destRect.y2 - m_destRect.y1);
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glClearColor(0, 0, 0, 0);
     glClear(GL_COLOR_BUFFER_BIT);
+    glScissor(0, 0, iWidth, iHeight);
 
     g_graphicsContext.EndPaint();
     return;


### PR DESCRIPTION
Currently RENDER_BYPASS clears out the whole screen which results in an ugly view when video isn't in fullscreen (e.g. pvr window in confluence).

This commit uses the glScissor function to clear out the video rect only.

Example before: https://dl.dropbox.com/u/8261657/bypass_before.png
Example after: https://dl.dropbox.com/u/8261657/bypass_after.png

Tested on linux (pivos buildroot) and android (amlplayer) with different resolutions.

These are my first lines of code in OpenGL... there can be very well a better solution for this. But I didn't see any problems (not with performance or anything else).
