### PR TITLE
Issue #13812 - performance of styled subtitles

### DIFF
--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -69,7 +69,7 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   m_dll.ass_set_extract_fonts(m_library, 1);
   if(g_advancedSettings.m_libassStyleOverrides.size() > 0)
   {
-    CLog::Log(LOGINFO, "CDVDSubtitlesLiabss: applying advanced settings");
+    CLog::Log(LOGINFO, "CDVDSubtitlesLibass: applying advanced settings");
     // convert string array to array of null terminated C strings that libass expects
     char** settings = new char*[g_advancedSettings.m_libassStyleOverrides.size() + 1];
     char** currentSetting = settings;
@@ -77,13 +77,11 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
         it != g_advancedSettings.m_libassStyleOverrides.end();
         ++it)
     {
-//      std::cerr << it->c_str() << std::endl;
       int len = it->GetLength();
       *currentSetting = new char[len + 1];
       char const* buf = it->c_str(); // copy internal buffer
       std::copy(buf, buf + len, *currentSetting);
       (*currentSetting)[len] = 0;
-//      std::cerr << *currentSetting << std::endl;
       currentSetting += 1;
     }
     *currentSetting = 0;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1051,6 +1051,25 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "nofliptimeout",             m_guiDirtyRegionNoFlipTimeout);
   }
 
+  pElement = pRootElement->FirstChildElement("libass");
+  if(pElement)
+  {
+    TiXmlElement* styleOverridesElement = pElement->FirstChildElement("styleoverrides");
+    if(styleOverridesElement)
+    {
+      TiXmlElement* style = styleOverridesElement->FirstChildElement("style");
+      while(style)
+      {
+        CStdString styleOverride("");
+        styleOverride += style->Attribute("name");
+        styleOverride += "=";
+        styleOverride += style->Attribute("value");
+        m_libassStyleOverrides.push_back(styleOverride);
+        style = style->NextSiblingElement("style");
+      }
+    }
+  }
+
   // load in the GUISettings overrides:
   g_guiSettings.LoadXML(pRootElement, true);  // true to hide the settings we read in
 }
@@ -1222,3 +1241,4 @@ void CAdvancedSettings::SetDebugMode(bool debug)
     CLog::SetLogLevel(level);
   }
 }
+

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -365,6 +365,8 @@ class CAdvancedSettings
     bool m_initialized;
 
     void SetDebugMode(bool debug);
+
+    CStdStringArray m_libassStyleOverrides;
 };
 
 XBMC_GLOBAL(CAdvancedSettings,g_advancedSettings);


### PR DESCRIPTION
This patch tries to address issue #13812 (performance of styled subs
with raspberry pi) via optional style overriding. Libass offers this
feature (used for example in vlc), via the ass_set_style_overrides
API.

The patch does the following :
- add a <libass> setting in advancedsettings.xml file with the
  following structure :

```
   <libass>
    <styleoverrides>
        <style name="Shadow" value="0" />
        <style name="Blur" value="0" />
        <style name="BorderStyle" value="0" />
    </styleoverrides>
  </libass>
```
- add the corresponding string container in AdvancedSettings class
  (values are converted to « name=value » format during parsing, which
  is better than storing a map because it is what libass expects)
- calls ass_set_style_overrides at libass initialization with
  the given parameters

Tests on raspberry pi 512 have shown that disabling effects such as
shadow and blur actually do suppress lags.
