### PR TITLE
Change SoftAEStream to use a RingBuffer

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -30,6 +30,7 @@
 
 #include "Interfaces/ThreadedAE.h"
 #include "Utils/AEBuffer.h"
+#include "Utils/AERingBuffer.h"
 #include "AEAudioFormat.h"
 #include "AESinkFactory.h"
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
@@ -29,6 +29,7 @@
 #include "Utils/AEConvert.h"
 #include "Utils/AERemap.h"
 #include "Utils/AEBuffer.h"
+#include "Utils/AERingBuffer.h"
 #include "Utils/AELimiter.h"
 
 class IAEPostProc;
@@ -122,7 +123,7 @@ private:
 
   CAEConvert::AEConvertToFn m_convertFn;
 
-  CAEBuffer           m_inputBuffer;
+  CAERingBuffer       m_inputBuffer;
   unsigned int        m_bytesPerSample;
   unsigned int        m_bytesPerFrame;
   unsigned int        m_samplesPerFrame;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -301,7 +301,7 @@ void CAESinkAUDIOTRACK::Process()
   m_audiotrack_empty_sec = 0.0;
 
   // setup a 1/4 second internal sink lockless ring buffer
-  m_sinkbuffer = new AERingBuffer(m_sink_frameSize * m_format.m_sampleRate / 4);
+  m_sinkbuffer = new CAERingBuffer(m_sink_frameSize * m_format.m_sampleRate / 4);
   m_sinkbuffer_sec_per_byte = 1.0 / (double)(m_sink_frameSize * m_format.m_sampleRate);
   m_sinkbuffer_sec = (double)m_sinkbuffer_sec_per_byte * m_sinkbuffer->GetMaxSize();
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -22,7 +22,7 @@
 #include "Interfaces/AESink.h"
 #include "Utils/AEDeviceInfo.h"
 
-class AERingBuffer;
+class CAERingBuffer;
 
 class CAESinkAUDIOTRACK : public CThread, public IAESink
 {
@@ -54,7 +54,7 @@ private:
   bool               m_volume_changed;
   volatile int       m_min_frames;
   int16_t           *m_alignedS16LE;
-  AERingBuffer      *m_sinkbuffer;
+  CAERingBuffer     *m_sinkbuffer;
   unsigned int       m_sink_frameSize;
   double             m_sinkbuffer_sec;
   double             m_sinkbuffer_sec_per_byte;

--- a/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
+++ b/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
@@ -209,9 +209,10 @@ public:
    */
   void Dump()
   {
-    unsigned char* bufferContents =  (unsigned char *)_aligned_malloc(m_iSize + 1,16);
-    for (unsigned int i=0; i<m_iSize; i++) {
-      if (i >= m_iReadPos && i<m_iWritePos)
+    unsigned char* bufferContents = (unsigned char *)_aligned_malloc(m_iSize + 1, 16);
+    for (unsigned int i = 0; i < m_iSize; i++)
+    {
+      if (i >= m_iReadPos && i < m_iWritePos)
         bufferContents[i] = m_Buffer[i];
       else
         bufferContents[i] = '_';
@@ -248,10 +249,10 @@ public:
   }
 
 private:
-  unsigned int m_iReadPos;
-  unsigned int m_iWritePos;
-  unsigned int m_iRead;
-  unsigned int m_iWritten;
-  unsigned int m_iSize;
+  unsigned int   m_iReadPos;
+  unsigned int   m_iWritePos;
+  unsigned int   m_iRead;
+  unsigned int   m_iWritten;
+  unsigned int   m_iSize;
   unsigned char *m_Buffer;
 };

--- a/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
+++ b/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
@@ -35,10 +35,10 @@
  * If you intend to call the Reset() method, please use Locks.
  * All other operations are thread-safe.
  */
-class AERingBuffer {
+class CAERingBuffer {
 
 public:
-  AERingBuffer() :
+  CAERingBuffer() :
     m_iReadPos(0),
     m_iWritePos(0),
     m_iRead(0),
@@ -48,7 +48,7 @@ public:
   {
   }
 
-  AERingBuffer(unsigned int size) :
+  CAERingBuffer(unsigned int size) :
     m_iReadPos(0),
     m_iWritePos(0),
     m_iRead(0),
@@ -59,10 +59,10 @@ public:
     Create(size);
   }
 
-  ~AERingBuffer()
+  ~CAERingBuffer()
   {
 #ifdef AE_RING_BUFFER_DEBUG
-    CLog::Log(LOGDEBUG, "AERingBuffer::~AERingBuffer: Deleting buffer.");
+    CLog::Log(LOGDEBUG, "CAERingBuffer::~CAERingBuffer: Deleting buffer.");
 #endif
     _aligned_free(m_Buffer);
   }
@@ -91,7 +91,7 @@ public:
    */
   void Reset() {
 #ifdef AE_RING_BUFFER_DEBUG
-    CLog::Log(LOGDEBUG, "AERingBuffer::Reset: Buffer reset.");
+    CLog::Log(LOGDEBUG, "CAERingBuffer::Reset: Buffer reset.");
 #endif
     m_iWritten = 0;
     m_iRead = 0;
@@ -112,7 +112,7 @@ public:
     //do we have enough space for all the data?
     if (size > space) {
 #ifdef AE_RING_BUFFER_DEBUG
-    CLog::Log(LOGDEBUG, "AERingBuffer: Not enough space, ignoring data. Requested: %u Available: %u",size, space);
+    CLog::Log(LOGDEBUG, "CAERingBuffer: Not enough space, ignoring data. Requested: %u Available: %u",size, space);
 #endif
       return AE_RING_BUFFER_FULL;
     }
@@ -121,7 +121,7 @@ public:
     if ( m_iSize > size + m_iWritePos )
     {
 #ifdef AE_RING_BUFFER_DEBUG
-      CLog::Log(LOGDEBUG, "AERingBuffer: Written to: %u size: %u space before: %u\n", m_iWritePos, size, space);
+      CLog::Log(LOGDEBUG, "CAERingBuffer: Written to: %u size: %u space before: %u\n", m_iWritePos, size, space);
 #endif
       memcpy(&(m_Buffer[m_iWritePos]), src, size);
       m_iWritePos+=size;
@@ -132,7 +132,7 @@ public:
       unsigned int first = m_iSize - m_iWritePos;
       unsigned int second = size - first;
 #ifdef AE_RING_BUFFER_DEBUG
-      CLog::Log(LOGDEBUG, "AERingBuffer: Written to (split) first: %u second: %u size: %u space before: %u\n", first, second, size, space);
+      CLog::Log(LOGDEBUG, "CAERingBuffer: Written to (split) first: %u second: %u size: %u space before: %u\n", first, second, size, space);
 #endif
       memcpy(&(m_Buffer[m_iWritePos]), src, first);
       memcpy(&(m_Buffer[0]), &src[first], second);
@@ -159,7 +159,7 @@ public:
     if( space <= 0 )
     {
 #ifdef AE_RING_BUFFER_DEBUG
-      CLog::Log(LOGDEBUG, "AERingBuffer: Can't read from empty buffer.");
+      CLog::Log(LOGDEBUG, "CAERingBuffer: Can't read from empty buffer.");
 #endif
       return AE_RING_BUFFER_EMPTY;
     }
@@ -168,7 +168,7 @@ public:
     if( size > space )
     {
 #ifdef AE_RING_BUFFER_DEBUG
-      CLog::Log(LOGDEBUG, "AERingBuffer: Can't read %u bytes when we only have %u.", size, space);
+      CLog::Log(LOGDEBUG, "CAERingBuffer: Can't read %u bytes when we only have %u.", size, space);
 #endif
       return AE_RING_BUFFER_NOTAVAILABLE;
     }
@@ -189,7 +189,7 @@ public:
       unsigned int first = m_iSize - m_iReadPos;
       unsigned int second = size - first;
 #ifdef AE_RING_BUFFER_DEBUG
-      CLog::Log(LOGDEBUG, "AERingBuffer: Reading from (split) first: %u second: %u size: %u space before: %u\n", first, second, size, space);
+      CLog::Log(LOGDEBUG, "CAERingBuffer: Reading from (split) first: %u second: %u size: %u space before: %u\n", first, second, size, space);
 #endif
       if (dest)
       {
@@ -217,7 +217,7 @@ public:
         bufferContents[i] = '_';
     }
     bufferContents[m_iSize] = '\0';
-    CLog::Log(LOGDEBUG, "AERingBuffer::Dump()\n%s",bufferContents);
+    CLog::Log(LOGDEBUG, "CAERingBuffer::Dump()\n%s", bufferContents);
     _aligned_free(bufferContents);
   }
 


### PR DESCRIPTION
This PR changes SoftAEStream to use a ring buffer instead of a flat buffer for the input buffer, this should improve performance as it avoids additional memmoves. Needs some profiling and testing to confirm on lower performance systems.
