### PR TITLE
[rbp/omxplayer] Fix for hang following seek after eos

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1178,7 +1178,13 @@ void COMXPlayer::Process()
       CDVDDemuxUtils::FreeDemuxPacket(pPacket);
       continue;
     }
-
+    if (pPacket)
+    {
+      // reset eos state when we get a packet (e.g. for case of seek after eos)
+      bOmxWaitVideo = false;
+      bOmxWaitAudio = false;
+      bOmxSentEOFs = false;
+    }
     if (!pPacket)
     {
       // when paused, demuxer could be be returning empty


### PR DESCRIPTION
If you seek after the demuxer eof, the eof state is cleared, but we are not clearing the flags relating to sending eos stream to audio/video players
