### PR TITLE
Add key mapping for the power button

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -94,6 +94,7 @@
       <backslash>ToggleFullScreen</backslash>
       <home>FirstPage</home>
       <end>LastPage</end>
+      <power>XBMC.ShutDown()</power>
       <!-- PVR windows -->
       <e>XBMC.ActivateWindowAndFocus(MyPVR, 31,0, 10,0)</e>
       <h>XBMC.ActivateWindowAndFocus(MyPVR, 32,0, 11,0)</h>


### PR DESCRIPTION
On Ubuntu (I haven't tested other varients of Linux) pressing the power button while XBMC is fullscreen sends a <power> keypress. At the moment keyboard.xml has no mapping for this keypress, so this commit adds a mapping to XBMC.Shutdown.

NB in XBMCBuntu the power button already shuts down the system. It's possible this mapping could interfere with this, but I have no way of testing this.

See http://trac.xbmc.org/ticket/10004 for the original problem report.
