### PR TITLE
[IOS] Fix ios gesture end event not sent problem when gesture canceled

### DIFF
--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -159,6 +159,17 @@ extern NSString* kBRScreenSaverDismissed;
 //--------------------------------------------------------------
 - (void)createGestureRecognizers 
 {
+  //1 finger single tab - left mouse
+  UITapGestureRecognizer *singleFingerSingleTap = [[UITapGestureRecognizer alloc]
+                                                   initWithTarget:self action:@selector(handleSingleFingerSingleTap:)];
+
+  singleFingerSingleTap.delaysTouchesBegan = YES;
+  singleFingerSingleTap.numberOfTapsRequired = 1;
+  singleFingerSingleTap.numberOfTouchesRequired = 1;
+
+  [m_glView addGestureRecognizer:singleFingerSingleTap];
+  [singleFingerSingleTap release];
+
   //2 finger single tab - right mouse
   //single finger double tab delays single finger single tab - so we
   //go for 2 fingers here - so single finger single tap is instant
@@ -366,6 +377,36 @@ extern NSString* kBRScreenSaverDismissed;
   CWinEventsIOS::MessagePush(&newEvent);
 }
 //--------------------------------------------------------------
+- (IBAction)handleSingleFingerSingleTap:(UIGestureRecognizer *)sender 
+{
+  if( [m_glView isXBMCAlive] )//NO GESTURES BEFORE WE ARE UP AND RUNNING
+  {
+    CGPoint point = [sender locationOfTouch:0 inView:m_glView];
+    point.x *= screenScale;
+    point.y *= screenScale;
+    //NSLog(@"%s singleTap", __PRETTY_FUNCTION__);
+
+    [self postMouseMotionEvent:point];
+
+    XBMC_Event newEvent;
+    memset(&newEvent, 0, sizeof(newEvent));
+
+    newEvent.type = XBMC_MOUSEBUTTONDOWN;
+    newEvent.button.type = XBMC_MOUSEBUTTONDOWN;
+    newEvent.button.button = XBMC_BUTTON_LEFT;
+    newEvent.button.x = point.x;
+    newEvent.button.y = point.y;
+
+    CWinEventsIOS::MessagePush(&newEvent);
+
+    newEvent.type = XBMC_MOUSEBUTTONUP;
+    newEvent.button.type = XBMC_MOUSEBUTTONUP;
+    CWinEventsIOS::MessagePush(&newEvent);
+
+    memset(&lastEvent, 0x0, sizeof(XBMC_Event));
+  }
+}
+//--------------------------------------------------------------
 - (IBAction)handleDoubleFingerSingleTap:(UIGestureRecognizer *)sender 
 {
   if( [m_glView isXBMCAlive] )//NO GESTURES BEFORE WE ARE UP AND RUNNING
@@ -411,62 +452,6 @@ extern NSString* kBRScreenSaverDismissed;
     if (sender.state == UIGestureRecognizerStateEnded)
     {
       [self handleDoubleFingerSingleTap:sender];
-    }
-  }
-}
-//--------------------------------------------------------------
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event 
-{
-  if( [m_glView isXBMCAlive] )//NO GESTURES BEFORE WE ARE UP AND RUNNING
-  {
-    UITouch *touch = [touches anyObject];
-    
-    if( [touches count] == 1 && [touch tapCount] == 1)
-    {
-      lastGesturePoint = [touch locationInView:m_glView];    
-      lastGesturePoint.x *= screenScale;
-      lastGesturePoint.y *= screenScale;  
-      [self postMouseMotionEvent:lastGesturePoint];//selects the current control
-
-      XBMC_Event newEvent;
-      memset(&newEvent, 0, sizeof(newEvent));
-      
-      newEvent.type = XBMC_MOUSEBUTTONDOWN;
-      newEvent.button.type = XBMC_MOUSEBUTTONDOWN;
-      newEvent.button.button = XBMC_BUTTON_LEFT;
-      newEvent.button.x = lastGesturePoint.x;
-      newEvent.button.y = lastGesturePoint.y;  
-      CWinEventsIOS::MessagePush(&newEvent);    
-      
-      /* Store the tap action for later */
-      lastEvent = newEvent;
-    }
-  }
-}
-//--------------------------------------------------------------
-- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event 
-{
-  
-}
-//--------------------------------------------------------------
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event 
-{
-  if( [m_glView isXBMCAlive] )//NO GESTURES BEFORE WE ARE UP AND RUNNING
-  {
-    UITouch *touch = [touches anyObject];
-    
-    if( [touches count] == 1 && [touch tapCount] == 1 )
-    {
-      XBMC_Event newEvent = lastEvent;
-      
-      newEvent.type = XBMC_MOUSEBUTTONUP;
-      newEvent.button.type = XBMC_MOUSEBUTTONUP;
-      newEvent.button.button = XBMC_BUTTON_LEFT;
-      newEvent.button.x = lastGesturePoint.x;
-      newEvent.button.y = lastGesturePoint.y;
-      CWinEventsIOS::MessagePush(&newEvent);
-      
-      memset(&lastEvent, 0x0, sizeof(XBMC_Event));     
     }
   }
 }

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -260,6 +260,7 @@ extern NSString* kBRScreenSaverDismissed;
                                                                    [sender scale], 0), WINDOW_INVALID,false);
         break;
       case UIGestureRecognizerStateEnded:
+      case UIGestureRecognizerStateCancelled:
         CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_END, 0, 0, 0,
                                                         0, 0), WINDOW_INVALID,false);
         break;
@@ -347,6 +348,12 @@ extern NSString* kBRScreenSaverDismissed;
       CGPoint velocity = [sender velocityInView:m_glView];
       //signal end of pan - this will start inertial scrolling with deacceleration in CApplication
       CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_END, 0, (float)velocity.x, (float)velocity.y, (int)lastGesturePoint.x, (int)lastGesturePoint.y),WINDOW_INVALID,false);
+      touchBeginSignaled = false;
+    }
+    else if( touchBeginSignaled && [sender state] == UIGestureRecognizerStateCancelled )
+    {
+      CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_END, 0, 0, 0,
+                                                      0, 0), WINDOW_INVALID,false);
       touchBeginSignaled = false;
     }
   }


### PR DESCRIPTION
this pr include 2 commits:
1. Change to use gesture recognizer to handle single tap. this will fix the xbmc home button strange behavior after xbmc was backgrounded by 4 finger minimize gesture then came back. what caused the problem is: the 4 finger minimize gesture trigger the single touch begin event which send mouse left down event to xbmc, but after xbmc backgrounded and come back, no mouse up event sent to xbmc, which cause xbmc consider mouse is in pressed state, then the xbmc home button not react.
2. Handle gesture canceled notification and send gesture end event to xbmc. This fix the bottom screen buttons no reaction problem after xbmc was backgrounded by 4 finger minimize gesture or 4 finger swipe up gesture.
