### PR TITLE
[guidialog] - fix autoclose

### DIFF
--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -142,6 +142,23 @@ void CGUIDialog::UpdateVisibility()
     else
       Close();
   }
+  
+  if (m_autoClosing)
+  { // check if our timer is running
+    if (!m_showStartTime)
+    {
+      if (HasProcessed()) // start timer
+        m_showStartTime = CTimeUtils::GetFrameTime();
+    }
+    else
+    {
+      if (m_showStartTime + m_showDuration < CTimeUtils::GetFrameTime() && !m_closing)
+      {
+        m_bAutoClosed = true;
+        Close();
+      }
+    }
+  }
 }
 
 void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const CStdString &param /* = "" */)
@@ -230,22 +247,6 @@ void CGUIDialog::Show()
 
 void CGUIDialog::FrameMove()
 {
-  if (m_autoClosing)
-  { // check if our timer is running
-    if (!m_showStartTime)
-    {
-      if (HasProcessed()) // start timer
-        m_showStartTime = CTimeUtils::GetFrameTime();
-    }
-    else
-    {
-      if (m_showStartTime + m_showDuration < CTimeUtils::GetFrameTime() && !m_closing)
-      {
-        m_bAutoClosed = true;
-        Close();
-      }
-    }
-  }
   CGUIWindow::FrameMove();
 }
 


### PR DESCRIPTION
... by moveing the autoclose logic into UpdateVisibility for ensuring that getframetime returns sane values - thx to jm for the solution.

This fixes premature close of the dialog "do you want to keep the resolution" when switching resolutions or switching to external screen on ios (which lasts between 6-8 secs and afterwards the dialog closed to quick so the user wasn't able to confirm it).

@jmarshallnz was this what you ment? (i can confirm that my issue is fixed with that...)
