### PR TITLE
Map two keys for toggle random and toggle repeat when playing video in full-screen

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -242,6 +242,8 @@
       <down mod="ctrl">SubtitleShiftDown</down>
       <pageup>SkipNext</pageup>
       <pagedown>SkipPrevious</pagedown>
+      <w>PlayerControl(Random,Notify)</w>
+      <y>PlayerControl(Repeat,Notify)</y>
     </keyboard>
   </FullscreenVideo>
   <VideoTimeSeek>


### PR DESCRIPTION
One of the common problems is that is not easy to toggle random and repeat on the default user interface when playing a video. This commit maps two keys to allow the user to quickly toggle the status of repeat and random. The notify parameter is required to show a small status notification.
