### PR TITLE
[win32] make BuildSetup.bat et. al. more robust for jenkins builds

### DIFF
--- a/lib/asap/win32/build_xbmc_win32.sh
+++ b/lib/asap/win32/build_xbmc_win32.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MAKEFLAGS=""
+BGPROCESSFILE="$2"
 
 if [ "$1" == "clean" ]
 then
@@ -13,3 +14,5 @@ fi
 make $MAKEFLAGS xbmc
 
 cp xbmc_asap.dll /xbmc/system/players/paplayer/
+#remove the bgprocessfile for signaling the process end
+rm $BGPROCESSFILE

--- a/lib/ffmpeg/build_xbmc_win32.sh
+++ b/lib/ffmpeg/build_xbmc_win32.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MAKEFLAGS=""
+BGPROCESSFILE="$2"
 
 if [ "$1" == "clean" ]
 then
@@ -60,3 +61,6 @@ cp .libs/avfilter-3.dll /xbmc/system/players/dvdplayer/ &&
 cp .libs/postproc-52.dll /xbmc/system/players/dvdplayer/ &&
 cp .libs/swresample-0.dll /xbmc/system/players/dvdplayer/ &&
 cp .libs/swscale-2.dll /xbmc/system/players/dvdplayer/
+
+#remove the bgprocessfile for signaling the process end
+rm $BGPROCESSFILE

--- a/lib/libdvd/build-xbmc-win32.sh
+++ b/lib/libdvd/build-xbmc-win32.sh
@@ -2,6 +2,7 @@
 
 MAKECLEAN=0
 MAKEFLAGS=""
+BGPROCESSFILE=$2
 
 if [ "$1" = "clean" ]
 then
@@ -80,3 +81,5 @@ strip -S obj/libdvdnav.dll
 cd ..
 cp libdvdnav/obj/libdvdnav.dll /xbmc/system/players/dvdplayer/
 echo "***** Done *****"
+#remove the bgprocessfile for signaling the process end
+rm $BGPROCESSFILE

--- a/lib/libmpeg2/make-xbmc-lib-win32.sh
+++ b/lib/libmpeg2/make-xbmc-lib-win32.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MAKEFLAGS=""
+BGPROCESSFILE="$2"
 
 if [ "$1" == "clean" ]
 then
@@ -27,3 +28,6 @@ make $MAKEFLAGS &&
 
 strip libmpeg2/.libs/*.dll &&
 cp libmpeg2/.libs/*.dll /xbmc/system/players/dvdplayer/
+
+#remove the bgprocessfile for signaling the process end
+rm $BGPROCESSFILE

--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
 rem ----Usage----
 rem BuildSetup [gl|dx] [clean|noclean]
 rem vs2010 for compiling with visual studio 2010
@@ -41,12 +42,29 @@ SET buildconfig=Release (DirectX)
 IF %target%==gl SET buildconfig=Release (OpenGL)
 
 IF %comp%==vs2010 (
-  IF "%VS100COMNTOOLS%"=="" (
-		set NET="%ProgramFiles%\Microsoft Visual Studio 10.0\Common7\IDE\VCExpress.exe"
-	) ELSE IF EXIST "%VS100COMNTOOLS%\..\IDE\VCExpress.exe" (
-		set NET="%VS100COMNTOOLS%\..\IDE\VCExpress.exe"
-	) ELSE IF EXIST "%VS100COMNTOOLS%\..\IDE\devenv.exe" (
-		set NET="%VS100COMNTOOLS%\..\IDE\devenv.exe"
+	REM look for MSBuild.exe in .NET Framework 4.x
+	FOR /F "tokens=3* delims=	" %%A IN ('REG QUERY HKLM\SOFTWARE\Microsoft\MSBuild\ToolsVersions\4.0 /v MSBuildToolsPath') DO SET NET=%%AMSBuild.exe
+	IF NOT EXIST "!NET!" (
+		FOR /F "tokens=3* delims= " %%A IN ('REG QUERY HKLM\SOFTWARE\Microsoft\MSBuild\ToolsVersions\4.0 /v MSBuildToolsPath') DO SET NET=%%AMSBuild.exe
+	)
+
+	IF EXIST "!NET!" (
+		set msbuildemitsolution=1
+		set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Build /p:Configuration="%buildconfig%"
+		set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Clean /p:Configuration="%buildconfig%"
+	) ELSE (
+		IF EXIST "%VS100COMNTOOLS%\..\IDE\devenv.com" (
+			set NET="%VS100COMNTOOLS%\..\IDE\devenv.com"
+		) ELSE IF EXIST "%VS100COMNTOOLS%\..\IDE\devenv.exe" (
+			set NET="%VS100COMNTOOLS%\..\IDE\devenv.exe"
+		) ELSE IF "%VS100COMNTOOLS%"=="" (
+			set NET="%ProgramFiles%\Microsoft Visual Studio 10.0\Common7\IDE\VCExpress.exe"
+		) ELSE IF EXIST "%VS100COMNTOOLS%\..\IDE\VCExpress.exe" (
+			set NET="%VS100COMNTOOLS%\..\IDE\VCExpress.exe"
+		)
+
+		set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /build "%buildconfig%"
+		set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /clean "%buildconfig%"
 	)
 )
 
@@ -55,8 +73,6 @@ IF %comp%==vs2010 (
 	 goto DIE
   )
   
-  set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /build "%buildconfig%"
-  set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /clean "%buildconfig%"
   set EXE= "..\VS2010Express\XBMC\%buildconfig%\XBMC.exe"
   set PDB= "..\VS2010Express\XBMC\%buildconfig%\XBMC.pdb"
   

--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -35,7 +35,7 @@ FOR %%b in (%1, %2, %3, %4, %5) DO (
 	IF %%b==noclean SET buildmode=noclean
 	IF %%b==noprompt SET promptlevel=noprompt
 	IF %%b==nomingwlibs SET buildmingwlibs=false
-    IF %%b==sh SET useshell=sh
+	IF %%b==sh SET useshell=sh
 )
 
 SET buildconfig=Release (DirectX)

--- a/project/Win32BuildSetup/buildmingwlibs.sh
+++ b/project/Win32BuildSetup/buildmingwlibs.sh
@@ -2,6 +2,7 @@
 ERRORFILE=/xbmc/project/Win32BuildSetup/errormingw
 NOPFILE=/xbmc/project/Win32BuildSetup/noprompt
 MAKECLEANFILE=/xbmc/project/Win32BuildSetup/makeclean
+BGPROCESSFILE=/xbmc/project/Win32BuildSetup/bgprocess
 TOUCH=/bin/touch
 RM=/bin/rm
 NOPROMPT=0
@@ -33,6 +34,20 @@ function checkfiles ()
   done
 }
 
+function runBackgroundProcess ()
+{
+  #start the process backgrounded
+  $TOUCH $BGPROCESSFILE
+  echo "backgrounding: sh $1 $BGPROCESSFILE & (workdir: $(PWD))"
+  sh $1 $BGPROCESSFILE &
+  echo "waiting on bgprocess..."
+  while [ -f $BGPROCESSFILE ]; do
+    echo -n "."
+    sleep 5
+  done
+  echo "done"
+}
+
 # cleanup
 if [ -f $ERRORFILE ]; then
   $RM $ERRORFILE
@@ -47,6 +62,8 @@ fi
 if [ -f $MAKECLEANFILE ]; then
   $RM $MAKECLEANFILE
   MAKECLEAN="clean"
+else
+  MAKECLEAN="noclean"
 fi
 
 if [ $NUMBER_OF_PROCESSORS > 1 ]; then
@@ -62,21 +79,21 @@ echo "################################"
 
 echo "##### building ffmpeg dlls #####"
 cd /xbmc/lib/ffmpeg/
-sh ./build_xbmc_win32.sh $MAKECLEAN
+runBackgroundProcess "./build_xbmc_win32.sh $MAKECLEAN"
 setfilepath /xbmc/system/players/dvdplayer
 checkfiles avcodec-54.dll avformat-54.dll avutil-52.dll postproc-52.dll swscale-2.dll avfilter-3.dll swresample-0.dll
 echo "##### building of ffmpeg dlls done #####"
 
 echo "##### building libdvd dlls #####"
 cd /xbmc/lib/libdvd/
-sh ./build-xbmc-win32.sh $MAKECLEAN
+runBackgroundProcess "./build-xbmc-win32.sh $MAKECLEAN"
 setfilepath /xbmc/system/players/dvdplayer
 checkfiles libdvdcss-2.dll libdvdnav.dll
 echo "##### building of libdvd dlls done #####"
 
 echo "##### building libmpeg2 dlls #####"
 cd /xbmc/lib/libmpeg2/
-sh ./make-xbmc-lib-win32.sh $MAKECLEAN
+runBackgroundProcess "./make-xbmc-lib-win32.sh $MAKECLEAN"
 setfilepath /xbmc/system/players/dvdplayer
 checkfiles libmpeg2-0.dll
 echo "##### building of libmpeg2 dlls done #####"
@@ -93,7 +110,7 @@ echo "##### building of timidity dlls done #####"
 
 echo "##### building asap dlls #####"
 cd /xbmc/lib/asap/win32
-sh ./build_xbmc_win32.sh $MAKECLEAN
+runBackgroundProcess "./build_xbmc_win32.sh $MAKECLEAN"
 setfilepath /xbmc/system/players/paplayer
 checkfiles xbmc_asap.dll
 echo "##### building of asap dlls done #####"

--- a/project/Win32BuildSetup/buildpvraddons.bat
+++ b/project/Win32BuildSetup/buildpvraddons.bat
@@ -15,7 +15,12 @@ SET GIT_URL=git://github.com/opdenkamp/%LIBNAME%.git
 SET SOURCE_DIR=%TMP_DIR%\%SOURCE%
 SET BUILT_ADDONS_DIR=%SOURCE_DIR%\addons
 
-set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /build Release
+REM check if MSBuild.exe is used because it requires different command line switches
+IF "%msbuildemitsolution%" == "1" (
+  set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /t:Build /p:Configuration="Release"
+) ELSE (
+  set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /build Release
+)
 
 REM Try wrapped msysgit - must be in the path
 SET GITEXE=git.cmd


### PR DESCRIPTION
Jenkins seems to have problems with keeping a connection between the master and a slave open if there are longer periods without any console output.

These commits adjust BuildSetup.bat etc for win32 to provide more output by using MSBuild.exe (or devenv.com instead of devenv.exe) if possible and by running the ffmpeg configure, which doesn't produce any output on the console in the background and constantly writing dots to the screen until the ffmpeg build scripts are ready to provide some output of their own.

The former change is nice to have anyway IMO because it makes it possible to actually follow the build progress. The latter is a workaround (thanks to @Memphiz) which seems to work well enough but could do with something better (if possible). But as long as it fixes the problem at hand and gives us a working build slave again, IMO we don't have much choice.
