### PR TITLE
ios support play background and native media control bar

### DIFF
--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		7CC3106F162AAFE3003E7579 /* EdenVideoArtUpdater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CC3106D162AAFE3003E7579 /* EdenVideoArtUpdater.cpp */; };
 		7CCFD9991514950700211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD9971514950700211D82 /* PCMCodec.cpp */; };
 		7CEE2E7F13D6B7D4000ABF2A /* TimeSmoother.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEE2E7D13D6B7D4000ABF2A /* TimeSmoother.cpp */; };
+		8253940516B25C2C00A85509 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8253940416B25C2C00A85509 /* AVFoundation.framework */; };
 		8253940716B25C2C00A85509 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8253940616B25C2C00A85509 /* MediaPlayer.framework */; };
 		C80711AD135DB85F002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80711AB135DB85F002F601B /* InputOperations.cpp */; };
 		C8B929D01573557B00284190 /* Epg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8B929C31573557B00284190 /* Epg.cpp */; };
@@ -1133,6 +1134,7 @@
 		7CCFD9981514950700211D82 /* PCMCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMCodec.h; sourceTree = "<group>"; };
 		7CEE2E7D13D6B7D4000ABF2A /* TimeSmoother.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TimeSmoother.cpp; sourceTree = "<group>"; };
 		7CEE2E7E13D6B7D4000ABF2A /* TimeSmoother.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeSmoother.h; sourceTree = "<group>"; };
+		8253940416B25C2C00A85509 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		8253940616B25C2C00A85509 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		83D619BB13C0D25300418A0F /* README.ios */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.ios; sourceTree = "<group>"; };
 		8D576316048677EA00EA77CD /* XBMC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XBMC.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3287,6 +3289,7 @@
 				F56C8C12131F4811000AD0F6 /* librtv.a in Frameworks */,
 				F56C8C14131F4811000AD0F6 /* libxdaap.a in Frameworks */,
 				18404DD31396C3D200863BBA /* SlingboxLib.a in Frameworks */,
+				8253940516B25C2C00A85509 /* AVFoundation.framework in Frameworks */,
 				8253940716B25C2C00A85509 /* MediaPlayer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6438,6 +6441,7 @@
 				F589AE481288E07D00D8079E /* libxml2.dylib */,
 				F589AE461288E07400D8079E /* libz.dylib */,
 				F56B14A412CAF523009B4C96 /* AudioToolbox.framework */,
+				8253940416B25C2C00A85509 /* AVFoundation.framework */,
 				4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */,
 				3255316512B2D02400837CD2 /* CoreAudio.framework */,
 				F56B143312CAF279009B4C96 /* CoreVideo.framework */,

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		7CC3106F162AAFE3003E7579 /* EdenVideoArtUpdater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CC3106D162AAFE3003E7579 /* EdenVideoArtUpdater.cpp */; };
 		7CCFD9991514950700211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD9971514950700211D82 /* PCMCodec.cpp */; };
 		7CEE2E7F13D6B7D4000ABF2A /* TimeSmoother.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEE2E7D13D6B7D4000ABF2A /* TimeSmoother.cpp */; };
+		8253940716B25C2C00A85509 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8253940616B25C2C00A85509 /* MediaPlayer.framework */; };
 		C80711AD135DB85F002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80711AB135DB85F002F601B /* InputOperations.cpp */; };
 		C8B929D01573557B00284190 /* Epg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8B929C31573557B00284190 /* Epg.cpp */; };
 		C8B929D11573557B00284190 /* EpgContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8B929C51573557B00284190 /* EpgContainer.cpp */; };
@@ -1132,6 +1133,7 @@
 		7CCFD9981514950700211D82 /* PCMCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMCodec.h; sourceTree = "<group>"; };
 		7CEE2E7D13D6B7D4000ABF2A /* TimeSmoother.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TimeSmoother.cpp; sourceTree = "<group>"; };
 		7CEE2E7E13D6B7D4000ABF2A /* TimeSmoother.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeSmoother.h; sourceTree = "<group>"; };
+		8253940616B25C2C00A85509 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		83D619BB13C0D25300418A0F /* README.ios */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.ios; sourceTree = "<group>"; };
 		8D576316048677EA00EA77CD /* XBMC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XBMC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C80711AB135DB85F002F601B /* InputOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputOperations.cpp; sourceTree = "<group>"; };
@@ -3285,6 +3287,7 @@
 				F56C8C12131F4811000AD0F6 /* librtv.a in Frameworks */,
 				F56C8C14131F4811000AD0F6 /* libxdaap.a in Frameworks */,
 				18404DD31396C3D200863BBA /* SlingboxLib.a in Frameworks */,
+				8253940716B25C2C00A85509 /* MediaPlayer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6442,6 +6445,7 @@
 				F56B15D412CD67A9009B4C96 /* CoreGraphics.framework */,
 				F5899DCD1287212700D8079E /* Foundation.framework */,
 				F56B160712CD6999009B4C96 /* ImageIO.framework */,
+				8253940616B25C2C00A85509 /* MediaPlayer.framework */,
 				F5899DCB1287212700D8079E /* OpenGLES.framework */,
 				F5899DCA1287212700D8079E /* QuartzCore.framework */,
 				F5899DCC1287212700D8079E /* UIKit.framework */,

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -404,6 +404,9 @@ CApplication::CApplication(void)
   XInitThreads();
 #endif
 
+  // we start in frontend
+  m_bInBackground = false;
+
   /* for now always keep this around */
 #ifdef HAS_KARAOKE
   m_pKaraokeMgr = new CKaraokeLyricsManager();
@@ -2260,8 +2263,8 @@ void CApplication::NewFrame()
 
 void CApplication::Render()
 {
-  // do not render if we are stopped
-  if (m_bStop)
+  // do not render if we are stopped or in background
+  if (m_bStop || m_bInBackground)
     return;
 
   if (!m_AppActive && !m_bStop && (!IsPlayingVideo() || IsPaused()))
@@ -4610,6 +4613,8 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
 
 void CApplication::CheckScreenSaverAndDPMS()
 {
+  if (m_bInBackground)
+    return;
   if (!m_dpmsIsActive)
     g_Windowing.ResetOSScreensaver();
 
@@ -4700,6 +4705,15 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     return;
   else if (!m_screenSaver->ID().IsEmpty())
     g_windowManager.ActivateWindow(WINDOW_SCREENSAVER);
+}
+
+void CApplication::SetInBackground(bool background)
+{
+  if (!background)
+  {
+    ResetScreenSaverTimer();
+  }
+  m_bInBackground = background;
 }
 
 void CApplication::CheckShutdown()

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -298,6 +298,10 @@ public:
 
   bool m_bPlaybackStarting;
 
+  bool m_bInBackground;
+  inline bool IsInBackground() { return m_bInBackground; };
+  void SetInBackground(bool background);
+
   CKaraokeLyricsManager* m_pKaraokeMgr;
 
   PLAYERCOREID m_eForcedNextPlayer;

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -512,6 +512,15 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       }
       break;
 
+    case TMSG_MEDIA_PAUSE_IF_PLAYING:
+      if (g_application.IsPlaying() && !g_application.IsPaused())
+      {
+        g_application.ResetScreenSaver();
+        g_application.WakeUpScreenSaverAndDPMS();
+        g_application.m_pPlayer->Pause();
+      }
+      break;
+
     case TMSG_SWITCHTOFULLSCREEN:
       if( g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO )
         g_application.SwitchToFullScreen();
@@ -926,6 +935,18 @@ void CApplicationMessenger::MediaStop(bool bWait /* = true */, int playlistid /*
 void CApplicationMessenger::MediaPause()
 {
   ThreadMessage tMsg = {TMSG_MEDIA_PAUSE};
+  SendMessage(tMsg, true);
+}
+
+void CApplicationMessenger::MediaUnPause()
+{
+  ThreadMessage tMsg = {TMSG_MEDIA_UNPAUSE};
+  SendMessage(tMsg, true);
+}
+
+void CApplicationMessenger::MediaPauseIfPlaying()
+{
+  ThreadMessage tMsg = {TMSG_MEDIA_PAUSE_IF_PLAYING};
   SendMessage(tMsg, true);
 }
 

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -52,9 +52,11 @@ namespace MUSIC_INFO
 
 #define TMSG_MEDIA_PLAY           200
 #define TMSG_MEDIA_STOP           201
+// the PAUSE is indeed a PLAYPAUSE
 #define TMSG_MEDIA_PAUSE          202
 #define TMSG_MEDIA_RESTART        203
 #define TMSG_MEDIA_UNPAUSE        204
+#define TMSG_MEDIA_PAUSE_IF_PLAYING   205
 
 #define TMSG_PLAYLISTPLAYER_PLAY  210
 #define TMSG_PLAYLISTPLAYER_NEXT  211
@@ -168,6 +170,8 @@ public:
   void MediaPlay(int playlistid, int song = -1);
   void MediaStop(bool bWait = true, int playlistid = -1);
   void MediaPause();
+  void MediaUnPause();
+  void MediaPauseIfPlaying();
   void MediaRestart(bool bWait);
 
   void PlayListPlayerPlay();

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
@@ -488,7 +488,11 @@ IAEStream* CCoreAudioAE::MakeStream(enum AEDataFormat dataFormat,
   // if we are suspended we don't
   // want anyone to mess with us
   if (m_isSuspended && !m_softSuspend)
+#if defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV)
+    Resume();
+#else
     return NULL;
+#endif
 
   CAEChannelInfo channelInfo(channelLayout);
   CLog::Log(LOGINFO, "CCoreAudioAE::MakeStream - %s, %u, %u, %s",

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
@@ -596,6 +596,10 @@ void CCoreAudioAEStream::Pause()
 
 void CCoreAudioAEStream::Resume()
 {
+#if defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV)
+  if (CAEFactory::IsSuspended())
+    CAEFactory::Resume();
+#endif
   m_paused = false;
 }
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -91,8 +91,8 @@ void PAPlayer::SoftStart(bool wait/* = false */)
     if (si->m_fadeOutTriggered)
       continue;
 
-    si->m_stream->FadeVolume(0.0f, 1.0f, FAST_XFADE_TIME);
     si->m_stream->Resume();
+    si->m_stream->FadeVolume(0.0f, 1.0f, FAST_XFADE_TIME);
   }
   
   if (wait)

--- a/xbmc/osx/IOSEAGLView.mm
+++ b/xbmc/osx/IOSEAGLView.mm
@@ -314,12 +314,14 @@
 {
   PRINT_SIGNATURE();
   pause = TRUE;
+  g_application.SetInBackground(true);
 }
 //--------------------------------------------------------------
 - (void) resumeAnimation
 {
   PRINT_SIGNATURE();
   pause = FALSE;
+  g_application.SetInBackground(false);
 }
 //--------------------------------------------------------------
 - (void) startAnimation

--- a/xbmc/osx/IOSEAGLView.mm
+++ b/xbmc/osx/IOSEAGLView.mm
@@ -46,6 +46,7 @@
 #import "IOSScreenManager.h"
 #import "AutoPool.h"
 #import "DarwinUtils.h"
+#import "XBMCDebugHelpers.h"
 
 //--------------------------------------------------------------
 @interface IOSEAGLView (PrivateMethods)
@@ -145,7 +146,7 @@
 //--------------------------------------------------------------
 - (id)initWithFrame:(CGRect)frame withScreen:(UIScreen *)screen
 {
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  //PRINT_SIGNATURE();
   framebufferResizeRequested = FALSE;
   if ((self = [super initWithFrame:frame]))
   {
@@ -165,9 +166,9 @@
       initWithAPI:kEAGLRenderingAPIOpenGLES2];
     
     if (!aContext)
-      NSLog(@"Failed to create ES context");
+      ELOG(@"Failed to create ES context");
     else if (![EAGLContext setCurrentContext:aContext])
-      NSLog(@"Failed to set ES context current");
+      ELOG(@"Failed to set ES context current");
     
     self.context = aContext;
     [aContext release];
@@ -188,7 +189,7 @@
 //--------------------------------------------------------------
 - (void) dealloc
 {
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  //PRINT_SIGNATURE();
   [self deleteFramebuffer];    
   [context release];
   
@@ -203,7 +204,7 @@
 //--------------------------------------------------------------
 - (void)setContext:(EAGLContext *)newContext
 {
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  PRINT_SIGNATURE();
   if (context != newContext)
   {
     [self deleteFramebuffer];
@@ -220,7 +221,7 @@
 {
   if (context && !defaultFramebuffer)
   {
-    //NSLog(@"%s", __PRETTY_FUNCTION__);
+    //PRINT_SIGNATURE();
     [EAGLContext setCurrentContext:context];
     
     // Create default framebuffer object.
@@ -241,7 +242,7 @@
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthRenderbuffer);
     
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-      NSLog(@"Failed to make complete framebuffer object %x", glCheckFramebufferStatus(GL_FRAMEBUFFER));
+      ELOG(@"Failed to make complete framebuffer object %x", glCheckFramebufferStatus(GL_FRAMEBUFFER));
   }
 }
 //--------------------------------------------------------------
@@ -249,7 +250,7 @@
 {
   if (context && !pause)
   {
-    //NSLog(@"%s", __PRETTY_FUNCTION__);
+    PRINT_SIGNATURE();
     [EAGLContext setCurrentContext:context];
     
     if (defaultFramebuffer)
@@ -311,16 +312,19 @@
 //--------------------------------------------------------------
 - (void) pauseAnimation
 {
+  PRINT_SIGNATURE();
   pause = TRUE;
 }
 //--------------------------------------------------------------
 - (void) resumeAnimation
 {
+  PRINT_SIGNATURE();
   pause = FALSE;
 }
 //--------------------------------------------------------------
 - (void) startAnimation
 {
+  PRINT_SIGNATURE();
 	if (!animating && context)
 	{
 		animating = TRUE;
@@ -338,6 +342,7 @@
 //--------------------------------------------------------------
 - (void) stopAnimation
 {
+  PRINT_SIGNATURE();
 	if (animating && context)
 	{
     [self deinitDisplayLink];
@@ -385,19 +390,19 @@
   if (!g_application.Create())
   {
     readyToRun = false;
-    NSLog(@"%sUnable to create application", __PRETTY_FUNCTION__);
+    ELOG(@"%sUnable to create application", __PRETTY_FUNCTION__);
   }
 
   if (!g_application.CreateGUI())
   {
     readyToRun = false;
-    NSLog(@"%sUnable to create GUI", __PRETTY_FUNCTION__);
+    ELOG(@"%sUnable to create GUI", __PRETTY_FUNCTION__);
   }
 
   if (!g_application.Initialize())
   {
     readyToRun = false;
-    NSLog(@"%sUnable to initialize application", __PRETTY_FUNCTION__);
+    ELOG(@"%sUnable to initialize application", __PRETTY_FUNCTION__);
   }
   
   if (readyToRun)
@@ -412,7 +417,7 @@
     }
     catch(...)
     {
-      NSLog(@"%sException caught on main loop. Exiting", __PRETTY_FUNCTION__);
+      ELOG(@"%sException caught on main loop. Exiting", __PRETTY_FUNCTION__);
     }
   }
 

--- a/xbmc/osx/ios/XBMCApplication.h
+++ b/xbmc/osx/ios/XBMCApplication.h
@@ -19,7 +19,8 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 
-@interface XBMCApplicationDelegate : NSObject <UIApplicationDelegate> {
+@interface XBMCApplicationDelegate : NSObject <UIApplicationDelegate, AVAudioSessionDelegate> {
 }
 @end

--- a/xbmc/osx/ios/XBMCApplication.m
+++ b/xbmc/osx/ios/XBMCApplication.m
@@ -23,32 +23,43 @@
 #import "XBMCApplication.h"
 #import "XBMCController.h"
 #import "IOSScreenManager.h"
+#import "XBMCDebugHelpers.h"
 
 @implementation XBMCApplicationDelegate
 XBMCController *m_xbmcController;  
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
+  PRINT_SIGNATURE();
+
   [m_xbmcController pauseAnimation];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
+  PRINT_SIGNATURE();
+
   [m_xbmcController resumeAnimation];
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
+  PRINT_SIGNATURE();
+
   [m_xbmcController pauseAnimation];
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application
 {
+  PRINT_SIGNATURE();
+
   [m_xbmcController pauseAnimation];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
+  PRINT_SIGNATURE();
+
   [m_xbmcController resumeAnimation];
 }
 
@@ -84,6 +95,8 @@ XBMCController *m_xbmcController;
 
 - (void)applicationDidFinishLaunching:(UIApplication *)application 
 {
+  PRINT_SIGNATURE();
+
   [[UIDevice currentDevice] setBatteryMonitoringEnabled:YES];
   UIScreen *currentScreen = [UIScreen mainScreen];
 
@@ -123,11 +136,11 @@ int main(int argc, char *argv[]) {
   } 
   @catch (id theException) 
   {
-    NSLog(@"%@", theException);
+    ELOG(@"%@", theException);
   }
   @finally 
   {
-    NSLog(@"This always happens.");
+    ILOG(@"This always happens.");
   }
     
   [pool release];

--- a/xbmc/osx/ios/XBMCController.h
+++ b/xbmc/osx/ios/XBMCController.h
@@ -42,6 +42,9 @@
   int  m_screenIdx;
 
   UIInterfaceOrientation orientation;
+  
+  bool m_isPlayingBeforeInactive;
+  bool m_isInterrupted;
 }
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property CGPoint lastGesturePoint;
@@ -55,6 +58,11 @@
 - (void) resumeAnimation;
 - (void) startAnimation;
 - (void) stopAnimation;
+- (void) enterBackground;
+- (void) enterForeground;
+- (void) becomeInactive;
+- (void) beginInterruption;
+- (void) endInterruption;
 - (void) sendKey: (XBMCKey) key;
 - (void) observeDefaultCenterStuff: (NSNotification *) notification;
 - (void) initDisplayLink;

--- a/xbmc/osx/ios/XBMCController.h
+++ b/xbmc/osx/ios/XBMCController.h
@@ -28,6 +28,13 @@
 
 @class IOSEAGLView;
 
+typedef enum
+{
+  IOS_PLAYBACK_STOPPED,
+  IOS_PLAYBACK_PAUSED,
+  IOS_PLAYBACK_PLAYING
+} IOSPlaybackState;
+
 @interface XBMCController : UIViewController <UIGestureRecognizerDelegate>
 {
   UIWindow *m_window;
@@ -46,6 +53,8 @@
   bool m_isPlayingBeforeInactive;
   bool m_isInterrupted;
   UIBackgroundTaskIdentifier m_bgTask;
+  NSTimer *m_networkAutoSuspendTimer;
+  IOSPlaybackState m_playbackState;
 }
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property CGPoint lastGesturePoint;
@@ -53,6 +62,7 @@
 @property bool touchBeginSignaled;
 @property int  m_screenIdx;
 @property CGSize screensize;
+@property (nonatomic, retain) NSTimer *m_networkAutoSuspendTimer;
 
 // message from which our instance is obtained
 - (void) pauseAnimation;
@@ -79,7 +89,7 @@
 - (void) deactivateKeyboard:(UIView *)view;
 
 - (void) disableNetworkAutoSuspend;
-- (void) enableNetworkAutoSuspend;
+- (void) enableNetworkAutoSuspend:(id)obj;
 - (void) disableSystemSleep;
 - (void) enableSystemSleep;
 - (void) disableScreenSaver;

--- a/xbmc/osx/ios/XBMCController.h
+++ b/xbmc/osx/ios/XBMCController.h
@@ -45,6 +45,7 @@
   
   bool m_isPlayingBeforeInactive;
   bool m_isInterrupted;
+  UIBackgroundTaskIdentifier m_bgTask;
 }
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property CGPoint lastGesturePoint;
@@ -77,6 +78,8 @@
 - (void) activateKeyboard:(UIView *)view;
 - (void) deactivateKeyboard:(UIView *)view;
 
+- (void) disableNetworkAutoSuspend;
+- (void) enableNetworkAutoSuspend;
 - (void) disableSystemSleep;
 - (void) enableSystemSleep;
 - (void) disableScreenSaver;

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -528,7 +528,7 @@ extern NSString* kBRScreenSaverDismissed;
 //--------------------------------------------------------------
 - (id)initWithFrame:(CGRect)frame withScreen:(UIScreen *)screen
 { 
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  PRINT_SIGNATURE();
   m_screenIdx = 0;
   self = [super init];
   if ( !self )
@@ -591,7 +591,7 @@ extern NSString* kBRScreenSaverDismissed;
 //--------------------------------------------------------------
 - (void)viewWillAppear:(BOOL)animated
 {
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  PRINT_SIGNATURE();
   
   // move this later into CocoaPowerSyscall
   [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
@@ -603,7 +603,7 @@ extern NSString* kBRScreenSaverDismissed;
 //--------------------------------------------------------------
 - (void)viewWillDisappear:(BOOL)animated
 {  
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  PRINT_SIGNATURE();
   
   [self pauseAnimation];
   
@@ -658,7 +658,7 @@ extern NSString* kBRScreenSaverDismissed;
 //--------------------------------------------------------------
 - (BOOL) recreateOnReselect
 { 
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  PRINT_SIGNATURE();
   return YES;
 }
 //--------------------------------------------------------------
@@ -719,7 +719,7 @@ extern NSString* kBRScreenSaverDismissed;
   
   /* Give player time to pause */
   Sleep(2000);
-  //NSLog(@"%s", __PRETTY_FUNCTION__);
+  PRINT_SIGNATURE();
   
   [m_glView pauseAnimation];
   
@@ -733,16 +733,22 @@ extern NSString* kBRScreenSaverDismissed;
   newEvent.appcommand.action = ACTION_PLAYER_PLAY;
   CWinEventsIOS::MessagePush(&newEvent);    
   
+  PRINT_SIGNATURE();
+
   [m_glView resumeAnimation];
 }
 //--------------------------------------------------------------
 - (void)startAnimation
 {
+  PRINT_SIGNATURE();
+
   [m_glView startAnimation];
 }
 //--------------------------------------------------------------
 - (void)stopAnimation
 {
+  PRINT_SIGNATURE();
+
   [m_glView stopAnimation];
 }
 #pragma mark -
@@ -750,7 +756,8 @@ extern NSString* kBRScreenSaverDismissed;
 //
 - (void)observeDefaultCenterStuff: (NSNotification *) notification
 {
-  //NSLog(@"default: %@", [notification name]);
+//  LOG(@"default: %@", [notification name]);
+//  LOG(@"userInfo: %@", [notification userInfo]);
 }
 
 @end

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -951,6 +951,22 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
       case UIEventSubtypeRemoteControlPreviousTrack:
         CApplicationMessenger::Get().SendAction(ACTION_PREV_ITEM);
         break;
+      case UIEventSubtypeRemoteControlBeginSeekingForward:
+        // use 4X speed forward.
+        CApplicationMessenger::Get().SendAction(ACTION_PLAYER_FORWARD);
+        CApplicationMessenger::Get().SendAction(ACTION_PLAYER_FORWARD);
+        break;
+      case UIEventSubtypeRemoteControlBeginSeekingBackward:
+        // use 4X speed rewind.
+        CApplicationMessenger::Get().SendAction(ACTION_PLAYER_REWIND);
+        CApplicationMessenger::Get().SendAction(ACTION_PLAYER_REWIND);
+        break;
+      case UIEventSubtypeRemoteControlEndSeekingForward:
+      case UIEventSubtypeRemoteControlEndSeekingBackward:
+        // restore to normal playback speed.
+        if (g_application.IsPlaying() && !g_application.IsPaused())
+          CApplicationMessenger::Get().SendAction(ACTION_PLAYER_PLAY);
+        break;
       default:
         LOG(@"unhandled subtype: %d", receivedEvent.subtype);
         break;

--- a/xbmc/osx/ios/XBMCIOS-Info.plist
+++ b/xbmc/osx/ios/XBMCIOS-Info.plist
@@ -36,6 +36,10 @@
 	<string>UIInterfaceOrientationLandscapeLeft</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
1. support ios native media control panel on lock screen and left of multi-task bar
2. continue play audio after lock screen with dark screen without stop.
3. support play audio in background (need user tap the play button in the media control panel of ios after xbmc enter background state)
4. support continue play after ios audio interrupt, like an alarm message form other app, or a phone call
5. support show current playing item info on ios' lock screen, thumb also supported (this is an feature need ios5+)

do not support play video background yet (when user init the video play/continue, default will pause video when enter background), since I not known how to drop frames.
