### PR TITLE
Webserver: add access to special:// URLs 

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -3264,7 +3264,12 @@ msgctxt "#1051"
 msgid "Enter web address"
 msgstr ""
 
-#empty strings from id 1052 to 1179
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#1052"
+msgid "Allow access to special:// URLs"
+msgstr ""
+
+#empty strings from id 1053 to 1179
 
 #: xbmc/settings/GUISettings.cpp
 msgctxt "#1180"

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -831,6 +831,7 @@
     <ClCompile Include="..\..\xbmc\network\GUIDialogNetworkSetup.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPImageHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPSpecialHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.cpp" />
@@ -1149,6 +1150,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\JSONRPCUtils.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\GUIOperations.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPSpecialHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2008,6 +2008,9 @@
     <ClCompile Include="..\..\xbmc\filesystem\AFPDirectory.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPSpecialHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp">
       <Filter>network\httprequesthandler</Filter>
     </ClCompile>
@@ -5320,6 +5323,9 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.h">
+      <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPSpecialHandler.h">
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h">

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -41,6 +41,7 @@
 #include "network/WebServer.h"
 #include "network/httprequesthandler/HTTPImageHandler.h"
 #include "network/httprequesthandler/HTTPVfsHandler.h"
+#include "network/httprequesthandler/HTTPSpecialHandler.h"
 #ifdef HAS_JSONRPC
 #include "network/httprequesthandler/HTTPJsonRpcHandler.h"
 #endif
@@ -379,6 +380,7 @@ CApplication::CApplication(void)
   , m_WebServer(*new CWebServer)
   , m_httpImageHandler(*new CHTTPImageHandler)
   , m_httpVfsHandler(*new CHTTPVfsHandler)
+  , m_httpSpecialHandler(*new CHTTPSpecialHandler)
 #ifdef HAS_JSONRPC
   , m_httpJsonRpcHandler(*new CHTTPJsonRpcHandler)
 #endif
@@ -454,6 +456,7 @@ CApplication::~CApplication(void)
   delete &m_WebServer;
   delete &m_httpImageHandler;
   delete &m_httpVfsHandler;
+  delete &m_httpSpecialHandler;
 #ifdef HAS_JSONRPC
   delete &m_httpJsonRpcHandler;
 #endif
@@ -1262,6 +1265,7 @@ bool CApplication::Initialize()
 #ifdef HAS_WEB_SERVER
   CWebServer::RegisterRequestHandler(&m_httpImageHandler);
   CWebServer::RegisterRequestHandler(&m_httpVfsHandler);
+  CWebServer::RegisterRequestHandler(&m_httpSpecialHandler);
 #ifdef HAS_JSONRPC
   CWebServer::RegisterRequestHandler(&m_httpJsonRpcHandler);
 #endif
@@ -3655,6 +3659,7 @@ void CApplication::Stop(int exitCode)
 #ifdef HAS_WEB_SERVER
   CWebServer::UnregisterRequestHandler(&m_httpImageHandler);
   CWebServer::UnregisterRequestHandler(&m_httpVfsHandler);
+  CWebServer::UnregisterRequestHandler(&m_httpSpecialHandler);
 #ifdef HAS_JSONRPC
   CWebServer::UnregisterRequestHandler(&m_httpJsonRpcHandler);
   CJSONRPC::Cleanup();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -75,6 +75,7 @@ class IPlayer;
 class CWebServer;
 class CHTTPImageHandler;
 class CHTTPVfsHandler;
+class CHTTPSpecialHandler;
 #ifdef HAS_JSONRPC
 class CHTTPJsonRpcHandler;
 #endif
@@ -288,6 +289,7 @@ public:
   CWebServer& m_WebServer;
   CHTTPImageHandler& m_httpImageHandler;
   CHTTPVfsHandler& m_httpVfsHandler;
+  CHTTPSpecialHandler& m_httpSpecialHandler;
 #ifdef HAS_JSONRPC
   CHTTPJsonRpcHandler& m_httpJsonRpcHandler;
 #endif

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -54,6 +54,8 @@ public:
   static std::string GetRequestHeaderValue(struct MHD_Connection *connection, enum MHD_ValueKind kind, const std::string &key);
   static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::map<std::string, std::string> &headerValues);
   static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::multimap<std::string, std::string> &headerValues);
+  static const char *CreateMimeTypeFromExtension(const char *ext);
+
 private:
   struct MHD_Daemon* StartMHD(unsigned int flags, int port);
   static int AskForAuthentication (struct MHD_Connection *connection);
@@ -101,7 +103,6 @@ private:
   static int FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
   static int FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
 
-  static const char *CreateMimeTypeFromExtension(const char *ext);
 
   struct MHD_Daemon *m_daemon;
   bool m_running, m_needcredentials;

--- a/xbmc/network/httprequesthandler/HTTPSpecialHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPSpecialHandler.cpp
@@ -26,12 +26,15 @@
 #include "utils/log.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
+#include "settings/GUISettings.h"
 
 using namespace std;
 
 bool CHTTPSpecialHandler::CheckHTTPRequest(const HTTPRequest &request)
 {
-  return (request.url.find("/special/") == 0 || request.url.find("/log") == 0);
+  return (g_guiSettings.GetBool("services.webserverallowspecialurl") &&
+		  (request.url.find("/special/") == 0 || request.url.find("/log") == 0)
+  );
 }
 
 int CHTTPSpecialHandler::HandleHTTPRequest(const HTTPRequest &request)

--- a/xbmc/network/httprequesthandler/HTTPSpecialHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPSpecialHandler.cpp
@@ -1,0 +1,138 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "HTTPSpecialHandler.h"
+#include "URL.h"
+#include "filesystem/File.h"
+#include "network/WebServer.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
+
+using namespace std;
+
+bool CHTTPSpecialHandler::CheckHTTPRequest(const HTTPRequest &request)
+{
+  return (request.url.find("/special/") == 0 || request.url.find("/log") == 0);
+}
+
+int CHTTPSpecialHandler::HandleHTTPRequest(const HTTPRequest &request)
+{
+  string ext;
+
+  /* our URL is /special */
+  if (request.url.substr(0, 19) == "/special/special://")
+  {
+    m_path = request.url.substr(9);
+    ext = URIUtils::GetExtension(request.url);
+    StringUtils::ToLower(ext);
+
+    if (!XFILE::CFile::Exists(m_path))
+    {
+      CLog::Log(LOGERROR, "CHTTPSpecialHandler::HandleHTTPRequest: file %s does not exist", m_path.c_str());
+      m_responseCode = MHD_HTTP_NOT_FOUND;
+      m_responseType = HTTPError;
+      return MHD_YES;
+    }
+  }
+  /* add a shortcut URL /log and /log/ pointing to xbmc.log */
+  else if (request.url.compare("/log") == 0 || request.url.compare("/log/") == 0)
+  {
+    m_path = "special://temp/xbmc.log";
+    ext = ".log";
+  }
+  else
+  {
+    CLog::Log(LOGDEBUG, "CHTTPSpecialHandler::HandleHTTPRequest: bad request");
+    m_responseCode = MHD_HTTP_BAD_REQUEST;
+    m_responseType = HTTPError;
+    return MHD_YES;
+  }
+
+  /* If we have a file that potentially holds user credentials
+   * we want to sanitize them.
+   * Else have the webserver handle the download */
+  if (ext == ".log" || ext == ".xml")
+  {
+    XFILE::CFile *file = new XFILE::CFile();
+    if (file->Open(m_path, READ_CACHED))
+    {
+      m_response = "";
+      char m_buf[1024];
+      memset(m_buf, '\0', sizeof(m_buf));
+      string line = "";
+      string user;
+      string pass;
+      string replace;
+
+      /* this replaces the following:
+       * - username:pass in URIs
+       * - <pass>pass</pass> in XMLs
+       */
+      CRegExp regex1, regex2;
+      regex1.RegComp("://(.*):(.*)@");
+      regex2.RegComp("<[^<>]*(pass|user)[^<>]*>([^<]+)</.*(pass|user).*>");
+
+      while (file->ReadString(m_buf, 1023))
+      {
+        line = m_buf;
+        if (regex1.RegFind(line))
+        {
+          user = regex1.GetReplaceString("\\1");
+          pass = regex1.GetReplaceString("\\2");
+          replace = "://" + user + ":" + pass + "@";
+          StringUtils::Replace(line, replace, "://xxx:xxx@");
+        }
+        if (regex2.RegFind(line))
+        {
+          replace = regex2.GetReplaceString("\\2");
+          if (replace.length() > 0)
+            StringUtils::Replace(line, replace, "xxx");
+        }
+        m_response += line;
+        memset(m_buf, '\0', sizeof(m_buf));
+      }
+
+      const char *mime = request.webserver->CreateMimeTypeFromExtension(ext.c_str());
+      if (mime)
+        m_responseHeaderFields.insert(pair<string, string>("Content-Type", mime));
+
+      file->Close();
+      delete file;
+      m_request.clear();
+
+      m_responseCode = MHD_HTTP_OK;
+      m_responseType = HTTPMemoryDownloadNoFreeCopy;
+    }
+    else
+    {
+      CLog::Log(LOGDEBUG, "CHTTPSpecialHandler::HandleHTTPRequest: cannot open file %s", m_path.c_str());
+      m_responseCode = MHD_HTTP_NOT_FOUND;
+      m_responseType = HTTPError;
+    }
+  }
+  else
+  {
+    m_responseCode = MHD_HTTP_OK;
+    m_responseType = HTTPFileDownload;
+  }
+  return MHD_YES;
+}

--- a/xbmc/network/httprequesthandler/HTTPSpecialHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPSpecialHandler.h
@@ -1,0 +1,44 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "IHTTPRequestHandler.h"
+
+class CHTTPSpecialHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPSpecialHandler() { };
+
+  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPSpecialHandler(); }
+  virtual bool CheckHTTPRequest(const HTTPRequest &request);
+  virtual int HandleHTTPRequest(const HTTPRequest &request);
+
+  virtual std::string GetHTTPResponseFile() const { return m_path; }
+  static int ResolveUrl(const std::string &url, std::string &path);
+  virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
+  virtual size_t GetHTTPResonseDataLength() const { return m_response.length(); }
+
+  virtual int GetPriority() const { return 2; }
+
+private:
+  std::string m_path;
+  std::string m_request;
+  std::string m_response;
+};

--- a/xbmc/network/httprequesthandler/Makefile
+++ b/xbmc/network/httprequesthandler/Makefile
@@ -1,5 +1,6 @@
 SRCS=HTTPImageHandler.cpp \
      HTTPJsonRpcHandler.cpp \
+     HTTPSpecialHandler.cpp \
      HTTPVfsHandler.cpp \
      HTTPWebinterfaceAddonsHandler.cpp \
      HTTPWebinterfaceHandler.cpp \

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -859,6 +859,7 @@ void CGUISettings::Initialize()
   AddString(srvWeb,"services.webserverport",    730, CUtil::CanBindPrivileged()?"80":"8080", EDIT_CONTROL_NUMBER_INPUT, false, 730);
   AddString(srvWeb,"services.webserverusername",1048, "xbmc", EDIT_CONTROL_INPUT);
   AddString(srvWeb,"services.webserverpassword",733, "", EDIT_CONTROL_HIDDEN_INPUT, true, 733);
+  AddBool(srvWeb,"services.webserverallowspecialurl",1052, false);
   AddDefaultAddon(srvWeb, "services.webskin",199, DEFAULT_WEB_INTERFACE, ADDON_WEB_INTERFACE);
 #endif
 #ifdef HAS_EVENT_SERVER


### PR DESCRIPTION
This adds a new HTTP handler allowing for special:// vfs files.
Access works analog to VFS via http://xbmchost:port/special/special://path/to/file
It also adds a shortcut URL /log for quick and easy xbmc.log downloading.

.log and .xml files are passed through a User/Pass stripper before download:
- username:pass in URIs
- <pass>pass</pass> in XMLs

I added VS2010 project files, but _did not test_ them. 
Since Xcode stuff is voodoo to me, I kindly ask someone in the know to help there.
