### PR TITLE
[rbp/omxplayer] Support planar float format audio directly

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -117,7 +117,6 @@ private:
   int           m_extrasize;
   std::string   m_deviceuse;
   // stuff for visualisation
-  unsigned int  m_vizBufferSamples;
   double        m_last_pts;
   int           m_vizBufferSize;
   uint8_t       *m_vizBuffer;

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.h
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.h
@@ -32,8 +32,6 @@
 class COMXAudioCodecOMX
 {
 public:
-  static void Upmix(void *input, unsigned int channelsInput,  void *output,
-    unsigned int channelsOutput, unsigned int frames, AEDataFormat dataFormat);
   COMXAudioCodecOMX();
   virtual ~COMXAudioCodecOMX();
   bool Open(CDVDStreamInfo &hints);
@@ -44,7 +42,7 @@ public:
   int GetChannels();
   virtual CAEChannelInfo GetChannelMap();
   int GetSampleRate();
-  static int GetBitsPerSample();
+  int GetBitsPerSample();
   static const char* GetName() { return "FFmpeg"; }
   int GetBufferSize() { return m_iBuffered; }
   int GetBitRate();
@@ -53,6 +51,7 @@ protected:
   AVCodecContext* m_pCodecContext;
   SwrContext*     m_pConvert;
   enum AVSampleFormat m_iSampleFormat;
+  enum AVSampleFormat m_desiredSampleFormat;
   CAEChannelInfo      m_channelLayout;
 
   AVFrame* m_pFrame1;
@@ -70,6 +69,7 @@ protected:
   int     m_channels;
   uint64_t m_layout;
 
+  bool m_bFirstFrame;
   DllAvCodec m_dllAvCodec;
   DllAvUtil m_dllAvUtil;
   DllSwResample m_dllSwResample;

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -683,7 +683,6 @@ AEDataFormat OMXPlayerAudio::GetDataFormat(CDVDStreamInfo hints)
     hdmi_passthrough_ac3 = true;
   if (m_DllBcmHost.vc_tv_hdmi_audio_supported(EDID_AudioFormat_eDTS, 2, EDID_AudioSampleRate_e44KHz, EDID_AudioSampleSize_16bit ) == 0)
     hdmi_passthrough_dts = true;
-  //printf("Audio support AC3=%d, DTS=%d\n", hdmi_passthrough_ac3, hdmi_passthrough_dts);
 
   m_passthrough = false;
   m_hw_decode   = false;
@@ -723,10 +722,10 @@ AEDataFormat OMXPlayerAudio::GetDataFormat(CDVDStreamInfo hints)
   /* software path */
   if(!m_passthrough && !m_hw_decode)
   {
-    /* 6 channel have to be mapped to 8 for PCM */
-    if(m_nChannels > 4)
-      m_nChannels = 8;
-    dataFormat = AE_FMT_S16NE;
+    if (m_pAudioCodec && m_pAudioCodec->GetBitsPerSample() == 16)
+      dataFormat = AE_FMT_S16NE;
+    else
+      dataFormat = AE_FMT_FLOAT;
   }
 
   return dataFormat;


### PR DESCRIPTION
The update to ffmpeg1.2 has produced a significant performance hit on the Pi when decoding multichannel audio without passthrough.
This is because (most) audio codecs now output planar floating point, rather than interleaved S16 samples.
OpenMax/GPU can handle interleaved S16 samples directly, whereas the floating point planar samples get converted with swr_convert.
This is a slow operation, and a quick profile showed it to be taking about 150MHz of ARM CPU when using 6 channel audio.

I've added support on GPU for a new floating point planar format in audio_decode component.
This PR makes this format also supported for sending audio to the GPU.
The GPU now also handles the 6->8 channel padding so the UpMix() function is no longer required,
which may improve performance compared to pre-ffpeg1.2 version.

This PR requires recent GPU firmware. (384946 or later).
