### PR TITLE
Backup and restore corrupted guisettings.xml

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3335,17 +3335,17 @@ void CApplication::Stop(int exitCode)
     {
       CLog::Log(LOGNOTICE, "Saving settings");
       CSettings::Get().Save();
+
+      // Delete settings backup file
+      if (CFile::Exists(URIUtils::GetBackupPath(CProfilesManager::Get().GetSettingsFile())))
+        CFile::Delete(URIUtils::GetBackupPath(CProfilesManager::Get().GetSettingsFile()));
+
+      // Save new settings backup file
+      CLog::Log(LOGNOTICE, "Saving settings to backup file");
+      CSettings::Get().Save(URIUtils::GetBackupPath(CProfilesManager::Get().GetSettingsFile()));
     }
     else
       CLog::Log(LOGNOTICE, "Not saving settings (settings.xml is not present)");
-
-    // Delete settings backup file
-    if (CFile::Exists(CProfilesManager::Get().GetSettingsFile().append(".bak")))
-      CFile::Delete(CProfilesManager::Get().GetSettingsFile().append(".bak"));
-
-    // Save new settings backup file
-    CLog::Log(LOGNOTICE, "Saving settings to backup file");
-    CSettings::Get().Save(CProfilesManager::Get().GetSettingsFile().append(".bak"));
 
     m_bStop = true;
     m_AppFocused = false;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3339,6 +3339,14 @@ void CApplication::Stop(int exitCode)
     else
       CLog::Log(LOGNOTICE, "Not saving settings (settings.xml is not present)");
 
+    // Delete settings backup file
+    if (CFile::Exists(CProfilesManager::Get().GetSettingsFile().append(".bak")))
+      CFile::Delete(CProfilesManager::Get().GetSettingsFile().append(".bak"));
+
+    // Save new settings backup file
+    CLog::Log(LOGNOTICE, "Saving settings to backup file");
+    CSettings::Get().Save(CProfilesManager::Get().GetSettingsFile().append(".bak"));
+
     m_bStop = true;
     m_AppFocused = false;
     m_ExitCode = exitCode;

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -510,6 +510,7 @@ std::string CProfilesManager::GetLibraryFolder() const
 
 std::string CProfilesManager::GetSettingsFile() const
 {
+  CStdString settings;
   if (m_currentProfile == 0)
     return "special://masterprofile/guisettings.xml";
 

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -510,7 +510,6 @@ std::string CProfilesManager::GetLibraryFolder() const
 
 std::string CProfilesManager::GetSettingsFile() const
 {
-  CStdString settings;
   if (m_currentProfile == 0)
     return "special://masterprofile/guisettings.xml";
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -275,22 +275,28 @@ bool CSettings::Initialize()
 
 bool CSettings::Load()
 {
-  return Load(CProfilesManager::Get().GetSettingsFile());
+  if (!Load(CProfilesManager::Get().GetSettingsFile()))
+  {
+    // Loading failed, try to reset settings to backup/defaults
+    if (!Reset())
+      return false;
+  }
+
+  return true;
 }
 
 bool CSettings::Load(const std::string &file)
 {
   CXBMCTinyXML xmlDoc;
   bool updated = false;
+
+  CLog::Log(LOGNOTICE, "CSettingsManager: loading settings from %s", file.c_str());
+
   if (!XFILE::CFile::Exists(file) || !xmlDoc.LoadFile(file) ||
       !m_settingsManager->Load(xmlDoc.RootElement(), updated))
   {
-    CLog::Log(LOGERROR, "CSettingsManager: unable to load settings from %s, creating new default settings", file.c_str());
-    if (!Reset())
-      return false;
-
-    if (!Load(file))
-      return false;
+    CLog::Log(LOGERROR, "CSettingsManager: unable to load settings from %s", file.c_str());
+    return false;
   }
   // if the settings had to be updated, we need to save the changes
   else if (updated)
@@ -961,19 +967,32 @@ void CSettings::InitializeISettingCallbacks()
 bool CSettings::Reset()
 {
   std::string settingsFile = CProfilesManager::Get().GetSettingsFile();
+  std::string settingsBackupFile = CProfilesManager::Get().GetSettingsFile().append(".bak");
+
   // try to delete the settings file
   if (XFILE::CFile::Exists(settingsFile, false) && !XFILE::CFile::Delete(settingsFile))
     CLog::Log(LOGWARNING, "Unable to delete old settings file at %s", settingsFile.c_str());
-  
+
   // unload any loaded settings
   Unload();
+
+  // try to load backup settings
+  bool restored = Load(settingsBackupFile);
+  if (!restored)
+  {
+    CLog::Log(LOGERROR, "Failed to load the backup settings from %s, fallback to default settings", settingsBackupFile.c_str());
+    Unload();
+  }
 
   // try to save the default settings
   if (!Save())
   {
-    CLog::Log(LOGWARNING, "Failed to save the default settings to %s", settingsFile.c_str());
+    CLog::Log(LOGWARNING, "Failed to save the restored/default settings to %s", settingsFile.c_str());
     return false;
   }
 
-  return true;
+  if (!restored)
+    restored = Load(settingsFile);
+
+  return restored;
 }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -79,6 +79,7 @@
 #include "utils/SystemInfo.h"
 #include "utils/Weather.h"
 #include "utils/XBMCTinyXML.h"
+#include "utils/URIUtils.h"
 #include "view/ViewStateSettings.h"
 #include "windowing/WindowingFactory.h"
 
@@ -967,7 +968,7 @@ void CSettings::InitializeISettingCallbacks()
 bool CSettings::Reset()
 {
   std::string settingsFile = CProfilesManager::Get().GetSettingsFile();
-  std::string settingsBackupFile = CProfilesManager::Get().GetSettingsFile().append(".bak");
+  std::string settingsBackupFile = URIUtils::GetBackupPath(settingsFile);
 
   // try to delete the settings file
   if (XFILE::CFile::Exists(settingsFile, false) && !XFILE::CFile::Delete(settingsFile))

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1144,3 +1144,18 @@ bool URIUtils::UpdateUrlEncoding(std::string &strFilename)
   strFilename = newFilename;
   return true;
 }
+
+std::string URIUtils::GetBackupPath(const std::string &strPath)
+{
+  std::string strReturn = strPath;
+
+  if (strReturn.length() > 0)
+  {
+    if (HasSlashAtEnd(strReturn))
+      strReturn.insert(strReturn.length() - 1,".bak");
+    else
+      strReturn.append(".bak");
+  }
+
+  return strReturn;
+}

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -158,6 +158,17 @@ public:
    */
   static bool UpdateUrlEncoding(std::string &strFilename);
 
+  /*!
+   \brief Get the backup path for the given path
+
+   This method is used to return the backup file for the given settings file
+   by adding '.bak' at the end.
+
+   \param strPath path to settings file
+   \return Actual path to settings backup file
+   */
+  static std::string URIUtils::GetBackupPath(const std::string &strPath);
+
 private:
   static std::string resolvePath(const std::string &path);
 };


### PR DESCRIPTION
Guisettings.xml is heavily used by xbmc (many read/write operations), hereby this file easely gets corrupted when xbmc crashes,OS crashes, power cut,...

This sucks big time as xbmc will recover guisettings.xml to its defaults!

With this PR: A backup from guisettings.xml will be made each time xbmc closes and the settings will be restored from this backup if necessary.

Very usefull for the raspberry pi, as most people just pull out the power cord and risks corroption (guisettings.xml)  by doing that.
