### PR TITLE
[WinEvents] Move win32 only code into win32 file.

### DIFF
--- a/xbmc/windowing/WinEvents.h
+++ b/xbmc/windowing/WinEvents.h
@@ -30,8 +30,6 @@ typedef bool (* PHANDLE_EVENT_FUNC)(XBMC_Event& newEvent);
 
 class CWinEventsBase
 {
-public:
-  static PHANDLE_EVENT_FUNC m_pEventFunc;
 };
 
 #if   defined(TARGET_WINDOWS)

--- a/xbmc/windowing/WinEventsLinux.cpp
+++ b/xbmc/windowing/WinEventsLinux.cpp
@@ -30,8 +30,6 @@
 #include "utils/log.h"
 #include "powermanagement/PowerManager.h"
 
-PHANDLE_EVENT_FUNC CWinEventsBase::m_pEventFunc = NULL;
-
 bool CWinEventsLinux::m_initialized = false;
 CLinuxInputDevices CWinEventsLinux::m_devices;
 

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -43,8 +43,6 @@
 #include "utils/log.h"
 #endif
 
-PHANDLE_EVENT_FUNC CWinEventsBase::m_pEventFunc = NULL;
-
 #if defined(_LINUX) && !defined(__APPLE__)
 // The following chunk of code is Linux specific. For keys that have
 // with keysym.sym set to zero it checks the scan code, and sets the sym

--- a/xbmc/windowing/android/WinEventsAndroid.cpp
+++ b/xbmc/windowing/android/WinEventsAndroid.cpp
@@ -27,8 +27,6 @@
 
 static CCriticalSection g_inputCond;
 
-PHANDLE_EVENT_FUNC CWinEventsBase::m_pEventFunc = NULL;
-
 static std::list<XBMC_Event> events;
 
 void CWinEventsAndroid::DeInit()

--- a/xbmc/windowing/osx/WinEventsIOS.mm
+++ b/xbmc/windowing/osx/WinEventsIOS.mm
@@ -30,8 +30,6 @@
 
 static CCriticalSection g_inputCond;
 
-PHANDLE_EVENT_FUNC CWinEventsBase::m_pEventFunc = NULL;
-
 static std::list<XBMC_Event> events;
 
 void CWinEventsIOS::DeInit()

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -64,7 +64,7 @@ uint32_t g_uQueryCancelAutoPlay = 0;
 
 int XBMC_TranslateUNICODE = 1;
 
-PHANDLE_EVENT_FUNC CWinEventsBase::m_pEventFunc = NULL;
+PHANDLE_EVENT_FUNC CWinEventsWin32::m_pEventFunc = NULL;
 int CWinEventsWin32::m_lastGesturePosX = 0;
 int CWinEventsWin32::m_lastGesturePosY = 0;
 

--- a/xbmc/windowing/windows/WinEventsWin32.h
+++ b/xbmc/windowing/windows/WinEventsWin32.h
@@ -30,6 +30,7 @@ class CWinEventsWin32 : public CWinEventsBase
 public:
   static bool MessagePump();
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+  static PHANDLE_EVENT_FUNC m_pEventFunc;
 private:
   static void RegisterDeviceInterfaceToHwnd(GUID InterfaceClassGuid, HWND hWnd, HDEVNOTIFY *hDeviceNotify);
   static void WindowFromScreenCoords(HWND hWnd, POINT *point);


### PR DESCRIPTION
m_pEventFunc is used only by win32, no need put it in the common base class.
