### PR TITLE
Two fixes for episode smartplaylists

### DIFF
--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -112,6 +112,9 @@ namespace XFILE
           else
             baseDir += group;
           URIUtils::AddSlashAtEnd(baseDir);
+
+          if (mediaType = MediaTypeEpisode)
+            baseDir += "-1/-1/";
         }
 
         CVideoDbUrl videoUrl;

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -697,12 +697,6 @@ std::vector<Field> CSmartPlaylistRule::GetGroups(const CStdString &type)
     groups.push_back(FieldStudio);
     groups.push_back(FieldTag);
   }
-  else if (type == "episodes")
-  {
-    groups.push_back(FieldActor);
-    groups.push_back(FieldDirector);
-    groups.push_back(FieldWriter);
-  }
   else if (type == "musicvideos")
   {
     groups.push_back(FieldArtist);


### PR DESCRIPTION
These two commits contain two fixes for episode smartplaylists. The first one fixes them in general (as they are currently broken, see http://trac.xbmc.org/ticket/14267 ) and the second  one disables grouping for episode smartplaylists (which I thought I had removed but obviously didn't).
