### PR TITLE
Fix race conditions during PlayFile()

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -266,7 +266,7 @@ public:
   MEDIA_DETECT::CDetectDVDMedia m_DetectDVDType;
 #endif
 
-  IPlayer* m_pPlayer;
+  boost::shared_ptr<IPlayer> m_pPlayer;
 
   inline bool IsInScreenSaver() { return m_bScreenSave; };
   int m_iScreenSaveLock; // spiff: are we checking for a lock? if so, ignore the screensaver state, if -1 we have failed to input locks

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -278,6 +278,7 @@ public:
   inline bool IsInScreenSaver() { return m_bScreenSave; };
   int m_iScreenSaveLock; // spiff: are we checking for a lock? if so, ignore the screensaver state, if -1 we have failed to input locks
 
+  unsigned int m_iPlayerOPSeq;  // used to detect whether an OpenFile request on player is canceled by us.
   bool m_bPlaybackStarting;
   typedef enum
   {

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -272,6 +272,16 @@ public:
   int m_iScreenSaveLock; // spiff: are we checking for a lock? if so, ignore the screensaver state, if -1 we have failed to input locks
 
   bool m_bPlaybackStarting;
+  typedef enum
+  {
+    PLAY_STATE_NONE = 0,
+    PLAY_STATE_STARTING,
+    PLAY_STATE_PLAYING,
+    PLAY_STATE_STOPPED,
+    PLAY_STATE_ENDED,
+  } PlayState;
+  PlayState m_ePlayState;
+  CCriticalSection m_playStateMutex;
 
   bool m_bInBackground;
   inline bool IsInBackground() { return m_bInBackground; };

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -109,6 +109,13 @@ protected:
   int       m_iPlayList;
 };
 
+typedef enum
+{
+  PLAYBACK_CANCELED = -1,
+  PLAYBACK_FAIL = 0,
+  PLAYBACK_OK = 1,
+} PlayBackRet;
+
 class CApplication : public CXBApplicationEx, public IPlayerCallback, public IMsgTargetCallback,
                      public ISettingCallback, public ISettingsHandler, public ISubSettings
 {
@@ -167,7 +174,7 @@ public:
   bool PlayMedia(const CFileItem& item, int iPlaylist = PLAYLIST_MUSIC);
   bool PlayMediaSync(const CFileItem& item, int iPlaylist = PLAYLIST_MUSIC);
   bool ProcessAndStartPlaylist(const CStdString& strPlayList, PLAYLIST::CPlayList& playlist, int iPlaylist, int track=0);
-  bool PlayFile(const CFileItem& item, bool bRestart = false);
+  PlayBackRet PlayFile(const CFileItem& item, bool bRestart = false);
   void SaveFileState(bool bForeground = false);
   void UpdateFileState();
   void StopPlaying();
@@ -442,7 +449,7 @@ protected:
 
   void VolumeChanged() const;
 
-  bool PlayStack(const CFileItem& item, bool bRestart);
+  PlayBackRet PlayStack(const CFileItem& item, bool bRestart);
   bool ProcessMouse();
   bool ProcessRemote(float frameTime);
   bool ProcessGamepad(float frameTime);

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -258,7 +258,10 @@ bool CPlayListPlayer::Play(int iSong, bool bAutoPlay /* = false */, bool bPlayPr
   m_bPlaybackStarted = false;
 
   unsigned int playAttempt = XbmcThreads::SystemClockMillis();
-  if (!g_application.PlayFile(*item, bAutoPlay))
+  PlayBackRet ret = g_application.PlayFile(*item, bAutoPlay);
+  if (ret == PLAYBACK_CANCELED)
+    return false;
+  if (ret == PLAYBACK_FAIL)
   {
     CLog::Log(LOGERROR,"Playlist Player: skipping unplayable item: %i, path [%s]", m_iCurrentSong, item->GetPath().c_str());
     playlist.SetUnPlayable(m_iCurrentSong);

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1090,17 +1090,16 @@ bool CGUIWindowSlideShow::PlayVideo()
     return false;
   CLog::Log(LOGDEBUG, "Playing current video slide %s", item->GetPath().c_str());
   m_bPlayingVideo = true;
-  /* PlayBackRet */ bool ret = g_application.PlayFile(*item);
-  if (ret/* == PLAYBACK_OK*/)
+  PlayBackRet ret = g_application.PlayFile(*item);
+  if (ret == PLAYBACK_OK)
     return true;
-  else
-//  if (ret == PLAYBACK_FAIL)
+  if (ret == PLAYBACK_FAIL)
   {
     CLog::Log(LOGINFO, "set video %s unplayable", item->GetPath().c_str());
     item->SetProperty("unplayable", true);
   }
-//  else if (ret == PLAYBACK_CANCELED)
-//    m_bPause = true;
+  else if (ret == PLAYBACK_CANCELED)
+    m_bPause = true;
   m_bPlayingVideo = false;
   return false;
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -168,15 +168,15 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonSwitch(CGUIMessage &message)
   if (message.GetSenderId() == CONTROL_BTN_SWITCH)
   {
     Close();
-
+    PlayBackRet ret = PLAYBACK_CANCELED;
     if (!m_progItem->GetEPGInfoTag()->HasPVRChannel() ||
-        !g_application.PlayFile(CFileItem(*m_progItem->GetEPGInfoTag()->ChannelTag())))
+        (ret = g_application.PlayFile(CFileItem(*m_progItem->GetEPGInfoTag()->ChannelTag()))) == PLAYBACK_FAIL)
     {
       CStdString msg;
       msg.Format(g_localizeStrings.Get(19035).c_str(), g_localizeStrings.Get(19029).c_str()); // Channel could not be played. Check the log for details.
       CGUIDialogOK::ShowAndGetInput(19033, 0, msg, 0);
     }
-    else
+    else if (ret == PLAYBACK_OK)
     {
       bReturn = true;
     }

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -524,27 +524,25 @@ bool CGUIWindowPVRCommon::ActionPlayChannel(CFileItem *item)
 
 bool CGUIWindowPVRCommon::ActionPlayEpg(CFileItem *item)
 {
-  bool bReturn = false;
-
   CEpgInfoTag *epgTag = item->GetEPGInfoTag();
   if (!epgTag)
-    return bReturn;
+    return false;
 
   CPVRChannelPtr channel = epgTag->ChannelTag();
   if (!channel || channel->ChannelNumber() > 0 ||
       !g_PVRManager.CheckParentalLock(*channel))
-    return bReturn;
+    return false;
 
-  bReturn = g_application.PlayFile(CFileItem(*channel));
+  PlayBackRet ret = g_application.PlayFile(CFileItem(*channel));
 
-  if (!bReturn)
+  if (ret == PLAYBACK_FAIL)
   {
     CStdString msg;
     msg.Format(g_localizeStrings.Get(19035).c_str(), channel->ChannelName().c_str()); // CHANNELNAME could not be played. Check the log for details.
     CGUIDialogOK::ShowAndGetInput(19033, 0, msg, 0);
   }
 
-  return bReturn;
+  return ret == PLAYBACK_OK;
 }
 
 bool CGUIWindowPVRCommon::ActionDeleteChannel(CFileItem *item)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -427,15 +427,15 @@ bool CGUIWindowPVRGuide::PlayEpgItem(CFileItem *item)
     return false;
 
   CLog::Log(LOGDEBUG, "play channel '%s'", channel->ChannelName().c_str());
-  bool bReturn = g_application.PlayFile(CFileItem(*channel));
-  if (!bReturn)
+  PlayBackRet ret = g_application.PlayFile(CFileItem(*channel));
+  if (ret == PLAYBACK_FAIL)
   {
     CStdString msg;
     msg.Format(g_localizeStrings.Get(19035).c_str(), channel->ChannelName().c_str()); // CHANNELNAME could not be played. Check the log for details.
     CGUIDialogOK::ShowAndGetInput(19033, 0, msg, 0);
   }
 
-  return bReturn;
+  return ret == PLAYBACK_OK;
 }
 
 bool CGUIWindowPVRGuide::OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTON button)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1358,7 +1358,7 @@ bool CGUIMediaWindow::OnPlayMedia(int iItem)
   if (pItem->IsInternetStream() || pItem->IsPlayList())
     bResult = g_application.PlayMedia(*pItem, m_guiState->GetPlaylist());
   else
-    bResult = g_application.PlayFile(*pItem);
+    bResult = g_application.PlayFile(*pItem) == PLAYBACK_OK;
 
   if (pItem->m_lStartOffset == STARTOFFSET_RESUME)
     pItem->m_lStartOffset = 0;


### PR DESCRIPTION
this PR trace the starting playing item's play state callback state change, with lock protect.
with this, kill the race condition in original code in PlayFile after starting flag reset.
there is chance OnPlaybackStarted/OnPlaybackEnded be called twice (once by xbmc main thread in the place, once by player thread called just after the starting flag set to false). or other race condition between IsPlaying() check and OnPlaybackStarted/OnPlaybackEnded/OnPlaybackStopped callbacks.
since we had to delay the callback process during starting state, we need to record which callbacks were called during starting state, so I add code for tracing that, and also need to not bother by the previous playing item's stopped/ended callback.
finally after starting state finished, we do the callback happened during starting state, that's all this commit does.
I did this because in https://github.com/xbmc/xbmc/pull/2228 @elupus said there is race condition if OpenFile return true, I checked, there indeed is race condition, but not caused by PR 2228, it existed for years, PR 2228 did work for fixing the crash and not related to the race condition mentioned. So I finally figure a way in this PR to kill the race condition, how does this like?

thanks @MartijnKaijser , notify me that this PR may fix ticket http://trac.xbmc.org/ticket/13064, it does. in my test, paplayer callback OnPlaybackStarted() later than starting flag set false when switching playing items, it will cause current code in CApplication::PlayFile() call OnPlaybackStarted() because IsPlaying() return true, and the paplayer will also call OnPlaybackStarted() after a little awhile it starting ProcessStream. by this PR, the m_ePlayState will be STARTING for this condition, and no call OnPlaybackStarted() in xbmc thread then paplayer will do its work.

UPDATED: this PR also include commits fix crash and wrong behaviors when second PlayFile is called during first's busy loop conditions.
