### PR TITLE
Re-enable skip previous/next as chapter jumps, when outside of playlist context

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2390,14 +2390,6 @@ bool CApplication::OnAction(const CAction &action)
       return OnAction(CAction(ACTION_PLAYER_PLAY));
   }
 
-  // Now check with the playlist player if action can be handled.
-  // In case of the action PREV_ITEM, we only allow the playlist player to take it if we're less than 3 seconds into playback.
-  if (!(action.GetID() == ACTION_PREV_ITEM && m_pPlayer && m_pPlayer->CanSeek() && GetTime() > 3) )
-  {
-    if (g_playlistPlayer.OnAction(action))
-      return true;
-  }
-
   //if the action would start or stop inertial scrolling
   //by gesture - bypass the normal OnAction handler of current window
   if( !m_pInertialScrollingHandler->CheckForInertialScrolling(&action) )
@@ -2481,6 +2473,18 @@ bool CApplication::OnAction(const CAction &action)
     }
     return true;
   }
+
+  // Now check with the playlist player if action can be handled.
+  // In case of the action PREV_ITEM, we only allow the playlist player to take it if we're less than 3 seconds into playback.
+  if (!(action.GetID() == ACTION_PREV_ITEM && m_pPlayer && m_pPlayer->CanSeek() && GetTime() > 3) )
+  {
+    if (g_playlistPlayer.OnAction(action))
+      return true;
+  }
+
+  // Now check with the player if action can be handled.
+  if (m_pPlayer != NULL && m_pPlayer->OnAction(action))
+    return true;
 
   // stop : stops playing current audio song
   if (action.GetID() == ACTION_STOP)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2390,6 +2390,14 @@ bool CApplication::OnAction(const CAction &action)
       return OnAction(CAction(ACTION_PLAYER_PLAY));
   }
 
+  // Now check with the playlist player if action can be handled.
+  // In case of the action PREV_ITEM, we only allow the playlist player to take it if we're less than 3 seconds into playback.
+  if (!(action.GetID() == ACTION_PREV_ITEM && m_pPlayer && m_pPlayer->CanSeek() && GetTime() > 3) )
+  {
+    if (g_playlistPlayer.OnAction(action))
+      return true;
+  }
+
   //if the action would start or stop inertial scrolling
   //by gesture - bypass the normal OnAction handler of current window
   if( !m_pInertialScrollingHandler->CheckForInertialScrolling(&action) )
@@ -2481,34 +2489,12 @@ bool CApplication::OnAction(const CAction &action)
     return true;
   }
 
-  // previous : play previous song from playlist
-  if (action.GetID() == ACTION_PREV_ITEM)
+  // In case the playlist player nor the player didn't handle PREV_ITEM, because we are past the 3 secs limit.
+  // If so, we just jump to the start of the track.
+  if (action.GetID() == ACTION_PREV_ITEM && m_pPlayer && m_pPlayer->CanSeek())
   {
-    // first check whether we're within 3 seconds of the start of the track
-    // if not, we just revert to the start of the track
-    if (m_pPlayer && m_pPlayer->CanSeek() && GetTime() > 3)
-    {
-      SeekTime(0);
-      SetPlaySpeed(1);
-    }
-    else
-    {
-      g_playlistPlayer.PlayPrevious();
-    }
-    return true;
-  }
-
-  // next : play next song from playlist
-  if (action.GetID() == ACTION_NEXT_ITEM)
-  {
-    if (IsPlaying() && m_pPlayer->SkipNext())
-      return true;
-
-    if (IsPaused())
-      m_pPlayer->Pause();
-
-    g_playlistPlayer.PlayNext();
-
+    SeekTime(0);
+    SetPlaySpeed(1);
     return true;
   }
 

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -34,6 +34,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "guilib/Key.h"
 
 using namespace PLAYLIST;
 
@@ -58,6 +59,22 @@ CPlayListPlayer::~CPlayListPlayer(void)
   delete m_PlaylistMusic;
   delete m_PlaylistVideo;
   delete m_PlaylistEmpty;
+}
+
+bool CPlayListPlayer::OnAction(const CAction &action)
+{
+  if (action.GetID() == ACTION_PREV_ITEM && !IsSingleItemNonRepeatPlaylist())
+  {
+    PlayPrevious();
+    return true;
+  }
+  else if (action.GetID() == ACTION_NEXT_ITEM && !IsSingleItemNonRepeatPlaylist())
+  {
+    PlayNext();
+    return true;
+  }
+  else
+    return false;
 }
 
 bool CPlayListPlayer::OnMessage(CGUIMessage &message)
@@ -198,6 +215,12 @@ bool CPlayListPlayer::PlayPrevious()
   }
 
   return Play(iSong, false, true);
+}
+
+bool CPlayListPlayer::IsSingleItemNonRepeatPlaylist() const
+{
+  const CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
+  return (playlist.size() <= 1 && !RepeatedOne(m_iCurrentPlayList) && !Repeated(m_iCurrentPlayList));
 }
 
 bool CPlayListPlayer::Play()

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -27,6 +27,7 @@
 #define PLAYLIST_VIDEO   1
 #define PLAYLIST_PICTURE 2
 
+class CAction;
 class CFileItem; typedef boost::shared_ptr<CFileItem> CFileItemPtr;
 class CFileItemList;
 
@@ -165,6 +166,10 @@ public:
   void Insert(int iPlaylist, CFileItemList& items, int iIndex);
   void Remove(int iPlaylist, int iPosition);
   void Swap(int iPlaylist, int indexItem1, int indexItem2);
+
+  bool IsSingleItemNonRepeatPlaylist() const;
+
+  bool OnAction(const CAction &action);
 protected:
   /*! \brief Returns true if the given is set to repeat all
    \param playlist Playlist to be query

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3672,6 +3672,28 @@ bool CDVDPlayer::OnAction(const CAction &action)
     }
   }
 
+  switch (action.GetID())
+  {
+    case ACTION_NEXT_ITEM:
+      if(GetChapterCount() > 0)
+      {
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()+1));
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
+      }
+      else
+        break;
+    case ACTION_PREV_ITEM:
+      if(GetChapterCount() > 0)
+      {
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()-1));
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
+      }
+      else
+        break;
+  }
+
   // return false to inform the caller we didn't handle the message
   return false;
 }

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3834,6 +3834,28 @@ bool COMXPlayer::OnAction(const CAction &action)
     }
   }
 
+  switch (action.GetID())
+  {
+    case ACTION_NEXT_ITEM:
+      if(GetChapterCount() > 0)
+      {
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()+1));
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
+      }
+      else
+        break;
+    case ACTION_PREV_ITEM:
+      if(GetChapterCount() > 0)
+      {
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()-1));
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
+      }
+      else
+        break;
+  }
+
   // return false to inform the caller we didn't handle the message
   return false;
 }

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -62,12 +62,6 @@ void CGUIDialogVideoOSD::FrameMove()
 
 bool CGUIDialogVideoOSD::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_NEXT_ITEM || action.GetID() == ACTION_PREV_ITEM || action.GetID() == ACTION_CHANNEL_UP || action.GetID() == ACTION_CHANNEL_DOWN)
-  {
-    // these could indicate next chapter if video supports it
-    if (g_application.m_pPlayer != NULL && g_application.m_pPlayer->OnAction(action))
-      return true;
-  }
   if (action.GetID() == ACTION_SHOW_OSD)
   {
     Close();

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -125,9 +125,6 @@ CGUIWindowFullScreen::~CGUIWindowFullScreen(void)
 
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
 {
-  if (g_application.m_pPlayer != NULL && g_application.m_pPlayer->OnAction(action))
-    return true;
-
   if (m_timeCodePosition > 0 && action.GetButtonCode())
   { // check whether we have a mapping in our virtual videotimeseek "window" and have a select action
     CKey key(action.GetButtonCode());


### PR DESCRIPTION
This is a follow up to #2809. 
This PR now re-enables chapter jumps using the skip previous-next action in case a video is not played back as part of a playlist.

The benefit is "playlist priority over chapters":

A) when playing a movie in a playlist, the behaviour is like #2809. User knows that a playlist is playing, so expects "skip next" to go to the next item in the playlist.
B) when playing a movie NOT in a playlist (actually a playlist but only one single item), the behaviour is like before. User may not even know or use the concept of playlists, and just wants to skip to the next (or previous) chapter. 

Note: From a code standpoint, the only comment I see is that DVD/OMXplayer is consulting g_playlistPlayer. Another way to achieve a cleaner separation could be to introduce a virtual method in the IPlayerCallback interface.
