### PR TITLE
[droid] attach/detach the jvm using thread storage

### DIFF
--- a/xbmc/android/activity/AndroidFeatures.cpp
+++ b/xbmc/android/activity/AndroidFeatures.cpp
@@ -19,10 +19,10 @@
  */
 
 #include "AndroidFeatures.h"
-#include "XBMCApp.h"
 #include "utils/log.h"
 
 #include <cpu-features.h>
+#include "JNIThreading.h"
 
 bool CAndroidFeatures::HasNeon()
 {
@@ -39,8 +39,7 @@ int CAndroidFeatures::GetVersion()
   {
     version = 0;
 
-    JNIEnv *jenv = NULL;
-    CXBMCApp::AttachCurrentThread(&jenv, NULL);
+    JNIEnv *jenv = xbmc_jnienv();
 
     jclass jcOsBuild = jenv->FindClass("android/os/Build$VERSION");
     if (jcOsBuild == NULL) 
@@ -59,7 +58,6 @@ int CAndroidFeatures::GetVersion()
     version = iSdkVersion;
 
     jenv->DeleteLocalRef(jcOsBuild);
-    CXBMCApp::DetachCurrentThread();
   }
   return version;
 }

--- a/xbmc/android/activity/Intents.cpp
+++ b/xbmc/android/activity/Intents.cpp
@@ -20,6 +20,7 @@
 #include "Intents.h"
 #include "utils/log.h"
 #include "XBMCApp.h"
+#include "JNIThreading.h"
 
 CAndroidIntents::CAndroidIntents()
 {
@@ -34,12 +35,11 @@ void CAndroidIntents::ReceiveIntent(JNIEnv *env, const jobject &intent)
 std::string CAndroidIntents::GetIntentAction(const jobject &intent)
 {
   std::string action;
-  JNIEnv *env;
+  JNIEnv* env = xbmc_jnienv();
 
  if (!intent)
     return "";
 
-  CXBMCApp::AttachCurrentThread(&env, NULL);
   jclass cIntent = env->GetObjectClass(intent);
 
   //action = intent.getAction()
@@ -50,6 +50,5 @@ std::string CAndroidIntents::GetIntentAction(const jobject &intent)
   action = std::string(nativeString);
 
   env->ReleaseStringUTFChars(sAction, nativeString);
-  CXBMCApp::DetachCurrentThread();
   return action;
 }

--- a/xbmc/android/activity/JNIThreading.cpp
+++ b/xbmc/android/activity/JNIThreading.cpp
@@ -1,0 +1,130 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *      Some code borrowed from Dmitry Moskalchuk.
+ *
+ * Copyright (c) 2011-2012 Dmitry Moskalchuk <dm@crystax.net>.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ * 
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ * 
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY Dmitry Moskalchuk ''AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Dmitry Moskalchuk OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Dmitry Moskalchuk.
+ */
+/*
+  This code is mostly borrowed from libcrystax. The functions and namespaces
+  were renamed to avoid collisions when linking against the originals.
+*/
+
+#include <jni.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <android/log.h>
+namespace xbmcjni
+{
+
+static JavaVM *s_jvm = NULL;
+static pthread_key_t s_jnienv_key;
+static pthread_once_t s_jnienv_key_once = PTHREAD_ONCE_INIT;
+
+JavaVM *jvm()
+{
+    return s_jvm;
+}
+
+static void jnienv_detach_thread(void *arg)
+{
+  if (!jvm())
+    return;
+  __android_log_print(ANDROID_LOG_VERBOSE, "XBMC","detaching thread");
+  jvm()->DetachCurrentThread();
+}
+
+static void jnienv_key_create()
+{
+    if (::pthread_key_create(&s_jnienv_key, &jnienv_detach_thread) != 0)
+        ::abort();
+}
+
+static bool save_jnienv(JNIEnv *env)
+{
+
+    ::pthread_once(&s_jnienv_key_once, &jnienv_key_create);
+
+    if (::pthread_setspecific(s_jnienv_key, env) != 0)
+        return false;
+    return true;
+}
+
+JNIEnv *jnienv()
+{
+    ::pthread_once(&s_jnienv_key_once, &jnienv_key_create);
+
+    JNIEnv *env = reinterpret_cast<JNIEnv *>(::pthread_getspecific(s_jnienv_key));
+    if (!env && jvm())
+    {
+        jvm()->AttachCurrentThread(&env, NULL);
+        if (!save_jnienv(env))
+            ::abort();
+    }
+    return env;
+}
+
+} // namespace xbmcjni
+
+JavaVM *xbmc_jvm()
+{
+    return ::xbmcjni::jvm();
+}
+
+JNIEnv *xbmc_jnienv()
+{
+    return ::xbmcjni::jnienv();
+}
+
+void xbmc_save_jnienv(JNIEnv *env)
+{
+    ::xbmcjni::save_jnienv(env);
+}
+
+jint xbmc_jni_on_load(JavaVM *vm, JNIEnv *env)
+{
+    jint jversion = JNI_VERSION_1_4;
+
+    if (!env)
+        return -1;
+
+    ::xbmcjni::s_jvm = vm;
+
+    // The main thread hands us an env. Attach and store it.
+    ::xbmcjni::jvm()->AttachCurrentThread(&env, NULL);
+    if (!::xbmcjni::save_jnienv(env))
+        return -1;
+
+    return jversion;
+}
+
+void xbmc_jni_on_unload()
+{
+  ::xbmcjni::jnienv_detach_thread(NULL);
+  ::xbmcjni::s_jvm = NULL;
+}

--- a/xbmc/android/activity/JNIThreading.h
+++ b/xbmc/android/activity/JNIThreading.h
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *      Some code borrowed from Dmitry Moskalchuk.
+ *
+ * Copyright (c) 2011-2012 Dmitry Moskalchuk <dm@crystax.net>.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ * 
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ * 
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY Dmitry Moskalchuk ''AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Dmitry Moskalchuk OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Dmitry Moskalchuk.
+ */
+
+#pragma once
+#include <jni.h>
+
+int xbmc_jni_on_load(JavaVM *vm, JNIEnv *env);
+void xbmc_jni_on_unload();
+
+/*
+ * Return pointer to application's Java VM.
+ * Return NULL if there is no JVM (standalone executable)
+ */
+JavaVM *xbmc_jvm();
+
+/*
+ * Return thread-specific JNIEnv pointer.
+ * Return NULL if there is no JVM (standalone executable)
+ */
+JNIEnv *xbmc_jnienv();
+
+/*
+ * Save specified JNIEnv to thread-specific storage.
+ * This value will then be returned on subsequent calls
+ * of crystax_jnienv()
+ */
+void xbmc_save_jnienv(JNIEnv *env);

--- a/xbmc/android/activity/Makefile.in
+++ b/xbmc/android/activity/Makefile.in
@@ -18,6 +18,7 @@ SRCS      += EventLoop.cpp
 SRCS      += XBMCApp.cpp
 SRCS      += JNI.cpp
 SRCS      += Intents.cpp
+SRCS      += JNIThreading.cpp
 
 OBJS      += $(APP_GLUE) $(CPU_OBJ)
 

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -97,14 +97,8 @@ public:
 
   static int GetDPI();
 protected:
-  // limit who can access AttachCurrentThread/DetachCurrentThread
+  // limit who can access Volume
   friend class CAESinkAUDIOTRACK;
-  friend class CAndroidFeatures;
-  friend class CFileAndroidApp;
-  friend class CAndroidIntents;
-
-  static int AttachCurrentThread(JNIEnv** p_env, void* thr_args = NULL);
-  static int DetachCurrentThread();
 
   static int GetMaxSystemVolume(JNIEnv *env);
   static void SetSystemVolume(JNIEnv *env, float percent);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -32,6 +32,8 @@
 #if defined(__ARM_NEON__)
 #include <arm_neon.h>
 #include "utils/CPUInfo.h"
+#include "android/activity/JNIThreading.h"
+
 // LGPLv2 from PulseAudio
 // float values from AE are pre-clamped so we do not need to clamp again here
 static void pa_sconv_s16le_from_f32ne_neon(unsigned n, const float32_t *a, int16_t *b)
@@ -263,8 +265,7 @@ void CAESinkAUDIOTRACK::Process()
 {
   CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::Process");
 
-  JNIEnv *jenv = NULL;
-  CXBMCApp::AttachCurrentThread(&jenv, NULL);
+  JNIEnv *jenv = xbmc_jnienv();
 
   jclass jcAudioTrack = jenv->FindClass("android/media/AudioTrack");
 
@@ -397,6 +398,4 @@ void CAESinkAUDIOTRACK::Process()
   jenv->DeleteLocalRef(jbuffer);
   jenv->DeleteLocalRef(joAudioTrack);
   jenv->DeleteLocalRef(jcAudioTrack);
-
-  CXBMCApp::DetachCurrentThread();
 }


### PR DESCRIPTION
Finally got around to this after being bitten too many times by manual thread attach/detach. Sorry for the big patch, but there was really no splitting this one up.

Threads are automatically attached when issuing a xbmc_jnienv(), and detach
automatically at destruction.

This eliminates manual intervention, and likely will save us from some bugs in
the future. The old code was very difficult to maintain since every function
had to assume that it was not attached and had to detach when finished.

This is the method recommended in the Android docs.

Current master suffers from a segfault on shutdown _without_ this patch, that will need to be fixed before pushing this one in, so that we can separate any resulting issues.
