### PR TITLE
[confluence] removed all occurrences of the uppercase style

### DIFF
--- a/addons/skin.confluence/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence/720p/DialogSeekBar.xml
@@ -230,7 +230,7 @@
 				<aligny>center</aligny>
 				<font>font10_title</font>
 				<textcolor>blue</textcolor>
-				<label>[UPPERCASE]$LOCALIZE[773][/UPPERCASE]</label>
+				<label>$LOCALIZE[31046]</label>
 				<visible>Player.Seeking</visible>
 			</control>
 			<control type="label">
@@ -243,7 +243,7 @@
 				<aligny>center</aligny>
 				<font>font10_title</font>
 				<textcolor>blue</textcolor>
-				<label>[UPPERCASE]$LOCALIZE[773][/UPPERCASE][COLOR=grey] $INFO[Player.SeekOffset][/COLOR]</label>
+				<label>$LOCALIZE[31046][COLOR=grey] $INFO[Player.SeekOffset][/COLOR]</label>
 				<visible>Player.DisplayAfterSeek + ![player.forwarding | player.rewinding]</visible>
 			</control>
 			<control type="label">

--- a/addons/skin.confluence/720p/Font.xml
+++ b/addons/skin.confluence/720p/Font.xml
@@ -83,7 +83,6 @@
 	 	<font>
 			<name>font_MainMenu</name>
 			<filename>Roboto-Bold.ttf</filename>
-			<style>uppercase</style>
 			<size>40</size>
 		</font>
 	 	<font>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -886,28 +886,28 @@
 				</focusedlayout>
 				<content>
 					<item id="7">
-						<label>8</label>
+						<label>31950</label>
 						<onclick>ActivateWindow(Weather)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoWeatherButton) + !IsEmpty(Weather.Plugin)</visible>
 					</item>
 					<item id="4">
-						<label>1</label>
+						<label>31951</label>
 						<onclick>ActivateWindow(Pictures)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoPicturesButton)</visible>
 					</item>
 					<item id="12">
-						<label>31502</label>
+						<label>31952</label>
 						<onclick>ActivateWindow(PVR)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>System.GetBool(pvrmanager.enabled)</visible>
 					</item>
 					<item id="2">
-						<label>3</label>
+						<label>31953</label>
 						<onclick condition="StringCompare(Window.Property(VideosDirectLink),True)">ActivateWindow(Videos)</onclick>
 						<onclick condition="!StringCompare(Window.Property(VideosDirectLink),True)">ActivateWindow(Videos,root)</onclick>
 						<icon>-</icon>
@@ -915,28 +915,28 @@
 						<visible>!Skin.HasSetting(HomeMenuNoVideosButton)</visible>
 					</item>
 					<item id="10">
-						<label>20342</label>
+						<label>31954</label>
 						<onclick>ActivateWindow(Videos,MovieTitles,return)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoMoviesButton) + Library.HasContent(Movies)</visible>
 					</item>
 					<item id="11">
-						<label>20343</label>
+						<label>31955</label>
 						<onclick>ActivateWindow(Videos,TVShowTitles,return)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoTVShowsButton) + Library.HasContent(TVShows)</visible>
 					</item>
 					<item id="3">
-						<label>2</label>
+						<label>31956</label>
 						<onclick>ActivateWindow(Music)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoMusicButton)</visible>
 					</item>
 					<item id="1">
-						<label>0</label>
+						<label>31957</label>
 						<onclick condition="!System.Platform.Android">ActivateWindow(Programs,Addons,return)</onclick>
 						<onclick condition="System.Platform.Android">ActivateWindow(Programs)</onclick>
 						<icon>-</icon>
@@ -944,14 +944,14 @@
 						<visible>!Skin.HasSetting(HomeMenuNoProgramsButton)</visible>
 					</item>
 					<item id="6">
-						<label>341</label>
+						<label>31958</label>
 						<onclick>XBMC.PlayDVD()</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>System.HasMediaDVD</visible>
 					</item>
 					<item id="5">
-						<label>13000</label>
+						<label>31959</label>
 						<onclick>ActivateWindow(Settings)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>

--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -126,6 +126,10 @@ msgctxt "#31045"
 msgid "REWIND"
 msgstr ""
 
+msgctxt "#31046"
+msgid "SEEKING"
+msgstr ""
+
 #empty strings from id 31046 to 31047
 
 msgctxt "#31048"
@@ -620,4 +624,46 @@ msgstr ""
 
 msgctxt "#31910"
 msgid "Map & Alerts"
+msgstr ""
+
+#empty strings from id 31910 to 31949
+
+msgctxt "#31950"
+msgid "WEATHER"
+msgstr ""
+
+msgctxt "#31951"
+msgid "PICTURES"
+msgstr ""
+
+msgctxt "#31952"
+msgid "LIVE TV"
+msgstr ""
+
+msgctxt "#31953"
+msgid "VIDEOS"
+msgstr ""
+
+msgctxt "#31954"
+msgid "MOVIES"
+msgstr ""
+
+msgctxt "#31955"
+msgid "TV SHOWS"
+msgstr ""
+
+msgctxt "#31956"
+msgid "MUSIC"
+msgstr ""
+
+msgctxt "#31957"
+msgid "PROGRAMS"
+msgstr ""
+
+msgctxt "#31958"
+msgid "PLAY DISC"
+msgstr ""
+
+msgctxt "#31959"
+msgid "SYSTEM"
 msgstr ""


### PR DESCRIPTION
This is workaround for bug #13701, not being able to uppercase non-ascii characters, for confluence by simply not using the feature.
