### PR TITLE
IOSKeyboard now can accept input from an ios UITextField control

### DIFF
--- a/xbmc/osx/ios/IOSKeyboardView.h
+++ b/xbmc/osx/ios/IOSKeyboardView.h
@@ -21,24 +21,27 @@
 #import <UIKit/UIKit.h>
 #include "IOSKeyboard.h"
 
-@interface KeyboardView : UIView <UIKeyInput>
+@interface KeyboardView : UIView <UITextFieldDelegate>
 {
-    NSMutableString                    *_heading;
-    NSMutableString                    *_text;
-    bool                                _result;
-    bool                                _hiddenInput;
-    CIOSKeyboard                        *_iosKeyboard;
-    bool                                *_canceled;
+  NSMutableString *text;
+  BOOL _confirmed;
+  CIOSKeyboard *_iosKeyboard;
+  bool *_canceled;
+  UITextField *_textField;
+  UILabel *_heading;
+  BOOL _keyboardIsShowing;
+  CGFloat _kbHeight;
 }
 
-@property (nonatomic, retain, getter = GetText) NSMutableString *_text;
-@property (copy, setter = SetHeading:) NSMutableString *_heading;
-@property (getter = GetResult) bool _result;
-@property (setter = SetHiddenInput:) bool _hiddenInput;
-@property (assign, setter = RegisterKeyboard:) CIOSKeyboard *_iosKeyboard;
+@property (nonatomic, retain) NSMutableString *text;
+@property (getter = isConfirmed) BOOL _confirmed;
+@property (assign, setter = registerKeyboard:) CIOSKeyboard *_iosKeyboard;
 
-- (void) setText:(NSMutableString *)text;
+- (void) setDefault:(NSString *)defaultText;
+- (void) setHeading:(NSString *)heading;
+- (void) setHidden:(BOOL)hidden;
 - (void) activate;
 - (void) deactivate;
+- (void) textChanged:(NSNotification*)aNotification;
 - (void) setCancelFlag:(bool *)cancelFlag;
 @end

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -168,7 +168,7 @@ extern NSString* kBRScreenSaverDismissed;
   doubleFingerSingleTap.delaysTouchesBegan = YES;
   doubleFingerSingleTap.numberOfTapsRequired = 1;
   doubleFingerSingleTap.numberOfTouchesRequired = 2;
-  [self.view addGestureRecognizer:doubleFingerSingleTap];
+  [m_glView addGestureRecognizer:doubleFingerSingleTap];
   [doubleFingerSingleTap release];
 
   //1 finger single long tab - right mouse - alernative
@@ -177,7 +177,7 @@ extern NSString* kBRScreenSaverDismissed;
 
   singleFingerSingleLongTap.delaysTouchesBegan = YES;
   singleFingerSingleLongTap.delaysTouchesEnded = YES;
-  [self.view addGestureRecognizer:singleFingerSingleLongTap];
+  [m_glView addGestureRecognizer:singleFingerSingleLongTap];
   [singleFingerSingleLongTap release];
 
   //double finger swipe left for backspace ... i like this fast backspace feature ;)
@@ -187,7 +187,7 @@ extern NSString* kBRScreenSaverDismissed;
   swipeLeft.delaysTouchesBegan = YES;
   swipeLeft.numberOfTouchesRequired = 2;
   swipeLeft.direction = UISwipeGestureRecognizerDirectionLeft;
-  [self.view addGestureRecognizer:swipeLeft];
+  [m_glView addGestureRecognizer:swipeLeft];
   [swipeLeft release];
 
   //for pan gestures with one finger
@@ -196,7 +196,7 @@ extern NSString* kBRScreenSaverDismissed;
 
   pan.delaysTouchesBegan = YES;
   pan.maximumNumberOfTouches = 1;
-  [self.view addGestureRecognizer:pan];
+  [m_glView addGestureRecognizer:pan];
   [pan release];
 
   //for zoom gesture
@@ -205,7 +205,7 @@ extern NSString* kBRScreenSaverDismissed;
 
   pinch.delaysTouchesBegan = YES;
   pinch.delegate = self;
-  [self.view addGestureRecognizer:pinch];
+  [m_glView addGestureRecognizer:pinch];
   [pinch release];
 
   //for rotate gesture
@@ -214,18 +214,20 @@ extern NSString* kBRScreenSaverDismissed;
 
   rotate.delaysTouchesBegan = YES;
   rotate.delegate = self;
-  [self.view addGestureRecognizer:rotate];
+  [m_glView addGestureRecognizer:rotate];
   [rotate release];
 }
 //--------------------------------------------------------------
 - (void) activateKeyboard:(UIView *)view
 {
   [self.view addSubview:view];
+  m_glView.userInteractionEnabled = NO;
 }
 //--------------------------------------------------------------
 - (void) deactivateKeyboard:(UIView *)view
 {
   [view removeFromSuperview];
+  m_glView.userInteractionEnabled = YES; 
 }
 //--------------------------------------------------------------
 -(void)handlePinch:(UIPinchGestureRecognizer*)sender 


### PR DESCRIPTION
this commit based on the PR https://github.com/xbmc/xbmc/pull/2101 which is not merged yet.
so the first 4 commits is come from that PR, the laters are the real work.

By switching to use an UITextField control, user can input any text in any native ios keyboard (original IOSKeyboard only support english and other several languages because it uses UIKeyInput protocol which has such limit), it also supports ios clipboard copy & paste.

tested on iphone4/ios 5.1.1, itouch4/ios 4.3.3, ipad/ios 4.3.3
tests on other ios platforms are welcome.
