### PR TITLE
UPower: enable m_CanPowerdown and m_CanReboot if ConsoleKit is not insta...

### DIFF
--- a/xbmc/powermanagement/linux/UPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/UPowerSyscall.cpp
@@ -83,8 +83,8 @@ CUPowerSyscall::CUPowerSyscall()
     m_connection = NULL;
   }
 
-  m_CanPowerdown = false;
-  m_CanReboot    = false;
+  m_CanPowerdown = true;
+  m_CanReboot    = true;
 
   UpdateCapabilities();
 


### PR DESCRIPTION
...lled but UPower is avaible. in this case we fallback to the exitcode method so we should show the Poweroff/reboot menu.
