### PR TITLE
Realtime streaming and interactive TV optimization parameters in advancedsettings.xml

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -425,7 +425,14 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
 
   // set the interrupt callback, appeared in libavformat 53.15.0
   m_pFormatContext->interrupt_callback = int_cb;
-
+  
+  // Analyze m_maxAnalyzeDuration microseconds of the stream. Default (as in ffmpeg): 5000000 usecs
+  m_pFormatContext->max_analyze_duration = g_advancedSettings.m_ffmpegMaxAnalyzeDuration;
+  
+  // For formats without headers, analyze m_probeSize bytes of the stream to get info about it. Default 5MB.
+  m_pFormatContext->probesize = g_advancedSettings.m_ffmpegProbeSize;
+  
+  
   // analyse very short to speed up mjpeg playback start
   if (iformat && (strcmp(iformat->name, "mjpeg") == 0) && m_ioContext->seekable == 0)
     m_pFormatContext->max_analyze_duration = 500000;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -298,6 +298,10 @@ void CAdvancedSettings::Initialize()
   m_measureRefreshrate = false;
 
   m_cacheMemBufferSize = 1024 * 1024 * 20;
+  
+  m_ffmpegMaxAnalyzeDuration = 5000000;
+  m_ffmpegProbeSize = 5000000;
+  
   m_addonPackageFolderSize = 200;
 
   m_jsonOutputCompact = true;
@@ -681,6 +685,13 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
+  }
+  
+  pElement = pRootElement->FirstChildElement("ffmpeg");
+  if(pElement) 
+  {
+    XMLUtils::GetUInt(pElement, "maxanalyzeduration", m_ffmpegMaxAnalyzeDuration);
+    XMLUtils::GetUInt(pElement, "probesize", m_ffmpegProbeSize);
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -349,6 +349,10 @@ class CAdvancedSettings
     unsigned int m_addonPackageFolderSize;
 
     unsigned int m_cacheMemBufferSize;
+    
+    
+    unsigned int m_ffmpegMaxAnalyzeDuration;
+    unsigned int m_ffmpegProbeSize;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;


### PR DESCRIPTION
For those formats with no headers (ie. mpegts), ffmpeg probes¹ the stream during $max_analyze_duration² microseconds (5.0 seconds by default) or $probesize³ bytes (default 5MB) in order to obtain information (codec, bitrate,...) about the media. For real-time multimedia streaming applications and interative TV services 5 seconds (or 5MB) are too much, given that for most cases 60ms of $max_analyze_duration and 100KB of $probesize is enough. This patch allows you to set those parameters in advancedsettings.xml.

If this patch is approved, advancedsettings.xml wiki page (http://wiki.xbmc.org/index.php?title=Advancedsettings.xml) should be updated with the new options (included in the new 'ffmpeg' element). 

---

¹: This probing is done at libavformat avformat_find_stream_info() method http://ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#gad42172e27cddafb81096939783b157bb 
²: max_analyze_duration http://ffmpeg.org/doxygen/trunk/structAVFormatContext.html#aa1f733fdfa1655d9e6ccc80f6b926274
³: probesize http://ffmpeg.org/doxygen/trunk/structAVFormatContext.html#afcff2757459cf56050b2d908f46957b0
