### PR TITLE
addons: Add Announce function and register addons for announcements

### DIFF
--- a/xbmc/addons/DllAddon.h
+++ b/xbmc/addons/DllAddon.h
@@ -36,6 +36,7 @@ public:
   virtual unsigned int GetSettings(ADDON_StructSetting*** sSet)=0;
   virtual void FreeSettings()=0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
+  virtual void Announce(const char *flag, const char *sender, const char *message, const void *data) =0;
 };
 
 template <typename TheStruct, typename Props>
@@ -52,6 +53,7 @@ public:
   DEFINE_METHOD0(void, FreeSettings)
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (TheStruct* p1))
+  DEFINE_METHOD4(void, Announce, (const char *p1, const char *p2, const char *p3, const void *p4))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
@@ -62,6 +64,7 @@ public:
     RESOLVE_METHOD_RENAME(ADDON_SetSetting, SetSetting)
     RESOLVE_METHOD_RENAME(ADDON_GetSettings, GetSettings)
     RESOLVE_METHOD_RENAME(ADDON_FreeSettings, FreeSettings)
+    RESOLVE_METHOD_RENAME(ADDON_Announce, Announce)
   END_METHOD_RESOLVE()
 };
 

--- a/xbmc/addons/include/xbmc_addon_dll.h
+++ b/xbmc/addons/include/xbmc_addon_dll.h
@@ -46,6 +46,7 @@ extern "C" {
   unsigned int __declspec(dllexport) ADDON_GetSettings(ADDON_StructSetting ***sSet);
   ADDON_STATUS __declspec(dllexport) ADDON_SetSetting(const char *settingName, const void *settingValue);
   void         __declspec(dllexport) ADDON_FreeSettings();
+  void         __declspec(dllexport) ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data);
 
 #ifdef __cplusplus
 };

--- a/xbmc/screensavers/rsxs-0.9/src/euphoria/euphoria.cc
+++ b/xbmc/screensavers/rsxs-0.9/src/euphoria/euphoria.cc
@@ -460,6 +460,10 @@ void ADDON_FreeSettings()
 {
 }
 
+void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}
+
 void GetInfo(SCR_INFO *info)
 {
 }

--- a/xbmc/screensavers/rsxs-0.9/src/plasma/plasma.cc
+++ b/xbmc/screensavers/rsxs-0.9/src/plasma/plasma.cc
@@ -381,6 +381,10 @@ void ADDON_FreeSettings()
 {
 }
 
+void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}
+
 void GetInfo(SCR_INFO *info)
 {
 }

--- a/xbmc/screensavers/rsxs-0.9/src/solarwinds/solarwinds.cc
+++ b/xbmc/screensavers/rsxs-0.9/src/solarwinds/solarwinds.cc
@@ -315,6 +315,10 @@ void ADDON_FreeSettings()
 {
 }
 
+void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}
+
 void GetInfo(SCR_INFO *info)
 {
 }

--- a/xbmc/visualizations/DirectXSpectrum/directx_spectrum.cpp
+++ b/xbmc/visualizations/DirectXSpectrum/directx_spectrum.cpp
@@ -463,3 +463,10 @@ extern "C" ADDON_STATUS ADDON_SetSetting(const char *strSetting, const void* val
   return ADDON_STATUS_UNKNOWN;
 }
 
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+//-----------------------------------------------------------------------------
+
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}

--- a/xbmc/visualizations/Goom/Main.cpp
+++ b/xbmc/visualizations/Goom/Main.cpp
@@ -299,3 +299,11 @@ extern "C" ADDON_STATUS ADDON_SetSetting(const char *strSetting, const void* val
 {
   return ADDON_STATUS_OK;
 }
+
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+// !!! Add-on master function !!!
+//-----------------------------------------------------------------------------
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}

--- a/xbmc/visualizations/Milkdrop/MilkdropXBMC.cpp
+++ b/xbmc/visualizations/Milkdrop/MilkdropXBMC.cpp
@@ -342,6 +342,14 @@ extern "C" ADDON_STATUS ADDON_SetSetting(const char* id, const void* value)
   return ADDON_STATUS_OK;
 }
 
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+//-----------------------------------------------------------------------------
+
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}
+
 //-- GetSubModules ------------------------------------------------------------
 // Return any sub modules supported by this vis
 //-----------------------------------------------------------------------------

--- a/xbmc/visualizations/OpenGLSpectrum/opengl_spectrum.cpp
+++ b/xbmc/visualizations/OpenGLSpectrum/opengl_spectrum.cpp
@@ -599,3 +599,10 @@ extern "C" ADDON_STATUS ADDON_SetSetting(const char *strSetting, const void* val
   return ADDON_STATUS_UNKNOWN;
 }
 
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+// !!! Add-on master function !!!
+//-----------------------------------------------------------------------------
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}

--- a/xbmc/visualizations/Vortex/VortexXBMC/VortexXBMC.cpp
+++ b/xbmc/visualizations/Vortex/VortexXBMC/VortexXBMC.cpp
@@ -238,3 +238,10 @@ extern "C"   unsigned int GetSubModules(char ***presets)
 {
   return 0; // this vis supports 0 sub modules
 }
+
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+//-----------------------------------------------------------------------------
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}

--- a/xbmc/visualizations/WaveForm/Main.cpp
+++ b/xbmc/visualizations/WaveForm/Main.cpp
@@ -297,3 +297,10 @@ extern "C" ADDON_STATUS ADDON_SetSetting(const char *strSetting, const void* val
   return ADDON_STATUS_OK;
 }
 
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+// !!! Add-on master function !!!
+//-----------------------------------------------------------------------------
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}

--- a/xbmc/visualizations/WaveForm/Main_gles.cpp
+++ b/xbmc/visualizations/WaveForm/Main_gles.cpp
@@ -327,3 +327,11 @@ extern "C" ADDON_STATUS ADDON_SetSetting(const char *strSetting, const void* val
 //    return ADDON_STATUS_OK;
   return ADDON_STATUS_UNKNOWN;
 }
+
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+// !!! Add-on master function !!!
+//-----------------------------------------------------------------------------
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}

--- a/xbmc/visualizations/XBMCProjectM/Main.cpp
+++ b/xbmc/visualizations/XBMCProjectM/Main.cpp
@@ -449,3 +449,10 @@ extern "C" unsigned int GetSubModules(char ***names)
 {
   return 0; // this vis supports 0 sub modules
 }
+
+//-- Announce -----------------------------------------------------------------
+// Receive announcements from XBMC
+//-----------------------------------------------------------------------------
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}

--- a/xbmc/visualizations/fishBMC/fishbmc_addon.cpp
+++ b/xbmc/visualizations/fishBMC/fishbmc_addon.cpp
@@ -372,3 +372,7 @@ extern "C" ADDON_STATUS ADDON_SetSetting (const char *strSetting, const void* va
 
     return ADDON_STATUS_OK;
 }
+
+extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
+{
+}


### PR DESCRIPTION
This allows addons to receive announcements and react properly on
all kind of events and system state transitions.

For example pvr addons might want to close and reopen their backend
connections when the system goes to or resumes from standby.
