### PR TITLE
AE: Make sure to reinit and avoid to have wrong sink after SoftResume()

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -1150,16 +1150,17 @@ bool CAESinkALSA::SoftSuspend()
 bool CAESinkALSA::SoftResume()
 {
     // reinit all the clibber
-    bool ret = true; // all fine
     if(!m_pcm)
     {
       if (!snd_config)
         snd_config_update();
 
-      ret = Initialize(m_initFormat, m_initDevice);
+      // Initialize what we had before again, SoftAE might keep it
+      // but ignore ret value to give the chance to do reopening
+      Initialize(m_initFormat, m_initDevice);
     }
-   //we want that AE loves us again - reinit when initialize failed
-   return ret; // force reinit if false
+   // make sure that OpenInternalSink is done again
+   return false;
 }
 
 void CAESinkALSA::sndLibErrorHandler(const char *file, int line, const char *function, int err, const char *fmt, ...)


### PR DESCRIPTION
With current code the following scenario could happen:

User watches video with AC3 sound, presses pause, waits 10 seconds, presses stop. When navigating to next menu item, SoftResume is called, that succesfully calls Initialize (for AC3). All menu sounds are played through AC3 - which sounds not so nice, cause reinit returns true.

Cause of this we have to return false to give a change to call InternalOpenSink again.

Next use case:
SoftAE decides to keep the current sink. In this case we only have to make sure that Initialize is also called.
