### PR TITLE
Revert curl ratelimit

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -905,11 +905,11 @@ bool CCurlFile::Open(const CURL& url)
   map<string, EndTime>::iterator it = s_hostLastAccessTime.find(url2.GetHostName());
   if (it != s_hostLastAccessTime.end())
   {
-    s_hostLastAccessTime.erase(it);
     if (!it->second.IsTimePast()) {
       CLog::Log(LOGDEBUG, "CurlFile::Open(%p) rate limiting queries to '%s' to avoid saturating, waiting %dmsec", (void*)this, it->first.c_str(), it->second.MillisLeft());
       Sleep(it->second.MillisLeft());
     }
+    s_hostLastAccessTime.erase(it);
   }
   s_hostLastAccessTime.insert(make_pair(url2.GetHostName(), EndTime(1500)));
   lock.Leave();

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -382,7 +382,6 @@ void CCurlFile::CReadState::Disconnect()
 
 CCurlFile::~CCurlFile()
 {
-  CSingleLock lock(s_hostMapLock);
   Close();
   delete m_state;
   delete m_oldState;
@@ -901,33 +900,20 @@ bool CCurlFile::Open(const CURL& url)
   CURL url2(url);
   ParseAndCorrectUrl(url2);
 
-  map<string, EndTime>::iterator it;
   // Rate-limit queries per domain to 1 per 2s
-  {
-    CSingleLock lock(s_hostMapLock);
-    it = s_hostLastAccessTime.find(url2.GetHostName());
-  }
+  CSingleLock lock(s_hostMapLock);
+  map<string, EndTime>::iterator it = s_hostLastAccessTime.find(url2.GetHostName());
   if (it != s_hostLastAccessTime.end())
   {
+    s_hostLastAccessTime.erase(it);
     if (!it->second.IsTimePast()) {
       CLog::Log(LOGDEBUG, "CurlFile::Open(%p) rate limiting queries to '%s' to avoid saturating, waiting %dmsec", (void*)this, it->first.c_str(), it->second.MillisLeft());
       Sleep(it->second.MillisLeft());
     }
-    {
-      CSingleLock lock(s_hostMapLock);
-      try {
-        s_hostLastAccessTime.erase(it);
-      }
-      catch (...)
-      {
-        CLog::Log(LOGERROR, "CurlFile::Open(%p) iterator invalidated while we were sleeping", (void*)this);
-      }
-    }
   }
-  {
-    CSingleLock lock(s_hostMapLock);
-    s_hostLastAccessTime.insert(make_pair(url2.GetHostName(), EndTime(2000)));
-  }
+  s_hostLastAccessTime.insert(make_pair(url2.GetHostName(), EndTime(1500)));
+  lock.Leave();
+
   CLog::Log(LOGDEBUG, "CurlFile::Open(%p) %s", (void*)this, m_url.c_str());
 
   ASSERT(!(!m_state->m_easyHandle ^ !m_state->m_multiHandle));

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -26,7 +26,6 @@
 #include "settings/Settings.h"
 #include "File.h"
 
-#include <map>
 #include <vector>
 #include <climits>
 
@@ -43,12 +42,9 @@
 #include "SpecialProtocol.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
-#include "utils/TimeUtils.h"
 
-using namespace std;
 using namespace XFILE;
 using namespace XCURL;
-using namespace XbmcThreads;
 
 #define XMIN(a,b) ((a)<(b)?(a):(b))
 #define FITS_INT(a) (((a) <= INT_MAX) && ((a) >= INT_MIN))
@@ -63,9 +59,6 @@ curl_proxytype proxyType2CUrlProxyType[] = {
   CURLPROXY_SOCKS5,
   CURLPROXY_SOCKS5_HOSTNAME,
 };
-
-static CCriticalSection s_hostMapLock;
-static map<string, EndTime> s_hostLastAccessTime; // used to rate-limit queries by host/domain
 
 // curl calls this routine to debug
 extern "C" int debug_callback(CURL_HANDLE *handle, curl_infotype info, char *output, size_t size, void *data)
@@ -899,20 +892,6 @@ bool CCurlFile::Open(const CURL& url)
 
   CURL url2(url);
   ParseAndCorrectUrl(url2);
-
-  // Rate-limit queries per domain to 1 per 2s
-  CSingleLock lock(s_hostMapLock);
-  map<string, EndTime>::iterator it = s_hostLastAccessTime.find(url2.GetHostName());
-  if (it != s_hostLastAccessTime.end())
-  {
-    if (!it->second.IsTimePast()) {
-      CLog::Log(LOGDEBUG, "CurlFile::Open(%p) rate limiting queries to '%s' to avoid saturating, waiting %dmsec", (void*)this, it->first.c_str(), it->second.MillisLeft());
-      Sleep(it->second.MillisLeft());
-    }
-    s_hostLastAccessTime.erase(it);
-  }
-  s_hostLastAccessTime.insert(make_pair(url2.GetHostName(), EndTime(1500)));
-  lock.Leave();
 
   CLog::Log(LOGDEBUG, "CurlFile::Open(%p) %s", (void*)this, m_url.c_str());
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1551,6 +1551,10 @@ bool CMusicInfoScanner::ResolveMusicBrainz(const CStdString strMusicBrainzID, Sc
     }
     if (!musicBrainzURL.m_url.empty())
     {
+      Sleep(2000); // MusicBrainz rate-limits queries to 1 p.s - once we hit the rate-limiter
+                   // they start serving up the 'you hit the rate-limiter' page fast - meaning
+                   // we will never get below the rate-limit threshold again in a specific run. 
+                   // This helps us to avoidthe rate-limiter as far as possible.
       CLog::Log(LOGDEBUG,"-- nfo-scraper: %s",vecScrapers[i]->Name().c_str());
       CLog::Log(LOGDEBUG,"-- nfo url: %s", musicBrainzURL.m_url[0].m_url.c_str());
       musicInfoScraper.SetScraperInfo(vecScrapers[i]);


### PR DESCRIPTION
as mentioned in https://github.com/xbmc/xbmc/commit/241a4fc0babb108f652b993b2b40a20397433118#commitcomment-3190048 we are going to revert the non-generic ratelimit code recently added into curl. and if still need the feature, we need a better implement which not affect other codes using CurlFile.

@night199uk @jmarshallnz
