### PR TITLE
renderer: tempfix for aml/omx player after #2811

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -301,6 +301,8 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     m_presentstep = PRESENT_IDLE;
     m_presentevent.notifyAll();
 
+    m_firstFlipPage = false;  // tempfix
+
     CLog::Log(LOGDEBUG, "CXBMCRenderManager::Configure - %d", m_QueueSize);
   }
 
@@ -309,7 +311,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
 
 bool CXBMCRenderManager::RendererHandlesPresent() const
 {
-  return IsConfigured() && m_format != RENDER_FMT_BYPASS;
+  return IsConfigured() && (m_firstFlipPage || m_format != RENDER_FMT_BYPASS);
 }
 
 bool CXBMCRenderManager::IsConfigured() const
@@ -646,6 +648,8 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
       return;
 
     if(!m_pRenderer) return;
+
+    m_firstFlipPage = true;              // tempfix
 
     EPRESENTMETHOD presentmethod;
 

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -252,6 +252,9 @@ protected:
   //set to true when adding something to m_captures, set to false when m_captures is made empty
   //std::list::empty() isn't thread safe, using an extra bool will save a lock per render when no captures are requested
   bool                       m_hasCaptures; 
+
+  // temporary fix for RendererHandlesPresent after #2811
+  bool m_firstFlipPage;
 };
 
 extern CXBMCRenderManager g_renderManager;


### PR DESCRIPTION
temporary fix after #2811 until we have investigated

ugly but makes the old behavior obvious
