### PR TITLE
Expose ACTION_FOO, ICON_TYPE_FOO and KEY_CODE_FOO to addons

### DIFF
--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -365,6 +365,8 @@
 #define ICON_TYPE_WEATHER       107
 #define ICON_TYPE_SETTINGS      109
 
+#ifndef SWIG
+
 class CKey;
 
 /*!
@@ -519,5 +521,7 @@ private:
   float m_repeat; // time since last keypress
   bool m_fromService;
 };
+#endif //undef SWIG
+
 #endif
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -28,6 +28,7 @@
 #include "interfaces/legacy/WindowDialog.h"
 #include "interfaces/legacy/Dialog.h"
 #include "interfaces/legacy/WindowXML.h"
+#include "guilib/Key.h"
 
 using namespace XBMCAddon;
 using namespace xbmcgui;
@@ -175,3 +176,4 @@ using namespace xbmcgui;
 
 %include "interfaces/legacy/WindowXML.h"
 
+%include "guilib/Key.h"


### PR DESCRIPTION
This exposes

```
xbmcgui.KEY_BUTTON_FOO
xbmcgui.ACTION_FOO
xbmcgui.ICON_TYPE_FOO
```

to the addon API. This is on Spheres wishlist: _8.1 actions by name in onAction()/constants for action IDs_ 

I wasn't sure if I should split Key.h into two parts to avoid the `#ifndef SWIG` but this seemed less intrusive
