### PR TITLE
Unify the assignment and usage of the name and language of streams

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11746,3 +11746,33 @@ msgstr ""
 msgctxt "#36042"
 msgid "Use limited color range (16-235)"
 msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37000"
+msgid "(Visually Impaired)"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37001"
+msgid "(Directors Comments)"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37002"
+msgid "(Directors Comments 2)"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37011"
+msgid "(CC)"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37012"
+msgid "(Forced)"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+msgctxt "#37013"
+msgid "(Directors Comments)"
+msgstr ""

--- a/lib/libdvd/libdvdnav/src/dvdnav.c
+++ b/lib/libdvd/libdvdnav/src/dvdnav.c
@@ -925,27 +925,10 @@ uint16_t dvdnav_audio_stream_format(dvdnav_t *this, uint8_t stream) {
   attr = vm_get_audio_attr(this->vm, stream);
   pthread_mutex_unlock(&this->vm_lock);
 
-  switch(attr.audio_format) {
-  case 0:
-    format = DVDNAV_FORMAT_AC3;
-    break;
-  case 2: /* MPEG-1 or MPEG-2 without extension bitstream. */
-  case 3: /* MPEG-2 with extension bitstream. */
-    format = DVDNAV_FORMAT_MPEGAUDIO;
-    break;
-  case 4:
-    format = DVDNAV_FORMAT_LPCM;
-    break;
-  case 6:
-    format = DVDNAV_FORMAT_DTS;
-    break;
-  case 7:
-    format = DVDNAV_FORMAT_SDDS;
-    break;
-  default:
+  if (attr.audio_format >=0 && attr.audio_format <= 7)
+    format = attr.audio_format;
+  else
     format = 0xffff;
-    break;
-  }
 
   return format;
 }

--- a/lib/libdvd/libdvdnav/src/dvdnav/dvd_types.h
+++ b/lib/libdvd/libdvdnav/src/dvdnav/dvd_types.h
@@ -161,14 +161,13 @@ typedef enum {
 /* The audio format */
 typedef enum {
   DVD_AUDIO_FORMAT_AC3       = 0,
-  DVD_AUDIO_FORMAT_MPEG1     = 1,
-  DVD_AUDIO_FORMAT_MPEG1_DRC = 2,
-  DVD_AUDIO_FORMAT_MPEG2     = 3,
-  DVD_AUDIO_FORMAT_MPEG2_DRC = 4,
-  DVD_AUDIO_FORMAT_LPCM      = 5,
+  DVD_AUDIO_FORMAT_UNKNOWN_1 = 1,
+  DVD_AUDIO_FORMAT_MPEG      = 2,
+  DVD_AUDIO_FORMAT_MPEG2_EXT = 3,
+  DVD_AUDIO_FORMAT_LPCM      = 4,
+  DVD_AUDIO_FORMAT_UNKNOWN_5 = 5,
   DVD_AUDIO_FORMAT_DTS       = 6,
-  DVD_AUDIO_FORMAT_SDDS      = 7,
-  DVD_AUDIO_FORMAT_Other     = 8
+  DVD_AUDIO_FORMAT_SDDS      = 7
 } DVDAudioFormat_t;
 
 /* Audio language extension */

--- a/lib/libdvd/libdvdnav/src/dvdnav/dvdnav.h
+++ b/lib/libdvd/libdvdnav/src/dvdnav/dvdnav.h
@@ -32,11 +32,11 @@
 extern "C" {
 #endif
 
-#  include <dvdnav/dvd_types.h>
-#  include <dvdread/dvd_reader.h>
-#  include <dvdread/nav_types.h>
-#  include <dvdread/ifo_types.h> /* For vm_cmd_t */
-#  include <dvdnav/dvdnav_events.h>
+#include <dvdnav/dvd_types.h>
+#include <dvdread/dvd_reader.h>
+#include <dvdread/nav_types.h>
+#include <dvdread/ifo_types.h> /* For vm_cmd_t */
+#include <dvdnav/dvdnav_events.h>
 
 
 

--- a/lib/libdvd/libdvdnav/src/dvdnav/dvdnav.h
+++ b/lib/libdvd/libdvdnav/src/dvdnav/dvdnav.h
@@ -63,12 +63,6 @@ typedef int32_t dvdnav_status_t;
 #define DVDNAV_STATUS_ERR 0
 #define DVDNAV_STATUS_OK  1
 
-#define DVDNAV_FORMAT_AC3 0
-#define DVDNAV_FORMAT_MPEGAUDIO 3
-#define DVDNAV_FORMAT_LPCM 4
-#define DVDNAV_FORMAT_DTS 5
-#define DVDNAV_FORMAT_SDDS 6
-
 /*********************************************************************
  * initialisation & housekeeping functions                           *
  *********************************************************************/

--- a/lib/libdvd/patches/libdvdnav_correct_audio_format_enum.diff
+++ b/lib/libdvd/patches/libdvdnav_correct_audio_format_enum.diff
@@ -1,0 +1,23 @@
+--- libdvdnav-4.2.0/src/dvdnav/dvd_types.h	Wed Mar 20 08:51:10 2013
++++ lib/libdvd/libdvdnav/src/dvdnav/dvd_types.h	Wed Mar 20 12:22:25 2013
+@@ -161,14 +161,13 @@
+ /* The audio format */
+ typedef enum {
+   DVD_AUDIO_FORMAT_AC3       = 0,
+-  DVD_AUDIO_FORMAT_MPEG1     = 1,
+-  DVD_AUDIO_FORMAT_MPEG1_DRC = 2,
+-  DVD_AUDIO_FORMAT_MPEG2     = 3,
+-  DVD_AUDIO_FORMAT_MPEG2_DRC = 4,
+-  DVD_AUDIO_FORMAT_LPCM      = 5,
++  DVD_AUDIO_FORMAT_UNKNOWN_1 = 1,
++  DVD_AUDIO_FORMAT_MPEG      = 2,
++  DVD_AUDIO_FORMAT_MPEG2_EXT = 3,
++  DVD_AUDIO_FORMAT_LPCM      = 4,
++  DVD_AUDIO_FORMAT_UNKNOWN_5 = 5,
+   DVD_AUDIO_FORMAT_DTS       = 6,
+-  DVD_AUDIO_FORMAT_SDDS      = 7,
+-  DVD_AUDIO_FORMAT_Other     = 8
++  DVD_AUDIO_FORMAT_SDDS      = 7
+ } DVDAudioFormat_t;
+ 
+ /* Audio language extension */

--- a/lib/libdvd/patches/libdvdnav_correct_dvdnav_audio_stream_format.diff
+++ b/lib/libdvd/patches/libdvdnav_correct_dvdnav_audio_stream_format.diff
@@ -1,0 +1,33 @@
+--- libdvdnav-4.2.0/src/dvdnav.c	Wed Mar 20 11:38:53 2013
++++ lib/libdvd/libdvdnav/src/dvdnav.c	Wed Mar 20 13:20:35 2013
+@@ -907,27 +925,10 @@
+   attr = vm_get_audio_attr(this->vm, stream);
+   pthread_mutex_unlock(&this->vm_lock);
+ 
+-  switch(attr.audio_format) {
+-  case 0:
+-    format = DVDNAV_FORMAT_AC3;
+-    break;
+-  case 2: /* MPEG-1 or MPEG-2 without extension bitstream. */
+-  case 3: /* MPEG-2 with extension bitstream. */
+-    format = DVDNAV_FORMAT_MPEGAUDIO;
+-    break;
+-  case 4:
+-    format = DVDNAV_FORMAT_LPCM;
+-    break;
+-  case 6:
+-    format = DVDNAV_FORMAT_DTS;
+-    break;
+-  case 7:
+-    format = DVDNAV_FORMAT_SDDS;
+-    break;
+-  default:
++  if (attr.audio_format >=0 && attr.audio_format <= 7)
++    format = attr.audio_format;
++  else
+     format = 0xffff;
+-    break;
+-  }
+ 
+   return format;
+ }

--- a/lib/libdvd/patches/libdvdnav_remove_unneeded_defines.diff
+++ b/lib/libdvd/patches/libdvdnav_remove_unneeded_defines.diff
@@ -1,0 +1,15 @@
+--- libdvdnav-4.2.0/src/dvdnav/dvdnav.h	Wed Mar 20 11:38:52 2013
++++ lib/libdvd/libdvdnav/src/dvdnav/dvdnav.h	Wed Mar 20 13:19:13 2013
+@@ -63,12 +63,6 @@
+ #define DVDNAV_STATUS_ERR 0
+ #define DVDNAV_STATUS_OK  1
+ 
+-#define DVDNAV_FORMAT_AC3 0
+-#define DVDNAV_FORMAT_MPEGAUDIO 3
+-#define DVDNAV_FORMAT_LPCM 4
+-#define DVDNAV_FORMAT_DTS 5
+-#define DVDNAV_FORMAT_SDDS 6
+-
+ /*********************************************************************
+  * initialisation & housekeeping functions                           *
+  *********************************************************************/

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -914,20 +914,9 @@ void CAMLPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
   if (index > (int)m_subtitle_streams.size() -1 || index < 0)
     return;
 
-  if (m_subtitle_streams[m_subtitle_index]->source == STREAM_SOURCE_NONE)
-  {
-    if ( m_subtitle_streams[index]->language.size())
-    {
-      CStdString name;
-      g_LangCodeExpander.Lookup(name, m_subtitle_streams[index]->language);
-      info.name = name;
-    }
-  }
-  else
-  {
-    if(m_subtitle_streams[m_subtitle_index]->name.length() > 0)
-      info.name = m_subtitle_streams[m_subtitle_index]->name;
-  }
+  info.language = m_subtitle_streams[index]->language;
+  info.name = m_subtitle_streams[m_subtitle_index]->name;
+
   if (m_log_level > 5)
     CLog::Log(LOGDEBUG, "CAMLPlayer::GetSubtitleName, iStream(%d)", index);
 }
@@ -1101,8 +1090,7 @@ void CAMLPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 
   info.bitrate = m_audio_streams[index]->bit_rate;
 
-  if ( m_audio_streams[index]->language.size())
-    info.language = m_audio_streams[index]->language;
+  info.language = m_audio_streams[index]->language;
 
   info.channels = m_audio_streams[index]->channel;
 

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -922,15 +922,11 @@ void CAMLPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
       g_LangCodeExpander.Lookup(name, m_subtitle_streams[index]->language);
       info.name = name;
     }
-    else
-      info.name = g_localizeStrings.Get(13205); // Unknown
   }
   else
   {
     if(m_subtitle_streams[m_subtitle_index]->name.length() > 0)
       info.name = m_subtitle_streams[m_subtitle_index]->name;
-    else
-      info.name = g_localizeStrings.Get(13205); // Unknown
   }
   if (m_log_level > 5)
     CLog::Log(LOGDEBUG, "CAMLPlayer::GetSubtitleName, iStream(%d)", index);
@@ -1112,13 +1108,30 @@ void CAMLPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 
   info.audioCodecName = AudioCodecName(m_audio_streams[index]->format);
 
-  info.name.Format("Undefined");
-    
-  if ( m_audio_streams[index]->language.size())
+  if (info.audioCodecName.size())
+    info.name = info.audioCodecName + " ";
+
+  switch(info.channels)
   {
-    CStdString name;
-    g_LangCodeExpander.Lookup( name, m_audio_streams[index]->language);
-    info.name = name;
+  case 1:
+    info.name += "Mono";
+    break;
+  case 2: 
+    info.name += "Stereo";
+    break;
+  case 6: 
+    info.name += "5.1";
+    break;
+  case 7:
+    info.name += "6.1";
+    break;
+  case 8:
+    info.name += "7.1";
+    break;
+  default:
+    char temp[32];
+    sprintf(temp, "%d-chs", info.channels);
+    info.name += temp;
   }
 }
 

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -1942,7 +1942,16 @@ bool CAMLPlayer::WaitForFormatValid(int timeout_ms)
             info->format          = media_info.audio_info[i]->aformat;
 #if !defined(TARGET_ANDROID)
             if (media_info.audio_info[i]->audio_language[0] != 0)
+            {
               info->language = std::string(media_info.audio_info[i]->audio_language, 3);
+
+              if (info->language.length() == 2)
+              {
+                CStdString lang;
+                g_LangCodeExpander.ConvertToThreeCharCode(lang, info->language);
+                info->language = lang;
+              }
+            }
 #endif
             m_audio_streams.push_back(info);
           }
@@ -1966,7 +1975,16 @@ bool CAMLPlayer::WaitForFormatValid(int timeout_ms)
             info->id   = media_info.sub_info[i]->id;
             info->type = STREAM_SUBTITLE;
             if (media_info.sub_info[i]->sub_language && media_info.sub_info[i]->sub_language[0] != 0)
+            {
               info->language = std::string(media_info.sub_info[i]->sub_language, 3);
+
+              if (info->language.length() == 2)
+              {
+                CStdString lang;
+                g_LangCodeExpander.ConvertToThreeCharCode(lang, info->language);
+                info->language = lang;
+              }
+            }
             m_subtitle_streams.push_back(info);
           }
           m_subtitle_index = media_info.stream_info.cur_sub_index;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -43,15 +43,17 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
       strcpy(sInfo, "DTS ");
   }
   else if (codec == CODEC_ID_MP2) strcpy(sInfo, "MP2 ");
+  else if (codec == CODEC_ID_TRUEHD) strcpy(sInfo, "Dolby TrueHD ");
   else strcpy(sInfo, "");
 
   if (iChannels == 1) strcat(sInfo, "Mono");
   else if (iChannels == 2) strcat(sInfo, "Stereo");
   else if (iChannels == 6) strcat(sInfo, "5.1");
+  else if (iChannels == 8) strcat(sInfo, "7.1");
   else if (iChannels != 0)
   {
     char temp[32];
-    sprintf(temp, " %d %s", iChannels, "Channels");
+    sprintf(temp, " %d%s", iChannels, "-chs");
     strcat(sInfo, temp);
   }
   strInfo = sInfo;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -20,7 +20,6 @@
 
 #include "DVDDemux.h"
 #include "DVDCodecs/DVDCodecs.h"
-#include "utils/LangCodeExpander.h"
 
 void CDemuxStreamTeletext::GetStreamInfo(std::string& strInfo)
 {
@@ -168,14 +167,7 @@ CDemuxStreamTeletext* CDVDDemux::GetStreamFromTeletextId(int iTeletextIndex)
 
 void CDemuxStream::GetStreamName( std::string& strInfo )
 {
-  if( language[0] == 0 )
-    strInfo = "";
-  else
-  {
-    CStdString name;
-    g_LangCodeExpander.Lookup( name, language );
-    strInfo = name;
-  }
+  strInfo = "";
 }
 
 AVDiscard CDemuxStream::GetDiscard()

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -960,16 +960,20 @@ void CDVDInputStreamNavigator::SetAudioStreamName(DVDNavStreamInfo &info, const 
   case DVD_AUDIO_FORMAT_AC3:
     info.name += " AC3";
     break;
-  case DVD_AUDIO_FORMAT_MPEG1:
-  case DVD_AUDIO_FORMAT_MPEG1_DRC:
-    info.name += " MP1";
+  case DVD_AUDIO_FORMAT_UNKNOWN_1:
+    info.name += " UNKNOWN #1";
     break;
-  case DVD_AUDIO_FORMAT_MPEG2:
-  case DVD_AUDIO_FORMAT_MPEG2_DRC:
-    info.name += " MP2";
+  case DVD_AUDIO_FORMAT_MPEG:
+    info.name += " MPEG AUDIO";
+    break;
+  case DVD_AUDIO_FORMAT_MPEG2_EXT:
+    info.name += " MP2 Ext.";
     break;
   case DVD_AUDIO_FORMAT_LPCM:
     info.name += " LPCM";
+    break;
+  case DVD_AUDIO_FORMAT_UNKNOWN_5:
+    info.name += " UNKNOWN #5";
     break;
   case DVD_AUDIO_FORMAT_DTS:
     info.name += " DTS";

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -28,6 +28,7 @@
 #include "guilib/Geometry.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "guilib/LocalizeStrings.h"
 #if defined(TARGET_DARWIN)
 #include "osx/CocoaInterface.h"
 #endif
@@ -864,15 +865,15 @@ void CDVDInputStreamNavigator::SetSubtitleStreamName(DVDNavStreamInfo &info, con
     case DVD_SUBPICTURE_LANG_EXT_NormalCC:
     case DVD_SUBPICTURE_LANG_EXT_BigCC:
     case DVD_SUBPICTURE_LANG_EXT_ChildrensCC:
-      info.name += "(CC)";
+      info.name += g_localizeStrings.Get(37011);
       break;
     case DVD_SUBPICTURE_LANG_EXT_Forced:
-      info.name += "(Forced)";
+      info.name += g_localizeStrings.Get(37012);
       break;
     case DVD_SUBPICTURE_LANG_EXT_NormalDirectorsComments:
     case DVD_SUBPICTURE_LANG_EXT_BigDirectorsComments:
     case DVD_SUBPICTURE_LANG_EXT_ChildrensDirectorsComments:
-      info.name += "(Directors Comments)";
+      info.name += g_localizeStrings.Get(37013);
       break;
     default:
       break;
@@ -940,13 +941,13 @@ void CDVDInputStreamNavigator::SetAudioStreamName(DVDNavStreamInfo &info, const 
   switch( audio_attributes.code_extension )
   {
   case DVD_AUDIO_LANG_EXT_VisuallyImpaired:
-    info.name = "(Visually Impaired)";
+    info.name = g_localizeStrings.Get(37000);
     break;
   case DVD_AUDIO_LANG_EXT_DirectorsComments1:
-    info.name = "(Directors Comments)";
+    info.name = g_localizeStrings.Get(37001);
     break;
   case DVD_AUDIO_LANG_EXT_DirectorsComments2:
-    info.name = "(Directors Comments 2)";
+    info.name = g_localizeStrings.Get(37002);
     break;
   case DVD_AUDIO_LANG_EXT_NotSpecified:
   case DVD_AUDIO_LANG_EXT_NormalCaptions:

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -105,8 +105,8 @@ public:
   bool IsInMenu() { return m_bInMenu; }
 
   int GetActiveSubtitleStream();
-  std::string GetSubtitleStreamLanguage(int iId);
   int GetSubTitleStreamCount();
+  bool GetSubtitleStreamInfo(const int iId, DVDNavStreamInfo &info);
 
   bool SetActiveSubtitleStream(int iId);
   void EnableSubtitleStream(bool bEnable);
@@ -155,6 +155,7 @@ protected:
   int ConvertSubtitleStreamId_ExternalToXBMC(int id);
 
   void SetAudioStreamName(DVDNavStreamInfo &info, const audio_attr_t audio_attributes);
+  void SetSubtitleStreamName(DVDNavStreamInfo &info, const subp_attr_t subp_attributes);
 
   DllDvdNav m_dll;
   bool m_bCheckButtons;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -44,6 +44,15 @@ class CDVDOverlayPicture;
 
 struct dvdnav_s;
 
+struct DVDNavStreamInfo
+{
+  std::string name;
+  std::string language;
+  int channels;
+
+  DVDNavStreamInfo() : channels(0) {}
+};
+
 class DVDNavResult
 {
 public:
@@ -104,9 +113,9 @@ public:
   bool IsSubtitleStreamEnabled();
 
   int GetActiveAudioStream();
-  std::string GetAudioStreamLanguage(int iId);
   int GetAudioStreamCount();
   bool SetActiveAudioStream(int iId);
+  bool GetAudioStreamInfo(const int iId, DVDNavStreamInfo &info);
 
   bool GetNavigatorState(std::string &xmlstate);
   bool SetNavigatorState(std::string &xmlstate);
@@ -144,6 +153,8 @@ protected:
    */
   int ConvertSubtitleStreamId_XBMCToExternal(int id);
   int ConvertSubtitleStreamId_ExternalToXBMC(int id);
+
+  void SetAudioStreamName(DVDNavStreamInfo &info, const audio_attr_t audio_attributes);
 
   DllDvdNav m_dll;
   bool m_bCheckButtons;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/dvdnav/dvd_types.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/dvdnav/dvd_types.h
@@ -163,15 +163,14 @@ typedef enum {
 
 /* The audio format */
 typedef enum {
-  DVD_AUDIO_FORMAT_AC3       = 0,
-  DVD_AUDIO_FORMAT_MPEG1     = 1,
-  DVD_AUDIO_FORMAT_MPEG1_DRC = 2,
-  DVD_AUDIO_FORMAT_MPEG2     = 3,
-  DVD_AUDIO_FORMAT_MPEG2_DRC = 4,
-  DVD_AUDIO_FORMAT_LPCM      = 5,
-  DVD_AUDIO_FORMAT_DTS       = 6,
-  DVD_AUDIO_FORMAT_SDDS      = 7,
-  DVD_AUDIO_FORMAT_Other     = 8
+  DVD_AUDIO_FORMAT_AC3        = 0,
+  DVD_AUDIO_FORMAT_UNKNOWN_1  = 1,
+  DVD_AUDIO_FORMAT_MPEG       = 2,
+  DVD_AUDIO_FORMAT_MPEG2_EXT  = 3,
+  DVD_AUDIO_FORMAT_LPCM       = 4,
+  DVD_AUDIO_FORMAT_UNKNOWN_5  = 5,
+  DVD_AUDIO_FORMAT_DTS        = 6,
+  DVD_AUDIO_FORMAT_SDDS       = 7
 } DVDAudioFormat_t;
 
 /* Audio language extension */

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -318,10 +318,14 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.source   = source;
       s.type     = STREAM_AUDIO;
       s.id       = i;
-      s.name     = nav->GetAudioStreamLanguage(i);
       s.flags    = CDemuxStream::FLAG_NONE;
       s.filename = filename;
-      s.channels = 0;
+
+      DVDNavStreamInfo info;
+      nav->GetAudioStreamInfo(i, info);
+      s.name     = info.name;
+      s.language = info.language;
+      s.channels = info.channels;
       Update(s);
     }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -336,10 +336,14 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.source   = source;
       s.type     = STREAM_SUBTITLE;
       s.id       = i;
-      s.name     = nav->GetSubtitleStreamLanguage(i);
       s.flags    = CDemuxStream::FLAG_NONE;
       s.filename = filename;
       s.channels = 0;
+
+      DVDNavStreamInfo info;
+      nav->GetSubtitleStreamInfo(i, info);
+      s.name     = info.name;
+      s.language = info.language;
       Update(s);
     }
   }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2711,11 +2711,7 @@ void CDVDPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
   if(s.type == STREAM_NONE)
     info.name += "(Invalid)";
 
-  CStdString strStreamLang;
-  if (!g_LangCodeExpander.Lookup(strStreamLang, s.language))
-    info.language = g_localizeStrings.Get(13205); // Unknown
-  else
-    info.language = strStreamLang;
+  info.language = s.language;
 }
 
 void CDVDPlayer::SetSubtitle(int iStream)

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -369,6 +369,14 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.type     = stream->type;
       s.id       = stream->iId;
       s.language = stream->language;
+
+      if (s.language.length() == 2)
+      {
+        CStdString lang;
+        g_LangCodeExpander.ConvertToThreeCharCode(lang, stream->language);
+        s.language = lang;
+      }
+
       s.flags    = stream->flags;
       s.filename = demuxer->GetFileName();
       stream->GetStreamName(s.name);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2699,8 +2699,6 @@ void CDVDPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
   SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, index);
   if(s.name.length() > 0)
     info.name = s.name;
-  else
-    info.name = g_localizeStrings.Get(13205); // Unknown
 
   if(s.type == STREAM_NONE)
     info.name += "(Invalid)";
@@ -3843,8 +3841,6 @@ void CDVDPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 
   if(s.name.length() > 0)
     info.name = s.name;
-  else
-    info.name += "Unknown";
 
   if(s.type == STREAM_NONE)
     info.name += " (Invalid)";

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2700,8 +2700,6 @@ void COMXPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
   OMXSelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, index);
   if(s.name.length() > 0)
     info.name = s.name;
-  else
-    info.name = g_localizeStrings.Get(13205); // Unknown
 
   if(s.type == STREAM_NONE)
     info.name += "(Invalid)";
@@ -3797,8 +3795,6 @@ void COMXPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 
   if(s.name.length() > 0)
     info.name = s.name;
-  else
-    info.name += "Unknown";
 
   if(s.type == STREAM_NONE)
     info.name += " (Invalid)";

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -336,10 +336,14 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.source   = source;
       s.type     = STREAM_SUBTITLE;
       s.id       = i;
-      s.name     = nav->GetSubtitleStreamLanguage(i);
       s.flags    = CDemuxStream::FLAG_NONE;
       s.filename = filename;
       s.channels = 0;
+
+      DVDNavStreamInfo info;
+      nav->GetSubtitleStreamInfo(i, info);
+      s.name     = info.name;
+      s.language = info.language;
       Update(s);
     }
   }

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2712,11 +2712,7 @@ void COMXPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
   if(s.type == STREAM_NONE)
     info.name += "(Invalid)";
 
-  CStdString strStreamLang;
-  if (!g_LangCodeExpander.Lookup(strStreamLang, s.language))
-    info.language = g_localizeStrings.Get(13205); // Unknown
-  else
-    info.language = strStreamLang;
+  info.language = s.language;
 }
 
 void COMXPlayer::SetSubtitle(int iStream)

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -369,6 +369,14 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.type     = stream->type;
       s.id       = stream->iId;
       s.language = stream->language;
+
+      if (s.language.length() == 2)
+      {
+        CStdString lang;
+        g_LangCodeExpander.ConvertToThreeCharCode(lang, stream->language);
+        s.language = lang;
+      }
+
       s.flags    = stream->flags;
       s.filename = demuxer->GetFileName();
       stream->GetStreamName(s.name);

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -318,10 +318,14 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.source   = source;
       s.type     = STREAM_AUDIO;
       s.id       = i;
-      s.name     = nav->GetAudioStreamLanguage(i);
       s.flags    = CDemuxStream::FLAG_NONE;
       s.filename = filename;
-      s.channels = 0;
+
+      DVDNavStreamInfo info;
+      nav->GetAudioStreamInfo(i, info);
+      s.name     = info.name;
+      s.language = info.language;
+      s.channels = info.channels;
       Update(s);
     }
 

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -28,7 +28,6 @@
 #include "ApplicationMessenger.h"
 #include "GUIInfoManager.h"
 #include "AddonUtils.h"
-#include "utils/LangCodeExpander.h"
 #include "utils/log.h"
 #include "cores/IPlayer.h"
 
@@ -396,11 +395,11 @@ namespace XBMCAddon
       {
         SPlayerSubtitleStreamInfo info;
         g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
-        CStdString strName = info.name;
 
-        if (strName == "Unknown(Invalid)")
-          strName = "";
-        return strName;
+        if (info.language.length() > 0)
+          return info.language;
+        else
+          return info.name;
       }
 
       return NULL;
@@ -428,10 +427,10 @@ namespace XBMCAddon
           SPlayerSubtitleStreamInfo info;
           g_application.m_pPlayer->GetSubtitleStreamInfo(iStream, info);
 
-          CStdString FullLang;
-          if (!g_LangCodeExpander.Lookup(FullLang, info.name))
-            FullLang = info.name;
-          (*ret)[iStream] = FullLang;
+          if (info.language.length() > 0)
+            (*ret)[iStream] = info.language;
+          else
+            (*ret)[iStream] = info.name;
         }
         return ret;
       }
@@ -463,11 +462,10 @@ namespace XBMCAddon
           SPlayerAudioStreamInfo info;
           g_application.m_pPlayer->GetAudioStreamInfo(iStream, info);
 
-          CStdString FullLang;
-          g_LangCodeExpander.Lookup(FullLang, info.language);
-          if (FullLang.IsEmpty())
-            FullLang = info.name;
-          (*ret)[iStream] = FullLang;
+          if (info.language.length() > 0)
+            (*ret)[iStream] = info.language;
+          else
+            (*ret)[iStream] = info.name;
         }
         return ret;
       }

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -38,6 +38,7 @@
 #include "pvr/PVRManager.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/IPlayer.h"
+#include "utils/LangCodeExpander.h"
 
 using namespace std;
 using namespace XFILE;
@@ -162,16 +163,20 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(unsigned int id)
   for (int i = 0; i <= setting.max; ++i)
   {
     CStdString strItem;
-    CStdString strName;
+    CStdString strLanguage;
 
     SPlayerAudioStreamInfo info;
     g_application.m_pPlayer->GetAudioStreamInfo(i, info);
 
-    strName = info.name;
-    if (strName.length() == 0)
-      strName = "Unnamed";
+    if (!g_LangCodeExpander.Lookup(strLanguage, info.language))
+      strLanguage = g_localizeStrings.Get(13205); // Unknown
 
-    strItem.Format("%s (%i/%i)", strName.c_str(), i + 1, (int)setting.max + 1);
+    if (info.name.length() == 0)
+      strItem = strLanguage;
+    else
+      strItem.Format("%s - %s", strLanguage.c_str(), info.name.c_str());
+
+    strItem.Format("%s (%i/%i)", strItem.c_str(), i + 1, (int)setting.max + 1);
     setting.entry.push_back(make_pair(setting.entry.size(), strItem));
   }
 
@@ -207,15 +212,17 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(unsigned int id)
     g_application.m_pPlayer->GetSubtitleStreamInfo(i, info);
 
     CStdString strItem;
-    CStdString strName = info.name;
+    CStdString strLanguage;
 
-    if (strName.length() == 0)
-      strName = "Unnamed";
+    if (!g_LangCodeExpander.Lookup(strLanguage, info.language))
+      strLanguage = g_localizeStrings.Get(13205); // Unknown
 
-    if (strName != info.language)
-      strName.Format("%s [%s]", strName.c_str(), info.language.c_str());
+    if (info.name.length() == 0)
+      strItem = strLanguage;
+    else
+      strItem.Format("%s - %s", strLanguage.c_str(), info.name.c_str());
 
-    strItem.Format("%s (%i/%i)", strName.c_str(), i + 1, (int)setting.max + 1);
+    strItem.Format("%s (%i/%i)", strItem.c_str(), i + 1, (int)setting.max + 1);
 
     setting.entry.push_back(make_pair(setting.entry.size(), strItem));
   }


### PR DESCRIPTION
The first few commits improve/correct the assignment of dvd streams' name and language.
Next the get*Language methods now return a three char code if possible.
This code is used to show the full language name in the gui.
