### PR TITLE
AE: Fix resume after song change with Pulseaudio

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.h
@@ -79,6 +79,12 @@ public:
   /* trigger the stream to update its volume relative to AE */
   void UpdateVolume(float max);
 
+  /* used to prepare a stream for resume */
+  void SetDrained() { m_ResumeCallback = true; };
+
+  /* Process the Resume of streams */
+  void ProcessCallbacks();
+
   virtual void RegisterSlave(IAEStream *stream);
 private:
   static void StreamRequestCallback(pa_stream *s, size_t length, void *userdata);
@@ -93,6 +99,7 @@ private:
   bool m_Destroyed;
   bool m_Initialized;
   bool m_Paused;
+  bool m_ResumeCallback;
 
   pa_stream *m_Stream;
   pa_sample_spec m_SampleSpec;


### PR DESCRIPTION
This commit fixes switching to next track without crossfade enabled.
Thx @elupus for the help. #Fixes 13387
