### PR TITLE
[airplay] - add setting for allowing/disallowing volume control from airplay clients

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -3603,9 +3603,13 @@ msgctxt "#1260"
 msgid "Announce these services to other systems via Zeroconf"
 msgstr ""
 
-#empty strings from id 1261 to 1269
+#empty strings from id 1261 to 1268
 
 #: system/settings/settings.xml
+msgctxt "#1269"
+msgid "Allow volume control"
+msgstr ""
+
 msgctxt "#1270"
 msgid "Allow XBMC to receive AirPlay content"
 msgstr ""
@@ -14299,6 +14303,11 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36540"
 msgid "No info available yet."
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#36541"
+msgid "Allows volume control from AirPlay clients."
 msgstr ""
 
 #reserved strings 365XX

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1815,6 +1815,13 @@
           <level>1</level>
           <default>false</default>
         </setting>
+        <setting id="services.airplayvolumecontrol" type="boolean" parent="services.airplay" label="1269" help="36541">
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable" setting="services.airplay">true</dependency>
+          </dependencies>
+        </setting>
         <setting id="services.useairplaypassword" type="boolean" parent="services.airplay" label="1272" help="36344">
           <level>1</level>
           <default>false</default>

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -38,6 +38,7 @@
 #include "ApplicationMessenger.h"
 #include "utils/md5.h"
 #include "utils/Variant.h"
+#include "settings/Settings.h"
 #include "guilib/GUIWindowManager.h"
 #include "URL.h"
 #include "cores/IPlayer.h"
@@ -670,7 +671,7 @@ void CAirPlayServer::backupVolume()
 
 void CAirPlayServer::restoreVolume()
 {
-  if (ServerInstance->m_origVolume != -1)
+  if (ServerInstance->m_origVolume != -1 && CSettings::Get().GetBool("services.airplayvolumecontrol"))
   {
     g_application.SetVolume((float)ServerInstance->m_origVolume);
     ServerInstance->m_origVolume = -1;
@@ -762,7 +763,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       {
         float oldVolume = g_application.GetVolume();
         volume *= 100;
-        if(oldVolume != volume)
+        if(oldVolume != volume && CSettings::Get().GetBool("services.airplayvolumecontrol"))
         {
           backupVolume();
           g_application.SetVolume(volume);          

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -48,6 +48,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "utils/Variant.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "utils/EndianSwap.h"
 #include "URL.h"
 #include "interfaces/AnnouncementManager.h"
@@ -210,7 +211,8 @@ void  CAirTunesServer::AudioOutputFunctions::audio_set_volume(void *cls, void *s
 #ifdef HAS_AIRPLAY
   CAirPlayServer::backupVolume();
 #endif
-  g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
+  if (CSettings::Get().GetBool("services.airplayvolumecontrol"))
+    g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
 }
 
 void  CAirTunesServer::AudioOutputFunctions::audio_process(void *cls, void *session, const void *buffer, int buflen)
@@ -313,7 +315,8 @@ void  CAirTunesServer::AudioOutputFunctions::ao_set_volume(float volume)
 #ifdef HAS_AIRPLAY
   CAirPlayServer::backupVolume();
 #endif
-  g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
+  if (CSettings::Get().GetString("services.airplayvolumecontrol"))
+    g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
 }
 
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -933,6 +933,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("services.webserverpassword");
   settingSet.insert("services.zeroconf");
   settingSet.insert("services.airplay");
+  settingSet.insert("services.airplayvolumecontrol");
   settingSet.insert("services.useairplaypassword");
   settingSet.insert("services.airplaypassword");
   settingSet.insert("services.upnpserver");


### PR DESCRIPTION
As the topic says. This one adds a setting (level2!) which allows the user to disable the ability that airplay clients can alter XBMCs volume. There seem to be some wonky setups/users who insist on that ;)
