### PR TITLE
FIX: [droid] restore system volume on exit

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -85,6 +85,7 @@ CEvent CXBMCApp::m_windowCreated;
 ANativeActivity *CXBMCApp::m_activity = NULL;
 ANativeWindow* CXBMCApp::m_window = NULL;
 int CXBMCApp::m_batteryLevel = 0;
+int CXBMCApp::m_initialVolume = 0;
 
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity)
   : CJNIContext(nativeActivity)
@@ -132,6 +133,10 @@ void CXBMCApp::onResume()
 void CXBMCApp::onPause()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
+
+  // Restore volume
+  SetSystemVolume(m_initialVolume);
+
   unregisterReceiver(*this);
 }
 
@@ -246,6 +251,8 @@ void CXBMCApp::run()
   int status = 0;
 
   SetupEnv();
+  
+  m_initialVolume = GetSystemVolume();
 
   CJNIIntent startIntent = getIntent();
   android_printf("XBMC Started with action: %s\n",startIntent.getAction().c_str());
@@ -511,6 +518,27 @@ int CXBMCApp::GetMaxSystemVolume(JNIEnv *env)
     return audioManager.getStreamMaxVolume();
     android_printf("CXBMCApp::SetSystemVolume: Could not get Audio Manager");
   return 0;
+}
+
+int CXBMCApp::GetSystemVolume()
+{
+  CJNIAudioManager audioManager(getSystemService("audio"));
+  if (audioManager)
+    return audioManager.getStreamVolume();
+  else 
+  {
+    android_printf("CXBMCApp::GetSystemVolume: Could not get Audio Manager");
+    return 0;
+  }
+}
+
+void CXBMCApp::SetSystemVolume(int val)
+{
+  CJNIAudioManager audioManager(getSystemService("audio"));
+  if (audioManager)
+    audioManager.setStreamVolume(val);
+  else
+    android_printf("CXBMCApp::SetSystemVolume: Could not get Audio Manager");
 }
 
 void CXBMCApp::SetSystemVolume(JNIEnv *env, float percent)

--- a/xbmc/android/activity/XBMCApp.h
+++ b/xbmc/android/activity/XBMCApp.h
@@ -99,6 +99,8 @@ public:
   static bool GetExternalStorage(std::string &path, const std::string &type = "");
   static bool GetStorageUsage(const std::string &path, std::string &usage);
   static int GetMaxSystemVolume();
+  static int GetSystemVolume();
+  static void SetSystemVolume(int val);
 
   static int GetDPI();
 protected:
@@ -118,6 +120,7 @@ private:
   static ANativeActivity *m_activity;
   CJNIWakeLock *m_wakeLock;
   static int m_batteryLevel;  
+  static int m_initialVolume;  
   bool m_firstrun;
   bool m_exiting;
   pthread_t m_thread;

--- a/xbmc/android/jni/AudioManager.cpp
+++ b/xbmc/android/jni/AudioManager.cpp
@@ -23,7 +23,7 @@
 
 using namespace jni;
 
-int CJNIAudioManager::STREAM_MUSIC(0);
+int CJNIAudioManager::STREAM_MUSIC(3);
 
 void CJNIAudioManager::PopulateStaticFields()
 {
@@ -35,6 +35,13 @@ int CJNIAudioManager::getStreamMaxVolume()
 {
   return call_method<jint>(m_object,
     "getStreamMaxVolume", "(I)I",
+    STREAM_MUSIC);
+}
+
+int CJNIAudioManager::getStreamVolume()
+{
+  return call_method<int>(m_object,
+    "getStreamVolume", "(I)I",
     STREAM_MUSIC);
 }
 

--- a/xbmc/android/jni/AudioManager.h
+++ b/xbmc/android/jni/AudioManager.h
@@ -29,6 +29,7 @@ public:
 
   // Note removal of streamType param.
   int  getStreamMaxVolume();
+  int  getStreamVolume();
   void setStreamVolume(int index = 0, int flags = 0);
 
   static void PopulateStaticFields();


### PR DESCRIPTION
XBMC forces the "media" volume on startup to his own, remembered value and leave it like that (+/- adjustments during the session) on exit.
This is somewhat problematic as the "media" volume also controls notifications. I often happen to watch videos muted, but then, on exit, my device is muted system-wise, including notifications.

I see 2 ways of solving this:
1) Ignore XBMC remembered value, get system volume on startup and go on as today
2) Restore initial system volume on exit/lost focus.

I implemented 2)
