### PR TITLE
settings: initialization fixes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -341,10 +341,6 @@
 #include "android/activity/XBMCApp.h"
 #endif
 
-#ifdef TARGET_LINUX
-#include "linux/LinuxTimezone.h"
-#endif
-
 #ifdef TARGET_WINDOWS
 #include "utils/Environment.h"
 #endif

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -250,8 +250,6 @@ bool CSettings::Initialize()
   if (!InitializeDefinitions())
     return false;
 
-  InitializeVisibility();
-  InitializeDefaults();
   m_settingsManager->SetInitialized();
 
   InitializeISettingsHandlers();  
@@ -562,6 +560,12 @@ bool CSettings::InitializeDefinitions()
 #endif
 #endif
 #endif
+
+  // load any custom visibility and default values before loading the special
+  // appliance.xml so that appliances are able to overwrite even those values
+  InitializeVisibility();
+  InitializeDefaults();
+
   if (CFile::Exists(SETTINGS_XML_FOLDER "appliance.xml") && !Initialize(SETTINGS_XML_FOLDER "appliance.xml"))
     CLog::Log(LOGFATAL, "Unable to load appliance-specific settings definitions");
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -535,9 +535,6 @@ bool CSettings::InitializeDefinitions()
 #if defined(TARGET_WINDOWS)
   if (CFile::Exists(SETTINGS_XML_FOLDER "win32.xml") && !Initialize(SETTINGS_XML_FOLDER "win32.xml"))
     CLog::Log(LOGFATAL, "Unable to load win32-specific settings definitions");
-#elif defined(TARGET_LINUX)
-  if (CFile::Exists(SETTINGS_XML_FOLDER "linux.xml") && !Initialize(SETTINGS_XML_FOLDER "linux.xml"))
-    CLog::Log(LOGFATAL, "Unable to load linux-specific settings definitions");
 #elif defined(TARGET_ANDROID)
   if (CFile::Exists(SETTINGS_XML_FOLDER "android.xml") && !Initialize(SETTINGS_XML_FOLDER "android.xml"))
     CLog::Log(LOGFATAL, "Unable to load android-specific settings definitions");
@@ -547,6 +544,9 @@ bool CSettings::InitializeDefinitions()
 #elif defined(TARGET_FREEBSD)
   if (CFile::Exists(SETTINGS_XML_FOLDER "freebsd.xml") && !Initialize(SETTINGS_XML_FOLDER "freebsd.xml"))
     CLog::Log(LOGFATAL, "Unable to load freebsd-specific settings definitions");
+#elif defined(TARGET_LINUX)
+  if (CFile::Exists(SETTINGS_XML_FOLDER "linux.xml") && !Initialize(SETTINGS_XML_FOLDER "linux.xml"))
+    CLog::Log(LOGFATAL, "Unable to load linux-specific settings definitions");
 #elif defined(TARGET_DARWIN)
   if (CFile::Exists(SETTINGS_XML_FOLDER "darwin.xml") && !Initialize(SETTINGS_XML_FOLDER "darwin.xml"))
     CLog::Log(LOGFATAL, "Unable to load darwin-specific settings definitions");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -45,9 +45,9 @@
 #elif defined(HAS_SDL_JOYSTICK)
 #include "input/SDLJoystick.h"
 #endif // defined(HAS_SDL_JOYSTICK)
-#if defined(TARGET_LINUX)
+#if defined(_LINUX)
 #include "linux/LinuxTimezone.h"
-#endif // defined(TARGET_LINUX)
+#endif // defined(_LINUX)
 #include "network/NetworkServices.h"
 #include "network/upnp/UPnPSettings.h"
 #include "network/WakeOnAccess.h"
@@ -578,24 +578,15 @@ void CSettings::InitializeSettingTypes()
 void CSettings::InitializeVisibility()
 {
   // hide some settings if necessary
-#if defined(TARGET_LINUX) || defined(TARGET_DARWIN)
+#if defined(TARGET_DARWIN)
   CSettingString* timezonecountry = (CSettingString*)m_settingsManager->GetSetting("locale.timezonecountry");
   CSettingString* timezone = (CSettingString*)m_settingsManager->GetSetting("locale.timezone");
 
-#if defined(TARGET_DARWIN)
   if (!g_sysinfo.IsAppleTV2() || GetIOSVersion() >= 4.3)
   {
     timezonecountry->SetVisible(false);
     timezone->SetVisible(false);
   }
-#endif
- 
-#if defined(TARGET_LINUX)
-  if (timezonecountry->IsVisible())
-    timezonecountry->SetDefault(g_timezone.GetCountryByTimezone(g_timezone.GetOSConfiguredTimezone()));
-  if (timezone->IsVisible())
-    timezone->SetDefault(g_timezone.GetOSConfiguredTimezone());
-#endif
 #endif
 }
 
@@ -605,6 +596,16 @@ void CSettings::InitializeDefaults()
 #if defined(HAS_SKIN_TOUCHED) && defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV2)
   ((CSettingAddon*)m_settingsManager->GetSetting("lookandfeel.skin"))->SetDefault("skin.touched");
 #endif
+
+#if defined(_LINUX)
+  CSettingString* timezonecountry = (CSettingString*)m_settingsManager->GetSetting("locale.timezonecountry");
+  CSettingString* timezone = (CSettingString*)m_settingsManager->GetSetting("locale.timezone");
+
+  if (timezonecountry->IsVisible())
+    timezonecountry->SetDefault(g_timezone.GetCountryByTimezone(g_timezone.GetOSConfiguredTimezone()));
+  if (timezone->IsVisible())
+    timezone->SetDefault(g_timezone.GetOSConfiguredTimezone());
+#endif // defined(_LINUX)
 
 #if defined(TARGET_WINDOWS)
   #if defined(HAS_DX)


### PR DESCRIPTION
These commits provide some fixes for the initialization routine of the new settings system.
- I mixed up _LINUX and TARGET_LINUX during my refactor. This affects timezone-related settings and the loading of platform-specific settings definition files (e.g. android or rpi which have both TARGET_LINUX and TARGET_XXX defined).
- The initialization of some special visibility conditions and default values in the code AFTER having read all the settings definition files makes it impossible to e.g. change the webserver's port in appliance.xml because it is overwritten in CSettings::InitializeDefaults(). I have moved the execution of InitializeDefaults() and InitializeVisibility() to before loading appliance.xml so that it will always be possible to overwrite anything from there without any C++ code interfering.
