### PR TITLE
[python] Notify python code about double clicks

### DIFF
--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -507,6 +507,7 @@ namespace XBMCAddon
 
     void Window::onControl(Control* action) { TRACE; /* do nothing by default */ }
     void Window::onClick(int controlId) { TRACE; /* do nothing by default */ }
+    void Window::onDoubleClick(int controlId) { TRACE; /* do nothing by default */ }
     void Window::onFocus(int controlId) { TRACE; /* do nothing by default */ }
     void Window::onInit() { TRACE; /* do nothing by default */ }
 

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -170,6 +170,7 @@ namespace XBMCAddon
       //  into Python anyway. This must result in a problem when 
       virtual void onControl(Control* control);
       virtual void onClick(int controlId);
+      virtual void onDoubleClick(int controlId);
       virtual void onFocus(int controlId);
       virtual void onInit();
 

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -381,6 +381,12 @@ namespace XBMCAddon
                 PulseActionEvent();
                 return true;
               }
+              else if (controlClicked->IsContainer() && message.GetParam1() == ACTION_MOUSE_DOUBLE_CLICK)
+              {
+                invokeCallback(new CallbackFunction<WindowXML,int>(this,&WindowXML::onDoubleClick,iControl));
+                PulseActionEvent();
+                return true;
+              }
               else if (controlClicked->IsContainer() && message.GetParam1() == ACTION_MOUSE_RIGHT_CLICK)
               {
                 AddonClass::Ref<Action> inf(new Action(CAction(ACTION_CONTEXT_MENU)));
@@ -435,6 +441,12 @@ namespace XBMCAddon
       TRACE;
       // Hook Over calling  CGUIMediaWindow::OnClick(iItem) results in it trying to PLAY the file item
       // which if its not media is BAD and 99 out of 100 times undesireable.
+      return false;
+    }
+
+    bool WindowXML::OnDoubleClick(int iItem)
+    {
+      TRACE;
       return false;
     }
 

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -86,6 +86,7 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL void      AllocResources(bool forceLoad = false);
       SWIGHIDDENVIRTUAL void      FreeResources(bool forceUnLoad = false);
       SWIGHIDDENVIRTUAL bool      OnClick(int iItem);
+      SWIGHIDDENVIRTUAL bool      OnDoubleClick(int iItem);
       SWIGHIDDENVIRTUAL void      Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
       SWIGHIDDENVIRTUAL bool IsMediaWindow() const { TRACE; return true; };


### PR DESCRIPTION
Only single left button clicks are propagated to the python code at the moment. The commit lets the python side know about double clicks as well.
