### PR TITLE
GUIListLabel optimization

### DIFF
--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -92,9 +92,9 @@ bool CGUILabel::Process(unsigned int currentTime)
   bool renderSolid = (m_color == COLOR_DISABLED);
 
   if (overFlows && m_scrolling && !renderSolid)
-    m_textLayout.UpdateScrollinfo(m_scrollInfo);
+    return m_textLayout.UpdateScrollinfo(m_scrollInfo);
 
-  return (overFlows && m_scrolling);
+  return false;
 }
 
 void CGUILabel::Render()


### PR DESCRIPTION
this handles high CPU usage in recently added movies ( and i hope tv, can't test as i don't have such ).
actual problem here:
CGUILabel::Process return true if it CAN scroll, not if it MUST AND WILL scroll. possible fix will be adding bool bScroll param to it, which, if false, will bypass entire function. directly affected controls from this fix will be: GUICheckMarkControl; GUIEditControl; GUILabelControl; GUIListLabel and GUISelectButtonControl. however for now i prefer this local fix, as general one is more complicated and will have more troubles to pass code review here. if i identify bottleneck in another affected control, i will proceed with it.

if is intentionally split in 2 lines because this way it shows more clearly what is intend. please, do not ask me to move in one line, i prefer this way.

@MartijnKaijser, as requested, yet another one ;)
thanks to @popcornmix for pointing me here.
