### PR TITLE
Fix "make check"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -92,10 +92,6 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/windows/windows.a \
                    xbmc/xbmc.a \
 
-ifneq (@USE_LIBXBMC@,1)
-DIRECTORY_ARCHIVES +=xbmc/main/main.a
-endif
-
 NWAOBJSXBMC=	xbmc/threads/threads.a \
 		xbmc/commons/commons.a
 
@@ -462,7 +458,7 @@ else
 	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $(MAINOBJS) -Wl,--start-group $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group -Wl,--no-undefined $(NWAOBJSXBMC) $(LIBS)
 endif
 
-xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)
+xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS) xbmc/main/main.a
 
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -o xbmc.bin -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS) -rdynamic

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -202,15 +202,19 @@ void CAdvancedSettings::Initialize()
 
   m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-1][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)";
 
+  m_videoCleanStringRegExps.clear();
   m_videoCleanStringRegExps.push_back("[ _\\,\\.\\(\\)\\[\\]\\-](ac3|dts|custom|dc|remastered|divx|divx5|dsr|dsrip|dutch|dvd|dvd5|dvd9|dvdrip|dvdscr|dvdscreener|screener|dvdivx|cam|fragment|fs|hdtv|hdrip|hdtvrip|internal|limited|multisubs|ntsc|ogg|ogm|pal|pdtv|proper|repack|rerip|retail|r3|r5|bd5|se|svcd|swedish|german|read.nfo|nfofix|unrated|extended|ws|telesync|ts|telecine|tc|brrip|bdrip|480p|480i|576p|576i|720p|720i|1080p|1080i|3d|hrhd|hrhdtv|hddvd|bluray|x264|h264|xvid|xvidvd|xxx|www.www|cd[1-9]|\\[.*\\])([ _\\,\\.\\(\\)\\[\\]\\-]|$)");
   m_videoCleanStringRegExps.push_back("(\\[.*\\])");
 
+  m_moviesExcludeFromScanRegExps.clear();
   m_moviesExcludeFromScanRegExps.push_back("-trailer");
   m_moviesExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
   m_tvshowExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
 
+  m_folderStackRegExps.clear();
   m_folderStackRegExps.push_back("((cd|dvd|dis[ck])[0-9]+)$");
 
+  m_videoStackRegExps.clear();
   m_videoStackRegExps.push_back("(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck]|d)[ _.-]*[0-9]+)(.*?)(\\.[^.]+)$");
   m_videoStackRegExps.push_back("(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck]|d)[ _.-]*[a-d])(.*?)(\\.[^.]+)$");
   m_videoStackRegExps.push_back("(.*?)([ ._-]*[a-d])(.*?)(\\.[^.]+)$");
@@ -218,6 +222,7 @@ void CAdvancedSettings::Initialize()
   // in a flat dir structure, but is perfectly safe in a dir-per-vid one.
   //m_videoStackRegExps.push_back("(.*?)([ ._-]*[0-9])(.*?)(\\.[^.]+)$");
 
+  m_tvshowEnumRegExps.clear();
   // foo.s01.e01, foo.s01_e01, S01E02 foo, S01 - E02
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[Ss]([0-9]+)[][ ._-]*[Ee]([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
   // foo.ep01, foo.EP_01

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -24,93 +24,115 @@
 
 #include "gtest/gtest.h"
 
-TEST(TestFileItem, GetLocalArt)
+using ::testing::Test;
+using ::testing::WithParamInterface;
+using ::testing::ValuesIn;
+
+struct TestFileData
 {
-  typedef struct
-  {
-    const char *file;
-    bool use_folder;
-    const char *base;
-  } testfiles;
+  const char *file;
+  bool use_folder;
+  const char *base;
+};
 
-  const testfiles test_files[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename-art.jpg" },
-                                  { "c:\\dir\\filename.avi", true,  "c:\\dir\\art.jpg" },
-                                  { "/dir/filename.avi", false, "/dir/filename-art.jpg" },
-                                  { "/dir/filename.avi", true,  "/dir/art.jpg" },
-                                  { "smb://somepath/file.avi", false, "smb://somepath/file-art.jpg" },
-                                  { "smb://somepath/file.avi", true, "smb://somepath/art.jpg" },
-                                  { "stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", false,  "/path/to/movie-art.jpg" },
-                                  { "stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", true,  "/path/to/art.jpg" },
-                                  { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/art.jpg" },
-                                  { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01-art.jpg" },
-                                  { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/art.jpg" },
-                                  { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere-art.jpg" },
-                                  { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", true, "g:\\multimedia\\movies\\art.jpg" },
-                                  { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/art.jpg" },
-                                  { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/art.jpg" },
-                                  { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/art.jpg" },
-                                  { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/art.jpg" }};
+class AdvancedSettingsResetBase : public Test
+{
+public:
+  AdvancedSettingsResetBase();
+};
 
-  const testfiles test_file2[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename.tbn" },
-                                  { "/dir/filename.avi", false, "/dir/filename.tbn" },
-                                  { "smb://somepath/file.avi", false, "smb://somepath/file.tbn" },
-                                  { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.tbn" },
-                                  { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere.tbn" }};
-
+AdvancedSettingsResetBase::AdvancedSettingsResetBase()
+{
   // Force all settings to be reset to defaults
   g_advancedSettings.OnSettingsUnloaded();
   g_advancedSettings.Initialize();
-
-  for (unsigned int i = 0; i < sizeof(test_files) / sizeof(testfiles); i++)
-  {
-    CFileItem item;
-    item.SetPath(test_files[i].file);
-    std::string path = CURL(item.GetLocalArt("art.jpg", test_files[i].use_folder)).Get();
-    std::string compare = CURL(test_files[i].base).Get();
-    EXPECT_EQ(compare, path);
-  }
-
-  for (unsigned int i = 0; i < sizeof(test_file2) / sizeof(testfiles); i++)
-  {
-    CFileItem item;
-    item.SetPath(test_file2[i].file);
-    std::string path = CURL(item.GetLocalArt("", test_file2[i].use_folder)).Get();
-    std::string compare = CURL(test_file2[i].base).Get();
-    EXPECT_EQ(compare, path);
-  }
 }
 
-TEST(TestFileItem, GetBaseMoviePath)
+class TestFileItemSpecifiedArtJpg : public AdvancedSettingsResetBase,
+                                    public WithParamInterface<TestFileData>
 {
-  typedef struct
-  {
-    const char *file;
-    bool use_folder;
-    const char *base;
-  } testfiles;
+};
 
-  const testfiles test_files[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi" },
-                                  { "c:\\dir\\filename.avi", true,  "c:\\dir\\" },
-                                  { "/dir/filename.avi", false, "/dir/filename.avi" },
-                                  { "/dir/filename.avi", true,  "/dir/" },
-                                  { "smb://somepath/file.avi", false, "smb://somepath/file.avi" },
-                                  { "smb://somepath/file.avi", true, "smb://somepath/" },
-                                  { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", false, "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi" },
-                                  { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/" },
-                                  { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi" },
-                                  { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/" },
-                                  { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", true, "g:\\multimedia\\movies\\" },
-                                  { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/" },
-                                  { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/" },
-                                  { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/" },
-                                  { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/" }};
 
-  for (unsigned int i = 0; i < sizeof(test_files) / sizeof(testfiles); i++)
-  {
-    CFileItem item;
-    item.SetPath(test_files[i].file);
-    std::string path = CURL(item.GetBaseMoviePath(test_files[i].use_folder)).Get();
-    std::string compare = CURL(test_files[i].base).Get();
-    EXPECT_EQ(path, compare);
-  }
+TEST_P(TestFileItemSpecifiedArtJpg, GetLocalArt)
+{
+  CFileItem item;
+  item.SetPath(GetParam().file);
+  std::string path = CURL(item.GetLocalArt("art.jpg", GetParam().use_folder)).Get();
+  std::string compare = CURL(GetParam().base).Get();
+  EXPECT_EQ(compare, path);
 }
+
+const TestFileData MovieFiles[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename-art.jpg" },
+                                   { "c:\\dir\\filename.avi", true,  "c:\\dir\\art.jpg" },
+                                   { "/dir/filename.avi", false, "/dir/filename-art.jpg" },
+                                   { "/dir/filename.avi", true,  "/dir/art.jpg" },
+                                   { "smb://somepath/file.avi", false, "smb://somepath/file-art.jpg" },
+                                   { "smb://somepath/file.avi", true, "smb://somepath/art.jpg" },
+                                   { "stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", false,  "/path/to/movie-art.jpg" },
+                                   { "stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", true,  "/path/to/art.jpg" },
+                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/art.jpg" },
+                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01-art.jpg" },
+                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/art.jpg" },
+                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere-art.jpg" },
+                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", true, "g:\\multimedia\\movies\\art.jpg" },
+                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/art.jpg" },
+                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/art.jpg" },
+                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/art.jpg" },
+                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/art.jpg" }};
+
+INSTANTIATE_TEST_CASE_P(MovieFiles, TestFileItemSpecifiedArtJpg, ValuesIn(MovieFiles));
+
+class TestFileItemFallbackArt : public AdvancedSettingsResetBase,
+                                public WithParamInterface<TestFileData>
+{
+};
+
+TEST_P(TestFileItemFallbackArt, GetLocalArt)
+{
+  CFileItem item;
+  item.SetPath(GetParam().file);
+  std::string path = CURL(item.GetLocalArt("", GetParam().use_folder)).Get();
+  std::string compare = CURL(GetParam().base).Get();
+  EXPECT_EQ(compare, path);
+}
+
+const TestFileData NoArtFiles[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename.tbn" },
+                                   { "/dir/filename.avi", false, "/dir/filename.tbn" },
+                                   { "smb://somepath/file.avi", false, "smb://somepath/file.tbn" },
+                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.tbn" },
+                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere.tbn" }};
+
+INSTANTIATE_TEST_CASE_P(NoArt, TestFileItemFallbackArt, ValuesIn(NoArtFiles));
+
+class TestFileItemBasePath : public AdvancedSettingsResetBase,
+                             public WithParamInterface<TestFileData>
+{
+};
+
+TEST_P(TestFileItemBasePath, GetBaseMoviePath)
+{
+  CFileItem item;
+  item.SetPath(GetParam().file);
+  std::string path = CURL(item.GetBaseMoviePath(GetParam().use_folder)).Get();
+  std::string compare = CURL(GetParam().base).Get();
+  EXPECT_EQ(compare, path);
+}
+
+const TestFileData BaseMovies[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi" },
+                                   { "c:\\dir\\filename.avi", true,  "c:\\dir\\" },
+                                   { "/dir/filename.avi", false, "/dir/filename.avi" },
+                                   { "/dir/filename.avi", true,  "/dir/" },
+                                   { "smb://somepath/file.avi", false, "smb://somepath/file.avi" },
+                                   { "smb://somepath/file.avi", true, "smb://somepath/" },
+                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", false, "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi" },
+                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/" },
+                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi" },
+                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/" },
+                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", true, "g:\\multimedia\\movies\\" },
+                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/" },
+                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/" },
+                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/" },
+                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/" }};
+
+INSTANTIATE_TEST_CASE_P(BaseNameMovies, TestFileItemBasePath, ValuesIn(BaseMovies));

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -57,6 +57,8 @@ TEST(TestFileItem, GetLocalArt)
                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.tbn" },
                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere.tbn" }};
 
+  // Force all settings to be reset to defaults
+  g_advancedSettings.OnSettingsUnloaded();
   g_advancedSettings.Initialize();
 
   for (unsigned int i = 0; i < sizeof(test_files) / sizeof(testfiles); i++)
@@ -65,7 +67,7 @@ TEST(TestFileItem, GetLocalArt)
     item.SetPath(test_files[i].file);
     std::string path = CURL(item.GetLocalArt("art.jpg", test_files[i].use_folder)).Get();
     std::string compare = CURL(test_files[i].base).Get();
-    EXPECT_EQ(path, compare);
+    EXPECT_EQ(compare, path);
   }
 
   for (unsigned int i = 0; i < sizeof(test_file2) / sizeof(testfiles); i++)
@@ -74,7 +76,7 @@ TEST(TestFileItem, GetLocalArt)
     item.SetPath(test_file2[i].file);
     std::string path = CURL(item.GetLocalArt("", test_file2[i].use_folder)).Get();
     std::string compare = CURL(test_file2[i].base).Get();
-    EXPECT_EQ(path, compare);
+    EXPECT_EQ(compare, path);
   }
 }
 

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -45,8 +45,8 @@ public:
     char tmp[MAX_PATH];
     int fd;
 
-    m_ptempFilePath = CSpecialProtocol::TranslatePath("special://temp/");
-    m_ptempFilePath += "xbmctempfileXXXXXX";
+    m_ptempFileDirectory = CSpecialProtocol::TranslatePath("special://temp/");
+    m_ptempFilePath = m_ptempFileDirectory + "xbmctempfileXXXXXX";
     m_ptempFilePath += suffix;
     if (m_ptempFilePath.length() >= MAX_PATH)
     {
@@ -85,8 +85,13 @@ public:
   {
     return m_ptempFilePath;
   }
+  CStdString getTempFileDirectory() const
+  {
+    return m_ptempFileDirectory;
+  }
 private:
   CStdString m_ptempFilePath;
+  CStdString m_ptempFileDirectory;
 };
 
 CXBMCTestUtils::CXBMCTestUtils()
@@ -144,6 +149,14 @@ CStdString CXBMCTestUtils::TempFilePath(XFILE::CFile const* const tempfile)
     return "";
   CTempFile const* const f = static_cast<CTempFile const* const>(tempfile);
   return f->getTempFilePath();
+}
+
+CStdString CXBMCTestUtils::TempFileDirectory(XFILE::CFile const* const tempfile)
+{
+  if (!tempfile)
+    return "";
+  CTempFile const* const f = static_cast<CTempFile const* const>(tempfile);
+  return f->getTempFileDirectory();
 }
 
 XFILE::CFile *CXBMCTestUtils::CreateCorruptedFile(CStdString const& strFileName,

--- a/xbmc/test/TestUtils.h
+++ b/xbmc/test/TestUtils.h
@@ -54,6 +54,9 @@ public:
   /* Function to get path of a tempfile */
   CStdString TempFilePath(XFILE::CFile const* const tempfile);
 
+  /* Get the containing directory of a tempfile */
+  CStdString TempFileDirectory(XFILE::CFile const* const tempfile);
+
   /* Functions to get variables used in the TestFileFactory tests. */
   std::vector<CStdString> &getTestFileFactoryReadUrls();
 

--- a/xbmc/utils/test/TestFileOperationJob.cpp
+++ b/xbmc/utils/test/TestFileOperationJob.cpp
@@ -230,6 +230,10 @@ TEST(TestFileOperationJob, ActionDeleteFolder)
 
   ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
+
+  CStdString tmpfiledirectory =
+    CXBMCTestUtils::Instance().TempFileDirectory(tmpfile);
+
   tmpfile->Close();
 
   destpath = tmpfilepath;
@@ -242,13 +246,13 @@ TEST(TestFileOperationJob, ActionDeleteFolder)
   item->Select(true);
   items.Add(item);
 
-  job.SetFileOperation(CFileOperationJob::ActionCreateFolder, items, destpath);
+  job.SetFileOperation(CFileOperationJob::ActionCreateFolder, items, tmpfiledirectory);
   EXPECT_EQ(CFileOperationJob::ActionCreateFolder, job.GetAction());
 
   EXPECT_TRUE(job.DoWork());
   EXPECT_TRUE(XFILE::CDirectory::Exists(destpath));
 
-  job.SetFileOperation(CFileOperationJob::ActionDeleteFolder, items, destpath);
+  job.SetFileOperation(CFileOperationJob::ActionDeleteFolder, items, tmpfiledirectory);
   EXPECT_EQ(CFileOperationJob::ActionDeleteFolder, job.GetAction());
 
   EXPECT_TRUE(job.DoWork());

--- a/xbmc/utils/test/TestFileOperationJob.cpp
+++ b/xbmc/utils/test/TestFileOperationJob.cpp
@@ -185,7 +185,6 @@ TEST(TestFileOperationJob, ActionReplace)
   EXPECT_TRUE(XFILE::CDirectory::Remove(destpath));
 }
 
-// This test will fail until ActionCreateFolder has a proper implementation
 TEST(TestFileOperationJob, ActionCreateFolder)
 {
   XFILE::CFile *tmpfile;
@@ -195,6 +194,10 @@ TEST(TestFileOperationJob, ActionCreateFolder)
 
   ASSERT_TRUE((tmpfile = XBMC_CREATETEMPFILE("")));
   tmpfilepath = XBMC_TEMPFILEPATH(tmpfile);
+
+  CStdString tmpfiledirectory =
+    CXBMCTestUtils::Instance().TempFileDirectory(tmpfile);
+
   tmpfile->Close();
 
   destpath = tmpfilepath;
@@ -207,7 +210,7 @@ TEST(TestFileOperationJob, ActionCreateFolder)
   item->Select(true);
   items.Add(item);
 
-  job.SetFileOperation(CFileOperationJob::ActionCreateFolder, items, destpath);
+  job.SetFileOperation(CFileOperationJob::ActionCreateFolder, items, tmpfiledirectory);
   EXPECT_EQ(CFileOperationJob::ActionCreateFolder, job.GetAction());
 
   EXPECT_TRUE(job.DoWork());


### PR DESCRIPTION
Various fixes to the test suite:
1. test-xbmc wasn't building due to a double-definition of main () because main.a was in DIRECTORY_ARCHIVES. It's already in MAINOBJS so I just removed it from the former.
2. ActionCreateFolder/ActionDeleteFolder expect the destination to be the _parent_ directory and not the directory to be created / destroyed
3. Ensure that CAdvancedSettings is reset between test runs as it can be polluted between tests and cause nondeterministic failures.
4. Refactor TestFileItem.cpp: use Google Test's parameterized test driver as opposed to iterating within the test body so that we can see specifically where failure is occurring.

Note: make check is still segfaulting on environment teardown. Fixing that would require a deeper dive into the global instances of CLog and friends which looks like a deep rabbit hole that's not worth getting into right now.
