### PR TITLE
[Confluence] fix 'Update library' button

### DIFF
--- a/addons/skin.confluence/720p/MyMusicNav.xml
+++ b/addons/skin.confluence/720p/MyMusicNav.xml
@@ -162,7 +162,7 @@
 					<altlabel>13353</altlabel>
 					<alttexturefocus border="5">button-focus.png</alttexturefocus>
 					<alttexturenofocus>-</alttexturenofocus>
-					<usealttexture>library.isscanningvideo</usealttexture>
+					<usealttexture>library.isscanningmusic</usealttexture>
 				</control>
 				<include>CommonNowPlaying_Controls</include>
 			</control>


### PR DESCRIPTION
the 'Stop scanning' button wouldn't appear when a music scan was in progress.
