### PR TITLE
Allow JSON-RPC to accept more content types 

### DIFF
--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -43,8 +43,10 @@ int CHTTPJsonRpcHandler::HandleHTTPRequest(const HTTPRequest &request)
   if (request.method == POST)
   {
     string contentType = CWebServer::GetRequestHeaderValue(request.connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_CONTENT_TYPE);
-    // If the content-type of the request was specified, it must be application/json
-    if (!contentType.empty() && contentType.compare("application/json") != 0)
+    // If the content-type of the request was specified, it must be application/json-rpc, application/json, or application/jsonrequest
+    // http://www.jsonrpc.org/historical/json-rpc-over-http.html
+    if (!contentType.empty() && contentType.compare("application/json-rpc") != 0 &&
+        contentType.compare("application/json") != 0 && contentType.compare("application/jsonrequest") != 0)
     {
       m_responseType = HTTPError;
       m_responseCode = MHD_HTTP_UNSUPPORTED_MEDIA_TYPE;


### PR DESCRIPTION
According to the RFC for JSON-RPC over HTTP at
http://www.jsonrpc.org/historical/json-rpc-over-http.html
"Content-Type SHOULD be 'application/json-rpc' but MAY be
'application/json' or 'application/jsonrequest'"

This patch fixes HTTPJsonRpcHandler to allow for any of those three
content types when accepting JSON-RPC HTTP requests.

This also fixes compatibility with the popular Python library jsonrpclib
which uses the application/json-rpc content type.
