### PR TITLE
add OnDatabaseScanStarted() to xbmc.Monitor()

### DIFF
--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -44,6 +44,7 @@ namespace XBMCAddon
       inline void    OnScreensaverActivated() { TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onScreensaverActivated)); }
       inline void    OnScreensaverDeactivated() { TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onScreensaverDeactivated)); }
       inline void    OnDatabaseUpdated(const String &database) { TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseUpdated,database)); }
+      inline void    OnDatabaseScanStarted(const String &database) { TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseScanStarted,database)); }
       inline void    OnAbortRequested() { TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onAbortRequested)); }
 #endif
 
@@ -77,6 +78,15 @@ namespace XBMCAddon
        */
       virtual void    onDatabaseUpdated(const String database) { TRACE; }
 
+      /**
+       * onDatabaseScanStarted(database) -- onDatabaseScanStarted method.
+       *
+       * database - video/music as string
+       *
+       * Will be called when database update starts and return video or music to indicate which DB is being updated
+       */
+      virtual void    onDatabaseScanStarted(const String database) { TRACE; }
+      
       /**
        * onAbortRequested() -- onAbortRequested method.
        * 

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -71,7 +71,7 @@ namespace XBMCAddon
       /**
        * onDatabaseUpdated(database) -- onDatabaseUpdated method.
        * 
-       * database - video/music as stri
+       * database - video/music as string
        * 
        * Will be called when database gets updated and return video or music to indicate which DB has been changed
        */

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -100,12 +100,12 @@ void XBPython::Announce(AnnouncementFlag flag, const char *sender, const char *m
   if (flag & VideoLibrary)
   {
    if (strcmp(message, "OnScanFinished") == 0)
-    OnDatabaseUpdated("video");
+     OnDatabaseUpdated("video");
   }
   else if (flag & AudioLibrary)
   {
    if (strcmp(message, "OnScanFinished") == 0)
-    OnDatabaseUpdated("music");
+     OnDatabaseUpdated("music");
   }
   else if (flag & GUI)
   {

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -101,11 +101,15 @@ void XBPython::Announce(AnnouncementFlag flag, const char *sender, const char *m
   {
    if (strcmp(message, "OnScanFinished") == 0)
      OnDatabaseUpdated("video");
+   else if (strcmp(message, "OnScanStarted") == 0)
+     OnDatabaseScanStarted("video");
   }
   else if (flag & AudioLibrary)
   {
    if (strcmp(message, "OnScanFinished") == 0)
      OnDatabaseUpdated("music");
+   else if (strcmp(message, "OnScanStarted") == 0)
+     OnDatabaseScanStarted("music");
   }
   else if (flag & GUI)
   {
@@ -345,6 +349,21 @@ void XBPython::OnDatabaseUpdated(const std::string &database)
   }
  }  
 } 
+
+void XBPython::OnDatabaseScanStarted(const std::string &database)
+{
+  TRACE;
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
+    while (it != m_vecMonitorCallbackList.end())
+    {
+      ((XBMCAddon::xbmc::Monitor*)(*it))->OnDatabaseScanStarted(database);
+      it++;
+    }
+  }  
+}
 
 void XBPython::OnAbortRequested(const CStdString &ID)
 {

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -79,6 +79,7 @@ public:
   void OnScreensaverActivated();
   void OnScreensaverDeactivated();
   void OnDatabaseUpdated(const std::string &database);
+  void OnDatabaseScanStarted(const std::string &database);
   void OnAbortRequested(const CStdString &ID="");
   void Initialize();
   void FinalizeScript();


### PR DESCRIPTION
@jimfcarroll I hope this is how you intended it to work :)

@MartijnKaijser  please test if this is what you had in mind

``` python

class MyMonitor( xbmc.Monitor ):
  def __init__( self, *args, **kwargs ):
    xbmc.Monitor.__init__( self )

  def onDatabaseScanStarted(self,database):
    print  "OnDatabaseScanStarted(%s)" % database 

```
