### PR TITLE
Display retry dialog in case a file to be played cannot be found

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -14372,3 +14372,9 @@ msgstr ""
 msgctxt "#37015"
 msgid "Browse Into"
 msgstr ""
+
+#: xbmc/Windows/GUIWindowVideoNav.cpp
+msgctxt "#37016"
+msgid "Retry"
+msgstr ""
+

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -67,14 +67,15 @@ void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
     SET_CONTROL_LABEL_THREAD_SAFE(1, m_strHeading);
 }
 
-void CGUIDialogBoxBase::SetLine(int iLine, const CVariant& line)
+void CGUIDialogBoxBase::SetLine(int iLine, const CVariant& line, bool scrolling/* = false*/)
 {
   if (iLine < 0 || iLine >= DIALOG_MAX_LINES)
     return;
 
   m_strLines[iLine] = GetLocalized(line);
+  m_lineScrolling[iLine] = scrolling;
   if (IsActive())
-    SET_CONTROL_LABEL_THREAD_SAFE(CONTROL_LINES_START + iLine, m_strLines[iLine]);
+    SET_CONTROL_LABEL_AND_SCROLLING_THREAD_SAFE(CONTROL_LINES_START + iLine, m_strLines[iLine], scrolling);
 }
 
 void CGUIDialogBoxBase::SetChoice(int iButton, const CVariant &choice) // iButton == 0 for no, 1 for yes
@@ -94,8 +95,8 @@ void CGUIDialogBoxBase::OnInitWindow()
 
   // set control labels
   SET_CONTROL_LABEL(CONTROL_HEADING, !m_strHeading.empty() ? m_strHeading : GetDefaultLabel(CONTROL_HEADING));
-  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i)
-    SET_CONTROL_LABEL(CONTROL_LINES_START + i, !m_strLines[i].empty() ? m_strLines[i] : GetDefaultLabel(CONTROL_LINES_START + i));
+  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i) 
+    SET_CONTROL_LABEL_AND_SCROLLING(CONTROL_LINES_START + i, !m_strLines[i].empty() ? m_strLines[i] : GetDefaultLabel(CONTROL_LINES_START + i), m_lineScrolling[i]);
   for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
     SET_CONTROL_LABEL(CONTROL_CHOICES_START + i, !m_strChoices[i].empty() ? m_strChoices[i] : GetDefaultLabel(CONTROL_CHOICES_START + i));
 
@@ -106,8 +107,10 @@ void CGUIDialogBoxBase::OnDeinitWindow(int nextWindowID)
 {
   // make sure we set default labels for heading, lines and choices
   SetHeading(m_strHeading = "");
-  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i)
+  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i) {
     SetLine(i, m_strLines[i] = "");
+    m_lineScrolling[i] = false;
+  }
   for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
     SetChoice(i, m_strChoices[i] = "");
 

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -34,7 +34,7 @@ public:
   virtual ~CGUIDialogBoxBase(void);
   virtual bool OnMessage(CGUIMessage& message);
   bool IsConfirmed() const;
-  void SetLine(int iLine, const CVariant &line);
+  void SetLine(int iLine, const CVariant &line, bool scrolling = false);
   void SetHeading(const CVariant &heading);
   void SetChoice(int iButton, const CVariant &choice);
 protected:
@@ -55,5 +55,6 @@ protected:
   // actual strings
   std::string m_strHeading;
   std::string m_strLines[DIALOG_MAX_LINES];
+  bool m_lineScrolling[DIALOG_MAX_LINES];
   std::string m_strChoices[DIALOG_MAX_CHOICES];
 };

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -261,7 +261,12 @@ bool CGUILabelControl::OnMessage(CGUIMessage& message)
     {
       SetLabel(message.GetLabel());
       return true;
-    }
+    } else if (message.GetMessage() == GUI_MSG_LABEL_SCROLL) 
+	  {
+	    if (m_label.SetScrolling(message.GetParam1() > 0)) { 
+	      MarkDirtyRegion(); 
+	    }
+	  }
   }
 
   return CGUIControl::OnMessage(message);

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -133,6 +133,12 @@
 
 #define GUI_MSG_WINDOW_LOAD 43
 
+/*!
+  \brief Set the scrolling property of a label
+  \arg param1 contains the boolean value if the label should scroll or not
+*/
+#define GUI_MSG_LABEL_SCROLL 44
+
 #define GUI_MSG_USER         1000
 
 /*!
@@ -213,6 +219,21 @@ do { \
  \ingroup winmsg
  \brief Set the label of the current control
  */
+#define SET_CONTROL_LABEL_AND_SCROLLING(controlID,label,scrolling) \
+do { \
+ CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), controlID); \
+ msg.SetLabel(label); \
+ OnMessage(msg); \
+ CGUIMessage scrollMsg(GUI_MSG_LABEL_SCROLL, GetID(), controlID); \
+ scrollMsg.SetParam1(scrolling ? 1 : 0); \
+ OnMessage(scrollMsg); \
+} while(0)
+
+
+/*!
+ \ingroup winmsg
+ \brief Set the label of the current control
+ */
 #define SET_CONTROL_LABEL_THREAD_SAFE(controlID,label) \
 { \
  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), controlID); \
@@ -221,6 +242,26 @@ do { \
    OnMessage(msg); \
  else \
    g_windowManager.SendThreadMessage(msg, GetID()); \
+}
+
+
+/*!
+ \ingroup winmsg
+ \brief Set the label of the current control
+ */
+#define SET_CONTROL_LABEL_AND_SCROLLING_THREAD_SAFE(controlID,label,scrolling) \
+{ \
+ CGUIMessage labelMsg(GUI_MSG_LABEL_SET, GetID(), controlID); \
+ labelMsg.SetLabel(label); \
+ CGUIMessage scrollMsg(GUI_MSG_LABEL_SCROLL, GetID(), controlID); \
+ scrollMsg.SetParam1(scrolling ? 1 : 0); \
+ if(g_application.IsCurrentThread()) { \
+   OnMessage(labelMsg); \
+   OnMessage(scrollMsg); \
+ } else { \
+   g_windowManager.SendThreadMessage(labelMsg, GetID()); \
+   g_windowManager.SendThreadMessage(scrollMsg, GetID()); \
+ } \
 }
 
 /*!

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -80,5 +80,7 @@ protected:
   bool GetItemsForTag(const CStdString &strHeading, const std::string &type, CFileItemList &items, int idTag = -1, bool showAll = true);
   static CStdString GetLocalizedType(const std::string &strType);
 
+  bool RetryItem(const CFileItemPtr& pItem, const int iItem);
+
   VECSOURCES m_shares;
 };


### PR DESCRIPTION
I have this problem of network access and external drives which can lead to files from the playlist being not found.
Currently xbmc does not tell me the path of the file in question but allows me to remove the item from the db.
I changed that to first show a "Retry" dialog, that displays the filepath in a scrolling label. If the user decides to cancel the retry logic, the old flow (asking the user to remove the item) continues but also shows the filepath in a scrolling label.

For the retry dialog I added English, German and Russian texts.
