### PR TITLE
[Frodo]backport some constructor initializations from 92e8bc4a4361d730abac9ad30...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -147,6 +147,10 @@ CVDPAU::CVDPAU()
   dl_vdp_device_create_x11 = NULL;
   dl_vdp_get_proc_address = NULL;
   dl_vdp_preemption_callback_register = NULL;
+  past[0] = NULL;
+  past[1] = NULL;
+  current = NULL;
+  future = NULL;
 }
 
 bool CVDPAU::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces)


### PR DESCRIPTION
@davilla
this are the relevant changes from 92e8bc4a4361d730abac9ad3080cd6923e9d551a which should fix trac 14334 (Rapidly changing live TV channel crashes XBMC)
