### PR TITLE
Close the inputstream when reaching EOF in FileCache

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -332,6 +332,12 @@ bool CFile::OpenForWrite(const CStdString& strFileName, bool bOverWrite)
   return false;
 }
 
+bool CFile::IsOpen() {
+  if (m_pFile)
+    return true;
+  return false;
+}
+
 bool CFile::Exists(const CStdString& strFileName, bool bUseCache /* = true */)
 {
   CURL url;

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -73,6 +73,7 @@ public:
   virtual ~CFile();
 
   bool Open(const CStdString& strFileName, unsigned int flags = 0);
+  bool IsOpen();
   bool OpenForWrite(const CStdString& strFileName, bool bOverWrite = false);
   unsigned int Read(void* lpBuf, int64_t uiBufSize);
   bool ReadString(char *szLine, int iLineLength);

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -248,10 +248,17 @@ void CFileCache::Process()
     {
       CLog::Log(LOGINFO, "CFileCache::Process - Hit eof.");
       m_pCache->EndOfInput();
+      m_source.Close();
 
       // The thread event will now also cause the wait of an event to return a false.
       if (AbortableWait(m_seekEvent) == WAIT_SIGNALED)
       {
+        if (!m_source.Open(m_sourcePath, READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
+        {
+          CLog::Log(LOGERROR,"%s - failed to reopen source <%s>", __FUNCTION__, m_sourcePath.c_str());
+          break;
+        }
+        m_source.IoControl(IOCTRL_SET_CACHE,this);
         m_pCache->ClearEndOfInput();
         m_seekEvent.Set(); // hack so that later we realize seek is needed
       }

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -404,7 +404,7 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
       return m_nSeekResult;
 
     /* never request closer to end than 2k, speeds up tag reading */
-    m_seekPos = std::min(iTarget, std::max((int64_t)0, m_length - m_chunkSize));
+    m_seekPos = std::min(iTarget, std::max((int64_t)0, m_source.GetLength() - m_chunkSize));
 
     m_seekEvent.Set();
     if (!m_seekEnded.Wait())
@@ -451,6 +451,8 @@ int64_t CFileCache::GetPosition()
 
 int64_t CFileCache::GetLength()
 {
+  if (m_source.IsOpen())
+    m_length = m_source.GetLength();
   return m_length;
 }
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -85,6 +85,7 @@ CFileCache::CFileCache() : CThread("CFileCache")
    m_seekPos = 0;
    m_readPos = 0;
    m_writePos = 0;
+   m_length = 0;
    if (g_advancedSettings.m_cacheMemBufferSize == 0)
      m_pCache = new CSimpleFileCache();
    else
@@ -101,6 +102,7 @@ CFileCache::CFileCache(CCacheStrategy *pCache, bool bDeleteCache) : CThread("CFi
   m_seekPos = 0;
   m_readPos = 0;
   m_writePos = 0;
+  m_length = 0;
   m_nSeekResult = 0;
   m_chunkSize = 0;
 }
@@ -169,6 +171,7 @@ bool CFileCache::Open(const CURL& url)
 
   m_readPos = 0;
   m_writePos = 0;
+  m_length = m_source.GetLength();
   m_writeRate = 1024 * 1024;
   m_writeRateActual = 0;
   m_cacheFull = false;
@@ -401,7 +404,7 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
       return m_nSeekResult;
 
     /* never request closer to end than 2k, speeds up tag reading */
-    m_seekPos = std::min(iTarget, std::max((int64_t)0, m_source.GetLength() - m_chunkSize));
+    m_seekPos = std::min(iTarget, std::max((int64_t)0, m_length - m_chunkSize));
 
     m_seekEvent.Set();
     if (!m_seekEnded.Wait())
@@ -448,7 +451,7 @@ int64_t CFileCache::GetPosition()
 
 int64_t CFileCache::GetLength()
 {
-  return m_source.GetLength();
+  return m_length;
 }
 
 void CFileCache::StopThread(bool bWait /*= true*/)

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -72,6 +72,7 @@ namespace XFILE
     int64_t      m_seekPos;
     int64_t      m_readPos;
     int64_t      m_writePos;
+    int64_t      m_length;
     unsigned     m_chunkSize;
     unsigned     m_writeRate;
     unsigned     m_writeRateActual;


### PR DESCRIPTION
This is more of a first try.

The Problem is described in http://trac.xbmc.org/ticket/14013 .
A better solution would be some sort of .pause() and .unpause(). inside IFile, but i am not abled to do that.
