### PR TITLE
Update system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml

### DIFF
--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -36,7 +36,7 @@
 <!--   Coming soon.                                                                           -->
 <keymap>
   <global>
-    <joystick name="Sony PLAYSTATION(R)3 Controller">
+    <joystick name="PLAYSTATION(R)3 Controller">
       <altname>PS3 Controller</altname>
       <altname>Sony Computer Entertainment Wireless Controller</altname>
       <button id="15">Select</button>


### PR DESCRIPTION
In OSX 10.8 the system name for the PS3 controller is "PLAYSTATION(R)3 Controller" not "Sony PLAYSTATION(R)3 Controller". This allows the key map to be correctly assigned and fixes the key map for use in OSX Mountain Lion. 
