### PR TITLE
[Fix] Load correct guisettings.xml file when switching profile

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -648,7 +648,6 @@ bool CApplication::Create()
   init_emu_environ();
 
   CProfilesManager::Get().Load();
-  CSpecialProtocol::SetProfilePath(CProfilesManager::Get().GetProfileUserDataFolder());
 
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
 #if defined(TARGET_DARWIN_OSX)

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -177,18 +177,18 @@ bool CProfilesManager::Load(const std::string &file)
   if (m_lastUsedProfile >= m_profiles.size())
     m_lastUsedProfile = 0;
 
-  m_currentProfile = m_lastUsedProfile;
+  SetCurrentProfileId(m_lastUsedProfile);
 
   // check the validity of the auto login profile index
   if (m_autoLoginProfile < -1 || m_autoLoginProfile >= (int)m_profiles.size())
     m_autoLoginProfile = -1;
   else if (m_autoLoginProfile >= 0)
-    m_currentProfile = m_autoLoginProfile;
+    SetCurrentProfileId(m_autoLoginProfile);
 
   // the login screen runs as the master profile, so if we're using this, we need to ensure
   // we switch to the master profile
   if (m_usingLoginScreen)
-    m_currentProfile = 0;
+    SetCurrentProfileId(0);
 
   return ret;
 }
@@ -226,8 +226,8 @@ void CProfilesManager::Clear()
   m_profiles.clear();
   m_usingLoginScreen = false;
   m_lastUsedProfile = 0;
-  m_currentProfile = 0;
   m_nextProfileId = 0;
+  SetCurrentProfileId(0);
 }
 
 bool CProfilesManager::LoadProfile(size_t index)
@@ -244,9 +244,7 @@ bool CProfilesManager::LoadProfile(size_t index)
   // unload any old settings
   CSettings::Get().Unload();
 
-  m_currentProfile = index;
-  // point special://profile to the correct profile path
-  CSpecialProtocol::SetProfilePath(GetProfileUserDataFolder());
+  SetCurrentProfileId(index);
 
   // load the new settings
   if (!CSettings::Get().Load())
@@ -533,4 +531,11 @@ std::string CProfilesManager::GetUserDataItem(const std::string& strFile) const
     path = "special://masterprofile/" + strFile;
 
   return path;
+}
+
+void CProfilesManager::SetCurrentProfileId(size_t profileId)
+{
+  CSingleLock lock(m_critical);
+  m_currentProfile = profileId;
+  CSpecialProtocol::SetProfilePath(GetProfileUserDataFolder());
 }

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -241,11 +241,14 @@ bool CProfilesManager::LoadProfile(size_t index)
   if (m_currentProfile == index)
     return true;
 
-  m_currentProfile = index;
-
-  // first unload any old settings
+  // unload any old settings
   CSettings::Get().Unload();
-  // then load the new settings
+
+  m_currentProfile = index;
+  // point special://profile to the correct profile path
+  CSpecialProtocol::SetProfilePath(GetProfileUserDataFolder());
+
+  // load the new settings
   if (!CSettings::Get().Load())
   {
     CLog::Log(LOGFATAL, "CProfilesManager: unable to load settings for profile \"%s\"", m_profiles.at(index).getName().c_str());

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -82,8 +82,6 @@ CProfilesManager& CProfilesManager::Get()
 
 bool CProfilesManager::OnSettingsLoading()
 {
-  CSpecialProtocol::SetProfilePath(GetProfileUserDataFolder());
-
   return true;
 }
 

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -183,11 +183,16 @@ protected:
   virtual ~CProfilesManager();
 
 private:
+  /*! \brief Set the current profile id and update the special://profile path
+    \param profileId profile index
+    */
+  void SetCurrentProfileId(size_t profileId);
+
   std::vector<CProfile> m_profiles;
   bool m_usingLoginScreen;
   int m_autoLoginProfile;
   uint32_t m_lastUsedProfile;
-  uint32_t m_currentProfile;
+  uint32_t m_currentProfile; // do not modify directly, use SetCurrentProfileId() function instead
   int m_nextProfileId; // for tracking the next available id to give to a new profile to ensure id's are not re-used
   CCriticalSection m_critical;
 };


### PR DESCRIPTION
Update special://profile before attempting to load the profile's guisettings.xml file.

When switching profiles the guisettings.xml file from the Master User was always used. This happens because when you switch from one profile to another one, always the Master User profile is loaded in between (not sure why that is necessary though).
So when CSettings::Get():Load() is called, special://profile still points to the profile path of the Master User. It is only after the file guisettings.xml file is loaded, that the CProfilesManager::OnSettingsLoading() is called to update the special://profile path to the correct profile path.
