### PR TITLE
Trivial changes to improve libav support in xbmc

### DIFF
--- a/lib/DllAvFormat.h
+++ b/lib/DllAvFormat.h
@@ -62,7 +62,6 @@ public:
   virtual ~DllAvFormatInterface() {}
   virtual void av_register_all_dont_call(void)=0;
   virtual AVInputFormat *av_find_input_format(const char *short_name)=0;
-  virtual int url_feof(AVIOContext *s)=0;
   virtual void avformat_close_input(AVFormatContext **s)=0;
   virtual int av_read_frame(AVFormatContext *s, AVPacket *pkt)=0;
   virtual void av_read_frame_flush(AVFormatContext *s)=0;
@@ -114,7 +113,6 @@ public:
   } 
   virtual void av_register_all_dont_call() { *(volatile int* )0x0 = 0; } 
   virtual AVInputFormat *av_find_input_format(const char *short_name) { return ::av_find_input_format(short_name); }
-  virtual int url_feof(AVIOContext *s) { return ::url_feof(s); }
   virtual void avformat_close_input(AVFormatContext **s) { ::avformat_close_input(s); }
   virtual int av_read_frame(AVFormatContext *s, AVPacket *pkt) { return ::av_read_frame(s, pkt); }
   virtual void av_read_frame_flush(AVFormatContext *s) { ::av_read_frame_flush(s); }
@@ -175,7 +173,6 @@ class DllAvFormat : public DllDynamic, DllAvFormatInterface
 
   DEFINE_METHOD0(void, av_register_all_dont_call)
   DEFINE_METHOD1(AVInputFormat*, av_find_input_format, (const char *p1))
-  DEFINE_METHOD1(int, url_feof, (AVIOContext *p1))
   DEFINE_METHOD1(void, avformat_close_input, (AVFormatContext **p1))
   DEFINE_METHOD1(int, av_read_play, (AVFormatContext *p1))
   DEFINE_METHOD1(int, av_read_pause, (AVFormatContext *p1))
@@ -212,7 +209,6 @@ class DllAvFormat : public DllDynamic, DllAvFormatInterface
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(av_register_all, av_register_all_dont_call)
     RESOLVE_METHOD(av_find_input_format)
-    RESOLVE_METHOD(url_feof)
     RESOLVE_METHOD(avformat_close_input)
     RESOLVE_METHOD(av_read_frame)
     RESOLVE_METHOD(av_read_play)

--- a/lib/DllSwResample.h
+++ b/lib/DllSwResample.h
@@ -113,7 +113,7 @@ public:
   }
   virtual int swr_init(struct SwrContext *s) { return ::avresample_open(s); }
   virtual void swr_free(struct SwrContext **s){ ::avresample_close(*s); *s = NULL; }
-  virtual int swr_convert(struct SwrContext *s, uint8_t **out, int out_count, const uint8_t **in , int in_count){ return ::avresample_convert(s, (void**)out, 0, out_count, (void**)in, 0,in_count); }
+  virtual int swr_convert(struct SwrContext *s, uint8_t **out, int out_count, const uint8_t **in , int in_count){ return ::avresample_convert(s, out, 0, out_count, (uint8_t**)in, 0,in_count); }
 };
 #endif
 


### PR DESCRIPTION
These are the trivial changes to improve libav support in xbmc: This is not sufficient as libavfilter is very different between FFmpeg and libav. I will ask for help on this, meanwhile these two commits should be harmless and help.
