### PR TITLE
Softae locking fixup

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -774,7 +774,7 @@ IAEStream *CSoftAE::MakeStream(enum AEDataFormat dataFormat, unsigned int sample
     ASSERT(encodedSampleRate);
 
   CSingleLock streamLock(m_streamLock);
-  CSoftAEStream *stream = new CSoftAEStream(dataFormat, sampleRate, encodedSampleRate, channelLayout, options);
+  CSoftAEStream *stream = new CSoftAEStream(dataFormat, sampleRate, encodedSampleRate, channelLayout, options, m_streamLock);
   m_newStreams.push_back(stream);
   streamLock.Leave();
   // this is really needed here

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -650,7 +650,9 @@ void CSoftAE::Deinitialize()
     delete m_thread;
     m_thread = NULL;
   }
+  lock.Leave();
 
+  CExclusiveLock sinkLock(m_sinkLock);
   if (m_sink)
   {
     /* shutdown the sink */

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -1219,7 +1219,7 @@ unsigned int CSoftAE::WriteSink(CAEBuffer& src, int src_len, uint8_t *data, bool
   CExclusiveLock lock(m_sinkLock); /* lock to maintain delay consistency */
 
   XbmcThreads::EndTime timeout(m_sinkBlockTime * 2);
-  while(m_sink)
+  while(m_sink && src.Used() >= src_len)
   {
     int frames = m_sink->AddPackets(data, m_sinkFormat.m_frames, hasAudio);
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -1212,7 +1212,7 @@ bool CSoftAE::FinalizeSamples(float *buffer, unsigned int samples, bool hasAudio
   return true;
 }
 
-unsigned int CSoftAE::WriteSink(CAEBuffer& src, uint8_t *data, bool hasAudio)
+unsigned int CSoftAE::WriteSink(CAEBuffer& src, int src_len, uint8_t *data, bool hasAudio)
 {
   CExclusiveLock lock(m_sinkLock); /* lock to maintain delay consistency */
   while(m_sink)
@@ -1229,7 +1229,7 @@ unsigned int CSoftAE::WriteSink(CAEBuffer& src, uint8_t *data, bool hasAudio)
 
     if (frames)
     {
-      m_buffer.Shift(NULL, frames * m_sinkFormat.m_frameSize);
+      m_buffer.Shift(NULL, src_len);
       return frames;
     }
 
@@ -1259,7 +1259,7 @@ int CSoftAE::RunOutputStage(bool hasAudio)
     data = m_converted;
   }
 
-  return WriteSink(m_buffer, (uint8_t*)data, hasAudio);
+  return WriteSink(m_buffer, needBytes, (uint8_t*)data, hasAudio);
 }
 
 int CSoftAE::RunRawOutputStage(bool hasAudio)
@@ -1287,7 +1287,7 @@ int CSoftAE::RunRawOutputStage(bool hasAudio)
     data = m_converted;
   }
 
-  return WriteSink(m_buffer, (uint8_t*)data, hasAudio);
+  return WriteSink(m_buffer, m_sinkBlockSize, (uint8_t*)data, hasAudio);
 }
 
 int CSoftAE::RunTranscodeStage(bool hasAudio)
@@ -1333,7 +1333,7 @@ int CSoftAE::RunTranscodeStage(bool hasAudio)
 
   /* if we have enough data to write */
   if (m_encodedBuffer.Used() >= sinkBlock)
-    WriteSink(m_encodedBuffer, (uint8_t*)m_encodedBuffer.Raw(sinkBlock), hasAudio);
+    WriteSink(m_encodedBuffer, sinkBlock, (uint8_t*)m_encodedBuffer.Raw(sinkBlock), hasAudio);
 
   return encodedFrames;
 }

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -247,6 +247,6 @@ private:
   void         RemoveStream(StreamList &streams, CSoftAEStream *stream);
   void         PrintSinks();
 
-  unsigned int WriteSink(CAEBuffer& src, uint8_t *data, bool hasAudio);
+  unsigned int WriteSink(CAEBuffer& src, int src_len, uint8_t *data, bool hasAudio);
 };
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -246,5 +246,7 @@ private:
 
   void         RemoveStream(StreamList &streams, CSoftAEStream *stream);
   void         PrintSinks();
+
+  unsigned int WriteSink(CAEBuffer& src, uint8_t *data, bool hasAudio);
 };
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -165,6 +165,7 @@ private:
   double                    m_sinkFormatSampleRateMul;
   double                    m_sinkFormatFrameSizeMul;
   unsigned int              m_sinkBlockSize;
+  unsigned int              m_sinkBlockTime;
   bool                      m_sinkHandlesVolume;
   AEAudioFormat             m_encoderFormat;
   double                    m_encoderFrameSizeMul;

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
@@ -36,7 +36,7 @@ class CSoftAEStream : public IAEStream
 {
 protected:
   friend class CSoftAE;
-  CSoftAEStream(enum AEDataFormat format, unsigned int sampleRate, unsigned int encodedSamplerate, CAEChannelInfo channelLayout, unsigned int options);
+  CSoftAEStream(enum AEDataFormat format, unsigned int sampleRate, unsigned int encodedSamplerate, CAEChannelInfo channelLayout, unsigned int options, CCriticalSection& lock);
   virtual ~CSoftAEStream();
 
   void Initialize();
@@ -91,7 +91,7 @@ private:
   void InternalFlush();
   void CheckResampleBuffers();
 
-  CSharedSection    m_lock;
+  CCriticalSection& m_lock;
   enum AEDataFormat m_initDataFormat;
   unsigned int      m_initSampleRate;
   unsigned int      m_initEncodedSampleRate;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -517,11 +517,7 @@ unsigned int CAESinkALSA::AddPackets(uint8_t *data, unsigned int frames, bool ha
   }
 
   if ((unsigned int)ret < frames)
-  {
-    ret = snd_pcm_wait(m_pcm, m_timeout);
-    if (ret < 0)
-      HandleError("snd_pcm_wait", ret);
-  }
+    return 0;
 
   ret = snd_pcm_writei(m_pcm, (void*)data, frames);
   if (ret < 0)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -240,10 +240,6 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t *data, unsigned int frames, b
         break;
     }
   }
-  // AddPackets runs under a non-idled AE thread we must block or sleep.
-  // Trying to calc the optimal sleep is tricky so just a minimal sleep.
-  Sleep(10);
-
   return hasAudio ? write_frames:frames;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -388,7 +388,8 @@ unsigned int CAESinkDirectSound::AddPackets(uint8_t *data, unsigned int frames, 
   {
     if (m_isDirtyDS)
       return INT_MAX;
-    Sleep(total * 1000 / m_AvgBytesPerSec);
+    else
+      return 0;
   }
 
   while (len)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
@@ -110,9 +110,6 @@ unsigned int CAESinkNULL::AddPackets(uint8_t *data, unsigned int frames, bool ha
     m_sinkbuffer_level += frames * m_sink_frameSize;
     m_wake.Set();
   }
-  // AddPackets runs under a non-idled AE thread we must block or sleep.
-  // Trying to calc the optimal sleep is tricky so just a minimal sleep.
-  Sleep(10);
 
   return frames;
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -488,22 +488,10 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t *data, unsigned int frames, bool 
 #endif
 
   /* Wait for Audio Driver to tell us it's got a buffer available */
-  DWORD eventAudioCallback = WaitForSingleObject(m_needDataEvent, 1100);
+  DWORD eventAudioCallback = WaitForSingleObject(m_needDataEvent, 0);
 
-  if (eventAudioCallback != WAIT_OBJECT_0 || !&buf)
-  {
-    /* Event handle timed out - flag sink as dirty for re-initializing */
-    CLog::Log(LOGERROR, __FUNCTION__": Endpoint Buffer timed out");
-    if (g_advancedSettings.m_streamSilence)
-    {
-      m_isDirty = true; //flag new device or re-init needed
-      Deinitialize();
-      m_running = false;
-      return INT_MAX;
-    }
-    m_running = false;
+  if (eventAudioCallback != WAIT_OBJECT_0)
     return 0;
-  }
 
   if (!m_running)
     return 0;


### PR DESCRIPTION
Some commits to try to fixup some of the race conditions in SoftAE.

Note: The windows sinks (WASAPI/DirectSound) have invalid ::GetDelay() functions. Thus they will still cause large delay fluctuations.
