### PR TITLE
[Profiles] Allow settings to be locked on specific levels

### DIFF
--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -25,6 +25,7 @@
 
 #include "settings/ISettingCallback.h"
 #include "utils/StdString.h"
+#include "settings/Setting.h"
 
 class CFileItem;
 class CMediaSource;
@@ -42,6 +43,20 @@ typedef enum
   LOCK_MODE_EEPROM_PARENTAL    =  5
 } LockType;
 
+namespace LOCK_LEVEL {
+  /**
+   Specifies, what Settings levels are locked for the user
+   **/
+  enum SETTINGS_LOCK
+  {
+    NONE,     //settings are unlocked => user can access all settings levels
+    ALL,      //all settings are locked => user always has to enter password, when entering the settings screen
+    STANDARD, //settings level standard and up are locked => user can still access the beginner levels
+    ADVANCED, 
+    EXPERT
+  };
+}
+
 class CGUIPassword : public ISettingCallback
 {
 public:
@@ -58,6 +73,13 @@ public:
 
   void UpdateMasterLockRetryCount(bool bResetCount);
   bool CheckStartUpLock();
+  /*! \brief Checks if the current profile is allowed to access the given settings level
+   \param level - The level to check
+   \param enforce - If false, CheckSettingLevelLock is allowed to lower the current settings level
+                    to a level we're allowed to access
+   \returns true if we're allowed to access the settings
+   */
+  bool CheckSettingLevelLock(const SettingLevel& level, bool enforce = false);
   bool CheckMenuLock(int iWindowID);
   bool SetMasterLockMode(bool bDetails=true);
   bool LockSource(const CStdString& strType, const CStdString& strName, bool bState);

--- a/xbmc/profiles/Profile.cpp
+++ b/xbmc/profiles/Profile.cpp
@@ -29,7 +29,7 @@ CProfile::CLock::CLock(LockType type, const CStdString &password)
   files = false;
   video = false;
   music = false;
-  settings = false;
+  settings = LOCK_LEVEL::NONE;
   addonManager = false;
   mode = type;
   code = password;
@@ -82,7 +82,7 @@ void CProfile::Load(const TiXmlNode *node, int nextIdProfile)
   XMLUtils::GetBoolean(node, "hassources", m_bSources);
   XMLUtils::GetBoolean(node, "canwritesources", m_bCanWriteSources);
   XMLUtils::GetBoolean(node, "lockaddonmanager", m_locks.addonManager);
-  XMLUtils::GetBoolean(node, "locksettings", m_locks.settings);
+  XMLUtils::GetInt(node, "locksettings", (int&)m_locks.settings);
   XMLUtils::GetBoolean(node, "lockfiles", m_locks.files);
   XMLUtils::GetBoolean(node, "lockmusic", m_locks.music);
   XMLUtils::GetBoolean(node, "lockvideo", m_locks.video);
@@ -113,7 +113,7 @@ void CProfile::Save(TiXmlNode *root) const
   XMLUtils::SetBoolean(node, "hassources", m_bSources);
   XMLUtils::SetBoolean(node, "canwritesources", m_bCanWriteSources);
   XMLUtils::SetBoolean(node, "lockaddonmanager", m_locks.addonManager);
-  XMLUtils::SetBoolean(node, "locksettings", m_locks.settings);
+  XMLUtils::SetInt(node, "locksettings", m_locks.settings);
   XMLUtils::SetBoolean(node, "lockfiles", m_locks.files);
   XMLUtils::SetBoolean(node, "lockmusic", m_locks.music);
   XMLUtils::SetBoolean(node, "lockvideo", m_locks.video);

--- a/xbmc/profiles/Profile.h
+++ b/xbmc/profiles/Profile.h
@@ -40,7 +40,7 @@ public:
     LockType mode;
     CStdString code;
     bool addonManager;
-    bool settings;
+    LOCK_LEVEL::SETTINGS_LOCK settings;
     bool music;
     bool video;
     bool files;
@@ -67,7 +67,11 @@ public:
   bool hasSources() const { return m_bSources; }
   bool canWriteSources() const { return m_bCanWriteSources; }
   bool hasAddons() const { return m_bAddons; }
-  bool settingsLocked() const { return m_locks.settings; }
+  /**
+   \brief Returns wich settings levels are locked for the current profile
+   \sa LOCK_LEVEL::SETTINGS_LOCK
+   */
+  LOCK_LEVEL::SETTINGS_LOCK settingsLockLevel() const { return m_locks.settings; }
   bool addonmanagerLocked() const { return m_locks.addonManager; }
   bool musicLocked() const { return m_locks.music; }
   bool videoLocked() const { return m_locks.video; }

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -101,7 +101,15 @@ void CGUIDialogLockSettings::CreateSettings()
     AddBool(5,20040,&m_locks.pictures);
     AddBool(6,20041,&m_locks.programs);
     AddBool(7,20042,&m_locks.files);
-    AddBool(8,20043,&m_locks.settings);
+    
+    std::vector<std::pair<int, int> > settingsLevelOptions;
+    settingsLevelOptions.push_back(std::make_pair(LOCK_LEVEL::NONE,     106));
+    settingsLevelOptions.push_back(std::make_pair(LOCK_LEVEL::ALL,      593));
+    settingsLevelOptions.push_back(std::make_pair(LOCK_LEVEL::STANDARD, 10037));
+    settingsLevelOptions.push_back(std::make_pair(LOCK_LEVEL::ADVANCED, 10038));
+    settingsLevelOptions.push_back(std::make_pair(LOCK_LEVEL::EXPERT,   10039));
+    AddSpin(8, 20043, (int*)&m_locks.settings, settingsLevelOptions);
+    
     AddBool(9,24090,&m_locks.addonManager);
     EnableDetails(m_locks.mode != LOCK_MODE_EVERYONE);
   }

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -266,7 +266,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
 
     bool bLock = CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser;
     dialog->m_locks.addonManager = bLock;
-    dialog->m_locks.settings = bLock;
+    dialog->m_locks.settings = (bLock) ? LOCK_LEVEL::ALL : LOCK_LEVEL::NONE;
     dialog->m_locks.files = bLock;
 
     dialog->m_strDirectory.Empty();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -185,7 +185,16 @@ bool ProfileHasProgramsLocked(const std::string &condition, const std::string &v
 
 bool ProfileHasSettingsLocked(const std::string &condition, const std::string &value, const std::string &settingId)
 {
-  return CProfilesManager::Get().GetCurrentProfile().settingsLocked();
+  LOCK_LEVEL::SETTINGS_LOCK slValue=LOCK_LEVEL::ALL;
+  if (StringUtils::EqualsNoCase(value, "none"))
+    slValue = LOCK_LEVEL::NONE;
+  else if (StringUtils::EqualsNoCase(value, "standard"))
+    slValue = LOCK_LEVEL::STANDARD;
+  else if (StringUtils::EqualsNoCase(value, "advanced"))
+    slValue = LOCK_LEVEL::ADVANCED;
+  else if (StringUtils::EqualsNoCase(value, "expert"))
+    slValue = LOCK_LEVEL::EXPERT;
+  return slValue <= CProfilesManager::Get().GetCurrentProfile().settingsLockLevel();
 }
 
 bool ProfileHasVideosLocked(const std::string &condition, const std::string &value, const std::string &settingId)

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -37,6 +37,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "view/ViewStateSettings.h"
+#include "GUIPassword.h"
 
 using namespace std;
 
@@ -290,6 +291,10 @@ bool CGUIWindowSettingsCategory::OnAction(const CAction &action)
 
     case ACTION_SETTINGS_LEVEL_CHANGE:
     {
+      //Test if we can access the new level
+      if (!g_passwordManager.CheckSettingLevelLock(CViewStateSettings::Get().GetNextSettingLevel(), true))
+        return false;
+      
       CViewStateSettings::Get().CycleSettingLevel();
       CSettings::Get().Save();
 
@@ -415,6 +420,8 @@ void CGUIWindowSettingsCategory::SetupControls(bool createSettings /* = true */)
   
   // update the screen string
   SET_CONTROL_LABEL(CONTROL_SETTINGS_LABEL, section->GetLabel());
+  
+  SET_CONTROL_LABEL(CONTRL_BTN_LEVELS, 10036 + (int)CViewStateSettings::Get().GetSettingLevel());
 
   // get the categories we need
   m_categories = section->GetCategories(CViewStateSettings::Get().GetSettingLevel());

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -356,10 +356,9 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
   }
   else if (setting.id == AUDIO_SETTINGS_MAKE_DEFAULT)
   {
-    if (CProfilesManager::Get().GetCurrentProfile().settingsLocked() &&
-        CProfilesManager::Get().GetMasterProfile().getLockMode() != ::LOCK_MODE_EVERYONE)
-      if (!g_passwordManager.IsMasterLockUnlocked(true))
-        return;
+    if (!g_passwordManager.CheckSettingLevelLock(SettingLevelExpert) &&
+        CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      return;
 
     // prompt user if they are sure
     if (CGUIDialogYesNo::ShowAndGetInput(12376, 750, 0, 12377))

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -229,9 +229,9 @@ void CGUIDialogVideoSettings::OnSettingChanged(SettingInfo &setting)
   }
   else if (setting.id == VIDEO_SETTINGS_MAKE_DEFAULT)
   {
-    if (CProfilesManager::Get().GetCurrentProfile().settingsLocked() && CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
-      if (!g_passwordManager.IsMasterLockUnlocked(true))
-        return;
+    if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+        !g_passwordManager.CheckSettingLevelLock(::SettingLevelExpert))
+      return;
 
     // prompt user if they are sure
     if (CGUIDialogYesNo::ShowAndGetInput(12376, 750, 0, 12377))

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -222,9 +222,9 @@ void CGUIDialogVideoSettings::OnSettingChanged(SettingInfo &setting)
   if (setting.id == VIDEO_SETTINGS_CALIBRATION)
   {
     // launch calibration window
-    if (CProfilesManager::Get().GetCurrentProfile().settingsLocked() && CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
-      if (!g_passwordManager.IsMasterLockUnlocked(true))
-        return;
+    if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
+        g_passwordManager.CheckSettingLevelLock(CSettings::Get().GetSetting("videoscreen.guicalibration")->GetLevel()))
+      return;
     g_windowManager.ActivateWindow(WINDOW_SCREEN_CALIBRATION);
   }
   else if (setting.id == VIDEO_SETTINGS_MAKE_DEFAULT)

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -193,9 +193,15 @@ void CViewStateSettings::SetSettingLevel(SettingLevel settingLevel)
 
 void CViewStateSettings::CycleSettingLevel()
 {
-  m_settingLevel = (SettingLevel)((int)m_settingLevel + 1);
-  if (m_settingLevel > SettingLevelExpert)
-    m_settingLevel = SettingLevelBasic;
+  m_settingLevel = GetNextSettingLevel();
+}
+
+SettingLevel CViewStateSettings::GetNextSettingLevel() const
+{
+  SettingLevel level = (SettingLevel)((int)m_settingLevel + 1);
+  if (level > SettingLevelExpert)
+    level = SettingLevelBasic;
+  return level;
 }
 
 void CViewStateSettings::AddViewState(const std::string& strTagName, int defaultView /* = DEFAULT_VIEW_LIST */, SORT_METHOD defaultSort /* = SORT_METHOD_LABEL */)

--- a/xbmc/view/ViewStateSettings.h
+++ b/xbmc/view/ViewStateSettings.h
@@ -45,6 +45,7 @@ public:
   SettingLevel GetSettingLevel() const { return m_settingLevel; }
   void SetSettingLevel(SettingLevel settingLevel);
   void CycleSettingLevel();
+  SettingLevel GetNextSettingLevel() const;
 
 protected:
   CViewStateSettings();


### PR DESCRIPTION
With this PR, you can limit a profiles access to the settings by setting a maximum setting level. (Full Access or No access are still possible).
