### PR TITLE
Volume Jump Fix

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1332,8 +1332,8 @@ void COMXPlayer::Process()
 
     if(m_change_volume && m_CurrentAudio.started)
     {
-      m_omxPlayerAudio.SetCurrentVolume(m_current_mute ? VOLUME_MINIMUM : m_current_volume);
-      m_change_volume = false;
+      if(m_player_audio.SetCurrentVolume(m_current_mute ? VOLUME_MINIMUM : m_current_volume))
+        m_change_volume = false;
     }
 
     // process the packet

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -717,9 +717,9 @@ void OMXPlayerAudio::UnRegisterAudioCallback()
   m_omxAudio.UnRegisterAudioCallback();
 }
 
-void OMXPlayerAudio::SetCurrentVolume(float fVolume)
+bool OMXPlayerAudio::SetCurrentVolume(float fVolume)
 {
-  m_omxAudio.SetCurrentVolume(fVolume);
+  return m_omxAudio.SetCurrentVolume(fVolume);
 }
 
 void OMXPlayerAudio::SetSpeed(int speed)

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -109,7 +109,7 @@ public:
   void SubmitEOS();
   void  RegisterAudioCallback(IAudioCallback* pCallback);
   void  UnRegisterAudioCallback();
-  void SetCurrentVolume(float fVolume);
+  bool SetCurrentVolume(float fVolume);
   void SetSpeed(int iSpeed);
   int  GetAudioBitrate();
   std::string GetPlayerInfo();


### PR DESCRIPTION
Building on the previous fix for the audio volume jumps experienced
when switching tracks, this adds a double check that the underlying audio
layer has actually set the volume to the new value. This may fail because
the COMXAudio object it not yet initialised.

If there is a failure, then the volume change is retried in the next
iteration of COMXPlayer::Process().

_After running this for a few days on my Raspberry Pi, I have not experience the volume jump bug when playback completes a track, and switches to the next track._
