### PR TITLE
fetch weather once every hour max

### DIFF
--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -384,7 +384,7 @@ void CWeatherJob::SetFromProperties()
   }
 }
 
-CWeather::CWeather(void) : CInfoLoader(30 * 60 * 1000) // 30 minutes
+CWeather::CWeather(void) : CInfoLoader(60 * 60 * 1000) // 60 minutes
 {
   Reset();
 }


### PR DESCRIPTION
@theuni mentioned on irc weather underground wasn't too thrilled with all the load we send their way. 
and if i'm not mistaken, we're in the same boat with world weather online as well.

in an effort to keep them happy i suggest we switch to hourly weather retrieval
instead of every 30 minutes.

this could (theoretically) reduce the load by half. 
