### PR TITLE
get rid of the setting not found log spam

### DIFF
--- a/xbmc/network/libscrobbler/lastfmscrobbler.cpp
+++ b/xbmc/network/libscrobbler/lastfmscrobbler.cpp
@@ -101,7 +101,6 @@ bool CLastfmScrobbler::CanScrobble()
 {
   return (!g_guiSettings.GetString("scrobbler.lastfmusername").IsEmpty()  &&
           !g_guiSettings.GetString("scrobbler.lastfmpass").IsEmpty()  &&
-         (g_guiSettings.GetBool("scrobbler.lastfmsubmit") ||
-          g_guiSettings.GetBool("scrobbler.lastfmsubmitradio")));
+          g_guiSettings.GetBool("scrobbler.lastfmsubmit"));
 }
 

--- a/xbmc/network/libscrobbler/scrobbler.cpp
+++ b/xbmc/network/libscrobbler/scrobbler.cpp
@@ -110,7 +110,7 @@ void CScrobbler::AddSong(const MUSIC_INFO::CMusicInfoTag &tag, bool lastfmradio)
   CURL::Encode(m_CurrentTrack.strMusicBrainzID);
 
   m_bNotified = false;
-  m_bSubmitted = !((lastfmradio && g_guiSettings.GetBool("scrobbler.lastfmsubmitradio")) ||
+  m_bSubmitted = !(lastfmradio ||
       (!lastfmradio && g_guiSettings.GetBool("scrobbler.lastfmsubmit") && (m_CurrentTrack.length > SCROBBLER_MIN_DURATION || !m_CurrentTrack.strMusicBrainzID.IsEmpty())));
 }
 

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -894,8 +894,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
     else if (strSetting.Equals("scrobbler.lastfmusername") || strSetting.Equals("scrobbler.lastfmpass"))
     {
       CGUIButtonControl *pControl = (CGUIButtonControl *)GetControl(pSettingControl->GetID());
-      if (pControl)
-        pControl->SetEnabled(g_guiSettings.GetBool("scrobbler.lastfmsubmit") | g_guiSettings.GetBool("scrobbler.lastfmsubmitradio"));
+      if (pControl) pControl->SetEnabled(g_guiSettings.GetBool("scrobbler.lastfmsubmit"));
     }
     else if (strSetting.Equals("scrobbler.librefmusername") || strSetting.Equals("scrobbler.librefmpass"))
     {
@@ -1222,12 +1221,11 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       musicdatabase.Close();
     }
   }
-  else if (strSetting.Equals("scrobbler.lastfmsubmit") || strSetting.Equals("scrobbler.lastfmsubmitradio") || strSetting.Equals("scrobbler.lastfmusername") || strSetting.Equals("scrobbler.lastfmpass"))
+  else if (strSetting.Equals("scrobbler.lastfmsubmit") || strSetting.Equals("scrobbler.lastfmusername") || strSetting.Equals("scrobbler.lastfmpass"))
   {
     CStdString strPassword=g_guiSettings.GetString("scrobbler.lastfmpass");
     CStdString strUserName=g_guiSettings.GetString("scrobbler.lastfmusername");
-    if ((g_guiSettings.GetBool("scrobbler.lastfmsubmit") ||
-         g_guiSettings.GetBool("scrobbler.lastfmsubmitradio")) &&
+    if (g_guiSettings.GetBool("scrobbler.lastfmsubmit") &&
          !strUserName.IsEmpty() && !strPassword.IsEmpty())
     {
       CLastfmScrobbler::GetInstance()->Init();
@@ -1237,12 +1235,11 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       CLastfmScrobbler::GetInstance()->Term();
     }
   }
-  else if (strSetting.Equals("scrobbler.librefmsubmit") || strSetting.Equals("scrobbler.librefmsubmitradio") || strSetting.Equals("scrobbler.librefmusername") || strSetting.Equals("scrobbler.librefmpass"))
+  else if (strSetting.Equals("scrobbler.librefmsubmit") || strSetting.Equals("scrobbler.librefmusername") || strSetting.Equals("scrobbler.librefmpass"))
   {
     CStdString strPassword=g_guiSettings.GetString("scrobbler.librefmpass");
     CStdString strUserName=g_guiSettings.GetString("scrobbler.librefmusername");
-    if ((g_guiSettings.GetBool("scrobbler.librefmsubmit") ||
-         g_guiSettings.GetBool("scrobbler.librefmsubmitradio")) &&
+    if (g_guiSettings.GetBool("scrobbler.librefmsubmit") &&
          !strUserName.IsEmpty() && !strPassword.IsEmpty())
     {
       CLibrefmScrobbler::GetInstance()->Init();


### PR DESCRIPTION
ever since we removed the lastfmradio scroblle setting, the logfile is getting spammed with:

DEBUG: Error: Requested setting (scrobbler.lastfmsubmitradio) was not found.  It must be case-sensitive

while is was at it, i also removed the check for the non-existent librefmsubmitradio setting.
