### PR TITLE
[FIX] Allow more paths in CFileUtils::RemoteAccessAllowed

### DIFF
--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -113,7 +113,12 @@ bool CFileUtils::RemoteAccessAllowed(const CStdString &strPath)
     return true;
   else if (StringUtils::StartsWith(realPath, "special://videoplaylists"))
     return true;
-
+  else if (StringUtils::StartsWith(realPath, "addons://sources"))
+    return true;
+  else if (StringUtils::StartsWith(realPath, "upnp://"))
+    return true;
+  else if (StringUtils::StartsWith(realPath, "plugin://"))
+    return true;
   bool isSource;
   for (unsigned int index = 0; index < SourcesSize; index++)
   {


### PR DESCRIPTION
As found by @Voyager1 there's some more path that should be allowed since they are used by addons / remotes or internally.
Perhaps more are needed, and perhaps a way to differentiate UPNP / Remote JSON / Addon JSON is needed.

@jmarshallnz and @Montellese for choices / feedback on the needed paths
