### PR TITLE
fixed: race condition when starting a new fresh profile besides master w...

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -360,6 +360,9 @@ void CAddonInstaller::UpdateRepos(bool force, bool wait)
     }
     return;
   }
+  // don't run repo update jobs while on the login screen which runs under the master profile
+  if((g_windowManager.GetActiveWindow() & WINDOW_ID_MASK) == WINDOW_LOGIN_SCREEN)
+    return;
   if (!force && m_repoUpdateWatch.IsRunning() && m_repoUpdateWatch.GetElapsedSeconds() < 600)
     return;
   m_repoUpdateWatch.StartZero();


### PR DESCRIPTION
...hich leads to an abort in cpluff. CAddonInstaller::UpdateRepos is called at startup and still runs if you login and CGUIWindowLoginScreen::LoadProfile calls ADDON::CAddonMgr::Get().ReInit() which leads to an invalid cpluff handle for the update job and aborts XBMC (#13826).

I created a pr as I dunno if this is the right way to fix it and if it could have other side effects. For me it runs fine and the update job is triggered again if the second profile is loaded.
