### PR TITLE
Protect pointer dereference to avoid a segfault when running headless.

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -86,7 +86,8 @@ namespace VIDEO
       {
         CGUIDialogExtendedProgressBar* dialog =
           (CGUIDialogExtendedProgressBar*)g_windowManager.GetWindow(WINDOW_DIALOG_EXT_PROGRESS);
-        m_handle = dialog->GetHandle(g_localizeStrings.Get(314));
+        if (dialog)
+           m_handle = dialog->GetHandle(g_localizeStrings.Get(314));
       }
 
       m_bCanInterrupt = true;


### PR DESCRIPTION
When using libxbmc.so in a headless setup for library scans, dialog will be NULL. See:
http://forum.xbmc.org/showthread.php?tid=132919&pid=1320914#pid1320914
