### PR TITLE
[python] add missing sort methods

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -396,6 +396,36 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const C
        dir->m_listItems->AddSortMethod(SORT_METHOD_LISTENERS,20455,LABEL_MASKS("%T","%W"));
        break;
       }
+    case SORT_METHOD_DATEADDED:
+      {
+        dir->m_listItems->AddSortMethod(SORT_METHOD_DATEADDED, 570, LABEL_MASKS("%T", "%a"));
+        break;
+      }
+    case SORT_METHOD_FULLPATH:
+      {
+        dir->m_listItems->AddSortMethod(SORT_METHOD_FULLPATH, 573, LABEL_MASKS("%T", label2Mask));
+        break;
+      }
+    case SORT_METHOD_LABEL_IGNORE_FOLDERS:
+      {
+        dir->m_listItems->AddSortMethod(SORT_METHOD_LABEL_IGNORE_FOLDERS, 551, LABEL_MASKS("%T", label2Mask));
+        break;
+      }
+    case SORT_METHOD_LASTPLAYED:
+      {
+        dir->m_listItems->AddSortMethod(SORT_METHOD_LASTPLAYED, 568, LABEL_MASKS("%T", "%G"));
+        break;
+      }
+    case SORT_METHOD_PLAYCOUNT:
+      {
+        dir->m_listItems->AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%T", "%V"));
+        break;
+      }
+    case SORT_METHOD_CHANNEL:
+      {
+        dir->m_listItems->AddSortMethod(SORT_METHOD_CHANNEL, 19029, LABEL_MASKS("%T", label2Mask));
+        break;
+      }
    
     default:
       break;

--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.h
@@ -97,19 +97,20 @@ namespace XBMCAddon
     void setResolvedUrl(int handle, bool succeeded, const XBMCAddon::xbmcgui::ListItem* listitem);
 
     /**
-     * addSortMethod(handle, sortMethod, label2) -- Adds a sorting method for the media list.
+     * addSortMethod(handle, sortMethod, label2Mask) -- Adds a sorting method for the media list.
      * 
      * handle      : integer - handle the plugin was started with.
-     * sortMethod  : integer - number for sortmethod see FileItem.h.
+     * sortMethod  : integer - number for sortmethod see SortFileItem.h.
      * label2Mask  : [opt] string - the label mask to use for the second label.  Defaults to '%D'
      *               applies to: SORT_METHOD_NONE, SORT_METHOD_UNSORTED, SORT_METHOD_VIDEO_TITLE,
      *                           SORT_METHOD_TRACKNUM, SORT_METHOD_FILE, SORT_METHOD_TITLE,
      *                           SORT_METHOD_TITLE_IGNORE_THE, SORT_METHOD_LABEL,
      *                           SORT_METHOD_LABEL_IGNORE_THE, SORT_METHOD_VIDEO_SORT_TITLE,
-     *                           SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE
+     *                           SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, SORT_METHOD_FULLPATH,
+     *                           SORT_METHOD_LABEL_IGNORE_FOLDERS, SORT_METHOD_CHANNEL
      * 
      * example:
-     *   - xbmcplugin.addSortMethod(int(sys.argv[1]), xbmcplugin.SORT_METHOD_TITLE)
+     *   - xbmcplugin.addSortMethod(int(sys.argv[1]), 1)
      */
     void addSortMethod(int handle, int sortMethod, const String& label2Mask = emptyString);
 
@@ -226,5 +227,12 @@ namespace XBMCAddon
     SWIG_CONSTANT(int,SORT_METHOD_UNSORTED);
     SWIG_CONSTANT(int,SORT_METHOD_BITRATE);
     SWIG_CONSTANT(int,SORT_METHOD_LISTENERS);
+    SWIG_CONSTANT(int,SORT_METHOD_COUNTRY);
+    SWIG_CONSTANT(int,SORT_METHOD_DATEADDED);
+    SWIG_CONSTANT(int,SORT_METHOD_FULLPATH);
+    SWIG_CONSTANT(int,SORT_METHOD_LABEL_IGNORE_FOLDERS);
+    SWIG_CONSTANT(int,SORT_METHOD_LASTPLAYED);
+    SWIG_CONSTANT(int,SORT_METHOD_PLAYCOUNT);
+    SWIG_CONSTANT(int,SORT_METHOD_CHANNEL);
   }
 }


### PR DESCRIPTION
these sortmethods were not available for python plugins.

cleaned up the python docs addSortMethod() as well.
