### PR TITLE
Added SSL for MySQL database connections

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -465,6 +465,9 @@ bool CDatabase::Connect(const CStdString &dbName, const DatabaseSettings &dbSett
   // database name is always required
   m_pDB->setDatabase(dbName.c_str());
 
+  // set SSL configuration regardless if any are empty (all empty means no SSL).
+  m_pDB->setSSLConfig(dbSettings.key.c_str(), dbSettings.cert.c_str(), dbSettings.ca.c_str(), dbSettings.capath.c_str(), dbSettings.ciphers.c_str());
+
   // create the datasets
   m_pDS.reset(m_pDB->CreateDataset());
   m_pDS2.reset(m_pDB->CreateDataset());

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -54,12 +54,18 @@ Database::~Database() {
   disconnect();		// Disconnect if connected to database
 }
 
-int Database::connectFull(const char *newHost, const char *newPort, const char *newDb, const char *newLogin, const char *newPasswd) {
+int Database::connectFull(const char *newHost, const char *newPort, const char *newDb, const char *newLogin, const char *newPasswd,
+                        const char *newKey, const char *newCert, const char *newCA, const char *newCApath, const char *newCiphers) {
   host = newHost;
   port = newPort;
   db = newDb;
   login = newLogin;
   passwd = newPasswd;
+  key = newKey;
+  cert = newCert;
+  ca = newCA;
+  capath = newCApath;
+  ciphers = newCiphers;
   return connect(true);
 }
 

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -71,7 +71,8 @@ protected:
   std::string error, // Error description
     host, port, db, login, passwd, //Login info
     sequence_table, //Sequence table for nextid
-    default_charset; //Default character set
+    default_charset, //Default character set
+    key, cert, ca, capath, ciphers; //SSL - Encryption info
 
 public:
 /* constructor */
@@ -107,6 +108,14 @@ public:
   const char *getSequenceTable(void) { return sequence_table.c_str(); }
 /* Get the default character set */
   const char *getDefaultCharset(void) { return default_charset.c_str(); }
+/* Sets SSL configuration */
+  virtual void setSSLConfig(const char *newKey, const char *newCert, const char *newCA, const char *newCApath, const char *newCiphers) {
+    key = newKey;
+    cert = newCert;
+    ca = newCA;
+    capath = newCApath;
+    ciphers = newCiphers;
+  }
 
 /* virtual methods that must be overloaded in derived classes */
 
@@ -117,7 +126,9 @@ public:
 	
   virtual int connect(bool create) { return DB_COMMAND_OK; }
   virtual int connectFull( const char *newDb, const char *newHost=NULL,
-                      const char *newLogin=NULL, const char *newPasswd=NULL,const char *newPort=NULL);
+                      const char *newLogin=NULL, const char *newPasswd=NULL,const char *newPort=NULL,
+                      const char *newKey=NULL, const char *newCert=NULL, const char *newCA=NULL, 
+                      const char *newCApath=NULL, const char *newCiphers=NULL);
   virtual void disconnect(void) { active = false; }
   virtual int reset(void) { return DB_COMMAND_OK; }
   virtual int create(void) { return DB_COMMAND_OK; }

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -116,8 +116,16 @@ int MysqlDatabase::connect(bool create_new) {
   {
     disconnect();
 
-    if (conn == NULL)
+    if (conn == NULL) {
       conn = mysql_init(conn);
+      mysql_ssl_set(
+        conn, 
+        key.empty() ? NULL : key.c_str(), 
+        cert.empty() ? NULL : cert.c_str(), 
+        ca.empty() ? NULL : ca.c_str(), 
+        capath.empty() ? NULL : capath.c_str(), 
+        ciphers.empty() ? NULL : ciphers.c_str());
+    }
 
     // establish connection with just user credentials
     if (mysql_real_connect(conn, host.c_str(),login.c_str(),passwd.c_str(), NULL, atoi(port.c_str()),NULL,0) != NULL)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1020,6 +1020,11 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetString(pDatabase, "user", m_databaseVideo.user);
     XMLUtils::GetString(pDatabase, "pass", m_databaseVideo.pass);
     XMLUtils::GetString(pDatabase, "name", m_databaseVideo.name);
+    XMLUtils::GetString(pDatabase, "key", m_databaseVideo.key);
+    XMLUtils::GetString(pDatabase, "cert", m_databaseVideo.cert);
+    XMLUtils::GetString(pDatabase, "ca", m_databaseVideo.ca);
+    XMLUtils::GetString(pDatabase, "capath", m_databaseVideo.capath);
+    XMLUtils::GetString(pDatabase, "ciphers", m_databaseVideo.ciphers);
   }
 
   pDatabase = pRootElement->FirstChildElement("musicdatabase");
@@ -1031,6 +1036,11 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetString(pDatabase, "user", m_databaseMusic.user);
     XMLUtils::GetString(pDatabase, "pass", m_databaseMusic.pass);
     XMLUtils::GetString(pDatabase, "name", m_databaseMusic.name);
+    XMLUtils::GetString(pDatabase, "key", m_databaseMusic.key);
+    XMLUtils::GetString(pDatabase, "cert", m_databaseMusic.cert);
+    XMLUtils::GetString(pDatabase, "ca", m_databaseMusic.ca);
+    XMLUtils::GetString(pDatabase, "capath", m_databaseMusic.capath);
+    XMLUtils::GetString(pDatabase, "ciphers", m_databaseMusic.ciphers);
   }
 
   pDatabase = pRootElement->FirstChildElement("tvdatabase");
@@ -1042,6 +1052,11 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetString(pDatabase, "user", m_databaseTV.user);
     XMLUtils::GetString(pDatabase, "pass", m_databaseTV.pass);
     XMLUtils::GetString(pDatabase, "name", m_databaseTV.name);
+    XMLUtils::GetString(pDatabase, "key", m_databaseTV.key);
+    XMLUtils::GetString(pDatabase, "cert", m_databaseTV.cert);
+    XMLUtils::GetString(pDatabase, "ca", m_databaseTV.ca);
+    XMLUtils::GetString(pDatabase, "capath", m_databaseTV.capath);
+    XMLUtils::GetString(pDatabase, "ciphers", m_databaseTV.ciphers);
   }
 
   pDatabase = pRootElement->FirstChildElement("epgdatabase");
@@ -1053,6 +1068,11 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetString(pDatabase, "user", m_databaseEpg.user);
     XMLUtils::GetString(pDatabase, "pass", m_databaseEpg.pass);
     XMLUtils::GetString(pDatabase, "name", m_databaseEpg.name);
+    XMLUtils::GetString(pDatabase, "key", m_databaseEpg.key);
+    XMLUtils::GetString(pDatabase, "cert", m_databaseEpg.cert);
+    XMLUtils::GetString(pDatabase, "ca", m_databaseEpg.ca);
+    XMLUtils::GetString(pDatabase, "capath", m_databaseEpg.capath);
+    XMLUtils::GetString(pDatabase, "ciphers", m_databaseEpg.ciphers);
   }
 
   pElement = pRootElement->FirstChildElement("enablemultimediakeys");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -38,6 +38,11 @@ public:
     user.clear();
     pass.clear();
     name.clear();
+    key.clear();
+    cert.clear();
+    ca.clear();
+    capath.clear();
+    ciphers.clear();
   };
   CStdString type;
   CStdString host;
@@ -45,6 +50,11 @@ public:
   CStdString user;
   CStdString pass;
   CStdString name;
+  CStdString key;
+  CStdString cert;
+  CStdString ca;
+  CStdString capath;
+  CStdString ciphers;
 };
 
 struct TVShowRegexp


### PR DESCRIPTION
I have added the ability to connect using SSL to a MySQL database.

The following options have been added to the videodatabase/musicdatabase sections of the advanced settings XML file.

```
    <key></key>
    <cert></cert>
    <ca></ca>
    <capath></capath>
    <ciphers></ciphers>
```

All of these new options are completely optional and are silently ignored if defined when using SQLite. The options follow the specifications as defined for the mysql_ssl_set() function in MySQL 5.0 and later. See the following link for details http://dev.mysql.com/doc/refman/5.0/en/mysql-ssl-set.html .

I have tested this update on Windows 8 x64 and Fedora 17 x64. I found no problems.
