### PR TITLE
DVDAudioCodecFFmpeg: Make sure swr resampler gets reinited when channel count changes

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -192,7 +192,7 @@ void CDVDAudioCodecFFmpeg::ConvertToFloat()
 {
   if(m_pCodecContext->sample_fmt != AV_SAMPLE_FMT_FLT && m_iBufferSize1 > 0)
   {
-    if(m_pConvert && m_pCodecContext->sample_fmt != m_iSampleFormat)
+    if(m_pConvert && (m_pCodecContext->sample_fmt != m_iSampleFormat || m_channels != m_pCodecContext->channels))
       m_dllSwResample.swr_free(&m_pConvert);
 
     if(!m_pConvert)


### PR DESCRIPTION
This fixes playback of this sample: http://skyboo.net/xbmc/sample.ts (with AC3 passthrough disabled)
