### PR TITLE
[airplay/airtunes] - backup volume on airplay/airtunes volume change and...

### DIFF
--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -48,6 +48,8 @@ public:
   static void StopServer(bool bWait);
   static bool SetCredentials(bool usePassword, const CStdString& password);
   static bool IsPlaying(){ return m_isPlaying > 0;}
+  static void backupVolume();
+  static void restoreVolume();
   static int m_isPlaying;
 
 protected:
@@ -107,6 +109,7 @@ private:
   bool m_nonlocal;
   bool m_usePassword;
   CStdString m_password;
+  int m_origVolume;
 
   static CAirPlayServer *ServerInstance;
 };

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -46,11 +46,13 @@
 #include "settings/AdvancedSettings.h"
 #include "utils/EndianSwap.h"
 #include "URL.h"
+#include "interfaces/AnnouncementManager.h"
 
 #include <map>
 #include <string>
 
 using namespace XFILE;
+using namespace ANNOUNCEMENT;
 
 #if defined(TARGET_WINDOWS)
 DllLibShairplay *CAirTunesServer::m_pLibShairplay = NULL;
@@ -91,6 +93,16 @@ void CAirTunesServer::SetMetadataFromBuffer(const char *buffer, unsigned int siz
   if(metadata["asar"].length())    
     tag.SetArtist(metadata["asar"]);//artist
   CApplicationMessenger::Get().SetCurrentSongTag(tag);
+}
+
+void CAirTunesServer::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+{
+  if ( (flag & Player) && strcmp(sender, "xbmc") == 0 && strcmp(message, "OnStop") == 0)
+  {
+#ifdef HAS_AIRPLAY
+    CAirPlayServer::restoreVolume();
+#endif
+  }
 }
 
 void CAirTunesServer::SetCoverArtFromBuffer(const char *buffer, unsigned int size)
@@ -192,6 +204,9 @@ void  CAirTunesServer::AudioOutputFunctions::audio_set_volume(void *cls, void *s
 {
   //volume from -30 - 0 - -144 means mute
   float volPercent = volume < -30.0f ? 0 : 1 - volume/-30;
+#ifdef HAS_AIRPLAY
+  CAirPlayServer::backupVolume();
+#endif
   g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
 }
 
@@ -563,6 +578,7 @@ CAirTunesServer::CAirTunesServer(int port, bool nonlocal) : CThread("AirTunesSer
 #else
   m_pLibShairport = new DllLibShairport();
 #endif
+  CAnnouncementManager::AddAnnouncer(this);
 }
 
 CAirTunesServer::~CAirTunesServer()
@@ -581,6 +597,7 @@ CAirTunesServer::~CAirTunesServer()
   }
   delete m_pLibShairport;
 #endif
+  CAnnouncementManager::RemoveAnnouncer(this);
 }
 
 void CAirTunesServer::Process()

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -41,13 +41,16 @@
 #include "utils/HttpParser.h"
 #include "utils/StdString.h"
 #include "filesystem/PipeFile.h"
+#include "interfaces/IAnnouncer.h"
 
 class DllLibShairport;
 
 
-class CAirTunesServer : public CThread
+class CAirTunesServer : public CThread, public ANNOUNCEMENT::IAnnouncer
 {
 public:
+  virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
+
   static bool StartServer(int port, bool nonlocal, bool usePassword, const CStdString &password="");
   static void StopServer(bool bWait);
   static void SetMetadataFromBuffer(const char *buffer, unsigned int size);


### PR DESCRIPTION
... restore it on playback stop. This should calm down some wifes of our users.

Basically we treat the volume changes which are done by airplay clients as if they are only valid during the airplay/airtunes session.
