### PR TITLE
[players] Fix dts time after seek

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2068,7 +2068,10 @@ void CDVDPlayer::HandleMessages()
               CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %d, success", time);
           }
           // dts after successful seek
-          m_StateInput.dts = start;
+          if (m_StateInput.time_src  == ETIMESOURCE_CLOCK && start == DVD_NOPTS_VALUE)
+            m_StateInput.dts = DVD_MSEC_TO_TIME(time);
+          else
+            m_StateInput.dts = start;
 
           FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate());
         }

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2149,7 +2149,10 @@ void COMXPlayer::HandleMessages()
               CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %d, success", time);
           }
           // dts after successful seek
-          m_StateInput.dts = start;
+          if (m_StateInput.time_src  == ETIMESOURCE_CLOCK && start == DVD_NOPTS_VALUE)
+            m_StateInput.dts = DVD_MSEC_TO_TIME(time);
+          else
+            m_StateInput.dts = start;
 
           FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate());
         }

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2155,6 +2155,9 @@ void COMXPlayer::HandleMessages()
             m_StateInput.dts = start;
 
           FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate());
+          // let clock know the new time so progress bar updates immediately
+          if(m_StateInput.dts != DVD_NOPTS_VALUE)
+            m_av_clock.OMXMediaTime(m_StateInput.dts);
         }
         else
           CLog::Log(LOGWARNING, "error while seeking");
@@ -2180,6 +2183,10 @@ void COMXPlayer::HandleMessages()
         if(m_pDemuxer && m_pDemuxer->SeekChapter(msg.GetChapter(), &start))
         {
           FlushBuffers(false, start, true);
+          // let clock know the new time so progress bar updates immediately
+          if(start != DVD_NOPTS_VALUE)
+            m_av_clock.OMXMediaTime(start);
+
           m_callback.OnPlayBackSeekChapter(msg.GetChapter());
         }
 
@@ -3350,9 +3357,6 @@ void COMXPlayer::FlushBuffers(bool queued, double pts, bool accurate)
     CSingleLock lock(m_StateSection);
     m_State = m_StateInput;
   }
-  // let clock know the new time so progress bar updates immediately
-  if(startpts != DVD_NOPTS_VALUE)
-    m_av_clock.OMXMediaTime(startpts);
 }
 
 // since we call ffmpeg functions to decode, this is being called in the same thread as ::Process() is


### PR DESCRIPTION
I've been having a problem on Pi with network streams that after a seek the displayed time reads zero until the first packet is received by players.
This means pressing seek twice uses the zero as the second seek's origin jumping back to near the start of the file.

For iPlayer (which uses rtmp), m_pDemuxer->SeekTime(time, msg.GetBackward(), &start) returns start=DVD_NOPTS_VALUE.

We call FlushBuffers which calls UpdatePlayState which does (on m_StateInput)

```
if(state.dts == DVD_NOPTS_VALUE)
  state.time     = 0;
```

and then FlushBuffers copies m_StateInput to m_state, so m_state.time = 0, which means GetTime returns zero, which is wrong.

Discussing this with FernetMenta he suggested dts should be set to the requested time, rather than the time from demuxer, so I've submitted this PR to get more opinions (e.g. from @elupus).

This does fix my iPlayer problem on the Pi. Not tested on dvdplayer, but it looks like it has the same behaviour.

A safer alternative would be to only use DVD_MSEC_TO_TIME(time) when start == DVD_NOPTS_VALUE, but I'd like to hear what is more correct.
