### PR TITLE
[CoreAudioAE] Fix CFString copy function in CCoreAudioHardware::GetOutputDeviceName

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
@@ -329,7 +329,7 @@ void CCoreAudioHardware::GetOutputDeviceName(std::string& name)
     if (ret != noErr)
       return;
 
-    const char *cstr = CFStringGetCStringPtr(theDeviceName, kCFStringEncodingUTF8);
+    const char *cstr = CFStringGetCStringPtr(theDeviceName, CFStringGetSystemEncoding());
     if (cstr)
       name = cstr;
     CFRelease(theDeviceName);


### PR DESCRIPTION
Using UTF8 encoding might fail and return NULL. Instead we pass
CFStringGetSystemEncoding().
