### PR TITLE
[AE/CA] - fix problem where 2 threads read from our lockfree ringbuffer which is not allowed

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
@@ -105,7 +105,8 @@ CCoreAudioAEStream::CCoreAudioAEStream(enum AEDataFormat dataFormat, unsigned in
   m_fadeRunning     (false),
   m_frameSize       (0    ),
   m_doRemap         (true ),
-  m_firstInput      (true )
+  m_firstInput      (true ),
+  m_flushRequested  (false)
 {
   m_ssrcData.data_out             = NULL;
 
@@ -331,7 +332,7 @@ unsigned int CCoreAudioAEStream::AddData(void *data, unsigned int size)
   unsigned int addsize  = size;
   unsigned int channelsInBuffer = m_chLayoutCountStream;
 
-  if (!m_valid || size == 0 || data == NULL || !m_Buffer)
+  if (!m_valid || size == 0 || data == NULL || !m_Buffer || m_flushRequested)
     return 0;
 
   // if the stream is draining
@@ -439,11 +440,18 @@ unsigned int CCoreAudioAEStream::AddData(void *data, unsigned int size)
   return size;
 }
 
+// this is only called on the context of the coreaudio thread!
 unsigned int CCoreAudioAEStream::GetFrames(uint8_t *buffer, unsigned int size)
 {
   // if we have been deleted
   if (!m_valid || m_delete || !m_Buffer || m_paused)
     return 0;
+  
+  if (m_flushRequested)
+  {
+    InternalFlush();
+    return 0;
+  }
 
   unsigned int readsize = std::min(m_Buffer->GetReadSize(), size);
   m_Buffer->Read(buffer, readsize);
@@ -615,7 +623,8 @@ bool CCoreAudioAEStream::IsDrained()
 
 void CCoreAudioAEStream::Flush()
 {
-  InternalFlush();
+  if (m_Buffer)
+    m_flushRequested = true;
 }
 
 float CCoreAudioAEStream::GetVolume()
@@ -668,6 +677,7 @@ void CCoreAudioAEStream::InternalFlush()
     }
   }
 
+  m_flushRequested = false;
   //if (m_Buffer)
   //  m_Buffer->Reset();
 }

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.h
@@ -172,5 +172,6 @@ private:
   bool              m_doRemap;
   void              Upmix(void *input, unsigned int channelsInput, void *output, unsigned int channelsOutput, unsigned int frames, AEDataFormat dataFormat);
   bool              m_firstInput;
+  bool              m_flushRequested;
 };
 

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioRingBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioRingBuffer.h
@@ -232,7 +232,7 @@ public:
    */
   unsigned int GetReadSize()
   {
-    return m_iWritten > m_iRead ? m_iWritten - m_iRead : 0;
+    return m_iWritten > m_iReadSize ? m_iWritten - m_iRead : 0;
   }
 
   /**

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioRingBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioRingBuffer.h
@@ -232,7 +232,7 @@ public:
    */
   unsigned int GetReadSize()
   {
-    return m_iWritten > m_iReadSize ? m_iWritten - m_iRead : 0;
+    return m_iWritten - m_iRead;
   }
 
   /**


### PR DESCRIPTION
First 2 commits revert a wrong fix for a race condition which crashed when switching tv channels. That wrong fix introduced the regression reported in the forum here:

http://forum.xbmc.org/showthread.php?tid=148243 (stuttering/no audio after 46 mins, 62mins, 3hours of playback).

The real fix for the crash is in the 3rd commit.

The crash during tv channel switching was because the principal of "1 consumer, 1 producer" was broken. The used lockfree ringbuffer implementation is only thread safe if only 1 thread reads and another thread writes to it.

In the tv channel switching use case the dvdplayeraudio thread flushs the stream which is a read - this happens while the coreaudio thread still pulls frames from the buffer. We end up in invalid buffer state leading to crash in some racy cases.

The solution is to move the flush of the buffer into the coreaudio thread.
