### PR TITLE
Remove incomplete IsExtSupported from CWinSystemEGL

### DIFF
--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -122,7 +122,6 @@ bool CWinSystemEGL::InitWindowSystem()
     CreateWindow(temp);
   }
 
-  m_extensions = m_egl->GetExtensions(m_display);
   return CWinSystemBase::InitWindowSystem();
 }
 
@@ -364,16 +363,6 @@ void CWinSystemEGL::UpdateResolutions()
   }
 }
 
-bool CWinSystemEGL::IsExtSupported(const char* extension)
-{
-  std::string name;
-
-  name  = " ";
-  name += extension;
-  name += " ";
-
-  return m_extensions.find(name) != std::string::npos;
-}
 
 bool CWinSystemEGL::PresentRenderImpl(const CDirtyRegionList &dirty)
 {

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -43,7 +43,6 @@ public:
   virtual bool  ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop);
   virtual bool  SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual void  UpdateResolutions();
-  virtual bool  IsExtSupported(const char* extension);
 
   virtual void  ShowOSMouse(bool show);
   virtual bool  HasCursor();
@@ -76,7 +75,6 @@ protected:
 
   CEGLWrapper           *m_egl;
   bool                  m_iVSyncMode;
-  std::string           m_extensions;
 };
 
 XBMC_GLOBAL_REF(CWinSystemEGL,g_Windowing);


### PR DESCRIPTION
In the log on Pi, we get:
18:17:44 T:3040780928  NOTICE: GL: Reverting to POT textures

which is strange because we support nPOT.

This means (in xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp):

```
  // determine whether GPU supports NPOT textures
  if (!g_Windowing.IsExtSupported("GL_TEXTURE_NPOT"))
```

is returning false.

But:

```
bool CRenderSystemGLES::IsExtSupported(const char* extension)
{
   ...
  else if (strcmp( extension, "GL_TEXTURE_NPOT" ) == 0)
  {
    // GLES supports non-power-of-two textures as standard.
        return true;
```

it should be returning true!

Trouble is, that xbmc/windowing/egl/WinSystemEGL.cpp overrides this
function with one that doesn't return true. I think this function
should be removed.

(Note: GL_TEXTURE_NPOT is not the correct extension name for GLES - it would need to be GL_OES_texture_npot if this is meant to query the GLES driver)
