### PR TITLE
[gui] set focus to default control in pvr channel/guide osd

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -89,6 +89,10 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
       CGUIWindow::OnMessage(message);
       Update(true);
 
+      // set focus to the default control
+      CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), m_defaultControl);
+      CGUIWindow::OnMessage(msg);
+
       return true;
     }
     break;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
@@ -64,6 +64,11 @@ bool CGUIDialogPVRGuideOSD::OnMessage(CGUIMessage& message)
       }
       CGUIWindow::OnMessage(message);
       Update();
+
+      // set focus to the default control
+      CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), m_defaultControl);
+      CGUIWindow::OnMessage(msg);
+
       return true;
     }
     break;


### PR DESCRIPTION
This calls OnMessage() on INIT to set the focus to the default control
in CGUIDialogPVRChannelOSD and GUIDialogPVRGuideOSD.
This fix the issue discussed in #2855.
