### PR TITLE
Speed up ffmpeg format probing if we'll trust codec fps for playback

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -426,6 +426,10 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
   // set the interrupt callback, appeared in libavformat 53.15.0
   m_pFormatContext->interrupt_callback = int_cb;
 
+  // Avoid detecting framerate if advancedsettings.xml says so
+  if (g_advancedSettings.m_videoFpsDetect == 0) 
+      m_pFormatContext->fps_probe_size = 0;
+  
   // analyse very short to speed up mjpeg playback start
   if (iformat && (strcmp(iformat->name, "mjpeg") == 0) && m_ioContext->seekable == 0)
     m_pFormatContext->max_analyze_duration = 500000;


### PR DESCRIPTION
This small change allows you to (re)use the pre-exiting advancedsettings.xml 'fpsdetect' option in order to reduce the playback starting time.

Until now, 'fpsdetect' was only used in the video players, with values:

0 = trust codec fps
1 = recalculate from video timestamps with uniform spacing
2 = recalculate from video timestamps always

With this patch AVFormatContext field 'fps_probe_size' will be 0 when we trust codec fps, avoiding spend up to 40 frames¹ per video stream recalculating the framerate.

---

¹: https://github.com/xbmc/xbmc/blob/master/lib/ffmpeg/libavformat/utils.c#L2606
