### PR TITLE
Pull request:  ffmpeg fix to properly detect video in SageTV recordings (ffmpeg bug #2147)

### DIFF
--- a/lib/ffmpeg/libavformat/mpeg.c
+++ b/lib/ffmpeg/libavformat/mpeg.c
@@ -453,7 +453,6 @@ static int mpegps_read_packet(AVFormatContext *s,
     }
 
     es_type = m->psm_es_type[startcode & 0xff];
-    if(es_type > 0 && es_type != STREAM_TYPE_PRIVATE_DATA){
         if(es_type == STREAM_TYPE_VIDEO_MPEG1){
             codec_id = CODEC_ID_MPEG2VIDEO;
             type = AVMEDIA_TYPE_VIDEO;
@@ -476,9 +475,6 @@ static int mpegps_read_packet(AVFormatContext *s,
         } else if(es_type == STREAM_TYPE_AUDIO_AC3){
             codec_id = CODEC_ID_AC3;
             type = AVMEDIA_TYPE_AUDIO;
-        } else {
-            goto skip;
-        }
     } else if (startcode >= 0x1e0 && startcode <= 0x1ef) {
         static const unsigned char avs_seqh[4] = { 0, 0, 1, 0xb0 };
         unsigned char buf[8];


### PR DESCRIPTION
Xbmc fails to play most of my recorded TV content, due to a bug in ffmpeg which makes it think most of my SageTV recordings have no video.  The bug was fixed upstream, and I would be deeply grateful the fix could be pulled into xbmc.

> commit c071b006436d663b977068f8d23cbc061f40491f
> Author: Michael Niedermayer michaelni@gmx.at
> Date:   Mon Jan 21 04:21:56 2013 +0100
> 
> ```
> mpeg12demux: Fallback to startcode for stream type identification.
> ```
> 
>    Fixes Ticket2147
>    Fixes SageTV support
> 
>    Based-on patch by Andrew Gallatin
>    Signed-off-by: Michael Niedermayer michaelni@gmx.at
