### PR TITLE
Allow empty String values to be read in XML tags

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -663,7 +663,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
           scurlMovie.strTitle.AppendFormat(" (%s)", sCompareYear.c_str());
 
         CStdString sLanguage;
-        if (XMLUtils::GetString(pxeMovie, "language", sLanguage))
+        if (XMLUtils::GetString(pxeMovie, "language", sLanguage) && !sLanguage.empty())
           scurlMovie.strTitle.AppendFormat(" (%s)", sLanguage.c_str());
 
         // filter for dupes from naughty scrapers
@@ -737,17 +737,17 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const CStdStr
       pxeAlbum; pxeAlbum = pxeAlbum->NextSiblingElement())
     {
       CStdString sTitle;
-      if (XMLUtils::GetString(pxeAlbum, "title", sTitle))
+      if (XMLUtils::GetString(pxeAlbum, "title", sTitle) && !sTitle.empty())
       {
         CStdString sArtist;
         CStdString sAlbumName;
-        if (XMLUtils::GetString(pxeAlbum, "artist", sArtist))
+        if (XMLUtils::GetString(pxeAlbum, "artist", sArtist) && !sArtist.empty())
           sAlbumName.Format("%s - %s", sArtist.c_str(), sTitle.c_str());
         else
           sAlbumName = sTitle;
 
         CStdString sYear;
-        if (XMLUtils::GetString(pxeAlbum, "year", sYear))
+        if (XMLUtils::GetString(pxeAlbum, "year", sYear) && !sYear.empty())
           sAlbumName.Format("%s (%s)", sAlbumName.c_str(), sYear.c_str());
 
         // if no URL is provided, use the URL we got back from CreateAlbumSearchUrl
@@ -895,13 +895,13 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
       TiXmlElement *pxeLink = pxeMovie->FirstChildElement("url");
       CStdString strEpNum;
       if (pxeLink && XMLUtils::GetInt(pxeMovie, "season", ep.iSeason) &&
-        XMLUtils::GetString(pxeMovie, "epnum", strEpNum))
+        XMLUtils::GetString(pxeMovie, "epnum", strEpNum) && !strEpNum.empty())
       {
         CScraperUrl &scurlEp(ep.cScraperUrl);
         int dot = strEpNum.Find(".");
         ep.iEpisode = atoi(strEpNum.c_str());
         ep.iSubepisode = (dot > -1) ? atoi(strEpNum.Mid(dot + 1).c_str()) : 0;
-        if (!XMLUtils::GetString(pxeMovie, "title", scurlEp.strTitle))
+        if (!XMLUtils::GetString(pxeMovie, "title", scurlEp.strTitle) || scurlEp.strTitle.empty() )
             scurlEp.strTitle = g_localizeStrings.Get(416);
         XMLUtils::GetString(pxeMovie, "id", scurlEp.strId);
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -656,7 +656,7 @@ bool CExternalPlayer::Initialize(TiXmlElement* pConfig)
     m_warpcursor = WARP_BOTTOM_RIGHT;
 
   CStdString warpCursor;
-  if (XMLUtils::GetString(pConfig, "warpcursor", warpCursor))
+  if (XMLUtils::GetString(pConfig, "warpcursor", warpCursor) && !warpCursor.empty())
   {
     if (warpCursor == "bottomright") m_warpcursor = WARP_BOTTOM_RIGHT;
     else if (warpCursor == "bottomleft") m_warpcursor = WARP_BOTTOM_LEFT;

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -905,7 +905,7 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
 
   // get the default value
   CStdString value;
-  if (XMLUtils::GetString(node, XML_ELM_DEFAULT, value))
+  if (XMLUtils::GetString(node, XML_ELM_DEFAULT, value) && !value.empty())
     m_value = m_default = value;
   else if (!update && !m_allowEmpty)
   {

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -64,7 +64,7 @@ bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */
   if (constraints != NULL)
   {
     // get the addon type
-    if (XMLUtils::GetString(constraints, "addontype", strAddonType))
+    if (XMLUtils::GetString(constraints, "addontype", strAddonType) && !strAddonType.empty())
     {
       m_addonType = ADDON::TranslateType(strAddonType);
       if (m_addonType != ADDON::ADDON_UNKNOWN)

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -62,7 +62,7 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
   // get the default value by abusing the FromString
   // implementation to parse the default value
   CStdString value;
-  if (XMLUtils::GetString(node, XML_ELM_DEFAULT, value))
+  if (XMLUtils::GetString(node, XML_ELM_DEFAULT, value) && !value.empty())
     m_value = m_default = value;
   else if (!update && !m_allowEmpty)
   {

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -59,17 +59,6 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
     return false;
   }
     
-  // get the default value by abusing the FromString
-  // implementation to parse the default value
-  CStdString value;
-  if (XMLUtils::GetString(node, XML_ELM_DEFAULT, value) && !value.empty())
-    m_value = m_default = value;
-  else if (!update && !m_allowEmpty)
-  {
-    CLog::Log(LOGERROR, "CSettingPath: error reading the default value of \"%s\"", m_id.c_str());
-    return false;
-  }
-    
   const TiXmlNode *constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
   if (constraints != NULL)
   {

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -149,7 +149,7 @@ bool XMLUtils::GetString(const TiXmlNode* pRootNode, const char* strTag, std::st
     return true;
   }
   strStringValue.clear();
-  return false;
+  return true;
 }
 
 bool XMLUtils::HasChild(const TiXmlNode* pRootNode, const char* strTag)

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -279,7 +279,7 @@ bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdStrin
 bool XMLUtils::GetDate(const TiXmlNode* pRootNode, const char* strTag, CDateTime& date)
 {
   CStdString strDate;
-  if (GetString(pRootNode, strTag, strDate))
+  if (GetString(pRootNode, strTag, strDate) && !strDate.empty())
   {
     date.SetFromDBDate(strDate);
     return true;
@@ -291,7 +291,7 @@ bool XMLUtils::GetDate(const TiXmlNode* pRootNode, const char* strTag, CDateTime
 bool XMLUtils::GetDateTime(const TiXmlNode* pRootNode, const char* strTag, CDateTime& dateTime)
 {
   CStdString strDateTime;
-  if (GetString(pRootNode, strTag, strDateTime))
+  if (GetString(pRootNode, strTag, strDateTime) && !strDateTime.empty())
   {
     dateTime.SetFromDBDateTime(strDateTime);
     return true;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8955,11 +8955,11 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
     while (path)
     {
       CStdString strPath;
-      if (XMLUtils::GetString(path,"url",strPath))
+      if (XMLUtils::GetString(path,"url",strPath) && !strPath.empty())
         AddPath(strPath);
 
       CStdString content;
-      if (XMLUtils::GetString(path,"content", content))
+      if (XMLUtils::GetString(path,"content", content) && !content.empty())
       { // check the scraper exists, if so store the path
         AddonPtr addon;
         CStdString id;

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -586,7 +586,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   XMLUtils::GetString(movie, "plot", m_strPlot);
   XMLUtils::GetString(movie, "tagline", m_strTagLine);
   CStdString runtime;
-  if (XMLUtils::GetString(movie, "runtime", runtime))
+  if (XMLUtils::GetString(movie, "runtime", runtime) && !runtime.empty())
     m_duration = GetDurationFromMinuteString(runtime);
   XMLUtils::GetString(movie, "mpaa", m_strMPAARating);
   XMLUtils::GetInt(movie, "playcount", m_playCount);


### PR DESCRIPTION
E.g. while reading Settings, < default > < /default > will read a value of "" instead of considering this an error.
