### PR TITLE
[rbp/omxplayer] Reduce the size of preroll

### DIFF
--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -32,7 +32,7 @@
 #include "OMXClock.h"
 #include "utils/MathUtils.h"
 
-#define OMX_PRE_ROLL 800
+#define OMX_PRE_ROLL 200
 
 OMXClock::OMXClock()
 {


### PR DESCRIPTION
The preroll defines how much earlier the clock starts compares to timestamps of audio/video.
This needs enough time for GPU side worst video/audio decode/schedule/render.
This should never be more than 200ms.

This makes playback start and seeks 600ms more responsive which is noticable when seeking through a video.
