### PR TITLE
[ffmpeg] fix shared library versions (closes #14274)

### DIFF
--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -12,10 +12,10 @@ else
 AVPREFIX=
 endif
 
-AVFORMAT_SO=$(AVPREFIX)avformat-53-$(ARCH).so
-AVCODEC_SO=$(AVPREFIX)avcodec-53-$(ARCH).so
-AVUTIL_SO=$(AVPREFIX)avutil-51-$(ARCH).so
-AVFILTER_SO=$(AVPREFIX)avfilter-2-$(ARCH).so
+AVFORMAT_SO=$(AVPREFIX)avformat-54-$(ARCH).so
+AVCODEC_SO=$(AVPREFIX)avcodec-54-$(ARCH).so
+AVUTIL_SO=$(AVPREFIX)avutil-52-$(ARCH).so
+AVFILTER_SO=$(AVPREFIX)avfilter-3-$(ARCH).so
 SWSCALE_SO=$(AVPREFIX)swscale-2-$(ARCH).so
 POSTPROC_SO=$(AVPREFIX)postproc-52-$(ARCH).so
 SWRESAMPLE_SO=$(AVPREFIX)swresample-0-$(ARCH).so

--- a/tools/buildsteps/win32/make-mingwlibs.sh
+++ b/tools/buildsteps/win32/make-mingwlibs.sh
@@ -61,7 +61,7 @@ echo "##### building ffmpeg dlls #####"
 cd /xbmc/lib/ffmpeg/
 sh ./build_xbmc_win32.sh $MAKECLEAN
 setfilepath /xbmc/system/players/dvdplayer
-checkfiles avcodec-53.dll avformat-53.dll avutil-51.dll postproc-52.dll swscale-2.dll avfilter-2.dll swresample-0.dll
+checkfiles avcodec-54.dll avformat-54.dll avutil-52.dll postproc-52.dll swscale-2.dll avfilter-3.dll swresample-0.dll
 echo "##### building of ffmpeg dlls done #####"
 
 echo "##### building libdvd dlls #####"

--- a/xbmc/DllPaths_generated.h.in
+++ b/xbmc/DllPaths_generated.h.in
@@ -72,12 +72,12 @@
 #define DLL_PATH_LIBMAD        "@MAD_SONAME@"
 
 /* ffmpeg */
-#define DLL_PATH_LIBAVCODEC    "special://xbmcbin/system/players/dvdplayer/avcodec-53-@ARCH@.so"
-#define DLL_PATH_LIBAVFORMAT   "special://xbmcbin/system/players/dvdplayer/avformat-53-@ARCH@.so"
-#define DLL_PATH_LIBAVUTIL     "special://xbmcbin/system/players/dvdplayer/avutil-51-@ARCH@.so"
+#define DLL_PATH_LIBAVCODEC    "special://xbmcbin/system/players/dvdplayer/avcodec-54-@ARCH@.so"
+#define DLL_PATH_LIBAVFORMAT   "special://xbmcbin/system/players/dvdplayer/avformat-54-@ARCH@.so"
+#define DLL_PATH_LIBAVUTIL     "special://xbmcbin/system/players/dvdplayer/avutil-52-@ARCH@.so"
 #define DLL_PATH_LIBPOSTPROC   "special://xbmcbin/system/players/dvdplayer/postproc-52-@ARCH@.so"
 #define DLL_PATH_LIBSWSCALE    "special://xbmcbin/system/players/dvdplayer/swscale-2-@ARCH@.so"
-#define DLL_PATH_LIBAVFILTER   "special://xbmcbin/system/players/dvdplayer/avfilter-2-@ARCH@.so"
+#define DLL_PATH_LIBAVFILTER   "special://xbmcbin/system/players/dvdplayer/avfilter-3-@ARCH@.so"
 #define DLL_PATH_LIBSWRESAMPLE "special://xbmcbin/system/players/dvdplayer/swresample-0-@ARCH@.so"
 
 /* cdrip */

--- a/xbmc/DllPaths_generated_android.h.in
+++ b/xbmc/DllPaths_generated_android.h.in
@@ -74,12 +74,12 @@
 #define DLL_PATH_LIBMAD        "@MAD_SONAME@"
 
 /* ffmpeg */
-#define DLL_PATH_LIBAVCODEC    "libavcodec-53-@ARCH@.so"
-#define DLL_PATH_LIBAVFORMAT   "libavformat-53-@ARCH@.so"
-#define DLL_PATH_LIBAVUTIL     "libavutil-51-@ARCH@.so"
+#define DLL_PATH_LIBAVCODEC    "libavcodec-54-@ARCH@.so"
+#define DLL_PATH_LIBAVFORMAT   "libavformat-54-@ARCH@.so"
+#define DLL_PATH_LIBAVUTIL     "libavutil-52-@ARCH@.so"
 #define DLL_PATH_LIBPOSTPROC   "libpostproc-52-@ARCH@.so"
 #define DLL_PATH_LIBSWSCALE    "libswscale-2-@ARCH@.so"
-#define DLL_PATH_LIBAVFILTER   "libavfilter-2-@ARCH@.so"
+#define DLL_PATH_LIBAVFILTER   "libavfilter-3-@ARCH@.so"
 #define DLL_PATH_LIBSWRESAMPLE "libswresample-0-@ARCH@.so"
 
 /* cdrip */


### PR DESCRIPTION
the hardcoded ffmpeg library versions are partly wrong after the bump.
This breaks packaging on linux, because dpkg-shlibs cannot find the correct libaries.

This PR corrects the major versions, I hope I found all places where they are used.
