### PR TITLE
Fix undefined reference caused by wrong detection of gcc builtin atomic functions.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -850,7 +850,7 @@ AC_CHECK_SIZEOF([size_t])
 
 # Check for intrinsics
 AC_MSG_CHECKING([for __sync_add_and_fetch(temp, 1)])
-AC_TRY_COMPILE([],[long* temp=0; __sync_add_and_fetch(temp, 1);],
+AC_TRY_LINK([],[long* temp=0; long ret=__sync_add_and_fetch(temp, 1);],
                 [have_builtin_sync_add_and_fetch=yes],
                 [have_builtin_sync_add_and_fetch=no])
 AC_MSG_RESULT($have_builtin_sync_add_and_fetch)
@@ -860,7 +860,7 @@ if test "x$have_builtin_sync_add_and_fetch" = "xyes"; then
 fi
 
 AC_MSG_CHECKING([for __sync_sub_and_fetch(temp, 1)])
-AC_TRY_COMPILE([],[long* temp=0; __sync_sub_and_fetch(temp, 1);],
+AC_TRY_LINK([],[long* temp=0; long ret=__sync_sub_and_fetch(temp, 1);],
                 [have_builtin_sync_sub_and_fetch=yes],
                 [have_builtin_sync_sub_and_fetch=no])
 AC_MSG_RESULT($have_builtin_sync_sub_and_fetch)
@@ -870,7 +870,7 @@ if test "x$have_builtin_sync_sub_and_fetch" = "xyes"; then
 fi
 
 AC_MSG_CHECKING([for __sync_val_compare_and_swap(temp, 1, 1)])
-AC_TRY_COMPILE([],[long *temp = 0; __sync_val_compare_and_swap(temp, 1, 1);],
+AC_TRY_LINK([],[long *temp = 0; long ret=__sync_val_compare_and_swap(temp, 1, 1);],
                 [have_builtin_sync_val_compare_and_swap=yes],
                 [have_builtin_sync_val_compare_and_swap=no])
 AC_MSG_RESULT($have_builtin_sync_val_compare_and_swap)


### PR DESCRIPTION
I found the current detection is not correct and finally got following errors on my linux build:

```
xbmc/threads/threads.a(Atomics.o): In function `AtomicSubtract(long volatile*, long)':
/var5/xbmc/xbmc/threads/Atomics.cpp:386: undefined reference to `__sync_sub_and_fetch_4'
xbmc/threads/threads.a(Atomics.o): In function `AtomicDecrement(long volatile*)':
/var5/xbmc/xbmc/threads/Atomics.cpp:308: undefined reference to `__sync_sub_and_fetch_4'
xbmc/threads/threads.a(Atomics.o): In function `AtomicAdd(long volatile*, long)':
/var5/xbmc/xbmc/threads/Atomics.cpp:230: undefined reference to `__sync_add_and_fetch_4'
xbmc/threads/threads.a(Atomics.o): In function `AtomicIncrement(long volatile*)':
/var5/xbmc/xbmc/threads/Atomics.cpp:152: undefined reference to `__sync_add_and_fetch_4'
xbmc/threads/threads.a(Atomics.o): In function `cas(long volatile*, long, long)':
/var5/xbmc/xbmc/threads/Atomics.cpp:30: undefined reference to `__sync_val_compare_and_swap_4'
/var5/xbmc/xbmc-deps/i686-linux-gnu/lib/libtag.a(mpegheader.cpp.o): In function `TagLib::RefCounter::deref()':
mpegheader.cpp:(.text._ZN6TagLib10RefCounter5derefEv[TagLib::RefCounter::deref()]+0x15): undefined reference to `__sync_sub_and_fetch_4'
collect2: ld returned 1 exit status
[btfans@localhost xbmc]$ vi t.c

```

so I found how to fix it, reference: http://osgeo-org.1560.x6.nabble.com/undefined-reference-to-sync-sub-and-fetch-4-td5009362.html
