### PR TITLE
Fix deadlock on exit when a pvr addon failed to connect

### DIFF
--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -70,7 +70,7 @@ CAddonStatusHandler::~CAddonStatusHandler()
 
 void CAddonStatusHandler::OnStartup()
 {
-  SetPriority(-15);
+  SetPriority(GetMinPriority());
 }
 
 void CAddonStatusHandler::OnExit()

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -60,7 +60,6 @@ CAddonStatusHandler::CAddonStatusHandler(const CStdString &addonID, ADDON_STATUS
   else
   {
     Create(true, THREAD_MINSTACKSIZE);
-    SetPriority(-15);
   }
 }
 
@@ -71,6 +70,7 @@ CAddonStatusHandler::~CAddonStatusHandler()
 
 void CAddonStatusHandler::OnStartup()
 {
+  SetPriority(-15);
 }
 
 void CAddonStatusHandler::OnExit()


### PR DESCRIPTION
As far as I know, this has only been observed on android, but there's nothing platform-specific about this, so it is likely due to a change in thread timings.

Fixes the deadlock in https://github.com/opdenkamp/xbmc-pvr-addons/issues/104 . See there and the commit messages for discussion/rationale.

@opdenkamp @FernetMenta @jimfcarroll Any thoughts would be appreciated. I'm confident that the issue is resolved, but I wonder if it's worth trying to fix the root cause as well, to avoid this elsewhere.
