### PR TITLE
Change AnnouncePlayerPlay to announce speed 0 for pausing slideshow or picture

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -160,7 +160,7 @@ CGUIWindowSlideShow::~CGUIWindowSlideShow(void)
 void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)
 {
   CVariant param;
-  param["player"]["speed"] = 1;
+  param["player"]["speed"] = m_bSlideShow && !m_bPause ? 1 : 0;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
   ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", item, param);
 }


### PR DESCRIPTION
because for picture/slideshow, it currently announce OnPlay with speed 1, it doesn't make sense, so I suggest change the speed to 0 for standalone picture or pausing slideshow.

although we can announce OnPause for that, but it's not unify since normally we use OnStart/OnStop pair. then a startup OnPause or OnPlay with speed 0, which should we use?
