### PR TITLE
[fix] stack could mistakenly be seen as a FileDirectory if the contained...

### DIFF
--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -62,6 +62,9 @@ CFileDirectoryFactory::~CFileDirectoryFactory(void)
 // return NULL + set pItem->m_bIsFolder to remove it completely from list.
 IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileItem* pItem, const CStdString& strMask)
 {
+  if (URIUtils::IsStack(strPath)) // disqualify stack as we need to work with each of the parts instead
+    return NULL;
+
   CStdString strExtension=URIUtils::GetExtension(strPath);
   strExtension.MakeLower();
 


### PR DESCRIPTION
... extension was ISO

The problem solved here is that CFileDirectoryFactory _just_ looks at the extension, without taking into account the 'protocol'. So a stack of .ISOs is seen by CFileDirectoryFactory as a single ISO, which then assumes that we're trying to open an ISO Directory (returns CUDFDirectory). 

This 'bug' has been introduced in 850a7e00a7a597df450ba8d0c73bfdbc6aace4af - the changes for ISO/UDF "Browse Into". 

In order to make the fix simple, it's better to ignore the creation of a FileDirectory when we're dealing with a stack . Anyway, when playing back a stack part, it will be treated as a separate file, and at that time lead to the (correct) opening of a UDFDirectory for that particular individual ISO.
