### PR TITLE
Fix ftp utf8 problem by add an 'utf8' option for ftp url.

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -655,8 +655,9 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     CStdString partial, filename(url2.GetFileName());
     CStdStringArray array;
 
-    /* our current client doesn't support utf8 */
-    g_charsetConverter.utf8ToStringCharset(filename);
+    // if server sent us the filename in non-utf8, we need send back with same encoding.
+    if (url2.GetProtocolOption("utf8") == "0")
+      g_charsetConverter.utf8ToStringCharset(filename);
 
     /* TODO: create a tokenizer that doesn't skip empty's */
     CUtil::Tokenize(filename, array, "/");


### PR DESCRIPTION
it's an old problem of xbmc ftp module: http://forum.xbmc.org/showthread.php?tid=121478

but it indeed is a bug of xbmc, since we read file list from ftp server and we should send the filename back to ftp server in same encoding the server send to us.

here's an easy fix for it, since the utf-8 is the most likely used and supported encoding of current world running ftp servers, we should support utf-8 encoding in a safe way.

so I added an 'utf8' option for ftp url, when adding ftp source, user can input it as part of the url or path, e.g. ftp://user:pwd@serveraddr:port/path/?utf8=1

UPDATED: now utf8 is the default encoding we work with ftp server, but we always try the gui language to decode filepath/name if it can not be decoded as utf8, if it can decoded by gui charset, we add a 'utf8=0' protocol option like:
ftp://user:pwd@serveraddr:port/path/|utf8=0 or ftp://user:pwd@serveraddr:port/path/file|utf8=0
and all subitems of the dir item with protocol option utf8=0 also inherit the option.

if there's special char in the initial top directory of the ftp source, and the server do not use ftp8 for transfer, then user can add the |utf8=0 protocol options as above when editing the source address to make xbmc talk with the ftp server with the xbmc gui charset.
