### PR TITLE
FIX: [stagefright] dyload the whole codec to prevent potential future api breakage

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,7 +14,11 @@ XBMCTEX_DIRS= \
 
 DVDPCODECS_DIRS= \
 	lib \
-	lib/libdvd
+	lib/libdvd 
+
+ifeq (@USE_LIBSTAGEFRIGHT@,1)
+DVDPCODECS_DIRS += xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS
+endif
 
 DVDPLAYER_ARCHIVES=xbmc/cores/dvdplayer/DVDPlayer.a \
                    xbmc/cores/dvdplayer/DVDCodecs/DVDCodecs.a \
@@ -329,7 +333,7 @@ all : $(FINAL_TARGETS)
 include Makefile.include
 
 .PHONY : dllloader exports visualizations screensavers eventclients papcodecs \
-	dvdpcodecs imagelib codecs externals force skins libaddon check \
+	dvdpcodecs dvdpextcodecs imagelib codecs externals force skins libaddon check \
 	testframework testsuite
 
 # hack targets to keep build system up to date
@@ -402,6 +406,14 @@ libaddon: exports
 dvdpcodecs: dllloader
 	$(MAKE) -C lib
 	$(MAKE) -C lib/libdvd
+
+ifeq (@USE_LIBSTAGEFRIGHT@,1)
+dvdpextcodecs: libxbmc.so 
+	$(MAKE) -C xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS
+else
+dvdpextcodecs:
+endif
+
 eventclients:
 ifeq ($(findstring osx,@ARCH@), osx)
 ifneq ($(findstring arm,@ARCH@), arm)
@@ -442,7 +454,7 @@ ifeq (@USE_PVR_ADDONS@,1)
 	$(MAKE) -C pvr-addons
 endif
 
-codecs: papcodecs dvdpcodecs
+codecs: papcodecs dvdpcodecs dvdpextcodecs
 
 libs: libhdhomerun imagelib libexif system/libcpluff-@ARCH@.so $(CMYTH)
 

--- a/configure.in
+++ b/configure.in
@@ -39,6 +39,7 @@ AC_DEFUN([XB_ADD_CODEC],
   AC_MSG_CHECKING([for $2])
   case $add_codecs in
     *$2*)
+      use_codec_$2="yes"
       AC_SUBST([USE_$1], 1)
       AC_DEFINE([HAS_$1], 1, [using $2])
       AC_MSG_RESULT([enabling $2])
@@ -1966,7 +1967,6 @@ case $add_codecs in
       XB_ADD_CODEC([LIBAMCODEC], [amcodec])
       ;;
   *libstagefright*)
-      LIBS+="-L${prefix}/opt/android-libs -lstdc++ -lutils -lcutils -lstagefright -lbinder -lui -lgui"
       XB_ADD_CODEC([LIBSTAGEFRIGHT], [libstagefright])
       ;;
   *)
@@ -2562,6 +2562,10 @@ fi
 
 if test "$use_skin_touched" = "yes"; then
 OUTPUT_FILES="$OUTPUT_FILES addons/skin.touched/media/Makefile"
+fi
+
+if test "$use_codec_libstagefright" = "yes"; then
+OUTPUT_FILES="$OUTPUT_FILES xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/Makefile"
 fi
 
 OUTPUT_FILES="$OUTPUT_FILES \

--- a/system/settings/android.xml
+++ b/system/settings/android.xml
@@ -17,22 +17,14 @@
           <updates>
             <update type="change" />
           </updates>
+          <control type="toggle" />
         </setting>
-      </group>
-    </category>
-    <category id="videoplayer">
-      <group id="2">
         <setting id="videoplayer.usestagefright" type="boolean" label="13436" help="36260">
           <requirement>HAVE_LIBSTAGEFRIGHTDECODER</requirement>
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
-      </group>
-    </category>
-  </section>
-  <section id="videos">
-    <category id="videoplayer">
-      <group id="2">
         <setting id="videoplayer.usemediacodec" type="boolean" label="13439" help="36544">
           <visible>HAS_MEDIACODEC</visible>
           <level>2</level>
@@ -40,6 +32,7 @@
           <updates>
             <update type="change" />
           </updates>
+          <control type="toggle" />
         </setting>
       </group>
     </category>

--- a/xbmc/DllPaths_generated_android.h.in
+++ b/xbmc/DllPaths_generated_android.h.in
@@ -73,6 +73,7 @@
 #define DLL_PATH_LIBDVDNAV     "libdvdnav-@ARCH@.so"
 #define DLL_PATH_LIBMPEG2      "@MPEG2_SONAME@"
 #define DLL_PATH_LIBMAD        "@MAD_SONAME@"
+#define DLL_PATH_LIBSTAGEFRIGHTICS    "libXBMCvcodec_stagefrightICS-@ARCH@.so"
 
 /* ffmpeg */
 #define DLL_PATH_LIBAVCODEC    "libavcodec-54-@ARCH@.so"

--- a/xbmc/android/activity/AndroidFeatures.cpp
+++ b/xbmc/android/activity/AndroidFeatures.cpp
@@ -55,6 +55,7 @@ int CAndroidFeatures::GetVersion()
     // <= 13 Honeycomb
     // <= 15 IceCreamSandwich
     //       JellyBean
+    // <= 19 KitKat
     version = iSdkVersion;
 
     jenv->DeleteLocalRef(jcOsBuild);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -68,7 +68,7 @@
 #include <EGL/eglext.h>
 #include "windowing/egl/EGLWrapper.h"
 #include "android/activity/XBMCApp.h"
-#include "DVDCodecs/Video/StageFrightVideo.h"
+#include "DVDCodecs/Video/DVDVideoCodecStageFright.h"
 
 // EGL extension functions
 static PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
@@ -2605,7 +2605,7 @@ void CLinuxRendererGLES::AddProcessor(struct __CVBuffer *cvBufferRef, int index)
 }
 #endif
 #ifdef HAS_LIBSTAGEFRIGHT
-void CLinuxRendererGLES::AddProcessor(CStageFrightVideo* stf, EGLImageKHR eglimg, int index)
+void CLinuxRendererGLES::AddProcessor(CDVDVideoCodecStageFright* stf, EGLImageKHR eglimg, int index)
 {
 #ifdef DEBUG_VERBOSE
   unsigned int time = XbmcThreads::SystemClockMillis();

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -40,7 +40,7 @@ class CBaseTexture;
 namespace Shaders { class BaseYUV2RGBShader; }
 namespace Shaders { class BaseVideoFilterShader; }
 class COpenMaxVideo;
-class CStageFrightVideo;
+class CDVDVideoCodecStageFright;
 class CDVDMediaCodecInfo;
 typedef std::vector<int>     Features;
 
@@ -167,7 +167,7 @@ public:
   virtual void         AddProcessor(struct __CVBuffer *cvBufferRef, int index);
 #endif
 #ifdef HAS_LIBSTAGEFRIGHT
-  virtual void         AddProcessor(CStageFrightVideo* stf, EGLImageKHR eglimg, int index);
+  virtual void         AddProcessor(CDVDVideoCodecStageFright* stf, EGLImageKHR eglimg, int index);
 #endif
 #if defined(TARGET_ANDROID)
   // mediaCodec
@@ -278,7 +278,7 @@ protected:
     struct __CVBuffer *cvBufferRef;
 #endif
 #ifdef HAS_LIBSTAGEFRIGHT
-    CStageFrightVideo* stf;
+    CDVDVideoCodecStageFright* stf;
     EGLImageKHR eglimg;
 #endif
 #if defined(TARGET_ANDROID)

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -45,6 +45,7 @@
 #endif
 #if defined(TARGET_ANDROID)
 #include "Video/DVDVideoCodecAndroidMediaCodec.h"
+#include "android/activity/AndroidFeatures.h"
 #endif
 #include "Audio/DVDAudioCodecFFmpeg.h"
 #include "Audio/DVDAudioCodecLibMad.h"
@@ -286,7 +287,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
 #endif
 
 #if defined(HAS_LIBSTAGEFRIGHT)
-  if (CSettings::Get().GetBool("videoplayer.usestagefright") && !hint.software )
+  if (!hint.software && CSettings::Get().GetBool("videoplayer.usestagefright") && CAndroidFeatures::GetVersion() < 19 )
   {
     switch(hint.codec)
     {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -38,7 +38,7 @@ namespace VDPAU { class CVdpauRenderPicture; }
 class COpenMax;
 class COpenMaxVideo;
 struct OpenMaxVideoBuffer;
-class CStageFrightVideo;
+class CDVDVideoCodecStageFright;
 class CDVDMediaCodecInfo;
 typedef void* EGLImageKHR;
 
@@ -75,7 +75,7 @@ struct DVDVideoPicture
     };
 
     struct {
-      CStageFrightVideo* stf;
+      CDVDVideoCodecStageFright* stf;
       EGLImageKHR eglimg;
     };
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecStageFright.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecStageFright.cpp
@@ -31,17 +31,27 @@
 #include "settings/Settings.h"
 #include "DVDStreamInfo.h"
 #include "DVDVideoCodecStageFright.h"
-#include "StageFrightVideo.h"
 #include "utils/log.h"
+#include "windowing/WindowingFactory.h"
+#include "settings/AdvancedSettings.h"
+
+#include "DllLibStageFrightCodec.h"
 
 #define CLASSNAME "CDVDVideoCodecStageFright"
 ////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////
+
+DllLibStageFrightCodec*     CDVDVideoCodecStageFright::m_stf_dll = NULL;
+
 CDVDVideoCodecStageFright::CDVDVideoCodecStageFright()
   : CDVDVideoCodec()
-  , m_stf_decoder(NULL), m_converter(NULL), m_convert_bitstream(false)
+  , m_convert_bitstream(false),  m_converter(NULL)
+  , m_stf_handle(NULL)
 {
   m_pFormatName = "stf-xxxx";
+
+  if (!m_stf_dll)
+    m_stf_dll = new DllLibStageFrightCodec;
 }
 
 CDVDVideoCodecStageFright::~CDVDVideoCodecStageFright()
@@ -94,21 +104,18 @@ bool CDVDVideoCodecStageFright::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
         break;
     }
 
-    m_stf_decoder = new CStageFrightVideo;
-    if (!m_stf_decoder->Open(hints))
+    if (!(m_stf_dll && m_stf_dll->Load()))
+      return false;
+    m_stf_dll->EnableDelayedUnload(false);
+
+    m_stf_handle = m_stf_dll->create_stf(&g_Windowing, &g_advancedSettings);
+
+    if (!m_stf_dll->stf_Open(m_stf_handle, hints))
     {
       CLog::Log(LOGERROR,
           "%s::%s - failed to open, codec(%d), profile(%d), level(%d)",
           CLASSNAME, __func__, hints.codec, hints.profile, hints.level);
-      delete m_stf_decoder;
-      m_stf_decoder = NULL;
-
-      if (m_converter)
-      {
-        m_converter->Close();
-        delete m_converter;
-        m_converter = NULL;
-      }
+      Dispose();
       return false;
     }
 
@@ -126,17 +133,17 @@ void CDVDVideoCodecStageFright::Dispose()
     delete m_converter;
     m_converter = NULL;
   }
-  if (m_stf_decoder)
+  if (m_stf_handle)
   {
-    m_stf_decoder->Close();
-    delete m_stf_decoder;
-    m_stf_decoder = NULL;
+    m_stf_dll->stf_Close(m_stf_handle);
+    m_stf_dll->destroy_stf(m_stf_handle);
+    m_stf_handle = NULL;
   }
 }
 
 void CDVDVideoCodecStageFright::SetDropState(bool bDrop)
 {
-  m_stf_decoder->SetDropState(bDrop);
+  m_stf_dll->stf_SetDropState(m_stf_handle, bDrop);
 }
 
 int CDVDVideoCodecStageFright::Decode(uint8_t *pData, int iSize, double dts, double pts)
@@ -163,29 +170,30 @@ int CDVDVideoCodecStageFright::Decode(uint8_t *pData, int iSize, double dts, dou
   CLog::Log(LOGDEBUG, ">>> decode conversion - tm:%d\n", XbmcThreads::SystemClockMillis() - time);
 #endif
 
-  rtn = m_stf_decoder->Decode(demuxer_content, demuxer_bytes, dts, pts);
+  rtn = m_stf_dll->stf_Decode(m_stf_handle, demuxer_content, demuxer_bytes, dts, pts);
 
   return rtn;
 }
 
 void CDVDVideoCodecStageFright::Reset(void)
 {
-  m_stf_decoder->Reset();
+  m_stf_dll->stf_Reset(m_stf_handle);
 }
 
 bool CDVDVideoCodecStageFright::GetPicture(DVDVideoPicture* pDvdVideoPicture)
 {
-  return m_stf_decoder->GetPicture(pDvdVideoPicture);
+  pDvdVideoPicture->stf = this;
+  return m_stf_dll->stf_GetPicture(m_stf_handle, pDvdVideoPicture);
 }
 
 bool CDVDVideoCodecStageFright::ClearPicture(DVDVideoPicture* pDvdVideoPicture)
 {
-  return m_stf_decoder->ClearPicture(pDvdVideoPicture);
+  return m_stf_dll->stf_ClearPicture(m_stf_handle, pDvdVideoPicture);
 }
 
 void CDVDVideoCodecStageFright::SetSpeed(int iSpeed)
 {
-  m_stf_decoder->SetSpeed(iSpeed);
+  m_stf_dll->stf_SetSpeed(m_stf_handle, iSpeed);
 }
 
 int CDVDVideoCodecStageFright::GetDataSize(void)
@@ -196,6 +204,16 @@ int CDVDVideoCodecStageFright::GetDataSize(void)
 double CDVDVideoCodecStageFright::GetTimeSize(void)
 {
   return 0;
+}
+
+void CDVDVideoCodecStageFright::LockBuffer(EGLImageKHR eglimg)
+{
+  m_stf_dll->stf_LockBuffer(m_stf_handle, eglimg);
+}
+
+void CDVDVideoCodecStageFright::ReleaseBuffer(EGLImageKHR eglimg)
+{
+  m_stf_dll->stf_ReleaseBuffer(m_stf_handle, eglimg);
 }
 
 #endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecStageFright.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecStageFright.h
@@ -24,7 +24,8 @@
 #include "DVDVideoCodec.h"
 #include "utils/BitstreamConverter.h"
 
-class CStageFrightVideo;
+class DllLibStageFrightCodec;
+
 class CDVDVideoCodecStageFright : public CDVDVideoCodec
 {
 public:
@@ -45,12 +46,16 @@ public:
   virtual int GetDataSize(void);
   virtual double GetTimeSize(void);
 
+  virtual void LockBuffer(EGLImageKHR eglimg);
+  virtual void ReleaseBuffer(EGLImageKHR eglimg);
+
 protected:
   const char        *m_pFormatName;
-  CStageFrightVideo     *m_stf_decoder;
-
   bool              m_convert_bitstream;
   CBitstreamConverter   *m_converter;
+  
+  static DllLibStageFrightCodec*     m_stf_dll;
+  void *            m_stf_handle;  
 };
 
 #endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DllLibStageFrightCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DllLibStageFrightCodec.h
@@ -1,0 +1,83 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+#include "config.h"
+#endif
+
+#include "DynamicDll.h"
+#include "DVDVideoCodec.h"
+
+class CWinSystemEGL;
+class CAdvancedSettings;
+
+class DllLibStageFrightCodecInterface
+{
+public:
+  virtual ~DllLibStageFrightCodecInterface() {}
+
+  virtual void* create_stf(CWinSystemEGL* windowing, CAdvancedSettings* advsettings)=0;
+  virtual void destroy_stf(void*)=0;
+  
+  virtual bool stf_Open(void*, CDVDStreamInfo &hints) = 0;
+  virtual void stf_Close(void*) = 0;
+  virtual int  stf_Decode(void*, uint8_t *pData, int iSize, double dts, double pts) = 0;
+  virtual void stf_Reset(void*) = 0;
+  virtual bool stf_GetPicture(void*, DVDVideoPicture *pDvdVideoPicture) = 0;
+  virtual bool stf_ClearPicture(void*, DVDVideoPicture* pDvdVideoPicture) = 0;
+  virtual void stf_SetDropState(void*, bool bDrop) = 0;
+  virtual void stf_SetSpeed(void*, int iSpeed) = 0;
+
+  virtual void stf_LockBuffer(void*, EGLImageKHR eglimg) = 0;
+  virtual void stf_ReleaseBuffer(void*, EGLImageKHR eglimg) = 0;
+};
+
+class DllLibStageFrightCodec : public DllDynamic, DllLibStageFrightCodecInterface
+{
+  DECLARE_DLL_WRAPPER(DllLibStageFrightCodec, DLL_PATH_LIBSTAGEFRIGHTICS)
+  DEFINE_METHOD2(void*, create_stf, (CWinSystemEGL* p1, CAdvancedSettings* p2))
+  DEFINE_METHOD1(void, destroy_stf, (void* p1))
+  DEFINE_METHOD2(bool, stf_Open, (void* p1, CDVDStreamInfo &p2))
+  DEFINE_METHOD1(void, stf_Close, (void* p1))
+  DEFINE_METHOD5(int, stf_Decode, (void* p1, uint8_t *p2, int p3, double p4, double p5))
+  DEFINE_METHOD1(void, stf_Reset, (void* p1))
+  DEFINE_METHOD2(bool, stf_GetPicture, (void* p1, DVDVideoPicture * p2))
+  DEFINE_METHOD2(bool, stf_ClearPicture, (void* p1, DVDVideoPicture * p2))
+  DEFINE_METHOD2(void, stf_SetDropState, (void* p1, bool p2))
+  DEFINE_METHOD2(void, stf_SetSpeed, (void* p1, int p2))
+  DEFINE_METHOD2(void, stf_LockBuffer, (void* p1, EGLImageKHR p2))
+  DEFINE_METHOD2(void, stf_ReleaseBuffer, (void* p1, EGLImageKHR p2))
+  BEGIN_METHOD_RESOLVE()
+    RESOLVE_METHOD(create_stf)
+    RESOLVE_METHOD(destroy_stf)
+    RESOLVE_METHOD(stf_Open)
+    RESOLVE_METHOD(stf_Close)
+    RESOLVE_METHOD(stf_Decode)
+    RESOLVE_METHOD(stf_Reset)
+    RESOLVE_METHOD(stf_GetPicture)
+    RESOLVE_METHOD(stf_ClearPicture)
+    RESOLVE_METHOD(stf_SetDropState)
+    RESOLVE_METHOD(stf_SetSpeed)
+    RESOLVE_METHOD(stf_LockBuffer)
+    RESOLVE_METHOD(stf_ReleaseBuffer)
+  END_METHOD_RESOLVE()
+};

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
@@ -22,18 +22,6 @@ SRCS += OpenMax.cpp
 SRCS += OpenMaxVideo.cpp
 SRCS += DVDVideoCodecOpenMax.cpp
 endif
-ifeq (@USE_LIBSTAGEFRIGHT@,1)
-SRCS += StageFrightVideo.cpp
-SRCS += StageFrightVideoPrivate.cpp
-SRCS += DVDVideoCodecStageFright.cpp
-INCLUDES += -I${prefix}/opt/android-source/frameworks/base/include
-INCLUDES += -I${prefix}/opt/android-source/frameworks/base/native/include
-INCLUDES += -I${prefix}/opt/android-source/frameworks/base/include/media/stagefright
-INCLUDES += -I${prefix}/opt/android-source/frameworks/base/include/media/stagefright/openmax
-INCLUDES += -I${prefix}/opt/android-source/system/core/include
-INCLUDES += -I${prefix}/opt/android-source/libhardware/include
-endif
-
 ifeq (@USE_LIBAMCODEC@,1)
 SRCS += AMLCodec.cpp
 SRCS += DVDVideoCodecAmlogic.cpp
@@ -44,13 +32,12 @@ endif
 ifeq (@USE_ANDROID@,1)
 SRCS += DVDVideoCodecAndroidMediaCodec.cpp
 endif
+ifeq (@USE_LIBSTAGEFRIGHT@,1)
+SRCS += DVDVideoCodecStageFright.cpp
+endif
 
 LIB=Video.a
 
 include @abs_top_srcdir@/Makefile.include
 -include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))
-
-ifeq (@USE_LIBSTAGEFRIGHT@,1)
-CXXFLAGS += -Wno-multichar -fno-rtti
-endif
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/Makefile.in
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/Makefile.in
@@ -1,0 +1,49 @@
+ARCH=@ARCH@
+
+INCLUDES+=-I@abs_top_srcdir@/xbmc/cores/dvdplayer
+INCLUDES+=-I..
+
+SRCS += StageFrightInterface.cpp
+SRCS += StageFrightVideo.cpp
+SRCS += StageFrightVideoPrivate.cpp
+INCLUDES += -I${prefix}/opt/android-source/frameworks/base/include
+INCLUDES += -I${prefix}/opt/android-source/frameworks/base/native/include
+INCLUDES += -I${prefix}/opt/android-source/frameworks/base/include/media/stagefright
+INCLUDES += -I${prefix}/opt/android-source/frameworks/base/include/media/stagefright/openmax
+INCLUDES += -I${prefix}/opt/android-source/system/core/include
+INCLUDES += -I${prefix}/opt/android-source/libhardware/include
+
+LIBNAME=libXBMCvcodec_stagefrightICS
+LIB_SHARED=@abs_top_srcdir@/system/players/dvdplayer/$(LIBNAME)-$(ARCH).so
+
+LIBS += -landroid -lEGL -lGLESv2 -L${prefix}/opt/android-libs -lstdc++ -lutils -lcutils -lstagefright -lbinder -lui -lgui -L@abs_top_srcdir@ -lxbmc
+
+all: $(LIB_SHARED)
+
+include @abs_top_srcdir@/Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))
+
+JNICXXFLAGS = $(CXXFLAGS) -std=gnu++0x -Wextra
+STFCXXFLAGS = $(CXXFLAGS) -Wno-multichar -fno-rtti -fPIC
+
+$(LIB_SHARED): $(OBJS)
+	$(CXX) $(STFCXXFLAGS) $(LDFLAGS) -shared -Wl,-no-undefined -g -o $(LIB_SHARED) $(OBJS) $(LIBS)
+
+StageFrightVideo.o: StageFrightVideo.cpp
+	$(CXX) -MF $*.d -MD -c $(STFCXXFLAGS) $(DEFINES) $(INCLUDES) $< -o $@
+
+StageFrightVideoPrivate.o: StageFrightVideoPrivate.cpp
+	$(CXX) -MF $*.d -MD -c $(STFCXXFLAGS) $(DEFINES) $(INCLUDES) $< -o $@
+
+Surface.o: Surface.cpp
+	$(CXX) -MF $*.d -MD -c $(JNICXXFLAGS) $(DEFINES) $(INCLUDES) $< -o $@
+
+SurfaceTexture.o: SurfaceTexture.cpp
+	$(CXX) -MF $*.d -MD -c $(JNICXXFLAGS) $(DEFINES) $(INCLUDES) $< -o $@
+
+CLEAN_FILES = \
+	$(LIB_SHARED) \
+
+DISTCLEAN_FILES= \
+	Makefile \
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightInterface.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightInterface.cpp
@@ -1,0 +1,86 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistfribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distfributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "StageFrightInterface.h"
+#include "StageFrightVideo.h"
+
+#include "windowing/WindowingFactory.h"
+#include "settings/AdvancedSettings.h"
+
+void* create_stf(CWinSystemEGL* windowing, CAdvancedSettings* advsettings)
+{
+  return (void*)new CStageFrightVideo(windowing, advsettings);
+}
+
+void destroy_stf(void* stf)
+{
+  delete (CStageFrightVideo*)stf;
+}
+
+bool stf_Open(void* stf, CDVDStreamInfo &hints)
+{
+  return ((CStageFrightVideo*)stf)->Open(hints);
+}
+
+void stf_Close(void* stf)
+{
+  ((CStageFrightVideo*)stf)->Close();
+}
+
+int  stf_Decode(void* stf, uint8_t *pData, int iSize, double dts, double pts)
+{
+  return ((CStageFrightVideo*)stf)->Decode(pData, iSize, dts, pts);
+}
+
+void stf_Reset(void* stf)
+{
+  ((CStageFrightVideo*)stf)->Reset();
+}
+
+bool stf_GetPicture(void* stf, DVDVideoPicture *pDvdVideoPicture)
+{
+  return ((CStageFrightVideo*)stf)->GetPicture(pDvdVideoPicture);
+}
+
+bool stf_ClearPicture(void* stf, DVDVideoPicture* pDvdVideoPicture)
+{
+  return ((CStageFrightVideo*)stf)->ClearPicture(pDvdVideoPicture);
+}
+
+void stf_SetDropState(void* stf, bool bDrop)
+{
+  ((CStageFrightVideo*)stf)->SetDropState(bDrop);
+}
+
+void stf_SetSpeed(void* stf, int iSpeed)
+{
+  ((CStageFrightVideo*)stf)->SetSpeed(iSpeed);
+}
+
+void stf_LockBuffer(void* stf, EGLImageKHR eglimg)
+{
+  ((CStageFrightVideo*)stf)->LockBuffer(eglimg);
+}
+
+void stf_ReleaseBuffer(void* stf, EGLImageKHR eglimg)
+{
+  ((CStageFrightVideo*)stf)->ReleaseBuffer(eglimg);
+}
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightInterface.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightInterface.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDVideoCodec.h"
+
+class CStageFrightVideo;
+class CWinSystemEGL;
+class CAdvancedSettings;
+
+extern "C"
+{
+  void* create_stf(CWinSystemEGL* windowing, CAdvancedSettings* advsettings);
+  void destroy_stf(void*);
+
+  bool stf_Open(void*, CDVDStreamInfo &hints);
+  void stf_Close(void*);
+  int  stf_Decode(void*, uint8_t *pData, int iSize, double dts, double pts);
+  void stf_Reset(void*);
+  bool stf_GetPicture(void*, DVDVideoPicture *pDvdVideoPicture);
+  bool stf_ClearPicture(void*, DVDVideoPicture* pDvdVideoPicture);
+  void stf_SetDropState(void*, bool bDrop);
+  void stf_SetSpeed(void*, int iSpeed);
+
+  void stf_LockBuffer(void*, EGLImageKHR eglimg);
+  void stf_ReleaseBuffer(void*, EGLImageKHR eglimg);
+}

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.h
@@ -24,6 +24,8 @@
 #include "cores/dvdplayer/DVDStreamInfo.h"
 #include "DVDVideoCodec.h"
 
+class CWinSystemEGL;
+class CAdvancedSettings;
 class CStageFrightVideoPrivate;
 
 namespace android { class MediaBuffer; }
@@ -31,8 +33,8 @@ namespace android { class MediaBuffer; }
 class CStageFrightVideo
 {
 public:
-  CStageFrightVideo() {};
-  virtual ~CStageFrightVideo() {};
+  CStageFrightVideo(CWinSystemEGL* windowing, CAdvancedSettings* advsettings);
+  virtual ~CStageFrightVideo();
 
   bool Open(CDVDStreamInfo &hints);
   void Close(void);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideoPrivate.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideoPrivate.h
@@ -54,6 +54,8 @@
 class CStageFrightDecodeThread;
 class CJNISurface;
 class CJNISurfaceTexture;
+class CWinSystemEGL;
+class CAdvancedSettings;
 
 using namespace android;
 
@@ -106,6 +108,9 @@ public:
   GLint mPositionHandle;
   GLint mTexSamplerHandle;
   GLint mTexMatrixHandle;
+
+  CWinSystemEGL* m_g_Windowing;
+  CAdvancedSettings* m_g_advancedSettings;
 
   CFrameBufferObject fbo;
   EGLDisplay eglDisplay;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -811,7 +811,8 @@ void CSettings::InitializeConditions()
     m_settingsManager->AddCondition("have_amcodec");
 #endif
 #ifdef HAS_LIBSTAGEFRIGHT
-  m_settingsManager->AddCondition("have_libstagefrightdecoder");
+  if (CAndroidFeatures::GetVersion() < 19)
+    m_settingsManager->AddCondition("have_libstagefrightdecoder");
 #endif
 #ifdef TARGET_DARWIN_IOS_ATV2
   if (g_sysinfo.IsAppleTV2())


### PR DESCRIPTION
This moves the gory details of libstagefright to a separate library, which is dyload'ed at runtime.
Whether the libstagefright private api changes, or libstagefright is absent altogether, XBMC won't crash.

Furthermore, this approach would permit to have multiple libstagefright codecs, dependent on the android version, in the same package.

Note:
I had to move the jni Surface and SurfaceTexture to the lib because, as they are not used inside libxbmc.so self, they are not exported.
An alternative would be to use -Wl,--whole-archive, if deemed better.
