### PR TITLE
settings: cleanup of the XML definition syntax

### DIFF
--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -37,11 +37,9 @@
         <setting id="input.appleremotealwayson" type="boolean" label="13602" help="">
           <level>4</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="input.appleremotemode" operator="!is">0</dependency> <!-- APPLE_REMOTE_DISABLED -->
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="input.appleremotemode" operator="!is">0</dependency> <!-- APPLE_REMOTE_DISABLED -->
+          </dependencies>
         </setting>
         <setting id="input.appleremotesequencetime" type="integer" label="13603" help="">
           <level>1</level>
@@ -51,11 +49,11 @@
             <step>50</step>
             <maximum>1000</maximum>
             <formatlabel>14046</formatlabel>
-            <dependencies>
-              <dependency type="enable" id="input.appleremotemode">2</dependency> <!-- APPLE_REMOTE_UNIVERSAL -->
-            </dependencies>
           </constraints>
-          <control type="spinner" format="string"/>
+          <dependencies>
+            <dependency type="enable" id="input.appleremotemode">2</dependency> <!-- APPLE_REMOTE_UNIVERSAL -->
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
     </category>

--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -48,12 +48,13 @@
             <minimum label="351">50</minimum>
             <step>50</step>
             <maximum>1000</maximum>
-            <formatlabel>14046</formatlabel>
           </constraints>
           <dependencies>
             <dependency type="enable" id="input.appleremotemode">2</dependency> <!-- APPLE_REMOTE_UNIVERSAL -->
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14046</formatlabel>
+          </control>
         </setting>
       </group>
     </category>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -6,7 +6,9 @@
         <setting id="lookandfeel.skin" type="addon" label="166" help="">
           <level>0</level>
           <default>skin.confluence</default>
-          <addontype>xbmc.gui.skin</addontype>
+          <constraints>
+            <addontype>xbmc.gui.skin</addontype>
+          </constraints>
         </setting>
         <setting id="lookandfeel.skinsettings" type="action" label="21417" help="">
           <level>0</level>
@@ -206,8 +208,8 @@
         <setting id="screensaver.mode" type="addon" label="356" help="">
           <level>0</level>
           <default>screensaver.xbmc.builtin.dim</default>
-          <addontype>xbmc.ui.screensaver</addontype>
           <constraints>
+            <addontype>xbmc.ui.screensaver</addontype>
             <allowempty>true</allowempty>
           </constraints>
           <updates>
@@ -718,17 +720,23 @@
         <setting id="scrapers.moviesdefault" type="addon" label="21413" help="">
           <level>4</level>
           <default>metadata.themoviedb.org</default>
-          <addontype>xbmc.metadata.scraper.movies</addontype>
+          <constraints>
+            <addontype>xbmc.metadata.scraper.movies</addontype>
+          </constraints>
         </setting>
         <setting id="scrapers.tvshowsdefault" type="addon" label="21414" help="">
           <level>4</level>
           <default>metadata.tvdb.com</default>
-          <addontype>xbmc.metadata.scraper.tvshows</addontype>
+          <constraints>
+            <addontype>xbmc.metadata.scraper.tvshows</addontype>
+          </constraints>
         </setting>
         <setting id="scrapers.musicvideosdefault" type="addon" label="21415" help="">
           <level>4</level>
           <default>metadata.musicvideos.theaudiodb.com</default>
-          <addontype>xbmc.metadata.scraper.musicvideos</addontype>
+          <constraints>
+            <addontype>xbmc.metadata.scraper.musicvideos</addontype>
+          </constraints>
           <updates>
             <update type="change" />
           </updates>
@@ -1111,12 +1119,16 @@
         <setting id="musiclibrary.albumsscraper" type="addon" label="20193" help="">
           <level>1</level>
           <default>metadata.album.universal</default>
-          <addontype>xbmc.metadata.scraper.albums</addontype>
+          <constraints>
+            <addontype>xbmc.metadata.scraper.albums</addontype>
+          </constraints>
         </setting>
         <setting id="musiclibrary.artistsscraper" type="addon" label="20194" help="">
           <level>1</level>
           <default>metadata.artists.universal</default>
-          <addontype>xbmc.metadata.scraper.artists</addontype>
+          <constraints>
+            <addontype>xbmc.metadata.scraper.artists</addontype>
+          </constraints>
         </setting>
         <setting id="musiclibrary.updateonstartup" type="boolean" label="22000" help="">
           <level>1</level>
@@ -1218,8 +1230,8 @@
         <setting id="musicplayer.visualisation" type="addon" label="250" help="">
           <level>0</level>
           <default>visualization.glspectrum</default>
-          <addontype>xbmc.player.musicviz</addontype>
           <constraints>
+            <addontype>xbmc.player.musicviz</addontype>
             <allowempty>true</allowempty>
           </constraints>
         </setting>
@@ -1553,8 +1565,8 @@
         <setting id="weather.addon" type="addon" label="24029" help="">
           <level>0</level>
           <default>weather.wunderground</default>
-          <addontype>xbmc.python.weather</addontype>
           <constraints>
+            <addontype>xbmc.python.weather</addontype>
             <allowempty>true</allowempty>
           </constraints>
         </setting>
@@ -1642,7 +1654,9 @@
         <setting id="services.webskin" type="addon" label="199" help="">
           <level>1</level>
           <default>webinterface.default</default>
-          <addontype>xbmc.gui.webinterface</addontype>
+          <constraints>
+            <addontype>xbmc.gui.webinterface</addontype>
+          </constraints>
         </setting>
       </group>
     </category>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -10,11 +10,10 @@
         </setting>
         <setting id="lookandfeel.skinsettings" type="action" label="21417" help="">
           <level>0</level>
-          <control type="button" format="action">
-            <dependencies>
-              <dependency type="enable" on="property" name="AddonHasSettings" setting="lookandfeel.skin" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="AddonHasSettings" setting="lookandfeel.skin" />
+          </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="lookandfeel.skintheme" type="string" label="15111" help="">
           <level>1</level>
@@ -77,11 +76,10 @@
           <level>1</level>
           <default></default>
           <allowempty>true</allowempty>
-          <control type="button" format="action">
-            <dependencies>
-              <dependency type="enable" setting="lookandfeel.enablerssfeeds">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="lookandfeel.enablerssfeeds">true</dependency>
+          </dependencies>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -101,11 +99,10 @@
           <constraints>
             <options>regions</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="update" setting="locale.language" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="update" setting="locale.language" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="locale.charset" type="string" label="14091" help="">
           <level>1</level>
@@ -113,11 +110,10 @@
           <constraints>
             <options>charsets</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="update" setting="locale.language" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="update" setting="locale.language" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
       <group id="2">
@@ -135,11 +131,10 @@
           <constraints>
             <options>timezones</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="update" setting="locale.timezonecountry" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="update" setting="locale.timezonecountry" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
       <group id="4">
@@ -178,30 +173,26 @@
         <setting id="filelists.allowfiledeletion" type="boolean" label="14071" help="">
           <level>1</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <or>
-                  <condition on="property" operator="!is" name="ProfileHasFilesLocked" />
-                  <condition on="property" name="IsMasterUser" />
-                </or>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition on="property" operator="!is" name="ProfileHasFilesLocked" />
+                <condition on="property" name="IsMasterUser" />
+              </or>
+            </dependency>
+          </dependencies>
         </setting>
         <setting id="filelists.showaddsourcebuttons" type="boolean" label="21382" help="">
           <level>1</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <or>
-                  <condition on="property" name="ProfileCanWriteSources" />
-                  <condition on="property" name="IsMasterUser" />
-                </or>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition on="property" name="ProfileCanWriteSources" />
+                <condition on="property" name="IsMasterUser" />
+              </or>
+            </dependency>
+          </dependencies>
         </setting>
         <setting id="filelists.showhidden" type="boolean" label="21330" help="">
           <level>1</level>
@@ -222,24 +213,20 @@
         </setting>
         <setting id="screensaver.settings" type="action" label="21417" help="">
           <level>0</level>
-          <control type="button" format="action">
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition on="setting" setting="screensaver.mode" operator="!is"></condition>
-                  <condition on="property" name="AddonHasSettings" setting="screensaver.mode" />
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition on="setting" setting="screensaver.mode" operator="!is"></condition>
+                <condition on="property" name="AddonHasSettings" setting="screensaver.mode" />
+              </and>
+            </dependency>
+          </dependencies>
         </setting>
         <setting id="screensaver.preview" type="action" label="1000" help="">
           <level>0</level>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
+          </dependencies>
         </setting>
         <setting id="screensaver.time" type="integer" label="355" help="">
           <level>0</level>
@@ -250,36 +237,31 @@
             <maximum>60</maximum>
             <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
       <group id="2">
         <setting id="screensaver.usemusicvisinstead" type="boolean" label="13392" help="">
           <level>1</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
+          </dependencies>
         </setting>
         <setting id="screensaver.usedimonpause" type="boolean" label="22014" help="">
           <level>1</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition setting="screensaver.mode" operator="!is">screensaver.xbmc.builtin.dim</condition>
-                  <condition setting="screensaver.mode" operator="!is"></condition>
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="screensaver.mode" operator="!is">screensaver.xbmc.builtin.dim</condition>
+                <condition setting="screensaver.mode" operator="!is"></condition>
+              </and>
+            </dependency>
+          </dependencies>
         </setting>
       </group>
     </category>
@@ -438,11 +420,10 @@
           <constraints>
             <options>refreshchangedelays</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="videoplayer.adjustrefreshrate" operator="!is">0</dependency> <!-- ADJUST_REFRESHRATE_OFF -->
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.adjustrefreshrate" operator="!is">0</dependency> <!-- ADJUST_REFRESHRATE_OFF -->
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="videoplayer.usedisplayasclock" type="boolean" label="13510" help="">
           <level>2</level>
@@ -458,11 +439,10 @@
               <option label="13503">2</option> <!-- SYNC_RESAMPLE -->
             </options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="videoplayer.usedisplayasclock" operator="is">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.usedisplayasclock" operator="is">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="videoplayer.maxspeedadjust" type="number" label="13504" help="">
           <level>4</level>
@@ -472,16 +452,15 @@
             <step>0.1</step>
             <maximum>10.0</maximum>
           </constraints>
-          <control type="spinner" format="number">
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition setting="videoplayer.usedisplayasclock" operator="is">true</condition>
-                  <condition setting="videoplayer.synctype" operator="is">2</condition> <!-- SYNC_RESAMPLE -->
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="videoplayer.usedisplayasclock" operator="is">true</condition>
+                <condition setting="videoplayer.synctype" operator="is">2</condition> <!-- SYNC_RESAMPLE -->
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="number" />
         </setting>
         <setting id="videoplayer.resamplequality" type="integer" label="13505" help="">
           <level>4</level>
@@ -494,16 +473,15 @@
               <option label="13509">3</option> <!-- RESAMPLE_REALLYHIGH -->
             </options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition setting="videoplayer.usedisplayasclock" operator="is">true</condition>
-                  <condition setting="videoplayer.synctype" operator="is">2</condition> <!-- SYNC_RESAMPLE -->
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="videoplayer.usedisplayasclock" operator="is">true</condition>
+                <condition setting="videoplayer.synctype" operator="is">2</condition> <!-- SYNC_RESAMPLE -->
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="videoplayer.errorinaspect" type="integer" label="22021" help="">
           <level>2</level>
@@ -622,11 +600,10 @@
             <step>2</step>
             <maximum>74</maximum>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="update" setting="subtitles.font" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="update" setting="subtitles.font" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="subtitles.style" type="integer" label="736" help="">
           <level>1</level>
@@ -639,11 +616,10 @@
               <option label="741">3</option> <!-- FONT_STYLE_BOLD | FONT_STYLE_ITALICS -->
             </options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="subtitles.color" type="integer" label="737" help="">
           <level>1</level>
@@ -660,11 +636,10 @@
               <option label="767">7</option> <!-- Grey -->
             </options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="subtitles.charset" type="string" label="735" help="">
           <level>1</level>
@@ -672,11 +647,10 @@
           <constraints>
             <options>charsets</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="subtitles.overrideassfonts" type="boolean" label="21368" help="">
           <level>1</level>
@@ -784,19 +758,15 @@
       <group id="3">
         <setting id="pvrmanager.channelmanager" type="action" label="19199" help="">
           <level>1</level>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
+          </dependencies>
         </setting>
         <setting id="pvrmanager.channelscan" type="action" label="19117" help="">
           <level>1</level>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
+          </dependencies>
         </setting>
         <setting id="pvrmanager.resetdb" type="action" label="19185" help="">
           <level>2</level>
@@ -848,11 +818,9 @@
         </setting>
         <setting id="pvrmenu.searchicons" type="action" label="19167" help="">
           <level>1</level>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
+          </dependencies>
         </setting>
       </group>
     </category>
@@ -1087,11 +1055,10 @@
           <level>1</level>
           <default></default>
           <allowempty>true</allowempty>
-          <control type="edit" format="integer" attributes="hidden,new" delayed="false">
-            <dependencies>
-              <dependency type="enable" setting="pvrparental.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="pvrparental.enabled">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" attributes="hidden,new" delayed="false" />
         </setting>
         <setting id="pvrparental.duration" type="integer" label="19260" help="">
           <level>1</level>
@@ -1102,11 +1069,10 @@
             <maximum>1200</maximum>
             <formatlabel>14045</formatlabel>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="pvrparental.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="pvrparental.enabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
     </category>
@@ -1232,15 +1198,13 @@
         <setting id="musicplayer.crossfadealbumtracks" type="boolean" label="13400" help="">
           <level>1</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition setting="musicplayer.crossfade" operator="!is">0</condition>
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="musicplayer.crossfade" operator="!is">0</condition>
+              </and>
+            </dependency>
+          </dependencies>
         </setting>
       </group>
       <group id="4">
@@ -1352,16 +1316,15 @@
               <option label="603">3</option> <!-- CDDARIP_QUALITY_EXTREME -->
             </options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition setting="audiocds.encoder" operator="!is">2</condition> <!-- CDDARIP_ENCODER_WAV -->
-                  <condition setting="audiocds.encoder" operator="!is">3</condition> <!-- CDDARIP_ENCODER_FLAC -->
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="audiocds.encoder" operator="!is">2</condition> <!-- CDDARIP_ENCODER_WAV -->
+                <condition setting="audiocds.encoder" operator="!is">3</condition> <!-- CDDARIP_ENCODER_FLAC -->
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="audiocds.bitrate" type="integer" label="623" help="">
           <level>2</level>
@@ -1372,17 +1335,16 @@
             <maximum>320</maximum>
             <formatlabel>14048</formatlabel>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition setting="audiocds.encoder" operator="!is">2</condition> <!-- CDDARIP_ENCODER_WAV -->
-                  <condition setting="audiocds.encoder" operator="!is">3</condition> <!-- CDDARIP_ENCODER_FLAC -->
-                  <condition setting="audiocds.quality" operator="is">0</condition> <!-- CDDARIP_QUALITY_CBR -->
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="audiocds.encoder" operator="!is">2</condition> <!-- CDDARIP_ENCODER_WAV -->
+                <condition setting="audiocds.encoder" operator="!is">3</condition> <!-- CDDARIP_ENCODER_FLAC -->
+                <condition setting="audiocds.quality" operator="is">0</condition> <!-- CDDARIP_QUALITY_CBR -->
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="audiocds.compressionlevel" type="integer" label="665" help="">
           <level>2</level>
@@ -1392,11 +1354,10 @@
             <step>1</step>
             <maximum>8</maximum>
           </constraints>
-          <control type="spinner" format="integer">
-            <dependencies>
-              <dependency type="enable" setting="audiocds.encoder">3</dependency> <!-- CDDARIP_ENCODER_FLAC -->
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="audiocds.encoder">3</dependency> <!-- CDDARIP_ENCODER_FLAC -->
+          </dependencies>
+          <control type="spinner" format="integer" />
         </setting>
         <setting id="audiocds.ejectonrip" type="boolean" label="14099" help="">
           <level>1</level>
@@ -1414,11 +1375,9 @@
         <setting id="karaoke.autopopupselector" type="boolean" label="22037" help="">
           <level>2</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="karaoke.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="karaoke.enabled">true</dependency>
+          </dependencies>
         </setting>
       </group>
       <group id="2">
@@ -1428,11 +1387,10 @@
           <constraints>
             <options>fonts</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="karaoke.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="karaoke.enabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="karaoke.fontheight" type="integer" label="22031" help="">
           <level>2</level>
@@ -1442,12 +1400,11 @@
             <step>2</step>
             <maximum>74</maximum>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="karaoke.enabled">true</dependency>
-              <dependency type="update" setting="karaoke.font" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="karaoke.enabled">true</dependency>
+            <dependency type="update" setting="karaoke.font" />
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="karaoke.fontcolors" type="integer" label="22032" help="">
           <level>2</level>
@@ -1460,11 +1417,10 @@
               <option label="22043">3</option> <!-- black/white -->
             </options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="karaoke.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="karaoke.enabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="karaoke.charset" type="string" label="22033" help="">
           <level>2</level>
@@ -1472,29 +1428,24 @@
           <constraints>
             <options>charsets</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="karaoke.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="karaoke.enabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
       <group id="3">
         <setting id="karaoke.export" type="action" label="22038" help="">
           <level>2</level>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="karaoke.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="karaoke.enabled">true</dependency>
+          </dependencies>
         </setting>
         <setting id="karaoke.importcsv" type="action" label="22036" help="">
           <level>2</level>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="karaoke.enabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="karaoke.enabled">true</dependency>
+          </dependencies>
         </setting>
       </group>
     </category>
@@ -1586,11 +1537,10 @@
         </setting>
         <setting id="weather.addonsettings" type="action" label="21417" help="">
           <level>0</level>
-          <control type="button" format="action">
-            <dependencies>
-              <dependency type="enable" on="property" name="AddonHasSettings" setting="weather.addon" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="AddonHasSettings" setting="weather.addon" />
+          </dependencies>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -1614,11 +1564,9 @@
         <setting id="services.upnpannounce" type="boolean" label="20188" help="">
           <level>2</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="services.upnpserver">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.upnpserver">true</dependency>
+          </dependencies>
         </setting>
         <setting id="services.upnprenderer" type="boolean" label="21881" help="">
           <level>1</level>
@@ -1651,21 +1599,19 @@
           <level>2</level>
           <default>xbmc</default>
           <allowempty>true</allowempty>
-          <control type="edit" format="string">
-            <dependencies>
-              <dependency type="enable" setting="services.webserver">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.webserver">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
         </setting>
         <setting id="services.webserverpassword" type="string" label="733" help="">
           <level>2</level>
           <default></default>
           <allowempty>true</allowempty>
-          <control type="edit" format="string" attributes="hidden">
-            <dependencies>
-              <dependency type="enable" setting="services.webserver">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.webserver">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" attributes="hidden" />
         </setting>
         <setting id="services.webskin" type="addon" label="199" help="">
           <level>1</level>
@@ -1695,11 +1641,10 @@
             <step>1</step>
             <maximum>65535</maximum>
           </constraints>
-          <control type="edit" format="integer">
-            <dependencies>
-              <dependency type="enable" setting="services.esenabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
         </setting>
         <setting id="services.esportrange" type="integer" label="793" help="">
           <visible>HAS_EVENT_SERVER</visible>
@@ -1710,11 +1655,10 @@
             <step>1</step>
             <maximum>100</maximum>
           </constraints>
-          <control type="spinner" format="integer">
-            <dependencies>
-              <dependency type="enable" setting="services.esenabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
         </setting>
         <setting id="services.esmaxclients" type="integer" label="797" help="">
           <visible>HAS_EVENT_SERVER</visible>
@@ -1725,20 +1669,17 @@
             <step>1</step>
             <maximum>100</maximum>
           </constraints>
-          <control type="spinner" format="integer">
-            <dependencies>
-              <dependency type="enable" setting="services.esenabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
         </setting>
         <setting id="services.esallinterfaces" type="boolean" label="794" help="">
           <level>1</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="services.esenabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
         </setting>
         <setting id="services.esinitialdelay" type="integer" label="795" help="">
           <visible>HAS_EVENT_SERVER</visible>
@@ -1749,11 +1690,10 @@
             <step>5</step>
             <maximum>10000</maximum>
           </constraints>
-          <control type="spinner" format="integer">
-            <dependencies>
-              <dependency type="enable" setting="services.esenabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
         </setting>
         <setting id="services.escontinuousdelay" type="integer" label="796" help="">
           <visible>HAS_EVENT_SERVER</visible>
@@ -1764,11 +1704,10 @@
             <step>5</step>
             <maximum>10000</maximum>
           </constraints>
-          <control type="spinner" format="integer">
-            <dependencies>
-              <dependency type="enable" setting="services.esenabled">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
         </setting>
       </group>
     </category>
@@ -1791,21 +1730,18 @@
         <setting id="services.useairplaypassword" type="boolean" label="1272" help="">
           <level>1</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="services.airplay">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.airplay">true</dependency>
+          </dependencies>
         </setting>
         <setting id="services.airplaypassword" type="string" label="733" help="">
           <level>1</level>
           <default></default>
           <allowempty>true</allowempty>
-          <control type="edit" format="string" attributes="hidden">
-            <dependencies>
-              <dependency type="enable" setting="services.useairplaypassword">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="services.useairplaypassword">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" attributes="hidden" />
         </setting>
       </group>
     </category>
@@ -1841,12 +1777,11 @@
           <constraints>
             <options>resolutions</options>
           </constraints>
-          <control type="spinner" format="string" delayed="true">
-            <dependencies>
-              <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
-              <dependency type="update" setting="videoscreen.screen" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
+            <dependency type="update" setting="videoscreen.screen" />
+          </dependencies>
+          <control type="spinner" format="string" delayed="true" />
         </setting>
         <setting id="videoscreen.screenmode" type="string" label="243" help="">
           <visible>IsStandAlone</visible>
@@ -1858,31 +1793,26 @@
           <updates>
             <update type="change" />
           </updates>
-          <control type="spinner" format="string" delayed="true">
-            <dependencies>
-              <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
-              <dependency type="update" setting="videoscreen.screen" />
-              <dependency type="update" setting="videoscreen.resolution" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
+            <dependency type="update" setting="videoscreen.screen" />
+            <dependency type="update" setting="videoscreen.resolution" />
+          </dependencies>
+          <control type="spinner" format="string" delayed="true" />
         </setting>
         <setting id="videoscreen.fakefullscreen" type="boolean" label="14083" help="">
           <level>2</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
+          </dependencies>
         </setting>
         <setting id="videoscreen.blankdisplays" type="boolean" label="13130" help="">
           <level>1</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" on="property" name="IsFullscreen" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsFullscreen" />
+          </dependencies>
         </setting>
       </group>
       <group id="2">
@@ -1959,76 +1889,64 @@
         <setting id="audiooutput.ac3passthrough" type="boolean" label="364" help="">
           <level>2</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <or>
-                  <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
-                  <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
-                </or>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
+                <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
+              </or>
+            </dependency>
+          </dependencies>
         </setting>
         <setting id="audiooutput.dtspassthrough" type="boolean" label="254" help="">
           <level>2</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <or>
-                  <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
-                  <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
-                </or>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
+                <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
+              </or>
+            </dependency>
+          </dependencies>
         </setting>
         <setting id="audiooutput.passthroughaac" type="boolean" label="299" help="">
           <level>2</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <or>
-                  <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
-                  <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
-                </or>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
+                <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
+              </or>
+            </dependency>
+          </dependencies>
         </setting>
         <setting id="audiooutput.multichannellpcm" type="boolean" label="348" help="">
           <level>2</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="audiooutput.mode">2</dependency> <!-- AUDIO_HDMI -->
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="audiooutput.mode">2</dependency> <!-- AUDIO_HDMI -->
+          </dependencies>
         </setting>
         <setting id="audiooutput.truehdpassthrough" type="boolean" label="349" help="">
           <level>2</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" setting="audiooutput.mode">2</dependency> <!-- AUDIO_HDMI -->
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="audiooutput.mode">2</dependency> <!-- AUDIO_HDMI -->
+          </dependencies>
         </setting>
         <setting id="audiooutput.dtshdpassthrough" type="boolean" label="347" help="">
           <level>2</level>
           <default>true</default>
-          <control>
-            <dependencies>
-              <dependency type="enable">
-                <and>
-                  <condition setting="audiooutput.dtspassthrough">true</condition>
-                  <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
-                </and>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="audiooutput.dtspassthrough">true</condition>
+                <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
+              </and>
+            </dependency>
+          </dependencies>
         </setting>
       </group>
       <group id="2">
@@ -2046,16 +1964,15 @@
           <constraints>
             <options>audiodevicespassthrough</options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable">
-                <or>
-                  <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
-                  <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
-                </or>
-              </dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
+                <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
+              </or>
+            </dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
       </group>
       <group id="3">
@@ -2077,11 +1994,9 @@
       <group id="1">
         <setting id="input.peripherals" type="action" label="35000" help="">
           <level>1</level>
-          <control>
-            <dependencies>
-              <dependency type="enable" on="property" name="HasPeripherals" />
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="HasPeripherals" />
+          </dependencies>
         </setting>
       </group>
       <group id="2">
@@ -2118,21 +2033,19 @@
               <option label="1185">4</option> <!-- PROXY_SOCKS5_REMOTE -->
             </options>
           </constraints>
-          <control type="spinner" format="string">
-            <dependencies>
-              <dependency type="enable" setting="network.usehttpproxy">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="network.usehttpproxy">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="network.httpproxyserver" type="string" label="706" help="">
           <level>1</level>
           <default></default>
           <allowempty>true</allowempty>
-          <control type="edit" format="string">
-            <dependencies>
-              <dependency type="enable" setting="network.usehttpproxy">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="network.usehttpproxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
         </setting>
         <setting id="network.httpproxyport" type="integer" label="730" help="">
           <level>1</level>
@@ -2142,31 +2055,28 @@
             <step>1</step>
             <maximum>65535</maximum>
           </constraints>
-          <control type="edit" format="integer">
-            <dependencies>
-              <dependency type="enable" setting="network.usehttpproxy">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="network.usehttpproxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
         </setting>
         <setting id="network.httpproxyusername" type="string" label="1048" help="">
           <level>1</level>
           <default></default>
           <allowempty>true</allowempty>
-          <control type="edit" format="string">
-            <dependencies>
-              <dependency type="enable" setting="network.usehttpproxy">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="network.usehttpproxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
         </setting>
         <setting id="network.httpproxypassword" type="string" label="733" help="">
           <level>1</level>
           <default></default>
           <allowempty>true</allowempty>
-          <control type="edit" format="string" attributes="hidden">
-            <dependencies>
-              <dependency type="enable" setting="network.usehttpproxy">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="network.usehttpproxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" attributes="hidden" />
         </setting>
       </group>
       <group id="2">
@@ -2231,11 +2141,9 @@
         </setting>
         <setting id="debug.setextraloglevel" type="action" label="666" help="">
           <level>1</level>
-          <control type="button" format="action">
-            <dependencies>
-              <dependency type="enable" setting="debug.showloginfo">true</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" setting="debug.showloginfo">true</dependency>
+          </dependencies>
         </setting>
         <setting id="debug.screenshotpath" type="path" label="20004" help="">
           <level>1</level>
@@ -2257,11 +2165,9 @@
         <setting id="masterlock.startuplock" type="boolean" label="20076" help="">
           <level>2</level>
           <default>false</default>
-          <control>
-            <dependencies>
-              <dependency type="enable" on="property" name="ProfileLockMode" operator="!is">0</dependency>
-            </dependencies>
-          </control>
+          <dependencies>
+            <dependency type="enable" on="property" name="ProfileLockMode" operator="!is">0</dependency>
+          </dependencies>
         </setting>
         <setting id="masterlock.maxretries" type="integer" label="12364" help="">
           <level>4</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -74,7 +74,9 @@
         <setting id="lookandfeel.rssedit" type="string" label="21450" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="lookandfeel.enablerssfeeds">true</dependency>
           </dependencies>
@@ -205,7 +207,9 @@
           <level>0</level>
           <default>screensaver.xbmc.builtin.dim</default>
           <addontype>xbmc.ui.screensaver</addontype>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <updates>
             <update type="change" />
           </updates>
@@ -660,9 +664,9 @@
         <setting id="subtitles.custompath" type="path" label="21366" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>657</heading>
           <constraints>
+            <allowempty>true</allowempty>
             <writable>false</writable>
             <sources>
               <source>videos</source>
@@ -808,9 +812,9 @@
         <setting id="pvrmenu.iconpath" type="path" label="19018" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>657</heading>
           <constraints>
+            <allowempty>true</allowempty>
             <writable>false</writable>
           </constraints>
           <control type="button" format="path" />
@@ -1014,7 +1018,9 @@
         <setting id="pvrpowermanagement.setwakeupcmd" type="string" label="19245" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <control type="edit" format="string" />
         </setting>
         <setting id="pvrpowermanagement.prewakeup" type="integer" label="19246" help="">
@@ -1053,7 +1059,9 @@
         <setting id="pvrparental.pin" type="string" label="19261" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="pvrparental.enabled">true</dependency>
           </dependencies>
@@ -1211,7 +1219,9 @@
           <level>0</level>
           <default>visualization.glspectrum</default>
           <addontype>xbmc.player.musicviz</addontype>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
         </setting>
       </group>
     </category>
@@ -1236,29 +1246,37 @@
         <setting id="musicfiles.nowplayingtrackformat" type="string" label="13307" help="">
           <level>4</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>16016</heading>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <control type="edit" format="string" />
         </setting>
         <setting id="musicfiles.nowplayingtrackformatright" type="string" label="13387" help="">
           <level>4</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>16016</heading>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <control type="edit" format="string" />
         </setting>
         <setting id="musicfiles.librarytrackformat" type="string" label="13307" help="">
           <level>4</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>16016</heading>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <control type="edit" format="string" />
         </setting>
         <setting id="musicfiles.librarytrackformatright" type="string" label="13387" help="">
           <level>4</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>16016</heading>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <control type="edit" format="string" />
         </setting>
         <setting id="musicfiles.findremotethumbs" type="boolean" label="14059" help="">
@@ -1286,8 +1304,10 @@
         <setting id="audiocds.recordingpath" type="path" label="20000" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>657</heading>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <control type="button" format="path" />
         </setting>
         <setting id="audiocds.trackpathformat" type="string" label="13307" help="">
@@ -1461,7 +1481,9 @@
         <setting id="mymusic.defaultlibview" type="string" label="0" help="">
           <level>4</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
         </setting>
       </group>
     </category>
@@ -1532,7 +1554,9 @@
           <level>0</level>
           <default>weather.wunderground</default>
           <addontype>xbmc.python.weather</addontype>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
         </setting>
         <setting id="weather.addonsettings" type="action" label="21417" help="">
           <level>0</level>
@@ -1596,7 +1620,9 @@
         <setting id="services.webserverusername" type="string" label="1048" help="">
           <level>2</level>
           <default>xbmc</default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="services.webserver">true</dependency>
           </dependencies>
@@ -1605,7 +1631,9 @@
         <setting id="services.webserverpassword" type="string" label="733" help="">
           <level>2</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="services.webserver">true</dependency>
           </dependencies>
@@ -1735,7 +1763,9 @@
         <setting id="services.airplaypassword" type="string" label="733" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="services.useairplaypassword">true</dependency>
           </dependencies>
@@ -2039,7 +2069,9 @@
         <setting id="network.httpproxyserver" type="string" label="706" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="network.usehttpproxy">true</dependency>
           </dependencies>
@@ -2061,7 +2093,9 @@
         <setting id="network.httpproxyusername" type="string" label="1048" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="network.usehttpproxy">true</dependency>
           </dependencies>
@@ -2070,7 +2104,9 @@
         <setting id="network.httpproxypassword" type="string" label="733" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <dependencies>
             <dependency type="enable" setting="network.usehttpproxy">true</dependency>
           </dependencies>
@@ -2146,8 +2182,10 @@
         <setting id="debug.screenshotpath" type="path" label="20004" help="">
           <level>1</level>
           <default></default>
-          <allowempty>true</allowempty>
           <heading>657</heading>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
           <control type="button" format="path" />
         </setting>
       </group>
@@ -2307,7 +2345,9 @@
         <setting id="system.playlistspath" type="path" label="20006" help="">
           <level>4</level>
           <default></default>
-          <allowempty>true</allowempty>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
         </setting>
       </group>
     </category>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -666,7 +666,6 @@
         <setting id="subtitles.custompath" type="path" label="21366" help="">
           <level>1</level>
           <default></default>
-          <heading>657</heading>
           <constraints>
             <allowempty>true</allowempty>
             <writable>false</writable>
@@ -674,7 +673,9 @@
               <source>videos</source>
             </sources>
           </constraints>
-          <control type="button" format="path" />
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
         </setting>
         <setting id="subtitles.align" type="integer" label="21460" help="">
           <level>1</level>
@@ -820,12 +821,13 @@
         <setting id="pvrmenu.iconpath" type="path" label="19018" help="">
           <level>1</level>
           <default></default>
-          <heading>657</heading>
           <constraints>
             <allowempty>true</allowempty>
             <writable>false</writable>
           </constraints>
-          <control type="button" format="path" />
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
         </setting>
         <setting id="pvrmenu.searchicons" type="action" label="19167" help="">
           <level>1</level>
@@ -1246,50 +1248,56 @@
         <setting id="musicfiles.trackformat" type="string" label="13307" help="">
           <level>2</level>
           <default>[%N. ]%A - %T</default>
-          <heading>16016</heading>
-          <control type="edit" format="string" />
+          <control type="edit" format="string">
+            <heading>16016</heading>
+          </control>
         </setting>
         <setting id="musicfiles.trackformatright" type="string" label="13387" help="">
           <level>2</level>
           <default>%D</default>
-          <heading>16016</heading>
-          <control type="edit" format="string" />
+          <control type="edit" format="string">
+            <heading>16016</heading>
+          </control>
         </setting>
         <setting id="musicfiles.nowplayingtrackformat" type="string" label="13307" help="">
           <level>4</level>
           <default></default>
-          <heading>16016</heading>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="edit" format="string" />
+          <control type="edit" format="string">
+            <heading>16016</heading>
+          </control>
         </setting>
         <setting id="musicfiles.nowplayingtrackformatright" type="string" label="13387" help="">
           <level>4</level>
           <default></default>
-          <heading>16016</heading>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="edit" format="string" />
+          <control type="edit" format="string">
+            <heading>16016</heading>
+          </control>
         </setting>
         <setting id="musicfiles.librarytrackformat" type="string" label="13307" help="">
           <level>4</level>
           <default></default>
-          <heading>16016</heading>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="edit" format="string" />
+          <control type="edit" format="string">
+            <heading>16016</heading>
+          </control>
         </setting>
         <setting id="musicfiles.librarytrackformatright" type="string" label="13387" help="">
           <level>4</level>
           <default></default>
-          <heading>16016</heading>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="edit" format="string" />
+          <control type="edit" format="string">
+            <heading>16016</heading>
+          </control>
         </setting>
         <setting id="musicfiles.findremotethumbs" type="boolean" label="14059" help="">
           <level>0</level>
@@ -1316,17 +1324,19 @@
         <setting id="audiocds.recordingpath" type="path" label="20000" help="">
           <level>1</level>
           <default></default>
-          <heading>657</heading>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="button" format="path" />
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
         </setting>
         <setting id="audiocds.trackpathformat" type="string" label="13307" help="">
           <level>2</level>
           <default>%A/%A - %B/[%N. ][%A - ]%T</default>
-          <heading>16016</heading>
-          <control type="edit" format="string" />
+          <control type="edit" format="string">
+            <heading>16016</heading>
+          </control>
         </setting>
         <setting id="audiocds.encoder" type="integer" label="621" help="">
           <level>2</level>
@@ -2196,11 +2206,12 @@
         <setting id="debug.screenshotpath" type="path" label="20004" help="">
           <level>1</level>
           <default></default>
-          <heading>657</heading>
           <constraints>
             <allowempty>true</allowempty>
           </constraints>
-          <control type="button" format="path" />
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
         </setting>
       </group>
     </category>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -13,7 +13,6 @@
           <dependencies>
             <dependency type="enable" on="property" name="AddonHasSettings" setting="lookandfeel.skin" />
           </dependencies>
-          <control type="button" format="action" />
         </setting>
         <setting id="lookandfeel.skintheme" type="string" label="15111" help="">
           <level>1</level>
@@ -1540,7 +1539,6 @@
           <dependencies>
             <dependency type="enable" on="property" name="AddonHasSettings" setting="weather.addon" />
           </dependencies>
-          <control type="button" format="action" />
         </setting>
       </group>
     </category>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -47,9 +47,10 @@
             <minimum>-20</minimum>
             <step>2</step>
             <maximum>20</maximum>
-            <formatlabel>14047</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14047</formatlabel>
+          </control>
         </setting>
         <setting id="lookandfeel.startupwindow" type="integer" label="512" help="">
           <level>0</level>
@@ -240,12 +241,13 @@
             <minimum>1</minimum>
             <step>1</step>
             <maximum>60</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
           <dependencies>
             <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="2">
@@ -363,9 +365,10 @@
             <minimum>0</minimum>
             <step>10</step>
             <maximum>100</maximum>
-            <formatlabel>14047</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14047</formatlabel>
+          </control>
         </setting>
         <setting id="videoplayer.usevdpau" type="boolean" label="13425" help="">
           <visible>HAVE_LIBVDPAU</visible>
@@ -495,9 +498,10 @@
             <minimum label="231">0</minimum>
             <step>1</step>
             <maximum>20</maximum>
-            <formatlabel>14047</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14047</formatlabel>
+          </control>
         </setting>
         <setting id="videoplayer.stretch43" type="integer" label="173" help="">
           <level>1</level>
@@ -812,9 +816,10 @@
             <minimum>1</minimum>
             <step>1</step>
             <maximum>10</maximum>
-            <formatlabel>14045</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14045</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="2">
@@ -857,9 +862,10 @@
             <minimum>1</minimum>
             <step>1</step>
             <maximum>14</maximum>
-            <formatlabel>17999</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>17999</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="2">
@@ -870,9 +876,10 @@
             <minimum>15</minimum>
             <step>15</step>
             <maximum>2880</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
         <setting id="epg.preventupdateswhileplayingtv" type="boolean" label="19230" help="">
           <level>1</level>
@@ -921,9 +928,10 @@
             <minimum>1</minimum>
             <step>1</step>
             <maximum>60</maximum>
-            <formatlabel>14045</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14045</formatlabel>
+          </control>
         </setting>
         <setting id="pvrplayback.confirmchannelswitch" type="boolean" label="19281" help="">
           <level>1</level>
@@ -936,9 +944,10 @@
             <minimum>0</minimum>
             <step>250</step>
             <maximum>10000</maximum>
-            <formatlabel>14046</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14046</formatlabel>
+          </control>
         </setting>
       </group>
     </category>
@@ -951,9 +960,10 @@
             <minimum>1</minimum>
             <step>1</step>
             <maximum>720</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
         <setting id="pvrrecord.defaultpriority" type="integer" label="19173" help="">
           <level>1</level>
@@ -972,9 +982,10 @@
             <minimum>1</minimum>
             <step>1</step>
             <maximum>365</maximum>
-            <formatlabel>17999</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>17999</formatlabel>
+          </control>
         </setting>
         <setting id="pvrrecord.marginstart" type="integer" label="19175" help="">
           <level>1</level>
@@ -983,9 +994,10 @@
             <minimum>0</minimum>
             <step>1</step>
             <maximum>60</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
         <setting id="pvrrecord.marginend" type="integer" label="19176" help="">
           <level>1</level>
@@ -994,9 +1006,10 @@
             <minimum>0</minimum>
             <step>1</step>
             <maximum>60</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="2">
@@ -1021,9 +1034,10 @@
             <minimum label="351">0</minimum>
             <step>5</step>
             <maximum>360</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
         <setting id="pvrpowermanagement.setwakeupcmd" type="string" label="19245" help="">
           <level>1</level>
@@ -1040,9 +1054,10 @@
             <minimum label="351">0</minimum>
             <step>1</step>
             <maximum>60</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="3">
@@ -1084,12 +1099,13 @@
             <minimum>5</minimum>
             <step>5</step>
             <maximum>1200</maximum>
-            <formatlabel>14045</formatlabel>
           </constraints>
           <dependencies>
             <dependency type="enable" setting="pvrparental.enabled">true</dependency>
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14045</formatlabel>
+          </control>
         </setting>
       </group>
     </category>
@@ -1184,9 +1200,10 @@
             <minimum>77</minimum>
             <step>1</step>
             <maximum>101</maximum>
-            <formatlabel>14050</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14050</formatlabel>
+          </control>
         </setting>
         <setting id="musicplayer.replaygainnogainpreamp" type="integer" label="642" help="">
           <level>2</level>
@@ -1195,9 +1212,10 @@
             <minimum>77</minimum>
             <step>1</step>
             <maximum>101</maximum>
-            <formatlabel>14050</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14050</formatlabel>
+          </control>
         </setting>
         <setting id="musicplayer.replaygainavoidclipping" type="boolean" label="643" help="">
           <level>2</level>
@@ -1212,9 +1230,10 @@
             <minimum label="351">0</minimum>
             <step>1</step>
             <maximum>15</maximum>
-            <formatlabel>14045</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14045</formatlabel>
+          </control>
         </setting>
         <setting id="musicplayer.crossfadealbumtracks" type="boolean" label="13400" help="">
           <level>1</level>
@@ -1374,7 +1393,6 @@
             <minimum>128</minimum>
             <step>32</step>
             <maximum>320</maximum>
-            <formatlabel>14048</formatlabel>
           </constraints>
           <dependencies>
             <dependency type="enable">
@@ -1385,7 +1403,9 @@
               </and>
             </dependency>
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14048</formatlabel>
+          </control>
         </setting>
         <setting id="audiocds.compressionlevel" type="integer" label="665" help="">
           <level>2</level>
@@ -1549,9 +1569,10 @@
             <minimum>1</minimum>
             <step>1</step>
             <maximum>100</maximum>
-            <formatlabel>14045</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14045</formatlabel>
+          </control>
         </setting>
         <setting id="slideshow.displayeffects" type="boolean" label="12379" help="">
           <level>0</level>
@@ -2145,9 +2166,10 @@
             <minimum label="351">0</minimum>
             <step>512</step>
             <maximum>102400</maximum>
-            <formatlabel>14048</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14048</formatlabel>
+          </control>
         </setting>
       </group>
     </category>
@@ -2160,9 +2182,10 @@
             <minimum label="351">0</minimum>
             <step>5</step>
             <maximum>120</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
         <setting id="powermanagement.shutdowntime" type="integer" label="357" help="">
           <level>2</level>
@@ -2171,9 +2194,10 @@
             <minimum label="351">0</minimum>
             <step>5</step>
             <maximum>120</maximum>
-            <formatlabel>14044</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14044</formatlabel>
+          </control>
         </setting>
         <setting id="powermanagement.shutdownstate" type="integer" label="13008" help="">
           <level>2</level>
@@ -2252,9 +2276,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>4096</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="2">
@@ -2265,9 +2290,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>16384</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
         <setting id="cachevideo.lan" type="integer" label="14027" help="">
           <level>4</level>
@@ -2276,9 +2302,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>16384</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
         <setting id="cachevideo.internet" type="integer" label="14028" help="">
           <level>4</level>
@@ -2287,9 +2314,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>16384</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="3">
@@ -2300,9 +2328,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>4096</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
         <setting id="cacheaudio.lan" type="integer" label="14031" help="">
           <level>4</level>
@@ -2311,9 +2340,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>4096</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
         <setting id="cacheaudio.internet" type="integer" label="14032" help="">
           <level>4</level>
@@ -2322,9 +2352,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>4096</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="4">
@@ -2335,9 +2366,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>16384</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
         <setting id="cachedvd.lan" type="integer" label="14060" help="">
           <level>4</level>
@@ -2346,9 +2378,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>16384</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
       </group>
       <group id="5">
@@ -2359,9 +2392,10 @@
             <minimum label="351">0</minimum>
             <step>256</step>
             <maximum>16384</maximum>
-            <formatlabel>14049</formatlabel>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="spinner" format="string">
+            <formatlabel>14049</formatlabel>
+          </control>
         </setting>
       </group>
     </category>

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -792,8 +792,13 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
     CLog::Log(LOGERROR, "CSettingString: invalid <control> of \"%s\"", m_id.c_str());
     return false;
   }
-  // get heading
-  XMLUtils::GetInt(node, "heading", m_heading);
+
+  const TiXmlNode *control = node->FirstChild("control");
+  if (control != NULL)
+  {
+    // get heading
+    XMLUtils::GetInt(control, "heading", m_heading);
+  }
 
   const TiXmlNode *constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
   if (constraints != NULL)

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -409,6 +409,13 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
     return false;
   }
 
+  if (m_control.GetFormat() == SettingControlFormatString)
+  {
+    const TiXmlNode *control = node->FirstChild("control");
+    if (control != NULL)
+      XMLUtils::GetInt(control, "formatlabel", m_format);
+  }
+
   const TiXmlNode *constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
   if (constraints != NULL)
   {
@@ -449,16 +456,11 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
     // get maximum
     XMLUtils::GetInt(constraints, XML_ELM_MAXIMUM, m_max);
 
-    if (m_control.GetFormat() == SettingControlFormatString)
+    if (m_control.GetFormat() == SettingControlFormatString && m_labelMin < 0)
     {
-      XMLUtils::GetInt(constraints, "formatlabel", m_format);
-
-      if (m_labelMin < 0)
-      {
-        CStdString strFormat;
-        if (XMLUtils::GetString(constraints, "format", strFormat) && !strFormat.empty())
-          m_strFormat = strFormat;
-      }
+      CStdString strFormat;
+      if (XMLUtils::GetString(constraints, "format", strFormat) && !strFormat.empty())
+        m_strFormat = strFormat;
     }
   }
 

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -792,12 +792,22 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
     CLog::Log(LOGERROR, "CSettingString: invalid <control> of \"%s\"", m_id.c_str());
     return false;
   }
-    
-  // get allowempty (needs to be parsed before parsing the default value)
-  XMLUtils::GetBoolean(node, "allowempty", m_allowEmpty);
   // get heading
   XMLUtils::GetInt(node, "heading", m_heading);
-    
+
+  const TiXmlNode *constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
+  if (constraints != NULL)
+  {
+    // get allowempty (needs to be parsed before parsing the default value)
+    XMLUtils::GetBoolean(constraints, "allowempty", m_allowEmpty);
+
+    // get the entries
+    const TiXmlNode *options = constraints->FirstChild(XML_ELM_OPTIONS);
+    if (options != NULL && options->FirstChild() != NULL &&
+        options->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT)
+      m_optionsFiller = options->FirstChild()->ValueStr();
+  }
+
   // get the default value
   CStdString value;
   if (XMLUtils::GetString(node, XML_ELM_DEFAULT, value))
@@ -806,16 +816,6 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
   {
     CLog::Log(LOGERROR, "CSettingString: error reading the default value of \"%s\"", m_id.c_str());
     return false;
-  }
-
-  const TiXmlNode *constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
-  if (constraints != NULL)
-  {
-    // get the entries
-    const TiXmlNode *options = constraints->FirstChild(XML_ELM_OPTIONS);
-    if (options != NULL && options->FirstChild() != NULL &&
-        options->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT)
-      m_optionsFiller = options->FirstChild()->ValueStr();
   }
 
   return true;

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -81,6 +81,22 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (m_level < (int)SettingLevelBasic || m_level > (int)SettingLevelInternal)
     m_level = SettingLevelStandard;
 
+  const TiXmlNode *dependencies = node->FirstChild("dependencies");
+  if (dependencies != NULL)
+  {
+    const TiXmlNode *dependencyNode = dependencies->FirstChild("dependency");
+    while (dependencyNode != NULL)
+    {
+      CSettingDependency dependency(m_settingsManager);
+      if (dependency.Deserialize(dependencyNode))
+        m_dependencies.push_back(dependency);
+      else
+        CLog::Log(LOGWARNING, "CSetting: error reading <dependency> tag of \"%s\"", m_id.c_str());
+
+      dependencyNode = dependencyNode->NextSibling("dependency");
+    }
+  }
+
   const TiXmlElement *control = node->FirstChildElement("control");
   if (control != NULL)
   {
@@ -89,22 +105,6 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
     {
       CLog::Log(LOGERROR, "CSetting: error reading <control> tag of \"%s\"", m_id.c_str());
       return false;
-    }
-
-    const TiXmlNode *dependencies = control->FirstChild("dependencies");
-    if (dependencies != NULL)
-    {
-      const TiXmlNode *dependencyNode = dependencies->FirstChild("dependency");
-      while (dependencyNode != NULL)
-      {
-        CSettingDependency dependency(m_settingsManager);
-        if (dependency.Deserialize(dependencyNode))
-          m_dependencies.push_back(dependency);
-        else
-          CLog::Log(LOGWARNING, "CSetting: error reading <dependency> tag of \"%s\"", m_id.c_str());
-
-        dependencyNode = dependencyNode->NextSibling("dependency");
-      }
     }
   }
 

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -31,11 +31,17 @@
 #define XML_ELM_DEFAULT     "default"
 #define XML_ELM_VALUE       "value"
 
-#define XML_ELM_CONSTRAINTS "constraints"
-#define XML_ELM_OPTIONS     "options"
-#define XML_ELM_MINIMUM     "minimum"
-#define XML_ELM_STEP        "step"
-#define XML_ELM_MAXIMUM     "maximum"
+#define XML_ELM_CONTROL       "control"
+#define XML_ELM_CONSTRAINTS   "constraints"
+#define XML_ELM_OPTIONS       "options"
+#define XML_ELM_OPTION        "option"
+#define XML_ELM_MINIMUM       "minimum"
+#define XML_ELM_STEP          "step"
+#define XML_ELM_MAXIMUM       "maximum"
+#define XML_ELM_DEPENDENCIES  "dependencies"
+#define XML_ELM_DEPENDENCY    "dependency"
+#define XML_ELM_UPDATES       "updates"
+#define XML_ELM_UPDATE        "update"
 
 CSetting::CSetting(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : ISetting(id, settingsManager),
@@ -81,10 +87,10 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (m_level < (int)SettingLevelBasic || m_level > (int)SettingLevelInternal)
     m_level = SettingLevelStandard;
 
-  const TiXmlNode *dependencies = node->FirstChild("dependencies");
+  const TiXmlNode *dependencies = node->FirstChild(XML_ELM_DEPENDENCIES);
   if (dependencies != NULL)
   {
-    const TiXmlNode *dependencyNode = dependencies->FirstChild("dependency");
+    const TiXmlNode *dependencyNode = dependencies->FirstChild(XML_ELM_DEPENDENCY);
     while (dependencyNode != NULL)
     {
       CSettingDependency dependency(m_settingsManager);
@@ -93,11 +99,11 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
       else
         CLog::Log(LOGWARNING, "CSetting: error reading <dependency> tag of \"%s\"", m_id.c_str());
 
-      dependencyNode = dependencyNode->NextSibling("dependency");
+      dependencyNode = dependencyNode->NextSibling(XML_ELM_DEPENDENCY);
     }
   }
 
-  const TiXmlElement *control = node->FirstChildElement("control");
+  const TiXmlElement *control = node->FirstChildElement(XML_ELM_CONTROL);
   if (control != NULL)
   {
     if (!m_control.Deserialize(control, update) ||
@@ -108,10 +114,10 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
     }
   }
 
-  const TiXmlNode *updates = node->FirstChild("updates");
+  const TiXmlNode *updates = node->FirstChild(XML_ELM_UPDATES);
   if (updates != NULL)
   {
-    const TiXmlElement *updateElem = updates->FirstChildElement("update");
+    const TiXmlElement *updateElem = updates->FirstChildElement(XML_ELM_UPDATE);
     while (updateElem != NULL)
     {
       CSettingUpdate update;
@@ -123,7 +129,7 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
       else
         CLog::Log(LOGWARNING, "CSetting: error reading <update> tag of \"%s\"", m_id.c_str());
 
-      updateElem = updateElem->NextSiblingElement("update");
+      updateElem = updateElem->NextSiblingElement(XML_ELM_UPDATE);
     }
   }
 
@@ -411,7 +417,7 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
 
   if (m_control.GetFormat() == SettingControlFormatString)
   {
-    const TiXmlNode *control = node->FirstChild("control");
+    const TiXmlNode *control = node->FirstChild(XML_ELM_CONTROL);
     if (control != NULL)
       XMLUtils::GetInt(control, "formatlabel", m_format);
   }
@@ -428,7 +434,7 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
       else
       {
         m_options.clear();
-        const TiXmlElement *optionElement = options->FirstChildElement("option");
+        const TiXmlElement *optionElement = options->FirstChildElement(XML_ELM_OPTION);
         while (optionElement != NULL)
         {
           std::pair<int, int> entry;
@@ -438,7 +444,7 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
             m_options.push_back(entry);
           }
 
-          optionElement = optionElement->NextSiblingElement("option");
+          optionElement = optionElement->NextSiblingElement(XML_ELM_OPTION);
         }
       }
     }
@@ -795,7 +801,7 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
     return false;
   }
 
-  const TiXmlNode *control = node->FirstChild("control");
+  const TiXmlNode *control = node->FirstChild(XML_ELM_CONTROL);
   if (control != NULL)
   {
     // get heading

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -68,15 +68,19 @@ bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */
     CLog::Log(LOGERROR, "CSettingAddon: error reading the default value of \"%s\"", m_id.c_str());
     return false;
   }
-    
-  // get the addon type
+
+  bool ok = false;
   CStdString strAddonType;
-  bool ok = XMLUtils::GetString(node, "addontype", strAddonType);
-  if (ok)
+  const TiXmlNode *constraints = node->FirstChild("constraints");
+  if (constraints != NULL)
   {
-    m_addonType = ADDON::TranslateType(strAddonType);
-    if (m_addonType == ADDON::ADDON_UNKNOWN)
-      ok = false;
+    // get the addon type
+    if (XMLUtils::GetString(constraints, "addontype", strAddonType))
+    {
+      m_addonType = ADDON::TranslateType(strAddonType);
+      if (m_addonType != ADDON::ADDON_UNKNOWN)
+        ok = true;
+    }
   }
 
   if (!ok && !update)


### PR DESCRIPTION
These commits move around some tags to put them into their proper places (e.g. dependencies are not really part of the <control> definition whereas <heading> is only used in combination with the GUI control so it should be part of <control>). This does not change the behaviour of anything, just moves around some XML tags and their parsing.
