### PR TITLE
[EGL] Fix the non-trivial dirty rectangle modes

### DIFF
--- a/xbmc/windowing/egl/EGLWrapper.cpp
+++ b/xbmc/windowing/egl/EGLWrapper.cpp
@@ -390,5 +390,12 @@ void* CEGLWrapper::GetProcAddress(const char* function)
   
   return ext;
 }
+
+bool CEGLWrapper::SurfaceAttrib(EGLDisplay display, EGLSurface surface, EGLint attribute, EGLint value)
+{
+  if ((display == EGL_NO_DISPLAY) || (surface == EGL_NO_SURFACE))
+    return false;
+  return eglSurfaceAttrib(display, surface, attribute, value);
+}
 #endif
 

--- a/xbmc/windowing/egl/EGLWrapper.h
+++ b/xbmc/windowing/egl/EGLWrapper.h
@@ -62,6 +62,7 @@ public:
   bool SetVSync(EGLDisplay display, bool enable);
   bool IsExtSupported(const char* extension);
   bool GetConfigAttrib(EGLDisplay display, EGLConfig config, EGLint attribute, EGLint *value);
+  bool SurfaceAttrib(EGLDisplay display, EGLSurface surface, EGLint  attribute, EGLint  value);
 
   static void* GetProcAddress(const char* function);
   

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -25,6 +25,8 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
+#include "guilib/IDirtyRegionSolver.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/DisplaySettings.h"
 #include "utils/log.h"
@@ -95,6 +97,12 @@ bool CWinSystemEGL::InitWindowSystem()
     return false;
   }
 
+  EGLint surface_type = EGL_WINDOW_BIT;
+  // for the non-trivial dirty region modes, we need the EGL buffer to be preserved across updates
+  if (g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
+      g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_UNION)
+    surface_type |= EGL_SWAP_BEHAVIOR_PRESERVED_BIT;
+
   EGLint configAttrs [] = {
         EGL_RED_SIZE,        8,
         EGL_GREEN_SIZE,      8,
@@ -104,7 +112,7 @@ bool CWinSystemEGL::InitWindowSystem()
         EGL_STENCIL_SIZE,    0,
         EGL_SAMPLE_BUFFERS,  0,
         EGL_SAMPLES,         0,
-        EGL_SURFACE_TYPE,    EGL_WINDOW_BIT,
+        EGL_SURFACE_TYPE,    surface_type,
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
         EGL_NONE
   };
@@ -190,6 +198,14 @@ bool CWinSystemEGL::CreateWindow(RESOLUTION_INFO &res)
   {
     CLog::Log(LOGERROR, "%s: Could not bind to context",__FUNCTION__);
     return false;
+  }
+
+  // for the non-trivial dirty region modes, we need the EGL buffer to be preserved across updates
+  if (g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
+      g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_UNION)
+  {
+    if (!m_egl->SurfaceAttrib(m_display, m_surface, EGL_SWAP_BEHAVIOR, EGL_BUFFER_PRESERVED))
+      CLog::Log(LOGDEBUG, "%s: Could not set EGL_SWAP_BEHAVIOR",__FUNCTION__);
   }
 
   m_bWindowCreated = true;


### PR DESCRIPTION
EGL is typically double or triple buffered, and the previous buffer contents are not preserved.
This means the non-trivial dirty rectangle modes display a flickery mess.

EGL does provide a means for requesting the EGL buffer is preserved across calls.
It seems appropriate to request that when using dirty rectangle modes.

This PR makes algorithmdirtyregions 1 and 2 work on the Raspberry Pi.
It needs testing on other EGL platforms.
