### PR TITLE
[nfs] bump to libnfs 1.6

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -9,7 +9,7 @@ dnssd-379.32.1-win32.7z
 doxygen-1.8.2-win32
 lame_enc-3.99.5-win32.7z
 libbluray-0.2.3-win32
-libnfs-1.3.0-win32
+libnfs-1.6.0-win32
 libshairplay-c159ca7-win32
 libjpeg-turbo-1.2.0-win32
 sqlite-3.7.16.1-win32

--- a/project/BuildDependencies/scripts/libnfs_d.bat
+++ b/project/BuildDependencies/scripts/libnfs_d.bat
@@ -7,7 +7,7 @@ CALL dlextract.bat libnfs %FILES%
 
 cd %TMP_PATH%
 
-xcopy libnfs-1.3.0-win32\project\BuildDependencies\include\* "%CUR_PATH%\include\" /E /Q /I /Y
-copy libnfs-1.3.0-win32\system\libnfs.dll "%XBMC_PATH%\system\" /Y
+xcopy libnfs-1.6.0-win32\project\BuildDependencies\include\* "%CUR_PATH%\include\" /E /Q /I /Y
+copy libnfs-1.6.0-win32\system\libnfs.dll "%XBMC_PATH%\system\" /Y
 
 cd %LOC_PATH%

--- a/project/BuildDependencies/scripts/libnfs_d.txt
+++ b/project/BuildDependencies/scripts/libnfs_d.txt
@@ -1,2 +1,2 @@
 ; filename                          source of the file
-libnfs-1.3.0-win32.7z            http://mirrors.xbmc.org/build-deps/win32/
+libnfs-1.6.0-win32.7z            http://mirrors.xbmc.org/build-deps/win32/

--- a/tools/depends/target/libnfs/Makefile
+++ b/tools/depends/target/libnfs/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libnfs
-VERSION=1.5.0
+VERSION=1.6.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
@@ -33,7 +33,7 @@ $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM) install
 ifeq ($(OS),android)
 	rm -f $(PREFIX)/lib/libnfs.la $(PREFIX)/lib/libnfs.so $(PREFIX)/lib/libnfs.so.1
-	mv -f $(PREFIX)/lib/libnfs.so.1.0.5 $(PREFIX)/lib/libnfs.so
+	mv -f $(PREFIX)/lib/libnfs.so.1.0.6 $(PREFIX)/lib/libnfs.so
 	$(RPL) -e "libnfs.so.1" "libnfs.so\x00\x00" $(PREFIX)/lib/libnfs.so
 	-$(READELF) --dynamic $(PREFIX)/lib/libnfs.so | grep ibrary
 endif

--- a/tools/depends/target/libnfs/timeval.patch
+++ b/tools/depends/target/libnfs/timeval.patch
@@ -1,11 +1,14 @@
---- include/nfsc/libnfs.h	2012-12-03 09:38:18.000000000 -0500
-+++ include/nfsc/libnfs.h	2013-01-17 23:04:35.000000000 -0500
-@@ -18,9 +18,7 @@
+--- include/nfsc/libnfs.h.orig	2013-05-28 21:59:32.000000000 +0200
++++ include/nfsc/libnfs.h	2013-05-28 21:59:56.000000000 +0200
+@@ -18,12 +18,7 @@
   * This is the highlevel interface to access NFS resources using a posix-like interface
   */
  #include <stdint.h>
 -#if defined(ANDROID)
  #include <sys/time.h>
+-#endif
+-#if defined(AROS)
+-#include <sys/time.h>
 -#endif
  
  struct nfs_context;

--- a/tools/rbp/depends/libnfs/Makefile
+++ b/tools/rbp/depends/libnfs/Makefile
@@ -3,7 +3,7 @@ include ../depends.mk
 
 # lib name, version
 LIBNAME=libnfs
-VERSION=1.3.0
+VERSION=1.6.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
@@ -24,6 +24,7 @@ $(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
 	$(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	echo $(SOURCE) > .gitignore
 	cd $(SOURCE); ./bootstrap
+	cd $(SOURCE); patch -p0 < ../timeval.patch
 	cd $(SOURCE); $(CONFIGURE)
 
 $(SO_NAME): $(SOURCE)

--- a/tools/rbp/depends/libnfs/timeval.patch
+++ b/tools/rbp/depends/libnfs/timeval.patch
@@ -1,0 +1,15 @@
+--- include/nfsc/libnfs.h.orig	2013-05-28 21:59:32.000000000 +0200
++++ include/nfsc/libnfs.h	2013-05-28 21:59:56.000000000 +0200
+@@ -18,12 +18,7 @@
+  * This is the highlevel interface to access NFS resources using a posix-like interface
+  */
+ #include <stdint.h>
+-#if defined(ANDROID)
+ #include <sys/time.h>
+-#endif
+-#if defined(AROS)
+-#include <sys/time.h>
+-#endif
+ 
+ struct nfs_context;
+ struct rpc_context;


### PR DESCRIPTION
Fixes issues with updated kernel nfs server where gid = -1 is invalid as of now. This affects ios/atv2/osx/android/linux (in ppa the version bump was already done).

@gimli could you test compile it for rbpi please? Also how much work would it be to get rid of tools/rbpi/depends and use unified depends for rbpi aswell?

libnfs 1.6 bump for windows will be seperate since it first needs upstream compilation fixing.
