### PR TITLE
SoftAE: Fix A/V sync issues caused by wrong buffer time calculation

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -243,8 +243,6 @@ void CSoftAE::InternalOpenSink()
       {
         if (m_masterStream->m_initChannelLayout == AE_CH_LAYOUT_2_0)
           m_transcode = false;
-        m_encoderInitFrameSizeMul  = 1.0 / (newFormat.m_channelLayout.Count() * 
-                                           (CAEUtil::DataFormatToBits(newFormat.m_dataFormat) >> 3));
         m_encoderInitSampleRateMul = 1.0 / newFormat.m_sampleRate;
       }
     }
@@ -349,7 +347,6 @@ void CSoftAE::InternalOpenSink()
 
     m_sinkFormat              = newFormat;
     m_sinkFormatSampleRateMul = 1.0 / (double)newFormat.m_sampleRate;
-    m_sinkFormatFrameSizeMul  = 1.0 / (double)newFormat.m_frameSize;
     m_sinkBlockSize           = newFormat.m_frames * newFormat.m_frameSize;
     m_sinkBlockTime           = 1000 * newFormat.m_frames / newFormat.m_sampleRate;
     // check if sink controls volume, if so, init the volume.
@@ -378,6 +375,7 @@ void CSoftAE::InternalOpenSink()
     m_convertFn      = NULL;
     m_bytesPerSample = CAEUtil::DataFormatToBits(m_sinkFormat.m_dataFormat) >> 3;
     m_frameSize      = m_sinkFormat.m_frameSize;
+    m_frameSizeMul   = 1.0 / (double)m_frameSize;
     neededBufferSize = m_sinkFormat.m_frames * m_sinkFormat.m_frameSize;
   }
   else
@@ -430,6 +428,7 @@ void CSoftAE::InternalOpenSink()
 
     m_bytesPerSample = CAEUtil::DataFormatToBits(AE_FMT_FLOAT) >> 3;
     m_frameSize      = m_bytesPerSample * m_chLayout.Count();
+    m_frameSizeMul   = 1.0 / (double)m_frameSize;
   }
 
   CLog::Log(LOGDEBUG, "CSoftAE::InternalOpenSink - Internal Buffer Size: %d", (int)neededBufferSize);
@@ -894,11 +893,11 @@ double CSoftAE::GetDelay()
  
   if (m_transcode && m_encoder && !m_rawPassthrough)
   {
-    delayBuffer     = (double)m_buffer.Used() * m_encoderInitFrameSizeMul * m_encoderInitSampleRateMul;
+    delayBuffer     = (double)m_buffer.Used() * m_frameSizeMul * m_encoderInitSampleRateMul;
     delayTranscoder = m_encoder->GetDelay((double)m_encodedBuffer.Used() * m_encoderFrameSizeMul);
   }
   else
-    delayBuffer = (double)m_buffer.Used() * m_sinkFormatFrameSizeMul *m_sinkFormatSampleRateMul;
+    delayBuffer = (double)m_buffer.Used() * m_frameSizeMul *m_sinkFormatSampleRateMul;
 
   return delayBuffer + delaySink + delayTranscoder;
 }
@@ -913,11 +912,11 @@ double CSoftAE::GetCacheTime()
 
   if (m_transcode && m_encoder && !m_rawPassthrough)
   {
-    timeBuffer     = (double)m_buffer.Used() * m_encoderInitFrameSizeMul * m_encoderInitSampleRateMul;
+    timeBuffer     = (double)m_buffer.Used() * m_frameSizeMul * m_encoderInitSampleRateMul;
     timeTranscoder = m_encoder->GetDelay((double)m_encodedBuffer.Used() * m_encoderFrameSizeMul);
   }
   else
-    timeBuffer = (double)m_buffer.Used() * m_sinkFormatFrameSizeMul *m_sinkFormatSampleRateMul;
+    timeBuffer = (double)m_buffer.Used() * m_frameSizeMul *m_sinkFormatSampleRateMul;
 
   return timeBuffer + timeSink + timeTranscoder;
 }
@@ -932,11 +931,11 @@ double CSoftAE::GetCacheTotal()
 
   if (m_transcode && m_encoder && !m_rawPassthrough)
   {
-    timeBuffer     = (double)m_buffer.Size() * m_encoderInitFrameSizeMul * m_encoderInitSampleRateMul;
+    timeBuffer     = (double)m_buffer.Size() * m_frameSizeMul * m_encoderInitSampleRateMul;
     timeTranscoder = m_encoder->GetDelay((double)m_encodedBuffer.Size() * m_encoderFrameSizeMul);
   }
   else
-    timeBuffer = (double)m_buffer.Size() * m_sinkFormatFrameSizeMul *m_sinkFormatSampleRateMul;
+    timeBuffer = (double)m_buffer.Size() * m_frameSizeMul *m_sinkFormatSampleRateMul;
 
   return timeBuffer + timeSink + timeTranscoder;
 }

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -157,20 +157,19 @@ private:
   bool                m_muted;
   CAEChannelInfo      m_chLayout;
   unsigned int        m_frameSize;
+  double              m_frameSizeMul;
 
   /* the sink, its format information, and conversion function */
   AESinkInfoList            m_sinkInfoList;
   IAESink                  *m_sink;
   AEAudioFormat             m_sinkFormat;
   double                    m_sinkFormatSampleRateMul;
-  double                    m_sinkFormatFrameSizeMul;
   unsigned int              m_sinkBlockSize;
   unsigned int              m_sinkBlockTime;
   bool                      m_sinkHandlesVolume;
   AEAudioFormat             m_encoderFormat;
   double                    m_encoderFrameSizeMul;
   double                    m_encoderInitSampleRateMul;
-  double                    m_encoderInitFrameSizeMul;
   unsigned int              m_bytesPerSample;
   CAEConvert::AEConvertFrFn m_convertFn;
 


### PR DESCRIPTION
CSoftAE::GetDelay(), CSoftAE::GetCacheTime(), and
CSoftAE::GetCacheTotal() assume in their calculations that m_buffer
contains frames that have sink/encoder frame size. However, m_buffer
actually contains frames in the format received from CSoftAEStream.

This causes varying levels of A/V de-sync depending on other conditions.
On my Linux system I encounter this always when using using HDMI audio
and having the display refresh rate set at 24Hz (approx 100-200ms desync
that stays approximately constant).

Fix those functions to use the correct frame size.
