### PR TITLE
[fixes] Fix a couple of EXC_BAD_ACCESS memory access bugs on OSX that cause real instability

### DIFF
--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -87,7 +87,11 @@ void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned in
     // we crash in CPicture::ScaleImage in ffmpegs swscale
     // because it tries to access beyond the source memory
     // (happens on osx and ios)
-    m_textureWidth = ((m_textureWidth + 1) / 2) * 2;
+    // UPDATE: don't just update to be on an even width;
+    // ffmpegs swscale relies on a 16-byte stride on some systems
+    // so the textureWidth needs to be a multiple of 16. see ffmpeg
+    // swscale headers for more info.
+    m_textureWidth = ((m_textureWidth + 15) / 16) * 16;
   }
 
   // check for max texture size

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -65,7 +65,8 @@ wstring trimRight(const wstring &str)
 int64_t str2int64(const string &str, int64_t fallback /* = 0 */)
 {
   char *end = NULL;
-  int64_t result = strtoll(trimRight(str).c_str(), &end, 0);
+  string tmp = trimRight(str);
+  int64_t result = strtoll(tmp.c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -75,7 +76,8 @@ int64_t str2int64(const string &str, int64_t fallback /* = 0 */)
 int64_t str2int64(const wstring &str, int64_t fallback /* = 0 */)
 {
   wchar_t *end = NULL;
-  int64_t result = wcstoll(trimRight(str).c_str(), &end, 0);
+  wstring tmp = trimRight(str);
+  int64_t result = wcstoll(tmp.c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -85,7 +87,8 @@ int64_t str2int64(const wstring &str, int64_t fallback /* = 0 */)
 uint64_t str2uint64(const string &str, uint64_t fallback /* = 0 */)
 {
   char *end = NULL;
-  uint64_t result = strtoull(trimRight(str).c_str(), &end, 0);
+  string tmp = trimRight(str);
+  uint64_t result = strtoull(tmp.c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -95,7 +98,8 @@ uint64_t str2uint64(const string &str, uint64_t fallback /* = 0 */)
 uint64_t str2uint64(const wstring &str, uint64_t fallback /* = 0 */)
 {
   wchar_t *end = NULL;
-  uint64_t result = wcstoull(trimRight(str).c_str(), &end, 0);
+  wstring tmp = trimRight(str);
+  uint64_t result = wcstoull(tmp.c_str(), &end, 0);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -105,7 +109,8 @@ uint64_t str2uint64(const wstring &str, uint64_t fallback /* = 0 */)
 double str2double(const string &str, double fallback /* = 0.0 */)
 {
   char *end = NULL;
-  double result = strtod(trimRight(str).c_str(), &end);
+  string tmp = trimRight(str);
+  double result = strtod(tmp.c_str(), &end);
   if (end == NULL || *end == '\0')
     return result;
 
@@ -115,7 +120,8 @@ double str2double(const string &str, double fallback /* = 0.0 */)
 double str2double(const wstring &str, double fallback /* = 0.0 */)
 {
   wchar_t *end = NULL;
-  double result = wcstod(trimRight(str).c_str(), &end);
+  wstring tmp = trimRight(str);
+  double result = wcstod(tmp.c_str(), &end);
   if (end == NULL || *end == '\0')
     return result;
 


### PR DESCRIPTION
These 2 bugs cause a significant amount of crashes on OSX especially when scanning movies and downloading images.
