### PR TITLE
ADD: matchesregex() to the visibility expressions

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -724,8 +724,8 @@ int CGUIInfoManager::TranslateSingleString(const CStdString &strCondition)
 {
   // trim whitespaces
   CStdString strTest = strCondition;
-  strTest.TrimLeft(" \t\r\n");
-  strTest.TrimRight(" \t\r\n");
+  strTest.TrimLeft(" \t\r\n\"");
+  strTest.TrimRight(" \t\r\n\"");
 
   vector< Property> info;
   SplitInfoString(strTest, info);
@@ -1998,6 +1998,19 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
   return false;
 }
 
+bool HasOperator(const CStdString& expression)
+{
+  bool escaped=false;
+  for(unsigned int i=0; i<expression.size(); ++i)
+  {
+    if(expression[i]=='"')
+      escaped=!escaped;
+    if(!escaped && InfoExpression::GetOperator(expression[i]))
+      return true;
+  }
+  return false;
+}
+
 unsigned int CGUIInfoManager::Register(const CStdString &expression, int context)
 {
   CStdString condition(CGUIInfoLabel::ReplaceLocalize(expression));
@@ -2016,7 +2029,7 @@ unsigned int CGUIInfoManager::Register(const CStdString &expression, int context
       return i+1;
   }
 
-  if (condition.find_first_of("|+[]!") != condition.npos)
+  if (HasOperator(condition))
     m_bools.push_back(new InfoExpression(condition, context));
   else
     m_bools.push_back(new InfoSingle(condition, context));

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -360,6 +360,8 @@ namespace INFO
 #define INTEGER_GREATER_THAN        413
 #define STRING_STR_LEFT             414
 #define STRING_STR_RIGHT            415
+#define MATCHES_REGEX_CASE_SENSITIVE   416
+#define MATCHES_REGEX_CASE_INSENSITIVE 417
 
 #define SKIN_BOOL                   600
 #define SKIN_STRING                 601

--- a/xbmc/interfaces/info/InfoBool.cpp
+++ b/xbmc/interfaces/info/InfoBool.cpp
@@ -54,7 +54,7 @@ void InfoExpression::Update(const CGUIListItem *item)
 #define OPERATOR_AND  2
 #define OPERATOR_OR   1
 
-short InfoExpression::GetOperator(const char ch) const
+short InfoExpression::GetOperator(const char ch)
 {
   if (ch == '[')
     return OPERATOR_LB;
@@ -74,9 +74,14 @@ void InfoExpression::Parse(const CStdString &expression)
 {
   stack<char> operators;
   CStdString operand;
+  bool escaped = false;
   for (unsigned int i = 0; i < expression.size(); i++)
   {
-    if (GetOperator(expression[i]))
+    if(expression[i]=='"') {
+      escaped = !escaped;
+    }
+    
+    if (!escaped && GetOperator(expression[i]))
     {
       // cleanup any operand, translate and put into our expression list
       if (!operand.IsEmpty())
@@ -123,7 +128,7 @@ void InfoExpression::Parse(const CStdString &expression)
     {
       operand += expression[i];
     }
-  }
+  }    
 
   if (!operand.empty())
   {
@@ -142,6 +147,9 @@ void InfoExpression::Parse(const CStdString &expression)
     operators.pop();
   }
 
+  if(escaped)
+    CLog::Log(LOGERROR, "No matching \" at the end of your string", expression.c_str());
+  
   // test evaluate
   bool test;
   if (!Evaluate(NULL, test))

--- a/xbmc/interfaces/info/InfoBool.h
+++ b/xbmc/interfaces/info/InfoBool.h
@@ -105,10 +105,10 @@ public:
   virtual ~InfoExpression() {};
 
   virtual void Update(const CGUIListItem *item);
+  static short GetOperator(const char ch);
 private:
   void Parse(const CStdString &expression);
   bool Evaluate(const CGUIListItem *item, bool &result);
-  short GetOperator(const char ch) const;
 
   std::vector<short> m_postfix;         ///< the postfix form of the expression (operators and operand indicies)
   std::vector<unsigned int> m_operands; ///< the operands in the expression

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -267,3 +267,9 @@ void CRegExp::DumpOvector(int iLog /* = LOGDEBUG */)
   str += "}";
   CLog::Log(iLog, "regexp ovector=%s", str.c_str());
 }
+
+bool CRegExp::operator ==(const CRegExp &rhs) const
+{
+  return m_iOptions == rhs.m_iOptions
+      && m_pattern == rhs.m_pattern;
+}

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -67,6 +67,7 @@ public:
   void DumpOvector(int iLog);
   const CRegExp& operator= (const CRegExp& re);
 
+  bool operator ==(const CRegExp &rhs) const;
 private:
   void Cleanup() { if (m_re) { PCRE::pcre_free(m_re); m_re = NULL; } }
 


### PR DESCRIPTION
This adds the function `matchesregex(INFO_LABEL, STRING, [BOOL=false])` to the `<visiblity></visibility` stuff of the skinning engine.

BOOL= if true, the regex matching will be case insensitive

Befor you ask why? This feature was requested in this PR #1654 by @bstrdsmkr.
This feature seemed standalone enough so I decided to make it a seperate PR 
