### PR TITLE
Make CDirectory::Exists support use directory cache by default.

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -251,10 +251,18 @@ bool CDirectory::Create(const CStdString& strPath)
   return false;
 }
 
-bool CDirectory::Exists(const CStdString& strPath)
+bool CDirectory::Exists(const CStdString& strPath, bool bUseCache /* = true */)
 {
   try
   {
+    if (bUseCache)
+    {
+      bool bPathInCache;
+      if (g_directoryCache.FileExists(strPath, bPathInCache))
+        return true;
+      if (bPathInCache)
+        return false;
+    }
     CStdString realPath = URIUtils::SubstitutePath(strPath);
     auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realPath));
     if (pDirectory.get())

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -55,7 +55,7 @@ public:
                            , bool allowThreads=false);
 
   static bool Create(const CStdString& strPath);
-  static bool Exists(const CStdString& strPath);
+  static bool Exists(const CStdString& strPath, bool bUseCache = true);
   static bool Remove(const CStdString& strPath);
 
   /*! \brief Filter files that act like directories from the list, replacing them with their directory counterparts

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -175,8 +175,10 @@ bool CDirectoryCache::FileExists(const CStdString& strFile, bool& bInCache)
   CSingleLock lock (m_cs);
   bInCache = false;
 
+  CStdString strPath(strFile);
+  URIUtils::RemoveSlashAtEnd(strPath);
   CStdString storedPath;
-  URIUtils::GetDirectory(strFile, storedPath);
+  URIUtils::GetDirectory(strPath, storedPath);
   URIUtils::RemoveSlashAtEnd(storedPath);
 
   ciCache i = m_cache.find(storedPath);


### PR DESCRIPTION
We check file exists in CFile::Open() and CFile::Exists() for files, but not for dir in CDirectory::Exists() yet, this PR make CDirectory::Exists() also use directory cache to speed up the Exists operation.
