### PR TITLE
gui: two texture speedups

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4953,7 +4953,7 @@ void CApplication::ProcessSlow()
   if (!IsPlayingVideo())
     g_largeTextureManager.CleanupUnusedImages();
 
-  g_TextureManager.FreeUnusedTextures();
+  g_TextureManager.FreeUnusedTextures(5000);
 
 #ifdef HAS_DVD_DRIVE
   // checks whats in the DVD drive and tries to autostart the content (xbox games, dvd, cdda, avi files...)

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -301,11 +301,12 @@ bool CGUITextureBase::AllocResources()
   { // we want to use the large image loader, but we first check for bundled textures
     if (!IsAllocated())
     {
-      int images = g_TextureManager.Load(m_info.filename, true);
-      if (images)
+      CTextureArray texture;
+      texture = g_TextureManager.Load(m_info.filename, true);
+      if (texture.size())
       {
         m_isAllocated = NORMAL;
-        m_texture = g_TextureManager.GetTexture(m_info.filename);
+        m_texture = texture;
         changed = true;
       }
     }
@@ -329,15 +330,14 @@ bool CGUITextureBase::AllocResources()
   }
   else if (!IsAllocated())
   {
-    int images = g_TextureManager.Load(m_info.filename);
+    CTextureArray texture = g_TextureManager.Load(m_info.filename);
 
     // set allocated to true even if we couldn't load the image to save
     // us hitting the disk every frame
-    m_isAllocated = images ? NORMAL : NORMAL_FAILED;
-    if (!images)
+    m_isAllocated = texture.size() ? NORMAL : NORMAL_FAILED;
+    if (!texture.size())
       return false;
-
-    m_texture = g_TextureManager.GetTexture(m_info.filename);
+    m_texture = texture;
     changed = true;
   }
   m_frameWidth = (float)m_texture.m_width;
@@ -346,8 +346,7 @@ bool CGUITextureBase::AllocResources()
   // load the diffuse texture (if necessary)
   if (!m_info.diffuse.IsEmpty())
   {
-    g_TextureManager.Load(m_info.diffuse);
-    m_diffuse = g_TextureManager.GetTexture(m_info.diffuse);
+    m_diffuse = g_TextureManager.Load(m_info.diffuse);
   }
 
   CalculateSize();

--- a/xbmc/guilib/TextureManager.h
+++ b/xbmc/guilib/TextureManager.h
@@ -27,6 +27,7 @@
 #define GUILIB_TEXTUREMANAGER_H
 
 #include <vector>
+#include <list>
 #include "TextureBundle.h"
 #include "threads/CriticalSection.h"
 
@@ -121,13 +122,14 @@ public:
   void SetTexturePath(const CStdString &texturePath);    ///< Set a single path as the path to check when loading media (clear then add)
   void RemoveTexturePath(const CStdString &texturePath); ///< Remove a path from the paths to check when loading media
 
-  void FreeUnusedTextures(); ///< Free textures (called from app thread only)
+  void FreeUnusedTextures(unsigned int timeDelay = 0); ///< Free textures (called from app thread only)
   void ReleaseHwTexture(unsigned int texture);
 protected:
   std::vector<CTextureMap*> m_vecTextures;
-  std::vector<CTextureMap*> m_unusedTextures;
+  std::list<std::pair<CTextureMap*, unsigned int> > m_unusedTextures;
   std::vector<unsigned int> m_unusedHwTextures;
   typedef std::vector<CTextureMap*>::iterator ivecTextures;
+  typedef std::list<std::pair<CTextureMap*, unsigned int> >::iterator ilistUnused;
   // we have 2 texture bundles (one for the base textures, one for the theme)
   CTextureBundle m_TexBundle[2];
 

--- a/xbmc/guilib/TextureManager.h
+++ b/xbmc/guilib/TextureManager.h
@@ -108,8 +108,7 @@ public:
 
   bool HasTexture(const CStdString &textureName, CStdString *path = NULL, int *bundle = NULL, int *size = NULL);
   bool CanLoad(const CStdString &texturePath) const; ///< Returns true if the texture manager can load this texture
-  int Load(const CStdString& strTextureName, bool checkBundleOnly = false);
-  const CTextureArray& GetTexture(const CStdString& strTextureName);
+  const CTextureArray& Load(const CStdString& strTextureName, bool checkBundleOnly = false);
   void ReleaseTexture(const CStdString& strTextureName);
   void Cleanup();
   void Dump() const;


### PR DESCRIPTION
1. Check to see if we have a texture loaded already before opening/uploading
   another instance of it.
2. Set a time-out for deleting textures. If they are needed again before the
   time-out expires, they are re-added to the loaded textures array and ready
   for use again. Otherwise, they are deleted after X msec. This helps to avoid
   doing _really_ nasty things, like re-loading the background image when
   moving from home to settings.

This gives a big improvement on embedded devices. Background image reloads were not noticed before because confluence no longer uses the large texture manager, so the slow jpeg decodes aren't logged.

This timeout will eventually move to a release after n scenes have been rendered. As I'm working on moving rendering to a dedicated thread (async render), we need the ability to guarantee that a texture will hang around for a period of time after guilib has processed it.
