### PR TITLE
[bluray] Fix stream info/language retrieval for blurays in non-nav mode.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -418,6 +418,7 @@ bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content
       CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to select title %d", m_title->idx);
       return false;
     }
+    m_clip = 0;
   }
 
   return true;


### PR DESCRIPTION
@da-anda  @elupus

Now the clip is set once if non-nav mode was selected. I'm not sure what to do if a title has multiple clips.
