### PR TITLE
Beginning of Android intents handling

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -45,6 +45,12 @@
                 android:name="android.app.lib_name"
                 android:value="xbmc" />
         </activity>
+        <receiver android:name="XBMCBroadcastReceiver" >
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_MOUNTED" />
+                <data android:scheme="file"/>
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest><!-- END_INCLUDE(manifest) -->

--- a/tools/android/packaging/xbmc/src/org/xbmc/xbmc/XBMCBroadcastReceiver.java
+++ b/tools/android/packaging/xbmc/src/org/xbmc/xbmc/XBMCBroadcastReceiver.java
@@ -1,0 +1,24 @@
+package org.xbmc.xbmc;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class XBMCBroadcastReceiver extends BroadcastReceiver
+{
+  native void ReceiveIntent(Intent intent);
+  static
+  {
+    System.loadLibrary("xbmc");
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent)
+  {
+    String actionName = intent.getAction();
+    if (actionName != null)
+    {
+        ReceiveIntent(intent);
+    }
+  }
+}

--- a/xbmc/android/activity/Intents.cpp
+++ b/xbmc/android/activity/Intents.cpp
@@ -1,0 +1,55 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "Intents.h"
+#include "utils/log.h"
+#include "XBMCApp.h"
+
+CAndroidIntents::CAndroidIntents()
+{
+}
+
+void CAndroidIntents::ReceiveIntent(JNIEnv *env, const jobject &intent)
+{
+  std::string action = GetIntentAction(intent);
+  CLog::Log(LOGDEBUG,"CAndroidIntents::ReceiveIntent: %s", action.c_str());
+}
+
+std::string CAndroidIntents::GetIntentAction(const jobject &intent)
+{
+  std::string action;
+  JNIEnv *env;
+
+ if (!intent)
+    return "";
+
+  CXBMCApp::AttachCurrentThread(&env, NULL);
+  jclass cIntent = env->GetObjectClass(intent);
+
+  //action = intent.getAction()
+  jmethodID mgetAction = env->GetMethodID(cIntent, "getAction", "()Ljava/lang/String;");
+  env->DeleteLocalRef(cIntent);
+  jstring sAction = (jstring)env->CallObjectMethod(intent, mgetAction);
+  const char *nativeString = env->GetStringUTFChars(sAction, 0);
+  action = std::string(nativeString);
+
+  env->ReleaseStringUTFChars(sAction, nativeString);
+  CXBMCApp::DetachCurrentThread();
+  return action;
+}

--- a/xbmc/android/activity/Intents.h
+++ b/xbmc/android/activity/Intents.h
@@ -1,0 +1,35 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <string>
+#include <jni.h>
+
+class CAndroidIntents
+{
+public:
+  void ReceiveIntent(JNIEnv *env, const jobject &intent);
+  static CAndroidIntents& getInstance() {static CAndroidIntents temp; return temp;};
+
+private:
+  CAndroidIntents();
+  CAndroidIntents(CAndroidIntents const&);
+  void operator=(CAndroidIntents const&);
+  std::string GetIntentAction(const jobject &intent);
+};

--- a/xbmc/android/activity/JNI.cpp
+++ b/xbmc/android/activity/JNI.cpp
@@ -19,11 +19,13 @@
  */
 #include <string>
 #include <jni.h>
+#include "Intents.h"
 
 extern "C"{
 
   static void jni_ReceiveIntent(JNIEnv *env, jobject thiz, jobject intent)
   {
+     CAndroidIntents::getInstance().ReceiveIntent(env, intent);
   }
 
   static JNINativeMethod jniMethods[] =

--- a/xbmc/android/activity/JNI.cpp
+++ b/xbmc/android/activity/JNI.cpp
@@ -1,0 +1,48 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <string>
+#include <jni.h>
+
+extern "C"{
+
+  static void jni_ReceiveIntent(JNIEnv *env, jobject thiz, jobject intent)
+  {
+  }
+
+  static JNINativeMethod jniMethods[] =
+  {
+    {"ReceiveIntent", "(Landroid/content/Intent;)V", (void*)jni_ReceiveIntent}
+  };
+
+  // This is a special function called when libxbmc is loaded. It sets up our
+  // internal functions so that we can use them in native code much more simply.
+  // It loads a array of methods, params, and function-pointers.
+  jint JNI_OnLoad(JavaVM* vm, void* reserved)
+  {
+    JNIEnv* env;
+    if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        return -1;
+    }
+    jclass jniClass = env->FindClass("org/xbmc/xbmc/XBMCBroadcastReceiver");
+    env->RegisterNatives(jniClass, jniMethods, sizeof(jniMethods) / sizeof(jniMethods[0]));
+
+    return JNI_VERSION_1_6;
+  }
+}

--- a/xbmc/android/activity/Makefile.in
+++ b/xbmc/android/activity/Makefile.in
@@ -17,6 +17,7 @@ SRCS      += GraphicBuffer.cpp
 SRCS      += EventLoop.cpp
 SRCS      += XBMCApp.cpp
 SRCS      += JNI.cpp
+SRCS      += Intents.cpp
 
 OBJS      += $(APP_GLUE) $(CPU_OBJ)
 

--- a/xbmc/android/activity/Makefile.in
+++ b/xbmc/android/activity/Makefile.in
@@ -16,6 +16,7 @@ SRCS      += AndroidMouse.cpp
 SRCS      += GraphicBuffer.cpp
 SRCS      += EventLoop.cpp
 SRCS      += XBMCApp.cpp
+SRCS      += JNI.cpp
 
 OBJS      += $(APP_GLUE) $(CPU_OBJ)
 

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -104,6 +104,7 @@ protected:
   friend class CAESinkAUDIOTRACK;
   friend class CAndroidFeatures;
   friend class CFileAndroidApp;
+  friend class CAndroidIntents;
 
   static int AttachCurrentThread(JNIEnv** p_env, void* thr_args = NULL);
   static int DetachCurrentThread();


### PR DESCRIPTION
I'm headed out of town, so I figured I'd go ahead and get some eyes on this and let some people start playing with it.

This is the start of cleanly handling intents on Android, so we can avoid a huge mess of jni as we start to do more.

Here, we add a new bridge that lets us call native from Java, which is much cleaner for more android-y interfaces like listeners and broadcasters.

Next step is to add functionality for waiting on messages, callbacks, etc, and to remove our jni code for sending intents in favor of adding it here.
