### PR TITLE
Generate stable DVD disk IDs by performing CSS first

### DIFF
--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -902,7 +902,7 @@ long iso9660::ReadFile(HANDLE hFile, uint8_t *pBuffer, long lSize)
   if ( pContext->m_bUseMode2 )
     sectorSize = MODE2_DATA_SIZE;
 
-  while (lSize > 0 && pContext->m_dwFilePos + sectorSize <= pContext->m_dwFileSize)
+  while (lSize > 0 && pContext->m_dwFilePos < pContext->m_dwFileSize)
   {
     pContext->m_dwCurrentBlock = (DWORD) (pContext->m_dwFilePos / sectorSize);
     int64_t iOffsetInBuffer = pContext->m_dwFilePos - (sectorSize * pContext->m_dwCurrentBlock);

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -902,15 +902,13 @@ long iso9660::ReadFile(HANDLE hFile, uint8_t *pBuffer, long lSize)
   if ( pContext->m_bUseMode2 )
     sectorSize = MODE2_DATA_SIZE;
 
-  while (lSize > 0 && pContext->m_dwFilePos <= pContext->m_dwFileSize)
+  while (lSize > 0 && pContext->m_dwFilePos + sectorSize <= pContext->m_dwFileSize)
   {
     pContext->m_dwCurrentBlock = (DWORD) (pContext->m_dwFilePos / sectorSize);
     int64_t iOffsetInBuffer = pContext->m_dwFilePos - (sectorSize * pContext->m_dwCurrentBlock);
     pContext->m_dwCurrentBlock += pContext->m_dwStartBlock;
 
-    //char szBuf[256];
-    //sprintf(szBuf,"pos:%i cblk:%i sblk:%i off:%i",(long)m_dwFilePos, (long)m_dwCurrentBlock,(long)m_dwStartBlock,(long)iOffsetInBuffer);
-    //DBG(szBuf);
+    // CLog::Log(LOGDEBUG, "pos:%li cblk:%li sblk:%li off:%li",(long)pContext->m_dwFilePos, (long)pContext->m_dwCurrentBlock,(long)pContext->m_dwStartBlock,(long)iOffsetInBuffer);
 
     uint8_t* pSector;
     bError = !ReadSectorFromCache(pContext, pContext->m_dwCurrentBlock, &pSector);


### PR DESCRIPTION
When generating DVD disk unique IDs (to identify individual disks mainly for resume / playerstate purposes), currently two different IDs can be generated:

a) One, when the disc is first inserted in the drive, and playback has never been attempted
b) Another, when the disc has already been played (and left in the drive) and CSS had been performed

This patch forces CSS to be attempted before trying to generate the disk unique ID, ensuring a result that's identical to what we get when the disk has already been played.

Any ideas on how to clean this up are welcome.

See also http://trac.xbmc.org/ticket/14484 and https://github.com/xbmc/xbmc/issues/2936

Also, this is related to https://github.com/xbmc/xbmc/pull/2940 which is needed to get a disk unique ID at all in szenarios which return uppercase filenames from iso9660.
