### PR TITLE
[rbp/omxplayer] Remove unused state from OMXClock

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1009,7 +1009,7 @@ void COMXPlayer::Process()
   // allow renderer to switch to fullscreen if requested
   m_omxPlayerVideo.EnableFullscreen(m_PlayerOptions.fullscreen);
 
-  if(!m_av_clock.OMXInitialize(&m_clock, false, false))
+  if(!m_av_clock.OMXInitialize(&m_clock))
   {
     m_bAbortRequest = true;
     return;
@@ -1018,8 +1018,6 @@ void COMXPlayer::Process()
     m_av_clock.HDMIClockSync();
   m_av_clock.OMXStateIdle();
   m_av_clock.OMXStop();
-  m_av_clock.HasAudio(m_HasVideo);
-  m_av_clock.HasVideo(m_HasAudio);
   m_av_clock.OMXPause();
 
   OpenDefaultStreams();
@@ -2524,9 +2522,7 @@ void COMXPlayer::HandleMessages()
 
         if ((player == DVDPLAYER_AUDIO || player == DVDPLAYER_VIDEO) && (!m_HasAudio || m_CurrentAudio.started) && (!m_HasVideo || m_CurrentVideo.started))
         {
-          m_av_clock.HasAudio(m_HasAudio);
-          m_av_clock.HasVideo(m_HasVideo);
-          m_av_clock.OMXReset();
+          m_av_clock.OMXReset(m_HasVideo, m_HasAudio);
         }
 
         CLog::Log(LOGDEBUG, "COMXPlayer::HandleMessages - player started %d", player);

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -45,24 +45,14 @@ static inline int64_t FromOMXTime(OMX_TICKS ticks)
 #define ToOMXTime(x) (x)
 #endif
 
-enum {
-  AV_SYNC_AUDIO_MASTER,
-  AV_SYNC_VIDEO_MASTER,
-  AV_SYNC_EXTERNAL_MASTER,
-};
-
 class OMXClock
 {
 protected:
   bool              m_pause;
-  bool              m_has_video;
-  bool              m_has_audio;
-  int               m_play_speed;
   pthread_mutex_t   m_lock;
   double            m_fps;
   int               m_omx_speed;
-  bool              m_video_start;
-  bool              m_audio_start;
+  OMX_TIME_REFCLOCKTYPE m_eClock;
   CDVDClock         *m_clock;
 private:
   COMXCoreComponent m_omx_clock;
@@ -75,14 +65,14 @@ public:
   double GetClock(bool interpolated = true) { return m_clock ? m_clock->GetClock(interpolated):0; }
   double GetClock(double& absolute, bool interpolated = true) { return m_clock ? m_clock->GetClock(absolute, interpolated):0; }
   void Discontinuity(double currentPts = 0LL) { if (m_clock) m_clock->Discontinuity(currentPts); }
-  void OMXSetClockPorts(OMX_TIME_CONFIG_CLOCKSTATETYPE *clock);
-  bool OMXSetReferenceClock(bool lock = true);
-  bool OMXInitialize(CDVDClock *clock, bool has_video, bool has_audio);
+  void OMXSetClockPorts(OMX_TIME_CONFIG_CLOCKSTATETYPE *clock, bool has_video, bool has_audio);
+  bool OMXSetReferenceClock(bool has_audio, bool lock = true);
+  bool OMXInitialize(CDVDClock *clock);
   void OMXDeinitialize();
   bool OMXIsPaused() { return m_pause; };
   bool OMXStop(bool lock = true);
   bool OMXStep(int steps = 1, bool lock = true);
-  bool OMXReset(bool lock = true);
+  bool OMXReset(bool has_video, bool has_audio, bool lock = true);
   double OMXMediaTime(bool lock = true);
   double OMXClockAdjustment(bool lock = true);
   bool OMXMediaTime(double pts, bool lock = true);
@@ -96,10 +86,6 @@ public:
   bool HDMIClockSync(bool lock = true);
   static int64_t CurrentHostCounter(void);
   static int64_t CurrentHostFrequency(void);
-  bool HasVideo() { return m_has_video; };
-  bool HasAudio() { return m_has_audio; };
-  void HasVideo(bool has_video) { m_has_video = has_video; };
-  void HasAudio(bool has_audio) { m_has_audio = has_audio; };
 
   int     GetRefreshRate(double* interval = NULL);
   void    SetRefreshRate(double fps) { m_fps = fps; };


### PR DESCRIPTION
m_has_audio/m_has_video are always set before OMXReset is called, so just make them local parameters.
m_video_start and m_audio_start are unused, so remove them.

This commit should have no functional change
