### PR TITLE
[rbp/omxplayer] Merge with current dvdplayer

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -63,33 +63,66 @@
 #include "DVDInputStreams/DVDInputStreamTV.h"
 #include "DVDInputStreams/DVDInputStreamPVRManager.h"
 
+#include "DVDDemuxers/DVDDemux.h"
 #include "DVDDemuxers/DVDDemuxUtils.h"
 #include "DVDDemuxers/DVDDemuxVobsub.h"
 #include "DVDDemuxers/DVDFactoryDemuxer.h"
 #include "DVDDemuxers/DVDDemuxFFmpeg.h"
 
+#include "DVDCodecs/DVDCodecs.h"
+#include "DVDCodecs/DVDFactoryCodec.h"
+
 #include "DVDFileInfo.h"
 
-#include "Util.h"
-#include "LangInfo.h"
+#include "utils/LangCodeExpander.h"
+#include "guilib/Key.h"
+#include "guilib/LocalizeStrings.h"
 
-#include "utils/JobManager.h"
-//#include "cores/AudioEngine/AEFactory.h"
-//#include "cores/AudioEngine/Utils/AEUtil.h"
-#include "video/VideoThumbLoader.h"
-
+#include "utils/URIUtils.h"
+#include "GUIInfoManager.h"
+#include "guilib/GUIWindowManager.h"
+#include "Application.h"
+#include "ApplicationMessenger.h"
+#include "DVDPerformanceCounter.h"
+#include "filesystem/File.h"
+#include "pictures/Picture.h"
+#include "DllSwScale.h"
+#ifdef HAS_VIDEO_PLAYBACK
+#include "cores/VideoRenderers/RenderManager.h"
+#endif
+#ifdef HAS_PERFORMANCE_SAMPLE
+#include "xbmc/utils/PerformanceSample.h"
+#else
+#define MEASURE_FUNCTION
+#endif
+#include "settings/AdvancedSettings.h"
+#include "FileItem.h"
+#include "GUIUserMessages.h"
+#include "settings/Settings.h"
+#include "settings/MediaSettings.h"
+#include "utils/log.h"
+#include "utils/TimeUtils.h"
+#include "utils/StreamDetails.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/windows/GUIWindowPVR.h"
 #include "pvr/addons/PVRClients.h"
 #include "filesystem/PVRFile.h"
-
+#include "video/dialogs/GUIDialogFullScreenInfo.h"
+#include "utils/StreamUtils.h"
+#include "utils/Variant.h"
+#include "storage/MediaManager.h"
+#include "dialogs/GUIDialogBusy.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "xbmc/playlists/PlayListM3U.h"
 #include "utils/StringUtils.h"
+#include "Util.h"
+#include "LangInfo.h"
+#include "URL.h"
 
-using namespace XFILE;
+using namespace std;
 using namespace PVR;
 
-// ****************************************************************
 void COMXSelectionStreams::Clear(StreamType type, StreamSource source)
 {
   CSingleLock lock(m_section);
@@ -402,7 +435,6 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
   }
 }
 
-// ****************************************************************
 COMXPlayer::COMXPlayer(IPlayerCallback &callback) 
     : IPlayer(callback),
       CThread("OMXPlayer"),
@@ -411,35 +443,43 @@ COMXPlayer::COMXPlayer(IPlayerCallback &callback)
       m_CurrentSubtitle(STREAM_SUBTITLE, DVDPLAYER_SUBTITLE),
       m_CurrentTeletext(STREAM_TELETEXT, DVDPLAYER_TELETEXT),
       m_messenger("player"),
-      m_player_video(&m_av_clock, &m_overlayContainer, m_messenger),
-      m_player_audio(&m_av_clock, m_messenger),
-      m_player_subtitle(&m_overlayContainer),
-      m_player_teletext(),
+      m_omxPlayerVideo(&m_av_clock, &m_overlayContainer, m_messenger),
+      m_omxPlayerAudio(&m_av_clock, m_messenger),
+      m_dvdPlayerSubtitle(&m_overlayContainer),
+      m_dvdPlayerTeletext(),
       m_ready(true)
 {
-  m_bAbortRequest     = false;
   m_pDemuxer          = NULL;
   m_pSubtitleDemuxer  = NULL;
   m_pInputStream      = NULL;
-  m_UpdateApplication = 0;
-  m_caching           = CACHESTATE_DONE;
-  m_playSpeed         = DVD_PLAYSPEED_NORMAL;
-  m_HasVideo          = false;
-  m_HasAudio          = false;
 
   m_dvd.Clear();
   m_State.Clear();
   m_EdlAutoSkipMarkers.Clear();
+  m_UpdateApplication = 0;
+
+  m_bAbortRequest = false;
+  m_errorCount = 0;
+  m_offset_pts = 0.0;
+  m_playSpeed = DVD_PLAYSPEED_NORMAL;
+  m_caching           = CACHESTATE_DONE;
+  m_HasVideo          = false;
+  m_HasAudio          = false;
 
   memset(&m_SpeedState, 0, sizeof(m_SpeedState));
+
+#ifdef DVDDEBUG_MESSAGE_TRACKER
+  g_dvdMessageTracker.Init();
+#endif
 }
 
 COMXPlayer::~COMXPlayer()
 {
   CloseFile();
 
-  if(m_messenger.IsInited())
-    m_messenger.End();
+#ifdef DVDDEBUG_MESSAGE_TRACKER
+  g_dvdMessageTracker.DeInit();
+#endif
 }
 
 bool COMXPlayer::OpenFile(const CFileItem &file, const CPlayerOptions &options)
@@ -460,27 +500,27 @@ bool COMXPlayer::OpenFile(const CFileItem &file, const CPlayerOptions &options)
     if(CSettings::Get().GetBool("videoplayer.adjustrefreshrate"))
       m_av_clock.HDMIClockSync();
 
-    m_playSpeed = DVD_PLAYSPEED_NORMAL;
+    m_bAbortRequest = false;
+
     SetPlaySpeed(DVD_PLAYSPEED_NORMAL);
 
-    m_PlayerOptions     = options;
-    m_bAbortRequest     = false;
-
+    m_State.Clear();
     m_UpdateApplication = 0;
     m_offset_pts        = 0;
     m_current_volume    = 0;
     m_current_mute      = false;
     m_change_volume     = true;
 
+    m_PlayerOptions = options;
     m_item              = file;
     m_mimetype          = file.GetMimeType();
     m_filename          = file.GetPath();
 
-    m_State.Clear();
-
     m_ready.Reset();
 
+#if defined(HAS_VIDEO_PLAYBACK)
     g_renderManager.PreInit();
+#endif
 
     Create();
     if(!m_ready.WaitMSec(100))
@@ -535,15 +575,16 @@ bool COMXPlayer::CloseFile()
   // we are done after the StopThread call
   StopThread();
   
-  CLog::Log(LOGDEBUG, "COMXPlayer: finished waiting");
-
   m_Edl.Clear();
   m_EdlAutoSkipMarkers.Clear();
 
   m_HasVideo = false;
   m_HasAudio = false;
 
+  CLog::Log(LOGNOTICE, "DVDPlayer: finished waiting");
+#if defined(HAS_VIDEO_PLAYBACK)
   g_renderManager.UnInit();
+#endif
   return true;
 }
 
@@ -581,7 +622,8 @@ bool COMXPlayer::OpenInputStream()
 
   // before creating the input stream, if this is an HLS playlist then get the
   // most appropriate bitrate based on our network settings
-  if (filename.Left(7) == "http://" && filename.Right(5) == ".m3u8")
+  // ensure to strip off the url options by using a temp CURL object
+  if (filename.Left(7) == "http://" && CURL(filename).GetFileName().Right(5) == ".m3u8")
   {
     // get the available bandwidth (as per user settings)
     int maxrate = CSettings::Get().GetInt("network.bandwidth");
@@ -652,6 +694,7 @@ bool COMXPlayer::OpenInputStream()
   SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
   m_av_clock.Reset();
   m_dvd.Clear();
+  m_errorCount = 0;
   m_iChannelEntryTimeOut = 0;
 
   return true;
@@ -744,7 +787,7 @@ void COMXPlayer::OpenDefaultStreams(bool reset)
     CloseAudioStream(true);
 
   // enable subtitles
-  m_player_video.EnableSubtitle(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn);
+  m_omxPlayerVideo.EnableSubtitle(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn);
 
   // open subtitle stream
   streams = m_SelectionStreams.Get(STREAM_SUBTITLE, PredicateSubtitlePriority);
@@ -755,7 +798,7 @@ void COMXPlayer::OpenDefaultStreams(bool reset)
     {
       valid = true;
       if(it->flags & CDemuxStream::FLAG_FORCED)
-        m_player_video.EnableSubtitle(true);
+        m_omxPlayerVideo.EnableSubtitle(true);
     }
   }
   if(!valid)
@@ -777,7 +820,7 @@ bool COMXPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
 {
 
   // check if we should read from subtitle demuxer
-  if(m_player_subtitle.AcceptsData() &&  m_pSubtitleDemuxer)
+  if(m_dvdPlayerSubtitle.AcceptsData() &&  m_pSubtitleDemuxer)
   {
     if(m_pSubtitleDemuxer)
       packet = m_pSubtitleDemuxer->Read();
@@ -969,7 +1012,8 @@ void COMXPlayer::Process()
     return;
   }
 
-  m_player_video.EnableFullscreen(true);
+  // allow renderer to switch to fullscreen if requested
+  m_omxPlayerVideo.EnableFullscreen(m_PlayerOptions.fullscreen);
 
   OpenDefaultStreams();
 
@@ -1056,17 +1100,6 @@ void COMXPlayer::Process()
   if (!CachePVRStream())
     SetCaching(CACHESTATE_FLUSH);
 
-  /*
-  if (CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW))
-  {
-    if (!WaitForPausedThumbJobs(20000))
-    {
-      CJobManager::GetInstance().UnPause(kJobTypeMediaFlags);
-      CLog::Log(LOGINFO, "COMXPlayer::Process:thumbgen jobs still running !!!");
-    }
-  }
-  */
-
   while (!m_bAbortRequest)
   {
     #ifdef _DEBUG
@@ -1075,14 +1108,14 @@ void COMXPlayer::Process()
     if ((count++ & 15) == 0)
     {
       vc_gencmd(response, sizeof response, "render_bar 4 video_fifo %d %d %d %d",
-            m_player_video.GetDecoderBufferSize()-m_player_video.GetDecoderFreeSpace(),
-            0 , 0, m_player_video.GetDecoderBufferSize());
+            m_omxPlayerVideo.GetDecoderBufferSize()-m_omxPlayerVideo.GetDecoderFreeSpace(),
+            0 , 0, m_omxPlayerVideo.GetDecoderBufferSize());
       vc_gencmd(response, sizeof response, "render_bar 5 audio_fifo %d %d %d %d",
-            (int)(100.0*m_player_audio.GetDelay()), 0, 0, 100*AUDIO_BUFFER_SECONDS);
+            (int)(100.0*m_omxPlayerAudio.GetDelay()), 0, 0, 100*AUDIO_BUFFER_SECONDS);
       vc_gencmd(response, sizeof response, "render_bar 6 video_queue %d %d %d %d",
-            m_player_video.GetLevel(), 0, 0, 100);
+            m_omxPlayerVideo.GetLevel(), 0, 0, 100);
       vc_gencmd(response, sizeof response, "render_bar 7 audio_queue %d %d %d %d",
-            m_player_audio.GetLevel(), 0, 0, 100);
+            m_omxPlayerAudio.GetLevel(), 0, 0, 100);
     }
     #endif
     // handle messages send to this thread, like seek or demuxer reset requests
@@ -1121,8 +1154,8 @@ void COMXPlayer::Process()
       OpenDefaultStreams();
 
       // never allow first frames after open to be skipped
-      if( m_player_video.IsInited() )
-        m_player_video.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
+      if( m_omxPlayerVideo.IsInited() )
+        m_omxPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
 
       if (CachePVRStream())
         SetCaching(CACHESTATE_PVR);
@@ -1141,9 +1174,9 @@ void COMXPlayer::Process()
     UpdateApplication(1000);
 
     // OMX emergency exit
-    if(HasAudio() && m_player_audio.BadState())
+    if(HasAudio() && m_omxPlayerAudio.BadState())
     {
-      CLog::Log(LOGERROR, "%s - Closing stream due to m_player_audio.BadState()", __FUNCTION__);
+      CLog::Log(LOGERROR, "%s - Closing stream due to m_omxPlayerAudio.BadState()", __FUNCTION__);
       m_bAbortRequest = true;
       break;
     }
@@ -1152,16 +1185,16 @@ void COMXPlayer::Process()
       continue;
 
     // if the queues are full, no need to read more
-    if ((!m_player_audio.AcceptsData() && m_CurrentAudio.id >= 0)
-    ||  (!m_player_video.AcceptsData() && m_CurrentVideo.id >= 0))
+    if ((!m_omxPlayerAudio.AcceptsData() && m_CurrentAudio.id >= 0) ||
+        (!m_omxPlayerVideo.AcceptsData() && m_CurrentVideo.id >= 0))
     {
       Sleep(10);
       continue;
     }
 
     // always yield to players if they have data levels > 50 percent
-    if((m_player_audio.GetLevel() > 50 || m_CurrentAudio.id < 0)
-    && (m_player_video.GetLevel() > 50 || m_CurrentVideo.id < 0))
+    if((m_omxPlayerAudio.GetLevel() > 50 || m_CurrentAudio.id < 0)
+    && (m_omxPlayerVideo.GetLevel() > 50 || m_CurrentVideo.id < 0))
       Sleep(0);
 
     DemuxPacket* pPacket = NULL;
@@ -1223,33 +1256,28 @@ void COMXPlayer::Process()
         Sleep(100);
         continue;
       }
-      else if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
-      {
-        CDVDInputStreamPVRManager* pStream = static_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
-        if (pStream->IsEOF())
-          break;
-
-        Sleep(100);
-        continue;
-      }
 
       // make sure we tell all players to finish it's data
       if (!bOmxSentEOFs)
       {
         if(m_CurrentAudio.inited)
         {
-          m_player_audio.SendMessage   (new CDVDMsg(CDVDMsg::GENERAL_EOF));
+          m_omxPlayerAudio.SendMessage   (new CDVDMsg(CDVDMsg::GENERAL_EOF));
           bOmxWaitAudio = true;
         }
         if(m_CurrentVideo.inited)
         {
-          m_player_video.SendMessage   (new CDVDMsg(CDVDMsg::GENERAL_EOF));
+          m_omxPlayerVideo.SendMessage   (new CDVDMsg(CDVDMsg::GENERAL_EOF));
           bOmxWaitVideo = true;
         }
         if(m_CurrentSubtitle.inited)
-          m_player_subtitle.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
+          m_dvdPlayerSubtitle.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
         if(m_CurrentTeletext.inited)
-          m_player_teletext.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
+          m_dvdPlayerTeletext.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_EOF));
+        m_CurrentAudio.inited    = false;
+        m_CurrentVideo.inited    = false;
+        m_CurrentSubtitle.inited = false;
+        m_CurrentTeletext.inited = false;
         bOmxSentEOFs = true;
       }
 
@@ -1257,20 +1285,20 @@ void COMXPlayer::Process()
       SetCaching(CACHESTATE_DONE);
 
       // while players are still playing, keep going to allow seekbacks
-      if(m_player_video.HasData()
-      || m_player_audio.HasData())
+      if(m_omxPlayerVideo.HasData()
+      || m_omxPlayerAudio.HasData())
       {
         Sleep(100);
         continue;
       }
 
       // wait for omx components to finish
-      if(bOmxWaitVideo && !m_player_video.IsEOS())
+      if(bOmxWaitVideo && !m_omxPlayerVideo.IsEOS())
       {
         Sleep(100);
         continue;
       }
-      if(bOmxWaitAudio && !m_player_audio.IsEOS())
+      if(bOmxWaitAudio && !m_omxPlayerAudio.IsEOS())
       {
         Sleep(100);
         continue;
@@ -1279,10 +1307,6 @@ void COMXPlayer::Process()
       if (!m_pInputStream->IsEOF())
         CLog::Log(LOGINFO, "%s - eof reading from demuxer", __FUNCTION__);
 
-      m_CurrentAudio.inited    = false;
-      m_CurrentVideo.inited    = false;
-      m_CurrentSubtitle.inited = false;
-      m_CurrentTeletext.inited = false;
       m_CurrentAudio.started    = false;
       m_CurrentVideo.started    = false;
       m_CurrentSubtitle.started = false;
@@ -1291,10 +1315,13 @@ void COMXPlayer::Process()
       break;
     }
 
+    // it's a valid data packet, reset error counter
+    m_errorCount = 0;
+
     // check so that none of our streams has become invalid
-    if (!IsValidStream(m_CurrentAudio)    && m_player_audio.IsStalled())    CloseAudioStream(true);
-    if (!IsValidStream(m_CurrentVideo)    && m_player_video.IsStalled())    CloseVideoStream(true);
-    if (!IsValidStream(m_CurrentSubtitle) && m_player_subtitle.IsStalled()) CloseSubtitleStream(true);
+    if (!IsValidStream(m_CurrentAudio)    && m_omxPlayerAudio.IsStalled())    CloseAudioStream(true);
+    if (!IsValidStream(m_CurrentVideo)    && m_omxPlayerVideo.IsStalled())    CloseVideoStream(true);
+    if (!IsValidStream(m_CurrentSubtitle) && m_dvdPlayerSubtitle.IsStalled()) CloseSubtitleStream(true);
     if (!IsValidStream(m_CurrentTeletext))                                  CloseTeletextStream(true);
 
     // see if we can find something better to play
@@ -1305,7 +1332,7 @@ void COMXPlayer::Process()
 
     if(m_change_volume && m_CurrentAudio.started)
     {
-      m_player_audio.SetCurrentVolume(m_current_mute ? VOLUME_MINIMUM : m_current_volume);
+      m_omxPlayerAudio.SetCurrentVolume(m_current_mute ? VOLUME_MINIMUM : m_current_volume);
       m_change_volume = false;
     }
 
@@ -1398,17 +1425,17 @@ void COMXPlayer::ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket)
   else if (m_Edl.InCut(DVD_TIME_TO_MSEC(m_CurrentAudio.dts + m_offset_pts), &cut) && cut.action == CEdl::MUTE // Inside EDL mute
   &&      !m_EdlAutoSkipMarkers.mute) // Mute not already triggered
   {
-    m_player_audio.SendMessage(new CDVDMsgBool(CDVDMsg::AUDIO_SILENCE, true));
+    m_omxPlayerAudio.SendMessage(new CDVDMsgBool(CDVDMsg::AUDIO_SILENCE, true));
     m_EdlAutoSkipMarkers.mute = true;
   }
   else if (!m_Edl.InCut(DVD_TIME_TO_MSEC(m_CurrentAudio.dts + m_offset_pts), &cut) // Outside of any EDL
   &&        m_EdlAutoSkipMarkers.mute) // But the mute hasn't been removed yet
   {
-    m_player_audio.SendMessage(new CDVDMsgBool(CDVDMsg::AUDIO_SILENCE, false));
+    m_omxPlayerAudio.SendMessage(new CDVDMsgBool(CDVDMsg::AUDIO_SILENCE, false));
     m_EdlAutoSkipMarkers.mute = false;
   }
 
-  m_player_audio.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_omxPlayerAudio.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
 }
 
 void COMXPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
@@ -1441,7 +1468,7 @@ void COMXPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
   if (CheckSceneSkip(m_CurrentVideo))
     drop = true;
 
-  m_player_video.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_omxPlayerVideo.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
 }
 
 void COMXPlayer::ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket)
@@ -1467,10 +1494,10 @@ void COMXPlayer::ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket)
   if (CheckSceneSkip(m_CurrentSubtitle))
     drop = true;
 
-  m_player_subtitle.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_dvdPlayerSubtitle.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
 
   if(m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
-    m_player_subtitle.UpdateOverlayInfo((CDVDInputStreamNavigator*)m_pInputStream, LIBDVDNAV_BUTTON_NORMAL);
+    m_dvdPlayerSubtitle.UpdateOverlayInfo((CDVDInputStreamNavigator*)m_pInputStream, LIBDVDNAV_BUTTON_NORMAL);
 }
 
 void COMXPlayer::ProcessTeletextData(CDemuxStream* pStream, DemuxPacket* pPacket)
@@ -1494,7 +1521,7 @@ void COMXPlayer::ProcessTeletextData(CDemuxStream* pStream, DemuxPacket* pPacket
   if (CheckSceneSkip(m_CurrentTeletext))
     drop = true;
 
-  m_player_teletext.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
+  m_dvdPlayerTeletext.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
 }
 
 bool COMXPlayer::GetCachingTimes(double& level, double& delay, double& offset)
@@ -1555,14 +1582,17 @@ void COMXPlayer::HandlePlaySpeed()
     if(GetCachingTimes(level, delay, offset))
     {
       if(level  < 0.0)
+      {
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(21454), g_localizeStrings.Get(21455));
         caching = CACHESTATE_INIT;
+      }
       if(level >= 1.0)
         caching = CACHESTATE_INIT;
     }
     else
     {
-      if ((!m_player_audio.AcceptsData() && m_CurrentAudio.id >= 0)
-      ||  (!m_player_video.AcceptsData() && m_CurrentVideo.id >= 0))
+      if ((!m_omxPlayerAudio.AcceptsData() && m_CurrentAudio.id >= 0)
+      ||  (!m_omxPlayerVideo.AcceptsData() && m_CurrentVideo.id >= 0))
         caching = CACHESTATE_INIT;
     }
   }
@@ -1577,8 +1607,8 @@ void COMXPlayer::HandlePlaySpeed()
     // handle situation that we get no data on one stream
     if(m_CurrentAudio.id >= 0 && m_CurrentVideo.id >= 0)
     {
-      if ((!m_player_audio.AcceptsData() && !m_CurrentVideo.started)
-      ||  (!m_player_video.AcceptsData() && !m_CurrentAudio.started))
+      if ((!m_omxPlayerAudio.AcceptsData() && !m_CurrentVideo.started)
+      ||  (!m_omxPlayerVideo.AcceptsData() && !m_CurrentAudio.started))
       {
         caching = CACHESTATE_DONE;
       }
@@ -1589,10 +1619,10 @@ void COMXPlayer::HandlePlaySpeed()
   {
     bool bGotAudio(m_pDemuxer->GetNrOfAudioStreams() > 0);
     bool bGotVideo(m_pDemuxer->GetNrOfVideoStreams() > 0);
-    bool bAudioLevelOk(m_player_audio.GetLevel() > g_advancedSettings.m_iPVRMinAudioCacheLevel);
-    bool bVideoLevelOk(m_player_video.GetLevel() > g_advancedSettings.m_iPVRMinVideoCacheLevel);
-    bool bAudioFull(!m_player_audio.AcceptsData());
-    bool bVideoFull(!m_player_video.AcceptsData());
+    bool bAudioLevelOk(m_omxPlayerAudio.GetLevel() > g_advancedSettings.m_iPVRMinAudioCacheLevel);
+    bool bVideoLevelOk(m_omxPlayerVideo.GetLevel() > g_advancedSettings.m_iPVRMinVideoCacheLevel);
+    bool bAudioFull(!m_omxPlayerAudio.AcceptsData());
+    bool bVideoFull(!m_omxPlayerVideo.AcceptsData());
 
     if (/* if all streams got at least g_advancedSettings.m_iPVRMinCacheLevel in their buffers, we're done */
         ((bGotVideo || bGotAudio) && (!bGotAudio || bAudioLevelOk) && (!bGotVideo || bVideoLevelOk)) ||
@@ -1600,8 +1630,8 @@ void COMXPlayer::HandlePlaySpeed()
         (bAudioFull || bVideoFull))
     {
       CLog::Log(LOGDEBUG, "set caching from pvr to done. audio (%d) = %d. video (%d) = %d",
-          bGotAudio, m_player_audio.GetLevel(),
-          bGotVideo, m_player_video.GetLevel());
+          bGotAudio, m_omxPlayerAudio.GetLevel(),
+          bGotVideo, m_omxPlayerVideo.GetLevel());
 
       CFileItem currentItem(g_application.CurrentFileItem());
       if (currentItem.HasPVRChannelInfoTag())
@@ -1613,17 +1643,17 @@ void COMXPlayer::HandlePlaySpeed()
     {
       /* ensure that automatically started players are stopped while caching */
       if (m_CurrentAudio.started)
-        m_player_audio.SetSpeed(DVD_PLAYSPEED_PAUSE);
+        m_omxPlayerAudio.SetSpeed(DVD_PLAYSPEED_PAUSE);
       if (m_CurrentVideo.started)
-        m_player_video.SetSpeed(DVD_PLAYSPEED_PAUSE);
+        m_omxPlayerVideo.SetSpeed(DVD_PLAYSPEED_PAUSE);
     }
   }
 
   if(caching == CACHESTATE_PLAY)
   {
     // if all enabled streams have started playing we are done
-    if((m_CurrentVideo.id < 0 || !m_player_video.IsStalled())
-    && (m_CurrentAudio.id < 0 || !m_player_audio.IsStalled()))
+    if((m_CurrentVideo.id < 0 || !m_omxPlayerVideo.IsStalled())
+    && (m_CurrentAudio.id < 0 || !m_omxPlayerAudio.IsStalled()))
       caching = CACHESTATE_DONE;
   }
 
@@ -1641,10 +1671,10 @@ void COMXPlayer::HandlePlaySpeed()
     }
     else if (m_CurrentVideo.id >= 0
           &&  m_CurrentVideo.inited == true
-          &&  m_SpeedState.lastpts  != m_player_video.GetCurrentPTS()
+          &&  m_SpeedState.lastpts  != m_omxPlayerVideo.GetCurrentPts()
           &&  m_SpeedState.lasttime != GetTime())
     {
-      m_SpeedState.lastpts  = m_player_video.GetCurrentPTS();
+      m_SpeedState.lastpts  = m_omxPlayerVideo.GetCurrentPts();
       m_SpeedState.lasttime = GetTime();
       // check how much off clock video is when ff/rw:ing
       // a problem here is that seeking isn't very accurate
@@ -1679,13 +1709,13 @@ bool COMXPlayer::CheckStartCaching(COMXCurrentStream& current)
   if(IsInMenu())
     return false;
 
-  if((current.type == STREAM_AUDIO && m_player_audio.IsStalled())
-  || (current.type == STREAM_VIDEO && m_player_video.IsStalled()))
+  if((current.type == STREAM_AUDIO && m_omxPlayerAudio.IsStalled())
+  || (current.type == STREAM_VIDEO && m_omxPlayerVideo.IsStalled()))
   {
     if (CachePVRStream())
     {
-      if ((current.type == STREAM_AUDIO && current.started && m_player_audio.GetLevel() == 0) ||
-         (current.type == STREAM_VIDEO && current.started && m_player_video.GetLevel() == 0))
+      if ((current.type == STREAM_AUDIO && current.started && m_omxPlayerAudio.GetLevel() == 0) ||
+         (current.type == STREAM_VIDEO && current.started && m_omxPlayerVideo.GetLevel() == 0))
       {
         CLog::Log(LOGDEBUG, "%s stream stalled. start buffering", current.type == STREAM_AUDIO ? "audio" : "video");
         SetCaching(CACHESTATE_PVR);
@@ -1694,8 +1724,8 @@ bool COMXPlayer::CheckStartCaching(COMXCurrentStream& current)
     }
 
     // don't start caching if it's only a single stream that has run dry
-    if(m_player_audio.GetLevel() > 50
-    || m_player_video.GetLevel() > 50)
+    if(m_omxPlayerAudio.GetLevel() > 50
+    || m_omxPlayerVideo.GetLevel() > 50)
       return false;
 
     if(current.inited)
@@ -1827,7 +1857,7 @@ void COMXPlayer::UpdateTimestamps(COMXCurrentStream& current, DemuxPacket* pPack
   }
 }
 
-void COMXPlayer::UpdateLimits(double& minimum, double& maximum, double dts)
+static void UpdateLimits(double& minimum, double& maximum, double dts)
 {
   if(dts == DVD_NOPTS_VALUE)
     return;
@@ -1943,7 +1973,7 @@ void COMXPlayer::CheckAutoSceneSkip()
     /*
      * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
      */
-    m_messenger.Put(new CDVDMsgPlayerSeek((int)seek, true, true, true, false, true));
+    m_messenger.Put(new CDVDMsgPlayerSeek((int)seek, true, false, true, false, true));
     /*
      * Seek doesn't always work reliably. Last physical seek time is recorded to prevent looping
      * if there was an error with seeking and it landed somewhere unexpected, perhaps back in the
@@ -1961,7 +1991,7 @@ void COMXPlayer::CheckAutoSceneSkip()
     /*
      * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
      */
-    m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, true, true, false, true));
+    m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, false, true, false, true));
     /*
      * Each commercial break is only skipped once so poorly detected commercial breaks can be
      * manually re-entered. Start and end are recorded to prevent looping and to allow seeking back
@@ -1993,15 +2023,15 @@ void COMXPlayer::SynchronizePlayers(unsigned int sources)
 
   CDVDMsgGeneralSynchronize* message = new CDVDMsgGeneralSynchronize(timeout, sources);
   if (m_CurrentAudio.id >= 0)
-    m_player_audio.SendMessage(message->Acquire());
+    m_omxPlayerAudio.SendMessage(message->Acquire());
 
   if (m_CurrentVideo.id >= 0)
-    m_player_video.SendMessage(message->Acquire());
+    m_omxPlayerVideo.SendMessage(message->Acquire());
 /* TODO - we have to rewrite the sync class, to not require
           all other players waiting for subtitle, should only
           be the oposite way
   if (m_CurrentSubtitle.id >= 0)
-    m_player_subtitle.SendMessage(message->Acquire()); 
+    m_dvdPlayerSubtitle.SendMessage(message->Acquire());
 */
   message->Release();
 }
@@ -2009,13 +2039,13 @@ void COMXPlayer::SynchronizePlayers(unsigned int sources)
 void COMXPlayer::SendPlayerMessage(CDVDMsg* pMsg, unsigned int target)
 {
   if(target == DVDPLAYER_AUDIO)
-    m_player_audio.SendMessage(pMsg);
+    m_omxPlayerAudio.SendMessage(pMsg);
   if(target == DVDPLAYER_VIDEO)
-    m_player_video.SendMessage(pMsg);
+    m_omxPlayerVideo.SendMessage(pMsg);
   if(target == DVDPLAYER_SUBTITLE)
-    m_player_subtitle.SendMessage(pMsg);
+    m_dvdPlayerSubtitle.SendMessage(pMsg);
   if(target == DVDPLAYER_TELETEXT)
-    m_player_teletext.SendMessage(pMsg);
+    m_dvdPlayerTeletext.SendMessage(pMsg);
 }
 
 void COMXPlayer::OnExit()
@@ -2078,7 +2108,7 @@ void COMXPlayer::OnExit()
     // clean up all selection streams
     m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NONE);
 
-    m_messenger.Flush();
+    m_messenger.End();
 
     m_av_clock.OMXDeinitialize();
 
@@ -2257,7 +2287,7 @@ void COMXPlayer::HandleMessages()
       {
         CDVDMsgBool* pValue = (CDVDMsgBool*)pMsg;
 
-        m_player_video.EnableSubtitle(pValue->m_value);
+        m_omxPlayerVideo.EnableSubtitle(pValue->m_value);
 
         if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
           static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->EnableSubtitleStream(pValue->m_value);
@@ -2326,8 +2356,8 @@ void COMXPlayer::HandleMessages()
         m_caching = CACHESTATE_DONE;
         m_av_clock.SetSpeed(speed);
         m_av_clock.OMXSetSpeed(speed);
-        m_player_audio.SetSpeed(speed);
-        m_player_video.SetSpeed(speed);
+        m_omxPlayerAudio.SetSpeed(speed);
+        m_omxPlayerVideo.SetSpeed(speed);
 
         // TODO - we really shouldn't pause demuxer
         //        until our buffers are somewhat filled
@@ -2421,7 +2451,7 @@ void COMXPlayer::HandleMessages()
         CSingleLock lock(m_StateSection);
         /* prioritize data from video player, but only accept data        *
          * after it has been started to avoid race conditions after seeks */
-        if(m_CurrentVideo.started && !m_player_video.SubmittedEOS())
+        if(m_CurrentVideo.started && !m_omxPlayerVideo.SubmittedEOS())
         {
           if(state.player == DVDPLAYER_VIDEO)
             m_State = state;
@@ -2464,10 +2494,10 @@ void COMXPlayer::SetCaching(ECacheState state)
   {
     m_av_clock.SetSpeed(DVD_PLAYSPEED_PAUSE);
     m_av_clock.OMXSetSpeed(DVD_PLAYSPEED_PAUSE);
-    m_player_audio.SetSpeed(DVD_PLAYSPEED_PAUSE);
-    m_player_audio.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
-    m_player_video.SetSpeed(DVD_PLAYSPEED_PAUSE);
-    m_player_video.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
+    m_omxPlayerAudio.SetSpeed(DVD_PLAYSPEED_PAUSE);
+    m_omxPlayerAudio.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
+    m_omxPlayerVideo.SetSpeed(DVD_PLAYSPEED_PAUSE);
+    m_omxPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
 
     if (state == CACHESTATE_PVR)
       m_pInputStream->ResetScanTimeout((unsigned int) CSettings::Get().GetInt("pvrplayback.scantime") * 1000);
@@ -2478,8 +2508,9 @@ void COMXPlayer::SetCaching(ECacheState state)
   {
     m_av_clock.SetSpeed(m_playSpeed);
     m_av_clock.OMXSetSpeed(m_playSpeed);
-    m_player_audio.SetSpeed(m_playSpeed);
-    m_player_video.SetSpeed(m_playSpeed);
+    m_omxPlayerAudio.SetSpeed(m_playSpeed);
+    m_omxPlayerVideo.SetSpeed(m_playSpeed);
+    m_pInputStream->ResetScanTimeout(0);
   }
   m_caching = state;
 }
@@ -2491,6 +2522,8 @@ void COMXPlayer::SetPlaySpeed(int speed)
     return;
 
   m_messenger.Put(new CDVDMsgInt(CDVDMsg::PLAYER_SETSPEED, speed));
+  m_omxPlayerAudio.SetSpeed(speed);
+  m_omxPlayerVideo.SetSpeed(speed);
   SynchronizeDemuxer(100);
 }
 
@@ -2543,7 +2576,7 @@ bool COMXPlayer::HasAudio() const
 
 bool COMXPlayer::IsPassthrough() const
 {
-  return m_player_audio.Passthrough();
+  return m_omxPlayerAudio.Passthrough();
 }
 
 bool COMXPlayer::CanSeek()
@@ -2554,6 +2587,15 @@ bool COMXPlayer::CanSeek()
 
 void COMXPlayer::Seek(bool bPlus, bool bLargeStep)
 {
+#if 0
+  // sadly this doesn't work for now, audio player must
+  // drop packets at the same rate as we play frames
+  if( m_playSpeed == DVD_PLAYSPEED_PAUSE && bPlus && !bLargeStep)
+  {
+    m_omxPlayerVideo.StepFrame();
+    return;
+  }
+#endif
   if (!m_State.canseek)
     return;
 
@@ -2682,7 +2724,7 @@ void COMXPlayer::GetAudioInfo(CStdString &strAudioInfo)
   { CSingleLock lock(m_StateSection);
     strAudioInfo.Format("D(%s)", m_StateInput.demux_audio.c_str());
   }
-  strAudioInfo.AppendFormat("\nP(%s)", m_player_audio.GetPlayerInfo().c_str());
+  strAudioInfo.AppendFormat("\nP(%s)", m_omxPlayerAudio.GetPlayerInfo().c_str());
 }
 
 void COMXPlayer::GetVideoInfo(CStdString &strVideoInfo)
@@ -2690,17 +2732,17 @@ void COMXPlayer::GetVideoInfo(CStdString &strVideoInfo)
   { CSingleLock lock(m_StateSection);
     strVideoInfo.Format("D(%s)", m_StateInput.demux_video.c_str());
   }
-  strVideoInfo.AppendFormat("\nP(%s)", m_player_video.GetPlayerInfo().c_str());
+  strVideoInfo.AppendFormat("\nP(%s)", m_omxPlayerVideo.GetPlayerInfo().c_str());
 }
 
 void COMXPlayer::GetGeneralInfo(CStdString& strGeneralInfo)
 {
   if (!m_bStop)
   {
-    double dDelay = m_player_video.GetDelay() / DVD_TIME_BASE - g_renderManager.GetDisplayLatency();
+    double dDelay = m_omxPlayerVideo.GetDelay() / DVD_TIME_BASE - g_renderManager.GetDisplayLatency();
 
-    double apts = m_player_audio.GetCurrentPTS();
-    double vpts = m_player_video.GetCurrentPTS();
+    double apts = m_omxPlayerAudio.GetCurrentPts();
+    double vpts = m_omxPlayerVideo.GetCurrentPts();
     double dDiff = 0;
 
     if( apts != DVD_NOPTS_VALUE && vpts != DVD_NOPTS_VALUE )
@@ -2725,23 +2767,23 @@ void COMXPlayer::GetGeneralInfo(CStdString& strGeneralInfo)
                          , dDiff
                          , strEDL.c_str()
                          , (int)(CThread::GetRelativeUsage()*100)
-                         , (int)(m_player_audio.GetRelativeUsage()*100)
-                         , (int)(m_player_video.GetRelativeUsage()*100)
+                         , (int)(m_omxPlayerAudio.GetRelativeUsage()*100)
+                         , (int)(m_omxPlayerVideo.GetRelativeUsage()*100)
                          , strBuf.c_str()
-                         , m_player_video.GetFreeSpace()
-                         , m_player_audio.GetDelay());
+                         , m_omxPlayerVideo.GetFreeSpace()
+                         , m_omxPlayerAudio.GetDelay());
 
   }
 }
 
-void COMXPlayer::SeekPercentage(float fPercent)
+void COMXPlayer::SeekPercentage(float iPercent)
 {
   int64_t iTotalTime = GetTotalTimeInMsec();
 
   if (!iTotalTime)
     return;
 
-  SeekTime((int64_t)(iTotalTime * fPercent / 100));
+  SeekTime((int64_t)(iTotalTime * iPercent / 100));
 }
 
 float COMXPlayer::GetPercentage()
@@ -2762,22 +2804,22 @@ float COMXPlayer::GetCachePercentage()
 
 void COMXPlayer::SetAVDelay(float fValue)
 {
-  m_player_video.SetDelay(fValue * DVD_TIME_BASE);
+  m_omxPlayerVideo.SetDelay(fValue * DVD_TIME_BASE);
 }
 
 float COMXPlayer::GetAVDelay()
 {
-  return m_player_video.GetDelay() / (float)DVD_TIME_BASE;
+  return m_omxPlayerVideo.GetDelay() / (float)DVD_TIME_BASE;
 }
 
 void COMXPlayer::SetSubTitleDelay(float fValue)
 {
-  m_player_video.SetSubtitleDelay(-fValue * DVD_TIME_BASE);
+  m_omxPlayerVideo.SetSubtitleDelay(-fValue * DVD_TIME_BASE);
 }
 
 float COMXPlayer::GetSubTitleDelay()
 {
-  return -m_player_video.GetSubtitleDelay() / DVD_TIME_BASE;
+  return -m_omxPlayerVideo.GetSubtitleDelay() / DVD_TIME_BASE;
 }
 
 // priority: 1: libdvdnav, 2: external subtitles, 3: muxed subtitles
@@ -2824,7 +2866,7 @@ bool COMXPlayer::GetSubtitleVisible()
       return pStream->IsSubtitleStreamEnabled();
   }
 
-  return m_player_video.IsSubtitleEnabled();
+  return m_omxPlayerVideo.IsSubtitleEnabled();
 }
 
 void COMXPlayer::SetSubtitleVisible(bool bVisible)
@@ -2856,7 +2898,7 @@ TextCacheStruct_t* COMXPlayer::GetTeletextCache()
   if (m_CurrentTeletext.id < 0)
     return 0;
 
-  return m_player_teletext.GetTeletextCache();
+  return m_dvdPlayerTeletext.GetTeletextCache();
 }
 
 void COMXPlayer::LoadPage(int p, int sp, unsigned char* buffer)
@@ -2864,7 +2906,7 @@ void COMXPlayer::LoadPage(int p, int sp, unsigned char* buffer)
   if (m_CurrentTeletext.id < 0)
       return;
 
-  return m_player_teletext.LoadPage(p, sp, buffer);
+  return m_dvdPlayerTeletext.LoadPage(p, sp, buffer);
 }
 
 void COMXPlayer::SeekTime(int64_t iTime)
@@ -2954,7 +2996,7 @@ bool COMXPlayer::OpenAudioStream(int iStream, int source, bool reset)
   if(m_CurrentAudio.id    < 0
   || m_CurrentAudio.hint != hint)
   {
-    if(!m_player_audio.OpenStream(hint))
+    if(!m_omxPlayerAudio.OpenStream(hint))
     {
       /* mark stream as disabled, to disallaw further attempts*/
       CLog::Log(LOGWARNING, "%s - Unsupported stream %d. Stream disabled.", __FUNCTION__, iStream);
@@ -2962,11 +3004,9 @@ bool COMXPlayer::OpenAudioStream(int iStream, int source, bool reset)
       pStream->SetDiscard(AVDISCARD_ALL);
       return false;
     }
-    m_av_clock.SetSpeed(DVD_PLAYSPEED_NORMAL);
-    m_av_clock.OMXSetSpeed(DVD_PLAYSPEED_NORMAL);
   }
   else if (reset)
-    m_player_audio.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_omxPlayerAudio.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
 
   /* store information about stream */
   m_CurrentAudio.id = iStream;
@@ -2977,10 +3017,10 @@ bool COMXPlayer::OpenAudioStream(int iStream, int source, bool reset)
   m_HasAudio = true;
 
   /* we are potentially going to be waiting on this */
-  m_player_audio.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
+  m_omxPlayerAudio.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
 
   /* software decoding normaly consumes full cpu time so prio it */
-  m_player_audio.SetPriority(GetPriority()+1);
+  m_omxPlayerAudio.SetPriority(GetPriority()+1);
 
   return true;
 }
@@ -3035,7 +3075,6 @@ bool COMXPlayer::OpenVideoStream(int iStream, int source, bool reset)
   if(m_CurrentVideo.id    < 0
   || m_CurrentVideo.hint != hint)
   {
-
     // for music file, don't open artwork as video
     bool disabled = false;
     CStdString extension = URIUtils::GetExtension(m_filename);
@@ -3045,7 +3084,7 @@ bool COMXPlayer::OpenVideoStream(int iStream, int source, bool reset)
       disabled = true;
     }
 
-    if (disabled || !m_player_video.OpenStream(hint))
+    if (disabled || !m_omxPlayerVideo.OpenStream(hint))
     {
       /* mark stream as disabled, to disallaw further attempts */
       CLog::Log(LOGWARNING, "%s - Unsupported stream %d. Stream disabled.", __FUNCTION__, iStream);
@@ -3053,18 +3092,16 @@ bool COMXPlayer::OpenVideoStream(int iStream, int source, bool reset)
       pStream->SetDiscard(AVDISCARD_ALL);
       return false;
     }
-    m_av_clock.SetSpeed(DVD_PLAYSPEED_NORMAL);
-    m_av_clock.OMXSetSpeed(DVD_PLAYSPEED_NORMAL);
   }
   else if (reset)
-    m_player_video.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_omxPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
 
   unsigned flags = 0;
   if(m_filename.find("3DSBS") != string::npos || m_filename.find("HSBS") != string::npos)
     flags = CONF_FLAGS_FORMAT_SBS;
   else if(m_filename.find("3DTAB") != string::npos || m_filename.find("HTAB") != string::npos)
     flags = CONF_FLAGS_FORMAT_TB;
-  m_player_video.SetFlags(flags);
+  m_omxPlayerVideo.SetFlags(flags);
 
   /* store information about stream */
   m_CurrentVideo.id = iStream;
@@ -3075,11 +3112,11 @@ bool COMXPlayer::OpenVideoStream(int iStream, int source, bool reset)
   m_HasVideo = true;
 
   /* we are potentially going to be waiting on this */
-  m_player_video.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
+  m_omxPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
 
   /* use same priority for video thread as demuxing thread, as */
   /* otherwise demuxer will starve if video consumes the full cpu */
-  m_player_video.SetPriority(GetPriority());
+  m_omxPlayerVideo.SetPriority(GetPriority());
 
   return true;
 }
@@ -3112,7 +3149,7 @@ bool COMXPlayer::OpenSubtitleStream(int iStream, int source)
     if(!pStream || pStream->disabled)
       return false;
     pStream->SetDiscard(AVDISCARD_NONE);
-    double pts = m_player_video.GetCurrentPTS();
+    double pts = m_omxPlayerVideo.GetCurrentPts();
     if(pts == DVD_NOPTS_VALUE)
       pts = m_CurrentVideo.dts;
     if(pts == DVD_NOPTS_VALUE)
@@ -3157,7 +3194,7 @@ bool COMXPlayer::OpenSubtitleStream(int iStream, int source)
       CloseSubtitleStream(false);
     }
 
-    if(!m_player_subtitle.OpenStream(hint, filename))
+    if(!m_dvdPlayerSubtitle.OpenStream(hint, filename))
     {
       CLog::Log(LOGWARNING, "%s - Unsupported stream %d. Stream disabled.", __FUNCTION__, iStream);
       if(pStream)
@@ -3169,7 +3206,7 @@ bool COMXPlayer::OpenSubtitleStream(int iStream, int source)
     }
   }
   else
-    m_player_subtitle.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_dvdPlayerSubtitle.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
 
   m_CurrentSubtitle.id     = iStream;
   m_CurrentSubtitle.source = source;
@@ -3191,7 +3228,7 @@ bool COMXPlayer::OpenTeletextStream(int iStream, int source)
 
   CDVDStreamInfo hint(*pStream, true);
 
-  if (!m_player_teletext.CheckStream(hint))
+  if (!m_dvdPlayerTeletext.CheckStream(hint))
     return false;
 
   CLog::Log(LOGNOTICE, "Opening teletext stream: %i source: %i", iStream, source);
@@ -3205,7 +3242,7 @@ bool COMXPlayer::OpenTeletextStream(int iStream, int source)
       CloseTeletextStream(true);
     }
 
-    if (!m_player_teletext.OpenStream(hint))
+    if (!m_dvdPlayerTeletext.OpenStream(hint))
     {
       /* mark stream as disabled, to disallaw further attempts*/
       CLog::Log(LOGWARNING, "%s - Unsupported teletext stream %d. Stream disabled.", __FUNCTION__, iStream);
@@ -3215,7 +3252,7 @@ bool COMXPlayer::OpenTeletextStream(int iStream, int source)
     }
   }
   else
-    m_player_teletext.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_dvdPlayerTeletext.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
 
   /* store information about stream */
   m_CurrentTeletext.id      = iStream;
@@ -3237,7 +3274,7 @@ bool COMXPlayer::CloseAudioStream(bool bWaitForBuffers)
   if(bWaitForBuffers)
     SetCaching(CACHESTATE_DONE);
 
-  m_player_audio.CloseStream(bWaitForBuffers);
+  m_omxPlayerAudio.CloseStream(bWaitForBuffers);
 
   m_CurrentAudio.Clear();
   return true;
@@ -3253,7 +3290,7 @@ bool COMXPlayer::CloseVideoStream(bool bWaitForBuffers)
   if(bWaitForBuffers)
     SetCaching(CACHESTATE_DONE);
 
-  m_player_video.CloseStream(bWaitForBuffers);
+  m_omxPlayerVideo.CloseStream(bWaitForBuffers);
 
   m_CurrentVideo.Clear();
   return true;
@@ -3266,7 +3303,7 @@ bool COMXPlayer::CloseSubtitleStream(bool bKeepOverlays)
 
   CLog::Log(LOGNOTICE, "Closing subtitle stream");
 
-  m_player_subtitle.CloseStream(!bKeepOverlays);
+  m_dvdPlayerSubtitle.CloseStream(!bKeepOverlays);
 
   m_CurrentSubtitle.Clear();
   return true;
@@ -3282,7 +3319,7 @@ bool COMXPlayer::CloseTeletextStream(bool bWaitForBuffers)
   if(bWaitForBuffers)
     SetCaching(CACHESTATE_DONE);
 
-  m_player_teletext.CloseStream(bWaitForBuffers);
+  m_dvdPlayerTeletext.CloseStream(bWaitForBuffers);
 
   m_CurrentTeletext.Clear();
   return true;
@@ -3321,19 +3358,19 @@ void COMXPlayer::FlushBuffers(bool queued, double pts, bool accurate)
 
   if(queued)
   {
-    m_player_audio.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_player_video.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_player_video.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
-    m_player_subtitle.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_player_teletext.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_omxPlayerAudio.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_omxPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_omxPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
+    m_dvdPlayerSubtitle.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    m_dvdPlayerTeletext.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
     SynchronizePlayers(SYNCSOURCE_ALL);
   }
   else
   {
-    m_player_video.Flush();
-    m_player_audio.Flush();
-    m_player_subtitle.Flush();
-    m_player_teletext.Flush();
+    m_omxPlayerAudio.Flush();
+    m_omxPlayerVideo.Flush();
+    m_dvdPlayerSubtitle.Flush();
+    m_dvdPlayerTeletext.Flush();
 
     // clear subtitle and menu overlays
     m_overlayContainer.Clear();
@@ -3343,8 +3380,8 @@ void COMXPlayer::FlushBuffers(bool queued, double pts, bool accurate)
     {
       // make sure players are properly flushed, should put them in stalled state
       CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(1000, 0);
-      m_player_video.SendMessage(msg->Acquire(), 1);
-      m_player_audio.SendMessage(msg->Acquire(), 1);
+      m_omxPlayerAudio.SendMessage(msg->Acquire(), 1);
+      m_omxPlayerVideo.SendMessage(msg->Acquire(), 1);
       msg->Wait(&m_bStop, 0);
       msg->Release();
 
@@ -3384,7 +3421,7 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
     else if(iMessage == 3)
       m_dvd.iSelectedSPUStream   = *(int*)pData;
     else if(iMessage == 4)
-      m_player_video.EnableSubtitle(*(int*)pData ? true: false);
+      m_omxPlayerVideo.EnableSubtitle(*(int*)pData ? true: false);
     else if(iMessage == 5)
     {
       if (m_dvd.state != DVDSTATE_STILL)
@@ -3398,7 +3435,7 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
         unsigned int time = 0;
         if( m_CurrentVideo.stream && m_dvd.iDVDStillTime > 0 )
         {
-          time = (unsigned int)(m_player_video.GetOutputDelay() / ( DVD_TIME_BASE / 1000 ));
+          time = (unsigned int)(m_omxPlayerVideo.GetOutputDelay() / ( DVD_TIME_BASE / 1000 ));
           if( time < 10000 && time > 0 )
             m_dvd.iDVDStillTime += time;
         }
@@ -3441,7 +3478,7 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
           DWORD time = 0;
           if( m_CurrentVideo.stream && m_dvd.iDVDStillTime > 0 )
           {
-            time = (DWORD)(m_player_video.GetOutputDelay() / ( DVD_TIME_BASE / 1000 ));
+            time = (DWORD)(m_omxPlayerVideo.GetOutputDelay() / ( DVD_TIME_BASE / 1000 ));
             if( time < 10000 && time > 0 )
               m_dvd.iDVDStillTime += time;
           }
@@ -3455,7 +3492,7 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
       break;
     case DVDNAV_SPU_CLUT_CHANGE:
       {
-        m_player_subtitle.SendMessage(new CDVDMsgSubtitleClutChange((BYTE*)pData));
+        m_dvdPlayerSubtitle.SendMessage(new CDVDMsgSubtitleClutChange((BYTE*)pData));
       }
       break;
     case DVDNAV_SPU_STREAM_CHANGE:
@@ -3465,7 +3502,7 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
         int iStream = event->physical_wide;
         bool visible = !(iStream & 0x80);
 
-        m_player_video.EnableSubtitle(visible);
+        m_omxPlayerVideo.EnableSubtitle(visible);
 
         if (iStream >= 0)
           m_dvd.iSelectedSPUStream = (iStream & ~0x80);
@@ -3495,7 +3532,7 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
         //dvdnav_highlight_event_t* pInfo = (dvdnav_highlight_event_t*)pData;
         int iButton = pStream->GetCurrentButton();
         CLog::Log(LOGDEBUG, "DVDNAV_HIGHLIGHT: Highlight button %d\n", iButton);
-        m_player_subtitle.UpdateOverlayInfo((CDVDInputStreamNavigator*)m_pInputStream, LIBDVDNAV_BUTTON_NORMAL);
+        m_dvdPlayerSubtitle.UpdateOverlayInfo((CDVDInputStreamNavigator*)m_pInputStream, LIBDVDNAV_BUTTON_NORMAL);
       }
       break;
     case DVDNAV_VTS_CHANGE:
@@ -3508,8 +3545,8 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
 
         //Force an aspect ratio that is set in the dvdheaders if available
         m_CurrentVideo.hint.aspect = pStream->GetVideoAspectRatio();
-        if( m_player_video.IsInited() )
-          m_player_video.SendMessage(new CDVDMsgDouble(CDVDMsg::VIDEO_SET_ASPECT, m_CurrentVideo.hint.aspect));
+        if( m_omxPlayerVideo.IsInited() )
+          m_omxPlayerVideo.SendMessage(new CDVDMsgDouble(CDVDMsg::VIDEO_SET_ASPECT, m_CurrentVideo.hint.aspect));
 
         m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NAV);
         m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
@@ -3524,8 +3561,8 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
 
         m_dvd.state = DVDSTATE_NORMAL;
 
-        if( m_player_video.IsInited() )
-          m_player_video.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
+        if( m_omxPlayerVideo.IsInited() )
+          m_omxPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
       }
       break;
     case DVDNAV_NAV_PACKET:
@@ -3730,7 +3767,7 @@ bool COMXPlayer::OnAction(const CAction &action)
           CLog::Log(LOGDEBUG, " - button select");
           // show button pushed overlay
           if(m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
-            m_player_subtitle.UpdateOverlayInfo((CDVDInputStreamNavigator*)m_pInputStream, LIBDVDNAV_BUTTON_CLICKED);
+            m_dvdPlayerSubtitle.UpdateOverlayInfo((CDVDInputStreamNavigator*)m_pInputStream, LIBDVDNAV_BUTTON_CLICKED);
 
           pMenus->ActivateButton();
         }
@@ -3846,15 +3883,15 @@ bool COMXPlayer::HasMenu()
 
 bool COMXPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
 {
+  double pts = m_av_clock.GetClock();
+
   if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
     return false;
 
-  double pts = m_av_clock.OMXMediaTime(false);
-
-  m_player_subtitle.GetCurrentSubtitle(strSubtitle, pts - m_player_video.GetSubtitleDelay());
+  m_dvdPlayerSubtitle.GetCurrentSubtitle(strSubtitle, pts - m_omxPlayerVideo.GetSubtitleDelay());
 
   // In case we stalled, don't output any subs
-  if ((m_player_video.IsStalled() && HasVideo()) || (m_player_audio.IsStalled() && HasAudio()))
+  if ((m_omxPlayerVideo.IsStalled() && HasVideo()) || (m_omxPlayerAudio.IsStalled() && HasAudio()))
     strSubtitle = m_lastSub;
   else
     m_lastSub = strSubtitle;
@@ -3929,14 +3966,14 @@ int COMXPlayer::GetCacheLevel() const
 
 double COMXPlayer::GetQueueTime()
 {
-  int a = m_player_video.GetLevel();
-  int v = m_player_audio.GetLevel();
+  int a = m_omxPlayerVideo.GetLevel();
+  int v = m_omxPlayerAudio.GetLevel();
   return max(a, v) * 8000.0 / 100;
 }
 
 void COMXPlayer::GetVideoStreamInfo(SPlayerVideoStreamInfo &info)
 {
-  info.bitrate = m_player_video.GetVideoBitrate();
+  info.bitrate = m_omxPlayerVideo.GetVideoBitrate();
 
   CStdString retVal;
   if (m_pDemuxer && (m_CurrentVideo.id != -1))
@@ -3960,7 +3997,7 @@ void COMXPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
     return;
 
   if (index == GetAudioStream())
-    info.bitrate = m_player_audio.GetAudioBitrate();
+    info.bitrate = m_omxPlayerAudio.GetAudioBitrate();
   else
     info.bitrate = m_pDemuxer->GetStreamFromAudioId(index)->iBitRate;
 
@@ -4044,11 +4081,7 @@ void COMXPlayer::UpdatePlayState(double timeout)
     if(state.dts == DVD_NOPTS_VALUE)
       state.time     = 0;
     else 
-      // TODO : workaround until omx clock handling is rewritten
-      if(m_playSpeed == DVD_PLAYSPEED_NORMAL)
-        state.time     = DVD_TIME_TO_MSEC(m_av_clock.OMXMediaTime(true));
-      else
-        state.time     = DVD_TIME_TO_MSEC(state.dts + m_offset_pts);
+      state.time     = DVD_TIME_TO_MSEC(state.dts + m_offset_pts);
     state.time_total = m_pDemuxer->GetStreamLength();
     state.time_src   = ETIMESOURCE_CLOCK;
   }
@@ -4233,7 +4266,7 @@ bool COMXPlayer::GetStreamDetails(CStreamDetails &details)
        * and UpdatePlayState() has been called at least once. In this case dvdplayer duration/AR will
        * return 0 and we'll have to fallback to the (less accurate) info from the demuxer.
        */
-      float aspect = m_player_video.GetAspectRatio();
+      float aspect = m_omxPlayerVideo.GetAspectRatio();
       if (aspect > 0.0f)
         ((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_fAspect = aspect;
 
@@ -4250,7 +4283,7 @@ bool COMXPlayer::GetStreamDetails(CStreamDetails &details)
 CStdString COMXPlayer::GetPlayingTitle()
 {
   /* Currently we support only Title Name from Teletext line 30 */
-  TextCacheStruct_t* ttcache = m_player_teletext.GetTeletextCache();
+  TextCacheStruct_t* ttcache = m_dvdPlayerTeletext.GetTeletextCache();
   if (ttcache && !ttcache->line30.empty())
     return ttcache->line30;
 
@@ -4297,23 +4330,6 @@ void COMXPlayer::SetVolume(float fVolume)
 {
   m_current_volume = fVolume;
   m_change_volume = true;
-}
-
-bool COMXPlayer::WaitForPausedThumbJobs(int timeout_ms)
-{
-  // use m_bStop and Sleep so we can get canceled.
-  while (!m_bStop && (timeout_ms > 0))
-  {
-    if (CJobManager::GetInstance().IsProcessing(CJob::PRIORITY_LOW))
-    {
-      Sleep(100);
-      timeout_ms -= 100;
-    }
-    else
-      return true;
-  }
-
-  return false;
 }
 
 void COMXPlayer::GetRenderFeatures(std::vector<int> &renderFeatures)

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -19,21 +19,12 @@
  *
  */
 
-#if defined(HAVE_CONFIG_H) && !defined(TARGET_WINDOWS)
-#include "config.h"
-#define DECLARE_UNUSED(a,b) a __attribute__((unused)) b;
-#endif
-
-#include <semaphore.h>
-#include <deque>
-
-#include "FileItem.h"
 #include "cores/IPlayer.h"
-#include "cores/dvdplayer/IDVDPlayer.h"
-#include "dialogs/GUIDialogBusy.h"
 #include "threads/Thread.h"
-#include "threads/SingleLock.h"
 
+#include "cores/dvdplayer/IDVDPlayer.h"
+
+#include "DVDMessageQueue.h"
 #include "OMXCore.h"
 #include "OMXClock.h"
 #include "OMXPlayerAudio.h"
@@ -41,22 +32,14 @@
 #include "DVDPlayerSubtitle.h"
 #include "DVDPlayerTeletext.h"
 
+//#include "DVDChapterReader.h"
+#include "DVDSubtitles/DVDFactorySubtitle.h"
 #include "utils/BitstreamStats.h"
 
 #include "linux/DllBCM.h"
 #include "Edl.h"
-
-#define MAX_CHAPTERS 64
-
-#define DVDPLAYER_AUDIO    1
-#define DVDPLAYER_VIDEO    2
-#define DVDPLAYER_SUBTITLE 3
-#define DVDPLAYER_TELETEXT 4
-
-#define DVDSTATE_NORMAL           0x00000001 // normal dvd state
-#define DVDSTATE_STILL            0x00000002 // currently displaying a still frame
-#define DVDSTATE_WAIT             0x00000003 // waiting for demuxer read error
-#define DVDSTATE_SEEK             0x00000004 // we are finishing a seek request
+#include "FileItem.h"
+#include "threads/SingleLock.h"
 
 class COMXPlayer;
 class OMXPlayerVideo;
@@ -66,6 +49,11 @@ namespace PVR
 {
   class CPVRChannel;
 }
+
+#define DVDSTATE_NORMAL           0x00000001 // normal dvd state
+#define DVDSTATE_STILL            0x00000002 // currently displaying a still frame
+#define DVDSTATE_WAIT             0x00000003 // waiting for demuxer read error
+#define DVDSTATE_SEEK             0x00000004 // we are finishing a seek request
 
 class COMXCurrentStream
 {
@@ -168,6 +156,11 @@ public:
 };
 
 
+#define DVDPLAYER_AUDIO    1
+#define DVDPLAYER_VIDEO    2
+#define DVDPLAYER_SUBTITLE 3
+#define DVDPLAYER_TELETEXT 4
+
 class COMXPlayer : public IPlayer, public CThread, public IDVDPlayer
 {
 public:
@@ -175,73 +168,35 @@ public:
   COMXPlayer(IPlayerCallback &callback);
   virtual ~COMXPlayer();
   
-  virtual void RegisterAudioCallback(IAudioCallback* pCallback) { m_player_audio.RegisterAudioCallback(pCallback); };
-  virtual void UnRegisterAudioCallback()                        { m_player_audio.UnRegisterAudioCallback();        };
-
-  virtual bool  IsValidStream(COMXCurrentStream& stream);
-  virtual bool  IsBetterStream(COMXCurrentStream& current, CDemuxStream* stream);
-  virtual bool  CheckDelayedChannelEntry(void);
-  virtual bool  ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream);
-  virtual bool  CloseAudioStream(bool bWaitForBuffers);
-  virtual bool  CloseVideoStream(bool bWaitForBuffers);
-  virtual bool  CloseSubtitleStream(bool bKeepOverlays);
-  virtual bool  CloseTeletextStream(bool bWaitForBuffers);
-  virtual bool  OpenAudioStream(int iStream, int source, bool reset = true);
-  virtual bool  OpenVideoStream(int iStream, int source, bool reset = true);
-  virtual bool  OpenSubtitleStream(int iStream, int source); 
-  virtual bool  OpenTeletextStream(int iStream, int source);
-  virtual void  OpenDefaultStreams(bool reset = true);
-  virtual bool  OpenDemuxStream();
-  virtual bool  OpenInputStream();
-  virtual bool  CheckPlayerInit(COMXCurrentStream& current, unsigned int source);
-  virtual void  UpdateCorrection(DemuxPacket* pkt, double correction);
-  virtual void  UpdateTimestamps(COMXCurrentStream& current, DemuxPacket* pPacket);
-  virtual void  UpdateLimits(double& minimum, double& maximum, double dts);
-  virtual bool  CheckSceneSkip(COMXCurrentStream& current);
-  virtual void  CheckAutoSceneSkip();
-  virtual void  CheckContinuity(COMXCurrentStream& current, DemuxPacket* pPacket);
-  virtual void  ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket);
-  virtual void  ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket);
-  virtual void  ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket);
-  virtual void  ProcessTeletextData(CDemuxStream* pStream, DemuxPacket* pPacket);
-  virtual void  ProcessPacket(CDemuxStream* pStream, DemuxPacket* pPacket);
-  virtual void  SynchronizeDemuxer(unsigned int timeout);
-  virtual void  SynchronizePlayers(unsigned int sources);
-  virtual void  SendPlayerMessage(CDVDMsg* pMsg, unsigned int target);
-  virtual void  HandleMessages();
-
   virtual bool  OpenFile(const CFileItem &file, const CPlayerOptions &options);
-  virtual bool  QueueNextFile(const CFileItem &file)             {return false;}
-  virtual void  OnNothingToQueueNotify()                         {}
   virtual bool  CloseFile();
   virtual bool  IsPlaying() const;
-  virtual void  SetPlaySpeed(int speed);
-  int GetPlaySpeed()                                                { return m_playSpeed; }
   virtual void  Pause();
   virtual bool  IsPaused() const;
   virtual bool  HasVideo() const;
   virtual bool  HasAudio() const;
   virtual bool  IsPassthrough() const;
   virtual bool  CanSeek();
-  virtual void  Seek(bool bPlus = true, bool bLargeStep = false);
+  virtual void Seek(bool bPlus, bool bLargeStep);
   virtual bool  SeekScene(bool bPlus = true);
-  virtual void  SeekPercentage(float fPercent = 0.0f);
+  virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();
   virtual float GetCachePercentage();
 
-  virtual void  SetMute(bool bOnOff);
-  virtual void  SetVolume(float fVolume);
-  virtual bool  ControlsVolume() {return true;}
-  virtual void  SetDynamicRangeCompression(long drc)              {}
-  virtual void  GetAudioInfo(CStdString &strAudioInfo);
-  virtual void  GetVideoInfo(CStdString &strVideoInfo);
-  virtual void  GetGeneralInfo(CStdString &strVideoInfo);
-  virtual void  UpdateApplication(double timeout);
-  virtual bool  CanRecord();
-  virtual bool  IsRecording();
-  virtual bool  CanPause();
-  virtual bool  Record(bool bOnOff);
-  virtual void  SetAVDelay(float fValue = 0.0f);
+  virtual void RegisterAudioCallback(IAudioCallback* pCallback) { m_omxPlayerAudio.RegisterAudioCallback(pCallback); }
+  virtual void UnRegisterAudioCallback()                        { m_omxPlayerAudio.UnRegisterAudioCallback(); }
+  virtual void SetVolume(float nVolume);
+  virtual void SetMute(bool bOnOff);
+  virtual bool ControlsVolume() {return true;}
+  virtual void SetDynamicRangeCompression(long drc)              {}
+  virtual void GetAudioInfo(CStdString &strAudioInfo);
+  virtual void GetVideoInfo(CStdString &strVideoInfo);
+  virtual void GetGeneralInfo(CStdString &strVideoInfo);
+  virtual bool CanRecord();
+  virtual bool IsRecording();
+  virtual bool CanPause();
+  virtual bool Record(bool bOnOff);
+  virtual void SetAVDelay(float fValue = 0.0f);
   virtual float GetAVDelay();
 
   virtual void  SetSubTitleDelay(float fValue = 0.0f);
@@ -266,25 +221,24 @@ public:
   virtual void  GetChapterName(CStdString& strChapterName);
   virtual int   SeekChapter(int iChapter);
 
-  virtual void  SeekTime(int64_t iTime = 0);
-  virtual int64_t GetTotalTimeInMsec();
+  virtual void SeekTime(int64_t iTime);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
-  virtual void  ToFFRW(int iSpeed = 0);
-  virtual void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
-  virtual void  GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
-  virtual int   GetSourceBitrate();
-  virtual int   GetPictureWidth();
-  virtual int   GetPictureHeight();
-  virtual bool  GetStreamDetails(CStreamDetails &details);
+  virtual void ToFFRW(int iSpeed );
+  virtual bool OnAction(const CAction &action);
+  virtual bool HasMenu();
+  virtual int GetSourceBitrate();
+  virtual void GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
 
-  virtual bool  IsInMenu() const;
-  virtual bool  HasMenu();
+  virtual int GetPictureWidth();
+  virtual int GetPictureHeight();
+  virtual bool GetStreamDetails(CStreamDetails &details);
+  virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
 
-  virtual bool  GetCurrentSubtitle(CStdString& strSubtitle);
-  //returns a state that is needed for resuming from a specific time
+  virtual bool GetCurrentSubtitle(CStdString& strSubtitle);
+
   virtual CStdString GetPlayerState();
-  virtual bool  SetPlayerState(CStdString state);
+  virtual bool SetPlayerState(CStdString state);
   
   virtual CStdString GetPlayingTitle();
 
@@ -300,23 +254,10 @@ public:
   , CACHESTATE_FLUSH    // temporary state player will choose startup between init or full
   };
 
-  int m_playSpeed;
-  struct SSpeedState
-  {
-    double lastpts;  // holds last display pts during ff/rw operations
-    double lasttime;
-  } m_SpeedState;
-
-  void    HandlePlaySpeed();
-  bool    GetCachingTimes(double& play_left, double& cache_left, double& file_offset);
-  bool    CheckStartCaching(COMXCurrentStream& current);
-  void    SetCaching(ECacheState state);
-  double  GetQueueTime();
-  virtual bool  IsCaching() const                                 { return m_caching == CACHESTATE_FULL; }
+  virtual bool  IsCaching() const                                 { return m_caching == CACHESTATE_FULL || m_caching == CACHESTATE_PVR; }
   virtual int   GetCacheLevel() const;
 
   virtual int  OnDVDNavResult(void* pData, int iMessage);
-  virtual bool OnAction(const CAction &action);
 
   virtual void  GetRenderFeatures(std::vector<int> &renderFeatures);
   virtual void  GetDeinterlaceMethods(std::vector<int> &deinterlaceMethods);
@@ -335,19 +276,115 @@ protected:
 
   virtual void  OnStartup();
   virtual void  OnExit();
-  bool WaitForPausedThumbJobs(int timeout_ms);
   virtual void  Process();
 
+  bool OpenAudioStream(int iStream, int source, bool reset = true);
+  bool OpenVideoStream(int iStream, int source, bool reset = true);
+  bool OpenSubtitleStream(int iStream, int source);
+  bool OpenTeletextStream(int iStream, int source);
+  bool CloseAudioStream(bool bWaitForBuffers);
+  bool CloseVideoStream(bool bWaitForBuffers);
+  bool CloseSubtitleStream(bool bKeepOverlays);
+  bool CloseTeletextStream(bool bWaitForBuffers);
+
+  void ProcessPacket(CDemuxStream* pStream, DemuxPacket* pPacket);
+  void ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket);
+  void ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket);
+  void ProcessSubData(CDemuxStream* pStream, DemuxPacket* pPacket);
+  void ProcessTeletextData(CDemuxStream* pStream, DemuxPacket* pPacket);
+
+  bool ShowPVRChannelInfo();
+
+  int  AddSubtitleFile(const std::string& filename, const std::string& subfilename = "", CDemuxStream::EFlags flags = CDemuxStream::FLAG_NONE);
+
+  /**
+   * one of the DVD_PLAYSPEED defines
+   */
+  void SetPlaySpeed(int iSpeed);
+  int GetPlaySpeed()                                                { return m_playSpeed; }
+  void    SetCaching(ECacheState state);
+
+  int64_t GetTotalTimeInMsec();
+
+  double  GetQueueTime();
+  bool    GetCachingTimes(double& play_left, double& cache_left, double& file_offset);
+
+
+  void FlushBuffers(bool queued, double pts = DVD_NOPTS_VALUE, bool accurate = true);
+
+
+  void  HandleMessages();
+  void    HandlePlaySpeed();
+  bool  IsInMenu() const;
+
+  void SynchronizePlayers(unsigned int sources);
+  void SynchronizeDemuxer(unsigned int timeout);
+  void CheckAutoSceneSkip();
+  void CheckContinuity(COMXCurrentStream& current, DemuxPacket* pPacket);
+  bool CheckSceneSkip(COMXCurrentStream& current);
+  bool CheckPlayerInit(COMXCurrentStream& current, unsigned int source);
+  bool CheckStartCaching(COMXCurrentStream& current);
+  void UpdateCorrection(DemuxPacket* pkt, double correction);
+  void UpdateTimestamps(COMXCurrentStream& current, DemuxPacket* pPacket);
+  void SendPlayerMessage(CDVDMsg* pMsg, unsigned int target);
+  bool ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream);
+  bool IsValidStream(COMXCurrentStream& stream);
+  bool IsBetterStream(COMXCurrentStream& current, CDemuxStream* stream);
+  bool CheckDelayedChannelEntry(void);
+  bool OpenInputStream();
+  bool OpenDemuxStream();
+  void OpenDefaultStreams(bool reset = true);
+
+  void UpdateApplication(double timeout);
+  void UpdatePlayState(double timeout);
+  double m_UpdateApplication;
+
+  bool m_bAbortRequest;
+
   std::string           m_filename; // holds the actual filename
-  CDVDInputStream       *m_pInputStream;
-  CDVDDemux             *m_pDemuxer;
+  std::string  m_mimetype;  // hold a hint to what content file contains (mime type)
+  ECacheState  m_caching;
+  CFileItem    m_item;
+  unsigned int m_iChannelEntryTimeOut;
+
+
+  COMXCurrentStream m_CurrentAudio;
+  COMXCurrentStream m_CurrentVideo;
+  COMXCurrentStream m_CurrentSubtitle;
+  COMXCurrentStream m_CurrentTeletext;
+
+  COMXSelectionStreams m_SelectionStreams;
+
+  int m_playSpeed;
+  struct SSpeedState
+  {
+    double lastpts;  // holds last display pts during ff/rw operations
+    double lasttime;
+  } m_SpeedState;
+
+  int m_errorCount;
+  double m_offset_pts;
+
+  CDVDMessageQueue m_messenger;     // thread messenger
+
+  OMXPlayerVideo m_omxPlayerVideo; // video part
+  OMXPlayerAudio m_omxPlayerAudio; // audio part
+  CDVDPlayerSubtitle m_dvdPlayerSubtitle; // subtitle part
+  CDVDTeletextData m_dvdPlayerTeletext; // teletext part
+
+  OMXClock m_av_clock;                // master clock
+
+  float m_current_volume;
+  bool m_current_mute;
+  bool m_change_volume;
+
+  CDVDOverlayContainer m_overlayContainer;
+
+  CDVDInputStream* m_pInputStream;  // input stream for current playing file
+  CDVDDemux* m_pDemuxer;            // demuxer for current playing file
   CDVDDemux*            m_pSubtitleDemuxer;
-  COMXSelectionStreams  m_SelectionStreams;
-  std::string           m_mimetype;
-  COMXCurrentStream     m_CurrentAudio;
-  COMXCurrentStream     m_CurrentVideo;
-  COMXCurrentStream     m_CurrentSubtitle;
-  COMXCurrentStream     m_CurrentTeletext;
+
+  CStdString m_lastSub;
 
   struct SDVDInfo
   {
@@ -437,6 +474,9 @@ protected:
   } m_State, m_StateInput;
   CCriticalSection m_StateSection;
 
+  CEvent m_ready;
+  CCriticalSection m_critStreamSection; // need to have this lock when switching streams (audio / video)
+
   CEdl m_Edl;
 
   struct SEdlAutoSkipMarkers {
@@ -458,45 +498,7 @@ protected:
 
   } m_EdlAutoSkipMarkers;
 
-  bool ShowPVRChannelInfo();
-
-  int  AddSubtitleFile(const std::string& filename, const std::string& subfilename = "", CDemuxStream::EFlags flags = CDemuxStream::FLAG_NONE);
-  virtual void UpdatePlayState(double timeout);
-
-  double m_UpdateApplication;
-
-  void RenderUpdateCallBack(const void *ctx, const CRect &SrcRect, const CRect &DestRect);
-
-private:
-  void FlushBuffers(bool queued, double pts = DVD_NOPTS_VALUE, bool accurate = true);
-
-  CCriticalSection        m_critStreamSection;
-
-  bool                    m_paused;
-  bool                    m_bAbortRequest;
-  CFileItem               m_item;
   CPlayerOptions          m_PlayerOptions;
-  unsigned int            m_iChannelEntryTimeOut;
-
-  std::string             m_lastSub;
-
-  double                  m_offset_pts;
-
-  CDVDMessageQueue        m_messenger;
-
-  OMXClock                m_av_clock;
-  OMXPlayerVideo          m_player_video;
-  OMXPlayerAudio          m_player_audio;
-  CDVDPlayerSubtitle      m_player_subtitle;
-  CDVDTeletextData        m_player_teletext;
-
-  CEvent                  m_ready;
-
-  float                   m_current_volume;
-  bool                    m_current_mute;
-  bool                    m_change_volume;
-  CDVDOverlayContainer    m_overlayContainer;
-  ECacheState             m_caching;
 
   bool m_HasVideo;
   bool m_HasAudio;

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -118,7 +118,7 @@ public:
   void CloseDecoder();
   double GetDelay();
   double GetCacheTime();
-  double GetCurrentPTS() { return m_audioClock; };
+  double GetCurrentPts() { return m_audioClock; };
   void WaitCompletion();
   void SubmitEOS();
   void  RegisterAudioCallback(IAudioCallback* pCallback);

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -45,6 +45,7 @@
 #include "settings/MediaSettings.h"
 #include "cores/VideoRenderers/RenderFormats.h"
 #include "cores/VideoRenderers/RenderFlags.h"
+#include "guilib/GraphicContext.h"
 
 #include "OMXPlayer.h"
 
@@ -296,7 +297,7 @@ void OMXPlayerVideo::Output(double pts, bool bDropPacket)
   if (!CThread::m_bStop && m_av_clock->GetAbsoluteClock(false) < m_iSleepEndTime + DVD_MSEC_TO_TIME(500))
     return;
 
-  int buffer = g_renderManager.WaitForBuffer(CThread::m_bStop, iSleepTime + DVD_MSEC_TO_TIME(500));
+  int buffer = g_renderManager.WaitForBuffer(CThread::m_bStop, std::max(DVD_TIME_TO_MSEC(iSleepTime) + 500, 0));
   if (buffer < 0)
     return;
 

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -106,7 +106,7 @@ public:
   bool OpenDecoder();
   int  GetDecoderBufferSize();
   int  GetDecoderFreeSpace();
-  double GetCurrentPTS() { return m_iCurrentPts; };
+  double GetCurrentPts() { return m_iCurrentPts; };
   double GetFPS() { return m_fFrameRate; };
   void  SubmitEOS();
   bool SubmittedEOS();


### PR DESCRIPTION
To make spotting differences between omxplayer and dvdplayer easier in the future,
this is a pretty slavish copy, including dvdplayer's whitespace and header file includes.
You now get a pretty clean diff between dvdplayer.cpp/dvdplayer.h and omxplayer.cpp/omxplayer.h
