### PR TITLE
fix possible access violation in CRssManager::Clear() during shutdown

### DIFF
--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -141,9 +141,7 @@ void CSettings::Initialize()
 }
 
 CSettings::~CSettings(void)
-{
-  Clear();
-}
+{ }
 
 
 void CSettings::Save() const

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -37,7 +37,6 @@ CRssManager::CRssManager()
 CRssManager::~CRssManager()
 {
   Stop();
-  Clear();
 }
 
 CRssManager& CRssManager::Get()

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -21,6 +21,7 @@
 #include "RssManager.h"
 #include "filesystem/File.h"
 #include "settings/Settings.h"
+#include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/RssReader.h"
 #include "utils/StringUtils.h"
@@ -52,6 +53,7 @@ void CRssManager::Start()
 
 void CRssManager::Stop()
 {
+  CSingleLock lock(m_critical);
   m_bActive = false;
   for (unsigned int i = 0; i < m_readers.size(); i++)
   {
@@ -63,6 +65,7 @@ void CRssManager::Stop()
 
 bool CRssManager::Load()
 {
+  CSingleLock lock(m_critical);
   string rssXML = g_settings.GetUserDataItem("RssFeeds.xml");
   if (!CFile::Exists(rssXML))
     return false;
@@ -134,12 +137,14 @@ bool CRssManager::Reload()
 
 void CRssManager::Clear()
 {
+  CSingleLock lock(m_critical);
   m_mapRssUrls.clear();
 }
 
 // returns true if the reader doesn't need creating, false otherwise
 bool CRssManager::GetReader(int controlID, int windowID, IRssObserver* observer, CRssReader *&reader)
 {
+  CSingleLock lock(m_critical);
   // check to see if we've already created this reader
   for (unsigned int i = 0; i < m_readers.size(); i++)
   {

--- a/xbmc/utils/RssManager.h
+++ b/xbmc/utils/RssManager.h
@@ -23,6 +23,8 @@
 #include <vector>
 #include <string>
 
+#include "threads/CriticalSection.h"
+
 class CRssReader;
 class IRssObserver;
 
@@ -66,4 +68,5 @@ private:
   std::vector<READERCONTROL> m_readers;
   RssUrls m_mapRssUrls;
   bool m_bActive;
+  CCriticalSection m_critical;
 };


### PR DESCRIPTION
This problem has been reported by @wsoltys and ace20022 but I'm not able to reproduce it. The problem is an access violation exception on win32 in CRssManager::Clear() when closing XBMC. The issue seems to be multiple threads trying to clear the map so I added some locking (which should be there anyway).

Furthermore I've removed the calls to Clear() in the destructors of CSettings and CRssManager as all the cleared member variables would be cleared anyway. The reason for removing it is a possible problem with the order of destruction of static variables. It's possible that CRssManager is destroyed before CSettings is destroyed but ~CSettings() calls CSettings::Clear() which calls CRssManager::Get().Clear() but the static instance returned by CRssManager::Get() has already been destroyed.
