### PR TITLE
Stop using AVCODEC_MAX_AUDIO_FRAME_SIZE in (L)Pcm decoders.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.cpp
@@ -24,8 +24,13 @@
 CDVDAudioCodecLPcm::CDVDAudioCodecLPcm() : CDVDAudioCodecPcm()
 {
   m_codecID = AV_CODEC_ID_NONE;
-  m_bufferSize = LPCM_BUFFER_SIZE;
-  memset(m_buffer, 0, sizeof(m_buffer));
+  m_bufferSize = 0;
+  m_buffer = NULL;
+}
+
+CDVDAudioCodecLPcm::~CDVDAudioCodecLPcm()
+{
+  delete m_buffer;
 }
 
 bool CDVDAudioCodecLPcm::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
@@ -48,7 +53,14 @@ int CDVDAudioCodecLPcm::Decode(uint8_t* pData, int iSize)
   uint8_t* d = m_buffer;
   uint8_t* s = pData;
 
-  if (iSize > m_bufferSize) iSize = m_bufferSize;
+  if (iSize > m_bufferSize)
+  {
+    delete m_buffer;
+    d = m_buffer = new uint8_t[iSize];
+    if(!m_buffer)
+      return -1;
+    m_bufferSize = iSize;
+  }
 
   if (iSize >= 12)
   {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.h
@@ -39,4 +39,8 @@ protected:
   uint8_t *m_buffer;
 
   AVCodecID m_codecID;
+
+private:
+  CDVDAudioCodecLPcm(const CDVDAudioCodecLPcm&);
+  CDVDAudioCodecLPcm const& operator=(CDVDAudioCodecLPcm const&);
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.h
@@ -24,13 +24,11 @@
 #include "DVDCodecs/DVDCodecs.h"
 #include "DVDAudioCodecPcm.h"
 
-#define LPCM_BUFFER_SIZE (AVCODEC_MAX_AUDIO_FRAME_SIZE / 2)
-
 class CDVDAudioCodecLPcm : public CDVDAudioCodecPcm
 {
 public:
   CDVDAudioCodecLPcm();
-  virtual ~CDVDAudioCodecLPcm() {}
+  virtual ~CDVDAudioCodecLPcm();
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
   virtual int Decode(uint8_t* pData, int iSize);
   virtual const char* GetName()  { return "lpcm"; }
@@ -38,7 +36,7 @@ public:
 protected:
 
   int m_bufferSize;
-  uint8_t m_buffer[LPCM_BUFFER_SIZE];
+  uint8_t *m_buffer;
 
   AVCodecID m_codecID;
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.cpp
@@ -116,13 +116,15 @@ CDVDAudioCodecPcm::CDVDAudioCodecPcm() : CDVDAudioCodec()
   m_codecID = AV_CODEC_ID_NONE;
   m_iOutputChannels = 0;
 
-  memset(m_decodedData, 0, sizeof(m_decodedData));
+  m_decodedData = NULL;
+  m_decodedDataBufSize = 0;
   memset(table, 0, sizeof(table));
 }
 
 CDVDAudioCodecPcm::~CDVDAudioCodecPcm()
 {
   Dispose();
+  delete m_decodedData;
 }
 
 bool CDVDAudioCodecPcm::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
@@ -172,8 +174,14 @@ int CDVDAudioCodecPcm::Decode(uint8_t* pData, int iSize)
     src = pData;
     int buf_size = iSize;
 
-    if (iSize > AVCODEC_MAX_AUDIO_FRAME_SIZE / 2)
-        iSize = AVCODEC_MAX_AUDIO_FRAME_SIZE / 2;
+    if (iSize > m_decodedDataBufSize)
+    {
+        delete m_decodedData;
+        samples = m_decodedData = new short[iSize];
+        if(!m_decodedData)
+            return -1;
+        m_decodedDataBufSize = iSize;
+    }
 
     switch (m_codecID)
     {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
@@ -41,7 +41,8 @@ public:
 protected:
   virtual void SetDefault();
 
-  short m_decodedData[131072]; // could be a bit to big
+  short* m_decodedData;
+  int m_decodedDataBufSize;
   int m_decodedDataSize;
 
   AVCodecID m_codecID;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
@@ -53,4 +53,8 @@ protected:
   int m_iOutputChannels;
 
   short table[256];
+
+private:
+  CDVDAudioCodecPcm(const CDVDAudioCodecPcm&);
+  CDVDAudioCodecPcm const& operator=(CDVDAudioCodecPcm const&);
 };


### PR DESCRIPTION
This constant has been deprecated and is now gone in FFmpeg 2.0.

There still remains some usages of this constant in xbmc code but the files are not built in my setup so that this PR finally lets me build xbmc against FFmpeg 2.0 / git master.
