### PR TITLE
Corrected order parameters in Control.setAnimations

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -779,8 +779,8 @@ namespace XBMCAddon
         if (pTuple.GetNumValuesSet() != 2)
           throw WindowException("Error unpacking tuple found in list");
 
-        const String& cAttr = pTuple.first();
-        const String& cEvent = pTuple.second();
+        const String& cEvent = pTuple.first();
+        const String& cAttr = pTuple.second();
 
         TiXmlElement pNode("animation");
         CStdStringArray attrs;


### PR DESCRIPTION
The documentation states that setAnimations receives a list of tuples,
every tuple being a pair (event, attr), for example:

self.button.setAnimations([('focus', 'effect=zoom end=90,247,220,56
time=0',)])

This patch corrects a bug by which the order of the tuple is reversed,
breaking Python scripts which send parameters in the order stated by
the documentation.

This bug is discussed in http://forum.xbmc.org/showthread.php?tid=144063 with example code about how to reproduce it.
