### PR TITLE
Fix for SMB shares after suspend

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5750,4 +5750,16 @@ void CApplication::CloseNetworkShares()
 #if defined(HAS_FILESYSTEM_SMB) && !defined(_WIN32)
   smb.Deinit();
 #endif
+  
+#ifdef HAS_FILESYSTEM_NFS
+  gNfsConnection.Deinit();
+#endif
+  
+#ifdef HAS_FILESYSTEM_AFP
+  gAfpConnection.Deinit();
+#endif
+  
+#ifdef HAS_FILESYSTEM_SFTP
+  CSFTPSessionManager::DisconnectAllSessions();
+#endif
 }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5742,3 +5742,12 @@ bool CApplication::SetLanguage(const CStdString &strLanguage)
 
   return true;
 }
+
+void CApplication::CloseNetworkShares()
+{
+  CLog::Log(LOGDEBUG,"CApplication::CloseNetworkShares: Closing all network shares");
+
+#if defined(HAS_FILESYSTEM_SMB) && !defined(_WIN32)
+  smb.Deinit();
+#endif
+}

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -198,6 +198,7 @@ public:
   void CheckScreenSaverAndDPMS();
   void CheckPlayingProgress();
   void ActivateScreenSaver(bool forceType = false);
+  void CloseNetworkShares();
 
   virtual void Process();
   void ProcessSlow();

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -240,6 +240,7 @@ void CPowerManager::OnSleep()
   g_application.StopPlaying();
   g_application.StopShutdownTimer();
   g_application.StopScreenSaverTimer();
+  g_application.CloseNetworkShares();
   CAEFactory::Suspend();
 }
 


### PR DESCRIPTION
It basically is supposed to do this:

-deinitialize libsmbclient before going to sleep (Linux only)
-start and stop all addon services before and after suspend (otherwise addons are able to reinitialize SMB right before actually going to sleep and break it)

More details here:
http://forum.xbmc.org/showthread.php?tid=166430
