### PR TITLE
Android register player

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -25,6 +25,31 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:mimeType="video/*" />
+                <data android:mimeType="audio/*" />
+                <data android:mimeType="image/*" />
+
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:scheme="ftp" />
+                <data android:scheme="ftps" />
+                <data android:scheme="rtp" />
+                <data android:scheme="rtsp" />
+                <data android:scheme="mms" />
+                <data android:scheme="dav" />
+                <data android:scheme="davs" />
+                <data android:scheme="ssh" />
+                <data android:scheme="sftp" />
+                <data android:scheme="smb" />
+             </intent-filter>
         </activity>
 
         <!--

--- a/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
+++ b/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 
 public class Main extends NativeActivity 
 {
+  native void _onNewIntent(Intent intent);
   public Main() 
   {
     super();
@@ -16,4 +17,12 @@ public class Main extends NativeActivity
   {
     super.onCreate(savedInstanceState);
   }
+
+  @Override
+  protected void onNewIntent(Intent intent)
+  {
+    super.onNewIntent(intent);
+    _onNewIntent(intent);
+  }
+
 }

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -533,6 +533,16 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     m_batteryLevel = intent.getIntExtra("level",-1);
 }
 
+void CXBMCApp::onNewIntent(CJNIIntent intent)
+{
+  std::string action = intent.getAction();
+  if (action == "android.intent.action.VIEW")
+  {
+    std::string playFile = GetFilenameFromIntent(intent);
+    CApplicationMessenger::Get().MediaPlay(playFile);
+  }
+}
+
 void CXBMCApp::SetupEnv()
 {
   setenv("XBMC_ANDROID_SYSTEM_LIBS", CJNISystem::getProperty("java.library.path").c_str(), 0);

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -87,7 +87,9 @@ ANativeWindow* CXBMCApp::m_window = NULL;
 int CXBMCApp::m_batteryLevel = 0;
 
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity)
-  : CJNIContext(nativeActivity), m_wakeLock(NULL)
+  : CJNIContext(nativeActivity)
+  , CJNIBroadcastReceiver("org/xbmc/xbmc/XBMCBroadcastReceiver")
+  , m_wakeLock(NULL)
 {
   m_activity = nativeActivity;
   m_firstrun = true;

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -242,6 +242,22 @@ void CXBMCApp::run()
   CJNIIntent startIntent = getIntent();
   android_printf("XBMC Started with action: %s\n",startIntent.getAction().c_str());
 
+  std::string filenameToPlay = GetFilenameFromIntent(startIntent);
+  if (!filenameToPlay.empty())
+  {
+    int argc = 2;
+    const char** argv = (const char**) malloc(argc*sizeof(char*));
+
+    std::string exe_name("XBMC");
+    argv[0] = exe_name.c_str();
+    argv[1] = filenameToPlay.c_str();
+
+    CAppParamParser appParamParser;
+    appParamParser.Parse((const char **)argv, argc);
+
+    free(argv);
+  }
+
   CJNIIntentFilter batteryFilter;
   batteryFilter.addAction("android.intent.action.BATTERY_CHANGED");
   registerReceiver(*this, batteryFilter);

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -124,11 +124,15 @@ void CXBMCApp::onStart()
 void CXBMCApp::onResume()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
+  CJNIIntentFilter batteryFilter;
+  batteryFilter.addAction("android.intent.action.BATTERY_CHANGED");
+  registerReceiver(*this, batteryFilter);
 }
 
 void CXBMCApp::onPause()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
+  unregisterReceiver(*this);
 }
 
 void CXBMCApp::onStop()
@@ -259,10 +263,6 @@ void CXBMCApp::run()
 
     free(argv);
   }
-
-  CJNIIntentFilter batteryFilter;
-  batteryFilter.addAction("android.intent.action.BATTERY_CHANGED");
-  registerReceiver(*this, batteryFilter);
 
   android_printf(" => waiting for a window");
   // Hack!

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -108,6 +108,7 @@ protected:
 private:
   static bool HasLaunchIntent(const std::string &package);
   bool getWakeLock();
+  std::string GetFilenameFromIntent(const CJNIIntent &intent);
   void run();
   void stop();
   void SetupEnv();

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -31,6 +31,7 @@
 
 #include "xbmc.h"
 #include "android/jni/Context.h"
+#include "android/jni/BroadcastReceiver.h"
 
 // forward delares
 class CJNIWakeLock;
@@ -51,7 +52,7 @@ struct androidPackage
 };
 
 
-class CXBMCApp : public IActivityHandler, public CJNIContext
+class CXBMCApp : public IActivityHandler, public CJNIContext, public CJNIBroadcastReceiver
 {
 public:
   CXBMCApp(ANativeActivity *nativeActivity);

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -57,6 +57,7 @@ public:
   CXBMCApp(ANativeActivity *nativeActivity);
   virtual ~CXBMCApp();
   virtual void onReceive(CJNIIntent intent);
+  virtual void onNewIntent(CJNIIntent intent);
 
   bool isValid() { return m_activity != NULL; }
 

--- a/xbmc/android/activity/android_main.cpp
+++ b/xbmc/android/activity/android_main.cpp
@@ -47,3 +47,26 @@ extern void android_main(struct android_app* state)
   }
   exit(0);
 }
+
+extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+  jint version = JNI_VERSION_1_6;
+  JNIEnv* env;
+  if (vm->GetEnv(reinterpret_cast<void**>(&env), version) != JNI_OK)
+    return -1;
+
+  jclass cMain = env->FindClass("org/xbmc/xbmc/XBMCBroadcastReceiver");
+  if(cMain)
+  {
+    JNINativeMethod mOnReceive =   { "_onReceive",     "(Landroid/content/Intent;)V", (void*)&CJNIBroadcastReceiver::_onReceive};
+    env->RegisterNatives(cMain, &mOnReceive, 1);
+  }
+
+  jclass cBroadcastReceiver = env->FindClass("org/xbmc/xbmc/Main");
+  if(cBroadcastReceiver)
+  {
+    JNINativeMethod mOnNewIntent = { "_onNewIntent",   "(Landroid/content/Intent;)V", (void*)&CJNIContext::_onNewIntent};
+    env->RegisterNatives(cBroadcastReceiver, &mOnNewIntent, 1);
+  }
+  return version;
+}

--- a/xbmc/android/jni/AudioManager.cpp
+++ b/xbmc/android/jni/AudioManager.cpp
@@ -23,9 +23,11 @@
 using namespace jni;
 
 int CJNIAudioManager::STREAM_MUSIC(0);
-CJNIAudioManager::CJNIAudioManager(const jni::jhobject &object) : CJNIBase(object)
+
+void CJNIAudioManager::PopulateStaticFields()
 {
-  STREAM_MUSIC = (get_static_field<int>(m_object, "STREAM_MUSIC"));
+  jhclass clazz = find_class("android/media/AudioManager");
+  STREAM_MUSIC = (get_static_field<int>(clazz, "STREAM_MUSIC"));
 }
 
 int CJNIAudioManager::getStreamMaxVolume()

--- a/xbmc/android/jni/AudioManager.h
+++ b/xbmc/android/jni/AudioManager.h
@@ -26,8 +26,10 @@ public:
   // Note removal of streamType param.
   int getStreamMaxVolume();
   void setStreamVolume(int index = 0, int flags = 0);
+
+  static void PopulateStaticFields();
   ~CJNIAudioManager(){};
-  CJNIAudioManager(const jni::jhobject &object);
+  CJNIAudioManager(const jni::jhobject &object) : CJNIBase(object){};
 
 private:
   CJNIAudioManager();

--- a/xbmc/android/jni/BaseColumns.cpp
+++ b/xbmc/android/jni/BaseColumns.cpp
@@ -1,0 +1,33 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "BaseColumns.h"
+#include "jutils/jutils-details.hpp"
+
+using namespace jni;
+
+std::string CJNIBaseColumns::_ID;
+std::string CJNIBaseColumns::_COUNT;
+
+void CJNIBaseColumns::PopulateStaticFields()
+{
+  jhclass clazz = find_class("android/provider/BaseColumns");
+  _ID = (jcast<std::string>(get_static_field<jhstring>(clazz, "_ID")));
+  _COUNT = (jcast<std::string>(get_static_field<jhstring>(clazz, "_COUNT")));
+}

--- a/xbmc/android/jni/BaseColumns.h
+++ b/xbmc/android/jni/BaseColumns.h
@@ -24,7 +24,7 @@ class CJNIBaseColumns
 public:
   static std::string _ID;
   static std::string _COUNT;
-  void static PopulateStaticFields();
+  static void PopulateStaticFields();
 private:
   CJNIBaseColumns();
 };

--- a/xbmc/android/jni/BaseColumns.h
+++ b/xbmc/android/jni/BaseColumns.h
@@ -1,0 +1,30 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <string>
+class CJNIBaseColumns
+{
+public:
+  static std::string _ID;
+  static std::string _COUNT;
+  void static PopulateStaticFields();
+private:
+  CJNIBaseColumns();
+};

--- a/xbmc/android/jni/BroadcastReceiver.cpp
+++ b/xbmc/android/jni/BroadcastReceiver.cpp
@@ -24,24 +24,22 @@
 #include "ClassLoader.h"
 #include "jutils/jutils-details.hpp"
 
-CJNIContext * CJNIBroadcastReceiver::jni_app_context=NULL;
-
 using namespace jni;
-CJNIBroadcastReceiver::CJNIBroadcastReceiver(CJNIContext *context) : CJNIBase("org/xbmc/xbmc/XBMCBroadcastReceiver")
+
+CJNIBroadcastReceiver::CJNIBroadcastReceiver() : CJNIBase("org/xbmc/xbmc/XBMCBroadcastReceiver")
 {
-  jni_app_context = context;
 }
 
 void CJNIBroadcastReceiver::InitializeBroadcastReceiver()
 {
   // Convert "the/class/name" to "the.class.name" as loadClass() expects it.
-  std::string className = GetClassName();
-  for (std::string::iterator it = className.begin(); it != className.end(); ++it)
+  std::string dotClassName = GetClassName();
+  for (std::string::iterator it = dotClassName.begin(); it != dotClassName.end(); ++it)
   {
     if (*it == '/')
       *it = '.';
   }
-  m_object = new_object(jni_app_context->getClassLoader().loadClass(className));
+  m_object = new_object(CJNIContext::GetAppInstance()->getClassLoader().loadClass(dotClassName));
   m_object.setGlobal();
 }
 

--- a/xbmc/android/jni/BroadcastReceiver.cpp
+++ b/xbmc/android/jni/BroadcastReceiver.cpp
@@ -47,11 +47,3 @@ void CJNIBroadcastReceiver::DestroyBroadcastReceiver()
 {
   m_object.reset();
 }
-
-extern "C"
-JNIEXPORT void JNICALL Java_org_xbmc_xbmc_XBMCBroadcastReceiver__1onReceive
-  (JNIEnv *env, jobject context, jobject intent)
-{
-  if(CJNIBroadcastReceiver::jni_app_context)
-    CJNIBroadcastReceiver::jni_app_context->onReceive(CJNIIntent(jhobject(intent)));
-}

--- a/xbmc/android/jni/BroadcastReceiver.h
+++ b/xbmc/android/jni/BroadcastReceiver.h
@@ -19,15 +19,17 @@
  *
  */
 #include "JNIBase.h"
-class CJNIContext;
+class CJNIIntent;
 class CJNIBroadcastReceiver : public CJNIBase
 {
 public:
+  static void _onReceive(JNIEnv *env, jobject context, jobject intent);
+
 protected:
-  void DestroyBroadcastReceiver();
-  CJNIBroadcastReceiver();
+  virtual void onReceive(CJNIIntent intent)=0;
   ~CJNIBroadcastReceiver(){};
-  void InitializeBroadcastReceiver();
+  CJNIBroadcastReceiver(const std::string &className);
+
 private:
-  explicit CJNIBroadcastReceiver(jni::jhobject const& object);
+  static CJNIBroadcastReceiver* m_receiverInstance;
 };

--- a/xbmc/android/jni/BroadcastReceiver.h
+++ b/xbmc/android/jni/BroadcastReceiver.h
@@ -23,10 +23,9 @@ class CJNIContext;
 class CJNIBroadcastReceiver : public CJNIBase
 {
 public:
-  static CJNIContext *jni_app_context;
 protected:
   void DestroyBroadcastReceiver();
-  CJNIBroadcastReceiver(CJNIContext *context);
+  CJNIBroadcastReceiver();
   ~CJNIBroadcastReceiver(){};
   void InitializeBroadcastReceiver();
 private:

--- a/xbmc/android/jni/ConnectivityManager.cpp
+++ b/xbmc/android/jni/ConnectivityManager.cpp
@@ -33,19 +33,21 @@ int CJNIConnectivityManager::TYPE_DUMMY(0);
 int CJNIConnectivityManager::TYPE_ETHERNET(0);
 int CJNIConnectivityManager::DEFAULT_NETWORK_PREFERENCE(0);
 using namespace jni;
-CJNIConnectivityManager::CJNIConnectivityManager(const jhobject &object) : CJNIBase(object)
+
+void CJNIConnectivityManager::PopulateStaticFields()
 {
-  TYPE_MOBILE = (get_static_field<int>(m_object, "TYPE_MOBILE"));
-  TYPE_WIFI = (get_static_field<int>(m_object, "TYPE_WIFI"));
-  TYPE_MOBILE_MMS = (get_static_field<int>(m_object, "TYPE_MOBILE_MMS"));
-  TYPE_MOBILE_SUPL = (get_static_field<int>(m_object, "TYPE_MOBILE_SUPL"));
-  TYPE_MOBILE_DUN = (get_static_field<int>(m_object, "TYPE_MOBILE_DUN"));
-  TYPE_MOBILE_HIPRI = (get_static_field<int>(m_object, "TYPE_MOBILE_HIPRI"));
-  TYPE_WIMAX = (get_static_field<int>(m_object, "TYPE_WIMAX"));
-  TYPE_BLUETOOTH = (get_static_field<int>(m_object, "TYPE_BLUETOOTH"));
-  TYPE_DUMMY = (get_static_field<int>(m_object, "TYPE_DUMMY"));
-  TYPE_ETHERNET = (get_static_field<int>(m_object, "TYPE_ETHERNET"));
-  DEFAULT_NETWORK_PREFERENCE = (get_static_field<int>(m_object, "DEFAULT_NETWORK_PREFERENCE"));
+  jhclass clazz = find_class("android.net.ConnectivityManager");
+  TYPE_MOBILE = (get_static_field<int>(clazz, "TYPE_MOBILE"));
+  TYPE_WIFI = (get_static_field<int>(clazz, "TYPE_WIFI"));
+  TYPE_MOBILE_MMS = (get_static_field<int>(clazz, "TYPE_MOBILE_MMS"));
+  TYPE_MOBILE_SUPL = (get_static_field<int>(clazz, "TYPE_MOBILE_SUPL"));
+  TYPE_MOBILE_DUN = (get_static_field<int>(clazz, "TYPE_MOBILE_DUN"));
+  TYPE_MOBILE_HIPRI = (get_static_field<int>(clazz, "TYPE_MOBILE_HIPRI"));
+  TYPE_WIMAX = (get_static_field<int>(clazz, "TYPE_WIMAX"));
+  TYPE_BLUETOOTH = (get_static_field<int>(clazz, "TYPE_BLUETOOTH"));
+  TYPE_DUMMY = (get_static_field<int>(clazz, "TYPE_DUMMY"));
+  TYPE_ETHERNET = (get_static_field<int>(clazz, "TYPE_ETHERNET"));
+  DEFAULT_NETWORK_PREFERENCE = (get_static_field<int>(clazz, "DEFAULT_NETWORK_PREFERENCE"));
 }
 
 bool CJNIConnectivityManager::isNetworkTypeValid(int networkType)

--- a/xbmc/android/jni/ConnectivityManager.h
+++ b/xbmc/android/jni/ConnectivityManager.h
@@ -24,7 +24,7 @@ class CJNINetworkInfo;
 class CJNIConnectivityManager : public CJNIBase
 {
 public:
-  CJNIConnectivityManager(const jni::jhobject &object);
+  CJNIConnectivityManager(const jni::jhobject &object) : CJNIBase(object){};
   bool isNetworkTypeValid(int);
   void setNetworkPreference(int);
   int getNetworkPreference();
@@ -47,6 +47,8 @@ public:
   static int TYPE_DUMMY;
   static int TYPE_ETHERNET;
   static int DEFAULT_NETWORK_PREFERENCE;
+
+  static void PopulateStaticFields();
 private:
   CJNIConnectivityManager();
 };

--- a/xbmc/android/jni/ContentResolver.cpp
+++ b/xbmc/android/jni/ContentResolver.cpp
@@ -1,0 +1,46 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "ContentResolver.h"
+#include "Cursor.h"
+#include "jutils/jutils-details.hpp"
+#include "URI.h"
+std::string CJNIContentResolver::SCHEME_CONTENT;
+std::string CJNIContentResolver::SCHEME_ANDROID_RESOURCE;
+std::string CJNIContentResolver::SCHEME_FILE;
+std::string CJNIContentResolver::CURSOR_ITEM_BASE_TYPE;
+std::string CJNIContentResolver::CURSOR_DIR_BASE_TYPE;
+
+using namespace jni;
+CJNIContentResolver::CJNIContentResolver(const jhobject &object) : CJNIBase(object)
+{
+  SCHEME_CONTENT = jcast<std::string>(get_static_field<jhstring>(m_object,"SCHEME_CONTENT"));
+  SCHEME_ANDROID_RESOURCE = jcast<std::string>(get_static_field<jhstring>(m_object,"SCHEME_ANDROID_RESOURCE"));
+  SCHEME_FILE = jcast<std::string>(get_static_field<jhstring>(m_object,"SCHEME_FILE"));
+  CURSOR_ITEM_BASE_TYPE = jcast<std::string>(get_static_field<jhstring>(m_object,"CURSOR_ITEM_BASE_TYPE"));
+  CURSOR_DIR_BASE_TYPE = jcast<std::string>(get_static_field<jhstring>(m_object,"CURSOR_DIR_BASE_TYPE"));
+}
+
+CJNICursor CJNIContentResolver::query(const CJNIURI &uri, const std::vector<std::string> &projection, const std::string &selection, const std::vector<std::string> &selectionArgs, const std::string &sortOrder)
+{
+
+  return (CJNICursor)(call_method<jhobject>(m_object, \
+         "query","(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;", \
+         uri.get(), jcast<jhstring>(selection), jcast<jhobjectArray>(selectionArgs), jcast<jhstring>(sortOrder)));
+}

--- a/xbmc/android/jni/ContentResolver.cpp
+++ b/xbmc/android/jni/ContentResolver.cpp
@@ -28,13 +28,14 @@ std::string CJNIContentResolver::CURSOR_ITEM_BASE_TYPE;
 std::string CJNIContentResolver::CURSOR_DIR_BASE_TYPE;
 
 using namespace jni;
-CJNIContentResolver::CJNIContentResolver(const jhobject &object) : CJNIBase(object)
+void CJNIContentResolver::PopulateStaticFields()
 {
-  SCHEME_CONTENT = jcast<std::string>(get_static_field<jhstring>(m_object,"SCHEME_CONTENT"));
-  SCHEME_ANDROID_RESOURCE = jcast<std::string>(get_static_field<jhstring>(m_object,"SCHEME_ANDROID_RESOURCE"));
-  SCHEME_FILE = jcast<std::string>(get_static_field<jhstring>(m_object,"SCHEME_FILE"));
-  CURSOR_ITEM_BASE_TYPE = jcast<std::string>(get_static_field<jhstring>(m_object,"CURSOR_ITEM_BASE_TYPE"));
-  CURSOR_DIR_BASE_TYPE = jcast<std::string>(get_static_field<jhstring>(m_object,"CURSOR_DIR_BASE_TYPE"));
+  jhclass clazz = find_class("android/content/ContentResolver");
+  SCHEME_CONTENT = jcast<std::string>(get_static_field<jhstring>(clazz,"SCHEME_CONTENT"));
+  SCHEME_ANDROID_RESOURCE = jcast<std::string>(get_static_field<jhstring>(clazz,"SCHEME_ANDROID_RESOURCE"));
+  SCHEME_FILE = jcast<std::string>(get_static_field<jhstring>(clazz,"SCHEME_FILE"));
+  CURSOR_ITEM_BASE_TYPE = jcast<std::string>(get_static_field<jhstring>(clazz,"CURSOR_ITEM_BASE_TYPE"));
+  CURSOR_DIR_BASE_TYPE = jcast<std::string>(get_static_field<jhstring>(clazz,"CURSOR_DIR_BASE_TYPE"));
 }
 
 CJNICursor CJNIContentResolver::query(const CJNIURI &uri, const std::vector<std::string> &projection, const std::string &selection, const std::vector<std::string> &selectionArgs, const std::string &sortOrder)

--- a/xbmc/android/jni/ContentResolver.h
+++ b/xbmc/android/jni/ContentResolver.h
@@ -1,0 +1,40 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "JNIBase.h"
+
+class CJNICursor;
+class CJNIURI;
+class CJNIContentResolver : public CJNIBase
+{
+public:
+  CJNIContentResolver(const jni::jhobject &object);
+
+  static std::string SCHEME_CONTENT;
+  static std::string SCHEME_ANDROID_RESOURCE;
+  static std::string SCHEME_FILE;
+  static std::string CURSOR_ITEM_BASE_TYPE;
+  static std::string CURSOR_DIR_BASE_TYPE;
+
+  CJNICursor query(const CJNIURI &uri, const std::vector<std::string> &projection, const std::string &selection, const std::vector<std::string> &selectionArgs, const std::string &sortOrder);
+
+private:
+  CJNIContentResolver();
+};

--- a/xbmc/android/jni/ContentResolver.h
+++ b/xbmc/android/jni/ContentResolver.h
@@ -25,7 +25,7 @@ class CJNIURI;
 class CJNIContentResolver : public CJNIBase
 {
 public:
-  CJNIContentResolver(const jni::jhobject &object);
+  CJNIContentResolver(const jni::jhobject &object) : CJNIBase(object){};
 
   static std::string SCHEME_CONTENT;
   static std::string SCHEME_ANDROID_RESOURCE;
@@ -35,6 +35,7 @@ public:
 
   CJNICursor query(const CJNIURI &uri, const std::vector<std::string> &projection, const std::string &selection, const std::vector<std::string> &selectionArgs, const std::string &sortOrder);
 
+  static void PopulateStaticFields();
 private:
   CJNIContentResolver();
 };

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -148,3 +148,9 @@ CJNIContentResolver CJNIContext::getContentResolver()
 {
   return (CJNIContentResolver)call_method<jhobject>(m_context, "getContentResolver", "()Landroid/content/ContentResolver;");
 }
+
+void CJNIContext::_onReceive(JNIEnv *env, jobject context, jobject intent)
+{
+  if(m_appInstance)
+    m_appInstance->onReceive(CJNIIntent(jhobject(intent)));
+}

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -28,6 +28,7 @@
 #include "JNIThreading.h"
 #include "ApplicationInfo.h"
 #include "File.h"
+#include "ContentResolver.h"
 #include <android/native_activity.h>
 
 using namespace jni;
@@ -117,4 +118,9 @@ CJNIFile CJNIContext::getDir(const std::string &path, int mode)
 CJNIFile CJNIContext::getExternalFilesDir(const std::string &path)
 {
   return (CJNIFile)call_method<jhobject>(m_context, "getExternalFilesDir", "(Ljava/lang/String;)Ljava/io/File;", jcast<jhstring>(path));
+}
+
+CJNIContentResolver CJNIContext::getContentResolver()
+{
+  return (CJNIContentResolver)call_method<jhobject>(m_context, "getContentResolver", "()Landroid/content/ContentResolver;");
 }

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -46,7 +46,6 @@ CJNIContext::CJNIContext(const ANativeActivity *nativeActivity)
   m_context.reset(nativeActivity->clazz);
   xbmc_jni_on_load(nativeActivity->vm, nativeActivity->env);
   PopulateStaticFields();
-  InitializeBroadcastReceiver();
   m_appInstance = this;
 }
 
@@ -54,7 +53,6 @@ CJNIContext::~CJNIContext()
 {
   m_appInstance = NULL;
   m_context.release();
-  DestroyBroadcastReceiver();
   xbmc_jni_on_unload();
 }
 
@@ -147,12 +145,6 @@ CJNIFile CJNIContext::getExternalFilesDir(const std::string &path)
 CJNIContentResolver CJNIContext::getContentResolver()
 {
   return (CJNIContentResolver)call_method<jhobject>(m_context, "getContentResolver", "()Landroid/content/ContentResolver;");
-}
-
-void CJNIContext::_onReceive(JNIEnv *env, jobject context, jobject intent)
-{
-  if(m_appInstance)
-    m_appInstance->onReceive(CJNIIntent(jhobject(intent)));
 }
 
 void CJNIContext::_onNewIntent(JNIEnv *env, jobject context, jobject intent)

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -102,6 +102,11 @@ CJNIIntent CJNIContext::registerReceiver(const CJNIIntentFilter &filter)
                              "(Landroid/content/BroadcastReceiver;Landroid/content/IntentFilter;)Landroid/content/Intent;", (jobject)NULL, filter.get());
 }
 
+void CJNIContext::unregisterReceiver(const CJNIBroadcastReceiver &receiver)
+{
+  call_method<void>(m_context, "unregisterReceiver", "(Landroid/content/BroadcastReceiver;)V", receiver.get());
+}
+
 CJNIIntent CJNIContext::sendBroadcast(const CJNIIntent &intent)
 {
   return (CJNIIntent)call_method<jhobject>(m_context, "sendBroadcast", "(Landroid/content/Intent;)V", intent.get());

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -154,3 +154,9 @@ void CJNIContext::_onReceive(JNIEnv *env, jobject context, jobject intent)
   if(m_appInstance)
     m_appInstance->onReceive(CJNIIntent(jhobject(intent)));
 }
+
+void CJNIContext::_onNewIntent(JNIEnv *env, jobject context, jobject intent)
+{
+  if(m_appInstance)
+    m_appInstance->onNewIntent(CJNIIntent(jhobject(intent)));
+}

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -31,6 +31,10 @@
 #include "ContentResolver.h"
 #include "BaseColumns.h"
 #include "MediaStore.h"
+#include "PowerManager.h"
+#include "Cursor.h"
+#include "ConnectivityManager.h"
+#include "AudioManager.h"
 #include <android/native_activity.h>
 
 using namespace jni;
@@ -55,6 +59,14 @@ void CJNIContext::PopulateStaticFields()
 {
   CJNIBaseColumns::PopulateStaticFields();
   CJNIMediaStoreMediaColumns::PopulateStaticFields();
+  CJNIPowerManager::PopulateStaticFields();
+  CJNIPackageManager::PopulateStaticFields();
+  CJNIMediaStoreMediaColumns::PopulateStaticFields();
+  CJNICursor::PopulateStaticFields();
+  CJNIContentResolver::PopulateStaticFields();
+  CJNIConnectivityManager::PopulateStaticFields();
+  CJNIAudioManager::PopulateStaticFields();
+
 }
 
 CJNIPackageManager CJNIContext::GetPackageManager()

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -40,16 +40,19 @@
 using namespace jni;
 
 jhobject CJNIContext::m_context(0);
-CJNIContext::CJNIContext(const ANativeActivity *nativeActivity) : CJNIBroadcastReceiver(this)
+CJNIContext* CJNIContext::m_appInstance(NULL);
+CJNIContext::CJNIContext(const ANativeActivity *nativeActivity)
 {
   m_context.reset(nativeActivity->clazz);
   xbmc_jni_on_load(nativeActivity->vm, nativeActivity->env);
   PopulateStaticFields();
   InitializeBroadcastReceiver();
+  m_appInstance = this;
 }
 
 CJNIContext::~CJNIContext()
 {
+  m_appInstance = NULL;
   m_context.release();
   DestroyBroadcastReceiver();
   xbmc_jni_on_unload();

--- a/xbmc/android/jni/Context.cpp
+++ b/xbmc/android/jni/Context.cpp
@@ -29,6 +29,8 @@
 #include "ApplicationInfo.h"
 #include "File.h"
 #include "ContentResolver.h"
+#include "BaseColumns.h"
+#include "MediaStore.h"
 #include <android/native_activity.h>
 
 using namespace jni;
@@ -38,6 +40,7 @@ CJNIContext::CJNIContext(const ANativeActivity *nativeActivity) : CJNIBroadcastR
 {
   m_context.reset(nativeActivity->clazz);
   xbmc_jni_on_load(nativeActivity->vm, nativeActivity->env);
+  PopulateStaticFields();
   InitializeBroadcastReceiver();
 }
 
@@ -46,6 +49,12 @@ CJNIContext::~CJNIContext()
   m_context.release();
   DestroyBroadcastReceiver();
   xbmc_jni_on_unload();
+}
+
+void CJNIContext::PopulateStaticFields()
+{
+  CJNIBaseColumns::PopulateStaticFields();
+  CJNIMediaStoreMediaColumns::PopulateStaticFields();
 }
 
 CJNIPackageManager CJNIContext::GetPackageManager()

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -47,6 +47,7 @@ public:
   static CJNIFile getDir(const std::string &path, int mode);
   static CJNIFile getExternalFilesDir(const std::string &path);
   static CJNIContentResolver getContentResolver();
+  static CJNIContext* GetAppInstance() { return m_appInstance; };
   virtual void onReceive(CJNIIntent intent)=0;
 protected:
   CJNIContext(const ANativeActivity *nativeActivity);
@@ -57,5 +58,6 @@ private:
   void PopulateStaticFields();
   void operator=(CJNIContext const&){};
   static jni::jhobject m_context;
+  static CJNIContext *m_appInstance;
 };
 

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -29,7 +29,7 @@ class CJNIClassLoader;
 class CJNIApplicationInfo;
 class CJNIFile;
 class CJNIContentResolver;
-class CJNIContext : public CJNIBroadcastReceiver
+class CJNIContext
 {
 public:
   static CJNIPackageManager GetPackageManager();
@@ -48,10 +48,8 @@ public:
   static CJNIFile getExternalFilesDir(const std::string &path);
   static CJNIContentResolver getContentResolver();
   static CJNIContext* GetAppInstance() { return m_appInstance; };
-  static void _onReceive(JNIEnv *env, jobject context, jobject intent);
   static void _onNewIntent(JNIEnv *env, jobject context, jobject intent);
 protected:
-  virtual void onReceive(CJNIIntent intent)=0;
   virtual void onNewIntent(CJNIIntent intent)=0;
   CJNIContext(const ANativeActivity *nativeActivity);
   ~CJNIContext();

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -54,6 +54,7 @@ protected:
 
 private:
   CJNIContext();
+  void PopulateStaticFields();
   void operator=(CJNIContext const&){};
   static jni::jhobject m_context;
 };

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -38,6 +38,7 @@ public:
   static int checkCallingOrSelfPermission(const std::string &permission);
   static CJNIIntent registerReceiver(const CJNIBroadcastReceiver &receiver, const CJNIIntentFilter &filter);
   static CJNIIntent registerReceiver(const CJNIIntentFilter &filter);
+  static void unregisterReceiver(const CJNIBroadcastReceiver &receiver);
   static CJNIIntent sendBroadcast(const CJNIIntent &intent);
   static CJNIIntent getIntent();
   static CJNIClassLoader getClassLoader();

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -49,8 +49,10 @@ public:
   static CJNIContentResolver getContentResolver();
   static CJNIContext* GetAppInstance() { return m_appInstance; };
   static void _onReceive(JNIEnv *env, jobject context, jobject intent);
+  static void _onNewIntent(JNIEnv *env, jobject context, jobject intent);
 protected:
   virtual void onReceive(CJNIIntent intent)=0;
+  virtual void onNewIntent(CJNIIntent intent)=0;
   CJNIContext(const ANativeActivity *nativeActivity);
   ~CJNIContext();
 

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -48,8 +48,9 @@ public:
   static CJNIFile getExternalFilesDir(const std::string &path);
   static CJNIContentResolver getContentResolver();
   static CJNIContext* GetAppInstance() { return m_appInstance; };
-  virtual void onReceive(CJNIIntent intent)=0;
+  static void _onReceive(JNIEnv *env, jobject context, jobject intent);
 protected:
+  virtual void onReceive(CJNIIntent intent)=0;
   CJNIContext(const ANativeActivity *nativeActivity);
   ~CJNIContext();
 

--- a/xbmc/android/jni/Context.h
+++ b/xbmc/android/jni/Context.h
@@ -28,6 +28,7 @@ class CJNIIntentFilter;
 class CJNIClassLoader;
 class CJNIApplicationInfo;
 class CJNIFile;
+class CJNIContentResolver;
 class CJNIContext : public CJNIBroadcastReceiver
 {
 public:
@@ -45,6 +46,7 @@ public:
   static CJNIFile getCacheDir();
   static CJNIFile getDir(const std::string &path, int mode);
   static CJNIFile getExternalFilesDir(const std::string &path);
+  static CJNIContentResolver getContentResolver();
   virtual void onReceive(CJNIIntent intent)=0;
 protected:
   CJNIContext(const ANativeActivity *nativeActivity);

--- a/xbmc/android/jni/Cursor.cpp
+++ b/xbmc/android/jni/Cursor.cpp
@@ -1,0 +1,180 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "Cursor.h"
+#include "jutils/jutils-details.hpp"
+#include "URI.h"
+
+using namespace jni;
+
+int CJNICursor::FIELD_TYPE_NULL(0);
+int CJNICursor::FIELD_TYPE_INTEGER(0);
+int CJNICursor::FIELD_TYPE_FLOAT(0);
+int CJNICursor::FIELD_TYPE_STRING(0);
+int CJNICursor::FIELD_TYPE_BLOB(0);
+
+CJNICursor::CJNICursor(const jni::jhobject &object) : CJNIBase(object)
+{
+  FIELD_TYPE_NULL = (get_static_field<int>(m_object, "FIELD_TYPE_NULL"));
+  FIELD_TYPE_INTEGER = (get_static_field<int>(m_object, "FIELD_TYPE_INTEGER"));
+  FIELD_TYPE_FLOAT = (get_static_field<int>(m_object, "FIELD_TYPE_FLOAT"));
+  FIELD_TYPE_STRING = (get_static_field<int>(m_object, "FIELD_TYPE_STRING"));
+  FIELD_TYPE_BLOB = (get_static_field<int>(m_object, "FIELD_TYPE_BLOB"));
+}
+
+int CJNICursor::getCount()
+{
+  return call_method<jint>(m_object, "getCount", "()I");
+}
+
+int CJNICursor::getPosition()
+{
+  return call_method<jint>(m_object, "getPosition", "()I");
+}
+
+bool CJNICursor::move(int offset)
+{
+  return call_method<jboolean>(m_object, "move", "(I)Z", offset);
+}
+
+bool CJNICursor::moveToPosition(int position)
+{
+  return call_method<jboolean>(m_object, "moveToPosition", "(I)Z", position);
+}
+
+bool CJNICursor::moveToFirst()
+{
+  return call_method<jboolean>(m_object, "moveToFirst", "()Z");
+}
+
+bool CJNICursor::moveToLast()
+{
+  return call_method<jboolean>(m_object, "moveToLast", "()Z");
+}
+
+bool CJNICursor::moveToNext()
+{
+  return call_method<jboolean>(m_object, "moveToNext", "()Z");
+}
+
+bool CJNICursor::moveToPrevious()
+{
+  return call_method<jboolean>(m_object, "moveToPrevious", "()Z");
+}
+
+bool CJNICursor::isFirst()
+{
+  return call_method<jboolean>(m_object, "isFirst", "()Z");
+}
+
+bool CJNICursor::isLast()
+{
+  return call_method<jboolean>(m_object, "isLast", "()Z");
+}
+
+bool CJNICursor::isBeforeFirst()
+{
+  return call_method<jboolean>(m_object, "isBeforeFirst", "()Z");
+}
+
+bool CJNICursor::isAfterLast()
+{
+  return call_method<jboolean>(m_object, "isAfterLast", "()Z");
+}
+
+int CJNICursor::getColumnIndex(const std::string &columnName)
+{
+  return call_method<jint>(m_object, "getColumnIndex", "(Ljava/lang/String;)I", jcast<jhstring>(columnName));
+}
+
+std::string CJNICursor::getColumnName(int columnIndex)
+{
+  return jcast<std::string>(call_method<jhstring>(m_object, "getColumnName", "(I)Ljava/lang/String;", columnIndex));
+}
+
+std::vector<std::string> CJNICursor::getColumnNames()
+{
+  return jcast<std::vector<std::string>>(call_method<jhobjectArray>(m_object, "getColumnNames", "()[Ljava/lang/String;"));
+}
+
+int CJNICursor::getColumnCount()
+{
+  return call_method<jint>(m_object, "getColumnCount", "()I");
+}
+
+std::string CJNICursor::getString(int columnIndex)
+{
+  return jcast<std::string>(call_method<jhstring>(m_object, "getString", "(I)Ljava/lang/String;", columnIndex));
+}
+
+short CJNICursor::getShort(int columnIndex)
+{
+  return call_method<jshort>(m_object, "getShort", "()S", columnIndex);
+}
+
+int CJNICursor::getInt(int columnIndex)
+{
+  return call_method<jint>(m_object, "getInt", "()I", columnIndex);
+}
+
+long CJNICursor::getLong(int columnIndex)
+{
+  return call_method<jint>(m_object, "getLong", "()J", columnIndex);
+}
+
+float CJNICursor::getFloat(int columnIndex)
+{
+  return call_method<jfloat>(m_object, "getFloat", "()F", columnIndex);
+}
+
+double CJNICursor::getDouble(int columnIndex)
+{
+  return call_method<jdouble>(m_object, "getDouble", "()D", columnIndex);
+}
+
+int CJNICursor::getType(int columnIndex)
+{
+  return call_method<jint>(m_object, "getType", "(I)I", columnIndex);
+}
+
+bool CJNICursor::isNull(int columnIndex)
+{
+  return call_method<jboolean>(m_object, "isNull", "(I)Z", columnIndex);
+}
+
+void CJNICursor::deactivate()
+{
+  call_method<void>(m_object, "deactivate", "()V");
+}
+
+bool CJNICursor::requery()
+{
+  return call_method<jboolean>(m_object, "requery", "()Z");
+}
+
+void CJNICursor::close()
+{
+  call_method<void>(m_object, "close", "()V");
+}
+
+bool CJNICursor::isClosed()
+{
+  return call_method<jboolean>(m_object, "isClosed", "()Z");
+}
+

--- a/xbmc/android/jni/Cursor.cpp
+++ b/xbmc/android/jni/Cursor.cpp
@@ -29,13 +29,14 @@ int CJNICursor::FIELD_TYPE_FLOAT(0);
 int CJNICursor::FIELD_TYPE_STRING(0);
 int CJNICursor::FIELD_TYPE_BLOB(0);
 
-CJNICursor::CJNICursor(const jni::jhobject &object) : CJNIBase(object)
+void CJNICursor::PopulateStaticFields()
 {
-  FIELD_TYPE_NULL = (get_static_field<int>(m_object, "FIELD_TYPE_NULL"));
-  FIELD_TYPE_INTEGER = (get_static_field<int>(m_object, "FIELD_TYPE_INTEGER"));
-  FIELD_TYPE_FLOAT = (get_static_field<int>(m_object, "FIELD_TYPE_FLOAT"));
-  FIELD_TYPE_STRING = (get_static_field<int>(m_object, "FIELD_TYPE_STRING"));
-  FIELD_TYPE_BLOB = (get_static_field<int>(m_object, "FIELD_TYPE_BLOB"));
+  jhclass clazz = find_class("android/database/Cursor");
+  FIELD_TYPE_NULL = (get_static_field<int>(clazz, "FIELD_TYPE_NULL"));
+  FIELD_TYPE_INTEGER = (get_static_field<int>(clazz, "FIELD_TYPE_INTEGER"));
+  FIELD_TYPE_FLOAT = (get_static_field<int>(clazz, "FIELD_TYPE_FLOAT"));
+  FIELD_TYPE_STRING = (get_static_field<int>(clazz, "FIELD_TYPE_STRING"));
+  FIELD_TYPE_BLOB = (get_static_field<int>(clazz, "FIELD_TYPE_BLOB"));
 }
 
 int CJNICursor::getCount()

--- a/xbmc/android/jni/Cursor.h
+++ b/xbmc/android/jni/Cursor.h
@@ -1,0 +1,66 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "JNIBase.h"
+#include "MediaStore.h"
+class CJNIURI;
+class CJNICursor : public CJNIBase
+{
+public:
+  ~CJNICursor(){};
+  CJNICursor(const jni::jhobject &object);
+  int getCount();
+  int getPosition();
+  bool move(int offset);
+  bool moveToPosition(int position);
+  bool moveToFirst();
+  bool moveToLast();
+  bool moveToNext();
+  bool moveToPrevious();
+  bool isFirst();
+  bool isLast();
+  bool isBeforeFirst();
+  bool isAfterLast();
+  int getColumnIndex(const std::string &columnName);
+  std::string getColumnName(int columnIndex);
+  std::vector<std::string> getColumnNames();
+  int getColumnCount();
+  std::string getString(int columnIndex);
+  short getShort(int columnIndex);
+  int getInt(int columnIndex);
+  long getLong(int columnIndex);
+  float getFloat(int columnIndex);
+  double getDouble(int columnIndex);
+  int getType(int columnIndex);
+  bool isNull(int columnIndex);
+  void deactivate();
+  bool requery();
+  void close();
+  bool isClosed();
+
+  static int FIELD_TYPE_NULL;
+  static int FIELD_TYPE_INTEGER;
+  static int FIELD_TYPE_FLOAT;
+  static int FIELD_TYPE_STRING;
+  static int FIELD_TYPE_BLOB;
+
+private:
+  CJNICursor();
+};

--- a/xbmc/android/jni/Cursor.h
+++ b/xbmc/android/jni/Cursor.h
@@ -25,7 +25,7 @@ class CJNICursor : public CJNIBase
 {
 public:
   ~CJNICursor(){};
-  CJNICursor(const jni::jhobject &object);
+  CJNICursor(const jni::jhobject &object) : CJNIBase(object){};
   int getCount();
   int getPosition();
   bool move(int offset);
@@ -61,6 +61,7 @@ public:
   static int FIELD_TYPE_STRING;
   static int FIELD_TYPE_BLOB;
 
+  static void PopulateStaticFields();
 private:
   CJNICursor();
 };

--- a/xbmc/android/jni/Intent.cpp
+++ b/xbmc/android/jni/Intent.cpp
@@ -108,3 +108,7 @@ void CJNIIntent::setType(const std::string &type)
   call_method<jhobject>(m_object, "setType", "(Ljava/lang/String;)Landroid/content/Intent;", jcast<jhstring>(type));
 }
 
+CJNIURI CJNIIntent::getData() const
+{
+  return (CJNIURI)call_method<jhobject>(m_object, "getData","()Landroid/net/Uri;");
+}

--- a/xbmc/android/jni/Intent.h
+++ b/xbmc/android/jni/Intent.h
@@ -50,4 +50,5 @@ public:
 
   void setPackage(const std::string &packageName);
   void setType(const std::string &type);
+  CJNIURI getData() const;
 };

--- a/xbmc/android/jni/Makefile.in
+++ b/xbmc/android/jni/Makefile.in
@@ -31,6 +31,8 @@ SRCS      += BitmapDrawable.cpp
 SRCS      += CharSequence.cpp
 SRCS      += ContentResolver.cpp
 SRCS      += Cursor.cpp
+SRCS      += BaseColumns.cpp
+SRCS      += MediaStore.cpp
 
 LIB        = jni.a
 

--- a/xbmc/android/jni/Makefile.in
+++ b/xbmc/android/jni/Makefile.in
@@ -29,6 +29,8 @@ SRCS      += System.cpp
 SRCS      += ApplicationInfo.cpp
 SRCS      += BitmapDrawable.cpp
 SRCS      += CharSequence.cpp
+SRCS      += ContentResolver.cpp
+SRCS      += Cursor.cpp
 
 LIB        = jni.a
 

--- a/xbmc/android/jni/MediaStore.cpp
+++ b/xbmc/android/jni/MediaStore.cpp
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "MediaStore.h"
+#include "jutils/jutils-details.hpp"
+
+using namespace jni;
+
+std::string CJNIMediaStoreMediaColumns::DATA;
+std::string CJNIMediaStoreMediaColumns::SIZE;
+std::string CJNIMediaStoreMediaColumns::DISPLAY_NAME;
+std::string CJNIMediaStoreMediaColumns::TITLE;
+std::string CJNIMediaStoreMediaColumns::DATE_ADDED;
+std::string CJNIMediaStoreMediaColumns::DATE_MODIFIED;
+std::string CJNIMediaStoreMediaColumns::MIME_TYPE;
+void CJNIMediaStoreMediaColumns::PopulateStaticFields()
+{
+  jhclass clazz = find_class("android/provider/MediaStore$MediaColumns");
+  DATA = (jcast<std::string>(get_static_field<jhstring>(clazz, "DATA")));
+  SIZE = (jcast<std::string>(get_static_field<jhstring>(clazz, "SIZE")));
+  DISPLAY_NAME = (jcast<std::string>(get_static_field<jhstring>(clazz, "DISPLAY_NAME")));
+  TITLE = (jcast<std::string>(get_static_field<jhstring>(clazz, "TITLE")));
+  DATE_ADDED = (jcast<std::string>(get_static_field<jhstring>(clazz, "DATE_ADDED")));
+  DATE_MODIFIED = (jcast<std::string>(get_static_field<jhstring>(clazz, "DATE_MODIFIED")));
+  MIME_TYPE = (jcast<std::string>(get_static_field<jhstring>(clazz, "MIME_TYPE")));
+}

--- a/xbmc/android/jni/MediaStore.h
+++ b/xbmc/android/jni/MediaStore.h
@@ -1,0 +1,43 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "JNIBase.h"
+#include "BaseColumns.h"
+class CJNIMediaStoreMediaColumns : public CJNIBaseColumns
+{
+public:
+  static std::string DATA; 
+  static std::string SIZE; 
+  static std::string DISPLAY_NAME;
+  static std::string TITLE;
+  static std::string DATE_ADDED;
+  static std::string DATE_MODIFIED;
+  static std::string MIME_TYPE;
+  static void PopulateStaticFields();
+private:
+  CJNIMediaStoreMediaColumns();
+};
+
+class CJNIMediaStore : public CJNIBase
+{
+public:
+  ~CJNIMediaStore(){};
+  CJNIMediaStore(const jni::jhobject &object) : CJNIBase(object){};
+};

--- a/xbmc/android/jni/PackageManager.cpp
+++ b/xbmc/android/jni/PackageManager.cpp
@@ -28,9 +28,10 @@
 using namespace jni;
 int CJNIPackageManager::GET_ACTIVITIES(0);
 
-CJNIPackageManager::CJNIPackageManager(const jni::jhobject &object) : CJNIBase(object)
+void CJNIPackageManager::PopulateStaticFields()
 {
-  GET_ACTIVITIES = (get_static_field<int>(m_object, "GET_ACTIVITIES"));
+  jhclass clazz = find_class("android/content/pm/PackageManager");
+  GET_ACTIVITIES = (get_static_field<int>(clazz, "GET_ACTIVITIES"));
 }
 
 CJNIIntent CJNIPackageManager::getLaunchIntentForPackage(const std::string &package)

--- a/xbmc/android/jni/PackageManager.h
+++ b/xbmc/android/jni/PackageManager.h
@@ -28,7 +28,7 @@ class CJNICharSequence;
 class CJNIPackageManager : public CJNIBase
 {
 public:
-  CJNIPackageManager(const jni::jhobject &object);
+  CJNIPackageManager(const jni::jhobject &object) : CJNIBase(object) {};
   ~CJNIPackageManager(){};
 
   CJNIIntent getLaunchIntentForPackage(const std::string &package);
@@ -36,6 +36,7 @@ public:
   CJNIList<CJNIApplicationInfo> getInstalledApplications(int flags);
   CJNICharSequence getApplicationLabel(const CJNIApplicationInfo &info);
 
+  static void PopulateStaticFields();
   static int GET_ACTIVITIES;
 private:
   CJNIPackageManager();

--- a/xbmc/android/jni/PowerManager.cpp
+++ b/xbmc/android/jni/PowerManager.cpp
@@ -24,9 +24,11 @@
 using namespace jni;
 
 int CJNIPowerManager::FULL_WAKE_LOCK(0);
-CJNIPowerManager::CJNIPowerManager(const jni::jhobject &object) : CJNIBase(object)
+
+void CJNIPowerManager::PopulateStaticFields()
 {
-  FULL_WAKE_LOCK = (get_static_field<int>(m_object, "FULL_WAKE_LOCK"));  
+  jhclass clazz = find_class("android/os/PowerManager");
+  FULL_WAKE_LOCK = (get_static_field<int>(clazz, "FULL_WAKE_LOCK"));
 }
 
 CJNIWakeLock CJNIPowerManager::newWakeLock(const std::string &name)

--- a/xbmc/android/jni/PowerManager.h
+++ b/xbmc/android/jni/PowerManager.h
@@ -28,7 +28,8 @@ public:
   void reboot(const std::string &reason);
   void goToSleep(int64_t timestamp);
 
-  CJNIPowerManager(const jni::jhobject &object);
+  static void PopulateStaticFields();
+  CJNIPowerManager(const jni::jhobject &object) : CJNIBase(object){};
   ~CJNIPowerManager(){};
 
 private:

--- a/xbmc/android/jni/URI.cpp
+++ b/xbmc/android/jni/URI.cpp
@@ -26,3 +26,23 @@ CJNIURI CJNIURI::parse(std::string uriString)
 {
   return (CJNIURI)call_static_method<jhobject>("android/net/Uri", "parse", "(Ljava/lang/String;)Landroid/net/Uri;", jcast<jhstring>(uriString));
 }
+
+std::string CJNIURI::getScheme() const
+{
+  return jcast<std::string>(call_method<jhstring>(m_object, "getScheme", "()Ljava/lang/String;"));
+}
+
+std::string CJNIURI::toString() const
+{
+  return jcast<std::string>(call_method<jhstring>(m_object, "toString", "()Ljava/lang/String;"));
+}
+
+std::string CJNIURI::getLastPathSegment() const
+{
+  return jcast<std::string>(call_method<jhstring>(m_object, "getLastPathSegment", "()Ljava/lang/String;"));
+}
+
+std::string CJNIURI::getPath() const
+{
+  return jcast<std::string>(call_method<jhstring>(m_object, "getPath", "()Ljava/lang/String;"));
+}

--- a/xbmc/android/jni/URI.h
+++ b/xbmc/android/jni/URI.h
@@ -23,9 +23,13 @@
 class CJNIURI : public CJNIBase
 {
   public:
+  CJNIURI(const jni::jhobject &uri) : CJNIBase(uri){};
+  std::string getScheme() const;
+  std::string toString() const;
+  std::string getLastPathSegment() const;
+  std::string getPath() const;
   static CJNIURI parse(std::string uriString);
   ~CJNIURI(){};
 private:
-  CJNIURI(const jni::jhobject &uri) : CJNIBase(uri){};
   CJNIURI();
 };

--- a/xbmc/android/jni/jutils.cpp
+++ b/xbmc/android/jni/jutils.cpp
@@ -76,6 +76,43 @@ jhstring jcast_helper<jhstring, std::string>::cast(const std::string &s)
     return jhstring(obj);
 }
 
+jhobjectArray jcast_helper<jhobjectArray, std::vector<std::string> >::cast(const std::vector<std::string> &s)
+{
+  JNIEnv *env = xbmc_jnienv();
+  jobjectArray ret = NULL;
+  if (!s.empty())
+  {
+    ret = env->NewObjectArray(s.size(), env->FindClass("java/lang/String"), NULL);
+    for (unsigned int i = 0; i < s.size(); i++)
+    env->SetObjectArrayElement(ret, i, env->NewStringUTF(s[i].c_str()));
+  }
+  return jhobjectArray(ret);
+}
+
+std::vector<std::string> jcast_helper<std::vector<std::string>, jobjectArray >::cast(const jobjectArray &s)
+{
+  JNIEnv *env = xbmc_jnienv();
+  std::vector<std::string> ret;
+  jstring element;
+  const char* newString = NULL;
+  if (!s)
+    return ret;
+
+  unsigned int arraySize = env->GetArrayLength(s);
+  ret.reserve(arraySize);
+  for (unsigned int i = 0; i < arraySize; ++i)
+  {
+    element = (jstring) env->GetObjectArrayElement(s, i);
+    newString = env->GetStringUTFChars(element, JNI_FALSE);
+    if (newString)
+    {
+      ret.push_back(newString);
+      env->ReleaseStringUTFChars(element, newString);
+    }
+  }
+  return ret;
+}
+
 #define CRYSTAX_PP_CAT(a, b, c) CRYSTAX_PP_CAT_IMPL(a, b, c)
 #define CRYSTAX_PP_CAT_IMPL(a, b, c) a ## b ## c
 

--- a/xbmc/android/jni/jutils.cpp
+++ b/xbmc/android/jni/jutils.cpp
@@ -72,8 +72,12 @@ std::string jcast_helper<std::string, jstring>::cast(jstring const &v)
 jhstring jcast_helper<jhstring, std::string>::cast(const std::string &s)
 {
     JNIEnv *env = xbmc_jnienv();
-    jstring obj = env->NewStringUTF(s.c_str());
-    return jhstring(obj);
+    jstring ret = NULL;
+    if (!s.empty())
+    {
+      ret = env->NewStringUTF(s.c_str());
+    }
+    return jhstring(ret);
 }
 
 jhobjectArray jcast_helper<jhobjectArray, std::vector<std::string> >::cast(const std::vector<std::string> &s)

--- a/xbmc/android/jni/jutils/jutils-details.hpp
+++ b/xbmc/android/jni/jutils/jutils-details.hpp
@@ -412,10 +412,16 @@ Ret get_field(const char *clsname, const char *name)
 */
 // Get static field
 
-template <typename Ret, typename T>
-Ret get_static_field(JNIEnv *env, jholder<T> const &obj, const char *name, const char *signature)
+template <typename Ret>
+Ret get_static_field(JNIEnv *env, jhobject const &obj, const char *name, const char *signature)
 {
     return details::jni_helper<Ret>::get_static_field(env, get_class(env, obj), get_static_field_id(env, obj, name, signature));
+}
+
+template <typename Ret>
+Ret get_static_field(JNIEnv *env, jhclass const &cls, const char *name, const char *signature)
+{
+    return details::jni_helper<Ret>::get_static_field(env, cls, get_static_field_id(env, cls, name, signature));
 }
 
 template <typename Ret, typename T>

--- a/xbmc/android/jni/jutils/jutils-details.hpp
+++ b/xbmc/android/jni/jutils/jutils-details.hpp
@@ -66,9 +66,21 @@ struct jcast_helper<std::string, jstring>
 };
 
 template <>
+struct jcast_helper<std::vector<std::string>, jobjectArray>
+{
+    static std::vector<std::string> cast(jobjectArray const &v);
+};
+
+template <>
 struct jcast_helper<jhstring, std::string>
 {
     static jhstring cast(const std::string &v);
+};
+
+template <>
+struct jcast_helper<jhobjectArray, std::vector<std::string> >
+{
+    static jhobjectArray cast(const std::vector<std::string> &v);
 };
 
 template <>
@@ -77,6 +89,15 @@ struct jcast_helper<std::string, jhstring>
     static std::string cast(jhstring const &v)
     {
         return jcast_helper<std::string, jstring>::cast(v);
+    }
+};
+
+template <>
+struct jcast_helper<std::vector<std::string>, jhobjectArray>
+{
+    static std::vector<std::string> cast(jhobjectArray const &v)
+    {
+        return jcast_helper<std::vector<std::string>, jobjectArray>::cast(v);
     }
 };
 


### PR DESCRIPTION
This is a rework of https://github.com/xbmc/xbmc/pull/2381 after the jni rewrite. It allows users to set XBMC as the default handler for the types in https://github.com/theuni/xbmc/commit/cf733f1b4072160c18529f2f9bb793d40120224e . Thanks to @koying for the original work.

the "jni" commits are internal lib work independent of xbmc. The final changes have been made to make it completely application-independent, so it can now be moved out of the xbmc code-base and into a new project. These can be squashed down to a single commit if desired.

the "droid" commits are the changes to xbmc to take advantage of the new features in the lib.
