### PR TITLE
[rbp/omxplayer] Move buffering decision to omxplayer level

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -41,7 +41,7 @@
 
 #include "threads/CriticalSection.h"
 
-#define AUDIO_BUFFER_SECONDS 2
+#define AUDIO_BUFFER_SECONDS 3
 #define VIS_PACKET_SIZE 512
 
 #define OMX_IS_RAW(x)       \

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -66,7 +66,6 @@ protected:
 
   BitstreamStats            m_audioStats;
 
-  struct timespec           m_starttime, m_endtime;
   bool                      m_buffer_empty;
   bool                      m_flush;
   int                       m_nChannels;

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -511,7 +511,7 @@ bool OMXClock::OMXResume(bool lock /* = true */)
     if(lock)
       Lock();
 
-    if (OMXSetSpeed(m_omx_speed, false, true))
+    if (OMXSetSpeed(DVD_PLAYSPEED_NORMAL, false, true))
       m_pause = false;
 
     if(lock)
@@ -528,22 +528,24 @@ bool OMXClock::OMXSetSpeed(int speed, bool lock /* = true */, bool pause_resume 
   if(lock)
     Lock();
 
-  CLog::Log(LOGDEBUG, "OMXClock::OMXSetSpeed(%.2f) pause_resume:%d", (float)m_omx_speed / (float)DVD_PLAYSPEED_NORMAL, pause_resume);
+  CLog::Log(LOGDEBUG, "OMXClock::OMXSetSpeed(%.2f) pause_resume:%d", (float)speed / (float)DVD_PLAYSPEED_NORMAL, pause_resume);
 
-  OMX_ERRORTYPE omx_err = OMX_ErrorNone;
-  OMX_TIME_CONFIG_SCALETYPE scaleType;
-  OMX_INIT_STRUCTURE(scaleType);
-
-  scaleType.xScale = (speed << 16) / DVD_PLAYSPEED_NORMAL;
-  omx_err = m_omx_clock.SetConfig(OMX_IndexConfigTimeScale, &scaleType);
-  if(omx_err != OMX_ErrorNone)
+  if (pause_resume)
   {
-    CLog::Log(LOGERROR, "OMXClock::OMXSetSpeed error setting OMX_IndexConfigTimeClockState\n");
-    if(lock)
-      UnLock();
-    return false;
-  }
+    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
+    OMX_TIME_CONFIG_SCALETYPE scaleType;
+    OMX_INIT_STRUCTURE(scaleType);
 
+    scaleType.xScale = (speed << 16) / DVD_PLAYSPEED_NORMAL;
+    omx_err = m_omx_clock.SetConfig(OMX_IndexConfigTimeScale, &scaleType);
+    if(omx_err != OMX_ErrorNone)
+    {
+      CLog::Log(LOGERROR, "OMXClock::OMXSetSpeed error setting OMX_IndexConfigTimeClockState\n");
+      if(lock)
+        UnLock();
+      return false;
+    }
+  }
   if (!pause_resume)
     m_omx_speed = speed;
 

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -63,7 +63,6 @@ protected:
   int               m_omx_speed;
   bool              m_video_start;
   bool              m_audio_start;
-  bool              m_audio_buffer;
   CDVDClock         *m_clock;
 private:
   COMXCoreComponent m_omx_clock;
@@ -106,9 +105,6 @@ public:
   bool AudioStart() { return m_audio_start; };
   void VideoStart(bool video_start);
   void AudioStart(bool audio_start);
-  void OMXAudioBufferStart();
-  void OMXAudioBufferStop();
-  bool OMXAudioBuffer() { return m_audio_buffer; };
 
   int     GetRefreshRate(double* interval = NULL);
   void    SetRefreshRate(double fps) { m_fps = fps; };


### PR DESCRIPTION
Move the decision of when to pause the GPU pipeline due to buffer underrun from the OMXPlayerAudio level to the OMXPlayer level. The decision is made based on difference in timestamps being submitted to GPU and the OMXMediaTime (i.e. how much buffered data the GPU has).

We now consider both audio and video. We pause when either is less than 0.1s. We unpause when both are greater than 0.2s, although this threshold increases each time it is hit. When this gets high, the limit will actually be AcceptsData returning false when queues are full).

Now timestamps are used for buffering decisions (rather than data buffered at audio_decode input), we can move the audio buffering to audio_decode output port. This avoids the memory being duplicated on ARM side, and also is half the size (input port is floating point, output port is 16 bit integer). I've bumped the buffer from 2s to 3s.
