### PR TITLE
Fix for AlarmClock(): Prevent freeze-up when time <=0 and loop = true

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -983,7 +983,9 @@ int CBuiltins::Execute(const CStdString& execString)
 
     if( g_alarmClock.IsRunning() )
       g_alarmClock.Stop(params[0],silent);
-
+    // no negative times not allowed, loop must have a positive time
+    if (seconds < 0 || (seconds == 0 && loop))
+      return false;
     g_alarmClock.Start(params[0], seconds, params[1], silent, loop);
   }
   else if (execute.Equals("notification"))


### PR DESCRIPTION
Small fix for a potential Freeze-up:
ATM xbmc freezes when we call AlarmClock() with time <= 0 and loop = true.
for skins this could happen when we allow the user to set the AlarmClock loop time with Skin.SetNumeric and then call
 "AlarmClock(name,Notification(test,test),$INFO[Skin.String(Time)],loop=true)"
 with "Time" <= 0. 
if that call is done in startup/main menu window then the user has no chance to change the skin / fix the invalid number.
This commit fixes that and prevents the alarmclock call for those invalid time values.
