### PR TITLE
Differentiate between "unsorted" and "unsortable"

### DIFF
--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -220,6 +220,11 @@ SortDescription CGUIViewState::GetSortMethod() const
   return sorting;
 }
 
+bool CGUIViewState::HasMultipleSortMethods() const
+{
+  return m_sortMethods.size() > 1;
+}
+
 int CGUIViewState::GetSortMethodLabel() const
 {
   if (m_currentSortMethod>=0 && m_currentSortMethod<(int)m_sortMethods.size())
@@ -293,6 +298,7 @@ void CGUIViewState::SetSortMethod(SortBy sortBy, SortAttribute sortAttributes /*
       break;
     }
   }
+  SetSortOrder(m_sortOrder);
 }
 
 void CGUIViewState::SetSortMethod(SortDescription sortDescription)
@@ -308,6 +314,7 @@ SortDescription CGUIViewState::SetNextSortMethod(int direction /* = 1 */)
     m_currentSortMethod = 0;
   if (m_currentSortMethod < 0)
     m_currentSortMethod = m_sortMethods.size() ? (int)m_sortMethods.size() - 1 : 0;
+  SetSortOrder(m_sortOrder);
 
   SaveViewState();
 

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -40,6 +40,7 @@ public:
   SortDescription SetNextSortMethod(int direction = 1);
   void SetCurrentSortMethod(int method);
   SortDescription GetSortMethod() const;
+  bool HasMultipleSortMethods() const;
   int GetSortMethodLabel() const;
   void GetSortMethodLabelMasks(LABEL_MASKS& masks) const;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -546,7 +546,7 @@ void CGUIMediaWindow::UpdateButtons()
     m_viewControl.SetCurrentView(m_guiState->GetViewAsControl());
 
     // Update sort by button
-    if (m_guiState->GetSortMethod().sortBy == SortByNone)
+    if (!m_guiState->HasMultipleSortMethods())
       CONTROL_DISABLE(CONTROL_BTNSORTBY);
     else
       CONTROL_ENABLE(CONTROL_BTNSORTBY);


### PR DESCRIPTION
The cleanup committed as 7ec41ee12967345673bad456d6d52a7a04a4f235 folds both `SORT_METHOD_NONE` (meaning "unsortable") and `SORT_METHOD_UNSORTED` (meaning "not sorted by one of the known criteria") into the new `SortByNone`.

This lack of differentiation breaks the sorting ability of a number of item lists; most prominently those generated by plugins. For an example, see channel lists in the YouTube plugin. It is not possible to apply sorting to lists with `SortByNone` in the UI, due to `CGUIMediaWindow::UpdateButtons()` at line 549.

This patch re-introduces a separate `SortByUnsorted` state, and treats this the same as the old `SORT_METHOD_UNSORTED`.

Suggestions for a better name than `SortByUnsorted` are more than welcome.

Note: When switching to the `SortByUnsorted` state (shown as "Sort by: Default" in the default Confluence skin), no sorting takes place at all.
I.e. the list does not necessarily return to the sort order originally produced by a plugin.
As far as I know, that's how the old `SORT_METHOD_UNSORTED` used to behave as well; and is a known issue for plugins (wanted to link to an issue here, but cannot find it again right now).

Ideally, items in lists with `SORT_METHOD_UNSORTED` could be extended by a position attribute, and could then be sort accordingly when returning to `SortByUnsorted`. Which could then be more appropriately named `SortByPosition` or `SortByNatural` or somesuch.
