### PR TITLE
[settings] added maxplayerforwardrate to advancedsettings

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2898,7 +2898,7 @@ bool CApplication::OnAction(const CAction &action)
 
         if (action.GetID() == ACTION_PLAYER_FORWARD && iPlaySpeed == -1) //sets iSpeed back to 1 if -1 (didn't plan for a -1)
           iPlaySpeed = 1;
-        if (iPlaySpeed > 32 || iPlaySpeed < -32)
+        if (iPlaySpeed > g_advancedSettings.m_maxPlayerForwardRate || iPlaySpeed < -g_advancedSettings.m_maxPlayerForwardRate)
           iPlaySpeed = 1;
 
         SetPlaySpeed(iPlaySpeed);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -137,6 +137,7 @@ void CAdvancedSettings::Initialize()
   m_videoFpsDetect = 1;
   m_videoDefaultLatency = 0.0;
   m_videoDisableHi10pMultithreading = false;
+  m_maxPlayerForwardRate = 32;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -798,6 +799,8 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetFloat(pRootElement,"sleepbeforeflip", m_sleepBeforeFlip, 0.0f, 1.0f);
   XMLUtils::GetBoolean(pRootElement,"virtualshares", m_bVirtualShares);
   XMLUtils::GetUInt(pRootElement, "packagefoldersize", m_addonPackageFolderSize);
+
+  XMLUtils::GetInt(pRootElement, "maxplayerforwardrate", m_maxPlayerForwardRate, 1, 32);
 
   //Tuxbox
   pElement = pRootElement->FirstChildElement("tuxbox");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -306,6 +306,7 @@ class CAdvancedSettings : public ISettingsHandler
     bool m_GLRectangleHack;
     int m_iSkipLoopFilter;
     float m_ForcedSwapTime; /* if nonzero, set's the explicit time in ms to allocate for buffer swap */
+    int m_maxPlayerForwardRate; /* limit seek speed for player */
 
     bool m_AllowD3D9Ex;
     bool m_ForceD3D9Ex;


### PR DESCRIPTION
I need this feature because of problems when seeking too fast on smb-shares.
I've put it into advancedsettings.xml, so that it doesn't affect anyone if it's not used.
