### PR TITLE
AE: Stop playing sounds when going to Suspend for all platforms (fixes #14211)

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -975,8 +975,10 @@ bool CSoftAE::Suspend()
 {
   CLog::Log(LOGDEBUG, "CSoftAE::Suspend - Suspending AE processing");
   m_isSuspended = true;
+
+  StopAllSounds();
+
   CSingleLock streamLock(m_streamLock);
-  
   for (StreamList::iterator itt = m_playingStreams.begin(); itt != m_playingStreams.end(); ++itt)
   {
     CSoftAEStream *stream = *itt;
@@ -985,7 +987,6 @@ bool CSoftAE::Suspend()
   streamLock.Leave();
   #if defined(TARGET_LINUX)
   /*workaround sinks not playing sound after resume */
-    StopAllSounds();
     bool ret = true;
     if(m_sink)
     {


### PR DESCRIPTION
Discussed with @DDDamian here: http://trac.xbmc.org/ticket/14211#comment:9

It is currently not tested on windows - so it would be nice if someone could test it. 
This changes global behaviour. So all sounds are freed on all systems that use SoftAE before Suspend.
