### PR TITLE
Streamdetails fixes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4421,7 +4421,8 @@ void CApplication::UpdateFileState()
         m_progressTrackingPlayCountUpdate = true;
       }
 
-      if (m_progressTrackingItem->IsVideo())
+      // Check whether we're *really* playing video else we may race when getting eg. stream details
+      if (IsPlayingVideo())
       {
         // Special case for DVDs: Only extract streamdetails if title length > 15m. Should yield more correct info
         if (!(m_progressTrackingItem->IsDVDImage() || m_progressTrackingItem->IsDVDFile()) || m_pPlayer->GetTotalTime() > 15*60*1000)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4125,24 +4125,6 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
       if( options.fullscreen && g_renderManager.IsStarted()
        && g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO )
        SwitchToFullScreen();
-
-      if (!item.IsDVDImage() && !item.IsDVDFile())
-      {
-        CVideoInfoTag *details = m_itemCurrentFile->GetVideoInfoTag();
-        // Save information about the stream if we currently have no data
-        if (!details->HasStreamDetails() ||
-             details->m_streamDetails.GetVideoDuration() <= 0)
-        {
-          if (m_pPlayer->GetStreamDetails(details->m_streamDetails) && details->HasStreamDetails())
-          {
-            CVideoDatabase dbs;
-            dbs.Open();
-            dbs.SetStreamDetailsForFileId(details->m_streamDetails, details->m_iFileId);
-            dbs.Close();
-            CUtil::DeleteVideoDatabaseDirectoryCache();
-          }
-        }
-      }
     }
 #endif
     else
@@ -4441,11 +4423,15 @@ void CApplication::UpdateFileState()
 
       if (m_progressTrackingItem->IsVideo())
       {
-        if ((m_progressTrackingItem->IsDVDImage() || m_progressTrackingItem->IsDVDFile()) && m_pPlayer->GetTotalTime() > 15*60*1000)
+        // Special case for DVDs: Only extract streamdetails if title length > 15m. Should yield more correct info
+        if (!(m_progressTrackingItem->IsDVDImage() || m_progressTrackingItem->IsDVDFile()) || m_pPlayer->GetTotalTime() > 15*60*1000)
         {
-          m_progressTrackingItem->GetVideoInfoTag()->m_streamDetails.Reset();
-          m_pPlayer->GetStreamDetails(m_progressTrackingItem->GetVideoInfoTag()->m_streamDetails);
+          CStreamDetails details;
+          // Update with stream details from player, if any
+          if (m_pPlayer->GetStreamDetails(details))
+            m_progressTrackingItem->GetVideoInfoTag()->m_streamDetails = details;
         }
+
         // Update bookmark for save
         m_progressTrackingVideoResumeBookmark.player = CPlayerCoreFactory::GetPlayerName(m_eCurrentPlayer);
         m_progressTrackingVideoResumeBookmark.playerState = m_pPlayer->GetPlayerState();

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -96,14 +96,19 @@ bool CSaveFileStateJob::DoWork()
           videodatabase.SetVideoSettings(progressTrackingFile, g_settings.m_currentVideoSettings);
         }
 
-        if ((m_item.IsDVDImage() ||
-             m_item.IsDVDFile()    ) &&
-             m_item.HasVideoInfoTag() &&
-             m_item.GetVideoInfoTag()->HasStreamDetails())
+        if (m_item.HasVideoInfoTag() && m_item.GetVideoInfoTag()->HasStreamDetails())
         {
-          videodatabase.SetStreamDetailsForFile(m_item.GetVideoInfoTag()->m_streamDetails,progressTrackingFile);
-          updateListing = true;
+          CFileItem dbItem(m_item);
+          videodatabase.GetStreamDetails(dbItem); // Fetch stream details from the db (if any)
+
+          // Check whether the item's db streamdetails need updating
+          if (!dbItem.GetVideoInfoTag()->HasStreamDetails() || dbItem.GetVideoInfoTag()->m_streamDetails != m_item.GetVideoInfoTag()->m_streamDetails)
+          {
+            videodatabase.SetStreamDetailsForFile(m_item.GetVideoInfoTag()->m_streamDetails, progressTrackingFile);
+            updateListing = true;
+          }
         }
+
         // in order to properly update the the list, we need to update the stack item which is held in g_application.m_stackFileItemToUpdate
         if (m_item.HasProperty("stackFileItemToUpdate"))
         {

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -23,6 +23,8 @@
 #include "StreamUtils.h"
 #include "Variant.h"
 
+const float VIDEOASPECT_EPSILON = 0.025f;
+
 void CStreamDetail::Archive(CArchive &ar)
 {
   // there's nothing to do here, the type is stored externally and parent isn't stored
@@ -184,6 +186,49 @@ CStreamDetails& CStreamDetails::operator=(const CStreamDetails &that)
   }  /* if this != that */
 
   return *this;
+}
+
+bool CStreamDetails::operator ==(const CStreamDetails &right) const
+{
+  if (this == &right) return true;
+
+  if (GetVideoStreamCount()    != right.GetVideoStreamCount() ||
+      GetAudioStreamCount()    != right.GetAudioStreamCount() ||
+      GetSubtitleStreamCount() != right.GetSubtitleStreamCount())
+    return false;
+
+  for (int iStream=1; iStream<=GetVideoStreamCount(); iStream++)
+  {
+    if (GetVideoCodec(iStream)    != right.GetVideoCodec(iStream)    ||
+        GetVideoWidth(iStream)    != right.GetVideoWidth(iStream)    ||
+        GetVideoHeight(iStream)   != right.GetVideoHeight(iStream)   ||
+        GetVideoDuration(iStream) != right.GetVideoDuration(iStream) ||
+        fabs(GetVideoAspect(iStream) - right.GetVideoAspect(iStream)) > VIDEOASPECT_EPSILON)
+      return false;
+  }
+
+  for (int iStream=1; iStream<=GetAudioStreamCount(); iStream++)
+  {
+    if (GetAudioCodec(iStream)    != right.GetAudioCodec(iStream)    ||
+        GetAudioLanguage(iStream) != right.GetAudioLanguage(iStream) ||
+        GetAudioChannels(iStream) != right.GetAudioChannels(iStream) )
+      return false;
+  }
+
+  for (int iStream=1; iStream<=GetSubtitleStreamCount(); iStream++)
+  {
+    if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) )
+      return false;
+  }
+
+  return true;
+}
+
+bool CStreamDetails::operator !=(const CStreamDetails &right) const
+{
+  if (this == &right) return false;
+
+  return !(*this == right);
 }
 
 CStreamDetail *CStreamDetails::NewStream(CStreamDetail::StreamType type)
@@ -465,8 +510,6 @@ void CStreamDetails::DetermineBestStreams(void)
       *champion = *iter;
   }  /* for each */
 }
-
-const float VIDEOASPECT_EPSILON = 0.025f;
 
 CStdString CStreamDetails::VideoDimsToResolutionDescription(int iWidth, int iHeight)
 {

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -92,6 +92,8 @@ public:
   CStreamDetails(const CStreamDetails &that);
   ~CStreamDetails() { Reset(); };
   CStreamDetails& operator=(const CStreamDetails &that);
+  bool operator ==(const CStreamDetails &that) const;
+  bool operator !=(const CStreamDetails &that) const;
 
   static CStdString VideoDimsToResolutionDescription(int iWidth, int iHeight);
   static CStdString VideoAspectToAspectDescription(float fAspect);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3098,6 +3098,19 @@ CVideoInfoTag CVideoDatabase::GetDetailsByTypeAndId(VIDEODB_CONTENT_TYPE type, i
   return details;
 }
 
+bool CVideoDatabase::GetStreamDetails(CFileItem& item)
+{
+  if (!item.HasVideoInfoTag())
+    return false;
+
+  CVideoInfoTag *tag = item.GetVideoInfoTag();
+  if (tag->m_iFileId < 0)
+    tag->m_iFileId = GetFileId(item);
+
+  return GetStreamDetails(*tag);
+}
+
+
 bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag) const
 {
   if (tag.m_iFileId < 0)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -483,6 +483,7 @@ public:
   void AddBookMarkForEpisode(const CVideoInfoTag& tag, const CBookmark& bookmark);
   void DeleteBookMarkForEpisode(const CVideoInfoTag& tag);
   bool GetResumePoint(CVideoInfoTag& tag);
+  bool GetStreamDetails(CFileItem& item);
   bool GetStreamDetails(CVideoInfoTag& tag) const;
 
   // scraper settings

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -200,10 +200,9 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
 
   m_database->Open();
 
-  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->HasStreamDetails() &&
-     (pItem->GetVideoInfoTag()->m_type == "movie" || pItem->GetVideoInfoTag()->m_type == "episode" || pItem->GetVideoInfoTag()->m_type == "musicvideo"))
+  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->HasStreamDetails() && pItem->IsVideo())
   {
-    if (m_database->GetStreamDetails(*pItem->GetVideoInfoTag()))
+    if (m_database->GetStreamDetails(*pItem))
       pItem->SetInvalid();
   }
 

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -211,11 +211,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
   {
     FillLibraryArt(*pItem);
 
-    if (!pItem->GetVideoInfoTag()->m_type.empty()         &&
-         pItem->GetVideoInfoTag()->m_type != "movie"      &&
-         pItem->GetVideoInfoTag()->m_type != "tvshow"     &&
-         pItem->GetVideoInfoTag()->m_type != "episode"    &&
-         pItem->GetVideoInfoTag()->m_type != "musicvideo")
+    if (!pItem->IsVideo() && !pItem->m_bIsFolder)
     {
       m_database->Close();
       return true; // nothing else to be done


### PR DESCRIPTION
This PR fixes a few problems concerning stream details:
- Stream details are now properly loaded/stored for items with incomplete/empty infotags;
- Fixed racing between DVDPlayer's GetStreamDetails() and CApp:PlayFile() causing the duration/aspect to always be wrong (0) causing it to be stored in the db over and over again and screwing up the streamdetails in the infotag. This would also occasionally cause showing 4:3 in the GUI for video items with totally different AR;
- As a bonus this puts all the logic in one place (FileSaveState job).
