### PR TITLE
make Throttle adaptive to rate not rate + 1mbit

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -143,7 +143,7 @@ int CDVDInputStreamFile::GetBlockSize()
 
 void CDVDInputStreamFile::SetReadRate(unsigned rate)
 {
-  unsigned maxrate = rate + 1024 * 1024 / 8;
+  unsigned maxrate = rate * 2;
   if(m_pFile->IoControl(IOCTRL_CACHE_SETRATE, &maxrate) >= 0)
     CLog::Log(LOGDEBUG, "CDVDInputStreamFile::SetReadRate - set cache throttle rate to %u bytes per second", maxrate);
 }


### PR DESCRIPTION
Setting the Throttle to rate +1 mbit has some bad potential.

Assume we have a file with a long initial credits and long ending, many slow sceenes with less bitrate. And one long lasting high bitrate scene. If the scenes bitrate is higher than the rate + 1 mbit / cache size, the file needs to buffer again.
By setting it to rate \* 2, we will most likely not get any buffering.

Why do we set a Throttle anyway? To keep others amused and don't take the whole bandwidth?

I often have problems with buffering over WLAN, but this PR helps in my case.
