### PR TITLE
[DVDDemux] Allow for larger difference in dts and pts of packet

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -642,7 +642,8 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
 
   if(timestamp > starttime)
     timestamp -= starttime;
-  else if( timestamp + 0.1f > starttime )
+  // allow for largest possible difference in pts and dts for a single packet
+  else if( timestamp + 0.5f > starttime )
     timestamp = 0;
 
   return timestamp*DVD_TIME_BASE;


### PR DESCRIPTION
If video does not start on an I frame, you can get a significant difference
in pts and dts values for the first frame. I've got two videos where they
differ by more than 0.1s.

In this case, we end up setting pts=0 and leaving dts alone (which may be minutes away).
This gets through to GPU on Pi, and it tends to stall waiting for this difference to elapse.

I'm not sure what the largest difference can be, but 0.5s feels completely safe.
I'm not sure of any problems increasing this will cause.
