### PR TITLE
[rbp/omxplayer] Remove flip timing logic from OMXPlayerVideo

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -82,7 +82,6 @@ OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
   m_speed                 = DVD_PLAYSPEED_NORMAL;
   m_stalled               = false;
   m_iSubtitleDelay        = 0;
-  m_FlipTimeStamp         = 0.0;
   m_bRenderSubs           = false;
   m_flags                 = 0;
   m_bAllowFullscreen      = false;
@@ -94,8 +93,7 @@ OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
   m_messageQueue.SetMaxTimeSize(8.0);
 
   m_dst_rect.SetRect(0, 0, 0, 0);
-  m_iSleepEndTime = 0.0;
-  m_audio_count = 0;
+  m_nextOverlay = DVD_NOPTS_VALUE;
   m_started = false;
   m_flush = false;
   m_view_mode = 0;
@@ -113,8 +111,7 @@ bool OMXPlayerVideo::OpenStream(CDVDStreamInfo &hints)
   m_started     = false;
   m_flush       = false;
   m_stalled     = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET) == 0;
-  m_autosync    = 1;
-  m_iSleepEndTime = DVD_NOPTS_VALUE;
+  m_nextOverlay = DVD_NOPTS_VALUE;
   // force SetVideoRect to be called initially
   m_dst_rect.SetRect(0, 0, 0, 0);
 
@@ -180,13 +177,47 @@ bool OMXPlayerVideo::CloseStream(bool bWaitForBuffers)
 void OMXPlayerVideo::OnStartup()
 {
   m_iCurrentPts = DVD_NOPTS_VALUE;
-  m_FlipTimeStamp = m_av_clock->GetAbsoluteClock();
+  m_nextOverlay = DVD_NOPTS_VALUE;
 }
 
 void OMXPlayerVideo::OnExit()
 {
   CLog::Log(LOGNOTICE, "thread end: video_thread");
 }
+
+double OMXPlayerVideo::NextOverlay(double pts)
+{
+  double delta_start, delta_stop, min_delta = DVD_NOPTS_VALUE;
+
+  CSingleLock lock(*m_pOverlayContainer);
+  VecOverlays* pVecOverlays = m_pOverlayContainer->GetOverlays();
+  VecOverlaysIter it = pVecOverlays->begin();
+
+  //Find the minimum time before a subtitle is added or removed
+  while (it != pVecOverlays->end())
+  {
+    CDVDOverlay* pOverlay = *it++;
+    if(!pOverlay->bForced && !m_bRenderSubs)
+      continue;
+
+    double pts2 = pOverlay->bForced ? pts : pts - m_iSubtitleDelay;
+
+    delta_start = pOverlay->iPTSStartTime - pts2;
+    delta_stop = pOverlay->iPTSStopTime - pts2;
+
+    // when currently on screen, we periodically update to allow (limited rate) ASS animation
+    if (delta_start <= 0.0 && delta_stop > 0.0 && (min_delta == DVD_NOPTS_VALUE || DVD_MSEC_TO_TIME(100) < min_delta))
+      min_delta = DVD_MSEC_TO_TIME(100);
+
+    else if (delta_start > 0.0 && (min_delta == DVD_NOPTS_VALUE || delta_start < min_delta))
+      min_delta = delta_start;
+
+    else if (delta_stop > 0.0 && (min_delta == DVD_NOPTS_VALUE || delta_stop < min_delta))
+      min_delta = delta_stop;
+  }
+  return min_delta == DVD_NOPTS_VALUE ? pts+DVD_MSEC_TO_TIME(500) : pts+min_delta;
+}
+
 
 void OMXPlayerVideo::ProcessOverlays(double pts)
 {
@@ -235,80 +266,34 @@ void OMXPlayerVideo::Output(double pts, bool bDropPacket)
     return;
   }
 
-  // calculate the time we need to delay this picture before displaying
-  double iSleepTime, iClockSleep, iFrameSleep, iPlayingClock, iCurrentClock, iFrameDuration;
+  m_iCurrentPts = pts;
 
-  iPlayingClock = m_av_clock->GetClock(iCurrentClock, false); // snapshot current clock
-  iClockSleep = pts - iPlayingClock; //sleep calculated by pts to clock comparison
-  iFrameSleep = m_FlipTimeStamp - iCurrentClock; // sleep calculated by duration of frame
-  iFrameDuration = (double)DVD_TIME_BASE / m_fFrameRate; //pPacket->duration;
-
-  // correct sleep times based on speed
-  if(m_speed)
-  {
-    iClockSleep = iClockSleep * DVD_PLAYSPEED_NORMAL / m_speed;
-    iFrameSleep = iFrameSleep * DVD_PLAYSPEED_NORMAL / abs(m_speed);
-    iFrameDuration = iFrameDuration * DVD_PLAYSPEED_NORMAL / abs(m_speed);
-  }
-  else
-  {
-    iClockSleep = 0;
-    iFrameSleep = 0;
-  }
-
-  // dropping to a very low framerate is not correct (it should not happen at all)
-  iClockSleep = min(iClockSleep, DVD_MSEC_TO_TIME(500));
-  iFrameSleep = min(iFrameSleep, DVD_MSEC_TO_TIME(500));
-
-  if( m_stalled )
-    iSleepTime = iFrameSleep;
-  else
-    iSleepTime = iFrameSleep + (iClockSleep - iFrameSleep) / m_autosync;
-
-  // present the current pts of this frame to user, and include the actual
-  // presentation delay, to allow him to adjust for it
-  if( m_stalled )
-    m_iCurrentPts = DVD_NOPTS_VALUE;
-  else
-    m_iCurrentPts = pts - max(0.0, iSleepTime);
-
-  // timestamp when we think next picture should be displayed based on current duration
-  m_FlipTimeStamp  = iCurrentClock;
-  m_FlipTimeStamp += max(0.0, iSleepTime);
-  m_FlipTimeStamp += iFrameDuration;
-
-  if( m_speed < 0 )
-  {
-    if( iClockSleep < -DVD_MSEC_TO_TIME(200))
-      return;
-  }
-
-  if(bDropPacket)
+  if (CThread::m_bStop)
     return;
 
-  // DVDPlayer sleeps until m_iSleepEndTime here before calling FlipPage.
-  // Video playback in asynchronous in OMXPlayer, so we don't want to do that here, as it prevents the video fifo from being kept full.
-  // So, we keep track of when FlipPage would have been called on DVDPlayer and return early if it is not time.
-  // m_iSleepEndTime == DVD_NOPTS_VALUE means we are not waiting to call FlipPage, otherwise it is the time we want to call FlipPage
-  if (m_iSleepEndTime == DVD_NOPTS_VALUE) {
-    m_iSleepEndTime = iCurrentClock + iSleepTime;
-  }
+  // we aim to submit subtitles 100ms early
+  const double preroll = DVD_MSEC_TO_TIME(100);
+  double media_pts = m_av_clock->OMXMediaTime(false);
 
-  if (!CThread::m_bStop && m_av_clock->GetAbsoluteClock(false) < m_iSleepEndTime + DVD_MSEC_TO_TIME(500))
+  if (m_nextOverlay != DVD_NOPTS_VALUE && media_pts + preroll <= m_nextOverlay)
     return;
 
-  int buffer = g_renderManager.WaitForBuffer(CThread::m_bStop, std::max(DVD_TIME_TO_MSEC(iSleepTime) + 500, 0));
+  int buffer = g_renderManager.WaitForBuffer(CThread::m_bStop);
   if (buffer < 0)
     return;
 
-  double pts_media = m_av_clock->OMXMediaTime(false);
-  ProcessOverlays(pts_media);
+  double subtitle_pts = m_nextOverlay;
+  double time = subtitle_pts != DVD_NOPTS_VALUE ? subtitle_pts - media_pts : 0.0;
 
-  g_renderManager.FlipPage(CThread::m_bStop, m_iSleepEndTime / DVD_TIME_BASE, -1, FS_NONE);
+  if (m_nextOverlay != DVD_NOPTS_VALUE)
+    media_pts = m_nextOverlay;
 
-  m_iSleepEndTime = DVD_NOPTS_VALUE;
+  m_nextOverlay = NextOverlay(media_pts);
 
-  //m_av_clock->WaitAbsoluteClock((iCurrentClock + iSleepTime));
+  ProcessOverlays(media_pts);
+
+  time += m_av_clock->GetAbsoluteClock();
+  g_renderManager.FlipPage(CThread::m_bStop, time/DVD_TIME_BASE);
 }
 
 void OMXPlayerVideo::Process()
@@ -357,9 +342,7 @@ void OMXPlayerVideo::Process()
       if(pMsgGeneralResync->m_timestamp != DVD_NOPTS_VALUE)
         pts = pMsgGeneralResync->m_timestamp;
 
-      double delay = m_FlipTimeStamp - m_av_clock->GetAbsoluteClock();
-      if( delay > frametime ) delay = frametime;
-      else if( delay < 0 )    delay = 0;
+      double delay = 0;
 
       if(pMsgGeneralResync->m_clock)
       {
@@ -402,14 +385,14 @@ void OMXPlayerVideo::Process()
       m_av_clock->OMXReset(false);
       m_av_clock->UnLock();
       m_started = false;
-      m_iSleepEndTime = DVD_NOPTS_VALUE;
+      m_nextOverlay = DVD_NOPTS_VALUE;
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH)) // private message sent by (COMXPlayerVideo::Flush())
     {
       CLog::Log(LOGDEBUG, "COMXPlayerVideo - CDVDMsg::GENERAL_FLUSH");
       m_stalled = true;
       m_started = false;
-      m_iSleepEndTime = DVD_NOPTS_VALUE;
+      m_nextOverlay = DVD_NOPTS_VALUE;
       m_av_clock->Lock();
       m_av_clock->OMXStop(false);
       m_omxVideo.Reset();

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -50,15 +50,13 @@ protected:
   bool                      m_open;
   CDVDStreamInfo            m_hints;
   double                    m_iCurrentPts;
-  double                    m_iSleepEndTime;
+  double                    m_nextOverlay;
   OMXClock                  *m_av_clock;
   COMXVideo                 m_omxVideo;
   float                     m_fFrameRate;
   bool                      m_hdmi_clock_sync;
   double                    m_iVideoDelay;
   int                       m_speed;
-  double                    m_FlipTimeStamp; // time stamp of last flippage. used to play at a forced framerate
-  int                       m_audio_count;
   bool                      m_stalled;
   bool                      m_started;
   bool                      m_flush;
@@ -82,6 +80,7 @@ protected:
   BitstreamStats m_videoStats;
 
   void ProcessOverlays(double pts);
+  double NextOverlay(double pts);
 
   virtual void OnStartup();
   virtual void OnExit();


### PR DESCRIPTION
Currently subs are ~500ms out of sync with a lot of jitter.

The video is not rendered by the arm, so a lot of the page flipping code is redundant.
Calling ProcessOverlays/FlipPage every frame is a big performance hit on Pi,
so I keep track of when the subs will next change and only call them then.

This has the side effect that ASS/SSA subs don't animate, so while sub is onscreen,
I periodically update (limited 10 fps).
