### PR TITLE
Remove double decoding code introduced by a2f0c6db3500e50052d102e75eaeec7bd5a2b449

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -759,10 +759,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
       for(std::map<CStdString, CStdString>::const_iterator it = options.begin(); it != options.end(); ++it)
       {
         const CStdString &name = it->first;
-        CStdString value = it->second;
-
-        // url decode value
-        CURL::Decode(value);
+        const CStdString &value = it->second;
 
         if(name.Equals("auth"))
         {


### PR DESCRIPTION
commit https://github.com/xbmc/xbmc/commit/a2f0c6db3500e50052d102e75eaeec7bd5a2b449 did not remove the decode code, which should be removed, done by this PR.
