### PR TITLE
Add a GUI message to let windows handle suspend/wakeup events to close their network/mysql connections

### DIFF
--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -133,6 +133,13 @@
 
 #define GUI_MSG_WINDOW_LOAD 43
 
+/*!
+ \brief Signal a window that the system is going to suspend or has just woke up
+ */
+#define GUI_MSG_SLEEP         44
+
+#define GUI_MSG_WAKE          45
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1049,3 +1049,19 @@ void CGUIWindowManager::DumpTextureUse()
   }
 }
 #endif
+
+void CGUIWindowManager::OnSleep()
+{
+    CLog::Log(LOGNOTICE, "%s: Going to sleep up", __FUNCTION__);
+
+    CGUIMessage msg(GUI_MSG_SLEEP, 0, 0);
+    this->SendMessage(msg);
+}
+
+void CGUIWindowManager::OnWake()
+{
+    CLog::Log(LOGNOTICE, "%s: Woke up", __FUNCTION__);
+
+    CGUIMessage msg(GUI_MSG_WAKE, 0, 0);
+    this->SendMessage(msg);
+}

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -141,6 +141,9 @@ public:
 #ifdef _DEBUG
   void DumpTextureUse();
 #endif
+  void OnSleep();
+  void OnWake();
+
 private:
   void RenderPass() const;
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -233,6 +233,12 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
         }
       }
     }
+  case GUI_MSG_SLEEP:
+    m_musicdatabase.Close();
+    break;
+  case GUI_MSG_WAKE:
+    m_musicdatabase.Open();
+    break;
   }
   return CGUIMediaWindow::OnMessage(message);
 }

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -248,12 +248,15 @@ void CPowerManager::OnSleep()
   g_application.StopShutdownTimer();
   g_application.StopScreenSaverTimer();
   g_application.CloseNetworkShares();
+  g_windowManager.OnSleep();
   CAEFactory::Suspend();
 }
 
 void CPowerManager::OnWake()
 {
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
+
+  g_windowManager.OnWake();
 
   // reset out timers
   g_application.ResetShutdownTimers();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -238,6 +238,12 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
   case GUI_MSG_SEARCH:
     OnSearch();
     break;
+  case GUI_MSG_SLEEP:
+    m_database.Close();
+    break;
+  case GUI_MSG_WAKE:
+    m_database.Open();
+    break;
   }
   return CGUIMediaWindow::OnMessage(message);
 }


### PR DESCRIPTION
A window having an open MySQL-connection when going to suspend will make XBMC freeze after wake up when the MySQL connection timed out in the meantime. (Observed and debugged on OpenELEC 3.1.7).
