### PR TITLE
Fix inability of libdvd 4.2.0 to read DVDs stored as VIDEO_TS files on n...

### DIFF
--- a/lib/libdvd/libdvdread/src/dvd_reader.c
+++ b/lib/libdvd/libdvdread/src/dvd_reader.c
@@ -445,7 +445,11 @@ dvd_reader_t *DVDOpen( const char *ppath )
 		close( cdir );
         cdir = -1;
         if( retval == -1 ) {
+#if defined(_XBMC)
+          perror("libdvdread: failed to reset working directory to \".\""); /* but ignore error */
+#else
           goto DVDOpen_error;
+#endif // _XBMC
         }
 		    path_copy = new_path;
         new_path = NULL;


### PR DESCRIPTION
...on-Windows OSs.

Fixes http://trac.xbmc.org/ticket/14115.

The approach of not erroring on fchdir is consistent with old libdvd 4.1.3 but nevertheless I've added a statement to print out what goes wrong. This will help further root cause analysis. 

The way to test is with DVD files stored as VIDEO_TS folder and files on your file system (not ISO, not optical). 
