### PR TITLE
[Lircmap.xml] Added some missing keys for devinput

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -443,7 +443,9 @@
 		<myvideo>KEY_VIDEO</myvideo>
 		<mymusic>KEY_AUDIO</mymusic>
 		<mypictures>KEY_MHP</mypictures>
+		<mypictures>KEY_CAMERA</mypictures>
 		<mytv>KEY_TV</mytv>
+		<liveradio>KEY_RADIO</liveradio>
 		<one>KEY_1</one>
 		<two>KEY_2</two>
 		<three>KEY_3</three>
@@ -454,6 +456,16 @@
 		<eight>KEY_8</eight>
 		<nine>KEY_9</nine>
 		<zero>KEY_0</zero>
+		<one>KEY_NUMERIC_1</one>
+		<two>KEY_NUMERIC_2</two>
+		<three>KEY_NUMERIC_3</three>
+		<four>KEY_NUMERIC_4</four>
+		<five>KEY_NUMERIC_5</five>
+		<six>KEY_NUMERIC_6</six>
+		<seven>KEY_NUMERIC_7</seven>
+		<eight>KEY_NUMERIC_8</eight>
+		<nine>KEY_NUMERIC_9</nine>
+		<zero>KEY_NUMERIC_0</zero>
 		<red>KEY_RED</red>
 		<green>KEY_GREEN</green>
 		<yellow>KEY_YELLOW</yellow>
@@ -465,6 +477,7 @@
 		<display>KEY_ANGLE</display>
 		<recordedtv>KEY_PVR</recordedtv>
 		<teletext>KEY_TEXT</teletext>
+		<clear>KEY_DELETE</clear>
 	</remote>
 	<remote device="mediacenter">
 		<pause>pause</pause>


### PR DESCRIPTION
Added some missing keys for remotes using devinput. These were taken from my MCE remote.

$ irw
201 0 KEY_NUMERIC_1 devinput
202 0 KEY_NUMERIC_2 devinput
203 0 KEY_NUMERIC_3 devinput
204 0 KEY_NUMERIC_4 devinput
205 0 KEY_NUMERIC_5 devinput
206 0 KEY_NUMERIC_6 devinput
207 0 KEY_NUMERIC_7 devinput
208 0 KEY_NUMERIC_8 devinput
209 0 KEY_NUMERIC_9 devinput
200 0 KEY_NUMERIC_0 devinput
6f 0 KEY_DELETE devinput - Clear
d4 0 KEY_CAMERA devinput - Pictures
181 0 KEY_RADIO devinput
