### PR TITLE
Only override episode/season numbers if the file name has them

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1351,9 +1351,12 @@ namespace VIDEO
       if (result == CNfoFile::FULL_NFO)
       {
         m_nfoReader.GetDetails(*item.GetVideoInfoTag());
-        // override with episode and season number
-        item.GetVideoInfoTag()->m_iEpisode = file->iEpisode;
-        item.GetVideoInfoTag()->m_iSeason = file->iSeason;
+        // override with episode and season number from file if available
+        if (file->iEpisode > -1)
+        {
+          item.GetVideoInfoTag()->m_iEpisode = file->iEpisode;
+          item.GetVideoInfoTag()->m_iSeason = file->iSeason;
+        }
         if (AddVideo(&item, CONTENT_TVSHOWS, file->isFolder, true, &showInfo) < 0)
           return INFO_ERROR;
         continue;


### PR DESCRIPTION
This fixes the issue in these forum threads:
http://forum.xbmc.org/showthread.php?tid=159206
http://forum.xbmc.org/showthread.php?tid=161064

where the combination of a date-based file name and a full nfo file would result in the episodes being added as "season -1, episode -1", causing all kinds of nonsense.

The code behind this was added in commit 2e5050a3c82e4c04401507f346f98ac423d1883b in order to fix ticket [#13665](http://trac.xbmc.org/ticket/13665), and it's said in the ticket that a better solution to the problem would be to have the nfo file checked first to prevent the file duplication, but that's a little beyond my capabilities.  

This should be seen as a stopgap measure to repair the new bug (I'm thinking specifically in terms of v12.2) until a full fix can be made.
