### PR TITLE
settings: dynamically show/hide settings

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -385,6 +385,9 @@
 		DF28EDA7170E1A11005FA9D2 /* ProfilesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF28ED9C170E1A11005FA9D2 /* ProfilesManager.cpp */; };
 		DF28EDA8170E1A11005FA9D2 /* GUIWindowSettingsProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF28ED9F170E1A11005FA9D2 /* GUIWindowSettingsProfile.cpp */; };
 		DF28EE03170E1E51005FA9D2 /* DisplaySettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF28EE01170E1E51005FA9D2 /* DisplaySettings.cpp */; };
+		DF29668017B2B04300DF10F9 /* SettingRequirement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF29667E17B2B04300DF10F9 /* SettingRequirement.cpp */; };
+		DF29668117B2B04300DF10F9 /* SettingRequirement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF29667E17B2B04300DF10F9 /* SettingRequirement.cpp */; };
+		DF29668217B2B04300DF10F9 /* SettingRequirement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF29667E17B2B04300DF10F9 /* SettingRequirement.cpp */; };
 		DF3488E713FD958F0026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF3488E513FD958F0026A711 /* GUIAction.cpp */; };
 		DF34892A13FD9C780026A711 /* AirPlayServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34892813FD9C780026A711 /* AirPlayServer.cpp */; };
 		DF34898213FDAAF60026A711 /* HttpParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34898113FDAAF60026A711 /* HttpParser.cpp */; };
@@ -541,7 +544,6 @@
 		DFECFB0F172D9CAB00A43CF7 /* SettingSection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB00172D9CAB00A43CF7 /* SettingSection.cpp */; };
 		DFECFB10172D9CAB00A43CF7 /* SettingsManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB02172D9CAB00A43CF7 /* SettingsManager.cpp */; };
 		DFECFB11172D9CAB00A43CF7 /* SettingUpdate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB03172D9CAB00A43CF7 /* SettingUpdate.cpp */; };
-		DFECFB12172D9CAB00A43CF7 /* SettingVisibility.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB05172D9CAB00A43CF7 /* SettingVisibility.cpp */; };
 		DFECFB1C172D9D0100A43CF7 /* BooleanLogic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB1A172D9D0100A43CF7 /* BooleanLogic.cpp */; };
 		DFECFB4C172D9D6D00A43CF7 /* NetworkServices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB4A172D9D6D00A43CF7 /* NetworkServices.cpp */; };
 		DFF0EB54175280D1002DA3A4 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CE6131F5DC6000AD0F6 /* libz.dylib */; };
@@ -1346,7 +1348,6 @@
 		DFF0F3A717528350002DA3A4 /* SettingSection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB00172D9CAB00A43CF7 /* SettingSection.cpp */; };
 		DFF0F3A817528350002DA3A4 /* SettingsManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB02172D9CAB00A43CF7 /* SettingsManager.cpp */; };
 		DFF0F3A917528350002DA3A4 /* SettingUpdate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB03172D9CAB00A43CF7 /* SettingUpdate.cpp */; };
-		DFF0F3AA17528350002DA3A4 /* SettingVisibility.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB05172D9CAB00A43CF7 /* SettingVisibility.cpp */; };
 		DFF0F3AB17528350002DA3A4 /* SkinSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF89901A1709BB2D00B35C21 /* SkinSettings.cpp */; };
 		DFF0F3AC17528350002DA3A4 /* VideoSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E010D25F9FD00618676 /* VideoSettings.cpp */; };
 		DFF0F3AD17528350002DA3A4 /* DarwinStorageProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD73108E6A7A0010EC2A /* DarwinStorageProvider.cpp */; };
@@ -2773,7 +2774,6 @@
 		E499142B174E603C00741B6D /* SettingSection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB00172D9CAB00A43CF7 /* SettingSection.cpp */; };
 		E499142C174E603C00741B6D /* SettingsManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB02172D9CAB00A43CF7 /* SettingsManager.cpp */; };
 		E499142D174E603C00741B6D /* SettingUpdate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB03172D9CAB00A43CF7 /* SettingUpdate.cpp */; };
-		E499142E174E603C00741B6D /* SettingVisibility.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFECFB05172D9CAB00A43CF7 /* SettingVisibility.cpp */; };
 		E499142F174E603C00741B6D /* SkinSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF89901A1709BB2D00B35C21 /* SkinSettings.cpp */; };
 		E4991430174E603C00741B6D /* VideoSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E010D25F9FD00618676 /* VideoSettings.cpp */; };
 		E4991431174E604300741B6D /* DarwinStorageProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD73108E6A7A0010EC2A /* DarwinStorageProvider.cpp */; };
@@ -4014,6 +4014,8 @@
 		DF28EDA0170E1A11005FA9D2 /* GUIWindowSettingsProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowSettingsProfile.h; sourceTree = "<group>"; };
 		DF28EE01170E1E51005FA9D2 /* DisplaySettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DisplaySettings.cpp; sourceTree = "<group>"; };
 		DF28EE02170E1E51005FA9D2 /* DisplaySettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisplaySettings.h; sourceTree = "<group>"; };
+		DF29667E17B2B04300DF10F9 /* SettingRequirement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SettingRequirement.cpp; sourceTree = "<group>"; };
+		DF29667F17B2B04300DF10F9 /* SettingRequirement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingRequirement.h; sourceTree = "<group>"; };
 		DF3488E513FD958F0026A711 /* GUIAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIAction.cpp; sourceTree = "<group>"; };
 		DF3488E613FD958F0026A711 /* GUIAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIAction.h; sourceTree = "<group>"; };
 		DF34892813FD9C780026A711 /* AirPlayServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AirPlayServer.cpp; sourceTree = "<group>"; };
@@ -4255,8 +4257,6 @@
 		DFECFB02172D9CAB00A43CF7 /* SettingsManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SettingsManager.cpp; sourceTree = "<group>"; };
 		DFECFB03172D9CAB00A43CF7 /* SettingUpdate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SettingUpdate.cpp; sourceTree = "<group>"; };
 		DFECFB04172D9CAB00A43CF7 /* SettingUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingUpdate.h; sourceTree = "<group>"; };
-		DFECFB05172D9CAB00A43CF7 /* SettingVisibility.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SettingVisibility.cpp; sourceTree = "<group>"; };
-		DFECFB06172D9CAB00A43CF7 /* SettingVisibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingVisibility.h; sourceTree = "<group>"; };
 		DFECFB1A172D9D0100A43CF7 /* BooleanLogic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BooleanLogic.cpp; sourceTree = "<group>"; };
 		DFECFB1B172D9D0100A43CF7 /* BooleanLogic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BooleanLogic.h; sourceTree = "<group>"; };
 		DFECFB4A172D9D6D00A43CF7 /* NetworkServices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkServices.cpp; sourceTree = "<group>"; };
@@ -8513,6 +8513,8 @@
 				DFECFAFD172D9CAB00A43CF7 /* SettingDependency.h */,
 				DFECFAFE172D9CAB00A43CF7 /* SettingPath.cpp */,
 				DFECFAFF172D9CAB00A43CF7 /* SettingPath.h */,
+				DF29667E17B2B04300DF10F9 /* SettingRequirement.cpp */,
+				DF29667F17B2B04300DF10F9 /* SettingRequirement.h */,
 				18B7C38E129420E5009E7A26 /* Settings.cpp */,
 				18B7C38F129420E5009E7A26 /* Settings.h */,
 				DFECFB00172D9CAB00A43CF7 /* SettingSection.cpp */,
@@ -8521,8 +8523,6 @@
 				0E30286C1759FCC200D93596 /* SettingsManager.h */,
 				DFECFB03172D9CAB00A43CF7 /* SettingUpdate.cpp */,
 				DFECFB04172D9CAB00A43CF7 /* SettingUpdate.h */,
-				DFECFB05172D9CAB00A43CF7 /* SettingVisibility.cpp */,
-				DFECFB06172D9CAB00A43CF7 /* SettingVisibility.h */,
 				DF89901A1709BB2D00B35C21 /* SkinSettings.cpp */,
 				DF89901B1709BB2D00B35C21 /* SkinSettings.h */,
 				E38E1E010D25F9FD00618676 /* VideoSettings.cpp */,
@@ -10567,7 +10567,6 @@
 				DFECFB0F172D9CAB00A43CF7 /* SettingSection.cpp in Sources */,
 				DFECFB10172D9CAB00A43CF7 /* SettingsManager.cpp in Sources */,
 				DFECFB11172D9CAB00A43CF7 /* SettingUpdate.cpp in Sources */,
-				DFECFB12172D9CAB00A43CF7 /* SettingVisibility.cpp in Sources */,
 				DFECFB1C172D9D0100A43CF7 /* BooleanLogic.cpp in Sources */,
 				DFECFB4C172D9D6D00A43CF7 /* NetworkServices.cpp in Sources */,
 				F5DB700217322DBB00D4DF21 /* FavouritesOperations.cpp in Sources */,
@@ -10586,6 +10585,7 @@
 				55611BA31766672F00754072 /* RenderFlags.cpp in Sources */,
 				5558ED10176396CD00118C35 /* StereoscopicsManager.cpp in Sources */,
 				F59EED7E17AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
+				DF29668017B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11376,7 +11376,6 @@
 				DFF0F3A717528350002DA3A4 /* SettingSection.cpp in Sources */,
 				DFF0F3A817528350002DA3A4 /* SettingsManager.cpp in Sources */,
 				DFF0F3A917528350002DA3A4 /* SettingUpdate.cpp in Sources */,
-				DFF0F3AA17528350002DA3A4 /* SettingVisibility.cpp in Sources */,
 				DFF0F3AB17528350002DA3A4 /* SkinSettings.cpp in Sources */,
 				DFF0F3AC17528350002DA3A4 /* VideoSettings.cpp in Sources */,
 				DFF0F3AD17528350002DA3A4 /* DarwinStorageProvider.cpp in Sources */,
@@ -11612,6 +11611,7 @@
 				F55BA70C17AB2265002A36D1 /* StereoscopicsManager.cpp in Sources */,
 				F55BA71117AB2293002A36D1 /* RenderFlags.cpp in Sources */,
 				F59EED8017AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
+				DF29668217B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12409,7 +12409,6 @@
 				E499142B174E603C00741B6D /* SettingSection.cpp in Sources */,
 				E499142C174E603C00741B6D /* SettingsManager.cpp in Sources */,
 				E499142D174E603C00741B6D /* SettingUpdate.cpp in Sources */,
-				E499142E174E603C00741B6D /* SettingVisibility.cpp in Sources */,
 				E499142F174E603C00741B6D /* SkinSettings.cpp in Sources */,
 				E4991430174E603C00741B6D /* VideoSettings.cpp in Sources */,
 				E4991431174E604300741B6D /* DarwinStorageProvider.cpp in Sources */,
@@ -12640,6 +12639,7 @@
 				F55BA70B17AB2264002A36D1 /* StereoscopicsManager.cpp in Sources */,
 				F55BA71017AB2293002A36D1 /* RenderFlags.cpp in Sources */,
 				F59EED7F17AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
+				DF29668117B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -984,7 +984,7 @@
     <ClCompile Include="..\..\xbmc\settings\SettingSection.cpp" />
     <ClCompile Include="..\..\xbmc\settings\SettingsManager.cpp" />
     <ClCompile Include="..\..\xbmc\settings\SettingUpdate.cpp" />
-    <ClCompile Include="..\..\xbmc\settings\SettingVisibility.cpp" />
+    <ClCompile Include="..\..\xbmc\settings\SettingRequirement.cpp" />
     <ClCompile Include="..\..\xbmc\settings\SkinSettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\VideoSettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\windows\GUIControlSettings.cpp" />
@@ -1185,7 +1185,7 @@
     <ClInclude Include="..\..\xbmc\settings\SettingSection.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingsManager.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingUpdate.h" />
-    <ClInclude Include="..\..\xbmc\settings\SettingVisibility.h" />
+    <ClInclude Include="..\..\xbmc\settings\SettingRequirement.h" />
     <ClInclude Include="..\..\xbmc\settings\SkinSettings.h" />
     <ClInclude Include="..\..\xbmc\settings\windows\GUIControlSettings.h" />
     <ClInclude Include="..\..\xbmc\settings\windows\GUIWindowSettings.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3005,9 +3005,6 @@
     <ClCompile Include="..\..\xbmc\settings\SettingDependency.cpp">
       <Filter>settings</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\xbmc\settings\SettingVisibility.cpp">
-      <Filter>settings</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\xbmc\network\NetworkServices.cpp">
       <Filter>network</Filter>
     </ClCompile>
@@ -3076,6 +3073,9 @@
       <Filter>utils</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\ApplicationPlayer.cpp" />
+    <ClCompile Include="..\..\xbmc\settings\SettingRequirement.cpp">
+      <Filter>settings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5948,9 +5948,6 @@
     <ClInclude Include="..\..\xbmc\settings\SettingDependency.h">
       <Filter>settings</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\xbmc\settings\SettingVisibility.h">
-      <Filter>settings</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\xbmc\network\NetworkServices.h">
       <Filter>network</Filter>
     </ClInclude>
@@ -6031,6 +6028,9 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\ApplicationPlayer.h" />
+    <ClInclude Include="..\..\xbmc\settings\SettingRequirement.h">
+      <Filter>settings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -34,10 +34,10 @@
     <category id="audiooutput">
       <group id="1">
         <setting id="audiooutput.ac3passthrough">
-          <visible>IsAppleTV2</visible>
+          <requirement>IsAppleTV2</requirement>
         </setting>
         <setting id="audiooutput.dtspassthrough">
-          <visible>IsAppleTV2</visible>
+          <requirement>IsAppleTV2</requirement>
         </setting>
         <setting id="audiooutput.multichannellpcm">
           <visible>false</visible>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -371,42 +371,42 @@
           </control>
         </setting>
         <setting id="videoplayer.usevdpau" type="boolean" label="13425" help="36155">
-          <visible>HAVE_LIBVDPAU</visible>
+          <requirement>HAVE_LIBVDPAU</requirement>
           <level>2</level>
           <default>true</default>
         </setting>
         <setting id="videoplayer.usevaapi" type="boolean" label="13426" help="36156">
-          <visible>HAVE_LIBVA</visible>
+          <requirement>HAVE_LIBVA</requirement>
           <level>2</level>
           <default>true</default>
         </setting>
         <setting id="videoplayer.usedxva2" type="boolean" label="13427" help="36158">
-          <visible>HasDXVA2</visible>
+          <requirement>HasDXVA2</requirement>
           <level>2</level>
           <default>true</default>
         </setting>
         <setting id="videoplayer.usechd" type="boolean" label="13428" help="36159">
-          <visible>HasCrystalHDDevice</visible>
+          <requirement>HasCrystalHDDevice</requirement>
           <level>2</level>
           <default>true</default>
         </setting>
         <setting id="videoplayer.useomx" type="boolean" label="13430" help="36161">
-          <visible>HAVE_LIBOPENMAX</visible>
+          <requirement>HAVE_LIBOPENMAX</requirement>
           <level>2</level>
           <default>true</default>
         </setting>
         <setting id="videoplayer.usevideotoolbox" type="boolean" label="13432" help="36162">
-          <visible>HasVideoToolBoxDecoder</visible>
+          <requirement>HasVideoToolBoxDecoder</requirement>
           <level>2</level>
           <default>true</default>
         </setting>
         <setting id="videoplayer.usestagefright" type="boolean" label="13436" help="36260">
-          <visible>HAVE_LIBSTAGEFRIGHTDECODER</visible>
+          <requirement>HAVE_LIBSTAGEFRIGHTDECODER</requirement>
           <level>2</level>
           <default>true</default>
         </setting>
         <setting id="videoplayer.usepbo" type="boolean" label="13424" help="36163">
-          <visible>HAS_GL</visible>
+          <requirement>HAS_GL</requirement>
           <level>4</level>
           <default>true</default>
         </setting>
@@ -517,13 +517,13 @@
           <control type="spinner" format="string" />
         </setting>
         <setting id="videoplayer.vdpau_allow_xrandr" type="boolean" label="13122" help="36172">
-          <visible>HAVE_LIBVDPAU</visible>
+          <requirement>HAVE_LIBVDPAU</requirement>
           <level>4</level>
           <default>false</default>
         </setting>
       </group>
       <group id="3">
-        <visible>
+        <requirement>
           <and>
             <or>
               <condition>HAS_GL</condition>
@@ -531,7 +531,7 @@
             </or>
             <condition>HAVE_LIBVDPAU</condition>
           </and>
-        </visible>
+        </requirement>
         <setting id="videoplayer.vdpauUpscalingLevel" type="boolean" label="13121" help="36173">
           <level>4</level>
           <default>false</default>
@@ -1444,7 +1444,7 @@
       </group>
     </category>
     <category id="karaoke" label="13327" help="36292">
-      <visible>HAS_KARAOKE</visible>
+      <requirement>HAS_KARAOKE</requirement>
       <group id="1">
         <setting id="karaoke.enabled" type="boolean" label="13323" help="36293">
           <level>2</level>
@@ -1661,7 +1661,7 @@
       </group>
     </category>
     <category id="webserver" label="33101" help="36327">
-      <visible>HAS_WEB_SERVER</visible>
+      <requirement>HAS_WEB_SERVER</requirement>
       <group id="1">
         <setting id="services.webserver" type="boolean" label="263" help="36328">
           <level>1</level>
@@ -1709,19 +1709,19 @@
       </group>
     </category>
     <category id="remotecontrol" label="790" help="36333">
-      <visible>
+      <requirement>
         <or>
           <condition>HAS_EVENT_SERVER</condition>
           <condition>HAS_JSONRPC</condition>
         </or>
-      </visible>
+      </requirement>
       <group id="1">
         <setting id="services.esenabled" type="boolean" label="791" help="36334">
           <level>1</level>
           <default>true</default>
         </setting>
         <setting id="services.esport" type="integer" label="792" help="36335">
-          <visible>HAS_EVENT_SERVER</visible>
+          <requirement>HAS_EVENT_SERVER</requirement>
           <level>4</level>
           <default>9777</default>
           <constraints>
@@ -1735,7 +1735,7 @@
           <control type="edit" format="integer" />
         </setting>
         <setting id="services.esportrange" type="integer" label="793" help="36336">
-          <visible>HAS_EVENT_SERVER</visible>
+          <requirement>HAS_EVENT_SERVER</requirement>
           <level>4</level>
           <default>10</default>
           <constraints>
@@ -1749,7 +1749,7 @@
           <control type="spinner" format="integer" />
         </setting>
         <setting id="services.esmaxclients" type="integer" label="797" help="36337">
-          <visible>HAS_EVENT_SERVER</visible>
+          <requirement>HAS_EVENT_SERVER</requirement>
           <level>4</level>
           <default>20</default>
           <constraints>
@@ -1770,7 +1770,7 @@
           </dependencies>
         </setting>
         <setting id="services.esinitialdelay" type="integer" label="795" help="36339">
-          <visible>HAS_EVENT_SERVER</visible>
+          <requirement>HAS_EVENT_SERVER</requirement>
           <level>4</level>
           <default>750</default>
           <constraints>
@@ -1784,7 +1784,7 @@
           <control type="spinner" format="integer" />
         </setting>
         <setting id="services.escontinuousdelay" type="integer" label="796" help="36340">
-          <visible>HAS_EVENT_SERVER</visible>
+          <requirement>HAS_EVENT_SERVER</requirement>
           <level>4</level>
           <default>25</default>
           <constraints>
@@ -1800,7 +1800,7 @@
       </group>
     </category>
     <category id="zeroconf" label="1259" help="36341">
-      <visible>HAS_ZEROCONF</visible>
+      <requirement>HAS_ZEROCONF</requirement>
       <group id="1">
         <setting id="services.zeroconf" type="boolean" label="1260" help="36342">
           <level>2</level>
@@ -1809,7 +1809,7 @@
       </group>
     </category>
     <category id="airplay" label="1273" help="36343">
-      <visible>HAS_AIRPLAY</visible>
+      <requirement>HAS_AIRPLAY</requirement>
       <group id="1">
         <setting id="services.airplay" type="boolean" label="1270" help="36343">
           <level>1</level>
@@ -1885,7 +1885,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="videoscreen.screenmode" type="string" label="243" help="36353">
-          <visible>IsStandAlone</visible>
+          <requirement>IsStandAlone</requirement>
           <level>0</level>
           <default>DESKTOP</default>
           <constraints>
@@ -1947,16 +1947,16 @@
           <level>1</level>
         </setting>
         <setting id="videoscreen.testpattern" type="action" label="226" help="36358">
-          <visible>HAS_GL</visible>
+          <requirement>HAS_GL</requirement>
           <level>1</level>
         </setting>
         <setting id="videoscreen.limitedrange" type="boolean" label="36042" help="36359">
-          <visible>
+          <requirement>
             <or>
               <condition>HAS_GL</condition>
               <condition>HAS_DX</condition>
             </or>
-          </visible>
+          </requirement>
           <level>3</level>
           <default>false</default>
           <updates>
@@ -2002,7 +2002,7 @@
           <default>true</default>
         </setting>
         <setting id="audiooutput.processquality" type="integer" label="13505" help="36169">
-          <visible>HAS_AE_QUALITY_LEVELS</visible>
+          <requirement>HAS_AE_QUALITY_LEVELS</requirement>
           <level>2</level>
           <default>30</default> <!-- AE_QUALITY_MID -->
           <constraints>
@@ -2078,7 +2078,7 @@
         </setting>
         <setting id="audiooutput.streamsilence" type="boolean" label="421" help="34111">
           <level>2</level>
-          <visible>audiosupportsdrain</visible>
+          <requirement>audiosupportsdrain</requirement>
           <default>true</default>
         </setting>
       </group>
@@ -2142,7 +2142,7 @@
           <default>true</default>
         </setting>
         <setting id="input.enablejoystick" type="boolean" label="35100" help="36378">
-          <visible>HAS_SDL_JOYSTICK</visible>
+          <requirement>HAS_SDL_JOYSTICK</requirement>
           <level>0</level>
           <default>true</default>
         </setting>

--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -11,10 +11,10 @@
     <category id="videoplayer">
       <group id="2">
         <setting id="videoplayer.usedisplayasclock">
-          <visible negated="true">HAS_GL</visible>
+          <requirement negated="true">HAS_GL</requirement>
         </setting>
         <setting id="videoplayer.synctype">
-          <visible negated="true">HAS_GL</visible>
+          <requirement negated="true">HAS_GL</requirement>
         </setting>
       </group>
     </category>
@@ -35,7 +35,7 @@
     <category id="videoscreen">
       <group id="1">
         <setting id="videoscreen.fakefullscreen">
-          <visible negated="true">HAS_GL</visible>
+          <requirement negated="true">HAS_GL</requirement>
         </setting>
       </group>
     </category>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1259,7 +1259,7 @@ bool CApplication::Initialize()
   m_dpms = new DPMSSupport();
   if (g_windowManager.Initialized())
   {
-    CSettings::Get().GetSetting("powermanagement.displaysoff")->SetVisible(m_dpms->IsSupported());
+    CSettings::Get().GetSetting("powermanagement.displaysoff")->SetRequirementsMet(m_dpms->IsSupported());
 
     g_windowManager.Add(new CGUIWindowHome);
     g_windowManager.Add(new CGUIWindowPrograms);

--- a/xbmc/settings/ISetting.cpp
+++ b/xbmc/settings/ISetting.cpp
@@ -21,8 +21,10 @@
 #include "ISetting.h"
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
 
 #define XML_VISIBLE     "visible"
+#define XML_REQUIREMENT "requirement"
 #define XML_CONDITION   "condition"
 
 using namespace std;
@@ -31,7 +33,8 @@ ISetting::ISetting(const std::string &id, CSettingsManager *settingsManager /* =
   : m_id(id),
     m_settingsManager(settingsManager),
     m_visible(true),
-    m_visibilityCondition(settingsManager)
+    m_meetsRequirements(true),
+    m_requirementCondition(settingsManager)
 { }
   
 bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
@@ -39,11 +42,15 @@ bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (node == NULL)
     return false;
 
-  const TiXmlNode *visibleNode = node->FirstChild(XML_VISIBLE);
-  if (visibleNode == NULL)
+  bool value;
+  if (XMLUtils::GetBoolean(node, XML_VISIBLE, value))
+    m_visible = value;
+
+  const TiXmlNode *requirementNode = node->FirstChild(XML_REQUIREMENT);
+  if (requirementNode == NULL)
     return true;
 
-  return m_visibilityCondition.Deserialize(visibleNode);
+  return m_requirementCondition.Deserialize(requirementNode);
 }
 
 bool ISetting::DeserializeIdentification(const TiXmlNode *node, std::string &identification)
@@ -63,7 +70,7 @@ bool ISetting::DeserializeIdentification(const TiXmlNode *node, std::string &ide
   return true;
 }
 
-void ISetting::CheckVisible()
+void ISetting::CheckRequirements()
 {
-  m_visible = m_visibilityCondition.Check();
+  m_meetsRequirements = m_requirementCondition.Check();
 }

--- a/xbmc/settings/ISetting.h
+++ b/xbmc/settings/ISetting.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "SettingVisibility.h"
+#include "SettingRequirement.h"
 
 #define XML_SETTING     "setting"
 
@@ -73,17 +73,30 @@ public:
 
    \return True if the setting object is visible, false otherwise
    */
-  bool IsVisible() const { return m_visible; }
-  /*!
-   \brief Updates the visibility state of the setting object.
-   */
-  void CheckVisible();
+  virtual bool IsVisible() const { return m_visible; }
   /*!
    \brief Sets the visibility state of the setting object.
 
    \param visible Whether the setting object shall be visible or not
    */
-  void SetVisible(bool visible) { m_visible = visible; }
+  virtual void SetVisible(bool visible) { m_visible = visible; }
+
+  /*!
+   \brief Whether the setting object meets all necessary requirements.
+
+   \return True if the setting object meets all necessary requirements, false otherwise
+   */
+  virtual bool MeetsRequirements() const { return m_meetsRequirements; }
+  /*!
+   \brief Checks if the setting object meets all necessary requirements.
+   */
+  virtual void CheckRequirements();
+  /*!
+   \brief Sets whether the setting object meets all necessary requirements.
+
+   \param visible Whether the setting object meets all necessary requirements or not
+   */
+  virtual void SetRequirementsMet(bool requirementsMet) { m_meetsRequirements = requirementsMet; }
 
   /*!
    \brief Deserializes the given XML node to retrieve a setting object's
@@ -101,5 +114,6 @@ protected:
 
 private:
   bool m_visible;
-  CSettingVisibility m_visibilityCondition;
+  bool m_meetsRequirements;
+  CSettingRequirement m_requirementCondition;
 };

--- a/xbmc/settings/Makefile
+++ b/xbmc/settings/Makefile
@@ -13,8 +13,8 @@ SRCS=AdvancedSettings.cpp \
      SettingSection.cpp \
      Settings.cpp \
      SettingsManager.cpp \
+     SettingRequirement.cpp \
      SettingUpdate.cpp \
-     SettingVisibility.cpp \
      SkinSettings.cpp \
      VideoSettings.cpp \
 

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -210,6 +210,7 @@ void CSetting::OnSettingPropertyChanged(const CSetting *setting, const char *pro
 void CSetting::Copy(const CSetting &setting)
 {
   SetVisible(setting.IsVisible());
+  SetRequirementsMet(setting.MeetsRequirements());
   m_callback = setting.m_callback;
   m_label = setting.m_label;
   m_help = setting.m_help;

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -167,6 +167,27 @@ bool CSetting::IsEnabled() const
   return enabled;
 }
 
+bool CSetting::IsVisible() const
+{
+  if (!ISetting::IsVisible())
+    return false;
+
+  bool visible = true;
+  for (SettingDependencies::const_iterator depIt = m_dependencies.begin(); depIt != m_dependencies.end(); ++depIt)
+  {
+    if (depIt->GetType() != SettingDependencyTypeVisible)
+      continue;
+
+    if (!depIt->Check())
+    {
+      visible = false;
+      break;
+    }
+  }
+
+  return visible;
+}
+
 bool CSetting::OnSettingChanging(const CSetting *setting)
 {
   if (m_callback == NULL)

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -100,6 +100,9 @@ public:
   const SettingDependencies& GetDependencies() const { return m_dependencies; }
   const std::set<CSettingUpdate>& GetUpdates() const { return m_updates; }
 
+  // overrides of ISetting
+  virtual bool IsVisible() const;
+
 protected:
   friend class CSettingsManager;
 

--- a/xbmc/settings/SettingDependency.cpp
+++ b/xbmc/settings/SettingDependency.cpp
@@ -245,6 +245,8 @@ bool CSettingDependency::setType(const std::string &type)
     m_type = SettingDependencyTypeEnable;
   else if (StringUtils::EqualsNoCase(type, "update"))
     m_type = SettingDependencyTypeUpdate;
+  else if (StringUtils::EqualsNoCase(type, "visible"))
+    m_type = SettingDependencyTypeVisible;
   else
     return false;
 

--- a/xbmc/settings/SettingDependency.h
+++ b/xbmc/settings/SettingDependency.h
@@ -29,7 +29,8 @@
 typedef enum {
   SettingDependencyTypeNone   = 0,
   SettingDependencyTypeEnable,
-  SettingDependencyTypeUpdate
+  SettingDependencyTypeUpdate,
+  SettingDependencyTypeVisible
 } SettingDependencyType;
 
 typedef enum {

--- a/xbmc/settings/SettingRequirement.cpp
+++ b/xbmc/settings/SettingRequirement.cpp
@@ -18,10 +18,10 @@
  *
  */
 
-#include "SettingVisibility.h"
+#include "SettingRequirement.h"
 #include "SettingsManager.h"
 
-bool CSettingVisibilityCondition::Check() const
+bool CSettingRequirementCondition::Check() const
 {
   if (m_settingsManager == NULL)
     return false;
@@ -33,7 +33,7 @@ bool CSettingVisibilityCondition::Check() const
   return found;
 }
 
-bool CSettingVisibilityConditionCombination::Check() const
+bool CSettingRequirementConditionCombination::Check() const
 {
   if (m_operations.empty() && m_values.empty())
     return true;
@@ -41,8 +41,8 @@ bool CSettingVisibilityConditionCombination::Check() const
   return CSettingConditionCombination::Check();
 }
 
-CSettingVisibility::CSettingVisibility(CSettingsManager *settingsManager /* = NULL */)
+CSettingRequirement::CSettingRequirement(CSettingsManager *settingsManager /* = NULL */)
   : CSettingCondition(settingsManager)
 {
-  m_operation = CBooleanLogicOperationPtr(new CSettingVisibilityConditionCombination(m_settingsManager));
+  m_operation = CBooleanLogicOperationPtr(new CSettingRequirementConditionCombination(m_settingsManager));
 }

--- a/xbmc/settings/SettingRequirement.h
+++ b/xbmc/settings/SettingRequirement.h
@@ -24,35 +24,35 @@
 
 #include "SettingConditions.h"
 
-class CSettingVisibilityCondition : public CSettingConditionItem
+class CSettingRequirementCondition : public CSettingConditionItem
 {
 public:
-  CSettingVisibilityCondition(CSettingsManager *settingsManager = NULL)
+  CSettingRequirementCondition(CSettingsManager *settingsManager = NULL)
     : CSettingConditionItem(settingsManager)
   { }
-  virtual ~CSettingVisibilityCondition() { }
+  virtual ~CSettingRequirementCondition() { }
 
   virtual bool Check() const;
 };
 
-class CSettingVisibilityConditionCombination : public CSettingConditionCombination
+class CSettingRequirementConditionCombination : public CSettingConditionCombination
 {
 public:
-  CSettingVisibilityConditionCombination(CSettingsManager *settingsManager = NULL)
+  CSettingRequirementConditionCombination(CSettingsManager *settingsManager = NULL)
     : CSettingConditionCombination(settingsManager)
   { }
-  virtual ~CSettingVisibilityConditionCombination() { }
+  virtual ~CSettingRequirementConditionCombination() { }
 
   virtual bool Check() const;
 
 private:
-  virtual CBooleanLogicOperation* newOperation() { return new CSettingVisibilityConditionCombination(m_settingsManager); }
-  virtual CBooleanLogicValue* newValue() { return new CSettingVisibilityCondition(m_settingsManager); }
+  virtual CBooleanLogicOperation* newOperation() { return new CSettingRequirementConditionCombination(m_settingsManager); }
+  virtual CBooleanLogicValue* newValue() { return new CSettingRequirementCondition(m_settingsManager); }
 };
 
-class CSettingVisibility : public CSettingCondition
+class CSettingRequirement : public CSettingCondition
 {
 public:
-  CSettingVisibility(CSettingsManager *settingsManager = NULL);
-  virtual ~CSettingVisibility() { }
+  CSettingRequirement(CSettingsManager *settingsManager = NULL);
+  virtual ~CSettingRequirement() { }
 };

--- a/xbmc/settings/SettingSection.cpp
+++ b/xbmc/settings/SettingSection.cpp
@@ -135,7 +135,7 @@ SettingList CSettingGroup::GetSettings(SettingLevel level) const
 
   for (SettingList::const_iterator it = m_settings.begin(); it != m_settings.end(); ++it)
   {
-    if ((*it)->GetLevel() <= level && (*it)->IsVisible())
+    if ((*it)->GetLevel() <= level && (*it)->MeetsRequirements())
       settings.push_back(*it);
   }
 
@@ -221,7 +221,7 @@ SettingGroupList CSettingCategory::GetGroups(SettingLevel level) const
 
   for (SettingGroupList::const_iterator it = m_groups.begin(); it != m_groups.end(); ++it)
   {
-    if ((*it)->IsVisible() && (*it)->GetSettings(level).size() > 0)
+    if ((*it)->MeetsRequirements() && (*it)->GetSettings(level).size() > 0)
       groups.push_back(*it);
   }
 
@@ -307,7 +307,7 @@ SettingCategoryList CSettingSection::GetCategories(SettingLevel level) const
 
   for (SettingCategoryList::const_iterator it = m_categories.begin(); it != m_categories.end(); ++it)
   {
-    if ((*it)->IsVisible() && (*it)->GetGroups(level).size() > 0)
+    if ((*it)->MeetsRequirements() && (*it)->GetGroups(level).size() > 0)
       categories.push_back(*it);
   }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -604,8 +604,8 @@ void CSettings::InitializeVisibility()
 
   if (!g_sysinfo.IsAppleTV2() || GetIOSVersion() >= 4.3)
   {
-    timezonecountry->SetVisible(false);
-    timezone->SetVisible(false);
+    timezonecountry->SetRequirementsMet(false);
+    timezone->SetRequirementsMet(false);
   }
 #endif
 }

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -953,6 +953,13 @@ void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, c
       break;
     }
 
+    case SettingDependencyTypeVisible:
+      // just trigger the property changed callback and a call to
+      // CSetting::IsVisible() will automatically determine the new
+      // visible state
+      OnSettingPropertyChanged(setting, "visible");
+      break;
+
     case SettingDependencyTypeNone:
     default:
       break;

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -73,20 +73,20 @@ bool CSettingsManager::Initialize(const TiXmlElement *root)
 
       if (section->Deserialize(sectionNode, update))
       {
-        section->CheckVisible();
+        section->CheckRequirements();
         if (!update)
           m_sections[section->GetId()] = section;
 
         // get all settings and add them to the settings map
         for (SettingCategoryList::const_iterator categoryIt = section->GetCategories().begin(); categoryIt != section->GetCategories().end(); ++categoryIt)
         {
-          (*categoryIt)->CheckVisible();
+          (*categoryIt)->CheckRequirements();
           for (SettingGroupList::const_iterator groupIt = (*categoryIt)->GetGroups().begin(); groupIt != (*categoryIt)->GetGroups().end(); ++groupIt)
           {
-            (*groupIt)->CheckVisible();
+            (*groupIt)->CheckRequirements();
             for (SettingList::const_iterator settingIt = (*groupIt)->GetSettings().begin(); settingIt != (*groupIt)->GetSettings().end(); ++settingIt)
             {
-              (*settingIt)->CheckVisible();
+              (*settingIt)->CheckRequirements();
 
               const std::string &settingId = (*settingIt)->GetId();
               SettingMap::iterator setting = m_settings.find(settingId);

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -57,8 +57,11 @@ bool CGUIControlBaseSetting::IsEnabled() const
 void CGUIControlBaseSetting::Update()
 {
   CGUIControl *control = GetControl();
-  if (control != NULL)
-    control->SetEnabled(IsEnabled());
+  if (control == NULL)
+    return;
+
+  control->SetEnabled(IsEnabled());
+  control->SetVisible(m_pSetting->IsVisible());
 }
 
 CGUIControlRadioButtonSetting::CGUIControlRadioButtonSetting(CGUIRadioButtonControl *pRadioButton, int id, CSetting *pSetting)


### PR DESCRIPTION
Based on the request in the team to be able to dynamically show/hide settings based on the (changed) value of another setting I have implemented that feature. Up until now visibility of a setting (control) was a static decision and was made when the list of visible settings was retrieved. To be able to do this dynamically all the potentially visible settings of a category need to be present (but some of the settings may be hidden) so I had to change the functionality of the <visible> tag in the settings XML definition.
I decided to split the original <visible> tag into a new (complex) <requirement> tag and a (simple) <visible> tag. The new <visible> tag simply takes a boolean value ("true" or "false") and is static but is very useful to hide specific settings or groups for a specific platform. The new <requirement> tag basically works exactly the same as the old <visible> tag and can make use of HAS_FOO variables etc (which are requirements for a setting to make sense, hence the name of the new tag).
Dynamic visibility of settings is solved using the existing <dependency> tags with the new type "visible" which can be defined for a setting and can reference a static/dynamic variable or depend upon the value of another setting. Changing the value of a setting will trigger dependency checks on all other settings in the current category and will update their state (enabled/disabled, visible/hidden, ...) if necessary.

With this it should be easily possible to define that a setting should only be visible if another setting has the value X etc.

Note: needs xcode project monkey work.
