### PR TITLE
PVR: Fix stopping when station timeline is open and user presses stop

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -148,8 +148,10 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction &action)
 CPVRChannelGroupPtr CGUIDialogPVRChannelsOSD::GetPlayingGroup()
 {
   CPVRChannelPtr channel;
-  g_PVRManager.GetCurrentChannel(channel);
-  return g_PVRManager.GetPlayingGroup(channel->IsRadio());
+  if(g_PVRManager.GetCurrentChannel(channel))
+    return g_PVRManager.GetPlayingGroup(channel->IsRadio());
+  else
+    return CPVRChannelGroupPtr();
 }
 
 void CGUIDialogPVRChannelsOSD::Update()
@@ -190,7 +192,8 @@ void CGUIDialogPVRChannelsOSD::SaveControlStates()
   CGUIDialog::SaveControlStates();
 
   CPVRChannelGroupPtr group = GetPlayingGroup();
-  SaveSelectedItem(group->GroupID());
+  if(group)
+    SaveSelectedItem(group->GroupID());
 }
 
 void CGUIDialogPVRChannelsOSD::RestoreControlStates()


### PR DESCRIPTION
If you watch a channel in fullscreen and press this TV icon in the osd (station timeline or something), you will see the station timeline. If you now press "stop" or "x" xbmc will segfault.

I debugged it to the GetPlayingGroup(channel) not being checked to false, so afterwards the GetPlayingGroup gets wrong. In the sequence another pointer was not checked for being null.

@opdenkamp: I don't really understand the codeflow of PVR - so feel free to close and fix it otherwise
