### PR TITLE
Scan for Movie Set Artwork

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2015,32 +2015,29 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
     int idSet = -1;
     if (!details.m_strSet.empty())
     {
-	  idSet = AddSet(details.m_strSet);
+      idSet = AddSet(details.m_strSet);
       map<string, string> setArt;
 
-	  if (GetArtForItem(idSet, "set", setArt))
-	  {
-		  for (map<string, string>::const_iterator i = details.m_setArt.begin(); i != details.m_setArt.end(); ++i)
-		  {
-			  if (!setArt[i->first].empty())
-			  {
-				  if (isMovieSetArtwork(details.m_strSet, i->first, i->second) && !isMovieSetArtwork(details.m_strSet, i->first, setArt[i->first]))
-				  {
-			  	     CLog::Log(LOGDEBUG, "VideoDatabase: Movie Set '%s' %s: Replaced %s with %s", details.m_strSet.c_str(), i->first.c_str(), setArt[i->first].c_str(), i->second.c_str());
-					 SetArtForItem(idSet, "set", i->first, i->second);
-				  }
-			  }
-			  else
-				SetArtForItem(idSet, "set", i->first, i->second);
-		  }
-	  }
-	  else if(!details.m_setArt.empty())
-	  {
+      if (GetArtForItem(idSet, "set", setArt))
+      {
+        // artwork exists, so check if the new art is set related and overwrite where the current is not, i.e. was taken from the (first) movie
+        for (map<string, string>::const_iterator i = details.m_setArt.begin(); i != details.m_setArt.end(); ++i)
+        {
+          if (!setArt[i->first].empty())
+          {
+            if (isMovieSetArtwork(details.m_strSet, i->first, i->second) && !isMovieSetArtwork(details.m_strSet, i->first, setArt[i->first]))
+            {
+              CLog::Log(LOGDEBUG, "VideoDatabase: Movie Set '%s' %s: Replaced %s with %s", details.m_strSet.c_str(), i->first.c_str(), setArt[i->first].c_str(), i->second.c_str());
+              SetArtForItem(idSet, "set", i->first, i->second);
+            }
+          }
+          else
+            SetArtForItem(idSet, "set", i->first, i->second);
+        }
+      }
+      else
         SetArtForItem(idSet, "set", details.m_setArt);
-	  }
-	  else
-        SetArtForItem(idSet, "set", artwork);
-	}
+    }
 
     // add tags...
     for (unsigned int i = 0; i < details.m_tags.size(); i++)
@@ -3709,16 +3706,15 @@ void CVideoDatabase::SetVideoSettings(const CStdString& strFilenameAndPath, cons
   }
 }
 
-
 bool CVideoDatabase::isMovieSetArtwork(const string &setName, const string &mediaType, const string &mediaFile)
 {
-	CStdString setImage = URIUtils::GetFileName(mediaFile);
-	URIUtils::RemoveExtension(setImage);
+  CStdString setImage = URIUtils::GetFileName(mediaFile);
+  URIUtils::RemoveExtension(setImage);
 
-	if ((setImage == mediaType) || setImage == "set-" + mediaType || setImage == setName + "-" + mediaType)
-		return true;
+  if ((setImage == mediaType) || setImage == setName + "-" + mediaType)
+    return true;
 
-	return false;
+  return false;
 }
 
 void CVideoDatabase::SetArtForItem(int mediaId, const string &mediaType, const map<string, string> &art)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -683,6 +683,8 @@ public:
     }
   }
 
+  bool CVideoDatabase::isMovieSetArtwork(const std::string &setName, const std::string &mediaType, const std::string &mediaFile);
+
   void SetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType, const std::string &url);
   void SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art);
   bool GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -683,8 +683,7 @@ public:
     }
   }
 
-  bool CVideoDatabase::isMovieSetArtwork(const std::string &setName, const std::string &mediaType, const std::string &mediaFile);
-
+  bool isMovieSetArtwork(const std::string &setName, const std::string &mediaType, const std::string &mediaFile);
   void SetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType, const std::string &url);
   void SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art);
   bool GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1083,60 +1083,52 @@ namespace VIDEO
       if (!strTrailer.IsEmpty())
         movieDetails.m_strTrailer = strTrailer;
 
-	  // BEGIN: Look for set artwork
-	  if (!movieDetails.m_strSet.empty() && useLocal)
+      // BEGIN: Look for set artwork
+      if (!movieDetails.m_strSet.empty() && useLocal)
       {
-	      CLog::Log(LOGDEBUG, "VideoInfoScanner: Locate artwork for movie set '%s'", movieDetails.m_strSet.c_str());
-		  std::string image;
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Locate artwork for movie set '%s'", movieDetails.m_strSet.c_str());
+        std::string image;
 
-		  // Check movie folder itself for set artwork
-		  if (movieDetails.m_setArt["poster"].empty() || movieDetails.m_setArt["poster"].compare(art["poster"]))
-		  {
-			  image = CVideoThumbLoader::GetLocalArt(*pItem, "set-poster", true);
-			  if (image.empty())
-	  		      image = CVideoThumbLoader::GetLocalArt(*pItem, movieDetails.m_strSet + "-poster", true);
-			  movieDetails.m_setArt["poster"] = (!image.empty()) ? image : (!movieDetails.m_setArt["poster"].empty()) ? movieDetails.m_setArt["poster"] : art["poster"];
-		  }
+        // Check movie folder itself for set artwork, <set name>-poster.jpg|png and <set name>-fanart.jpg|png
+        if (movieDetails.m_setArt["poster"].empty() || movieDetails.m_setArt["poster"].compare(art["poster"]))
+        {
+          image = CVideoThumbLoader::GetLocalArt(*pItem, movieDetails.m_strSet + "-poster", true);
+          movieDetails.m_setArt["poster"] = (!image.empty()) ? image : (!movieDetails.m_setArt["poster"].empty()) ? movieDetails.m_setArt["poster"] : art["poster"];
+        }
 
-		  if (movieDetails.m_setArt["fanart"].empty() || movieDetails.m_setArt["fanart"].compare(art["fanart"]))
-		  {
-			  image = CVideoThumbLoader::GetLocalArt(*pItem, "set-fanart", true);
-			  if (image.empty())
-	  		      image = CVideoThumbLoader::GetLocalArt(*pItem, movieDetails.m_strSet + "-fanart", true);
-			  movieDetails.m_setArt["fanart"] = (!image.empty()) ? image : (!movieDetails.m_setArt["fanart"].empty()) ? movieDetails.m_setArt["fanart"] : art["fanart"];
-		  }
+        if (movieDetails.m_setArt["fanart"].empty() || movieDetails.m_setArt["fanart"].compare(art["fanart"]))
+        {
+          image = CVideoThumbLoader::GetLocalArt(*pItem, movieDetails.m_strSet + "-fanart", true);
+          movieDetails.m_setArt["fanart"] = (!image.empty()) ? image : (!movieDetails.m_setArt["fanart"].empty()) ? movieDetails.m_setArt["fanart"] : art["fanart"];
+        }
 
-		  // Check parent folder for set artwork
-		  if (pItem->m_idepth >= 1)
-		  {
-			  CStdString setPath = URIUtils::GetParentPath(movieDetails.m_basePath);
-			  URIUtils::RemoveSlashAtEnd(setPath);
-			  CStdString setPathName = URIUtils::GetFileName(setPath);
+        // Check parent folder for set artwork, poster.jpg|png and folder.jpg|png
+        if (pItem->m_idepth >= 1)
+        {
+          CStdString setPath = URIUtils::GetParentPath(movieDetails.m_basePath);
+          URIUtils::RemoveSlashAtEnd(setPath);
+          CStdString setPathName = URIUtils::GetFileName(setPath);
 
-  			  if (movieDetails.m_strSet.Compare(setPathName) || setPathName.Compare(movieDetails.m_strSet.Left(setPathName.length())))
-			  {
-				 CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s', fuzzy name match with parent path: %s", movieDetails.m_strSet.c_str(), setPathName.c_str());
-				 CFileItemPtr parent(new CFileItem(setPath, true));
+          if (movieDetails.m_strSet.Compare(setPathName) || setPathName.Compare(movieDetails.m_strSet.Left(setPathName.length())))
+          {
+            CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s', fuzzy name match with parent path: %s", movieDetails.m_strSet.c_str(), setPathName.c_str());
+            CFileItemPtr parent(new CFileItem(setPath, true));
 
- 				 std::string image = CVideoThumbLoader::GetLocalArt(*parent, "poster", true);
-				 if (image.empty())
-			        image = CVideoThumbLoader::GetLocalArt(*parent, movieDetails.m_strSet + "-poster", true);
-				 if (!image.empty())
-					movieDetails.m_setArt["poster"] = image;
+            image = CVideoThumbLoader::GetLocalArt(*parent, "poster", true);
+            if (!image.empty())
+              movieDetails.m_setArt["poster"] = image;
 
- 				 image = CVideoThumbLoader::GetLocalArt(*parent, "fanart", true);
-				 if (image.empty())
-			        image = CVideoThumbLoader::GetLocalArt(*parent, movieDetails.m_strSet + "-fanart", true);
-				 if (!image.empty())
-					movieDetails.m_setArt["fanart"] = image;
-			  }
-		  }
+            image = CVideoThumbLoader::GetLocalArt(*parent, "fanart", true);
+            if (!image.empty())
+              movieDetails.m_setArt["fanart"] = image;
+          }
+        }
 
-	      CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s' Poster: %s", movieDetails.m_strSet.c_str(), movieDetails.m_setArt["poster"].c_str());
-	      CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s' Fanart: %s", movieDetails.m_strSet.c_str(), movieDetails.m_setArt["fanart"].c_str());
-	  }  
-	  // END: Look for set artwork
-	  
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s' Poster: %s", movieDetails.m_strSet.c_str(), movieDetails.m_setArt["poster"].c_str());
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s' Fanart: %s", movieDetails.m_strSet.c_str(), movieDetails.m_setArt["fanart"].c_str());
+      }  
+      // END: Look for set artwork
+
       lResult = m_database.SetDetailsForMovie(pItem->GetPath(), movieDetails, art);
       movieDetails.m_iDbId = lResult;
       movieDetails.m_type = "movie";

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1083,6 +1083,60 @@ namespace VIDEO
       if (!strTrailer.IsEmpty())
         movieDetails.m_strTrailer = strTrailer;
 
+	  // BEGIN: Look for set artwork
+	  if (!movieDetails.m_strSet.empty() && useLocal)
+      {
+	      CLog::Log(LOGDEBUG, "VideoInfoScanner: Locate artwork for movie set '%s'", movieDetails.m_strSet.c_str());
+		  std::string image;
+
+		  // Check movie folder itself for set artwork
+		  if (movieDetails.m_setArt["poster"].empty() || movieDetails.m_setArt["poster"].compare(art["poster"]))
+		  {
+			  image = CVideoThumbLoader::GetLocalArt(*pItem, "set-poster", true);
+			  if (image.empty())
+	  		      image = CVideoThumbLoader::GetLocalArt(*pItem, movieDetails.m_strSet + "-poster", true);
+			  movieDetails.m_setArt["poster"] = (!image.empty()) ? image : (!movieDetails.m_setArt["poster"].empty()) ? movieDetails.m_setArt["poster"] : art["poster"];
+		  }
+
+		  if (movieDetails.m_setArt["fanart"].empty() || movieDetails.m_setArt["fanart"].compare(art["fanart"]))
+		  {
+			  image = CVideoThumbLoader::GetLocalArt(*pItem, "set-fanart", true);
+			  if (image.empty())
+	  		      image = CVideoThumbLoader::GetLocalArt(*pItem, movieDetails.m_strSet + "-fanart", true);
+			  movieDetails.m_setArt["fanart"] = (!image.empty()) ? image : (!movieDetails.m_setArt["fanart"].empty()) ? movieDetails.m_setArt["fanart"] : art["fanart"];
+		  }
+
+		  // Check parent folder for set artwork
+		  if (pItem->m_idepth >= 1)
+		  {
+			  CStdString setPath = URIUtils::GetParentPath(movieDetails.m_basePath);
+			  URIUtils::RemoveSlashAtEnd(setPath);
+			  CStdString setPathName = URIUtils::GetFileName(setPath);
+
+  			  if (movieDetails.m_strSet.Compare(setPathName) || setPathName.Compare(movieDetails.m_strSet.Left(setPathName.length())))
+			  {
+				 CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s', fuzzy name match with parent path: %s", movieDetails.m_strSet.c_str(), setPathName.c_str());
+				 CFileItemPtr parent(new CFileItem(setPath, true));
+
+ 				 std::string image = CVideoThumbLoader::GetLocalArt(*parent, "poster", true);
+				 if (image.empty())
+			        image = CVideoThumbLoader::GetLocalArt(*parent, movieDetails.m_strSet + "-poster", true);
+				 if (!image.empty())
+					movieDetails.m_setArt["poster"] = image;
+
+ 				 image = CVideoThumbLoader::GetLocalArt(*parent, "fanart", true);
+				 if (image.empty())
+			        image = CVideoThumbLoader::GetLocalArt(*parent, movieDetails.m_strSet + "-fanart", true);
+				 if (!image.empty())
+					movieDetails.m_setArt["fanart"] = image;
+			  }
+		  }
+
+	      CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s' Poster: %s", movieDetails.m_strSet.c_str(), movieDetails.m_setArt["poster"].c_str());
+	      CLog::Log(LOGDEBUG, "VideoInfoScanner: Movie Set '%s' Fanart: %s", movieDetails.m_strSet.c_str(), movieDetails.m_setArt["fanart"].c_str());
+	  }  
+	  // END: Look for set artwork
+	  
       lResult = m_database.SetDetailsForMovie(pItem->GetPath(), movieDetails, art);
       movieDetails.m_iDbId = lResult;
       movieDetails.m_type = "movie";

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -107,7 +107,7 @@ public:
   typedef std::vector< SActorInfo >::const_iterator iCast;
   CStdString m_strSet;
   int m_iSetId;
-  std::map<std::string, std::string> m_setArt;
+  std::map<std::string, std::string> m_setArt;  // Movie set artwork
   std::vector<std::string> m_tags;
   CStdString m_strFile;
   CStdString m_strPath;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -107,6 +107,7 @@ public:
   typedef std::vector< SActorInfo >::const_iterator iCast;
   CStdString m_strSet;
   int m_iSetId;
+  std::map<std::string, std::string> m_setArt;
   std::vector<std::string> m_tags;
   CStdString m_strFile;
   CStdString m_strPath;


### PR DESCRIPTION
Movie Set Artwork Scan, simplified and tidied code.

Checks for a [Set Name]-poster.jpg|png and a [Set Name]-fanart.jpg|png inside
the folder where a movie resides (so will pick up set art in a flat structure) also
if the movie resides in a common folder where the folder is named similar to the
set name, it will check for a poster.jpg|png and a fanart.jpg.png.
