### PR TITLE
[fix] don't activate mouse on an unknown event (continue PR #2533)

### DIFF
--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -157,12 +157,12 @@ void CMouseStat::HandleEvent(XBMC_Event& newEvent)
   else
     m_Action = ACTION_NOOP;
 
-  // Activate the mouse pointer
-  if (MovedPastThreshold() || m_mouseState.dz)
-    SetActive();
-  else if (bNothingDown)
+  // Normalize the cursor
+  if (!MovedPastThreshold() && !m_mouseState.dz && bNothingDown)
     SetState(MOUSE_STATE_NORMAL);
-  else
+
+  // Activate the mouse pointer
+  else if (m_Action != ACTION_NOOP)
     SetActive();
 }
 


### PR DESCRIPTION
Minor glitch on the PR #2533 got unnoticed. Mouse is activated if the mouse handler gets an unknown event. For example double-clicking middle mouse button causes an event like that.

Naturally unknown events can't be mapped to any action. That's why an unknown event shouldn't change the activity state of the mouse.
