### PR TITLE
[gui] - remove FrameMove from GUIDialog as it is not needed anymore

### DIFF
--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -245,11 +245,6 @@ void CGUIDialog::Show()
     Show_Internal();
 }
 
-void CGUIDialog::FrameMove()
-{
-  CGUIWindow::FrameMove();
-}
-
 void CGUIDialog::Render()
 {
   if (!m_active)

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -41,7 +41,6 @@ public:
 
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual void FrameMove();
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
 


### PR DESCRIPTION
... as the title says

@jmarshallnz - a button to push - just for you :)
