### PR TITLE
Speed up xbmc ui nav by change loaders use StopAsync(true)

### DIFF
--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -113,12 +113,12 @@ void CBackgroundInfoLoader::Run()
 
 void CBackgroundInfoLoader::Load(CFileItemList& items)
 {
-  StopThread();
+  CSingleLock lock(m_lock);
+
+  StopAsync(true);
 
   if (items.Size() == 0)
     return;
-
-  CSingleLock lock(m_lock);
 
   for (int nItem=0; nItem < items.Size(); nItem++)
     m_vecItems.push_back(items[nItem]);

--- a/xbmc/BackgroundInfoLoader.h
+++ b/xbmc/BackgroundInfoLoader.h
@@ -54,7 +54,10 @@ public:
   virtual bool LoadItem(CFileItem* pItem) { return false; };
 
   void StopThread(); // will actually stop all worker threads.
-  void StopAsync();  // will ask loader to stop as soon as possible, but not block
+
+  // will ask loader to stop as soon as possible, but not block
+  // if invokeOnLoaderFinish set, will call OnLoaderFinish() and discard left work.
+  void StopAsync(bool invokeOnLoaderFinish=false);
 
   void SetNumOfWorkers(int nThreads); // -1 means auto compute num of required threads
 
@@ -67,6 +70,7 @@ protected:
   CCriticalSection m_lock;
 
   bool m_bStartCalled;
+  bool m_bFinishCalled;
   volatile bool m_bStop;
   int  m_nRequestedThreads;
   int  m_nActiveThreads;

--- a/xbmc/BackgroundInfoLoader.h
+++ b/xbmc/BackgroundInfoLoader.h
@@ -27,6 +27,9 @@
 #include <vector>
 #include "boost/shared_ptr.hpp"
 
+#define SINGLE_LOCK_CHECK_THREAD_STOP_AND_RETURN(l, x) \
+  CSingleLock lock(l); if (CThread::IsCurrentThreadStopping()) return x
+
 class CFileItem; typedef boost::shared_ptr<CFileItem> CFileItemPtr;
 class CFileItemList;
 

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -74,12 +74,14 @@ bool CProgramThumbLoader::FillThumb(CFileItem &item)
     thumb = GetCachedImage(item, "thumb");
     if (thumb.IsEmpty())
     {
+      CHECK_THREAD_STOP_AND_RETURN(false);
       thumb = GetLocalThumb(item);
       if (!thumb.IsEmpty())
         SetCachedImage(item, "thumb", thumb);
     }
   }
 
+  CHECK_THREAD_STOP_AND_RETURN(false);
   if (!thumb.IsEmpty())
   {
     CTextureCache::Get().BackgroundCacheImage(thumb);

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -73,7 +73,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
     case GUI_MSG_WINDOW_DEINIT:
     {
       if (m_thumbLoader.IsLoading())
-        m_thumbLoader.StopThread();
+        m_thumbLoader.StopAsync(true);
     }
     break;
   case GUI_MSG_WINDOW_INIT:
@@ -354,7 +354,7 @@ void CGUIWindowAddonBrowser::SetItemLabel2(CFileItemPtr item)
 bool CGUIWindowAddonBrowser::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -21,6 +21,7 @@
  */
 
 #include "utils/StdString.h"
+#include "threads/SingleLock.h"
 
 namespace dbiplus {
   class Database;
@@ -173,4 +174,23 @@ private:
 
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */
   unsigned int m_openCount;
+};
+
+class CDBCloseGuard
+{
+public:
+  CDBCloseGuard(CDatabase *db, CCriticalSection *lock = NULL) : m_db(db), m_lock(lock) {}
+  ~CDBCloseGuard()
+  {
+    if (m_lock)
+    {
+      CSingleLock lock(*m_lock);
+      m_db->Close();
+    }
+    else
+      m_db->Close();
+  }
+protected:
+  CDatabase *m_db;
+  CCriticalSection *m_lock;
 };

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -132,7 +132,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       if (m_thumbLoader.IsLoading())
-        m_thumbLoader.StopThread();
+        m_thumbLoader.StopAsync(true);
       CGUIDialog::OnMessage(message);
       ClearFileItems();
       m_addNetworkShareEnabled = false;
@@ -340,7 +340,7 @@ void CGUIDialogFileBrowser::OnSort()
 void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
 {
   if (m_browsingForImages && m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
   // get selected item
   int iItem = m_viewControl.GetSelectedItem();
   CStdString strSelectedItem = "";

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -77,9 +77,11 @@ bool CMusicThumbLoader::LoadItem(CFileItem* pItem)
 
   if (pItem->HasVideoInfoTag() && pItem->GetArt().empty())
   { // music video
+    CHECK_THREAD_STOP_AND_RETURN(false);
     CVideoThumbLoader loader;
     if (loader.LoadItem(pItem))
       return true;
+    CHECK_THREAD_STOP_AND_RETURN(false);
   }
 
   if (!pItem->HasArt("fanart"))
@@ -87,6 +89,7 @@ bool CMusicThumbLoader::LoadItem(CFileItem* pItem)
     if (pItem->HasMusicInfoTag() && !pItem->GetMusicInfoTag()->GetArtist().empty())
     {
       std::string artist = pItem->GetMusicInfoTag()->GetArtist()[0];
+      SINGLE_LOCK_CHECK_THREAD_STOP_AND_RETURN(m_lock, false);
       m_database->Open();
       int idArtist = m_database->GetArtistByName(artist);
       if (idArtist >= 0)
@@ -104,6 +107,7 @@ bool CMusicThumbLoader::LoadItem(CFileItem* pItem)
 
   if (!pItem->HasArt("thumb"))
   {
+    CHECK_THREAD_STOP_AND_RETURN(false);
     // Look for embedded art
     if (pItem->HasMusicInfoTag() && !pItem->GetMusicInfoTag()->GetCoverArtInfo().empty())
     {
@@ -145,6 +149,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
   CMusicInfoTag &tag = *item.GetMusicInfoTag();
   if (tag.GetDatabaseId() > -1 && !tag.GetType().empty())
   {
+    SINGLE_LOCK_CHECK_THREAD_STOP_AND_RETURN(m_lock, false);
     m_database->Open();
     map<string, string> artwork;
     if (m_database->GetArtForItem(tag.GetDatabaseId(), tag.GetType(), artwork))

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -94,7 +94,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_WINDOW_DEINIT:
     if (m_thumbLoader.IsLoading())
-      m_thumbLoader.StopThread();
+      m_thumbLoader.StopAsync(true);
     break;
   case GUI_MSG_WINDOW_INIT:
     {
@@ -267,7 +267,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem)
 bool CGUIWindowMusicNav::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   if (CGUIWindowMusicBase::Update(strDirectory, updateFilterPath))
   {

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -96,7 +96,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       if (m_musicInfoLoader.IsLoading())
-        m_musicInfoLoader.StopThread();
+        m_musicInfoLoader.StopAsync(true);
 
       m_movingFrom = -1;
     }
@@ -147,14 +147,14 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_BTNSAVE)
       {
         if (m_musicInfoLoader.IsLoading()) // needed since we destroy m_vecitems to save memory
-          m_musicInfoLoader.StopThread();
+          m_musicInfoLoader.StopAsync(true);
 
         SavePlayList();
       }
       else if (iControl == CONTROL_BTNCLEAR)
       {
         if (m_musicInfoLoader.IsLoading())
-          m_musicInfoLoader.StopThread();
+          m_musicInfoLoader.StopAsync(true);
 
         ClearPlayList();
       }
@@ -482,7 +482,7 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
 bool CGUIWindowMusicPlayList::Update(const CStdString& strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_musicInfoLoader.IsLoading())
-    m_musicInfoLoader.StopThread();
+    m_musicInfoLoader.StopAsync(true);
 
   if (!CGUIWindowMusicBase::Update(strDirectory, updateFilterPath))
     return false;
@@ -623,7 +623,7 @@ void CGUIWindowMusicPlayList::OnMove(int iItem, int iAction)
 
   bool bRestart = m_musicInfoLoader.IsLoading();
   if (bRestart)
-    m_musicInfoLoader.StopThread();
+    m_musicInfoLoader.StopAsync(true);
 
   MoveCurrentPlayListItem(iItem, iAction);
 
@@ -648,7 +648,7 @@ void CGUIWindowMusicPlayList::MoveItem(int iStart, int iDest)
 
   bool bRestart = m_musicInfoLoader.IsLoading();
   if (bRestart)
-    m_musicInfoLoader.StopThread();
+    m_musicInfoLoader.StopAsync(true);
 
   // keep swapping until you get to the destination or you
   // hit the currently playing song

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -72,9 +72,9 @@ bool CGUIWindowMusicPlaylistEditor::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     if (m_thumbLoader.IsLoading())
-      m_thumbLoader.StopThread();
+      m_thumbLoader.StopAsync(true);
     if (m_playlistThumbLoader.IsLoading())
-      m_playlistThumbLoader.StopThread();
+      m_playlistThumbLoader.StopAsync(true);
     CGUIWindowMusicBase::OnMessage(message);
     return true;
 
@@ -219,7 +219,7 @@ void CGUIWindowMusicPlaylistEditor::OnQueueItem(int iItem)
 bool CGUIWindowMusicPlaylistEditor::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
@@ -243,7 +243,7 @@ void CGUIWindowMusicPlaylistEditor::ClearPlaylist()
 void CGUIWindowMusicPlaylistEditor::UpdatePlaylist()
 {
   if (m_playlistThumbLoader.IsLoading())
-    m_playlistThumbLoader.StopThread();
+    m_playlistThumbLoader.StopAsync(true);
 
   // deselect all items
   for (int i = 0; i < m_playlist->Size(); i++)

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -73,7 +73,7 @@ bool CGUIWindowMusicSongs::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     if (m_thumbLoader.IsLoading())
-      m_thumbLoader.StopThread();
+      m_thumbLoader.StopAsync(true);
     break;
   case GUI_MSG_WINDOW_INIT:
     {
@@ -466,7 +466,7 @@ void CGUIWindowMusicSongs::PlayItem(int iItem)
 bool CGUIWindowMusicSongs::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -94,7 +94,7 @@ bool CGUIWindowPictures::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       if (m_thumbLoader.IsLoading())
-        m_thumbLoader.StopThread();
+        m_thumbLoader.StopAsync(true);
 
       if (message.GetParam1() != WINDOW_SLIDESHOW)
       {
@@ -263,7 +263,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
 bool CGUIWindowPictures::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -52,6 +52,7 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
 
   if (pItem->HasArt("thumb") && m_regenerateThumbs)
   {
+    CHECK_THREAD_STOP_AND_RETURN(false);
     CTextureCache::Get().ClearCachedImage(pItem->GetArt("thumb"));
     CTextureDatabase db;
     if (db.Open())

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -55,7 +55,7 @@ bool CGUIWindowPrograms::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       if (m_thumbLoader.IsLoading())
-        m_thumbLoader.StopThread();
+        m_thumbLoader.StopAsync(true);
     }
     break;
 
@@ -150,7 +150,7 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 bool CGUIWindowPrograms::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -406,7 +406,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &ite
 void CGUIWindowPVRRecordings::BeforeUpdate(const CStdString &strDirectory)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 }
 
 void CGUIWindowPVRRecordings::AfterUpdate(CFileItemList& items)

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -45,6 +45,10 @@ public:
 // minimum as mandated by XTL
 #define THREAD_MINSTACKSIZE 0x10000
 
+#define CHECK_THREAD_STOP_AND_RETURN(x) do { \
+  if (CThread::IsCurrentThreadStopping()) return x ; \
+} while(0)
+
 namespace XbmcThreads { class ThreadSettings; }
 
 class CThread
@@ -82,6 +86,7 @@ public:
   static bool IsCurrentThread(const ThreadIdentifier tid);
   static ThreadIdentifier GetCurrentThreadId();
   static CThread* GetCurrentThread();
+  static bool IsCurrentThreadStopping() { return GetCurrentThread() && GetCurrentThread()->m_bStop; };
   static inline void SetLogger(XbmcCommons::ILogger* logger_) { CThread::logger = logger_; }
   static inline XbmcCommons::ILogger* GetLogger() { return CThread::logger; }
 

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -203,8 +203,9 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
   ||  pItem->IsParentFolder())
     return false;
 
+  SINGLE_LOCK_CHECK_THREAD_STOP_AND_RETURN(m_lock, false);
   m_database->Open();
-  CDBCloseGuard dbCloseGuard(m_database);
+  CDBCloseGuard dbCloseGuard(m_database, &m_lock);
 
   if (!pItem->HasVideoInfoTag() || !pItem->GetVideoInfoTag()->HasStreamDetails()) // no stream details
   {
@@ -221,6 +222,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
   {
     FillLibraryArt(*pItem);
 
+    CHECK_THREAD_STOP_AND_RETURN(false);
     if (!pItem->GetVideoInfoTag()->m_type.empty()         &&
          pItem->GetVideoInfoTag()->m_type != "movie"      &&
          pItem->GetVideoInfoTag()->m_type != "tvshow"     &&
@@ -230,6 +232,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
       return true; // nothing else to be done
     }
   }
+  lock.Leave();
 
   // if we have no art, look for it all
   map<string, string> artwork = pItem->GetArt();
@@ -276,6 +279,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
         pItem->SetProperty("AutoThumbImage", thumbURL);
         pItem->SetArt("thumb", thumbURL);
 
+        SINGLE_LOCK_CHECK_THREAD_STOP_AND_RETURN(m_lock, false);
         if (pItem->HasVideoInfoTag())
         {
           // Item has cached autogen image but no art entry. Save it to db.
@@ -292,6 +296,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
         if (URIUtils::IsInRAR(item.GetPath()))
           SetupRarOptions(item,path);
 
+        CHECK_THREAD_STOP_AND_RETURN(false);
         CThumbExtractor* extract = new CThumbExtractor(item, path, true, thumbURL);
         AddJob(extract);
         return true;
@@ -308,6 +313,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
       CStdString path(item.GetPath());
       if (URIUtils::IsInRAR(item.GetPath()))
         SetupRarOptions(item,path);
+      CHECK_THREAD_STOP_AND_RETURN(false);
       CThumbExtractor* extract = new CThumbExtractor(item,path,false);
       AddJob(extract);
     }
@@ -333,12 +339,14 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
   if (tag.m_iDbId > -1 && !tag.m_type.IsEmpty())
   {
     map<string, string> artwork;
+    SINGLE_LOCK_CHECK_THREAD_STOP_AND_RETURN(m_lock, false);
     m_database->Open();
-    CDBCloseGuard dbCloser(m_database);
+    CDBCloseGuard dbCloser(m_database, &m_lock);
     if (m_database->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
       SetArt(item, artwork);
     else if (tag.m_type == "artist")
     { // we retrieve music video art from the music database (no backward compat)
+      lock.Leave();
       CMusicDatabase database;
       database.Open();
       int idArtist = database.GetArtistByName(item.GetLabel());
@@ -347,6 +355,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     }
     else if (tag.m_type == "album")
     { // we retrieve music video art from the music database (no backward compat)
+      lock.Leave();
       CMusicDatabase database;
       database.Open();
       int idAlbum = database.GetAlbumByName(item.GetLabel(), tag.m_artist);
@@ -356,6 +365,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     // For episodes and seasons, we want to set fanart for that of the show
     if (!item.HasArt("fanart") && tag.m_iIdShow >= 0)
     {
+      SINGLE_LOCK_CHECK_THREAD_STOP_AND_RETURN(m_lock, false);
       ArtCache::const_iterator i = m_showArt.find(tag.m_iIdShow);
       if (i == m_showArt.end())
       {

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -204,6 +204,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
     return false;
 
   m_database->Open();
+  CDBCloseGuard dbCloseGuard(m_database);
 
   if (!pItem->HasVideoInfoTag() || !pItem->GetVideoInfoTag()->HasStreamDetails()) // no stream details
   {
@@ -226,7 +227,6 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
          pItem->GetVideoInfoTag()->m_type != "episode"    &&
          pItem->GetVideoInfoTag()->m_type != "musicvideo")
     {
-      m_database->Close();
       return true; // nothing else to be done
     }
   }
@@ -294,8 +294,6 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
 
         CThumbExtractor* extract = new CThumbExtractor(item, path, true, thumbURL);
         AddJob(extract);
-
-        m_database->Close();
         return true;
       }
     }
@@ -314,8 +312,6 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
       AddJob(extract);
     }
   }
-
-  m_database->Close();
   return true;
 }
 
@@ -338,6 +334,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
   {
     map<string, string> artwork;
     m_database->Open();
+    CDBCloseGuard dbCloser(m_database);
     if (m_database->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
       SetArt(item, artwork);
     else if (tag.m_type == "artist")
@@ -373,7 +370,6 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
         item.SetArtFallback("tvshow.thumb", "tvshow.poster");
       }
     }
-    m_database->Close();
   }
   return !item.GetArt().empty();
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -133,7 +133,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     if (m_thumbLoader.IsLoading())
-      m_thumbLoader.StopThread();
+      m_thumbLoader.StopAsync(true);
     m_database.Close();
     break;
 
@@ -1616,7 +1616,7 @@ void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
   playlist.Add(movieItem);
 
   if(m_thumbLoader.IsLoading())
-    m_thumbLoader.StopAsync();
+    m_thumbLoader.StopAsync(true);
 
   // play movie...
   g_playlistPlayer.Play(0);
@@ -1831,7 +1831,7 @@ void CGUIWindowVideoBase::PlayItem(int iItem)
 bool CGUIWindowVideoBase::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
@@ -1923,7 +1923,7 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
 
   // reload thumbs after filtering and grouping
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   m_thumbLoader.Load(items);
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -114,7 +114,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_WINDOW_DEINIT:
     if (m_thumbLoader.IsLoading())
-      m_thumbLoader.StopThread();
+      m_thumbLoader.StopAsync(true);
     break;
   case GUI_MSG_WINDOW_INIT:
     {
@@ -271,7 +271,7 @@ CStdString CGUIWindowVideoNav::GetQuickpathName(const CStdString& strPath) const
 bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
 {
   if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
+    m_thumbLoader.StopAsync(true);
 
   items.ClearProperties();
 


### PR DESCRIPTION
currently, each time when nav win changed the path, the bg info loader has to wait all workers stopped and block ui. if the worker is working on a slow task, e.g. list a zip file or on slow link, this will make the ui looks 'lock'.
This PR changed the StopAsync method of bg loader, make it support finish (save) current work asap, before the working workers finish their half work.
