### PR TITLE
[win32] ping ; avoid log when no reply

### DIFF
--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -275,7 +275,7 @@ bool CNetworkWin32::PingHost(unsigned long host, unsigned int timeout_ms /* = 20
                                 NULL, ReplyBuffer, sizeof(ReplyBuffer), timeout_ms);
 
   DWORD lastErr = GetLastError();
-  if (lastErr != ERROR_SUCCESS)
+  if (lastErr != ERROR_SUCCESS && lastErr != IP_REQ_TIMED_OUT)
     CLog::Log(LOGERROR, "%s - IcmpSendEcho failed - %s", __FUNCTION__, WUSysMsg(lastErr).c_str());
 
   IcmpCloseHandle (hIcmpFile);


### PR DESCRIPTION
cosmetics ; sporadically when ping times out with no reply GetLastError() may return IP_REQ_TIMED_OUT which has same value as WSA_QOS_ADMISSION_FAILURE and FormatMessage() therefore generates a non-sensical message "Error due to lack of resources"

ref also ; http://forum.xbmc.org/showthread.php?tid=124340&pid=1440588#pid1440588
