### PR TITLE
dmuxer streams: some fixes after #1757

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1187,7 +1187,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
 
 #ifdef HAVE_LIBBLURAY
     if( m_pInput->IsStreamType(DVDSTREAM_TYPE_BLURAY) )
-      static_cast<CDVDInputStreamBluray*>(m_pInput)->GetStreamInfo(pStream->id, m_streams[iId]->language);
+      static_cast<CDVDInputStreamBluray*>(m_pInput)->GetStreamInfo(pStream->id, stream->language);
 #endif
     if( m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD) )
     {

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -646,7 +646,10 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
 
       return pPacket;
     }
-    else if (m_pkt.pkt.size < 0 || !GetStreamInternal(m_pkt.pkt.stream_index))
+    // check size and stream index for being in a valid range
+    else if (m_pkt.pkt.size < 0 ||
+             m_pkt.pkt.stream_index < 0 ||
+             m_pkt.pkt.stream_index >= m_pFormatContext->nb_streams)
     {
       // XXX, in some cases ffmpeg returns a negative packet size
       if(m_pFormatContext->pb && !m_pFormatContext->pb->eof_reached)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -121,7 +121,7 @@ protected:
   friend class CDemuxStreamSubtitleFFmpeg;
 
   int ReadFrame(AVPacket *packet);
-  void AddStream(int iId);
+  CDemuxStream* AddStream(int iId);
   void AddStream(int iId, CDemuxStream* stream);
   CDemuxStream* GetStreamInternal(int iStreamId);
   void CreateStreams(unsigned int program = UINT_MAX);


### PR DESCRIPTION
- fix mixed-up stream ids. the internal ffmpeg id was set in DemuxPacket which goes to player
- don't discard packets of unknown streams, they are added later to the map

Thanks again @Voyager1. Please let me know if this finally fixes the VobSub issue
