### PR TITLE
[rbp/omxplayer] Enable zoom and pixel ratio in video OSD

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -4436,6 +4436,8 @@ void COMXPlayer::GetRenderFeatures(std::vector<int> &renderFeatures)
 {
   renderFeatures.push_back(RENDERFEATURE_STRETCH);
   renderFeatures.push_back(RENDERFEATURE_CROP);
+  renderFeatures.push_back(RENDERFEATURE_PIXEL_RATIO);
+  renderFeatures.push_back(RENDERFEATURE_ZOOM);
 }
 
 void COMXPlayer::GetDeinterlaceMethods(std::vector<int> &deinterlaceMethods)


### PR DESCRIPTION
They work. Why not enable.
