### PR TITLE
[IOS] Fix long press gesture send mouse right down/up/move event correctly

### DIFF
--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -400,17 +400,39 @@ extern NSString* kBRScreenSaverDismissed;
 {
   if( [m_glView isXBMCAlive] )//NO GESTURES BEFORE WE ARE UP AND RUNNING
   {
+    CGPoint point = [sender locationOfTouch:0 inView:m_glView];
+    point.x *= screenScale;
+    point.y *= screenScale;
     if (sender.state == UIGestureRecognizerStateBegan)
     {
-      CGPoint point = [sender locationOfTouch:0 inView:m_glView];
-      point.x *= screenScale;
-      point.y *= screenScale;
       [self postMouseMotionEvent:point];//selects the current control
-    }
+      XBMC_Event newEvent;
+      memset(&newEvent, 0, sizeof(newEvent));
 
-    if (sender.state == UIGestureRecognizerStateEnded)
+      newEvent.type = XBMC_MOUSEBUTTONDOWN;
+      newEvent.button.type = XBMC_MOUSEBUTTONDOWN;
+      newEvent.button.button = XBMC_BUTTON_RIGHT;
+      newEvent.button.x = point.x;
+      newEvent.button.y = point.y;
+
+      CWinEventsIOS::MessagePush(&newEvent);
+    }
+    else if (sender.state == UIGestureRecognizerStateChanged)
     {
-      [self handleDoubleFingerSingleTap:sender];
+      [self postMouseMotionEvent:point];
+    }
+    else if (sender.state == UIGestureRecognizerStateEnded)
+    {
+      XBMC_Event newEvent;
+      memset(&newEvent, 0, sizeof(newEvent));
+
+      newEvent.type = XBMC_MOUSEBUTTONUP;
+      newEvent.button.type = XBMC_MOUSEBUTTONUP;
+      newEvent.button.button = XBMC_BUTTON_RIGHT;
+      newEvent.button.x = point.x;
+      newEvent.button.y = point.y;
+
+      CWinEventsIOS::MessagePush(&newEvent);
     }
   }
 }


### PR DESCRIPTION
Currently, long press gesture only send out event when press finished, it not accurate like a mouse event style.
This commit fix it by separate send mouse down, mouse move, and mouse up event by the gesture state type.
there was a scrolling problem after a swipe: old code triggered only a long press event after press released, but not trace the press move progress if then user continue to scroll. this commit also fixed this.
