### PR TITLE
wake-on-access ; avoid attempting mac-discovery for internet addresses

### DIFF
--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -39,6 +39,7 @@
 #include "utils/JobManager.h"
 #include "utils/log.h"
 #include "utils/XMLUtils.h"
+#include "utils/URIUtils.h"
 
 #include "WakeOnAccess.h"
 
@@ -488,7 +489,12 @@ static void AddHostFromDatabase(const DatabaseSettings& setting, vector<string>&
 void CWakeOnAccess::QueueMACDiscoveryForHost(const CStdString& host)
 {
   if (IsEnabled())
-    CJobManager::GetInstance().AddJob(new CMACDiscoveryJob(host), this);
+  {
+    if (URIUtils::IsHostOnLAN(host, true))
+      CJobManager::GetInstance().AddJob(new CMACDiscoveryJob(host), this);
+    else
+      CLog::Log(LOGNOTICE, "%s - skip Mac discovery for non-local host '%s'", __FUNCTION__, host.c_str());
+  }
 }
 
 static void AddHostsFromMediaSource(const CMediaSource& source, std::vector<std::string>& hosts)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -97,6 +97,7 @@ public:
   static bool IsAfp(const CStdString& strFile);    
   static bool IsOnDVD(const CStdString& strFile);
   static bool IsOnLAN(const CStdString& strFile);
+  static bool IsHostOnLAN(const CStdString& hostName, bool offLineCheck = false);
   static bool IsPlugin(const CStdString& strFile);
   static bool IsScript(const CStdString& strFile);
   static bool IsRAR(const CStdString& strFile);


### PR DESCRIPTION
.. file-sources can be internet-links and must be filtered out else an attempt will be made and fail and show a kai-toast-error
