### PR TITLE
[OverlayRenderGL] Fix corrupt pixels in graphical subs

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
@@ -56,12 +56,18 @@ static void LoadTexture(GLenum target
                       , GLfloat* u, GLfloat* v
                       , GLenum internalFormat, GLenum externalFormat, const GLvoid* pixels)
 {
-  int width2  = NP2(width);
-  int height2 = NP2(height);
+  int width2  = width;
+  int height2 = height;
   char *pixelVector = NULL;
   const GLvoid *pixelData = pixels;
 
   int bytesPerPixel = glFormatElementByteCount(externalFormat);
+
+  if (!g_Windowing.SupportsNPOT(0))
+  {
+    width2  = NP2(width);
+    height2 = NP2(height);
+  }
 
 #ifdef HAS_GLES
   /** OpenGL ES does not support strided texture input. Make a copy without stride **/


### PR DESCRIPTION
On Pi you can see a corrupt line of pixels on bottom and right edges of subtitle bounding box.
This is due to using a subregion of a texture (due to the power of two rounding) and not ensuring
the texture coordinates are inside the valid pixels.

The easy solution is to use NPOT when available (always on GLES) and then the clamping works
(as well as saving memory).
