### PR TITLE
pvr: fix too early finish of recordings

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -45,7 +45,6 @@ CDVDInputStreamPVRManager::CDVDInputStreamPVRManager(IDVDPlayer* pPlayer) : CDVD
   m_pLiveTV         = NULL;
   m_pOtherStream    = NULL;
   m_eof             = true;
-  m_bReopened       = false;
   m_iScanTimeout    = 0;
 }
 
@@ -311,28 +310,20 @@ bool CDVDInputStreamPVRManager::UpdateItem(CFileItem& item)
 
 CDVDInputStream::ENextStream CDVDInputStreamPVRManager::NextStream()
 {
-  if(!m_pFile) return NEXTSTREAM_NONE;
+  if(!m_pFile)
+    return NEXTSTREAM_NONE;
 
-  if(m_bReopened)
-  {
-    if (IsEOF())
-      return NEXTSTREAM_NONE;
-    else
-    {
-      m_bReopened = false;
-      m_eof       = false;
-      return NEXTSTREAM_RETRY;
-    }
-  }
+  m_eof = IsEOF();
 
   if (m_pOtherStream)
     return m_pOtherStream->NextStream();
   else if(m_pFile->SkipNext())
   {
-    m_eof = false;
-    return NEXTSTREAM_OPEN;
+    if (m_eof)
+      return NEXTSTREAM_OPEN;
+    else
+      return NEXTSTREAM_RETRY;
   }
-
   return NEXTSTREAM_NONE;
 }
 
@@ -385,7 +376,6 @@ bool CDVDInputStreamPVRManager::CloseAndOpen(const char* strFile)
 
   if (Open(strFile, m_content))
   {
-    m_bReopened = true;
     return true;
   }
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -315,9 +315,14 @@ CDVDInputStream::ENextStream CDVDInputStreamPVRManager::NextStream()
 
   if(m_bReopened)
   {
-    m_bReopened = false;
-    m_eof       = false;
-    return NEXTSTREAM_RETRY;
+    if (IsEOF())
+      return NEXTSTREAM_NONE;
+    else
+    {
+      m_bReopened = false;
+      m_eof       = false;
+      return NEXTSTREAM_RETRY;
+    }
   }
 
   if (m_pOtherStream)

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -98,7 +98,6 @@ protected:
   XFILE::IRecordable*       m_pRecordable;
   bool                      m_eof;
   std::string               m_strContent;
-  bool                      m_bReopened;
   unsigned int              m_iScanTimeout;
 };
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1174,15 +1174,6 @@ void CDVDPlayer::Process()
         Sleep(100);
         continue;
       }
-      else if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
-      {
-        CDVDInputStreamPVRManager* pStream = static_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
-        if (pStream->IsEOF())
-          break;
-
-        Sleep(100);
-        continue;
-      }
 
       // make sure we tell all players to finish it's data
       if(m_CurrentAudio.inited)

--- a/xbmc/filesystem/PVRFile.h
+++ b/xbmc/filesystem/PVRFile.h
@@ -44,7 +44,7 @@ public:
   virtual void          Close();
   virtual unsigned int  Read(void* buffer, int64_t size);
   virtual CStdString    GetContent()                                   { return ""; }
-  virtual bool          SkipNext()                                     { return true; }
+  virtual bool          SkipNext()                                     { return !m_isPlayRecording; }
 
   virtual bool          Delete(const CURL& url);
   virtual bool          Rename(const CURL& url, const CURL& urlnew);


### PR DESCRIPTION
pvr recordings stopped right after input stream has detected eof.
