### PR TITLE
[Python] move setting sys.argv[0] to XBPython::evalFile()

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -123,16 +123,15 @@ bool CPluginDirectory::StartScript(const CStdString& strPath, bool retrievingDir
   CStdString strHandle;
   strHandle.Format("%i", handle);
   vector<CStdString> argv;
-  argv.push_back(basePath);
   argv.push_back(strHandle);
   argv.push_back(options);
 
   // run the script
-  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s')", __FUNCTION__, m_addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str());
+  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s')", __FUNCTION__, m_addon->Name().c_str(), basePath.c_str(), argv[0].c_str(), argv[1].c_str());
   bool success = false;
 #ifdef HAS_PYTHON
   CStdString file = m_addon->LibPath();
-  int id = g_pythonParser.evalFile(file, argv,m_addon);
+  int id = g_pythonParser.evalFile(file, argv, m_addon, true);
   if (id >= 0)
   { // wait for our script to finish
     CStdString scriptName = m_addon->Name();
@@ -471,14 +470,13 @@ bool CPluginDirectory::RunScriptWithParams(const CStdString& strPath)
   CStdString strHandle;
   strHandle.Format("%i", -1);
   vector<CStdString> argv;
-  argv.push_back(basePath);
   argv.push_back(strHandle);
   argv.push_back(options);
 
   // run the script
 #ifdef HAS_PYTHON
-  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s')", __FUNCTION__, addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str());
-  if (g_pythonParser.evalFile(addon->LibPath(), argv,addon) >= 0)
+  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s')", __FUNCTION__, addon->Name().c_str(), basePath.c_str(), argv[0].c_str(), argv[1].c_str());
+  if (g_pythonParser.evalFile(addon->LibPath(), argv, addon, true) >= 0)
     return true;
   else
 #endif

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -423,13 +423,12 @@ int CBuiltins::Execute(const CStdString& execString)
 #endif
     {
 #ifdef HAS_PYTHON
-      vector<CStdString> argv = params;
-
-      vector<CStdString> path;
-      //split the path up to find the filename
-      StringUtils::SplitString(params[0],"\\",path);
-      if (path.size())
-        argv[0] = path[path.size() - 1];
+      vector<CStdString> argv;
+      for (unsigned int i = 1; i < params.size(); ++i)
+      {
+        CStdString arg = params[i];
+        argv.push_back(arg);
+      }
 
       AddonPtr script;
       CStdString scriptpath(params[0]);

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -687,7 +687,7 @@ int XBPython::evalFile(const CStdString &src, ADDON::AddonPtr addon)
   return evalFile(src, argv, addon);
 }
 // execute script, returns -1 if script doesn't exist
-int XBPython::evalFile(const CStdString &src, const std::vector<CStdString> &argv, ADDON::AddonPtr addon)
+int XBPython::evalFile(const CStdString &src, const std::vector<CStdString> &argv, ADDON::AddonPtr addon, bool plugin /*= false */)
 {
   CSingleExit ex(g_graphicsContext);
   // return if file doesn't exist
@@ -708,7 +708,20 @@ int XBPython::evalFile(const CStdString &src, const std::vector<CStdString> &arg
 
   m_nextid++;
   boost::shared_ptr<XBPyThread> pyThread = boost::shared_ptr<XBPyThread>(new XBPyThread(this, m_nextid));
-  pyThread->setArgv(argv);
+
+  // add addon id formatted properly as first arg in argv
+  std::vector<CStdString> newargv;
+  CStdString path = addon->ID();
+  if (plugin)
+    path.Format("plugin://%s", addon->ID().c_str());
+  newargv.push_back(path);
+  for (unsigned int i = 0; i < argv.size(); ++i)
+  {
+    CStdString arg = argv[i];
+    newargv.push_back(arg);
+  }
+  
+  pyThread->setArgv(newargv);
   pyThread->setAddon(addon);
   pyThread->evalFile(src);
   PyElem inf;

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -95,7 +95,7 @@ public:
   int ScriptsSize();
   int GetPythonScriptId(int scriptPosition);
   int evalFile(const CStdString &src, ADDON::AddonPtr addon);
-  int evalFile(const CStdString &src, const std::vector<CStdString> &argv, ADDON::AddonPtr addon);
+  int evalFile(const CStdString &src, const std::vector<CStdString> &argv, ADDON::AddonPtr addon, bool plugin = false);
   int evalString(const CStdString &src, const std::vector<CStdString> &argv);
 
   bool isRunning(int scriptId);

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -86,7 +86,6 @@ bool CWeatherJob::DoWork()
 
   // initialize our sys.argv variables
   std::vector<CStdString> argv;
-  argv.push_back(addon->LibPath());
 
   CStdString strSetting;
   strSetting.Format("%i", m_location);
@@ -95,7 +94,7 @@ bool CWeatherJob::DoWork()
   // Download our weather
   CLog::Log(LOGINFO, "WEATHER: Downloading weather");
   // call our script, passing the areacode
-  if (g_pythonParser.evalFile(argv[0], argv,addon))
+  if (g_pythonParser.evalFile(addon->LibPath(), argv,addon))
   {
     while (true)
     {


### PR DESCRIPTION
This is useful so sys.argv[0] is always set.

This does break the xbmc version check addon, since now sys.argv[0] is always filled. this is the way python should be, sys.arg[0] is usually the path to the script.

This just sets it to the &lt;addon id> for scripts and plugin://&lt;addon id> for plugins.

@garbear: fixed the formatting (github hates &lt;)
