### PR TITLE
pvr: do not call sortandrenumber after adding every single channel to dummy...

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -106,7 +106,6 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group)
   m_bChanged                    = group.m_bChanged;
   m_bUsingBackendChannelOrder   = group.m_bUsingBackendChannelOrder;
   m_bUsingBackendChannelNumbers = group.m_bUsingBackendChannelNumbers;
-  m_bIsDummy                    = group.m_bIsDummy;
 
   for (int iPtr = 0; iPtr < group.Size(); iPtr++)
     m_members.push_back(group.m_members.at(iPtr));

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -49,7 +49,8 @@ CPVRChannelGroup::CPVRChannelGroup(void) :
     m_iGroupId(-1),
     m_bLoaded(false),
     m_bChanged(false),
-    m_bUsingBackendChannelOrder(false)
+    m_bUsingBackendChannelOrder(false),
+    m_bIsDummy(false)
 {
 }
 
@@ -60,7 +61,8 @@ CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const CSt
     m_strGroupName(strGroupName),
     m_bLoaded(false),
     m_bChanged(false),
-    m_bUsingBackendChannelOrder(false)
+    m_bUsingBackendChannelOrder(false),
+    m_bIsDummy(false)
 {
 }
 
@@ -71,7 +73,8 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
     m_strGroupName(group.strGroupName),
     m_bLoaded(false),
     m_bChanged(false),
-    m_bUsingBackendChannelOrder(false)
+    m_bUsingBackendChannelOrder(false),
+    m_bIsDummy(false)
 {
 }
 
@@ -103,6 +106,7 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group)
   m_bChanged                    = group.m_bChanged;
   m_bUsingBackendChannelOrder   = group.m_bUsingBackendChannelOrder;
   m_bUsingBackendChannelNumbers = group.m_bUsingBackendChannelNumbers;
+  m_bIsDummy                    = group.m_bIsDummy;
 
   for (int iPtr = 0; iPtr < group.Size(); iPtr++)
     m_members.push_back(group.m_members.at(iPtr));
@@ -1116,6 +1120,11 @@ CStdString CPVRChannelGroup::GroupName(void) const
   CSingleLock lock(m_critSection);
   CStdString strReturn(m_strGroupName);
   return strReturn;
+}
+
+void CPVRChannelGroup::SetIsDummy(bool bIsDummy /* = true */)
+{
+  m_bIsDummy = bIsDummy;
 }
 
 bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool bVirtual, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const CStdString &strChannelName, const CStdString &strIconPath, const CStdString &strStreamURL)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -181,6 +181,12 @@ namespace PVR
     bool IsRadio(void) const { return m_bRadio; }
 
     /*!
+     * @brief True if this group is a dummy group.
+     * @return True if this group is a dummy group.
+     */
+    bool IsDummy(void) const { return m_bIsDummy; }
+
+    /*!
      * @brief The database ID of this group.
      * @return The database ID of this group.
      */
@@ -202,6 +208,12 @@ namespace PVR
      * @brief Return the type of this group.
      */
     int GroupType(void) const;
+
+    /*!
+     * @brief Set whether this group is a dummy group or not.
+     * @param bIsDummy The new dummy value for this group.
+     */
+    void SetIsDummy(bool bIsDummy = true);
 
     /*!
      * @brief The name of this group.
@@ -473,6 +485,7 @@ namespace PVR
     bool             m_bUsingBackendChannelOrder;   /*!< true to use the channel order from backends, false otherwise */
     bool             m_bUsingBackendChannelNumbers; /*!< true to use the channel numbers from 1 backend, false otherwise */
     bool             m_bSelectedGroup;              /*!< true when this is the selected group, false otherwise */
+    bool             m_bIsDummy;                    /*!< true when the group is a dummy group, used for temporary channel storage */
     std::vector<PVRChannelGroupMember> m_members;
     CCriticalSection m_critSection;
   };

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -103,10 +103,8 @@ void CPVRChannelGroupInternal::UpdateFromClient(const CPVRChannel &channel, unsi
     m_members.push_back(newMember);
     m_bChanged = true;
 
-    if (!IsDummy()) {
-	CLog::Log(LOGINFO, "PVRChannelGroupInternal - %s - Group is not dummy, calling sort and renumber.",__FUNCTION__);
+    if (!IsDummy())
       SortAndRenumber();
-    }
   }
 }
 
@@ -308,6 +306,8 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup &chan
     if (!member.channel)
       continue;
 
+    SetIsDummy();
+
     /* check whether this channel is present in this container */
     CPVRChannelPtr existingChannel = GetByClient(member.channel->UniqueID(), member.channel->ClientID());
     if (existingChannel)
@@ -327,6 +327,10 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup &chan
       CLog::Log(LOGINFO,"PVRChannelGroupInternal - %s - added %s channel '%s'", __FUNCTION__, m_bRadio ? "radio" : "TV", member.channel->ChannelName().c_str());
     }
   }
+
+  SetIsDummy(false);
+  if (m_bChanged)
+    SortAndRenumber();
 
   return bReturn;
 }

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -103,7 +103,10 @@ void CPVRChannelGroupInternal::UpdateFromClient(const CPVRChannel &channel, unsi
     m_members.push_back(newMember);
     m_bChanged = true;
 
-    SortAndRenumber();
+    if (!IsDummy()) {
+	CLog::Log(LOGINFO, "PVRChannelGroupInternal - %s - Group is not dummy, calling sort and renumber.",__FUNCTION__);
+      SortAndRenumber();
+    }
   }
 }
 
@@ -116,7 +119,13 @@ bool CPVRChannelGroupInternal::InsertInGroup(CPVRChannel &channel, int iChannelN
 bool CPVRChannelGroupInternal::Update(void)
 {
   CPVRChannelGroupInternal PVRChannels_tmp(m_bRadio);
-  return PVRChannels_tmp.LoadFromClients() && UpdateGroupEntries(PVRChannels_tmp);
+  PVRChannels_tmp.SetIsDummy();
+  if (PVRChannels_tmp.LoadFromClients())
+  {
+    PVRChannels_tmp.SortAndRenumber();
+    return UpdateGroupEntries(PVRChannels_tmp);
+  }
+  return false;
 }
 
 bool CPVRChannelGroupInternal::AddToGroup(CPVRChannel &channel, int iChannelNumber /* = 0 */, bool bSortAndRenumber /* = true */)


### PR DESCRIPTION
... (temporary) internal channel groups from clients; speeds up channel groups import from clients.

I actually kept the call to sortandrenumber, but it's called only once after all channels have been added to the dummy group. I suppose it can be excluded completely, but was not sure so I kept it like that.

A new channel group boolean property "is Dummy" is used to implement this, which can be used for other speed optimizations, too.
