### PR TITLE
[touch] allow swipe gestures with a perpendicular movement of up to 20 degrees

### DIFF
--- a/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
+++ b/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
@@ -18,17 +18,24 @@
  *
  */
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+#include <math.h>
 #include <stdlib.h>
 
 #include "GenericTouchSwipeDetector.h"
 
 // maximum time between touch down and up (in nanoseconds)
-#define SWIPE_MAX_TIME      500000000
+#define SWIPE_MAX_TIME            500000000
 // maxmium swipe distance between touch down and up (in multiples of screen DPI)
-#define SWIPE_MIN_DISTANCE  0.5
-// maximum distance the touch movement may vary in a direction transversal to
-// the swipe direction
-#define SWIPE_MAX_VARIANCE  30.0
+#define SWIPE_MIN_DISTANCE        0.5
+// original maximum variance of the touch movement
+#define SWIPE_MAX_VARIANCE        0.2
+// tangens of the maximum angle (20 degrees) the touch movement may vary in a
+// direction perpendicular to the swipe direction (in radians)
+// => tan(20 deg) = tan(20 * M_PI / 180)
+#define SWIPE_MAX_VARIANCE_ANGLE  0.363970234266
 
 CGenericTouchSwipeDetector::CGenericTouchSwipeDetector(ITouchActionHandler *handler, float dpi)
   : IGenericTouchGestureDetector(handler, dpi),
@@ -112,11 +119,13 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
 
   float deltaXabs = abs(pointer.current.x - pointer.down.x);
   float deltaYabs = abs(pointer.current.y - pointer.down.y);
+  float varXabs = deltaYabs * SWIPE_MAX_VARIANCE_ANGLE + (m_dpi * SWIPE_MAX_VARIANCE) / 2;
+  float varYabs = deltaXabs * SWIPE_MAX_VARIANCE_ANGLE + (m_dpi * SWIPE_MAX_VARIANCE) / 2;
 
   if (m_directions & TouchMoveDirectionLeft)
   {
     // check if the movement went too much in Y direction
-    if (deltaYabs > SWIPE_MAX_VARIANCE)
+    if (deltaYabs > varYabs)
       m_directions &= ~TouchMoveDirectionLeft;
     // check if the movement went far enough in the X direction
     else if (deltaXabs > m_dpi * SWIPE_MIN_DISTANCE)
@@ -126,7 +135,7 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
   if (m_directions & TouchMoveDirectionRight)
   {
     // check if the movement went too much in Y direction
-    if (deltaYabs > SWIPE_MAX_VARIANCE)
+    if (deltaYabs > varYabs)
       m_directions &= ~TouchMoveDirectionRight;
     // check if the movement went far enough in the X direction
     else if (deltaXabs > m_dpi * SWIPE_MIN_DISTANCE)
@@ -136,7 +145,7 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
   if (m_directions & TouchMoveDirectionUp)
   {
     // check if the movement went too much in X direction
-    if (deltaXabs > SWIPE_MAX_VARIANCE)
+    if (deltaXabs > varXabs)
       m_directions &= ~TouchMoveDirectionUp;
     // check if the movement went far enough in the Y direction
     else if (deltaYabs > m_dpi * SWIPE_MIN_DISTANCE)
@@ -146,7 +155,7 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
   if (m_directions & TouchMoveDirectionDown)
   {
     // check if the movement went too much in X direction
-    if (deltaXabs > SWIPE_MAX_VARIANCE)
+    if (deltaXabs > varXabs)
       m_directions &= ~TouchMoveDirectionDown;
     // check if the movement went far enough in the Y direction
     else if (deltaYabs > m_dpi * SWIPE_MIN_DISTANCE)


### PR DESCRIPTION
The title says it all. This allows gestures to be recognised as vertical/horizontal swipes even if the swipe movement is a bit diagonal (up to 20 degrees from the horizontal or vertical movement) which improves swipe gesture recognition a lot especially because most swipe gestures tend to move up/down a bit at the end of the gesture.
