### PR TITLE
add gui setting for set proxy types curl supported, so we can support socks4/4a/5/5 with remote dns

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -3255,7 +3255,42 @@ msgctxt "#1051"
 msgid "Enter web address"
 msgstr ""
 
-#empty strings from id 1052 to 1199
+#empty strings from id 1052 to 1179
+
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#1180"
+msgid "Proxy type"
+msgstr ""
+
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#1181"
+msgid "HTTP"
+msgstr ""
+
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#1182"
+msgid "SOCKS4"
+msgstr ""
+
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#1183"
+msgid "SOCKS4A"
+msgstr ""
+
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#1184"
+msgid "SOCKS5"
+msgstr ""
+
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#1185"
+msgid "SOCKS5 with remote dns resolving"
+msgstr ""
+
+#empty strings from id 1186 to 1189
+#strings 1186 to 1189 reserved for more proxy types
+
+#empty strings from id 1190 to 1199
 
 #: xbmc/settings/GUISettings.cpp
 msgctxt "#1200"

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -208,7 +208,8 @@ extern "C" void __stdcall update_emu_environ()
   // Use a proxy, if the GUI was configured as such
   if (g_guiSettings.GetBool("network.usehttpproxy")
       && !g_guiSettings.GetString("network.httpproxyserver").empty()
-      && !g_guiSettings.GetString("network.httpproxyport").empty())
+      && !g_guiSettings.GetString("network.httpproxyport").empty()
+      && g_guiSettings.GetInt("network.httpproxytype") == 0)
   {
     CStdString strProxy;
     if (g_guiSettings.GetString("network.httpproxyusername") &&

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -52,6 +52,15 @@ using namespace XCURL;
 
 #define dllselect select
 
+
+curl_proxytype proxyType2CUrlProxyType[] = {
+  CURLPROXY_HTTP,
+  CURLPROXY_SOCKS4,
+  CURLPROXY_SOCKS4A,
+  CURLPROXY_SOCKS5,
+  CURLPROXY_SOCKS5_HOSTNAME,
+};
+
 // curl calls this routine to debug
 extern "C" int debug_callback(CURL_HANDLE *handle, curl_infotype info, char *output, size_t size, void *data)
 {
@@ -326,6 +335,7 @@ CCurlFile::CCurlFile()
   m_username = "";
   m_password = "";
   m_httpauth = "";
+  m_proxytype = PROXY_HTTP;
   m_state = new CReadState();
   m_skipshout = false;
   m_httpresponse = -1;
@@ -499,6 +509,7 @@ void CCurlFile::SetCommonOptions(CReadState* state)
   if (m_proxy.length() > 0)
   {
     g_curlInterface.easy_setopt(h, CURLOPT_PROXY, m_proxy.c_str());
+    g_curlInterface.easy_setopt(h, CURLOPT_PROXYTYPE, proxyType2CUrlProxyType[m_proxytype]);
     if (m_proxyuserpass.length() > 0)
       g_curlInterface.easy_setopt(h, CURLOPT_PROXYUSERPWD, m_proxyuserpass.c_str());
 
@@ -658,14 +669,15 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         && !g_guiSettings.GetString("network.httpproxyport").empty()
         && m_proxy.IsEmpty())
     {
-      m_proxy = "http://" + g_guiSettings.GetString("network.httpproxyserver");
+      m_proxy = g_guiSettings.GetString("network.httpproxyserver");
       m_proxy += ":" + g_guiSettings.GetString("network.httpproxyport");
       if (g_guiSettings.GetString("network.httpproxyusername").length() > 0 && m_proxyuserpass.IsEmpty())
       {
         m_proxyuserpass = g_guiSettings.GetString("network.httpproxyusername");
         m_proxyuserpass += ":" + g_guiSettings.GetString("network.httpproxypassword");
       }
-      CLog::Log(LOGDEBUG, "Using proxy %s", m_proxy.c_str());
+      m_proxytype = (ProxyType)g_guiSettings.GetInt("network.httpproxytype");
+      CLog::Log(LOGDEBUG, "Using proxy %s, type %d", m_proxy.c_str(), proxyType2CUrlProxyType[m_proxytype]);
     }
 
     // get username and password

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -38,6 +38,15 @@ namespace XFILE
   class CCurlFile : public IFile
   {
     public:
+      typedef enum
+      {
+        PROXY_HTTP = 0,
+        PROXY_SOCKS4,
+        PROXY_SOCKS4A,
+        PROXY_SOCKS5,
+        PROXY_SOCKS5_REMOTE,
+      } ProxyType;
+    
       CCurlFile();
       virtual ~CCurlFile();
       virtual bool Open(const CURL& url);
@@ -62,6 +71,7 @@ namespace XFILE
       void SetUserAgent(CStdString sUserAgent)                   { m_userAgent = sUserAgent; }
       void SetProxy(CStdString &proxy)                           { m_proxy = proxy; }
       void SetProxyUserPass(CStdString &proxyuserpass)           { m_proxyuserpass = proxyuserpass; }
+      void SetProxyType(ProxyType proxytype)                     { m_proxytype = proxytype; }
       void SetCustomRequest(CStdString &request)                 { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetContentEncoding(CStdString encoding)               { m_contentencoding = encoding; }
@@ -133,6 +143,7 @@ namespace XFILE
       CStdString      m_userAgent;
       CStdString      m_proxy;
       CStdString      m_proxyuserpass;
+      ProxyType       m_proxytype;
       CStdString      m_customrequest;
       CStdString      m_contentencoding;
       CStdString      m_ftpauth;

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -40,6 +40,7 @@
 #include "cores/dvdplayer/DVDCodecs/Video/CrystalHD.h"
 #include "cores/AudioEngine/AEFactory.h"
 #include "cores/AudioEngine/AEAudioFormat.h"
+#include "filesystem/CurlFile.h"
 #include "guilib/GUIFont.h" // for FONT_STYLE_* definitions
 #if defined(TARGET_DARWIN_OSX)
   #include "cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.h"
@@ -580,6 +581,13 @@ void CGUISettings::Initialize()
 #endif
   }
   AddBool(net, "network.usehttpproxy", 708, false);
+  map<int,int> proxyTypes;
+  proxyTypes.insert(make_pair(1181, XFILE::CCurlFile::PROXY_HTTP));
+  proxyTypes.insert(make_pair(1182, XFILE::CCurlFile::PROXY_SOCKS4));
+  proxyTypes.insert(make_pair(1183, XFILE::CCurlFile::PROXY_SOCKS4A));
+  proxyTypes.insert(make_pair(1184, XFILE::CCurlFile::PROXY_SOCKS5));
+  proxyTypes.insert(make_pair(1185, XFILE::CCurlFile::PROXY_SOCKS5_REMOTE));
+  AddInt(net, "network.httpproxytype", 1180, XFILE::CCurlFile::PROXY_HTTP, proxyTypes, SPIN_CONTROL_TEXT);
   AddString(net, "network.httpproxyserver", 706, "", EDIT_CONTROL_INPUT);
   AddString(net, "network.httpproxyport", 730, "8080", EDIT_CONTROL_NUMBER_INPUT, false, 707);
   AddString(net, "network.httpproxyusername", 1048, "", EDIT_CONTROL_INPUT);

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -872,7 +872,8 @@ void CGUIWindowSettingsCategory::UpdateSettings()
        if (pControl) pControl->SetEnabled(enabled);
     }
     else if (strSetting.Equals("network.httpproxyserver")   || strSetting.Equals("network.httpproxyport") ||
-             strSetting.Equals("network.httpproxyusername") || strSetting.Equals("network.httpproxypassword"))
+             strSetting.Equals("network.httpproxyusername") || strSetting.Equals("network.httpproxypassword") ||
+             strSetting.Equals("network.httpproxytype"))
     {
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
       if (pControl) pControl->SetEnabled(g_guiSettings.GetBool("network.usehttpproxy"));


### PR DESCRIPTION
as @elupus suggested in https://github.com/xbmc/xbmc/pull/2195 , the feature is added to gui setting now.
