### PR TITLE
Fix redirected shoutcast ticket 12729

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -575,6 +575,13 @@ void CCurlFile::SetCommonOptions(CReadState* state)
 
   // Set the lowspeed time very low as it seems Curl takes much longer to detect a lowspeed condition
   g_curlInterface.easy_setopt(h, CURLOPT_LOW_SPEED_TIME, m_lowspeedtime);
+
+  if (m_skipshout)
+    // For shoutcast file, content-length should not be set, and in libcurl there is a bug, if the
+    // cast file was 302 redirected then getinfo of CURLINFO_CONTENT_LENGTH_DOWNLOAD will return
+    // the 302 response's body length, which cause the next read request failed, so we ignore
+    // content-length for shoutcast file to workaround this.
+    g_curlInterface.easy_setopt(h, CURLOPT_IGNORE_CONTENT_LENGTH, 1);
 }
 
 void CCurlFile::SetRequestHeaders(CReadState* state)

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -134,6 +134,7 @@ void CShoutcastFile::Close()
 {
   StopThread();
   delete[] m_buffer;
+  m_buffer = NULL;
   m_file.Close();
 }
 


### PR DESCRIPTION
First commit fix a delete crash when testing ticket 12729, caused by buffer pointer not set to NULL after delete.

Second commit fix ticket 12729 by tell libcurl ignore content-length of shoutcast file.:
When the shoutcast file was 302 redirected, libcurl may return the content-length of the 302 page's body, it cause next read return 0.
