### PR TITLE
Fix sometimes select plugin setting from context menu not works problem.

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1609,7 +1609,11 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
   case CONTEXT_BUTTON_PLUGIN_SETTINGS:
     {
-      CURL plugin(m_vecItems->Get(itemNumber)->GetPath());
+      CFileItemPtr item = m_vecItems->Get(itemNumber);
+      // CONTEXT_BUTTON_PLUGIN_SETTINGS can be called for plugin item
+      // or script item; or for the plugin directory current listing.
+      bool isPluginOrScriptItem = (item && (item->IsPlugin() || item->IsScript()));
+      CURL plugin(isPluginOrScriptItem ? item->GetPath() : m_vecItems->GetPath());
       ADDON::AddonPtr addon;
       if (CAddonMgr::Get().GetAddon(plugin.GetHostName(), addon))
         if (CGUIDialogAddonSettings::ShowAndGetInput(addon))


### PR DESCRIPTION
currently, when we are in a plugin source dir, if selected item's path is not a plugin/script path, e.g. raw final http url, select 'Plugin Settings' from the item's context menu items will now show the plugin's setting dialog.
that's because the current code only use the selected item's path's hostname to get plugin/addon, it will fail in condition I mentioned.
I checked codes to show the context menu, there's condition like this:

```
    if (item->IsPlugin() || item->IsScript() || m_vecItems->IsPlugin())
      buttons.Add(CONTEXT_BUTTON_PLUGIN_SETTINGS, 1045);
```

obviously we will lost if the item is an http url item in a plugin dir in current code, so here's the fix PR.
