### PR TITLE
Built in function PlayMedia does not play music folders

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -604,7 +604,9 @@ int CBuiltins::Execute(const CStdString& execString)
     if (item.m_bIsFolder)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(),items,g_settings.m_videoExtensions);
+      CStdString extensions = g_settings.m_videoExtensions + "|" + g_settings.m_musicExtensions;
+      CDirectory::GetDirectory(item.GetPath(),items,extensions);
+
       int playlist = PLAYLIST_MUSIC;
       for (int i = 0; i < items.Size(); i++)
       {


### PR DESCRIPTION
This is a pull request to backport https://github.com/xbmc/xbmc/pull/2965 into Frodo

Following specification, PlayMedia should be able of playing content of
folders, either with content of video or music.

An issue has been found by which passing a music folder to this
function won't play its content. However, if the folder contains video
files it works.

This function internally enumerates files by extension, and when a
folder is received, only video extensions are searched. This commit add
music extensions too to the search, solving the issue.
