### PR TITLE
Small cleanup for CSysInfo

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -101,7 +101,7 @@ IAESink *CAESinkFactory::Create(std::string &device, AEAudioFormat &desiredForma
 
 
 #if defined(TARGET_WINDOWS)
-  if ((driver.empty() && g_sysinfo.IsVistaOrHigher() ||
+  if ((driver.empty() && g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista) ||
     driver == "WASAPI") && !g_advancedSettings.m_audioForceDirectSound)
     TRY_SINK(WASAPI)
   else
@@ -141,7 +141,7 @@ void CAESinkFactory::EnumerateEx(AESinkInfoList &list, bool force)
 {
 #if defined(TARGET_WINDOWS)
   ENUMERATE_SINK(DirectSound, force);
-  if (g_sysinfo.IsVistaOrHigher() && !g_advancedSettings.m_audioForceDirectSound)
+  if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista) && !g_advancedSettings.m_audioForceDirectSound)
     ENUMERATE_SINK(WASAPI, force);
 #elif defined(TARGET_ANDROID)
     ENUMERATE_SINK(AUDIOTRACK, force);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -234,7 +234,7 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
   dsbdesc.dwFlags = DSBCAPS_GETCURRENTPOSITION2 /** Better position accuracy */
                   | DSBCAPS_GLOBALFOCUS;         /** Allows background playing */
 
-  if (!g_sysinfo.IsVistaOrHigher())
+  if (!g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista))
     dsbdesc.dwFlags |= DSBCAPS_LOCHARDWARE;     /** Needed for 5.1 on emu101k, fails by design on Vista */
 
   dsbdesc.dwBufferBytes = m_dwBufferLen;
@@ -478,7 +478,7 @@ void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bo
   HRESULT                hr;
 
   /* See if we are on Windows XP */
-  if (!g_sysinfo.IsVistaOrHigher())
+  if (!g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista))
   {
     /* We are on XP - WASAPI not supported - enumerate using DS devices */
     LPGUID deviceGUID = NULL;

--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -716,7 +716,7 @@ void CBaseRenderer::SettingOptionsRenderMethodsFiller(const CSetting *setting, s
   list.push_back(make_pair(g_localizeStrings.Get(13416), RENDER_METHOD_AUTO));
 
 #ifdef HAS_DX
-  if (g_sysinfo.IsVistaOrHigher())
+  if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista))
     list.push_back(make_pair(g_localizeStrings.Get(16319), RENDER_METHOD_DXVA));
   list.push_back(make_pair(g_localizeStrings.Get(13431), RENDER_METHOD_D3D_PS));
   list.push_back(make_pair(g_localizeStrings.Get(13419), RENDER_METHOD_SOFTWARE));

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -100,7 +100,7 @@ bool CRenderSystemDX::InitRenderSystem()
 {
   m_bVSync = true;
 
-  m_useD3D9Ex = (g_advancedSettings.m_AllowD3D9Ex && g_sysinfo.IsVistaOrHigher() && LoadD3D9Ex());
+  m_useD3D9Ex = (g_advancedSettings.m_AllowD3D9Ex && g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista) && LoadD3D9Ex());
   m_pD3D = NULL;
 
   if (m_useD3D9Ex)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -759,7 +759,7 @@ void CSettings::InitializeConditions()
 #endif
 #if defined(TARGET_WINDOWS) && defined(HAS_DX)
   m_settingsManager->AddCondition("has_dx");
-  if (g_sysinfo.IsVistaOrHigher())
+  if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista))
     m_settingsManager->AddCondition("hasdxva2");
 #endif
 

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -356,7 +356,7 @@ CStdString CSysInfo::GetCPUSerial()
 bool CSysInfo::IsAeroDisabled()
 {
 #ifdef _WIN32
-  if (IsVistaOrHigher())
+  if (IsWindowsVersionAtLeast(CSysInfo::WindowsVersionVista))
   {
     BOOL aeroEnabled = FALSE;
     HRESULT res = DwmIsCompositionEnabled(&aeroEnabled);

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -371,24 +371,6 @@ bool CSysInfo::IsAeroDisabled()
   return false;
 }
 
-bool CSysInfo::IsVistaOrHigher()
-{
-#ifdef TARGET_WINDOWS
-  return IsWindowsVersionAtLeast(WindowsVersionVista);
-#else // TARGET_WINDOWS
-  return false;
-#endif // TARGET_WINDOWS
-}
-
-bool CSysInfo::IsWindows8OrHigher()
-{
-#ifdef TARGET_WINDOWS
-  return IsWindowsVersionAtLeast(WindowsVersionWin8);
-#else // TARGET_WINDOWS
-  return false;
-#endif // TARGET_WINDOWS
-}
-
 CSysInfo::WindowsVersion CSysInfo::m_WinVer = WindowsVersionUnknown;
 
 bool CSysInfo::IsWindowsVersion(WindowsVersion ver)

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -118,8 +118,6 @@ public:
   bool HasVDADecoder();
   bool HasVideoToolBoxDecoder();
   bool IsAeroDisabled();
-  bool IsVistaOrHigher();
-  bool IsWindows8OrHigher();
   static bool IsWindowsVersion(WindowsVersion ver);
   static bool IsWindowsVersionAtLeast(WindowsVersion ver);
   static WindowsVersion GetWindowsVersion();

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -282,7 +282,7 @@ bool CWIN32Util::PowerManagement(PowerState State)
     break;
   case POWERSTATE_SHUTDOWN:
     CLog::Log(LOGINFO, "Shutdown Windows...");
-    if (g_sysinfo.IsWindows8OrHigher())
+    if (g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin8))
       uExitFlags = 0x00400000; /* EWX_HYBRID_SHUTDOWN */
     return ExitWindowsEx(uExitFlags | EWX_SHUTDOWN | EWX_FORCE, SHTDN_REASON_MAJOR_OPERATINGSYSTEM | SHTDN_REASON_MINOR_UPGRADE | SHTDN_REASON_FLAG_PLANNED) == TRUE;
     break;


### PR DESCRIPTION
Right now CSysInfo has many function for checking Windows version.
This cleanup removes specialized function 'IsVistaOrHigher' and 'IsWindows8OrHigher' and replace it usage with general function 'IsWindowsVersionAtLeast'

Hopefully in future CSysInfo will not be spoiled with additional functions like 'IsWindows7OrLater', 'IsWindowsBlueOrLater'...
