### PR TITLE
[GUI] Show the language of audio tracks in the audio settings dialog

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -326,6 +326,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.type     = STREAM_AUDIO;
       s.id       = i;
       s.name     = nav->GetAudioStreamLanguage(i);
+      s.language = nav->GetAudioStreamLanguage(i);
       s.flags    = CDemuxStream::FLAG_NONE;
       s.filename = filename;
       s.channels = 0;


### PR DESCRIPTION
This adds the language or "unknown" in front of a audio track name.
For example: `English - 2/0 - AC3 Stereo`.
