### PR TITLE
remove unused and incomplete timeserver code

### DIFF
--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -281,9 +281,6 @@ bool CNetwork::WakeOnLan(const char* mac)
 
 void CNetwork::StartServices()
 {
-#ifdef HAS_TIME_SERVER
-  g_application.StartTimeServer();
-#endif
 #ifdef HAS_WEB_SERVER
   if (!g_application.StartWebServer())
     CGUIDialogKaiToast::QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33101), g_localizeStrings.Get(33100));
@@ -314,9 +311,6 @@ void CNetwork::StopServices(bool bWait)
 {
   if (bWait)
   {
-#ifdef HAS_TIME_SERVER
-    g_application.StopTimeServer();
-#endif
 #ifdef HAS_UPNP
     g_application.StopUPnP(bWait);
 #endif

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -906,11 +906,6 @@ void CGUISettings::Initialize()
     AddString(loc, "locale.timezone", 14080, g_timezone.GetOSConfiguredTimezone(), SPIN_CONTROL_TEXT);
   }
 #endif
-#ifdef HAS_TIME_SERVER
-  AddSeparator(loc, "locale.sep2");
-  AddBool(loc, "locale.timeserver", 168, false);
-  AddString(loc, "locale.timeserveraddress", 731, "pool.ntp.org", EDIT_CONTROL_INPUT);
-#endif
   AddSeparator(loc, "locale.sep3");
   AddString(loc, "locale.audiolanguage", 285, "original", SPIN_CONTROL_TEXT);
   AddString(loc, "locale.subtitlelanguage", 286, "original", SPIN_CONTROL_TEXT);

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -946,13 +946,6 @@ void CGUIWindowSettingsCategory::UpdateSettings()
         m_strOldTrackFormatRight = g_guiSettings.GetString("musicfiles.trackformatright");
       }
     }
-#ifdef HAS_TIME_SERVER
-    else if (strSetting.Equals("locale.timeserveraddress"))
-    {
-      CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
-      if (pControl) pControl->SetEnabled(g_guiSettings.GetBool("locale.timeserver"));
-    }
-#endif
     else if (strSetting.Equals("audiocds.recordingpath") || strSetting.Equals("debug.screenshotpath"))
     {
       CGUIButtonControl *pControl = (CGUIButtonControl *)GetControl(pSettingControl->GetID());
@@ -1657,14 +1650,6 @@ void CGUIWindowSettingsCategory::OnSettingChanged(BaseSettingControlPtr pSetting
     g_guiSettings.SetString("locale.country", strRegion);
     g_weatherManager.Refresh(); // need to reset our weather, as temperatures need re-translating.
   }
-#ifdef HAS_TIME_SERVER
-  else if (strSetting.Equals("locale.timeserver") || strSetting.Equals("locale.timeserveraddress"))
-  {
-    g_application.StopTimeServer();
-    if (g_guiSettings.GetBool("locale.timeserver"))
-      g_application.StartTimeServer();
-  }
-#endif
   else if (strSetting.Equals("smb.winsserver") || strSetting.Equals("smb.workgroup") )
   {
     if (g_guiSettings.GetString("smb.winsserver") == "0.0.0.0")


### PR DESCRIPTION
This commit removes code guarded by HAS_TIME_SERVER which is not used by any platform and e.g. CApplication::StartTimeServer() and CApplication::StopTimeServer() don't even exist but would be called in xbmc/network/Network.cpp.
