### PR TITLE
Always load Startup.xml

### DIFF
--- a/addons/skin.confluence/720p/Startup.xml
+++ b/addons/skin.confluence/720p/Startup.xml
@@ -4,7 +4,7 @@
 	<controls>
 		<control type="button" id="10">
 			<description>trigger</description>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+			<onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>!Skin.HasSetting(Use_Startup_Playlist)</visible>
@@ -12,7 +12,7 @@
 		<control type="button" id="10">
 			<description>trigger with startup Playlist</description>
 			<onfocus>XBMC.PlayMedia($INFO[Skin.String(Startup_Playlist_Path)])</onfocus>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+			<onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>Skin.HasSetting(Use_Startup_Playlist)</visible>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -275,7 +275,8 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "alarmpos",         SYSTEM_ALARM_POS },
                                   { "isinhibit",        SYSTEM_ISINHIBIT },
                                   { "hasshutdown",      SYSTEM_HAS_SHUTDOWN },
-                                  { "haspvr",           SYSTEM_HAS_PVR }};
+                                  { "haspvr",           SYSTEM_HAS_PVR },
+                                  { "startupwindow",    SYSTEM_STARTUP_WINDOW }};
 
 const infomap system_param[] =   {{ "hasalarm",         SYSTEM_HAS_ALARM },
                                   { "hascoreid",        SYSTEM_HAS_CORE_ID },
@@ -1660,6 +1661,9 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     break;
   case SYSTEM_CURRENT_WINDOW:
     return g_localizeStrings.Get(g_windowManager.GetFocusedWindow());
+    break;
+  case SYSTEM_STARTUP_WINDOW:
+    strLabel.Format("%i", g_guiSettings.GetInt("lookandfeel.startupwindow"));
     break;
   case SYSTEM_CURRENT_CONTROL:
     {

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -184,6 +184,7 @@ namespace INFO
 #define SYSTEM_ISINHIBIT            184
 #define SYSTEM_HAS_SHUTDOWN         185
 #define SYSTEM_HAS_PVR              186
+#define SYSTEM_STARTUP_WINDOW       187
 
 #define NETWORK_IP_ADDRESS          190
 #define NETWORK_MAC_ADDRESS         191

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -92,7 +92,6 @@ CSkinInfo::CSkinInfo(const cp_extension_t *ext)
   str = CAddonMgr::Get().GetExtValue(ext->configuration, "@debugging");
   m_debugging = !strcmp(str.c_str(), "true");
 
-  m_onlyAnimateToHome = true;
   LoadStartupWindows(ext);
   m_Version = 2.11;
 }
@@ -222,7 +221,6 @@ bool CSkinInfo::LoadStartupWindows(const cp_extension_t *ext)
   m_startupWindows.push_back(CStartupWindow(WINDOW_FILES, "7"));
   m_startupWindows.push_back(CStartupWindow(WINDOW_SETTINGS_MENU, "5"));
   m_startupWindows.push_back(CStartupWindow(WINDOW_WEATHER, "8"));
-  m_onlyAnimateToHome = true;
   return true;
 }
 
@@ -258,7 +256,7 @@ bool CSkinInfo::TranslateResolution(const CStdString &name, RESOLUTION_INFO &res
 int CSkinInfo::GetFirstWindow() const
 {
   int startWindow = GetStartWindow();
-  if (HasSkinFile("Startup.xml") && (!m_onlyAnimateToHome || startWindow == WINDOW_HOME))
+  if (HasSkinFile("Startup.xml"))
     startWindow = WINDOW_STARTUP_ANIM;
   return startWindow;
 }

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -137,7 +137,6 @@ protected:
   CStdString m_currentAspect;
 
   std::vector<CStartupWindow> m_startupWindows;
-  bool m_onlyAnimateToHome;
   bool m_debugging;
 };
 


### PR DESCRIPTION
Currently XBMC skips Startup.xml when a custom startup window is defined in settings.
This could lead to issues since skins depend on whatever they've defined in Startup.xml

This PR fixes that making sure xbmc loads Startup.xml on startup and by introducing a System.StartupWindow infolabel that skinners should use in their Startup.xml

Fixes #13445

Not for Frodo.
