### PR TITLE
Add gesture handling to GUIControlGroupList and GUIEpgGridContainer

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1528,25 +1528,25 @@ void CGUIEPGGridContainer::ValidateOffset()
   if (!m_programmeLayout)
     return;
 
-  if (m_channelOffset > m_channels - m_channelsPerPage)
+  if (m_channelOffset > m_channels - m_channelsPerPage || m_channelScrollOffset > (m_channels - m_channelsPerPage) * m_channelHeight)
   {
     m_channelOffset = m_channels - m_channelsPerPage;
     m_channelScrollOffset = m_channelOffset * m_channelHeight;
   }
 
-  if (m_channelOffset < 0)
+  if (m_channelOffset < 0 || m_channelScrollOffset < 0)
   {
     m_channelOffset = 0;
     m_channelScrollOffset = 0;
   }
 
-  if (m_blockOffset > m_blocks - m_blocksPerPage)
+  if (m_blockOffset > m_blocks - m_blocksPerPage || m_programmeScrollOffset > (m_blocks - m_blocksPerPage) * m_blockSize)
   {
     m_blockOffset = m_blocks - m_blocksPerPage;
     m_programmeScrollOffset = m_blockOffset * m_blockSize;
   }
 
-  if (m_blockOffset < 0)
+  if (m_blockOffset < 0 || m_programmeScrollOffset < 0)
   {
     m_blockOffset = 0;
     m_programmeScrollOffset = 0;

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1204,10 +1204,10 @@ CGUIListItemLayout *CGUIEPGGridContainer::GetFocusedLayout() const
   return NULL;
 }
 
-bool CGUIEPGGridContainer::SelectItemFromPoint(const CPoint &point)
+bool CGUIEPGGridContainer::SelectItemFromPoint(const CPoint &point, bool justGrid /* = false */)
 {
   /* point has already had origin set to m_posX, m_posY */
-  if (!m_focusedProgrammeLayout || !m_programmeLayout)
+  if (!m_focusedProgrammeLayout || !m_programmeLayout || (justGrid && point.x < 0))
     return false;
 
   int channel = (int)(point.y / m_channelHeight);
@@ -1255,7 +1255,7 @@ EVENT_RESULT CGUIEPGGridContainer::OnMouseEvent(const CPoint &point, const CMous
 bool CGUIEPGGridContainer::OnMouseOver(const CPoint &point)
 {
   // select the item under the pointer
-  SelectItemFromPoint(point - CPoint(m_gridPosX, m_posY + m_rulerHeight));
+  SelectItemFromPoint(point - CPoint(m_gridPosX, m_posY + m_rulerHeight), false);
   return CGUIControl::OnMouseOver(point);
 }
 

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1219,6 +1219,10 @@ bool CGUIEPGGridContainer::SelectItemFromPoint(const CPoint &point)
   if (block > m_blocksPerPage) block = m_blocksPerPage - 1;
   if (block < 0) block = 0;
 
+  // bail if block isn't occupied
+  if (!m_gridIndex[channel + m_channelOffset][block + m_blockOffset].item)
+    return false;
+
   SetChannel(channel);
   SetBlock(block);
   return true;

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -98,7 +98,7 @@ namespace EPG
 
   protected:
     bool OnClick(int actionID);
-    bool SelectItemFromPoint(const CPoint &point);
+    bool SelectItemFromPoint(const CPoint &point, bool justGrid = true);
 
     void UpdateItems();
 

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -481,6 +481,25 @@ EVENT_RESULT CGUIControlGroupList::OnMouseEvent(const CPoint &point, const CMous
       offset = nextOffset;
     }
   }
+  else if (event.m_id == ACTION_GESTURE_BEGIN)
+  { // grab exclusive access
+    CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, GetID(), GetParentID());
+    SendWindowMessage(msg);
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_END)
+  { // release exclusive access
+    CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, 0, GetParentID());
+    SendWindowMessage(msg);
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_PAN)
+  { // do the drag and validate our offset (corrects for end of scroll)
+    m_scroller.SetValue(CLAMP(m_scroller.GetValue() - ((m_orientation == HORIZONTAL) ? event.m_offsetX : event.m_offsetY), 0, m_totalSize - Size()));
+    SetInvalid();
+    return EVENT_RESULT_HANDLED;
+  }
+
   return EVENT_RESULT_UNHANDLED;
 }
 


### PR DESCRIPTION
Not much to describe, title says it all.

I added one behaviour changing commit that I'm not sure about ( 3rd commit ) - currently we will react on clicking on channel list in epggrid same way we react on clicking programme block and I find it a little bit weird. In said commit I changed it so it reacts to mouse actions (mouse hovering being one exception) just on programme grid part of epggrid. Alternatively we could select currently active programme from hovered channel. Or just drop it and decide that current behaviour is not weird :)

--- edit
If anyone feel like testing, here's android build: http://mirrors.xbmc.org/test-builds/android/xbmc-20130410-c742dfb-panning-armeabi-v7a.apk <-- this build is outdated (mentioned above behaviour change isn't working there), but still can be used for gesture testing
