### PR TITLE
14119

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5012,7 +5012,7 @@ void CGUIInfoManager::SetCurrentSlide(CFileItem &item)
 {
   if (m_currentSlide->GetPath() != item.GetPath())
   {
-    if (!item.HasPictureInfoTag() && !item.GetPictureInfoTag()->Loaded())
+    if (!item.GetPictureInfoTag()->Loaded())  // Get metadata from file if not yet loaded
       item.GetPictureInfoTag()->Load(item.GetPath());
     *m_currentSlide = item;
   }

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -57,8 +57,8 @@ bool CPictureInfoTag::Load(const CStdString &path)
   /* Its possible that exiftime and resolution were already set externally */
   /* Retrieve them so they can be used if not found in file */
   if (m_isExternallyLoaded){
-	exiftime = GetInfo(TranslateString("exiftime"));
-	resolution = GetInfo(TranslateString("resolution"));
+    exiftime = GetInfo(TranslateString("exiftime"));
+    resolution = GetInfo(TranslateString("resolution"));
   }
   
   if (exifDll.process_jpeg(path.c_str(), &m_exifInfo, &m_iptcInfo))
@@ -610,14 +610,14 @@ void CPictureInfoTag::SetInfo(int info, const CStdString& value)
       {
         m_exifInfo.Width = atoi(dimension[0].c_str());
         m_exifInfo.Height = atoi(dimension[1].c_str());
-		m_isExternallyLoaded = true;
+        m_isExternallyLoaded = true;
       }
       break;
     }
   case SLIDE_EXIF_DATE_TIME:
     {
       strcpy(m_exifInfo.DateTime, value.c_str());
-	  m_isExternallyLoaded = true;
+      m_isExternallyLoaded = true;
       break;
     }
   default:

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -69,7 +69,7 @@ bool CPictureInfoTag::Load(const CStdString &path)
   if (m_isExternallyLoaded){
     if ((GetInfo(TranslateString("exiftime")) == "") && (exiftime != "")) 
       SetInfo(TranslateString("exiftime"),exiftime);
-	if ((GetInfo(TranslateString("resolution")) == "") && (resolution != "")) 
+    if ((GetInfo(TranslateString("resolution")) == "") && (resolution != "")) 
       SetInfo(TranslateString("resolution"),resolution);  
   }
   

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -53,7 +53,7 @@ bool CPictureInfoTag::Load(const CStdString &path)
   DllLibExif exifDll;
   if (path.IsEmpty() || !exifDll.Load())
     return false;
- 
+
   /* Its possible that exiftime and resolution were already set externally */
   /* Retrieve them so they can be used if not found in file */
   if (m_isExternallyLoaded){
@@ -68,9 +68,9 @@ bool CPictureInfoTag::Load(const CStdString &path)
   /* put the externally set metadata back in. */
   if (m_isExternallyLoaded){
     if ((GetInfo(TranslateString("exiftime")) == "") && (exiftime != "")) 
-	  SetInfo(TranslateString("exiftime"),exiftime);
+      SetInfo(TranslateString("exiftime"),exiftime);
 	if ((GetInfo(TranslateString("resolution")) == "") && (resolution != "")) 
-	  SetInfo(TranslateString("resolution"),resolution);  
+      SetInfo(TranslateString("resolution"),resolution);  
   }
   
   return m_isLoaded;

--- a/xbmc/pictures/PictureInfoTag.h
+++ b/xbmc/pictures/PictureInfoTag.h
@@ -107,5 +107,6 @@ private:
   ExifInfo_t m_exifInfo;
   IPTCInfo_t m_iptcInfo;
   bool       m_isLoaded;
+  bool       m_isExternallyLoaded; // Distiguish between loaded from file and loaded by external call to SetInfo
 };
 


### PR DESCRIPTION
These are the changes required to fix defect 14119 which I opened a few days ago.  The problem was that all of the $INFO[slideshow.*] variables were blank when used in SlideShow.xml.
There were two problems.
The first problem was an incorrect condition in an if statement in GUIInfoManager.cpp.  The condition was always false, so no metadata would be loaded from the picture file when going through this code path.  I fixed the condition.
The second problem was that when metadata was explicitly set using PictureInfoTag.SetInfo(), it would cause all future calls to load the metadata from the picture file to be ignored.  I created a new private variable to distinguish between setting metadata with SetInfo(), and setting metadata by loading it from the picture file.  I used the variable to allow loading of metadata from the picture file even after some metadata had been set using SetInfo().  The metadata provided by SetInfo() is used if it does not appear in the file.  If the data exists in the file, it overrides that provided by SetInfo().
