### PR TITLE
Add ability to control resampling quality for SoftAE from settings 

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12043,8 +12043,52 @@ msgctxt "#34123"
 msgid "Never"
 msgstr ""
 
-#empty strings from id 34124 to 34200
-#34124-34200 reserved for future use
+#empty strings from id 34124 to 34129
+#34124-34129 reserved for future use
+
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#34130"
+msgid "Resampling quality"
+msgstr ""
+
+#. Resampling quality
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#34131"
+msgid "Simplest"
+msgstr ""
+
+#. Resampling quality
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#34132"
+msgid "Fast"
+msgstr ""
+
+#. Resampling quality
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#34133"
+msgid "Standard"
+msgstr ""
+
+#. Resampling quality
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#34134"
+msgid "Better"
+msgstr ""
+
+#. Resampling quality
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#34135"
+msgid "Best"
+msgstr ""
+
+#. Resampling quality
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#34136"
+msgid "Insane"
+msgstr ""
+
+#empty strings from id 34137 to 34200
+#34137-34200 reserved for future use
 
 #: xbmc\PlayListPlayer.cpp
 msgctxt "#34201"

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -532,7 +532,8 @@ void CSoftAE::OnSettingsChange(const std::string& setting)
       setting == "audiooutput.channels"     ||
       setting == "audiooutput.useexclusivemode"  ||
       setting == "audiooutput.multichannellpcm"  ||
-      setting == "audiooutput.stereoupmix")
+      setting == "audiooutput.stereoupmix"       ||
+      setting == "audiooutput.resamplequality")
   {
     OpenSink();
   }
@@ -555,6 +556,8 @@ void CSoftAE::LoadSettings()
   m_stereoUpmix = g_guiSettings.GetBool("audiooutput.stereoupmix");
   if (m_stereoUpmix)
     CLog::Log(LOGINFO, "CSoftAE::LoadSettings - Stereo upmix is enabled");
+
+  m_resampleQuality = (enum AEQuality) g_guiSettings.GetInt("audiooutput.resamplequality");
 
   /* load the configuration */
   m_stdChLayout = AE_CH_LAYOUT_2_0;
@@ -776,7 +779,7 @@ IAEStream *CSoftAE::MakeStream(enum AEDataFormat dataFormat, unsigned int sample
     ASSERT(encodedSampleRate);
 
   CSingleLock streamLock(m_streamLock);
-  CSoftAEStream *stream = new CSoftAEStream(dataFormat, sampleRate, encodedSampleRate, channelLayout, options);
+  CSoftAEStream *stream = new CSoftAEStream(dataFormat, sampleRate, encodedSampleRate, channelLayout, options, m_resampleQuality);
   m_newStreams.push_back(stream);
   streamLock.Leave();
   // this is really needed here

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -134,6 +134,7 @@ private:
   std::string m_deviceFriendlyName;
   bool m_audiophile;
   bool m_stereoUpmix;
+  AEQuality m_resampleQuality;
 
   /* internal vars */
   bool             m_running, m_reOpen;

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
@@ -36,7 +36,7 @@ class CSoftAEStream : public IAEStream
 {
 protected:
   friend class CSoftAE;
-  CSoftAEStream(enum AEDataFormat format, unsigned int sampleRate, unsigned int encodedSamplerate, CAEChannelInfo channelLayout, unsigned int options);
+  CSoftAEStream(enum AEDataFormat format, unsigned int sampleRate, unsigned int encodedSamplerate, CAEChannelInfo channelLayout, unsigned int options, enum AEQuality resampleQuality = AE_QUALITY_DEFAULT);
   virtual ~CSoftAEStream();
 
   void Initialize();
@@ -141,6 +141,7 @@ private:
   bool                m_autoStart;
   bool                m_draining;
   CAELimiter          m_limiter;
+  int                 m_samplerateQuality;
 
   /* vizualization internals */
   CAERemap           m_vizRemap;

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -40,6 +40,18 @@ class IAEPacketizer;
 #define AE_SOUND_IDLE   1 /* only play sounds while no streams are running */
 #define AE_SOUND_ALWAYS 2 /* always play sounds */
 
+enum AEQuality:int
+{
+  AE_QUALITY_UNKNOWN  = -1,
+  AE_QUALITY_DEFAULT  =  0,
+  AE_QUALITY_SIMPLEST = 10,
+  AE_QUALITY_FAST     = 20,
+  AE_QUALITY_STANDARD = 30,
+  AE_QUALITY_BETTER   = 40,
+  AE_QUALITY_BEST     = 50,
+  AE_QUALITY_INSANE   = 100
+};
+
 /**
  * IAE Interface
  */

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -499,6 +499,12 @@ void CGUISettings::Initialize()
     channelLayout.insert(make_pair(34100+layout, layout));
   AddInt(ao, "audiooutput.channels", 34100, AE_CH_LAYOUT_2_0, channelLayout, SPIN_CONTROL_TEXT);
   AddBool(ao, "audiooutput.normalizelevels", 346, true);
+  map<int,int> resamplequality;
+  resamplequality.insert(make_pair(34131, AE_QUALITY_SIMPLEST));
+  resamplequality.insert(make_pair(34132, AE_QUALITY_FAST));
+  resamplequality.insert(make_pair(34133, AE_QUALITY_STANDARD));
+  resamplequality.insert(make_pair(34135, AE_QUALITY_BEST));
+  AddInt(ao, "audiooutput.resamplequality", 34130, AE_QUALITY_STANDARD, resamplequality, SPIN_CONTROL_TEXT);
   AddBool(ao, "audiooutput.stereoupmix", 252, false);
 
 #if defined(TARGET_DARWIN_IOS)


### PR DESCRIPTION
Useful both for limited hardware (allow to lower CPU usage) and for powerful hardware (allow to set better quality).
