### PR TITLE
[droid] Enable launching android apps from add-ons

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -730,52 +730,119 @@ bool CXBMCApp::HasLaunchIntent(const string &package)
   return true;
 }
 
-bool CXBMCApp::StartActivity(const string &package)
+// Note intent, dataType, dataURI all default to ""
+bool CXBMCApp::StartActivity(const string &package, const string &intent, const string &dataType, const string &dataURI)
 {
   if (!m_activity || !package.size())
-    return false;
+   return false;
+
+  CLog::Log(LOGDEBUG, "CXBMCApp::StartActivity package: '%s' intent: '%s' dataType: '%s' dataURI: '%s'", package.c_str(), intent.c_str(), dataType.c_str(), dataURI.c_str());
 
   jthrowable exc;
   JNIEnv *env = NULL;
   AttachCurrentThread(&env);
+  
   jobject oActivity = m_activity->clazz;
   jclass cActivity = env->GetObjectClass(oActivity);
 
-  // oPackageManager = new PackageManager();
-  jmethodID mgetPackageManager = env->GetMethodID(cActivity, "getPackageManager", "()Landroid/content/pm/PackageManager;");
-  jobject oPackageManager = (jobject)env->CallObjectMethod(oActivity, mgetPackageManager);
-
-  // oPackageIntent = oPackageManager.getLaunchIntentForPackage(package);
-  jclass cPackageManager = env->GetObjectClass(oPackageManager);
-  jmethodID mgetLaunchIntentForPackage = env->GetMethodID(cPackageManager, "getLaunchIntentForPackage", "(Ljava/lang/String;)Landroid/content/Intent;");
-  jstring sPackageName = env->NewStringUTF(package.c_str());
-  jobject oPackageIntent = env->CallObjectMethod(oPackageManager, mgetLaunchIntentForPackage, sPackageName);
-  env->DeleteLocalRef(cPackageManager);
-  env->DeleteLocalRef(sPackageName);
-  env->DeleteLocalRef(oPackageManager);
-
-  exc = env->ExceptionOccurred();
-  if (exc)
+  jobject oIntent = NULL;
+  jclass cIntent = NULL;
+  if (intent.size())
   {
-    CLog::Log(LOGERROR, "CXBMCApp::StartActivity Failed to load %s. Exception follows:", package.c_str());
-    env->ExceptionDescribe();
-    env->ExceptionClear();
-    env->DeleteLocalRef(cActivity);
-    DetachCurrentThread();
-    return false;
+    // Java equivalent for following JNI
+    //    Intent oIntent = new Intent(Intent.ACTION_VIEW);
+    cIntent = env->FindClass("android/content/Intent");
+    jmethodID midIntentCtor = env->GetMethodID(cIntent, "<init>", "(Ljava/lang/String;)V");
+    jstring sIntent = env->NewStringUTF(intent.c_str());
+    oIntent = env->NewObject(cIntent, midIntentCtor, sIntent);
+    env->DeleteLocalRef(sIntent);
   }
-  if (!oPackageIntent)
+  else
   {
-    CLog::Log(LOGERROR, "CXBMCApp::StartActivity %s has no Launch Intent", package.c_str());
-    env->DeleteLocalRef(cActivity);
-    DetachCurrentThread();
-    return false;
+    // oPackageManager = new PackageManager();
+    jmethodID mgetPackageManager = env->GetMethodID(cActivity, "getPackageManager", "()Landroid/content/pm/PackageManager;");
+    jobject oPackageManager = (jobject)env->CallObjectMethod(oActivity, mgetPackageManager);
+
+    // oPackageIntent = oPackageManager.getLaunchIntentForPackage(package);
+    jclass cPackageManager = env->GetObjectClass(oPackageManager);
+    jmethodID mgetLaunchIntentForPackage = env->GetMethodID(cPackageManager, "getLaunchIntentForPackage", "(Ljava/lang/String;)Landroid/content/Intent;");
+    jstring sPackageName = env->NewStringUTF(package.c_str());
+    oIntent = env->CallObjectMethod(oPackageManager, mgetLaunchIntentForPackage, sPackageName);
+    cIntent = env->GetObjectClass(oIntent);
+    env->DeleteLocalRef(cPackageManager);
+    env->DeleteLocalRef(sPackageName);
+    env->DeleteLocalRef(oPackageManager);
+
+    exc = env->ExceptionOccurred();
+    if (exc)
+    {
+      CLog::Log(LOGERROR, "CXBMCApp::StartActivity Failed to load %s. Exception follows:", package.c_str());
+      env->ExceptionDescribe();
+      env->ExceptionClear();
+      env->DeleteLocalRef(cActivity);
+      DetachCurrentThread();
+      return false;
+    }
+    if (!oIntent)
+    {
+      CLog::Log(LOGERROR, "CXBMCApp::StartActivity %s has no Launch Intent", package.c_str());
+      env->DeleteLocalRef(cActivity);
+      DetachCurrentThread();
+      return false;
+    }
   }
-  // startActivity(oIntent);
+
+  jobject oUri;
+  if (dataURI.size())
+  {
+    // Java equivalent for the following JNI
+    //   Uri oUri = Uri.parse(sPath);
+    jclass cUri = env->FindClass("android/net/Uri");
+    jmethodID midUriParse = env->GetStaticMethodID(cUri, "parse", "(Ljava/lang/String;)Landroid/net/Uri;");
+    jstring sPath = env->NewStringUTF(dataURI.c_str());
+    oUri = env->CallStaticObjectMethod(cUri, midUriParse, sPath);
+    env->DeleteLocalRef(sPath);
+    env->DeleteLocalRef(cUri);
+
+    // Run setData or setDataAndType depending on what was passed into the method
+    //   This allows opening market links or external players using the same method
+    if (dataType.size())
+    {
+      // Java equivalent for the following JNI
+      //   oIntent.setDataAndType(oUri, "video/*");
+      jmethodID midIntentSetDataAndType = env->GetMethodID(cIntent, "setDataAndType", "(Landroid/net/Uri;Ljava/lang/String;)Landroid/content/Intent;");
+      jstring sMimeType = env->NewStringUTF(dataType.c_str());
+      oIntent = env->CallObjectMethod(oIntent, midIntentSetDataAndType, oUri, sMimeType);
+      env->DeleteLocalRef(sMimeType);
+    }
+    else 
+    {
+      // Java equivalent for the following JNI
+      //   oIntent.setData(oUri);
+      jmethodID midIntentSetData = env->GetMethodID(cIntent, "setData", "(Landroid/net/Uri;)Landroid/content/Intent;");
+      oIntent = env->CallObjectMethod(oIntent, midIntentSetData, oUri);
+    }
+  }
+  
+  // Java equivalent for the following JNI
+  //   oIntent.setPackage(sPackage);
+  jstring sPackage = env->NewStringUTF(package.c_str());
+  jmethodID mSetPackage = env->GetMethodID(cIntent, "setPackage", "(Ljava/lang/String;)Landroid/content/Intent;");
+  oIntent = env->CallObjectMethod(oIntent, mSetPackage, sPackage);
+
+  if (oUri != NULL)
+  {
+    env->DeleteLocalRef(oUri);
+  }
+  env->DeleteLocalRef(cIntent);
+  env->DeleteLocalRef(sPackage);
+ 
+  // Java equivalent for the following JNI
+  //   startActivity(oIntent);
   jmethodID mStartActivity = env->GetMethodID(cActivity, "startActivity", "(Landroid/content/Intent;)V");
-  env->CallVoidMethod(oActivity, mStartActivity, oPackageIntent);
+  env->CallVoidMethod(oActivity, mStartActivity, oIntent);
   env->DeleteLocalRef(cActivity);
-  env->DeleteLocalRef(oPackageIntent);
+  env->DeleteLocalRef(oIntent);
 
   exc = env->ExceptionOccurred();
   if (exc)

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -83,7 +83,7 @@ public:
   static int android_printf(const char *format, ...);
   
   static int GetBatteryLevel();
-  static bool StartActivity(const std::string &package);
+  static bool StartActivity(const std::string &package, const std::string &intent = std::string(), const std::string &dataType = std::string(), const std::string &dataURI = std::string());
   static bool ListApplications(std::vector <androidPackage> *applications);
   static bool GetIconSize(const std::string &packageName, int *width, int *height);
   static bool GetIcon(const std::string &packageName, void* buffer, unsigned int bufSize); 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -98,6 +98,10 @@ using namespace ADDON;
 using namespace MEDIA_DETECT;
 #endif
 
+#if defined(TARGET_ANDROID)
+#include "xbmc/android/activity/XBMCApp.h"
+#endif
+
 typedef struct
 {
   const char* command;
@@ -216,6 +220,9 @@ const BUILT_IN commands[] = {
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
   { "StartPVRManager",            false,  "(Re)Starts the PVR manager" },
   { "StopPVRManager",             false,  "Stops the PVR manager" },
+#if defined(TARGET_ANDROID)
+  { "StartActivity",              true,   "Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI." },
+#endif
 };
 
 bool CBuiltins::HasCommand(const CStdString& execString)
@@ -1637,6 +1644,36 @@ int CBuiltins::Execute(const CStdString& execString)
   {
     g_application.StopPVRManager();
   }
+#if defined(TARGET_ANDROID)
+  else if (execute.Equals("StartActivity") && params.size() > 0)
+  {
+    bool ret = false;
+
+    std::string package = params[0];
+    std::string intent = "";
+    std::string dataType = "";
+    std::string dataURI = "";
+
+    if (params.size() >=2)
+    {
+      intent = params[1];
+    }
+    if (params.size() >= 3)
+    {
+      dataType = params[2];
+    }
+    if (params.size() >= 4)
+    {
+      dataURI = params[3];
+    }
+    ret = CXBMCApp::StartActivity(package, intent, dataType, dataURI);
+    
+    if (!ret)
+    {
+      CLog::Log(LOGERROR, "Error launching activity: %s with intent: '%s' dataType: '%s' dataURI: '%s'", package.c_str(), intent.c_str(), dataType.c_str(), dataURI.c_str());
+    }
+  }
+#endif
   else
     return -1;
   return 0;


### PR DESCRIPTION
Add a "StartActivity" built-in to the add-on system that allows launching of android application.  This includes a way to set the data type and uri which allows add-on authors more flexibility than the current PlayMedia method of launching an android application.
