### PR TITLE
dvdplayer video: fix unneeded drops.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -571,6 +571,9 @@ void CDVDPlayerVideo::Process()
         m_iDroppedFrames++;
         iDropped++;
       }
+      // reset the request, the following while loop may break before
+      // setting the flag to a new value
+      bRequestDrop = false;
 
       // loop while no error
       while (!m_bStop)


### PR DESCRIPTION
Some videos, in particular 50Hz interlaced, have started with 500 drops and slow motion. If iDecoderState had not set VC_PICTURE, the flag was not reset.
