### PR TITLE
[osx] check if hogPid was set before resetting it

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioDevice.cpp
@@ -361,7 +361,8 @@ bool CCoreAudioDevice::SetHogStatus(bool hog)
       // even if setting hogmode was successfull our PID might not get written
       // into m_HogPid (so it stays -1). Readback hogstatus for judging if we
       // had success on getting hog status
-      m_HogPid = GetHogStatus();
+      if (m_HogPid == -1)
+        m_HogPid = GetHogStatus();
 
       if (ret || m_HogPid != getpid())
       {


### PR DESCRIPTION
@Memphiz I found it :)

I am not sure if its a placebo effect or not, but my build is stable now ... issues are always when switching from DTS/AC3 video to divx with mp3.

Its not always reproducible on my macmini(on MBP I can never repro it), I think its the race that we set new hogpid but its not correct. check for -1 and if true try to reset cant do any harm.
