### PR TITLE
[Fix] slideshow swipe wrong direction detection.

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -645,12 +645,10 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
     if (m_iZoomFactor == 1 || !m_Image[m_iCurrentPic].m_bCanMoveHorizontally)
     {
       // on zoomlevel 1 just detect swipe left and right
-      if (point.x < m_firstGesturePoint.x)
+      if (event.m_id == ACTION_GESTURE_SWIPE_LEFT)
         OnAction(CAction(ACTION_NEXT_PICTURE));
       else
         OnAction(CAction(ACTION_PREV_PICTURE));
-      
-      m_firstGesturePoint.x = 0;
     }
   }
   else if (event.m_id == ACTION_GESTURE_END)


### PR DESCRIPTION
the current code was from old code without swipe support, now we has generic swipe detector, and swipe actions, so directly use it.

else on iOS, a fast swipe left will generate events like this:

```
2013-03-19 21:23:33.110 XBMC[4727:707] [DEBUG] -[XBMCController handleSwipe:]: [744.000000, 300.000000], direction: 2, touch num: 1
2013-03-19 21:23:33.114 XBMC[4727:707] [DEBUG] -[XBMCController handlePan:]: <UIPanGestureRecognizer: 0x4664d60; state = Began; delaysTouchesBegan = YES; view = <IOSEAGLView 0x46f6f00>; target= <(action=handlePan:, target=<XBMCController 0x46f9420>)>>
2013-03-19 21:23:33.122 XBMC[4727:707] [DEBUG] -[XBMCController handlePan:]: <UIPanGestureRecognizer: 0x4664d60; state = Changed; delaysTouchesBegan = YES; view = <IOSEAGLView 0x46f6f00>; target= <(action=handlePan:, target=<XBMCController 0x46f9420>)>>
2013-03-19 21:23:33.124 XBMC[4727:707] [DEBUG] -[XBMCController handlePan:]: <UIPanGestureRecognizer: 0x4664d60; state = Changed; delaysTouchesBegan = YES; view = <IOSEAGLView 0x46f6f00>; target= <(action=handlePan:, target=<XBMCController 0x46f9420>)>>
```

so the m_firstGesturePoint is not inited yet when we got the swipe action, the old code will wrong goto the previous slide when swipe left.
