### PR TITLE
added arguments for ffmpeg streams

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -25,7 +25,8 @@ using namespace XFILE;
 CDVDInputStreamFFmpeg::CDVDInputStreamFFmpeg()
   : CDVDInputStream(DVDSTREAM_TYPE_FFMPEG)
 {
-
+  m_seekable = true;
+  m_pauseable = true;
 }
 
 CDVDInputStreamFFmpeg::~CDVDInputStreamFFmpeg()

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -34,6 +34,13 @@ public:
   virtual bool Pause(double dTime) { return false; };
   virtual bool IsEOF();
   virtual int64_t GetLength();
+  virtual void setSeekable(bool seekable) { m_seekable = seekable; };
+  virtual bool getSeekable() { return m_seekable; };
+  virtual void setPauseable(bool pauseable) { m_pauseable = pauseable; };
+  virtual bool getPauseable() { return m_pauseable; };
 
 protected:
+  bool m_seekable;
+  bool m_pauseable;
 };
+


### PR DESCRIPTION
Dear XBMC-developers,

this is a fix for my problem with switching back channels at live streams that are not seekable.
I implemented it, so that u can specify the behavior of the stream with parameters, just like:
udp://@233.1.1.1?seekable=false&pauseable=false

kind regards,
Wolfgang Haupt
