### PR TITLE
[AE] ALSA: Do not try to bypass dmix for other sample rates

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -177,16 +177,7 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
   snd_config_t *config;
   snd_config_copy(&config, snd_config);
 
-  snd_config_t *dmixRateConf;
-  long dmixRate;
-
-  if (snd_config_search(config, "defaults.pcm.dmix.rate", &dmixRateConf) < 0
-      || snd_config_get_integer(dmixRateConf, &dmixRate) < 0)
-    dmixRate = 48000; /* assume default */
-
-
-  /* Prefer dmix for non-passthrough stereo when sample rate matches */
-  if (!OpenPCMDevice(device, AESParams, m_channelLayout.Count(), &m_pcm, config, format.m_sampleRate == (unsigned int) dmixRate && !m_passthrough))
+  if (!OpenPCMDevice(device, AESParams, m_channelLayout.Count(), &m_pcm, config))
   {
     CLog::Log(LOGERROR, "CAESinkALSA::Initialize - failed to initialize device \"%s\"", device.c_str());
     snd_config_delete(config);
@@ -639,7 +630,7 @@ bool CAESinkALSA::TryDeviceWithParams(const std::string &name, const std::string
   return TryDevice(name, pcmp, lconf);
 }
 
-bool CAESinkALSA::OpenPCMDevice(const std::string &name, const std::string &params, int channels, snd_pcm_t **pcmp, snd_config_t *lconf, bool preferDmixStereo)
+bool CAESinkALSA::OpenPCMDevice(const std::string &name, const std::string &params, int channels, snd_pcm_t **pcmp, snd_config_t *lconf)
 {
  /* Special name denoting surroundXX mangling. This is needed for some
    * devices for multichannel to work. */
@@ -667,12 +658,8 @@ bool CAESinkALSA::OpenPCMDevice(const std::string &name, const std::string &para
           return true;
     }
 
-    /* If preferDmix is false, try non-dmix configuration first.
-     * This allows output with non-48000 sample rate if device is free */
-    if (!preferDmixStereo && TryDeviceWithParams("front" + openName, params, pcmp, lconf))
-      return true;
-
-    /* Try "sysdefault" and "default" (they provide dmix),
+    /* Try "sysdefault" and "default" (they provide dmix if needed, and route
+     * audio to all extra channels on subdeviced cards),
      * unless the selected devices is not DEV=0 of the card, in which case
      * "sysdefault" and "default" would point to another device.
      * "sysdefault" is a newish device name that won't be overwritten in case
@@ -691,8 +678,8 @@ bool CAESinkALSA::OpenPCMDevice(const std::string &name, const std::string &para
         return true;
     }
 
-    /* Try non-dmix "front" */
-    if (preferDmixStereo && TryDeviceWithParams("front" + openName, params, pcmp, lconf))
+    /* Try "front" (no dmix, no audio in other channels on subdeviced cards) */
+    if (TryDeviceWithParams("front" + openName, params, pcmp, lconf))
       return true;
 
   }
@@ -911,7 +898,7 @@ std::string CAESinkALSA::GetParamFromName(const std::string &name, const std::st
 void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &device, const std::string &description, snd_config_t *config)
 {
   snd_pcm_t *pcmhandle = NULL;
-  if (!OpenPCMDevice(device, "", ALSA_MAX_CHANNELS, &pcmhandle, config, false))
+  if (!OpenPCMDevice(device, "", ALSA_MAX_CHANNELS, &pcmhandle, config))
     return;
 
   snd_pcm_info_t *pcminfo;
@@ -1061,7 +1048,7 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
   {
     /* Reopen the device if needed on the special "surroundXX" cases */
     if (info.m_deviceType == AE_DEVTYPE_PCM && (i == 8 || i == 6 || i == 4))
-      OpenPCMDevice(device, "", i, &pcmhandle, config, false);
+      OpenPCMDevice(device, "", i, &pcmhandle, config);
 
     if (snd_pcm_hw_params_test_channels(pcmhandle, hwparams, i) >= 0)
     {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -77,7 +77,7 @@ private:
   static void AppendParams(std::string &device, const std::string &params);
   static bool TryDevice(const std::string &name, snd_pcm_t **pcmp, snd_config_t *lconf);
   static bool TryDeviceWithParams(const std::string &name, const std::string &params, snd_pcm_t **pcmp, snd_config_t *lconf);
-  static bool OpenPCMDevice(const std::string &name, const std::string &params, int channels, snd_pcm_t **pcmp, snd_config_t *lconf, bool preferDmixStereo = false);
+  static bool OpenPCMDevice(const std::string &name, const std::string &params, int channels, snd_pcm_t **pcmp, snd_config_t *lconf);
 
   static AEDeviceType AEDeviceTypeFromName(const std::string &name);
   static std::string GetParamFromName(const std::string &name, const std::string &param);


### PR DESCRIPTION
Currently the ALSA sink tries to bypass ALSA dmix when the audio sample
rate is different from dmix sample rate (usually 48000). This is done by
opening "front" device instead of "default" (or "sysdefault").

However, this has the effect that stereo audio is only played on the
front speakers, while "default" device might have routed the audio to
multiple speakers on a multichannel system. This effect is triggered
even on systems that have a hardware mixer and therefore no dmix in the
first place.

To avoid this issue, remove the bypass behavior that was added between
11.0 and 12.0. This change affects stereo audio only as multichannel
audio does not normally have ALSA dmix in the first place.

It would not have been feasible to limit the previous behavior to dmix
systems only, since the ALSA design does not allow us to easily detect
dmix, since user applications should not care about that. If dmix is not
wanted, the user should not have it enabled in the first place.

This supersedes PR #1909.
