### PR TITLE
[rbp/omxplayer] Fix for srt subtitle sync

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3862,7 +3862,7 @@ bool COMXPlayer::HasMenu()
 
 bool COMXPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
 {
-  double pts = m_av_clock.GetClock();
+  double pts = m_av_clock.OMXMediaTime(false);
 
   if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
     return false;


### PR DESCRIPTION
Textual subs should be synchronised to the mediatime (OMXMediaTime) like graphical subs
