### PR TITLE
add Player.IsInternetStream Infolabel

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -200,6 +200,7 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "starrating",       PLAYER_STAR_RATING },
                                   { "folderpath",       PLAYER_PATH },
                                   { "filenameandpath",  PLAYER_FILEPATH },
+                                  { "isinternetstream", PLAYER_ISINTERNETSTREAM },
                                   { "pauseenabled",     PLAYER_CAN_PAUSE },
                                   { "seekenabled",      PLAYER_CAN_SEEK }};
 
@@ -2406,6 +2407,9 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     break;
     case PLAYER_PASSTHROUGH:
       bReturn = g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough();
+      break;
+    case PLAYER_ISINTERNETSTREAM:
+      bReturn = m_currentFile && URIUtils::IsInternetStream(m_currentFile->GetPath());
       break;
     case MUSICPM_ENABLED:
       bReturn = g_partyModeManager.IsEnabled();

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -109,6 +109,7 @@ namespace INFO
 #define PLAYER_CAN_SEEK              51
 #define PLAYER_START_TIME            52
 #define PLAYER_TITLE                 53
+#define PLAYER_ISINTERNETSTREAM      54
 
 #define WEATHER_CONDITIONS          100
 #define WEATHER_TEMPERATURE         101


### PR DESCRIPTION
This adds a bool "Player.IsInternetStream" which might be used by addons and/or skins to determine if the currently playing file js a network stream by utilizing URIUtils::IsInternetStream (which in turn seems to be used at many places in the core code to accomplish the same).

A practical use case (and "emulation" in python) might be seen at https://github.com/herrnst/script.xbmc.lcdproc/blob/master/resources/lib/infolabels.py#L150 in InfoLabels_IsInternetStream(), which is used to determine if any webcast/stream/cloud icon on displays is to be lit (at https://github.com/herrnst/script.xbmc.lcdproc/blob/master/resources/lib/lcdbase.py#L519 ).

While implementing the check in python works fine, it might be a nicetohave thing for other addons and authors and any changes regarding added network URI protocols in XBMC's core will immediately be available in addons.
