### PR TITLE
smartplaylist: implement sorting of grouped items

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -456,6 +456,7 @@
     <ClCompile Include="..\..\xbmc\epg\EpgSearchFilter.cpp" />
     <ClCompile Include="..\..\xbmc\epg\GUIEPGGridContainer.cpp" />
     <ClCompile Include="..\..\xbmc\FileItem.cpp" />
+    <ClCompile Include="..\..\xbmc\FileItemListModification.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\AddonsDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\AFPDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\AFPFile.cpp" />
@@ -909,6 +910,7 @@
     <ClCompile Include="..\..\xbmc\playlists\PlayListWPL.cpp" />
     <ClCompile Include="..\..\xbmc\playlists\PlayListXML.cpp" />
     <ClCompile Include="..\..\xbmc\playlists\SmartPlayList.cpp" />
+    <ClCompile Include="..\..\xbmc\playlists\SmartPlaylistFileItemListModifier.cpp" />
     <ClCompile Include="..\..\xbmc\powermanagement\DPMSSupport.cpp" />
     <ClCompile Include="..\..\xbmc\powermanagement\PowerManager.cpp" />
     <ClCompile Include="..\..\xbmc\powermanagement\windows\Win32PowerSyscall.cpp" />
@@ -1075,6 +1077,7 @@
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogKeyboardGeneric.h" />
     <ClInclude Include="..\..\xbmc\DbUrl.h" />
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogMediaFilter.h" />
+    <ClInclude Include="..\..\xbmc\FileItemListModification.h" />
     <ClInclude Include="..\..\xbmc\filesystem\HTTPFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\DAVCommon.h" />
     <ClInclude Include="..\..\xbmc\filesystem\DAVFile.h" />
@@ -1098,6 +1101,7 @@
     <ClInclude Include="..\..\xbmc\guilib\GUIKeyboardFactory.h" />
     <ClInclude Include="..\..\xbmc\guilib\iimage.h" />
     <ClInclude Include="..\..\xbmc\guilib\imagefactory.h" />
+    <ClInclude Include="..\..\xbmc\IFileItemListModifier.h" />
     <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchActionHandler.h" />
     <ClInclude Include="..\..\xbmc\input\touch\generic\GenericTouchSwipeDetector.h" />
     <ClInclude Include="..\..\xbmc\input\touch\generic\IGenericTouchGestureDetector.h" />
@@ -1158,6 +1162,7 @@
     <ClInclude Include="..\..\xbmc\network\NetworkServices.h" />
     <ClInclude Include="..\..\xbmc\peripherals\bus\virtual\PeripheralBusCEC.h" />
     <ClInclude Include="..\..\xbmc\network\upnp\UPnPSettings.h" />
+    <ClInclude Include="..\..\xbmc\playlists\SmartPlaylistFileItemListModifier.h" />
     <ClInclude Include="..\..\xbmc\profiles\dialogs\GUIDialogLockSettings.h" />
     <ClInclude Include="..\..\xbmc\profiles\dialogs\GUIDialogProfileSettings.h" />
     <ClInclude Include="..\..\xbmc\profiles\Profile.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3075,6 +3075,10 @@
     <ClCompile Include="..\..\xbmc\utils\ActorProtocol.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\playlists\SmartPlaylistFileItemListModifier.cpp">
+      <Filter>playlists</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\FileItemListModification.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6029,6 +6033,11 @@
     <ClInclude Include="..\..\xbmc\utils\ActorProtocol.h">
       <Filter>utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\IFileItemListModifier.h" />
+    <ClInclude Include="..\..\xbmc\playlists\SmartPlaylistFileItemListModifier.h">
+      <Filter>playlists</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\FileItemListModification.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/FileItemListModification.cpp
+++ b/xbmc/FileItemListModification.cpp
@@ -1,0 +1,64 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FileItemListModification.h"
+
+#include "playlists/SmartPlaylistFileItemListModifier.h"
+
+using namespace std;
+
+CFileItemListModification::CFileItemListModification()
+{
+  m_modifiers.insert(new CSmartPlaylistFileItemListModifier());
+}
+
+CFileItemListModification::~CFileItemListModification()
+{
+  for (set<IFileItemListModifier*>::const_iterator modifier = m_modifiers.begin(); modifier != m_modifiers.end(); ++modifier)
+    delete *modifier;
+
+  m_modifiers.clear();
+}
+
+CFileItemListModification& CFileItemListModification::Get()
+{
+  static CFileItemListModification instance;
+  return instance;
+}
+
+bool CFileItemListModification::CanModify(const CFileItemList &items) const
+{
+  for (set<IFileItemListModifier*>::const_iterator modifier = m_modifiers.begin(); modifier != m_modifiers.end(); ++modifier)
+  {
+    if ((*modifier)->CanModify(items))
+      return true;
+  }
+
+  return false;
+}
+
+bool CFileItemListModification::Modify(CFileItemList &items) const
+{
+  bool result = false;
+  for (set<IFileItemListModifier*>::const_iterator modifier = m_modifiers.begin(); modifier != m_modifiers.end(); ++modifier)
+    result |= (*modifier)->Modify(items);
+
+  return result;
+}

--- a/xbmc/FileItemListModification.h
+++ b/xbmc/FileItemListModification.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <set>
+
+#include "IFileItemListModifier.h"
+
+class CFileItemListModification : public IFileItemListModifier
+{
+public:
+  ~CFileItemListModification();
+
+  static CFileItemListModification& Get();
+
+  virtual bool CanModify(const CFileItemList &items) const;
+  virtual bool Modify(CFileItemList &items) const;
+
+private:
+  CFileItemListModification();
+  CFileItemListModification(const CFileItemListModification&);
+  CFileItemListModification const& operator=(CFileItemListModification const&);
+
+  std::set<IFileItemListModifier*> m_modifiers;
+};

--- a/xbmc/IFileItemListModifier.h
+++ b/xbmc/IFileItemListModifier.h
@@ -1,0 +1,32 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class CFileItemList;
+
+class IFileItemListModifier
+{
+public:
+  IFileItemListModifier() { }
+  virtual ~IFileItemListModifier() { }
+
+  virtual bool CanModify(const CFileItemList &items) const = 0;
+  virtual bool Modify(CFileItemList &items) const = 0;
+};

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -101,6 +101,7 @@ void CGUIViewStateMusicSearch::SaveViewState()
   SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV, CViewStateSettings::Get().Get("musicnavsongs"));
 }
 
+
 CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
   CMusicDatabaseDirectory dir;
@@ -123,140 +124,102 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   CLog::Log(LOGDEBUG,"Album format left  = [%s]", strAlbumLeft.c_str());
   CLog::Log(LOGDEBUG,"Album format right = [%s]", strAlbumRight.c_str());
 
-  SortAttribute sortAttribute = SortAttributeNone;
+  SortDescription sorting;
   if (CSettings::Get().GetBool("filelists.ignorethewhensorting"))
-    sortAttribute = SortAttributeIgnoreArticle;
+    sorting.sortAttributes = SortAttributeIgnoreArticle;
+  LABEL_MASKS labelMask;
+  int view = DEFAULT_VIEW_LIST;
 
   switch (NodeType)
   {
   case NODE_TYPE_OVERVIEW:
-    {
-      AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
-      SetSortMethod(SortByNone);
-
-      SetViewAsControl(DEFAULT_VIEW_LIST);
-
-      SetSortOrder(SortOrderNone);
-    }
+    AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
     break;
   case NODE_TYPE_TOP100:
-    {
-      AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
-      SetSortMethod(SortByNone);
-
-      SetViewAsControl(DEFAULT_VIEW_LIST);
-
-      SetSortOrder(SortOrderNone);
-    }
+    AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
     break;
   case NODE_TYPE_GENRE:
     {
       AddSortMethod(SortByGenre, 515, LABEL_MASKS("%F", "", "%G", ""));  // Filename, empty | Genre, empty
-      SetSortMethod(SortByGenre);
-
-      SetViewAsControl(DEFAULT_VIEW_LIST);
-
-      SetSortOrder(SortOrderAscending);
+      sorting.sortBy = SortByGenre;
+      sorting.sortOrder = SortOrderAscending;
     }
     break;
   case NODE_TYPE_YEAR:
     {
       AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "", "%Y", ""));  // Filename, empty | Year, empty
-      SetSortMethod(SortByLabel);
-
-      SetViewAsControl(DEFAULT_VIEW_LIST);
-
-      SetSortOrder(SortOrderAscending);
+      sorting.sortBy = SortByLabel;
+      sorting.sortOrder = SortOrderAscending;
     }
     break;
   case NODE_TYPE_ARTIST:
     {
-      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", "%A", ""));  // Filename, empty | Artist, empty
-      SetSortMethod(SortByArtist, sortAttribute);
+      sorting.sortBy = SortByArtist;
+      labelMask = LABEL_MASKS("%F", "", "%A", "");
+
+      AddSortMethod(sorting, 557, labelMask);  // Filename, empty | Artist, empty
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavartists");
-      SetViewAsControl(viewState->m_viewMode);
-      SetSortOrder(viewState->m_sortDescription.sortOrder);
+      sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+      view = viewState->m_viewMode;
     }
     break;
   case NODE_TYPE_ALBUM_COMPILATIONS:
   case NODE_TYPE_ALBUM:
   case NODE_TYPE_YEAR_ALBUM:
     {
+      labelMask = LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight);  // Filename, empty | Userdefined, Userdefined
+
       // album
-      AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
+      AddSortMethod(SortByAlbum, sorting.sortAttributes, 558, labelMask);
       // artist
-      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
+      AddSortMethod(SortByArtist, sorting.sortAttributes, 557, labelMask);
       // year
-      AddSortMethod(SortByYear, 562, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
+      AddSortMethod(SortByYear, 562, labelMask);
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavalbums");
-      SetSortMethod(viewState->m_sortDescription);
-      SetViewAsControl(viewState->m_viewMode);
-      SetSortOrder(viewState->m_sortDescription.sortOrder);
+      sorting = viewState->m_sortDescription;
+      view = viewState->m_viewMode;
     }
     break;
   case NODE_TYPE_ALBUM_RECENTLY_ADDED:
     {
       AddSortMethod(SortByNone, 552, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      SetSortMethod(SortByNone);
-
-      SetViewAsControl(CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode);
-
-      SetSortOrder(SortOrderNone);
+      view = CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode;
     }
     break;
   case NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS:
     {
       AddSortMethod(SortByNone, 552, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
-      SetSortMethod(SortByNone);
-
-      SetViewAsControl(CViewStateSettings::Get().Get("musicnavsongs")->m_viewMode);
-
-      SetSortOrder(SortOrderNone);
+      view = CViewStateSettings::Get().Get("musicnavsongs")->m_viewMode;
     }
     break;
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
     {
       AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      SetSortMethod(SortByNone);
-
-      SetViewAsControl(CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode);
-
-      SetSortOrder(SortOrderNone);
+      view = CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode;
     }
     break;
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS:
     {
       AddSortMethod(SortByNone, 551, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
-      SetSortMethod(SortByNone);
-
-      SetViewAsControl(CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode);
-
-      SetSortOrder(SortOrderNone);
+      view = CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode;
     }
     break;
   case NODE_TYPE_ALBUM_TOP100:
-    {
-      AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      SetSortMethod(SortByNone);
-
-      SetViewAsControl(DEFAULT_VIEW_LIST);
-      SetSortOrder(SortOrderNone);
-    }
+    AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
     break;
   case NODE_TYPE_SINGLES:
     {
-      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
-      AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-      AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
+      AddSortMethod(SortByArtist, sorting.sortAttributes, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
+      AddSortMethod(SortByTitle, sorting.sortAttributes, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
       AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
       AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavsongs");
-      SetSortMethod(viewState->m_sortDescription);
-      SetViewAsControl(viewState->m_viewMode);
-      SetSortOrder(viewState->m_sortDescription.sortOrder);
+      sorting = viewState->m_sortDescription;
+      view = viewState->m_viewMode;
     }
     break;
   case NODE_TYPE_ALBUM_COMPILATIONS_SONGS:
@@ -265,41 +228,39 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   case NODE_TYPE_SONG:
     {
       AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
-      AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-      AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
-      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
-      AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
+      AddSortMethod(SortByTitle, sorting.sortAttributes, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByAlbum, sorting.sortAttributes, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByArtist, sorting.sortAttributes, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
+      AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
       AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
       AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
       AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
+      AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Titel - Artist, PlayCount
 
       const CViewState *viewState = CViewStateSettings::Get().Get("musicnavsongs");
       // the "All Albums" entries always default to SortByAlbum as this is most logical - user can always
       // change it and the change will be saved for this particular path
+      sorting.sortBy = viewState->m_sortDescription.sortBy;
       if (dir.IsAllItem(items.GetPath()))
-        SetSortMethod(SortByAlbum, sortAttribute);
-      else
-        SetSortMethod(viewState->m_sortDescription);
-
-      AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Titel - Artist, PlayCount
-
-      SetViewAsControl(viewState->m_viewMode);
-      SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortBy = SortByAlbum;
+      sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+      labelMask = LABEL_MASKS(strTrackLeft, strTrackRight);
+      view = viewState->m_viewMode;
     }
     break;
   case NODE_TYPE_SONG_TOP100:
     {
       AddSortMethod(SortByNone, 576, LABEL_MASKS("%T - %A", "%V"));
-      SetSortMethod(SortByPlaycount);
-
-      SetViewAsControl(CViewStateSettings::Get().Get("musicnavsongs")->m_viewMode);
-
-      SetSortOrder(SortOrderNone);
+      sorting.sortBy = SortByPlaycount;
+      view = CViewStateSettings::Get().Get("musicnavsongs")->m_viewMode;
     }
     break;
   default:
     break;
   }
+
+  AddPlaylistOrder(items, labelMask, sorting);
+  SetViewAsControl(view);
 
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
@@ -343,9 +304,11 @@ void CGUIViewStateMusicDatabase::SaveViewState()
 
 CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
-  SortAttribute sortAttribute = SortAttributeNone;
+  SortDescription sorting;
   if (CSettings::Get().GetBool("filelists.ignorethewhensorting"))
-    sortAttribute = SortAttributeIgnoreArticle;
+    sorting.sortAttributes = SortAttributeIgnoreArticle;
+  LABEL_MASKS labelMask;
+  int view = DEFAULT_VIEW_LIST;
 
   if (items.GetContent() == "songs" || items.GetContent() == "mixed") 
   {
@@ -353,15 +316,15 @@ CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItem
     CStdString strTrackRight=CSettings::Get().GetString("musicfiles.trackformatright");
 
     AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
-    AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-    AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
-    AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
-    AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
+    AddSortMethod(SortByTitle, sorting.sortAttributes, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+    AddSortMethod(SortByAlbum, sorting.sortAttributes, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
+    AddSortMethod(SortByArtist, sorting.sortAttributes, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
+    AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
     AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
     AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Titel, Artist, Rating| empty, empty
-    AddPlaylistOrder(items, LABEL_MASKS(strTrackLeft, strTrackRight));
-
-    SetViewAsControl(CViewStateSettings::Get().Get("musicnavsongs")->m_viewMode);
+    
+    labelMask = LABEL_MASKS(strTrackLeft, strTrackRight);
+    view = CViewStateSettings::Get().Get("musicnavsongs")->m_viewMode;
   } 
   else if (items.GetContent() == "albums") 
   {
@@ -373,20 +336,28 @@ CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItem
       strAlbumRight = "%A"; // artist
 
     // album
-    AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
+    AddSortMethod(SortByAlbum, sorting.sortAttributes, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
     // artist
-    AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
+    AddSortMethod(SortByArtist, sorting.sortAttributes, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
     // year
     AddSortMethod(SortByYear, 562, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
 
-    AddPlaylistOrder(items, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
-
-    SetViewAsControl(CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode);
-  } 
-  else 
-  {
-    CLog::Log(LOGERROR,"Music Smart Playlist must be one of songs, mixed or albums");
+    labelMask = LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight);
+    view = CViewStateSettings::Get().Get("musicnavalbums")->m_viewMode;
   }
+  else if (items.GetContent() == "artists")
+  {
+    sorting.sortBy = SortByArtist;
+    labelMask = LABEL_MASKS("%F", "", "%A", "");
+    view = CViewStateSettings::Get().Get("musicnavartists")->m_viewMode;
+
+    AddSortMethod(sorting.sortBy, sorting.sortAttributes, 557, labelMask);  // Filename, empty | Artist, empty
+  }
+  else
+    CLog::Log(LOGERROR,"Music Smart Playlist must be one of songs, mixed, albums or artists");
+
+  AddPlaylistOrder(items, labelMask, sorting);
+  SetViewAsControl(view);
   
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
@@ -395,6 +366,7 @@ void CGUIViewStateMusicSmartPlaylist::SaveViewState()
 {
   SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV, CViewStateSettings::Get().Get("musicnavsongs"));
 }
+
 
 CGUIViewStateMusicPlaylist::CGUIViewStateMusicPlaylist(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
@@ -429,19 +401,12 @@ void CGUIViewStateMusicPlaylist::SaveViewState()
 
 CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
-  SortAttribute sortAttribute = SortAttributeNone;
+  SortDescription sorting;
   if (CSettings::Get().GetBool("filelists.ignorethewhensorting"))
-    sortAttribute = SortAttributeIgnoreArticle;
+    sorting.sortAttributes = SortAttributeIgnoreArticle;
 
   if (items.IsVirtualDirectoryRoot())
-  {
     AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Foldername, empty
-    SetSortMethod(SortByNone);
-
-    SetViewAsControl(DEFAULT_VIEW_LIST);
-
-    SetSortOrder(SortOrderNone);
-  }
   else
   {
     if (items.IsVideoDb() && items.Size() > (CSettings::Get().GetBool("filelists.showparentdiritems")?1:0))
@@ -450,10 +415,10 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
       XFILE::CVideoDatabaseDirectory::GetQueryParams(items[CSettings::Get().GetBool("filelists.showparentdiritems")?1:0]->GetPath(),params);
       if (params.GetMVideoId() != -1)
       {
-        AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS("%T", "%Y"));  // Filename, Duration | Foldername, empty
+        AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS("%T", "%Y"));  // Filename, Duration | Foldername, empty
         AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));
-        AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%Y"));
-        AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T", "%Y"));
+        AddSortMethod(SortByArtist, sorting.sortAttributes, 557, LABEL_MASKS("%A - %T", "%Y"));
+        AddSortMethod(SortByAlbum, sorting.sortAttributes, 558, LABEL_MASKS("%B - %T", "%Y"));
         
         CStdString strTrackLeft=CSettings::Get().GetString("musicfiles.trackformat");
         CStdString strTrackRight=CSettings::Get().GetString("musicfiles.trackformatright");
@@ -462,18 +427,20 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
       else
       {
         AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-        SetSortMethod(SortByLabel);
+        sorting.sortBy = SortByLabel;
       }
     }
     else
     {
       AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-      SetSortMethod(SortByLabel);
+      sorting.sortBy = SortByLabel;
     }
-    SetViewAsControl(DEFAULT_VIEW_LIST);
-
-    SetSortOrder(SortOrderAscending);
+    sorting.sortOrder = SortOrderAscending;
   }
+
+  AddPlaylistOrder(items, LABEL_MASKS(), sorting);
+  SetViewAsControl(DEFAULT_VIEW_LIST);
+
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
@@ -545,22 +512,29 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
   return CGUIViewStateWindowMusic::GetSources();
 }
 
+
 CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
+  SortDescription sorting;
+  if (CSettings::Get().GetBool("filelists.ignorethewhensorting"))
+    sorting.sortAttributes = SortAttributeIgnoreArticle;
+  LABEL_MASKS labelMask;
+  int view = VIEW_TYPE_NONE;
+
   if (items.IsVirtualDirectoryRoot())
   {
     AddSortMethod(SortByLabel, 551, LABEL_MASKS()); // Preformated
     AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformated
-    SetSortMethod(SortByLabel);
 
-    SetViewAsControl(DEFAULT_VIEW_LIST);
-
-    SetSortOrder(SortOrderAscending);
+    sorting.sortBy = SortByLabel;
+    sorting.sortOrder = SortOrderAscending;
+    view = DEFAULT_VIEW_LIST;
   }
   else if (items.GetPath() == "special://musicplaylists/")
   { // playlists list sorts by label only, ignoring folders
     AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-    SetSortMethod(SortByLabel, SortAttributeIgnoreFolders);
+    sorting.sortBy = SortByLabel;
+    sorting.sortAttributes = SortAttributeIgnoreFolders;
   }
   else
   {
@@ -576,10 +550,15 @@ CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList
     AddSortMethod(SortByListeners, 20455,LABEL_MASKS(strTrackLeft, "%W", "%L", "%W"));
     
     const CViewState *viewState = CViewStateSettings::Get().Get("musicfiles");
-    SetSortMethod(viewState->m_sortDescription);
-    SetViewAsControl(viewState->m_viewMode);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
+    sorting.sortBy = viewState->m_sortDescription.sortBy;
+    sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+    view = viewState->m_viewMode;
   }
+
+  AddPlaylistOrder(items, LABEL_MASKS(), sorting);
+  if (view != VIEW_TYPE_NONE)
+    SetViewAsControl(view);
+
   LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
 }
 
@@ -594,6 +573,7 @@ VECSOURCES& CGUIViewStateWindowMusicSongs::GetSources()
   AddOrReplace(*musicSources, CGUIViewStateWindowMusic::GetSources());
   return *musicSources;
 }
+
 
 CGUIViewStateWindowMusicPlaylist::CGUIViewStateWindowMusicPlaylist(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -259,7 +259,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   }
 
-  AddPlaylistOrder(items, labelMask, sorting);
+  AddAndSetSortMethod(items, labelMask, sorting);
   SetViewAsControl(view);
 
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
@@ -356,7 +356,7 @@ CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItem
   else
     CLog::Log(LOGERROR,"Music Smart Playlist must be one of songs, mixed, albums or artists");
 
-  AddPlaylistOrder(items, labelMask, sorting);
+  AddAndSetSortMethod(items, labelMask, sorting);
   SetViewAsControl(view);
   
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
@@ -438,7 +438,7 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
     sorting.sortOrder = SortOrderAscending;
   }
 
-  AddPlaylistOrder(items, LABEL_MASKS(), sorting);
+  AddAndSetSortMethod(items, LABEL_MASKS(), sorting);
   SetViewAsControl(DEFAULT_VIEW_LIST);
 
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
@@ -555,7 +555,7 @@ CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList
     view = viewState->m_viewMode;
   }
 
-  AddPlaylistOrder(items, LABEL_MASKS(), sorting);
+  AddAndSetSortMethod(items, LABEL_MASKS(), sorting);
   if (view != VIEW_TYPE_NONE)
     SetViewAsControl(view);
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1140,10 +1140,6 @@ bool CGUIWindowMusicBase::GetDirectory(const CStdString &strDirectory, CFileItem
   return bResult;
 }
 
-void CGUIWindowMusicBase::OnPrepareFileItems(CFileItemList &items)
-{
-}
-
 bool CGUIWindowMusicBase::CheckFilterAdvanced(CFileItemList &items) const
 {
   CStdString content = items.GetContent();

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -68,7 +68,6 @@ protected:
   void AddItemToPlayList(const CFileItemPtr &pItem, CFileItemList &queuedItems);
   virtual void OnScan(int iItem) {};
   void OnRipCD();
-  virtual void OnPrepareFileItems(CFileItemList &items);
   virtual CStdString GetStartFolder(const CStdString &dir);
 
   virtual bool CheckFilterAdvanced(CFileItemList &items) const;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -797,11 +797,6 @@ void CGUIWindowMusicNav::FrameMove()
   CGUIWindowMusicBase::FrameMove();
 }
 
-void CGUIWindowMusicNav::OnPrepareFileItems(CFileItemList &items)
-{
-  CGUIWindowMusicBase::OnPrepareFileItems(items);
-}
-
 void CGUIWindowMusicNav::AddSearchFolder()
 {
   // we use a general viewstate (and not our member) here as our

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -36,7 +36,6 @@ public:
   virtual bool OnAction(const CAction& action);
   virtual void FrameMove();
 
-  virtual void OnPrepareFileItems(CFileItemList &items);
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
   // override base class methods

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -167,6 +167,8 @@ bool CGUIWindowMusicPlaylistEditor::GetDirectory(const CStdString &strDirectory,
 
 void CGUIWindowMusicPlaylistEditor::OnPrepareFileItems(CFileItemList &items)
 {
+  CGUIWindowMusicBase::OnPrepareFileItems(items);
+
   RetrieveMusicInfo();
 }
 

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -209,6 +209,8 @@ bool CGUIWindowMusicSongs::GetDirectory(const CStdString &strDirectory, CFileIte
 
 void CGUIWindowMusicSongs::OnPrepareFileItems(CFileItemList &items)
 {
+  CGUIWindowMusicBase::OnPrepareFileItems(items);
+
   RetrieveMusicInfo();
 }
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -212,6 +212,8 @@ void CGUIWindowPictures::UpdateButtons()
 
 void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
 {
+  CGUIMediaWindow::OnPrepareFileItems(items);
+
   for (int i=0;i<items.Size();++i )
     if (items[i]->GetLabel().Equals("folder.jpg"))
       items.Remove(i);

--- a/xbmc/playlists/SmartPlaylistFileItemListModifier.cpp
+++ b/xbmc/playlists/SmartPlaylistFileItemListModifier.cpp
@@ -1,0 +1,66 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+
+#include "SmartPlaylistFileItemListModifier.h"
+#include "FileItem.h"
+#include "URL.h"
+#include "playlists/SmartPlayList.h"
+#include "utils/StringUtils.h"
+
+#define URL_OPTION_XSP              "xsp"
+#define PROPERTY_SORT_ORDER         "sort.order"
+#define PROPERTY_SORT_ASCENDING     "sort.ascending"
+using namespace std;
+
+bool CSmartPlaylistFileItemListModifier::CanModify(const CFileItemList &items) const
+{
+  return !GetUrlOption(items.GetPath(), URL_OPTION_XSP).empty();
+}
+
+bool CSmartPlaylistFileItemListModifier::Modify(CFileItemList &items) const
+{
+  if (items.HasProperty(PROPERTY_SORT_ORDER))
+    return false;
+
+  std::string xspOption = GetUrlOption(items.GetPath(), URL_OPTION_XSP);
+  if (xspOption.empty())
+    return false;
+
+  // check for smartplaylist-specific sorting information
+  CSmartPlaylist xsp;
+  if (!xsp.LoadFromJson(xspOption))
+    return false;
+
+  items.SetProperty(PROPERTY_SORT_ORDER, (int)xsp.GetOrder());
+  items.SetProperty(PROPERTY_SORT_ASCENDING, xsp.GetOrderDirection() == SortOrderAscending);
+
+  return true;
+}
+
+std::string CSmartPlaylistFileItemListModifier::GetUrlOption(const std::string &path, const std::string &option)
+{
+  if (path.empty() || option.empty())
+    return StringUtils::Empty;
+
+  CURL url(path);
+  return url.GetOption(option);
+}

--- a/xbmc/playlists/SmartPlaylistFileItemListModifier.h
+++ b/xbmc/playlists/SmartPlaylistFileItemListModifier.h
@@ -1,0 +1,37 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "IFileItemListModifier.h"
+
+class CSmartPlaylistFileItemListModifier : public IFileItemListModifier
+{
+public:
+  CSmartPlaylistFileItemListModifier() { }
+  virtual ~CSmartPlaylistFileItemListModifier() { }
+
+  virtual bool CanModify(const CFileItemList &items) const;
+  virtual bool Modify(CFileItemList &items) const;
+
+private:
+  static std::string GetUrlOption(const std::string &path, const std::string &option);
+};

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -58,17 +58,19 @@ VECSOURCES& CGUIViewStateWindowVideo::GetSources()
   return CGUIViewState::GetSources();
 }
 
+
 CGUIViewStateWindowVideoFiles::CGUIViewStateWindowVideoFiles(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
+  SortDescription sorting;
+  int view = DEFAULT_VIEW_AUTO;
+
   if (items.IsVirtualDirectoryRoot())
   {
     AddSortMethod(SortByLabel, 551, LABEL_MASKS()); // Preformated
-    AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformated
-    SetSortMethod(SortByLabel);
+    AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformatedn
 
-    SetViewAsControl(DEFAULT_VIEW_LIST);
-
-    SetSortOrder(SortOrderAscending);
+    sorting.sortBy = SortByLabel;
+    view = DEFAULT_VIEW_LIST;
   }
   else
   {
@@ -79,10 +81,13 @@ CGUIViewStateWindowVideoFiles::CGUIViewStateWindowVideoFiles(const CFileItemList
     AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
 
     const CViewState *viewState = CViewStateSettings::Get().Get("videofiles");
-    SetSortMethod(viewState->m_sortDescription);
-    SetViewAsControl(viewState->m_viewMode);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
+    sorting = viewState->m_sortDescription;
+    view = viewState->m_viewMode;
   }
+
+  AddPlaylistOrder(items, LABEL_MASKS(), sorting);
+  SetViewAsControl(view);
+
   LoadViewState(items.GetPath(), WINDOW_VIDEO_FILES);
 }
 
@@ -98,20 +103,19 @@ VECSOURCES& CGUIViewStateWindowVideoFiles::GetSources()
   return *videoSources;
 }
 
+
 CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
-  SortAttribute sortAttributes = SortAttributeNone;
+  SortDescription sorting;
   if (CSettings::Get().GetBool("filelists.ignorethewhensorting"))
-    sortAttributes = SortAttributeIgnoreArticle;
+    sorting.sortAttributes = SortAttributeIgnoreArticle;
+  LABEL_MASKS labelMask;
+  int view = DEFAULT_VIEW_AUTO;
 
   if (items.IsVirtualDirectoryRoot())
   {
     AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
-    SetSortMethod(SortByNone);
-
-    SetViewAsControl(DEFAULT_VIEW_LIST);
-
-    SetSortOrder(SortOrderNone);
+    view = DEFAULT_VIEW_LIST;
   }
   else if (items.IsVideoDb())
   {
@@ -127,58 +131,54 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     case NODE_TYPE_OVERVIEW:
       {
         AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
-
-        SetSortMethod(SortByNone);
-
-        SetViewAsControl(DEFAULT_VIEW_LIST);
-
-        SetSortOrder(SortOrderNone);
+        view = DEFAULT_VIEW_LIST;
       }
       break;
     case NODE_TYPE_DIRECTOR:
     case NODE_TYPE_ACTOR:
       {
         AddSortMethod(SortByLabel, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
-        SetSortMethod(SortByLabel);
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavactors");
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortBy = SortByLabel;
+        sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_YEAR:
       {
         AddSortMethod(SortByLabel, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
-        SetSortMethod(SortByLabel);
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavyears");
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortBy = SortByLabel;
+        sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_SEASONS:
       {
         AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%L", "","%L",""));  // Label, empty | Label, empty
-        SetSortMethod(SortBySortTitle);
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavseasons");
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortBy = SortBySortTitle;
+        sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_TITLE_TVSHOWS:
       {
-        AddSortMethod(SortBySortTitle, sortAttributes, 556, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
+        AddSortMethod(SortBySortTitle, sorting.sortAttributes, 556, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
 
         // NOTE: This uses SortByEpisodeNumber to mean "sort shows by the number of episodes" and uses the label "Episodes"
         AddSortMethod(SortByEpisodeNumber, 20360, LABEL_MASKS("%L", "%M", "%L", "%M"));  // Label, #Episodes | Label, #Episodes
         AddSortMethod(SortByLastPlayed, 568, LABEL_MASKS("%T", "%p", "%T", "%p"));  // Title, #Last played | Title, #Last played
         AddSortMethod(SortByYear, 562, LABEL_MASKS("%L","%Y","%L","%Y")); // Label, Year | Label, Year
-        SetSortMethod(SortByLabel);
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavtvshows");
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortBy = SortBySortTitle;
+        sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+        labelMask = LABEL_MASKS("%T", "%M", "%T", "%M");  // Title, #Episodes | Title, #Episodes
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_MUSICVIDEOS_ALBUM:
@@ -187,16 +187,16 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     case NODE_TYPE_STUDIO:
       {
         AddSortMethod(SortByLabel, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
-        SetSortMethod(SortByLabel);
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavgenres");
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortBy = SortByLabel;
+        sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_SETS:
       {
-        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T","%R", "%T","%R"));  // Title, Rating | Title, Rating
+        AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS("%T","%R", "%T","%R"));  // Title, Rating | Title, Rating
 
         AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
         AddSortMethod(SortByRating, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
@@ -205,21 +205,21 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         if (CMediaSettings::Get().GetWatchedMode(items.GetContent()) == WatchedModeAll)
           AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V", "%T", "%V"));  // Title, Playcount | Title, Playcount
 
-        SetSortMethod(SortByLabel, SortAttributeIgnoreArticle);
-
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavgenres");
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortBy = SortByLabel;
+        sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_TAGS:
       {
-        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T","", "%T",""));  // Title, empty | Title, empty
-        SetSortMethod(SortByLabel, sortAttributes);
-        
+        sorting.sortBy = SortByLabel;
+
+        AddSortMethod(sorting, 551, LABEL_MASKS("%T","", "%T",""));  // Title, empty | Title, empty
+
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavgenres");
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting.sortOrder = viewState->m_sortDescription.sortOrder;
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_EPISODES:
@@ -246,21 +246,18 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
           if (CMediaSettings::Get().GetWatchedMode(items.GetContent()) == WatchedModeAll)
             AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%H. %T", "%V"));  // Order. Title, Playcount | empty, empty
         }
-        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T","%R"));  // Title, Rating | empty, empty
+        AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS("%T","%R"));  // Title, Rating | empty, empty
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavepisodes");
-        SetSortMethod(viewState->m_sortDescription);
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting = viewState->m_sortDescription;
+        labelMask = LABEL_MASKS("%Z - %H. %T", "%R");  // TvShow - Order. Title, Rating | empty, empty
+        view = viewState->m_viewMode;
         break;
       }
     case NODE_TYPE_RECENTLY_ADDED_EPISODES:
       {
         AddSortMethod(SortByNone, 552, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
-        SetSortMethod(SortByNone);
-
-        SetViewAsControl(CViewStateSettings::Get().Get("videonavepisodes")->m_viewMode);
-        SetSortOrder(SortOrderNone);
+        view = CViewStateSettings::Get().Get("videonavepisodes")->m_viewMode;
 
         break;
       }
@@ -269,11 +266,11 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         if (params.GetSetId() > -1) // Is this a listing within a set?
         {
           AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-          AddSortMethod(SortBySortTitle, sortAttributes, 556, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
+          AddSortMethod(SortBySortTitle, sorting.sortAttributes, 556, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
         }
         else
         {
-          AddSortMethod(SortBySortTitle, sortAttributes, 556, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
+          AddSortMethod(SortBySortTitle, sorting.sortAttributes, 556, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
           AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
         }
         AddSortMethod(SortByRating, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
@@ -285,22 +282,21 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
           AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V", "%T", "%V"));  // Title, Playcount | Title, Playcount
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavtitles");
+        sorting = viewState->m_sortDescription;
         if (params.GetSetId() > -1)
-          SetSortMethod(SortByYear);
-        else
-          SetSortMethod(viewState->m_sortDescription);
+          sorting.sortBy = SortByYear;
 
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        labelMask = LABEL_MASKS("%T", "%R", "%T", "%R");  // Title, Rating | Title, Rating
+        view = viewState->m_viewMode;
       }
       break;
       case NODE_TYPE_TITLE_MUSICVIDEOS:
       {
-        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
+        AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
         AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T", "%O"));
         AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-        AddSortMethod(SortByArtist, sortAttributes, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-        AddSortMethod(SortByAlbum, sortAttributes, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
+        AddSortMethod(SortByArtist, sorting.sortAttributes, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
+        AddSortMethod(SortByAlbum, sorting.sortAttributes, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
 
         if (CMediaSettings::Get().GetWatchedMode(items.GetContent()) == WatchedModeAll)
           AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V"));  // Title, Playcount | empty, empty
@@ -310,29 +306,21 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavmusicvideos");
-        SetSortMethod(viewState->m_sortDescription);
-        SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
+        sorting = viewState->m_sortDescription;
+        labelMask = LABEL_MASKS("%A - %T", "%Y");  // Artist - Title, Year | empty, empty
+        view = viewState->m_viewMode;
       }
       break;
     case NODE_TYPE_RECENTLY_ADDED_MOVIES:
       {
         AddSortMethod(SortByNone, 552, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
-        SetSortMethod(SortByNone);
-
-        SetViewAsControl(CViewStateSettings::Get().Get("videonavtitles")->m_viewMode);
-
-        SetSortOrder(SortOrderNone);
+        view = CViewStateSettings::Get().Get("videonavtitles")->m_viewMode;
       }
       break;
     case NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS:
       {
         AddSortMethod(SortByNone, 552, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-        SetSortMethod(SortByNone);
-
-        SetViewAsControl(CViewStateSettings::Get().Get("videonavmusicvideos")->m_viewMode);
-
-        SetSortOrder(SortOrderNone);
+        view = CViewStateSettings::Get().Get("videonavmusicvideos")->m_viewMode;
       }
       break;
     default:
@@ -341,16 +329,19 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
   }
   else
   {
-    AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
+    AddSortMethod(SortByLabel, sorting.sortAttributes, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
     AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Label, Size | Label, Size
     AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Label, Date | Label, Date
     AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
     
     const CViewState *viewState = CViewStateSettings::Get().Get("videofiles");
-    SetSortMethod(viewState->m_sortDescription);
-    SetViewAsControl(viewState->m_viewMode);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
+    sorting = viewState->m_sortDescription;
+    view = viewState->m_viewMode;
   }
+
+  AddPlaylistOrder(items, labelMask, sorting);
+  SetViewAsControl(view);
+
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
 }
 
@@ -430,6 +421,7 @@ bool CGUIViewStateWindowVideoNav::AutoPlayNextItem()
   return CSettings::Get().GetBool("videoplayer.autoplaynextitem");
 }
 
+
 CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
   AddSortMethod(SortByNone, 551, LABEL_MASKS("%L", "", "%L", ""));  // Label, empty | Label, empty
@@ -479,14 +471,7 @@ CGUIViewStateVideoMovies::CGUIViewStateVideoMovies(const CFileItemList& items) :
   AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavtitles");
-  if (items.IsSmartPlayList() || items.GetProperty("library.filter").asBoolean())
-    AddPlaylistOrder(items, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-  else
-  {
-    SetSortMethod(viewState->m_sortDescription);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
-  }
-
+  AddPlaylistOrder(items, LABEL_MASKS("%T", "%R", "%T", "%R"), viewState->m_sortDescription);  // Title, Rating | Title, Rating
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
@@ -516,14 +501,7 @@ CGUIViewStateVideoMusicVideos::CGUIViewStateVideoMusicVideos(const CFileItemList
   AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavmusicvideos");
-  if (items.IsSmartPlayList() || items.GetProperty("library.filter").asBoolean())
-    AddPlaylistOrder(items, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-  else
-  {
-    SetSortMethod(viewState->m_sortDescription);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
-  }
-
+  AddPlaylistOrder(items, LABEL_MASKS("%A - %T", "%Y"), viewState->m_sortDescription);  // Artist - Title, Year | empty, empty
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
@@ -534,6 +512,7 @@ void CGUIViewStateVideoMusicVideos::SaveViewState()
   SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, CViewStateSettings::Get().Get("videonavmusicvideos"));
 }
 
+
 CGUIViewStateVideoTVShows::CGUIViewStateVideoTVShows(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
   AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%T", "%M", "%T", "%M"),  // Title, #Episodes | Title, #Episodes
@@ -541,14 +520,7 @@ CGUIViewStateVideoTVShows::CGUIViewStateVideoTVShows(const CFileItemList& items)
   AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavtvshows");
-  if (items.IsSmartPlayList() || items.GetProperty("library.filter").asBoolean())
-    AddPlaylistOrder(items, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
-  else
-  {
-    SetSortMethod(viewState->m_sortDescription);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
-  }
-
+  AddPlaylistOrder(items, LABEL_MASKS("%T", "%M", "%T", "%M"), viewState->m_sortDescription);  // Title, #Episodes | Title, #Episodes
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
@@ -581,14 +553,7 @@ CGUIViewStateVideoEpisodes::CGUIViewStateVideoEpisodes(const CFileItemList& item
   }
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavepisodes");
-  if (items.IsSmartPlayList() || items.GetProperty("library.filter").asBoolean())
-    AddPlaylistOrder(items, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
-  else
-  {
-    SetSortMethod(viewState->m_sortDescription);
-    SetSortOrder(viewState->m_sortDescription.sortOrder);
-  }
-
+  AddPlaylistOrder(items, LABEL_MASKS("%Z - %H. %T", "%R"), viewState->m_sortDescription);  // TvShow - Order. Title, Rating | empty, empty
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -85,7 +85,7 @@ CGUIViewStateWindowVideoFiles::CGUIViewStateWindowVideoFiles(const CFileItemList
     view = viewState->m_viewMode;
   }
 
-  AddPlaylistOrder(items, LABEL_MASKS(), sorting);
+  AddAndSetSortMethod(items, LABEL_MASKS(), sorting);
   SetViewAsControl(view);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_FILES);
@@ -339,7 +339,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     view = viewState->m_viewMode;
   }
 
-  AddPlaylistOrder(items, labelMask, sorting);
+  AddAndSetSortMethod(items, labelMask, sorting);
   SetViewAsControl(view);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
@@ -471,7 +471,7 @@ CGUIViewStateVideoMovies::CGUIViewStateVideoMovies(const CFileItemList& items) :
   AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavtitles");
-  AddPlaylistOrder(items, LABEL_MASKS("%T", "%R", "%T", "%R"), viewState->m_sortDescription);  // Title, Rating | Title, Rating
+  AddAndSetSortMethod(items, LABEL_MASKS("%T", "%R", "%T", "%R"), viewState->m_sortDescription);  // Title, Rating | Title, Rating
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
@@ -501,7 +501,7 @@ CGUIViewStateVideoMusicVideos::CGUIViewStateVideoMusicVideos(const CFileItemList
   AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavmusicvideos");
-  AddPlaylistOrder(items, LABEL_MASKS("%A - %T", "%Y"), viewState->m_sortDescription);  // Artist - Title, Year | empty, empty
+  AddAndSetSortMethod(items, LABEL_MASKS("%A - %T", "%Y"), viewState->m_sortDescription);  // Artist - Title, Year | empty, empty
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
@@ -520,7 +520,7 @@ CGUIViewStateVideoTVShows::CGUIViewStateVideoTVShows(const CFileItemList& items)
   AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavtvshows");
-  AddPlaylistOrder(items, LABEL_MASKS("%T", "%M", "%T", "%M"), viewState->m_sortDescription);  // Title, #Episodes | Title, #Episodes
+  AddAndSetSortMethod(items, LABEL_MASKS("%T", "%M", "%T", "%M"), viewState->m_sortDescription);  // Title, #Episodes | Title, #Episodes
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
@@ -553,7 +553,7 @@ CGUIViewStateVideoEpisodes::CGUIViewStateVideoEpisodes(const CFileItemList& item
   }
 
   const CViewState *viewState = CViewStateSettings::Get().Get("videonavepisodes");
-  AddPlaylistOrder(items, LABEL_MASKS("%Z - %H. %T", "%R"), viewState->m_sortDescription);  // TvShow - Order. Title, Rating | empty, empty
+  AddAndSetSortMethod(items, LABEL_MASKS("%Z - %H. %T", "%R"), viewState->m_sortDescription);  // TvShow - Order. Title, Rating | empty, empty
   SetViewAsControl(viewState->m_viewMode);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -836,11 +836,6 @@ bool CGUIWindowVideoNav::DeleteItem(CFileItem* pItem, bool bUnavailable /* = fal
   return true;
 }
 
-void CGUIWindowVideoNav::OnPrepareFileItems(CFileItemList &items)
-{
-  CGUIWindowVideoBase::OnPrepareFileItems(items);
-}
-
 void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   CFileItemPtr item;

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -34,8 +34,6 @@ public:
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);
 
-  virtual void OnPrepareFileItems(CFileItemList &items);
-
   virtual void OnInfo(CFileItem* pItem, ADDON::ScraperPtr &info);
   static bool CanDelete(const CStdString& strPath);
   static bool DeleteItem(CFileItem* pItem, bool bUnavailable=false);

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -488,7 +488,7 @@ void CGUIViewState::SaveViewToDb(const CStdString &path, int windowID, CViewStat
   }
 }
 
-bool CGUIViewState::AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks, SortBy sortBy /* = SortByPlaylistOrder */, SortOrder sortOrder /* = SortOrderAscending */, SortAttribute sortAttributes /* = SortAttributeNone */)
+bool CGUIViewState::AddAndSetSortMethod(const CFileItemList &items, LABEL_MASKS label_masks /* = LABEL_MASKS() */, SortBy sortBy /* = SortByPlaylistOrder */, SortOrder sortOrder /* = SortOrderAscending */, SortAttribute sortAttributes /* = SortAttributeNone */)
 {
   bool add = false;
   int sortLabel = 559;
@@ -520,9 +520,9 @@ bool CGUIViewState::AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS lab
   return add;
 }
 
-bool CGUIViewState::AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks, SortDescription sortDescription)
+bool CGUIViewState::AddAndSetSortMethod(const CFileItemList &items, LABEL_MASKS label_masks, SortDescription sortDescription)
 {
-  return AddPlaylistOrder(items, label_masks, sortDescription.sortBy, sortDescription.sortOrder, sortDescription.sortAttributes);
+  return AddAndSetSortMethod(items, label_masks, sortDescription.sortBy, sortDescription.sortOrder, sortDescription.sortAttributes);
 }
 
 

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -79,8 +79,10 @@ protected:
    Defaults to SORT_METHOD_PLAYLIST_ORDER if no order is defined.
    \param items the list of items for the view state.
    \param label_mask the label masks for formatting items.
+   \return True if a special playlist order has been added, false otherwise
    */
-  void AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks);
+  bool AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks, SortBy sortBy = SortByPlaylistOrder, SortOrder sortOrder = SortOrderAscending, SortAttribute sortAttributes = SortAttributeNone);
+  bool AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks, SortDescription sortDescription);
 
   void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone);
   void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks);

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -81,8 +81,8 @@ protected:
    \param label_mask the label masks for formatting items.
    \return True if a special playlist order has been added, false otherwise
    */
-  bool AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks, SortBy sortBy = SortByPlaylistOrder, SortOrder sortOrder = SortOrderAscending, SortAttribute sortAttributes = SortAttributeNone);
-  bool AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks, SortDescription sortDescription);
+  bool AddAndSetSortMethod(const CFileItemList &items, LABEL_MASKS label_masks = LABEL_MASKS(), SortBy sortBy = SortByPlaylistOrder, SortOrder sortOrder = SortOrderAscending, SortAttribute sortAttributes = SortAttributeNone);
+  bool AddAndSetSortMethod(const CFileItemList &items, LABEL_MASKS label_masks, SortDescription sortDescription);
 
   void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone);
   void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -751,10 +751,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
   CStdString filter;
   CURL url(directory);
   if (canfilter && url.HasOption("filter"))
-  {
-    filter = url.GetOption("filter");
     directory = RemoveParameterFromPath(directory, "filter");
-  }
 
   CFileItemList items;
   if (!GetDirectory(directory, items))
@@ -776,44 +773,8 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
   ClearFileItems();
   m_vecItems->Copy(items);
 
-  // only set the filter path if it hasn't been marked
-  // as preset or if it's empty
-  if (updateFilterPath || m_strFilterPath.empty())
-  {
-    if (items.HasProperty(PROPERTY_PATH_DB))
-      m_strFilterPath = items.GetProperty(PROPERTY_PATH_DB).asString();
-    else
-      m_strFilterPath = items.GetPath();
-  }
-  
-  // maybe the filter path can contain a filter
-  if (!canfilter && CanContainFilter(m_strFilterPath))
-    canfilter = true;
-
-  // check if the filter path contains a filter
-  CURL filterPathUrl(m_strFilterPath);
-  if (canfilter && filter.empty())
-  {
-    if (filterPathUrl.HasOption("filter"))
-      filter = filterPathUrl.GetOption("filter");
-  }
-
-  // check if there is a filter and re-apply it
-  if (canfilter && !filter.empty())
-  {
-    if (!m_filter.LoadFromJson(filter))
-    {
-      CLog::Log(LOGWARNING, "CGUIMediaWindow::Update: unable to load existing filter (%s)", filter.c_str());
-      m_filter.Reset();
-      m_strFilterPath = m_vecItems->GetPath();
-    }
-    else
-    {
-      // add the filter to the filter path
-      filterPathUrl.SetOption("filter", filter);
-      m_strFilterPath = filterPathUrl.Get();
-    }
-  }
+  // check the given path for filter data
+  UpdateFilterPath(strDirectory, items, updateFilterPath);
     
   // if we're getting the root source listing
   // make sure the path history is clean
@@ -1663,6 +1624,55 @@ bool CGUIMediaWindow::WaitForNetwork() const
   }
   progress->Close();
   return true;
+}
+
+void CGUIMediaWindow::UpdateFilterPath(const CStdString &strDirectory, const CFileItemList &items, bool updateFilterPath)
+{
+  bool canfilter = CanContainFilter(strDirectory);
+
+  CStdString filter;
+  CURL url(strDirectory);
+  if (canfilter && url.HasOption("filter"))
+    filter = url.GetOption("filter");
+
+  // only set the filter path if it hasn't been marked
+  // as preset or if it's empty
+  if (updateFilterPath || m_strFilterPath.empty())
+  {
+    if (items.HasProperty(PROPERTY_PATH_DB))
+      m_strFilterPath = items.GetProperty(PROPERTY_PATH_DB).asString();
+    else
+      m_strFilterPath = items.GetPath();
+  }
+  
+  // maybe the filter path can contain a filter
+  if (!canfilter && CanContainFilter(m_strFilterPath))
+    canfilter = true;
+
+  // check if the filter path contains a filter
+  CURL filterPathUrl(m_strFilterPath);
+  if (canfilter && filter.empty())
+  {
+    if (filterPathUrl.HasOption("filter"))
+      filter = filterPathUrl.GetOption("filter");
+  }
+
+  // check if there is a filter and re-apply it
+  if (canfilter && !filter.empty())
+  {
+    if (!m_filter.LoadFromJson(filter))
+    {
+      CLog::Log(LOGWARNING, "CGUIMediaWindow::UpdateFilterPath(): unable to load existing filter (%s)", filter.c_str());
+      m_filter.Reset();
+      m_strFilterPath = m_vecItems->GetPath();
+    }
+    else
+    {
+      // add the filter to the filter path
+      filterPathUrl.SetOption("filter", filter);
+      m_strFilterPath = filterPathUrl.Get();
+    }
+  }
 }
 
 void CGUIMediaWindow::OnFilterItems(const CStdString &filter)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -595,7 +595,7 @@ void CGUIMediaWindow::SortItems(CFileItemList &items)
         sorting.sortAttributes = CSettings::Get().GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone;
 
         // if the sort order is descending, we need to switch the original sort order, as we assume
-        // in CGUIViewState::AddPlaylistOrder that SortByPlaylistOrder is ascending.
+        // in CGUIViewState::AddAndSetSortMethod that SortByPlaylistOrder is ascending.
         if (guiState->GetDisplaySortOrder() == SortOrderDescending)
           sorting.sortOrder = sorting.sortOrder == SortOrderDescending ? SortOrderAscending : SortOrderDescending;
       }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -69,6 +69,7 @@
 #if defined(TARGET_ANDROID)
 #include "xbmc/android/activity/XBMCApp.h"
 #endif
+#include "FileItemListModification.h"
 
 #define CONTROL_BTNVIEWASICONS       2
 #define CONTROL_BTNSORTBY            3
@@ -890,7 +891,7 @@ bool CGUIMediaWindow::Refresh(bool clearCache /* = false */)
 // It's used to load tag info for music.
 void CGUIMediaWindow::OnPrepareFileItems(CFileItemList &items)
 {
-
+  CFileItemListModification::Get().Modify(items);
 }
 
 // \brief This function will be called by Update() before

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -104,6 +104,7 @@ protected:
    \return true if the given path can contain a "filter" parameter otherwise false
    */
   virtual bool CanContainFilter(const CStdString &strDirectory) const { return false; }
+  virtual void UpdateFilterPath(const CStdString &strDirector, const CFileItemList &items, bool updateFilterPath);
   virtual bool Filter(bool advanced = true);
 
   /* \brief Called on response to a GUI_MSG_FILTER_ITEMS message


### PR DESCRIPTION
A while ago I implemented grouping for smartplaylist (e.g. make a movie smartplaylist and group the result into genres) but I didn't have an implementation for the sort order/direction back then yet. I finally had the time to look into it and came up with this solution.

With this it is possible to make a smartplaylist that e.g. retrieves all action movies, groups them into directors and shows the movies of a specific directory sorted by rating descending. So when opening the smartplaylist the user will see a list of directors that directed at least one action movie. When opening a specific director the user will see a list of action movies directed by that specific director and the list will be sorted by rating descending.

The first commit doesn't really belong here but I had to work through CGUIMediaWindow::Update() once again to see where the sorting information extraction would fit best and came across that refactorable code (and I'm too lazy to move it to a separate PR).

I also refactored CGUIViewState::AddPlaylistOrder() which was introduced by jmarshall a while ago and I turned it into CGUIViewState::AddAndSetSortMethod() which is a bit more generic and more "powerful".

Apart from that the only real change is the extraction of sort information from the "xsp" URL option in CGUIMediaWindow::OnPrepareFileItems(). I'm not 100% happy with that approach but it has to be done somewhere and I didn't want to duplicate the code in a ton of places in e.g. CVideoDatabase and CMusicDatabase. But if anyone has a better idea, I'm all ears.
