### PR TITLE
Fix event pump order on ios when we drop in deeper message loop.

### DIFF
--- a/xbmc/windowing/android/WinEventsAndroid.h
+++ b/xbmc/windowing/android/WinEventsAndroid.h
@@ -35,7 +35,9 @@ public:
   static bool MessagePump();
 
 protected:
+  static int  GetQueueSize();
 
 };
 
 #endif // WINDOW_EVENTS_ANDROID_H
+


### PR DESCRIPTION
Found bug in CWinEventsIOS::MessagePump(). after some debug log entry, got the log output. it seems there is another MessagePump call in a previous half implemented MessagePump call because in CApplication::OnEvent it inited another message loop.
so in the original code, there would be some events not implemented left in the stack, until the deeper message loop ends and OnEvent return, the events on the stack then be processed finally, it break the event process ordering. this PR fixed it.

sample test log:

```
2013-02-01 22:35:53.669 XBMC[917:2003] CWinEventsIOS::MessagePush(4) prelog

2013-02-01 22:35:53.670 XBMC[917:2003] CWinEventsIOS::MessagePush(4), [669, 336]

2013-02-01 22:35:53.672 XBMC[917:2003] CWinEventsIOS::MessagePush(5) prelog

2013-02-01 22:35:53.672 XBMC[917:2003] CWinEventsIOS::MessagePush(5), [669, 336]

2013-02-01 22:35:53.675 XBMC[917:2003] CWinEventsIOS::MessagePush(6) prelog

2013-02-01 22:35:53.676 XBMC[917:2003] CWinEventsIOS::MessagePush(6), [669, 336]

2013-02-01 22:35:53.692 XBMC[917:8303] 22:35:53 T:134189056   DEBUG:  CApplication::OnEvent(4) [669, 336]

2013-02-01 22:35:53.701 XBMC[917:8303] 22:35:53 T:134189056   DEBUG:  ------ Window Init (VideoOSD.xml) ------

2013-02-01 22:35:53.702 XBMC[917:8303] 22:35:53 T:134189056    INFO:  Loading skin file: VideoOSD.xml, load type: KEEP_IN_MEMORY

2013-02-01 22:35:54.073 XBMC[917:8303] 22:35:54 T:134189056   DEBUG:  Load VideoOSD.xml: 370.77ms

2013-02-01 22:35:54.141 XBMC[917:8303] 22:35:54 T:134189056   DEBUG:  Alloc resources: 439.08ms  (372.33 ms skin load)

2013-02-01 22:35:57.408 XBMC[917:2003] CWinEventsIOS::MessagePush(4) prelog

2013-02-01 22:35:57.409 XBMC[917:2003] CWinEventsIOS::MessagePush(4), [487, 641]

2013-02-01 22:35:57.409 XBMC[917:2003] CWinEventsIOS::MessagePush(5) prelog

2013-02-01 22:35:57.410 XBMC[917:2003] CWinEventsIOS::MessagePush(5), [487, 641]

2013-02-01 22:35:57.411 XBMC[917:2003] CWinEventsIOS::MessagePush(6) prelog

2013-02-01 22:35:57.411 XBMC[917:2003] CWinEventsIOS::MessagePush(6), [487, 641]

2013-02-01 22:35:57.451 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  CApplication::OnEvent(4) [487, 641]

2013-02-01 22:35:57.455 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  CApplication::OnEvent(5) [487, 641]

2013-02-01 22:35:57.456 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  CApplication::OnEvent(6) [487, 641]

........

2013-02-01 22:35:57.793 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  CGUIWindowManager::PreviousWindow: Deactivate

2013-02-01 22:35:57.794 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  ------ Window Deinit (VideoOSD.xml) ------

2013-02-01 22:35:57.795 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  ExecuteXBMCAction : Translating Skin.Reset(PlayerControlsSubMenuVisible)

2013-02-01 22:35:57.797 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  ExecuteXBMCAction : To Skin.Reset(PlayerControlsSubMenuVisible)

2013-02-01 22:35:57.886 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  ------ Window Deinit (VideoFullScreen.xml) ------

2013-02-01 22:35:57.953 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  CGUIWindowManager::PreviousWindow: Activate new

2013-02-01 22:35:57.982 XBMC[917:8303] 22:35:57 T:134189056   DEBUG:  ------ Window Init (MyVideoNav.xml) ------

2013-02-01 22:35:58.029 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:  Window MyVideoNav.xml was already loaded

2013-02-01 22:35:58.030 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:  Alloc resources: 45.33m

2013-02-01 22:35:58.038 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:  CGUIMediaWindow::GetDirectory (plugin://plugin.video.xunleiark/root_square/)

2013-02-01 22:35:58.039 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:    ParentPath = [plugin://plugin.video.xunleiark/root_square/]

2013-02-01 22:35:58.049 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:  Loading fileitems [plugin://plugin.video.xunleiark/root_square/]

2013-02-01 22:35:58.307 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:    -- items: 69, directory: plugin://plugin.video.xunleiark/root_square/ sort method: 0, ascending: false

2013-02-01 22:35:58.339 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:  RunQuery took 12 ms for 21 items query: SELECT  files.strFilename, files.playCount,  bookmark.timeInSeconds, bookmark.totalTimeInSeconds FROM files  LEFT JOIN bookmark ON    files.idFile = bookmark.idFile AND bookmark.type = 1  WHERE files.idPath=2

2013-02-01 22:35:58.694 XBMC[917:8303] 22:35:58 T:134189056   DEBUG:  Unfocus WindowID: 10025, ControlID: 50

2013-02-01 22:35:59.067 XBMC[917:8303] 22:35:59 T:134189056   DEBUG:  CApplication::OnEvent(5) [669, 336]

2013-02-01 22:35:59.068 XBMC[917:8303] 22:35:59 T:134189056   DEBUG:  CApplication::OnEvent(6) [669, 336]

2013-02-01 22:35:59.069 XBMC[917:8303] 22:35:59 T:134189056   DEBUG:  ProcessMouse: trying mouse action leftclick

```
