### PR TITLE
[IPlayer et al.] Replace various Getxxx methods with GetxxxStreamInfo methods

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1452,7 +1452,11 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
   break;
   case VIDEOPLAYER_VIDEO_CODEC:
     if(g_application.IsPlaying() && g_application.m_pPlayer)
-      strLabel = g_application.m_pPlayer->GetVideoCodecName();
+    {
+      SPlayerVideoStreamInfo info;
+      g_application.m_pPlayer->GetVideoStreamInfo(info);
+      strLabel = info.videoCodecName;
+    }
     break;
   case VIDEOPLAYER_VIDEO_RESOLUTION:
     if(g_application.IsPlaying() && g_application.m_pPlayer)
@@ -1469,9 +1473,9 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
   case VIDEOPLAYER_VIDEO_ASPECT:
     if (g_application.IsPlaying() && g_application.m_pPlayer)
     {
-      float aspect;
-      g_application.m_pPlayer->GetVideoAspectRatio(aspect);
-      strLabel = CStreamDetails::VideoAspectToAspectDescription(aspect);
+      SPlayerVideoStreamInfo info;
+      g_application.m_pPlayer->GetVideoStreamInfo(info);
+      strLabel = CStreamDetails::VideoAspectToAspectDescription(info.videoAspectRatio);
     }
     break;
   case VIDEOPLAYER_AUDIO_CHANNELS:

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1460,7 +1460,11 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     break;
   case VIDEOPLAYER_AUDIO_CODEC:
     if(g_application.IsPlaying() && g_application.m_pPlayer)
-      strLabel = g_application.m_pPlayer->GetAudioCodecName();
+    {
+      SPlayerAudioStreamInfo info;
+      g_application.m_pPlayer->GetAudioStreamInfo(g_application.m_pPlayer->GetAudioStream(), info);
+      strLabel = info.audioCodecName;
+    }
     break;
   case VIDEOPLAYER_VIDEO_ASPECT:
     if (g_application.IsPlaying() && g_application.m_pPlayer)
@@ -1472,7 +1476,11 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     break;
   case VIDEOPLAYER_AUDIO_CHANNELS:
     if(g_application.IsPlaying() && g_application.m_pPlayer)
-      strLabel.Format("%i", g_application.m_pPlayer->GetChannels());
+    {
+      SPlayerAudioStreamInfo info;
+      g_application.m_pPlayer->GetAudioStreamInfo(g_application.m_pPlayer->GetAudioStream(), info);
+      strLabel.Format("%i", info.channels);
+    }
     break;
   case PLAYLIST_LENGTH:
   case PLAYLIST_POSITION:
@@ -3343,6 +3351,10 @@ CStdString CGUIInfoManager::GetPlaylistLabel(int item) const
 CStdString CGUIInfoManager::GetMusicLabel(int item)
 {
   if (!g_application.IsPlaying() || !m_currentFile->HasMusicInfoTag()) return "";
+
+  SPlayerAudioStreamInfo info;
+  g_application.m_pPlayer->GetAudioStreamInfo(g_application.m_pPlayer->GetAudioStream(), info);
+
   switch (item)
   {
   case MUSICPLAYER_PLAYLISTLEN:
@@ -3362,7 +3374,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
       float fTimeSpan = (float)(CTimeUtils::GetFrameTime() - m_lastMusicBitrateTime);
       if (fTimeSpan >= 500.0f)
       {
-        m_MusicBitrate = g_application.m_pPlayer->GetAudioBitrate();
+        m_MusicBitrate = info.bitrate;
         m_lastMusicBitrateTime = CTimeUtils::GetFrameTime();
       }
       CStdString strBitrate = "";
@@ -3374,9 +3386,9 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
   case MUSICPLAYER_CHANNELS:
     {
       CStdString strChannels = "";
-      if (g_application.m_pPlayer->GetChannels() > 0)
+      if (info.channels > 0)
       {
-        strChannels.Format("%i", g_application.m_pPlayer->GetChannels());
+        strChannels.Format("%i", info.channels);
       }
       return strChannels;
     }
@@ -3404,7 +3416,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
   case MUSICPLAYER_CODEC:
     {
       CStdString strCodec;
-      strCodec.Format("%s", g_application.m_pPlayer->GetAudioCodecName().c_str());
+      strCodec.Format("%s", info.audioCodecName);
       return strCodec;
     }
     break;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -110,6 +110,23 @@ struct SPlayerSubtitleStreamInfo
   std::string name;
 };
 
+struct SPlayerVideoStreamInfo
+{
+  int bitrate;
+  float videoAspectRatio;
+  std::string language;
+  std::string name;
+  std::string videoCodecName;
+  CRect SrcRect;
+  CRect DestRect;
+
+  SPlayerVideoStreamInfo()
+  {
+    bitrate = 0;
+    videoAspectRatio = 1.0f;
+  }
+};
+
 class IPlayer
 {
 public:
@@ -143,8 +160,6 @@ public:
   virtual void GetVideoInfo( CStdString& strVideoInfo) = 0;
   virtual void GetGeneralInfo( CStdString& strVideoInfo) = 0;
   virtual void Update(bool bPauseDrawing = false) = 0;
-  virtual void GetVideoRect(CRect& SrcRect, CRect& DestRect) {}
-  virtual void GetVideoAspectRatio(float& fAR) { fAR = 1.0f; }
   virtual bool CanRecord() { return false;};
   virtual bool IsRecording() { return false;};
   virtual bool Record(bool bOnOff) { return false;};
@@ -186,11 +201,10 @@ public:
    \brief total time in milliseconds
    */
   virtual int64_t GetTotalTime() { return 0; }
-  virtual int GetVideoBitrate(){ return 0;}
+  virtual void GetVideoStreamInfo(SPlayerVideoStreamInfo &info){};
   virtual int GetSourceBitrate(){ return 0;}
   virtual int GetBitsPerSample(){ return 0;};
   virtual int GetSampleRate(){ return 0;};
-  virtual CStdString GetVideoCodecName(){ return "";}
   virtual int GetPictureWidth(){ return 0;}
   virtual int GetPictureHeight(){ return 0;}
   virtual bool GetStreamDetails(CStreamDetails &details){ return false;}

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -89,6 +89,21 @@ enum IPlayerSubtitleCapabilities
   IPC_SUBS_OFFSET
 };
 
+struct SPlayerAudioStreamInfo
+{
+  int bitrate;
+  int channels;
+  std::string language;
+  std::string name;
+  std::string audioCodecName;
+
+  SPlayerAudioStreamInfo()
+  {
+    bitrate = 0;
+    channels = 0;
+  }
+};
+
 class IPlayer
 {
 public:
@@ -145,9 +160,8 @@ public:
 
   virtual int  GetAudioStreamCount()  { return 0; }
   virtual int  GetAudioStream()       { return -1; }
-  virtual void GetAudioStreamName(int iStream, CStdString &strStreamName){};
   virtual void SetAudioStream(int iStream){};
-  virtual void GetAudioStreamLanguage(int iStream, CStdString &strLanguage){};
+  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info){};
 
   virtual TextCacheStruct_t* GetTeletextCache() { return NULL; };
   virtual void LoadPage(int p, int sp, unsigned char* buffer) {};
@@ -168,13 +182,10 @@ public:
    \brief total time in milliseconds
    */
   virtual int64_t GetTotalTime() { return 0; }
-  virtual int GetAudioBitrate(){ return 0;}
   virtual int GetVideoBitrate(){ return 0;}
   virtual int GetSourceBitrate(){ return 0;}
-  virtual int GetChannels(){ return 0;};
   virtual int GetBitsPerSample(){ return 0;};
   virtual int GetSampleRate(){ return 0;};
-  virtual CStdString GetAudioCodecName(){ return "";}
   virtual CStdString GetVideoCodecName(){ return "";}
   virtual int GetPictureWidth(){ return 0;}
   virtual int GetPictureHeight(){ return 0;}

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -104,6 +104,12 @@ struct SPlayerAudioStreamInfo
   }
 };
 
+struct SPlayerSubtitleStreamInfo
+{
+  std::string language;
+  std::string name;
+};
+
 class IPlayer
 {
 public:
@@ -150,8 +156,7 @@ public:
   virtual float GetSubTitleDelay()    { return 0.0f; }
   virtual int  GetSubtitleCount()     { return 0; }
   virtual int  GetSubtitle()          { return -1; }
-  virtual void GetSubtitleName(int iStream, CStdString &strStreamName){};
-  virtual void GetSubtitleLanguage(int iStream, CStdString &strStreamLang){};
+  virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info){};
   virtual void SetSubtitle(int iStream){};
   virtual bool GetSubtitleVisible(){ return false;};
   virtual void SetSubtitleVisible(bool bVisible){};

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -160,7 +160,6 @@ public:
   virtual void SetSubtitle(int iStream){};
   virtual bool GetSubtitleVisible(){ return false;};
   virtual void SetSubtitleVisible(bool bVisible){};
-  virtual bool GetSubtitleExtension(CStdString &strSubtitleExtension){ return false;};
   virtual int  AddSubtitle(const CStdString& strSubPath) {return -1;};
 
   virtual int  GetAudioStreamCount()  { return 0; }

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -907,35 +907,33 @@ int CAMLPlayer::GetSubtitle()
     return -1;
 }
 
-void CAMLPlayer::GetSubtitleName(int iStream, CStdString &strStreamName)
+void CAMLPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info)
 {
   CSingleLock lock(m_aml_csection);
 
-  strStreamName = "";
-
-  if (iStream > (int)m_subtitle_streams.size() || iStream < 0)
+  if (index > (int)m_subtitle_streams.size() -1 || index < 0)
     return;
 
   if (m_subtitle_streams[m_subtitle_index]->source == STREAM_SOURCE_NONE)
   {
-    if ( m_subtitle_streams[iStream]->language.size())
+    if ( m_subtitle_streams[index]->language.size())
     {
       CStdString name;
-      g_LangCodeExpander.Lookup(name, m_subtitle_streams[iStream]->language);
-      strStreamName = name;
+      g_LangCodeExpander.Lookup(name, m_subtitle_streams[index]->language);
+      info.name = name;
     }
     else
-      strStreamName = g_localizeStrings.Get(13205); // Unknown
+      info.name = g_localizeStrings.Get(13205); // Unknown
   }
   else
   {
     if(m_subtitle_streams[m_subtitle_index]->name.length() > 0)
-      strStreamName = m_subtitle_streams[m_subtitle_index]->name;
+      info.name = m_subtitle_streams[m_subtitle_index]->name;
     else
-      strStreamName = g_localizeStrings.Get(13205); // Unknown
+      info.name = g_localizeStrings.Get(13205); // Unknown
   }
   if (m_log_level > 5)
-    CLog::Log(LOGDEBUG, "CAMLPlayer::GetSubtitleName, iStream(%d)", iStream);
+    CLog::Log(LOGDEBUG, "CAMLPlayer::GetSubtitleName, iStream(%d)", index);
 }
  
 void CAMLPlayer::SetSubtitle(int iStream)

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -846,25 +846,6 @@ int CAMLPlayer::GetAudioStream()
   return m_audio_index;
 }
 
-void CAMLPlayer::GetAudioStreamName(int iStream, CStdString &strStreamName)
-{
-  //CLog::Log(LOGDEBUG, "CAMLPlayer::GetAudioStreamName");
-  CSingleLock lock(m_aml_csection);
-
-  strStreamName.Format("Undefined");
-
-  if (iStream > (int)m_audio_streams.size() || iStream < 0)
-    return;
-
-  if ( m_audio_streams[iStream]->language.size())
-  {
-    CStdString name;
-    g_LangCodeExpander.Lookup( name, m_audio_streams[iStream]->language);
-    strStreamName = name;
-  }
-
-}
-
 void CAMLPlayer::SetAudioStream(int SetAudioStream)
 {
   //CLog::Log(LOGDEBUG, "CAMLPlayer::SetAudioStream");
@@ -1128,13 +1109,29 @@ __int64 CAMLPlayer::GetTotalTime()
   return m_duration_ms;
 }
 
-int CAMLPlayer::GetAudioBitrate()
+void CAMLPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 {
   CSingleLock lock(m_aml_csection);
-  if (m_audio_streams.size() == 0 || m_audio_index > (int)(m_audio_streams.size() - 1))
-    return 0;
+  if (index < 0 || m_audio_streams.size() == 0 || index > (int)(m_audio_streams.size() - 1))
+    return;
 
-  return m_audio_streams[m_audio_index]->bit_rate;
+  info.bitrate = m_audio_streams[index]->bit_rate;
+
+  if ( m_audio_streams[index]->language.size())
+    info.language = m_audio_streams[index]->language;
+
+  info.channels = m_audio_streams[index]->channel;
+
+  info.audioCodecName = AudioCodecName(m_audio_streams[index]->format);
+
+  info.name.Format("Undefined");
+    
+  if ( m_audio_streams[index]->language.size())
+  {
+    CStdString name;
+    g_LangCodeExpander.Lookup( name, m_audio_streams[index]->language);
+    info.name = name;
+  }
 }
 
 int CAMLPlayer::GetVideoBitrate()
@@ -1152,15 +1149,6 @@ int CAMLPlayer::GetSourceBitrate()
   return 0;
 }
 
-int CAMLPlayer::GetChannels()
-{
-  CSingleLock lock(m_aml_csection);
-  if (m_audio_streams.size() == 0 || m_audio_index > (int)(m_audio_streams.size() - 1))
-    return 0;
-  
-  return m_audio_streams[m_audio_index]->channel;
-}
-
 int CAMLPlayer::GetBitsPerSample()
 {
   CLog::Log(LOGDEBUG, "CAMLPlayer::GetBitsPerSample");
@@ -1174,17 +1162,6 @@ int CAMLPlayer::GetSampleRate()
     return 0;
   
   return m_audio_streams[m_audio_index]->sample_rate;
-}
-
-CStdString CAMLPlayer::GetAudioCodecName()
-{
-  CStdString strAudioCodec = "";
-  if (m_audio_streams.size() == 0 || m_audio_index > (int)(m_audio_streams.size() - 1))
-    return strAudioCodec;
-
-  strAudioCodec = AudioCodecName(m_audio_streams[m_audio_index]->format);
-
-  return strAudioCodec;
 }
 
 CStdString CAMLPlayer::GetVideoCodecName()

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -995,16 +995,6 @@ void CAMLPlayer::Update(bool bPauseDrawing)
   g_renderManager.Update(bPauseDrawing);
 }
 
-void CAMLPlayer::GetVideoRect(CRect& SrcRect, CRect& DestRect)
-{
-  g_renderManager.GetVideoRect(SrcRect, DestRect);
-}
-
-void CAMLPlayer::GetVideoAspectRatio(float &fAR)
-{
-  fAR = g_renderManager.GetAspectRatio();
-}
-
 int CAMLPlayer::GetChapterCount()
 {
   return m_chapter_count;
@@ -1132,13 +1122,16 @@ void CAMLPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
   }
 }
 
-int CAMLPlayer::GetVideoBitrate()
+void CAMLPlayer::GetVideoStreamInfo(SPlayerVideoStreamInfo &info)
 {
   CSingleLock lock(m_aml_csection);
   if (m_video_streams.size() == 0 || m_video_index > (int)(m_video_streams.size() - 1))
-    return 0;
+    return;
 
-  return m_video_streams[m_video_index]->bit_rate;
+  info.bitrate = m_video_streams[m_video_index]->bit_rate;
+  info.videoCodecName = VideoCodecName(m_video_streams[m_video_index]->format);
+  info.videoAspectRatio = g_renderManager.GetAspectRatio();
+  g_renderManager.GetVideoRect(info.SrcRect, info.DestRect);
 }
 
 int CAMLPlayer::GetSourceBitrate()
@@ -1160,17 +1153,6 @@ int CAMLPlayer::GetSampleRate()
     return 0;
   
   return m_audio_streams[m_audio_index]->sample_rate;
-}
-
-CStdString CAMLPlayer::GetVideoCodecName()
-{
-  CStdString strVideoCodec = "";
-  if (m_video_streams.size() == 0 || m_video_index > (int)(m_video_streams.size() - 1))
-    return strVideoCodec;
-  
-  strVideoCodec = VideoCodecName(m_video_streams[m_video_index]->format);
-
-  return strVideoCodec;
 }
 
 int CAMLPlayer::GetPictureWidth()

--- a/xbmc/cores/amlplayer/AMLPlayer.h
+++ b/xbmc/cores/amlplayer/AMLPlayer.h
@@ -101,7 +101,7 @@ public:
   virtual float GetSubTitleDelay();
   virtual int   GetSubtitleCount();
   virtual int   GetSubtitle();
-  virtual void  GetSubtitleName(int iStream, CStdString &strStreamName);
+  virtual void  GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
   virtual void  SetSubtitle(int iStream);
   virtual bool  GetSubtitleVisible();
   virtual void  SetSubtitleVisible(bool bVisible);

--- a/xbmc/cores/amlplayer/AMLPlayer.h
+++ b/xbmc/cores/amlplayer/AMLPlayer.h
@@ -105,7 +105,6 @@ public:
   virtual void  SetSubtitle(int iStream);
   virtual bool  GetSubtitleVisible();
   virtual void  SetSubtitleVisible(bool bVisible);
-  virtual bool  GetSubtitleExtension(CStdString &strSubtitleExtension) { return false; }
   virtual int   AddSubtitle(const CStdString& strSubPath);
 
   virtual int   GetAudioStreamCount();

--- a/xbmc/cores/amlplayer/AMLPlayer.h
+++ b/xbmc/cores/amlplayer/AMLPlayer.h
@@ -88,8 +88,6 @@ public:
   virtual void  GetVideoInfo(CStdString &strVideoInfo);
   virtual void  GetGeneralInfo(CStdString &strVideoInfo) {};
   virtual void  Update(bool bPauseDrawing);
-  virtual void  GetVideoRect(CRect& SrcRect, CRect& DestRect);
-  virtual void  GetVideoAspectRatio(float &fAR);
   virtual bool  CanRecord()                                       {return false;};
   virtual bool  IsRecording()                                     {return false;};
   virtual bool  Record(bool bOnOff)                               {return false;};
@@ -124,11 +122,10 @@ public:
   virtual __int64 GetTime();
   virtual __int64 GetTotalTime();
   virtual void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
-  virtual int   GetVideoBitrate();
+  virtual void  GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
   virtual int   GetSourceBitrate();
   virtual int   GetBitsPerSample();
   virtual int   GetSampleRate();
-  virtual CStdString GetVideoCodecName();
   virtual int   GetPictureWidth();
   virtual int   GetPictureHeight();
   virtual bool  GetStreamDetails(CStreamDetails &details);

--- a/xbmc/cores/amlplayer/AMLPlayer.h
+++ b/xbmc/cores/amlplayer/AMLPlayer.h
@@ -110,9 +110,7 @@ public:
 
   virtual int   GetAudioStreamCount();
   virtual int   GetAudioStream();
-  virtual void  GetAudioStreamName(int iStream, CStdString &strStreamName);
   virtual void  SetAudioStream(int iStream);
-  virtual void  GetAudioStreamLanguage(int iStream, CStdString &strLanguage) {};
 
   virtual TextCacheStruct_t* GetTeletextCache()                   {return NULL;};
   virtual void  LoadPage(int p, int sp, unsigned char* buffer)    {};
@@ -126,13 +124,11 @@ public:
   virtual void  SeekTime(__int64 iTime = 0);
   virtual __int64 GetTime();
   virtual __int64 GetTotalTime();
-  virtual int   GetAudioBitrate();
+  virtual void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
   virtual int   GetVideoBitrate();
   virtual int   GetSourceBitrate();
-  virtual int   GetChannels();
   virtual int   GetBitsPerSample();
   virtual int   GetSampleRate();
-  virtual CStdString GetAudioCodecName();
   virtual CStdString GetVideoCodecName();
   virtual int   GetPictureWidth();
   virtual int   GetPictureHeight();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2669,24 +2669,25 @@ int CDVDPlayer::GetSubtitle()
   return m_SelectionStreams.IndexOf(STREAM_SUBTITLE, *this);
 }
 
-void CDVDPlayer::GetSubtitleName(int iStream, CStdString &strStreamName)
+void CDVDPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info)
 {
-  strStreamName = "";
-  SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, iStream);
+  if (index < 0 || index > (int) GetSubtitleCount() - 1)
+    return;
+
+  SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, index);
   if(s.name.length() > 0)
-    strStreamName = s.name;
+    info.name = s.name;
   else
-    strStreamName = g_localizeStrings.Get(13205); // Unknown
+    info.name = g_localizeStrings.Get(13205); // Unknown
 
   if(s.type == STREAM_NONE)
-    strStreamName += "(Invalid)";
-}
+    info.name += "(Invalid)";
 
-void CDVDPlayer::GetSubtitleLanguage(int iStream, CStdString &strStreamLang)
-{
-  SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, iStream);
+  CStdString strStreamLang;
   if (!g_LangCodeExpander.Lookup(strStreamLang, s.language))
-    strStreamLang = g_localizeStrings.Get(13205); // Unknown
+    info.language = g_localizeStrings.Get(13205); // Unknown
+  else
+    info.language = strStreamLang;
 }
 
 void CDVDPlayer::SetSubtitle(int iStream)

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -216,9 +216,7 @@ public:
 
   virtual int GetAudioStreamCount();
   virtual int GetAudioStream();
-  virtual void GetAudioStreamName(int iStream, CStdString &strStreamName);
   virtual void SetAudioStream(int iStream);
-  virtual void GetAudioStreamLanguage(int iStream, CStdString &strLanguage);
 
   virtual TextCacheStruct_t* GetTeletextCache();
   virtual void LoadPage(int p, int sp, unsigned char* buffer);
@@ -234,15 +232,14 @@ public:
   virtual void ToFFRW(int iSpeed);
   virtual bool OnAction(const CAction &action);
   virtual bool HasMenu();
-  virtual int GetAudioBitrate();
+
   virtual int GetVideoBitrate();
   virtual int GetSourceBitrate();
-  virtual int GetChannels();
-  virtual CStdString GetAudioCodecName();
   virtual CStdString GetVideoCodecName();
   virtual int GetPictureWidth();
   virtual int GetPictureHeight();
   virtual bool GetStreamDetails(CStreamDetails &details);
+  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
 
   virtual bool GetCurrentSubtitle(CStdString& strSubtitle);
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -210,7 +210,6 @@ public:
   virtual void SetSubtitle(int iStream);
   virtual bool GetSubtitleVisible();
   virtual void SetSubtitleVisible(bool bVisible);
-  virtual bool GetSubtitleExtension(CStdString &strSubtitleExtension) { return false; }
   virtual int  AddSubtitle(const CStdString& strSubPath);
 
   virtual int GetAudioStreamCount();

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -206,8 +206,7 @@ public:
   virtual float GetSubTitleDelay();
   virtual int GetSubtitleCount();
   virtual int GetSubtitle();
-  virtual void GetSubtitleName(int iStream, CStdString &strStreamName);
-  virtual void GetSubtitleLanguage(int iStream, CStdString &strStreamLang);
+  virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
   virtual void SetSubtitle(int iStream);
   virtual bool GetSubtitleVisible();
   virtual void SetSubtitleVisible(bool bVisible);

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -193,8 +193,6 @@ public:
   virtual void GetVideoInfo(CStdString& strVideoInfo);
   virtual void GetGeneralInfo( CStdString& strVideoInfo);
   virtual void Update(bool bPauseDrawing)                       { m_dvdPlayerVideo.Update(bPauseDrawing); }
-  virtual void GetVideoRect(CRect& SrcRect, CRect& DestRect)    { m_dvdPlayerVideo.GetVideoRect(SrcRect, DestRect); }
-  virtual void GetVideoAspectRatio(float& fAR)                  { fAR = m_dvdPlayerVideo.GetAspectRatio(); }
   virtual bool CanRecord();
   virtual bool IsRecording();
   virtual bool CanPause();
@@ -231,9 +229,8 @@ public:
   virtual bool OnAction(const CAction &action);
   virtual bool HasMenu();
 
-  virtual int GetVideoBitrate();
   virtual int GetSourceBitrate();
-  virtual CStdString GetVideoCodecName();
+  virtual void GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
   virtual int GetPictureWidth();
   virtual int GetPictureHeight();
   virtual bool GetStreamDetails(CStreamDetails &details);

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2690,24 +2690,25 @@ int COMXPlayer::GetSubtitle()
   return m_SelectionStreams.IndexOf(STREAM_SUBTITLE, *this);
 }
 
-void COMXPlayer::GetSubtitleName(int iStream, CStdString &strStreamName)
+void COMXPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
 {
-  strStreamName = "";
-  OMXSelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, iStream);
+  if (index < 0 || index > (int) GetSubtitleCount() - 1)
+    return;
+
+  OMXSelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, index);
   if(s.name.length() > 0)
-    strStreamName = s.name;
+    info.name = s.name;
   else
-    strStreamName = g_localizeStrings.Get(13205); // Unknown
+    info.name = g_localizeStrings.Get(13205); // Unknown
 
   if(s.type == STREAM_NONE)
-    strStreamName += "(Invalid)";
-}
+    info.name += "(Invalid)";
 
-void COMXPlayer::GetSubtitleLanguage(int iStream, CStdString &strStreamLang)
-{
-  OMXSelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, iStream);
+  CStdString strStreamLang;
   if (!g_LangCodeExpander.Lookup(strStreamLang, s.language))
-    strStreamLang = g_localizeStrings.Get(13205); // Unknown
+    info.language = g_localizeStrings.Get(13205); // Unknown
+  else
+    info.language = strStreamLang;
 }
 
 void COMXPlayer::SetSubtitle(int iStream)

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -249,8 +249,7 @@ public:
   virtual float GetSubTitleDelay();
   virtual int   GetSubtitleCount();
   virtual int   GetSubtitle();
-  virtual void  GetSubtitleName(int iStream, CStdString &strStreamName);
-  virtual void  GetSubtitleLanguage(int iStream, CStdString &strStreamLang);
+  virtual void  GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
   virtual void  SetSubtitle(int iStream);
   virtual bool  GetSubtitleVisible();
   virtual void  SetSubtitleVisible(bool bVisible);

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -259,9 +259,7 @@ public:
 
   virtual int   GetAudioStreamCount();
   virtual int   GetAudioStream();
-  virtual void  GetAudioStreamName(int iStream, CStdString &strStreamName);
   virtual void  SetAudioStream(int iStream);
-  virtual void  GetAudioStreamLanguage(int iStream, CStdString &strLanguage);
 
   virtual TextCacheStruct_t* GetTeletextCache();
   virtual void  LoadPage(int p, int sp, unsigned char* buffer);
@@ -276,11 +274,9 @@ public:
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
   virtual void  ToFFRW(int iSpeed = 0);
-  virtual int   GetAudioBitrate();
+  virtual void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
   virtual int   GetVideoBitrate();
   virtual int   GetSourceBitrate();
-  virtual int   GetChannels();
-  virtual CStdString GetAudioCodecName();
   virtual CStdString GetVideoCodecName();
   virtual int   GetPictureWidth();
   virtual int   GetPictureHeight();

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -235,8 +235,6 @@ public:
   virtual void  GetVideoInfo(CStdString &strVideoInfo);
   virtual void  GetGeneralInfo(CStdString &strVideoInfo);
   virtual void  Update(bool bPauseDrawing);
-  virtual void  GetVideoRect(CRect& SrcRect, CRect& DestRect);
-  virtual void  GetVideoAspectRatio(float &fAR);
   virtual void  UpdateApplication(double timeout);
   virtual bool  CanRecord();
   virtual bool  IsRecording();
@@ -273,9 +271,8 @@ public:
   virtual int64_t GetTotalTime();
   virtual void  ToFFRW(int iSpeed = 0);
   virtual void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
-  virtual int   GetVideoBitrate();
+  virtual void  GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
   virtual int   GetSourceBitrate();
-  virtual CStdString GetVideoCodecName();
   virtual int   GetPictureWidth();
   virtual int   GetPictureHeight();
   virtual bool  GetStreamDetails(CStreamDetails &details);

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -253,7 +253,6 @@ public:
   virtual void  SetSubtitle(int iStream);
   virtual bool  GetSubtitleVisible();
   virtual void  SetSubtitleVisible(bool bVisible);
-  virtual bool  GetSubtitleExtension(CStdString &strSubtitleExtension) { return false; }
   virtual int   AddSubtitle(const CStdString& strSubPath);
 
   virtual int   GetAudioStreamCount();

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -824,11 +824,6 @@ int PAPlayer::GetCacheLevel() const
   return m_playerGUIData.m_cacheLevel;
 }
 
-int PAPlayer::GetChannels()
-{
-  return m_playerGUIData.m_channelCount;
-}
-
 int PAPlayer::GetBitsPerSample()
 {
   return m_playerGUIData.m_bitsPerSample;
@@ -839,14 +834,11 @@ int PAPlayer::GetSampleRate()
   return m_playerGUIData.m_sampleRate;
 }
 
-CStdString PAPlayer::GetAudioCodecName()
+void PAPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 {
-  return m_playerGUIData.m_codec;
-}
-
-int PAPlayer::GetAudioBitrate()
-{
-  return m_playerGUIData.m_audioBitrate;
+  info.bitrate = m_playerGUIData.m_audioBitrate;
+  info.channels = m_playerGUIData.m_channelCount;
+  info.audioCodecName = m_playerGUIData.m_codec;
 }
 
 bool PAPlayer::CanSeek()

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -63,11 +63,9 @@ public:
   virtual void ToFFRW(int iSpeed = 0);
   virtual int GetCacheLevel() const;
   virtual int64_t GetTotalTime();
-  virtual int GetAudioBitrate();
-  virtual int GetChannels();
+  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
   virtual int GetBitsPerSample();
   virtual int GetSampleRate();
-  virtual CStdString GetAudioCodecName();
   virtual int64_t GetTime();
   virtual void SeekTime(int64_t iTime = 0);
   virtual bool SkipNext();

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1431,13 +1431,12 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
           int index = g_application.m_pPlayer->GetSubtitle();
           if (index >= 0)
           {
+            SPlayerSubtitleStreamInfo info;
+            g_application.m_pPlayer->GetSubtitleStreamInfo(index, info);
+
             result["index"] = index;
-            CStdString value;
-            g_application.m_pPlayer->GetSubtitleName(index, value);
-            result["name"] = value;
-            value.Empty();
-            g_application.m_pPlayer->GetSubtitleLanguage(index, value);
-            result["language"] = value;
+            result["name"] = info.name;
+            result["language"] = info.language;
           }
         }
         else
@@ -1461,14 +1460,13 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
         {
           for (int index = 0; index < g_application.m_pPlayer->GetSubtitleCount(); index++)
           {
+            SPlayerSubtitleStreamInfo info;
+            g_application.m_pPlayer->GetSubtitleStreamInfo(index, info);
+
             CVariant subtitle(CVariant::VariantTypeObject);
             subtitle["index"] = index;
-            CStdString value;
-            g_application.m_pPlayer->GetSubtitleName(index, value);
-            subtitle["name"] = value;
-            value.Empty();
-            g_application.m_pPlayer->GetSubtitleLanguage(index, value);
-            subtitle["language"] = value;
+            subtitle["name"] = info.name;
+            subtitle["language"] = info.language;
 
             result.append(subtitle);
           }

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1354,17 +1354,15 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
           int index = g_application.m_pPlayer->GetAudioStream();
           if (index >= 0)
           {
-            result["index"] = index;
-            CStdString value;
-            g_application.m_pPlayer->GetAudioStreamName(index, value);
-            result["name"] = value;
-            value.Empty();
-            g_application.m_pPlayer->GetAudioStreamLanguage(index, value);
-            result["language"] = value;
+            SPlayerAudioStreamInfo info;
+            g_application.m_pPlayer->GetAudioStreamInfo(index, info);
 
-            result["codec"] = g_application.m_pPlayer->GetAudioCodecName();
-            result["bitrate"] = g_application.m_pPlayer->GetAudioBitrate();
-            result["channels"] = g_application.m_pPlayer->GetChannels();
+            result["index"] = index;
+            result["name"] = info.name;
+            result["language"] = info.language;
+            result["codec"] = info.audioCodecName;
+            result["bitrate"] = info.bitrate;
+            result["channels"] = info.channels;
           }
         }
         else
@@ -1387,14 +1385,13 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
         {
           for (int index = 0; index < g_application.m_pPlayer->GetAudioStreamCount(); index++)
           {
+            SPlayerAudioStreamInfo info;
+            g_application.m_pPlayer->GetAudioStreamInfo(index, info);
+
             CVariant audioStream(CVariant::VariantTypeObject);
             audioStream["index"] = index;
-            CStdString value;
-            g_application.m_pPlayer->GetAudioStreamName(index, value);
-            audioStream["name"] = value;
-            value.Empty();
-            g_application.m_pPlayer->GetAudioStreamLanguage(index, value);
-            audioStream["language"] = value;
+            audioStream["name"] = info.name;
+            audioStream["language"] = info.language;
 
             result.append(audioStream);
           }

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -457,13 +457,14 @@ namespace XBMCAddon
         int streamCount = g_application.m_pPlayer->GetAudioStreamCount();
         std::vector<String>* ret = new std::vector<String>(streamCount);
         for (int iStream=0; iStream < streamCount; iStream++)
-        {  
-          CStdString strName;
+        {
+          SPlayerAudioStreamInfo info;
+          g_application.m_pPlayer->GetAudioStreamInfo(iStream, info);
+
           CStdString FullLang;
-          g_application.m_pPlayer->GetAudioStreamLanguage(iStream, strName);
-          g_LangCodeExpander.Lookup(FullLang, strName);
+          g_LangCodeExpander.Lookup(FullLang, info.language);
           if (FullLang.IsEmpty())
-            g_application.m_pPlayer->GetAudioStreamName(iStream, FullLang);
+            FullLang = info.name;
           (*ret)[iStream] = FullLang;
         }
         return ret;

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -393,9 +393,10 @@ namespace XBMCAddon
       TRACE;
       if (g_application.m_pPlayer)
       {
+        SPlayerSubtitleStreamInfo info;
+        g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
         int i = g_application.m_pPlayer->GetSubtitle();
-        CStdString strName;
-        g_application.m_pPlayer->GetSubtitleName(i, strName);
+        CStdString strName = info.name;
 
         if (strName == "Unknown(Invalid)")
           strName = "";
@@ -424,11 +425,12 @@ namespace XBMCAddon
         std::vector<String>* ret = new std::vector<String>(subtitleCount);
         for (int iStream=0; iStream < subtitleCount; iStream++)
         {
-          CStdString strName;
+          SPlayerSubtitleStreamInfo info;
+          g_application.m_pPlayer->GetSubtitleStreamInfo(iStream, info);
+
           CStdString FullLang;
-          g_application.m_pPlayer->GetSubtitleName(iStream, strName);
-          if (!g_LangCodeExpander.Lookup(FullLang, strName))
-            FullLang = strName;
+          if (!g_LangCodeExpander.Lookup(FullLang, info.name))
+            FullLang = info.name;
           (*ret)[iStream] = FullLang;
         }
         return ret;

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -162,7 +162,11 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(unsigned int id)
   {
     CStdString strItem;
     CStdString strName;
-    g_application.m_pPlayer->GetAudioStreamName(i, strName);
+
+    SPlayerAudioStreamInfo info;
+    g_application.m_pPlayer->GetAudioStreamInfo(i, info);
+
+    strName = info.name;
     if (strName.length() == 0)
       strName = "Unnamed";
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -202,17 +202,17 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(unsigned int id)
   // cycle through each subtitle and add it to our entry list
   for (int i = 0; i <= setting.max; ++i)
   {
+    SPlayerSubtitleStreamInfo info;
+    g_application.m_pPlayer->GetSubtitleStreamInfo(i, info);
+
     CStdString strItem;
-    CStdString strName;
-    g_application.m_pPlayer->GetSubtitleName(i, strName);
+    CStdString strName = info.name;
+
     if (strName.length() == 0)
       strName = "Unnamed";
 
-    CStdString strLanguage;
-    g_application.m_pPlayer->GetSubtitleLanguage(i, strLanguage);
-
-    if (strName != strLanguage)
-      strName.Format("%s [%s]", strName.c_str(), strLanguage.c_str());
+    if (strName != info.language)
+      strName.Format("%s [%s]", strName.c_str(), info.language.c_str());
 
     strItem.Format("%s (%i/%i)", strName.c_str(), i + 1, (int)setting.max + 1);
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -364,7 +364,9 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
         g_settings.m_currentVideoSettings.m_AudioStream = 0;
       g_application.m_pPlayer->SetAudioStream(g_settings.m_currentVideoSettings.m_AudioStream);    // Set the audio stream to the one selected
       CStdString aud;
-      g_application.m_pPlayer->GetAudioStreamName(g_settings.m_currentVideoSettings.m_AudioStream,aud);
+      SPlayerAudioStreamInfo info;
+      g_application.m_pPlayer->GetAudioStreamInfo(g_settings.m_currentVideoSettings.m_AudioStream, info);
+      aud = info.name;
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(460), aud, DisplTime, false, MsgTime);
       return true;
     }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -226,10 +226,11 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       CStdString sub, lang;
       if (g_settings.m_currentVideoSettings.m_SubtitleOn)
       {
-        g_application.m_pPlayer->GetSubtitleName(g_application.m_pPlayer->GetSubtitle(),sub);
-        g_application.m_pPlayer->GetSubtitleLanguage(g_application.m_pPlayer->GetSubtitle(),lang);
-        if (sub != lang)
-          sub.Format("%s [%s]", sub.c_str(), lang.c_str());
+        SPlayerSubtitleStreamInfo info;
+        g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
+        sub = info.name;
+        if (sub != info.language)
+          sub.Format("%s [%s]", sub.c_str(), info.language.c_str());
       }
       else
         sub = g_localizeStrings.Get(1223);
@@ -279,10 +280,11 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       CStdString sub, lang;
       if (g_settings.m_currentVideoSettings.m_SubtitleOn)
       {
-        g_application.m_pPlayer->GetSubtitleName(g_settings.m_currentVideoSettings.m_SubtitleStream,sub);
-        g_application.m_pPlayer->GetSubtitleLanguage(g_settings.m_currentVideoSettings.m_SubtitleStream,lang);
-        if (sub != lang)
-          sub.Format("%s [%s]", sub.c_str(), lang.c_str());
+        SPlayerSubtitleStreamInfo info;
+        g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
+        sub = info.name;
+        if (sub != info.language)
+          sub.Format("%s [%s]", sub.c_str(), info.language.c_str());
       }
       else
         sub = g_localizeStrings.Get(1223);

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -951,10 +951,8 @@ void CGUIWindowFullScreen::FrameMove()
       OnMessage(msg);
     }
     // show sizing information
-    CRect SrcRect, DestRect;
-    float fAR;
-    g_application.m_pPlayer->GetVideoRect(SrcRect, DestRect);
-    g_application.m_pPlayer->GetVideoAspectRatio(fAR);
+    SPlayerVideoStreamInfo info;
+    g_application.m_pPlayer->GetVideoStreamInfo(info);
     {
       // Splitres scaling factor
       RESOLUTION res = g_graphicsContext.GetVideoResolution();
@@ -963,9 +961,9 @@ void CGUIWindowFullScreen::FrameMove()
 
       CStdString strSizing;
       strSizing.Format(g_localizeStrings.Get(245),
-                       (int)SrcRect.Width(), (int)SrcRect.Height(),
-                       (int)(DestRect.Width() * xscale), (int)(DestRect.Height() * yscale),
-                       g_settings.m_fZoomAmount, fAR*g_settings.m_fPixelRatio, 
+                       (int)info.SrcRect.Width(), (int)info.SrcRect.Height(),
+                       (int)(info.DestRect.Width() * xscale), (int)(info.DestRect.Height() * yscale),
+                       g_settings.m_fZoomAmount, info.videoAspectRatio*g_settings.m_fPixelRatio, 
                        g_settings.m_fPixelRatio, g_settings.m_fVerticalShift);
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW2);
       msg.SetLabel(strSizing);
@@ -1122,13 +1120,13 @@ void CGUIWindowFullScreen::RenderTTFSubtitles()
         y = (float) g_settings.m_ResInfo[res].iSubtitles - textHeight;
       else
       {
-        CRect SrcRect, DestRect;
-        g_application.m_pPlayer->GetVideoRect(SrcRect, DestRect);
+        SPlayerVideoStreamInfo info;
+        g_application.m_pPlayer->GetVideoStreamInfo(info);
 
         if ((subalign == SUBTITLE_ALIGN_TOP_INSIDE) || (subalign == SUBTITLE_ALIGN_TOP_OUTSIDE))
-          y = DestRect.y1;
+          y = info.DestRect.y1;
         else
-          y = DestRect.y2;
+          y = info.DestRect.y2;
 
         // use the manual distance to the screenbottom as an offset to the automatic location
         if ((subalign == SUBTITLE_ALIGN_BOTTOM_INSIDE) || (subalign == SUBTITLE_ALIGN_TOP_OUTSIDE))


### PR DESCRIPTION
This PR removes various \* `GetAudioXxx, GetSubtitleXxx and GetVideoXxx` methods

from all players and replaces them with `GetXxxStreamInfo(int iStream, SPlayerXxxStreamInfo &info)`.

See commit messages for exact method names.

All affected places are adapted.

Since I'm on windows I have only check this. I could use some help/feedback from other platform devs.
