### PR TITLE
[touch/generic] support swipe gesture detection for multiple pointers

### DIFF
--- a/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
+++ b/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
@@ -33,7 +33,7 @@
 CGenericTouchSwipeDetector::CGenericTouchSwipeDetector(ITouchActionHandler *handler, float dpi)
   : IGenericTouchGestureDetector(handler, dpi),
     m_directions(TouchMoveDirectionLeft | TouchMoveDirectionRight | TouchMoveDirectionUp | TouchMoveDirectionDown),
-    m_swipeDetected(false)
+    m_swipeDetected(false), m_size(0)
 { }
 
 bool CGenericTouchSwipeDetector::OnTouchDown(unsigned int index, const Pointer &pointer)
@@ -41,9 +41,9 @@ bool CGenericTouchSwipeDetector::OnTouchDown(unsigned int index, const Pointer &
   if (index < 0 || index >= TOUCH_MAX_POINTERS)
     return false;
 
-  // only handle one-finger swipes
-  if (index > 0)
-    return false;
+  m_size += 1;
+  if (m_size > 1)
+    return true;
 
   // reset all values
   m_done = false;
@@ -58,8 +58,8 @@ bool CGenericTouchSwipeDetector::OnTouchUp(unsigned int index, const Pointer &po
   if (index < 0 || index >= TOUCH_MAX_POINTERS)
     return false;
 
-  // only handle one-finger swipes
-  if (index > 0 || m_done)
+  m_size -= 1;
+  if (m_done)
     return false;
 
   m_done = true;
@@ -78,7 +78,7 @@ bool CGenericTouchSwipeDetector::OnTouchUp(unsigned int index, const Pointer &po
   pointer.velocity(velocityX, velocityY, false);
 
   // call the OnSwipe() callback
-  OnSwipe((TouchMoveDirection)m_directions, pointer.down.x, pointer.down.y, pointer.current.x, pointer.current.y, velocityX, velocityY, 1);
+  OnSwipe((TouchMoveDirection)m_directions, pointer.down.x, pointer.down.y, pointer.current.x, pointer.current.y, velocityX, velocityY, m_size + 1);
   return true;
 }
 
@@ -87,8 +87,8 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
   if (index < 0 || index >= TOUCH_MAX_POINTERS)
     return false;
 
-  // only handle one-finger swipes of moved pointers
-  if (index > 0 || m_done || !pointer.moving)
+  // only handle swipes of moved pointers
+  if (index >= m_size || m_done || !pointer.moving)
     return false;
 
   float deltaXmovement = pointer.current.x - pointer.last.x;
@@ -154,4 +154,15 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
   }
   
   return true;
+}
+
+bool CGenericTouchSwipeDetector::OnTouchUpdate(unsigned int index, const Pointer &pointer)
+{
+  if (index < 0 || index >= TOUCH_MAX_POINTERS)
+    return false;
+
+  if (m_done)
+    return true;
+
+  return OnTouchMove(index, pointer);
 }

--- a/xbmc/input/touch/generic/GenericTouchSwipeDetector.h
+++ b/xbmc/input/touch/generic/GenericTouchSwipeDetector.h
@@ -37,6 +37,7 @@ public:
   virtual bool OnTouchDown(unsigned int index, const Pointer &pointer);
   virtual bool OnTouchUp(unsigned int index, const Pointer &pointer);
   virtual bool OnTouchMove(unsigned int index, const Pointer &pointer);
+  virtual bool OnTouchUpdate(unsigned int index, const Pointer &pointer);
 
 private:
   /*!
@@ -52,4 +53,8 @@ private:
    * \brief Whether a swipe gesture has been detected or not
    */
   bool m_swipeDetected;
+  /*!
+   * \brief Number of active pointeres
+   */
+  unsigned int m_size;
 };


### PR DESCRIPTION
This is a replacement for #2483 and is more complete i.e. it only detects a multi-pointer (currently limited to 2) gesture if both pointers move in the same direction and both fulfil the conditions for a pan gesture to be recognised as a swipe gesture.
