### PR TITLE
Partial fix for ffmpeg VAAPI

### DIFF
--- a/lib/ffmpeg/libavcodec/vaapi.c
+++ b/lib/ffmpeg/libavcodec/vaapi.c
@@ -212,7 +212,7 @@ int ff_vaapi_mpeg_end_frame(AVCodecContext *avctx)
     ff_mpeg_draw_horiz_band(s, 0, s->avctx->height);
 
 finish:
-    ff_vaapi_common_end_frame(avctx->priv_data);
+    ff_vaapi_common_end_frame(avctx);
     return ret;
 }
 

--- a/lib/ffmpeg/patches/0030-vaapi-fix-argument-for-ff_vaapi_common_end_frame-cal.patch
+++ b/lib/ffmpeg/patches/0030-vaapi-fix-argument-for-ff_vaapi_common_end_frame-cal.patch
@@ -1,0 +1,25 @@
+From b066d90211072c7532e17c0c54d8475f10fc97ad Mon Sep 17 00:00:00 2001
+From: Janne Grunau <janne-libav@jannau.net>
+Date: Thu, 14 Mar 2013 15:12:30 +0100
+Subject: [PATCH] vaapi: fix argument for ff_vaapi_common_end_frame call
+
+---
+ libavcodec/vaapi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/vaapi.c b/libavcodec/vaapi.c
+index 9c07c8d..0532daf 100644
+--- a/libavcodec/vaapi.c
++++ b/libavcodec/vaapi.c
+@@ -212,7 +212,7 @@ int ff_vaapi_mpeg_end_frame(AVCodecContext *avctx)
+     ff_mpeg_draw_horiz_band(s, 0, s->avctx->height);
+ 
+ finish:
+-    ff_vaapi_common_end_frame(avctx->priv_data);
++    ff_vaapi_common_end_frame(avctx);
+     return ret;
+ }
+ 
+-- 
+1.8.1.5
+


### PR DESCRIPTION
This only partialy fixes ffmpeg.
It still is very crashy with vaapi, even with this patch.
Specialy mpeg2 decoding always crashes.

Upstream commit is b066d90211072c7532e17c0c54d8475f10fc97ad

Without this patch, xbmc always crashes when using vaapi.
