### PR TITLE
Linux: fix handling of zombie processes

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1637,6 +1637,15 @@ bool CUtil::Command(const CStdStringArray& arrArgs, bool waitExit)
   int n = 0;
   if (child == 0)
   {
+    if (!waitExit)
+    {
+      // fork again in order not to leave a zombie process
+      child = fork();
+      if (child == -1)
+        _exit(2);
+      else if (child != 0)
+        _exit(0);
+    }
     close(0);
     close(1);
     close(2);
@@ -1651,7 +1660,7 @@ bool CUtil::Command(const CStdStringArray& arrArgs, bool waitExit)
   }
   else
   {
-    if (waitExit) waitpid(child, &n, 0);
+    waitpid(child, &n, 0);
   }
 
   return (waitExit) ? (WEXITSTATUS(n) == 0) : true;


### PR DESCRIPTION
after SA_NOCLDWAIT has been removed from main.cpp by the wake on access pr which also fixes an issue with Nvidia driver 319.17 we need some other method for handling zomie processes.

Needs testing.
