### PR TITLE
Pause low priority (image) jobs for video play

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4407,7 +4407,7 @@ void CApplication::SaveFileState(bool bForeground /* = false */)
         *m_stackFileItemToUpdate,
         m_progressTrackingVideoResumeBookmark,
         m_progressTrackingPlayCountUpdate);
-    CJobManager::GetInstance().AddJob(job, NULL);
+    CJobManager::GetInstance().AddJob(job, NULL, CJob::PRIORITY_NORMAL);
   }
 }
 

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -299,14 +299,14 @@ void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)
 
 void CTextureCache::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 {
-  if (strcmp(job->GetType(), "cacheimage") == 0)
+  if (strcmp(job->GetType(), kJobTypeCacheImage) == 0)
     OnCachingComplete(success, (CTextureCacheJob *)job);
   return CJobQueue::OnJobComplete(jobID, success, job);
 }
 
 void CTextureCache::OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job)
 {
-  if (strcmp(job->GetType(), "cacheimage") == 0 && !progress)
+  if (strcmp(job->GetType(), kJobTypeCacheImage) == 0 && !progress)
   { // check our processing list
     {
       CSingleLock lock(m_processingSection);

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -64,7 +64,7 @@ public:
   CTextureCacheJob(const CStdString &url, const CStdString &oldHash = "");
   virtual ~CTextureCacheJob();
 
-  virtual const char* GetType() const { return "cacheimage"; };
+  virtual const char* GetType() const { return kJobTypeCacheImage; };
   virtual bool operator==(const CJob *job) const;
   virtual bool DoWork();
 
@@ -129,7 +129,7 @@ class CTextureDDSJob : public CJob
 public:
   CTextureDDSJob(const CStdString &original);
 
-  virtual const char* GetType() const { return "ddscompress"; };
+  virtual const char* GetType() const { return kJobTypeDDSCompress; };
   virtual bool operator==(const CJob *job) const;
   virtual bool DoWork();
 

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -1306,9 +1306,7 @@ void CAMLPlayer::Process()
   CLog::Log(LOGNOTICE, "CAMLPlayer::Process");
   try
   {
-    CJobManager::GetInstance().Pause(kJobTypeMediaFlags);
-
-    if (CJobManager::GetInstance().IsProcessing(kJobTypeMediaFlags) > 0)
+    if (CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW))
     {
       if (!WaitForPausedThumbJobs(20000))
       {
@@ -1614,8 +1612,6 @@ void CAMLPlayer::Process()
 
   // reset ac3/dts passthough
   SetAudioPassThrough(AFORMAT_UNKNOWN);
-  // let thumbgen jobs resume.
-  CJobManager::GetInstance().UnPause(kJobTypeMediaFlags);
 
   if (m_log_level > 5)
     CLog::Log(LOGDEBUG, "CAMLPlayer::Process exit");
@@ -1721,7 +1717,7 @@ bool CAMLPlayer::WaitForPausedThumbJobs(int timeout_ms)
   // use m_bStop and Sleep so we can get canceled.
   while (!m_bStop && (timeout_ms > 0))
   {
-    if (CJobManager::GetInstance().IsProcessing(kJobTypeMediaFlags) > 0)
+    if (CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW))
     {
       Sleep(100);
       timeout_ms -= 100;

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1043,11 +1043,8 @@ void COMXPlayer::Process()
   if (!CachePVRStream())
     SetCaching(CACHESTATE_FLUSH);
 
-  // stop thumb jobs
-  CJobManager::GetInstance().Pause(kJobTypeMediaFlags);
-
   /*
-  if (CJobManager::GetInstance().IsProcessing(kJobTypeMediaFlags) > 0)
+  if (CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW))
   {
     if (!WaitForPausedThumbJobs(20000))
     {
@@ -1273,9 +1270,6 @@ void COMXPlayer::Process()
     // check if in a cut or commercial break that should be automatically skipped
     CheckAutoSceneSkip();
   }
-
-  // let thumbgen jobs resume.
-  CJobManager::GetInstance().UnPause(kJobTypeMediaFlags);
 }
 
 bool COMXPlayer::CheckDelayedChannelEntry(void)
@@ -4154,7 +4148,7 @@ bool COMXPlayer::WaitForPausedThumbJobs(int timeout_ms)
   // use m_bStop and Sleep so we can get canceled.
   while (!m_bStop && (timeout_ms > 0))
   {
-    if (CJobManager::GetInstance().IsProcessing(kJobTypeMediaFlags) > 0)
+    if (CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW))
     {
       Sleep(100);
       timeout_ms -= 100;

--- a/xbmc/utils/Job.h
+++ b/xbmc/utils/Job.h
@@ -23,6 +23,10 @@ class CJob;
 
 #include <stddef.h>
 
+#define kJobTypeMediaFlags  "mediaflags"
+#define kJobTypeCacheImage  "cacheimage"
+#define kJobTypeDDSCompress "ddscompress"
+
 /*!
  \ingroup jobs
  \brief Callback interface for asynchronous jobs.

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -315,11 +315,11 @@ bool CJobManager::IsProcessing(const CJob::PRIORITY &priority) const
   return false;
 }
 
-int CJobManager::IsProcessing(const std::string &pausedType)
+int CJobManager::IsProcessing(const std::string &pausedType) const
 {
   int jobsMatched = 0;
   CSingleLock lock(m_section);
-  for(Processing::iterator it = m_processing.begin(); it < m_processing.end(); it++)
+  for(Processing::const_iterator it = m_processing.begin(); it < m_processing.end(); it++)
   {
     if (pausedType == std::string(it->m_job->GetType()))
       jobsMatched++;

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -165,11 +165,12 @@ class CJobManager
   class CWorkItem
   {
   public:
-    CWorkItem(CJob *job, unsigned int id, IJobCallback *callback)
+    CWorkItem(CJob *job, unsigned int id, CJob::PRIORITY priority, IJobCallback *callback)
     {
       m_job = job;
       m_id = id;
       m_callback = callback;
+      m_priority = priority;
     }
     bool operator==(unsigned int jobID) const
     {
@@ -191,6 +192,7 @@ class CJobManager
     CJob         *m_job;
     unsigned int  m_id;
     IJobCallback *m_callback;
+    CJob::PRIORITY m_priority;
   };
 
 public:
@@ -257,6 +259,37 @@ public:
    */
   int IsProcessing(const std::string &pausedType);
 
+  /*!
+   \brief Suspends queueing of the specified priority until unpaused
+   Useful to (for ex) stop queuing thumb jobs during video start/playback.
+   Does not affect currently processing jobs, use IsProcessing to see if any need to be waited on
+   \param priority only jobs of this priority will be affected
+   \sa UnPause(), IsPaused(), IsProcessing()
+   */
+  void Pause(const CJob::PRIORITY &priority);
+
+  /*!
+   \brief Resumes queueing of the specified priority
+   \param priority only jobs of this priority will be affected
+   \sa Pause(), IsPaused(), IsProcessing()
+   */
+  void UnPause(const CJob::PRIORITY &priority);
+
+  /*!
+   \brief Checks if jobs of specified priority are paused.
+   \param priority only jobs of this priority will be affected
+   \sa Pause(), UnPause(), IsProcessing()
+   */
+  bool IsPaused(const CJob::PRIORITY &priority) const;
+
+  /*!
+   \brief Checks to see if any jobs with specific priority are currently processing.
+   \param priority to search for
+   \return true if processing jobs, else returns false
+   \sa Pause(), UnPause(), IsPaused()
+   */
+  bool IsProcessing(const CJob::PRIORITY &priority) const;
+
 protected:
   friend class CJobWorker;
   friend class CJob;
@@ -319,6 +352,7 @@ private:
   typedef std::vector<CJobWorker*> Workers;
 
   JobQueue   m_jobQueue[CJob::PRIORITY_HIGH+1];
+  bool       m_jobPause[CJob::PRIORITY_HIGH+1];
   Processing m_processing;
   Workers    m_workers;
 

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -227,31 +227,6 @@ public:
   void CancelJobs();
 
   /*!
-   \brief Suspends queueing of the specified type until unpaused
-   Useful to (for ex) stop queuing thumb jobs during video playback. Only affects PRIORITY_LOW or lower.
-   Does not affect currently processing jobs, use IsProcessing to see if any need to be waited on
-   Types accumulate, so more than one can be set at a time.
-   Refcounted, so UnPause() must be called once for each Pause().
-   \param pausedType only jobs of this type will be affected
-   \sa UnPause(), IsPaused(), IsProcessing()
-   */
-  void Pause(const std::string &pausedType);
-
-  /*!
-   \brief Resumes queueing of the specified type
-   \param pausedType only jobs of this type will be affected
-   \sa Pause(), IsPaused(), IsProcessing()
-   */
-  void UnPause(const std::string &pausedType);
-
-  /*!
-   \brief Checks if jobs of specified type are paused.
-   \param pausedType only jobs of this type will be affected
-   \sa Pause(), UnPause(), IsProcessing()
-   */
-  bool IsPaused(const std::string &pausedType);
-
-  /*!
    \brief Checks to see if any jobs of a specific type are currently processing.
    \param pausedType Job type to search for
    \return Number of matching jobs
@@ -337,14 +312,6 @@ private:
   void RemoveWorker(const CJobWorker *worker);
   unsigned int GetMaxWorkers(CJob::PRIORITY priority) const;
 
-  /*! \brief skips over any paused jobs of given priority.
-   Moves any paused jobs at the front of the queue to the back of the
-   queue, allowing unpaused jobs to continue processing.
-   \param priority the priority queue to consider.
-   \return true if an unpaused job is available, false if no unpaused jobs are available.
-   */
-  bool SkipPausedJobs(CJob::PRIORITY priority);
-
   unsigned int m_jobCounter;
 
   typedef std::deque<CWorkItem>    JobQueue;
@@ -359,5 +326,4 @@ private:
   CCriticalSection m_section;
   CEvent           m_jobEvent;
   bool             m_running;
-  std::vector<std::string>  m_pausedTypes;
 };

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -232,7 +232,7 @@ public:
    \return Number of matching jobs
    \sa Pause(), UnPause(), IsPaused()
    */
-  int IsProcessing(const std::string &pausedType);
+  int IsProcessing(const std::string &pausedType) const;
 
   /*!
    \brief Suspends queueing of the specified priority until unpaused

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -24,8 +24,6 @@
 #include "utils/JobManager.h"
 #include "FileItem.h"
 
-#define kJobTypeMediaFlags "mediaflags"
-
 class CStreamDetails;
 class IStreamDetailsObserver;
 class CVideoDatabase;


### PR DESCRIPTION
This should result in faster starting times for video items on eg. internet filesystems and on low powered systems (ARM/Atom). Maybe there's a better way to implement this? Suggestions are welcome
