### PR TITLE
[rbp/omxplayer] Make audio_render configurable as the clock master

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -192,6 +192,19 @@ bool COMXAudio::PortSettingsChanged()
 
   m_omx_render.ResetEos();
 
+  // By default audio_render is the clock master, and if output samples don't fit the timestamps, it will speed up/slow down the clock.
+  // This tends to be better for maintaining audio sync and avoiding audio glitches, but can affect video/display sync
+  if(CSettings::Get().GetBool("videoplayer.usedisplayasclock"))
+  {
+    OMX_CONFIG_BOOLEANTYPE configBool;
+    OMX_INIT_STRUCTURE(configBool);
+    configBool.bEnabled = OMX_FALSE;
+
+    omx_err = m_omx_render.SetConfig(OMX_IndexConfigBrcmClockReferenceSource, &configBool);
+    if (omx_err != OMX_ErrorNone)
+       return false;
+  }
+
   OMX_CONFIG_BRCMAUDIODESTINATIONTYPE audioDest;
   OMX_INIT_STRUCTURE(audioDest);
   strncpy((char *)audioDest.sName, m_deviceuse.c_str(), strlen(m_deviceuse.c_str()));

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -107,9 +107,7 @@ bool OMXClock::OMXSetReferenceClock(bool lock /* = true */)
   OMX_TIME_CONFIG_ACTIVEREFCLOCKTYPE refClock;
   OMX_INIT_STRUCTURE(refClock);
 
-  if(CSettings::Get().GetBool("videoplayer.usedisplayasclock") && m_has_video)
-    refClock.eClock = OMX_TIME_RefClockVideo;
-  else if(m_has_audio)
+  if(m_has_audio)
     refClock.eClock = OMX_TIME_RefClockAudio;
   else
     refClock.eClock = OMX_TIME_RefClockVideo;
@@ -465,9 +463,7 @@ bool OMXClock::OMXMediaTime(double pts, bool fixPreroll /* = true*/, bool lock /
   OMX_INIT_STRUCTURE(timeStamp);
   timeStamp.nPortIndex = m_omx_clock.GetInputPort();
 
-  if(CSettings::Get().GetBool("videoplayer.usedisplayasclock") && m_has_video)
-    index = OMX_IndexConfigTimeCurrentVideoReference;
-  else if(m_has_audio)
+  if(m_has_audio)
     index = OMX_IndexConfigTimeCurrentAudioReference;
   else
     index = OMX_IndexConfigTimeCurrentVideoReference;


### PR DESCRIPTION
By default audio_render is the clock master, and if output samples don't fit the timestamps, it will speed up/slow down the clock.
This tends to be better for maintaining audio sync and avoiding audio glitches, but can affect video/display sync.
The other option makes audio_render the clock slave, and it has to drop packet or output silence to maintain sync.

As both settings have some advantages, and as this mode more accurately defines whether playback is synced to display or audio, I've used the GUI setting "sync playback to display" to control this.

The previous use of "sync playback to display" didn't have any benefits, and was never recommended.
