### PR TITLE
Fix load of python module PIL egg.

### DIFF
--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -32,8 +32,9 @@ $(LIBDYLIB): $(PLATFORM)
 	cd $(PLATFORM); $(CROSSFLAGS) $(NATIVEPREFIX)/bin/python setup.py build -x bdist_egg --plat-name $(OS)-$(CPU)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	mkdir -p $(PREFIX)/lib/python2.6/site-packages
-	cp $(LIBDYLIB) $(PREFIX)/lib/python2.6/site-packages
+	mkdir -p $(PREFIX)/lib/python2.6/site-packages/PIL
+	unzip $(LIBDYLIB) -d $(PREFIX)/lib/python2.6/site-packages/PIL/
+	echo 'PIL' > $(PREFIX)/lib/python2.6/site-packages/PIL.pth
 	touch $@
 
 clean:

--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -29,7 +29,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 
 $(LIBDYLIB): $(PLATFORM)
 	mkdir -p $(PLATFORM)/output
-	cd $(PLATFORM); $(CROSSFLAGS) $(NATIVEPREFIX)/bin/python setup.py build -x bdist_egg --plat-name $(OS)-$(CPU) --exclude-source-files
+	cd $(PLATFORM); $(CROSSFLAGS) $(NATIVEPREFIX)/bin/python setup.py build -x bdist_egg --plat-name $(OS)-$(CPU)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	mkdir -p $(PREFIX)/lib/python2.6/site-packages


### PR DESCRIPTION
there are 2 problem to prevent the egg be loaded.
1. on darwin/win32, only pyo can be loaded by xbmc, pyc can not, but the egg was built to pyc without py source, so add the souce to egg fixes this.
2. the egg file is not in python's sys.path, so no one can load it without add the egg file into sys.path, I first fixed it by add a PIL.pth file in the site-packages dir which include the egg filename, but found the c runtime library can not be loaded from egg file, so we had to extract files inside the egg into the PIL subdir and put PIL subdir in to the PIL.pth file, just like the installed PIL in any system python site-packages dir does.
