### PR TITLE
[rbp/omxplayer] Use aspect ratio from video decoder

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -537,8 +537,11 @@ bool OMXPlayerVideo::OpenDecoder()
     CLog::Log(LOGINFO, "OMXPlayerVideo::OpenDecoder : Invalid framerate %d, using forced 25fps and just trust timestamps\n", (int)m_fFrameRate);
     m_fFrameRate = 25;
   }
-  // use aspect in stream always
-  m_fForcedAspectRatio = m_hints.aspect;
+  // use aspect in stream if available
+  if (m_hints.forced_aspect)
+    m_fForcedAspectRatio = m_hints.aspect;
+  else
+    m_fForcedAspectRatio = 0.0;
 
 
   m_av_clock->Lock();

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -691,7 +691,7 @@ void OMXPlayerVideo::RenderUpdateCallBack(const void *ctx, const CRect &SrcRect,
   player->SetVideoRect(SrcRect, DestRect);
 }
 
-void OMXPlayerVideo::ResolutionUpdateCallBack(uint32_t width, uint32_t height)
+void OMXPlayerVideo::ResolutionUpdateCallBack(uint32_t width, uint32_t height, float display_aspect)
 {
   RESOLUTION res  = g_graphicsContext.GetVideoResolution();
   uint32_t video_width   = CDisplaySettings::Get().GetResolutionInfo(res).iScreenWidth;
@@ -729,6 +729,8 @@ void OMXPlayerVideo::ResolutionUpdateCallBack(uint32_t width, uint32_t height)
   /* use forced aspect if any */
   if( m_fForcedAspectRatio != 0.0f )
     iDisplayWidth = (int) (iDisplayHeight * m_fForcedAspectRatio);
+  else if( display_aspect != 0.0f )
+    iDisplayWidth = (int) (iDisplayHeight * display_aspect);
 
   CLog::Log(LOGDEBUG,"%s - change configuration. video:%dx%d. framerate: %4.2f. %dx%d format: BYPASS",
       __FUNCTION__, video_width, video_height, m_fFrameRate, iDisplayWidth, iDisplayHeight);
@@ -744,9 +746,9 @@ void OMXPlayerVideo::ResolutionUpdateCallBack(uint32_t width, uint32_t height)
   g_renderManager.RegisterRenderUpdateCallBack((const void*)this, RenderUpdateCallBack);
 }
 
-void OMXPlayerVideo::ResolutionUpdateCallBack(void *ctx, uint32_t width, uint32_t height)
+void OMXPlayerVideo::ResolutionUpdateCallBack(void *ctx, uint32_t width, uint32_t height, float display_aspect)
 {
   OMXPlayerVideo *player = static_cast<OMXPlayerVideo*>(ctx);
-  player->ResolutionUpdateCallBack(width, height);
+  player->ResolutionUpdateCallBack(width, height, display_aspect);
 }
 

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -124,7 +124,7 @@ public:
   int GetFreeSpace();
   void  SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
   static void RenderUpdateCallBack(const void *ctx, const CRect &SrcRect, const CRect &DestRect);
-  void ResolutionUpdateCallBack(uint32_t width, uint32_t height);
-  static void ResolutionUpdateCallBack(void *ctx, uint32_t width, uint32_t height);
+  void ResolutionUpdateCallBack(uint32_t width, uint32_t height, float pixel_aspect);
+  static void ResolutionUpdateCallBack(void *ctx, uint32_t width, uint32_t height, float pixel_aspect);
 };
 #endif

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -37,7 +37,7 @@
 
 #define CLASSNAME "COMXVideo"
 
-typedef void (*ResolutionUpdateCallBackFn)(void *ctx, uint32_t width, uint32_t height);
+typedef void (*ResolutionUpdateCallBackFn)(void *ctx, uint32_t width, uint32_t height, float display_aspect);
 
 class COMXVideo
 {

--- a/xbmc/linux/OMXCore.cpp
+++ b/xbmc/linux/OMXCore.cpp
@@ -1669,6 +1669,11 @@ OMX_ERRORTYPE COMXCoreComponent::DecoderEventHandler(
       CLog::Log(LOGDEBUG, "%s::%s %s - OMX_EventPortSettingsChanged(output)\n", CLASSNAME, __func__, ctx->GetName().c_str());
       #endif
     break;
+    case OMX_EventParamOrConfigChanged:
+      #if defined(OMX_DEBUG_EVENTHANDLER)
+      CLog::Log(LOGDEBUG, "%s::%s %s - OMX_EventParamOrConfigChanged(output)\n", CLASSNAME, __func__, ctx->GetName().c_str());
+      #endif
+    break;
     #if defined(OMX_DEBUG_EVENTHANDLER)
     case OMX_EventMark:
       CLog::Log(LOGDEBUG, "%s::%s %s - OMX_EventMark\n", CLASSNAME, __func__, ctx->GetName().c_str());


### PR DESCRIPTION
We don't get a valid aspect ratio from tvheadend with mpeg2 files, but the decoder does know, so use that.
This also supports streams where aspect ratio changes (e.g. at commercials) (with firmware from 25 June or newer).

Also revert an earlier commit that was trying to fix a problem that this fixes in a better way.
