### PR TITLE
[scrapers] use new default music scrapers after upgrade if the broken scrapers were still selected

### DIFF
--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -1468,6 +1468,19 @@ void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = fa
     updated = true;
   }
 
+  // replace broken default artist scrapers with universal scraper if it's still in use
+  if (GetString("musiclibrary.albumsscraper") == "metadata.albums.allmusic.com")
+  {
+    SetString("musiclibrary.albumsscraper", "metadata.album.universal");
+    updated = true;
+  }
+
+  if (GetString("musiclibrary.artistsscraper") == "metadata.artists.allmusic.com")
+  {
+    SetString("musiclibrary.artistsscraper", "metadata.artists.universal");
+    updated = true;
+  }
+
   if (updated)
     g_settings.Save();
 }


### PR DESCRIPTION
I noticed after doing an upgrade from Eden to Frodo a broken scraper was still selected. So this replaces the broken album scraper and while we're at it the artist one too.
(don't mind commit message. i will fix that tonight)
