### PR TITLE
 [DVD/OMXPlayer] Fix auto-selection of audio and subtitle streams.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -326,7 +326,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       DVDNavStreamInfo info;
       nav->GetAudioStreamInfo(i, info);
       s.name     = info.name;
-      s.language = info.language;
+      s.language = g_LangCodeExpander.ConvertToISO6392T(info.language);
       s.channels = info.channels;
       Update(s);
     }
@@ -345,7 +345,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       DVDNavStreamInfo info;
       nav->GetSubtitleStreamInfo(i, info);
       s.name     = info.name;
-      s.language = info.language;
+      s.language = g_LangCodeExpander.ConvertToISO6392T(info.language);
       Update(s);
     }
   }
@@ -370,15 +370,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.source   = source;
       s.type     = stream->type;
       s.id       = stream->iId;
-      s.language = stream->language;
-
-      if (s.language.length() == 2)
-      {
-        CStdString lang;
-        g_LangCodeExpander.ConvertToThreeCharCode(lang, stream->language);
-        s.language = lang;
-      }
-
+      s.language = g_LangCodeExpander.ConvertToISO6392T(stream->language);
       s.flags    = stream->flags;
       s.filename = demuxer->GetFileName();
       stream->GetStreamName(s.name);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -86,6 +86,7 @@
 #include "Util.h"
 #include "LangInfo.h"
 #include "URL.h"
+#include "utils/LangCodeExpander.h"
 
 using namespace std;
 using namespace PVR;
@@ -145,8 +146,8 @@ static bool PredicateAudioPriority(const SelectionStream& lh, const SelectionStr
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.audiolanguage"), "original"))
   {
     CStdString audio_language = g_langInfo.GetAudioLanguage();
-    PREDICATE_RETURN(audio_language.Equals(lh.language.c_str())
-                   , audio_language.Equals(rh.language.c_str()));
+    PREDICATE_RETURN(g_LangCodeExpander.CompareLangCodes(audio_language, lh.language)
+                   , g_LangCodeExpander.CompareLangCodes(audio_language, rh.language));
   }
 
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
@@ -174,8 +175,8 @@ static bool PredicateSubtitlePriority(const SelectionStream& lh, const Selection
   CStdString subtitle_language = g_langInfo.GetSubtitleLanguage();
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.subtitlelanguage"), "original"))
   {
-    PREDICATE_RETURN((lh.source == STREAM_SOURCE_DEMUX_SUB || lh.source == STREAM_SOURCE_TEXT) && subtitle_language.Equals(lh.language.c_str())
-                   , (rh.source == STREAM_SOURCE_DEMUX_SUB || rh.source == STREAM_SOURCE_TEXT) && subtitle_language.Equals(rh.language.c_str()));
+    PREDICATE_RETURN((lh.source == STREAM_SOURCE_DEMUX_SUB || lh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
+                   , (rh.source == STREAM_SOURCE_DEMUX_SUB || rh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
   }
 
   PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
@@ -186,8 +187,8 @@ static bool PredicateSubtitlePriority(const SelectionStream& lh, const Selection
 
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.subtitlelanguage"), "original"))
   {
-    PREDICATE_RETURN(subtitle_language.Equals(lh.language.c_str())
-                   , subtitle_language.Equals(rh.language.c_str()));
+    PREDICATE_RETURN(g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
+                   , g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
   }
 
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -365,7 +365,7 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       DVDNavStreamInfo info;
       nav->GetAudioStreamInfo(i, info);
       s.name     = info.name;
-      s.language = info.language;
+      s.language = g_LangCodeExpander.ConvertToISO6392T(info.language);
       s.channels = info.channels;
       Update(s);
     }
@@ -384,7 +384,7 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       DVDNavStreamInfo info;
       nav->GetSubtitleStreamInfo(i, info);
       s.name     = info.name;
-      s.language = info.language;
+      s.language = g_LangCodeExpander.ConvertToISO6392T(info.language);
       Update(s);
     }
   }
@@ -409,15 +409,7 @@ void COMXSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
       s.source   = source;
       s.type     = stream->type;
       s.id       = stream->iId;
-      s.language = stream->language;
-
-      if (s.language.length() == 2)
-      {
-        CStdString lang;
-        g_LangCodeExpander.ConvertToThreeCharCode(lang, stream->language);
-        s.language = lang;
-      }
-
+      s.language = g_LangCodeExpander.ConvertToISO6392T(stream->language);
       s.flags    = stream->flags;
       s.filename = demuxer->GetFileName();
       stream->GetStreamName(s.name);

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -120,6 +120,7 @@
 #include "Util.h"
 #include "LangInfo.h"
 #include "URL.h"
+#include "utils/LangCodeExpander.h"
 
 // video not playing from clock, but stepped
 #define TP(speed)  ((speed) < 0 || (speed) > 4*DVD_PLAYSPEED_NORMAL)
@@ -184,8 +185,8 @@ static bool PredicateAudioPriority(const OMXSelectionStream& lh, const OMXSelect
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.audiolanguage"), "original"))
   {
     CStdString audio_language = g_langInfo.GetAudioLanguage();
-    PREDICATE_RETURN(audio_language.Equals(lh.language.c_str())
-                   , audio_language.Equals(rh.language.c_str()));
+    PREDICATE_RETURN(g_LangCodeExpander.CompareLangCodes(audio_language, lh.language)
+                   , g_LangCodeExpander.CompareLangCodes(audio_language, rh.language));
   }
 
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
@@ -213,8 +214,8 @@ static bool PredicateSubtitlePriority(const OMXSelectionStream& lh, const OMXSel
   CStdString subtitle_language = g_langInfo.GetSubtitleLanguage();
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.subtitlelanguage"), "original"))
   {
-    PREDICATE_RETURN((lh.source == STREAM_SOURCE_DEMUX_SUB || lh.source == STREAM_SOURCE_TEXT) && subtitle_language.Equals(lh.language.c_str())
-                   , (rh.source == STREAM_SOURCE_DEMUX_SUB || rh.source == STREAM_SOURCE_TEXT) && subtitle_language.Equals(rh.language.c_str()));
+    PREDICATE_RETURN((lh.source == STREAM_SOURCE_DEMUX_SUB || lh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
+                   , (rh.source == STREAM_SOURCE_DEMUX_SUB || rh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
   }
 
   PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
@@ -225,8 +226,8 @@ static bool PredicateSubtitlePriority(const OMXSelectionStream& lh, const OMXSel
 
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.subtitlelanguage"), "original"))
   {
-    PREDICATE_RETURN(subtitle_language.Equals(lh.language.c_str())
-                   , subtitle_language.Equals(rh.language.c_str()));
+    PREDICATE_RETURN(g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
+                   , g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
   }
 
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -420,6 +420,28 @@ void CLangCodeExpander::CodeToString(long code, CStdString& ret)
   }
 }
 
+bool CLangCodeExpander::CompareFullLangNames(const CStdString& lang1, const CStdString& lang2)
+{
+  if (lang1.Equals(lang2))
+    return true;
+
+  CStdString expandedLang1, expandedLang2, code1, code2;
+
+  if (!ReverseLookup(lang1, code1))
+    return false;
+  else
+    code1 = lang1;
+
+  if (!ReverseLookup(lang2, code2))
+    return false;
+  else
+    code2 = lang2;
+
+  Lookup(expandedLang1, code1);
+  Lookup(expandedLang2, code2);
+  return expandedLang1.Equals(expandedLang2);
+}
+
 std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format /* = CLangCodeExpander::ISO_639_1 */) const
 {
   std::vector<std::string> languages;

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -441,6 +441,22 @@ std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format 
   return languages;
 }
 
+bool CLangCodeExpander::CompareLangCodes(const CStdString& code1, const CStdString& code2)
+{
+  if (code1.Equals(code2))
+    return true;
+
+  CStdString expandedLang1, expandedLang2;
+
+  if (!Lookup(expandedLang1, code1))
+    return false;
+
+  if (!Lookup(expandedLang2, code2))
+    return false;
+
+  return expandedLang1.Equals(expandedLang2);
+}
+
 extern const LCENTRY g_iso639_1[144] =
 {
   { MAKECODE('\0','\0','c','c'), "Closed Caption" },

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -479,6 +479,17 @@ bool CLangCodeExpander::CompareLangCodes(const CStdString& code1, const CStdStri
   return expandedLang1.Equals(expandedLang2);
 }
 
+CStdString CLangCodeExpander::ConvertToISO6392T(const CStdString& lang)
+{
+  CStdString two, three;
+  if (ConvertToTwoCharCode(two, lang))
+  {
+    if (ConvertToThreeCharCode(three, two))
+      return three;
+  }
+  return lang;
+}
+
 extern const LCENTRY g_iso639_1[144] =
 {
   { MAKECODE('\0','\0','c','c'), "Closed Caption" },

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -41,6 +41,14 @@ public:
   bool Lookup(CStdString& desc, const CStdString& code);
   bool Lookup(CStdString& desc, const int code);
 
+  /** \brief Determines if two english language names represent the same language.
+  *   \param[in] lang1 The first language string to compare given as english language name.
+  *   \param[in] lang2 The second language string to compare given as english language name.
+  *   \return true if the two language strings represent the same language, false otherwise.
+  *   For example "Abkhaz" and "Abkhazian" represent the same language.
+  */ 
+  bool CompareFullLangNames(const CStdString& lang1, const CStdString& lang2);
+
   /** \brief Determines if two languages given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B codes represent the same language.
   *   \param[in] code1 The first language to compare given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B code.
   *   \param[in] code2 The second language to compare given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B code.

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -41,6 +41,14 @@ public:
   bool Lookup(CStdString& desc, const CStdString& code);
   bool Lookup(CStdString& desc, const int code);
 
+  /** \brief Determines if two languages given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B codes represent the same language.
+  *   \param[in] code1 The first language to compare given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B code.
+  *   \param[in] code2 The second language to compare given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B code.
+  *   \return true if the two language codes represent the same language, false otherwise.
+  *   For example "ger", "deu" and "de" represent the same language.
+  */ 
+  bool CompareLangCodes(const CStdString& code1, const CStdString& code2);
+
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),
   *          or full english name string to a 2-Char (ISO 639-1) code.  

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -65,6 +65,14 @@ public:
   *   \return true if the conversion succeeded, false otherwise. 
   */ 
   bool ConvertToTwoCharCode(CStdString& code, const CStdString& lang);
+
+  /** \brief Converts a language given as 2-Char (ISO 639-1),
+  *          3-Char (ISO 639-2/T or ISO 639-2/B),
+  *          or full english name string to a 3-Char ISO 639-2/T code.
+  *   \param[in] lang The language that should be converted.
+  *   \return The 3-Char ISO 639-2/T code of lang if that code exists, lang otherwise.
+  */
+  CStdString ConvertToISO6392T(const CStdString& lang);
 #ifdef TARGET_WINDOWS
   bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool localeHack = false);
   bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool localeHack = false);


### PR DESCRIPTION
XBMC's audio and subtitle language is stored as an ISO 639-2 T code, but a video's meta data could also store it as an ISO 639-2 B code which could differ from the T variant.
This problem is solved by using a new generic language compare method.

This PR replaces the abandoned PR #2722.
@popcornmix can you have a look at this please, since OMXPlayer is involved?
