### PR TITLE
[rbp/omxplayer] Remove clock manipulation

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -106,6 +106,7 @@ COMXAudio::COMXAudio() :
   m_omx_clock       (NULL   ),
   m_av_clock        (NULL   ),
   m_settings_changed(false  ),
+  m_setStartTime    (false  ),
   m_LostSync        (true   ),
   m_SampleRate      (0      ),
   m_eEncoding       (OMX_AUDIO_CodingPCM),
@@ -568,6 +569,7 @@ bool COMXAudio::Initialize(AEAudioFormat format, std::string& device, OMXClock *
 
   m_Initialized   = true;
   m_settings_changed = false;
+  m_setStartTime = true;
   m_last_pts      = DVD_NOPTS_VALUE;
 
   CLog::Log(LOGDEBUG, "COMXAudio::Initialize Input bps %d samplerate %d channels %d buffer size %d bytes per second %d", 
@@ -635,6 +637,7 @@ void COMXAudio::Flush()
   
   m_last_pts      = DVD_NOPTS_VALUE;
   m_LostSync      = true;
+  m_setStartTime  = true;
 }
 
 //***********************************************************************************************
@@ -855,7 +858,7 @@ unsigned int COMXAudio::AddPackets(const void* data, unsigned int len, double dt
 
     uint64_t val  = (uint64_t)(pts == DVD_NOPTS_VALUE) ? 0 : pts;
 
-    if(m_av_clock->AudioStart())
+    if(m_setStartTime)
     {
       omx_buffer->nFlags = OMX_BUFFERFLAG_STARTTIME;
       if(pts == DVD_NOPTS_VALUE)
@@ -864,7 +867,7 @@ unsigned int COMXAudio::AddPackets(const void* data, unsigned int len, double dt
       m_last_pts = pts;
 
       CLog::Log(LOGDEBUG, "COMXAudio::Decode ADec : setStartTime %f\n", (float)val / DVD_TIME_BASE);
-      m_av_clock->AudioStart(false);
+      m_setStartTime = false;
     }
     else
     {

--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -110,6 +110,7 @@ private:
   COMXCoreComponent *m_omx_clock;
   OMXClock       *m_av_clock;
   bool          m_settings_changed;
+  bool          m_setStartTime;
   bool          m_LostSync;
   int           m_SampleRate;
   OMX_AUDIO_CODINGTYPE m_eEncoding;

--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -41,7 +41,7 @@
 
 #include "threads/CriticalSection.h"
 
-#define AUDIO_BUFFER_SECONDS 2
+#define AUDIO_BUFFER_SECONDS 3
 #define VIS_PACKET_SIZE 512
 
 #define OMX_IS_RAW(x)       \

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -400,22 +400,14 @@ void OMXPlayerAudio::Process()
       CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::GENERAL_RESET");
       if (m_pAudioCodec)
         m_pAudioCodec->Reset();
-      m_av_clock->Lock();
-      m_av_clock->OMXStop(false);
       m_omxAudio.Flush();
-      m_av_clock->OMXReset(false);
-      m_av_clock->UnLock();
       m_started = false;
       m_audioClock = DVD_NOPTS_VALUE;
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
     {
       CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::GENERAL_FLUSH");
-      m_av_clock->Lock();
-      m_av_clock->OMXStop(false);
       m_omxAudio.Flush();
-      m_av_clock->OMXReset(false);
-      m_av_clock->UnLock();
       m_stalled   = true;
       m_started   = false;
 
@@ -589,9 +581,6 @@ bool OMXPlayerAudio::OpenDecoder()
   else
     device = "local";
 
-  m_av_clock->Lock();
-  m_av_clock->OMXStop(false);
-
   bool bAudioRenderOpen = m_omxAudio.Initialize(m_format, device, m_av_clock, m_hints, m_passthrough, m_hw_decode);
 
   m_codec_name = "";
@@ -608,11 +597,6 @@ bool OMXPlayerAudio::OpenDecoder()
       m_codec_name.c_str(), m_nChannels, m_hints.samplerate, m_hints.bitspersample);
   }
 
-  m_av_clock->OMXStateExecute(false);
-  m_av_clock->HasAudio(bAudioRenderOpen);
-  m_av_clock->OMXReset(false);
-  m_av_clock->UnLock();
-
   m_started = false;
 
   // TODO : Send FLUSH to parent, only if we had a valid open codec. 
@@ -626,13 +610,7 @@ bool OMXPlayerAudio::OpenDecoder()
 
 void OMXPlayerAudio::CloseDecoder()
 {
-  m_av_clock->Lock();
-  m_av_clock->OMXStop(false);
   m_omxAudio.Deinitialize();
-  m_av_clock->HasAudio(false);
-  m_av_clock->OMXReset(false);
-  m_av_clock->UnLock();
-
   m_DecoderOpen = false;
 }
 

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -66,7 +66,6 @@ protected:
 
   BitstreamStats            m_audioStats;
 
-  struct timespec           m_starttime, m_endtime;
   bool                      m_buffer_empty;
   bool                      m_flush;
   int                       m_nChannels;

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -166,12 +166,7 @@ bool OMXPlayerVideo::CloseStream(bool bWaitForBuffers)
   m_speed         = DVD_PLAYSPEED_NORMAL;
   m_started       = false;
 
-  m_av_clock->Lock();
-  m_av_clock->OMXStop(false);
   m_omxVideo.Close();
-  m_av_clock->HasVideo(false);
-  m_av_clock->OMXReset(false);
-  m_av_clock->UnLock();
 
   if(m_DllBcmHost.IsLoaded())
     m_DllBcmHost.Unload();
@@ -365,11 +360,7 @@ void OMXPlayerVideo::Process()
     else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
       CLog::Log(LOGDEBUG, "COMXPlayerVideo - CDVDMsg::GENERAL_RESET");
-      m_av_clock->Lock();
-      m_av_clock->OMXStop(false);
       m_omxVideo.Reset();
-      m_av_clock->OMXReset(false);
-      m_av_clock->UnLock();
       m_started = false;
       m_nextOverlay = DVD_NOPTS_VALUE;
       m_iCurrentPts = DVD_NOPTS_VALUE;
@@ -380,12 +371,8 @@ void OMXPlayerVideo::Process()
       m_stalled = true;
       m_started = false;
       m_nextOverlay = DVD_NOPTS_VALUE;
-      m_av_clock->Lock();
-      m_av_clock->OMXStop(false);
       m_iCurrentPts = DVD_NOPTS_VALUE;
       m_omxVideo.Reset();
-      m_av_clock->OMXReset(false);
-      m_av_clock->UnLock();
       m_flush = false;
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
@@ -526,10 +513,6 @@ bool OMXPlayerVideo::OpenDecoder()
   else
     m_fForcedAspectRatio = 0.0;
 
-
-  m_av_clock->Lock();
-  m_av_clock->OMXStop(false);
-
   bool bVideoDecoderOpen = m_omxVideo.Open(m_hints, m_av_clock, CMediaSettings::Get().GetCurrentVideoSettings().m_DeinterlaceMode, m_hdmi_clock_sync);
   m_omxVideo.RegisterResolutionUpdateCallBack((void *)this, ResolutionUpdateCallBack);
 
@@ -556,10 +539,6 @@ bool OMXPlayerVideo::OpenDecoder()
     m_av_clock->SetRefreshRate(m_fFrameRate);
   }
 
-  m_av_clock->OMXStateExecute(false);
-  m_av_clock->HasVideo(bVideoDecoderOpen);
-  m_av_clock->OMXReset(false);
-  m_av_clock->UnLock();
   // start from assuming all recent frames had valid pts
   m_history_valid_pts = ~0;
 

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -81,6 +81,7 @@ COMXVideo::COMXVideo() : m_video_codec_name("")
   m_res_ctx           = NULL;
   m_submitted_eos     = false;
   m_settings_changed  = false;
+  m_setStartTime      = false;
   m_transform         = OMX_DISPLAY_ROT0;
 }
 
@@ -342,6 +343,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, EDEINTERLACEMODE de
   OMX_ERRORTYPE omx_err   = OMX_ErrorNone;
   std::string decoder_name;
   m_settings_changed = false;
+  m_setStartTime = true;
 
   m_res_ctx           = NULL;
   m_res_callback      = NULL;
@@ -747,11 +749,11 @@ int COMXVideo::Decode(uint8_t *pData, int iSize, double pts)
       omx_buffer->nFlags = 0;
       omx_buffer->nOffset = 0;
 
-      if(m_av_clock->VideoStart())
+      if(m_setStartTime)
       {
         omx_buffer->nFlags |= OMX_BUFFERFLAG_STARTTIME;
         CLog::Log(LOGDEBUG, "OMXVideo::Decode VDec : setStartTime %f\n", (pts == DVD_NOPTS_VALUE ? 0.0 : pts) / DVD_TIME_BASE);
-        m_av_clock->VideoStart(false);
+        m_setStartTime = false;
       }
       if(pts == DVD_NOPTS_VALUE)
         omx_buffer->nFlags |= OMX_BUFFERFLAG_TIME_UNKNOWN;
@@ -817,6 +819,7 @@ void COMXVideo::Reset(void)
   if(!m_is_open)
     return;
 
+  m_setStartTime = true;
   m_omx_decoder.FlushInput();
   m_omx_tunnel_decoder.Flush();
 }

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -83,6 +83,7 @@ protected:
   COMXCoreTunel     m_omx_tunnel_sched;
   COMXCoreTunel     m_omx_tunnel_image_fx;
   bool              m_is_open;
+  bool              m_setStartTime;
 
   uint8_t           *m_extradata;
   int               m_extrasize;

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -244,38 +244,6 @@ bool  OMXClock::OMXStop(bool lock /* = true */)
   return true;
 }
 
-bool OMXClock::OMXStart(bool lock /* = true */)
-{
-  if(m_omx_clock.GetComponent() == NULL)
-    return false;
-
-  if(lock)
-    Lock();
-
-  CLog::Log(LOGDEBUG, "OMXClock::OMXStart\n");
-
-  OMX_ERRORTYPE omx_err = OMX_ErrorNone;
-  OMX_TIME_CONFIG_CLOCKSTATETYPE clock;
-  OMX_INIT_STRUCTURE(clock);
-
-  clock.eState      = OMX_TIME_ClockStateRunning;
-  clock.nOffset     = ToOMXTime(-1000LL * OMX_PRE_ROLL);
-
-  omx_err = m_omx_clock.SetConfig(OMX_IndexConfigTimeClockState, &clock);
-  if(omx_err != OMX_ErrorNone)
-  {
-    CLog::Log(LOGERROR, "OMXClock::Start error setting OMX_IndexConfigTimeClockState\n");
-    if(lock)
-      UnLock();
-    return false;
-  }
-
-  if(lock)
-    UnLock();
-
-  return true;
-}
-
 bool OMXClock::OMXStep(int steps /* = 1 */, bool lock /* = true */)
 {
   if(m_omx_clock.GetComponent() == NULL)

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -276,20 +276,6 @@ bool OMXClock::OMXStart(bool lock /* = true */)
   return true;
 }
 
-void OMXClock::VideoStart(bool video_start)
-{ 
-  Lock();
-  m_video_start = video_start; 
-  UnLock();
-};
-
-void OMXClock::AudioStart(bool audio_start) 
-{ 
-  Lock();
-  m_audio_start = audio_start; 
-  UnLock();
-};
-
 bool OMXClock::OMXStep(int steps /* = 1 */, bool lock /* = true */)
 {
   if(m_omx_clock.GetComponent() == NULL)

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -349,25 +349,28 @@ bool OMXClock::OMXReset(bool lock /* = true */)
     return false;
   }
 
-  clock.eState    = OMX_TIME_ClockStateWaitingForStartTime;
-  clock.nOffset   = ToOMXTime(-1000LL * OMX_PRE_ROLL);
-
-  OMXSetClockPorts(&clock);
-
-  if(clock.nWaitMask)
+  OMX_TIME_CLOCKSTATE old_eState = clock.eState;
+  if (clock.eState == OMX_TIME_ClockStateStopped)
   {
-    omx_err = m_omx_clock.SetConfig(OMX_IndexConfigTimeClockState, &clock);
-    if(omx_err != OMX_ErrorNone)
+    clock.eState    = OMX_TIME_ClockStateWaitingForStartTime;
+    clock.nOffset   = ToOMXTime(-1000LL * OMX_PRE_ROLL);
+
+    OMXSetClockPorts(&clock);
+
+    if(clock.nWaitMask)
     {
-      CLog::Log(LOGERROR, "OMXClock::OMXReset error setting OMX_IndexConfigTimeClockState\n");
-      if(lock)
-        UnLock();
-      return false;
+      omx_err = m_omx_clock.SetConfig(OMX_IndexConfigTimeClockState, &clock);
+      if(omx_err != OMX_ErrorNone)
+      {
+        CLog::Log(LOGERROR, "OMXClock::OMXReset error setting OMX_IndexConfigTimeClockState\n");
+        if(lock)
+          UnLock();
+        return false;
+      }
     }
   }
-
-  CLog::Log(LOGDEBUG, "OMXClock::OMXReset audio / video : %d / %d start audio / video : %d / %d wait mask %d\n", 
-      m_has_audio, m_has_video, m_audio_start, m_video_start, clock.nWaitMask);
+  CLog::Log(LOGDEBUG, "OMXClock::OMXReset audio / video : %d / %d start audio / video : %d / %d wait mask %d state : %d->%d\n",
+      m_has_audio, m_has_video, m_audio_start, m_video_start, clock.nWaitMask, old_eState, clock.eState);
 
   if(lock)
     UnLock();

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -511,7 +511,7 @@ bool OMXClock::OMXResume(bool lock /* = true */)
     if(lock)
       Lock();
 
-    if (OMXSetSpeed(m_omx_speed, false, true))
+    if (OMXSetSpeed(DVD_PLAYSPEED_NORMAL, false, true))
       m_pause = false;
 
     if(lock)
@@ -528,22 +528,24 @@ bool OMXClock::OMXSetSpeed(int speed, bool lock /* = true */, bool pause_resume 
   if(lock)
     Lock();
 
-  CLog::Log(LOGDEBUG, "OMXClock::OMXSetSpeed(%.2f) pause_resume:%d", (float)m_omx_speed / (float)DVD_PLAYSPEED_NORMAL, pause_resume);
+  CLog::Log(LOGDEBUG, "OMXClock::OMXSetSpeed(%.2f) pause_resume:%d", (float)speed / (float)DVD_PLAYSPEED_NORMAL, pause_resume);
 
-  OMX_ERRORTYPE omx_err = OMX_ErrorNone;
-  OMX_TIME_CONFIG_SCALETYPE scaleType;
-  OMX_INIT_STRUCTURE(scaleType);
-
-  scaleType.xScale = (speed << 16) / DVD_PLAYSPEED_NORMAL;
-  omx_err = m_omx_clock.SetConfig(OMX_IndexConfigTimeScale, &scaleType);
-  if(omx_err != OMX_ErrorNone)
+  if (pause_resume)
   {
-    CLog::Log(LOGERROR, "OMXClock::OMXSetSpeed error setting OMX_IndexConfigTimeClockState\n");
-    if(lock)
-      UnLock();
-    return false;
-  }
+    OMX_ERRORTYPE omx_err = OMX_ErrorNone;
+    OMX_TIME_CONFIG_SCALETYPE scaleType;
+    OMX_INIT_STRUCTURE(scaleType);
 
+    scaleType.xScale = (speed << 16) / DVD_PLAYSPEED_NORMAL;
+    omx_err = m_omx_clock.SetConfig(OMX_IndexConfigTimeScale, &scaleType);
+    if(omx_err != OMX_ErrorNone)
+    {
+      CLog::Log(LOGERROR, "OMXClock::OMXSetSpeed error setting OMX_IndexConfigTimeClockState\n");
+      if(lock)
+        UnLock();
+      return false;
+    }
+  }
   if (!pause_resume)
     m_omx_speed = speed;
 

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -63,7 +63,6 @@ protected:
   int               m_omx_speed;
   bool              m_video_start;
   bool              m_audio_start;
-  bool              m_audio_buffer;
   CDVDClock         *m_clock;
 private:
   COMXCoreComponent m_omx_clock;
@@ -106,9 +105,6 @@ public:
   bool AudioStart() { return m_audio_start; };
   void VideoStart(bool video_start);
   void AudioStart(bool audio_start);
-  void OMXAudioBufferStart();
-  void OMXAudioBufferStop();
-  bool OMXAudioBuffer() { return m_audio_buffer; };
 
   int     GetRefreshRate(double* interval = NULL);
   void    SetRefreshRate(double fps) { m_fps = fps; };

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -81,7 +81,6 @@ public:
   void OMXDeinitialize();
   bool OMXIsPaused() { return m_pause; };
   bool OMXStop(bool lock = true);
-  bool OMXStart(bool lock = true);
   bool OMXStep(int steps = 1, bool lock = true);
   bool OMXReset(bool lock = true);
   double OMXMediaTime(bool lock = true);

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -101,10 +101,6 @@ public:
   bool HasAudio() { return m_has_audio; };
   void HasVideo(bool has_video) { m_has_video = has_video; };
   void HasAudio(bool has_audio) { m_has_audio = has_audio; };
-  bool VideoStart() { return m_video_start; };
-  bool AudioStart() { return m_audio_start; };
-  void VideoStart(bool video_start);
-  void AudioStart(bool audio_start);
 
   int     GetRefreshRate(double* interval = NULL);
   void    SetRefreshRate(double fps) { m_fps = fps; };


### PR DESCRIPTION
Currently the clock's state gets modified by OMXPlayer, OMXPlayerAudio and OMXPlayerVideo. This can lead to race conditions.

This change makes OMXPlayer the only place to modify the OMXClock state.
The previous change to move buffering to OMXPlayer level means the clock is paused whenever flushing or initialising audio/video components, so the locking and stopping of clocks from audio/video components is not required.

This PR includes the commits from #2926, and should be applied after it.
