### PR TITLE
[RFC] Protect Player!

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -3076,6 +3076,9 @@
 		F5987FDB0FBE2DFD008EF4FB /* PAPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987FDA0FBE2DFD008EF4FB /* PAPlayer.cpp */; };
 		F599CD2B108E65370010EC2A /* IoSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD29108E65370010EC2A /* IoSupport.cpp */; };
 		F599CD74108E6A7A0010EC2A /* DarwinStorageProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD73108E6A7A0010EC2A /* DarwinStorageProvider.cpp */; };
+		F59EED7E17AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59EED7C17AD5174005BB7C6 /* ApplicationPlayer.cpp */; };
+		F59EED7F17AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59EED7C17AD5174005BB7C6 /* ApplicationPlayer.cpp */; };
+		F59EED8017AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59EED7C17AD5174005BB7C6 /* ApplicationPlayer.cpp */; };
 		F5A7A702112893E50059D6AA /* AnnouncementManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7A700112893E50059D6AA /* AnnouncementManager.cpp */; };
 		F5A7A85B112908F00059D6AA /* WebServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7A859112908F00059D6AA /* WebServer.cpp */; };
 		F5A7B37E113AFB900059D6AA /* SFTPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7B37C113AFB900059D6AA /* SFTPDirectory.cpp */; };
@@ -5382,6 +5385,8 @@
 		F599CD2A108E65370010EC2A /* IoSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IoSupport.h; sourceTree = "<group>"; };
 		F599CD72108E6A7A0010EC2A /* DarwinStorageProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DarwinStorageProvider.h; sourceTree = "<group>"; };
 		F599CD73108E6A7A0010EC2A /* DarwinStorageProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DarwinStorageProvider.cpp; sourceTree = "<group>"; };
+		F59EED7C17AD5174005BB7C6 /* ApplicationPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ApplicationPlayer.cpp; sourceTree = "<group>"; };
+		F59EED7D17AD5174005BB7C6 /* ApplicationPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplicationPlayer.h; sourceTree = "<group>"; };
 		F5A7A700112893E50059D6AA /* AnnouncementManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AnnouncementManager.cpp; sourceTree = "<group>"; };
 		F5A7A701112893E50059D6AA /* AnnouncementManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnnouncementManager.h; sourceTree = "<group>"; };
 		F5A7A859112908F00059D6AA /* WebServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebServer.cpp; sourceTree = "<group>"; };
@@ -7163,6 +7168,8 @@
 				E38E14650D25F9F900618676 /* Application.h */,
 				E38E14660D25F9F900618676 /* ApplicationMessenger.cpp */,
 				E38E14670D25F9F900618676 /* ApplicationMessenger.h */,
+				F59EED7C17AD5174005BB7C6 /* ApplicationPlayer.cpp */,
+				F59EED7D17AD5174005BB7C6 /* ApplicationPlayer.h */,
 				F56352C616E5436900D21BAD /* AppParamParser.cpp */,
 				F56352C716E5436900D21BAD /* AppParamParser.h */,
 				E38E146E0D25F9F900618676 /* Autorun.cpp */,
@@ -10578,6 +10585,7 @@
 				DFBB430A178B574E006CC20A /* AddonCallbacksCodec.cpp in Sources */,
 				55611BA31766672F00754072 /* RenderFlags.cpp in Sources */,
 				5558ED10176396CD00118C35 /* StereoscopicsManager.cpp in Sources */,
+				F59EED7E17AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11603,6 +11611,7 @@
 				DFBB4309178B574E006CC20A /* AddonCallbacksCodec.cpp in Sources */,
 				F55BA70C17AB2265002A36D1 /* StereoscopicsManager.cpp in Sources */,
 				F55BA71117AB2293002A36D1 /* RenderFlags.cpp in Sources */,
+				F59EED8017AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12630,6 +12639,7 @@
 				DFBB4308178B574E006CC20A /* AddonCallbacksCodec.cpp in Sources */,
 				F55BA70B17AB2264002A36D1 /* StereoscopicsManager.cpp in Sources */,
 				F55BA71017AB2293002A36D1 /* RenderFlags.cpp in Sources */,
+				F59EED7F17AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -372,6 +372,7 @@
     <ClCompile Include="..\..\xbmc\addons\Skin.cpp" />
     <ClCompile Include="..\..\xbmc\Application.cpp" />
     <ClCompile Include="..\..\xbmc\ApplicationMessenger.cpp" />
+    <ClCompile Include="..\..\xbmc\ApplicationPlayer.cpp" />
     <ClCompile Include="..\..\xbmc\AppParamParser.cpp" />
     <ClCompile Include="..\..\xbmc\Autorun.cpp" />
     <ClCompile Include="..\..\xbmc\AutoSwitch.cpp" />
@@ -1033,6 +1034,7 @@
     <ClCompile Include="..\..\xbmc\TextureDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\DatabaseManager.cpp" />
     <ClInclude Include="..\..\xbmc\addons\AddonCallbacksCodec.h" />
+    <ClInclude Include="..\..\xbmc\ApplicationPlayer.h" />
     <ClInclude Include="..\..\xbmc\AppParamParser.h" />
     <ClInclude Include="..\..\xbmc\cores\AudioEngine\AEAudioFormat.h" />
     <ClInclude Include="..\..\xbmc\cores\AudioEngine\AEFactory.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3075,6 +3075,7 @@
     <ClCompile Include="..\..\xbmc\utils\ActorProtocol.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\ApplicationPlayer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6029,6 +6030,7 @@
     <ClInclude Include="..\..\xbmc\utils\ActorProtocol.h">
       <Filter>utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\ApplicationPlayer.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -177,10 +177,6 @@ public:
   void Restart(bool bSamePosition = true);
   void DelayedPlayerRestart();
   void CheckDelayedPlayerRestart();
-  bool IsPlaying() const;
-  bool IsPaused() const;
-  bool IsPlayingAudio() const;
-  bool IsPlayingVideo() const;
   bool IsPlayingFullScreenVideo() const;
   bool IsStartingPlayback() const { return m_bPlaybackStarting; }
   bool IsFullScreen();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -65,6 +65,8 @@ class CPlayerController;
 #include "windowing/XBMC_events.h"
 #include "threads/Thread.h"
 
+#include "ApplicationPlayer.h"
+
 class CSeekHandler;
 class CKaraokeLyricsManager;
 class CInertialScrollingHandler;
@@ -109,16 +111,10 @@ protected:
   int       m_iPlayList;
 };
 
-typedef enum
-{
-  PLAYBACK_CANCELED = -1,
-  PLAYBACK_FAIL = 0,
-  PLAYBACK_OK = 1,
-} PlayBackRet;
-
 class CApplication : public CXBApplicationEx, public IPlayerCallback, public IMsgTargetCallback,
                      public ISettingCallback, public ISettingsHandler, public ISubSettings
 {
+  friend class CApplicationPlayer;
 public:
 
   enum ESERVERS
@@ -273,12 +269,11 @@ public:
   MEDIA_DETECT::CDetectDVDMedia m_DetectDVDType;
 #endif
 
-  boost::shared_ptr<IPlayer> m_pPlayer;
+  CApplicationPlayer* m_pPlayer;
 
   inline bool IsInScreenSaver() { return m_bScreenSave; };
   int m_iScreenSaveLock; // spiff: are we checking for a lock? if so, ignore the screensaver state, if -1 we have failed to input locks
 
-  unsigned int m_iPlayerOPSeq;  // used to detect whether an OpenFile request on player is canceled by us.
   bool m_bPlaybackStarting;
   typedef enum
   {
@@ -413,7 +408,6 @@ protected:
   CStdString m_prevMedia;
   CSplash* m_splash;
   ThreadIdentifier m_threadID;       // application thread ID.  Used in applicationMessanger to know where we are firing a thread with delay from.
-  PLAYERCOREID m_eCurrentPlayer;
   bool m_bInitializing;
   bool m_bPlatformDirectories;
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -197,13 +197,12 @@ public:
   float GetVolume(bool percentage = true) const;
   void SetVolume(float iValue, bool isPercentage = true);
   bool IsMuted() const;
+  bool IsMutedInternal() const { return m_muted; }
   void ToggleMute(void);
   void SetMute(bool mute);
   void ShowVolumeBar(const CAction *action = NULL);
-  int GetPlaySpeed() const;
   int GetSubtitleDelay() const;
   int GetAudioDelay() const;
-  void SetPlaySpeed(int iSpeed);
   void ResetSystemIdleTimer();
   void ResetScreenSaverTimer();
   void StopScreenSaverTimer();
@@ -411,7 +410,6 @@ protected:
   CFileItemPtr m_progressTrackingItem;
   bool m_progressTrackingPlayCountUpdate;
 
-  int m_iPlaySpeed;
   int m_currentStackPosition;
   int m_nextPlaylistItem;
 

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -504,7 +504,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       break;
 
     case TMSG_MEDIA_PAUSE:
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         g_application.ResetScreenSaver();
         g_application.WakeUpScreenSaverAndDPMS();

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -391,7 +391,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         if (!pSlideShow) return ;
 
         // stop playing file
-        if (g_application.IsPlayingVideo()) g_application.StopPlaying();
+        if (g_application.m_pPlayer->IsPlayingVideo()) g_application.StopPlaying();
 
         if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
           g_windowManager.PreviousWindow();
@@ -439,7 +439,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         CGUIWindowSlideShow *pSlideShow = (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
         if (!pSlideShow) return ;
 
-        if (g_application.IsPlayingVideo())
+        if (g_application.m_pPlayer->IsPlayingVideo())
           g_application.StopPlaying();
 
         g_graphicsContext.Lock();
@@ -499,7 +499,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         g_application.WakeUpScreenSaverAndDPMS();
 
         // stop playing file
-        if (g_application.IsPlaying()) g_application.StopPlaying();
+        if (g_application.m_pPlayer->IsPlaying()) g_application.StopPlaying();
       }
       break;
 
@@ -513,7 +513,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       break;
 
     case TMSG_MEDIA_UNPAUSE:
-      if (g_application.IsPaused())
+      if (g_application.m_pPlayer->IsPausedPlayback())
       {
         g_application.ResetScreenSaver();
         g_application.WakeUpScreenSaverAndDPMS();
@@ -522,7 +522,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       break;
 
     case TMSG_MEDIA_PAUSE_IF_PLAYING:
-      if (g_application.IsPlaying() && !g_application.IsPaused())
+      if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
       {
         g_application.ResetScreenSaver();
         g_application.WakeUpScreenSaverAndDPMS();

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -175,6 +175,21 @@ bool CApplicationPlayer::IsPlaying() const
   return (player && player->IsPlaying());
 }
 
+bool CApplicationPlayer::IsPausedPlayback() const
+{
+  return (IsPlaying() && IsPaused());
+}
+
+bool CApplicationPlayer::IsPlayingAudio() const
+{
+  return (IsPlaying() && !HasVideo() && HasAudio());
+}
+
+bool CApplicationPlayer::IsPlayingVideo() const
+{
+  return (IsPlaying() && HasVideo());
+}
+
 void CApplicationPlayer::Pause()
 {
   boost::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -21,6 +21,9 @@
 #include "ApplicationPlayer.h"
 #include "cores/IPlayer.h"
 
+#define VOLUME_MINIMUM 0.0f        // -60dB
+#define VOLUME_MAXIMUM 1.0f        // 0dB
+
 CApplicationPlayer::CApplicationPlayer()
 {
   m_iPlayerOPSeq = 0;
@@ -656,7 +659,7 @@ void CApplicationPlayer::GetScalingMethods(std::vector<int> &scalingMethods)
     player->GetScalingMethods(scalingMethods);
 }
 
-void CApplicationPlayer::SetPlaySpeed(int iSpeed)
+void CApplicationPlayer::SetPlaySpeed(int iSpeed, bool bApplicationMuted)
 {
   if (!IsPlayingAudio() && !IsPlayingVideo())
     return ;
@@ -690,7 +693,7 @@ void CApplicationPlayer::SetPlaySpeed(int iSpeed)
     { // mute volume
       m_pPlayer->SetVolume(VOLUME_MINIMUM);
     }
-    m_pPlayer->SetMute(g_application.m_muted);
+    m_pPlayer->SetMute(bApplicationMuted);
   }
 }
 
@@ -698,4 +701,3 @@ int CApplicationPlayer::GetPlaySpeed() const
 {
   return m_iPlaySpeed;
 }
-

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -1,0 +1,686 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ApplicationPlayer.h"
+#include "cores/IPlayer.h"
+
+CApplicationPlayer::CApplicationPlayer()
+{
+  m_iPlayerOPSeq = 0;
+  m_eCurrentPlayer = EPC_NONE;
+}
+
+boost::shared_ptr<IPlayer> CApplicationPlayer::GetInternal() const
+{
+  CSingleLock lock(m_player_lock);
+  return m_pPlayer;
+}
+
+void CApplicationPlayer::ClosePlayer()
+{
+  CSingleLock lock(m_player_lock);
+  if (m_pPlayer)
+  {
+    CloseFile();
+    m_pPlayer.reset();
+  }
+}
+
+void CApplicationPlayer::CloseFile()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    ++m_iPlayerOPSeq;
+    player->CloseFile();
+  }
+}
+
+void CApplicationPlayer::ClosePlayerGapless(PLAYERCOREID newCore)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (!player)
+    return;
+
+  bool gaplessSupported = (m_eCurrentPlayer == EPC_DVDPLAYER || m_eCurrentPlayer == EPC_PAPLAYER);
+#if defined(HAS_OMXPLAYER)
+  gaplessSupported = gaplessSupported || (m_eCurrentPlayer == EPC_OMXPLAYER);
+#endif            
+  gaplessSupported = gaplessSupported && (m_eCurrentPlayer == newCore);
+  if (!gaplessSupported)
+  {
+    ClosePlayer();
+  }
+  else
+  {
+    // XXX: we had to stop the previous playing item, it was done in dvdplayer::OpenFile.
+    // but in paplayer::OpenFile, it sometimes just fade in without call CloseFile.
+    // but if we do not stop it, we can not distingush callbacks from previous
+    // item and current item, it will confused us then we can not make correct delay
+    // callback after the starting state.
+    CloseFile();
+  }
+}
+
+void CApplicationPlayer::CreatePlayer(PLAYERCOREID newCore, IPlayerCallback& callback)
+{
+  CSingleLock lock(m_player_lock);
+  if (!m_pPlayer)
+  {
+    m_eCurrentPlayer = newCore;
+    m_pPlayer.reset(CPlayerCoreFactory::Get().CreatePlayer(newCore, callback));
+  }
+}
+
+PlayBackRet CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& options)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  PlayBackRet iResult = PLAYBACK_FAIL;
+  if (player)
+  {
+    // op seq for detect cancel (CloseFile be called or OpenFile be called again) during OpenFile.
+    unsigned int startingSeq = ++m_iPlayerOPSeq;
+
+    iResult = player->OpenFile(item, options) ? PLAYBACK_OK : PLAYBACK_FAIL;
+    // check whether the OpenFile was canceled by either CloseFile or another OpenFile.
+    if (m_iPlayerOPSeq != startingSeq)
+      iResult = PLAYBACK_CANCELED;
+  }
+  return iResult;
+}
+
+bool CApplicationPlayer::HasPlayer() const 
+{ 
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return player != NULL; 
+}
+
+void CApplicationPlayer::RegisterAudioCallback(IAudioCallback* pCallback)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->RegisterAudioCallback(pCallback);
+}
+
+void CApplicationPlayer::UnRegisterAudioCallback()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->UnRegisterAudioCallback();
+}
+
+int CApplicationPlayer::GetChapter()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetChapter();
+  else 
+    return -1;
+}
+
+int CApplicationPlayer::GetChapterCount()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetChapterCount();
+  else 
+    return 0;
+}
+
+void CApplicationPlayer::GetChapterName(CStdString& strChapterName)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetChapterName(strChapterName);
+}
+
+bool CApplicationPlayer::HasAudio() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->HasAudio());
+}
+
+bool CApplicationPlayer::HasVideo() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->HasVideo());
+}
+
+bool CApplicationPlayer::IsPaused() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->IsPaused());
+}
+
+bool CApplicationPlayer::IsPlaying() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->IsPlaying());
+}
+
+void CApplicationPlayer::Pause()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->Pause();
+}
+
+bool CApplicationPlayer::ControlsVolume() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->ControlsVolume());
+}
+
+void CApplicationPlayer::SetMute(bool bOnOff)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetMute(bOnOff);
+}
+
+void CApplicationPlayer::SetVolume(float volume)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetVolume(volume);
+}
+
+void CApplicationPlayer::Seek(bool bPlus, bool bLargeStep)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->Seek(bPlus, bLargeStep);
+}
+
+void CApplicationPlayer::SeekPercentage(float fPercent)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SeekPercentage(fPercent);
+}
+
+bool CApplicationPlayer::IsPassthrough() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->IsPassthrough());
+}
+
+bool CApplicationPlayer::CanSeek()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->CanSeek());
+}
+
+bool CApplicationPlayer::SeekScene(bool bPlus)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->SeekScene(bPlus));
+}
+
+void CApplicationPlayer::SeekTime(int64_t iTime)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SeekTime(iTime);
+}
+
+CStdString CApplicationPlayer::GetPlayingTitle()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetPlayingTitle();
+  else
+    return "";
+}
+
+int64_t CApplicationPlayer::GetTime() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetTime();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetPictureHeight()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetPictureHeight();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetPictureWidth()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetPictureWidth();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetSampleRate()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetSampleRate();
+  else
+    return 0;
+}
+
+bool CApplicationPlayer::IsCaching() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->IsCaching());
+}
+
+bool CApplicationPlayer::IsInMenu() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->IsInMenu());
+}
+
+bool CApplicationPlayer::HasMenu() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->HasMenu());
+}
+
+int CApplicationPlayer::GetCacheLevel() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetCacheLevel();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetSubtitleCount()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetSubtitleCount();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetBitsPerSample()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetBitsPerSample();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetAudioStream()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetAudioStream();
+  else
+    return 0;
+}
+
+int CApplicationPlayer::GetSubtitle()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetSubtitle();
+  else
+    return 0;
+}
+
+bool CApplicationPlayer::GetSubtitleVisible()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->GetSubtitleVisible());
+}
+
+bool CApplicationPlayer::CanRecord()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->CanRecord());
+}
+
+bool CApplicationPlayer::CanPause()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->CanPause());
+}
+
+bool CApplicationPlayer::IsRecording() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->IsRecording());
+}
+
+TextCacheStruct_t* CApplicationPlayer::GetTeletextCache()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetTeletextCache();
+  else
+    return NULL;
+}
+
+int64_t CApplicationPlayer::GetTotalTime() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetTotalTime();
+  else
+    return 0;
+}
+
+float CApplicationPlayer::GetPercentage() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetPercentage();
+  else
+    return 0.0;
+}
+
+float CApplicationPlayer::GetCachePercentage() const
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetCachePercentage();
+  else
+    return 0.0;
+}
+
+void CApplicationPlayer::ToFFRW(int iSpeed)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->ToFFRW(iSpeed);
+}
+
+void CApplicationPlayer::DoAudioWork()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->DoAudioWork();
+}
+
+CStdString CApplicationPlayer::GetPlayerState()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetPlayerState();
+  else
+    return "";
+}
+
+bool CApplicationPlayer::QueueNextFile(const CFileItem &file)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->QueueNextFile(file));
+}
+
+bool CApplicationPlayer::GetStreamDetails(CStreamDetails &details)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->GetStreamDetails(details));
+}
+
+bool CApplicationPlayer::SetPlayerState(CStdString state)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->SetPlayerState(state));
+}
+
+void CApplicationPlayer::OnNothingToQueueNotify()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->OnNothingToQueueNotify();
+}
+
+void CApplicationPlayer::GetVideoStreamInfo(SPlayerVideoStreamInfo &info)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetVideoStreamInfo(info);
+}
+
+void CApplicationPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetAudioStreamInfo(index, info);
+}
+
+bool CApplicationPlayer::OnAction(const CAction &action)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->OnAction(action));
+}
+
+bool CApplicationPlayer::Record(bool bOnOff)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->Record(bOnOff));
+}
+
+int  CApplicationPlayer::GetAudioStreamCount()
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetAudioStreamCount();
+  else
+    return 0;
+}
+
+void CApplicationPlayer::SetAudioStream(int iStream)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetAudioStream(iStream);
+}
+
+void CApplicationPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetSubtitleStreamInfo(index, info);
+}
+
+void CApplicationPlayer::SetSubtitle(int iStream)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetSubtitle(iStream);
+}
+
+void CApplicationPlayer::SetSubtitleVisible(bool bVisible)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetSubtitleVisible(bVisible);
+}
+
+int  CApplicationPlayer::AddSubtitle(const CStdString& strSubPath)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->AddSubtitle(strSubPath);
+  else
+    return 0;
+}
+
+void CApplicationPlayer::SetSubTitleDelay(float fValue)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetSubTitleDelay(fValue);
+}
+
+void CApplicationPlayer::SetAVDelay(float fValue)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetAVDelay(fValue);
+}
+
+void CApplicationPlayer::SetDynamicRangeCompression(long drc)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetDynamicRangeCompression(drc);
+}
+
+bool CApplicationPlayer::SwitchChannel(const PVR::CPVRChannel &channel)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->SwitchChannel(channel));
+}
+
+void CApplicationPlayer::LoadPage(int p, int sp, unsigned char* buffer)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->LoadPage(p, sp, buffer);
+}
+
+void CApplicationPlayer::GetAudioCapabilities(std::vector<int> &audioCaps)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetAudioCapabilities(audioCaps);
+}
+
+void CApplicationPlayer::GetSubtitleCapabilities(std::vector<int> &subCaps)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetSubtitleCapabilities(subCaps);
+}
+
+void CApplicationPlayer::GetAudioInfo( CStdString& strAudioInfo)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetAudioInfo(strAudioInfo);
+}
+
+void CApplicationPlayer::GetVideoInfo( CStdString& strVideoInfo)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetVideoInfo(strVideoInfo);
+}
+
+void CApplicationPlayer::GetGeneralInfo( CStdString& strVideoInfo)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetGeneralInfo(strVideoInfo);
+}
+
+bool CApplicationPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->GetCurrentSubtitle(strSubtitle));
+}
+
+int  CApplicationPlayer::SeekChapter(int iChapter)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->SeekChapter(iChapter);
+  else
+    return 0;
+}
+
+void CApplicationPlayer::GetRenderFeatures(std::vector<int> &renderFeatures)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetRenderFeatures(renderFeatures);
+}
+
+void CApplicationPlayer::GetDeinterlaceMethods(std::vector<int> &deinterlaceMethods)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetDeinterlaceMethods(deinterlaceMethods);
+}
+
+void CApplicationPlayer::GetDeinterlaceModes(std::vector<int> &deinterlaceModes)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetDeinterlaceModes(deinterlaceModes);
+}
+
+void CApplicationPlayer::GetScalingMethods(std::vector<int> &scalingMethods)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->GetScalingMethods(scalingMethods);
+}
+
+void CApplicationPlayer::SetPlaySpeed(int iSpeed)
+{
+  if (!IsPlayingAudio() && !IsPlayingVideo())
+    return ;
+  if (m_iPlaySpeed == iSpeed)
+    return ;
+  if (!CanSeek())
+    return;
+  if (IsPaused())
+  {
+    if (
+      ((m_iPlaySpeed > 1) && (iSpeed > m_iPlaySpeed)) ||
+      ((m_iPlaySpeed < -1) && (iSpeed < m_iPlaySpeed))
+    )
+    {
+      iSpeed = m_iPlaySpeed; // from pause to ff/rw, do previous ff/rw speed
+    }
+    Pause();
+  }
+  m_iPlaySpeed = iSpeed;
+
+  ToFFRW(m_iPlaySpeed);
+
+  // if player has volume control, set it.
+  if (ControlsVolume())
+  {
+    if (m_iPlaySpeed == 1)
+    { // restore volume
+      m_pPlayer->SetVolume(VOLUME_MAXIMUM);
+    }
+    else
+    { // mute volume
+      m_pPlayer->SetVolume(VOLUME_MINIMUM);
+    }
+    m_pPlayer->SetMute(g_application.m_muted);
+  }
+}
+
+int CApplicationPlayer::GetPlaySpeed() const
+{
+  return m_iPlaySpeed;
+}
+

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -115,9 +115,11 @@ public:
   bool  IsCaching() const;
   bool  IsInMenu() const;
   bool  IsPaused() const;
+  bool  IsPausedPlayback() const;
   bool  IsPassthrough() const;
   bool  IsPlaying() const;
-  bool  IsRecording() const;
+  bool  IsPlayingAudio() const;
+  bool  IsPlayingVideo() const;  bool  IsRecording() const;
   void  LoadPage(int p, int sp, unsigned char* buffer);
   bool  OnAction(const CAction &action);
   void  OnNothingToQueueNotify();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -1,0 +1,145 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <boost/shared_ptr.hpp>
+#include "threads/SingleLock.h"
+#include "cores/playercorefactory/PlayerCoreFactory.h"
+
+typedef enum
+{
+  PLAYBACK_CANCELED = -1,
+  PLAYBACK_FAIL = 0,
+  PLAYBACK_OK = 1,
+} PlayBackRet;
+
+namespace PVR
+{
+  class CPVRChannel;
+}
+
+class IAudioCallback;
+class CAction;
+class CPlayerOptions;
+class CStreamDetails;
+
+struct SPlayerAudioStreamInfo;
+struct SPlayerVideoStreamInfo;
+struct SPlayerSubtitleStreamInfo;
+struct TextCacheStruct_t;
+
+class CApplicationPlayer
+{
+  boost::shared_ptr<IPlayer> m_pPlayer;
+  unsigned int m_iPlayerOPSeq;  // used to detect whether an OpenFile request on player is canceled by us.
+  PLAYERCOREID m_eCurrentPlayer;
+
+  CCriticalSection  m_player_lock;
+  
+public:
+  CApplicationPlayer();
+
+  // player management
+  void CloseFile();
+  void ClosePlayer();
+  void ClosePlayerGapless(PLAYERCOREID newCore);
+  void CreatePlayer(PLAYERCOREID newCore, IPlayerCallback& callback);
+  bool HasPlayer() const;
+  PLAYERCOREID GetCurrentPlayer() const { return m_eCurrentPlayer; }
+  boost::shared_ptr<IPlayer> GetInternal() const;
+  PlayBackRet OpenFile(const CFileItem& item, const CPlayerOptions& options);
+  void ResetPlayer() { m_eCurrentPlayer = EPC_NONE; }
+
+  // proxy calls
+  int   AddSubtitle(const CStdString& strSubPath);
+  bool  CanPause();
+  bool  CanRecord();
+  bool  CanSeek();
+  bool  ControlsVolume() const;
+  void  DoAudioWork();
+  void  GetAudioCapabilities(std::vector<int> &audioCaps);
+  void  GetAudioInfo( CStdString& strAudioInfo);
+  int   GetAudioStream();
+  int   GetAudioStreamCount();
+  void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
+  int   GetBitsPerSample();
+  int   GetCacheLevel() const;
+  float GetCachePercentage() const;
+  int   GetChapterCount();
+  int   GetChapter();  
+  void  GetChapterName(CStdString& strChapterName);
+  void  GetDeinterlaceMethods(std::vector<int> &deinterlaceMethods);
+  void  GetDeinterlaceModes(std::vector<int> &deinterlaceModes);
+  bool  GetCurrentSubtitle(CStdString& strSubtitle);
+  void  GetGeneralInfo( CStdString& strVideoInfo);
+  float GetPercentage() const;
+  int   GetPictureHeight();
+  int   GetPictureWidth();
+  CStdString GetPlayerState();
+  CStdString GetPlayingTitle();
+  void  GetRenderFeatures(std::vector<int> &renderFeatures);
+  int   GetSampleRate();
+  void  GetScalingMethods(std::vector<int> &scalingMethods);
+  bool  GetStreamDetails(CStreamDetails &details);
+  int   GetSubtitle();
+  void  GetSubtitleCapabilities(std::vector<int> &subCaps);
+  int   GetSubtitleCount();
+  void  GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
+  bool  GetSubtitleVisible();
+  TextCacheStruct_t* GetTeletextCache();
+  int64_t GetTime() const;
+  int64_t GetTotalTime() const;
+  void  GetVideoInfo( CStdString& strVideoInfo);
+  void  GetVideoStreamInfo(SPlayerVideoStreamInfo &info);
+  bool  HasAudio() const;
+  bool  HasMenu() const;
+  bool  HasVideo() const;
+  bool  IsCaching() const;
+  bool  IsInMenu() const;
+  bool  IsPaused() const;
+  bool  IsPassthrough() const;
+  bool  IsPlaying() const;
+  bool  IsRecording() const;
+  void  LoadPage(int p, int sp, unsigned char* buffer);
+  bool  OnAction(const CAction &action);
+  void  OnNothingToQueueNotify();
+  void  Pause();
+  bool  QueueNextFile(const CFileItem &file);
+  bool  Record(bool bOnOff);
+  void  RegisterAudioCallback(IAudioCallback* pCallback);
+  void  Seek(bool bPlus = true, bool bLargeStep = false);
+  int   SeekChapter(int iChapter);
+  void  SeekPercentage(float fPercent = 0);
+  bool  SeekScene(bool bPlus = true);
+  void  SeekTime(int64_t iTime = 0);
+  void  SetAudioStream(int iStream);
+  void  SetAVDelay(float fValue = 0.0f);
+  void  SetDynamicRangeCompression(long drc);
+  void  SetMute(bool bOnOff);
+  bool  SetPlayerState(CStdString state);
+  void  SetSubtitle(int iStream);
+  void  SetSubTitleDelay(float fValue = 0.0f);
+  void  SetSubtitleVisible(bool bVisible);
+  void  SetVolume(float volume);
+  bool  SwitchChannel(const PVR::CPVRChannel &channel);
+  void  ToFFRW(int iSpeed = 0);
+  void  UnRegisterAudioCallback();
+};

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -57,16 +57,20 @@ class CApplicationPlayer
 public:
   CApplicationPlayer();
 
+  int m_iPlaySpeed;
+
   // player management
   void CloseFile();
   void ClosePlayer();
   void ClosePlayerGapless(PLAYERCOREID newCore);
   void CreatePlayer(PLAYERCOREID newCore, IPlayerCallback& callback);
-  bool HasPlayer() const;
   PLAYERCOREID GetCurrentPlayer() const { return m_eCurrentPlayer; }
   boost::shared_ptr<IPlayer> GetInternal() const;
+  int  GetPlaySpeed() const;
+  bool HasPlayer() const;
   PlayBackRet OpenFile(const CFileItem& item, const CPlayerOptions& options);
   void ResetPlayer() { m_eCurrentPlayer = EPC_NONE; }
+  void SetPlaySpeed(int iSpeed, bool bApplicationMuted);
 
   // proxy calls
   int   AddSubtitle(const CStdString& strSubPath);

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -60,7 +60,7 @@ CAutorun::~CAutorun()
 
 void CAutorun::ExecuteAutorun(const CStdString& path, bool bypassSettings, bool ignoreplaying, bool startFromBeginning )
 {
-  if ((!ignoreplaying && (g_application.IsPlayingAudio() || g_application.IsPlayingVideo() || g_windowManager.HasModalDialog())) || g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN)
+  if ((!ignoreplaying && (g_application.m_pPlayer->IsPlayingAudio() || g_application.m_pPlayer->IsPlayingVideo() || g_windowManager.HasModalDialog())) || g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN)
     return ;
 
   CCdInfo* pInfo = g_mediaManager.GetCdInfo(path);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1363,30 +1363,30 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     strLabel.Format("%2.3f s", CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
     break;
   case PLAYER_CHAPTER:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
       strLabel.Format("%02d", g_application.m_pPlayer->GetChapter());
     break;
   case PLAYER_CHAPTERCOUNT:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
       strLabel.Format("%02d", g_application.m_pPlayer->GetChapterCount());
     break;
   case PLAYER_CHAPTERNAME:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
       g_application.m_pPlayer->GetChapterName(strLabel);
     break;
   case PLAYER_CACHELEVEL:
     {
       int iLevel = 0;
-      if(g_application.IsPlaying() && GetInt(iLevel, PLAYER_CACHELEVEL) && iLevel >= 0)
+      if(g_application.m_pPlayer->IsPlaying() && GetInt(iLevel, PLAYER_CACHELEVEL) && iLevel >= 0)
         strLabel.Format("%i", iLevel);
     }
     break;
   case PLAYER_TIME:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
       strLabel = GetCurrentPlayTime(TIME_FORMAT_HH_MM);
     break;
   case PLAYER_DURATION:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
       strLabel = GetDuration(TIME_FORMAT_HH_MM);
     break;
   case PLAYER_PATH:
@@ -1511,32 +1511,32 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     strLabel = GetVideoLabel(info);
   break;
   case VIDEOPLAYER_VIDEO_CODEC:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
     {
       UpdateAVInfo();
       strLabel = m_videoInfo.videoCodecName;
     }
     break;
   case VIDEOPLAYER_VIDEO_RESOLUTION:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
       return CStreamDetails::VideoDimsToResolutionDescription(g_application.m_pPlayer->GetPictureWidth(), g_application.m_pPlayer->GetPictureHeight());
     break;
   case VIDEOPLAYER_AUDIO_CODEC:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
     {
       UpdateAVInfo();
       strLabel = m_audioInfo.audioCodecName;
     }
     break;
   case VIDEOPLAYER_VIDEO_ASPECT:
-    if (g_application.IsPlaying())
+    if (g_application.m_pPlayer->IsPlaying())
     {
       UpdateAVInfo();
       strLabel = CStreamDetails::VideoAspectToAspectDescription(m_videoInfo.videoAspectRatio);
     }
     break;
   case VIDEOPLAYER_AUDIO_CHANNELS:
-    if(g_application.IsPlaying())
+    if(g_application.m_pPlayer->IsPlaying())
     {
       UpdateAVInfo();
       strLabel.Format("%i", m_audioInfo.channels);
@@ -1959,7 +1959,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
     case PLAYER_CHAPTER:
     case PLAYER_CHAPTERCOUNT:
       {
-        if( g_application.IsPlaying())
+        if( g_application.m_pPlayer->IsPlaying())
         {
           switch( info )
           {
@@ -2229,11 +2229,11 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   }
   else if (condition == SKIN_HAS_VIDEO_OVERLAY)
   {
-    bReturn = g_windowManager.IsOverlayAllowed() && g_application.IsPlayingVideo();
+    bReturn = g_windowManager.IsOverlayAllowed() && g_application.m_pPlayer->IsPlayingVideo();
   }
   else if (condition == SKIN_HAS_MUSIC_OVERLAY)
   {
-    bReturn = g_windowManager.IsOverlayAllowed() && g_application.IsPlayingAudio();
+    bReturn = g_windowManager.IsOverlayAllowed() && g_application.m_pPlayer->IsPlayingAudio();
   }
   else if (condition == CONTAINER_HASFILES || condition == CONTAINER_HASFOLDERS)
   {
@@ -2337,7 +2337,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     CGUIWindowSlideShow *slideShow = (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
     bReturn = (slideShow && slideShow->GetCurrentSlide() && slideShow->GetCurrentSlide()->IsVideo());
   }
-  else if (g_application.IsPlaying())
+  else if (g_application.m_pPlayer->IsPlaying())
   {
     switch (condition)
     {
@@ -2345,52 +2345,52 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = true;
       break;
     case PLAYER_HAS_AUDIO:
-      bReturn = g_application.IsPlayingAudio();
+      bReturn = g_application.m_pPlayer->IsPlayingAudio();
       break;
     case PLAYER_HAS_VIDEO:
-      bReturn = g_application.IsPlayingVideo();
+      bReturn = g_application.m_pPlayer->IsPlayingVideo();
       break;
     case PLAYER_PLAYING:
-      bReturn = !g_application.IsPaused() && (g_application.GetPlaySpeed() == 1);
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && (g_application.GetPlaySpeed() == 1);
       break;
     case PLAYER_PAUSED:
-      bReturn = g_application.IsPaused();
+      bReturn = g_application.m_pPlayer->IsPausedPlayback();
       break;
     case PLAYER_REWINDING:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() < 1;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() < 1;
       break;
     case PLAYER_FORWARDING:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() > 1;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() > 1;
       break;
     case PLAYER_REWINDING_2x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == -2;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -2;
       break;
     case PLAYER_REWINDING_4x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == -4;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -4;
       break;
     case PLAYER_REWINDING_8x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == -8;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -8;
       break;
     case PLAYER_REWINDING_16x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == -16;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -16;
       break;
     case PLAYER_REWINDING_32x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == -32;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -32;
       break;
     case PLAYER_FORWARDING_2x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == 2;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 2;
       break;
     case PLAYER_FORWARDING_4x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == 4;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 4;
       break;
     case PLAYER_FORWARDING_8x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == 8;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 8;
       break;
     case PLAYER_FORWARDING_16x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == 16;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 16;
       break;
     case PLAYER_FORWARDING_32x:
-      bReturn = !g_application.IsPaused() && g_application.GetPlaySpeed() == 32;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 32;
       break;
     case PLAYER_CAN_RECORD:
       bReturn = g_application.m_pPlayer->CanRecord();
@@ -2450,7 +2450,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     case MUSICPLAYER_PLAYLISTPLAYING:
       {
         bReturn = false;
-        if (g_application.IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+        if (g_application.m_pPlayer->IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
           bReturn = true;
       }
       break;
@@ -3184,24 +3184,24 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow, CStdString *fa
   }
   else if (info == MUSICPLAYER_COVER)
   {
-    if (!g_application.IsPlayingAudio()) return "";
+    if (!g_application.m_pPlayer->IsPlayingAudio()) return "";
     if (fallback)
       *fallback = "DefaultAlbumCover.png";
     return m_currentFile->HasArt("thumb") ? m_currentFile->GetArt("thumb") : "DefaultAlbumCover.png";
   }
   else if (info == MUSICPLAYER_RATING)
   {
-    if (!g_application.IsPlayingAudio()) return "";
+    if (!g_application.m_pPlayer->IsPlayingAudio()) return "";
     return GetItemImage(m_currentFile, LISTITEM_RATING);
   }
   else if (info == PLAYER_STAR_RATING)
   {
-    if (!g_application.IsPlaying()) return "";
+    if (!g_application.m_pPlayer->IsPlaying()) return "";
     return GetItemImage(m_currentFile, LISTITEM_STAR_RATING);
   }
   else if (info == VIDEOPLAYER_COVER)
   {
-    if (!g_application.IsPlayingVideo()) return "";
+    if (!g_application.m_pPlayer->IsPlayingVideo()) return "";
     if (fallback)
       *fallback = "DefaultVideoCover.png";
     if(m_currentMovieThumb.IsEmpty())
@@ -3292,13 +3292,13 @@ CStdString CGUIInfoManager::LocalizeTime(const CDateTime &time, TIME_FORMAT form
 
 CStdString CGUIInfoManager::GetDuration(TIME_FORMAT format) const
 {
-  if (g_application.IsPlayingAudio() && m_currentFile->HasMusicInfoTag())
+  if (g_application.m_pPlayer->IsPlayingAudio() && m_currentFile->HasMusicInfoTag())
   {
     const CMusicInfoTag& tag = *m_currentFile->GetMusicInfoTag();
     if (tag.GetDuration() > 0)
       return StringUtils::SecondsToTimeString(tag.GetDuration(), format);
   }
-  if (g_application.IsPlayingVideo() && !m_currentMovieDuration.IsEmpty())
+  if (g_application.m_pPlayer->IsPlayingVideo() && !m_currentMovieDuration.IsEmpty())
     return m_currentMovieDuration;  // for tuxbox
   unsigned int iTotal = (unsigned int)g_application.GetTotalTime();
   if (iTotal > 0)
@@ -3396,7 +3396,7 @@ const CStdString CGUIInfoManager::GetMusicPlaylistInfo(const GUIInfo& info)
 
 CStdString CGUIInfoManager::GetPlaylistLabel(int item) const
 {
-  if (!g_application.IsPlaying()) return "";
+  if (!g_application.m_pPlayer->IsPlaying()) return "";
   int iPlaylist = g_playlistPlayer.GetCurrentPlaylist();
   switch (item)
   {
@@ -3435,7 +3435,7 @@ CStdString CGUIInfoManager::GetPlaylistLabel(int item) const
 
 CStdString CGUIInfoManager::GetMusicLabel(int item)
 {
-  if (!g_application.IsPlaying() || !m_currentFile->HasMusicInfoTag()) return "";
+  if (!g_application.m_pPlayer->IsPlaying() || !m_currentFile->HasMusicInfoTag()) return "";
 
   UpdateAVInfo();
   switch (item)
@@ -3583,12 +3583,12 @@ CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
 
 CStdString CGUIInfoManager::GetVideoLabel(int item)
 {
-  if (!g_application.IsPlaying())
+  if (!g_application.m_pPlayer->IsPlaying())
     return "";
 
   if (item == VIDEOPLAYER_TITLE)
   {
-    if(g_application.IsPlayingVideo())
+    if(g_application.m_pPlayer->IsPlayingVideo())
        return GetLabel(PLAYER_TITLE);
   }
   else if (item == VIDEOPLAYER_PLAYLISTLEN)
@@ -3807,7 +3807,7 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
 
 int64_t CGUIInfoManager::GetPlayTime() const
 {
-  if (g_application.IsPlaying())
+  if (g_application.m_pPlayer->IsPlaying())
   {
     int64_t lPTS = (int64_t)(g_application.GetTime() * 1000);
     if (lPTS < 0) lPTS = 0;
@@ -3820,7 +3820,7 @@ CStdString CGUIInfoManager::GetCurrentPlayTime(TIME_FORMAT format) const
 {
   if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
     format = TIME_FORMAT_HH_MM_SS;
-  if (g_application.IsPlaying())
+  if (g_application.m_pPlayer->IsPlaying())
     return StringUtils::SecondsToTimeString((int)(GetPlayTime()/1000), format);
   return "";
 }
@@ -3850,7 +3850,7 @@ CStdString CGUIInfoManager::GetCurrentPlayTimeRemaining(TIME_FORMAT format) cons
   if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
     format = TIME_FORMAT_HH_MM_SS;
   int timeRemaining = GetPlayTimeRemaining();
-  if (timeRemaining && g_application.IsPlaying())
+  if (timeRemaining && g_application.m_pPlayer->IsPlaying())
     return StringUtils::SecondsToTimeString(timeRemaining, format);
   return "";
 }
@@ -3963,7 +3963,7 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
   if (item.IsInternetStream())
   {
     // case where .strm is used to start an audio stream
-    if (g_application.IsPlayingAudio())
+    if (g_application.m_pPlayer->IsPlayingAudio())
     {
       SetCurrentSong(item);
       return;
@@ -4110,7 +4110,7 @@ void CGUIInfoManager::UpdateFPS()
 
 void CGUIInfoManager::UpdateAVInfo()
 {
-  if(g_application.IsPlaying())
+  if(g_application.m_pPlayer->IsPlaying())
   {
     if (!m_AVInfoValid)
     {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1363,15 +1363,15 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     strLabel.Format("%2.3f s", CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
     break;
   case PLAYER_CHAPTER:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
       strLabel.Format("%02d", g_application.m_pPlayer->GetChapter());
     break;
   case PLAYER_CHAPTERCOUNT:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
       strLabel.Format("%02d", g_application.m_pPlayer->GetChapterCount());
     break;
   case PLAYER_CHAPTERNAME:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
       g_application.m_pPlayer->GetChapterName(strLabel);
     break;
   case PLAYER_CACHELEVEL:
@@ -1382,11 +1382,11 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     }
     break;
   case PLAYER_TIME:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
       strLabel = GetCurrentPlayTime(TIME_FORMAT_HH_MM);
     break;
   case PLAYER_DURATION:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
       strLabel = GetDuration(TIME_FORMAT_HH_MM);
     break;
   case PLAYER_PATH:
@@ -1429,7 +1429,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
         if (m_currentFile->HasMusicInfoTag() && !m_currentFile->GetMusicInfoTag()->GetTitle().IsEmpty())
           return m_currentFile->GetMusicInfoTag()->GetTitle();
         // don't have the title, so use dvdplayer, label, or drop down to title from path
-        if (g_application.m_pPlayer && !g_application.m_pPlayer->GetPlayingTitle().IsEmpty())
+        if (!g_application.m_pPlayer->GetPlayingTitle().IsEmpty())
           return g_application.m_pPlayer->GetPlayingTitle();
         if (!m_currentFile->GetLabel().IsEmpty())
           return m_currentFile->GetLabel();
@@ -1437,7 +1437,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
       }
       else
       {
-        if (g_application.m_pPlayer && !g_application.m_pPlayer->GetPlayingTitle().IsEmpty())
+        if (!g_application.m_pPlayer->GetPlayingTitle().IsEmpty())
           return g_application.m_pPlayer->GetPlayingTitle();
       }
     }
@@ -1511,39 +1511,39 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     strLabel = GetVideoLabel(info);
   break;
   case VIDEOPLAYER_VIDEO_CODEC:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
     {
       UpdateAVInfo();
       strLabel = m_videoInfo.videoCodecName;
     }
     break;
   case VIDEOPLAYER_VIDEO_RESOLUTION:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
       return CStreamDetails::VideoDimsToResolutionDescription(g_application.m_pPlayer->GetPictureWidth(), g_application.m_pPlayer->GetPictureHeight());
     break;
   case VIDEOPLAYER_AUDIO_CODEC:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
     {
       UpdateAVInfo();
       strLabel = m_audioInfo.audioCodecName;
     }
     break;
   case VIDEOPLAYER_VIDEO_ASPECT:
-    if (g_application.IsPlaying() && g_application.m_pPlayer)
+    if (g_application.IsPlaying())
     {
       UpdateAVInfo();
       strLabel = CStreamDetails::VideoAspectToAspectDescription(m_videoInfo.videoAspectRatio);
     }
     break;
   case VIDEOPLAYER_AUDIO_CHANNELS:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.IsPlaying())
     {
       UpdateAVInfo();
       strLabel.Format("%i", m_audioInfo.channels);
     }
     break;
   case VIDEOPLAYER_STEREOSCOPIC_MODE:
-    if(g_application.IsPlaying() && g_application.m_pPlayer)
+    if(g_application.m_pPlayer->IsPlaying())
     {
       UpdateAVInfo();
       strLabel = m_videoInfo.stereoMode;
@@ -1959,7 +1959,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
     case PLAYER_CHAPTER:
     case PLAYER_CHAPTERCOUNT:
       {
-        if( g_application.IsPlaying() && g_application.m_pPlayer)
+        if( g_application.IsPlaying())
         {
           switch( info )
           {
@@ -2423,7 +2423,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = m_playerShowTime;
     break;
     case PLAYER_PASSTHROUGH:
-      bReturn = g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough();
+      bReturn = g_application.m_pPlayer->IsPassthrough();
       break;
     case PLAYER_ISINTERNETSTREAM:
       bReturn = m_currentFile && URIUtils::IsInternetStream(m_currentFile->GetPath());
@@ -2507,7 +2507,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       }
     break;
     case VIDEOPLAYER_IS_STEREOSCOPIC:
-      if(g_application.IsPlaying() && g_application.m_pPlayer)
+      if(g_application.m_pPlayer->IsPlaying())
       {
         UpdateAVInfo();
         bReturn = !m_videoInfo.stereoMode.empty();
@@ -4110,7 +4110,7 @@ void CGUIInfoManager::UpdateFPS()
 
 void CGUIInfoManager::UpdateAVInfo()
 {
-  if(g_application.IsPlaying() && g_application.m_pPlayer)
+  if(g_application.IsPlaying())
   {
     if (!m_AVInfoValid)
     {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2351,46 +2351,46 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = g_application.m_pPlayer->IsPlayingVideo();
       break;
     case PLAYER_PLAYING:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && (g_application.GetPlaySpeed() == 1);
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && (g_application.m_pPlayer->GetPlaySpeed() == 1);
       break;
     case PLAYER_PAUSED:
       bReturn = g_application.m_pPlayer->IsPausedPlayback();
       break;
     case PLAYER_REWINDING:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() < 1;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() < 1;
       break;
     case PLAYER_FORWARDING:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() > 1;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() > 1;
       break;
     case PLAYER_REWINDING_2x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -2;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == -2;
       break;
     case PLAYER_REWINDING_4x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -4;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == -4;
       break;
     case PLAYER_REWINDING_8x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -8;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == -8;
       break;
     case PLAYER_REWINDING_16x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -16;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == -16;
       break;
     case PLAYER_REWINDING_32x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == -32;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == -32;
       break;
     case PLAYER_FORWARDING_2x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 2;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == 2;
       break;
     case PLAYER_FORWARDING_4x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 4;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == 4;
       break;
     case PLAYER_FORWARDING_8x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 8;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == 8;
       break;
     case PLAYER_FORWARDING_16x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 16;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == 16;
       break;
     case PLAYER_FORWARDING_32x:
-      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.GetPlaySpeed() == 32;
+      bReturn = !g_application.m_pPlayer->IsPausedPlayback() && g_application.m_pPlayer->GetPlaySpeed() == 32;
       break;
     case PLAYER_CAN_RECORD:
       bReturn = g_application.m_pPlayer->CanRecord();
@@ -3036,8 +3036,8 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
   else if (info.m_info == PLAYER_TIME_SPEED)
   {
     CStdString strTime;
-    if (g_application.GetPlaySpeed() != 1)
-      strTime.Format("%s (%ix)", GetCurrentPlayTime((TIME_FORMAT)info.GetData1()).c_str(), g_application.GetPlaySpeed());
+    if (g_application.m_pPlayer->GetPlaySpeed() != 1)
+      strTime.Format("%s (%ix)", GetCurrentPlayTime((TIME_FORMAT)info.GetData1()).c_str(), g_application.m_pPlayer->GetPlaySpeed());
     else
       strTime = GetCurrentPlayTime();
     return strTime;

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -1,5 +1,6 @@
 SRCS=Application.cpp \
      ApplicationMessenger.cpp \
+     ApplicationPlayer.cpp \
      AppParamParser.cpp \
      Autorun.cpp \
      AutoSwitch.cpp \

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -701,7 +701,7 @@ bool CPartyModeManager::IsEnabled(PartyModeContext context /* = PARTYMODECONTEXT
 
 void CPartyModeManager::Announce()
 {
-  if (g_application.IsPlaying())
+  if (g_application.m_pPlayer->IsPlaying())
   {
     CVariant data;
     

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -576,8 +576,8 @@ void CPlayListPlayer::ReShuffle(int iPlaylist, int iPosition)
   else if (iPlaylist == m_iCurrentPlayList)
   {
     if (
-      (g_application.IsPlayingAudio() && iPlaylist == PLAYLIST_MUSIC) ||
-      (g_application.IsPlayingVideo() && iPlaylist == PLAYLIST_VIDEO)
+      (g_application.m_pPlayer->IsPlayingAudio() && iPlaylist == PLAYLIST_MUSIC) ||
+      (g_application.m_pPlayer->IsPlayingVideo() && iPlaylist == PLAYLIST_VIDEO)
       )
     {
       g_playlistPlayer.GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
@@ -709,8 +709,8 @@ void CPlayListPlayer::Swap(int iPlaylist, int indexItem1, int indexItem2)
 void CPlayListPlayer::AnnouncePropertyChanged(int iPlaylist, const std::string &strProperty, const CVariant &value)
 {
   if (strProperty.empty() || value.isNull() ||
-     (iPlaylist == PLAYLIST_VIDEO && !g_application.IsPlayingVideo()) ||
-     (iPlaylist == PLAYLIST_MUSIC && !g_application.IsPlayingAudio()))
+     (iPlaylist == PLAYLIST_VIDEO && !g_application.m_pPlayer->IsPlayingVideo()) ||
+     (iPlaylist == PLAYLIST_MUSIC && !g_application.m_pPlayer->IsPlayingAudio()))
     return;
 
   CVariant data;

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -108,9 +108,7 @@ bool CVisualisation::Create(int x, int y, int w, int h, void *device)
 
     CreateBuffers();
 
-    if (g_application.m_pPlayer)
-      g_application.m_pPlayer->RegisterAudioCallback(this);
-    CAEFactory::RegisterAudioCallback(this);
+    g_application.m_pPlayer->RegisterAudioCallback(this);
 
     return true;
   }
@@ -174,8 +172,7 @@ void CVisualisation::Render()
 
 void CVisualisation::Stop()
 {
-  if (g_application.m_pPlayer) g_application.m_pPlayer->UnRegisterAudioCallback();
-  CAEFactory::UnregisterAudioCallback();
+  g_application.m_pPlayer->UnRegisterAudioCallback();
   if (Initialized())
   {
     CAddonDll<DllVisualisation, Visualisation, VIS_PROPS>::Stop();

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -293,7 +293,7 @@ void CXBMCApp::XBMC_Pause(bool pause)
 {
   android_printf("XBMC_Pause(%s)", pause ? "true" : "false");
   // Only send the PAUSE action if we are pausing XBMC and something is currently playing
-  if (pause && g_application.IsPlaying() && !g_application.IsPaused())
+  if (pause && g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
     CApplicationMessenger::Get().SendAction(CAction(ACTION_PAUSE), WINDOW_INVALID, true);
 }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -1268,7 +1268,7 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
 
   //disable non-linear stretch when a dvd menu is shown, parts of the menu are rendered through the overlay renderer
   //having non-linear stretch on breaks the alignment
-  if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
+  if (g_application.m_pPlayer->IsInMenu())
     m_pYUVShader->SetNonLinStretch(1.0);
   else
     m_pYUVShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
@@ -1501,7 +1501,7 @@ void CLinuxRendererGL::RenderFromFBO()
 
     //disable non-linear stretch when a dvd menu is shown, parts of the menu are rendered through the overlay renderer
     //having non-linear stretch on breaks the alignment
-    if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
+    if (g_application.m_pPlayer->IsInMenu())
       m_pVideoFilterShader->SetNonLinStretch(1.0);
     else
       m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
@@ -1585,7 +1585,7 @@ void CLinuxRendererGL::RenderVDPAU(int index, int field)
 
     //disable non-linear stretch when a dvd menu is shown, parts of the menu are rendered through the overlay renderer
     //having non-linear stretch on breaks the alignment
-    if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
+    if (g_application.m_pPlayer->IsInMenu())
       m_pVideoFilterShader->SetNonLinStretch(1.0);
     else
       m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
@@ -1680,7 +1680,7 @@ void CLinuxRendererGL::RenderVAAPI(int index, int field)
 
     //disable non-linear stretch when a dvd menu is shown, parts of the menu are rendered through the overlay renderer
     //having non-linear stretch on breaks the alignment
-    if (g_application.m_pPlayer && g_application.m_pPlayer->IsInMenu())
+    if (g_application.m_pPlayer->IsInMenu())
       m_pVideoFilterShader->SetNonLinStretch(1.0);
     else
       m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::Get().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -62,7 +62,7 @@ bool CGUIDialogSeekBar::OnMessage(CGUIMessage& message)
 
 void CGUIDialogSeekBar::FrameMove()
 {
-  if (!g_application.m_pPlayer)
+  if (!g_application.m_pPlayer->HasPlayer())
   {
     Close(true);
     return;

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -55,13 +55,13 @@ void CGUIVideoControl::Render()
   // don't render if we aren't playing video, or if the renderer isn't started
   // (otherwise the lock we have from CApplication::Render() may clash with the startup
   // locks in the RenderManager.)
-  if (g_application.IsPlayingVideo() && g_renderManager.IsStarted())
+  if (g_application.m_pPlayer->IsPlayingVideo() && g_renderManager.IsStarted())
   {
 #else
-  if (g_application.IsPlayingVideo())
+  if (g_application.m_pPlayer->IsPlayingVideo())
   {
 #endif
-    if (!g_application.IsPaused())
+    if (!g_application.m_pPlayer->IsPausedPlayback())
       g_application.ResetScreenSaver();
 
     g_graphicsContext.SetViewWindow(m_posX, m_posY, m_posX + m_width, m_posY + m_height);
@@ -78,7 +78,7 @@ void CGUIVideoControl::Render()
 
 EVENT_RESULT CGUIVideoControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
-  if (!g_application.IsPlayingVideo()) return EVENT_RESULT_UNHANDLED;
+  if (!g_application.m_pPlayer->IsPlayingVideo()) return EVENT_RESULT_UNHANDLED;
   if (event.m_id == ACTION_MOUSE_LEFT_CLICK)
   { // switch to fullscreen
     CGUIMessage message(GUI_MSG_FULLSCREEN, GetID(), GetParentID());

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -61,7 +61,7 @@ void CGUIVideoControl::Render()
   if (g_application.IsPlayingVideo())
   {
 #endif
-    if (!g_application.m_pPlayer->IsPaused())
+    if (!g_application.IsPaused())
       g_application.ResetScreenSaver();
 
     g_graphicsContext.SetViewWindow(m_posX, m_posY, m_posX + m_width, m_posY + m_height);
@@ -70,7 +70,7 @@ void CGUIVideoControl::Render()
     color_t alpha = g_graphicsContext.MergeAlpha(0xFF000000) >> 24;
     g_renderManager.Render(false, 0, alpha);
 #else
-    ((CDummyVideoPlayer *)g_application.m_pPlayer)->Render();
+    ((CDummyVideoPlayer *)g_application.m_pPlayer->GetInternal())->Render();
 #endif
   }
   CGUIControl::Render();

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -94,7 +94,7 @@ bool CGUIVisualisationControl::OnAction(const CAction &action)
 
 void CGUIVisualisationControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  if (g_application.IsPlayingAudio())
+  if (g_application.m_pPlayer->IsPlayingAudio())
   {
     if (m_bInvalidated)
       FreeResources(true);

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -326,7 +326,7 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
   if(m_bFullScreenRoot)
   {
     bool allowDesktopRes = CSettings::Get().GetInt("videoplayer.adjustrefreshrate") == ADJUST_REFRESHRATE_ALWAYS;
-    if(m_bFullScreenVideo || (!allowDesktopRes && g_application.IsPlayingVideo()))
+    if(m_bFullScreenVideo || (!allowDesktopRes && g_application.m_pPlayer->IsPlayingVideo()))
       SetVideoResolution(g_renderManager.GetResolution());
     else if(CDisplaySettings::Get().GetCurrentResolution() > RES_DESKTOP)
       SetVideoResolution(CDisplaySettings::Get().GetCurrentResolution());
@@ -387,7 +387,7 @@ void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate)
   {
     //pause the player during the refreshrate change
     int delay = CSettings::Get().GetInt("videoplayer.pauseafterrefreshchange");
-    if (delay > 0 && CSettings::Get().GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF && g_application.IsPlayingVideo() && !g_application.IsPaused())
+    if (delay > 0 && CSettings::Get().GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF && g_application.m_pPlayer->IsPlayingVideo() && !g_application.m_pPlayer->IsPausedPlayback())
     {
       g_application.m_pPlayer->Pause();
       ThreadMessage msg = {TMSG_MEDIA_UNPAUSE};

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -753,7 +753,7 @@ int CBuiltins::Execute(const CStdString& execString)
     }
     else if (parameter.Equals("rewind") || parameter.Equals("forward"))
     {
-      if (g_application.IsPlaying() && !g_application.m_pPlayer->IsPaused())
+      if (g_application.IsPlaying() && !g_application.IsPaused())
       {
         int iPlaySpeed = g_application.GetPlaySpeed();
         if (parameter.Equals("rewind") && iPlaySpeed == 1) // Enables Rewinding
@@ -822,12 +822,12 @@ int CBuiltins::Execute(const CStdString& execString)
     }
     else if( parameter.Equals("showvideomenu") )
     {
-      if( g_application.IsPlaying() && g_application.m_pPlayer )
+      if( g_application.IsPlaying() )
         g_application.m_pPlayer->OnAction(CAction(ACTION_SHOW_VIDEOMENU));
     }
     else if( parameter.Equals("record") )
     {
-      if( g_application.IsPlaying() && g_application.m_pPlayer && g_application.m_pPlayer->CanRecord())
+      if( g_application.IsPlaying() && g_application.m_pPlayer->CanRecord())
         g_application.m_pPlayer->Record(!g_application.m_pPlayer->IsRecording());
     }
     else if (parameter.Left(9).Equals("partymode"))

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -741,8 +741,8 @@ int CBuiltins::Execute(const CStdString& execString)
       // either resume playing, or pause
       if (g_application.m_pPlayer->IsPlaying())
       {
-        if (g_application.GetPlaySpeed() != 1)
-          g_application.SetPlaySpeed(1);
+        if (g_application.m_pPlayer->GetPlaySpeed() != 1)
+          g_application.m_pPlayer->SetPlaySpeed(1, g_application.IsMutedInternal());
         else
           g_application.m_pPlayer->Pause();
       }
@@ -755,7 +755,7 @@ int CBuiltins::Execute(const CStdString& execString)
     {
       if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
       {
-        int iPlaySpeed = g_application.GetPlaySpeed();
+        int iPlaySpeed = g_application.m_pPlayer->GetPlaySpeed();
         if (parameter.Equals("rewind") && iPlaySpeed == 1) // Enables Rewinding
           iPlaySpeed *= -2;
         else if (parameter.Equals("rewind") && iPlaySpeed > 1) //goes down a notch if you're FFing
@@ -771,7 +771,7 @@ int CBuiltins::Execute(const CStdString& execString)
         if (iPlaySpeed > 32 || iPlaySpeed < -32)
           iPlaySpeed = 1;
 
-        g_application.SetPlaySpeed(iPlaySpeed);
+        g_application.m_pPlayer->SetPlaySpeed(iPlaySpeed, g_application.IsMutedInternal());
       }
     }
     else if (parameter.Equals("next"))

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -739,7 +739,7 @@ int CBuiltins::Execute(const CStdString& execString)
     if (parameter.Equals("play"))
     { // play/pause
       // either resume playing, or pause
-      if (g_application.IsPlaying())
+      if (g_application.m_pPlayer->IsPlaying())
       {
         if (g_application.GetPlaySpeed() != 1)
           g_application.SetPlaySpeed(1);
@@ -753,7 +753,7 @@ int CBuiltins::Execute(const CStdString& execString)
     }
     else if (parameter.Equals("rewind") || parameter.Equals("forward"))
     {
-      if (g_application.IsPlaying() && !g_application.IsPaused())
+      if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
       {
         int iPlaySpeed = g_application.GetPlaySpeed();
         if (parameter.Equals("rewind") && iPlaySpeed == 1) // Enables Rewinding
@@ -784,22 +784,22 @@ int CBuiltins::Execute(const CStdString& execString)
     }
     else if (parameter.Equals("bigskipbackward"))
     {
-      if (g_application.IsPlaying())
+      if (g_application.m_pPlayer->IsPlaying())
         g_application.m_pPlayer->Seek(false, true);
     }
     else if (parameter.Equals("bigskipforward"))
     {
-      if (g_application.IsPlaying())
+      if (g_application.m_pPlayer->IsPlaying())
         g_application.m_pPlayer->Seek(true, true);
     }
     else if (parameter.Equals("smallskipbackward"))
     {
-      if (g_application.IsPlaying())
+      if (g_application.m_pPlayer->IsPlaying())
         g_application.m_pPlayer->Seek(false, false);
     }
     else if (parameter.Equals("smallskipforward"))
     {
-      if (g_application.IsPlaying())
+      if (g_application.m_pPlayer->IsPlaying())
         g_application.m_pPlayer->Seek(true, false);
     }
     else if (parameter.Left(14).Equals("seekpercentage"))
@@ -816,18 +816,18 @@ int CBuiltins::Execute(const CStdString& execString)
         float offsetpercent = (float) atof(offset.c_str());
         if (offsetpercent < 0 || offsetpercent > 100)
           CLog::Log(LOGERROR,"PlayerControl(seekpercentage(n)) argument, %f, must be 0-100", offsetpercent);
-        else if (g_application.IsPlaying())
+        else if (g_application.m_pPlayer->IsPlaying())
           g_application.SeekPercentage(offsetpercent);
       }
     }
     else if( parameter.Equals("showvideomenu") )
     {
-      if( g_application.IsPlaying() )
+      if( g_application.m_pPlayer->IsPlaying() )
         g_application.m_pPlayer->OnAction(CAction(ACTION_SHOW_VIDEOMENU));
     }
     else if( parameter.Equals("record") )
     {
-      if( g_application.IsPlaying() && g_application.m_pPlayer->CanRecord())
+      if( g_application.m_pPlayer->IsPlaying() && g_application.m_pPlayer->CanRecord())
         g_application.m_pPlayer->Record(!g_application.m_pPlayer->IsRecording());
     }
     else if (parameter.Left(9).Equals("partymode"))
@@ -985,7 +985,7 @@ int CBuiltins::Execute(const CStdString& execString)
     // play the desired offset
     int pos = atol(strPos.c_str());
     // playlist is already playing
-    if (g_application.IsPlaying())
+    if (g_application.m_pPlayer->IsPlaying())
       g_playlistPlayer.PlayNext(pos);
     // we start playing the 'other' playlist so we need to use play to initialize the player state
     else

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -244,13 +244,13 @@ JSONRPC_STATUS CPlayerOperations::PlayPause(const CStdString &method, ITransport
         {
           if (g_application.m_pPlayer->IsPausedPlayback())
             CApplicationMessenger::Get().MediaPause();
-          else if (g_application.GetPlaySpeed() != 1)
-            g_application.SetPlaySpeed(1);
+          else if (g_application.m_pPlayer->GetPlaySpeed() != 1)
+            g_application.m_pPlayer->SetPlaySpeed(1, g_application.IsMutedInternal());
         }
         else if (!g_application.m_pPlayer->IsPausedPlayback())
           CApplicationMessenger::Get().MediaPause();
       }
-      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.GetPlaySpeed();
+      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.m_pPlayer->GetPlaySpeed();
       return OK;
 
     case Picture:
@@ -305,7 +305,7 @@ JSONRPC_STATUS CPlayerOperations::SetSpeed(const CStdString &method, ITransportL
           // If the player is paused we first need to unpause
           if (g_application.m_pPlayer->IsPausedPlayback())
             g_application.m_pPlayer->Pause();
-          g_application.SetPlaySpeed(speed);
+          g_application.m_pPlayer->SetPlaySpeed(speed, g_application.IsMutedInternal());
         }
         else
           g_application.m_pPlayer->Pause();
@@ -320,7 +320,7 @@ JSONRPC_STATUS CPlayerOperations::SetSpeed(const CStdString &method, ITransportL
       else
         return InvalidParams;
 
-      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.GetPlaySpeed();
+      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.m_pPlayer->GetPlaySpeed();
       return OK;
 
     case Picture:
@@ -1052,7 +1052,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     {
       case Video:
       case Audio:
-        result = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.GetPlaySpeed();
+        result = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.m_pPlayer->GetPlaySpeed();
         break;
 
       case Picture:

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -233,7 +233,7 @@ JSONRPC_STATUS CPlayerOperations::PlayPause(const CStdString &method, ITransport
   {
     case Video:
     case Audio:
-      if (g_application.m_pPlayer && !g_application.m_pPlayer->CanPause())
+      if (!g_application.m_pPlayer->CanPause())
         return FailedToExecute;
       
       if (parameterObject["play"].isString())
@@ -337,7 +337,7 @@ JSONRPC_STATUS CPlayerOperations::Seek(const CStdString &method, ITransportLayer
   {
     case Video:
     case Audio:
-      if (g_application.m_pPlayer && !g_application.m_pPlayer->CanSeek())
+      if (!g_application.m_pPlayer->CanSeek())
         return FailedToExecute;
       
       if (parameterObject["value"].isObject())
@@ -795,7 +795,7 @@ JSONRPC_STATUS CPlayerOperations::SetAudioStream(const CStdString &method, ITran
   switch (GetPlayer(parameterObject["playerid"]))
   {
     case Video:
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         int index = -1;
         if (parameterObject["stream"].isString())
@@ -842,7 +842,7 @@ JSONRPC_STATUS CPlayerOperations::SetSubtitle(const CStdString &method, ITranspo
   switch (GetPlayer(parameterObject["playerid"]))
   {
     case Video:
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         int index = -1;
         if (parameterObject["subtitle"].isString())
@@ -1255,10 +1255,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     {
       case Video:
       case Audio:
-        if (g_application.m_pPlayer)
-          result = g_application.m_pPlayer->CanSeek();
-        else
-          result = false;
+        result = g_application.m_pPlayer->CanSeek();
         break;
 
       case Picture:
@@ -1363,7 +1360,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     {
       case Video:
       case Audio:
-        if (g_application.m_pPlayer)
+        if (g_application.m_pPlayer->HasPlayer())
         {
           result = CVariant(CVariant::VariantTypeObject);
           int index = g_application.m_pPlayer->GetAudioStream();
@@ -1396,7 +1393,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     switch (player)
     {
       case Video:
-        if (g_application.m_pPlayer)
+        if (g_application.m_pPlayer->HasPlayer())
         {
           for (int index = 0; index < g_application.m_pPlayer->GetAudioStreamCount(); index++)
           {
@@ -1427,8 +1424,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     switch (player)
     {
       case Video:
-        if (g_application.m_pPlayer)
-          result = g_application.m_pPlayer->GetSubtitleVisible();
+        result = g_application.m_pPlayer->GetSubtitleVisible();
         break;
         
       case Audio:
@@ -1443,7 +1439,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     switch (player)
     {
       case Video:
-        if (g_application.m_pPlayer)
+        if (g_application.m_pPlayer->HasPlayer())
         {
           result = CVariant(CVariant::VariantTypeObject);
           int index = CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream;
@@ -1474,7 +1470,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     switch (player)
     {
       case Video:
-        if (g_application.m_pPlayer)
+        if (g_application.m_pPlayer->HasPlayer())
         {
           for (int index = 0; index < g_application.m_pPlayer->GetSubtitleCount(); index++)
           {

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -242,15 +242,15 @@ JSONRPC_STATUS CPlayerOperations::PlayPause(const CStdString &method, ITransport
       {
         if (parameterObject["play"].asBoolean())
         {
-          if (g_application.IsPaused())
+          if (g_application.m_pPlayer->IsPausedPlayback())
             CApplicationMessenger::Get().MediaPause();
           else if (g_application.GetPlaySpeed() != 1)
             g_application.SetPlaySpeed(1);
         }
-        else if (!g_application.IsPaused())
+        else if (!g_application.m_pPlayer->IsPausedPlayback())
           CApplicationMessenger::Get().MediaPause();
       }
-      result["speed"] = g_application.IsPaused() ? 0 : g_application.GetPlaySpeed();
+      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.GetPlaySpeed();
       return OK;
 
     case Picture:
@@ -303,7 +303,7 @@ JSONRPC_STATUS CPlayerOperations::SetSpeed(const CStdString &method, ITransportL
         if (speed != 0)
         {
           // If the player is paused we first need to unpause
-          if (g_application.IsPaused())
+          if (g_application.m_pPlayer->IsPausedPlayback())
             g_application.m_pPlayer->Pause();
           g_application.SetPlaySpeed(speed);
         }
@@ -320,7 +320,7 @@ JSONRPC_STATUS CPlayerOperations::SetSpeed(const CStdString &method, ITransportL
       else
         return InvalidParams;
 
-      result["speed"] = g_application.IsPaused() ? 0 : g_application.GetPlaySpeed();
+      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.GetPlaySpeed();
       return OK;
 
     case Picture:
@@ -902,9 +902,9 @@ int CPlayerOperations::GetActivePlayers()
 {
   int activePlayers = 0;
 
-  if (g_application.IsPlayingVideo() || g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRecording())
+  if (g_application.m_pPlayer->IsPlayingVideo() || g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRecording())
     activePlayers |= Video;
-  if (g_application.IsPlayingAudio() || g_PVRManager.IsPlayingRadio())
+  if (g_application.m_pPlayer->IsPlayingAudio() || g_PVRManager.IsPlayingRadio())
     activePlayers |= Audio;
   if (g_windowManager.IsWindowActive(WINDOW_SLIDESHOW))
     activePlayers |= Picture;
@@ -1052,7 +1052,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
     {
       case Video:
       case Audio:
-        result = g_application.IsPaused() ? 0 : g_application.GetPlaySpeed();
+        result = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.GetPlaySpeed();
         break;
 
       case Picture:

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -287,25 +287,25 @@ namespace XBMCAddon
     bool Player::isPlaying()
     {
       TRACE;
-      return g_application.IsPlaying();
+      return g_application.m_pPlayer->IsPlaying();
     }
 
     bool Player::isPlayingAudio()
     {
       TRACE;
-      return g_application.IsPlayingAudio();
+      return g_application.m_pPlayer->IsPlayingAudio();
     }
 
     bool Player::isPlayingVideo()
     {
       TRACE;
-      return g_application.IsPlayingVideo();
+      return g_application.m_pPlayer->IsPlayingVideo();
     }
 
     String Player::getPlayingFile() throw (PlayerException)
     {
       TRACE;
-      if (!g_application.IsPlaying())
+      if (!g_application.m_pPlayer->IsPlaying())
         throw PlayerException("XBMC is not playing any file");
 
       return g_application.CurrentFile();
@@ -314,7 +314,7 @@ namespace XBMCAddon
     InfoTagVideo* Player::getVideoInfoTag() throw (PlayerException)
     {
       TRACE;
-      if (!g_application.IsPlayingVideo())
+      if (!g_application.m_pPlayer->IsPlayingVideo())
         throw PlayerException("XBMC is not playing any videofile");
 
       const CVideoInfoTag* movie = g_infoManager.GetCurrentMovieTag();
@@ -327,7 +327,7 @@ namespace XBMCAddon
     InfoTagMusic* Player::getMusicInfoTag() throw (PlayerException)
     {
       TRACE;
-      if (g_application.IsPlayingVideo() || !g_application.IsPlayingAudio())
+      if (g_application.m_pPlayer->IsPlayingVideo() || !g_application.m_pPlayer->IsPlayingAudio())
         throw PlayerException("XBMC is not playing any music file");
 
       const MUSIC_INFO::CMusicInfoTag* tag = g_infoManager.GetCurrentSongTag();
@@ -340,7 +340,7 @@ namespace XBMCAddon
     double Player::getTotalTime() throw (PlayerException)
     {
       TRACE;
-      if (!g_application.IsPlaying())
+      if (!g_application.m_pPlayer->IsPlaying())
         throw PlayerException("XBMC is not playing any media file");
 
       return g_application.GetTotalTime();
@@ -349,7 +349,7 @@ namespace XBMCAddon
     double Player::getTime() throw (PlayerException)
     {
       TRACE;
-      if (!g_application.IsPlaying())
+      if (!g_application.m_pPlayer->IsPlaying())
         throw PlayerException("XBMC is not playing any media file");
 
       return g_application.GetTime();
@@ -358,7 +358,7 @@ namespace XBMCAddon
     void Player::seekTime(double pTime) throw (PlayerException)
     {
       TRACE;
-      if (!g_application.IsPlaying())
+      if (!g_application.m_pPlayer->IsPlaying())
         throw PlayerException("XBMC is not playing any media file");
 
       g_application.SeekTime( pTime );

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -367,7 +367,7 @@ namespace XBMCAddon
     void Player::setSubtitles(const char* cLine)
     {
       TRACE;
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         int nStream = g_application.m_pPlayer->AddSubtitle(cLine);
         if(nStream >= 0)
@@ -383,7 +383,7 @@ namespace XBMCAddon
     void Player::showSubtitles(bool bVisible)
     {
       TRACE;
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = bVisible != 0;
         g_application.m_pPlayer->SetSubtitleVisible(bVisible != 0);
@@ -393,7 +393,7 @@ namespace XBMCAddon
     String Player::getSubtitles()
     {
       TRACE;
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         SPlayerSubtitleStreamInfo info;
         g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
@@ -411,7 +411,7 @@ namespace XBMCAddon
     {
       TRACE;
       CLog::Log(LOGWARNING,"'xbmc.Player().disableSubtitles()' is deprecated and will be removed in future releases, please use 'xbmc.Player().showSubtitles(false)' instead");
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
         g_application.m_pPlayer->SetSubtitleVisible(false);
@@ -420,7 +420,7 @@ namespace XBMCAddon
 
     std::vector<String>* Player::getAvailableSubtitleStreams()
     {
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         int subtitleCount = g_application.m_pPlayer->GetSubtitleCount();
         std::vector<String>* ret = new std::vector<String>(subtitleCount);
@@ -442,7 +442,7 @@ namespace XBMCAddon
 
     void Player::setSubtitleStream(int iStream)
     {
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         int streamCount = g_application.m_pPlayer->GetSubtitleCount();
         if(iStream < streamCount)
@@ -455,7 +455,7 @@ namespace XBMCAddon
 
     std::vector<String>* Player::getAvailableAudioStreams()
     {
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         int streamCount = g_application.m_pPlayer->GetAudioStreamCount();
         std::vector<String>* ret = new std::vector<String>(streamCount);
@@ -477,7 +477,7 @@ namespace XBMCAddon
 
     void Player::setAudioStream(int iStream)
     {
-      if (g_application.m_pPlayer)
+      if (g_application.m_pPlayer->HasPlayer())
       {
         int streamCount = g_application.m_pPlayer->GetAudioStreamCount();
         if(iStream < streamCount)

--- a/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
+++ b/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
@@ -48,7 +48,7 @@ bool CGUIWindowKaraokeLyrics::OnAction(const CAction &action)
 {
   CSingleLock lock (m_CritSection);
 
-  if ( !m_Lyrics || !g_application.IsPlayingAudio() )
+  if ( !m_Lyrics || !g_application.m_pPlayer->IsPlayingAudio() )
     return false;
 
   CGUIDialogKaraokeSongSelectorSmall * songSelector = (CGUIDialogKaraokeSongSelectorSmall *)

--- a/xbmc/music/karaoke/karaokelyricsmanager.cpp
+++ b/xbmc/music/karaoke/karaokelyricsmanager.cpp
@@ -136,7 +136,7 @@ void CKaraokeLyricsManager::ProcessSlow()
 {
   CSingleLock lock (m_CritSection);
 
-  if ( g_application.IsPlaying() )
+  if ( g_application.m_pPlayer->IsPlaying() )
   {
     if ( m_karaokeSongPlaying )
       m_lastPlayedTime = XbmcThreads::SystemClockMillis();

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -222,7 +222,7 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
           {
             if (g_application.m_pPlayer->IsPausedPlayback())
               return false;
-            if (g_application.GetPlaySpeed() != 1)
+            if (g_application.m_pPlayer->GetPlaySpeed() != 1)
               return false;
           }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -220,7 +220,7 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
           // if playback is paused or playback speed != 1, return
           if (g_application.IsPlayingAudio())
           {
-            if (g_application.m_pPlayer->IsPaused())
+            if (g_application.IsPaused())
               return false;
             if (g_application.GetPlaySpeed() != 1)
               return false;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -218,9 +218,9 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
         else if (iAction == ACTION_PLAYER_PLAY)
         {
           // if playback is paused or playback speed != 1, return
-          if (g_application.IsPlayingAudio())
+          if (g_application.m_pPlayer->IsPlayingAudio())
           {
-            if (g_application.IsPaused())
+            if (g_application.m_pPlayer->IsPausedPlayback())
               return false;
             if (g_application.GetPlaySpeed() != 1)
               return false;
@@ -566,7 +566,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem)
   }
 
   g_playlistPlayer.Add(PLAYLIST_MUSIC, queuedItems);
-  if (g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size() && !g_application.IsPlayingAudio())
+  if (g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size() && !g_application.m_pPlayer->IsPlayingAudio())
   {
     if (m_guiState.get())
       m_guiState->SetPlaylistDirectory("playlistmusic://");
@@ -1012,7 +1012,7 @@ void CGUIWindowMusicBase::UpdateThumb(const CAlbum &album, const CStdString &pat
   // Update currently playing song if it's from the same album.  This is necessary as when the album
   // first gets it's cover, the info manager's item doesn't have the updated information (so will be
   // sending a blank thumb to the skin.)
-  if (g_application.IsPlayingAudio())
+  if (g_application.m_pPlayer->IsPlayingAudio())
   {
     const CMusicInfoTag* tag=g_infoManager.GetCurrentSongTag();
     if (tag)

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -119,7 +119,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
         SET_CONTROL_FOCUS(m_iLastControl, 0);
       }
 
-      if (g_application.IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+      if (g_application.m_pPlayer->IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
       {
         int iSong = g_playlistPlayer.GetCurrentSong();
         if (iSong >= 0 && iSong <= m_vecItems->Size())
@@ -252,7 +252,7 @@ bool CGUIWindowMusicPlayList::MoveCurrentPlayListItem(int iItem, int iAction, bo
 
   // is the currently playing item affected?
   bool bFixCurrentSong = false;
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.IsPlayingAudio()) &&
+  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.m_pPlayer->IsPlayingAudio()) &&
     ((g_playlistPlayer.GetCurrentSong() == iSelected) || (g_playlistPlayer.GetCurrentSong() == iNew)))
     bFixCurrentSong = true;
 
@@ -340,7 +340,7 @@ void CGUIWindowMusicPlayList::RemovePlayListItem(int iItem)
   if (iItem < 0 || iItem > m_vecItems->Size()) return;
 
   // The current playing song can't be removed
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC && g_application.IsPlayingAudio()
+  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC && g_application.m_pPlayer->IsPlayingAudio()
       && g_playlistPlayer.GetCurrentSong() == iItem)
     return ;
 
@@ -373,7 +373,7 @@ void CGUIWindowMusicPlayList::UpdateButtons()
     CONTROL_ENABLE(CONTROL_BTNREPEAT);
     CONTROL_ENABLE(CONTROL_BTNPLAY);
 
-    if (g_application.IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+    if (g_application.m_pPlayer->IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
     {
       CONTROL_ENABLE(CONTROL_BTNNEXT);
       CONTROL_ENABLE(CONTROL_BTNPREVIOUS);
@@ -675,7 +675,7 @@ void CGUIWindowMusicPlayList::MarkPlaying()
     m_vecItems->Get(i)->Select(false);
 
   // mark the currently playing item
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.IsPlayingAudio()))
+  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.m_pPlayer->IsPlayingAudio()))
   {
     int iSong = g_playlistPlayer.GetCurrentSong();
     if (iSong >= 0 && iSong <= m_vecItems->Size())

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -125,7 +125,7 @@ bool CGUIWindowMusicSongs::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNREC)
       {
-        if (g_application.IsPlayingAudio() )
+        if (g_application.m_pPlayer->IsPlayingAudio() )
         {
           if (g_application.m_pPlayer->CanRecord() )
           {
@@ -216,7 +216,7 @@ void CGUIWindowMusicSongs::UpdateButtons()
 {
   CGUIWindowMusicBase::UpdateButtons();
 
-  bool bIsPlaying = g_application.IsPlayingAudio();
+  bool bIsPlaying = g_application.m_pPlayer->IsPlayingAudio();
   bool bCanRecord = false;
   bool bIsRecording = false;
 

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -163,7 +163,7 @@ bool CGUIWindowVisualisation::OnMessage(CGUIMessage& message)
     {
       // check whether we've come back here from a window during which time we've actually
       // stopped playing music
-      if (message.GetParam1() == WINDOW_INVALID && !g_application.IsPlayingAudio())
+      if (message.GetParam1() == WINDOW_INVALID && !g_application.m_pPlayer->IsPlayingAudio())
       { // why are we here if nothing is playing???
         g_windowManager.PreviousWindow();
         return true;

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -730,14 +730,14 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       }
       else if (rate == 0)
       {
-        if (g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
+        if (g_application.IsPlaying() && !g_application.IsPaused())
         {
           CApplicationMessenger::Get().MediaPause();
         }
       }
       else
       {
-        if (g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && g_application.m_pPlayer->IsPaused())
+        if (g_application.IsPlaying() && g_application.IsPaused())
         {
           CApplicationMessenger::Get().MediaPause();
         }
@@ -881,7 +881,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
     {
       CLog::Log(LOGDEBUG, "AIRPLAY: got GET request %s", uri.c_str());
       
-      if (g_application.m_pPlayer && g_application.m_pPlayer->GetTotalTime())
+      if (g_application.m_pPlayer->GetTotalTime())
       {
         float position = ((float) g_application.m_pPlayer->GetTime()) / 1000;
         responseBody.Format("duration: %.6f\r\nposition: %.6f\r\n", (float)g_application.m_pPlayer->GetTotalTime() / 1000, position);
@@ -895,7 +895,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
     {
       const char* found = strstr(queryString.c_str(), "position=");
       
-      if (found && g_application.m_pPlayer)
+      if (found && g_application.m_pPlayer->HasPlayer())
       {
         int64_t position = (int64_t) (atof(found + strlen("position=")) * 1000.0);
         g_application.m_pPlayer->SeekTime(position);
@@ -978,13 +978,13 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
     {
       status = AIRPLAY_STATUS_NEED_AUTH;
     }
-    else if (g_application.m_pPlayer)
+    else if (g_application.m_pPlayer->HasPlayer())
     {
       if (g_application.m_pPlayer->GetTotalTime())
       {
         position = ((float) g_application.m_pPlayer->GetTime()) / 1000;
         duration = ((float) g_application.m_pPlayer->GetTotalTime()) / 1000;
-        playing = g_application.m_pPlayer ? !g_application.m_pPlayer->IsPaused() : false;
+        playing = !g_application.m_pPlayer->IsPaused();
         cachePosition = position + (duration * g_application.m_pPlayer->GetCachePercentage() / 100.0f);
       }
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -730,14 +730,14 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       }
       else if (rate == 0)
       {
-        if (g_application.IsPlaying() && !g_application.IsPaused())
+        if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
         {
           CApplicationMessenger::Get().MediaPause();
         }
       }
       else
       {
-        if (g_application.IsPlaying() && g_application.IsPaused())
+        if (g_application.m_pPlayer->IsPausedPlayback())
         {
           CApplicationMessenger::Get().MediaPause();
         }

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -325,7 +325,7 @@ int CAirTunesServer::AudioOutputFunctions::ao_play(ao_device *device, char *outp
   if (!device)
     return 0;
 
-  /*if (num_bytes && g_application.m_pPlayer)
+  /*if (num_bytes && g_application.m_pPlayer->HasPlayer())
     g_application.m_pPlayer->SetCaching(CACHESTATE_NONE);*///TODO
 
   ao_device_xbmc* device_xbmc = (ao_device_xbmc*) device;

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -391,7 +391,7 @@ void CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
   {
     CLog::Log(LOGERROR,"WakeOnAccess failed to send. (Is it blocked by firewall?)");
 
-    if (g_application.IsCurrentThread() || !g_application.IsPlaying())
+    if (g_application.IsCurrentThread() || !g_application.m_pPlayer->IsPlaying())
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, heading, LOCALIZED(13029));
     return;
   }

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -305,7 +305,7 @@ CUPnPRenderer::UpdateState()
 
     avt->SetStateVariable("TransportStatus", "OK");
 
-    if (g_application.IsPlaying() || g_application.IsPaused()) {
+    if (g_application.m_pPlayer->IsPlaying() || g_application.m_pPlayer->IsPausedPlayback()) {
         avt->SetStateVariable("NumberOfTracks", "1");
         avt->SetStateVariable("CurrentTrack", "1");
 
@@ -449,7 +449,7 @@ CUPnPRenderer::OnPause(PLT_ActionReference& action)
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         CAction action(ACTION_PAUSE);
         CApplicationMessenger::Get().SendAction(action, WINDOW_SLIDESHOW);
-    } else if (!g_application.IsPaused())
+    } else if (!g_application.m_pPlayer->IsPausedPlayback())
       CApplicationMessenger::Get().MediaPause();
     return NPT_SUCCESS;
 }
@@ -462,9 +462,9 @@ CUPnPRenderer::OnPlay(PLT_ActionReference& action)
 {
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         return NPT_SUCCESS;
-    } else if (g_application.IsPaused()) {
+    } else if (g_application.m_pPlayer->IsPausedPlayback()) {
       CApplicationMessenger::Get().MediaPause();
-    } else if (!g_application.IsPlaying()) {
+    } else if (!g_application.m_pPlayer->IsPlaying()) {
         NPT_String uri, meta;
         PLT_Service* service;
         // look for value set previously by SetAVTransportURI
@@ -523,7 +523,7 @@ CUPnPRenderer::OnSetAVTransportURI(PLT_ActionReference& action)
 
     // if not playing already, just keep around uri & metadata
     // and wait for play command
-    if (!g_application.IsPlaying() && g_windowManager.GetActiveWindow() != WINDOW_SLIDESHOW) {
+    if (!g_application.m_pPlayer->IsPlaying() && g_windowManager.GetActiveWindow() != WINDOW_SLIDESHOW) {
         service->SetStateVariable("TransportState", "STOPPED");
         service->SetStateVariable("TransportStatus", "OK");
         service->SetStateVariable("TransportPlaySpeed", "1");
@@ -557,7 +557,7 @@ CUPnPRenderer::OnSetNextAVTransportURI(PLT_ActionReference& action)
         return NPT_FAILURE;
     }
 
-    if (g_application.IsPlaying()) {
+    if (g_application.m_pPlayer->IsPlaying()) {
 
         int playlist = PLAYLIST_MUSIC;
         if(item->IsVideo())
@@ -614,7 +614,7 @@ CUPnPRenderer::PlayMedia(const NPT_String& uri, const NPT_String& meta, PLT_Acti
         CApplicationMessenger::Get().MediaPlay(*item);
     }
 
-    if (g_application.IsPlaying() || g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
+    if (g_application.m_pPlayer->IsPlaying() || g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         NPT_AutoLock lock(m_state);
         service->SetStateVariable("TransportState", "PLAYING");
         service->SetStateVariable("TransportStatus", "OK");
@@ -666,7 +666,7 @@ CUPnPRenderer::OnSetMute(PLT_ActionReference& action)
 NPT_Result
 CUPnPRenderer::OnSeek(PLT_ActionReference& action)
 {
-    if (!g_application.IsPlaying()) return NPT_ERROR_INVALID_STATE;
+    if (!g_application.m_pPlayer->IsPlaying()) return NPT_ERROR_INVALID_STATE;
 
     NPT_String unit, target;
     NPT_CHECK_SEVERE(action->GetArgumentValue("Unit", unit));

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -379,7 +379,7 @@ void DarwinSetScheduling(int message)
   policy = SCHED_OTHER;
   thread_extended_policy_data_t theFixedPolicy={true};
 
-  if (message == GUI_MSG_PLAYBACK_STARTED && g_application.IsPlayingVideo())
+  if (message == GUI_MSG_PLAYBACK_STARTED && g_application.m_pPlayer->IsPlayingVideo())
   {
     policy = SCHED_RR;
     theFixedPolicy.timeshare = false;

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -956,7 +956,7 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
       case UIEventSubtypeRemoteControlEndSeekingForward:
       case UIEventSubtypeRemoteControlEndSeekingBackward:
         // restore to normal playback speed.
-        if (g_application.IsPlaying() && !g_application.IsPaused())
+        if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
           CApplicationMessenger::Get().SendAction(ACTION_PLAYER_PLAY);
         break;
       default:
@@ -970,7 +970,7 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
 - (void)enterBackground
 {
   PRINT_SIGNATURE();
-  if (g_application.IsPlaying() && !g_application.IsPaused())
+  if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
   {
     m_isPlayingBeforeInactive = YES;
     CApplicationMessenger::Get().MediaPauseIfPlaying();
@@ -994,7 +994,7 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
   LOG(@"%s: was interrupted: %d", __PRETTY_FUNCTION__,  m_isInterrupted);
   // if we were interrupted, already paused here
   // else if user background us or lock screen, only pause video here, audio keep playing.
-  if (g_application.IsPlayingVideo() && !g_application.IsPaused())
+  if (g_application.m_pPlayer->IsPlayingVideo() && !g_application.m_pPlayer->IsPaused())
   {
     m_isPlayingBeforeInactive = YES;
     CApplicationMessenger::Get().MediaPauseIfPlaying();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -173,7 +173,7 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
   else if (flag == GUI && !strcmp(sender, "xbmc") && !strcmp(message, "OnScreensaverActivated") && m_bIsReady)
   {
     // Don't put devices to standby if application is currently playing
-    if ((!g_application.IsPlaying() && !g_application.IsPaused()) && m_configuration.bPowerOffScreensaver == 1)
+    if ((!g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused()) && m_configuration.bPowerOffScreensaver == 1)
     {
       m_screensaverLastActivated = CDateTime::GetCurrentDateTime();
       // only power off when we're the active source
@@ -1136,9 +1136,9 @@ void CPeripheralCecAdapter::CecSourceActivated(void *cbParam, const CEC::cec_log
     bool bShowingSlideshow = (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW);
     CGUIWindowSlideShow *pSlideShow = bShowingSlideshow ? (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW) : NULL;
     bool bPlayingAndDeactivated = activated == 0 && (
-        (pSlideShow && pSlideShow->IsPlaying()) || g_application.IsPlaying());
+        (pSlideShow && pSlideShow->IsPlaying()) || g_application.m_pPlayer->IsPlaying());
     bool bPausedAndActivated = activated == 1 && adapter->m_bPlaybackPaused && (
-        (pSlideShow && pSlideShow->IsPaused()) || g_application.IsPaused());
+        (pSlideShow && pSlideShow->IsPaused()) || g_application.m_pPlayer->IsPausedPlayback());
     if (bPlayingAndDeactivated)
       adapter->m_bPlaybackPaused = true;
     else if (bPausedAndActivated)

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -338,7 +338,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
   CGUIWindowSlideShow *pSlideShow = (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
   if (!pSlideShow)
     return false;
-  if (g_application.IsPlayingVideo())
+  if (g_application.m_pPlayer->IsPlayingVideo())
     g_application.StopPlaying();
 
   pSlideShow->Reset();
@@ -381,7 +381,7 @@ void CGUIWindowPictures::OnShowPictureRecursive(const CStdString& strPath)
   if (pSlideShow)
   {
     // stop any video
-    if (g_application.IsPlayingVideo())
+    if (g_application.m_pPlayer->IsPlayingVideo())
       g_application.StopPlaying();
 
     SortDescription sorting = m_guiState->GetSortMethod();
@@ -584,7 +584,7 @@ void CGUIWindowPictures::LoadPlayList(const CStdString& strPlayList)
     CGUIWindowSlideShow *pSlideShow = (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
     if (!pSlideShow)
       return;
-    if (g_application.IsPlayingVideo())
+    if (g_application.m_pPlayer->IsPlayingVideo())
       g_application.StopPlaying();
 
     // convert playlist items into slideshow items

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1216,7 +1216,7 @@ void CGUIWindowSlideShow::RunSlideShow(const CStdString &strPath,
                                        const CStdString &strExtensions)
 {
   // stop any video
-  if (g_application.IsPlayingVideo())
+  if (g_application.m_pPlayer->IsPlayingVideo())
     g_application.StopPlaying();
 
   AddFromPath(strPath, bRecursive, method, order, sortAttributes, strExtensions);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1062,7 +1062,7 @@ void CPVRClients::LoadCurrentChannelSettings(void)
   if (!database)
     return;
 
-  if (g_application.m_pPlayer)
+  if (g_application.m_pPlayer->HasPlayer())
   {
     /* set the default settings first */
     CVideoSettings loadedChannelSettings = CMediaSettings::Get().GetDefaultVideoSettings();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -230,7 +230,7 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
     return;
   }
 
-  if (g_PVRManager.IsPlaying() && pItem->HasPVRChannelInfoTag() && g_application.m_pPlayer)
+  if (g_PVRManager.IsPlaying() && pItem->HasPVRChannelInfoTag() && g_application.m_pPlayer->HasPlayer())
   {
     CPVRChannel *channel = pItem->GetPVRChannelInfoTag();
     if (!g_PVRManager.CheckParentalLock(*channel) ||

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -706,7 +706,7 @@ bool CGUIWindowPVRCommon::PlayFile(CFileItem *item, bool bPlayMinimized /* = fal
     {
       /* try a fast switch */
       if (channel && (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio()) &&
-         (channel->IsRadio() == g_PVRManager.IsPlayingRadio()) && g_application.m_pPlayer)
+         (channel->IsRadio() == g_PVRManager.IsPlayingRadio()))
       {
         if (channel->StreamURL().IsEmpty())
           bSwitchSuccessful = g_application.m_pPlayer->SwitchChannel(*channel);

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -142,7 +142,7 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
 
       // Get the allowable resolutions that we can calibrate...
       m_Res.clear();
-      if (g_application.IsPlayingVideo())
+      if (g_application.m_pPlayer->IsPlayingVideo())
       { // don't allow resolution switching if we are playing a video
 
 #ifdef HAS_VIDEO_PLAYBACK

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -97,7 +97,7 @@ void CDetectDVDMedia::Process()
 
   while (( !m_bStop ))
   {
-    if (g_application.IsPlayingVideo())
+    if (g_application.m_pPlayer->IsPlayingVideo())
     {
       Sleep(10000);
     }

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -60,7 +60,7 @@ bool CScreenshotSurface::capture()
 #ifdef HAS_DX
   LPDIRECT3DSURFACE9 lpSurface = NULL, lpBackbuffer = NULL;
   g_graphicsContext.Lock();
-  if (g_application.IsPlayingVideo())
+  if (g_application.m_pPlayer->IsPlayingVideo())
   {
 #ifdef HAS_VIDEO_PLAYBACK
     g_renderManager.SetupScreenshot();
@@ -106,7 +106,7 @@ bool CScreenshotSurface::capture()
 #elif defined(HAS_GL) || defined(HAS_GLES)
 
   g_graphicsContext.BeginPaint();
-  if (g_application.IsPlayingVideo())
+  if (g_application.m_pPlayer->IsPlayingVideo())
   {
 #ifdef HAS_VIDEO_PLAYBACK
     g_renderManager.SetupScreenshot();

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -97,7 +97,7 @@ void CTuxBoxService::Process()
   CStdString strCurrentServiceName = g_tuxbox.sCurSrvData.service_name;
   CStdString strURL;
 
-  while(!CThread::m_bStop && g_application.IsPlaying())
+  while(!CThread::m_bStop && g_application.m_pPlayer->IsPlaying())
   {
     strURL = g_application.CurrentFileItem().GetPath();
     if(!URIUtils::IsTuxBox(strURL))
@@ -119,7 +119,7 @@ void CTuxBoxService::Process()
         //Detect Channel Change
         //We need to detect the channel on the TuxBox Device!
         //On changing the channel on the device we will loose the stream and mplayer seems not able to detect it to stop
-        if (strCurrentServiceName != g_tuxbox.sCurSrvData.service_name && g_application.IsPlaying() && !g_tuxbox.sZapstream.available)
+        if (strCurrentServiceName != g_tuxbox.sCurSrvData.service_name && g_application.m_pPlayer->IsPlaying() && !g_tuxbox.sZapstream.available)
         {
           CLog::Log(LOGDEBUG," - ERROR: Non controlled channel change detected! Stopping current playing stream!");
           CApplicationMessenger::Get().MediaStop();
@@ -602,7 +602,7 @@ bool CTuxBoxUtil::GetZapUrl(const CStdString& strPath, CFileItem &items )
         streamURL.SetPort(g_advancedSettings.m_iTuxBoxZapstreamPort);
       }
 
-      if (g_application.IsPlaying() && !g_tuxbox.sZapstream.available)
+      if (g_application.m_pPlayer->IsPlaying() && !g_tuxbox.sZapstream.available)
         CApplicationMessenger::Get().MediaStop();
 
       strLabel.Format("%s: %s %s-%s",items.GetLabel().c_str(), sCurSrvData.current_event_date.c_str(),sCurSrvData.current_event_start.c_str(), sCurSrvData.current_event_start.c_str());
@@ -1462,7 +1462,7 @@ bool CTuxBoxUtil::GetVideoSubChannels(CStdString& strVideoSubChannelName, CStdSt
     return false;
 
   // IsPlaying, Stop it..
-  if(g_application.IsPlaying())
+  if(g_application.m_pPlayer->IsPlaying())
     CApplicationMessenger::Get().MediaStop();
 
   // popup the context menu

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -129,8 +129,7 @@ bool CPlayerController::OnAction(const CAction &action)
       CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay -= 0.1f;
       if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay < -g_advancedSettings.m_videoSubsDelayRange)
         CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = -g_advancedSettings.m_videoSubsDelayRange;
-      if (g_application.m_pPlayer)
-        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
+      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
 
       ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
                                         -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
@@ -143,8 +142,7 @@ bool CPlayerController::OnAction(const CAction &action)
       CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay += 0.1f;
       if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay > g_advancedSettings.m_videoSubsDelayRange)
         CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = g_advancedSettings.m_videoSubsDelayRange;
-      if (g_application.m_pPlayer)
-        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
+      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
 
       ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
                                         -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
@@ -173,8 +171,7 @@ bool CPlayerController::OnAction(const CAction &action)
       CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay -= 0.025f;
       if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay < -g_advancedSettings.m_videoAudioDelayRange)
         CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = -g_advancedSettings.m_videoAudioDelayRange;
-      if (g_application.m_pPlayer)
-        g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
+      g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
 
       ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
                                       -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
@@ -187,8 +184,7 @@ bool CPlayerController::OnAction(const CAction &action)
       CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay += 0.025f;
       if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay > g_advancedSettings.m_videoAudioDelayRange)
         CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = g_advancedSettings.m_videoAudioDelayRange;
-      if (g_application.m_pPlayer)
-        g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
+      g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
 
       ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
                                       -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
@@ -376,8 +372,7 @@ bool CPlayerController::OnAction(const CAction &action)
       CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification =
         std::max(std::min(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, sliderMax), sliderMin);
 
-      if (g_application.m_pPlayer)
-        g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification * 100));
+      g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification * 100));
 
       ShowSlider(action.GetID(), 660, CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, sliderMin, 1.0f, sliderMax);
       return true;
@@ -417,7 +412,7 @@ void CPlayerController::OnSliderChange(void *data, CGUISliderControl *slider)
   else
     slider->SetTextValue(CGUIDialogAudioSubtitleSettings::FormatDelay(slider->GetFloatValue(), 0.025f));
 
-  if (g_application.m_pPlayer)
+  if (g_application.m_pPlayer->HasPlayer())
   {
     if (m_sliderAction == ACTION_AUDIO_DELAY)
     {

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -77,7 +77,7 @@ void CGUIDialogAudioSubtitleSettings::CreateSettings()
 {
   m_usePopupSliders = g_SkinInfo->HasSkinFile("DialogSlider.xml");
 
-  if (g_application.m_pPlayer)
+  if (g_application.m_pPlayer->HasPlayer())
   {
     g_application.m_pPlayer->GetAudioCapabilities(m_audioCaps);
     g_application.m_pPlayer->GetSubtitleCapabilities(m_subCaps);
@@ -90,7 +90,7 @@ void CGUIDialogAudioSubtitleSettings::CreateSettings()
   AddSlider(AUDIO_SETTINGS_VOLUME, 13376, &m_volume, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM, PercentAsDecibel, false);
   if (SupportsAudioFeature(IPC_AUD_AMP))
     AddSlider(AUDIO_SETTINGS_VOLUME_AMPLIFICATION, 660, &CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) / 6000.0f, VOLUME_DRC_MAXIMUM * 0.01f, FormatDecibel, false);
-  if (g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough())
+  if (g_application.m_pPlayer->IsPassthrough())
   {
     EnableSettings(AUDIO_SETTINGS_VOLUME,false);
     EnableSettings(AUDIO_SETTINGS_VOLUME_AMPLIFICATION,false);
@@ -245,13 +245,11 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
     g_application.SetVolume(m_volume, false); //false - value is not in percent
   else if (setting.id == AUDIO_SETTINGS_VOLUME_AMPLIFICATION)
   {
-    if (g_application.m_pPlayer)
-      g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification * 100));
+    g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification * 100));
   }
   else if (setting.id == AUDIO_SETTINGS_DELAY)
   {
-    if (g_application.m_pPlayer)
-      g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
+    g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
   }
   else if (setting.id == AUDIO_SETTINGS_STREAM)
   {
@@ -382,7 +380,7 @@ void CGUIDialogAudioSubtitleSettings::FrameMove()
 {
   m_volume = g_application.GetVolume(false);
   UpdateSetting(AUDIO_SETTINGS_VOLUME);
-  if (g_application.m_pPlayer)
+  if (g_application.m_pPlayer->HasPlayer())
   {
     // these settings can change on the fly
     UpdateSetting(AUDIO_SETTINGS_DELAY);

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -278,7 +278,7 @@ void CGUIDialogVideoBookmarks::Clear()
 void CGUIDialogVideoBookmarks::GotoBookmark(int item)
 {
   if (item < 0 || item >= (int)m_bookmarks.size()) return;
-  if (g_application.m_pPlayer)
+  if (g_application.m_pPlayer->HasPlayer())
   {
     g_application.m_pPlayer->SetPlayerState(m_bookmarks[item].playerState);
     g_application.SeekTime((double)m_bookmarks[item].timeInSeconds);
@@ -307,7 +307,7 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
   bookmark.timeInSeconds = (int)g_application.GetTime();
   bookmark.totalTimeInSeconds = (int)g_application.GetTotalTime();
 
-  if( g_application.m_pPlayer )
+  if( g_application.m_pPlayer->HasPlayer() )
     bookmark.playerState = g_application.m_pPlayer->GetPlayerState();
   else
     bookmark.playerState.Empty();

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -374,7 +374,7 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
     {
       // check whether we've come back here from a window during which time we've actually
       // stopped playing videos
-      if (message.GetParam1() == WINDOW_INVALID && !g_application.IsPlayingVideo())
+      if (message.GetParam1() == WINDOW_INVALID && !g_application.m_pPlayer->IsPlayingVideo())
       { // why are we here if nothing is playing???
         g_windowManager.PreviousWindow();
         return true;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -558,7 +558,7 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
 
 void CGUIWindowFullScreen::FrameMove()
 {
-  if (g_application.GetPlaySpeed() != 1)
+  if (g_application.m_pPlayer->GetPlaySpeed() != 1)
     g_infoManager.SetDisplayAfterSeek();
   if (m_bShowCurrentTime)
     g_infoManager.SetDisplayAfterSeek();

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -563,7 +563,7 @@ void CGUIWindowFullScreen::FrameMove()
   if (m_bShowCurrentTime)
     g_infoManager.SetDisplayAfterSeek();
 
-  if (!g_application.m_pPlayer) return;
+  if (!g_application.m_pPlayer->HasPlayer()) return;
 
   if( g_application.m_pPlayer->IsCaching() )
   {
@@ -751,7 +751,7 @@ void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &d
 
 void CGUIWindowFullScreen::Render()
 {
-  if (g_application.m_pPlayer)
+  if (g_application.m_pPlayer->HasPlayer())
     RenderTTFSubtitles();
   CGUIWindow::Render();
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -214,7 +214,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         {
           return OnInfo(iItem);
         }
-        else if (iAction == ACTION_PLAYER_PLAY && !g_application.IsPlayingVideo())
+        else if (iAction == ACTION_PLAYER_PLAY && !g_application.m_pPlayer->IsPlayingVideo())
         {
           return OnResumeItem(iItem);
         }
@@ -1604,7 +1604,7 @@ void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
   // play movie...
   g_playlistPlayer.Play(0);
 
-  if(!g_application.IsPlayingVideo())
+  if(!g_application.m_pPlayer->IsPlayingVideo())
     m_thumbLoader.Load(*m_vecItems);
 }
 

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -108,7 +108,7 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
         SET_CONTROL_FOCUS(m_iLastControl, 0);
       }
 
-      if (g_application.IsPlayingVideo() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
+      if (g_application.m_pPlayer->IsPlayingVideo() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
       {
         int iSong = g_playlistPlayer.GetCurrentSong();
         if (iSong >= 0 && iSong <= (int)m_vecItems->Size())
@@ -233,7 +233,7 @@ bool CGUIWindowVideoPlaylist::MoveCurrentPlayListItem(int iItem, int iAction, bo
 
   // is the currently playing item affected?
   bool bFixCurrentSong = false;
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.IsPlayingVideo()) &&
+  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.m_pPlayer->IsPlayingVideo()) &&
     ((g_playlistPlayer.GetCurrentSong() == iSelected) || (g_playlistPlayer.GetCurrentSong() == iNew)))
     bFixCurrentSong = true;
 
@@ -285,7 +285,7 @@ void CGUIWindowVideoPlaylist::UpdateButtons()
     CONTROL_ENABLE(CONTROL_BTNSHUFFLE);
     CONTROL_ENABLE(CONTROL_BTNREPEAT);
 
-    if (g_application.IsPlayingVideo() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
+    if (g_application.m_pPlayer->IsPlayingVideo() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
     {
       CONTROL_ENABLE(CONTROL_BTNNEXT);
       CONTROL_ENABLE(CONTROL_BTNPREVIOUS);
@@ -348,7 +348,7 @@ bool CGUIWindowVideoPlaylist::OnPlayMedia(int iItem)
 void CGUIWindowVideoPlaylist::RemovePlayListItem(int iItem)
 {
   // The current playing song can't be removed
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO && g_application.IsPlayingVideo()
+  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO && g_application.m_pPlayer->IsPlayingVideo()
       && g_playlistPlayer.GetCurrentSong() == iItem)
     return ;
 
@@ -558,7 +558,7 @@ void CGUIWindowVideoPlaylist::MarkPlaying()
     m_vecItems->Get(i)->Select(false);
 
   // mark the currently playing item
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.IsPlayingVideo()))
+  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.m_pPlayer->IsPlayingVideo()))
   {
     int iSong = g_playlistPlayer.GetCurrentSong();
     if (iSong >= 0 && iSong <= m_vecItems->Size())

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -487,7 +487,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       switch( wParam&0xFFF0 )
       {
         case SC_MONITORPOWER:
-          if (g_application.IsPlaying() || g_application.IsPaused())
+          if (g_application.m_pPlayer->IsPlaying() || g_application.m_pPlayer->IsPausedPlayback())
             return 0;
           else if(CSettings::Get().GetInt("powermanagement.displaysoff") == 0)
             return 0;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -626,7 +626,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem)
     CGUIWindowSlideShow *pSlideShow = (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
     if (!pSlideShow)
       return ;
-    if (g_application.IsPlayingVideo())
+    if (g_application.m_pPlayer->IsPlayingVideo())
       g_application.StopPlaying();
 
     pSlideShow->Reset();

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -53,7 +53,7 @@ bool CGUIWindowHome::OnAction(const CAction &action)
   static unsigned int min_hold_time = 1000;
   if (action.GetID() == ACTION_NAV_BACK &&
       action.GetHoldTime() < min_hold_time &&
-      g_application.IsPlaying())
+      g_application.m_pPlayer->IsPlaying())
   {
     g_application.SwitchToFullScreen();
     return true;


### PR DESCRIPTION
When I was looking at the action handling stuff re. the ACTION_PREV/NEXT_ITEM (other pull request) I came across the very many calls to the player from different places, and thought it wasn't very clean.

The idea is to remove direct access to CApplication::m_pPlayer, by making it a proxy (CApplicationPlayer) to the real player object. Additional benefits are:
- remove unnecessary null-checks e.g. when also checking IsPlayingXXX 
- calling CApplication::IsPlaying / IsPaused instead of player's equivalents
- locking of the player operations (thread safety)
- move player management logic out of CApplication into CApplicationPlayer
