### PR TITLE
[rbp] fixed compile on raspberrypi

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -18,15 +18,15 @@
  *
  */
 
-#include "EGLNativeTypeAmlogic.h"
-#include "guilib/gui3d.h"
-#include "utils/AMLUtils.h"
-#include "utils/StringUtils.h"
-
 #include <stdlib.h>
 #include <linux/fb.h>
 #include <sys/ioctl.h>
 #include <EGL/egl.h>
+
+#include "EGLNativeTypeAmlogic.h"
+#include "guilib/gui3d.h"
+#include "utils/AMLUtils.h"
+#include "utils/StringUtils.h"
 
 CEGLNativeTypeAmlogic::CEGLNativeTypeAmlogic()
 {


### PR DESCRIPTION
fixing the following compile error on raspberrypi introduced by https://github.com/xbmc/xbmc/pull/2691

make: Entering directory `/media/usbdisk/xbmc/xbmc-bcm/xbmc-rbp/xbmc/windowing/egl'
CPP     xbmc/windowing/egl/EGLNativeTypeAmlogic.o
In file included from /media/usbdisk/xbmc/xbmc-bcm/buildroot-rbp/output/host/usr/arm-unknown-linux-gnueabi/sysroot/usr/include/linux/fb.h:5:0,
                 from EGLNativeTypeAmlogic.cpp:31:
                 /media/usbdisk/xbmc/xbmc-bcm/buildroot-rbp/output/host/usr/arm-unknown-linux-gnueabi/sysroot/usr/include/linux/i2c.h:126:7: error: multiple types in one declaration
                 /media/usbdisk/xbmc/xbmc-bcm/buildroot-rbp/output/host/usr/arm-unknown-linux-gnueabi/sysroot/usr/include/linux/i2c.h:126:7: error: declaration does not declare anything [-fpermissive]
                 make: **\* [EGLNativeTypeAmlogic.o] Fehler 1
