### PR TITLE
[Fix] work with non-ascii filter word which can not be seperated by space

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -523,6 +523,36 @@ CStdString StringUtils::SizeToString(int64_t size)
   return strLabel;
 }
 
+// return -1 if not, else return the utf8 char length.
+int IsUTF8Letter(const unsigned char *str)
+{
+  // reference:
+  // unicode -> utf8 table: http://www.utf8-chartable.de/
+  // latin characters in unicode: http://en.wikipedia.org/wiki/Latin_characters_in_Unicode
+  unsigned char ch = str[0];
+  if (!ch)
+    return -1;
+  if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z'))
+    return 1;
+  if (!(ch & 0x80))
+    return -1;
+  unsigned char ch2 = str[1];
+  if (!ch2)
+    return -1;
+  // check latin 1 letter table: http://en.wikipedia.org/wiki/C1_Controls_and_Latin-1_Supplement
+  if (ch == 0xC3 && ch2 >= 0x80 && ch2 <= 0xBF && ch2 != 0x97 && ch2 != 0xB7)
+    return 2;
+  // check latin extended A table: http://en.wikipedia.org/wiki/Latin_Extended-A
+  if (ch >= 0xC4 && ch <= 0xC7 && ch2 >= 0x80 && ch2 <= 0xBF)
+    return 2;
+  // check latin extended B table: http://en.wikipedia.org/wiki/Latin_Extended-B
+  // and International Phonetic Alphabet: http://en.wikipedia.org/wiki/IPA_Extensions_(Unicode_block)
+  if (((ch == 0xC8 || ch == 0xC9) && ch2 >= 0x80 && ch2 <= 0xBF)
+      || (ch == 0xCA && ch2 >= 0x80 && ch2 <= 0xAF))
+    return 2;
+  return -1;
+}
+
 size_t StringUtils::FindWords(const char *str, const char *wordLowerCase)
 {
   // NOTE: This assumes word is lowercase!
@@ -545,8 +575,18 @@ size_t StringUtils::FindWords(const char *str, const char *wordLowerCase)
     if (same && *w == 0)  // only the same if word has been exhausted
       return (const char *)s - str;
 
-    // otherwise, find a space and skip to the end of the whitespace
-    while (*s && *s != ' ') s++;
+    // otherwise, skip current word (composed by latin letters) or number
+    int l;
+    if (*s >= '0' && *s <= '9')
+    {
+      ++s;
+      while (*s >= '0' && *s <= '9') ++s;
+    }
+    else if ((l = IsUTF8Letter(s)) > 0)
+    {
+      s += l;
+      while ((l = IsUTF8Letter(s)) > 0) s += l;
+    }
     while (*s && *s == ' ') s++;
 
     // and repeat until we're done

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -396,6 +396,35 @@ TEST(TestStringUtils, FindWords)
   ref = 5;
   var = StringUtils::FindWords("test string", "string");
   EXPECT_EQ(ref, var);
+  var = StringUtils::FindWords("12345string", "string");
+  EXPECT_EQ(ref, var);
+  var = StringUtils::FindWords("apple2012", "2012");
+  EXPECT_EQ(ref, var);
+  ref = -1;
+  var = StringUtils::FindWords("12345string", "ring");
+  EXPECT_EQ(ref, var);
+  var = StringUtils::FindWords("12345string", "345");
+  EXPECT_EQ(ref, var);
+  var = StringUtils::FindWords("apple2012", "e2012");
+  EXPECT_EQ(ref, var);
+  var = StringUtils::FindWords("apple2012", "12");
+  EXPECT_EQ(ref, var);
+}
+
+TEST(TestStringUtils, FindWords_NonAscii)
+{
+  int ref, var;
+
+  ref = 6;
+  var = StringUtils::FindWords("我的视频", "视频");
+  EXPECT_EQ(ref, var);
+  var = StringUtils::FindWords("我的视频", "视");
+  EXPECT_EQ(ref, var);
+  var = StringUtils::FindWords("Apple ple", "ple");
+  EXPECT_EQ(ref, var);
+  ref = 7;
+  var = StringUtils::FindWords("Äpfel.pfel", "pfel");
+  EXPECT_EQ(ref, var);
 }
 
 TEST(TestStringUtils, FindEndBracket)


### PR DESCRIPTION
The file item filter, filter items by StringUtils::FindWords method.
but the StringUtils::FindWords method assume file labels is words separated by space, that's not true for non-ascii labels.
This pr will do a strstr like search for non-ascii filter word, and keep old behavior for ascii filter word.
