### PR TITLE
ActiveAE: fix crackling sound for WASAPI

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -796,6 +796,7 @@ void CActiveAE::Process()
 void CActiveAE::Configure(AEAudioFormat *desiredFmt)
 {
   bool initSink = false;
+
   AEAudioFormat sinkInputFormat, inputFormat;
   m_mode = MODE_PCM;
 
@@ -829,7 +830,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
   std::string device = AE_IS_RAW(m_sinkRequestFormat.m_dataFormat) ? m_settings.passthoughdevice : m_settings.device;
   std::string driver;
   CAESinkFactory::ParseDevice(device, driver);
-  if (!m_sink.IsCompatible(m_sinkRequestFormat, device) || m_settings.driver.compare(driver) != 0)
+  if (!IsSinkCompatible(m_sinkRequestFormat, device) || m_settings.driver.compare(driver) != 0)
   {
     if (!InitSink())
       return;
@@ -1015,7 +1016,8 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
   }
 
   // resample buffers for sink
-  if (m_sinkBuffers && !m_sink.IsCompatible(m_sinkBuffers->m_format, device))
+  if (m_sinkBuffers && 
+     (!CompareFormat(m_sinkBuffers->m_format,m_sinkFormat) || !CompareFormat(m_sinkBuffers->m_inputFormat, sinkInputFormat)))
   {
     m_discardBufferPools.push_back(m_sinkBuffers);
     m_sinkBuffers = NULL;
@@ -1292,7 +1294,7 @@ bool CActiveAE::NeedReconfigureSink()
   if (m_settings.driver.compare(driver) != 0)
     return true;
 
-  if (!m_sink.IsCompatible(newFormat, device))
+  if (!IsSinkCompatible(newFormat, device))
     return true;
 
   return false;
@@ -1303,6 +1305,8 @@ bool CActiveAE::InitSink()
   SinkConfig config;
   config.format = m_sinkRequestFormat;
   config.stats = &m_stats;
+  config.device = AE_IS_RAW(m_sinkRequestFormat.m_dataFormat) ? &m_settings.passthoughdevice :
+                                                                &m_settings.device;
 
   // send message to sink
   Message *reply;
@@ -1363,6 +1367,40 @@ void CActiveAE::DrainSink()
     m_extError = true;
     return;
   }
+}
+
+bool CActiveAE::IsSinkCompatible(const AEAudioFormat format, const std::string &device)
+{
+  bool compatible = false;
+  SinkConfig config;
+  config.format = format;
+  config.device = &device;
+
+  // send message to sink
+  Message *reply;
+  if (m_sink.m_controlPort.SendOutMessageSync(CSinkControlProtocol::ISCOMPATIBLE,
+                                                 &reply,
+                                                 1000,
+                                                 &config, sizeof(config)))
+  {
+    bool success = reply->signal == CSinkControlProtocol::ACC ? true : false;
+    if (!success)
+    {
+      reply->Release();
+      CLog::Log(LOGERROR, "ActiveAE::%s - returned error", __FUNCTION__);
+      m_extError = true;
+      return false;
+    }
+    compatible = *(bool*)reply->data;
+    reply->Release();
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "ActiveAE::%s - failed to query compatibility", __FUNCTION__);
+    m_extError = true;
+    return false;
+  }
+  return compatible;
 }
 
 void CActiveAE::UnconfigureSink()
@@ -2039,6 +2077,17 @@ void CActiveAE::FreeSoundSample(uint8_t **data)
 {
   m_dllAvUtil.av_freep(data);
   delete [] data;
+}
+
+bool CActiveAE::CompareFormat(AEAudioFormat &lhs, AEAudioFormat &rhs)
+{
+  if (lhs.m_channelLayout != rhs.m_channelLayout ||
+      lhs.m_dataFormat != rhs.m_dataFormat ||
+      lhs.m_sampleRate != rhs.m_sampleRate ||
+      lhs.m_frames != rhs.m_frames)
+    return false;
+  else
+    return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2144,6 +2144,7 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
         {
           int samples = fileSize / m_dllAvUtil.av_get_bytes_per_sample(dec_ctx->sample_fmt) / config.channels;
           config.fmt = dec_ctx->sample_fmt;
+          config.bits_per_sample = dec_ctx->bits_per_coded_sample;
           sound->InitSound(true, config, samples);
           init = true;
         }
@@ -2214,16 +2215,19 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
   dst_config.channels = m_internalFormat.m_channelLayout.Count();
   dst_config.sample_rate = m_internalFormat.m_sampleRate;
   dst_config.fmt = CActiveAEResample::GetAVSampleFormat(m_internalFormat.m_dataFormat);
+  dst_config.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_internalFormat.m_dataFormat);
 
   CActiveAEResample *resampler = new CActiveAEResample();
   resampler->Init(dst_config.channel_layout,
                   dst_config.channels,
                   dst_config.sample_rate,
                   dst_config.fmt,
+                  dst_config.bits_per_sample,
                   orig_config.channel_layout,
                   orig_config.channels,
                   orig_config.sample_rate,
                   orig_config.fmt,
+                  orig_config.bits_per_sample,
                   NULL,
                   AE_QUALITY_MID);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2027,8 +2027,10 @@ uint8_t **CActiveAE::AllocSoundSample(SampleConfig &config, int &samples, int &b
   uint8_t **buffer;
   planes = m_dllAvUtil.av_sample_fmt_is_planar(config.fmt) ? config.channels : 1;
   buffer = new uint8_t*[planes];
+
+  // align buffer to 16 in order to be compatible with sse in CAEConvert
   m_dllAvUtil.av_samples_alloc(buffer, &linesize, config.channels,
-                                 samples, config.fmt, 0);
+                                 samples, config.fmt, 16);
   bytes_per_sample = m_dllAvUtil.av_get_bytes_per_sample(config.fmt);
   return buffer;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -245,6 +245,7 @@ protected:
   bool InitSink();
   void DrainSink();
   void UnconfigureSink();
+  bool IsSinkCompatible(const AEAudioFormat format, const std::string &device);
   void Start();
   void Dispose();
   void LoadSettings();
@@ -267,6 +268,8 @@ protected:
   bool ResampleSound(CActiveAESound *sound);
   void MixSounds(CSoundPacket &dstSample);
   void Deamplify(CSoundPacket &dstSample);
+
+  bool CompareFormat(AEAudioFormat &lhs, AEAudioFormat &rhs);
 
   CEvent m_inMsgEvent;
   CEvent m_outMsgEvent;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -21,6 +21,7 @@
 #include "ActiveAEBuffer.h"
 #include "AEFactory.h"
 #include "ActiveAE.h"
+#include "Utils/AEUtil.h"
 
 using namespace ActiveAE;
 
@@ -105,6 +106,7 @@ bool CActiveAEBufferPool::Create(unsigned int totaltime)
   CSampleBuffer *buffer;
   SampleConfig config;
   config.fmt = CActiveAEResample::GetAVSampleFormat(m_format.m_dataFormat);
+  config.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_format.m_dataFormat);
   config.channels = m_format.m_channelLayout.Count();
   config.sample_rate = m_format.m_sampleRate;
   config.channel_layout = CActiveAEResample::GetAVChannelLayout(m_format.m_channelLayout);
@@ -163,10 +165,12 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap)
                                 m_format.m_channelLayout.Count(),
                                 m_format.m_sampleRate,
                                 CActiveAEResample::GetAVSampleFormat(m_format.m_dataFormat),
+                                CAEUtil::DataFormatToUsedBits(m_format.m_dataFormat),
                                 CActiveAEResample::GetAVChannelLayout(m_inputFormat.m_channelLayout),
                                 m_inputFormat.m_channelLayout.Count(),
                                 m_inputFormat.m_sampleRate,
                                 CActiveAEResample::GetAVSampleFormat(m_inputFormat.m_dataFormat),
+                                CAEUtil::DataFormatToUsedBits(m_inputFormat.m_dataFormat),
                                 remap ? &m_format.m_channelLayout : NULL,
                                 m_resampleQuality);
   }
@@ -188,10 +192,12 @@ void CActiveAEBufferPoolResample::ChangeResampler()
                                 m_format.m_channelLayout.Count(),
                                 m_outSampleRate,
                                 CActiveAEResample::GetAVSampleFormat(m_format.m_dataFormat),
+                                CAEUtil::DataFormatToUsedBits(m_format.m_dataFormat),
                                 CActiveAEResample::GetAVChannelLayout(m_inputFormat.m_channelLayout),
                                 m_inputFormat.m_channelLayout.Count(),
                                 m_inputFormat.m_sampleRate,
                                 CActiveAEResample::GetAVSampleFormat(m_inputFormat.m_dataFormat),
+                                CAEUtil::DataFormatToUsedBits(m_inputFormat.m_dataFormat),
                                 NULL,
                                 m_resampleQuality);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -34,6 +34,7 @@ struct SampleConfig
   uint64_t channel_layout;
   int channels;
   int sample_rate;
+  int bits_per_sample;
 };
 
 /**

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
@@ -34,7 +34,7 @@ class CActiveAEResample
 public:
   CActiveAEResample();
   virtual ~CActiveAEResample();
-  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, CAEChannelInfo *remapLayout, AEQuality quality);
+  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, CAEChannelInfo *remapLayout, AEQuality quality);
   int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples);
   int64_t GetDelay(int64_t base);
   int GetBufferedSamples();
@@ -44,7 +44,7 @@ public:
   static uint64_t GetAVChannelLayout(CAEChannelInfo &info);
 //  static CAEChannelInfo GetAEChannelLayout(uint64_t layout);
   static AVSampleFormat GetAVSampleFormat(AEDataFormat format);
-  static AEDataFormat GetAESampleFormat(AVSampleFormat format);
+  static AEDataFormat GetAESampleFormat(AVSampleFormat format, int bits);
   static uint64_t GetAVChannel(enum AEChannel aechannel);
   int GetAVChannelIndex(enum AEChannel aechannel, uint64_t layout);
 
@@ -55,6 +55,7 @@ protected:
   int m_src_rate, m_dst_rate;
   int m_src_channels, m_dst_channels;
   AVSampleFormat m_src_fmt, m_dst_fmt;
+  int m_src_bits, m_dst_bits;
   SwrContext *m_pContext;
   double m_rematrix[AE_CH_MAX][AE_CH_MAX];
 };

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -850,7 +850,7 @@ uint8_t* CActiveAESink::Convert(CSampleBuffer* samples)
 void CActiveAESink::GenerateNoise()
 {
   int nb_floats = m_sinkFormat.m_frames*m_sinkFormat.m_channelLayout.Count();
-  float *noise = new float[nb_floats];
+  float *noise = (float*)_aligned_malloc(nb_floats*sizeof(float), 16);
 
   float R1, R2;
   for(int i=0; i<nb_floats;i++)
@@ -868,5 +868,5 @@ void CActiveAESink::GenerateNoise()
   AEDataFormat fmt = CActiveAEResample::GetAESampleFormat(m_sampleOfNoise.pkt->config.fmt, m_sampleOfNoise.pkt->config.bits_per_sample);
   CAEConvert::AEConvertFrFn convertFn = CAEConvert::FrFloat(fmt);
   convertFn(noise, nb_floats, m_sampleOfNoise.pkt->data[0]);
-  delete [] noise;
+  _aligned_free(noise);
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -706,6 +706,7 @@ void CActiveAESink::OpenSink()
   // init sample of silence
   SampleConfig config;
   config.fmt = CActiveAEResample::GetAVSampleFormat(m_sinkFormat.m_dataFormat);
+  config.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_sinkFormat.m_dataFormat);
   config.channel_layout = CActiveAEResample::GetAVChannelLayout(m_sinkFormat.m_channelLayout);
   config.channels = m_sinkFormat.m_channelLayout.Count();
   config.sample_rate = m_sinkFormat.m_sampleRate;
@@ -802,7 +803,7 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
 
 void CActiveAESink::ConvertInit(CSampleBuffer* samples)
 {
-  if (CActiveAEResample::GetAESampleFormat(samples->pkt->config.fmt) != m_sinkFormat.m_dataFormat)
+  if (CActiveAEResample::GetAESampleFormat(samples->pkt->config.fmt, samples->pkt->config.bits_per_sample) != m_sinkFormat.m_dataFormat)
   {
     m_convertFn = CAEConvert::FrFloat(m_sinkFormat.m_dataFormat);
     if (m_convertBuffer)
@@ -860,7 +861,7 @@ void CActiveAESink::GenerateNoise()
     noise[i] = (float) sqrt( -2.0f * log( R1 )) * cos( 2.0f * PI * R2 ) * 0.00001;
   }
 
-  AEDataFormat fmt = CActiveAEResample::GetAESampleFormat(m_sampleOfNoise.pkt->config.fmt);
+  AEDataFormat fmt = CActiveAEResample::GetAESampleFormat(m_sampleOfNoise.pkt->config.fmt, m_sampleOfNoise.pkt->config.bits_per_sample);
   CAEConvert::AEConvertFrFn convertFn = CAEConvert::FrFloat(fmt);
   convertFn(noise, nb_floats, m_sampleOfNoise.pkt->data[0]);
   delete [] noise;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -38,6 +38,7 @@ struct SinkConfig
 {
   AEAudioFormat format;
   CEngineStats *stats;
+  const std::string *device;
 };
 
 class CSinkControlProtocol : public Protocol
@@ -49,6 +50,7 @@ public:
     CONFIGURE,
     UNCONFIGURE,
     SILENCEMODE,
+    ISCOMPATIBLE,
     VOLUME,
     FLUSH,
     TIMEOUT,
@@ -86,7 +88,6 @@ public:
   std::string GetDefaultDevice(bool passthrough);
   void Start();
   void Dispose();
-  bool IsCompatible(const AEAudioFormat format, const std::string &device);
   bool HasVolume();
   CSinkControlProtocol m_controlPort;
   CSinkDataProtocol m_dataPort;
@@ -98,6 +99,7 @@ protected:
   void GetDeviceFriendlyName(std::string &device);
   void OpenSink();
   void ReturnBuffers();
+  bool IsCompatible(const AEAudioFormat format, const std::string &device);
 
   unsigned int OutputSamples(CSampleBuffer* samples);
   void ConvertInit(CSampleBuffer* samples);
@@ -129,6 +131,7 @@ protected:
   } m_convertState;
 
   std::string m_deviceFriendlyName;
+  std::string m_device;
   AESinkInfoList m_sinkInfoList;
   IAESink *m_sink;
   AEAudioFormat m_sinkFormat, m_requestedFormat;

--- a/xbmc/cores/AudioEngine/Utils/AEConvert.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEConvert.cpp
@@ -797,7 +797,7 @@ unsigned int CAEConvert::Float_S24NE4(float *data, const unsigned int samples, u
   /* work around invalid alignment */
   while ((((uintptr_t)data & 0xF) || ((uintptr_t)dest & 0xF)) && count > 0)
   {
-    dst[0] = safeRound(data[0] * ((float)INT24_MAX+.5f));
+    dst[0] = (safeRound(data[0] * ((float)INT24_MAX+.5f)) & 0xFFFFFF) << 8;
     ++data;
     ++dst;
     --count;
@@ -812,11 +812,11 @@ unsigned int CAEConvert::Float_S24NE4(float *data, const unsigned int samples, u
     memcpy(dst, &con, sizeof(int32_t) * 4);
   }
 
-  if (samples != even)
+  if (count != even)
   {
-    const uint32_t odd = samples - even;
+    const uint32_t odd = count - even;
     if (odd == 1)
-      dst[0] = safeRound(data[0] * ((float)INT24_MAX+.5f));
+      dst[0] = (safeRound(data[0] * ((float)INT24_MAX+.5f)) & 0xFFFFFF) << 8;
     else
     {
       __m128 in;
@@ -886,9 +886,9 @@ unsigned int CAEConvert::Float_S24NE3(float *data, const unsigned int samples, u
     *((uint32_t*)(dest + 9)) = (dst[3] & 0xFFFFFF) << leftShift;
   }
 
-  if (samples != even)
+  if (count != even)
   {
-    const uint32_t odd = samples - even;
+    const uint32_t odd = count - even;
     if (odd == 1)
       dst[0] = safeRound(data[0] * ((float)INT24_MAX+.5f)) & 0xFFFFFF;
     else
@@ -958,9 +958,9 @@ unsigned int CAEConvert::Float_S32LE(float *data, const unsigned int samples, ui
     dst[3] = Endian_SwapLE32(dst[3]);
   }
 
-  if (samples != even)
+  if (count != even)
   {
-    const uint32_t odd = samples - even;
+    const uint32_t odd = count - even;
     if (odd == 1)
     {
       dst[0] = safeRound(data[0] * AE_MUL32);
@@ -1067,9 +1067,9 @@ unsigned int CAEConvert::Float_S32BE(float *data, const unsigned int samples, ui
     dst[3] = Endian_SwapBE32(dst[3]);
   }
 
-  if (samples != even)
+  if (count != even)
   {
-    const uint32_t odd = samples - even;
+    const uint32_t odd = count - even;
     if (odd == 1)
     {
       dst[0] = safeRound(data[0] * AE_MUL32);

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -123,6 +123,14 @@ const unsigned int CAEUtil::DataFormatToBits(const enum AEDataFormat dataFormat)
   return formats[dataFormat];
 }
 
+const unsigned int CAEUtil::DataFormatToUsedBits(const enum AEDataFormat dataFormat)
+{
+  if (dataFormat == AE_FMT_S24BE4 || dataFormat == AE_FMT_S24LE4 || dataFormat == AE_FMT_S24NE4)
+    return 24;
+  else
+    return DataFormatToBits(dataFormat);
+}
+
 const char* CAEUtil::DataFormatToStr(const enum AEDataFormat dataFormat)
 {
   if (dataFormat < 0 || dataFormat >= AE_FMT_MAX)

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -80,6 +80,7 @@ public:
   static CAEChannelInfo          GuessChLayout     (const unsigned int channels);
   static const char*             GetStdChLayoutName(const enum AEStdChLayout layout);
   static const unsigned int      DataFormatToBits  (const enum AEDataFormat dataFormat);
+  static const unsigned int      DataFormatToUsedBits (const enum AEDataFormat dataFormat);
   static const char*             DataFormatToStr   (const enum AEDataFormat dataFormat);
 
   /*! \brief convert a volume percentage (as a proportion) to a dB gain


### PR DESCRIPTION
this lets ffmpeg do the conversion from float to 24 bit format required by WASAPI. ffmpeg should do this properly.
