### PR TITLE
android: fixed loading of shared libraries

### DIFF
--- a/xbmc/android/loader/AndroidDyload.cpp
+++ b/xbmc/android/loader/AndroidDyload.cpp
@@ -201,7 +201,6 @@ void CAndroidDyload::GetDeps(string filename, strings *results)
 void* CAndroidDyload::Open(const char * path)
 {
   string filename = path;
-  filename = filename.substr(filename.find_last_of('/') +1);
   void *handle = NULL;
   m_lib.deps.clear();
   handle = Find(filename);


### PR DESCRIPTION
the absolute path to the library was always stripped.
now libraries can be loaded from unusual (!= XBMC_ANDROID_LIBS || XBMC_ANDROID_SYSTEM_LIBS) places.
