### PR TITLE
[FIX] CSimpleDoubleCache: do not change type of underlying cache

### DIFF
--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -334,7 +334,7 @@ void CSimpleDoubleCache::Reset(int64_t iSourcePosition, bool clearAnyway)
   }
   if (!m_pCacheOld)
   {
-    CSimpleFileCache *pCacheNew = new CSimpleFileCache();
+    CCacheStrategy *pCacheNew = m_pCache->CreateNew();
     if (pCacheNew->Open() != CACHE_RC_OK)
     {
       delete pCacheNew;


### PR DESCRIPTION
if user choice memory buffers via advancedsettings, old code silently will discard this and will create file cache. this effectively will burn a lot of ssd, or will slowdown anything of networked FS is used.
