### PR TITLE
fix: remove plugin directory handle without fail handles greater than the removed one.

### DIFF
--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -71,6 +71,7 @@ private:
   static std::vector<CPluginDirectory*> globalHandles;
   static int getNewHandle(CPluginDirectory *cp);
   static void removeHandle(int handle);
+  static CPluginDirectory *dirFromHandle(int handle);
   static CCriticalSection m_handleLock;
 
   CFileItemList* m_listItems;


### PR DESCRIPTION
currently, remove a handle will fail all other handles which greater than the removed one, this will happen when more than one plugindirectory script running within a overlapped time.
it's a obvious bug since the handle supposed not always be 0, there is possibility following example happens:

ui make a plugin dir listing request, which assigned handle 0:
plugin with handle 0 begin
json-rpc make another plugin dir listing request, which assigned handle 1:
plugin with handle 1 begin
plugin with handle 0 end, in the current code, the handle will be erased
plugin with handle 1 call function like setEndOfDirectory but handle 1 does not existed, the globalHandles vector size is 1 now the CPluginDirectory object with original handle 1 now on the handle 0 position, so the setEndOfDirectory call will failed, it's a mistake, this commit fix this problem.

btw, I'm writing addons, but have no machine to compile xbmc, so please test it first before merge to the main branch.
