### PR TITLE
Ftp switch from url options to protocol options

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -195,7 +195,7 @@ void CURL::Parse(const CStdString& strURL1)
     sep = "?;#|";
   else if(strProtocol2.Equals("ftp")
        || strProtocol2.Equals("ftps"))
-    sep = "?;";
+    sep = "?;|";
 
   if(sep)
   {


### PR DESCRIPTION
this need https://github.com/xbmc/xbmc/pull/2356 to go in first. for current pr, check the last commit here.

this pr also still keep the support of ftp use url options, but print a deprecated warning log for it.
