### PR TITLE
Add OnPasteClipboard method to CGUIDialogKeyboardGeneric

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -34,6 +34,9 @@
 #include "windowing/WindowingFactory.h"
 #include "utils/CharsetConverter.h"
 
+#if defined(TARGET_DARWIN)
+#include "osx/CocoaInterface.h"
+#endif
 
 // Symbol mapping (based on MS virtual keyboard - may need improving)
 static char symbol_map[37] = ")!@#$%^&*([]{}-_=+;:\'\",.<>/?\\|`~    ";
@@ -751,10 +754,9 @@ void CGUIDialogKeyboardGeneric::OnPasteClipboard(void)
 
 // Get text from the clipboard
 #if defined(TARGET_DARWIN_OSX)
-// NB - not tested on OSX yet. I'll uncomment this when I've tested it.
-//  const char *szStr = Cocoa_Paste();
-//  if (szStr)
-//    pasted_text = szStr;
+  const char *szStr = Cocoa_Paste();
+  if (szStr)
+    pasted_text = szStr;
 #elif defined TARGET_WINDOWS
   if (OpenClipboard(NULL))
   {

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -145,6 +145,10 @@ bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
   {
     OnRemoteNumberClick(action.GetID());
   }
+  else if (action.GetID() == ACTION_PASTE)
+  {
+    OnPasteClipboard();
+  }
   else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
   { // input from the keyboard (vkey, not ascii)
     if (!m_strEditing.IsEmpty())
@@ -739,4 +743,46 @@ bool CGUIDialogKeyboardGeneric::ShowAndGetInput(char_callback_t pCallback, const
     return true;
   }
   else return false;
+}
+
+void CGUIDialogKeyboardGeneric::OnPasteClipboard(void)
+{
+  CStdStringW pasted_text;
+
+// Get text from the clipboard
+#if defined(TARGET_DARWIN_OSX)
+// NB - not tested on OSX yet. I'll uncomment this when I've tested it.
+//  const char *szStr = Cocoa_Paste();
+//  if (szStr)
+//    pasted_text = szStr;
+#elif defined TARGET_WINDOWS
+  if (OpenClipboard(NULL))
+  {
+    HGLOBAL hglb = GetClipboardData(CF_UNICODETEXT);
+    if (hglb != NULL)
+    {
+      LPWSTR lpwstr = (LPWSTR) GlobalLock(hglb);
+      if (lpwstr != NULL)
+      {
+        pasted_text = lpwstr;
+        GlobalUnlock(hglb);
+      }
+    }
+    CloseClipboard();
+  }
+#endif
+
+  // Insert the pasted text at the current cursor position.
+  if (pasted_text.length() > 0)
+  {
+    int i = GetCursorPos();
+    CStdStringW left_end = m_strEdit.Left(i);
+    CStdStringW right_end = m_strEdit.Right(m_strEdit.length() - i);
+
+    m_strEdit = left_end;
+    m_strEdit.append(pasted_text);
+    m_strEdit.append(right_end);
+    UpdateLabel();
+    MoveCursor(pasted_text.length());
+  }
 }

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.h
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.h
@@ -46,6 +46,7 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     bool IsConfirmed() { return m_bIsConfirmed; };
     void SetHiddenInput(bool hiddenInput) { m_hiddenInput = hiddenInput; };
     void Character(WCHAR wch);
+    void OnPasteClipboard(void);
 
   protected:
     virtual void OnInitWindow();


### PR DESCRIPTION
This is a follow up to https://github.com/xbmc/xbmc/pull/3026. It adds a handler for ACTION_PASTE to CGUIDialogKeyboardGeneric.

I've duplicated some code from CGUIEditControl. If this gets the nod it would be tidier to put the common code in the utils somewhere. I'll need advice on the best place to put this code.
