### PR TITLE
[Python] Extend xbmc.getLangauge to return various language formats.

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -52,6 +52,7 @@
 #include "cores/AudioEngine/AEFactory.h"
 #include "storage/MediaManager.h"
 #include "utils/FileUtils.h"
+#include "utils/LangCodeExpander.h"
 
 #include "CallbackHandler.h"
 #include "AddonUtils.h"
@@ -180,10 +181,54 @@ namespace XBMCAddon
       return g_guiSettings.GetString("lookandfeel.skin");
     }
 
-    String getLanguage()
+    String getLanguage(int format /* = CLangCodeExpander::ENGLISH_NAME */, bool region /*= false*/)
     {
       TRACE;
-      return g_guiSettings.GetString("locale.language");
+      CStdString lang = g_guiSettings.GetString("locale.language");
+
+      switch (format)
+      {
+      case CLangCodeExpander::ENGLISH_NAME:
+        {
+          if (region)
+          {
+            CStdString region = "-" + g_langInfo.GetCurrentRegion();
+            return (lang += region).c_str();
+          }
+          return lang.c_str();
+        }
+      case CLangCodeExpander::ISO_639_1:
+        {
+          CStdString langCode;
+          g_LangCodeExpander.ConvertToTwoCharCode(langCode, lang);
+          if (region)
+          {
+            CStdString region = g_langInfo.GetRegionLocale();
+            CStdString region2Code;
+            g_LangCodeExpander.ConvertToTwoCharCode(region2Code, region);
+            region2Code = "-" + region2Code;
+            return (langCode += region2Code).c_str();
+          }
+          return langCode.c_str();
+        }
+      case CLangCodeExpander::ISO_639_2:
+        {
+          CStdString langCode;
+          g_LangCodeExpander.ConvertToThreeCharCode(langCode, lang);
+          if (region)
+          {
+            CStdString region = g_langInfo.GetRegionLocale();
+            CStdString region3Code;
+            g_LangCodeExpander.ConvertToThreeCharCode(region3Code, region, true);
+            region3Code = "-" + region3Code;
+            return (langCode += region3Code).c_str();
+          }
+
+          return langCode.c_str();
+        }
+      default:
+        return "";
+      }
     }
 
     String getIPAddress()
@@ -481,6 +526,11 @@ namespace XBMCAddon
     // render capture flags
     int getCAPTURE_FLAG_CONTINUOUS() { return (int)CAPTUREFLAG_CONTINUOUS; }
     int getCAPTURE_FLAG_IMMEDIATELY() { return (int)CAPTUREFLAG_IMMEDIATELY; }
+
+    // language string formats
+    int getISO_639_1() { return CLangCodeExpander::ISO_639_1; } 
+    int getISO_639_2(){ return CLangCodeExpander::ISO_639_2; }
+    int getENGLISH_NAME() { return CLangCodeExpander::ENGLISH_NAME; }
 
     const int lLOGNOTICE = LOGNOTICE;
   }

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -23,6 +23,7 @@
 #include "Tuple.h"
 //#include "Monitor.h"
 
+#include "utils/LangCodeExpander.h"
 #include "utils/log.h"
 #include "utils/StdString.h"
 
@@ -150,12 +151,20 @@ namespace XBMCAddon
     String getSkinDir();
 
     /**
-     * getLanguage() -- Returns the active language as a string.
-     * 
-     * example:
-     *   - language = xbmc.getLanguage()
-     */
-    String getLanguage();
+    * getLanguage([format], [region]) -- Returns the active language as a string.
+    *
+    * format: [opt] format of the returned language string
+    *               xbmc.ISO_639_1: two letter code as defined in ISO 639-1
+    *               xbmc.ISO_639_2: three letter code as defined in ISO 639-2/T or ISO 639-2/B
+    *               xbmc.ENGLISH_NAME: full language name in English (default)
+    *
+    * region: [opt] append the region delimited by "-" of the language (setting)
+    *               to the returned language string
+    *
+    * example:
+    *   - language = xbmc.getLanguage(xbmc.ENGLISH_NAME)
+    */
+    String getLanguage(int format = CLangCodeExpander::ENGLISH_NAME, bool region = false);
 
     /**
      * getIPAddress() -- Returns the current ip address as a string.
@@ -429,6 +438,9 @@ namespace XBMCAddon
 
     SWIG_CONSTANT_FROM_GETTER(int,CAPTURE_FLAG_CONTINUOUS);
     SWIG_CONSTANT_FROM_GETTER(int,CAPTURE_FLAG_IMMEDIATELY);
+    SWIG_CONSTANT_FROM_GETTER(int,ISO_639_1);
+    SWIG_CONSTANT_FROM_GETTER(int,ISO_639_2);
+    SWIG_CONSTANT_FROM_GETTER(int,ENGLISH_NAME);
 #if 0
     void registerMonitor(Monitor* monitor);
     void unregisterMonitor(Monitor* monitor);

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -202,6 +202,14 @@ bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, con
         return true;
       }
     }
+    for (unsigned int index = 0; index < sizeof(RegionCode2To3) / sizeof(RegionCode2To3[0]); ++index)
+    {
+      if (strCharCode.Equals(RegionCode2To3[index].id))
+      {
+        strThreeCharCode = strCharCode;
+        return true;
+      }
+    }
   }
   else if (strCharCode.size() > 3)
   {
@@ -303,10 +311,17 @@ bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString&
       return true;
     }
     else if (tmp.length() == 3)
-      return ConvertToTwoCharCode(tmp, code);
+      return ConvertToTwoCharCode(code, tmp);
   }
 
-  return false;
+  // try xbmc specific language names
+  CStdString strLangInfoPath;
+  strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", lang.c_str());
+  CLangInfo langInfo;
+  if (!langInfo.Load(strLangInfoPath))
+    return false;
+
+  return ConvertToTwoCharCode(code, langInfo.GetLanguageCode());
 }
 
 bool CLangCodeExpander::ReverseLookup(const CStdString& desc, CStdString& code)

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -261,7 +261,7 @@ bool CLangCodeExpander::ConvertWindowsToGeneralCharCode(const CStdString& strWin
 }
 #endif
 
-bool CLangCodeExpander::ConvertToTwoCharCode(const CStdString& lang, CStdString& code)
+bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString& lang)
 {
   if (lang.length() == 2)
   {

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -28,6 +28,13 @@ class CLangCodeExpander
 {
 public:
 
+  enum LANGFORMATS
+  {
+    ISO_639_1,
+    ISO_639_2,
+    ENGLISH_NAME
+  };
+
   CLangCodeExpander(void);
   ~CLangCodeExpander(void);
 

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -33,6 +33,7 @@ public:
 
   bool Lookup(CStdString& desc, const CStdString& code);
   bool Lookup(CStdString& desc, const int code);
+  bool ConvertToTwoCharCode(const CStdString& lang, CStdString& code);
 #ifdef TARGET_WINDOWS
   bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool localeHack = false);
   bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool localeHack = false);
@@ -49,13 +50,14 @@ public:
   void LoadUserCodes(const TiXmlElement* pRootElement);
   void Clear();
 protected:
-
+  void CodeToString(long code, CStdString& ret);
 
   typedef std::map<CStdString, CStdString> STRINGLOOKUPTABLE;
   STRINGLOOKUPTABLE m_mapUser;
 
   bool LookupInDb(CStdString& desc, const CStdString& code);
   bool LookupInMap(CStdString& desc, const CStdString& code);
+  bool ReverseLookup(const CStdString& desc, CStdString& code);
 };
 
 extern CLangCodeExpander g_LangCodeExpander;

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -33,7 +33,15 @@ public:
 
   bool Lookup(CStdString& desc, const CStdString& code);
   bool Lookup(CStdString& desc, const int code);
-  bool ConvertToTwoCharCode(const CStdString& lang, CStdString& code);
+
+  /** \brief Converts a language given as 2-Char (ISO 639-1),
+  *          3-Char (ISO 639-2/T or ISO 639-2/B),
+  *          or full english name string to a 2-Char (ISO 639-1) code.  
+  *   \param[out] code The 2-Char language code of the given language lang.
+  *   \param[in] lang The language that should be converted.
+  *   \return true if the conversion succeeded, false otherwise. 
+  */ 
+  bool ConvertToTwoCharCode(CStdString& code, const CStdString& lang);
 #ifdef TARGET_WINDOWS
   bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool localeHack = false);
   bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool localeHack = false);
@@ -50,6 +58,12 @@ public:
   void LoadUserCodes(const TiXmlElement* pRootElement);
   void Clear();
 protected:
+
+  /** \brief Converts a language code given as a long, see #MAKECODE(a, b, c, d)
+  *          to its string representation.
+  *   \param[in] code The language code given as a long, see #MAKECODE(a, b, c, d).
+  *   \param[out] ret The string representation of the given language code code.
+  */ 
   void CodeToString(long code, CStdString& ret);
 
   typedef std::map<CStdString, CStdString> STRINGLOOKUPTABLE;
@@ -57,6 +71,13 @@ protected:
 
   bool LookupInDb(CStdString& desc, const CStdString& code);
   bool LookupInMap(CStdString& desc, const CStdString& code);
+
+  /** \brief Looks up the ISO 639-1, ISO 639-2/T, or ISO 639-2/B, whichever it finds first,
+  *          code of the given english language name.
+  *   \param[in] desc The english language name for which a code is looked for.
+  *   \param[out] code The ISO 639-1, ISO 639-2/T, or ISO 639-2/B code of the given language desc.
+  *   \return true if the a code was found, false otherwise.
+  */ 
   bool ReverseLookup(const CStdString& desc, CStdString& code);
 };
 


### PR DESCRIPTION
This PR allows addon devs to specify the format of the returned language string.
The signature is

``` C++
    /**
    * getLanguage([format], [region]) -- Returns the active language as a string.
    *
    * format: [opt] format of the returned language string
    *               xbmc.ISO_639_1: two letter code as defined in ISO 639-1
    *               xbmc.ISO_639_2: three letter code as defined in ISO 639-2/T or ISO 639-2/B
    *               xbmc.ENGLISH_NAME: full language name in English (default)
    *
    * region: [opt] append the region delimited by "-" of the language (setting)
    *               to the returned language string
    *
    * example:
    *   - language = xbmc.getLanguage(xbmc.ENGLISH_NAME)
    */
    String getLanguage(int format = CLangCodeExpander::ENGLISH_NAME, bool region = false);
```

I've taken the ConvertToTwoCharCode method from @pieh's repository.
Thanks @pieh! 

The feature request: http://forum.xbmc.org/showthread.php?tid=163023
