### PR TITLE
[OSX] Remove unused function Cocoa_GetAppVersion()

### DIFF
--- a/xbmc/osx/CocoaInterface.h
+++ b/xbmc/osx/CocoaInterface.h
@@ -57,7 +57,6 @@ extern "C"
 
   // Version.
   //
-  const char* Cocoa_GetAppVersion();
   bool Cocoa_HasVDADecoder();
   bool Cocoa_GPUForDisplayIsNvidiaPureVideo3();
   int Cocoa_GetOSVersion();

--- a/xbmc/osx/CocoaInterface.mm
+++ b/xbmc/osx/CocoaInterface.mm
@@ -373,31 +373,6 @@ void Cocoa_ShowMouse()
 }
 
 //---------------------------------------------------------------------------------
-static char strVersion[32];
-
-const char* Cocoa_GetAppVersion()
-{
-  // Get the main bundle for the app and return the version.
-  CFBundleRef mainBundle = CFBundleGetMainBundle();
-  CFStringRef versStr = (CFStringRef)CFBundleGetValueForInfoDictionaryKey(mainBundle, kCFBundleVersionKey);
-  
-  memset(strVersion,0,32);
-  
-  if (versStr != NULL && CFGetTypeID(versStr) == CFStringGetTypeID())
-  {
-    bool res = CFStringGetCString(versStr, strVersion, 32,kCFStringEncodingUTF8);
-    if (!res)
-    {
-      printf("Error converting version string\n");      
-      strcpy(strVersion, "SVN");
-    }
-  }
-  else
-    strcpy(strVersion, "SVN");
-  
-  return strVersion;
-}
-
 bool Cocoa_HasVDADecoder()
 {
   static int result = -1;


### PR DESCRIPTION
When cleaning out the CFStringGetCString references I noticed that
this function isn't used anywhere. So instead of changing it, I rather
just remove it.
