### PR TITLE
Fix for 14005. GIL wasn't managed correctly in python spawned threads

### DIFF
--- a/xbmc/interfaces/python/PyContext.h
+++ b/xbmc/interfaces/python/PyContext.h
@@ -22,6 +22,8 @@ namespace XBMCAddon
 {
   namespace Python
   {
+    class PyGILLock;
+
     /**
      * These classes should NOT be used with 'new'. They are expected to reside 
      *  as stack instances and they act as "Guard" classes that track the
@@ -30,9 +32,13 @@ namespace XBMCAddon
     class PyContext
     {
     protected:
+      friend class PyGILLock;
+      static void* enterContext();
+      static void leaveContext();
     public:
-      PyContext();
-      ~PyContext();
+
+      inline PyContext() { enterContext(); }
+      inline ~PyContext() { leaveContext(); }
     };
 
     /**


### PR DESCRIPTION
In threads spawned within python the PyContext was never used. In those cases the releasing/acquiring of the Gil was simply skipped. Therefore scripts that looped over 'sleep' from a python created thread (a typical pattern in python services) would block all other python threads forever.

Closes #14005
