### PR TITLE
RenderCapture implementation for RPi

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoRenderers/RenderCapture.cpp
@@ -54,7 +54,43 @@ bool CRenderCaptureBase::UseOcclusionQuery()
     return true;
 }
 
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(TARGET_RASPBERRY_PI)
+
+CRenderCaptureDispmanX::CRenderCaptureDispmanX()
+{
+}
+
+CRenderCaptureDispmanX::~CRenderCaptureDispmanX()
+{
+	delete[] m_pixels;
+}
+
+int CRenderCaptureDispmanX::GetCaptureFormat()
+{
+	return CAPTUREFORMAT_BGRA;
+}
+
+void CRenderCaptureDispmanX::BeginRender()
+{
+}
+
+void CRenderCaptureDispmanX::EndRender()
+{
+	m_pixels = g_RBP.CaptureDisplay(m_width, m_height, NULL, true);
+
+	SetState(CAPTURESTATE_DONE);
+}
+
+void* CRenderCaptureDispmanX::GetRenderBuffer()
+{
+    return m_pixels;
+}
+
+void CRenderCaptureDispmanX::ReadOut()
+{
+}
+
+#elif defined(HAS_GL) || defined(HAS_GLES)
 
 CRenderCaptureGL::CRenderCaptureGL()
 {

--- a/xbmc/cores/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoRenderers/RenderCapture.h
@@ -172,7 +172,33 @@ class CRenderCaptureBase
     bool             m_asyncChecked;
 };
 
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(TARGET_RASPBERRY_PI)
+#include "xbmc/linux/RBP.h"
+
+class CRenderCaptureDispmanX : public CRenderCaptureBase
+{
+  public:
+    CRenderCaptureDispmanX();
+    ~CRenderCaptureDispmanX();
+
+    int   GetCaptureFormat();
+
+    void  BeginRender();
+    void  EndRender();
+    void  ReadOut();
+
+    void* GetRenderBuffer();
+};
+
+//used instead of typedef CRenderCaptureGL CRenderCapture
+//since C++ doesn't allow you to forward declare a typedef
+class CRenderCapture : public CRenderCaptureDispmanX
+{
+  public:
+    CRenderCapture() {};
+};
+
+#elif defined(HAS_GL) || defined(HAS_GLES)
 #include "system_gl.h"
 
 class CRenderCaptureGL : public CRenderCaptureBase


### PR DESCRIPTION
This is an implementation of the RenderCapture interface for RPi.
This was done in order to be able to make boblight work on RPi
