### PR TITLE
Add missing thread names, improve existing thread names

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -75,7 +75,7 @@ using namespace PVR;
 using namespace std;
 using namespace MUSIC_INFO;
 
-CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay) : CThread("CDelayedMessage")
+CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay) : CThread("DelayedMessage")
 {
   m_msg.dwMessage  = msg.dwMessage;
   m_msg.dwParam1   = msg.dwParam1;

--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -134,7 +134,7 @@ void CBackgroundInfoLoader::Load(CFileItemList& items)
   m_nActiveThreads = nThreads;
   for (int i=0; i < nThreads; i++)
   {
-    CThread *pThread = new CThread(this, "Background Loader");
+    CThread *pThread = new CThread(this, "BackgroundLoader");
     pThread->Create();
 #ifndef _LINUX
     pThread->SetPriority(THREAD_PRIORITY_BELOW_NORMAL);

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -43,7 +43,7 @@ namespace ADDON
 CCriticalSection CAddonStatusHandler::m_critSection;
 
 CAddonStatusHandler::CAddonStatusHandler(const CStdString &addonID, ADDON_STATUS status, CStdString message, bool sameThread)
-  : CThread("CAddonStatusHandler:" + addonID)
+  : CThread("AddonStatus " + addonID)
 {
   if (!CAddonMgr::Get().GetAddon(addonID, m_addon))
     return;

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
@@ -614,7 +614,7 @@ void CPulseAEStream::RegisterSlave(IAEStream *stream)
   m_slave = stream;
 }
 
-CPulseAEStream::CLinearFader::CLinearFader(IAEStream *stream) : CThread("AE Stream"), m_stream(stream)
+CPulseAEStream::CLinearFader::CLinearFader(IAEStream *stream) : CThread("AEStream"), m_stream(stream)
 {
   m_from = 0;
   m_target = 0;

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -513,7 +513,7 @@ bool CSoftAE::Initialize()
   CSingleLock lock(m_threadLock);
   InternalOpenSink();
   m_running = true;
-  m_thread  = new CThread(this, "CSoftAE");
+  m_thread  = new CThread(this, "SoftAE");
   m_thread->Create();
   m_thread->SetPriority(THREAD_PRIORITY_ABOVE_NORMAL);
   return true;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -70,7 +70,7 @@ static jint GetStaticIntField(JNIEnv *jenv, std::string class_name, std::string 
 CAEDeviceInfo CAESinkAUDIOTRACK::m_info;
 ////////////////////////////////////////////////////////////////////////////////////////////
 CAESinkAUDIOTRACK::CAESinkAUDIOTRACK()
-  : CThread("audiotrack")
+  : CThread("AudioTrack")
 {
   m_sinkbuffer = NULL;
   m_alignedS16LE = NULL;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
@@ -28,7 +28,7 @@
 #include "utils/log.h"
 
 CAESinkNULL::CAESinkNULL()
-  : CThread("nullsink"),
+  : CThread("AESinkNull"),
     m_draining(false),
     m_sink_frameSize(0),
     m_sinkbuffer_size(0),

--- a/xbmc/cores/DummyVideoPlayer.cpp
+++ b/xbmc/cores/DummyVideoPlayer.cpp
@@ -32,7 +32,7 @@
 
 CDummyVideoPlayer::CDummyVideoPlayer(IPlayerCallback& callback)
     : IPlayer(callback),
-      CThread("CDummyVideoPlayer")
+      CThread("DummyVideoPlayer")
 {
   m_paused = false;
   m_clock = 0;

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -68,7 +68,7 @@ extern HWND g_hWnd;
 
 CExternalPlayer::CExternalPlayer(IPlayerCallback& callback)
     : IPlayer(callback),
-      CThread("CExternalPlayer")
+      CThread("ExternalPlayer")
 {
   m_bAbortRequest = false;
   m_bIsPlaying = false;

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -302,7 +302,7 @@ static const char* AudioCodecName(int aformat)
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 CAMLSubTitleThread::CAMLSubTitleThread(DllLibAmplayer *dll) :
-  CThread("CAMLSubTitleThread"),
+  CThread("AMLSubTitle"),
   m_dll(dll),
   m_subtitle_codec(-1)
 {
@@ -500,7 +500,7 @@ void CAMLSubTitleThread::Process(void)
 ////////////////////////////////////////////////////////////////////////////////////////////
 CAMLPlayer::CAMLPlayer(IPlayerCallback &callback)
   : IPlayer(callback),
-  CThread                 ("CAMLPlayer" ),
+  CThread                 ("AMLPlayer" ),
   m_cpu                   (0            ),
   m_speed                 (0            ),
   m_paused                (false        ),
@@ -1262,7 +1262,7 @@ void CAMLPlayer::OnStartup()
   //m_CurrentAudio.Clear();
   //m_CurrentSubtitle.Clear();
 
-  //CThread::SetName("CAMLPlayer");
+  //CThread::SetName("AMLPlayer");
 }
 
 void CAMLPlayer::OnExit()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
@@ -325,7 +325,7 @@ CPictureBuffer::~CPictureBuffer()
 #pragma mark -
 #endif
 CMPCOutputThread::CMPCOutputThread(void *device, DllLibCrystalHD *dll, bool has_bcm70015) :
-  CThread("CMPCOutputThread"),
+  CThread("MPCOutput"),
   m_dll(dll),
   m_device(device),
   m_has_bcm70015(has_bcm70015),

--- a/xbmc/cores/dvdplayer/DVDMessageTracker.cpp
+++ b/xbmc/cores/dvdplayer/DVDMessageTracker.cpp
@@ -29,7 +29,7 @@
 
 CDVDMessageTracker g_dvdMessageTracker;
 
-CDVDMessageTracker::CDVDMessageTracker() : CThread()
+CDVDMessageTracker::CDVDMessageTracker() : CThread("DVDMsgTracker")
 {
   m_bInitialized = false;
   InitializeCriticalSection(&m_critSection);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -403,7 +403,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
 
 CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
     : IPlayer(callback),
-      CThread("CDVDPlayer"),
+      CThread("DVDPlayer"),
       m_CurrentAudio(STREAM_AUDIO, DVDPLAYER_AUDIO),
       m_CurrentVideo(STREAM_VIDEO, DVDPLAYER_VIDEO),
       m_CurrentSubtitle(STREAM_SUBTITLE, DVDPLAYER_SUBTITLE),

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -99,7 +99,7 @@ public:
 
 
 CDVDPlayerAudio::CDVDPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent)
-: CThread("CDVDPlayerAudio")
+: CThread("DVDPlayerAudio")
 , m_messageQueue("audio")
 , m_messageParent(parent)
 , m_dvdAudio((bool&)m_bStop)

--- a/xbmc/cores/dvdplayer/DVDPlayerTeletext.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerTeletext.cpp
@@ -92,7 +92,7 @@ signed int CDVDTeletextTools::deh24(unsigned char *p)
 
 
 CDVDTeletextData::CDVDTeletextData()
-: CThread("CDVDTeletextData")
+: CThread("DVDTeletextData")
 , m_messageQueue("teletext")
 {
   m_speed = DVD_PLAYSPEED_NORMAL;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -123,7 +123,7 @@ public:
 CDVDPlayerVideo::CDVDPlayerVideo( CDVDClock* pClock
                                 , CDVDOverlayContainer* pOverlayContainer
                                 , CDVDMessageQueue& parent)
-: CThread("CDVDPlayerVideo")
+: CThread("DVDPlayerVideo")
 , m_messageQueue("video")
 , m_messageParent(parent)
 {

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -405,7 +405,7 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
 // ****************************************************************
 COMXPlayer::COMXPlayer(IPlayerCallback &callback) 
     : IPlayer(callback),
-      CThread("COMXPlayer"),
+      CThread("OMXPlayer"),
       m_CurrentAudio(STREAM_AUDIO, DVDPLAYER_AUDIO),
       m_CurrentVideo(STREAM_VIDEO, DVDPLAYER_VIDEO),
       m_CurrentSubtitle(STREAM_SUBTITLE, DVDPLAYER_SUBTITLE),

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -63,7 +63,7 @@ public:
 };
 
 OMXPlayerAudio::OMXPlayerAudio(OMXClock *av_clock, CDVDMessageQueue& parent)
-: CThread("COMXPlayerAudio")
+: CThread("OMXPlayerAudio")
 , m_messageQueue("audio")
 , m_messageParent(parent)
 {

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -68,7 +68,7 @@ public:
 OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
                                CDVDOverlayContainer* pOverlayContainer,
                                CDVDMessageQueue& parent)
-: CThread("COMXPlayerVideo")
+: CThread("OMXPlayerVideo")
 , m_messageQueue("video")
 , m_codecname("")
 , m_messageParent(parent)

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -28,7 +28,7 @@
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 
-CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const CStdString& strHeader, const CStdString& strMsg) : CThread("CGUIDialogCache")
+CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const CStdString& strHeader, const CStdString& strMsg) : CThread("GUIDialogCache")
 {
   m_strHeader = strHeader;
   m_strLinePrev = strMsg;

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -43,7 +43,7 @@ using namespace PVR;
 typedef std::map<int, CEpg*>::iterator EPGITR;
 
 CEpgContainer::CEpgContainer(void) :
-    CThread("EPG updater")
+    CThread("EPGUpdater")
 {
   m_progressHandle = NULL;
   m_bStop = true;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -78,7 +78,7 @@ private:
 };
 
 
-CFileCache::CFileCache() : CThread("CFileCache")
+CFileCache::CFileCache() : CThread("FileCache")
 {
    m_bDeleteCache = true;
    m_nSeekResult = 0;
@@ -94,7 +94,7 @@ CFileCache::CFileCache() : CThread("CFileCache")
    m_cacheFull = false;
 }
 
-CFileCache::CFileCache(CCacheStrategy *pCache, bool bDeleteCache) : CThread("CFileCache")
+CFileCache::CFileCache(CCacheStrategy *pCache, bool bDeleteCache) : CThread("FileCacheStrategy")
 {
   m_pCache = pCache;
   m_bDeleteCache = bDeleteCache;

--- a/xbmc/filesystem/HTSPDirectory.cpp
+++ b/xbmc/filesystem/HTSPDirectory.cpp
@@ -75,7 +75,7 @@ static SSessions         g_sessions;
 static CCriticalSection  g_section;
 
 
-CHTSPDirectorySession::CHTSPDirectorySession() : CThread("CHTSPDirectorySession")
+CHTSPDirectorySession::CHTSPDirectorySession() : CThread("HTSPDirectorySession")
 {
 }
 

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -358,7 +358,7 @@ void CMythSession::SetSeasonAndEpisode(const cmyth_proginfo_t &program, int *sea
   return;
 }
 
-CMythSession::CMythSession(const CURL& url) : CThread("CMythSession")
+CMythSession::CMythSession(const CURL& url) : CThread("MythSession")
 {
   m_control   = NULL;
   m_event     = NULL;

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -42,7 +42,7 @@ using namespace std;
 #define SEEKTIMOUT 30000
 
 #ifdef HAS_FILESYSTEM_RAR
-CRarFileExtractThread::CRarFileExtractThread() : CThread("CFileRarExtractThread"), hRunning(true), hQuit(true)
+CRarFileExtractThread::CRarFileExtractThread() : CThread("RarFileExtract"), hRunning(true), hQuit(true)
 {
   m_pArc = NULL;
   m_pCmd = NULL;

--- a/xbmc/filesystem/SAPDirectory.cpp
+++ b/xbmc/filesystem/SAPDirectory.cpp
@@ -275,7 +275,7 @@ namespace SDP
 using namespace SDP;
 
 
-CSAPSessions::CSAPSessions() : CThread("CSAPSessions")
+CSAPSessions::CSAPSessions() : CThread("SAPSessions")
 {
   m_socket = INVALID_SOCKET;
 }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -42,7 +42,7 @@ using namespace XFILE;
 using namespace MUSIC_INFO;
 
 CShoutcastFile::CShoutcastFile() :
-  IFile(), CThread("Shoutcast file")
+  IFile(), CThread("ShoutcastFile")
 {
   m_discarded = 0;
   m_currint = 0;

--- a/xbmc/input/windows/IRServerSuite.cpp
+++ b/xbmc/input/windows/IRServerSuite.cpp
@@ -31,7 +31,7 @@
 
 CRemoteControl g_RemoteControl;
 
-CRemoteControl::CRemoteControl() : CThread("CRemoteControl")
+CRemoteControl::CRemoteControl() : CThread("RemoteControl")
 {
   m_socket = INVALID_SOCKET;
   m_bInitialized = false;

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -71,7 +71,7 @@ extern "C"
   char* dll_getenv(const char* szKey);
 }
 
-XBPyThread::XBPyThread(XBPython *pExecuter, int id) : CThread("XBPyThread")
+XBPyThread::XBPyThread(XBPython *pExecuter, int id) : CThread("XBPython")
 {
   CLog::Log(LOGDEBUG,"new python thread created. id=%d", id);
   m_pExecuter   = pExecuter;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -58,7 +58,7 @@ using namespace MUSIC_INFO;
 using namespace XFILE;
 using namespace MUSIC_GRABBER;
 
-CMusicInfoScanner::CMusicInfoScanner() : CThread("CMusicInfoScanner")
+CMusicInfoScanner::CMusicInfoScanner() : CThread("MusicInfoScanner")
 {
   m_bRunning = false;
   m_showDialog = false;
@@ -104,7 +104,7 @@ void CMusicInfoScanner::Process()
 
       // Create the thread to count all files to be scanned
       SetPriority( GetMinPriority() );
-      CThread fileCountReader(this, "CMusicInfoScanner");
+      CThread fileCountReader(this, "MusicFileCounter");
       if (m_handle)
         fileCountReader.Create();
 

--- a/xbmc/music/infoscanner/MusicInfoScraper.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScraper.cpp
@@ -26,7 +26,7 @@ using namespace MUSIC_GRABBER;
 using namespace ADDON;
 using namespace std;
 
-CMusicInfoScraper::CMusicInfoScraper(const ADDON::ScraperPtr &scraper) : CThread("CMusicInfoScraper")
+CMusicInfoScraper::CMusicInfoScraper(const ADDON::ScraperPtr &scraper) : CThread("MusicInfoScraper")
 {
   m_bSucceeded=false;
   m_bCanceled=false;

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -48,7 +48,7 @@ using namespace std;
 /* CEventServer                                                         */
 /************************************************************************/
 CEventServer* CEventServer::m_pInstance = NULL;
-CEventServer::CEventServer() : CThread("CEventServer")
+CEventServer::CEventServer() : CThread("EventServer")
 {
   m_pSocket       = NULL;
   m_pPacketBuffer = NULL;

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -85,7 +85,7 @@ void CTCPServer::StopServer(bool bWait)
   }
 }
 
-CTCPServer::CTCPServer(int port, bool nonlocal) : CThread("CTCPServer")
+CTCPServer::CTCPServer(int port, bool nonlocal) : CThread("TCPServer")
 {
   m_port = port;
   m_nonlocal = nonlocal;

--- a/xbmc/network/UdpClient.cpp
+++ b/xbmc/network/UdpClient.cpp
@@ -34,7 +34,7 @@
 
 #define UDPCLIENT_DEBUG_LEVEL LOGDEBUG
 
-CUdpClient::CUdpClient(void) : CThread("CUdpClient")
+CUdpClient::CUdpClient(void) : CThread("UDPClient")
 {}
 
 CUdpClient::~CUdpClient(void)

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -30,7 +30,7 @@ using namespace PERIPHERALS;
 #define PERIPHERAL_DEFAULT_RESCAN_INTERVAL 1000
 
 CPeripheralBus::CPeripheralBus(CPeripherals *manager, PeripheralBusType type) :
-    CThread("XBMC Peripherals"),
+    CThread("PeripheralBus"),
     m_iRescanTime(PERIPHERAL_DEFAULT_RESCAN_INTERVAL),
     m_bInitialised(false),
     m_bIsStarted(false),

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -82,7 +82,7 @@ class DllLibCEC : public DllDynamic, DllLibCECInterface
 
 CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralScanResult& scanResult) :
   CPeripheralHID(scanResult),
-  CThread("CEC Adapter"),
+  CThread("CECAdapter"),
   m_dll(NULL),
   m_cecAdapter(NULL)
 {
@@ -1402,7 +1402,7 @@ bool CPeripheralCecAdapter::WriteLogicalAddresses(const cec_logical_addresses& a
 }
 
 CPeripheralCecAdapterUpdateThread::CPeripheralCecAdapterUpdateThread(CPeripheralCecAdapter *adapter, libcec_configuration *configuration) :
-    CThread("CEC Adapter Update Thread"),
+    CThread("CECAdapterUpdate"),
     m_adapter(adapter),
     m_configuration(*configuration),
     m_bNextConfigurationScheduled(false),

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -72,7 +72,7 @@ using namespace XFILE;
 
 static float zoomamount[10] = { 1.0f, 1.2f, 1.5f, 2.0f, 2.8f, 4.0f, 6.0f, 9.0f, 13.5f, 20.0f };
 
-CBackgroundPicLoader::CBackgroundPicLoader() : CThread("CBackgroundPicLoader")
+CBackgroundPicLoader::CBackgroundPicLoader() : CThread("BgPicLoader")
 {
   m_pCallback = NULL;
   m_isLoading = false;

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -39,7 +39,7 @@ using namespace EPG;
 using namespace std;
 
 CPVRGUIInfo::CPVRGUIInfo(void) :
-    CThread("PVR GUI info updater"),
+    CThread("PVRGUIInfo"),
     m_playingEpgTag(NULL)
 {
   ResetProperties();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -62,7 +62,7 @@ using namespace PVR;
 using namespace EPG;
 
 CPVRManager::CPVRManager(void) :
-    CThread("PVR manager"),
+    CThread("PVRManager"),
     m_channelGroups(NULL),
     m_recordings(NULL),
     m_timers(NULL),

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -48,7 +48,7 @@ using namespace PVR;
 using namespace EPG;
 
 CPVRClients::CPVRClients(void) :
-    CThread("PVR add-on updater"),
+    CThread("PVRClient"),
     m_bChannelScanRunning(false),
     m_bIsSwitchingChannels(false),
     m_bIsValidChannelSettings(false),

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -50,7 +50,7 @@ CGUIWindowPVRChannels::CGUIWindowPVRChannels(CGUIWindowPVR *parent, bool bRadio)
                       bRadio ? PVR_WINDOW_CHANNELS_RADIO : PVR_WINDOW_CHANNELS_TV,
                       bRadio ? CONTROL_BTNCHANNELS_RADIO : CONTROL_BTNCHANNELS_TV,
                       bRadio ? CONTROL_LIST_CHANNELS_RADIO: CONTROL_LIST_CHANNELS_TV),
-  CThread("PVR Channel Window")
+  CThread("PVRChannelWin")
 {
   m_bRadio              = bRadio;
   m_bShowHiddenChannels = false;

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -63,7 +63,7 @@ CDetectDVDMedia* CDetectDVDMedia::m_pInstance = NULL;
 CStdString CDetectDVDMedia::m_diskLabel = "";
 CStdString CDetectDVDMedia::m_diskPath = "";
 
-CDetectDVDMedia::CDetectDVDMedia() : CThread("CDetectDVDMedia")
+CDetectDVDMedia::CDetectDVDMedia() : CThread("DetectDVDMedia")
 {
   m_bAutorun = false;
   m_bStop = false;

--- a/xbmc/threads/Timer.cpp
+++ b/xbmc/threads/Timer.cpp
@@ -24,7 +24,7 @@
 #include "SystemClock.h"
 
 CTimer::CTimer(ITimerCallback *callback)
-  : CThread("CTimer"),
+  : CThread("Timer"),
     m_callback(callback),
     m_timeout(0),
     m_interval(false),

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -72,7 +72,7 @@ class thread
 //  inline thread(const thread& other) { }
 public:
   inline explicit thread(IRunnable& runnable) : 
-    f(&runnable), cthread(new CThread(f, "dumb thread"))
+    f(&runnable), cthread(new CThread(f, "DumbThread"))
   {
     cthread->Create();
   }

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -27,7 +27,7 @@
 
 using namespace std;
 
-CAlarmClock::CAlarmClock() : CThread("CAlarmClock"), m_bIsRunning(false)
+CAlarmClock::CAlarmClock() : CThread("AlarmClock"), m_bIsRunning(false)
 {
 }
 

--- a/xbmc/utils/AsyncFileCopy.cpp
+++ b/xbmc/utils/AsyncFileCopy.cpp
@@ -26,7 +26,7 @@
 #include "utils/TimeUtils.h"
 #include "URL.h"
 
-CAsyncFileCopy::CAsyncFileCopy() : CThread("CAsyncFileCopy")
+CAsyncFileCopy::CAsyncFileCopy() : CThread("AsyncFileCopy")
 {
   m_cancelled = false;
   m_succeeded = false;

--- a/xbmc/utils/DownloadQueue.cpp
+++ b/xbmc/utils/DownloadQueue.cpp
@@ -31,7 +31,7 @@ using namespace XFILE;
 
 WORD CDownloadQueue::m_wNextQueueId = 0;
 
-CDownloadQueue::CDownloadQueue(void) : CThread("CDownloadQueue")
+CDownloadQueue::CDownloadQueue(void) : CThread("DownloadQueue")
 {
   m_bStop = false;
   m_wQueueId = m_wNextQueueId++;

--- a/xbmc/utils/EdenVideoArtUpdater.cpp
+++ b/xbmc/utils/EdenVideoArtUpdater.cpp
@@ -45,7 +45,7 @@ using namespace std;
 using namespace VIDEO;
 using namespace XFILE;
 
-CEdenVideoArtUpdater::CEdenVideoArtUpdater() : CThread("EdenVideoArtUpdater")
+CEdenVideoArtUpdater::CEdenVideoArtUpdater() : CThread("VideoArtUpdater")
 {
   m_textureDB.Open();
 }

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -35,7 +35,7 @@ bool CJob::ShouldCancel(unsigned int progress, unsigned int total) const
   return false;
 }
 
-CJobWorker::CJobWorker(CJobManager *manager) : CThread("Jobworker")
+CJobWorker::CJobWorker(CJobManager *manager) : CThread("JobWorker")
 {
   m_jobManager = manager;
   Create(true); // start work immediately, and kill ourselves when we're done

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -48,7 +48,7 @@ using namespace XFILE;
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-CRssReader::CRssReader() : CThread("CRssReader")
+CRssReader::CRssReader() : CThread("RSSReader")
 {
   m_pObserver = NULL;
   m_spacesBetweenFeeds = 0;

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -30,7 +30,7 @@
 
 using namespace XFILE;
 
-CSplash::CSplash(const CStdString& imageName) : CThread("CSplash")
+CSplash::CSplash(const CStdString& imageName) : CThread("Splash")
 {
   m_ImageName = imageName;
   fade = 0.5;

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -48,7 +48,7 @@ using namespace std;
 CTuxBoxUtil g_tuxbox;
 CTuxBoxService g_tuxboxService;
 
-CTuxBoxService::CTuxBoxService() : CThread("CTuxBoxService")
+CTuxBoxService::CTuxBoxService() : CThread("TuxBoxService")
 {
 }
 CTuxBoxService::~CTuxBoxService()

--- a/xbmc/utils/test/TestBitstreamStats.cpp
+++ b/xbmc/utils/test/TestBitstreamStats.cpp
@@ -30,7 +30,7 @@ class CTestBitstreamStatsThread : public CThread
 {
 public:
   CTestBitstreamStatsThread() :
-    CThread("CTestBitstreamStatsThread"){}
+    CThread("TestBitstreamStats"){}
   
 };
 

--- a/xbmc/utils/test/TestDownloadQueue.cpp
+++ b/xbmc/utils/test/TestDownloadQueue.cpp
@@ -29,7 +29,7 @@ class CTestDownloadQueueThread : public CThread
 {
 public:
   CTestDownloadQueueThread() :
-    CThread("CTestDownloadQueueThread"){}
+    CThread("TestDownloadQueue"){}
 };
 
 /* Need to set some settings for network connectivity when an

--- a/xbmc/utils/test/TestDownloadQueueManager.cpp
+++ b/xbmc/utils/test/TestDownloadQueueManager.cpp
@@ -29,7 +29,7 @@ class CTestDownloadQueueManagerThread : public CThread
 {
 public:
   CTestDownloadQueueManagerThread() :
-    CThread("CTestDownloadQueueManagerThread"){}
+    CThread("TestDownloadQueueManager"){}
 };
 
 /* Need to set some settings for network connectivity when an

--- a/xbmc/utils/test/TestStopwatch.cpp
+++ b/xbmc/utils/test/TestStopwatch.cpp
@@ -27,7 +27,7 @@ class CTestStopWatchThread : public CThread
 {
 public:
   CTestStopWatchThread() :
-    CThread("CTestStopWatchThread"){}
+    CThread("TestStopWatch"){}
 };
 
 TEST(TestStopWatch, Start)

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -38,7 +38,7 @@ using namespace VIDEO;
 #endif
 
 CVideoInfoDownloader::CVideoInfoDownloader(const ADDON::ScraperPtr &scraper) :
-  CThread("CVideoInfoDownloader"), m_state(DO_NOTHING), m_found(0), m_info(scraper)
+  CThread("VideoInfoDownloader"), m_state(DO_NOTHING), m_found(0), m_info(scraper)
 {
   m_http = new XFILE::CCurlFile;
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -57,7 +57,7 @@ using namespace ADDON;
 namespace VIDEO
 {
 
-  CVideoInfoScanner::CVideoInfoScanner() : CThread("CVideoInfoScanner")
+  CVideoInfoScanner::CVideoInfoScanner() : CThread("VideoInfoScanner")
   {
     m_bRunning = false;
     m_handle = NULL;

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -106,7 +106,7 @@ using namespace std;
 
 #endif
 
-CVideoReferenceClock::CVideoReferenceClock() : CThread("CVideoReferenceClock")
+CVideoReferenceClock::CVideoReferenceClock() : CThread("VideoReferenceClock")
 {
   m_SystemFrequency = CurrentHostFrequency();
   m_ClockSpeed = 1.0;

--- a/xbmc/win32/WindowHelper.cpp
+++ b/xbmc/win32/WindowHelper.cpp
@@ -27,7 +27,7 @@ using namespace std;
 
 CWHelper g_windowHelper;
 
-CWHelper::CWHelper(void) : CThread("CWHelper")
+CWHelper::CWHelper(void) : CThread("WindowHelper")
 {
   m_hwnd = NULL;
   m_hProcess = NULL;


### PR DESCRIPTION
This extends on the work of PR #2323.

Since thread names are limited to 15 characters, we reduced the length of the name (removing starting C, get rid of spaces, remove trailing Thread, ...) where it made sense.

```
xbmc02:~ # pstree -p 715
xbmc.bin(715)-+-{EPGUpdater}(798)
              |-{EventServer}(790)
              |-{PeripheralBus}(778)
              |-{PeripheralBus}(779)
              |-{PVRAddon}(800)
              |-{PVRAddon}(932)
              |-{PVRGUIInfo}(933)
              |-{PVRManager}(799)
              |-{SoftAE}(777)
              |-{TCPServer}(791)
              |-{XBPython}(783)
              |-{XBPython}(784)
              |-{XBPython}(786)
              |-{XBPython}(787)
              |-{XBPython}(955)
              |-{XBPython}(972)
              `-{xbmc.bin}(792)
```

I would like to see more specific names for XBPython, PeripheralBus and PVRAddon. And also get rid of the remaining xbmc.bin thread name.
