### PR TITLE
[pvr] Use play count and resume point information from the PVR client if available.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1448,6 +1448,9 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
   if (item.HasVideoInfoTag())
   { // copy info across (TODO: premiered info is normally stored in m_dateTime by the db)
     *GetVideoInfoTag() = *item.GetVideoInfoTag();
+    // preferably use some information from PVR info tag if available
+    if (HasPVRRecordingInfoTag())
+      GetPVRRecordingInfoTag()->CopyClientInfo(GetVideoInfoTag());
     SetOverlayImage(ICON_OVERLAY_UNWATCHED, GetVideoInfoTag()->m_playCount > 0);
   }
   if (item.HasMusicInfoTag())

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -274,3 +274,14 @@ CStdString CPVRRecording::GetTitleFromURL(const CStdString &url)
   }
   return StringUtils::EmptyString;
 }
+
+void CPVRRecording::CopyClientInfo(CVideoInfoTag *target)
+{
+  if (!target)
+    return;
+
+  if (g_PVRClients->SupportsRecordingPlayCount(m_iClientId))
+    target->m_playCount = m_playCount;
+  if (g_PVRClients->SupportsLastPlayedPosition(m_iClientId))
+    target->m_resumePoint = m_resumePoint;
+}

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -132,6 +132,12 @@ namespace PVR
      */
     static CStdString GetTitleFromURL(const CStdString &url);
 
+    /*!
+     * @brief Copy some information from the client to the given video info tag
+     * @param target video info tag to which the information will be copied
+     */
+    void CopyClientInfo(CVideoInfoTag *target);
+
   private:
     CDateTime m_recordingTime; /*!< start time of the recording */
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -53,6 +53,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "video/VideoInfoScanner.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
+#include "pvr/recordings/PVRRecording.h"
 
 using namespace XFILE;
 using namespace VIDEODATABASEDIRECTORY;
@@ -469,6 +470,10 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
         fetchedPlayCounts = true;
       }
       
+      // preferably use some information from PVR info tag if available
+      if (pItem->HasPVRRecordingInfoTag())
+        pItem->GetPVRRecordingInfoTag()->CopyClientInfo(pItem->GetVideoInfoTag());
+
       // set the watched overlay
       if (pItem->IsVideo())
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_playCount > 0);


### PR DESCRIPTION
Fixes the issue reported by @fetzerch that as a result of #1719 the watched status and resume position supplied by the PVR client are overwritten with the values read from the library. If the backend is also used without XBMC, those values can differ.

With this PR the respective values of the PVR client (if available/supported) take precedence over those from the library.
