### PR TITLE
[pvr] fix: CAddonCallbacksAddon::GetAddonSetting doesn't returns slider setting value.

### DIFF
--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -220,6 +220,20 @@ bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSetti
             *(bool*) settingValue = (bool) (addonHelper->m_addon->GetSetting(id) == "true" ? true : false);
             return true;
           }
+          else if (strcmpi(type, "slider") == 0)
+          {
+            const char *option = setting->Attribute("option");
+            if (option && strcmpi(option, "int") == 0)
+            {
+              *(int*) settingValue = (int) atoi(addonHelper->m_addon->GetSetting(id));
+              return true;
+            }
+            else
+            {
+              *(float*) settingValue = (float) atof(addonHelper->m_addon->GetSetting(id));
+              return true;
+            }
+          }
         }
         setting = setting->NextSiblingElement("setting");
       }


### PR DESCRIPTION
This PR fix issue with impossibility the pvr addons get value of theirs slider settings.
