### PR TITLE
StringUtils::FindWords fix dead loop (introduced by PR #2536)

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -587,6 +587,8 @@ size_t StringUtils::FindWords(const char *str, const char *wordLowerCase)
       s += l;
       while ((l = IsUTF8Letter(s)) > 0) s += l;
     }
+    else
+      ++s;
     while (*s && *s == ' ') s++;
 
     // and repeat until we're done


### PR DESCRIPTION
as title. fix dead loop caused by https://github.com/xbmc/xbmc/pull/2536
