### PR TITLE
fixed: Folder.jpg didn't work for music folders with multiple albums

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -941,24 +941,13 @@ void CMusicInfoScanner::FixupAlbums(VECALBUMS &albums)
 
 void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const CStdString &path)
 {
-  /*
-   If there's a single album in the folder, then art can be taken from
-   the folder art.
-   */
+  CFileItem folderItem(path, true);
+  std::string folderArt = folderItem.GetUserMusicThumb(true);
+
   std::string albumArt;
-  if (albums.size() == 1)
-  {
-    CFileItem album(path, true);
-    albumArt = album.GetUserMusicThumb(true);
-    if (!albumArt.empty())
-      albums[0].art["thumb"] = albumArt;
-  }
   for (VECALBUMS::iterator i = albums.begin(); i != albums.end(); ++i)
   {
     CAlbum &album = *i;
-
-    if (albums.size() != 1)
-      albumArt = "";
 
     /*
      Find art that is common across these items
@@ -984,10 +973,11 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const CStdString &pa
     }
 
     /*
-      assign the first art found to the album - better than no art at all
+      In case of a single album in this folder use folder.jpg for album and fallback to first found song art (if any)
+      Additionally with multiple albums, overrule folder art if common art for all songs was found
     */
-
-    if (art && albumArt.empty())
+    albumArt = folderArt;
+    if (art && (albumArt.empty() || (albums.size() > 1 && singleArt) ) )
     {
       if (!art->strThumb.empty())
         albumArt = art->strThumb;
@@ -1012,12 +1002,17 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const CStdString &pa
       }
     }
   }
-  if (albums.size() == 1 && !albumArt.empty())
+
+  // In case we have no folderArt, use albumArt if it's a single album
+  if (folderArt.empty() && albums.size() == 1)
+    folderArt = albumArt;
+
+  if (!folderArt.empty())
   {
     // assign to folder thumb as well
-    CFileItem albumItem(path, true);
+    CFileItem folderItem(path, true);
     CMusicThumbLoader loader;
-    loader.SetCachedImage(albumItem, "thumb", albumArt);
+    loader.SetCachedImage(folderItem, "thumb", folderArt);
   }
 }
 


### PR DESCRIPTION
Currently we eg. don't fallback to folder.jpg for music folder holding more than one album. This PR changes (and improves) the logic involved to properly choose fallback art in such cases.
