### PR TITLE
add "Add art" button to video artwork selection dialog

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -5392,7 +5392,12 @@ msgctxt "#13515"
 msgid "No art"
 msgstr ""
 
-#empty strings from id 13516 to 13549
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+msgctxt "#13516"
+msgid "Add art"
+msgstr ""
+
+#empty strings from id 13517 to 13549
 
 #: xbmc/settings/GUISettings.cpp
 msgctxt "#13550"

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -29,6 +29,7 @@
 #include "video/VideoInfoScanner.h"
 #include "ApplicationMessenger.h"
 #include "video/VideoInfoTag.h"
+#include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -604,6 +605,7 @@ string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, map<string
   dialog->SetHeading(13511);
   dialog->Reset();
   dialog->SetUseDetails(true);
+  dialog->EnableButton(true, 13516);
 
   CVideoDatabase db;
   db.Open();
@@ -630,6 +632,16 @@ string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, map<string
 
   dialog->SetItems(&items);
   dialog->DoModal();
+
+  if (dialog->IsButtonPressed())
+  {
+    // Get the new artwork name
+    CStdString strArtworkName;
+    if (!CGUIKeyboardFactory::ShowAndGetInput(strArtworkName, g_localizeStrings.Get(13516), false))
+      return "";
+
+    return strArtworkName;
+  }
 
   return dialog->GetSelectedItem()->GetLabel();
 }


### PR DESCRIPTION
This adds an "Add art" button to the video artwork selection dialog. This allows users to add alternative artwork (landscape, banner, etc) without having to use an addon like Artwork Downloader (which does a great job but is fully automated). Ideally we'd offer the user with a list of existing artwork types when using the "Add art" button but that can still be added later on.

PS: I accidentally hit Enter when editing the PR title, so I submitted it without a description.
