### PR TITLE
RssFeeds feedburner feed died?

### DIFF
--- a/userdata/RssFeeds.xml
+++ b/userdata/RssFeeds.xml
@@ -3,6 +3,6 @@
   <!-- RSS feeds. To have multiple feeds, just add a feed to the set. You can also have multiple sets. 	!-->
   <!-- To use different sets in your skin, each must be called from skin with a unique id.             	!-->
   <set id="1">
-    <feed updateinterval="30">http://feeds.feedburner.com/xbmc</feed>
+    <feed updateinterval="30">http://xbmc.org/feed/</feed>
   </set>
 </rssfeeds>


### PR DESCRIPTION
http://feeds.feedburner.com/xbmc is showing outdated feeds from NOv 2011
so feedburner is gonner.

http://xbmc.org/feed/ seems to be working ok so change to use this as it seems to work fine everywhere.
