### PR TITLE
CharsetConverter rework - part 1

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -916,6 +916,12 @@ if test "x$have_builtin_sync_val_compare_and_swap" = "xyes"; then
         [Define to 1 if your compiler supports the __sync_val_compare_and_swap() intrinsic.])
 fi
 
+# Check for u16string/u32string declarations
+AC_LANG_PUSH([C++])
+AC_CHECK_TYPES([std::u16string, std::u32string], [], [], [[#include <string>]])
+AC_CHECK_TYPES([char16_t, char32_t])
+AC_LANG_POP([C++])
+
 # Add top source directory for all builds so we can use config.h
 INCLUDES="-I\$(abs_top_srcdir) $INCLUDES" 
 

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1210,6 +1210,7 @@
     <ClInclude Include="..\..\xbmc\utils\LegacyPathTranslation.h" />
     <ClInclude Include="..\..\xbmc\utils\RssManager.h" />
     <ClInclude Include="..\..\xbmc\utils\StringValidation.h" />
+    <ClInclude Include="..\..\xbmc\utils\uXstrings.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
     <ClInclude Include="..\..\xbmc\video\FFmpegVideoDecoder.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\swig.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -6034,6 +6034,9 @@
     <ClInclude Include="..\..\xbmc\utils\StringValidation.h">
       <Filter>utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\uXstrings.h">
+      <Filter>utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -65,7 +65,7 @@ public:
     if (encoding.IsEmpty())
       g_charsetConverter.unknownToUTF8(strUtf8);
     else
-      g_charsetConverter.stringCharsetToUtf8(encoding, strDoc, strUtf8);
+      g_charsetConverter.ToUtf8(encoding, strDoc, strUtf8);
 
     doc.Clear();
     doc.Parse(strUtf8.c_str(),0,TIXML_ENCODING_UTF8);

--- a/xbmc/cores/DllLoader/Win32DllLoader.cpp
+++ b/xbmc/cores/DllLoader/Win32DllLoader.cpp
@@ -157,7 +157,7 @@ bool Win32DllLoader::Load()
   CStdString strFileName = GetFileName();
 
   CStdStringW strDllW;
-  g_charsetConverter.utf8ToW(CSpecialProtocol::TranslatePath(strFileName), strDllW);
+  g_charsetConverter.utf8ToW(CSpecialProtocol::TranslatePath(strFileName), strDllW, false, false, false);
   m_dllHandle = LoadLibraryExW(strDllW.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
   if (!m_dllHandle)
   {

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleStream.cpp
@@ -61,7 +61,7 @@ bool CDVDSubtitleStream::Open(const string& strFile)
       {
         buffer[size_read] = buffer[size_read + 1] = '\0';
         CStdStringW temp; 
-        g_charsetConverter.utf16LEtoW(CStdString16((uint16_t*)buffer),temp); 
+        g_charsetConverter.utf16LEtoW(std::u16string((char16_t*)buffer),temp); 
         wstringstream << temp; 
       }
       delete pInputStream;

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -701,7 +701,7 @@ bool iso9660::FindClose( HANDLE szLocalFolder )
 string iso9660::GetThinText(BYTE* strTxt, int iLen )
 {
   // convert from "fat" text (UTF-16BE) to "thin" text (UTF-8)
-  CStdString16 strTxtUnicode((uint16_t*)strTxt, iLen / 2);
+  std::u16string strTxtUnicode((char16_t*)strTxt, iLen / 2);
   CStdString utf8String;
 
   g_charsetConverter.utf16BEtoUTF8(strTxtUnicode, utf8String);

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -45,7 +45,7 @@ CStdString CLocalizeStrings::ToUTF8(const CStdString& strEncoding, const CStdStr
     return str;
 
   CStdString ret;
-  g_charsetConverter.stringCharsetToUtf8(strEncoding, str, ret);
+  g_charsetConverter.ToUtf8(strEncoding, str, ret);
   return ret;
 }
 

--- a/xbmc/music/karaoke/karaokelyricstextkar.cpp
+++ b/xbmc/music/karaoke/karaokelyricstextkar.cpp
@@ -603,7 +603,7 @@ CStdString CKaraokeLyricsTextKAR::convertText( const char * data )
   if ( g_charsetConverter.isValidUtf8(data) || CSettings::Get().GetString("karaoke.charset") == "DEFAULT" )
     strUTF8 = data;
   else
-    g_charsetConverter.stringCharsetToUtf8( CSettings::Get().GetString("karaoke.charset"), data, strUTF8 );
+    g_charsetConverter.ToUtf8( CSettings::Get().GetString("karaoke.charset"), data, strUTF8 );
 
   if ( strUTF8.size() == 0 )
     strUTF8 = " ";

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -328,7 +328,7 @@ const CStdString CPictureInfoTag::GetInfo(int info) const
     // Ascii, Unicode (UCS2), JIS (X208-1990), Unknown (application specific)
     if (m_exifInfo.CommentsCharset == EXIF_COMMENT_CHARSET_UNICODE)
     {
-      g_charsetConverter.ucs2ToUTF8(CStdString16((uint16_t*)m_exifInfo.Comments), value);
+      g_charsetConverter.ucs2ToUTF8(std::u16string((char16_t*)m_exifInfo.Comments), value);
     }
     else
     {

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -211,7 +211,7 @@ bool CSmartPlaylistRule::Load(const TiXmlNode *node, const std::string &encoding
     if (encoding.empty()) // utf8
       utf8Parameter = parameter->ValueStr();
     else
-      g_charsetConverter.stringCharsetToUtf8(encoding, parameter->ValueStr(), utf8Parameter);
+      g_charsetConverter.ToUtf8(encoding, parameter->ValueStr(), utf8Parameter);
 
     if (!utf8Parameter.empty())
       m_parameter.push_back(utf8Parameter);
@@ -228,7 +228,7 @@ bool CSmartPlaylistRule::Load(const TiXmlNode *node, const std::string &encoding
         if (encoding.empty()) // utf8
           utf8Parameter = value->ValueStr();
         else
-          g_charsetConverter.stringCharsetToUtf8(encoding, value->ValueStr(), utf8Parameter);
+          g_charsetConverter.ToUtf8(encoding, value->ValueStr(), utf8Parameter);
 
         if (!utf8Parameter.empty())
           m_parameter.push_back(utf8Parameter);

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -144,8 +144,8 @@ static struct SCharsetMapping
 #define ICONV_PREPARE(iconv) iconv=(iconv_t)-1
 #define ICONV_SAFE_CLOSE(iconv) if (iconv!=(iconv_t)-1) { iconv_close(iconv); iconv=(iconv_t)-1; }
 
-size_t iconv_const (void* cd, const char** inbuf, size_t *inbytesleft,
-                    char* * outbuf, size_t *outbytesleft)
+size_t iconv_const (void* cd, const char** inbuf, size_t* inbytesleft,
+                    char** outbuf, size_t* outbytesleft)
 {
     struct iconv_param_adapter {
         iconv_param_adapter(const char**p) : p(p) {}
@@ -316,7 +316,7 @@ static void logicalToVisualBiDi(const std::string& strSource, std::string& strDe
       // Apperently a string can get longer during this transformation
       // so make sure we allocate the maximum possible character utf8
       // can generate atleast, should cover all bases
-      char *result = strTmp.GetBuffer(len*4);
+      char* result = strTmp.GetBuffer(len*4);
 
       // Convert back from Unicode to the charset
       int len2 = fribidi_unicode_to_charset(fribidiCharset, visual, len, result);
@@ -351,12 +351,12 @@ CCharsetConverter::CCharsetConverter()
 {
 }
 
-void CCharsetConverter::OnSettingChanged(const CSetting *setting)
+void CCharsetConverter::OnSettingChanged(const CSetting* setting)
 {
   if (setting == NULL)
     return;
 
-  const std::string &settingId = setting->GetId();
+  const std::string& settingId = setting->GetId();
   // TODO: does this make any sense at all for subtitles and karaoke?
   if (settingId == "subtitles.charset" ||
       settingId == "karaoke.charset" ||
@@ -371,7 +371,7 @@ void CCharsetConverter::clear()
 std::vector<std::string> CCharsetConverter::getCharsetLabels()
 {
   vector<std::string> lab;
-  for(SCharsetMapping * c = g_charsets; c->charset; c++)
+  for(SCharsetMapping* c = g_charsets; c->charset; c++)
     lab.push_back(c->caption);
 
   return lab;
@@ -379,7 +379,7 @@ std::vector<std::string> CCharsetConverter::getCharsetLabels()
 
 std::string CCharsetConverter::getCharsetLabelByName(const std::string& charsetName)
 {
-  for(SCharsetMapping * c = g_charsets; c->charset; c++)
+  for(SCharsetMapping* c = g_charsets; c->charset; c++)
   {
     if (StringUtils::EqualsNoCase(charsetName,c->charset))
       return c->caption;
@@ -390,7 +390,7 @@ std::string CCharsetConverter::getCharsetLabelByName(const std::string& charsetN
 
 std::string CCharsetConverter::getCharsetNameByLabel(const std::string& charsetLabel)
 {
-  for(SCharsetMapping *c = g_charsets; c->charset; c++)
+  for(SCharsetMapping* c = g_charsets; c->charset; c++)
   {
     if (StringUtils::EqualsNoCase(charsetLabel, c->caption))
       return c->charset;
@@ -401,7 +401,7 @@ std::string CCharsetConverter::getCharsetNameByLabel(const std::string& charsetL
 
 bool CCharsetConverter::isBidiCharset(const std::string& charset)
 {
-  for(SFribidMapping *c = g_fribidi; c->charset; c++)
+  for(SFribidMapping* c = g_fribidi; c->charset; c++)
   {
     if (StringUtils::EqualsNoCase(charset, c->charset))
       return true;
@@ -429,7 +429,7 @@ void CCharsetConverter::reset(void)
   m_stringFribidiCharset = FRIBIDI_NOTFOUND;
 
   std::string strCharset=g_langInfo.GetGuiCharSet();
-  for(SFribidMapping *c = g_fribidi; c->charset; c++)
+  for(SFribidMapping* c = g_fribidi; c->charset; c++)
   {
     if (StringUtils::EqualsNoCase(strCharset, c->charset))
       m_stringFribidiCharset = c->name;
@@ -531,13 +531,13 @@ void CCharsetConverter::utf8To(const std::string& strDestCharset, const std::str
   iconv_close(iconvString);
 }
 
-void CCharsetConverter::unknownToUTF8(std::string &sourceAndDest)
+void CCharsetConverter::unknownToUTF8(std::string& sourceAndDest)
 {
   std::string source = sourceAndDest;
   unknownToUTF8(source, sourceAndDest);
 }
 
-void CCharsetConverter::unknownToUTF8(const std::string &source, std::string &dest)
+void CCharsetConverter::unknownToUTF8(const std::string& source, std::string& dest)
 {
   // checks whether it's utf8 already, and if not converts using the sourceCharset if given, else the string charset
   if (isValidUtf8(source))
@@ -549,20 +549,20 @@ void CCharsetConverter::unknownToUTF8(const std::string &source, std::string &de
   }
 }
 
-void CCharsetConverter::wToUTF8(const std::wstring& strSource, std::string &strDest)
+void CCharsetConverter::wToUTF8(const std::wstring& strSource, std::string& strDest)
 {
   CSingleLock lock(m_critSection);
   convert(m_iconvWtoUtf8,UTF8_DEST_MULTIPLIER,WCHAR_CHARSET,"UTF-8",strSource,strDest);
 }
 
-void CCharsetConverter::utf16BEtoUTF8(const std::u16string& strSource, std::string &strDest)
+void CCharsetConverter::utf16BEtoUTF8(const std::u16string& strSource, std::string& strDest)
 {
   CSingleLock lock(m_critSection);
   convert(m_iconvUtf16BEtoUtf8,UTF8_DEST_MULTIPLIER,"UTF-16BE","UTF-8",strSource,strDest);
 }
 
 void CCharsetConverter::utf16LEtoUTF8(const std::u16string& strSource,
-                                      std::string &strDest)
+                                      std::string& strDest)
 {
   CSingleLock lock(m_critSection);
   convert(m_iconvUtf16LEtoUtf8,UTF8_DEST_MULTIPLIER,"UTF-16LE","UTF-8",strSource,strDest);
@@ -620,14 +620,14 @@ void CCharsetConverter::utf32ToStringCharset(const unsigned long* strSource, std
     const char* src = (const char*) strSource;
     size_t inBytes = (ptr-strSource+1)*4;
 
-    char *dst = dstTmp.GetBuffer(inBytes);
+    char* dst = dstTmp.GetBuffer(inBytes);
     size_t outBytes = inBytes;
 
     if (iconv_const(m_iconvUtf32ToStringCharset, &src, &inBytes, &dst, &outBytes) == (size_t)-1)
     {
       CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
       dstTmp.ReleaseBuffer();
-      strDest = (const char *)strSource;
+      strDest = (const char*)strSource;
       return;
     }
 
@@ -635,7 +635,7 @@ void CCharsetConverter::utf32ToStringCharset(const unsigned long* strSource, std
     {
       CLog::Log(LOGERROR, "%s failed cleanup", __FUNCTION__);
       dstTmp.ReleaseBuffer();
-      strDest = (const char *)strSource;
+      strDest = (const char*)strSource;
       return;
     }
 
@@ -652,9 +652,9 @@ void CCharsetConverter::utf8ToSystem(std::string& strSourceDest)
 }
 
 // Taken from RFC2640
-bool CCharsetConverter::isValidUtf8(const char *buf, unsigned int len)
+bool CCharsetConverter::isValidUtf8(const char* buf, unsigned int len)
 {
-  const unsigned char *endbuf = (unsigned char*)buf + len;
+  const unsigned char* endbuf = (unsigned char*)buf + len;
   unsigned char byte2mask=0x00, c;
   int trailing=0; // trailing (continuation) bytes to follow
 
@@ -722,7 +722,7 @@ void CCharsetConverter::utf8logicalToVisualBiDi(const std::string& strSource, st
   logicalToVisualBiDi(strSource, strDest, FRIBIDI_UTF8, FRIBIDI_TYPE_RTL);
 }
 
-void CCharsetConverter::SettingOptionsCharsetsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
+void CCharsetConverter::SettingOptionsCharsetsFiller(const CSetting* setting, std::vector< std::pair<std::string, std::string> >& list, std::string& current)
 {
   vector<std::string> vecCharsets = g_charsetConverter.getCharsetLabels();
   sort(vecCharsets.begin(), vecCharsets.end(), sortstringbyname());

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -182,7 +182,7 @@ static bool convert_checked(iconv_t& type, int multiplier, const CStdString& str
     return true; //empty strings are easy
 
   //input buffer for iconv() is the buffer from strSource
-  size_t      inBufSize  = (strSource.length() + 1) * sizeof(strSource[0]);
+  size_t      inBufSize  = (strSource.length() + 1) * sizeof(typename INPUT::value_type);
   const char* inBuf      = (const char*)strSource.c_str();
 
   //allocate output buffer for iconv()

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -56,7 +56,6 @@
 #endif
 
 
-static iconv_t m_iconvStringCharsetToFontCharset = (iconv_t)-1;
 static iconv_t m_iconvSubtitleCharsetToW         = (iconv_t)-1;
 static iconv_t m_iconvUtf8ToStringCharset        = (iconv_t)-1;
 static iconv_t m_iconvStringCharsetToUtf8        = (iconv_t)-1;
@@ -425,7 +424,6 @@ void CCharsetConverter::reset(void)
 {
   CSingleLock lock(m_critSection);
 
-  ICONV_SAFE_CLOSE(m_iconvStringCharsetToFontCharset);
   ICONV_SAFE_CLOSE(m_iconvUtf8ToStringCharset);
   ICONV_SAFE_CLOSE(m_iconvStringCharsetToUtf8);
   ICONV_SAFE_CLOSE(m_iconvSubtitleCharsetToW);

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -654,7 +654,7 @@ void CCharsetConverter::utf32ToStringCharset(const unsigned long* strSource, std
 
 void CCharsetConverter::utf8ToSystem(std::string& strSourceDest)
 {
-  CStdString strDest;
+  std::string strDest;
   g_charsetConverter.utf8To("", strSourceDest, strDest);
   strSourceDest = strDest;
 }

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -60,7 +60,6 @@ static iconv_t m_iconvStringCharsetToFontCharset = (iconv_t)-1;
 static iconv_t m_iconvSubtitleCharsetToW         = (iconv_t)-1;
 static iconv_t m_iconvUtf8ToStringCharset        = (iconv_t)-1;
 static iconv_t m_iconvStringCharsetToUtf8        = (iconv_t)-1;
-static iconv_t m_iconvUcs2CharsetToStringCharset = (iconv_t)-1;
 static iconv_t m_iconvUtf32ToStringCharset       = (iconv_t)-1;
 static iconv_t m_iconvWtoUtf8                    = (iconv_t)-1;
 static iconv_t m_iconvUtf16LEtoW                 = (iconv_t)-1;
@@ -429,7 +428,6 @@ void CCharsetConverter::reset(void)
   ICONV_SAFE_CLOSE(m_iconvStringCharsetToFontCharset);
   ICONV_SAFE_CLOSE(m_iconvUtf8ToStringCharset);
   ICONV_SAFE_CLOSE(m_iconvStringCharsetToUtf8);
-  ICONV_SAFE_CLOSE(m_iconvUcs2CharsetToStringCharset);
   ICONV_SAFE_CLOSE(m_iconvSubtitleCharsetToW);
   ICONV_SAFE_CLOSE(m_iconvWtoUtf8);
   ICONV_SAFE_CLOSE(m_iconvUtf16BEtoUtf8);
@@ -605,28 +603,6 @@ bool CCharsetConverter::utf16LEtoW(const std::u16string& utf16String, std::wstri
 {
   CSingleLock lock(m_critSection);
   return convert(m_iconvUtf16LEtoW,1,"UTF-16LE",WCHAR_CHARSET,utf16String,wString);
-}
-
-bool CCharsetConverter::ucs2CharsetToStringCharset(const std::u16string& ucs2StringSrc, std::string& stringDst, bool swap /*= false*/)
-{
-  std::u16string strCopy = ucs2StringSrc;
-  if (swap)
-  {
-    char* s = (char*) strCopy.c_str();
-
-    while (*s || *(s + 1))
-    {
-      char c = *s;
-      *s = *(s + 1);
-      *(s + 1) = c;
-
-      s++;
-      s++;
-    }
-  }
-  CSingleLock lock(m_critSection);
-  return convert(m_iconvUcs2CharsetToStringCharset,1,"UTF-16LE",
-          g_langInfo.GetGuiCharSet(),strCopy,stringDst);
 }
 
 bool CCharsetConverter::utf32ToStringCharset(const std::u32string& utf32StringSrc, std::string& stringDst)

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -332,7 +332,7 @@ static bool logicalToVisualBiDi(const std::string& stringSrc, std::string& strin
 
       // Convert back from Unicode to the charset
       int len2 = fribidi_unicode_to_charset(fribidiCharset, visual, len, result);
-      ASSERT(len2 <= len*4);
+      assert(len2 <= len*4);
       stringDst += result;
       delete[] result;
 

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -27,7 +27,6 @@
 #include "settings/Setting.h"
 #include "threads/SingleLock.h"
 #include "log.h"
-#include "utils/StdString.h"
 
 #include <errno.h>
 #include <iconv.h>

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -512,7 +512,7 @@ bool CCharsetConverter::utf8ToStringCharset(std::string& stringSrcDst)
   return utf8ToStringCharset(strSrc, stringSrcDst);
 }
 
-bool CCharsetConverter::stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst)
+bool CCharsetConverter::ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst)
 {
   if (strSourceCharset == "UTF-8")
   { // simple case - no conversion necessary

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -163,7 +163,7 @@ size_t iconv_const (void* cd, const char** inbuf, size_t *inbytesleft,
 }
 
 template<class INPUT,class OUTPUT>
-static bool convert_checked(iconv_t& type, int multiplier, const std::string& strFromCharset, const std::string& strToCharset, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar = false)
+static bool convert(iconv_t& type, int multiplier, const std::string& strFromCharset, const std::string& strToCharset, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar = false)
 {
   strDest.clear();
 
@@ -279,13 +279,6 @@ static bool convert_checked(iconv_t& type, int multiplier, const std::string& st
   free(outBuf);
 
   return true;
-}
-
-template<class INPUT,class OUTPUT>
-static void convert(iconv_t& type, int multiplier, const CStdString& strFromCharset, const CStdString& strToCharset, const INPUT& strSource,  OUTPUT& strDest)
-{
-  if(!convert_checked(type, multiplier, strFromCharset, strToCharset, strSource, strDest))
-    strDest = strSource;
 }
 
 using namespace std;
@@ -524,8 +517,7 @@ void CCharsetConverter::utf8To(const CStdStringA& strDestCharset, const CStdStri
 {
   iconv_t iconvString;
   ICONV_PREPARE(iconvString);
-  if(!convert_checked(iconvString,UTF8_DEST_MULTIPLIER,UTF8_SOURCE,strDestCharset,strSource,strDest))
-    strDest.clear();
+  convert(iconvString,UTF8_DEST_MULTIPLIER,UTF8_SOURCE,strDestCharset,strSource,strDest);
   iconv_close(iconvString);
 }
 
@@ -533,8 +525,7 @@ void CCharsetConverter::utf8To(const CStdStringA& strDestCharset, const CStdStri
 {
   iconv_t iconvString;
   ICONV_PREPARE(iconvString);
-  if(!convert_checked(iconvString,UTF8_DEST_MULTIPLIER,UTF8_SOURCE,strDestCharset,strSource,strDest))
-    strDest.clear();
+  convert(iconvString,UTF8_DEST_MULTIPLIER,UTF8_SOURCE,strDestCharset,strSource,strDest);
   iconv_close(iconvString);
 }
 
@@ -565,30 +556,26 @@ void CCharsetConverter::wToUTF8(const CStdStringW& strSource, CStdStringA &strDe
 void CCharsetConverter::utf16BEtoUTF8(const CStdString16& strSource, CStdStringA &strDest)
 {
   CSingleLock lock(m_critSection);
-  if(!convert_checked(m_iconvUtf16BEtoUtf8,UTF8_DEST_MULTIPLIER,"UTF-16BE","UTF-8",strSource,strDest))
-    strDest.clear();
+  convert(m_iconvUtf16BEtoUtf8,UTF8_DEST_MULTIPLIER,"UTF-16BE","UTF-8",strSource,strDest);
 }
 
 void CCharsetConverter::utf16LEtoUTF8(const CStdString16& strSource,
                                       CStdStringA &strDest)
 {
   CSingleLock lock(m_critSection);
-  if(!convert_checked(m_iconvUtf16LEtoUtf8,UTF8_DEST_MULTIPLIER,"UTF-16LE","UTF-8",strSource,strDest))
-    strDest.clear();
+  convert(m_iconvUtf16LEtoUtf8,UTF8_DEST_MULTIPLIER,"UTF-16LE","UTF-8",strSource,strDest);
 }
 
 void CCharsetConverter::ucs2ToUTF8(const CStdString16& strSource, CStdStringA& strDest)
 {
   CSingleLock lock(m_critSection);
-  if(!convert_checked(m_iconvUcs2CharsetToUtf8,UTF8_DEST_MULTIPLIER,"UCS-2LE","UTF-8",strSource,strDest))
-    strDest.clear();
+  convert(m_iconvUcs2CharsetToUtf8,UTF8_DEST_MULTIPLIER,"UCS-2LE","UTF-8",strSource,strDest);
 }
 
 void CCharsetConverter::utf16LEtoW(const CStdString16& strSource, CStdStringW &strDest)
 {
   CSingleLock lock(m_critSection);
-  if(!convert_checked(m_iconvUtf16LEtoW,sizeof(wchar_t),"UTF-16LE",WCHAR_CHARSET,strSource,strDest))
-    strDest.clear();
+  convert(m_iconvUtf16LEtoW,sizeof(wchar_t),"UTF-16LE",WCHAR_CHARSET,strSource,strDest);
 }
 
 void CCharsetConverter::ucs2CharsetToStringCharset(const CStdStringW& strSource, CStdStringA& strDest, bool swap)

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -443,7 +443,10 @@ void CCharsetConverter::reset(void)
   for(SFribidMapping* c = g_fribidi; c->charset; c++)
   {
     if (StringUtils::EqualsNoCase(strCharset, c->charset))
+    {
       m_stringFribidiCharset = c->name;
+      break;
+    }
   }
 }
 

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -220,8 +220,8 @@ static bool convert(iconv_t& type, int multiplier, const std::string& strFromCha
         char* newBuf  = (char*)realloc(outBuf, outBufSize);
         if (!newBuf)
         {
-          CLog::Log(LOGERROR, "%s realloc failed with buffer=%p size=%zu errno=%d(%s)",
-                    __FUNCTION__, outBuf, outBufSize, errno, strerror(errno));
+          CLog::Log(LOGSEVERE, "%s realloc failed with errno=%d(%s)",
+                    __FUNCTION__, errno, strerror(errno));
           break;
         }
         outBuf = newBuf;

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -580,9 +580,9 @@ void CCharsetConverter::utf16LEtoW(const std::u16string& utf16String, std::wstri
   convert(m_iconvUtf16LEtoW,sizeof(wchar_t),"UTF-16LE",WCHAR_CHARSET,utf16String,wString);
 }
 
-void CCharsetConverter::ucs2CharsetToStringCharset(const std::wstring& strSource, std::string& strDest, bool swap /*= false*/)
+void CCharsetConverter::ucs2CharsetToStringCharset(const std::u16string& strSource, std::string& strDest, bool swap /*= false*/)
 {
-  std::wstring strCopy = strSource;
+  std::u16string strCopy = strSource;
   if (swap)
   {
     char* s = (char*) strCopy.c_str();

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -629,46 +629,10 @@ bool CCharsetConverter::ucs2CharsetToStringCharset(const std::u16string& ucs2Str
           g_langInfo.GetGuiCharSet(),strCopy,stringDst);
 }
 
-bool CCharsetConverter::utf32ToStringCharset(const unsigned long* utf32StringSrc, std::string& stringDst)
+bool CCharsetConverter::utf32ToStringCharset(const std::u32string& utf32StringSrc, std::string& stringDst)
 {
-  stringDst.clear();
-
   CSingleLock lock(m_critSection);
-
-  if (m_iconvUtf32ToStringCharset == (iconv_t) - 1)
-    m_iconvUtf32ToStringCharset = iconv_open(g_langInfo.GetGuiCharSet().c_str(), "UTF-32LE");
-
-  if (m_iconvUtf32ToStringCharset != (iconv_t) - 1)
-  {
-    const unsigned long* ptr=utf32StringSrc;
-    while (*ptr) ptr++;
-    const char* src = (const char*) utf32StringSrc;
-    size_t inBytes = (ptr-utf32StringSrc+1)*4;
-
-    char* dst = new char[inBytes];
-    size_t outBytes = inBytes;
-
-    if (iconv_const(m_iconvUtf32ToStringCharset, &src, &inBytes, &dst, &outBytes) == (size_t)-1)
-    {
-      CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-      delete[] dst;
-      stringDst = (const char*)utf32StringSrc;
-      return false;
-    }
-
-    if (iconv(m_iconvUtf32ToStringCharset, NULL, NULL, &dst, &outBytes) == (size_t)-1)
-    {
-      CLog::Log(LOGERROR, "%s failed cleanup", __FUNCTION__);
-      delete[] dst;
-      stringDst = (const char*)utf32StringSrc;
-      return false;
-    }
-    stringDst = dst;
-    delete[] dst;
-    return true;
-  }
-
-  return false;
+  return convert(m_iconvUtf32ToStringCharset, 1, g_langInfo.GetGuiCharSet().c_str(), "UTF-32", utf32StringSrc, stringDst);
 }
 
 bool CCharsetConverter::utf8ToSystem(std::string& stringSrcDst, bool failOnBadChar /*= false*/)

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -513,6 +513,11 @@ bool CCharsetConverter::utf8ToStringCharset(std::string& stringSrcDst)
 
 bool CCharsetConverter::stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst)
 {
+  if (strSourceCharset == "UTF-8")
+  { // simple case - no conversion necessary
+    utf8StringDst = stringSrc;
+    return true;
+  }
   iconv_t iconvString;
   ICONV_PREPARE(iconvString);
   const bool result = convert(iconvString,m_Utf8CharMaxSize,strSourceCharset,"UTF-8",stringSrc,utf8StringDst);

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -163,7 +163,7 @@ size_t iconv_const (void* cd, const char** inbuf, size_t *inbytesleft,
 }
 
 template<class INPUT,class OUTPUT>
-static bool convert_checked(iconv_t& type, int multiplier, const CStdString& strFromCharset, const CStdString& strToCharset, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar = false)
+static bool convert_checked(iconv_t& type, int multiplier, const std::string& strFromCharset, const std::string& strToCharset, const INPUT& strSource, OUTPUT& strDest, bool failOnInvalidChar = false)
 {
   strDest.clear();
 

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -268,14 +268,14 @@ static bool convert_checked(iconv_t& type, int multiplier, const CStdString& str
   }
   //we're done
 
-  size_t bytesWritten = outBufSize - outBytesAvail;
-  char*  dest         = (char*)strDest.GetBuffer(bytesWritten);
+  const typename OUTPUT::size_type sizeInChars = (typename OUTPUT::size_type) (outBufSize - outBytesAvail) / sizeof(typename OUTPUT::value_type);
+  typename OUTPUT::const_pointer strPtr = (typename OUTPUT::const_pointer) outBuf;
+  /* Make sure that all buffer is assigned and string is stopped at end of buffer */
+  if (strPtr[sizeInChars-1] == 0)
+    strDest.assign(strPtr, sizeInChars-1);
+  else
+    strDest.assign(strPtr, sizeInChars);
 
-  //copy the output from iconv() into the CStdString
-  memcpy(dest, outBuf, bytesWritten);
-
-  strDest.ReleaseBuffer();
-  
   free(outBuf);
 
   return true;

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -74,7 +74,7 @@ public:
 
   bool utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst);
 
-  bool utf32ToStringCharset(const unsigned long* utf32StringSrc, std::string& stringDst);
+  bool utf32ToStringCharset(const std::u32string& utf32StringSrc, std::string& stringDst);
 
   std::vector<std::string> getCharsetLabels();
   std::string getCharsetLabelByName(const std::string& charsetName);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -42,7 +42,9 @@ public:
 
   void clear();
 
-  bool utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst, bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false, bool* bWasFlipped = NULL);
+  bool utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst,
+                bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false,
+                bool failOnBadChar = false, bool* bWasFlipped = NULL);
 
   bool utf16LEtoW(const std::u16string& utf16String, std::wstring& wString);
 
@@ -51,7 +53,7 @@ public:
   bool utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst);
 
   bool utf8ToStringCharset(std::string& stringSrcDst);
-  bool utf8ToSystem(std::string& stringSrcDst);
+  bool utf8ToSystem(std::string& stringSrcDst, bool failOnBadChar = false);
 
   bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst);
   bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst);
@@ -65,7 +67,7 @@ public:
 
   bool ucs2CharsetToStringCharset(const std::u16string& ucs2StringSrc, std::string& stringDst, bool swap = false);
 
-  bool wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst);
+  bool wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
   bool utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
   bool utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
   bool ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
@@ -80,7 +82,7 @@ public:
   bool isBidiCharset(const std::string& charset);
 
   bool unknownToUTF8(std::string& stringSrcDst);
-  bool unknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst);
+  bool unknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
 
   bool toW(const std::string& stringSrc, std::wstring& wStringDst, const std::string& enc);
   bool fromW(const std::wstring& wStringSrc, std::string& stringDst, const std::string& enc);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -65,8 +65,6 @@ public:
 
   bool isValidUtf8(const char* buf, unsigned int len);
 
-  bool ucs2CharsetToStringCharset(const std::u16string& ucs2StringSrc, std::string& stringDst, bool swap = false);
-
   bool wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
   bool utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
   bool utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -24,8 +24,9 @@
 #include "settings/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 #include "utils/GlobalsHandling.h"
-#include "utils/StdString.h"
+#include "utils/uXstrings.h"
 
+#include <string>
 #include <vector>
 
 class CSetting;
@@ -35,60 +36,60 @@ class CCharsetConverter : public ISettingCallback
 public:
   CCharsetConverter();
 
-  virtual void OnSettingChanged(const CSetting *setting);
+  virtual void OnSettingChanged(const CSetting* setting);
 
   void reset();
 
   void clear();
 
-  void utf8ToW(const CStdStringA& utf8String, CStdStringW &utf16String, bool bVisualBiDiFlip=true, bool forceLTRReadingOrder=false, bool* bWasFlipped=NULL);
+  void utf8ToW(const std::string& utf8String, std::wstring& wString, bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false, bool* bWasFlipped = NULL);
 
-  void utf16LEtoW(const CStdString16& utf16String, CStdStringW &wString);
+  void utf16LEtoW(const std::u16string& utf16String, std::wstring& wString);
 
-  void subtitleCharsetToW(const CStdStringA& strSource, CStdStringW& strDest);
+  void subtitleCharsetToW(const std::string& strSource, std::wstring& strDest);
 
-  void utf8ToStringCharset(const CStdStringA& strSource, CStdStringA& strDest);
+  void utf8ToStringCharset(const std::string& strSource, std::string& strDest);
 
-  void utf8ToStringCharset(CStdStringA& strSourceDest);
-  void utf8ToSystem(CStdStringA& strSourceDest);
+  void utf8ToStringCharset(std::string& strSourceDest);
+  void utf8ToSystem(std::string& strSourceDest);
 
-  void utf8To(const CStdStringA& strDestCharset, const CStdStringA& strSource, CStdStringA& strDest);
-  void utf8To(const CStdStringA& strDestCharset, const CStdStringA& strSource, CStdString16& strDest);
-  void utf8To(const CStdStringA& strDestCharset, const CStdStringA& strSource, CStdString32& strDest);
+  void utf8To(const std::string& strDestCharset, const std::string& strSource, std::string& strDest);
+  void utf8To(const std::string& strDestCharset, const std::string& strSource, std::u16string& strDest);
+  void utf8To(const std::string& strDestCharset, const std::string& strSource, std::u32string& strDest);
 
-  void stringCharsetToUtf8(const CStdStringA& strSourceCharset, const CStdStringA& strSource, CStdStringA& strDest);
+  void stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& strSource, std::string& strDest);
 
-  bool isValidUtf8(const CStdString& str);
+  bool isValidUtf8(const std::string& str);
 
-  bool isValidUtf8(const char *buf, unsigned int len);
+  bool isValidUtf8(const char* buf, unsigned int len);
 
-  void ucs2CharsetToStringCharset(const CStdStringW& strSource, CStdStringA& strDest, bool swap = false);
+  void ucs2CharsetToStringCharset(const std::wstring& strSource, std::string& strDest, bool swap = false);
 
-  void wToUTF8(const CStdStringW& strSource, CStdStringA &strDest);
-  void utf16BEtoUTF8(const CStdString16& strSource, CStdStringA &strDest);
-  void utf16LEtoUTF8(const CStdString16& strSource, CStdStringA &strDest);
-  void ucs2ToUTF8(const CStdString16& strSource, CStdStringA& strDest);
+  void wToUTF8(const std::wstring& strSource, std::string& strDest);
+  void utf16BEtoUTF8(const std::u16string& strSource, std::string& strDest);
+  void utf16LEtoUTF8(const std::u16string& strSource, std::string& strDest);
+  void ucs2ToUTF8(const std::u16string& strSource, std::string& strDest);
 
-  void utf8logicalToVisualBiDi(const CStdStringA& strSource, CStdStringA& strDest);
+  void utf8logicalToVisualBiDi(const std::string& strSource, std::string& strDest);
 
-  void utf32ToStringCharset(const unsigned long* strSource, CStdStringA& strDest);
+  void utf32ToStringCharset(const unsigned long* strSource, std::string& strDest);
 
-  std::vector<CStdString> getCharsetLabels();
-  CStdString getCharsetLabelByName(const CStdString& charsetName);
-  CStdString getCharsetNameByLabel(const CStdString& charsetLabel);
-  bool isBidiCharset(const CStdString& charset);
+  std::vector<std::string> getCharsetLabels();
+  std::string getCharsetLabelByName(const std::string& charsetName);
+  std::string getCharsetNameByLabel(const std::string& charsetLabel);
+  bool isBidiCharset(const std::string& charset);
 
-  void unknownToUTF8(CStdStringA &sourceDest);
-  void unknownToUTF8(const CStdStringA &source, CStdStringA &dest);
+  void unknownToUTF8(std::string& sourceDest);
+  void unknownToUTF8(const std::string& source, std::string& dest);
 
-  void toW(const CStdStringA& source, CStdStringW& dest, const CStdStringA& enc);
-  void fromW(const CStdStringW& source, CStdStringA& dest, const CStdStringA& enc);
+  void toW(const std::string& source, std::wstring& dest, const std::string& enc);
+  void fromW(const std::wstring& source, std::string& dest, const std::string& enc);
 
-  static void SettingOptionsCharsetsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
+  static void SettingOptionsCharsetsFiller(const CSetting* setting, std::vector< std::pair<std::string, std::string> >& list, std::string& current);
 };
 
 XBMC_GLOBAL(CCharsetConverter,g_charsetConverter);
 
-size_t iconv_const (void* cd, const char** inbuf, size_t *inbytesleft, char* * outbuf, size_t *outbytesleft);
+size_t iconv_const (void* cd, const char** inbuf, size_t* inbytesleft, char** outbuf, size_t* outbytesleft);
 
 #endif

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -42,48 +42,48 @@ public:
 
   void clear();
 
-  void utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst, bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false, bool* bWasFlipped = NULL);
+  bool utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst, bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false, bool* bWasFlipped = NULL);
 
-  void utf16LEtoW(const std::u16string& utf16String, std::wstring& wString);
+  bool utf16LEtoW(const std::u16string& utf16String, std::wstring& wString);
 
-  void subtitleCharsetToW(const std::string& stringSrc, std::wstring& wStringDst);
+  bool subtitleCharsetToW(const std::string& stringSrc, std::wstring& wStringDst);
 
-  void utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst);
+  bool utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst);
 
-  void utf8ToStringCharset(std::string& stringSrcDst);
-  void utf8ToSystem(std::string& stringSrcDst);
+  bool utf8ToStringCharset(std::string& stringSrcDst);
+  bool utf8ToSystem(std::string& stringSrcDst);
 
-  void utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst);
-  void utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst);
-  void utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst);
+  bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst);
+  bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst);
+  bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst);
 
-  void stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst);
+  bool stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst);
 
   bool isValidUtf8(const std::string& str);
 
   bool isValidUtf8(const char* buf, unsigned int len);
 
-  void ucs2CharsetToStringCharset(const std::u16string& ucs2StringSrc, std::string& stringDst, bool swap = false);
+  bool ucs2CharsetToStringCharset(const std::u16string& ucs2StringSrc, std::string& stringDst, bool swap = false);
 
-  void wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst);
-  void utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
-  void utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
-  void ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
+  bool wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst);
+  bool utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+  bool utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+  bool ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
 
-  void utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst);
+  bool utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst);
 
-  void utf32ToStringCharset(const unsigned long* utf32StringSrc, std::string& stringDst);
+  bool utf32ToStringCharset(const unsigned long* utf32StringSrc, std::string& stringDst);
 
   std::vector<std::string> getCharsetLabels();
   std::string getCharsetLabelByName(const std::string& charsetName);
   std::string getCharsetNameByLabel(const std::string& charsetLabel);
   bool isBidiCharset(const std::string& charset);
 
-  void unknownToUTF8(std::string& stringSrcDst);
-  void unknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst);
+  bool unknownToUTF8(std::string& stringSrcDst);
+  bool unknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst);
 
-  void toW(const std::string& stringSrc, std::wstring& wStringDst, const std::string& enc);
-  void fromW(const std::wstring& wStringSrc, std::string& stringDst, const std::string& enc);
+  bool toW(const std::string& stringSrc, std::wstring& wStringDst, const std::string& enc);
+  bool fromW(const std::wstring& wStringSrc, std::string& stringDst, const std::string& enc);
 
   static void SettingOptionsCharsetsFiller(const CSetting* setting, std::vector< std::pair<std::string, std::string> >& list, std::string& current);
 };

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -63,7 +63,7 @@ public:
 
   bool isValidUtf8(const char* buf, unsigned int len);
 
-  void ucs2CharsetToStringCharset(const std::wstring& strSource, std::string& strDest, bool swap = false);
+  void ucs2CharsetToStringCharset(const std::u16string& strSource, std::string& strDest, bool swap = false);
 
   void wToUTF8(const std::wstring& strSource, std::string& strDest);
   void utf16BEtoUTF8(const std::u16string& strSource, std::string& strDest);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -86,6 +86,8 @@ public:
   bool fromW(const std::wstring& wStringSrc, std::string& stringDst, const std::string& enc);
 
   static void SettingOptionsCharsetsFiller(const CSetting* setting, std::vector< std::pair<std::string, std::string> >& list, std::string& current);
+private:
+  static const int m_Utf8CharMinSize, m_Utf8CharMaxSize;
 };
 
 XBMC_GLOBAL(CCharsetConverter,g_charsetConverter);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -42,48 +42,48 @@ public:
 
   void clear();
 
-  void utf8ToW(const std::string& utf8String, std::wstring& wString, bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false, bool* bWasFlipped = NULL);
+  void utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst, bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false, bool* bWasFlipped = NULL);
 
   void utf16LEtoW(const std::u16string& utf16String, std::wstring& wString);
 
-  void subtitleCharsetToW(const std::string& strSource, std::wstring& strDest);
+  void subtitleCharsetToW(const std::string& stringSrc, std::wstring& wStringDst);
 
-  void utf8ToStringCharset(const std::string& strSource, std::string& strDest);
+  void utf8ToStringCharset(const std::string& utf8StringSrc, std::string& stringDst);
 
-  void utf8ToStringCharset(std::string& strSourceDest);
-  void utf8ToSystem(std::string& strSourceDest);
+  void utf8ToStringCharset(std::string& stringSrcDst);
+  void utf8ToSystem(std::string& stringSrcDst);
 
-  void utf8To(const std::string& strDestCharset, const std::string& strSource, std::string& strDest);
-  void utf8To(const std::string& strDestCharset, const std::string& strSource, std::u16string& strDest);
-  void utf8To(const std::string& strDestCharset, const std::string& strSource, std::u32string& strDest);
+  void utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::string& stringDst);
+  void utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst);
+  void utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst);
 
-  void stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& strSource, std::string& strDest);
+  void stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst);
 
   bool isValidUtf8(const std::string& str);
 
   bool isValidUtf8(const char* buf, unsigned int len);
 
-  void ucs2CharsetToStringCharset(const std::u16string& strSource, std::string& strDest, bool swap = false);
+  void ucs2CharsetToStringCharset(const std::u16string& ucs2StringSrc, std::string& stringDst, bool swap = false);
 
-  void wToUTF8(const std::wstring& strSource, std::string& strDest);
-  void utf16BEtoUTF8(const std::u16string& strSource, std::string& strDest);
-  void utf16LEtoUTF8(const std::u16string& strSource, std::string& strDest);
-  void ucs2ToUTF8(const std::u16string& strSource, std::string& strDest);
+  void wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst);
+  void utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+  void utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
+  void ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);
 
-  void utf8logicalToVisualBiDi(const std::string& strSource, std::string& strDest);
+  void utf8logicalToVisualBiDi(const std::string& utf8StringSrc, std::string& utf8StringDst);
 
-  void utf32ToStringCharset(const unsigned long* strSource, std::string& strDest);
+  void utf32ToStringCharset(const unsigned long* utf32StringSrc, std::string& stringDst);
 
   std::vector<std::string> getCharsetLabels();
   std::string getCharsetLabelByName(const std::string& charsetName);
   std::string getCharsetNameByLabel(const std::string& charsetLabel);
   bool isBidiCharset(const std::string& charset);
 
-  void unknownToUTF8(std::string& sourceDest);
-  void unknownToUTF8(const std::string& source, std::string& dest);
+  void unknownToUTF8(std::string& stringSrcDst);
+  void unknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst);
 
-  void toW(const std::string& source, std::wstring& dest, const std::string& enc);
-  void fromW(const std::wstring& source, std::string& dest, const std::string& enc);
+  void toW(const std::string& stringSrc, std::wstring& wStringDst, const std::string& enc);
+  void fromW(const std::wstring& wStringSrc, std::string& stringDst, const std::string& enc);
 
   static void SettingOptionsCharsetsFiller(const CSetting* setting, std::vector< std::pair<std::string, std::string> >& list, std::string& current);
 };

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -59,7 +59,7 @@ public:
   bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u16string& utf16StringDst);
   bool utf8To(const std::string& strDestCharset, const std::string& utf8StringSrc, std::u32string& utf32StringDst);
 
-  bool stringCharsetToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst);
+  bool ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst);
 
   bool isValidUtf8(const std::string& str);
 

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -317,7 +317,7 @@ void CRssReader::fromRSSToUTF16(const CStdStringA& strSource, CStdStringW& strDe
 {
   CStdString flippedStrSource, strSourceUtf8;
 
-  g_charsetConverter.stringCharsetToUtf8(m_encoding, strSource, strSourceUtf8);
+  g_charsetConverter.ToUtf8(m_encoding, strSource, strSourceUtf8);
   if (m_rtlText)
     g_charsetConverter.utf8logicalToVisualBiDi(strSourceUtf8, flippedStrSource);
   else

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -341,7 +341,7 @@ CStdStringArray StringUtils::SplitString(const CStdString& input, const CStdStri
   return result;
 }
 
-vector<string> StringUtils::Split(const CStdString& input, const CStdString& delimiter, unsigned int iMaxStrings /* = 0 */)
+vector<string> StringUtils::Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings /* = 0 */)
 {
   CStdStringArray result;
   SplitString(input, delimiter, result, iMaxStrings);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -72,7 +72,7 @@ public:
   static CStdString Join(const std::vector<std::string> &strings, const CStdString& delimiter);
   static int SplitString(const CStdString& input, const CStdString& delimiter, CStdStringArray &results, unsigned int iMaxStrings = 0);
   static CStdStringArray SplitString(const CStdString& input, const CStdString& delimiter, unsigned int iMaxStrings = 0);
-  static std::vector<std::string> Split(const CStdString& input, const CStdString& delimiter, unsigned int iMaxStrings = 0);
+  static std::vector<std::string> Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings = 0);
   static int FindNumber(const CStdString& strInput, const CStdString &strFind);
   static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
   static long TimeStringToSeconds(const CStdString &timeString);

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -306,7 +306,7 @@ void CWeatherJob::LoadLocalizedToken()
           if (strEncoding.IsEmpty()) // Is language file utf8?
             utf8Label=pChild->FirstChild()->Value();
           else
-            g_charsetConverter.stringCharsetToUtf8(strEncoding, pChild->FirstChild()->Value(), utf8Label);
+            g_charsetConverter.ToUtf8(strEncoding, pChild->FirstChild()->Value(), utf8Label);
 
           if (!utf8Label.IsEmpty())
             m_localizedTokens.insert(make_pair(utf8Label, id));

--- a/xbmc/utils/uXstrings.h
+++ b/xbmc/utils/uXstrings.h
@@ -1,0 +1,61 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/** @file utils/uXstrings.h
+ *  Declarations of std::u16string and std::u32string for systems without those declarations
+ */
+#pragma once
+
+#include <string>
+
+#ifndef TARGET_WINDOWS
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
+#if !defined(HAVE_STD__U16STRING) || !defined(HAVE_STD__U32STRING) 
+#if defined(HAVE_STDINT_H)
+#include <stdint.h>
+#elif defined(HAVE_INTTYPES_H)
+#include <inttypes.h>
+#endif // defined(HAVE_INTTYPES_H)
+
+#ifndef HAVE_STD__U16STRING
+#ifndef HAVE_CHAR16_T
+typedef uint_least16_t char16_t;
+#endif // HAVE_CHAR16_T
+namespace std
+{
+  typedef basic_string<char16_t> u16string;
+}
+#endif // HAVE_STD__U16STRING
+
+#ifndef HAVE_STD__U32STRING
+#ifndef HAVE_CHAR32_T
+typedef uint_least32_t char32_t;
+#endif // HAVE_CHAR32_T
+namespace std
+{
+  typedef basic_string<char32_t> u32string;
+}
+#endif // HAVE_STD__U32STRING
+
+#endif // !defined(HAVE_STD__U16STRING) || !defined(HAVE_STD__U32STRING) 
+#endif // TARGET_WINDOWS


### PR DESCRIPTION
The main goal was removing "CStdString" from CharsetConverter so std::string can be used in XBMC for any strings that require conversion.
I think that CharsetConverter can be improved further, but current state is itself complete so this PR can be reviewed while I'm continue working on second part.
