### PR TITLE
Update for the keyname so it's the same as used in keyboard.xml

### DIFF
--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -211,7 +211,7 @@ CStdString CKeyboardStat::GetKeyName(int KeyID)
     keyname.append(keytable.keyname);
   else
     keyname.AppendFormat("%i", keyid);
-  keyname.AppendFormat(" (%02x)", KeyID);
+  keyname.AppendFormat(" (%i)", KeyID);
 
   return keyname;
 }


### PR DESCRIPTION
Format of keyname must NOT be hex. The usage in keyboard.xml in the keymap directory is also NOT hex. This is giving very much trouble for people who want to use keyboard.xml. I spend more than an hour on this to figer it out as a non XBMC developer.
