### PR TITLE
changed: Improve performance (considerably) when browsing streamed (inte...

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -380,6 +380,18 @@ bool CVideoThumbLoader::FillThumb(CFileItem &item)
 
 std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::string &type, bool checkFolder)
 {
+  /* Cache directory for (sub) folders on streamed filesystems. We need to do this
+     else entering (new) directories from the app thread becomes much slower. This
+     is caused by the fact that Curl Stat/Exist() is really slow and that the 
+     thumbloader thread accesses the streamed filesystem at the same time as the
+     App thread and the latter has to wait for it.
+   */
+  if (item.m_bIsFolder && item.IsInternetStream(true))
+  {
+    CFileItemList items; // Dummy list
+    CDirectory::GetDirectory(item.GetPath(), items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+  }
+
   std::string art;
   if (!type.empty())
   {


### PR DESCRIPTION
...rnet) filesystems + increase dir cache size. The performance of streamed filesystems compared to Eden is terrible in Frodo. While browsing such filesystems in the GUI feels really slow. The reason is that our backgroundinfo/thumb-loader check for more art types now and thus hit the filesystem more often with Exists() calls, which are insanely slow with Curl. To workaround this we first cache the item's directory before checking for local (art) file existance. I also increased the directory cache size a bit as I don't think there are any platforms should have problems handling bigger sizes. Perhaps we should consider doing this for all filesystems and perhaps even increase the MAX_CACHED_DIR to an even higher value?

Since it's a regression from Eden, and the performance gain is huge, it would be nice if this could still be included for Frodo.
