### PR TITLE
[json-rpc] Fix Player.GetProperties' result "currentaudiostream" if there is no audio stream

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1361,10 +1361,11 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
             value.Empty();
             g_application.m_pPlayer->GetAudioStreamLanguage(index, value);
             result["language"] = value;
+
+            result["codec"] = g_application.m_pPlayer->GetAudioCodecName();
+            result["bitrate"] = g_application.m_pPlayer->GetAudioBitrate();
+            result["channels"] = g_application.m_pPlayer->GetChannels();
           }
-          result["codec"] = g_application.m_pPlayer->GetAudioCodecName();
-          result["bitrate"] = g_application.m_pPlayer->GetAudioBitrate();
-          result["channels"] = g_application.m_pPlayer->GetChannels();
         }
         else
           result = CVariant(CVariant::VariantTypeNull);


### PR DESCRIPTION
Fix the result of Player.GetProperties with param "currentaudiostream" for videos without an audio stream (index = -1). The correct return value is an empty list.
