### PR TITLE
[Python] Passes "screensaver" to a python screensaver addon.

### DIFF
--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -48,7 +48,13 @@ bool CScreenSaver::CreateScreenSaver()
     g_alarmClock.Stop(PYTHON_ALARM, true);
 
     if (!g_pythonParser.StopScript(LibPath()))
-      g_pythonParser.evalFile(LibPath(), AddonPtr(new CScreenSaver(Props())));
+    {
+      std::vector<CStdString> argv;
+      argv.push_back(LibPath());
+      argv.push_back("screensaver=1");
+
+      g_pythonParser.evalFile(LibPath(), argv, AddonPtr(new CScreenSaver(Props())));
+    }
     return true;
   }
 #endif


### PR DESCRIPTION
This or something similar to allow a python addon to run as a script/plugin, but also as a screensaver.

Allowing the addon to check for "screensaver" or anything else you pass, would allow say a Movie Trailers plugin to also act as a screensaver and save having two addons installed.
