### PR TITLE
Raspberry PI standby mode

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2226,6 +2226,13 @@ bool CApplication::OnKey(const CKey& key)
   // special handling if the screensaver is active
   CAction action = CButtonTranslator::GetInstance().GetAction(iWin, key);
 
+  // give the PowerManager a chance to process a keypress, and
+  // suppress further processing. we need this for virtual sleep.
+  if (g_powerManager.ProcessAction(action))
+  {
+    return true;
+  }
+
   // a key has been pressed.
   // reset Idle Timer
   m_idleTimer.StartZero();

--- a/xbmc/linux/DllBCM.h
+++ b/xbmc/linux/DllBCM.h
@@ -48,6 +48,9 @@ public:
   virtual void bcm_host_init() = 0;
   virtual void bcm_host_deinit() = 0;
   virtual int32_t graphics_get_display_size( const uint16_t display_number, uint32_t *width, uint32_t *height) = 0;
+  virtual int vc_tv_power_off() = 0;
+  virtual int vc_tv_sdtv_power_on(SDTV_MODE_T mode, SDTV_OPTIONS_T *options) = 0;
+  virtual int vc_tv_hdmi_power_on_preferred() = 0;
   virtual int vc_tv_hdmi_power_on_best(uint32_t width, uint32_t height, uint32_t frame_rate,
                                        HDMI_INTERLACED_T scan_mode, EDID_MODE_MATCH_FLAG_T match_flags) = 0;
   virtual int vc_tv_hdmi_power_on_best_3d(uint32_t width, uint32_t height, uint32_t frame_rate,
@@ -92,6 +95,12 @@ public:
     { return ::bcm_host_deinit(); };
   virtual int32_t graphics_get_display_size( const uint16_t display_number, uint32_t *width, uint32_t *height)
     { return ::graphics_get_display_size(display_number, width, height); };
+  virtual int vc_tv_power_off()
+    { return ::vc_tv_power_off(); }
+  virtual int vc_tv_sdtv_power_on(SDTV_MODE_T mode, SDTV_OPTIONS_T *options)
+    { return ::vc_tv_sdtv_power_on(mode, options); }
+  virtual int vc_tv_hdmi_power_on_preferred()
+    { return ::vc_tv_hdmi_power_on_preferred(); }
   virtual int vc_tv_hdmi_power_on_best(uint32_t width, uint32_t height, uint32_t frame_rate,
                                        HDMI_INTERLACED_T scan_mode, EDID_MODE_MATCH_FLAG_T match_flags)
     { return ::vc_tv_hdmi_power_on_best(width, height, frame_rate, scan_mode, match_flags); };

--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -22,6 +22,12 @@
 #if defined(TARGET_RASPBERRY_PI)
 
 #include "utils/log.h"
+#include "windowing/WindowingFactory.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/GraphicContext.h"
+#include "settings/GUISettings.h"
+#include "settings/Settings.h"
+#include "Application.h"
 
 CRBP::CRBP()
 {
@@ -156,4 +162,18 @@ void CRBP::Deinitialize()
   m_initialized     = false;
   m_omx_initialized = false;
 }
+void CRBP::SuspendVideoOutput()
+{
+  CLog::Log(LOGDEBUG, "Raspberry PI suspending video output\n");
+  g_Windowing.DestroyWindow();
+}
+
+void CRBP::ResumeVideoOutput()
+{
+  CLog::Log(LOGDEBUG, "Raspberry PI resuming video output\n");
+  RESOLUTION_INFO res = g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution];
+  g_Windowing.CreateNewWindow("XBMC", true, res, CApplication::OnEvent);
+  g_windowManager.MarkDirty();
+}
+
 #endif

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -53,6 +53,9 @@ public:
   // stride can be null for packed output
   unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue);
 
+  void SuspendVideoOutput();
+  void ResumeVideoOutput();
+
 private:
   DllBcmHost *m_DllBcmHost;
   bool       m_initialized;

--- a/xbmc/powermanagement/IPowerSyscall.h
+++ b/xbmc/powermanagement/IPowerSyscall.h
@@ -20,6 +20,9 @@
  *
  */
 
+// forward declaration
+class CAction;
+
 class IPowerEventsCallback
 {
 public:
@@ -60,6 +63,10 @@ public:
    \param callback the callback to signal to
    */
   virtual bool PumpPowerEvents(IPowerEventsCallback *callback) = 0;
+
+  // this is an optional part of the interface, so we provide a no-op implementation here.
+  // return true to suppress further processing of the CAction.
+  virtual bool ProcessAction(const CAction& action) { return false; }
 };
 
 class CPowerSyscallWithoutEvents : public IPowerSyscall

--- a/xbmc/powermanagement/Makefile
+++ b/xbmc/powermanagement/Makefile
@@ -1,5 +1,6 @@
 SRCS=DPMSSupport.cpp \
      PowerManager.cpp \
+     PowerSyscallVirtualSleep.cpp \
 
 LIB=powermanagement.a
 

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -38,6 +38,8 @@
 
 #if defined(TARGET_DARWIN)
 #include "osx/CocoaPowerSyscall.h"
+#elif defined(TARGET_RASPBERRY_PI)
+#include "linux/RaspberryPIPowerSyscall.h"
 #elif defined(TARGET_ANDROID)
 #include "android/AndroidPowerSyscall.h"
 #elif defined(TARGET_POSIX)
@@ -74,6 +76,8 @@ void CPowerManager::Initialize()
 {
 #if defined(TARGET_DARWIN)
   m_instance = new CCocoaPowerSyscall();
+#elif defined(TARGET_RASPBERRY_PI)
+  m_instance = new CRaspberryPIPowerSyscall();
 #elif defined(TARGET_ANDROID)
   m_instance = new CAndroidPowerSyscall();
 #elif defined(TARGET_POSIX)

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -232,6 +232,12 @@ void CPowerManager::ProcessEvents()
   nesting--;
 }
 
+bool CPowerManager::ProcessAction(const CAction& action)
+{
+  return m_instance->ProcessAction(action);
+}
+
+
 void CPowerManager::OnSleep()
 {
   CAnnouncementManager::Announce(System, "xbmc", "OnSleep");

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -58,6 +58,8 @@ public:
 
 
   virtual bool PumpPowerEvents(IPowerEventsCallback *callback) { return false; }
+
+  virtual bool ProcessAction(const CAction& action) { return false; }
 };
 
 // This class will wrap and handle PowerSyscalls.
@@ -84,6 +86,7 @@ public:
   int  BatteryLevel();
 
   void ProcessEvents();
+  bool ProcessAction(const CAction& action);
 
   static void SettingOptionsShutdownStatesFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
 

--- a/xbmc/powermanagement/PowerSyscallVirtualSleep.cpp
+++ b/xbmc/powermanagement/PowerSyscallVirtualSleep.cpp
@@ -1,0 +1,81 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PowerSyscallVirtualSleep.h"
+#include "guilib/Key.h"
+
+bool CPowerSyscallVirtualSleep::Suspend()
+{
+  if (m_virtualSleepState == VIRTUAL_SLEEP_STATE_AWAKE)
+  {
+    if (VirtualSleep())
+    {
+      m_virtualSleepState = VIRTUAL_SLEEP_STATE_WILL_SLEEP;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool CPowerSyscallVirtualSleep::PumpPowerEvents(IPowerEventsCallback *callback)
+{
+  if (m_virtualSleepState == VIRTUAL_SLEEP_STATE_WILL_WAKE)
+  {
+    callback->OnWake();
+    m_virtualSleepState = VIRTUAL_SLEEP_STATE_AWAKE;
+    return true;
+  }
+  else if (m_virtualSleepState == VIRTUAL_SLEEP_STATE_WILL_SLEEP)
+  {
+    callback->OnSleep();
+    m_virtualSleepState = VIRTUAL_SLEEP_STATE_ASLEEP;
+    return true;
+  }
+  
+  return false;
+}
+
+bool CPowerSyscallVirtualSleep::ProcessAction(const CAction& action)
+{
+  if (m_virtualSleepState != VIRTUAL_SLEEP_STATE_ASLEEP)
+    return false;
+
+  // device is in virtual sleep, only one of the power keys will
+  // wake it up again.
+  if (action.GetID() == ACTION_BUILT_IN_FUNCTION)
+  {
+    CStdString name = action.GetName();
+    name.ToLower();
+    if(name.Equals("shutdown") ||
+       name.Equals("suspend")  ||
+       name.Equals("hibernate"))
+    {
+      if(VirtualWake())
+      {
+        m_virtualSleepState = VIRTUAL_SLEEP_STATE_WILL_WAKE;
+        return false;
+      }
+    }
+  }
+
+  // wasn't a power key, suppress this and stay asleep
+  return true;
+}

--- a/xbmc/powermanagement/PowerSyscallVirtualSleep.h
+++ b/xbmc/powermanagement/PowerSyscallVirtualSleep.h
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef _POWER_SYSCALL_VIRTUAL_SLEEP_H_
+#define _POWER_SYSCALL_VIRTUAL_SLEEP_H_
+#include "IPowerSyscall.h"
+
+// Systems that have no native standby mode, can base their
+// IPowerSyscall implementation on this class, and need only
+// implement VirtualSleep()/VirtualWake().
+class CPowerSyscallVirtualSleep : public IPowerSyscall
+{
+public:
+  CPowerSyscallVirtualSleep() : m_virtualSleepState(VIRTUAL_SLEEP_STATE_AWAKE) {}
+  virtual ~CPowerSyscallVirtualSleep() {}
+
+  virtual bool CanSuspend() { return true; }
+  virtual bool Suspend();
+
+  virtual bool PumpPowerEvents(IPowerEventsCallback *callback);
+
+  virtual bool ProcessAction(const CAction& action);
+
+  virtual bool VirtualSleep() = 0;
+  virtual bool VirtualWake()  = 0;
+
+protected:
+  // keep track of virtual sleep state for devices that support it
+  typedef enum {
+    VIRTUAL_SLEEP_STATE_AWAKE = 0,
+    VIRTUAL_SLEEP_STATE_ASLEEP,
+    VIRTUAL_SLEEP_STATE_WILL_WAKE,
+    VIRTUAL_SLEEP_STATE_WILL_SLEEP,
+  } VirtualSleepState;
+
+  VirtualSleepState m_virtualSleepState;
+};
+
+#endif // _POWER_SYSCALL_VIRTUAL_SLEEP_H_

--- a/xbmc/powermanagement/linux/Makefile
+++ b/xbmc/powermanagement/linux/Makefile
@@ -1,6 +1,7 @@
 SRCS=ConsoleDeviceKitPowerSyscall.cpp \
      ConsoleUPowerSyscall.cpp \
      HALPowerSyscall.cpp \
+     RaspberryPIPowerSyscall.cpp \
      UPowerSyscall.cpp \
      LogindUPowerSyscall.cpp
 

--- a/xbmc/powermanagement/linux/RaspberryPIPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/RaspberryPIPowerSyscall.cpp
@@ -1,0 +1,38 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+ 
+#if defined(TARGET_RASPBERRY_PI)
+
+#include "RaspberryPIPowerSyscall.h"
+#include "RBP.h"
+
+bool CRaspberryPIPowerSyscall::VirtualSleep()
+{
+  g_RBP.SuspendVideoOutput();
+  return true;
+}
+
+bool CRaspberryPIPowerSyscall::VirtualWake()
+{
+  g_RBP.ResumeVideoOutput();
+  return true;
+}
+
+#endif

--- a/xbmc/powermanagement/linux/RaspberryPIPowerSyscall.h
+++ b/xbmc/powermanagement/linux/RaspberryPIPowerSyscall.h
@@ -1,0 +1,49 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef _RASPBERRY_PI_POWER_SYSCALL_H_
+#define _RASPBERRY_PI_POWER_SYSCALL_H_
+
+#if defined(TARGET_RASPBERRY_PI)
+#include "powermanagement/PowerSyscallVirtualSleep.h"
+
+class CRaspberryPIPowerSyscall : public CPowerSyscallVirtualSleep
+{
+public:
+  CRaspberryPIPowerSyscall() : CPowerSyscallVirtualSleep() {}
+  virtual ~CRaspberryPIPowerSyscall() {}
+  
+  virtual bool Powerdown()    { return false; }
+  virtual bool Hibernate()    { return false; }
+  virtual bool Reboot()       { return false; }
+
+  virtual bool CanPowerdown() { return false; }
+  virtual bool CanHibernate() { return false; }
+  virtual bool CanReboot()    { return true; }
+
+  virtual int  BatteryLevel() { return 0; }
+
+  virtual bool VirtualSleep();
+  virtual bool VirtualWake();
+};
+#endif // TARGET_RASPBERRY_PI
+
+#endif // _RASPBERRY_PI_POWER_SYSCALL_H_

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -222,7 +222,7 @@ bool CEGLNativeTypeRaspberryPI::SetNativeResolution(const RESOLUTION_INFO &res)
 
   DestroyDispmaxWindow();
 
-  if(!m_fixedMode && GETFLAGS_GROUP(res.dwFlags) && GETFLAGS_MODE(res.dwFlags))
+  if(GETFLAGS_GROUP(res.dwFlags) && GETFLAGS_MODE(res.dwFlags))
   {
     sem_init(&m_tv_synced, 0, 0);
     m_DllBcmHost->vc_tv_register_callback(CallbackTvServiceCallback, this);
@@ -258,6 +258,33 @@ bool CEGLNativeTypeRaspberryPI::SetNativeResolution(const RESOLUTION_INFO &res)
                           GETFLAGS_GROUP(res.dwFlags), GETFLAGS_MODE(res.dwFlags), success,
                           (res.dwFlags & D3DPRESENTFLAG_MODE3DSBS) ? " SBS":"",
                           (res.dwFlags & D3DPRESENTFLAG_MODE3DTB) ? " TB":"");
+    }
+    m_DllBcmHost->vc_tv_unregister_callback(CallbackTvServiceCallback);
+    sem_destroy(&m_tv_synced);
+
+    m_desktopRes = res;
+  }
+  else if(!GETFLAGS_GROUP(res.dwFlags) && GETFLAGS_MODE(res.dwFlags))
+  {
+    sem_init(&m_tv_synced, 0, 0);
+    m_DllBcmHost->vc_tv_register_callback(CallbackTvServiceCallback, this);
+
+    SDTV_OPTIONS_T options;
+    options.aspect = get_sdtv_aspect_from_display_aspect((float)res.iScreenWidth / (float)res.iScreenHeight);
+
+    int success = m_DllBcmHost->vc_tv_sdtv_power_on((SDTV_MODE_T)GETFLAGS_MODE(res.dwFlags), &options);
+
+    if (success == 0)
+    {
+      CLog::Log(LOGDEBUG, "EGL set SDTV mode (%d,%d)=%d\n",
+                          GETFLAGS_GROUP(res.dwFlags), GETFLAGS_MODE(res.dwFlags), success);
+
+      sem_wait(&m_tv_synced);
+    }
+    else
+    {
+      CLog::Log(LOGERROR, "EGL failed to set SDTV mode (%d,%d)=%d\n",
+                          GETFLAGS_GROUP(res.dwFlags), GETFLAGS_MODE(res.dwFlags), success);
     }
     m_DllBcmHost->vc_tv_unregister_callback(CallbackTvServiceCallback);
     sem_destroy(&m_tv_synced);
@@ -337,8 +364,6 @@ bool CEGLNativeTypeRaspberryPI::ProbeResolutions(std::vector<RESOLUTION_INFO> &r
   if(!m_DllBcmHost)
     return false;
 
-  m_fixedMode               = false;
-
   /* read initial desktop resolution before probe resolutions.
    * probing will replace the desktop resolution when it finds the same one.
    * we raplace it because probing will generate more detailed 
@@ -384,7 +409,7 @@ bool CEGLNativeTypeRaspberryPI::ProbeResolutions(std::vector<RESOLUTION_INFO> &r
       m_desktopRes.iHeight      = tv_state.display.sdtv.height;
       m_desktopRes.iScreenWidth = tv_state.display.sdtv.width;
       m_desktopRes.iScreenHeight= tv_state.display.sdtv.height;
-      m_desktopRes.dwFlags      = D3DPRESENTFLAG_INTERLACED;
+      m_desktopRes.dwFlags      = MAKEFLAGS(HDMI_RES_GROUP_INVALID, tv_state.display.sdtv.mode, 1);
       m_desktopRes.fRefreshRate = (float)tv_state.display.sdtv.frame_rate;
       m_desktopRes.fPixelRatio  = get_display_aspect_ratio((SDTV_ASPECT_T)tv_state.display.sdtv.display_options.aspect) / ((float)m_desktopRes.iScreenWidth / (float)m_desktopRes.iScreenHeight);
     }
@@ -421,9 +446,6 @@ bool CEGLNativeTypeRaspberryPI::ProbeResolutions(std::vector<RESOLUTION_INFO> &r
 
     AddUniqueResolution(m_desktopRes, resolutions);
   }
-
-  if(resolutions.size() < 2)
-    m_fixedMode = true;
 
   DLOG("CEGLNativeTypeRaspberryPI::ProbeResolutions\n");
   return true;

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -55,6 +55,11 @@
 # define DLOG(fmt, args...)
 #endif
 
+#if defined(TARGET_RASPBERRY_PI)
+static float get_display_aspect_ratio(HDMI_ASPECT_T aspect);
+static float get_display_aspect_ratio(SDTV_ASPECT_T aspect);
+#endif
+
 
 CEGLNativeTypeRaspberryPI::CEGLNativeTypeRaspberryPI()
 {
@@ -321,36 +326,6 @@ bool CEGLNativeTypeRaspberryPI::SetNativeResolution(const RESOLUTION_INFO &res)
   return false;
 #endif
 }
-
-#if defined(TARGET_RASPBERRY_PI)
-static float get_display_aspect_ratio(HDMI_ASPECT_T aspect)
-{
-  float display_aspect;
-  switch (aspect) {
-    case HDMI_ASPECT_4_3:   display_aspect = 4.0/3.0;   break;
-    case HDMI_ASPECT_14_9:  display_aspect = 14.0/9.0;  break;
-    case HDMI_ASPECT_16_9:  display_aspect = 16.0/9.0;  break;
-    case HDMI_ASPECT_5_4:   display_aspect = 5.0/4.0;   break;
-    case HDMI_ASPECT_16_10: display_aspect = 16.0/10.0; break;
-    case HDMI_ASPECT_15_9:  display_aspect = 15.0/9.0;  break;
-    case HDMI_ASPECT_64_27: display_aspect = 64.0/27.0; break;
-    default:                display_aspect = 16.0/9.0;  break;
-  }
-  return display_aspect;
-}
-
-static float get_display_aspect_ratio(SDTV_ASPECT_T aspect)
-{
-  float display_aspect;
-  switch (aspect) {
-    case SDTV_ASPECT_4_3:  display_aspect = 4.0/3.0;  break;
-    case SDTV_ASPECT_14_9: display_aspect = 14.0/9.0; break;
-    case SDTV_ASPECT_16_9: display_aspect = 16.0/9.0; break;
-    default:               display_aspect = 4.0/3.0;  break;
-  }
-  return display_aspect;
-}
-#endif
 
 bool CEGLNativeTypeRaspberryPI::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
 {
@@ -639,3 +614,35 @@ bool CEGLNativeTypeRaspberryPI::ClampToGUIDisplayLimits(int &width, int &height)
 
 #endif
 
+
+// private utility functions
+
+#if defined(TARGET_RASPBERRY_PI)
+static float get_display_aspect_ratio(HDMI_ASPECT_T aspect)
+{
+  float display_aspect;
+  switch (aspect) {
+    case HDMI_ASPECT_4_3:   display_aspect = 4.0/3.0;   break;
+    case HDMI_ASPECT_14_9:  display_aspect = 14.0/9.0;  break;
+    case HDMI_ASPECT_16_9:  display_aspect = 16.0/9.0;  break;
+    case HDMI_ASPECT_5_4:   display_aspect = 5.0/4.0;   break;
+    case HDMI_ASPECT_16_10: display_aspect = 16.0/10.0; break;
+    case HDMI_ASPECT_15_9:  display_aspect = 15.0/9.0;  break;
+    case HDMI_ASPECT_64_27: display_aspect = 64.0/27.0; break;
+    default:                display_aspect = 16.0/9.0;  break;
+  }
+  return display_aspect;
+}
+
+static float get_display_aspect_ratio(SDTV_ASPECT_T aspect)
+{
+  float display_aspect;
+  switch (aspect) {
+    case SDTV_ASPECT_4_3:  display_aspect = 4.0/3.0;  break;
+    case SDTV_ASPECT_14_9: display_aspect = 14.0/9.0; break;
+    case SDTV_ASPECT_16_9: display_aspect = 16.0/9.0; break;
+    default:               display_aspect = 4.0/3.0;  break;
+  }
+  return display_aspect;
+}
+#endif

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 #include "guilib/gui3d.h"
 #include "linux/DllBCM.h"
+#include "math.h"
 
 #ifndef __VIDEOCORE4__
 #define __VIDEOCORE4__
@@ -58,6 +59,7 @@
 #if defined(TARGET_RASPBERRY_PI)
 static float get_display_aspect_ratio(HDMI_ASPECT_T aspect);
 static float get_display_aspect_ratio(SDTV_ASPECT_T aspect);
+static SDTV_ASPECT_T get_sdtv_aspect_from_display_aspect(float display_aspect);
 #endif
 
 
@@ -644,5 +646,24 @@ static float get_display_aspect_ratio(SDTV_ASPECT_T aspect)
     default:               display_aspect = 4.0/3.0;  break;
   }
   return display_aspect;
+}
+
+static SDTV_ASPECT_T get_sdtv_aspect_from_display_aspect(float display_aspect)
+{
+  SDTV_ASPECT_T aspect;
+  const float delta = 1e-3;
+  if(fabs(get_display_aspect_ratio(SDTV_ASPECT_16_9) - display_aspect) < delta)
+  {
+    aspect = SDTV_ASPECT_16_9;
+  }
+  else if(fabs(get_display_aspect_ratio(SDTV_ASPECT_14_9) - display_aspect) < delta)
+  {
+    aspect = SDTV_ASPECT_14_9;
+  }
+  else
+  {
+    aspect = SDTV_ASPECT_4_3;
+  }
+  return aspect;
 }
 #endif

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
@@ -59,7 +59,6 @@ private:
   DISPMANX_ELEMENT_HANDLE_T     m_dispman_element;
   TV_GET_STATE_RESP_T           m_tv_state;
   sem_t                         m_tv_synced;
-  bool                          m_fixedMode;
   RESOLUTION_INFO               m_desktopRes;
   int                           m_width;
   int                           m_height;

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
@@ -36,7 +36,7 @@ public:
   virtual bool  CheckCompatibility();
   virtual void  Initialize();
   virtual void  Destroy();
-  virtual int   GetQuirks() { return EGL_QUIRK_NONE; };
+  virtual int   GetQuirks() { return EGL_QUIRK_DESTROY_NATIVE_WINDOW_WITH_SURFACE|EGL_QUIRK_NEED_WINDOW_FOR_RES; };
 
   virtual bool  CreateNativeDisplay();
   virtual bool  CreateNativeWindow();


### PR DESCRIPTION
As the Raspberry PI has no proper standby mode from which it can be woken up again, it's so far impossible to turn off the attached display automatically.

This change set allows the PI's video output to be powered down, and back on again (works for HDMI and SDTV).

Also, there's a generic and reusable IPowerSyscall subclass CPowerSyscallVirtualSleep that allows devices to implement VirtualSleep/VirtualWake methods. For that to work the PowerManager now gets a chance to process and suppress events from CApplication::OnKey().

The PI's specific power management subclass is just a minor specialization of CPowerSyscallVirtualSleep which powers the video interface down during virtual sleep, and back on for virtual wake.
