### PR TITLE
AE: distinguish between AC-3 and EAC-3

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1874,7 +1874,10 @@ msgctxt "#447"
 msgid "Autorun media"
 msgstr ""
 
-#empty string with id 448
+#: system/settings/settings.xml
+msgctxt "#448"
+msgid "Dolby Digital Plus (E-AC3) capable receiver"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#449"
@@ -14371,4 +14374,9 @@ msgstr ""
 #: xbmc/Windows/GUIMediaWindow.cpp
 msgctxt "#37015"
 msgid "Browse Into"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#37016"
+msgid "Select this option if your receiver is capable of decoding E-AC3 streams."
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2021,6 +2021,18 @@
             </dependency>
           </dependencies>
         </setting>
+        <setting id="audiooutput.eac3passthrough" type="boolean" parent="audiooutput.mode" label="448" help="37016">
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable">
+              <or>
+                <condition setting="audiooutput.mode">1</condition> <!-- AUDIO_IEC958 -->
+                <condition setting="audiooutput.mode">2</condition> <!-- AUDIO_HDMI -->
+              </or>
+            </dependency>
+          </dependencies>
+        </setting>
         <setting id="audiooutput.dtspassthrough" type="boolean" parent="audiooutput.mode" label="254" help="36366">
           <level>2</level>
           <default>true</default>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1218,6 +1218,7 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
   if (m_settings.mode != AUDIO_ANALOG && AE_IS_RAW(format.m_dataFormat))
   {
     if ((format.m_dataFormat == AE_FMT_AC3 && !settings.ac3passthrough) ||
+        (format.m_dataFormat == AE_FMT_EAC3 && !settings.eac3passthrough) ||
         (format.m_dataFormat == AE_FMT_TRUEHD && !settings.truehdpassthrough) ||
         (format.m_dataFormat == AE_FMT_DTS && !settings.dtspassthrough) ||
         (format.m_dataFormat == AE_FMT_DTSHD && !settings.dtshdpassthrough))
@@ -1903,6 +1904,7 @@ void CActiveAE::LoadSettings()
 
   m_settings.stereoupmix = CSettings::Get().GetBool("audiooutput.stereoupmix");
   m_settings.ac3passthrough = CSettings::Get().GetBool("audiooutput.ac3passthrough");
+  m_settings.eac3passthrough = CSettings::Get().GetBool("audiooutput.eac3passthrough");
   m_settings.truehdpassthrough = CSettings::Get().GetBool("audiooutput.truehdpassthrough");
   m_settings.dtspassthrough = CSettings::Get().GetBool("audiooutput.dtspassthrough");
   m_settings.dtshdpassthrough = CSettings::Get().GetBool("audiooutput.dtshdpassthrough");
@@ -1968,6 +1970,7 @@ void CActiveAE::OnSettingsChange(const std::string& setting)
       setting == "audiooutput.audiodevice"       ||
       setting == "audiooutput.mode"              ||
       setting == "audiooutput.ac3passthrough"    ||
+      setting == "audiooutput.eac3passthrough"   ||
       setting == "audiooutput.dtspassthrough"    ||
       setting == "audiooutput.passthroughaac"    ||
       setting == "audiooutput.truehdpassthrough" ||

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -51,6 +51,7 @@ struct AudioSettings
   int mode;
   int channels;
   bool ac3passthrough;
+  bool eac3passthrough;
   bool dtspassthrough;
   bool aacpassthrough;
   bool truehdpassthrough;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -45,6 +45,7 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
     return false;
 
   bool bSupportsAC3Out    = false;
+  bool bSupportsEAC3Out   = false;
   bool bSupportsDTSOut    = false;
   bool bSupportsTrueHDOut = false;
   bool bSupportsDTSHDOut  = false;
@@ -53,6 +54,7 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
   if (AUDIO_IS_BITSTREAM(audioMode))
   {
     bSupportsAC3Out = CSettings::Get().GetBool("audiooutput.ac3passthrough");
+    bSupportsEAC3Out = CSettings::Get().GetBool("audiooutput.eac3passthrough");
     bSupportsDTSOut = CSettings::Get().GetBool("audiooutput.dtspassthrough");
   }
 
@@ -66,17 +68,13 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
   m_info.SetCoreOnly(!bSupportsDTSHDOut);
   m_bufferSize = 0;
 
-  if (
-      (hints.codec == AV_CODEC_ID_AC3 && bSupportsAC3Out) ||
+  if ((hints.codec == AV_CODEC_ID_AC3 && bSupportsAC3Out) ||
+      (hints.codec == AV_CODEC_ID_EAC3 && bSupportsEAC3Out) ||
       (hints.codec == AV_CODEC_ID_DTS && bSupportsDTSOut) ||
-      (audioMode == AUDIO_HDMI &&
-        (
-          (hints.codec == AV_CODEC_ID_EAC3   && bSupportsAC3Out   ) ||
-          (hints.codec == AV_CODEC_ID_TRUEHD && bSupportsTrueHDOut)
-        )
-      )
-  )
+      (hints.codec == AV_CODEC_ID_TRUEHD && bSupportsTrueHDOut))
+  {
     return true;
+  }
 
   return false;
 }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -869,6 +869,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("audiooutput.guisoundmode");
   settingSet.insert("audiooutput.stereoupmix");
   settingSet.insert("audiooutput.ac3passthrough");
+  settingSet.insert("audiooutput.eac3passthrough");
   settingSet.insert("audiooutput.dtspassthrough");
   settingSet.insert("audiooutput.passthroughaac");
   settingSet.insert("audiooutput.truehdpassthrough");


### PR DESCRIPTION
This has ever been wrong. A receiver which is capable of AC3 is not necessarily capable of EAC-3
