### PR TITLE
Adjusted OMXPlayer buffersize to be like DVDPlayer's.

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -83,7 +83,7 @@ OMXPlayerAudio::OMXPlayerAudio(OMXClock *av_clock, CDVDMessageQueue& parent)
 
   m_av_clock->SetMasterClock(false);
 
-  m_messageQueue.SetMaxDataSize(3 * 1024 * 1024);
+  m_messageQueue.SetMaxDataSize(6 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
 }
 

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -92,7 +92,7 @@ OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
   m_autosync              = 1;
   m_fForcedAspectRatio    = 0.0f;
   m_send_eos              = false;
-  m_messageQueue.SetMaxDataSize(10 * 1024 * 1024);
+  m_messageQueue.SetMaxDataSize(40 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
 
   m_dst_rect.SetRect(0, 0, 0, 0);

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -338,7 +338,8 @@ CLinuxInputDevice::CLinuxInputDevice(const std::string fileName, int index)
   m_deviceMinKeyCode = 0;
   m_deviceMaxKeyCode = 0;
   m_deviceMaxAxis = 0;
-
+  m_bUnplugged = false;
+  
   Open();
 }
 
@@ -744,7 +745,15 @@ XBMC_Event CLinuxInputDevice::ReadEvent()
     readlen = read(m_fd, &levt, sizeof(levt));
 
     if (readlen <= 0)
+    {
+      if (errno == ENODEV)
+      {
+        CLog::Log(LOGINFO,"input device was unplugged %s",m_deviceName);
+        m_bUnplugged = true;
+      }
+      
       break;
+    }
 
     //printf("read event readlen = %d device name %s m_fileName %s\n", readlen, m_deviceName, m_fileName.c_str());
 
@@ -963,6 +972,16 @@ void CLinuxInputDevice::GetInfo(int fd)
   //printf("pref: %d\n", m_devicePreferredId);
 }
 
+char* CLinuxInputDevice::GetDeviceName()
+{
+  return m_deviceName;
+}
+
+bool CLinuxInputDevice::IsUnplugged()
+{
+  return m_bUnplugged;
+}
+
 bool CLinuxInputDevices::CheckDevice(const char *device)
 {
   int fd;
@@ -1012,6 +1031,41 @@ void CLinuxInputDevices::InitAvailable()
 
     snprintf(buf, 32, "/dev/input/event%d", i);
     if (CheckDevice(buf))
+    {
+      CLog::Log(LOGINFO, "Found input device %s", buf);
+      m_devices.push_back(new CLinuxInputDevice(buf, deviceId));
+      ++deviceId;
+    }
+  }
+}
+
+/*
+ * Check for hot plugged devices.
+ */
+void CLinuxInputDevices::CheckHotplugged()
+{
+  CSingleLock lock(m_devicesListLock);
+
+  int deviceId = m_devices.size();
+  
+  /* No devices specified. Try to guess some. */
+  for (int i = 0; i < MAX_LINUX_INPUT_DEVICES; i++)
+  {
+    char buf[32];
+    bool ispresent = false;
+
+    snprintf(buf, 32, "/dev/input/event%d", i);
+
+    for (size_t j = 0; j < m_devices.size(); j++)
+    {
+      if (strcmp(m_devices[j]->GetDeviceName(),buf) == 0)
+      {
+        ispresent = true;
+        break;
+      }
+    }
+
+    if (!ispresent && CheckDevice(buf))
     {
       CLog::Log(LOGINFO, "Found input device %s", buf);
       m_devices.push_back(new CLinuxInputDevice(buf, deviceId));
@@ -1076,6 +1130,9 @@ bool CLinuxInputDevice::Open()
   {
     if (m_vt_fd < 0)
       m_vt_fd = open("/dev/tty0", O_RDWR | O_NOCTTY);
+
+    if (m_vt_fd < 0)
+      m_vt_fd = open("/dev/tty1", O_RDWR | O_NOCTTY);
 
     if (m_vt_fd < 0)
       CLog::Log(LOGWARNING, "no keymap support (requires /dev/tty0 - CONFIG_VT)");
@@ -1195,16 +1252,39 @@ void CLinuxInputDevice::Close()
 
 XBMC_Event CLinuxInputDevices::ReadEvent()
 {
+  if (m_bReInitialize)
+  {
+    InitAvailable();
+    m_bReInitialize = false;
+  }
+  else
+  {
+    struct timeval now;
+    gettimeofday(&now, NULL);
+
+    if ((now.tv_sec - m_lastHotplugCheck) >= 10)
+    {
+      CheckHotplugged();
+      m_lastHotplugCheck = now.tv_sec;
+    }
+  }
+  
   CSingleLock lock(m_devicesListLock);
 
   XBMC_Event event;
   event.type = XBMC_NOEVENT;
-
+  
   for (size_t i = 0; i < m_devices.size(); i++)
   {
     event = m_devices[i]->ReadEvent();
     if (event.type != XBMC_NOEVENT)
     {
+      break;
+    }
+
+    if (m_devices[i]->IsUnplugged())
+    {
+      m_bReInitialize = true;
       break;
     }
   }

--- a/xbmc/input/linux/LinuxInputDevices.h
+++ b/xbmc/input/linux/LinuxInputDevices.h
@@ -41,7 +41,9 @@ public:
   CLinuxInputDevice(const std::string fileName, int index);
   ~CLinuxInputDevice();
   XBMC_Event ReadEvent();
- 
+  char* GetDeviceName();
+  bool IsUnplugged();
+  
 private:
   void SetupKeyboardAutoRepeat(int fd);
   XBMCKey TranslateKey(unsigned short code);
@@ -76,12 +78,14 @@ private:
   int m_deviceMaxKeyCode;
   int m_deviceMaxAxis;
   bool m_bSkipNonKeyEvents;
+  bool m_bUnplugged;
 };
 
 class CLinuxInputDevices
 {
 public:
   void InitAvailable();
+  void CheckHotplugged();
   XBMC_Event ReadEvent();
   bool IsRemoteLowBattery();
   bool IsRemoteNotPaired();
@@ -89,6 +93,8 @@ private:
   CCriticalSection m_devicesListLock;
   bool CheckDevice(const char *device);
   std::vector<CLinuxInputDevice*> m_devices;
+  bool m_bReInitialize;
+  time_t m_lastHotplugCheck;
 };
 
 #endif /* LINUXINPUTDEVICES_H_ */


### PR DESCRIPTION
Scenario: Playing a complex VOB File with 5 AC3 5.1 Audio Streams on a Raspberry PI over a WLAN-network from an Apple Airport shared disk via CIFS mount produces audio buffer underruns approx every 15 minutes. This results in re-caching, which annoys my lady.

See original queue sizes for DVDPlayer and OMXPlayer:

xbmc/cores/dvdplayer/DVDPlayerVideo.cpp:146:  m_messageQueue.SetMaxDataSize(40 \* 1024 \* 1024);
xbmc/cores/dvdplayer/DVDPlayerAudio.cpp:132:  m_messageQueue.SetMaxDataSize(6 \* 1024 \* 1024);
xbmc/cores/omxplayer/OMXPlayerAudio.cpp:86:  m_messageQueue.SetMaxDataSize(3 \* 1024 \* 1024);
xbmc/cores/omxplayer/OMXPlayerVideo.cpp:95:  m_messageQueue.SetMaxDataSize(10 \* 1024 \* 1024);

I adjusted OMXPlayers queue data size to be the same as DVDPlayer's, which solved my problem and made lady happy.
