### PR TITLE
music: fix crash when calling CTagLoaderTagLib::Load() through IMusicInfoTagLoader::Load()

### DIFF
--- a/xbmc/cores/paplayer/FLACcodec.cpp
+++ b/xbmc/cores/paplayer/FLACcodec.cpp
@@ -56,7 +56,7 @@ bool FLACCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   //  Extract ReplayGain info
   CTagLoaderTagLib tagLoaderTagLib;
-  tagLoaderTagLib.Load(strFile, m_tag, NULL, "flac");
+  tagLoaderTagLib.Load(strFile, m_tag, "flac");
 
   m_pFlacDecoder=m_dll.FLAC__stream_decoder_new();
 

--- a/xbmc/cores/paplayer/MP3codec.cpp
+++ b/xbmc/cores/paplayer/MP3codec.cpp
@@ -175,7 +175,7 @@ bool MP3Codec::Init(const CStdString &strFile, unsigned int filecache)
   if (length != 0)
   {
     CTagLoaderTagLib tagLoaderTagLib; //opens the file so needs to be after m_file.Open 
-    bTags = tagLoaderTagLib.Load(strFile, m_tag, NULL, "mp3");
+    bTags = tagLoaderTagLib.Load(strFile, m_tag, "mp3");
 
     if (bTags)
       ReadDuration();

--- a/xbmc/cores/paplayer/OGGcodec.cpp
+++ b/xbmc/cores/paplayer/OGGcodec.cpp
@@ -131,7 +131,7 @@ bool OGGCodec::Init(const CStdString &strFile1, unsigned int filecache)
   if (pComments)
   {
     CTagLoaderTagLib tagLoaderTagLib;
-    tagLoaderTagLib.Load(strFile, m_tag, NULL, "oga");
+    tagLoaderTagLib.Load(strFile, m_tag, "oga");
   }
 
   //  Seek to the logical bitstream to play

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -84,7 +84,12 @@ static const vector<string> StringListToVectorString(const StringList& stringLis
   return values;
 }
 
-bool CTagLoaderTagLib::Load(const string& strFileName, CMusicInfoTag& tag, EmbeddedArt *art /* = NULL */, const string& fallbackFileExtension /* = "" */)
+bool CTagLoaderTagLib::Load(const CStdString& strFileName, MUSIC_INFO::CMusicInfoTag& tag, MUSIC_INFO::EmbeddedArt *art /* = NULL */)
+{
+  return Load(strFileName, tag, "", art);
+}
+
+bool CTagLoaderTagLib::Load(const CStdString& strFileName, CMusicInfoTag& tag, const CStdString& fallbackFileExtension, MUSIC_INFO::EmbeddedArt *art /* = NULL */)
 {  
   CStdString strExtension = URIUtils::GetExtension(strFileName);
   strExtension.ToLower();

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -42,6 +42,7 @@
 #include <taglib/xiphcomment.h>
 #include <taglib/mp4tag.h>
 #include "TagLibVFSStream.h"
+#include "ImusicInfoTagLoader.h"
 
 namespace MUSIC_INFO
 {
@@ -49,12 +50,14 @@ namespace MUSIC_INFO
   class EmbeddedArt;
 };
 
-class CTagLoaderTagLib
+class CTagLoaderTagLib : public MUSIC_INFO::IMusicInfoTagLoader
 {
 public:
   CTagLoaderTagLib();
   virtual ~CTagLoaderTagLib();
-  virtual bool                   Load(const std::string& strFileName, MUSIC_INFO::CMusicInfoTag& tag, MUSIC_INFO::EmbeddedArt *art = NULL, const std::string& fallbackFileExtension = "");
+  virtual bool                   Load(const CStdString& strFileName, MUSIC_INFO::CMusicInfoTag& tag, MUSIC_INFO::EmbeddedArt *art = NULL);
+
+  bool                           Load(const CStdString& strFileName, MUSIC_INFO::CMusicInfoTag& tag, const CStdString& fallbackFileExtension, MUSIC_INFO::EmbeddedArt *art = NULL);
 private:
   bool                           Open(const std::string& strFileName, bool readOnly);
   const std::vector<std::string> GetASFStringList(const TagLib::List<TagLib::ASF::Attribute>& list);


### PR DESCRIPTION
This fixes a crash surfaced through d0a5a97e0c6c7831db382dfdc3e8650ff500acb9 but which was always potentially there. The class definition of CTagLoaderTagLib was completely screwed up. It is used as if it was derived from IMusicInfoTagLoader but it actually wasn't. Furthermore the signature of the CTagLoaderTagLib::Load() method was not completely identical to the pure virtual method definition in IMusicInfoTagLoader (std::string instead of CStdString) so it's a miracle this didn't blow into our faces earlier.

Since the extension fallback introduced with d0a5a97e0c6c7831db382dfdc3e8650ff500acb9  is specific to CTagLoaderTagLib I just added a non-virtual method which takes that additional parameter so that we can still implement the actual virtual Load() method.
