### PR TITLE
[dvdplayer] fix deadlock when trying to go to disc menu

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3511,7 +3511,7 @@ bool CDVDPlayer::OnAction(const CAction &action)
         pMenus->OnMenu();
         // send a message to everyone that we've gone to the menu
         CGUIMessage msg(GUI_MSG_VIDEO_MENU_STARTED, 0, 0);
-        g_windowManager.SendMessage(msg);
+        g_windowManager.SendThreadMessage(msg);
         return true;
       }
       break;


### PR DESCRIPTION
fix a deadlock occurring when trying to navigate to DVD disc menu. This happens most of the time when trying to skip directly to DVD menu from start of playback. The deadlock is on g_graphicsContext, since g_windowManager.SendMessage uses this object as a mutex. Changing to SendThreadMessage does the job fixing this issue, and is consistent with what other players (like PlaylistPlayer) are using.
