### PR TITLE
[Fix] workaround osx 10.6 lost first keypress problem, fix #14525

### DIFF
--- a/tools/depends/target/libsdl/03-OSX_interpretKeyEvents.patch
+++ b/tools/depends/target/libsdl/03-OSX_interpretKeyEvents.patch
@@ -1,0 +1,15 @@
+--- src/video/quartz/SDL_QuartzEvents.m	2009-10-13 07:07:14.000000000 +0800
++++ src/video/quartz/SDL_QuartzEvents.m	2013-08-03 09:12:27.000000000 +0800
+@@ -280,7 +280,11 @@
+         the scancode/keysym.
+     */
+     if (SDL_TranslateUNICODE && state == SDL_PRESSED) {
+-        [field_edit interpretKeyEvents:[NSArray arrayWithObject:event]];
++        NSResponder *firstResponder = [[NSApp keyWindow] firstResponder];
++        if ([NSStringFromClass([firstResponder class]) isEqual:@"OSXTextInputResponder"])
++          [firstResponder interpretKeyEvents:[NSArray arrayWithObject:event]];
++        else
++          [field_edit interpretKeyEvents:[NSArray arrayWithObject:event]];
+         chars = [ event characters ];
+         numChars = [ chars length ];
+         if (numChars > 0)

--- a/tools/depends/target/libsdl/Makefile
+++ b/tools/depends/target/libsdl/Makefile
@@ -23,6 +23,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p0 < ../01-SDL_SetWidthHeight.patch
 	cd $(PLATFORM); patch -p0 < ../02-mmx.patch
+	cd $(PLATFORM); patch -p0 < ../03-OSX_interpretKeyEvents.patch
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
this PR may fix http://trac.xbmc.org/ticket/14525
there seems be a bug on osx 10.6 only, it will lost the first keypress in when we work with the system input method.
so the problem maybe caused by the way key events was processed by the libsdl, to workaround it, I add a little patch for the osx part of code of libsdl, to let it send the key events directly to our OSXTextInputResponser, so let's test it to see...
