### PR TITLE
Change CircularCache internal pos members from uint64_t to int64_t.

### DIFF
--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -169,7 +169,7 @@ int CCircularCache::ReadFromCache(char *buf, size_t len)
 int64_t CCircularCache::WaitForData(unsigned int minumum, unsigned int millis)
 {
   CSingleLock lock(m_sync);
-  uint64_t avail = m_end - m_cur;
+  int64_t avail = m_end - m_cur;
 
   if(millis == 0 || IsEndOfInput())
     return avail;
@@ -195,14 +195,14 @@ int64_t CCircularCache::Seek(int64_t pos)
 
   // if seek is a bit over what we have, try to wait a few seconds for the data to be available.
   // we try to avoid a (heavy) seek on the source
-  if ((uint64_t)pos >= m_end && (uint64_t)pos < m_end + 100000)
+  if (pos >= m_end && pos < m_end + 100000)
   {
     lock.Leave();
     WaitForData((size_t)(pos - m_cur), 5000);
     lock.Enter();
   }
 
-  if((uint64_t)pos >= m_beg && (uint64_t)pos <= m_end)
+  if(pos >= m_beg && pos <= m_end)
   {
     m_cur = pos;
     return pos;

--- a/xbmc/filesystem/CircularCache.h
+++ b/xbmc/filesystem/CircularCache.h
@@ -44,9 +44,9 @@ public:
     virtual void Reset(int64_t pos) ;
 
 protected:
-    uint64_t          m_beg;       /**< index in file (not buffer) of beginning of valid data */
-    uint64_t          m_end;       /**< index in file (not buffer) of end of valid data */
-    uint64_t          m_cur;       /**< current reading index in file */
+    int64_t           m_beg;       /**< index in file (not buffer) of beginning of valid data */
+    int64_t           m_end;       /**< index in file (not buffer) of end of valid data */
+    int64_t           m_cur;       /**< current reading index in file */
     uint8_t          *m_buf;       /**< buffer holding data */
     size_t            m_size;      /**< size of data buffer used (m_buf) */
     size_t            m_size_back; /**< guaranteed size of back buffer (actual size can be smaller, or larger if front buffer doesn't need it) */


### PR DESCRIPTION
as title, the seek position api use int64_t, change class member from uint64_t to int64_t reduce type cast code and nothing to lose.@arnova
