### PR TITLE
FIX: BitstreamConverter: don't silently close the converter in case of conversion error

### DIFF
--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -609,10 +609,9 @@ bool CBitstreamConverter::Convert(uint8_t *pData, int iSize)
           }
           else
           {
-            Close();
             m_inputBuffer = pData;
             m_inputSize   = iSize;
-            CLog::Log(LOGERROR, "CBitstreamConverter::Convert error converting. disable converter\n");
+            CLog::Log(LOGERROR, "CBitstreamConverter::Convert error converting.\n");
           }
         }
         else


### PR DESCRIPTION
@huceke Not sure who to assign this as we lost history;)

This patch just silently ignore conversion errors (beside logging an error).
Before, the error was silently ignored AND the converter was silently closed.

There might very well a better solution to handle this...
The context is that, apparently, the first frame after a h264 rtmp seek is not correct from a BitStream perspective. 
Could be a librtmp bug or something I miss...
