### PR TITLE
Addon binary reading and writing

### DIFF
--- a/tools/codegenerator/SwigTypeParser.groovy
+++ b/tools/codegenerator/SwigTypeParser.groovy
@@ -42,9 +42,9 @@ public class SwigTypeParser
    public static String convertTypeToLTypeForParam(String ty)
    {
       // in the case where we're converting from a type to an ltype for a parameter,
-      //  and the type is a r.q(const).*, we are going to assume the ltype is
+      //  and the type is a r.*, we are going to assume the ltype is
       //  a "pass-by-value" on the stack.
-      return (ty.trim().startsWith('r.q(const).') ? SwigTypeParser.SwigType_ltype(ty.trim().substring(11)) : SwigTypeParser.SwigType_ltype(ty.trim()))
+      return (ty.trim().startsWith('r.') ? SwigTypeParser.SwigType_ltype(ty.trim().substring(2)) : SwigTypeParser.SwigType_ltype(ty.trim()))
    }
 
   /**
@@ -248,8 +248,16 @@ public class SwigTypeParser
 
    public static boolean SwigType_ispointer(String t)
    {
-      if (t.startsWith('q(')) t = t.substring(t.indexOf('.') + 1,)
+      if (t.startsWith('q(')) t = t.substring(t.indexOf('.') + 1)
       return t.startsWith('p.')
+   }
+
+   public static String SwigType_makepointer(String t)
+   {
+     String prefix = (t.startsWith('q(')) ? t.substring(0,t.indexOf('.') + 1) : ""
+     String remainder = (t.startsWith('q(')) ? t.substring(t.indexOf('.') + 1) : t
+     
+     return prefix + "p." + remainder
    }
 
    public static boolean SwigType_isarray(String t) { return t.startsWith('a(') }
@@ -542,11 +550,12 @@ public class SwigTypeParser
       //System.out.println "${convertTypeToLType('bool')}"
       //testPrint('p.q(const).XBMCAddon::xbmcgui::ListItemList')
       //testPrint('p.q(const).XBMCAddon::xbmcgui::ListItemList')
-      testPrint('r.q(const).std::map<(String,String)>', 'foo')
+      //testPrint(SwigTypeParser.SwigType_makepointer('r.q(const).std::map<(String,String)>'), 'foo')
+      testPrint(SwigTypeParser.SwigType_makepointer('q(const).p.q(const).char'),'bfoo')
    }
 
    private static void testPrint(String ty, String id = 'foo')
    {
-      println SwigTypeParser.SwigType_ltype(ty) + "|" + SwigTypeParser.SwigType_str(SwigTypeParser.SwigType_ltype(ty),id) + ' ' + " = " + SwigTypeParser.SwigType_str(ty,id)
+      println SwigTypeParser.SwigType_ltype(ty) + "|" + SwigTypeParser.SwigType_str(SwigTypeParser.SwigType_ltype(ty),id) + ' ' + " = " + ty + '|' + SwigTypeParser.SwigType_str(ty,id)
    }
 }

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -1,0 +1,232 @@
+
+#pragma once
+
+#include <string.h>
+#include <string>
+#include <boost/shared_array.hpp>
+
+namespace XbmcCommons
+{
+  class BufferException
+  {
+    std::string message;
+
+  public:
+    BufferException(const char* message_) : message(message_) {}
+  };
+
+  /**
+   * This class is based on the java java.nio.Buffer class however, it 
+   *  does not implement the 'mark' functionality. 
+   *
+   * [ the following is borrowed from the javadocs for java.nio.Buffer 
+   * where it applies to this class]:
+   *
+   * A buffer is a linear, finite sequence of elements of a unspecified types.
+   * Aside from its content, the essential properties of a buffer are its capacity, 
+   *   limit, and position:
+   *    A buffer's capacity is the number of elements it contains. The capacity 
+   *      of a buffer is never negative and never changes.
+   *
+   *    A buffer's limit is the index of the first element that should not be 
+   *      read or written. A buffer's limit is never negative and is never greater 
+   *      than its capacity.
+   *
+   *     A buffer's position is the index of the next element to be read or written. 
+   *       A buffer's position is never negative and is never greater than its limit.
+   *
+   * Invariants:
+   *
+   * The following invariant holds for the mark, position, limit, and capacity values:
+   *
+   *     0 <= mark <= position <= limit <= capacity 
+   *
+   * A newly-created buffer always has a position of zero and a limit set to the 
+   * capacity. The initial content of a buffer is, in general, undefined. 
+   *
+   * Example:
+   *  Buffer buffer(1024);
+   *  buffer.putInt(1).putString("hello there").putLongLong( ((long long)2)^40 );
+   *  buffer.flip();
+   *  std::cout << "buffer contents:" << buffer.getInt() << ", ";
+   *  std::cout << buffer.getCharPointerDirect() << ", ";
+   *  std::cout << buffer.getLongLong() << std::endl;
+   *
+   * Note: the 'gets' are sensitive to the order-of-operations. Therefore, while
+   *  the above is correct, it would be wrong to chain the output as follows:
+   *
+   *  std::cout << "buffer contents:" << buffer.getInt() << ", " << std::cout
+   *      << buffer.getCharPointerDirect() << ", " << buffer.getLongLong() 
+   *      << std::endl;
+   *
+   * This would result in the get's executing from right to left and therefore would
+   *  produce totally erroneous results. This is also a problem when the values are
+   *  passed to a method as in:
+   *
+   * printf("buffer contents: %d, \"%s\", %ll\n", buffer.getInt(), 
+   *         buffer.getCharPointerDirect(), buffer.getLongLong());
+   *
+   * This would also produce erroneous results as they get's will be evaluated
+   *   from right to left in the parameter list of printf.
+   */
+  class Buffer
+  {
+    boost::shared_array<unsigned char> bufferRef;
+    unsigned char* buffer;
+    size_t mposition;
+    size_t mcapacity;
+    size_t mlimit;
+
+    inline void check(int count) const throw(BufferException)
+    { 
+      if ((mposition + count) > mlimit) 
+        throw BufferException("Buffer buffer overflow: Cannot add more data to the Buffer's buffer.");
+    }
+
+  public:
+    /**
+     * Construct an uninitialized buffer instance, perhaps as an lvalue.
+     */
+    inline Buffer() : buffer(NULL), mposition(0), mcapacity(0), mlimit(0) { clear(); }
+
+    /**
+     * Construct a buffer given an externally managed memory buffer.
+     * The ownership of the buffer is assumed to be the code that called
+     * this constructor, therefore the Buffer descrutor will not free it.
+     */
+    inline Buffer(void* buffer_, size_t bufferSize) : buffer((unsigned char*)buffer_), mcapacity(bufferSize) { clear(); }
+
+    /**
+     * Construct a buffer buffer using the size buffer provided. The
+     * buffer will be internally managed and potentiall shared with 
+     * other Buffer instances. It will be freed upon destruction of
+     * the last Buffer that references it.
+     */
+    inline Buffer(size_t bufferSize) : buffer(bufferSize ? new unsigned char[bufferSize] : NULL), mcapacity(bufferSize)
+    { 
+      clear(); 
+      bufferRef.reset(buffer);
+    }
+
+    /**
+     * Copy another buffer. This is a "shallow copy" and therefore
+     * shares the underlying data buffer with the Buffer it is a copy
+     * of. Changes made to the data through this buffer will be seen
+     * in the source buffer and vice/vrs. However, each buffer maintains
+     * it's own indexing.
+     */
+    inline Buffer(const Buffer& buf) : bufferRef(buf.bufferRef), buffer(buf.buffer), 
+      mposition(buf.mposition), mcapacity(buf.mcapacity), mlimit(mlimit) { }
+
+    inline ~Buffer() { }
+
+    /**
+     * Copy another buffer. This is a "shallow copy" and therefore
+     * shares the underlying data buffer with the Buffer it is a copy
+     * of. Changes made to the data through this buffer will be seen
+     * in the source buffer and vice/vrs. However, each buffer maintains
+     * it's own indexing.
+     */
+    inline Buffer& operator=(const Buffer& buf)
+    {
+      buffer = buf.buffer;
+      bufferRef = buf.bufferRef;
+      mcapacity = buf.mcapacity;
+      mlimit = buf.mlimit;
+      return *this;
+    }
+
+    inline void allocate(size_t bufferSize)
+    {
+      buffer = bufferSize ? new unsigned char[bufferSize] : NULL;
+      bufferRef.reset(buffer);
+      mcapacity = bufferSize;
+      clear();      
+    }
+
+    /**
+     * Flips this buffer. The limit is set to the current position 
+     *   and then the position is set to zero. 
+     *
+     * After a sequence of channel-read or put operations, invoke this 
+     *   method to prepare for a sequence of channel-write or relative 
+     *   get operations. For example:
+     *
+     * buf.put(magic);    // Prepend header
+     * in.read(buf);      // Read data into rest of buffer
+     * buf.flip();        // Flip buffer
+     * out.write(buf);    // Write header + data to channel
+     *
+     * This is used to prepare the Buffer for reading from after
+     *  it has been written to.
+     */
+    inline Buffer& flip() { mlimit = mposition; mposition = 0; return *this; }
+
+    /**
+     *Clears this buffer. The position is set to zero, the limit 
+     *  is set to the capacity.
+     *
+     * Invoke this method before using a sequence of channel-read 
+     *  or put operations to fill this buffer. For example:
+     *
+     *     buf.clear();     // Prepare buffer for reading
+     *     in.read(buf);    // Read data
+     *
+     * This method does not actually erase the data in the buffer, 
+     *  but it is named as if it did because it will most often be used 
+     *  in situations in which that might as well be the case. 
+     */
+    inline Buffer& clear() { mlimit = mcapacity; mposition = 0; return *this; }
+
+    /**
+     * This method resets the position to the beginning of the buffer
+     *  so that it can be either reread or written to all over again.
+     */
+    inline Buffer& rewind() { mposition = 0; return *this; }
+
+    /**
+     * This method provides for the remaining number of bytes
+     *  that can be read out of the buffer or written into the
+     *  buffer before it's finished.
+     */
+    inline size_t remaining() { return mlimit - mposition; }
+
+    inline Buffer& put(const void* src, size_t bytes) throw(BufferException)
+    { check(bytes); memcpy( buffer + mposition, src, bytes); mposition += bytes; return *this; }
+    inline Buffer& get(void* dest, size_t bytes) throw(BufferException) 
+    { check(bytes); memcpy( dest, buffer + mposition, bytes); mposition += bytes; return *this; }
+
+    inline unsigned char* array() { return buffer; }
+    inline unsigned char* curPosition() { return buffer + mposition; }
+    inline void setPosition(size_t position) { mposition = position; }
+    inline void forward(size_t positionIncrement) throw(BufferException)
+    { check(positionIncrement); mposition += positionIncrement; }
+
+    inline size_t limit() const { return mlimit; }
+    inline size_t capacity() const { return mcapacity; }
+    inline size_t position() const { return mposition; }
+
+#define DEFAULTBUFFERRELATIVERW(name,type) \
+    inline Buffer& put##name(const type & val) throw(BufferException) { return put(&val, sizeof(type)); } \
+    inline type get##name() throw(BufferException) { type ret; get(&ret, sizeof(type)); return ret; }
+
+    DEFAULTBUFFERRELATIVERW(Bool,bool);
+    DEFAULTBUFFERRELATIVERW(Int,int);
+    DEFAULTBUFFERRELATIVERW(Char,char);
+    DEFAULTBUFFERRELATIVERW(Long,long);
+    DEFAULTBUFFERRELATIVERW(Float,float);
+    DEFAULTBUFFERRELATIVERW(Double,double);
+    DEFAULTBUFFERRELATIVERW(Pointer,void*);
+    DEFAULTBUFFERRELATIVERW(LongLong,long long);
+#undef DEFAULTBUFFERRELATIVERW
+
+    inline Buffer& putString(const char* str) throw (BufferException) { size_t len = strlen(str) + 1; check(len); put(str, len); return (*this); }
+    inline Buffer& putString(const std::string& str) throw (BufferException) { size_t len = str.length() + 1; check(len); put(str.c_str(), len); return (*this); }
+
+    inline std::string getString() throw (BufferException) { std::string ret((const char*)(buffer + mposition)); size_t len = ret.length() + 1; check(len); mposition += len; return ret; }
+    inline char* getCharPointerDirect() throw (BufferException) { char* ret = (char*)(buffer + mposition); size_t len = strlen(ret) + 1; check(len); mposition += len; return ret; }
+
+  };
+
+}
+

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -93,8 +93,18 @@ namespace XbmcCommons
      * Construct a buffer given an externally managed memory buffer.
      * The ownership of the buffer is assumed to be the code that called
      * this constructor, therefore the Buffer descrutor will not free it.
+     *
+     * The newly constructed buffer is considered empty and is ready to
+     * have data written into it.
+     *
+     * If you want to read from the buffer you just created, you can use:
+     *
+     * Buffer b = Buffer(buf,bufSize).forward(bufSize).flip();
      */
-    inline Buffer(void* buffer_, size_t bufferSize) : buffer((unsigned char*)buffer_), mcapacity(bufferSize) { clear(); }
+    inline Buffer(void* buffer_, size_t bufferSize) : buffer((unsigned char*)buffer_), mcapacity(bufferSize) 
+    {
+      clear();
+    }
 
     /**
      * Construct a buffer buffer using the size buffer provided. The
@@ -136,12 +146,13 @@ namespace XbmcCommons
       return *this;
     }
 
-    inline void allocate(size_t bufferSize)
+    inline Buffer& allocate(size_t bufferSize)
     {
       buffer = bufferSize ? new unsigned char[bufferSize] : NULL;
       bufferRef.reset(buffer);
       mcapacity = bufferSize;
-      clear();      
+      clear();
+      return *this;
     }
 
     /**
@@ -198,9 +209,9 @@ namespace XbmcCommons
 
     inline unsigned char* array() { return buffer; }
     inline unsigned char* curPosition() { return buffer + mposition; }
-    inline void setPosition(size_t position) { mposition = position; }
-    inline void forward(size_t positionIncrement) throw(BufferException)
-    { check(positionIncrement); mposition += positionIncrement; }
+    inline Buffer& setPosition(size_t position) { mposition = position; return *this; }
+    inline Buffer& forward(size_t positionIncrement) throw(BufferException)
+    { check(positionIncrement); mposition += positionIncrement; return *this; }
 
     inline size_t limit() const { return mlimit; }
     inline size_t capacity() const { return mcapacity; }

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -235,6 +235,13 @@ namespace XbmcCommons
     inline Buffer& putString(const std::string& str) throw (BufferException) { size_t len = str.length() + 1; check(len); put(str.c_str(), len); return (*this); }
 
     inline std::string getString() throw (BufferException) { std::string ret((const char*)(buffer + mposition)); size_t len = ret.length() + 1; check(len); mposition += len; return ret; }
+    inline std::string getString(size_t length) throw (BufferException) 
+    { 
+      check(length); 
+      std::string ret((const char*)(buffer + mposition),length);
+      mposition += length;
+      return ret;
+    }
     inline char* getCharPointerDirect() throw (BufferException) { char* ret = (char*)(buffer + mposition); size_t len = strlen(ret) + 1; check(len); mposition += len; return ret; }
 
   };

--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -26,7 +26,7 @@ namespace XBMCAddon
 
   namespace xbmcvfs
   {
-    XbmcCommons::Buffer File::read(unsigned long numBytes)
+    XbmcCommons::Buffer File::readBytes(unsigned long numBytes)
     {
       DelayedCallGuard dg(languageHook);
       int64_t size = file->GetLength();

--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -53,7 +53,7 @@ namespace XBMCAddon
       return ret;
     }
 
-    long File::write(XbmcCommons::Buffer& buffer)
+    bool File::write(XbmcCommons::Buffer& buffer)
     {
       DelayedCallGuard dg(languageHook);
       unsigned long totalBytesWritten = 0;
@@ -65,9 +65,9 @@ namespace XBMCAddon
                                      //  it could mean something else when a negative number means an error
                                      //  (see CCurlFile). There is no consistency so we can only assume we're
                                      //  done when we get a 0.
-          return totalBytesWritten;  // And we'll return what we've already read.
+          return false;
         else if (bytesWritten < 0)   // But, if we get something less than zero, we KNOW it's an error.
-          return bytesWritten;       //  so we'll return whatever the indication was.
+          return false;
         buffer.forward(bytesWritten);// Otherwise, we advance the buffer by the amount written.
       }
       return totalBytesWritten;

--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -26,18 +26,51 @@ namespace XBMCAddon
 
   namespace xbmcvfs
   {
-    unsigned long File::read(void* buffer, unsigned long numBytes)
+    XbmcCommons::Buffer File::read(unsigned long numBytes)
     {
       DelayedCallGuard dg(languageHook);
-      if (!numBytes)
-        numBytes = (unsigned long)file->GetLength();
-      return (unsigned long)file->Read(buffer, numBytes);
+      int64_t size = file->GetLength();
+      if (!numBytes || (((int64_t)numBytes) > size))
+        numBytes = (unsigned long) size;
+
+      
+      XbmcCommons::Buffer ret(numBytes);
+
+      if (numBytes == 0)
+        return ret;
+
+      while(ret.remaining() > 0)
+      {
+        int bytesRead = file->Read(ret.curPosition(), ret.remaining());
+        if (bytesRead == 0) // we consider this a failure or a EOF, can't tell which,
+        {                   //  return whatever we have already.
+          ret.flip();
+          return ret;
+        }
+        ret.forward(bytesRead);
+      }
+      ret.flip();
+      return ret;
     }
 
-    bool File::write(const char* pBuffer)
+    long File::write(XbmcCommons::Buffer& buffer)
     {
       DelayedCallGuard dg(languageHook);
-      return file->Write( (void*) pBuffer, strlen( pBuffer ) ) > 0;
+      unsigned long totalBytesWritten = 0;
+      while (buffer.remaining() > 0)
+      {
+        int bytesWritten = file->Write( buffer.curPosition(), buffer.remaining());
+        totalBytesWritten += bytesWritten;
+        if (bytesWritten == 0)       // this could be a failure (see HDFile, and XFileUtils) or
+                                     //  it could mean something else when a negative number means an error
+                                     //  (see CCurlFile). There is no consistency so we can only assume we're
+                                     //  done when we get a 0.
+          return totalBytesWritten;  // And we'll return what we've already read.
+        else if (bytesWritten < 0)   // But, if we get something less than zero, we KNOW it's an error.
+          return bytesWritten;       //  so we'll return whatever the indication was.
+        buffer.forward(bytesWritten);// Otherwise, we advance the buffer by the amount written.
+      }
+      return totalBytesWritten;
     }
 
   }

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -58,7 +58,25 @@ namespace XBMCAddon
       /**
        * read(bytes)
        * 
-       * bytes : how many bytes to read [opt]- if not set it will read the whole fi
+       * bytes : how many bytes to read [opt]- if not set it will read the whole file
+       *
+       * returns: string
+       * 
+       * example:
+       *  f = xbmcvfs.File(file)
+       *  b = f.read()
+       *  f.close()
+       */
+      inline String read(unsigned long numBytes = 0) 
+      { 
+        XbmcCommons::Buffer b = readBytes(numBytes);
+        return b.getString(numBytes == 0 ? b.limit() : numBytes);
+      }
+
+      /**
+       * readBytes(numbytes)
+       * 
+       * numbytes : how many bytes to read [opt]- if not set it will read the whole file
        *
        * returns: bytearray
        * 
@@ -67,7 +85,7 @@ namespace XBMCAddon
        *  b = f.read()
        *  f.close()
        */
-      XbmcCommons::Buffer read(unsigned long numBytes = 0);
+      XbmcCommons::Buffer readBytes(unsigned long numBytes = 0);
 
       /**
        * write(buffer)

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -25,6 +25,7 @@
 #include "AddonString.h"
 #include "AddonClass.h"
 #include "LanguageHook.h"
+#include "commons/Buffer.h"
 
 namespace XBMCAddon
 {
@@ -54,19 +55,19 @@ namespace XBMCAddon
 
       inline ~File() { delete file; }
 
-#ifndef SWIG
       /**
        * read(bytes)
        * 
        * bytes : how many bytes to read [opt]- if not set it will read the whole fi
+       *
+       * returns: bytearray
        * 
        * example:
        *  f = xbmcvfs.File(file)
        *  b = f.read()
        *  f.close()
        */
-      unsigned long read(void* buffer, unsigned long numBytes = 0);
-#endif
+      XbmcCommons::Buffer read(unsigned long numBytes = 0);
 
       /**
        * write(buffer)
@@ -78,7 +79,7 @@ namespace XBMCAddon
        *  result = f.write(buffer)
        *  f.close()
        */
-      bool write(const char* file);
+      long write(XbmcCommons::Buffer& buffer);
 
       /**
        * size()

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -70,7 +70,7 @@ namespace XBMCAddon
       inline String read(unsigned long numBytes = 0) 
       { 
         XbmcCommons::Buffer b = readBytes(numBytes);
-        return b.getString(numBytes == 0 ? b.limit() : numBytes);
+        return b.getString(numBytes == 0 ? b.remaining() : std::min(b.remaining(),numBytes));
       }
 
       /**

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -90,14 +90,16 @@ namespace XBMCAddon
       /**
        * write(buffer)
        * 
-       * buffer : buffer to write to fi
+       * buffer : buffer to write to file
+       *
+       * returns: true on success.
        * 
        * example:
        *  f = xbmcvfs.File(file, 'w', True)
        *  result = f.write(buffer)
        *  f.close()
        */
-      long write(XbmcCommons::Buffer& buffer);
+      bool write(XbmcCommons::Buffer& buffer);
 
       /**
        * size()

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -24,11 +24,15 @@
 #include "cores/VideoRenderers/RenderManager.h"
 #include "cores/VideoRenderers/RenderCapture.h"
 #include "AddonClass.h"
+#include "Exception.h"
+#include "commons/Buffer.h"
 
 namespace XBMCAddon
 {
   namespace xbmc
   {
+    XBMCCOMMONS_STANDARD_EXCEPTION(RenderCaptureException);
+
     class RenderCapture : public AddonClass
     {
       CRenderCapture* m_capture;
@@ -71,25 +75,17 @@ namespace XBMCAddon
       }
 
       // RenderCapture_GetImage
-      // TODO: This needs to be done with a class that holds the Image
-      // data. A memory buffer type. Then a typemap needs to be defined
-      // for that type.
       /**
        * getImage() -- returns captured image as a bytearray.
        * 
        * The size of the image is getWidth() * getHeight() * 4
        */
-//      PyObject* RenderCapture_GetImage(RenderCapture *self, PyObject *args)
-//      {
-//        if (self->capture->GetUserState() != CAPTURESTATE_DONE)
-//        {
-//          PyErr_SetString(PyExc_SystemError, "illegal user state");
-//          return NULL;
-//        }
-//
-//        Py_ssize_t size = self->capture->GetWidth() * self->capture->GetHeight() * 4;
-//        return PyByteArray_FromStringAndSize((const char *)self->capture->GetPixels(), size);
-//      }
+      inline XbmcCommons::Buffer getImage() throw(RenderCaptureException)
+      {
+        if (GetUserState() != CAPTURESTATE_DONE)
+          throw RenderCaptureException("illegal user state");
+        return XbmcCommons::Buffer(this->GetPixels(), getWidth() * getHeight() * 4);
+      }
 
       /**
        * capture(width, height [, flags]) -- issue capture request.

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -84,7 +84,8 @@ namespace XBMCAddon
       {
         if (GetUserState() != CAPTURESTATE_DONE)
           throw RenderCaptureException("illegal user state");
-        return XbmcCommons::Buffer(this->GetPixels(), getWidth() * getHeight() * 4);
+        size_t size = getWidth() * getHeight() * 4;
+        return XbmcCommons::Buffer(this->GetPixels(), size).forward(size).flip();
       }
 
       /**

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -57,6 +57,8 @@ Helper.setup(this,classes,
       'float': '${result} = Py_BuildValue((char*)"f", ${api});',
       'String' : new File('typemaps/python.string.outtm'),
       'p.q(const).char' : '${result} = PyString_FromString(${api});',
+      (Pattern.compile('''(p.){0,1}XbmcCommons::Buffer''')) : new File('typemaps/python.buffer.outtm'),
+      (Pattern.compile('''boost::shared_ptr<\\(.*\\)>''')) : new File('typemaps/python.boost_shared_ptr.outtm'),
       (Pattern.compile('''(p.){0,1}std::vector<\\(.*\\)>''')) : new File('typemaps/python.vector.outtm'),
       (Pattern.compile('''(p.){0,1}Tuple<\\(.*\\)>''')) : new File('typemaps/python.Tuple.outtm'),
       (Pattern.compile('''(p.){0,1}Alternative<\\(.*\\)>''')) : new File('typemaps/python.Alternative.outtm')
@@ -77,6 +79,7 @@ Helper.setup(this,classes,
       //  parameter declarations. TODO: Maybe I should fix this.
       'r.q(const).Dictionary' : new File('typemaps/python.dict.intm'),
       'r.q(const).XBMCAddon::Dictionary' : new File('typemaps/python.dict.intm'),
+      (Pattern.compile('''(r.){0,1}XbmcCommons::Buffer''')) : new File('typemaps/python.buffer.intm'),
       (Pattern.compile('''(p.){0,1}std::map<\\(.*\\)>''')) : new File('typemaps/python.map.intm'),
       'bool' : '${api} = (PyInt_AsLong(${slarg}) == 0L ? false : true);',
       'long' : '${api} = PyInt_AsLong(${slarg});'

--- a/xbmc/interfaces/python/typemaps/python.boost_shared_ptr.outtm
+++ b/xbmc/interfaces/python/typemaps/python.boost_shared_ptr.outtm
@@ -1,5 +1,6 @@
+<%
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -18,31 +19,12 @@
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */
-
-%module xbmcvfs
-
-%{
-#include "interfaces/legacy/ModuleXbmcvfs.h"
-#include "interfaces/legacy/File.h"
-#include "interfaces/legacy/Stat.h"
-#include "utils/log.h"
-
-using namespace XBMCAddon;
-using namespace xbmcvfs;
-
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-
-%}
-
-%include "interfaces/legacy/File.h"
-
-%rename ("st_atime") XBMCAddon::xbmcvfs::Stat::atime;
-%rename ("st_mtime") XBMCAddon::xbmcvfs::Stat::mtime;
-%rename ("st_ctime") XBMCAddon::xbmcvfs::Stat::ctime;
-%include "interfaces/legacy/Stat.h"
-
-%rename ("delete") XBMCAddon::xbmcvfs::deleteFile;
-%include "interfaces/legacy/ModuleXbmcvfs.h"
-
+%>
+<%
+    matcher = type =~ /shared_ptr<\((.*)\)>/
+    itype = matcher[0][1]
+    pointertype = swigTypeParser.SwigType_makepointer(itype)
+    int seq = sequence.increment()
+%>
+    ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(pointertype))} entry${seq} = ${api}.get();
+    ${helper.getOutConversion(pointertype,'result',method,[ 'api' : 'entry' + seq, 'sequence' : sequence ])}

--- a/xbmc/interfaces/python/typemaps/python.buffer.intm
+++ b/xbmc/interfaces/python/typemaps/python.buffer.intm
@@ -1,5 +1,6 @@
+<%
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -18,31 +19,21 @@
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */
-
-%module xbmcvfs
-
-%{
-#include "interfaces/legacy/ModuleXbmcvfs.h"
-#include "interfaces/legacy/File.h"
-#include "interfaces/legacy/Stat.h"
-#include "utils/log.h"
-
-using namespace XBMCAddon;
-using namespace xbmcvfs;
-
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-
-%}
-
-%include "interfaces/legacy/File.h"
-
-%rename ("st_atime") XBMCAddon::xbmcvfs::Stat::atime;
-%rename ("st_mtime") XBMCAddon::xbmcvfs::Stat::mtime;
-%rename ("st_ctime") XBMCAddon::xbmcvfs::Stat::ctime;
-%include "interfaces/legacy/Stat.h"
-
-%rename ("delete") XBMCAddon::xbmcvfs::deleteFile;
-%include "interfaces/legacy/ModuleXbmcvfs.h"
-
+%>
+    if (PyString_Check(${slarg}))
+    {
+      const char* str = PyString_AsString(${slarg});
+      size_t size = (size_t)PyString_Size(${slarg});
+      ${api}.allocate(size);
+      ${api}.put(str,size);
+      ${api}.flip(); // prepare the buffer for reading from
+    }
+    else if (PyByteArray_Check(${slarg}))
+    {
+      size_t size = PyByteArray_Size(${slarg});
+      ${api}.allocate(size);
+      ${api}.put(PyByteArray_AsString(${slarg}),size);
+      ${api}.flip(); // prepare the buffer for reading from
+    }
+    else
+      throw XBMCAddon::WrongTypeException("argument \"%s\" for \"%s\" must be a string or a bytearray", "${api}", "${method.@name}");

--- a/xbmc/interfaces/python/typemaps/python.buffer.outtm
+++ b/xbmc/interfaces/python/typemaps/python.buffer.outtm
@@ -1,5 +1,6 @@
+<%
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -18,31 +19,9 @@
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */
-
-%module xbmcvfs
-
-%{
-#include "interfaces/legacy/ModuleXbmcvfs.h"
-#include "interfaces/legacy/File.h"
-#include "interfaces/legacy/Stat.h"
-#include "utils/log.h"
-
-using namespace XBMCAddon;
-using namespace xbmcvfs;
-
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-
-%}
-
-%include "interfaces/legacy/File.h"
-
-%rename ("st_atime") XBMCAddon::xbmcvfs::Stat::atime;
-%rename ("st_mtime") XBMCAddon::xbmcvfs::Stat::mtime;
-%rename ("st_ctime") XBMCAddon::xbmcvfs::Stat::ctime;
-%include "interfaces/legacy/Stat.h"
-
-%rename ("delete") XBMCAddon::xbmcvfs::deleteFile;
-%include "interfaces/legacy/ModuleXbmcvfs.h"
-
+%>
+<%
+    boolean ispointer = swigTypeParser.SwigType_ispointer(type)
+    String accessor = ispointer ? '->' : '.'
+%>
+    ${result} = PyByteArray_FromStringAndSize((char*)${api}${accessor}curPosition(),${api}${accessor}remaining());

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -114,21 +114,19 @@ using namespace xbmc;
 
 %include "interfaces/legacy/Player.h"
 
- // TODO: This needs to be done with a class that holds the Image
- // data. A memory buffer type. Then a typemap needs to be defined
- // for that type.
-%feature("python:method:getImage") RenderCapture
-{
-  RenderCapture* rc = ((RenderCapture*)retrieveApiInstance((PyObject*)self,&PyXBMCAddon_xbmc_RenderCapture_Type,"getImage","XBMCAddon::xbmc::RenderCapture"));
-  if (rc->GetUserState() != CAPTURESTATE_DONE)
-  {
-    PyErr_SetString(PyExc_SystemError, "illegal user state");
-    return NULL;
-  }
-  
-  Py_ssize_t size = rc->getWidth() * rc->getHeight() * 4;
-  return PyByteArray_FromStringAndSize((const char *)rc->GetPixels(), size);
-}
+
+//%feature("python:method:getImage") RenderCapture
+//{
+//  RenderCapture* rc = ((RenderCapture*)retrieveApiInstance((PyObject*)self,&PyXBMCAddon_xbmc_RenderCapture_Type,"getImage","XBMCAddon::xbmc::RenderCapture"));
+//  if (rc->GetUserState() != CAPTURESTATE_DONE)
+//  {
+//    PyErr_SetString(PyExc_SystemError, "illegal user state");
+//    return NULL;
+//  }
+//  
+//  Py_ssize_t size = rc->getWidth() * rc->getHeight() * 4;
+//  return PyByteArray_FromStringAndSize((const char *)rc->GetPixels(), size);
+//}
 
 %include "interfaces/legacy/RenderCapture.h"
 

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -114,20 +114,6 @@ using namespace xbmc;
 
 %include "interfaces/legacy/Player.h"
 
-
-//%feature("python:method:getImage") RenderCapture
-//{
-//  RenderCapture* rc = ((RenderCapture*)retrieveApiInstance((PyObject*)self,&PyXBMCAddon_xbmc_RenderCapture_Type,"getImage","XBMCAddon::xbmc::RenderCapture"));
-//  if (rc->GetUserState() != CAPTURESTATE_DONE)
-//  {
-//    PyErr_SetString(PyExc_SystemError, "illegal user state");
-//    return NULL;
-//  }
-//  
-//  Py_ssize_t size = rc->getWidth() * rc->getHeight() * 4;
-//  return PyByteArray_FromStringAndSize((const char *)rc->GetPixels(), size);
-//}
-
 %include "interfaces/legacy/RenderCapture.h"
 
 %include "interfaces/legacy/InfoTagMusic.h"


### PR DESCRIPTION
This PR introduces a "Buffer" class usable from the addons. It's used to replace the custom codegenerator code in the RenderCapture and also for xbmcvfs read/write.
