### PR TITLE
CDirectoryCache::FileExists failing for cached directories with no parent

### DIFF
--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -190,7 +190,7 @@ bool CDirectoryCache::FileExists(const CStdString& strFile, bool& bInCache)
 #ifdef _DEBUG
     m_cacheHits++;
 #endif
-    return dir->m_Items->Contains(strFile);
+    return (strPath.Equals(storedPath) || dir->m_Items->Contains(strFile));
   }
 #ifdef _DEBUG
   m_cacheMisses++;


### PR DESCRIPTION
this was brought up by a routine in UPnPServer which stopped working after c003a4c7

If we check "musidb://" for existence, and it's contents are cached, then it fails the check in CDirectoryCache::FileExists due to having no parent. this fixes that but as it may potentially affect other behaviour, placing it here for comments.
