### PR TITLE
Always write v2 ID3 tags when ripping to mp3

### DIFF
--- a/xbmc/cdrip/DllLameenc.h
+++ b/xbmc/cdrip/DllLameenc.h
@@ -31,6 +31,7 @@ class DllLameEncInterface
 {
 public:
   virtual void id3tag_init(lame_global_flags* gfp)=0;
+  virtual void id3tag_add_v2(lame_global_flags* gfp)=0;
   virtual int id3tag_set_genre(lame_global_flags* gfp, const char* genre)=0;
   virtual void id3tag_set_title(lame_global_flags* gfp, const char* title)=0;
   virtual void id3tag_set_artist(lame_global_flags* gfp, const char* artist)=0;
@@ -61,6 +62,7 @@ class DllLameEnc : public DllDynamic, DllLameEncInterface
 {
   DECLARE_DLL_WRAPPER(DllLameEnc, DLL_PATH_LAME_ENC)
   DEFINE_METHOD1(void, id3tag_init, (lame_global_flags* p1));
+  DEFINE_METHOD1(void, id3tag_add_v2, (lame_global_flags* p1));
   DEFINE_METHOD2(int, id3tag_set_genre, (lame_global_flags* p1, const char* p2))
   DEFINE_METHOD2(void, id3tag_set_title, (lame_global_flags* p1, const char* p2))
   DEFINE_METHOD2(void, id3tag_set_artist, (lame_global_flags* p1, const char* p2))
@@ -85,6 +87,7 @@ class DllLameEnc : public DllDynamic, DllLameEncInterface
   DEFINE_METHOD3(int, lame_encode_flush, (lame_global_flags* p1, unsigned char* p2, int p3))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(id3tag_init)
+    RESOLVE_METHOD(id3tag_add_v2)
     RESOLVE_METHOD(id3tag_set_genre)
     RESOLVE_METHOD(id3tag_set_title)
     RESOLVE_METHOD(id3tag_set_artist)

--- a/xbmc/cdrip/EncoderLame.cpp
+++ b/xbmc/cdrip/EncoderLame.cpp
@@ -87,16 +87,9 @@ bool CEncoderLame::Init(const char* strFile, int iInChannels, int iInRate, int i
   m_dll.lame_set_asm_optimizations(m_pGlobalFlags, SSE, 1);
   m_dll.lame_set_in_samplerate(m_pGlobalFlags, 44100);
 
-  // Now that all the options are set, lame needs to analyze them and
-  // set some more internal options and check for problems
-  if (m_dll.lame_init_params(m_pGlobalFlags) < 0)
-  {
-    CLog::Log(LOGERROR, "Error: Cannot init Lame params");
-    return false;
-  }
-
   // Setup the ID3 tagger
   m_dll.id3tag_init(m_pGlobalFlags);
+  m_dll.id3tag_add_v2(m_pGlobalFlags);
   m_dll.id3tag_set_title(m_pGlobalFlags, m_strTitle.c_str());
   m_dll.id3tag_set_artist(m_pGlobalFlags, m_strArtist.c_str());
   m_dll.id3tag_set_textinfo_latin1(m_pGlobalFlags, "TPE2", m_strAlbumArtist.c_str());
@@ -106,6 +99,14 @@ bool CEncoderLame::Init(const char* strFile, int iInChannels, int iInRate, int i
   int test = m_dll.id3tag_set_genre(m_pGlobalFlags, m_strGenre.c_str());
   if(test==-1)
     m_dll.id3tag_set_genre(m_pGlobalFlags,"Other");
+
+  // Now that all the options are set, lame needs to analyze them and
+  // set some more internal options and check for problems
+  if (m_dll.lame_init_params(m_pGlobalFlags) < 0)
+  {
+    CLog::Log(LOGERROR, "Error: Cannot init Lame params");
+    return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
Needs testing on all platforms that allow CD ripping.  Untested currently.  Fixes #13876.
