### PR TITLE
[Fix] Videoscanner should not skip sftp/ssh sources

### DIFF
--- a/xbmc/filesystem/SFTPDirectory.cpp
+++ b/xbmc/filesystem/SFTPDirectory.cpp
@@ -20,6 +20,7 @@
 
 #include "SFTPDirectory.h"
 #ifdef HAS_FILESYSTEM_SFTP
+#include "utils/log.h"
 #include "URL.h"
 
 using namespace XFILE;
@@ -38,5 +39,19 @@ bool CSFTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
 
   CSFTPSessionPtr session = CSFTPSessionManager::CreateSession(url);
   return session->GetDirectory(url.GetWithoutFilename().c_str(), url.GetFileName().c_str(), items);
+}
+
+bool CSFTPDirectory::Exists(const char* strPath)
+{
+  CURL url(strPath);
+
+  CSFTPSessionPtr session = CSFTPSessionManager::CreateSession(url);
+  if (session)
+    return session->DirectoryExists(url.GetFileName().c_str());
+  else
+  {
+    CLog::Log(LOGERROR, "SFTPDirectory: Failed to create session to check exists");
+    return false;
+  }
 }
 #endif

--- a/xbmc/filesystem/SFTPDirectory.h
+++ b/xbmc/filesystem/SFTPDirectory.h
@@ -35,6 +35,7 @@ namespace XFILE
     CSFTPDirectory(void);
     virtual ~CSFTPDirectory(void);
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool Exists(const char* strPath);
   };
 }
 #endif

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -58,7 +58,8 @@ public:
   sftp_file CreateFileHande(const CStdString &file);
   void CloseFileHandle(sftp_file handle);
   bool GetDirectory(const CStdString &base, const CStdString &folder, CFileItemList &items);
-  bool Exists(const char *path);
+  bool DirectoryExists(const char *path);
+  bool FileExists(const char *path);
   int Stat(const char *path, struct __stat64* buffer);
   int Seek(sftp_file handle, uint64_t position);
   int Read(sftp_file handle, void *buffer, size_t length);
@@ -68,6 +69,7 @@ private:
   bool VerifyKnownHost(ssh_session session);
   bool Connect(const CStdString &host, unsigned int port, const CStdString &username, const CStdString &password);
   void Disconnect();
+  bool GetItemPermissions(const char *path, uint32_t &permissions);
   CCriticalSection m_critSect;
 
   bool m_connected;


### PR DESCRIPTION
Override CSFTPDirectory::Exists() method to correctly report whether an SFTP url represents a directory or not.

Fixes ticket #13784.

Refactored CSFTPSession::Exists() into FileExists() and DirectoryExists() methods, and have CSFTPFile and CSFTPDirectory classes use them.
This means that Exists() calls on these classes correctly only return true if the url refers to an item of the appropriate type (e.g. a file or a directory).

This has been tested under Linux (Ubuntu 12.04) and Windows Vista (32-bit).
