### PR TITLE
AE: Workaround (ugly) non existing channel maps in old ffmpeg #14407

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -319,6 +319,8 @@ void CDVDAudioCodecFFmpeg::BuildChannelMap()
   {
     CLog::Log(LOGINFO, "CDVDAudioCodecFFmpeg::GetChannelMap - FFmpeg reported %d channels, but the layout contains %d ignoring", m_pCodecContext->channels, bits);
     layout = m_dllAvUtil.av_get_default_channel_layout(m_pCodecContext->channels);
+    while(layout == 0 && m_pCodecContext->channels > 2)
+      layout = m_dllAvUtil.av_get_default_channel_layout(--m_pCodecContext->channels);
   }
 
   m_channelLayout.Reset();


### PR DESCRIPTION
Old ffmpeg lacks a complete channel_map. So we can end up empty and run into an assert later. This patch workarounds it by choosing the next lower available profile.

I don't call it fix, cause a proper fix would incorporate the user layout, e.g. 6.1 -> 5.1 but 7.0 gets 5.0 with proper channel mixing.

ffmpeg 1.2 (master) has a full channel_map, so no problem here.
