### PR TITLE
re-init tcp server when encounter EBADF

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -253,7 +253,15 @@ void CAirPlayServer::Process()
         newconnection.m_socket = accept(m_ServerSocket, &newconnection.m_cliaddr, &newconnection.m_addrlen);
 
         if (newconnection.m_socket == INVALID_SOCKET)
-          CLog::Log(LOGERROR, "AIRPLAY Server: Accept of new connection failed");
+        {
+          CLog::Log(LOGERROR, "AIRPLAY Server: Accept of new connection failed: %d", errno);
+          if (EBADF == errno)
+          {
+            Sleep(1000);
+            Initialize();
+            break;
+          }
+        }
         else
         {
           CLog::Log(LOGINFO, "AIRPLAY Server: New connection added");

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -182,7 +182,15 @@ void CTCPServer::Process()
           newconnection->m_socket = accept(*it, (sockaddr*)&newconnection->m_cliaddr, &newconnection->m_addrlen);
 
           if (newconnection->m_socket == INVALID_SOCKET)
-            CLog::Log(LOGERROR, "JSONRPC Server: Accept of new connection failed");
+          {
+            CLog::Log(LOGERROR, "JSONRPC Server: Accept of new connection failed: %d", errno);
+            if (EBADF == errno)
+            {
+              Sleep(1000);
+              Initialize();
+              break;
+            }
+          }
           else
           {
             CLog::Log(LOGINFO, "JSONRPC Server: New connection added");


### PR DESCRIPTION
on ios, if you lock screen for a while, then re-open, may encounter the EBADF erron of tcp listen socket accept() call and will dead loop forever with ECONNABORTED errno after the first EBADF error.

this commit fix this and make the tcp-server reinit when EBADF errno catched.
