### PR TITLE
[droid] Native volume control

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -335,6 +335,10 @@
 #include "input/SDLJoystick.h"
 #endif
 
+#if defined(TARGET_ANDROID)
+#include "android/activity/XBMCApp.h"
+#endif
+
 using namespace std;
 using namespace ADDON;
 using namespace XFILE;
@@ -2859,15 +2863,19 @@ bool CApplication::OnAction(const CAction &action)
       if (g_settings.m_bMute)
         UnMute();
       float volume = g_settings.m_fVolumeLevel;
+// Android has steps based on the max available volume level
+#if defined(TARGET_ANDROID)
+      float step = (VOLUME_MAXIMUM - VOLUME_MINIMUM) / CXBMCApp::GetMaxSystemVolume();
+#else
       float step   = (VOLUME_MAXIMUM - VOLUME_MINIMUM) / VOLUME_CONTROL_STEPS;
+
       if (action.GetRepeat())
         step *= action.GetRepeat() * 50; // 50 fps
-
+#endif
       if (action.GetID() == ACTION_VOLUME_UP)
         volume += (float)fabs(action.GetAmount()) * action.GetAmount() * step;
       else
         volume -= (float)fabs(action.GetAmount()) * action.GetAmount() * step;
-
       SetVolume(volume, false);
     }
     // show visual feedback of volume change...

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -87,6 +87,7 @@ public:
   static bool ListApplications(std::vector <androidPackage> *applications);
   static bool GetIconSize(const std::string &packageName, int *width, int *height);
   static bool GetIcon(const std::string &packageName, void* buffer, unsigned int bufSize); 
+
   /*!
    * \brief If external storage is available, it returns the path for the external storage (for the specified type)
    * \param path will contain the path of the external storage (for the specified type)
@@ -95,6 +96,7 @@ public:
    */
   static bool GetExternalStorage(std::string &path, const std::string &type = "");
   static bool GetStorageUsage(const std::string &path, std::string &usage);
+  static int GetMaxSystemVolume();
 
   static int GetDPI();
 protected:
@@ -106,6 +108,9 @@ protected:
   static int AttachCurrentThread(JNIEnv** p_env, void* thr_args = NULL);
   static int DetachCurrentThread();
 
+  static int GetMaxSystemVolume(JNIEnv *env);
+  static void SetSystemVolume(JNIEnv *env, float percent);
+
 private:
   static bool HasLaunchIntent(const std::string &package);
   bool getWakeLock(JNIEnv *env);
@@ -116,7 +121,6 @@ private:
 
   static ANativeActivity *m_activity;
   jobject m_wakeLock;
-  
   typedef enum {
     // XBMC_Initialize hasn't been executed yet
     Uninitialized,

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -228,9 +228,11 @@ bool CAESinkAUDIOTRACK::HasVolume()
   return true;
 }
 
-void  CAESinkAUDIOTRACK::SetVolume(float volume)
+void  CAESinkAUDIOTRACK::SetVolume(float scale)
 {
-  m_volume = volume;
+  // Android uses fixed steps, reverse scale back to percent
+  float gain = CAEUtil::ScaleToGain(scale);
+  m_volume = CAEUtil::GainToPercent(gain);
   m_volume_changed = true;
 }
 
@@ -273,7 +275,6 @@ void CAESinkAUDIOTRACK::Process()
   jmethodID jmRelease           = jenv->GetMethodID(jcAudioTrack, "release", "()V");
   jmethodID jmWrite             = jenv->GetMethodID(jcAudioTrack, "write", "([BII)I");
   jmethodID jmPlayState         = jenv->GetMethodID(jcAudioTrack, "getPlayState", "()I");
-  jmethodID jmSetStereoVolume   = jenv->GetMethodID(jcAudioTrack, "setStereoVolume", "(FF)I");
   jmethodID jmPlayHeadPosition  = jenv->GetMethodID(jcAudioTrack, "getPlaybackHeadPosition", "()I");
   jmethodID jmGetMinBufferSize  = jenv->GetStaticMethodID(jcAudioTrack, "getMinBufferSize", "(III)I");
 
@@ -322,8 +323,7 @@ void CAESinkAUDIOTRACK::Process()
     {
       // check of volume changes and make them,
       // do it here to keep jni calls local to this thread.
-      jfloat jvolume = m_volume;
-      jenv->CallIntMethod(joAudioTrack, jmSetStereoVolume, jvolume, jvolume);
+      CXBMCApp::SetSystemVolume(jenv, m_volume);
       m_volume_changed = false;
     }
     if (m_draining)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -42,7 +42,7 @@ public:
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio);
   virtual void         Drain           ();
   virtual bool         HasVolume       ();
-  virtual void         SetVolume       (float volume);
+  virtual void         SetVolume       (float scale);
   static void          EnumerateDevicesEx(AEDeviceInfoList &list);
 
 private:

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -71,6 +71,19 @@ public:
     return (value - 1)*db_range;
   }
 
+  /*! \brief convert a dB gain to volume percentage (as a proportion)
+   We assume a dB range of 60dB, i.e. assume that 0% volume corresponds
+   to a reduction of 60dB.
+   \param the corresponding gain in dB from -60dB .. 0dB.
+   \return value the volume from 0..1
+   \sa ScaleToGain
+   */
+  static inline const float GainToPercent(const float gain)
+  {
+    static const float db_range = 60.0f;
+    return 1+(gain/db_range);
+  }
+
   /*! \brief convert a dB gain to a scale factor for audio manipulation
    Inverts gain = 20 log_10(scale)
    \param dB the gain in decibels.
@@ -80,6 +93,17 @@ public:
   static inline const float GainToScale(const float dB)
   {
     return pow(10.0f, dB/20);
+  }
+
+  /*! \brief convert a scale factor to dB gain for audio manipulation
+   Inverts GainToScale result
+   \param the scale factor (equivalent to a voltage multiplier).
+   \return dB the gain in decibels.
+   \sa GainToScale
+   */
+  static inline const float ScaleToGain(const float scale)
+  {
+    return 20*log10(scale);
   }
 
   #ifdef __SSE__


### PR DESCRIPTION
Allow controlling native volume from within XBMC.  Option 2 in @jmarshallnz's comment below.

This PR started life as a way to auto-max the android volume when launching XBMC.
