### PR TITLE
decouple rendering and window closing, fixes #13650

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -357,15 +357,15 @@ void CGUIWindow::DoRender()
   if (CGUIControlProfiler::IsRunning()) CGUIControlProfiler::Instance().EndFrame();
 }
 
-void CGUIWindow::Render()
+void CGUIWindow::AfterRender()
 {
-  CGUIControlGroup::Render();
   // Check to see if we should close at this point
   // We check after the controls have finished rendering, as we may have to close due to
   // the controls rendering after the window has finished it's animation
   // we call the base class instead of this class so that we can find the change
   if (m_closing && !CGUIControlGroup::IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
     Close(true);
+
 }
 
 void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -98,7 +98,11 @@ public:
    \sa FrameMove
    */
   virtual void DoRender();
-  virtual void Render();
+
+  /*! \brief Do any post render activities.
+    Check if window closing animation is finished and finalize window closing.
+   */
+  void AfterRender();
   
   /*! \brief Main update function, called every frame prior to rendering
    Any window that requires updating on a frame by frame basis (such as to maintain

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -593,7 +593,25 @@ bool CGUIWindowManager::Render()
 
   m_tracker.CleanMarkedRegions();
 
+  // execute post rendering actions (finalize window closing)
+  AfterRender();
+
   return hasRendered;
+}
+
+void CGUIWindowManager::AfterRender()
+{
+  CGUIWindow* pWindow = GetWindow(GetActiveWindow());
+  if (pWindow)
+    pWindow->AfterRender();
+
+  // make copy of vector as we may remove items from it as we go
+  vector<CGUIWindow *> activeDialogs = m_activeDialogs;
+  for (iDialog it = activeDialogs.begin(); it != activeDialogs.end(); ++it)
+  {
+    if ((*it)->IsDialogRunning())
+      (*it)->AfterRender();
+  }
 }
 
 void CGUIWindowManager::FrameMove()

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -90,6 +90,10 @@ public:
    */
   bool Render();
 
+  /*! \brief Do any post render activities.
+   */
+  void AfterRender();
+
   /*! \brief Per-frame updating of the current window and any dialogs
    FrameMove is called every frame to update the current window and any dialogs
    on screen. It should only be called from the application thread.


### PR DESCRIPTION
We can stuck on window closing if control report empty dirty region (f.e. label control without text or control group without child controls) because we rely on CGUIWindow::Render() being called to finish window closing (which won't be called as empty dirty regions are discarded in dirty region tracker). 

This decouples rendereing and window closing by adding new AfterRender() methods that will be called each frame (regardless of dirty region state) that will handle window closing.

More details in http://trac.xbmc.org/ticket/13650
