### PR TITLE
Add support for the power and sleep buttons

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -94,7 +94,8 @@
       <backslash>ToggleFullScreen</backslash>
       <home>FirstPage</home>
       <end>LastPage</end>
-      <power>XBMC.ShutDown()</power>
+      <power>ActivateWindow(shutdownmenu)</power>
+      <sleep>ActivateWindow(shutdownmenu)</sleep>
       <!-- PVR windows -->
       <e>XBMC.ActivateWindowAndFocus(MyPVR, 31,0, 10,0)</e>
       <h>XBMC.ActivateWindowAndFocus(MyPVR, 32,0, 11,0)</h>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -94,6 +94,7 @@
       <backslash>ToggleFullScreen</backslash>
       <home>FirstPage</home>
       <end>LastPage</end>
+      <power>XBMC.ShutDown()</power>
       <!-- PVR windows -->
       <e>XBMC.ActivateWindowAndFocus(MyPVR, 31,0, 10,0)</e>
       <h>XBMC.ActivateWindowAndFocus(MyPVR, 32,0, 11,0)</h>

--- a/system/keymaps/nyxboard/keyboard.xml
+++ b/system/keymaps/nyxboard/keyboard.xml
@@ -8,7 +8,7 @@
       <f4 mod="shift">ActivateWindow(music)</f4>    <!-- Green -->
       <f5 mod="shift">ActivateWindow(pictures)</f5> <!-- Yellow -->
       <f6 mod="shift">ActivateWindow(programs)</f6> <!-- Blue -->
-      <key id='285'>ContextMenu</key>                    <!-- User button -->
+      <f4>ContextMenu</f4>                          <!-- User button -->
     </keyboard>
   </global>
 </keymap>

--- a/system/keymaps/nyxboard/keyboard.xml
+++ b/system/keymaps/nyxboard/keyboard.xml
@@ -8,7 +8,6 @@
       <f4 mod="shift">ActivateWindow(music)</f4>    <!-- Green -->
       <f5 mod="shift">ActivateWindow(pictures)</f5> <!-- Yellow -->
       <f6 mod="shift">ActivateWindow(programs)</f6> <!-- Blue -->
-      <key id='61952'>ActivateWindow(shutdownmenu)</key> <!-- Power button -->
       <key id='285'>ContextMenu</key>                    <!-- User button -->
     </keyboard>
   </global>

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -214,6 +214,7 @@ typedef enum {
   XBMCK_POWER       = 0x140,    // Power Macintosh power key
   XBMCK_EURO        = 0x141,    // Some european keyboards
   XBMCK_UNDO        = 0x142,    // Atari keyboard has Undo
+  XBMCK_SLEEP       = 0x143,    // Sleep button on Nyxboard remote (and others?)
 
   // Add any other keys here
 

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -222,6 +222,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_SCROLLOCK,              0,    0, XBMCVK_SCROLLLOCK,    "scrolllock" }
 , { XBMCK_PRINT,                  0,    0, XBMCVK_PRINTSCREEN,   "printscreen" }
 , { XBMCK_POWER,                  0,    0, XBMCVK_POWER,         "power" }
+, { XBMCK_SLEEP,                  0,    0, XBMCVK_SLEEP,         "sleep" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -205,6 +205,7 @@ typedef enum {
   XBMCVK_SCROLLLOCK     = 0xDC,
   XBMCVK_PAUSE          = 0XDD,
   XBMCVK_POWER          = 0XDE,
+  XBMCVK_SLEEP          = 0XDF,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -69,7 +69,7 @@ static uint16_t SymMappingsEvdev[][2] =
 , { 138, 0x69 /* 'i' */}             // Info
 , { 147, 0x6d /* 'm' */}             // Menu
 , { 148, XBMCK_LAUNCH_APP2 }         // Launch app 2
-, { 150, 0x9f }                      // Sleep
+, { 150, XBMCK_SLEEP }               // Sleep
 , { 152, XBMCK_LAUNCH_APP1 }         // Launch app 1
 , { 163, XBMCK_LAUNCH_MAIL }         // Launch Mail
 , { 164, XBMCK_BROWSER_FAVORITES }   // Browser favorites


### PR DESCRIPTION
This applies to Linux (and presumably OSX):

The power button was already handled but there was no mapping for it in keyboard.xml. The sleep button on the Nyxboard remote (and presumably others) was not handled. This commit addresses both issues.

All this SDL nonsense will be gone when we merge elupus and FernetMenta's changes, but for Frodo we still need to patch up keys not properly handled by SDL.
