### PR TITLE
jsonrpc: fix (odd) paths being passed to builtins methods

### DIFF
--- a/xbmc/Favourites.cpp
+++ b/xbmc/Favourites.cpp
@@ -25,6 +25,7 @@
 #include "FileItem.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "video/VideoInfoTag.h"
@@ -148,37 +149,20 @@ bool CFavourites::IsFavourite(CFileItem *item, int contextWindow)
   return items.Contains(GetExecutePath(item, contextWindow));
 }
 
-static CStdString Paramify(const CStdString& param)
-{
-  CStdString result(param);
-  result.Replace("\\", "\\\\");
-  result.Replace("\"", "\\\"");
-  return "\"" + result + "\"";
-}
-
-#ifdef UNIT_TESTING
-bool CFavourites::TestParamify()
-{
-  return (Paramify("test") == "\"test\"" &&
-          Paramify("test\"foo\"test") == "\"test\\\"foo\\\"test\"" &&
-          Paramify("C:\\foo\\bar\\") == "\"C:\\\\foo\\\\bar\\\\\"");
-}
-#endif
-
 CStdString CFavourites::GetExecutePath(const CFileItem *item, int contextWindow)
 {
   CStdString execute;
   if (item->m_bIsFolder && (g_advancedSettings.m_playlistAsFolders ||
                             !(item->IsSmartPlayList() || item->IsPlayList())))
-    execute.Format("ActivateWindow(%i,%s)", contextWindow, Paramify(item->GetPath()));
+    execute.Format("ActivateWindow(%i,%s)", contextWindow, StringUtils::Paramify(item->GetPath()).c_str());
   else if (item->IsScript())
-    execute.Format("RunScript(%s)", Paramify(item->GetPath().Mid(9)));
+    execute.Format("RunScript(%s)", StringUtils::Paramify(item->GetPath().Mid(9)).c_str());
   else  // assume a media file
   {
     if (item->IsVideoDb() && item->HasVideoInfoTag())
-      execute.Format("PlayMedia(%s)", Paramify(item->GetVideoInfoTag()->m_strFileNameAndPath));
+      execute.Format("PlayMedia(%s)", StringUtils::Paramify(item->GetVideoInfoTag()->m_strFileNameAndPath).c_str());
     else
-      execute.Format("PlayMedia(%s)", Paramify(item->GetPath()));
+      execute.Format("PlayMedia(%s)", StringUtils::Paramify(item->GetPath()).c_str());
   }
   return execute;
 }

--- a/xbmc/Favourites.h
+++ b/xbmc/Favourites.h
@@ -33,11 +33,6 @@ public:
   static bool AddOrRemove(CFileItem *item, int contextWindow);
   static bool Save(const CFileItemList& items);
   static bool IsFavourite(CFileItem *item, int contextWindow);
-
-#ifdef UNIT_TESTING
-  static bool TestParamify();
-#endif
-
 private:
   static CStdString GetExecutePath(const CFileItem *item, int contextWindow);
 };

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -27,6 +27,7 @@
 #include "ApplicationMessenger.h"
 #include "TextureCache.h"
 #include "filesystem/File.h"
+#include "utils/StringUtils.h"
 
 using namespace std;
 using namespace JSONRPC;
@@ -187,7 +188,7 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const CStdString &method, ITransp
     {
       if (it != params.begin_array())
         argv += ",";
-      argv += it->asString();
+      argv += StringUtils::Paramify(it->asString());
     }
   }
   

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -22,6 +22,7 @@
 #include "music/MusicDatabase.h"
 #include "FileItem.h"
 #include "Util.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/Artist.h"
@@ -531,7 +532,7 @@ JSONRPC_STATUS CAudioLibrary::Scan(const CStdString &method, ITransportLayer *tr
   if (directory.empty())
     cmd = "updatelibrary(music)";
   else
-    cmd.Format("updatelibrary(music, %s)", directory.c_str());
+    cmd.Format("updatelibrary(music, %s)", StringUtils::Paramify(directory).c_str());
 
   CApplicationMessenger::Get().ExecBuiltIn(cmd);
   return ACK;
@@ -541,7 +542,7 @@ JSONRPC_STATUS CAudioLibrary::Export(const CStdString &method, ITransportLayer *
 {
   CStdString cmd;
   if (parameterObject["options"].isMember("path"))
-    cmd.Format("exportlibrary(music, false, %s)", parameterObject["options"]["path"].asString());
+    cmd.Format("exportlibrary(music, false, %s)", StringUtils::Paramify(parameterObject["options"]["path"].asString()));
   else
     cmd.Format("exportlibrary(music, true, %s, %s)",
       parameterObject["options"]["images"].asBoolean() ? "true" : "false",

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://www.xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.0.2";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.0.3";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -22,6 +22,7 @@
 #include "ApplicationMessenger.h"
 #include "TextureCache.h"
 #include "Util.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
 
@@ -654,7 +655,7 @@ JSONRPC_STATUS CVideoLibrary::Scan(const CStdString &method, ITransportLayer *tr
   if (directory.empty())
     cmd = "updatelibrary(video)";
   else
-    cmd.Format("updatelibrary(video, %s)", directory.c_str());
+    cmd.Format("updatelibrary(video, %s)", StringUtils::Paramify(directory).c_str());
 
   CApplicationMessenger::Get().ExecBuiltIn(cmd);
   return ACK;
@@ -664,7 +665,7 @@ JSONRPC_STATUS CVideoLibrary::Export(const CStdString &method, ITransportLayer *
 {
   CStdString cmd;
   if (parameterObject["options"].isMember("path"))
-    cmd.Format("exportlibrary(video, false, %s)", parameterObject["options"]["path"].asString());
+    cmd.Format("exportlibrary(video, false, %s)", StringUtils::Paramify(parameterObject["options"]["path"].asString()));
   else
     cmd.Format("exportlibrary(video, true, %s, %s, %s)",
       parameterObject["options"]["images"].asBoolean() ? "true" : "false",

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -679,3 +679,15 @@ size_t StringUtils::utf8_strlen(const char *s)
   }
   return length;
 }
+
+std::string StringUtils::Paramify(const std::string &param)
+{
+  std::string result = param;
+  // escape backspaces
+  StringUtils::Replace(result, "\\", "\\\\");
+  // escape double quotes
+  StringUtils::Replace(result, "\"", "\\\"");
+
+  // add double quotes around the whole string
+  return "\"" + result + "\"";
+}

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -114,6 +114,16 @@ public:
   static bool ValidateUUID(const CStdString &uuid); // NB only validates syntax
   static double CompareFuzzy(const CStdString &left, const CStdString &right);
   static int FindBestMatch(const CStdString &str, const CStdStringArray &strings, double &matchscore);
+
+  /*! \brief Escapes the given string to be able to be used as a parameter.
+
+   Escapes backslashes and double-quotes with an additional backslash and
+   adds double-quotes around the whole string.
+
+   \param param String to escape/paramify
+   \return Escaped/Paramified string
+   */
+  static std::string Paramify(const std::string &param);
 private:
   static CStdString m_lastUUID;
 };

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -462,3 +462,12 @@ TEST(TestStringUtils, FindBestMatch)
   EXPECT_EQ(refint, varint);
   EXPECT_EQ(refdouble, vardouble);
 }
+
+TEST(TestStringUtils, Paramify)
+{
+  const char *input = "some, very \\ odd \"string\"";
+  const char *ref   = "\"some, very \\\\ odd \\\"string\\\"\"";
+
+  std::string result = StringUtils::Paramify(input);
+  EXPECT_STREQ(ref, result.c_str());
+}


### PR DESCRIPTION
This is an attempt to fix http://trac.xbmc.org/ticket/14066. The problem is that JSON-RPC simply takes paths/strings passed in as parameters and passes them on to CBuiltins as string parameters. If a path contains a , (which is used as a separator for parameters) or a double quote (which is used to delimit a string), the call results in unexpected behaviour because the path/string parameter is not properly parsed by CBuiltins.

This fix adds an Escape() method to CBuiltins which escapes all backslashes and double quotes in a string with a backslash and adds double-quotes around the whole string. That way the resulting string can be safely passed as a parameter to any builtins method.

Can anyone think of other special characters that need escaping or special treatment or is this enough?
