### PR TITLE
[AirTunes] - add volume control using libshairport

### DIFF
--- a/tools/depends/target/libshairport/012_add_volume_control.patch
+++ b/tools/depends/target/libshairport/012_add_volume_control.patch
@@ -1,0 +1,28 @@
+--- src/ao.h	2013-03-14 19:07:04.000000000 +0100
++++ src/ao.h	2013-03-14 20:45:15.000000000 +0100
+@@ -141,6 +141,7 @@
+ 
+ #endif  /* __AO_H__ */
+ 
++#define SHAIRPORT_AUDIOOUTPUT_VERSION 2
+ extern struct AudioOutput g_ao;
+ struct AudioOutput                                                                                                                                                                                              
+   {                                                                                                                                                                                                              
+@@ -155,4 +156,5 @@
+       char* (*ao_get_option)(ao_option *, const char* );
+       void (*ao_set_metadata)(const char *buffer, unsigned int size);                                                                                                                                                         
+       void (*ao_set_metadata_coverart)(const char *buffer, unsigned int size);
++      void (*ao_set_volume)(float volume);
+   }; 
+diff -uPr orig/src/hairtunes.c macosx10.6_i386-target/src/hairtunes.c
+--- src/hairtunes.c	2013-03-14 19:07:04.000000000 +0100
++++ src/hairtunes.c	2013-03-14 20:46:33.000000000 +0100
+@@ -265,6 +265,8 @@
+   assert(f<=0);
+   if (debug)
+       xprintf("VOL: %lf\n", f);
++  if (g_ao.ao_set_volume)
++    g_ao.ao_set_volume(f);
+   volume = pow(10.0,0.05*f);
+   fix_volume = 65536.0 * volume;
+ }

--- a/tools/depends/target/libshairport/Makefile
+++ b/tools/depends/target/libshairport/Makefile
@@ -36,6 +36,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../010_handle_metadata.patch
 	cd $(PLATFORM); patch -p0 < ../011_fix_ipv4_fallback.patch
 	cd $(PLATFORM); patch -p0 < ../android.patch
+	cd $(PLATFORM); patch -p0 < ../012_add_volume_control.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -288,6 +288,17 @@ void CAirTunesServer::AudioOutputFunctions::ao_initialize(void)
 {
 }
 
+void  CAirTunesServer::AudioOutputFunctions::ao_set_volume(float volume)
+{
+  //volume from -30 - 0 - -144 means mute
+  float volPercent = volume < -30.0f ? 0 : 1 - volume/-30;
+#ifdef HAS_AIRPLAY
+  CAirPlayServer::backupVolume();
+#endif
+  g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
+}
+
+
 int CAirTunesServer::AudioOutputFunctions::ao_play(ao_device *device, char *output_samples, uint32_t num_bytes)
 {
   if (!device)
@@ -675,6 +686,11 @@ bool CAirTunesServer::Initialize(const CStdString &password)
 #ifdef HAVE_STRUCT_AUDIOOUTPUT_AO_SET_METADATA
     ao.ao_set_metadata = AudioOutputFunctions::ao_set_metadata;    
     ao.ao_set_metadata_coverart = AudioOutputFunctions::ao_set_metadata_coverart;        
+#endif
+#if defined(SHAIRPORT_AUDIOOUTPUT_VERSION)
+#if   SHAIRPORT_AUDIOOUTPUT_VERSION >= 2
+    ao.ao_set_volume = AudioOutputFunctions::ao_set_volume;
+#endif
 #endif
     struct printfPtr funcPtr;
     funcPtr.extprintf = shairport_log;

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -86,6 +86,7 @@ private:
       static void  audio_destroy(void *cls, void *session);
 #else
       static void ao_initialize(void);
+      static void ao_set_volume(float volume);
       static int ao_play(ao_device *device, char *output_samples, uint32_t num_bytes);
       static int ao_default_driver_id(void);
       static ao_device* ao_open_live( int driver_id, ao_sample_format *format,


### PR DESCRIPTION
This adds volume control when using libshairport (all platforms beside windows). We do the same on windows (utilising libshairplay) already and this should sync up the feature on all platforms.

Upstream libshairport (used for linux distributions and maintained by amejia) got a PR for the libshairport change aswell.
