### PR TITLE
[fix] fix compilation with --disable-webserver

### DIFF
--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -90,8 +90,8 @@ using namespace UPNP;
 #endif // HAS_UPNP
 
 CNetworkServices::CNetworkServices()
-  :
 #ifdef HAS_WEB_SERVER
+  :
   m_webserver(*new CWebServer),
   m_httpImageHandler(*new CHTTPImageHandler),
   m_httpVfsHandler(*new CHTTPVfsHandler)


### PR DESCRIPTION
While updating XBMC to current master on my gentoo box, I discovered this with USE="-webserver" (which translates to 'configure --disable-webserver'):

```
CPP     xbmc/network/NetworkServices.o
NetworkServices.cpp: In Konstruktor »CNetworkServices::CNetworkServices()«:
NetworkServices.cpp:106:1: Fehler: expected identifier before »{« token
```

This rather simple fix makes it compile and produces a working binary with and without webserver.
