### PR TITLE
[Frodo] Don't block waiting for EOS in audio/video players

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -331,6 +331,8 @@ bool COMXAudio::Initialize(AEAudioFormat format, std::string& device, OMXClock *
   if(!m_omx_render->Initialize((const std::string)componentName, OMX_IndexParamAudioInit))
     return false;
 
+  m_omx_render->ResetEos();
+
   OMX_CONFIG_BRCMAUDIODESTINATIONTYPE audioDest;
   OMX_INIT_STRUCTURE(audioDest);
   strncpy((char *)audioDest.sName, device.c_str(), strlen(device.c_str()));
@@ -1137,6 +1139,8 @@ void COMXAudio::UnRegisterAudioCallback()
 
 unsigned int COMXAudio::GetAudioRenderingLatency()
 {
+  CSingleLock lock (m_critSection);
+
   if(!m_Initialized)
     return 0;
 
@@ -1157,7 +1161,7 @@ unsigned int COMXAudio::GetAudioRenderingLatency()
   return param.nU32;
 }
 
-void COMXAudio::WaitCompletion()
+void COMXAudio::SubmitEOS()
 {
   CSingleLock lock (m_critSection);
 
@@ -1185,43 +1189,15 @@ void COMXAudio::WaitCompletion()
     CLog::Log(LOGERROR, "%s::%s - OMX_EmptyThisBuffer() failed with result(0x%x)\n", CLASSNAME, __func__, omx_err);
     return;
   }
+}
 
-  unsigned int nTimeOut = AUDIO_BUFFER_SECONDS * 1000;
-  while(nTimeOut)
-  {
-    if(m_omx_render->IsEOS())
-    {
-      CLog::Log(LOGDEBUG, "%s::%s - got eos\n", CLASSNAME, __func__);
-      break;
-    }
-
-    if(nTimeOut == 0)
-    {
-      CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", CLASSNAME, __func__);
-      break;
-    }
-    Sleep(50);
-    nTimeOut -= 50;
-  }
-
-  nTimeOut = AUDIO_BUFFER_SECONDS * 1000;
-  while(nTimeOut)
-  {
-    if(!GetAudioRenderingLatency())
-      break;
-
-    if(nTimeOut == 0)
-    {
-      CLog::Log(LOGERROR, "%s::%s - wait for GetAudioRenderingLatency timed out\n", CLASSNAME, __func__);
-      break;
-    }
-    Sleep(50);
-    nTimeOut -= 50;
-  }
-
-  m_omx_render->ResetEos();
-
-  return;
+bool COMXAudio::IsEOS()
+{
+  if(!m_Initialized || m_Pause)
+    return true;
+  unsigned int latency = GetAudioRenderingLatency();
+  CSingleLock lock (m_critSection);
+  return m_omx_decoder.IsEOS() && latency <= 0;
 }
 
 void COMXAudio::SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers)

--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -76,7 +76,8 @@ public:
   bool SetCurrentVolume(float fVolume);
   void SetDynamicRangeCompression(long drc) { m_drc = drc; }
   int SetPlaySpeed(int iSpeed);
-  void WaitCompletion();
+  void SubmitEOS();
+  bool IsEOS();
   void SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers);
 
   void Flush();

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -88,7 +88,6 @@ protected:
   bool                      m_DecoderOpen;
 
   DllBcmHost                m_DllBcmHost;
-  bool                      m_send_eos;
   bool                      m_bad_state;
 
   virtual void OnStartup();
@@ -106,7 +105,7 @@ public:
   bool IsInited() const                             { return m_messageQueue.IsInited(); }
   int  GetLevel() const                             { return m_messageQueue.GetLevel(); }
   bool IsStalled()                                  { return m_stalled;  }
-  bool IsEOS()                                      { return m_send_eos; };
+  bool IsEOS();
   void WaitForBuffers();
   bool CloseStream(bool bWaitForBuffers);
   bool CodecChange();
@@ -121,6 +120,7 @@ public:
   double GetCacheTime();
   double GetCurrentPTS() { return m_audioClock; };
   void WaitCompletion();
+  void SubmitEOS();
   void  RegisterAudioCallback(IAudioCallback* pCallback);
   void  UnRegisterAudioCallback();
   void SetCurrentVolume(float fVolume);

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -91,7 +91,6 @@ OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
   m_dropbase              = 0.0;
   m_autosync              = 1;
   m_fForcedAspectRatio    = 0.0f;
-  m_send_eos              = false;
   m_messageQueue.SetMaxDataSize(10 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
 
@@ -120,8 +119,6 @@ bool OMXPlayerVideo::OpenStream(CDVDStreamInfo &hints)
   m_iSleepEndTime = DVD_NOPTS_VALUE;
   // force SetVideoRect to be called initially
   m_dst_rect.SetRect(0, 0, 0, 0);
-
-  m_audio_count = m_av_clock->HasAudio();
 
   if (!m_DllBcmHost.Load())
     return false;
@@ -152,7 +149,6 @@ bool OMXPlayerVideo::OpenStream(CDVDStreamInfo &hints)
   */
 
   m_open        = true;
-  m_send_eos    = false;
 
   return true;
 }
@@ -486,10 +482,10 @@ void OMXPlayerVideo::Process()
       OpenStream(msg->m_hints, msg->m_codec);
       msg->m_codec = NULL;
     }
-    else if (pMsg->IsType(CDVDMsg::GENERAL_EOF) && !m_audio_count)
+    else if (pMsg->IsType(CDVDMsg::GENERAL_EOF))
     {
       CLog::Log(LOGDEBUG, "COMXPlayerVideo - CDVDMsg::GENERAL_EOF");
-      WaitCompletion();
+      SubmitEOS();
     }
     else if (pMsg->IsType(CDVDMsg::DEMUXER_PACKET))
     {
@@ -654,11 +650,19 @@ int  OMXPlayerVideo::GetDecoderFreeSpace()
   return m_omxVideo.GetFreeSpace();
 }
 
-void OMXPlayerVideo::WaitCompletion()
+void OMXPlayerVideo::SubmitEOS()
 {
-  if(!m_send_eos)
-    m_omxVideo.WaitCompletion();
-  m_send_eos = true;
+  m_omxVideo.SubmitEOS();
+}
+
+bool OMXPlayerVideo::SubmittedEOS()
+{
+  return m_omxVideo.SubmittedEOS();
+}
+
+bool OMXPlayerVideo::IsEOS()
+{
+  return m_omxVideo.IsEOS();
 }
 
 void OMXPlayerVideo::SetSpeed(int speed)

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -78,7 +78,6 @@ protected:
   int                       m_view_mode;
 
   DllBcmHost                m_DllBcmHost;
-  bool                      m_send_eos;
 
   CDVDOverlayContainer  *m_pOverlayContainer;
   CDVDMessageQueue      &m_messageParent;
@@ -105,7 +104,7 @@ public:
   void WaitForBuffers()                             { m_messageQueue.WaitUntilEmpty(); }
   int  GetLevel() const                             { return m_messageQueue.GetLevel(); }
   bool IsStalled()                                  { return m_stalled;  }
-  bool IsEOS()                                      { return m_send_eos; };
+  bool IsEOS();
   bool CloseStream(bool bWaitForBuffers);
   void Output(int iGroupId, double pts, bool bDropPacket);
   void Flush();
@@ -114,7 +113,8 @@ public:
   int  GetDecoderFreeSpace();
   double GetCurrentPTS() { return m_iCurrentPts; };
   double GetFPS() { return m_fFrameRate; };
-  void  WaitCompletion();
+  void  SubmitEOS();
+  bool SubmittedEOS();
   void SetDelay(double delay) { m_iVideoDelay = delay; }
   double GetDelay() { return m_iVideoDelay; }
   void SetSpeed(int iSpeed);

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -59,7 +59,9 @@ public:
   std::string GetDecoderName() { return m_video_codec_name; };
   void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
   int GetInputBufferSize();
-  void WaitCompletion();
+  void SubmitEOS();
+  bool IsEOS();
+  bool SubmittedEOS() { return m_submitted_eos; }
   bool BadState() { return m_omx_decoder.BadState(); };
 protected:
   // Video format
@@ -95,6 +97,7 @@ protected:
   uint32_t          m_history_valid_pts;
   ResolutionUpdateCallBackFn m_res_callback;
   void              *m_res_ctx;
+  bool              m_submitted_eos;
   bool NaluFormatStartCodes(enum CodecID codec, uint8_t *in_extradata, int in_extrasize);
 };
 


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/commit/607cc54ab54a53a96999d0fab31fabde93f02c65

Currently we block in OMXPlayerAudio/OMXPlayerVideo from the point we see EOF from demuxer,
until the last frame/audio sample has been played out. This can be a few seconds.
It means no more messages (such as abort) can be received during this period.
This results in a bug where if you press stop after the demuxer EOF has occurred it takes
a long time to stop. You would expect this to be the few seconds of queued data,
but it actually turns out to be 30 seconds, as the clocks get stopped by the stop message,
but the players never find out and we hit a timeout.
It also stops seek/pause working during the playout period.
It also stops (graphical) subtitles from being rendered during this time.
The fix involves not blocking for the EOS, but allowing the polling from OMXPlayer to catch it.
