### PR TITLE
music: hide progress dialog before opening the artist/album/song info dialog

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -347,12 +347,10 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
     if (pItem->HasMusicInfoTag() && pItem->GetMusicInfoTag()->Loaded() &&
        !pItem->GetMusicInfoTag()->GetAlbum().IsEmpty())
     {
-      bool result = ShowAlbumInfo(pItem.get());
-
       if (m_dlgProgress && bShowInfo)
         m_dlgProgress->Close();
 
-      if (!result) // Something went wrong, so bail for the rest
+      if (!ShowAlbumInfo(pItem.get())) // Something went wrong, so bail for the rest
         break;
     }
   }
@@ -399,6 +397,9 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
         break;
       }
     }
+
+    if (m_dlgProgress)
+      m_dlgProgress->Close();
 
     CGUIDialogMusicInfo *pDlgArtistInfo = (CGUIDialogMusicInfo*)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_INFO);
     if (pDlgArtistInfo)
@@ -469,6 +470,9 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
         return false;
       }
     }
+
+    if (m_dlgProgress)
+      m_dlgProgress->Close();
 
     CGUIDialogMusicInfo *pDlgAlbumInfo = (CGUIDialogMusicInfo*)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_INFO);
     if (pDlgAlbumInfo)


### PR DESCRIPTION
When opening the artist/album/song dialog of an item for which additional information hasn't been retrieved yet, this is done automatically before opening the music info dialog. To let the user know that xbmc is doing some lookup, we show the progress dialog. Once the information is available we open the music info dialog but the progress dialog is still open and is only closed after the music info dialog has been closed as well. This is not a problem in confluence because the music info dialog hides the progress dialog. But in other skins where the music info dialog doesn't cover the whole screen or uses a transparent background, the progress dialog is still visible in the background which looks very odd.

I'm not sure why the logic is that way in the first place so I kept most of the original calls to m_dlgProgress->Close() and just threw in some more right before actually opening the music info dialog.
