### PR TITLE
don't use rand() for choosing a random song for partymode

### DIFF
--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -684,13 +684,9 @@ void CPartyModeManager::AddToHistory(int type, int songID)
 
 void CPartyModeManager::GetRandomSelection(vector< pair<int,int> >& in, unsigned int number, vector< pair<int,int> >& out)
 {
-  // only works if we have < 32768 in the in vector
-  for (unsigned int i = 0; i < number; i++)
-  {
-    int num = rand() % in.size();
-    out.push_back(in[num]);
-    in.erase(in.begin() + num);
-  }
+  number = min(number, (unsigned int)in.size());
+  random_shuffle(in.begin(), in.end());
+  out.assign(in.begin(), in.begin() + number);
 }
 
 bool CPartyModeManager::IsEnabled(PartyModeContext context /* = PARTYMODECONTEXT_UNKNOWN */) const

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4003,24 +4003,17 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &f
   {
     idSong = -1;
 
-    int iCount = GetSongsCount(filter);
-    if (iCount <= 0)
-      return false;
-    int iRandom = rand() % iCount;
-
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted
     CStdString strSQL = PrepareSQL("select %s from songview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
     Filter extFilter = filter;
-    extFilter.AppendOrder("idSong");
+    extFilter.AppendOrder(PrepareSQL("RANDOM()"));
     extFilter.limit = "1";
 
     if (!CDatabase::BuildSQL(strSQL, extFilter, strSQL))
       return false;
-
-    strSQL += PrepareSQL(" OFFSET %i", iRandom);
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7214,17 +7214,12 @@ bool CVideoDatabase::GetRandomMusicVideo(CFileItem* item, int& idSong, const CSt
   {
     idSong = -1;
 
-    int iCount = GetMusicVideoCount(strWhere);
-    if (iCount <= 0)
-      return false;
-    int iRandom = rand() % iCount;
-
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted.
     CStdString strSQL;
-    strSQL.Format("select * from musicvideoview where %s order by idMVideo limit 1 offset %i",strWhere.c_str(),iRandom);
+    strSQL.Format("select * from musicvideoview where %s order by RANDOM() limit 1",strWhere.c_str());
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
     if (!m_pDS->query(strSQL.c_str()))


### PR DESCRIPTION
Ideally for Frodo.  rand() typically returns a number between 0..32767, so for larger databases doesn't hit every possible row.

@koying: please test mysql.  I have a feeling it will be quite slow, but not sure.  Easy to test - just start partymode then skip a song.
