### PR TITLE
Fix video in slideshow not show and hang in black problem.

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -287,8 +287,12 @@ void CGUIWindowSlideShow::Add(const CFileItem *picture)
   CFileItemPtr item(new CFileItem(*picture));
   if (!item->HasVideoInfoTag() && !item->HasPictureInfoTag())
   {
-    // item without tag; assume it is a picture and force tag generation
-    item->GetPictureInfoTag();
+    // item without tag; get mimetype then we can tell whether it's video item
+    item->GetMimeType();
+
+    if (!item->IsVideo())
+      // then it is a picture and force tag generation
+      item->GetPictureInfoTag();
   }
   AnnouncePlaylistAdd(item, m_slides->Size());
 


### PR DESCRIPTION
This is a simple version of https://github.com/xbmc/xbmc/pull/2164
By call GetMimeType() for items without either picture or video info tag. then we can detect video item. current old code will trade such items as picture and hang there.

There will be additional commit for minor fix slideshow video related problem will be added after this, but less than what in https://github.com/xbmc/xbmc/pull/2164 thanks @DigitalDJ for the initial PR for this.
