### PR TITLE
[WIP][win32] fix: best dxva deinterlacing on Intel platforms.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -1287,6 +1287,14 @@ bool CProcessor::OpenProcessor()
   D3DFORMAT rtFormat = D3DFMT_X8R8G8B8;
   CHECK(m_service->GetVideoProcessorCaps(m_device, &m_desc, rtFormat, &m_caps))
 
+  /* HACK for Intel Egde Device. 
+   * won't work if backward refs is equals value from the capabilities *
+   * Possible reasons are:                                             *
+   * 1) The device capabilities are incorrectly reported               *
+   * 2) The device is broken                                           */
+  if (IsEqualGUID(m_device, DXVA2_VideoProcIntelEdgeDevice))
+    m_caps.NumBackwardRefSamples = 0;
+
   if (m_caps.DeviceCaps & DXVA2_VPDev_SoftwareDevice)
     CLog::Log(LOGDEBUG, "DXVA - processor is software device");
 


### PR DESCRIPTION
This PR is possible solution to resolve issue with best dxva deinterlacing on Intel platforms.

Intel device won't work if backward refs is equals value from the capabilities. This hack overrides value of backward refs.

Possible reasons are:
- the device capabilities are incorrectly reported
- the device is broken

I also find weird that the device capabilities are incorrectly reported and that backward refs value needs to be overridden.

I have tested this solution on Intel platforms (i5-2400 and i3-3225 with only integrated GPU) and deinterlacing works.
