### PR TITLE
websocket: fix inability to handle multiple queued websocket frames/messages (fixes #13848)

### DIFF
--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -654,23 +654,28 @@ void CTCPServer::CWebSocketClient::Send(const char *data, unsigned int size)
 void CTCPServer::CWebSocketClient::PushBuffer(CTCPServer *host, const char *buffer, int length)
 {
   bool send;
-  const CWebSocketMessage *msg;
-  if ((msg = m_websocket->Handle(buffer, length, send)) != NULL && msg->IsComplete())
+  const CWebSocketMessage *msg = NULL;
+  size_t len = length;
+  do
   {
-    std::vector<const CWebSocketFrame *> frames = msg->GetFrames();
-    if (send)
+    if ((msg = m_websocket->Handle(buffer, len, send)) != NULL && msg->IsComplete())
     {
-      for (unsigned int index = 0; index < frames.size(); index++)
-        Send(frames.at(index)->GetFrameData(), (unsigned int)frames.at(index)->GetFrameLength());
-    }
-    else
-    {
-      for (unsigned int index = 0; index < frames.size(); index++)
-        CTCPClient::PushBuffer(host, frames.at(index)->GetApplicationData(), (int)frames.at(index)->GetLength());
-    }
+      std::vector<const CWebSocketFrame *> frames = msg->GetFrames();
+      if (send)
+      {
+        for (unsigned int index = 0; index < frames.size(); index++)
+          Send(frames.at(index)->GetFrameData(), (unsigned int)frames.at(index)->GetFrameLength());
+      }
+      else
+      {
+        for (unsigned int index = 0; index < frames.size(); index++)
+          CTCPClient::PushBuffer(host, frames.at(index)->GetApplicationData(), (int)frames.at(index)->GetLength());
+      }
 
-    delete msg;
+      delete msg;
+    }
   }
+  while (len > 0 && msg != NULL);
 
   if (m_websocket->GetState() == WebSocketStateClosed)
     Disconnect();

--- a/xbmc/network/websocket/WebSocket.h
+++ b/xbmc/network/websocket/WebSocket.h
@@ -122,7 +122,7 @@ public:
   WebSocketState GetState() { return m_state; }
 
   virtual bool Handshake(const char* data, size_t length, std::string &response) = 0;
-  virtual const CWebSocketMessage* Handle(const char *buffer, size_t length, bool &send);
+  virtual const CWebSocketMessage* Handle(const char* &buffer, size_t &length, bool &send);
   virtual const CWebSocketMessage* Send(WebSocketFrameOpcode opcode, const char* data = NULL, uint32_t length = 0);
   virtual const CWebSocketFrame* Ping(const char* data = NULL) const = 0;
   virtual const CWebSocketFrame* Pong(const char* data = NULL) const = 0;


### PR DESCRIPTION
With the current code the websocket implementation always expects one frame at the time in the TCP socket buffer but that's obviously not always the case as demonstrated by http://trac.xbmc.org/ticket/13848. These changes does away with that assumption and runs a loop to get messages and frames as long as there is data available from the TCP socket buffer.
