### PR TITLE
unicode --> latin-1 for weather wunderground alerts to fix special chars...

### DIFF
--- a/addons/weather.wunderground/default.py
+++ b/addons/weather.wunderground/default.py
@@ -515,8 +515,8 @@ def properties(data,loc):
         rss = ''
         alerts = ''
         for count, item in enumerate(data['alerts']):
-            set_property('Alerts.%i.Description'     % (count+1), item['description'])
-            set_property('Alerts.%i.Message'         % (count+1), item['message'])
+            set_property('Alerts.%i.Description'     % (count+1), item['description'].encode('latin-1'))
+            set_property('Alerts.%i.Message'         % (count+1), item['message'].encode('latin-1'))
             set_property('Alerts.%i.StartDate'       % (count+1), item['date'])
             set_property('Alerts.%i.EndDate'         % (count+1), item['expires'])
             set_property('Alerts.%i.Significance'    % (count+1), SEVERITY[item['significance']])


### PR DESCRIPTION
... (ä,ö,ü etc)

is there a reason that this was never fixed? does it break something else when converting to latin-1? seems to work here without problems...

EDIT: I see, i get an "&NBSP" now at the end.

should i fix that with some string parsing?
or do you expect them to make the fixes on their API side?
