### PR TITLE
add #ifdef around UPnP setting things to fix build with --disable-upnp

### DIFF
--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -55,7 +55,9 @@
 #include "filesystem/File.h"
 #include "filesystem/DirectoryCache.h"
 #include "DatabaseManager.h"
+#ifdef HAS_UPNP
 #include "network/upnp/UPnPSettings.h"
+#endif
 #include "utils/RssManager.h"
 
 using namespace std;
@@ -1428,7 +1430,9 @@ void CSettings::Clear()
   m_ResInfo.clear();
   m_Calibrations.clear();
 
+#ifdef HAS_UPNP
   CUPnPSettings::Get().Clear();
+#endif
   CRssManager::Get().Clear();
 }
 


### PR DESCRIPTION
Discovered a build problem on my Gentoo box while updating to latest master (please forgive the german system locale/messages):

```
CPP     xbmc/cores/paplayer/SPCCodec.o
AR      xbmc/cores/paplayer/paplayer.a
LD      xbmc.bin
xbmc/settings/settings.a(Settings.o): In function `CSettings::Clear()':
Settings.cpp:(.text+0x43da): undefined reference to `CUPnPSettings::Get()'
Settings.cpp:(.text+0x43e2): undefined reference to `CUPnPSettings::Clear()'
collect2: Fehler: ld gab 1 als Ende-Status zurück
make: *** [xbmc.bin] Fehler 1
```

This happens when supplying "--disable-upnp" to configure (which in turn is done by USE="-upnp" by the ebuild). https://github.com/xbmc/xbmc/commit/ead4525c45142369bd2e1897e8c5b030fd34f37e seems to have introduced the problem.

The PR fixes that by adding #ifdef HAS_UPNP around the (new) UPnP things in xbmc/settings/Settings.cpp. Build and function tested on Linux and working fine.
