### PR TITLE
DVDVideoCodecFFmpeg: Feed the decoder with timestamps and use the best effort timestamp.

### DIFF
--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -93,6 +93,7 @@ public:
   virtual void avcodec_free_frame(AVFrame **frame)=0;
   virtual int av_codec_is_decoder(const AVCodec *codec)=0;
   virtual AVDictionary* av_frame_get_metadata(const AVFrame* frame)=0;
+  virtual int64_t av_frame_get_best_effort_timestamp(const AVFrame *frame) = 0;
 };
 
 #if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
@@ -163,6 +164,7 @@ public:
   virtual void avcodec_free_frame(AVFrame **frame) { return ::avcodec_free_frame(frame); };
   virtual int av_codec_is_decoder(const AVCodec *codec) { return ::av_codec_is_decoder(codec); }
   virtual AVDictionary* av_frame_get_metadata(const AVFrame* frame) { return ::av_frame_get_metadata(frame); }
+  virtual int64_t av_frame_get_best_effort_timestamp(const AVFrame *frame) { return ::av_frame_get_best_effort_timestamp(frame); }
 
   // DLL faking.
   virtual bool ResolveExports() { return true; }
@@ -214,6 +216,7 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
   DEFINE_METHOD1(AVCodec*, av_codec_next, (AVCodec *p1))
   DEFINE_METHOD1(int, av_codec_is_decoder, (const AVCodec *p1))
   DEFINE_METHOD1(AVDictionary*, av_frame_get_metadata, (const AVFrame* p1))
+  DEFINE_METHOD1(int64_t, av_frame_get_best_effort_timestamp, (const AVFrame *p1))
 
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(avcodec_flush_buffers)
@@ -249,6 +252,7 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
     RESOLVE_METHOD(avcodec_free_frame)
     RESOLVE_METHOD(av_codec_is_decoder)
     RESOLVE_METHOD(av_frame_get_metadata)
+    RESOLVE_METHOD(av_frame_get_best_effort_timestamp)
   END_METHOD_RESOLVE()
 
   /* dependencies of libavcodec */

--- a/lib/xbmc-libav-hacks/accessors.c
+++ b/lib/xbmc-libav-hacks/accessors.c
@@ -33,3 +33,8 @@ AVRational av_stream_get_r_frame_rate(const AVStream *s)
     zero.den = 1;
     return zero;
 }
+
+int64_t av_frame_get_best_effort_timestamp(const AVFrame *frame)
+{
+    return frame->pts;
+}

--- a/lib/xbmc-libav-hacks/accessors.c
+++ b/lib/xbmc-libav-hacks/accessors.c
@@ -36,5 +36,5 @@ AVRational av_stream_get_r_frame_rate(const AVStream *s)
 
 int64_t av_frame_get_best_effort_timestamp(const AVFrame *frame)
 {
-    return frame->pts;
+    return frame->pkt_pts;
 }

--- a/lib/xbmc-libav-hacks/libav_hacks.h
+++ b/lib/xbmc-libav-hacks/libav_hacks.h
@@ -54,6 +54,8 @@ int avformat_alloc_output_context2(AVFormatContext **ctx, AVOutputFormat *oforma
 
 AVRational av_stream_get_r_frame_rate(const AVStream *s);
 
+int64_t av_frame_get_best_effort_timestamp(const AVFrame *frame);
+
 // libavresample
 
 #define SwrContext AVAudioResampleContext

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -414,26 +414,6 @@ unsigned int CDVDVideoCodecFFmpeg::SetFilters(unsigned int flags)
   return flags;
 }
 
-union pts_union
-{
-  double  pts_d;
-  int64_t pts_i;
-};
-
-static int64_t pts_dtoi(double pts)
-{
-  pts_union u;
-  u.pts_d = pts;
-  return u.pts_i;
-}
-
-static double pts_itod(int64_t pts)
-{
-  pts_union u;
-  u.pts_i = pts;
-  return u.pts_d;
-}
-
 int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double pts)
 {
   int iGotPicture = 0, len = 0;
@@ -471,12 +451,20 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
   }
 
   m_dts = dts;
-  m_pCodecContext->reordered_opaque = pts_dtoi(pts);
 
   AVPacket avpkt;
   m_dllAvCodec.av_init_packet(&avpkt);
   avpkt.data = pData;
   avpkt.size = iSize;
+#define SET_PKT_TS(ts) \
+  if(ts != DVD_NOPTS_VALUE)\
+    avpkt.ts  = (ts / DVD_TIME_BASE) * AV_TIME_BASE;\
+  else\
+    avpkt.ts = AV_NOPTS_VALUE
+  SET_PKT_TS(pts);
+  SET_PKT_TS(dts);
+#undef SET_PKT_TS
+
   /* We lie, but this flag is only used by pngdec.c.
    * Setting it correctly would allow CorePNG decoding. */
   avpkt.flags = AV_PKT_FLAG_KEY;
@@ -658,8 +646,10 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(DVDVideoPicture* pDvdVideoPicture)
 
   pDvdVideoPicture->dts = m_dts;
   m_dts = DVD_NOPTS_VALUE;
-  if (m_pFrame->reordered_opaque)
-    pDvdVideoPicture->pts = pts_itod(m_pFrame->reordered_opaque);
+
+  int64_t bpts = m_dllAvCodec.av_frame_get_best_effort_timestamp(m_pFrame);
+  if(bpts != AV_NOPTS_VALUE)
+    pDvdVideoPicture->pts = (double)bpts * DVD_TIME_BASE / AV_TIME_BASE;
   else
     pDvdVideoPicture->pts = DVD_NOPTS_VALUE;
 


### PR DESCRIPTION
Fixes ticket 14337.

Needs testing with various streams. Basic testing seems fine here.
