### PR TITLE
rss: fix xbmc.org feed

### DIFF
--- a/userdata/RssFeeds.xml
+++ b/userdata/RssFeeds.xml
@@ -3,6 +3,6 @@
   <!-- RSS feeds. To have multiple feeds, just add a feed to the set. You can also have multiple sets. 	!-->
   <!-- To use different sets in your skin, each must be called from skin with a unique id.             	!-->
   <set id="1">
-    <feed updateinterval="30">http://feeds.feedburner.com/xbmc</feed>
+    <feed updateinterval="30">http://feeds.xbmc.org/xbmc</feed>
   </set>
 </rssfeeds>


### PR DESCRIPTION
http://feeds.xbmc.org has been created so that we can prevent this in the
future. It is now a CNAME using the "MyBrand" feature at feedburner, which is
up and running again after the latest news entry.

With this set, we change we can modify the feed at any time in the future.

Attn: For immediate merge and backport to Frodo.
