### PR TITLE
Slideshow picture with video rework

### DIFF
--- a/addons/skin.confluence/720p/SlideShow.xml
+++ b/addons/skin.confluence/720p/SlideShow.xml
@@ -35,5 +35,17 @@
 			<include>VisibleFadeEffect</include>
 			<include>SmallMusicInfo</include>
 		</control>
+		<control type="button">
+			<visible>SlideShow.IsVideo + [!SlideShow.IsActive | SlideShow.IsPaused]</visible>
+			<description>Video Play Button</description>
+			<posx>540</posx>
+			<posy>260</posy>
+			<width>200</width>
+			<height>200</height>
+			<font>-</font>
+			<onclick>play</onclick>
+			<texturefocus>arrow-big-right.png</texturefocus>
+			<texturenofocus>arrow-big-right.png</texturenofocus>
+		</control>
 	</controls>
 </window>

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -161,7 +161,7 @@ CGUIWindowSlideShow::~CGUIWindowSlideShow(void)
 void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)
 {
   CVariant param;
-  param["player"]["speed"] = 1;
+  param["player"]["speed"] = m_bSlideShow && !m_bPause ? 1 : 0;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
   ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", item, param);
 }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -499,6 +499,8 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     return;
   }
 
+  CSingleLock lock(m_slideSection);
+
   if (!m_Image[m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading())
   { // load first image
     CFileItemPtr item = m_slides->Get(m_iCurrentSlide);

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -289,8 +289,12 @@ void CGUIWindowSlideShow::Add(const CFileItem *picture)
   CFileItemPtr item(new CFileItem(*picture));
   if (!item->HasVideoInfoTag() && !item->HasPictureInfoTag())
   {
-    // item without tag; assume it is a picture and force tag generation
-    item->GetPictureInfoTag();
+    // item without tag; get mimetype then we can tell whether it's video item
+    item->GetMimeType();
+
+    if (!item->IsVideo())
+      // then it is a picture and force tag generation
+      item->GetPictureInfoTag();
   }
   AnnouncePlaylistAdd(item, m_slides->Size());
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -691,7 +691,7 @@ int CGUIWindowSlideShow::GetNextSlide()
 {
   if (m_slides->Size() <= 1)
     return m_iCurrentSlide;
-  int step = (m_bSlideShow && !m_bPause) || m_iDirection >= 0 ? 1 : -1;
+  int step = m_iDirection >= 0 ? 1 : -1;
   int nextSlide = (m_iCurrentSlide + step + m_slides->Size()) % m_slides->Size();
   while (nextSlide != m_iCurrentSlide)
   {

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -121,7 +121,7 @@ void CBackgroundPicLoader::Process()
               bFullSize = true;
           }
         }
-        m_pCallback->OnLoadPic(m_iPic, m_iSlideNumber, texture, bFullSize);
+        m_pCallback->OnLoadPic(m_iPic, m_iSlideNumber, m_strFileName, texture, bFullSize);
         m_isLoading = false;
       }
     }
@@ -1067,18 +1067,18 @@ bool CGUIWindowSlideShow::PlayVideo()
   return false;
 }
 
-void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, CBaseTexture* pTexture, bool bFullSize)
+void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, const CStdString &strFileName, CBaseTexture* pTexture, bool bFullSize)
 {
   if (pTexture)
   {
     // set the pic's texture + size etc.
     CSingleLock lock(m_slideSection);
-    if (iSlideNumber >= m_slides->Size())
+    if (iSlideNumber >= m_slides->Size() || GetPicturePath(m_slides->Get(iSlideNumber).get()) != strFileName)
     { // throw this away - we must have cleared the slideshow while we were still loading
       delete pTexture;
       return;
     }
-    CLog::Log(LOGDEBUG, "Finished background loading %s", m_slides->Get(iSlideNumber)->GetPath().c_str());
+    CLog::Log(LOGDEBUG, "Finished background loading slot %d, %d: %s", iPic, iSlideNumber, m_slides->Get(iSlideNumber)->GetPath().c_str());
     if (m_bReloadImage)
     {
       if (m_Image[m_iCurrentPic].IsLoaded() && m_Image[m_iCurrentPic].SlideNumber() != iSlideNumber)
@@ -1110,6 +1110,9 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, CBaseTexture* pT
         }
       }
     }
+  }
+  else if (iSlideNumber >= m_slides->Size() || GetPicturePath(m_slides->Get(iSlideNumber).get()) != strFileName)
+  { // Failed to load image. and not match values calling LoadPic, then something is changed, ignore.
   }
   else
   { // Failed to load image.  What should be done??

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -615,10 +615,15 @@ int CGUIWindowSlideShow::GetNextSlide()
 {
   if (m_slides->Size() <= 1)
     return m_iCurrentSlide;
-  if (m_bSlideShow || m_iDirection >= 0)
-    return (m_iCurrentSlide + 1) % m_slides->Size();
-
-  return (m_iCurrentSlide - 1 + m_slides->Size()) % m_slides->Size();
+  int step = (m_bSlideShow && !m_bPause) || m_iDirection >= 0 ? 1 : -1;
+  int nextSlide = (m_iCurrentSlide + step + m_slides->Size()) % m_slides->Size();
+  while (nextSlide != m_iCurrentSlide)
+  {
+    if (!m_slides->Get(nextSlide)->HasProperty("unplayable"))
+      return nextSlide;
+    nextSlide = (nextSlide + step + m_slides->Size()) % m_slides->Size();
+  }
+  return m_iCurrentSlide;
 }
 
 EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouseEvent &event)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -412,6 +412,14 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   }
 
   bool bSlideShow = m_bSlideShow && !m_bPause && !m_bPlayingVideo;
+  if (bSlideShow && m_slides->Get(m_iCurrentSlide)->HasProperty("unplayable"))
+  {
+    m_iNextSlide    = GetNextSlide();
+    if (m_iCurrentSlide == m_iNextSlide)
+      return;
+    m_iCurrentSlide = m_iNextSlide;
+    m_iNextSlide    = GetNextSlide();
+  }
 
   if (m_bErrorMessage)
   { // we have an error when loading either the current or next picture

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -385,7 +385,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
 {
   // reset the screensaver if we're in a slideshow
   // (unless we are the screensaver!)
-  if (m_bSlideShow && !g_application.IsInScreenSaver())
+  if (m_bSlideShow && !m_bPause && !g_application.IsInScreenSaver())
     g_application.ResetScreenSaver();
   int iSlides = m_slides->Size();
   if (!iSlides) return ;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -388,6 +388,16 @@ void CGUIWindowSlideShow::StartSlideShow()
     AnnouncePlayerPlay(m_slides->Get(m_iCurrentSlide));
 }
 
+void CGUIWindowSlideShow::SetDirection(int direction)
+{
+  direction = direction >= 0 ? 1 : -1;
+  if (m_iDirection != direction)
+  {
+    m_iDirection = direction;
+    m_iNextSlide = GetNextSlide();
+  }
+}
+
 void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &regions)
 {
   // reset the screensaver if we're in a slideshow
@@ -830,7 +840,10 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
       if (!m_bPlayingVideo)
       {
         if (m_bSlideShow)
+        {
+          SetDirection(1);
           m_bPause = false;
+        }
         PlayVideo();
       }
     }
@@ -838,6 +851,7 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
     {
       m_bSlideShow = true;
       m_bPause = false;
+      SetDirection(1);
       if (m_Image[m_iCurrentPic].IsLoaded())
       {
         CSlideShowPic::DISPLAY_EFFECT effect = GetDisplayEffect(m_iCurrentSlide);

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -486,7 +486,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   }
 
   // check if we should discard an already loaded next slide
-  if (m_bLoadNextPic && m_Image[1 - m_iCurrentPic].IsLoaded() && m_Image[1 - m_iCurrentPic].SlideNumber() != m_iNextSlide)
+  if (m_Image[1 - m_iCurrentPic].IsLoaded() && m_Image[1 - m_iCurrentPic].SlideNumber() != m_iNextSlide)
     m_Image[1 - m_iCurrentPic].Close();
 
   // if we're reloading current image

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -492,7 +492,12 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   // if we're reloading current image
   if (m_bReloadImage)
   {
-    if (m_Image[m_iCurrentPic].IsLoaded() && !m_Image[1 - m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading() && !m_bWaitForNextPic && !m_slides->Get(m_iCurrentSlide)->IsVideo())
+    if (m_bWaitForNextPic || m_slides->Get(m_iCurrentSlide)->IsVideo())
+    {
+      // not reload current if we already wait the next or curent one is video thumb.
+      m_bReloadImage = false;
+    }
+    else if (m_Image[m_iCurrentPic].IsLoaded() && !m_Image[1 - m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading())
     { // reload the image if we need to
       CLog::Log(LOGDEBUG, "Reloading the current image %s at zoom level %i", m_slides->Get(m_iCurrentSlide)->GetPath().c_str(), m_iZoomFactor);
       // first, our maximal size for this zoom level

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1081,7 +1081,7 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, const CStdString
     CLog::Log(LOGDEBUG, "Finished background loading slot %d, %d: %s", iPic, iSlideNumber, m_slides->Get(iSlideNumber)->GetPath().c_str());
     if (m_bReloadImage)
     {
-      if (m_Image[m_iCurrentPic].IsLoaded() && m_Image[m_iCurrentPic].SlideNumber() != iSlideNumber)
+      if (!m_Image[m_iCurrentPic].IsLoaded() || m_Image[m_iCurrentPic].SlideNumber() != iSlideNumber)
       { // wrong image (ie we finished loading the next image, not the current image)
         delete pTexture;
         return;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1069,6 +1069,14 @@ bool CGUIWindowSlideShow::PlayVideo()
   return false;
 }
 
+CSlideShowPic::DISPLAY_EFFECT CGUIWindowSlideShow::GetDisplayEffect(int iSlideNumber) const
+{
+  if (m_bSlideShow && !m_bPause && !m_slides->Get(iSlideNumber)->IsVideo())
+    return CSettings::Get().GetBool("slideshow.displayeffects") ? CSlideShowPic::EFFECT_RANDOM : CSlideShowPic::EFFECT_NONE;
+  else
+    return CSlideShowPic::EFFECT_NO_TIMEOUT;
+}
+
 void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, const CStdString &strFileName, CBaseTexture* pTexture, bool bFullSize)
 {
   if (pTexture)
@@ -1094,10 +1102,7 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, const CStdString
     }
     else
     {
-      if (m_bSlideShow)
-        m_Image[iPic].SetTexture(iSlideNumber, pTexture, CSettings::Get().GetBool("slideshow.displayeffects") ? CSlideShowPic::EFFECT_RANDOM : CSlideShowPic::EFFECT_NONE);
-      else
-        m_Image[iPic].SetTexture(iSlideNumber, pTexture, CSlideShowPic::EFFECT_NO_TIMEOUT);
+      m_Image[iPic].SetTexture(iSlideNumber, pTexture, GetDisplayEffect(iSlideNumber));
       m_Image[iPic].SetOriginalSize(pTexture->GetOriginalWidth(), pTexture->GetOriginalHeight(), bFullSize);
 
       m_Image[iPic].m_bIsComic = false;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -489,10 +489,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   if (m_bLoadNextPic && m_Image[1 - m_iCurrentPic].IsLoaded() && m_Image[1 - m_iCurrentPic].SlideNumber() != m_iNextSlide)
     m_Image[1 - m_iCurrentPic].Close();
 
-  // if we're reloading an image (for better res on zooming we need to close any open ones as well)
-  if (m_bReloadImage && m_Image[1 - m_iCurrentPic].IsLoaded() && m_Image[1 - m_iCurrentPic].SlideNumber() != m_iCurrentSlide)
-    m_Image[1 - m_iCurrentPic].Close();
-
+  // if we're reloading current image
   if (m_bReloadImage)
   {
     if (m_Image[m_iCurrentPic].IsLoaded() && !m_Image[1 - m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading() && !m_bWaitForNextPic && !m_slides->Get(m_iCurrentSlide)->IsVideo())

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -611,7 +611,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
       if (!m_Image[1 - m_iCurrentPic].IsStarted())
       {
         CSlideShowPic::DISPLAY_EFFECT effect = GetDisplayEffect(m_iNextSlide);
-        if (m_Image[1 - m_iCurrentPic].IsDisplayEffectNeedChange(effect))
+        if (m_Image[1 - m_iCurrentPic].DisplayEffectNeedChange(effect))
           m_Image[1 - m_iCurrentPic].Reset(effect);
       }
       // set the appropriate transistion time
@@ -855,7 +855,7 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
       if (m_Image[m_iCurrentPic].IsLoaded())
       {
         CSlideShowPic::DISPLAY_EFFECT effect = GetDisplayEffect(m_iCurrentSlide);
-        if (m_Image[m_iCurrentPic].IsDisplayEffectNeedChange(effect))
+        if (m_Image[m_iCurrentPic].DisplayEffectNeedChange(effect))
           m_Image[m_iCurrentPic].Reset(effect);
       }
       AnnouncePlayerPlay(m_slides->Get(m_iCurrentSlide));

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -265,22 +265,25 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
 
   g_windowManager.ShowOverlay(OVERLAY_STATE_SHOWN);
 
-  // wait for any outstanding picture loads
-  if (m_pBackgroundLoader)
+  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO)
   {
-    // sleep until the loader finishes loading the current pic
-    CLog::Log(LOGDEBUG,"Waiting for BackgroundLoader thread to close");
-    while (m_pBackgroundLoader->IsLoading())
-      Sleep(10);
-    // stop the thread
-    CLog::Log(LOGDEBUG,"Stopping BackgroundLoader thread");
-    m_pBackgroundLoader->StopThread();
-    delete m_pBackgroundLoader;
-    m_pBackgroundLoader = NULL;
+    // wait for any outstanding picture loads
+    if (m_pBackgroundLoader)
+    {
+      // sleep until the loader finishes loading the current pic
+      CLog::Log(LOGDEBUG,"Waiting for BackgroundLoader thread to close");
+      while (m_pBackgroundLoader->IsLoading())
+        Sleep(10);
+      // stop the thread
+      CLog::Log(LOGDEBUG,"Stopping BackgroundLoader thread");
+      m_pBackgroundLoader->StopThread();
+      delete m_pBackgroundLoader;
+      m_pBackgroundLoader = NULL;
+    }
+    // and close the images.
+    m_Image[0].Close();
+    m_Image[1].Close();
   }
-  // and close the images.
-  m_Image[0].Close();
-  m_Image[1].Close();
   g_infoManager.ResetCurrentSlide();
 
   CGUIWindow::OnDeinitWindow(nextWindowID);

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -338,14 +338,17 @@ void CGUIWindowSlideShow::Select(const CStdString& strPicture)
     if (item->GetPath() == strPicture)
     {
       m_iDirection = 1;
-      if (IsActive())
-        m_iNextSlide = i;
-      else
+      if (!m_Image[m_iCurrentPic].IsLoaded() && (!m_pBackgroundLoader || !m_pBackgroundLoader->IsLoading()))
       {
+        // will trigger loading current slide when next Process call.
         m_iCurrentSlide = i;
         m_iNextSlide = GetNextSlide();
       }
-      m_bLoadNextPic = true;
+      else
+      {
+        m_iNextSlide = i;
+        m_bLoadNextPic = true;
+      }
       return ;
     }
   }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -306,11 +306,8 @@ void CGUIWindowSlideShow::ShowNext()
   if (m_slides->Size() == 1)
     return;
 
-  m_iNextSlide = m_iCurrentSlide + 1;
-  if (m_iNextSlide >= m_slides->Size())
-    m_iNextSlide = 0;
-
   m_iDirection   = 1;
+  m_iNextSlide   = GetNextSlide();
   m_iZoomFactor  = 1;
   m_fZoom        = 1.0f;
   m_fRotate      = 0.0f;
@@ -322,11 +319,8 @@ void CGUIWindowSlideShow::ShowPrevious()
   if (m_slides->Size() == 1)
     return;
 
-  m_iNextSlide = m_iCurrentSlide - 1;
-  if (m_iNextSlide < 0)
-    m_iNextSlide = m_slides->Size() - 1;
-
   m_iDirection   = -1;
+  m_iNextSlide   = GetNextSlide();
   m_iZoomFactor  = 1;
   m_fZoom        = 1.0f;
   m_fRotate      = 0.0f;
@@ -399,10 +393,10 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   if (!HasProcessed())
     regions.push_back(CRect(0.0f, 0.0f, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight()));
 
-  if (m_iNextSlide < 0 || m_iNextSlide >= m_slides->Size())
-    m_iNextSlide = 0;
   if (m_iCurrentSlide < 0 || m_iCurrentSlide >= m_slides->Size())
     m_iCurrentSlide = 0;
+  if (m_iNextSlide < 0 || m_iNextSlide >= m_slides->Size())
+    m_iNextSlide = GetNextSlide();
 
   // Create our background loader if necessary
   if (!m_pBackgroundLoader)
@@ -1061,7 +1055,7 @@ void CGUIWindowSlideShow::Shuffle()
 {
   m_slides->Randomize();
   m_iCurrentSlide = 0;
-  m_iNextSlide = 1;
+  m_iNextSlide = GetNextSlide();
   m_bShuffled = true;
 
   AnnouncePropertyChanged("shuffled", true);

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -104,6 +104,7 @@ private:
                 SORT_METHOD method = SORT_METHOD_LABEL,
                 SortOrder order = SortOrderAscending);
   bool PlayVideo();
+  CSlideShowPic::DISPLAY_EFFECT GetDisplayEffect(int iSlideNumber) const;
   void RenderPause();
   void RenderErrorMessage();
   void Rotate(float fAngle, bool immediate = false);

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -43,6 +43,8 @@ public:
   void Create(CGUIWindowSlideShow *pCallback);
   void LoadPic(int iPic, int iSlideNumber, const CStdString &strFileName, const int maxWidth, const int maxHeight);
   bool IsLoading() { return m_isLoading;};
+  int SlideNumber() const { return m_iSlideNumber; }
+  int Pic() const { return m_iPic; }
 
 private:
   void Process();

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -148,7 +148,6 @@ private:
   CBackgroundPicLoader* m_pBackgroundLoader;
   int m_iLastFailedNextSlide;
   bool m_bLoadNextPic;
-  bool m_bReloadImage;
   DllImageLib m_ImageLib;
   RESOLUTION m_Resolution;
   CCriticalSection m_slideSection;

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -89,7 +89,7 @@ public:
   virtual void Render();
   virtual void Process(unsigned int currentTime, CDirtyRegionList &regions);
   virtual void OnDeinitWindow(int nextWindowID);
-  void OnLoadPic(int iPic, int iSlideNumber, CBaseTexture* pTexture, bool bFullSize);
+  void OnLoadPic(int iPic, int iSlideNumber, const CStdString &strFileName, CBaseTexture* pTexture, bool bFullSize);
   int NumSlides() const;
   int CurrentSlide() const;
   void Shuffle();

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -101,6 +101,7 @@ private:
   void AddItems(const CStdString &strPath, path_set *recursivePaths,
                 SORT_METHOD method = SORT_METHOD_LABEL,
                 SortOrder order = SortOrderAscending);
+  bool PlayVideo();
   void RenderPause();
   void RenderErrorMessage();
   void Rotate(float fAngle, bool immediate = false);
@@ -108,6 +109,7 @@ private:
   void ZoomRelative(float fZoom, bool immediate = false);
   void Move(float fX, float fY);
   void GetCheckedSize(float width, float height, int &maxWidth, int &maxHeight);
+  CStdString GetPicturePath(CFileItem *item);
   int  GetNextSlide();
 
   void AnnouncePlayerPlay(const CFileItemPtr& item);

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -145,7 +145,7 @@ private:
   int m_iCurrentPic;
   // background loader
   CBackgroundPicLoader* m_pBackgroundLoader;
-  bool m_bWaitForNextPic;
+  int m_iLastFailedNextSlide;
   bool m_bLoadNextPic;
   bool m_bReloadImage;
   DllImageLib m_ImageLib;

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -98,6 +98,7 @@ public:
   bool IsPaused() const { return m_bPause; }
   bool IsShuffled() const { return m_bShuffled; }
   int GetDirection() const { return m_iDirection; }
+  void SetDirection(int direction); // -1: rewind, 1: forward
 private:
   typedef std::set<CStdString> path_set;  // set to track which paths we're adding
   void AddItems(const CStdString &strPath, path_set *recursivePaths,

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -87,7 +87,7 @@ void CSlideShowPic::Reset(DISPLAY_EFFECT dispEffect, TRANSISTION_EFFECT transEff
     Close();
 }
 
-bool CSlideShowPic::IsDisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const
+bool CSlideShowPic::DisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const
 {
   if (m_displayEffect == newDispEffect)
     return false;

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -78,10 +78,34 @@ void CSlideShowPic::Close()
   m_bIsDirty = true;
 }
 
+void CSlideShowPic::Reset(DISPLAY_EFFECT dispEffect, TRANSISTION_EFFECT transEffect)
+{
+  CSingleLock lock(m_textureAccess);
+  if (m_pImage)
+    SetTexture_Internal(m_iSlideNumber, m_pImage, dispEffect, transEffect);
+  else
+    Close();
+}
+
+bool CSlideShowPic::IsDisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const
+{
+  if (m_displayEffect == newDispEffect)
+    return false;
+  if (newDispEffect == EFFECT_RANDOM && m_displayEffect != EFFECT_NONE && m_displayEffect != EFFECT_NO_TIMEOUT)
+    return false;
+  return true;
+}
+
 void CSlideShowPic::SetTexture(int iSlideNumber, CBaseTexture* pTexture, DISPLAY_EFFECT dispEffect, TRANSISTION_EFFECT transEffect)
 {
   CSingleLock lock(m_textureAccess);
   Close();
+  SetTexture_Internal(iSlideNumber, pTexture, dispEffect, transEffect);
+}
+
+void CSlideShowPic::SetTexture_Internal(int iSlideNumber, CBaseTexture* pTexture, DISPLAY_EFFECT dispEffect, TRANSISTION_EFFECT transEffect)
+{
+  CSingleLock lock(m_textureAccess);
   m_bPause = false;
   m_bNoEffect = false;
   m_bTransistionImmediately = false;

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -52,6 +52,10 @@ public:
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   void Render();
   void Close();
+  void Reset(DISPLAY_EFFECT dispEffect = EFFECT_RANDOM, TRANSISTION_EFFECT transEffect = FADEIN_FADEOUT);
+  DISPLAY_EFFECT DisplayEffect() const { return m_displayEffect; }
+  bool IsDisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const;
+  bool IsStarted() const { return m_iCounter > 0; }
   bool IsFinished() const { return m_bIsFinished;};
   bool DrawNextImage() const { return m_bDrawNextImage;};
 
@@ -81,6 +85,7 @@ public:
   bool m_bCanMoveHorizontally;
   bool m_bCanMoveVertically;
 private:
+  void SetTexture_Internal(int iSlideNumber, CBaseTexture* pTexture, DISPLAY_EFFECT dispEffect = EFFECT_RANDOM, TRANSISTION_EFFECT transEffect = FADEIN_FADEOUT);
   void UpdateVertices(float cur_x[4], float cur_y[4], const float new_x[4], const float new_y[4], CDirtyRegionList &dirtyregions);
   void Render(float *x, float *y, CBaseTexture* pTexture, color_t color);
   CBaseTexture *m_pImage;

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -54,7 +54,7 @@ public:
   void Close();
   void Reset(DISPLAY_EFFECT dispEffect = EFFECT_RANDOM, TRANSISTION_EFFECT transEffect = FADEIN_FADEOUT);
   DISPLAY_EFFECT DisplayEffect() const { return m_displayEffect; }
-  bool IsDisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const;
+  bool DisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const;
   bool IsStarted() const { return m_iCounter > 0; }
   bool IsFinished() const { return m_bIsFinished;};
   bool DrawNextImage() const { return m_bDrawNextImage;};


### PR DESCRIPTION
This PR fixed some issues in slideshow/picture window:
1. unify slideshow/picture window behavior.
2. video in slideshow/picture nav now works as iDevice's photo app. when nav, show video thumb with a big play button.
3. better error handling, and skip error/unplayable picture during slideshow.

for touch screen, need this too: https://github.com/xbmc/skin.touched/pull/5

this one also included https://github.com/xbmc/xbmc/pull/2369 and https://github.com/xbmc/xbmc/pull/2573
and could consider as a rework and super version of https://github.com/xbmc/xbmc/issues/2164

besides, this one need https://github.com/xbmc/xbmc/pull/2244 to do better with video.
