### PR TITLE
[rbp/omxplayer] Use timestamps given to gpu as GetCurrentPts

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -71,7 +71,7 @@ OMXPlayerAudio::OMXPlayerAudio(OMXClock *av_clock, CDVDMessageQueue& parent)
   m_speed         = DVD_PLAYSPEED_NORMAL;
   m_started       = false;
   m_stalled       = false;
-  m_audioClock    = 0;
+  m_audioClock    = DVD_NOPTS_VALUE;
   m_buffer_empty  = false;
   m_nChannels     = 0;
   m_DecoderOpen   = false;
@@ -136,7 +136,7 @@ void OMXPlayerAudio::OpenStream(CDVDStreamInfo &hints, COMXAudioCodecOMX *codec)
     m_hints.bitspersample = 16;
 
   m_speed           = DVD_PLAYSPEED_NORMAL;
-  m_audioClock      = 0;
+  m_audioClock      = DVD_NOPTS_VALUE;
   m_hw_decode       = false;
   m_silence         = false;
   m_started         = false;
@@ -410,6 +410,7 @@ void OMXPlayerAudio::Process()
       CDVDMsgGeneralResync* pMsgGeneralResync = (CDVDMsgGeneralResync*)pMsg;
       CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::GENERAL_RESYNC(%f, %d)", m_audioClock, pMsgGeneralResync->m_clock);
       m_flush = false;
+      m_audioClock = DVD_NOPTS_VALUE;
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
@@ -422,6 +423,7 @@ void OMXPlayerAudio::Process()
       m_av_clock->OMXReset(false);
       m_av_clock->UnLock();
       m_started = false;
+      m_audioClock = DVD_NOPTS_VALUE;
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
     {
@@ -436,6 +438,7 @@ void OMXPlayerAudio::Process()
 
       if (m_pAudioCodec)
         m_pAudioCodec->Reset();
+      m_audioClock = DVD_NOPTS_VALUE;
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_STARTED))
     {

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -92,10 +92,12 @@ OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
   m_messageQueue.SetMaxTimeSize(8.0);
 
   m_dst_rect.SetRect(0, 0, 0, 0);
-  m_nextOverlay = DVD_NOPTS_VALUE;
   m_started = false;
+  m_iCurrentPts = DVD_NOPTS_VALUE;
+  m_nextOverlay = DVD_NOPTS_VALUE;
   m_flush = false;
   m_view_mode = 0;
+  m_history_valid_pts = 0;
 }
 
 OMXPlayerVideo::~OMXPlayerVideo()
@@ -134,6 +136,8 @@ bool OMXPlayerVideo::OpenStream(CDVDStreamInfo &hints)
   }
 
   m_open        = true;
+  m_iCurrentPts = DVD_NOPTS_VALUE;
+  m_nextOverlay = DVD_NOPTS_VALUE;
 
   return true;
 }
@@ -175,8 +179,6 @@ bool OMXPlayerVideo::CloseStream(bool bWaitForBuffers)
 
 void OMXPlayerVideo::OnStartup()
 {
-  m_iCurrentPts = DVD_NOPTS_VALUE;
-  m_nextOverlay = DVD_NOPTS_VALUE;
 }
 
 void OMXPlayerVideo::OnExit()
@@ -265,8 +267,6 @@ void OMXPlayerVideo::Output(double pts, bool bDropPacket)
     return;
   }
 
-  m_iCurrentPts = pts;
-
   if (CThread::m_bStop)
     return;
 
@@ -295,9 +295,16 @@ void OMXPlayerVideo::Output(double pts, bool bDropPacket)
   g_renderManager.FlipPage(CThread::m_bStop, time/DVD_TIME_BASE);
 }
 
+static unsigned count_bits(int32_t value)
+{
+  unsigned bits = 0;
+  for(;value;++bits)
+    value &= value - 1;
+  return bits;
+}
+
 void OMXPlayerVideo::Process()
 {
-  double pts = 0;
   double frametime = (double)DVD_TIME_BASE / m_fFrameRate;
   bool bRequestDrop = false;
 
@@ -337,11 +344,9 @@ void OMXPlayerVideo::Process()
     else if (pMsg->IsType(CDVDMsg::GENERAL_RESYNC))
     {
       CDVDMsgGeneralResync* pMsgGeneralResync = (CDVDMsgGeneralResync*)pMsg;
-
-      if(pMsgGeneralResync->m_timestamp != DVD_NOPTS_VALUE)
-        pts = pMsgGeneralResync->m_timestamp;
-
-      CLog::Log(LOGDEBUG, "COMXPlayerVideo - CDVDMsg::GENERAL_RESYNC(%f, %d)", pts, pMsgGeneralResync->m_clock);
+      CLog::Log(LOGDEBUG, "COMXPlayerVideo - CDVDMsg::GENERAL_RESYNC(%f, %d)", pMsgGeneralResync->m_timestamp, pMsgGeneralResync->m_clock);
+      m_nextOverlay = DVD_NOPTS_VALUE;
+      m_iCurrentPts = DVD_NOPTS_VALUE;
       pMsgGeneralResync->Release();
       continue;
     }
@@ -375,6 +380,7 @@ void OMXPlayerVideo::Process()
       m_av_clock->UnLock();
       m_started = false;
       m_nextOverlay = DVD_NOPTS_VALUE;
+      m_iCurrentPts = DVD_NOPTS_VALUE;
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH)) // private message sent by (COMXPlayerVideo::Flush())
     {
@@ -384,6 +390,7 @@ void OMXPlayerVideo::Process()
       m_nextOverlay = DVD_NOPTS_VALUE;
       m_av_clock->Lock();
       m_av_clock->OMXStop(false);
+      m_iCurrentPts = DVD_NOPTS_VALUE;
       m_omxVideo.Reset();
       m_av_clock->OMXReset(false);
       m_av_clock->UnLock();
@@ -465,32 +472,20 @@ void OMXPlayerVideo::Process()
           m_stalled = false;
         }
 
-        double output_pts = 0;
-        // validate picture timing,
-        // if both dts/pts invalid, use pts calulated from picture.iDuration
-        // if pts invalid use dts, else use picture.pts as passed
-        if (pPacket->dts == DVD_NOPTS_VALUE && pPacket->pts == DVD_NOPTS_VALUE)
-          output_pts = pts;
-        else if (pPacket->pts == DVD_NOPTS_VALUE)
-          output_pts = pts;
-        else
-          output_pts = pPacket->pts;
+        // some packed bitstream AVI files set almost all pts values to DVD_NOPTS_VALUE, but have a scattering of real pts values.
+        // the valid pts values match the dts values.
+        // if a stream has had more than 4 valid pts values in the last 16, the use UNKNOWN, otherwise use dts
+        m_history_valid_pts = (m_history_valid_pts << 1) | (pPacket->pts != DVD_NOPTS_VALUE);
+        double pts = pPacket->pts;
+        if(pPacket->pts == DVD_NOPTS_VALUE && count_bits(m_history_valid_pts & 0xffff) < 4)
+          pts = pPacket->dts;
 
-        if(pPacket->pts != DVD_NOPTS_VALUE)
-          pPacket->pts += m_iVideoDelay;
+        if (pts != DVD_NOPTS_VALUE)
+          pts += m_iVideoDelay;
 
-        if(pPacket->dts != DVD_NOPTS_VALUE)
-          pPacket->dts += m_iVideoDelay;
-
-        if(pPacket->duration == 0)
-          pPacket->duration = frametime;
-
-        if(output_pts != DVD_NOPTS_VALUE)
-          pts = output_pts;
-
-        m_omxVideo.Decode(pPacket->pData, pPacket->iSize, pPacket->dts, pPacket->pts);
-
-        Output(output_pts, bRequestDrop);
+        m_omxVideo.Decode(pPacket->pData, pPacket->iSize, pts);
+        Output(pts, bRequestDrop);
+        m_iCurrentPts = pts;
 
         if(m_started == false)
         {
@@ -498,10 +493,6 @@ void OMXPlayerVideo::Process()
           m_started = true;
           m_messageParent.Put(new CDVDMsgInt(CDVDMsg::PLAYER_STARTED, DVDPLAYER_VIDEO));
         }
-
-        // guess next frame pts. iDuration is always valid
-        if (m_speed != 0)
-          pts += pPacket->duration * m_speed / abs(m_speed);
 
         break;
       }
@@ -574,6 +565,8 @@ bool OMXPlayerVideo::OpenDecoder()
   m_av_clock->HasVideo(bVideoDecoderOpen);
   m_av_clock->OMXReset(false);
   m_av_clock->UnLock();
+  // start from assuming all recent frames had valid pts
+  m_history_valid_pts = ~0;
 
   return bVideoDecoderOpen;
 }

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -71,6 +71,7 @@ protected:
   CRect                     m_dst_rect;
   int                       m_view_mode;
 
+  uint32_t                  m_history_valid_pts;
   DllBcmHost                m_DllBcmHost;
 
   CDVDOverlayContainer  *m_pOverlayContainer;

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -53,7 +53,7 @@ public:
   void Close(void);
   unsigned int GetFreeSpace();
   unsigned int GetSize();
-  int  Decode(uint8_t *pData, int iSize, double dts, double pts);
+  int  Decode(uint8_t *pData, int iSize, double pts);
   void Reset(void);
   void SetDropState(bool bDrop);
   std::string GetDecoderName() { return m_video_codec_name; };
@@ -93,7 +93,6 @@ protected:
   bool              m_deinterlace;
   EDEINTERLACEMODE  m_deinterlace_request;
   bool              m_hdmi_clock_sync;
-  uint32_t          m_history_valid_pts;
   ResolutionUpdateCallBackFn m_res_callback;
   void              *m_res_ctx;
   bool              m_submitted_eos;


### PR DESCRIPTION
Currently the timestamps gpu is using and those returned from GetCurrentPts can diverge, making decisions inaccurate.
Make sure they use the same timestamps by bringing the timestamp adjustment code up from OMXVideo to OMXPlayerVideo.

This is required for a future commit that calculates time to underrun as GetCurrentPts-OMXMediaTime.
