### PR TITLE
[RFC/bluray] Attempt to fix ext. subtitle and language issues with blurays

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -589,7 +589,8 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   double starttime = 0.0f;
 
   // for dvd's we need the original time
-  if(dynamic_cast<CDVDInputStream::IMenus*>(m_pInput))
+  // starttime is always 0 for blurays (default implementation)
+  if(!m_pInput->IsStreamType(DVDSTREAM_TYPE_BLURAY) && dynamic_cast<CDVDInputStream::IMenus*>(m_pInput))
     starttime = dynamic_cast<CDVDInputStream::IMenus*>(m_pInput)->GetTimeStampCorrection() / DVD_TIME_BASE;
   else if (m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
     starttime = (double)m_pFormatContext->start_time / AV_TIME_BASE;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -961,6 +961,9 @@ static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, char* lang
 
 void CDVDInputStreamBluray::GetStreamInfo(int pid, char* language)
 {
+  if (!m_navmode && m_clip == (uint32_t)-1)
+    m_clip = 0;
+
   if(!m_title || m_clip >= m_title->clip_count)
     return;
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3729,8 +3729,11 @@ bool CDVDPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
 {
   double pts = m_clock.GetClock();
 
-  if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
-    return false;
+  //if (m_pInputStream && (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD)
+  //                     ||m_pInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY)))
+  //{
+  //  pts = DVD_MSEC_TO_TIME(GetTime());
+  //}
 
   m_dvdPlayerSubtitle.GetCurrentSubtitle(strSubtitle, pts - m_dvdPlayerVideo.GetSubtitleDelay());
 


### PR DESCRIPTION
@elupus, @vicbitter
I suspect this isn't a proper solution, but I wanted to present my findings.

The inability to retrieve the language if title is played directly, i.e. not over the play menu button, was introduced here: f55d9dca1495c8bf478c026e41bbf42da7388ac0. The problem is that 
`m_clip  = (uint32_t)-1;` isn't updated in that case.

The issue with external subs is due to a "wrong"/not happening  timestamp correction:

``` c++
  if(dynamic_cast<CDVDInputStream::IMenus*>(m_pInput))
    starttime = dynamic_cast<CDVDInputStream::IMenus*>(m_pInput)->GetTimeStampCorrection() / DVD_TIME_BASE;
  else if (m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
    starttime = (double)m_pFormatContext->start_time / AV_TIME_BASE;
```

because `GetTimeStampCorrection()` always returns `0` for blurays.
