### PR TITLE
FIX: don't free a null pointer in CXImage

### DIFF
--- a/xbmc/guilib/cximage.cpp
+++ b/xbmc/guilib/cximage.cpp
@@ -30,9 +30,12 @@ CXImage::CXImage(const std::string& strMimeType): m_strMimeType(strMimeType), m_
 
 CXImage::~CXImage()
 {
-  m_dll.FreeMemory(m_thumbnailbuffer);
-  m_dll.ReleaseImage(&m_image);
-  m_dll.Unload();
+  if (m_dll.IsLoaded()) 
+  {
+    m_dll.FreeMemory(m_thumbnailbuffer);
+    m_dll.ReleaseImage(&m_image);
+    m_dll.Unload();
+  }
 }
 
 bool CXImage::LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height)


### PR DESCRIPTION
Got that exception when the Dialog to switch the skin could not find the addon logo.

While I was at it, i thought it is a good idea to not call functions on m_dll when it is not loaded?!?
