### PR TITLE
change timeformat hh:mm:ss to not return AM/PM anymore, introduce 'h:mm:ss xx' and 'hh:mm:ss xx' for that purpose

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1164,8 +1164,10 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const CStdString &format)
   else if (format.Equals("hh:mm")) return TIME_FORMAT_HH_MM;
   else if (format.Equals("mm:ss")) return TIME_FORMAT_MM_SS;
   else if (format.Equals("hh:mm:ss")) return TIME_FORMAT_HH_MM_SS;
+  else if (format.Equals("hh:mm:ss xx")) return TIME_FORMAT_HH_MM_SS_XX;
   else if (format.Equals("h")) return TIME_FORMAT_H;
   else if (format.Equals("h:mm:ss")) return TIME_FORMAT_H_MM_SS;
+  else if (format.Equals("h:mm:ss xx")) return TIME_FORMAT_H_MM_SS_XX;
   else if (format.Equals("xx")) return TIME_FORMAT_XX;
   return TIME_FORMAT_GUESS;
 }
@@ -3150,11 +3152,15 @@ CStdString CGUIInfoManager::LocalizeTime(const CDateTime &time, TIME_FORMAT form
   case TIME_FORMAT_HH_MM_XX:
       return time.GetAsLocalizedTime(use12hourclock ? "h:mm xx" : "HH:mm", false);
   case TIME_FORMAT_HH_MM_SS:
-    return time.GetAsLocalizedTime("", true);
+    return time.GetAsLocalizedTime("hh:mm:ss", true);
+  case TIME_FORMAT_HH_MM_SS_XX:
+    return time.GetAsLocalizedTime("hh:mm:ss xx", true);
   case TIME_FORMAT_H:
     return time.GetAsLocalizedTime("h", false);
   case TIME_FORMAT_H_MM_SS:
     return time.GetAsLocalizedTime("h:mm:ss", true);
+  case TIME_FORMAT_H_MM_SS_XX:
+    return time.GetAsLocalizedTime("h:mm:ss xx", true);
   case TIME_FORMAT_XX:
     return use12hourclock ? time.GetAsLocalizedTime("xx", false) : "";
   default:

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -27,18 +27,20 @@
   TIME_FORMAT_HH_MM_SS = TIME_FORMAT_HH | TIME_FORMAT_MM | TIME_FORMAT_SS
  \sa StringUtils::SecondsToTimeString
  */
-enum TIME_FORMAT { TIME_FORMAT_GUESS     =  0,
-                   TIME_FORMAT_SS        =  1,
-                   TIME_FORMAT_MM        =  2,
-                   TIME_FORMAT_MM_SS     =  3,
-                   TIME_FORMAT_HH        =  4,
-                   TIME_FORMAT_HH_SS     =  5, // not particularly useful
-                   TIME_FORMAT_HH_MM     =  6,
-                   TIME_FORMAT_HH_MM_SS  =  7,
-                   TIME_FORMAT_XX        =  8, // AM/PM
-                   TIME_FORMAT_HH_MM_XX  = 14,
-                   TIME_FORMAT_H         = 16,
-                   TIME_FORMAT_H_MM_SS   = 19};
+enum TIME_FORMAT { TIME_FORMAT_GUESS       =  0,
+                   TIME_FORMAT_SS          =  1,
+                   TIME_FORMAT_MM          =  2,
+                   TIME_FORMAT_MM_SS       =  3,
+                   TIME_FORMAT_HH          =  4,
+                   TIME_FORMAT_HH_SS       =  5, // not particularly useful
+                   TIME_FORMAT_HH_MM       =  6,
+                   TIME_FORMAT_HH_MM_SS    =  7,
+                   TIME_FORMAT_XX          =  8, // AM/PM
+                   TIME_FORMAT_HH_MM_XX    = 14,
+                   TIME_FORMAT_HH_MM_SS_XX = 15,
+                   TIME_FORMAT_H           = 16,
+                   TIME_FORMAT_H_MM_SS     = 19,
+                   TIME_FORMAT_H_MM_SS_XX  = 27};
 
 class CDateTime;
 


### PR DESCRIPTION
This one puzzled me a bit the last day or two:

Tried to retrieve the system time via the System.Time() label in python, but always in hh:mm:ss format with leading zero where needed. That worked as expected when setting XBMC to some 24h clock format region (e.g. "Germany" - "13:23:45"). When switched to a 12h region ("English (US)"), it suddenly returned "h:mm:ss xx" (i.e. "1:23:45 PM"), where it was expected to return "01:23:45" for that format specifier.

This PR changes that so "hh:mm:ss" returns a time formatted in the expected way (and not behave like an empty format string was given resulting in guessing), and additionally adds formats "h:mm:ss xx" and "hh:mm:ss xx" to have format specifiers including am/pm. 

Grepped through my (small) list of system/user addons, none seems to use that. GUI (system time display, movie duration/length, EPG) seems unaffected.
