### PR TITLE
Move Add/RemoveExtraLongPathPrefix functions to WIN32Util class

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -397,7 +397,7 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
     //expand potential relative path to full path
     CStdStringW strPathW;
     g_charsetConverter.utf8ToW(strPath, strPathW, false);
-    AddExtraLongPathPrefix(strPathW);
+    CWIN32Util::AddExtraLongPathPrefix(strPathW);
     const unsigned int bufSize = GetFullPathNameW(strPathW, 0, NULL, NULL);
     if (bufSize != 0)
     {
@@ -405,7 +405,7 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
       if (GetFullPathNameW(strPathW, bufSize, buf, NULL) <= bufSize-1)
       {
         std::wstring expandedPathW(buf);
-        RemoveExtraLongPathPrefix(expandedPathW);
+        CWIN32Util::RemoveExtraLongPathPrefix(expandedPathW);
         g_charsetConverter.wToUTF8(expandedPathW, strPath);
       }
 
@@ -1502,30 +1502,6 @@ bool CUtil::MakeShortenPath(CStdString StrInput, CStdString& StrOutput, int iTex
   StrOutput = StrInput;
   return true;
 }
-
-#ifdef TARGET_WINDOWS
-bool CUtil::AddExtraLongPathPrefix(std::wstring& path)
-{
-  const wchar_t* const str = path.c_str();
-  if (path.length() < 4 || str[0] != L'\\' || str[1] != L'\\' || str[3] != L'\\' || str[2] != L'?')
-  {
-    path.insert(0, L"\\\\?\\");
-    return true;
-  }
-  return false;
-}
-
-bool CUtil::RemoveExtraLongPathPrefix(std::wstring& path)
-{
-  const wchar_t* const str = path.c_str();
-  if (path.length() >= 4 && str[0] == L'\\' && str[1] == L'\\' && str[3] == L'\\' && str[2] == L'?')
-  {
-    path.erase(0, 4);
-    return true;
-  }
-  return false;
-}
-#endif // TARGET_WINDOWS
 
 bool CUtil::SupportsWriteFileOperations(const CStdString& strPath)
 {

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -144,10 +144,6 @@ public:
 
   static double AlbumRelevance(const CStdString& strAlbumTemp1, const CStdString& strAlbum1, const CStdString& strArtistTemp1, const CStdString& strArtist1);
   static bool MakeShortenPath(CStdString StrInput, CStdString& StrOutput, int iTextMaxLength);
-#ifdef TARGET_WINDOWS
-  static bool AddExtraLongPathPrefix(std::wstring& path);
-  static bool RemoveExtraLongPathPrefix(std::wstring& path);
-#endif // TARGET_WINDOWS
   /*! \brief Checks wether the supplied path supports Write file operations (e.g. Rename, Delete, ...)
 
    \param strPath the path to be checked

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -495,6 +495,28 @@ CStdString CWIN32Util::SmbToUnc(const CStdString &strPath)
   return strRetPath;
 }
 
+bool CWIN32Util::AddExtraLongPathPrefix(std::wstring& path)
+{
+  const wchar_t* const str = path.c_str();
+  if (path.length() < 4 || str[0] != L'\\' || str[1] != L'\\' || str[3] != L'\\' || str[2] != L'?')
+  {
+    path.insert(0, L"\\\\?\\");
+    return true;
+  }
+  return false;
+}
+
+bool CWIN32Util::RemoveExtraLongPathPrefix(std::wstring& path)
+{
+  const wchar_t* const str = path.c_str();
+  if (path.length() >= 4 && str[0] == L'\\' && str[1] == L'\\' && str[3] == L'\\' && str[2] == L'?')
+  {
+    path.erase(0, 4);
+    return true;
+  }
+  return false;
+}
+
 void CWIN32Util::ExtendDllPath()
 {
   CStdString strEnv;

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -59,6 +59,8 @@ public:
   static CStdString GetProfilePath();
   static CStdString UncToSmb(const CStdString &strPath);
   static CStdString SmbToUnc(const CStdString &strPath);
+  static bool AddExtraLongPathPrefix(std::wstring& path);
+  static bool RemoveExtraLongPathPrefix(std::wstring& path);
   static void ExtendDllPath();
   static HRESULT ToggleTray(const char cDriveLetter='\0');
   static HRESULT EjectTray(const char cDriveLetter='\0');


### PR DESCRIPTION
As requested, correction for #3189
