### PR TITLE
ActiveAE: limit sampling rate to 48khz on SPDIF

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1201,6 +1201,12 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
       }
     }
 
+    if (m_settings.mode == AUDIO_IEC958 && format.m_sampleRate > 48000)
+    {
+      format.m_sampleRate = 48000;
+      CLog::Log(LOGINFO, "CActiveAE::ApplySettings - limit samplerate for SPDIF to %d", format.m_sampleRate);
+    }
+
     if (g_advancedSettings.m_audioResample)
     {
       format.m_sampleRate = g_advancedSettings.m_audioResample;


### PR DESCRIPTION
fix for trac 14530: high bitrate FLAC requires <resample> on SPDIF

@MartijnKaijser could you test this please? I have not SPDIF myself.
