### PR TITLE
Fix xbmcvfs for write binary data to File.

### DIFF
--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -34,10 +34,10 @@ namespace XBMCAddon
       return (unsigned long)file->Read(buffer, numBytes);
     }
 
-    bool File::write(const char* pBuffer)
+    bool File::write(const char* pBuffer, unsigned long numBytes)
     {
       DelayedCallGuard dg(languageHook);
-      return file->Write( (void*) pBuffer, strlen( pBuffer ) ) > 0;
+      return file->Write( (void*) pBuffer, numBytes ) == numBytes;
     }
 
   }

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -66,7 +66,6 @@ namespace XBMCAddon
        *  f.close()
        */
       unsigned long read(void* buffer, unsigned long numBytes = 0);
-#endif
 
       /**
        * write(buffer)
@@ -78,7 +77,8 @@ namespace XBMCAddon
        *  result = f.write(buffer)
        *  f.close()
        */
-      bool write(const char* file);
+      bool write(const char* buffer, unsigned long numBytes);
+#endif
 
       /**
        * size()

--- a/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
@@ -71,6 +71,64 @@ using namespace xbmcvfs;
     return ret;
 }
 
+%feature("python:method:write") File
+{
+    TRACE;
+    static const char *keywords[] = {
+      "buffer",
+      NULL};
+
+
+    PyObject * bufferObj = 0 ;
+    if (!PyArg_ParseTupleAndKeywords(args,kwds,(char*)"O",
+         (char**)keywords,
+           &bufferObj
+         ))
+    {
+      return NULL;
+    }
+
+    if (!PyString_Check(bufferObj)) {
+      PyErr_SetString(PyExc_ValueError,"Expected a string");
+      return NULL;
+    }
+    const char *buffer = PyString_AsString(bufferObj);
+    unsigned long numBytes = PyString_Size(bufferObj);
+
+    bool  apiResult;
+    try
+    {
+
+      apiResult = (bool )((XBMCAddon::xbmcvfs::File*)retrieveApiInstance((PyObject*)self,&PyXBMCAddon_xbmcvfs_File_Type,"write","XBMCAddon::xbmcvfs::File"))-> write(  buffer,  numBytes  );
+
+    }
+    catch (const XBMCAddon::WrongTypeException& e)
+    { 
+      CLog::Log(LOGERROR,"EXCEPTION: %s",e.GetMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetMessage()); 
+      return NULL; 
+    }
+    catch (const XbmcCommons::Exception& e)
+    { 
+      CLog::Log(LOGERROR,"EXCEPTION: %s",e.GetMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetMessage()); 
+      return NULL; 
+    }
+    catch (...)
+    {
+      CLog::Log(LOGERROR,"EXCEPTION: Unknown exception thrown from the call 'write'");
+      PyErr_SetString(PyExc_RuntimeError, "Unknown exception thrown from the call 'write'"); 
+      return NULL; 
+    }
+
+    PyObject* result;
+
+    // transform the result
+    result = Py_BuildValue((char*)"b", apiResult);
+
+    return result; 
+}
+
 %include "interfaces/legacy/File.h"
 
 %rename ("st_atime") XBMCAddon::xbmcvfs::Stat::atime;


### PR DESCRIPTION
the swig support typemap for such situation, but seems xbmc not use swig generate code, instead output xml file and then use groovy code with some code copied from swig do the real work which seems not support multiple params typemap.
so, for support binary data write for the xbmcvfs module, I had to write a patch like the read method did, here it is.
