### PR TITLE
dvdplayer: fix stuttering when changing audio track

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2133,9 +2133,7 @@ void CDVDPlayer::HandleMessages()
           }
           else
           {
-            CloseAudioStream(false);
             OpenAudioStream(st.id, st.source);
-            m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true, true, true));
           }
         }
       }


### PR DESCRIPTION
I may be wrong but I don't see any reason for closing/re-opening audio stream when changing an audio track. audio player can handle codec changes by itself.
should fix trac 13322: very choppy video after switching Audio Track (rather old ticket)
