### PR TITLE
[fix] make sure we actually stop the service addon before upgrading it

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -556,7 +556,9 @@ bool CAddonInstallJob::OnPreInstall()
 
   if (m_addon->Type() == ADDON_SERVICE)
   {
-    boost::shared_ptr<CService> service = boost::dynamic_pointer_cast<CService>(m_addon);
+    AddonPtr addon;
+    ADDON::CAddonMgr::Get().GetAddon(m_addon->ID(), addon);
+    boost::shared_ptr<CService> service = boost::dynamic_pointer_cast<CService>(addon);
     if (service)
       service->Stop();
     return true;


### PR DESCRIPTION
this is a fix to make sure we actually stop service addons before we update them.

currently we attempt to stop the addon that is in a zip and fail miserably as we cannot find that addon path in database, after install we start the new one and endup with 2 versions of the same addon running.

what happens now is that addon id from zip is used to find the actual installed addon and stop it, install the newer version and start it again.

@ronie if you could test please, I think its a FIX for Frodo
