### PR TITLE
Add new Built-In function to control attached CEC device

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11689,7 +11689,9 @@ msgctxt "#36009"
 msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
-#empty string with id 36010
+msgctxt "#36010"
+msgid "Wake devices when deactivating screensaver"
+msgstr ""
 
 #: xbmc/peripherals/devices/peripheralcecadapter.cpp
 msgctxt "#36011"

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -14,14 +14,15 @@
     <setting key="standby_devices" type="enum" value="36037" label="36008" lvalues="36037|36038|36039|231" order="4" />
     <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
     <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
-    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="7" lvalues="36028|13005|13011" />
-    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="8" />
-    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="9" />
-    <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" order="10" />
-    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="11" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="12" />
-    <setting key="physical_address" type="string" label="36021" value="0" order="13" />
-    <setting key="port" type="string" value="" label="36022" order="14" />
+    <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011" />
+    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
+    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
+    <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" order="11" />
+    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="12" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="13" />
+    <setting key="physical_address" type="string" label="36021" value="0" order="14" />
+    <setting key="port" type="string" value="" label="36022" order="15" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="XBMC" configurable="0" />

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -164,7 +164,7 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
       if (bIgnoreDeactivate)
         CLog::Log(LOGDEBUG, "%s - ignoring OnScreensaverDeactivated for power action", __FUNCTION__);
     }
-    if (m_configuration.bPowerOffScreensaver == 1 && !bIgnoreDeactivate &&
+    if (m_configuration.bPowerOnScreensaver == 1 && !bIgnoreDeactivate &&
         m_configuration.bActivateSource == 1)
     {
       ActivateSource();
@@ -1239,6 +1239,9 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
   m_configuration.bPowerOffScreensaver = config.bPowerOffScreensaver;
   bChanged |= SetSetting("cec_standby_screensaver", m_configuration.bPowerOffScreensaver == 1);
 
+  m_configuration.bPowerOnScreensaver = config.bPowerOnScreensaver;
+  bChanged |= SetSetting("cec_wake_screensaver", m_configuration.bPowerOnScreensaver == 1);
+
   m_configuration.bPowerOffOnStandby = config.bPowerOffOnStandby;
 
   m_configuration.bSendInactiveSource = config.bSendInactiveSource;
@@ -1331,6 +1334,7 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
   m_configuration.bUseTVMenuLanguage   = GetSettingBool("use_tv_menu_language") ? 1 : 0;
   m_configuration.bActivateSource      = GetSettingBool("activate_source") ? 1 : 0;
   m_configuration.bPowerOffScreensaver = GetSettingBool("cec_standby_screensaver") ? 1 : 0;
+  m_configuration.bPowerOnScreensaver  = GetSettingBool("cec_wake_screensaver") ? 1 : 0;
   m_configuration.bSendInactiveSource  = GetSettingBool("send_inactive_source") ? 1 : 0;
 
   // read the mutually exclusive boolean settings


### PR DESCRIPTION
Hi,

this is my first contribution to xbmc. They're a couple patches targeted at USB CEC
or RaspberryPi owners:
- A new Built-In method to control the state of the attached playing CEC device,
  thought to be mapped to a remote key.
- Support for a new libcec method, PowerOnScreensaver, to control whether
  waking the CEC device when waking the screensaver.
