### PR TITLE
[Python] Add convertLanguage(const char* language, int format) method.

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -491,6 +491,34 @@ namespace XBMCAddon
       CAEFactory::Resume();
     }
 
+    String convertLanguage(const char* language, int format)
+    {
+      CStdString convertedLanguage;
+      switch (format)
+      {
+      case CLangCodeExpander::ENGLISH_NAME:
+        {
+          g_LangCodeExpander.Lookup(convertedLanguage, language);
+          // maybe it's a check whether the language exists or not
+          if (convertedLanguage.empty())
+          {
+            g_LangCodeExpander.ConvertToThreeCharCode(convertedLanguage, language);
+            g_LangCodeExpander.Lookup(convertedLanguage, convertedLanguage);
+          }
+          break;
+        }
+      case CLangCodeExpander::ISO_639_1:
+        g_LangCodeExpander.ConvertToTwoCharCode(convertedLanguage, language);
+        break;
+      case CLangCodeExpander::ISO_639_2:
+        g_LangCodeExpander.ConvertToThreeCharCode(convertedLanguage, language);
+        break;
+      default:
+        return "";
+      }
+      return convertedLanguage.c_str();
+    }
+
     int getSERVER_WEBSERVER() { return CApplication::ES_WEBSERVER; }
     int getSERVER_AIRPLAYSERVER() { return CApplication::ES_AIRPLAYSERVER; }
     int getSERVER_UPNPSERVER() { return CApplication::ES_UPNPSERVER; }

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -404,6 +404,21 @@ namespace XBMCAddon
      */  
     void audioResume();
 
+    /**
+    * convertLanguage(language, format) -- Returns the given language converted to the given format as a string.
+    *
+    * language: string either as name in English, two letter code (ISO 639-1), or three letter code (ISO 639-2/T(B)
+    *
+    * format: format of the returned language string
+    *         xbmc.ISO_639_1: two letter code as defined in ISO 639-1
+    *         xbmc.ISO_639_2: three letter code as defined in ISO 639-2/T or ISO 639-2/B
+    *         xbmc.ENGLISH_NAME: full language name in English (default)
+    *
+    * example:
+    *   - language = xbmc.convertLanguage(English, xbmc.ISO_639_2)
+    */
+    String convertLanguage(const char* language, int format); 
+
     SWIG_CONSTANT_FROM_GETTER(int,SERVER_WEBSERVER);
     SWIG_CONSTANT_FROM_GETTER(int,SERVER_AIRPLAYSERVER);
     SWIG_CONSTANT_FROM_GETTER(int,SERVER_UPNPSERVER);


### PR DESCRIPTION
This PR allows addon devs to convert one language format to another.
The method works as follows:

```
    /**
    * convertLanguage(language, format) -- Returns the given language converted to the given format as a string.
    *
    * language: string either as name in English, two letter code (ISO 639-1), or three letter code (ISO 639-2/T(B)
    *
    * format: format of the returned language string
    *         xbmc.ISO_639_1: two letter code as defined in ISO 639-1
    *         xbmc.ISO_639_2: three letter code as defined in ISO 639-2/T or ISO 639-2/B
    *         xbmc.ENGLISH_NAME: full language name in English (default)
    *
    * example:
    *   - language = xbmc.convertLanguage(English, xbmc.ISO_639_2)
    */
    String convertLanguage(const char* language, int format); 
```
