### PR TITLE
settings: fix handling of settings unloading

### DIFF
--- a/xbmc/network/upnp/UPnPSettings.cpp
+++ b/xbmc/network/upnp/UPnPSettings.cpp
@@ -52,7 +52,7 @@ CUPnPSettings& CUPnPSettings::Get()
   return sUPnPSettings;
 }
 
-void CUPnPSettings::OnSettingsCleared()
+void CUPnPSettings::OnSettingsUnloaded()
 {
   Clear();
 }

--- a/xbmc/network/upnp/UPnPSettings.h
+++ b/xbmc/network/upnp/UPnPSettings.h
@@ -29,7 +29,7 @@ class CUPnPSettings : public ISettingsHandler
 public:
   static CUPnPSettings& Get();
   
-  virtual void OnSettingsCleared();
+  virtual void OnSettingsUnloaded();
 
   bool Load(const std::string &file);
   bool Save(const std::string &file) const;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -73,6 +73,11 @@ void CAdvancedSettings::OnSettingsLoaded()
   CLog::SetLogLevel(m_logLevel);
 }
 
+void CAdvancedSettings::OnSettingsUnloaded()
+{
+  m_initialized = false;
+}
+
 void CAdvancedSettings::OnSettingChanged(const CSetting *setting)
 {
   if (setting == NULL)
@@ -100,6 +105,9 @@ void CAdvancedSettings::OnSettingAction(const CSetting *setting)
 
 void CAdvancedSettings::Initialize()
 {
+  if (m_initialized)
+    return;
+
   m_audioHeadRoom = 0;
   m_ac3Gain = 12.0f;
   m_audioApplyDrc = true;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -95,6 +95,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     static CAdvancedSettings* getInstance();
 
     virtual void OnSettingsLoaded();
+    virtual void OnSettingsUnloaded();
 
     virtual void OnSettingChanged(const CSetting *setting);
 

--- a/xbmc/settings/ISettingsHandler.h
+++ b/xbmc/settings/ISettingsHandler.h
@@ -54,10 +54,16 @@ public:
    */
   virtual void OnSettingsSaved() const { }
   /*!
+   \brief Setting values have been unloaded.
+
+   This callback can be used to trigger uninitializing any state variables
+   (e.g. before re-loading the settings).
+   */
+  virtual void OnSettingsUnloaded() { }
+  /*!
    \brief Settings have been cleared.
 
-   This callback can be used to trigger clearing any state variables (e.g.
-   before re-loading the settings).
+   This callback can be used to trigger clearing any state variables.
    */
   virtual void OnSettingsCleared() { }
 };

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -67,7 +67,7 @@ void CMediaSourceSettings::OnSettingsLoaded()
   Load();
 }
 
-void CMediaSourceSettings::OnSettingsCleared()
+void CMediaSourceSettings::OnSettingsUnloaded()
 {
   Clear();
 }

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -34,7 +34,7 @@ public:
   static std::string GetSourcesFile();
   
   virtual void OnSettingsLoaded();
-  virtual void OnSettingsCleared();
+  virtual void OnSettingsUnloaded();
 
   bool Load();
   bool Load(const std::string &file);

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -581,7 +581,7 @@ void CGUIWindowSettingsCategory::SetDescription(const CVariant &label)
   if (label.isString())
     SET_CONTROL_LABEL(CONTROL_DESCRIPTION, label.asString());
   else if (label.isInteger() && label.asInteger() >= 0)
-    SET_CONTROL_LABEL(CONTROL_DESCRIPTION, label.asInteger());
+    SET_CONTROL_LABEL(CONTROL_DESCRIPTION, (int)label.asInteger());
   else
     SET_CONTROL_LABEL(CONTROL_DESCRIPTION, "");
 }

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -55,7 +55,7 @@ void CRssManager::OnSettingsLoaded()
   Load();
 }
 
-void CRssManager::OnSettingsCleared()
+void CRssManager::OnSettingsUnloaded()
 {
   Clear();
 }

--- a/xbmc/utils/RssManager.h
+++ b/xbmc/utils/RssManager.h
@@ -45,7 +45,7 @@ public:
   static CRssManager& Get();
 
   virtual void OnSettingsLoaded();
-  virtual void OnSettingsCleared();
+  virtual void OnSettingsUnloaded();
 
   virtual void OnSettingAction(const CSetting *setting);
 


### PR DESCRIPTION
These commits fix the proper handling of the settings unloading event with a new OnSettingsUnloaded() callback in the ISettingsHandler interface which mostly (but not completely) replaces the OnSettingsCleared() callback. The most prominent use case for OnSettingsUnloaded() is switching profiles which is currently broken due to completely unloading and uninitializing all profiles when performing a profile switch.

Furthermore the last commit fixes the "-fs" app parameter switch which is currently overwritten by a second call to CAdvancedSettings::Initialize() after having already parsed the app parameters.
