### PR TITLE
[OSX] Kickout screensaver if it's running. Fix #14271

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1489,6 +1489,7 @@ void CWinSystemOSX::EnableSystemScreenSaver(bool bEnable)
       IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep,
         kIOPMAssertionLevelOn, reasonForActivity, &assertionID);
     }
+    UpdateSystemActivity(UsrActivity);
   }
   else if (assertionID != 0)
   {


### PR DESCRIPTION
 IOPMAssertionCreateWithName did work for prevent screensaver from kick in, but if the screensaver is already running, like in http://trac.xbmc.org/ticket/14271 it won't help, so we had to add an UpdateSystemActivity call to overcome it.
