### PR TITLE
[win32] Set minimum of Vista and up required to install

### DIFF
--- a/project/Win32BuildSetup/XBMC for Windows.nsi
+++ b/project/Win32BuildSetup/XBMC for Windows.nsi
@@ -10,6 +10,7 @@
   !include "MUI2.nsh"
   !include "nsDialogs.nsh"
   !include "LogicLib.nsh"
+  !include "WinVer.nsh"
 ;--------------------------------
 ;General
 
@@ -380,6 +381,10 @@ Section "-Check DirectX installation" SEC_DIRECTXCHECK
 SectionEnd
 
 Function .onInit
+  ${IfNot} ${AtLeastWinVista}
+    MessageBox MB_OK|MB_ICONSTOP|MB_TOPMOST|MB_SETFOREGROUND "Windows Vista or above required.$\nThis program can not be run on Windows XP"
+    Quit
+  ${EndIf}
   # set section 'SEC_DIRECTX' as selected and read-only if required dx version not found
   IfFileExists ${DXVERSIONDLL} +3 0
   IntOp $0 ${SF_SELECTED} | ${SF_RO}


### PR DESCRIPTION
Since Win XP support will be dropped next year and there's no dev any more using XP i suggest we drop official XP support starting with the installer.
Also it seems that recent changes already killed XP usability judging from the forum.
@wsoltys

**This will be a Team XBMC decision only so do NOT starting commenting to not remove XP**
