### PR TITLE
Libdvdread fix for SMB, NFS, VIDEO_TS files (non-Windows platforms) - Part 2

### DIFF
--- a/lib/libdvd/libdvdread/src/dvd_reader.c
+++ b/lib/libdvd/libdvdread/src/dvd_reader.c
@@ -429,17 +429,10 @@ dvd_reader_t *DVDOpen( const char *ppath )
               /* Also WIN32 does not have symlinks, so we don't need this bit of code. */
 
     /* Resolve any symlinks and get the absolute dir name. */
-#if defined(_XBMC) /* for XBMC, only do symlink resolution for (real) non-xbmc-VFS paths */
-	if ( path[0] == '/' )
-#endif // _XBMC
 	{
       if( ( cdir  = open( ".", O_RDONLY ) ) >= 0 ) {
         if( chdir( path_copy ) == -1 ) {
-#if defined(_XBMC)
-          fprintf( stderr, "libdvdread: failed to change working directory to \"%s\": %s\n", path_copy, strerror(errno)); /* but ignore error */
-#else
           goto DVDOpen_error;
-#endif // _XBMC
         }
 		new_path = malloc(PATH_MAX+1);
 		if(!new_path) {
@@ -452,11 +445,7 @@ dvd_reader_t *DVDOpen( const char *ppath )
 		close( cdir );
         cdir = -1;
         if( retval == -1 ) {
-#if defined(_XBMC)
-          fprintf( stderr, "libdvdread: failed to reset working directory to \".\": %s\n", strerror(errno)); /* but ignore error */
-#else
           goto DVDOpen_error;
-#endif // _XBMC
         }
 		    path_copy = new_path;
         new_path = NULL;

--- a/lib/libdvd/libdvdread/src/dvd_reader.c
+++ b/lib/libdvd/libdvdread/src/dvd_reader.c
@@ -425,8 +425,9 @@ dvd_reader_t *DVDOpen( const char *ppath )
     if( !(path_copy = strdup( path ) ) )
       goto DVDOpen_error;
 
-#ifndef WIN32 /* don't have fchdir, and getcwd( NULL, ... ) is strange */
+#if !defined(WIN32) && !defined(_XBMC) /* don't have fchdir, and getcwd( NULL, ... ) is strange */
               /* Also WIN32 does not have symlinks, so we don't need this bit of code. */
+			  /* XBMC also doesn't need symlink resolution */
 
     /* Resolve any symlinks and get the absolute dir name. */
 	{

--- a/lib/libdvd/patches/02-libdvdread_fix_symlinks_resolution_vfs.diff
+++ b/lib/libdvd/patches/02-libdvdread_fix_symlinks_resolution_vfs.diff
@@ -1,34 +1,15 @@
 diff --git a/lib/libdvd/libdvdread/src/dvd_reader.c b/lib/libdvd/libdvdread/src/dvd_reader.c
-index d9544b3..f5ee550 100644
+index d9544b3..57dd2d0 100644
 --- a/lib/libdvd/libdvdread/src/dvd_reader.c
 +++ b/lib/libdvd/libdvdread/src/dvd_reader.c
-@@ -429,10 +429,17 @@ dvd_reader_t *DVDOpen( const char *ppath )
+@@ -425,8 +425,9 @@ dvd_reader_t *DVDOpen( const char *ppath )
+     if( !(path_copy = strdup( path ) ) )
+       goto DVDOpen_error;
+ 
+-#ifndef WIN32 /* don't have fchdir, and getcwd( NULL, ... ) is strange */
++#if !defined(WIN32) && !defined(_XBMC) /* don't have fchdir, and getcwd( NULL, ... ) is strange */
                /* Also WIN32 does not have symlinks, so we don't need this bit of code. */
++			  /* XBMC also doesn't need symlink resolution */
  
      /* Resolve any symlinks and get the absolute dir name. */
-+#if defined(_XBMC) /* for XBMC, only do symlink resolution for (real) non-xbmc-VFS paths */
-+	if ( path[0] == '/' )
-+#endif // _XBMC
  	{
-       if( ( cdir  = open( ".", O_RDONLY ) ) >= 0 ) {
-         if( chdir( path_copy ) == -1 ) {
-+#if defined(_XBMC)
-+          fprintf( stderr, "libdvdread: failed to change working directory to \"%s\": %s\n", path_copy, strerror(errno)); /* but ignore error */
-+#else
-           goto DVDOpen_error;
-+#endif // _XBMC
-         }
- 		new_path = malloc(PATH_MAX+1);
- 		if(!new_path) {
-@@ -445,7 +452,11 @@ dvd_reader_t *DVDOpen( const char *ppath )
- 		close( cdir );
-         cdir = -1;
-         if( retval == -1 ) {
-+#if defined(_XBMC)
-+          fprintf( stderr, "libdvdread: failed to reset working directory to \".\": %s\n", strerror(errno)); /* but ignore error */
-+#else
-           goto DVDOpen_error;
-+#endif // _XBMC
-         }
- 		    path_copy = new_path;
-         new_path = NULL;

--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -405,6 +405,11 @@ int __wrap__stat(const char *path, struct _stat *buffer)
   return dll_stat(path, buffer);
 }
 
+int __wrap_stat(const char *path, struct _stat *buffer)
+{
+  return dll_stat(path, buffer);
+}
+
 int __wrap___xstat64(int __ver, const char *__filename, struct stat64 *__stat_buf)
 {
   return dll_stat64(__filename, __stat_buf);


### PR DESCRIPTION
follow up to #2723 - after further investigation concluded that it's better to get rid of the symlink resolution block in libdvdread.
symlink resolution only works partially with our wrapped VFS, because 3 function calls - chdir, fchdir, getcwd - are not wrapped and our VFS can handle symlinks correctly anyway.
