### PR TITLE
[json-rpc] Extend "audiostreams" result of Player.GetProperties.

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1395,6 +1395,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
             g_application.m_pPlayer->GetAudioStreamLanguage(index, value);
             audioStream["language"] = value;
 
+            audioStream["codec"] = g_application.m_pPlayer->GetAudioCodecName();
+            audioStream["bitrate"] = g_application.m_pPlayer->GetAudioBitrate();
+            audioStream["channels"] = g_application.m_pPlayer->GetChannels();
+
             result.append(audioStream);
           }
         }


### PR DESCRIPTION
Add codec, bitrate and channels to the "audiostreams" result of Player.GetProperties.
This changes the returned type from Player.Audio.Stream[] to Player.Audio.Stream.Extended[]
