### PR TITLE
GUI frame rate moved to advanced settings

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2268,7 +2268,8 @@ void CApplication::Render()
   bool decrement = false;
   bool hasRendered = false;
   bool limitFrames = false;
-  unsigned int singleFrameTime = 10; // default limit 100 fps
+  // Round to nearest lower frame rate time delay
+  unsigned int singleFrameTime = ( 1000 / g_advancedSettings.m_guiFrameRate ) + 0.5; 
 
   {
     // Less fps in DPMS

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -308,6 +308,7 @@ void CAdvancedSettings::Initialize()
   m_guiVisualizeDirtyRegions = false;
   m_guiAlgorithmDirtyRegions = 3;
   m_guiDirtyRegionNoFlipTimeout = 0;
+  m_guiFrameRate = 100;
   m_logEnableAirtunes = false;
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;
@@ -1036,6 +1037,8 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "visualizedirtyregions", m_guiVisualizeDirtyRegions);
     XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
     XMLUtils::GetInt(pElement, "nofliptimeout",             m_guiDirtyRegionNoFlipTimeout);
+    XMLUtils::GetUInt(pElement, "framerate",                m_guiFrameRate);
+    m_guiFrameRate = std::max(m_guiFrameRate, 1U); // Divide by zero in CApplication::Render
   }
 
   // load in the GUISettings overrides:

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -345,6 +345,7 @@ class CAdvancedSettings
     bool m_guiVisualizeDirtyRegions;
     int  m_guiAlgorithmDirtyRegions;
     int  m_guiDirtyRegionNoFlipTimeout;
+    unsigned int m_guiFrameRate;
     unsigned int m_addonPackageFolderSize;
 
     unsigned int m_cacheMemBufferSize;


### PR DESCRIPTION
This allow to keep cpu cool on low powered systems. Old value of 100 fps are kept as default.

I found value of 20 fps to keep my RPI at 700MHz at ~80-85% cpu time. With original value of 100 fps it can produce only 35-38 frames at 1000MHz with 100% cpu time. 20 fps looks pretty good and does not cause any visual defects.

100 fps is unusually high for regular x86 HTPC too. 
