### PR TITLE
[rbp] Fix for audio out of sync part 2

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -805,6 +805,8 @@ unsigned int COMXAudio::AddPackets(const void* data, unsigned int len, double dt
     if(m_av_clock->AudioStart())
     {
       omx_buffer->nFlags = OMX_BUFFERFLAG_STARTTIME;
+      if(pts == DVD_NOPTS_VALUE)
+        omx_buffer->nFlags |= OMX_BUFFERFLAG_TIME_UNKNOWN;
 
       m_last_pts = pts;
 

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -90,7 +90,7 @@ protected:
   bool              m_deinterlace;
   bool              m_hdmi_clock_sync;
   bool              m_first_frame;
-  bool              m_contains_valid_pts;
+  uint32_t          m_history_valid_pts;
 
   bool NaluFormatStartCodes(enum CodecID codec, uint8_t *in_extradata, int in_extrasize);
 };


### PR DESCRIPTION
Fix for this problem:
http://forum.stmlabs.com/showthread.php?tid=5629&pid=48268#pid48268

Basically we assume that packed b frame avi files have no pts timestamps and we should use dts. To distinguish these types of files from other files with occasional missing timestamps (e.g. B frames in ts file) we flag whether we've ever seen a valid pts.

The linked file has about six valid pts values spread through the file. Not sure why. They always equal the dts.

This patch assumes the B frames case will have at least 4 valid timestamps in last 16, and if less than that, then it is the sporadic pts case.
