### PR TITLE
fix horizontal alignment of outlined text

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -168,8 +168,20 @@ void CGUITextLayout::RenderOutline(float x, float y, color_t color, color_t outl
       uint32_t align = alignment;
       if (align & XBFONT_JUSTIFIED && string.m_carriageReturn)
         align &= ~XBFONT_JUSTIFIED;
+      // text centered horizontally must be computed using the original font, not the bordered
+      // font, as the bordered font will be wider, and thus will end up uncentered.
+      // TODO: We should really have a better way to handle text extent - at the moment we assume
+      //       that text is rendered from a posx, posy, width, and height which isn't enough to
+      //       accurately position text. We need a vertical and horizontal offset of the baseline
+      //       and cursor as well.
+      float bx = x;
+      if (align & XBFONT_CENTER_X)
+      {
+        bx -= m_font->GetTextWidth(string.m_text) * 0.5f;
+        align &= ~XBFONT_CENTER_X;
+      }
 
-      m_borderFont->DrawText(x, by, outlineColors, 0, string.m_text, align, maxWidth);
+      m_borderFont->DrawText(bx, by, outlineColors, 0, string.m_text, align, maxWidth);
       by += m_borderFont->GetLineHeight();
     }
     m_borderFont->End();


### PR DESCRIPTION
@pike this one is for you.  Just needs testing by someone who can reproduce the problem - issue is that subtitle border text (for text-based subs such as .srt) are slightly out of alignment on occasion - it depends on the width of the text + the size of the border on the left and right-most characters.  Border will be to the left of where it should be by a few pixels.  Should be reproducible every time with the right bit of sub.

Once confirmed fixed, it can be pulled for Frodo.
