### PR TITLE
move the new 'auto login' string to the xbmc language file

### DIFF
--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -113,7 +113,7 @@
 				<width>250</width> 
 				<height>72</height> 
 				<textoffsety>8</textoffsety> 
-				<label>31960</label> 
+				<label>33084</label> 
 				<font>font24_title</font> 
 				<align>right</align> 
 				<aligny>top</aligny> 
@@ -133,7 +133,7 @@
 				<width>250</width> 
 				<height>72</height> 
 				<textoffsety>8</textoffsety> 
-				<label>31960</label> 
+				<label>33084</label> 
 				<font>font24_title</font> 
 				<textcolor>grey2</textcolor> 
 				<align>right</align> 

--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -667,7 +667,3 @@ msgstr ""
 msgctxt "#31959"
 msgid "SYSTEM"
 msgstr ""
-
-msgctxt "#31960"
-msgid "Auto login"
-msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11333,7 +11333,12 @@ msgctxt "#33083"
 msgid "Enable custom script button"
 msgstr ""
 
-#empty strings from id 33084 to 33099
+#: addons/skin.confluence/720p/SettingsProfile.xml
+msgctxt "#33084"
+msgid "Auto login"
+msgstr ""
+
+#empty strings from id 33085 to 33099
 
 #: xbmc/network/network.cpp
 msgctxt "#33100"


### PR DESCRIPTION
move the new 'auto login' string, introduced by PR #2577,
to the xbmc language file.

it's not a 'skin specific' feature, so should be in the main language file.
it also saves all skinners to hassle of adding it to their language files.
