### PR TITLE
Allow key ids in keyboard.xml to be in hex

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1268,9 +1268,17 @@ uint32_t CButtonTranslator::TranslateKeyboardButton(TiXmlElement *pButton)
   CStdString strKey = szButton;
   if (strKey.Equals("key"))
   {
-    int id = 0;
-    if (pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS)
-      button_id = (uint32_t)id;
+    CStdString strID;
+    if (pButton->QueryValueAttribute("id", &strID) == TIXML_SUCCESS)
+    {
+      const char *str = strID.c_str();
+      char *endptr;
+      long int id = strtol(str, &endptr, 0);
+      if (endptr - str != strlen(str) || id <= 0 || id > 0x00FFFFFF)
+        CLog::Log(LOGDEBUG, "%s - invalid key id %s", __FUNCTION__, strID.c_str());
+      else
+        button_id = (uint32_t) id;
+    }
     else
       CLog::Log(LOGERROR, "Keyboard Translator: `key' button has no id");
   }

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1268,7 +1268,7 @@ uint32_t CButtonTranslator::TranslateKeyboardButton(TiXmlElement *pButton)
   CStdString strKey = szButton;
   if (strKey.Equals("key"))
   {
-    CStdString strID;
+    std::string strID;
     if (pButton->QueryValueAttribute("id", &strID) == TIXML_SUCCESS)
     {
       const char *str = strID.c_str();

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -84,7 +84,7 @@ const CKey CKeyboardStat::ProcessKeyDown(XBMC_keysym& keysym)
   if (keysym.mod & XBMCKMOD_SUPER)
     modifiers |= CKey::MODIFIER_SUPER;
 
-  CLog::Log(LOGDEBUG, "Keyboard: scancode: %02x, sym: %04x, unicode: %04x, modifier: %x", keysym.scancode, keysym.sym, keysym.unicode, keysym.mod);
+  CLog::Log(LOGDEBUG, "Keyboard: scancode: 0x%02x, sym: 0x%04x, unicode: 0x%04x, modifier: 0x%x", keysym.scancode, keysym.sym, keysym.unicode, keysym.mod);
 
   // The keysym.unicode is usually valid, even if it is zero. A zero
   // unicode just means this is a non-printing keypress. The ascii and
@@ -211,7 +211,7 @@ CStdString CKeyboardStat::GetKeyName(int KeyID)
     keyname.append(keytable.keyname);
   else
     keyname.AppendFormat("%i", keyid);
-  keyname.AppendFormat(" (%02x)", KeyID);
+  keyname.AppendFormat(" (0x%02x)", KeyID);
 
   return keyname;
 }


### PR DESCRIPTION
This addresses the problem described in https://github.com/xbmc/xbmc/pull/2141

Keypress logging now prefixes hex values with 0x, and the key ids read from keyboard.xml can be in any base.
