### PR TITLE
Fix resume playback from playlist does not work (trac 13929)

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -68,7 +68,7 @@ bool CPlayListPlayer::OnMessage(CGUIMessage &message)
     if (message.GetParam1() == GUI_MSG_UPDATE_ITEM && message.GetItem())
     {
       // update the items in our playlist(s) if necessary
-      for (int i = PLAYLIST_MUSIC; i != PLAYLIST_VIDEO; i++)
+      for (int i = PLAYLIST_MUSIC; i <= PLAYLIST_VIDEO; i++)
       {
         CPlayList &playlist = GetPlaylist(i);
         CFileItemPtr item = boost::static_pointer_cast<CFileItem>(message.GetItem());

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -490,7 +490,9 @@ void CPlayList::UpdateItem(const CFileItem *item)
     CFileItemPtr playlistItem = *it;
     if (playlistItem->IsSamePath(item))
     {
+      CStdString temp = playlistItem->GetPath(); // save path, it may have been altered
       *playlistItem = *item;
+      playlistItem->SetPath(temp);
       break;
     }
   }

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -330,6 +330,15 @@ bool CGUIWindowVideoPlaylist::OnPlayMedia(int iItem)
     CFileItemPtr pItem = m_vecItems->Get(iItem);
     CStdString strPath = pItem->GetPath();
     g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
+    // need to update Playlist FileItem's startOffset and resumePoint based on GUIWindowVideoPlaylist FileItem
+    if (pItem->m_lStartOffset == STARTOFFSET_RESUME)
+    {
+      CFileItemPtr pPlaylistItem = g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO)[iItem];
+      pPlaylistItem->m_lStartOffset = pItem->m_lStartOffset;
+      if (pPlaylistItem->HasVideoInfoTag() && pItem->HasVideoInfoTag())
+        pPlaylistItem->GetVideoInfoTag()->m_resumePoint = pItem->GetVideoInfoTag()->m_resumePoint;
+    }
+    // now play item
     g_playlistPlayer.Play( iItem );
   }
   return true;


### PR DESCRIPTION
It appears that the root cause is that playlist GUI uses copies of the FileItem objects that are in the playlist. The result of this that the resumepoint and startoffset are set in the wrong place (the "gui" copy item) and then the playlistplayer starts the playback of the actual playlist (library) item, which does not have these values set...

Next to the problem described in the ticket (cannot resume in playlist), once fixed, this has the additional effect that when playback of a movie via the library, the resume point in the playlist GUI "playing now..." is out of date, because it does not get refreshed.
