### PR TITLE
[android] Fixed missing error message in debug log, "Unable to load '.so file', reason: (null)"

### DIFF
--- a/xbmc/android/loader/AndroidDyload.cpp
+++ b/xbmc/android/loader/AndroidDyload.cpp
@@ -266,9 +266,6 @@ void* CAndroidDyload::Open_Internal(string filename, bool checkSystem)
 
   handle = dlopen(path.c_str(), RTLD_LOCAL);
 
-  if (handle == NULL)
-    CXBMCApp::android_printf("xb_dlopen: Error from dlopen(%s): %s", path.c_str(), dlerror());
-
   recursivelibdep dep;
   dep.handle = handle;
   dep.filename = filename.substr(filename.find_last_of('/') +1);


### PR DESCRIPTION
Error message comes from dlerror() in xbmc/cores/DllLoader/SoLoader.cpp when CAndroidDyload::Open() fails. However, dlerror() is also called inside CAndroidDyload::Open(). This causes the second, outer dlerror() to return NULL, because (from the documentation) "dlerror() returns NULL if no errors have occurred since initialization or since it was last called".
