### PR TITLE
Add easy methods for url protocol options 

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -206,12 +206,11 @@ void CURL::Parse(const CStdString& strURL1)
       if (iProto >= 0)
       {
         m_strProtocolOptions = strURL.substr(iProto+1);
-        m_strOptions = strURL.substr(iOptions,iProto-iOptions);
+        SetOptions(strURL.substr(iOptions,iProto-iOptions));
       }
       else
-        m_strOptions = strURL.substr(iOptions);
+        SetOptions(strURL.substr(iOptions));
       iEnd = iOptions;
-      m_options.AddOptions(m_strOptions);
     }
   }
 

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -69,6 +69,7 @@ void CURL::Reset()
   m_strOptions.clear();
   m_strProtocolOptions.clear();
   m_options.Clear();
+  m_protocolOptions.Clear();
   m_iPort = 0;
 }
 
@@ -205,7 +206,7 @@ void CURL::Parse(const CStdString& strURL1)
       int iProto = strURL.find_first_of("|",iOptions);
       if (iProto >= 0)
       {
-        m_strProtocolOptions = strURL.substr(iProto+1);
+        SetProtocolOptions(strURL.substr(iProto+1));
         SetOptions(strURL.substr(iOptions,iProto-iOptions));
       }
       else
@@ -401,7 +402,16 @@ void CURL::SetOptions(const CStdString& strOptions)
 
 void CURL::SetProtocolOptions(const CStdString& strOptions)
 {
-  m_strProtocolOptions = strOptions;
+  m_strProtocolOptions.Empty();
+  m_protocolOptions.Clear();
+  if (strOptions.length() > 0)
+  {
+    if (strOptions[0] == '|')
+      m_strProtocolOptions = strOptions.Mid(1);
+    else
+      m_strProtocolOptions = strOptions;
+    m_protocolOptions.AddOptions(m_strProtocolOptions);
+  }
 }
 
 void CURL::SetPort(int port)
@@ -805,4 +815,47 @@ void CURL::RemoveOption(const CStdString &key)
 {
   m_options.RemoveOption(key);
   SetOptions(m_options.GetOptionsString(true));
+}
+
+void CURL::GetProtocolOptions(std::map<CStdString, CStdString> &options) const
+{
+  CUrlOptions::UrlOptions optionsMap = m_protocolOptions.GetOptions();
+  for (CUrlOptions::UrlOptions::const_iterator option = optionsMap.begin(); option != optionsMap.end(); option++)
+    options[option->first] = option->second.asString();
+}
+
+bool CURL::HasProtocolOption(const CStdString &key) const
+{
+  return m_protocolOptions.HasOption(key);
+}
+
+bool CURL::GetProtocolOption(const CStdString &key, CStdString &value) const
+{
+  CVariant valueObj;
+  if (!m_protocolOptions.GetOption(key, valueObj))
+    return false;
+  
+  value = valueObj.asString();
+  return true;
+}
+
+CStdString CURL::GetProtocolOption(const CStdString &key) const
+{
+  CStdString value;
+  if (!GetProtocolOption(key, value))
+    return "";
+  
+  return value;
+}
+
+void CURL::SetProtocolOption(const CStdString &key, const CStdString &value)
+{
+  m_protocolOptions.AddOption(key, value);
+  m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);
+}
+
+void CURL::RemoveProtocolOption(const CStdString &key)
+{
+  m_options.RemoveOption(key);
+  m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);
 }

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -82,6 +82,13 @@ public:
   void SetOption(const CStdString &key, const CStdString &value);
   void RemoveOption(const CStdString &key);
 
+  void GetProtocolOptions(std::map<CStdString, CStdString> &options) const;
+  bool HasProtocolOption(const CStdString &key) const;
+  bool GetProtocolOption(const CStdString &key, CStdString &value) const;
+  CStdString GetProtocolOption(const CStdString &key) const;
+  void SetProtocolOption(const CStdString &key, const CStdString &value);
+  void RemoveProtocolOption(const CStdString &key);
+
 protected:
   int m_iPort;
   CStdString m_strHostName;
@@ -95,4 +102,5 @@ protected:
   CStdString m_strOptions;
   CStdString m_strProtocolOptions;
   CUrlOptions m_options;
+  CUrlOptions m_protocolOptions;
 };

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -736,30 +736,17 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     m_password = url2.GetPassWord();
 
     // handle any protocol options
-    CStdString options = url2.GetProtocolOptions();
-    options.TrimRight('/'); // hack for trailing slashes being added from source
-    if (options.length() > 0)
+    std::map<CStdString, CStdString> options;
+    url2.GetProtocolOptions(options);
+    if (options.size() > 0)
     {
       // clear protocol options
       url2.SetProtocolOptions("");
       // set xbmc headers
-      CStdStringArray array;
-      CUtil::Tokenize(options, array, "&");
-      for(CStdStringArray::iterator it = array.begin(); it != array.end(); it++)
+      for(std::map<CStdString, CStdString>::const_iterator it = options.begin(); it != options.end(); ++it)
       {
-        // parse name, value
-        CStdString name, value;
-        int pos = it->Find('=');
-        if(pos >= 0)
-        {
-          name = it->Left(pos);
-          value = it->Mid(pos+1, it->size());
-        }
-        else
-        {
-          name = (*it);
-          value = "";
-        }
+        const CStdString &name = it->first;
+        CStdString value = it->second;
 
         // url decode value
         CURL::Decode(value);

--- a/xbmc/utils/UrlOptions.h
+++ b/xbmc/utils/UrlOptions.h
@@ -29,10 +29,10 @@ public:
   typedef std::map<std::string, CVariant> UrlOptions;
 
   CUrlOptions();
-  CUrlOptions(const std::string &options);
+  CUrlOptions(const std::string &options, const char *strLead = "");
   virtual ~CUrlOptions();
 
-  virtual void Clear() { m_options.clear(); }
+  virtual void Clear() { m_options.clear(); m_strLead = ""; }
 
   virtual const UrlOptions& GetOptions() const { return m_options; }
   virtual std::string GetOptionsString(bool withLeadingSeperator = false) const;


### PR DESCRIPTION
Add easy method for protocol options similar with url options'

another commit make class CUrlOptions support specify leading str, default unspecified leading str fallback to '?' when calling GetOptionsString(withLeadingSeperator=true) as the old code.
