### PR TITLE
[3d] fixed wrong size of ass subtitles under sbs/tab 3d mode.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 #include "threads/SingleLock.h"
 #include "threads/Atomics.h"
+#include "guilib/GraphicContext.h"
 
 using namespace std;
 
@@ -159,7 +160,9 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(int imageWidth, int imageHeight, dou
     return NULL;
   }
 
+  double storage_aspact = (double)imageWidth / imageHeight;
   m_dll.ass_set_frame_size(m_renderer, imageWidth, imageHeight);
+  m_dll.ass_set_aspect_ratio(m_renderer, storage_aspact / g_graphicsContext.GetResInfo().fPixelRatio, storage_aspact);
   return m_dll.ass_render_frame(m_renderer, m_track, DVD_TIME_TO_MSEC(pts), changes);
 }
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
@@ -50,6 +50,7 @@ public:
   virtual ASS_Library* ass_library_init(void)=0;
   virtual ASS_Renderer* ass_renderer_init(ASS_Library* library)=0;
   virtual void ass_set_frame_size(ASS_Renderer* priv, int w, int h)=0;
+  virtual void ass_set_aspect_ratio(ASS_Renderer* priv, double dar, double sar)=0;
   virtual void ass_set_margins(ASS_Renderer* priv, int t, int b, int l, int r)=0;
   virtual void ass_set_use_margins(ASS_Renderer* priv, int use)=0;
   virtual void ass_set_font_scale(ASS_Renderer* priv, double font_scale)=0;
@@ -76,6 +77,7 @@ class DllLibass : public DllDynamic, DllLibassInterface
   DEFINE_METHOD0(ASS_Library *, ass_library_init)
   DEFINE_METHOD1(ASS_Renderer *, ass_renderer_init, (ASS_Library * p1))
   DEFINE_METHOD3(void, ass_set_frame_size, (ASS_Renderer * p1, int p2, int p3))
+  DEFINE_METHOD3(void, ass_set_aspect_ratio, (ASS_Renderer * p1, double p2, double p3))
   DEFINE_METHOD5(void, ass_set_margins, (ASS_Renderer * p1, int p2, int p3, int p4, int p5))
   DEFINE_METHOD2(void, ass_set_use_margins, (ASS_Renderer * p1, int p2))
   DEFINE_METHOD2(void, ass_set_font_scale, (ASS_Renderer * p1, double p2))
@@ -97,6 +99,7 @@ class DllLibass : public DllDynamic, DllLibassInterface
     RESOLVE_METHOD(ass_library_init)
     RESOLVE_METHOD(ass_renderer_init)
     RESOLVE_METHOD(ass_set_frame_size)
+    RESOLVE_METHOD(ass_set_aspect_ratio)
     RESOLVE_METHOD(ass_set_margins)
     RESOLVE_METHOD(ass_set_use_margins)
     RESOLVE_METHOD(ass_set_font_scale)


### PR DESCRIPTION
In sbs 3d mode, ass subtitles is so bigger because render in half screen width picture and show by 3d display at full screen let it's width x2. render ass subtitles in full screen width picture solve is.

and tab 3d mode similar like this.
