### PR TITLE
External FFmpeg cleaning

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1624,7 +1624,7 @@ if test "$use_external_ffmpeg" = "yes"; then
   [AC_MSG_ERROR($missing_headers)])])
 
   # optional
-  AC_CHECK_HEADERS([libavutil/mem.h libavutil/samplefmt.h])
+  AC_CHECK_HEADERS([libavutil/samplefmt.h])
 
   # Check for libswresample or libavresample headers.
   AC_CHECK_HEADERS([libswresample/swresample.h libavresample/avresample.h])

--- a/configure.in
+++ b/configure.in
@@ -1652,21 +1652,10 @@ if test "$use_external_ffmpeg" = "yes"; then
       AC_MSG_RESULT($ffmpeg_vdpau_not_supported)
     fi])
 
-  # Check for 'PIX_FMT_VDPAU_MPEG4' from libavutil
-  if test "x$use_vdpau" != "xno"; then
-    AC_LANG_PUSH([C++])
-    AC_LINK_IFELSE(
-      [AC_LANG_SOURCE([ #include <libavutil/pixfmt.h>
-        int main() { PixelFormat format = PIX_FMT_VDPAU_MPEG4; }])],
-      [AC_DEFINE([PIX_FMT_VDPAU_MPEG4_IN_AVUTIL], [1],
-      [Whether AVUtil defines PIX_FMT_VDPAU_MPEG4.])],)
-    AC_LANG_POP([C++])
-  fi
   CPPFLAGS="$SAVE_CPPFLAGS"
 else
   AC_MSG_NOTICE($external_ffmpeg_disabled)
   USE_EXTERNAL_FFMPEG=0
-  AC_DEFINE([PIX_FMT_VDPAU_MPEG4_IN_AVUTIL], [1], [Whether AVUtil defines PIX_FMT_VDPAU_MPEG4.])
 fi
 
 echo "Checking for SWIG installation"

--- a/configure.in
+++ b/configure.in
@@ -1629,10 +1629,6 @@ if test "$use_external_ffmpeg" = "yes"; then
   # new FFmpeg have math headers
   AC_CHECK_HEADERS([libavutil/mathematics.h],,)
 
-  # We'll support the use of rgb2rgb.h if it exists.
-  AC_CHECK_HEADERS([libswscale/rgb2rgb.h],,)
-  AC_CHECK_HEADERS([ffmpeg/rgb2rgb.h],,)
-
   # Check for libswresample or libavresample headers.
   AC_CHECK_HEADERS([libswresample/swresample.h libavresample/avresample.h])
 

--- a/configure.in
+++ b/configure.in
@@ -1603,9 +1603,6 @@ fi
 if test "$use_external_ffmpeg" = "yes"; then
   FFMPEG_LIBNAMES="libavcodec libavfilter libavformat libavutil libpostproc libswscale"
 
-  # libavcore is optional
-  PKG_CHECK_EXISTS([libavcore], FFMPEG_LIBNAMES="$FFMPEG_LIBNAMES libavcore")
-
   # one of libswresample or libavresample is needed
   PKG_CHECK_EXISTS([libswresample], FFMPEG_LIBNAMES="$FFMPEG_LIBNAMES libswresample",
                    [PKG_CHECK_EXISTS([libavresample],
@@ -1634,7 +1631,7 @@ if test "$use_external_ffmpeg" = "yes"; then
   [AC_MSG_ERROR($missing_headers)])])
 
   # optional
-  AC_CHECK_HEADERS([libavcore/avcore.h libavcore/samplefmt.h libavutil/mem.h libavutil/samplefmt.h])
+  AC_CHECK_HEADERS([libavutil/mem.h libavutil/samplefmt.h])
 
   # old FFmpeg have this in libavcodec/opt.h instead:
   AC_CHECK_HEADERS([libavutil/opt.h])

--- a/configure.in
+++ b/configure.in
@@ -1618,7 +1618,6 @@ if test "$use_external_ffmpeg" = "yes"; then
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $FFMPEG_CFLAGS"
 
-  # Possible places the ffmpeg headers may be
   AC_CHECK_HEADERS([libavcodec/avcodec.h libavfilter/avfilter.h libavformat/avformat.h libavutil/avutil.h libpostproc/postprocess.h libswscale/swscale.h],,
   [AC_MSG_ERROR($missing_headers)])
 

--- a/configure.in
+++ b/configure.in
@@ -1624,20 +1624,6 @@ if test "$use_external_ffmpeg" = "yes"; then
   # Check for libswresample or libavresample headers.
   AC_CHECK_HEADERS([libswresample/swresample.h libavresample/avresample.h])
 
-  # Check if AVFilterBufferRefVideoProps AVRational member is named
-  # 'pixel_aspect' or 'sample_aspect_ratio'.
-  AC_CHECK_MEMBER([AVFilterBufferRefVideoProps.sample_aspect_ratio],
-    [AC_DEFINE([HAVE_AVFILTERBUFFERREFVIDEOPROPS_SAMPLE_ASPECT_RATIO],
-    [1],
-    [Define to 1 if AVFilterBufferRefVideoProps has member sample_aspect_ratio.])],
-      [AC_CHECK_MEMBER([AVFilterBufferRefVideoProps.sample_aspect_ratio],
-      [AC_DEFINE([HAVE_AVFILTERBUFFERREFVIDEOPROPS_SAMPLE_ASPECT_RATIO],
-      [1],
-      [Define to 1 if AVFilterBufferRefVideoProps has member sample_aspect_ratio.])],
-      ,
-      [[#include <ffmpeg/avfilter.h>]])],
-    [[#include <libavfilter/avfilter.h>]])
-
   AC_MSG_NOTICE($external_ffmpeg_enabled)
   USE_EXTERNAL_FFMPEG=1
   AC_DEFINE([USE_EXTERNAL_FFMPEG], [1], [Whether to use external FFmpeg libraries.])

--- a/configure.in
+++ b/configure.in
@@ -1626,9 +1626,6 @@ if test "$use_external_ffmpeg" = "yes"; then
   # optional
   AC_CHECK_HEADERS([libavutil/mem.h libavutil/samplefmt.h])
 
-  # old FFmpeg have this in libavcodec/opt.h instead:
-  AC_CHECK_HEADERS([libavutil/opt.h])
-
   # new FFmpeg have math headers
   AC_CHECK_HEADERS([libavutil/mathematics.h],,)
 

--- a/configure.in
+++ b/configure.in
@@ -1623,9 +1623,6 @@ if test "$use_external_ffmpeg" = "yes"; then
   [AC_CHECK_HEADERS([ffmpeg/avcodec.h ffmpeg/avfilter.h ffmpeg/avformat.h ffmpeg/avutil.h postproc/postprocess.h ffmpeg/swscale.h],,
   [AC_MSG_ERROR($missing_headers)])])
 
-  # optional
-  AC_CHECK_HEADERS([libavutil/samplefmt.h])
-
   # Check for libswresample or libavresample headers.
   AC_CHECK_HEADERS([libswresample/swresample.h libavresample/avresample.h])
 

--- a/configure.in
+++ b/configure.in
@@ -1620,8 +1620,7 @@ if test "$use_external_ffmpeg" = "yes"; then
 
   # Possible places the ffmpeg headers may be
   AC_CHECK_HEADERS([libavcodec/avcodec.h libavfilter/avfilter.h libavformat/avformat.h libavutil/avutil.h libpostproc/postprocess.h libswscale/swscale.h],,
-  [AC_CHECK_HEADERS([ffmpeg/avcodec.h ffmpeg/avfilter.h ffmpeg/avformat.h ffmpeg/avutil.h postproc/postprocess.h ffmpeg/swscale.h],,
-  [AC_MSG_ERROR($missing_headers)])])
+  [AC_MSG_ERROR($missing_headers)])
 
   # Check for libswresample or libavresample headers.
   AC_CHECK_HEADERS([libswresample/swresample.h libavresample/avresample.h])

--- a/configure.in
+++ b/configure.in
@@ -1626,9 +1626,6 @@ if test "$use_external_ffmpeg" = "yes"; then
   # optional
   AC_CHECK_HEADERS([libavutil/mem.h libavutil/samplefmt.h])
 
-  # new FFmpeg have math headers
-  AC_CHECK_HEADERS([libavutil/mathematics.h],,)
-
   # Check for libswresample or libavresample headers.
   AC_CHECK_HEADERS([libswresample/swresample.h libavresample/avresample.h])
 

--- a/configure.in
+++ b/configure.in
@@ -1614,13 +1614,6 @@ if test "$use_external_ffmpeg" = "yes"; then
                     [INCLUDES="$INCLUDES $FFMPEG_CFLAGS"; LIBS="$LIBS $FFMPEG_LIBS"],
                     AC_MSG_ERROR($missing_library))
 
-  # Determine whether AVPacket and relevant functions are defined in libavformat
-  # or libavcodec
-  AC_CHECK_LIB([avcodec], [av_free_packet],
-  [AC_MSG_NOTICE(== AVPacket and relevant functions defined in libavcodec. ==)],
-  [AC_MSG_NOTICE(== AVPacket and relevant functions defined in libavformat. ==)
-   AC_DEFINE([AVPACKET_IN_AVFORMAT], [1], [Whether AVPacket is in libavformat.])])
-
   # in case the headers are in a custom directory
   SAVE_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $FFMPEG_CFLAGS"

--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -45,12 +45,8 @@ extern "C" {
 #if (defined USE_EXTERNAL_FFMPEG)
   #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
     #include <libavcodec/avcodec.h>
-    #if (defined HAVE_LIBAVCODEC_OPT_H)
-      #include <libavcodec/opt.h>
-    #endif
   #elif (defined HAVE_FFMPEG_AVCODEC_H)
     #include <ffmpeg/avcodec.h>
-    #include <ffmpeg/opt.h>
   #endif
 #else
   #include "libavcodec/avcodec.h"

--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -43,11 +43,7 @@ extern "C" {
 #endif
 
 #if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
-    #include <libavcodec/avcodec.h>
-  #elif (defined HAVE_FFMPEG_AVCODEC_H)
-    #include <ffmpeg/avcodec.h>
-  #endif
+  #include <libavcodec/avcodec.h>
 #else
   #include "libavcodec/avcodec.h"
 #endif

--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -277,7 +277,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
 
   /* dependencies of libavcodec */
   DllAvUtil m_dllAvUtil;
-  // DllAvUtil loaded implicitely by m_dllAvCore
 
 public:
     static CCriticalSection m_critSection;

--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -48,15 +48,9 @@ extern "C" {
     #if (defined HAVE_LIBAVCODEC_OPT_H)
       #include <libavcodec/opt.h>
     #endif
-    #if (defined AVPACKET_IN_AVFORMAT)
-      #include <libavformat/avformat.h>
-    #endif
   #elif (defined HAVE_FFMPEG_AVCODEC_H)
     #include <ffmpeg/avcodec.h>
     #include <ffmpeg/opt.h>
-    #if (defined AVPACKET_IN_AVFORMAT)
-      #include <ffmpeg/avformat.h>
-    #endif
   #endif
 #else
   #include "libavcodec/avcodec.h"

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -42,15 +42,9 @@ extern "C" {
 #endif
 
 #if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVFILTER_AVFILTER_H)
-    #include <libavfilter/avfiltergraph.h>
-    #include <libavfilter/buffersink.h>
-    #include <libavfilter/avcodec.h>
-  #elif (defined HAVE_FFMPEG_AVFILTER_H)
-    #include <ffmpeg/avfiltergraph.h>
-    #include <ffmpeg/buffersink.h>
-    #include <ffmpeg/avcodec.h>
-  #endif
+  #include <libavfilter/avfiltergraph.h>
+  #include <libavfilter/buffersink.h>
+  #include <libavfilter/avcodec.h>
 #else
   #include "libavfilter/avfiltergraph.h"
   #include "libavfilter/buffersink.h"

--- a/lib/DllAvFormat.h
+++ b/lib/DllAvFormat.h
@@ -37,11 +37,7 @@ extern "C" {
 #pragma warning(disable:4244)
 #endif
 #if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVFORMAT_AVFORMAT_H)
-    #include <libavformat/avformat.h>
-  #else
-    #include <ffmpeg/avformat.h>
-  #endif
+  #include <libavformat/avformat.h>
   /* xbmc_read_frame_flush() is defined for us in lib/xbmc-dll-symbols/DllAvFormat.c */
   void xbmc_read_frame_flush(AVFormatContext *s);
 #else

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -61,9 +61,7 @@ extern "C" {
   #else
     #include <ffmpeg/mem.h>
   #endif
-  #if (defined HAVE_LIBAVUTIL_MATHEMATICS_H)
-    #include <libavutil/mathematics.h>
-  #endif
+  #include <libavutil/mathematics.h>
 #else
   #include "libavutil/avutil.h"
   //for av_get_default_channel_layout

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -56,11 +56,7 @@ extern "C" {
     #include <ffmpeg/avcodec.h>
   #endif
   #include <libavutil/opt.h>
-  #if defined(HAVE_LIBAVUTIL_MEM_H)
-    #include <libavutil/mem.h>
-  #else
-    #include <ffmpeg/mem.h>
-  #endif
+  #include <libavutil/mem.h>
   #include <libavutil/mathematics.h>
 #else
   #include "libavutil/avutil.h"

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -40,8 +40,6 @@ extern "C" {
     #include <libavutil/audioconvert.h>
     #include <libavutil/crc.h>
     #include <libavutil/fifo.h>
-    // for enum AVSampleFormat
-    #include <libavutil/samplefmt.h>
     // for LIBAVCODEC_VERSION_INT:
     #include <libavcodec/avcodec.h>
   #elif (defined HAVE_FFMPEG_AVUTIL_H)
@@ -50,11 +48,11 @@ extern "C" {
     #include <ffmpeg/audioconvert.h>
     #include <ffmpeg/crc.h>
     #include <ffmpeg/fifo.h>
-    // for enum AVSampleFormat
-    #include <ffmpeg/samplefmt.h>
     // for LIBAVCODEC_VERSION_INT:
     #include <ffmpeg/avcodec.h>
   #endif
+  // for enum AVSampleFormat
+  #include <libavutil/samplefmt.h>
   #include <libavutil/opt.h>
   #include <libavutil/mem.h>
   #include <libavutil/mathematics.h>

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -55,13 +55,7 @@ extern "C" {
     // for LIBAVCODEC_VERSION_INT:
     #include <ffmpeg/avcodec.h>
   #endif
-  #if defined(HAVE_LIBAVUTIL_OPT_H)
-    #include <libavutil/opt.h>
-  #elif defined(HAVE_LIBAVCODEC_AVCODEC_H)
-    #include <libavcodec/opt.h>
-  #else
-    #include <ffmpeg/opt.h>
-  #endif
+  #include <libavutil/opt.h>
   #if defined(HAVE_LIBAVUTIL_MEM_H)
     #include <libavutil/mem.h>
   #else

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -34,23 +34,13 @@
 
 extern "C" {
 #if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVUTIL_AVUTIL_H)
-    #include <libavutil/avutil.h>
-    // for av_get_default_channel_layout
-    #include <libavutil/audioconvert.h>
-    #include <libavutil/crc.h>
-    #include <libavutil/fifo.h>
-    // for LIBAVCODEC_VERSION_INT:
-    #include <libavcodec/avcodec.h>
-  #elif (defined HAVE_FFMPEG_AVUTIL_H)
-    #include <ffmpeg/avutil.h>
-    // for av_get_default_channel_layout
-    #include <ffmpeg/audioconvert.h>
-    #include <ffmpeg/crc.h>
-    #include <ffmpeg/fifo.h>
-    // for LIBAVCODEC_VERSION_INT:
-    #include <ffmpeg/avcodec.h>
-  #endif
+  #include <libavutil/avutil.h>
+  // for av_get_default_channel_layout
+  #include <libavutil/audioconvert.h>
+  #include <libavutil/crc.h>
+  #include <libavutil/fifo.h>
+  // for LIBAVCODEC_VERSION_INT:
+  #include <libavcodec/avcodec.h>
   // for enum AVSampleFormat
   #include <libavutil/samplefmt.h>
   #include <libavutil/opt.h>

--- a/lib/DllPostProc.h
+++ b/lib/DllPostProc.h
@@ -39,16 +39,8 @@ extern "C" {
 #endif
   
 #if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVUTIL_AVUTIL_H)
-    #include <libavutil/avutil.h>
-  #elif (defined HAVE_FFMPEG_AVUTIL_H)
-    #include <ffmpeg/avutil.h>
-  #endif
-  #if (defined HAVE_LIBPOSTPROC_POSTPROCESS_H)
-    #include <libpostproc/postprocess.h>
-  #elif (defined HAVE_POSTPROC_POSTPROCESS_H)
-    #include <postproc/postprocess.h>
-  #endif
+  #include <libavutil/avutil.h>
+  #include <libpostproc/postprocess.h>
 #else
   #include "libavutil/avutil.h"
   #include "libpostproc/postprocess.h"

--- a/lib/DllSwScale.h
+++ b/lib/DllSwScale.h
@@ -45,11 +45,7 @@ extern "C" {
 #endif
 
 #if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBSWSCALE_SWSCALE_H)
-    #include <libswscale/swscale.h>
-  #elif (defined HAVE_FFMPEG_SWSCALE_H)
-    #include <ffmpeg/swscale.h>
-  #endif
+  #include <libswscale/swscale.h>
 #else
   #include "libswscale/swscale.h"
 #endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -559,7 +559,11 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(DVDVideoPicture* pDvdVideoPicture)
   /* use variable in the frame */
   AVRational pixel_aspect = m_pCodecContext->sample_aspect_ratio;
   if (m_pBufferRef)
+#if defined(LIBAVFILTER_FROM_FFMPEG)
     pixel_aspect = m_pBufferRef->video->sample_aspect_ratio;
+#else
+    pixel_aspect = m_pBufferRef->video->pixel_aspect;
+#endif
 
   if (pixel_aspect.num == 0)
     aspect_ratio = 0;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -952,8 +952,7 @@ void CVDPAU::ReadFormatOf( AVCodecID codec
       vdp_decoder_profile = VDP_DECODER_PROFILE_VC1_ADVANCED;
       vdp_chroma_type     = VDP_CHROMA_TYPE_420;
       break;
-#if (defined PIX_FMT_VDPAU_MPEG4_IN_AVUTIL) && \
-    (defined VDP_DECODER_PROFILE_MPEG4_PART2_ASP)
+#if (defined VDP_DECODER_PROFILE_MPEG4_PART2_ASP)
     case AV_CODEC_ID_MPEG4:
       vdp_decoder_profile = VDP_DECODER_PROFILE_MPEG4_PART2_ASP;
       vdp_chroma_type     = VDP_CHROMA_TYPE_420;


### PR DESCRIPTION
This series of commits cleans up legacy ffmpeg support that is useless (xbmc wont build against such old versions) and simplifies the code.
