### PR TITLE
[rbp] Enable Vsync as a default

### DIFF
--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -36,7 +36,7 @@
 #ifdef MID
 #define DEFAULT_VSYNC       VSYNC_DISABLED
 #else  // MID
-#if defined(TARGET_DARWIN) || defined(_WIN32)
+#if defined(TARGET_DARWIN) || defined(_WIN32) || defined(TARGET_RASPBERRY_PI)
 #define DEFAULT_VSYNC       VSYNC_ALWAYS
 #else
 #define DEFAULT_VSYNC       VSYNC_DRIVER


### PR DESCRIPTION
I'll start this PR with the simplest fix, but it's more of an RFC.

Raspberry Pi currently defaults vsync to "let driver decide". This defaults to disabled.

For a low specced device, this is a bad default option. 
Rendering more frames than you can display is pointless. Even f you do choose to use a 24/25/30 Hz mode, then the GUI still tries to update at 60+ fps and the cpu hits 100%.

I think a better fix would be to keep the default vsync as "let driver decide" (for Pi, and probably all platforms). And change the driver's default to enabled.

Would anyone object if this was the case for all platforms?
Is there any reason to run fps above vsync rate apart from benchmarking (which is still available with "always on"
