### PR TITLE
AESinkAlsa: Make sure to reinit but return false if format might be changing

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -1150,16 +1150,17 @@ bool CAESinkALSA::SoftSuspend()
 bool CAESinkALSA::SoftResume()
 {
     // reinit all the clibber
-    bool ret = true; // all fine
     if(!m_pcm)
     {
       if (!snd_config)
         snd_config_update();
 
-      ret = Initialize(m_initFormat, m_initDevice);
+    // Initialize what we had before again, SoftAE might keep it
+    // but ignore ret value to give the chance to do reopening
+    Initialize(m_initFormat, m_initDevice);
     }
-   //we want that AE loves us again - reinit when initialize failed
-   return ret; // force reinit if false
+   // make sure that OpenInternalSink is done again
+   return false;
 }
 
 void CAESinkALSA::sndLibErrorHandler(const char *file, int line, const char *function, int err, const char *fmt, ...)


### PR DESCRIPTION
If we watch a movie in let's say AC3 and pause the movie for 20 seconds, the sink would be unloaded. If we press stop then, the sink is resumed but might have the wrong format, as we returned true but needed a reinit -> return false always

returning false is not enough when AE thinks, that "keeping the device should be done", then we end up uninitialized if Initialize is not done.
