### PR TITLE
Set proper UPnP class for playlists 

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -347,7 +347,7 @@ BuildObject(CFileItem&                    item,
         rooturi = NPT_HttpUrl("localhost", upnp_server->GetPort(), "/");
     }
 
-    if (!item.m_bIsFolder) {
+    if (!item.m_bIsFolder && !item.IsPlayList() && !item.IsSmartPlayList()) {
         object = new PLT_MediaItem();
         object->m_ObjectID = item.GetPath();
 
@@ -517,7 +517,7 @@ BuildObject(CFileItem&                    item,
                   container->m_ObjectClass.type += ".storageFolder";
                   break;
             }
-        } else if (item.IsPlayList()) {
+        } else if (item.IsPlayList() || item.IsSmartPlayList()) {
             container->m_ObjectClass.type += ".playlistContainer";
         }
 


### PR DESCRIPTION
XBMC sets object.item.audioItem.musicTrack class for playlists.

Currently Showtime rejects to load XBMC's playlist via UPnP because it doesn't expect object.item.audioItem.musicTrack.

Perhaps some other UPnP clients may have problems as well.

Playlist should be container, not item.
