### PR TITLE
settings: add list control using CGUIDialogSelect

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -95,7 +95,7 @@
           <constraints>
             <options>languages</options>
           </constraints>
-          <control type="spinner" format="string" delayed="true" />
+          <control type="list" format="string" />
         </setting>
         <setting id="locale.country" type="string" label="20026" help="36115">
           <level>0</level>
@@ -106,7 +106,7 @@
           <dependencies>
             <dependency type="update" setting="locale.language" />
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
         <setting id="locale.charset" type="string" label="14091" help="36116">
           <level>1</level>
@@ -117,7 +117,7 @@
           <dependencies>
             <dependency type="update" setting="locale.language" />
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
       </group>
       <group id="2">
@@ -127,7 +127,7 @@
           <constraints>
             <options>timezonecountries</options>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
         <setting id="locale.timezone" type="string" label="14080" help="36118">
           <level>2</level>
@@ -138,7 +138,7 @@
           <dependencies>
             <dependency type="update" setting="locale.timezonecountry" />
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
       </group>
       <group id="4">
@@ -148,7 +148,7 @@
           <constraints>
             <options>streamlanguages</options>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
         <setting id="locale.subtitlelanguage" type="string" label="286" help="36120">
           <level>1</level>
@@ -156,7 +156,7 @@
           <constraints>
             <options>streamlanguages</options>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
       </group>
     </category>
@@ -659,7 +659,7 @@
           <dependencies>
             <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
         <setting id="subtitles.overrideassfonts" type="boolean" label="21368" help="36190">
           <level>1</level>
@@ -1492,7 +1492,7 @@
           <dependencies>
             <dependency type="enable" setting="karaoke.enabled">true</dependency>
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
       </group>
       <group id="3">
@@ -1858,7 +1858,7 @@
             <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
             <dependency type="update" setting="videoscreen.screen" />
           </dependencies>
-          <control type="spinner" format="string" delayed="true" />
+          <control type="list" format="string" />
         </setting>
         <setting id="videoscreen.screenmode" type="string" label="243" help="36353">
           <visible>IsStandAlone</visible>

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -705,7 +705,8 @@ bool CSettingNumber::Deserialize(const TiXmlNode *node, bool update /* = false *
   if (!CSetting::Deserialize(node, update))
     return false;
     
-  if (m_control.GetType() == SettingControlTypeCheckmark)
+  if (m_control.GetType() == SettingControlTypeCheckmark ||
+      m_control.GetType() == SettingControlTypeList)
   {
     CLog::Log(LOGERROR, "CSettingInt: invalid <control> of \"%s\"", m_id.c_str());
     return false;

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -79,6 +79,8 @@ bool CSettingControl::setType(const std::string &strType)
     m_type = SettingControlTypeEdit;
     m_delayed = true;
   }
+  else if (StringUtils::EqualsNoCase(strType, "list"))
+    m_type = SettingControlTypeList;
   else if (StringUtils::EqualsNoCase(strType, "button"))
     m_type = SettingControlTypeButton;
   else

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -28,6 +28,7 @@ typedef enum {
   SettingControlTypeCheckmark,
   SettingControlTypeSpinner,
   SettingControlTypeEdit,
+  SettingControlTypeList,
   SettingControlTypeButton
 } SettingControlType;
 

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -29,7 +29,11 @@ class CGUIButtonControl;
 class CGUIRadioButtonControl;
 
 class CSetting;
+class CSettingString;
 class CSettingPath;
+
+class CFileItemList;
+class CVariant;
 
 class CGUIControlBaseSetting
 {
@@ -107,6 +111,23 @@ private:
   void FillControl();
   void FillIntegerSettingControl();
   CGUISpinControlEx *m_pSpin;
+};
+
+class CGUIControlListSetting : public CGUIControlBaseSetting
+{
+public:
+  CGUIControlListSetting(CGUIButtonControl* pButton, int id, CSetting *pSetting);
+  virtual ~CGUIControlListSetting();
+
+  virtual CGUIControl* GetControl() { return (CGUIControl*)m_pButton; }
+  virtual bool OnClick();
+  virtual void Update();
+  virtual void Clear() { m_pButton = NULL; }
+private:
+  static bool GetItems(CSetting *setting, CFileItemList &items);
+  static bool GetIntegerItems(CSetting *setting, CFileItemList &items);
+
+  CGUIButtonControl *m_pButton;
 };
 
 class CGUIControlButtonSetting : public CGUIControlBaseSetting

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -643,6 +643,17 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
       break;
     }
     
+    case SettingControlTypeList:
+    {
+      pControl = new CGUIButtonControl(*m_pOriginalButton);
+      if (pControl == NULL)
+        return NULL;
+      
+      ((CGUIButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
+      pSettingControl.reset(new CGUIControlListSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
+      break;
+    }
+    
     case SettingControlTypeButton:
     {
       pControl = new CGUIButtonControl(*m_pOriginalButton);


### PR DESCRIPTION
These commits add a "list" control to the settings system which uses a CGUIDialogSelect dialog to show all the available options in a list. It should be a good alternative for a spinner if there are many options available.

I have changed the control type of a few settings from "spinner" to "list" but those are obviously open for discussion.

Here's a screenshot of how the list looks for the language setting:
![screenshot007](https://f.cloud.github.com/assets/75864/556203/4475e846-c3d3-11e2-98be-23f548d1ef47.png)
