### PR TITLE
[rbp/omxplayer] Fix build error in types for max

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -473,7 +473,7 @@ bool COMXAudio::Initialize(AEAudioFormat format, std::string& device, OMXClock *
     return false;
   }
 
-  port_param.nBufferCountActual = std::max(port_param.nBufferCountMin, m_BufferLen / port_param.nBufferSize);
+  port_param.nBufferCountActual = std::max((unsigned int)port_param.nBufferCountMin, m_BufferLen / port_param.nBufferSize);
 
   omx_err = m_omx_decoder.SetParameter(OMX_IndexParamPortDefinition, &port_param);
   if(omx_err != OMX_ErrorNone)


### PR DESCRIPTION
It seems there is a compile error when STDINT_H_AVAILABLE is not defined.
See: http://raspbmc.apt-get.eu/downloads/bin/xbmc/nightlies/xbmc-rbp-20130710.log
