### PR TITLE
Fix crash when stopping music - FRODO FOOD!

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4795,11 +4795,18 @@ bool CApplication::OnMessage(CGUIMessage& message)
 #endif
       // reset the seek handler
       m_seekHandler->Reset();
+      CPlayList playList = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist());
 
       // Update our infoManager with the new details etc.
       if (m_nextPlaylistItem >= 0)
-      { // we've started a previously queued item
-        CFileItemPtr item = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist())[m_nextPlaylistItem];
+      { 
+        // playing an item which is not in the list - player might be stopped already
+        // so do nothing
+        if (playList.size() <= m_nextPlaylistItem)
+          return true;
+
+        // we've started a previously queued item
+        CFileItemPtr item = playList[m_nextPlaylistItem];
         // update the playlist manager
         int currentSong = g_playlistPlayer.GetCurrentSong();
         int param = ((currentSong & 0xffff) << 16) | (m_nextPlaylistItem & 0xffff);


### PR DESCRIPTION
When paplayer gets stopped in the last 5 secs where the next stream is already slaved the stop is blocked until the next track starts (no clue draining the stream i guess). In that case the onplaybackstarted callback for the next track is fired even if we are about to stop. In the message handler the current playlist is fetched and accessed directly with [] operator without checking if the playlist is still valid. This leads to bad access crashing because the playlist is empty already when the started message gets processed. This fix just fetches the playlist and checks the size before accessing the playlist item - fixes #13792

This is for frodo. I'm doing it as a PR because i was unsure if the early return true is right in that case. Talked about it with Montellese already and Martijn verified that this fixes the crash for windows too (and i did tests on osx).

@davilla @jmarshallnz for review
