### PR TITLE
settings: fix videoscreen setting changing once and for all

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1856,6 +1856,7 @@
           <dependencies>
             <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
             <dependency type="update" setting="videoscreen.screen" />
+            <dependency type="update" setting="videoscreen.screenmode" />
           </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -424,6 +424,33 @@ DisplayMode CDisplaySettings::GetCurrentDisplayMode() const
   return GetCurrentResolutionInfo().iScreen;
 }
 
+RESOLUTION CDisplaySettings::FindBestMatchingResolution(const std::map<RESOLUTION, RESOLUTION_INFO> &resolutionInfos, int screen, int width, int height, float refreshrate, bool interlaced)
+{
+  int interlace = interlaced ? 100 : 200;
+
+  // find the closest match to these in our res vector.  If we have the screen, we score the res
+  RESOLUTION bestRes = RES_DESKTOP;
+  float bestScore = FLT_MAX;
+
+  for (std::map<RESOLUTION, RESOLUTION_INFO>::const_iterator it = resolutionInfos.begin(); it != resolutionInfos.end(); ++it)
+  {
+    const RESOLUTION_INFO &info = it->second;
+    if (info.iScreen != screen)
+      continue;
+    float score = 10 * (square_error((float)info.iScreenWidth, (float)width) +
+                  square_error((float)info.iScreenHeight, (float)height) +
+                  square_error(info.fRefreshRate, refreshrate) +
+                  square_error((float)((info.dwFlags & D3DPRESENTFLAG_INTERLACED) ? 100 : 200), (float)interlace));
+    if (score < bestScore)
+    {
+      bestScore = score;
+      bestRes = it->first;
+    }
+  }
+
+  return bestRes;
+}
+
 RESOLUTION CDisplaySettings::GetResolutionFromString(const std::string &strResolution)
 {
   if (strResolution == "DESKTOP")
@@ -439,28 +466,13 @@ RESOLUTION CDisplaySettings::GetResolutionFromString(const std::string &strResol
     float refresh = (float)strtod(StringUtils::Mid(strResolution, 11,9).c_str(), NULL);
     // look for 'i' and treat everything else as progressive,
     // and use 100/200 to get a nice square_error.
-    int interlaced = (StringUtils::Right(strResolution, 1) == "i") ? 100 : 200;
+    bool interlaced = StringUtils::EndsWith(strResolution, "i");
 
-    // find the closest match to these in our res vector.  If we have the screen, we score the res
-    RESOLUTION bestRes = RES_DESKTOP;
-    float bestScore = FLT_MAX;
-    
-    for (size_t resolution = 0; resolution < CDisplaySettings::Get().ResolutionInfoSize(); resolution++)
-    {
-      const RESOLUTION_INFO &info = CDisplaySettings::Get().GetResolutionInfo(resolution);
-      if (info.iScreen != screen)
-        continue;
-      float score = 10 * (square_error((float)info.iScreenWidth, (float)width) +
-                    square_error((float)info.iScreenHeight, (float)height) +
-                    square_error(info.fRefreshRate, refresh) +
-                    square_error((float)((info.dwFlags & D3DPRESENTFLAG_INTERLACED) ? 100 : 200), (float)interlaced));
-      if (score < bestScore)
-      {
-        bestScore = score;
-        bestRes = (RESOLUTION)resolution;
-      }
-    }
-    return bestRes;
+    std::map<RESOLUTION, RESOLUTION_INFO> resolutionInfos;
+    for (size_t resolution = RES_DESKTOP; resolution < CDisplaySettings::Get().ResolutionInfoSize(); resolution++)
+      resolutionInfos.insert(make_pair((RESOLUTION)resolution, CDisplaySettings::Get().GetResolutionInfo(resolution)));
+
+    return FindBestMatchingResolution(resolutionInfos, screen, width, height, refresh, interlaced);
   }
 
   return RES_DESKTOP;
@@ -471,13 +483,17 @@ std::string CDisplaySettings::GetStringFromResolution(RESOLUTION resolution, flo
   if (resolution == RES_WINDOW)
     return "WINDOW";
 
-  if (resolution >= RES_CUSTOM && resolution < (RESOLUTION)CDisplaySettings::Get().ResolutionInfoSize())
+  if (resolution >= RES_DESKTOP && resolution < (RESOLUTION)CDisplaySettings::Get().ResolutionInfoSize())
   {
     const RESOLUTION_INFO &info = CDisplaySettings::Get().GetResolutionInfo(resolution);
-    return StringUtils::Format("%1i%05i%05i%09.5f%s", info.iScreen,
-                               info.iScreenWidth, info.iScreenHeight,
-                               refreshrate > 0.0f ? refreshrate : info.fRefreshRate,
-                               (info.dwFlags & D3DPRESENTFLAG_INTERLACED) ? "i":"p");
+    // also handle RES_DESKTOP resolutions with non-default refresh rates
+    if (resolution != RES_DESKTOP || (refreshrate > 0.0f && refreshrate != info.fRefreshRate))
+    {
+      return StringUtils::Format("%1i%05i%05i%09.5f%s", info.iScreen,
+                                 info.iScreenWidth, info.iScreenHeight,
+                                 refreshrate > 0.0f ? refreshrate : info.fRefreshRate,
+                                 (info.dwFlags & D3DPRESENTFLAG_INTERLACED) ? "i":"p");
+    }
   }
 
   return "DESKTOP";
@@ -509,7 +525,7 @@ void CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller(const CSetting *s
 void CDisplaySettings::SettingOptionsRefreshRatesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
 {
   // get the proper resolution
-  RESOLUTION res = GetResolutionForScreen();
+  RESOLUTION res = CDisplaySettings::Get().GetDisplayResolution();
   if (res < RES_WINDOW)
     return;
 
@@ -521,55 +537,50 @@ void CDisplaySettings::SettingOptionsRefreshRatesFiller(const CSetting *setting,
     return;
   }
 
+  RESOLUTION_INFO resInfo = CDisplaySettings::Get().GetResolutionInfo(res);
   // The only meaningful parts of res here are iScreen, iScreenWidth, iScreenHeight
-  vector<REFRESHRATE> refreshrates = g_Windowing.RefreshRates(CDisplaySettings::Get().GetResolutionInfo(res).iScreen,
-                                                              CDisplaySettings::Get().GetResolutionInfo(res).iScreenWidth,
-                                                              CDisplaySettings::Get().GetResolutionInfo(res).iScreenHeight,
-                                                              CDisplaySettings::Get().GetResolutionInfo(res).dwFlags);
+  vector<REFRESHRATE> refreshrates = g_Windowing.RefreshRates(resInfo.iScreen, resInfo.iScreenWidth, resInfo.iScreenHeight, resInfo.dwFlags);
 
   bool match = false;
   for (vector<REFRESHRATE>::const_iterator refreshrate = refreshrates.begin(); refreshrate != refreshrates.end(); refreshrate++)
   {
-    std::string screenmode = GetStringFromResolution(res, refreshrate->RefreshRate);
+    std::string screenmode = GetStringFromResolution((RESOLUTION)refreshrate->ResInfo_Index, refreshrate->RefreshRate);
     if (!match && StringUtils::EqualsNoCase(((CSettingString*)setting)->GetValue(), screenmode))
       match = true;
     list.push_back(make_pair(StringUtils::Format("%.02f", refreshrate->RefreshRate), screenmode));
   }
 
   if (!match)
-    current = GetStringFromResolution(res, g_Windowing.DefaultRefreshRate(CDisplaySettings::Get().GetResolutionInfo(res).iScreen, refreshrates).RefreshRate);
+    current = GetStringFromResolution(res, g_Windowing.DefaultRefreshRate(resInfo.iScreen, refreshrates).RefreshRate);
 }
 
 void CDisplaySettings::SettingOptionsResolutionsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current)
 {
-  RESOLUTION res = RES_INVALID;
-  DisplayMode screen = CSettings::Get().GetInt("videoscreen.screen");
-  if (screen == DM_WINDOWED)
+  RESOLUTION res = CDisplaySettings::Get().GetDisplayResolution();
+  RESOLUTION_INFO info = CDisplaySettings::Get().GetResolutionInfo(res);
+  if (res == RES_WINDOW)
   {
-    res = RES_WINDOW;
-    list.push_back(make_pair(g_localizeStrings.Get(242), RES_WINDOW));
+    current = res;
+    list.push_back(make_pair(g_localizeStrings.Get(242), res));
   }
   else
   {
-    vector<RESOLUTION_WHR> resolutions = g_Windowing.ScreenResolutions(screen);
+    std::map<RESOLUTION, RESOLUTION_INFO> resolutionInfos;
+    vector<RESOLUTION_WHR> resolutions = g_Windowing.ScreenResolutions(info.iScreen, info.fRefreshRate);
     for (vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); resolution++)
     {
       list.push_back(make_pair(
-        StringUtils::Format("%dx%d%s", resolution->width, resolution->height, (resolution->interlaced == D3DPRESENTFLAG_INTERLACED) ? "i" : "p"),
-        resolution->ResInfo_Index));
+        StringUtils::Format("%dx%d%s", resolution->width, resolution->height,
+                            (resolution->interlaced == D3DPRESENTFLAG_INTERLACED) ? "i" : "p"),
+                            resolution->ResInfo_Index));
 
-      RESOLUTION_INFO res1 = CDisplaySettings::Get().GetCurrentResolutionInfo();
-      RESOLUTION_INFO res2 = CDisplaySettings::Get().GetResolutionInfo(resolution->ResInfo_Index);
-      if (res1.iScreen == res2.iScreen &&
-          res1.iScreenWidth  == res2.iScreenWidth &&
-          res1.iScreenHeight == res2.iScreenHeight &&
-          (res1.dwFlags & D3DPRESENTFLAG_INTERLACED) == (res2.dwFlags & D3DPRESENTFLAG_INTERLACED))
-        res = (RESOLUTION)resolution->ResInfo_Index;
+      resolutionInfos.insert(make_pair((RESOLUTION)resolution->ResInfo_Index, CDisplaySettings::Get().GetResolutionInfo(resolution->ResInfo_Index)));
     }
-  }
 
-  if (res != RES_INVALID)
-    current = res;
+    current = FindBestMatchingResolution(resolutionInfos, info.iScreen,
+                                         info.iScreenWidth, info.iScreenHeight,
+                                         info.fRefreshRate, info.dwFlags & D3DPRESENTFLAG_INTERLACED);
+  }
 }
 
 void CDisplaySettings::SettingOptionsScreensFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current)
@@ -584,7 +595,6 @@ void CDisplaySettings::SettingOptionsScreensFiller(const CSetting *setting, std:
   }
 
   RESOLUTION res = CDisplaySettings::Get().GetDisplayResolution();
-
   if (res == RES_WINDOW)
     current = DM_WINDOWED;
   else

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <map>
 #include <set>
 #include <vector>
 
@@ -104,6 +105,8 @@ protected:
   static RESOLUTION GetResolutionFromString(const std::string &strResolution);
   static std::string GetStringFromResolution(RESOLUTION resolution, float refreshrate = 0.0f);
   static RESOLUTION GetResolutionForScreen();
+
+  static RESOLUTION FindBestMatchingResolution(const std::map<RESOLUTION, RESOLUTION_INFO> &resolutionInfos, int screen, int width, int height, float refreshrate, bool interlaced);
 
 private:
   // holds the real gui resolution

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -121,13 +121,6 @@ private:
   float m_verticalShift;      // current vertical shift
   bool  m_nonLinearStretched;   // current non-linear stretch
 
-  /*!
-   \brief A set of pairs consisting of a setting identifier
-   and a boolean value which should be ignored in specific
-   situations. If the boolean value is "true" the whole
-   OnSettingChanging() logic must be skipped once. If it
-   is "false" only showing the GUI dialog must be skipped.
-   */
-  std::set< std::pair<std::string, bool> > m_ignoreSettingChanging;
+  bool m_resolutionChangeAborted;
   CCriticalSection m_critical;
 };

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -112,17 +112,28 @@ int CWinSystemBase::DesktopResolution(int screen)
   return RES_DESKTOP;
 }
 
-static void AddResolution(vector<RESOLUTION_WHR> &resolutions, unsigned int addindex)
+static void AddResolution(vector<RESOLUTION_WHR> &resolutions, unsigned int addindex, float bestRefreshrate)
 {
-  int width  = CDisplaySettings::Get().GetResolutionInfo(addindex).iScreenWidth;
-  int height = CDisplaySettings::Get().GetResolutionInfo(addindex).iScreenHeight;
-  int interlaced = CDisplaySettings::Get().GetResolutionInfo(addindex).dwFlags & D3DPRESENTFLAG_INTERLACED;
+  RESOLUTION_INFO resInfo = CDisplaySettings::Get().GetResolutionInfo(addindex);
+  int width  = resInfo.iScreenWidth;
+  int height = resInfo.iScreenHeight;
+  int interlaced = resInfo.dwFlags & D3DPRESENTFLAG_INTERLACED;
+  float refreshrate = resInfo.fRefreshRate;
 
   for (unsigned int idx = 0; idx < resolutions.size(); idx++)
     if (   resolutions[idx].width == width
         && resolutions[idx].height == height
         && resolutions[idx].interlaced == interlaced)
-      return; // already taken care of.
+    {
+      // check if the refresh rate of this resolution is better suited than
+      // the refresh rate of the resolution with the same width/height/interlaced
+      // property and if so replace it
+      if (bestRefreshrate > 0.0 && refreshrate == bestRefreshrate)
+        resolutions[idx].ResInfo_Index = addindex;
+
+      // no need to add the resolution again
+      return;
+    }
 
   RESOLUTION_WHR res = {width, height, interlaced, (int)addindex};
   resolutions.push_back(res);
@@ -135,13 +146,16 @@ static bool resSortPredicate(RESOLUTION_WHR i, RESOLUTION_WHR j)
           || (i.width == j.width && i.height == j.height && i.interlaced != j.interlaced) );
 }
 
-vector<RESOLUTION_WHR> CWinSystemBase::ScreenResolutions(int screen)
+vector<RESOLUTION_WHR> CWinSystemBase::ScreenResolutions(int screen, float refreshrate)
 {
   vector<RESOLUTION_WHR> resolutions;
 
   for (unsigned int idx = RES_DESKTOP; idx < CDisplaySettings::Get().ResolutionInfoSize(); idx++)
-    if (CDisplaySettings::Get().GetResolutionInfo(idx).iScreen == screen)
-      AddResolution(resolutions, idx);
+  {
+    RESOLUTION_INFO info = CDisplaySettings::Get().GetResolutionInfo(idx);
+    if (info.iScreen == screen)
+      AddResolution(resolutions, idx, refreshrate);
+  }
 
   // Can't assume a sort order
   sort(resolutions.begin(), resolutions.end(), resSortPredicate);

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -100,7 +100,7 @@ public:
   virtual void UpdateResolutions();
   void SetWindowResolution(int width, int height);
   int DesktopResolution(int screen);
-  std::vector<RESOLUTION_WHR> ScreenResolutions(int screen);
+  std::vector<RESOLUTION_WHR> ScreenResolutions(int screen, float refreshrate);
   std::vector<REFRESHRATE> RefreshRates(int screen, int width, int height, uint32_t dwFlags);
   REFRESHRATE DefaultRefreshRate(int screen, std::vector<REFRESHRATE> rates);
 


### PR DESCRIPTION
This should be the final fix for the dreaded videoscreen setting changes which are/were a complete mess because they all influence each other. But, as always, in the end the solution was much simpler than expected. Instead of trying to equally handle changes to videoscreen.screen/resolution/screenmode we now only really change the display configuration when videoscreen.screenmode is changed. This is the one that is used throughout the rest of the xbmc code and the other two are just there to show them as GUI settings and changing them will always result in changing videoscreen.screenmode. That also greatly simplifies the problem of not really knowing when to show the "Would you like to keep this resolution?" prompt.

@FernetMenta: With this changing refreshrates should finally be fixed as well.
