### PR TITLE
[cddb] use uint32_t for the disc id rather than unsigned long

### DIFF
--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -209,7 +209,7 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo, int inexact_list_select)
     return false;
   }
 
-  unsigned long discid = pInfo->GetCddbDiscId();
+  uint32_t discid = pInfo->GetCddbDiscId();
 
 
   //##########################################################
@@ -354,7 +354,7 @@ int Xcddb::cddb_sum(int n)
 }
 
 //-------------------------------------------------------------------------------------------------------------------
-unsigned long Xcddb::calc_disc_id(int tot_trks, toc cdtoc[])
+uint32_t Xcddb::calc_disc_id(int tot_trks, toc cdtoc[])
 {
   int i = 0, t = 0, n = 0;
 
@@ -749,7 +749,7 @@ void Xcddb::setCacheDir(const CStdString& pCacheDir )
 }
 
 //-------------------------------------------------------------------------------------------------------------------
-bool Xcddb::queryCache( unsigned long discid )
+bool Xcddb::queryCache( uint32_t discid )
 {
   if (cCacheDir.size() == 0)
     return false;
@@ -770,7 +770,7 @@ bool Xcddb::queryCache( unsigned long discid )
 }
 
 //-------------------------------------------------------------------------------------------------------------------
-bool Xcddb::writeCacheFile( const char* pBuffer, unsigned long discid )
+bool Xcddb::writeCacheFile( const char* pBuffer, uint32_t discid )
 {
   if (cCacheDir.size() == 0)
     return false;
@@ -820,7 +820,7 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo)
 
   int lead_out = pInfo->GetTrackCount();
   int real_track_count = pInfo->GetTrackCount();
-  unsigned long discid = pInfo->GetCddbDiscId();
+  uint32_t discid = pInfo->GetCddbDiscId();
   unsigned long frames[100];
 
 
@@ -828,7 +828,7 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo)
   //
   if ( queryCache(discid) )
   {
-    CLog::Log(LOGDEBUG, "Xcddb::queryCDinfo discid [%08lx] already cached", discid);
+    CLog::Log(LOGDEBUG, "Xcddb::queryCDinfo discid [%08x] already cached", discid);
     return true;
   }
 
@@ -927,7 +927,7 @@ bool Xcddb::queryCDinfo(CCdInfo* pInfo)
   strcat(query_buffer, "cddb query");
   {
     char tmp_buffer[256];
-    sprintf(tmp_buffer, " %08lx", discid);
+    sprintf(tmp_buffer, " %08x", discid);
     strcat(query_buffer, tmp_buffer);
   }
   {
@@ -1065,7 +1065,7 @@ bool Xcddb::isCDCached( CCdInfo* pInfo )
   return XFILE::CFile::Exists(GetCacheFile(pInfo->GetCddbDiscId()));
 }
 
-CStdString Xcddb::GetCacheFile(unsigned int disc_id) const
+CStdString Xcddb::GetCacheFile(uint32_t disc_id) const
 {
   CStdString strFileName;
   strFileName.Format("%x.cddb", disc_id);

--- a/xbmc/network/cddb.h
+++ b/xbmc/network/cddb.h
@@ -81,11 +81,11 @@ public:
   void getDiskArtist(CStdString& strdisk_artist) const;
   void getDiskTitle(CStdString& strdisk_title) const;
   const CStdString& getTrackExtended(int track) const;
-  unsigned long calc_disc_id(int nr_of_tracks, toc cdtoc[]);
+  uint32_t calc_disc_id(int nr_of_tracks, toc cdtoc[]);
   const CStdString& getInexactArtist(int select) const;
   const CStdString& getInexactTitle(int select) const;
-  bool queryCache( unsigned long discid );
-  bool writeCacheFile( const char* pBuffer, unsigned long discid );
+  bool queryCache( uint32_t discid );
+  bool writeCacheFile( const char* pBuffer, uint32_t discid );
   bool isCDCached( int nr_of_tracks, toc cdtoc[] );
   bool isCDCached( MEDIA_DETECT::CCdInfo* pInfo );
 
@@ -121,7 +121,7 @@ protected:
   void addInexactList(const char *list);
   void addInexactListLine(int line_cnt, const char *line, int len);
   const CStdString& getInexactCommand(int select) const;
-  CStdString GetCacheFile(unsigned int disc_id) const;
+  CStdString GetCacheFile(uint32_t disc_id) const;
   /*! \brief Trim and convert some text to UTF8
    \param untrimmedText original text to trim and convert
    \return a utf8 version of the trimmed text

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -926,7 +926,7 @@ UINT CCdIoSupport::MsfSeconds(msf_t *msf)
 //    the total length of the disk, and
 //    the number of tracks.
 
-ULONG CCdIoSupport::CddbDiscId()
+uint32_t CCdIoSupport::CddbDiscId()
 {
   CSingleLock lock(*m_cdio);
 

--- a/xbmc/storage/cdioSupport.h
+++ b/xbmc/storage/cdioSupport.h
@@ -134,7 +134,7 @@ public:
   int GetFirstDataTrack() { return m_nFirstData; }
   int GetDataTrackCount() { return m_nNumData; }
   int GetAudioTrackCount() { return m_nNumAudio; }
-  ULONG GetCddbDiscId() { return m_ulCddbDiscId; }
+  uint32_t GetCddbDiscId() { return m_ulCddbDiscId; }
   int GetDiscLength() { return m_nLength; }
   CStdString GetDiscLabel(){ return m_strDiscLabel; }
 
@@ -229,7 +229,7 @@ public:
   void SetTrackInformation( int nTrack, trackinfo nInfo ) { if ( nTrack > 0 && nTrack <= 99 ) m_ti[nTrack - 1] = nInfo; }
   void SetDiscCDTextInformation( xbmc_cdtext_t cdtext ) { m_cdtext = cdtext; }
 
-  void SetCddbDiscId( ULONG ulCddbDiscId ) { m_ulCddbDiscId = ulCddbDiscId; }
+  void SetCddbDiscId( uint32_t ulCddbDiscId ) { m_ulCddbDiscId = ulCddbDiscId; }
   void SetDiscLength( int nLength ) { m_nLength = nLength; }
   bool HasCDDBInfo() { return m_bHasCDDBInfo; }
   void SetNoCDDBInfo() { m_bHasCDDBInfo = false; }
@@ -244,7 +244,7 @@ private:
   int m_nNumTrack;
   int m_nFirstTrack;
   trackinfo m_ti[100];
-  ULONG m_ulCddbDiscId;
+  uint32_t m_ulCddbDiscId;
   int m_nLength;   // Disclength can be used for cddb query, also see trackinfo.nFrames
   bool m_bHasCDDBInfo;
   CStdString m_strDiscLabel;
@@ -313,7 +313,7 @@ protected:
   int GetJolietLevel( void );
   int GuessFilesystem(int start_session, track_t track_num);
 
-  ULONG CddbDiscId();
+  uint32_t CddbDiscId();
   int CddbDecDigitSum(int n);
   UINT MsfSeconds(msf_t *msf);
 


### PR DESCRIPTION
Done as a PR as there may be build implications on win32, plus I don't have a cd drive to test this out with.

fixes #13933.
