### PR TITLE
RenderManager refactoring

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -416,8 +416,6 @@ CApplication::CApplication(void)
 #endif
   m_currentStack = new CFileItemList;
 
-  m_frameCount = 0;
-
   m_bPresentFrame = false;
   m_bPlatformDirectories = true;
 
@@ -2034,32 +2032,6 @@ float CApplication::GetDimScreenSaverLevel() const
   return 100.0f;
 }
 
-bool CApplication::WaitFrame(unsigned int timeout)
-{
-  bool done = false;
-
-  // Wait for all other frames to be presented
-  CSingleLock lock(m_frameMutex);
-  //wait until event is set, but modify remaining time
-
-  TightConditionVariable<InversePredicate<int&> > cv(m_frameCond, InversePredicate<int&>(m_frameCount));
-  cv.wait(lock,timeout);
-  done = m_frameCount == 0;
-
-  return done;
-}
-
-void CApplication::NewFrame()
-{
-  // We just posted another frame. Keep track and notify.
-  {
-    CSingleLock lock(m_frameMutex);
-    m_frameCount++;
-  }
-
-  m_frameCond.notifyAll();
-}
-
 void CApplication::Render()
 {
   // do not render if we are stopped or in background
@@ -2070,7 +2042,6 @@ void CApplication::Render()
 
   int vsync_mode = CSettings::Get().GetInt("videoscreen.vsync");
 
-  bool decrement = false;
   bool hasRendered = false;
   bool limitFrames = false;
   unsigned int singleFrameTime = 10; // default limit 100 fps
@@ -2084,13 +2055,7 @@ void CApplication::Render()
     m_bPresentFrame = false;
     if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !IsPaused() && g_renderManager.RendererHandlesPresent())
     {
-      CSingleLock lock(m_frameMutex);
-
-      TightConditionVariable<int&> cv(m_frameCond,m_frameCount);
-      cv.wait(lock,100);
-
-      m_bPresentFrame = m_frameCount > 0;
-      decrement = m_bPresentFrame;
+      m_bPresentFrame = g_renderManager.FrameWait(100);
       hasRendered = true;
     }
     else
@@ -2115,7 +2080,6 @@ void CApplication::Render()
           singleFrameTime = 200;  // 5 fps, <=200 ms latency to wake up
       }
 
-      decrement = true;
     }
   }
 
@@ -2181,13 +2145,6 @@ void CApplication::Render()
 
   g_renderManager.UpdateResolution();
   g_renderManager.ManageCaptures();
-
-  {
-    CSingleLock lock(m_frameMutex);
-    if(m_frameCount > 0 && decrement)
-      m_frameCount--;
-  }
-  m_frameCond.notifyAll();
 }
 
 void CApplication::SetStandAlone(bool value)
@@ -5506,12 +5463,6 @@ bool CApplication::SwitchToFullScreen()
   // See if we're playing a video, and are in GUI mode
   if ( IsPlayingVideo() && g_windowManager.GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO)
   {
-    // Reset frame count so that timing is FPS will be correct.
-    {
-      CSingleLock lock(m_frameMutex);
-      m_frameCount = 0;
-    }
-
     // then switch to fullscreen mode
     g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
     return true;
@@ -5744,10 +5695,7 @@ bool CApplication::IsCurrentThread() const
 
 bool CApplication::IsPresentFrame()
 {
-  CSingleLock lock(m_frameMutex);
-  bool ret = m_bPresentFrame;
-
-  return ret;
+  return m_bPresentFrame;
 }
 
 void CApplication::SetRenderGUI(bool renderGUI)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1763,13 +1763,10 @@ void CApplication::LoadSkin(const SkinPtr& skin)
     if (bPreviousPlayingState)
       g_application.m_pPlayer->Pause();
 #ifdef HAS_VIDEO_PLAYBACK
-    if (!g_renderManager.Paused())
+    if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
     {
-      if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
-     {
-        g_windowManager.ActivateWindow(WINDOW_HOME);
-        bPreviousRenderingState = true;
-      }
+      g_windowManager.ActivateWindow(WINDOW_HOME);
+      bPreviousRenderingState = true;
     }
 #endif
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2090,6 +2090,9 @@ void CApplication::Render()
   else if (vsync_mode != VSYNC_DRIVER)
     g_Windowing.SetVSync(false);
 
+  if (m_bPresentFrame && IsPlaying() && !IsPaused())
+    ResetScreenSaver();
+
   if(!g_Windowing.BeginRender())
     return;
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2004,13 +2004,7 @@ bool CApplication::RenderNoPresent()
   // dont show GUI when playing full screen video
   if (g_graphicsContext.IsFullScreenVideo())
   {
-    if (m_bPresentFrame && IsPlaying() && !IsPaused())
-    {
-      ResetScreenSaver();
-      g_renderManager.Present();
-    }
-    else
-      g_renderManager.RenderUpdate(true);
+    g_renderManager.Render(true, 0, 255);
 
     // close window overlays
     CGUIDialog *overlay = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_OVERLAY);
@@ -2138,9 +2132,13 @@ void CApplication::Render()
   if(!g_Windowing.BeginRender())
     return;
 
+  g_renderManager.FrameMove();
+
   CDirtyRegionList dirtyRegions = g_windowManager.GetDirty();
   if (RenderNoPresent())
     hasRendered = true;
+
+  g_renderManager.FrameFinish();
 
   g_Windowing.EndRender();
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5693,11 +5693,6 @@ bool CApplication::IsCurrentThread() const
   return CThread::IsCurrentThread(m_threadID);
 }
 
-bool CApplication::IsPresentFrame()
-{
-  return m_bPresentFrame;
-}
-
 void CApplication::SetRenderGUI(bool renderGUI)
 {
   if (renderGUI && ! m_renderGUI)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -339,8 +339,6 @@ public:
     return m_bTestMode;
   }
 
-  bool IsPresentFrame();
-
   void Minimize();
   bool ToggleDPMS(bool manual);
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -301,8 +301,6 @@ public:
   CStdString m_strPlayListFile;
 
   int GlobalIdleTime();
-  void NewFrame();
-  bool WaitFrame(unsigned int timeout);
 
   void EnablePlatformDirectories(bool enable=true)
   {
@@ -432,10 +430,6 @@ protected:
   bool m_bEnableLegacyRes;
   bool m_bTestMode;
   bool m_bSystemScreenSaverEnable;
-
-  int        m_frameCount;
-  CCriticalSection m_frameMutex;
-  XbmcThreads::ConditionVariable  m_frameCond;
 
   VIDEO::CVideoInfoScanner *m_videoInfoScanner;
   MUSIC_INFO::CMusicInfoScanner *m_musicInfoScanner;

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -58,7 +58,6 @@ public:
   virtual void GetAudioInfo(CStdString& strAudioInfo);
   virtual void GetVideoInfo(CStdString& strVideoInfo);
   virtual void GetGeneralInfo( CStdString& strVideoInfo);
-  virtual void Update(bool bPauseDrawing)                       {}
   virtual void SwitchToNextAudioLanguage();
   virtual bool CanRecord() { return false; }
   virtual bool IsRecording() { return false; }

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -145,7 +145,6 @@ public:
   virtual void GetAudioInfo( CStdString& strAudioInfo) = 0;
   virtual void GetVideoInfo( CStdString& strVideoInfo) = 0;
   virtual void GetGeneralInfo( CStdString& strVideoInfo) = 0;
-  virtual void Update(bool bPauseDrawing = false) = 0;
   virtual bool CanRecord() { return false;};
   virtual bool IsRecording() { return false;};
   virtual bool Record(bool bOnOff) { return false;};

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -620,7 +620,7 @@ void CLinuxRendererGL::Flush()
   m_fbo.fbo.Cleanup();
 }
 
-void CLinuxRendererGL::Update(bool bPauseDrawing)
+void CLinuxRendererGL::Update()
 {
   if (!m_bConfigured) return;
   ManageDisplay();

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -124,7 +124,7 @@ public:
   CLinuxRendererGL();
   virtual ~CLinuxRendererGL();
 
-  virtual void Update(bool bPauseDrawing);
+  virtual void Update();
   virtual void SetupScreenshot() {};
 
   bool RenderCapture(CRenderCapture* capture);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -412,7 +412,7 @@ void CLinuxRendererGLES::Reset()
   }
 }
 
-void CLinuxRendererGLES::Update(bool bPauseDrawing)
+void CLinuxRendererGLES::Update()
 {
   if (!m_bConfigured) return;
   ManageDisplay();

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -124,7 +124,7 @@ public:
   CLinuxRendererGLES();
   virtual ~CLinuxRendererGLES();
 
-  virtual void Update(bool bPauseDrawing);
+  virtual void Update();
   virtual void SetupScreenshot() {};
 
   bool RenderCapture(CRenderCapture* capture);

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -302,7 +302,7 @@ bool CXBMCRenderManager::FrameWait(int ms)
   while(m_presentstep == PRESENT_IDLE && !timeout.IsTimePast())
   {
     lock.Leave();
-    m_presentevent.WaitMSec(100);
+    m_presentevent.WaitMSec(timeout.MillisLeft());
     lock.Enter();
   }
   return m_presentstep != PRESENT_IDLE;

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -299,7 +299,7 @@ void CXBMCRenderManager::Update(bool bPauseDrawing)
   m_presentevent.Set();
 }
 
-void CXBMCRenderManager::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
+void CXBMCRenderManager::FrameMove()
 {
   { CRetakeLock<CExclusiveLock> lock(m_sharedSection);
     if (!m_pRenderer)
@@ -313,16 +313,32 @@ void CXBMCRenderManager::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
       m_presentevent.Set();
     }
   }
+}
 
-  if (g_advancedSettings.m_videoDisableBackgroundDeinterlace)
-  {
-    CSharedLock lock(m_sharedSection);
-    PresentSingle(clear, flags, alpha);
+void CXBMCRenderManager::FrameFinish()
+{
+  /* wait for this present to be valid */
+  if(g_graphicsContext.IsFullScreenVideo())
+    WaitPresentTime(m_presenttime);
+
+  { CRetakeLock<CExclusiveLock> lock(m_sharedSection);
+
+    if(m_presentstep == PRESENT_FRAME)
+    {
+      if( m_presentmethod == PRESENT_METHOD_BOB
+      ||  m_presentmethod == PRESENT_METHOD_WEAVE)
+      {
+        m_presentstep = PRESENT_FRAME2;
+        g_application.NewFrame();
+      }
+      else
+        m_presentstep = PRESENT_IDLE;
+    }
+    else if(m_presentstep == PRESENT_FRAME2)
+      m_presentstep = PRESENT_IDLE;
+
+    m_presentevent.Set();
   }
-  else
-    Render(clear, flags, alpha);
-
-  m_presentevent.Set();
 }
 
 unsigned int CXBMCRenderManager::PreInit()
@@ -687,37 +703,12 @@ void CXBMCRenderManager::Render(bool clear, DWORD flags, DWORD alpha)
   m_overlays.Render();
 }
 
-void CXBMCRenderManager::Present()
-{
-  { CRetakeLock<CExclusiveLock> lock(m_sharedSection);
-    if (!m_pRenderer)
-      return;
-
-    if(m_presentstep == PRESENT_FLIP)
-    {
-      m_overlays.Flip();
-      m_pRenderer->FlipPage(m_presentsource);
-      m_presentstep = PRESENT_FRAME;
-      m_presentevent.Set();
-    }
-  }
-
-  Render(true, 0, 255);
-
-  /* wait for this present to be valid */
-  if(g_graphicsContext.IsFullScreenVideo())
-    WaitPresentTime(m_presenttime);
-
-  m_presentevent.Set();
-}
-
 /* simple present method */
 void CXBMCRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
 {
   CSingleLock lock(g_graphicsContext);
 
   m_pRenderer->RenderUpdate(clear, flags, alpha);
-  m_presentstep = PRESENT_IDLE;
 }
 
 /* new simpler method of handling interlaced material, *
@@ -732,8 +723,6 @@ void CXBMCRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
       m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOT | RENDER_FLAG_FIELD0, alpha);
     else
       m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_TOP | RENDER_FLAG_FIELD0, alpha);
-    m_presentstep = PRESENT_FRAME2;
-    g_application.NewFrame();
   }
   else
   {
@@ -741,7 +730,6 @@ void CXBMCRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
       m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOT | RENDER_FLAG_FIELD1, alpha);
     else
       m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_TOP | RENDER_FLAG_FIELD1, alpha);
-    m_presentstep = PRESENT_IDLE;
   }
 }
 
@@ -759,7 +747,6 @@ void CXBMCRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
     m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_TOP | RENDER_FLAG_NOOSD, alpha);
     m_pRenderer->RenderUpdate(false, flags | RENDER_FLAG_BOT, alpha / 2);
   }
-  m_presentstep = PRESENT_IDLE;
 }
 
 void CXBMCRenderManager::Recover()

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -92,7 +92,6 @@ private:
 CXBMCRenderManager::CXBMCRenderManager()
 {
   m_pRenderer = NULL;
-  m_bPauseDrawing = false;
   m_bIsStarted = false;
 
   m_presentfield = FS_NONE;
@@ -264,7 +263,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     if( format & RENDER_FMT_BYPASS )
       m_presentmethod = PRESENT_METHOD_BYPASS;
 
-    m_pRenderer->Update(false);
+    m_pRenderer->Update();
     m_bIsStarted = true;
     m_bReconfigured = true;
     m_presentstep = PRESENT_IDLE;
@@ -286,15 +285,12 @@ bool CXBMCRenderManager::IsConfigured() const
   return m_pRenderer->IsConfigured();
 }
 
-void CXBMCRenderManager::Update(bool bPauseDrawing)
+void CXBMCRenderManager::Update()
 {
   CRetakeLock<CExclusiveLock> lock(m_sharedSection);
 
-  m_bPauseDrawing = bPauseDrawing;
   if (m_pRenderer)
-  {
-    m_pRenderer->Update(bPauseDrawing);
-  }
+    m_pRenderer->Update();
 
   m_presentevent.Set();
 }
@@ -361,7 +357,6 @@ unsigned int CXBMCRenderManager::PreInit()
   memset(m_errorbuff, 0, sizeof(m_errorbuff));
 
   m_bIsStarted = false;
-  m_bPauseDrawing = false;
   if (!m_pRenderer)
   {
 #if defined(HAS_GL)

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -601,6 +601,9 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
     EDEINTERLACEMODE deinterlacemode = CMediaSettings::Get().GetCurrentVideoSettings().m_DeinterlaceMode;
     EINTERLACEMETHOD interlacemethod = AutoInterlaceMethodInternal(CMediaSettings::Get().GetCurrentVideoSettings().m_InterlaceMethod);
 
+    if(g_advancedSettings.m_videoDisableBackgroundDeinterlace && !g_graphicsContext.IsFullScreenVideo())
+      deinterlacemode = VS_DEINTERLACEMODE_OFF;
+
     if (deinterlacemode == VS_DEINTERLACEMODE_OFF)
       m_presentmethod = PRESENT_METHOD_SINGLE;
     else

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -299,6 +299,19 @@ void CXBMCRenderManager::Update(bool bPauseDrawing)
   m_presentevent.Set();
 }
 
+bool CXBMCRenderManager::FrameWait(int ms)
+{
+  XbmcThreads::EndTime timeout(ms);
+  CRetakeLock<CExclusiveLock> lock(m_sharedSection);
+  while(m_presentstep == PRESENT_IDLE && !timeout.IsTimePast())
+  {
+    lock.Leave();
+    m_presentevent.WaitMSec(100);
+    lock.Enter();
+  }
+  return m_presentstep != PRESENT_IDLE;
+}
+
 void CXBMCRenderManager::FrameMove()
 {
   { CRetakeLock<CExclusiveLock> lock(m_sharedSection);
@@ -327,10 +340,7 @@ void CXBMCRenderManager::FrameFinish()
     {
       if( m_presentmethod == PRESENT_METHOD_BOB
       ||  m_presentmethod == PRESENT_METHOD_WEAVE)
-      {
         m_presentstep = PRESENT_FRAME2;
-        g_application.NewFrame();
-      }
       else
         m_presentstep = PRESENT_IDLE;
     }
@@ -631,7 +641,6 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
 
   }
 
-  g_application.NewFrame();
   /* wait untill render thread have flipped buffers */
   timeout = m_presenttime + 1.0;
   while(m_presentstep == PRESENT_FLIP && !bStop)

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -54,7 +54,9 @@ public:
   void GetVideoRect(CRect &source, CRect &dest);
   float GetAspectRatio();
   void Update(bool bPauseDrawing);
-  void RenderUpdate(bool clear, DWORD flags = 0, DWORD alpha = 255);
+  void FrameMove();
+  void FrameFinish();
+  void Render(bool clear, DWORD flags = 0, DWORD alpha = 255);
   void SetupScreenshot();
 
   CRenderCapture* AllocRenderCapture();
@@ -127,7 +129,6 @@ public:
   // Supported pixel formats, can be called before configure
   std::vector<ERenderFormat> SupportedFormats();
 
-  void Present();
   void Recover(); // called after resolution switch if something special is needed
 
   CSharedSection& GetSection() { return m_sharedSection; };
@@ -136,7 +137,6 @@ public:
   void RegisterRenderFeaturesCallBack(const void *ctx, RenderFeaturesCallBackFn fn);
 
 protected:
-  void Render(bool clear, DWORD flags, DWORD alpha);
 
   void PresentSingle(bool clear, DWORD flags, DWORD alpha);
   void PresentFields(bool clear, DWORD flags, DWORD alpha);

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -53,7 +53,7 @@ public:
   // Functions called from the GUI
   void GetVideoRect(CRect &source, CRect &dest);
   float GetAspectRatio();
-  void Update(bool bPauseDrawing);
+  void Update();
   void FrameMove();
   void FrameFinish();
   bool FrameWait(int ms);
@@ -95,7 +95,6 @@ public:
   RESOLUTION GetResolution();
 
   float GetMaximumFPS();
-  inline bool Paused() { return m_bPauseDrawing; };
   inline bool IsStarted() { return m_bIsStarted;}
   double GetDisplayLatency() { return m_displayLatency; }
 
@@ -144,8 +143,6 @@ protected:
   void PresentBlend(bool clear, DWORD flags, DWORD alpha);
 
   EINTERLACEMETHOD AutoInterlaceMethodInternal(EINTERLACEMETHOD mInt);
-
-  bool m_bPauseDrawing;   // true if we should pause rendering
 
   bool m_bIsStarted;
   CSharedSection m_sharedSection;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -56,6 +56,7 @@ public:
   void Update(bool bPauseDrawing);
   void FrameMove();
   void FrameFinish();
+  bool FrameWait(int ms);
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255);
   void SetupScreenshot();
 

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -316,7 +316,7 @@ void CWinRenderer::Reset()
 {
 }
 
-void CWinRenderer::Update(bool bPauseDrawing)
+void CWinRenderer::Update()
 {
   if (!m_bConfigured) return;
   ManageDisplay();

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -150,7 +150,7 @@ public:
   CWinRenderer();
   ~CWinRenderer();
 
-  virtual void Update(bool bPauseDrawing);
+  virtual void Update();
   virtual void SetupScreenshot() {};
 
   bool RenderCapture(CRenderCapture* capture);

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -1049,11 +1049,6 @@ int CAMLPlayer::AddSubtitle(const CStdString& strSubPath)
   return AddSubtitleFile(strSubPath);
 }
 
-void CAMLPlayer::Update(bool bPauseDrawing)
-{
-  g_renderManager.Update(bPauseDrawing);
-}
-
 void CAMLPlayer::GetVideoRect(CRect& SrcRect, CRect& DestRect)
 {
   g_renderManager.GetVideoRect(SrcRect, DestRect);

--- a/xbmc/cores/amlplayer/AMLPlayer.h
+++ b/xbmc/cores/amlplayer/AMLPlayer.h
@@ -88,7 +88,6 @@ public:
   virtual void  GetAudioInfo(CStdString &strAudioInfo);
   virtual void  GetVideoInfo(CStdString &strVideoInfo);
   virtual void  GetGeneralInfo(CStdString &strVideoInfo) {};
-  virtual void  Update(bool bPauseDrawing);
   virtual void  GetVideoRect(CRect& SrcRect, CRect& DestRect);
   virtual void  GetVideoAspectRatio(float &fAR);
   virtual bool  CanRecord()                                       {return false;};

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -192,7 +192,6 @@ public:
   virtual void GetAudioInfo(CStdString& strAudioInfo);
   virtual void GetVideoInfo(CStdString& strVideoInfo);
   virtual void GetGeneralInfo( CStdString& strVideoInfo);
-  virtual void Update(bool bPauseDrawing)                       { m_dvdPlayerVideo.Update(bPauseDrawing); }
   virtual bool CanRecord();
   virtual bool IsRecording();
   virtual bool CanPause();

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1093,21 +1093,26 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   double config_framerate = m_bFpsInvalid ? 0.0 : m_fFrameRate;
   /* check so that our format or aspect has changed. if it has, reconfigure renderer */
   if (!g_renderManager.IsConfigured()
-   || m_output.width != pPicture->iWidth
-   || m_output.height != pPicture->iHeight
-   || m_output.dwidth != pPicture->iDisplayWidth
-   || m_output.dheight != pPicture->iDisplayHeight
-   || m_output.framerate != config_framerate
-   || m_output.color_format != (unsigned int)pPicture->format
-   || m_output.extended_format != pPicture->extended_format
-   || ( m_output.color_matrix != pPicture->color_matrix && pPicture->color_matrix != 0 ) // don't reconfigure on unspecified
+   || ( m_output.width           != pPicture->iWidth )
+   || ( m_output.height          != pPicture->iHeight )
+   || ( m_output.dwidth          != pPicture->iDisplayWidth )
+   || ( m_output.dheight         != pPicture->iDisplayHeight )
+   || ( m_output.framerate       != config_framerate )
+   || ( m_output.color_format    != (unsigned int)pPicture->format )
+   || ( m_output.extended_format != pPicture->extended_format )
+   || ( m_output.color_matrix    != pPicture->color_matrix    && pPicture->color_matrix    != 0 ) // don't reconfigure on unspecified
    || ( m_output.chroma_position != pPicture->chroma_position && pPicture->chroma_position != 0 )
    || ( m_output.color_primaries != pPicture->color_primaries && pPicture->color_primaries != 0 )
-   || ( m_output.color_transfer != pPicture->color_transfer && pPicture->color_transfer != 0 )
-   || m_output.color_range != pPicture->color_range)
+   || ( m_output.color_transfer  != pPicture->color_transfer  && pPicture->color_transfer  != 0 )
+   || ( m_output.color_range     != pPicture->color_range ))
   {
-    CLog::Log(LOGNOTICE, " fps: %f, pwidth: %i, pheight: %i, dwidth: %i, dheight: %i",
-      config_framerate, pPicture->iWidth, pPicture->iHeight, pPicture->iDisplayWidth, pPicture->iDisplayHeight);
+    CLog::Log(LOGNOTICE, " fps: %f, pwidth: %i, pheight: %i, dwidth: %i, dheight: %i"
+                       , config_framerate
+                       , pPicture->iWidth
+                       , pPicture->iHeight
+                       , pPicture->iDisplayWidth
+                       , pPicture->iDisplayHeight);
+
     unsigned flags = 0;
     if(pPicture->color_range == 1)
       flags |= CONF_FLAGS_YUV_FULLRANGE;
@@ -1126,24 +1131,32 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
     }
 
     CLog::Log(LOGDEBUG,"%s - change configuration. %dx%d. framerate: %4.2f. format: %s",__FUNCTION__,pPicture->iWidth, pPicture->iHeight, config_framerate, formatstr.c_str());
-    if(!g_renderManager.Configure(pPicture->iWidth, pPicture->iHeight, pPicture->iDisplayWidth, pPicture->iDisplayHeight, config_framerate, flags, pPicture->format, pPicture->extended_format, m_hints.orientation))
+    if(!g_renderManager.Configure(pPicture->iWidth
+                                , pPicture->iHeight
+                                , pPicture->iDisplayWidth
+                                , pPicture->iDisplayHeight
+                                , config_framerate
+                                , flags
+                                , pPicture->format
+                                , pPicture->extended_format
+                                , m_hints.orientation))
     {
       CLog::Log(LOGERROR, "%s - failed to configure renderer", __FUNCTION__);
       return EOS_ABORT;
     }
 
-    m_output.width = pPicture->iWidth;
-    m_output.height = pPicture->iHeight;
-    m_output.dwidth = pPicture->iDisplayWidth;
-    m_output.dheight = pPicture->iDisplayHeight;
-    m_output.framerate = config_framerate;
-    m_output.color_format = pPicture->format;
+    m_output.width           = pPicture->iWidth;
+    m_output.height          = pPicture->iHeight;
+    m_output.dwidth          = pPicture->iDisplayWidth;
+    m_output.dheight         = pPicture->iDisplayHeight;
+    m_output.framerate       = config_framerate;
+    m_output.color_format    = pPicture->format;
     m_output.extended_format = pPicture->extended_format;
-    m_output.color_matrix = pPicture->color_matrix;
+    m_output.color_matrix    = pPicture->color_matrix;
     m_output.chroma_position = pPicture->chroma_position;
     m_output.color_primaries = pPicture->color_primaries;
-    m_output.color_transfer = pPicture->color_transfer;
-    m_output.color_range = pPicture->color_range;
+    m_output.color_transfer  = pPicture->color_transfer;
+    m_output.color_range     = pPicture->color_range;
   }
 
   double maxfps  = 60.0;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -61,12 +61,6 @@ public:
   bool IsInited() const                             { return m_messageQueue.IsInited(); }
   void SendMessage(CDVDMsg* pMsg, int priority = 0) { m_messageQueue.Put(pMsg, priority); }
 
-#ifdef HAS_VIDEO_PLAYBACK
-  void Update(bool bPauseDrawing)                   { g_renderManager.Update(bPauseDrawing); }
-#else
-  void Update(bool bPauseDrawing)                   { }
-#endif
-
   void EnableSubtitle(bool bEnable)                 { m_bRenderSubs = bEnable; }
   bool IsSubtitleEnabled()                          { return m_bRenderSubs; }
 

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -4305,11 +4305,6 @@ bool COMXPlayer::WaitForPausedThumbJobs(int timeout_ms)
   return false;
 }
 
-void COMXPlayer::Update(bool bPauseDrawing)
-{
-  g_renderManager.Update(bPauseDrawing);
-}
-
 void COMXPlayer::GetRenderFeatures(std::vector<int> &renderFeatures)
 {
   renderFeatures.push_back(RENDERFEATURE_STRETCH);

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -236,7 +236,6 @@ public:
   virtual void  GetAudioInfo(CStdString &strAudioInfo);
   virtual void  GetVideoInfo(CStdString &strVideoInfo);
   virtual void  GetGeneralInfo(CStdString &strVideoInfo);
-  virtual void  Update(bool bPauseDrawing);
   virtual void  UpdateApplication(double timeout);
   virtual bool  CanRecord();
   virtual bool  IsRecording();

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -59,7 +59,6 @@ public:
   virtual void GetAudioInfo( CStdString& strAudioInfo) {}
   virtual void GetVideoInfo( CStdString& strVideoInfo) {}
   virtual void GetGeneralInfo( CStdString& strVideoInfo) {}
-  virtual void Update(bool bPauseDrawing = false) {}
   virtual void ToFFRW(int iSpeed = 0);
   virtual int GetCacheLevel() const;
   virtual int64_t GetTotalTime();

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -68,7 +68,7 @@ void CGUIVideoControl::Render()
 
 #ifdef HAS_VIDEO_PLAYBACK
     color_t alpha = g_graphicsContext.MergeAlpha(0xFF000000) >> 24;
-    g_renderManager.RenderUpdate(false, 0, alpha);
+    g_renderManager.Render(false, 0, alpha);
 #else
     ((CDummyVideoPlayer *)g_application.m_pPlayer)->Render();
 #endif

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -47,7 +47,6 @@ public:
   virtual void GetAudioInfo( CStdString& strAudioInfo) {};
   virtual void GetVideoInfo( CStdString& strVideoInfo) {};
   virtual void GetGeneralInfo( CStdString& strVideoInfo) {};
-  virtual void Update(bool bPauseDrawing = false)  {};
   virtual bool CanRecord() { return false;};
   virtual bool IsRecording() { return false;};
   virtual bool Record(bool bOnOff) { return false;};

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -125,7 +125,7 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
       g_graphicsContext.SetVideoResolution(CDisplaySettings::Get().GetCurrentResolution());
       // Inform the player so we can update the resolution
 #ifdef HAS_VIDEO_PLAYBACK
-      g_renderManager.Update(false);
+      g_renderManager.Update();
 #endif
       g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
     }
@@ -146,7 +146,7 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
         RESOLUTION res = g_renderManager.GetResolution();
         g_graphicsContext.SetVideoResolution(res);
         // Inform the renderer so we can update the resolution
-        g_renderManager.Update(false);
+        g_renderManager.Update();
 #endif
 
         m_iCurRes = 0;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -393,7 +393,7 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
 
 #ifdef HAS_VIDEO_PLAYBACK
       // make sure renderer is uptospeed
-      g_renderManager.Update(false);
+      g_renderManager.Update();
 #endif
       // now call the base class to load our windows
       CGUIWindow::OnMessage(message);
@@ -450,7 +450,7 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
 
 #ifdef HAS_VIDEO_PLAYBACK
       // make sure renderer is uptospeed
-      g_renderManager.Update(false);
+      g_renderManager.Update();
 #endif
 
       CSingleLock lockFont(m_fontLock);


### PR DESCRIPTION
Here are some render manager and dvdplayervideo refactoring that had queued up in my 3d branch. Thought i'd split them out.

They will cause conflicts with https://github.com/xbmc/xbmc/pull/2309 but I think they do create a better base for that to stand on. The removal of frame waits in application are directly stolen from the buffering pull, but implemented inline with the current event model in the render manager.

I know this will create a messy merge for @FernetMenta, I may have some time to do that merge he following days thou. 
