### PR TITLE
PVRChannelsOSD: replace hardcoded left/right group switching with proper action handling

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRChannelsOSD.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelsOSD.xml
@@ -87,7 +87,7 @@
 				<posy>70</posy>
 				<width>410</width>
 				<height>520</height>
-				<onleft>60</onleft>
+				<onleft>PreviousChannelGroup</onleft>
 				<onright>60</onright>
 				<onup>11</onup>
 				<ondown>11</ondown>
@@ -334,7 +334,7 @@
 				<textureslidernib>ScrollBarNib.png</textureslidernib>
 				<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
 				<onleft>11</onleft>
-				<onright>11</onright>
+				<onright>NextChannelGroup</onright>
 				<ondown>61</ondown>
 				<onup>61</onup>
 				<showonepage>false</showonepage>

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -115,24 +115,6 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
       }
     }
     break;
-
-  case GUI_MSG_MOVE:
-    {
-      int iAction = message.GetParam1();
-
-      if (iAction == ACTION_MOVE_RIGHT || iAction == ACTION_MOVE_LEFT)
-      {
-        CPVRChannelGroupPtr group = GetPlayingGroup();
-        CPVRChannelGroupPtr nextGroup = iAction == ACTION_MOVE_RIGHT ? group->GetNextGroup() : group->GetPreviousGroup();
-        g_PVRManager.SetPlayingGroup(nextGroup);
-        SetLastSelectedItem(group->GroupID());
-
-        Update();
-
-        return true;
-      }
-    }
-    break;
   }
 
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -138,6 +138,25 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogPVRChannelsOSD::OnAction(const CAction &action)
+{
+  switch (action.GetID())
+  {
+  case ACTION_PREVIOUS_CHANNELGROUP:
+  case ACTION_NEXT_CHANNELGROUP:
+    {
+      CPVRChannelGroupPtr group = GetPlayingGroup();
+      CPVRChannelGroupPtr nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP ? group->GetNextGroup() : group->GetPreviousGroup();
+      g_PVRManager.SetPlayingGroup(nextGroup);
+      SetLastSelectedItem(group->GroupID());
+      Update();
+      return true;
+    }
+  }
+
+  return CGUIDialog::OnAction(action);
+}
+
 CPVRChannelGroupPtr CGUIDialogPVRChannelsOSD::GetPlayingGroup()
 {
   CPVRChannelPtr channel;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -35,6 +35,7 @@ namespace PVR
     CGUIDialogPVRChannelsOSD(void);
     virtual ~CGUIDialogPVRChannelsOSD(void);
     virtual bool OnMessage(CGUIMessage& message);
+    virtual bool OnAction(const CAction &action);
     virtual void OnWindowLoaded();
     virtual void OnWindowUnload();
     virtual void Notify(const Observable &obs, const ObservableMessage msg);


### PR DESCRIPTION
As @JezzX noticed earlier group switching is hardcoded in PVRChannelsOSD dialog. This remove it and replace it with action handling. Confluence (and other skins) would need to be updated to get group switching back by adding f.e. buttons with NextChannelGroup / PreviousChannelGroup action.
