### PR TITLE
correct spanish date formats. fixes #14286

### DIFF
--- a/language/Galician/langinfo.xml
+++ b/language/Galician/langinfo.xml
@@ -11,15 +11,15 @@
   </dvd>
   <regions>
     <region name="Santiago, Galicia" locale="GL">
-      <dateshort>D/M/YYYY</dateshort>
-      <datelong>DDD, DD' de 'MMMM' de 'YYYY</datelong>
+      <dateshort>DD/MM/YYYY</dateshort>
+      <datelong>DDDD, DD' de 'MMMM' de 'YYYY</datelong>
       <time symbolAM="AM" symbolPM="PM">H:mm:ss</time>
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
     </region>
     <region name="La Coruna, Galicia" locale="GL">
-      <dateshort>D/M/YYYY</dateshort>
-      <datelong>DDD, DD' de 'MMMM' de 'YYYY</datelong>
+      <dateshort>DD/MM/YYYY</dateshort>
+      <datelong>DDDD, DD' de 'MMMM' de 'YYYY</datelong>
       <time symbolAM="AM" symbolPM="PM">H:mm:ss</time>
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>

--- a/language/Spanish (Argentina)/langinfo.xml
+++ b/language/Spanish (Argentina)/langinfo.xml
@@ -13,8 +13,8 @@
 
 	<regions>
 	<region name="Argentina" locale="AR">
-  	  	<dateshort>D/M/YYYY</dateshort>
-  	  	<datelong>DDD, DD' de 'MMMM' de 'YYYY</datelong>
+  	  	<dateshort>DD/MM/YYYY</dateshort>
+  	  	<datelong>DDDD, DD' de 'MMMM' de 'YYYY</datelong>
   	  	<time symbolAM="" symbolPM="">H:mm:ss</time>
   	  	<tempunit>C</tempunit>
 		<speedunit>kmh</speedunit>

--- a/language/Spanish/langinfo.xml
+++ b/language/Spanish/langinfo.xml
@@ -13,32 +13,32 @@
 
 	<regions>
 	<region name="España (12 horas)" locale="ES">
-  	  	<dateshort>D/M/YYYY</dateshort>
-  	  	<datelong>DDD, DD' de 'MMMM' de 'YYYY</datelong>
+  	  	<dateshort>DD/MM/YYYY</dateshort>
+  	  	<datelong>DDDD, DD' de 'MMMM' de 'YYYY</datelong>
 		<time symbolAM="AM" symbolPM="PM">h:mm:ss xx</time>
   	  	<tempunit>C</tempunit>
   	  	<speedunit>kmh</speedunit>
 		<timezone>CEST</timezone>
 	</region>
 	<region name="España (24 horas)" locale="ES">
-  	  	<dateshort>D/M/YYYY</dateshort>
-  	  	<datelong>DDD, DD' de 'MMMM' de 'YYYY</datelong>
+  	  	<dateshort>DD/MM/YYYY</dateshort>
+  	  	<datelong>DDDD, DD' de 'MMMM' de 'YYYY</datelong>
   	  	<time symbolAM="" symbolPM="">H:mm:ss</time>
   	  	<tempunit>C</tempunit>
   	  	<speedunit>kmh</speedunit>
 		<timezone>CEST</timezone>
 	</region>
 	<region name="Canarias (12 horas)" locale="ES">
-  	  	<dateshort>D/M/YYYY</dateshort>
-  	  	<datelong>DDD, DD' de 'MMMM' de 'YYYY</datelong>
+  	  	<dateshort>DD/MM/YYYY</dateshort>
+  	  	<datelong>DDDD, DD' de 'MMMM' de 'YYYY</datelong>
 		<time symbolAM="AM" symbolPM="PM">h:mm:ss xx</time>
   	  	<tempunit>C</tempunit>
   	  	<speedunit>kmh</speedunit>
 		<timezone>GMT</timezone>
 	</region>
 	<region name="Canarias (24 horas)" locale="ES">
-  	  	<dateshort>D/M/YYYY</dateshort>
-  	  	<datelong>DDD, DD' de 'MMMM' de 'YYYY</datelong>
+  	  	<dateshort>DD/MM/YYYY</dateshort>
+  	  	<datelong>DDDD, DD' de 'MMMM' de 'YYYY</datelong>
   	  	<time symbolAM="" symbolPM="">H:mm:ss</time>
   	  	<tempunit>C</tempunit>
   	  	<speedunit>kmh</speedunit>


### PR DESCRIPTION
in python xbmc.getRegion( "dateshort" ) and xbmc.getRegion( "datelong" ) return foobar
due to incorrect date formats in langinfo.xml

fixes trac #14286
