### PR TITLE
show all existing artwork types for a specific media type in the "Choose art" dialog

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3718,6 +3718,33 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, map<int, map<string, string>
   return false;
 }
 
+bool CVideoDatabase::GetArtTypes(const std::string &mediaType, std::vector<std::string> &artTypes)
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS.get()) return false;
+
+    CStdString sql = PrepareSQL("SELECT DISTINCT type FROM art WHERE media_type='%s'", mediaType.c_str());
+    int numRows = RunQuery(sql);
+    if (numRows <= 0)
+      return numRows == 0;
+
+    while (!m_pDS->eof())
+    {
+      artTypes.push_back(m_pDS->fv(0).get_asString());
+      m_pDS->next();
+    }
+    m_pDS->close();
+    return true;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, mediaType.c_str());
+  }
+  return false;
+}
+
 /// \brief GetStackTimes() obtains any saved video times for the stacked file
 /// \retval Returns true if the stack times exist, false otherwise.
 bool CVideoDatabase::GetStackTimes(const CStdString &filePath, vector<int> &times)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -681,6 +681,7 @@ public:
   bool GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);
   std::string GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
   bool GetTvShowSeasonArt(int mediaId, std::map<int, std::map<std::string, std::string> > &seasonArt);
+  bool GetArtTypes(const std::string &mediaType, std::vector<std::string> &artTypes);
 
   int AddTag(const std::string &tag);
   void AddTagToItem(int idItem, int idTag, const std::string &type);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -620,6 +620,15 @@ string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, map<string
       artTypes.push_back(i->first);
   }
 
+  // add any art types that exist for other media items of the same type
+  vector<string> dbArtTypes;
+  db.GetArtTypes(videoItem.GetVideoInfoTag()->m_type, dbArtTypes);
+  for (vector<string>::const_iterator it = dbArtTypes.begin(); it != dbArtTypes.end(); it++)
+  {
+    if (find(artTypes.begin(), artTypes.end(), *it) == artTypes.end())
+      artTypes.push_back(*it);
+  }
+
   for (vector<string>::const_iterator i = artTypes.begin(); i != artTypes.end(); ++i)
   {
     string type = *i;


### PR DESCRIPTION
This commit implements what @jmarshallnz thought was already there in the "Choose art" dialog. It retrieves all known artwork types for a specific media type from the video database using the new GetArtTypes() method and adds them to the list of artwork in the "Choose art" dialog independent of whether they have a valid value or not. This means that when I (manually) add a "landscape" artwork type to tvshow A, "landscape" will also show up in the "Choose art" dialog for tvshow B but with no image assigned to it. That should make it easier for users to add the same custom artwork types across all media items of the same type.
