### PR TITLE
[Confluence] some minor fixes

### DIFF
--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -848,7 +848,7 @@
 					<posx>210</posx>
 					<posy>515</posy>
 					<width>1030</width>
-					<height>120</height>
+					<height>130</height>
 					<font>font12</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -699,7 +699,7 @@
 			</control>
 			<control type="group">
 				<posx>40</posx>
-				<posy>200</posy>
+				<posy>195</posy>
 				<control type="label">
 					<posx>0</posx>
 					<posy>0</posy>
@@ -718,7 +718,7 @@
 					<posx>0</posx>
 					<posy>30</posy>
 					<width>850</width>
-					<height>120</height>
+					<height>130</height>
 					<font>font12</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>


### PR DESCRIPTION
Hey guys,

found the one or other glitch.

1)
Plot was cut off in DialogVideoInfo.xml
Before:
http://www.xbmcnerds.com/wcf/images/photos/photo-1184-579fefa7.png
After:
http://www.xbmcnerds.com/wcf/images/photos/photo-1183-94ae6deb.png

2)
Plot was cut off in view 508 (Fanart)
Before:
http://www.xbmcnerds.com/wcf/images/photos/photo-1182-af02581a.png
After:
http://www.xbmcnerds.com/wcf/images/photos/photo-1181-cc8e2dce.png

cheers,
mad-max
