### PR TITLE
[rbp] Don't block waiting for EOS in audio/video players

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -76,7 +76,8 @@ public:
   bool SetCurrentVolume(float fVolume);
   void SetDynamicRangeCompression(long drc) { m_drc = drc; }
   int SetPlaySpeed(int iSpeed);
-  void WaitCompletion();
+  void SubmitEOS();
+  bool IsEOS();
   void SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers);
 
   void Flush();

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2394,7 +2394,7 @@ void COMXPlayer::HandleMessages()
         CSingleLock lock(m_StateSection);
         /* prioritize data from video player, but only accept data        *
          * after it has been started to avoid race conditions after seeks */
-        if(m_CurrentVideo.started)
+        if(m_CurrentVideo.started && !m_player_video.SubmittedEOS())
         {
           if(state.player == DVDPLAYER_VIDEO)
             m_State = state;

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -77,7 +77,6 @@ OMXPlayerAudio::OMXPlayerAudio(OMXClock *av_clock, CDVDMessageQueue& parent)
   m_nChannels     = 0;
   m_DecoderOpen   = false;
   m_freq          = CurrentHostFrequency();
-  m_send_eos      = false;
   m_bad_state     = false;
   m_hints_current.Clear();
 
@@ -168,7 +167,6 @@ void OMXPlayerAudio::OpenStream(CDVDStreamInfo &hints, COMXAudioCodecOMX *codec)
   m_stalled         = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET) == 0;
   m_use_passthrough = (g_guiSettings.GetInt("audiooutput.mode") == AUDIO_HDMI) ? true : false ;
   m_use_hw_decode   = g_advancedSettings.m_omxHWAudioDecode;
-  m_send_eos        = false;
 }
 
 bool OMXPlayerAudio::CloseStream(bool bWaitForBuffers)
@@ -604,7 +602,7 @@ void OMXPlayerAudio::Process()
     else if (pMsg->IsType(CDVDMsg::GENERAL_EOF))
     {
       CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::GENERAL_EOF");
-      WaitCompletion();
+      SubmitEOS();
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_DELAY))
     {
@@ -821,11 +819,36 @@ double OMXPlayerAudio::GetCacheTime()
   return m_omxAudio.GetCacheTime();
 }
 
+void OMXPlayerAudio::SubmitEOS()
+{
+  if(!m_bad_state)
+    m_omxAudio.SubmitEOS();
+}
+
+bool OMXPlayerAudio::IsEOS()
+{
+  return m_bad_state || m_omxAudio.IsEOS();
+}
+
 void OMXPlayerAudio::WaitCompletion()
 {
-  if(!m_send_eos && !m_bad_state)
-    m_omxAudio.WaitCompletion();
-  m_send_eos = true;
+  unsigned int nTimeOut = AUDIO_BUFFER_SECONDS * 1000;
+  while(nTimeOut)
+  {
+    if(IsEOS())
+    {
+      CLog::Log(LOGDEBUG, "%s::%s - got eos\n", CLASSNAME, __func__);
+      break;
+    }
+
+    if(nTimeOut == 0)
+    {
+      CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", CLASSNAME, __func__);
+      break;
+    }
+    Sleep(50);
+    nTimeOut -= 50;
+  }
 }
 
 void OMXPlayerAudio::RegisterAudioCallback(IAudioCallback *pCallback)

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -88,7 +88,6 @@ protected:
   bool                      m_DecoderOpen;
 
   DllBcmHost                m_DllBcmHost;
-  bool                      m_send_eos;
   bool                      m_bad_state;
 
   virtual void OnStartup();
@@ -106,7 +105,7 @@ public:
   bool IsInited() const                             { return m_messageQueue.IsInited(); }
   int  GetLevel() const                             { return m_messageQueue.GetLevel(); }
   bool IsStalled()                                  { return m_stalled;  }
-  bool IsEOS()                                      { return m_send_eos; };
+  bool IsEOS();
   void WaitForBuffers();
   bool CloseStream(bool bWaitForBuffers);
   bool CodecChange();
@@ -121,6 +120,7 @@ public:
   double GetCacheTime();
   double GetCurrentPTS() { return m_audioClock; };
   void WaitCompletion();
+  void SubmitEOS();
   void  RegisterAudioCallback(IAudioCallback* pCallback);
   void  UnRegisterAudioCallback();
   void SetCurrentVolume(float fVolume);

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -78,7 +78,6 @@ protected:
   int                       m_view_mode;
 
   DllBcmHost                m_DllBcmHost;
-  bool                      m_send_eos;
 
   CDVDOverlayContainer  *m_pOverlayContainer;
   CDVDMessageQueue      &m_messageParent;
@@ -105,7 +104,7 @@ public:
   void WaitForBuffers()                             { m_messageQueue.WaitUntilEmpty(); }
   int  GetLevel() const                             { return m_messageQueue.GetLevel(); }
   bool IsStalled()                                  { return m_stalled;  }
-  bool IsEOS()                                      { return m_send_eos; };
+  bool IsEOS();
   bool CloseStream(bool bWaitForBuffers);
   void Output(int iGroupId, double pts, bool bDropPacket);
   void Flush();
@@ -114,7 +113,8 @@ public:
   int  GetDecoderFreeSpace();
   double GetCurrentPTS() { return m_iCurrentPts; };
   double GetFPS() { return m_fFrameRate; };
-  void  WaitCompletion();
+  void  SubmitEOS();
+  bool SubmittedEOS();
   void SetDelay(double delay) { m_iVideoDelay = delay; }
   double GetDelay() { return m_iVideoDelay; }
   void SetSpeed(int iSpeed);

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -92,6 +92,7 @@ COMXVideo::COMXVideo() : m_video_codec_name("")
   m_av_clock          = NULL;
   m_res_callback      = NULL;
   m_res_ctx           = NULL;
+  m_submitted_eos     = false;
 }
 
 COMXVideo::~COMXVideo()
@@ -169,6 +170,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool deinterlace, b
   m_decoded_height = hints.height;
 
   m_hdmi_clock_sync = hdmi_clock_sync;
+  m_submitted_eos = false;
 
   if(!m_decoded_width || !m_decoded_height)
     return false;
@@ -323,6 +325,8 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool deinterlace, b
   componentName = "OMX.broadcom.video_render";
   if(!m_omx_render.Initialize((const std::string)componentName, OMX_IndexParamVideoInit))
     return false;
+
+  m_omx_render.ResetEos();
 
   componentName = "OMX.broadcom.video_scheduler";
   if(!m_omx_sched.Initialize((const std::string)componentName, OMX_IndexParamVideoInit))
@@ -1035,10 +1039,12 @@ int COMXVideo::GetInputBufferSize()
   return m_omx_decoder.GetInputBufferSize();
 }
 
-void COMXVideo::WaitCompletion()
+void COMXVideo::SubmitEOS()
 {
   if(!m_is_open)
     return;
+
+  m_submitted_eos = true;
 
   OMX_ERRORTYPE omx_err = OMX_ErrorNone;
   OMX_BUFFERHEADERTYPE *omx_buffer = m_omx_decoder.GetInputBuffer();
@@ -1061,27 +1067,11 @@ void COMXVideo::WaitCompletion()
     CLog::Log(LOGERROR, "%s::%s - OMX_EmptyThisBuffer() failed with result(0x%x)\n", CLASSNAME, __func__, omx_err);
     return;
   }
+}
 
-  unsigned int nTimeOut = 30000;
-
-  while(nTimeOut)
-  {
-    if(m_omx_render.IsEOS())
-    {
-      CLog::Log(LOGDEBUG, "%s::%s - got eos\n", CLASSNAME, __func__);
-      break;
-    }
-
-    if(nTimeOut == 0)
-    {
-      CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", CLASSNAME, __func__);
-      break;
-    }
-    Sleep(50);
-    nTimeOut -= 50;
-  }
-
-  m_omx_render.ResetEos();
-
-  return;
+bool COMXVideo::IsEOS()
+{
+  if(!m_is_open)
+    return true;
+  return m_omx_render.IsEOS();
 }

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -59,7 +59,9 @@ public:
   std::string GetDecoderName() { return m_video_codec_name; };
   void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
   int GetInputBufferSize();
-  void WaitCompletion();
+  void SubmitEOS();
+  bool IsEOS();
+  bool SubmittedEOS() { return m_submitted_eos; }
   bool BadState() { return m_omx_decoder.BadState(); };
 protected:
   // Video format
@@ -95,6 +97,7 @@ protected:
   uint32_t          m_history_valid_pts;
   ResolutionUpdateCallBackFn m_res_callback;
   void              *m_res_ctx;
+  bool              m_submitted_eos;
   bool NaluFormatStartCodes(enum CodecID codec, uint8_t *in_extradata, int in_extrasize);
 };
 


### PR DESCRIPTION
Currently we block in OMXPlayerAudio/OMXPlayerVideo from the point we see EOF from demuxer,
until the last frame/audio sample has been played out. This can be a few seconds.
It means no more messages (such as abort) can be received during this period.
This results in a bug where if you press stop after the demuxer EOF has occurred it takes
a long time to stop. You would expect this to be the few seconds of queued data,
but it actually turns out to be 30 seconds, as the clocks get stopped by the stop message,
but the players never find out and we hit a timeout.
It also stops seek/pause working during the playout period.
It also stops (graphical) subtitles from being rendered during this time.
The fix involves not blocking for the EOS, but allowing the polling from OMXPlayer to catch it.
