### PR TITLE
[win32] bump libmicrohttpd to 0.9.17

### DIFF
--- a/project/BuildDependencies/scripts/libmicrohttpd_d.txt
+++ b/project/BuildDependencies/scripts/libmicrohttpd_d.txt
@@ -1,2 +1,2 @@
 ; filename                        source of the file
-libmicrohttpd-0.4.5-win32.7z                    http://mirrors.xbmc.org/build-deps/win32/
+libmicrohttpd-0.9.17-win32.7z     http://mirrors.xbmc.org/build-deps/win32/

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -193,7 +193,7 @@
       <IgnoreSpecificDefaultLibraries>libc;msvcrt;libcmt;msvcrtd;msvcprtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
-      <DelayLoadDLLs>dnssd.dll;dwmapi.dll;libmicrohttpd-5.dll;ssh.dll;sqlite3.dll;libsamplerate-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>dnssd.dll;dwmapi.dll;libmicrohttpd-10.dll;ssh.dll;sqlite3.dll;libsamplerate-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)XBMC.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>

--- a/xbmc/DllPaths_win32.h
+++ b/xbmc/DllPaths_win32.h
@@ -29,7 +29,7 @@
 #define DLL_PATH_LIBCMYTH      "special://xbmcbin/system/libcmyth.dll"
 #define DLL_PATH_LIBHDHOMERUN  "special://xbmcbin/system/hdhomerun.dll"
 #define DLL_PATH_LIBCURL       "special://xbmcbin/system/libcurl.dll"
-#define DLL_PATH_LIBMICROHTTP  "special://xbmcbin/system/webserver/libmicrohttpd-5.dll"
+#define DLL_PATH_LIBMICROHTTP  "special://xbmcbin/system/webserver/libmicrohttpd-10.dll"
 #define DLL_PATH_LIBNFS        "special://xbmcbin/system/libnfs.dll"
 #define DLL_PATH_LIBPLIST      "special://xbmcbin/system/airplay/libplist.dll"
 #define DLL_PATH_LIBSHAIRPLAY  "special://xbmcbin/system/airplay/libshairplay-1.dll"

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -21,14 +21,8 @@
 
 #include "system.h"
 #ifdef HAS_WEB_SERVER
-#include <sys/types.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-#include <stdint.h>
 #include <vector>
+
 #include "interfaces/json-rpc/ITransportLayer.h"
 #include "threads/CriticalSection.h"
 #include "httprequesthandler/IHTTPRequestHandler.h"
@@ -115,4 +109,4 @@ private:
     struct MHD_PostProcessor *postprocessor;
   } ConnectionHandler;
 };
-#endif
+#endif // HAS_WEB_SERVER

--- a/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "HTTPImageHandler.h"
+
+#ifdef HAS_WEB_SERVER
 #include "network/WebServer.h"
 #include "URL.h"
 #include "filesystem/ImageFile.h"
@@ -56,3 +58,4 @@ int CHTTPImageHandler::HandleHTTPRequest(const HTTPRequest &request)
 
   return MHD_YES;
 }
+#endif // HAS_WEB_SERVER

--- a/xbmc/network/httprequesthandler/HTTPImageHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPImageHandler.h
@@ -21,6 +21,7 @@
 
 #include "IHTTPRequestHandler.h"
 
+#ifdef HAS_WEB_SERVER
 #include "utils/StdString.h"
 
 class CHTTPImageHandler : public IHTTPRequestHandler
@@ -39,3 +40,4 @@ public:
 private:
   CStdString m_path;
 };
+#endif // HAS_WEB_SERVER

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "HTTPJsonRpcHandler.h"
+
+#if defined(HAS_WEB_SERVER) && defined(HAS_JSONRPC)
 #include "interfaces/json-rpc/JSONRPC.h"
 #include "interfaces/json-rpc/JSONServiceDescription.h"
 #include "interfaces/json-rpc/JSONUtils.h"
@@ -119,3 +121,4 @@ bool CHTTPJsonRpcHandler::CHTTPClient::SetAnnouncementFlags(int flags)
 {
   return false;
 }
+#endif // defined(HAS_WEB_SERVER) && defined(HAS_JSONRPC)

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -20,6 +20,8 @@
  */
 
 #include "IHTTPRequestHandler.h"
+
+#if defined(HAS_WEB_SERVER) && defined(HAS_JSONRPC)
 #include "interfaces/json-rpc/IClient.h"
 
 class CHTTPJsonRpcHandler : public IHTTPRequestHandler
@@ -55,3 +57,4 @@ private:
     virtual bool SetAnnouncementFlags(int flags);
   };
 };
+#endif // defined(HAS_WEB_SERVER) && defined(HAS_JSONRPC)

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "HTTPVfsHandler.h"
+
+#ifdef HAS_WEB_SERVER
 #include "MediaSource.h"
 #include "URL.h"
 #include "filesystem/File.h"
@@ -107,3 +109,4 @@ int CHTTPVfsHandler::HandleHTTPRequest(const HTTPRequest &request)
 
   return MHD_YES;
 }
+#endif // HAS_WEB_SERVER

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.h
@@ -21,6 +21,7 @@
 
 #include "IHTTPRequestHandler.h"
 
+#ifdef HAS_WEB_SERVER
 #include "utils/StdString.h"
 
 class CHTTPVfsHandler : public IHTTPRequestHandler
@@ -39,3 +40,4 @@ public:
 private:
   CStdString m_path;
 };
+#endif // HAS_WEB_SERVER

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "HTTPWebinterfaceAddonsHandler.h"
+
+#if defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)
 #include "network/WebServer.h"
 #include "addons/AddonManager.h"
 
@@ -48,5 +50,4 @@ int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(const HTTPRequest &request
 
   return MHD_YES;
 }
-
-
+#endif // defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -21,6 +21,7 @@
 
 #include "IHTTPRequestHandler.h"
 
+#if defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)
 class CHTTPWebinterfaceAddonsHandler : public IHTTPRequestHandler
 {
 public:
@@ -38,3 +39,4 @@ public:
 private:
   std::string m_response;
 };
+#endif // defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "HTTPWebinterfaceHandler.h"
+
+#if defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)
 #include "network/WebServer.h"
 #include "addons/AddonManager.h"
 #include "utils/URIUtils.h"
@@ -130,3 +132,4 @@ int CHTTPWebinterfaceHandler::ResolveUrl(const std::string &url, std::string &pa
 
   return MHD_HTTP_OK;
 }
+#endif // defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
@@ -20,6 +20,8 @@
  */
 
 #include "IHTTPRequestHandler.h"
+
+#if defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)
 #include "addons/IAddon.h"
 
 class CHTTPWebinterfaceHandler : public IHTTPRequestHandler
@@ -40,3 +42,4 @@ public:
 private:
   std::string m_url;
 };
+#endif // defined(HAS_WEB_SERVER) && defined(HAS_WEB_INTERFACE)

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
@@ -20,6 +20,7 @@
 
 #include "IHTTPRequestHandler.h"
 
+#ifdef HAS_WEB_SERVER
 void IHTTPRequestHandler::AddPostField(const std::string &key, const std::string &value)
 {
   if (key.empty())
@@ -43,3 +44,4 @@ bool IHTTPRequestHandler::AddPostData(const char *data, unsigned int size)
   
   return true;
 }
+#endif // HAS_WEB_SERVER

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -24,13 +24,16 @@
 #include <string>
 #include <map>
 
-#include <sys/types.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
+#include <unistd.h>
+#include <stdarg.h>
 #include <stdint.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#ifndef MHD_PLATFORM_H
+#define MHD_PLATFORM_H
+#endif
 #include <microhttpd.h>
 
 class CWebServer;

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include "system.h"
+#ifdef HAS_WEB_SERVER
 #include <string>
 #include <map>
 
@@ -104,3 +106,4 @@ protected:
 
   std::map<std::string, std::string> m_postFields;
 };
+#endif // HAS_WEB_SERVER

--- a/xbmc/win32/Win32DelayedDllLoad.cpp
+++ b/xbmc/win32/Win32DelayedDllLoad.cpp
@@ -29,7 +29,7 @@ FARPROC WINAPI delayHookNotifyFunc (unsigned dliNotify, PDelayLoadInfo pdli)
   switch (dliNotify)
   {
     case dliNotePreLoadLibrary:
-      if (stricmp(pdli->szDll, "libmicrohttpd-5.dll") == 0)
+      if (stricmp(pdli->szDll, "libmicrohttpd-10.dll") == 0)
       {
         CStdString strDll = CSpecialProtocol::TranslatePath(DLL_PATH_LIBMICROHTTP);
         HMODULE hMod = LoadLibraryEx(strDll.c_str(), 0, LOAD_WITH_ALTERED_SEARCH_PATH);


### PR DESCRIPTION
After libmicrohttpd has been bumped from 0.4.6 to 0.9.x for darwin (not sure about linux?) I've taken a look into updating it for win32 as well. I went for the 0.9.17 release because it's the newest release with pre-built win32 binaries.

The first commit contains some general cleanup concerning the webserver. The second commit cleans up the includes used by microhttpd.h. The third commit changes the loaded libmicrohttpd DLL (the dependency file hasn't been uploaded to our mirrors yet).

I didn't do any extensive testing except starting and stopping the webserver a few times, playing around with the webinterface and making some json-rpc requests over HTTP but I didn't notice anything out of the ordinary.

PS: This bump increases the size of the win32 install exe by approximately 2 MB because of the included HTTPS/TLS support.
