### PR TITLE
FIX: If an autogen image is cached but not in db, push it to db

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -267,6 +267,10 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
         pItem->SetProperty("HasAutoThumb", true);
         pItem->SetProperty("AutoThumbImage", thumbURL);
         pItem->SetArt("thumb", thumbURL);
+        // Item has cached autogen image but no art entry. Save it to db.
+        CVideoInfoTag* info = pItem->GetVideoInfoTag();
+        if (info->m_iDbId > 0 && !info->m_type.empty())
+          m_database->SetArtForItem(info->m_iDbId, info->m_type, "thumb", thumbURL);
       }
       else if (g_guiSettings.GetBool("myvideos.extractthumb") &&
         g_guiSettings.GetBool("myvideos.extractflags"))


### PR DESCRIPTION
Otherwise, the autogen image doesn't show in upnp
