### PR TITLE
Fix crash on delete of active profile + other fixes for PR 2577

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11892,5 +11892,5 @@ msgstr ""
 
 #: xbmc/GUIInfoManager.cpp
 msgctxt "#37014"
-msgid "Most recent"
+msgid "Last used profile"
 msgstr ""

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1755,13 +1755,8 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
   case SYSTEM_PROFILEAUTOLOGIN:
     {
       int profileId = CProfilesManager::Get().GetAutoLoginProfileId();
-      if (profileId == -1)
-        strLabel = g_localizeStrings.Get(37014); // Most recent
-      else
-      {
-        const CProfile *profile = CProfilesManager::Get().GetProfile(profileId);
-        strLabel = profile->getName();
-      }
+      if ((profileId < 0) || (!CProfilesManager::Get().GetProfileName(profileId, strLabel)))
+        strLabel = g_localizeStrings.Get(37014); // Last used profile
     }
     break;
   case SYSTEM_LANGUAGE:

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -321,14 +321,18 @@ bool CProfilesManager::DeleteProfile(size_t index)
   if (!dlgYesNo->IsConfirmed())
     return false;
 
-  //delete profile
+  // fall back to master profile if necessary
+  if ((int)index == m_autoLoginProfile)
+    m_autoLoginProfile = 0;
+
+  // delete profile
   string strDirectory = profile->getDirectory();
   m_profiles.erase(m_profiles.begin() + index);
 
   // fall back to master profile if necessary
   if (index == m_currentProfile)
   {
-    Load(0);
+    LoadProfile(0);
     g_settings.Save();
   }
 
@@ -432,6 +436,17 @@ void CProfilesManager::LoadMasterProfileForLogin()
   m_lastUsedProfile = m_currentProfile;
   if (m_currentProfile != 0)
     LoadProfile(0);
+}
+
+bool CProfilesManager::GetProfileName(const size_t profileId, std::string& name) const
+{
+  CSingleLock lock(m_critical);
+  const CProfile *profile = GetProfile(profileId);
+  if (!profile)
+    return false;
+
+  name = profile->getName();
+  return true;
 }
 
 std::string CProfilesManager::GetUserDataFolder() const

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -156,6 +156,13 @@ public:
     */
   void SetAutoLoginProfileId(const int profileId) { m_autoLoginProfile = profileId; }
 
+  /*! \brief Retrieve the name of a particular profile by index
+    \param profileId profile index for which to retrieve the name
+    \param name will hold the name of the profile when a valid profile index has been provided
+    \return false if profileId is an invalid index, true if the name parameter is set
+    */
+  bool GetProfileName(const size_t profileId, std::string& name) const;
+
   std::string GetUserDataFolder() const;
   std::string GetProfileUserDataFolder() const;
   std::string GetDatabaseFolder() const;

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -172,7 +172,7 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_AUTOLOGIN)
       {
-    	int currentId = CProfilesManager::Get().GetAutoLoginProfileId();
+        int currentId = CProfilesManager::Get().GetAutoLoginProfileId();
         int profileId;
         if (GetAutoLoginProfileChoice(profileId) && (currentId != profileId))
         {
@@ -238,11 +238,11 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
   if (!dialog) return false;
 
   // add items
-  // "Most recent" option comes first, so up indices by 1
+  // "Last used profile" option comes first, so up indices by 1
   int autoLoginProfileId = CProfilesManager::Get().GetAutoLoginProfileId() + 1;
   CFileItemList items;
   CFileItemPtr item(new CFileItem());
-  item->SetLabel(g_localizeStrings.Get(37014)); // Most recent
+  item->SetLabel(g_localizeStrings.Get(37014)); // Last used profile
   item->SetIconImage("unknown-user.png");
   items.Add(item);
 


### PR DESCRIPTION
- Fixes a crash when the active profile is deleted.

Fixes for PR #2577
- Set the auto login profile to the Master user when profile being deleted is the currently configured auto login profile.
- Solved getting the profile name in GUIInfoManager.cpp line 1758 differently avoiding a NULL pointer posibility and making it thread safe.
- Changes the "Most recent" text to "Last used profile".
