### PR TITLE
Add media parameter to Playlist.Item directory type

### DIFF
--- a/xbmc/interfaces/json-rpc/PlaylistOperations.h
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.h
@@ -41,5 +41,6 @@ namespace JSONRPC
     static int GetPlaylist(const CVariant &playlist);
     static inline void NotifyAll();
     static JSONRPC_STATUS GetPropertyValue(int playlist, const CStdString &property, CVariant &result);
+    static bool CheckMediaParameter(int playlist, const CVariant &parameterObject);
   };
 }

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://www.xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.3.0";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.4.0";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -174,7 +174,7 @@ namespace JSONRPC
     "\"Playlist.Item\": {"
       "\"type\": ["
         "{ \"type\": \"object\", \"properties\": { \"file\": { \"type\": \"string\", \"description\": \"Path to a file (not a directory) to be added to the playlist\", \"required\": true } }, \"additionalProperties\": false },"
-        "{ \"type\": \"object\", \"properties\": { \"directory\": { \"type\": \"string\", \"required\": true }, \"recursive\": { \"type\": \"boolean\", \"default\": false } }, \"additionalProperties\": false },"
+        "{ \"type\": \"object\", \"properties\": { \"directory\": { \"type\": \"string\", \"required\": true }, \"recursive\": { \"type\": \"boolean\", \"default\": false }, \"media\": { \"$ref\": \"Files.Media\" } }, \"additionalProperties\": false },"
         "{ \"type\": \"object\", \"properties\": { \"movieid\": { \"$ref\": \"Library.Id\", \"required\": true } }, \"additionalProperties\": false },"
         "{ \"type\": \"object\", \"properties\": { \"episodeid\": { \"$ref\": \"Library.Id\", \"required\": true } }, \"additionalProperties\": false },"
         "{ \"type\": \"object\", \"properties\": { \"musicvideoid\": { \"$ref\": \"Library.Id\", \"required\": true } }, \"additionalProperties\": false },"

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -147,7 +147,7 @@
   "Playlist.Item": {
     "type": [
       { "type": "object", "properties": { "file": { "type": "string", "description": "Path to a file (not a directory) to be added to the playlist", "required": true } }, "additionalProperties": false },
-      { "type": "object", "properties": { "directory": { "type": "string", "required": true }, "recursive": { "type": "boolean", "default": false } }, "additionalProperties": false },
+      { "type": "object", "properties": { "directory": { "type": "string", "required": true }, "recursive": { "type": "boolean", "default": false }, "media": { "$ref": "Files.Media" } }, "additionalProperties": false },
       { "type": "object", "properties": { "movieid": { "$ref": "Library.Id", "required": true } }, "additionalProperties": false },
       { "type": "object", "properties": { "episodeid": { "$ref": "Library.Id", "required": true } }, "additionalProperties": false },
       { "type": "object", "properties": { "musicvideoid": { "$ref": "Library.Id", "required": true } }, "additionalProperties": false },


### PR DESCRIPTION
Allow complete control from remote of the media to add, now permit a correct Player.Open on directories with mixed items.
Also permit to have metadata loaded when files are added from Player.Open
The cases where user force a wrong type for a specific playlist type is already handled in the code and return the FailedToExecute error.

@Montellese for review.
With previous commit should handle all needs from http://forum.xbmc.org/showthread.php?tid=154373
