### PR TITLE
[rbp/omxplayer] Fix divide by zero at eof

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -916,7 +916,7 @@ unsigned int COMXAudio::GetSpace()
 float COMXAudio::GetDelay()
 {
   unsigned int free = m_omx_decoder.GetInputBufferSize() - m_omx_decoder.GetInputBufferSpace();
-  return (float)free / (float)m_BytesPerSec;
+  return m_BytesPerSec ? (float)free / (float)m_BytesPerSec : 0.0f;
 }
 
 float COMXAudio::GetCacheTime()
@@ -924,13 +924,13 @@ float COMXAudio::GetCacheTime()
   float fBufferLenFull = (float)m_BufferLen - (float)GetSpace();
   if(fBufferLenFull < 0)
     fBufferLenFull = 0;
-  float ret = fBufferLenFull / (float)m_BytesPerSec;
+  float ret = m_BytesPerSec ? fBufferLenFull / (float)m_BytesPerSec : 0.0f;
   return ret;
 }
 
 float COMXAudio::GetCacheTotal()
 {
-  return (float)m_BufferLen / (float)m_BytesPerSec;
+  return m_BytesPerSec ? (float)m_BufferLen / (float)m_BytesPerSec : 0.0f;
 }
 
 //***********************************************************************************************


### PR DESCRIPTION
If you leave the codec info up in a debug build and reach eof, you will abort.

This is due to audio decoder being closed, which zeros m_BytesPerSec, but the player info is still requested.
GetCacheTime will do a divide by zero. This change protects that divide.

This is the call stack of the abort:

```
#0  0xb67187e4 in abort () from /home/dc4/rootfs/lib/arm-linux-gnueabihf/libc.so.6
#1  0xb670d8d4 in __assert_fail () from /home/dc4/rootfs/lib/arm-linux-gnueabihf/libc.so.6
#2  0x006c119c in round_int (x=<optimized out>) at /home/pi/pop/xbmc/xbmc/utils/MathUtils.h:75
#3  OMXPlayerAudio::GetPlayerInfo (this=0xce1842) at OMXPlayerAudio.cpp:886
#4  0x006b93c0 in COMXPlayer::GetAudioInfo (this=0xb239b008, strAudioInfo=...) at OMXPlayer.cpp:2727
#5  0x006eb574 in CGUIWindowFullScreen::FrameMove (this=0x32a4488) at GUIWindowFullScreen.cpp:582
#6  0x003bd480 in CGUIWindowManager::FrameMove (this=0x30bd050) at GUIWindowManager.cpp:633
#7  0x005fdda4 in CXBApplicationEx::Run (this=0x30ba008) at XBApplicationEx.cpp:140
#8  0x00327708 in XBMC_Run (renderGUI=<optimized out>) at xbmc.cpp:69
#9  0x002e02d0 in main (argc=3, argv=0xbef5d724) at main.cpp:76
```
