### PR TITLE
[win32][added] Hybrid shutdown on Windows 8

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -380,6 +380,15 @@ bool CSysInfo::IsVistaOrHigher()
 #endif // TARGET_WINDOWS
 }
 
+bool CSysInfo::IsWindows8OrHigher()
+{
+#ifdef TARGET_WINDOWS
+  return IsWindowsVersionAtLeast(WindowsVersionWin8);
+#else // TARGET_WINDOWS
+  return false;
+#endif // TARGET_WINDOWS
+}
+
 CSysInfo::WindowsVersion CSysInfo::m_WinVer = WindowsVersionUnknown;
 
 bool CSysInfo::IsWindowsVersion(WindowsVersion ver)

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -119,6 +119,7 @@ public:
   bool HasVideoToolBoxDecoder();
   bool IsAeroDisabled();
   bool IsVistaOrHigher();
+  bool IsWindows8OrHigher();
   static bool IsWindowsVersion(WindowsVersion ver);
   static bool IsWindowsVersionAtLeast(WindowsVersion ver);
   static WindowsVersion GetWindowsVersion();

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -42,6 +42,7 @@
 #include "FileSystem/File.h"
 #include "utils/URIUtils.h"
 #include "powermanagement\PowerManager.h"
+#include "utils/SystemInfo.h"
 
 // default Broadcom registy bits (setup when installing a CrystalHD card)
 #define BC_REG_PATH       "Software\\Broadcom\\MediaPC"
@@ -269,6 +270,7 @@ bool CWIN32Util::PowerManagement(PowerState State)
   // process OnSleep() events. This is called in main thread.
   g_powerManager.ProcessEvents();
 
+  UINT uExitFlags = 0;
   switch (State)
   {
   case POWERSTATE_HIBERNATE:
@@ -281,7 +283,9 @@ bool CWIN32Util::PowerManagement(PowerState State)
     break;
   case POWERSTATE_SHUTDOWN:
     CLog::Log(LOGINFO, "Shutdown Windows...");
-    return ExitWindowsEx(EWX_SHUTDOWN | EWX_FORCE, SHTDN_REASON_MAJOR_OPERATINGSYSTEM | SHTDN_REASON_MINOR_UPGRADE | SHTDN_REASON_FLAG_PLANNED) == TRUE;
+    if (g_sysinfo.IsWindows8OrHigher())
+      uExitFlags = 0x00400000; /* EWX_HYBRID_SHUTDOWN */
+    return ExitWindowsEx(uExitFlags | EWX_SHUTDOWN | EWX_FORCE, SHTDN_REASON_MAJOR_OPERATINGSYSTEM | SHTDN_REASON_MINOR_UPGRADE | SHTDN_REASON_FLAG_PLANNED) == TRUE;
     break;
   case POWERSTATE_REBOOT:
     CLog::Log(LOGINFO, "Rebooting Windows...");


### PR DESCRIPTION
Do a hybrid shutdown on Windows 8+ (which in turn enables quick boot). This is what the standard Windows shutdown command does and as a user I expect XBMC to do the same.

Actually Microsoft managed to do this in a non-backwards compatible fashion so I have to check the OS version before flagging ExitWindowsEx. Also our standard build environment does not know about EWX_HYBRID_SHUTDOWN so I just used its hex equivalent.

Tested on Windows XP Prof 32 bit, Windows 7 Home Premium 64-bit and Windows 8 Pro 64-bit.
