### PR TITLE
[WIN32] implemented a poor man's stacktrace for windows.

### DIFF
--- a/xbmc/threads/platform/win/Win32Exception.h
+++ b/xbmc/threads/platform/win/Win32Exception.h
@@ -36,11 +36,13 @@ public:
     unsigned code() const { return mCode; };
     virtual void LogThrowMessage(const char *prefix) const;
     static bool write_minidump(EXCEPTION_POINTERS* pEp);
+    static bool write_stacktrace(EXCEPTION_POINTERS* pEp);
 protected:
     win32_exception(EXCEPTION_POINTERS*, const char* classname = NULL);
     static void translate(unsigned code, EXCEPTION_POINTERS* info);
 
     inline bool write_minidump() const { return write_minidump(mExceptionPointers); };
+    inline bool write_stacktrace() const { return write_stacktrace(mExceptionPointers); };
 private:
     const char* mWhat;
     Address mWhere;

--- a/xbmc/win32/XBMC_PC.cpp
+++ b/xbmc/win32/XBMC_PC.cpp
@@ -34,6 +34,7 @@
 // Minidump creation function
 LONG WINAPI CreateMiniDump( EXCEPTION_POINTERS* pEp )
 {
+  win32_exception::write_stacktrace(pEp);
   win32_exception::write_minidump(pEp);
   return pEp->ExceptionRecord->ExceptionCode;;
 }


### PR DESCRIPTION
Just prints the stacktrace of the current thread into a file. It's still missing the function parameters but it could be extended to print all running threads.
Sample output:

```
Thread 2416 (process 6068)
#0 CApplication::FrameMove at c:\development\xbmc\xbmc\application.cpp:2948
#1 CGUIWindowManager::ProcessRenderLoop at c:\development\xbmc\xbmc\guilib\guiwindowmanager.cpp:666
#2 CGUIWindowManager::CloseWindowSync at c:\development\xbmc\xbmc\guilib\guiwindowmanager.cpp:997
#3 CGUIWindowManager::ActivateWindow_Internal at c:\development\xbmc\xbmc\guilib\guiwindowmanager.cpp:417
#4 CGUIWindowManager::ActivateWindow at c:\development\xbmc\xbmc\guilib\guiwindowmanager.cpp:351
#5 CBuiltins::Execute at c:\development\xbmc\xbmc\interfaces\builtins.cpp:350
#6 CApplication::ExecuteXBMCAction at c:\development\xbmc\xbmc\application.cpp:5058
#7 CApplication::OnMessage at c:\development\xbmc\xbmc\application.cpp:5042
#8 CGUIWindowManager::SendMessageA at c:\development\xbmc\xbmc\guilib\guiwindowmanager.cpp:77
#9 CGUIWindowManager::DispatchThreadMessages at c:\development\xbmc\xbmc\guilib\guiwindowmanager.cpp:808
#10 CApplication::Process at c:\development\xbmc\xbmc\application.cpp:5096
#11 CXBApplicationEx::Run at c:\development\xbmc\xbmc\xbapplicationex.cpp:111
#12 WinMain at c:\development\xbmc\xbmc\win32\xbmc_pc.cpp:164
#13 __tmainCRTStartup at f:\dd\vctools\crt_bld\self_x86\crt\src\crt0.c:275
#14 WinMainCRTStartup at f:\dd\vctools\crt_bld\self_x86\crt\src\crt0.c:189
#15 BaseThreadInitThunk
#16 RtlInitializeExceptionChain
#17 RtlInitializeExceptionChai
```
