### PR TITLE
[Fix] Change from DarwinCFStringRefToString to DarwinCFStringRefToUTF8String

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.cpp
@@ -340,7 +340,7 @@ void CCoreAudioHardware::GetOutputDeviceName(std::string& name)
     if (ret != noErr)
       return;
 
-    DarwinCFStringRefToString(theDeviceName, name);
+    DarwinCFStringRefToUTF8String(theDeviceName, name);
 
     CFRelease(theDeviceName);
   }

--- a/xbmc/network/osx/ZeroconfBrowserOSX.cpp
+++ b/xbmc/network/osx/ZeroconfBrowserOSX.cpp
@@ -59,7 +59,7 @@ namespace
           for(idx = 0; idx < numValues; idx++)
           {
             std::string key;
-            if (DarwinCFStringRefToString(keys[idx], key))
+            if (DarwinCFStringRefToUTF8String(keys[idx], key))
             {
               recordMap.insert(
                 std::make_pair(
@@ -148,9 +148,9 @@ void CZeroconfBrowserOSX::BrowserCallback(CFNetServiceBrowserRef browser, CFOpti
 
     //store the service
     std::string name, type, domain;
-    if (!DarwinCFStringRefToString(CFNetServiceGetName(service), name) ||
-        !DarwinCFStringRefToString(CFNetServiceGetType(service), type) ||
-        !DarwinCFStringRefToString(CFNetServiceGetDomain(service), domain))
+    if (!DarwinCFStringRefToUTF8String(CFNetServiceGetName(service), name) ||
+        !DarwinCFStringRefToUTF8String(CFNetServiceGetType(service), type) ||
+        !DarwinCFStringRefToUTF8String(CFNetServiceGetDomain(service), domain))
     {
       CLog::Log(LOGWARNING, "CZeroconfBrowserOSX::BrowserCallback failed to convert service strings.");
       return;

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -42,6 +42,7 @@ extern "C"
   int         DarwinBatteryLevel(void);
   void        DarwinSetScheduling(int message);
   bool        DarwinCFStringRefToString(CFStringRef source, std::string& destination);
+  bool        DarwinCFStringRefToUTF8String(CFStringRef source, std::string& destination);
 #ifdef __cplusplus
 }
 #endif

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -393,19 +393,19 @@ void DarwinSetScheduling(int message)
   result = pthread_setschedparam(this_pthread_self, policy, &param );
 }
 
-bool DarwinCFStringRefToString(CFStringRef source, std::string &destination)
+bool DarwinCFStringRefToStringWithEncoding(CFStringRef source, std::string &destination, CFStringEncoding encoding)
 {
-  const char *cstr = CFStringGetCStringPtr(source, CFStringGetSystemEncoding());
+  const char *cstr = CFStringGetCStringPtr(source, encoding);
   if (!cstr)
   {
     CFIndex strLen = CFStringGetMaximumSizeForEncoding(CFStringGetLength(source) + 1,
-                                                       CFStringGetSystemEncoding());
+                                                       encoding);
     char *allocStr = (char*)malloc(strLen);
 
     if(!allocStr)
       return false;
 
-    if(!CFStringGetCString(source, allocStr, strLen, CFStringGetSystemEncoding()))
+    if(!CFStringGetCString(source, allocStr, strLen, encoding))
     {
       free((void*)allocStr);
       return false;
@@ -419,6 +419,16 @@ bool DarwinCFStringRefToString(CFStringRef source, std::string &destination)
 
   destination = cstr;
   return true;
+}
+
+bool DarwinCFStringRefToString(CFStringRef source, std::string &destination)
+{
+  return DarwinCFStringRefToStringWithEncoding(source, destination, CFStringGetSystemEncoding());
+}
+
+bool DarwinCFStringRefToUTF8String(CFStringRef source, std::string &destination)
+{
+  return DarwinCFStringRefToStringWithEncoding(source, destination, kCFStringEncodingUTF8);
 }
 
 #endif

--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
@@ -250,7 +250,7 @@ void CPeripheralBusUSB::DeviceAttachCallback(CPeripheralBusUSB* refCon, io_itera
             if (deviceFilePathAsCFString)
             {
               // Convert the path from a CFString to a std::string
-              if (!DarwinCFStringRefToString(deviceFilePathAsCFString, ttlDeviceFilePath))
+              if (!DarwinCFStringRefToUTF8String(deviceFilePathAsCFString, ttlDeviceFilePath))
                 CLog::Log(LOGWARNING, "CPeripheralBusUSB::DeviceAttachCallback failed to convert CFStringRef");
               CFRelease(deviceFilePathAsCFString);
             }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1361,7 +1361,7 @@ bool CWinSystemOSX::IsObscured(void)
         if (!obscureLogged)
         {
           std::string appName;
-          if (DarwinCFStringRefToString(ownerName, appName))
+          if (DarwinCFStringRefToUTF8String(ownerName, appName))
             CLog::Log(LOGDEBUG, "WinSystemOSX: Fullscreen window %s obscures XBMC!", appName.c_str());
           obscureLogged = true;
         }


### PR DESCRIPTION
the zeroconf service name was unicode CFString, but we convert them into system encoding instead of utf8, which cause crash on osx for afp.
we should always convert unicode CFString to utf8 string since xbmc internal using utf8.
