### PR TITLE
[RFC] BaseContainer now has a FileItemList

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1558,6 +1558,23 @@ CFileItemList::CFileItemList()
   m_replaceListing = false;
 }
 
+CFileItemList::CFileItemList(const CFileItemList& rhs) 
+  : CFileItem(rhs), 
+    m_items(rhs.m_items), 
+    m_map(rhs.m_map), 
+    m_sortDetails(rhs.m_sortDetails)
+{
+  m_fastLookup = rhs.m_fastLookup;
+  m_bIsFolder = rhs.m_bIsFolder;
+  m_cacheToDisc = rhs.m_cacheToDisc;
+  m_sortMethod = rhs.m_sortMethod;
+  m_sortOrder = rhs.m_sortOrder;
+  m_sortIgnoreFolders = rhs.m_sortIgnoreFolders;
+  m_replaceListing = rhs.m_replaceListing;
+  m_cacheToDisc = rhs.m_cacheToDisc;
+  m_content = rhs.m_content;
+}
+
 CFileItemList::CFileItemList(const CStdString& strPath) : CFileItem(strPath, true)
 {
   m_fastLookup = false;
@@ -1716,6 +1733,17 @@ void CFileItemList::Remove(int iItem)
     }
     m_items.erase(m_items.begin() + iItem);
   }
+}
+
+void CFileItemList::RemoveRange(int iRangeBegin, int iRangeEnd)
+{
+  CSingleLock lock(m_lock);
+  if (m_fastLookup)
+  {
+    for (int i = iRangeBegin; i<iRangeEnd; ++i)
+      m_map.erase(m_items[i]->GetPath());
+  }
+  m_items.erase(m_items.begin() + iRangeBegin, m_items.begin() + iRangeEnd);
 }
 
 void CFileItemList::Append(const CFileItemList& itemlist)
@@ -3064,6 +3092,25 @@ bool CFileItem::LoadMusicTag()
   }
   return false;
 }
+/*
+void CFileItemList::Move(int position, int move)
+{
+  int newPosition = position + move;
+  if (newPosition < 0 ||
+      (unsigned)newPosition >= m_items.size() ||
+      position < 0 ||
+      (unsigned)position >= m_items.size() ||
+      move == 0)
+    return;
+  
+  int direction = (move>0) ? 1 : -1;
+  
+  for (; move!=0; move-=direction) 
+  {
+    std::swap(m_items[position], m_items[position+direction]);
+    position+=direction;
+  }
+}*/
 
 void CFileItemList::Swap(unsigned int item1, unsigned int item2)
 {

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -487,6 +487,7 @@ public:
 
   CFileItemList();
   CFileItemList(const CStdString& strPath);
+  CFileItemList(const CFileItemList& rhs);
   virtual ~CFileItemList();
   virtual void Archive(CArchive& ar);
   CFileItemPtr operator[] (int iItem);
@@ -499,6 +500,7 @@ public:
   void AddFront(const CFileItemPtr &pItem, int itemPosition);
   void Remove(CFileItem* pItem);
   void Remove(int iItem);
+  void RemoveRange(int iRangeBegin, int iRangeEnd);
   CFileItemPtr Get(int iItem);
   const CFileItemPtr Get(int iItem) const;
   const VECFILEITEMS GetList() const { return m_items; }
@@ -578,6 +580,7 @@ public:
   void RemoveDiscCache(int windowID = 0) const;
   bool AlwaysCache() const;
 
+    //void Move(int position, int move);
   void Swap(unsigned int item1, unsigned int item2);
 
   /*! \brief Update an item in the item list

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -29,6 +29,7 @@
 #include "GUIListItemLayout.h"
 #include "boost/shared_ptr.hpp"
 #include "utils/Stopwatch.h"
+#include "FileItem.h"
 
 typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
 
@@ -131,7 +132,7 @@ protected:
   virtual bool SelectItemFromPoint(const CPoint &point) { return false; };
   virtual int GetCursorFromPoint(const CPoint &point, CPoint *itemPoint = NULL) const { return -1; };
   virtual void Reset();
-  virtual unsigned int GetNumItems() const { return m_items.size(); };
+  virtual unsigned int GetNumItems() const { return m_items.Size(); };
   virtual int GetCurrentPage() const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
   virtual void OnFocus();
@@ -152,7 +153,7 @@ protected:
   ORIENTATION m_orientation;
   int m_itemsPerPage;
 
-  std::vector< CGUIListItemPtr > m_items;
+  CFileItemList m_items;
   typedef std::vector<CGUIListItemPtr> ::iterator iItems;
   CGUIListItemPtr m_lastItem;
 

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -90,7 +90,7 @@ bool CGUIFixedListContainer::MoveUp(bool wrapAround)
     SelectItem(item - 1);
   else if (wrapAround)
   {
-    SelectItem((int)m_items.size() - 1);
+    SelectItem(m_items.Size() - 1);
     SetContainerMoving(-1);
   }
   else
@@ -101,7 +101,7 @@ bool CGUIFixedListContainer::MoveUp(bool wrapAround)
 bool CGUIFixedListContainer::MoveDown(bool wrapAround)
 {
   int item = GetSelectedItem();
-  if (item < (int)m_items.size() - 1)
+  if (item < m_items.Size() - 1)
     SelectItem(item + 1);
   else if (wrapAround)
   { // move first item in list
@@ -115,7 +115,7 @@ bool CGUIFixedListContainer::MoveDown(bool wrapAround)
 
 void CGUIFixedListContainer::Scroll(int amount)
 {
-  // increase or decrease the offset within [-minCursor, m_items.size() - maxCursor]
+  // increase or decrease the offset within [-minCursor, m_items.Size() - maxCursor]
   int minCursor, maxCursor;
   GetCursorRange(minCursor, maxCursor);
   int offset = GetOffset() + amount;
@@ -124,9 +124,9 @@ void CGUIFixedListContainer::Scroll(int amount)
     offset = -minCursor;
     SetCursor(minCursor);
   }
-  if (offset > (int)m_items.size() - 1 - maxCursor)
+  if (offset > m_items.Size() - 1 - maxCursor)
   {
-    offset = m_items.size() - 1 - maxCursor;
+    offset = m_items.Size() - 1 - maxCursor;
     SetCursor(maxCursor);
   }
   ScrollToOffset(offset);
@@ -136,7 +136,7 @@ bool CGUIFixedListContainer::GetOffsetRange(int &minOffset, int &maxOffset) cons
 {
   GetCursorRange(minOffset, maxOffset);
   minOffset = -minOffset;
-  maxOffset = m_items.size() - maxOffset - 1;
+  maxOffset = m_items.Size() - maxOffset - 1;
   return true;
 }
 
@@ -225,7 +225,7 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
     }
     return true;
   }
-  else if (pos > end && GetOffset() + maxCursor < (int)m_items.size() - 1)
+  else if (pos > end && GetOffset() + maxCursor < m_items.Size() - 1)
   {
     if (!InsideLayout(m_layout, point))
       return false;
@@ -255,7 +255,7 @@ void CGUIFixedListContainer::SelectItem(int item)
   // Check that GetOffset() is valid
   ValidateOffset();
   // only select an item if it's in a valid range
-  if (item >= 0 && item < (int)m_items.size())
+  if (item >= 0 && item < m_items.Size())
   {
     // Select the item requested - we first set the cursor position
     // which may be different at either end of the list, then the offset
@@ -263,8 +263,8 @@ void CGUIFixedListContainer::SelectItem(int item)
     GetCursorRange(minCursor, maxCursor);
 
     int cursor;
-    if ((int)m_items.size() - 1 - item <= maxCursor - m_fixedCursor)
-      cursor = std::max(m_fixedCursor, maxCursor + item - (int)m_items.size() + 1);
+    if (m_items.Size() - 1 - item <= maxCursor - m_fixedCursor)
+      cursor = std::max(m_fixedCursor, maxCursor + item - m_items.Size() + 1);
     else if (item <= m_fixedCursor - minCursor)
       cursor = std::min(m_fixedCursor, minCursor + item);
     else
@@ -283,7 +283,7 @@ bool CGUIFixedListContainer::HasPreviousPage() const
 
 bool CGUIFixedListContainer::HasNextPage() const
 {
-  return (GetOffset() != (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
+  return (GetOffset() != m_items.Size() - m_itemsPerPage && m_items.Size() >= m_itemsPerPage);
 }
 
 int CGUIFixedListContainer::GetCurrentPage() const
@@ -299,14 +299,14 @@ void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) cons
   minCursor = std::max(m_fixedCursor - m_cursorRange, 0);
   maxCursor = std::min(m_fixedCursor + m_cursorRange, m_itemsPerPage);
 
-  if (!m_items.size())
+  if (!m_items.Size())
   {
     minCursor = m_fixedCursor;
     maxCursor = m_fixedCursor;
     return;
   }
 
-  while (maxCursor - minCursor > (int)m_items.size() - 1)
+  while (maxCursor - minCursor > m_items.Size() - 1)
   {
     if (maxCursor - m_fixedCursor > m_fixedCursor - minCursor)
       maxCursor--;

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -53,9 +53,9 @@ bool CGUIListContainer::OnAction(const CAction &action)
     break;
   case ACTION_PAGE_DOWN:
     {
-      if (GetOffset() == (int)m_items.size() - m_itemsPerPage || (int)m_items.size() < m_itemsPerPage)
+      if (GetOffset() == m_items.Size() - m_itemsPerPage || m_items.Size() < m_itemsPerPage)
       { // already at the last page, so move to the last item.
-        SetCursor(m_items.size() - GetOffset() - 1);
+        SetCursor(m_items.Size() - GetOffset() - 1);
       }
       else
       { // scroll down to the next page
@@ -93,11 +93,11 @@ bool CGUIListContainer::OnAction(const CAction &action)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;
-        if (GetOffset() + m_itemsPerPage < (int)m_items.size() && GetCursor() >= m_itemsPerPage / 2)
+        if (GetOffset() + m_itemsPerPage < m_items.Size() && GetCursor() >= m_itemsPerPage / 2)
         {
           Scroll(1);
         }
-        else if (GetCursor() < m_itemsPerPage - 1 && GetOffset() + GetCursor() < (int)m_items.size() - 1)
+        else if (GetCursor() < m_itemsPerPage - 1 && GetOffset() + GetCursor() < m_items.Size() - 1)
         {
           SetCursor(GetCursor() + 1);
         }
@@ -121,7 +121,7 @@ bool CGUIListContainer::OnMessage(CGUIMessage& message)
     {
       if (message.GetParam1()) // subfocus item is specified, so set the offset appropriately
       {
-        int item = std::min(GetOffset() + (int)message.GetParam1() - 1, (int)m_items.size() - 1);
+        int item = std::min(GetOffset() + (int)message.GetParam1() - 1, m_items.Size() - 1);
         SelectItem(item);
       }
     }
@@ -141,11 +141,11 @@ bool CGUIListContainer::MoveUp(bool wrapAround)
   }
   else if (wrapAround)
   {
-    if (m_items.size() > 0)
+    if (m_items.Size() > 0)
     { // move 2 last item in list, and set our container moving up
-      int offset = m_items.size() - m_itemsPerPage;
+      int offset = m_items.Size() - m_itemsPerPage;
       if (offset < 0) offset = 0;
-      SetCursor(m_items.size() - offset - 1);
+      SetCursor(m_items.Size() - offset - 1);
       ScrollToOffset(offset);
       SetContainerMoving(-1);
     }
@@ -157,7 +157,7 @@ bool CGUIListContainer::MoveUp(bool wrapAround)
 
 bool CGUIListContainer::MoveDown(bool wrapAround)
 {
-  if (GetOffset() + GetCursor() + 1 < (int)m_items.size())
+  if (GetOffset() + GetCursor() + 1 < m_items.Size())
   {
     if (GetCursor() + 1 < m_itemsPerPage)
     {
@@ -184,9 +184,9 @@ void CGUIListContainer::Scroll(int amount)
 {
   // increase or decrease the offset
   int offset = GetOffset() + amount;
-  if (offset > (int)m_items.size() - m_itemsPerPage)
+  if (offset > m_items.Size() - m_itemsPerPage)
   {
-    offset = m_items.size() - m_itemsPerPage;
+    offset = m_items.Size() - m_itemsPerPage;
   }
   if (offset < 0) offset = 0;
   ScrollToOffset(offset);
@@ -225,7 +225,7 @@ void CGUIListContainer::SelectItem(int item)
   // Check that our offset is valid
   ValidateOffset();
   // only select an item if it's in a valid range
-  if (item >= 0 && item < (int)m_items.size())
+  if (item >= 0 && item < m_items.Size())
   {
     // Select the item requested
     if (item >= GetOffset() && item < GetOffset() + m_itemsPerPage)
@@ -255,7 +255,7 @@ int CGUIListContainer::GetCursorFromPoint(const CPoint &point, CPoint *itemPoint
   while (row < m_itemsPerPage + 1)  // 1 more to ensure we get the (possible) half item at the end.
   {
     const CGUIListItemLayout *layout = (row == GetCursor()) ? m_focusedLayout : m_layout;
-    if (pos < layout->Size(m_orientation) && row + GetOffset() < (int)m_items.size())
+    if (pos < layout->Size(m_orientation) && row + GetOffset() < m_items.Size())
     { // found correct "row" -> check horizontal
       if (!InsideLayout(layout, point))
         return -1;
@@ -307,7 +307,7 @@ CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, fl
 
 bool CGUIListContainer::HasNextPage() const
 {
-  return (GetOffset() != (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
+  return (GetOffset() != m_items.Size() - m_itemsPerPage && m_items.Size() >= m_itemsPerPage);
 }
 
 bool CGUIListContainer::HasPreviousPage() const

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -64,9 +64,9 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
 
   int current = (offset - cacheBefore) * m_itemsPerRow;
   int col = 0;
-  while (pos < end && m_items.size())
+  while (pos < end && m_items.Size())
   {
-    if (current >= (int)m_items.size())
+    if (current >= m_items.Size())
       break;
     if (current >= 0)
     {
@@ -122,9 +122,9 @@ void CGUIPanelContainer::Render()
     CGUIListItemPtr focusedItem;
     int current = (offset - cacheBefore) * m_itemsPerRow;
     int col = 0;
-    while (pos < end && m_items.size())
+    while (pos < end && m_items.Size())
     {
-      if (current >= (int)m_items.size())
+      if (current >= m_items.Size())
         break;
       if (current >= 0)
       {
@@ -188,9 +188,9 @@ bool CGUIPanelContainer::OnAction(const CAction &action)
     break;
   case ACTION_PAGE_DOWN:
     {
-      if ((GetOffset() + m_itemsPerPage) * m_itemsPerRow >= (int)m_items.size() || (int)m_items.size() < m_itemsPerPage)
+      if ((GetOffset() + m_itemsPerPage) * m_itemsPerRow >= m_items.Size() || m_items.Size() < m_itemsPerPage)
       { // already at the last page, so move to the last item.
-        SetCursor(m_items.size() - GetOffset() * m_itemsPerRow - 1);
+        SetCursor(m_items.Size() - GetOffset() * m_itemsPerRow - 1);
       }
       else
       { // scroll down to the next page
@@ -228,11 +228,11 @@ bool CGUIPanelContainer::OnAction(const CAction &action)
       {
         handled = true;
         m_analogScrollCount -= AnalogScrollSpeed();
-        if ((GetOffset() + m_itemsPerPage) * m_itemsPerRow < (int)m_items.size())// && GetCursor() >= m_itemsPerPage * m_itemsPerRow / 2)
+        if ((GetOffset() + m_itemsPerPage) * m_itemsPerRow < m_items.Size())// && GetCursor() >= m_itemsPerPage * m_itemsPerRow / 2)
         {
           Scroll(1);
         }
-        else if (GetCursor() < m_itemsPerPage * m_itemsPerRow - 1 && GetOffset() * m_itemsPerRow + GetCursor() < (int)m_items.size() - 1)
+        else if (GetCursor() < m_itemsPerPage * m_itemsPerRow - 1 && GetOffset() * m_itemsPerRow + GetCursor() < m_items.Size() - 1)
         {
           SetCursor(GetCursor() + 1);
         }
@@ -299,17 +299,17 @@ void CGUIPanelContainer::OnDown()
 
 bool CGUIPanelContainer::MoveDown(bool wrapAround)
 {
-  if (GetCursor() + m_itemsPerRow < m_itemsPerPage * m_itemsPerRow && (GetOffset() + 1 + GetCursor() / m_itemsPerRow) * m_itemsPerRow < (int)m_items.size())
+  if (GetCursor() + m_itemsPerRow < m_itemsPerPage * m_itemsPerRow && (GetOffset() + 1 + GetCursor() / m_itemsPerRow) * m_itemsPerRow < m_items.Size())
   { // move to last item if necessary
-    if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= (int)m_items.size())
-      SetCursor((int)m_items.size() - 1 - GetOffset()*m_itemsPerRow);
+    if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= m_items.Size())
+      SetCursor(m_items.Size() - 1 - GetOffset()*m_itemsPerRow);
     else
       SetCursor(GetCursor() + m_itemsPerRow);
   }
-  else if ((GetOffset() + 1 + GetCursor() / m_itemsPerRow) * m_itemsPerRow < (int)m_items.size())
+  else if ((GetOffset() + 1 + GetCursor() / m_itemsPerRow) * m_itemsPerRow < m_items.Size())
   { // we scroll to the next row, and move to last item if necessary
-    if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= (int)m_items.size())
-      SetCursor((int)m_items.size() - 1 - (GetOffset() + 1)*m_itemsPerRow);
+    if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= m_items.Size())
+      SetCursor(m_items.Size() - 1 - (GetOffset() + 1)*m_itemsPerRow);
     ScrollToOffset(GetOffset() + 1);
   }
   else if (wrapAround)
@@ -334,8 +334,8 @@ bool CGUIPanelContainer::MoveUp(bool wrapAround)
     SetCursor((GetCursor() % m_itemsPerRow) + (m_itemsPerPage - 1) * m_itemsPerRow);
     int offset = max((int)GetRows() - m_itemsPerPage, 0);
     // should check here whether cursor is actually allowed here, and reduce accordingly
-    if (offset * m_itemsPerRow + GetCursor() >= (int)m_items.size())
-      SetCursor((int)m_items.size() - offset * m_itemsPerRow - 1);
+    if (offset * m_itemsPerRow + GetCursor() >= m_items.Size())
+      SetCursor(m_items.Size() - offset * m_itemsPerRow - 1);
     ScrollToOffset(offset);
     SetContainerMoving(-1);
   }
@@ -352,8 +352,8 @@ bool CGUIPanelContainer::MoveLeft(bool wrapAround)
   else if (wrapAround)
   { // wrap around
     SetCursor(GetCursor() + m_itemsPerRow - 1);
-    if (GetOffset() * m_itemsPerRow + GetCursor() >= (int)m_items.size())
-      SetCursor((int)m_items.size() - GetOffset() * m_itemsPerRow - 1);
+    if (GetOffset() * m_itemsPerRow + GetCursor() >= m_items.Size())
+      SetCursor(m_items.Size() - GetOffset() * m_itemsPerRow - 1);
   }
   else
     return false;
@@ -363,7 +363,7 @@ bool CGUIPanelContainer::MoveLeft(bool wrapAround)
 bool CGUIPanelContainer::MoveRight(bool wrapAround)
 {
   int col = GetCursor() % m_itemsPerRow;
-  if (col + 1 < m_itemsPerRow && GetOffset() * m_itemsPerRow + GetCursor() + 1 < (int)m_items.size())
+  if (col + 1 < m_itemsPerRow && GetOffset() * m_itemsPerRow + GetCursor() + 1 < m_items.Size())
     SetCursor(GetCursor() + 1);
   else if (wrapAround) // move first item in row
     SetCursor(GetCursor() - col);
@@ -438,7 +438,7 @@ void CGUIPanelContainer::CalculateLayout()
 unsigned int CGUIPanelContainer::GetRows() const
 {
   assert(m_itemsPerRow > 0);
-  return (m_items.size() + m_itemsPerRow - 1) / m_itemsPerRow;
+  return (m_items.Size() + m_itemsPerRow - 1) / m_itemsPerRow;
 }
 
 float CGUIPanelContainer::AnalogScrollSpeed() const
@@ -466,7 +466,7 @@ int CGUIPanelContainer::GetCursorFromPoint(const CPoint &point, CPoint *itemPoin
     for (int x = 0; x < m_itemsPerRow; x++)
     {
       int item = x + y * m_itemsPerRow;
-      if (posX < sizeX && posY < sizeY && item + GetOffset() < (int)m_items.size())
+      if (posX < sizeX && posY < sizeY && item + GetOffset() < m_items.Size())
       { // found
         return item;
       }
@@ -508,7 +508,7 @@ void CGUIPanelContainer::SelectItem(int item)
   // Check that our offset is valid
   ValidateOffset();
   // only select an item if it's in a valid range
-  if (item >= 0 && item < (int)m_items.size())
+  if (item >= 0 && item < m_items.Size())
   {
     // Select the item requested
     if (item >= GetOffset() * m_itemsPerRow && item < (GetOffset() + m_itemsPerPage) * m_itemsPerRow)

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -127,22 +127,22 @@ bool CGUIWrappingListContainer::GetOffsetRange(int &minOffset, int &maxOffset) c
 void CGUIWrappingListContainer::ValidateOffset()
 {
   // our minimal amount of items - we need to take into acount extra items to display wrapped items when scrolling
-  unsigned int minItems = (unsigned int)m_itemsPerPage + ScrollCorrectionRange() + GetCacheCount() / 2;
-  if (minItems <= m_items.size())
+  int minItems = m_itemsPerPage + ScrollCorrectionRange() + GetCacheCount() / 2;
+  if (minItems <= m_items.Size())
     return;
 
   // no need to check the range here, but we need to check we have
   // more items than slots.
   ResetExtraItems();
-  if (m_items.size())
+  if (m_items.Size())
   {
-    unsigned int numItems = m_items.size();
-    while (m_items.size() < minItems)
+    int numItems = m_items.Size();
+    while (m_items.Size() < minItems)
     {
       // add additional copies of items, as we require extras at render time
-      for (unsigned int i = 0; i < numItems; i++)
+      for (int i = 0; i < numItems; i++)
       {
-        m_items.push_back(CGUIListItemPtr(m_items[i]->Clone()));
+        m_items.Add(CFileItemPtr(new CFileItem(*(m_items[i]))));
         m_extraItems++;
       }
     }
@@ -151,10 +151,10 @@ void CGUIWrappingListContainer::ValidateOffset()
 
 int CGUIWrappingListContainer::CorrectOffset(int offset, int cursor) const
 {
-  if (m_items.size())
+  if (m_items.Size())
   {
-    int correctOffset = (offset + cursor) % (int)m_items.size();
-    if (correctOffset < 0) correctOffset += m_items.size();
+    int correctOffset = (offset + cursor) % (int)m_items.Size();
+    if (correctOffset < 0) correctOffset += m_items.Size();
     return correctOffset;
   }
   return 0;
@@ -162,9 +162,9 @@ int CGUIWrappingListContainer::CorrectOffset(int offset, int cursor) const
 
 int CGUIWrappingListContainer::GetSelectedItem() const
 {
-  if (m_items.size() > m_extraItems)
+  if (m_items.Size() > (int)m_extraItems)
   {
-    int numItems = (int)(m_items.size() - m_extraItems);
+    int numItems = (int)(m_items.Size() - m_extraItems);
     int correctOffset = (GetOffset() + GetCursor()) % numItems;
     if (correctOffset < 0) correctOffset += numItems;
     return correctOffset;
@@ -216,7 +216,7 @@ bool CGUIWrappingListContainer::SelectItemFromPoint(const CPoint &point)
 
 void CGUIWrappingListContainer::SelectItem(int item)
 {
-  if (item >= 0 && item < (int)m_items.size())
+  if (item >= 0 && item < m_items.Size())
     ScrollToOffset(item - GetCursor());
 }
 
@@ -224,7 +224,7 @@ void CGUIWrappingListContainer::ResetExtraItems()
 {
   // delete any extra items
   if (m_extraItems)
-    m_items.erase(m_items.begin() + m_items.size() - m_extraItems, m_items.end());
+    m_items.RemoveRange(m_items.Size() - m_extraItems, m_items.Size());
   m_extraItems = 0;
 }
 

--- a/xbmc/guilib/GUIWrappingListContainer.h
+++ b/xbmc/guilib/GUIWrappingListContainer.h
@@ -51,7 +51,7 @@ protected:
   virtual bool SelectItemFromPoint(const CPoint &point);
   virtual void SelectItem(int item);
   virtual void Reset();
-  virtual unsigned int GetNumItems() const { return m_items.size() - m_extraItems; };
+  virtual unsigned int GetNumItems() const { return m_items.Size() - m_extraItems; };
   virtual int GetCurrentPage() const;
   virtual void SetPageControlRange();
   virtual void UpdatePageControl(int offset);


### PR DESCRIPTION
BaseContainer now has a FileItemList instead of a vector<GUIlistItemPtr>.
Reason behind this is, that you want to let skinner add lists everywhere (e.g. a Favourites list in library view). In order to do that we need to move content specific logic out of the CGUIWindows*.

Right now my Drag&Drop stuff uses this, to determine if a FileItemList is dropable and reorderable.
I also started to work on a context menu rfc where i wanted to move the decision of the visible items out of CGUIWindow*. There I need this one too.
