### PR TITLE
[IOS] Fix and unify postMouseMotionEvent use scaled point position.

### DIFF
--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -353,9 +353,6 @@ extern NSString* kBRScreenSaverDismissed;
 {
   XBMC_Event newEvent;
 
-  point.x *= screenScale;
-  point.y *= screenScale;
-
   memset(&newEvent, 0, sizeof(newEvent));
 
   newEvent.type = XBMC_MOUSEMOTION;
@@ -406,6 +403,8 @@ extern NSString* kBRScreenSaverDismissed;
     if (sender.state == UIGestureRecognizerStateBegan)
     {
       CGPoint point = [sender locationOfTouch:0 inView:m_glView];
+      point.x *= screenScale;
+      point.y *= screenScale;
       [self postMouseMotionEvent:point];//selects the current control
     }
 
@@ -425,10 +424,10 @@ extern NSString* kBRScreenSaverDismissed;
     if( [touches count] == 1 && [touch tapCount] == 1)
     {
       lastGesturePoint = [touch locationInView:m_glView];    
-      [self postMouseMotionEvent:lastGesturePoint];//selects the current control
-
       lastGesturePoint.x *= screenScale;
       lastGesturePoint.y *= screenScale;  
+      [self postMouseMotionEvent:lastGesturePoint];//selects the current control
+
       XBMC_Event newEvent;
       memset(&newEvent, 0, sizeof(newEvent));
       


### PR DESCRIPTION
there are 3 places using postMouseMotionEvent not unify, some use scaled point pos, some not use unscaled pos.
Here I unified it all use scaled point pos to call postMouseMotionEvent.
