### PR TITLE
Cache fixes, e.g. after pathsubstituion

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -133,14 +133,14 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
       return false;
 
     // check our cache for this path
-    if (g_directoryCache.GetDirectory(strPath, items, (hints.flags & DIR_FLAG_READ_CACHE) == DIR_FLAG_READ_CACHE))
+    if (g_directoryCache.GetDirectory(realPath, items, (hints.flags & DIR_FLAG_READ_CACHE) == DIR_FLAG_READ_CACHE))
       items.SetPath(strPath);
     else
     {
       // need to clear the cache (in case the directory fetch fails)
       // and (re)fetch the folder
       if (!(hints.flags & DIR_FLAG_BYPASS_CACHE))
-        g_directoryCache.ClearDirectory(strPath);
+        g_directoryCache.ClearDirectory(realPath);
 
       pDirectory->SetFlags(hints.flags);
 
@@ -198,7 +198,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
 
       // cache the directory, if necessary
       if (!(hints.flags & DIR_FLAG_BYPASS_CACHE))
-        g_directoryCache.SetDirectory(strPath, items, pDirectory->GetCacheType(strPath));
+        g_directoryCache.SetDirectory(realPath, items, pDirectory->GetCacheType(strPath));
     }
 
     // now filter for allowed files

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -64,7 +64,7 @@ bool CDirectoryCache::GetDirectory(const CStdString& strPath, CFileItemList &ite
 {
   CSingleLock lock (m_cs);
 
-  CStdString storedPath = URIUtils::SubstitutePath(strPath);
+  CStdString storedPath = strPath;
   URIUtils::RemoveSlashAtEnd(storedPath);
 
   ciCache i = m_cache.find(storedPath);
@@ -103,7 +103,7 @@ void CDirectoryCache::SetDirectory(const CStdString& strPath, const CFileItemLis
   // this is the best solution for now.
   CSingleLock lock (m_cs);
 
-  CStdString storedPath = URIUtils::SubstitutePath(strPath);
+  CStdString storedPath = strPath;
   URIUtils::RemoveSlashAtEnd(storedPath);
 
   ClearDirectory(storedPath);
@@ -127,7 +127,7 @@ void CDirectoryCache::ClearDirectory(const CStdString& strPath)
 {
   CSingleLock lock (m_cs);
 
-  CStdString storedPath = URIUtils::SubstitutePath(strPath);
+  CStdString storedPath = strPath;
   URIUtils::RemoveSlashAtEnd(storedPath);
 
   iCache i = m_cache.find(storedPath);
@@ -139,7 +139,7 @@ void CDirectoryCache::ClearSubPaths(const CStdString& strPath)
 {
   CSingleLock lock (m_cs);
 
-  CStdString storedPath = URIUtils::SubstitutePath(strPath);
+  CStdString storedPath = strPath;
   URIUtils::RemoveSlashAtEnd(storedPath);
 
   iCache i = m_cache.begin();
@@ -176,11 +176,11 @@ bool CDirectoryCache::FileExists(const CStdString& strFile, bool& bInCache)
   CSingleLock lock (m_cs);
   bInCache = false;
 
-  CStdString strPath;
-  URIUtils::GetDirectory(strFile, strPath);
-  URIUtils::RemoveSlashAtEnd(strPath);
+  CStdString storedPath;
+  URIUtils::GetDirectory(strFile, storedPath);
+  URIUtils::RemoveSlashAtEnd(storedPath);
 
-  ciCache i = m_cache.find(strPath);
+  ciCache i = m_cache.find(storedPath);
   if (i != m_cache.end())
   {
     bInCache = true;


### PR DESCRIPTION
As folders are saved after substitution, a file lookup will fail as the folder name will not be substituted.
As for the other commit, shouldn't a file be readded after a rename?
