### PR TITLE
[settings] Fix memory corruption caused by resolution sorting

### DIFF
--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -149,9 +149,11 @@ static void AddResolution(vector<RESOLUTION_WHR> &resolutions, unsigned int addi
 
 static bool resSortPredicate(RESOLUTION_WHR i, RESOLUTION_WHR j)
 {
+  // note: this comparison must obey "strict weak ordering"
+  // a "!=" on the flags comparison resulted in memory corruption
   return (    i.width < j.width
           || (i.width == j.width && i.height < j.height)
-          || (i.width == j.width && i.height == j.height && i.flags != j.flags) );
+          || (i.width == j.width && i.height == j.height && i.flags < j.flags) );
 }
 
 vector<RESOLUTION_WHR> CWinSystemBase::ScreenResolutions(int screen, float refreshrate)


### PR DESCRIPTION
This is possibly the most subtle bug I've seen.
What I've seen over last couple of weeks is random memory corruption
failures when browsing the settings/video output window.

I tracked it down to the sort function in CWinSystemBase::ScreenResolutions.
But why? Everything looked fine.

Eventually spotted it. The compare function doesn't obey strict weak ordering.
std::sort considers a reasonable response to that is to corrupt memory.

Here's a description from someone else who hit a similar bug:
http://schneide.wordpress.com/2010/11/01/bug-hunting-fun-with-stdsort/
