### PR TITLE
Prefer the duration from the stream unless it's smaller than <runtime>

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -790,8 +790,13 @@ bool CVideoInfoTag::IsEmpty() const
 
 unsigned int CVideoInfoTag::GetDuration() const
 {
-  if (m_streamDetails.GetVideoDuration() > 0)
-    return m_streamDetails.GetVideoDuration();
+  /*
+   Prefer the duration from the stream if it isn't too
+   small (60%) compared to the duration from the tag.
+   */
+  unsigned int duration = m_streamDetails.GetVideoDuration();
+  if (duration > m_duration * 0.6)
+    return duration;
 
   return m_duration;
 }


### PR DESCRIPTION
The current problem of preferring the stream duration if it's non-zero doesn't work for stacks, where the stream duration is the duration of the first part.

This fixes it to use the stream duration if it's less than 60% of the runtime, which should mean all stacks with accurate runtime will use that in preference.

@Montellese to review.
