### PR TITLE
Remove use of CStdString::Mid(0)

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -223,7 +223,7 @@ void URIUtils::GetCommonPath(CStdString& strParent, const CStdString& strPath)
   if (!HasSlashAtEnd(strParent))
   {
     // currently GetDirectory() removes trailing slashes
-    GetDirectory(strParent.Mid(0), strParent);
+    GetDirectory(strParent, strParent);
     AddSlashAtEnd(strParent);
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -732,11 +732,11 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
 
     if (URIUtils::GetFileName(strDeletePath).Equals("VIDEO_TS.IFO"))
     {
-      URIUtils::GetDirectory(strDeletePath.Mid(0),strDeletePath);
+      URIUtils::GetDirectory(strDeletePath, strDeletePath);
       if (strDeletePath.Right(9).Equals("VIDEO_TS/"))
       {
         URIUtils::RemoveSlashAtEnd(strDeletePath);
-        URIUtils::GetDirectory(strDeletePath.Mid(0),strDeletePath);
+        URIUtils::GetDirectory(strDeletePath, strDeletePath);
       }
     }
     if (URIUtils::HasSlashAtEnd(strDeletePath))


### PR DESCRIPTION
Is there a reason to use Mid(0)? I think that str.Mid(0) always equals str.
