### PR TITLE
[rbp/omxplayer] Remove fixPreroll parameter

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3884,7 +3884,7 @@ bool COMXPlayer::HasMenu()
 
 bool COMXPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
 {
-  double pts = m_av_clock.OMXMediaTime(false);
+  double pts = m_av_clock.OMXMediaTime();
 
   if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
     return false;

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -448,7 +448,7 @@ void OMXPlayerAudio::Process()
       COMXPlayer::SPlayerState& state = ((CDVDMsgType<COMXPlayer::SPlayerState>*)pMsg)->m_value;
 
       if(state.time_src == COMXPlayer::ETIMESOURCE_CLOCK)
-        state.time      = DVD_TIME_TO_MSEC(m_av_clock->OMXMediaTime(true));
+        state.time      = DVD_TIME_TO_MSEC(m_av_clock->OMXMediaTime());
         //state.time      = DVD_TIME_TO_MSEC(m_av_clock->GetClock(state.timestamp) + state.time_offset);
       else
         state.timestamp = m_av_clock->GetAbsoluteClock();

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -272,7 +272,7 @@ void OMXPlayerVideo::Output(double pts, bool bDropPacket)
 
   // we aim to submit subtitles 100ms early
   const double preroll = DVD_MSEC_TO_TIME(100);
-  double media_pts = m_av_clock->OMXMediaTime(false);
+  double media_pts = m_av_clock->OMXMediaTime();
 
   if (m_nextOverlay != DVD_NOPTS_VALUE && media_pts + preroll <= m_nextOverlay)
     return;
@@ -408,7 +408,7 @@ void OMXPlayerVideo::Process()
       COMXPlayer::SPlayerState& state = ((CDVDMsgType<COMXPlayer::SPlayerState>*)pMsg)->m_value;
 
       if(state.time_src == COMXPlayer::ETIMESOURCE_CLOCK)
-        state.time      = DVD_TIME_TO_MSEC(m_av_clock->OMXMediaTime(true));
+        state.time      = DVD_TIME_TO_MSEC(m_av_clock->OMXMediaTime());
         //state.time      = DVD_TIME_TO_MSEC(m_av_clock->GetClock(state.timestamp) + state.time_offset);
       else
         state.timestamp = m_av_clock->GetAbsoluteClock();

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -381,7 +381,7 @@ bool OMXClock::OMXReset(bool lock /* = true */)
   return true;
 }
 
-double OMXClock::OMXMediaTime(bool fixPreroll /* true */ , bool lock /* = true */)
+double OMXClock::OMXMediaTime(bool lock /* = true */)
 {
   if(m_omx_clock.GetComponent() == NULL)
     return 0;
@@ -406,9 +406,6 @@ double OMXClock::OMXMediaTime(bool fixPreroll /* true */ , bool lock /* = true *
   }
 
   pts = FromOMXTime(timeStamp.nTimestamp);
-
-  if(fixPreroll)
-    pts += (OMX_PRE_ROLL * 1000);
 
   if(lock)
     UnLock();
@@ -451,7 +448,7 @@ double OMXClock::OMXClockAdjustment(bool lock /* = true */)
 
 // Set the media time, so calls to get media time use the updated value,
 // useful after a seek so mediatime is updated immediately (rather than waiting for first decoded packet)
-bool OMXClock::OMXMediaTime(double pts, bool fixPreroll /* = true*/, bool lock /* = true*/)
+bool OMXClock::OMXMediaTime(double pts, bool lock /* = true*/)
 {
   if(m_omx_clock.GetComponent() == NULL)
     return false;
@@ -472,8 +469,6 @@ bool OMXClock::OMXMediaTime(double pts, bool fixPreroll /* = true*/, bool lock /
   else
     index = OMX_IndexConfigTimeCurrentVideoReference;
 
-  if(fixPreroll)
-    pts -= (OMX_PRE_ROLL * 1000);
   timeStamp.nTimestamp = ToOMXTime(pts);
 
   omx_err = m_omx_clock.SetConfig(index, &timeStamp);

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -85,9 +85,9 @@ public:
   bool OMXStart(bool lock = true);
   bool OMXStep(int steps = 1, bool lock = true);
   bool OMXReset(bool lock = true);
-  double OMXMediaTime(bool fixPreroll = true, bool lock = true);
+  double OMXMediaTime(bool lock = true);
   double OMXClockAdjustment(bool lock = true);
-  bool OMXMediaTime(double pts, bool fixPreroll = true, bool lock = true);
+  bool OMXMediaTime(double pts, bool lock = true);
   bool OMXPause(bool lock = true);
   bool OMXResume(bool lock = true);
   bool OMXSetSpeed(int speed, bool lock = true, bool pause_resume = false);


### PR DESCRIPTION
The preroll only affects when the clock component starts. It doesn't affect the reported timestamps,
so adjusting timestamp by the preroll is incorrect
