### PR TITLE
Fix return from fullscreen for linux/gnome not returning to previous size.

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -26,6 +26,7 @@
 #include "Application.h"
 #include "ApplicationMessenger.h"
 #include "GUIUserMessages.h"
+#include "settings/DisplaySettings.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #ifdef HAS_SDL_JOYSTICK
@@ -363,6 +364,16 @@ bool CWinEventsSDL::MessagePump()
       }
       case SDL_VIDEORESIZE:
       {
+        // Under linux returning from fullscreen, SDL sends an extra event to resize to the desktop
+        // resolution causing the previous window dimensions to be lost. This is needed to rectify
+        // that problem.
+        if(!g_Windowing.IsFullScreen())
+        {
+          int RES_SCREEN = g_Windowing.DesktopResolution(g_Windowing.GetCurrentScreen());
+          if((event.resize.w == CDisplaySettings::Get().GetResolutionInfo(RES_SCREEN).iWidth) &&
+              (event.resize.h == CDisplaySettings::Get().GetResolutionInfo(RES_SCREEN).iHeight))
+            break;
+        }
         XBMC_Event newEvent;
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = event.resize.w;


### PR DESCRIPTION
Seems I am not the only one with this issue. Not sure the exact test cases that cause this issue but under linux/gnome when returning from fullscreen mode to window mode. There is a window resize event sent to XBMC after exiting fullscreen that sets it to the size of current desktop resolution after setting it to the previous window size, resulting in an unwanted maximized window. This simple fix just checks if the resize event is the same dimensions as the desktop resolution while NOT in fullscreen to avoid a resize. Has only been tested on linux mint 15 (cinnamon). Since this case should never happen anyways seems like a reasonable quick fix. Possible to cause resize issues with hidden task bars when maximizing the widow though, this is untested. 
