### PR TITLE
Fix DVD resume: Get and use correct (removable://) file record from database

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3921,7 +3921,11 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
     CVideoDatabase dbs;
     if (dbs.Open())
     {
-      dbs.LoadVideoInfo(item.GetPath(), *m_currentFile->GetVideoInfoTag());
+      CStdString path = item.GetPath();
+      CStdString videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
+      if (videoInfoTagPath.Find("removable://") == 0)
+        path = videoInfoTagPath;
+      dbs.LoadVideoInfo(path, *m_currentFile->GetVideoInfoTag());
       dbs.Close();
     }
   }

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -120,7 +120,11 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
       CVideoDatabase videodatabase;
       if (videodatabase.Open())
       {
-        if (videodatabase.LoadVideoInfo(item->GetPath(), *item->GetVideoInfoTag()))
+        CStdString path = item->GetPath();
+        CStdString videoInfoTagPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
+        if (videoInfoTagPath.Find("removable://") == 0)
+          path = videoInfoTagPath;
+        if (videodatabase.LoadVideoInfo(path, *item->GetVideoInfoTag()))
           id = item->GetVideoInfoTag()->m_iDbId;
 
         videodatabase.Close();


### PR DESCRIPTION
Currently, DVD resume only works once - i.e., when first stopping DVD playback a resume record is created, which is used when playing this DVD again.

(But: See also https://github.com/xbmc/xbmc/pull/2940 and https://github.com/xbmc/xbmc/pull/2951)

Updating this existing resume / playerstate record does **not** work.

I traced this to `CVideoDatabase::GetFileInfo()`, where the `removable://DVD_<diskId>` path in `CVideoInfoTag.m_strFileNameAndPath` is overwritten with information obtained from the 'wrong' place in the VideoDB; namely the record for `iso9660://VIDEO_TS/VIDEO_TS.IFO` is used (which cannot discern between different disks).
The overwritten name `iso9660://VIDEO_TS/VIDEO_TS.IFO` is then later used to find the resume record to be updated, which cannot work since this record is not disk-specific and will not be used/read by `CApplication::PlayFile()` / `CVideoDatabase::GetResumeBookMark()`.

In the attached patch, I've changed `GetFileInfo()` to return the DB record for the `removable://DVD_<diskId>` path; in the same manner that is used in a number of other places as well; e.g. in `CSaveFileStateJob::DoWork()` and `CApplication::PlayFile()` where access to a disk-specific record is intended.

With this patch (including the prerequisites mentioned above), successively updating the DVD resume / playerState record works fine here.
