### PR TITLE
Fix: now mp4 file on internet url (http, etc) can be played by dvdplayer.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -51,8 +51,13 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
   if (!m_pFile)
     return false;
 
+  unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
+
+  if (content == "video/mp4")
+    flags |= READ_FREQ_RANDOM_SEEK;
+
   // open file in binary mode
-  if (!m_pFile->Open(strFile, READ_TRUNCATED | READ_BITRATE | READ_CHUNKED))
+  if (!m_pFile->Open(strFile, flags))
   {
     delete m_pFile;
     m_pFile = NULL;

--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -66,7 +66,7 @@ protected:
 */
 class CSimpleFileCache : public CCacheStrategy {
 public:
-  CSimpleFileCache();
+  CSimpleFileCache(bool needFreqRandomSeek=false);
   virtual ~CSimpleFileCache();
 
   virtual int Open() ;
@@ -89,6 +89,7 @@ protected:
   volatile int64_t m_nStartPosition;
   volatile int64_t m_nWritePosition;
   volatile int64_t m_nReadPosition;
+  bool m_bNeedFreqRandomSeek;
 };
 
 }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -227,12 +227,14 @@ bool CFile::Open(const CStdString& strFileName, unsigned int flags)
     }
 
     CURL url(URIUtils::SubstitutePath(strFileName));
-    if ( (flags & READ_NO_CACHE) == 0 && URIUtils::IsInternetStream(url, true) && !CUtil::IsPicture(strFileName) )
+    bool isInternetStream = URIUtils::IsInternetStream(url, true);
+    if ( (flags & READ_NO_CACHE) == 0 && isInternetStream && !CUtil::IsPicture(strFileName) )
       m_flags |= READ_CACHED;
 
     if (m_flags & READ_CACHED)
     {
-      m_pFile = new CFileCache();
+      // for internet stream, if need frequent random seek, file cache need handle it specially.
+      m_pFile = new CFileCache((m_flags & READ_FREQ_RANDOM_SEEK)!=0 && isInternetStream);
       return m_pFile->Open(url);
     }
 

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -64,6 +64,9 @@ public:
 /* calcuate bitrate for file while reading */
 #define READ_BITRATE   0x10
 
+/* indicate the caller will random seek frequently */
+#define READ_FREQ_RANDOM_SEEK 0x20
+
 class CFileStreamBuffer;
 
 class CFile

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -78,15 +78,15 @@ private:
 };
 
 
-CFileCache::CFileCache() : CThread("FileCache")
+CFileCache::CFileCache(bool needFreqRandomSeek) : CThread("FileCache")
 {
    m_bDeleteCache = true;
    m_nSeekResult = 0;
    m_seekPos = 0;
    m_readPos = 0;
    m_writePos = 0;
-   if (g_advancedSettings.m_cacheMemBufferSize == 0)
-     m_pCache = new CSimpleFileCache();
+   if (g_advancedSettings.m_cacheMemBufferSize == 0 || needFreqRandomSeek)
+     m_pCache = new CSimpleFileCache(needFreqRandomSeek);
    else
      m_pCache = new CCircularCache(g_advancedSettings.m_cacheMemBufferSize
                                  , std::max<unsigned int>( g_advancedSettings.m_cacheMemBufferSize / 4, 1024 * 1024));

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -31,7 +31,7 @@ namespace XFILE
   class CFileCache : public IFile, public CThread
   {
   public:
-    CFileCache();
+    CFileCache(bool needFreqRandomSeek=false);
     CFileCache(CCacheStrategy *pCache, bool bDeleteCache=true);
     virtual ~CFileCache();
 


### PR DESCRIPTION
currently in frodo, mp4 file on on http link is unplayable, after some dig, I fount it's because the dvdplayer(ffmpeg/avformat) handle mp4 file with many many random seeks between file head, middle and end. then check the file cache code, the cache will be reset after each seek, it cause the file is totally unplayable by xbmc.
by check other players, I found:
in vlc, it almost same with xbmc, almost unplayable
in mplayer, it cache from file head until the seek position then continue it can play
in ios native player, it also seeks from here to there, but it seems has a better cache strategy or keep the main stream continue cached, it also played well.

so, an easy fix for this type file (frequently random seek), cache should work in different strategy.

this commit fix this by set frequent_random_seek flag to cache let cache work in the mplayer way, then the mp4 file on net url can be played by xbmc.
