### PR TITLE
[FIX] CheckMenuLock ignored WINDOW_SETTINGS_PVR

### DIFF
--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -323,10 +323,10 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
   int iSwitch = iWindowID;
 
   // check if a settings subcategory was called from other than settings window
-  if (iWindowID >= WINDOW_SCREEN_CALIBRATION && iWindowID <= WINDOW_SETTINGS_APPEARANCE)
+  if (iWindowID >= WINDOW_SCREEN_CALIBRATION && iWindowID <= WINDOW_SETTINGS_MYPVR)
   {
     int iCWindowID = g_windowManager.GetActiveWindow();
-    if (iCWindowID != WINDOW_SETTINGS_MENU && (iCWindowID < WINDOW_SCREEN_CALIBRATION || iCWindowID > WINDOW_SETTINGS_APPEARANCE))
+    if (iCWindowID != WINDOW_SETTINGS_MENU && (iCWindowID < WINDOW_SCREEN_CALIBRATION || iCWindowID > WINDOW_SETTINGS_MYPVR))
       iSwitch = WINDOW_SETTINGS_MENU;
   }
 


### PR DESCRIPTION
First off, I haven't checked if that actually was an issue or not, or if it is fixed now (don't have PVR). This is just based on looking on the code and trying to understand the locking mechanism.

Also, there are still IDs free in the range between WINDOW_SCREEN_CALIBRATION and WINDOW_SETTINGS_APPEARANCE, so a cleaner solution would probably be to change the id of WINDOW_SETTINGS_PVR, but I'm not sure if that has any implications
