### PR TITLE
Use different names for USB/CEC and Udev related threads

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -29,8 +29,8 @@ using namespace PERIPHERALS;
 
 #define PERIPHERAL_DEFAULT_RESCAN_INTERVAL 1000
 
-CPeripheralBus::CPeripheralBus(CPeripherals *manager, PeripheralBusType type) :
-    CThread("PeripheralBus"),
+CPeripheralBus::CPeripheralBus(const CStdString &threadname, CPeripherals *manager, PeripheralBusType type) :
+    CThread(threadname),
     m_iRescanTime(PERIPHERAL_DEFAULT_RESCAN_INTERVAL),
     m_bInitialised(false),
     m_bIsStarted(false),

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -42,7 +42,7 @@ namespace PERIPHERALS
   class CPeripheralBus : protected CThread
   {
   public:
-    CPeripheralBus(CPeripherals *manager, PeripheralBusType type);
+    CPeripheralBus(const CStdString &threadname, CPeripherals *manager, PeripheralBusType type);
     virtual ~CPeripheralBus(void) { Clear(); }
 
     /*!

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.cpp
@@ -26,7 +26,7 @@
 using namespace PERIPHERALS;
 
 CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
-    CPeripheralBus(manager, PERIPHERAL_BUS_USB)
+    CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   usb_init();
   usb_find_busses();

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
@@ -77,7 +77,7 @@ extern "C" {
 using namespace PERIPHERALS;
 
 CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
-    CPeripheralBus(manager, PERIPHERAL_BUS_USB)
+    CPeripheralBus("PeripBusUSBUdev", manager, PERIPHERAL_BUS_USB)
 {
   /* the Process() method in this class overrides the one in CPeripheralBus, so leave this set to true */
   m_bNeedsPolling = true;

--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
@@ -43,7 +43,7 @@ typedef struct USBDevicePrivateData {
 #endif
 
 CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
-    CPeripheralBus(manager, PERIPHERAL_BUS_USB)
+    CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   m_bNeedsPolling = false;
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
@@ -53,7 +53,7 @@ class PERIPHERALS::DllLibCEC : public DllDynamic, DllLibCECInterface
 };
 
 CPeripheralBusCEC::CPeripheralBusCEC(CPeripherals *manager) :
-    CPeripheralBus(manager, PERIPHERAL_BUS_CEC),
+    CPeripheralBus("PeripBusCEC", manager, PERIPHERAL_BUS_CEC),
     m_dll(new DllLibCEC),
     m_cecAdapter(NULL)
 {

--- a/xbmc/peripherals/bus/win32/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/win32/PeripheralBusUSB.cpp
@@ -31,7 +31,7 @@ static GUID USB_NIC_GUID =  { 0xAD498944, 0x762F, 0x11D0, { 0x8D, 0xCB, 0x00, 0x
 using namespace PERIPHERALS;
 
 CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
-    CPeripheralBus(manager, PERIPHERAL_BUS_USB)
+    CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   /* device removals aren't always triggering OnDeviceRemoved events, so poll for changes every 5 seconds to be sure we don't miss anything */
   m_iRescanTime = 5000;


### PR DESCRIPTION
While debugging some rescanning issues, it helped to distinguish the different PeripheralBus threads. Since there is a limit to thread names, I had to make sure the name fitted into 15 characters.

This is part of a series of PRs: #2323 and #2541

Before:

```
xbmc.bin-+-{EPGUpdater}
         |-{EventServer}
         |-2*[{PVRClient}]
         |-{PVRGUIInfo}
         |-{PVRManager}
         |-2*{PeripheralBus}            <-
         |-{SoftAE}
         |-{TCPServer}
         |-5*[{XBPython}]
         `-8*[{xbmc.bin}]
```

After:

```
xbmc.bin-+-{EPGUpdater}
         |-{EventServer}
         |-2*[{PVRClient}]
         |-{PVRGUIInfo}
         |-{PVRManager}
         |-{PeripBusCEC}                <-
         |-{PeripBusUSBUdev}            <-
         |-{SoftAE}
         |-{TCPServer}
         |-5*[{XBPython}]
         `-8*[{xbmc.bin}]
```
