### PR TITLE
[rbp/omxplayer] Go directly from executing to idle in OMX_Clock

### DIFF
--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -185,9 +185,6 @@ void OMXClock::OMXStateIdle(bool lock /* = true */)
   if(lock)
     Lock();
 
-  if(m_omx_clock.GetState() == OMX_StateExecuting)
-    m_omx_clock.SetStateForComponent(OMX_StatePause);
-
   if(m_omx_clock.GetState() != OMX_StateIdle)
     m_omx_clock.SetStateForComponent(OMX_StateIdle);
 


### PR DESCRIPTION
OMX spec says there's no need to go through pause state
