### PR TITLE
Correct Player.PlayPause behavior

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -230,7 +230,14 @@ JSONRPC_STATUS CPlayerOperations::PlayPause(const CStdString &method, ITransport
         CBuiltins::Execute("playercontrol(play)");
       else
       {
-        if (parameterObject["play"].asBoolean() == g_application.IsPaused())
+        if (parameterObject["play"].asBoolean())
+        {
+          if (g_application.IsPaused())
+            CApplicationMessenger::Get().MediaPause();
+          else if (g_application.GetPlaySpeed() != 1)
+            g_application.SetPlaySpeed(1);
+        }
+        else if (!g_application.IsPaused())
           CApplicationMessenger::Get().MediaPause();
       }
       result["speed"] = g_application.IsPaused() ? 0 : g_application.GetPlaySpeed();

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://www.xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.0.1";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.0.2";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  


### PR DESCRIPTION
In current implementation using play parameter as boolean won't force the playerspeed to 1 as it should.
This PR correct this so that using a bool parameter act the same as the toggle and provide the same behavior as GUI or EventServer.

@montellese for review
