### PR TITLE
python: move more logic from XBPython to CPythonInvoker

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -533,6 +533,9 @@
 		DFCA6ACB152245CD000BFAAE /* IHTTPRequestHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6AC3152245CD000BFAAE /* IHTTPRequestHandler.cpp */; };
 		DFD5812516C828500008EEA0 /* DAVCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD5812116C8284F0008EEA0 /* DAVCommon.cpp */; };
 		DFD5812616C828500008EEA0 /* DAVFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD5812316C828500008EEA0 /* DAVFile.cpp */; };
+		DFD882F617DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
+		DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
+		DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
 		DFD928F316384B6800709DAE /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD928F116384B6800709DAE /* Timer.cpp */; };
 		DFDA3153160E34230047A626 /* DVDOverlayCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDA3152160E34230047A626 /* DVDOverlayCodec.cpp */; };
 		DFE4095B17417FDF00473BD9 /* LegacyPathTranslation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFE4095917417FDF00473BD9 /* LegacyPathTranslation.cpp */; };
@@ -3809,7 +3812,7 @@
 		88ACB01D0DCF409E0083CFDF /* ASAPCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASAPCodec.h; sourceTree = "<group>"; };
 		88ACB01E0DCF409E0083CFDF /* DllASAP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DllASAP.h; sourceTree = "<group>"; };
 		88ECB6580DE013C4003396A7 /* DiskArbitration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiskArbitration.framework; path = /System/Library/Frameworks/DiskArbitration.framework; sourceTree = "<absolute>"; };
-		8DD76F7E0486A8DE00D96B5E /* XBMC */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = XBMC; sourceTree = BUILT_PRODUCTS_DIR; };
+		8DD76F7E0486A8DE00D96B5E /* XBMC */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.executable"; path = XBMC; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE84CB5915A5B8A600A3810E /* TagLibVFSStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TagLibVFSStream.cpp; sourceTree = "<group>"; };
 		AE84CB5C15A5B8BA00A3810E /* TagLibVFSStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLibVFSStream.h; sourceTree = "<group>"; };
 		AE89ACA41621DAB800E17DBC /* DVDDemuxBXA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDDemuxBXA.cpp; sourceTree = "<group>"; };
@@ -4235,6 +4238,8 @@
 		DFD5812216C8284F0008EEA0 /* DAVCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DAVCommon.h; sourceTree = "<group>"; };
 		DFD5812316C828500008EEA0 /* DAVFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DAVFile.cpp; sourceTree = "<group>"; };
 		DFD5812416C828500008EEA0 /* DAVFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DAVFile.h; sourceTree = "<group>"; };
+		DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AddonPythonInvoker.cpp; path = python/AddonPythonInvoker.cpp; sourceTree = "<group>"; };
+		DFD882F517DD1A5B001516FE /* AddonPythonInvoker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AddonPythonInvoker.h; path = python/AddonPythonInvoker.h; sourceTree = "<group>"; };
 		DFD928F116384B6800709DAE /* Timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Timer.cpp; sourceTree = "<group>"; };
 		DFD928F216384B6800709DAE /* Timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
 		DFDA3152160E34230047A626 /* DVDOverlayCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDOverlayCodec.cpp; sourceTree = "<group>"; };
@@ -6798,6 +6803,8 @@
 			isa = PBXGroup;
 			children = (
 				DF1ACFD015FCE50700E10810 /* generated */,
+				DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */,
+				DFD882F517DD1A5B001516FE /* AddonPythonInvoker.h */,
 				F502BFDA160F34B900C96C76 /* CallbackHandler.cpp */,
 				F502BFDB160F34B900C96C76 /* CallbackHandler.h */,
 				F502BFE4160F34DC00C96C76 /* LanguageHook.cpp */,
@@ -10600,6 +10607,7 @@
 				DF29668017B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 				DF28DF4D17B8379E0077F41A /* ProfilesOperations.cpp in Sources */,
 				180F6C8117CE9A5700127892 /* smc.c in Sources */,
+				DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11627,6 +11635,7 @@
 				F59EED8017AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
 				DF29668217B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 				DF28DF4F17B8379E0077F41A /* ProfilesOperations.cpp in Sources */,
+				DFD882F617DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12656,6 +12665,7 @@
 				F59EED7F17AD5174005BB7C6 /* ApplicationPlayer.cpp in Sources */,
 				DF29668117B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 				DF28DF4E17B8379E0077F41A /* ProfilesOperations.cpp in Sources */,
+				DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -777,6 +777,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\legacy\WindowDialog.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\legacy\WindowDialogMixin.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\legacy\WindowXML.cpp" />
+    <ClCompile Include="..\..\xbmc\interfaces\python\AddonPythonInvoker.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\CallbackHandler.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\generated\AddonModuleXbmc.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\generated\AddonModuleXbmcaddon.cpp" />
@@ -1159,6 +1160,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\legacy\WindowException.h" />
     <ClInclude Include="..\..\xbmc\interfaces\legacy\WindowInterceptor.h" />
     <ClInclude Include="..\..\xbmc\interfaces\legacy\WindowXML.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\AddonPythonInvoker.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\CallbackHandler.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\LanguageHook.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\preamble.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3067,6 +3067,9 @@
     <ClCompile Include="..\..\xbmc\settings\SettingRequirement.cpp">
       <Filter>settings</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\AddonPythonInvoker.cpp">
+      <Filter>interfaces\python</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6021,6 +6024,9 @@
     <ClInclude Include="..\..\xbmc\ApplicationPlayer.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingRequirement.h">
       <Filter>settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\python\AddonPythonInvoker.h">
+      <Filter>interfaces\python</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/interfaces/generic/ILanguageInvoker.h
+++ b/xbmc/interfaces/generic/ILanguageInvoker.h
@@ -68,12 +68,12 @@ protected:
   virtual bool execute(const std::string &script, const std::vector<std::string> &arguments) = 0;
   virtual bool stop(bool abort) = 0;
 
-  virtual void onError()
+  virtual void onExectuionFailed()
   {
     if (m_invocationHandler)
       m_invocationHandler->OnScriptEnded(this);
   }
-  virtual void onDone()
+  virtual void onExectuionDone()
   {
     if (m_invocationHandler)
       m_invocationHandler->OnScriptEnded(this);

--- a/xbmc/interfaces/generic/LanguageInvokerThread.cpp
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.cpp
@@ -97,7 +97,7 @@ void CLanguageInvokerThread::OnExit()
   if (m_invoker == NULL)
     return;
 
-  m_invoker->onDone();
+  m_invoker->onExectuionDone();
   m_invocationManager->OnScriptEnded(GetId());
 }
 
@@ -106,6 +106,6 @@ void CLanguageInvokerThread::OnException()
   if (m_invoker == NULL)
     return;
 
-  m_invoker->onError();
+  m_invoker->onExectuionFailed();
   m_invocationManager->OnScriptEnded(GetId());
 }

--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -1,0 +1,136 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+  #include "config.h"
+#endif
+
+// python.h should always be included first before any other includes
+#include <Python.h>
+#include <osdefs.h>
+
+#include "system.h"
+#include "AddonPythonInvoker.h"
+#include "addons/AddonVersion.h"
+
+#define MODULE "xbmc"
+
+#define RUNSCRIPT_PRAMBLE \
+        "" \
+        "import " MODULE "\n" \
+        "xbmc.abortRequested = False\n" \
+        "class xbmcout:\n" \
+        "\tdef __init__(self, loglevel=" MODULE ".LOGNOTICE):\n" \
+        "\t\tself.ll=loglevel\n" \
+        "\tdef write(self, data):\n" \
+        "\t\t" MODULE ".log(data,self.ll)\n" \
+        "\tdef close(self):\n" \
+        "\t\t" MODULE ".log('.')\n" \
+        "\tdef flush(self):\n" \
+        "\t\t" MODULE ".log('.')\n" \
+        "import sys\n" \
+        "sys.stdout = xbmcout()\n" \
+        "sys.stderr = xbmcout(" MODULE ".LOGERROR)\n"
+
+#define RUNSCRIPT_OVERRIDE_HACK \
+        "" \
+        "import os\n" \
+        "def getcwd_xbmc():\n" \
+        "  import __main__\n" \
+        "  import warnings\n" \
+        "  if hasattr(__main__, \"__file__\"):\n" \
+        "    warnings.warn(\"os.getcwd() currently lies to you so please use addon.getAddonInfo('path') to find the script's root directory and DO NOT make relative path accesses based on the results of 'os.getcwd.' \", DeprecationWarning, stacklevel=2)\n" \
+        "    return os.path.dirname(__main__.__file__)\n" \
+        "  else:\n" \
+        "    return os.getcwd_original()\n" \
+        "" \
+        "def chdir_xbmc(dir):\n" \
+        "  raise RuntimeError(\"os.chdir not supported in xbmc\")\n" \
+        "" \
+        "os_getcwd_original = os.getcwd\n" \
+        "os.getcwd          = getcwd_xbmc\n" \
+        "os.chdir_orignal   = os.chdir\n" \
+        "os.chdir           = chdir_xbmc\n" \
+        ""
+
+#define RUNSCRIPT_POSTSCRIPT \
+        "print '-->Python Interpreter Initialized<--'\n" \
+        ""
+
+#define RUNSCRIPT_BWCOMPATIBLE \
+  RUNSCRIPT_PRAMBLE RUNSCRIPT_OVERRIDE_HACK RUNSCRIPT_POSTSCRIPT
+
+#define RUNSCRIPT_COMPLIANT \
+  RUNSCRIPT_PRAMBLE RUNSCRIPT_POSTSCRIPT
+
+namespace PythonBindings {
+  void initModule_xbmcgui(void);
+  void initModule_xbmc(void);
+  void initModule_xbmcplugin(void);
+  void initModule_xbmcaddon(void);
+  void initModule_xbmcvfs(void);
+}
+
+using namespace std;
+using namespace PythonBindings;
+
+typedef struct
+{
+  const char *name;
+  CPythonInvoker::PythonModuleInitialization initialization;
+} PythonModule;
+
+static PythonModule PythonModules[] =
+  {
+    { "xbmcgui",    initModule_xbmcgui    },
+    { "xbmc",       initModule_xbmc       },
+    { "xbmcplugin", initModule_xbmcplugin },
+    { "xbmcaddon",  initModule_xbmcaddon  },
+    { "xbmcvfs",    initModule_xbmcvfs    }
+  };
+
+#define PythonModulesSize sizeof(PythonModules) / sizeof(PythonModule)
+
+CAddonPythonInvoker::CAddonPythonInvoker(ILanguageInvocationHandler *invocationHandler)
+  : CPythonInvoker(invocationHandler)
+{ }
+
+CAddonPythonInvoker::~CAddonPythonInvoker()
+{ }
+
+std::map<std::string, CPythonInvoker::PythonModuleInitialization> CAddonPythonInvoker::getModules() const
+{
+  static std::map<std::string, PythonModuleInitialization> modules;
+  if (modules.empty())
+  {
+    for (size_t i = 0; i < PythonModulesSize; i++)
+      modules.insert(make_pair(PythonModules[i].name, PythonModules[i].initialization));
+  }
+
+  return modules;
+}
+
+const char* CAddonPythonInvoker::getInitializationScript() const
+{
+  CStdString addonVer = ADDON::GetXbmcApiVersionDependency(m_addon);
+  bool bwcompatMode = (m_addon.get() == NULL ||
+                       ADDON::AddonVersion(addonVer) <= ADDON::AddonVersion("1.0"));
+  return bwcompatMode ? RUNSCRIPT_BWCOMPATIBLE : RUNSCRIPT_COMPLIANT;
+}

--- a/xbmc/interfaces/python/AddonPythonInvoker.h
+++ b/xbmc/interfaces/python/AddonPythonInvoker.h
@@ -1,0 +1,34 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "interfaces/python/PythonInvoker.h"
+
+class CAddonPythonInvoker : public CPythonInvoker
+{
+public:
+  CAddonPythonInvoker(ILanguageInvocationHandler *invocationHandler);
+  virtual ~CAddonPythonInvoker();
+
+protected:
+  // overrides of CPythonInvoker
+  virtual std::map<std::string, PythonModuleInitialization> getModules() const;
+  virtual const char* getInitializationScript() const;
+};

--- a/xbmc/interfaces/python/Makefile.in
+++ b/xbmc/interfaces/python/Makefile.in
@@ -11,7 +11,7 @@ all: $(LIB)
 
 include ../../../codegenerator.mk
 
-SRCS=	CallbackHandler.cpp LanguageHook.cpp \
+SRCS=	AddonPythonInvoker.cpp CallbackHandler.cpp LanguageHook.cpp \
 	PythonInvoker.cpp XBPython.cpp swig.cpp PyContext.cpp \
 	$(GENERATED)
 

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -51,19 +51,10 @@
 
 #include "interfaces/legacy/Monitor.h"
 #include "interfaces/legacy/AddonUtils.h"
+#include "interfaces/python/AddonPythonInvoker.h"
 #include "interfaces/python/PythonInvoker.h"
 
 using namespace ANNOUNCEMENT;
-
-namespace PythonBindings {
-  void initModule_xbmcgui(void);
-  void initModule_xbmc(void);
-  void initModule_xbmcplugin(void);
-  void initModule_xbmcaddon(void);
-  void initModule_xbmcvfs(void);
-}
-
-using namespace PythonBindings;
 
 XBPython::XBPython()
 {
@@ -419,82 +410,6 @@ void XBPython::UnloadExtensionLibs()
   m_extensions.clear();
 }
 
-#define MODULE "xbmc"
-
-#define RUNSCRIPT_PRAMBLE \
-        "" \
-        "import " MODULE "\n" \
-        "xbmc.abortRequested = False\n" \
-        "class xbmcout:\n" \
-        "\tdef __init__(self, loglevel=" MODULE ".LOGNOTICE):\n" \
-        "\t\tself.ll=loglevel\n" \
-        "\tdef write(self, data):\n" \
-        "\t\t" MODULE ".log(data,self.ll)\n" \
-        "\tdef close(self):\n" \
-        "\t\t" MODULE ".log('.')\n" \
-        "\tdef flush(self):\n" \
-        "\t\t" MODULE ".log('.')\n" \
-        "import sys\n" \
-        "sys.stdout = xbmcout()\n" \
-        "sys.stderr = xbmcout(" MODULE ".LOGERROR)\n"
-
-#define RUNSCRIPT_OVERRIDE_HACK \
-        "" \
-        "import os\n" \
-        "def getcwd_xbmc():\n" \
-        "  import __main__\n" \
-        "  import warnings\n" \
-        "  if hasattr(__main__, \"__file__\"):\n" \
-        "    warnings.warn(\"os.getcwd() currently lies to you so please use addon.getAddonInfo('path') to find the script's root directory and DO NOT make relative path accesses based on the results of 'os.getcwd.' \", DeprecationWarning, stacklevel=2)\n" \
-        "    return os.path.dirname(__main__.__file__)\n" \
-        "  else:\n" \
-        "    return os.getcwd_original()\n" \
-        "" \
-        "def chdir_xbmc(dir):\n" \
-        "  raise RuntimeError(\"os.chdir not supported in xbmc\")\n" \
-        "" \
-        "os_getcwd_original = os.getcwd\n" \
-        "os.getcwd          = getcwd_xbmc\n" \
-        "os.chdir_orignal   = os.chdir\n" \
-        "os.chdir           = chdir_xbmc\n" \
-        ""
-
-#define RUNSCRIPT_POSTSCRIPT \
-        "print '-->Python Interpreter Initialized<--'\n" \
-        ""
-
-#define RUNSCRIPT_BWCOMPATIBLE \
-  RUNSCRIPT_PRAMBLE RUNSCRIPT_OVERRIDE_HACK RUNSCRIPT_POSTSCRIPT
-
-#define RUNSCRIPT_COMPLIANT \
-  RUNSCRIPT_PRAMBLE RUNSCRIPT_POSTSCRIPT
-
-void XBPython::InitializeInterpreter(ADDON::AddonPtr addon)
-{
-  TRACE;
-  {
-    GilSafeSingleLock lock(m_critSection);
-    initModule_xbmcgui();
-    initModule_xbmc();
-    initModule_xbmcplugin();
-    initModule_xbmcaddon();
-    initModule_xbmcvfs();
-  }
-
-  CStdString addonVer = ADDON::GetXbmcApiVersionDependency(addon);
-  bool bwcompatMode = (addon.get() == NULL || (ADDON::AddonVersion(addonVer) <= ADDON::AddonVersion("1.0")));
-  const char* runscript = bwcompatMode ? RUNSCRIPT_BWCOMPATIBLE : RUNSCRIPT_COMPLIANT;
-
-  // redirecting default output to debug console
-  if (PyRun_SimpleString(runscript) == -1)
-    CLog::Log(LOGFATAL, "Python Initialize Error");
-}
-
-void XBPython::DeInitializeInterpreter()
-{
-  TRACE;
-}
-
 /**
 * Should be called before executing a script
 */
@@ -724,7 +639,7 @@ void XBPython::OnScriptEnded(ILanguageInvoker *invoker)
 
 ILanguageInvoker* XBPython::CreateInvoker()
 {
-  return new CPythonInvoker(this);
+  return new CAddonPythonInvoker(this);
 }
 
 void XBPython::PulseGlobalEvent()

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -100,13 +100,6 @@ public:
   void PulseGlobalEvent();
   bool WaitForEvent(CEvent& hEvent, unsigned int milliseconds);
 
-  // inject xbmc stuff into the interpreter.
-  // should be called for every new interpreter
-  void InitializeInterpreter(ADDON::AddonPtr addon);
-
-  // remove modules and references when interpreter done
-  void DeInitializeInterpreter();
-
   void RegisterExtensionLib(LibraryLoader *pLib);
   void UnregisterExtensionLib(LibraryLoader *pLib);
   void UnloadExtensionLibs();


### PR DESCRIPTION
This commit moves some more logic from XBPython to the recently introduced CPythonInvoker and refactores some of the code into being more generic so that it will be possible to implement specialized CPythonInvoker derivates which use special/additional python modules etc. XBPython should now mostly contain logic that affects the overall handling of python and not a specific python interpreter instance.
