### PR TITLE
library: support simultaneous simple and advanced filtering (fixes #13915)

### DIFF
--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -103,7 +103,7 @@ protected:
    \return true if the given path can contain a "filter" parameter otherwise false
    */
   virtual bool CanContainFilter(const CStdString &strDirectory) const { return false; }
-  virtual bool Filter();
+  virtual bool Filter(bool advanced = true);
 
   /* \brief Called on response to a GUI_MSG_FILTER_ITEMS message
    Filters the current list with the given filter using FilterItems()


### PR DESCRIPTION
With these changes it becomes possible to use simple and advanced filtering in a library view (where advanced filtering is supported). This fixes the broken Filter SMS behaviour as reported in http://trac.xbmc.org/ticket/13915.

As it's up to skins/skinners to support advanced library filtering they now have the possibility to support simple filtering and not provide the advanced filtering or they can provide both but IMO that's not very user-friendly.

When applying a simple and an advanced filter simultaneously, there are a few behaviours that are probably not very intuitive. Changing the title filter in the advanced filter dialog e.g. doesn't change the simple filter (which also applies to the title of the item). Clearing the advanced filter also doesn't clear the simple filter. But that's only a problem if a skin shows a button/input for simple filter AND a button for advanced filtering. If they only show one of them (advanced if supported, otherwise simple) then the user can't really run into these problems.
