### PR TITLE
Fix IsAudio|IsVideo|IsPicture() incorrectly returning false when the MIME type...

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3628,6 +3628,10 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
 
 PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
 {
+  // Ensure the MIME type has been retrieved for http:// and shout:// streams
+  if (item.GetMimeType().empty())
+    const_cast<CFileItem&>(item).FillInMimeType();
+
   if (!bRestart)
   {
     SaveCurrentFileSettings();

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -360,11 +360,18 @@ public:
 
   virtual bool LoadMusicTag();
 
-  /* returns the content type of this item if known. will lookup for http streams */
-  const CStdString& GetMimeType(bool lookup = true) const;
+  /* Returns the content type of this item if known */
+  const CStdString& GetMimeType() const { return m_mimetype; }
 
   /* sets the mime-type if known beforehand */
   void SetMimeType(const CStdString& mimetype) { m_mimetype = mimetype; } ;
+
+  /*! \brief Resolve the MIME type based on file extension or a web lookup
+   If m_mimetype is already set (non-empty), this function has no effect. For
+   http:// and shout:// streams, this will query the stream (blocking operation).
+   Set lookup=false to skip any internet lookups and always return immediately.
+   */
+  void FillInMimeType(bool lookup = true);
 
   /* general extra info about the contents of the item, not for display */
   void SetExtraInfo(const CStdString& info) { m_extrainfo = info; };

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -173,6 +173,7 @@ CBaseTexture *CTextureCacheJob::LoadImage(const CStdString &image, unsigned int 
 
   // Validate file URL to see if it is an image
   CFileItem file(image, false);
+  file.FillInMimeType();
   if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ() ))
       && !file.GetMimeType().Left(6).Equals("image/") && !file.GetMimeType().Equals("application/octet-stream")) // ignore non-pictures
     return NULL;

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -160,7 +160,7 @@ bool CPluginDirectory::GetPluginResult(const CStdString& strPath, CFileItem &res
     if (!resultItem.HasProperty("original_listitem_url"))
       resultItem.SetProperty("original_listitem_url", resultItem.GetPath());
     resultItem.SetPath(newDir->m_fileResult->GetPath());
-    resultItem.SetMimeType(newDir->m_fileResult->GetMimeType(false));
+    resultItem.SetMimeType(newDir->m_fileResult->GetMimeType());
     resultItem.UpdateInfo(*newDir->m_fileResult);
     if (newDir->m_fileResult->HasVideoInfoTag() && newDir->m_fileResult->GetVideoInfoTag()->m_resumePoint.IsSet())
       resultItem.m_lStartOffset = STARTOFFSET_RESUME; // resume point set in the resume item, so force resume

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -298,6 +298,7 @@ bool CGUIMultiImage::CMultiImageJob::DoWork()
 {
   // check to see if we have a single image or a folder of images
   CFileItem item(m_path, false);
+  item.FillInMimeType();
   if (item.IsPicture() || item.GetMimeType().Left(6).Equals("image/"))
   {
     m_files.push_back(m_path);

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -815,7 +815,7 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
 
   // store original path so we remember it
   item.SetProperty("original_listitem_url",  item.GetPath());
-  item.SetProperty("original_listitem_mime", item.GetMimeType(false));
+  item.SetProperty("original_listitem_mime", item.GetMimeType());
 
   // look for a resource with "xbmc-get" protocol
   // if we can't find one, try to find a valid resource

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -294,7 +294,7 @@ void CGUIWindowSlideShow::Add(const CFileItem *picture)
   if (!item->HasVideoInfoTag() && !item->HasPictureInfoTag())
   {
     // item without tag; get mimetype then we can tell whether it's video item
-    item->GetMimeType();
+    item->FillInMimeType();
 
     if (!item->IsVideo())
       // then it is a picture and force tag generation

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -39,6 +39,10 @@ CPlayList* CPlayListFactory::Create(const CFileItem& item)
 {
   if( item.IsInternetStream() )
   {
+    // Ensure the MIME type has been retrieved for http:// and shout:// streams
+    if (item.GetMimeType().empty())
+      const_cast<CFileItem&>(item).FillInMimeType();
+
     CStdString strMimeType = item.GetMimeType();
     strMimeType.MakeLower();
 


### PR DESCRIPTION
...helps determine the media type

This also fixes the following inconsistency:

``` c++
item.IsVideo(); // returns false

CStdString mime = item.GetMimeType();

item.IsVideo(); // returns true

```
