### PR TITLE
Don't utilize rect.flags for an external ffmpeg that doesn't support it

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -259,7 +259,10 @@ CDVDOverlay* CDVDOverlayCodecFFmpeg::GetOverlay()
     overlay->y        = rect.y;
     overlay->width    = rect.w;
     overlay->height   = rect.h;
-    overlay->bForced  = rect.flags;
+
+#if (!defined USE_EXTERNAL_FFMPEG) || (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54,71,100))
+    overlay->bForced  = rect.flags != 0;
+#endif
 
     int right  = overlay->x + overlay->width;
     int bottom = overlay->y + overlay->height;


### PR DESCRIPTION
Modifies the PGS Forced Subtitles Fix recently merged under the commit
below so that users who can't upgrade their external ffmeg don't utilize
the new objects.

https://github.com/xbmc/xbmc/commit/e6f195c8d2b3c7e66b74daf760bb7229ee469780
