### PR TITLE
[WIN32] workaround: get the default audio interface for DirectSound to have audio on a fresh installation.

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -622,10 +622,23 @@ void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
     deviceInfo.m_displayNameExtra = std::string("DirectSound: ").append(strFriendlyName);
     deviceInfo.m_deviceType       = aeDeviceType;
 
-    /* Now logged by AESinkFactory on startup */
-    //CLog::Log(LOGDEBUG,"Audio Device %d:    %s", i, ((std::string)deviceInfo).c_str());
-
     deviceInfoList.push_back(deviceInfo);
+  }
+
+  // since AE takes the first device in deviceInfoList as default audio device we need
+  // to sort it in order to use the real default device
+  if(deviceInfoList.size() > 1)
+  {
+    std::string strDD = GetDefaultDevice();
+    for (AEDeviceInfoList::iterator itt = deviceInfoList.begin(); itt != deviceInfoList.end(); ++itt)
+    {
+      CAEDeviceInfo devInfo = *itt;
+      if(devInfo.m_deviceName == strDD)
+      {
+        deviceInfoList.erase(itt);
+        deviceInfoList.insert(deviceInfoList.begin(), devInfo);
+      }
+    }
   }
 
   return;
@@ -825,5 +838,61 @@ const char *CAESinkDirectSound::WASAPIErrToStr(HRESULT err)
   return NULL;
 }
 
+std::string CAESinkDirectSound::GetDefaultDevice()
+{
+  IMMDeviceEnumerator* pEnumerator = NULL;
+  IMMDevice*           pDevice = NULL;
+  IPropertyStore*      pProperty = NULL;
+  HRESULT              hr;
+  PROPVARIANT          varName;
+  std::string          strDevName = "default";
 
+  hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void**)&pEnumerator);
+  if (FAILED(hr))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": Could not allocate WASAPI device enumerator. CoCreateInstance error code: %s", WASAPIErrToStr(hr));
+    goto failed;
+  }
 
+  hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, &pDevice);
+  if (FAILED(hr))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": Retrieval of audio endpoint enumeration failed.");
+    goto failed;
+  }
+
+  hr = pDevice->OpenPropertyStore(STGM_READ, &pProperty);
+  if (FAILED(hr))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": Retrieval of DirectSound endpoint properties failed.");
+    goto failed;
+  }
+
+  PropVariantInit(&varName);
+  hr = pProperty->GetValue(PKEY_AudioEndpoint_FormFactor, &varName);
+  if (FAILED(hr))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": Retrieval of DirectSound endpoint form factor failed.");
+    goto failed;
+  }
+  AEDeviceType aeDeviceType = winEndpoints[(EndpointFormFactor)varName.uiVal].aeDeviceType;
+  PropVariantClear(&varName);
+
+  hr = pProperty->GetValue(PKEY_AudioEndpoint_GUID, &varName);
+  if (FAILED(hr))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": Retrieval of DirectSound endpoint GUID failed.");    
+    goto failed;
+  }
+
+  strDevName = localWideToUtf(varName.pwszVal);
+  PropVariantClear(&varName);
+
+failed:
+
+  SAFE_RELEASE(pProperty);
+  SAFE_RELEASE(pDevice);
+  SAFE_RELEASE(pEnumerator);
+
+  return strDevName;
+}

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -44,6 +44,7 @@ public:
   virtual double       GetCacheTotal      ();
   virtual unsigned int AddPackets         (uint8_t *data, unsigned int frames, bool hasAudio);
   static  void         EnumerateDevicesEx (AEDeviceInfoList &deviceInfoList);
+  static  std::string  GetDefaultDevice   ();
 private:
   void          AEChannelsFromSpeakerMask(DWORD speakers);
   DWORD         SpeakerMaskFromAEChannels(const CAEChannelInfo &channels);


### PR DESCRIPTION
Thats not a fine way of doing it but it works at least. On my setup (connected speakers) AE always choose spdif as default interface on a fresh installation. As a result I don't have any sound.
The problem is that AE just chooses the first device from the devicelist and treads it as default interface (passthrough=false).
I assume a better way would be to let the sink return the default interface or add a flag to CAEDeviceInfo. But what do I know...
This is for >=Vista only.
