### PR TITLE
tag animations as ready to go once processed once, not when rendered once

### DIFF
--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -88,7 +88,7 @@ void CGUIDialogProgress::StartModal()
     // we must be running from fullscreen video or similar where the
     // calling thread handles rendering (ie not main app thread) but
     // is waiting on this routine before rendering begins
-    if (!m_hasRendered)
+    if (!HasProcessed())
       break;
   }
 }

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -82,7 +82,7 @@ public:
   virtual void DoRender();
   virtual void Render();
 
-  bool HasRendered() const { return m_hasRendered; };
+  bool HasProcessed() const { return m_hasProcessed; };
 
   // OnAction() is called by our window when we are the focused control.
   // We should process any control-specific actions in the derived classes,
@@ -341,7 +341,7 @@ protected:
   bool m_visibleFromSkinCondition;
   bool m_forceHidden;       // set from the code when a hidden operation is given - overrides m_visible
   CGUIInfoBool m_allowHiddenFocus;
-  bool m_hasRendered;
+  bool m_hasProcessed;
   // enable/disable state
   unsigned int m_enableCondition;
   bool m_enabled;

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -233,7 +233,7 @@ void CGUIDialog::FrameMove()
   { // check if our timer is running
     if (!m_showStartTime)
     {
-      if (HasRendered()) // start timer
+      if (HasProcessed()) // start timer
         m_showStartTime = CTimeUtils::GetFrameTime();
     }
     else

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -68,7 +68,7 @@ void CGUIImage::UpdateInfo(const CGUIListItem *item)
     return; // nothing to do
 
   // don't allow image to change while animating out
-  if (HasRendered() && IsAnimating(ANIM_TYPE_HIDDEN) && !IsVisibleFromSkin())
+  if (HasProcessed() && IsAnimating(ANIM_TYPE_HIDDEN) && !IsVisibleFromSkin())
     return;
 
   if (item)
@@ -253,7 +253,7 @@ void CGUIImage::FreeResourcesButNotAnims()
 {
   FreeTextures();
   m_bAllocated=false;
-  m_hasRendered = false;
+  m_hasProcessed = false;
 }
 
 void CGUIImage::DynamicResourceAlloc(bool bOnOff)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -494,7 +494,7 @@ void CGUIWindow::OnInitWindow()
     g_audioManager.PlayWindowSound(GetID(), SOUND_INIT);
 
   // set our rendered state
-  m_hasRendered = false;
+  m_hasProcessed = false;
   m_closing = false;
   m_active = true;
   ResetAnimations();  // we need to reset our animations as those windows that don't dynamically allocate
@@ -820,7 +820,7 @@ bool CGUIWindow::CheckAnimation(ANIMATION_TYPE animType)
   // special cases first
   if (animType == ANIM_TYPE_WINDOW_CLOSE)
   {
-    if (!m_bAllocated || !m_hasRendered) // can't render an animation if we aren't allocated or haven't rendered
+    if (!m_bAllocated || !HasProcessed()) // can't process an animation if we aren't allocated or haven't processed
       return false;
     // make sure we update our visibility prior to queuing the window close anim
     for (unsigned int i = 0; i < m_children.size(); i++)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -389,8 +389,8 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   int iSlides = m_slides->Size();
   if (!iSlides) return ;
 
-  // if we haven't rendered yet, we should mark the whole screen
-  if (!m_hasRendered)
+  // if we haven't processed yet, we should mark the whole screen
+  if (!HasProcessed())
     regions.push_back(CRect(0.0f, 0.0f, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight()));
 
   if (m_iNextSlide < 0 || m_iNextSlide >= m_slides->Size())


### PR DESCRIPTION
Basically Render() should not contain anything that sets state.  This avoid this for animations.

Fixes #13912.

For post-Frodo
