### PR TITLE
[rbp/omxplayer] do not reopen the resample context for each frame.

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -200,14 +200,14 @@ int COMXAudioCodecOMX::Decode(BYTE* pData, int iSize)
                       m_dllAvUtil.av_get_default_channel_layout(m_pCodecContext->channels), 
                       m_pCodecContext->sample_fmt, m_pCodecContext->sample_rate,
                       0, NULL);
-    }
 
-    if(!m_pConvert || m_dllSwResample.swr_init(m_pConvert) < 0)
-    {
-      CLog::Log(LOGERROR, "COMXAudioCodecOMX::Decode - Unable to initialise convert format %d to %d", m_pCodecContext->sample_fmt, m_desiredSampleFormat);
-      m_iBufferSize1 = 0;
-      m_iBufferSize2 = 0;
-      return iBytesUsed;
+      if(!m_pConvert || m_dllSwResample.swr_init(m_pConvert) < 0)
+      {
+        CLog::Log(LOGERROR, "COMXAudioCodecOMX::Decode - Unable to initialise convert format %d to %d", m_pCodecContext->sample_fmt, m_desiredSampleFormat);
+        m_iBufferSize1 = 0;
+        m_iBufferSize2 = 0;
+        return iBytesUsed;
+      }
     }
     m_iBufferSize1 = 0;
 


### PR DESCRIPTION
I think this doesn't tend to happen on Pi now, as AV_SAMPLE_FMT_S16 and AV_SAMPLE_FMT_FLTP bypass the resampler,
but best to fix it if some obscure codec returns something else.

See #2873
