### PR TITLE
[gui] refactor and focus fix for pvr dialogs

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -64,6 +64,9 @@ using namespace PVR;
 CGUIDialogPVRChannelManager::CGUIDialogPVRChannelManager(void) :
     CGUIDialog(WINDOW_DIALOG_PVR_CHANNEL_MANAGER, "DialogPVRChannelManager.xml"),
     m_bIsRadio(false),
+    m_bMovingMode(false),
+    m_bContainsChanges(false),
+    m_iSelected(0),
     m_channelItems(new CFileItemList)
 {
 }
@@ -134,9 +137,10 @@ bool CGUIDialogPVRChannelManager::OnAction(const CAction& action)
          CGUIDialog::OnAction(action);
 }
 
-bool CGUIDialogPVRChannelManager::OnMessageInit(CGUIMessage &message)
+void CGUIDialogPVRChannelManager::OnInitWindow()
 {
-  CGUIWindow::OnMessage(message);
+  CGUIDialog::OnInitWindow();
+
   m_iSelected = 0;
   m_bIsRadio = false;
   m_bMovingMode = false;
@@ -144,8 +148,13 @@ bool CGUIDialogPVRChannelManager::OnMessageInit(CGUIMessage &message)
   SetProperty("IsRadio", "");
   Update();
   SetData(m_iSelected);
+}
 
-  return true;
+void CGUIDialogPVRChannelManager::OnDeinitWindow(int nextWindowID)
+{
+  Clear();
+
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 bool CGUIDialogPVRChannelManager::OnClickListChannels(CGUIMessage &message)
@@ -573,11 +582,6 @@ bool CGUIDialogPVRChannelManager::OnMessage(CGUIMessage& message)
 
   switch (iMessage)
   {
-    case GUI_MSG_WINDOW_DEINIT:
-      Clear();
-      break;
-    case GUI_MSG_WINDOW_INIT:
-      return OnMessageInit(message);
     case GUI_MSG_CLICKED:
       return OnMessageClick(message);
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -39,12 +39,14 @@ namespace PVR
     virtual CFileItemPtr GetCurrentListItem(int offset = 0);
 
   protected:
+    virtual void OnInitWindow();
+    virtual void OnDeinitWindow(int nextWindowID);
+
     virtual bool OnPopupMenu(int iItem);
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
 
     virtual bool OnActionMove(const CAction &action);
 
-    virtual bool OnMessageInit(CGUIMessage &message);
     virtual bool OnMessageClick(CGUIMessage &message);
 
     virtual bool OnClickListChannels(CGUIMessage &message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -102,10 +102,9 @@ void CGUIDialogPVRChannelsOSD::OnInitWindow()
     return;
   }
 
-  CGUIDialog::OnInitWindow();
+  Update();
 
-  m_group = GetPlayingGroup();
-  Update(true);
+  CGUIDialog::OnInitWindow();
 }
 
 void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
@@ -113,25 +112,32 @@ void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
   if (m_group)
   {
     g_PVRManager.SetPlayingGroup(m_group);
-    SetLastSelectedItem(m_group->GroupID());
+    m_group.reset();
   }
-  Clear();
 
   CGUIDialog::OnDeinitWindow(nextWindowID);
+
+  Clear();
 }
 
 bool CGUIDialogPVRChannelsOSD::OnAction(const CAction &action)
 {
   switch (action.GetID())
   {
-  case ACTION_PREVIOUS_CHANNELGROUP:
-  case ACTION_NEXT_CHANNELGROUP:
+    case ACTION_PREVIOUS_CHANNELGROUP:
+    case ACTION_NEXT_CHANNELGROUP:
     {
+      // save control states and currently selected item of group
+      SaveControlStates();
+
+      // switch to next or previous group
       CPVRChannelGroupPtr group = GetPlayingGroup();
       CPVRChannelGroupPtr nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP ? group->GetNextGroup() : group->GetPreviousGroup();
       g_PVRManager.SetPlayingGroup(nextGroup);
-      SetLastSelectedItem(group->GroupID());
       Update();
+
+      // restore control states and previously selected item of group
+      RestoreControlStates();
       return true;
     }
   }
@@ -147,11 +153,6 @@ CPVRChannelGroupPtr CGUIDialogPVRChannelsOSD::GetPlayingGroup()
 }
 
 void CGUIDialogPVRChannelsOSD::Update()
-{
-  CGUIDialogPVRChannelsOSD::Update(false);
-}
-
-void CGUIDialogPVRChannelsOSD::Update(bool selectPlayingChannel)
 {
   // lock our display, as this window is rendered from the player thread
   g_graphicsContext.Lock();
@@ -172,10 +173,35 @@ void CGUIDialogPVRChannelsOSD::Update(bool selectPlayingChannel)
   {
     group->GetMembers(*m_vecItems);
     m_viewControl.SetItems(*m_vecItems);
-    m_viewControl.SetSelectedItem(selectPlayingChannel ? group->GetIndex(*channel) : GetLastSelectedItem(group->GroupID()));
+
+    if(!m_group)
+    {
+        m_group = group;
+        m_viewControl.SetSelectedItem(group->GetIndex(*channel));
+        SaveSelectedItem(group->GroupID());
+    }
   }
 
   g_graphicsContext.Unlock();
+}
+
+void CGUIDialogPVRChannelsOSD::SaveControlStates()
+{
+  CGUIDialog::SaveControlStates();
+
+  CPVRChannelGroupPtr group = GetPlayingGroup();
+  SaveSelectedItem(group->GroupID());
+}
+
+void CGUIDialogPVRChannelsOSD::RestoreControlStates()
+{
+  CGUIDialog::RestoreControlStates();
+
+  CPVRChannelGroupPtr group = GetPlayingGroup();
+  if(group)
+  {
+    m_viewControl.SetSelectedItem(GetLastSelectedItem(group->GroupID()));
+  }
 }
 
 void CGUIDialogPVRChannelsOSD::Clear()
@@ -290,7 +316,7 @@ void CGUIDialogPVRChannelsOSD::Notify(const Observable &obs, const ObservableMes
   }
 }
 
-void CGUIDialogPVRChannelsOSD::SetLastSelectedItem(int iGroupID)
+void CGUIDialogPVRChannelsOSD::SaveSelectedItem(int iGroupID)
 {
   m_groupSelectedItems[iGroupID] = m_viewControl.GetSelectedItem();
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -64,36 +64,7 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
   {
-  case GUI_MSG_WINDOW_DEINIT:
-    {
-      if (m_group)
-      {
-        g_PVRManager.SetPlayingGroup(m_group);
-        SetLastSelectedItem(m_group->GroupID());
-      }
-      Clear();
-    }
-    break;
-
-  case GUI_MSG_WINDOW_INIT:
-    {
-      /* Close dialog immediately if now TV or radio channel is playing */
-      if (!g_PVRManager.IsPlaying())
-      {
-        Close();
-        return true;
-      }
-
-      m_group = GetPlayingGroup();
-
-      CGUIWindow::OnMessage(message);
-      Update(true);
-
-      return true;
-    }
-    break;
-
-  case GUI_MSG_CLICKED:
+    case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
 
@@ -120,6 +91,33 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
   }
 
   return CGUIDialog::OnMessage(message);
+}
+
+void CGUIDialogPVRChannelsOSD::OnInitWindow()
+{
+  /* Close dialog immediately if now TV or radio channel is playing */
+  if (!g_PVRManager.IsPlaying())
+  {
+    Close();
+    return;
+  }
+
+  CGUIDialog::OnInitWindow();
+
+  m_group = GetPlayingGroup();
+  Update(true);
+}
+
+void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
+{
+  if (m_group)
+  {
+    g_PVRManager.SetPlayingGroup(m_group);
+    SetLastSelectedItem(m_group->GroupID());
+  }
+  Clear();
+
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 bool CGUIDialogPVRChannelsOSD::OnAction(const CAction &action)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -41,6 +41,9 @@ namespace PVR
     virtual void Notify(const Observable &obs, const ObservableMessage msg);
 
   protected:
+    virtual void OnInitWindow();
+    virtual void OnDeinitWindow(int nextWindowID);
+
     void CloseOrSelect(unsigned int iItem);
     void GotoChannel(int iItem);
     void ShowInfo(int item);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -43,13 +43,14 @@ namespace PVR
   protected:
     virtual void OnInitWindow();
     virtual void OnDeinitWindow(int nextWindowID);
+    virtual void RestoreControlStates();
+    virtual void SaveControlStates();
 
     void CloseOrSelect(unsigned int iItem);
     void GotoChannel(int iItem);
     void ShowInfo(int item);
     void Clear();
     void Update();
-    void Update(bool selectPlayingChannel);
     CPVRChannelGroupPtr GetPlayingGroup();
     CGUIControl *GetFirstFocusableControl(int id);
 
@@ -59,7 +60,7 @@ namespace PVR
   private:
     CPVRChannelGroupPtr m_group;
     std::map<int,int> m_groupSelectedItems;
-    void SetLastSelectedItem(int iGroupID);
+    void SaveSelectedItem(int iGroupID);
     int GetLastSelectedItem(int iGroupID) const;
   };
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -263,23 +263,6 @@ bool CGUIDialogPVRGroupManager::OnMessage(CGUIMessage& message)
 
   switch (iMessage)
   {
-    case GUI_MSG_WINDOW_DEINIT:
-    {
-      Clear();
-    }
-    break;
-
-    case GUI_MSG_WINDOW_INIT:
-    {
-      CGUIWindow::OnMessage(message);
-      m_iSelectedUngroupedChannel  = 0;
-      m_iSelectedGroupMember = 0;
-      m_iSelectedChannelGroup = 0;
-      Update();
-      return true;
-    }
-    break;
-
     case GUI_MSG_CLICKED:
     {
       OnMessageClick(message);
@@ -288,6 +271,21 @@ bool CGUIDialogPVRGroupManager::OnMessage(CGUIMessage& message)
   }
 
   return CGUIDialog::OnMessage(message);
+}
+
+void CGUIDialogPVRGroupManager::OnInitWindow()
+{
+  CGUIDialog::OnInitWindow();
+  m_iSelectedUngroupedChannel  = 0;
+  m_iSelectedGroupMember = 0;
+  m_iSelectedChannelGroup = 0;
+  Update();
+}
+
+void CGUIDialogPVRGroupManager::OnDeinitWindow(int nextWindowID)
+{
+  Clear();
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 void CGUIDialogPVRGroupManager::OnWindowLoaded()

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -38,6 +38,9 @@ namespace PVR
     void SetRadio(bool IsRadio) { m_bIsRadio = IsRadio; }
 
   protected:
+    virtual void OnInitWindow();
+    virtual void OnDeinitWindow(int nextWindowID);
+
     void Clear();
     void Update();
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -189,10 +189,6 @@ bool CGUIDialogPVRGuideInfo::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
   {
-  case GUI_MSG_WINDOW_INIT:
-    CGUIDialog::OnMessage(message);
-    Update();
-    return true;
   case GUI_MSG_CLICKED:
     return OnClickButtonOK(message) ||
            OnClickButtonRecord(message) ||
@@ -212,8 +208,10 @@ CFileItemPtr CGUIDialogPVRGuideInfo::GetCurrentListItem(int offset)
   return m_progItem;
 }
 
-void CGUIDialogPVRGuideInfo::Update()
+void CGUIDialogPVRGuideInfo::OnInitWindow()
 {
+  CGUIDialog::OnInitWindow();
+
   const CEpgInfoTag *tag = m_progItem->GetEPGInfoTag();
   if (!tag)
   {

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -42,7 +42,8 @@ namespace PVR
     void SetProgInfo(const CFileItem *item);
 
   protected:
-    void Update();
+    virtual void OnInitWindow();
+
     bool ActionStartTimer(const EPG::CEpgInfoTag *tag);
     bool ActionCancelTimer(CFileItemPtr timer);
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
@@ -79,8 +79,6 @@ void CGUIDialogPVRGuideOSD::OnInitWindow()
     return;
   }
 
-  CGUIDialog::OnInitWindow();
-
   // lock our display, as this window is rendered from the player thread
   g_graphicsContext.Lock();
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
@@ -91,7 +89,12 @@ void CGUIDialogPVRGuideOSD::OnInitWindow()
   g_PVRManager.GetCurrentEpg(*m_vecItems);
   m_viewControl.SetItems(*m_vecItems);
 
-  /* select the active entry */
+  g_graphicsContext.Unlock();
+
+  // call init
+  CGUIDialog::OnInitWindow();
+
+  // select the active entry
   unsigned int iSelectedItem = 0;
   for (int iEpgPtr = 0; iEpgPtr < m_vecItems->Size(); iEpgPtr++)
   {
@@ -103,14 +106,12 @@ void CGUIDialogPVRGuideOSD::OnInitWindow()
     }
   }
   m_viewControl.SetSelectedItem(iSelectedItem);
-
-  g_graphicsContext.Unlock();
 }
 
 void CGUIDialogPVRGuideOSD::OnDeinitWindow(int nextWindowID)
 {
-  Clear();
   CGUIDialog::OnDeinitWindow(nextWindowID);
+  Clear();
 }
 
 void CGUIDialogPVRGuideOSD::Clear()

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.cpp
@@ -48,27 +48,7 @@ bool CGUIDialogPVRGuideOSD::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
   {
-  case GUI_MSG_WINDOW_DEINIT:
-    {
-      Clear();
-    }
-    break;
-
-  case GUI_MSG_WINDOW_INIT:
-    {
-      /* Close dialog immediately if now TV or radio channel is playing */
-      if (!g_PVRManager.IsPlaying())
-      {
-        Close();
-        return true;
-      }
-      CGUIWindow::OnMessage(message);
-      Update();
-      return true;
-    }
-    break;
-
-  case GUI_MSG_CLICKED:
+    case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
 
@@ -90,8 +70,17 @@ bool CGUIDialogPVRGuideOSD::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
-void CGUIDialogPVRGuideOSD::Update()
+void CGUIDialogPVRGuideOSD::OnInitWindow()
 {
+  /* Close dialog immediately if no TV or radio channel is playing */
+  if (!g_PVRManager.IsPlaying())
+  {
+    Close();
+    return;
+  }
+
+  CGUIDialog::OnInitWindow();
+
   // lock our display, as this window is rendered from the player thread
   g_graphicsContext.Lock();
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
@@ -116,6 +105,12 @@ void CGUIDialogPVRGuideOSD::Update()
   m_viewControl.SetSelectedItem(iSelectedItem);
 
   g_graphicsContext.Unlock();
+}
+
+void CGUIDialogPVRGuideOSD::OnDeinitWindow(int nextWindowID)
+{
+  Clear();
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 void CGUIDialogPVRGuideOSD::Clear()

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideOSD.h
@@ -36,9 +36,11 @@ namespace PVR
     virtual void OnWindowUnload();
 
   protected:
+    virtual void OnInitWindow();
+    virtual void OnDeinitWindow(int nextWindowID);
+
     void ShowInfo(int iItem);
     void Clear();
-    void Update();
 
     CGUIControl *GetFirstFocusableControl(int id);
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -177,13 +177,6 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
 
   switch (message.GetMessage())
   {
-    case GUI_MSG_WINDOW_INIT:
-    {
-      m_bConfirmed = false;
-      m_bCanceled = false;
-    }
-    break;
-
     case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
@@ -221,6 +214,14 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
   }
 
   return false;
+}
+
+void CGUIDialogPVRGuideSearch::OnInitWindow()
+{
+  CGUIDialog::OnInitWindow();
+
+  m_bConfirmed = false;
+  m_bCanceled = false;
 }
 
 void CGUIDialogPVRGuideSearch::OnWindowLoaded()

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
@@ -43,6 +43,8 @@ namespace PVR
     void OnSearch();
 
   protected:
+    virtual void OnInitWindow();
+
     void UpdateChannelSpin(void);
     void UpdateGroupsSpin(void);
     void UpdateGenreSpin(void);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -47,7 +47,10 @@ CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings(void)
   : CGUIDialogSettings(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogPVRTimerSettings.xml")
 {
   m_cancelled = true;
-  m_tmp_day   = 11;
+  m_tmp_day = 11;
+  m_bTimerActive = false;
+  m_tmp_iFirstDay = 0;
+  m_timerItem = new CFileItem;
   m_loadType = LOAD_EVERY_TIME;
 }
 


### PR DESCRIPTION
Refactoring some stuff out of switch/case section of OnMessage() to OnInitWindow() and OnDeinitWindow().

Restore the control states in channel osd, guide info osd and guide osd. This fixes the issue that the default control is not focused on init.
