### PR TITLE
paplayer: fix gain for mp3 files

### DIFF
--- a/xbmc/cores/paplayer/MP3codec.cpp
+++ b/xbmc/cores/paplayer/MP3codec.cpp
@@ -90,7 +90,7 @@ MP3Codec::MP3Codec()
   m_InputBufferPos = 0;
 
   memset(&m_Formatdata,0,sizeof(m_Formatdata));
-  m_DataFormat = AE_FMT_S32NE;
+  m_DataFormat = AE_FMT_FLOAT;
 
   // create our output buffer
   m_OutputBufferSize = OUTPUTFRAMESIZE * 4;        // enough for 4 frames
@@ -557,15 +557,15 @@ madx_sig MP3Codec::madx_read(madx_house *mxhouse, madx_stat *mxstat, int maxwrit
   mxhouse->frame_cnt++;
   m_dll.mad_timer_add( &mxhouse->timer, mxhouse->frame.header.duration );
 
-  int32_t *dest = (int32_t*)mxhouse->output_ptr;
+  float *dest = (float *)mxhouse->output_ptr;
   for(int i=0; i < mxhouse->synth.pcm.length; i++)
   {
     // Left channel
-    *dest++ = (int32_t)(mxhouse->synth.pcm.samples[0][i] << 2);
+    *dest++ = mad_f_todouble(mxhouse->synth.pcm.samples[0][i]);
 
     // Right channel
     if(MAD_NCHANNELS(&mxhouse->frame.header) == 2)
-      *dest++ = (int32_t)(mxhouse->synth.pcm.samples[1][i] << 2);
+      *dest++ = mad_f_todouble(mxhouse->synth.pcm.samples[1][i]);
   }
 
   // Tell calling code buffer size


### PR DESCRIPTION
This will make MP3 (and possibly MP1/MP2, don't have any files encoded as L1/L2 for testing) files played via paplayer reproduced with correct gain/loudness.

Some background:
I wondered for a long time why any of my mp3 files are replayed with reduced volume/gain, while any other format (FLAC, Vorbis et al) played back right, compared with any other audio player (e.g. Audacious, WinAMP or "lame --decode"), and wasn't able to improve by playing with ReplayGain settings or "audiophile=1". After looking at how libmad works and paplayer/MP3codec.cpp handles this, I found samples are bitshifted (converted) from mad's fixfloat (28bit) to AE_32bit_signed one bit off. While this saves some CPU cycles by not having to apply clipping, it results in reduced gain. Normally, the applied clipping shouldn't be neccessary at all or at least very seldom (the way mp3 works causes some clipping anyway at maxgain source files) and happens with any audio player, and the increased precision is still there with this commit.

Compiled and tested on linux with SoftAE in "analog" and "hdmi" mode (guess other engines and platforms will just work)

(Yes, the clipping is duplicated code, but I preferred this to be inline to save the cycles of function calling, and I didn't get this into a macro/#define...)

EDIT: commit updated, found out that due to format conversion in CAEConvert, audio could clip beyond INT32_MAX - 127 (could go to INT32_MAX) causing crackles at 100% volume (gone when lowering to 98%), thus now clipping the result.
