### PR TITLE
JSONRPCServer, AirPlayServer, WebServer: listen on ipv6 if available, else fall back to ipv4

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -331,7 +331,7 @@ void CAirPlayServer::Process()
       {
         CLog::Log(LOGDEBUG, "AIRPLAY Server: New connection detected");
         CTCPClient newconnection;
-        newconnection.m_socket = accept(m_ServerSocket, &newconnection.m_cliaddr, &newconnection.m_addrlen);
+        newconnection.m_socket = accept(m_ServerSocket, (struct sockaddr*) &newconnection.m_cliaddr, &newconnection.m_addrlen);
         sessionCounter++;
         newconnection.m_sessionCounter = sessionCounter;
 
@@ -361,41 +361,10 @@ void CAirPlayServer::Process()
 bool CAirPlayServer::Initialize()
 {
   Deinitialize();
-
-  struct sockaddr_in myaddr;
-  memset(&myaddr, 0, sizeof(myaddr));
-
-  myaddr.sin_family = AF_INET;
-  myaddr.sin_port = htons(m_port);
-
-  if (m_nonlocal)
-    myaddr.sin_addr.s_addr = INADDR_ANY;
-  else
-    inet_pton(AF_INET, "127.0.0.1", &myaddr.sin_addr.s_addr);
-
-  m_ServerSocket = socket(PF_INET, SOCK_STREAM, 0);
-
-  if (m_ServerSocket == INVALID_SOCKET)
-  {
-
-    CLog::Log(LOGERROR, "AIRPLAY Server: Failed to create serversocket");
+  
+  if ((m_ServerSocket = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "AIRPLAY")) == INVALID_SOCKET)
     return false;
-  }
-
-  if (bind(m_ServerSocket, (struct sockaddr*)&myaddr, sizeof myaddr) < 0)
-  {
-    CLog::Log(LOGERROR, "AIRPLAY Server: Failed to bind serversocket");
-    close(m_ServerSocket);
-    return false;
-  }
-
-  if (listen(m_ServerSocket, 10) < 0)
-  {
-    CLog::Log(LOGERROR, "AIRPLAY Server: Failed to set listen");
-    close(m_ServerSocket);
-    return false;
-  }
-
+  
   CLog::Log(LOGINFO, "AIRPLAY Server: Successfully initialized");
   return true;
 }
@@ -422,7 +391,7 @@ CAirPlayServer::CTCPClient::CTCPClient()
   m_socket = INVALID_SOCKET;
   m_httpParser = new HttpParser();
 
-  m_addrlen = sizeof(struct sockaddr);
+  m_addrlen = sizeof(struct sockaddr_storage);
   m_pLibPlist = new DllLibPlist();
 
   m_bAuthenticated = false;

--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -81,7 +81,7 @@ private:
     void Disconnect();
 
     int m_socket;
-    struct sockaddr m_cliaddr;
+    struct sockaddr_storage m_cliaddr;
     socklen_t m_addrlen;
     CCriticalSection m_critSection;
     int  m_sessionCounter;

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -385,3 +385,85 @@ bool CNetwork::PingHost(unsigned long ipaddr, unsigned short port, unsigned int 
 
   return err_msg == 0;
 }
+
+//creates, binds and listens a tcp socket on the desired port. Set bindLocal to
+//true to bind to localhost only. The socket will listen over ipv6 if possible
+//and fall back to ipv4 if ipv6 is not available on the platform.
+int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlog, const char *callerName)
+{
+  struct sockaddr_storage addr;
+  struct sockaddr_in6 *s6;
+  struct sockaddr_in  *s4;
+  int    sock;
+  bool   v4_fallback = false;
+
+#ifdef WINSOCK_VERSION
+  const char yes = 1;
+  const char no = 0;
+#else
+  unsigned int yes = 1;
+  unsigned int no = 0;
+#endif
+  
+  memset(&addr, 0, sizeof(addr));
+  
+  if ((sock = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP)) < 0)
+    v4_fallback = true;
+  
+  //in case we're on ipv6, make sure the socket is dual stacked
+  if (!v4_fallback)
+    setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &no, sizeof(no)); 
+  
+  if (v4_fallback)
+    sock = socket(PF_INET, SOCK_STREAM, 0);
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+  
+  if (sock == INVALID_SOCKET)
+  {
+    CLog::Log(LOGERROR, "%s Server: Failed to create serversocket", callerName);
+    return INVALID_SOCKET;
+  }
+  
+  if (v4_fallback)
+  {
+    addr.ss_family = AF_INET;
+    s4 = (struct sockaddr_in *) &addr;
+    s4->sin_port = htons(port);
+
+    if (bindLocal)
+      s4->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    else
+      s4->sin_addr.s_addr = htonl(INADDR_ANY);
+  }
+  else
+  {
+    addr.ss_family = AF_INET6;
+    s6 = (struct sockaddr_in6 *) &addr;
+    s6->sin6_port = htons(port);
+
+    if (bindLocal)
+      s6->sin6_addr = in6addr_loopback;
+    else
+      s6->sin6_addr = in6addr_any;
+  }
+
+  if (::bind( sock, (struct sockaddr *) &addr,
+            (addr.ss_family == AF_INET6) ? sizeof(struct sockaddr_in6) :
+                                           sizeof(struct sockaddr_in)  ) < 0)
+  {
+    closesocket(sock);
+    CLog::Log(LOGERROR, "%s Server: Failed to bind serversocket", callerName);
+    return INVALID_SOCKET;
+  }
+
+  if (listen(sock, backlog) < 0)
+  {
+    closesocket(sock);
+    CLog::Log(LOGERROR, "%s Server: Failed to set listen", callerName);
+    return INVALID_SOCKET;
+  }
+
+  return sock;
+}
+

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -133,3 +133,9 @@ public:
 #else
 #include "windows/NetworkWin32.h"
 #endif
+
+//creates, binds and listens a tcp socket on the desired port. Set bindLocal to
+//true to bind to localhost only. The socket will listen over ipv6 if possible
+//and fall back to ipv4 if ipv6 is not available on the platform.
+int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlog, const char *callerName);
+

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -32,6 +32,7 @@
 #include "utils/Variant.h"
 #include "threads/SingleLock.h"
 #include "websocket/WebSocketManager.h"
+#include "Network.h"
 
 static const char     bt_service_name[] = "XBMC JSON-RPC";
 static const char     bt_service_desc[] = "Interface for XBMC remote control over bluetooth";
@@ -444,39 +445,13 @@ bool CTCPServer::InitializeBlue()
 
 bool CTCPServer::InitializeTCP()
 {
+  SOCKET fd;
 
-  struct sockaddr_in myaddr;
-  memset(&myaddr, 0, sizeof(myaddr));
+  Deinitialize();
 
-  myaddr.sin_family = AF_INET;
-  myaddr.sin_port = htons(m_port);
-
-  if (m_nonlocal)
-    myaddr.sin_addr.s_addr = INADDR_ANY;
-  else
-    inet_pton(AF_INET, "127.0.0.1", &myaddr.sin_addr.s_addr);
-
-  SOCKET fd = socket(PF_INET, SOCK_STREAM, 0);
-
-  if (fd == INVALID_SOCKET)
-  {
-    CLog::Log(LOGERROR, "JSONRPC Server: Failed to create serversocket");
+  if ((fd = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "JSONRPC")) == INVALID_SOCKET)
     return false;
-  }
 
-  if (bind(fd, (struct sockaddr*)&myaddr, sizeof myaddr) < 0)
-  {
-    CLog::Log(LOGERROR, "JSONRPC Server: Failed to bind serversocket");
-    closesocket(fd);
-    return false;
-  }
-
-  if (listen(fd, 10) < 0)
-  {
-    CLog::Log(LOGERROR, "JSONRPC Server: Failed to set listen");
-    closesocket(fd);
-    return false;
-  }
   m_servers.push_back(fd);
   return true;
 }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -785,15 +785,16 @@ bool CWebServer::Start(int port, const string &username, const string &password)
   SetCredentials(username, password);
   if (!m_running)
   {
-  	int v6testSock;
-  	if((v6testSock = socket(AF_INET6, SOCK_STREAM, 0)) > 0) {
-      close(v6testSock);
+    int v6testSock;
+    if ((v6testSock = socket(AF_INET6, SOCK_STREAM, 0)) > 0)
+    {
+      closesocket(v6testSock);
       m_daemon_ip6 = StartMHD(MHD_USE_IPv6, port);
-  	}
-
+    }
+    
     m_daemon_ip4 = StartMHD(0 , port);
-
-    m_running = (m_daemon_ip6 != NULL) | (m_daemon_ip4 != NULL);
+    
+    m_running = (m_daemon_ip6 != NULL) || (m_daemon_ip4 != NULL);
     if (m_running)
       CLog::Log(LOGNOTICE, "WebServer: Started the webserver");
     else
@@ -806,15 +807,16 @@ bool CWebServer::Stop()
 {
   if (m_running)
   {
-	if(m_daemon_ip6 != NULL)
-    	MHD_stop_daemon(m_daemon_ip6);
+    if (m_daemon_ip6 != NULL)
+      MHD_stop_daemon(m_daemon_ip6);
 
-	if(m_daemon_ip4 != NULL)
-    	MHD_stop_daemon(m_daemon_ip4);
-
+    if (m_daemon_ip4 != NULL)
+      MHD_stop_daemon(m_daemon_ip4);
+    
     m_running = false;
     CLog::Log(LOGNOTICE, "WebServer: Stopped the webserver");
-  } else 
+  }
+  else 
     CLog::Log(LOGNOTICE, "WebServer: Stopped failed because its not running");
 
   return !m_running;

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -67,7 +67,8 @@ vector<IHTTPRequestHandler *> CWebServer::m_requestHandlers;
 CWebServer::CWebServer()
 {
   m_running = false;
-  m_daemon = NULL;
+  m_daemon_ip6 = NULL;
+  m_daemon_ip4 = NULL;
   m_needcredentials = true;
   m_Credentials64Encoded = "eGJtYzp4Ym1j"; // xbmc:xbmc
 }
@@ -784,9 +785,15 @@ bool CWebServer::Start(int port, const string &username, const string &password)
   SetCredentials(username, password);
   if (!m_running)
   {
-    m_daemon = StartMHD(0 , port);
+  	int v6testSock;
+  	if((v6testSock = socket(AF_INET6, SOCK_STREAM, 0)) > 0) {
+      close(v6testSock);
+      m_daemon_ip6 = StartMHD(MHD_USE_IPv6, port);
+  	}
 
-    m_running = m_daemon != NULL;
+    m_daemon_ip4 = StartMHD(0 , port);
+
+    m_running = (m_daemon_ip6 != NULL) | (m_daemon_ip4 != NULL);
     if (m_running)
       CLog::Log(LOGNOTICE, "WebServer: Started the webserver");
     else
@@ -799,7 +806,12 @@ bool CWebServer::Stop()
 {
   if (m_running)
   {
-    MHD_stop_daemon(m_daemon);
+	if(m_daemon_ip6 != NULL)
+    	MHD_stop_daemon(m_daemon_ip6);
+
+	if(m_daemon_ip4 != NULL)
+    	MHD_stop_daemon(m_daemon_ip4);
+
     m_running = false;
     CLog::Log(LOGNOTICE, "WebServer: Stopped the webserver");
   } else 

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -119,7 +119,8 @@ private:
   static std::string GenerateMultipartBoundary();
   static bool GetLastModifiedDateTime(XFILE::CFile *file, CDateTime &lastModified);
 
-  struct MHD_Daemon *m_daemon;
+  struct MHD_Daemon *m_daemon_ip6;
+  struct MHD_Daemon *m_daemon_ip4;
   bool m_running, m_needcredentials;
   std::string m_Credentials64Encoded;
   CCriticalSection m_critSection;


### PR DESCRIPTION
Rebased and squashed pull request #2668 as per @wsoltys request.

Re-tested on both OSX and linux OK, with and without ipv6 support in kernel : Airplay, Airtunes and Webserver all work OK.
