### PR TITLE
Fix videos from being unrecognised by picture slideshow.

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -837,6 +837,10 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
       if (m_slides->Size() <= 1)
         m_bSlideShow = false;
 
+      // stop all video when becoming visible, e.g. an interrupted video
+      if (g_application.IsPlayingVideo())
+        g_application.StopPlaying();
+
       return true;
     }
     break;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -289,6 +289,8 @@ void CGUIWindowSlideShow::Add(const CFileItem *picture)
   {
     // item without tag; assume it is a picture and force tag generation
     item->GetPictureInfoTag();
+    // videos can have picture tags but they should have a video mime type 
+    item->GetMimeType(true);
   }
   AnnouncePlaylistAdd(item, m_slides->Size());
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -522,7 +522,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     m_Image[m_iCurrentPic].Process(currentTime, regions);
   }
 
-  if (m_slides->Get(m_iCurrentSlide)->IsVideo() && bSlideShow)
+  if (m_slides->Get(m_iCurrentSlide)->IsVideo())
   { 
     CLog::Log(LOGDEBUG, "Playing slide %s as video", m_slides->Get(m_iCurrentSlide)->GetPath().c_str());
     m_bPlayingVideo = true;
@@ -865,21 +865,20 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
     case GUI_MSG_PLAYLISTPLAYER_STOPPED:
       {
         m_bPlayingVideo = false;
-        if (m_bSlideShow)
-          g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
+        g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
       }
       break;
 
     case GUI_MSG_PLAYBACK_STARTED:
       {
-        if (m_bSlideShow && m_bPlayingVideo)
+        if (m_bPlayingVideo)
           g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
       }
       break;
 
     case GUI_MSG_PLAYBACK_STOPPED:
       {
-        if (m_bSlideShow && m_bPlayingVideo)
+        if (m_bPlayingVideo)
         {
           m_bSlideShow = false;
           g_windowManager.PreviousWindow();

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -390,6 +390,8 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     g_application.ResetScreenSaver();
   int iSlides = m_slides->Size();
   if (!iSlides) return ;
+  // prevent next image being shown between two consecutive videos; dont waste cpu
+  if (m_bPlayingVideo) return ;
 
   // if we haven't rendered yet, we should mark the whole screen
   if (!m_hasRendered)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -522,7 +522,8 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     m_Image[m_iCurrentPic].Process(currentTime, regions);
   }
 
-  if (m_slides->Get(m_iCurrentSlide)->IsVideo())
+  // play video, but only if one isn't already playing
+  if (m_slides->Get(m_iCurrentSlide)->IsVideo() && !m_bPlayingVideo)
   { 
     CLog::Log(LOGDEBUG, "Playing slide %s as video", m_slides->Get(m_iCurrentSlide)->GetPath().c_str());
     m_bPlayingVideo = true;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -862,23 +862,22 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
     }
     break;
 
-    case GUI_MSG_PLAYLISTPLAYER_STOPPED:
-      {
-        m_bPlayingVideo = false;
-        g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
-      }
-      break;
-
     case GUI_MSG_PLAYBACK_STARTED:
       {
-        if (m_bPlayingVideo)
-          g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
+        m_bPlayingVideo = true;
+        g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
       }
       break;
 
-    case GUI_MSG_PLAYBACK_STOPPED:
+    case GUI_MSG_PLAYBACK_ENDED:
+	case GUI_MSG_PLAYBACK_STOPPED:
       {
         if (m_bPlayingVideo)
+        {
+          m_bPlayingVideo = false;
+          g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
+        }
+        else
         {
           m_bSlideShow = false;
           g_windowManager.PreviousWindow();


### PR DESCRIPTION
This allows videos to be played in a picture slideshow _if_ the user has video extensions enabled for their picture library.

Even though there is code to support videos, they do not play since slideshow items do not have a mimetype or VideoInfoTag. This results in a black screen when a video is encountered.

Issues that have also been resolved are:
- correct transitions to/from the original(previous) window - WINDOW_SLIDESHOW - WINDOW_FULLSCREEN_VIDEO, etc.
- issues of loading videos on top of each other, if a video is followed by a video
- preventing background loaded images from showing between two consecutive videos
- including videos in the list of items to be shown in a non-"slideshow" mode (i.e. just selecting a picture from a list)
