### PR TITLE
[GUI/Player] Proper subtitle lang-name string for kai toast

### DIFF
--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -35,6 +35,7 @@
 #include "cores/VideoRenderers/RenderManager.h"
 #endif
 #include "Application.h"
+#include "utils/LangCodeExpander.h"
 
 CPlayerController::CPlayerController()
 {
@@ -64,9 +65,13 @@ bool CPlayerController::OnAction(const CAction &action)
       {
         SPlayerSubtitleStreamInfo info;
         g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
-        sub = info.name;
-        if (sub != info.language)
-          sub.Format("%s [%s]", sub.c_str(), info.language.c_str());
+        if (!g_LangCodeExpander.Lookup(lang, info.language))
+          lang = g_localizeStrings.Get(13205); // Unknown
+
+        if (info.name.length() == 0)
+          sub = lang;
+        else
+          sub.Format("%s - %s", lang.c_str(), info.name.c_str());
       }
       else
         sub = g_localizeStrings.Get(1223);
@@ -105,9 +110,13 @@ bool CPlayerController::OnAction(const CAction &action)
       {
         SPlayerSubtitleStreamInfo info;
         g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
-        sub = info.name;
-        if (sub != info.language)
-          sub.Format("%s [%s]", sub.c_str(), info.language.c_str());
+        if (!g_LangCodeExpander.Lookup(lang, info.language))
+          lang = g_localizeStrings.Get(13205); // Unknown
+
+        if (info.name.length() == 0)
+          sub = lang;
+        else
+          sub.Format("%s - %s", lang.c_str(), info.name.c_str());
       }
       else
         sub = g_localizeStrings.Get(1223);


### PR DESCRIPTION
Generate a proper subtitle lang-name string for presentation in the osd.
The format of the displayed subtitle string is same as in the settings dialogue.
Thanks @mikkle for the impulse ;)
