### PR TITLE
[win32] fixed: DX runtime setup was not included after 9eaf1cd

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -282,7 +282,7 @@ IF %comp%==vs2010 (
   )
 
   SET NSISExe=%NSISExePath%\makensis.exe
-  "%NSISExe%" /V1 /X"SetCompressor /FINAL lzma" /Dxbmc_root="%CD%\BUILD_WIN32" /Dxbmc_revision="%GIT_REV%" /Dxbmc_target="%BRANCH%" "XBMC for Windows.nsi"
+  "%NSISExe%" /V1 /X"SetCompressor /FINAL lzma" /Dxbmc_root="%CD%\BUILD_WIN32" /Dxbmc_revision="%GIT_REV%" /Dxbmc_target="%target%" /Dxbmc_branch="%BRANCH%" "XBMC for Windows.nsi"
   IF NOT EXIST "%XBMC_SETUPFILE%" (
 	  set DIETEXT=Failed to create %XBMC_SETUPFILE%. NSIS installed?
 	  goto DIE

--- a/project/Win32BuildSetup/XBMC for Windows.nsi
+++ b/project/Win32BuildSetup/XBMC for Windows.nsi
@@ -15,7 +15,7 @@
 
   ;Name and file
   Name "XBMC"
-  OutFile "XBMCSetup-${xbmc_revision}-${xbmc_target}.exe"
+  OutFile "XBMCSetup-${xbmc_revision}-${xbmc_branch}.exe"
 
   XPStyle on
   


### PR DESCRIPTION
@wsoltys: This worked in my tests. If you are OK with this then merge please.
