### PR TITLE
Allow dashes in music videos on the first pass

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -510,7 +510,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
   if (IsNoop())
     return vcscurl;
 
-  if (!fFirst || Content() == CONTENT_MUSICVIDEOS)
+  if (!fFirst)
     sTitle.Replace("-"," ");
 
   sTitle.ToLower();


### PR DESCRIPTION
This removes the limitation on Music videos to have their dashes removed immediately prior to scraping.

Not sure why this was put in in the first place?

(This will require an update to the scraper before being pulled.)
