### PR TITLE
Don't leave failed fileop jobs in the processing list.

### DIFF
--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1178,8 +1178,7 @@ void CGUIWindowFileManager::OnJobComplete(unsigned int jobID, bool success, CJob
     CApplicationMessenger::Get().SendGUIMessage(msg, GetID(), false);
   }
 
-  if (success)
-    CJobQueue::OnJobComplete(jobID, success, job);
+  CJobQueue::OnJobComplete(jobID, success, job);
 }
 
 void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)


### PR DESCRIPTION
We want to remove fileop jobs from the queue regardless of whether they
were successful or not.  Otherwise we crash on the next call to
AddJob().

To test: In the file manager, try to copy a large dir to a nearly full thumb drive. The xfer will fail.  Try to delete the failed dest dir. Pop!
