### PR TITLE
[rbp/omxplayer] Add logging for when audio/video EOS is first detected

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -124,6 +124,7 @@ private:
   int           m_vizRemapBufferSize;
   uint8_t       *m_vizRemapBuffer;
   CAERemap      m_vizRemap;
+  bool          m_submitted_eos;
 
   OMX_AUDIO_PARAM_PCMMODETYPE m_pcm_output;
   OMX_AUDIO_PARAM_PCMMODETYPE m_pcm_input;

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -888,11 +888,19 @@ void COMXVideo::SubmitEOS()
     CLog::Log(LOGERROR, "%s::%s - OMX_EmptyThisBuffer() failed with result(0x%x)\n", CLASSNAME, __func__, omx_err);
     return;
   }
+  CLog::Log(LOGINFO, "%s::%s", CLASSNAME, __func__);
 }
 
 bool COMXVideo::IsEOS()
 {
   if(!m_is_open)
     return true;
-  return m_omx_render.IsEOS();
+  if (!m_omx_render.IsEOS())
+    return false;
+  if (m_submitted_eos)
+  {
+    CLog::Log(LOGINFO, "%s::%s", CLASSNAME, __func__);
+    m_submitted_eos = false;
+  }
+  return true;
 }


### PR DESCRIPTION
This is useful for diagnosing streams that hang at end of file
