### PR TITLE
added: url option to set proxy for http streams

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -717,11 +717,12 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         else if (name.Equals("Encoding"))
           SetContentEncoding(value);
         else if (name.Equals("Proxy") && !g_guiSettings.GetBool("network.usehttpproxy"))
+        {  
           if (name.Equals("ProxyUserPass"))
           {
             SetProxyUserPass(value);
           }
-          if (value.Equals('http://'))
+          if (value.Left(7).Equals("http://"))
           {
             m_proxy = value;
           }
@@ -731,6 +732,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
           }
           SetProxy(m_proxy);
           CLog::Log(LOGDEBUG, "Using url option proxy %s", m_proxy.c_str());
+        }
         else if (name.Equals("noshout") && value.Equals("true"))
           m_skipshout = true;
         else

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -730,7 +730,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
             m_proxy = "http://" + value;
           }
           SetProxy(m_proxy);
-          CLog::Log(LOGDEBUG, "Using proxy %s", m_proxy.c_str());
+          CLog::Log(LOGDEBUG, "Using url option proxy %s", m_proxy.c_str());
         else if (name.Equals("noshout") && value.Equals("true"))
           m_skipshout = true;
         else

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -716,6 +716,21 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
           SetCookie(value);
         else if (name.Equals("Encoding"))
           SetContentEncoding(value);
+        else if (name.Equals("Proxy") && !g_guiSettings.GetBool("network.usehttpproxy"))
+          if (name.Equals("ProxyUserPass"))
+          {
+            SetProxyUserPass(value);
+          }
+          if (value.Equals('http://'))
+          {
+            m_proxy = value;
+          }
+          else
+          {
+            m_proxy = "http://" + value;
+          }
+          SetProxy(m_proxy);
+          CLog::Log(LOGDEBUG, "Using proxy %s", m_proxy.c_str());
         else if (name.Equals("noshout") && value.Equals("true"))
           m_skipshout = true;
         else


### PR DESCRIPTION
Hi,
this is my first trial for contribute to xbmc code. I don't have build environment and I couldn't build and try this code. It should work I guess :)

I did it for using proxy without enable for hole XBMC. For add-on's mainly.

I need some feedbacks about this feature. Is it necessary or how is the code etc.

TODO: [DONE] Better log message to distinguish from XBMC proxy settings ("Using url option proxy %s")
