### PR TITLE
cpu freq, cpu temp, gpu temp

### DIFF
--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -93,7 +93,7 @@ private:
 
   FILE* m_fProcStat;
   FILE* m_fProcTemperature;
-  FILE* m_fCPUInfo;
+  FILE* m_fCPUFreq;
 
   unsigned long long m_userTicks;
   unsigned long long m_niceTicks;

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -141,7 +141,9 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s %s", 22023, SYSTEM_RENDER_VENDOR);
     SetControlLabel(i++, "%s %s", 22024, SYSTEM_RENDER_VERSION);
 #endif
+#ifndef __arm__
     SetControlLabel(i++, "%s %s", 22010, SYSTEM_GPU_TEMPERATURE);
+#endif
   }
   else if (m_section == CONTROL_BT_HARDWARE)
   {
@@ -155,7 +157,7 @@ void CGUIWindowSystemInfo::FrameMove()
     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUSerial());
 #endif
     SetControlLabel(i++, "%s %s", 22011, SYSTEM_CPU_TEMPERATURE);
-#if !defined(__arm__)
+#if !defined(__arm__) || defined(TARGET_RASPBERRY_PI)
     SetControlLabel(i++, "%s %s", 13284, SYSTEM_CPUFREQUENCY);
 #endif
 #endif


### PR DESCRIPTION
Changed cpu frequency for all Linux platforms, added RPI specific cpu temp command and removed irrelevant gpu temp for all ARM platforms.

second attempt, changed as advised in previous one.
