### PR TITLE
pvr: Pass selected item to menu hooks

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -108,10 +108,11 @@ extern "C"
    * Call one of the menu hooks (if supported).
    * Supported PVR_MENUHOOK instances have to be added in ADDON_Create(), by calling AddMenuHook() on the callback.
    * @param menuhook The hook to call.
+   * @param item The selected item for which the hook was called.
    * @return PVR_ERROR_NO_ERROR if the hook was called successfully.
    * @remarks Optional. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook);
+  PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA &item);
   //@}
 
   /*! @name PVR EPG methods

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -121,6 +121,7 @@ extern "C" {
    */
   typedef enum
   {
+    PVR_MENUHOOK_UNKNOWN         =-1, /*!< @brief unknown menu hook */
     PVR_MENUHOOK_ALL             = 0, /*!< @brief all categories */
     PVR_MENUHOOK_CHANNEL         = 1, /*!< @brief for channels */
     PVR_MENUHOOK_TIMER           = 2, /*!< @brief for timers */
@@ -310,6 +311,20 @@ extern "C" {
   } ATTRIBUTE_PACKED PVR_EDL_ENTRY;
 
   /*!
+   * @brief PVR menu hook data
+   */
+  typedef struct PVR_MENUHOOK_DATA
+  {
+    PVR_MENUHOOK_CAT cat;
+    union data {
+      int iEpgUid;
+      PVR_CHANNEL channel;
+      PVR_TIMER timer;
+      PVR_RECORDING recording;
+    } data;
+  } ATTRIBUTE_PACKED PVR_MENUHOOK_DATA;
+
+  /*!
    * @brief Structure to transfer the methods from xbmc_pvr_dll.h to XBMC
    */
   typedef struct PVRClient
@@ -324,7 +339,7 @@ extern "C" {
     const char*  (__cdecl* GetBackendVersion)(void);
     const char*  (__cdecl* GetConnectionString)(void);
     PVR_ERROR    (__cdecl* GetDriveSpace)(long long*, long long*);
-    PVR_ERROR    (__cdecl* MenuHook)(const PVR_MENUHOOK&);
+    PVR_ERROR    (__cdecl* MenuHook)(const PVR_MENUHOOK&, const PVR_MENUHOOK_DATA&);
     PVR_ERROR    (__cdecl* GetEpg)(ADDON_HANDLE, const PVR_CHANNEL&, time_t, time_t);
     int          (__cdecl* GetChannelGroupsAmount)(void);
     PVR_ERROR    (__cdecl* GetChannelGroups)(ADDON_HANDLE, bool);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -166,7 +166,7 @@ void CPVRManager::OnSettingAction(const CSetting *setting)
   else if (settingId == "pvrclient.menuhook")
   {
     if (IsStarted())
-      Clients()->ProcessMenuHooks(-1, PVR_MENUHOOK_SETTING);
+      Clients()->ProcessMenuHooks(-1, PVR_MENUHOOK_SETTING, NULL);
   }
 }
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -156,8 +156,9 @@ namespace PVR
     /*!
      * @brief Call one of the menu hooks of this client.
      * @param hook The hook to call.
+     * @param item The selected file item for which the hook was called.
      */
-    void CallMenuHook(const PVR_MENUHOOK &hook);
+    void CallMenuHook(const PVR_MENUHOOK &hook, const CFileItem *item);
 
     //@}
     /** @name PVR EPG methods */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -682,7 +682,7 @@ bool CPVRClients::GetMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, PVR_MENUHOOK
   return bReturn;
 }
 
-void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat)
+void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CFileItem *item)
 {
   PVR_MENUHOOKS *hooks = NULL;
 
@@ -739,7 +739,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat)
 
     int selection = pDialog->GetSelectedLabel();
     if (selection >= 0)
-      client->CallMenuHook(hooks->at(selection));
+      client->CallMenuHook(hooks->at(selection), item);
   }
 }
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -519,8 +519,9 @@ namespace PVR
     /*!
      * @brief Open selection and progress PVR actions.
      * @param iClientId The ID of the client to process the menu entries for. Process the menu entries for the active channel if iClientId < 0.
+     * @param item The selected file item for which the hook was called.
      */
-    void ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat);
+    void ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CFileItem *item);
 
     //@}
 

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -342,13 +342,13 @@ bool CGUIWindowPVRCommon::OnContextButtonMenuHooks(CFileItem *item, CONTEXT_BUTT
     bReturn = true;
 
     if (item->IsEPG() && item->GetEPGInfoTag()->HasPVRChannel())
-      g_PVRClients->ProcessMenuHooks(item->GetEPGInfoTag()->ChannelTag()->ClientID(), PVR_MENUHOOK_EPG);
+      g_PVRClients->ProcessMenuHooks(item->GetEPGInfoTag()->ChannelTag()->ClientID(), PVR_MENUHOOK_EPG, item);
     else if (item->IsPVRChannel())
-      g_PVRClients->ProcessMenuHooks(item->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL);
+      g_PVRClients->ProcessMenuHooks(item->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL, item);
     else if (item->IsPVRRecording())
-      g_PVRClients->ProcessMenuHooks(item->GetPVRRecordingInfoTag()->m_iClientId, PVR_MENUHOOK_RECORDING);
+      g_PVRClients->ProcessMenuHooks(item->GetPVRRecordingInfoTag()->m_iClientId, PVR_MENUHOOK_RECORDING, item);
     else if (item->IsPVRTimer())
-      g_PVRClients->ProcessMenuHooks(item->GetPVRTimerInfoTag()->m_iClientId, PVR_MENUHOOK_TIMER);
+      g_PVRClients->ProcessMenuHooks(item->GetPVRTimerInfoTag()->m_iClientId, PVR_MENUHOOK_TIMER, item);
   }
 
   return bReturn;


### PR DESCRIPTION
Currently it is not possible to retrieve any information about the
selected item in the addon's menu hook callback. Therefore menu
hooks can only trigger actions per category, but not per item.

This patch removes this limitation by extending CallMenuHook with
an item parameter representing the type (PVR_MENUHOOK_CAT) and the
data of the currently selected item. The type PVR_MENUHOOK_UNKNOWN
indicates that no selection is available (as for settings hooks).

Needs PVR API version bump and the corresponding changes in the addon's repository.

I hope this can be considered, since it allows to call some backend specific functionalities.
