### PR TITLE
[win32] improved touch input/gesture handling

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -701,6 +701,9 @@
     <ClCompile Include="..\..\xbmc\input\KeyboardLayoutConfiguration.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardStat.cpp" />
     <ClCompile Include="..\..\xbmc\input\MouseStat.cpp" />
+    <ClCompile Include="..\..\xbmc\input\touch\generic\GenericTouchActionHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\input\touch\generic\GenericTouchSwipeDetector.cpp" />
+    <ClCompile Include="..\..\xbmc\input\touch\ITouchInputHandling.cpp" />
     <ClCompile Include="..\..\xbmc\input\windows\IRServerSuite.cpp" />
     <ClCompile Include="..\..\xbmc\input\windows\IrssMessage.cpp" />
     <ClCompile Include="..\..\xbmc\input\windows\WINJoystick.cpp" />
@@ -1048,6 +1051,13 @@
     <ClInclude Include="..\..\xbmc\guilib\GUIKeyboardFactory.h" />
     <ClInclude Include="..\..\xbmc\guilib\iimage.h" />
     <ClInclude Include="..\..\xbmc\guilib\imagefactory.h" />
+    <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchActionHandler.h" />
+    <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchSwipeDetector.h" />
+    <ClInclude Include="..\..\xbmc\input\touch\generic\IGenericTouchGestureDetector.h" />
+    <ClInclude Include="..\..\xbmc\input\touch\ITouchActionHandler.h" />
+    <ClInclude Include="..\..\xbmc\input\touch\ITouchInputHandler.h" />
+    <ClInclude Include="..\..\xbmc\input\touch\ITouchInputHandling.h" />
+    <ClInclude Include="..\..\xbmc\input\touch\TouchTypes.h" />
     <ClInclude Include="..\..\xbmc\input\windows\WINJoystick.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\PVROperations.h" />
     <ClInclude Include="..\..\xbmc\interfaces\legacy\Addon.h" />
@@ -1114,6 +1124,7 @@
     <ClInclude Include="..\..\xbmc\settings\windows\GUIWindowTestPattern.h" />
     <ClInclude Include="..\..\xbmc\utils\IRssObserver.h" />
     <ClInclude Include="..\..\xbmc\utils\RssManager.h" />
+    <ClInclude Include="..\..\xbmc\utils\Vector.h" />
     <ClInclude Include="..\..\xbmc\video\FFmpegVideoDecoder.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\swig.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\XBPython.h" />
@@ -1257,6 +1268,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Template|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\Vector.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoThumbLoader.cpp" />
     <ClCompile Include="..\..\xbmc\music\MusicThumbLoader.cpp" />
     <ClCompile Include="..\..\xbmc\ThumbnailCache.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -295,6 +295,12 @@
     <Filter Include="profiles\windows">
       <UniqueIdentifier>{b5a6d872-7e56-4976-81c5-47baad252337}</UniqueIdentifier>
     </Filter>
+    <Filter Include="input\touch">
+      <UniqueIdentifier>{4e236b17-3720-4ed8-89af-90cb86bf9b03}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="input\touch\generic">
+      <UniqueIdentifier>{d062c356-66f2-49e7-9510-b216701d2298}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -2999,6 +3005,18 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\profiles\ProfilesManager.cpp">
       <Filter>profiles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\input\touch\generic\GenericTouchActionHandler.cpp">
+      <Filter>input\touch\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\input\touch\generic\GenericTouchSwipeDetector.cpp">
+      <Filter>input\touch\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\input\touch\ITouchInputHandling.cpp">
+      <Filter>input\touch</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\Vector.cpp">
+      <Filter>utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -5857,6 +5875,30 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\profiles\ProfilesManager.h">
       <Filter>profiles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\touch\ITouchActionHandler.h">
+      <Filter>input\touch</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchActionHandler.h">
+      <Filter>input\touch\generic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\touch\TouchTypes.h">
+      <Filter>input\touch</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchSwipeDetector.h">
+      <Filter>input\touch\generic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\touch\generic\IGenericTouchGestureDetector.h">
+      <Filter>input\touch\generic</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\touch\ITouchInputHandler.h">
+      <Filter>input\touch</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\touch\ITouchInputHandling.h">
+      <Filter>input\touch</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\Vector.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
+++ b/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
@@ -161,6 +161,12 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
     else if (deltaYabs > m_dpi * SWIPE_MIN_DISTANCE)
       m_swipeDetected = true;
   }
+
+  if (m_directions == TouchMoveDirectionNone)
+  {
+    m_done = true;
+    return false;
+  }
   
   return true;
 }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -355,6 +355,16 @@ static XBMC_keysym *TranslateKey(WPARAM vkey, UINT scancode, XBMC_keysym *keysym
   return(keysym);
 }
 
+void CWinEventsWin32::MessagePush(XBMC_Event *newEvent)
+{
+  // m_pEventFunc should be set because MessagePush is only executed by
+  // methods called from WndProc()
+  if (m_pEventFunc == NULL)
+    return;
+
+  m_pEventFunc(*newEvent);
+}
+
 bool CWinEventsWin32::MessagePump()
 {
   MSG  msg;

--- a/xbmc/windowing/windows/WinEventsWin32.h
+++ b/xbmc/windowing/windows/WinEventsWin32.h
@@ -28,6 +28,7 @@
 class CWinEventsWin32 : public CWinEventsBase
 {
 public:
+  static void MessagePush(XBMC_Event *newEvent);
   static bool MessagePump();
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
   static PHANDLE_EVENT_FUNC m_pEventFunc;

--- a/xbmc/windowing/windows/WinEventsWin32.h
+++ b/xbmc/windowing/windows/WinEventsWin32.h
@@ -23,7 +23,11 @@
 
 #pragma once
 
-#include "WinEvents.h"
+#include "windowing/WinEvents.h"
+#include "input/MouseStat.h"
+#include "input/touch/TouchTypes.h"
+
+class CGenericTouchSwipeDetector;
 
 class CWinEventsWin32 : public CWinEventsBase
 {
@@ -31,15 +35,17 @@ public:
   static void MessagePush(XBMC_Event *newEvent);
   static bool MessagePump();
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-  static PHANDLE_EVENT_FUNC m_pEventFunc;
+
 private:
   static void RegisterDeviceInterfaceToHwnd(GUID InterfaceClassGuid, HWND hWnd, HDEVNOTIFY *hDeviceNotify);
   static void WindowFromScreenCoords(HWND hWnd, POINT *point);
   static void OnGestureNotify(HWND hWnd, LPARAM lParam);
   static void OnGesture(HWND hWnd, LPARAM lParam);
 
-  static int m_lastGesturePosX;
-  static int m_lastGesturePosY;
+  static PHANDLE_EVENT_FUNC m_pEventFunc;
+  static int m_originalZoomDistance;
+  static Pointer m_touchPointer;
+  static CGenericTouchSwipeDetector *m_touchSwipeDetector;
 };
 
 #endif // WINDOW_EVENTS_WIN32_H

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -115,6 +115,9 @@ typedef struct tagGESTURENOTIFYSTRUCT {
     DWORD dwInstanceID;             // internally used
 } GESTURENOTIFYSTRUCT, *PGESTURENOTIFYSTRUCT;
 
+#define GID_ROTATE_ANGLE_TO_ARGUMENT(_arg_)     ((USHORT)((((_arg_) + 2.0 * 3.14159265) / (4.0 * 3.14159265)) * 65535.0))
+#define GID_ROTATE_ANGLE_FROM_ARGUMENT(_arg_)   ((((double)(_arg_) / 65535.0) * 4.0 * 3.14159265) - 2.0 * 3.14159265)
+
 DECLARE_HANDLE(HGESTUREINFO);
 
 #endif


### PR DESCRIPTION
This PR moves the win32-specific touch input/gesture handling (using WM_GESTURES) to the recently introduced generic touch input handling also used by Android and iOS. New features are
- user-mappable gestures through touchscreen.xml
- support for rotate gestures (e.g. in picture viewing)
- support for zoom/pinch gestures (e.g. in picture viewing)
- support for one finger swipe gestures

Unfortunately WM_GESTURES does not seem to allow simultaneous rotate and zoom/pinch gestures so users can only use one of them at a time but still better than nothing.

As I don't have a touch-capable device running Windows 7 or Windows 8 I'm not able to test these changes myself but @MartijnKaijser was kind enough to be my guinea pig for a week or so and he should be able to confirm that everything works as expected.

I kept with WM_GESTURES because it is the API we used until now and because it's the easiest to use. Windows 7/8 also offer WM_TOUCH which provides access to raw touch events but doesn't provide any builtin gesture recognition. It would however allow us to support simultaneous rotate and zoom/pinch and we could also support multi-finger swipe etc by using the same generic touch implementation used by Android. Windows 8 offers an improved WM_POINTER API which has additional functionality but it's Windows 8 only. Maybe at some point it might make sense to either switch to WM_TOUCH or if it's worth the additional effort use WM_POINTER on Win8 devices and WM_TOUCH on Win7 devices but that's out of the question right now.
