### PR TITLE
pvr: channel scanner cosmetics

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -809,16 +809,10 @@ void CPVRClients::StartChannelScan(void)
       __FUNCTION__, scanClient->GetFriendlyName().c_str());
   long perfCnt = XbmcThreads::SystemClockMillis();
 
-  /* stop the supervisor thread */
-  g_PVRManager.StopUpdateThreads();
-
   /* do the scan */
   if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
     /* an error occured */
     CGUIDialogOK::ShowAndGetInput(19111,0,19193,0);
-
-  /* restart the supervisor thread */
-  g_PVRManager.StartUpdateThreads();
 
   CLog::Log(LOGNOTICE, "PVRManager - %s - channel scan finished after %li.%li seconds",
       __FUNCTION__, (XbmcThreads::SystemClockMillis()-perfCnt)/1000, (XbmcThreads::SystemClockMillis()-perfCnt)%1000);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -809,6 +809,15 @@ void CPVRClients::StartChannelScan(void)
       __FUNCTION__, scanClient->GetFriendlyName().c_str());
   long perfCnt = XbmcThreads::SystemClockMillis();
 
+  /* stop live tv */
+  lock.Leave();
+  if (IsPlayingTV() || IsPlayingRadio())
+  {
+    CGUIMessage msg(GUI_MSG_PLAYBACK_STOPPED, 0, 0);
+    g_windowManager.SendMessage(msg);
+  }
+  lock.Enter();
+
   /* do the scan */
   if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
     /* an error occured */


### PR DESCRIPTION
I changed 2 things to make channel scanning useable:

do not stop / start the pvr manager:
- backends may want to do scanning in background (with more than one tuner)
- it simply deadlocks the system

removed the "Cannot use PVR functions ..." dialog:
- this is simply not true because backends may be able to do scanning in background
- it's quite annoying
