### PR TITLE
Fix dvdplayer crash when STOP playing immediately followed by PlayFile.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4903,6 +4903,8 @@ bool CApplication::OnMessage(CGUIMessage& message)
   case GUI_MSG_PLAYBACK_ENDED:
   case GUI_MSG_PLAYLISTPLAYER_STOPPED:
     {
+      if (m_bPlaybackStarting)
+        return true;
 #ifdef HAS_KARAOKE
       if (m_pKaraokeMgr )
         m_pKaraokeMgr->Stop();


### PR DESCRIPTION
there is a flag m_bPlaybackStarting in CApplication, which is used to protect the play starting state from callbacks from previous stopped playing, in CApplication::OnPlayBackEnded(), CApplication::OnPlayBackStopped() both has code in the beginning check the flag if set return.
But in CApplication::OnMessage, the code handling these messages: GUI_MSG_PLAYBACK_STOPPED, GUI_MSG_PLAYBACK_ENDED, GUI_MSG_PLAYLISTPLAYER_STOPPED, does not check the flag.
I encounter some crash, caused by start playing new video immediately after STOP previous playing video, which happens when the OnPlayBackStopped() callback already called from dvdplayer thread, then xbmc main thread starting play new video, set the m_bPlaybackStarting flag, before the GUI_MSG_PLAYBACK_STOPPED message processed by xbmc main thread, then in dvdplayer::OpenFile's busy dialog message loop, the GUI_MSG_PLAYBACK_STOPPED be processed finaly, it deconstructed the dvdplayer then finally crashed, here's some detail crash info: http://pastebin.ubuntu.com/1641207/

finally I found the starting flag in CApplication and it is used to protect the starting process not break by previous stop/end callback, but there is still chance the OnPlayBackStopped() be called before the flag set, then finally in the code handling message GUI_MSG_PLAYBACK_STOPPED, we should continue protect starting process by the flag, so here's the 2 line fix commit.
