### PR TITLE
Optionally allow caching for all network streams, including those on LAN (via new advanced setting 'alwaysforcebuffer')

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -21,6 +21,7 @@
 #include "DVDInputStreamFile.h"
 #include "filesystem/File.h"
 #include "filesystem/IFile.h"
+#include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 
@@ -52,6 +53,12 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
     return false;
 
   unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
+
+  if ( g_advancedSettings.m_alwaysForceBuffer && 
+       !URIUtils::IsOnDVD(strFile) && 
+       !URIUtils::IsBluray(strFile) )
+    flags |= READ_CACHED; 
+
 
   if (content == "video/mp4" || content == "video/x-msvideo" || content == "video/avi")
     flags |= READ_MULTI_STREAM;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -361,6 +361,7 @@ void CAdvancedSettings::Initialize()
   m_measureRefreshrate = false;
 
   m_cacheMemBufferSize = 1024 * 1024 * 20;
+  m_alwaysForceBuffer = false;
   m_addonPackageFolderSize = 200;
 
   m_jsonOutputCompact = true;
@@ -764,6 +765,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
+    XMLUtils::GetBoolean(pElement, "alwaysforcebuffer", m_alwaysForceBuffer);
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -364,6 +364,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     unsigned int m_addonPackageFolderSize;
 
     unsigned int m_cacheMemBufferSize;
+    bool m_alwaysForceBuffer;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;


### PR DESCRIPTION
This is a subset of PR2607 originally created by @mtisza (and, which in turn is based on PR1388 and PR831).

This PR is a subset of the previously submitted change. It introduces a new advanced setting for category 'network', 'alwaysforcebuffer'. If set to 1, it'll cause the implemented memory cache mechanism to be applied to all streams with the exclusion of local DVD and Blu-Ray. In case when this new setting is absent or set to 0, no changes in current functionality are expected.
