### PR TITLE
[rbp] Fix for stuttery video when seeking before zero

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -42,7 +42,6 @@ using namespace std;
 class OMXPlayerAudio : public CThread
 {
 protected:
-  CCriticalSection      m_flushLock;
   CDVDMessageQueue      m_messageQueue;
   CDVDMessageQueue      &m_messageParent;
 

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -61,6 +61,7 @@ protected:
   int                       m_audio_count;
   bool                      m_stalled;
   bool                      m_started;
+  bool                      m_flush;
   std::string               m_codecname;
   double                    m_droptime;
   double                    m_dropbase;

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -809,17 +809,12 @@ int COMXVideo::Decode(uint8_t *pData, int iSize, double dts, double pts)
         // only send dts on first frame to get nearly correct starttime
         if(pts == DVD_NOPTS_VALUE)
           pts = dts;
-        if(pts == DVD_NOPTS_VALUE)
-          omx_buffer->nFlags |= OMX_BUFFERFLAG_TIME_UNKNOWN;
-        omx_buffer->nFlags = OMX_BUFFERFLAG_STARTTIME;
+        omx_buffer->nFlags |= OMX_BUFFERFLAG_STARTTIME;
         CLog::Log(LOGDEBUG, "OMXVideo::Decode VDec : setStartTime %f\n", (pts == DVD_NOPTS_VALUE ? 0.0 : pts) / DVD_TIME_BASE);
         m_av_clock->VideoStart(false);
       }
-      else
-      {
-        if(pts == DVD_NOPTS_VALUE)
-          omx_buffer->nFlags = OMX_BUFFERFLAG_TIME_UNKNOWN;
-      }
+      if(pts == DVD_NOPTS_VALUE)
+        omx_buffer->nFlags |= OMX_BUFFERFLAG_TIME_UNKNOWN;
 
       omx_buffer->nTimeStamp = ToOMXTime((uint64_t)(pts == DVD_NOPTS_VALUE) ? 0 : pts);
       omx_buffer->nFilledLen = (demuxer_bytes > omx_buffer->nAllocLen) ? omx_buffer->nAllocLen : demuxer_bytes;


### PR DESCRIPTION
There are a few issues with seeking I found.
We weren't correctly setting OMX_BUFFERFLAG_TIME_UNKNOWN on the first frame after a seek which could make the GPU think video was at 0 and audio at a much larger offset.
A full video fifo (to GPU) stops any higher priority messages from being received which can stall a seek and the flush message doesn't get through. Use m_flush to discard the video packet that doesn't fit.
We get an audio frame through with unknown pts/dts after the flush, but before the GENERAL_RESYNC when seeking. This was given to GPU and was perhaps 30 seconds out from the following packets and that throws off the timing between audio and video streams. Keeping m_flush true until the GENERAL_RESYNC discards this frame. Hopefully that is safe.
