### PR TITLE
Fix for ignoring Protocol Options in CShoutcastFile::Open.

### DIFF
--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -69,7 +69,7 @@ int64_t CShoutcastFile::GetLength()
 bool CShoutcastFile::Open(const CURL& url)
 {
   CURL url2(url);
-  url2.SetProtocolOptions("noshout=true&Icy-MetaData=1");
+  url2.SetProtocolOptions(url2.GetProtocolOptions()+"&noshout=true&Icy-MetaData=1");
   url2.SetProtocol("http");
 
   bool result=false;


### PR DESCRIPTION
In old version all custom request headers like UserAgent, Referer are just ignored and replaced by "noshout=true&Icy-MetaData=1".
Now all headers will be merged.
