### PR TITLE
Improve recompile speed: Don't include git_rev.h/git_revision.h in system.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -706,6 +706,7 @@ lib/cmyth/Makefile
 /xbmc/visualizations/fishBMC/Makefile
 
 #/xbmc/win32/
+# no longer used
 /xbmc/win32/git_rev.h
 
 # /lib/ffmpeg/

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -510,6 +510,9 @@
 		DFB65FD315373AE7006B8FF1 /* AEUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FB115373AE7006B8FF1 /* AEUtil.cpp */; };
 		DFB65FD415373AE7006B8FF1 /* AEWAVLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FB315373AE7006B8FF1 /* AEWAVLoader.cpp */; };
 		DFB6610915374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB6610615374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp */; };
+		DFBB4319178B5E6F006CC20A /* GitRevision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFBB4317178B5E6F006CC20A /* GitRevision.cpp */; };
+		DFBB431A178B5E6F006CC20A /* GitRevision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFBB4317178B5E6F006CC20A /* GitRevision.cpp */; };
+		DFBB431B178B5E6F006CC20A /* GitRevision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFBB4317178B5E6F006CC20A /* GitRevision.cpp */; };
 		DFBB4308178B574E006CC20A /* AddonCallbacksCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFBB4306178B574E006CC20A /* AddonCallbacksCodec.cpp */; };
 		DFBB4309178B574E006CC20A /* AddonCallbacksCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFBB4306178B574E006CC20A /* AddonCallbacksCodec.cpp */; };
 		DFBB430A178B574E006CC20A /* AddonCallbacksCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFBB4306178B574E006CC20A /* AddonCallbacksCodec.cpp */; };
@@ -4190,6 +4193,8 @@
 		DFB65FB415373AE7006B8FF1 /* AEWAVLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEWAVLoader.h; sourceTree = "<group>"; };
 		DFB6610615374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDAudioCodecPassthrough.cpp; sourceTree = "<group>"; };
 		DFB6610715374E80006B8FF1 /* DVDAudioCodecPassthrough.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DVDAudioCodecPassthrough.h; sourceTree = "<group>"; };
+		DFBB4317178B5E6F006CC20A /* GitRevision.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GitRevision.cpp; sourceTree = "<group>"; };
+		DFBB4318178B5E6F006CC20A /* GitRevision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitRevision.h; sourceTree = "<group>"; };
 		DFBB4306178B574E006CC20A /* AddonCallbacksCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddonCallbacksCodec.cpp; sourceTree = "<group>"; };
 		DFBB4307178B574E006CC20A /* AddonCallbacksCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddonCallbacksCodec.h; sourceTree = "<group>"; };
 		DFBE803D15F7D72100D7D102 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -7165,6 +7170,8 @@
 				E38E168D0D25F9FA00618676 /* DynamicDll.h */,
 				E38E16920D25F9FA00618676 /* FileItem.cpp */,
 				E38E16930D25F9FA00618676 /* FileItem.h */,
+				DFBB4317178B5E6F006CC20A /* GitRevision.cpp */,
+				DFBB4318178B5E6F006CC20A /* GitRevision.h */,
 				E38E1E3E0D25F9FD00618676 /* GUIInfoManager.cpp */,
 				E38E1E3F0D25F9FD00618676 /* GUIInfoManager.h */,
 				E38E17EE0D25F9FA00618676 /* GUILargeTextureManager.cpp */,
@@ -10550,6 +10557,7 @@
 				DFE4095B17417FDF00473BD9 /* LegacyPathTranslation.cpp in Sources */,
 				0E3036EC1760F68A00D93596 /* FavouritesDirectory.cpp in Sources */,
 				551C3A45175A12010051AAAD /* VDA.cpp in Sources */,
+				DFBB431B178B5E6F006CC20A /* GitRevision.cpp in Sources */,
 				DF40BC20178B4BEC009DB567 /* PythonInvoker.cpp in Sources */,
 				DF40BC2F178B4C07009DB567 /* LanguageInvokerThread.cpp in Sources */,
 				DF40BC31178B4C07009DB567 /* ScriptInvocationManager.cpp in Sources */,
@@ -11572,6 +11580,7 @@
 				DF3C3C0F1752A7EE000989C3 /* IOSExternalTouchController.mm in Sources */,
 				DF3C3C101752A7EE000989C3 /* IOSScreenManager.mm in Sources */,
 				0E3036EE1760F68A00D93596 /* FavouritesDirectory.cpp in Sources */,
+				DFBB431A178B5E6F006CC20A /* GitRevision.cpp in Sources */,
 				DF40BC1F178B4BEC009DB567 /* PythonInvoker.cpp in Sources */,
 				DF40BC2C178B4C07009DB567 /* LanguageInvokerThread.cpp in Sources */,
 				DF40BC2E178B4C07009DB567 /* ScriptInvocationManager.cpp in Sources */,
@@ -12596,6 +12605,7 @@
 				E4991593174E707400741B6D /* cc_decoder.c in Sources */,
 				E4991596174E70BF00741B6D /* yuv2rgb.neon.S in Sources */,
 				0E3036ED1760F68A00D93596 /* FavouritesDirectory.cpp in Sources */,
+				DFBB4319178B5E6F006CC20A /* GitRevision.cpp in Sources */,
 				DF40BC1E178B4BEC009DB567 /* PythonInvoker.cpp in Sources */,
 				DF40BC29178B4C07009DB567 /* LanguageInvokerThread.cpp in Sources */,
 				DF40BC2B178B4C07009DB567 /* ScriptInvocationManager.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -585,6 +585,7 @@
     <ClCompile Include="..\..\xbmc\filesystem\ZipDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\ZipFile.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\ZipManager.cpp" />
+    <ClCompile Include="..\..\xbmc\GitRevision.cpp" />
     <ClCompile Include="..\..\xbmc\GUIInfoManager.cpp" />
     <ClCompile Include="..\..\xbmc\GUILargeTextureManager.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\AnimatedGif.cpp" />
@@ -1069,6 +1070,16 @@
     <ClInclude Include="..\..\xbmc\filesystem\VideoDatabaseDirectory\DirectoryNodeGrouped.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINFileSMB.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINSMBDirectory.h" />
+    <CustomBuild Include="..\..\xbmc\GitRevision.h">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL update_git_rev.bat</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">..\..\xbmc\win32\git_rev.h</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">..\..\.git\HEAD;..\..\xbmc\win32\git_rev.tmpl</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL update_git_rev.bat</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">..\..\xbmc\win32\git_rev.h</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">..\..\.git\HEAD;..\..\xbmc\win32\git_rev.tmpl</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">Retrieving the git revision</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">Retrieving the git revision</Message>
+    </CustomBuild>
     <ClInclude Include="..\..\xbmc\guilib\cximage.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIKeyboard.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIKeyboardFactory.h" />
@@ -2534,16 +2545,7 @@
     <ClInclude Include="..\..\xbmc\win32\PlatformDefs.h" />
     <ClInclude Include="..\..\xbmc\XBDateTime.h" />
     <ClInclude Include="..\..\xbmc\XbmcContext.h" />
-    <CustomBuild Include="..\..\xbmc\win32\PlatformInclude.h">
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL update_git_rev.bat</Command>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">..\..\xbmc\win32\git_rev.h</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">..\..\.git\HEAD;..\..\xbmc\win32\git_rev.tmpl</AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL update_git_rev.bat</Command>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">..\..\xbmc\win32\git_rev.h</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">..\..\.git\HEAD;..\..\xbmc\win32\git_rev.tmpl</AdditionalInputs>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">Retrieving the git revision</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">Retrieving the git revision</Message>
-    </CustomBuild>
+    <ClInclude Include="..\..\xbmc\win32\PlatformInclude.h" />
     <ClInclude Include="..\..\xbmc\win32\stat_utf8.h" />
     <ClInclude Include="..\..\xbmc\win32\stdio_utf8.h" />
     <ClInclude Include="..\..\xbmc\win32\WIN32Util.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3041,6 +3041,7 @@
     <ClCompile Include="..\..\xbmc\addons\AddonCallbacksCodec.cpp">
       <Filter>addons</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\GitRevision.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5964,6 +5965,7 @@
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksCodec.h">
       <Filter>addons</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\win32\PlatformInclude.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">
@@ -5971,9 +5973,6 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <CustomBuild Include="..\..\xbmc\win32\PlatformInclude.h">
-      <Filter>win32</Filter>
-    </CustomBuild>
     <CustomBuild Include="..\..\xbmc\interfaces\swig\AddonModuleXbmcplugin.i">
       <Filter>interfaces\swig</Filter>
     </CustomBuild>
@@ -5989,6 +5988,7 @@
     <CustomBuild Include="..\..\xbmc\interfaces\swig\AddonModuleXbmc.i">
       <Filter>interfaces\swig</Filter>
     </CustomBuild>
+    <CustomBuild Include="..\..\xbmc\GitRevision.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\xbmc\interfaces\swig\ControlListAddItemMethods.i">

--- a/project/VS2010Express/update_git_rev.bat
+++ b/project/VS2010Express/update_git_rev.bat
@@ -1,24 +1,11 @@
 @echo off
 
-SET TEMPLATE=..\..\xbmc\win32\git_rev.tmpl
-SET TEMP=..\..\xbmc\win32\git_rev.tmp
-SET REV_FILE=..\..\xbmc\win32\git_rev.h
-IF EXIST "%TEMP%" (
-  del "%TEMP%" > nul
-)
+SET REV_FILE=..\..\git_revision.h
 
 CALL ..\Win32BuildSetup\extract_git_rev.bat
 
-copy "%TEMPLATE%" "%TEMP%" > nul
-
-echo #define GIT_REV "%GIT_REV%" >> "%TEMP%"
-
-fc /B "%TEMP%" "%REV_FILE%" > nul
-IF ERRORLEVEL 1 (
-  IF EXIST "%REV_FILE%" (
-    del "%REV_FILE%" > nul
-  )
-  COPY "%TEMP%" "%REV_FILE%" > nul
+IF NOT [%GIT_REV%]==[] (
+  echo #define GIT_REV "%GIT_REV%" > "%REV_FILE%"
+) ELSE (
+  echo. > "%REV_FILE%"
 )
-
-DEL %TEMP%

--- a/project/Win32BuildSetup/extract_git_rev.bat
+++ b/project/Win32BuildSetup/extract_git_rev.bat
@@ -2,7 +2,7 @@
 
 REM Batch file output: %GIT_REV% variable, containing the git revision
 
-SET GIT_REV=unknown
+SET GIT_REV=
 
 
 REM Try wrapped msysgit - must be in the path

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -20,6 +20,7 @@
 
 #include "network/Network.h"
 #include "system.h"
+#include "GitRevision.h"
 #include "GUIInfoManager.h"
 #include "windows/GUIMediaWindow.h"
 #include "dialogs/GUIDialogProgress.h"
@@ -4021,11 +4022,10 @@ CTemperature CGUIInfoManager::GetGPUTemperature()
 CStdString CGUIInfoManager::GetVersion()
 {
   CStdString tmp;
-#ifdef GIT_REV
-  tmp.Format("%d.%d%s Git:%s", VERSION_MAJOR, VERSION_MINOR, VERSION_TAG, GIT_REV);
-#else
-  tmp.Format("%d.%d%s", VERSION_MAJOR, VERSION_MINOR, VERSION_TAG);
-#endif
+  if (GetXbmcGitRevision())
+    tmp.Format("%d.%d%s Git:%s", VERSION_MAJOR, VERSION_MINOR, VERSION_TAG, GetXbmcGitRevision());
+  else
+    tmp.Format("%d.%d%s", VERSION_MAJOR, VERSION_MINOR, VERSION_TAG);
   return tmp;
 }
 

--- a/xbmc/GitRevision.cpp
+++ b/xbmc/GitRevision.cpp
@@ -20,7 +20,7 @@
 
 #include "GitRevision.h"
 
-#if defined(TARGET_DARWIN) || (defined(TARGET_WINDOWS) && !defined(_DEBUG) && !defined(_LIB))
+#if defined(TARGET_DARWIN) || (defined(TARGET_WINDOWS) && !defined(_DEBUG))
 #include "../git_revision.h" // generated file
 #endif
 

--- a/xbmc/GitRevision.cpp
+++ b/xbmc/GitRevision.cpp
@@ -1,8 +1,5 @@
-#ifndef __PLATFORM_INCLUDE__H__
-#define __PLATFORM_INCLUDE__H__
-
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2011-2013 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -21,8 +18,17 @@
  *
  */
 
-#include <errno.h> // for ENOENT and EINVAL
-#include "PlatformDefs.h"
+#include "GitRevision.h"
 
+#if defined(TARGET_DARWIN) || (defined(TARGET_WINDOWS) && !defined(_DEBUG) && !defined(_LIB))
+#include "../git_revision.h" // generated file
 #endif
 
+const char *GetXbmcGitRevision()
+{
+#ifdef GIT_REV
+  return GIT_REV;
+#else
+  return NULL;
+#endif
+}

--- a/xbmc/GitRevision.h
+++ b/xbmc/GitRevision.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  *      Copyright (C) 2011-2013 Team XBMC
  *      http://www.xbmc.org
@@ -18,7 +20,5 @@
  *
  */
 
-#pragma once
-
-#undef GIT_REV
-
+// Returns the current Git revision, or NULL if unavailable.
+const char *GetXbmcGitRevision();

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -9,6 +9,7 @@ SRCS=Application.cpp \
      DbUrl.cpp \
      DynamicDll.cpp \
      FileItem.cpp \
+     GitRevision.cpp \
      GUIInfoManager.cpp \
      GUILargeTextureManager.cpp \
      GUIPassword.cpp \

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 #include "GUIInfoManager.h"
 #include "system.h"
+#include "GitRevision.h"
 
 using namespace JSONRPC;
 
@@ -119,9 +120,8 @@ JSONRPC_STATUS CApplicationOperations::GetPropertyValue(const CStdString &proper
     result = CVariant(CVariant::VariantTypeObject);
     result["major"] = VERSION_MAJOR;
     result["minor"] = VERSION_MINOR;
-#ifdef GIT_REV
-    result["revision"] = GIT_REV;
-#endif
+    if (GetXbmcGitRevision())
+      result["revision"] = GetXbmcGitRevision();
     CStdString tag(VERSION_TAG);
     if (tag.ToLower().Equals("-pre"))
       result["tag"] = "alpha";

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -198,18 +198,6 @@
 #define HAS_FILESYSTEM_SFTP
 #endif
 
-/*****************
- * Git revision
- *****************/
-
-#if defined(TARGET_DARWIN)
-#include "../git_revision.h"
-#endif
-
-#ifndef GIT_REV
-#define GIT_REV "Unknown"
-#endif
-
 /****************************************
  * Additional platform specific includes
  ****************************************/


### PR DESCRIPTION
Tested on Windows/Core i7/SSD (to qualify system specs, `make -j8` from scratch on linux x64 takes between 6 and 6.5 minutes):

Before the patch, updating git_rev.h and recompiling (on windows) averages about 16 minutes. With this patch, updating git_rev.h and recompiling averages about 1 minute, 10 seconds, a big improvement.

Needs some Xcode loving, but it's only a new header so it should compile fine until then.
