### PR TITLE
remove incorrect 'add source' entries

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -848,7 +848,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
       showLabel = 997;
     else if (iWindow == WINDOW_MUSIC_FILES)
       showLabel = 998;
-    else // WINDOW_FILES
+    else if (iWindow == WINDOW_FILES || iWindow == WINDOW_PROGRAMS)
       showLabel = 1026;
   }
   if (strDirectory.Equals("sources://video/"))


### PR DESCRIPTION
this fix removes the 'add source' entries at the root of the video- and musiclibrary.
those were introduced by https://github.com/xbmc/xbmc/pull/2217.
