### PR TITLE
DVDAudioCodecFFmpeg: Convert unknown audio formats to float.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -42,6 +42,7 @@ CDVDAudioCodecFFmpeg::CDVDAudioCodecFFmpeg() : CDVDAudioCodec()
   m_layout = 0;
   
   m_bLpcmMode = false;
+  m_bNeedConversion = false;
 
   m_pFrame1 = NULL;
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
@@ -174,7 +175,7 @@ int CDVDAudioCodecFFmpeg::Decode(BYTE* pData, int iSize)
   else
     m_iBuffered = 0;
     
-  if(m_bLpcmMode)
+  if(m_bLpcmMode || m_bNeedConversion)
     ConvertToFloat();
 
   return iBytesUsed;
@@ -277,9 +278,12 @@ enum AEDataFormat CDVDAudioCodecFFmpeg::GetDataFormat()
       case AV_SAMPLE_FMT_S32: return AE_FMT_S32NE;
       case AV_SAMPLE_FMT_FLT: return AE_FMT_FLOAT;
       case AV_SAMPLE_FMT_DBL: return AE_FMT_DOUBLE;
-      default:
+      case AV_SAMPLE_FMT_NONE:
         assert(false);
         return AE_FMT_INVALID;
+      default:
+        m_bNeedConversion = true;
+        return AE_FMT_FLOAT;
     }
   }
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -51,6 +51,7 @@ protected:
   enum AVSampleFormat m_iSampleFormat;  
   CAEChannelInfo      m_channelLayout;
   bool                m_bLpcmMode;  
+  bool                m_bNeedConversion;
 
   AVFrame* m_pFrame1;
   int      m_iBufferSize1;


### PR DESCRIPTION
As of FFmpeg-1.1, some decoders started to output planar audio.
This fixes track ticket 13944.

This will be needed when we'll update the internal FFmpeg to a newer release.
It's not my call but it'd be cool if this were backported to Frodo as it fixes a crash.

TODO: I fear passthrough is affected too, will have a look, but this one was easy enough.
