### PR TITLE
[fix] KaiToast display of "next subtitle" was always one behind

### DIFF
--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -104,7 +104,7 @@ bool CPlayerController::OnAction(const CAction &action)
       if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
       {
         SPlayerSubtitleStreamInfo info;
-        g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
+        g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
         sub = info.name;
         if (sub != info.language)
           sub.Format("%s [%s]", sub.c_str(), info.language.c_str());


### PR DESCRIPTION
as description says. 

Pressing the "next subtitle" key (lower case L) shows the current subtitle instead of the next one. Reason is that the change is actually effected through a message back to the player.
