### PR TITLE
Fix check common subtitle subdir existence without suffix slash bug.

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1947,6 +1947,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     for (int j=0; common_sub_dirs[j]; j++)
     {
       CStdString strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],common_sub_dirs[j]);
+      URIUtils::AddSlashAtEnd(strPath2);
       if (CDirectory::Exists(strPath2))
         strLookInPaths.push_back(strPath2);
     }


### PR DESCRIPTION
In CUtil::ScanForExternalSubtitles it check subtitle subdir's existences, when checking common common subtitle subdirs, it did not append directory suffix, it will cause problem on filesystems checking file exists in different way, e.g. ftp

this pr fixed it, as the code next the the fixed part which tests 'cd%d' subdir's existence.
