### PR TITLE
Fix CGUIWindowSlideShow::RenderErrorMessage() to not spam log.

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -803,7 +803,6 @@ void CGUIWindowSlideShow::RenderErrorMessage()
   const CGUIControl *control = GetControl(LABEL_ROW1);
   if (NULL == control || control->GetControlType() != CGUIControl::GUICONTROL_LABEL)
   {
-     CLog::Log(LOGERROR,"CGUIWindowSlideShow::RenderErrorMessage - cant get label control!");
      return;
   }
 


### PR DESCRIPTION
this function be called by CGUIWindowSlideShow::Render() each time. and there's another log triggered by the error flag in CGUIWindowSlideShow::Process, so if the GetControl failed, it will produce 2 messages each round, which can not be catch by the log duplication detection, then spam.
