### PR TITLE
fix wrong recreated history causing wrong sort order (viewstate not foun...

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1355,6 +1355,13 @@ void CGUIMediaWindow::SetHistoryForPath(const CStdString& strDirectory)
         }
       }
 
+      if (URIUtils::IsVideoDb(strPath))
+      {
+        CURL url(strParentPath);
+        url.SetOptions(""); // clear any URL options from recreated parent path
+        strParentPath = url.Get();
+      }
+
       URIUtils::AddSlashAtEnd(strPath);
       m_history.AddPathFront(strPath);
       m_history.SetSelectedItem(strPath, strParentPath);


### PR DESCRIPTION
...d in db)

This issue fixes trac http://trac.xbmc.org/ticket/13777 
CGUIMediaWindow::SetHistoryForPath "recreates" a history for use by the back key in case we jump right into a given path. For example if we jump to  videodb://2/2/7/-2/?tvshowid=7 (an actual example from my tests) then SetHistoryForPath is constructing a history like this:  videodb://2/2/7/?tvshowid=7;  videodb://2/2/?tvshowid=7;  videodb://2/?tvshowid=7;  videodb://?tvshowid=7. The option part (after the ?) is maintained since URIUtils::GetParentPath does only modify the middle part (file). The consequence of this is that when using back, we're looking for the wrong saved viewstate, hence the sort order changes from what was originally set.

The obvious solution is to clear the option part when getting the parent path (only in the condition of being called by SetHistoryForPath). This does not seem to be dangerous, for the reason that it only affects the "recreated history" when accessing a library path directly. 
