### PR TITLE
[ffmpeg] Backport of mpegts optimisations

### DIFF
--- a/lib/ffmpeg/libavcodec/mathops.h
+++ b/lib/ffmpeg/libavcodec/mathops.h
@@ -195,6 +195,15 @@ if ((y) < (x)) {\
 #   define FASTDIV(a,b) ((uint32_t)((((uint64_t)a) * ff_inverse[b]) >> 32))
 #endif /* FASTDIV */
 
+#ifndef MOD_UNLIKELY
+#   define MOD_UNLIKELY(modulus, dividend, divisor, prev_dividend) \
+    do { \
+        if ((prev_dividend) == 0 || (dividend) - (prev_dividend) != (divisor)) \
+            (modulus) = (dividend) % (divisor); \
+        (prev_dividend) = (dividend); \
+    } while (0)
+#endif
+
 static inline av_const unsigned int ff_sqrt(unsigned int a)
 {
     unsigned int b;

--- a/lib/ffmpeg/libavformat/avio_internal.h
+++ b/lib/ffmpeg/libavformat/avio_internal.h
@@ -38,6 +38,23 @@ int ffio_init_context(AVIOContext *s,
 
 
 /**
+ * Read size bytes from AVIOContext, returning a pointer.
+ * Note that the data pointed at by the returned pointer is only
+ * valid until the next call that references the same IO context.
+ * @param s IO context
+ * @param buf pointer to buffer into which to assemble the requested
+ *    data if it is not available in contiguous addresses in the
+ *    underlying buffer
+ * @param size number of bytes requested
+ * @param data address at which to store pointer: this will be a
+ *    a direct pointer into the underlying buffer if the requested
+ *    number of bytes are available at contiguous addresses, otherwise
+ *    will be a copy of buf
+ * @return number of bytes read or AVERROR
+ */
+int ffio_read_indirect(AVIOContext *s, unsigned char *buf, int size, unsigned char **data);
+
+/**
  * Read size bytes from AVIOContext into buf.
  * This reads at most 1 packet. If that is not enough fewer bytes will be
  * returned.

--- a/lib/ffmpeg/libavformat/aviobuf.c
+++ b/lib/ffmpeg/libavformat/aviobuf.c
@@ -522,6 +522,18 @@ int avio_read(AVIOContext *s, unsigned char *buf, int size)
     return size1 - size;
 }
 
+int ffio_read_indirect(AVIOContext *s, unsigned char *buf, int size, unsigned char **data)
+{
+    if (s->buf_end - s->buf_ptr >= size && !s->write_flag) {
+        *data = s->buf_ptr;
+        s->buf_ptr += size;
+        return size;
+    } else {
+        *data = buf;
+        return avio_read(s, buf, size);
+    }
+}
+
 int ffio_read_partial(AVIOContext *s, unsigned char *buf, int size)
 {
     int len;

--- a/lib/ffmpeg/libavformat/mpegts.c
+++ b/lib/ffmpeg/libavformat/mpegts.c
@@ -268,6 +268,17 @@ static int discard_pid(MpegTSContext *ts, unsigned int pid)
     int i, j, k;
     int used = 0, discarded = 0;
     struct Program *p;
+
+    /* If none of the programs have .discard=AVDISCARD_ALL then there's
+     * no way we have to discard this packet
+     */
+    for (k = 0; k < ts->stream->nb_programs; k++) {
+        if (ts->stream->programs[k]->discard == AVDISCARD_ALL)
+            break;
+    }
+    if (k == ts->stream->nb_programs)
+        return 0;
+
     for(i=0; i<ts->nb_prg; i++) {
         p = &ts->prg[i];
         for(j=0; j<p->nb_pids; j++) {

--- a/lib/ffmpeg/libavformat/mpegts.c
+++ b/lib/ffmpeg/libavformat/mpegts.c
@@ -1863,17 +1863,17 @@ static int mpegts_resync(AVFormatContext *s)
 }
 
 /* return -1 if error or EOF. Return 0 if OK. */
-static int read_packet(AVFormatContext *s, uint8_t *buf, int raw_packet_size)
+static int read_packet(AVFormatContext *s, uint8_t *buf, int raw_packet_size, uint8_t **data)
 {
     AVIOContext *pb = s->pb;
-    int skip, len;
+    int len;
 
     for(;;) {
-        len = avio_read(pb, buf, TS_PACKET_SIZE);
+        len = ffio_read_indirect(pb, buf, TS_PACKET_SIZE, data);
         if (len != TS_PACKET_SIZE)
             return len < 0 ? len : AVERROR_EOF;
         /* check packet sync byte */
-        if (buf[0] != 0x47) {
+        if ((*data)[0] != 0x47) {
             /* find a new packet start */
             avio_seek(pb, -TS_PACKET_SIZE, SEEK_CUR);
             if (mpegts_resync(s) < 0)
@@ -1881,19 +1881,25 @@ static int read_packet(AVFormatContext *s, uint8_t *buf, int raw_packet_size)
             else
                 continue;
         } else {
-            skip = raw_packet_size - TS_PACKET_SIZE;
-            if (skip > 0)
-                avio_skip(pb, skip);
             break;
         }
     }
     return 0;
 }
 
+static void finished_reading_packet(AVFormatContext *s, int raw_packet_size)
+{
+    AVIOContext *pb = s->pb;
+    int skip = raw_packet_size - TS_PACKET_SIZE;
+    if (skip > 0)
+        avio_skip(pb, skip);
+}
+
 static int handle_packets(MpegTSContext *ts, int nb_packets)
 {
     AVFormatContext *s = ts->stream;
     uint8_t packet[TS_PACKET_SIZE + FF_INPUT_BUFFER_PADDING_SIZE];
+    uint8_t *data;
     int packet_num, ret = 0;
 
     if (avio_tell(s->pb) != ts->last_pos) {
@@ -1926,10 +1932,11 @@ static int handle_packets(MpegTSContext *ts, int nb_packets)
         if (ts->stop_parse > 0)
             break;
 
-        ret = read_packet(s, packet, ts->raw_packet_size);
+        ret = read_packet(s, packet, ts->raw_packet_size, &data);
         if (ret != 0)
             break;
-        ret = handle_packet(ts, packet);
+        ret = handle_packet(ts, data);
+        finished_reading_packet(s, ts->raw_packet_size);
         if (ret != 0)
             break;
     }
@@ -2087,6 +2094,7 @@ static int mpegts_read_header(AVFormatContext *s)
         int64_t pcrs[2], pcr_h;
         int packet_count[2];
         uint8_t packet[TS_PACKET_SIZE];
+        uint8_t *data;
 
         /* only read packets */
 
@@ -2102,18 +2110,21 @@ static int mpegts_read_header(AVFormatContext *s)
         nb_pcrs = 0;
         nb_packets = 0;
         for(;;) {
-            ret = read_packet(s, packet, ts->raw_packet_size);
+            ret = read_packet(s, packet, ts->raw_packet_size, &data);
             if (ret < 0)
                 return -1;
-            pid = AV_RB16(packet + 1) & 0x1fff;
+            pid = AV_RB16(data + 1) & 0x1fff;
             if ((pcr_pid == -1 || pcr_pid == pid) &&
-                parse_pcr(&pcr_h, &pcr_l, packet) == 0) {
+                parse_pcr(&pcr_h, &pcr_l, data) == 0) {
+                finished_reading_packet(s, ts->raw_packet_size);
                 pcr_pid = pid;
                 packet_count[nb_pcrs] = nb_packets;
                 pcrs[nb_pcrs] = pcr_h * 300 + pcr_l;
                 nb_pcrs++;
                 if (nb_pcrs >= 2)
                     break;
+            } else {
+                finished_reading_packet(s, ts->raw_packet_size);
             }
             nb_packets++;
         }
@@ -2145,15 +2156,19 @@ static int mpegts_raw_read_packet(AVFormatContext *s,
     int64_t pcr_h, next_pcr_h, pos;
     int pcr_l, next_pcr_l;
     uint8_t pcr_buf[12];
+    uint8_t *data;
 
     if (av_new_packet(pkt, TS_PACKET_SIZE) < 0)
         return AVERROR(ENOMEM);
     pkt->pos= avio_tell(s->pb);
-    ret = read_packet(s, pkt->data, ts->raw_packet_size);
+    ret = read_packet(s, pkt->data, ts->raw_packet_size, &data);
     if (ret < 0) {
         av_free_packet(pkt);
         return ret;
     }
+    if (data != pkt->data)
+        memcpy(pkt->data, data, ts->raw_packet_size);
+    finished_reading_packet(s, ts->raw_packet_size);
     if (ts->mpeg2ts_compute_pcr) {
         /* compute exact PCR for each packet */
         if (parse_pcr(&pcr_h, &pcr_l, pkt->data) == 0) {

--- a/lib/ffmpeg/libavformat/mpegts.c
+++ b/lib/ffmpeg/libavformat/mpegts.c
@@ -28,6 +28,7 @@
 #include "libavutil/avassert.h"
 #include "libavcodec/bytestream.h"
 #include "libavcodec/get_bits.h"
+#include "libavcodec/mathops.h"
 #include "avformat.h"
 #include "mpegts.h"
 #include "internal.h"
@@ -99,6 +100,8 @@ struct MpegTSContext {
     int raw_packet_size;
 
     int pos47;
+    /** position corresponding to pos47, or 0 if pos47 invalid */
+    int64_t pos;
 
     /** if true, all pids are analyzed to find streams       */
     int auto_guess;
@@ -1814,7 +1817,7 @@ static int handle_packet(MpegTSContext *ts, const uint8_t *packet)
         return 0;
 
     pos = avio_tell(ts->stream->pb);
-    ts->pos47= pos % ts->raw_packet_size;
+    MOD_UNLIKELY(ts->pos47, pos, ts->raw_packet_size, ts->pos);
 
     if (tss->type == MPEGTS_SECTION) {
         if (is_start) {

--- a/lib/ffmpeg/patches/0051-ffmpeg-backport-avio-Add-an-internal-function-for-re.patch
+++ b/lib/ffmpeg/patches/0051-ffmpeg-backport-avio-Add-an-internal-function-for-re.patch
@@ -1,0 +1,72 @@
+From 5ce8f2bf354b7adf904ac3e1438915586c5a0bb1 Mon Sep 17 00:00:00 2001
+From: Ben Avison <bavison@riscosopen.org>
+Date: Wed, 31 Jul 2013 23:46:08 +0100
+Subject: [PATCH 51/54] [ffmpeg] - backport - avio: Add an internal function
+ for reading without copying
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As long as there is enough contiguous data in the avio buffer,
+just return a pointer to it instead of copying it to the caller
+provided buffer.
+
+Signed-off-by: Martin Storsjö <martin@martin.st>
+---
+ lib/ffmpeg/libavformat/avio_internal.h |   17 +++++++++++++++++
+ lib/ffmpeg/libavformat/aviobuf.c       |   12 ++++++++++++
+ 2 files changed, 29 insertions(+)
+
+diff --git a/lib/ffmpeg/libavformat/avio_internal.h b/lib/ffmpeg/libavformat/avio_internal.h
+index cf36764..e9ece57 100644
+--- a/lib/ffmpeg/libavformat/avio_internal.h
++++ b/lib/ffmpeg/libavformat/avio_internal.h
+@@ -38,6 +38,23 @@ int ffio_init_context(AVIOContext *s,
+
+
+ /**
++ * Read size bytes from AVIOContext, returning a pointer.
++ * Note that the data pointed at by the returned pointer is only
++ * valid until the next call that references the same IO context.
++ * @param s IO context
++ * @param buf pointer to buffer into which to assemble the requested
++ *    data if it is not available in contiguous addresses in the
++ *    underlying buffer
++ * @param size number of bytes requested
++ * @param data address at which to store pointer: this will be a
++ *    a direct pointer into the underlying buffer if the requested
++ *    number of bytes are available at contiguous addresses, otherwise
++ *    will be a copy of buf
++ * @return number of bytes read or AVERROR
++ */
++int ffio_read_indirect(AVIOContext *s, unsigned char *buf, int size, unsigned char **data);
++
++/**
+  * Read size bytes from AVIOContext into buf.
+  * This reads at most 1 packet. If that is not enough fewer bytes will be
+  * returned.
+diff --git a/lib/ffmpeg/libavformat/aviobuf.c b/lib/ffmpeg/libavformat/aviobuf.c
+index 7a73a17..465c46d 100644
+--- a/lib/ffmpeg/libavformat/aviobuf.c
++++ b/lib/ffmpeg/libavformat/aviobuf.c
+@@ -522,6 +522,18 @@ int avio_read(AVIOContext *s, unsigned char *buf, int size)
+     return size1 - size;
+ }
+
++int ffio_read_indirect(AVIOContext *s, unsigned char *buf, int size, unsigned char **data)
++{
++    if (s->buf_end - s->buf_ptr >= size && !s->write_flag) {
++        *data = s->buf_ptr;
++        s->buf_ptr += size;
++        return size;
++    } else {
++        *data = buf;
++        return avio_read(s, buf, size);
++    }
++}
++
+ int ffio_read_partial(AVIOContext *s, unsigned char *buf, int size)
+ {
+     int len;
+--
+1.7.9.5

--- a/lib/ffmpeg/patches/0052-ffmpeg-backport-mpegts-Remove-one-memcpy-per-packet.patch
+++ b/lib/ffmpeg/patches/0052-ffmpeg-backport-mpegts-Remove-one-memcpy-per-packet.patch
@@ -1,0 +1,149 @@
+From 1496d8c12075c0f3783e348a5d73fef9e3000b0f Mon Sep 17 00:00:00 2001
+From: Ben Avison <bavison@riscosopen.org>
+Date: Wed, 31 Jul 2013 23:46:08 +0100
+Subject: [PATCH 52/54] [ffmpeg] - backport - mpegts: Remove one memcpy per
+ packet
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This was being performed to ensure that a complete packet was held in
+contiguous memory, prior to parsing the packet. However, the source buffer
+is typically large enough that the packet was already contiguous, so it is
+beneficial to return the packet by reference in most cases.
+
+         Before          After
+         Mean   StdDev   Mean   StdDev  Change
+memcpy    720.7  32.7     649.8  25.1   +10.9%
+Overall  2372.7  46.1    2291.7  21.8    +3.5%
+
+Signed-off-by: Martin Storsjö <martin@martin.st>
+---
+ lib/ffmpeg/libavformat/mpegts.c |   41 ++++++++++++++++++++++++++-------------
+ 1 file changed, 28 insertions(+), 13 deletions(-)
+
+diff --git a/lib/ffmpeg/libavformat/mpegts.c b/lib/ffmpeg/libavformat/mpegts.c
+index b5f5d63..5307521 100644
+--- a/lib/ffmpeg/libavformat/mpegts.c
++++ b/lib/ffmpeg/libavformat/mpegts.c
+@@ -1863,17 +1863,17 @@ static int mpegts_resync(AVFormatContext *s)
+ }
+
+ /* return -1 if error or EOF. Return 0 if OK. */
+-static int read_packet(AVFormatContext *s, uint8_t *buf, int raw_packet_size)
++static int read_packet(AVFormatContext *s, uint8_t *buf, int raw_packet_size, uint8_t **data)
+ {
+     AVIOContext *pb = s->pb;
+-    int skip, len;
++    int len;
+
+     for(;;) {
+-        len = avio_read(pb, buf, TS_PACKET_SIZE);
++        len = ffio_read_indirect(pb, buf, TS_PACKET_SIZE, data);
+         if (len != TS_PACKET_SIZE)
+             return len < 0 ? len : AVERROR_EOF;
+         /* check packet sync byte */
+-        if (buf[0] != 0x47) {
++        if ((*data)[0] != 0x47) {
+             /* find a new packet start */
+             avio_seek(pb, -TS_PACKET_SIZE, SEEK_CUR);
+             if (mpegts_resync(s) < 0)
+@@ -1881,19 +1881,25 @@ static int read_packet(AVFormatContext *s, uint8_t *buf, int raw_packet_size)
+             else
+                 continue;
+         } else {
+-            skip = raw_packet_size - TS_PACKET_SIZE;
+-            if (skip > 0)
+-                avio_skip(pb, skip);
+             break;
+         }
+     }
+     return 0;
+ }
+
++static void finished_reading_packet(AVFormatContext *s, int raw_packet_size)
++{
++    AVIOContext *pb = s->pb;
++    int skip = raw_packet_size - TS_PACKET_SIZE;
++    if (skip > 0)
++        avio_skip(pb, skip);
++}
++
+ static int handle_packets(MpegTSContext *ts, int nb_packets)
+ {
+     AVFormatContext *s = ts->stream;
+     uint8_t packet[TS_PACKET_SIZE + FF_INPUT_BUFFER_PADDING_SIZE];
++    uint8_t *data;
+     int packet_num, ret = 0;
+
+     if (avio_tell(s->pb) != ts->last_pos) {
+@@ -1926,10 +1932,11 @@ static int handle_packets(MpegTSContext *ts, int nb_packets)
+         if (ts->stop_parse > 0)
+             break;
+
+-        ret = read_packet(s, packet, ts->raw_packet_size);
++        ret = read_packet(s, packet, ts->raw_packet_size, &data);
+         if (ret != 0)
+             break;
+-        ret = handle_packet(ts, packet);
++        ret = handle_packet(ts, data);
++        finished_reading_packet(s, ts->raw_packet_size);
+         if (ret != 0)
+             break;
+     }
+@@ -2087,6 +2094,7 @@ static int mpegts_read_header(AVFormatContext *s)
+         int64_t pcrs[2], pcr_h;
+         int packet_count[2];
+         uint8_t packet[TS_PACKET_SIZE];
++        uint8_t *data;
+
+         /* only read packets */
+
+@@ -2102,18 +2110,21 @@ static int mpegts_read_header(AVFormatContext *s)
+         nb_pcrs = 0;
+         nb_packets = 0;
+         for(;;) {
+-            ret = read_packet(s, packet, ts->raw_packet_size);
++            ret = read_packet(s, packet, ts->raw_packet_size, &data);
+             if (ret < 0)
+                 return -1;
+-            pid = AV_RB16(packet + 1) & 0x1fff;
++            pid = AV_RB16(data + 1) & 0x1fff;
+             if ((pcr_pid == -1 || pcr_pid == pid) &&
+-                parse_pcr(&pcr_h, &pcr_l, packet) == 0) {
++                parse_pcr(&pcr_h, &pcr_l, data) == 0) {
++                finished_reading_packet(s, ts->raw_packet_size);
+                 pcr_pid = pid;
+                 packet_count[nb_pcrs] = nb_packets;
+                 pcrs[nb_pcrs] = pcr_h * 300 + pcr_l;
+                 nb_pcrs++;
+                 if (nb_pcrs >= 2)
+                     break;
++            } else {
++                finished_reading_packet(s, ts->raw_packet_size);
+             }
+             nb_packets++;
+         }
+@@ -2145,15 +2156,19 @@ static int mpegts_raw_read_packet(AVFormatContext *s,
+     int64_t pcr_h, next_pcr_h, pos;
+     int pcr_l, next_pcr_l;
+     uint8_t pcr_buf[12];
++    uint8_t *data;
+
+     if (av_new_packet(pkt, TS_PACKET_SIZE) < 0)
+         return AVERROR(ENOMEM);
+     pkt->pos= avio_tell(s->pb);
+-    ret = read_packet(s, pkt->data, ts->raw_packet_size);
++    ret = read_packet(s, pkt->data, ts->raw_packet_size, &data);
+     if (ret < 0) {
+         av_free_packet(pkt);
+         return ret;
+     }
++    if (data != pkt->data)
++        memcpy(pkt->data, data, ts->raw_packet_size);
++    finished_reading_packet(s, ts->raw_packet_size);
+     if (ts->mpeg2ts_compute_pcr) {
+         /* compute exact PCR for each packet */
+         if (parse_pcr(&pcr_h, &pcr_l, pkt->data) == 0) {
+--
+1.7.9.5

--- a/lib/ffmpeg/patches/0053-ffmpeg-backport-mpegts-Make-discard_pid-faster-for-s.patch
+++ b/lib/ffmpeg/patches/0053-ffmpeg-backport-mpegts-Make-discard_pid-faster-for-s.patch
@@ -1,0 +1,47 @@
+From 6aec5772fd5331b3514f308ab0895f6234b60045 Mon Sep 17 00:00:00 2001
+From: Ben Avison <bavison@riscosopen.org>
+Date: Mon, 5 Aug 2013 13:12:51 +0100
+Subject: [PATCH 53/54] [ffmpeg] - backport - mpegts: Make discard_pid()
+ faster for single-program streams
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When a stream contains a single program, there's no point in doing a
+PID -> program lookup. Normally the one and only program isn't disabled,
+so no packets should be discarded.
+
+              Before          After
+              Mean   StdDev   Mean   StdDev  Change
+discard_pid()   73.8  9.4       20.2  1.5    +264.8%
+Overall       2300.8 28.0     2253.1 20.6      +2.1%
+
+Signed-off-by: Martin Storsjö <martin@martin.st>
+---
+ lib/ffmpeg/libavformat/mpegts.c |   11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/lib/ffmpeg/libavformat/mpegts.c b/lib/ffmpeg/libavformat/mpegts.c
+index 5307521..82dd209 100644
+--- a/lib/ffmpeg/libavformat/mpegts.c
++++ b/lib/ffmpeg/libavformat/mpegts.c
+@@ -268,6 +268,17 @@ static int discard_pid(MpegTSContext *ts, unsigned int pid)
+     int i, j, k;
+     int used = 0, discarded = 0;
+     struct Program *p;
++
++    /* If none of the programs have .discard=AVDISCARD_ALL then there's
++     * no way we have to discard this packet
++     */
++    for (k = 0; k < ts->stream->nb_programs; k++) {
++        if (ts->stream->programs[k]->discard == AVDISCARD_ALL)
++            break;
++    }
++    if (k == ts->stream->nb_programs)
++        return 0;
++
+     for(i=0; i<ts->nb_prg; i++) {
+         p = &ts->prg[i];
+         for(j=0; j<p->nb_pids; j++) {
+--
+1.7.9.5

--- a/lib/ffmpeg/patches/0054-ffmpeg-backport-mpegts-Remove-one-64-bit-integer-mod.patch
+++ b/lib/ffmpeg/patches/0054-ffmpeg-backport-mpegts-Remove-one-64-bit-integer-mod.patch
@@ -1,0 +1,76 @@
+From b79aa2b89ed9027a72a10c1d26ccdf2bb385d57b Mon Sep 17 00:00:00 2001
+From: Ben Avison <bavison@riscosopen.org>
+Date: Mon, 5 Aug 2013 13:12:49 +0100
+Subject: [PATCH 54/54] [ffmpeg] - backport - mpegts: Remove one 64-bit
+ integer modulus operation per packet
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The common case of the pointer having increased by one packet (which results
+in no change to the modulus) can be detected with a 64-bit subtraction,
+which is far cheaper than a division on many platforms.
+
+           Before          After
+           Mean   StdDev   Mean   StdDev  Change
+Divisions   248.3  8.8      51.5   7.4    +381.7%
+Overall    2773.2 25.6     2372.5 43.1     +16.9%
+
+Signed-off-by: Martin Storsjö <martin@martin.st>
+---
+ lib/ffmpeg/libavcodec/mathops.h |    9 +++++++++
+ lib/ffmpeg/libavformat/mpegts.c |    5 ++++-
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/lib/ffmpeg/libavcodec/mathops.h b/lib/ffmpeg/libavcodec/mathops.h
+index 592f5a5..1d57342 100644
+--- a/lib/ffmpeg/libavcodec/mathops.h
++++ b/lib/ffmpeg/libavcodec/mathops.h
+@@ -195,6 +195,15 @@ if ((y) < (x)) {\
+ #   define FASTDIV(a,b) ((uint32_t)((((uint64_t)a) * ff_inverse[b]) >> 32))
+ #endif /* FASTDIV */
+
++#ifndef MOD_UNLIKELY
++#   define MOD_UNLIKELY(modulus, dividend, divisor, prev_dividend) \
++    do { \
++        if ((prev_dividend) == 0 || (dividend) - (prev_dividend) != (divisor)) \
++            (modulus) = (dividend) % (divisor); \
++        (prev_dividend) = (dividend); \
++    } while (0)
++#endif
++
+ static inline av_const unsigned int ff_sqrt(unsigned int a)
+ {
+     unsigned int b;
+diff --git a/lib/ffmpeg/libavformat/mpegts.c b/lib/ffmpeg/libavformat/mpegts.c
+index 82dd209..b995f60 100644
+--- a/lib/ffmpeg/libavformat/mpegts.c
++++ b/lib/ffmpeg/libavformat/mpegts.c
+@@ -28,6 +28,7 @@
+ #include "libavutil/avassert.h"
+ #include "libavcodec/bytestream.h"
+ #include "libavcodec/get_bits.h"
++#include "libavcodec/mathops.h"
+ #include "avformat.h"
+ #include "mpegts.h"
+ #include "internal.h"
+@@ -99,6 +100,8 @@ struct MpegTSContext {
+     int raw_packet_size;
+
+     int pos47;
++    /** position corresponding to pos47, or 0 if pos47 invalid */
++    int64_t pos;
+
+     /** if true, all pids are analyzed to find streams       */
+     int auto_guess;
+@@ -1814,7 +1817,7 @@ static int handle_packet(MpegTSContext *ts, const uint8_t *packet)
+         return 0;
+
+     pos = avio_tell(ts->stream->pb);
+-    ts->pos47= pos % ts->raw_packet_size;
++    MOD_UNLIKELY(ts->pos47, pos, ts->raw_packet_size, ts->pos);
+
+     if (tss->type == MPEGTS_SECTION) {
+         if (is_start) {
+--
+1.7.9.5


### PR DESCRIPTION
There have been some mpegts parsing optimisations accepted in upstream ffmpeg. 
They reduce mpeg2ts parsing time by about 20% on the Pi. All platforms should benefit.
This improves startup time and playback for high bitrate m2ts/iso files.
