### PR TITLE
Revert broken part of [6f653c5a2ba30008d62ab589ff5686df8a29ef72].

### DIFF
--- a/lib/DllAvFormat.h
+++ b/lib/DllAvFormat.h
@@ -43,12 +43,9 @@ extern "C" {
     #include <ffmpeg/avformat.h>
   #endif
   /* av_read_frame_flush() is defined for us in lib/xbmc-dll-symbols/DllAvFormat.c */
-  // void av_read_frame_flush(AVFormatContext *s); // av_read_frame_flush decrepated
-  void ff_read_frame_flush(AVFormatContext *s);    // internal replacement
+  void av_read_frame_flush(AVFormatContext *s);
 #else
   #include "libavformat/avformat.h"
-  void ff_read_frame_flush(AVFormatContext *s);    // internal replacement
-
 #endif
 }
 
@@ -118,7 +115,7 @@ public:
   virtual AVInputFormat *av_find_input_format(const char *short_name) { return ::av_find_input_format(short_name); }
   virtual void avformat_close_input(AVFormatContext **s) { ::avformat_close_input(s); }
   virtual int av_read_frame(AVFormatContext *s, AVPacket *pkt) { return ::av_read_frame(s, pkt); }
-  virtual void av_read_frame_flush(AVFormatContext *s) { ::ff_read_frame_flush(s); } // av_read_frame_flush decrepated 
+  virtual void av_read_frame_flush(AVFormatContext *s) { ::av_read_frame_flush(s); }
   virtual int av_read_play(AVFormatContext *s) { return ::av_read_play(s); }
   virtual int av_read_pause(AVFormatContext *s) { return ::av_read_pause(s); }
   virtual int av_seek_frame(AVFormatContext *s, int stream_index, int64_t timestamp, int flags) { return ::av_seek_frame(s, stream_index, timestamp, flags); }

--- a/lib/DllAvFormat.h
+++ b/lib/DllAvFormat.h
@@ -42,8 +42,8 @@ extern "C" {
   #else
     #include <ffmpeg/avformat.h>
   #endif
-  /* av_read_frame_flush() is defined for us in lib/xbmc-dll-symbols/DllAvFormat.c */
-  void av_read_frame_flush(AVFormatContext *s);
+  /* xbmc_read_frame_flush() is defined for us in lib/xbmc-dll-symbols/DllAvFormat.c */
+  void xbmc_read_frame_flush(AVFormatContext *s);
 #else
   #include "libavformat/avformat.h"
 #endif
@@ -115,7 +115,7 @@ public:
   virtual AVInputFormat *av_find_input_format(const char *short_name) { return ::av_find_input_format(short_name); }
   virtual void avformat_close_input(AVFormatContext **s) { ::avformat_close_input(s); }
   virtual int av_read_frame(AVFormatContext *s, AVPacket *pkt) { return ::av_read_frame(s, pkt); }
-  virtual void av_read_frame_flush(AVFormatContext *s) { ::av_read_frame_flush(s); }
+  virtual void av_read_frame_flush(AVFormatContext *s) { ::xbmc_read_frame_flush(s); }
   virtual int av_read_play(AVFormatContext *s) { return ::av_read_play(s); }
   virtual int av_read_pause(AVFormatContext *s) { return ::av_read_pause(s); }
   virtual int av_seek_frame(AVFormatContext *s, int stream_index, int64_t timestamp, int flags) { return ::av_seek_frame(s, stream_index, timestamp, flags); }

--- a/lib/xbmc-dll-symbols/DllAvFormat.c
+++ b/lib/xbmc-dll-symbols/DllAvFormat.c
@@ -76,8 +76,10 @@ static void flush_packet_queue(AVFormatContext *s)
 }
 #endif
 
-/* Taken from libavformat/utils.c */
-void av_read_frame_flush(AVFormatContext *s)
+/* Taken from libavformat/utils.c
+ * Original name is ff_read_frame_flush
+ * */
+void xbmc_read_frame_flush(AVFormatContext *s)
 {
     AVStream *st;
     int i, j;


### PR DESCRIPTION
This was obviously untested as it breaks external ffmpeg build and only changes this code path.
xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxers.a(DVDDemuxFFmpeg.o): In function `DllAvFormat::av_read_frame_flush(AVFormatContext*):
/home/alexis/xbmc/lib/DllAvFormat.h:121: undefined reference to
`ff_read_frame_flush'

Even if it did not break, the change is wrong anyway.
