### PR TITLE
Introduced setting 'limitcacherate', which, if present and set to 'false', disables rate limiter when writing to the cache buffer, therefore allowing the buffer to be filled as fast as the source allows

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -246,7 +246,7 @@ void CFileCache::Process()
       m_seekEnded.Set();
     }
 
-    while (m_writeRate)
+    while (m_writeRate && g_advancedSettings.m_limitCacheRate)
     {
       if (m_writePos - m_readPos < m_writeRate)
       {
@@ -487,6 +487,10 @@ int CFileCache::IoControl(EIoControl request, void* param)
 {
   if (request == IOCTRL_CACHE_STATUS)
   {
+    if (!g_advancedSettings.m_limitCacheRate) {
+      // m_writeRateActual isn't calculated ... let player think there's no cache
+      return -1;
+    }
     SCacheStatus* status = (SCacheStatus*)param;
     status->forward = m_pCache->WaitForData(0, 0);
     status->maxrate = m_writeRate;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -362,6 +362,8 @@ void CAdvancedSettings::Initialize()
 
   m_cacheMemBufferSize = 1024 * 1024 * 20;
   m_alwaysForceBuffer = false;
+  m_limitCacheRate = true;
+
   m_addonPackageFolderSize = 200;
 
   m_jsonOutputCompact = true;
@@ -766,6 +768,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
     XMLUtils::GetBoolean(pElement, "alwaysforcebuffer", m_alwaysForceBuffer);
+    XMLUtils::GetBoolean(pElement, "limitcacherate", m_limitCacheRate);  
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -365,6 +365,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     unsigned int m_cacheMemBufferSize;
     bool m_alwaysForceBuffer;
+    bool m_limitCacheRate;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;


### PR DESCRIPTION
I've been testing some more with PR:2843, and have been logging buffer utilization stats, to track the performance. I've noticed, that with the limiter on, buffer was still being depleted at times, during bitrate surge periods. Not with every source, not every time -- but still was happening.

Disabling the limiter (and, when doing so, making player believe it doesn't utilize cache by not returning stats) helps to maintain buffer as full as possible. Underruns are virtually gone. And, if memory buffer is used, the cache writer thread will block whenever the buffer is full, therefore preventing uncontrolled looping.
