### PR TITLE
paplayer/DVDPlayerCodec: prevent multiple Init() runs with the same arguments, do DeInit() on instance reuse, do more cleanup in DeInit() - fixes playback of DTS-WAV via paplayer (closes #14405)

### DIFF
--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -41,7 +41,7 @@ DVDPlayerCodec::DVDPlayerCodec()
   m_nAudioStream = -1;
   m_audioPos = 0;
   m_pPacket = NULL;
-  m_decoded = NULL;;
+  m_decoded = NULL;
   m_nDecodedLen = 0;
 }
 
@@ -57,7 +57,7 @@ void DVDPlayerCodec::SetContentType(const CStdString &strContent)
 
 bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
 {
-  m_decoded = NULL;;
+  m_decoded = NULL;
   m_nDecodedLen = 0;
 
   CStdString strFileToOpen = strFile;
@@ -208,7 +208,7 @@ void DVDPlayerCodec::DeInit()
   }
 
   m_audioPos = 0;
-  m_decoded = NULL;;
+  m_decoded = NULL;
   m_nDecodedLen = 0;
 }
 
@@ -221,7 +221,7 @@ int64_t DVDPlayerCodec::Seek(int64_t iSeekTime)
   m_pDemuxer->SeekTime((int)iSeekTime, false);
   m_pAudioCodec->Reset();
 
-  m_decoded = NULL;;
+  m_decoded = NULL;
   m_nDecodedLen = 0;
 
   return iSeekTime;

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -43,6 +43,8 @@ DVDPlayerCodec::DVDPlayerCodec()
   m_pPacket = NULL;
   m_decoded = NULL;
   m_nDecodedLen = 0;
+  m_strFileName = "";
+  m_bInited = false;
 }
 
 DVDPlayerCodec::~DVDPlayerCodec()
@@ -57,6 +59,17 @@ void DVDPlayerCodec::SetContentType(const CStdString &strContent)
 
 bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
 {
+  // take precaution if Init()ialized earlier
+  if (m_bInited)
+  {
+    // keep things as is if Init() was done with known strFile
+    if (m_strFileName == strFile)
+      return true;
+
+    // got differing filename, so cleanup before starting over
+    DeInit();
+  }
+
   m_decoded = NULL;
   m_nDecodedLen = 0;
 
@@ -180,6 +193,9 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
   m_Bitrate = m_pAudioCodec->GetBitRate();
   m_pDemuxer->GetStreamCodecName(m_nAudioStream,m_CodecName);
 
+  m_strFileName = strFile;
+  m_bInited = true;
+
   return true;
 }
 
@@ -207,9 +223,21 @@ void DVDPlayerCodec::DeInit()
     m_pAudioCodec = NULL;
   }
 
+  // cleanup format information
+  m_TotalTime = 0;
+  m_SampleRate = 0;
+  m_EncodedSampleRate = 0;
+  m_BitsPerSample = 0;
+  m_DataFormat = AE_FMT_INVALID;
+  m_Channels = 0;
+  m_Bitrate = 0;
+
   m_audioPos = 0;
   m_decoded = NULL;
   m_nDecodedLen = 0;
+
+  m_strFileName = "";
+  m_bInited = false;
 }
 
 int64_t DVDPlayerCodec::Seek(int64_t iSeekTime)

--- a/xbmc/cores/paplayer/DVDPlayerCodec.h
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.h
@@ -50,6 +50,8 @@ private:
 
   CStdString m_strContentType;
 
+  std::string m_strFileName;
+
   int m_nAudioStream;
 
   int m_audioPos;
@@ -59,6 +61,8 @@ private:
   int  m_nDecodedLen;
 
   CAEChannelInfo m_ChannelInfo;
+
+  bool m_bInited;
 };
 
 #endif


### PR DESCRIPTION
Sometime around the ffmpeg-1.2 bump, DTS-WAV playback broke in a way that only noise was played when trying to play back WAV files containing DTS-encoded audio, using paplayer. In http://trac.xbmc.org/ticket/14405 this was worked around by removing the call to DVDPlayerCodec::Init(). Indeed, multiple calls to Init() are placed, which seems to screw up things regarding decoder initialisation/handling. This patch/PR makes Init() track multiple invocations and doesn't do subsequent runs when called with the same arguments (filecache not considered as it's not used), but rather does a proper DeInit(), while DeInit() is enhanced to be more proper so further Init()'s can do their work properly. This effectively fixes DTS-WAV playback.

Should be tested with SPDIF/HDMI passthrough, I was only able to test using stereo downmix (ffmpeg/libdca decode).

Closes trac ticket #14405.
