### PR TITLE
[PVR] add possibility to start liveTV playback via cAction and keymaps.

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6815,7 +6815,7 @@ msgid "Already started recording on this channel"
 msgstr ""
 
 msgctxt "#19035"
-msgid "This channel cannot be played. Check the log for details."
+msgid "%s could not be played. Check the log for details."
 msgstr ""
 
 msgctxt "#19036"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2733,6 +2733,10 @@ bool CApplication::OnAction(const CAction &action)
     return true;
   }
 
+  // forward action to g_PVRManager and break if it was able to handle it
+  if (g_PVRManager.OnAction(action))
+    return true;
+
   if (IsPlaying())
   {
     // forward channel switches to the player - he knows what to do

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -277,6 +277,9 @@
 #define ACTION_CHANNEL_DOWN           185
 #define ACTION_NEXT_CHANNELGROUP      186
 #define ACTION_PREVIOUS_CHANNELGROUP  187
+#define ACTION_PVR_PLAY               188
+#define ACTION_PVR_PLAY_TV            189
+#define ACTION_PVR_PLAY_RADIO         190
 
 #define ACTION_TOGGLE_FULLSCREEN      199 // switch 2 desktop resolution
 #define ACTION_TOGGLE_WATCHED         200 // Toggle watched status (videos)

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -223,6 +223,9 @@ static const ActionMapping actions[] =
         {"channeldown"           , ACTION_CHANNEL_DOWN},
         {"previouschannelgroup"  , ACTION_PREVIOUS_CHANNELGROUP},
         {"nextchannelgroup"      , ACTION_NEXT_CHANNELGROUP},
+        {"playpvr"               , ACTION_PVR_PLAY},
+        {"playpvrtv"             , ACTION_PVR_PLAY_TV},
+        {"playpvrradio"          , ACTION_PVR_PLAY_RADIO},
 
         // Mouse actions
         {"leftclick"         , ACTION_MOUSE_LEFT_CLICK},

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -53,6 +53,7 @@
 #include "timers/PVRTimers.h"
 #include "interfaces/AnnouncementManager.h"
 #include "addons/AddonInstaller.h"
+#include "guilib/Key.h"
 
 using namespace std;
 using namespace MUSIC_INFO;
@@ -1023,6 +1024,73 @@ bool CPVRManager::StartPlayback(const CPVRChannel *channel, bool bPreview /* = f
   return true;
 }
 
+bool CPVRManager::StartPlayback(PlaybackType type /* = PlaybackTypeAny */)
+{
+  bool bIsRadio(false);
+  bool bReturn(false);
+  bool bIsPlaying(false);
+  CFileItemPtr channel;
+
+  // check if the desired PlaybackType is already playing,
+  // and if not, try to grab the last played channel of this type
+  switch (type)
+  {
+    case PlaybackTypeRadio:
+      if (IsPlayingRadio())
+        bIsPlaying = true;
+      else
+        channel = m_channelGroups->GetGroupAllRadio()->GetLastPlayedChannel();
+      bIsRadio = true;
+      break;
+
+    case PlaybackTypeTv:
+      if (IsPlayingTV())
+        bIsPlaying = true;
+      else
+        channel = m_channelGroups->GetGroupAllTV()->GetLastPlayedChannel();
+      break;
+
+    default:
+      if (IsPlaying())
+        bIsPlaying = true;
+      else
+        channel = m_channelGroups->GetLastPlayedChannel();
+  }
+
+  // we're already playing? Then nothing to do
+  if (bIsPlaying)
+    return true;
+
+  // if we have a last played channel, start playback
+  if (channel && channel->HasPVRChannelInfoTag())
+  {
+    bReturn = StartPlayback(channel->GetPVRChannelInfoTag(), false);
+  }
+  else
+  {
+    // if we don't, find the active channel group of the demanded type and play it's first channel
+    CPVRChannelGroupPtr channelGroup = GetPlayingGroup(bIsRadio);
+    if (channelGroup)
+    {
+      // try to start playback of first channel in this group
+      CFileItemPtr channel = channelGroup->GetByIndex(0);
+      if (channel && channel->HasPVRChannelInfoTag())
+        bReturn = StartPlayback(channel->GetPVRChannelInfoTag(), false);
+    }
+  }
+
+  if (!bReturn)
+  {
+    CLog::Log(LOGNOTICE, "PVRManager - %s - could not determine %s channel to start playback with. No last played channel found, and first channel of active group could also not be determined.", __FUNCTION__, bIsRadio ? "radio": "tv");
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
+            g_localizeStrings.Get(19166), // PVR information
+            g_localizeStrings.Get(19035)); // This channel cannot be played. Check the log for details.
+  }
+
+  return bReturn;
+}
+
+
 bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview)
 {
   // check parental lock state
@@ -1321,6 +1389,42 @@ void CPVRManager::ExecutePendingJobs(void)
   }
 
   m_triggerEvent.Reset();
+}
+
+bool CPVRManager::OnAction(const CAction &action)
+{
+  // process PVR specific play actions
+  if (action.GetID() == ACTION_PVR_PLAY || action.GetID() == ACTION_PVR_PLAY_TV || action.GetID() == ACTION_PVR_PLAY_RADIO)
+  {
+    // pvr not active yet, show error message
+    if (!IsStarted())
+    {
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(19045), g_localizeStrings.Get(19044));
+    }
+    else
+    {
+      // see if we're already playing a PVR stream and if not or the stream type
+      // doesn't match the demanded type, start playback of according type
+      bool isPlayingPvr(IsPlaying() && g_application.CurrentFileItem().HasPVRChannelInfoTag());
+      switch (action.GetID())
+      {
+        case ACTION_PVR_PLAY:
+          if (!isPlayingPvr)
+            StartPlayback(PlaybackTypeAny);
+          break;
+        case ACTION_PVR_PLAY_TV:
+          if (!isPlayingPvr || g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
+            StartPlayback(PlaybackTypeTv);
+          break;
+        case ACTION_PVR_PLAY_RADIO:
+          if (!isPlayingPvr || !g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
+            StartPlayback(PlaybackTypeRadio);
+          break;
+      }
+    }
+    return true;
+  }
+  return false;
 }
 
 bool CPVRChannelSwitchJob::DoWork(void)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1082,9 +1082,12 @@ bool CPVRManager::StartPlayback(PlaybackType type /* = PlaybackTypeAny */)
   if (!bReturn)
   {
     CLog::Log(LOGNOTICE, "PVRManager - %s - could not determine %s channel to start playback with. No last played channel found, and first channel of active group could also not be determined.", __FUNCTION__, bIsRadio ? "radio": "tv");
+
+    CStdString msg;
+    msg.Format(g_localizeStrings.Get(19035).c_str(), g_localizeStrings.Get(bIsRadio ? 19021 : 19020).c_str()); // RADIO/TV could not be played. Check the log for details.
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
             g_localizeStrings.Get(19166), // PVR information
-            g_localizeStrings.Get(19035)); // This channel cannot be played. Check the log for details.
+            msg);
   }
 
   return bReturn;
@@ -1151,9 +1154,11 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
 
     CLog::Log(LOGERROR, "PVRManager - %s - failed to switch to channel '%s'", __FUNCTION__, channel.ChannelName().c_str());
 
+    CStdString msg;
+    msg.Format(g_localizeStrings.Get(19035).c_str(), channel.ChannelName().c_str()); // CHANNELNAME could not be played. Check the log for details.
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
         g_localizeStrings.Get(19166), // PVR information
-        g_localizeStrings.Get(19035)); // This channel cannot be played. Check the log for details.
+        msg);
   }
   else
   {

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -27,6 +27,7 @@
 
 class CGUIDialogProgressBarHandle;
 class CStopWatch;
+class CAction;
 
 namespace EPG
 {
@@ -55,6 +56,13 @@ namespace PVR
     ManagerStateStopping,
     ManagerStateInterrupted,
     ManagerStateStarted
+  };
+
+  enum PlaybackType
+  {
+    PlaybackTypeAny = 0,
+    PlaybackTypeTv,
+    PlaybackTypeRadio
   };
 
   #define g_PVRManager       CPVRManager::Get()
@@ -389,6 +397,13 @@ namespace PVR
     bool StartPlayback(const CPVRChannel *channel, bool bPreview = false);
 
     /*!
+     * @brief Start playback of the last used channel, and if it fails use first channel in the current channelgroup.
+     * @param type The type of playback to be started (any, radio, tv). See PlaybackType enum
+     * @return True if playback was started, false otherwise.
+     */
+    bool StartPlayback(PlaybackType type = PlaybackTypeAny);
+
+    /*!
      * @brief Update the current playing file in the guiinfomanager and application.
      */
     void UpdateCurrentFile(void);
@@ -472,6 +487,13 @@ namespace PVR
      * @return True when loaded, false otherwise
      */
     bool WaitUntilInitialised(void);
+
+    /*!
+     * @brief Handle PVR specific cActions
+     * @param action The action to process
+     * @return True if action could be handled, false otherwise.
+     */
+    bool OnAction(const CAction &action);
 
   protected:
     /*!

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -209,9 +209,11 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
     if (!g_PVRManager.CheckParentalLock(*channel) ||
         !g_application.m_pPlayer->SwitchChannel(*channel))
     {
+      CStdString msg;
+      msg.Format(g_localizeStrings.Get(19035).c_str(), channel->ChannelName().c_str()); // CHANNELNAME could not be played. Check the log for details.
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
               g_localizeStrings.Get(19166), // PVR information
-              g_localizeStrings.Get(19035)); // This channel cannot be played. Check the log for details.
+              msg);
       return;
     }
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -23,6 +23,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "guilib/LocalizeStrings.h"
 
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -170,9 +171,15 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonSwitch(CGUIMessage &message)
 
     if (!m_progItem->GetEPGInfoTag()->HasPVRChannel() ||
         !g_application.PlayFile(CFileItem(*m_progItem->GetEPGInfoTag()->ChannelTag())))
-      CGUIDialogOK::ShowAndGetInput(19033,0,19035,0);
+    {
+      CStdString msg;
+      msg.Format(g_localizeStrings.Get(19035).c_str(), g_localizeStrings.Get(19029).c_str()); // Channel could not be played. Check the log for details.
+      CGUIDialogOK::ShowAndGetInput(19033, 0, msg, 0);
+    }
     else
+    {
       bReturn = true;
+    }
   }
 
   return bReturn;

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -537,8 +537,9 @@ bool CGUIWindowPVRCommon::ActionPlayEpg(CFileItem *item)
 
   if (!bReturn)
   {
-    /* cannot play file */
-    CGUIDialogOK::ShowAndGetInput(19033,0,19035,0);
+    CStdString msg;
+    msg.Format(g_localizeStrings.Get(19035).c_str(), channel->ChannelName().c_str()); // CHANNELNAME could not be played. Check the log for details.
+    CGUIDialogOK::ShowAndGetInput(19033, 0, msg, 0);
   }
 
   return bReturn;
@@ -717,9 +718,15 @@ bool CGUIWindowPVRCommon::PlayFile(CFileItem *item, bool bPlayMinimized /* = fal
 
     if (!bSwitchSuccessful)
     {
+      CStdString msg;
+      CStdString channelName = g_localizeStrings.Get(19029); // Channel
+      if (channel)
+        channelName = channel->ChannelName();
+      msg.Format(g_localizeStrings.Get(19035).c_str(), channelName.c_str()); // CHANNELNAME could not be played. Check the log for details.
+
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
               g_localizeStrings.Get(19166), // PVR information
-              g_localizeStrings.Get(19035)); // This channel cannot be played. Check the log for details.
+              msg);
       return false;
     }
   }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -429,7 +429,11 @@ bool CGUIWindowPVRGuide::PlayEpgItem(CFileItem *item)
   CLog::Log(LOGDEBUG, "play channel '%s'", channel->ChannelName().c_str());
   bool bReturn = g_application.PlayFile(CFileItem(*channel));
   if (!bReturn)
-    CGUIDialogOK::ShowAndGetInput(19033,0,19035,0);
+  {
+    CStdString msg;
+    msg.Format(g_localizeStrings.Get(19035).c_str(), channel->ChannelName().c_str()); // CHANNELNAME could not be played. Check the log for details.
+    CGUIDialogOK::ShowAndGetInput(19033, 0, msg, 0);
+  }
 
   return bReturn;
 }


### PR DESCRIPTION
When called, it first tries to play the last watched channel - if this fails/is not available it uses the first TV channel of the current channel group. If PVR is disabled or PVRmanager is not yet ready, it'll throw a kaitoast.
