### PR TITLE
dvdplayer/pvr: fix seek/ff/rw for PVR, calculate offset to pts on screen

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -169,3 +169,12 @@ protected:
   std::string m_content;
   CFileItem m_item;
 };
+
+struct DisplayTime
+{
+  int m_display_time;
+  int m_chapter;
+  std::string m_chapter_name;
+  double m_processing_time;
+  int player;
+};

--- a/xbmc/cores/dvdplayer/DVDMessage.h
+++ b/xbmc/cores/dvdplayer/DVDMessage.h
@@ -73,11 +73,12 @@ public:
     PLAYER_CHANNEL_SELECT,          // switches to the provided channel
     PLAYER_STARTED,                 // sent whenever a sub player has finished it's first frame after open
 
+    PLAYER_DISPLAYTIME,             // display time struct from av players
+
     // demuxer related messages
 
     DEMUXER_PACKET,                 // data packet
     DEMUXER_RESET,                  // reset the demuxer
-
 
     // video related messages
 
@@ -280,8 +281,6 @@ class CDVDMsgDemuxerReset : public CDVDMsg
 public:
   CDVDMsgDemuxerReset() : CDVDMsg(DEMUXER_RESET)  {}
 };
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 //////

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2278,6 +2278,20 @@ void CDVDPlayer::HandleMessages()
           m_CurrentVideo.started = true;
         CLog::Log(LOGDEBUG, "CDVDPlayer::HandleMessages - player started %d", player);
       }
+      else if (pMsg->IsType(CDVDMsg::PLAYER_DISPLAYTIME))
+      {
+        DisplayTime dTime = ((CDVDMsgType<DisplayTime>*)pMsg)->m_value;
+
+        int player = dTime.player;
+        if(player == DVDPLAYER_AUDIO && m_CurrentAudio.started)
+        {
+          m_CurrentAudio.displayTime = dTime;
+        }
+        else if(player == DVDPLAYER_VIDEO && m_CurrentVideo.started)
+        {
+          m_CurrentVideo.displayTime = dTime;
+        }
+      }
     }
     catch (...)
     {
@@ -3193,6 +3207,8 @@ void CDVDPlayer::FlushBuffers(bool queued, double pts, bool accurate)
       m_CurrentVideo.started    = false;
       m_CurrentSubtitle.started = false;
       m_CurrentTeletext.started = false;
+      m_CurrentVideo.displayTime.m_processing_time = DVD_NOPTS_VALUE;
+      m_CurrentAudio.displayTime.m_processing_time = DVD_NOPTS_VALUE;
     }
 
     if(pts != DVD_NOPTS_VALUE)
@@ -3876,10 +3892,40 @@ void CDVDPlayer::UpdatePlayState(double timeout)
       state.player_state = "";
   }
 
-  if (state.time_src == ETIMESOURCE_CLOCK)
-    state.time_offset = 0;
-  else
+  if (state.time_src != ETIMESOURCE_CLOCK)
+  {
+    // calculate offset at dvdplayer input, it is supposed to stay constant
     state.time_offset = DVD_MSEC_TO_TIME(state.time) - state.dts;
+
+    // get display time from av players
+    // 1. send message through queue
+    DisplayTime dTime;
+    dTime.m_display_time = state.time;
+    dTime.m_chapter = state.chapter;
+    dTime.m_chapter_name = state.chapter_name;
+    if (m_CurrentVideo.inited)
+      m_dvdPlayerVideo.SendMessage(new CDVDMsgType<DisplayTime>(CDVDMsg::PLAYER_DISPLAYTIME, dTime));
+    else if (m_CurrentAudio.inited)
+      m_dvdPlayerAudio.SendMessage(new CDVDMsgType<DisplayTime>(CDVDMsg::PLAYER_DISPLAYTIME, dTime));
+
+    // 2. check if we got respose from av players
+    if (m_CurrentVideo.displayTime.m_processing_time != DVD_NOPTS_VALUE)
+    {
+      state.time = m_CurrentVideo.displayTime.m_display_time
+                 + DVD_TIME_TO_MSEC(CDVDClock::GetAbsoluteClock()-m_CurrentVideo.displayTime.m_processing_time);
+      state.chapter = m_CurrentVideo.displayTime.m_chapter;
+      state.chapter_name = m_CurrentVideo.displayTime.m_chapter_name;
+    }
+    else if (m_CurrentAudio.displayTime.m_processing_time != DVD_NOPTS_VALUE)
+    {
+      state.time = m_CurrentAudio.displayTime.m_display_time
+                 + DVD_TIME_TO_MSEC(CDVDClock::GetAbsoluteClock()-m_CurrentAudio.displayTime.m_processing_time);
+      state.chapter = m_CurrentAudio.displayTime.m_chapter;
+      state.chapter_name = m_CurrentAudio.displayTime.m_chapter_name;
+    }
+  }
+  else
+    state.time_offset = 0;
 
   if (m_CurrentAudio.id >= 0 && m_pDemuxer)
   {

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -31,6 +31,7 @@
 #include "DVDPlayerVideo.h"
 #include "DVDPlayerSubtitle.h"
 #include "DVDPlayerTeletext.h"
+#include "DVDInputStreams/DVDInputStream.h"
 
 //#include "DVDChapterReader.h"
 #include "DVDSubtitles/DVDFactorySubtitle.h"
@@ -75,6 +76,8 @@ public:
   // stuff to handle starting after seek
   double   startpts;
 
+  DisplayTime      displayTime;
+
   CCurrentStream(StreamType t, int i)
     : type(t)
     , player(i)
@@ -94,6 +97,7 @@ public:
     inited = false;
     started = false;
     startpts  = DVD_NOPTS_VALUE;
+    displayTime.m_processing_time = DVD_NOPTS_VALUE;
   }
 
   double dts_end()

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -425,6 +425,14 @@ int CDVDPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe, bool bDropPacket)
       if(m_started)
         m_messageParent.Put(new CDVDMsgInt(CDVDMsg::PLAYER_STARTED, DVDPLAYER_AUDIO));
     }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_DISPLAYTIME))
+    {
+      DisplayTime dTime = ((CDVDMsgType<DisplayTime>*)pMsg)->m_value;
+
+      dTime.m_processing_time = CDVDClock::GetAbsoluteClock();
+      dTime.player = DVDPLAYER_AUDIO;
+      m_messageParent.Put(new CDVDMsgType<DisplayTime>(CDVDMsg::PLAYER_DISPLAYTIME, dTime));
+    }
     else if (pMsg->IsType(CDVDMsg::GENERAL_EOF))
     {
       CLog::Log(LOGDEBUG, "CDVDPlayerAudio - CDVDMsg::GENERAL_EOF");

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -473,6 +473,14 @@ void CDVDPlayerVideo::Process()
       if(m_started)
         m_messageParent.Put(new CDVDMsgInt(CDVDMsg::PLAYER_STARTED, DVDPLAYER_VIDEO));
     }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_DISPLAYTIME))
+    {
+      DisplayTime dTime = ((CDVDMsgType<DisplayTime>*)pMsg)->m_value;
+
+      dTime.m_processing_time = CDVDClock::GetAbsoluteClock();
+      dTime.player = DVDPLAYER_VIDEO;
+      m_messageParent.Put(new CDVDMsgType<DisplayTime>(CDVDMsg::PLAYER_DISPLAYTIME, dTime));
+    }
     else if (pMsg->IsType(CDVDMsg::GENERAL_STREAMCHANGE))
     {
       CDVDMsgVideoCodecChange* msg(static_cast<CDVDMsgVideoCodecChange*>(pMsg));


### PR DESCRIPTION
With approximately 8 seconds in the dvd queues a small step back of 5 secs resulted in a step forward of 3 secs.
