### PR TITLE
Fix code generate python binary string

### DIFF
--- a/codegenerator.mk
+++ b/codegenerator.mk
@@ -27,7 +27,7 @@ GENERATED += $(GENDIR)/AddonModuleXbmcplugin.cpp
 GENERATED += $(GENDIR)/AddonModuleXbmcaddon.cpp
 GENERATED += $(GENDIR)/AddonModuleXbmcvfs.cpp
 
-GENERATE_DEPS += $(TOPDIR)/xbmc/interfaces/legacy/*.h
+GENERATE_DEPS += $(TOPDIR)/xbmc/interfaces/legacy/*.h $(TOPDIR)/xbmc/interfaces/python/typemaps/*.intm $(TOPDIR)/xbmc/interfaces/python/typemaps/*.outtm
 
 vpath %.i $(INTERFACES_DIR)/swig
 

--- a/xbmc/interfaces/python/typemaps/python.string.outtm
+++ b/xbmc/interfaces/python/typemaps/python.string.outtm
@@ -22,4 +22,4 @@
 %>
 ${result} = <% 
   if(method.@feature_python_coerceToUnicode) { %>PyUnicode_DecodeUTF8(${api}.c_str(),${api}.size(),"replace");<% }
-  else { %>PyString_FromString(${api}.c_str());<% } %>
+  else { %>PyString_FromStringAndSize(${api}.c_str(), ${api}.length());<% } %>


### PR DESCRIPTION
the typemap from std::string to python string does not support binary, when we really use it to hold binary string, e.g. for return read() result, it broke the binary read(), here's the fix. need clean up generated xml and cpp files of the interface python's.
