### PR TITLE
[Fix] Python xbmcvfs.listdir(url) not returning upnp address folder data.

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -23,6 +23,7 @@
 #include "LanguageHook.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
+#include "filesystem/UPnPDirectory.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "Util.h"
@@ -84,7 +85,22 @@ namespace XBMCAddon
       CFileItemList items;
       CStdString strSource;
       strSource = path;
-      XFILE::CDirectory::GetDirectory(strSource, items, "", XFILE::DIR_FLAG_NO_FILE_DIRS);
+
+	  // See if this is an upnp address
+	  if(strSource.Left(7).Equals("upnp://"))
+	  {
+		  // Create the directory factory for this address
+		  XFILE::IDirectory* ptrDir = XFILE::CDirectoryFactory::Create(strSource);
+		  if(ptrDir != NULL)
+		  {
+			  ptrDir->GetDirectory(strSource, items);
+		  }
+	  }
+	  // Else, use the old method
+	  else
+	  {
+		  XFILE::CDirectory::GetDirectory(strSource, items, "", XFILE::DIR_FLAG_NO_FILE_DIRS);
+	  }
 
       Tuple<std::vector<String>, std::vector<String> > ret;
       // initialize the Tuple to two values


### PR DESCRIPTION
...if it's an upnp://[address], and calling the XFILE::CDirectoryFactory::Create() method to create the CUPnPDirectory class object.

This will allow the python method in xbmcvfs.listdir() method to return upnp data. This check-in is required for an add-on I'm working on extending the tv-guide addon for hdhomerun devices.
