### PR TITLE
[Fix] Generic touch focus and unfocus gui control correctly.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -534,16 +534,8 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
       int windowId = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
 
       if (newEvent.touch.action == ACTION_TOUCH_TAP)
-      {
-        // Send a mouse motion event for getting the current guiitem selected
-        XBMC_Event mouseEvent;
-        memset(&mouseEvent, 0, sizeof(mouseEvent));
-
-        mouseEvent.type = XBMC_MOUSEMOTION;
-        mouseEvent.motion.type = XBMC_MOUSEMOTION;
-        mouseEvent.motion.x = newEvent.touch.x;
-        mouseEvent.motion.y = newEvent.touch.y;
-        OnEvent(mouseEvent);
+      { // Send a mouse motion event with no dx,dy for getting the current guiitem selected
+        g_application.OnAction(CAction(ACTION_MOUSE_MOVE, 0, newEvent.touch.x, newEvent.touch.y, 0, 0));
       }
       int actionId = 0;
       if (newEvent.touch.action == ACTION_GESTURE_BEGIN || newEvent.touch.action == ACTION_GESTURE_END)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -532,6 +532,19 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
     case XBMC_TOUCH:
     {
       int windowId = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
+
+      if (newEvent.touch.action == ACTION_TOUCH_TAP)
+      {
+        // Send a mouse motion event for getting the current guiitem selected
+        XBMC_Event mouseEvent;
+        memset(&mouseEvent, 0, sizeof(mouseEvent));
+
+        mouseEvent.type = XBMC_MOUSEMOTION;
+        mouseEvent.motion.type = XBMC_MOUSEMOTION;
+        mouseEvent.motion.x = newEvent.touch.x;
+        mouseEvent.motion.y = newEvent.touch.y;
+        OnEvent(mouseEvent);
+      }
       int actionId = 0;
       if (newEvent.touch.action == ACTION_GESTURE_BEGIN || newEvent.touch.action == ACTION_GESTURE_END)
       {

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -543,6 +543,12 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
         return false;
 
       CApplicationMessenger::Get().SendAction(CAction(actionId, 0, newEvent.touch.x, newEvent.touch.y, newEvent.touch.x2, newEvent.touch.y2), windowId, false);
+      // Post an unfocus message for touch device after the action.
+      if (newEvent.touch.action == ACTION_GESTURE_END || newEvent.touch.action == ACTION_TOUCH_TAP)
+      {
+        CGUIMessage msg(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);
+        CApplicationMessenger::Get().SendGUIMessage(msg);
+      }
       break;
     }
   }

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -190,5 +190,13 @@ void CGenericTouchActionHandler::sendEvent(int actionId, float x, float y, float
 void CGenericTouchActionHandler::focusControl(float x, float y)
 {
   // Send a mouse motion event for getting the current guiitem selected
-  touch(XBMC_MOUSEMOTION, 0, (uint16_t)x, (uint16_t)y);
+  XBMC_Event newEvent;
+  memset(&newEvent, 0, sizeof(newEvent));
+
+  newEvent.type = XBMC_MOUSEMOTION;
+  newEvent.motion.type = XBMC_MOUSEMOTION;
+  newEvent.motion.x = x;
+  newEvent.motion.y = y;
+
+  CWinEvents::MessagePush(&newEvent);
 }

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -113,7 +113,6 @@ void CGenericTouchActionHandler::OnLongPress(float x, float y, int32_t pointers 
   if (pointers <= 0 || pointers > 10)
     return;
 
-  focusControl(x, y);
   sendEvent(ACTION_TOUCH_LONGPRESS, (uint16_t)x, (uint16_t)y, 0.0f, 0.0f, pointers);
 }
 

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -101,7 +101,6 @@ void CGenericTouchActionHandler::OnTap(float x, float y, int32_t pointers /* = 1
   if (pointers <= 0 || pointers > 10)
     return;
 
-  focusControl(x, y);
   sendEvent(ACTION_TOUCH_TAP, (uint16_t)x, (uint16_t)y, 0.0f, 0.0f, pointers);
 }
 

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -93,9 +93,6 @@ bool CGenericTouchActionHandler::OnTouchGestureEnd(float x, float y, float offse
 {
   sendEvent(ACTION_GESTURE_END, velocityX, velocityY, x, y);
 
-  // unfocus the focused GUI item
-  g_windowManager.SendMessage(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);
-
   return true;
 }
 

--- a/xbmc/windowing/osx/WinEventsIOS.mm
+++ b/xbmc/windowing/osx/WinEventsIOS.mm
@@ -82,16 +82,7 @@ bool CWinEventsIOS::MessagePump()
     }
     else
       ret |= g_application.OnEvent(pumpEvent);
-
-//on ios touch devices - unfocus controls on finger lift
-#if !defined(TARGET_DARWIN_IOS_ATV2)
-    if (pumpEvent.type == XBMC_MOUSEBUTTONUP)
-    {
-      g_windowManager.SendMessage(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);
-    }
-#endif
   }
-
   return ret;
 }
 


### PR DESCRIPTION
currently, the both focus and unfocus not work correctly.

focus did not send out correct mouse motion event
unfocus did not sent at correct place.

this pr fixed these.
