### PR TITLE
[RFC] Auto login profile selection

### DIFF
--- a/addons/skin.confluence/720p/ProfileSettings.xml
+++ b/addons/skin.confluence/720p/ProfileSettings.xml
@@ -107,7 +107,7 @@
 			<description>control area</description>
 			<posx>30</posx>
 			<posy>230</posy>
-			<width>640</width>
+			<width>610</width>
 			<height>265</height>
 			<itemgap>5</itemgap>
 			<pagecontrol>60</pagecontrol>
@@ -115,6 +115,21 @@
 			<onright>60</onright>
 			<onup>28</onup>
 			<ondown>28</ondown>
+		</control>
+		<control type="scrollbar" id="60">
+			<posx>645</posx>
+			<posy>230</posy>
+			<width>25</width>
+			<height>265</height>
+			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
+			<texturesliderbar border="2,16,2,16">ScrollBarV_bar.png</texturesliderbar>
+			<texturesliderbarfocus border="2,16,2,16">ScrollBarV_bar_focus.png</texturesliderbarfocus>
+			<textureslidernib>ScrollBarNib.png</textureslidernib>
+			<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
+			<onleft>5</onleft>
+			<onright>28</onright>
+			<showonepage>false</showonepage>
+			<orientation>vertical</orientation>
 		</control>
 		<control type="button" id="7">
 			<description>Default Button</description>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12459,3 +12459,8 @@ msgstr ""
 msgctxt "#37014"
 msgid "Last used profile"
 msgstr ""
+
+#: xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+msgctxt "#37015"
+msgid "Auto login using this profile"
+msgstr ""

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -129,6 +129,8 @@ void CGUIDialogProfileSettings::CreateSettings()
 
     m_settings.push_back(setting2);
   }
+
+  AddBool(7,37015,&m_bAutoLogin,true);
 }
 
 void CGUIDialogProfileSettings::OnSettingChanged(unsigned int num)
@@ -287,6 +289,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         CDirectory::Remove(URIUtils::AddFileToFolder("special://masterprofile/", defaultDir));
     }
     dialog->m_strDirectory = userDir;
+    dialog->m_bAutoLogin = false;
     dialog->m_bNeedSave = true;
   }
   else
@@ -300,6 +303,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       dialog->m_iDbMode += 2;
     if (profile->hasSources())
       dialog->m_iSourcesMode += 2;
+    dialog->m_bAutoLogin = (!(CProfilesManager::Get().UsingLoginScreen()) && (CProfilesManager::Get().GetAutoLoginProfileId() == (int)iProfile));
 
     dialog->m_locks = profile->GetLocks();
   }
@@ -381,6 +385,15 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
     profile->setDatabases((dialog->m_iDbMode & 2) == 2);
     profile->setSources((dialog->m_iSourcesMode & 2) == 2);
     profile->SetLocks(dialog->m_locks);
+
+    if (dialog->m_bAutoLogin)
+    {
+      CProfilesManager::Get().SetAutoLoginProfileId(iProfile);
+      if (CProfilesManager::Get().UsingLoginScreen())
+        CProfilesManager::Get().ToggleLoginScreen();
+    }
+    else if (CProfilesManager::Get().GetAutoLoginProfileId() == (int)iProfile)
+      CProfilesManager::Get().SetAutoLoginProfileId(-1); // Last used profile
 
     CProfilesManager::Get().Save();
     return true;

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.h
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.h
@@ -56,6 +56,7 @@ protected:
   bool m_bIsDefault;
   bool m_bIsNewUser;
   bool m_bShowDetails;
+  bool m_bAutoLogin;
 
   CProfile::CLock m_locks;
   CStdString m_strDefaultImage;

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -172,13 +172,18 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_AUTOLOGIN)
       {
-        int currentId = CProfilesManager::Get().GetAutoLoginProfileId();
-        int profileId;
-        if (GetAutoLoginProfileChoice(profileId) && (currentId != profileId))
-        {
-          CProfilesManager::Get().SetAutoLoginProfileId(profileId);
-          CProfilesManager::Get().Save();
-        }
+        int profileId = CProfilesManager::Get().GetAutoLoginProfileId() + 1;
+        if (profileId >= (int)CProfilesManager::Get().GetNumberOfProfiles())
+          profileId = -1;
+        CProfilesManager::Get().SetAutoLoginProfileId(profileId);
+        CProfilesManager::Get().Save();
+//        int currentId = CProfilesManager::Get().GetAutoLoginProfileId();
+//        int profileId;
+//        if (GetAutoLoginProfileChoice(profileId) && (currentId != profileId))
+//        {
+//          CProfilesManager::Get().SetAutoLoginProfileId(profileId);
+//          CProfilesManager::Get().Save();
+//        }
         return true;
       }
     }


### PR DESCRIPTION
This PR is a request for comments. The current Auto Login profile selection was thought to be [clunky UI-wise](https://github.com/xbmc/xbmc/pull/2577#commitcomment-2978080) by @jmarshallnz

This PR contains two possible solutions:
1. Pressing the 'Auto login' button at the left side of the 'Settings - Profiles' window will cycle through all profiles including the 'Last used profile' option. Note that this button is disabled when the Login screen is enabled.
2. The 'Auto login using this profile' option is added to the 'Edit profile' dialogbox. In addition a scrollbar is added to indicate to the user that not all available options are visible and that scrolling is required (see screenshot).
   When the login screen is enabled, then the login screen will automatically be disabled when the profile is selected as auto login profile.
   When the profile is deselected for auto login, then automatically the Auto login option will fall back to the 'Last used profile' option. 

![autologin_added_to_editprofiledialog](https://f.cloud.github.com/assets/671891/446716/45eaf6a0-b1de-11e2-870d-1e143dbd088a.png)

Another [solution](https://github.com/xbmc/xbmc/pull/2577#issuecomment-16171866) suggested by @da-anda has not been implemented yet. The benefit of the two possible solutions in this PR is that it requires only minor modifications to skins whereas the solution suggested by da-anda might have a bigger impact on skins due to the fact that the whole 'Settings - Profiles' window changes.

A forum [topic](http://forum.xbmc.org/showthread.php?tid=162069) is also available for discussion.
