### PR TITLE
ffmpeg: backport latm: fix initialization on some streams when no extrad...

### DIFF
--- a/lib/ffmpeg/libavcodec/aacdec.c
+++ b/lib/ffmpeg/libavcodec/aacdec.c
@@ -2403,7 +2403,8 @@ static int latm_decode_audio_specific_config(struct LATMContext *latmctx,
     if (bits_consumed < 0)
         return AVERROR_INVALIDDATA;
 
-    if (ac->m4ac.sample_rate != m4ac.sample_rate ||
+    if (!latmctx->initialized ||
+        ac->m4ac.sample_rate != m4ac.sample_rate ||
         ac->m4ac.chan_config != m4ac.chan_config) {
 
         av_log(avctx, AV_LOG_INFO, "audio config changed\n");


### PR DESCRIPTION
Folow-up from #1983

ffmpag backport:
http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=d039b6074ca68da9b6dc88d8bb40056fee9fecb6

Note: commit did not directly apply because of renaming in:
http://git.videolan.org/?p=ffmpeg.git;a=commit;h=00c3b67b8ac6bfdc5a01535173dc537824a53d6e
