### PR TITLE
DllAvCodec.h: Stop mapping avcodec_default_{get,release}_buffer.

### DIFF
--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -92,8 +92,6 @@ public:
   virtual void av_free_packet(AVPacket *pkt)=0;
   virtual int avpicture_alloc(AVPicture *picture, PixelFormat pix_fmt, int width, int height)=0;
   virtual enum PixelFormat avcodec_default_get_format(struct AVCodecContext *s, const enum PixelFormat *fmt)=0;
-  virtual int avcodec_default_get_buffer(AVCodecContext *s, AVFrame *pic)=0;
-  virtual void avcodec_default_release_buffer(AVCodecContext *s, AVFrame *pic)=0;
   virtual AVCodec *av_codec_next(AVCodec *c)=0;
   virtual int av_dup_packet(AVPacket *pkt)=0;
   virtual void av_init_packet(AVPacket *pkt)=0;
@@ -161,8 +159,6 @@ public:
   virtual void avpicture_free(AVPicture *picture) { ::avpicture_free(picture); }
   virtual void av_free_packet(AVPacket *pkt) { ::av_free_packet(pkt); }
   virtual int avpicture_alloc(AVPicture *picture, PixelFormat pix_fmt, int width, int height) { return ::avpicture_alloc(picture, pix_fmt, width, height); }
-  virtual int avcodec_default_get_buffer(AVCodecContext *s, AVFrame *pic) { return ::avcodec_default_get_buffer(s, pic); }
-  virtual void avcodec_default_release_buffer(AVCodecContext *s, AVFrame *pic) { ::avcodec_default_release_buffer(s, pic); }
   virtual enum PixelFormat avcodec_default_get_format(struct AVCodecContext *s, const enum PixelFormat *fmt) { return ::avcodec_default_get_format(s, fmt); }
   virtual AVCodec *av_codec_next(AVCodec *c) { return ::av_codec_next(c); }
 
@@ -216,8 +212,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
   DEFINE_METHOD1(void, av_bitstream_filter_close, (AVBitStreamFilterContext *p1))
   DEFINE_METHOD1(void, av_free_packet, (AVPacket *p1))
   DEFINE_METHOD4(int, avpicture_alloc, (AVPicture *p1, PixelFormat p2, int p3, int p4))
-  DEFINE_METHOD2(int, avcodec_default_get_buffer, (AVCodecContext *p1, AVFrame *p2))
-  DEFINE_METHOD2(void, avcodec_default_release_buffer, (AVCodecContext *p1, AVFrame *p2))
   DEFINE_METHOD2(enum PixelFormat, avcodec_default_get_format, (struct AVCodecContext *p1, const enum PixelFormat *p2))
   DEFINE_METHOD6(int, avcodec_fill_audio_frame, (AVFrame* p1, int p2, enum AVSampleFormat p3, const uint8_t* p4, int p5, int p6))
   DEFINE_METHOD1(void, avcodec_free_frame, (AVFrame **p1))
@@ -250,8 +244,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
     RESOLVE_METHOD(avpicture_free)
     RESOLVE_METHOD(avpicture_alloc)
     RESOLVE_METHOD(av_free_packet)
-    RESOLVE_METHOD(avcodec_default_get_buffer)
-    RESOLVE_METHOD(avcodec_default_release_buffer)
     RESOLVE_METHOD(avcodec_default_get_format)
     RESOLVE_METHOD(av_codec_next)
     RESOLVE_METHOD(av_dup_packet)


### PR DESCRIPTION
Those are unused in xbmc code and deprecated in FFmpeg 2.0.
This removes the related deprecation warnings.
