### PR TITLE
FIX: add libm to librtmp

### DIFF
--- a/tools/depends/target/librtmp/Makefile
+++ b/tools/depends/target/librtmp/Makefile
@@ -28,6 +28,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p0 < ../prefix.patch
 	cd $(PLATFORM); patch -p1 < ../librtmp-60-second-fix.patch
+	cd $(PLATFORM)/librtmp; patch -p0 < ../../libm.patch
 	sed -i -e 's|CC=|#CC=|' $(PLATFORM)/librtmp/Makefile
 	sed -i -e 's|LD=|#LD=|' $(PLATFORM)/librtmp/Makefile
 	sed -i -e 's|AR=|#AR=|' $(PLATFORM)/librtmp/Makefile

--- a/tools/depends/target/librtmp/libm.patch
+++ b/tools/depends/target/librtmp/libm.patch
@@ -1,0 +1,11 @@
+--- Makefile.old	2013-06-04 17:35:58.000000000 +0200
++++ Makefile	2013-06-04 17:36:13.000000000 +0200
+@@ -25,7 +25,7 @@
+ REQ_GNUTLS=gnutls
+ REQ_OPENSSL=libssl,libcrypto
+ LIBZ=-lz
+-LIBS_posix=
++LIBS_posix=-lm
+ LIBS_darwin=
+ LIBS_mingw=-lws2_32 -lwinmm -lgdi32
+ LIB_GNUTLS=-lgnutls -lhogweed -lnettle -lgmp $(LIBZ)


### PR DESCRIPTION
librtmp miss -lm on droid for atan, sqrt, ... introduced in librtmp-60-second-fix.patch. This popping up now might be due to the change of NDK...

Obviously not the proper fix, but I cannot reproduce the diff.
@davilla This is probably yours
