### PR TITLE
add maxScroll method for xbmcgui.ControlTextBox

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -306,6 +306,11 @@ void CGUITextBox::Scroll(unsigned int offset)
   ScrollToOffset(offset);
 }
 
+unsigned int CGUITextBox::MaxScroll() const
+{
+  return m_lines.size() > m_itemsPerPage ? m_lines.size() - m_itemsPerPage : 0;
+}
+
 void CGUITextBox::ScrollToOffset(int offset, bool autoScroll)
 {
   m_scrollOffset = m_offset * m_itemHeight;

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -62,6 +62,7 @@ public:
   CStdString GetLabel(int info) const;
 
   void Scroll(unsigned int offset);
+  unsigned int MaxScroll() const;
 
 protected:
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -155,6 +155,11 @@ namespace XBMCAddon
       static_cast<CGUITextBox*>(pGUIControl)->Scroll((int)position);
     }
 
+    long ControlTextBox::size() throw (UnimplementedException)
+    {
+      return static_cast<CGUITextBox*>(pGUIControl)->GetRows();
+    }
+
     CGUIControl* ControlTextBox::Create() throw (WindowException)
     {
       // create textbox

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -122,6 +122,7 @@ namespace XBMCAddon
       virtual void setColorDiffuse(const char* hexString) DECL_UNIMP("Control");
       virtual void selectItem(long item) DECL_UNIMP("Control");
       virtual void scroll(long id) DECL_UNIMP("Control");
+      virtual long maxScroll() DECL_UNIMP("Control");
       virtual bool isSelected() DECL_UNIMP("Control");
       virtual Control* getSpinControl() DECL_UNIMP("Control");
       virtual long getSpace() DECL_UNIMP("Control");
@@ -937,7 +938,7 @@ namespace XBMCAddon
 
       // scroll() Method
       /**
-       * scroll(position) -- Scrolls to the given position.
+       * scroll(position) -- Scrolls to the given position (row).
        * 
        * id           : integer - position to scroll to.
        * 
@@ -945,6 +946,15 @@ namespace XBMCAddon
        *   - self.textbox.scroll(10)
        */
       virtual void scroll(long id) throw(UnimplementedException);
+
+      // maxScroll() method
+      /**
+       * maxScroll() -- Returns the max offset which can be scroll to.
+       * 
+       * example:
+       *   - self.textbox.scroll(self.textbox.maxScroll()) # scroll to end
+       */
+      virtual long maxScroll() throw (UnimplementedException);
 
 #ifndef SWIG
       std::string strFont;


### PR DESCRIPTION
xbmcgui.ControlTextBox has method scroll(offset), but which does not supply method to figure out the max scroll-able offset, so codes using ControlTextBox won't do a good scroll work if it scroll too much it will looks the page can not be scroll down or up anymore, because it scroll too much, until user scroll up as many as which scroll over, it can get the scroll function back.

anyway, this commit try to add a method to get the max scroll-able offset of the textbox (with the current text content set), the result value can be used to prevent from scroll over the text end.

I can not compile xbmc, so please test it before merge to main branch.
