### PR TITLE
[rbp/omxplayer] Remove flush of video codec when audio codec changes

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -558,14 +558,11 @@ bool OMXPlayerAudio::OpenDecoder()
   m_passthrough = false;
   m_hw_decode   = false;
 
-  bool bSendParent = false;
-
   if(m_DecoderOpen)
   {
     WaitCompletion();
     m_omxAudio.Deinitialize();
     m_DecoderOpen = false;
-    bSendParent = true;
   }
 
   /* setup audi format for audio render */
@@ -598,12 +595,6 @@ bool OMXPlayerAudio::OpenDecoder()
   }
 
   m_started = false;
-
-  // TODO : Send FLUSH to parent, only if we had a valid open codec. 
-  // this is just a workaround to get the omx video decoder happy again
-  // This situation happens, for example where we have in the stream an audio codec change
-  if(bSendParent)
-    m_messageParent.Put(new CDVDMsg(CDVDMsg::GENERAL_FLUSH));
 
   return bAudioRenderOpen;
 }


### PR DESCRIPTION
I believe this was added to work around a race condition that is no longer present.
It discards video and results in a corruption until the next I frame.
