### PR TITLE
[mouse] reworks the order of the mouse event handling (issue #2315)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3175,6 +3175,16 @@ bool CApplication::ProcessMouse()
   CKey key(mousecommand | KEY_MOUSE, (unsigned int) 0);
   CAction mouseaction = CButtonTranslator::GetInstance().GetAction(iWin, key);
 
+  // Deactivate mouse if non-mouse action
+  if (!mouseaction.IsMouse())
+    g_Mouse.SetActive(false);
+
+  // Consume ACTION_NOOP.
+  // Some views or dialogs gets closed after any ACTION and
+  // a sensitive mouse might cause problems.
+  if (mouseaction.GetID() == ACTION_NOOP)
+    return false;
+
   // If we couldn't find an action return false to indicate we have not
   // handled this mouse action
   if (!mouseaction.GetID())


### PR DESCRIPTION
This pull request allows higher customizability of mouse keymaps. Meaning that mouse events can be mapped to any actions without incorrectly activating the mouse cursor on screen. Allows users of certain mice or mouse+keyboard remotes to take advantage of every button they got.

Gets the CAction from a mouse event and determines it's type before treating it as a mouse action. These events aren't treated incorrectly as mouse events. Mouse cursor gets activated by proper mouse actions, not straight after getting an event from any mouse device.

User ends up getting fancy results for example if:
- mousemove = NOOP
- wheeldown = wheeldown

The mouse cursor doesn't get activated after a mouse movement but after a wheeldown event it stays active and can be moved around for a short time. That's the user's responsibility to map sane actions.

Implements a feature request from forums: http://forum.xbmc.org/showthread.php?tid=157744
