### PR TITLE
OverlayContainer: release render resources on cleanup

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -103,6 +103,12 @@ public:
 
   bool IsOverlayType(DVDOverlayType type) { return (m_type == type); }
 
+  /**
+   * return a copy to DVDPlayerSubtitle in order to have hw resources cleared
+   * after rendering
+   */
+  virtual CDVDOverlay* Clone() { return Acquire(); }
+
   double iPTSStartTime;
   double iPTSStopTime;
   bool bForced; // display, no matter what

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "PlatformDefs.h"
 #include "DVDOverlay.h"
 #include <string.h>
 #include <stdlib.h>
@@ -115,6 +116,11 @@ public:
   {
     if(data) free(data);
     if(palette) free(palette);
+  }
+
+  virtual CDVDOverlayImage* Clone()
+  {
+    return new CDVDOverlayImage(*this);
   }
 
   BYTE* data_at(int sub_x, int sub_y) const

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySSA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySSA.h
@@ -37,10 +37,21 @@ public:
     libass->Acquire();
   }
 
+  CDVDOverlaySSA(CDVDOverlaySSA& src)
+    : CDVDOverlay(src)
+    , m_libass(src.m_libass)
+  {
+    m_libass->Acquire();
+  }
+
   ~CDVDOverlaySSA()
   {
     if(m_libass)
       SAFE_RELEASE(m_libass);
   }
 
+  virtual CDVDOverlaySSA* Clone()
+  {
+    return new CDVDOverlaySSA(*this);
+  }
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayText.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayText.h
@@ -46,6 +46,12 @@ public:
       m_type = type;
     }
 
+    CElement(CElement& src)
+    {
+      pNext  = NULL;
+      m_type = src.m_type;
+    }
+
     virtual ~CElement()
     {
     }
@@ -71,6 +77,12 @@ public:
       }
     }
 
+    CElementText(CElementText& src)
+     : CElement(src)
+    {
+      m_text = strdup(src.m_text);
+    }
+
     virtual ~CElementText()
     {
       if (m_text) free(m_text);
@@ -81,10 +93,18 @@ public:
 
   class CElementProperty : public CElement
   {
+  public:
     CElementProperty() : CElement(ELEMENT_TYPE_PROPERTY)
     {
       bItalic = false;
       bBold = false;
+    }
+
+    CElementProperty(CElementProperty& src)
+    : CElement(src)
+    {
+      bItalic = src.bItalic;
+      bBold   = src.bBold;
     }
 
   public:
@@ -99,6 +119,22 @@ public:
     m_pEnd = NULL;
   }
 
+  CDVDOverlayText(CDVDOverlayText& src)
+    : CDVDOverlay(src)
+  {
+    m_pHead = NULL;
+    m_pEnd = NULL;
+    for(CElement* e = src.m_pHead; e; e = e->pNext)
+    {
+      if(e->IsElementType(ELEMENT_TYPE_TEXT))
+        AddElement(new CElementText(*static_cast<CElementText*>(e)));
+      else if(e->IsElementType(ELEMENT_TYPE_PROPERTY))
+        AddElement(new CElementProperty(*static_cast<CElementProperty*>(e)));
+      else
+        AddElement(new CElement(*static_cast<CElement*>(e)));
+    }
+  }
+
   virtual ~CDVDOverlayText()
   {
     CElement* pTemp;
@@ -108,6 +144,11 @@ public:
       m_pHead = m_pHead->pNext;
       delete pTemp;
     }
+  }
+
+  virtual CDVDOverlayText* Clone()
+  {
+    return new CDVDOverlayText(*this);
   }
 
   void AddElement(CDVDOverlayText::CElement* pElement)

--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
@@ -222,6 +222,7 @@ void CDVDPlayerSubtitle::Process(double pts)
     while(pOverlay)
     {
       m_pOverlayContainer->Add(pOverlay);
+      pOverlay->Release();
       pOverlay = m_pSubtitleFileParser->Parse(pts);
     }
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParser.h
@@ -47,7 +47,13 @@ public:
     m_filename = strFile;
   }
   virtual ~CDVDSubtitleParserCollection() { }
-  virtual CDVDOverlay* Parse(double iPts) { return m_collection.Get(iPts); }
+  virtual CDVDOverlay* Parse(double iPts)
+  {
+    CDVDOverlay* o = m_collection.Get(iPts);
+    if(o == NULL)
+      return o;
+    return o->Clone();
+  }
   virtual void         Reset()            { m_collection.Reset(); }
   virtual void         Dispose()          { m_collection.Clear(); }
 


### PR DESCRIPTION
If subtitles are loaded from a separate file, it seems that they are ref counted elsewhere. Render resources are not cleared until the video is stopped. The Pi runs out of GPU memory after an hour of playback.
Credits to @popcornmix for tracking this down.
