### PR TITLE
GUIRadioButton: add separate textures for radio image for focus/unfocus states

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -617,7 +617,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   CTextureInfo textureCheckMark, textureCheckMarkNF;
   CTextureInfo textureFocus, textureNoFocus;
   CTextureInfo textureAltFocus, textureAltNoFocus;
-  CTextureInfo textureRadioOn, textureRadioOff;
+  CTextureInfo textureRadioOnFocus, textureRadioOnNoFocus;
+  CTextureInfo textureRadioOffFocus, textureRadioOffNoFocus;
   CTextureInfo imageNoFocus, imageFocus;
   CGUIInfoLabel texturePath;
   CRect borderSize;
@@ -818,10 +819,18 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   XMLUtils::GetFloat(pControlNode, "sliderheight", sliderHeight);
   GetTexture(pControlNode, "texturecheckmark", textureCheckMark);
   GetTexture(pControlNode, "texturecheckmarknofocus", textureCheckMarkNF);
-  GetTexture(pControlNode, "textureradiofocus", textureRadioOn);    // backward compatibility
-  GetTexture(pControlNode, "textureradionofocus", textureRadioOff);
-  GetTexture(pControlNode, "textureradioon", textureRadioOn);
-  GetTexture(pControlNode, "textureradiooff", textureRadioOff);
+  if (!GetTexture(pControlNode, "textureradioonfocus", textureRadioOnFocus) || !GetTexture(pControlNode, "textureradioonnofocus", textureRadioOnNoFocus))
+  {
+    GetTexture(pControlNode, "textureradiofocus", textureRadioOnFocus);    // backward compatibility
+    GetTexture(pControlNode, "textureradioon", textureRadioOnFocus);
+    textureRadioOnNoFocus = textureRadioOnFocus;
+  }
+  if (!GetTexture(pControlNode, "textureradioofffocus", textureRadioOffFocus) || !GetTexture(pControlNode, "textureradiooffnofocus", textureRadioOffNoFocus))
+  {
+    GetTexture(pControlNode, "textureradionofocus", textureRadioOffFocus);    // backward compatibility
+    GetTexture(pControlNode, "textureradiooff", textureRadioOffFocus);
+    textureRadioOffNoFocus = textureRadioOffFocus;
+  }
 
   GetTexture(pControlNode, "texturesliderbackground", textureBackground);
   GetTexture(pControlNode, "texturesliderbar", textureBar);
@@ -1119,7 +1128,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       parentID, id, posX, posY, width, height,
       textureFocus, textureNoFocus,
       labelInfo,
-      textureRadioOn, textureRadioOff);
+      textureRadioOnFocus, textureRadioOnNoFocus, textureRadioOffFocus, textureRadioOffNoFocus);
 
     ((CGUIRadioButtonControl *)control)->SetLabel(strLabel);
     ((CGUIRadioButtonControl *)control)->SetRadioDimensions(radioPosX, radioPosY, radioWidth, radioHeight);

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -26,16 +26,21 @@
 CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID, int controlID, float posX, float posY, float width, float height,
     const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus,
     const CLabelInfo& labelInfo,
-    const CTextureInfo& radioOn, const CTextureInfo& radioOff)
+    const CTextureInfo& radioOnFocus, const CTextureInfo& radioOnNoFocus,
+    const CTextureInfo& radioOffFocus, const CTextureInfo& radioOffNoFocus)
     : CGUIButtonControl(parentID, controlID, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo)
-    , m_imgRadioOn(posX, posY, 16, 16, radioOn)
-    , m_imgRadioOff(posX, posY, 16, 16, radioOff)
+    , m_imgRadioOnFocus(posX, posY, 16, 16, radioOnFocus)
+    , m_imgRadioOnNoFocus(posX, posY, 16, 16, radioOnNoFocus)
+    , m_imgRadioOffFocus(posX, posY, 16, 16, radioOffFocus)
+    , m_imgRadioOffNoFocus(posX, posY, 16, 16, radioOffNoFocus)
 {
   m_radioPosX = 0;
   m_radioPosY = 0;
   m_toggleSelect = 0;
-  m_imgRadioOn.SetAspectRatio(CAspectRatio::AR_KEEP);\
-  m_imgRadioOff.SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgRadioOnFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgRadioOnNoFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgRadioOffFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
+  m_imgRadioOffNoFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
   ControlType = GUICONTROL_RADIO;
 }
 
@@ -47,9 +52,19 @@ void CGUIRadioButtonControl::Render()
   CGUIButtonControl::Render();
 
   if ( IsSelected() && !IsDisabled() )
-    m_imgRadioOn.Render();
+  {
+    if (HasFocus())
+      m_imgRadioOnFocus.Render();
+    else
+      m_imgRadioOnNoFocus.Render();
+  }
   else
-    m_imgRadioOff.Render();
+  {
+    if (HasFocus())
+      m_imgRadioOffFocus.Render();
+    else
+      m_imgRadioOffNoFocus.Render();
+  }
 }
 
 void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
@@ -65,9 +80,11 @@ void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList 
       m_bSelected = selected;
     }
   }
-
-  m_imgRadioOn.Process(currentTime);
-  m_imgRadioOff.Process(currentTime);
+  
+  m_imgRadioOnFocus.Process(currentTime);
+  m_imgRadioOnNoFocus.Process(currentTime);
+  m_imgRadioOffFocus.Process(currentTime);
+  m_imgRadioOffNoFocus.Process(currentTime);
 
   CGUIButtonControl::Process(currentTime, dirtyregions);
 }
@@ -90,40 +107,49 @@ bool CGUIRadioButtonControl::OnMessage(CGUIMessage& message)
 void CGUIRadioButtonControl::AllocResources()
 {
   CGUIButtonControl::AllocResources();
-  m_imgRadioOn.AllocResources();
-  m_imgRadioOff.AllocResources();
-
+  m_imgRadioOnFocus.AllocResources();
+  m_imgRadioOnNoFocus.AllocResources();
+  m_imgRadioOffFocus.AllocResources();
+  m_imgRadioOffNoFocus.AllocResources();
   SetPosition(m_posX, m_posY);
 }
 
 void CGUIRadioButtonControl::FreeResources(bool immediately)
 {
   CGUIButtonControl::FreeResources(immediately);
-  m_imgRadioOn.FreeResources(immediately);
-  m_imgRadioOff.FreeResources(immediately);
+  m_imgRadioOnFocus.FreeResources(immediately);
+  m_imgRadioOnNoFocus.FreeResources(immediately);
+  m_imgRadioOffFocus.FreeResources(immediately);
+  m_imgRadioOffNoFocus.FreeResources(immediately);
 }
 
 void CGUIRadioButtonControl::DynamicResourceAlloc(bool bOnOff)
 {
   CGUIControl::DynamicResourceAlloc(bOnOff);
-  m_imgRadioOn.DynamicResourceAlloc(bOnOff);
-  m_imgRadioOff.DynamicResourceAlloc(bOnOff);
+  m_imgRadioOnFocus.DynamicResourceAlloc(bOnOff);
+  m_imgRadioOnNoFocus.DynamicResourceAlloc(bOnOff);
+  m_imgRadioOffFocus.DynamicResourceAlloc(bOnOff);
+  m_imgRadioOffNoFocus.DynamicResourceAlloc(bOnOff);
 }
 
 void CGUIRadioButtonControl::SetInvalid()
 {
   CGUIButtonControl::SetInvalid();
-  m_imgRadioOn.SetInvalid();
-  m_imgRadioOff.SetInvalid();
+  m_imgRadioOnFocus.SetInvalid();
+  m_imgRadioOnNoFocus.SetInvalid();
+  m_imgRadioOffFocus.SetInvalid();
+  m_imgRadioOffNoFocus.SetInvalid();
 }
 
 void CGUIRadioButtonControl::SetPosition(float posX, float posY)
 {
   CGUIButtonControl::SetPosition(posX, posY);
-  float radioPosX = m_radioPosX ? m_posX + m_radioPosX : (m_posX + m_width - 8) - m_imgRadioOn.GetWidth();
-  float radioPosY = m_radioPosY ? m_posY + m_radioPosY : m_posY + (m_height - m_imgRadioOn.GetHeight()) / 2;
-  m_imgRadioOn.SetPosition(radioPosX, radioPosY);
-  m_imgRadioOff.SetPosition(radioPosX, radioPosY);
+  float radioPosX = m_radioPosX ? m_posX + m_radioPosX : (m_posX + m_width - 8) - m_imgRadioOnFocus.GetWidth();
+  float radioPosY = m_radioPosY ? m_posY + m_radioPosY : m_posY + (m_height - m_imgRadioOnFocus.GetHeight()) / 2;
+  m_imgRadioOnFocus.SetPosition(radioPosX, radioPosY);
+  m_imgRadioOnNoFocus.SetPosition(radioPosX, radioPosY);
+  m_imgRadioOffFocus.SetPosition(radioPosX, radioPosY);
+  m_imgRadioOffNoFocus.SetPosition(radioPosX, radioPosY);
 }
 
 void CGUIRadioButtonControl::SetRadioDimensions(float posX, float posY, float width, float height)
@@ -132,13 +158,17 @@ void CGUIRadioButtonControl::SetRadioDimensions(float posX, float posY, float wi
   m_radioPosY = posY;
   if (width)
   {
-    m_imgRadioOn.SetWidth(width);
-    m_imgRadioOff.SetWidth(width);
+    m_imgRadioOnFocus.SetWidth(width);
+    m_imgRadioOnNoFocus.SetWidth(width);
+    m_imgRadioOffFocus.SetWidth(width);
+    m_imgRadioOffNoFocus.SetWidth(width);
   }
   if (height)
   {
-    m_imgRadioOn.SetHeight(height);
-    m_imgRadioOff.SetHeight(height);
+    m_imgRadioOnFocus.SetHeight(height);
+    m_imgRadioOnNoFocus.SetHeight(height);
+    m_imgRadioOffFocus.SetHeight(height);
+    m_imgRadioOffNoFocus.SetHeight(height);
   }
   SetPosition(GetXPosition(), GetYPosition());
 }
@@ -168,9 +198,10 @@ CStdString CGUIRadioButtonControl::GetDescription() const
 bool CGUIRadioButtonControl::UpdateColors()
 {
   bool changed = CGUIButtonControl::UpdateColors();
-  changed |= m_imgRadioOn.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgRadioOff.SetDiffuseColor(m_diffuseColor);
-
+  changed |= m_imgRadioOnFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRadioOnNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRadioOffFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRadioOffNoFocus.SetDiffuseColor(m_diffuseColor);
   return changed;
 }
 

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -39,7 +39,8 @@ public:
                          float posX, float posY, float width, float height,
                          const CTextureInfo& textureFocus, const CTextureInfo& textureNoFocus,
                          const CLabelInfo& labelInfo,
-                         const CTextureInfo& radioOn, const CTextureInfo& radioOff);
+                         const CTextureInfo& radioOnFocus, const CTextureInfo& radioOnNoFocus,
+                         const CTextureInfo& radioOffFocus, const CTextureInfo& radioOffNoFocus);
 
   virtual ~CGUIRadioButtonControl(void);
   virtual CGUIRadioButtonControl *Clone() const { return new CGUIRadioButtonControl(*this); };
@@ -61,8 +62,10 @@ public:
   bool IsSelected() const { return m_bSelected; };
 protected:
   virtual bool UpdateColors();
-  CGUITexture m_imgRadioOn;
-  CGUITexture m_imgRadioOff;
+  CGUITexture m_imgRadioOnFocus;
+  CGUITexture m_imgRadioOnNoFocus;
+  CGUITexture m_imgRadioOffFocus;
+  CGUITexture m_imgRadioOffNoFocus;
   float m_radioPosX;
   float m_radioPosY;
   unsigned int m_toggleSelect;

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -584,7 +584,9 @@ namespace XBMCAddon
     // ============================================================
     // ============================================================
     ControlRadioButton::ControlRadioButton(long x, long y, long width, long height, const String& label,
-                                           const char* focusTexture, const char* noFocusTexture, 
+                                           const char* focusOnTexture,  const char* noFocusOnTexture,
+                                           const char* focusOffTexture, const char* noFocusOffTexture,
+                                           const char* focusTexture,    const char* noFocusTexture, 
                                            long _textOffsetX, long _textOffsetY, 
                                            long alignment, const char* font, const char* _textColor,
                                            const char* _disabledColor, long angle,
@@ -606,11 +608,29 @@ namespace XBMCAddon
         XBMCAddonUtils::getDefaultImage((char*)"button", (char*)"texturefocus", (char*)"button-focus.png");
       strTextureNoFocus = noFocusTexture ? noFocusTexture :
         XBMCAddonUtils::getDefaultImage((char*)"button", (char*)"texturenofocus", (char*)"button-nofocus.jpg");
-      strTextureRadioFocus = TextureRadioFocus ? TextureRadioFocus :
-        XBMCAddonUtils::getDefaultImage((char*)"radiobutton", (char*)"textureradiofocus", (char*)"radiobutton-focus.png");
-      strTextureRadioNoFocus = TextureRadioNoFocus ? TextureRadioNoFocus :
-        XBMCAddonUtils::getDefaultImage((char*)"radiobutton", (char*)"textureradionofocus", (char*)"radiobutton-nofocus.jpg");
-      
+
+      if (focusOnTexture && noFocusOnTexture)
+      {
+        strTextureRadioOnFocus = focusOnTexture;
+        strTextureRadioOnNoFocus = noFocusOnTexture;
+      }
+      else
+      {
+        strTextureRadioOnFocus = strTextureRadioOnNoFocus = focusTexture ? focusTexture :
+          XBMCAddonUtils::getDefaultImage((char*)"radiobutton", (char*)"textureradiofocus", (char*)"radiobutton-focus.png");
+      }
+
+      if (focusOffTexture && noFocusOffTexture)
+      {
+        strTextureRadioOffFocus = focusOffTexture;
+        strTextureRadioOffNoFocus = noFocusOffTexture;
+      }
+      else
+      {
+        strTextureRadioOffFocus = strTextureRadioOffNoFocus = noFocusTexture ? noFocusTexture :
+          XBMCAddonUtils::getDefaultImage((char*)"radiobutton", (char*)"textureradiofocus", (char*)"radiobutton-focus.png");
+      }
+
       if (font) strFont = font;
       if (_textColor) sscanf( _textColor, "%x", &textColor );
       if (_disabledColor) sscanf( _disabledColor, "%x", &disabledColor );
@@ -698,8 +718,10 @@ namespace XBMCAddon
         (CStdString)strTextureFocus,
         (CStdString)strTextureNoFocus,
         label,
-        (CStdString)strTextureRadioFocus,
-        (CStdString)strTextureRadioNoFocus);
+        (CStdString)strTextureRadioOnFocus,
+        (CStdString)strTextureRadioOnNoFocus,
+        (CStdString)strTextureRadioOffFocus,
+        (CStdString)strTextureRadioOffNoFocus);
 
       CGUIRadioButtonControl* pGuiButtonControl =
         (CGUIRadioButtonControl*)pGUIControl;

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -1355,10 +1355,45 @@ namespace XBMCAddon
 #endif
     };
 
+    // ControlRadioButton class
+    /**
+     * ControlRadioButton class.
+     * 
+     * ControlRadioButton(x, y, width, height, label[, focusOnTexture, noFocusOnTexture,
+     *                   focusOffTexture, noFocusOffTexture, focusTexture, noFocusTexture,
+     *                   textOffsetX, textOffsetY, alignment, font, textColor, disabledColor])
+     * 
+     * x                 : integer - x coordinate of control.
+     * y                 : integer - y coordinate of control.
+     * width             : integer - width of control.
+     * height            : integer - height of control.
+     * label             : string or unicode - text string.
+     * focusOnTexture    : [opt] string - filename for radio ON focused texture.
+     * noFocusOnTexture  : [opt] string - filename for radio ON not focused texture.
+     * focusOfTexture    : [opt] string - filename for radio OFF focused texture.
+     * noFocusOffTexture : [opt] string - filename for radio OFF not focused texture.
+     * focusTexture      : [opt] string - filename for radio ON texture (deprecated, use focusOnTexture and noFocusOnTexture).
+     * noFocusTexture    : [opt] string - filename for radio OFF texture (deprecated, use focusOffTexture and noFocusOffTexture).
+     * textOffsetX       : [opt] integer - horizontal text offset
+     * textOffsetY       : [opt] integer - vertical text offset
+     * alignment         : [opt] integer - alignment of label - *Note, see xbfont.h
+     * font              : [opt] string - font used for label text. (e.g. 'font13')
+     * textColor         : [opt] hexstring - color of enabled checkmark's label. (e.g. '0xFFFFFFFF')
+     * disabledColor     : [opt] hexstring - color of disabled checkmark's label. (e.g. '0xFFFF3300')
+     * 
+     * *Note, You can use the above as keywords for arguments and skip certain optional arguments.
+     *        Once you use a keyword, all following arguments require the keyword.
+     *        After you create the control, you need to add it to the window with addControl().
+     * 
+     * example:
+     *   - self.radiobutton = xbmcgui.ControlRadioButton(100, 250, 200, 50, 'Enable', font='font14')
+     */
     class ControlRadioButton : public Control
     {
     public:
       ControlRadioButton(long x, long y, long width, long height, const String& label,
+                         const char* focusOnTexture = NULL, const char* noFocusOnTexture = NULL,
+                         const char* focusOffTexture = NULL, const char* noFocusOffTexture = NULL,
                          const char* focusTexture = NULL, const char* noFocusTexture = NULL, 
                          long textOffsetX = CONTROL_TEXT_OFFSET_X, 
                          long textOffsetY = CONTROL_TEXT_OFFSET_Y, 
@@ -1441,8 +1476,10 @@ namespace XBMCAddon
       std::string strText;
       std::string strTextureFocus;
       std::string strTextureNoFocus;
-      std::string strTextureRadioFocus;
-      std::string strTextureRadioNoFocus;
+      std::string strTextureRadioOnFocus;
+      std::string strTextureRadioOnNoFocus;
+      std::string strTextureRadioOffFocus;
+      std::string strTextureRadioOffNoFocus;
       color_t textColor;
       color_t disabledColor;
       int textOffsetX;


### PR DESCRIPTION
As per request: http://forum.xbmc.org/showthread.php?tid=164787 this adds support for following radio textures (and keeps bw-compat):

```
<textureradioonfocus>radiobutton-on-focus.png</textureradioonfocus>
<textureradioonnofocus>radiobutton-on-nofocus.png</textureradioonnofocus>
<textureradioofffocus>radiobutton-off-focus.png</textureradioofffocus>
<textureradiooffnofocus>radiobutton-off-nofocus.png</textureradiooffnofocus>
```
