### PR TITLE
Fix seeking in audio files played over http for urls without file extens...

### DIFF
--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -116,6 +116,7 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
 {
   CURL urlFile(strFile);
   if( strContent.Equals("audio/mpeg")
+  ||  strContent.Equals("audio/mpeg3")
   ||  strContent.Equals("audio/mp3") )
     return new MP3Codec();
   else if (strContent.Left(9).Equals("audio/l16"))

--- a/xbmc/cores/paplayer/FLACcodec.cpp
+++ b/xbmc/cores/paplayer/FLACcodec.cpp
@@ -56,7 +56,7 @@ bool FLACCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   //  Extract ReplayGain info
   CTagLoaderTagLib tagLoaderTagLib;
-  tagLoaderTagLib.Load(strFile, m_tag);
+  tagLoaderTagLib.Load(strFile, m_tag, NULL, "flac");
 
   m_pFlacDecoder=m_dll.FLAC__stream_decoder_new();
 

--- a/xbmc/cores/paplayer/MP3codec.cpp
+++ b/xbmc/cores/paplayer/MP3codec.cpp
@@ -175,7 +175,7 @@ bool MP3Codec::Init(const CStdString &strFile, unsigned int filecache)
   if (length != 0)
   {
     CTagLoaderTagLib tagLoaderTagLib; //opens the file so needs to be after m_file.Open 
-    bTags = tagLoaderTagLib.Load(strFile, m_tag);
+    bTags = tagLoaderTagLib.Load(strFile, m_tag, NULL, "mp3");
 
     if (bTags)
       ReadDuration();

--- a/xbmc/cores/paplayer/OGGcodec.cpp
+++ b/xbmc/cores/paplayer/OGGcodec.cpp
@@ -131,7 +131,7 @@ bool OGGCodec::Init(const CStdString &strFile1, unsigned int filecache)
   if (pComments)
   {
     CTagLoaderTagLib tagLoaderTagLib;
-    tagLoaderTagLib.Load(strFile, m_tag);
+    tagLoaderTagLib.Load(strFile, m_tag, NULL, "oga");
   }
 
   //  Seek to the logical bitstream to play

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -84,14 +84,19 @@ static const vector<string> StringListToVectorString(const StringList& stringLis
   return values;
 }
 
-bool CTagLoaderTagLib::Load(const string& strFileName, CMusicInfoTag& tag, EmbeddedArt *art /* = NULL */)
+bool CTagLoaderTagLib::Load(const string& strFileName, CMusicInfoTag& tag, EmbeddedArt *art /* = NULL */, const string& fallbackFileExtension /* = "" */)
 {  
   CStdString strExtension = URIUtils::GetExtension(strFileName);
   strExtension.ToLower();
   strExtension.TrimLeft('.');
 
   if (strExtension.IsEmpty())
-    return false;
+  {
+    strExtension = fallbackFileExtension;
+    if (strExtension.IsEmpty())
+      return false;
+    strExtension.ToLower();
+  }
 
   TagLibVFSStream*           stream = new TagLibVFSStream(strFileName, true);
   if (!stream)

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -54,7 +54,7 @@ class CTagLoaderTagLib
 public:
   CTagLoaderTagLib();
   virtual ~CTagLoaderTagLib();
-  virtual bool                   Load(const std::string& strFileName, MUSIC_INFO::CMusicInfoTag& tag, MUSIC_INFO::EmbeddedArt *art = NULL);
+  virtual bool                   Load(const std::string& strFileName, MUSIC_INFO::CMusicInfoTag& tag, MUSIC_INFO::EmbeddedArt *art = NULL, const std::string& fallbackFileExtension = "");
 private:
   bool                           Open(const std::string& strFileName, bool readOnly);
   const std::vector<std::string> GetASFStringList(const TagLib::List<TagLib::ASF::Attribute>& list);


### PR DESCRIPTION
Fix to enable seeking in audio files played over http if no file extension is provided in the media url
http://trac.xbmc.org/ticket/13891
