### PR TITLE
[CueDocument] Cosmetic: Change the log string to a more meaningful one

### DIFF
--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -106,7 +106,7 @@ bool CCueDocument::Parse(const CStdString &strFile)
     {
       if (bCurrentFileChanged)
       {
-        OutputDebugString("Track split over multiple files, unsupported");
+        OutputDebugString("Track split over multiple files, unsupported ('" + strFile + "')\n");
         return false;
       }
 
@@ -377,7 +377,7 @@ bool CCueDocument::ResolvePath(CStdString &strPath, const CStdString &strBase)
         return true;
       }
     }
-    CLog::Log(LOGERROR,"Could not find FILE referenced in cue, case sensitivity issue?");
+    CLog::Log(LOGERROR,"Could not find '%s' referenced in cue, case sensitivity issue?", strPath);
     return false;
   }
 


### PR DESCRIPTION
This may lead to a performance drawback because "Previous line repeats x times" can't be used anymore. On the other hand the erroneous files are reported.
