### PR TITLE
Correct typo CDVDPlayerAudio:: Discontinuity 1

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -660,7 +660,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
   {
     m_pClock->Discontinuity(clock+error);
     if(m_speed == DVD_PLAYSPEED_NORMAL)
-      CLog::Log(LOGDEBUG, "CDVDPlayerAudio:: Discontinuity1 - was:%f, should be:%f, error:%f", clock, clock+error, error);
+      CLog::Log(LOGDEBUG, "CDVDPlayerAudio:: Discontinuity 1 - was:%f, should be:%f, error:%f", clock, clock+error, error);
 
     m_errorbuff = 0;
     m_errorcount = 0;


### PR DESCRIPTION
`DEBUG: CDVDPlayerAudio:: Discontinuity1 - was:660386.178000, should be:-37959.118334, error:-698345.296334`

Now reads

`DEBUG: CDVDPlayerAudio:: Discontinuity 1 - was:660386.178000, should be:-37959.118334, error:-698345.296334`
