### PR TITLE
FIX: Send Touch actions to the proper window

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -528,12 +528,15 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
       int windowId = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
       int actionId = 0;
       if (newEvent.touch.action == ACTION_GESTURE_BEGIN || newEvent.touch.action == ACTION_GESTURE_END)
+      {
         actionId = newEvent.touch.action;
-      else if (!CButtonTranslator::GetInstance().TranslateTouchAction(windowId, newEvent.touch.action, newEvent.touch.pointers, actionId) ||
+        windowId = WINDOW_INVALID;
+      }
+      else if (!CButtonTranslator::GetInstance().TranslateTouchAction(newEvent.touch.action, newEvent.touch.pointers, windowId, actionId) ||
           actionId <= 0)
         return false;
 
-      CApplicationMessenger::Get().SendAction(CAction(actionId, 0, newEvent.touch.x, newEvent.touch.y, newEvent.touch.x2, newEvent.touch.y2), WINDOW_INVALID, false);
+      CApplicationMessenger::Get().SendAction(CAction(actionId, 0, newEvent.touch.x, newEvent.touch.y, newEvent.touch.x2, newEvent.touch.y2), windowId, false);
       break;
     }
   }

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -870,7 +870,7 @@ bool CButtonTranslator::TranslateJoystickString(int window, const char* szDevice
   return (action > 0);
 }
 
-bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int touchPointers, int &action)
+bool CButtonTranslator::TranslateTouchAction(int touchAction, int touchPointers, int &window, int &action)
 {
   action = 0;
   if (touchPointers <= 0)
@@ -881,7 +881,10 @@ bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int to
 
   action = GetTouchActionCode(window, touchAction);
   if (action <= 0)
+  {
+    window = WINDOW_INVALID;
     action = GetTouchActionCode(-1, touchAction);
+  }
 
   return action > 0;
 }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -97,7 +97,7 @@ public:
                                bool &fullrange);
 #endif
 
-  bool TranslateTouchAction(int window, int touchAction, int touchPointers, int &action);
+  bool TranslateTouchAction(int touchAction, int touchPointers, int &window, int &action);
 
 private:
   typedef std::multimap<uint32_t, CButtonAction> buttonMap; // our button map to fill in


### PR DESCRIPTION
This allows:

```
...
  <FullScreenVideo>
    <touch>
      <swipeleft>StepBack</swipeleft>
      <swiperight>StepForward</swiperight>
      <swipeup>BigStepForward</swipeup>
      <swipedown>BigStepBack</swipedown>
    </touch>
  </FullScreenVideo>
...
```
