### PR TITLE
Filemanager fixes

### DIFF
--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1180,21 +1180,18 @@ void CGUIWindowFileManager::OnJobComplete(unsigned int jobID, bool success, CJob
 
 void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)
 {
-  if (pItem->m_bIsShareOrDrive)
-  {
-    int idMessageText=0;
-    CURL url(pItem->GetPath());
-    const CStdString& strHostName=url.GetHostName();
+  int idMessageText = 0;
+  CURL url(pItem->GetPath());
+  const CStdString& strHostName = url.GetHostName();
 
-    if (pItem->m_iDriveType!=CMediaSource::SOURCE_TYPE_REMOTE) //  Local shares incl. dvd drive
-      idMessageText=15300;
-    else if (url.GetProtocol()=="smb" && strHostName.IsEmpty()) //  smb workgroup
-      idMessageText=15303;
-    else  //  All other remote shares
-      idMessageText=15301;
+  if (url.GetProtocol() == "smb" && strHostName.IsEmpty()) //  smb workgroup
+    idMessageText = 15303; // Workgroup not found
+  else if (pItem->m_iDriveType == CMediaSource::SOURCE_TYPE_REMOTE || URIUtils::IsRemote(pItem->GetPath()))
+    idMessageText = 15301; // Could not connect to network server
+  else
+    idMessageText = 15300; // Path not found or invalid
 
-    CGUIDialogOK::ShowAndGetInput(220, idMessageText, 0, 0);
-  }
+  CGUIDialogOK::ShowAndGetInput(220, idMessageText, 0, 0);
 }
 
 void CGUIWindowFileManager::OnInitWindow()
@@ -1209,11 +1206,6 @@ void CGUIWindowFileManager::OnInitWindow()
   {
     bCheckShareConnectivity = true; //reset
     CFileItem pItem(strCheckSharePath, true);
-    pItem.m_bIsShareOrDrive = true;
-    if (URIUtils::IsHD(strCheckSharePath))
-      pItem.m_iDriveType=CMediaSource::SOURCE_TYPE_LOCAL;
-    else //we asume that this is a remote share else we can set SOURCE_TYPE_UNKNOWN
-      pItem.m_iDriveType=CMediaSource::SOURCE_TYPE_REMOTE;
     ShowShareErrorMessage(&pItem); //show the error message after window is loaded!
     Update(0,""); // reset view to root
   }

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -471,7 +471,11 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   CFileItemList items;
   if (!GetDirectory(iList, m_Directory[iList]->GetPath(), items))
   {
-    m_Directory[iList]->SetPath(strOldDirectory);
+    if (strDirectory != strOldDirectory && GetDirectory(iList, strOldDirectory, items))
+      m_Directory[iList]->SetPath(strOldDirectory); // Fallback to old (previous) path)
+    else
+      Update(iList, ""); // Fallback to root
+
     return false;
   }
 
@@ -1196,10 +1200,9 @@ void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)
 
 void CGUIWindowFileManager::OnInitWindow()
 {
-  for (int i = 0; i < 2; i++)
-  {
-    Update(i, m_Directory[i]->GetPath());
-  }
+  bool bResult0 = Update(0, m_Directory[0]->GetPath());
+  bool bResult1 = Update(1, m_Directory[1]->GetPath());
+
   CGUIWindow::OnInitWindow();
 
   if (!bCheckShareConnectivity)
@@ -1208,6 +1211,15 @@ void CGUIWindowFileManager::OnInitWindow()
     CFileItem pItem(strCheckSharePath, true);
     ShowShareErrorMessage(&pItem); //show the error message after window is loaded!
     Update(0,""); // reset view to root
+  }
+  else if (!bResult0)
+  {
+    ShowShareErrorMessage(m_Directory[0]); //show the error message after window is loaded!
+  }
+
+  if (!bResult1)
+  {
+    ShowShareErrorMessage(m_Directory[1]); //show the error message after window is loaded!
   }
 }
 


### PR DESCRIPTION
To begin with: our Filemanager class is quite messy, so I did the best I could to fix this problem. Post-Frodo it could probably use a proper cleanup. Anyway this PR is to mainly fix the issue described in ticket #13767, where the filemanager becomes unusable when one of the current paths disappears (eg. USB removal).
