### PR TITLE
changed: Improve/cleanup logging when seeking cached streams

### DIFF
--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -209,9 +209,10 @@ int64_t CSimpleFileCache::Seek(int64_t iFilePosition)
   }
 
   int64_t nDiff = iTarget - m_nWritePosition;
-  if ( nDiff > 500000 || (nDiff > 0 && WaitForData((unsigned int)(iTarget - m_nReadPosition), 5000) == CACHE_RC_TIMEOUT)  ) {
-    CLog::Log(LOGWARNING,"%s - attempt to seek past read data (seek to %"PRId64". max: %"PRId64". reset read pointer. (%"PRId64")", __FUNCTION__, iTarget, m_nWritePosition, iFilePosition);
-    return  CACHE_RC_ERROR;
+  if (nDiff > 500000 || (nDiff > 0 && WaitForData((unsigned int)(iTarget - m_nReadPosition), 5000) == CACHE_RC_TIMEOUT))
+  {
+    CLog::Log(LOGDEBUG,"CSimpleFileCache::Seek - Attempt to seek past read data");
+    return CACHE_RC_ERROR;
   }
 
   LARGE_INTEGER pos;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -323,6 +323,9 @@ void CCurlFile::CReadState::SetResume(void)
 
 long CCurlFile::CReadState::Connect(unsigned int size)
 {
+  if (m_filePos != 0)
+    CLog::Log(LOGDEBUG,"CurlFile::CReadState::Connect - Resume from position %"PRId64, m_filePos);
+
   SetResume();
   g_curlInterface.multi_add_handle(m_multiHandle, m_easyHandle);
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -223,7 +223,6 @@ void CFileCache::Process()
       bool sourceSeekFailed = false;
       if (!cacheReachEOF)
       {
-        CLog::Log(LOGDEBUG,"CFileCache::Process - Request seek on source to %"PRId64, cacheMaxPos);
         m_nSeekResult = m_source.Seek(cacheMaxPos, SEEK_SET);
         if (m_nSeekResult != cacheMaxPos)
         {


### PR DESCRIPTION
This is another attempt to reduce the log spam introduced by https://github.com/xbmc/xbmc/pull/2229. At the same time it improves logging (imo) by assuming that we just want to know when we actually execute (expensive) seeks on streamed filesystems.
