### PR TITLE
changed: Add rule for selecting remote (or non-local) items for player s...

### DIFF
--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -44,6 +44,7 @@ void CPlayerSelectionRule::Initialize(TiXmlElement* pRule)
   CLog::Log(LOGDEBUG, "CPlayerSelectionRule::Initialize: creating rule: %s", m_name.c_str());
 
   m_tInternetStream = GetTristate(pRule->Attribute("internetstream"));
+  m_tRemote = GetTristate(pRule->Attribute("remote"));
   m_tAudio = GetTristate(pRule->Attribute("audio"));
   m_tVideo = GetTristate(pRule->Attribute("video"));
 
@@ -110,6 +111,7 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, VECPLAYERCORES &vec
   if (m_tAudio >= 0 && (m_tAudio > 0) != item.IsAudio()) return;
   if (m_tVideo >= 0 && (m_tVideo > 0) != item.IsVideo()) return;
   if (m_tInternetStream >= 0 && (m_tInternetStream > 0) != item.IsInternetStream()) return;
+  if (m_tRemote >= 0 && (m_tRemote > 0) != item.IsRemote()) return;
 
   if (m_tBD >= 0 && (m_tBD > 0) != (item.IsBDFile() && item.IsOnDVD())) return;
   if (m_tDVD >= 0 && (m_tDVD > 0) != item.IsDVD()) return;

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -47,6 +47,7 @@ private:
   int m_tAudio;
   int m_tVideo;
   int m_tInternetStream;
+  int m_tRemote;
 
   int m_tBD;
   int m_tDVD;


### PR DESCRIPTION
...election rules. Extremely useful since most external players only handle local (non-remote) items.
