### PR TITLE
[UPNP/JSONRPC] add source setting allowSharing to secure source access from UPNP/WebServer

### DIFF
--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -54,6 +54,7 @@ void CMediaSource::FromNameAndPaths(const CStdString &category, const CStdString
   m_strLockCode = "0";
   m_iBadPwdCount = 0;
   m_iHasLock = 0;
+  m_allowSharing = true;
 
   if (URIUtils::IsMultiPath(strPath))
     m_iDriveType = SOURCE_TYPE_VPATH;

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -41,7 +41,7 @@ public:
     SOURCE_TYPE_VPATH        = 5,
     SOURCE_TYPE_REMOVABLE    = 6
   };
-  CMediaSource() { m_iDriveType=SOURCE_TYPE_UNKNOWN; m_iLockMode=LOCK_MODE_EVERYONE; m_iBadPwdCount=0; m_iHasLock=0; m_ignore=false; };
+  CMediaSource() { m_iDriveType=SOURCE_TYPE_UNKNOWN; m_iLockMode=LOCK_MODE_EVERYONE; m_iBadPwdCount=0; m_iHasLock=0; m_ignore=false; m_allowSharing=true; };
   virtual ~CMediaSource() {};
 
   bool operator==(const CMediaSource &right) const;
@@ -98,6 +98,7 @@ public:
 
   std::vector<CStdString> vecPaths;
   bool m_ignore; /// <Do not store in xml
+  bool m_allowSharing; /// <Allow browsing of source from UPnP / WebServer
 };
 
 /*!

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -64,8 +64,8 @@ int CHTTPVfsHandler::HandleHTTPRequest(const HTTPRequest &request)
 
           for (VECSOURCES::const_iterator source = sources->begin(); source != sources->end() && !accessible; source++)
           {
-            // don't allow access to locked sources
-            if (source->m_iHasLock == 2)
+            // don't allow access to locked / disabled sharing sources
+            if (source->m_iHasLock == 2 || !source->m_allowSharing)
               continue;
 
             for (vector<CStdString>::const_iterator path = source->vecPaths.begin(); path != source->vecPaths.end(); path++)

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -24,6 +24,7 @@
 #include "video/VideoDatabase.h"
 #include "guilib/GUIWindowManager.h"
 #include "xbmc/GUIUserMessages.h"
+#include "utils/FileUtils.h"
 
 using namespace std;
 using namespace ANNOUNCEMENT;
@@ -475,23 +476,7 @@ static NPT_String TranslateWMPObjectId(NPT_String id)
 NPT_Result
 ObjectIDValidate(const NPT_String& id)
 {
-    if(id.Find("..") != -1)
-        return NPT_ERROR_NO_SUCH_FILE;
-    if(id.StartsWith("virtualpath://upnproot/"))
-        return NPT_SUCCESS;
-    else if(id.StartsWith("musicdb://"))
-        return NPT_SUCCESS;
-    else if(id.StartsWith("videodb://"))
-        return NPT_SUCCESS;
-    else if(id.StartsWith("library://video"))
-        return NPT_SUCCESS;
-    else if(id.StartsWith("sources://video"))
-        return NPT_SUCCESS;
-    else if(id.StartsWith("special://musicplaylists"))
-        return NPT_SUCCESS;
-    else if(id.StartsWith("special://profile/playlists"))
-        return NPT_SUCCESS;
-    else if(id.StartsWith("special://videoplaylists"))
+    if (CFileUtils::RemoteAccessAllowed(id.GetChars()))
         return NPT_SUCCESS;
     return NPT_ERROR_NO_SUCH_FILE;
 }

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -416,6 +416,8 @@ bool CMediaSourceSettings::GetSource(const std::string &category, const TiXmlNod
   if (pThumbnailNode && pThumbnailNode->FirstChild())
     share.m_strThumbnailImage = pThumbnailNode->FirstChild()->Value();
 
+  XMLUtils::GetBoolean(source, "allowsharing", share.m_allowSharing);
+
   return true;
 }
 
@@ -485,8 +487,11 @@ bool CMediaSourceSettings::SetSources(TiXmlNode *root, const char *section, cons
       XMLUtils::SetString(&source, "lockcode", share.m_strLockCode);
       XMLUtils::SetInt(&source, "badpwdcount", share.m_iBadPwdCount);
     }
+
     if (!share.m_strThumbnailImage.empty())
       XMLUtils::SetPath(&source, "thumbnail", share.m_strThumbnailImage);
+
+    XMLUtils::SetBoolean(&source, "allowsharing", share.m_allowSharing);
 
     sectionNode->InsertEndChild(source);
   }

--- a/xbmc/utils/FileUtils.h
+++ b/xbmc/utils/FileUtils.h
@@ -7,4 +7,5 @@ public:
   static bool DeleteItem(const CFileItemPtr &item, bool force=false);
   static bool DeleteItem(const CStdString &strPath, bool force=false);
   static bool RenameFile(const CStdString &strFile);
+  static bool RemoteAccessAllowed(const CStdString &strPath);
 };


### PR DESCRIPTION
[UPNP/JSONRPC] add source setting allowSharing to secure source access from UPNP/WebServer

Continuation of 1220d8c
Add a source flag allowsharing defaulting to true to allow or disallow
access to a source from UPNP/WebServer

The checks are now available as a function in FileUtils and common to UPNP and JSON
Also make the check correctly works in JSON as current implementation have flow allowing browsing any directory with Files.GetDirectory.
