### PR TITLE
[AESinks] Fix things found by Cppcheck

### DIFF
--- a/xbmc/cores/AudioEngine/AEAudioFormat.h
+++ b/xbmc/cores/AudioEngine/AEAudioFormat.h
@@ -70,7 +70,7 @@ enum AEDataFormat
 /**
  * The audio format structure that fully defines a stream's audio information
  */
-typedef struct {
+typedef struct AEAudioFormat{
   /**
    * The stream's data format (eg, AE_FMT_S16LE)
    */
@@ -105,5 +105,16 @@ typedef struct {
    * The size of one frame in bytes
    */
   unsigned int m_frameSize;
+ 
+  AEAudioFormat()
+  {
+    m_dataFormat = AE_FMT_INVALID;
+    m_sampleRate = 0;
+    m_encodedRate = 0;
+    m_frames = 0;
+    m_frameSamples = 0;
+    m_frameSize = 0;
+  }
+ 
 } AEAudioFormat;
 

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
@@ -556,8 +556,10 @@ void CPulseAEStream::StreamDrainComplete(pa_stream *s, int success, void *userda
 {
   CPulseAEStream *stream = (CPulseAEStream *)userdata;
   if(stream)
+  {
     stream->SetDrained();
-  pa_threaded_mainloop_signal(stream->m_MainLoop, 0);
+    pa_threaded_mainloop_signal(stream->m_MainLoop, 0);
+  }
 }
 
 void CPulseAEStream::ProcessCallbacks()

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -49,7 +49,7 @@ public:
   /*
     Return true if the supplied format and device are compatible with the current open sink
   */
-  virtual bool IsCompatible(const AEAudioFormat format, const std::string device) = 0;
+  virtual bool IsCompatible(const AEAudioFormat format, const std::string &device) = 0;
 
   /*
     This method returns the time in seconds that it will take

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -66,7 +66,11 @@ static unsigned int ALSASampleRateList[] =
 };
 
 CAESinkALSA::CAESinkALSA() :
-  m_pcm(NULL)
+  m_pcm(NULL),
+  m_bufferSize(0),
+  m_formatSampleRateMul(0.0),
+  m_passthrough(false),
+  m_timeout(0)
 {
   /* ensure that ALSA has been initialized */
   if (!snd_config)
@@ -210,7 +214,7 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
   return true;
 }
 
-bool CAESinkALSA::IsCompatible(const AEAudioFormat format, const std::string device)
+bool CAESinkALSA::IsCompatible(const AEAudioFormat format, const std::string &device)
 {
   return (
       /* compare against the requested format and the real format */

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -41,7 +41,7 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat format, const std::string device);
+  virtual bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
   virtual void         Stop            ();
   virtual double       GetDelay        ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -74,6 +74,15 @@ CAESinkAUDIOTRACK::CAESinkAUDIOTRACK()
 {
   m_sinkbuffer = NULL;
   m_alignedS16LE = NULL;
+  m_volume_changed = false;
+  m_min_frames = 0;
+  m_sink_frameSize = 0;
+  m_sinkbuffer_sec = 0.0;
+  m_sinkbuffer_sec_per_byte = 0.0;
+  m_draining = false;
+  m_audiotrackbuffer_sec = 0.0;
+  m_audiotrack_empty_sec = 0.0;
+  m_volume = 0.0;
 #if defined(HAS_AMLPLAYER)
   aml_cpufreq_limit(true);
 #endif
@@ -151,7 +160,7 @@ void CAESinkAUDIOTRACK::Deinitialize()
     _aligned_free(m_alignedS16LE), m_alignedS16LE = NULL;
 }
 
-bool CAESinkAUDIOTRACK::IsCompatible(const AEAudioFormat format, const std::string device)
+bool CAESinkAUDIOTRACK::IsCompatible(const AEAudioFormat format, const std::string &device)
 {
   return ((m_format.m_sampleRate    == format.m_sampleRate) &&
           (m_format.m_dataFormat    == format.m_dataFormat) &&

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -34,7 +34,7 @@ public:
 
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat format, const std::string device);
+  virtual bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
   virtual double       GetDelay        ();
   virtual double       GetCacheTime    ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -36,7 +36,7 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat format, const std::string device);
+  virtual bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
   virtual void         Stop               ();
   virtual double       GetDelay           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
@@ -75,7 +75,7 @@ void CAESinkNULL::Deinitialize()
   StopThread();
 }
 
-bool CAESinkNULL::IsCompatible(const AEAudioFormat format, const std::string device)
+bool CAESinkNULL::IsCompatible(const AEAudioFormat format, const std::string &device)
 {
   return ((m_format.m_sampleRate    == format.m_sampleRate) &&
           (m_format.m_dataFormat    == format.m_dataFormat) &&

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
@@ -33,7 +33,7 @@ public:
 
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat format, const std::string device);
+  virtual bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
   virtual double       GetDelay        ();
   virtual double       GetCacheTime    ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -64,6 +64,7 @@ static int OSSSampleRateList[] =
 
 CAESinkOSS::CAESinkOSS()
 {
+  m_fd = 0;
 }
 
 CAESinkOSS::~CAESinkOSS()
@@ -71,7 +72,7 @@ CAESinkOSS::~CAESinkOSS()
   Deinitialize();
 }
 
-std::string CAESinkOSS::GetDeviceUse(const AEAudioFormat format, const std::string device)
+std::string CAESinkOSS::GetDeviceUse(const AEAudioFormat format, const std::string &device)
 {
 #ifdef OSS4
   if (AE_IS_RAW(format.m_dataFormat))
@@ -287,7 +288,6 @@ bool CAESinkOSS::Initialize(AEAudioFormat &format, std::string &device)
     if (ioctl(m_fd, SNDCTL_DSP_GET_CHNORDER, &order) == -1)
     {
       CLog::Log(LOGWARNING, "CAESinkOSS::Initialize - Failed to get the channel order, assuming CHNORDER_NORMAL");
-      order = CHNORDER_NORMAL;
     }
   }
 #endif
@@ -367,7 +367,7 @@ inline CAEChannelInfo CAESinkOSS::GetChannelLayout(AEAudioFormat format)
   return info;
 }
 
-bool CAESinkOSS::IsCompatible(const AEAudioFormat format, const std::string device)
+bool CAESinkOSS::IsCompatible(const AEAudioFormat format, const std::string &device)
 {
   AEAudioFormat tmp  = format;
   tmp.m_channelLayout = GetChannelLayout(format);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
@@ -35,7 +35,7 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat format, const std::string device);
+  virtual bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
   virtual void         Stop            ();
   virtual double       GetDelay        ();
@@ -51,6 +51,6 @@ private:
   AEAudioFormat   m_format;
 
   CAEChannelInfo  GetChannelLayout(AEAudioFormat format);
-  std::string      GetDeviceUse(const AEAudioFormat format, const std::string device);
+  std::string      GetDeviceUse(const AEAudioFormat format, const std::string &device);
 };
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.cpp
@@ -56,7 +56,7 @@ void CAESinkProfiler::Deinitialize()
 {
 }
 
-bool CAESinkProfiler::IsCompatible(const AEAudioFormat format, const std::string device)
+bool CAESinkProfiler::IsCompatible(const AEAudioFormat format, const std::string &device)
 {
   if (AE_IS_RAW(format.m_dataFormat))
     return false;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.h
@@ -34,7 +34,7 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat format, const std::string device);
+  virtual bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
   virtual double       GetDelay        ();
   virtual double       GetCacheTime    () { return 0.0; }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -37,7 +37,7 @@ public:
 
     virtual bool Initialize  (AEAudioFormat &format, std::string &device);
     virtual void Deinitialize();
-    virtual bool IsCompatible(const AEAudioFormat format, const std::string device);
+    virtual bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
     virtual double       GetDelay                    ();
     virtual double       GetCacheTime                ();


### PR DESCRIPTION
Inspired by @kylhill and curios what can be found with a free tool, I check the sinks with Cppcheck (http://cppcheck.sourceforge.net/).

Commits marked with [_REVIEW_] should be looked more closely by the corresponding dev.

I have not changed warnings like " Member variable 'CAESinkDirectSound::m_running' is not initialized in the constructor., because I don't know if these are considerable. The report of these can be found here: https://gist.github.com/ace20022/b7556b9640563efc9a32
