### PR TITLE
fixed: addoninstaller unguarded null pointer after #2475

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -343,13 +343,14 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
     }
     // at this point we have our dep, or the dep is optional (and we don't have it) so check that it's OK as well
     // TODO: should we assume that installed deps are OK?
-    if (dep && 
-       std::find(preDeps.begin(), preDeps.end(), dep->ID()) == preDeps.end() &&
-       !CheckDependencies(dep, preDeps))
+    if (dep)
     {
-      return false;
+      if (std::find(preDeps.begin(), preDeps.end(), dep->ID()) == preDeps.end() &&
+       !CheckDependencies(dep, preDeps))
+        return false;
+      else
+        preDeps.push_back(dep->ID());
     }
-    preDeps.push_back(dep->ID());
   }
   return true;
 }


### PR DESCRIPTION
This fixes a small bug when an addon dependency is not present (don't have) and not mandatory. In that case a null pointer exception happens.

This bug is there since https://github.com/xbmc/xbmc/commit/b0825b1a212849e52fca27409ea87e81591f7cf4
