### PR TITLE
[Linux] os-release: unescape quotes / backslashes

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -643,6 +643,27 @@ CStdString CSysInfo::GetLinuxDistro()
           pretty_name[strlen(pretty_name) - 1] = '\0';
         }
 
+        // unescape quotes and backslashes
+        char *p = pretty_name;
+        while (*p)
+        {
+          char *this_char = p;
+          char *next_char = p + 1;
+
+          if (*this_char == '\\' &&
+              (*next_char == '\'' || *next_char == '\"' || *next_char == '\\'))
+          {
+            while (*this_char)
+            {
+              *this_char = *next_char;
+              this_char++;
+              next_char++;
+            }
+          }
+
+          p++;
+        }
+
         result = pretty_name;
         break;
       }


### PR DESCRIPTION
The os-release specification states that single quotes, double quotes
and backslashes are supposed to be escaped with a backslash. Unfortunately
I missed this in my original commit 7a9aa6f5d9ac8df1c79eb06ed63bce8af162c3ba.

http://www.freedesktop.org/software/systemd/man/os-release.html
