### PR TITLE
libdvdnav runs dvdread-config to update CFLAGS and LDFLAGS with libdirs,...

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2725,7 +2725,6 @@ XB_CONFIG_MODULE([lib/libdvd/libdvdread], [
     --disable-strip \
     --disable-opts \
     --cc="$CC" &&
-  $MAKE dvdread-config &&
   mkdir -p `pwd`/../includes/dvdread
   cp `pwd`/../libdvdread/src/*.h `pwd`/../includes/dvdread
   cp `pwd`/../libdvdread/src/dvdread/*.h `pwd`/../includes/dvdread
@@ -2735,7 +2734,7 @@ XB_CONFIG_MODULE([lib/libdvd/libdvdnav], [
   ./configure2 \
     --extra-cflags="$CFLAGS $DVDREAD_CFLAGS -I`pwd`/../includes" \
     --extra-ldflags="-L`pwd`/../libdvdread/obj" \
-    --with-dvdread-config="`pwd`/../libdvdread/obj/dvdread-config" \
+    --with-dvdread-config="`pwd`/../dvdread-config" \
     --prefix="${prefix}" --includedir="${includedir}" --libdir="${libdir}" --datadir="${datadir}" \
     --host=$host_alias \
     --build=$build_alias \

--- a/lib/libdvd/build-xbmc-win32.sh
+++ b/lib/libdvd/build-xbmc-win32.sh
@@ -64,7 +64,7 @@ echo "***** Building libdvdnav *****"
       --disable-shared \
       --enable-static \
       --extra-cflags="-D_XBMC -DNDEBUG -I`pwd`/../includes" \
-      --with-dvdread-config="`pwd`/../libdvdread/obj/dvdread-config" \
+      --with-dvdread-config="`pwd`/../dvdread-config" \
       --disable-debug
 mkdir -p ../includes/dvdnav
 cp ../libdvdnav/src/dvdnav/*.h ../includes/dvdnav

--- a/lib/libdvd/dvdread-config
+++ b/lib/libdvd/dvdread-config
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# this configfile is based on the original libdvdread config
+# 'dvdread-config' but stripped down to not output the include
+# and libdirs to not break crosscompiling with including
+# system includes and libraries
+
+prefix=/usr
+dvdreadlib="-ldvdread"
+
+usage()
+{
+	cat <<EOF
+Usage: dvdread-config [OPTIONS] [LIBRARIES]
+Options:
+	[--prefix[=DIR]]
+        [--libs]
+	[--cflags]
+EOF
+	exit $1
+}
+
+if test $# -eq 0; then
+	usage 1 1>&2
+fi
+
+while test $# -gt 0; do
+  case "$1" in
+  -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
+  *) optarg= ;;
+  esac
+
+  case $1 in
+    --prefix)
+      echo_prefix=yes
+      ;;
+    --cflags)
+      echo_cflags=yes
+      ;;
+    --libs)
+      echo_libs=yes
+      ;;
+    *)
+      usage 1 1>&2
+      ;;
+  esac
+  shift
+done
+
+if test "$echo_prefix" = "yes"; then
+	echo $prefix
+fi
+
+if test "$echo_cflags" = "yes"; then
+      echo $extracflags
+fi
+
+if test "$echo_libs" = "yes"; then
+      echo $dvdreadlib
+fi


### PR DESCRIPTION
... includirs and libraries but wrongly with locations on the buildsystem. this breaks crosscompiling. We fix this with providing a own 'dvdread-config' file which dont inject /usr/include and /usr/lib in our *CFLAGS.
