### PR TITLE
[rbp] Remove unnecessary gl ifdef

### DIFF
--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -138,11 +138,7 @@ bool CRenderSystemGLES::ResetRenderSystem(int width, int height, bool fullScreen
   g_matrices.MatrixMode(MM_PROJECTION);
   g_matrices.LoadIdentity();
 
-#ifdef TARGET_RASPBERRY_PI
-  g_matrices.Ortho(0.0f, width-1, height-1, 0.0f, +1.0f, 1.0f);
-#else
   g_matrices.Ortho(0.0f, width-1, height-1, 0.0f, -1.0f, 1.0f);
-#endif
 
   g_matrices.MatrixMode(MM_MODELVIEW);
   g_matrices.LoadIdentity();


### PR DESCRIPTION
I'm not sure why this was originally added.
I couldn't think of a reason why the Pi would want things done differently here,
so I tried without the ifdef. I can't see any difference in behaviour,
so I think we're better off removing it.
