### PR TITLE
use CFileItem::IsSamePath() to match the item in OnPlayAndQueueMedia

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1128,6 +1128,7 @@ bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item, const CStdString
     if(item_new->m_bIsFolder == false)
     {
       item.reset(new CFileItem(*item));
+      item->SetProperty("original_listitem_url", item->GetPath());
       item->SetPath(item_new->GetPath());
       return true;
     }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1415,7 +1415,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item)
       if (!nItem->IsPlayList() && !nItem->IsZIP() && !nItem->IsRAR())
         g_playlistPlayer.Add(iPlaylist, nItem);
 
-      if (nItem == item)
+      if (item->IsSamePath(nItem.get()))
       { // item that was clicked
         mediaToPlay = g_playlistPlayer.GetPlaylist(iPlaylist).size() - 1;
       }


### PR DESCRIPTION
Fixes the problem introduced by 682f1214c3f291a43b78562d9f01e9920d712d65

fixes #13762
