### PR TITLE
[python] fix xbmcvfs.File(file).write(buffer)

### DIFF
--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -37,7 +37,7 @@ namespace XBMCAddon
     bool File::write(const char* pBuffer)
     {
       DelayedCallGuard dg(languageHook);
-      return file->Write( (void*) pBuffer, strlen( pBuffer ) + 1 ) > 0;
+      return file->Write( (void*) pBuffer, strlen( pBuffer ) ) > 0;
     }
 
   }


### PR DESCRIPTION
the xbmcvfs write method is currently rendered useless by the fact we append a null-terminator
to the buffer when writing it to a file.

fixes trac #13545

for frodo, sign-off by @amet or @jimfcarroll
