### PR TITLE
VAAPI: Add check for maximum surface count in EnsureSurfaces

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -396,6 +396,12 @@ bool CDecoder::EnsureSurfaces(AVCodecContext *avctx, unsigned n_surfaces_count)
 {
   CLog::Log(LOGDEBUG, "VAAPI - making sure %d surfaces are allocated for given %d references", n_surfaces_count, avctx->refs);
 
+  if(n_surfaces_count > m_surfaces_max)
+  {
+    CLog::Log(LOGERROR, "VAAPI - Failed to ensure surfaces! Requested %d surfaces. Maximum possible count is %d!", n_surfaces_count, m_surfaces_max);
+    return false;
+  }
+
   if(n_surfaces_count <= m_surfaces_count)
     return true;
 


### PR DESCRIPTION
EnsureSurfaces does not check if the requested number of surfaces exceeds the hardcoded maximum count.
If for example the renderer stalls and keeps too many surfaces, it'll keep allocating more surfaces, and at one point start writing beyond the maximum 32 array-elements, which causes weird crashes.

This patch simply adds a check to EnsureSurfaces, so it just fails if too many surfaces are requested.

@fritsch
@elupus
