### PR TITLE
GroupUtils: fix URL options when grouping movies into sets

### DIFF
--- a/xbmc/utils/GroupUtils.h
+++ b/xbmc/utils/GroupUtils.h
@@ -37,6 +37,6 @@ typedef enum {
 class GroupUtils
 {
 public:
-  static bool Group(GroupBy groupBy, const CFileItemList &items, CFileItemList &groupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
-  static bool GroupAndSort(GroupBy groupBy, const CFileItemList &items, const SortDescription &sortDescription, CFileItemList &groupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
+  static bool Group(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
+  static bool GroupAndSort(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, const SortDescription &sortDescription, CFileItemList &groupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
 };

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4953,7 +4953,7 @@ bool CVideoDatabase::GetSetsByWhere(const CStdString& strBaseDir, const Filter &
       return false;
 
     CFileItemList sets;
-    if (!GroupUtils::Group(GroupBySet, items, sets))
+    if (!GroupUtils::Group(GroupBySet, strBaseDir, items, sets))
       return false;
 
     items.ClearItems();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1884,7 +1884,7 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
       g_guiSettings.GetBool("videolibrary.groupmoviesets"))
   {
     CFileItemList groupedItems;
-    if (GroupUtils::Group(GroupBySet, items, groupedItems, GroupAttributeIgnoreSingleItems))
+    if (GroupUtils::Group(GroupBySet, m_strFilterPath, items, groupedItems, GroupAttributeIgnoreSingleItems))
     {
       items.ClearItems();
       items.Append(groupedItems);


### PR DESCRIPTION
This fixes a bug in movie smartplaylists with rules limiting the matching movies. If a rule matches some but not all of the movies in a set created with GroupUtils::Group() and the user opens the set all the movies belonging to that set will be listed and not just the ones matching the smartplaylist rules. That is because we don't append any videodb:// URL options to the URL used for the set. By passing in the original lists URL to GroupUtils::Group() we can extract any URL options (like the smartplaylist definition in "xsp") and also add it to the URL of the dynamically created movie sets.

This bug has been introduced with the move from doing the set grouping in the db to doing the set grouping dynamically outside of the database. Would be great if it can go in for Frodo, but it's not a blocker.
