### PR TITLE
settings: support "subsettings" using a "parent" attribute

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -676,7 +676,10 @@ msgctxt "#167"
 msgid "Cancel file operations"
 msgstr ""
 
-#empty string with id 168
+#: xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+msgctxt "#168"
+msgid "%s- %s"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#169"
@@ -1033,7 +1036,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#254"
-msgid "- DTS capable receiver"
+msgid "DTS capable receiver"
 msgstr ""
 
 msgctxt "#255"
@@ -1182,7 +1185,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#289"
-msgid "- Size"
+msgid "Size"
 msgstr ""
 
 msgctxt "#290"
@@ -1222,19 +1225,19 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#299"
-msgid "- AAC capable receiver"
+msgid "AAC capable receiver"
 msgstr ""
 
 msgctxt "#300"
-msgid "- MP1 capable receiver"
+msgid "MP1 capable receiver"
 msgstr ""
 
 msgctxt "#301"
-msgid "- MP2 capable receiver"
+msgid "MP2 capable receiver"
 msgstr ""
 
 msgctxt "#302"
-msgid "- MP3 capable receiver"
+msgid "MP3 capable receiver"
 msgstr ""
 
 msgctxt "#303"
@@ -1419,17 +1422,17 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#347"
-msgid "- DTS-HD capable receiver"
+msgid "DTS-HD capable receiver"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#348"
-msgid "- Multichannel LPCM capable receiver"
+msgid "Multichannel LPCM capable receiver"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#349"
-msgid "- TrueHD capable receiver"
+msgid "TrueHD capable receiver"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -1497,7 +1500,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#364"
-msgid "- Dolby Digital (AC3) capable receiver"
+msgid "Dolby Digital (AC3) capable receiver"
 msgstr ""
 
 msgctxt "#365"
@@ -2727,7 +2730,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#666"
-msgid "- Verbose logging..."
+msgid "Verbose logging..."
 msgstr ""
 
 #empty strings from id 667 to 699
@@ -2752,7 +2755,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#706"
-msgid "- Server"
+msgid "Server"
 msgstr ""
 
 #empty string with id 707
@@ -2780,7 +2783,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#715"
-msgid "- Assignment"
+msgid "Assignment"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -2797,22 +2800,22 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#719"
-msgid "- IP address"
+msgid "IP address"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#720"
-msgid "- Netmask"
+msgid "Netmask"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#721"
-msgid "- Default gateway"
+msgid "Default gateway"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#722"
-msgid "- DNS server"
+msgid "DNS server"
 msgstr ""
 
 msgctxt "#723"
@@ -2843,7 +2846,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#730"
-msgid "- Port"
+msgid "Port"
 msgstr ""
 
 #empty string with id 731
@@ -2854,7 +2857,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#733"
-msgid "- Password"
+msgid "Password"
 msgstr ""
 
 msgctxt "#734"
@@ -2863,17 +2866,17 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#735"
-msgid "- Character set"
+msgid "Character set"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#736"
-msgid "- Style"
+msgid "Style"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#737"
-msgid "- Colour"
+msgid "Colour"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -3024,17 +3027,17 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#776"
-msgid "- Wireless network name (ESSID)"
+msgid "Wireless network name (ESSID)"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#777"
-msgid "- Wireless password"
+msgid "Wireless password"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#778"
-msgid "- Wireless security"
+msgid "Wireless security"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -3179,7 +3182,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#1000"
-msgid "- Preview"
+msgid "Preview"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -3403,7 +3406,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#1048"
-msgid "- Username"
+msgid "Username"
 msgstr ""
 
 msgctxt "#1049"
@@ -3614,7 +3617,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#1272"
-msgid "- Use password protection"
+msgid "Use password protection"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -5255,7 +5258,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13303"
-msgid "- Fonts"
+msgid "Fonts"
 msgstr ""
 
 msgctxt "#13304"
@@ -6035,12 +6038,12 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14027"
-msgid "- Local Network"
+msgid "Local Network"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14028"
-msgid "- Internet"
+msgid "Internet"
 msgstr ""
 
 #empty string with id 14029
@@ -6052,12 +6055,12 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14031"
-msgid "- Local Network"
+msgid "Local Network"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14032"
-msgid "- Internet"
+msgid "Internet"
 msgstr ""
 
 #empty string with id 14033
@@ -6069,7 +6072,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14035"
-msgid "- Local Network"
+msgid "Local Network"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -6246,7 +6249,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14078"
-msgid "- Colours"
+msgid "Colours"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -6432,7 +6435,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#15111"
-msgid "- Theme"
+msgid "Theme"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -8921,7 +8924,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#20109"
-msgid "- Zoom"
+msgid "Zoom"
 msgstr ""
 
 msgctxt "#20110"
@@ -10402,7 +10405,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21417"
-msgid "- Settings"
+msgid "Settings"
 msgstr ""
 
 msgctxt "#21418"
@@ -10542,7 +10545,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21450"
-msgid "- Edit"
+msgid "Edit"
 msgstr ""
 
 msgctxt "#21451"
@@ -10968,7 +10971,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#22002"
-msgid "- DNS suffix"
+msgid "DNS suffix"
 msgstr ""
 
 msgctxt "#22003"
@@ -11079,17 +11082,17 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#22031"
-msgid "- Size"
+msgid "Size"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#22032"
-msgid "- Colours"
+msgid "Colours"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#22033"
-msgid "- Charset"
+msgid "Charset"
 msgstr ""
 
 msgctxt "#22034"

--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
   <section id="system">
-    <category id="videoscreen" label="21373" help="36350">
+    <category id="videoscreen">
       <group id="1">
         <setting id="videoscreen.resolution" label="131" />
       </group>

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -16,7 +16,7 @@
     </category>
   </section>
   <section id="music">
-    <category id="audiocds" label="620" help="36282">
+    <category id="audiocds">
       <visible>false</visible>
     </category>
   </section>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -10,13 +10,13 @@
             <addontype>xbmc.gui.skin</addontype>
           </constraints>
         </setting>
-        <setting id="lookandfeel.skinsettings" type="action" label="21417" help="36104">
+        <setting id="lookandfeel.skinsettings" type="action" parent="lookandfeel.skin" label="21417" help="36104">
           <level>0</level>
           <dependencies>
             <dependency type="enable" on="property" name="AddonHasSettings" setting="lookandfeel.skin" />
           </dependencies>
         </setting>
-        <setting id="lookandfeel.skintheme" type="string" label="15111" help="36105">
+        <setting id="lookandfeel.skintheme" type="string" parent="lookandfeel.skin" label="15111" help="36105">
           <level>1</level>
           <default>SKINDEFAULT</default>
           <constraints>
@@ -24,7 +24,7 @@
           </constraints>
           <control type="spinner" format="string" delayed="true" />
         </setting>
-        <setting id="lookandfeel.skincolors" type="string" label="14078" help="36106">
+        <setting id="lookandfeel.skincolors" type="string" parent="lookandfeel.skin" label="14078" help="36106">
           <level>1</level>
           <default>SKINDEFAULT</default>
           <constraints>
@@ -32,7 +32,7 @@
           </constraints>
           <control type="spinner" format="string" delayed="true" />
         </setting>
-        <setting id="lookandfeel.font" type="string" label="13303" help="36107">
+        <setting id="lookandfeel.font" type="string" parent="lookandfeel.skin" label="13303" help="36107">
           <level>1</level>
           <default>Default</default>
           <constraints>
@@ -40,7 +40,7 @@
           </constraints>
           <control type="spinner" format="string" delayed="true" />
         </setting>
-        <setting id="lookandfeel.skinzoom" type="integer" label="20109" help="36108">
+        <setting id="lookandfeel.skinzoom" type="integer" parent="lookandfeel.skin" label="20109" help="36108">
           <level>2</level>
           <default>0</default>
           <constraints>
@@ -74,7 +74,7 @@
           <level>1</level>
           <default>true</default>
         </setting>
-        <setting id="lookandfeel.rssedit" type="string" label="21450" help="36112">
+        <setting id="lookandfeel.rssedit" type="string" parent="lookandfeel.enablerssfeeds" label="21450" help="36112">
           <level>1</level>
           <default></default>
           <constraints>
@@ -217,7 +217,7 @@
             <update type="change" />
           </updates>
         </setting>
-        <setting id="screensaver.settings" type="action" label="21417" help="36130">
+        <setting id="screensaver.settings" parent="screensaver.mode" type="action" label="21417" help="36130">
           <level>0</level>
           <dependencies>
             <dependency type="enable">
@@ -228,7 +228,7 @@
             </dependency>
           </dependencies>
         </setting>
-        <setting id="screensaver.preview" type="action" label="1000" help="36131">
+        <setting id="screensaver.preview" type="action" parent="screensaver.mode" label="1000" help="36131">
           <level>0</level>
           <dependencies>
             <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
@@ -601,7 +601,7 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="subtitles.height" type="integer" label="289" help="36186">
+        <setting id="subtitles.height" type="integer" parent="subtitles.font" label="289" help="36186">
           <level>1</level>
           <default>28</default>
           <constraints>
@@ -614,7 +614,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="subtitles.style" type="integer" label="736" help="36187">
+        <setting id="subtitles.style" type="integer" parent="subtitles.font" label="736" help="36187">
           <level>1</level>
           <default>1</default> <!-- FONT_STYLE_BOLD -->
           <constraints>
@@ -630,7 +630,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="subtitles.color" type="integer" label="737" help="36188">
+        <setting id="subtitles.color" type="integer" parent="subtitles.font" label="737" help="36188">
           <level>1</level>
           <default>1</default> <!-- White -->
           <constraints>
@@ -650,7 +650,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="subtitles.charset" type="string" label="735" help="36189">
+        <setting id="subtitles.charset" type="string" parent="subtitles.font" label="735" help="36189">
           <level>1</level>
           <default>DEFAULT</default>
           <constraints>
@@ -1453,7 +1453,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="karaoke.fontheight" type="integer" label="22031" help="36296">
+        <setting id="karaoke.fontheight" type="integer" parent="karaoke.font" label="22031" help="36296">
           <level>2</level>
           <default>36</default>
           <constraints>
@@ -1467,7 +1467,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="karaoke.fontcolors" type="integer" label="22032" help="36297">
+        <setting id="karaoke.fontcolors" type="integer" parent="karaoke.font" label="22032" help="36297">
           <level>2</level>
           <default>0</default> <!-- white/green -->
           <constraints>
@@ -1483,7 +1483,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="karaoke.charset" type="string" label="22033" help="36298">
+        <setting id="karaoke.charset" type="string" parent="karaoke.font" label="22033" help="36298">
           <level>2</level>
           <default>DEFAULT</default>
           <constraints>
@@ -1601,7 +1601,7 @@
             <allowempty>true</allowempty>
           </constraints>
         </setting>
-        <setting id="weather.addonsettings" type="action" label="21417" help="36103">
+        <setting id="weather.addonsettings" type="action" parent="weather.addon" label="21417" help="36103">
           <level>0</level>
           <dependencies>
             <dependency type="enable" on="property" name="AddonHasSettings" setting="weather.addon" />
@@ -1650,7 +1650,7 @@
           <level>1</level>
           <default>false</default>
         </setting>
-        <setting id="services.webserverport" type="integer" label="730" help="36329">
+        <setting id="services.webserverport" type="integer" parent="services.webserver" label="730" help="36329">
           <level>2</level>
           <default>8080</default>
           <constraints>
@@ -1660,7 +1660,7 @@
           </constraints>
           <control type="edit" format="integer" />
         </setting>
-        <setting id="services.webserverusername" type="string" label="1048" help="36330">
+        <setting id="services.webserverusername" type="string" parent="services.webserver" label="1048" help="36330">
           <level>2</level>
           <default>xbmc</default>
           <constraints>
@@ -1671,7 +1671,7 @@
           </dependencies>
           <control type="edit" format="string" />
         </setting>
-        <setting id="services.webserverpassword" type="string" label="733" help="36331">
+        <setting id="services.webserverpassword" type="string" parent="services.webserver" label="733" help="36331">
           <level>2</level>
           <default></default>
           <constraints>
@@ -1798,14 +1798,14 @@
           <level>1</level>
           <default>false</default>
         </setting>
-        <setting id="services.useairplaypassword" type="boolean" label="1272" help="36344">
+        <setting id="services.useairplaypassword" type="boolean" parent="services.airplay" label="1272" help="36344">
           <level>1</level>
           <default>false</default>
           <dependencies>
             <dependency type="enable" setting="services.airplay">true</dependency>
           </dependencies>
         </setting>
-        <setting id="services.airplaypassword" type="string" label="733" help="36345">
+        <setting id="services.airplaypassword" type="string" parent="services.useairplaypassword" label="733" help="36345">
           <level>1</level>
           <default></default>
           <constraints>
@@ -1962,7 +1962,7 @@
           <level>2</level>
           <default>false</default>
         </setting>
-        <setting id="audiooutput.ac3passthrough" type="boolean" label="364" help="36365">
+        <setting id="audiooutput.ac3passthrough" type="boolean" parent="audiooutput.mode" label="364" help="36365">
           <level>2</level>
           <default>true</default>
           <dependencies>
@@ -1974,7 +1974,7 @@
             </dependency>
           </dependencies>
         </setting>
-        <setting id="audiooutput.dtspassthrough" type="boolean" label="254" help="36366">
+        <setting id="audiooutput.dtspassthrough" type="boolean" parent="audiooutput.mode" label="254" help="36366">
           <level>2</level>
           <default>true</default>
           <dependencies>
@@ -1986,7 +1986,7 @@
             </dependency>
           </dependencies>
         </setting>
-        <setting id="audiooutput.passthroughaac" type="boolean" label="299" help="36367">
+        <setting id="audiooutput.passthroughaac" type="boolean" parent="audiooutput.mode" label="299" help="36367">
           <level>2</level>
           <default>false</default>
           <dependencies>
@@ -1998,21 +1998,21 @@
             </dependency>
           </dependencies>
         </setting>
-        <setting id="audiooutput.multichannellpcm" type="boolean" label="348" help="36368">
+        <setting id="audiooutput.multichannellpcm" type="boolean" parent="audiooutput.mode" label="348" help="36368">
           <level>2</level>
           <default>true</default>
           <dependencies>
             <dependency type="enable" setting="audiooutput.mode">2</dependency> <!-- AUDIO_HDMI -->
           </dependencies>
         </setting>
-        <setting id="audiooutput.truehdpassthrough" type="boolean" label="349" help="36369">
+        <setting id="audiooutput.truehdpassthrough" type="boolean" parent="audiooutput.mode" label="349" help="36369">
           <level>2</level>
           <default>true</default>
           <dependencies>
             <dependency type="enable" setting="audiooutput.mode">2</dependency> <!-- AUDIO_HDMI -->
           </dependencies>
         </setting>
-        <setting id="audiooutput.dtshdpassthrough" type="boolean" label="347" help="36370">
+        <setting id="audiooutput.dtshdpassthrough" type="boolean" parent="audiooutput.mode" label="347" help="36370">
           <level>2</level>
           <default>true</default>
           <dependencies>
@@ -2097,7 +2097,7 @@
           <level>1</level>
           <default>false</default>
         </setting>
-        <setting id="network.httpproxytype" type="integer" label="1180" help="36381">
+        <setting id="network.httpproxytype" type="integer" parent="network.usehttpproxy" label="1180" help="36381">
           <level>1</level>
           <default>0</default>
           <constraints>
@@ -2114,7 +2114,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="network.httpproxyserver" type="string" label="706" help="36382">
+        <setting id="network.httpproxyserver" type="string" parent="network.usehttpproxy" label="706" help="36382">
           <level>1</level>
           <default></default>
           <constraints>
@@ -2125,7 +2125,7 @@
           </dependencies>
           <control type="edit" format="string" />
         </setting>
-        <setting id="network.httpproxyport" type="integer" label="730" help="36383">
+        <setting id="network.httpproxyport" type="integer" parent="network.usehttpproxy" label="730" help="36383">
           <level>1</level>
           <default>8080</default>
           <constraints>
@@ -2138,7 +2138,7 @@
           </dependencies>
           <control type="edit" format="integer" />
         </setting>
-        <setting id="network.httpproxyusername" type="string" label="1048" help="36384">
+        <setting id="network.httpproxyusername" type="string" parent="network.usehttpproxy" label="1048" help="36384">
           <level>1</level>
           <default></default>
           <constraints>
@@ -2149,7 +2149,7 @@
           </dependencies>
           <control type="edit" format="string" />
         </setting>
-        <setting id="network.httpproxypassword" type="string" label="733" help="36385">
+        <setting id="network.httpproxypassword" type="string" parent="network.usehttpproxy" label="733" help="36385">
           <level>1</level>
           <default></default>
           <constraints>
@@ -2224,7 +2224,7 @@
           <level>1</level>
           <default>false</default>
         </setting>
-        <setting id="debug.setextraloglevel" type="action" label="666" help="36394">
+        <setting id="debug.setextraloglevel" type="action" parent="debug.showloginfo" label="666" help="36394">
           <level>1</level>
           <dependencies>
             <dependency type="enable" setting="debug.showloginfo">true</dependency>

--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -27,7 +27,7 @@
         </setting>
       </group>
     </category>
-    <category id="smb" label="1200" help="36420">
+    <category id="smb">
       <visible>false</visible>
     </category>
   </section>

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -79,6 +79,9 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
     m_label = tmp;
   if (element->QueryIntAttribute(XML_ATTR_HELP, &m_help) == TIXML_SUCCESS && tmp > 0)
     m_help = tmp;
+  const char *parentSetting = element->Attribute("parent");
+  if (parentSetting != NULL)
+    m_parentSetting = parentSetting;
 
   // get the <level>
   int level = -1;

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -94,6 +94,7 @@ public:
   int GetLabel() const { return m_label; }
   int GetHelp() const { return m_help; }
   bool IsEnabled() const;
+  const std::string& GetParent() const { return m_parentSetting; }
   SettingLevel GetLevel() const { return m_level; }
   const CSettingControl& GetControl() const { return m_control; }
   const SettingDependencies& GetDependencies() const { return m_dependencies; }
@@ -113,6 +114,7 @@ protected:
   ISettingCallback *m_callback;
   int m_label;
   int m_help;
+  std::string m_parentSetting;
   SettingLevel m_level;
   CSettingControl m_control;
   SettingDependencies m_dependencies;

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -35,6 +35,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "view/ViewStateSettings.h"
 
 using namespace std;
@@ -608,6 +609,26 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
   BaseSettingControlPtr pSettingControl;
   CGUIControl *pControl = NULL;
 
+  // determine the label and any possible indentation in case of sub settings
+  string label = g_localizeStrings.Get(pSetting->GetLabel());
+  int parentLevels = 0;
+  CSetting *parentSetting = m_settings.GetSetting(pSetting->GetParent());
+  while (parentSetting != NULL)
+  {
+    parentLevels++;
+    parentSetting = m_settings.GetSetting(parentSetting->GetParent());
+  }
+
+  if (parentLevels > 0)
+  {
+    // add additional 2 spaces indentation for anything past one level
+    string indentation;
+    for (int index = 1; index < parentLevels; index++)
+      indentation.append("  ");
+    label = StringUtils::Format(g_localizeStrings.Get(168).c_str(), indentation.c_str(), label.c_str());
+  }
+
+  // create the proper controls
   switch (pSetting->GetControl().GetType())
   {
     case SettingControlTypeCheckmark:
@@ -616,7 +637,7 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
       if (pControl == NULL)
         return NULL;
 
-      ((CGUIRadioButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
+      ((CGUIRadioButtonControl *)pControl)->SetLabel(label);
       pSettingControl.reset(new CGUIControlRadioButtonSetting((CGUIRadioButtonControl *)pControl, iControlID, pSetting));
       break;
     }
@@ -627,7 +648,7 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
       if (pControl == NULL)
         return NULL;
 
-      ((CGUISpinControlEx *)pControl)->SetText(g_localizeStrings.Get(pSetting->GetLabel()));
+      ((CGUISpinControlEx *)pControl)->SetText(label);
       pSettingControl.reset(new CGUIControlSpinExSetting((CGUISpinControlEx *)pControl, iControlID, pSetting));
       break;
     }
@@ -638,7 +659,7 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
       if (pControl == NULL)
         return NULL;
       
-      ((CGUIEditControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
+      ((CGUIEditControl *)pControl)->SetLabel(label);
       pSettingControl.reset(new CGUIControlEditSetting((CGUIEditControl *)pControl, iControlID, pSetting));
       break;
     }
@@ -649,7 +670,7 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
       if (pControl == NULL)
         return NULL;
       
-      ((CGUIButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
+      ((CGUIButtonControl *)pControl)->SetLabel(label);
       pSettingControl.reset(new CGUIControlButtonSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
       break;
     }


### PR DESCRIPTION
This change allows to define setting B as the parent of setting A making setting A a "subsetting". Subsettings are distinguished by automatically adding a "- " in front of their label. That way we can clean up the setting labels a bit and make the whole thing more generic. This has been suggested by @MartijnKaijser and @nuka1195 as this is already possible for addon settings. I didn't choose the same way as addon settings (using a "subsetting" attribute) because the "parent" approach is more generic i.e. you can make setting A a subsetting of setting B which is a subsetting of setting C (e.g. for the airplay password).
