### PR TITLE
Bypass rendering and dirty regions

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2057,6 +2057,12 @@ void CApplication::Render()
       m_bPresentFrame = g_renderManager.FrameWait(100);
       hasRendered = true;
     }
+    else if(!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !g_renderManager.RendererHandlesPresent())
+    {
+      //Whether we're paused or not, if the renderer isn't in charge of presenting and we're fullscreen, we limit
+      singleFrameTime = 30;
+      limitFrames = true;
+    }
     else
     {
       // engage the frame limiter as needed

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2098,8 +2098,6 @@ void CApplication::Render()
   if(!g_Windowing.BeginRender())
     return;
 
-  g_renderManager.FrameMove();
-
   CDirtyRegionList dirtyRegions = g_windowManager.GetDirty();
   if (RenderNoPresent())
     hasRendered = true;
@@ -2756,6 +2754,8 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
   }
   if (processGUI && m_renderGUI)
   {
+    g_renderManager.FrameMove();
+
     if (!m_bStop)
       g_windowManager.Process(CTimeUtils::GetFrameTime());
     g_windowManager.FrameMove();

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -268,8 +268,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
       lock.Enter();
     }
     lock2.Enter();
-    if( format & RENDER_FMT_BYPASS )
-      m_presentmethod = PRESENT_METHOD_BYPASS;
+    m_format = format;
 
     int processor = m_pRenderer->GetProcessorSize();
     if(processor)
@@ -303,7 +302,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
 
 bool CXBMCRenderManager::RendererHandlesPresent() const
 {
-  return IsConfigured() && m_presentmethod != PRESENT_METHOD_BYPASS;
+  return IsConfigured() && m_format != RENDER_FMT_BYPASS;
 }
 
 bool CXBMCRenderManager::IsConfigured() const

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -329,6 +329,16 @@ bool CXBMCRenderManager::FrameWait(int ms)
   return m_presentstep != PRESENT_IDLE;
 }
 
+bool CXBMCRenderManager::FrameDirty()
+{
+  CSingleLock lock(m_presentlock);
+  if(m_presentstep == PRESENT_FRAME
+  || m_presentstep == PRESENT_FRAME2)
+    return true;
+  else
+    return false;
+}
+
 void CXBMCRenderManager::FrameMove()
 {
   { CSharedLock lock(m_sharedSection);

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -56,6 +56,7 @@ public:
   void Update();
   void FrameMove();
   void FrameFinish();
+  bool FrameDirty();
   bool FrameWait(int ms);
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255);
   void SetupScreenshot();

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -212,7 +212,6 @@ protected:
     PRESENT_METHOD_BLEND,
     PRESENT_METHOD_WEAVE,
     PRESENT_METHOD_BOB,
-    PRESENT_METHOD_BYPASS,
   };
 
   double m_displayLatency;
@@ -251,6 +250,7 @@ protected:
   CCriticalSection m_presentlock;
   CEvent     m_flushEvent;
 
+  ERenderFormat   m_format;
 
   OVERLAY::CRenderer m_overlays;
 

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -42,8 +42,7 @@ CGUIVideoControl::~CGUIVideoControl(void)
 
 void CGUIVideoControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  // TODO Proper processing which marks when its actually changed. Just mark always for now.
-  if (g_renderManager.RendererHandlesPresent())
+  if (g_renderManager.FrameDirty())
     MarkDirtyRegion();
 
   CGUIControl::Process(currentTime, dirtyregions);

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -744,7 +744,8 @@ void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &d
 {
   // TODO: This isn't quite optimal - ideally we'd only be dirtying up the actual video render rect
   //       which is probably the job of the renderer as it can more easily track resizing etc.
-  MarkDirtyRegion();
+  if(g_renderManager.FrameDirty())
+    MarkDirtyRegion();
   CGUIWindow::Process(currentTime, dirtyregion);
   m_renderRegion.SetRect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
 }


### PR DESCRIPTION
This fixed the bypass format to avoid blocking GUI and adds support for dirty region tracking during video playback.
