### PR TITLE
fixed: Crash in GUIPicturesWindow caused by PR2890 (fixes #14500)

### DIFF
--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -272,7 +272,8 @@ bool CGUIWindowPictures::Update(const CStdString &strDirectory, bool updateFilte
   if (CSettings::Get().GetBool("pictures.generatethumbs"))
     m_thumbLoader.Load(*m_vecItems);
 
-  CStdString thumb = m_thumbLoader.GetCachedImage(*m_vecItems, "thumb");
+  CPictureThumbLoader thumbLoader;
+  CStdString thumb = thumbLoader.GetCachedImage(*m_vecItems, "thumb");
   m_vecItems->SetArt("thumb", thumb);
 
   return true;


### PR DESCRIPTION
This should fix #14500, haven't tried to reproduce it myself but the problem seems pretty obvious.
