### PR TITLE
DllAvFilter: Always include libavfilter/buffersrc.h for av_buffersrc_add...

### DIFF
--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -45,10 +45,12 @@ extern "C" {
   #include <libavfilter/avfiltergraph.h>
   #include <libavfilter/buffersink.h>
   #include <libavfilter/avcodec.h>
+  #include <libavfilter/buffersrc.h>
 #else
   #include "libavfilter/avfiltergraph.h"
   #include "libavfilter/buffersink.h"
   #include "libavfilter/avcodec.h"
+  #include "libavfilter/buffersrc.h"
 #endif
 }
 


### PR DESCRIPTION
..._frame.

Note: This is not needed right now but is with FFmpeg master.
