### PR TITLE
Get rid of #define byte in PlatformDefs.h

### DIFF
--- a/lib/UnrarXLib/rartypes.hpp
+++ b/lib/UnrarXLib/rartypes.hpp
@@ -1,9 +1,7 @@
 #ifndef _RAR_TYPES_
 #define _RAR_TYPES_
 
-#ifndef byte
 typedef unsigned char    byte;   //8 bits
-#endif
 typedef unsigned short   ushort; //preferably 16 bits, but can be more
 typedef unsigned int     uint;   //32 bits or more
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DllLibMad.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DllLibMad.h
@@ -22,8 +22,6 @@
 #if (defined HAVE_CONFIG_H) && (!defined WIN32)
   #include "config.h"
 #endif
-/* undefine byte from PlatformDefs.h since it's used in mad.h */
-#undef byte
 #if defined(_LINUX) || defined(TARGET_DARWIN)
   #include <mad.h>
 #else

--- a/xbmc/filesystem/ISOFile.cpp
+++ b/xbmc/filesystem/ISOFile.cpp
@@ -87,7 +87,7 @@ unsigned int CISOFile::Read(void *lpBuf, int64_t uiBufSize)
 
       if (m_cache.getMaxWriteSize() > 5000)
       {
-        byte buffer[5000];
+        uint8_t buffer[5000];
         long lBytesRead = m_isoReader.ReadFile( m_hFile, buffer, sizeof(buffer));
         if (lBytesRead > 0)
           m_cache.WriteData((char*)buffer, lBytesRead);
@@ -97,7 +97,7 @@ unsigned int CISOFile::Read(void *lpBuf, int64_t uiBufSize)
     }
     return lTotalBytesRead;
   }
-  int iResult = m_isoReader.ReadFile( m_hFile, (byte*)pData, (long)uiBufSize);
+  int iResult = m_isoReader.ReadFile( m_hFile, (uint8_t*)pData, (long)uiBufSize);
   if (iResult == -1)
     return 0;
   return iResult;

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -287,7 +287,7 @@ unsigned int CRarFile::Read(void *lpBuf, int64_t uiBufSize)
   }
 
 
-  byte* pBuf = (byte*)lpBuf;
+  uint8_t* pBuf = (uint8_t*)lpBuf;
   int64_t uicBufSize = uiBufSize;
   if (m_iDataInBuffer > 0)
   {
@@ -718,7 +718,7 @@ bool CRarFile::OpenInArchive()
       m_pArc->SeekToNext();
     }
 
-    m_szBuffer = new byte[MAXWINMEMSIZE];
+    m_szBuffer = new uint8_t[MAXWINMEMSIZE];
     m_szStartOfBuffer = m_szBuffer;
     m_pExtract->GetDataIO().SetUnpackToMemory(m_szBuffer,0);
     m_iDataInBuffer = -1;

--- a/xbmc/filesystem/RarFile.h
+++ b/xbmc/filesystem/RarFile.h
@@ -104,8 +104,8 @@ namespace XFILE
     CmdExtract* m_pExtract;
     CRarFileExtractThread* m_pExtractThread;
 #endif
-    byte* m_szBuffer;
-    byte* m_szStartOfBuffer;
+    uint8_t* m_szBuffer;
+    uint8_t* m_szStartOfBuffer;
     int64_t m_iDataInBuffer;
     int64_t m_iBufferStart;
   };

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -752,7 +752,7 @@ HANDLE iso9660::OpenFile(const char *filename)
 
   pContext->m_dwCurrentBlock = m_searchpointer->Location;
   pContext->m_dwFileSize = m_info.curr_filesize = fileinfo.nFileSizeLow;
-  pContext->m_pBuffer = new byte[CIRC_BUFFER_SIZE * BUFFER_SIZE];
+  pContext->m_pBuffer = new uint8_t[CIRC_BUFFER_SIZE * BUFFER_SIZE];
   pContext->m_dwStartBlock = pContext->m_dwCurrentBlock;
   pContext->m_dwFilePos = 0;
   pContext->m_dwCircBuffBegin = 0;
@@ -791,7 +791,7 @@ void iso9660::CloseFile(HANDLE hFile)
   FreeFileContext(hFile);
 }
 //************************************************************************************
-bool iso9660::ReadSectorFromCache(iso9660::isofile* pContext, DWORD sector, byte** ppBuffer)
+bool iso9660::ReadSectorFromCache(iso9660::isofile* pContext, DWORD sector, uint8_t** ppBuffer)
 {
 
   DWORD StartSectorInCircBuff = pContext->m_dwCircBuffSectorStart;
@@ -891,7 +891,7 @@ void iso9660::ReleaseSectorFromCache(iso9660::isofile* pContext, DWORD sector)
   }
 }
 //************************************************************************************
-long iso9660::ReadFile(HANDLE hFile, byte *pBuffer, long lSize)
+long iso9660::ReadFile(HANDLE hFile, uint8_t *pBuffer, long lSize)
 {
   bool bError;
   long iBytesRead = 0;
@@ -912,7 +912,7 @@ long iso9660::ReadFile(HANDLE hFile, byte *pBuffer, long lSize)
     //sprintf(szBuf,"pos:%i cblk:%i sblk:%i off:%i",(long)m_dwFilePos, (long)m_dwCurrentBlock,(long)m_dwStartBlock,(long)iOffsetInBuffer);
     //DBG(szBuf);
 
-    byte* pSector;
+    uint8_t* pSector;
     bError = !ReadSectorFromCache(pContext, pContext->m_dwCurrentBlock, &pSector);
     if (!bError)
     {

--- a/xbmc/filesystem/iso9660.h
+++ b/xbmc/filesystem/iso9660.h
@@ -185,7 +185,7 @@ public:
   int64_t GetFilePosition(HANDLE hFile);
   int64_t Seek(HANDLE hFile, int64_t lOffset, int whence);
   HANDLE OpenFile( const char* filename );
-  long ReadFile(HANDLE fd, byte *pBuffer, long lSize);
+  long ReadFile(HANDLE fd, uint8_t *pBuffer, long lSize);
   void CloseFile(HANDLE hFile);
   void Reset();
   void Scan();
@@ -196,7 +196,7 @@ protected:
   struct iso_dirtree* ReadRecursiveDirFromSector( DWORD sector, const char * );
   struct iso_dirtree* FindFolder( char *Folder );
   std::string GetThinText(BYTE* strTxt, int iLen );
-  bool ReadSectorFromCache(iso9660::isofile* pContext, DWORD sector, byte** ppBuffer);
+  bool ReadSectorFromCache(iso9660::isofile* pContext, DWORD sector, uint8_t** ppBuffer);
   void ReleaseSectorFromCache(iso9660::isofile* pContext, DWORD sector);
   const std::string ParseName(struct iso9660_Directory& isodir);
   HANDLE AllocFileContext();

--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -155,7 +155,6 @@
 #define ZeroMemory(dst,size) memset(dst, 0, size)
 
 #define VOID    void
-#define byte    unsigned char
 #define __int8    char
 #define __int16   short
 #define __int32   int

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -36,7 +36,6 @@
 #include <taglib/unsynchronizedlyricsframe.h>
 #include <taglib/attachedpictureframe.h>
 
-#undef byte
 #include <taglib/tstring.h>
 #include <taglib/tpropertymap.h>
 

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -20,7 +20,6 @@
  *
  */
 
-#undef byte
 #include <taglib/aifffile.h>
 #include <taglib/apefile.h>
 #include <taglib/asffile.h>

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -18,15 +18,15 @@
  *
  */
 
-#include <stdlib.h>
-#include <linux/fb.h>
-#include <sys/ioctl.h>
-#include <EGL/egl.h>
-
 #include "EGLNativeTypeAmlogic.h"
 #include "guilib/gui3d.h"
 #include "utils/AMLUtils.h"
 #include "utils/StringUtils.h"
+
+#include <stdlib.h>
+#include <linux/fb.h>
+#include <sys/ioctl.h>
+#include <EGL/egl.h>
 
 CEGLNativeTypeAmlogic::CEGLNativeTypeAmlogic()
 {


### PR DESCRIPTION
As far as I could tell (OSX) used only in rarlib + iso9660.  Removed in the latter, and it was already typedef'd in the former.

IOS, Android, OSX built fine.  Needs linux (don't anticipate any issues) and win32 (jenkins build failed).

Reverts the kludgy fix of #2727, thus needs testing on rpi.
