### PR TITLE
[Python] Uses addon's name for script error notification.

### DIFF
--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -341,7 +341,17 @@ void XBPyThread::Process()
       if (pDlgToast)
       {
         CStdString desc;
-        desc.Format(g_localizeStrings.Get(2100), addon->Name());
+        CStdString path;
+        CStdString script;
+        URIUtils::Split(m_source, path, script);
+        if (script.Equals("default.py"))
+        {
+          CStdString path2;
+          URIUtils::RemoveSlashAtEnd(path);
+          URIUtils::Split(path, path2, script);
+        }
+
+        desc.Format(g_localizeStrings.Get(2100), script);
         pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(257), desc);
       }
     }

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -341,17 +341,7 @@ void XBPyThread::Process()
       if (pDlgToast)
       {
         CStdString desc;
-        CStdString path;
-        CStdString script;
-        URIUtils::Split(m_source, path, script);
-        if (script.Equals("default.py"))
-        {
-          CStdString path2;
-          URIUtils::RemoveSlashAtEnd(path);
-          URIUtils::Split(path, path2, script);
-        }
-
-        desc.Format(g_localizeStrings.Get(2100), script);
+        desc.Format(g_localizeStrings.Get(2100), addon->Name());
         pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(257), desc);
       }
     }

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -341,14 +341,21 @@ void XBPyThread::Process()
       if (pDlgToast)
       {
         CStdString desc;
-        CStdString path;
         CStdString script;
-        URIUtils::Split(m_source, path, script);
-        if (script.Equals("default.py"))
+        if (addon.get() != NULL)
         {
-          CStdString path2;
-          URIUtils::RemoveSlashAtEnd(path);
-          URIUtils::Split(path, path2, script);
+          script = addon->Name();
+        }
+        else
+        {
+          URIUtils::Split(m_source, path, script);
+          if (script.Equals("default.py"))
+          {
+            CStdString path;
+            CStdString path2;
+            URIUtils::RemoveSlashAtEnd(path);
+            URIUtils::Split(path, path2, script);
+          }
         }
 
         desc.Format(g_localizeStrings.Get(2100), script);

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -348,10 +348,10 @@ void XBPyThread::Process()
         }
         else
         {
+          CStdString path;
           URIUtils::Split(m_source, path, script);
           if (script.Equals("default.py"))
           {
-            CStdString path;
             CStdString path2;
             URIUtils::RemoveSlashAtEnd(path);
             URIUtils::Split(path, path2, script);


### PR DESCRIPTION
This is a little nicer to know exactly what addon errored without looking in the log, especially with multiple services running.
