### PR TITLE
xbmc/utils/BitstreamConverter.{cpp,h}: s/CodecID/AVCodecID/, fixes compile with external ffmpeg >=2.0

### DIFF
--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -296,7 +296,7 @@ CBitstreamConverter::~CBitstreamConverter()
   Close();
 }
 
-bool CBitstreamConverter::Open(enum CodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb)
+bool CBitstreamConverter::Open(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb)
 {
   m_to_annexb = to_annexb;
 

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -133,7 +133,7 @@ public:
   CBitstreamConverter();
   ~CBitstreamConverter();
 
-  bool              Open(enum CodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb);
+  bool              Open(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize, bool to_annexb);
   void              Close(void);
   bool              NeedConvert(void) { return m_convert_bitstream; };
   bool              Convert(uint8_t *pData, int iSize);


### PR DESCRIPTION
Just found out about a compile error with external ffmpeg (>=2.0) on gentoo:

```
CPP     xbmc/utils/BitstreamConverter.o
In file included from BitstreamConverter.cpp:25:0:
BitstreamConverter.h:136:31: error: use of enum 'CodecID' without previous declaration
BitstreamConverter.cpp:299:37: error: use of enum 'CodecID' without previous declaration
BitstreamConverter.cpp: In member function 'bool CBitstreamConverter::Open(int, uint8_t*, int, bool)':
BitstreamConverter.cpp:303:13: error: invalid conversion from 'int' to 'AVCodecID' [-fpermissive]
make[1]: *** [BitstreamConverter.o] Error 1
make: *** [xbmc/utils/utils.a] Error 2
```

This small patch fixes compiling and brings "CodecID" on par with everything else to "AVCodecID". Build-tested with external ffmpeg on gentoo/amd64 and on Ubuntu Precise/amd64 with internal ffmpeg. Probably should be build-tested on iOS/OSX/Android/Win32.
