### PR TITLE
[droid] allow landscape and reverse landscape orientation

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:configChanges="orientation|keyboardHidden"
             android:finishOnTaskLaunch="true"
             android:launchMode="singleInstance"
-            android:screenOrientation="landscape"
+            android:screenOrientation="sensorLandscape"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -37,7 +37,7 @@
             android:finishOnTaskLaunch="true"
             android:label="XBMC"
             android:launchMode="singleInstance"
-            android:screenOrientation="landscape"
+            android:screenOrientation="sensorLandscape"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
 
             <!-- Tell NativeActivity the name of or .so -->


### PR DESCRIPTION
This small change should allow users to flip their android device by 180 degrees and XBMC will rotate with it. It still ensures that XBMC is only displayed in landscape orientation but it will react to changes to the orientation. I can only test this on my Samsung Galaxy S2 so would love to get some additional feedback from other devices (phones, tablets and set-top boxes).

I tested the rotation during the initial boot screen, during library viewing and during video playback and music visualization and it worked fine in all cases.
