### PR TITLE
[rbp] Don't consider half-SBS/TB 3D modes to have double the framerate

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -202,8 +202,6 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
   /*
    * For 3D modes the following is assumed :
    *
-   * fps is fps * 2 : 25 fps -> 50 fps
-   *
    * side-by-side :
    *
    * width is width / 2 : 1920 -> 960
@@ -227,12 +225,10 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
   if(m_iFlags & CONF_FLAGS_FORMAT_SBS)
   {
     iScreenWidth /= 2;
-    fRefreshRate *= 2;
   }
   else if(m_iFlags & CONF_FLAGS_FORMAT_TB)
   {
     iScreenHeight /= 2;
-    fRefreshRate *= 2;
   }
 
   float last_diff = fRefreshRate;


### PR DESCRIPTION
Fix for this bug report:
http://forum.xbmc.org/showthread.php?tid=140518&pid=1306106#pid1306106

This change only has an effect when CONF_FLAGS_FORMAT_SBS/CONF_FLAGS_FORMAT_TB is set, so only affects Pi.

On Pi, the 3D modes look like:
960x1080@24 for SBS
1920x540@24 for TB

(note: framerate is not reported as 48)

So, doubling a video's framerate (which is ~24 fps) means that the 24p TV modes are rejected for being too low, and so you get a 50Hz mode.

The fix removes this unwanted doubling of framerate.
