### PR TITLE
Refactor CGUIWindowManager::DispatchThreadMessages() to be a solid thread message dispatch and process method.

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -782,25 +782,45 @@ void CGUIWindowManager::SendThreadMessage(CGUIMessage& message, int window /*= 0
 
 void CGUIWindowManager::DispatchThreadMessages()
 {
+  // This method only be called in the xbmc main thread.
+
+  // XXX: for more info of this method
+  //      check the pr here: https://github.com/xbmc/xbmc/pull/2253
+
+  // As a thread message queue service, it should follow these rules:
+  // 1. [Must] Thread safe, message can be pushed into queue in arbitrary thread context.
+  // 2. Messages [must] be processed in dispatch message thread context with the same
+  //    order as they be pushed into the queue.
+  // 3. Dispatch function [must] support call itself during message process procedure,
+  //    and do not break other rules listed here. to make it clear: in the
+  //    SendMessage(), it could start another xbmc main thread loop, calling
+  //    DispatchThreadMessages() in it's internal loop, this must be supported.
+  // 4. During DispatchThreadMessages() processing, any new pushed message [should] not
+  //    be processed by the current loop in DispatchThreadMessages(), prevent dead loop.
+  // 5. If possible, queued messages can be removed by certain filter condition
+  //    and not break above.
+
   CSingleLock lock(m_critSection);
-  vector< pair<CGUIMessage*,int> > messages(m_vecThreadMessages);
-  m_vecThreadMessages.erase(m_vecThreadMessages.begin(), m_vecThreadMessages.end());
-  lock.Leave();
 
-  while ( messages.size() > 0 )
+  for(int msgCount = m_vecThreadMessages.size(); m_vecThreadMessages.size() > 0 && msgCount > 0; --msgCount)
   {
-    vector< pair<CGUIMessage*,int> >::iterator it = messages.begin();
-    CGUIMessage* pMsg = it->first;
-    int window = it->second;
-    // first remove the message from the queue,
-    // else the message could be processed more then once
-    it = messages.erase(it);
+    // pop up one message per time to make messages be processed by order.
+    // this will ensure rule No.2 & No.3
+    CGUIMessage *pMsg = m_vecThreadMessages.front().first;
+    int window = m_vecThreadMessages.front().second;
+    m_vecThreadMessages.pop_front();
 
+    lock.Leave();
+
+    // XXX: during SendMessage(), there could be a deeper 'xbmc main loop' inited by e.g. doModal
+    //      which may loop there and callback to DispatchThreadMessages() multiple times.
     if (window)
       SendMessage( *pMsg, window );
     else
       SendMessage( *pMsg );
     delete pMsg;
+
+    lock.Enter();
   }
 }
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -824,6 +824,32 @@ void CGUIWindowManager::DispatchThreadMessages()
   }
 }
 
+int CGUIWindowManager::RemoveThreadMessageByMessageIds(int *pMessageIDList)
+{
+  CSingleLock lock(m_critSection);
+  int removedMsgCount = 0;
+  for (std::list < std::pair<CGUIMessage*,int> >::iterator it = m_vecThreadMessages.begin();
+       it != m_vecThreadMessages.end();)
+  {
+    CGUIMessage *pMsg = it->first;
+    int *pMsgID;
+    for(pMsgID = pMessageIDList; *pMsgID != 0; ++pMsgID)
+      if (pMsg->GetMessage() == *pMsgID)
+        break;
+    if (*pMsgID)
+    {
+      it = m_vecThreadMessages.erase(it);
+      delete pMsg;
+      ++removedMsgCount;
+    }
+    else
+    {
+      ++it;
+    }
+  }
+  return removedMsgCount;
+}
+
 void CGUIWindowManager::AddMsgTarget( IMsgTargetCallback* pMsgTarget )
 {
   m_vecMsgTargets.push_back( pMsgTarget );

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -121,6 +121,9 @@ public:
 
   void SendThreadMessage(CGUIMessage& message, int window = 0);
   void DispatchThreadMessages();
+  // method to removed queued messages with message id in the requested message id list.
+  // pMessageIDList: point to first integer of a 0 ends integer array.
+  int RemoveThreadMessageByMessageIds(int *pMessageIDList);
   void AddMsgTarget( IMsgTargetCallback* pMsgTarget );
   int GetActiveWindow() const;
   int GetFocusedWindow() const;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -33,6 +33,7 @@
 #include "IMsgTargetCallback.h"
 #include "DirtyRegionTracker.h"
 #include "utils/GlobalsHandling.h"
+#include <list>
 
 class CGUIDialog;
 
@@ -164,7 +165,7 @@ private:
   std::stack<int> m_windowHistory;
 
   IWindowManagerCallback* m_pCallback;
-  std::vector < std::pair<CGUIMessage*,int> > m_vecThreadMessages;
+  std::list < std::pair<CGUIMessage*,int> > m_vecThreadMessages;
   CCriticalSection m_critSection;
   std::vector <IMsgTargetCallback*> m_vecMsgTargets;
 


### PR DESCRIPTION
in CGUIWindowManager::DispatchThreadMessages(), copy to temp vector and loop method also be used, which will delay left messages in temp vector if SendMessage cause a modal dialog or something init another deeper message loop, then the left messages in temp vector will not be processed until the deeper message loop exit and SendMessage returned, then the messages will be processed delayed and not in order, result is unexpected.

I made a similar fix for it like https://github.com/xbmc/xbmc/pull/2167 but it seems has some limitation, so I refactor it under these rules:

As a thread message queue service, it should fulfill:
- Must: Thread safe, message can be pushed into queue in arbitrary thread context.
- Must: Messages be processed in dispatch message thread context with the same order as they be pushed into the queue.
- Must: Dispatch function support call itself during message process procedure, and do not break other rules listed here.
- Should: Message will be processed in next dispatch message call after it be pushed into the queue, then no deadlock.
- If possible: Queued messages can be removed by certain filter condition.

if we both agree above, then how to implement it should has free space as long as it's bug free, although it could be a little complex and not easy to understand.
