### PR TITLE
[fix] ping timeout option for darwin

### DIFF
--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -535,7 +535,11 @@ bool CNetworkLinux::PingHost(unsigned long remote_ip, unsigned int timeout_ms)
   struct in_addr host_ip; 
   host_ip.s_addr = remote_ip;
 
+#if defined(TARGET_DARWIN)
+  sprintf(cmd_line, "ping -c 1 -t %d %s", timeout_ms / 1000 + (timeout_ms % 1000) != 0, inet_ntoa(host_ip));
+#else
   sprintf(cmd_line, "ping -c 1 -w %d %s", timeout_ms / 1000 + (timeout_ms % 1000) != 0, inet_ntoa(host_ip));
+#endif
 
   int status = system (cmd_line);
 


### PR DESCRIPTION
- timeout option -w is invalid on osx, should be -t
- needs testing (osx + ios I assume)

@da-anda hope this PR is more like they should be ;)
