### PR TITLE
re-open the video artwork selection dialog after having chosen a specific artwork

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -641,109 +641,111 @@ void CGUIDialogVideoInfo::OnGetArt()
   if (type.empty())
     return; // cancelled
 
+  // TODO: this can be removed once these are unified.
   if (type == "fanart")
-  { // TODO: this can be removed once these are unified.
     OnGetFanart();
-    return;
-  }
-
-  CFileItemList items;
-
-  // Current thumb
-  if (m_movieItem->HasArt(type))
-  {
-    CFileItemPtr item(new CFileItem("thumb://Current", false));
-    item->SetArt("thumb", m_movieItem->GetArt(type));
-    item->SetLabel(g_localizeStrings.Get(13512));
-    items.Add(item);
-  }
-  else if ((type == "poster" || type == "banner") && currentArt.find("thumb") != currentArt.end())
-  { // add the 'thumb' type in
-    CFileItemPtr item(new CFileItem("thumb://Thumb", false));
-    item->SetArt("thumb", currentArt["thumb"]);
-    item->SetLabel(g_localizeStrings.Get(13512));
-    items.Add(item);
-  }
-
-  // Grab the thumbnails from the web
-  vector<CStdString> thumbs;
-  int season = (m_movieItem->GetVideoInfoTag()->m_type == "season") ? m_movieItem->GetVideoInfoTag()->m_iSeason : -1;
-  m_movieItem->GetVideoInfoTag()->m_strPictureURL.GetThumbURLs(thumbs, type, season);
-
-  for (unsigned int i = 0; i < thumbs.size(); ++i)
-  {
-    CStdString strItemPath;
-    strItemPath.Format("thumb://Remote%i", i);
-    CFileItemPtr item(new CFileItem(strItemPath, false));
-    item->SetArt("thumb", thumbs[i]);
-    item->SetIconImage("DefaultPicture.png");
-    item->SetLabel(g_localizeStrings.Get(13513));
-
-    // TODO: Do we need to clear the cached image?
-    //    CTextureCache::Get().ClearCachedImage(thumb);
-    items.Add(item);
-  }
-
-  CStdString localThumb = CVideoThumbLoader::GetLocalArt(*m_movieItem, type);
-  if (!localThumb.empty())
-  {
-    CFileItemPtr item(new CFileItem("thumb://Local", false));
-    item->SetArt("thumb", localThumb);
-    item->SetLabel(g_localizeStrings.Get(13514));
-    items.Add(item);
-  }
   else
-  { // no local thumb exists, so we are just using the IMDb thumb or cached thumb
-    // which is probably the IMDb thumb.  These could be wrong, so allow the user
-    // to delete the incorrect thumb
-    CFileItemPtr item(new CFileItem("thumb://None", false));
-    item->SetIconImage("DefaultVideo.png");
-    item->SetLabel(g_localizeStrings.Get(13515));
-    items.Add(item);
-  }
-
-  CStdString result;
-  VECSOURCES sources(g_settings.m_videoSources);
-  AddItemPathToFileBrowserSources(sources, *m_movieItem);
-  g_mediaManager.GetLocalDrives(sources);
-  if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result))
-    return;   // user cancelled
-
-  if (result == "thumb://Current")
-    return;   // user chose the one they have
-
-  CStdString newThumb;
-  if (result.Left(14) == "thumb://Remote")
   {
-    int number = atoi(result.Mid(14));
-    newThumb = thumbs[number];
-  }
-  else if (result == "thumb://Thumb")
-    newThumb = currentArt["thumb"];
-  else if (result == "thumb://Local")
-    newThumb = localThumb;
-  else if (CFile::Exists(result))
-    newThumb = result;
-  else // none
-    newThumb.clear();
+    CFileItemList items;
 
-  // update thumb in the database
-  CVideoDatabase db;
-  if (db.Open())
-  {
-    db.SetArtForItem(m_movieItem->GetVideoInfoTag()->m_iDbId, m_movieItem->GetVideoInfoTag()->m_type, type, newThumb);
-    db.Close();
+    // Current thumb
+    if (m_movieItem->HasArt(type))
+    {
+      CFileItemPtr item(new CFileItem("thumb://Current", false));
+      item->SetArt("thumb", m_movieItem->GetArt(type));
+      item->SetLabel(g_localizeStrings.Get(13512));
+      items.Add(item);
+    }
+    else if ((type == "poster" || type == "banner") && currentArt.find("thumb") != currentArt.end())
+    { // add the 'thumb' type in
+      CFileItemPtr item(new CFileItem("thumb://Thumb", false));
+      item->SetArt("thumb", currentArt["thumb"]);
+      item->SetLabel(g_localizeStrings.Get(13512));
+      items.Add(item);
+    }
+
+    // Grab the thumbnails from the web
+    vector<CStdString> thumbs;
+    int season = (m_movieItem->GetVideoInfoTag()->m_type == "season") ? m_movieItem->GetVideoInfoTag()->m_iSeason : -1;
+    m_movieItem->GetVideoInfoTag()->m_strPictureURL.GetThumbURLs(thumbs, type, season);
+
+    for (unsigned int i = 0; i < thumbs.size(); ++i)
+    {
+      CStdString strItemPath;
+      strItemPath.Format("thumb://Remote%i", i);
+      CFileItemPtr item(new CFileItem(strItemPath, false));
+      item->SetArt("thumb", thumbs[i]);
+      item->SetIconImage("DefaultPicture.png");
+      item->SetLabel(g_localizeStrings.Get(13513));
+
+      // TODO: Do we need to clear the cached image?
+      //    CTextureCache::Get().ClearCachedImage(thumb);
+      items.Add(item);
+    }
+
+    CStdString localThumb = CVideoThumbLoader::GetLocalArt(*m_movieItem, type);
+    if (!localThumb.empty())
+    {
+      CFileItemPtr item(new CFileItem("thumb://Local", false));
+      item->SetArt("thumb", localThumb);
+      item->SetLabel(g_localizeStrings.Get(13514));
+      items.Add(item);
+    }
+    else
+    { // no local thumb exists, so we are just using the IMDb thumb or cached thumb
+      // which is probably the IMDb thumb.  These could be wrong, so allow the user
+      // to delete the incorrect thumb
+      CFileItemPtr item(new CFileItem("thumb://None", false));
+      item->SetIconImage("DefaultVideo.png");
+      item->SetLabel(g_localizeStrings.Get(13515));
+      items.Add(item);
+    }
+
+    CStdString result;
+    VECSOURCES sources(g_settings.m_videoSources);
+    AddItemPathToFileBrowserSources(sources, *m_movieItem);
+    g_mediaManager.GetLocalDrives(sources);
+    if (CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result) &&
+        result != "thumb://Current") // user didn't choose the one they have
+    {
+      CStdString newThumb;
+      if (result.Left(14) == "thumb://Remote")
+      {
+        int number = atoi(result.Mid(14));
+        newThumb = thumbs[number];
+      }
+      else if (result == "thumb://Thumb")
+        newThumb = currentArt["thumb"];
+      else if (result == "thumb://Local")
+        newThumb = localThumb;
+      else if (CFile::Exists(result))
+        newThumb = result;
+      else // none
+        newThumb.clear();
+
+      // update thumb in the database
+      CVideoDatabase db;
+      if (db.Open())
+      {
+        db.SetArtForItem(m_movieItem->GetVideoInfoTag()->m_iDbId, m_movieItem->GetVideoInfoTag()->m_type, type, newThumb);
+        db.Close();
+      }
+      CUtil::DeleteVideoDatabaseDirectoryCache(); // to get them new thumbs to show
+      m_movieItem->SetArt(type, newThumb);
+      if (m_movieItem->HasProperty("set_folder_thumb"))
+      { // have a folder thumb to set as well
+        VIDEO::CVideoInfoScanner::ApplyThumbToFolder(m_movieItem->GetProperty("set_folder_thumb").asString(), newThumb);
+      }
+      m_hasUpdatedThumb = true;
+    }
   }
-  CUtil::DeleteVideoDatabaseDirectoryCache(); // to get them new thumbs to show
-  m_movieItem->SetArt(type, newThumb);
-  if (m_movieItem->HasProperty("set_folder_thumb"))
-  { // have a folder thumb to set as well
-    VIDEO::CVideoInfoScanner::ApplyThumbToFolder(m_movieItem->GetProperty("set_folder_thumb").asString(), newThumb);
-  }
-  m_hasUpdatedThumb = true;
 
   // Update our screen
   Update();
+
+  // re-open the art selection dialog as we come back from
+  // the image selection dialog
+  OnGetArt();
 }
 
 // Allow user to select a Fanart


### PR DESCRIPTION
This is an improvement for the artwork selection process. Currently a user opens the video info dialog for a video, then selects "Choose art" which opens a dialog with a list of all the different artwork types and their current image. Then the user chooses which artwork type to change which closes the "Choose art" dialog and opens the file browser which lets the user choose a specific image. After either choosing an image or closing the dialog we go back to the video info dialog and not to the "Choose art" dialog even though that's the previously active dialog. This has annoyed me several times, either when I accidentally chose the wrong artwork type and had to go back or when I wanted to change multiple artwork types. In either case I had to press "Choose art" again in the video info dialog to get back into the artwork selection dialog.

The diff looks bigger than it is (I had to refactor a bit because there were some early returns). Basically what I have changed is to call OnGetArt() again after the user has chosen a specific image. The user can still close that dialog by executing the Back action.

Obviously this is nice to have and therefore for Frodo+1.
