### PR TITLE
Provide extended language selection for preferred audio/subtitle stream selection

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -593,18 +593,41 @@ const CStdString& CLangInfo::GetSpeedUnitString() const
 
 void CLangInfo::SettingOptionsLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
 {
-  SettingOptionsLanguagesFillerGeneral(setting, list, current);
+  //find languages...
+  CFileItemList items;
+  XFILE::CDirectory::GetDirectory("special://xbmc/language/", items);
+
+  vector<string> vecLanguage;
+  for (int i = 0; i < items.Size(); ++i)
+  {
+    CFileItemPtr pItem = items[i];
+    if (pItem->m_bIsFolder)
+    {
+      if (StringUtils::EqualsNoCase(pItem->GetLabel(), ".svn") ||
+          StringUtils::EqualsNoCase(pItem->GetLabel(), "fonts") ||
+          StringUtils::EqualsNoCase(pItem->GetLabel(), "media"))
+        continue;
+
+      vecLanguage.push_back(pItem->GetLabel());
+    }
+  }
+
+  sort(vecLanguage.begin(), vecLanguage.end(), sortstringbyname());
+
+  for (unsigned int i = 0; i < vecLanguage.size(); ++i)
+    list.push_back(make_pair(vecLanguage[i], vecLanguage[i]));
 }
 
 void CLangInfo::SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
 {
-  vector<string> languages;
-  languages.push_back(g_localizeStrings.Get(308));
-  languages.push_back(g_localizeStrings.Get(309));
-  vector<string> languageKeys;
-  languageKeys.push_back("original");
-  languageKeys.push_back("default");
-  SettingOptionsLanguagesFillerGeneral(setting, list, current, languages, languageKeys);
+  list.push_back(make_pair(g_localizeStrings.Get(308), "original"));
+  list.push_back(make_pair(g_localizeStrings.Get(309), "default"));
+
+  // get a list of language names
+  vector<string> languages = g_LangCodeExpander.GetLanguageNames();
+  sort(languages.begin(), languages.end(), sortstringbyname());
+  for (std::vector<std::string>::const_iterator language = languages.begin(); language != languages.end(); ++language)
+    list.push_back(make_pair(*language, *language));
 }
 
 void CLangInfo::SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
@@ -628,39 +651,4 @@ void CLangInfo::SettingOptionsRegionsFiller(const CSetting *setting, std::vector
 
   if (!match && regions.size() > 0)
     current = regions[0];
-}
-
-void CLangInfo::SettingOptionsLanguagesFillerGeneral(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current,
-                                                     const std::vector<std::string> &languages /* = std::vector<std::string>() */,
-                                                     const std::vector<std::string> &languageKeys /* = std::vector<std::string>() */)
-{
-  //find languages...
-  CFileItemList items;
-  XFILE::CDirectory::GetDirectory("special://xbmc/language/", items);
-
-  vector<string> vecLanguage;
-  for (int i = 0; i < items.Size(); ++i)
-  {
-    CFileItemPtr pItem = items[i];
-    if (pItem->m_bIsFolder)
-    {
-      if (StringUtils::EqualsNoCase(pItem->GetLabel(), ".svn") ||
-          StringUtils::EqualsNoCase(pItem->GetLabel(), "fonts") ||
-          StringUtils::EqualsNoCase(pItem->GetLabel(), "media"))
-        continue;
-
-      vecLanguage.push_back(pItem->GetLabel());
-    }
-  }
-
-  sort(vecLanguage.begin(), vecLanguage.end(), sortstringbyname());
-  // Add language options passed by parameter at the beginning
-  if (languages.size() > 0)
-  {
-    for (unsigned int i = 0; i < languages.size(); ++i)
-      list.push_back(make_pair(languages[i], languageKeys[i]));
-  }
-  
-  for (unsigned int i = 0; i < vecLanguage.size(); ++i)
-    list.push_back(make_pair(vecLanguage[i], vecLanguage[i]));
 }

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -127,12 +127,6 @@ public:
 protected:
   void SetDefaults();
 
-protected:
-
-  static void SettingOptionsLanguagesFillerGeneral(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current,
-                                                   const std::vector<std::string> &languages = std::vector<std::string>(),
-                                                   const std::vector<std::string> &languageKeys = std::vector<std::string>());
-
   class CRegion
   {
   public:

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -420,6 +420,27 @@ void CLangCodeExpander::CodeToString(long code, CStdString& ret)
   }
 }
 
+std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format /* = CLangCodeExpander::ISO_639_1 */) const
+{
+  std::vector<std::string> languages;
+  const LCENTRY *lang = g_iso639_1;
+  size_t length = sizeof(g_iso639_1);
+  if (format == CLangCodeExpander::ISO_639_2)
+  {
+    lang = g_iso639_2;
+    length = sizeof(g_iso639_2);
+  }
+  length /= sizeof(LCENTRY);
+
+  for (size_t i = 0; i < length; i++)
+  {
+    languages.push_back(lang->name);
+    ++lang;
+  }
+
+  return languages;
+}
+
 extern const LCENTRY g_iso639_1[144] =
 {
   { MAKECODE('\0','\0','c','c'), "Closed Caption" },

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -64,6 +64,8 @@ public:
 
   void LoadUserCodes(const TiXmlElement* pRootElement);
   void Clear();
+
+  std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1) const;
 protected:
 
   /** \brief Converts a language code given as a long, see #MAKECODE(a, b, c, d)


### PR DESCRIPTION
This addresses http://trac.xbmc.org/ticket/14118. Right now the list of languages displayed for the "Preferred audio/subtitle stream language" settings depend upon the languages installed with XBMC. If a user (mostly on win32) decides to only install the english language, he won't be able to choose any other language for the preferred audio/subtitle stream language settings.
This change lets the user choose from the english names of the ISO 639-1 language codes independent of the installed XBMC languages. We could also use ISO 639-2 but there are lots of languages in there which don't make much sense IMO (e.g. "English, Old (ca.450-1100)" or "English, Middle (1100-1500)") which I doubt are used in any media files.
