### PR TITLE
[dvd/omxplayer] don't override NextItem/PreviousItem with chapter skipping

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3672,28 +3672,6 @@ bool CDVDPlayer::OnAction(const CAction &action)
     }
   }
 
-  switch (action.GetID())
-  {
-    case ACTION_NEXT_ITEM:
-      if(GetChapterCount() > 0)
-      {
-        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()+1));
-        g_infoManager.SetDisplayAfterSeek();
-        return true;
-      }
-      else
-        break;
-    case ACTION_PREV_ITEM:
-      if(GetChapterCount() > 0)
-      {
-        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()-1));
-        g_infoManager.SetDisplayAfterSeek();
-        return true;
-      }
-      else
-        break;
-  }
-
   // return false to inform the caller we didn't handle the message
   return false;
 }

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3786,28 +3786,6 @@ bool COMXPlayer::OnAction(const CAction &action)
     }
   }
 
-  switch (action.GetID())
-  {
-    case ACTION_NEXT_ITEM:
-      if(GetChapterCount() > 0)
-      {
-        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()+1));
-        g_infoManager.SetDisplayAfterSeek();
-        return true;
-      }
-      else
-        break;
-    case ACTION_PREV_ITEM:
-      if(GetChapterCount() > 0)
-      {
-        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()-1));
-        g_infoManager.SetDisplayAfterSeek();
-        return true;
-      }
-      else
-        break;
-  }
-
   // return false to inform the caller we didn't handle the message
   return false;
 }


### PR DESCRIPTION
As outlined here:

http://forum.xbmc.org/showthread.php?tid=166190

we currently translate both BigStepForward/Back and NextItem/PreviousItem into chapter skips if chapters are present.  This changes it so that Next/Previous item are always available to skip through playlists etc.
