### PR TITLE
droid: add builtin for executing android apps via applicationmanager

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -65,6 +65,9 @@
 #include "windows/GUIWindowLoginScreen.h"
 
 #include "utils/GlobalsHandling.h"
+#if defined(TARGET_ANDROID)
+  #include "xbmc/android/activity/XBMCApp.h"
+#endif
 
 using namespace PVR;
 using namespace std;
@@ -805,6 +808,19 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       CGUIWindowLoginScreen::LoadProfile(pMsg->dwParam1);
       break;
     }
+    case TMSG_START_ANDROID_ACTIVITY:
+    {
+#if defined(TARGET_ANDROID)
+      if (pMsg->params.size())
+      {
+        CXBMCApp::StartActivity(pMsg->params[0],
+                                pMsg->params.size() > 1 ? pMsg->params[1] : "",
+                                pMsg->params.size() > 2 ? pMsg->params[2] : "",
+                                pMsg->params.size() > 3 ? pMsg->params[3] : "");
+      }
+#endif
+      break;
+    }
   }
 }
 
@@ -1288,5 +1304,12 @@ void CApplicationMessenger::LoadProfile(unsigned int idx)
 {
   ThreadMessage tMsg = {TMSG_LOADPROFILE};
   tMsg.dwParam1 = idx;
+  SendMessage(tMsg, false);
+}
+
+void CApplicationMessenger::StartAndroidActivity(const vector<CStdString> &params)
+{
+  ThreadMessage tMsg = {TMSG_START_ANDROID_ACTIVITY};
+  tMsg.params = params;
   SendMessage(tMsg, false);
 }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -101,6 +101,7 @@ namespace MUSIC_INFO
 #define TMSG_GUI_INFOBOOL             609
 #define TMSG_GUI_ADDON_DIALOG         610
 #define TMSG_GUI_MESSAGE              611
+#define TMSG_START_ANDROID_ACTIVITY   612
 
 #define TMSG_CALLBACK             800
 
@@ -241,6 +242,7 @@ public:
   
   bool SetupDisplay();
   bool DestroyDisplay();
+  void StartAndroidActivity(const std::vector<CStdString> &params);
 
   virtual ~CApplicationMessenger();
 private:

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -211,6 +211,9 @@ const BUILT_IN commands[] = {
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
   { "StartPVRManager",            false,  "(Re)Starts the PVR manager" },
   { "StopPVRManager",             false,  "Stops the PVR manager" },
+#if defined(TARGET_ANDROID)
+  { "StartAndroidActivity",       true,   "Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI." },
+#endif
 };
 
 bool CBuiltins::HasCommand(const CStdString& execString)
@@ -1623,6 +1626,10 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("stoppvrmanager"))
   {
     g_application.StopPVRManager();
+  }
+  else if (execute.Equals("StartAndroidActivity") && params.size() > 0)
+  {
+    CApplicationMessenger::Get().StartAndroidActivity(params);
   }
   else
     return -1;


### PR DESCRIPTION
These are the remaining bits from https://github.com/xbmc/xbmc/pull/2060

With this, skins and addons can launch android apps with optional params. Credit to @mcrosson for the work, I just cleaned it up a bit and shoved it through the app manager.
