### PR TITLE
video library: fix handling of watched episode count in custom tvshow nodes

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1721,7 +1721,7 @@ void CFileItemList::Assign(const CFileItemList& itemlist, bool append)
   m_cacheToDisc = itemlist.m_cacheToDisc;
 }
 
-bool CFileItemList::Copy(const CFileItemList& items)
+bool CFileItemList::Copy(const CFileItemList& items, bool copyItems /* = true */)
 {
   // assign all CFileItem parts
   *(CFileItem*)this = *(CFileItem*)&items;
@@ -1736,11 +1736,14 @@ bool CFileItemList::Copy(const CFileItemList& items)
   m_sortOrder      = items.m_sortOrder;
   m_sortIgnoreFolders = items.m_sortIgnoreFolders;
 
-  // make a copy of each item
-  for (int i = 0; i < items.Size(); i++)
+  if (copyItems)
   {
-    CFileItemPtr newItem(new CFileItem(*items[i]));
-    Add(newItem);
+    // make a copy of each item
+    for (int i = 0; i < items.Size(); i++)
+    {
+      CFileItemPtr newItem(new CFileItem(*items[i]));
+      Add(newItem);
+    }
   }
 
   return true;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -475,7 +475,7 @@ public:
   bool IsEmpty() const;
   void Append(const CFileItemList& itemlist);
   void Assign(const CFileItemList& itemlist, bool append = false);
-  bool Copy  (const CFileItemList& item);
+  bool Copy  (const CFileItemList& item, bool copyItems = true);
   void Reserve(int iCount);
   void Sort(SORT_METHOD sortMethod, SortOrder sortOrder);
   /* \brief Sorts the items based on the given sorting options

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1649,7 +1649,8 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
     filterWatched = true;
   if (!items.IsVideoDb())
     filterWatched = true;
-  if (items.IsSmartPlayList() && items.GetContent() == "tvshows")
+  if (items.GetContent() == "tvshows" &&
+     (items.IsSmartPlayList() || (items.HasProperty("library.filter") && items.GetProperty("library.filter").asBoolean())))
     node = NODE_TYPE_TITLE_TVSHOWS; // so that the check below works
 
   int watchMode = g_settings.GetWatchMode(m_vecItems->GetContent());

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1686,7 +1686,8 @@ void CGUIMediaWindow::OnFilterItems(const CStdString &filter)
   
   m_viewControl.Clear();
   
-  CFileItemList items(m_vecItems->GetPath()); // use the original path - it'll likely be relied on for other things later.
+  CFileItemList items;
+  items.Copy(*m_vecItems, false); // use the original path - it'll likely be relied on for other things later.
   items.Append(*m_unfilteredItems);
   bool filtered = GetFilteredItems(filter, items);
 


### PR DESCRIPTION
This fixes http://trac.xbmc.org/ticket/14097. The problem is that for custom tvshow nodes, the number of available episodes isn't properly updated when changing the watched filter. The reason for this is that the CFileItemList instance that we pass to GetFilteredItems() does not have m_content set and that CGUIWindowVideoNav::ApplyWatchedFilter() is missing the logic to handle custom video nodes (but the logic for smartplaylists is there).

To make sure m_content is set, I copy all the properties of the original CFileItemList in CGUIMediaWindow into the list to be filtered and pass it on to GetFilteredItems() which also calls CGUIWindowVideoNav::ApplyWatchedFilter(). There I extended the smartplaylist tvshow handling logic to also apply for custom video nodes (which is basically a smartplaylist but not recognised as such by CFileItem::IsSmartPlaylist() because of the different file path).
