### PR TITLE
use the script id, not the plugin name to lookup the script

### DIFF
--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -66,7 +66,7 @@ public:
 private:
   ADDON::AddonPtr m_addon;
   bool StartScript(const CStdString& strPath, bool retrievingDir);
-  bool WaitOnScriptResult(const CStdString &scriptPath, const CStdString &scriptName, bool retrievingDir);
+  bool WaitOnScriptResult(const CStdString &scriptPath, int scriptId, const CStdString &scriptName, bool retrievingDir);
 
   static std::vector<CPluginDirectory*> globalHandles;
   static int getNewHandle(CPluginDirectory *cp);


### PR DESCRIPTION
In CPluginDirectory::WaitOnScriptResult we need to check whether the plugin is still running - to do this we use the plugin name, but if 2 instances are running we get the first one which may not be the one we want.  Use the script id instead seeing as we have it.  Fixes #13776.

@jimfcarroll to review.

While I don't see any reason why this would do anything odd, it would be nice for this to be in RC2 so we make sure of it.
