### PR TITLE
transcoding to AC3 for CoreAudio

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -156,10 +156,11 @@ private:
   unsigned int      m_lastSampleRate;
   unsigned int      m_chLayoutCount;
   bool              m_rawPassthrough;
+  bool              m_transcode;
 
   enum AEStdChLayout m_stdChLayout;
 
-  bool              OpenCoreAudio(unsigned int sampleRate, bool forceRaw, enum AEDataFormat rawDataFormat);
+  bool              OpenCoreAudio(unsigned int sampleRate, bool forceRaw, enum AEDataFormat rawDataFormat, bool forceTranscode);
   void              Deinitialize();
   void              Start();
   void              Stop();

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
@@ -26,6 +26,7 @@
 #include "xbmc/cores/AudioEngine/Interfaces/AE.h"
 #include "xbmc/cores/AudioEngine/AEFactory.h"
 #include "xbmc/cores/AudioEngine/Utils/AEUtil.h"
+#include "xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "settings/AdvancedSettings.h"
@@ -88,7 +89,7 @@ void CCoreAudioAEStream::Upmix(void *input,
   }
 }
 
-CCoreAudioAEStream::CCoreAudioAEStream(enum AEDataFormat dataFormat, unsigned int sampleRate, unsigned int encodedSamplerate, CAEChannelInfo channelLayout, unsigned int options) :
+CCoreAudioAEStream::CCoreAudioAEStream(enum AEDataFormat dataFormat, unsigned int sampleRate, unsigned int encodedSamplerate, CAEChannelInfo channelLayout, unsigned int options, bool transcode) :
   m_outputUnit      (NULL ),
   m_valid           (false),
   m_delete          (false),
@@ -106,18 +107,44 @@ CCoreAudioAEStream::CCoreAudioAEStream(enum AEDataFormat dataFormat, unsigned in
   m_frameSize       (0    ),
   m_doRemap         (true ),
   m_firstInput      (true ),
-  m_flushRequested  (false)
+  m_flushRequested  (false),
+  m_encoder         (NULL )
 {
   m_ssrcData.data_out             = NULL;
+  m_transcode                     = transcode;
 
-  m_rawDataFormat                 = dataFormat;
-  m_StreamFormat.m_dataFormat     = dataFormat;
-  m_StreamFormat.m_sampleRate     = sampleRate;
-  m_StreamFormat.m_encodedRate    = 0;  //we don't support this
-  m_StreamFormat.m_channelLayout  = channelLayout;
+  if (!transcode)
+  {
+    m_rawDataFormat                 = dataFormat;
+    m_StreamFormat.m_dataFormat     = dataFormat;
+    m_StreamFormat.m_sampleRate     = sampleRate;
+    m_StreamFormat.m_encodedRate    = 0;  //we don't support this
+    m_StreamFormat.m_channelLayout  = channelLayout;
+    m_isRaw                         = COREAUDIO_IS_RAW(dataFormat);
+  }
+  else
+  {
+    m_rawDataFormat                 = AE_FMT_AC3;
+    m_StreamFormat.m_dataFormat     = AE_FMT_AC3;
+    m_StreamFormat.m_sampleRate     = 48000;
+    m_StreamFormat.m_encodedRate    = 0;  
+    enum AEChannel ac3Layout[3] = {AE_CH_RAW, AE_CH_RAW, AE_CH_NULL};
+    m_StreamFormat.m_channelLayout  = ac3Layout;
+    m_isRaw                         = true;
+    
+    // setup encoder format
+    m_encoderFormat.m_dataFormat    = dataFormat;
+    m_encoderFormat.m_sampleRate    = sampleRate;
+    m_encoderFormat.m_encodedRate   = 0;
+    m_encoderFormat.m_channelLayout = channelLayout;
+    m_encoderFormat.m_frames        = 0;
+    m_encoderFormat.m_frameSamples  = 0;
+    m_encoderFormat.m_frameSize     = 0;
+  }
+  
+  m_incomingFormat                = dataFormat;
   m_chLayoutCountStream           = m_StreamFormat.m_channelLayout.Count();
-  m_StreamFormat.m_frameSize      = (CAEUtil::DataFormatToBits(dataFormat) >> 3) * m_chLayoutCountStream;
-
+  m_StreamFormat.m_frameSize      = (CAEUtil::DataFormatToBits(m_rawDataFormat) >> 3) * m_chLayoutCountStream;
   m_OutputFormat                  = AE.GetAudioFormat();
   m_chLayoutCountOutput           = m_OutputFormat.m_channelLayout.Count();
 
@@ -131,7 +158,6 @@ CCoreAudioAEStream::CCoreAudioAEStream(enum AEDataFormat dataFormat, unsigned in
   m_remapBuffer                   = (uint8_t *)_aligned_malloc(m_remapBufferSize,16);
   m_vizRemapBuffer                = (uint8_t *)_aligned_malloc(m_vizRemapBufferSize,16);
 
-  m_isRaw                         = COREAUDIO_IS_RAW(dataFormat);
   m_limiter.SetSamplerate(AE.GetSampleRate());
 }
 
@@ -152,6 +178,12 @@ CCoreAudioAEStream::~CCoreAudioAEStream()
 
   delete m_Buffer; m_Buffer = NULL;
 
+  delete m_encoder;
+  m_encoder = NULL;
+  ResetEncoder();
+  
+  m_unencodedBuffer.DeAlloc();
+  
   /*
   if (m_resample)
   {
@@ -231,9 +263,9 @@ void CCoreAudioAEStream::Initialize()
   else
     m_OutputBytesPerSample = (CAEUtil::DataFormatToBits(m_OutputFormat.m_dataFormat) >> 3);
 
-  if (m_isRaw)
+  if (m_isRaw || m_transcode)
   {
-    // we are raw, which means we need to work in the output format
+    // we are raw or transcode, which means we need to work in the output format
     if (m_rawDataFormat != AE_FMT_LPCM)
     {
       m_StreamFormat = AE.GetAudioFormat();
@@ -266,10 +298,7 @@ void CCoreAudioAEStream::Initialize()
     }
 
     m_doRemap  = m_chLayoutCountStream != 2;
-  }
 
-  if (!m_isRaw)
-  {
     if (!m_vizRemap.Initialize(m_OutputFormat.m_channelLayout, CAEChannelInfo(AE_CH_LAYOUT_2_0), false, true))
     {
       m_valid = false;
@@ -277,7 +306,13 @@ void CCoreAudioAEStream::Initialize()
     }
   }
 
-  m_convert = m_StreamFormat.m_dataFormat != AE_FMT_FLOAT && !m_isRaw;
+  // only try to convert if we're not in AE_FMT_FLOAT and (we're not raw or we are transcoding)
+  m_convert =
+    (m_StreamFormat.m_dataFormat != AE_FMT_FLOAT && !m_isRaw)
+    ||
+    (m_incomingFormat != AE_FMT_FLOAT && m_transcode);
+  
+  
   //m_resample = false; //(m_StreamFormat.m_sampleRate != m_OutputFormat.m_sampleRate) && !m_isRaw;
 
   // if we need to convert, set it up
@@ -285,10 +320,23 @@ void CCoreAudioAEStream::Initialize()
   {
     // get the conversion function and allocate a buffer for the data
     CLog::Log(LOGDEBUG, "CCoreAudioAEStream::CCoreAudioAEStream - Converting from %s to AE_FMT_FLOAT", CAEUtil::DataFormatToStr(m_StreamFormat.m_dataFormat));
-    m_convertFn = CAEConvert::ToFloat(m_StreamFormat.m_dataFormat);
+    
+    if (!m_transcode)
+      m_convertFn = CAEConvert::ToFloat(m_StreamFormat.m_dataFormat);
+    else
+      m_convertFn = CAEConvert::ToFloat(m_incomingFormat);
 
     if (!m_convertFn)
       m_valid = false;
+  }
+  
+  // if we need to transcode, set it up
+  if (m_transcode)
+  {    
+    m_unencodedBuffer.Empty();
+
+    if (!m_encoder || !m_encoder->IsCompatible(m_encoderFormat))
+      SetupEncoder();
   }
 
   // if we need to resample, set it up
@@ -365,6 +413,35 @@ unsigned int CCoreAudioAEStream::AddData(void *data, unsigned int size)
   if (samples == 0)
     return 0;
 
+  // transcode if we need to
+  if (m_transcode && m_encoder)
+  {
+    // put adddata in the unencodedBuffer
+    if (m_unencodedBuffer.Free() < addsize)
+      m_unencodedBuffer.ReAlloc(m_unencodedBuffer.Used() + addsize);
+    
+    m_unencodedBuffer.Push(adddata, addsize);
+    
+    unsigned int block = m_encoderFormat.m_frames * m_encoderFormat.m_frameSize;
+    
+    // only try to encode if we have enough data
+    if (m_unencodedBuffer.Used() >= block)
+    {
+        frames = m_encoder->Encode((float *)m_unencodedBuffer.Raw(block), m_encoderFormat.m_frames);
+        m_unencodedBuffer.Shift(NULL, frames * m_encoderFormat.m_frameSize);
+        addsize = m_encoder->GetData(&adddata);
+        samples = addsize / m_OutputBytesPerSample;
+    }
+    else
+      // return size here or whoever calling us will block if we return 0
+      // we have essentially been successful, because we add the audio to our buffer to encode
+      return size;
+  }
+
+  if (samples == 0)
+    return 0;
+
+
   // resample it if we need to
   /*
   if (m_resample)
@@ -437,6 +514,8 @@ unsigned int CCoreAudioAEStream::AddData(void *data, unsigned int size)
   else
     m_Buffer->Write(adddata, addsize);
 
+  // still only return size to indicate success
+  // we likely wrote something !size to m_Buffer, but our called doesn't realy care
   return size;
 }
 
@@ -549,23 +628,31 @@ double CCoreAudioAEStream::GetDelay()
   if (m_delete || !m_Buffer)
     return 0.0f;
 
-  double delay = (double)(m_Buffer->GetReadSize()) / (double)m_AvgBytesPerSec;
-  delay += AE.GetDelay();
-
-  return delay;
+  double delayBuffer = (double)(m_Buffer->GetReadSize()) / (double)m_AvgBytesPerSec;
+  double delayTranscoder = 0.0;
+  
+  if (m_transcode)
+    delayTranscoder = (double)(m_unencodedBuffer.Used()) / (double)(m_encoderFormat.m_frameSize * m_encoderFormat.m_sampleRate);
+    
+  return AE.GetDelay() + delayBuffer + delayTranscoder;
 }
 
 bool CCoreAudioAEStream::IsBuffering()
 {
-  return m_Buffer->GetReadSize() == 0;
+  return (m_Buffer->GetReadSize() == 0 && m_unencodedBuffer.Used() == 0);
 }
 
 double CCoreAudioAEStream::GetCacheTime()
 {
   if (m_delete || !m_Buffer)
     return 0.0f;
-
-  return (double)(m_Buffer->GetReadSize()) / (double)m_AvgBytesPerSec;
+  double delayBuffer = (double)(m_Buffer->GetReadSize()) / (double)m_AvgBytesPerSec;
+  double delayTranscoder = 0.0;
+  
+  if (m_transcode)
+    delayTranscoder = (double)(m_unencodedBuffer.Used()) / (double)(m_encoderFormat.m_frameSize * m_encoderFormat.m_sampleRate);
+  
+  return AE.GetDelay() + delayBuffer + delayTranscoder;
 }
 
 double CCoreAudioAEStream::GetCacheTotal()
@@ -803,4 +890,29 @@ OSStatus CCoreAudioAEStream::OnRender(AudioUnitRenderActionFlags *ioActionFlags,
     *ioActionFlags |= kAudioUnitRenderAction_OutputIsSilence;
 
   return noErr;
+}
+
+void CCoreAudioAEStream::ResetEncoder()
+{
+  if (m_encoder)
+    m_encoder->Reset();
+  m_unencodedBuffer.Empty();
+}
+
+bool CCoreAudioAEStream::SetupEncoder()
+{
+  ResetEncoder();
+  delete m_encoder;
+  m_encoder = NULL;
+  
+  if (!m_transcode)
+    return false;
+  
+  m_encoder = new CAEEncoderFFmpeg();
+  if (m_encoder && m_encoder->Initialize(m_encoderFormat))
+    return true;
+  
+  delete m_encoder;
+  m_encoder = NULL;
+  return false;
 }


### PR DESCRIPTION
Adds transcoding of multichannel audio to AC3 for the CoreAudioEngine.

Basic strategy is to detect is transcoding is needed and possible in CoreAudioAE when MakeStream is called. If transcoding is called for, that gets passed to OpenCoreAudio and changes how the CoreAudioAE object is setup.

The transcoding is triggered in CoreAudioAEStream. It uses the preexisting AEEncoderFFmpeg class that SoftAE uses for the same purpose. In CoreAudioAEStream, transcoded audio is mostly treated like passthrough audio.

Trickest bit CareAudioAEStream is the addition of a buffer for incoming audio that needs to be encoded. The encoder needs to work in specific block sizes, and the incoming stream is not always handed to us in appropriate chunks so we need to buffer it up so we can process it. This required a little fiddling with the delays to make sure sync was kept tight.

I've tested this on Mac mini (mid-2010) running 10.8.4 with both a Denon receiver and a Sonos Playbar, both over HDMI that has its audio stripped out to optical.

I've testing the following formats and everything works as I'd expect:

AC3 Enabled:
AC3 2ch -> passthrough
DTS 2ch -> PCM 2ch
MP3 2ch -> PCM 2ch
AAC 2ch -> PCM 2ch
AC3 5.1 -> passthrough
DTS 5.1 -> transcoded to AC3 5.1
AAC 5.1 -> transcoded to AC3 5.1
DTS-MA 5.1 -> transcoded to AC3 5.1
Dolby True 5.1 -> transcoded to AC3 5.1 (I think we should be able to strip the AC3 out of this stream and pass that through, but the existing code didn't do that either, it just decoded to PCM 5.1)

AC3 and DTS Enabled:

AC3 2ch -> passthrough
DTS 2ch -> passthrough
MP3 2ch -> PCM 2ch
AAC 2ch -> PCM 2ch
AC3 5.1 -> passthrough
DTS 5.1 -> passthrough
AAC 5.1 -> transcoded to AC3 5.1
DTS-MA 5.1 -> passthrough
Dolby True 5.1 -> transcoded to AC3 5.1 
