### PR TITLE
CGUIEditControl: add input validation

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -536,6 +536,9 @@
 		DFD882F617DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
 		DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
 		DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */; };
+		DFD882E717DD189E001516FE /* StringValidation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882E517DD189E001516FE /* StringValidation.cpp */; };
+		DFD882E817DD189E001516FE /* StringValidation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882E517DD189E001516FE /* StringValidation.cpp */; };
+		DFD882E917DD189E001516FE /* StringValidation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD882E517DD189E001516FE /* StringValidation.cpp */; };
 		DFD928F316384B6800709DAE /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD928F116384B6800709DAE /* Timer.cpp */; };
 		DFDA3153160E34230047A626 /* DVDOverlayCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDA3152160E34230047A626 /* DVDOverlayCodec.cpp */; };
 		DFE4095B17417FDF00473BD9 /* LegacyPathTranslation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFE4095917417FDF00473BD9 /* LegacyPathTranslation.cpp */; };
@@ -4240,6 +4243,8 @@
 		DFD5812416C828500008EEA0 /* DAVFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DAVFile.h; sourceTree = "<group>"; };
 		DFD882F417DD1A5B001516FE /* AddonPythonInvoker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AddonPythonInvoker.cpp; path = python/AddonPythonInvoker.cpp; sourceTree = "<group>"; };
 		DFD882F517DD1A5B001516FE /* AddonPythonInvoker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AddonPythonInvoker.h; path = python/AddonPythonInvoker.h; sourceTree = "<group>"; };
+		DFD882E517DD189E001516FE /* StringValidation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringValidation.cpp; sourceTree = "<group>"; };
+		DFD882E617DD189E001516FE /* StringValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringValidation.h; sourceTree = "<group>"; };
 		DFD928F116384B6800709DAE /* Timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Timer.cpp; sourceTree = "<group>"; };
 		DFD928F216384B6800709DAE /* Timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
 		DFDA3152160E34230047A626 /* DVDOverlayCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDOverlayCodec.cpp; sourceTree = "<group>"; };
@@ -8675,6 +8680,8 @@
 				18ECC96113CF178D00A9ED6C /* StreamUtils.h */,
 				18B7C8F11294261F009E7A26 /* StringUtils.cpp */,
 				18B7C8F21294261F009E7A26 /* StringUtils.h */,
+				DFD882E517DD189E001516FE /* StringValidation.cpp */,
+				DFD882E617DD189E001516FE /* StringValidation.h */,
 				E38E1E830D25F9FD00618676 /* SystemInfo.cpp */,
 				E38E1E840D25F9FD00618676 /* SystemInfo.h */,
 				C848291D156D003E005A996F /* TextSearch.cpp */,
@@ -10608,6 +10615,7 @@
 				DF28DF4D17B8379E0077F41A /* ProfilesOperations.cpp in Sources */,
 				180F6C8117CE9A5700127892 /* smc.c in Sources */,
 				DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
+				DFD882E917DD189E001516FE /* StringValidation.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11636,6 +11644,7 @@
 				DF29668217B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 				DF28DF4F17B8379E0077F41A /* ProfilesOperations.cpp in Sources */,
 				DFD882F617DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
+				DFD882E717DD189E001516FE /* StringValidation.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12666,6 +12675,7 @@
 				DF29668117B2B04300DF10F9 /* SettingRequirement.cpp in Sources */,
 				DF28DF4E17B8379E0077F41A /* ProfilesOperations.cpp in Sources */,
 				DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
+				DFD882E817DD189E001516FE /* StringValidation.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -168,6 +168,7 @@
 			<font>font13</font>
 			<textcolor>grey2</textcolor>
 			<focusedcolor>white</focusedcolor>
+			<invalidcolor>invalid</invalidcolor>
 			<texturefocus border="0,2,0,2">MenuItemFO.png</texturefocus>
 			<texturenofocus border="0,2,0,2">MenuItemNF.png</texturenofocus>
 		</control>

--- a/addons/skin.confluence/720p/SmartPlaylistRule.xml
+++ b/addons/skin.confluence/720p/SmartPlaylistRule.xml
@@ -132,6 +132,7 @@
 			<height>40</height>
 			<font>font13</font>
 			<aligny>center</aligny>
+			<invalidcolor>invalid</invalidcolor>
 			<texturefocus border="3">button-focus2.png</texturefocus>
 			<texturenofocus border="3">button-nofocus.png</texturenofocus>
 			<label>-</label>

--- a/addons/skin.confluence/720p/defaults.xml
+++ b/addons/skin.confluence/720p/defaults.xml
@@ -188,6 +188,7 @@
 		<font>font13</font>
 		<textcolor>white</textcolor>
 		<disabledcolor>grey3</disabledcolor>
+		<invalidcolor>invalid</invalidcolor>
 		<textoffsetx>7</textoffsetx>
 		<aligny>center</aligny>
 		<pulseonselect>no</pulseonselect>

--- a/addons/skin.confluence/colors/defaults.xml
+++ b/addons/skin.confluence/colors/defaults.xml
@@ -6,4 +6,5 @@
 	<color name="black">FF000000</color>
 	<color name="blue">FF0084ff</color>
 	<color name="selected">FFEB9E17</color>
+	<color name="invalid">FFFF0000</color>
 </colors>

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1209,6 +1209,7 @@
     <ClInclude Include="..\..\xbmc\utils\IXmlDeserializable.h" />
     <ClInclude Include="..\..\xbmc\utils\LegacyPathTranslation.h" />
     <ClInclude Include="..\..\xbmc\utils\RssManager.h" />
+    <ClInclude Include="..\..\xbmc\utils\StringValidation.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
     <ClInclude Include="..\..\xbmc\video\FFmpegVideoDecoder.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\swig.h" />
@@ -1350,6 +1351,7 @@
     <ClCompile Include="..\..\xbmc\utils\BooleanLogic.cpp" />
     <ClCompile Include="..\..\xbmc\utils\LegacyPathTranslation.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RssManager.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\StringValidation.cpp" />
     <ClCompile Include="..\..\xbmc\utils\test\TestUrlOptions.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">true</ExcludedFromBuild>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3070,6 +3070,9 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\AddonPythonInvoker.cpp">
       <Filter>interfaces\python</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\StringValidation.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6027,6 +6030,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\AddonPythonInvoker.h">
       <Filter>interfaces\python</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\StringValidation.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -84,6 +84,10 @@ bool CGUIDialogSmartPlaylistRule::OnMessage(CGUIMessage& message)
       return true;
     }
     break;
+
+  case GUI_MSG_VALIDITY_CHANGED:
+    CONTROL_ENABLE_ON_CONDITION(CONTROL_OK, message.GetParam1());
+    break;
   }
   return CGUIDialog::OnMessage(message);
 }
@@ -496,6 +500,10 @@ void CGUIDialogSmartPlaylistRule::OnInitWindow()
     OnMessage(msg);
   }
   UpdateButtons();
+
+  CGUIEditControl *editControl = (CGUIEditControl*)GetControl(CONTROL_VALUE);
+  if (editControl != NULL)
+    editControl->SetInputValidation(CSmartPlaylistRule::Validate, &m_rule);
 }
 
 void CGUIDialogSmartPlaylistRule::OnDeinitWindow(int nextWindowID)

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -86,7 +86,7 @@ protected:
   void OnUnFocus();
   virtual void ProcessText(unsigned int currentTime);
   virtual void RenderText();
-  CGUILabel::COLOR GetTextColor() const;
+  virtual CGUILabel::COLOR GetTextColor() const;
 
   CGUITexture m_imgFocus;
   CGUITexture m_imgNoFocus;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -757,6 +757,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetInfoColor(pControlNode, "disabledcolor", labelInfo.disabledColor, parentID);
   GetInfoColor(pControlNode, "shadowcolor", labelInfo.shadowColor, parentID);
   GetInfoColor(pControlNode, "selectedcolor", labelInfo.selectedColor, parentID);
+  GetInfoColor(pControlNode, "invalidcolor", labelInfo.invalidColor, parentID);
   XMLUtils::GetFloat(pControlNode, "textoffsetx", labelInfo.offsetX);
   XMLUtils::GetFloat(pControlNode, "textoffsety", labelInfo.offsetY);
   int angle = 0;  // use the negative angle to compensate for our vertically flipped cartesian plane

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -476,6 +476,15 @@ void CGUIEditControl::RenderText()
   }
 }
 
+CGUILabel::COLOR CGUIEditControl::GetTextColor() const
+{
+  CGUILabel::COLOR color = CGUIButtonControl::GetTextColor();
+  if (color != CGUILabel::COLOR_DISABLED && HasInvalidInput())
+    return CGUILabel::COLOR_INVALID;
+
+  return color;
+}
+
 void CGUIEditControl::SetHint(const CGUIInfoLabel& hint)
 {
   m_hintInfo = hint;

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -66,6 +66,9 @@ void CGUIEditControl::DefaultConstructor()
   m_label.SetAlign(m_label.GetLabelInfo().align & XBFONT_CENTER_Y); // left align
   m_label2.GetLabelInfo().offsetX = 0;
   m_isMD5 = false;
+  m_invalidInput = false;
+  m_inputValidator = NULL;
+  m_inputValidatorData = NULL;
 }
 
 CGUIEditControl::CGUIEditControl(const CGUIButtonControl &button)
@@ -335,6 +338,8 @@ void CGUIEditControl::UpdateText(bool sendUpdate)
   m_smsTimer.Stop();
   if (sendUpdate)
   {
+    ValidateInput();
+
     SEND_CLICK_MESSAGE(GetID(), GetParentID(), 0);
 
     m_textChangeActions.ExecuteActions(GetID(), GetParentID());
@@ -508,6 +513,7 @@ void CGUIEditControl::SetLabel2(const std::string &text)
     m_isMD5 = (m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW);
     m_text2 = newText;
     m_cursorPos = m_text2.size();
+    ValidateInput();
     SetInvalid();
   }
 }
@@ -596,5 +602,42 @@ void CGUIEditControl::OnPasteClipboard()
     m_text2.append(right_end);
     m_cursorPos += unicode_text.length();
     UpdateText();
+  }
+}
+
+void CGUIEditControl::SetInputValidation(StringValidation::Validator inputValidator, void *data /* = NULL */)
+{
+  if (m_inputValidator == inputValidator)
+    return;
+  
+  m_inputValidator = inputValidator;
+  m_inputValidatorData = data;
+  // the input validator has changed, so re-validate the current data
+  ValidateInput();
+}
+
+bool CGUIEditControl::ValidateInput(const CStdStringW &data) const
+{
+  if (m_inputValidator == NULL)
+    return true;
+
+  return m_inputValidator(GetLabel2(), (void*)(m_inputValidatorData != NULL ? m_inputValidatorData : this));
+}
+
+void CGUIEditControl::ValidateInput()
+{
+  // validate the input
+  bool invalid = !ValidateInput(m_text2);
+  // nothing to do if still valid/invalid
+  if (invalid != m_invalidInput)
+  {
+    // the validity state has changed so we need to update the control
+    m_invalidInput = invalid;
+
+    // let the window/dialog know that the validity has changed
+    CGUIMessage msg(GUI_MSG_VALIDITY_CHANGED, GetID(), GetID(), m_invalidInput ? 0 : 1);
+    SendWindowMessage(msg);
+
+    SetInvalid();
   }
 }

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -87,6 +87,7 @@ public:
 protected:
   virtual void ProcessText(unsigned int currentTime);
   virtual void RenderText();
+  virtual CGUILabel::COLOR GetTextColor() const;
   CStdStringW GetDisplayedText() const;
   void RecalcLabelPosition();
   void ValidateCursor();

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -30,6 +30,7 @@
 
 #include "GUIButtonControl.h"
 #include "utils/Stopwatch.h"
+#include "utils/StringValidation.h"
 
 /*!
  \ingroup controls
@@ -80,6 +81,9 @@ public:
 
   bool HasTextChangeActions() const { return m_textChangeActions.HasActionsMeetingCondition(); };
 
+  virtual bool HasInvalidInput() const { return m_invalidInput; }
+  virtual void SetInputValidation(StringValidation::Validator inputValidator, void *data = NULL);
+
 protected:
   virtual void ProcessText(unsigned int currentTime);
   virtual void RenderText();
@@ -90,6 +94,9 @@ protected:
   void OnPasteClipboard();
   void OnSMSCharacter(unsigned int key);
   void DefaultConstructor();  
+
+  virtual bool ValidateInput(const CStdStringW &data) const;
+  void ValidateInput();
 
   /*! \brief Clear out the current text input if it's an MD5 password.
    \return true if the password is cleared, false otherwise.
@@ -113,6 +120,10 @@ protected:
   bool m_isMD5;
 
   CGUIAction m_textChangeActions;
+
+  bool m_invalidInput;
+  StringValidation::Validator m_inputValidator;
+  void *m_inputValidatorData;
 
   unsigned int m_smsKeyIndex;
   unsigned int m_smsLastKey;

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -78,6 +78,8 @@ color_t CGUILabel::GetColor() const
       return m_label.disabledColor;
     case COLOR_FOCUSED:
       return m_label.focusedColor ? m_label.focusedColor : m_label.textColor;
+    case COLOR_INVALID:
+      return m_label.invalidColor ? m_label.invalidColor : m_label.textColor;
     default:
       break;
   }

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -52,6 +52,7 @@ public:
     changed |= selectedColor.Update();
     changed |= disabledColor.Update();
     changed |= focusedColor.Update();
+    changed |= invalidColor.Update();
 
     return changed;
   };
@@ -61,6 +62,7 @@ public:
   CGUIInfoColor selectedColor;
   CGUIInfoColor disabledColor;
   CGUIInfoColor focusedColor;
+  CGUIInfoColor invalidColor;
   uint32_t align;
   float offsetX;
   float offsetY;
@@ -83,7 +85,8 @@ public:
   enum COLOR { COLOR_TEXT = 0,
                COLOR_SELECTED,
                COLOR_FOCUSED,
-               COLOR_DISABLED };
+               COLOR_DISABLED,
+               COLOR_INVALID };
   
   /*! \brief allowed overflow handling techniques for labels, as defined by the skin
    */

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -133,6 +133,8 @@
 
 #define GUI_MSG_WINDOW_LOAD 43
 
+#define GUI_MSG_VALIDITY_CHANGED  44
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -105,6 +105,8 @@ public:
   static FIELD_TYPE           GetFieldType(Field field);
   static bool                 IsFieldBrowseable(Field field);
 
+  static bool Validate(const std::string &input, void *data);
+  static bool ValidateRating(const std::string &input, void *data);
 
   Field                       m_field;
   SEARCH_OPERATOR             m_operator;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -570,6 +570,10 @@ CGUIControlEditSetting::CGUIControlEditSetting(CGUIEditControl *pEdit, int id, C
   m_pEdit->SetInputType(inputType, heading);
 
   Update();
+
+  // this will automatically trigger validation so it must be executed after
+  // having set the value of the control based on the value of the setting
+  m_pEdit->SetInputValidation(InputValidation, this);
 }
 
 CGUIControlEditSetting::~CGUIControlEditSetting()
@@ -592,6 +596,18 @@ void CGUIControlEditSetting::Update()
   CGUIControlBaseSetting::Update();
 
   m_pEdit->SetLabel2(m_pSetting->ToString());
+}
+
+bool CGUIControlEditSetting::InputValidation(const std::string &input, void *data)
+{
+  if (data == NULL)
+    return true;
+
+  CGUIControlEditSetting *editControl = reinterpret_cast<CGUIControlEditSetting*>(data);
+  if (editControl == NULL || editControl->GetSetting() == NULL)
+    return true;
+
+  return editControl->GetSetting()->FromString(input);
 }
 
 CGUIControlSeparatorSetting::CGUIControlSeparatorSetting(CGUIImage *pImage, int id)

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -157,6 +157,8 @@ public:
   virtual void Update();
   virtual void Clear() { m_pEdit = NULL; }
 private:
+  static bool InputValidation(const std::string &input, void *data);
+
   CGUIEditControl *m_pEdit;
 };
 

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -58,6 +58,7 @@ SRCS += Stopwatch.cpp
 SRCS += StreamDetails.cpp
 SRCS += StreamUtils.cpp
 SRCS += StringUtils.cpp
+SRCS += StringValidation.cpp
 SRCS += SystemInfo.cpp
 SRCS += TextSearch.cpp
 SRCS += TimeSmoother.cpp

--- a/xbmc/utils/StringValidation.cpp
+++ b/xbmc/utils/StringValidation.cpp
@@ -1,0 +1,59 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "StringValidation.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+
+bool StringValidation::IsInteger(const std::string &input, void *data)
+{
+  return StringUtils::IsInteger(input);
+}
+
+bool StringValidation::IsPositiveInteger(const std::string &input, void *data)
+{
+  return StringUtils::IsNaturalNumber(input);
+}
+
+bool StringValidation::IsTime(const std::string &input, void *data)
+{
+  std::string strTime = input;
+  StringUtils::Trim(strTime);
+
+  if (StringUtils::EndsWith(strTime, " min"))
+  {
+    strTime = StringUtils::Left(strTime, strTime.size() - 4);
+    StringUtils::TrimRight(strTime);
+
+    return IsPositiveInteger(strTime, NULL);
+  }
+  else
+  {
+    size_t pos = strTime.find(":");
+    // if there's no ":", the value must be in seconds only
+    if (pos == std::string::npos)
+      return IsPositiveInteger(strTime, NULL);
+
+    std::string strMin = StringUtils::Left(strTime, pos);
+    std::string strSec = StringUtils::Mid(strTime, pos + 1);
+    return IsPositiveInteger(strMin, NULL) && IsPositiveInteger(strSec, NULL);
+  }
+  return false;
+}

--- a/xbmc/utils/StringValidation.h
+++ b/xbmc/utils/StringValidation.h
@@ -27,6 +27,9 @@ public:
   typedef bool (*Validator)(const std::string &input, void *data);
 
   static bool NonEmpty(const std::string &input, void *data) { return !input.empty(); }
+  static bool IsInteger(const std::string &input, void *data);
+  static bool IsPositiveInteger(const std::string &input, void *data);
+  static bool IsTime(const std::string &input, void *data);
 
 private:
   StringValidation() { }

--- a/xbmc/utils/StringValidation.h
+++ b/xbmc/utils/StringValidation.h
@@ -1,0 +1,33 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+class StringValidation
+{
+public:
+  typedef bool (*Validator)(const std::string &input, void *data);
+
+  static bool NonEmpty(const std::string &input, void *data) { return !input.empty(); }
+
+private:
+  StringValidation() { }
+};


### PR DESCRIPTION
This is an idea I had when I was working on the settings refactor. With the new settings system it is possible to get feedback on whether a value provided by the user is valid or not. Invalid values are ignored by the settings system but they are still displayed in the user interface (because it would look odd if the string just entered would automagically change itself) until the control focus is changed, at which point the value of the setting is reverted to the last valid value. Unfortunately there's no way for the user to actually know that the provided value is invalid before leaving the control.

First I just implemented the validation logic and implications in CGUIWindowSettingsCategory but then I thought it could also come in handy in other places like the smartplaylist rule editor so I tried to abstract it a bit and added the logic to set an external validation method in CGUIEditControl which will be automatically triggered whenever the value of the edit control changes. It might also make sense to be able to register a callback that is executed whenever the validity state of a control changes to be able to e.g. disable the "OK" button in the smartplaylist rule editor if the provided value is invalid.

This is more of an RFC right now because I would like to get some feedback on the general idea and approach. I first added the code to CGUIButtonControl but then thought about the possible use cases and it doesn't really make sense for radio button controls, checkboxes, spinners etc. Can anyone think of another control where this might make sense?

I would also like to get some feedback on how this could best be visualized in the user interface and what would be needed in the guilib to do that (maybe an <invalidtexture> tag and an <invalidcolor> tag?).
