### PR TITLE
[AE/CA] - implement the advancedsetting for streamsilence

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -172,4 +172,6 @@ private:
   int               m_soundMode;
   bool              m_streamsPlaying;
   bool              m_isSuspended;
+  bool              m_softSuspend;
+  unsigned int      m_softSuspendTimer;
 };


### PR DESCRIPTION
This is the implementation for obeying the streamsilence flag from advancedsettings.xml. Its something like softae does. Basically when the streamsilence flag is deactivated via advancedsettings.xml we will close the ca device after 10 secs of no sound/stream is playing.

This is important as of lion - because since lion opening an even shared ca device will hold an preventidlesleep assertion in the os powermanagement. This means even when running XBMC windowed the idle sleep from the os is not able to kick in because we have the ca device open.

When streamsilence is disabled we stop the hal - which leads to the release of the assertion from coreaudiod. I have tested this on 10.7.5 and on 10.8.2 and was not able to break sound with this (means either gui sounds or a new stream just instantly wakes up the device and plays as usual) - even my amp keeps the audio lock during idle suspend.

Not sure if we want this for frodo - but the commit i did before

e5ceca9ad000e687a96638a57f30e3fc2788b84a

should only be backported when this PR goes in aswell (else it doesn't fix anything because coreaudiod is still preventing the sleep).
