### PR TITLE
Correct handling of multimedia keypresses

### DIFF
--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -261,6 +261,25 @@ static int XBMC_MapVirtualKey(int scancode, int vkey)
     case VK_RMENU:
     case VK_SNAPSHOT:
     case VK_PAUSE:
+    /* Multimedia keys are already handled */
+    case VK_BROWSER_BACK:
+    case VK_BROWSER_FORWARD:
+    case VK_BROWSER_REFRESH:
+    case VK_BROWSER_STOP:
+    case VK_BROWSER_SEARCH:
+    case VK_BROWSER_FAVORITES:
+    case VK_BROWSER_HOME:
+    case VK_VOLUME_MUTE:
+    case VK_VOLUME_DOWN:
+    case VK_VOLUME_UP:
+    case VK_MEDIA_NEXT_TRACK:
+    case VK_MEDIA_PREV_TRACK:
+    case VK_MEDIA_STOP:
+    case VK_MEDIA_PLAY_PAUSE:
+    case VK_LAUNCH_MAIL:
+    case VK_LAUNCH_MEDIA_SELECT:
+    case VK_LAUNCH_APP1:
+    case VK_LAUNCH_APP2:
       return vkey;
   }
   switch(mvke)


### PR DESCRIPTION
http://trac.xbmc.org/ticket/13585 reports that on some laptops multimedia keypresses are having unintended affects. This is because on some keyboards (it isn't clear exactly which) the multimedia keys send scan codes used by different keys e.g. the mute key sends the same scancode as the "d" key. This means that (on Windows) XBMC sees the WM_APPCOMMAND message from the mute key, but then a rogue "d" keypress as well. This has started mattering since new key mappings were added to support the PVR functions.

This commit is a quick fix that stops XBMC processing the scan code for multimedia keys. This should do for Frodo, though in the longer term we need to look at exactly what scancode processing is required as it isn't clear why the current code is needed.
