### PR TITLE
AE: Fix menu sounds decreasing buffer(max 200 ms) and periodSize(50 ms)

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -332,18 +332,19 @@ bool CAESinkALSA::InitializeHW(AEAudioFormat &format)
   snd_pcm_hw_params_get_period_size_max(hw_params, &periodSize, NULL);
 
   /* 
-   We want to make sure, that we have approx 500 to 800 ms Buffer with 
-   a periodSize of approx 100 ms.
-   It is calced:
-   periodSize = sampleRate / 10 
-   buffersize = periodSize * 1 frame * 8.
+   We want to make sure, that we have max 200 ms Buffer with 
+   a periodSize of approx 50 ms. Choosing a higher bufferSize
+   will cause problems with menu sounds. Buffer will be increased
+   after those are fixed.
+   periodSize = sampleRate / 20 
+   bufferSize = periodSize * 1 frame * 4.
   */
-  periodSize  = std::min(periodSize, (snd_pcm_uframes_t) sampleRate / 10);
-  bufferSize  = std::min(bufferSize, (snd_pcm_uframes_t) periodSize * 8);
+  periodSize  = std::min(periodSize, (snd_pcm_uframes_t) sampleRate / 20);
+  bufferSize  = std::min(bufferSize, (snd_pcm_uframes_t) periodSize * 4);
   
   /* 
-     According to upstream we should set buffer size first - so make sure it is always at least
-     double of period size to not get underruns
+   According to upstream we should set buffer size first - so make sure it is always at least
+   double of period size to not get underruns
   */
   periodSize = std::min(periodSize, bufferSize / 2);
 


### PR DESCRIPTION
After last commit, I broke menu sounds, cause of a too large buffer. The menu sounds problem has to be investigated separately. Until this happens, let us go back to save values. 

Advantage over the old values are, that periodSize and bufferSize scale with the sampleRate. The fix of the menu sounds is, that hopefully no one realizes 200ms waiting time in the menus.

I will look into menu sounds later, something like "drain when there is nothing playing" and don't eat silence if not forced - we will see.

@elupus: I hope the larger buffer can come back, as it is rather great for movie playback
@anssih: thx for review
