### PR TITLE
[WIN32][AE] implemented an interface to ISimpleAudioVolume to set the vo...

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -25,6 +25,7 @@
 #include "../Utils/AEDeviceInfo.h"
 
 #include "threads/CriticalSection.h"
+#include <Audioclient.h>
 
 class CAESinkDirectSound : public IAESink
 {
@@ -45,7 +46,10 @@ public:
   virtual unsigned int AddPackets         (uint8_t *data, unsigned int frames, bool hasAudio);
   static  std::string  GetDefaultDevice   ();
   static  void         EnumerateDevicesEx (AEDeviceInfoList &deviceInfoList, bool force = false);
+  virtual bool         HasVolume();
+  virtual void         SetVolume(float volume);
 private:
+  bool          InitAudioSessionVolume();
   void          AEChannelsFromSpeakerMask(DWORD speakers);
   DWORD         SpeakerMaskFromAEChannels(const CAEChannelInfo &channels);
   void          CheckPlayStatus();
@@ -78,4 +82,5 @@ private:
   bool                m_initialized;
   bool                m_isDirtyDS;
   CCriticalSection    m_runLock;
+  ISimpleAudioVolume  *m_pSimpleAudioVolume;
 };


### PR DESCRIPTION
...lume of the XBMC audio session. Unfortunately it seems to be that AE doesn't use GetVolume to get the current volume (of the sink) and relies on m_volume only.
This means that setting the volume in XBMC will also set the slider in the windows audio mixer. Setting the volume in the mixer will reduce the volume in XBMC but not shown in the XBMC volume bar. Changing the volume in XBMC afterwards will restore the old volume.
This is Vista and up only.
