### PR TITLE
Added property to show tvshow/season progress in %

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -337,6 +337,10 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
         pItem->SetProperty("numepisodes", watched + unwatched); // will be changed later to reflect watchmode setting
         pItem->SetProperty("watchedepisodes", watched);
         pItem->SetProperty("unwatchedepisodes", unwatched);
+        if (watched + unwatched > 0)
+          pItem->SetProperty("percentwatched", (int)((100.0f * watched / (watched + unwatched)) + 0.5f));
+        else
+          pItem->SetProperty("percentwatched", 0);
         if (items.Size() && items[0]->GetVideoInfoTag())
         {
           *pItem->GetVideoInfoTag() = *items[0]->GetVideoInfoTag();

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -801,6 +801,10 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry)
       pItem->SetProperty("numepisodes", episodes);
       pItem->SetProperty("watchedepisodes", played);
       pItem->SetProperty("unwatchedepisodes", episodes - played);
+      if (episodes > 0)
+        pItem->SetProperty("percentwatched", (int)((100.0f * played / episodes) + 0.5f));
+      else
+        pItem->SetProperty("percentwatched", 0);
       watched = (episodes && played == episodes);
     }
     else if (type == "episode" || type == "movie")

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5654,6 +5654,10 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->SetProperty("numepisodes", it->second.numEpisodes); // will be changed later to reflect watchmode setting
         pItem->SetProperty("watchedepisodes", it->second.numWatched);
         pItem->SetProperty("unwatchedepisodes", it->second.numEpisodes - it->second.numWatched);
+        if (it->second.numEpisodes > 0)
+          pItem->SetProperty("percentwatched", (int)((100.0f * it->second.numWatched / it->second.numEpisodes) + 0.5f));
+        else
+          pItem->SetProperty("percentwatched", 0);
         if (iSeason == 0) pItem->SetProperty("isspecial", true);
         pItem->GetVideoInfoTag()->m_playCount = (it->second.numEpisodes == it->second.numWatched) ? 1 : 0;
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
@@ -5697,6 +5701,10 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->SetProperty("numepisodes", totalEpisodes); // will be changed later to reflect watchmode setting
         pItem->SetProperty("watchedepisodes", watchedEpisodes);
         pItem->SetProperty("unwatchedepisodes", totalEpisodes - watchedEpisodes);
+        if (totalEpisodes > 0)
+          pItem->SetProperty("percentwatched", (int)((100.0f * watchedEpisodes / totalEpisodes) + 0.5f));
+        else
+          pItem->SetProperty("percentwatched", 0);
         if (iSeason == 0) pItem->SetProperty("isspecial", true);
         pItem->GetVideoInfoTag()->m_playCount = (totalEpisodes == watchedEpisodes) ? 1 : 0;
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
@@ -5980,11 +5988,14 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filte
         CStdString path; path.Format("%ld/", record->at(0).get_asInt());
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
-
         pItem->m_dateTime = movie.m_premiered;
         pItem->GetVideoInfoTag()->m_iYear = pItem->m_dateTime.GetYear();
         pItem->SetProperty("totalseasons", record->at(VIDEODB_DETAILS_TVSHOW_NUM_SEASONS).get_asInt());
         pItem->SetProperty("totalepisodes", movie.m_iEpisode);
+        if (movie.m_iEpisode > 0)
+          pItem->SetProperty("percentwatched", (int)((100.0f * movie.m_playCount / movie.m_iEpisode) + 0.5f));
+        else
+          pItem->SetProperty("percentwatched", 0);
         pItem->SetProperty("numepisodes", movie.m_iEpisode); // will be changed later to reflect watchmode setting
         pItem->SetProperty("watchedepisodes", movie.m_playCount);
         pItem->SetProperty("unwatchedepisodes", movie.m_iEpisode - movie.m_playCount);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -294,6 +294,10 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       m_movieItem->SetProperty("numepisodes", m_movieItem->GetVideoInfoTag()->m_iEpisode); // info view has no concept of current watched/unwatched filter as we could come here from files view, but set for consistency
       m_movieItem->SetProperty("watchedepisodes", m_movieItem->GetVideoInfoTag()->m_playCount);
       m_movieItem->SetProperty("unwatchedepisodes", m_movieItem->GetVideoInfoTag()->m_iEpisode - m_movieItem->GetVideoInfoTag()->m_playCount);
+      if ( m_movieItem->GetVideoInfoTag()->m_iEpisode > 0)
+        m_movieItem->SetProperty("percentwatched", (int)((100.0f * m_movieItem->GetVideoInfoTag()->m_playCount / m_movieItem->GetVideoInfoTag()->m_iEpisode) + 0.5f));
+      else
+        m_movieItem->SetProperty("percentwatched", 0);
       m_movieItem->GetVideoInfoTag()->m_playCount = (m_movieItem->GetVideoInfoTag()->m_iEpisode == m_movieItem->GetVideoInfoTag()->m_playCount) ? 1 : 0;
     }
     else if (type == VIDEODB_CONTENT_EPISODES)


### PR DESCRIPTION
Adds a new property "percentplayed" for tvshows and seasons which returns the amount of played episodes in percent.
also useful to display a progress image, here´s an example of what we skinners can do with it:
http://i.imgur.com/cx43M6L.jpg (tvshow level)
http://i.imgur.com/f8J7V5X.jpg (season level)

if you know a more elegant way to cast the data types let me know :)
same goes for the label, not sure if "percentplayed" is the best choice.
