### PR TITLE
[python] Add removeItem to ControlList

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -1225,6 +1225,16 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
+    void ControlList::removeItem(int index) throw(UnimplementedException,WindowException)
+    {
+      if (index < 0 || index >= (int)vecItems.size())
+        throw WindowException("Index out of range");
+
+      vecItems.erase(vecItems.begin() + index);
+
+      sendLabelBind(vecItems.size());
+    }
+
     void ControlList::reset() throw(UnimplementedException)
     {
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -101,6 +101,7 @@ namespace XBMCAddon
                             const char* focusedColor = NULL,
                             const String& label2 = emptyString) DECL_UNIMP("Control");
       virtual void reset() DECL_UNIMP("Control");
+      virtual void removeItem(int index) DECL_UNIMP2("Control",WindowException);
       virtual void setSelected(bool selected) DECL_UNIMP("Control");
       virtual void setPercent(float pct) DECL_UNIMP("Control");
       virtual void setDisabledColor(const char* color) DECL_UNIMP("Control");
@@ -654,6 +655,16 @@ namespace XBMCAddon
        *   - cList.selectItem(12)
        */
       virtual void selectItem(long item) throw(UnimplementedException);
+
+      /**
+       * removeItem(index) -- Remove an item by index number.
+       *
+       * index              : integer - index number of the item to remove.
+       *
+       * example:
+       *   - cList.removeItem(12)
+       */
+      virtual void removeItem(int index) throw (UnimplementedException,WindowException);
 
       /**
        * reset() -- Clear all ListItems in this control list.


### PR DESCRIPTION
Currently, the only way to remove items from the list is reset(), which clears the list entirely -  this is not very useful for periodically updated lists since it might cause flickering. The commit adds a method to remove individual items from a list. The way the list is updated after the removal is ad-hoc and might need to be improved.
