### PR TITLE
Built in function PlayMedia does not play music folders

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -618,16 +618,35 @@ int CBuiltins::Execute(const CStdString& execString)
     if (item.m_bIsFolder)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(),items,g_advancedSettings.m_videoExtensions);
-      int playlist = PLAYLIST_MUSIC;
+      CStdString extensions = g_advancedSettings.m_videoExtensions + "|" + g_advancedSettings.m_musicExtensions;
+      CDirectory::GetDirectory(item.GetPath(),items,extensions);
+
+      bool containsMusic = false, containsVideo = false;
       for (int i = 0; i < items.Size(); i++)
       {
-        if (items[i]->IsVideo())
-        {
-          playlist = PLAYLIST_VIDEO;
+        bool isVideo = items[i]->IsVideo();
+        containsMusic |= !isVideo;
+        containsVideo |= isVideo;
+        
+        if (containsMusic && containsVideo)
           break;
-        }
+      } //for
+		
+      int playlist;
+      if (containsMusic && containsVideo) //mixed content found in the folder
+      {
+        playlist = PLAYLIST_VIDEO;
+        for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
+        {
+          if (!items[i]->IsVideo())
+            items.Remove(i);
+        } //for
       }
+      else
+      {
+        playlist = (containsMusic? PLAYLIST_MUSIC : PLAYLIST_VIDEO);
+      } //if-else
+
       g_playlistPlayer.ClearPlaylist(playlist);
       g_playlistPlayer.Add(playlist, items);
       g_playlistPlayer.SetCurrentPlaylist(playlist);

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -620,7 +620,7 @@ int CBuiltins::Execute(const CStdString& execString)
       CFileItemList items;
       CStdString extensions = g_advancedSettings.m_videoExtensions + "|" + g_advancedSettings.m_musicExtensions;
       CDirectory::GetDirectory(item.GetPath(),items,extensions);
-
+      
       bool containsMusic = false, containsVideo = false;
       for (int i = 0; i < items.Size(); i++)
       {
@@ -630,23 +630,18 @@ int CBuiltins::Execute(const CStdString& execString)
         
         if (containsMusic && containsVideo)
           break;
-      } //for
-		
-      int playlist;
+      }
+      
+      int playlist = containsVideo? PLAYLIST_VIDEO : PLAYLIST_MUSIC;;
       if (containsMusic && containsVideo) //mixed content found in the folder
       {
-        playlist = PLAYLIST_VIDEO;
         for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
         {
           if (!items[i]->IsVideo())
             items.Remove(i);
-        } //for
+        }
       }
-      else
-      {
-        playlist = (containsMusic? PLAYLIST_MUSIC : PLAYLIST_VIDEO);
-      } //if-else
-
+      
       g_playlistPlayer.ClearPlaylist(playlist);
       g_playlistPlayer.Add(playlist, items);
       g_playlistPlayer.SetCurrentPlaylist(playlist);


### PR DESCRIPTION
Following specification, PlayMedia should be able of playing content of
folders, either with content of video or music.

An issue has been found by which passing a music folder to this
function won't play its content. However, if the folder contains video
files it works.

This function internally enumerates files by extension, and when a
folder is received, only video extensions are searched. This commit add
music extensions too to the search, solving the issue.
