### PR TITLE
[Fix] episode nfo with XML declaration and mismatched episode numbers would be ignored

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -71,6 +71,7 @@ CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr
     if (episode > -1 && bNfo && m_type == ADDON_SCRAPER_TVSHOWS)
     {
       int infos=0;
+      m_headofdoc = strstr(m_headofdoc,"<episodedetails");
       while (m_headofdoc && details.m_iEpisode != episode)
       {
         m_headofdoc = strstr(m_headofdoc+1,"<episodedetails");


### PR DESCRIPTION
Stumbled across this...

The usual behaviour for XBMC when an episode nfo file has a single episodedetails block but mismatched episode numbers is to use the details regardless (and set the episode numbers from the file name).  If there are multiple episodedetails blocks, however,  XBMC will ignore the nfo file if it can't find a match.

The flaw here is that if there's an xml declaration (such as from a library export), the first block will get counted twice, first starting at the declaration, and then again after advancing to the "next" episodedetails tag (which is really the first one).  In the case of a single episodedetails, the count will then appear to be 2 (if the episode numbers don't match), so the nfo file will be ignored.

The simple fix is just to ensure we start checking from the first episodedetails tag.
