### PR TITLE
[droid] Store the log file in a user-accessible location

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -553,7 +553,6 @@ void CXBMCApp::SetupEnv()
   setenv("XBMC_ANDROID_APK", getPackageResourcePath().c_str(), 0);
 
   std::string cacheDir = getCacheDir().getAbsolutePath();
-  setenv("XBMC_TEMP", (cacheDir + "/temp").c_str(), 0);
   setenv("XBMC_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
   setenv("XBMC_HOME", (cacheDir + "/apk/assets").c_str(), 0);
 


### PR DESCRIPTION
The log file (xbmc.log) on Android is stored in /data/data/org.xbmc.xbmc/ which can only be accessed with root permissions.
With the huge work on Android by XBMC team; and the fragmentation of the Android platform, logs are very crucial but a lot of Android users including myself don't have easy access to the log file due to the need of root permissions to view/edit/copy it. This PR fixes this issue.

This patch changes the log path to:
/sdcard/Android/data/org.xbmc.xbmc/files/.xbmc/temp/ which is accessible by all file managers and ftp servers with no root privileges needed.

Note: the Wiki\* states that the current log is stored on the sdcard. On my three phones and the tablet it is stored inside of /data/ which is only root-accessed. This patch changes the path to a more consistent path which is the one stated above (the same folder as advancedsettings.xml).  
- http://wiki.xbmc.org/index.php?title=Log_file/Advanced#Location
