### PR TITLE
[rbp] Fix for broken ASS subtitles.

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -49,6 +49,7 @@ protected:
   bool                      m_open;
   CDVDStreamInfo            m_hints;
   double                    m_iCurrentPts;
+  double                    m_iSleepEndTime;
   OMXClock                  *m_av_clock;
   COMXVideo                 m_omxVideo;
   float                     m_fFrameRate;


### PR DESCRIPTION
The video fifo patch broke some types of subtitles including ASS.
This keeps closer track of when the sleep time would have ended and calls FlipPage at the appropriate time.
I've also removed the 500ms in the sleep time calculation as that makes the subs render 500ms late. Not sure what its purpose was.
