### PR TITLE
Fix problems introduced by PR2496 (check dir exists use dircache)

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -259,7 +259,8 @@ bool CDirectory::Exists(const CStdString& strPath, bool bUseCache /* = true */)
     if (bUseCache)
     {
       bool bPathInCache;
-      if (g_directoryCache.FileExists(strPath, bPathInCache))
+      URIUtils::AddSlashAtEnd(realPath);
+      if (g_directoryCache.FileExists(realPath, bPathInCache))
         return true;
       if (bPathInCache)
         return false;

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -255,6 +255,7 @@ bool CDirectory::Exists(const CStdString& strPath, bool bUseCache /* = true */)
 {
   try
   {
+    CStdString realPath = URIUtils::SubstitutePath(strPath);
     if (bUseCache)
     {
       bool bPathInCache;
@@ -263,7 +264,6 @@ bool CDirectory::Exists(const CStdString& strPath, bool bUseCache /* = true */)
       if (bPathInCache)
         return false;
     }
-    CStdString realPath = URIUtils::SubstitutePath(strPath);
     auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realPath));
     if (pDirectory.get())
       return pDirectory->Exists(realPath.c_str());


### PR DESCRIPTION
in https://github.com/xbmc/xbmc/pull/2496 I didn't make sure the calling cache dir path ends with slash, which will cause the cache report false for subdir in it.
beside, there's SubstitutePath code in the CDirectory::Exists, it should be called before check the cache.
This PR fixed these 2 problems.
