### PR TITLE
Add a mutex for the db connection. Fixes #14500

### DIFF
--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -150,7 +150,7 @@ bool CTextureDatabase::GetCachedTexture(const CStdString &url, CTextureDetails &
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("SELECT id, cachedurl, lasthashcheck, imagehash, width, height FROM texture JOIN sizes ON (texture.id=sizes.idtexture AND sizes.size=1) WHERE url='%s'", url.c_str());
@@ -188,7 +188,7 @@ bool CTextureDatabase::AddCachedTexture(const CStdString &url, const CTextureDet
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("DELETE FROM texture WHERE url='%s'", url.c_str());
@@ -214,7 +214,7 @@ bool CTextureDatabase::ClearCachedTexture(const CStdString &url, CStdString &cac
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("select id, cachedurl from texture where url='%s'", url.c_str());
@@ -250,7 +250,7 @@ CStdString CTextureDatabase::GetTextureForPath(const CStdString &url, const CStd
 {
   try
   {
-    if (NULL == m_pDB.get()) return "";
+    if (isNullDb()) return "";
     if (NULL == m_pDS.get()) return "";
 
     if (url.empty())
@@ -278,7 +278,7 @@ void CTextureDatabase::SetTextureForPath(const CStdString &url, const CStdString
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (url.empty())
@@ -311,7 +311,7 @@ void CTextureDatabase::ClearTextureForPath(const CStdString &url, const CStdStri
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CStdString sql = PrepareSQL("DELETE FROM path WHERE url='%s' and type='%s'", url.c_str(), type.c_str());

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -123,7 +123,7 @@ int CAddonDatabase::AddAddon(const AddonPtr& addon,
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     bool bDisablePVRAddon = addon->Type() == ADDON_PVRDLL && !HasAddon(addon->ID());
@@ -175,7 +175,7 @@ bool CAddonDatabase::GetAddon(const CStdString& id, AddonPtr& addon)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     // there may be multiple addons with this id (eg from different repositories) in the database,
@@ -213,7 +213,7 @@ bool CAddonDatabase::GetRepoForAddon(const CStdString& addonID, CStdString& repo
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     CStdString sql = PrepareSQL("select repo.addonID from repo join addonlinkrepo on repo.id=addonlinkrepo.idRepo join addon on addonlinkrepo.idAddon=addon.id where addon.addonID like '%s'", addonID.c_str()); 
@@ -236,7 +236,7 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr& addon)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     CStdString sql = PrepareSQL("select * from addon where id=%i",id);
@@ -293,7 +293,7 @@ bool CAddonDatabase::GetAddons(VECADDONS& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     CStdString sql = PrepareSQL("select distinct addonID from addon");
@@ -321,7 +321,7 @@ void CAddonDatabase::DeleteRepository(const CStdString& id)
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CStdString sql = PrepareSQL("select id from repo where addonID='%s'",id.c_str());
@@ -339,7 +339,7 @@ void CAddonDatabase::DeleteRepository(int idRepo)
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CStdString sql = PrepareSQL("delete from repo where id=%i",idRepo);
@@ -364,7 +364,7 @@ int CAddonDatabase::AddRepository(const CStdString& id, const VECADDONS& addons,
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString sql;
@@ -396,7 +396,7 @@ int CAddonDatabase::GetRepoChecksum(const CStdString& id, CStdString& checksum)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
@@ -420,7 +420,7 @@ CDateTime CAddonDatabase::GetRepoTimestamp(const CStdString& id)
   CDateTime date;
   try
   {
-    if (NULL == m_pDB.get()) return date;
+    if (isNullDb()) return date;
     if (NULL == m_pDS.get()) return date;
 
     CStdString strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
@@ -442,7 +442,7 @@ bool CAddonDatabase::SetRepoTimestamp(const CStdString& id, const CStdString& ti
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("update repo set lastcheck='%s' where addonID='%s'",time.c_str(),id.c_str());
@@ -461,7 +461,7 @@ bool CAddonDatabase::GetRepository(int id, VECADDONS& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL = PrepareSQL("select * from addonlinkrepo where idRepo=%i",id);
@@ -486,7 +486,7 @@ bool CAddonDatabase::GetRepository(const CStdString& id, VECADDONS& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL = PrepareSQL("select id from repo where addonID='%s'",id.c_str());
@@ -505,7 +505,7 @@ bool CAddonDatabase::Search(const CStdString& search, VECADDONS& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -561,7 +561,7 @@ bool CAddonDatabase::DisableAddon(const CStdString &addonID, bool disable /* = t
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     if (disable)
@@ -619,7 +619,7 @@ bool CAddonDatabase::BreakAddon(const CStdString &addonID, const CStdString& rea
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("delete from broken where addonID='%s'", addonID.c_str());
@@ -651,7 +651,7 @@ bool CAddonDatabase::IsAddonDisabled(const CStdString &addonID)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("select id from disabled where addonID='%s'", addonID.c_str());
@@ -679,7 +679,7 @@ CStdString CAddonDatabase::IsAddonBroken(const CStdString &addonID)
 {
   try
   {
-    if (NULL == m_pDB.get()) return "";
+    if (isNullDb()) return "";
     if (NULL == m_pDS.get()) return "";
 
     CStdString sql = PrepareSQL("select reason from broken where addonID='%s'", addonID.c_str());
@@ -701,7 +701,7 @@ bool CAddonDatabase::HasDisabledAddons()
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     m_pDS->query("select count(id) from disabled");
@@ -721,7 +721,7 @@ bool CAddonDatabase::BlacklistAddon(const CStdString& addonID,
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("insert into blacklist(id, addonID, version) values(NULL, '%s', '%s')", addonID.c_str(),version.c_str());
@@ -748,7 +748,7 @@ bool CAddonDatabase::RemoveAddonFromBlacklist(const CStdString& addonID,
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("delete from blacklist where addonID='%s' and version='%s'",addonID.c_str(),version.c_str());

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -21,6 +21,7 @@
  */
 
 #include "utils/StdString.h"
+#include "threads/CriticalSection.h"
 
 namespace dbiplus {
   class Database;
@@ -162,6 +163,8 @@ protected:
 
   bool m_sqlite; ///< \brief whether we use sqlite (defaults to true)
 
+  // The critical section protects the m_pDB
+  CCriticalSection lock;
   std::auto_ptr<dbiplus::Database> m_pDB;
   std::auto_ptr<dbiplus::Dataset> m_pDS;
   std::auto_ptr<dbiplus::Dataset> m_pDS2;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -21,7 +21,7 @@
  */
 
 #include "utils/StdString.h"
-#include "threads/CriticalSection.h"
+#include "threads/SingleLock.h"
 
 namespace dbiplus {
   class Database;
@@ -163,13 +163,17 @@ protected:
 
   bool m_sqlite; ///< \brief whether we use sqlite (defaults to true)
 
-  // The critical section protects the m_pDB
-  CCriticalSection lock;
-  std::auto_ptr<dbiplus::Database> m_pDB;
   std::auto_ptr<dbiplus::Dataset> m_pDS;
   std::auto_ptr<dbiplus::Dataset> m_pDS2;
 
+  inline bool isNullDb() const { CSingleLock l(lock); return NULL == m_pDB.get(); }
+  dbiplus::Dataset* CreateDataset() const;
+
 private:
+  // The critical section protects the m_pDB
+  CCriticalSection lock;
+  std::auto_ptr<dbiplus::Database> m_pDB;
+
   void InitSettings(DatabaseSettings &dbSettings);
   bool Connect(const CStdString &dbName, const DatabaseSettings &db, bool create);
   bool UpdateVersionNumber();

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -351,7 +351,7 @@ int CMusicDatabase::AddSong(const int idAlbum,
     if (strTitle.IsEmpty())
       return -1;
 
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strPath, strFileName;
@@ -497,7 +497,7 @@ int CMusicDatabase::AddAlbum(const CStdString& strAlbum, const CStdString& strMu
   CStdString strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     if (!strMusicBrainzAlbumID.empty())
@@ -567,7 +567,7 @@ int CMusicDatabase::AddGenre(const CStdString& strGenre1)
     if (strGenre.IsEmpty())
       strGenre=g_localizeStrings.Get(13205); // Unknown
 
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
     map <CStdString, int>::const_iterator it;
 
@@ -610,7 +610,7 @@ int CMusicDatabase::AddArtist(const CStdString& strArtist, const CStdString& str
   CStdString strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     if (!strMusicBrainzArtistID.empty())
@@ -892,7 +892,7 @@ int CMusicDatabase::AddPath(const CStdString& strPath1)
     if (!URIUtils::HasSlashAtEnd(strPath))
       URIUtils::AddSlashAtEnd(strPath);
 
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     map <CStdString, int>::const_iterator it;
@@ -1115,7 +1115,7 @@ bool CMusicDatabase::GetSongByFileName(const CStdString& strFileName, CSong& son
     URIUtils::GetDirectory(strFileName, strPath);
     URIUtils::AddSlashAtEnd(strPath);
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     DWORD crc = ComputeCRC(strFileName);
@@ -1201,7 +1201,7 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
   {
     song.Clear();
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("select * from songview "
@@ -1231,7 +1231,7 @@ bool CMusicDatabase::SearchArtists(const CStdString& search, CFileItemList &arti
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strVariousArtists = g_localizeStrings.Get(340).c_str();
@@ -1283,7 +1283,7 @@ bool CMusicDatabase::GetAlbumInfo(int idAlbum, CAlbum &info, VECSONGS* songs, bo
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     if (idAlbum == -1)
@@ -1357,7 +1357,7 @@ bool CMusicDatabase::GetArtistInfo(int idArtist, CArtist &info, bool needAll)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     if (idArtist == -1)
@@ -1445,7 +1445,7 @@ bool CMusicDatabase::GetTop100(const CStdString& strBaseDir, CFileItemList& item
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL="select * from songview "
@@ -1486,7 +1486,7 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // NOTE: The song.idAlbum is needed for the group by, as for some reason group by albumview.idAlbum doesn't work
@@ -1525,7 +1525,7 @@ bool CMusicDatabase::GetTop100AlbumSongs(const CStdString& strBaseDir, CFileItem
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -1566,7 +1566,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -1600,7 +1600,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const CStdString& strBaseDir, C
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -1641,7 +1641,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -1677,7 +1677,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const CStdString& strBaseDir, CF
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -1717,7 +1717,7 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     int idSong = GetSongIDFromPath(item.GetPath());
@@ -1742,7 +1742,7 @@ bool CMusicDatabase::GetSongsByPath(const CStdString& strPath1, MAPSONGS& songs,
     if (!bAppendToMap)
       songs.clear();
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("select * from songview where strPath='%s'", strPath.c_str() );
@@ -1804,7 +1804,7 @@ bool CMusicDatabase::SearchSongs(const CStdString& search, CFileItemList &items)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -1840,7 +1840,7 @@ bool CMusicDatabase::SearchAlbums(const CStdString& search, CFileItemList &album
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -1881,7 +1881,7 @@ int CMusicDatabase::SetAlbumInfo(int idAlbum, const CAlbum& album, const VECSONG
   CStdString strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     if (bTransaction)
@@ -1936,7 +1936,7 @@ int CMusicDatabase::SetArtistInfo(int idArtist, const CArtist& artist)
   CStdString strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     // delete any artist info we may have
@@ -1983,7 +1983,7 @@ bool CMusicDatabase::SetAlbumInfoSongs(int idAlbumInfo, const VECSONGS& songs)
   CStdString strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     strSQL=PrepareSQL("delete from albuminfosong where idAlbumInfo=%i", idAlbumInfo);
@@ -2013,7 +2013,7 @@ bool CMusicDatabase::CleanupSongsByIds(const CStdString &strSongIds)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     // ok, now find all idSong's
     CStdString strSQL=PrepareSQL("select * from song join path on song.idPath = path.idPath where song.idSong in %s", strSongIds.c_str());
@@ -2254,7 +2254,7 @@ bool CMusicDatabase::CleanupGenres()
 bool CMusicDatabase::CleanupOrphanedItems()
 {
   // paths aren't cleaned up here - they're cleaned up in RemoveSongsFromPath()
-  if (NULL == m_pDB.get()) return false;
+  if (isNullDb()) return false;
   if (NULL == m_pDS.get()) return false;
   if (!CleanupAlbums()) return false;
   if (!CleanupArtists()) return false;
@@ -2264,7 +2264,7 @@ bool CMusicDatabase::CleanupOrphanedItems()
 
 int CMusicDatabase::Cleanup(CGUIDialogProgress *pDlgProgress)
 {
-  if (NULL == m_pDB.get()) return ERROR_DATABASE;
+  if (isNullDb()) return ERROR_DATABASE;
   if (NULL == m_pDS.get()) return ERROR_DATABASE;
 
   int ret = ERROR_OK;
@@ -2374,7 +2374,7 @@ void CMusicDatabase::DeleteAlbumInfo()
 {
   // open our database
   Open();
-  if (NULL == m_pDB.get()) return ;
+  if (isNullDb()) return ;
   if (NULL == m_pDS.get()) return ;
 
   // If we are scanning for music info in the background,
@@ -2655,7 +2655,7 @@ bool CMusicDatabase::GetGenresNav(const CStdString& strBaseDir, CFileItemList& i
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // get primary genres for songs - could be simplified to just SELECT * FROM genre?
@@ -2752,7 +2752,7 @@ bool CMusicDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     Filter extFilter = filter;
@@ -2824,7 +2824,7 @@ bool CMusicDatabase::GetAlbumsByYear(const CStdString& strBaseDir, CFileItemList
 
 bool CMusicDatabase::GetCommonNav(const CStdString &strBaseDir, const CStdString &table, const CStdString &labelField, CFileItemList &items, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
+  if (isNullDb()) return false;
   if (NULL == m_pDS.get()) return false;
 
   if (table.empty() || labelField.empty())
@@ -2915,7 +2915,7 @@ bool CMusicDatabase::GetMusicLabelsNav(const CStdString &strBaseDir, CFileItemLi
 
 bool CMusicDatabase::GetArtistsNav(const CStdString& strBaseDir, CFileItemList& items, bool albumArtistsOnly /* = false */, int idGenre /* = -1 */, int idAlbum /* = -1 */, int idSong /* = -1 */, const Filter &filter /* = Filter() */, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
+  if (isNullDb()) return false;
   if (NULL == m_pDS.get()) return false;
   try
   {
@@ -2949,7 +2949,7 @@ bool CMusicDatabase::GetArtistsNav(const CStdString& strBaseDir, CFileItemList& 
 
 bool CMusicDatabase::GetArtistsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
+  if (isNullDb()) return false;
   if (NULL == m_pDS.get()) return false;
 
   try
@@ -3084,7 +3084,7 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL = PrepareSQL("select albumview.* from song join albumview on song.idAlbum = albumview.idAlbum where song.idSong='%i'", idSong);
@@ -3127,7 +3127,7 @@ bool CMusicDatabase::GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& i
 
 bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (m_pDB.get() == NULL || m_pDS.get() == NULL)
+  if (isNullDb() || m_pDS.get() == NULL)
     return false;
 
   try
@@ -3239,7 +3239,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const Filter &f
 
 bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
 {
-  if (m_pDB.get() == NULL || m_pDS.get() == NULL)
+  if (isNullDb() || m_pDS.get() == NULL)
     return false;
 
   try
@@ -3814,7 +3814,7 @@ unsigned int CMusicDatabase::GetSongIDs(const Filter &filter, vector<pair<int,in
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
+    if (isNullDb()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
     CStdString strSQL = "select idSong from songview ";
@@ -3848,7 +3848,7 @@ int CMusicDatabase::GetSongsCount(const Filter &filter)
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
+    if (isNullDb()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
     CStdString strSQL = "select count(idSong) as NumSongs from songview ";
@@ -3878,7 +3878,7 @@ bool CMusicDatabase::GetAlbumPath(int idAlbum, CStdString& path)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     path.Empty();
@@ -3925,7 +3925,7 @@ bool CMusicDatabase::GetArtistPath(int idArtist, CStdString &basePath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     // find all albums from this artist, and all the paths to the songs from those albums
@@ -3984,7 +3984,7 @@ int CMusicDatabase::GetArtistByName(const CStdString& strArtist)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("select idArtist from artist where artist.strArtist like '%s'", strArtist.c_str());
@@ -4012,7 +4012,7 @@ int CMusicDatabase::GetAlbumByName(const CStdString& strAlbum, const CStdString&
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -4061,7 +4061,7 @@ int CMusicDatabase::GetGenreByName(const CStdString& strGenre)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -4089,7 +4089,7 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &f
   {
     idSong = -1;
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted
@@ -4163,7 +4163,7 @@ bool CMusicDatabase::SetPathHash(const CStdString &path, const CStdString &hash)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     if (hash.IsEmpty())
@@ -4192,7 +4192,7 @@ bool CMusicDatabase::GetPathHash(const CStdString &path, CStdString &hash)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
@@ -4244,7 +4244,7 @@ bool CMusicDatabase::RemoveSongsFromPath(const CStdString &path1, MAPSONGS& song
     if (!URIUtils::HasSlashAtEnd(path))
       URIUtils::AddSlashAtEnd(path);
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString where;
@@ -4304,7 +4304,7 @@ bool CMusicDatabase::GetPaths(set<string> &paths)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     paths.clear();
@@ -4337,7 +4337,7 @@ bool CMusicDatabase::SetSongRating(const CStdString &filePath, char rating)
   try
   {
     if (filePath.IsEmpty()) return false;
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     int songID = GetSongIDFromPath(filePath);
@@ -4367,7 +4367,7 @@ int CMusicDatabase::GetSongIDFromPath(const CStdString &filePath)
   // hit the db
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
     CStdString strPath;
     URIUtils::GetDirectory(filePath, strPath);
@@ -4409,7 +4409,7 @@ bool CMusicDatabase::SetScraperForPath(const CStdString& strPath, const ADDON::S
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // wipe old settings
@@ -4434,7 +4434,7 @@ bool CMusicDatabase::GetScraperForPath(const CStdString& strPath, ADDON::Scraper
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL = PrepareSQL("select * from content where strPath='%s'",strPath.c_str());
@@ -4523,7 +4523,7 @@ bool CMusicDatabase::ScraperInUse(const CStdString &scraperID) const
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("select count(1) from content where strScraperPath='%s'",scraperID.c_str());
@@ -4586,7 +4586,7 @@ void CMusicDatabase::ExportToXML(const CStdString &xmlFile, bool singleFiles, bo
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
     if (NULL == m_pDS2.get()) return;
 
@@ -4688,7 +4688,7 @@ void CMusicDatabase::ExportToXML(const CStdString &xmlFile, bool singleFiles, bo
 
     // needed due to getartistpath
     auto_ptr<dbiplus::Dataset> pDS;
-    pDS.reset(m_pDB->CreateDataset());
+    pDS.reset(CreateDataset());
     pDS->query(sql.c_str());
 
     total = pDS->num_rows();
@@ -4778,7 +4778,7 @@ void CMusicDatabase::ImportFromXML(const CStdString &xmlFile)
   CGUIDialogProgress *progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CXBMCTinyXML xmlDoc;
@@ -4904,7 +4904,7 @@ bool CMusicDatabase::GetSongByKaraokeNumber(int number, CSong & song)
   try
   {
     // Get info from karaoke db
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("SELECT * FROM karaokedata where iKaraNumber=%ld", number);
@@ -4933,7 +4933,7 @@ void CMusicDatabase::ExportKaraokeInfo(const CStdString & outFile, bool asHTML)
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     // find all karaoke songs
@@ -5030,7 +5030,7 @@ void CMusicDatabase::ImportKaraokeInfo(const CStdString & inputFile)
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
 
     XFILE::CFile file;
 
@@ -5184,7 +5184,7 @@ bool CMusicDatabase::SetKaraokeSongDelay(int idSong, int delay)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL = PrepareSQL("UPDATE karaokedata SET iKaraDelay=%i WHERE idSong=%i", delay, idSong);
@@ -5204,7 +5204,7 @@ int CMusicDatabase::GetKaraokeSongsCount()
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
+    if (isNullDb()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
     if (!m_pDS->query( "select count(idSong) as NumSongs from karaokedata")) return 0;
@@ -5298,7 +5298,7 @@ void CMusicDatabase::SetArtForItem(int mediaId, const string &mediaType, const s
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     // don't set <foo>.<bar> art types - these are derivative types from parent items
@@ -5331,7 +5331,7 @@ bool CMusicDatabase::GetArtForItem(int mediaId, const string &mediaType, map<str
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     CStdString sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
@@ -5361,7 +5361,7 @@ bool CMusicDatabase::GetArtistArtForItem(int mediaId, const std::string &mediaTy
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     CStdString sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=(SELECT idArtist from %s_artist WHERE id%s=%i AND iOrder=0) AND media_type='artist'", mediaType.c_str(), mediaType.c_str(), mediaId);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -470,7 +470,7 @@ int CVideoDatabase::GetPathId(const CStdString& strPath)
   try
   {
     int idPath=-1;
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strPath1(strPath);
@@ -498,7 +498,7 @@ bool CVideoDatabase::GetPaths(set<CStdString> &paths)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     paths.clear();
@@ -569,7 +569,7 @@ bool CVideoDatabase::GetPathsForTvShow(int idShow, set<int>& paths)
   CStdString strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     strSQL = PrepareSQL("SELECT DISTINCT idPath FROM files JOIN episode ON episode.idFile=files.idFile WHERE episode.idShow=%i",idShow);
     m_pDS->query(strSQL.c_str());
@@ -607,7 +607,7 @@ bool CVideoDatabase::GetSubPaths(const CStdString &basepath, vector< pair<int,st
   CStdString sql;
   try
   {
-    if (!m_pDB.get() || !m_pDS.get())
+    if (isNullDb() || !m_pDS.get())
       return false;
 
     CStdString path(basepath);
@@ -638,7 +638,7 @@ int CVideoDatabase::AddPath(const CStdString& strPath, const CStdString &strDate
     if (idPath >= 0)
       return idPath; // already have the path
 
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strPath1(strPath);
@@ -667,7 +667,7 @@ bool CVideoDatabase::GetPathHash(const CStdString &path, CStdString &hash)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
@@ -692,7 +692,7 @@ int CVideoDatabase::AddFile(const CStdString& strFileNameAndPath)
   try
   {
     int idFile;
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strFileName, strPath;
@@ -740,7 +740,7 @@ void CVideoDatabase::UpdateFileDateAdded(int idFile, const CStdString& strFileNa
   CStdString strSQL = "";
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CStdString file = strFileNameAndPath;
@@ -803,7 +803,7 @@ bool CVideoDatabase::SetPathHash(const CStdString &path, const CStdString &hash)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     if (hash.IsEmpty())
@@ -832,7 +832,7 @@ bool CVideoDatabase::LinkMovieToTvshow(int idMovie, int idShow, bool bRemove)
 {
    try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     if (bRemove) // delete link
@@ -859,7 +859,7 @@ bool CVideoDatabase::IsLinkedToTvshow(int idMovie)
 {
    try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("select * from movielinktvshow where idMovie=%i", idMovie);
@@ -885,7 +885,7 @@ bool CVideoDatabase::GetLinksToTvShow(int idMovie, vector<int>& ids)
 {
    try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL=PrepareSQL("select * from movielinktvshow where idMovie=%i", idMovie);
@@ -913,7 +913,7 @@ int CVideoDatabase::GetFileId(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
     CStdString strPath, strFileName;
     SplitPath(strFilenameAndPath,strPath,strFileName);
@@ -951,7 +951,7 @@ int CVideoDatabase::GetMovieId(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
     int idMovie = -1;
 
@@ -998,7 +998,7 @@ int CVideoDatabase::GetTvShowId(const CStdString& strPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
     int idTvShow = -1;
 
@@ -1047,12 +1047,12 @@ int CVideoDatabase::GetEpisodeId(const CStdString& strFilenameAndPath, int idEpi
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     // need this due to the nested GetEpisodeInfo query
     auto_ptr<Dataset> pDS;
-    pDS.reset(m_pDB->CreateDataset());
+    pDS.reset(CreateDataset());
     if (NULL == pDS.get()) return -1;
 
     int idFile = GetFileId(strFilenameAndPath);
@@ -1103,7 +1103,7 @@ int CVideoDatabase::GetMusicVideoId(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     int idFile = GetFileId(strFilenameAndPath);
@@ -1133,7 +1133,7 @@ int CVideoDatabase::AddMovie(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     int idMovie = GetMovieId(strFilenameAndPath);
@@ -1162,7 +1162,7 @@ int CVideoDatabase::AddTvShow(const CStdString& strPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strSQL=PrepareSQL("select tvshowlinkpath.idShow from path,tvshowlinkpath where path.strPath='%s' and path.idPath=tvshowlinkpath.idPath",strPath.c_str());
@@ -1216,7 +1216,7 @@ int CVideoDatabase::AddEpisode(int idShow, const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     int idFile = AddFile(strFilenameAndPath);
@@ -1239,7 +1239,7 @@ int CVideoDatabase::AddMusicVideo(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     int idMVideo = GetMusicVideoId(strFilenameAndPath);
@@ -1268,7 +1268,7 @@ int CVideoDatabase::AddToTable(const CStdString& table, const CStdString& firstF
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strSQL = PrepareSQL("select %s from %s where %s like '%s'", firstField.c_str(), table.c_str(), secondField.c_str(), value.c_str());
@@ -1333,7 +1333,7 @@ int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& thumb
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
     int idActor = -1;
     CStdString strSQL=PrepareSQL("select idActor from actors where strActor like '%s'", strActor.c_str());
@@ -1375,7 +1375,7 @@ void CVideoDatabase::AddLinkToActor(const char *table, int actorID, const char *
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL=PrepareSQL("select * from %s where idActor=%i and %s=%i", table, actorID, secondField, secondID);
@@ -1398,7 +1398,7 @@ void CVideoDatabase::AddToLinkTable(const char *table, const char *firstField, i
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL = PrepareSQL("select * from %s where %s=%i and %s=%i", table, firstField, firstID, secondField, secondID);
@@ -1426,7 +1426,7 @@ void CVideoDatabase::RemoveFromLinkTable(const char *table, const char *firstFie
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL = PrepareSQL("DELETE FROM %s WHERE %s = %i AND %s = %i", table, firstField, firstID, secondField, secondID);
@@ -1574,7 +1574,7 @@ bool CVideoDatabase::HasMovieInfo(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     int idMovie = GetMovieId(strFilenameAndPath);
     return (idMovie > 0); // index of zero is also invalid
@@ -1590,7 +1590,7 @@ bool CVideoDatabase::HasTvShowInfo(const CStdString& strPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     int idTvShow = GetTvShowId(strPath);
     return (idTvShow > 0); // index of zero is also invalid
@@ -1606,7 +1606,7 @@ bool CVideoDatabase::HasEpisodeInfo(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     int idEpisode = GetEpisodeId(strFilenameAndPath);
     return (idEpisode > 0); // index of zero is also invalid
@@ -1622,7 +1622,7 @@ bool CVideoDatabase::HasMusicVideoInfo(const CStdString& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     int idMVideo = GetMusicVideoId(strFilenameAndPath);
     return (idMVideo > 0); // index of zero is also invalid
@@ -1638,7 +1638,7 @@ void CVideoDatabase::DeleteDetailsForTvShow(const CStdString& strPath, int idTvS
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     if (idTvShow < 0)
@@ -1722,7 +1722,7 @@ void CVideoDatabase::GetMusicVideosByArtist(const CStdString& strArtist, CFileIt
   try
   {
     items.Clear();
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL;
@@ -2082,7 +2082,7 @@ int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoI
 {
   try
   {
-    if (!m_pDB.get() || !m_pDS.get())
+    if (isNullDb() || !m_pDS.get())
     {
       CLog::Log(LOGERROR, "%s: called without database open", __FUNCTION__);
       return -1;
@@ -2436,7 +2436,7 @@ void CVideoDatabase::GetFilePathById(int idMovie, CStdString &filePath, VIDEODB_
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     if (idMovie < 0) return ;
@@ -2491,7 +2491,7 @@ void CVideoDatabase::GetBookMarksForFile(const CStdString& strFilenameAndPath, V
       if (idFile < 0) return ;
       if (!bAppend)
         bookmarks.erase(bookmarks.begin(), bookmarks.end());
-      if (NULL == m_pDB.get()) return ;
+      if (isNullDb()) return ;
       if (NULL == m_pDS.get()) return ;
 
       CStdString strSQL=PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds", idFile, (int)type);
@@ -2541,7 +2541,7 @@ bool CVideoDatabase::GetResumeBookMark(const CStdString& strFilenameAndPath, CBo
 
 void CVideoDatabase::DeleteResumeBookMark(const CStdString &strFilenameAndPath)
 {
-  if (!m_pDB.get() || !m_pDS.get())
+  if (isNullDb() || !m_pDS.get())
     return;
 
   int fileID = GetFileId(strFilenameAndPath);
@@ -2586,7 +2586,7 @@ void CVideoDatabase::AddBookMarkToFile(const CStdString& strFilenameAndPath, con
     int idFile = AddFile(strFilenameAndPath);
     if (idFile < 0)
       return;
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL;
@@ -2631,7 +2631,7 @@ void CVideoDatabase::ClearBookMarkOfFile(const CStdString& strFilenameAndPath, C
   {
     int idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0) return ;
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     /* a litle bit uggly, we clear first bookmark that is within one second of given */
@@ -2668,7 +2668,7 @@ void CVideoDatabase::ClearBookMarksOfFile(const CStdString& strFilenameAndPath, 
   {
     int idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0) return ;
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL=PrepareSQL("delete from bookmark where idFile=%i and type=%i", idFile, (int)type);
@@ -2767,7 +2767,7 @@ void CVideoDatabase::DeleteMovie(const CStdString& strFilenameAndPath, bool bKee
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
     if (idMovie < 0)
     {
@@ -2841,7 +2841,7 @@ void CVideoDatabase::DeleteTvShow(const CStdString& strPath, bool bKeepId /* = f
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
     if (idTvShow < 0)
     {
@@ -2912,7 +2912,7 @@ void CVideoDatabase::DeleteEpisode(const CStdString& strFilenameAndPath, int idE
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
     if (idEpisode < 0)
     {
@@ -2971,7 +2971,7 @@ void CVideoDatabase::DeleteMusicVideo(const CStdString& strFilenameAndPath, bool
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
     if (idMVideo < 0)
     {
@@ -3032,7 +3032,7 @@ void CVideoDatabase::DeleteSet(int idSet)
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL;
@@ -3064,7 +3064,7 @@ void CVideoDatabase::DeleteTag(int idTag, VIDEODB_CONTENT_TYPE mediaType)
 {
   try
   {
-    if (m_pDB.get() == NULL || m_pDS.get() == NULL)
+    if (isNullDb() || m_pDS.get() == NULL)
       return;
 
     std::string type;
@@ -3182,7 +3182,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag) const
   CStreamDetails& details = tag.m_streamDetails;
   details.Reset();
 
-  auto_ptr<Dataset> pDS(m_pDB->CreateDataset());
+  auto_ptr<Dataset> pDS(CreateDataset());
   try
   {
     CStdString strSQL = PrepareSQL("SELECT * FROM streamdetails WHERE idFile = %i", tag.m_iFileId);
@@ -3523,7 +3523,7 @@ void CVideoDatabase::GetCast(const CStdString &table, const CStdString &table_id
 {
   try
   {
-    if (!m_pDB.get()) return;
+    if (isNullDb()) return;
     if (!m_pDS2.get()) return;
 
     CStdString sql = PrepareSQL("SELECT actors.strActor,"
@@ -3576,7 +3576,7 @@ bool CVideoDatabase::GetVideoSettings(const CStdString &strFilenameAndPath, CVid
   {
     // obtain the FileID (if it exists)
 #ifdef NEW_VIDEODB_METHODS
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     CStdString strPath, strFileName;
     URIUtils::Split(strFilenameAndPath, strPath, strFileName);
@@ -3584,7 +3584,7 @@ bool CVideoDatabase::GetVideoSettings(const CStdString &strFilenameAndPath, CVid
 #else
     int idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0) return false;
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     // ok, now obtain the settings for this file
     CStdString strSQL=PrepareSQL("select * from settings where settings.idFile = '%i'", idFile);
@@ -3637,7 +3637,7 @@ void CVideoDatabase::SetVideoSettings(const CStdString& strFilenameAndPath, cons
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
     int idFile = AddFile(strFilenameAndPath);
     if (idFile < 0)
@@ -3699,7 +3699,7 @@ void CVideoDatabase::SetArtForItem(int mediaId, const string &mediaType, const s
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     // don't set <foo>.<bar> art types - these are derivative types from parent items
@@ -3732,7 +3732,7 @@ bool CVideoDatabase::GetArtForItem(int mediaId, const string &mediaType, map<str
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     CStdString sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
@@ -3762,7 +3762,7 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, map<int, map<string, string>
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     // get all seasons for this show
@@ -3796,7 +3796,7 @@ bool CVideoDatabase::GetArtTypes(const std::string &mediaType, std::vector<std::
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("SELECT DISTINCT type FROM art WHERE media_type='%s'", mediaType.c_str());
@@ -3828,7 +3828,7 @@ bool CVideoDatabase::GetStackTimes(const CStdString &filePath, vector<int> &time
     // obtain the FileID (if it exists)
     int idFile = GetFileId(filePath);
     if (idFile < 0) return false;
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
     // ok, now obtain the settings for this file
     CStdString strSQL=PrepareSQL("select times from stacktimes where idFile=%i\n", idFile);
@@ -3861,7 +3861,7 @@ void CVideoDatabase::SetStackTimes(const CStdString& filePath, vector<int> &time
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
     int idFile = AddFile(filePath);
     if (idFile < 0)
@@ -3900,7 +3900,7 @@ void CVideoDatabase::RemoveContentForPath(const CStdString& strPath, CGUIDialogP
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     if (progress)
@@ -3981,7 +3981,7 @@ void CVideoDatabase::SetScraperForPath(const CStdString& filePath, const Scraper
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     int idPath = AddPath(filePath);
@@ -4015,7 +4015,7 @@ bool CVideoDatabase::ScraperInUse(const CStdString &scraperID) const
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("select count(1) from path where strScraper='%s'", scraperID.c_str());
@@ -4519,7 +4519,7 @@ bool CVideoDatabase::GetPlayCounts(const CStdString &strPath, CFileItemList &ite
   try
   {
     // error!
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // TODO: also test a single query for the above and below
@@ -4571,7 +4571,7 @@ int CVideoDatabase::GetPlayCount(const CFileItem &item)
   try
   {
     // error!
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strSQL = PrepareSQL("select playCount from files WHERE idFile=%i", id);
@@ -4594,7 +4594,7 @@ int CVideoDatabase::GetPlayCount(const CFileItem &item)
 
 void CVideoDatabase::UpdateFanart(const CFileItem &item, VIDEODB_CONTENT_TYPE type)
 {
-  if (NULL == m_pDB.get()) return;
+  if (isNullDb()) return;
   if (NULL == m_pDS.get()) return;
   if (!item.HasVideoInfoTag() || item.GetVideoInfoTag()->m_iDbId < 0) return;
 
@@ -4637,7 +4637,7 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
   // and mark as watched
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL;
@@ -4692,7 +4692,7 @@ void CVideoDatabase::UpdateMovieTitle(int idMovie, const CStdString& strNewMovie
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
+    if (isNullDb()) return ;
     if (NULL == m_pDS.get()) return ;
     CStdString content;
     CStdString strSQL;
@@ -4769,7 +4769,7 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -4950,7 +4950,7 @@ bool CVideoDatabase::GetTagsNav(const CStdString& strBaseDir, CFileItemList& ite
 
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL = "SELECT %s FROM taglinks ";
@@ -5037,7 +5037,7 @@ bool CVideoDatabase::GetSetsByWhere(const CStdString& strBaseDir, const Filter &
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CVideoDbUrl videoUrl;
@@ -5073,7 +5073,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL = "select %s from musicvideoview ";
@@ -5225,7 +5225,7 @@ bool CVideoDatabase::GetActorsNav(const CStdString& strBaseDir, CFileItemList& i
 
 bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const CStdString &type, int idContent /* = -1 */, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
+  if (isNullDb()) return false;
   if (NULL == m_pDS.get()) return false;
 
   try
@@ -5442,7 +5442,7 @@ bool CVideoDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
@@ -5606,7 +5606,7 @@ bool CVideoDatabase::GetStackedTvShowList(int idShow, CStdString& strIn) const
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // look for duplicate show titles and stack them into a list
@@ -5641,7 +5641,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // parse the base path to get additional filters
@@ -5830,7 +5830,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
 
 bool CVideoDatabase::GetSortedVideos(MediaType mediaType, const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter /* = Filter() */)
 {
-  if (NULL == m_pDB.get() || NULL == m_pDS.get())
+  if (isNullDb() || NULL == m_pDS.get())
     return false;
 
   if (mediaType != MediaTypeMovie && mediaType != MediaTypeTvShow && mediaType != MediaTypeEpisode && mediaType != MediaTypeMusicVideo)
@@ -6004,7 +6004,7 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter
     movieTime = 0;
     castTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // parse the base path to get additional filters
@@ -6114,7 +6114,7 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filte
   {
     movieTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     int total = -1;
@@ -6433,7 +6433,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filt
     movieTime = 0;
     castTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     int total = -1;
@@ -6611,7 +6611,7 @@ bool CVideoDatabase::HasSets() const
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     m_pDS->query("SELECT movieview.idSet,COUNT(1) AS c FROM movieview "
@@ -6633,7 +6633,7 @@ int CVideoDatabase::GetTvShowForEpisode(int idEpisode)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS2.get()) return false;
 
     // make sure we use m_pDS2, as this is called in loops using m_pDS
@@ -6676,7 +6676,7 @@ bool CVideoDatabase::HasContent(VIDEODB_CONTENT_TYPE type)
   bool result = false;
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql;
@@ -6704,7 +6704,7 @@ int CVideoDatabase::GetMusicVideoCount(const CStdString& strWhere)
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
+    if (isNullDb()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
     CStdString strSQL;
@@ -6742,7 +6742,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const CStdString& strPath, SScanSet
   foundDirectly = false;
   try
   {
-    if (strPath.IsEmpty() || !m_pDB.get() || !m_pDS.get()) return ScraperPtr();
+    if (strPath.IsEmpty() || isNullDb() || !m_pDS.get()) return ScraperPtr();
 
     ScraperPtr scraper;
     CStdString strPath1;
@@ -6912,7 +6912,7 @@ void CVideoDatabase::GetMovieGenresByName(const CStdString& strSearch, CFileItem
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -6953,7 +6953,7 @@ void CVideoDatabase::GetMovieCountriesByName(const CStdString& strSearch, CFileI
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -6994,7 +6994,7 @@ void CVideoDatabase::GetTvShowGenresByName(const CStdString& strSearch, CFileIte
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7034,7 +7034,7 @@ void CVideoDatabase::GetMovieActorsByName(const CStdString& strSearch, CFileItem
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7074,7 +7074,7 @@ void CVideoDatabase::GetTvShowsActorsByName(const CStdString& strSearch, CFileIt
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7114,7 +7114,7 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const CStdString& strSearch, CFi
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CStdString strLike;
@@ -7157,7 +7157,7 @@ void CVideoDatabase::GetMusicVideoGenresByName(const CStdString& strSearch, CFil
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7197,7 +7197,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const CStdString& strSearch, CFil
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CStdString strLike;
@@ -7253,7 +7253,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const CStdString& strSearch, CFileIte
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7295,7 +7295,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filt
     movieTime = 0;
     castTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     int total = -1;
@@ -7373,7 +7373,7 @@ unsigned int CVideoDatabase::GetMusicVideoIDs(const CStdString& strWhere, vector
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
+    if (isNullDb()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
     CStdString strSQL = "select distinct idMVideo from musicvideoview " + strWhere;
@@ -7406,7 +7406,7 @@ bool CVideoDatabase::GetRandomMusicVideo(CFileItem* item, int& idSong, const CSt
   {
     idSong = -1;
 
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted.
@@ -7442,7 +7442,7 @@ int CVideoDatabase::GetMatchingMusicVideo(const CStdString& strArtist, const CSt
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
+    if (isNullDb()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strSQL;
@@ -7489,7 +7489,7 @@ void CVideoDatabase::GetMoviesByName(const CStdString& strSearch, CFileItemList&
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7534,7 +7534,7 @@ void CVideoDatabase::GetTvShowsByName(const CStdString& strSearch, CFileItemList
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7576,7 +7576,7 @@ void CVideoDatabase::GetEpisodesByName(const CStdString& strSearch, CFileItemLis
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7619,7 +7619,7 @@ void CVideoDatabase::GetMusicVideosByName(const CStdString& strSearch, CFileItem
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7667,7 +7667,7 @@ void CVideoDatabase::GetEpisodesByPlot(const CStdString& strSearch, CFileItemLis
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7706,7 +7706,7 @@ void CVideoDatabase::GetMoviesByPlot(const CStdString& strSearch, CFileItemList&
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7748,7 +7748,7 @@ void CVideoDatabase::GetMovieDirectorsByName(const CStdString& strSearch, CFileI
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7790,7 +7790,7 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const CStdString& strSearch, CFil
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7832,7 +7832,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const CStdString& strSearch, C
 
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
@@ -7873,7 +7873,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
   CGUIDialogProgress *progress=NULL;
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     unsigned int time = XbmcThreads::SystemClockMillis();
@@ -8331,17 +8331,17 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
   CGUIDialogProgress *progress=NULL;
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
     if (NULL == m_pDS2.get()) return;
 
     // create a 3rd dataset as well as GetEpisodeDetails() etc. uses m_pDS2, and we need to do 3 nested queries on tv shows
     auto_ptr<Dataset> pDS;
-    pDS.reset(m_pDB->CreateDataset());
+    pDS.reset(CreateDataset());
     if (NULL == pDS.get()) return;
 
     auto_ptr<Dataset> pDS2;
-    pDS2.reset(m_pDB->CreateDataset());
+    pDS2.reset(CreateDataset());
     if (NULL == pDS2.get()) return;
 
     // if we're exporting to a single folder, we export thumbs as well
@@ -8897,7 +8897,7 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
   CGUIDialogProgress *progress=NULL;
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CXBMCTinyXML xmlDoc;
@@ -9144,7 +9144,7 @@ void CVideoDatabase::SetDetail(const CStdString& strDetail, int id, int field,
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
+    if (isNullDb()) return;
     if (NULL == m_pDS.get()) return;
 
     CStdString strTable, strField;

--- a/xbmc/view/ViewDatabase.cpp
+++ b/xbmc/view/ViewDatabase.cpp
@@ -106,7 +106,7 @@ bool CViewDatabase::GetViewState(const CStdString &path, int window, CViewState 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString path1(path);
@@ -141,7 +141,7 @@ bool CViewDatabase::SetViewState(const CStdString &path, int window, const CView
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString path1(path);
@@ -175,7 +175,7 @@ bool CViewDatabase::ClearViewStates(int windowID)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
+    if (isNullDb()) return false;
     if (NULL == m_pDS.get()) return false;
 
     CStdString sql = PrepareSQL("delete from view where window = %i", windowID);


### PR DESCRIPTION
Assuming sqlite is compiled in multithreading mode (see http://www.sqlite.org/threadsafe.html ) then we at least need to protect the database instance.
