### PR TITLE
settings: use <visible> conditions in setting definition XML files to determine which files to load

### DIFF
--- a/system/settings/android.xml
+++ b/system/settings/android.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
+  <visible>TARGET_ANDROID</visible>
   <section id="appearance">
     <category id="locale">
       <group id="2">

--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
+  <visible>TARGET_DARWIN</visible>
   <section id="system">
     <category id="videoscreen" label="21373" help="">
       <group id="1">

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
+  <visible>
+    <and>
+      <condition>TARGET_DARWIN</condition>
+      <condition>TARGET_DARWIN_IOS</condition>
+    </and>
+  </visible>
   <section id="videos">
     <category id="videoplayer">
       <group id="2">

--- a/system/settings/darwin_ios_atv2.xml
+++ b/system/settings/darwin_ios_atv2.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
+  <visible>
+    <and>
+      <condition>TARGET_DARWIN</condition>
+      <condition>TARGET_DARWIN_IOS</condition>
+      <condition>TARGET_DARWIN_IOS_ATV2</condition>
+    </and>
+  </visible>
   <section id="system">
     <category id="videoscreen">
       <group id="1">

--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
+  <visible>
+    <and>
+      <condition>TARGET_DARWIN</condition>
+      <condition>TARGET_DARWIN_OSX</condition>
+    </and>
+  </visible>
   <section id="system">
     <category id="input">
       <group id="1">

--- a/system/settings/freebsd.xml
+++ b/system/settings/freebsd.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
-
+  <visible>TARGET_FREEBSD</visible>
 </settings>

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
+  <visible>TARGET_LINUX</visible>
   <section id="system">
     <category id="videoscreen">
       <group id="1">

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<settings><section id="system">
+<settings>
+  <visible>TARGET_RASPBERRY_PI</visible>
+  <section id="system">
     <category id="videoscreen">
       <group id="1">
         <setting id="videoscreen.screen">

--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
+  <visible>TARGET_WINDOWS</visible>
   <section id="appearance">
     <category id="locale">
       <group id="2">

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -269,13 +269,13 @@ private:
   CSettings(const CSettings&);
   CSettings const& operator=(CSettings const&);
 
-  bool Initialize(const std::string &file);
+  bool Initialize(const std::string &file, CSettingsManager *visibilityManager, bool &hidden);
   bool InitializeDefinitions();
   void InitializeSettingTypes();
   void InitializeVisibility();
   void InitializeDefaults();
   void InitializeOptionFillers();
-  void InitializeConditions();
+  void InitializeConditions(CSettingsManager *settingsManager = NULL, bool staticConditions = true, bool dynamicConditions = true, bool platformConditions = false);
   void InitializeISettingsHandlers();
   void InitializeISubSettings();
   void InitializeISettingCallbacks();


### PR DESCRIPTION
Right now the list and name of the setting definition XML files which are used to initialize the settings system is hard-coded in CSettings::InitializeDefinitions() and depends on the platform (using TARGET_FOO defines). For XBMC forks which require special setting definitions I added "appliance.xml" which would be used on any platform. But I didn't like this limitation so I came up with a different solution.

With this change we can add any kind of XML files into the system/settings/ folder and CSettings::InitializeDefinitions() will pick them up and load them. It then first checks the <visible> tag of the XML file (inside the <settings> root tag) and evaluates it. If it evaluates to true, the file is loaded otherwise it is ignored. That way e.g. OE can just throw in an extra oe.xml file into the system/settings/ folder and specify its custom setting definitions in there.
The available visible conditions are limited to static conditions (like HAS_GL etc) and TARGET_FOO defines. Dynamic conditions are not available because they may change during runtime and may not even be properly initialized at the time the settings system is initialized.
