### PR TITLE
Remove URIUtils::GetExtension(..) function without return value

### DIFF
--- a/lib/UnrarXLib/pathfn.cpp
+++ b/lib/UnrarXLib/pathfn.cpp
@@ -194,15 +194,13 @@ void SetSFXExt(wchar *SFXName)
 
 char *GetExt(const char *Name)
 {
-  CStdString strExtension;
-  URIUtils::GetExtension(Name,strExtension);
+  CStdString strExtension = URIUtils::GetExtension(Name);
   return((char *)strstr((char *)Name,strExtension.c_str()));
 }
 
 wchar *GetExt(const wchar *Name)
 {
-  CStdString strExtension;
-  URIUtils::GetExtension(Name,strExtension);
+  CStdString strExtension = URIUtils::GetExtension(Name);
   return((wchar *)wcsstr((wchar_t *)Name,CStdStringW(strExtension).c_str()));
 }
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -777,7 +777,7 @@ bool CFileItem::IsVideo() const
      return true;
   }
 
-  URIUtils::GetExtension(m_strPath, extension);
+  extension = URIUtils::GetExtension(m_strPath);
 
   if (extension.IsEmpty())
     return false;
@@ -819,8 +819,7 @@ bool CFileItem::IsDiscStub() const
     return dbItem.IsDiscStub();
   }
 
-  CStdString strExtension;
-  URIUtils::GetExtension(m_strPath, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(m_strPath);
 
   if (strExtension.IsEmpty())
     return false;
@@ -852,7 +851,7 @@ bool CFileItem::IsAudio() const
      return true;
   }
 
-  URIUtils::GetExtension(m_strPath, extension);
+  extension = URIUtils::GetExtension(m_strPath);
 
   if (extension.IsEmpty())
     return false;
@@ -922,8 +921,7 @@ bool CFileItem::IsSmartPlayList() const
   if (HasProperty("library.smartplaylist") && GetProperty("library.smartplaylist").asBoolean())
     return true;
 
-  CStdString strExtension;
-  URIUtils::GetExtension(m_strPath, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(m_strPath);
   strExtension.ToLower();
   return (strExtension == ".xsp");
 }
@@ -950,8 +948,7 @@ bool CFileItem::IsNFO() const
 
 bool CFileItem::IsDVDImage() const
 {
-  CStdString strExtension;
-  URIUtils::GetExtension(m_strPath, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(m_strPath);
   return (strExtension.Equals(".img") || strExtension.Equals(".iso") || strExtension.Equals(".nrg"));
 }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -242,8 +242,7 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
 
   CRegExp reTags(true);
   CRegExp reYear;
-  CStdString strExtension;
-  URIUtils::GetExtension(strFileName, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFileName);
 
   if (!reYear.RegComp(g_advancedSettings.m_videoCleanDateTimeRegExp))
   {
@@ -1570,8 +1569,7 @@ void CUtil::GetSkinThemes(vector<CStdString>& vecTheme)
     CFileItemPtr pItem = items[i];
     if (!pItem->m_bIsFolder)
     {
-      CStdString strExtension;
-      URIUtils::GetExtension(pItem->GetPath(), strExtension);
+      CStdString strExtension = URIUtils::GetExtension(pItem->GetPath());
       if ((strExtension == ".xpr" && pItem->GetLabel().CompareNoCase("Textures.xpr")) ||
           (strExtension == ".xbt" && pItem->GetLabel().CompareNoCase("Textures.xbt")))
       {

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -67,9 +67,7 @@ CCDDARipper::~CCDDARipper()
 bool CCDDARipper::RipTrack(CFileItem* pItem)
 {
   // don't rip non cdda items
-  CStdString strExt;
-  URIUtils::GetExtension(pItem->GetPath(), strExt);
-  if (strExt.CompareNoCase(".cdda") != 0) 
+  if (URIUtils::GetExtension(pItem->GetPath()).CompareNoCase(".cdda") != 0)
   {
     CLog::Log(LOGDEBUG, "cddaripper: file is not a cdda track");
     return false;

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -834,7 +834,7 @@ extern "C"
     }
     else if (url.GetFileName().Find("*.") != string::npos)
     {
-      URIUtils::GetExtension(url.GetFileName(),strMask);
+      strMask = URIUtils::GetExtension(url.GetFileName());
       url.SetFileName(url.GetFileName().Left(url.GetFileName().Find("*.")));
     }
     else if (url.GetFileName().Find("*") != string::npos)

--- a/xbmc/cores/paplayer/ASAPCodec.cpp
+++ b/xbmc/cores/paplayer/ASAPCodec.cpp
@@ -38,8 +38,7 @@ bool ASAPCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   CStdString strFileToLoad = strFile;
   int song = -1;
-  CStdString strExtension;
-  URIUtils::GetExtension(strFile, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFile);
   strExtension.MakeLower();
   if (strExtension == ".asapstream")
   {

--- a/xbmc/cores/paplayer/ModplugCodec.cpp
+++ b/xbmc/cores/paplayer/ModplugCodec.cpp
@@ -47,7 +47,7 @@ bool ModplugCodec::Init(const CStdString &strFile, unsigned int filecache)
     return false;
 
   // set correct codec name
-  URIUtils::GetExtension(strFile,m_CodecName);
+  m_CodecName = URIUtils::GetExtension(strFile);
   m_CodecName.erase(0,1);
   m_CodecName.ToUpper();
 

--- a/xbmc/cores/paplayer/NSFCodec.cpp
+++ b/xbmc/cores/paplayer/NSFCodec.cpp
@@ -49,8 +49,7 @@ bool NSFCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   CStdString strFileToLoad = strFile;
   m_iTrack = 0;
-  CStdString strExtension;
-  URIUtils::GetExtension(strFile,strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFile);
   strExtension.MakeLower();
   if (strExtension==".nsfstream")
   {

--- a/xbmc/cores/paplayer/OGGcodec.cpp
+++ b/xbmc/cores/paplayer/OGGcodec.cpp
@@ -55,8 +55,7 @@ bool OGGCodec::Init(const CStdString &strFile1, unsigned int filecache)
 
   m_CurrentStream=0;
 
-  CStdString strExtension;
-  URIUtils::GetExtension(strFile, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFile);
 
   //  A bitstream inside a ogg file?
   if (strExtension==".oggstream")

--- a/xbmc/cores/paplayer/SIDCodec.cpp
+++ b/xbmc/cores/paplayer/SIDCodec.cpp
@@ -47,8 +47,7 @@ bool SIDCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   CStdString strFileToLoad = strFile;
   m_iTrack = 0;
-  CStdString strExtension;
-  URIUtils::GetExtension(strFile,strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFile);
   strExtension.MakeLower();
   if (strExtension==".sidstream")
   {
@@ -154,3 +153,4 @@ CAEChannelInfo SIDCodec::GetChannelInfo()
 
   return CAEChannelInfo(map[m_Channels - 1]);
 }
+

--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -218,8 +218,7 @@ int64_t CFileCDDA::GetLength()
 bool CFileCDDA::IsValidFile(const CURL& url)
 {
   // Only .cdda files are supported
-  CStdString strExtension;
-  URIUtils::GetExtension(url.Get(), strExtension);
+  CStdString strExtension = URIUtils::GetExtension(url.Get());
   strExtension.MakeLower();
 
   return (strExtension == ".cdda");

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -45,13 +45,13 @@ IDirectory::~IDirectory(void)
  */
 bool IDirectory::IsAllowed(const CStdString& strFile) const
 {
-  CStdString strExtension;
   if ( !m_strFileMask.size() ) return true;
   if ( !strFile.size() ) return true;
 
-  URIUtils::GetExtension(strFile, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFile);
 
-  if (!strExtension.size()) return false;
+  if (strExtension.empty())
+    return false;
 
   strExtension.ToLower();
   strExtension += '|'; // ensures that we have a | at the end of it

--- a/xbmc/filesystem/MusicDatabaseFile.cpp
+++ b/xbmc/filesystem/MusicDatabaseFile.cpp
@@ -44,8 +44,7 @@ CStdString CMusicDatabaseFile::TranslateUrl(const CURL& url)
     return "";
 
   CStdString strFileName=URIUtils::GetFileName(url.Get());
-  CStdString strExtension;
-  URIUtils::GetExtension(strFileName, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFileName);
   URIUtils::RemoveExtension(strFileName);
 
   if (!StringUtils::IsNaturalNumber(strFileName))
@@ -57,8 +56,7 @@ CStdString CMusicDatabaseFile::TranslateUrl(const CURL& url)
   if (!musicDatabase.GetSong(idSong, song))
     return "";
 
-  CStdString strExtensionFromDb;
-  URIUtils::GetExtension(song.strFileName, strExtensionFromDb);
+  CStdString strExtensionFromDb = URIUtils::GetExtension(song.strFileName);
 
   if (!strExtensionFromDb.Equals(strExtension))
     return "";

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -88,8 +88,7 @@ bool CRSSDirectory::ContainsFiles(const CStdString& strPath)
 
 static bool IsPathToMedia(const CStdString& strPath )
 {
-  CStdString extension;
-  URIUtils::GetExtension(strPath, extension);
+  CStdString extension = URIUtils::GetExtension(strPath);
 
   if (extension.IsEmpty())
     return false;
@@ -112,8 +111,7 @@ static bool IsPathToThumbnail(const CStdString& strPath )
 {
   // Currently just check if this is an image, maybe we will add some
   // other checks later
-  CStdString extension;
-  URIUtils::GetExtension(strPath, extension);
+  CStdString extension = URIUtils::GetExtension(strPath);
 
   if (extension.IsEmpty())
     return false;

--- a/xbmc/music/karaoke/karaokelyricsfactory.cpp
+++ b/xbmc/music/karaoke/karaokelyricsfactory.cpp
@@ -33,9 +33,9 @@
 // A helper function to have all the checks in a single place
 bool CheckAndCreateLyrics( const CStdString & songName, CKaraokeLyrics ** lyricptr )
 {
-  CStdString ext, filename = songName;
+  CStdString filename = songName;
   URIUtils::RemoveExtension( filename );
-  URIUtils::GetExtension( songName, ext );
+  CStdString ext = URIUtils::GetExtension(songName);
 
   // LRC lyrics have .lrc extension
   if ( XFILE::CFile::Exists( filename + ".lrc" ) )

--- a/xbmc/music/karaoke/karaokelyricstextlrc.cpp
+++ b/xbmc/music/karaoke/karaokelyricstextlrc.cpp
@@ -90,8 +90,7 @@ bool CKaraokeLyricsTextLRC::Load()
 
   unsigned int offset = 0;
 
-  CStdString ext, songfilename = getSongFile();
-  URIUtils::GetExtension( songfilename, ext );
+  CStdString songfilename = getSongFile();
 
   // Skip windoze UTF8 file prefix, if any, and reject UTF16 files
   if ( lyricSize > 3 )

--- a/xbmc/music/tags/MusicInfoTagLoaderASAP.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderASAP.cpp
@@ -41,8 +41,7 @@ bool CMusicInfoTagLoaderASAP::Load(const CStdString &strFile, CMusicInfoTag &tag
 
   CStdString strFileToLoad = strFile;
   int song = -1;
-  CStdString strExtension;
-  URIUtils::GetExtension(strFile, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFile);
   strExtension.MakeLower();
   if (strExtension == ".asapstream")
   {

--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -59,8 +59,7 @@ IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CStdString& 
   if (item.IsMusicDb())
     return new CMusicInfoTagLoaderDatabase();
 
-  CStdString strExtension;
-  URIUtils::GetExtension( strFileName, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFileName);
   strExtension.ToLower();
   strExtension.TrimLeft('.');
 

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -88,8 +88,7 @@ static const vector<string> StringListToVectorString(const StringList& stringLis
 
 bool CTagLoaderTagLib::Load(const string& strFileName, CMusicInfoTag& tag, EmbeddedArt *art /* = NULL */)
 {  
-  CStdString strExtension;
-  URIUtils::GetExtension(strFileName, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(strFileName);
   strExtension.ToLower();
   strExtension.TrimLeft('.');
 

--- a/xbmc/utils/DownloadQueue.cpp
+++ b/xbmc/utils/DownloadQueue.cpp
@@ -97,8 +97,7 @@ TICKET CDownloadQueue::RequestFile(const CStdString& aUrl, IDownloadQueueObserve
 
   CLog::Log(LOGDEBUG, "RequestFile from observer at %p", aObserver);
   // create a temporary destination
-  CStdString strExtension;
-  URIUtils::GetExtension(aUrl, strExtension);
+  CStdString strExtension = URIUtils::GetExtension(aUrl);
 
   TICKET ticket(m_wQueueId, m_dwNextItemId++);
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -54,28 +54,19 @@ bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
 }
 
 /* returns filename extension including period of filename */
-const CStdString URIUtils::GetExtension(const CStdString& strFileName)
+CStdString URIUtils::GetExtension(const CStdString& strFileName)
 {
-  if(IsURL(strFileName))
+  if (IsURL(strFileName))
   {
     CURL url(strFileName);
     return GetExtension(url.GetFileName());
   }
 
-  int period = strFileName.find_last_of('.');
-  if(period >= 0)
-  {
-    if( strFileName.find_first_of('/', period+1) != string::npos ) return "";
-    if( strFileName.find_first_of('\\', period+1) != string::npos ) return "";
-    return strFileName.substr(period);
-  }
-  else
-    return "";
-}
+  size_t period = strFileName.find_last_of("./\\");
+  if (period == string::npos || strFileName[period] != '.')
+    return CStdString();
 
-void URIUtils::GetExtension(const CStdString& strFile, CStdString& strExtension)
-{
-  strExtension = GetExtension(strFile);
+  return strFileName.substr(period);
 }
 
 void URIUtils::RemoveExtension(CStdString& strFileName)
@@ -94,8 +85,7 @@ void URIUtils::RemoveExtension(CStdString& strFileName)
   // Extension found
   if (iPos > 0)
   {
-    CStdString strExtension;
-    GetExtension(strFileName, strExtension);
+    CStdString strExtension = GetExtension(strFileName);
     strExtension.ToLower();
     strExtension += "|";
 
@@ -126,8 +116,7 @@ CStdString URIUtils::ReplaceExtension(const CStdString& strFile,
   }
 
   CStdString strChangedFile;
-  CStdString strExtension;
-  GetExtension(strFile, strExtension);
+  CStdString strExtension = GetExtension(strFile);
   if ( strExtension.size() )
   {
     strChangedFile = strFile.substr(0, strFile.size() - strExtension.size()) ;
@@ -550,8 +539,7 @@ bool URIUtils::IsStack(const CStdString& strFile)
 
 bool URIUtils::IsRAR(const CStdString& strFile)
 {
-  CStdString strExtension;
-  GetExtension(strFile,strExtension);
+  CStdString strExtension = GetExtension(strFile);
 
   if (strExtension.Equals(".001") && strFile.Mid(strFile.length()-7,7).CompareNoCase(".ts.001"))
     return true;
@@ -593,19 +581,12 @@ bool URIUtils::IsInRAR(const CStdString& strFile)
 
 bool URIUtils::IsAPK(const CStdString& strFile)
 {
-  CStdString strExtension;
-  GetExtension(strFile,strExtension);
-
-  if (strExtension.CompareNoCase(".apk") == 0)
-    return true;
-
-  return false;
+  return GetExtension(strFile).CompareNoCase(".apk") == 0;
 }
 
 bool URIUtils::IsZIP(const CStdString& strFile) // also checks for comic books!
 {
-  CStdString strExtension;
-  GetExtension(strFile,strExtension);
+  CStdString strExtension = GetExtension(strFile);
 
   if (strExtension.CompareNoCase(".zip") == 0)
     return true;
@@ -618,8 +599,7 @@ bool URIUtils::IsZIP(const CStdString& strFile) // also checks for comic books!
 
 bool URIUtils::IsArchive(const CStdString& strFile)
 {
-  CStdString extension;
-  GetExtension(strFile, extension);
+  CStdString extension = GetExtension(strFile);
 
   return (extension.CompareNoCase(".zip") == 0 ||
           extension.CompareNoCase(".rar") == 0 ||

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -35,10 +35,9 @@ public:
   static void GetDirectory(const CStdString& strFilePath,
                            CStdString& strDirectoryPath);
   static CStdString GetDirectory(const CStdString &filePath);
-
-  static const CStdString GetExtension(const CStdString& strFileName);
-  static void GetExtension(const CStdString& strFile, CStdString& strExtension);
   static const CStdString GetFileName(const CStdString& strFileNameAndPath);
+
+  static CStdString GetExtension(const CStdString& strFileName);
   static void RemoveExtension(CStdString& strFileName);
   static CStdString ReplaceExtension(const CStdString& strFile,
                                      const CStdString& strNewExtension);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -64,15 +64,8 @@ TEST_F(TestURIUtils, GetDirectory)
 
 TEST_F(TestURIUtils, GetExtension)
 {
-  CStdString ref, var;
-
-  ref = ".avi";
-  EXPECT_STREQ(ref.c_str(),
+  EXPECT_STREQ(".avi",
                URIUtils::GetExtension("/path/to/movie.avi").c_str());
-
-  var.clear();
-  URIUtils::GetExtension("/path/to/movie.avi", var);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 
 TEST_F(TestURIUtils, GetFileName)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1494,8 +1494,7 @@ namespace VIDEO
     if (!item->m_bIsFolder)
     {
       // file
-      CStdString strExtension;
-      URIUtils::GetExtension(item->GetPath(), strExtension);
+      CStdString strExtension = URIUtils::GetExtension(item->GetPath());
 
       if (URIUtils::IsInRAR(item->GetPath())) // we have a rarred item - we want to check outside the rars
       {

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -494,9 +494,8 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   for (int i = 0; i < (int)m_vecItems[iList]->Size(); i++)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
-    CStdString strExtension;
-    URIUtils::GetExtension(pItem->GetPath(), strExtension);
-    if (pItem->IsHD() && strExtension == ".tbn")
+    if (pItem->IsHD() &&
+        URIUtils::GetExtension(pItem->GetPath()).CompareNoCase(".tbn") == 0)
     {
       pItem->SetArt("thumb", pItem->GetPath());
     }


### PR DESCRIPTION
Like my earlier PR but this time for void URIUtils::GetExtension(..).
