### PR TITLE
[OSX] Fix minor memory leak in ZeroconfOSX.cpp

### DIFF
--- a/xbmc/network/osx/ZeroconfOSX.cpp
+++ b/xbmc/network/osx/ZeroconfOSX.cpp
@@ -95,6 +95,8 @@ bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
                                                   );
                                                   
       CFDictionaryAddValue(txtDict,key, value);
+      CFRelease(key);
+      CFRelease(value);
     }    
     
     //add txt records to service


### PR DESCRIPTION
Need to unref it after we add it to the dict.
