### PR TITLE
[Regression?] add/restore possibility to disable some embedded subtitles

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2139,7 +2139,9 @@ void CDVDPlayer::HandleMessages()
           else
           {
             CloseSubtitleStream(false);
-            OpenSubtitleStream(st.id, st.source);
+            if(GetSubtitleVisible()) {
+              OpenSubtitleStream(st.id, st.source);
+            }
           }
         }
       }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -225,6 +225,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
 
       g_settings.m_currentVideoSettings.m_SubtitleOn = !g_settings.m_currentVideoSettings.m_SubtitleOn;
       g_application.m_pPlayer->SetSubtitleVisible(g_settings.m_currentVideoSettings.m_SubtitleOn);
+      g_application.m_pPlayer->SetSubtitle(g_settings.m_currentVideoSettings.m_SubtitleStream);
       CStdString sub, lang;
       if (g_settings.m_currentVideoSettings.m_SubtitleOn)
       {
@@ -271,13 +272,13 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
           g_settings.m_currentVideoSettings.m_SubtitleOn = false;
           g_application.m_pPlayer->SetSubtitleVisible(false);
         }
-        g_application.m_pPlayer->SetSubtitle(g_settings.m_currentVideoSettings.m_SubtitleStream);
       }
       else
       {
         g_settings.m_currentVideoSettings.m_SubtitleOn = true;
         g_application.m_pPlayer->SetSubtitleVisible(true);
       }
+      g_application.m_pPlayer->SetSubtitle(g_settings.m_currentVideoSettings.m_SubtitleStream);
 
       CStdString sub, lang;
       if (g_settings.m_currentVideoSettings.m_SubtitleOn)


### PR DESCRIPTION
Fixed a problem where it was not possible to disable some types of embedded subtitles.
Refs #13993 and probably #14079. This should also fix them.

It appears that a call to SetSubtitleVisible is not enough to actually disable a subtitle in the DVDPlayer. Maybe there's a better way to fix this but I'm not that familiar with the entire codebase yet.
