### PR TITLE
[IOS] Fix crash when thumb file is unreadable to ios system.

### DIFF
--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -1083,9 +1083,16 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
     NSString *thumb = [item objectForKey:@"thumb"];
     if (thumb && thumb.length > 0)
     {
-      MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:[UIImage imageWithContentsOfFile:thumb]];
-      [dict setObject:mArt forKey:MPMediaItemPropertyArtwork];
-      [mArt release];
+      UIImage *image = [UIImage imageWithContentsOfFile:thumb];
+      if (image)
+      {
+        MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:image];
+        if (mArt)
+        {
+          [dict setObject:mArt forKey:MPMediaItemPropertyArtwork];
+          [mArt release];
+        }
+      }
     }
     // these proprity keys are ios5+ only
     NSNumber *elapsed = [item objectForKey:@"elapsed"];


### PR DESCRIPTION
ios now playing info need the thumb file ensure readable, else may cause crash on my test device, so if the GetArt("thumb") return a skin image file (e.g. DefaultAlbumCover.png) which is also be considered as cached image but without fullpath, ios can not read it.
