### PR TITLE
Kill USE_EXTERNAL_FFMPEG usage in xbmc/* code

### DIFF
--- a/xbmc/cores/dvdplayer/DVDAudio.h
+++ b/xbmc/cores/dvdplayer/DVDAudio.h
@@ -30,17 +30,7 @@
 #include "cores/AudioEngine/Utils/AEChannelInfo.h"
 class IAEStream;
 
-extern "C" {
-#if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
-    #include <libavcodec/avcodec.h>
-  #elif (defined HAVE_FFMPEG_AVCODEC_H)
-    #include <ffmpeg/avcodec.h>
-  #endif
-#else
-  #include "libavcodec/avcodec.h"
-#endif
-}
+#include "DllAvCodec.h"
 
 typedef struct stDVDAudioFrame DVDAudioFrame;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecs.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecs.h
@@ -28,30 +28,6 @@
 #include <vector>
 #include "cores/VideoRenderers/RenderFormats.h"
 
-extern "C" {
-#ifndef HAVE_MMX
-#define HAVE_MMX
-#endif
-#ifndef __STDC_CONSTANT_MACROS
-#define __STDC_CONSTANT_MACROS
-#endif
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-#ifndef __GNUC__
-#pragma warning(disable:4244)
-#endif
-#if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
-    #include <libavcodec/avcodec.h>
-  #else
-    #include <ffmpeg/avcodec.h>
-  #endif
-#else
-  #include "libavcodec/avcodec.h"
-#endif
-}
-
 // 0x100000 is the video starting range
 
 // 0x200000 is the audio starting range

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -34,22 +34,7 @@ class CDVDInputStream;
 #if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
   #include "config.h"
 #endif
-#ifndef TARGET_POSIX
-// enum AVCodecID; // auto defined when neccesary
-#include <libavcodec/avcodec.h>
-#else
-extern "C" {
-#if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
-    #include <libavcodec/avcodec.h>
-  #elif (defined HAVE_FFMPEG_AVCODEC_H)
-    #include <ffmpeg/avcodec.h>
-  #endif
-#else
-  #include "libavcodec/avcodec.h"
-#endif
-}
-#endif
+#include "DllAvCodec.h"
 
 #ifndef __GNUC__
 #pragma warning(pop)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1186,9 +1186,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
     case AVMEDIA_TYPE_ATTACHMENT:
       { //mkv attachments. Only bothering with fonts for now.
         if(pStream->codec->codec_id == AV_CODEC_ID_TTF
-#if (!defined USE_EXTERNAL_FFMPEG)
           || pStream->codec->codec_id == AV_CODEC_ID_OTF
-#endif
           )
         {
           std::string fileName = "special://temp/fonts/";

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
@@ -24,22 +24,6 @@
 #include "DllAvCodec.h"
 #include "DllAvFormat.h"
 
-#ifndef TARGET_POSIX
-#include <libavformat/avformat.h>
-#else
-extern "C" {
-#if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVFORMAT_AVFORMAT_H)
-    #include <libavformat/avformat.h>
-  #elif (defined HAVE_FFMPEG_AVFORMAT_H)
-    #include <ffmpeg/avformat.h>
-  #endif
-#else
-  #include "libavformat/avformat.h"
-#endif
-}
-#endif
-
 #include "pvr/addons/PVRClient.h"
 
 class CDVDDemuxPVRClient;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -24,17 +24,7 @@
 #include "DVDDemuxUtils.h"
 #include "DVDClock.h"
 #include "utils/log.h"
-extern "C" {
-#if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
-    #include <libavcodec/avcodec.h>
-  #else
-    #include <ffmpeg/avcodec.h>
-  #endif
-#else
-  #include "libavcodec/avcodec.h"
-#endif
-}
+#include "DllAvCodec.h"
 
 void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
 {

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.h
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.h
@@ -25,17 +25,7 @@
 #endif
 
 #include "DVDDemuxers/DVDDemux.h"
-extern "C" {
-#if (defined USE_EXTERNAL_FFMPEG)
-  #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
-    #include <libavcodec/avcodec.h>
-  #elif (defined HAVE_FFMPEG_AVCODEC_H)
-    #include <ffmpeg/avcodec.h>
-  #endif
-#else
-  #include "libavcodec/avcodec.h"
-#endif
-}
+#include "DllAvCodec.h"
 
 class CDemuxStream;
 


### PR DESCRIPTION
This makes the code under xbmc/\* agnostic to the usage of internal or external ffmpeg.

All but the last commit are mainly cosmetic changes. The last commit enables a feature for external ffmpeg that used to be disabled but since the minimum required ffmpeg version for building xbmc includes that feature there is no point in disabling it anymore.
