### PR TITLE
[AE/OSX] Plug minor memory leak in CoreAudioAEStream

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
@@ -148,6 +148,7 @@ CCoreAudioAEStream::~CCoreAudioAEStream()
   //_aligned_free(m_resampleBuffer); m_resampleBuffer = NULL;
   _aligned_free(m_remapBuffer); m_remapBuffer = NULL;
   _aligned_free(m_vizRemapBuffer); m_vizRemapBuffer = NULL;
+  _aligned_free(m_upmixBuffer); m_upmixBuffer = NULL;
 
   delete m_Buffer; m_Buffer = NULL;
 


### PR DESCRIPTION
This buffer was not deallocated in the destructor.
