### PR TITLE
[dvdplayer] fixes PGS subtitles

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -186,7 +186,8 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
     // for pgs subtitles the packet pts of the end_segments are wrong
     // instead use the subtitle pts to calc the offset here
     // see http://git.videolan.org/?p=ffmpeg.git;a=commit;h=2939e258f9d1fff89b3b68536beb931b54611585
-    if (m_Subtitle.pts != DVD_NOPTS_VALUE)
+
+    if (m_Subtitle.pts != AV_NOPTS_VALUE && pPacket->pts != DVD_NOPTS_VALUE)
     {
       pts_offset = m_Subtitle.pts - pPacket->pts ;
     }


### PR DESCRIPTION
Statment  "if (m_Subtitle.pts != DVD_NOPTS_VALUE)" will never eval to false since ffmpeg sets pts to AV_NOPTS_VALUE. 

xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp:
1. CDVDOverlayCodecFFmpeg::Decode ->
2. len = m_dllAvCodec.avcodec_decode_subtitle2(m_pCodecContext, &m_Subtitle, &gotsub, &avpkt); ->
3. lib/ffmpeg/libavcodec/utils.c:
static void avcodec_get_subtitle_defaults (AVSubtitle _sub)
{
    memset(sub, 0, sizeof(_sub));
    sub->pts = AV_NOPTS_VALUE;
}

DVD_NOPTS_VALUE  = 0xfff0000000000000
AV_NOPTS_VALUE  = 0x8000000000000000

./xbmc/cores/dvdplayer/DVDClock.h:
# define DVD_NOPTS_VALUE    (-1LL<<52) // should be possible to represent in both double and int64_t

./lib/ffmpeg/libavutil/avutil.h:
# define AV_NOPTS_VALUE          INT64_C(0x8000000000000000)
