### PR TITLE
bump libmicrohttpd for darwin to 0.9.24

### DIFF
--- a/tools/darwin/depends/libmicrohttpd/Makefile
+++ b/tools/darwin/depends/libmicrohttpd/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.include
 
 # lib name, version
 LIBNAME=libmicrohttpd
-VERSION=0.4.6
+VERSION=0.9.24
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
current old one low version hang xbmc when stop web server on ios.
so let we try to bump it to newer version.
current test indicate that the new version won't crash my xbmc on ios when stop/start web server in the network setting panel. 
