### PR TITLE
CDVDDemuxPVRClient: zero-init props in RequestStreams()

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -325,7 +325,7 @@ void CDVDDemuxPVRClient::RequestStreams()
   if (!g_PVRManager.IsStarted())
     return;
 
-  PVR_STREAM_PROPERTIES props;
+  PVR_STREAM_PROPERTIES props = {};
   m_pvrClient->GetStreamProperties(&props);
   unsigned int i;
 


### PR DESCRIPTION
When not cleared upon declaration and the following m_pvrClient->GetStreamProperties(&props) fails for some reason (non-working or busy client backends might just abort without touching props) and doesn't init/fill props with proper values, the iteration through props will run with random stuff, leading to funny things and very likely crash.
