### PR TITLE
[rbp/omxplayer] Improve the player diagnostics overlay

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -376,6 +376,8 @@ protected:
   OMXClock m_av_clock;
 
   bool m_stepped;
+  int m_video_fifo;
+  int m_audio_fifo;
 
   CDVDOverlayContainer m_overlayContainer;
 


### PR DESCRIPTION
Show the values that determine when gpu underrun occurs in player diagnostics overlay.
