### PR TITLE
Add useCache option to python ControlImage.setImage function

### DIFF
--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -35,7 +35,7 @@
 class CImageLoader : public CJob
 {
 public:
-  CImageLoader(const CStdString &path);
+  CImageLoader(const CStdString &path, const bool useCache);
   virtual ~CImageLoader();
 
   /*!
@@ -43,6 +43,7 @@ public:
    */
   virtual bool DoWork();
 
+  bool          m_use_cache; ///< Whether or not to use any caching with this image
   CStdString    m_path; ///< path of image to load
   CBaseTexture *m_texture; ///< Texture object to load the image into \sa CBaseTexture.
 };
@@ -85,7 +86,7 @@ public:
    \return true if the image exists, else false.
    \sa CGUITextureArray and CGUITexture
    */
-  bool GetImage(const CStdString &path, CTextureArray &texture, bool firstRequest);
+  bool GetImage(const CStdString &path, CTextureArray &texture, bool firstRequest, bool useCache = true);
 
   /*!
    \brief Request a texture to be unloaded.
@@ -135,7 +136,7 @@ private:
     unsigned int m_timeToDelete;
   };
 
-  void QueueImage(const CStdString &path);
+  void QueueImage(const CStdString &path, bool useCache = true);
 
   std::vector< std::pair<unsigned int, CLargeTexture *> > m_queued;
   std::vector<CLargeTexture *> m_allocated;

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -310,10 +310,13 @@ void CGUIImage::SetCrossFade(unsigned int time)
     m_crossFadeTime = 1;
 }
 
-void CGUIImage::SetFileName(const CStdString& strFileName, bool setConstant)
+void CGUIImage::SetFileName(const CStdString& strFileName, bool setConstant, const bool useCache)
 {
   if (setConstant)
     m_info.SetLabel(strFileName, "", GetParentID());
+
+  // Set whether or not to use cache
+  m_texture.SetUseCache(useCache);
 
   if (m_crossFadeTime)
   {

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -84,7 +84,7 @@ public:
   virtual void UpdateInfo(const CGUIListItem *item = NULL);
 
   virtual void SetInfo(const CGUIInfoLabel &info);
-  virtual void SetFileName(const CStdString& strFileName, bool setConstant = false);
+  virtual void SetFileName(const CStdString& strFileName, bool setConstant = false, const bool useCache = true);
   virtual void SetAspectRatio(const CAspectRatio &aspect);
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -47,7 +47,6 @@ CTextureInfo& CTextureInfo::operator=(const CTextureInfo &right)
   filename = right.filename;
   useLarge = right.useLarge;
   diffuseColor = right.diffuseColor;
-
   return *this;
 }
 
@@ -83,6 +82,7 @@ CGUITextureBase::CGUITextureBase(float posX, float posY, float width, float heig
   m_allocateDynamically = false;
   m_isAllocated = NO;
   m_invalid = true;
+  m_use_cache = true;
 }
 
 CGUITextureBase::CGUITextureBase(const CGUITextureBase &right) :
@@ -99,6 +99,7 @@ CGUITextureBase::CGUITextureBase(const CGUITextureBase &right) :
   m_diffuseColor = right.m_diffuseColor;
 
   m_allocateDynamically = right.m_allocateDynamically;
+  m_use_cache = right.m_use_cache;
 
   // defaults
   m_vertex.SetRect(m_posX, m_posY, m_posX + m_width, m_posY + m_height);
@@ -317,7 +318,7 @@ bool CGUITextureBase::AllocResources()
     if (m_isAllocated != NORMAL)
     { // use our large image background loader
       CTextureArray texture;
-      if (g_largeTextureManager.GetImage(m_info.filename, texture, !IsAllocated()))
+      if (g_largeTextureManager.GetImage(m_info.filename, texture, !IsAllocated(), m_use_cache))
       {
         m_isAllocated = LARGE;
 
@@ -654,6 +655,11 @@ bool CGUITextureBase::SetFileName(const CStdString& filename)
   m_info.filename = filename;
   // Don't allocate resources here as this is done at render time
   return true;
+}
+
+void CGUITextureBase::SetUseCache(const bool useCache)
+{
+  m_use_cache = useCache;
 }
 
 int CGUITextureBase::GetOrientation() const

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -104,6 +104,7 @@ public:
   bool SetWidth(float width);
   bool SetHeight(float height);
   bool SetFileName(const CStdString &filename);
+  void SetUseCache(const bool useCache = true);
   bool SetAspectRatio(const CAspectRatio &aspect);
 
   const CStdString& GetFileName() const { return m_info.filename; };
@@ -146,7 +147,7 @@ protected:
 
   CRect m_vertex;       // vertex coords to render
   bool m_invalid;       // if true, we need to recalculate
-
+  bool m_use_cache;
   unsigned char m_alpha;
 
   float m_frameWidth, m_frameHeight;          // size in pixels of the actual frame within the texture

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -417,13 +417,13 @@ namespace XBMCAddon
         sscanf(_colorDiffuse, "%x", &colorDiffuse);
     }
 
-    void ControlImage::setImage(const char* imageFilename) throw (UnimplementedException)
+    void ControlImage::setImage(const char* imageFilename, const bool useCache) throw (UnimplementedException)
     {
       strFileName = imageFilename;
 
       LOCKGUI;
       if (pGUIControl)
-        ((CGUIImage*)pGUIControl)->SetFileName(strFileName);
+        ((CGUIImage*)pGUIControl)->SetFileName(strFileName, false, useCache);
     }
 
     void ControlImage::setColorDiffuse(const char* cColorDiffuse) throw (UnimplementedException)

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -950,14 +950,15 @@ namespace XBMCAddon
                    const char* colorDiffuse = NULL);
 
       /**
-       * setImage(filename) -- Changes the image.
+       * setImage(filename, useCache) -- Changes the image.
        * 
        * filename       : string - image filename.
+       * useCache       : [opt] bool - true/use cache, false/don't use cache
        * 
        * example:
        *   - self.image.setImage('special://home/scripts/test.png')
        */
-      virtual void setImage(const char* imageFilename) throw (UnimplementedException);
+      virtual void setImage(const char* imageFilename, const bool useCache = true) throw (UnimplementedException);
 
       /**
        * setColorDiffuse(colorDiffuse) -- Changes the images color.


### PR DESCRIPTION
Using the current official slideshow screensaver addon, it seems that sometimes the slideshow pictures are cached - at low quality - in the texture cache.  I've gone ahead and added a useCache option to the setImage function for images.  The default is true (which means all current plugins work exactly the same), but if you set it to false, the texture cache will be completely bypassed when loading the picture.

If you apply this patch, and then change the following line in the slideshow addon, XBMC will no longer try to cache the pictures.

``` python
-                cur_img.setImage(img[0])
+                cur_img.setImage(img[0], False)
```

Most of the work is passing the useCache option from the python interpreter to the code that actually loads the image.

Also, I'm not sure if it's intended, but only one of the two different image loading paths (LargeImage) is caching textures.  It seems that regular Images are already bypassing the texture cache.
