### PR TITLE
Add av_dict_free() to DllAvUtil also for Windows

### DIFF
--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -116,6 +116,7 @@ public:
   virtual int av_get_bytes_per_sample(enum AVSampleFormat p1) = 0;
   virtual AVDictionaryEntry *av_dict_get(AVDictionary *m, const char *key, const AVDictionaryEntry *prev, int flags) = 0;
   virtual int av_dict_set(AVDictionary **pm, const char *key, const char *value, int flags)=0;
+  virtual void av_dict_free(AVDictionary **pm) = 0;
   virtual int av_samples_get_buffer_size (int *linesize, int nb_channels, int nb_samples, enum AVSampleFormat sample_fmt, int align) = 0;
   virtual int64_t av_get_default_channel_layout(int nb_channels)=0;
 };
@@ -198,6 +199,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
   DEFINE_METHOD1(int, av_get_bytes_per_sample, (enum AVSampleFormat p1))
   DEFINE_METHOD4(AVDictionaryEntry *, av_dict_get, (AVDictionary *p1, const char *p2, const AVDictionaryEntry *p3, int p4))
   DEFINE_METHOD4(int, av_dict_set, (AVDictionary **p1, const char *p2, const char *p3, int p4));
+  DEFINE_METHOD1(void, av_dict_free, (AVDictionary **p1))
   DEFINE_METHOD5(int, av_samples_get_buffer_size, (int *p1, int p2, int p3, enum AVSampleFormat p4, int p5))
   DEFINE_METHOD1(int64_t, av_get_default_channel_layout, (int p1))
 
@@ -225,6 +227,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
     RESOLVE_METHOD(av_get_bytes_per_sample)
     RESOLVE_METHOD(av_dict_get)
     RESOLVE_METHOD(av_dict_set)
+    RESOLVE_METHOD(av_dict_free)
     RESOLVE_METHOD(av_samples_get_buffer_size)
     RESOLVE_METHOD(av_get_default_channel_layout)
   END_METHOD_RESOLVE()


### PR DESCRIPTION
Fixes Windows compilation after pull request #2730
