### PR TITLE
FIX: in CDAVDirectory::Exists, using PROPFIND without depth might return 403

### DIFF
--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -219,6 +219,7 @@ bool CDAVDirectory::Exists(const char* strPath)
   // on the server's configuration
   CStdString strRequest = "PROPFIND";
   dav.SetCustomRequest(strRequest);
+  dav.SetRequestHeader("depth", 0);
 
   CURL url(strPath);
   return dav.Exists(url);


### PR DESCRIPTION
Not specifying a "depth" to a propfind is equivalent to "infinite", and "infinite" (besides being pointless here) is disabled by default on apache (http://httpd.apache.org/docs/2.2/mod/mod_dav.html#davdepthinfinity).
