### PR TITLE
webserver: support for HTTP Range handling (makes HTTP streams seekable)

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -457,7 +457,7 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
   {
     delete file;
     CLog::Log(LOGERROR, "WebServer: Failed to open %s", strURL.c_str());
-    return SendErrorResponse(connection, MHD_HTTP_NOT_FOUND, GET); /* GET Assumed Temporarily */
+    return SendErrorResponse(connection, MHD_HTTP_NOT_FOUND, methodType);
   }
   return MHD_YES;
 }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -416,7 +416,7 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
       getData = false;
 
       CStdString contentLength;
-      contentLength.Format("%I64d", file->GetLength());
+      contentLength.Format("%" PRId64, fileLength);
 
       response = MHD_create_response_from_data(0, NULL, MHD_NO, MHD_NO);
       if (response == NULL)

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -27,6 +27,7 @@
 #include "threads/SingleLock.h"
 #include "utils/Base64.h"
 #include "utils/log.h"
+#include "utils/Mime.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 
@@ -731,60 +732,10 @@ int CWebServer::GetRequestHeaderValues(struct MHD_Connection *connection, enum M
   return MHD_get_connection_values(connection, kind, FillArgumentMultiMap, &headerValues);
 }
 
-const char *CWebServer::CreateMimeTypeFromExtension(const char *ext)
+std::string CWebServer::CreateMimeTypeFromExtension(const char *ext)
 {
-  if (strcmp(ext, ".aif") == 0)   return "audio/aiff";
-  if (strcmp(ext, ".aiff") == 0)  return "audio/aiff";
-  if (strcmp(ext, ".asf") == 0)   return "video/x-ms-asf";
-  if (strcmp(ext, ".asx") == 0)   return "video/x-ms-asf";
-  if (strcmp(ext, ".avi") == 0)   return "video/avi";
-  if (strcmp(ext, ".avs") == 0)   return "video/avs-video";
-  if (strcmp(ext, ".bin") == 0)   return "application/octet-stream";
-  if (strcmp(ext, ".bmp") == 0)   return "image/bmp";
-  if (strcmp(ext, ".dv") == 0)    return "video/x-dv";
-  if (strcmp(ext, ".fli") == 0)   return "video/fli";
-  if (strcmp(ext, ".gif") == 0)   return "image/gif";
-  if (strcmp(ext, ".htm") == 0)   return "text/html";
-  if (strcmp(ext, ".html") == 0)  return "text/html";
-  if (strcmp(ext, ".htmls") == 0) return "text/html";
-  if (strcmp(ext, ".ico") == 0)   return "image/x-icon";
-  if (strcmp(ext, ".it") == 0)    return "audio/it";
-  if (strcmp(ext, ".jpeg") == 0)  return "image/jpeg";
-  if (strcmp(ext, ".jpg") == 0)   return "image/jpeg";
-  if (strcmp(ext, ".json") == 0)  return "application/json";
   if (strcmp(ext, ".kar") == 0)   return "audio/midi";
-  if (strcmp(ext, ".list") == 0)  return "text/plain";
-  if (strcmp(ext, ".log") == 0)   return "text/plain";
-  if (strcmp(ext, ".lst") == 0)   return "text/plain";
-  if (strcmp(ext, ".m2v") == 0)   return "video/mpeg";
-  if (strcmp(ext, ".m3u") == 0)   return "audio/x-mpequrl";
-  if (strcmp(ext, ".mid") == 0)   return "audio/midi";
-  if (strcmp(ext, ".midi") == 0)  return "audio/midi";
-  if (strcmp(ext, ".mod") == 0)   return "audio/mod";
-  if (strcmp(ext, ".mov") == 0)   return "video/quicktime";
-  if (strcmp(ext, ".mp2") == 0)   return "audio/mpeg";
-  if (strcmp(ext, ".mp3") == 0)   return "audio/mpeg3";
-  if (strcmp(ext, ".mpa") == 0)   return "audio/mpeg";
-  if (strcmp(ext, ".mpeg") == 0)  return "video/mpeg";
-  if (strcmp(ext, ".mpg") == 0)   return "video/mpeg";
-  if (strcmp(ext, ".mpga") == 0)  return "audio/mpeg";
-  if (strcmp(ext, ".pcx") == 0)   return "image/x-pcx";
-  if (strcmp(ext, ".png") == 0)   return "image/png";
-  if (strcmp(ext, ".rm") == 0)    return "audio/x-pn-realaudio";
-  if (strcmp(ext, ".s3m") == 0)   return "audio/s3m";
-  if (strcmp(ext, ".sid") == 0)   return "audio/x-psid";
-  if (strcmp(ext, ".tif") == 0)   return "image/tiff";
-  if (strcmp(ext, ".tiff") == 0)  return "image/tiff";
-  if (strcmp(ext, ".txt") == 0)   return "text/plain";
-  if (strcmp(ext, ".uni") == 0)   return "text/uri-list";
-  if (strcmp(ext, ".viv") == 0)   return "video/vivo";
-  if (strcmp(ext, ".wav") == 0)   return "audio/wav";
-  if (strcmp(ext, ".xm") == 0)    return "audio/xm";
-  if (strcmp(ext, ".xml") == 0)   return "text/xml";
-  if (strcmp(ext, ".zip") == 0)   return "application/zip";
   if (strcmp(ext, ".tbn") == 0)   return "image/jpeg";
-  if (strcmp(ext, ".js") == 0)    return "application/javascript";
-  if (strcmp(ext, ".css") == 0)   return "text/css";
-  return NULL;
+  return CMime::GetMimeType(ext);
 }
 #endif

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -366,6 +366,7 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
     {
       if (methodType == GET)
       {
+        // handle If-Modified-Since
         string ifModifiedSince = GetRequestHeaderValue(connection, MHD_HEADER_KIND, "If-Modified-Since");
         if (!ifModifiedSince.empty())
         {
@@ -382,7 +383,7 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
               if (lastModified.GetAsUTCDateTime() <= ifModifiedSinceDate)
               {
                 getData = false;
-                response = MHD_create_response_from_data (0, NULL, MHD_NO, MHD_NO);
+                response = MHD_create_response_from_data(0, NULL, MHD_NO, MHD_NO);
                 responseCode = MHD_HTTP_NOT_MODIFIED;
               }
             }
@@ -409,7 +410,7 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
       CStdString contentLength;
       contentLength.Format("%I64d", file->GetLength());
 
-      response = MHD_create_response_from_data (0, NULL, MHD_NO, MHD_NO);
+      response = MHD_create_response_from_data(0, NULL, MHD_NO, MHD_NO);
       if (response == NULL)
       {
         file->Close();
@@ -459,6 +460,7 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
     CLog::Log(LOGERROR, "WebServer: Failed to open %s", strURL.c_str());
     return SendErrorResponse(connection, MHD_HTTP_NOT_FOUND, methodType);
   }
+
   return MHD_YES;
 }
 
@@ -516,7 +518,7 @@ void* CWebServer::UriRequestLogger(void *cls, const char *uri)
 }
 
 #if (MHD_VERSION >= 0x00090200)
-ssize_t CWebServer::ContentReaderCallback (void *cls, uint64_t pos, char *buf, size_t max)
+ssize_t CWebServer::ContentReaderCallback(void *cls, uint64_t pos, char *buf, size_t max)
 #elif (MHD_VERSION >= 0x00040001)
 int CWebServer::ContentReaderCallback(void *cls, uint64_t pos, char *buf, int max)
 #else   //libmicrohttpd < 0.4.0

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -103,7 +103,7 @@ private:
   static int FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
   static int FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
 
-  static const char *CreateMimeTypeFromExtension(const char *ext);
+  static std::string CreateMimeTypeFromExtension(const char *ext);
 
   struct MHD_Daemon *m_daemon;
   bool m_running, m_needcredentials;

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -105,6 +105,8 @@ private:
 
   static std::string CreateMimeTypeFromExtension(const char *ext);
 
+  static int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value);
+
   struct MHD_Daemon *m_daemon;
   bool m_running, m_needcredentials;
   std::string m_Credentials64Encoded;

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -40,6 +40,9 @@ namespace XFILE
 }
 class CDateTime;
 
+typedef std::pair<int64_t, int64_t> HttpRange;
+typedef std::vector<HttpRange> HttpRanges;
+
 class CWebServer : public JSONRPC::ITransportLayer
 {
 public:
@@ -112,6 +115,8 @@ private:
   static std::string CreateMimeTypeFromExtension(const char *ext);
 
   static int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value);
+  static int64_t ParseRangeHeader(const std::string &rangeHeaderValue, int64_t totalLength, HttpRanges &ranges, int64_t &firstPosition, int64_t &lastPosition);
+  static std::string GenerateMultipartBoundary();
   static bool GetLastModifiedDateTime(XFILE::CFile *file, CDateTime &lastModified);
 
   struct MHD_Daemon *m_daemon;

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -34,6 +34,12 @@
 #include "network/httprequesthandler/IHTTPRequestHandler.h"
 #include "threads/CriticalSection.h"
 
+namespace XFILE
+{
+  class CFile;
+}
+class CDateTime;
+
 class CWebServer : public JSONRPC::ITransportLayer
 {
 public:
@@ -106,6 +112,7 @@ private:
   static std::string CreateMimeTypeFromExtension(const char *ext);
 
   static int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value);
+  static bool GetLastModifiedDateTime(XFILE::CFile *file, CDateTime &lastModified);
 
   struct MHD_Daemon *m_daemon;
   bool m_running, m_needcredentials;

--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -59,7 +59,7 @@ map<string, string> fillMimeTypes()
   mimeTypes.insert(pair<string, string>("asp",       "text/asp"));
   mimeTypes.insert(pair<string, string>("asx",       "video/x-ms-asf"));
   mimeTypes.insert(pair<string, string>("au",        "audio/basic"));
-  mimeTypes.insert(pair<string, string>("avi",       "video/x-msvideo"));
+  mimeTypes.insert(pair<string, string>("avi",       "video/avi"));
   mimeTypes.insert(pair<string, string>("avs",       "video/avs-video"));
   mimeTypes.insert(pair<string, string>("bcpio",     "application/x-bcpio"));
   mimeTypes.insert(pair<string, string>("bin",       "application/octet-stream"));
@@ -193,7 +193,8 @@ map<string, string> fillMimeTypes()
   mimeTypes.insert(pair<string, string>("jpeg",      "image/jpeg"));
   mimeTypes.insert(pair<string, string>("jpg",       "image/jpeg"));
   mimeTypes.insert(pair<string, string>("jps",       "image/x-jps"));
-  mimeTypes.insert(pair<string, string>("js",        "application/x-javascript"));
+  mimeTypes.insert(pair<string, string>("js",        "application/javascript"));
+  mimeTypes.insert(pair<string, string>("json",      "application/json"));
   mimeTypes.insert(pair<string, string>("jut",       "image/jutvision"));
   mimeTypes.insert(pair<string, string>("kar",       "music/x-karaoke"));
   mimeTypes.insert(pair<string, string>("ksh",       "application/x-ksh"));
@@ -404,6 +405,7 @@ map<string, string> fillMimeTypes()
   mimeTypes.insert(pair<string, string>("text",      "text/plain"));
   mimeTypes.insert(pair<string, string>("tgz",       "application/x-compressed"));
   mimeTypes.insert(pair<string, string>("tif",       "image/tiff"));
+  mimeTypes.insert(pair<string, string>("tiff",      "image/tiff"));
   mimeTypes.insert(pair<string, string>("tr",        "application/x-troff"));
   mimeTypes.insert(pair<string, string>("ts",        "video/mp2t"));
   mimeTypes.insert(pair<string, string>("tsi",       "audio/tsp-audio"));

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -24,6 +24,20 @@
 
 #include "Variant.h"
 
+#ifndef strtoll
+#ifdef TARGET_WINDOWS
+#define strtoll  _strtoi64
+#define strtoull _strtoui64
+#define wcstoll  _wcstoi64
+#define wcstoull _wcstoui64
+#else // TARGET_WINDOWS
+#define strtoll  (int64_t)strtod
+#define strtoull (uint64_t)strtod
+#define wcstoll  (int64_t)wcstod
+#define wcstoull (uint64_t)wcstod
+#endif // TARGET_WINDOWS
+#endif // strtoll
+
 using namespace std;
 
 string trimRight(const string &str)
@@ -51,7 +65,7 @@ wstring trimRight(const wstring &str)
 int64_t str2int64(const string &str, int64_t fallback /* = 0 */)
 {
   char *end = NULL;
-  int64_t result = strtol(trimRight(str).c_str(), &end, 0);
+  int64_t result = strtoll(trimRight(str).c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -61,7 +75,7 @@ int64_t str2int64(const string &str, int64_t fallback /* = 0 */)
 int64_t str2int64(const wstring &str, int64_t fallback /* = 0 */)
 {
   wchar_t *end = NULL;
-  int64_t result = wcstol(trimRight(str).c_str(), &end, 0);
+  int64_t result = wcstoll(trimRight(str).c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -71,7 +85,7 @@ int64_t str2int64(const wstring &str, int64_t fallback /* = 0 */)
 uint64_t str2uint64(const string &str, uint64_t fallback /* = 0 */)
 {
   char *end = NULL;
-  uint64_t result = strtoul(trimRight(str).c_str(), &end, 0);
+  uint64_t result = strtoull(trimRight(str).c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -81,7 +95,7 @@ uint64_t str2uint64(const string &str, uint64_t fallback /* = 0 */)
 uint64_t str2uint64(const wstring &str, uint64_t fallback /* = 0 */)
 {
   wchar_t *end = NULL;
-  uint64_t result = wcstoul(trimRight(str).c_str(), &end, 0);
+  uint64_t result = wcstoull(trimRight(str).c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 


### PR DESCRIPTION
These commits add support for HTTP Range handling in XBMC's webserver which allows other players to seek in HTTP streams accessed through the webserver. a9dcdb1 adds support for handling the following additional HTTP header fields:
- <b>Accept-Ranges</b> is added to any HEAD and GET response that is returning a file
- <b>Range</b> and <b>If-Range</b> are handling for any GET requests to an existing file. Range support includes handling of multiple ranges using the multipart/byteranges content type in the response data.
- <b>Content-Range</b> is added to any GET response that contains only a certain range of data.

There are some additional (mostly cosmetic) commits as well which do some cleanup of stuff I came across while I worked on Range support. The last commit adds optional debug logging which came in very handy during development but I wouldn't mind removing that commit if requested.

ad27c71 needs some discussion as the utility methods str2int64 et. al. don't actually do what they say (at least on win32). They use strtol et. al. which returns a long and on win32 a long is 32bit and not 64bit. So I tried to use strtoll et. al. which returns a long long (which is 64bit) but strtoll is not available on win32 and is only part of C99 and/or C++11. How is this best handled? On win32 there are alternative methods which can be called (see the code in the commit).

I have mainly tested the functionality with VLC accessing a 1080p movie from my video library through XBMC's webserver (on the same machine and from another machine) and seeking during playback multiple times. I also made a quick test using MX Player on my android phone and that worked as well (although a lot slower because that was over WiFi).
