### PR TITLE
Assert on settings misuse

### DIFF
--- a/xbmc/settings/SettingDependency.cpp
+++ b/xbmc/settings/SettingDependency.cpp
@@ -89,11 +89,6 @@ bool CSettingDependencyCondition::Check() const
         return false;
 
       const CSetting *setting = m_settingsManager->GetSetting(m_setting);
-      if (setting == NULL)
-      {
-        CLog::Log(LOGWARNING, "CSettingDependencyCondition: unable to check condition on unknown setting \"%s\"", m_setting.c_str());
-        return false;
-      }
 
       if (m_operator == SettingDependencyOperatorEquals)
         result = setting->Equals(m_value);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -94,8 +94,6 @@ bool AddonHasSettings(const std::string &condition, const std::string &value, co
     return false;
 
   CSettingAddon *setting = (CSettingAddon*)CSettings::Get().GetSetting(settingId);
-  if (setting == NULL)
-    return false;
 
   ADDON::AddonPtr addon;
   if (!ADDON::CAddonMgr::Get().GetAddon(setting->GetValue(), addon, setting->GetAddonType()) || addon == NULL)

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -243,7 +243,7 @@ bool CSettingsManager::LoadSetting(const TiXmlNode *node, const std::string &set
   if (node == NULL)
     return false;
 
-  CSetting *setting = GetSetting(settingId);
+  CSetting *setting = GetSetting(settingId, true);
   if (setting == NULL)
     return false;
 
@@ -416,7 +416,7 @@ void* CSettingsManager::GetSettingOptionsFiller(const CSetting *setting)
   return fillerIt->second.filler;
 }
 
-CSetting* CSettingsManager::GetSetting(const std::string &id) const
+CSetting* CSettingsManager::GetSetting(const std::string &id, bool allowNULL /*=false*/) const
 {
   CSingleLock lock(m_critical);
   if (id.empty())
@@ -426,10 +426,10 @@ CSetting* CSettingsManager::GetSetting(const std::string &id) const
   StringUtils::ToLower(settingId);
 
   SettingMap::const_iterator setting = m_settings.find(settingId);
+  assert(setting != m_settings.end() || allowNULL);
   if (setting != m_settings.end())
     return setting->second.setting;
 
-  CLog::Log(LOGDEBUG, "CSettingsManager: requested setting (%s) was not found.", id.c_str());
   return NULL;
 }
 
@@ -472,7 +472,7 @@ SettingDependencyMap CSettingsManager::GetDependencies(const CSetting *setting) 
 bool CSettingsManager::GetBool(const std::string &id) const
 {
   CSingleLock lock(m_critical);
-  CSetting *setting = GetSetting(id);
+  CSetting *setting = GetSetting(id, true);
   if (setting == NULL || setting->GetType() != SettingTypeBool)
   {
     // Backward compatibility (skins use this setting)
@@ -923,8 +923,6 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode *node, CSetting *setting, c
 void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, const CSettingDependency &dependency)
 {
   CSetting *setting = GetSetting(settingId);
-  if (setting == NULL)
-    return;
 
   switch (dependency.GetType())
   {

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -473,15 +473,12 @@ bool CSettingsManager::GetBool(const std::string &id) const
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id, true);
-  if (setting == NULL || setting->GetType() != SettingTypeBool)
-  {
     // Backward compatibility (skins use this setting)
     if (setting == NULL && StringUtils::EqualsNoCase(id.c_str(), "lookandfeel.enablemouse"))
       return GetBool("input.enablemouse");
 
-    return false;
-  }
-
+  assert(setting->GetType() == SettingTypeBool);
+  
   return ((CSettingBool*)setting)->GetValue();
 }
 
@@ -489,8 +486,7 @@ bool CSettingsManager::SetBool(const std::string &id, bool value)
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeBool)
-    return false;
+  assert(setting->GetType() == SettingTypeBool);
 
   return ((CSettingBool*)setting)->SetValue(value);
 }
@@ -499,8 +495,7 @@ bool CSettingsManager::ToggleBool(const std::string &id)
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeBool)
-    return false;
+  assert(setting->GetType() == SettingTypeBool);
 
   return SetBool(id, !((CSettingBool*)setting)->GetValue());
 }
@@ -509,8 +504,7 @@ int CSettingsManager::GetInt(const std::string &id) const
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeInteger)
-    return 0;
+  assert(setting->GetType() == SettingTypeInteger);
 
   return ((CSettingInt*)setting)->GetValue();
 }
@@ -519,8 +513,7 @@ bool CSettingsManager::SetInt(const std::string &id, int value)
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeInteger)
-    return false;
+  assert(setting->GetType() == SettingTypeInteger);
 
   return ((CSettingInt*)setting)->SetValue(value);
 }
@@ -529,8 +522,7 @@ double CSettingsManager::GetNumber(const std::string &id) const
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeNumber)
-    return 0.0;
+  assert(setting->GetType() == SettingTypeNumber);
 
   return ((CSettingNumber*)setting)->GetValue();
 }
@@ -539,8 +531,7 @@ bool CSettingsManager::SetNumber(const std::string &id, double value)
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeNumber)
-    return false;
+  assert(setting->GetType() == SettingTypeNumber);
 
   return ((CSettingNumber*)setting)->SetValue(value);
 }
@@ -549,8 +540,7 @@ std::string CSettingsManager::GetString(const std::string &id) const
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeString)
-    return "";
+  assert(setting->GetType() == SettingTypeString);
 
   return ((CSettingString*)setting)->GetValue();
 }
@@ -559,8 +549,7 @@ bool CSettingsManager::SetString(const std::string &id, const std::string &value
 {
   CSingleLock lock(m_critical);
   CSetting *setting = GetSetting(id);
-  if (setting == NULL || setting->GetType() != SettingTypeString)
-    return false;
+  assert(setting->GetType() == SettingTypeString);
 
   return ((CSettingString*)setting)->SetValue(value);
 }

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -245,7 +245,10 @@ bool CSettingsManager::LoadSetting(const TiXmlNode *node, const std::string &set
 
   CSetting *setting = GetSetting(settingId, true);
   if (setting == NULL)
+  {
+    CLog::Log(LOGDEBUG, "CSettingsManager: Settings %s already exists in map!", settingId.c_str());
     return false;
+  }
 
   return LoadSetting(node, setting);
 }

--- a/xbmc/settings/SettingsManager.h
+++ b/xbmc/settings/SettingsManager.h
@@ -212,9 +212,10 @@ public:
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier
+   \param allowNULL Don't assert if the requested setting isn't found
    \return Setting object with the given identifier or NULL if the identifier is unknown
    */
-  CSetting* GetSetting(const std::string &id) const;
+  CSetting* GetSetting(const std::string &id, bool allowNULL=false) const;
   /*!
    \brief Gets the setting section with the given identifier.
 


### PR DESCRIPTION
As discussed with @montellese in #3103, assert instead of failing gracefully (aka hiding a bug) when misusing settings.  Only real question is 42ab797, maybe this wasn't logged on purpose because it actually happens often?
