### PR TITLE
Add ripped CDs automatically to database

### DIFF
--- a/xbmc/cdrip/CDDARipJob.h
+++ b/xbmc/cdrip/CDDARipJob.h
@@ -52,6 +52,7 @@ public:
   virtual const char* GetType() const { return "cdrip"; };
   virtual bool operator==(const CJob *job) const;
   virtual bool DoWork();
+  CStdString GetOutput() const { return m_output; }
 protected:
   //! \brief Setup the audio encoder
   CEncoder* SetupEncoder(XFILE::CFile& reader);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2193,6 +2193,12 @@ bool CMusicDatabase::CleanupPaths()
   return false;
 }
 
+bool CMusicDatabase::InsideScannedPath(const CStdString& path)
+{
+  CStdString sql = PrepareSQL("select idPath from path where SUBSTR(strPath,1,%i)='%s' LIMIT 1", path.size(), path.c_str());
+  return !GetSingleValue(sql).empty();
+}
+
 bool CMusicDatabase::CleanupArtists()
 {
   try

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -171,6 +171,10 @@ public:
   bool GetAlbum(int idAlbum, CAlbum& album);
   int  UpdateAlbum(int idAlbum, const CAlbum &album);
   bool DeleteAlbum(int idAlbum);
+  /*! \brief Checks if the given path is inside a folder that has already been scanned into the library
+   \param path the path we want to check
+   */
+  bool InsideScannedPath(const CStdString& path);
 
   //// Misc Album
   int  GetAlbumIdByPath(const CStdString& path);

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -158,6 +158,13 @@ void CJobQueue::CancelJobs()
   m_processing.clear();
 }
 
+
+bool CJobQueue::QueueEmpty() const
+{
+  CSingleLock lock(m_section);
+  return m_jobQueue.empty();
+}
+
 CJobManager &CJobManager::GetInstance()
 {
   static CJobManager sJobManager;

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -135,6 +135,13 @@ public:
    */
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
 
+protected:
+  /*!
+   \brief Returns if we still have jobs waiting to be processed
+   NOTE: This function does not take into account the jobs that are currently processing 
+   */
+  bool QueueEmpty() const;
+  
 private:
   void QueueNextJob();
 


### PR DESCRIPTION
After ripping a CD, the albumfolder will be scanned into the database.

Instead of adding a setting to enable this behavior, i check if the rip path is inside a music source, and if so, do the scan. 
