### PR TITLE
Revert back to old behavior before PR2187 to fix #14204.

### DIFF
--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -114,6 +114,7 @@ namespace XFILE
           int64_t         m_filePos;
           bool            m_bFirstLoop;
           bool            m_isPaused;
+          bool            m_requireRange;
 
           char*           m_readBuffer;
 
@@ -175,6 +176,7 @@ namespace XFILE
       bool            m_multisession;
       bool            m_skipshout;
       bool            m_postdataset;
+      bool            m_requireRange;
 
       CRingBuffer     m_buffer;           // our ringhold buffer
       char *          m_overflowBuffer;   // in the rare case we would overflow the above buffer


### PR DESCRIPTION
Also add protocol option 'require_range' for addons to workaround buggy Silverlight, so streams on the buggy server works on 12.1 but won't on 12.2 (we may apply this or a clean revert without new protocol option), but will work on 13.0 if the addons add require_range=1 protocol option to the stream url.

This PR is a replacement of https://github.com/xbmc/xbmc/pull/2620 which is too complex and that's all because of the buggy silverlight server. we should not do so much for the buggy server, a protocol option can be added by addon will workaround it. and won't affect all other existed usage like the one in http://trac.xbmc.org/ticket/14204
