### PR TITLE
[RFC] Clarify behavior of GetOffset

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -183,7 +183,16 @@ protected:
    this also marks the control as dirty (if needed)
    */
   void SetOffset(int offset);
+  /*! \brief Returns the index of the first visible row
+   returns the first row. This may be outside of the range of available items. Use GetItemOffset() to retrieve the first visible item in the list.
+   \sa GetItemOffset
+  */
   inline int GetOffset() const { return m_offset; };
+  /*! \brief Returns the index of the first visible item
+   returns the first visible item. This will always be in the range of available items. Use GetOffset() to retrieve the first visible row in the list.
+   \sa GetOffset
+  */
+  inline int GetItemOffset() const { return CorrectOffset(GetOffset(), 0); }
 
 private:
   int m_cursor;


### PR DESCRIPTION
GetOffset() returns the page that is currently visible, but for my Drag&Drop stuff I needed to know the first item that is visible.
So I added a GetItemOffset() function and in order to reduce confusion I renamed GetOffset to GetRowOffset.
