### PR TITLE
[mdnsembedded] - fix zeroconfbrowser

### DIFF
--- a/tools/depends/target/mdnsresponder/01-android-embedded.patch
+++ b/tools/depends/target/mdnsresponder/01-android-embedded.patch
@@ -1,206 +1,20 @@
-diff -rupN mDNSResponder-333.10/mDNSCore/mDNSEmbeddedAPI.h mDNSResponder-333.10.patched/mDNSCore/mDNSEmbeddedAPI.h
---- mDNSResponder-333.10/mDNSCore/mDNSEmbeddedAPI.h	2011-06-30 22:56:04.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSCore/mDNSEmbeddedAPI.h	2012-04-15 15:10:42.000000000 +0200
-@@ -1051,6 +1051,10 @@ enum
- 	McastResolver_FlagNew    = 2
- 	};
+diff -uPr ./mDNSCore/mDNSEmbeddedAPI.h ./mDNSCore/mDNSEmbeddedAPI.h
+--- ./mDNSCore/mDNSEmbeddedAPI.h	2012-10-24 01:18:23.000000000 +0200
++++ ./mDNSCore/mDNSEmbeddedAPI.h	2013-06-10 18:45:59.000000000 +0200
+@@ -1144,6 +1144,10 @@
+     McastResolver_FlagNew    = 2
+ };
  
 +// everyone loves proprietary language extensions in the global namespace
 +#ifdef _MSC_VER
 +#undef interface
 +#endif
  typedef struct McastResolver
- 	{
- 	struct McastResolver *next;
-diff -rupN mDNSResponder-333.10/mDNSPosix/mDNSPosix.h mDNSResponder-333.10.patched/mDNSPosix/mDNSPosix.h
---- mDNSResponder-333.10/mDNSPosix/mDNSPosix.h	2009-08-11 03:13:47.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSPosix/mDNSPosix.h	2012-04-15 15:10:42.000000000 +0200
-@@ -25,6 +25,10 @@
-     extern "C" {
- #endif
- 
-+#ifdef ANDROID
-+#include <fcntl.h>
-+#endif
-+
- // PosixNetworkInterface is a record extension of the core NetworkInterfaceInfo
- // type that supports extra fields needed by the Posix platform.
- //
-diff -rupN mDNSResponder-333.10/mDNSShared/PlatformCommon.c mDNSResponder-333.10.patched/mDNSShared/PlatformCommon.c
---- mDNSResponder-333.10/mDNSShared/PlatformCommon.c	2011-04-12 00:54:35.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSShared/PlatformCommon.c	2012-04-15 15:10:42.000000000 +0200
-@@ -27,6 +27,10 @@
- #include "DNSCommon.h"
- #include "PlatformCommon.h"
- 
-+#ifdef ANDROID
-+#include <android/log.h>
-+#endif
-+
- #ifdef NOT_HAVE_SOCKLEN_T
-     typedef unsigned int socklen_t;
- #endif
-@@ -143,13 +147,20 @@ mDNSexport void ReadDDNSSettingsFromConf
- #if MDNS_DEBUGMSGS
- mDNSexport void mDNSPlatformWriteDebugMsg(const char *msg)
- 	{
-+#ifdef ANDROID
-+	__android_log_print(ANDROID_LOG_DEBUG, "bonjour", "%s", msg);
-+#else
- 	fprintf(stderr,"%s\n", msg);
- 	fflush(stderr);
-+#endif
- 	}
- #endif
- 
- mDNSexport void mDNSPlatformWriteLogMsg(const char *ident, const char *buffer, mDNSLogLevel_t loglevel)
- 	{
-+#ifdef ANDROID
-+	__android_log_print(ANDROID_LOG_DEBUG, "bonjour", "%s", buffer);
-+#else
- #if APPLE_OSX_mDNSResponder && LogTimeStamps
- 	extern mDNS mDNSStorage;
- 	extern mDNSu32 mDNSPlatformClockDivisor;
-@@ -193,4 +204,5 @@ mDNSexport void mDNSPlatformWriteLogMsg(
- #endif
- 			syslog(syslog_level, "%s", buffer);
- 		}
-+#endif
- 	}
-diff -rupN mDNSResponder-333.10/mDNSShared/dns_sd.h mDNSResponder-333.10.patched/mDNSShared/dns_sd.h
---- mDNSResponder-333.10/mDNSShared/dns_sd.h	2011-08-31 03:44:17.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSShared/dns_sd.h	2012-04-15 15:10:42.000000000 +0200
-@@ -93,7 +93,7 @@
- /* standard calling convention under Win32 is __stdcall */
- /* Note: When compiling Intel EFI (Extensible Firmware Interface) under MS Visual Studio, the */
- /* _WIN32 symbol is defined by the compiler even though it's NOT compiling code for Windows32 */
--#if defined(_WIN32) && !defined(EFI32) && !defined(EFI64)
-+#if defined(_WIN32) && !defined(EFI32) && !defined(EFI64) && !defined(DISC_BONJOUR_EMBED)
- #define DNSSD_API __stdcall
- #else
- #define DNSSD_API
-diff -rupN mDNSResponder-333.10/mDNSShared/dnssd_clientshim.c mDNSResponder-333.10.patched/mDNSShared/dnssd_clientshim.c
---- mDNSResponder-333.10/mDNSShared/dnssd_clientshim.c	2011-06-02 00:44:37.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSShared/dnssd_clientshim.c	2012-04-15 15:10:42.000000000 +0200
-@@ -25,6 +25,13 @@
- 
- #include "dns_sd.h"				// Defines the interface to the client layer above
- #include "mDNSEmbeddedAPI.h"		// The interface we're building on top of
-+#ifndef _MSC_VER
-+#include <sys/socket.h>
-+#include <netinet/in.h>
-+#else
-+#include <winsock2.h>
-+#endif
-+
- extern mDNS mDNSStorage;		// We need to pass the address of this storage to the lower-layer functions
- 
- #if MDNS_BUILDINGSHAREDLIBRARY || MDNS_BUILDINGSTUBLIBRARY
-@@ -71,6 +78,14 @@ typedef struct
- typedef struct
- 	{
- 	mDNS_DirectOP_Dispose  *disposefn;
-+	DNSServiceRef                aQuery;
-+	DNSServiceGetAddrInfoReply   callback;
-+	void                         *context;
-+	} mDNS_DirectOP_GetAddrInfo;
-+
-+typedef struct
-+	{
-+	mDNS_DirectOP_Dispose  *disposefn;
- 	DNSServiceResolveReply  callback;
- 	void                   *context;
- 	const ResourceRecord   *SRV;
-@@ -659,7 +674,7 @@ DNSServiceErrorType DNSServiceQueryRecor
- 	x->q.ExpectUnique        = mDNSfalse;
- 	x->q.ForceMCast          = (flags & kDNSServiceFlagsForceMulticast) != 0;
- 	x->q.ReturnIntermed      = (flags & kDNSServiceFlagsReturnIntermediates) != 0;
--	x->q.SuppressUnsable     = (flags & kDNSServiceFlagsSuppressUnusable) != 0;
-+	x->q.SuppressUnusable    = (flags & kDNSServiceFlagsSuppressUnusable) != 0;
- 	x->q.SearchListIndex     = 0;
- 	x->q.AppendSearchDomains = 0;
- 	x->q.RetryWithSearchDomains = mDNSfalse;
-diff -rupN mDNSResponder-333.10/mDNSShared/dnssd_ipc.h mDNSResponder-333.10.patched/mDNSShared/dnssd_ipc.h
---- mDNSResponder-333.10/mDNSShared/dnssd_ipc.h	2011-06-30 22:56:04.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSShared/dnssd_ipc.h	2012-04-15 15:10:42.000000000 +0200
-@@ -29,6 +29,11 @@
- #ifndef DNSSD_IPC_H
- #define DNSSD_IPC_H
- 
-+#ifdef ANDROID
-+#include <sys/socket.h>
-+#include <sys/un.h>
-+#endif
-+
- #include "dns_sd.h"
- 
- //
-diff -rupN mDNSResponder-333.10/mDNSShared/uds_daemon.h mDNSResponder-333.10.patched/mDNSShared/uds_daemon.h
---- mDNSResponder-333.10/mDNSShared/uds_daemon.h	2011-05-18 00:18:08.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSShared/uds_daemon.h	2012-04-15 15:10:42.000000000 +0200
-@@ -22,6 +22,11 @@
- 
-  */
- 
-+#ifdef ANDROID
-+#include <sys/socket.h>
-+#include <sys/un.h>
-+#endif
-+
- #include "mDNSEmbeddedAPI.h"
- #include "dnssd_ipc.h"
- 
-diff -rupN mDNSResponder-333.10/mDNSWindows/mDNSWin32.c mDNSResponder-333.10.patched/mDNSWindows/mDNSWin32.c
---- mDNSResponder-333.10/mDNSWindows/mDNSWin32.c	2011-08-31 03:42:48.000000000 +0200
-+++ mDNSResponder-333.10.patched/mDNSWindows/mDNSWin32.c	2012-04-15 15:17:34.000000000 +0200
-@@ -2843,10 +2843,7 @@ mDNSlocal mStatus	SetupSocket( mDNS * co
- 		sa4.sin_family 		= AF_INET;
- 		sa4.sin_port 		= port.NotAnInteger;
- 		sa4.sin_addr.s_addr	= ipv4.NotAnInteger;
--		
--		err = bind( sock, (struct sockaddr *) &sa4, sizeof( sa4 ) );
--		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
--		
-+				
- 		// Turn on option to receive destination addresses and receiving interface.
- 		
- 		option = 1;
-@@ -2887,6 +2884,9 @@ mDNSlocal mStatus	SetupSocket( mDNS * co
- 		err = setsockopt( sock, IPPROTO_IP, IP_MULTICAST_TTL, (char *) &option, sizeof( option ) );
- 		check_translated_errno( err == 0, errno_compat(), kOptionErr );
- 
-+		err = bind( sock, (struct sockaddr *) &sa4, sizeof( sa4 ) );
-+		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
-+
- 	}
- 	else if( inAddr->sa_family == AF_INET6 )
- 	{
-@@ -2904,10 +2904,7 @@ mDNSlocal mStatus	SetupSocket( mDNS * co
- 		sa6.sin6_flowinfo	= 0;
- 		sa6.sin6_addr		= sa6p->sin6_addr;
- 		sa6.sin6_scope_id	= sa6p->sin6_scope_id;
--		
--		err = bind( sock, (struct sockaddr *) &sa6, sizeof( sa6 ) );
--		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
--		
-+				
- 		// Turn on option to receive destination addresses and receiving interface.
- 		
- 		option = 1;
-@@ -2957,6 +2954,10 @@ mDNSlocal mStatus	SetupSocket( mDNS * co
- 		option = 255;
- 		err = setsockopt( sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (char *) &option, sizeof( option ) );
- 		check_translated_errno( err == 0, errno_compat(), kOptionErr );
-+		
-+		err = bind( sock, (struct sockaddr *) &sa6, sizeof( sa6 ) );
-+		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
-+
- 	}
- 	else
- 	{
-diff -uPr mDNSResponder-333.10/mDNSCore.orig/mDnsEmbedded.c mDNSResponder-333.10/mDNSCore/mDnsEmbedded.c
---- mDNSResponder-333.10/mDNSCore/mDnsEmbedded.c	1970-01-01 01:00:00.000000000 +0100
-+++ mDNSResponder-333.10/mDNSCore/mDnsEmbedded.c	2013-06-01 13:04:44.000000000 +0100
+ {
+     struct McastResolver *next;
+diff -uPr ./mDNSCore/mDnsEmbedded.c ./mDNSCore/mDnsEmbedded.c
+--- ./mDNSCore/mDnsEmbedded.c	1970-01-01 01:00:00.000000000 +0100
++++ ./mDNSCore/mDnsEmbedded.c	2013-06-10 18:45:59.000000000 +0200
 @@ -0,0 +1,145 @@
 +/**
 + *  @file
@@ -347,9 +161,9 @@ diff -uPr mDNSResponder-333.10/mDNSCore.orig/mDnsEmbedded.c mDNSResponder-333.10
 +	return result;
 +}
 +#endif
-diff -uPr mDNSResponder-333.10/mDNSCore.orig/mDnsEmbedded.h mDNSResponder-333.10/mDNSCore/mDnsEmbedded.h
---- mDNSResponder-333.10/mDNSCore/mDnsEmbedded.h	1970-01-01 01:00:00.000000000 +0100
-+++ mDNSResponder-333.10/mDNSCore/mDnsEmbedded.h	2013-06-01 13:00:29.000000000 +0100
+diff -uPr ./mDNSCore/mDnsEmbedded.h ./mDNSCore/mDnsEmbedded.h
+--- ./mDNSCore/mDnsEmbedded.h	1970-01-01 01:00:00.000000000 +0100
++++ ./mDNSCore/mDnsEmbedded.h	2013-06-10 18:45:59.000000000 +0200
 @@ -0,0 +1,32 @@
 +/*                                                                                                                                                                                        
 + *      Copyright (C) 2005-2013 Team XBMC                                                                                                                                                 
@@ -383,14 +197,210 @@ diff -uPr mDNSResponder-333.10/mDNSCore.orig/mDnsEmbedded.h mDNSResponder-333.10
 +}
 +#endif
 +#endif //_MDNSEMBEDDED_H_
---- mDNSResponder-333.10/mDNSShared/dnssd_clientshim.c	2013-06-04 21:24:45.000000000 +0200
-+++ mDNSResponder-333.10/mDNSShared/dnssd_clientshim.c	2013-06-04 22:01:48.000000000 +0200
-@@ -414,7 +414,7 @@
+diff -uPr ./mDNSPosix/mDNSPosix.h ./mDNSPosix/mDNSPosix.h
+--- ./mDNSPosix/mDNSPosix.h	2011-12-02 01:39:45.000000000 +0100
++++ ./mDNSPosix/mDNSPosix.h	2013-06-10 18:45:59.000000000 +0200
+@@ -25,6 +25,10 @@
+ extern "C" {
+ #endif
  
- 	// Check parameters
- 	if (!regtype[0] || !MakeDomainNameFromDNSNameString(&t, regtype))      { errormsg = "Illegal regtype"; goto badparam; }
--	if (!MakeDomainNameFromDNSNameString(&d, *domain ? domain : "local.")) { errormsg = "Illegal domain";  goto badparam; }
-+	if (!MakeDomainNameFromDNSNameString(&d, domain ? domain : "local.")) { errormsg = "Illegal domain";  goto badparam; }
++#ifdef ANDROID
++#include <fcntl.h>
++#endif
++
+ // PosixNetworkInterface is a record extension of the core NetworkInterfaceInfo
+ // type that supports extra fields needed by the Posix platform.
+ //
+diff -uPr ./mDNSShared/dnssd_clientshim.c ./mDNSShared/dnssd_clientshim.c
+--- ./mDNSShared/dnssd_clientshim.c	2013-04-10 01:09:07.000000000 +0200
++++ ./mDNSShared/dnssd_clientshim.c	2013-06-10 18:53:18.000000000 +0200
+@@ -25,6 +25,13 @@
  
- 	// Allocate memory, and handle failure
- 	x = (mDNS_DirectOP_Browse *)mDNSPlatformMemAllocate(sizeof(*x));
+ #include "dns_sd.h"             // Defines the interface to the client layer above
+ #include "mDNSEmbeddedAPI.h"        // The interface we're building on top of
++#ifndef _MSC_VER
++#include <sys/socket.h>
++#include <netinet/in.h>
++#else
++#include <winsock2.h>
++#endif
++
+ extern mDNS mDNSStorage;        // We need to pass the address of this storage to the lower-layer functions
+ 
+ #if MDNS_BUILDINGSHAREDLIBRARY || MDNS_BUILDINGSTUBLIBRARY
+@@ -71,6 +78,14 @@
+ typedef struct
+ {
+     mDNS_DirectOP_Dispose  *disposefn;
++    DNSServiceRef                aQuery;
++    DNSServiceGetAddrInfoReply   callback;
++    void                         *context;
++} mDNS_DirectOP_GetAddrInfo;
++
++typedef struct
++{
++    mDNS_DirectOP_Dispose  *disposefn;
+     DNSServiceResolveReply callback;
+     void                   *context;
+     const ResourceRecord   *SRV;
+@@ -399,7 +414,7 @@
+ 
+     // Check parameters
+     if (!regtype[0] || !MakeDomainNameFromDNSNameString(&t, regtype))      { errormsg = "Illegal regtype"; goto badparam; }
+-    if (!MakeDomainNameFromDNSNameString(&d, *domain ? domain : "local.")) { errormsg = "Illegal domain";  goto badparam; }
++    if (!MakeDomainNameFromDNSNameString(&d, (domain && *domain) ? domain : "local.")) { errormsg = "Illegal domain";  goto badparam; }
+ 
+     // Allocate memory, and handle failure
+     x = (mDNS_DirectOP_Browse *)mDNSPlatformMemAllocate(sizeof(*x));
+@@ -668,7 +683,7 @@
+     x->q.ExpectUnique        = mDNSfalse;
+     x->q.ForceMCast          = (flags & kDNSServiceFlagsForceMulticast) != 0;
+     x->q.ReturnIntermed      = (flags & kDNSServiceFlagsReturnIntermediates) != 0;
+-    x->q.SuppressUnsable     = (flags & kDNSServiceFlagsSuppressUnusable) != 0;
++    x->q.SuppressUnusable    = (flags & kDNSServiceFlagsSuppressUnusable) != 0;
+     x->q.SearchListIndex     = 0;
+     x->q.AppendSearchDomains = 0;
+     x->q.RetryWithSearchDomains = mDNSfalse;
+diff -uPr ./mDNSShared/dns_sd.h ./mDNSShared/dns_sd.h
+--- ./mDNSShared/dns_sd.h	2013-04-10 01:08:48.000000000 +0200
++++ ./mDNSShared/dns_sd.h	2013-06-10 18:45:59.000000000 +0200
+@@ -93,7 +93,7 @@
+ /* standard calling convention under Win32 is __stdcall */
+ /* Note: When compiling Intel EFI (Extensible Firmware Interface) under MS Visual Studio, the */
+ /* _WIN32 symbol is defined by the compiler even though it's NOT compiling code for Windows32 */
+-#if defined(_WIN32) && !defined(EFI32) && !defined(EFI64)
++#if defined(_WIN32) && !defined(EFI32) && !defined(EFI64) && !defined(DISC_BONJOUR_EMBED)
+ #define DNSSD_API __stdcall
+ #else
+ #define DNSSD_API
+diff -uPr ./mDNSShared/dnssd_ipc.h ./mDNSShared/dnssd_ipc.h
+--- ./mDNSShared/dnssd_ipc.h	2012-07-12 23:57:14.000000000 +0200
++++ ./mDNSShared/dnssd_ipc.h	2013-06-10 18:45:59.000000000 +0200
+@@ -29,6 +29,11 @@
+ #ifndef DNSSD_IPC_H
+ #define DNSSD_IPC_H
+ 
++#ifdef ANDROID
++#include <sys/socket.h>
++#include <sys/un.h>
++#endif
++
+ #include "dns_sd.h"
+ 
+ //
+diff -uPr ./mDNSShared/PlatformCommon.c ./mDNSShared/PlatformCommon.c
+--- ./mDNSShared/PlatformCommon.c	2012-01-18 03:45:05.000000000 +0100
++++ ./mDNSShared/PlatformCommon.c	2013-06-10 19:24:58.064683350 +0200
+@@ -15,6 +15,8 @@
+  * limitations under the License.
+  */
+ 
++#include "DNSCommon.h"
++
+ #include <stdio.h>              // Needed for fopen() etc.
+ #include <unistd.h>             // Needed for close()
+ #include <string.h>             // Needed for strlen() etc.
+@@ -24,9 +26,12 @@
+ #include <syslog.h>
+ 
+ #include "mDNSEmbeddedAPI.h"    // Defines the interface provided to the client layer above
+-#include "DNSCommon.h"
+ #include "PlatformCommon.h"
+ 
++#ifdef ANDROID
++#include <android/log.h>
++#endif
++
+ #ifdef NOT_HAVE_SOCKLEN_T
+ typedef unsigned int socklen_t;
+ #endif
+@@ -143,13 +148,20 @@
+ #if MDNS_DEBUGMSGS
+ mDNSexport void mDNSPlatformWriteDebugMsg(const char *msg)
+ {
++#ifdef ANDROID
++       __android_log_print(ANDROID_LOG_DEBUG, "bonjour", "%s", msg);
++#else
+     fprintf(stderr,"%s\n", msg);
+     fflush(stderr);
++#endif
+ }
+ #endif
+ 
+ mDNSexport void mDNSPlatformWriteLogMsg(const char *ident, const char *buffer, mDNSLogLevel_t loglevel)
+ {
++#ifdef ANDROID
++       __android_log_print(ANDROID_LOG_DEBUG, "bonjour", "%s", buffer);
++#else
+ #if APPLE_OSX_mDNSResponder && LogTimeStamps
+     extern mDNS mDNSStorage;
+     extern mDNSu32 mDNSPlatformClockDivisor;
+@@ -193,4 +205,5 @@
+ #endif
+         syslog(syslog_level, "%s", buffer);
+     }
++#endif
+ }
+diff -uPr ./mDNSShared/uds_daemon.h ./mDNSShared/uds_daemon.h
+--- ./mDNSShared/uds_daemon.h	2012-07-12 23:57:14.000000000 +0200
++++ ./mDNSShared/uds_daemon.h	2013-06-10 18:45:59.000000000 +0200
+@@ -22,6 +22,11 @@
+ 
+  */
+ 
++#ifdef ANDROID
++#include <sys/socket.h>
++#include <sys/un.h>
++#endif
++
+ #include "mDNSEmbeddedAPI.h"
+ #include "dnssd_ipc.h"
+ 
+diff -uPr ./mDNSWindows/mDNSWin32.c ./mDNSWindows/mDNSWin32.c
+--- ./mDNSWindows/mDNSWin32.c	2012-10-31 00:24:17.000000000 +0100
++++ ./mDNSWindows/mDNSWin32.c	2013-06-10 18:45:59.000000000 +0200
+@@ -2920,10 +2920,7 @@
+ 		sa4.sin_family 		= AF_INET;
+ 		sa4.sin_port 		= port.NotAnInteger;
+ 		sa4.sin_addr.s_addr	= ipv4.NotAnInteger;
+-		
+-		err = bind( sock, (struct sockaddr *) &sa4, sizeof( sa4 ) );
+-		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
+-		
++				
+ 		// Turn on option to receive destination addresses and receiving interface.
+ 		
+ 		option = 1;
+@@ -2964,6 +2961,9 @@
+ 		err = setsockopt( sock, IPPROTO_IP, IP_MULTICAST_TTL, (char *) &option, sizeof( option ) );
+ 		check_translated_errno( err == 0, errno_compat(), kOptionErr );
+ 
++		err = bind( sock, (struct sockaddr *) &sa4, sizeof( sa4 ) );
++		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
++
+ 	}
+ 	else if( inAddr->sa_family == AF_INET6 )
+ 	{
+@@ -2981,10 +2981,7 @@
+ 		sa6.sin6_flowinfo	= 0;
+ 		sa6.sin6_addr		= sa6p->sin6_addr;
+ 		sa6.sin6_scope_id	= sa6p->sin6_scope_id;
+-		
+-		err = bind( sock, (struct sockaddr *) &sa6, sizeof( sa6 ) );
+-		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
+-		
++				
+ 		// Turn on option to receive destination addresses and receiving interface.
+ 		
+ 		option = 1;
+@@ -3034,6 +3031,10 @@
+ 		option = 255;
+ 		err = setsockopt( sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (char *) &option, sizeof( option ) );
+ 		check_translated_errno( err == 0, errno_compat(), kOptionErr );
++		
++		err = bind( sock, (struct sockaddr *) &sa6, sizeof( sa6 ) );
++		check_translated_errno( err == 0, errno_compat(), kUnknownErr );
++
+ 	}
+ 	else
+ 	{

--- a/tools/depends/target/mdnsresponder/Makefile
+++ b/tools/depends/target/mdnsresponder/Makefile
@@ -4,7 +4,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=mDNSResponder
-VERSION=333.10
+VERSION=379.37
 OUTPUTNAME=libmDNSEmbedded
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz

--- a/tools/depends/target/mdnsresponder/makefile.internal
+++ b/tools/depends/target/mdnsresponder/makefile.internal
@@ -11,6 +11,7 @@ OBJECTS =  mDNSShared/dnssd_clientshim.o mDNSPosix/mDNSPosix.o mDNSCore/mDNS.o
 OBJECTS += mDNSCore/DNSCommon.o mDNSShared/mDNSDebug.o mDNSShared/GenLinkedList.o
 OBJECTS += mDNSCore/uDNS.o mDNSShared/PlatformCommon.o mDNSPosix/mDNSUNP.o
 OBJECTS += mDNSCore/DNSDigest.o mDNSCore/mDnsEmbedded.o mDNSShared/dnssd_clientlib.o
+OBJECTS += mDNSCore/CryptoAlg.o
 
 all: $(LIB)
 install: $(LIBDIR)/$(LIB) $(addprefix $(INCDIR)/,$(HEADERS))

--- a/xbmc/network/ZeroconfBrowser.cpp
+++ b/xbmc/network/ZeroconfBrowser.cpp
@@ -35,8 +35,7 @@
 #include "threads/SingleLock.h"
 #include "threads/Atomics.h"
 
-// FIXME - once zeroconf browser with mdnsembedded is fixed -remove that condition here
-#if !defined(HAS_ZEROCONF) || defined(HAS_MDNS_EMBEDDED)
+#if !defined(HAS_ZEROCONF)
 //dummy implementation used if no zeroconf is present
 //should be optimized away
 class CZeroconfBrowserDummy : public CZeroconfBrowser
@@ -152,8 +151,7 @@ CZeroconfBrowser*  CZeroconfBrowser::GetInstance()
     CAtomicSpinLock lock(sm_singleton_guard);
     if(!smp_instance)
     {
-// FIXME - once zeroconf browser with mdnsembedded is fixed -remove that condition here
-#if !defined(HAS_ZEROCONF) || defined(HAS_MDNS_EMBEDDED)
+#if !defined(HAS_ZEROCONF)
       smp_instance = new CZeroconfBrowserDummy;
 #else
 #if defined(TARGET_DARWIN)

--- a/xbmc/network/ZeroconfBrowser.cpp
+++ b/xbmc/network/ZeroconfBrowser.cpp
@@ -208,6 +208,11 @@ void CZeroconfBrowser::ZeroconfService::SetDomain(const CStdString& fcr_domain)
   m_domain = fcr_domain;
 }
 
+void CZeroconfBrowser::ZeroconfService::SetHostname(const CStdString& fcr_hostname)
+{
+  m_hostname = fcr_hostname;
+}
+
 void CZeroconfBrowser::ZeroconfService::SetIP(const CStdString& fcr_ip)
 {
   m_ip = fcr_ip;

--- a/xbmc/network/ZeroconfBrowser.h
+++ b/xbmc/network/ZeroconfBrowser.h
@@ -69,6 +69,9 @@ public:
       void SetIP(const CStdString& fcr_ip);
       const CStdString& GetIP() const {return m_ip;}
 
+      void SetHostname(const CStdString& fcr_hostname);
+      const CStdString& GetHostname() const {return m_hostname;}
+
       void SetPort(int f_port);
       int GetPort() const {return m_port;}
     
@@ -84,6 +87,10 @@ public:
       //2 entries below store 1 ip:port pair for this service
       CStdString m_ip;
       int        m_port;
+
+      //used for mdns in case dns resolution fails
+      //we store the hostname and resolve with mdns functions again
+      CStdString m_hostname;
       
       //1 entry below stores the txt-record as a key value map for this service
       tTxtRecordMap m_txtrecords_map;    

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.h
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.h
@@ -53,6 +53,17 @@ private:
                                         const char *regtype,
                                         const char *replyDomain,
                                         void *context);
+  /// GetAddrInfo callback
+  static void DNSSD_API GetAddrInfoCallback(DNSServiceRef                    sdRef,
+                                            DNSServiceFlags                  flags,
+                                            uint32_t                         interfaceIndex,
+                                            DNSServiceErrorType              errorCode,
+                                            const char                       *hostname,
+                                            const struct sockaddr            *address,
+                                            uint32_t                         ttl,
+                                            void                             *context
+                                            );
+
   /// resolve callback
   static void DNSSD_API ResolveCallback(DNSServiceRef                       sdRef,
                                         DNSServiceFlags                     flags,
@@ -85,4 +96,5 @@ private:
   DNSServiceRef m_browser;
   CZeroconfBrowser::ZeroconfService m_resolving_service;
   CEvent m_resolved_event;
+  CEvent m_addrinfo_event;
 };


### PR DESCRIPTION
As pointed out in the former pull request which added zeroconf support for android by utilising mdnsembedded - the zeroconfbrowser was deactivated because browsing worked - but resolving into an ip didn't.

I tracked it down to the following reason:
1. In the resolve callback we used our CDNSNameCache to resolve the hostname - which always failed on android (for example our CDNSNameCache was not able to resolve DockStar.local. to an ip) - not sure why it works on windows - but gethostbyname definitly doesn't resolve .local domains on my odroid-x.

I solved it by:
1. Moving the DNSCache out of the callback into the zeroconfthread (else the callback could stall and timeout)
2. Falling back to the mdns resolver (DNSServiceGetAddrInfo) when our CDNSNameCache fails

This PR also bumps the version of mdnsresponder to the latest. Speed of browsing is now same as on all other implementations (before it lasted about 5 secs before the list showed up).

@wsoltys do you think we even need the CDNSNameCache? Imo it would be sufficient to leave the resolution of local. hostnames to mdns completly - it caches aswell and is able to resolve those local domains without issues. Would be cool if you could give it a shot (just comment out the call to CDNSNameCache::Lookup in ZeroconfBrowserMDNS.cpp and see if it works on windows aswell...

This fixes zeroconfbrowser support for android and therefor completes zeroconf support. (and i consider this a fix and want to pull it as soon as i get the sign-off by @wsoltys ...)

@TheUni - we need the multicastlock for wifi networks then ;)
