### PR TITLE
Use utf8 for text pasted from the clipboard

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -750,22 +750,25 @@ bool CGUIDialogKeyboardGeneric::ShowAndGetInput(char_callback_t pCallback, const
 
 void CGUIDialogKeyboardGeneric::OnPasteClipboard(void)
 {
-  CStdStringW pasted_text;
+  CStdStringW unicode_text;
+  CStdStringA utf8_text;
 
 // Get text from the clipboard
-  pasted_text = g_Windowing.GetClipboard();
+  utf8_text = g_Windowing.GetClipboardText();
 
   // Insert the pasted text at the current cursor position.
-  if (pasted_text.length() > 0)
+  if (utf8_text.length() > 0)
   {
+    g_charsetConverter.utf8ToW(utf8_text, unicode_text);
+
     int i = GetCursorPos();
     CStdStringW left_end = m_strEdit.Left(i);
     CStdStringW right_end = m_strEdit.Right(m_strEdit.length() - i);
 
     m_strEdit = left_end;
-    m_strEdit.append(pasted_text);
+    m_strEdit.append(unicode_text);
     m_strEdit.append(right_end);
     UpdateLabel();
-    MoveCursor(pasted_text.length());
+    MoveCursor(unicode_text.length());
   }
 }

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -578,21 +578,23 @@ void CGUIEditControl::OnSMSCharacter(unsigned int key)
 
 void CGUIEditControl::OnPasteClipboard()
 {
-  CStdStringW pasted_text;
+  CStdStringW unicode_text;
+  CStdStringA utf8_text;
 
 // Get text from the clipboard
-  pasted_text = g_Windowing.GetClipboard();
+  utf8_text = g_Windowing.GetClipboardText();
+  g_charsetConverter.utf8ToW(utf8_text, unicode_text);
 
   // Insert the pasted text at the current cursor position.
-  if (pasted_text.length() > 0)
+  if (unicode_text.length() > 0)
   {
     CStdStringW left_end = m_text2.Left(m_cursorPos);
     CStdStringW right_end = m_text2.Right(m_text2.length() - m_cursorPos);
 
     m_text2 = left_end;
-    m_text2.append(pasted_text);
+    m_text2.append(unicode_text);
     m_text2.append(right_end);
-    m_cursorPos += pasted_text.length();
+    m_cursorPos += unicode_text.length();
     UpdateText();
   }
 }

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -236,7 +236,7 @@ bool CWinSystemBase::UseLimitedColor()
 #endif
 }
 
-CStdStringW CWinSystemBase::GetClipboard(void)
+std::string CWinSystemBase::GetClipboardText(void)
 {
   return "";
 }

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -108,7 +108,7 @@ public:
   virtual void EnableTextInput(bool bEnable) {}
   virtual bool IsTextInputEnabled() { return false; }
 
-  CStdStringW GetClipboard(void);
+  std::string GetClipboardText(void);
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, int screen, int width, int height, float refreshRate, uint32_t dwFlags = 0);

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -69,7 +69,7 @@ public:
   
   void* GetCGLContextObj();
 
-  CStdStringW GetClipboard(void);
+  std::string GetClipboardText(void);
 
 protected:
   void* CreateWindowedContext(void* shareCtx);

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1626,15 +1626,15 @@ void* CWinSystemOSX::GetCGLContextObj()
   return [(NSOpenGLContext*)m_glContext CGLContextObj];
 }
 
-CStdStringW CWinSystemOSX::GetClipboard(void)
+std::string CWinSystemOSX::GetClipboardText(void)
 {
-  CStdStringW pasted_text;
+  std::string utf8_text;
 
   const char *szStr = Cocoa_Paste();
   if (szStr)
-    pasted_text = szStr;
+    utf8_text = szStr;
 
-  return pasted_text;
+  return utf8_text;
 }
 
 #endif

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -22,6 +22,7 @@
 #include "WinSystemWin32DX.h"
 #include "settings/Settings.h"
 #include "guilib/gui3d.h"
+#include "utils/CharsetConverter.h"
 
 #ifdef HAS_DX
 
@@ -98,9 +99,10 @@ bool CWinSystemWin32DX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, boo
   return true;
 }
 
-CStdStringW CWinSystemWin32DX::GetClipboard(void)
+std::string CWinSystemWin32DX::GetClipboardText(void)
 {
-  CStdStringW pasted_text;
+  CStdStringW unicode_text;
+  CStdStringA utf8_text;
 
   if (OpenClipboard(NULL))
   {
@@ -110,14 +112,16 @@ CStdStringW CWinSystemWin32DX::GetClipboard(void)
       LPWSTR lpwstr = (LPWSTR) GlobalLock(hglb);
       if (lpwstr != NULL)
       {
-        pasted_text = lpwstr;
+        unicode_text = lpwstr;
         GlobalUnlock(hglb);
       }
     }
     CloseClipboard();
   }
 
-  return pasted_text;
+  g_charsetConverter.wToUTF8(unicode_text, utf8_text);
+
+  return utf8_text;
 }
 
 #endif

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -45,7 +45,7 @@ public:
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual bool WindowedMode() { return CRenderSystemDX::m_useWindowedDX; }
 
-  CStdStringW GetClipboard(void);
+  std::string GetClipboardText(void);
 
 protected:
   virtual void UpdateMonitor();


### PR DESCRIPTION
Change the g_Windowing paste function to return a utf8 string. I've also renamed the function to GetClipboardText to make it clear what is being returned (we might want to paste other objects, e.g. media files, in the future.

I've used g_charsetConverter to do the utf8 to unicode conversions. This means using a CStdStringA in place of std::string.

I'm not as comfortable as I could be with the unicode to utf8 conversions and back, but I've tested by pasting unicode (Cyrillic) characters, both on Win32 and OSX, and it works fine.
