### PR TITLE
fixed memory leak on minimized due to missing deletion of unused textures (fixes #14245)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2413,8 +2413,6 @@ void CApplication::Render()
     g_graphicsContext.Flip(dirtyRegions);
   CTimeUtils::UpdateFrameTime(flip);
 
-  g_TextureManager.FreeUnusedTextures();
-
   g_renderManager.UpdateResolution();
   g_renderManager.ManageCaptures();
 
@@ -5181,6 +5179,8 @@ void CApplication::ProcessSlow()
 
   if (!IsPlayingVideo())
     g_largeTextureManager.CleanupUnusedImages();
+
+  g_TextureManager.FreeUnusedTextures();
 
 #ifdef HAS_DVD_DRIVE
   // checks whats in the DVD drive and tries to autostart the content (xbox games, dvd, cdda, avi files...)


### PR DESCRIPTION
I made this a pr since it looks like m_AppActive is also used for SDL and android.

Using multiimage controls lead to heavy memory leaking when being minimized because we don't free the unused textures anymore. I just removed the hole block because on windows doing a FreeUnusedTextures() inside that block costs more cpu power than process the whole Render path (7% to 5%).
Given that we just want to leave early to save resources this makes no sense at least on win. What I need to know is if this has counter effects on the other platforms using m_AppActive.
