### PR TITLE
AE: fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -896,19 +896,12 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
     {
       outputFormat = inputFormat;
       outputFormat.m_dataFormat = AE_FMT_FLOATP;
+      outputFormat.m_sampleRate = 48000;
 
       if (g_advancedSettings.m_audioResample)
       {
         outputFormat.m_sampleRate = g_advancedSettings.m_audioResample;
         CLog::Log(LOGINFO, "CActiveAE::Configure - Forcing samplerate to %d", inputFormat.m_sampleRate);
-      }
-
-      // check for valid sampling rates
-      if (inputFormat.m_sampleRate != 48000 &&
-          inputFormat.m_sampleRate != 44100 &&
-          inputFormat.m_sampleRate != 32000)
-      {
-        outputFormat.m_sampleRate = 48000;
       }
 
       // setup encoder

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2356,7 +2356,7 @@ IAEStream *CActiveAE::MakeStream(enum AEDataFormat dataFormat, unsigned int samp
 
   Message *reply;
   if (m_dataPort.SendOutMessageSync(CActiveAEDataProtocol::NEWSTREAM,
-                                    &reply,1000,
+                                    &reply,10000,
                                     &msg, sizeof(MsgStreamNew)))
   {
     bool success = reply->signal == CActiveAEControlProtocol::ACC ? true : false;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -1182,11 +1182,7 @@ initialize:
 
   REFERENCE_TIME audioSinkBufferDurationMsec, hnsLatency;
 
-  /* Get m_audioSinkBufferSizeMsec from advancedsettings.xml */
-  audioSinkBufferDurationMsec = (REFERENCE_TIME)g_advancedSettings.m_audioSinkBufferDurationMsec * 10000;
-
-  /* Use advancedsetting value for buffer size as long as it's over minimum set above */
-  audioSinkBufferDurationMsec = (REFERENCE_TIME)std::max(audioSinkBufferDurationMsec, (REFERENCE_TIME)500000);
+  audioSinkBufferDurationMsec = (REFERENCE_TIME)500000;
   audioSinkBufferDurationMsec = (REFERENCE_TIME)((audioSinkBufferDurationMsec / format.m_frameSize) * format.m_frameSize); //even number of frames
 
   if (AE_IS_RAW(format.m_dataFormat))

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -118,7 +118,6 @@ void CAdvancedSettings::Initialize()
   m_audioAudiophile = false;
   m_allChannelStereo = false;
   m_streamSilence = false;
-  m_audioSinkBufferDurationMsec = 50;
 
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
   m_limiterHold = 0.025f;
@@ -495,7 +494,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "allchannelstereo", m_allChannelStereo);
     XMLUtils::GetBoolean(pElement, "streamsilence", m_streamSilence);
     XMLUtils::GetString(pElement, "transcodeto", m_audioTranscodeTo);
-    XMLUtils::GetInt(pElement, "audiosinkbufferdurationmsec", m_audioSinkBufferDurationMsec);
 
     TiXmlElement* pAudioExcludes = pElement->FirstChildElement("excludefromlisting");
     if (pAudioExcludes)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -134,7 +134,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_audioAudiophile;
     bool m_allChannelStereo;
     bool m_streamSilence;
-    int m_audioSinkBufferDurationMsec;
     CStdString m_audioTranscodeTo;
     float m_limiterHold;
     float m_limiterRelease;


### PR DESCRIPTION
fix of three issues:
- increase timeout when waiting for stream to be created, should not fail unless something goes wrong completely
- remove advancedsettings audioSinkBufferDurationMsec, a too large buffer does harm. @arnova already felt into this trap
- fix transcoding for sample rates != 48khz
