### PR TITLE
python: add Monitor::onNotification() to receive (JSON-RPC) notifications

### DIFF
--- a/xbmc/interfaces/legacy/CallbackFunction.h
+++ b/xbmc/interfaces/legacy/CallbackFunction.h
@@ -153,6 +153,33 @@ namespace XBMCAddon
   };
 
 
+  /**
+   * This is the template to carry a callback to a member function
+   *  that returns 'void' (has no return) and takes three parameters.
+   */
+  template<class M, typename P1, typename P2, typename P3> class CallbackFunction<M,P1,P2,P3, cb_null_type, cb_null_type> : public Callback
+  {
+  public:
+    typedef void (M::*MemberFunction)(P1,P2,P3);
+
+  protected:
+    MemberFunction meth;
+    M* obj;
+    P1 param1;
+    P2 param2;
+    P3 param3;
+
+  public:
+    CallbackFunction(M* object, MemberFunction method, P1 parameter, P2 parameter2, P3 parameter3) : 
+      Callback(object, "CallbackFunction<M,P1,P2,P3>"), meth(method), obj(object),
+      param1(parameter), param2(parameter2), param3(parameter3) {}
+
+    virtual ~CallbackFunction() { deallocating(); }
+
+    virtual void executeCallback() { TRACE; ((*obj).*(meth))(param1,param2,param3); }
+  };
+
+
 }
 
 

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -45,6 +45,7 @@ namespace XBMCAddon
       inline void    OnDatabaseUpdated(const String &database) { TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseUpdated,database)); }
       inline void    OnDatabaseScanStarted(const String &database) { TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseScanStarted,database)); }
       inline void    OnAbortRequested() { TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onAbortRequested)); }
+      inline void    OnNotification(const String &sender, const String &method, const String &data) { TRACE; invokeCallback(new CallbackFunction<Monitor,const String,const String,const String>(this,&Monitor::onNotification,sender,method,data)); }
 #endif
 
       /**
@@ -92,6 +93,17 @@ namespace XBMCAddon
        * Will be called when XBMC requests Abort
        */
       virtual void    onAbortRequested() { TRACE; }
+
+      /**
+       * onNotification(sender, method, data) -- onNotification method.
+       *
+       * sender - sender of the notification
+       * method - name of the notification
+       * data - JSON-encoded data of the notification
+       *
+       * Will be called when XBMC receives or sends a notification
+       */
+      virtual void    onNotification(const String sender, const String method, const String data) { TRACE; }
 
       virtual ~Monitor();
 

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -86,6 +86,7 @@ public:
   void OnDatabaseUpdated(const std::string &database);
   void OnDatabaseScanStarted(const std::string &database);
   void OnAbortRequested(const CStdString &ID="");
+  void OnNotification(const std::string &sender, const std::string &method, const std::string &data);
 
   virtual void Process();
   virtual void Uninitialize();


### PR DESCRIPTION
This adds another callback called onNotification() to the Monitor class which allows addons that implement the Monitor class to receive JSON-RPC notifications directly through the python bindings. Addons already have the possibility to send JSON-RPC requests to xbmc through the python bindings (and can therefore avoid using HTTP, TCP or WebSockets) but to receive notifications they currently have to rely on a TCP or WebSocket connection. Unfortunately those must be manually enabled by the user in the service settings of XBMC so it's not guaranteed to be available. In addition a user might have changed the default TCP port so the addon also needs to provide a setting for the TCP port which is all very cumbersome.

The method signature looks like this

```
Monitor::onNotification(const String sender, const String method, const String data)
```

"sender" is the name of the sender of the notification (mostly "xbmc").
"method" is the name of the notification (e.g. "VideoLibrary.OnUpdate").
"data" is the JSON-encoded data of the notification (e.g. "false" or "0" or "{ "type": "movie", "id": 25 }").
