### PR TITLE
start/stop all addons before/after suspend/hibernate

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5723,3 +5723,25 @@ void CApplication::CloseNetworkShares()
   CSFTPSessionManager::DisconnectAllSessions();
 #endif
 }
+
+void CApplication::StopAddonServices()
+{
+  CLog::Log(LOGDEBUG,"CApplication::StopAddonServices");
+  CAddonMgr::Get().StopServices(false);
+}
+
+void CApplication::StartAddonServices()
+{
+  CLog::Log(LOGDEBUG,"CApplication::StartAddonServices - before login services");
+
+  //we start all services that run before login
+  CAddonMgr::Get().StartServices(true);
+
+  //this is meant to find out if we are logged in already
+  //so only start after-login services if we are not seeing the login screen
+  if (g_windowManager.GetActiveWindow() != WINDOW_LOGIN_SCREEN)
+  {
+    CLog::Log(LOGDEBUG,"CApplication::StartAddonServices - No login screen? So starting after-login-services also");
+    CAddonMgr::Get().StartServices(false);
+  }
+}

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5724,15 +5724,15 @@ void CApplication::CloseNetworkShares()
 #endif
 }
 
-void CApplication::StopAddonServices()
+void CApplication::StopServiceAddons()
 {
-  CLog::Log(LOGDEBUG,"CApplication::StopAddonServices");
+  CLog::Log(LOGDEBUG,"CApplication::StopServiceAddons");
   CAddonMgr::Get().StopServices(false);
 }
 
-void CApplication::StartAddonServices()
+void CApplication::StartServiceAddons()
 {
-  CLog::Log(LOGDEBUG,"CApplication::StartAddonServices - before login services");
+  CLog::Log(LOGDEBUG,"CApplication::StartServiceAddons - before login services");
 
   //we start all services that run before login
   CAddonMgr::Get().StartServices(true);
@@ -5741,7 +5741,7 @@ void CApplication::StartAddonServices()
   //so only start after-login services if we are not seeing the login screen
   if (g_windowManager.GetActiveWindow() != WINDOW_LOGIN_SCREEN)
   {
-    CLog::Log(LOGDEBUG,"CApplication::StartAddonServices - No login screen? So starting after-login-services also");
+    CLog::Log(LOGDEBUG,"CApplication::StartServiceAddons - No login screen? So starting after-login-services also");
     CAddonMgr::Get().StartServices(false);
   }
 }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -191,8 +191,8 @@ public:
   void CheckPlayingProgress();
   void ActivateScreenSaver(bool forceType = false);
   void CloseNetworkShares();
-  void StartAddonServices();
-  void StopAddonServices();
+  void StartServiceAddons();
+  void StopServiceAddons();
 
   virtual void Process();
   void ProcessSlow();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -191,6 +191,8 @@ public:
   void CheckPlayingProgress();
   void ActivateScreenSaver(bool forceType = false);
   void CloseNetworkShares();
+  void StartAddonServices();
+  void StopAddonServices();
 
   virtual void Process();
   void ProcessSlow();

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -161,7 +161,12 @@ bool CPowerManager::Powerdown()
 
 bool CPowerManager::Suspend()
 {
-  if (CanSuspend() && m_instance->Suspend())
+  if (!CanSuspend())
+    return false;
+
+  OnPrepareSleep();
+
+  if (m_instance->Suspend())
   {
     CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
     if (dialog)
@@ -175,7 +180,12 @@ bool CPowerManager::Suspend()
 
 bool CPowerManager::Hibernate()
 {
-  if (CanHibernate() && m_instance->Hibernate())
+  if (!CanHibernate())
+    return false;
+
+  OnPrepareSleep();
+
+  if (m_instance->Hibernate())
   {
     CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
     if (dialog)
@@ -232,6 +242,16 @@ void CPowerManager::ProcessEvents()
   nesting--;
 }
 
+void CPowerManager::OnPrepareSleep()
+{
+  CLog::Log(LOGNOTICE, "%s: Preparing sleep", __FUNCTION__);
+
+  //stop all addon services here
+  //we do this here instead in OnSleep cause according to DBUS specification we only have 1 second of time in OnSleep
+  //so shutdowns that may potentially take longer should be issued in here
+  g_application.StopAddonServices();
+}
+
 void CPowerManager::OnSleep()
 {
   CAnnouncementManager::Announce(System, "xbmc", "OnSleep");
@@ -254,6 +274,9 @@ void CPowerManager::OnSleep()
 void CPowerManager::OnWake()
 {
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
+
+  //re-start addon services
+  g_application.StartAddonServices();
 
   // reset out timers
   g_application.ResetShutdownTimers();

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -249,7 +249,7 @@ void CPowerManager::OnPrepareSleep()
   //stop all addon services here
   //we do this here instead in OnSleep cause according to DBUS specification we only have 1 second of time in OnSleep
   //so shutdowns that may potentially take longer should be issued in here
-  g_application.StopAddonServices();
+  g_application.StopServiceAddons();
 }
 
 void CPowerManager::OnSleep()
@@ -276,7 +276,7 @@ void CPowerManager::OnWake()
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
 
   //re-start addon services
-  g_application.StartAddonServices();
+  g_application.StartServiceAddons();
 
   // reset out timers
   g_application.ResetShutdownTimers();

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -88,6 +88,7 @@ public:
   static void SettingOptionsShutdownStatesFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
 
 private:
+  void OnPrepareSleep();
   void OnSleep();
   void OnWake();
 


### PR DESCRIPTION
stop/start all addons before/after suspend

This is needed for correctly deinitializing network shares cause otherwise addon threads might re-init a network share just after it has been deinitialized but before the system is actually going to suspend.
