### PR TITLE
line break in video codec info

### DIFF
--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -339,7 +339,7 @@
 			<control type="label" id="11">
 				<description>row 2 label</description>
 				<posx>50</posx>
-				<posy>40</posy>
+				<posy>55</posy>
 				<width>1180</width>
 				<height>30</height>
 				<align>left</align>
@@ -350,7 +350,7 @@
 			<control type="label" id="12">
 				<description>row 3 label</description>
 				<posx>50</posx>
-				<posy>85</posy>
+				<posy>100</posy>
 				<width>1180</width>
 				<height>30</height>
 				<align>left</align>

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2579,7 +2579,7 @@ void CDVDPlayer::GetVideoInfo(CStdString& strVideoInfo)
   { CSingleLock lock(m_StateSection);
     strVideoInfo.Format("D(%s)", m_StateInput.demux_video.c_str());
   }
-  strVideoInfo.AppendFormat(" P(%s)", m_dvdPlayerVideo.GetPlayerInfo().c_str());
+  strVideoInfo.AppendFormat("\nP(%s)", m_dvdPlayerVideo.GetPlayerInfo().c_str());
 }
 
 void CDVDPlayer::GetGeneralInfo(CStdString& strGeneralInfo)


### PR DESCRIPTION
There are quite a couple of videos where video codec info does not fit on screen. Even the drop counter was not visible.
