### PR TITLE
[WIN32] fixed: support for long paths broke file access on UNC shares

### DIFF
--- a/xbmc/filesystem/HDFile.cpp
+++ b/xbmc/filesystem/HDFile.cpp
@@ -37,6 +37,9 @@
 #include "utils/URIUtils.h"
 #endif
 #include "utils/log.h"
+#ifdef TARGET_WINDOWS
+#include "win32/WIN32Util.h"
+#endif
 
 #include <algorithm>
 
@@ -78,8 +81,7 @@ CStdString CHDFile::GetLocal(const CURL &url)
   }
 
 #ifdef TARGET_WINDOWS
-  path.Insert(0, "\\\\?\\");
-  path.Replace('/', '\\');
+  path = CWIN32Util::NormalToExtendedLengthPath(path);
 #endif
 
   if (IsAliasShortcut(path))
@@ -160,7 +162,7 @@ int CHDFile::Stat(const CURL& url, struct __stat64* buffer)
 #ifdef TARGET_WINDOWS
   CStdStringW strWFile;
   /* _wstat64 can't handle long paths therefore we remove the \\?\ */
-  strFile.Replace("\\\\?\\", "");
+  strFile = CWIN32Util::ExtendedToNormalLengthPath(strFile);
   // win32 can only stat root drives with a slash at the end
   if(strFile.length() == 2 && strFile[1] ==':')
     URIUtils::AddSlashAtEnd(strFile);

--- a/xbmc/filesystem/windows/WINFileSMB.cpp
+++ b/xbmc/filesystem/windows/WINFileSMB.cpp
@@ -28,6 +28,7 @@
 #include "utils/CharsetConverter.h"
 #include "utils/URIUtils.h"
 #include "WINSMBDirectory.h"
+#include "win32/WIN32Util.h"
 
 using namespace XFILE;
 
@@ -147,7 +148,7 @@ int CWINFileSMB::Stat(const CURL& url, struct __stat64* buffer)
 {
   CStdString strFile = GetLocal(url);
   /* _wstat64 can't handle long paths therefore we remove the \\?\UNC\ */
-  strFile.Replace("\\\\?\\UNC\\", "\\\\");
+  strFile = CWIN32Util::ExtendedToNormalLengthPath(strFile);
   /* _wstat64 calls FindFirstFileEx. According to MSDN, the path should not end in a trailing backslash.
     Remove it before calling _wstat64 */
   if (strFile.length() > 3 && URIUtils::HasSlashAtEnd(strFile))

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -492,6 +492,31 @@ CStdString CWIN32Util::SmbToUnc(const CStdString &strPath)
   return strRetPath;
 }
 
+CStdString CWIN32Util::NormalToExtendedLengthPath(const CStdString &strPath)
+{
+  CStdString strRetPath(strPath);
+  // support local and UNC paths with more than MAX_PATH characters by
+  // adding the correct \\?\ prefix
+  strRetPath.Replace("/", "\\");
+  if(strRetPath.Left(2).Equals("\\\\"))
+  {
+    strRetPath.Insert(2, "?\\UNC\\");
+  }
+  else
+  {
+    strRetPath.Insert(0, "\\\\?\\");
+  }
+  return strRetPath;
+}
+
+CStdString CWIN32Util::ExtendedToNormalLengthPath(const CStdString &strPath)
+{
+  CStdString strRetPath(strPath);
+  strRetPath.Replace("\\\\?\\", "");
+  strRetPath.Replace("UNC\\", "\\\\");
+  return strRetPath;
+}
+
 void CWIN32Util::ExtendDllPath()
 {
   CStdString strEnv;

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -57,6 +57,8 @@ public:
   static CStdString GetSpecialFolder(int csidl);
   static CStdString GetSystemPath();
   static CStdString GetProfilePath();
+  static CStdString NormalToExtendedLengthPath(const CStdString &strPath);
+  static CStdString ExtendedToNormalLengthPath(const CStdString &strPath);
   static CStdString UncToSmb(const CStdString &strPath);
   static CStdString SmbToUnc(const CStdString &strPath);
   static void ExtendDllPath();


### PR DESCRIPTION
Gotham users reported some problems with network share access using the MediaPortal pvr addon with as result broken Live TV. After some testing I saw that the recent addition of @wsoltys to support local paths with more than MAX_PATH characters broke the access to \server\share\ paths. 

The correct extended length name for UNC paths is \?\UNC\server\share and not \?\server\share
(see also http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx)

This pull requests corrects the changes from commit faaf4ef9d70f8540062be47bd7a5cd96f09dba1d
for UNC shares.
