### PR TITLE
Set autologin profile via the GUI

### DIFF
--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -68,8 +68,8 @@
 				<posx>10</posx>
 				<posy>90</posy>
 				<width>250</width>
-				<height>80</height>
-				<textoffsety>13</textoffsety>
+				<height>72</height>
+				<textoffsety>8</textoffsety>
 				<label>20096</label>
 				<font>font24_title</font>
 				<align>right</align>
@@ -78,13 +78,13 @@
 				<texturefocus border="5">MenuItemFO.png</texturefocus>
 				<onleft>2</onleft>
 				<onright>2</onright>
-				<onup>4</onup>
-				<ondown>4</ondown>
+				<onup>5</onup>
+				<ondown>5</ondown>
 				<enable>!Window.IsVisible(ProfileSettings)</enable>
 			</control>
 			<control type="label">
 				<posx>250</posx>
-				<posy>135</posy>
+				<posy>130</posy>
 				<width>240</width>
 				<height>25</height>
 				<font>font13</font>
@@ -96,7 +96,7 @@
 			</control>
 			<control type="label">
 				<posx>250</posx>
-				<posy>135</posy>
+				<posy>130</posy>
 				<width>240</width>
 				<height>25</height>
 				<font>font13</font>
@@ -106,9 +106,64 @@
 				<label>1223</label>
 				<visible>!System.HasLoginScreen</visible>
 			</control>
+			<control type="button" id="5"> 
+				<description>Choose auto login user</description> 
+				<posx>10</posx> 
+				<posy>161</posy> 
+				<width>250</width> 
+				<height>72</height> 
+				<textoffsety>8</textoffsety> 
+				<label>31960</label> 
+				<font>font24_title</font> 
+				<align>right</align> 
+				<aligny>top</aligny> 
+				<texturenofocus border="5">MenuItemNF.png</texturenofocus> 
+				<texturefocus border="5">MenuItemFO.png</texturefocus> 
+				<onleft>2</onleft> 
+				<onright>2</onright> 
+				<onup>4</onup> 
+				<ondown>4</ondown> 
+				<visible>!System.HasLoginScreen</visible> 
+				<enable>!Window.IsVisible(ProfileSettings) + !System.HasLoginScreen</enable> 
+			</control> 
+			<control type="button"> 
+				<description>Choose auto login user (grayed out)</description> 
+				<posx>10</posx> 
+				<posy>161</posy> 
+				<width>250</width> 
+				<height>72</height> 
+				<textoffsety>8</textoffsety> 
+				<label>31960</label> 
+				<font>font24_title</font> 
+				<textcolor>grey2</textcolor> 
+				<align>right</align> 
+				<aligny>top</aligny> 
+				<texturenofocus border="5">MenuItemNF.png</texturenofocus> 
+				<texturefocus border="5">MenuItemFO.png</texturefocus> 
+				<onleft>2</onleft> 
+				<onright>2</onright> 
+				<onup>4</onup> 
+				<ondown>4</ondown> 
+				<visible>System.HasLoginScreen</visible> 
+				<enable>false</enable> 
+			</control> 
+			<control type="label"> 
+				<posx>247</posx> 
+				<posy>201</posy> 
+				<width>200</width> 
+				<height>25</height> 
+				<font>font13caps</font> 
+				<textcolor>grey2</textcolor> 
+				<align>right</align> 
+ 				<aligny>center</aligny> 
+				<label>$INFO[System.ProfileAutoLogin]</label> 
+				<scroll>Control.HasFocus(5)</scroll> 
+				<scrollspeed>30</scrollspeed> 
+				<visible>!System.HasLoginScreen</visible> 
+			</control> 
 			<control type="group">
 				<posx>20</posx>
-				<posy>210</posy>
+				<posy>260</posy>
 				<control type="image">
 					<posx>0</posx>
 					<posy>0</posy>
@@ -121,7 +176,7 @@
 				</control>
 				<control type="label">
 					<posx>0</posx>
-					<posy>220</posy>
+					<posy>210</posy>
 					<width>240</width>
 					<height>20</height>
 					<font>font12_title</font>
@@ -132,7 +187,7 @@
 				</control>
 				<control type="label">
 					<posx>0</posx>
-					<posy>245</posy>
+					<posy>235</posy>
 					<width>240</width>
 					<height>20</height>
 					<font>font13</font>
@@ -143,7 +198,7 @@
 				</control>
 				<control type="label">
 					<posx>0</posx>
-					<posy>280</posy>
+					<posy>265</posy>
 					<width>240</width>
 					<height>30</height>
 					<font>font12_title</font>
@@ -154,7 +209,7 @@
 				</control>
 				<control type="label">
 					<posx>0</posx>
-					<posy>305</posy>
+					<posy>290</posy>
 					<width>240</width>
 					<height>30</height>
 					<font>font13</font>

--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -667,3 +667,7 @@ msgstr ""
 msgctxt "#31959"
 msgid "SYSTEM"
 msgstr ""
+
+msgctxt "#31960"
+msgid "Auto login"
+msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11887,3 +11887,8 @@ msgstr ""
 msgctxt "#37013"
 msgid "(Directors Comments)"
 msgstr ""
+
+#: xbmc/GUIInfoManager.cpp
+msgctxt "#37014"
+msgid "Most recent"
+msgstr ""

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -268,6 +268,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "profilename",      SYSTEM_PROFILENAME },
                                   { "profilethumb",     SYSTEM_PROFILETHUMB },
                                   { "profilecount",     SYSTEM_PROFILECOUNT },
+                                  { "profileautologin", SYSTEM_PROFILEAUTOLOGIN },
                                   { "progressbar",      SYSTEM_PROGRESS_BAR },
                                   { "batterylevel",     SYSTEM_BATTERY_LEVEL },
                                   { "friendlyname",     SYSTEM_FRIENDLY_NAME },
@@ -1750,6 +1751,18 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     break;
   case SYSTEM_PROFILECOUNT:
     strLabel.Format("%i", CProfilesManager::Get().GetNumberOfProfiles());
+    break;
+  case SYSTEM_PROFILEAUTOLOGIN:
+    {
+      int profileId = CProfilesManager::Get().GetAutoLoginProfileId();
+      if (profileId == -1)
+        strLabel = g_localizeStrings.Get(37014); // Most recent
+      else
+      {
+        const CProfile *profile = CProfilesManager::Get().GetProfile(profileId);
+        strLabel = profile->getName();
+      }
+    }
     break;
   case SYSTEM_LANGUAGE:
     strLabel = g_guiSettings.GetString("locale.language");

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -418,6 +418,8 @@ namespace INFO
 #define FANART_COLOR3               1002
 #define FANART_IMAGE                1003
 
+#define SYSTEM_PROFILEAUTOLOGIN     1004
+
 #define PVR_CONDITIONS_START        1100
 #define PVR_IS_RECORDING            (PVR_CONDITIONS_START)
 #define PVR_HAS_TIMER               (PVR_CONDITIONS_START + 1)

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -142,6 +142,20 @@ public:
 
   int GetCurrentProfileId() const { return GetCurrentProfile().getId(); }
 
+  /*! \brief Retrieve the autologin profile id
+    Retrieves the autologin profile id. When set to -1, then the last
+    used profile will be loaded
+    \return the id to the autologin profile
+    */
+  int GetAutoLoginProfileId() const { return m_autoLoginProfile; }
+
+  /*! \brief Retrieve the autologin profile id
+    Retrieves the autologin profile id. When set to -1, then the last
+    used profile will be loaded
+    \return the id to the autologin profile
+    */
+  void SetAutoLoginProfileId(const int profileId) { m_autoLoginProfile = profileId; }
+
   std::string GetUserDataFolder() const;
   std::string GetProfileUserDataFolder() const;
   std::string GetDatabaseFolder() const;

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -24,6 +24,7 @@
 #include "profiles/ProfilesManager.h"
 #include "Application.h"
 #include "dialogs/GUIDialogContextMenu.h"
+#include "dialogs/GUIDialogSelect.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
 #include "network/Network.h"
 #include "utils/URIUtils.h"
@@ -41,6 +42,7 @@ using namespace XFILE;
 #define CONTROL_PROFILES 2
 #define CONTROL_LASTLOADED_PROFILE 3
 #define CONTROL_LOGINSCREEN 4
+#define CONTROL_AUTOLOGIN 5
 
 CGUIWindowSettingsProfile::CGUIWindowSettingsProfile(void)
     : CGUIWindow(WINDOW_SETTINGS_PROFILES, "SettingsProfile.xml")
@@ -168,6 +170,17 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
         CProfilesManager::Get().Save();
         return true;
       }
+      else if (iControl == CONTROL_AUTOLOGIN)
+      {
+    	int currentId = CProfilesManager::Get().GetAutoLoginProfileId();
+        int profileId;
+        if (GetAutoLoginProfileChoice(profileId) && (currentId != profileId))
+        {
+          CProfilesManager::Get().SetAutoLoginProfileId(profileId);
+          CProfilesManager::Get().Save();
+        }
+        return true;
+      }
     }
     break;
   }
@@ -219,3 +232,44 @@ void CGUIWindowSettingsProfile::OnInitWindow()
   CGUIWindow::OnInitWindow();
 }
 
+bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
+{
+  CGUIDialogSelect *dialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
+  if (!dialog) return false;
+
+  // add items
+  // "Most recent" option comes first, so up indices by 1
+  int autoLoginProfileId = CProfilesManager::Get().GetAutoLoginProfileId() + 1;
+  CFileItemList items;
+  CFileItemPtr item(new CFileItem());
+  item->SetLabel(g_localizeStrings.Get(37014)); // Most recent
+  item->SetIconImage("unknown-user.png");
+  items.Add(item);
+
+  for (unsigned int i = 0; i < CProfilesManager::Get().GetNumberOfProfiles(); i++)
+  {
+    const CProfile *profile = CProfilesManager::Get().GetProfile(i);
+    CStdString locked = g_localizeStrings.Get(profile->getLockMode() > 0 ? 20166 : 20165);
+    CFileItemPtr item(new CFileItem(profile->getName()));
+    item->SetProperty("Addon.Summary", locked); // lock setting
+    CStdString thumb = profile->getThumb();
+    if (thumb.IsEmpty())
+      thumb = "unknown-user.png";
+    item->SetIconImage(thumb);
+    items.Add(item);
+  }
+
+  dialog->SetHeading(20093); // Profile name
+  dialog->Reset();
+  dialog->SetUseDetails(true);
+  dialog->EnableButton(true, 222); // Cancel
+  dialog->SetItems(&items);
+  dialog->SetSelected(autoLoginProfileId);
+  dialog->DoModal();
+
+  if (dialog->IsButtonPressed() || dialog->GetSelectedLabel() < 0)
+    return false; // user cancelled
+  iProfile = dialog->GetSelectedLabel() - 1;
+
+  return true;
+}

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.h
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.h
@@ -41,4 +41,5 @@ protected:
   void LoadList();
   void SetLastLoaded();
   void ClearListItems();
+  bool GetAutoLoginProfileChoice(int &iProfile);
 };


### PR DESCRIPTION
PR #1540 added the option for auto login of a specific selected user profile.
This PR exposing this new setting to the skin and adds support for it in Confluence.

This concludes the refactoring of the patches provided by bruing in trac [10708](http://trac.xbmc.org/ticket/10708). This PR contains patches 2 and 3.

![screenshot000](https://f.cloud.github.com/assets/671891/358696/23894026-a149-11e2-9522-162ef575e91e.png)
![screenshot002](https://f.cloud.github.com/assets/671891/358697/2394eb42-a149-11e2-95d8-b9dadb287186.png)
![screenshot003](https://f.cloud.github.com/assets/671891/358698/239dd7b6-a149-11e2-9e17-12abf1015470.png)
