### PR TITLE
Raise USB and CEC rescan interval to 5 seconds

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace PERIPHERALS;
 
-#define PERIPHERAL_DEFAULT_RESCAN_INTERVAL 1000
+#define PERIPHERAL_DEFAULT_RESCAN_INTERVAL 5000
 
 CPeripheralBus::CPeripheralBus(CPeripherals *manager, PeripheralBusType type) :
     CThread("PeripheralBus"),

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -33,7 +33,7 @@ namespace PERIPHERALS
 
   /*!
    * @class CPeripheralBus
-   * This represents a bus on the system. By default, this bus instance will scan for changes every second.
+   * This represents a bus on the system. By default, this bus instance will scan for changes every 5 seconds.
    * If this bus only has to be updated after a notification sent by the system, set m_bNeedsPolling to false
    * in the constructor, and implement the OnDeviceAdded(), OnDeviceChanged() and OnDeviceRemoved() methods.
    *

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
@@ -57,7 +57,7 @@ CPeripheralBusCEC::CPeripheralBusCEC(CPeripherals *manager) :
     m_dll(new DllLibCEC),
     m_cecAdapter(NULL)
 {
-  m_iRescanTime = 1000;
+  m_iRescanTime = 5000;
   if (!m_dll->Load() || !m_dll->IsLoaded())
   {
     delete m_dll;


### PR DESCRIPTION
In one of my investigations to see why XBMC performance is not good when idle I found one of the threads (in my case PeripheralBusCEC) scan a big sysfs tree recursively. On the 1Ghz AppleTV 1 device this would be about 2% to 3% of the CPU **every** second (half of the CPU usage when idle !). For the USB thread we luckily have Udev events, but for CEC it is using sysfs polling (of Udev devices) which is quite expensive. It would be better to make use of Udev events for CEC (much like PeripheralBusUSBLibUdev does) however increasing the rescan to 5 seconds should not harm anyone for the time being.

In my own builds I even brought it down to 30 seconds. Which means 29 seconds of reduced CPU usage.

The CEC polling probably should be more restricted to specific sysfs sections, or preferably use Udev as well.

PS XBMC needs a special idle-state where it can turn down these expensive threads to make sure hardware can go into deeper sleep states. Especially for devices that doesn't do suspend for various reasons this is a requirement. (The ATV1 device for instance gets warm even when idle) If we can combine display-sleep with low-power states and a less expensive main-loop, that would be already quite an improvement without needing a complete refactoring of the code.
