### PR TITLE
[WIP] ADD: [droid] Hide action bar during video playback

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
+++ b/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
@@ -2,10 +2,18 @@ package org.xbmc.xbmc;
 
 import android.app.NativeActivity;
 import android.content.Intent;
+import android.view.View;
 import android.os.Bundle;
+import android.os.Handler;
 
 public class Main extends NativeActivity 
 {
+  native void OnSystemUiNavigationShown();
+
+  private static final String TAG = "XBMC";
+  private View thisView;
+  private Handler handler = new Handler();
+  
   public Main() 
   {
     super();
@@ -15,5 +23,34 @@ public class Main extends NativeActivity
   public void onCreate(Bundle savedInstanceState) 
   {
     super.onCreate(savedInstanceState);
+    
+    thisView = getWindow().getDecorView(); 
+    thisView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
+      @Override
+      public void onSystemUiVisibilityChange(int visibility) {
+        if ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0) {
+          OnSystemUiNavigationShown();
+        }
+      }
+    });
   }
+
+  protected void showActionBar()
+  {
+    handler.post(new Runnable() {
+      public void run() {
+        thisView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+      }
+    });
+  }
+
+  protected void hideActionBar()
+  {
+    handler.post(new Runnable() {
+      public void run() {
+        thisView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+      }
+    });
+  }
+
 }

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -52,6 +52,10 @@ struct androidPackage
 
 class CXBMCApp : public IActivityHandler
 {
+friend class CAndroidJNIManager;
+public:
+  void OnSystemUiNavigationShown(JNIEnv *env, jobject thiz);
+
 public:
   CXBMCApp(ANativeActivity *nativeActivity);
   virtual ~CXBMCApp();
@@ -95,6 +99,8 @@ public:
   static bool GetStorageUsage(const std::string &path, std::string &usage);
   static int GetMaxSystemVolume();
 
+  static void HideActionBar();
+  static void ShowActionBar();
   static int GetDPI();
 protected:
   // limit who can access Volume
@@ -118,6 +124,10 @@ private:
   bool m_exiting;
   pthread_t m_thread;
   
+  //used for hiding action bar
+  static jmethodID m_midShowActionBar;
+  static jmethodID m_midHideActionBar;
+  
   static ANativeWindow* m_window;
   
   void XBMC_Pause(bool pause);
@@ -125,3 +135,5 @@ private:
   bool XBMC_DestroyDisplay();
   bool XBMC_SetupDisplay();
 };
+
+extern "C" void jni_MainOnSystemUiNavigationShown(JNIEnv *env, jobject thiz);

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -30,6 +30,10 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
 
+#if defined(TARGET_ANDROID)
+#include "android/activity/XBMCApp.h"
+#endif
+
 using namespace MUSIC_INFO;
 
 #define START_FADE_LENGTH  2.0f // 2 seconds on startup
@@ -72,6 +76,9 @@ bool CGUIWindowVisualisation::OnAction(const CAction &action)
   case ACTION_SHOW_GUI:
     // save the settings
     g_settings.Save();
+#if defined(TARGET_ANDROID)
+    CXBMCApp::ShowActionBar();
+#endif
     g_windowManager.PreviousWindow();
     return true;
     break;
@@ -158,10 +165,16 @@ bool CGUIWindowVisualisation::OnMessage(CGUIMessage& message)
       if (pOSD && pOSD->IsDialogRunning()) pOSD->Close(true);
       CGUIDialogVisualisationPresetList *pList = (CGUIDialogVisualisationPresetList *)g_windowManager.GetWindow(WINDOW_DIALOG_VIS_PRESET_LIST);
       if (pList && pList->IsDialogRunning()) pList->Close(true);
+#if defined(TARGET_ANDROID)
+      CXBMCApp::ShowActionBar();
+#endif
     }
     break;
   case GUI_MSG_WINDOW_INIT:
     {
+#if defined(TARGET_ANDROID)
+      CXBMCApp::HideActionBar();
+#endif
       // check whether we've come back here from a window during which time we've actually
       // stopped playing music
       if (message.GetParam1() == WINDOW_INVALID && !g_application.IsPlayingAudio())
@@ -208,6 +221,9 @@ EVENT_RESULT CGUIWindowVisualisation::OnMouseEvent(const CPoint &point, const CM
     {
       pOSD->SetAutoClose(3000);
       pOSD->DoModal();
+#if defined(TARGET_ANDROID)
+      CXBMCApp::HideActionBar();
+#endif
     }
     return EVENT_RESULT_HANDLED;
   }

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -30,6 +30,10 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 
+#if defined(TARGET_ANDROID)
+#include "android/activity/XBMCApp.h"
+#endif
+
 using namespace PVR;
 
 CGUIDialogVideoOSD::CGUIDialogVideoOSD(void)
@@ -121,6 +125,11 @@ bool CGUIDialogVideoOSD::OnMessage(CGUIMessage& message)
       if (pDialog && pDialog->IsDialogRunning()) pDialog->Close(true);
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_OSD_TELETEXT);
       if (pDialog && pDialog->IsDialogRunning()) pDialog->Close(true);
+      
+#if defined(TARGET_ANDROID)
+      CXBMCApp::HideActionBar();
+#endif
+
     }
     break;
   }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -63,6 +63,9 @@
 #if defined(TARGET_DARWIN)
 #include "linux/LinuxResourceCounter.h"
 #endif
+#if defined(TARGET_ANDROID)
+#include "android/activity/XBMCApp.h"
+#endif
 
 using namespace PVR;
 
@@ -143,6 +146,9 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
   switch (action.GetID())
   {
   case ACTION_SHOW_OSD:
+#if defined(TARGET_ANDROID)
+    CXBMCApp::ShowActionBar();
+#endif
     ToggleOSD();
     return true;
 
@@ -150,6 +156,9 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     {
       // switch back to the menu
       OutputDebugString("Switching to GUI\n");
+#if defined(TARGET_ANDROID)
+      CXBMCApp::ShowActionBar();
+#endif
       g_windowManager.PreviousWindow();
       OutputDebugString("Now in GUI\n");
       return true;
@@ -376,6 +385,9 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_INIT:
     {
+#if defined(TARGET_ANDROID)
+      CXBMCApp::HideActionBar();
+#endif
       // check whether we've come back here from a window during which time we've actually
       // stopped playing videos
       if (message.GetParam1() == WINDOW_INVALID && !g_application.IsPlayingVideo())
@@ -441,6 +453,9 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CUTTER);
       if (pDialog) pDialog->Close(true);
 
+#if defined(TARGET_ANDROID)
+      CXBMCApp::ShowActionBar();
+#endif
       CGUIWindow::OnMessage(message);
 
       g_settings.Save();
@@ -462,7 +477,6 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
         delete m_subsLayout;
         m_subsLayout = NULL;
       }
-
       return true;
     }
   case GUI_MSG_CLICKED:


### PR DESCRIPTION
As https://github.com/xbmc/xbmc/pull/2091 seems to be stale, this one follows it up, adapted to latest changes (min api 14, main.java, ...)

There is still an issue:
When the nav bar is hidden, a touch shows it up but we don't get the touch event, so you actually have to touch twice to get the OSD.
