### PR TITLE
[rbp/omxplayer] Check total memory, and if plenty use full size buffers

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -41,6 +41,7 @@
 #include "utils/TimeUtils.h"
 
 #include "OMXPlayer.h"
+#include "linux/RBP.h"
 
 #include <iostream>
 #include <sstream>
@@ -78,7 +79,9 @@ OMXPlayerAudio::OMXPlayerAudio(OMXClock *av_clock, CDVDMessageQueue& parent)
   m_bad_state     = false;
   m_hints_current.Clear();
 
-  m_messageQueue.SetMaxDataSize(3 * 1024 * 1024);
+  bool small_mem = g_RBP.GetArmMem() < 256;
+  m_messageQueue.SetMaxDataSize((small_mem ? 3:6) * 1024 * 1024);
+
   m_messageQueue.SetMaxTimeSize(8.0);
   m_use_passthrough = false;
   m_passthrough = false;

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -48,6 +48,7 @@
 #include "guilib/GraphicContext.h"
 
 #include "OMXPlayer.h"
+#include "linux/RBP.h"
 
 class COMXMsgVideoCodecChange : public CDVDMsg
 {
@@ -88,7 +89,8 @@ OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
   m_iCurrentPts           = DVD_NOPTS_VALUE;
   m_iVideoDelay           = 0;
   m_fForcedAspectRatio    = 0.0f;
-  m_messageQueue.SetMaxDataSize(10 * 1024 * 1024);
+  bool small_mem = g_RBP.GetArmMem() < 256;
+  m_messageQueue.SetMaxDataSize((small_mem ? 10:40) * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
 
   m_dst_rect.SetRect(0, 0, 0, 0);

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -34,6 +34,8 @@
 #include "settings/Settings.h"
 #include "utils/BitstreamConverter.h"
 
+#include "linux/RBP.h"
+
 #include <sys/time.h>
 #include <inttypes.h>
 
@@ -511,8 +513,8 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, EDEINTERLACEMODE de
   }
 
   portParam.nPortIndex = m_omx_decoder.GetInputPort();
-  portParam.nBufferCountActual = VIDEO_BUFFERS;
-
+  bool small_mem = g_RBP.GetArmMem() < 256;
+  portParam.nBufferCountActual = small_mem ? VIDEO_BUFFERS:2*VIDEO_BUFFERS;
   portParam.format.video.nFrameWidth  = m_decoded_width;
   portParam.format.video.nFrameHeight = m_decoded_height;
 

--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -50,6 +50,14 @@ bool CRBP::Initialize()
   if(!m_omx_initialized)
     return false;
 
+  char response[80] = "";
+  m_arm_mem = 0;
+  m_gpu_mem = 0;
+  if (vc_gencmd(response, sizeof response, "get_mem arm") == 0)
+    vc_gencmd_number_property(response, "arm", &m_arm_mem);
+  if (vc_gencmd(response, sizeof response, "get_mem gpu") == 0)
+    vc_gencmd_number_property(response, "gpu", &m_gpu_mem);
+
   return true;
 }
 
@@ -59,6 +67,7 @@ void CRBP::LogFirmwareVerison()
   m_DllBcmHost->vc_gencmd(response, sizeof response, "version");
   response[sizeof(response) - 1] = '\0';
   CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
+  CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB", m_arm_mem, m_gpu_mem);
 }
 
 void CRBP::Deinitialize()

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -47,11 +47,15 @@ public:
   bool Initialize();
   void LogFirmwareVerison();
   void Deinitialize();
+  int GetArmMem() { return m_arm_mem; }
+  int GetGpuMem() { return m_gpu_mem; }
 
 private:
   DllBcmHost *m_DllBcmHost;
   bool       m_initialized;
   bool       m_omx_initialized;
+  int        m_arm_mem;
+  int        m_gpu_mem;
   COMXCore   *m_OMX;
 };
 


### PR DESCRIPTION
omxplayer has used a quarter sized video buffer and a half sized audio buffer for the file reading message queue, compared to dvdplayer.
This is required on 256M boards, but is unneccessary on 512M board. So we query the memory size and use full size buffers if possible.
