### PR TITLE
FIX: implement libcurl openssl thread-safe locking

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1106,6 +1106,11 @@ AC_CHECK_HEADER([FLAC/stream_decoder.h],, AC_MSG_ERROR($missing_library))
 # we need to check for the header because if it exists we set the openssl
 # and gcrypt MT callback hooks. This is mostly so that libcurl operates 
 # in MT manner correctly.
+AC_MSG_CHECKING([for CRYPTO_set_locking_callback(0)])
+AC_TRY_LINK([],[CRYPTO_set_locking_callback(0);],
+                [have_curl_static=yes],
+                [have_curl_static=no])
+AC_MSG_RESULT($have_curl_static)
 AC_CHECK_HEADER([openssl/crypto.h], AC_DEFINE([HAVE_OPENSSL],[1],[Define if we have openssl]),)
 AC_CHECK_HEADER([gcrypt.h], gcrypt_headers_available=yes,gcrypt_headers_available=no)
 if test "$gcrypt_headers_available" = "yes"; then
@@ -1516,6 +1521,11 @@ if test "x$use_ssh" = "xno"; then
 else
   AC_CHECK_LIB([ssh], [sftp_tell64],, AC_MSG_ERROR($ssh_not_found))
   AC_DEFINE([HAVE_LIBSSH], [1], [Whether to use libSSH library.])
+fi
+
+# libcurl
+if test "x$have_curl_static" = "xyes"; then
+  AC_DEFINE([HAS_CURL_STATIC], [1], [Whether OpenSSL inside libcurl is static.])
 fi
 
 # libRTMP

--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -79,6 +79,10 @@ namespace XCURL
     DEFINE_METHOD2(struct curl_slist*, slist_append, (struct curl_slist * p1, const char * p2))
     DEFINE_METHOD1(void, slist_free_all, (struct curl_slist * p1))
     DEFINE_METHOD1(const char *, easy_strerror, (CURLcode p1))
+#if defined(HAS_CURL_STATIC)
+    DEFINE_METHOD1(void, crypto_set_id_callback, (unsigned long (*p1)(void)))
+    DEFINE_METHOD1(void, crypto_set_locking_callback, (void (*p1)(int, int, const char *, int)))
+#endif
     BEGIN_METHOD_RESOLVE()
       RESOLVE_METHOD_RENAME(curl_global_init, global_init)
       RESOLVE_METHOD_RENAME(curl_global_cleanup, global_cleanup)
@@ -101,6 +105,10 @@ namespace XCURL
       RESOLVE_METHOD_RENAME(curl_multi_cleanup, multi_cleanup)
       RESOLVE_METHOD_RENAME(curl_slist_append, slist_append)
       RESOLVE_METHOD_RENAME(curl_slist_free_all, slist_free_all)
+#if defined(HAS_CURL_STATIC)
+      RESOLVE_METHOD_RENAME(CRYPTO_set_id_callback, crypto_set_id_callback)
+      RESOLVE_METHOD_RENAME(CRYPTO_set_locking_callback, crypto_set_locking_callback)
+#endif
     END_METHOD_RESOLVE()
 
   };


### PR DESCRIPTION
When libcurl is linked with openssl, SSL connections are not thread-safe.
E.g. using the "cheezburger" picture addon (which uses ssl) leads to crashes in libcurl/openssl on droid.
GnuTls is not a problem, apparently.

This patch implements the necessary callbacks to make libcurl with openssl connections thread-safe (see http://curl.haxx.se/libcurl/c/opensslthreadlock.html for reference).

Problem:
This patch is made for droid, where openssl is statically linked into libcurl (and even then, the HAVE_OPENSSL's are probably wrong, as it doesn't tell us with which ssl library curl is linked).
I don't know about the other potential platforms (ios? osx?)
