### PR TITLE
move vdpau into hwaccel

### DIFF
--- a/lib/ffmpeg/libavcodec/mpeg12.c
+++ b/lib/ffmpeg/libavcodec/mpeg12.c
@@ -1202,6 +1202,7 @@ static const enum AVPixelFormat mpeg1_hwaccel_pixfmt_list_420[] = {
 #endif
 #if CONFIG_MPEG1_VDPAU_HWACCEL
     AV_PIX_FMT_VDPAU_MPEG1,
+    AV_PIX_FMT_VDPAU,
 #endif
     AV_PIX_FMT_YUV420P,
     AV_PIX_FMT_NONE
@@ -1214,6 +1215,7 @@ static const enum AVPixelFormat mpeg2_hwaccel_pixfmt_list_420[] = {
 #endif
 #if CONFIG_MPEG2_VDPAU_HWACCEL
     AV_PIX_FMT_VDPAU_MPEG2,
+    AV_PIX_FMT_VDPAU,
 #endif
 #if CONFIG_MPEG2_DXVA2_HWACCEL
     AV_PIX_FMT_DXVA2_VLD,

--- a/lib/ffmpeg/libavcodec/vdpau_vc1.c
+++ b/lib/ffmpeg/libavcodec/vdpau_vc1.c
@@ -59,7 +59,7 @@ static int vdpau_vc1_start_frame(AVCodecContext *avctx,
     else
         info->picture_type  = s->pict_type - 1 + s->pict_type / 3;
 
-    info->frame_coding_mode = v->fcm;
+    info->frame_coding_mode = v->fcm ? v->fcm + 1 : 0;
     info->postprocflag      = v->postprocflag;
     info->pulldown          = v->broadcast;
     info->interlace         = v->interlace;

--- a/lib/ffmpeg/patches/0036-backport-register-vdpau-hwaccel-for-mpeg12-fe1f36547d0be963e352de0cde1a6cba59ea2e78.patch
+++ b/lib/ffmpeg/patches/0036-backport-register-vdpau-hwaccel-for-mpeg12-fe1f36547d0be963e352de0cde1a6cba59ea2e78.patch
@@ -1,0 +1,32 @@
+From bb6ba57092c402b6f2e5edf6d1691beafafa0460 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Mon, 6 May 2013 20:58:28 +0200
+Subject: [PATCH] ffmpeg backport: register vdpau hwaccel for mpeg12
+
+---
+ libavcodec/mpeg12.c |    2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libavcodec/mpeg12.c b/libavcodec/mpeg12.c
+index 9d2743a..0f94772 100644
+--- a/libavcodec/mpeg12.c
++++ b/libavcodec/mpeg12.c
+@@ -1202,6 +1202,7 @@ static const enum AVPixelFormat mpeg1_hwaccel_pixfmt_list_420[] = {
+ #endif
+ #if CONFIG_MPEG1_VDPAU_HWACCEL
+     AV_PIX_FMT_VDPAU_MPEG1,
++    AV_PIX_FMT_VDPAU,
+ #endif
+     AV_PIX_FMT_YUV420P,
+     AV_PIX_FMT_NONE
+@@ -1214,6 +1215,7 @@ static const enum AVPixelFormat mpeg2_hwaccel_pixfmt_list_420[] = {
+ #endif
+ #if CONFIG_MPEG2_VDPAU_HWACCEL
+     AV_PIX_FMT_VDPAU_MPEG2,
++    AV_PIX_FMT_VDPAU,
+ #endif
+ #if CONFIG_MPEG2_DXVA2_HWACCEL
+     AV_PIX_FMT_DXVA2_VLD,
+-- 
+1.7.9.5
+

--- a/lib/ffmpeg/patches/0037-backport-fix-vdpau-vc1-interlace-modes-b37cc5995b88ec68a68cb8e496a008e1cd467077.patch
+++ b/lib/ffmpeg/patches/0037-backport-fix-vdpau-vc1-interlace-modes-b37cc5995b88ec68a68cb8e496a008e1cd467077.patch
@@ -1,0 +1,25 @@
+From b37cc5995b88ec68a68cb8e496a008e1cd467077 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Sun, 5 May 2013 15:12:59 +0200
+Subject: [PATCH] fix vdpau vc1 interlace modes
+
+---
+ libavcodec/vdpau_vc1.c |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/vdpau_vc1.c b/libavcodec/vdpau_vc1.c
+index f5da9bb..993ef26 100644
+--- a/libavcodec/vdpau_vc1.c
++++ b/libavcodec/vdpau_vc1.c
+@@ -59,7 +59,7 @@ static int vdpau_vc1_start_frame(AVCodecContext *avctx,
+     else
+         info->picture_type  = s->pict_type - 1 + s->pict_type / 3;
+ 
+-    info->frame_coding_mode = v->fcm;
++    info->frame_coding_mode = v->fcm ? v->fcm + 1 : 0;
+     info->postprocflag      = v->postprocflag;
+     info->pulldown          = v->broadcast;
+     info->interlace         = v->interlace;
+-- 
+1.7.9.5
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -94,6 +94,10 @@ public:
                                const AVFrame *src, int offset[4],
                                int y, int type, int height);
   static int              FFGetBuffer(AVCodecContext *avctx, AVFrame *pic);
+  static VdpStatus        Render(VdpDecoder decoder, VdpVideoSurface target,
+                                 VdpPictureInfo const *picture_info,
+                                 uint32_t bitstream_buffer_count,
+                                 VdpBitstreamBuffer const * bitstream_buffers);
 
   void Present();
   bool ConfigVDPAU(AVCodecContext *avctx, int ref_frames);
@@ -222,11 +226,12 @@ public:
   int                  m_feature_count;
 
   static bool IsVDPAUFormat(PixelFormat fmt);
-  static void ReadFormatOf( PixelFormat fmt
+  static void ReadFormatOf( AVCodecID codec
                           , VdpDecoderProfile &decoder_profile
                           , VdpChromaType     &chroma_type);
 
   std::vector<vdpau_render_state*> m_videoSurfaces;
+  AVVDPAUContext m_hwContext;
   DllAvUtil   m_dllAvUtil;
 
   enum VDPAUOutputMethod


### PR DESCRIPTION
- ffmpeg has aligned vdpau with other hw accelerators. vdpau special handling is obsolete.
- fix vc1 interlace modes for vdpau (ffmpeg backport)

this is factored out from #870
