### PR TITLE
Support for samba 4

### DIFF
--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -1,4 +1,3 @@
-
 /*
  *      Copyright (C) 2005-2013 Team XBMC
  *      http://www.xbmc.org
@@ -43,7 +42,7 @@
 #include "threads/SingleLock.h"
 #include "PasswordManager.h"
 
-#include <libsmbclient.h>
+#include <samba-4.0/libsmbclient.h>
 
 #if defined(TARGET_DARWIN)
 #define XBMC_SMB_MOUNT_PATH "Library/Application Support/XBMC/Mounts/"

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -27,7 +27,7 @@
 #include "PasswordManager.h"
 #include "SMBDirectory.h"
 #include "Util.h"
-#include <libsmbclient.h>
+#include <samba-4.0/libsmbclient.h>
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"


### PR DESCRIPTION
When I was compiling gotham alpha 5 version on Fedora 19 I realized that I realized that it comes with samba 4. 
I need to change include directive to make it work.
