### PR TITLE
Fixes crash when audio encoder is not initalized.

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -1295,6 +1295,8 @@ int CSoftAE::RunRawOutputStage(bool hasAudio)
 
 int CSoftAE::RunTranscodeStage(bool hasAudio)
 {
+  if (!m_encoder) return 0;
+  
   /* if we dont have enough samples to encode yet, return */
   unsigned int block     = m_encoderFormat.m_frames * m_encoderFormat.m_frameSize;
   unsigned int sinkBlock = m_sinkFormat.m_frames    * m_sinkFormat.m_frameSize;


### PR DESCRIPTION
In some cases, audio encoder is not initalized (as explained in ticket #14298).
