### PR TITLE
[confluence] change "wide icons" view naming to "wide".

### DIFF
--- a/addons/skin.confluence/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence/720p/ViewsFileMode.xml
@@ -420,7 +420,7 @@
 				<onright>60</onright>
 				<onup>505</onup>
 				<ondown>505</ondown>
-				<viewtype label="$LOCALIZE[539] $LOCALIZE[536]">list</viewtype>
+				<viewtype label="$LOCALIZE[539]">list</viewtype>
 				<pagecontrol>60</pagecontrol>
 				<scrolltime>200</scrolltime>
 				<preloaditems>2</preloaditems>


### PR DESCRIPTION
As discussed in http://trac.xbmc.org/ticket/13485
