### PR TITLE
[codegenerator] python: add support for class variables

### DIFF
--- a/tools/codegenerator/Helper.groovy
+++ b/tools/codegenerator/Helper.groovy
@@ -85,7 +85,7 @@ public class Helper
     Node doc = null
     def ret = ''
 
-    // make the class name or namespave
+    // make the class name or namespace
     String doxygenId = findFullClassName(methodOrClass,'_1_1')
     boolean isInClass = doxygenId != null
     if (!doxygenId)

--- a/tools/codegenerator/Helper.groovy
+++ b/tools/codegenerator/Helper.groovy
@@ -107,7 +107,7 @@ public class Helper
     {
       Node memberdef = docspec.depthFirst().find { 
         return (it instanceof String) ? false :
-          ((it.name() == 'memberdef' && it.@kind == 'function' && it.@id.startsWith(doxygenId)) &&
+          ((it.name() == 'memberdef' && (it.@kind == 'function' || it.@kind == 'variable') && it.@id.startsWith(doxygenId)) &&
            (it.name != null && it.name.text().trim() == methodOrClass.@sym_name))
       }
 
@@ -479,6 +479,19 @@ public class Helper
       List allMethods = ret.depthFirst().findAll({ it.name() == 'function' || it.name() == 'destructor' || it.name() == 'constructor'})
       allMethods.each {
          if (it.@access != null && it.@access != 'public' && it.name() != 'constructor')
+            it.parent().remove(it)
+         else
+         {
+           def doc = retrieveDocStringFromDoxygen(it)
+           if (doc != null && doc != '' && doc.trim() != ' ')
+             new Node(it,'doc',['value' : doc])
+         }
+      }
+      
+      // now remove all non-public variables
+      List allVariables = ret.depthFirst().findAll({ it.name() == 'variable' })
+      allVariables.each {
+         if (it.@access != null && it.@access != 'public')
             it.parent().remove(it)
          else
          {

--- a/xbmc/interfaces/legacy/Keyboard.h
+++ b/xbmc/interfaces/legacy/Keyboard.h
@@ -55,11 +55,13 @@ namespace XBMCAddon
     class Keyboard : public AddonClass
     {
     public:
+#ifndef SWIG
       String strDefault;
       String strHeading;
       bool bHidden;
       String strText;
       bool bConfirmed;
+#endif
 
       Keyboard(const String& line = emptyString, const String& heading = emptyString, bool hidden = false);
       virtual ~Keyboard();

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -47,7 +47,9 @@ namespace XBMCAddon
     class ListItem : public AddonClass
     {
     public:
+#ifndef SWIG
       CFileItemPtr item;
+#endif
 
       ListItem(const String& label = emptyString, 
                const String& label2 = emptyString,

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -314,6 +314,8 @@ void doClassMethodInfo(Node clazz, List initTypeCalls = null)
 
   List normalMethods = clazz.function.findAll { !it.@name.startsWith("operator ") }
   List operators =  clazz.function.findAll { it.@name.startsWith("operator ") }
+  List properties = clazz.variable.findAll { it.@access != null && it.@access == "public" }
+  List properties_set = properties.findAll { it.@feature_immutable == null || it.@feature_immutable == 0 }
 
   operators.each {
     // we have an operator. The only one we can handle is ==
@@ -404,6 +406,119 @@ void doClassMethodInfo(Node clazz, List initTypeCalls = null)
     {NULL, NULL, 0, NULL}
   };
 
+<%
+  if (properties.size() > 0) {
+%>  static PyObject* ${classNameAsVariable}_getMember(PyHolder *self, void *name)
+  {
+    if (self == NULL)
+      return NULL;
+<%
+    String clazzName = Helper.findFullClassName(properties[0])
+%>
+    try
+    {
+      ${clazzName}* theObj = (${clazzName}*)retrieveApiInstance((PyObject*)self, &Py${classNameAsVariable}_Type, "${classNameAsVariable}_getMember()", "${clazzName}");
+
+      PyObject* result = NULL;
+   <%
+  properties.each {
+%>   if (strcmp((char*)name, "${it.@sym_name}") == 0)
+      {
+        ${SwigTypeParser.SwigType_lstr(it.@type)} apiResult = (${SwigTypeParser.SwigType_lstr(it.@type)})theObj->${it.@sym_name};
+        ${Helper.getOutConversion(it.@type, 'result', it)}
+      }
+      else<%
+  } %>
+      {
+        Py_INCREF(Py_None);
+        return Py_None;
+      }
+
+      return result;
+    }
+    catch (const XBMCAddon::WrongTypeException& e)
+    {
+      CLog::Log(LOGERROR,"EXCEPTION: %s",e.GetMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetMessage());
+      return NULL;
+    }
+    catch (const XbmcCommons::Exception& e)
+    {
+      CLog::Log(LOGERROR,"EXCEPTION: %s",e.GetMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetMessage());
+      return NULL;
+    }
+    catch (...)
+    {
+      CLog::Log(LOGERROR,"EXCEPTION: Unknown exception thrown from the call \"${classNameAsVariable}_getMember()\"");
+      PyErr_SetString(PyExc_RuntimeError, "Unknown exception thrown from the call \"${classNameAsVariable}_getMember()\"");
+      return NULL;
+    }
+
+    return NULL;
+  }
+
+<%
+    if (properties_set.size() > 0) {
+%>  int ${classNameAsVariable}_setMember(PyHolder *self, PyObject *value, void *name)
+  {
+    if (self == NULL)
+      return -1;
+
+    ${clazzName}* theObj = NULL;
+    try
+    {
+      theObj = (${clazzName}*)retrieveApiInstance((PyObject*)self, &Py${classNameAsVariable}_Type, "${classNameAsVariable}_getMember()", "${clazzName}");
+    }
+    catch (const XBMCAddon::WrongTypeException& e)
+    {
+      CLog::Log(LOGERROR,"EXCEPTION: %s",e.GetMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetMessage());
+      return NULL;
+    }
+    catch (const XbmcCommons::Exception& e)
+    {
+      CLog::Log(LOGERROR,"EXCEPTION: %s",e.GetMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetMessage());
+      return NULL;
+    }
+    catch (...)
+    {
+      CLog::Log(LOGERROR,"EXCEPTION: Unknown exception thrown from the call \"${classNameAsVariable}_getMember()\"");
+      PyErr_SetString(PyExc_RuntimeError, "Unknown exception thrown from the call \"${classNameAsVariable}_getMember()\"");
+      return NULL;
+    }
+
+<%
+  properties_set.each {
+%>   if (strcmp((char*)name, "${it.@sym_name}") == 0)
+      {
+        ${SwigTypeParser.SwigType_lstr(it.@type)} tmp;
+        ${Helper.getInConversion(it.@type, 'tmp', 'value', it)}
+        if (PyErr_Occurred())
+          throw PythonBindings::PythonToCppException();
+        
+        theObj->${it.@sym_name} = tmp;
+      }
+      else<%
+  } %>
+        return -1;
+
+    return 0;
+  } <%
+    }
+%>
+
+  // All of the methods on this class
+  static PyGetSetDef ${classNameAsVariable}_getsets[] = { <%
+    properties.each {  %>
+    {(char*)"${it.@sym_name}", (getter)${classNameAsVariable}_getMember, ${(it.@feature_immutable == null || it.@feature_immutable == 0) ? '(setter)' + classNameAsVariable + '_setMember' : 'NULL'}, (char*)${Helper.hasDoc(it) ? PythonTools.makeDocString(it.doc[0]) : 'NULL'}, (char*)"${it.@sym_name}" }, <% }
+%>
+    {NULL}
+  };
+<%
+  } %>
+
   // This method initializes the above mentioned Python Type structure
   static void ${initTypeCall}()
   {
@@ -429,11 +544,13 @@ void doClassMethodInfo(Node clazz, List initTypeCalls = null)
 
     Py${classNameAsVariable}_Type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     Py${classNameAsVariable}_Type.tp_doc = ${Helper.hasDoc(clazz) ? (classNameAsVariable + '__doc__') : 'NULL' };
-    Py${classNameAsVariable}_Type.tp_methods = ${classNameAsVariable}_methods;
+    Py${classNameAsVariable}_Type.tp_methods = ${classNameAsVariable}_methods; <%
+ if (properties.size() > 0) { %>
+    Py${classNameAsVariable}_Type.tp_getset = ${classNameAsVariable}_getsets;
 <%
-    if (doAsMapping)
-    {
-%>    Py${classNameAsVariable}_Type.tp_as_mapping = &${module.@name}_${classNameAsVariable}_as_mapping;
+ }
+ if (doAsMapping) { %>
+    Py${classNameAsVariable}_Type.tp_as_mapping = &${module.@name}_${classNameAsVariable}_as_mapping;
 <%  }
     Node baseclass = PythonTools.findValidBaseClass(clazz, module)
 

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -82,7 +82,13 @@ Helper.setup(this,classes,
       (Pattern.compile('''(r.){0,1}XbmcCommons::Buffer''')) : new File('typemaps/python.buffer.intm'),
       (Pattern.compile('''(p.){0,1}std::map<\\(.*\\)>''')) : new File('typemaps/python.map.intm'),
       'bool' : '${api} = (PyInt_AsLong(${slarg}) == 0L ? false : true);',
-      'long' : '${api} = PyInt_AsLong(${slarg});'
+      'long' : '${api} = PyInt_AsLong(${slarg});',
+      'unsigned long' : '${api} = PyLong_AsUnsignedLong(${slarg});',
+      'long long' : '${api} = PyLong_AsLongLong(${slarg});',
+      'unsigned long long' : '${api} = PyLong_AsUnsignedLongLong(${slarg});',
+      'int' : '${api} = (int)PyInt_AsLong(${slarg});',
+      'double' : '${api} = PyFloat_AsDouble(${slarg});',
+      'float' : '${api} = (float)PyFloat_AsDouble(${slarg});'
     ], '${api} = (${swigTypeParser.SwigType_str(ltype)})retrieveApiInstance(${slarg},"${ltype}","${helper.findNamespace(method)}","${helper.callingName(method)}");')
 
 //println 'this: ' + this.binding.getVariables()


### PR DESCRIPTION
Call me crazy but I thought I'd look a bit into our codegenerator to get to know it a bit better.

I already noticed last year that the current python code/binding generator does not support class variables even though the python C API supports it through tp_getset. So I adjusted the swig template used to generate the python code/bindings to handle public class variables. There are read-write and read-only class variables where read-only class variables are defined using "const" in the C++ class definition.

Currently we don't use class variables anywhere (well we do but they aren't meant to be exposed to python so I had to hide them from swig) but I wrote a very simple example at 7d7ac06df55306a185f6df70adec282163eb7c87 so you can see how it would work. With that change to the InfoTagVideo class and this PR it is possible to e.g. execute the following script (yes my python skills suck)

``` python
import xbmc

video = xbmc.InfoTagVideo()
print 'video.testInt = ' + str(video.testInt)
print 'video.testFloat = ' + str(video.testFloat)
print 'video.testDouble = ' + str(video.testDouble)
print 'video.testString = ' + video.testString
print 'video.pi = ' + str(video.pi)
video.testInt = 1
video.testFloat = 1.1
video.testDouble = 1.2
video.testString = 'goodbye world'
print 'video.testInt = ' + str(video.testInt)
print 'video.testFloat = ' + str(video.testFloat)
print 'video.testDouble = ' + str(video.testDouble)
print 'video.testString = ' + video.testString
video.pi = 200
```

which will result in the following output when executed

```
video.testInt = 42
video.testFloat = 42.0999984741
video.testDouble = 42.2000007629
video.testString = hello world
video.pi = 3.142
video.testInt = 1
video.testFloat = 1.10000002384
video.testDouble = 1.2
video.testString = goodbye world

EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
 - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
Error Type: <type 'exceptions.AttributeError'>
Error Contents: attribute 'pi' of 'xbmc.InfoTagVideo' objects is not writable
Traceback (most recent call last):
  File "D:\Projects\Custom\xbmc\portable_data\userdata\python_properties.py", line 17, in <module>
    video.pi = 200
AttributeError: attribute 'pi' of 'xbmc.InfoTagVideo' objects is not writable
-->End of Python script error report<--
```

With this we can make use of direct getters and setters without any extra method but obviously there's no way to error-check the stored value in the setter etc. If we'd want that someday we'll have to think of some "workaround".
