### PR TITLE
[FIX] CEC: end of non-void reached

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1703,6 +1703,7 @@ bool CPeripheralCecAdapter::ToggleDeviceState(CecStateChange mode /*= STATE_SWIT
     ActivateSource();
     return true;
   }
+  return m_cecAdapter->IsLibCECActiveSource();
 }
 
 #endif


### PR DESCRIPTION
We're in trouble if `mode == STATE_STANDBY` and `m_cecAdapter->IsLibCECActiveSource() == false`...
I not entirely sure if I'm returning the correct value though.
