### PR TITLE
release: add a script for creating bootstrapped tarballs for release

### DIFF
--- a/tools/mk-release-source
+++ b/tools/mk-release-source
@@ -1,0 +1,31 @@
+#!/bin/sh
+REVISION="${1}"
+COMPRESS="gzip"
+WORKDIR="xbmc-${REVISION}"
+
+if [[ -z "${REVISION}" ]]; then echo "Usage: ${0} tag|branch|commit [gzip|xz|...]" && exit 1; fi
+if [[ -d "${WORKDIR}" ]]; then echo "${WORKDIR} dir exists, refusing to overwrite" && exit 1; fi
+if [[ -n "${2}" ]]; then COMPRESS="${2}"; fi
+
+which git >/dev/null || exit 1
+git rev-list -1 ${REVISION} >/dev/null || exit 1
+
+mkdir -p "${WORKDIR}"
+GIT_WORK_TREE="${WORKDIR}" git checkout "${REVISION}" -- . || exit 1
+
+pushd "${WORKDIR}" >/dev/null
+./bootstrap || ( rm -rf "${WORKDIR}" && exit 1 )
+popd >/dev/null
+
+pushd "${WORKDIR}/tools/android/depends" >/dev/null
+./bootstrap || ( rm -rf "${WORKDIR}" && exit 1 )
+popd >/dev/null
+
+echo "${REVISION}" > "${WORKDIR}"/VERSION
+echo "`git rev-list -1 ${REVISION}`" >> "${WORKDIR}"/VERSION
+
+tar cf "${WORKDIR}.tar" "${WORKDIR}" || ( rm -f "${WORKDIR}.tar" && rm -rf "${WORKDIR}" exit 1 )
+${COMPRESS} ${WORKDIR}.tar || ( rm -f "${WORKDIR}.tar" && rm -rf "${WORKDIR}" && exit 1 )
+
+rm -rf ${WORKDIR}
+exit 0


### PR DESCRIPTION
As discussed at devcon. This is the reason for rearranging the bootstrapping, it creates a source tarball that does not require java/swig/autotools.

example: 'mk-release-source 10.0-Dharma' will create xbmc-10.0-Dharma.tar.gz,
ready to be uploaded and deployed. It works in a subdir and does not affect the
current working dir or git repo.

This should also solve the problem in https://github.com/xbmc/xbmc/pull/1934, as it will create a file called VERSION in the tarball, containing the current git tag/revision, so that it never needs to be generated in a real repo.

This will also allow debian/ubuntu to pre-bootstrap their sources and drop java/swig/autotools as build-deps.
