### PR TITLE
[rbp] Set mediatime on GPU after a seek.

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3296,6 +3296,9 @@ void COMXPlayer::FlushBuffers(bool queued, double pts, bool accurate)
     CSingleLock lock(m_StateSection);
     m_State = m_StateInput;
   }
+  // let clock know the new time so progress bar updates immediately
+  if(startpts != DVD_NOPTS_VALUE)
+    m_av_clock.OMXMediaTime(startpts);
 }
 
 // since we call ffmpeg functions to decode, this is being called in the same thread as ::Process() is

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -116,6 +116,7 @@ public:
   bool OMXReset(bool lock = true);
   double OMXWallTime(bool lock = true);
   double OMXMediaTime(bool fixPreroll = true, bool lock = true);
+  bool OMXMediaTime(double pts, bool fixPreroll = true, bool lock = true);
   bool OMXPause(bool lock = true);
   bool OMXResume(bool lock = true);
   bool OMXUpdateClock(double pts, bool lock = true);


### PR DESCRIPTION
Currently after a seek, the mediatime doesn't update until an audio and video packet have been fetched from demuxer, and been decoded. For HD content this can take a second or two.
This has a couple of undesirable effects:
The seek time that pops up after a seek initially shows the before seek time, and the file progress bar is laggy.
If you seek a second time, before the time has updated, it will use the before seek time, and the second seek has no effect.
This limits a sequence of seeks to a maximum of about 1 every second or two.

The fix udpates the GPU mediatime immediately after the seek, so the mediatime is correct immediately which fixes the undesirable behaviour.
