### PR TITLE
Micro-cleanup patch in confluence skin

### DIFF
--- a/addons/skin.confluence/720p/Font.xml
+++ b/addons/skin.confluence/720p/Font.xml
@@ -1,37 +1,37 @@
 <fonts>
 	<fontset id="Default" idloc="31390" unicode="true"> 
 	<!-- Normal Fonts -->
-	 	<font>
+		<font>
 			<name>font10</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>14</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font12</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>17</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font13</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>20</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font14</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>22</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font16</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>25</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font30</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>30</size>
 		</font>
-	 	<font>
+		<font>
 			<name>fontContextMenu</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>18</size>
@@ -39,53 +39,53 @@
 
 
 	<!-- Title Fonts -->
-	 	<font>
+		<font>
 			<name>font10_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>12</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font12_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>17</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font13_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>20</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font24_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>24</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font28_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>28</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font30_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>30</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font35_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>35</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font45caps_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>45</size>
 		</font>
 
-	 	<font>
+		<font>
 			<name>font_MainMenu</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>40</size>
 		</font>
-	 	<font>
+		<font>
 			<name>WeatherTemp</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>80</size>
@@ -94,37 +94,37 @@
 
 	<fontset id="DefaultNoCaps" idloc="31391" unicode="true"> 
 	<!-- Normal Fonts -->
-	 	<font>
+		<font>
 			<name>font10</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>14</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font12</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>17</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font13</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>20</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font14</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>22</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font16</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>25</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font30</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>30</size>
 		</font>
-	 	<font>
+		<font>
 			<name>fontContextMenu</name>
 			<filename>Roboto-Regular.ttf</filename>
 			<size>18</size>
@@ -132,53 +132,53 @@
 
 
 	<!-- Title Fonts -->
-	 	<font>
+		<font>
 			<name>font10_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>12</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font12_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>17</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font13_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>20</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font24_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>24</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font28_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>28</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font30_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>30</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font35_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>35</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font45caps_title</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>45</size>
 		</font>
 
-	 	<font>
+		<font>
 			<name>font_MainMenu</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>40</size>
 		</font>
-	 	<font>
+		<font>
 			<name>WeatherTemp</name>
 			<filename>Roboto-Bold.ttf</filename>
 			<size>80</size>
@@ -187,37 +187,37 @@
 
 	<fontset id="Arial" idloc="31392" unicode="true"> 
 	<!-- Arial Font better for non English -->
-	 	<font>
+		<font>
 			<name>font10</name>
 			<filename>arial.ttf</filename>
 			<size>12</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font12</name>
 			<filename>arial.ttf</filename>
 			<size>15</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font13</name>
 			<filename>arial.ttf</filename>
 			<size>18</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font14</name>
 			<filename>arial.ttf</filename>
 			<size>20</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font16</name>
 			<filename>arial.ttf</filename>
 			<size>23</size>
 		</font>
-	 	<font>
+		<font>
 			<name>font30</name>
 			<filename>arial.ttf</filename>
 			<size>28</size>
 		</font>
-	 	<font>
+		<font>
 			<name>fontContextMenu</name>
 			<filename>arial.ttf</filename>
 			<size>16</size>
@@ -225,62 +225,62 @@
 
 
 	<!-- Title Fonts -->
-	 	<font>
+		<font>
 			<name>font10_title</name>
 			<filename>arial.ttf</filename>
 			<size>10</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>font12_title</name>
 			<filename>arial.ttf</filename>
 			<size>15</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>font13_title</name>
 			<filename>arial.ttf</filename>
 			<size>18</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>font24_title</name>
 			<filename>arial.ttf</filename>
 			<size>22</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>font28_title</name>
 			<filename>arial.ttf</filename>
 			<size>26</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>font30_title</name>
 			<filename>arial.ttf</filename>
 			<size>28</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>font35_title</name>
 			<filename>arial.ttf</filename>
 			<size>33</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>font45caps_title</name>
 			<filename>arial.ttf</filename>
 			<size>43</size>
 			<style>bold</style>
 		</font>
 
-	 	<font>
+		<font>
 			<name>font_MainMenu</name>
 			<filename>arial.ttf</filename>
 			<size>35</size>
 			<style>bold</style>
 		</font>
-	 	<font>
+		<font>
 			<name>WeatherTemp</name>
 			<filename>arial.ttf</filename>
 			<size>80</size>


### PR DESCRIPTION
the confluence skin has some spaces inbetween tabs. Using vim for example and visualizing tabs
(from vim.tiny)

set list                " show tabs and spaces at end of line:
set listchars=tab:>-,trail:.,extends:>

this quickly can be spotted. This micro-patch cleans this up.
