### PR TITLE
[WIN32] Peripherals: clarification of iMON setting

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12182,7 +12182,7 @@ msgstr ""
 
 #: system/peripherals.xml
 msgctxt "#35102"
-msgid "Disable joystick when device is present"
+msgid "Disable joystick when this device is present"
 msgstr ""
 
 #empty strings from id 35103 to 35499


### PR DESCRIPTION
Replace 
"Disable joystick when device is present" with 
"Disable joystick when **this** device is present"
