### PR TITLE
builtins: pass arguments of RunAddon() to ActivateWindow() (fixes JSON-RPC's Addons.ExecuteAddon)

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -566,14 +566,26 @@ int CBuiltins::Execute(const CStdString& execString)
         CStdString cmd;
         if (plugin && addon->Type() == ADDON_PLUGIN)
         {
+          CStdString addonid = params[0];
+          CStdString urlParameters;
+          CStdStringArray parameters;
+          if (params.size() == 2 &&
+             (StringUtils::StartsWith(params[1], "/") || StringUtils::StartsWith(params[1], "?")))
+            urlParameters = params[1];
+          else if (params.size() > 1)
+          {
+            parameters.insert(parameters.begin(), params.begin() + 1, params.end());
+            urlParameters = "?" + StringUtils::JoinString(parameters, "&");
+          }
+
           if (plugin->Provides(CPluginSource::VIDEO))
-            cmd.Format("ActivateWindow(Video,plugin://%s,return)",params[0]);
+            cmd.Format("ActivateWindow(Video,plugin://%s%s,return)", addonid, urlParameters);
           else if (plugin->Provides(CPluginSource::AUDIO))
-            cmd.Format("ActivateWindow(Music,plugin://%s,return)",params[0]);
+            cmd.Format("ActivateWindow(Music,plugin://%s%s,return)", addonid, urlParameters);
           else if (plugin->Provides(CPluginSource::EXECUTABLE))
-            cmd.Format("ActivateWindow(Programs,plugin://%s,return)",params[0]);
+            cmd.Format("ActivateWindow(Programs,plugin://%s%s,return)", addonid, urlParameters);
           else if (plugin->Provides(CPluginSource::IMAGE))
-            cmd.Format("ActivateWindow(Pictures,plugin://%s,return)",params[0]);
+            cmd.Format("ActivateWindow(Pictures,plugin://%s%s,return)", addonid, urlParameters);
           else
             // Pass the script name (params[0]) and all the parameters
             // (params[1] ... params[x]) separated by a comma to RunPlugin

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -186,6 +186,11 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const CStdString &method, ITransp
       argv += StringUtils::Paramify(it->asString());
     }
   }
+  else if (params.isString())
+  {
+    if (!params.empty())
+      argv = StringUtils::Paramify(params.asString());
+  }
   
   CStdString cmd;
   if (params.size() == 0)

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.12.0";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.12.1";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -3019,8 +3019,10 @@ namespace JSONRPC
         "{ \"name\": \"addonid\", \"type\": \"string\", \"required\": true },"
         "{ \"name\": \"params\", \"type\": ["
             "{ \"type\": \"object\", \"additionalProperties\": { \"type\": \"string\" } },"
-            "{ \"type\": \"array\", \"items\": { \"type\": \"string\" } }"
-          "]"
+            "{ \"type\": \"array\", \"items\": { \"type\": \"string\" } },"
+            "{ \"type\": \"string\", \"description\": \"URL path (must start with / or ?\" }"
+          "],"
+          "\"default\": \"\""
         "},"
         "{ \"name\": \"wait\", \"type\": \"boolean\", \"default\": false }"
       "],"

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -1626,8 +1626,10 @@
       { "name": "addonid", "type": "string", "required": true },
       { "name": "params", "type": [
           { "type": "object", "additionalProperties": { "type": "string" } },
-          { "type": "array", "items": { "type": "string" } }
-        ]
+          { "type": "array", "items": { "type": "string" } },
+          { "type": "string", "description": "URL path (must start with / or ?" }
+        ],
+        "default": ""
       },
       { "name": "wait", "type": "boolean", "default": false }
     ],


### PR DESCRIPTION
This makes sure to pass on any parameters provided in the call to the RunAddon() builtin function on to any resulting ActivateWindow() call and therefore to the plugin being executed. We already pass on the parameters for any non-media addons.

This fixes a bug reported in the forum when using JSON-RPC's Addons.ExecuteAddon on a video or music addon with specific parameters (e.g. to jump to a specific section of the youtube plugin).
