### PR TITLE
[OSX] Remove all direct calls to CFStringGetCString and CFStringGetCStringPtr

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
@@ -22,6 +22,7 @@
 
 #include "CoreAudioAEHAL.h"
 #include "utils/log.h"
+#include "osx/DarwinUtils.h"
 
 bool CCoreAudioHardware::GetAutoHogMode()
 {
@@ -329,9 +330,8 @@ void CCoreAudioHardware::GetOutputDeviceName(std::string& name)
     if (ret != noErr)
       return;
 
-    const char *cstr = CFStringGetCStringPtr(theDeviceName, CFStringGetSystemEncoding());
-    if (cstr)
-      name = cstr;
+    DarwinCFStringRefToString(theDeviceName, name);
+
     CFRelease(theDeviceName);
   }
 }

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -22,6 +22,11 @@
 
 #include <string>
 
+// We forward declare CFStringRef in order to avoid
+// pulling in tons of Objective-C headers.
+struct __CFString;
+typedef const struct __CFString * CFStringRef;
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -35,6 +40,7 @@ extern "C"
   bool        DarwinHasVideoToolboxDecoder(void);
   int         DarwinBatteryLevel(void);
   void        DarwinSetScheduling(int message);
+  bool        DarwinCFStringRefToString(CFStringRef source, std::string& destination);
 #ifdef __cplusplus
 }
 #endif

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -35,6 +35,7 @@
   #import <sys/sysctl.h>
 #else
   #import <Cocoa/Cocoa.h>
+  #import <CoreFoundation/CoreFoundation.h>
   #import <IOKit/ps/IOPowerSources.h>
   #import <IOKit/ps/IOPSKeys.h>
 #endif
@@ -314,6 +315,34 @@ void DarwinSetScheduling(int message)
     THREAD_EXTENDED_POLICY_COUNT);
 
   result = pthread_setschedparam(this_pthread_self, policy, &param );
+}
+
+bool DarwinCFStringRefToString(CFStringRef source, std::string &destination)
+{
+  const char *cstr = CFStringGetCStringPtr(source, CFStringGetSystemEncoding());
+  if (!cstr)
+  {
+    CFIndex strLen = CFStringGetMaximumSizeForEncoding(CFStringGetLength(source) + 1,
+                                                       CFStringGetSystemEncoding());
+    char *allocStr = (char*)malloc(strLen);
+
+    if(!allocStr)
+      return false;
+
+    if(!CFStringGetCString(source, allocStr, strLen, CFStringGetSystemEncoding()))
+    {
+      free((void*)allocStr);
+      return false;
+    }
+
+    destination = allocStr;
+    free((void*)allocStr);
+
+    return true;
+  }
+
+  destination = cstr;
+  return true;
 }
 
 #endif

--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
@@ -21,6 +21,7 @@
 #include "PeripheralBusUSB.h"
 #include "peripherals/Peripherals.h"
 #include "utils/log.h"
+#include "osx/DarwinUtils.h"
 
 #include <sys/param.h>
 
@@ -224,7 +225,7 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
       result = (*interfaceInterface)->GetInterfaceClass(interfaceInterface, &bInterfaceClass);
       if (bInterfaceClass == kUSBHIDInterfaceClass || bInterfaceClass == kUSBCommunicationDataInterfaceClass)
       {
-        char ttlDeviceFilePath[MAXPATHLEN] = {0};
+        std::string ttlDeviceFilePath;
         CFStringRef deviceFilePathAsCFString;
         USBDevicePrivateData *privateDataRef;
         privateDataRef = new USBDevicePrivateData;
@@ -248,16 +249,16 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
               kIOServicePlane, CFSTR(kIOCalloutDeviceKey), kCFAllocatorDefault, kIORegistryIterateRecursively);
             if (deviceFilePathAsCFString)
             {
-              // Convert the path from a CFString to a NULL-terminated C string
-              CFStringGetCString((CFStringRef)deviceFilePathAsCFString,
-                ttlDeviceFilePath, MAXPATHLEN - 1, kCFStringEncodingASCII);
+              // Convert the path from a CFString to a std::string
+              if (!DarwinCFStringRefToString(deviceFilePathAsCFString, ttlDeviceFilePath))
+                CLog::Log(LOGWARNING, "CPeripheralBusUSB::DeviceAttachCallback failed to convert CFStringRef");
               CFRelease(deviceFilePathAsCFString);
             }
             IOObjectRelease(parent);
           }
         }
-        if (strlen(ttlDeviceFilePath))
-          privateDataRef->result.m_strLocation.Format("%s", ttlDeviceFilePath);
+        if (!ttlDeviceFilePath.empty())
+          privateDataRef->result.m_strLocation.Format("%s", ttlDeviceFilePath.c_str());
         else
           privateDataRef->result.m_strLocation.Format("%d", locationId);
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -36,6 +36,7 @@
 #include "osx/XBMCHelper.h"
 #include "utils/SystemInfo.h"
 #include "osx/CocoaInterface.h"
+#include "osx/DarwinUtils.h"
 #undef BOOL
 
 #import <SDL/SDL_video.h>
@@ -1358,8 +1359,9 @@ bool CWinSystemOSX::IsObscured(void)
         // if the windowBounds completely encloses our bounds, we are obscured.
         if (!obscureLogged)
         {
-          const char* cstr = CFStringGetCStringPtr(ownerName, CFStringGetSystemEncoding());
-          CLog::Log(LOGDEBUG, "WinSystemOSX: Fullscreen window %s obscures XBMC!", cstr);
+          std::string appName;
+          if (DarwinCFStringRefToString(ownerName, appName))
+            CLog::Log(LOGDEBUG, "WinSystemOSX: Fullscreen window %s obscures XBMC!", appName.c_str());
           obscureLogged = true;
         }
         m_obscured = true;


### PR DESCRIPTION
This adds a new util function DarwinCFStringToString that handles errors
and tries to first get the pointer otherwise copies the string into a
std::string. It also makes sure to use CFStringGetSystemEncoding()
everywhere so we don't get in trouble for using a hardcoded encoding.
