### PR TITLE
fixed: Freezing when player fails to queue the next song (fixes #14297 #14231 #14229 #13919)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5001,11 +5001,22 @@ bool CApplication::OnMessage(CGUIMessage& message)
       }
 #endif
 
-      // ok - send the file to the player if it wants it
-      if (m_pPlayer && m_pPlayer->QueueNextFile(file))
-      { // player wants the next file
-        m_nextPlaylistItem = iNext;
+      // ok - send the file to the player, if it accepts it
+      if (m_pPlayer)
+      {
+        if (m_pPlayer->QueueNextFile(file))
+        {
+          // player accepted the next file
+          m_nextPlaylistItem = iNext;
+        }
+        else
+        {
+          /* Player didn't accept next file: *ALWAYS* advance playlist in this case so the player can
+             queue the next (if it wants to) and it doesn't keep looping on this song */
+          g_playlistPlayer.SetCurrentSong(iNext);
+        }
       }
+
       return true;
     }
     break;


### PR DESCRIPTION
This fixes freezing (due to looping) of XBMC when trying to play eg. non-existent items in the playlist by simply also advancing the playlist in case of failure. Note that I'm pretty sure this is a regression at least from 11.0
