### PR TITLE
Add URIUtils::HasExtension(..)

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -780,14 +780,7 @@ bool CFileItem::IsVideo() const
      return true;
   }
 
-  extension = URIUtils::GetExtension(m_strPath);
-
-  if (extension.IsEmpty())
-    return false;
-
-  extension.ToLower();
-
-  return (g_advancedSettings.m_videoExtensions.Find(extension) != -1);
+  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_videoExtensions);
 }
 
 bool CFileItem::IsEPG() const
@@ -822,15 +815,7 @@ bool CFileItem::IsDiscStub() const
     return dbItem.IsDiscStub();
   }
 
-  CStdString strExtension = URIUtils::GetExtension(m_strPath);
-
-  if (strExtension.IsEmpty())
-    return false;
-
-  strExtension.ToLower();
-  strExtension += '|';
-
-  return (g_advancedSettings.m_discStubExtensions + '|').Find(strExtension) != -1;
+  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_discStubExtensions);
 }
 
 bool CFileItem::IsAudio() const
@@ -844,24 +829,16 @@ bool CFileItem::IsAudio() const
   if (HasPictureInfoTag()) return false;
   if (IsCDDA()) return true;
 
-  CStdString extension;
   if( m_mimetype.Left(12).Equals("application/") )
   { /* check for some standard types */
-    extension = m_mimetype.Mid(12);
+    CStdString extension = m_mimetype.Mid(12);
     if( extension.Equals("ogg")
      || extension.Equals("mp4")
      || extension.Equals("mxf") )
      return true;
   }
 
-  extension = URIUtils::GetExtension(m_strPath);
-
-  if (extension.IsEmpty())
-    return false;
-
-  extension.ToLower();
-
-  return (g_advancedSettings.m_musicExtensions.Find(extension) != -1);
+  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_musicExtensions);
 }
 
 bool CFileItem::IsKaraoke() const
@@ -886,12 +863,12 @@ bool CFileItem::IsPicture() const
 
 bool CFileItem::IsLyrics() const
 {
-  return URIUtils::GetExtension(m_strPath).Equals(".cdg", false) || URIUtils::GetExtension(m_strPath).Equals(".lrc", false);
+  return URIUtils::HasExtension(m_strPath, ".cdg|.lrc");
 }
 
 bool CFileItem::IsCUESheet() const
 {
-  return URIUtils::GetExtension(m_strPath).Equals(".cue", false);
+  return URIUtils::HasExtension(m_strPath, ".cue");
 }
 
 bool CFileItem::IsInternetStream(const bool bStrictCheck /* = false */) const
@@ -919,12 +896,7 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
     || IsZIP()
     || IsRAR()
     || IsRSS()
-    || IsType(".ogg")
-    || IsType(".oga")
-    || IsType(".nsf")
-    || IsType(".sid")
-    || IsType(".sap")
-    || IsType(".xsp")
+    || IsType(".ogg|.oga|.nsf|.sid|.sap|.xsp")
 #if defined(TARGET_ANDROID)
     || IsType(".apk")
 #endif
@@ -951,9 +923,7 @@ bool CFileItem::IsSmartPlayList() const
   if (HasProperty("library.smartplaylist") && GetProperty("library.smartplaylist").asBoolean())
     return true;
 
-  CStdString strExtension = URIUtils::GetExtension(m_strPath);
-  strExtension.ToLower();
-  return (strExtension == ".xsp");
+  return URIUtils::HasExtension(m_strPath, ".xsp");
 }
 
 bool CFileItem::IsPlayList() const
@@ -963,23 +933,22 @@ bool CFileItem::IsPlayList() const
 
 bool CFileItem::IsPythonScript() const
 {
-  return URIUtils::GetExtension(m_strPath).Equals(".py", false);
+  return URIUtils::HasExtension(m_strPath, ".py");
 }
 
 bool CFileItem::IsType(const char *ext) const
 {
-  return URIUtils::GetExtension(m_strPath).Equals(ext, false);
+  return URIUtils::HasExtension(m_strPath, ext);
 }
 
 bool CFileItem::IsNFO() const
 {
-  return URIUtils::GetExtension(m_strPath).Equals(".nfo", false);
+  return URIUtils::HasExtension(m_strPath, ".nfo");
 }
 
 bool CFileItem::IsDVDImage() const
 {
-  CStdString strExtension = URIUtils::GetExtension(m_strPath);
-  return (strExtension.Equals(".img") || strExtension.Equals(".iso") || strExtension.Equals(".nrg"));
+  return URIUtils::HasExtension(m_strPath, ".img|.iso|.nrg");
 }
 
 bool CFileItem::IsOpticalMediaFile() const
@@ -1030,20 +999,17 @@ bool CFileItem::IsZIP() const
 
 bool CFileItem::IsCBZ() const
 {
-  return URIUtils::GetExtension(m_strPath).Equals(".cbz", false);
+  return URIUtils::HasExtension(m_strPath, ".cbz");
 }
 
 bool CFileItem::IsCBR() const
 {
-  return URIUtils::GetExtension(m_strPath).Equals(".cbr", false);
+  return URIUtils::HasExtension(m_strPath, ".cbr");
 }
 
 bool CFileItem::IsRSS() const
 {
-  if (m_strPath.Left(6).Equals("rss://"))
-    return true;
-
-  return URIUtils::GetExtension(m_strPath).Equals(".rss")
+  return m_strPath.Left(6).Equals("rss://") || URIUtils::HasExtension(m_strPath, ".rss")
       || GetMimeType() == "application/rss+xml";
 }
 

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -236,7 +236,7 @@ bool CTextureDDSJob::operator==(const CJob* job) const
 
 bool CTextureDDSJob::DoWork()
 {
-  if (URIUtils::GetExtension(m_original).Equals(".dds"))
+  if (URIUtils::HasExtension(m_original, ".dds"))
     return false;
   CBaseTexture *texture = CBaseTexture::LoadFromFile(m_original);
   if (texture)

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -125,7 +125,7 @@ AddonPtr CAddonMgr::Factory(const cp_extension_t *props)
         if (type == ADDON_SCREENSAVER)
         { // Python screensaver
           CStdString library = CAddonMgr::Get().GetExtValue(props->configuration, "@library");
-          if (URIUtils::GetExtension(library).Equals(".py", false))
+          if (URIUtils::HasExtension(library, ".py"))
             return AddonPtr(new CScreenSaver(props));
         }
 #if defined(TARGET_ANDROID)                                                                                                                                                      

--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -42,7 +42,7 @@ namespace ADDON
 bool CScreenSaver::CreateScreenSaver()
 {
 #ifdef HAS_PYTHON
-  if (URIUtils::GetExtension(LibPath()).Equals(".py", false))
+  if (URIUtils::HasExtension(LibPath(), ".py"))
   {
     // Don't allow a previously-scheduled alarm to kill our new screensaver
     g_alarmClock.Stop(PYTHON_ALARM, true);
@@ -99,7 +99,7 @@ void CScreenSaver::GetInfo(SCR_INFO *info)
 void CScreenSaver::Destroy()
 {
 #ifdef HAS_PYTHON
-  if (URIUtils::GetExtension(LibPath()).Equals(".py", false))
+  if (URIUtils::HasExtension(LibPath(), ".py"))
   {
     g_alarmClock.Start(PYTHON_ALARM, PYTHON_SCRIPT_TIMEOUT, "StopScript(" + LibPath() + ")", true, false);
     return;

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -309,7 +309,7 @@ void CSkinInfo::SettingOptionsSkinColorsFiller(const CSetting *setting, std::vec
 
   CStdString settingValue = ((const CSettingString*)setting)->GetValue();
   // Remove the .xml extension from the Themes
-  if (URIUtils::GetExtension(settingValue) == ".xml")
+  if (URIUtils::HasExtension(settingValue, ".xml"))
     URIUtils::RemoveExtension(settingValue);
   
   // Set the choosen theme

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -71,7 +71,7 @@ CCDDARipper::~CCDDARipper()
 bool CCDDARipper::RipTrack(CFileItem* pItem)
 {
   // don't rip non cdda items
-  if (URIUtils::GetExtension(pItem->GetPath()).CompareNoCase(".cdda") != 0)
+  if (!URIUtils::HasExtension(pItem->GetPath(), ".cdda"))
   {
     CLog::Log(LOGDEBUG, "cddaripper: file is not a cdda track");
     return false;

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -2163,7 +2163,7 @@ void CAMLPlayer::FindSubtitleFiles()
   for(unsigned int i=0;i<filenames.size();i++)
   {
     // if vobsub subtitle:		
-    if (URIUtils::GetExtension(filenames[i]) == ".idx")
+    if (URIUtils::HasExtension(filenames[i], ".idx"))
     {
       CStdString strSubFile;
       if ( CUtil::FindVobSubPair( filenames, filenames[i], strSubFile ) )

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -254,8 +254,6 @@ bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content
   CStdString strPath(strFile);
   CStdString filename;
   CStdString root;
-  CStdString ext(URIUtils::GetExtension(strPath));
-  ext.ToLower();
 
   if(strPath.Left(7).Equals("bluray:"))
   {
@@ -263,8 +261,7 @@ bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content
     root     = url.GetHostName();
     filename = URIUtils::GetFileName(url.GetFileName());
   }
-  else if(ext == ".iso"
-       || ext == ".img")
+  else if(URIUtils::HasExtension(strPath, ".iso|.img"))
   {
     CURL url("udf://");
     url.SetHostName(strPath);
@@ -352,7 +349,7 @@ bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content
     m_navmode = false;
     m_title = GetTitleLongest();
   }
-  else if(URIUtils::GetExtension(filename).Equals(".mpls"))
+  else if(URIUtils::HasExtension(filename, ".mpls"))
   {
     m_navmode = false;
     m_title = GetTitleFile(filename);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -622,7 +622,7 @@ bool CDVDPlayer::OpenInputStream()
     for(unsigned int i=0;i<filenames.size();i++)
     {
       // if vobsub subtitle:
-      if (URIUtils::GetExtension(filenames[i]) == ".idx")
+      if (URIUtils::HasExtension(filenames[i], ".idx"))
       {
         CStdString strSubFile;
         if ( CUtil::FindVobSubPair( filenames, filenames[i], strSubFile ) )

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -672,7 +672,7 @@ bool COMXPlayer::OpenInputStream()
     for(unsigned int i=0;i<filenames.size();i++)
     {
       // if vobsub subtitle:
-      if (URIUtils::GetExtension(filenames[i]) == ".idx")
+      if (URIUtils::HasExtension(filenames[i], ".idx"))
       {
         CStdString strSubFile;
         if ( CUtil::FindVobSubPair( filenames, filenames[i], strSubFile ) )

--- a/xbmc/cores/paplayer/ASAPCodec.cpp
+++ b/xbmc/cores/paplayer/ASAPCodec.cpp
@@ -22,6 +22,7 @@
 #include "utils/URIUtils.h"
 #include "filesystem/File.h"
 
+
 ASAPCodec::ASAPCodec()
 {
   m_CodecName = "asap";
@@ -38,9 +39,7 @@ bool ASAPCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   CStdString strFileToLoad = strFile;
   int song = -1;
-  CStdString strExtension = URIUtils::GetExtension(strFile);
-  strExtension.MakeLower();
-  if (strExtension == ".asapstream")
+  if (URIUtils::HasExtension(strFile, ".asapstream"))
   {
     CStdString strFileName = URIUtils::GetFileName(strFile);
     int iStart = strFileName.ReverseFind('-') + 1;
@@ -96,3 +95,4 @@ bool ASAPCodec::IsSupportedFormat(const CStdString &strExt)
     || ext == "tmc" || ext == "tm8" || ext == "tm2"
     || ext == "cms" || ext == "cm3" || ext == "dlt";
 }
+

--- a/xbmc/cores/paplayer/NSFCodec.cpp
+++ b/xbmc/cores/paplayer/NSFCodec.cpp
@@ -49,9 +49,7 @@ bool NSFCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   CStdString strFileToLoad = strFile;
   m_iTrack = 0;
-  CStdString strExtension = URIUtils::GetExtension(strFile);
-  strExtension.MakeLower();
-  if (strExtension==".nsfstream")
+  if (URIUtils::HasExtension(strFile, ".nsfstream"))
   {
     //  Extract the track to play
     CStdString strFileName=URIUtils::GetFileName(strFile);

--- a/xbmc/cores/paplayer/OGGcodec.cpp
+++ b/xbmc/cores/paplayer/OGGcodec.cpp
@@ -55,10 +55,8 @@ bool OGGCodec::Init(const CStdString &strFile1, unsigned int filecache)
 
   m_CurrentStream=0;
 
-  CStdString strExtension = URIUtils::GetExtension(strFile);
-
   //  A bitstream inside a ogg file?
-  if (strExtension==".oggstream")
+  if (URIUtils::HasExtension(strFile, ".oggstream"))
   {
     //  Extract the bitstream to play
     CStdString strFileName=URIUtils::GetFileName(strFile);

--- a/xbmc/cores/paplayer/SIDCodec.cpp
+++ b/xbmc/cores/paplayer/SIDCodec.cpp
@@ -47,9 +47,7 @@ bool SIDCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   CStdString strFileToLoad = strFile;
   m_iTrack = 0;
-  CStdString strExtension = URIUtils::GetExtension(strFile);
-  strExtension.MakeLower();
-  if (strExtension==".sidstream")
+  if (URIUtils::HasExtension(strFile, ".sidstream"))
   {
     //  Extract the track to play
     CStdString strFileName=URIUtils::GetFileName(strFile);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -172,7 +172,7 @@ void CGUIDialogSmartPlaylistEditor::OnOK()
     }
     else
       return;
-    if (URIUtils::GetExtension(path) != ".xsp")
+    if (!URIUtils::HasExtension(path, ".xsp"))
       path += ".xsp";
 
     // should we check whether we should overwrite?

--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -218,10 +218,7 @@ int64_t CFileCDDA::GetLength()
 bool CFileCDDA::IsValidFile(const CURL& url)
 {
   // Only .cdda files are supported
-  CStdString strExtension = URIUtils::GetExtension(url.Get());
-  strExtension.MakeLower();
-
-  return (strExtension == ".cdda");
+  return URIUtils::HasExtension(url.Get(), ".cdda");
 }
 
 int CFileCDDA::GetTrackNum(const CURL& url)

--- a/xbmc/filesystem/HDHomeRunFile.cpp
+++ b/xbmc/filesystem/HDHomeRunFile.cpp
@@ -57,11 +57,7 @@ bool CHomeRunFile::Exists(const CURL& url)
    * The filename starts with "tuner" and has no extension. This check will cover off requests
    * for *.tbn, *.jpg, *.jpeg, *.edl etc. that do not exist.
    */
-  if(path.Left(5) == "tuner"
-  && URIUtils::GetExtension(path).IsEmpty())
-    return true;
-
-  return false;
+  return path.Left(5) == "tuner" && !URIUtils::HasExtension(path);
 }
 
 int64_t CHomeRunFile::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -51,7 +51,7 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
   if (libNode.IsEmpty())
     return false;
 
-  if (URIUtils::GetExtension(libNode).Equals(".xml"))
+  if (URIUtils::HasExtension(libNode, ".xml"))
   { // a filter node
     TiXmlElement *node = LoadXML(libNode);
     if (node)

--- a/xbmc/filesystem/MusicDatabaseFile.cpp
+++ b/xbmc/filesystem/MusicDatabaseFile.cpp
@@ -56,9 +56,7 @@ CStdString CMusicDatabaseFile::TranslateUrl(const CURL& url)
   if (!musicDatabase.GetSong(idSong, song))
     return "";
 
-  CStdString strExtensionFromDb = URIUtils::GetExtension(song.strFileName);
-
-  if (!strExtensionFromDb.Equals(strExtension))
+  if (!URIUtils::HasExtension(song.strFileName, strExtension))
     return "";
 
   return song.strFileName;

--- a/xbmc/filesystem/MythDirectory.cpp
+++ b/xbmc/filesystem/MythDirectory.cpp
@@ -647,7 +647,7 @@ bool CMythDirectory::SupportsWriteFileOperations(const CStdString& strPath)
    */
   return filename.Left(11) == "recordings/" ||
          filename.Left(7)  == "movies/" ||
-        (filename.Left(8)  == "tvshows/" && URIUtils::GetExtension(filename) != "");
+        (filename.Left(8)  == "tvshows/" && URIUtils::HasExtension(filename));
 }
 
 bool CMythDirectory::IsLiveTV(const CStdString& strPath)

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -194,7 +194,7 @@ bool CMythFile::SetupLiveTV(const CURL& url)
     return false;
 
   CStdString channel = url.GetFileNameWithoutPath();
-  if(!URIUtils::GetExtension(channel).Equals(".ts"))
+  if(!URIUtils::HasExtension(channel, ".ts"))
   {
     CLog::Log(LOGERROR, "%s - invalid channel url %s", __FUNCTION__, channel.c_str());
     return false;
@@ -396,8 +396,7 @@ bool CMythFile::Exists(const CURL& url)
   if ((path.Left(11) == "recordings/"
     || path.Left(7)  == "movies/"
     || path.Left(8)  == "tvshows/")
-    && (URIUtils::GetExtension(path).Equals(".mpg")
-    ||  URIUtils::GetExtension(path).Equals(".nuv")))
+    && (URIUtils::HasExtension(path, ".mpg|.nuv")))
   {
     if(!SetupConnection(url, true, false, false))
       return false;

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -88,40 +88,18 @@ bool CRSSDirectory::ContainsFiles(const CStdString& strPath)
 
 static bool IsPathToMedia(const CStdString& strPath )
 {
-  CStdString extension = URIUtils::GetExtension(strPath);
-
-  if (extension.IsEmpty())
-    return false;
-
-  extension.ToLower();
-
-  if (g_advancedSettings.m_videoExtensions.Find(extension) != -1)
-    return true;
-
-  if (g_advancedSettings.m_musicExtensions.Find(extension) != -1)
-    return true;
-
-  if (g_advancedSettings.m_pictureExtensions.Find(extension) != -1)
-    return true;
-
-  return false;
+  return URIUtils::HasExtension(strPath,
+                              g_advancedSettings.m_videoExtensions + '|' +
+                              g_advancedSettings.m_musicExtensions + '|' +
+                              g_advancedSettings.m_pictureExtensions);
 }
 
 static bool IsPathToThumbnail(const CStdString& strPath )
 {
   // Currently just check if this is an image, maybe we will add some
   // other checks later
-  CStdString extension = URIUtils::GetExtension(strPath);
-
-  if (extension.IsEmpty())
-    return false;
-
-  extension.ToLower();
-
-  if (g_advancedSettings.m_pictureExtensions.Find(extension) != -1)
-    return true;
-
-  return false;
+  return URIUtils::HasExtension(strPath,
+                                    g_advancedSettings.m_pictureExtensions);
 }
 
 static time_t ParseDate(const CStdString & strDate)

--- a/xbmc/filesystem/VTPFile.cpp
+++ b/xbmc/filesystem/VTPFile.cpp
@@ -69,7 +69,7 @@ bool CVTPFile::Open(const CURL& url2)
   {
 
     CStdString channel = path.Mid(9);
-    if(!URIUtils::GetExtension(channel).Equals(".ts"))
+    if(!URIUtils::HasExtension(channel, ".ts"))
     {
       CLog::Log(LOGERROR, "%s - invalid channel url %s", __FUNCTION__, channel.c_str());
       return false;

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -596,11 +596,9 @@ void GUIFontManager::SettingOptionsFontsFiller(const CSetting *setting, std::vec
     {
       CFileItemPtr pItem = items[i];
 
-      if (!pItem->m_bIsFolder)
+      if (!pItem->m_bIsFolder
+          && URIUtils::HasExtension(pItem->GetLabel(), ".ttf"))
       {
-        if (!URIUtils::GetExtension(pItem->GetLabel()).Equals(".ttf"))
-          continue;
-
         list.push_back(make_pair(pItem->GetLabel(), pItem->GetLabel()));
       }
     }

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -215,9 +215,8 @@ CBaseTexture *CBaseTexture::LoadFromFileInMemory(unsigned char *buffer, size_t b
 bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate)
 {
 #if defined(HAS_OMXPLAYER)
-  if (URIUtils::GetExtension(texturePath).Equals(".jpg") || 
-      URIUtils::GetExtension(texturePath).Equals(".tbn") 
-      /*|| URIUtils::GetExtension(texturePath).Equals(".png")*/)
+  if (URIUtils::HasExtension(texturePath, ".jpg|.tbn")
+      /*|| URIUtils::HasExtension(texturePath, ".png")*/)
   {
     COMXImage omx_image;
 
@@ -281,7 +280,7 @@ bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned 
     omx_image.ClampLimits(maxWidth, maxHeight);
   }
 #endif
-  if (URIUtils::GetExtension(texturePath).Equals(".dds"))
+  if (URIUtils::HasExtension(texturePath, ".dds"))
   { // special case for DDS images
     CDDSImage image;
     if (image.ReadFile(texturePath))

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -401,8 +401,7 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("runscript") && params.size())
   {
 #if defined(TARGET_DARWIN_OSX)
-    if (URIUtils::GetExtension(strParameterCaseIntact) == ".applescript" ||
-        URIUtils::GetExtension(strParameterCaseIntact) == ".scpt")
+    if (URIUtils::HasExtension(strParameterCaseIntact, ".applescript|.scpt"))
     {
       CStdString osxPath = CSpecialProtocol::TranslatePath(strParameterCaseIntact);
       Cocoa_DoAppleScriptFile(osxPath.c_str());

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2022,8 +2022,7 @@ bool CMusicDatabase::CleanupSongsByIds(const CStdString &strSongIds)
       //  Special case for streams inside an ogg file. (oggstream)
       //  The last dir in the path is the ogg file that
       //  contains the stream, so test if its there
-      CStdString strExtension=URIUtils::GetExtension(strFileName);
-      if (strExtension==".oggstream" || strExtension==".nsfstream")
+      if (URIUtils::HasExtension(strFileName, ".oggstream|.nsfstream"))
       {
         CStdString strFileAndPath=strFileName;
         URIUtils::GetDirectory(strFileAndPath, strFileName);

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -561,8 +561,7 @@ BuildObject(CFileItem&                    item,
             CTextureCache::GetWrappedImageURL(thumb).c_str());
 
         // Set DLNA profileID by extension, defaulting to JPEG.
-        NPT_String ext = URIUtils::GetExtension(thumb).c_str();
-        if (strcmp(ext, ".png") == 0) {
+        if (URIUtils::HasExtension(thumb, ".png")) {
             art.dlna_profile = "PNG_TN";
         } else {
             art.dlna_profile = "JPEG_TN";

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -392,8 +392,7 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
             "/thumb",
             query.ToString()).ToString();
         // Set DLNA profileID by extension, defaulting to JPEG.
-        NPT_String ext = URIUtils::GetExtension(item.GetArt("thumb")).c_str();
-        if (strcmp(ext, ".png") == 0) {
+        if (URIUtils::HasExtension(item.GetArt("thumb"), ".png")) {
             art.dlna_profile = "PNG_TN";
         } else {
             art.dlna_profile = "JPEG_TN";

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1142,7 +1142,7 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, const CStdString
     {
       CURL url(m_slides->Get(m_iCurrentSlide)->GetPath());
       CStdString strHostName = url.GetHostName();
-      if (URIUtils::GetExtension(strHostName).Equals(".cbr", false) || URIUtils::GetExtension(strHostName).Equals(".cbz", false))
+      if (URIUtils::HasExtension(strHostName, ".cbr|.cbz"))
       {
         m_Image[iPic].m_bIsComic = true;
         m_Image[iPic].Move((float)m_Image[iPic].GetOriginalWidth(),(float)m_Image[iPic].GetOriginalHeight());

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -42,7 +42,7 @@ using namespace XFILE;
 bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width, int height, int stride, const CStdString &thumbFile)
 {
   CLog::Log(LOGDEBUG, "cached image '%s' size %dx%d", thumbFile.c_str(), width, height);
-  if (URIUtils::GetExtension(thumbFile).Equals(".jpg"))
+  if (URIUtils::HasExtension(thumbFile, ".jpg"))
   {
 #if defined(HAS_OMXPLAYER)
     COMXImage *omxImage = new COMXImage();

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -129,18 +129,7 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
 
 bool CPlayListFactory::IsPlaylist(const CStdString& filename)
 {
-  CStdString extension = URIUtils::GetExtension(filename);
-  extension.ToLower();
-
-  if (extension == ".m3u") return true;
-  if (extension == ".b4s") return true;
-  if (extension == ".pls") return true;
-  if (extension == ".strm") return true;
-  if (extension == ".wpl") return true;
-  if (extension == ".asx") return true;
-  if (extension == ".ram") return true;
-  if (extension == ".url") return true;
-  if (extension == ".pxml") return true;
-  return false;
+  return URIUtils::HasExtension(filename,
+                     ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml");
 }
 

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1323,7 +1323,7 @@ const TiXmlNode* CSmartPlaylist::readNameFromPath(const CStdString &path)
   if (m_playlistName.empty())
   {
     m_playlistName = CUtil::GetTitleFromPath(path);
-    if (URIUtils::GetExtension(m_playlistName) == ".xsp")
+    if (URIUtils::HasExtension(m_playlistName, ".xsp"))
       URIUtils::RemoveExtension(m_playlistName);
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -643,7 +643,7 @@ bool CGUIWindowPVRCommon::PlayRecording(CFileItem *item, bool bPlayMinimized /* 
       vector<int> stack;
       for (int i = 0; i < items.Size(); ++i)
       {
-        if (URIUtils::GetExtension(items[i]->GetPath()) == ext)
+        if (URIUtils::HasExtension(items[i]->GetPath(), ext))
           stack.push_back(i);
       }
 

--- a/xbmc/utils/AliasShortcutUtils.cpp
+++ b/xbmc/utils/AliasShortcutUtils.cpp
@@ -34,7 +34,7 @@ bool IsAliasShortcut(CStdString &path)
 #if defined(TARGET_DARWIN_OSX)
   // Note: regular files that have an .alias extension can be
   //   reported as an alias when clearly, they are not. Trap them out.
-  if (URIUtils::GetExtension(path) != ".alias")
+  if (!URIUtils::HasExtension(path, ".alias"))
   {
     FSRef fileRef;
     Boolean targetIsFolder, wasAliased;

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -168,7 +168,7 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
         // get filename from label instead of path
         strFileName = pItem->GetLabel();
 
-        if(!pItem->m_bIsFolder && URIUtils::GetExtension(strFileName).length() == 0)
+        if(!pItem->m_bIsFolder && !URIUtils::HasExtension(strFileName))
         {
           // FIXME: for now we only work well if the url has the extension
           // we should map the content type to the extension otherwise

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -61,6 +61,51 @@ CStdString URIUtils::GetExtension(const CStdString& strFileName)
   return strFileName.substr(period);
 }
 
+bool URIUtils::HasExtension(const CStdString& strFileName)
+{
+  if (IsURL(strFileName))
+  {
+    CURL url(strFileName);
+    return HasExtension(url.GetFileName());
+  }
+
+  size_t iPeriod = strFileName.find_last_of("./\\");
+  return iPeriod != string::npos && strFileName[iPeriod] == '.';
+}
+
+bool URIUtils::HasExtension(const CStdString& strFileName, const CStdString& strExtensions)
+{
+  if (IsURL(strFileName))
+  {
+    CURL url(strFileName);
+    return HasExtension(url.GetFileName(), strExtensions);
+  }
+
+  // Search backwards so that '.' can be used as a search terminator.
+  CStdString::const_reverse_iterator itExtensions = strExtensions.rbegin();
+  while (itExtensions != strExtensions.rend())
+  {
+    // Iterate backwards over strFileName untill we hit a '.' or a mismatch
+    for (CStdString::const_reverse_iterator itFileName = strFileName.rbegin();
+         itFileName != strFileName.rend(), itExtensions != strExtensions.rend(),
+         tolower(*itFileName) == *itExtensions;
+         ++itFileName, ++itExtensions)
+    {
+      if (*itExtensions == '.')
+        return true; // Match
+    }
+
+    // No match. Look for more extensions to try.
+    while (itExtensions != strExtensions.rend() && *itExtensions != '|')
+      ++itExtensions;
+
+    while (itExtensions != strExtensions.rend() && *itExtensions == '|')
+      ++itExtensions;
+  }
+
+  return false;
+}
+
 void URIUtils::RemoveExtension(CStdString& strFileName)
 {
   if(IsURL(strFileName))

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -618,31 +618,17 @@ bool URIUtils::IsInRAR(const CStdString& strFile)
 
 bool URIUtils::IsAPK(const CStdString& strFile)
 {
-  return GetExtension(strFile).CompareNoCase(".apk") == 0;
+  return HasExtension(strFile, ".apk");
 }
 
 bool URIUtils::IsZIP(const CStdString& strFile) // also checks for comic books!
 {
-  CStdString strExtension = GetExtension(strFile);
-
-  if (strExtension.CompareNoCase(".zip") == 0)
-    return true;
-
-  if (strExtension.CompareNoCase(".cbz") == 0)
-    return true;
-
-  return false;
+  return HasExtension(strFile, ".zip|.cbz");
 }
 
 bool URIUtils::IsArchive(const CStdString& strFile)
 {
-  CStdString extension = GetExtension(strFile);
-
-  return (extension.CompareNoCase(".zip") == 0 ||
-          extension.CompareNoCase(".rar") == 0 ||
-          extension.CompareNoCase(".apk") == 0 ||
-          extension.CompareNoCase(".cbz") == 0 ||
-          extension.CompareNoCase(".cbr") == 0);
+  return HasExtension(strFile, ".zip|.rar|.apk|.cbz|.cbr");
 }
 
 bool URIUtils::IsSpecial(const CStdString& strFile)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -36,6 +36,28 @@ public:
   static const CStdString GetFileName(const CStdString& strFileNameAndPath);
 
   static CStdString GetExtension(const CStdString& strFileName);
+
+  /*!
+   \brief Check if there is a file extension
+   \param strFileName Path or URL to check
+   \return \e true if strFileName have an extension.
+   \note Returns false when strFileName is empty.
+   \sa GetExtension
+   */
+  static bool HasExtension(const CStdString& strFileName);
+
+  /*!
+   \brief Check if filename have any of the listed extensions
+   \param strFileName Path or URL to check
+   \param strExtensions List of '.' prefixed lowercase extensions seperated with '|'
+   \return \e true if strFileName have any one of the extensions.
+   \note The check is case insensitive for strFileName, but requires
+         strExtensions to be lowercase. Returns false when strFileName or
+         strExtensions is empty.
+   \sa GetExtension
+   */
+  static bool HasExtension(const CStdString& strFileName, const CStdString& strExtensions);
+
   static void RemoveExtension(CStdString& strFileName);
   static CStdString ReplaceExtension(const CStdString& strFile,
                                      const CStdString& strNewExtension);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -55,6 +55,25 @@ TEST_F(TestURIUtils, GetExtension)
                URIUtils::GetExtension("/path/to/movie.avi").c_str());
 }
 
+TEST_F(TestURIUtils, HasExtension)
+{
+  EXPECT_TRUE (URIUtils::HasExtension("/path/to/movie.AvI"));
+  EXPECT_FALSE(URIUtils::HasExtension("/path/to/movie"));
+  EXPECT_FALSE(URIUtils::HasExtension("/path/.to/movie"));
+  EXPECT_FALSE(URIUtils::HasExtension(""));
+
+  EXPECT_TRUE (URIUtils::HasExtension("/path/to/movie.AvI", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("/path/to/movie.AvI", ".mkv"));
+  EXPECT_FALSE(URIUtils::HasExtension("/path/.avi/movie", ".avi"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi"));
+
+  EXPECT_TRUE (URIUtils::HasExtension("/path/movie.AvI", ".avi|.mkv|.mp4"));
+  EXPECT_TRUE (URIUtils::HasExtension("/path/movie.AvI", ".mkv|.avi|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("/path/movie.AvI", ".mpg|.mkv|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("/path.mkv/movie.AvI", ".mpg|.mkv|.mp4"));
+  EXPECT_FALSE(URIUtils::HasExtension("", ".avi|.mkv|.mp4"));
+}
+
 TEST_F(TestURIUtils, GetFileName)
 {
   EXPECT_STREQ("movie.avi",

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -548,7 +548,7 @@ namespace VIDEO
   INFO_RET CVideoInfoScanner::RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ScraperPtr &info2, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress)
   {
     if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsNFO() ||
-       (pItem->IsPlayList() && !URIUtils::GetExtension(pItem->GetPath()).Equals(".strm")))
+       (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
       return INFO_NOT_NEEDED;
 
     if (ProgressCancelled(pDlgProgress, 198, pItem->GetLabel()))
@@ -597,7 +597,7 @@ namespace VIDEO
   INFO_RET CVideoInfoScanner::RetrieveInfoForMusicVideo(CFileItem *pItem, bool bDirNames, ScraperPtr &info2, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress)
   {
     if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsNFO() ||
-       (pItem->IsPlayList() && !URIUtils::GetExtension(pItem->GetPath()).Equals(".strm")))
+       (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
       return INFO_NOT_NEEDED;
 
     if (ProgressCancelled(pDlgProgress, 20394, pItem->GetLabel()))
@@ -1493,9 +1493,6 @@ namespace VIDEO
     // Find a matching .nfo file
     if (!item->m_bIsFolder)
     {
-      // file
-      CStdString strExtension = URIUtils::GetExtension(item->GetPath());
-
       if (URIUtils::IsInRAR(item->GetPath())) // we have a rarred item - we want to check outside the rars
       {
         CFileItem item2(*item);
@@ -1537,7 +1534,7 @@ namespace VIDEO
       else
       {
         // already an .nfo file?
-        if ( strcmpi(strExtension.c_str(), ".nfo") == 0 )
+        if (URIUtils::HasExtension(item->GetPath(), ".nfo"))
           nfoFile = item->GetPath();
         // no, create .nfo file
         else

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -339,7 +339,7 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
     }
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares,strMask,g_localizeStrings.Get(293),strPath,false,true)) // "subtitles"
     {
-      if (URIUtils::GetExtension(strPath) == ".sub")
+      if (URIUtils::HasExtension(strPath, ".sub"))
         if (CFile::Exists(URIUtils::ReplaceExtension(strPath, ".idx")))
           strPath = URIUtils::ReplaceExtension(strPath, ".idx");
       

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -286,7 +286,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
     return;
 
   if (pItem->IsParentFolder() || pItem->m_bIsShareOrDrive || pItem->GetPath().Equals("add") ||
-     (pItem->IsPlayList() && !URIUtils::GetExtension(pItem->GetPath()).Equals(".strm")))
+     (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
     return;
 
   // ShowIMDB can kill the item as this window can be closed while we do it,
@@ -993,7 +993,7 @@ bool CGUIWindowVideoBase::OnInfo(int iItem)
   CFileItemPtr item = m_vecItems->Get(iItem);
 
   if (item->GetPath().Equals("add") || item->IsParentFolder() ||
-     (item->IsPlayList() && !URIUtils::GetExtension(item->GetPath()).Equals(".strm")))
+     (item->IsPlayList() && !URIUtils::HasExtension(item->GetPath(), ".strm")))
     return false;
 
   if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
@@ -1094,9 +1094,7 @@ bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item)
     }
   }
 
-  CStdString ext = URIUtils::GetExtension(item->GetPath());
-  ext.ToLower();
-  if (ext == ".iso" ||  ext == ".img")
+  if (URIUtils::HasExtension(item->GetPath(), ".iso|.img"))
   {
     CURL url2("udf://");
     url2.SetHostName(item->GetPath());
@@ -1554,7 +1552,7 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem)
           vector<int> stack;
           for (int i = 0; i < items.Size(); ++i)
           {
-            if (URIUtils::GetExtension(items[i]->GetPath()) == ext)
+            if (URIUtils::HasExtension(items[i]->GetPath(), ext))
               stack.push_back(i);
           }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -496,7 +496,7 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
     if (pItem->IsHD() &&
-        URIUtils::GetExtension(pItem->GetPath()).CompareNoCase(".tbn") == 0)
+        URIUtils::HasExtension(pItem->GetPath(), ".tbn"))
     {
       pItem->SetArt("thumb", pItem->GetPath());
     }


### PR DESCRIPTION
A common use case for URIUtils::GetExtension(..) is to test for the existance of extensions. So i added functions for that.
- Hopefully a bit cleaner and more efficient
- Switched over as much code that i could find
- Gtest added
- Some extra cleaning in IDirectory::IsAllowed(..)
