### PR TITLE
[Python] Adds an optional parameter "sound" to Dialog::notification to allow a silent notification

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -236,7 +236,7 @@ namespace XBMCAddon
       return value;
     }
 
-    void Dialog::notification(const String& heading, const String& message, const String& icon, int time)
+    void Dialog::notification(const String& heading, const String& message, const String& icon, int time, bool sound)
     {
       DelayedCallGuard dcguard(languageHook);
 
@@ -249,13 +249,13 @@ namespace XBMCAddon
         strIcon = icon;
       
       if (strIcon.Equals(getNOTIFICATION_INFO()))
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, heading, message, iTime);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, heading, message, iTime, sound);
       else if (strIcon.Equals(getNOTIFICATION_WARNING()))
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, heading, message, iTime);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, heading, message, iTime, sound);
       else if (strIcon.Equals(getNOTIFICATION_ERROR()))
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, heading, message, iTime);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, heading, message, iTime, sound);
       else
-        CGUIDialogKaiToast::QueueNotification(strIcon, heading, message, iTime);
+        CGUIDialogKaiToast::QueueNotification(strIcon, heading, message, iTime, sound);
     }
     
     DialogProgress::~DialogProgress() { TRACE; deallocating(); }

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -219,12 +219,13 @@ namespace XBMCAddon
       String numeric(int type, const String& heading, const String& defaultt = emptyString);
       
       /**
-       * notification(heading, message[, icon, time]) -- Show a Notification alert.
+       * notification(heading, message[, icon, time, sound]) -- Show a Notification alert.
        * 
        * heading        : string - dialog heading.
        * message        : string - dialog message.
        * icon           : [opt] string - icon to use. (default xbmcgui.NOTIFICATION_INFO)
        * time           : [opt] integer - time in milliseconds (default 5000)
+       * sound          : [opt] bool - play notification sound (default True)
        * 
        * Builtin Icons:
        *   xbmcgui.NOTIFICATION_INFO
@@ -235,7 +236,7 @@ namespace XBMCAddon
        *   - dialog = xbmcgui.Dialog()
        *   - dialog.notification('Movie Trailers', 'Finding Nemo download finished.', xbmcgui.NOTIFICATION_INFO, 5000)\n
        */
-      void notification(const String& heading, const String& message, const String& icon = emptyString, int time = 0);
+      void notification(const String& heading, const String& message, const String& icon = emptyString, int time = 0, bool sound = true);
     };
 
     /**


### PR DESCRIPTION
Sometimes it's nice to not play a sound, especially for simple acknowledgement of adding to a background download queue.
