### PR TITLE
configure, external ffmpeg: do not check if libavcodec contains vdpau fu...

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1646,15 +1646,6 @@ if test "$use_external_ffmpeg" = "yes"; then
   USE_EXTERNAL_FFMPEG=1
   AC_DEFINE([USE_EXTERNAL_FFMPEG], [1], [Whether to use external FFmpeg libraries.])
 
-  # Disable vdpau support if external libavcodec doesn't have it
-  AC_CHECK_LIB([avcodec], [ff_vdpau_vc1_decode_picture],,
-    [if test "x$use_vdpau" = "xyes"; then
-      AC_MSG_ERROR($ffmpeg_vdpau_not_supported)
-    else
-      use_vdpau=no
-      AC_MSG_RESULT($ffmpeg_vdpau_not_supported)
-    fi])
-
   CPPFLAGS="$SAVE_CPPFLAGS"
 else
   AC_MSG_NOTICE($external_ffmpeg_disabled)


### PR DESCRIPTION
...nctions.

it will fall back to other methods if not present and we have no guarantee that the libavcodec version we build against will be the same we run with (except it has the same ABI but ff_vdpau symbols are not part of the ABI).
