### PR TITLE
Unpause (if applicable) when going to DVD menu

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3520,6 +3520,11 @@ bool CDVDPlayer::OnAction(const CAction &action)
         THREAD_ACTION(action);
         CLog::Log(LOGDEBUG, " - go to menu");
         pMenus->OnMenu();
+        if (m_playSpeed == DVD_PLAYSPEED_PAUSE)
+        {
+          SetPlaySpeed(DVD_PLAYSPEED_NORMAL);
+          m_callback.OnPlayBackResumed();
+        }
         // send a message to everyone that we've gone to the menu
         CGUIMessage msg(GUI_MSG_VIDEO_MENU_STARTED, 0, 0);
         g_windowManager.SendThreadMessage(msg);


### PR DESCRIPTION
Currently, pushing "Menu" while DVD playback is paused has no immediate visible effect.
But, the "Menu" action is queued and executed when playback is resumed (e.g. by pressing "Pause" again).

This is different to what people are used to from hardware players - pressing "Menu" should immediately go to the menu.

This patch causes "unpause" to be effected when the menu is entered in paused playback, I've tried it with a few discs and it works as expected here.
