### PR TITLE
Create channels with m_bEPGEnabled set to false for hidden channels

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -99,7 +99,7 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL &channel, unsigned int iClientId)
   m_strFileNameAndPath      = StringUtils::EmptyString;
   m_bIsVirtual              = false;
   m_iLastWatched            = 0;
-  m_bEPGEnabled             = true;
+  m_bEPGEnabled             = !channel.bIsHidden;
   m_strEPGScraper           = "client";
   m_iEpgId                  = -1;
   m_bEPGCreated             = false;

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -268,6 +268,7 @@ bool CPVRChannel::SetHidden(bool bIsHidden)
   {
     /* update the hidden flag */
     m_bIsHidden = bIsHidden;
+	m_bEPGEnabled = !bIsHidden;
     SetChanged();
     m_bChanged = true;
 


### PR DESCRIPTION
When first creating a channel, set m_bEPGEnabled to !channel.bIsHidden.
This enables the EPG scanner to only work on visible channels as
default, thereby reducing scan time, especially important on setups with
thousands of available channels, but with only a limited set visible.
