### PR TITLE
Screensaver crash fix

### DIFF
--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -37,6 +37,8 @@ namespace XBMCAddon
 {
   namespace xbmcgui
   {
+    XbmcThreads::ThreadLocal<ref> InterceptorBase::upcallTls;
+
     /**
      * Used in add/remove control. It only locks if it's given a 
      * non-NULL CCriticalSection. It's given a NULL CCriticalSection

--- a/xbmc/interfaces/legacy/WindowInterceptor.h
+++ b/xbmc/interfaces/legacy/WindowInterceptor.h
@@ -43,7 +43,8 @@ namespace XBMCAddon
     {
     protected:
       AddonClass::Ref<Window> window;
-      XbmcThreads::ThreadLocal<ref> upcallTls;
+      // This instance is in Window.cpp
+      static XbmcThreads::ThreadLocal<ref> upcallTls;
 
       InterceptorBase() : window(NULL) { upcallTls.set(NULL); }
 

--- a/xbmc/interfaces/python/LanguageHook.h
+++ b/xbmc/interfaces/python/LanguageHook.h
@@ -28,7 +28,6 @@
 #include <Python.h>
 
 #include "interfaces/legacy/LanguageHook.h"
-#include "threads/ThreadLocal.h"
 #include "threads/Event.h"
 
 #include <set>

--- a/xbmc/interfaces/python/swig.h
+++ b/xbmc/interfaces/python/swig.h
@@ -27,7 +27,6 @@
 #include "interfaces/legacy/Exception.h"
 #include "interfaces/legacy/AddonClass.h"
 #include "interfaces/legacy/Window.h"
-#include "threads/ThreadLocal.h"
 
 namespace PythonBindings
 {

--- a/xbmc/threads/platform/win/ThreadLocal.h
+++ b/xbmc/threads/platform/win/ThreadLocal.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <windows.h>
+#include "commons/Exception.h"
 
 namespace XbmcThreads
 {
@@ -32,11 +33,23 @@ namespace XbmcThreads
   {
     DWORD key;
   public:
-    inline ThreadLocal() { key = TlsAlloc(); }
+    inline ThreadLocal()
+    {
+       if ((key = TlsAlloc()) == TLS_OUT_OF_INDEXES)
+          throw XbmcCommons::UncheckedException("Ran out of Windows TLS Indexes. Windows Error Code %d",(int)GetLastError());
+    }
 
-    inline ~ThreadLocal() { TlsFree(key);  }
+    inline ~ThreadLocal() 
+    {
+       if (!TlsFree(key))
+          throw XbmcCommons::UncheckedException("Failed to free Tls %d, Windows Error Code %d",(int)key, (int)GetLastError());
+    }
 
-    inline void set(T* val) {  TlsSetValue(key,(LPVOID)val);  }
+    inline void set(T* val)
+    {
+       if (!TlsSetValue(key,(LPVOID)val))
+          throw XbmcCommons::UncheckedException("Failed to set Tls %d, Windows Error Code %d",(int)key, (int)GetLastError());
+    }
 
     inline T* get() { return (T*)TlsGetValue(key); }
   };


### PR DESCRIPTION
It appears that we are running out of Tls (Thread local storage) slots on Windows (which has a very limited number of them). The current codebase uses a new one per add Window instance. This collapses that use to a single instance for all windows.

Closes #13859
