### PR TITLE
Frodo airplayconflicts

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -37,6 +37,10 @@
 #include "utils/Variant.h"
 #include "guilib/GUIWindowManager.h"
 #include "URL.h"
+#include "cores/IPlayer.h"
+#include "interfaces/AnnouncementManager.h"
+
+using namespace ANNOUNCEMENT;
 
 #ifdef TARGET_WINDOWS
 #define close closesocket
@@ -133,6 +137,8 @@ const char *eventStrings[] = {"playing", "paused", "loading", "stopped"};
 "<dict>\r\n"\
 "<key>category</key>\r\n"\
 "<string>video</string>\r\n"\
+"<key>sessionID</key>\r\n"\
+"<integer>%d</integer>\r\n"\
 "<key>state</key>\r\n"\
 "<string>%s</string>\r\n"\
 "</dict>\r\n"\
@@ -140,6 +146,25 @@ const char *eventStrings[] = {"playing", "paused", "loading", "stopped"};
 
 #define AUTH_REALM "AirPlay"
 #define AUTH_REQUIRED "WWW-Authenticate: Digest realm=\""  AUTH_REALM  "\", nonce=\"%s\"\r\n"
+
+void CAirPlayServer::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+{
+  if ( (flag & Player) && strcmp(sender, "xbmc") == 0 && ServerInstance)
+  {
+    if (strcmp(message, "OnStop") == 0)
+    {
+      ServerInstance->AnnounceToClients(EVENT_STOPPED);
+    }
+    else if (strcmp(message, "OnPlay") == 0)
+    {
+      ServerInstance->AnnounceToClients(EVENT_PLAYING);
+    }
+    else if (strcmp(message, "OnPause") == 0)
+    {
+      ServerInstance->AnnounceToClients(EVENT_PAUSED);
+    }
+  }
+}
 
 bool CAirPlayServer::StartServer(int port, bool nonlocal)
 {
@@ -186,17 +211,62 @@ void CAirPlayServer::StopServer(bool bWait)
   }
 }
 
+void CAirPlayServer::AnnounceToClients(int state)
+{
+  CSingleLock lock (m_connectionLock);
+  
+  std::vector<CTCPClient>::iterator it;
+  for (it = m_connections.begin(); it != m_connections.end(); it++)
+  {
+    CStdString reverseHeader;
+    CStdString reverseBody;
+    CStdString response;
+    int reverseSocket = INVALID_SOCKET;
+    it->ComposeReverseEvent(reverseHeader, reverseBody, state);
+  
+    // Send event status per reverse http socket (play, loading, paused)
+    // if we have a reverse header and a reverse socket
+    if (reverseHeader.size() > 0 && m_reverseSockets.find(it->m_sessionId) != m_reverseSockets.end())
+    {
+      //search the reverse socket to this sessionid
+      response.Format("POST /event HTTP/1.1\r\n");
+      reverseSocket = m_reverseSockets[it->m_sessionId]; //that is our reverse socket
+      response += reverseHeader;
+    }
+    response += "\r\n";
+  
+    if (reverseBody.size() > 0)
+    {
+      response += reverseBody;
+    }
+  
+    // don't send it to the connection object
+    // the reverse socket itself belongs to
+    if (reverseSocket != INVALID_SOCKET && reverseSocket != it->m_socket)
+    {
+      send(reverseSocket, response.c_str(), response.size(), 0);//send the event status on the eventSocket
+    }
+  }
+}
+
 CAirPlayServer::CAirPlayServer(int port, bool nonlocal) : CThread("AirPlayServer")
 {
   m_port = port;
   m_nonlocal = nonlocal;
   m_ServerSocket = INVALID_SOCKET;
   m_usePassword = false;
+  CAnnouncementManager::AddAnnouncer(this);
+}
+
+CAirPlayServer::~CAirPlayServer()
+{
+  CAnnouncementManager::RemoveAnnouncer(this);
 }
 
 void CAirPlayServer::Process()
 {
   m_bStop = false;
+  static int sessionCounter = 0;
 
   while (!m_bStop)
   {
@@ -239,6 +309,7 @@ void CAirPlayServer::Process()
           }
           if (nread <= 0)
           {
+            CSingleLock lock (m_connectionLock);
             CLog::Log(LOGINFO, "AIRPLAY Server: Disconnection detected");
             m_connections[i].Disconnect();
             m_connections.erase(m_connections.begin() + i);
@@ -251,6 +322,8 @@ void CAirPlayServer::Process()
         CLog::Log(LOGDEBUG, "AIRPLAY Server: New connection detected");
         CTCPClient newconnection;
         newconnection.m_socket = accept(m_ServerSocket, &newconnection.m_cliaddr, &newconnection.m_addrlen);
+        sessionCounter++;
+        newconnection.m_sessionCounter = sessionCounter;
 
         if (newconnection.m_socket == INVALID_SOCKET)
         {
@@ -264,6 +337,7 @@ void CAirPlayServer::Process()
         }
         else
         {
+          CSingleLock lock (m_connectionLock);
           CLog::Log(LOGINFO, "AIRPLAY Server: New connection added");
           m_connections.push_back(newconnection);
         }
@@ -318,6 +392,7 @@ bool CAirPlayServer::Initialize()
 
 void CAirPlayServer::Deinitialize()
 {
+  CSingleLock lock (m_connectionLock);
   for (unsigned int i = 0; i < m_connections.size(); i++)
     m_connections[i].Disconnect();
 
@@ -380,11 +455,9 @@ void CAirPlayServer::CTCPClient::PushBuffer(CAirPlayServer *host, const char *bu
     // Parse the request
     CStdString responseHeader;
     CStdString responseBody;
-    CStdString reverseHeader;
-    CStdString reverseBody;
-    int status = ProcessRequest(responseHeader, responseBody, reverseHeader, reverseBody, sessionId);
+    int status = ProcessRequest(responseHeader, responseBody);
+    sessionId = m_sessionId;
     CStdString statusMsg = "OK";
-    int reverseSocket = INVALID_SOCKET;
 
     switch(status)
     {
@@ -434,28 +507,6 @@ void CAirPlayServer::CTCPClient::PushBuffer(CAirPlayServer *host, const char *bu
     {
       send(m_socket, response.c_str(), response.size(), 0);
     }
-
-    // Send event status per reverse http socket (play, loading, paused)
-    // if we have a reverse header and a reverse socket
-    if (reverseHeader.size() > 0 && reverseSockets.find(sessionId) != reverseSockets.end())
-    {
-      //search the reverse socket to this sessionid
-      response.Format("POST /event HTTP/1.1\r\n");
-      reverseSocket = reverseSockets[sessionId]; //that is our reverse socket
-      response += reverseHeader;
-    }
-    response += "\r\n";
-
-    if (reverseBody.size() > 0)
-    {
-      response += reverseBody;
-    }
-
-    if (reverseSocket != INVALID_SOCKET)
-    {
-      send(reverseSocket, response.c_str(), response.size(), 0);//send the event status on the eventSocket
-    }
-
     // We need a new parser...
     delete m_httpParser;
     m_httpParser = new HttpParser;
@@ -483,12 +534,12 @@ void CAirPlayServer::CTCPClient::Copy(const CTCPClient& client)
   m_httpParser        = client.m_httpParser;
   m_authNonce         = client.m_authNonce;
   m_bAuthenticated    = client.m_bAuthenticated;
+  m_sessionCounter    = client.m_sessionCounter;
 }
 
 
 void CAirPlayServer::CTCPClient::ComposeReverseEvent( CStdString& reverseHeader,
                                                       CStdString& reverseBody,
-                                                      CStdString sessionId,
                                                       int state)
 {
 
@@ -500,13 +551,13 @@ void CAirPlayServer::CTCPClient::ComposeReverseEvent( CStdString& reverseHeader,
       case EVENT_LOADING:
       case EVENT_PAUSED:
       case EVENT_STOPPED:      
-        reverseBody.Format(EVENT_INFO, eventStrings[state]);
+        reverseBody.Format(EVENT_INFO, m_sessionCounter, eventStrings[state]);
         CLog::Log(LOGDEBUG, "AIRPLAY: sending event: %s", eventStrings[state]);
         break;
     }
     reverseHeader = "Content-Type: text/x-apple-plist+xml\r\n";
-    reverseHeader.Format("%sContent-Length: %d",reverseHeader.c_str(),reverseBody.size());
-    reverseHeader.Format("%sx-apple-session-id: %s\r\n",reverseHeader.c_str(),sessionId.c_str());
+    reverseHeader.Format("%sContent-Length: %d\r\n",reverseHeader.c_str(),reverseBody.size());
+    reverseHeader.Format("%sx-apple-session-id: %s\r\n",reverseHeader.c_str(),m_sessionId.c_str());
     m_lastEvent = state;
   }
 }
@@ -630,17 +681,14 @@ bool CAirPlayServer::CTCPClient::checkAuthorization(const CStdString& authStr,
 }
 
 int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
-                                                CStdString& responseBody,
-                                                CStdString& reverseHeader,
-                                                CStdString& reverseBody,
-                                                CStdString& sessionId)
+                                                CStdString& responseBody)
 {
   CStdString method = m_httpParser->getMethod();
   CStdString uri = m_httpParser->getUri();
   CStdString queryString = m_httpParser->getQueryString();
   CStdString body = m_httpParser->getBody();
   CStdString contentType = m_httpParser->getValue("content-type");
-  sessionId = m_httpParser->getValue("x-apple-session-id");
+  m_sessionId = m_httpParser->getValue("x-apple-session-id");
   CStdString authorization = m_httpParser->getValue("authorization");
   int status = AIRPLAY_STATUS_OK;
   bool needAuth = false;
@@ -687,7 +735,6 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
         if (g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
         {
           CApplicationMessenger::Get().MediaPause();
-          ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PAUSED);
         }
       }
       else
@@ -695,7 +742,6 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
         if (g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && g_application.m_pPlayer->IsPaused())
         {
           CApplicationMessenger::Get().MediaPause();
-          ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PLAYING);
         }
       }
   }
@@ -819,8 +865,8 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
 
       CFileItem fileToPlay(location, false);
       fileToPlay.SetProperty("StartPercent", position*100.0f);
+      ServerInstance->AnnounceToClients(EVENT_LOADING);
       CApplicationMessenger::Get().MediaPlay(fileToPlay);
-      ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PLAYING);
     }
   }
 
@@ -878,7 +924,6 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       {
         g_windowManager.PreviousWindow();
       }
-      ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_STOPPED);
     }
   }
 
@@ -949,22 +994,13 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
 
       if (g_application.m_pPlayer->IsCaching())
       {
-        ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_LOADING);
-      }
-      else if (playing)
-      {
-        ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PLAYING);
-      }
-      else
-      {
-        ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PAUSED);
+        CAirPlayServer::ServerInstance->AnnounceToClients(EVENT_LOADING);
       }
     }
     else
     {
       responseBody.Format(PLAYBACK_INFO_NOT_READY, duration, cachePosition, position, (playing ? 1 : 0), duration);
       responseHeader = "Content-Type: text/x-apple-plist+xml\r\n";     
-      ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_STOPPED);
     }
   }
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -644,6 +644,9 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
   CStdString authorization = m_httpParser->getValue("authorization");
   int status = AIRPLAY_STATUS_OK;
   bool needAuth = false;
+  
+  if (m_sessionId.IsEmpty())
+    m_sessionId = "00000000-0000-0000-0000-000000000000";
 
   if (ServerInstance->m_usePassword && !m_bAuthenticated)
   {


### PR DESCRIPTION
fixed the conflicts and merged:

Commit:b93a152 - [airplay] - handle empty session ids from itunes
Commit:7f0b5c6 - [airplay] - refactor the playstate announcement by using the IAnnouncer interface
- also adapt to some new findings on revers engineering itunes airplay traffic (add sessioncounter to reverse event and fix http request formatting), fixes #14191 - use the include and namespace from the commit - the breakage is because of cptspiffs "split off IPlayer callback to a separate file" commit which is not backported and added an include in that file
