### PR TITLE
[AE] Fix for non-SSE2 platforms.

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEConvert.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEConvert.cpp
@@ -33,11 +33,6 @@
 #include <math.h>
 #include <string.h>
 
-#ifdef __SSE__
-#include <xmmintrin.h>
-#include <emmintrin.h>
-#endif
-
 #ifdef __ARM_NEON__
 #include <arm_neon.h>
 #endif
@@ -517,7 +512,7 @@ unsigned int CAEConvert::Float_S8(float *data, const unsigned int samples, uint8
 unsigned int CAEConvert::Float_S16LE(float *data, const unsigned int samples, uint8_t *dest)
 {
   int16_t *dst = (int16_t*)dest;
-  #ifdef __SSE__
+  #ifdef __SSE2__
 
   unsigned int count     = samples;
   unsigned int unaligned = (0x10 - ((uintptr_t)data & 0xF)) >> 2;
@@ -623,7 +618,7 @@ unsigned int CAEConvert::Float_S16LE(float *data, const unsigned int samples, ui
   /* cleanup */
   _mm_empty();
 
-  #else /* no SSE */
+  #else /* no SSE2 */
 
   uint32_t i    = 0;
   uint32_t even = samples & ~0x3;
@@ -651,7 +646,7 @@ unsigned int CAEConvert::Float_S16LE(float *data, const unsigned int samples, ui
 unsigned int CAEConvert::Float_S16BE(float *data, const unsigned int samples, uint8_t *dest)
 {
   int16_t *dst = (int16_t*)dest;
-  #ifdef __SSE__
+  #ifdef __SSE2__
 
   unsigned int count     = samples;
   unsigned int unaligned = (0x10 - ((uintptr_t)data & 0xF)) >> 2;
@@ -757,7 +752,7 @@ unsigned int CAEConvert::Float_S16BE(float *data, const unsigned int samples, ui
   /* cleanup */
   _mm_empty();
 
-  #else /* no SSE */
+  #else /* no SSE2 */
 
   uint32_t i    = 0;
   uint32_t even = samples & ~0x3;
@@ -785,7 +780,7 @@ unsigned int CAEConvert::Float_S16BE(float *data, const unsigned int samples, ui
 unsigned int CAEConvert::Float_S24NE4(float *data, const unsigned int samples, uint8_t *dest)
 {
   int32_t *dst = (int32_t*)dest;
-  #ifdef __SSE__
+  #ifdef __SSE2__
 
   const __m128 mul = _mm_set_ps1((float)INT24_MAX+.5f);
   unsigned int count = samples;
@@ -835,7 +830,7 @@ unsigned int CAEConvert::Float_S24NE4(float *data, const unsigned int samples, u
     }
   }
   _mm_empty();
-  #else /* no SSE */
+  #else /* no SSE2 */
   for (uint32_t i = 0; i < samples; ++i)
     *dst++ = (safeRound(*data++ * ((float)INT24_MAX+.5f)) & 0xFFFFFF) << 8;
   #endif
@@ -929,7 +924,7 @@ unsigned int CAEConvert::Float_S24NE3(float *data, const unsigned int samples, u
 unsigned int CAEConvert::Float_S32LE(float *data, const unsigned int samples, uint8_t *dest)
 {
   int32_t *dst = (int32_t*)dest;
-  #ifdef __SSE__
+  #ifdef __SSE2__
   const __m128 mul = _mm_set_ps1(AE_MUL32);
   unsigned int count = samples;
 
@@ -989,7 +984,7 @@ unsigned int CAEConvert::Float_S32LE(float *data, const unsigned int samples, ui
   _mm_empty();
   #else
 
-  /* no SIMD */
+  /* no SSE2 */
   for (uint32_t i = 0; i < samples; ++i, ++data, ++dst)
   {
     dst[0] = safeRound(data[0] * AE_MUL32);
@@ -1038,7 +1033,7 @@ unsigned int CAEConvert::Float_S32LE_Neon(float *data, const unsigned int sample
 unsigned int CAEConvert::Float_S32BE(float *data, const unsigned int samples, uint8_t *dest)
 {
   int32_t *dst = (int32_t*)dest;
-  #ifdef __SSE__
+  #ifdef __SSE2__
   const __m128 mul = _mm_set_ps1(AE_MUL32);
   unsigned int count = samples;
 
@@ -1097,7 +1092,7 @@ unsigned int CAEConvert::Float_S32BE(float *data, const unsigned int samples, ui
   }
   _mm_empty();
   #else
-  /* no SIMD */
+  /* no SSE2 */
   for (uint32_t i = 0; i < samples; ++i, ++data, ++dst)
   {
     dst[0] = safeRound(data[0] * AE_MUL32);

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -30,7 +30,7 @@ using namespace std;
 
 /* declare the rng seed and initialize it */
 unsigned int CAEUtil::m_seed = (unsigned int)(CurrentHostCounter() / 1000.0f);
-#ifdef __SSE__
+#ifdef __SSE2__
   /* declare the SSE seed and initialize it */
   MEMALIGN(16, __m128i CAEUtil::m_sseSeed) = _mm_set_epi32(CAEUtil::m_seed, CAEUtil::m_seed+1, CAEUtil::m_seed, CAEUtil::m_seed+1);
 #endif
@@ -386,7 +386,7 @@ float CAEUtil::FloatRand1(const float min, const float max)
 
 void CAEUtil::FloatRand4(const float min, const float max, float result[4], __m128 *sseresult/* = NULL */)
 {
-  #ifdef __SSE__
+  #ifdef __SSE2__
     /*
       this method may be called from other SSE code, we need
       to calculate the delta & factor using SSE as the FPU

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -27,6 +27,9 @@
 #ifdef TARGET_WINDOWS
 #if _M_IX86_FP>0 && !defined(__SSE__)
 #define __SSE__
+#if _M_IX86_FP>1 && !defined(__SSE2__)
+#define __SSE2__
+#endif
 #endif
 #endif
 
@@ -34,6 +37,10 @@
 #include <xmmintrin.h>
 #else
 #define __m128 void
+#endif
+
+#ifdef __SSE2__
+#include <emmintrin.h>
 #endif
 
 #ifdef __GNUC__
@@ -63,7 +70,7 @@ class CAEUtil
 {
 private:
   static unsigned int m_seed;
-  #ifdef __SSE__
+  #ifdef __SSE2__
     static __m128i m_sseSeed;
   #endif
 


### PR DESCRIPTION
Compilation on an older 32-bit Athlon XP chip fails with the error
"./Utils/AEUtil.h:50:12: error: '__m128i' does not name a type"
This is because the __m128i type is only available on SSE2 platforms.
Modify the preprocessor logic to detect SSE and SSE2 support separately.

The "emmintrin.h" header should only be included on SSE2 platforms as
well.
