### PR TITLE
GUIViewControl: send gui messages to proper window, fixes #14291

### DIFF
--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -120,7 +120,7 @@ void CGUIViewControl::SetCurrentView(int viewMode, bool bRefresh /* = false */)
   if (hasFocus)
   {
     CGUIMessage msg(GUI_MSG_SETFOCUS, m_parentWindow, pNewView->GetID(), 0);
-    g_windowManager.SendMessage(msg);
+    g_windowManager.SendMessage(msg, m_parentWindow);
   }
 
   // Update our view control only if we are not in the TV Window
@@ -140,7 +140,7 @@ void CGUIViewControl::UpdateContents(const CGUIControl *control, int currentItem
 {
   if (!control || !m_fileItems) return;
   CGUIMessage msg(GUI_MSG_LABEL_BIND, m_parentWindow, control->GetID(), currentItem, 0, m_fileItems);
-  g_windowManager.SendMessage(msg);
+  g_windowManager.SendMessage(msg, m_parentWindow);
 }
 
 void CGUIViewControl::UpdateView()
@@ -159,7 +159,7 @@ int CGUIViewControl::GetSelectedItem(const CGUIControl *control) const
 {
   if (!control || !m_fileItems) return -1;
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, m_parentWindow, control->GetID());
-  g_windowManager.SendMessage(msg);
+  g_windowManager.SendMessage(msg, m_parentWindow);
 
   int iItem = msg.GetParam1();
   if (iItem >= m_fileItems->Size())
@@ -184,7 +184,7 @@ void CGUIViewControl::SetSelectedItem(int item)
     return; // no valid current view!
 
   CGUIMessage msg(GUI_MSG_ITEM_SELECT, m_parentWindow, m_visibleViews[m_currentView]->GetID(), item);
-  g_windowManager.SendMessage(msg);
+  g_windowManager.SendMessage(msg, m_parentWindow);
 }
 
 void CGUIViewControl::SetSelectedItem(const CStdString &itemPath)
@@ -215,7 +215,7 @@ void CGUIViewControl::SetFocused()
     return; // no valid current view!
 
   CGUIMessage msg(GUI_MSG_SETFOCUS, m_parentWindow, m_visibleViews[m_currentView]->GetID(), 0);
-  g_windowManager.SendMessage(msg);
+  g_windowManager.SendMessage(msg, m_parentWindow);
 }
 
 bool CGUIViewControl::HasControl(int viewControlID) const
@@ -279,7 +279,7 @@ void CGUIViewControl::Clear()
     return; // no valid current view!
 
   CGUIMessage msg(GUI_MSG_LABEL_RESET, m_parentWindow, m_visibleViews[m_currentView]->GetID(), 0);
-  g_windowManager.SendMessage(msg);
+  g_windowManager.SendMessage(msg, m_parentWindow);
 }
 
 int CGUIViewControl::GetView(VIEW_TYPE type, int id) const
@@ -297,7 +297,7 @@ void CGUIViewControl::UpdateViewAsControl(const CStdString &viewLabel)
 {
   // the view as control could be a select/spin/dropdown button
   CGUIMessage msg(GUI_MSG_LABEL_RESET, m_parentWindow, m_viewAsControl);
-  g_windowManager.SendMessage(msg);
+  g_windowManager.SendMessage(msg, m_parentWindow);
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
   {
     IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
@@ -305,17 +305,17 @@ void CGUIViewControl::UpdateViewAsControl(const CStdString &viewLabel)
     CStdString label;
     label.Format(g_localizeStrings.Get(534).c_str(), view->GetLabel().c_str()); // View: %s
     msg.SetLabel(label);
-    g_windowManager.SendMessage(msg);
+    g_windowManager.SendMessage(msg, m_parentWindow);
   }
   CGUIMessage msgSelect(GUI_MSG_ITEM_SELECT, m_parentWindow, m_viewAsControl, m_currentView);
-  g_windowManager.SendMessage(msgSelect);
+  g_windowManager.SendMessage(msgSelect, m_parentWindow);
 
   // otherwise it's just a normal button
   CStdString label;
   label.Format(g_localizeStrings.Get(534).c_str(), viewLabel.c_str()); // View: %s
   CGUIMessage msgSet(GUI_MSG_LABEL_SET, m_parentWindow, m_viewAsControl);
   msgSet.SetLabel(label);
-  g_windowManager.SendMessage(msgSet);
+  g_windowManager.SendMessage(msgSet, m_parentWindow);
 }
 
 void CGUIViewControl::UpdateViewVisibility()


### PR DESCRIPTION
This solves http://trac.xbmc.org/ticket/14291 but I'm not sure if issue shouldn't be looked at one level higher.

Problem here is that messages sent by Addon Browser view control are first handled by topmost dialogs first ( which will be yes/no dialog in track ticket ): https://github.com/xbmc/xbmc/blob/master/xbmc/guilib/GUIWindowManager.cpp#L100. Shouldn't we first try to to handle message by window that sent that message first and only then try active dialogs?
