### PR TITLE
final settings cleanup

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1914,10 +1914,10 @@ void CApplication::StartServices()
 #endif
 
   CLog::Log(LOGNOTICE, "initializing playlistplayer");
-  g_playlistPlayer.SetRepeat(PLAYLIST_MUSIC, g_settings.m_bMyMusicPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
-  g_playlistPlayer.SetShuffle(PLAYLIST_MUSIC, g_settings.m_bMyMusicPlaylistShuffle);
-  g_playlistPlayer.SetRepeat(PLAYLIST_VIDEO, g_settings.m_bMyVideoPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
-  g_playlistPlayer.SetShuffle(PLAYLIST_VIDEO, g_settings.m_bMyVideoPlaylistShuffle);
+  g_playlistPlayer.SetRepeat(PLAYLIST_MUSIC, CMediaSettings::Get().DoesMusicPlaylistRepeat() ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
+  g_playlistPlayer.SetShuffle(PLAYLIST_MUSIC, CMediaSettings::Get().IsMusicPlaylistShuffled());
+  g_playlistPlayer.SetRepeat(PLAYLIST_VIDEO, CMediaSettings::Get().DoesVideoPlaylistRepeat() ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
+  g_playlistPlayer.SetShuffle(PLAYLIST_VIDEO, CMediaSettings::Get().IsVideoPlaylistShuffled());
   CLog::Log(LOGNOTICE, "DONE initializing playlistplayer");
 }
 
@@ -4137,23 +4137,23 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
   if (item.IsVideo() && g_playlistPlayer.GetPlaylist(playlist).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
-    options.fullscreen = !g_playlistPlayer.HasPlayedFirstFile() && g_advancedSettings.m_fullScreenOnMovieStart && !g_settings.m_bStartVideoWindowed;
+    options.fullscreen = !g_playlistPlayer.HasPlayedFirstFile() && g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::Get().DoesVideoStartWindowed();
   }
   else if(m_itemCurrentFile->IsStack() && m_currentStack->Size() > 0)
   {
     // TODO - this will fail if user seeks back to first file in stack
     if(m_currentStackPosition == 0 || m_itemCurrentFile->m_lStartOffset == STARTOFFSET_RESUME)
-      options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !g_settings.m_bStartVideoWindowed;
+      options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::Get().DoesVideoStartWindowed();
     else
       options.fullscreen = false;
     // reset this so we don't think we are resuming on seek
     m_itemCurrentFile->m_lStartOffset = 0;
   }
   else
-    options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !g_settings.m_bStartVideoWindowed;
+    options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::Get().DoesVideoStartWindowed();
 
-  // reset m_bStartVideoWindowed as it's a temp setting
-  g_settings.m_bStartVideoWindowed = false;
+  // reset VideoStartWindowed as it's a temp setting
+  CMediaSettings::Get().SetVideoStartWindowed(false);
 
 #ifdef HAS_KARAOKE
   //We have to stop parsing a cdg before mplayer is deallocated

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -640,7 +640,7 @@ bool CApplication::Create()
 #endif
 
   // only the InitDirectories* for the current platform should return true
-  // putting this before the first log entries saves another ifdef for g_settings.m_logFolder
+  // putting this before the first log entries saves another ifdef for g_advancedSettings.m_logFolder
   bool inited = InitDirectoriesLinux();
   if (!inited)
     inited = InitDirectoriesOSX();
@@ -652,10 +652,10 @@ bool CApplication::Create()
   CopyUserDataIfNeeded("special://masterprofile/", "favourites.xml");
   CopyUserDataIfNeeded("special://masterprofile/", "Lircmap.xml");
 
-  if (!CLog::Init(CSpecialProtocol::TranslatePath(g_settings.m_logFolder).c_str()))
+  if (!CLog::Init(CSpecialProtocol::TranslatePath(g_advancedSettings.m_logFolder).c_str()))
   {
     fprintf(stderr,"Could not init logging classes. Permission errors on ~/.xbmc (%s)\n",
-      CSpecialProtocol::TranslatePath(g_settings.m_logFolder).c_str());
+      CSpecialProtocol::TranslatePath(g_advancedSettings.m_logFolder).c_str());
     return false;
   }
 
@@ -691,7 +691,7 @@ bool CApplication::Create()
   CStdString executable = CUtil::ResolveExecutablePath();
   CLog::Log(LOGNOTICE, "The executable running is: %s", executable.c_str());
   CLog::Log(LOGNOTICE, "Local hostname: %s", m_network->GetHostName().c_str());
-  CLog::Log(LOGNOTICE, "Log File is located: %sxbmc.log", g_settings.m_logFolder.c_str());
+  CLog::Log(LOGNOTICE, "Log File is located: %sxbmc.log", g_advancedSettings.m_logFolder.c_str());
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
 
   CStdString strExecutablePath;
@@ -708,7 +708,7 @@ bool CApplication::Create()
       for (int i=0;i<items.Size();++i)
           CFile::Cache(items[i]->GetPath(),"special://masterprofile/"+URIUtils::GetFileName(items[i]->GetPath()));
     }
-    g_settings.m_logFolder = "special://masterprofile/";
+    g_advancedSettings.m_logFolder = "special://masterprofile/";
   }
 
 #ifdef HAS_XRANDR
@@ -1064,7 +1064,7 @@ bool CApplication::InitDirectoriesLinux()
     CSpecialProtocol::SetTempPath(strTempPath);
 
     URIUtils::AddSlashAtEnd(strTempPath);
-    g_settings.m_logFolder = strTempPath;
+    g_advancedSettings.m_logFolder = strTempPath;
 
     CreateUserDirs();
 
@@ -1072,7 +1072,7 @@ bool CApplication::InitDirectoriesLinux()
   else
   {
     URIUtils::AddSlashAtEnd(xbmcPath);
-    g_settings.m_logFolder = xbmcPath;
+    g_advancedSettings.m_logFolder = xbmcPath;
 
     CSpecialProtocol::SetXBMCBinPath(xbmcBinPath);
     CSpecialProtocol::SetXBMCPath(xbmcPath);
@@ -1087,7 +1087,7 @@ bool CApplication::InitDirectoriesLinux()
     CreateUserDirs();
 
     URIUtils::AddSlashAtEnd(strTempPath);
-    g_settings.m_logFolder = strTempPath;
+    g_advancedSettings.m_logFolder = strTempPath;
   }
 
   return true;
@@ -1156,14 +1156,14 @@ bool CApplication::InitDirectoriesOSX()
       strTempPath = userHome + "/Library/Logs";
     #endif
     URIUtils::AddSlashAtEnd(strTempPath);
-    g_settings.m_logFolder = strTempPath;
+    g_advancedSettings.m_logFolder = strTempPath;
 
     CreateUserDirs();
   }
   else
   {
     URIUtils::AddSlashAtEnd(xbmcPath);
-    g_settings.m_logFolder = xbmcPath;
+    g_advancedSettings.m_logFolder = xbmcPath;
 
     CSpecialProtocol::SetXBMCBinPath(xbmcPath);
     CSpecialProtocol::SetXBMCPath(xbmcPath);
@@ -1174,7 +1174,7 @@ bool CApplication::InitDirectoriesOSX()
     CSpecialProtocol::SetTempPath(strTempPath);
 
     URIUtils::AddSlashAtEnd(strTempPath);
-    g_settings.m_logFolder = strTempPath;
+    g_advancedSettings.m_logFolder = strTempPath;
   }
 
   return true;
@@ -1195,7 +1195,7 @@ bool CApplication::InitDirectoriesWin32()
 
   CStdString strWin32UserFolder = CWIN32Util::GetProfilePath();
 
-  g_settings.m_logFolder = strWin32UserFolder;
+  g_advancedSettings.m_logFolder = strWin32UserFolder;
   CSpecialProtocol::SetHomePath(strWin32UserFolder);
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));
   CSpecialProtocol::SetTempPath(URIUtils::AddFileToFolder(strWin32UserFolder,"cache"));

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -747,6 +747,7 @@ bool CApplication::Create()
   g_settings.RegisterSubSettings(&CDisplaySettings::Get());
   g_settings.RegisterSubSettings(&CMediaSettings::Get());
   g_settings.RegisterSubSettings(&CSkinSettings::Get());
+  g_settings.RegisterSubSettings(&g_sysinfo);
   g_settings.RegisterSubSettings(&CViewStateSettings::Get());
 
   g_guiSettings.Initialize();  // Initialize default Settings - don't move
@@ -3564,6 +3565,7 @@ bool CApplication::Cleanup()
     g_settings.UnregisterSubSettings(&CDisplaySettings::Get());
     g_settings.UnregisterSubSettings(&CMediaSettings::Get());
     g_settings.UnregisterSubSettings(&CSkinSettings::Get());
+    g_settings.UnregisterSubSettings(&g_sysinfo);
     g_settings.UnregisterSubSettings(&CViewStateSettings::Get());
 
     g_settings.UnregisterSettingsHandler(&g_advancedSettings);
@@ -3622,7 +3624,7 @@ void CApplication::Stop(int exitCode)
       g_Windowing.EnableSystemScreenSaver(true);
 
     CLog::Log(LOGNOTICE, "Storing total System Uptime");
-    g_settings.m_iSystemTimeTotalUp = g_settings.m_iSystemTimeTotalUp + (int)(CTimeUtils::GetFrameTime() / 60000);
+    g_sysinfo.SetTotalUptime(g_sysinfo.GetTotalUptime() + (int)(CTimeUtils::GetFrameTime() / 60000));
 
     // Update the settings information (volume, uptime etc. need saving)
     if (CFile::Exists(CProfilesManager::Get().GetSettingsFile()))

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -50,6 +50,7 @@ class CPlayerController;
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "PlayListPlayer.h"
 #include "settings/ISettingsHandler.h"
+#include "settings/ISubSettings.h"
 #if !defined(_WIN32) && defined(HAS_DVD_DRIVE)
 #include "storage/DetectDVDType.h"
 #endif
@@ -96,6 +97,11 @@ namespace MUSIC_INFO
   class CMusicInfoScanner;
 }
 
+#define VOLUME_MINIMUM 0.0f        // -60dB
+#define VOLUME_MAXIMUM 1.0f        // 0dB
+#define VOLUME_DYNAMIC_RANGE 90.0f // 60dB
+#define VOLUME_CONTROL_STEPS 90    // 90 steps
+
 class CBackgroundPlayer : public CThread
 {
 public:
@@ -108,7 +114,7 @@ protected:
 };
 
 class CApplication : public CXBApplicationEx, public IPlayerCallback, public IMsgTargetCallback,
-                     public ISettingsHandler
+                     public ISettingsHandler, public ISubSettings
 {
 public:
 
@@ -212,10 +218,11 @@ public:
   virtual void Process();
   void ProcessSlow();
   void ResetScreenSaver();
-  int GetVolume() const;
+  float GetVolume(bool percentage = true) const;
   void SetVolume(float iValue, bool isPercentage = true);
   bool IsMuted() const;
   void ToggleMute(void);
+  void SetMute(bool mute);
   void ShowVolumeBar(const CAction *action = NULL);
   int GetPlaySpeed() const;
   int GetSubtitleDelay() const;
@@ -374,6 +381,9 @@ public:
 protected:
   virtual bool OnSettingsSaving() const;
 
+  virtual bool Load(const TiXmlNode *settings);
+  virtual bool Save(TiXmlNode *settings) const;
+
   bool LoadSkin(const CStdString& skinID);
   void LoadSkin(const boost::shared_ptr<ADDON::CSkinInfo>& skin);
 
@@ -440,6 +450,9 @@ protected:
 
   VIDEO::CVideoInfoScanner *m_videoInfoScanner;
   MUSIC_INFO::CMusicInfoScanner *m_musicInfoScanner;
+
+  bool m_muted;
+  float m_volumeLevel;
 
   void Mute();
   void UnMute();

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -35,7 +35,7 @@
 #include "utils/Variant.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
-#include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
 #include "FileItem.h"
 #include "guilib/GUIDialog.h"
@@ -405,7 +405,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
           else
             URIUtils::CreateArchivePath(strPath, "rar", pMsg->strParam.c_str(), "");
 
-          CUtil::GetRecursiveListing(strPath, items, g_settings.m_pictureExtensions);
+          CUtil::GetRecursiveListing(strPath, items, g_advancedSettings.m_pictureExtensions);
           if (items.Size() > 0)
           {
             pSlideShow->Reset();
@@ -440,7 +440,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
         CFileItemList items;
         CStdString strPath = pMsg->strParam;
-        CStdString extensions = g_settings.m_pictureExtensions;
+        CStdString extensions = g_advancedSettings.m_pictureExtensions;
         if (pMsg->dwParam1)
           extensions += "|.tbn";
         CUtil::GetRecursiveListing(strPath, items, extensions);

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -33,7 +33,6 @@
 #include "filesystem/File.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "playlists/PlayList.h"
 #include "guilib/GUIWindowManager.h"
 #include "storage/MediaManager.h"
@@ -359,7 +358,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
     // stack video files
     CFileItemList tempItems;
     tempItems.Append(vecItems);
-    if (g_settings.m_videoStacking)
+    if (g_guiSettings.GetBool("myvideos.stackvideos"))
       tempItems.Stack();
     CFileItemList itemlist;
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -51,7 +51,6 @@
 #include "URL.h"
 #include "settings/GUISettings.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
 #include "utils/RegExp.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
@@ -785,7 +784,7 @@ bool CFileItem::IsVideo() const
 
   extension.ToLower();
 
-  return (g_settings.m_videoExtensions.Find(extension) != -1);
+  return (g_advancedSettings.m_videoExtensions.Find(extension) != -1);
 }
 
 bool CFileItem::IsEPG() const
@@ -829,7 +828,7 @@ bool CFileItem::IsDiscStub() const
   strExtension.ToLower();
   strExtension += '|';
 
-  return (g_settings.m_discStubExtensions + '|').Find(strExtension) != -1;
+  return (g_advancedSettings.m_discStubExtensions + '|').Find(strExtension) != -1;
 }
 
 bool CFileItem::IsAudio() const
@@ -860,7 +859,7 @@ bool CFileItem::IsAudio() const
 
   extension.ToLower();
 
-  return (g_settings.m_musicExtensions.Find(extension) != -1);
+  return (g_advancedSettings.m_musicExtensions.Find(extension) != -1);
 }
 
 bool CFileItem::IsKaraoke() const
@@ -2126,7 +2125,7 @@ void CFileItemList::FilterCueItems()
                 else
                 { // try replacing the extension with one of our allowed ones.
                   CStdStringArray extensions;
-                  StringUtils::SplitString(g_settings.m_musicExtensions, "|", extensions);
+                  StringUtils::SplitString(g_advancedSettings.m_musicExtensions, "|", extensions);
                   for (unsigned int i = 0; i < extensions.size(); i++)
                   {
                     strMediaFile = URIUtils::ReplaceExtension(pItem->GetPath(), extensions[i]);
@@ -2294,7 +2293,7 @@ void CFileItemList::StackFolders()
           if (bMatch)
           {
             CFileItemList items;
-            CDirectory::GetDirectory(item->GetPath(),items,g_settings.m_videoExtensions);
+            CDirectory::GetDirectory(item->GetPath(),items,g_advancedSettings.m_videoExtensions);
             // optimized to only traverse listing once by checking for filecount
             // and recording last file item for later use
             int nFiles = 0;
@@ -2928,11 +2927,11 @@ CStdString CFileItem::GetLocalFanart() const
     return "";
 
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+  CDirectory::GetDirectory(strDir, items, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
   if (IsOpticalMediaFile())
   { // grab from the optical media parent folder as well
     CFileItemList moreItems;
-    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
     items.Append(moreItems);
   }
 
@@ -3177,7 +3176,7 @@ CStdString CFileItem::FindTrailer() const
   CStdString strDir;
   URIUtils::GetDirectory(strFile, strDir);
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_settings.m_videoExtensions, DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+  CDirectory::GetDirectory(strDir, items, g_advancedSettings.m_videoExtensions, DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
   URIUtils::RemoveExtension(strFile);
   strFile += "-trailer";
   CStdString strFile3 = URIUtils::AddFileToFolder(strDir, "movie-trailer");

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1276,7 +1276,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     strLabel.Format("%02.2f", m_fps);
     break;
   case PLAYER_VOLUME:
-    strLabel.Format("%2.1f dB", CAEUtil::PercentToGain(g_settings.m_fVolumeLevel));
+    strLabel.Format("%2.1f dB", CAEUtil::PercentToGain(g_application.GetVolume(false)));
     break;
   case PLAYER_SUBTITLE_DELAY:
     strLabel.Format("%2.3f s", CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
@@ -1850,7 +1850,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
   switch( info )
   {
     case PLAYER_VOLUME:
-      value = g_application.GetVolume();
+      value = (int)g_application.GetVolume();
       return true;
     case PLAYER_SUBTITLE_DELAY:
       value = g_application.GetSubtitleDelay();
@@ -2016,7 +2016,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     bReturn = (pWindow && pWindow->IsMediaWindow());
   }
   else if (condition == PLAYER_MUTED)
-    bReturn = g_settings.m_bMute;
+    bReturn = g_application.IsMuted();
   else if (condition >= LIBRARY_HAS_MUSIC && condition <= LIBRARY_HAS_MUSICVIDEOS)
     bReturn = GetLibraryBool(condition);
   else if (condition == LIBRARY_IS_SCANNING)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -76,6 +76,7 @@
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/MediaSettings.h"
 #ifdef HAS_IRSERVERSUITE
   #include "input/windows/IRServerSuite.h"
 #endif
@@ -1910,20 +1911,20 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
   CStdString strMovieFileNameNoExt(URIUtils::ReplaceExtension(strMovieFileName, ""));
   strLookInPaths.push_back(strPath);
   
-  if (!g_settings.iAdditionalSubtitleDirectoryChecked && !g_guiSettings.GetString("subtitles.custompath").IsEmpty()) // to avoid checking non-existent directories (network) every time..
+  if (!CMediaSettings::Get().GetAdditionalSubtitleDirectoryChecked() && !g_guiSettings.GetString("subtitles.custompath").IsEmpty()) // to avoid checking non-existent directories (network) every time..
   {
     if (!g_application.getNetwork().IsAvailable() && !URIUtils::IsHD(g_guiSettings.GetString("subtitles.custompath")))
     {
       CLog::Log(LOGINFO,"CUtil::CacheSubtitles: disabling alternate subtitle directory for this session, it's nonaccessible");
-      g_settings.iAdditionalSubtitleDirectoryChecked = -1; // disabled
+      CMediaSettings::Get().SetAdditionalSubtitleDirectoryChecked(-1); // disabled
     }
     else if (!CDirectory::Exists(g_guiSettings.GetString("subtitles.custompath")))
     {
       CLog::Log(LOGINFO,"CUtil::CacheSubtitles: disabling alternate subtitle directory for this session, it's nonexistant");
-      g_settings.iAdditionalSubtitleDirectoryChecked = -1; // disabled
+      CMediaSettings::Get().SetAdditionalSubtitleDirectoryChecked(-1); // disabled
     }
     
-    g_settings.iAdditionalSubtitleDirectoryChecked = 1;
+    CMediaSettings::Get().SetAdditionalSubtitleDirectoryChecked(1);
   }
   
   if (strMovie.Left(6) == "rar://") // <--- if this is found in main path then ignore it!
@@ -1989,7 +1990,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
   // .. done checking for cd-dirs
   
   // this is last because we dont want to check any common subdirs or cd-dirs in the alternate <subtitles> dir.
-  if (g_settings.iAdditionalSubtitleDirectoryChecked == 1)
+  if (CMediaSettings::Get().GetAdditionalSubtitleDirectoryChecked() == 1)
   {
     strPath = g_guiSettings.GetString("subtitles.custompath");
     URIUtils::AddSlashAtEnd(strPath);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -60,6 +60,7 @@
 #include "profiles/ProfilesManager.h"
 #include "utils/RegExp.h"
 #include "settings/GUISettings.h"
+#include "guilib/GraphicContext.h"
 #include "guilib/TextureManager.h"
 #include "utils/fstrcmp.h"
 #include "storage/MediaManager.h"

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -508,7 +508,7 @@ bool CUtil::IsPicture(const CStdString& strFile)
     return false;
 
   extension.ToLower();
-  if (g_settings.m_pictureExtensions.Find(extension) != -1)
+  if (g_advancedSettings.m_pictureExtensions.Find(extension) != -1)
     return true;
 
   if (extension == ".tbn" || extension == ".dds")

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -28,7 +28,6 @@
 #include "filesystem/Directory.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "ApplicationMessenger.h"
 #include "Favourites.h"
 #include "utils/JobManager.h"
@@ -655,7 +654,7 @@ bool CAddonInstallJob::Install(const CStdString &installFrom)
 
 void CAddonInstallJob::OnPostInstall(bool reloadAddon)
 {
-  if (m_addon->Type() < ADDON_VIZ_LIBRARY && g_settings.m_bAddonNotifications)
+  if (m_addon->Type() < ADDON_VIZ_LIBRARY && g_guiSettings.GetBool("general.addonnotifications"))
   {
     CGUIDialogKaiToast::QueueNotification(m_addon->Icon(),
                                           m_addon->Name(),

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -42,7 +42,7 @@
 #include "ApplicationMessenger.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "FileItem.h"
-#include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "GUIInfoManager.h"
 #include "GUIUserMessages.h"
@@ -371,9 +371,9 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
             {
               strMask = setting->Attribute("mask");
               // convert mask qualifiers
-              strMask.Replace("$AUDIO", g_settings.m_musicExtensions);
-              strMask.Replace("$VIDEO", g_settings.m_videoExtensions);
-              strMask.Replace("$IMAGE", g_settings.m_pictureExtensions);
+              strMask.Replace("$AUDIO", g_advancedSettings.m_musicExtensions);
+              strMask.Replace("$VIDEO", g_advancedSettings.m_videoExtensions);
+              strMask.Replace("$IMAGE", g_advancedSettings.m_pictureExtensions);
 #if defined(_WIN32_WINNT)
               strMask.Replace("$EXECUTABLE", ".exe|.bat|.cmd|.py");
 #else
@@ -383,9 +383,9 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
             else
             {
               if (strcmpi(type, "video") == 0)
-                strMask = g_settings.m_videoExtensions;
+                strMask = g_advancedSettings.m_videoExtensions;
               else if (strcmpi(type, "audio") == 0)
-                strMask = g_settings.m_musicExtensions;
+                strMask = g_advancedSettings.m_musicExtensions;
               else if (strcmpi(type, "executable") == 0)
 #if defined(_WIN32_WINNT)
                 strMask = ".exe|.bat|.cmd|.py";

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -90,19 +90,19 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
       int iControl = message.GetSenderId();
       if (iControl == CONTROL_AUTOUPDATE)
       {
-        g_settings.m_bAddonAutoUpdate = !g_settings.m_bAddonAutoUpdate;
+        g_guiSettings.ToggleBool("general.addonautoupdate");
         g_settings.Save();
         return true;
       }
       else if (iControl == CONTROL_SHUTUP)
       {
-        g_settings.m_bAddonNotifications = !g_settings.m_bAddonNotifications;
+        g_guiSettings.ToggleBool("general.addonnotifications");
         g_settings.Save();
         return true;
       }
       else if (iControl == CONTROL_FOREIGNFILTER)
       {
-        g_settings.m_bAddonForeignFilter = !g_settings.m_bAddonForeignFilter;
+        g_guiSettings.ToggleBool("general.addonforeignfilter");
         g_settings.Save();
         Refresh();
         return true;
@@ -251,9 +251,9 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
 
 void CGUIWindowAddonBrowser::UpdateButtons()
 {
-  SET_CONTROL_SELECTED(GetID(),CONTROL_AUTOUPDATE,g_settings.m_bAddonAutoUpdate);
-  SET_CONTROL_SELECTED(GetID(),CONTROL_SHUTUP,g_settings.m_bAddonNotifications);
-  SET_CONTROL_SELECTED(GetID(),CONTROL_FOREIGNFILTER,g_settings.m_bAddonForeignFilter);
+  SET_CONTROL_SELECTED(GetID(),CONTROL_AUTOUPDATE,g_guiSettings.GetBool("general.addonautoupdate"));
+  SET_CONTROL_SELECTED(GetID(),CONTROL_SHUTUP,g_guiSettings.GetBool("general.addonnotifications"));
+  SET_CONTROL_SELECTED(GetID(),CONTROL_FOREIGNFILTER,g_guiSettings.GetBool("general.addonforeignfilter"));
   CGUIMediaWindow::UpdateButtons();
 }
 
@@ -298,14 +298,14 @@ bool CGUIWindowAddonBrowser::GetDirectory(const CStdString& strDirectory,
   else
   {
     result = CGUIMediaWindow::GetDirectory(strDirectory,items);
-    if (g_settings.m_bAddonForeignFilter)
+    if (g_guiSettings.GetBool("general.addonforeignfilter"))
     {
       int i=0;
       while (i < items.Size())
       {
-        if (!FilterVar(g_settings.m_bAddonForeignFilter,
+        if (!FilterVar(g_guiSettings.GetBool("general.addonforeignfilter"),
                       items[i]->GetProperty("Addon.Language"), "en") ||
-            !FilterVar(g_settings.m_bAddonForeignFilter,
+            !FilterVar(g_guiSettings.GetBool("general.addonforeignfilter"),
                       items[i]->GetProperty("Addon.Language"),
                       g_langInfo.GetLanguageLocale()))
         {

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -22,7 +22,7 @@
 #include "utils/XBMCTinyXML.h"
 #include "filesystem/File.h"
 #include "AddonDatabase.h"
-#include "settings/Settings.h"
+#include "settings/GUISettings.h"
 #include "FileItem.h"
 #include "utils/JobManager.h"
 #include "addons/AddonInstaller.h"
@@ -222,7 +222,7 @@ bool CRepositoryUpdateJob::DoWork()
     if (addon && addons[i]->Version() > addon->Version() &&
         !database.IsAddonBlacklisted(addons[i]->ID(),addons[i]->Version().c_str()))
     {
-      if (g_settings.m_bAddonAutoUpdate || addon->Type() >= ADDON_VIZ_LIBRARY)
+      if (g_guiSettings.GetBool("general.addonautoupdate") || addon->Type() >= ADDON_VIZ_LIBRARY)
       {
         CStdString referer;
         if (URIUtils::IsInternetStream(addons[i]->Path()))
@@ -234,7 +234,7 @@ bool CRepositoryUpdateJob::DoWork()
         else
           CAddonInstaller::Get().Install(addon->ID(), true, referer);
       }
-      else if (g_settings.m_bAddonNotifications)
+      else if (g_guiSettings.GetBool("general.addonnotifications"))
       {
         CGUIDialogKaiToast::QueueNotification(addon->Icon(),
                                               g_localizeStrings.Get(24061),

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
@@ -24,9 +24,9 @@
 
 #include "CoreAudioAEStream.h"
 #include "CoreAudioAESound.h"
+#include "Application.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
 #include "utils/EndianSwap.h"

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.cpp
@@ -24,9 +24,9 @@
 #include "PulseAE.h"
 #include "PulseAEStream.h"
 #include "PulseAESound.h"
+#include "Application.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
-#include "settings/Settings.h"
 #include <pulse/pulseaudio.h>
 #include <pulse/simple.h>
 #include "guilib/LocalizeStrings.h"
@@ -126,7 +126,7 @@ bool CPulseAE::CanInit()
 
 bool CPulseAE::Initialize()
 {
-  m_Volume = g_settings.m_fVolumeLevel;
+  m_Volume = g_application.GetVolume(false);
 
   if ((m_MainLoop = pa_threaded_mainloop_new()) == NULL)
   {

--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -572,7 +572,7 @@ void CBaseRenderer::ManageDisplay()
   m_sourceRect.x2 = (float)m_sourceWidth - CMediaSettings::Get().GetCurrentVideoSettings().m_CropRight;
   m_sourceRect.y2 = (float)m_sourceHeight - CMediaSettings::Get().GetCurrentVideoSettings().m_CropBottom;
 
-  CalcNormalDisplayRect(view.x1, view.y1, view.Width(), view.Height(), GetAspectRatio() * g_settings.m_fPixelRatio, g_settings.m_fZoomAmount, g_settings.m_fVerticalShift);
+  CalcNormalDisplayRect(view.x1, view.y1, view.Width(), view.Height(), GetAspectRatio() * CDisplaySettings::Get().GetPixelRatio(), CDisplaySettings::Get().GetZoomAmount(), CDisplaySettings::Get().GetVerticalShift());
 }
 
 void CBaseRenderer::SetViewMode(int viewMode)
@@ -607,70 +607,70 @@ void CBaseRenderer::SetViewMode(int viewMode)
   screenWidth   *= xscale;
   screenHeight  *= yscale;
 
-  g_settings.m_fVerticalShift = 0.0f;
-  g_settings.m_bNonLinStretch = false;
+  CDisplaySettings::Get().SetVerticalShift(0.0f);
+  CDisplaySettings::Get().SetNonLinearStretched(false);
 
   if ( CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeZoom ||
        (is43 && g_guiSettings.GetInt("videoplayer.stretch43") == ViewModeZoom))
   { // zoom image so no black bars
-    g_settings.m_fPixelRatio = 1.0;
+    CDisplaySettings::Get().SetPixelRatio(1.0);
     // calculate the desired output ratio
-    float outputFrameRatio = sourceFrameRatio * g_settings.m_fPixelRatio / CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio;
+    float outputFrameRatio = sourceFrameRatio * CDisplaySettings::Get().GetPixelRatio() / CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio;
     // now calculate the correct zoom amount.  First zoom to full height.
     float newHeight = screenHeight;
     float newWidth = newHeight * outputFrameRatio;
-    g_settings.m_fZoomAmount = newWidth / screenWidth;
+    CDisplaySettings::Get().SetZoomAmount(newWidth / screenWidth);
     if (newWidth < screenWidth)
     { // zoom to full width
       newWidth = screenWidth;
       newHeight = newWidth / outputFrameRatio;
-      g_settings.m_fZoomAmount = newHeight / screenHeight;
+      CDisplaySettings::Get().SetZoomAmount(newHeight / screenHeight);
     }
   }
   else if (CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeStretch4x3)
   { // stretch image to 4:3 ratio
-    g_settings.m_fZoomAmount = 1.0;
+    CDisplaySettings::Get().SetZoomAmount(1.0);
     if (res == RES_PAL_4x3 || res == RES_PAL60_4x3 || res == RES_NTSC_4x3 || res == RES_HDTV_480p_4x3)
     { // stretch to the limits of the 4:3 screen.
       // incorrect behaviour, but it's what the users want, so...
-      g_settings.m_fPixelRatio = (screenWidth / screenHeight) * CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio / sourceFrameRatio;
+      CDisplaySettings::Get().SetPixelRatio((screenWidth / screenHeight) * CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio / sourceFrameRatio);
     }
     else
     {
-      // now we need to set g_settings.m_fPixelRatio so that
+      // now we need to set CDisplaySettings::Get().GetPixelRatio() so that
       // fOutputFrameRatio = 4:3.
-      g_settings.m_fPixelRatio = (4.0f / 3.0f) / sourceFrameRatio;
+      CDisplaySettings::Get().SetPixelRatio((4.0f / 3.0f) / sourceFrameRatio);
     }
   }
   else if ( CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeWideZoom ||
            (is43 && g_guiSettings.GetInt("videoplayer.stretch43") == ViewModeWideZoom))
   { // super zoom
     float stretchAmount = (screenWidth / screenHeight) * CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio / sourceFrameRatio;
-    g_settings.m_fPixelRatio = pow(stretchAmount, float(2.0/3.0));
-    g_settings.m_fZoomAmount = pow(stretchAmount, float((stretchAmount < 1.0) ? -1.0/3.0 : 1.0/3.0));
-    g_settings.m_bNonLinStretch = true;
+    CDisplaySettings::Get().SetPixelRatio(pow(stretchAmount, float(2.0/3.0)));
+    CDisplaySettings::Get().SetZoomAmount(pow(stretchAmount, float((stretchAmount < 1.0) ? -1.0/3.0 : 1.0/3.0)));
+    CDisplaySettings::Get().SetNonLinearStretched(true);
   }
   else if ( CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeStretch16x9 ||
            (is43 && g_guiSettings.GetInt("videoplayer.stretch43") == ViewModeStretch16x9))
   { // stretch image to 16:9 ratio
-    g_settings.m_fZoomAmount = 1.0;
+    CDisplaySettings::Get().SetZoomAmount(1.0);
     if (res == RES_PAL_4x3 || res == RES_PAL60_4x3 || res == RES_NTSC_4x3 || res == RES_HDTV_480p_4x3)
-    { // now we need to set g_settings.m_fPixelRatio so that
+    { // now we need to set CDisplaySettings::Get().GetPixelRatio() so that
       // outputFrameRatio = 16:9.
-      g_settings.m_fPixelRatio = (16.0f / 9.0f) / sourceFrameRatio;
+      CDisplaySettings::Get().SetPixelRatio((16.0f / 9.0f) / sourceFrameRatio);
     }
     else
     { // stretch to the limits of the 16:9 screen.
       // incorrect behaviour, but it's what the users want, so...
-      g_settings.m_fPixelRatio = (screenWidth / screenHeight) * CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio / sourceFrameRatio;
+      CDisplaySettings::Get().SetPixelRatio((screenWidth / screenHeight) * CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio / sourceFrameRatio);
     }
   }
   else  if (CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeOriginal)
   { // zoom image so that the height is the original size
-    g_settings.m_fPixelRatio = 1.0;
+    CDisplaySettings::Get().SetPixelRatio(1.0);
     // get the size of the media file
     // calculate the desired output ratio
-    float outputFrameRatio = sourceFrameRatio * g_settings.m_fPixelRatio / CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio;
+    float outputFrameRatio = sourceFrameRatio * CDisplaySettings::Get().GetPixelRatio() / CDisplaySettings::Get().GetResolutionInfo(res).fPixelRatio;
     // now calculate the correct zoom amount.  First zoom to full width.
     float newHeight = screenWidth / outputFrameRatio;
     if (newHeight > screenHeight)
@@ -678,25 +678,25 @@ void CBaseRenderer::SetViewMode(int viewMode)
       newHeight = screenHeight;
     }
     // now work out the zoom amount so that no zoom is done
-    g_settings.m_fZoomAmount = (m_sourceHeight - CMediaSettings::Get().GetCurrentVideoSettings().m_CropTop - CMediaSettings::Get().GetCurrentVideoSettings().m_CropBottom) / newHeight;
+    CDisplaySettings::Get().SetZoomAmount((m_sourceHeight - CMediaSettings::Get().GetCurrentVideoSettings().m_CropTop - CMediaSettings::Get().GetCurrentVideoSettings().m_CropBottom) / newHeight);
   }
   else if (CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeCustom)
   {
-    g_settings.m_fZoomAmount = CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount;
-    g_settings.m_fPixelRatio = CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio;
-    g_settings.m_bNonLinStretch = CMediaSettings::Get().GetCurrentVideoSettings().m_CustomNonLinStretch;
-    g_settings.m_fVerticalShift = CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift;
+    CDisplaySettings::Get().SetZoomAmount(CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount);
+    CDisplaySettings::Get().SetPixelRatio(CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio);
+    CDisplaySettings::Get().SetNonLinearStretched(CMediaSettings::Get().GetCurrentVideoSettings().m_CustomNonLinStretch);
+    CDisplaySettings::Get().SetVerticalShift(CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift);
   }
   else // if (CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode == ViewModeNormal)
   {
-    g_settings.m_fPixelRatio = 1.0;
-    g_settings.m_fZoomAmount = 1.0;
+    CDisplaySettings::Get().SetPixelRatio(1.0);
+    CDisplaySettings::Get().SetZoomAmount(1.0);
   }
 
-  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = g_settings.m_fZoomAmount;
-  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio = g_settings.m_fPixelRatio;
-  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomNonLinStretch = g_settings.m_bNonLinStretch;
-  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift = g_settings.m_fVerticalShift;
+  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = CDisplaySettings::Get().GetZoomAmount();
+  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio = CDisplaySettings::Get().GetPixelRatio();
+  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomNonLinStretch = CDisplaySettings::Get().IsNonLinearStretched();
+  CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift = CDisplaySettings::Get().GetVerticalShift();
 }
 
 void CBaseRenderer::MarkDirty()

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -829,13 +829,13 @@ unsigned int CLinuxRendererGL::PreInit()
 
 void CLinuxRendererGL::UpdateVideoFilter()
 {
-  bool pixelRatioChanged    = (g_settings.m_fPixelRatio > 1.001f || g_settings.m_fPixelRatio < 0.999f) !=
+  bool pixelRatioChanged    = (CDisplaySettings::Get().GetPixelRatio() > 1.001f || CDisplaySettings::Get().GetPixelRatio() < 0.999f) !=
                               (m_pixelRatio > 1.001f || m_pixelRatio < 0.999f);
   bool nonLinStretchChanged = false;
-  if (m_nonLinStretchGui != g_settings.m_bNonLinStretch || pixelRatioChanged)
+  if (m_nonLinStretchGui != CDisplaySettings::Get().IsNonLinearStretched() || pixelRatioChanged)
   {
-    m_nonLinStretchGui   = g_settings.m_bNonLinStretch;
-    m_pixelRatio         = g_settings.m_fPixelRatio;
+    m_nonLinStretchGui   = CDisplaySettings::Get().IsNonLinearStretched();
+    m_pixelRatio         = CDisplaySettings::Get().GetPixelRatio();
     m_reloadShaders      = 1;
     nonLinStretchChanged = true;
 
@@ -1273,7 +1273,7 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
   if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
     m_pYUVShader->SetNonLinStretch(1.0);
   else
-    m_pYUVShader->SetNonLinStretch(pow(g_settings.m_fPixelRatio, g_advancedSettings.m_videoNonLinStretchRatio));
+    m_pYUVShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
 
   if     (field == FIELD_TOP)
     m_pYUVShader->SetField(1);
@@ -1506,7 +1506,7 @@ void CLinuxRendererGL::RenderFromFBO()
     if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
       m_pVideoFilterShader->SetNonLinStretch(1.0);
     else
-      m_pVideoFilterShader->SetNonLinStretch(pow(g_settings.m_fPixelRatio, g_advancedSettings.m_videoNonLinStretchRatio));
+      m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
 
     m_pVideoFilterShader->Enable();
   }
@@ -1586,7 +1586,7 @@ void CLinuxRendererGL::RenderVDPAU(int index, int field)
     if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
       m_pVideoFilterShader->SetNonLinStretch(1.0);
     else
-      m_pVideoFilterShader->SetNonLinStretch(pow(g_settings.m_fPixelRatio, g_advancedSettings.m_videoNonLinStretchRatio));
+      m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
 
     m_pVideoFilterShader->Enable();
   }
@@ -1677,7 +1677,7 @@ void CLinuxRendererGL::RenderVAAPI(int index, int field)
     if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
       m_pVideoFilterShader->SetNonLinStretch(1.0);
     else
-      m_pVideoFilterShader->SetNonLinStretch(pow(g_settings.m_fPixelRatio, g_advancedSettings.m_videoNonLinStretchRatio));
+      m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
 
     m_pVideoFilterShader->Enable();
   }

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -27,6 +27,7 @@
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySSA.h"
 #include "cores/VideoRenderers/RenderManager.h"
 #include "Application.h"
+#include "guilib/GraphicContext.h"
 #include "windowing/WindowingFactory.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"

--- a/xbmc/cores/VideoRenderers/legacy/ComboRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/legacy/ComboRenderer.cpp
@@ -22,6 +22,7 @@
 #include "ComboRenderer.h"
 #include "Application.h"
 #include "Settings.h"
+#include "settings/DisplaySettings.h"
 
 CComboRenderer::CComboRenderer(LPDIRECT3DDEVICE8 pDevice)
     : CXBoxRenderer(pDevice)
@@ -117,7 +118,7 @@ void CComboRenderer::ManageDisplay()
   float fScreenHeight = (float)rv.bottom - rv.top;
   float fOffsetX1 = (float)rv.left;
   float fOffsetY1 = (float)rv.top;
-  float fPixelRatio = g_settings.m_fPixelRatio;
+  float fPixelRatio = CDisplaySettings::Get().GetPixelRatio();
   float fMaxScreenWidth = (float)CDisplaySettings::Get().GetResolutionInfo(g_graphicsContext.GetVideoResolution()).iWidth;
   float fMaxScreenHeight = (float)CDisplaySettings::Get().GetResolutionInfo(g_graphicsContext.GetVideoResolution()).iHeight;
   if (fOffsetX1 < 0) fOffsetX1 = 0;
@@ -139,7 +140,7 @@ void CComboRenderer::ManageDisplay()
   rs.right = m_iSourceWidth - CMediaSettings::Get().GetCurrentVideoSettings().m_CropRight;
   rs.bottom = m_iSourceHeight - CMediaSettings::Get().GetCurrentVideoSettings().m_CropBottom;
 
-  CalcNormalDisplayRect(fOffsetX1, fOffsetY1, fScreenWidth, fScreenHeight, GetAspectRatio() * fPixelRatio, g_settings.m_fZoomAmount);
+  CalcNormalDisplayRect(fOffsetX1, fOffsetY1, fScreenWidth, fScreenHeight, GetAspectRatio() * fPixelRatio, CDisplaySettings::Get().GetZoomAmount());
 
   // check whether we need to alter our source rect
   if (rd.left < fOffsetX1 || rd.right > fOffsetX1 + fScreenWidth)

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -1446,10 +1446,10 @@ void CAMLPlayer::Process()
       GetStatus();
 
       // restore mute setting.
-      SetMute(g_settings.m_bMute);
+      SetMute(g_application.IsMuted());
 
       // restore system volume setting.
-      SetVolume(g_settings.m_fVolumeLevel);
+      SetVolume(g_application.GetVolume(false));
 
       // the default staturation is to high, drop it
       SetVideoSaturation(110);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -23,6 +23,7 @@
 #include <dlfcn.h>
 #include "windowing/WindowingFactory.h"
 #include "VDPAU.h"
+#include "guilib/GraphicContext.h"
 #include "guilib/TextureManager.h"
 #include "cores/VideoRenderers/RenderManager.h"
 #include "DVDVideoCodecFFmpeg.h"

--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "OMXAudio.h"
+#include "Application.h"
 #include "utils/log.h"
 
 #define CLASSNAME "COMXAudio"
@@ -33,7 +34,6 @@
 
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
 #include "cores/AudioEngine/Utils/AEConvert.h"
 

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -40,7 +40,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "windowing/WindowingFactory.h"
 

--- a/xbmc/dialogs/GUIDialogMuteBug.cpp
+++ b/xbmc/dialogs/GUIDialogMuteBug.cpp
@@ -20,7 +20,7 @@
 
 #include "GUIDialogMuteBug.h"
 #include "GUIUserMessages.h"
-#include "settings/Settings.h"
+#include "Application.h"
 
 // the MuteBug is a true modeless dialog
 
@@ -35,7 +35,7 @@ CGUIDialogMuteBug::~CGUIDialogMuteBug(void)
 
 void CGUIDialogMuteBug::UpdateVisibility()
 {
-  if (g_settings.m_bMute || g_settings.m_fVolumeLevel == VOLUME_MINIMUM)
+  if (g_application.IsMuted() || g_application.GetVolume(false) <= VOLUME_MINIMUM)
     Show();
   else
     Close();

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -24,7 +24,6 @@
 #include "URL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "File.h"
 
 #include <vector>
@@ -566,7 +565,7 @@ void CCurlFile::SetCommonOptions(CReadState* state)
   if (m_userAgent.length() > 0)
     g_curlInterface.easy_setopt(h, CURLOPT_USERAGENT, m_userAgent.c_str());
   else /* set some default agent as shoutcast doesn't return proper stuff otherwise */
-    g_curlInterface.easy_setopt(h, CURLOPT_USERAGENT, g_settings.m_userAgent.c_str());
+    g_curlInterface.easy_setopt(h, CURLOPT_USERAGENT, g_advancedSettings.m_userAgent.c_str());
 
   if (m_useOldHttpVersion)
     g_curlInterface.easy_setopt(h, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -21,7 +21,6 @@
 #include "RSSDirectory.h"
 #include "FileItem.h"
 #include "CurlFile.h"
-#include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -96,13 +95,13 @@ static bool IsPathToMedia(const CStdString& strPath )
 
   extension.ToLower();
 
-  if (g_settings.m_videoExtensions.Find(extension) != -1)
+  if (g_advancedSettings.m_videoExtensions.Find(extension) != -1)
     return true;
 
-  if (g_settings.m_musicExtensions.Find(extension) != -1)
+  if (g_advancedSettings.m_musicExtensions.Find(extension) != -1)
     return true;
 
-  if (g_settings.m_pictureExtensions.Find(extension) != -1)
+  if (g_advancedSettings.m_pictureExtensions.Find(extension) != -1)
     return true;
 
   return false;
@@ -120,7 +119,7 @@ static bool IsPathToThumbnail(const CStdString& strPath )
 
   extension.ToLower();
 
-  if (g_settings.m_pictureExtensions.Find(extension) != -1)
+  if (g_advancedSettings.m_pictureExtensions.Find(extension) != -1)
     return true;
 
   return false;

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -21,9 +21,10 @@
 #include "SpecialProtocol.h"
 #include "URL.h"
 #include "Util.h"
+#include "guilib/GraphicContext.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 
@@ -146,7 +147,7 @@ CStdString CSpecialProtocol::TranslatePath(const CURL &url)
   else if (RootDir.Equals("skin"))
     URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), FileName, translatedPath);
   else if (RootDir.Equals("logpath"))
-    URIUtils::AddFileToFolder(g_settings.m_logFolder, FileName, translatedPath);
+    URIUtils::AddFileToFolder(g_advancedSettings.m_logFolder, FileName, translatedPath);
 
 
   // from here on, we have our "real" special paths

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -25,7 +25,7 @@
 #include "guilib/TextureManager.h"
 #include "File.h"
 #include "FileItem.h"
-#include "settings/Settings.h"
+#include "settings/GUISettings.h"
 #include "utils/Crc32.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
@@ -229,7 +229,7 @@ CStdString CVideoDatabaseDirectory::GetIcon(const CStdString &strDirectory)
   case NODE_TYPE_TITLE_MOVIES:
     if (strDirectory.Equals("videodb://1/2/"))
     {
-      if (g_settings.m_bMyVideoNavFlatten)
+      if (g_guiSettings.GetBool("myvideos.flatten"))
         return "DefaultMovies.png";
       return "DefaultMovieTitle.png";
     }
@@ -237,7 +237,7 @@ CStdString CVideoDatabaseDirectory::GetIcon(const CStdString &strDirectory)
   case NODE_TYPE_TITLE_TVSHOWS:
     if (strDirectory.Equals("videodb://2/2/"))
     {
-      if (g_settings.m_bMyVideoNavFlatten)
+      if (g_guiSettings.GetBool("myvideos.flatten"))
         return "DefaultTVShows.png";
       return "DefaultTVShowTitle.png";
     }
@@ -245,7 +245,7 @@ CStdString CVideoDatabaseDirectory::GetIcon(const CStdString &strDirectory)
   case NODE_TYPE_TITLE_MUSICVIDEOS:
     if (strDirectory.Equals("videodb://3/2/"))
     {
-      if (g_settings.m_bMyVideoNavFlatten)
+      if (g_guiSettings.GetBool("myvideos.flatten"))
         return "DefaultMusicVideos.png";
       return "DefaultMusicVideoTitle.png";
     }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -20,7 +20,7 @@
 
 #include "video/VideoDatabase.h"
 #include "DirectoryNodeOverview.h"
-#include "settings/Settings.h"
+#include "settings/GUISettings.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
 #include "video/VideoDbUrl.h"
@@ -71,21 +71,21 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
   vector<pair<const char*, int> > vec;
   if (hasMovies)
   {
-    if (g_settings.m_bMyVideoNavFlatten)
+    if (g_guiSettings.GetBool("myvideos.flatten"))
       vec.push_back(make_pair("1/2", 342));
     else
       vec.push_back(make_pair("1", 342));   // Movies
   }
   if (hasTvShows)
   {
-    if (g_settings.m_bMyVideoNavFlatten)
+    if (g_guiSettings.GetBool("myvideos.flatten"))
       vec.push_back(make_pair("2/2", 20343));
     else
       vec.push_back(make_pair("2", 20343)); // TV Shows
   }
   if (hasMusicVideos)
   {
-    if (g_settings.m_bMyVideoNavFlatten)
+    if (g_guiSettings.GetBool("myvideos.flatten"))
       vec.push_back(make_pair("3/2", 20389));
     else
       vec.push_back(make_pair("3", 20389)); // Music Videos

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -24,7 +24,7 @@
 #include "utils/URIUtils.h"
 #include "utils/JobManager.h"
 #include "FileItem.h"
-#include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 #include "Key.h"
 #include "TextureCache.h"
 #include "WindowIDs.h"
@@ -312,7 +312,7 @@ bool CGUIMultiImage::CMultiImageJob::DoWork()
 
     URIUtils::AddSlashAtEnd(realPath);
     CFileItemList items;
-    CDirectory::GetDirectory(realPath, items, g_settings.m_pictureExtensions + "|.tbn|.dds", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
+    CDirectory::GetDirectory(realPath, items, g_advancedSettings.m_pictureExtensions + "|.tbn|.dds", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
     for (int i=0; i < items.Size(); i++)
     {
       CFileItem* pItem = items[i].get();

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -28,7 +28,6 @@
 #include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "addons/Skin.h"
 #include "GUITexture.h"
@@ -361,7 +360,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<CStd
   // virtual music window which returns the last open music window (aka the music start window)
   if (iWindowID == WINDOW_MUSIC)
   {
-    iWindowID = g_settings.m_iMyMusicStartWindow;
+    iWindowID = g_guiSettings.GetInt("mymusic.startwindow");
     // ensure the music virtual window only returns music files and music library windows
     if (iWindowID != WINDOW_MUSIC_NAV)
       iWindowID = WINDOW_MUSIC_FILES;

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -51,6 +51,7 @@
 #include "profiles/ProfilesManager.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
+#include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SkinSettings.h"
 #include "utils/StringUtils.h"
@@ -577,7 +578,7 @@ int CBuiltins::Execute(const CStdString& execString)
       if (params[i].Equals("isdir"))
         item.m_bIsFolder = true;
       else if (params[i].Equals("1")) // set fullscreen or windowed
-        g_settings.m_bStartVideoWindowed = true;
+        CMediaSettings::Get().SetVideoStartWindowed(true);
       else if (params[i].Equals("resume"))
       {
         // force the item to resume (if applicable) (see CApplication::PlayMedia)
@@ -833,11 +834,11 @@ int CBuiltins::Execute(const CStdString& execString)
       switch (iPlaylist)
       {
       case PLAYLIST_MUSIC:
-        g_settings.m_bMyMusicPlaylistShuffle = g_playlistPlayer.IsShuffled(iPlaylist);
+        CMediaSettings::Get().SetMusicPlaylistShuffled(g_playlistPlayer.IsShuffled(iPlaylist));
         g_settings.Save();
         break;
       case PLAYLIST_VIDEO:
-        g_settings.m_bMyVideoPlaylistShuffle = g_playlistPlayer.IsShuffled(iPlaylist);
+        CMediaSettings::Get().SetVideoPlaylistShuffled(g_playlistPlayer.IsShuffled(iPlaylist));
         g_settings.Save();
       }
 
@@ -877,11 +878,11 @@ int CBuiltins::Execute(const CStdString& execString)
       switch (iPlaylist)
       {
       case PLAYLIST_MUSIC:
-        g_settings.m_bMyMusicPlaylistRepeat = (state == PLAYLIST::REPEAT_ALL);
+        CMediaSettings::Get().SetMusicPlaylistRepeat(state == PLAYLIST::REPEAT_ALL);
         g_settings.Save();
         break;
       case PLAYLIST_VIDEO:
-        g_settings.m_bMyVideoPlaylistRepeat = (state == PLAYLIST::REPEAT_ALL);
+        CMediaSettings::Get().SetVideoPlaylistRepeat(state == PLAYLIST::REPEAT_ALL);
         g_settings.Save();
       }
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -902,11 +902,11 @@ int CBuiltins::Execute(const CStdString& execString)
   }
   else if (execute.Equals("setvolume"))
   {
-    int oldVolume = g_application.GetVolume();
+    float oldVolume = g_application.GetVolume();
     float volume = (float)strtod(parameter.c_str(), NULL);
 
     g_application.SetVolume(volume);
-    if(oldVolume != (int)volume)
+    if(oldVolume != volume)
     {
       if(params.size() > 1 && params[1].Equals("showVolumeBar"))    
       {

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -606,7 +606,7 @@ int CBuiltins::Execute(const CStdString& execString)
     if (item.m_bIsFolder)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(),items,g_settings.m_videoExtensions);
+      CDirectory::GetDirectory(item.GetPath(),items,g_advancedSettings.m_videoExtensions);
       int playlist = PLAYLIST_MUSIC;
       for (int i = 0; i < items.Size(); i++)
       {

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -54,7 +54,7 @@ JSONRPC_STATUS CApplicationOperations::SetVolume(const CStdString &method, ITran
   bool up = false;
   if (parameterObject["volume"].isInteger())
   {
-    int oldVolume = g_application.GetVolume();
+    int oldVolume = (int)g_application.GetVolume();
     int volume = (int)parameterObject["volume"].asInteger();
   
     g_application.SetVolume((float)volume, true);

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -21,7 +21,6 @@
 #include "FileOperations.h"
 #include "VideoLibrary.h"
 #include "AudioLibrary.h"
-#include "settings/Settings.h"
 #include "MediaSource.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
@@ -99,17 +98,17 @@ JSONRPC_STATUS CFileOperations::GetDirectory(const CStdString &method, ITranspor
   if (media.Equals("video"))
   {
     regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
-    extensions = g_settings.m_videoExtensions;
+    extensions = g_advancedSettings.m_videoExtensions;
   }
   else if (media.Equals("music"))
   {
     regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
-    extensions = g_settings.m_musicExtensions;
+    extensions = g_advancedSettings.m_musicExtensions;
   }
   else if (media.Equals("pictures"))
   {
     regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
-    extensions = g_settings.m_pictureExtensions;
+    extensions = g_advancedSettings.m_pictureExtensions;
   }
 
   if (CDirectory::GetDirectory(strPath, items, extensions))
@@ -310,17 +309,17 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
       if (media.Equals("video"))
       {
         regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
-        extensions = g_settings.m_videoExtensions;
+        extensions = g_advancedSettings.m_videoExtensions;
       }
       else if (media.Equals("music"))
       {
         regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
-        extensions = g_settings.m_musicExtensions;
+        extensions = g_advancedSettings.m_musicExtensions;
       }
       else if (media.Equals("pictures"))
       {
         regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
-        extensions = g_settings.m_pictureExtensions;
+        extensions = g_advancedSettings.m_pictureExtensions;
       }
 
       CDirectory directory;

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -36,6 +36,7 @@
 #include "XTimeUtils.h"
 #endif
 #include "guilib/LocalizeStrings.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIAudioManager.h"
@@ -45,7 +46,6 @@
 #include "utils/Crc32.h"
 #include "FileItem.h"
 #include "LangInfo.h"
-#include "settings/Settings.h"
 #include "guilib/TextureManager.h"
 #include "Util.h"
 #include "URL.h"
@@ -409,11 +409,11 @@ namespace XBMCAddon
       TRACE;
       String result;
       if (strcmpi(mediaType, "video") == 0)
-        result = g_settings.m_videoExtensions;
+        result = g_advancedSettings.m_videoExtensions;
       else if (strcmpi(mediaType, "music") == 0)
-        result = g_settings.m_musicExtensions;
+        result = g_advancedSettings.m_musicExtensions;
       else if (strcmpi(mediaType, "picture") == 0)
-        result = g_settings.m_pictureExtensions;
+        result = g_advancedSettings.m_pictureExtensions;
 
       // TODO:
       //    else

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -23,7 +23,6 @@
 #include "ListItem.h"
 #include "PlayList.h"
 #include "PlayListPlayer.h"
-#include "settings/Settings.h"
 #include "settings/MediaSettings.h"
 #include "Application.h"
 #include "ApplicationMessenger.h"
@@ -74,7 +73,7 @@ namespace XBMCAddon
       if (!item.empty())
       {
         // set fullscreen or windowed
-        g_settings.m_bStartVideoWindowed = windowed;
+        CMediaSettings::Get().SetVideoStartWindowed(windowed);
 
         // force a playercore before playing
         g_application.m_eForcedNextPlayer = playerCore;
@@ -102,7 +101,7 @@ namespace XBMCAddon
       TRACE;
       DelayedCallGuard dc(languageHook);
       // set fullscreen or windowed
-      g_settings.m_bStartVideoWindowed = windowed;
+      CMediaSettings::Get().SetVideoStartWindowed(windowed);
 
       // force a playercore before playing
       g_application.m_eForcedNextPlayer = playerCore;
@@ -120,7 +119,7 @@ namespace XBMCAddon
       if (playlist != NULL)
       {
         // set fullscreen or windowed
-        g_settings.m_bStartVideoWindowed = windowed;
+        CMediaSettings::Get().SetVideoStartWindowed(windowed);
 
         // force a playercore before playing
         g_application.m_eForcedNextPlayer = playerCore;

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -24,7 +24,6 @@
 #include "settings/GUISettings.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
-#include "settings/Settings.h"
 #include "FileItem.h"
 #include "guilib/WindowIDs.h"
 #include "Util.h"
@@ -58,7 +57,7 @@ CStdString CGUIViewStateWindowMusic::GetLockType()
 
 CStdString CGUIViewStateWindowMusic::GetExtensions()
 {
-  return g_settings.m_musicExtensions;
+  return g_advancedSettings.m_musicExtensions;
 }
 
 VECSOURCES& CGUIViewStateWindowMusic::GetSources()

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -44,6 +44,7 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "filesystem/File.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/MediaSettings.h"
 #include "settings/GUISettings.h"
 #include "settings/AdvancedSettings.h"
 #include "FileItem.h"
@@ -3679,7 +3680,7 @@ bool CMusicDatabase::UpdateOldVersion(int version)
   {
     m_pDS->exec("DROP TABLE thumb");
 
-    g_settings.m_musicNeedsUpdate = 27;
+    CMediaSettings::Get().SetMusicNeedsUpdate(27);
     g_settings.Save();
   }
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -40,7 +40,6 @@
 #include "filesystem/Directory.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
@@ -392,7 +391,7 @@ bool CMusicInfoScanner::DoScan(const CStdString& strDirectory)
 
   // load subfolder
   CFileItemList items;
-  CDirectory::GetDirectory(strDirectory, items, g_settings.m_musicExtensions + "|.jpg|.tbn|.lrc|.cdg");
+  CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_musicExtensions + "|.jpg|.tbn|.lrc|.cdg");
 
   // sort and get the path hash.  Note that we don't filter .cue sheet items here as we want
   // to detect changes in the .cue sheet as well.  The .cue sheet items only need filtering
@@ -858,7 +857,7 @@ int CMusicInfoScanner::CountFilesRecursively(const CStdString& strPath)
   // load subfolder
   CFileItemList items;
 //  CLog::Log(LOGDEBUG, __FUNCTION__" - processing dir: %s", strPath.c_str());
-  CDirectory::GetDirectory(strPath, items, g_settings.m_musicExtensions, DIR_FLAG_NO_FILE_DIRS);
+  CDirectory::GetDirectory(strPath, items, g_advancedSettings.m_musicExtensions, DIR_FLAG_NO_FILE_DIRS);
 
   if (m_bStop)
     return 0;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -146,9 +146,9 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
 
       // save current window, unless the current window is the music playlist window
       if (GetID() != WINDOW_MUSIC_PLAYLIST &&
-          g_settings.m_iMyMusicStartWindow != GetID())
+          g_guiSettings.GetInt("mymusic.startwindow") != GetID())
       {
-        g_settings.m_iMyMusicStartWindow = GetID();
+        g_guiSettings.SetInt("mymusic.startwindow", GetID());
         g_settings.Save();
       }
 
@@ -175,11 +175,11 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
         if (nWindow == GetID())
           return true;
 
-        g_settings.m_iMyMusicStartWindow = nWindow;
+        g_guiSettings.SetInt("mymusic.startwindow", nWindow);
         g_settings.Save();
         g_windowManager.ChangeActiveWindow(nWindow);
 
-        CGUIMessage msg2(GUI_MSG_SETFOCUS, g_settings.m_iMyMusicStartWindow, CONTROL_BTNTYPE);
+        CGUIMessage msg2(GUI_MSG_SETFOCUS, g_guiSettings.GetInt("mymusic.startwindow"), CONTROL_BTNTYPE);
         g_windowManager.SendMessage(msg2);
 
         return true;
@@ -779,7 +779,7 @@ void CGUIWindowMusicBase::UpdateButtons()
   g_windowManager.SendMessage(msg2);
 
   // Select the current window as default item
-  CONTROL_SELECT_ITEM(CONTROL_BTNTYPE, g_settings.m_iMyMusicStartWindow - WINDOW_MUSIC_FILES);
+  CONTROL_SELECT_ITEM(CONTROL_BTNTYPE, g_guiSettings.GetInt("mymusic.startwindow") - WINDOW_MUSIC_FILES);
 
   CGUIMediaWindow::UpdateButtons();
 }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -58,6 +58,7 @@
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
+#include "settings/MediaSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
@@ -1359,14 +1360,14 @@ bool CGUIWindowMusicBase::CanContainFilter(const CStdString &strDirectory) const
 void CGUIWindowMusicBase::OnInitWindow()
 {
   CGUIMediaWindow::OnInitWindow();
-  if (g_settings.m_musicNeedsUpdate == 27 && !g_application.IsMusicScanning() &&
+  if (CMediaSettings::Get().GetMusicNeedsUpdate() == 27 && !g_application.IsMusicScanning() &&
       g_infoManager.GetLibraryBool(LIBRARY_HAS_MUSIC))
   {
     // rescan of music library required
     if (CGUIDialogYesNo::ShowAndGetInput(799, 800, 801, -1))
     {
       g_application.StartMusicScan("", CMusicInfoScanner::SCAN_RESCAN);
-      g_settings.m_musicNeedsUpdate = 0; // once is enough (user may interrupt, but that's up to them)
+      CMediaSettings::Get().SetMusicNeedsUpdate(0); // once is enough (user may interrupt, but that's up to them)
       g_settings.Save();
     }
   }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -46,6 +46,7 @@
 #include "ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/GUISettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -102,7 +103,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
 
       // is this the first time the window is opened?
       if (m_vecItems->GetPath() == "?" && message.GetStringParam().IsEmpty())
-        message.SetStringParam(g_settings.m_defaultMusicLibSource);
+        message.SetStringParam(g_guiSettings.GetString("mymusic.defaultlibview"));
       
       DisplayEmptyDatabaseMessage(false); // reset message state
 
@@ -482,9 +483,9 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
          nodetype == NODE_TYPE_OVERVIEW ||
          nodetype == NODE_TYPE_TOP100))
     {
-      if (!item->GetPath().Equals(g_settings.m_defaultMusicLibSource))
+      if (!item->GetPath().Equals(g_guiSettings.GetString("mymusic.defaultlibview")))
         buttons.Add(CONTEXT_BUTTON_SET_DEFAULT, 13335); // set default
-      if (strcmp(g_settings.m_defaultMusicLibSource, ""))
+      if (strcmp(g_guiSettings.GetString("mymusic.defaultlibview"), ""))
         buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // clear default
     }
     NODE_TYPE childtype = dir.GetDirectoryChildType(item->GetPath());
@@ -621,12 +622,12 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
 
   case CONTEXT_BUTTON_SET_DEFAULT:
-    g_settings.m_defaultMusicLibSource = GetQuickpathName(item->GetPath());
+    g_guiSettings.SetString("mymusic.defaultlibview", GetQuickpathName(item->GetPath()));
     g_settings.Save();
     return true;
 
   case CONTEXT_BUTTON_CLEAR_DEFAULT:
-    g_settings.m_defaultMusicLibSource.Empty();
+    g_guiSettings.SetString("mymusic.defaultlibview", "");
     g_settings.Save();
     return true;
 

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -35,6 +35,7 @@
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
+#include "settings/MediaSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -138,7 +139,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
         if (!g_partyModeManager.IsEnabled())
         {
           g_playlistPlayer.SetShuffle(PLAYLIST_MUSIC, !(g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC)));
-          g_settings.m_bMyMusicPlaylistShuffle = g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC);
+          CMediaSettings::Get().SetMusicPlaylistShuffled(g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC));
           g_settings.Save();
           UpdateButtons();
           Refresh();
@@ -188,7 +189,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
           g_playlistPlayer.SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_NONE);
 
         // save settings
-        g_settings.m_bMyMusicPlaylistRepeat = g_playlistPlayer.GetRepeat(PLAYLIST_MUSIC) == PLAYLIST::REPEAT_ALL;
+        CMediaSettings::Get().SetMusicPlaylistRepeat(g_playlistPlayer.GetRepeat(PLAYLIST_MUSIC) == PLAYLIST::REPEAT_ALL);
         g_settings.Save();
 
         UpdateButtons();

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -28,6 +28,7 @@
 #include "guilib/Key.h"
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/GUISettings.h"
 
 using namespace MUSIC_INFO;
 
@@ -59,7 +60,7 @@ bool CGUIWindowVisualisation::OnAction(const CAction &action)
   case ACTION_SHOW_INFO:
     {
       m_initTimer.Stop();
-      g_settings.m_bMyMusicSongThumbInVis = g_infoManager.ToggleShowInfo();
+      g_guiSettings.SetBool("mymusic.songthumbinvis", g_infoManager.ToggleShowInfo());
       return true;
     }
     break;
@@ -176,7 +177,7 @@ bool CGUIWindowVisualisation::OnMessage(CGUIMessage& message)
       if (g_infoManager.GetCurrentSongTag())
         m_tag = *g_infoManager.GetCurrentSongTag();
 
-      if (g_settings.m_bMyMusicSongThumbInVis)
+      if (g_guiSettings.GetBool("mymusic.songthumbinvis"))
       { // always on
         m_initTimer.Stop();
       }
@@ -227,7 +228,7 @@ void CGUIWindowVisualisation::FrameMove()
   if (m_initTimer.IsRunning() && m_initTimer.GetElapsedSeconds() > (float)g_advancedSettings.m_songInfoDuration)
   {
     m_initTimer.Stop();
-    if (!g_settings.m_bMyMusicSongThumbInVis)
+    if (!g_guiSettings.GetBool("mymusic.songthumbinvis"))
     { // reached end of fade in, fade out again
       g_infoManager.SetShowInfo(false);
     }

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -685,7 +685,7 @@ bool CAirPlayServer::CTCPClient::checkAuthorization(const CStdString& authStr,
 void CAirPlayServer::backupVolume()
 {
   if (ServerInstance->m_origVolume == -1)
-    ServerInstance->m_origVolume = g_application.GetVolume();
+    ServerInstance->m_origVolume = (int)g_application.GetVolume();
 }
 
 void CAirPlayServer::restoreVolume()
@@ -782,9 +782,9 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       }
       else if (volume >= 0 && volume <= 1)
       {
-        int oldVolume = g_application.GetVolume();
+        float oldVolume = g_application.GetVolume();
         volume *= 100;
-        if(oldVolume != (int)volume)
+        if(oldVolume != volume)
         {
           backupVolume();
           g_application.SetVolume(volume);          

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -637,7 +637,7 @@ CUPnPRenderer::OnSetMute(PLT_ActionReference& action)
 {
     NPT_String mute;
     NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredMute",mute));
-    if((mute == "1") ^ g_settings.m_bMute)
+    if((mute == "1") ^ g_application.IsMuted())
         g_application.ToggleMute();
     return NPT_SUCCESS;
 }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -13,7 +13,7 @@
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "guilib/WindowIDs.h"
 #include "music/tags/MusicInfoTag.h"
-#include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
 #include "utils/log.h"
 #include "utils/md5.h"
@@ -606,10 +606,10 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
             // this is the only way to hide unplayable items in the 'files'
             // view as we cannot tell what context (eg music vs video) the
             // request came from
-            string supported = g_settings.m_pictureExtensions + "|"
-                             + g_settings.m_videoExtensions + "|"
-                             + g_settings.m_musicExtensions + "|"
-                             + g_settings.m_discStubExtensions;
+            string supported = g_advancedSettings.m_pictureExtensions + "|"
+                             + g_advancedSettings.m_videoExtensions + "|"
+                             + g_advancedSettings.m_musicExtensions + "|"
+                             + g_advancedSettings.m_discStubExtensions;
             CDirectory::GetDirectory((const char*)parent_id, items, supported);
             DefaultSortItems(items);
         }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -34,7 +34,6 @@
 #include "peripherals/bus/PeripheralBus.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
 
@@ -1501,8 +1500,8 @@ CStdString CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
 
     // set amp present
     m_adapter->SetAudioSystemConnected(true);
-    g_settings.m_bMute = false;
-    g_settings.m_fVolumeLevel = VOLUME_MAXIMUM;
+    g_application.SetMute(false);
+    g_application.SetVolume(VOLUME_MAXIMUM, false);
   }
   else
   {

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -23,7 +23,6 @@
 #include "view/ViewState.h"
 #include "settings/GUISettings.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
 #include "settings/MediaSourceSettings.h"
 #include "filesystem/Directory.h"
 #include "filesystem/PluginDirectory.h"
@@ -75,9 +74,9 @@ CStdString CGUIViewStateWindowPictures::GetLockType()
 CStdString CGUIViewStateWindowPictures::GetExtensions()
 {
   if (g_guiSettings.GetBool("pictures.showvideos"))
-    return g_settings.m_pictureExtensions+"|"+g_settings.m_videoExtensions;
+    return g_advancedSettings.m_pictureExtensions+"|"+g_advancedSettings.m_videoExtensions;
 
-  return g_settings.m_pictureExtensions;
+  return g_advancedSettings.m_pictureExtensions;
 }
 
 VECSOURCES& CGUIViewStateWindowPictures::GetSources()

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -33,8 +33,8 @@
 #include "GUIDialogPictureInfo.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
-#include "settings/Settings.h"
 #include "settings/GUISettings.h"
 #include "FileItem.h"
 #include "guilib/Texture.h"
@@ -1146,7 +1146,7 @@ void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursiv
 
   // fetch directory and sort accordingly
   CFileItemList items;
-  if (!CDirectory::GetDirectory(strPath, items, m_strExtensions.IsEmpty()?g_settings.m_pictureExtensions:m_strExtensions,DIR_FLAG_NO_FILE_DIRS,true))
+  if (!CDirectory::GetDirectory(strPath, items, m_strExtensions.IsEmpty()?g_advancedSettings.m_pictureExtensions:m_strExtensions,DIR_FLAG_NO_FILE_DIRS,true))
     return;
 
   items.Sort(method, order);

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -29,7 +29,6 @@
 #include "GUIUserMessages.h"
 #include "settings/GUISettings.h"
 #include "utils/URIUtils.h"
-#include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "video/VideoThumbLoader.h"
 
@@ -165,7 +164,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
       CFileItemList items;
 
-      CDirectory::GetDirectory(strPath, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
+      CDirectory::GetDirectory(strPath, items, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
       
       // create the folder thumb by choosing 4 random thumbs within the folder and putting
       // them into one thumb.
@@ -184,7 +183,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       {
         if (pItem->IsCBZ() || pItem->IsCBR())
         {
-          CDirectory::GetDirectory(strPath, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
+          CDirectory::GetDirectory(strPath, items, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
           for (int i=0;i<items.Size();++i)
           {
             CFileItemPtr item = items[i];

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -20,6 +20,7 @@
 
 #include "SlideShowPicture.h"
 #include "system.h"
+#include "guilib/GraphicContext.h"
 #include "guilib/Texture.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -345,7 +345,6 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
           CStdString path = URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_strDirectory);
           path = URIUtils::AddFileToFolder(path, "guisettings.xml");
           CSettings settings;
-          settings.Initialize();
           settings.SaveSettings(path, &localSettings);
         }
       }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -115,7 +115,7 @@ bool CPVRManager::InstallAddonAllowed(const std::string& strAddonId) const
 
 void CPVRManager::MarkAsOutdated(const std::string& strAddonId, const std::string& strReferer)
 {
-  if (IsStarted() && g_settings.m_bAddonAutoUpdate)
+  if (IsStarted() && g_guiSettings.GetBool("general.addonautoupdate"))
   {
     CSingleLock lock(m_critSection);
     m_outdatedAddons.insert(make_pair<string, string>(strAddonId, strReferer));

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -31,6 +31,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
+#include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "windows/GUIWindowPVR.h"
@@ -1017,7 +1018,7 @@ bool CPVRManager::UpdateItem(CFileItem& item)
 
 bool CPVRManager::StartPlayback(const CPVRChannel *channel, bool bPreview /* = false */)
 {
-  g_settings.m_bStartVideoWindowed = bPreview;
+  CMediaSettings::Get().SetVideoStartWindowed(bPreview);
   CApplicationMessenger::Get().MediaPlay(CFileItem(*channel));
   CLog::Log(LOGNOTICE, "PVRManager - %s - started playback on channel '%s'",
       __FUNCTION__, channel->ChannelName().c_str());

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -29,6 +29,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/PVRDatabase.h"
 #include "guilib/GUIWindowManager.h"
+#include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/MediaSettings.h"
 #include "pvr/channels/PVRChannelGroups.h"
@@ -1097,8 +1098,8 @@ void CPVRClients::LoadCurrentChannelSettings(void)
       CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = loadedChannelSettings.m_ViewMode;
 
       g_renderManager.SetViewMode(CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode);
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = g_settings.m_fZoomAmount;
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio = g_settings.m_fPixelRatio;
+      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = CDisplaySettings::Get().GetZoomAmount();
+      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio = CDisplaySettings::Get().GetPixelRatio();
     }
 
     /* only change the subtitle stream, if it's different */

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -42,6 +42,7 @@
 #include "pvr/windows/GUIWindowPVRSearch.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "settings/GUISettings.h"
+#include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -689,7 +690,7 @@ bool CGUIWindowPVRCommon::PlayFile(CFileItem *item, bool bPlayMinimized /* = fal
     return true;
   }
 
-  g_settings.m_bStartVideoWindowed = bPlayMinimized;
+  CMediaSettings::Get().SetVideoStartWindowed(bPlayMinimized);
 
   if (item->HasPVRRecordingInfoTag())
   {

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -365,6 +365,16 @@ class CAdvancedSettings : public ISettingsHandler
     bool m_initialized;
 
     void SetDebugMode(bool debug);
+
+    // runtime settings which cannot be set from advancedsettings.xml
+    CStdString m_pictureExtensions;
+    CStdString m_musicExtensions;
+    CStdString m_videoExtensions;
+    CStdString m_discStubExtensions;
+
+    CStdString m_logFolder;
+
+    CStdString m_userAgent;
 };
 
 XBMC_GLOBAL(CAdvancedSettings,g_advancedSettings);

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -44,6 +44,11 @@ float square_error(float x, float y)
 CDisplaySettings::CDisplaySettings()
 {
   m_resolutions.insert(m_resolutions.begin(), RES_CUSTOM, RESOLUTION_INFO());
+
+  m_zoomAmount = 1.0f;
+  m_pixelRatio = 1.0f;
+  m_verticalShift = 0.0f;
+  m_nonLinearStretched = false;
 }
 
 CDisplaySettings::~CDisplaySettings()
@@ -169,6 +174,11 @@ void CDisplaySettings::Clear()
   CSingleLock lock(m_critical);
   m_calibrations.clear();
   m_resolutions.clear();
+
+  m_zoomAmount = 1.0f;
+  m_pixelRatio = 1.0f;
+  m_verticalShift = 0.0f;
+  m_nonLinearStretched = false;
 }
 
 void CDisplaySettings::SetCurrentResolution(RESOLUTION resolution, bool save /* = false */)

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -71,6 +71,15 @@ public:
   void ApplyCalibrations();
   void UpdateCalibrations();
 
+  float GetZoomAmount() const { return m_zoomAmount; }
+  void SetZoomAmount(float zoomAmount) { m_zoomAmount = zoomAmount; }
+  float GetPixelRatio() const { return m_pixelRatio; }
+  void SetPixelRatio(float pixelRatio) { m_pixelRatio = pixelRatio; }
+  float GetVerticalShift() const { return m_verticalShift; }
+  void SetVerticalShift(float verticalShift) { m_verticalShift = verticalShift; }
+  bool IsNonLinearStretched() const { return m_nonLinearStretched; }
+  void SetNonLinearStretched(bool nonLinearStretch) { m_nonLinearStretched = nonLinearStretch; }
+
 protected:
   CDisplaySettings();
   CDisplaySettings(const CDisplaySettings&);
@@ -86,5 +95,10 @@ private:
   typedef std::vector<RESOLUTION_INFO> ResolutionInfos;
   ResolutionInfos m_resolutions;
   ResolutionInfos m_calibrations;
+
+  float m_zoomAmount;         // current zoom amount
+  float m_pixelRatio;         // current pixel ratio
+  float m_verticalShift;      // current vertical shift
+  bool  m_nonLinearStretched;   // current non-linear stretch
   CCriticalSection m_critical;
 };

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -807,6 +807,11 @@ void CGUISettings::Initialize()
   AddBool(vid, "myvideos.replacelabels", 20419, true);
   AddBool(NULL, "myvideos.extractthumb",20433, true);
 
+  AddSeparator(NULL, "myvideos.sep1");
+  AddInt(NULL, "myvideos.startwindow", 0, WINDOW_VIDEO_FILES, WINDOW_VIDEO_FILES, 1, WINDOW_VIDEO_NAV, SPIN_CONTROL_INT);
+  AddBool(NULL, "myvideos.stackvideos", 0, false);
+  AddBool(NULL, "myvideos.flatten", 0, false);
+
   CSettingsCategory* sub = AddCategory(SETTINGS_VIDEOS, "subtitles", 287);
   AddString(sub, "subtitles.font", 14089, "arial.ttf", SPIN_CONTROL_TEXT);
   AddInt(sub, "subtitles.height", 289, 28, 16, 2, 74, SPIN_CONTROL_TEXT); // use text as there is a disk based lookup needed
@@ -956,6 +961,14 @@ void CGUISettings::Initialize()
   AddInt(NULL, "window.height", 0, 480, 10, 1, INT_MAX, SPIN_CONTROL_INT);
 
   AddPath(NULL,"system.playlistspath",20006,"set default",BUTTON_CONTROL_PATH_INPUT,false);
+
+  AddInt(NULL, "mymusic.startwindow", 0, WINDOW_MUSIC_FILES, WINDOW_MUSIC_FILES, 1, WINDOW_MUSIC_NAV, SPIN_CONTROL_INT);
+  AddBool(NULL, "mymusic.songthumbinvis", 0, false);
+  AddString(NULL, "mymusic.defaultlibview", 0, "", BUTTON_CONTROL_STANDARD);
+
+  AddBool(NULL, "general.addonautoupdate", 0, true);
+  AddBool(NULL, "general.addonnotifications", 0, true);
+  AddBool(NULL, "general.addonforeignfilter", 0, false);
 
   // tv settings (access over TV menu from home window)
   AddGroup(SETTINGS_PVR, 19180);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -89,6 +89,18 @@ using namespace PVR;
 #endif
 #endif
 
+#define DEFAULT_WEB_INTERFACE "webinterface.default"
+
+#ifdef MID
+#define DEFAULT_VSYNC       VSYNC_DISABLED
+#else  // MID
+#if defined(TARGET_DARWIN) || defined(_WIN32) || defined(TARGET_RASPBERRY_PI)
+#define DEFAULT_VSYNC       VSYNC_ALWAYS
+#else
+#define DEFAULT_VSYNC       VSYNC_DRIVER
+#endif
+#endif // MID
+
 struct sortsettings
 {
   bool operator()(const CSetting* pSetting1, const CSetting* pSetting2)

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -27,6 +27,17 @@
 #include "utils/Observer.h"
 #include "utils/GlobalsHandling.h"
 
+//FIXME - after eden - make that one nicer somehow...
+#if defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV2)
+#include "system.h" //for HAS_SKIN_TOUCHED
+#endif
+
+#if defined(HAS_SKIN_TOUCHED) && defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV2)
+#define DEFAULT_SKIN          "skin.touched"
+#else
+#define DEFAULT_SKIN          "skin.confluence"
+#endif
+
 class TiXmlNode;
 class TiXmlElement;
 

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -70,6 +70,26 @@ public:
    */
   void CycleWatchedMode(const std::string &content);
 
+  bool DoesMusicPlaylistRepeat() const { return m_musicPlaylistRepeat; }
+  void SetMusicPlaylistRepeat(bool repeats) { m_musicPlaylistRepeat = repeats; }
+  bool IsMusicPlaylistShuffled() const { return m_musicPlaylistShuffle; }
+  void SetMusicPlaylistShuffled(bool shuffled) { m_musicPlaylistShuffle = shuffled; }
+
+  bool DoesVideoPlaylistRepeat() const { return m_videoPlaylistRepeat; }
+  void SetVideoPlaylistRepeat(bool repeats) { m_videoPlaylistRepeat = repeats; }
+  bool IsVideoPlaylistShuffled() const { return m_videoPlaylistShuffle; }
+  void SetVideoPlaylistShuffled(bool shuffled) { m_videoPlaylistShuffle = shuffled; }
+
+  bool DoesVideoStartWindowed() const { return m_videoStartWindowed; }
+  void SetVideoStartWindowed(bool windowed) { m_videoStartWindowed = windowed; }
+  int GetAdditionalSubtitleDirectoryChecked() const { return m_additionalSubtitleDirectoryChecked; }
+  void SetAdditionalSubtitleDirectoryChecked(int checked) { m_additionalSubtitleDirectoryChecked = checked; }
+
+  int GetMusicNeedsUpdate() const { return m_musicNeedsUpdate; }
+  void SetMusicNeedsUpdate(int version) { m_musicNeedsUpdate = version; }
+  int GetVideoNeedsUpdate() const { return m_videoNeedsUpdate; }
+  void SetVideoNeedsUpdate(int version) { m_videoNeedsUpdate = version; }
+
 protected:
   CMediaSettings();
   CMediaSettings(const CMediaSettings&);
@@ -84,6 +104,17 @@ private:
 
   typedef std::map<std::string, WatchedMode> WatchedModes;
   WatchedModes m_watchedModes;
+
+  bool m_musicPlaylistRepeat;
+  bool m_musicPlaylistShuffle;
+  bool m_videoPlaylistRepeat;
+  bool m_videoPlaylistShuffle;
+
+  bool m_videoStartWindowed;
+  int m_additionalSubtitleDirectoryChecked;
+
+  int m_musicNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
+  int m_videoNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
 
   CCriticalSection m_critical;
 };

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -27,7 +27,6 @@
 #include "settings/GUISettings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
-#include "utils/SystemInfo.h"
 #include "utils/XMLUtils.h"
 
 using namespace std;
@@ -94,30 +93,11 @@ void CSettings::Initialize()
   m_fVolumeLevel = 1.0f;
   m_bMute = false;
 
-  m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.cbr|.rar|.m3u|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss";
-  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.mod|.amf|.669|.dmf|.dsm|.far|.gdm|.imf|.it|.m15|.med|.okt|.s3m|.stm|.sfx|.ult|.uni|.xm|.sid|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.nsf|.spc|.gym|.adx|.dsp|.adp|.ymf|.ast|.afc|.hps|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.mid|.kar|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.cm3|.cms|.dlt|.brstm|.wtv|.mka";
-  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
-  m_discStubExtensions = ".disc";
-  // internal music extensions
-  m_musicExtensions += "|.sidstream|.oggstream|.nsfstream|.asapstream|.cdda";
-  // internal video extensions
-  m_videoExtensions += "|.pvr";
-
-  #if defined(TARGET_DARWIN)
-    CStdString logDir = getenv("HOME");
-    logDir += "/Library/Logs/";
-    m_logFolder = logDir;
-  #else
-    m_logFolder = "special://home/";              // log file location
-  #endif
-
   iAdditionalSubtitleDirectoryChecked = 0;
   m_iMyMusicStartWindow = WINDOW_MUSIC_FILES;
   m_iVideoStartWindow = WINDOW_VIDEO_FILES;
 
   m_iSystemTimeTotalUp = 0;
-
-  m_userAgent = g_sysinfo.GetUserAgent();
 
   m_musicNeedsUpdate = 0;
   m_videoNeedsUpdate = 0;
@@ -132,7 +112,6 @@ CSettings::~CSettings(void)
 
   Clear();
 }
-
 
 void CSettings::Save() const
 {
@@ -376,14 +355,6 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
 
 void CSettings::Clear()
 {
-  m_pictureExtensions.clear();
-  m_musicExtensions.clear();
-  m_videoExtensions.clear();
-  m_discStubExtensions.clear();
-
-  m_logFolder.clear();
-  m_userAgent.clear();
-
   m_defaultMusicLibSource.clear();
 
   OnSettingsCleared();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -78,14 +78,7 @@ void CSettings::Initialize()
 
   m_bMyMusicSongInfoInVis = true;    // UNUSED - depreciated.
   m_bMyMusicSongThumbInVis = false;  // used for music info in vis screen
-
-  m_bMyMusicPlaylistRepeat = false;
-  m_bMyMusicPlaylistShuffle = false;
-
-  m_bMyVideoPlaylistRepeat = false;
-  m_bMyVideoPlaylistShuffle = false;
   m_bMyVideoNavFlatten = false;
-  m_bStartVideoWindowed = false;
   m_bAddonAutoUpdate = true;
   m_bAddonNotifications = true;
   m_bAddonForeignFilter = false;
@@ -93,14 +86,10 @@ void CSettings::Initialize()
   m_fVolumeLevel = 1.0f;
   m_bMute = false;
 
-  iAdditionalSubtitleDirectoryChecked = 0;
   m_iMyMusicStartWindow = WINDOW_MUSIC_FILES;
   m_iVideoStartWindow = WINDOW_VIDEO_FILES;
 
   m_iSystemTimeTotalUp = 0;
-
-  m_musicNeedsUpdate = 0;
-  m_videoNeedsUpdate = 0;
 }
 
 CSettings::~CSettings(void)
@@ -221,16 +210,9 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
   TiXmlElement *pElement = pRootElement->FirstChildElement("mymusic");
   if (pElement)
   {
-    TiXmlElement *pChild = pElement->FirstChildElement("playlist");
-    if (pChild)
-    {
-      XMLUtils::GetBoolean(pChild, "repeat", m_bMyMusicPlaylistRepeat);
-      XMLUtils::GetBoolean(pChild, "shuffle", m_bMyMusicPlaylistShuffle);
-    }
     GetInteger(pElement, "startwindow", m_iMyMusicStartWindow, WINDOW_MUSIC_FILES, WINDOW_MUSIC_FILES, WINDOW_MUSIC_NAV); //501; view songs
     XMLUtils::GetBoolean(pElement, "songinfoinvis", m_bMyMusicSongInfoInVis);
     XMLUtils::GetBoolean(pElement, "songthumbinvis", m_bMyMusicSongThumbInVis);
-    GetInteger(pElement, "needsupdate", m_musicNeedsUpdate, 0, 0, INT_MAX);
     GetPath(pElement, "defaultlibview", m_defaultMusicLibSource);
   }
 
@@ -241,14 +223,6 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
     GetInteger(pElement, "startwindow", m_iVideoStartWindow, WINDOW_VIDEO_FILES, WINDOW_VIDEO_FILES, WINDOW_VIDEO_NAV);
     XMLUtils::GetBoolean(pElement, "stackvideos", m_videoStacking);
     XMLUtils::GetBoolean(pElement, "flatten", m_bMyVideoNavFlatten);
-    GetInteger(pElement, "needsupdate", m_videoNeedsUpdate, 0, 0, INT_MAX);
-
-    TiXmlElement *pChild = pElement->FirstChildElement("playlist");
-    if (pChild)
-    { // playlist
-      XMLUtils::GetBoolean(pChild, "repeat", m_bMyVideoPlaylistRepeat);
-      XMLUtils::GetBoolean(pChild, "shuffle", m_bMyVideoPlaylistShuffle);
-    }
   }
 
   // general settings
@@ -290,15 +264,7 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
   TiXmlElement musicNode("mymusic");
   TiXmlNode *pNode = pRoot->InsertEndChild(musicNode);
   if (!pNode) return false;
-  {
-    TiXmlElement childNode("playlist");
-    TiXmlNode *pChild = pNode->InsertEndChild(childNode);
-    if (!pChild) return false;
-    XMLUtils::SetBoolean(pChild, "repeat", m_bMyMusicPlaylistRepeat);
-    XMLUtils::SetBoolean(pChild, "shuffle", m_bMyMusicPlaylistShuffle);
-  }
 
-  XMLUtils::SetInt(pNode, "needsupdate", m_musicNeedsUpdate);
   XMLUtils::SetInt(pNode, "startwindow", m_iMyMusicStartWindow);
   XMLUtils::SetBoolean(pNode, "songinfoinvis", m_bMyMusicSongInfoInVis);
   XMLUtils::SetBoolean(pNode, "songthumbinvis", m_bMyMusicSongThumbInVis);
@@ -312,16 +278,7 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
   XMLUtils::SetInt(pNode, "startwindow", m_iVideoStartWindow);
 
   XMLUtils::SetBoolean(pNode, "stackvideos", m_videoStacking);
-  XMLUtils::SetInt(pNode, "needsupdate", m_videoNeedsUpdate);
   XMLUtils::SetBoolean(pNode, "flatten", m_bMyVideoNavFlatten);
-
-  { // playlist window
-    TiXmlElement childNode("playlist");
-    TiXmlNode *pChild = pNode->InsertEndChild(childNode);
-    if (!pChild) return false;
-    XMLUtils::SetBoolean(pChild, "repeat", m_bMyVideoPlaylistRepeat);
-    XMLUtils::SetBoolean(pChild, "shuffle", m_bMyVideoPlaylistShuffle);
-  }
 
   // general settings
   TiXmlElement generalNode("general");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -76,8 +76,6 @@ void CSettings::Initialize()
 {
   m_fVolumeLevel = 1.0f;
   m_bMute = false;
-
-  m_iSystemTimeTotalUp = 0;
 }
 
 CSettings::~CSettings(void)
@@ -194,15 +192,8 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
     return false;
   }
 
-  // general settings
-  const TiXmlElement *pElement = pRootElement->FirstChildElement("general");
-  if (pElement)
-  {
-    GetInteger(pElement, "systemtotaluptime", m_iSystemTimeTotalUp, 0, 0, INT_MAX);
-  }
-
   // audio settings
-  pElement = pRootElement->FirstChildElement("audio");
+  TiXmlElement *pElement = pRootElement->FirstChildElement("audio");
   if (pElement)
   {
     XMLUtils::GetBoolean(pElement, "mute", m_bMute);
@@ -226,15 +217,9 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
   if (!OnSettingsSaving())
     return false;
 
-  // general settings
-  TiXmlElement generalNode("general");
-  TiXmlNode *pNode = pRoot->InsertEndChild(generalNode);
-  if (!pNode) return false;
-  XMLUtils::SetInt(pNode, "systemtotaluptime", m_iSystemTimeTotalUp);
-
   // audio settings
   TiXmlElement volumeNode("audio");
-  pNode = pRoot->InsertEndChild(volumeNode);
+  TiXmlNode *pNode = pRoot->InsertEndChild(volumeNode);
   if (!pNode) return false;
   XMLUtils::SetBoolean(pNode, "mute", m_bMute);
   XMLUtils::SetFloat(pNode, "fvolumelevel", m_fVolumeLevel);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -93,9 +93,6 @@ void CSettings::Initialize()
 
   m_fVolumeLevel = 1.0f;
   m_bMute = false;
-  m_fZoomAmount = 1.0f;
-  m_fPixelRatio = 1.0f;
-  m_bNonLinStretch = false;
 
   m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.cbr|.rar|.m3u|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss";
   m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.mod|.amf|.669|.dmf|.dsm|.far|.gdm|.imf|.it|.m15|.med|.okt|.s3m|.stm|.sfx|.ult|.uni|.xm|.sid|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.nsf|.spc|.gym|.adx|.dsp|.adp|.ymf|.ast|.afc|.hps|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.mid|.kar|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.cm3|.cms|.dlt|.brstm|.wtv|.mka";

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -74,20 +74,8 @@ void CSettings::UnregisterSubSettings(ISubSettings *subSettings)
 
 void CSettings::Initialize()
 {
-  m_videoStacking = false;
-
-  m_bMyMusicSongInfoInVis = true;    // UNUSED - depreciated.
-  m_bMyMusicSongThumbInVis = false;  // used for music info in vis screen
-  m_bMyVideoNavFlatten = false;
-  m_bAddonAutoUpdate = true;
-  m_bAddonNotifications = true;
-  m_bAddonForeignFilter = false;
-
   m_fVolumeLevel = 1.0f;
   m_bMute = false;
-
-  m_iMyMusicStartWindow = WINDOW_MUSIC_FILES;
-  m_iVideoStartWindow = WINDOW_VIDEO_FILES;
 
   m_iSystemTimeTotalUp = 0;
 }
@@ -206,33 +194,11 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
     return false;
   }
 
-  // mymusic settings
-  TiXmlElement *pElement = pRootElement->FirstChildElement("mymusic");
-  if (pElement)
-  {
-    GetInteger(pElement, "startwindow", m_iMyMusicStartWindow, WINDOW_MUSIC_FILES, WINDOW_MUSIC_FILES, WINDOW_MUSIC_NAV); //501; view songs
-    XMLUtils::GetBoolean(pElement, "songinfoinvis", m_bMyMusicSongInfoInVis);
-    XMLUtils::GetBoolean(pElement, "songthumbinvis", m_bMyMusicSongThumbInVis);
-    GetPath(pElement, "defaultlibview", m_defaultMusicLibSource);
-  }
-
-  // myvideos settings
-  pElement = pRootElement->FirstChildElement("myvideos");
-  if (pElement)
-  {
-    GetInteger(pElement, "startwindow", m_iVideoStartWindow, WINDOW_VIDEO_FILES, WINDOW_VIDEO_FILES, WINDOW_VIDEO_NAV);
-    XMLUtils::GetBoolean(pElement, "stackvideos", m_videoStacking);
-    XMLUtils::GetBoolean(pElement, "flatten", m_bMyVideoNavFlatten);
-  }
-
   // general settings
-  pElement = pRootElement->FirstChildElement("general");
+  const TiXmlElement *pElement = pRootElement->FirstChildElement("general");
   if (pElement)
   {
     GetInteger(pElement, "systemtotaluptime", m_iSystemTimeTotalUp, 0, 0, INT_MAX);
-    XMLUtils::GetBoolean(pElement, "addonautoupdate", m_bAddonAutoUpdate);
-    XMLUtils::GetBoolean(pElement, "addonnotifications", m_bAddonNotifications);
-    XMLUtils::GetBoolean(pElement, "addonforeignfilter", m_bAddonForeignFilter);
   }
 
   // audio settings
@@ -260,34 +226,11 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
   if (!OnSettingsSaving())
     return false;
 
-  // mymusic settings
-  TiXmlElement musicNode("mymusic");
-  TiXmlNode *pNode = pRoot->InsertEndChild(musicNode);
-  if (!pNode) return false;
-
-  XMLUtils::SetInt(pNode, "startwindow", m_iMyMusicStartWindow);
-  XMLUtils::SetBoolean(pNode, "songinfoinvis", m_bMyMusicSongInfoInVis);
-  XMLUtils::SetBoolean(pNode, "songthumbinvis", m_bMyMusicSongThumbInVis);
-  XMLUtils::SetPath(pNode, "defaultlibview", m_defaultMusicLibSource);
-
-  // myvideos settings
-  TiXmlElement videosNode("myvideos");
-  pNode = pRoot->InsertEndChild(videosNode);
-  if (!pNode) return false;
-
-  XMLUtils::SetInt(pNode, "startwindow", m_iVideoStartWindow);
-
-  XMLUtils::SetBoolean(pNode, "stackvideos", m_videoStacking);
-  XMLUtils::SetBoolean(pNode, "flatten", m_bMyVideoNavFlatten);
-
   // general settings
   TiXmlElement generalNode("general");
-  pNode = pRoot->InsertEndChild(generalNode);
+  TiXmlNode *pNode = pRoot->InsertEndChild(generalNode);
   if (!pNode) return false;
   XMLUtils::SetInt(pNode, "systemtotaluptime", m_iSystemTimeTotalUp);
-  XMLUtils::SetBoolean(pNode, "addonautoupdate", m_bAddonAutoUpdate);
-  XMLUtils::SetBoolean(pNode, "addonnotifications", m_bAddonNotifications);
-  XMLUtils::SetBoolean(pNode, "addonforeignfilter", m_bAddonForeignFilter);
 
   // audio settings
   TiXmlElement volumeNode("audio");
@@ -312,8 +255,6 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
 
 void CSettings::Clear()
 {
-  m_defaultMusicLibSource.clear();
-
   OnSettingsCleared();
 
   for (SubSettings::const_iterator it = m_subSettings.begin(); it != m_subSettings.end(); it++)

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -84,13 +84,6 @@ public:
 
   void Clear();
 
-  CStdString m_pictureExtensions;
-  CStdString m_musicExtensions;
-  CStdString m_videoExtensions;
-  CStdString m_discStubExtensions;
-
-  CStdString m_logFolder;
-
   bool m_bMyMusicSongInfoInVis;
   bool m_bMyMusicSongThumbInVis;
   bool m_bMyMusicPlaylistRepeat;
@@ -114,8 +107,6 @@ public:
   float m_fVolumeLevel;        // float 0.0 - 1.0 range
   bool m_bMute;
   int m_iSystemTimeTotalUp;    // Uptime in minutes!
-
-  CStdString m_userAgent;
 
   CStdString m_defaultMusicLibSource;
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -84,24 +84,9 @@ public:
 
   void Clear();
 
-  bool m_bMyMusicSongInfoInVis;
-  bool m_bMyMusicSongThumbInVis;
-  int m_iMyMusicStartWindow;
-
-  bool m_bMyVideoNavFlatten;
-  bool m_bAddonAutoUpdate;
-  bool m_bAddonNotifications;
-  bool m_bAddonForeignFilter;
-
-  int m_iVideoStartWindow;
-
-  bool m_videoStacking;
-
   float m_fVolumeLevel;        // float 0.0 - 1.0 range
   bool m_bMute;
   int m_iSystemTimeTotalUp;    // Uptime in minutes!
-
-  CStdString m_defaultMusicLibSource;
 
   bool SaveSettings(const CStdString& strSettingsFile, CGUISettings *localSettings = NULL) const;
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -29,11 +29,6 @@
 #include "threads/CriticalSection.h"
 #include "utils/StdString.h"
 
-#define VOLUME_MINIMUM 0.0f        // -60dB
-#define VOLUME_MAXIMUM 1.0f        // 0dB
-#define VOLUME_DYNAMIC_RANGE 90.0f // 60dB
-#define VOLUME_CONTROL_STEPS 90    // 90 steps
-
 class CGUISettings;
 class TiXmlElement;
 class TiXmlNode;
@@ -49,28 +44,14 @@ public:
   void RegisterSubSettings(ISubSettings *subSettings);
   void UnregisterSubSettings(ISubSettings *subSettings);
 
-  void Initialize();
-
   bool Load();
   void Save() const;
-  bool Reset();
-
-  void Clear();
-
-  float m_fVolumeLevel;        // float 0.0 - 1.0 range
-  bool m_bMute;
-
   bool SaveSettings(const CStdString& strSettingsFile, CGUISettings *localSettings = NULL) const;
-
-  bool GetInteger(const TiXmlElement* pRootElement, const char *strTagName, int& iValue, const int iDefault, const int iMin, const int iMax);
-  bool GetFloat(const TiXmlElement* pRootElement, const char *strTagName, float& fValue, const float fDefault, const float fMin, const float fMax);
-  static bool GetPath(const TiXmlElement* pRootElement, const char *tagName, CStdString &strValue);
-  static bool GetString(const TiXmlElement* pRootElement, const char *strTagName, CStdString& strValue, const CStdString& strDefaultValue);
-  bool GetString(const TiXmlElement* pRootElement, const char *strTagName, char *szValue, const CStdString& strDefaultValue);
+  bool Reset();
+  void Clear();
 
 protected:
   bool LoadSettings(const CStdString& strSettingsFile);
-//  bool SaveSettings(const CStdString& strSettingsFile) const;
 
 private:
   // implementation of ISettingsHandler

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -19,42 +19,15 @@
  *
  */
 
-#include <vector>
-#include <map>
 #include <set>
 
 #define PRE_SKIN_VERSION_9_10_COMPATIBILITY 1
 #define PRE_SKIN_VERSION_11_COMPATIBILITY 1
 
-//FIXME - after eden - make that one nicer somehow...
-#if defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV2)
-#include "system.h" //for HAS_SKIN_TOUCHED
-#endif
-
-#if defined(HAS_SKIN_TOUCHED) && defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV2)
-#define DEFAULT_SKIN          "skin.touched"
-#else
-#define DEFAULT_SKIN          "skin.confluence"
-#endif
-#define DEFAULT_WEB_INTERFACE "webinterface.default"
-#ifdef MID
-#define DEFAULT_VSYNC       VSYNC_DISABLED
-#else  // MID
-#if defined(TARGET_DARWIN) || defined(_WIN32) || defined(TARGET_RASPBERRY_PI)
-#define DEFAULT_VSYNC       VSYNC_ALWAYS
-#else
-#define DEFAULT_VSYNC       VSYNC_DRIVER
-#endif
-#endif // MID
-
 #include "settings/ISettingsHandler.h"
 #include "settings/ISubSettings.h"
-#include "guilib/GraphicContext.h"
 #include "threads/CriticalSection.h"
-
-#define CACHE_AUDIO 0
-#define CACHE_VIDEO 1
-#define CACHE_VOB   2
+#include "utils/StdString.h"
 
 #define VOLUME_MINIMUM 0.0f        // -60dB
 #define VOLUME_MAXIMUM 1.0f        // 0dB

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -59,7 +59,6 @@ public:
 
   float m_fVolumeLevel;        // float 0.0 - 1.0 range
   bool m_bMute;
-  int m_iSystemTimeTotalUp;    // Uptime in minutes!
 
   bool SaveSettings(const CStdString& strSettingsFile, CGUISettings *localSettings = NULL) const;
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -86,14 +86,9 @@ public:
 
   bool m_bMyMusicSongInfoInVis;
   bool m_bMyMusicSongThumbInVis;
-  bool m_bMyMusicPlaylistRepeat;
-  bool m_bMyMusicPlaylistShuffle;
   int m_iMyMusicStartWindow;
 
-  bool m_bMyVideoPlaylistRepeat;
-  bool m_bMyVideoPlaylistShuffle;
   bool m_bMyVideoNavFlatten;
-  bool m_bStartVideoWindowed;
   bool m_bAddonAutoUpdate;
   bool m_bAddonNotifications;
   bool m_bAddonForeignFilter;
@@ -102,16 +97,11 @@ public:
 
   bool m_videoStacking;
 
-  int iAdditionalSubtitleDirectoryChecked;
-
   float m_fVolumeLevel;        // float 0.0 - 1.0 range
   bool m_bMute;
   int m_iSystemTimeTotalUp;    // Uptime in minutes!
 
   CStdString m_defaultMusicLibSource;
-
-  int        m_musicNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
-  int        m_videoNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
 
   bool SaveSettings(const CStdString& strSettingsFile, CGUISettings *localSettings = NULL) const;
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -97,11 +97,6 @@ public:
   bool m_bMyMusicPlaylistShuffle;
   int m_iMyMusicStartWindow;
 
-  float m_fZoomAmount;      // current zoom amount
-  float m_fPixelRatio;      // current pixel ratio
-  float m_fVerticalShift;   // current vertical shift
-  bool  m_bNonLinStretch;   // current non-linear stretch
-
   bool m_bMyVideoPlaylistRepeat;
   bool m_bMyVideoPlaylistShuffle;
   bool m_bMyVideoNavFlatten;

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -30,7 +30,7 @@
 #if defined(TARGET_DARWIN)
 #include "osx/CocoaInterface.h"
 #endif
-#include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIRSSControl.h"
 #include "utils/TimeUtils.h"
@@ -133,7 +133,7 @@ void CRssReader::Process()
     m_strColors[iFeed] = "";
 
     CCurlFile http;
-    http.SetUserAgent(g_settings.m_userAgent);
+    http.SetUserAgent(g_advancedSettings.m_userAgent);
     http.SetTimeout(2);
     CStdString strXML;
     CStdString strUrl = m_vecUrls[iFeed];

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <limits.h>
+
 #include "threads/SystemClock.h"
 #include "system.h"
 #include "SystemInfo.h"
@@ -31,7 +33,6 @@
 #include "network/Network.h"
 #include "Application.h"
 #include "windowing/WindowingFactory.h"
-#include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
 #include "CPUInfo.h"
 #include "utils/TimeUtils.h"
@@ -45,6 +46,7 @@
 #endif
 #include "powermanagement/PowerManager.h"
 #include "utils/StringUtils.h"
+#include "utils/XMLUtils.h"
 
 CSysInfo g_sysinfo;
 
@@ -145,7 +147,7 @@ CStdString CSysInfoJob::GetSystemUpTime(bool bTotalUptime)
   if(bTotalUptime)
   {
     //Total Uptime
-    iInputMinutes = g_settings.m_iSystemTimeTotalUp + ((int)(XbmcThreads::SystemClockMillis() / 60000));
+    iInputMinutes = g_sysinfo.GetTotalUptime() + ((int)(XbmcThreads::SystemClockMillis() / 60000));
   }
   else
   {
@@ -213,10 +215,41 @@ void CSysInfo::Reset()
 CSysInfo::CSysInfo(void) : CInfoLoader(15 * 1000)
 {
   memset(MD5_Sign, 0, sizeof(MD5_Sign));
+  m_iSystemTimeTotalUp = 0;
 }
 
 CSysInfo::~CSysInfo()
 {
+}
+
+bool CSysInfo::Load(const TiXmlNode *settings)
+{
+  if (settings == NULL)
+    return false;
+  
+  const TiXmlElement *pElement = settings->FirstChildElement("general");
+  if (pElement)
+    XMLUtils::GetInt(pElement, "systemtotaluptime", m_iSystemTimeTotalUp, 0, INT_MAX);
+
+  return true;
+}
+
+bool CSysInfo::Save(TiXmlNode *settings) const
+{
+  if (settings == NULL)
+    return false;
+
+  TiXmlNode *generalNode = settings->FirstChild("general");
+  if (generalNode == NULL)
+  {
+    TiXmlElement generalNodeNew("general");
+    generalNode = settings->InsertEndChild(generalNodeNew);
+    if (generalNode == NULL)
+      return false;
+  }
+  XMLUtils::SetInt(generalNode, "systemtotaluptime", m_iSystemTimeTotalUp);
+
+  return true;
 }
 
 bool CSysInfo::GetDiskSpace(const CStdString drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed)

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -22,6 +22,7 @@
 
 #include "md5.h"
 #include "InfoLoader.h"
+#include "settings/ISubSettings.h"
 
 #define KB  (1024)          // 1 KiloByte (1KB)   1024 Byte (2^10 Byte)
 #define MB  (1024*KB)       // 1 MegaByte (1MB)   1024 KB (2^10 KB)
@@ -76,7 +77,7 @@ private:
   CSysData m_info;
 };
 
-class CSysInfo : public CInfoLoader
+class CSysInfo : public CInfoLoader, public ISubSettings
 {
 public:
   enum WindowsVersion
@@ -92,6 +93,9 @@ public:
 
   CSysInfo(void);
   virtual ~CSysInfo();
+
+  virtual bool Load(const TiXmlNode *settings);
+  virtual bool Save(TiXmlNode *settings) const;
 
   char MD5_Sign[32 + 1];
 
@@ -129,6 +133,9 @@ public:
   CStdString GetHddSpaceInfo(int& percent, int drive, bool shortText=false);
   CStdString GetHddSpaceInfo(int drive, bool shortText=false);
 
+  int GetTotalUptime() const { return m_iSystemTimeTotalUp; }
+  void SetTotalUptime(int uptime) { m_iSystemTimeTotalUp = uptime; }
+
 protected:
   virtual CJob *GetJob() const;
   virtual CStdString TranslateInfo(int info) const;
@@ -137,6 +144,7 @@ protected:
 private:
   CSysData m_info;
   static WindowsVersion m_WinVer;
+  int m_iSystemTimeTotalUp; // Uptime in minutes!
   void Reset();
 };
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -27,7 +27,6 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
 #include "network/DNSNameCache.h"
-#include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "URL.h"
 #include "StringUtils.h"
@@ -100,9 +99,9 @@ void URIUtils::RemoveExtension(CStdString& strFileName)
     strExtension += "|";
 
     CStdString strFileMask;
-    strFileMask = g_settings.m_pictureExtensions;
-    strFileMask += "|" + g_settings.m_musicExtensions;
-    strFileMask += "|" + g_settings.m_videoExtensions;
+    strFileMask = g_advancedSettings.m_pictureExtensions;
+    strFileMask += "|" + g_advancedSettings.m_musicExtensions;
+    strFileMask += "|" + g_advancedSettings.m_videoExtensions;
 #if defined(TARGET_DARWIN)
     strFileMask += "|.py|.xml|.milk|.xpr|.xbt|.cdg|.app|.applescript|.workflow";
 #else

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -139,7 +139,7 @@ bool CLog::Init(const char* path)
   CSingleLock waitLock(critSec);
   if (!m_file)
   {
-    // g_settings.m_logFolder is initialized in the CSettings constructor
+    // g_advancedSettings.m_logFolder is initialized in the CSettings constructor
     // and changed in CApplication::Create()
     CStdString strLogFile, strLogFileOld;
 

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -45,7 +45,7 @@ CStdString CGUIViewStateWindowVideo::GetLockType()
 
 CStdString CGUIViewStateWindowVideo::GetExtensions()
 {
-  return g_settings.m_videoExtensions;
+  return g_advancedSettings.m_videoExtensions;
 }
 
 int CGUIViewStateWindowVideo::GetPlaylist()

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -29,7 +29,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
-#include "settings/Settings.h"
 #include "FileItem.h"
 #include "guilib/WindowIDs.h"
 #include "guilib/LocalizeStrings.h"
@@ -437,7 +436,7 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
   //  Setup shares we want to have
   m_sources.clear();
   CFileItemList items;
-  if (g_settings.m_bMyVideoNavFlatten)
+  if (g_guiSettings.GetBool("myvideos.flatten"))
     CDirectory::GetDirectory("library://video_flat/", items, "");
   else
     CDirectory::GetDirectory("library://video/", items, "");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4236,7 +4236,7 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
     m_pDS->exec("CREATE TRIGGER delete_set AFTER DELETE ON sets FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idSet AND media_type='set'; END");
     m_pDS->exec("CREATE TRIGGER delete_person AFTER DELETE ON actors FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idActor AND media_type IN ('actor','artist','writer','director'); END");
 
-    g_settings.m_videoNeedsUpdate = 63;
+    CMediaSettings::Get().SetVideoNeedsUpdate(63);
     g_settings.Save();
   }
   if (iVersion < 64)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -38,7 +38,6 @@
 #include "interfaces/AnnouncementManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
-#include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIWindowManager.h"
@@ -273,7 +272,7 @@ namespace VIDEO
       }
       if (!bSkip)
       { // need to fetch the folder
-        CDirectory::GetDirectory(strDirectory, items, g_settings.m_videoExtensions);
+        CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
         items.Stack();
         // compute hash
         GetPathHash(items, hash);
@@ -309,7 +308,7 @@ namespace VIDEO
 
       if (foundDirectly && !settings.parent_name_root)
       {
-        CDirectory::GetDirectory(strDirectory, items, g_settings.m_videoExtensions);
+        CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
         items.SetPath(strDirectory);
         GetPathHash(items, hash);
         bSkip = true;
@@ -666,7 +665,7 @@ namespace VIDEO
 
     if (item->m_bIsFolder)
     {
-      CUtil::GetRecursiveListing(item->GetPath(), items, g_settings.m_videoExtensions, true);
+      CUtil::GetRecursiveListing(item->GetPath(), items, g_advancedSettings.m_videoExtensions, true);
       CStdString hash, dbHash;
       int numFilesInFolder = GetPathHash(items, hash);
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -327,7 +327,7 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
     if (g_application.GetCurrentPlayer() == EPC_DVDPLAYER)
       strMask = ".srt|.rar|.zip|.ifo|.smi|.sub|.idx|.ass|.ssa|.txt";
     VECSOURCES shares(*CMediaSourceSettings::Get().GetSources("video"));
-    if (g_settings.iAdditionalSubtitleDirectoryChecked != -1 && !g_guiSettings.GetString("subtitles.custompath").IsEmpty())
+    if (CMediaSettings::Get().GetAdditionalSubtitleDirectoryChecked() != -1 && !g_guiSettings.GetString("subtitles.custompath").IsEmpty())
     {
       CMediaSource share;
       std::vector<CStdString> paths;

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -87,7 +87,7 @@ void CGUIDialogAudioSubtitleSettings::CreateSettings()
   // clear out any old settings
   m_settings.clear();
   // create our settings
-  m_volume = g_settings.m_fVolumeLevel;
+  m_volume = g_application.GetVolume(false);
   AddSlider(AUDIO_SETTINGS_VOLUME, 13376, &m_volume, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM, PercentAsDecibel, false);
   if (SupportsAudioFeature(IPC_AUD_AMP))
     AddSlider(AUDIO_SETTINGS_VOLUME_AMPLIFICATION, 660, &CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) / 6000.0f, VOLUME_DRC_MAXIMUM * 0.01f, FormatDecibel, false);
@@ -243,10 +243,7 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
 {
   // check and update anything that needs it
   if (setting.id == AUDIO_SETTINGS_VOLUME)
-  {
-    g_settings.m_fVolumeLevel = m_volume;
-    g_application.SetVolume(m_volume, false);//false - value is not in percent
-  }
+    g_application.SetVolume(m_volume, false); //false - value is not in percent
   else if (setting.id == AUDIO_SETTINGS_VOLUME_AMPLIFICATION)
   {
     if (g_application.m_pPlayer)
@@ -385,7 +382,7 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
 
 void CGUIDialogAudioSubtitleSettings::FrameMove()
 {
-  m_volume = g_settings.m_fVolumeLevel;
+  m_volume = g_application.GetVolume(false);
   UpdateSetting(AUDIO_SETTINGS_VOLUME);
   if (g_application.m_pPlayer)
   {

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -659,8 +659,8 @@ void CGUIWindowFullScreen::FrameMove()
       strSizing.Format(g_localizeStrings.Get(245),
                        (int)info.SrcRect.Width(), (int)info.SrcRect.Height(),
                        (int)(info.DestRect.Width() * xscale), (int)(info.DestRect.Height() * yscale),
-                       g_settings.m_fZoomAmount, info.videoAspectRatio*g_settings.m_fPixelRatio, 
-                       g_settings.m_fPixelRatio, g_settings.m_fVerticalShift);
+                       CDisplaySettings::Get().GetZoomAmount(), info.videoAspectRatio*CDisplaySettings::Get().GetPixelRatio(), 
+                       CDisplaySettings::Get().GetPixelRatio(), CDisplaySettings::Get().GetVerticalShift());
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW2);
       msg.SetLabel(strSizing);
       OnMessage(msg);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -302,7 +302,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
     if (item.m_bIsFolder && scraper && scraper->Content() != CONTENT_TVSHOWS)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(), items, g_settings.m_videoExtensions);
+      CDirectory::GetDirectory(item.GetPath(), items, g_advancedSettings.m_videoExtensions);
       items.Stack();
 
       // check for media files

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -2212,14 +2212,14 @@ void CGUIWindowVideoBase::OnAssignContent(const CStdString &path)
 void CGUIWindowVideoBase::OnInitWindow()
 {
   CGUIMediaWindow::OnInitWindow();
-  if (g_settings.m_videoNeedsUpdate == 63 && !g_application.IsVideoScanning() &&
+  if (CMediaSettings::Get().GetVideoNeedsUpdate() == 63 && !g_application.IsVideoScanning() &&
       g_infoManager.GetLibraryBool(LIBRARY_HAS_VIDEO))
   {
     // rescan of video library required
     if (CGUIDialogYesNo::ShowAndGetInput(799, 12351, 12352, 12354))
     {
       CEdenVideoArtUpdater::Start();
-      g_settings.m_videoNeedsUpdate = 0; // once is enough
+      CMediaSettings::Get().SetVideoNeedsUpdate(0); // once is enough
       g_settings.Save();
     }
   }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -141,9 +141,9 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
       m_dlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
 
       // save current window, unless the current window is the video playlist window
-      if (GetID() != WINDOW_VIDEO_PLAYLIST && g_settings.m_iVideoStartWindow != GetID())
+      if (GetID() != WINDOW_VIDEO_PLAYLIST && g_guiSettings.GetInt("myvideos.startwindow") != GetID())
       {
-        g_settings.m_iVideoStartWindow = GetID();
+        g_guiSettings.SetInt("myvideos.startwindow", GetID());
         g_settings.Save();
       }
 
@@ -156,7 +156,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
       int iControl = message.GetSenderId();
       if (iControl == CONTROL_STACK)
       {
-        g_settings.m_videoStacking = !g_settings.m_videoStacking;
+        g_guiSettings.ToggleBool("myvideos.stackvideos");
         g_settings.Save();
         UpdateButtons();
         Update( m_vecItems->GetPath() );
@@ -187,7 +187,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
 
         if (nNewWindow != GetID())
         {
-          g_settings.m_iVideoStartWindow = nNewWindow;
+          g_guiSettings.SetInt("myvideos.startwindow", nNewWindow);
           g_settings.Save();
           g_windowManager.ChangeActiveWindow(nNewWindow);
           CGUIMessage msg2(GUI_MSG_SETFOCUS, nNewWindow, CONTROL_BTNTYPE);
@@ -265,13 +265,13 @@ void CGUIWindowVideoBase::UpdateButtons()
   g_windowManager.SendMessage(msg2);
 
   // Select the current window as default item
-  int nWindow = g_settings.m_iVideoStartWindow-WINDOW_VIDEO_FILES;
+  int nWindow = g_guiSettings.GetInt("myvideos.startwindow")-WINDOW_VIDEO_FILES;
   CONTROL_SELECT_ITEM(CONTROL_BTNTYPE, nWindow);
 
   CONTROL_ENABLE(CONTROL_BTNSCAN);
 
   SET_CONTROL_LABEL(CONTROL_STACK, 14000);  // Stack
-  SET_CONTROL_SELECTED(GetID(), CONTROL_STACK, g_settings.m_videoStacking);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_STACK, g_guiSettings.GetBool("myvideos.stackvideos"));
   CONTROL_ENABLE_ON_CONDITION(CONTROL_STACK, m_stackingAvailable);
   
   CGUIMediaWindow::UpdateButtons();
@@ -1867,7 +1867,7 @@ bool CGUIWindowVideoBase::GetDirectory(const CStdString &strDirectory, CFileItem
   if (info && info->Content() == CONTENT_TVSHOWS)
     m_stackingAvailable = false;
 
-  if (m_stackingAvailable && !items.IsStack() && g_settings.m_videoStacking)
+  if (m_stackingAvailable && !items.IsStack() && g_guiSettings.GetBool("myvideos.stackvideos"))
     items.Stack();
 
   return bResult;
@@ -2053,7 +2053,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
 
     Update(strParentPath);
 
-    if (pSelItem->IsVideoDb() && g_settings.m_bMyVideoNavFlatten)
+    if (pSelItem->IsVideoDb() && g_guiSettings.GetBool("myvideos.flatten"))
       SetHistoryForPath("");
     else
       SetHistoryForPath(strParentPath);
@@ -2080,7 +2080,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
 
     Update(strPath);
 
-    if (pSelItem->IsVideoDb() && g_settings.m_bMyVideoNavFlatten)
+    if (pSelItem->IsVideoDb() && g_guiSettings.GetBool("myvideos.flatten"))
       SetHistoryForPath("");
     else
       SetHistoryForPath(strPath);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -121,7 +121,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       /* We don't want to show Autosourced items (ie removable pendrives, memorycards) in Library mode */
       m_rootDir.AllowNonLocalSources(false);
 
-      SetProperty("flattened", g_settings.m_bMyVideoNavFlatten);
+      SetProperty("flattened", g_guiSettings.GetBool("myvideos.flatten"));
       if (message.GetNumStringParams() && message.GetStringParam(0).Equals("Files") &&
           CMediaSourceSettings::Get().GetSources("video")->empty())
       {
@@ -171,9 +171,9 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNFLATTEN)
       {
-        g_settings.m_bMyVideoNavFlatten = !g_settings.m_bMyVideoNavFlatten;
+        g_guiSettings.ToggleBool("myvideos.flatten");
         g_settings.Save();
-        SetProperty("flattened", g_settings.m_bMyVideoNavFlatten);
+        SetProperty("flattened", g_guiSettings.GetBool("myvideos.flatten"));
         CUtil::DeleteVideoDatabaseDirectoryCache();
         SetupShares();
         Update("");
@@ -425,7 +425,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
     Similarly, we assign the "clean" library labels to the item only if the "Replace filenames with library titles"
     setting is enabled.
     */
-  const bool stackItems    = items.GetProperty("isstacked").asBoolean() || (StackingAvailable(items) && g_settings.m_videoStacking);
+  const bool stackItems    = items.GetProperty("isstacked").asBoolean() || (StackingAvailable(items) && g_guiSettings.GetBool("myvideos.stackvideos"));
   const bool replaceLabels = allowReplaceLabels && g_guiSettings.GetBool("myvideos.replacelabels");
 
   CFileItemList dbItems;
@@ -543,7 +543,7 @@ void CGUIWindowVideoNav::UpdateButtons()
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
-  SET_CONTROL_SELECTED(GetID(),CONTROL_BTNFLATTEN, g_settings.m_bMyVideoNavFlatten);
+  SET_CONTROL_SELECTED(GetID(),CONTROL_BTNFLATTEN, g_guiSettings.GetBool("myvideos.flatten"));
 }
 
 bool CGUIWindowVideoNav::GetFilteredItems(const CStdString &filter, CFileItemList &items)

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -32,6 +32,7 @@
 #include "Favourites.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
+#include "settings/MediaSettings.h"
 #include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
@@ -127,7 +128,7 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
         if (!g_partyModeManager.IsEnabled())
         {
           g_playlistPlayer.SetShuffle(PLAYLIST_VIDEO, !(g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO)));
-          g_settings.m_bMyVideoPlaylistShuffle = g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO);
+          CMediaSettings::Get().SetVideoPlaylistShuffled(g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO));
           g_settings.Save();
           UpdateButtons();
           Refresh();
@@ -170,7 +171,7 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
           g_playlistPlayer.SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_NONE);
 
         // save settings
-        g_settings.m_bMyVideoPlaylistRepeat = g_playlistPlayer.GetRepeat(PLAYLIST_VIDEO) == PLAYLIST::REPEAT_ALL;
+        CMediaSettings::Get().SetVideoPlaylistRepeat(g_playlistPlayer.GetRepeat(PLAYLIST_VIDEO) == PLAYLIST::REPEAT_ALL);
         g_settings.Save();
 
         UpdateButtons();

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "WinSystem.h"
+#include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -26,6 +26,7 @@
 #include "WinSystemX11.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
+#include "guilib/GraphicContext.h"
 #include "guilib/Texture.h"
 #include "guilib/DispResource.h"
 #include "utils/log.h"

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -23,6 +23,7 @@
 
 #include "WinSystemEGL.h"
 #include "filesystem/SpecialProtocol.h"
+#include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -32,6 +32,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
+#include "guilib/GraphicContext.h"
 #include "guilib/Texture.h"
 #include <vector>
 #undef BOOL

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -20,8 +20,8 @@
 
 #include "WinSystemWin32.h"
 #include "WinEventsWin32.h"
-#include "settings/Settings.h"
 #include "resource.h"
+#include "guilib/gui3d.h"
 #include "settings/DisplaySettings.h"
 #include "settings/GUISettings.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -21,7 +21,6 @@
 #include "GUIWindowDebugInfo.h"
 #include "input/MouseStat.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
 #include "addons/Skin.h"
 #include "utils/CPUInfo.h"
 #include "utils/log.h"
@@ -104,11 +103,11 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     CStdString profiling = CGUIControlProfiler::IsRunning() ? " (profiling)" : "";
     CStdString strCores = g_cpuInfo.GetCoresUsageString();
 #if !defined(_LINUX)
-    info.Format("LOG: %sxbmc.log\nMEM: %"PRIu64"/%"PRIu64" KB - FPS: %2.1f fps\nCPU: %s%s", g_settings.m_logFolder.c_str(),
+    info.Format("LOG: %sxbmc.log\nMEM: %"PRIu64"/%"PRIu64" KB - FPS: %2.1f fps\nCPU: %s%s", g_advancedSettings.m_logFolder.c_str(),
                 stat.ullAvailPhys/1024, stat.ullTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), profiling.c_str());
 #else
     double dCPU = m_resourceCounter.GetCPUUsage();
-    info.Format("LOG: %sxbmc.log\nMEM: %"PRIu64"/%"PRIu64" KB - FPS: %2.1f fps\nCPU: %s (CPU-XBMC %4.2f%%%s)", g_settings.m_logFolder.c_str(),
+    info.Format("LOG: %sxbmc.log\nMEM: %"PRIu64"/%"PRIu64" KB - FPS: %2.1f fps\nCPU: %s (CPU-XBMC %4.2f%%%s)", g_advancedSettings.m_logFolder.c_str(),
                 stat.ullAvailPhys/1024, stat.ullTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), dCPU, profiling.c_str());
 #endif
   }


### PR DESCRIPTION
This should be the last settings-related cleanup PR. It moves the remaining members from CSettings to a more appropriate location and cleans up includes and defines in Settings.h. With this done and merged I can start working on the real settings refactor again.

I've compile and runtime tested these changes on win32, linux (kubuntu) and android.
