### PR TITLE
FIX: Consistenly look for fonts in special//home, then special://xbmc

### DIFF
--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -24,6 +24,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
+#include "utils/URIUtils.h"
 #include "threads/SingleLock.h"
 #include "threads/Atomics.h"
 
@@ -76,14 +77,10 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   if(!m_renderer)
     return;
 
-  //Setting default font to the Arial in \media\fonts (used if FontConfig fails)  
-  strPath = "special://home/media/Fonts/";
-  strPath += CSettings::Get().GetString("subtitles.font");
+  //Setting default font to the Arial in \media\fonts (used if FontConfig fails)
+  strPath = URIUtils::AddFileToFolder("special://home/media/Fonts/", CSettings::Get().GetString("subtitles.font"));
   if (!XFILE::CFile::Exists(strPath))
-  {
-    strPath = "special://xbmc/media/Fonts/";
-    strPath += CSettings::Get().GetString("subtitles.font");
-  }
+    strPath = URIUtils::AddFileToFolder("special://xbmc/media/Fonts/", CSettings::Get().GetString("subtitles.font"));
   int fc = !CSettings::Get().GetBool("subtitles.overrideassfonts");
 
   m_dll.ass_set_margins(m_renderer, 0, 0, 0, 0);

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -20,6 +20,7 @@
 
 #include "DVDSubtitlesLibass.h"
 #include "DVDClock.h"
+#include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -75,9 +76,14 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   if(!m_renderer)
     return;
 
-  //Setting default font to the Arial in \media\fonts (used if FontConfig fails)
-  strPath = "special://xbmc/media/Fonts/";
+  //Setting default font to the Arial in \media\fonts (used if FontConfig fails)  
+  strPath = "special://home/media/Fonts/";
   strPath += CSettings::Get().GetString("subtitles.font");
+  if (!XFILE::CFile::Exists(strPath))
+  {
+    strPath = "special://xbmc/media/Fonts/";
+    strPath += CSettings::Get().GetString("subtitles.font");
+  }
   int fc = !CSettings::Get().GetBool("subtitles.overrideassfonts");
 
   m_dll.ass_set_margins(m_renderer, 0, 0, 0, 0);

--- a/xbmc/music/karaoke/karaokelyricstext.cpp
+++ b/xbmc/music/karaoke/karaokelyricstext.cpp
@@ -139,9 +139,9 @@ bool CKaraokeLyricsText::InitGraphics()
   if ( m_lyrics.empty() )
     return false;
 
-  CStdString fontPath = "special://home/media/Fonts/" + CSettings::Get().GetString("karaoke.font");
+  CStdString fontPath = URIUtils::AddFileToFolder("special://home/media/Fonts/", CSettings::Get().GetString("karaoke.font"));
   if (!XFILE::CFile::Exists(fontPath))
-      fontPath = "special://xbmc/media/Fonts/" + CSettings::Get().GetString("karaoke.font");
+      fontPath = URIUtils::AddFileToFolder("special://xbmc/media/Fonts/", CSettings::Get().GetString("karaoke.font"));
   m_karaokeFont = g_fontManager.LoadTTF("__karaoke__", fontPath,
                   m_colorLyrics, 0, CSettings::Get().GetInt("karaoke.fontheight"), FONT_STYLE_BOLD );
   CGUIFont *karaokeBorder = g_fontManager.LoadTTF("__karaokeborder__", fontPath,

--- a/xbmc/music/karaoke/karaokelyricstext.cpp
+++ b/xbmc/music/karaoke/karaokelyricstext.cpp
@@ -139,7 +139,9 @@ bool CKaraokeLyricsText::InitGraphics()
   if ( m_lyrics.empty() )
     return false;
 
-  CStdString fontPath = "special://xbmc/media/Fonts/" + CSettings::Get().GetString("karaoke.font");
+  CStdString fontPath = "special://home/media/Fonts/" + CSettings::Get().GetString("karaoke.font");
+  if (!XFILE::CFile::Exists(fontPath))
+      fontPath = "special://xbmc/media/Fonts/" + CSettings::Get().GetString("karaoke.font");
   m_karaokeFont = g_fontManager.LoadTTF("__karaoke__", fontPath,
                   m_colorLyrics, 0, CSettings::Get().GetInt("karaoke.fontheight"), FONT_STYLE_BOLD );
   CGUIFont *karaokeBorder = g_fontManager.LoadTTF("__karaokeborder__", fontPath,

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -56,6 +56,7 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "windowing/WindowingFactory.h"
 #include "cores/IPlayer.h"
+#include "filesystem/File.h"
 
 #include <stdio.h>
 #include <algorithm>
@@ -401,8 +402,13 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       {
         CSingleLock lock (m_fontLock);
 
-        CStdString fontPath = "special://xbmc/media/Fonts/";
+        CStdString fontPath = "special://home/media/Fonts/";
         fontPath += CSettings::Get().GetString("subtitles.font");
+        if (!XFILE::CFile::Exists(fontPath))
+        {
+          fontPath = "special://xbmc/media/Fonts/";
+          fontPath += CSettings::Get().GetString("subtitles.font");
+        }
 
         // We scale based on PAL4x3 - this at least ensures all sizing is constant across resolutions.
         RESOLUTION_INFO pal(720, 576, 0);

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -50,6 +50,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "utils/URIUtils.h"
 #include "XBDateTime.h"
 #include "input/ButtonTranslator.h"
 #include "pvr/PVRManager.h"
@@ -402,13 +403,9 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       {
         CSingleLock lock (m_fontLock);
 
-        CStdString fontPath = "special://home/media/Fonts/";
-        fontPath += CSettings::Get().GetString("subtitles.font");
+        CStdString fontPath = URIUtils::AddFileToFolder("special://home/media/Fonts/", CSettings::Get().GetString("subtitles.font"));
         if (!XFILE::CFile::Exists(fontPath))
-        {
-          fontPath = "special://xbmc/media/Fonts/";
-          fontPath += CSettings::Get().GetString("subtitles.font");
-        }
+          fontPath = URIUtils::AddFileToFolder("special://xbmc/media/Fonts/", CSettings::Get().GetString("subtitles.font"));
 
         // We scale based on PAL4x3 - this at least ensures all sizing is constant across resolutions.
         RESOLUTION_INFO pal(720, 576, 0);


### PR DESCRIPTION
As the title says.

The GUI selection allows to pick fonts from "special://home/media/Fonts", so we should first look there for them at usage time, then fallback to "special://xbmc/media/Fonts".
