### PR TITLE
AE: possible segfault after suspend / resume (m_sink might be gone)

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -1536,7 +1536,8 @@ inline void CSoftAE::ProcessSuspend()
      */
     if (!m_isSuspended && (!m_playingStreams.empty() || !m_playing_sounds.empty()))
     {
-      m_reOpen = !m_sink->SoftResume() || m_reOpen; // sink returns false if it requires reinit (worthless with current implementation)
+      // the sink might still be not initialized after Resume of real suspend
+      m_reOpen = m_sink && (!m_sink->SoftResume() || m_reOpen); // sink returns false if it requires reinit (worthless with current implementation)
       m_sinkIsSuspended = false; //sink processing data
       m_softSuspend   = false; //break suspend loop (under some conditions)
       CLog::Log(LOGDEBUG, "Resumed the Sink");


### PR DESCRIPTION
Famous CEC Adapter plays a "tadamm" sound directly after resume. Therefore ProcessSuspend leaves out of the front door before a reOpen could have been triggered. As the ::Resume only flags m_reOpen = true, m_sink could still be NULL.

This checks takes care of this. 
Backtrace of the error is here: http://pastebin.ubuntu.com/5649014/

Thx @olympia for the time for tracking it down.
