### PR TITLE
Extend and clarify startup log information

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -685,8 +685,8 @@ bool CApplication::Create()
   CLog::Log(LOGNOTICE, "Running on %s", g_sysinfo.GetKernelVersion().c_str());
 #endif
   
+  CLog::Log(LOGNOTICE, "Host CPU: %s", g_cpuInfo.getCPUModel().c_str());
 #if defined(TARGET_WINDOWS)
-  CLog::Log(LOGNOTICE, "%s", g_cpuInfo.getCPUModel().c_str());
   CLog::Log(LOGNOTICE, "%s", CWIN32Util::GetResInfoString().c_str());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");
   CLog::Log(LOGNOTICE, "Aero is %s", (g_sysinfo.IsAeroDisabled() == true) ? "disabled" : "enabled");

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -657,9 +657,9 @@ bool CApplication::Create()
   CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (MSVC version %i). Platform: %s", g_infoManager.GetVersion().c_str(), _MSC_VER, g_sysinfo.GetKernelVersion().c_str());
 #endif
 #if defined(_DEBUG)
-  CLog::Log(LOGINFO, "Using Debug XBMC build");
+  CLog::Log(LOGNOTICE, "Using Debug XBMC build");
 #elif defined(NDEBUG)
-  CLog::Log(LOGINFO, "Using Release XBMC build");
+  CLog::Log(LOGNOTICE, "Using Release XBMC build");
 #endif
 #if defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "%s", g_cpuInfo.getCPUModel().c_str());

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -650,6 +650,8 @@ bool CApplication::Create()
   std::string compilerStr;
 #if defined(__clang__)
   compilerStr = "Clang " XSTR_MACRO(__clang_major__) "." XSTR_MACRO(__clang_minor__) "." XSTR_MACRO(__clang_patchlevel__);
+#elif defined (__INTEL_COMPILER)
+  compilerStr = "Intel Compiler " XSTR_MACRO(__INTEL_COMPILER);
 #elif defined (__GNUC__)
 #ifdef __llvm__
   /* Note: this will not detect GCC + DragonEgg */

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -676,7 +676,7 @@ bool CApplication::Create()
 #if defined(TARGET_DARWIN_OSX)
   CLog::Log(LOGNOTICE, "Running on Darwin OSX %s", g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_DARWIN_IOS)
-  CLog::Log(LOGNOTICE, "Running on Darwin iOS %s", g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Running on Darwin iOS%s %s", g_sysinfo.IsAppleTV2() ? " (AppleTV2)" : "", g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_FREEBSD)
   CLog::Log(LOGNOTICE, "Running on FreeBSD %s", g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_POSIX)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -641,26 +641,50 @@ bool CApplication::Create()
   CProfilesManager::Get().Load();
 
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
-#if defined(TARGET_DARWIN_OSX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: Darwin OSX (%s)", 
-              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
-#elif defined(TARGET_DARWIN_IOS)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: Darwin iOS (%s)",
-              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
-#elif defined(TARGET_FREEBSD)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: FreeBSD (%s)",
-              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetUnameVersion().c_str());
-#elif defined(TARGET_POSIX)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (GCC version %i.%i.%i). Platform: Linux (%s, %s)",
-              g_infoManager.GetVersion().c_str(), __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
-#elif defined(TARGET_WINDOWS)
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s), Built on " __DATE__ " (MSVC version %i). Platform: %s", g_infoManager.GetVersion().c_str(), _MSC_VER, g_sysinfo.GetKernelVersion().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s). Platform: %s", g_infoManager.GetVersion().c_str(), g_sysinfo.GetBuildTargetPlatformName().c_str());
+
+/* Expand macro before stringify */
+#define STR_MACRO(x) #x
+#define XSTR_MACRO(x) STR_MACRO(x)
+
+  std::string compilerStr;
+#if defined(__clang__)
+  compilerStr = "Clang " XSTR_MACRO(__clang_major__) "." XSTR_MACRO(__clang_minor__) "." XSTR_MACRO(__clang_patchlevel__);
+#elif defined (__GNUC__)
+#ifdef __llvm__
+  /* Note: this will not detect GCC + DragonEgg */
+  compilerStr = "llvm-gcc "; 
+#else // __llvm__
+  compilerStr = "GCC ";
+#endif // !__llvm__
+  compilerStr += XSTR_MACRO(__GNUC__) "." XSTR_MACRO(__GNUC_MINOR__) "." XSTR_MACRO(__GNUC_PATCHLEVEL__);
+#elif defined (_MSC_VER)
+  compilerStr = "MSVC " XSTR_MACRO(_MSC_FULL_VER);
+#else
+  compilerStr = "unknown compiler";
 #endif
+  std::string buildType;
 #if defined(_DEBUG)
-  CLog::Log(LOGNOTICE, "Using Debug XBMC build");
+  buildType = "Debug";
 #elif defined(NDEBUG)
-  CLog::Log(LOGNOTICE, "Using Release XBMC build");
+  buildType = "Release";
+#else
+  buildType = "Unknown";
 #endif
+  CLog::Log(LOGNOTICE, "Using %s XBMC build, compiled " __DATE__ " by %s for %s %s", buildType.c_str(), compilerStr.c_str(), g_sysinfo.GetBuildTargetPlatformName().c_str(), g_sysinfo.GetBuildTargetPlatformVersion().c_str());
+
+#if defined(TARGET_DARWIN_OSX)
+  CLog::Log(LOGNOTICE, "Running on Darwin OSX %s", g_sysinfo.GetUnameVersion().c_str());
+#elif defined(TARGET_DARWIN_IOS)
+  CLog::Log(LOGNOTICE, "Running on Darwin iOS %s", g_sysinfo.GetUnameVersion().c_str());
+#elif defined(TARGET_FREEBSD)
+  CLog::Log(LOGNOTICE, "Running on FreeBSD %s", g_sysinfo.GetUnameVersion().c_str());
+#elif defined(TARGET_POSIX)
+  CLog::Log(LOGNOTICE, "Running on Linux (%s, %s)", g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
+#elif defined(TARGET_WINDOWS)
+  CLog::Log(LOGNOTICE, "Running on %s", g_sysinfo.GetKernelVersion().c_str());
+#endif
+  
 #if defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "%s", g_cpuInfo.getCPUModel().c_str());
   CLog::Log(LOGNOTICE, "%s", CWIN32Util::GetResInfoString().c_str());

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -85,6 +85,7 @@
 
 #include "log.h"
 #include "settings/AdvancedSettings.h"
+#include "utils/StringUtils.h"
 
 using namespace std;
 
@@ -383,6 +384,8 @@ CCPUInfo::CCPUInfo(void)
   }
 
 #endif
+  StringUtils::RemoveDuplicatedSpacesAndTabs(m_cpuModel);
+
   /* Set some default for empty string variables */
   if (m_cpuBogoMips.empty())
     m_cpuBogoMips = "N/A";

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -165,6 +165,33 @@ std::string& StringUtils::TrimRight(std::string &str)
   return str;
 }
 
+std::string& StringUtils::RemoveDuplicatedSpacesAndTabs(std::string& str)
+{
+  std::string::iterator it = str.begin();
+  bool onSpace = false;
+  while(it != str.end())
+  {
+    if (*it == '\t')
+      *it = ' ';
+
+    if (*it == ' ')
+    {
+      if (onSpace)
+      {
+        it = str.erase(it);
+        continue;
+      }
+      else
+        onSpace = true;
+    }
+    else
+      onSpace = false;
+
+    ++it;
+  }
+  return str;
+}
+
 int StringUtils::Replace(string &str, char oldChar, char newChar)
 {
   int replacedChars = 0;

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -61,6 +61,7 @@ public:
   static std::string& Trim(std::string &str);
   static std::string& TrimLeft(std::string &str);
   static std::string& TrimRight(std::string &str);
+  static std::string& RemoveDuplicatedSpacesAndTabs(std::string& str);
   static int Replace(std::string &str, char oldChar, char newChar);
   static int Replace(std::string &str, const std::string &oldStr, const std::string &newStr);
   static bool StartsWith(const std::string &str, const std::string &str2, bool useCase = false);

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -48,6 +48,17 @@
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 
+/* Target identification */
+#if defined(TARGET_DARWIN)
+#include <Availability.h>
+#elif defined(TARGET_ANDROID)
+#include <android/api-level.h>
+#elif defined(TARGET_FREEBSD)
+#include <sys/param.h>
+#elif defined(TARGET_LINUX)
+#include <linux/version.h>
+#endif
+
 CSysInfo g_sysinfo;
 
 CSysInfoJob::CSysInfoJob()
@@ -806,6 +817,52 @@ bool CSysInfo::HasVideoToolBoxDecoder()
 #endif
   return result;
 }
+
+std::string CSysInfo::GetBuildTargetPlatformName(void)
+{
+#if defined(TARGET_DARWIN_OSX)
+  return "Darwin OSX";
+#elif defined(TARGET_DARWIN_IOS_ATV2)
+  return "Darwin iOS ATV2";
+#elif defined(TARGET_DARWIN_IOS)
+  return "Darwin iOS";
+#elif defined(TARGET_FREEBSD)
+  return "FreeBSD";
+#elif defined(TARGET_ANDROID)
+  return "Android";
+#elif defined(TARGET_LINUX)
+  return "Linux";
+#elif defined(TARGET_WINDOWS)
+  return "Win32";
+#else
+  return "unknown platform";
+#endif
+}
+
+std::string CSysInfo::GetBuildTargetPlatformVersion(void)
+{
+/* Expand macro before stringify */
+#define STR_MACRO(x) #x
+#define XSTR_MACRO(x) STR_MACRO(x)
+
+#if defined(TARGET_DARWIN_OSX)
+  return "version " XSTR_MACRO(__MAC_OS_X_VERSION_MIN_REQUIRED);
+#elif defined(TARGET_DARWIN_IOS)
+  return "version " XSTR_MACRO(__IPHONE_OS_VERSION_MIN_REQUIRED);
+#elif defined(TARGET_FREEBSD)
+  return "version " XSTR_MACRO(__FreeBSD_version);
+#elif defined(TARGET_ANDROID)
+  return "API level " XSTR_MACRO(__ANDROID_API__);
+#elif defined(TARGET_LINUX)
+  std::string ver = StringUtils::Format("%i.%i.%i", LINUX_VERSION_CODE >> 16, (LINUX_VERSION_CODE >> 8) & 0xff, LINUX_VERSION_CODE & 0xff);
+  return ver;
+#elif defined(TARGET_WINDOWS)
+  return "version " XSTR_MACRO(NTDDI_VERSION);
+#else
+  return "(unknown platform)";
+#endif
+}
+
 
 CJob *CSysInfo::GetJob() const
 {

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -134,6 +134,9 @@ public:
   int GetTotalUptime() const { return m_iSystemTimeTotalUp; }
   void SetTotalUptime(int uptime) { m_iSystemTimeTotalUp = uptime; }
 
+  static std::string GetBuildTargetPlatformName(void);
+  static std::string GetBuildTargetPlatformVersion(void);
+
 protected:
   virtual CJob *GetJob() const;
   virtual CStdString TranslateInfo(int info) const;


### PR DESCRIPTION
As continuation for PR #1556
Now logged separately build-time information and run-time information.
Clang compiler detection was added.
Fixed log info about release build.
