### PR TITLE
Uniquedvdid use libdvdnav

### DIFF
--- a/lib/libdvd/libdvdnav/src/vm/vm.c
+++ b/lib/libdvd/libdvdnav/src/vm/vm.c
@@ -176,7 +176,6 @@ static void dvd_read_name(char *name, char *serial, const char *device) {
       off = lseek( fd, 32 * (off_t) DVD_VIDEO_LB_LEN, SEEK_SET );
       if( off == ( 32 * (off_t) DVD_VIDEO_LB_LEN ) ) {
         off = read( fd, data, DVD_VIDEO_LB_LEN );
-        close(fd);
         if (off == ( (off_t) DVD_VIDEO_LB_LEN )) {
           fprintf(MSG_OUT, "libdvdnav: DVD Title: ");
           for(i=25; i < 73; i++ ) {

--- a/lib/libdvd/libdvdnav/src/vm/vm.c
+++ b/lib/libdvd/libdvdnav/src/vm/vm.c
@@ -399,14 +399,13 @@ int vm_reset(vm_t *vm, const char *dvdroot) {
       /* return 0; Not really used for now.. */
     }
     /* ifoRead_TXTDT_MGI(vmgi); Not implemented yet */
+    dvd_read_name(vm->dvd_name, vm->dvd_serial, dvdroot);
 #ifdef _XBMC
     if(DVDUDFVolumeInfo(vm->dvd, vm->dvd_name, sizeof(vm->dvd_name), NULL, 0))
       if(DVDISOVolumeInfo(vm->dvd, vm->dvd_name, sizeof(vm->dvd_name), NULL, 0))
         strcpy(vm->dvd_name, "");
 
     fprintf(MSG_OUT, "libdvdnav: vm: DVD Title: %s\n", vm->dvd_name);
-#else
-    dvd_read_name(vm->dvd_name, vm->dvd_serial, dvdroot);
 #endif
     vm->map  = remap_loadmap(vm->dvd_name);
   }

--- a/lib/libdvd/patches/libdvdnav_reenable_serialstring.diff
+++ b/lib/libdvd/patches/libdvdnav_reenable_serialstring.diff
@@ -1,0 +1,28 @@
+diff --git a/libdvdnav/src/vm/vm.c b/libdvdnav/src/vm/vm.c
+index aea50f3..a14e675 100644
+--- a/libdvdnav/src/vm/vm.c
++++ b/libdvdnav/src/vm/vm.c
+@@ -176,7 +176,6 @@ static void dvd_read_name(char *name, char *serial, const char *device) {
+       off = lseek( fd, 32 * (off_t) DVD_VIDEO_LB_LEN, SEEK_SET );
+       if( off == ( 32 * (off_t) DVD_VIDEO_LB_LEN ) ) {
+         off = read( fd, data, DVD_VIDEO_LB_LEN );
+-        close(fd);
+         if (off == ( (off_t) DVD_VIDEO_LB_LEN )) {
+           fprintf(MSG_OUT, "libdvdnav: DVD Title: ");
+           for(i=25; i < 73; i++ ) {
+@@ -399,14 +398,13 @@ int vm_reset(vm_t *vm, const char *dvdroot) {
+       /* return 0; Not really used for now.. */
+     }
+     /* ifoRead_TXTDT_MGI(vmgi); Not implemented yet */
++    dvd_read_name(vm->dvd_name, vm->dvd_serial, dvdroot);
+ #ifdef _XBMC
+     if(DVDUDFVolumeInfo(vm->dvd, vm->dvd_name, sizeof(vm->dvd_name), NULL, 0))
+       if(DVDISOVolumeInfo(vm->dvd, vm->dvd_name, sizeof(vm->dvd_name), NULL, 0))
+         strcpy(vm->dvd_name, "");
+ 
+     fprintf(MSG_OUT, "libdvdnav: vm: DVD Title: %s\n", vm->dvd_name);
+-#else
+-    dvd_read_name(vm->dvd_name, vm->dvd_serial, dvdroot);
+ #endif
+     vm->map  = remap_loadmap(vm->dvd_name);
+   }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1412,3 +1412,21 @@ int CDVDInputStreamNavigator::ConvertSubtitleStreamId_ExternalToXBMC(int id)
     return 0;
   }
 }
+
+bool CDVDInputStreamNavigator::GetDVDTitleString(std::string& titleStr)
+{
+  if (!m_dvdnav) return false;
+  const char* str = NULL;
+  m_dll.dvdnav_get_title_string(m_dvdnav, &str);
+  titleStr.assign(str);
+  return true;
+}
+
+bool CDVDInputStreamNavigator::GetDVDSerialString(std::string& serialStr)
+{
+  if (!m_dvdnav) return false;
+  const char* str = NULL;
+  m_dll.dvdnav_get_serial_string(m_dvdnav, &str);
+  serialStr.assign(str);
+  return true;
+}

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -137,6 +137,10 @@ public:
   bool SeekTime(int iTimeInMsec); //seek within current pg(c)
 
   double GetTimeStampCorrection() { return (double)(m_iVobUnitCorrection * 1000) / 90; }
+
+  bool GetDVDTitleString(std::string& titleStr);
+  bool GetDVDSerialString(std::string& serialStr);
+
 protected:
 
   int ProcessBlock(uint8_t* buffer, int* read);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DllDvdNav.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DllDvdNav.h
@@ -108,6 +108,8 @@ public:
   virtual dvdnav_status_t dvdnav_get_angle_info(dvdnav_t *self, int32_t *current_angle,int32_t *number_of_angles)=0;
   virtual dvdnav_status_t dvdnav_mouse_activate(dvdnav_t *self, pci_t *pci, int32_t x, int32_t y)=0;
   virtual dvdnav_status_t dvdnav_mouse_select(dvdnav_t *self, pci_t *pci, int32_t x, int32_t y)=0;
+  virtual dvdnav_status_t dvdnav_get_title_string(dvdnav_t *self, const char **title_str)=0;
+  virtual dvdnav_status_t dvdnav_get_serial_string(dvdnav_t *self, const char **serial_str)=0;
 };
 
 #if (defined USE_STATIC_LIBDVDNAV)
@@ -237,6 +239,10 @@ public:
         { return ::dvdnav_mouse_activate(self, pci, x, y); }
     virtual dvdnav_status_t dvdnav_mouse_select(dvdnav_t *self, pci_t *pci, int32_t x, int32_t y)
         { return ::dvdnav_mouse_select(self, pci, x, y); }
+    virtual dvdnav_status_t dvdnav_get_title_string(dvdnav_t *self, const char **title_str)
+        { return ::dvdnav_get_title_string(self, title_str); }
+    virtual dvdnav_status_t dvdnav_get_serial_string(dvdnav_t *self, const char **serial_str)
+        { return ::dvdnav_get_serial_string(self, serial_str); }
 
     // DLL faking.
     virtual bool ResolveExports() { return true; }
@@ -310,6 +316,8 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
   DEFINE_METHOD3(dvdnav_status_t, dvdnav_get_angle_info, (dvdnav_t *p1, int32_t *p2,int32_t *p3))
   DEFINE_METHOD4(dvdnav_status_t, dvdnav_mouse_activate, (dvdnav_t *p1, pci_t *p2, int32_t p3, int32_t p4))
   DEFINE_METHOD4(dvdnav_status_t, dvdnav_mouse_select, (dvdnav_t *p1, pci_t *p2, int32_t p3, int32_t p4))
+  DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_title_string, (dvdnav_t *p1, const char **p2))
+  DEFINE_METHOD2(dvdnav_status_t, dvdnav_get_serial_string, (dvdnav_t *p1, const char **p2))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(dvdnav_open)
     RESOLVE_METHOD(dvdnav_close)
@@ -371,6 +379,8 @@ class DllDvdNav : public DllDynamic, DllDvdNavInterface
     RESOLVE_METHOD(dvdnav_get_angle_info)
     RESOLVE_METHOD(dvdnav_mouse_activate)
     RESOLVE_METHOD(dvdnav_mouse_select)
+    RESOLVE_METHOD(dvdnav_get_title_string)
+    RESOLVE_METHOD(dvdnav_get_serial_string)
 END_METHOD_RESOLVE()
 };
 

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -52,6 +52,8 @@
 #include "filesystem/Directory.h"
 #include "utils/Crc32.h"
 
+#include "cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h"
+
 #if defined(TARGET_DARWIN)
 #include "osx/DarwinStorageProvider.h"
 #elif defined(TARGET_ANDROID)
@@ -496,52 +498,51 @@ CStdString CMediaManager::GetDiskLabel(const CStdString& devicePath)
 
 CStdString CMediaManager::GetDiskUniqueId(const CStdString& devicePath)
 {
-  CStdString strDevice = devicePath;
+  CStdString mediaPath;
 
-  if (strDevice.IsEmpty()) // if no value passed, use the current default disc path.
-    strDevice = GetDiscPath();    // in case of non-Windows we must obtain the disc path
+  CCdInfo* pInfo = g_mediaManager.GetCdInfo(devicePath);
+  if (pInfo == NULL)
+    return "";
+
+  if (mediaPath.IsEmpty() && pInfo->IsAudio(1))
+    mediaPath = "cdda://local/";
+
+  if (mediaPath.IsEmpty() && (pInfo->IsISOUDF(1) || pInfo->IsISOHFS(1) || pInfo->IsIso9660(1) || pInfo->IsIso9660Interactive(1)))
+    mediaPath = "iso9660://";
+
+  if (mediaPath.IsEmpty())
+    mediaPath = devicePath;
 
 #ifdef TARGET_WINDOWS
-  if (!m_bhasoptical)
-    return "";
-  strDevice = TranslateDevicePath(strDevice);
-  URIUtils::AddSlashAtEnd(strDevice);
-#endif
-
-  CStdString strDrive = g_mediaManager.TranslateDevicePath(strDevice);
-
-#ifndef TARGET_WINDOWS
+  if (mediaPath.IsEmpty() || mediaPath.CompareNoCase("iso9660://") == 0)
   {
-    CSingleLock waitLock(m_muAutoSource);
-    CCdInfo* pInfo = g_mediaManager.GetCdInfo();
-    if ( pInfo  )
-    {
-      if (pInfo->IsISOUDF(1) || pInfo->IsISOHFS(1) || pInfo->IsIso9660(1) || pInfo->IsIso9660Interactive(1))
-        strDrive = "iso9660://";
-      else
-        strDrive = "D:\\";
-    }
-    else
-    {
-      CLog::Log(LOGERROR, "GetDiskUniqueId: Failed getting CD info");
-      return "";
-    }
+    mediaPath = g_mediaManager.TranslateDevicePath("");
+    URIUtils::AddSlashAtEnd(mediaPath);
   }
 #endif
 
-  CStdString pathVideoTS = URIUtils::AddFileToFolder(strDrive, "VIDEO_TS");
-  if(! CDirectory::Exists(pathVideoTS) )
+  // Try finding VIDEO_TS/VIDEO_TS.IFO - this indicates a DVD disc is inserted 
+  CStdString pathVideoTS = URIUtils::AddFileToFolder(mediaPath, "VIDEO_TS"); 
+  if(!CFile::Exists(URIUtils::AddFileToFolder(pathVideoTS, "VIDEO_TS.IFO"))) 
     return ""; // return empty
+
+  // correct the filename if needed 
+  if (pathVideoTS.Left(6).CompareNoCase("dvd://") == 0 || pathVideoTS.Left(10).CompareNoCase("iso9660://") == 0)
+    pathVideoTS = g_mediaManager.TranslateDevicePath(""); 
 
   CLog::Log(LOGDEBUG, "GetDiskUniqueId: Trying to retrieve ID for path %s", pathVideoTS.c_str());
   uint32_t dvdcrc = 0;
   CStdString strID;
 
-  if (HashDVD(pathVideoTS, dvdcrc))
-  {
-    strID.Format("removable://%s_%08x", GetDiskLabel(devicePath), dvdcrc);
-    CLog::Log(LOGDEBUG, "GetDiskUniqueId: Got ID %s for DVD disk", strID.c_str());
-  }
+  CDVDInputStreamNavigator dvdNavigator(NULL);
+  dvdNavigator.Open(pathVideoTS, "");
+  CStdString labelString;
+  dvdNavigator.GetDVDTitleString(labelString);
+  CStdString serialString;
+  dvdNavigator.GetDVDSerialString(serialString);
+
+  strID.Format("removable://%s_%s", labelString.c_str(), serialString.c_str());
+  CLog::Log(LOGDEBUG, "GetDiskUniqueId: Got ID %s for DVD disk", strID.c_str());
 
   return strID;
 }

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -104,7 +104,6 @@ protected:
   CCriticalSection m_muAutoSource, m_CritSecStorageProvider;
 #ifdef HAS_DVD_DRIVE
   std::map<CStdString,CCdInfo*> m_mapCdInfo;
-  bool HashDVD(const CStdString& dvdpath, uint32_t& crc);
 #endif
   bool m_bhasoptical;
   CStdString m_strFirstAvailDrive;


### PR DESCRIPTION
attempt to use the libdvdnav built-in "serial string" as a better solution to calculating a unique dvd id. 
See also #2951
