### PR TITLE
Preserve playcount on file update

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2036,6 +2036,26 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
 
     SetArtForItem(idMovie, "movie", artwork);
 
+    // query DB for any movies matching imdbid and year
+    CStdString strSQL = PrepareSQL("files.playCount, files.lastPlayed from movie,files where files.idFile=movie.idFile and movie.c%02d='%s' and movie.c%02d=%i and movie.idMovie!=%i and files.playCount > 0", VIDEODB_ID_IDENT, details.m_strIMDBNumber, VIDEODB_ID_YEAR, details.m_iYear, idMovie);
+    m_pDS->query(strSQL.c_str());
+	
+    if (!m_pDS->eof())
+    {
+      int playCount = m_pDS->fv("files.playCount").get_asInt();
+
+      CDateTime lastPlayed;
+      lastPlayed.SetFromDBDateTime(m_pDS->fv("files.lastPlayed").get_asString());
+
+      int idFile = GetFileId(strFilenameAndPath);
+
+      // update with playCount and lastPlayed
+      strSQL = PrepareSQL("update files set playCount=%i,lastPlayed='%s' where idFile=%i", playCount, lastPlayed.GetAsDBDateTime().c_str(), idFile);
+      m_pDS->exec(strSQL.c_str());
+    }
+
+    m_pDS->close();
+
     // update our movie table (we know it was added already above)
     // and insert the new row
     CStdString sql = "update movie set " + GetValueString(details, VIDEODB_ID_MIN, VIDEODB_ID_MAX, DbMovieOffsets);
@@ -2198,6 +2218,26 @@ int CVideoDatabase::SetDetailsForEpisode(const CStdString& strFilenameAndPath, c
     AddSeason(idShow, details.m_iSeason);
 
     SetArtForItem(idEpisode, "episode", artwork);
+
+    // query DB for any episodes matching idShow, Season and Episode
+    CStdString strSQL = PrepareSQL("select files.playCount, files.lastPlayed from episode, files where files.idFile=episode.idFile and episode.c%02d=%i and episode.c%02d=%i AND episode.idShow=%i and episode.idEpisode!=%i and files.playCount > 0",VIDEODB_ID_EPISODE_SEASON, details.m_iSeason, VIDEODB_ID_EPISODE_EPISODE, details.m_iEpisode, idShow, idEpisode);
+    m_pDS->query(strSQL.c_str());
+
+    if (!m_pDS->eof())
+    {
+      int playCount = m_pDS->fv("files.playCount").get_asInt();
+
+      CDateTime lastPlayed;
+      lastPlayed.SetFromDBDateTime(m_pDS->fv("files.lastPlayed").get_asString());
+
+      int idFile = GetFileId(strFilenameAndPath);
+
+      // update with playCount and lastPlayed
+      strSQL = PrepareSQL("update files set playCount=%i,lastPlayed='%s' where idFile=%i", playCount, lastPlayed.GetAsDBDateTime().c_str(), idFile);
+      m_pDS->exec(strSQL.c_str());
+    }
+
+    m_pDS->close();
 
     // and insert the new row
     CStdString sql = "update episode set " + GetValueString(details, VIDEODB_ID_EPISODE_MIN, VIDEODB_ID_EPISODE_MAX, DbEpisodeOffsets);


### PR DESCRIPTION
Attempt to preserve the playcount of a file when its updated (i.e. better quality file).
Add new advanced setting, preserveplaycount to toggle this feature, by default its false.
Episodes are matched on showID, season and episode.
Movies are matched on imdbID and year.
