### PR TITLE
add DVDVideoCodec::SetSpeed

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -192,6 +192,12 @@ public:
   virtual void SetDropState(bool bDrop) = 0;
 
   /*
+   * will be called by video player indicating the playback speed. see DVD_PLAYSPEED_NORMAL,
+   * DVD_PLAYSPEED_PAUSE and friends.
+   */
+  virtual void SetSpeed(int iSpeed) {};
+
+  /*
    * returns the number of demuxer bytes in any internal buffers
    */
   virtual int GetDataSize(void)

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -465,6 +465,8 @@ void CDVDPlayerVideo::Process()
       m_speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
       if(m_speed == DVD_PLAYSPEED_PAUSE)
         m_iNrOfPicturesNotToSkip = 0;
+      if (m_pVideoCodec)
+        m_pVideoCodec->SetSpeed(m_speed);
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_STARTED))
     {


### PR DESCRIPTION
Permit video codecs to know when we are doing play, pause or ff/rw. This allows hardware codecs to use various trick modes and also to play/pause without having to drain internal buffers to empty.
