### PR TITLE
GUIWindowSystemInfo optimization

### DIFF
--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -56,7 +56,6 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       CGUIWindow::OnMessage(message);
-      ResetLabels();
       SET_CONTROL_LABEL(52, "XBMC " + g_infoManager.GetLabel(SYSTEM_BUILD_VERSION) +
                             " (Compiled: " + g_infoManager.GetLabel(SYSTEM_BUILD_DATE)+")");
       CONTROL_ENABLE_ON_CONDITION(CONTROL_BT_PVR,
@@ -68,7 +67,6 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
     {
       CGUIWindow::OnMessage(message);
       m_diskUsage.clear();
-      ResetLabels();
       return true;
     }
     break;
@@ -76,8 +74,11 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
     {
       CGUIWindow::OnMessage(message);
       int focusedControl = GetFocusedControlID();
-      if (focusedControl >= CONTROL_START && focusedControl <= CONTROL_END)
+      if (m_section != focusedControl && focusedControl >= CONTROL_START && focusedControl <= CONTROL_END)
+      {
+        ResetLabels();
         m_section = focusedControl;
+      }
       return true;
     }
     break;
@@ -87,7 +88,6 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
 
 void CGUIWindowSystemInfo::FrameMove()
 {
-  ResetLabels();
   int i = 2;
   if (m_section == CONTROL_BT_DEFAULT)
   {


### PR DESCRIPTION
for best results, this depend on #3114, GUILabelControl optimization.
with this, and VSING = always, finally i see 'system info' on my RPI working on 50-60%CPU and on 700MHz. my low powered laptop with windows version definitely relaxes too. I didn't dig why this lowers fps in this combination, but i am happy for now.

NOTE: although this will make a lot of users happy, it only optimizes this window, not entire GUI. 

if i found more free time, i will continue with this initiative. any help will be greatly appreciated.
