### PR TITLE
changed: Pause low priority jobs when loading/showing pictures

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4950,8 +4950,13 @@ void CApplication::ProcessSlow()
   }
 #endif
 
-  // Resume low priority jobs when current item is not video
-  if (!CurrentFileItem().IsVideo())
+  // Temporarely pause pausable jobs when viewing video/picture
+  int currentWindow = g_windowManager.GetActiveWindow();
+  if (CurrentFileItem().IsVideo() || CurrentFileItem().IsPicture() || currentWindow == WINDOW_FULLSCREEN_VIDEO || currentWindow == WINDOW_SLIDESHOW)
+  {
+    CJobManager::GetInstance().PauseJobs();
+  }
+  else
   {
     CJobManager::GetInstance().UnPauseJobs();
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3950,7 +3950,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
      */
     if (item.IsVideo())
     {
-      CJobManager::GetInstance().Pause(CJob::PRIORITY_LOW); // Pause any low priority jobs
+      CJobManager::GetInstance().PauseJobs();
     }
 
     // don't hold graphicscontext here since player
@@ -4953,7 +4953,7 @@ void CApplication::ProcessSlow()
   // Resume low priority jobs when current item is not video
   if (!CurrentFileItem().IsVideo())
   {
-    CJobManager::GetInstance().UnPause(CJob::PRIORITY_LOW);
+    CJobManager::GetInstance().UnPauseJobs();
   }
 
   // Store our file state for use on close()

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -37,7 +37,7 @@ CTextureCache &CTextureCache::Get()
   return s_cache;
 }
 
-CTextureCache::CTextureCache()
+CTextureCache::CTextureCache() : CJobQueue(false, 1, CJob::PRIORITY_LOW_PAUSABLE)
 {
 }
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -302,7 +302,7 @@ bool PAPlayer::QueueNextFile(const CFileItem &file)
     CExclusiveLock lock(m_streamsLock);
     m_jobCounter++;
   }
-  CJobManager::GetInstance().AddJob(new CQueueNextFileJob(file, *this), this);
+  CJobManager::GetInstance().AddJob(new CQueueNextFileJob(file, *this), this, CJob::PRIORITY_NORMAL);
   return true;
 }
 

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -35,7 +35,7 @@
 using namespace XFILE;
 using namespace std;
 
-CPictureThumbLoader::CPictureThumbLoader() : CThumbLoader(), CJobQueue(true)
+CPictureThumbLoader::CPictureThumbLoader() : CThumbLoader(), CJobQueue(true, 1, CJob::PRIORITY_LOW_PAUSABLE)
 {
   m_regenerateThumbs = false;
 }

--- a/xbmc/utils/Job.h
+++ b/xbmc/utils/Job.h
@@ -106,7 +106,8 @@ public:
    \sa CJobManager
    */
   enum PRIORITY {
-    PRIORITY_LOW = 0,
+    PRIORITY_LOW_PAUSABLE = 0,
+    PRIORITY_LOW,
     PRIORITY_NORMAL,
     PRIORITY_HIGH
   };

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -315,13 +315,13 @@ bool CJobManager::IsProcessing(const CJob::PRIORITY &priority) const
   return false;
 }
 
-int CJobManager::IsProcessing(const std::string &pausedType) const
+int CJobManager::IsProcessing(const std::string &type) const
 {
   int jobsMatched = 0;
   CSingleLock lock(m_section);
   for(Processing::const_iterator it = m_processing.begin(); it < m_processing.end(); it++)
   {
-    if (pausedType == std::string(it->m_job->GetType()))
+    if (type == std::string(it->m_job->GetType()))
       jobsMatched++;
   }
   return jobsMatched;

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -175,9 +175,7 @@ CJobManager::CJobManager()
 {
   m_jobCounter = 0;
   m_running = true;
-  
-  for (unsigned int priority = CJob::PRIORITY_LOW; priority <= CJob::PRIORITY_HIGH; ++priority)
-    m_jobPause[priority] = false; // Set this priority to unpaused
+  m_pauseJobs = false;
 }
 
 void CJobManager::CancelJobs()
@@ -186,7 +184,7 @@ void CJobManager::CancelJobs()
   m_running = false;
 
   // clear any pending jobs
-  for (unsigned int priority = CJob::PRIORITY_LOW; priority <= CJob::PRIORITY_HIGH; ++priority)
+  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_HIGH; ++priority)
   {
     for_each(m_jobQueue[priority].begin(), m_jobQueue[priority].end(), mem_fun_ref(&CWorkItem::FreeJob));
     m_jobQueue[priority].clear();
@@ -234,7 +232,7 @@ void CJobManager::CancelJob(unsigned int jobID)
   CSingleLock lock(m_section);
 
   // check whether we have this job in the queue
-  for (unsigned int priority = CJob::PRIORITY_LOW; priority <= CJob::PRIORITY_HIGH; ++priority)
+  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_HIGH; ++priority)
   {
     JobQueue::iterator i = find(m_jobQueue[priority].begin(), m_jobQueue[priority].end(), jobID);
     if (i != m_jobQueue[priority].end())
@@ -272,9 +270,10 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
 CJob *CJobManager::PopJob()
 {
   CSingleLock lock(m_section);
-  for (int priority = CJob::PRIORITY_HIGH; priority >= CJob::PRIORITY_LOW; --priority)
+  for (int priority = CJob::PRIORITY_HIGH; priority >= CJob::PRIORITY_LOW_PAUSABLE; --priority)
   {
-    if (m_jobPause[priority]) // In case this priority is paused, skip it
+    // Check whether we're pausing pausable jobs
+    if (priority == CJob::PRIORITY_LOW_PAUSABLE && m_pauseJobs)
       continue;
 
     if (m_jobQueue[priority].size() && m_processing.size() < GetMaxWorkers(CJob::PRIORITY(priority)))
@@ -292,22 +291,16 @@ CJob *CJobManager::PopJob()
   return NULL;
 }
 
-void CJobManager::Pause(const CJob::PRIORITY &priority)
+void CJobManager::PauseJobs()
 {
   CSingleLock lock(m_section);
-  m_jobPause[priority] = true;
+  m_pauseJobs = true;
 }
 
-void CJobManager::UnPause(const CJob::PRIORITY &priority)
+void CJobManager::UnPauseJobs()
 {
   CSingleLock lock(m_section);
-  m_jobPause[priority] = false;
-}
-
-bool CJobManager::IsPaused(const CJob::PRIORITY &priority) const
-{
-  CSingleLock lock(m_section);
-  return m_jobPause[priority];
+  m_pauseJobs = false;
 }
 
 bool CJobManager::IsProcessing(const CJob::PRIORITY &priority) const

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -235,11 +235,10 @@ public:
 
   /*!
    \brief Checks to see if any jobs of a specific type are currently processing.
-   \param pausedType Job type to search for
+   \param type Job type to search for
    \return Number of matching jobs
-   \sa Pause(), UnPause(), IsPaused()
    */
-  int IsProcessing(const std::string &pausedType) const;
+  int IsProcessing(const std::string &type) const;
 
   /*!
    \brief Suspends queueing of jobs with priority PRIORITY_LOW_PAUSABLE until unpaused

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -242,33 +242,23 @@ public:
   int IsProcessing(const std::string &pausedType) const;
 
   /*!
-   \brief Suspends queueing of the specified priority until unpaused
+   \brief Suspends queueing of jobs with priority PRIORITY_LOW_PAUSABLE until unpaused
    Useful to (for ex) stop queuing thumb jobs during video start/playback.
    Does not affect currently processing jobs, use IsProcessing to see if any need to be waited on
-   \param priority only jobs of this priority will be affected
-   \sa UnPause(), IsPaused(), IsProcessing()
+   \sa UnPauseJobs()
    */
-  void Pause(const CJob::PRIORITY &priority);
+  void PauseJobs();
 
   /*!
-   \brief Resumes queueing of the specified priority
-   \param priority only jobs of this priority will be affected
-   \sa Pause(), IsPaused(), IsProcessing()
+   \brief Resumes queueing of (previously paused) jobs with priority PRIORITY_LOW_PAUSABLE
+   \sa PauseJobs()
    */
-  void UnPause(const CJob::PRIORITY &priority);
-
-  /*!
-   \brief Checks if jobs of specified priority are paused.
-   \param priority only jobs of this priority will be affected
-   \sa Pause(), UnPause(), IsProcessing()
-   */
-  bool IsPaused(const CJob::PRIORITY &priority) const;
+  void UnPauseJobs();
 
   /*!
    \brief Checks to see if any jobs with specific priority are currently processing.
    \param priority to search for
    \return true if processing jobs, else returns false
-   \sa Pause(), UnPause(), IsPaused()
    */
   bool IsProcessing(const CJob::PRIORITY &priority) const;
 
@@ -326,7 +316,7 @@ private:
   typedef std::vector<CJobWorker*> Workers;
 
   JobQueue   m_jobQueue[CJob::PRIORITY_HIGH+1];
-  bool       m_jobPause[CJob::PRIORITY_HIGH+1];
+  bool       m_pauseJobs;
   Processing m_processing;
   Workers    m_workers;
 

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -143,7 +143,7 @@ bool CThumbExtractor::DoWork()
 }
 
 CVideoThumbLoader::CVideoThumbLoader() :
-  CThumbLoader(), CJobQueue(true)
+  CThumbLoader(), CJobQueue(true, 1, CJob::PRIORITY_LOW_PAUSABLE)
 {
   m_videoDatabase = new CVideoDatabase();
 }


### PR DESCRIPTION
This fixes performance issues on mainly low powered (Atom/ARM) devices where the background image(picture) caching is forcing the GUI to its knees making advancing to eg. the next picture an extremely slow operation. Furthermore tweaked the previous implementation a bit so that the job pausing/unpausing is handled at the same location.
