### PR TITLE
add legacy videodb/musicdb path translation

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1158,6 +1158,7 @@
     <ClInclude Include="..\..\xbmc\utils\BooleanLogic.h" />
     <ClInclude Include="..\..\xbmc\utils\IRssObserver.h" />
     <ClInclude Include="..\..\xbmc\utils\IXmlDeserializable.h" />
+    <ClInclude Include="..\..\xbmc\utils\LegacyPathTranslation.h" />
     <ClInclude Include="..\..\xbmc\utils\RssManager.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
     <ClInclude Include="..\..\xbmc\video\FFmpegVideoDecoder.h" />
@@ -1297,6 +1298,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\AddonsOperations.h" />
     <ClCompile Include="..\..\xbmc\ThumbLoader.cpp" />
     <ClCompile Include="..\..\xbmc\utils\BooleanLogic.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\LegacyPathTranslation.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RssManager.cpp" />
     <ClCompile Include="..\..\xbmc\utils\test\TestUrlOptions.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">true</ExcludedFromBuild>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3036,6 +3036,9 @@
     <ClCompile Include="..\..\xbmc\utils\Environment.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\LegacyPathTranslation.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5943,6 +5946,9 @@
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\Environment.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\LegacyPathTranslation.h">
       <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -27,6 +27,7 @@
 #include "utils/Crc32.h"
 #include "guilib/TextureManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/LegacyPathTranslation.h"
 #include "utils/log.h"
 
 using namespace std;
@@ -43,7 +44,8 @@ CMusicDatabaseDirectory::~CMusicDatabaseDirectory(void)
 
 bool CMusicDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return false;
@@ -66,7 +68,8 @@ bool CMusicDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemL
 
 NODE_TYPE CMusicDatabaseDirectory::GetDirectoryChildType(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return NODE_TYPE_NONE;
@@ -76,7 +79,8 @@ NODE_TYPE CMusicDatabaseDirectory::GetDirectoryChildType(const CStdString& strPa
 
 NODE_TYPE CMusicDatabaseDirectory::GetDirectoryType(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return NODE_TYPE_NONE;
@@ -86,7 +90,8 @@ NODE_TYPE CMusicDatabaseDirectory::GetDirectoryType(const CStdString& strPath)
 
 NODE_TYPE CMusicDatabaseDirectory::GetDirectoryParentType(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return NODE_TYPE_NONE;
@@ -114,7 +119,7 @@ bool CMusicDatabaseDirectory::HasAlbumInfo(const CStdString& strDirectory)
 
 void CMusicDatabaseDirectory::ClearDirectoryCache(const CStdString& strDirectory)
 {
-  CStdString path(strDirectory);
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strDirectory);
   URIUtils::RemoveSlashAtEnd(path);
 
   Crc32 crc;
@@ -136,13 +141,14 @@ bool CMusicDatabaseDirectory::GetLabel(const CStdString& strDirectory, CStdStrin
 {
   strLabel = "";
 
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strDirectory));
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strDirectory);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
   if (!pNode.get())
     return false;
 
   // first see if there's any filter criteria
   CQueryParams params;
-  CDirectoryNode::GetDatabaseInfo(strDirectory, params);
+  CDirectoryNode::GetDatabaseInfo(path, params);
 
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())
@@ -242,7 +248,8 @@ bool CMusicDatabaseDirectory::ContainsSongs(const CStdString &path)
 
 bool CMusicDatabaseDirectory::Exists(const char* strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return false;
@@ -255,7 +262,8 @@ bool CMusicDatabaseDirectory::Exists(const char* strPath)
 
 bool CMusicDatabaseDirectory::CanCache(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
   if (!pNode.get())
     return false;
   return pNode->CanCache();
@@ -301,4 +309,3 @@ CStdString CMusicDatabaseDirectory::GetIcon(const CStdString &strDirectory)
 
   return "";
 }
-

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -28,6 +28,7 @@
 #include "settings/Settings.h"
 #include "utils/Crc32.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/LegacyPathTranslation.h"
 #include "utils/log.h"
 
 using namespace std;
@@ -44,7 +45,8 @@ CVideoDatabaseDirectory::~CVideoDatabaseDirectory(void)
 
 bool CVideoDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return false;
@@ -67,7 +69,8 @@ bool CVideoDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemL
 
 NODE_TYPE CVideoDatabaseDirectory::GetDirectoryChildType(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return NODE_TYPE_NONE;
@@ -77,7 +80,8 @@ NODE_TYPE CVideoDatabaseDirectory::GetDirectoryChildType(const CStdString& strPa
 
 NODE_TYPE CVideoDatabaseDirectory::GetDirectoryType(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return NODE_TYPE_NONE;
@@ -87,7 +91,8 @@ NODE_TYPE CVideoDatabaseDirectory::GetDirectoryType(const CStdString& strPath)
 
 NODE_TYPE CVideoDatabaseDirectory::GetDirectoryParentType(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return NODE_TYPE_NONE;
@@ -102,7 +107,8 @@ NODE_TYPE CVideoDatabaseDirectory::GetDirectoryParentType(const CStdString& strP
 
 bool CVideoDatabaseDirectory::GetQueryParams(const CStdString& strPath, CQueryParams& params)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return false;
@@ -113,7 +119,7 @@ bool CVideoDatabaseDirectory::GetQueryParams(const CStdString& strPath, CQueryPa
 
 void CVideoDatabaseDirectory::ClearDirectoryCache(const CStdString& strDirectory)
 {
-  CStdString path(strDirectory);
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strDirectory);
   URIUtils::RemoveSlashAtEnd(path);
 
   Crc32 crc;
@@ -135,13 +141,14 @@ bool CVideoDatabaseDirectory::GetLabel(const CStdString& strDirectory, CStdStrin
 {
   strLabel = "";
 
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strDirectory));
-  if (!pNode.get() || strDirectory.IsEmpty())
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strDirectory);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
+  if (!pNode.get() || path.IsEmpty())
     return false;
 
   // first see if there's any filter criteria
   CQueryParams params;
-  CDirectoryNode::GetDatabaseInfo(strDirectory, params);
+  CDirectoryNode::GetDatabaseInfo(path, params);
 
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())
@@ -224,10 +231,11 @@ bool CVideoDatabaseDirectory::GetLabel(const CStdString& strDirectory, CStdStrin
 
 CStdString CVideoDatabaseDirectory::GetIcon(const CStdString &strDirectory)
 {
-  switch (GetDirectoryChildType(strDirectory))
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strDirectory);
+  switch (GetDirectoryChildType(path))
   {
   case NODE_TYPE_TITLE_MOVIES:
-    if (strDirectory.Equals("videodb://movies/titles/"))
+    if (path.Equals("videodb://movies/titles/"))
     {
       if (CSettings::Get().GetBool("myvideos.flatten"))
         return "DefaultMovies.png";
@@ -235,7 +243,7 @@ CStdString CVideoDatabaseDirectory::GetIcon(const CStdString &strDirectory)
     }
     return "";
   case NODE_TYPE_TITLE_TVSHOWS:
-    if (strDirectory.Equals("videodb://tvshows/titles/"))
+    if (path.Equals("videodb://tvshows/titles/"))
     {
       if (CSettings::Get().GetBool("myvideos.flatten"))
         return "DefaultTVShows.png";
@@ -243,7 +251,7 @@ CStdString CVideoDatabaseDirectory::GetIcon(const CStdString &strDirectory)
     }
     return "";
   case NODE_TYPE_TITLE_MUSICVIDEOS:
-    if (strDirectory.Equals("videodb://musicvideos/titles/"))
+    if (path.Equals("videodb://musicvideos/titles/"))
     {
       if (CSettings::Get().GetBool("myvideos.flatten"))
         return "DefaultMusicVideos.png";
@@ -297,7 +305,8 @@ bool CVideoDatabaseDirectory::ContainsMovies(const CStdString &path)
 
 bool CVideoDatabaseDirectory::Exists(const char* strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())
     return false;
@@ -310,7 +319,8 @@ bool CVideoDatabaseDirectory::Exists(const char* strPath)
 
 bool CVideoDatabaseDirectory::CanCache(const CStdString& strPath)
 {
-  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
   if (!pNode.get())
     return false;
   return pNode->CanCache();

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -47,6 +47,7 @@
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/LegacyPathTranslation.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "TextureCache.h"
@@ -206,31 +207,32 @@ bool CGUIWindowMusicNav::OnAction(const CAction& action)
 
 CStdString CGUIWindowMusicNav::GetQuickpathName(const CStdString& strPath) const
 {
-  if (strPath.Equals("musicdb://genres/") || strPath.Equals("musicdb://1/"))
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  if (path.Equals("musicdb://genres/"))
     return "Genres";
-  else if (strPath.Equals("musicdb://artists/") || strPath.Equals("musicdb://2/"))
+  else if (path.Equals("musicdb://artists/"))
     return "Artists";
-  else if (strPath.Equals("musicdb://albums/") || strPath.Equals("musicdb://3/"))
+  else if (path.Equals("musicdb://albums/"))
     return "Albums";
-  else if (strPath.Equals("musicdb://songs/") || strPath.Equals("musicdb://4/"))
+  else if (path.Equals("musicdb://songs/"))
     return "Songs";
-  else if (strPath.Equals("musicdb://top100/") || strPath.Equals("musicdb://5/"))
+  else if (path.Equals("musicdb://top100/"))
     return "Top100";
-  else if (strPath.Equals("musicdb://top100/songs/") || strPath.Equals("musicdb://5/2/"))
+  else if (path.Equals("musicdb://top100/songs/"))
     return "Top100Songs";
-  else if (strPath.Equals("musicdb://top100/albums/") || strPath.Equals("musicdb://5/1/"))
+  else if (path.Equals("musicdb://top100/albums/"))
     return "Top100Albums";
-  else if (strPath.Equals("musicdb://recentlyaddedalbums/") || strPath.Equals("musicdb://6/"))
+  else if (path.Equals("musicdb://recentlyaddedalbums/"))
     return "RecentlyAddedAlbums";
-  else if (strPath.Equals("musicdb://recentlyplayedalbums/") || strPath.Equals("musicdb://7/"))
+  else if (path.Equals("musicdb://recentlyplayedalbums/"))
     return "RecentlyPlayedAlbums";
-  else if (strPath.Equals("musicdb://compilations/") || strPath.Equals("musicdb://8/"))
+  else if (path.Equals("musicdb://compilations/"))
     return "Compilations";
-  else if (strPath.Equals("musicdb://years/") || strPath.Equals("musicdb://9/"))
+  else if (path.Equals("musicdb://years/"))
     return "Years";
-  else if (strPath.Equals("musicdb://singles/") || strPath.Equals("musicdb://10/"))
+  else if (path.Equals("musicdb://singles/"))
     return "Singles";
-  else if (strPath.Equals("special://musicplaylists/"))
+  else if (path.Equals("special://musicplaylists/"))
     return "Playlists";
   else
   {

--- a/xbmc/utils/LegacyPathTranslation.cpp
+++ b/xbmc/utils/LegacyPathTranslation.cpp
@@ -1,0 +1,106 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "LegacyPathTranslation.h"
+#include "utils/StringUtils.h"
+
+typedef struct Translator {
+  const char *legacyPath;
+  const char *newPath;
+} Translator;
+
+// ATTENTION: Make sure the longer match strings go first
+// because the string match is performed with StringUtils::StartsWith()
+static Translator s_videoDbTranslator[] = {
+  { "videodb://1/1",  "videodb://movies/genres" },
+  { "videodb://1/2",  "videodb://movies/titles" },
+  { "videodb://1/3",  "videodb://movies/years" },
+  { "videodb://1/4",  "videodb://movies/actors" },
+  { "videodb://1/5",  "videodb://movies/directors" },
+  { "videodb://1/6",  "videodb://movies/studios" },
+  { "videodb://1/7",  "videodb://movies/sets" },
+  { "videodb://1/8",  "videodb://movies/countries" },
+  { "videodb://1/9",  "videodb://movies/tags" },
+  { "videodb://1",    "videodb://movies" },
+  { "videodb://2/1",  "videodb://tvshows/genres" },
+  { "videodb://2/2",  "videodb://tvshows/titles" },
+  { "videodb://2/3",  "videodb://tvshows/years" },
+  { "videodb://2/4",  "videodb://tvshows/actors" },
+  { "videodb://2/5",  "videodb://tvshows/studios" },
+  { "videodb://2/9",  "videodb://tvshows/tags" },
+  { "videodb://2",    "videodb://tvshows" },
+  { "videodb://3/1",  "videodb://musicvideos/genres" },
+  { "videodb://3/2",  "videodb://musicvideos/titles" },
+  { "videodb://3/3",  "videodb://musicvideos/years" },
+  { "videodb://3/4",  "videodb://musicvideos/artists" },
+  { "videodb://3/5",  "videodb://musicvideos/albums" },
+  { "videodb://3/9",  "videodb://musicvideos/tags" },
+  { "videodb://3",    "videodb://musicvideos" },
+  { "videodb://4",    "videodb://recentlyaddedmovies" },
+  { "videodb://5",    "videodb://recentlyaddedepisodes" },
+  { "videodb://6",    "videodb://recentlyaddedmusicvideos" }
+};
+
+#define VideoDbTranslatorSize sizeof(s_videoDbTranslator) / sizeof(Translator)
+
+// ATTENTION: Make sure the longer match strings go first
+// because the string match is performed with StringUtils::StartsWith()
+static Translator s_musicDbTranslator[] = {
+  { "musicdb://10",   "musicdb://singles" },
+  { "musicdb://1",    "musicdb://genres" },
+  { "musicdb://2",    "musicdb://artists" },
+  { "musicdb://3",    "musicdb://albums" },
+  { "musicdb://4",    "musicdb://songs" },
+  { "musicdb://5/1",  "musicdb://top100/albums" },
+  { "musicdb://5/2",  "musicdb://top100/songs" },
+  { "musicdb://5",    "musicdb://top100" },
+  { "musicdb://6",    "musicdb://recentlyaddedalbums" },
+  { "musicdb://7",    "musicdb://recentlyplayedalbums" },
+  { "musicdb://8",    "musicdb://compilations" },
+  { "musicdb://9",    "musicdb://years" }
+};
+
+#define MusicDbTranslatorSize sizeof(s_musicDbTranslator) / sizeof(Translator)
+
+
+std::string CLegacyPathTranslation::TranslateVideoDbPath(const std::string &legacyPath)
+{
+  return TranslatePath(legacyPath, s_videoDbTranslator, VideoDbTranslatorSize);
+}
+
+std::string CLegacyPathTranslation::TranslateMusicDbPath(const std::string &legacyPath)
+{
+  return TranslatePath(legacyPath, s_musicDbTranslator, MusicDbTranslatorSize);
+}
+
+std::string CLegacyPathTranslation::TranslatePath(const std::string &legacyPath, Translator *translationMap, size_t translationMapSize)
+{
+  std::string newPath = legacyPath;
+  for (size_t index = 0; index < translationMapSize; index++)
+  {
+    if (StringUtils::StartsWith(newPath, translationMap[index].legacyPath))
+    {
+      StringUtils::Replace(newPath, translationMap[index].legacyPath, translationMap[index].newPath);
+      break;
+    }
+  }
+
+  return newPath;
+}

--- a/xbmc/utils/LegacyPathTranslation.h
+++ b/xbmc/utils/LegacyPathTranslation.h
@@ -1,0 +1,54 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <string>
+
+typedef struct Translator Translator;
+
+/*!
+ \brief Translates old internal paths into new ones
+
+ Translates old videodb:// and musicdb:// paths which used numbers
+ to indicate a specific category to new paths using more descriptive
+ strings to indicate categories.
+ */
+class CLegacyPathTranslation
+{
+public:
+  /*!
+   \brief Translates old videodb:// paths to new ones
+
+   \param legacyPath Path in the old videodb:// format using numbers
+   \return Path in the new videodb:// format using descriptive strings
+   */
+  static std::string TranslateVideoDbPath(const std::string &legacyPath);
+
+  /*!
+   \brief Translates old musicdb:// paths to new ones
+
+   \param legacyPath Path in the old musicdb:// format using numbers
+   \return Path in the new musicdb:// format using descriptive strings
+   */
+  static std::string TranslateMusicDbPath(const std::string &legacyPath);
+
+private:
+  static std::string TranslatePath(const std::string &legacyPath, Translator *translationMap, size_t translationMapSize);
+};

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -37,6 +37,7 @@ SRCS += JSONVariantParser.cpp
 SRCS += JSONVariantWriter.cpp
 SRCS += LabelFormatter.cpp
 SRCS += LangCodeExpander.cpp
+SRCS += LegacyPathTranslation.cpp
 SRCS += log.cpp
 SRCS += md5.cpp
 SRCS += Mime.cpp

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1949,7 +1949,7 @@ bool CGUIWindowVideoNav::GetSetForMovie(CFileItemPtr &movieItem, CFileItemPtr &s
     return false;
 }
 
-bool CGUIWindowVideoNav::SetMovieSet (CFileItemPtr &movieItem, CFileItemPtr &selectedSet)
+bool CGUIWindowVideoNav::SetMovieSet(CFileItemPtr &movieItem, CFileItemPtr &selectedSet)
 {
   CVideoDatabase videodb;
   if (!videodb.Open())

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -241,7 +241,7 @@ CStdString CGUIWindowVideoNav::GetQuickpathName(const CStdString& strPath) const
     return "MusicVideoTitles";
   else if (strPath.Equals("videodb://musicvideos/years/") || strPath.Equals("videodb://3/3/"))
     return "MusicVideoYears";
-  else if (strPath.Equals("videodb://musicvideos/artist/") || strPath.Equals("videodb://3/4/"))
+  else if (strPath.Equals("videodb://musicvideos/artists/") || strPath.Equals("videodb://3/4/"))
     return "MusicVideoArtists";
   else if (strPath.Equals("videodb://musicvideos/albums/") || strPath.Equals("videodb://3/5/"))
     return "MusicVideoDirectors";

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -49,6 +49,7 @@
 #include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
+#include "utils/LegacyPathTranslation.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -201,63 +202,64 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
 
 CStdString CGUIWindowVideoNav::GetQuickpathName(const CStdString& strPath) const
 {
-  if (strPath.Equals("videodb://movies/genres/") || strPath.Equals("videodb://1/1/"))
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  if (path.Equals("videodb://movies/genres/"))
     return "MovieGenres";
-  else if (strPath.Equals("videodb://movies/titles/") || strPath.Equals("videodb://1/2/"))
+  else if (path.Equals("videodb://movies/titles/"))
     return "MovieTitles";
-  else if (strPath.Equals("videodb://movies/years/") || strPath.Equals("videodb://1/3/"))
+  else if (path.Equals("videodb://movies/years/"))
     return "MovieYears";
-  else if (strPath.Equals("videodb://movies/actors/") || strPath.Equals("videodb://1/4/"))
+  else if (path.Equals("videodb://movies/actors/"))
     return "MovieActors";
-  else if (strPath.Equals("videodb://movies/directors/") || strPath.Equals("videodb://1/5/"))
+  else if (path.Equals("videodb://movies/directors/"))
     return "MovieDirectors";
-  else if (strPath.Equals("videodb://movies/studios/") || strPath.Equals("videodb://1/6/"))
+  else if (path.Equals("videodb://movies/studios/"))
     return "MovieStudios";
-  else if (strPath.Equals("videodb://movies/sets/") || strPath.Equals("videodb://1/7/"))
+  else if (path.Equals("videodb://movies/sets/"))
     return "MovieSets";
-  else if (strPath.Equals("videodb://movies/countries/") || strPath.Equals("videodb://1/8/"))
+  else if (path.Equals("videodb://movies/countries/"))
     return "MovieCountries";
-  else if (strPath.Equals("videodb://movies/tags/") || strPath.Equals("videodb://1/9/"))
+  else if (path.Equals("videodb://movies/tags/"))
     return "MovieTags";
-  else if (strPath.Equals("videodb://movies/") || strPath.Equals("videodb://1/"))
+  else if (path.Equals("videodb://movies/"))
     return "Movies";
-  else if (strPath.Equals("videodb://tvshows/genres/") || strPath.Equals("videodb://2/1/"))
+  else if (path.Equals("videodb://tvshows/genres/"))
     return "TvShowGenres";
-  else if (strPath.Equals("videodb://tvshows/titles/") || strPath.Equals("videodb://2/2/"))
+  else if (path.Equals("videodb://tvshows/titles/"))
     return "TvShowTitles";
-  else if (strPath.Equals("videodb://tvshows/years/") || strPath.Equals("videodb://2/3/"))
+  else if (path.Equals("videodb://tvshows/years/"))
     return "TvShowYears";
-  else if (strPath.Equals("videodb://tvshows/actors/") || strPath.Equals("videodb://2/4/"))
+  else if (path.Equals("videodb://tvshows/actors/"))
     return "TvShowActors";
-  else if (strPath.Equals("videodb://tvshows/studios/") || strPath.Equals("videodb://2/9/"))
+  else if (path.Equals("videodb://tvshows/studios/"))
     return "TvShowStudios";
-  else if (strPath.Equals("videodb://tvshows/tags/") || strPath.Equals("videodb://2/"))
+  else if (path.Equals("videodb://tvshows/tags/"))
     return "TvShowTags";
-  else if (strPath.Equals("videodb://tvshows/") || strPath.Equals("videodb://2/"))
+  else if (path.Equals("videodb://tvshows/"))
     return "TvShows";
-  else if (strPath.Equals("videodb://musicvideos/genres/") || strPath.Equals("videodb://3/1/"))
+  else if (path.Equals("videodb://musicvideos/genres/"))
     return "MusicVideoGenres";
-  else if (strPath.Equals("videodb://musicvideos/titles/") || strPath.Equals("videodb://3/2/"))
+  else if (path.Equals("videodb://musicvideos/titles/"))
     return "MusicVideoTitles";
-  else if (strPath.Equals("videodb://musicvideos/years/") || strPath.Equals("videodb://3/3/"))
+  else if (path.Equals("videodb://musicvideos/years/"))
     return "MusicVideoYears";
-  else if (strPath.Equals("videodb://musicvideos/artists/") || strPath.Equals("videodb://3/4/"))
+  else if (path.Equals("videodb://musicvideos/artists/"))
     return "MusicVideoArtists";
-  else if (strPath.Equals("videodb://musicvideos/albums/") || strPath.Equals("videodb://3/5/"))
+  else if (path.Equals("videodb://musicvideos/albums/"))
     return "MusicVideoDirectors";
-  else if (strPath.Equals("videodb://musicvideos/tags/") || strPath.Equals("videodb://3/9/"))
+  else if (path.Equals("videodb://musicvideos/tags/"))
     return "MusicVideoTags";
-  else if (strPath.Equals("videodb://musicvideos/") || strPath.Equals("videodb://3/"))
+  else if (path.Equals("videodb://musicvideos/"))
     return "MusicVideos";
-  else if (strPath.Equals("videodb://recentlyaddedmovies/") || strPath.Equals("videodb://4/"))
+  else if (path.Equals("videodb://recentlyaddedmovies/"))
     return "RecentlyAddedMovies";
-  else if (strPath.Equals("videodb://recentlyaddedepisodes/") || strPath.Equals("videodb://5/"))
+  else if (path.Equals("videodb://recentlyaddedepisodes/"))
     return "RecentlyAddedEpisodes";
-  else if (strPath.Equals("videodb://recentlyaddedmusicvideos/") || strPath.Equals("videodb://6/"))
+  else if (path.Equals("videodb://recentlyaddedmusicvideos/"))
     return "RecentlyAddedMusicVideos";
-  else if (strPath.Equals("special://videoplaylists/"))
+  else if (path.Equals("special://videoplaylists/"))
     return "Playlists";
-  else if (strPath.Equals("sources://video/"))
+  else if (path.Equals("sources://video/"))
     return "Files";
   else
   {

--- a/xbmc/view/ViewDatabase.cpp
+++ b/xbmc/view/ViewDatabase.cpp
@@ -21,7 +21,9 @@
 #include "ViewDatabase.h"
 #include "utils/URIUtils.h"
 #include "view/ViewState.h"
+#include "utils/LegacyPathTranslation.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #ifdef _LINUX
 #include "linux/ConvUtils.h" // GetLastError()
 #endif
@@ -72,6 +74,31 @@ bool CViewDatabase::UpdateOldVersion(int version)
 {
   if (version < 4)
     m_pDS->exec("alter table view add skin text");
+  if (version < 5)
+  {
+    // translate legacy videodb:// and musicdb:// paths
+    std::vector< std::pair<int, std::string> > paths;
+    if (m_pDS->query("SELECT idView, path FROM view"))
+    {
+      while (!m_pDS->eof())
+      {
+        std::string originalPath = m_pDS->fv(1).get_asString();
+        std::string path = originalPath;
+        if (StringUtils::StartsWith(path, "musicdb://"))
+          path = CLegacyPathTranslation::TranslateMusicDbPath(path);
+        else if (StringUtils::StartsWith(path, "videodb://"))
+          path = CLegacyPathTranslation::TranslateVideoDbPath(path);
+
+        if (!StringUtils::EqualsNoCase(path, originalPath))
+          paths.push_back(std::make_pair(m_pDS->fv(0).get_asInt(), path));
+        m_pDS->next();
+      }
+      m_pDS->close();
+
+      for (std::vector< std::pair<int, std::string> >::const_iterator it = paths.begin(); it != paths.end(); it++)
+        m_pDS->exec(PrepareSQL("UPDATE view SET path='%s' WHERE idView=%d", it->second.c_str(), it->first).c_str());
+    }
+  }
   return true;
 }
 

--- a/xbmc/view/ViewDatabase.h
+++ b/xbmc/view/ViewDatabase.h
@@ -36,6 +36,6 @@ public:
 protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 4; };
+  virtual int GetMinVersion() const { return 5; };
   const char *GetBaseDBName() const { return "ViewModes"; };
 };


### PR DESCRIPTION
This adds some logic to translate legacy videodb:// and musicdb:// paths to the new ones and is necessary to fix favourites using the old paths. I put the logic into CGUIWindowVideoNav and CGUIWindowMusicNav but maybe it would be better off in CVideoDatabaseDirectory and CMusicDatabaseDirectory which would cover any calls to GetDirectory using the old/legacy paths?
