### PR TITLE
[VideoInfoScanner] If no matching subepisode in guide, try full episode

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1393,16 +1393,25 @@ namespace VIDEO
       }
 
       EPISODE key(file->iSeason, file->iEpisode, file->iSubepisode);
+      EPISODE backupkey(file->iSeason, file->iEpisode, 0);
       bool bFound = false;
       EPISODELIST::iterator guide = episodes.begin();;
       EPISODELIST matches;
 
       for (; guide != episodes.end(); ++guide )
       {
-        if ((file->iEpisode!=-1) && (file->iSeason!=-1) && (key==*guide))
+        if ((file->iEpisode!=-1) && (file->iSeason!=-1))
         {
-          bFound = true;
-          break;
+          if (key==*guide)
+          {
+            bFound = true;
+            break;
+          }
+          else if ((file->iSubepisode!=0) && (backupkey==*guide))
+          {
+            matches.push_back(*guide);
+            continue;
+          }
         }
         if (file->cDate.IsValid() && guide->cDate.IsValid() && file->cDate==guide->cDate)
         {


### PR DESCRIPTION
This PR attempts to fix the issue described in the note at [Video library/Naming files/TV shows#Split-episode](http://wiki.xbmc.org/index.php?title=Video_library/Naming_files/TV_shows#Split-episode), wherein a file such as:
`24.1x02.1.00.am-2.00.am.avi`
gets mis-enumerated as being (in this case) season 1, episode 2, sub-episode 1, which does not exist in the episode guide for the show and so the file doesn't get added.

With the patch, we assume the file was meant to be the full episode if there isn't an exact match to the sub-episode.

In cases where the user deliberately used a sub-episode numbering, but failed to get a match, I think this still makes sense (sort of).
The most likely scenario is that the user has named the files according to the DVD order, but is using the Aired order in the scraper.  E.g. His files are numbered `1.1:"A", 1.2:"B", 2:"C", 3:"D"`, but the scraper returns `1:"A", 2:"B", 3:"C", 4:"D"`.
Then currently, he would only get (the incorrect) `2:"B", 3:"C"`, whereas with the patch, he'll get (the still-wrong) `1:"A", 1:"A", 2:"B", 3:"C"`.

At least in the latter case all the files are in the library, and it might be a bigger hint as to the source of the issue.
