### PR TITLE
Allow ms value for AlarmClock()

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -952,10 +952,12 @@ int CBuiltins::Execute(const CStdString& execString)
     float seconds = 0;
     if (params.size() > 2)
     {
-      if (params[2].Find(':') == -1)
-        seconds = static_cast<float>(atoi(params[2].c_str())*60);
-      else
+      if (params[2].Find(':') != -1)
         seconds = (float)StringUtils::TimeStringToSeconds(params[2]);
+      else if (params[2].Find('ms') != -1)
+        seconds = static_cast<float>(atof(params[2].c_str())/1000.0f);
+      else
+        seconds = static_cast<float>(atoi(params[2].c_str())*60);
     }
     else
     { // check if shutdown is specified in particular, and get the time for it

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -98,15 +98,15 @@ void CAlarmClock::Stop(const CStdString& strName, bool bSilent /* false */)
     strAlarmClock = g_localizeStrings.Get(13208);
 
   CStdString strMessage;
-  if( iter->second.watch.GetElapsedSeconds() > iter->second.m_fSecs )
+  if( iter->second.watch.GetElapsedMilliseconds()/1000.0f > iter->second.m_fSecs )
     strMessage = g_localizeStrings.Get(13211);
   else
   {
-    float remaining = static_cast<float>(iter->second.m_fSecs-iter->second.watch.GetElapsedSeconds());
+    float remaining = static_cast<float>(iter->second.m_fSecs-iter->second.watch.GetElapsedMilliseconds()/1000.0f);
     CStdString strStarted = g_localizeStrings.Get(13212);
     strMessage.Format(strStarted.c_str(),static_cast<int>(remaining)/60,static_cast<int>(remaining)%60);
   }
-  if (iter->second.m_strCommand.IsEmpty() || iter->second.m_fSecs > iter->second.watch.GetElapsedSeconds())
+  if (iter->second.m_strCommand.IsEmpty() || iter->second.m_fSecs > iter->second.watch.GetElapsedMilliseconds()/1000.0f)
   {
     if(!bSilent)
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, strAlarmClock, strMessage);
@@ -133,7 +133,7 @@ void CAlarmClock::Process()
     {
       CSingleLock lock(m_events);
       for (map<CStdString,SAlarmClockEvent>::iterator iter=m_event.begin();iter != m_event.end(); ++iter)
-        if (iter->second.watch.GetElapsedSeconds() >= iter->second.m_fSecs)
+        if (iter->second.watch.GetElapsedMilliseconds()/1000.0f >= iter->second.m_fSecs)
         {
           Stop(iter->first);
           if ((iter = m_event.find(strLast)) == m_event.end())


### PR DESCRIPTION
this commit allows AlarmClock() to take values in milliseconds.
can be useful for skinners (see http://forum.xbmc.org/showthread.php?tid=156191&pid=1337513#pid1337513 )
needs a ms suffix for time parameter (for example, "300ms"), the original behaviour isn´t changed. (still uses minutes when time parameter is an integer)
other way would be to move that to TimeStringToSeconds()
