### PR TITLE
Make TvDB Scraper aware of multiple languages per TV show.

### DIFF
--- a/addons/metadata.tvdb.com/tvdb.xml
+++ b/addons/metadata.tvdb.com/tvdb.xml
@@ -2,7 +2,7 @@
 <!-- should be self-explanatory -->
 <scraper framework="1.1" date="2009-01-27">
 	<NfoUrl dest="3">
-		<RegExp input="$$1" output="&lt;url cache=&quot;\1.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;" dest="3">
 			<expression>http://(?:www\.)?thetvdb.com/(?:index\.php)?\?tab=series&amp;id=([0-9]+)</expression>
 		</RegExp>
 		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;tt\1.xml&quot; function=&quot;GetTVDBId&quot;&gt;http://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=tt\1&amp;amp;language=$INFO[language]&lt;/url&gt;&lt;/details&gt;" dest="3+">
@@ -14,7 +14,7 @@
 	</NfoUrl>
 
 	<GetTVDBId dest="3">
-		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;details&gt;&lt;url cache=&quot;\1-$INFO[language].xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/details&gt;" dest="3">
 			<expression>&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;</expression>
 		</RegExp>
 	</GetTVDBId>
@@ -31,7 +31,7 @@
 	<!-- input:	$1=query string -->
 	<!-- returns:	the url we should use to do the search -->
 	<CreateSearchUrl dest="3">
-		<RegExp input="$$1" output="&lt;url&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
+		<RegExp input="$$1" output="&lt;url cache=&quot;cache-\1$$4.xml&quot;&gt;http://www.thetvdb.com/api/GetSeries.php?seriesname=\1$$4&amp;amp;language=$INFO[language]&lt;/url&gt;" dest="3">
 			<RegExp input="$$2" output="%20(\1)" dest="4">
 				<expression clear="yes">(.+)</expression>
 			</RegExp>
@@ -43,7 +43,7 @@
 	<!-- returns:	results in xml format <results><movie><title>*</title><url>*</url>*#urls<extra>*</extra></movie>*</results> -->
 	<GetSearchResults dest="1">
 		<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="1">
-			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/\2.zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
+			<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\3&lt;/title&gt;&lt;language&gt;\2&lt;/language&gt;&lt;url cache=&quot;\1-\2.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/\2.zip&lt;/url&gt;&lt;id&gt;\1&lt;/id&gt;&lt;/entity&gt;" dest="4">
 				<expression repeat="yes">&lt;seriesid&gt;([0-9]*)&lt;/seriesid&gt;[^&lt;]*&lt;language&gt;([^&lt;]*)&lt;/language&gt;[^&lt;]*&lt;SeriesName&gt;([^&lt;]*)&lt;/SeriesName&gt;</expression>
 			</RegExp>
 			<expression noclean="1"/>
@@ -144,7 +144,7 @@
 				</RegExp>
 				<expression noclean="1"/>
 			</RegExp>
-			<RegExp input="$$2" output="&lt;episodeguide&gt;&lt;url cache=&quot;$$2.xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;/episodeguide&gt;" dest="4+">
+			<RegExp input="$$2" output="&lt;episodeguide&gt;&lt;url cache=&quot;$$2-$INFO[language].xml&quot;&gt;http://www.thetvdb.com/api/1D62F2F90030C444/series/\1/all/$INFO[language].zip&lt;/url&gt;&lt;/episodeguide&gt;" dest="4+">
 				<expression/>
 			</RegExp>
 			<expression noclean="1"/>
@@ -156,7 +156,7 @@
 	<!-- returns:	results in xml format <episodeguide><episode><title>*</title><url>*</url><season>*</season><epnum>*</epnum><thumb>*</thumb><id>*</id><aired>*</aired></episode>*</episodeguide> !-->
 	<GetEpisodeList dest="3">
 		<RegExp input="$$4" output="&lt;episodeguide&gt;\1&lt;/episodeguide&gt;" dest="3">
-			<RegExp input="$$2" output="\2" dest="10">
+			<RegExp input="$$2" output="\2-\3" dest="10">
 				<expression>http://(?:www\.)thetvdb.com/api/(.+)/series/([0-9]*)/all/(.+).zip</expression>
 			</RegExp>
 			<RegExp conditional="!dvdorder">


### PR DESCRIPTION
Fixes caching of TVDB data. Fixes http://trac.xbmc.org/ticket/13621, which CAN be reproduced.

Episode information is downloaded from thedvdb.com an URL like this:
- http://www.thetvdb.com/api/.../series/134241/all/en.zip
- http://www.thetvdb.com/api/.../series/134241/all/de.zip

But the downloaded file is put into the cache as just "134241.zip" -- regardless of the language. So what happen is: When you do scraping once with "en", the english zip file is downloaded and cached. After you switch to "de", the german zip file is requested, but since it uses the same cache file name as before, the english one is used.

The fix is simple: Add language to the cached file name.
- 134241-en.zip
- 134241-de.zip

In my setup, I have two TV-Show directories, one set up for tvdb-scraping using "en" and another one with "de". For some shows, there are both english and german versions, which now are both correctly scraped.
