### PR TITLE
Fix Media Center Master-generated nfo files being ignored

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -71,6 +71,7 @@ CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr
     {
       int infos=0;
       m_headofdoc = strstr(m_headofdoc,"<episodedetails");
+      bNfo = GetDetails(details);
       while (m_headofdoc && details.m_iEpisode != episode)
       {
         m_headofdoc = strstr(m_headofdoc+1,"<episodedetails");


### PR DESCRIPTION
This fixes the issue described in http://forum.xbmc.org/showthread.php?tid=164078
