### PR TITLE
Add ctrl-V shortcut for paste in edit controls

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2314,15 +2314,32 @@ bool CApplication::OnKey(const CKey& key)
         if (key.GetFromService())
           action = CAction(key.GetButtonCode() != KEY_INVALID ? key.GetButtonCode() : 0, key.GetUnicode());
         else
-        { // see if we've got an ascii key
-          if (key.GetUnicode())
+        {
+          // Check for paste keypress
+#ifdef TARGET_WINDOWS
+          // In Windows paste is ctrl-V
+          if (key.GetVKey() == XBMCVK_V && key.GetModifiers() == CKey::MODIFIER_CTRL)
+#elif defined(TARGET_LINUX)
+          // In Linux paste is ctrl-V
+          if (key.GetVKey() == XBMCVK_V && key.GetModifiers() == CKey::MODIFIER_CTRL)
+#elif defined(TARGET_DARWIN_OSX)
+          // In OSX paste is cmd-V
+          if (key.GetVKey() == XBMCVK_V && key.GetModifiers() == CKey::MODIFIER_META)
+#else
+          // Placeholder for other operating systems
+          if (false)
+#endif
+            action = CAction(ACTION_PASTE);
+          // If the unicode is non-zero the keypress is a non-printing character
+          else if (key.GetUnicode())
             action = CAction(key.GetAscii() | KEY_ASCII, key.GetUnicode());
+          // The keypress is a non-printing character
           else
             action = CAction(key.GetVKey() | KEY_VKEY);
         }
       }
 
-      CLog::Log(LOGDEBUG, "%s: %s pressed, trying keyboard action %i", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetID());
+      CLog::Log(LOGDEBUG, "%s: %s pressed, trying keyboard action %x", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetID());
 
       if (OnAction(action))
         return true;

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -142,6 +142,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
     {
       ClearMD5();
       OnPasteClipboard();
+      return true;
     }
     else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
     {

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -511,27 +511,6 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     {
       switch (wParam)
       {
-        case VK_V:
-          if(GetKeyState(VK_CONTROL) & 0x8000)
-          {
-            // CTRL+V
-            if(OpenClipboard(NULL))
-            {
-              CStdString strtext;
-              HANDLE htext = GetClipboardData(CF_UNICODETEXT);
-              CStdStringW strwtext = (WCHAR*)htext;
-              g_charsetConverter.wToUTF8(strwtext, strtext);
-              if(!strtext.empty())
-              {
-                CGUIMessage msg(GUI_MSG_INPUT_TEXT, 0, 0);
-                msg.SetLabel(strtext);
-                g_windowManager.SendMessage(msg, g_windowManager.GetFocusedWindow());
-              }
-              CloseClipboard();
-              return(0);
-            }
-          }
-          break;
         case VK_CONTROL:
           if ( lParam & EXTENDED_KEYMASK )
             wParam = VK_RCONTROL;


### PR DESCRIPTION
This commit implements ctrl-V as a shortcut for paste, but only in edit controls. Globally ctrl-V can be mapped however the user wishes using the usual keyboard mapping file.

I've tested on both Windows and OSX, though for now I have not changed the hardcoded ctrl-V handler in xbmc/windowing/WinEventsSDL.cpp. I've put the code in for Linux, though at the moment Linux does not handle ACTION_PASTE.
