### PR TITLE
fixed: Seeking in (some?) Silverlight video streams didn't work and/or c...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -89,6 +89,7 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, 
        || file.substr(0, 6) == "mms://"
        || file.substr(0, 7) == "mmst://"
        || file.substr(0, 7) == "mmsh://"
+       || (item.IsInternetStream() && content == "video/mp4")
        || (item.IsInternetStream() && item.IsType(".m3u8")))
     return new CDVDInputStreamFFmpeg();
   else if(file.substr(0, 8) == "sling://"


### PR DESCRIPTION
...rashed XBMC. Somehow Curl doesn't play nice with Silverlight streams, therefor let ffmpeg handle these.
