### PR TITLE
GUIWindowPVR: don't spawn dedicated thread just to invalidate channel items every 5 seconds

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVR.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVR.cpp
@@ -36,6 +36,8 @@
 
 using namespace PVR;
 
+#define CHANNELS_REFRESH_INTERVAL 5000
+
 CGUIWindowPVR::CGUIWindowPVR(void) :
   CGUIMediaWindow(WINDOW_PVR, "MyPVR.xml"),
   m_guideGrid(NULL),
@@ -76,6 +78,9 @@ void CGUIWindowPVR::SetActiveView(CGUIWindowPVRCommon *window)
       m_currentSubwindow->m_history = m_history;
       m_currentSubwindow->m_iSelected = m_viewControl.GetSelectedItem();
     }
+
+    if (window == m_windowChannelsRadio || window == m_windowChannelsTV)
+      m_refreshWatch.StartZero();
 
     // update m_history
     if (window)
@@ -334,4 +339,18 @@ void CGUIWindowPVR::Cleanup(void)
 
   ClearFileItems();
   FreeResources();
+}
+
+void CGUIWindowPVR::FrameMove()
+{
+  CGUIWindowPVRCommon* view = GetActiveView();
+  if (view == m_windowChannelsRadio || view == m_windowChannelsTV)
+  {
+    if (m_refreshWatch.GetElapsedMilliseconds() > CHANNELS_REFRESH_INTERVAL)
+    {
+      view->SetInvalid();
+      m_refreshWatch.Reset();
+    }
+  }
+  CGUIMediaWindow::FrameMove();
 }

--- a/xbmc/pvr/windows/GUIWindowPVR.h
+++ b/xbmc/pvr/windows/GUIWindowPVR.h
@@ -22,6 +22,7 @@
 
 #include "GUIWindowPVRCommon.h"
 #include "epg/GUIEPGGridContainer.h"
+#include "utils/Stopwatch.h"
 #include "threads/CriticalSection.h"
 
 namespace PVR
@@ -56,6 +57,7 @@ namespace PVR
     virtual bool OnMessage(CGUIMessage& message);
     virtual void OnWindowLoaded(void);
     virtual void OnWindowUnload(void);
+    virtual void FrameMove();
     virtual void Reset(void);
     virtual void Cleanup(void);
 
@@ -85,5 +87,7 @@ namespace PVR
     bool                     m_bWasReset;
 
     CCriticalSection         m_critSection;
+
+    CStopWatch               m_refreshWatch;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -49,18 +49,14 @@ CGUIWindowPVRChannels::CGUIWindowPVRChannels(CGUIWindowPVR *parent, bool bRadio)
   CGUIWindowPVRCommon(parent,
                       bRadio ? PVR_WINDOW_CHANNELS_RADIO : PVR_WINDOW_CHANNELS_TV,
                       bRadio ? CONTROL_BTNCHANNELS_RADIO : CONTROL_BTNCHANNELS_TV,
-                      bRadio ? CONTROL_LIST_CHANNELS_RADIO: CONTROL_LIST_CHANNELS_TV),
-  CThread("PVRChannelWin")
+                      bRadio ? CONTROL_LIST_CHANNELS_RADIO: CONTROL_LIST_CHANNELS_TV)
 {
   m_bRadio              = bRadio;
   m_bShowHiddenChannels = false;
-  m_bThreadCreated      = false;
 }
 
 CGUIWindowPVRChannels::~CGUIWindowPVRChannels(void)
 {
-  if (m_bThreadCreated)
-    StopThread(true);
 }
 
 void CGUIWindowPVRChannels::ResetObservers(void)
@@ -266,13 +262,6 @@ void CGUIWindowPVRChannels::UpdateData(bool bUpdateSelectedFile /* = true */)
     m_parent->SetLabel(CONTROL_LABELGROUP, g_localizeStrings.Get(19022));
   else
     m_parent->SetLabel(CONTROL_LABELGROUP, currentGroup->GroupName());
-
-  if (!m_bThreadCreated)
-  {
-    m_bThreadCreated = true;
-    Create();
-    SetPriority(-1);
-  }
 }
 
 bool CGUIWindowPVRChannels::OnClickButton(CGUIMessage &message)
@@ -607,19 +596,4 @@ void CGUIWindowPVRChannels::ShowGroupManager(void)
   pDlgInfo->DoModal();
 
   return;
-}
-
-void CGUIWindowPVRChannels::Process(void)
-{
-  // ugly hack to refresh the progress bars and item contents every 5 seconds
-  int iCount(0);
-  while (!m_bStop)
-  {
-    if (++iCount == 100)
-    {
-      iCount = 0;
-      SetInvalid();
-    }
-    Sleep(50);
-  }
 }

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -22,14 +22,13 @@
 
 #include "GUIWindowPVRCommon.h"
 #include "utils/Observer.h"
-#include "threads/Thread.h"
 #include "../channels/PVRChannelGroup.h"
 
 namespace PVR
 {
   class CGUIWindowPVR;
 
-  class CGUIWindowPVRChannels : public CGUIWindowPVRCommon, private Observer, private CThread
+  class CGUIWindowPVRChannels : public CGUIWindowPVRCommon, private Observer
   {
     friend class CGUIWindowPVR;
 
@@ -48,7 +47,6 @@ namespace PVR
     void UnregisterObservers(void);
 
   private:
-    void Process(void);
     bool OnClickButton(CGUIMessage &message);
     bool OnClickList(CGUIMessage &message);
 
@@ -70,6 +68,5 @@ namespace PVR
     CPVRChannelGroupPtr m_selectedGroup;
     bool              m_bShowHiddenChannels;
     bool              m_bRadio;
-    bool              m_bThreadCreated;
   };
 }


### PR DESCRIPTION
This essentially replace hack with a little less ugly hack
