### PR TITLE
Replace deprecated CodecID and CODEC_ID_* by AVCodecID and AV_CODEC_ID_* everywhere in xbmc code.

### DIFF
--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -64,8 +64,8 @@ public:
   virtual void avcodec_register_all(void)=0;
   virtual void avcodec_flush_buffers(AVCodecContext *avctx)=0;
   virtual int avcodec_open2_dont_call(AVCodecContext *avctx, AVCodec *codec, AVDictionary **options)=0;
-  virtual AVCodec *avcodec_find_decoder(enum CodecID id)=0;
-  virtual AVCodec *avcodec_find_encoder(enum CodecID id)=0;
+  virtual AVCodec *avcodec_find_decoder(enum AVCodecID id)=0;
+  virtual AVCodec *avcodec_find_encoder(enum AVCodecID id)=0;
   virtual int avcodec_close_dont_call(AVCodecContext *avctx)=0;
   virtual AVFrame *avcodec_alloc_frame(void)=0;
   virtual int avpicture_fill(AVPicture *picture, uint8_t *ptr, PixelFormat pix_fmt, int width, int height)=0;
@@ -124,8 +124,8 @@ public:
   }
   virtual int avcodec_open2_dont_call(AVCodecContext *avctx, AVCodec *codec, AVDictionary **options) { *(volatile int *)0x0 = 0; return 0; }
   virtual int avcodec_close_dont_call(AVCodecContext *avctx) { *(volatile int *)0x0 = 0; return 0; }
-  virtual AVCodec *avcodec_find_decoder(enum CodecID id) { return ::avcodec_find_decoder(id); }
-  virtual AVCodec *avcodec_find_encoder(enum CodecID id) { return ::avcodec_find_encoder(id); }
+  virtual AVCodec *avcodec_find_decoder(enum AVCodecID id) { return ::avcodec_find_decoder(id); }
+  virtual AVCodec *avcodec_find_encoder(enum AVCodecID id) { return ::avcodec_find_encoder(id); }
   virtual int avcodec_close(AVCodecContext *avctx)
   {
     CSingleLock lock(DllAvCodec::m_critSection);
@@ -202,8 +202,8 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
   LOAD_SYMBOLS();
 
   DEFINE_METHOD0(void, avcodec_register_all_dont_call)
-  DEFINE_METHOD1(AVCodec*, avcodec_find_decoder, (enum CodecID p1))
-  DEFINE_METHOD1(AVCodec*, avcodec_find_encoder, (enum CodecID p1))
+  DEFINE_METHOD1(AVCodec*, avcodec_find_decoder, (enum AVCodecID p1))
+  DEFINE_METHOD1(AVCodec*, avcodec_find_encoder, (enum AVCodecID p1))
   DEFINE_METHOD1(int, avcodec_close_dont_call, (AVCodecContext *p1))
   DEFINE_METHOD0(AVFrame*, avcodec_alloc_frame)
   DEFINE_METHOD5(int, avpicture_fill, (AVPicture *p1, uint8_t *p2, PixelFormat p3, int p4, int p5))

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -67,7 +67,7 @@ bool CEncoderFFmpeg::Init(const char* strFile, int iInChannels, int iInRate, int
 
   AVCodec *codec;
   codec = m_dllAvCodec.avcodec_find_encoder(
-    strcmp(fmt->name, "ogg") == 0 ? CODEC_ID_VORBIS : fmt->audio_codec
+    strcmp(fmt->name, "ogg") == 0 ? AV_CODEC_ID_VORBIS : fmt->audio_codec
   );
 
   if (!codec)

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -116,7 +116,7 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format)
   if (dts && (!ac3 || g_advancedSettings.m_audioTranscodeTo.Equals("dts")))
   {
     m_CodecName = "DTS";
-    m_CodecID   = CODEC_ID_DTS;
+    m_CodecID   = AV_CODEC_ID_DTS;
     m_PackFunc  = &CAEPackIEC61937::PackDTS_1024;
     m_BitRate   = DTS_ENCODE_BITRATE;
     codec = m_dllAvCodec.avcodec_find_encoder(m_CodecID);
@@ -127,7 +127,7 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format)
   if (!codec && ac3)
   {
     m_CodecName = "AC3";
-    m_CodecID   = CODEC_ID_AC3;
+    m_CodecID   = AV_CODEC_ID_AC3;
     m_PackFunc  = &CAEPackIEC61937::PackAC3;
     m_BitRate   = AC3_ENCODE_BITRATE;
     codec = m_dllAvCodec.avcodec_find_encoder(m_CodecID);
@@ -252,7 +252,7 @@ unsigned int CAEEncoderFFmpeg::GetBitRate()
   return m_BitRate;
 }
 
-CodecID CAEEncoderFFmpeg::GetCodecID()
+AVCodecID CAEEncoderFFmpeg::GetCodecID()
 {
   return m_CodecID;
 }

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h
@@ -40,7 +40,7 @@ public:
   virtual void Reset();
 
   virtual unsigned int GetBitRate    ();
-  virtual CodecID      GetCodecID    ();
+  virtual AVCodecID    GetCodecID    ();
   virtual unsigned int GetFrames     ();
 
   virtual int Encode (float *data, unsigned int frames);
@@ -53,7 +53,7 @@ private:
   DllSwResample m_dllSwResample;
 
   std::string                m_CodecName;
-  CodecID                   m_CodecID;
+  AVCodecID                  m_CodecID;
   unsigned int              m_BitRate;
   CAEPackIEC61937::PackFunc m_PackFunc;
 

--- a/xbmc/cores/AudioEngine/Interfaces/AEEncoder.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEEncoder.h
@@ -64,10 +64,10 @@ public:
   virtual unsigned int GetBitRate() = 0;
 
   /**
-   * Returns the CodecID of the encoder
+   * Returns the AVCodecID of the encoder
    * @return the ffmpeg codec id
    */
-  virtual CodecID GetCodecID() = 0;
+  virtual AVCodecID GetCodecID() = 0;
 
   /**
    * Return the number of frames needed to encode

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -408,16 +408,16 @@ void CAMLSubTitleThread::Process(void)
 
             /* TODO: handle other subtitle codec types
             // subtitle codecs
-            CODEC_ID_DVD_SUBTITLE= 0x17000,
-            CODEC_ID_DVB_SUBTITLE,
-            CODEC_ID_TEXT,  ///< raw UTF-8 text
-            CODEC_ID_XSUB,
-            CODEC_ID_SSA,
-            CODEC_ID_MOV_TEXT,
-            CODEC_ID_HDMV_PGS_SUBTITLE,
-            CODEC_ID_DVB_TELETEXT,
-            CODEC_ID_SRT,
-            CODEC_ID_MICRODVD,
+            AV_CODEC_ID_DVD_SUBTITLE= 0x17000,
+            AV_CODEC_ID_DVB_SUBTITLE,
+            AV_CODEC_ID_TEXT,  ///< raw UTF-8 text
+            AV_CODEC_ID_XSUB,
+            AV_CODEC_ID_SSA,
+            AV_CODEC_ID_MOV_TEXT,
+            AV_CODEC_ID_HDMV_PGS_SUBTITLE,
+            AV_CODEC_ID_DVB_TELETEXT,
+            AV_CODEC_ID_SRT,
+            AV_CODEC_ID_MICRODVD,
             */
             switch(sub_type)
             {
@@ -426,12 +426,12 @@ void CAMLSubTitleThread::Process(void)
                   "sub_type(0x%x), size(%d), bgntime(%lld), endtime(%lld), string(%s)",
                   sub_type, sub_size-20, subtitle->bgntime, subtitle->endtime, &sub_buffer[20]);
                 break;
-              case CODEC_ID_TEXT:
+              case AV_CODEC_ID_TEXT:
                 subtitle->bgntime = sub_pts/ 90;
                 subtitle->endtime = subtitle->bgntime + 4000;
                 subtitle->string  = &sub_buffer[20];
                 break;
-              case CODEC_ID_SSA:
+              case AV_CODEC_ID_SSA:
                 if (strncmp((const char*)&sub_buffer[20], "Dialogue:", 9) == 0)
                 {
                   int  vars_found, hour1, min1, sec1, hunsec1, hour2, min2, sec2, hunsec2, nothing;

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -116,7 +116,7 @@ CDVDAudio::~CDVDAudio()
   free(m_pBuffer);
 }
 
-bool CDVDAudio::Create(const DVDAudioFrame &audioframe, CodecID codec, bool needresampler)
+bool CDVDAudio::Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool needresampler)
 {
   CLog::Log(LOGNOTICE,
     "Creating audio stream (codec id: %i, channels: %i, sample rate: %i, %s)",

--- a/xbmc/cores/dvdplayer/DVDAudio.h
+++ b/xbmc/cores/dvdplayer/DVDAudio.h
@@ -76,7 +76,7 @@ public:
   float GetCurrentAttenuation();
   void Pause();
   void Resume();
-  bool Create(const DVDAudioFrame &audioframe, CodecID codec, bool needresampler);
+  bool Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool needresampler);
   bool IsValidFormat(const DVDAudioFrame &audioframe);
   void Destroy();
   unsigned int AddPackets(const DVDAudioFrame &audioframe);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.cpp
@@ -23,7 +23,7 @@
 
 CDVDAudioCodecLPcm::CDVDAudioCodecLPcm() : CDVDAudioCodecPcm()
 {
-  m_codecID = CODEC_ID_NONE;
+  m_codecID = AV_CODEC_ID_NONE;
   m_bufferSize = LPCM_BUFFER_SIZE;
   memset(m_buffer, 0, sizeof(m_buffer));
 }
@@ -33,11 +33,11 @@ bool CDVDAudioCodecLPcm::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   m_codecID = hints.codec;
 
   CDVDStreamInfo hints2(hints, true);
-  hints2.codec = CODEC_ID_NONE;
+  hints2.codec = AV_CODEC_ID_NONE;
 #if 0
-  if (hints.codecID = CODEC_ID_LPCM_S24BE) hints2.codec = CODEC_ID_PCM_S24BE;
+  if (hints.codecID = AV_CODEC_ID_LPCM_S24BE) hints2.codec = AV_CODEC_ID_PCM_S24BE;
 #endif
-  if (hints2.codec != CODEC_ID_NONE)
+  if (hints2.codec != AV_CODEC_ID_NONE)
     return CDVDAudioCodecPcm::Open(hints2, options);
 
   return false;
@@ -54,7 +54,7 @@ int CDVDAudioCodecLPcm::Decode(uint8_t* pData, int iSize)
   {
     int iDecoded = 0;
 #if 0
-    if (m_codecID == CODEC_ID_LPCM_S24BE)
+    if (m_codecID == AV_CODEC_ID_LPCM_S24BE)
 #endif
     {
       for (iDecoded = 0; iDecoded <= (iSize - 12); iDecoded += 12)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.h
@@ -40,5 +40,5 @@ protected:
   int m_bufferSize;
   uint8_t m_buffer[LPCM_BUFFER_SIZE];
 
-  CodecID m_codecID;
+  AVCodecID m_codecID;
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -67,12 +67,12 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
   m_bufferSize = 0;
 
   if (
-      (hints.codec == CODEC_ID_AC3 && bSupportsAC3Out) ||
-      (hints.codec == CODEC_ID_DTS && bSupportsDTSOut) ||
+      (hints.codec == AV_CODEC_ID_AC3 && bSupportsAC3Out) ||
+      (hints.codec == AV_CODEC_ID_DTS && bSupportsDTSOut) ||
       (audioMode == AUDIO_HDMI &&
         (
-          (hints.codec == CODEC_ID_EAC3   && bSupportsAC3Out   ) ||
-          (hints.codec == CODEC_ID_TRUEHD && bSupportsTrueHDOut)
+          (hints.codec == AV_CODEC_ID_EAC3   && bSupportsAC3Out   ) ||
+          (hints.codec == AV_CODEC_ID_TRUEHD && bSupportsTrueHDOut)
         )
       )
   )

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthroughFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthroughFFmpeg.cpp
@@ -145,7 +145,7 @@ bool CDVDAudioCodecPassthroughFFmpeg::SetupMuxer(CDVDStreamInfo &hints, CStdStri
 
   /* set the stream's parameters */
   m_SampleRate = hints.samplerate;
-  if(!m_SampleRate && hints.codec == CODEC_ID_AC3)
+  if(!m_SampleRate && hints.codec == AV_CODEC_ID_AC3)
     m_SampleRate = 48000;
 
   AVCodecContext *codec = muxer.m_pStream->codec;
@@ -283,9 +283,9 @@ bool CDVDAudioCodecPassthroughFFmpeg::SupportsFormat(CDVDStreamInfo &hints)
 {
   m_pSyncFrame = NULL;
 
-       if (m_bSupportsAC3Out && hints.codec == CODEC_ID_AC3) m_pSyncFrame = &CDVDAudioCodecPassthroughFFmpeg::SyncAC3;
-  else if (m_bSupportsDTSOut && hints.codec == CODEC_ID_DTS) m_pSyncFrame = &CDVDAudioCodecPassthroughFFmpeg::SyncDTS;
-  else if (m_bSupportsAACOut && hints.codec == CODEC_ID_AAC) m_pSyncFrame = &CDVDAudioCodecPassthroughFFmpeg::SyncAAC;
+       if (m_bSupportsAC3Out && hints.codec == AV_CODEC_ID_AC3) m_pSyncFrame = &CDVDAudioCodecPassthroughFFmpeg::SyncAC3;
+  else if (m_bSupportsDTSOut && hints.codec == AV_CODEC_ID_DTS) m_pSyncFrame = &CDVDAudioCodecPassthroughFFmpeg::SyncDTS;
+  else if (m_bSupportsAACOut && hints.codec == AV_CODEC_ID_AAC) m_pSyncFrame = &CDVDAudioCodecPassthroughFFmpeg::SyncAAC;
   else return false;
 
   return true;
@@ -334,7 +334,7 @@ bool CDVDAudioCodecPassthroughFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   else
   {
     /* aac needs to be wrapped into ADTS frames */
-    if (hints.codec == CODEC_ID_AAC)
+    if (hints.codec == AV_CODEC_ID_AAC)
       if (!SetupMuxer(hints, "adts", m_ADTS))
       {
         CLog::Log(LOGERROR, "CDVDAudioCodecPassthroughFFmpeg::Open - Unable to setup ADTS muxer");
@@ -487,8 +487,8 @@ enum AEDataFormat CDVDAudioCodecPassthroughFFmpeg::GetDataFormat()
 {
   switch(m_codec)
   {
-    case CODEC_ID_AC3:      return AE_FMT_AC3;
-    case CODEC_ID_DTS:      return AE_FMT_DTS;
+    case AV_CODEC_ID_AC3:      return AE_FMT_AC3;
+    case AV_CODEC_ID_DTS:      return AE_FMT_DTS;
     default:
       return AE_FMT_INVALID; //Unknown stream type
   }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthroughFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthroughFFmpeg.h
@@ -94,7 +94,7 @@ private:
   unsigned int m_Needed;
   bool         m_LostSync;
   int          m_SampleRate;
-  CodecID      m_codec;
+  AVCodecID    m_codec;
 
   unsigned int (CDVDAudioCodecPassthroughFFmpeg::*m_pSyncFrame)(uint8_t* pData, unsigned int iSize, unsigned int *fSize);
   unsigned int SyncAC3(uint8_t* pData, unsigned int iSize, unsigned int *fSize);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.cpp
@@ -113,7 +113,7 @@ CDVDAudioCodecPcm::CDVDAudioCodecPcm() : CDVDAudioCodec()
   m_iSourceSampleRate = 0;
   m_iSourceBitrate = 0;
   m_decodedDataSize = 0;
-  m_codecID = CODEC_ID_NONE;
+  m_codecID = AV_CODEC_ID_NONE;
   m_iOutputChannels = 0;
 
   memset(m_decodedData, 0, sizeof(m_decodedData));
@@ -136,12 +136,12 @@ bool CDVDAudioCodecPcm::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 
   switch (m_codecID)
   {
-    case CODEC_ID_PCM_ALAW:
+    case AV_CODEC_ID_PCM_ALAW:
     {
       for (int i = 0; i < 256; i++) table[i] = alaw2linear(i);
       break;
     }
-    case CODEC_ID_PCM_MULAW:
+    case AV_CODEC_ID_PCM_MULAW:
     {
       for (int i = 0; i < 256; i++) table[i] = ulaw2linear(i);
       break;
@@ -177,31 +177,31 @@ int CDVDAudioCodecPcm::Decode(uint8_t* pData, int iSize)
 
     switch (m_codecID)
     {
-    case CODEC_ID_PCM_S32LE:
+    case AV_CODEC_ID_PCM_S32LE:
         decode_to16(4, 1, 0, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_S32BE:
+    case AV_CODEC_ID_PCM_S32BE:
         decode_to16(4, 0, 0, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_U32LE:
+    case AV_CODEC_ID_PCM_U32LE:
         decode_to16(4, 1, 1, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_U32BE:
+    case AV_CODEC_ID_PCM_U32BE:
         decode_to16(4, 0, 1, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_S24LE:
+    case AV_CODEC_ID_PCM_S24LE:
         decode_to16(3, 1, 0, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_S24BE:
+    case AV_CODEC_ID_PCM_S24BE:
         decode_to16(3, 0, 0, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_U24LE:
+    case AV_CODEC_ID_PCM_U24LE:
         decode_to16(3, 1, 1, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_U24BE:
+    case AV_CODEC_ID_PCM_U24BE:
         decode_to16(3, 0, 1, &src, &samples, buf_size);
         break;
-    case CODEC_ID_PCM_S24DAUD:
+    case AV_CODEC_ID_PCM_S24DAUD:
         n = buf_size / 3;
         for(;n>0;n--) {
           uint32_t v = src[0] << 16 | src[1] << 8 | src[2];
@@ -211,50 +211,50 @@ int CDVDAudioCodecPcm::Decode(uint8_t* pData, int iSize)
           src += 3;
         }
         break;
-    case CODEC_ID_PCM_S16LE:
+    case AV_CODEC_ID_PCM_S16LE:
         n = buf_size >> 1;
         for(;n>0;n--) {
             *samples++ = src[0] | (src[1] << 8);
             src += 2;
         }
         break;
-    case CODEC_ID_PCM_S16BE:
+    case AV_CODEC_ID_PCM_S16BE:
         n = buf_size >> 1;
         for(;n>0;n--) {
             *samples++ = (src[0] << 8) | src[1];
             src += 2;
         }
         break;
-    case CODEC_ID_PCM_U16LE:
+    case AV_CODEC_ID_PCM_U16LE:
         n = buf_size >> 1;
         for(;n>0;n--) {
             *samples++ = (src[0] | (src[1] << 8)) - 0x8000;
             src += 2;
         }
         break;
-    case CODEC_ID_PCM_U16BE:
+    case AV_CODEC_ID_PCM_U16BE:
         n = buf_size >> 1;
         for(;n>0;n--) {
             *samples++ = ((src[0] << 8) | src[1]) - 0x8000;
             src += 2;
         }
         break;
-    case CODEC_ID_PCM_S8:
+    case AV_CODEC_ID_PCM_S8:
         n = buf_size;
         for(;n>0;n--) {
             *samples++ = src[0] << 8;
             src++;
         }
         break;
-    case CODEC_ID_PCM_U8:
+    case AV_CODEC_ID_PCM_U8:
         n = buf_size;
         for(;n>0;n--) {
             *samples++ = ((int)src[0] - 128) << 8;
             src++;
         }
         break;
-    case CODEC_ID_PCM_ALAW:
-    case CODEC_ID_PCM_MULAW:
+    case AV_CODEC_ID_PCM_ALAW:
+    case AV_CODEC_ID_PCM_MULAW:
         n = buf_size;
         for(;n>0;n--) {
             *samples++ = table[src[0]];
@@ -281,7 +281,7 @@ void CDVDAudioCodecPcm::SetDefault()
   m_iSourceSampleRate = 0;
   m_iSourceBitrate = 0;
   m_decodedDataSize = 0;
-  m_codecID = CODEC_ID_NONE;
+  m_codecID = AV_CODEC_ID_NONE;
 }
 
 void CDVDAudioCodecPcm::Reset()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
@@ -44,7 +44,7 @@ protected:
   short m_decodedData[131072]; // could be a bit to big
   int m_decodedDataSize;
 
-  CodecID m_codecID;
+  AVCodecID m_codecID;
   int m_iSourceSampleRate;
   int m_iSourceChannels;
   int m_iSourceBitrate;

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -181,7 +181,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
   CLog::Log(LOGDEBUG, "CDVDFactoryCodec: compiled in hardware support: %s", hwSupport.c_str());
 #if !defined(HAS_LIBAMCODEC)
   // dvd's have weird still-frames in it, which is not fully supported in ffmpeg
-  if(hint.stills && (hint.codec == CODEC_ID_MPEG2VIDEO || hint.codec == CODEC_ID_MPEG1VIDEO))
+  if(hint.stills && (hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_MPEG1VIDEO))
   {
     if( (pCodec = OpenCodec(new CDVDVideoCodecLibMpeg2(), hint, options)) ) return pCodec;
   }
@@ -190,7 +190,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
 #if defined(TARGET_DARWIN_OSX)
   if (!hint.software && CSettings::Get().GetBool("videoplayer.usevda"))
   {
-    if (hint.codec == CODEC_ID_H264 && !hint.ptsinvalid)
+    if (hint.codec == AV_CODEC_ID_H264 && !hint.ptsinvalid)
     {
       if ( (pCodec = OpenCodec(new CDVDVideoCodecVDA(), hint, options)) ) return pCodec;
     }
@@ -204,8 +204,8 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
     {
       switch(hint.codec)
       {
-        case CODEC_ID_H264:
-          if (hint.codec == CODEC_ID_H264 && hint.ptsinvalid)
+        case AV_CODEC_ID_H264:
+          if (hint.codec == AV_CODEC_ID_H264 && hint.ptsinvalid)
             break;
           if ( (pCodec = OpenCodec(new CDVDVideoCodecVideoToolBox(), hint, options)) ) return pCodec;
         break;
@@ -223,13 +223,13 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
     {
       switch(hint.codec)
       {
-        case CODEC_ID_VC1:
-        case CODEC_ID_WMV3:
-        case CODEC_ID_H264:
-        case CODEC_ID_MPEG2VIDEO:
-          if (hint.codec == CODEC_ID_H264 && hint.ptsinvalid)
+        case AV_CODEC_ID_VC1:
+        case AV_CODEC_ID_WMV3:
+        case AV_CODEC_ID_H264:
+        case AV_CODEC_ID_MPEG2VIDEO:
+          if (hint.codec == AV_CODEC_ID_H264 && hint.ptsinvalid)
             break;
-          if (hint.codec == CODEC_ID_MPEG2VIDEO && hint.width <= 720)
+          if (hint.codec == AV_CODEC_ID_MPEG2VIDEO && hint.width <= 720)
             break;
           if ( (pCodec = OpenCodec(new CDVDVideoCodecCrystalHD(), hint, options)) ) return pCodec;
         break;
@@ -251,7 +251,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
 #if defined(HAVE_LIBOPENMAX)
   if (CSettings::Get().GetBool("videoplayer.useomx") && !hint.software )
   {
-      if (hint.codec == CODEC_ID_H264 || hint.codec == CODEC_ID_MPEG2VIDEO || hint.codec == CODEC_ID_VC1)
+      if (hint.codec == AV_CODEC_ID_H264 || hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_VC1)
     {
       if ( (pCodec = OpenCodec(new CDVDVideoCodecOpenMax(), hint, options)) ) return pCodec;
     }
@@ -286,8 +286,8 @@ CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec( CDVDStreamInfo &hint, bool p
 #if defined(TARGET_DARWIN_OSX) || defined(TARGET_DARWIN_IOS)
     switch(hint.codec)
     {
-      case CODEC_ID_AC3:
-      case CODEC_ID_DTS:
+      case AV_CODEC_ID_AC3:
+      case AV_CODEC_ID_DTS:
         pCodec = OpenCodec( new CDVDAudioCodecPassthroughFFmpeg(), hint, options );
         if( pCodec ) return pCodec;
         break;
@@ -301,39 +301,39 @@ CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec( CDVDStreamInfo &hint, bool p
 
   switch (hint.codec)
   {
-  case CODEC_ID_MP2:
-  case CODEC_ID_MP3:
+  case AV_CODEC_ID_MP2:
+  case AV_CODEC_ID_MP3:
     {
       pCodec = OpenCodec( new CDVDAudioCodecLibMad(), hint, options );
       if( pCodec ) return pCodec;
       break;
     }
-  case CODEC_ID_PCM_S32LE:
-  case CODEC_ID_PCM_S32BE:
-  case CODEC_ID_PCM_U32LE:
-  case CODEC_ID_PCM_U32BE:
-  case CODEC_ID_PCM_S24LE:
-  case CODEC_ID_PCM_S24BE:
-  case CODEC_ID_PCM_U24LE:
-  case CODEC_ID_PCM_U24BE:
-  case CODEC_ID_PCM_S24DAUD:
-  case CODEC_ID_PCM_S16LE:
-  case CODEC_ID_PCM_S16BE:
-  case CODEC_ID_PCM_U16LE:
-  case CODEC_ID_PCM_U16BE:
-  case CODEC_ID_PCM_S8:
-  case CODEC_ID_PCM_U8:
-  case CODEC_ID_PCM_ALAW:
-  case CODEC_ID_PCM_MULAW:
+  case AV_CODEC_ID_PCM_S32LE:
+  case AV_CODEC_ID_PCM_S32BE:
+  case AV_CODEC_ID_PCM_U32LE:
+  case AV_CODEC_ID_PCM_U32BE:
+  case AV_CODEC_ID_PCM_S24LE:
+  case AV_CODEC_ID_PCM_S24BE:
+  case AV_CODEC_ID_PCM_U24LE:
+  case AV_CODEC_ID_PCM_U24BE:
+  case AV_CODEC_ID_PCM_S24DAUD:
+  case AV_CODEC_ID_PCM_S16LE:
+  case AV_CODEC_ID_PCM_S16BE:
+  case AV_CODEC_ID_PCM_U16LE:
+  case AV_CODEC_ID_PCM_U16BE:
+  case AV_CODEC_ID_PCM_S8:
+  case AV_CODEC_ID_PCM_U8:
+  case AV_CODEC_ID_PCM_ALAW:
+  case AV_CODEC_ID_PCM_MULAW:
     {
       pCodec = OpenCodec( new CDVDAudioCodecPcm(), hint, options );
       if( pCodec ) return pCodec;
       break;
     }
 #if 0
-  //case CODEC_ID_LPCM_S16BE:
-  //case CODEC_ID_LPCM_S20BE:
-  case CODEC_ID_LPCM_S24BE:
+  //case AV_CODEC_ID_LPCM_S16BE:
+  //case AV_CODEC_ID_LPCM_S20BE:
+  case AV_CODEC_ID_LPCM_S24BE:
     {
       pCodec = OpenCodec( new CDVDAudioCodecLPcm(), hint, options );
       if( pCodec ) return pCodec;
@@ -360,7 +360,7 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
 
   switch (hint.codec)
   {
-    case CODEC_ID_TEXT:
+    case AV_CODEC_ID_TEXT:
 #if defined(LIBAVCODEC_FROM_FFMPEG) && LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54,53,100)
     // API changed in:
     // ffmpeg: commit 2626cc4580bfd560c6983338d77b2c11c16af94f (11 Aug 2012)
@@ -371,7 +371,7 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
       if( pCodec ) return pCodec;
       break;
 
-    case CODEC_ID_SSA:
+    case AV_CODEC_ID_SSA:
       pCodec = OpenCodec(new CDVDOverlayCodecSSA(), hint, options);
       if( pCodec ) return pCodec;
 
@@ -379,7 +379,7 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
       if( pCodec ) return pCodec;
       break;
 
-    case CODEC_ID_MOV_TEXT:
+    case AV_CODEC_ID_MOV_TEXT:
       pCodec = OpenCodec(new CDVDOverlayCodecTX3G(), hint, options);
       if( pCodec ) return pCodec;
       break;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -181,7 +181,7 @@ int CDVDOverlayCodecFFmpeg::Decode(DemuxPacket *pPacket)
 
   double pts_offset = 0.0;
  
-  if (m_pCodecContext->codec_id == CODEC_ID_HDMV_PGS_SUBTITLE && m_Subtitle.format == 0) 
+  if (m_pCodecContext->codec_id == AV_CODEC_ID_HDMV_PGS_SUBTITLE && m_Subtitle.format == 0)
   {
     // for pgs subtitles the packet pts of the end_segments are wrong
     // instead use the subtitle pts to calc the offset here

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -44,7 +44,7 @@ CDVDOverlayCodecSSA::~CDVDOverlayCodecSSA()
 
 bool CDVDOverlayCodecSSA::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
-  if(hints.codec != CODEC_ID_SSA)
+  if(hints.codec != AV_CODEC_ID_SSA)
     return false;
 
   Dispose();

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -75,7 +75,7 @@ CDVDOverlayCodecTX3G::~CDVDOverlayCodecTX3G()
 
 bool CDVDOverlayCodecTX3G::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
-  if (hints.codec == CODEC_ID_MOV_TEXT)
+  if (hints.codec == AV_CODEC_ID_MOV_TEXT)
     return true;
   return false;
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -41,8 +41,8 @@ CDVDOverlayCodecText::~CDVDOverlayCodecText()
 
 bool CDVDOverlayCodecText::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
-  m_bIsSSA = (hints.codec == CODEC_ID_SSA);
-  if(hints.codec == CODEC_ID_TEXT || hints.codec == CODEC_ID_SSA)
+  m_bIsSSA = (hints.codec == AV_CODEC_ID_SSA);
+  if(hints.codec == AV_CODEC_ID_TEXT || hints.codec == AV_CODEC_ID_SSA)
     return true;
 #if defined(LIBAVCODEC_FROM_FFMPEG) && LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54,53,100)
   // API changed in:

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -282,49 +282,49 @@ static int set_pts_pcrscr(int64_t value)
   return -1;
 }
 
-static vformat_t codecid_to_vformat(enum CodecID id)
+static vformat_t codecid_to_vformat(enum AVCodecID id)
 {
   vformat_t format;
   switch (id)
   {
-    case CODEC_ID_MPEG1VIDEO:
-    case CODEC_ID_MPEG2VIDEO:
-    case CODEC_ID_MPEG2VIDEO_XVMC:
+    case AV_CODEC_ID_MPEG1VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO_XVMC:
       format = VFORMAT_MPEG12;
       break;
-    case CODEC_ID_H263:
-    case CODEC_ID_MPEG4:
-    case CODEC_ID_H263P:
-    case CODEC_ID_H263I:
-    case CODEC_ID_MSMPEG4V2:
-    case CODEC_ID_MSMPEG4V3:
-    case CODEC_ID_FLV1:
+    case AV_CODEC_ID_H263:
+    case AV_CODEC_ID_MPEG4:
+    case AV_CODEC_ID_H263P:
+    case AV_CODEC_ID_H263I:
+    case AV_CODEC_ID_MSMPEG4V2:
+    case AV_CODEC_ID_MSMPEG4V3:
+    case AV_CODEC_ID_FLV1:
       format = VFORMAT_MPEG4;
       break;
-    case CODEC_ID_RV10:
-    case CODEC_ID_RV20:
-    case CODEC_ID_RV30:
-    case CODEC_ID_RV40:
+    case AV_CODEC_ID_RV10:
+    case AV_CODEC_ID_RV20:
+    case AV_CODEC_ID_RV30:
+    case AV_CODEC_ID_RV40:
       format = VFORMAT_REAL;
       break;
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
       format = VFORMAT_H264;
       break;
     /*
-    case CODEC_ID_H264MVC:
+    case AV_CODEC_ID_H264MVC:
       // H264 Multiview Video Coding (3d blurays)
       format = VFORMAT_H264MVC;
       break;
     */
-    case CODEC_ID_MJPEG:
+    case AV_CODEC_ID_MJPEG:
       format = VFORMAT_MJPEG;
       break;
-    case CODEC_ID_VC1:
-    case CODEC_ID_WMV3:
+    case AV_CODEC_ID_VC1:
+    case AV_CODEC_ID_WMV3:
       format = VFORMAT_VC1;
       break;
-    case CODEC_ID_AVS:
-    case CODEC_ID_CAVS:
+    case AV_CODEC_ID_AVS:
+    case AV_CODEC_ID_CAVS:
       format = VFORMAT_AVS;
       break;
 
@@ -381,11 +381,11 @@ static vdec_type_t codec_tag_to_vdec_type(unsigned int codec_tag)
     case CODEC_TAG_RMP4:
     case CODEC_TAG_MPG4:
     case CODEC_TAG_mp4v:
-    case CODEC_ID_MPEG4:
+    case AV_CODEC_ID_MPEG4:
       // mp4
       dec_type = VIDEO_DEC_FORMAT_MPEG4_5;
       break;
-    case CODEC_ID_H263:
+    case AV_CODEC_ID_H263:
     case CODEC_TAG_H263:
     case CODEC_TAG_h263:
     case CODEC_TAG_s263:
@@ -397,21 +397,21 @@ static vdec_type_t codec_tag_to_vdec_type(unsigned int codec_tag)
     case CODEC_TAG_avc1:
     case CODEC_TAG_H264:
     case CODEC_TAG_h264:
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
       // h264
       dec_type = VIDEO_DEC_FORMAT_H264;
       break;
     /*
-    case CODEC_ID_H264MVC:
+    case AV_CODEC_ID_H264MVC:
       dec_type = VIDEO_DEC_FORMAT_H264;
       break;
     */
-    case CODEC_ID_RV30:
+    case AV_CODEC_ID_RV30:
     case CODEC_TAG_RV30:
       // realmedia 3
       dec_type = VIDEO_DEC_FORMAT_REAL_8;
       break;
-    case CODEC_ID_RV40:
+    case AV_CODEC_ID_RV40:
     case CODEC_TAG_RV40:
       // realmedia 4
       dec_type = VIDEO_DEC_FORMAT_REAL_9;
@@ -420,19 +420,19 @@ static vdec_type_t codec_tag_to_vdec_type(unsigned int codec_tag)
       // wmv3
       dec_type = VIDEO_DEC_FORMAT_WMV3;
       break;
-    case CODEC_ID_VC1:
+    case AV_CODEC_ID_VC1:
     case CODEC_TAG_VC_1:
     case CODEC_TAG_WVC1:
     case CODEC_TAG_WMVA:
       // vc1
       dec_type = VIDEO_DEC_FORMAT_WVC1;
       break;
-    case CODEC_ID_VP6F:
+    case AV_CODEC_ID_VP6F:
       // vp6
       dec_type = VIDEO_DEC_FORMAT_SW;
       break;
-    case CODEC_ID_CAVS:
-    case CODEC_ID_AVS:
+    case AV_CODEC_ID_CAVS:
+    case AV_CODEC_ID_AVS:
       // avs
       dec_type = VIDEO_DEC_FORMAT_AVS;
       break;
@@ -1129,9 +1129,9 @@ int pre_header_feeding(am_private_t *para, am_packet_t *pkt)
                 return PLAYER_NOMEM;
             }
         }
-        if (( CODEC_ID_MPEG1VIDEO == para->video_codec_id)
-          || (CODEC_ID_MPEG2VIDEO == para->video_codec_id)
-          || (CODEC_ID_MPEG2VIDEO_XVMC == para->video_codec_id)) {
+        if (( AV_CODEC_ID_MPEG1VIDEO == para->video_codec_id)
+          || (AV_CODEC_ID_MPEG2VIDEO == para->video_codec_id)
+          || (AV_CODEC_ID_MPEG2VIDEO_XVMC == para->video_codec_id)) {
             ret = mpeg_add_header(para, pkt);
             if (ret != PLAYER_SUCCESS) {
                 return ret;
@@ -1531,7 +1531,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
 
   // check for SD h264 content incorrectly reported as 60 fsp
   // mp4/avi containers :(
-  if (hints.codec == CODEC_ID_H264 && hints.width <= 720 && am_private->video_rate == 1602)
+  if (hints.codec == AV_CODEC_ID_H264 && hints.width <= 720 && am_private->video_rate == 1602)
   {
     CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder video_rate exception");
     am_private->video_rate = 0.5 + (float)UNIT_FREQ * 1001 / 24000;
@@ -1539,7 +1539,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
 
   // check for SD h264 content incorrectly reported as some form of 30 fsp
   // mp4/avi containers :(
-  if (hints.codec == CODEC_ID_H264 && hints.width <= 720)
+  if (hints.codec == AV_CODEC_ID_H264 && hints.width <= 720)
   {
     if (am_private->video_rate >= 3200 && am_private->video_rate <= 3210)
     {
@@ -1576,7 +1576,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
     am_private->video_codec_type = codec_tag_to_vdec_type(am_private->video_codec_id);
 
   am_private->flv_flag = 0;
-  if (am_private->video_codec_id == CODEC_ID_FLV1)
+  if (am_private->video_codec_id == AV_CODEC_ID_FLV1)
   {
     am_private->video_codec_tag = CODEC_TAG_F263;
     am_private->flv_flag = 1;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -61,12 +61,12 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
 {
   switch(hints.codec)
   {
-    case CODEC_ID_MJPEG:
+    case AV_CODEC_ID_MJPEG:
       m_pFormatName = "am-mjpeg";
       break;
-    case CODEC_ID_MPEG1VIDEO:
-    case CODEC_ID_MPEG2VIDEO:
-    case CODEC_ID_MPEG2VIDEO_XVMC:
+    case AV_CODEC_ID_MPEG1VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO_XVMC:
       m_mpeg2_sequence_pts = 0;
       m_mpeg2_sequence = new mpeg2_sequence;
       m_mpeg2_sequence->width  = hints.width;
@@ -80,36 +80,36 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
         m_mpeg2_sequence->rate = 1.0;
       m_pFormatName = "am-mpeg2";
       break;
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
       m_pFormatName = "am-h264";
       break;
-    case CODEC_ID_MPEG4:
-    case CODEC_ID_MSMPEG4V2:
-    case CODEC_ID_MSMPEG4V3:
+    case AV_CODEC_ID_MPEG4:
+    case AV_CODEC_ID_MSMPEG4V2:
+    case AV_CODEC_ID_MSMPEG4V3:
       m_pFormatName = "am-mpeg4";
       break;
-    case CODEC_ID_H263:
-    case CODEC_ID_H263P:
-    case CODEC_ID_H263I:
+    case AV_CODEC_ID_H263:
+    case AV_CODEC_ID_H263P:
+    case AV_CODEC_ID_H263I:
       m_pFormatName = "am-h263";
       break;
-    case CODEC_ID_FLV1:
+    case AV_CODEC_ID_FLV1:
       m_pFormatName = "am-flv1";
       break;
-    case CODEC_ID_RV10:
-    case CODEC_ID_RV20:
-    case CODEC_ID_RV30:
-    case CODEC_ID_RV40:
+    case AV_CODEC_ID_RV10:
+    case AV_CODEC_ID_RV20:
+    case AV_CODEC_ID_RV30:
+    case AV_CODEC_ID_RV40:
       m_pFormatName = "am-rv";
       break;
-    case CODEC_ID_VC1:
+    case AV_CODEC_ID_VC1:
       m_pFormatName = "am-vc1";
       break;
-    case CODEC_ID_WMV3:
+    case AV_CODEC_ID_WMV3:
       m_pFormatName = "am-wmv3";
       break;
-    case CODEC_ID_AVS:
-    case CODEC_ID_CAVS:
+    case AV_CODEC_ID_AVS:
+    case AV_CODEC_ID_CAVS:
       m_pFormatName = "am-avs";
       break;
     default:

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecCrystalHD.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecCrystalHD.cpp
@@ -55,11 +55,11 @@ bool CDVDVideoCodecCrystalHD::Open(CDVDStreamInfo &hints, CDVDCodecOptions &opti
   {
     switch (hints.codec)
     {
-      case CODEC_ID_MPEG2VIDEO:
+      case AV_CODEC_ID_MPEG2VIDEO:
         m_CodecType = CRYSTALHD_CODEC_ID_MPEG2;
         m_pFormatName = "chd-mpeg2";
       break;
-      case CODEC_ID_H264:
+      case AV_CODEC_ID_H264:
         switch(hints.profile)
         {
           case FF_PROFILE_H264_HIGH_10:
@@ -86,11 +86,11 @@ bool CDVDVideoCodecCrystalHD::Open(CDVDStreamInfo &hints, CDVDCodecOptions &opti
 
         m_pFormatName = "chd-h264";
       break;
-      case CODEC_ID_VC1:
+      case AV_CODEC_ID_VC1:
         m_CodecType = CRYSTALHD_CODEC_ID_VC1;
         m_pFormatName = "chd-vc1";
       break;
-      case CODEC_ID_WMV3:
+      case AV_CODEC_ID_WMV3:
         m_CodecType = CRYSTALHD_CODEC_ID_WMV3;
         m_pFormatName = "chd-wmv3";
       break;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -104,7 +104,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #ifdef HAVE_LIBVA
     // mpeg4 vaapi decoding is disabled
     if(*cur == PIX_FMT_VAAPI_VLD && CSettings::Get().GetBool("videoplayer.usevaapi") 
-    && (avctx->codec_id != CODEC_ID_MPEG4 || g_advancedSettings.m_videoAllowMpeg4VAAPI)) 
+    && (avctx->codec_id != AV_CODEC_ID_MPEG4 || g_advancedSettings.m_videoAllowMpeg4VAAPI)) 
     {
       if (ctx->GetHardware() != NULL)
       {
@@ -198,7 +198,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   pCodec = NULL;
   m_pCodecContext = NULL;
 
-  if (hints.codec == CODEC_ID_H264)
+  if (hints.codec == AV_CODEC_ID_H264)
   {
     switch(hints.profile)
     {
@@ -256,8 +256,8 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   // ffmpeg with enabled neon will crash and burn if this is enabled
   m_pCodecContext->flags &= CODEC_FLAG_EMU_EDGE;
 #else
-  if (pCodec->id != CODEC_ID_H264 && pCodec->capabilities & CODEC_CAP_DR1
-      && pCodec->id != CODEC_ID_VP8
+  if (pCodec->id != AV_CODEC_ID_H264 && pCodec->capabilities & CODEC_CAP_DR1
+      && pCodec->id != AV_CODEC_ID_VP8
      )
     m_pCodecContext->flags |= CODEC_FLAG_EMU_EDGE;
 #endif
@@ -292,8 +292,8 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 
   int num_threads = std::min(8 /*MAX_THREADS*/, g_cpuInfo.getCPUCount());
   if( num_threads > 1 && !hints.software && m_pHardware == NULL // thumbnail extraction fails when run threaded
-  && ( pCodec->id == CODEC_ID_H264
-    || pCodec->id == CODEC_ID_MPEG4 ))
+  && ( pCodec->id == AV_CODEC_ID_H264
+    || pCodec->id == AV_CODEC_ID_MPEG4 ))
     m_pCodecContext->thread_count = num_threads;
 
   if (m_dllAvCodec.avcodec_open2(m_pCodecContext, pCodec, NULL) < 0)
@@ -492,8 +492,8 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
     m_iLastKeyframe = 300;
 
   /* h264 doesn't always have keyframes + won't output before first keyframe anyway */
-  if(m_pCodecContext->codec_id == CODEC_ID_H264
-  || m_pCodecContext->codec_id == CODEC_ID_SVQ3)
+  if(m_pCodecContext->codec_id == AV_CODEC_ID_H264
+  || m_pCodecContext->codec_id == AV_CODEC_ID_SVQ3)
     m_started = true;
 
   if(m_pHardware == NULL)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecOpenMax.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecOpenMax.cpp
@@ -57,7 +57,7 @@ bool CDVDVideoCodecOpenMax::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
 
     switch (hints.codec)
     {
-      case CODEC_ID_H264:
+      case AV_CODEC_ID_H264:
       {
         m_pFormatName = "omx-h264";
         if (hints.extrasize < 7 || hints.extradata == NULL)
@@ -71,13 +71,13 @@ bool CDVDVideoCodecOpenMax::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
           m_convert_bitstream = bitstream_convert_init(hints.extradata, hints.extrasize);
       }
       break;
-      case CODEC_ID_MPEG4:
+      case AV_CODEC_ID_MPEG4:
         m_pFormatName = "omx-mpeg4";
       break;
-      case CODEC_ID_MPEG2VIDEO:
+      case AV_CODEC_ID_MPEG2VIDEO:
         m_pFormatName = "omx-mpeg2";
       break;
-      case CODEC_ID_VC1:
+      case AV_CODEC_ID_VC1:
         m_pFormatName = "omx-vc1";
       break;
       default:

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVDA.cpp
@@ -192,7 +192,7 @@ bool CDVDVideoCodecVDA::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
     CFDataRef avcCData;
     switch (hints.codec)
     {
-      case CODEC_ID_H264:
+      case AV_CODEC_ID_H264:
         m_bitstream = new CBitstreamConverter;
         if (!m_bitstream->Open(hints.codec, (uint8_t*)hints.extradata, hints.extrasize, false))
           return false;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVideoToolBox.cpp
@@ -538,7 +538,7 @@ quicktime_esds_t* quicktime_set_esds(DllAvFormat *av_format_ctx, const uint8_t *
   esds->esid            = 0;
   esds->stream_priority = 0;      // 16 ? 0x1f
   
-  esds->objectTypeId    = 32;     // 32 = CODEC_ID_MPEG4, 33 = CODEC_ID_H264
+  esds->objectTypeId    = 32;     // 32 = AV_CODEC_ID_MPEG4, 33 = AV_CODEC_ID_H264
   // the following fields is made of 6 bits to identify the streamtype (4 for video, 5 for audio)
   // plus 1 bit to indicate upstream and 1 bit set to 1 (reserved)
   esds->streamType      = 0x11;
@@ -1097,7 +1097,7 @@ bool CDVDVideoCodecVideoToolBox::Open(CDVDStreamInfo &hints, CDVDCodecOptions &o
     
     switch (hints.codec)
     {
-      case CODEC_ID_MPEG4:
+      case AV_CODEC_ID_MPEG4:
         if (extrasize)
         {
           AVIOContext *pb;
@@ -1129,12 +1129,12 @@ bool CDVDVideoCodecVideoToolBox::Open(CDVDStreamInfo &hints, CDVDCodecOptions &o
         m_pFormatName = "vtb-mpeg4";
       break;
 
-      case CODEC_ID_MPEG2VIDEO:
+      case AV_CODEC_ID_MPEG2VIDEO:
         m_fmt_desc = CreateFormatDescription(kVTFormatMPEG2Video, width, height);
         m_pFormatName = "vtb-mpeg2";
       break;
 
-      case CODEC_ID_H264:
+      case AV_CODEC_ID_H264:
         if (extrasize < 7 || extradata == NULL)
         {
           //m_fmt_desc = CreateFormatDescription(kVTFormatH264, width, height);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -97,19 +97,19 @@ typedef struct {
 
 /* XXX Prefered modes must come first */
 static const dxva2_mode_t dxva2_modes[] = {
-    { "MPEG2 VLD",    &DXVA2_ModeMPEG2_VLD,     CODEC_ID_MPEG2VIDEO },
-    { "MPEG1/2 VLD",  &DXVA_ModeMPEG2and1_VLD,  CODEC_ID_MPEG2VIDEO },
+    { "MPEG2 VLD",    &DXVA2_ModeMPEG2_VLD,     AV_CODEC_ID_MPEG2VIDEO },
+    { "MPEG1/2 VLD",  &DXVA_ModeMPEG2and1_VLD,  AV_CODEC_ID_MPEG2VIDEO },
     { "MPEG2 MoComp", &DXVA2_ModeMPEG2_MoComp,  0 },
     { "MPEG2 IDCT",   &DXVA2_ModeMPEG2_IDCT,    0 },
 
     // Intel drivers return standard modes in addition to the Intel specific ones. Try the Intel specific first, they work better for Sandy Bridges.
-    { "Intel H.264 VLD, no FGT",                                      &DXVADDI_Intel_ModeH264_E, CODEC_ID_H264 },
+    { "Intel H.264 VLD, no FGT",                                      &DXVADDI_Intel_ModeH264_E, AV_CODEC_ID_H264 },
     { "Intel H.264 inverse discrete cosine transform (IDCT), no FGT", &DXVADDI_Intel_ModeH264_C, 0 },
     { "Intel H.264 motion compensation (MoComp), no FGT",             &DXVADDI_Intel_ModeH264_A, 0 },
     { "Intel VC-1 VLD",                                               &DXVADDI_Intel_ModeVC1_E,  0 },
 
-    { "H.264 variable-length decoder (VLD), FGT",               &DXVA2_ModeH264_F, CODEC_ID_H264 },
-    { "H.264 VLD, no FGT",                                      &DXVA2_ModeH264_E, CODEC_ID_H264 },
+    { "H.264 variable-length decoder (VLD), FGT",               &DXVA2_ModeH264_F, AV_CODEC_ID_H264 },
+    { "H.264 VLD, no FGT",                                      &DXVA2_ModeH264_E, AV_CODEC_ID_H264 },
     { "H.264 IDCT, FGT",                                        &DXVA2_ModeH264_D, 0,            },
     { "H.264 inverse discrete cosine transform (IDCT), no FGT", &DXVA2_ModeH264_C, 0,            },
     { "H.264 MoComp, FGT",                                      &DXVA2_ModeH264_B, 0,            },
@@ -122,10 +122,10 @@ static const dxva2_mode_t dxva2_modes[] = {
     { "Windows Media Video 9 MoComp",           &DXVA2_ModeWMV9_B, 0 },
     { "Windows Media Video 9 post processing",  &DXVA2_ModeWMV9_A, 0 },
 
-    { "VC-1 VLD",             &DXVA2_ModeVC1_D,    CODEC_ID_VC1 },
-    { "VC-1 VLD",             &DXVA2_ModeVC1_D,    CODEC_ID_WMV3 },
-    { "VC-1 VLD 2010",        &DXVA_ModeVC1_D2010, CODEC_ID_VC1 },
-    { "VC-1 VLD 2010",        &DXVA_ModeVC1_D2010, CODEC_ID_WMV3 },
+    { "VC-1 VLD",             &DXVA2_ModeVC1_D,    AV_CODEC_ID_VC1 },
+    { "VC-1 VLD",             &DXVA2_ModeVC1_D,    AV_CODEC_ID_WMV3 },
+    { "VC-1 VLD 2010",        &DXVA_ModeVC1_D2010, AV_CODEC_ID_VC1 },
+    { "VC-1 VLD 2010",        &DXVA_ModeVC1_D2010, AV_CODEC_ID_WMV3 },
     { "VC-1 IDCT",            &DXVA2_ModeVC1_C,    0 },
     { "VC-1 MoComp",          &DXVA2_ModeVC1_B,    0 },
     { "VC-1 post processing", &DXVA2_ModeVC1_A,    0 },
@@ -437,7 +437,7 @@ static bool HasVP3WidthBug(AVCodecContext *avctx)
 static bool CheckCompatibility(AVCodecContext *avctx)
 {
   // The incompatibilities are all for H264
-  if(avctx->codec_id != CODEC_ID_H264)
+  if(avctx->codec_id != AV_CODEC_ID_H264)
     return true;
 
   // Macroblock width incompatibility
@@ -628,7 +628,7 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
 
   if(m_refs == 0)
   {
-    if(avctx->codec_id == CODEC_ID_H264)
+    if(avctx->codec_id == AV_CODEC_ID_H264)
       m_refs = 16;
     else
       m_refs = 2;
@@ -773,9 +773,9 @@ int CDecoder::Check(AVCodecContext* avctx)
   }
 
   // Status reports are available only for the DXVA2_ModeH264 and DXVA2_ModeVC1 modes
-  if(avctx->codec_id != CODEC_ID_H264
-  && avctx->codec_id != CODEC_ID_VC1
-  && avctx->codec_id != CODEC_ID_WMV3)
+  if(avctx->codec_id != AV_CODEC_ID_H264
+  && avctx->codec_id != AV_CODEC_ID_VC1
+  && avctx->codec_id != AV_CODEC_ID_WMV3)
     return 0;
 
   DXVA2_DecodeExecuteParams params = {};
@@ -788,7 +788,7 @@ int CDecoder::Check(AVCodecContext* avctx)
   params.pExtensionData = &data;
   data.Function = DXVA_STATUS_REPORTING_FUNCTION;
   data.pPrivateOutputData    = &status;
-  data.PrivateOutputDataSize = avctx->codec_id == CODEC_ID_H264 ? sizeof(DXVA_Status_H264) : sizeof(DXVA_Status_VC1);
+  data.PrivateOutputDataSize = avctx->codec_id == AV_CODEC_ID_H264 ? sizeof(DXVA_Status_H264) : sizeof(DXVA_Status_VC1);
   HRESULT hr;
   if(FAILED( hr = m_decoder->Execute(&params)))
   {
@@ -796,7 +796,7 @@ int CDecoder::Check(AVCodecContext* avctx)
     return VC_ERROR;
   }
 
-  if(avctx->codec_id == CODEC_ID_H264)
+  if(avctx->codec_id == AV_CODEC_ID_H264)
   {
     if(status.h264.bStatus)
       CLog::Log(LOGWARNING, "DXVA - decoder problem of status %d with %d", status.h264.bStatus, status.h264.bBufType);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/OpenMaxVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/OpenMaxVideo.cpp
@@ -124,7 +124,7 @@ bool COpenMaxVideo::Open(CDVDStreamInfo &hints)
 
   switch (hints.codec)
   {
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
     {
       switch(hints.profile)
       {
@@ -149,7 +149,7 @@ bool COpenMaxVideo::Open(CDVDStreamInfo &hints)
       }
     }
     break;
-    case CODEC_ID_MPEG4:
+    case AV_CODEC_ID_MPEG4:
       // (role name) video_decoder.mpeg4
       // MPEG-4, DivX 4/5 and Xvid compatible
       decoder_name = OMX_MPEG4_DECODER;
@@ -163,12 +163,12 @@ bool COpenMaxVideo::Open(CDVDStreamInfo &hints)
       m_pFormatName = "omx-mpeg4";
     break;
     */
-    case CODEC_ID_MPEG2VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO:
       // (role name) video_decoder.mpeg2
       // MPEG-2
       decoder_name = OMX_MPEG2V_DECODER;
     break;
-    case CODEC_ID_VC1:
+    case AV_CODEC_ID_VC1:
       // (role name) video_decoder.vc1
       // VC-1, WMV9
       decoder_name = OMX_VC1_DECODER;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -268,14 +268,14 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
 
   vector<VAProfile> accepted;
   switch (avctx->codec_id) {
-    case CODEC_ID_MPEG2VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO:
       accepted.push_back(VAProfileMPEG2Main);
       break;
-    case CODEC_ID_MPEG4:
-    case CODEC_ID_H263:
+    case AV_CODEC_ID_MPEG4:
+    case AV_CODEC_ID_H263:
       accepted.push_back(VAProfileMPEG4AdvancedSimple);
       break;
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
     {
 #ifdef FF_PROFILE_H264_BASELINE
       if  (avctx->profile == FF_PROFILE_H264_BASELINE)
@@ -294,10 +294,10 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
       }
       break;
     }
-    case CODEC_ID_WMV3:
+    case AV_CODEC_ID_WMV3:
       accepted.push_back(VAProfileVC1Main);
       break;
-    case CODEC_ID_VC1:
+    case AV_CODEC_ID_VC1:
       accepted.push_back(VAProfileVC1Advanced);
       break;
     default:
@@ -384,7 +384,7 @@ bool CDecoder::EnsureContext(AVCodecContext *avctx)
   m_refs = avctx->refs;
   if(m_refs == 0)
   {
-    if(avctx->codec_id == CODEC_ID_H264)
+    if(avctx->codec_id == AV_CODEC_ID_H264)
       m_refs = 16;
     else
       m_refs = 2;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -185,7 +185,7 @@ bool CVDPAU::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int su
     return false;
   }
 
-  if ((avctx->codec_id == CODEC_ID_MPEG4) && !g_advancedSettings.m_videoAllowMpeg4VDPAU)
+  if ((avctx->codec_id == AV_CODEC_ID_MPEG4) && !g_advancedSettings.m_videoAllowMpeg4VDPAU)
     return false;
 
   if (!dl_handle)
@@ -214,10 +214,10 @@ bool CVDPAU::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int su
     SpewHardwareAvailable();
 
     VdpDecoderProfile profile = 0;
-    if(avctx->codec_id == CODEC_ID_H264)
+    if(avctx->codec_id == AV_CODEC_ID_H264)
       profile = VDP_DECODER_PROFILE_H264_HIGH;
 #ifdef VDP_DECODER_PROFILE_MPEG4_PART2_ASP
-    else if(avctx->codec_id == CODEC_ID_MPEG4)
+    else if(avctx->codec_id == AV_CODEC_ID_MPEG4)
       profile = VDP_DECODER_PROFILE_MPEG4_PART2_ASP;
 #endif
     if(profile)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -30,8 +30,8 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
 {
   char sInfo[64];
 
-  if (codec == CODEC_ID_AC3) strcpy(sInfo, "AC3 ");
-  else if (codec == CODEC_ID_DTS)
+  if (codec == AV_CODEC_ID_AC3) strcpy(sInfo, "AC3 ");
+  else if (codec == AV_CODEC_ID_DTS)
   {
 #ifdef FF_PROFILE_DTS_HD_MA
     if (profile == FF_PROFILE_DTS_HD_MA)
@@ -42,8 +42,8 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
 #endif
       strcpy(sInfo, "DTS ");
   }
-  else if (codec == CODEC_ID_MP2) strcpy(sInfo, "MP2 ");
-  else if (codec == CODEC_ID_TRUEHD) strcpy(sInfo, "Dolby TrueHD ");
+  else if (codec == AV_CODEC_ID_MP2) strcpy(sInfo, "MP2 ");
+  else if (codec == AV_CODEC_ID_TRUEHD) strcpy(sInfo, "Dolby TrueHD ");
   else strcpy(sInfo, "");
 
   if (iChannels == 1) strcat(sInfo, "Mono");

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -35,7 +35,7 @@ class CDVDInputStream;
   #include "config.h"
 #endif
 #ifndef TARGET_POSIX
-// enum CodecID; // auto defined when neccesary
+// enum AVCodecID; // auto defined when neccesary
 #include <libavcodec/avcodec.h>
 #else
 extern "C" {
@@ -88,7 +88,7 @@ public:
   {
     iId = 0;
     iPhysicalId = 0;
-    codec = (CodecID)0; // CODEC_ID_NONE
+    codec = (AVCodecID)0; // AV_CODEC_ID_NONE
     codec_fourcc = 0;
     profile = FF_PROFILE_UNKNOWN;
     level = 0;
@@ -122,7 +122,7 @@ public:
 
   int iId;         // most of the time starting from 0
   int iPhysicalId; // id
-  CodecID codec;
+  AVCodecID codec;
   unsigned int codec_fourcc; // if available
   int profile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
   int level;   // encoder level of the stream reported by the decoder. used to qualify hw decoders.

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxBXA.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxBXA.cpp
@@ -91,7 +91,7 @@ bool CDVDDemuxBXA::Open(CDVDInputStream* pInput)
   m_stream->iBitRate        = m_header.sampleRate * m_header.channels * m_header.bitsPerSample;
   m_stream->iChannels       = m_header.channels;
   m_stream->type            = STREAM_AUDIO;
-  m_stream->codec           = CODEC_ID_PCM_S16LE;
+  m_stream->codec           = AV_CODEC_ID_PCM_S16LE;
 
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCDDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCDDA.cpp
@@ -71,7 +71,7 @@ bool CDVDDemuxCDDA::Open(CDVDInputStream* pInput)
   m_stream->iBitRate        = 44100 * 2 * 16;
   m_stream->iChannels       = 2;
   m_stream->type            = STREAM_AUDIO;
-  m_stream->codec           = CODEC_ID_PCM_S16LE;
+  m_stream->codec           = AV_CODEC_ID_PCM_S16LE;
 
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -464,7 +464,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
       CLog::Log(LOGWARNING,"could not find codec parameters for %s", strFile.c_str());
       if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD)
       ||  m_pInput->IsStreamType(DVDSTREAM_TYPE_BLURAY)
-      || (m_pFormatContext->nb_streams == 1 && m_pFormatContext->streams[0]->codec->codec_id == CODEC_ID_AC3))
+      || (m_pFormatContext->nb_streams == 1 && m_pFormatContext->streams[0]->codec->codec_id == AV_CODEC_ID_AC3))
       {
         // special case, our codecs can still handle it.
       }
@@ -758,7 +758,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
         }
 
         // we need to get duration slightly different for matroska embedded text subtitels
-        if(m_bMatroska && stream->codec->codec_id == CODEC_ID_TEXT && m_pkt.pkt.convergence_duration != 0)
+        if(m_bMatroska && stream->codec->codec_id == AV_CODEC_ID_TEXT && m_pkt.pkt.convergence_duration != 0)
           m_pkt.pkt.duration = m_pkt.pkt.convergence_duration;
 
         if(m_bAVI && stream->codec && stream->codec->codec_type == AVMEDIA_TYPE_VIDEO)
@@ -1090,7 +1090,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
           st->bVFR = false;
 
         // never trust pts in avi files with h264.
-        if (m_bAVI && pStream->codec->codec_id == CODEC_ID_H264)
+        if (m_bAVI && pStream->codec->codec_id == AV_CODEC_ID_H264)
           st->bPTSInvalid = true;
 
         //average fps is more accurate for mkv files
@@ -1143,15 +1143,15 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
         
         if ( m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD) )
         {
-          if (pStream->codec->codec_id == CODEC_ID_PROBE)
+          if (pStream->codec->codec_id == AV_CODEC_ID_PROBE)
           {
-            // fix MPEG-1/MPEG-2 video stream probe returning CODEC_ID_PROBE for still frames.
+            // fix MPEG-1/MPEG-2 video stream probe returning AV_CODEC_ID_PROBE for still frames.
             // ffmpeg issue 1871, regression from ffmpeg r22831.
             if ((pStream->id & 0xF0) == 0xE0)
             {
-              pStream->codec->codec_id = CODEC_ID_MPEG2VIDEO;
+              pStream->codec->codec_id = AV_CODEC_ID_MPEG2VIDEO;
               pStream->codec->codec_tag = MKTAG('M','P','2','V');
-              CLog::Log(LOGERROR, "%s - CODEC_ID_PROBE detected, forcing CODEC_ID_MPEG2VIDEO", __FUNCTION__);
+              CLog::Log(LOGERROR, "%s - AV_CODEC_ID_PROBE detected, forcing AV_CODEC_ID_MPEG2VIDEO", __FUNCTION__);
             }
           }
         }
@@ -1165,7 +1165,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
       }
     case AVMEDIA_TYPE_SUBTITLE:
       {
-        if (pStream->codec->codec_id == CODEC_ID_DVB_TELETEXT && CSettings::Get().GetBool("videoplayer.teletextenabled"))
+        if (pStream->codec->codec_id == AV_CODEC_ID_DVB_TELETEXT && CSettings::Get().GetBool("videoplayer.teletextenabled"))
         {
           CDemuxStreamTeletext* st = new CDemuxStreamTeletext();
           stream = st;
@@ -1185,9 +1185,9 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
       }
     case AVMEDIA_TYPE_ATTACHMENT:
       { //mkv attachments. Only bothering with fonts for now.
-        if(pStream->codec->codec_id == CODEC_ID_TTF
+        if(pStream->codec->codec_id == AV_CODEC_ID_TTF
 #if (!defined USE_EXTERNAL_FFMPEG)
-          || pStream->codec->codec_id == CODEC_ID_OTF
+          || pStream->codec->codec_id == AV_CODEC_ID_OTF
 #endif
           )
         {
@@ -1256,19 +1256,19 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
       // id's reported from libdvdnav
       switch(stream->codec)
       {
-        case CODEC_ID_AC3:
+        case AV_CODEC_ID_AC3:
           stream->iPhysicalId = pStream->id - 128;
           break;
-        case CODEC_ID_DTS:
+        case AV_CODEC_ID_DTS:
           stream->iPhysicalId = pStream->id - 136;
           break;
-        case CODEC_ID_MP2:
+        case AV_CODEC_ID_MP2:
           stream->iPhysicalId = pStream->id - 448;
           break;
-        case CODEC_ID_PCM_S16BE:
+        case AV_CODEC_ID_PCM_S16BE:
           stream->iPhysicalId = pStream->id - 160;
           break;
-        case CODEC_ID_DVD_SUBTITLE:
+        case AV_CODEC_ID_DVD_SUBTITLE:
           stream->iPhysicalId = pStream->id - 0x20;
           break;
         default:
@@ -1434,7 +1434,7 @@ void CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId, CStdString &strName)
 
 #ifdef FF_PROFILE_DTS_HD_MA
     /* use profile to determine the DTS type */
-    if (stream->codec == CODEC_ID_DTS)
+    if (stream->codec == AV_CODEC_ID_DTS)
     {
       if (stream->profile == FF_PROFILE_DTS_HD_MA)
         strName = "dtshd_ma";

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
@@ -290,29 +290,29 @@ void CDVDDemuxHTSP::SubscriptionStart (htsmsg_t *m)
 
     if(!strcmp(type, "AC3")) {
       st.a = new CDemuxStreamAudioHTSP(this, type);
-      st.a->codec = CODEC_ID_AC3;
+      st.a->codec = AV_CODEC_ID_AC3;
     } else if(!strcmp(type, "EAC3")) {
       st.a = new CDemuxStreamAudioHTSP(this, type);
-      st.a->codec = CODEC_ID_EAC3;
+      st.a->codec = AV_CODEC_ID_EAC3;
     } else if(!strcmp(type, "MPEG2AUDIO")) {
       st.a = new CDemuxStreamAudioHTSP(this, type);
-      st.a->codec = CODEC_ID_MP2;
+      st.a->codec = AV_CODEC_ID_MP2;
     } else if(!strcmp(type, "AAC")) {
       st.a = new CDemuxStreamAudioHTSP(this, type);
-      st.a->codec = CODEC_ID_AAC;
+      st.a->codec = AV_CODEC_ID_AAC;
     } else if(!strcmp(type, "MPEG2VIDEO")) {
       st.v = new CDemuxStreamVideoHTSP(this, type);
-      st.v->codec = CODEC_ID_MPEG2VIDEO;
+      st.v->codec = AV_CODEC_ID_MPEG2VIDEO;
       st.v->iWidth  = htsmsg_get_u32_or_default(sub, "width" , 0);
       st.v->iHeight = htsmsg_get_u32_or_default(sub, "height", 0);
     } else if(!strcmp(type, "H264")) {
       st.v = new CDemuxStreamVideoHTSP(this, type);
-      st.v->codec = CODEC_ID_H264;
+      st.v->codec = AV_CODEC_ID_H264;
       st.v->iWidth  = htsmsg_get_u32_or_default(sub, "width" , 0);
       st.v->iHeight = htsmsg_get_u32_or_default(sub, "height", 0);
     } else if(!strcmp(type, "DVBSUB")) {
       st.s = new CDemuxStreamSubtitle();
-      st.s->codec = CODEC_ID_DVB_SUBTITLE;
+      st.s->codec = AV_CODEC_ID_DVB_SUBTITLE;
       uint32_t composition_id = 0, ancillary_id = 0;
       htsmsg_get_u32(sub, "composition_id", &composition_id);
       htsmsg_get_u32(sub, "ancillary_id"  , &ancillary_id);
@@ -325,10 +325,10 @@ void CDVDDemuxHTSP::SubscriptionStart (htsmsg_t *m)
       }
     } else if(!strcmp(type, "TEXTSUB")) {
       st.s = new CDemuxStreamSubtitle();
-      st.s->codec = CODEC_ID_TEXT;
+      st.s->codec = AV_CODEC_ID_TEXT;
     } else if(!strcmp(type, "TELETEXT")) {
       st.t = new CDemuxStreamTeletext();
-      st.t->codec = CODEC_ID_DVB_TELETEXT;
+      st.t->codec = AV_CODEC_ID_DVB_TELETEXT;
     } else {
       continue;
     }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -61,10 +61,10 @@ void CDemuxStreamVideoPVRClient::GetStreamInfo(std::string& strInfo)
 {
   switch (codec)
   {
-    case CODEC_ID_MPEG2VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO:
       strInfo = "mpeg2video";
       break;
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
       strInfo = "h264";
       break;
     default:
@@ -76,19 +76,19 @@ void CDemuxStreamAudioPVRClient::GetStreamInfo(std::string& strInfo)
 {
   switch (codec)
   {
-    case CODEC_ID_AC3:
+    case AV_CODEC_ID_AC3:
       strInfo = "ac3";
       break;
-    case CODEC_ID_EAC3:
+    case AV_CODEC_ID_EAC3:
       strInfo = "eac3";
       break;
-    case CODEC_ID_MP2:
+    case AV_CODEC_ID_MP2:
       strInfo = "mpeg2audio";
       break;
-    case CODEC_ID_AAC:
+    case AV_CODEC_ID_AAC:
       strInfo = "aac";
       break;
-    case CODEC_ID_DTS:
+    case AV_CODEC_ID_DTS:
       strInfo = "dts";
       break;
     default:
@@ -340,7 +340,7 @@ void CDVDDemuxPVRClient::RequestStreams()
       {
         st = dynamic_cast<CDemuxStreamAudioPVRClient*>(stm);
         if (!st
-            || (st->codec != (CodecID)props.stream[i].iCodecId)
+            || (st->codec != (AVCodecID)props.stream[i].iCodecId)
             || (st->iChannels != props.stream[i].iChannels))
           DisposeStream(i);
       }
@@ -366,7 +366,7 @@ void CDVDDemuxPVRClient::RequestStreams()
       {
         st = dynamic_cast<CDemuxStreamVideoPVRClient*>(stm);
         if (!st
-            || (st->codec != (CodecID)props.stream[i].iCodecId)
+            || (st->codec != (AVCodecID)props.stream[i].iCodecId)
             || (st->iWidth != props.stream[i].iWidth)
             || (st->iHeight != props.stream[i].iHeight))
           DisposeStream(i);
@@ -386,11 +386,11 @@ void CDVDDemuxPVRClient::RequestStreams()
       m_streams[i] = st;
       st->m_parser_split = true;
     }
-    else if (props.stream[i].iCodecId == CODEC_ID_DVB_TELETEXT)
+    else if (props.stream[i].iCodecId == AV_CODEC_ID_DVB_TELETEXT)
     {
       if (stm)
       {
-        if (stm->codec != (CodecID)props.stream[i].iCodecId)
+        if (stm->codec != (AVCodecID)props.stream[i].iCodecId)
           DisposeStream(i);
       }
       if (!m_streams[i])
@@ -402,7 +402,7 @@ void CDVDDemuxPVRClient::RequestStreams()
       if (stm)
       {
         st = dynamic_cast<CDemuxStreamSubtitlePVRClient*>(stm);
-        if (!st || (st->codec != (CodecID)props.stream[i].iCodecId))
+        if (!st || (st->codec != (AVCodecID)props.stream[i].iCodecId))
           DisposeStream(i);
       }
       if (!m_streams[i])
@@ -425,7 +425,7 @@ void CDVDDemuxPVRClient::RequestStreams()
       m_streams[i] = new CDemuxStream();
     }
 
-    m_streams[i]->codec       = (CodecID)props.stream[i].iCodecId;
+    m_streams[i]->codec       = (AVCodecID)props.stream[i].iCodecId;
     m_streams[i]->iId         = i;
     m_streams[i]->iPhysicalId = props.stream[i].iPhysicalId;
     m_streams[i]->language[0] = props.stream[i].strLanguage[0];
@@ -472,19 +472,19 @@ void CDVDDemuxPVRClient::GetStreamCodecName(int iStreamId, CStdString &strName)
   CDemuxStream *stream = GetStream(iStreamId);
   if (stream)
   {
-    if (stream->codec == CODEC_ID_AC3)
+    if (stream->codec == AV_CODEC_ID_AC3)
       strName = "ac3";
-    else if (stream->codec == CODEC_ID_MP2)
+    else if (stream->codec == AV_CODEC_ID_MP2)
       strName = "mp2";
-    else if (stream->codec == CODEC_ID_AAC)
+    else if (stream->codec == AV_CODEC_ID_AAC)
       strName = "aac";
-    else if (stream->codec == CODEC_ID_DTS)
+    else if (stream->codec == AV_CODEC_ID_DTS)
       strName = "dca";
-    else if (stream->codec == CODEC_ID_MPEG2VIDEO)
+    else if (stream->codec == AV_CODEC_ID_MPEG2VIDEO)
       strName = "mpeg2video";
-    else if (stream->codec == CODEC_ID_H264)
+    else if (stream->codec == AV_CODEC_ID_H264)
       strName = "h264";
-    else if (stream->codec == CODEC_ID_EAC3)
+    else if (stream->codec == AV_CODEC_ID_EAC3)
       strName = "eac3";
   }
 }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxShoutcast.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxShoutcast.cpp
@@ -86,12 +86,12 @@ bool CDVDDemuxShoutcast::Open(CDVDInputStream* pInput)
       stricmp(strMimeType.c_str(), CONTENT_TYPE_AACPLUS) == 0)
   {
     // need an aac decoder first
-    m_pDemuxStream->codec = CODEC_ID_AAC;
+    m_pDemuxStream->codec = AV_CODEC_ID_AAC;
   }
   else // (stricmp(strMimeType, CONTENT_TYPE_MP3) == 0)
   {
     // default to mp3
-    m_pDemuxStream->codec = CODEC_ID_MP3;
+    m_pDemuxStream->codec = AV_CODEC_ID_MP3;
   }
 
   return true;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -71,7 +71,7 @@ bool CDVDDemuxVobsub::Open(const string& filename, const string& subfilename)
 
   CDVDStreamInfo hints;
   CDVDCodecOptions options;
-  hints.codec = CODEC_ID_DVD_SUBTITLE;
+  hints.codec = AV_CODEC_ID_DVD_SUBTITLE;
 
   char line[2048];
   DECLARE_UNUSED(bool,res)
@@ -212,7 +212,7 @@ bool CDVDDemuxVobsub::ParseId(SState& state, char* line)
   else
     stream->iPhysicalId = -1;
 
-  stream->codec = CODEC_ID_DVD_SUBTITLE;
+  stream->codec = AV_CODEC_ID_DVD_SUBTITLE;
   stream->iId = m_Streams.size();
 
   state.id = stream->iId;

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -162,7 +162,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
     CDVDStreamInfo hint(*pDemuxer->GetStream(nVideoStream), true);
     hint.software = true;
 
-    if (hint.codec == CODEC_ID_MPEG2VIDEO || hint.codec == CODEC_ID_MPEG1VIDEO)
+    if (hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_MPEG1VIDEO)
     {
       // libmpeg2 is not thread safe so use ffmepg for mpeg2/mpeg1 thumb extraction
       CDVDCodecOptions dvdOptions;

--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
@@ -85,7 +85,7 @@ void CDVDPlayerSubtitle::SendMessage(CDVDMsg* pMsg)
         }
       }
     }
-    else if (m_streaminfo.codec == CODEC_ID_DVD_SUBTITLE)
+    else if (m_streaminfo.codec == AV_CODEC_ID_DVD_SUBTITLE)
     {
       CDVDOverlaySpu* pSPUInfo = m_dvdspus.AddData(pPacket->pData, pPacket->iSize, pPacket->pts);
       if (pSPUInfo)
@@ -169,7 +169,7 @@ bool CDVDPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, string &filename)
   }
 
   // dvd's use special subtitle decoder
-  if(hints.codec == CODEC_ID_DVD_SUBTITLE && filename == "dvd")
+  if(hints.codec == AV_CODEC_ID_DVD_SUBTITLE && filename == "dvd")
     return true;
 
   m_pOverlayCodec = CDVDFactoryCodec::CreateOverlayCodec(hints);

--- a/xbmc/cores/dvdplayer/DVDPlayerTeletext.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerTeletext.cpp
@@ -113,7 +113,7 @@ CDVDTeletextData::~CDVDTeletextData()
 
 bool CDVDTeletextData::CheckStream(CDVDStreamInfo &hints)
 {
-  if (hints.codec == CODEC_ID_DVB_TELETEXT)
+  if (hints.codec == AV_CODEC_ID_DVB_TELETEXT)
     return true;
 
   return false;
@@ -123,7 +123,7 @@ bool CDVDTeletextData::OpenStream(CDVDStreamInfo &hints)
 {
   m_messageQueue.Init();
 
-  if (hints.codec == CODEC_ID_DVB_TELETEXT)
+  if (hints.codec == AV_CODEC_ID_DVB_TELETEXT)
   {
     CLog::Log(LOGNOTICE, "Creating teletext data thread");
     Create();

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -31,7 +31,6 @@
 #include "cores/VideoRenderers/RenderManager.h"
 #endif
 
-enum CodecID;
 class CDemuxStreamVideo;
 class CDVDOverlayCodecCC;
 

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
@@ -38,7 +38,7 @@ CDVDStreamInfo::~CDVDStreamInfo()
 
 void CDVDStreamInfo::Clear()
 {
-  codec = CODEC_ID_NONE;
+  codec = AV_CODEC_ID_NONE;
   type = STREAM_NONE;
   software = false;
   codec_tag  = 0;

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.h
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.h
@@ -55,7 +55,7 @@ public:
   void Assign(const CDVDStreamInfo &right, bool withextradata);
   void Assign(const CDemuxStream &right, bool withextradata);
 
-  CodecID codec;
+  AVCodecID codec;
   StreamType type;
   bool software;  //force software decoding
 

--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -1049,17 +1049,17 @@ void COMXAudio::SetCodingType(AEDataFormat dataFormat)
   } 
 }
 
-bool COMXAudio::CanHWDecode(CodecID codec)
+bool COMXAudio::CanHWDecode(AVCodecID codec)
 {
   bool ret = false;
   switch(codec)
   { 
-    case CODEC_ID_DTS:
+    case AV_CODEC_ID_DTS:
       CLog::Log(LOGDEBUG, "COMXAudio::CanHWDecode OMX_AUDIO_CodingDTS\n");
       ret = true;
       break;
-    case CODEC_ID_AC3:
-    case CODEC_ID_EAC3:
+    case AV_CODEC_ID_AC3:
+    case AV_CODEC_ID_EAC3:
       CLog::Log(LOGDEBUG, "COMXAudio::CanHWDecode OMX_AUDIO_CodingDDP\n");
       ret = true;
       break;

--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -83,7 +83,7 @@ public:
   void Process();
 
   void SetCodingType(AEDataFormat dataFormat);
-  static bool CanHWDecode(CodecID codec);
+  static bool CanHWDecode(AVCodecID codec);
 
   static void PrintChannels(OMX_AUDIO_CHANNELTYPE eChannelMapping[]);
   void PrintPCM(OMX_AUDIO_PARAM_PCMMODETYPE *pcm, std::string direction);

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -194,8 +194,8 @@ bool OMXPlayerAudio::CodecChange()
     m_hints.samplerate = m_pAudioCodec->GetSampleRate();
   }
 
-  /* only check bitrate changes on CODEC_ID_DTS, CODEC_ID_AC3, CODEC_ID_EAC3 */
-  if(m_hints.codec != CODEC_ID_DTS && m_hints.codec != CODEC_ID_AC3 && m_hints.codec != CODEC_ID_EAC3)
+  /* only check bitrate changes on AV_CODEC_ID_DTS, AV_CODEC_ID_AC3, AV_CODEC_ID_EAC3 */
+  if(m_hints.codec != AV_CODEC_ID_DTS && m_hints.codec != AV_CODEC_ID_AC3 && m_hints.codec != AV_CODEC_ID_EAC3)
     new_bitrate = old_bitrate = 0;
     
   if(m_hints_current.codec          != m_hints.codec ||
@@ -545,12 +545,12 @@ AEDataFormat OMXPlayerAudio::GetDataFormat(CDVDStreamInfo hints)
   /* pathrought is overriding hw decode*/
   if(AUDIO_IS_BITSTREAM(CSettings::Get().GetInt("audiooutput.mode")) && m_use_passthrough)
   {
-    if(hints.codec == CODEC_ID_AC3 && CSettings::Get().GetBool("audiooutput.ac3passthrough") && hdmi_passthrough_ac3)
+    if(hints.codec == AV_CODEC_ID_AC3 && CSettings::Get().GetBool("audiooutput.ac3passthrough") && hdmi_passthrough_ac3)
     {
       dataFormat = AE_FMT_AC3;
       m_passthrough = true;
     }
-    if(hints.codec == CODEC_ID_DTS && CSettings::Get().GetBool("audiooutput.dtspassthrough") && hdmi_passthrough_dts)
+    if(hints.codec == AV_CODEC_ID_DTS && CSettings::Get().GetBool("audiooutput.dtspassthrough") && hdmi_passthrough_dts)
     {
       dataFormat = AE_FMT_DTS;
       m_passthrough = true;
@@ -560,12 +560,12 @@ AEDataFormat OMXPlayerAudio::GetDataFormat(CDVDStreamInfo hints)
   /* hw decode */
   if(m_use_hw_decode && !m_passthrough)
   {
-    if(hints.codec == CODEC_ID_AC3 && COMXAudio::CanHWDecode(m_hints.codec))
+    if(hints.codec == AV_CODEC_ID_AC3 && COMXAudio::CanHWDecode(m_hints.codec))
     {
       dataFormat = AE_FMT_AC3;
       m_hw_decode = true;
     }
-    if(hints.codec == CODEC_ID_DTS && COMXAudio::CanHWDecode(m_hints.codec))
+    if(hints.codec == AV_CODEC_ID_DTS && COMXAudio::CanHWDecode(m_hints.codec))
     {
       dataFormat = AE_FMT_DTS;
       m_hw_decode = true;

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -124,11 +124,11 @@ bool COMXVideo::SendDecoderConfig()
   return true;
 }
 
-bool COMXVideo::NaluFormatStartCodes(enum CodecID codec, uint8_t *in_extradata, int in_extrasize)
+bool COMXVideo::NaluFormatStartCodes(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize)
 {
   switch(codec)
   {
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
       if (in_extrasize < 7 || in_extradata == NULL)
         return true;
       // valid avcC atom data always starts with the value 1 (version), otherwise annexb
@@ -349,7 +349,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, EDEINTERLACEMODE de
 
   switch (hints.codec)
   {
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
     {
       switch(hints.profile)
       {
@@ -387,64 +387,64 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, EDEINTERLACEMODE de
       }
     }
     break;
-    case CODEC_ID_MPEG4:
+    case AV_CODEC_ID_MPEG4:
       // (role name) video_decoder.mpeg4
       // MPEG-4, DivX 4/5 and Xvid compatible
       decoder_name = OMX_MPEG4_DECODER;
       m_codingType = OMX_VIDEO_CodingMPEG4;
       m_video_codec_name = "omx-mpeg4";
       break;
-    case CODEC_ID_MPEG1VIDEO:
-    case CODEC_ID_MPEG2VIDEO:
+    case AV_CODEC_ID_MPEG1VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO:
       // (role name) video_decoder.mpeg2
       // MPEG-2
       decoder_name = OMX_MPEG2V_DECODER;
       m_codingType = OMX_VIDEO_CodingMPEG2;
       m_video_codec_name = "omx-mpeg2";
       break;
-    case CODEC_ID_H263:
+    case AV_CODEC_ID_H263:
       // (role name) video_decoder.mpeg4
       // MPEG-4, DivX 4/5 and Xvid compatible
       decoder_name = OMX_MPEG4_DECODER;
       m_codingType = OMX_VIDEO_CodingMPEG4;
       m_video_codec_name = "omx-h263";
       break;
-    case CODEC_ID_VP6:
+    case AV_CODEC_ID_VP6:
       // this form is encoded upside down
       vflip = true;
       // fall through
-    case CODEC_ID_VP6F:
-    case CODEC_ID_VP6A:
+    case AV_CODEC_ID_VP6F:
+    case AV_CODEC_ID_VP6A:
       // (role name) video_decoder.vp6
       // VP6
       decoder_name = OMX_VP6_DECODER;
       m_codingType = OMX_VIDEO_CodingVP6;
       m_video_codec_name = "omx-vp6";
     break;
-    case CODEC_ID_VP8:
+    case AV_CODEC_ID_VP8:
       // (role name) video_decoder.vp8
       // VP8
       decoder_name = OMX_VP8_DECODER;
       m_codingType = OMX_VIDEO_CodingVP8;
       m_video_codec_name = "omx-vp8";
     break;
-    case CODEC_ID_THEORA:
+    case AV_CODEC_ID_THEORA:
       // (role name) video_decoder.theora
       // theora
       decoder_name = OMX_THEORA_DECODER;
       m_codingType = OMX_VIDEO_CodingTheora;
       m_video_codec_name = "omx-theora";
     break;
-    case CODEC_ID_MJPEG:
-    case CODEC_ID_MJPEGB:
+    case AV_CODEC_ID_MJPEG:
+    case AV_CODEC_ID_MJPEGB:
       // (role name) video_decoder.mjpg
       // mjpg
       decoder_name = OMX_MJPEG_DECODER;
       m_codingType = OMX_VIDEO_CodingMJPEG;
       m_video_codec_name = "omx-mjpeg";
     break;
-    case CODEC_ID_VC1:
-    case CODEC_ID_WMV3:
+    case AV_CODEC_ID_VC1:
+    case AV_CODEC_ID_WMV3:
       // (role name) video_decoder.vc1
       // VC-1, WMV9
       decoder_name = OMX_VC1_DECODER;

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -99,7 +99,7 @@ protected:
   bool              m_submitted_eos;
   OMX_DISPLAYTRANSFORMTYPE m_transform;
   bool              m_settings_changed;
-  static bool NaluFormatStartCodes(enum CodecID codec, uint8_t *in_extradata, int in_extrasize);
+  static bool NaluFormatStartCodes(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize);
 };
 
 #endif

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -556,14 +556,14 @@ CBitstreamConverter::~CBitstreamConverter()
   Close();
 }
 
-bool CBitstreamConverter::Open(enum CodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb)
+bool CBitstreamConverter::Open(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb)
 {
   m_codec = codec;
   m_to_annexb = to_annexb;
 
   switch(codec)
   {
-    case CODEC_ID_H264:
+    case AV_CODEC_ID_H264:
       if (in_extrasize < 7 || in_extradata == NULL)
       {
         CLog::Log(LOGERROR, "CBitstreamConverter::Open avcC data too small or missing\n");
@@ -696,7 +696,7 @@ bool CBitstreamConverter::Convert(uint8_t *pData, int iSize)
 
   if (pData)
   {
-    if (m_codec == CODEC_ID_H264)
+    if (m_codec == AV_CODEC_ID_H264)
     {
       if (m_to_annexb)
       {

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -124,7 +124,7 @@ public:
   static void     skip_bits( bits_reader_t *br, int nbits );
   static uint32_t get_bits( bits_reader_t *br, int nbits );
 
-  bool Open(enum CodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb);
+  bool Open(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb);
   void Close(void);
   bool NeedConvert(void) { return m_convert_bitstream; };
   bool Convert(uint8_t *pData, int iSize);
@@ -175,7 +175,7 @@ protected:
   bool              m_convert_bytestream;
   DllAvUtil         *m_dllAvUtil;
   DllAvFormat       *m_dllAvFormat;
-  CodecID           m_codec;
+  AVCodecID           m_codec;
 };
 
 #endif


### PR DESCRIPTION
Ok, this was boring but had to be done at some point. Some months ago FFmpeg renamed them as in $subject and used some tricks to preserve the old names until the next major version. xbmc was using some mixed style of CODEC_ID and AV_CODEC_ID in some parts of its code; since those appeared in ffmpeg-1.0 which xbmc already requires, just switch to the new name and be done.
