### PR TITLE
python interface now can use native keyboard (ios currently) if possible.

### DIFF
--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -25,6 +25,7 @@
 #include "GUIUserMessages.h"
 #include "GUIWindowManager.h"
 #include "settings/GUISettings.h"
+#include "ApplicationMessenger.h"
 #include "utils/md5.h"
 
 
@@ -46,22 +47,19 @@ void CGUIKeyboardFactory::keyTypedCB(CGUIKeyboard *ref, const std::string &typed
 {
   if(ref)
   {
-    // send our search message (only the active window needs it)
+    // send our search message in safe way (only the active window needs it)
     CGUIMessage message(GUI_MSG_NOTIFY_ALL, ref->GetWindowId(), 0);
-    CGUIWindow *window = NULL;
     switch(m_filtering)
     {
       case FILTERING_SEARCH:
-        window = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
         message.SetParam1(GUI_MSG_SEARCH_UPDATE);
         message.SetStringParam(typedString);
-        if (window)
-          window->OnMessage(message);
+        CApplicationMessenger::Get().SendGUIMessage(message, g_windowManager.GetActiveWindow());
         break;
       case FILTERING_CURRENT:
         message.SetParam1(GUI_MSG_FILTER_ITEMS);
         message.SetStringParam(typedString);
-        g_windowManager.SendMessage(message);
+        CApplicationMessenger::Get().SendGUIMessage(message);
         break;
       case FILTERING_NONE:
         break;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -156,6 +156,9 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
 
 bool CGUIWindowManager::SendMessage(CGUIMessage& message, int window)
 {
+  if (window == 0)
+    // send to no specified windows.
+    return SendMessage(message);
   CGUIWindow* pWindow = GetWindow(window);
   if(pWindow)
     return pWindow->OnMessage(message);

--- a/xbmc/interfaces/legacy/Keyboard.h
+++ b/xbmc/interfaces/legacy/Keyboard.h
@@ -58,7 +58,8 @@ namespace XBMCAddon
       String strDefault;
       String strHeading;
       bool bHidden;
-      CGUIDialogKeyboardGeneric* dlg;
+      String strText;
+      bool bConfirmed;
 
       Keyboard(const String& line = emptyString, const String& heading = emptyString, bool hidden = false);
       virtual ~Keyboard();
@@ -71,7 +72,7 @@ namespace XBMCAddon
        * example:
        *   - kb.doModal(30000)
        */
-      void doModal(int autoclose = 0) throw (KeyboardException);
+      void doModal(int autoclose = 0);
 
       // setDefault() Method
       /**
@@ -82,7 +83,7 @@ namespace XBMCAddon
        * example:
        *   - kb.setDefault('password')
        */
-      void setDefault(const String& line = emptyString) throw (KeyboardException);
+      void setDefault(const String& line = emptyString);
 
       /**
        * setHiddenInput(hidden) -- Allows hidden text entry.
@@ -91,7 +92,7 @@ namespace XBMCAddon
        * example:
        *   - kb.setHiddenInput(True)
        */
-      void setHiddenInput(bool hidden = false) throw (KeyboardException);
+      void setHiddenInput(bool hidden = false);
 
       // setHeading() Method
       /**
@@ -102,7 +103,7 @@ namespace XBMCAddon
        * example:
        *   - kb.setHeading('Enter password')
        */
-      void setHeading(const String& heading) throw (KeyboardException);
+      void setHeading(const String& heading);
 
       // getText() Method
       /**
@@ -114,7 +115,7 @@ namespace XBMCAddon
        * example:
        *   - text = kb.getText()
        */
-      String getText() throw (KeyboardException);
+      String getText();
 
       // isConfirmed() Method
       /**
@@ -123,7 +124,7 @@ namespace XBMCAddon
        * example:
        *   - if (kb.isConfirmed()):
        */
-      bool isConfirmed() throw (KeyboardException);
+      bool isConfirmed();
 
     };
   }

--- a/xbmc/osx/ios/IOSKeyboard.h
+++ b/xbmc/osx/ios/IOSKeyboard.h
@@ -24,7 +24,7 @@
 class CIOSKeyboard : public CGUIKeyboard
 {
   public:
-    CIOSKeyboard():m_pCharCallback(NULL),m_pIosKeyboard(NULL){}
+    CIOSKeyboard():m_pCharCallback(NULL),m_bCanceled(false){}
     virtual bool ShowAndGetInput(char_callback_t pCallback, const std::string &initialString, std::string &typedString, const std::string &heading, bool bHiddenInput);
     virtual void Cancel();
     void fireCallback(const std::string &str);
@@ -32,5 +32,5 @@ class CIOSKeyboard : public CGUIKeyboard
 
   private:
     char_callback_t m_pCharCallback;
-    void *m_pIosKeyboard;
+    bool m_bCanceled;
 };

--- a/xbmc/osx/ios/IOSKeyboard.mm
+++ b/xbmc/osx/ios/IOSKeyboard.mm
@@ -51,8 +51,9 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
   [keyboard RegisterKeyboard:this]; // for calling back
   [keyboard activate];//blocks and loops our application loop (like a modal dialog)
   // user is done - get resulted text and confirmation
-  typedString = [[keyboard GetText] UTF8String];
   confirmed = [keyboard GetResult];
+  if (confirmed)
+    typedString = [[keyboard GetText] UTF8String];
   [keyboard release]; // bye bye native keyboard
   m_pIosKeyboard = NULL;
   return confirmed;

--- a/xbmc/osx/ios/IOSKeyboard.mm
+++ b/xbmc/osx/ios/IOSKeyboard.mm
@@ -22,9 +22,12 @@
 #include "IOSKeyboard.h"
 #include "IOSKeyboardView.h"
 
+#import "AutoPool.h"
+
 
 bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string &initialString, std::string &typedString, const std::string &heading, bool bHiddenInput)
 {
+  CCocoaAutoPool pool;
   bool confirmed = false;
   CGRect keyboardFrame;
 

--- a/xbmc/osx/ios/IOSKeyboard.mm
+++ b/xbmc/osx/ios/IOSKeyboard.mm
@@ -40,8 +40,7 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
   keyboardFrame.origin.x = frameHeight / 2;
   keyboardFrame.origin.y = (pCurrentScreen.bounds.size.width/2) - frameHeight*scale + 10;
   //create the keyboardview
-  m_pIosKeyboard = [[KeyboardView alloc] initWithFrame:keyboardFrame];
-  KeyboardView *keyboard = (KeyboardView*)m_pIosKeyboard;
+  KeyboardView *keyboard = [[KeyboardView alloc] initWithFrame:keyboardFrame];
   m_pCharCallback = pCallback;
 
   // init keyboard stuff
@@ -49,23 +48,22 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
   [keyboard SetHiddenInput:bHiddenInput];
   [keyboard SetHeading:[NSString stringWithUTF8String:heading.c_str()]];
   [keyboard RegisterKeyboard:this]; // for calling back
-  [keyboard activate];//blocks and loops our application loop (like a modal dialog)
-  // user is done - get resulted text and confirmation
-  confirmed = [keyboard GetResult];
-  if (confirmed)
-    typedString = [[keyboard GetText] UTF8String];
+  if (!m_bCanceled)
+  {
+    [keyboard setCancelFlag:&m_bCanceled];
+    [keyboard activate];//blocks and loops our application loop (like a modal dialog)
+    // user is done - get resulted text and confirmation
+    confirmed = [keyboard GetResult];
+    if (confirmed)
+      typedString = [[keyboard GetText] UTF8String];
+  }
   [keyboard release]; // bye bye native keyboard
-  m_pIosKeyboard = NULL;
   return confirmed;
 }
 
 void CIOSKeyboard::Cancel()
 {
-  if (m_pIosKeyboard)
-  {
-    KeyboardView *keyboard = (KeyboardView*)m_pIosKeyboard;
-    [keyboard keyboardDidHide:nil];
-  }
+  m_bCanceled = true;
 }
 
 //wrap our callback between objc and c++

--- a/xbmc/osx/ios/IOSKeyboardView.h
+++ b/xbmc/osx/ios/IOSKeyboardView.h
@@ -28,6 +28,7 @@
     bool                                _result;
     bool                                _hiddenInput;
     CIOSKeyboard                        *_iosKeyboard;
+    bool                                *_canceled;
 }
 
 @property (nonatomic, retain, getter = GetText) NSMutableString *_text;
@@ -39,5 +40,5 @@
 - (void) setText:(NSMutableString *)text;
 - (void) activate;
 - (void) deactivate;
-- (void)keyboardDidHide:(id)sender;
+- (void) setCancelFlag:(bool *)cancelFlag;
 @end

--- a/xbmc/osx/ios/IOSKeyboardView.mm
+++ b/xbmc/osx/ios/IOSKeyboardView.mm
@@ -46,6 +46,7 @@ static CEvent keyboardFinishedEvent;
     _iosKeyboard = nil;
     _text = [[NSMutableString alloc] initWithString:@""];
     _heading = [[NSMutableString alloc] initWithString:@""];    
+    _canceled = NULL;
 
     [[NSNotificationCenter defaultCenter] addObserver:self 
                                           selector:@selector(keyboardDidHide:) 
@@ -119,6 +120,11 @@ static CEvent keyboardFinishedEvent;
   // basicall what our GUIDialog does if called modal
   while(!keyboardFinishedEvent.WaitMSec(500) && !g_application.m_bStop)
   {
+    if (NULL != _canceled && *_canceled)
+    {
+      [self deactivate];
+      _canceled = NULL;
+    }
     // if we are not in xbmc main thread, ProcessRenderLoop() is nop.
     g_windowManager.ProcessRenderLoop();
   }
@@ -221,6 +227,11 @@ static CEvent keyboardFinishedEvent;
   {
     _iosKeyboard->fireCallback([_text UTF8String]);
   }  
+}
+
+- (void) setCancelFlag:(bool *)cancelFlag
+{
+  _canceled = cancelFlag;
 }
 
 - (void) dealloc

--- a/xbmc/osx/ios/IOSKeyboardView.mm
+++ b/xbmc/osx/ios/IOSKeyboardView.mm
@@ -119,6 +119,7 @@ static CEvent keyboardFinishedEvent;
   // basicall what our GUIDialog does if called modal
   while(!keyboardFinishedEvent.WaitMSec(500) && !g_application.m_bStop)
   {
+    // if we are not in xbmc main thread, ProcessRenderLoop() is nop.
     g_windowManager.ProcessRenderLoop();
   }
 }


### PR DESCRIPTION
I'm glad to see native keyboard feature in Frodo currently, it comes from https://github.com/xbmc/xbmc/pull/1194, but the Keyboard in python interface still wasn't benefit from the feature.
This little commit, just enable use native keyboard feature in python interface if possible.
since the python addon is running in standalone thread other than the main xbmc thread, there is a little adjust need to be set to let the ios keyboard works, which include:
1. in the input callback in the keyboard factory, use async SendGUIMessage instead of direct call win->OnMessage() or windowsmanager->SendMessage().
2. addon instance running without an autopool for object-c by default, then an autopool is added in the ioskeyboard main function.
3. in ApplicationMessenger, the SendGUIMessage method take default window id param and then send 0 to windowsmanager->SendMessage(msg, winid), but the win manager does not handle the winid 0 condition, since SendGUIMessage in the project is not used so many times, I checked and fixed it to redirect to windowsmanager->SendMessage(msg) if winid==0
