### PR TITLE
[Confluence] Don't process subsequent onclicks if the first one was cancelled

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -313,8 +313,8 @@
 				<onclick>Close</onclick>
 				<onclick>XBMC.RunScript($INFO[Skin.String(SubtitleScript_Path)])</onclick>
 				<altclick>Skin.SetAddon(SubtitleScript_Path,xbmc.python.subtitles)</altclick>
-				<altclick>Close</altclick>
-				<altclick>XBMC.RunScript($INFO[Skin.String(SubtitleScript_Path)])</altclick>
+				<altclick condition="Window.IsVisible(VideoOSD)">Dialog.Close(VideoOSD)</altclick>
+				<altclick condition="!IsEmpty(Skin.String(SubtitleScript_Path))">XBMC.RunScript($INFO[Skin.String(SubtitleScript_Path)])</altclick>
 				<usealttexture>IsEmpty(Skin.String(SubtitleScript_Path))</usealttexture>
 			</control>
 			<control type="button" id="251">


### PR DESCRIPTION
The subtitles button on the VideOSD has three actions assigned to it.
The first one is to select a subtitle addon. When this select dialog is cancelled, 
don't try to process the other defined actions.

this PR fixes two things:
- change the 'Close' action to 'Dialog.Close(VideoOSD)' as it would potentially close the FullScreenVideo window instead of just the VideoOSD
- don't try to run a subtitles addon if no addon was selected.

Fixes #13576
