### PR TITLE
refresh the correct video viewed in the video info dialog (fixes #13676)

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -456,6 +456,14 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
     needsRefresh = pDlgInfo->NeedRefresh();
     if (!needsRefresh)
       return pDlgInfo->HasUpdatedThumb();
+    // check if the item in the video info dialog has changed and if so, get the new item
+    else if (pDlgInfo->GetCurrentListItem() != NULL)
+    {
+      item = pDlgInfo->GetCurrentListItem().get();
+
+      if (item->IsVideoDb() && item->HasVideoInfoTag())
+        item->SetPath(item->GetVideoInfoTag()->GetPath());
+    }
   }
 
   // quietly return if Internet lookups are disabled


### PR DESCRIPTION
This change fixes http://trac.xbmc.org/ticket/13676. The issue at hand is that if a user opens another video from the video info dialog without going back to the list of video items, we refresh the wrong video item (the one we used to open the video info dialog). The change grabs the CFileItem instance from the dialog if it needs to perform a refresh. I wanted to use the CFileItem's path as a comparison to determine whether the item has changed but that's not possible because the item we get from CVideoInfoDialog has a videodb:// path whereas the item we passed in has the file's real path.

I don't think this solution is ideal but as long as the whole update procedure is so tied into the whole GUI logic it's probably the least impact change to solve the problem.
