### PR TITLE
[Cosmetic] Remove AddFileToFolder version without return value

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1808,8 +1808,7 @@ void CApplication::LoadSkin(const SkinPtr& skin)
   g_fontManager.LoadFonts(CSettings::Get().GetString("lookandfeel.font"));
 
   // load in the skin strings
-  CStdString langPath;
-  URIUtils::AddFileToFolder(skin->Path(), "language", langPath);
+  CStdString langPath = URIUtils::AddFileToFolder(skin->Path(), "language");
   URIUtils::AddSlashAtEnd(langPath);
 
   g_localizeStrings.LoadSkinStrings(langPath, CSettings::Get().GetString("locale.language"));

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -362,7 +362,7 @@ bool CCueDocument::ResolvePath(CStdString &strPath, const CStdString &strBase)
 
   CStdString strFilename = URIUtils::GetFileName(strPath);
 
-  URIUtils::AddFileToFolder(strDirectory, strFilename, strPath);
+  strPath = URIUtils::AddFileToFolder(strDirectory, strFilename);
 
   // i *hate* windows
   if (!CFile::Exists(strPath))

--- a/xbmc/Favourites.cpp
+++ b/xbmc/Favourites.cpp
@@ -40,7 +40,7 @@ bool CFavourites::Load(CFileItemList &items)
     CFavourites::LoadFavourites(favourites, items);
   else
     CLog::Log(LOGDEBUG, "CFavourites::Load - no system favourites found, skipping");
-  URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml", favourites);
+  favourites = URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml");
   if(XFILE::CFile::Exists(favourites))
     CFavourites::LoadFavourites(favourites, items);
   else
@@ -108,7 +108,7 @@ bool CFavourites::Save(const CFileItemList &items)
     rootNode->InsertEndChild(favNode);
   }
 
-  URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml", favourites);
+  favourites = URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml");
   return doc.SaveFile(favourites);
 }
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2321,13 +2321,13 @@ void CFileItemList::StackFolders()
         {
           CStdString path;
           CStdString dvdPath;
-          URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS.IFO", path);
+          path = URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS.IFO");
           if (CFile::Exists(path))
             dvdPath = path;
           else
           {
-            URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS", dvdPath);
-            URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO", path);
+            dvdPath = URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS");
+            path = URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO");
             dvdPath.Empty();
             if (CFile::Exists(path))
               dvdPath = path;
@@ -2335,13 +2335,13 @@ void CFileItemList::StackFolders()
 #ifdef HAVE_LIBBLURAY
           if (dvdPath.IsEmpty())
           {
-            URIUtils::AddFileToFolder(item->GetPath(), "index.bdmv", path);
+            path = URIUtils::AddFileToFolder(item->GetPath(), "index.bdmv");
             if (CFile::Exists(path))
               dvdPath = path;
             else
             {
-              URIUtils::AddFileToFolder(item->GetPath(), "BDMV", dvdPath);
-              URIUtils::AddFileToFolder(dvdPath, "index.bdmv", path);
+              dvdPath = URIUtils::AddFileToFolder(item->GetPath(), "BDMV");
+              path = URIUtils::AddFileToFolder(dvdPath, "index.bdmv");
               dvdPath.Empty();
               if (CFile::Exists(path))
                 dvdPath = path;
@@ -2685,11 +2685,11 @@ CStdString CFileItem::GetTBNFile() const
     URIUtils::GetParentPath(m_strPath,strPath);
     CFileItem item(CStackDirectory::GetFirstStackedFile(strFile),false);
     CStdString strTBNFile = item.GetTBNFile();
-    URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strTBNFile),strReturn);
+    strReturn = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
     if (CFile::Exists(strReturn))
       return strReturn;
 
-    URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)),strFile);
+    strFile = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)));
   }
 
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
@@ -2697,7 +2697,7 @@ CStdString CFileItem::GetTBNFile() const
     CStdString strPath, strParent;
     URIUtils::GetDirectory(strFile,strPath);
     URIUtils::GetParentPath(strPath,strParent);
-    URIUtils::AddFileToFolder(strParent,URIUtils::GetFileName(m_strPath),strFile);
+    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(m_strPath));
   }
 
   CURL url(strFile);
@@ -2766,7 +2766,7 @@ CStdString CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) co
     */
     CStdString strPath;
     URIUtils::GetParentPath(m_strPath,strPath);
-    URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)),strFile);
+    strFile = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)));
   }
 
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
@@ -2774,7 +2774,7 @@ CStdString CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) co
     CStdString strPath, strParent;
     URIUtils::GetDirectory(strFile,strPath);
     URIUtils::GetParentPath(strPath,strParent);
-    URIUtils::AddFileToFolder(strParent,URIUtils::GetFileName(strFile),strFile);
+    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(strFile));
   }
 
   if (IsMultiPath())
@@ -2808,7 +2808,6 @@ CStdString CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) co
 
 CStdString CFileItem::GetFolderThumb(const CStdString &folderJPG /* = "folder.jpg" */) const
 {
-  CStdString folderThumb;
   CStdString strFolder = m_strPath;
 
   if (IsStack() ||
@@ -2821,8 +2820,7 @@ CStdString CFileItem::GetFolderThumb(const CStdString &folderJPG /* = "folder.jp
   if (IsMultiPath())
     strFolder = CMultiPathDirectory::GetFirstPath(m_strPath);
 
-  URIUtils::AddFileToFolder(strFolder, folderJPG, folderThumb);
-  return folderThumb;
+  return URIUtils::AddFileToFolder(strFolder, folderJPG);
 }
 
 CStdString CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
@@ -2895,17 +2893,17 @@ CStdString CFileItem::GetLocalFanart() const
     CStackDirectory dir;
     CStdString strPath2;
     strPath2 = dir.GetStackedTitlePath(strFile);
-    URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strPath2),strFile);
+    strFile = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strPath2));
     CFileItem item(dir.GetFirstStackedFile(m_strPath),false);
     CStdString strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-fanart"));
-    URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strTBNFile),strFile2);
+    strFile2 = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
   }
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
   {
     CStdString strPath, strParent;
     URIUtils::GetDirectory(strFile,strPath);
     URIUtils::GetParentPath(strPath,strParent);
-    URIUtils::AddFileToFolder(strParent,URIUtils::GetFileName(m_strPath),strFile);
+    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(m_strPath));
   }
 
   // no local fanart available for these
@@ -3151,17 +3149,17 @@ CStdString CFileItem::FindTrailer() const
     CStackDirectory dir;
     CStdString strPath2;
     strPath2 = dir.GetStackedTitlePath(strFile);
-    URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strPath2),strFile);
+    strFile = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strPath2));
     CFileItem item(dir.GetFirstStackedFile(m_strPath),false);
     CStdString strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-trailer"));
-    URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strTBNFile),strFile2);
+    strFile2 = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strTBNFile));
   }
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
   {
     CStdString strPath, strParent;
     URIUtils::GetDirectory(strFile,strPath);
     URIUtils::GetParentPath(strPath,strParent);
-    URIUtils::AddFileToFolder(strParent,URIUtils::GetFileName(m_strPath),strFile);
+    strFile = URIUtils::AddFileToFolder(strParent,URIUtils::GetFileName(m_strPath));
   }
 
   // no local trailer available for these

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1318,56 +1318,49 @@ int CUtil::GetMatchingSource(const CStdString& strPath1, VECSOURCES& VECSOURCES,
 
 CStdString CUtil::TranslateSpecialSource(const CStdString &strSpecial)
 {
-  CStdString strReturn=strSpecial;
   if (!strSpecial.IsEmpty() && strSpecial[0] == '$')
   {
     if (strSpecial.Left(5).Equals("$HOME"))
-      URIUtils::AddFileToFolder("special://home/", strSpecial.Mid(5), strReturn);
+      return URIUtils::AddFileToFolder("special://home/", strSpecial.Mid(5));
     else if (strSpecial.Left(10).Equals("$SUBTITLES"))
-      URIUtils::AddFileToFolder("special://subtitles/", strSpecial.Mid(10), strReturn);
+      return URIUtils::AddFileToFolder("special://subtitles/", strSpecial.Mid(10));
     else if (strSpecial.Left(9).Equals("$USERDATA"))
-      URIUtils::AddFileToFolder("special://userdata/", strSpecial.Mid(9), strReturn);
+      return URIUtils::AddFileToFolder("special://userdata/", strSpecial.Mid(9));
     else if (strSpecial.Left(9).Equals("$DATABASE"))
-      URIUtils::AddFileToFolder("special://database/", strSpecial.Mid(9), strReturn);
+      return URIUtils::AddFileToFolder("special://database/", strSpecial.Mid(9));
     else if (strSpecial.Left(11).Equals("$THUMBNAILS"))
-      URIUtils::AddFileToFolder("special://thumbnails/", strSpecial.Mid(11), strReturn);
+      return URIUtils::AddFileToFolder("special://thumbnails/", strSpecial.Mid(11));
     else if (strSpecial.Left(11).Equals("$RECORDINGS"))
-      URIUtils::AddFileToFolder("special://recordings/", strSpecial.Mid(11), strReturn);
+      return URIUtils::AddFileToFolder("special://recordings/", strSpecial.Mid(11));
     else if (strSpecial.Left(12).Equals("$SCREENSHOTS"))
-      URIUtils::AddFileToFolder("special://screenshots/", strSpecial.Mid(12), strReturn);
+      return URIUtils::AddFileToFolder("special://screenshots/", strSpecial.Mid(12));
     else if (strSpecial.Left(15).Equals("$MUSICPLAYLISTS"))
-      URIUtils::AddFileToFolder("special://musicplaylists/", strSpecial.Mid(15), strReturn);
+      return URIUtils::AddFileToFolder("special://musicplaylists/", strSpecial.Mid(15));
     else if (strSpecial.Left(15).Equals("$VIDEOPLAYLISTS"))
-      URIUtils::AddFileToFolder("special://videoplaylists/", strSpecial.Mid(15), strReturn);
+      return URIUtils::AddFileToFolder("special://videoplaylists/", strSpecial.Mid(15));
     else if (strSpecial.Left(7).Equals("$CDRIPS"))
-      URIUtils::AddFileToFolder("special://cdrips/", strSpecial.Mid(7), strReturn);
+      return URIUtils::AddFileToFolder("special://cdrips/", strSpecial.Mid(7));
     // this one will be removed post 2.0
     else if (strSpecial.Left(10).Equals("$PLAYLISTS"))
-      URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), strSpecial.Mid(10), strReturn);
+      return URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), strSpecial.Mid(10));
   }
-  return strReturn;
+  return strSpecial;
 }
 
 CStdString CUtil::MusicPlaylistsLocation()
 {
   vector<CStdString> vec;
-  CStdString strReturn;
-  URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "music", strReturn);
-  vec.push_back(strReturn);
-  URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "mixed", strReturn);
-  vec.push_back(strReturn);
-  return XFILE::CMultiPathDirectory::ConstructMultiPath(vec);;
+  vec.push_back(URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "music"));
+  vec.push_back(URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "mixed"));
+  return XFILE::CMultiPathDirectory::ConstructMultiPath(vec);
 }
 
 CStdString CUtil::VideoPlaylistsLocation()
 {
   vector<CStdString> vec;
-  CStdString strReturn;
-  URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "video", strReturn);
-  vec.push_back(strReturn);
-  URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "mixed", strReturn);
-  vec.push_back(strReturn);
-  return XFILE::CMultiPathDirectory::ConstructMultiPath(vec);;
+  vec.push_back(URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "video"));
+  vec.push_back(URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "mixed"));
+  return XFILE::CMultiPathDirectory::ConstructMultiPath(vec);
 }
 
 void CUtil::DeleteMusicDatabaseDirectoryCache()
@@ -1568,8 +1561,7 @@ CStdString CUtil::GetDefaultFolderThumb(const CStdString &folderThumb)
 
 void CUtil::GetSkinThemes(vector<CStdString>& vecTheme)
 {
-  CStdString strPath;
-  URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(),"media",strPath);
+  CStdString strPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), "media");
   CFileItemList items;
   CDirectory::GetDirectory(strPath, items);
   // Search for Themes in the Current skin!

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -252,7 +252,7 @@ CAddon::CAddon(const cp_extension_t *ext)
 {
   BuildLibName(ext);
   BuildProfilePath();
-  URIUtils::AddFileToFolder(Profile(), "settings.xml", m_userSettingsPath);
+  m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_enabled = true;
   m_hasSettings = true;
   m_hasStrings = false;
@@ -280,7 +280,7 @@ CAddon::CAddon(const AddonProps &props)
   if (props.libname.IsEmpty()) BuildLibName();
   else m_strLibName = props.libname;
   BuildProfilePath();
-  URIUtils::AddFileToFolder(Profile(), "settings.xml", m_userSettingsPath);
+  m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_enabled = true;
   m_hasSettings = true;
   m_hasStrings = false;
@@ -299,7 +299,7 @@ CAddon::CAddon(const CAddon &rhs, const AddonPtr &parent)
   m_userSettingsLoaded = rhs.m_userSettingsLoaded;
   m_hasSettings = rhs.m_hasSettings;
   BuildProfilePath();
-  URIUtils::AddFileToFolder(Profile(), "settings.xml", m_userSettingsPath);
+  m_userSettingsPath = URIUtils::AddFileToFolder(Profile(), "settings.xml");
   m_strLibName  = rhs.m_strLibName;
   m_enabled = rhs.Enabled();
   m_hasStrings  = false;

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -187,10 +187,9 @@ GUIHANDLE CAddonCallbacksGUI::Window_New(void *addonData, const char *xmlFilenam
     if (!XFILE::CFile::Exists(strSkinPath))
     {
       /* Check for the matching folder for the skin in the fallback skins folder */
-      CStdString basePath;
-      URIUtils::AddFileToFolder(guiHelper->m_addon->Path(), "resources", basePath);
-      URIUtils::AddFileToFolder(basePath, "skins", basePath);
-      URIUtils::AddFileToFolder(basePath, URIUtils::GetFileName(g_SkinInfo->Path()), basePath);
+      CStdString basePath = URIUtils::AddFileToFolder(guiHelper->m_addon->Path(), "resources");
+      basePath = URIUtils::AddFileToFolder(basePath, "skins");
+      basePath = URIUtils::AddFileToFolder(basePath, URIUtils::GetFileName(g_SkinInfo->Path()));
       strSkinPath = g_SkinInfo->GetSkinPath(xmlFilename, &res, basePath);
       if (!XFILE::CFile::Exists(strSkinPath))
       {
@@ -206,10 +205,9 @@ GUIHANDLE CAddonCallbacksGUI::Window_New(void *addonData, const char *xmlFilenam
     //FIXME make this static method of current skin?
     CStdString str("none");
     AddonProps props(str, ADDON_SKIN, str, str);
-    CStdString basePath;
-    URIUtils::AddFileToFolder(guiHelper->m_addon->Path(), "resources", basePath);
-    URIUtils::AddFileToFolder(basePath, "skins", basePath);
-    URIUtils::AddFileToFolder(basePath, defaultSkin, basePath);
+    CStdString basePath = URIUtils::AddFileToFolder(guiHelper->m_addon->Path(), "resources");
+    basePath = URIUtils::AddFileToFolder(basePath, "skins");
+    basePath = URIUtils::AddFileToFolder(basePath, defaultSkin);
     props.path = basePath;
 
     CSkinInfo skinInfo(props);

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -193,7 +193,7 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag, CStdS
 
   if (!strAlbumDir.IsEmpty())
   {
-    URIUtils::AddFileToFolder(strDirectory, strAlbumDir, strDirectory);
+    strDirectory = URIUtils::AddFileToFolder(strDirectory, strAlbumDir);
     URIUtils::AddSlashAtEnd(strDirectory);
   }
 

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -211,8 +211,7 @@ int SqliteDatabase::connect(bool create) {
 
   //CLog::Log(LOGDEBUG, "Connecting to sqlite:%s:%s", host.c_str(), db.c_str());
 
-  CStdString db_fullpath;
-  URIUtils::AddFileToFolder(host, db, db_fullpath);
+  CStdString db_fullpath = URIUtils::AddFileToFolder(host, db);
 
   try
   {

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -205,7 +205,6 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
       {
         if (m_browsingForFolders == 2)
         {
-          CStdString strTest;
           int iItem = m_viewControl.GetSelectedItem();
 
           CStdString strPath;
@@ -214,7 +213,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
           else
             strPath = (*m_vecItems)[iItem]->GetPath();
 
-          URIUtils::AddFileToFolder(strPath,"1",strTest);
+          CStdString strTest = URIUtils::AddFileToFolder(strPath, "1");
           CFile file;
           if (file.OpenForWrite(strTest,true))
           {
@@ -252,8 +251,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         CStdString strInput;
         if (CGUIKeyboardFactory::ShowAndGetInput(strInput,g_localizeStrings.Get(119),false))
         {
-          CStdString strPath;
-          URIUtils::AddFileToFolder(m_vecItems->GetPath(),strInput,strPath);
+          CStdString strPath = URIUtils::AddFileToFolder(m_vecItems->GetPath(), strInput);
           if (CDirectory::Create(strPath))
             Update(m_vecItems->GetPath());
           else

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -476,7 +476,7 @@ void CCurlFile::SetCommonOptions(CReadState* state)
   // Enable cookie engine for current handle to re-use them in future requests
   CStdString strCookieFile;
   CStdString strTempPath = CSpecialProtocol::TranslatePath(g_advancedSettings.m_cachePath);
-  URIUtils::AddFileToFolder(strTempPath, "cookies.dat", strCookieFile);
+  strCookieFile = URIUtils::AddFileToFolder(strTempPath, "cookies.dat");
 
   g_curlInterface.easy_setopt(h, CURLOPT_COOKIEFILE, strCookieFile.c_str());
   g_curlInterface.easy_setopt(h, CURLOPT_COOKIEJAR, strCookieFile.c_str());

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -136,8 +136,8 @@ bool CRarManager::CacheRarredFile(CStdString& strPathInCache, const CStdString& 
   strPath.Replace('/', '\\');
 #endif
   //g_charsetConverter.unknownToUTF8(strPath);
-  CStdString strCachedPath;
-  URIUtils::AddFileToFolder(strDir + "rarfolder%04d", URIUtils::GetFileName(strPathInRar), strCachedPath);
+  CStdString strCachedPath = URIUtils::AddFileToFolder(strDir + "rarfolder%04d",
+                                           URIUtils::GetFileName(strPathInRar));
   strCachedPath = CUtil::GetNextPathname(strCachedPath, 9999);
   if (strCachedPath.IsEmpty())
   {

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -129,25 +129,25 @@ CStdString CSpecialProtocol::TranslatePath(const CURL &url)
     RootDir = FullFileName;
 
   if (RootDir.Equals("subtitles"))
-    URIUtils::AddFileToFolder(CSettings::Get().GetString("subtitles.custompath"), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CSettings::Get().GetString("subtitles.custompath"), FileName);
   else if (RootDir.Equals("userdata"))
-    URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), FileName);
   else if (RootDir.Equals("database"))
-    URIUtils::AddFileToFolder(CProfilesManager::Get().GetDatabaseFolder(), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::Get().GetDatabaseFolder(), FileName);
   else if (RootDir.Equals("thumbnails"))
-    URIUtils::AddFileToFolder(CProfilesManager::Get().GetThumbnailsFolder(), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::Get().GetThumbnailsFolder(), FileName);
   else if (RootDir.Equals("recordings") || RootDir.Equals("cdrips"))
-    URIUtils::AddFileToFolder(CSettings::Get().GetString("audiocds.recordingpath"), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CSettings::Get().GetString("audiocds.recordingpath"), FileName);
   else if (RootDir.Equals("screenshots"))
-    URIUtils::AddFileToFolder(CSettings::Get().GetString("debug.screenshotpath"), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CSettings::Get().GetString("debug.screenshotpath"), FileName);
   else if (RootDir.Equals("musicplaylists"))
-    URIUtils::AddFileToFolder(CUtil::MusicPlaylistsLocation(), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CUtil::MusicPlaylistsLocation(), FileName);
   else if (RootDir.Equals("videoplaylists"))
-    URIUtils::AddFileToFolder(CUtil::VideoPlaylistsLocation(), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(CUtil::VideoPlaylistsLocation(), FileName);
   else if (RootDir.Equals("skin"))
-    URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), FileName);
   else if (RootDir.Equals("logpath"))
-    URIUtils::AddFileToFolder(g_advancedSettings.m_logFolder, FileName, translatedPath);
+    translatedPath = URIUtils::AddFileToFolder(g_advancedSettings.m_logFolder, FileName);
 
 
   // from here on, we have our "real" special paths
@@ -162,7 +162,7 @@ CStdString CSpecialProtocol::TranslatePath(const CURL &url)
   {
     CStdString basePath = GetPath(RootDir);
     if (!basePath.IsEmpty())
-      URIUtils::AddFileToFolder(basePath, FileName, translatedPath);
+      translatedPath = URIUtils::AddFileToFolder(basePath, FileName);
     else
       translatedPath.clear();
   }

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -48,7 +48,6 @@ namespace XFILE
     {
       CStdString file = files[i];
       CFileItemPtr item(new CFileItem(file));
-      //URIUtils::AddFileToFolder(folder, file, item->GetPath());
       item->SetPath(file);
       item->m_bIsFolder = false;
       items.Add(item);
@@ -159,7 +158,7 @@ namespace XFILE
   {
     // the stacked files are always in volume order, so just get up to the first filename
     // occurence of " , "
-    CStdString path, file, folder;
+    CStdString file, folder;
     int pos = strPath.Find(" , ");
     if (pos > 0)
       URIUtils::Split(strPath.Left(pos), folder, file);
@@ -169,9 +168,8 @@ namespace XFILE
     // remove "stack://" from the folder
     folder = folder.Mid(8);
     file.Replace(",,", ",");
-    URIUtils::AddFileToFolder(folder, file, path);
 
-    return path;
+    return URIUtils::AddFileToFolder(folder, file);
   }
 
   bool CStackDirectory::GetPaths(const CStdString& strPath, vector<CStdString>& vecPaths)

--- a/xbmc/guilib/GUIColorManager.cpp
+++ b/xbmc/guilib/GUIColorManager.cpp
@@ -52,9 +52,8 @@ void CGUIColorManager::Load(const CStdString &colorFile)
     LoadXML(xmlDoc);
 
   // first load the default color map if it exists
-  CStdString path, basePath;
-  URIUtils::AddFileToFolder(g_SkinInfo->Path(), "colors", basePath);
-  URIUtils::AddFileToFolder(basePath, "defaults.xml", path);
+  CStdString basePath = URIUtils::AddFileToFolder(g_SkinInfo->Path(), "colors");
+  CStdString path = URIUtils::AddFileToFolder(basePath, "defaults.xml");
 
   if (xmlDoc.LoadFile(CSpecialProtocol::TranslatePathConvertCase(path)))
     LoadXML(xmlDoc);
@@ -63,7 +62,7 @@ void CGUIColorManager::Load(const CStdString &colorFile)
   if (colorFile.CompareNoCase("SKINDEFAULT") == 0)
     return; // nothing to do
 
-  URIUtils::AddFileToFolder(basePath, colorFile, path);
+  path = URIUtils::AddFileToFolder(basePath, colorFile);
   CLog::Log(LOGINFO, "Loading colors from %s", path.c_str());
 
   if (xmlDoc.LoadFile(path))

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -564,8 +564,7 @@ bool CButtonTranslator::Load(bool AlwaysLoad)
 #else
 #define REMOTEMAP "IRSSmap.xml"
 #endif
-  CStdString lircmapPath;
-  URIUtils::AddFileToFolder("special://xbmc/system/", REMOTEMAP, lircmapPath);
+  CStdString lircmapPath = URIUtils::AddFileToFolder("special://xbmc/system/", REMOTEMAP);
   lircRemotesMap.clear();
   if(CFile::Exists(lircmapPath))
     success |= LoadLircMap(lircmapPath);

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1421,7 +1421,7 @@ int CBuiltins::Execute(const CStdString& execString)
       else
       {
         if (URIUtils::HasSlashAtEnd(path))
-          URIUtils::AddFileToFolder(path, "musicdb.xml", path);
+          path = URIUtils::AddFileToFolder(path, "musicdb.xml");
         CMusicDatabase musicdatabase;
         musicdatabase.Open();
         musicdatabase.ExportToXML(path, singleFile, thumbs, overwrite);

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -512,9 +512,8 @@ namespace XBMCAddon
     {
       TRACE;
       // Path where the language strings reside
-      CStdString pathToLanguageFile = m_scriptPath;
-      URIUtils::AddFileToFolder(pathToLanguageFile, "resources", pathToLanguageFile);
-      URIUtils::AddFileToFolder(pathToLanguageFile, "language", pathToLanguageFile);
+      CStdString pathToLanguageFile = URIUtils::AddFileToFolder(m_scriptPath, "resources");
+      pathToLanguageFile = URIUtils::AddFileToFolder(pathToLanguageFile, "language");
       URIUtils::AddSlashAtEnd(pathToLanguageFile);
 
       // allocate a bunch of strings

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -949,7 +949,7 @@ CSong CMusicDatabase::GetSongFromDataset(bool bWithMusicDbPath/*=false*/)
 
   // Get filename with full path
   if (!bWithMusicDbPath)
-    URIUtils::AddFileToFolder(m_pDS->fv(song_strPath).get_asString(), m_pDS->fv(song_strFileName).get_asString(), song.strFileName);
+    song.strFileName = URIUtils::AddFileToFolder(m_pDS->fv(song_strPath).get_asString(), m_pDS->fv(song_strFileName).get_asString());
   else
   {
     CStdString strFileName = m_pDS->fv(song_strFileName).get_asString();
@@ -990,8 +990,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   item->GetMusicInfoTag()->SetComment(record->at(song_comment).get_asString());
   item->GetMusicInfoTag()->SetPlayCount(record->at(song_iTimesPlayed).get_asInt());
   item->GetMusicInfoTag()->SetLastPlayed(record->at(song_lastplayed).get_asString());
-  CStdString strRealPath;
-  URIUtils::AddFileToFolder(record->at(song_strPath).get_asString(), record->at(song_strFileName).get_asString(), strRealPath);
+  CStdString strRealPath = URIUtils::AddFileToFolder(record->at(song_strPath).get_asString(), record->at(song_strFileName).get_asString());
   item->GetMusicInfoTag()->SetURL(strRealPath);
   item->GetMusicInfoTag()->SetCompilation(record->at(song_bCompilation).get_asInt() == 1);
   item->GetMusicInfoTag()->SetAlbumArtist(record->at(song_strAlbumArtists).get_asString());
@@ -2017,8 +2016,7 @@ bool CMusicDatabase::CleanupSongsByIds(const CStdString &strSongIds)
     CStdString strSongsToDelete = "";
     while (!m_pDS->eof())
     { // get the full song path
-      CStdString strFileName;
-      URIUtils::AddFileToFolder(m_pDS->fv("path.strPath").get_asString(), m_pDS->fv("song.strFileName").get_asString(), strFileName);
+      CStdString strFileName = URIUtils::AddFileToFolder(m_pDS->fv("path.strPath").get_asString(), m_pDS->fv("song.strFileName").get_asString());
 
       //  Special case for streams inside an ogg file. (oggstream)
       //  The last dir in the path is the ogg file that
@@ -4597,8 +4595,7 @@ void CMusicDatabase::ExportToXML(const CStdString &xmlFile, bool singleFiles, bo
           CLog::Log(LOGDEBUG, "%s - Not exporting item %s as it does not exist", __FUNCTION__, strPath.c_str());
         else
         {
-          CStdString nfoFile;
-          URIUtils::AddFileToFolder(strPath, "album.nfo", nfoFile);
+          CStdString nfoFile = URIUtils::AddFileToFolder(strPath, "album.nfo");
           if (overwrite || !CFile::Exists(nfoFile))
           {
             if (!xmlDoc.SaveFile(nfoFile))
@@ -4682,8 +4679,7 @@ void CMusicDatabase::ExportToXML(const CStdString &xmlFile, bool singleFiles, bo
           CLog::Log(LOGDEBUG, "%s - Not exporting item %s as it does not exist", __FUNCTION__, strPath.c_str());
         else
         {
-          CStdString nfoFile;
-          URIUtils::AddFileToFolder(strPath, "artist.nfo", nfoFile);
+          CStdString nfoFile = URIUtils::AddFileToFolder(strPath, "artist.nfo");
           if (overwrite || !CFile::Exists(nfoFile))
           {
             if (!xmlDoc.SaveFile(nfoFile))

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -373,7 +373,7 @@ void CGUIDialogMusicInfo::OnGetThumb()
     database.Open();
     CStdString strArtistPath;
     if (database.GetArtistPath(m_artist.idArtist,strArtistPath))
-      URIUtils::AddFileToFolder(strArtistPath,"folder.jpg",localThumb);
+      localThumb = URIUtils::AddFileToFolder(strArtistPath, "folder.jpg");
   }
   else
     localThumb = m_albumItem->GetUserMusicThumb();

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -262,7 +262,7 @@ void CGUIDialogSongInfo::OnGetThumb()
   // Grab the thumbnail from the web
   /*
   CStdString thumbFromWeb;
-  URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath, "allmusicThumb.jpg", thumbFromWeb);
+  thumbFromWeb = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath, "allmusicThumb.jpg");
   if (DownloadThumbnail(thumbFromWeb))
   {
     CFileItemPtr item(new CFileItem("thumb://allmusic.com", false));

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1152,8 +1152,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, ADDON::Scrape
   }
 
   // handle nfo files
-  CStdString strNfo;
-  URIUtils::AddFileToFolder(album.strPath, "album.nfo", strNfo);
+  CStdString strNfo = URIUtils::AddFileToFolder(album.strPath, "album.nfo");
   CNfoFile::NFOResult result = CNfoFile::NO_NFO;
   CNfoFile nfoReader;
   if (XFILE::CFile::Exists(strNfo))
@@ -1366,8 +1365,7 @@ INFO_RET CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist, ADDON::Scr
   }
 
   // handle nfo files
-  CStdString strNfo;
-  URIUtils::AddFileToFolder(artist.strPath, "artist.nfo", strNfo);
+  CStdString strNfo = URIUtils::AddFileToFolder(artist.strPath, "artist.nfo");
   CNfoFile::NFOResult result=CNfoFile::NO_NFO;
   CNfoFile nfoReader;
   if (XFILE::CFile::Exists(strNfo))

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -284,11 +284,10 @@ void CGUIWindowMusicPlayList::SavePlayList()
   if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, g_localizeStrings.Get(16012), false))
   {
     // need 2 rename it
-    CStdString strFolder, strPath;
-    URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "music", strFolder);
-    strNewFileName= CUtil::MakeLegalFileName( strNewFileName );
+    CStdString strFolder = URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "music");
+    strNewFileName = CUtil::MakeLegalFileName(strNewFileName);
     strNewFileName += ".m3u";
-    URIUtils::AddFileToFolder(strFolder, strNewFileName, strPath);
+    CStdString strPath = URIUtils::AddFileToFolder(strFolder, strNewFileName);
 
     // get selected item
     int iItem = m_viewControl.GetSelectedItem();

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -396,9 +396,8 @@ void CGUIWindowMusicPlaylistEditor::OnSavePlaylist()
   { // save playlist as an .m3u
     PLAYLIST::CPlayListM3U playlist;
     playlist.Add(*m_playlist);
-    CStdString path, strBase;
-    URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "music", strBase);
-    URIUtils::AddFileToFolder(strBase, name + ".m3u", path);
+    CStdString strBase = URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "music");
+    CStdString path = URIUtils::AddFileToFolder(strBase, name + ".m3u");
     playlist.Save(path);
     m_strLoadedPlaylist = name;
   }

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -527,8 +527,7 @@ CUPnP::StartServer()
     if (!m_ServerHolder->m_Device.IsNull()) return false;
 
     // load upnpserver.xml
-    CStdString filename;
-    URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), "upnpserver.xml", filename);
+    CStdString filename = URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::Get().Load(filename);
 
     // create the server with a XBox compatible friendlyname and UUID from upnpserver.xml if found
@@ -607,8 +606,7 @@ bool CUPnP::StartRenderer()
 {
     if (!m_RendererHolder->m_Device.IsNull()) return false;
 
-    CStdString filename;
-    URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), "upnpserver.xml", filename);
+    CStdString filename = URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::Get().Load(filename);
 
     m_RendererHolder->m_Device = CreateRenderer(CUPnPSettings::Get().GetRendererPort());

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -275,12 +275,12 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
 
         if ( retVal == 1 )
         {
-          URIUtils::AddFileToFolder(path, "karaoke.html", path);
+          path = URIUtils::AddFileToFolder(path, "karaoke.html");
           musicdatabase.ExportKaraokeInfo( path, true );
         }
         else
         {
-          URIUtils::AddFileToFolder(path, "karaoke.csv", path);
+          path = URIUtils::AddFileToFolder(path, "karaoke.csv");
           musicdatabase.ExportKaraokeInfo( path, false );
         }
         musicdatabase.Close();

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -180,7 +180,7 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
 
       CStdString strnewDestFile;
       if(!strDestFile.IsEmpty()) // only do this if we have a destination
-        URIUtils::AddFileToFolder(strDestFile, strFileName, strnewDestFile);
+        strnewDestFile = URIUtils::AddFileToFolder(strDestFile, strFileName);
 
       if (pItem->m_bIsFolder)
       {

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -71,7 +71,7 @@ bool CFileUtils::RenameFile(const CStdString &strFile)
         CStdString filePath(paths[i]);
         URIUtils::RemoveSlashAtEnd(filePath);
         URIUtils::GetDirectory(filePath, filePath);
-        URIUtils::AddFileToFolder(filePath, strFileName, filePath);
+        filePath = URIUtils::AddFileToFolder(filePath, strFileName);
         if (CFile::Rename(paths[i], filePath))
           success = true;
       }

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -207,9 +207,8 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
 
   if (!scrURL.m_cache.IsEmpty())
   {
-    URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
-                              "scrapers/"+cacheContext+"/"+scrURL.m_cache,
-                              strCachePath);
+    strCachePath = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
+                              "scrapers/" + cacheContext + "/" + scrURL.m_cache);
     if (XFILE::CFile::Exists(strCachePath))
     {
       XFILE::CFile file;
@@ -257,10 +256,8 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
 
   if (!scrURL.m_cache.IsEmpty())
   {
-    CStdString strCachePath;
-    URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
-                              "scrapers/"+cacheContext+"/"+scrURL.m_cache,
-                              strCachePath);
+    CStdString strCachePath = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
+                              "scrapers/" + cacheContext + "/" + scrURL.m_cache);
     XFILE::CFile file;
     if (file.OpenForWrite(strCachePath,true))
       file.Write(strHTML.data(),strHTML.size());

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -932,24 +932,21 @@ bool URIUtils::CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdSt
   return strc1.Equals(strc2);
 }
 
-void URIUtils::AddFileToFolder(const CStdString& strFolder, 
-                                const CStdString& strFile,
-                                CStdString& strResult)
+CStdString URIUtils::AddFileToFolder(const CStdString& strFolder, 
+                                const CStdString& strFile)
 {
   if (IsURL(strFolder))
   {
     CURL url(strFolder);
     if (url.GetFileName() != strFolder)
     {
-      AddFileToFolder(url.GetFileName(), strFile, strResult);
-      url.SetFileName(strResult);
-      strResult = url.Get();
-      return;
+      url.SetFileName(AddFileToFolder(url.GetFileName(), strFile));
+      return url.Get();
     }
   }
 
-  strResult = strFolder;
-  if(!strResult.IsEmpty())
+  CStdString strResult = strFolder;
+  if (!strResult.IsEmpty())
     AddSlashAtEnd(strResult);
 
   // Remove any slash at the start of the file
@@ -963,6 +960,8 @@ void URIUtils::AddFileToFolder(const CStdString& strFolder,
     strResult.Replace('\\', '/');
   else
     strResult.Replace('/', '\\');
+
+  return strResult;
 }
 
 CStdString URIUtils::GetDirectory(const CStdString &filePath)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -107,15 +107,7 @@ public:
                                 const CStdString& strFilePathInArchive,
                                 const CStdString& strPwd="");
 
-  static void AddFileToFolder(const CStdString& strFolder,
-                              const CStdString& strFile, CStdString& strResult);
-  static CStdString AddFileToFolder(const CStdString &strFolder, 
-                                    const CStdString &strFile)
-  {
-    CStdString result;
-    AddFileToFolder(strFolder, strFile, result);
-    return result;
-  }
+  static CStdString AddFileToFolder(const CStdString &strFolder, const CStdString &strFile);
 
   static bool ProtocolHasParentInHostname(const CStdString& prot);
   static bool ProtocolHasEncodedHostname(const CStdString& prot);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -450,14 +450,8 @@ TEST_F(TestURIUtils, CreateArchivePath)
 
 TEST_F(TestURIUtils, AddFileToFolder)
 {
-  CStdString ref, var;
-
-  ref = "/path/to/file";
-  URIUtils::AddFileToFolder("/path/to", "file", var);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-
-  var.clear();
-  var = URIUtils::AddFileToFolder("/path/to", "file");
+  CStdString ref = "/path/to/file";
+  CStdString var = URIUtils::AddFileToFolder("/path/to", "file");
   EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8290,8 +8290,7 @@ void CVideoDatabase::DumpToDummyFiles(const CStdString &path)
   {
     // create a folder in this directory
     CStdString showName = CUtil::MakeLegalFileName(items[i]->GetVideoInfoTag()->m_strShowTitle);
-    CStdString TVFolder;
-    URIUtils::AddFileToFolder(showPath, showName, TVFolder);
+    CStdString TVFolder = URIUtils::AddFileToFolder(showPath, showName);
     if (CDirectory::Create(TVFolder))
     { // right - grab the episodes and dump them as well
       CFileItemList episodes;
@@ -8303,8 +8302,7 @@ void CVideoDatabase::DumpToDummyFiles(const CStdString &path)
         CStdString episode;
         episode.Format("%s.s%02de%02d.avi", showName.c_str(), tag->m_iSeason, tag->m_iEpisode);
         // and make a file
-        CStdString episodePath;
-        URIUtils::AddFileToFolder(TVFolder, episode, episodePath);
+        CStdString episodePath = URIUtils::AddFileToFolder(TVFolder, episode);
         CFile file;
         if (file.OpenForWrite(episodePath))
           file.Close();
@@ -8655,8 +8653,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
         }
         else
         {
-          CStdString nfoFile;
-          URIUtils::AddFileToFolder(tvshow.m_strPath, "tvshow.nfo", nfoFile);
+          CStdString nfoFile = URIUtils::AddFileToFolder(tvshow.m_strPath, "tvshow.nfo");
 
           if (overwrite || !CFile::Exists(nfoFile, false))
           {
@@ -9088,7 +9085,7 @@ void CVideoDatabase::ConstructPath(CStdString& strDest, const CStdString& strPat
       URIUtils::IsInArchive(strFileName) || URIUtils::IsPlugin(strPath))
     strDest = strFileName;
   else
-    URIUtils::AddFileToFolder(strPath, strFileName, strDest);
+    strDest = URIUtils::AddFileToFolder(strPath, strFileName);
 }
 
 void CVideoDatabase::SplitPath(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1808,7 +1808,7 @@ namespace VIDEO
         || (info->Content() == CONTENT_TVSHOWS && !pItem->m_bIsFolder))
       strNfoFile = GetnfoFile(pItem, bGrabAny);
     if (info->Content() == CONTENT_TVSHOWS && pItem->m_bIsFolder)
-      URIUtils::AddFileToFolder(pItem->GetPath(), "tvshow.nfo", strNfoFile);
+      strNfoFile = URIUtils::AddFileToFolder(pItem->GetPath(), "tvshow.nfo");
 
     CNfoFile::NFOResult result=CNfoFile::NO_NFO;
     if (!strNfoFile.IsEmpty() && CFile::Exists(strNfoFile))

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1187,8 +1187,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       bool local=false;
       if (button == CONTEXT_BUTTON_SET_ARTIST_THUMB)
       {
-        CStdString strThumb;
-        URIUtils::AddFileToFolder(artistPath,"folder.jpg",strThumb);
+        CStdString strThumb = URIUtils::AddFileToFolder(artistPath, "folder.jpg");
         if (XFILE::CFile::Exists(strThumb))
         {
           CFileItemPtr pItem(new CFileItem(strThumb,false));
@@ -1204,8 +1203,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (button == CONTEXT_BUTTON_SET_ACTOR_THUMB)
       {
         CStdString picturePath;
-        CStdString strThumb;
-        URIUtils::AddFileToFolder(picturePath,"folder.jpg",strThumb);
+        CStdString strThumb = URIUtils::AddFileToFolder(picturePath, "folder.jpg");
         if (XFILE::CFile::Exists(strThumb))
         {
           CFileItemPtr pItem(new CFileItem(strThumb,false));

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -375,11 +375,10 @@ void CGUIWindowVideoPlaylist::SavePlayList()
   if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, g_localizeStrings.Get(16012), false))
   {
     // need 2 rename it
-    CStdString strPath, strFolder;
-    URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "video", strFolder);
+    CStdString strFolder = URIUtils::AddFileToFolder(CSettings::Get().GetString("system.playlistspath"), "video");
     strNewFileName = CUtil::MakeLegalFileName(strNewFileName);
     strNewFileName += ".m3u";
-    URIUtils::AddFileToFolder(strFolder, strNewFileName, strPath);
+    CStdString strPath = URIUtils::AddFileToFolder(strFolder, strNewFileName);
 
     CPlayListM3U playlist;
     playlist.Add(*m_vecItems);


### PR DESCRIPTION
I think that the benefit of only having the version with return value is:
- Makes the code cleaner and easier to follow. Promotes better style.
- Removes temporary variables and lines of code.
- It could be faster. For example by initializing variables at definition.
- (I am learning the codebase)

Is this useful?

There is i couple of other functions in the URIUtils class that i think can benefit from this in the same way. Can i work on them also?
