### PR TITLE
Fix the GUI_MSG_WINDOW_DEINIT message to include the next window id as param1

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -389,7 +389,7 @@ void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*
   }
 
   m_closing = false;
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
+  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, nextWindowID);
   OnMessage(msg);
 }
 


### PR DESCRIPTION
which is designed should be there, but missed in current code, I made it up.

and existed codes using GetParam1 on the message to get next window is include:
CGUIWindow::OnMessage which then call OnDeinitWindow(int nextWindowID) with it but seems current it is always 0, this commit fixed this.
CGUIWindowPictures::OnMessage according whether it is going to the slideshow window to decide whether unload imagelib.
