### PR TITLE
JSONRPCServer, AirPlayServer, WebServer: listen on ipv6 if available, else fall back to ipv4

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -323,7 +323,7 @@ void CAirPlayServer::Process()
       {
         CLog::Log(LOGDEBUG, "AIRPLAY Server: New connection detected");
         CTCPClient newconnection;
-        newconnection.m_socket = accept(m_ServerSocket, &newconnection.m_cliaddr, &newconnection.m_addrlen);
+        newconnection.m_socket = accept(m_ServerSocket, (struct sockaddr*) &newconnection.m_cliaddr, &newconnection.m_addrlen);
         sessionCounter++;
         newconnection.m_sessionCounter = sessionCounter;
 
@@ -383,7 +383,7 @@ CAirPlayServer::CTCPClient::CTCPClient()
   m_socket = INVALID_SOCKET;
   m_httpParser = new HttpParser();
 
-  m_addrlen = sizeof(struct sockaddr);
+  m_addrlen = sizeof(struct sockaddr_storage);
   m_pLibPlist = new DllLibPlist();
 
   m_bAuthenticated = false;

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -353,12 +353,10 @@ void CAirPlayServer::Process()
 bool CAirPlayServer::Initialize()
 {
   Deinitialize();
-
-  if((m_ServerSocket = CreateTCPServerSocket(m_port, !m_nonlocal, 10,
-		"AIRPLAY")) == INVALID_SOCKET) {
-	return false;
-  }
-
+  
+  if ((m_ServerSocket = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "AIRPLAY")) == INVALID_SOCKET)
+    return false;
+  
   CLog::Log(LOGINFO, "AIRPLAY Server: Successfully initialized");
   return true;
 }

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -354,38 +354,9 @@ bool CAirPlayServer::Initialize()
 {
   Deinitialize();
 
-  struct sockaddr_in myaddr;
-  memset(&myaddr, 0, sizeof(myaddr));
-
-  myaddr.sin_family = AF_INET;
-  myaddr.sin_port = htons(m_port);
-
-  if (m_nonlocal)
-    myaddr.sin_addr.s_addr = INADDR_ANY;
-  else
-    inet_pton(AF_INET, "127.0.0.1", &myaddr.sin_addr.s_addr);
-
-  m_ServerSocket = socket(PF_INET, SOCK_STREAM, 0);
-
-  if (m_ServerSocket == INVALID_SOCKET)
-  {
-
-    CLog::Log(LOGERROR, "AIRPLAY Server: Failed to create serversocket");
-    return false;
-  }
-
-  if (bind(m_ServerSocket, (struct sockaddr*)&myaddr, sizeof myaddr) < 0)
-  {
-    CLog::Log(LOGERROR, "AIRPLAY Server: Failed to bind serversocket");
-    close(m_ServerSocket);
-    return false;
-  }
-
-  if (listen(m_ServerSocket, 10) < 0)
-  {
-    CLog::Log(LOGERROR, "AIRPLAY Server: Failed to set listen");
-    close(m_ServerSocket);
-    return false;
+  if((m_ServerSocket = CreateTCPServerSocket(m_port, !m_nonlocal, 10,
+		"AIRPLAY")) == INVALID_SOCKET) {
+	return false;
   }
 
   CLog::Log(LOGINFO, "AIRPLAY Server: Successfully initialized");

--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -80,7 +80,7 @@ private:
     void Disconnect();
 
     int m_socket;
-    struct sockaddr m_cliaddr;
+    struct sockaddr_storage m_cliaddr;
     socklen_t m_addrlen;
     CCriticalSection m_critSection;
     int  m_sessionCounter;

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -346,6 +346,14 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
   struct sockaddr_in  *s4;
   int    sock;
   bool   v4_fallback = false;
+
+#ifdef WINSOCK_VERSION
+  const char yes = 1;
+  const char no = 0;
+#else
+  unsigned int yes = 1;
+  unsigned int no = 0;
+#endif
   
   memset(&addr, 0, sizeof(addr));
   
@@ -353,12 +361,13 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
     v4_fallback = true;
   
   //in case we're on ipv6, make sure the socket is dual stacked
-  unsigned int no = 0;
   if (!v4_fallback)
-    setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char *) &no, sizeof(no)); 
+    setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &no, sizeof(no)); 
   
   if (v4_fallback)
     sock = socket(PF_INET, SOCK_STREAM, 0);
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
   
   if (sock == INVALID_SOCKET)
   {

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -369,9 +369,9 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
 	s4->sin_port = htons(port);
 
     if(bindLocal)
-		s4->sin_addr.s_addr = INADDR_LOOPBACK;
+		s4->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     else
-		s4->sin_addr.s_addr = INADDR_ANY;
+		s4->sin_addr.s_addr = htonl(INADDR_ANY);
 
   } else {
 	addr.ss_family	= AF_INET6;

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -398,7 +398,7 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
       s6->sin6_addr = in6addr_any;
   }
 
-  if (bind( sock, (struct sockaddr *) &addr,
+  if (::bind( sock, (struct sockaddr *) &addr,
             (addr.ss_family == AF_INET6) ? sizeof(struct sockaddr_in6) :
                                            sizeof(struct sockaddr_in)  ) < 0)
   {

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -27,10 +27,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "dialogs/GUIDialogKaiToast.h"
 
-#ifdef TARGET_WINDOWS
-#define close closesocket
-#endif
-
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -402,14 +398,14 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
             (addr.ss_family == AF_INET6) ? sizeof(struct sockaddr_in6) :
                                            sizeof(struct sockaddr_in)  ) < 0)
   {
-    close(sock);
+    closesocket(sock);
     CLog::Log(LOGERROR, "%s Server: Failed to bind serversocket", callerName);
     return INVALID_SOCKET;
   }
 
   if (listen(sock, backlog) < 0)
   {
-    close(sock);
+    closesocket(sock);
     CLog::Log(LOGERROR, "%s Server: Failed to set listen", callerName);
     return INVALID_SOCKET;
   }

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -24,6 +24,8 @@
 #include <vector>
 #include "utils/StdString.h"
 #include "system.h"
+#include <string>
+using namespace std;
 
 enum EncMode { ENC_NONE = 0, ENC_WEP = 1, ENC_WPA = 2, ENC_WPA2 = 3 };
 enum NetworkAssignment { NETWORK_DASH = 0, NETWORK_DHCP = 1, NETWORK_STATIC = 2, NETWORK_DISABLED = 3 };
@@ -128,3 +130,9 @@ public:
 #include "windows/NetworkWin32.h"
 #endif
 #endif
+
+//creates, binds and listens a tcp socket on the desired port. Set bindLocal to
+//true to bind to localhost only. The socket will listen over ipv6 if possible
+//and fall back to ipv4 if ipv6 is not available on the platform.
+int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlog, const char *callerName);
+

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -24,8 +24,6 @@
 #include <vector>
 #include "utils/StdString.h"
 #include "system.h"
-#include <string>
-using namespace std;
 
 enum EncMode { ENC_NONE = 0, ENC_WEP = 1, ENC_WPA = 2, ENC_WPA2 = 3 };
 enum NetworkAssignment { NETWORK_DASH = 0, NETWORK_DHCP = 1, NETWORK_STATIC = 2, NETWORK_DISABLED = 3 };

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -441,10 +441,8 @@ bool CTCPServer::InitializeTCP()
 
   Deinitialize();
 
-  if((fd = CreateTCPServerSocket(m_port, !m_nonlocal, 10,
-		"JSONRPC")) == INVALID_SOCKET) {
-	return false;
-  }
+  if ((fd = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "JSONRPC")) == INVALID_SOCKET)
+    return false;
 
   m_servers.push_back(fd);
   return true;

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -32,6 +32,7 @@
 #include "utils/Variant.h"
 #include "threads/SingleLock.h"
 #include "websocket/WebSocketManager.h"
+#include "Network.h"
 
 static const char     bt_service_name[] = "XBMC JSON-RPC";
 static const char     bt_service_desc[] = "Interface for XBMC remote control over bluetooth";
@@ -436,39 +437,15 @@ bool CTCPServer::InitializeBlue()
 
 bool CTCPServer::InitializeTCP()
 {
+  SOCKET fd;
 
-  struct sockaddr_in myaddr;
-  memset(&myaddr, 0, sizeof(myaddr));
+  Deinitialize();
 
-  myaddr.sin_family = AF_INET;
-  myaddr.sin_port = htons(m_port);
-
-  if (m_nonlocal)
-    myaddr.sin_addr.s_addr = INADDR_ANY;
-  else
-    inet_pton(AF_INET, "127.0.0.1", &myaddr.sin_addr.s_addr);
-
-  SOCKET fd = socket(PF_INET, SOCK_STREAM, 0);
-
-  if (fd == INVALID_SOCKET)
-  {
-    CLog::Log(LOGERROR, "JSONRPC Server: Failed to create serversocket");
-    return false;
+  if((fd = CreateTCPServerSocket(m_port, !m_nonlocal, 10,
+		"JSONRPC")) == INVALID_SOCKET) {
+	return false;
   }
 
-  if (bind(fd, (struct sockaddr*)&myaddr, sizeof myaddr) < 0)
-  {
-    CLog::Log(LOGERROR, "JSONRPC Server: Failed to bind serversocket");
-    closesocket(fd);
-    return false;
-  }
-
-  if (listen(fd, 10) < 0)
-  {
-    CLog::Log(LOGERROR, "JSONRPC Server: Failed to set listen");
-    closesocket(fd);
-    return false;
-  }
   m_servers.push_back(fd);
   return true;
 }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -33,6 +33,10 @@
 #pragma comment(lib, "libmicrohttpd.dll.lib")
 #endif
 
+#ifdef TARGET_WINDOWS
+#define close closesocket
+#endif
+
 #define MAX_POST_BUFFER_SIZE 2048
 
 #define PAGE_FILE_NOT_FOUND "<html><head><title>File not found</title></head><body>File not found</body></html>"
@@ -576,15 +580,16 @@ bool CWebServer::Start(int port, const string &username, const string &password)
   SetCredentials(username, password);
   if (!m_running)
   {
-  	int v6testSock;
-  	if((v6testSock = socket(AF_INET6, SOCK_STREAM, 0)) > 0) {
+    int v6testSock;
+    if ((v6testSock = socket(AF_INET6, SOCK_STREAM, 0)) > 0)
+    {
       close(v6testSock);
       m_daemon_ip6 = StartMHD(MHD_USE_IPv6, port);
-  	}
-
+    }
+    
     m_daemon_ip4 = StartMHD(0 , port);
-
-    m_running = (m_daemon_ip6 != NULL) | (m_daemon_ip4 != NULL);
+    
+    m_running = (m_daemon_ip6 != NULL) || (m_daemon_ip4 != NULL);
     if (m_running)
       CLog::Log(LOGNOTICE, "WebServer: Started the webserver");
     else
@@ -597,15 +602,16 @@ bool CWebServer::Stop()
 {
   if (m_running)
   {
-	if(m_daemon_ip6 != NULL)
-    	MHD_stop_daemon(m_daemon_ip6);
+    if (m_daemon_ip6 != NULL)
+      MHD_stop_daemon(m_daemon_ip6);
 
-	if(m_daemon_ip4 != NULL)
-    	MHD_stop_daemon(m_daemon_ip4);
-
+    if (m_daemon_ip4 != NULL)
+      MHD_stop_daemon(m_daemon_ip4);
+    
     m_running = false;
     CLog::Log(LOGNOTICE, "WebServer: Stopped the webserver");
-  } else 
+  }
+  else 
     CLog::Log(LOGNOTICE, "WebServer: Stopped failed because its not running");
 
   return !m_running;

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -47,7 +47,8 @@ vector<IHTTPRequestHandler *> CWebServer::m_requestHandlers;
 CWebServer::CWebServer()
 {
   m_running = false;
-  m_daemon = NULL;
+  m_daemon_ip6 = NULL;
+  m_daemon_ip4 = NULL;
   m_needcredentials = true;
   m_Credentials64Encoded = "eGJtYzp4Ym1j"; // xbmc:xbmc
 }
@@ -575,9 +576,15 @@ bool CWebServer::Start(int port, const string &username, const string &password)
   SetCredentials(username, password);
   if (!m_running)
   {
-    m_daemon = StartMHD(0 , port);
+  	int v6testSock;
+  	if((v6testSock = socket(AF_INET6, SOCK_STREAM, 0)) > 0) {
+      close(v6testSock);
+      m_daemon_ip6 = StartMHD(MHD_USE_IPv6, port);
+  	}
 
-    m_running = m_daemon != NULL;
+    m_daemon_ip4 = StartMHD(0 , port);
+
+    m_running = (m_daemon_ip6 != NULL) | (m_daemon_ip4 != NULL);
     if (m_running)
       CLog::Log(LOGNOTICE, "WebServer: Started the webserver");
     else
@@ -590,7 +597,12 @@ bool CWebServer::Stop()
 {
   if (m_running)
   {
-    MHD_stop_daemon(m_daemon);
+	if(m_daemon_ip6 != NULL)
+    	MHD_stop_daemon(m_daemon_ip6);
+
+	if(m_daemon_ip4 != NULL)
+    	MHD_stop_daemon(m_daemon_ip4);
+
     m_running = false;
     CLog::Log(LOGNOTICE, "WebServer: Stopped the webserver");
   } else 

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -33,10 +33,6 @@
 #pragma comment(lib, "libmicrohttpd.dll.lib")
 #endif
 
-#ifdef TARGET_WINDOWS
-#define close closesocket
-#endif
-
 #define MAX_POST_BUFFER_SIZE 2048
 
 #define PAGE_FILE_NOT_FOUND "<html><head><title>File not found</title></head><body>File not found</body></html>"
@@ -583,7 +579,7 @@ bool CWebServer::Start(int port, const string &username, const string &password)
     int v6testSock;
     if ((v6testSock = socket(AF_INET6, SOCK_STREAM, 0)) > 0)
     {
-      close(v6testSock);
+      closesocket(v6testSock);
       m_daemon_ip6 = StartMHD(MHD_USE_IPv6, port);
     }
     

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -103,7 +103,8 @@ private:
 
   static const char *CreateMimeTypeFromExtension(const char *ext);
 
-  struct MHD_Daemon *m_daemon;
+  struct MHD_Daemon *m_daemon_ip6;
+  struct MHD_Daemon *m_daemon_ip4;
   bool m_running, m_needcredentials;
   std::string m_Credentials64Encoded;
   CCriticalSection m_critSection;


### PR DESCRIPTION
This PR makes JSONRPCServer, AirPlayServer and WebServer available over ipv6.

If the platform we are running on doesn't support ipv6 (i.e. the ipv6 module is not inserted), trying to create an ipv6 socket will fail. In this case, we safely fall back to ipv4.

JSONRPCServer, AirPlayServer:
The code attempts to make ipv6 sockets dual stack by setting setsockopt(IPV6_V6ONLY) to false. This means that both ipv4 and ipv6 connections will be handled by the same socket.

Binding to localhost works for both address families.

WebServer:
By design, MHD tries to bind to only one address family, so in case ipv6 is available, the best solution seems to start two instances of the server.

On some systems (OSX at least), MHD seems to use dual stack sockets. In this case, the ipv6 instance will serve both ipv6 and ipv4 clients and the ipv4 instance will fail to start (port already in use). The code handles both situations.

Tested OK on Linux (raspberry pi) and MacOSX (macbook air).
