### PR TITLE
pvr: fix channel switch for addons using other stream

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -315,8 +315,9 @@ CDVDInputStream::ENextStream CDVDInputStreamPVRManager::NextStream()
 
   m_eof = IsEOF();
 
-  if (m_pOtherStream)
-    return m_pOtherStream->NextStream();
+  CDVDInputStream::ENextStream next;
+  if (m_pOtherStream && ((next = m_pOtherStream->NextStream()) != NEXTSTREAM_NONE))
+    return next;
   else if(m_pFile->SkipNext())
   {
     if (m_eof)


### PR DESCRIPTION
@opdenkamp
fix trac 14307 Player stops if switch channel

pOtherStream->NextStream returns always STREAM_NONE. we need to call this on m_pFile
