### PR TITLE
Remove URIUtils::GetParentFolderURI(..)

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -38,14 +38,6 @@
 using namespace std;
 using namespace XFILE;
 
-CStdString URIUtils::GetParentFolderURI(const CStdString& uri, bool preserveFileNameInPath)
-{
-  if (preserveFileNameInPath)
-    return AddFileToFolder(GetParentPath(uri), GetFileName(uri));
-  else
-    return GetParentPath(uri);
-}
-
 bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
 {
   CStdString uriPath = CSpecialProtocol::TranslatePath(uri);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -28,8 +28,6 @@ class URIUtils
 public:
   URIUtils(void);
   virtual ~URIUtils(void);
-  static CStdString GetParentFolderURI(const CStdString& uri,
-                                       bool preserveFileNameInPath);
   static bool IsInPath(const CStdString &uri, const CStdString &baseURI);
 
   static void GetDirectory(const CStdString& strFilePath,

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -34,19 +34,6 @@ protected:
   }
 };
 
-TEST_F(TestURIUtils, GetParentFolderURI)
-{
-  CStdString ref, var;
-
-  ref = "/path/to/";
-  var = URIUtils::GetParentFolderURI("/path/to/movie.avi", false);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-
-  ref = "/path/to/movie.avi";
-  var = URIUtils::GetParentFolderURI("/path/to/movie.avi", true);
-  EXPECT_STREQ(ref.c_str(), var.c_str());
-}
-
 TEST_F(TestURIUtils, IsInPath)
 {
   EXPECT_TRUE(URIUtils::IsInPath("/path/to/movie.avi", "/path/to/"));

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8445,7 +8445,9 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
 
           if (item.IsOpticalMediaFile())
           {
-            nfoFile = URIUtils::GetParentFolderURI(nfoFile, true);
+            nfoFile = URIUtils::AddFileToFolder(
+                                    URIUtils::GetParentPath(nfoFile),
+                                    URIUtils::GetFileName(nfoFile));
           }
 
           if (overwrite || !CFile::Exists(nfoFile, false))


### PR DESCRIPTION
It is only called from one deeply nested place with the bool always set to true.

It is a bit hard to follow what it does. First looks like it only splits the path in directory and filename, and then puts it together again. But it is probably used to extract the path in a protocol aware way. That is done by using URIUtils::GetParentPath(..).
