### PR TITLE
paplayer handle prepare stream failure.

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -354,7 +354,15 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn/* = true */)
   si->m_playNextAtFrame = 0;
   si->m_playNextTriggered = false;
 
-  PrepareStream(si);
+  if (!PrepareStream(si))
+  {
+    CLog::Log(LOGINFO, "PAPlayer::QueueNextFileEx - Error preparing stream");
+    
+    si->m_decoder.Destroy();
+    delete si;
+    m_callback.OnQueueNextItem();
+    return false;
+  }
 
   /* add the stream to the list */
   CExclusiveLock lock(m_streamsLock);


### PR DESCRIPTION
I've encountered a crash in gdb after  log message:

```
PAPlayer::PrepareStream - Failed to get IAEStream 
```

what cause crash is at line in PAPlayer::ProcessStream with si->m_stream == NULL:

```
    si->m_stream->RegisterAudioCallback(m_audioCallback);
```

I checked only place called PrepareStream is in PAPlayer::QueueNextFileEx where did not check failure, so here is the fix for it, please check whether it is correct..
