### PR TITLE
[rbp/omxplayer] Avoid loss of volume messages

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -97,6 +97,7 @@ COMXAudio::COMXAudio() :
   m_pCallback       (NULL   ),
   m_Initialized     (false  ),
   m_CurrentVolume   (0      ),
+  m_Mute            (false  ),
   m_drc             (0      ),
   m_Passthrough     (false  ),
   m_HWDecode        (false  ),
@@ -167,6 +168,7 @@ CAEChannelInfo COMXAudio::GetChannelLayout(AEAudioFormat format)
 
 bool COMXAudio::PortSettingsChanged()
 {
+  CSingleLock lock (m_critSection);
   OMX_ERRORTYPE omx_err   = OMX_ErrorNone;
 
   if (m_settings_changed)
@@ -184,6 +186,8 @@ bool COMXAudio::PortSettingsChanged()
 
   if(!m_omx_render.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
     return false;
+
+  ApplyVolume();
 
   if(!m_Passthrough)
   {
@@ -295,6 +299,7 @@ bool COMXAudio::PortSettingsChanged()
 
 bool COMXAudio::Initialize(AEAudioFormat format, std::string& device, OMXClock *clock, CDVDStreamInfo &hints, bool bUsePassthrough, bool bUseHWDecode)
 {
+  CSingleLock lock (m_critSection);
   OMX_ERRORTYPE omx_err;
 
   Deinitialize();
@@ -640,6 +645,7 @@ bool COMXAudio::Deinitialize()
 
 void COMXAudio::Flush()
 {
+  CSingleLock lock (m_critSection);
   if(!m_Initialized)
     return;
 
@@ -654,32 +660,39 @@ void COMXAudio::Flush()
 }
 
 //***********************************************************************************************
-long COMXAudio::GetCurrentVolume() const
+void COMXAudio::SetDynamicRangeCompression(long drc)
 {
-  return m_CurrentVolume;
 }
 
 //***********************************************************************************************
-void COMXAudio::Mute(bool bMute)
+void COMXAudio::SetMute(bool bMute)
 {
-  if(!m_Initialized)
-    return;
-
-  if (bMute)
-    SetCurrentVolume(VOLUME_MINIMUM);
-  else
-    SetCurrentVolume(m_CurrentVolume);
+  CSingleLock lock (m_critSection);
+  m_Mute = bMute;
+  if (m_settings_changed)
+    ApplyVolume();
 }
 
 //***********************************************************************************************
-bool COMXAudio::SetCurrentVolume(float fVolume)
+void COMXAudio::SetVolume(float fVolume)
+{
+  CSingleLock lock (m_critSection);
+  m_CurrentVolume = fVolume;
+  if (m_settings_changed)
+    ApplyVolume();
+}
+
+//***********************************************************************************************
+bool COMXAudio::ApplyVolume(void)
 {
   CSingleLock lock (m_critSection);
 
-  if(!m_Initialized || m_Passthrough)
+  if (!m_Initialized || m_Passthrough)
     return false;
+
+  float fVolume = m_Mute ? VOLUME_MINIMUM : m_CurrentVolume;
+
   double gain = pow(10, (g_advancedSettings.m_ac3Gain - 12.0f) / 20.0);
-  m_CurrentVolume = fVolume;
 
   if (m_format.m_channelLayout.Count() > 2)
   {
@@ -745,7 +758,8 @@ bool COMXAudio::SetCurrentVolume(float fVolume)
                 CLASSNAME, __func__, omx_err);
       return false;
     }
-  }  
+  }
+  CLog::Log(LOGINFO, "%s::%s - Volume=%.2f\n", CLASSNAME, __func__, fVolume);
   return true;
 }
 

--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -69,10 +69,10 @@ public:
   unsigned int GetSpace();
   bool Deinitialize();
 
-  long GetCurrentVolume() const;
-  void Mute(bool bMute);
-  bool SetCurrentVolume(float fVolume);
-  void SetDynamicRangeCompression(long drc) { m_drc = drc; }
+  void SetVolume(float nVolume);
+  void SetMute(bool bOnOff);
+  void SetDynamicRangeCompression(long drc);
+  bool ApplyVolume();
   int SetPlaySpeed(int iSpeed);
   void SubmitEOS();
   bool IsEOS();
@@ -100,6 +100,7 @@ private:
   IAudioCallback* m_pCallback;
   bool          m_Initialized;
   float         m_CurrentVolume;
+  bool          m_Mute;
   long          m_drc;
   bool          m_Passthrough;
   bool          m_HWDecode;

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -506,9 +506,6 @@ bool COMXPlayer::OpenFile(const CFileItem &file, const CPlayerOptions &options)
     m_State.Clear();
     m_UpdateApplication = 0;
     m_offset_pts        = 0;
-    m_current_volume    = 0;
-    m_current_mute      = false;
-    m_change_volume     = true;
 
     m_PlayerOptions = options;
     m_item              = file;
@@ -1429,12 +1426,6 @@ void COMXPlayer::Process()
     if (IsBetterStream(m_CurrentVideo,    pStream)) OpenVideoStream   (pStream->iId, pStream->source);
     if (IsBetterStream(m_CurrentSubtitle, pStream)) OpenSubtitleStream(pStream->iId, pStream->source);
     if (IsBetterStream(m_CurrentTeletext, pStream)) OpenTeletextStream(pStream->iId, pStream->source);
-
-    if(m_change_volume && m_CurrentAudio.started)
-    {
-      if(m_omxPlayerAudio.SetCurrentVolume(m_current_mute ? VOLUME_MINIMUM : m_current_volume))
-        m_change_volume = false;
-    }
 
     // process the packet
     ProcessPacket(pStream, pPacket);
@@ -4445,18 +4436,6 @@ bool COMXPlayer::CachePVRStream(void) const
   return m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) &&
       !g_PVRManager.IsPlayingRecording() &&
       g_advancedSettings.m_bPVRCacheInDvdPlayer;
-}
-
-void COMXPlayer::SetMute(bool bOnOff)
-{
-  m_current_mute = bOnOff;
-  m_change_volume = true;
-}
-
-void COMXPlayer::SetVolume(float fVolume)
-{
-  m_current_volume = fVolume;
-  m_change_volume = true;
 }
 
 void COMXPlayer::GetRenderFeatures(std::vector<int> &renderFeatures)

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -185,10 +185,10 @@ public:
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) { m_omxPlayerAudio.RegisterAudioCallback(pCallback); }
   virtual void UnRegisterAudioCallback()                        { m_omxPlayerAudio.UnRegisterAudioCallback(); }
-  virtual void SetVolume(float nVolume);
-  virtual void SetMute(bool bOnOff);
+  virtual void SetVolume(float nVolume)                         { m_omxPlayerAudio.SetVolume(nVolume); }
+  virtual void SetMute(bool bOnOff)                             { m_omxPlayerAudio.SetMute(bOnOff); }
+  virtual void SetDynamicRangeCompression(long drc)             { m_omxPlayerAudio.SetDynamicRangeCompression(drc); }
   virtual bool ControlsVolume() {return true;}
-  virtual void SetDynamicRangeCompression(long drc)              {}
   virtual void GetAudioInfo(CStdString &strAudioInfo);
   virtual void GetVideoInfo(CStdString &strVideoInfo);
   virtual void GetGeneralInfo(CStdString &strVideoInfo);
@@ -375,9 +375,7 @@ protected:
   CDVDClock m_clock;                // master clock
   OMXClock m_av_clock;
 
-  float m_current_volume;
-  bool m_current_mute;
-  bool m_change_volume;
+  bool m_stepped;
 
   CDVDOverlayContainer m_overlayContainer;
 

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -652,21 +652,6 @@ void OMXPlayerAudio::WaitCompletion()
   }
 }
 
-void OMXPlayerAudio::RegisterAudioCallback(IAudioCallback *pCallback)
-{
-  m_omxAudio.RegisterAudioCallback(pCallback);
-}
-
-void OMXPlayerAudio::UnRegisterAudioCallback()
-{
-  m_omxAudio.UnRegisterAudioCallback();
-}
-
-bool OMXPlayerAudio::SetCurrentVolume(float fVolume)
-{
-  return m_omxAudio.SetCurrentVolume(fVolume);
-}
-
 void OMXPlayerAudio::SetSpeed(int speed)
 {
   if(m_messageQueue.IsInited())

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -106,9 +106,12 @@ public:
   double GetCurrentPts() { return m_audioClock; };
   void WaitCompletion();
   void SubmitEOS();
-  void  RegisterAudioCallback(IAudioCallback* pCallback);
-  void  UnRegisterAudioCallback();
-  bool SetCurrentVolume(float fVolume);
+
+  void  RegisterAudioCallback(IAudioCallback* pCallback) { m_omxAudio.RegisterAudioCallback(pCallback); }
+  void  UnRegisterAudioCallback()                        { m_omxAudio.UnRegisterAudioCallback(); }
+  void SetVolume(float fVolume)                          { m_omxAudio.SetVolume(fVolume); }
+  void SetMute(bool bOnOff)                              { m_omxAudio.SetMute(bOnOff); }
+  void SetDynamicRangeCompression(long drc)              { m_omxAudio.SetDynamicRangeCompression(drc); }
   void SetSpeed(int iSpeed);
   int  GetAudioBitrate();
   std::string GetPlayerInfo();


### PR DESCRIPTION
There seems to be a race condition where the volume request arrives as the omx audio pipeline is being created.
Restructure the volume messages to apply the initial volume as pipeline is being created, and add missing locks.
This also reduces the differences between OMXPlayer and DVDPlayer
