### PR TITLE
[Fix] Airplay can work without airtunes server.

### DIFF
--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -215,15 +215,13 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
         return false;
       }
 
-      if (!StartAirTunesServer())
-      {
-        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(1274), "", g_localizeStrings.Get(33100), "");
-        return false;
-      }
+      StartAirTunesServer();
     }
     else
     {
-      if (!StopAirPlayServer(true) || !StopAirTunesServer(true))
+      bool ret = StopAirPlayServer(true);
+      StopAirTunesServer(true);
+      if (!ret)
         return false;
     }
   }


### PR DESCRIPTION
currently on my osx test build, airplay server can not be switched on and it report airtunes not start error. I checked the old code in CApplication, which does not check result from start/stop airtunes server, this PR fixed this.
