### PR TITLE
Bookmarks via Keypress

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9541,7 +9541,17 @@ msgctxt "#21361"
 msgid "Look for remote UPnP players"
 msgstr ""
 
-#empty strings from id 21362 to 21363
+#: xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+msgctx "#21362"
+msgid "Bookmark created"
+msgstr ""
+
+#: xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+msgctxt "#21363"
+msgid "Episode Bookmark created"
+msgstr ""
+
+
 
 msgctxt "#21364"
 msgid "Edit media share"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2659,6 +2659,16 @@ bool CApplication::OnAction(const CAction &action)
   if (action.IsMouse())
     g_Mouse.SetActive(true);
 
+  
+  if (action.GetID() == ACTION_CREATE_EPISODE_BOOKMARK)   
+  {
+    CGUIDialogVideoBookmarks::OnAddEpisodeBookmark();
+  }
+  if (action.GetID() == ACTION_CREATE_BOOKMARK)
+  {
+    CGUIDialogVideoBookmarks::OnAddBookmark();
+  }
+  
   // The action PLAYPAUSE behaves as ACTION_PAUSE if we are currently
   // playing or ACTION_PLAYER_PLAY if we are not playing.
   if (action.GetID() == ACTION_PLAYER_PLAYPAUSE)

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -190,6 +190,9 @@
 #define ACTION_VOLAMP_UP            93
 #define ACTION_VOLAMP_DOWN          94
 
+#define ACTION_CREATE_EPISODE_BOOKMARK 95 //Creates an episode bookmark on the currently playing video file containing more than one episode
+#define ACTION_CREATE_BOOKMARK         96 //Creates a bookmark of the currently playing video file
+
 #define ACTION_MOUSE_START            100
 #define ACTION_MOUSE_LEFT_CLICK       100
 #define ACTION_MOUSE_RIGHT_CLICK      101

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -218,6 +218,8 @@ static const ActionMapping actions[] =
         {"decreasepar"       , ACTION_DECREASE_PAR},
         {"volampup"          , ACTION_VOLAMP_UP},
         {"volampdown"        , ACTION_VOLAMP_DOWN},
+        {"createbookmark"        , ACTION_CREATE_BOOKMARK},
+        {"createepisodebookmark" , ACTION_CREATE_EPISODE_BOOKMARK},
 
         // PVR actions
         {"channelup"             , ACTION_CHANNEL_UP},

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -30,6 +30,7 @@
 #include "dialogs/GUIDialogContextMenu.h"
 #include "view/ViewState.h"
 #include "profiles/ProfilesManager.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "settings/AdvancedSettings.h"
 #include "FileItem.h"
 #include "guilib/Texture.h"
@@ -378,6 +379,9 @@ bool CGUIDialogVideoBookmarks::OnAddBookmark()
   if (CGUIDialogVideoBookmarks::AddBookmark()) 
   {
     g_windowManager.SendMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
+                                          g_localizeStrings.Get(298),   //"Bookmarks"
+                                          g_localizeStrings.Get(21362));//"Bookmark created"
     return true;
   }
   return false;
@@ -398,6 +402,10 @@ bool CGUIDialogVideoBookmarks::OnAddEpisodeBookmark()
       if(bReturn)
       {
         g_windowManager.SendMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, 
+                                              g_localizeStrings.Get(298),   //"Bookmarks"
+                                              g_localizeStrings.Get(21363));//"Episode Bookmark created"
+ 
       }
     }
     videoDatabase.Close();

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.h
@@ -35,13 +35,37 @@ public:
   virtual void OnWindowLoaded();
   virtual void OnWindowUnload();
 
+  /*!
+   \brief Creates a bookmark of the currently playing video file.
+   
+          NOTE: sends a GUI_MSG_REFRESH_LIST message to DialogVideoBookmark on success
+   \return True if creation of bookmark was succesful
+   \sa OnAddEpisodeBookmark
+   */
+  static bool OnAddBookmark();
+  
+  /*!
+   \brief Creates an episode bookmark of the currently playing file
+   
+          An episode bookmark specifies the end/beginning of episodes on files like: S01E01E02
+          Fails if the current video isn't a multi-episode file
+          NOTE: sends a GUI_MSG_REFRESH_LIST message to DialogVideoBookmark on success
+   \return True, if bookmark was successfully created
+   \sa OnAddBookmark
+   **/
+  static bool OnAddEpisodeBookmark();
+  
+  
+  void Update();
 protected:
   void GotoBookmark(int iItem);
   void ClearBookmarks();
-  void AddBookmark(CVideoInfoTag* tag=NULL);
+  static bool AddEpisodeBookmark();
+  static bool AddBookmark(CVideoInfoTag *tag=NULL);
+  
   void Clear();
-  void Update();
-  void AddEpisodeBookmark();
+  void OnRefreshList();
+  
 
   CGUIControl *GetFirstFocusableControl(int id);
 


### PR DESCRIPTION
This PR adds the functionality to add `<KEY>createbookmark</KEY>`
  or `<KEY mod="ctrl">createepisodebookmark</KEY>` to your keymaps.

Idea is from here: http://forum.xbmc.org/showthread.php?tid=83178

I also added a commit that adds 

``` xml
<b>createbookmark</b>
<b mod="ctrl">createepisodebookmark</b>
```

to the default keyboard.xml

I know that `<b>` is already used for some PVR related stuff, so not sure if I should remove that commit again. But for now I left it in for easier testing.
