### PR TITLE
Fix empty video title in announce

### DIFF
--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -206,6 +206,12 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
         object["item"]["artist"] = item->GetMusicInfoTag()->GetArtist();
     }
   }
+  else if (item->IsVideo())
+  {
+    // video item but has no video info tag.
+    type = "movies";
+    object["item"]["title"] = item->GetLabel();
+  }
   else if (item->HasPictureInfoTag())
   {
     type = "picture";

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -137,7 +137,10 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
       // TODO: Can be removed once this is properly handled when starting playback of a file
       item->SetProperty(LOOKUP_PROPERTY, false);
 
-      object["item"]["title"] = item->GetVideoInfoTag()->m_strTitle;
+      CStdString title = item->GetVideoInfoTag()->m_strTitle;
+      if (title.IsEmpty())
+        title = item->GetLabel();
+      object["item"]["title"] = title;
 
       switch (item->GetVideoContentType())
       {


### PR DESCRIPTION
sometimes video item has no title in the video info tag, the announce will report an empty title, should fallback to the label.

the second commit fix the video item in the picture window, which may has no video info tag, since it seems we have some scaner in the video window do that job but not in picture/slideshow window. this fix to make it detect the video item rather consider it as 'unknown' type and use item label as title.
