### PR TITLE
[win] Fix default value of vertical sync setting from disable to always.

### DIFF
--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -38,6 +38,11 @@
           <requirement negated="true">HAS_GL</requirement>
         </setting>
       </group>
+      <group id="3">
+        <setting id="videoscreen.vsync">
+          <default>2</default> <!-- VSYNC_ALWAYS -->
+        </setting>
+      </group>
     </category>
     <category id="audiooutput" label="772" help="36360">
       <group id="2">


### PR DESCRIPTION
By default vsync setting set to VSYNC_DRIVER what are not supported on some platforms, so default value of vsync setting is VSYNC_DISABLED.

PR change the default value of videoscreen.vsync setting to VSYNC_ALWAYS on windows platform.
