### PR TITLE
Settings API: allow conditional levels

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -964,6 +964,7 @@
     <ClCompile Include="..\..\xbmc\settings\SettingConditions.cpp" />
     <ClCompile Include="..\..\xbmc\settings\SettingControl.cpp" />
     <ClCompile Include="..\..\xbmc\settings\SettingDependency.cpp" />
+    <ClCompile Include="..\..\xbmc\settings\SettingLevel.cpp" />
     <ClCompile Include="..\..\xbmc\settings\SettingPath.cpp" />
     <ClCompile Include="..\..\xbmc\settings\Settings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\SettingSection.cpp" />
@@ -1143,6 +1144,7 @@
     <ClInclude Include="..\..\xbmc\settings\SettingConditions.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingControl.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingDependency.h" />
+    <ClInclude Include="..\..\xbmc\settings\SettingLevel.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingPath.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingSection.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingsManager.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3030,6 +3030,9 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.cpp">
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\settings\SettingLevel.cpp">
+      <Filter>settings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5932,6 +5935,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.h">
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\settings\SettingLevel.h">
+      <Filter>settings</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/settings/Makefile
+++ b/xbmc/settings/Makefile
@@ -9,6 +9,7 @@ SRCS=AdvancedSettings.cpp \
      SettingConditions.cpp \
      SettingControl.cpp \
      SettingDependency.cpp \
+     SettingLevel.cpp \
      SettingPath.cpp \
      SettingSection.cpp \
      Settings.cpp \

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -40,6 +40,7 @@ CSetting::CSetting(const std::string &id, CSettingsManager *settingsManager /* =
   : ISetting(id, settingsManager),
     m_callback(NULL),
     m_label(-1), m_help(-1),
+    m_level(settingsManager),
     m_changed(false)
 { }
   
@@ -47,6 +48,7 @@ CSetting::CSetting(const std::string &id, const CSetting &setting)
   : ISetting(id, setting.m_settingsManager),
     m_callback(NULL),
     m_label(-1), m_help(-1),
+    m_level(setting.m_settingsManager),
     m_changed(false)
 {
   m_id = id;
@@ -80,7 +82,7 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   }
   else if ((levels = node->FirstChild(XML_ELM_LEVELS)) != NULL)
   {
-    if (!m_level.Deserialize(levels, m_settingsManager))
+    if (!m_level.Deserialize(levels))
       CLog::Log(LOGWARNING, "CSetting: error reading <%s> tag of \"%s\"", XML_ELM_LEVELS, m_id.c_str());
   }
 

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -73,23 +73,15 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   // get the <level> or <levels> tag
   int level = -1;
   const TiXmlNode *levels;
-  if (XMLUtils::GetInt(node, XML_ELM_LEVEL, level))
+  m_level.SetLevel(SETTINGS_LEVEL_DEFAULT);
+  if (XMLUtils::GetInt(node, XML_ELM_LEVEL, level) && SettingLevelBasic <= level && level <= SettingLevelInternal)
   {
-    if (level < SettingLevelBasic || level > SettingLevelInternal)
-      level = SETTINGS_LEVEL_DEFAULT;
     m_level.SetLevel((SettingLevel)level);
   }
   else if ((levels = node->FirstChild(XML_ELM_LEVELS)) != NULL)
   {
     if (!m_level.Deserialize(levels, m_settingsManager))
-    {
       CLog::Log(LOGWARNING, "CSetting: error reading <%s> tag of \"%s\"", XML_ELM_LEVELS, m_id.c_str());
-      m_level.SetLevel(SETTINGS_LEVEL_DEFAULT);
-    }
-  }
-  else
-  {
-    m_level.SetLevel(SETTINGS_LEVEL_DEFAULT);
   }
 
   const TiXmlElement *control = node->FirstChildElement("control");

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -27,7 +27,6 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 
-#define XML_ELM_LEVEL       "level"
 #define XML_ELM_DEFAULT     "default"
 #define XML_ELM_VALUE       "value"
 
@@ -41,7 +40,6 @@ CSetting::CSetting(const std::string &id, CSettingsManager *settingsManager /* =
   : ISetting(id, settingsManager),
     m_callback(NULL),
     m_label(-1), m_help(-1),
-    m_level(SettingLevelStandard),
     m_changed(false)
 { }
   
@@ -49,7 +47,6 @@ CSetting::CSetting(const std::string &id, const CSetting &setting)
   : ISetting(id, setting.m_settingsManager),
     m_callback(NULL),
     m_label(-1), m_help(-1),
-    m_level(SettingLevelStandard),
     m_changed(false)
 {
   m_id = id;
@@ -73,13 +70,27 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (element->QueryIntAttribute(XML_ATTR_HELP, &m_help) == TIXML_SUCCESS && tmp > 0)
     m_help = tmp;
 
-  // get the <level>
+  // get the <level> or <levels> tag
   int level = -1;
+  const TiXmlNode *levels;
   if (XMLUtils::GetInt(node, XML_ELM_LEVEL, level))
-    m_level = (SettingLevel)level;
-    
-  if (m_level < (int)SettingLevelBasic || m_level > (int)SettingLevelInternal)
-    m_level = SettingLevelStandard;
+  {
+    if (level < SettingLevelBasic || level > SettingLevelInternal)
+      level = SETTINGS_LEVEL_DEFAULT;
+    m_level.SetLevel((SettingLevel)level);
+  }
+  else if ((levels = node->FirstChild(XML_ELM_LEVELS)) != NULL)
+  {
+    if (!m_level.Deserialize(levels, m_settingsManager))
+    {
+      CLog::Log(LOGWARNING, "CSetting: error reading <%s> tag of \"%s\"", XML_ELM_LEVELS, m_id.c_str());
+      m_level.SetLevel(SETTINGS_LEVEL_DEFAULT);
+    }
+  }
+  else
+  {
+    m_level.SetLevel(SETTINGS_LEVEL_DEFAULT);
+  }
 
   const TiXmlElement *control = node->FirstChildElement("control");
   if (control != NULL)

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -28,6 +28,7 @@
 #include "ISettingCallback.h"
 #include "SettingControl.h"
 #include "SettingDependency.h"
+#include "SettingLevel.h"
 #include "SettingUpdate.h"
 #include "threads/CriticalSection.h"
 
@@ -39,14 +40,6 @@ typedef enum {
   SettingTypeString,
   SettingTypeAction
 } SettingType;
-
-typedef enum {
-  SettingLevelBasic  = 0,
-  SettingLevelStandard,
-  SettingLevelAdvanced,
-  SettingLevelExpert,
-  SettingLevelInternal
-} SettingLevel;
 
 typedef std::pair<int, int> SettingOption;
 typedef std::vector<SettingOption> SettingOptions;
@@ -70,7 +63,7 @@ public:
 
   int GetLabel() const { return m_label; }
   int GetHelp() const { return m_help; }
-  SettingLevel GetLevel() const { return m_level; }
+  SettingLevel GetLevel() const { return m_level.GetLevel(); }
   const CSettingControl& GetControl() const { return m_control; }
   const SettingDependencies& GetDependencies() const { return m_dependencies; }
   const std::set<CSettingUpdate>& GetUpdates() const { return m_updates; }
@@ -88,7 +81,7 @@ protected:
   ISettingCallback *m_callback;
   int m_label;
   int m_help;
-  SettingLevel m_level;
+  CSettingLevel m_level;
   CSettingControl m_control;
   SettingDependencies m_dependencies;
   std::set<CSettingUpdate> m_updates;

--- a/xbmc/settings/SettingLevel.cpp
+++ b/xbmc/settings/SettingLevel.cpp
@@ -1,0 +1,125 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "SettingLevel.h"
+#include "SettingsManager.h"
+#include "utils/log.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <algorithm>
+
+#define XML_ATTR_DEFAULT   "default"
+#define XML_ATTR_VALUE     "value"
+
+using namespace std;
+
+bool CSettingLevelCondition::Check() const
+{
+  if (m_settingsManager == NULL)
+    return false;
+
+  bool found = m_settingsManager->GetConditions().Check("IsDefined", m_value);
+  if (m_negated)
+    return !found;
+
+  return found;
+}
+
+CLevelCondition::CLevelCondition(CSettingsManager *settingsManager /* = NULL */)
+  : CSettingCondition(settingsManager), m_level(SETTINGS_LEVEL_DEFAULT)
+{
+  m_operation = CBooleanLogicOperationPtr(new CSettingLevelConditionCombination(m_settingsManager));
+}
+
+CLevelCondition::CLevelCondition(const CLevelCondition &rhs)
+  : CSettingCondition(rhs.m_settingsManager), m_level(rhs.m_level)
+{
+  m_operation = rhs.m_operation;
+}
+
+bool CLevelCondition::Deserialize(const TiXmlNode *node)
+{
+  if (node == NULL)
+    return false;
+
+  const TiXmlElement *element = node->ToElement();
+  if (element == NULL)
+    return false;
+
+  // get the level this condition is intended for
+  int level = -1;
+  if (element->QueryIntAttribute(XML_ATTR_VALUE, &level) != TIXML_SUCCESS || !(0 <= level && level <= SettingLevelInternal))
+    return false;
+
+  if (!CSettingCondition::Deserialize(node))
+    return false;
+
+  m_level = (SettingLevel)level;
+  return true;
+}
+
+CSettingLevel::CSettingLevel()
+  : m_default(SETTINGS_LEVEL_DEFAULT)
+{ }
+
+bool CSettingLevel::Deserialize(const TiXmlNode *node, CSettingsManager *settingsManager /* = NULL */)
+{
+  if (node == NULL)
+    return false;
+
+  const TiXmlElement *element = node->ToElement();
+  if (element == NULL)
+    return false;
+
+  // get the default level
+  int def_lvl = -1;
+  if (element->QueryIntAttribute(XML_ATTR_DEFAULT, &def_lvl) != TIXML_SUCCESS || def_lvl < 0)
+    return false;
+
+  // traverse <level> tags
+  vector<CLevelCondition> vec_lvl;
+  const TiXmlElement *level = node->FirstChildElement(XML_ELM_LEVEL);
+  while (level != NULL)
+  {
+    CLevelCondition levelCondition(settingsManager);
+    if (!levelCondition.Deserialize(level))
+      return false;
+    vec_lvl.push_back(levelCondition);
+    level = level->NextSiblingElement(XML_ELM_LEVEL);
+  }
+
+  m_default = std::min((SettingLevel)def_lvl, SettingLevelInternal);
+  m_levelConditions = vec_lvl;
+  return true;
+}
+
+void CSettingLevel::SetLevel(SettingLevel level)
+{
+  m_default = level;
+  m_levelConditions.clear();
+}
+
+SettingLevel CSettingLevel::GetLevel() const
+{
+  for (vector<CLevelCondition>::const_iterator it = m_levelConditions.begin(); it != m_levelConditions.end(); ++it)
+    if (it->Check())
+      return it->GetLevel();
+  return m_default;
+}

--- a/xbmc/settings/SettingLevel.cpp
+++ b/xbmc/settings/SettingLevel.cpp
@@ -65,7 +65,8 @@ bool CLevelCondition::Deserialize(const TiXmlNode *node)
 
   // get the level this condition is intended for
   int level = -1;
-  if (element->QueryIntAttribute(XML_ATTR_VALUE, &level) != TIXML_SUCCESS || !(0 <= level && level <= SettingLevelInternal))
+  if (element->QueryIntAttribute(XML_ATTR_VALUE, &level) != TIXML_SUCCESS ||
+        level < SettingLevelBasic || level > SettingLevelInternal)
     return false;
 
   if (!CSettingCondition::Deserialize(node))

--- a/xbmc/settings/SettingLevel.cpp
+++ b/xbmc/settings/SettingLevel.cpp
@@ -120,7 +120,9 @@ void CSettingLevel::SetLevel(SettingLevel level)
 SettingLevel CSettingLevel::GetLevel() const
 {
   for (vector<CLevelCondition>::const_iterator it = m_levelConditions.begin(); it != m_levelConditions.end(); ++it)
+  {
     if (it->Check())
       return it->GetLevel();
+  }
   return m_default;
 }

--- a/xbmc/settings/SettingLevel.cpp
+++ b/xbmc/settings/SettingLevel.cpp
@@ -75,11 +75,11 @@ bool CLevelCondition::Deserialize(const TiXmlNode *node)
   return true;
 }
 
-CSettingLevel::CSettingLevel()
-  : m_default(SETTINGS_LEVEL_DEFAULT)
+CSettingLevel::CSettingLevel(CSettingsManager *settingsManager /* = NULL */)
+  : m_default(SETTINGS_LEVEL_DEFAULT), m_settingsManager(settingsManager)
 { }
 
-bool CSettingLevel::Deserialize(const TiXmlNode *node, CSettingsManager *settingsManager /* = NULL */)
+bool CSettingLevel::Deserialize(const TiXmlNode *node)
 {
   if (node == NULL)
     return false;
@@ -98,7 +98,7 @@ bool CSettingLevel::Deserialize(const TiXmlNode *node, CSettingsManager *setting
   const TiXmlElement *level = node->FirstChildElement(XML_ELM_LEVEL);
   while (level != NULL)
   {
-    CLevelCondition levelCondition(settingsManager);
+    CLevelCondition levelCondition(m_settingsManager);
     if (!levelCondition.Deserialize(level))
       return false;
     vec_lvl.push_back(levelCondition);

--- a/xbmc/settings/SettingLevel.h
+++ b/xbmc/settings/SettingLevel.h
@@ -80,10 +80,10 @@ private:
 class CSettingLevel
 {
 public:
-  CSettingLevel();
+  CSettingLevel(CSettingsManager *settingsManager = NULL);
   virtual ~CSettingLevel() { }
 
-  virtual bool Deserialize(const TiXmlNode *node, CSettingsManager *settingsManager = NULL);
+  virtual bool Deserialize(const TiXmlNode *node);
 
   /**
    * Alternative, simplified deserialization method, where only a default level
@@ -101,4 +101,5 @@ public:
 private:
   SettingLevel m_default;
   std::vector<CLevelCondition> m_levelConditions;
+  CSettingsManager *m_settingsManager;
 };

--- a/xbmc/settings/SettingLevel.h
+++ b/xbmc/settings/SettingLevel.h
@@ -1,0 +1,104 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "SettingConditions.h"
+
+#include <vector>
+
+#define SETTINGS_LEVEL_DEFAULT  SettingLevelStandard
+
+#define XML_ELM_LEVEL           "level"
+#define XML_ELM_LEVELS          "levels"
+
+class TiXmlNode;
+
+typedef enum {
+  SettingLevelBasic  = 0,
+  SettingLevelStandard,
+  SettingLevelAdvanced,
+  SettingLevelExpert,
+  SettingLevelInternal
+} SettingLevel;
+
+class CSettingLevelCondition : public CSettingConditionItem
+{
+public:
+  CSettingLevelCondition(CSettingsManager *settingsManager = NULL)
+    : CSettingConditionItem(settingsManager)
+  { }
+  virtual ~CSettingLevelCondition() { }
+
+  virtual bool Check() const;
+};
+
+class CSettingLevelConditionCombination : public CSettingConditionCombination
+{
+public:
+  CSettingLevelConditionCombination(CSettingsManager *settingsManager = NULL)
+    : CSettingConditionCombination(settingsManager)
+  { }
+  virtual ~CSettingLevelConditionCombination() { }
+
+protected:
+  virtual CBooleanLogicOperation* newOperation() { return new CSettingLevelConditionCombination(m_settingsManager); }
+  virtual CBooleanLogicValue* newValue() { return new CSettingLevelCondition(m_settingsManager); }
+};
+
+class CLevelCondition : public CSettingCondition
+{
+public:
+  CLevelCondition(CSettingsManager *settingsManager = NULL);
+  CLevelCondition(const CLevelCondition &rhs);
+  virtual ~CLevelCondition() { }
+
+  virtual bool Deserialize(const TiXmlNode *node);
+
+  SettingLevel GetLevel() const { return m_level; }
+
+private:
+  SettingLevel m_level;
+};
+
+class CSettingLevel
+{
+public:
+  CSettingLevel();
+  virtual ~CSettingLevel() { }
+
+  virtual bool Deserialize(const TiXmlNode *node, CSettingsManager *settingsManager = NULL);
+
+  /**
+   * Alternative, simplified deserialization method, where only a default level
+   * is specified and no level conditions are needed.
+   */
+  void SetLevel(SettingLevel level);
+
+  /**
+   * For complex levels with conditions, this applies the level conditions in
+   * the order that the <level> tags appeared. If no <level> tags evaluate to
+   * true, the default level is returned.
+   */
+  SettingLevel GetLevel() const;
+
+private:
+  SettingLevel m_default;
+  std::vector<CLevelCondition> m_levelConditions;
+};


### PR DESCRIPTION
This PR enables settings levels to be conditional, in certain cases we may want the level to depend on an external factor. For example, we might assume that only advanced users would want to change a peripheral's settings from their default values when that device is unplugged. This should help with our settings levels matrix when a "one-size-fits-all" solution isn't appropriate for all HTPC setups and scenarios.

Settings level can either be a simple `<level>2</level>` tag or a more complex one (in this case evaluating to "1"):

```
<levels default="2">
    <level value="0">false</level>
    <level value="1">
        <and>
            <condition>true</condition>
            <or>
                <condition>false</condition>
                <condition>true</condition>
            </or>
        </and>
    </level>
</levels>
```

needs xcode project settings (only has Makefile and VS2010 project entries)
