### PR TITLE
[rbp] Fix new settings scheme for RPi and provide defaults

### DIFF
--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -1,8 +1,31 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<settings><section id="system">
+<settings>
+  <section id="videos">
+    <category id="videoplayer">
+      <group id="2">
+        <setting id="videoplayer.rendermethod">
+          <visible>false</visible>
+        </setting>
+        <setting id="videoplayer.hqscalers">
+          <visible>false</visible>
+        </setting>
+        <setting id="videoplayer.synctype">
+          <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
+
+  <section id="system">
     <category id="videoscreen">
       <group id="1">
         <setting id="videoscreen.screen">
+          <visible>false</visible>
+        </setting>
+        <setting id="videoscreen.blankdisplays">
+          <visible>false</visible>
+        </setting>
+        <setting id="videoscreen.fakefullscreen">
           <visible>false</visible>
         </setting>
       </group>
@@ -11,6 +34,12 @@
       <group id="1">
         <setting id="audiooutput.mode">
           <default>2</default> <!-- AUDIO_HDMI -->
+        </setting>
+        <setting id="audiooutput.channels">
+          <visible>false</visible>
+        </setting>
+        <setting id="audiooutput.stereoupmix">
+          <visible>false</visible>
         </setting>
         <setting id="audiooutput.passthroughaac">
           <visible>false</visible>


### PR DESCRIPTION
The Pi has both TARGET_LINUX and TARGET_RASPBERRY_PI defined, so the ordering of the checks in settings.c needs to be changed or we use linux.xml.
I've also been through the settings carefully and have made any settings that are not implemented on Pi be not-visible.

I've also changed the default for some settings. These are:
RSS: disabled. It kills dirty rectangle code and makes Pi run at 100% cpu
Extract thumbnails and video info: disabled. It can take 30 seconds to extract a video thumbnail on Pi,
   and it is not uncommon to crash with out of memory in this code.
Skip DVD intro: enabled. The DVD support on Pi is pretty poor and disabling the intro gives you a better chance of actually watching the movie.

Thanks to montellese for making this configuration so simple.
