### PR TITLE
[Linux] small xbmc.sh crashlog improvements

### DIFF
--- a/tools/Linux/xbmc.sh.in
+++ b/tools/Linux/xbmc.sh.in
@@ -77,6 +77,9 @@ print_crash_report()
   echo >> $FILE
   echo "############### STACK TRACE #################" >> $FILE
   if which gdb >/dev/null 2>&1; then
+    if which systemd-coredumpctl &> /dev/null; then
+      systemd-coredumpctl dump -o core xbmc.bin &> /dev/null
+    fi
     single_stacktrace "$PWD" 1
     # Find in plugins directories
     if [ $XBMC_HOME ]; then

--- a/tools/Linux/xbmc.sh.in
+++ b/tools/Linux/xbmc.sh.in
@@ -64,7 +64,10 @@ print_crash_report()
   echo -n " Kernel: " >> $FILE
   uname -rvs >> $FILE
   echo -n " Release: " >> $FILE
-  if which lsb_release > /dev/null; then
+  if [ -f /etc/os-release ]; then
+	  . /etc/os-release
+	  echo $NAME $VERSION >> $FILE
+  elif which lsb_release > /dev/null; then
     echo >> $FILE
     lsb_release -a 2> /dev/null | sed -e 's/^/    /' >> $FILE
   else


### PR DESCRIPTION
- read release information from /etc/os-release instead of relying on lsb_release
- read the core dump from the systemd journal if it was dumped there (this fixes cases where the stack trace would be empty in the crashlog)

see the commit messages for details.
