### PR TITLE
Remove APT support from versioncheck script.

### DIFF
--- a/addons/service.xbmc.versioncheck/addon.xml
+++ b/addons/service.xbmc.versioncheck/addon.xml
@@ -14,7 +14,7 @@
         <description lang="en">XBMC Version Check only supports a number of platforms/distros as releases may differ between them. For more information visit the xbmc.org website.</description>
         <disclaimer lang="en">Feel free to use this script. For information visit xbmc.org</disclaimer>
         <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
-        <platform>osx osx32 osx64 ios windx wingl linux</platform>
+        <platform>osx osx32 osx64 ios windx wingl</platform>
         <website>http://xbmc.org</website>
         <source>https://github.com/XBMC-Addons/service.xbmc.versioncheck</source>
         <forum>http://forum.xbmc.org/showthread.php?tid=160228</forum>

--- a/addons/service.xbmc.versioncheck/changelog.txt
+++ b/addons/service.xbmc.versioncheck/changelog.txt
@@ -1,3 +1,7 @@
+v0.1.3
+- Remove notification for Ubuntu users checking through apt. The python
+aptdaemon module is unusably broken in our subinterpreter environment.
+
 v0.1.2
 - Add notification for Ubuntu users checking through apt command
 

--- a/addons/service.xbmc.versioncheck/resources/language/English/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/English/strings.po
@@ -56,10 +56,6 @@ msgctxt "#32010"
 msgid "You can enable/disable it through addon settings."
 msgstr ""
 
-msgctxt "#32011"
-msgid "Use your package manager(apt) to upgrade."
-msgstr ""
-
 msgctxt "#32020"
 msgid "General"
 msgstr ""


### PR DESCRIPTION
This is to combat the hang on exit caused by versioncheck under linux.
As jcarroll discovered, the aptdaemon module is broken in our
sub-interpreter environment. Technical details at:

http://docs.python.org/2/c-api/init.html#bugs-and-caveats (second
paragraph)
