### PR TITLE
[rtbp/omxplayer] Support ff/rew

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -226,7 +226,7 @@ bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket)
   const uint8_t *data_dec = pkt->pData;
   int            data_len = pkt->iSize;
 
-  if(!OMX_IS_RAW(m_format.m_dataFormat))
+  if(!OMX_IS_RAW(m_format.m_dataFormat) && !bDropPacket)
   {
     while(!m_bStop && data_len > 0)
     {
@@ -283,15 +283,12 @@ bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket)
           }
         }
 
-        int n = (m_nChannels * m_hints.bitspersample * m_hints.samplerate)>>3;
-        if (n > 0)
-          m_audioClock += ((double)decoded_size * DVD_TIME_BASE) / n;
         break;
 
       }
     }
   }
-  else
+  else if(!bDropPacket)
   {
     if(CodecChange())
     {

--- a/xbmc/linux/OMXClock.h
+++ b/xbmc/linux/OMXClock.h
@@ -52,6 +52,8 @@ protected:
   pthread_mutex_t   m_lock;
   double            m_fps;
   int               m_omx_speed;
+  OMX_U32           m_WaitMask;
+  OMX_TIME_CLOCKSTATE   m_eState;
   OMX_TIME_REFCLOCKTYPE m_eClock;
   CDVDClock         *m_clock;
 private:


### PR DESCRIPTION
Big missing feature added for Pi.
It works by increasing the clock and discarding audio when at 2x and 4x.
For rewind and 8x and higher, it uses a different scheme. It pauses video, and single steps.

For both schemes it uses the normal dvd player mechanism of seeking when the clock has diverged by too much.

Notes:
dvdplayer still decodes (then discards) audio when ff/rew.
I'm skipping the decode step (too much cpu at 4x realtime).

I've made GetTime return m_clock.GetClock() when ff/rew. (m_State.time is too jumpy).
