### PR TITLE
use a smart ptr for the BaseSettingControl pointers

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1234,6 +1234,9 @@ bool CMusicDatabase::GetAlbumInfo(int idAlbum, CAlbum &info, VECSONGS* songs, bo
 {
   try
   {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS2.get()) return false;
+
     if (idAlbum == -1)
       return false; // not in the database
 
@@ -1289,30 +1292,18 @@ bool CMusicDatabase::HasAlbumInfo(int idAlbum)
 
 bool CMusicDatabase::DeleteAlbumInfo(int idAlbum)
 {
-  try
-  {
-    if (idAlbum == -1)
-      return false; // not in the database
-
-    CStdString strSQL = PrepareSQL("delete from albuminfo where idAlbum=%i",idAlbum);
-
-    if (!m_pDS2->exec(strSQL.c_str()))
-      return false;
-
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s - (%i) failed", __FUNCTION__, idAlbum);
-  }
-
-  return false;
+  if (idAlbum == -1)
+    return false; // not in the database
+  return ExecuteQuery(PrepareSQL("delete from albuminfo where idAlbum=%i",idAlbum));
 }
 
 bool CMusicDatabase::GetArtistInfo(int idArtist, CArtist &info, bool needAll)
 {
   try
   {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS2.get()) return false;
+
     if (idArtist == -1)
       return false; // not in the database
 
@@ -1358,24 +1349,10 @@ bool CMusicDatabase::GetArtistInfo(int idArtist, CArtist &info, bool needAll)
 
 bool CMusicDatabase::DeleteArtistInfo(int idArtist)
 {
-  try
-  {
-    if (idArtist == -1)
-      return false; // not in the database
+  if (idArtist == -1)
+    return false; // not in the database
 
-    CStdString strSQL = PrepareSQL("delete from artistinfo where idArtist=%i",idArtist);
-
-    if (!m_pDS2->exec(strSQL.c_str()))
-      return false;
-
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s - (%i) failed", __FUNCTION__, idArtist);
-  }
-
-  return false;
+  return ExecuteQuery(PrepareSQL("delete from artistinfo where idArtist=%i",idArtist));
 }
 
 bool CMusicDatabase::GetAlbumInfoSongs(int idAlbumInfo, VECSONGS& songs)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -103,7 +103,7 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_ALBUMINFO)
       {
-        CGUIWindowMusicBase *window = (CGUIWindowMusicBase *)g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
+        CGUIWindowMusicBase *window = (CGUIWindowMusicBase *)g_windowManager.GetWindow(WINDOW_MUSIC_NAV);
         if (window)
         {
           CFileItem item(*m_song);

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -301,6 +301,9 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
     return;
   }
 
+  // this function called from outside this window - make sure the database is open
+  m_musicdatabase.Open();
+
   CStdString strPath = pItem->GetPath();
 
   // Try to find an album to lookup from the current item
@@ -346,7 +349,10 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
       m_dlgProgress->StartModal();
       m_dlgProgress->Progress();
       if (m_dlgProgress->IsCanceled())
+      {
+        m_musicdatabase.Close();
         return;
+      }
     }
     // check the first song we find in the folder, and grab it's album info
     for (int i = 0; i < items.Size() && !foundAlbum; i++)
@@ -374,6 +380,7 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
       CLog::Log(LOGINFO, "%s called on a folder containing no songs with tag info - nothing can be done", __FUNCTION__);
       if (m_dlgProgress && bShowInfo)
         m_dlgProgress->Close();
+      m_musicdatabase.Close();
       return;
     }
 
@@ -385,6 +392,7 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
     ShowArtistInfo(artist, pItem->GetPath(), false, bShowInfo);
   else
     ShowAlbumInfo(album, strPath, false, bShowInfo);
+  m_musicdatabase.Close();
 }
 
 void CGUIWindowMusicBase::OnManualAlbumInfo()

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2039,10 +2039,12 @@ void CGUIWindowSettingsCategory::FreeSettingsControls()
     control->ClearAll();
   }
 
-  for(int i = 0; (size_t)i < m_vecSettings.size(); i++)
+  for (int i = 0; (size_t)i < m_vecSettings.size(); i++)
   {
+    m_vecSettings[i]->Clear();
     delete m_vecSettings[i];
   }
+
   m_vecSettings.clear();
 }
 

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -166,7 +166,7 @@ CGUIWindowSettingsCategory::CGUIWindowSettingsCategory(void)
   m_strOldTrackFormat = "";
   m_strOldTrackFormatRight = "";
   m_returningFromSkinLoad = false;
-  m_delayedSetting = NULL;
+  m_delayedSetting.reset();
 }
 
 CGUIWindowSettingsCategory::~CGUIWindowSettingsCategory(void)
@@ -204,7 +204,7 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
           focusedControl - CONTROL_START_BUTTONS != m_iSection && !m_returningFromSkinLoad)
       {
         // changing section, check for updates and cancel any delayed changes
-        m_delayedSetting = NULL;
+        m_delayedSetting.reset();
         CheckForUpdates();
 
         if (m_vecSections[focusedControl-CONTROL_START_BUTTONS]->m_strCategory == "masterlock")
@@ -239,7 +239,7 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
     break;
   case GUI_MSG_WINDOW_INIT:
     {
-      m_delayedSetting = NULL;
+      m_delayedSetting.reset();
       if (message.GetParam1() != WINDOW_INVALID && !m_returningFromSkinLoad)
       { // coming to this window first time (ie not returning back from some other window)
         // so we reset our section and control states
@@ -256,7 +256,7 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
     if (m_delayedSetting)
     {
       OnSettingChanged(m_delayedSetting);
-      m_delayedSetting = NULL;
+      m_delayedSetting.reset();
       return true;
     }
     break;
@@ -273,7 +273,7 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
       if (message.GetParam1() == GUI_MSG_WINDOW_RESIZE)
       {
         // Cancel delayed setting - it's only used for res changing anyway
-        m_delayedSetting = NULL;
+        m_delayedSetting.reset();
         if (IsActive() && g_guiSettings.GetResolution() != g_graphicsContext.GetVideoResolution())
         {
           g_guiSettings.SetResolution(g_graphicsContext.GetVideoResolution());
@@ -284,7 +284,7 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
     break;
   case GUI_MSG_WINDOW_DEINIT:
     {
-      m_delayedSetting = NULL;
+      m_delayedSetting.reset();
 
       CheckForUpdates();
       CGUIWindow::OnMessage(message);
@@ -422,7 +422,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
     else if (strSetting.Equals("services.webserverport"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
-      CBaseSettingControl *control = GetSetting(pSetting->GetSetting());
+      BaseSettingControlPtr control = GetSetting(pSetting->GetSetting());
       control->SetDelayed();
       continue;
     }
@@ -431,7 +431,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
     {
 #ifdef HAS_EVENT_SERVER
       AddSetting(pSetting, group->GetWidth(), iControlID);
-      CBaseSettingControl *control = GetSetting(pSetting->GetSetting());
+      BaseSettingControlPtr control = GetSetting(pSetting->GetSetting());
       control->SetDelayed();
       continue;
 #endif
@@ -439,7 +439,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
     else if (strSetting.Equals("network.httpproxyport"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
-      CBaseSettingControl *control = GetSetting(pSetting->GetSetting());
+      BaseSettingControlPtr control = GetSetting(pSetting->GetSetting());
       control->SetDelayed();
       continue;
     }
@@ -584,7 +584,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
 {
   for (unsigned int i = 0; i < m_vecSettings.size(); i++)
   {
-    CBaseSettingControl *pSettingControl = m_vecSettings[i];
+    BaseSettingControlPtr pSettingControl = m_vecSettings[i];
     pSettingControl->Update();
     CStdString strSetting = pSettingControl->GetSetting()->GetSetting();
 #ifdef HAVE_LIBVDPAU
@@ -1028,7 +1028,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
   g_guiSettings.NotifyObservers(ObservableMessageGuiSettings);
 }
 
-void CGUIWindowSettingsCategory::OnClick(CBaseSettingControl *pSettingControl)
+void CGUIWindowSettingsCategory::OnClick(BaseSettingControlPtr pSettingControl)
 {
   CStdString strSetting = pSettingControl->GetSetting()->GetSetting();
   if (strSetting.Equals("weather.addonsettings"))
@@ -1094,7 +1094,7 @@ void CGUIWindowSettingsCategory::CheckForUpdates()
 {
   for (unsigned int i = 0; i < m_vecSettings.size(); i++)
   {
-    CBaseSettingControl *pSettingControl = m_vecSettings[i];
+    BaseSettingControlPtr pSettingControl = m_vecSettings[i];
     if (pSettingControl->NeedsUpdate())
     {
       OnSettingChanged(pSettingControl);
@@ -1103,7 +1103,7 @@ void CGUIWindowSettingsCategory::CheckForUpdates()
   }
 }
 
-void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingControl)
+void CGUIWindowSettingsCategory::OnSettingChanged(BaseSettingControlPtr pSettingControl)
 {
   CStdString strSetting = pSettingControl->GetSetting()->GetSetting();
 
@@ -2040,10 +2040,7 @@ void CGUIWindowSettingsCategory::FreeSettingsControls()
   }
 
   for (int i = 0; (size_t)i < m_vecSettings.size(); i++)
-  {
     m_vecSettings[i]->Clear();
-    delete m_vecSettings[i];
-  }
 
   m_vecSettings.clear();
 }
@@ -2051,7 +2048,7 @@ void CGUIWindowSettingsCategory::FreeSettingsControls()
 CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int &iControlID)
 {
   if (!pSetting->IsVisible()) return NULL;  // not displayed in current session
-  CBaseSettingControl *pSettingControl = NULL;
+  BaseSettingControlPtr pSettingControl;
   CGUIControl *pControl = NULL;
   if (pSetting->GetControlType() == CHECKMARK_CONTROL)
   {
@@ -2059,7 +2056,7 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
     if (!pControl) return NULL;
     ((CGUIRadioButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
-    pSettingControl = new CRadioButtonSettingControl((CGUIRadioButtonControl *)pControl, iControlID, pSetting);
+    pSettingControl.reset(new CRadioButtonSettingControl((CGUIRadioButtonControl *)pControl, iControlID, pSetting));
   }
   else if (pSetting->GetControlType() == SPIN_CONTROL_FLOAT || pSetting->GetControlType() == SPIN_CONTROL_INT_PLUS || pSetting->GetControlType() == SPIN_CONTROL_TEXT || pSetting->GetControlType() == SPIN_CONTROL_INT)
   {
@@ -2067,14 +2064,14 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
     if (!pControl) return NULL;
     pControl->SetWidth(width);
     ((CGUISpinControlEx *)pControl)->SetText(g_localizeStrings.Get(pSetting->GetLabel()));
-    pSettingControl = new CSpinExSettingControl((CGUISpinControlEx *)pControl, iControlID, pSetting);
+    pSettingControl.reset(new CSpinExSettingControl((CGUISpinControlEx *)pControl, iControlID, pSetting));
   }
   else if (pSetting->GetControlType() == SEPARATOR_CONTROL && m_pOriginalImage)
   {
     pControl = new CGUIImage(*m_pOriginalImage);
     if (!pControl) return NULL;
     pControl->SetWidth(width);
-    pSettingControl = new CSeparatorSettingControl((CGUIImage *)pControl, iControlID, pSetting);
+    pSettingControl.reset(new CSeparatorSettingControl((CGUIImage *)pControl, iControlID, pSetting));
   }
   else if (pSetting->GetControlType() == EDIT_CONTROL_INPUT ||
            pSetting->GetControlType() == EDIT_CONTROL_HIDDEN_INPUT ||
@@ -2087,7 +2084,7 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
     if (!pControl) return NULL;
     ((CGUIEditControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
-    pSettingControl = new CEditSettingControl((CGUIEditControl *)pControl, iControlID, pSetting);
+    pSettingControl.reset(new CEditSettingControl((CGUIEditControl *)pControl, iControlID, pSetting));
   }
   else if (pSetting->GetControlType() != SEPARATOR_CONTROL) // button control
   {
@@ -2095,11 +2092,11 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
     if (!pControl) return NULL;
     ((CGUIButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
-    pSettingControl = new CButtonSettingControl((CGUIButtonControl *)pControl, iControlID, pSetting);
+    pSettingControl.reset(new CButtonSettingControl((CGUIButtonControl *)pControl, iControlID, pSetting));
   }
   if (!pControl)
   {
-    delete pSettingControl;
+    pSettingControl.reset();
     return NULL;
   }
   pControl->SetID(iControlID++);
@@ -2225,7 +2222,7 @@ void CGUIWindowSettingsCategory::FillInSubtitleFonts(CSetting *pSetting)
 
 void CGUIWindowSettingsCategory::FillInSkinFonts(CSetting *pSetting)
 {
-  CBaseSettingControl *setting = GetSetting(pSetting->GetSetting());
+  BaseSettingControlPtr setting = GetSetting(pSetting->GetSetting());
   CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(setting->GetID());
   pControl->SetType(SPIN_CONTROL_TYPE_TEXT);
   pControl->Clear();
@@ -2391,7 +2388,7 @@ DisplayMode CGUIWindowSettingsCategory::FillInScreens(CStdString strSetting, RES
 
   // we expect "videoscreen.screen" but it might be hidden on some platforms,
   // so check that we actually have a visable control.
-  CBaseSettingControl *control = GetSetting(strSetting);
+  BaseSettingControlPtr control = GetSetting(strSetting);
   if (control)
   {
     control->SetDelayed();
@@ -2416,7 +2413,7 @@ DisplayMode CGUIWindowSettingsCategory::FillInScreens(CStdString strSetting, RES
 
 void CGUIWindowSettingsCategory::FillInResolutions(CStdString strSetting, DisplayMode mode, RESOLUTION res, bool UserChange)
 {
-  CBaseSettingControl *control = GetSetting(strSetting);
+  BaseSettingControlPtr control = GetSetting(strSetting);
   control->SetDelayed();
   CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(control->GetID());
 
@@ -2491,7 +2488,7 @@ void CGUIWindowSettingsCategory::FillInRefreshRates(CStdString strSetting, RESOL
       g_settings.m_ResInfo[res].dwFlags);
 
   // The control setting doesn't exist when not in standalone mode, don't manipulate it
-  CBaseSettingControl *control = GetSetting(strSetting);
+  BaseSettingControlPtr control = GetSetting(strSetting);
   CGUISpinControlEx *pControl= NULL;
 
   // Populate
@@ -2559,7 +2556,7 @@ void CGUIWindowSettingsCategory::OnRefreshRateChanged(RESOLUTION nextRes)
 void CGUIWindowSettingsCategory::FillInLanguages(CSetting *pSetting, const std::vector<CStdString> &languages /* = std::vector<CStdString>() */, const std::vector<CStdString> &languageKeys /* = std::vector<CStdString>() */)
 {
   CSettingString *pSettingString = (CSettingString *)pSetting;
-  CBaseSettingControl *setting = GetSetting(pSetting->GetSetting());
+  BaseSettingControlPtr setting = GetSetting(pSetting->GetSetting());
   CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(setting->GetID());
   pControl->Clear();
 
@@ -2624,14 +2621,14 @@ void CGUIWindowSettingsCategory::FillInRegions(CSetting *pSetting)
   pControl->SetValue(iCurrentRegion);
 }
 
-CBaseSettingControl *CGUIWindowSettingsCategory::GetSetting(const CStdString &strSetting)
+BaseSettingControlPtr CGUIWindowSettingsCategory::GetSetting(const CStdString &strSetting)
 {
   for (unsigned int i = 0; i < m_vecSettings.size(); i++)
   {
     if (m_vecSettings[i]->GetSetting()->GetSetting() == strSetting)
       return m_vecSettings[i];
   }
-  return NULL;
+  return BaseSettingControlPtr();
 }
 
 void CGUIWindowSettingsCategory::FillInSkinThemes(CSetting *pSetting)
@@ -2639,7 +2636,7 @@ void CGUIWindowSettingsCategory::FillInSkinThemes(CSetting *pSetting)
   // There is a default theme (just Textures.xpr/xbt)
   // any other *.xpr|*.xbt files are additional themes on top of this one.
   CSettingString *pSettingString = (CSettingString *)pSetting;
-  CBaseSettingControl *setting = GetSetting(pSetting->GetSetting());
+  BaseSettingControlPtr setting = GetSetting(pSetting->GetSetting());
   CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(setting->GetID());
   CStdString strSettingString = g_guiSettings.GetString("lookandfeel.skintheme");
   setting->SetDelayed();
@@ -2676,7 +2673,7 @@ void CGUIWindowSettingsCategory::FillInSkinColors(CSetting *pSetting)
 {
   // There is a default theme (just defaults.xml)
   // any other *.xml files are additional color themes on top of this one.
-  CBaseSettingControl *setting = GetSetting(pSetting->GetSetting());
+  BaseSettingControlPtr setting = GetSetting(pSetting->GetSetting());
   CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(setting->GetID());
   CStdString strSettingString = g_guiSettings.GetString("lookandfeel.skincolors");
   setting->SetDelayed();
@@ -2998,7 +2995,7 @@ void CGUIWindowSettingsCategory::NetworkInterfaceChanged(void)
 #endif
 }
 
-void CGUIWindowSettingsCategory::ValidatePortNumber(CBaseSettingControl* pSettingControl, const CStdString& userPort, const CStdString& privPort, bool listening/*=true*/)
+void CGUIWindowSettingsCategory::ValidatePortNumber(BaseSettingControlPtr pSettingControl, const CStdString& userPort, const CStdString& privPort, bool listening/*=true*/)
 {
   CSettingString *pSetting = (CSettingString *)pSettingControl->GetSetting();
   // check that it's a valid port

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -25,6 +25,8 @@
 #include "GUISettings.h"
 #include "utils/Stopwatch.h"
 
+typedef boost::shared_ptr<CBaseSettingControl> BaseSettingControlPtr;
+
 class CGUIWindowSettingsCategory :
       public CGUIWindow
 {
@@ -74,14 +76,14 @@ protected:
   void CheckForUpdates();
   void FreeSettingsControls();
   virtual void FreeControls();
-  virtual void OnClick(CBaseSettingControl *pSettingControl);
-  virtual void OnSettingChanged(CBaseSettingControl *pSettingControl);
+  virtual void OnClick(BaseSettingControlPtr pSettingControl);
+  virtual void OnSettingChanged(BaseSettingControlPtr pSettingControl);
   CGUIControl* AddSetting(CSetting *pSetting, float width, int &iControlID);
-  CBaseSettingControl* GetSetting(const CStdString &strSetting);
+  BaseSettingControlPtr GetSetting(const CStdString &strSetting);
 
-  void ValidatePortNumber(CBaseSettingControl* pSettingControl, const CStdString& userPort, const CStdString& privPort, bool listening=true);
+  void ValidatePortNumber(BaseSettingControlPtr pSettingControl, const CStdString& userPort, const CStdString& privPort, bool listening=true);
 
-  std::vector<CBaseSettingControl *> m_vecSettings;
+  std::vector<BaseSettingControlPtr> m_vecSettings;
   int m_iSection;
   int m_iScreen;
   vecSettingsCategory m_vecSections;
@@ -103,7 +105,7 @@ protected:
 
   bool m_returningFromSkinLoad; // true if we are returning from loading the skin
 
-  CBaseSettingControl *m_delayedSetting; ///< Current delayed setting \sa CBaseSettingControl::SetDelayed()
+  boost::shared_ptr<CBaseSettingControl> m_delayedSetting; ///< Current delayed setting \sa CBaseSettingControl::SetDelayed()
   CStopWatch           m_delayedTimer;   ///< Delayed setting timer
 };
 

--- a/xbmc/settings/SettingsControls.cpp
+++ b/xbmc/settings/SettingsControls.cpp
@@ -55,7 +55,8 @@ bool CRadioButtonSettingControl::OnClick()
 
 void CRadioButtonSettingControl::Update()
 {
-  m_pRadioButton->SetSelected(((CSettingBool *)m_pSetting)->GetData());
+  if (m_pRadioButton)
+    m_pRadioButton->SetSelected(((CSettingBool *)m_pSetting)->GetData());
 }
 
 CSpinExSettingControl::CSpinExSettingControl(CGUISpinControlEx *pSpin, int id, CSetting *pSetting)
@@ -125,6 +126,8 @@ bool CSpinExSettingControl::OnClick()
 
 void CSpinExSettingControl::Update()
 {
+  if (!m_pSpin)
+    return;
   if (m_pSetting->GetControlType() == SPIN_CONTROL_FLOAT)
   {
     CSettingFloat *pSettingFloat = (CSettingFloat *)m_pSetting;
@@ -174,7 +177,8 @@ void CButtonSettingControl::Update()
   }
   else if (m_pSetting->GetControlType() == BUTTON_CONTROL_STANDARD)
     return;
-  m_pButton->SetLabel2(strText);
+  if (m_pButton)
+    m_pButton->SetLabel2(strText);
 }
 
 CEditSettingControl::CEditSettingControl(CGUIEditControl *pEdit, int id, CSetting *pSetting)
@@ -215,7 +219,7 @@ bool CEditSettingControl::OnClick()
 
 void CEditSettingControl::Update()
 {
-  if (!m_needsUpdate)
+  if (!m_needsUpdate && m_pEdit)
     m_pEdit->SetLabel2(((CSettingString *)m_pSetting)->GetData());
 }
 

--- a/xbmc/settings/SettingsControls.h
+++ b/xbmc/settings/SettingsControls.h
@@ -40,6 +40,7 @@ public:
   CSetting* GetSetting() { return m_pSetting; };
   virtual bool NeedsUpdate() { return false; };   ///< Returns true if the control needs an update
   virtual void Reset() {}; ///< Resets the NeedsUpdate() state
+  virtual void Clear()=0;  ///< Clears the attached control
 
   /*!
    \brief Specifies that this setting should update after a delay
@@ -70,6 +71,7 @@ public:
   virtual ~CRadioButtonSettingControl();
   virtual bool OnClick();
   virtual void Update();
+  virtual void Clear() { m_pRadioButton = NULL; }
   void Select(bool bSelect);
 private:
   CGUIRadioButtonControl *m_pRadioButton;
@@ -82,6 +84,7 @@ public:
   virtual ~CSpinExSettingControl();
   virtual bool OnClick();
   virtual void Update();
+  virtual void Clear() { m_pSpin = NULL; }
 private:
   CGUISpinControlEx *m_pSpin;
 };
@@ -93,6 +96,7 @@ public:
   virtual ~CButtonSettingControl();
   virtual bool OnClick();
   virtual void Update();
+  virtual void Clear() { m_pButton = NULL; }
 private:
   CGUIButtonControl *m_pButton;
 };
@@ -106,6 +110,7 @@ public:
   virtual void Update();
   virtual bool NeedsUpdate() { return m_needsUpdate; };
   virtual void Reset() { m_needsUpdate = false; };
+  virtual void Clear() { m_pEdit = NULL; }
 private:
   bool IsValidIPAddress(const CStdString &strIP);
   CGUIEditControl *m_pEdit;
@@ -119,6 +124,7 @@ public:
   virtual ~CSeparatorSettingControl();
   virtual bool OnClick() { return false; };
   virtual void Update() {};
+  virtual void Clear() { m_pImage = NULL; }
 private:
   CGUIImage *m_pImage;
 };


### PR DESCRIPTION
So that they stay alive after window close if they're still being used. fixes #13766.

Pressing Ctrl-M while awaiting a setting change in a dialog (e.g. while choosing skin) allows you to switch to Music underneath the dialog, thus freeing the settings vector.  When the dialog window is then closed, it attempts to use the free'd setting.

This fixes it in the obvious way by making them smart pointers.
