### PR TITLE
[AE/CA] - fix regression - re-add the default audio device

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
@@ -24,6 +24,7 @@
 
 #include "CoreAudioAEStream.h"
 #include "CoreAudioAESound.h"
+#include "CoreAudioHardware.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
@@ -53,7 +54,8 @@ CCoreAudioAE::CCoreAudioAE() :
   m_streamsPlaying     (false         ),
   m_isSuspended        (false         ),
   m_softSuspend        (false         ),
-  m_softSuspendTimer   (0             )
+  m_softSuspendTimer   (0             ),
+  m_currentAudioDevice (0             )
 {
   HAL = new CCoreAudioAEHAL;
 }
@@ -272,6 +274,11 @@ bool CCoreAudioAE::OpenCoreAudio(unsigned int sampleRate, bool forceRaw,
       (*itt)->Initialize();
     streamLock.Leave();
   }
+  
+  if (m_Initialized)
+  {
+    m_currentAudioDevice = CCoreAudioHardware::FindAudioDevice(m_outputDevice);
+  }
 
   return m_Initialized;
 }
@@ -429,6 +436,7 @@ CCoreAudioAEHAL* CCoreAudioAE::GetHAL()
 IAEStream* CCoreAudioAE::MakeStream(enum AEDataFormat dataFormat,
   unsigned int sampleRate, unsigned int encodedSamplerate, CAEChannelInfo channelLayout, unsigned int options)
 {
+  bool defaultDeviceChanged = false;
   // if we are suspended we don't
   // want anyone to mess with us
   if (m_isSuspended && !m_softSuspend)
@@ -443,6 +451,18 @@ IAEStream* CCoreAudioAE::MakeStream(enum AEDataFormat dataFormat,
   m_streams.push_back(stream);
   streamLock.Leave();
 
+  // check if default device has changed - in that case we need to reinit
+  // TODO hook into osx callbacks for getting notifiaction on device
+  // changes and then queue a change of the default device
+  // to a point where engine is idle.
+  std::string outputDevice = g_guiSettings.GetString("audiooutput.audiodevice");
+  if (outputDevice.compare("CoreAudio:default") == 0)
+  {
+    AudioDeviceID currentId = CCoreAudioHardware::FindAudioDevice("default");
+    if (currentId != m_currentAudioDevice)
+      defaultDeviceChanged = true;
+  }
+
   if ((options & AESTREAM_PAUSED) == 0)
     Stop();
 
@@ -450,7 +470,8 @@ IAEStream* CCoreAudioAE::MakeStream(enum AEDataFormat dataFormat,
   if (m_Initialized && ( m_lastStreamFormat != dataFormat ||
                          m_lastChLayoutCount != channelLayout.Count() ||
                          m_lastSampleRate != sampleRate ||
-                         COREAUDIO_IS_RAW(dataFormat)))
+                         COREAUDIO_IS_RAW(dataFormat) ||
+                         defaultDeviceChanged))
   {
     CSingleLock engineLock(m_engineLock);
     Stop();

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -174,4 +174,5 @@ private:
   bool              m_isSuspended;
   bool              m_softSuspend;
   unsigned int      m_softSuspendTimer;
+  AudioDeviceID     m_currentAudioDevice;
 };

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.cpp
@@ -396,8 +396,7 @@ void CCoreAudioAEHALOSX::EnumerateOutputDevices(AEDeviceList &devices, bool pass
   CoreAudioDeviceList deviceList;
   CCoreAudioHardware::GetOutputDevices(&deviceList);
 
-  std::string defaultDeviceName;
-  CCoreAudioHardware::GetOutputDeviceName(defaultDeviceName);
+  devices.push_back(AEDevice("Default", "CoreAudio:default"));
 
   std::string deviceName;
   for (int i = 0; !deviceList.empty(); i++)

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
@@ -292,22 +292,32 @@ AudioDeviceID CCoreAudioHardware::FindAudioDevice(const std::string &searchName)
 
 AudioDeviceID CCoreAudioHardware::GetDefaultOutputDevice()
 {
+  AudioDeviceID deviceId = 0;
+  static AudioDeviceID lastDeviceId = 0;
+
   AudioObjectPropertyAddress  propertyAddress;
   propertyAddress.mScope    = kAudioObjectPropertyScopeGlobal;
   propertyAddress.mElement  = kAudioObjectPropertyElementMaster;
   propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-
-  AudioDeviceID deviceId = 0;
+  
   UInt32 size = sizeof(AudioDeviceID);
   OSStatus ret = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, NULL, &size, &deviceId);
+
   // outputDevice is set to 0 if there is no audio device available
   // or if the default device is set to an encoded format
   if (ret != noErr || !deviceId) 
   {
     CLog::Log(LOGERROR, "CCoreAudioHardware::GetDefaultOutputDevice:"
       " Unable to identify default output device. Error = %s", GetError(ret).c_str());
-    return 0;
+    // if there was no error and no deviceId was returned
+    // return the last known default device
+    if (ret == noErr && !deviceId)
+      return lastDeviceId;
+    else
+      return 0;
   }
+  
+  lastDeviceId = deviceId;
 
   return deviceId;
 }


### PR DESCRIPTION
Since AE merge users are missing the ability to select "default" as audio device in osx. This uses the default device set by osx.

The first commit readds this feature and works already. Though i saw that osx sometimes doesn't return a valid audiodeviceid (but returns NOERR) - in that case the 2nd commit returns the last good known id.

Since we optimized the reinit (only reinit if something changed) we need the 3rd commit. If user selected "default" we check if the deviceid for the default device has changed in makestream (i added a todo comment for a future solution by os notifications).

All 3 commits restore the behaviour of Eden. As an example my test user plugs in a bluetooth headset during XBMC runtime. Now he just needs to start a movie (makestream gets called) for getting xbmc use it - since osx selects the headset as default output on plug&play.

I have verified that behaviour by utilising AirFoil which also adds a device during runtime.

Thx to TripKip for spending his evening for helping me testing and debugging this out.

@huceke comments?
@davilla too much code for frodo?
