### PR TITLE
Fixes for bug 14119

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5012,7 +5012,7 @@ void CGUIInfoManager::SetCurrentSlide(CFileItem &item)
 {
   if (m_currentSlide->GetPath() != item.GetPath())
   {
-    if (!item.HasPictureInfoTag() && !item.GetPictureInfoTag()->Loaded())
+    if (!item.GetPictureInfoTag()->Loaded()) // If picture metadata has not been loaded yet, load it now
       item.GetPictureInfoTag()->Load(item.GetPath());
     *m_currentSlide = item;
   }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -442,7 +442,6 @@ namespace XBMCAddon
       }
       else if (strcmpi(type,"pictures") == 0)
       {
-        bool pictureTagLoaded = false;
         for (Dictionary::const_iterator it = infoLabels.begin(); it != infoLabels.end(); it++)
         {
           CStdString key = it->first;
@@ -468,11 +467,8 @@ namespace XBMCAddon
             if (!exifkey.Left(5).Equals("exif:") || exifkey.length() < 6) continue;
             int info = CPictureInfoTag::TranslateString(exifkey.Mid(5));
             item->GetPictureInfoTag()->SetInfo(info, value);
-            pictureTagLoaded = true;
           }
         }
-        if (pictureTagLoaded)
-          item->GetPictureInfoTag()->SetLoaded(true);
       }
     } // end ListItem::setInfo
 

--- a/xbmc/pictures/PictureInfoTag.h
+++ b/xbmc/pictures/PictureInfoTag.h
@@ -100,12 +100,12 @@ public:
   static int TranslateString(const CStdString &info);
 
   void SetInfo(int info, const CStdString& value);
-  void SetLoaded(bool loaded = true);
 
 private:
   void GetStringFromArchive(CArchive &ar, char *string, size_t length);
   ExifInfo_t m_exifInfo;
   IPTCInfo_t m_iptcInfo;
-  bool       m_isLoaded;
+  bool       m_isLoaded;             // Set to true if metadata has been loaded from the picture file successfully
+  bool       m_isInfoSetExternally;  // Set to true if metadata has been set by an external call to SetInfo
 };
 


### PR DESCRIPTION
These are the changes required to fix defect 14119 which I opened a few days ago. The problem was that all of the $INFO[slideshow.*] variables were blank when used in SlideShow.xml.
There were two problems.
The first problem was an incorrect condition in an if statement in GUIInfoManager.cpp. The condition tried to use a pointer only if the pointer was NOT set.  It should have tried to use the pointer only if it WAS set.  I fixed the condition. 

The second problem was that when metadata was explicitly set using PictureInfoTag.SetInfo(), it would cause all future calls to load the metadata from the picture file to be ignored. I created a new private variable to distinguish between setting metadata with SetInfo(), and setting metadata by loading it from the picture file. I used the variable to allow loading of metadata from the picture file even after some metadata had been set using SetInfo(). The metadata provided by SetInfo() is used if it does not appear in the file. If the data exists in the file, it overrides that provided by SetInfo().

The only two pieces of metadata accepted by PictureInfoTag.SetInfo() are "exiftime" and "resolution". If SetInfo() is called with any value other than those two, nothing happens. I think this is to handle the case where pictures were created using a scanner rather than a camera. An addon can get the info from the file attributes, then call SetInfo to make sure the picture has at least those two useful pieces of metadata.
