### PR TITLE
video: add a default frame latency of 1 frame

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -112,6 +112,7 @@ void CAdvancedSettings::Initialize()
   m_DXVANoDeintProcForProgressive = false;
   m_videoFpsDetect = 1;
   m_videoDefaultLatency = 0.0;
+  m_videoFrameLatency = 1;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -625,6 +626,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
 
       // Get default global display latency
       XMLUtils::GetFloat(pVideoLatency, "delay", m_videoDefaultLatency, -600.0f, 600.0f);
+      XMLUtils::GetInt(pVideoLatency, "frames", m_videoFrameLatency, -60, 60);
     }
   }
 
@@ -1195,6 +1197,8 @@ void CAdvancedSettings::AddSettingsFile(const CStdString &filename)
 float CAdvancedSettings::GetDisplayLatency(float refreshrate)
 {
   float delay = m_videoDefaultLatency / 1000.0f;
+  if(refreshrate)
+    delay += m_videoFrameLatency / refreshrate;
   for (int i = 0; i < (int) m_videoRefreshLatency.size(); i++)
   {
     RefreshVideoLatency& videolatency = m_videoRefreshLatency[i];

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -157,6 +157,7 @@ class CAdvancedSettings
     std::vector<RefreshOverride> m_videoAdjustRefreshOverrides;
     std::vector<RefreshVideoLatency> m_videoRefreshLatency;
     float m_videoDefaultLatency;
+    int   m_videoFrameLatency;
     bool m_videoDisableBackgroundDeinterlace;
     int  m_videoCaptureUseOcclusionQuery;
     bool m_DXVACheckCompatibility;


### PR DESCRIPTION
This is configureable in adancedsettings under video/latency/frames.
The default value should correspond to a A/V delay of -16ms at 60 hz
and -41ms at 24hz

Most video output will be counting it's delay in times of frames, not
in absolute time. Any advanced frame processing on normal TV's will
at least incure a 1 frame delay.
