### PR TITLE
VampireAE fixes, mmm'kay

### DIFF
--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -21,6 +21,7 @@
 #include "system.h"
 #include "PowerManager.h"
 #include "Application.h"
+#include "cores/AudioEngine/AEFactory.h"
 #include "input/KeyboardStat.h"
 #include "settings/GUISettings.h"
 #include "windowing/WindowingFactory.h"
@@ -206,6 +207,7 @@ void CPowerManager::OnSleep()
   g_application.StopPlaying();
   g_application.StopShutdownTimer();
   g_application.StopScreenSaverTimer();
+  CAEFactory::Suspend();
 }
 
 void CPowerManager::OnWake()
@@ -245,6 +247,7 @@ void CPowerManager::OnWake()
   g_lcd->Initialize();
 #endif
 
+  CAEFactory::Resume();
   g_application.UpdateLibraries();
   g_weatherManager.Refresh();
 


### PR DESCRIPTION
Several fixes here.

1) fixed if internal player has suspended AE and supports volume changes
2) really suspend/resume alsa
3) sleep a little in CSoftAE::ProcessSuspend so we don't suck the life out of devices
4) suspend/resume AE when we actually suspend/resume, d'uh.

This is an attempt to resolve the linux suspend/resume Frodo Blocker.
