### PR TITLE
[IOS] fix ios5+ crash, last fix in 2411 has wrong code during merge.

### DIFF
--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -1100,18 +1100,14 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
     NSString *thumb = [item objectForKey:@"thumb"];
     if (thumb && thumb.length > 0)
     {
-      MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:image];
-      if (mArt)
+      UIImage *image = [UIImage imageWithContentsOfFile:thumb];
+      if (image)
       {
-        UIImage *image = [UIImage imageWithContentsOfFile:thumb];
-        if (image)
+        MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:image];
+        if (mArt)
         {
-          MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:image];
-          if (mArt)
-          {
-            [dict setObject:mArt forKey:MPMediaItemPropertyArtwork];
-            [mArt release];
-          }
+          [dict setObject:mArt forKey:MPMediaItemPropertyArtwork];
+          [mArt release];
         }
       }
     }


### PR DESCRIPTION
as title, ios4 jumped this part of code, I just found it. introduced in https://github.com/xbmc/xbmc/pull/2411
