### PR TITLE
addons: Add WakeOnLan function

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -158,6 +158,10 @@ namespace ADDON
         dlsym(m_libXBMC_addon, "XBMC_queue_notification");
       if (XBMC_queue_notification == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
+      XBMC_wake_on_lan = (bool (*)(void* HANDLE, void *CB, const char *mac))
+        dlsym(m_libXBMC_addon, "XBMC_wake_on_lan");
+      if (XBMC_wake_on_lan == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
       XBMC_unknown_to_utf8 = (char* (*)(void* HANDLE, void* CB, const char* str))
         dlsym(m_libXBMC_addon, "XBMC_unknown_to_utf8");
       if (XBMC_unknown_to_utf8 == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
@@ -293,6 +297,16 @@ namespace ADDON
       vsprintf (buffer, format, args);
       va_end (args);
       return XBMC_queue_notification(m_Handle, m_Callbacks, type, buffer);
+    }
+
+    /*!
+     * @brief Send WakeOnLan magic packet.
+     * @param mac Network address of the host to wake.
+     * @return True if the magic packet was successfully sent, false otherwise.
+     */
+    bool WakeOnLan(const char* mac)
+    {
+      return XBMC_wake_on_lan(m_Handle, m_Callbacks, mac);
     }
 
     /*!
@@ -541,6 +555,7 @@ namespace ADDON
     void (*XBMC_log)(void *HANDLE, void* CB, const addon_log_t loglevel, const char *msg);
     bool (*XBMC_get_setting)(void *HANDLE, void* CB, const char* settingName, void *settingValue);
     void (*XBMC_queue_notification)(void *HANDLE, void* CB, const queue_msg_t type, const char *msg);
+    bool (*XBMC_wake_on_lan)(void *HANDLE, void* CB, const char* mac);
     char* (*XBMC_unknown_to_utf8)(void *HANDLE, void* CB, const char* str);
     char* (*XBMC_get_localized_string)(void *HANDLE, void* CB, int dwCode);
     char* (*XBMC_get_dvd_menu_language)(void *HANDLE, void* CB);

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -84,6 +84,14 @@ DLLEXPORT void XBMC_queue_notification(void *hdl, void* cb, const queue_msg_t ty
   ((CB_AddOnLib*)cb)->QueueNotification(((AddonCB*)hdl)->addonData, type, msg);
 }
 
+DLLEXPORT bool XBMC_wake_on_lan(void* hdl, void* cb, char* mac)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->WakeOnLan(mac);
+}
+
 DLLEXPORT char* XBMC_unknown_to_utf8(void *hdl, void* cb, const char* str)
 {
   if (cb == NULL)

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -26,6 +26,7 @@
 
 typedef void (*AddOnLogCallback)(void *addonData, const ADDON::addon_log_t loglevel, const char *msg);
 typedef void (*AddOnQueueNotification)(void *addonData, const ADDON::queue_msg_t type, const char *msg);
+typedef bool (*AddOnWakeOnLan)(const char* mac);
 typedef bool (*AddOnGetSetting)(void *addonData, const char *settingName, void *settingValue);
 typedef char* (*AddOnUnknownToUTF8)(const char *sourceDest);
 typedef char* (*AddOnGetLocalizedString)(const void* addonData, long dwCode);
@@ -56,6 +57,7 @@ typedef struct CB_AddOn
 {
   AddOnLogCallback        Log;
   AddOnQueueNotification  QueueNotification;
+  AddOnWakeOnLan          WakeOnLan;
   AddOnGetSetting         GetSetting;
   AddOnUnknownToUTF8      UnknownToUTF8;
   AddOnGetLocalizedString GetLocalizedString;

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -28,6 +28,7 @@
 #include "filesystem/Directory.h"
 #include "utils/URIUtils.h"
 #include "FileItem.h"
+#include "network/Network.h"
 
 using namespace XFILE;
 
@@ -42,6 +43,7 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   /* write XBMC addon-on specific add-on function addresses to the callback table */
   m_callbacks->Log                = AddOnLog;
   m_callbacks->QueueNotification  = QueueNotification;
+  m_callbacks->WakeOnLan          = WakeOnLan;
   m_callbacks->GetSetting         = GetAddonSetting;
   m_callbacks->UnknownToUTF8      = UnknownToUTF8;
   m_callbacks->GetLocalizedString = GetLocalizedString;
@@ -155,6 +157,11 @@ void CAddonCallbacksAddon::QueueNotification(void *addonData, const queue_msg_t 
     CLog::Log(LOGERROR, "CAddonCallbacksAddon - %s - exception '%s' caught in call in add-on '%s'. please contact the developer of this addon: %s",
         __FUNCTION__, e.what(), addonHelper->m_addon->Name().c_str(), addonHelper->m_addon->Author().c_str());
   }
+}
+
+bool CAddonCallbacksAddon::WakeOnLan(const char *mac)
+{
+  return g_application.getNetwork().WakeOnLan(mac);
 }
 
 bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSettingName, void *settingValue)

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -38,6 +38,7 @@ public:
   static void AddOnLog(void *addonData, const addon_log_t addonLogLevel, const char *strMessage);
   static bool GetAddonSetting(void *addonData, const char *strSettingName, void *settingValue);
   static void QueueNotification(void *addonData, const queue_msg_t type, const char *strMessage);
+  static bool WakeOnLan(const char *mac);
   static char* UnknownToUTF8(const char *strSource);
   static char* GetLocalizedString(const void* addonData, long dwCode);
   static char* GetDVDMenuLanguage(const void* addonData);


### PR DESCRIPTION
WakeOnLan allows addons to send a wol magic packet.

This can be used for example in pvr addons to wake up a pvr backend.
