### PR TITLE
settings: move dependency handling into CSettingsManager and fix videoscreen settings

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1837,7 +1837,11 @@
           <constraints>
             <options>screens</options>
           </constraints>
-          <control type="spinner" format="string" delayed="true" />
+          <control type="spinner" format="string" delayed="true">
+            <dependencies>
+              <dependency type="update" setting="videoscreen.screenmode" />
+            </dependencies>
+          </control>
         </setting>
         <setting id="videoscreen.resolution" type="integer" label="169" help="">
           <level>0</level>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -505,10 +505,7 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
         // when fullscreen, remain fullscreen and resize to the dimensions of the new screen
         RESOLUTION newRes = (RESOLUTION) g_Windowing.DesktopResolution(g_Windowing.GetCurrentScreen());
         if (newRes != g_graphicsContext.GetVideoResolution())
-        {
           CDisplaySettings::Get().SetCurrentResolution(newRes, true);
-          g_graphicsContext.SetVideoResolution(newRes);
-        }
       }
       else
 #endif

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -30,6 +30,7 @@
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
 #include "Util.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "guilib/GUIWindowManager.h"
 #include "FileItem.h"

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -27,6 +27,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -25,6 +25,7 @@
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/WindowIDs.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"

--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -343,7 +343,7 @@ void CAEFactory::SettingOptionsAudioDevicesFillerGeneral(const CSetting *setting
         firstDevice = sink->second;
 
 #if defined(TARGET_DARWIN)
-      list.push_back(StringSettingOption(sink->first, sink->first));
+      list.push_back(std::make_pair(sink->first, sink->first));
 #else
       list.push_back(std::make_pair(sink->first, sink->second));
 #endif

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -21,6 +21,7 @@
 #include "Application.h"
 #include "threads/SingleLock.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogProgress.h"

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -22,6 +22,7 @@
 #include "GUIAudioManager.h"
 #include "Key.h"
 #include "input/ButtonTranslator.h"
+#include "settings/Setting.h"
 #include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -857,7 +857,6 @@ bool CGraphicContext::ToggleFullScreenRoot ()
 #endif
   }
 
-  SetVideoResolution(newRes);
   CDisplaySettings::Get().SetCurrentResolution(uiRes, true);
 
   return m_bFullScreenRoot;

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -25,6 +25,7 @@
 #include "ApplicationMessenger.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "cores/VideoRenderers/RenderManager.h"
 #include "windowing/WindowingFactory.h"

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -23,6 +23,7 @@
 #include "ButtonTranslator.h"
 #include "peripherals/devices/PeripheralImon.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Setting.h"
 #include "utils/log.h"
 
 #include <math.h>

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -473,7 +473,6 @@ int CBuiltins::Execute(const CStdString& execString)
     if (g_graphicsContext.IsValidResolution(res))
     {
       CDisplaySettings::Get().SetCurrentResolution(res, true);
-      g_graphicsContext.SetVideoResolution(res);
       g_application.ReloadSkin();
     }
   }

--- a/xbmc/linux/LinuxTimezone.cpp
+++ b/xbmc/linux/LinuxTimezone.cpp
@@ -35,6 +35,7 @@
 
 #include "Util.h"
 #include "XBDateTime.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 
 using namespace std;

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -74,6 +74,7 @@
 #endif
 
 #include "settings/AdvancedSettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/RssManager.h"

--- a/xbmc/osx/XBMCHelper.cpp
+++ b/xbmc/osx/XBMCHelper.cpp
@@ -32,6 +32,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "utils/log.h"
 #include "system.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "utils/SystemInfo.h"
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -106,7 +106,7 @@ void CGUIDialogPeripheralSettings::CreateSettings()
               {
                 m_intTextSettings.insert(make_pair(CStdString(intSetting->GetId()), intSetting->GetValue()));
                 vector<pair<int, int> > entries;
-                SettingOptions::const_iterator entriesItr = intSetting->GetOptions().begin();
+                StaticIntegerSettingOptions::const_iterator entriesItr = intSetting->GetOptions().begin();
                 while (entriesItr != intSetting->GetOptions().end())
                 {
                   entries.push_back(make_pair(entriesItr->first, entriesItr->second));

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -23,6 +23,7 @@
 #include "Application.h"
 #include "cores/AudioEngine/AEFactory.h"
 #include "input/KeyboardStat.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "windowing/WindowingFactory.h"
 #include "utils/log.h"

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -32,6 +32,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "windows/GUIWindowPVR.h"

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "settings/AdvancedSettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogYesNo.h"

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -28,6 +28,7 @@
 #include "utils/LangCodeExpander.h"
 #include "LangInfo.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -570,6 +570,15 @@ void CDisplaySettings::SettingOptionsScreensFiller(const CSetting *setting, std:
     int screen = CDisplaySettings::Get().GetResolutionInfo(RES_DESKTOP + idx).iScreen;
     list.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(241), screen + 1), screen));
   }
+
+  RESOLUTION res = CDisplaySettings::Get().GetDisplayResolution();
+  if (res == RES_WINDOW)
+    current = DM_WINDOWED;
+  else
+  {
+    RESOLUTION_INFO resInfo = CDisplaySettings::Get().GetResolutionInfo(res);
+    current = resInfo.iScreen;
+  }
 }
 
 void CDisplaySettings::SettingOptionsVerticalSyncsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current)

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -27,6 +27,7 @@
 #include "guilib/gui3d.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -99,6 +99,8 @@ protected:
   CDisplaySettings const& operator=(CDisplaySettings const&);
   virtual ~CDisplaySettings();
 
+  DisplayMode GetCurrentDisplayMode() const;
+
   static RESOLUTION GetResolutionFromString(const std::string &strResolution);
   static std::string GetStringFromResolution(RESOLUTION resolution, float refreshrate = 0.0f);
   static RESOLUTION GetResolutionForScreen();

--- a/xbmc/settings/ISettingCallback.h
+++ b/xbmc/settings/ISettingCallback.h
@@ -73,4 +73,15 @@ public:
    \return True if the setting has been successfully updated otherwise false
    */
   virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) { return false; }
+
+  /*!
+   \brief The given property of the given setting has changed
+
+   This callback is triggered when a property (e.g. enabled or the list of
+   dynamic options) has changed.
+
+   \param setting The setting which has a changed property
+   \param propertyName The string representation of the changed property
+   */
+  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName) { }
 };

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -169,6 +169,14 @@ bool CSetting::OnSettingUpdate(CSetting* &setting, const char *oldSettingId, con
   return m_callback->OnSettingUpdate(setting, oldSettingId, oldSettingNode);
 }
 
+void CSetting::OnSettingPropertyChanged(const CSetting *setting, const char *propertyName)
+{
+  if (m_callback == NULL)
+    return;
+
+  m_callback->OnSettingPropertyChanged(setting, propertyName);
+}
+
 void CSetting::Copy(const CSetting &setting)
 {
   SetVisible(setting.IsVisible());

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -137,6 +137,24 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   return true;
 }
   
+bool CSetting::IsEnabled() const
+{
+  bool enabled = true;
+  for (SettingDependencies::const_iterator depIt = m_dependencies.begin(); depIt != m_dependencies.end(); ++depIt)
+  {
+    if (depIt->GetType() != SettingDependencyTypeEnable)
+      continue;
+
+    if (!depIt->Check())
+    {
+      enabled = false;
+      break;
+    }
+  }
+
+  return enabled;
+}
+
 bool CSetting::OnSettingChanging(const CSetting *setting)
 {
   if (m_callback == NULL)

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -95,6 +95,7 @@ protected:
   virtual void OnSettingChanged(const CSetting *setting);
   virtual void OnSettingAction(const CSetting *setting);
   virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
+  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName);
 
   void Copy(const CSetting &setting);
 

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -56,8 +56,18 @@ typedef enum {
   SettingLevelInternal
 } SettingLevel;
 
-typedef std::pair<int, int> SettingOption;
-typedef std::vector<SettingOption> SettingOptions;
+typedef enum {
+  SettingOptionsTypeNone = 0,
+  SettingOptionsTypeStatic,
+  SettingOptionsTypeDynamic
+} SettingOptionsType;
+
+typedef std::pair<int, int> StaticIntegerSettingOption;
+typedef std::vector<StaticIntegerSettingOption> StaticIntegerSettingOptions;
+typedef std::pair<std::string, int> DynamicIntegerSettingOption;
+typedef std::vector<DynamicIntegerSettingOption> DynamicIntegerSettingOptions;
+typedef std::pair<std::string, std::string> DynamicStringSettingOption;
+typedef std::vector<DynamicStringSettingOption> DynamicStringSettingOptions;
 
 /*!
  \ingroup settings
@@ -160,7 +170,7 @@ public:
   CSettingInt(const std::string &id, const CSettingInt &setting);
   CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, int format, int minimumLabel, CSettingsManager *settingsManager = NULL);
   CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, const std::string &format, CSettingsManager *settingsManager = NULL);
-  CSettingInt(const std::string &id, int label, int value, const SettingOptions &options, CSettingsManager *settingsManager = NULL);
+  CSettingInt(const std::string &id, int label, int value, const StaticIntegerSettingOptions &options, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingInt() { }
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
@@ -185,8 +195,10 @@ public:
   int GetFormat() const { return m_format; }
   int GetMinimumLabel() const { return m_labelMin; }
   const std::string& GetFormatString() const { return m_strFormat; }
-  const SettingOptions& GetOptions() const { return m_options; }
+  SettingOptionsType GetOptionsType() const;
+  const StaticIntegerSettingOptions& GetOptions() const { return m_options; }
   const std::string& GetOptionsFiller() const { return m_optionsFiller; }
+  DynamicIntegerSettingOptions UpdateDynamicOptions();
 
 private:
   void copy(const CSettingInt &setting);
@@ -200,8 +212,9 @@ private:
   int m_format;
   int m_labelMin;
   std::string m_strFormat;
-  SettingOptions m_options;
+  StaticIntegerSettingOptions m_options;
   std::string m_optionsFiller;
+  DynamicIntegerSettingOptions m_dynamicOptions;
 };
 
 /*!
@@ -277,7 +290,9 @@ public:
   virtual bool AllowEmpty() const { return m_allowEmpty; }
   virtual int GetHeading() const { return m_heading; }
 
+  SettingOptionsType GetOptionsType() const;
   const std::string& GetOptionsFiller() const { return m_optionsFiller; }
+  DynamicStringSettingOptions UpdateDynamicOptions();
 
 protected:
   virtual void copy(const CSettingString &setting);
@@ -287,6 +302,7 @@ protected:
   bool m_allowEmpty;
   int m_heading;
   std::string m_optionsFiller;
+  DynamicStringSettingOptions m_dynamicOptions;
 };
 
 /*!

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -83,6 +83,7 @@ public:
 
   int GetLabel() const { return m_label; }
   int GetHelp() const { return m_help; }
+  bool IsEnabled() const;
   SettingLevel GetLevel() const { return m_level; }
   const CSettingControl& GetControl() const { return m_control; }
   const SettingDependencies& GetDependencies() const { return m_dependencies; }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -457,21 +457,6 @@ CSettingSection* CSettings::GetSection(const std::string &section) const
   return m_settingsManager->GetSection(section);
 }
 
-SettingDependencyMap CSettings::GetDependencies(const std::string &id) const
-{
-  return m_settingsManager->GetDependencies(id);
-}
-
-SettingDependencyMap CSettings::GetDependencies(const CSetting *setting) const
-{
-  return m_settingsManager->GetDependencies(setting);
-}
-
-void* CSettings::GetSettingOptionsFiller(const CSetting *setting)
-{
-  return m_settingsManager->GetSettingOptionsFiller(setting);
-}
-
 bool CSettings::GetBool(const std::string &id) const
 {
   return m_settingsManager->GetBool(id);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -24,9 +24,9 @@
 
 #include "settings/ISettingCallback.h"
 #include "settings/ISettingCreator.h"
-#include "settings/Setting.h"
 #include "threads/CriticalSection.h"
 
+class CSetting;
 class CSettingSection;
 class CSettingsManager;
 class TiXmlElement;
@@ -152,39 +152,6 @@ public:
    \return Setting section with the given identifier or NULL if the identifier is unknown
    */
   CSettingSection* GetSection(const std::string &section) const;
-  /*!
-   \brief Gets a map of settings (and their dependencies) which depend on
-   the setting with the given identifier.
-
-   It is important to note that the returned dependencies are not the
-   dependencies of the setting with the given identifier but the settings
-   (and their dependencies) which depend on the setting with the given
-   identifier.
-
-   \param id Setting identifier
-   \return Map of settings (and their dependencies) which depend on the setting with the given identifier
-   */
-  SettingDependencyMap GetDependencies(const std::string &id) const;
-  /*!
-   \brief Gets a map of settings (and their dependencies) which depend on
-   the given setting.
-
-   It is important to note that the returned dependencies are not the
-   dependencies of the given setting but the settings (and their dependencies)
-   which depend on the given setting.
-
-   \param setting Setting object
-   \return Map of settings (and their dependencies) which depend on the given setting
-   */
-  SettingDependencyMap GetDependencies(const CSetting *setting) const;
-  /*!
-   \brief Gets the implementation of the setting options filler used by the
-   given setting.
-
-   \param setting Setting object
-   \return Implementation of the setting options filler (either IntegerSettingOptionsFiller or StringSettingOptionsFiller)
-   */
-  void* GetSettingOptionsFiller(const CSetting *setting);
 
   /*!
    \brief Gets the boolean value of the setting with the given identifier.

--- a/xbmc/settings/SettingsManager.h
+++ b/xbmc/settings/SettingsManager.h
@@ -38,12 +38,8 @@ class CSettingUpdate;
 class TiXmlElement;
 class TiXmlNode;
 
-typedef std::pair<std::string, int> IntegerSettingOption;
-typedef std::pair<std::string, std::string> StringSettingOption;
-typedef std::vector<IntegerSettingOption> IntegerSettingOptions;
-typedef std::vector<StringSettingOption> StringSettingOptions;
-typedef void (*IntegerSettingOptionsFiller)(const CSetting *setting, IntegerSettingOptions &list, int &current);
-typedef void (*StringSettingOptionsFiller)(const CSetting *setting, StringSettingOptions &list, std::string &current);
+typedef void (*IntegerSettingOptionsFiller)(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
+typedef void (*StringSettingOptionsFiller)(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
 
 /*!
  \ingroup settings
@@ -371,6 +367,7 @@ private:
   bool LoadSetting(const TiXmlNode *node, CSetting *setting);
   bool UpdateSettings(const TiXmlNode *root);
   bool UpdateSetting(const TiXmlNode *node, CSetting *setting, const CSettingUpdate& update);
+  void UpdateSettingByDependency(const std::string &settingId, const CSettingDependency &dependency);
 
   typedef enum {
     SettingOptionsFillerTypeNone = 0,

--- a/xbmc/settings/SettingsManager.h
+++ b/xbmc/settings/SettingsManager.h
@@ -353,6 +353,7 @@ private:
   virtual void OnSettingChanged(const CSetting *setting);
   virtual void OnSettingAction(const CSetting *setting);
   virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode);
+  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName);
 
   // implementation of ISettingsHandler
   virtual bool OnSettingsLoading();

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -58,17 +58,6 @@ public:
   bool IsDelayed() const { return m_delayed; }
 
   /*!
-   \brief Specifies that this setting is enabled or disabled
-   This is used for settings which are enabled/disabled based
-   on conditions involving other settings and their values.
-   It must not be confused with a setting spin control being
-   disabled because it contains less than two items.
-   \param enabled Whether the setting is enabled or disabled
-   \sa IsEnabled()
-   */
-  void SetEnabled(bool enabled) { m_enabled = enabled; }
-
-  /*!
    \brief Returns whether this setting is enabled or disabled
    This state is independent of the real enabled state of a
    setting control but represents the enabled state of the
@@ -76,7 +65,7 @@ public:
    \return true if the setting is enabled otherwise false
    \sa SetEnabled()
    */
-  bool IsEnabled() const { return m_enabled; }
+  bool IsEnabled() const;
 
   virtual CGUIControl* GetControl() { return NULL; }
   virtual bool OnClick() { return false; }
@@ -86,7 +75,6 @@ protected:
   int m_id;
   CSetting* m_pSetting;
   bool m_delayed;
-  bool m_enabled;
 };
 
 class CGUIControlRadioButtonSetting : public CGUIControlBaseSetting
@@ -116,6 +104,8 @@ public:
   virtual void Update();
   virtual void Clear() { m_pSpin = NULL; }
 private:
+  void FillControl();
+  void FillIntegerSettingControl();
   CGUISpinControlEx *m_pSpin;
 };
 

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.h
@@ -56,9 +56,7 @@ protected:
 
   virtual void OnTimeout();
   virtual void OnSettingChanged(const CSetting *setting);
-  
-  void UpdateControl(const std::string &dependingSetting, const CSettingDependency &dependency);
-  void CheckDependency(BaseSettingControlPtr pSettingControl, const CSettingDependency &dependency);
+  virtual void OnSettingPropertyChanged(const CSetting *setting, const char *propertyName);
   
   void CreateSettings();
   void UpdateSettings();
@@ -82,8 +80,6 @@ protected:
   CSettingSection* GetSection(int windowID) const;
   BaseSettingControlPtr GetSettingControl(const std::string &setting);
   BaseSettingControlPtr GetSettingControl(int controlId);
-
-  void FillControl(CSetting *pSetting, CGUIControl *pSettingControl);
   
   CSettings& m_settings;
   SettingCategoryList m_categories;

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -28,6 +28,7 @@
 #include "Temperature.h"
 #include "network/Network.h"
 #include "Application.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -21,6 +21,7 @@
 #include "WinSystem.h"
 #include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
+#include "settings/Setting.h"
 #include "settings/Settings.h"
 
 using namespace std;


### PR DESCRIPTION
This is an attempt to fix the problems with the videoscreen settings popup and switching between windowed and fullscreen mode.

To make sure that all settings depending on the value of another setting are always up-to-date I have moved the logic to handle those dependencies from CGUIWindowSettingsCategory to CSettingsManager. Initially I thought the dependencies would only affect the GUI controls (enabled/disabled etc) but they can also affect the value of another setting so handling this in CSettingsManager makes more sense. It also means that we should probably move the &lt;dependencies&gt; tag out of the &lt;control&gt; tag and directly into the &lt;setting&gt; tag but that can still be done later.

To be able to react to changes of the enabled status or if the list of possible options of a setting has changed I added the OnSettingPropertyChanged() callback to ISettingCallback but I'm not completely happy with this. I don't want to "abuse" the OnSettingChanged() callback if the value hasn't changed but I don't like the additional OnSettingPropertyChanged() callback either :-/

Furthermore I have moved the logic to retrieve the list of dynamic options (those which are determined during runtime with a registered method implementation outside of the settings system) into CSettingInt/String so that the rest of XBMC doesn't really have to know about the registered methods etc. Right now there are GetOptions() and UpdateDynamicOptions() (because a change of options may lead to a change of the setting's value). I first tried to provide a single GetOptions() method but the problem is that the options pre-defined in settings.xml use string IDs for localization whereas the dynamic options use already localized strings.

Last but not least I have extended the logic to handle changes to videoscreen.foo settings to not show a prompt when changing from/to windowed mode as suggested by @jmarshallnz. Furthermore thanks to the automatic dependency handling in CSettingsManager all the videoscreen.foo settings should always be in sync i.e. changing videoscreen.screenmode will automatically affect the values of videoscreen.screen and videoscreen.resolution (and vice versa but that was already present before).

I'd be grateful if the people which are constantly encountering the "Do you want to keep this resolution?" prompt could test this and report back. In some cases (especially if using backslash to toggle fullscreen/windowed mode) it might be that the videoscreen.foo settings in guisettings.xml have become "corrupt" (happened to @MartijnKaijser) so in case you still run into problems please always provide the values of videoscreen.screen/resolution/screenmode from your guisettings.xml file as well. Thanks.

PS: Thanks to some of the refactoring I managed to eliminate the inclusion of "settings/Setting.h" (which pulls in a few other settings system internal classes) in settings/Settings.h (which is included everywhere) so now there should be quite a bit less re-compilation if anything inside the settings system is changed.
