### PR TITLE
[OSX] support system input method

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		810C9FA90D67D1FB0095F5DD /* MythDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA50D67D1FB0095F5DD /* MythDirectory.cpp */; };
 		810C9FAA0D67D1FB0095F5DD /* MythFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA70D67D1FB0095F5DD /* MythFile.cpp */; };
 		815EE6350E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 815EE6330E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp */; };
+		820023DB171A28A300667D1C /* OSXTextInputResponder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 820023DA171A28A300667D1C /* OSXTextInputResponder.mm */; };
 		83A72B970FBC8E3B00171871 /* LockFree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83A72B950FBC8E3B00171871 /* LockFree.cpp */; settings = {COMPILER_FLAGS = "-O0"; }; };
 		83E0B2490F7C95FF0091643F /* Atomics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B2480F7C95FF0091643F /* Atomics.cpp */; };
 		880DBE4E0DC223FF00E26B71 /* MediaSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 880DBE4B0DC223FF00E26B71 /* MediaSource.cpp */; };
@@ -1665,6 +1666,8 @@
 		810C9FA80D67D1FB0095F5DD /* MythFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MythFile.h; sourceTree = "<group>"; };
 		815EE6330E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDInputStreamRTMP.cpp; sourceTree = "<group>"; };
 		815EE6340E17F1DC009FBE3C /* DVDInputStreamRTMP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DVDInputStreamRTMP.h; sourceTree = "<group>"; };
+		820023D9171A28A300667D1C /* OSXTextInputResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSXTextInputResponder.h; sourceTree = "<group>"; };
+		820023DA171A28A300667D1C /* OSXTextInputResponder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSXTextInputResponder.mm; sourceTree = "<group>"; };
 		82F6F0EA16F269BB0081CC3C /* Buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Buffer.h; path = commons/Buffer.h; sourceTree = "<group>"; };
 		83A72B950FBC8E3B00171871 /* LockFree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LockFree.cpp; sourceTree = "<group>"; };
 		83A72B960FBC8E3B00171871 /* LockFree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LockFree.h; sourceTree = "<group>"; };
@@ -4796,6 +4799,8 @@
 				F51CEEF00F5C5D28004F4602 /* OSXGNUReplacements.h */,
 				E306D12C0DDF7B590052C2AD /* XBMCHelper.cpp */,
 				E306D12D0DDF7B590052C2AD /* XBMCHelper.h */,
+				820023D9171A28A300667D1C /* OSXTextInputResponder.h */,
+				820023DA171A28A300667D1C /* OSXTextInputResponder.mm */,
 			);
 			path = osx;
 			sourceTree = "<group>";
@@ -7842,6 +7847,7 @@
 				F5DB700217322DBB00D4DF21 /* FavouritesOperations.cpp in Sources */,
 				DF52566D1732C1890094A464 /* DVDDemuxCDDA.cpp in Sources */,
 				DFA8157E16713B1200E4E597 /* WakeOnAccess.cpp in Sources */,
+				820023DB171A28A300667D1C /* OSXTextInputResponder.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -132,3 +132,7 @@
 
 // Message sent to CGUIWindowSlideshow to show picture
 #define GUI_MSG_SHOW_PICTURE          GUI_MSG_USER + 36
+
+// Sent to text field to support 'input method'
+#define GUI_MSG_INPUT_TEXT            GUI_MSG_USER + 37
+#define GUI_MSG_INPUT_TEXT_EDIT       GUI_MSG_USER + 38

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.h
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.h
@@ -40,6 +40,8 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     virtual void FrameMove();
     void SetHeading(const std::string& heading);
     void SetText(const CStdString& aTextString);
+    void InputText(const CStdString& aTextString);
+    void InputTextEditing(const CStdString& aTextString, int start, int length);
     CStdString GetText() const;
     bool IsConfirmed() { return m_bIsConfirmed; };
     void SetHiddenInput(bool hiddenInput) { m_hiddenInput = hiddenInput; };
@@ -70,6 +72,13 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void SendSearchMessage();
 
     CStdStringW m_strEdit;
+    int m_iCursorPos;
+
+    // holds the spelling region of keystrokes/text generated from 'input method'
+    CStdStringW m_strEditing;
+    int m_iEditingOffset;
+    int m_iEditingLength;
+
     bool m_bIsConfirmed;
     KEYBOARD m_keyType;
     int m_iMode;

--- a/xbmc/osx/OSXTextInputResponder.h
+++ b/xbmc/osx/OSXTextInputResponder.h
@@ -1,0 +1,31 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import <Cocoa/Cocoa.h>
+
+@interface OSXTextInputResponder : NSView <NSTextInputClient>
+{
+  NSString *_markedText;
+  NSRange   _markedRange;
+  NSRange   _selectedRange;
+  NSRect    _inputRect;
+}
+- (void) setInputRect:(NSRect) rect;
+@end

--- a/xbmc/osx/OSXTextInputResponder.mm
+++ b/xbmc/osx/OSXTextInputResponder.mm
@@ -1,0 +1,202 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ *
+ *  OSXTextInputResponder is modified from SDLTranslatorResponder in SDL_cocoakeyboard.m
+ *  Copyright (C) 1997-2010 Sam Lantinga, LGPLV2.1 or later.
+ */
+
+#import "OSXTextInputResponder.h"
+
+#define BOOL XBMC_BOOL
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+#undef BOOL
+
+void SendKeyboardText(const char *text)
+{
+//  CLog::Log(LOGDEBUG, "SendKeyboardText(%s)", text);
+
+  /* Don't post text events for unprintable characters */
+  if ((unsigned char)*text < ' ' || *text == 127)
+    return;
+
+  CGUIMessage msg(GUI_MSG_INPUT_TEXT, 0, 0);
+  msg.SetLabel(text);
+  g_windowManager.SendThreadMessage(msg, g_windowManager.GetFocusedWindow());
+}
+
+void SendEditingText(const char *text, unsigned int location, unsigned int length)
+{
+//  CLog::Log(LOGDEBUG, "SendEditingText(%s, %u, %u)", text, location, length);
+  CGUIMessage msg(GUI_MSG_INPUT_TEXT_EDIT, 0, 0, location, length);
+  msg.SetLabel(text);
+  g_windowManager.SendThreadMessage(msg, g_windowManager.GetFocusedWindow());
+}
+
+@implementation OSXTextInputResponder
+
+- (id)initWithFrame:(NSRect)frame
+{
+  self = [super initWithFrame:frame];
+  if (self) {
+    // Initialization code here.
+    _selectedRange = NSMakeRange(0, 0);
+    _markedRange = NSMakeRange(NSNotFound, 0);
+    _inputRect = NSZeroRect;
+  }
+
+  return self;
+}
+
+- (void) setInputRect:(NSRect) rect
+{
+  _inputRect = rect;
+}
+
+- (void) insertText:(id) aString replacementRange:(NSRange)replacementRange
+{
+  const char *str;
+
+  if (replacementRange.location == NSNotFound) {
+    if (_markedRange.location != NSNotFound) {
+      replacementRange = _markedRange;
+    } else {
+      replacementRange = _selectedRange;
+    }
+  }
+
+  /* Could be NSString or NSAttributedString, so we have
+   * to test and convert it */
+  if ([aString isKindOfClass: [NSAttributedString class]])
+    str = [[aString string] UTF8String];
+  else
+    str = [aString UTF8String];
+
+  SendKeyboardText(str);
+
+  [self unmarkText];
+}
+
+- (void) doCommandBySelector:(SEL) myselector
+{
+  // No need to do anything since we are not using Cocoa
+  // selectors to handle special keys, instead we use SDL
+  // key events to do the same job.
+}
+
+- (BOOL) hasMarkedText
+{
+  return _markedText != nil;
+}
+
+- (NSRange) markedRange
+{
+  return _markedRange;
+}
+
+- (NSRange) selectedRange
+{
+  return _selectedRange;
+}
+
+- (void) setMarkedText:(id) aString
+         selectedRange:(NSRange) selRange
+      replacementRange:(NSRange) replacementRange
+{
+  if (replacementRange.location == NSNotFound) {
+    if (_markedRange.location != NSNotFound)
+      replacementRange = _markedRange;
+    else
+      replacementRange = _selectedRange;
+  }
+
+  if ([aString isKindOfClass: [NSAttributedString class]])
+    aString = [aString string];
+
+  if ([aString length] == 0)
+  {
+    [self unmarkText];
+    return;
+  }
+
+  if (_markedText != aString)
+  {
+    [_markedText release];
+    _markedText = [aString retain];
+  }
+
+  _selectedRange = selRange;
+//  _markedRange = NSMakeRange(0, [aString length]);
+  _markedRange = NSMakeRange(replacementRange.location, [aString length]);
+
+  SendEditingText([aString UTF8String], selRange.location, selRange.length);
+}
+
+- (void) unmarkText
+{
+  [_markedText release];
+  _markedText = nil;
+  _markedRange = NSMakeRange(NSNotFound, 0);
+
+  SendEditingText("", 0, 0);
+}
+
+- (NSRect) firstRectForCharacterRange: (NSRange) theRange
+                          actualRange:(NSRangePointer)actualRange
+{
+  if (actualRange)
+    *actualRange = theRange;
+
+  NSWindow *window = [self window];
+  NSRect contentRect = [window contentRectForFrameRect: [window frame]];
+  float windowHeight = contentRect.size.height;
+  NSRect rect = NSMakeRect(_inputRect.origin.x, windowHeight - _inputRect.origin.y - _inputRect.size.height,
+                           _inputRect.size.width, _inputRect.size.height);
+
+//  CLog::Log(LOGDEBUG, "firstRectForCharacterRange: (%lu, %lu): windowHeight = %g, rect = %s",
+//            theRange.location, theRange.length, windowHeight,
+//            [NSStringFromRect(rect) UTF8String]);
+  rect.origin = [[self window] convertBaseToScreen: rect.origin];
+
+  return rect;
+}
+
+- (NSAttributedString*)attributedSubstringForProposedRange:(NSRange)theRange
+                                               actualRange:(NSRangePointer)actualRange
+{
+  return nil;
+}
+
+// This method returns the index for character that is
+// nearest to thePoint.  thPoint is in screen coordinate system.
+- (NSUInteger) characterIndexForPoint:(NSPoint) thePoint
+{
+  return 0;
+}
+
+// This method is the key to attribute extension.
+// We could add new attributes through this method.
+// NSInputServer examines the return value of this
+// method & constructs appropriate attributed string.
+- (NSArray *) validAttributesForMarkedText
+{
+  return [NSArray array];
+}
+
+@end

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -104,6 +104,10 @@ public:
   std::vector<REFRESHRATE> RefreshRates(int screen, int width, int height, uint32_t dwFlags);
   REFRESHRATE DefaultRefreshRate(int screen, std::vector<REFRESHRATE> rates);
 
+  // text input interface
+  virtual void EnableTextInput(bool bEnable) {}
+  virtual bool IsTextInputEnabled() { return false; }
+
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, int screen, int width, int height, float refreshRate, uint32_t dwFlags = 0);
 

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -57,6 +57,9 @@ public:
   virtual void ResetOSScreensaver();
   virtual bool EnableFrameLimiter();
 
+  virtual void EnableTextInput(bool bEnable);
+  virtual bool IsTextInputEnabled();
+
   virtual void Register(IDispResource *resource);
   virtual void Unregister(IDispResource *resource);
   
@@ -75,6 +78,8 @@ protected:
   void  FillInVideoModes();
   bool  FlushBuffer(void);
   bool  IsObscured(void);
+  void  StartTextInput();
+  void  StopTextInput();
 
   void* m_glContext;
   static void* m_lastOwnedContext;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -47,6 +47,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
 #import <IOKit/graphics/IOGraphicsLib.h>
+#import "osx/OSXTextInputResponder.h"
 
 // turn off deprecated warning spew.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -1512,6 +1513,52 @@ void CWinSystemOSX::ResetOSScreensaver()
 bool CWinSystemOSX::EnableFrameLimiter()
 {
   return IsObscured();
+}
+
+void CWinSystemOSX::EnableTextInput(bool bEnable)
+{
+  if (bEnable)
+    StartTextInput();
+  else
+    StopTextInput();
+}
+
+OSXTextInputResponder *g_textInputResponder = nil;
+
+bool CWinSystemOSX::IsTextInputEnabled()
+{
+  return g_textInputResponder != nil && [[g_textInputResponder superview] isEqual: [[NSApp keyWindow] contentView]];
+}
+
+void CWinSystemOSX::StartTextInput()
+{
+  NSView *parentView = [[NSApp keyWindow] contentView];
+
+  /* We only keep one field editor per process, since only the front most
+   * window can receive text input events, so it make no sense to keep more
+   * than one copy. When we switched to another window and requesting for
+   * text input, simply remove the field editor from its superview then add
+   * it to the front most window's content view */
+  if (!g_textInputResponder) {
+    g_textInputResponder =
+    [[OSXTextInputResponder alloc] initWithFrame: NSMakeRect(0.0, 0.0, 0.0, 0.0)];
+  }
+
+  if (![[g_textInputResponder superview] isEqual: parentView])
+  {
+    DLOG(@"add fieldEdit to window contentView");
+    [g_textInputResponder removeFromSuperview];
+    [parentView addSubview: g_textInputResponder];
+    [[NSApp keyWindow] makeFirstResponder: g_textInputResponder];
+  }
+}
+void CWinSystemOSX::StopTextInput()
+{
+  if (g_textInputResponder) {
+    [g_textInputResponder removeFromSuperview];
+    [g_textInputResponder release];
+    g_textInputResponder = nil;
+  }
 }
 
 void CWinSystemOSX::Register(IDispResource *resource)


### PR DESCRIPTION
This PR need https://github.com/xbmc/xbmc/pull/2522

osx user now can first press option+e then press key 'e' to input 'é' when using us keyboard layout(input method)

and support all osx system input methods
