### PR TITLE
FIX: log spamming

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -986,7 +986,6 @@ bool CLinuxInputDevices::CheckDevice(const char *device)
 {
   int fd;
 
-  CLog::Log(LOGDEBUG, "Checking device: %s\n", device);
   /* Check if we are able to open the device */
   fd = open(device, O_RDWR);
   if (fd < 0)


### PR DESCRIPTION
Since hotplug support, debug log is spammed by 15  "Checking device" every x seconds...
