### PR TITLE
Update AMLPlayer.cpp

### DIFF
--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -1800,7 +1800,7 @@ int CAMLPlayer::UpdatePlayerInfo(int pid, player_info_t *info)
   // we get called when status changes or after update time expires.
   // static callback from libamplayer, since it does not pass an opaque,
   // we have to retreve our player class reference the hard way.
-  CAMLPlayer *amlplayer = dynamic_cast<CAMLPlayer*>(g_application.m_pPlayer);
+  CAMLPlayer *amlplayer = dynamic_cast<CAMLPlayer*>(g_application.m_pPlayer.get());
   if (amlplayer)
   {
     CSingleLock lock(amlplayer->m_aml_state_csection);


### PR DESCRIPTION
Pointers are smart pointers. But in some cases it doesn't compile right. Hence adding the .get() function fixing compiling errors you get from git now.

CPP     xbmc/cores/amlplayer/AMLPlayer.o
AMLPlayer.cpp: In static member function 'static int CAMLPlayer::UpdatePlayerInfo(int, player_info_t_)':
AMLPlayer.cpp:1803:76: error: cannot dynamic_cast 'xbmcutil::GlobalsSingleton<T>::getQuick<CApplication>()->CApplication::m_pPlayer' (of type 'class boost::shared_ptr<IPlayer>') to type 'class CAMLPlayer_' (source is not a pointer)
make[1]: **\* [AMLPlayer.o] Error 1
make: **\* [xbmc/cores/amlplayer/amlplayer.a] Error 2
