### PR TITLE
Fix win32 relative home path

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -54,6 +54,13 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
+    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
+    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
+    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
+    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Template|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -397,12 +397,17 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
     //expand potential relative path to full path
     CStdStringW strPathW;
     g_charsetConverter.utf8ToW(strPath, strPathW, false);
+    AddExtraLongPathPrefix(strPathW);
     const unsigned int bufSize = GetFullPathNameW(strPathW, 0, NULL, NULL);
     if (bufSize != 0)
     {
       wchar_t * buf = new wchar_t[bufSize];
       if (GetFullPathNameW(strPathW, bufSize, buf, NULL) <= bufSize-1)
-        g_charsetConverter.wToUTF8(buf, strPath);
+      {
+        std::wstring expandedPathW(buf);
+        RemoveExtraLongPathPrefix(expandedPathW);
+        g_charsetConverter.wToUTF8(expandedPathW, strPath);
+      }
 
       delete [] buf;
     }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1498,6 +1498,30 @@ bool CUtil::MakeShortenPath(CStdString StrInput, CStdString& StrOutput, int iTex
   return true;
 }
 
+#ifdef TARGET_WINDOWS
+bool CUtil::AddExtraLongPathPrefix(std::wstring& path)
+{
+  const wchar_t* const str = path.c_str();
+  if (path.length() < 4 || str[0] != L'\\' || str[1] != L'\\' || str[3] != L'\\' || str[2] != L'?')
+  {
+    path.insert(0, L"\\\\?\\");
+    return true;
+  }
+  return false;
+}
+
+bool CUtil::RemoveExtraLongPathPrefix(std::wstring& path)
+{
+  const wchar_t* const str = path.c_str();
+  if (path.length() >= 4 && str[0] == L'\\' && str[1] == L'\\' && str[3] == L'\\' && str[2] == L'?')
+  {
+    path.erase(0, 4);
+    return true;
+  }
+  return false;
+}
+#endif // TARGET_WINDOWS
+
 bool CUtil::SupportsWriteFileOperations(const CStdString& strPath)
 {
   // currently only hd, smb, nfs, afp and dav support delete and rename

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -392,7 +392,7 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
   strPath = CEnvironment::getenv(strTarget);
 
 #ifdef TARGET_WINDOWS
-  if (!strPath.IsEmpty())
+  if (strPath.find("..") != std::string::npos)
   {
     //expand potential relative path to full path
     CStdStringW strPathW;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -397,8 +397,8 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
     //expand potential relative path to full path
     CStdStringW strPathW;
     g_charsetConverter.utf8ToW(strPath, strPathW, false);
-    const int bufSize = GetFullPathNameW(strPathW, 0, NULL, NULL);
-    if (bufSize > 0)
+    const unsigned int bufSize = GetFullPathNameW(strPathW, 0, NULL, NULL);
+    if (bufSize != 0)
     {
       wchar_t * buf = new wchar_t[bufSize];
       if (GetFullPathNameW(strPathW, bufSize, buf, NULL) <= bufSize-1)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -401,7 +401,7 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
     if (bufSize > 0)
     {
       wchar_t * buf = new wchar_t[bufSize];
-      if (GetFullPathNameW(strPathW, bufSize, buf, NULL) == bufSize-1)
+      if (GetFullPathNameW(strPathW, bufSize, buf, NULL) <= bufSize-1)
         g_charsetConverter.wToUTF8(buf, strPath);
 
       delete [] buf;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -144,6 +144,10 @@ public:
 
   static double AlbumRelevance(const CStdString& strAlbumTemp1, const CStdString& strAlbum1, const CStdString& strArtistTemp1, const CStdString& strArtist1);
   static bool MakeShortenPath(CStdString StrInput, CStdString& StrOutput, int iTextMaxLength);
+#ifdef TARGET_WINDOWS
+  static bool AddExtraLongPathPrefix(std::wstring& path);
+  static bool RemoveExtraLongPathPrefix(std::wstring& path);
+#endif // TARGET_WINDOWS
   /*! \brief Checks wether the supplied path supports Write file operations (e.g. Rename, Delete, ...)
 
    \param strPath the path to be checked


### PR DESCRIPTION
Workaround for win32 behavior with overestimate required buffer size.
Additionally, now possible to skip [one preparation step](http://wiki.xbmc.org/index.php?title=HOW-TO:Compile_XBMC_for_Windows#Running.2FDebugging_XBMC_from_Visual_C.2B.2B_Express_2010) for build and run XBMC on Windows.
