### PR TITLE
AE: Fix resample of e.g. 192 khz to 48 khz audio by scaling refillbuffer and waterlevel

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -196,6 +196,13 @@ void CSoftAEStream::Initialize()
     m_ssrcData.data_out      = (float*)_aligned_malloc(m_format.m_frameSamples * (int)std::ceil(m_ssrcData.src_ratio) * sizeof(float), 16);
     m_ssrcData.output_frames = m_format.m_frames * (long)std::ceil(m_ssrcData.src_ratio);
     m_ssrcData.end_of_input  = 0;
+    // we must buffer the same amount as before but taking the source sample rate into account
+    // there is no reason to decrease the buffer for upsampling
+    if (m_internalRatio < 1)
+    {
+      m_waterLevel *= (1.0 / m_internalRatio);
+      m_refillBuffer = m_waterLevel;
+    }
   }
 
   m_limiter.SetSamplerate(AE.GetSampleRate());


### PR DESCRIPTION
We need enough data in the buffer to not Underrun.
