### PR TITLE
[rbp/omxplayer] Fix audio volume jumps when switching tracks

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1302,7 +1302,7 @@ void COMXPlayer::Process()
     if (IsBetterStream(m_CurrentSubtitle, pStream)) OpenSubtitleStream(pStream->iId, pStream->source);
     if (IsBetterStream(m_CurrentTeletext, pStream)) OpenTeletextStream(pStream->iId, pStream->source);
 
-    if(m_change_volume)
+    if(m_change_volume && m_CurrentAudio.started)
     {
       m_player_audio.SetCurrentVolume(m_current_mute ? VOLUME_MINIMUM : m_current_volume);
       m_change_volume = false;


### PR DESCRIPTION
When the global volume has been set low, and a sequence of tracks are being played, there are complaints of occasional jumps to full volume.
This is down to a race condition where the volume request can arrive at OMXAudio before it has been initialised.
The fix is simple, don't send the volume change until m_CurrentAudio.started.
