### PR TITLE
renderer: replace ring buffer logic with queues for free, queued, and discarded buffers

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -699,9 +699,10 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
     if(source < 0)
       source = m_free.front();
 
-    m_Queue[source].timestamp     = timestamp;
-    m_Queue[source].presentfield  = sync;
-    m_Queue[source].presentmethod = presentmethod;
+    SPresent& m = m_Queue[source];
+    m.timestamp     = timestamp;
+    m.presentfield  = sync;
+    m.presentmethod = presentmethod;
     requeue(m_queued, m_free);
 
     /* signal to any waiters to check state */

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -272,8 +272,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
       lock.Enter();
     }
     lock2.Enter();
-    if( format & RENDER_FMT_BYPASS )
-      m_presentmethod = PRESENT_METHOD_BYPASS;
+    m_format = format;
 
     int processor = m_pRenderer->GetProcessorSize();
     if(processor)
@@ -312,7 +311,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
 
 bool CXBMCRenderManager::RendererHandlesPresent() const
 {
-  return IsConfigured() && m_presentmethod != PRESENT_METHOD_BYPASS;
+  return IsConfigured() && m_format != RENDER_FMT_BYPASS;
 }
 
 bool CXBMCRenderManager::IsConfigured() const

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -878,9 +878,13 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
   if (!m_pRenderer)
     return -1;
 
-  if(m_free.empty())
-    return -1;
-  int index = m_free.front();
+  int index;
+  {
+    CSingleLock lock(m_presentlock);
+    if (m_free.empty())
+      return -1;
+    index = m_free.front();
+  }
 
   if(m_pRenderer->AddVideoPicture(&pic, index))
     return 1;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -231,13 +231,11 @@ protected:
   std::deque<int> m_discard;
 
   ERenderFormat   m_format;
-  double     m_presenttime;
+
   double     m_presentcorr;
   double     m_presenterr;
   double     m_errorbuff[ERRORBUFFSIZE];
   int        m_errorindex;
-  EFIELDSYNC m_presentfield;
-  EPRESENTMETHOD m_presentmethod;
   EPRESENTSTEP     m_presentstep;
   int        m_presentsource;
   XbmcThreads::ConditionVariable  m_presentevent;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -220,7 +220,7 @@ protected:
   int m_QueueSize;
   int m_QueueSkip;
 
-  struct
+  struct SPresent
   {
     double         timestamp;
     EFIELDSYNC     presentfield;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -185,8 +185,6 @@ protected:
   void PresentFields(bool clear, DWORD flags, DWORD alpha);
   void PresentBlend(bool clear, DWORD flags, DWORD alpha);
 
-  int  GetNextRender();
-  int  GetNextDecode();
   void PrepareNextRender();
 
   EINTERLACEMETHOD AutoInterlaceMethodInternal(EINTERLACEMETHOD mInt);

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -211,7 +211,6 @@ protected:
     PRESENT_METHOD_BLEND,
     PRESENT_METHOD_WEAVE,
     PRESENT_METHOD_BOB,
-    PRESENT_METHOD_BYPASS,
   };
 
   double m_displayLatency;
@@ -231,6 +230,7 @@ protected:
   std::deque<int> m_queued;
   std::deque<int> m_discard;
 
+  ERenderFormat   m_format;
   double     m_presenttime;
   double     m_presentcorr;
   double     m_presenterr;


### PR DESCRIPTION
@elupus this is follow up on our discussion on render buffers and implements your idea of using fences.

d416c5314e9a0c5faf0046abf165bbc89e267524 moves the ringbuffer into dedicated queues of free buffers, queued buffers, and rendered buffers. This is more flexible and allows the buffers carrying their own state.

It should not change current behavior even not for vdpau because it uses only a single pixmap buffer. #870 will require this change.

EDIT: updated scope, fence for detection when a buffer has actually been rendered was moved to a future pr.
