### PR TITLE
paplayer: implement Seek() to support (small/big)skip(forward/backward)

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -839,6 +839,29 @@ bool PAPlayer::CanSeek()
 
 void PAPlayer::Seek(bool bPlus, bool bLargeStep)
 {
+  if (!CanSeek()) return;
+
+  __int64 seek;
+  if (g_advancedSettings.m_musicUseTimeSeeking && GetTotalTime() > 2 * g_advancedSettings.m_musicTimeSeekForwardBig)
+  {
+    if (bLargeStep)
+      seek = bPlus ? g_advancedSettings.m_musicTimeSeekForwardBig : g_advancedSettings.m_musicTimeSeekBackwardBig;
+    else
+      seek = bPlus ? g_advancedSettings.m_musicTimeSeekForward : g_advancedSettings.m_musicTimeSeekBackward;
+    seek *= 1000;
+    seek += GetTime();
+  }
+  else
+  {
+    float percent;
+    if (bLargeStep)
+      percent = bPlus ? (float)g_advancedSettings.m_musicPercentSeekForwardBig : (float)g_advancedSettings.m_musicPercentSeekBackwardBig;
+    else
+      percent = bPlus ? (float)g_advancedSettings.m_musicPercentSeekForward : (float)g_advancedSettings.m_musicPercentSeekBackward;
+    seek = (__int64)(GetTotalTime64() * (GetPercentage() + percent) / 100);
+  }
+
+  SeekTime(seek);
 }
 
 void PAPlayer::SeekTime(int64_t iTime /*=0*/)


### PR DESCRIPTION
As the title says this adds back the implementation of CPAPlayer::Seek() which was lost in the re-write during the AE merge. The code is exactly the same as from before the AE merge (except for some cosmetics). This brings back the possibility to use smallskipforward, smallskipbackward, bigskipforward and bigskipbackward which can either be used through CBuiltin's "playercontrol" function or through JSON-RPC's Player.Seek.

I've gotten a lot of complaints about this from JSON-RPC API users ever since AE has been merged but I always thought the new PAPlayer didn't support any seeking at all so I never looked into it. But as I found out today absolute seeking work just fine so implementing the relative seeking is straight forward. I consider this a bug fix as it worked in Eden and currently doesn't work in Frodo.
