### PR TITLE
Modernize libavfilter usage

### DIFF
--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -42,11 +42,13 @@ extern "C" {
 #endif
 
 #if (defined USE_EXTERNAL_FFMPEG)
+  #include <libavfilter/avfilter.h>
   #include <libavfilter/avfiltergraph.h>
   #include <libavfilter/buffersink.h>
   #include <libavfilter/avcodec.h>
   #include <libavfilter/buffersrc.h>
 #else
+  #include "libavfilter/avfilter.h"
   #include "libavfilter/avfiltergraph.h"
   #include "libavfilter/buffersink.h"
   #include "libavfilter/avcodec.h"

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -97,10 +97,8 @@ public:
 #if (defined(LIBAVFILTER_FROM_LIBAV) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(3,5,0)) || \
     (defined(LIBAVFILTER_FROM_FFMPEG) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(3,43,100))
   virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame *frame)=0;
-#elif defined(LIBAVFILTER_FROM_FFMPEG) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,72,105)
-  virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
 #else
-  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
+  virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
 #endif
 #if !defined(LIBAVFILTER_AVFRAME_BASED)
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref)=0;
@@ -177,10 +175,8 @@ public:
 #if (defined(LIBAVFILTER_FROM_LIBAV) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(3,5,0)) || \
     (defined(LIBAVFILTER_FROM_FFMPEG) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(3,43,100))
   virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame* frame) { return ::av_buffersrc_add_frame(buffer_filter, frame); }
-#elif defined(LIBAVFILTER_FROM_FFMPEG) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,72,105)
-  virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame* frame, int flags) { return ::av_buffersrc_add_frame(buffer_filter, frame, flags); }
 #else
-  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
+  virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame* frame, int flags) { return ::av_buffersrc_add_frame(buffer_filter, frame, flags); }
 #endif
 #if !defined(LIBAVFILTER_AVFRAME_BASED)
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref) { ::avfilter_unref_buffer(ref); }
@@ -231,10 +227,8 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
 #if (defined(LIBAVFILTER_FROM_LIBAV) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(3,5,0)) || \
     (defined(LIBAVFILTER_FROM_FFMPEG) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(3,43,100))
   DEFINE_METHOD2(int, av_buffersrc_add_frame, (AVFilterContext *p1, AVFrame *p2))
-#elif defined(LIBAVFILTER_FROM_FFMPEG) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,72,105)
-  DEFINE_METHOD3(int, av_buffersrc_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
 #else
-  DEFINE_METHOD3(int, av_vsrc_buffer_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
+  DEFINE_METHOD3(int, av_buffersrc_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
 #endif
 #if !defined(LIBAVFILTER_AVFRAME_BASED)
   DEFINE_METHOD1(void, avfilter_unref_buffer, (AVFilterBufferRef *p1))
@@ -265,11 +259,7 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
     RESOLVE_METHOD_RENAME(avfilter_graph_parse, avfilter_graph_parse_dont_call)
 #endif
     RESOLVE_METHOD_RENAME(avfilter_graph_config, avfilter_graph_config_dont_call)
-#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,0,0)
-    RESOLVE_METHOD(av_vsrc_buffer_add_frame)
-#else
     RESOLVE_METHOD(av_buffersrc_add_frame)
-#endif
 #if !defined(LIBAVFILTER_AVFRAME_BASED)
     RESOLVE_METHOD(avfilter_unref_buffer)
 #endif

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -67,7 +67,6 @@ class DllAvFilterInterface
 {
 public:
   virtual ~DllAvFilterInterface() {}
-  virtual int avfilter_open(AVFilterContext **filter_ctx, AVFilter *filter, const char *inst_name)=0;
   virtual void avfilter_free(AVFilterContext *filter)=0;
   virtual void avfilter_graph_free(AVFilterGraph **graph)=0;
   virtual int avfilter_graph_create_filter(AVFilterContext **filt_ctx, AVFilter *filt, const char *name, const char *args, void *opaque, AVFilterGraph *graph_ctx)=0;
@@ -98,11 +97,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
 {
 public:
   virtual ~DllAvFilter() {}
-  virtual int avfilter_open(AVFilterContext **filter_ctx, AVFilter *filter, const char *inst_name)
-  {
-    CSingleLock lock(DllAvCodec::m_critSection);
-    return ::avfilter_open(filter_ctx, filter, inst_name);
-  }
   virtual void avfilter_free(AVFilterContext *filter)
   {
     CSingleLock lock(DllAvCodec::m_critSection);
@@ -170,7 +164,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
 
   LOAD_SYMBOLS()
 
-  DEFINE_METHOD3(int, avfilter_open_dont_call, (AVFilterContext **p1, AVFilter *p2, const char *p3))
   DEFINE_METHOD1(void, avfilter_free_dont_call, (AVFilterContext *p1))
   DEFINE_METHOD1(void, avfilter_graph_free_dont_call, (AVFilterGraph **p1))
   DEFINE_METHOD0(void, avfilter_register_all_dont_call)
@@ -196,7 +189,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
   DEFINE_FUNC_ALIGNED1(int                , __cdecl, av_buffersink_poll_frame, AVFilterContext *);
 
   BEGIN_METHOD_RESOLVE()
-    RESOLVE_METHOD_RENAME(avfilter_open, avfilter_open_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_free, avfilter_free_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_free, avfilter_graph_free_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_register_all, avfilter_register_all_dont_call)
@@ -225,11 +217,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
   DllAvFormat m_dllAvFormat;
 
 public:
-  int avfilter_open(AVFilterContext **filter_ctx, AVFilter *filter, const char *inst_name)
-  {
-    CSingleLock lock(DllAvCodec::m_critSection);
-    return avfilter_open_dont_call(filter_ctx, filter, inst_name);
-  }
   void avfilter_free(AVFilterContext *filter)
   {
     CSingleLock lock(DllAvCodec::m_critSection);

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -45,13 +45,17 @@ extern "C" {
   #include <libavfilter/avfilter.h>
   #include <libavfilter/avfiltergraph.h>
   #include <libavfilter/buffersink.h>
+#if LIBAVFILTER_VERSION_MICRO >= 100 && LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,43,100)
   #include <libavfilter/avcodec.h>
+#endif
   #include <libavfilter/buffersrc.h>
 #else
   #include "libavfilter/avfilter.h"
   #include "libavfilter/avfiltergraph.h"
   #include "libavfilter/buffersink.h"
+#if LIBAVFILTER_VERSION_MICRO >= 100 && LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,43,100)
   #include "libavfilter/avcodec.h"
+#endif
   #include "libavfilter/buffersrc.h"
 #endif
 }

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -59,6 +59,13 @@ extern "C" {
 #endif
 }
 
+#if LIBAVUTIL_VERSION_MICRO >= 100
+  #define LIBAVUTIL_FROM_FFMPEG
+#else
+  #define LIBAVUTIL_FROM_LIBAV
+#endif
+
+
 #ifndef __GNUC__
 #pragma warning(pop)
 #endif

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -116,6 +116,7 @@ public:
 #if defined(AVFRAME_IN_LAVU)
   virtual void av_frame_free(AVFrame **frame)=0;
   virtual AVFrame *av_frame_alloc(void)=0;
+  virtual void av_frame_unref(AVFrame *frame)=0;
 #endif
 };
 
@@ -168,6 +169,7 @@ public:
 #if defined(AVFRAME_IN_LAVU)
   virtual void av_frame_free(AVFrame **frame) { return ::av_frame_free(frame); }
   virtual AVFrame *av_frame_alloc() { return ::av_frame_alloc(); }
+  virtual void av_frame_unref(AVFrame *frame) { return ::av_frame_unref(frame); }
 #endif
 
    // DLL faking.
@@ -224,6 +226,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
 #if defined(AVFRAME_IN_LAVU)
   DEFINE_METHOD1(void, av_frame_free, (AVFrame **p1))
   DEFINE_METHOD0(AVFrame *, av_frame_alloc)
+  DEFINE_METHOD1(void, av_frame_unref, (AVFrame *p1))
 #endif
 
   public:
@@ -263,6 +266,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
 #if defined(AVFRAME_IN_LAVU)
     RESOLVE_METHOD(av_frame_free)
     RESOLVE_METHOD(av_frame_alloc)
+    RESOLVE_METHOD(av_frame_unref)
 #endif
   END_METHOD_RESOLVE()
 };

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -65,6 +65,10 @@ extern "C" {
   #define LIBAVUTIL_FROM_LIBAV
 #endif
 
+#if (defined LIBAVUTIL_FROM_FFMPEG && LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(52,29,100)) || \
+    (defined LIBAVUTIL_FROM_LIBAV  && LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(52,8,0))
+#define AVFRAME_IN_LAVU
+#endif
 
 #ifndef __GNUC__
 #pragma warning(pop)
@@ -109,6 +113,9 @@ public:
   virtual int av_get_channel_layout_channel_index (uint64_t channel_layout, uint64_t channel) = 0;
   virtual int av_samples_fill_arrays(uint8_t **audio_data, int *linesize, const uint8_t *buf, int nb_channels, int nb_samples, enum AVSampleFormat sample_fmt, int align) = 0;
   virtual int av_samples_copy(uint8_t **dst, uint8_t *const *src, int dst_offset, int src_offset, int nb_samples, int nb_channels, enum AVSampleFormat sample_fmt) = 0;
+#if defined(AVFRAME_IN_LAVU)
+  virtual void av_frame_free(AVFrame **frame)=0;
+#endif
 };
 
 #if defined (USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
@@ -157,6 +164,9 @@ public:
     { return ::av_samples_fill_arrays(audio_data, linesize, buf, nb_channels, nb_samples, AVSampleFormat sample_fmt, align); }
   virtual int av_samples_copy(uint8_t **dst, uint8_t *const *src, int dst_offset, int src_offset, int nb_samples, int nb_channels, enum AVSampleFormat sample_fmt)
     { return ::av_samples_copy(dst, src, dst_offset, src_offset, nb_samples, nb_channels, sample_fmt); }
+#if defined(AVFRAME_IN_LAVU)
+  virtual void av_frame_free(AVFrame **frame) { return ::av_frame_free(frame); }
+#endif
 
    // DLL faking.
    virtual bool ResolveExports() { return true; }
@@ -209,6 +219,9 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
   DEFINE_METHOD2(int, av_get_channel_layout_channel_index, (uint64_t p1, uint64_t p2))
   DEFINE_METHOD7(int, av_samples_fill_arrays, (uint8_t **p1, int *p2, const uint8_t *p3, int p4, int p5, enum AVSampleFormat p6, int p7))
   DEFINE_METHOD7(int, av_samples_copy, (uint8_t **p1, uint8_t *const *p2, int p3, int p4, int p5, int p6, enum AVSampleFormat p7))
+#if defined(AVFRAME_IN_LAVU)
+  DEFINE_METHOD1(void, av_frame_free, (AVFrame **p1))
+#endif
 
   public:
   BEGIN_METHOD_RESOLVE()
@@ -244,6 +257,9 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
     RESOLVE_METHOD(av_get_channel_layout_channel_index)
     RESOLVE_METHOD(av_samples_fill_arrays)
     RESOLVE_METHOD(av_samples_copy)
+#if defined(AVFRAME_IN_LAVU)
+    RESOLVE_METHOD(av_frame_free)
+#endif
   END_METHOD_RESOLVE()
 };
 

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -115,6 +115,7 @@ public:
   virtual int av_samples_copy(uint8_t **dst, uint8_t *const *src, int dst_offset, int src_offset, int nb_samples, int nb_channels, enum AVSampleFormat sample_fmt) = 0;
 #if defined(AVFRAME_IN_LAVU)
   virtual void av_frame_free(AVFrame **frame)=0;
+  virtual AVFrame *av_frame_alloc(void)=0;
 #endif
 };
 
@@ -166,6 +167,7 @@ public:
     { return ::av_samples_copy(dst, src, dst_offset, src_offset, nb_samples, nb_channels, sample_fmt); }
 #if defined(AVFRAME_IN_LAVU)
   virtual void av_frame_free(AVFrame **frame) { return ::av_frame_free(frame); }
+  virtual AVFrame *av_frame_alloc() { return ::av_frame_alloc(); }
 #endif
 
    // DLL faking.
@@ -221,6 +223,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
   DEFINE_METHOD7(int, av_samples_copy, (uint8_t **p1, uint8_t *const *p2, int p3, int p4, int p5, int p6, enum AVSampleFormat p7))
 #if defined(AVFRAME_IN_LAVU)
   DEFINE_METHOD1(void, av_frame_free, (AVFrame **p1))
+  DEFINE_METHOD0(AVFrame *, av_frame_alloc)
 #endif
 
   public:
@@ -259,6 +262,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
     RESOLVE_METHOD(av_samples_copy)
 #if defined(AVFRAME_IN_LAVU)
     RESOLVE_METHOD(av_frame_free)
+    RESOLVE_METHOD(av_frame_alloc)
 #endif
   END_METHOD_RESOLVE()
 };

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -117,6 +117,7 @@ public:
   virtual void av_frame_free(AVFrame **frame)=0;
   virtual AVFrame *av_frame_alloc(void)=0;
   virtual void av_frame_unref(AVFrame *frame)=0;
+  virtual void av_frame_move_ref(AVFrame *dst, AVFrame *src)=0;
 #endif
 };
 
@@ -170,6 +171,7 @@ public:
   virtual void av_frame_free(AVFrame **frame) { return ::av_frame_free(frame); }
   virtual AVFrame *av_frame_alloc() { return ::av_frame_alloc(); }
   virtual void av_frame_unref(AVFrame *frame) { return ::av_frame_unref(frame); }
+  virtual void av_frame_move_ref(AVFrame *dst, AVFrame *src) { return ::av_frame_move_ref(dst,src); }
 #endif
 
    // DLL faking.
@@ -227,6 +229,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
   DEFINE_METHOD1(void, av_frame_free, (AVFrame **p1))
   DEFINE_METHOD0(AVFrame *, av_frame_alloc)
   DEFINE_METHOD1(void, av_frame_unref, (AVFrame *p1))
+  DEFINE_METHOD2(void, av_frame_move_ref, (AVFrame *p1, AVFrame* p2))
 #endif
 
   public:
@@ -267,6 +270,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
     RESOLVE_METHOD(av_frame_free)
     RESOLVE_METHOD(av_frame_alloc)
     RESOLVE_METHOD(av_frame_unref)
+    RESOLVE_METHOD(av_frame_move_ref)
 #endif
   END_METHOD_RESOLVE()
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -842,17 +842,15 @@ int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
     // libav: commit 7e350379f87e7f74420b4813170fe808e2313911 (28 Nov 2012)
     //        release v9 (5 January 2013)
     result = m_dllAvFilter.av_buffersrc_add_frame(m_pFilterIn, frame);
-#elif defined(LIBAVFILTER_FROM_FFMPEG) && LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,72,105)
+#else
     // API changed in:
     // ffmpeg: commit 7bac2a78c2241df4bcc1665703bb71afd9a3e692 (28 Apr 2012)
     //         release 0.11 (25 May 2012)
     result = m_dllAvFilter.av_buffersrc_add_frame(m_pFilterIn, frame, 0);
-#else
-    result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, 0);
 #endif
     if (result < 0)
     {
-      CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterProcess - av_buffersrc_add_frame/av_vsrc_buffer_add_frame");
+      CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterProcess - av_buffersrc_add_frame");
       return VC_ERROR;
     }
   }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -775,7 +775,13 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const CStdString& filters, bool scale)
     inputs->pad_idx = 0;
     inputs->next    = NULL;
 
+#if defined(HAVE_AVFILTER_GRAPH_PARSE_PTR)
+    if ((result = m_dllAvFilter.avfilter_graph_parse_ptr(m_pFilterGraph, (const char*)m_filters.c_str(), &inputs, &outputs, NULL)) < 0)
+#elif defined(AVFILTER_GRAPH_PARSE_TAKES_PTR_PTR_ARG)
     if ((result = m_dllAvFilter.avfilter_graph_parse(m_pFilterGraph, (const char*)m_filters.c_str(), &inputs, &outputs, NULL)) < 0)
+#else
+    if ((result = m_dllAvFilter.avfilter_graph_parse(m_pFilterGraph, (const char*)m_filters.c_str(), inputs, outputs, NULL)) < 0)
+#endif
     {
       CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterOpen - avfilter_graph_parse");
       return result;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -99,7 +99,11 @@ protected:
   AVFilterGraph*   m_pFilterGraph;
   AVFilterContext* m_pFilterIn;
   AVFilterContext* m_pFilterOut;
+#if defined(LIBAVFILTER_AVFRAME_BASED)
+  AVFrame*         m_pFilterFrame;
+#else
   AVFilterBufferRef* m_pBufferRef;
+#endif
 
   int m_iPictureWidth;
   int m_iPictureHeight;


### PR DESCRIPTION
Use the refcounted frame based API and clean up the deprecation warnings with FFmpeg 2.0.
