### PR TITLE
[rbp] Avoid overflow in version string

### DIFF
--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -55,9 +55,10 @@ bool CRBP::Initialize()
 
 void CRBP::LogFirmwareVerison()
 {
-  char  response[80];
+  char  response[160];
   m_DllBcmHost->vc_gencmd(response, sizeof response, "version");
-  CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s\n", response);
+  response[sizeof(response) - 1] = '\0';
+  CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
 }
 
 void CRBP::Deinitialize()


### PR DESCRIPTION
gedit complains about invalid characters when opening xbmc.log file produced by pi
Since the change from perforce revision number to git hash, the version string has increased in size.

Fortunately we don't overrun the "response" buffer.
Unfortunately when buffer doesn't fit, it is not null terminated, so logging message pulls in garbage.

Version string looks like:
Jun 17 2013 20:49:11
Copyright (c) 2012 Broadcom
version d380dde43fe729f043befb5cf775f99e54586cde (clean) (release)

So, 80 characters is not enough (it is about 115 plus newlines).
160 seems more than enough, but truncate the string just in case.
