### PR TITLE
[IOS] Fix popen crash during xbmc starting up, it may not work on ios

### DIFF
--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -33,6 +33,7 @@ extern "C"
 #endif
   bool        DarwinIsAppleTV2(void);
   bool        DarwinHasRetina(void);
+  const char *GetDarwinOSReleaseString(void);
   const char *GetDarwinVersionString(void);
   float       GetIOSVersion(void);
   int         GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize);

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -148,6 +148,20 @@ bool DarwinHasRetina(void)
   return (platform >= iPhone4);
 }
 
+const char *GetDarwinOSReleaseString(void)
+{
+  static std::string osreleaseStr;
+  if (osreleaseStr.empty())
+  {
+    size_t size;
+    sysctlbyname("kern.osrelease", NULL, &size, NULL, 0);
+    char *osrelease = new char[size];
+    sysctlbyname("kern.osrelease", osrelease, &size, NULL, 0);
+    osreleaseStr = osrelease;
+    delete [] osrelease;
+  }
+  return osreleaseStr.c_str();
+}
 
 const char *GetDarwinVersionString(void)
 {

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -634,6 +634,10 @@ CStdString CSysInfo::GetUnameVersion()
   result += name.release;
   result += " ";
   result += name.machine;
+#elif defined(TARGET_DARWIN_IOS)
+  result = GetDarwinOSReleaseString();
+  result += ", ";
+  result += GetDarwinVersionString();
 #else
   FILE* pipe = popen("uname -rm", "r");
   if (pipe)


### PR DESCRIPTION
I found it always crash my iphone4 ios 5.1.1 without debugger attached.

the crash log: http://xbmclogs.com/show.php?id=4946

anyway, even with debugger, the popen(uname...) just fails, but the log not produced since where the code called is earlier than the log file be opened.

so here's the fix, with this, I feel the startup of xbmc is much faster than ever.
