### PR TITLE
ActiveAE: fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1237,20 +1237,25 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
   else
   {
     format.m_dataFormat = AE_FMT_FLOAT;
-    switch (settings.channels)
+    if ((format.m_channelLayout.Count() > 2) ||
+         settings.stereoupmix ||
+         !g_advancedSettings.m_audioAudiophile)
     {
-      default:
-      case  0: format.m_channelLayout = AE_CH_LAYOUT_2_0; break;
-      case  1: format.m_channelLayout = AE_CH_LAYOUT_2_0; break;
-      case  2: format.m_channelLayout = AE_CH_LAYOUT_2_1; break;
-      case  3: format.m_channelLayout = AE_CH_LAYOUT_3_0; break;
-      case  4: format.m_channelLayout = AE_CH_LAYOUT_3_1; break;
-      case  5: format.m_channelLayout = AE_CH_LAYOUT_4_0; break;
-      case  6: format.m_channelLayout = AE_CH_LAYOUT_4_1; break;
-      case  7: format.m_channelLayout = AE_CH_LAYOUT_5_0; break;
-      case  8: format.m_channelLayout = AE_CH_LAYOUT_5_1; break;
-      case  9: format.m_channelLayout = AE_CH_LAYOUT_7_0; break;
-      case 10: format.m_channelLayout = AE_CH_LAYOUT_7_1; break;
+      switch (settings.channels)
+      {
+        default:
+        case  0: format.m_channelLayout = AE_CH_LAYOUT_2_0; break;
+        case  1: format.m_channelLayout = AE_CH_LAYOUT_2_0; break;
+        case  2: format.m_channelLayout = AE_CH_LAYOUT_2_1; break;
+        case  3: format.m_channelLayout = AE_CH_LAYOUT_3_0; break;
+        case  4: format.m_channelLayout = AE_CH_LAYOUT_3_1; break;
+        case  5: format.m_channelLayout = AE_CH_LAYOUT_4_0; break;
+        case  6: format.m_channelLayout = AE_CH_LAYOUT_4_1; break;
+        case  7: format.m_channelLayout = AE_CH_LAYOUT_5_0; break;
+        case  8: format.m_channelLayout = AE_CH_LAYOUT_5_1; break;
+        case  9: format.m_channelLayout = AE_CH_LAYOUT_7_0; break;
+        case 10: format.m_channelLayout = AE_CH_LAYOUT_7_1; break;
+      }
     }
 
     if (m_settings.mode == AUDIO_IEC958 && format.m_sampleRate > 48000)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -423,8 +423,9 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           CActiveAEStream *stream;
           stream = *(CActiveAEStream**)msg->data;
           stream->m_paused = true;
-          if (m_streams.size() == 1)
+          if (stream->m_paused != true && m_streams.size() == 1)
             FlushEngine();
+          stream->m_paused = true;
           return;
         case CActiveAEControlProtocol::RESUMESTREAM:
           stream = *(CActiveAEStream**)msg->data;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -899,12 +899,6 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       outputFormat.m_dataFormat = AE_FMT_FLOATP;
       outputFormat.m_sampleRate = 48000;
 
-      if (g_advancedSettings.m_audioResample)
-      {
-        outputFormat.m_sampleRate = g_advancedSettings.m_audioResample;
-        CLog::Log(LOGINFO, "CActiveAE::Configure - Forcing samplerate to %d", inputFormat.m_sampleRate);
-      }
-
       // setup encoder
       if (!m_encoder)
       {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -261,7 +261,7 @@ protected:
   void ClearDiscardedBuffers();
   void SStopSound(CActiveAESound *sound);
   void DiscardSound(CActiveAESound *sound);
-  void ChangeResampleQuality();
+  void ChangeResamplers();
 
   bool RunStages();
   bool HasWork();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -145,6 +145,7 @@ CActiveAEBufferPoolResample::CActiveAEBufferPoolResample(AEAudioFormat inputForm
   m_resampleRatio = 1.0;
   m_resampleQuality = quality;
   m_changeResampler = false;
+  m_stereoUpmix = false;
 }
 
 CActiveAEBufferPoolResample::~CActiveAEBufferPoolResample()
@@ -152,7 +153,7 @@ CActiveAEBufferPoolResample::~CActiveAEBufferPoolResample()
   delete m_resampler;
 }
 
-bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap)
+bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, bool upmix)
 {
   CActiveAEBufferPool::Create(totaltime);
 
@@ -171,12 +172,15 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap)
                                 m_inputFormat.m_sampleRate,
                                 CActiveAEResample::GetAVSampleFormat(m_inputFormat.m_dataFormat),
                                 CAEUtil::DataFormatToUsedBits(m_inputFormat.m_dataFormat),
+                                upmix,
                                 remap ? &m_format.m_channelLayout : NULL,
                                 m_resampleQuality);
   }
 
   // store output sampling rate, needed when ratio gets changed
   m_outSampleRate = m_format.m_sampleRate;
+
+  m_stereoUpmix = upmix;
 
   return true;
 }
@@ -198,6 +202,7 @@ void CActiveAEBufferPoolResample::ChangeResampler()
                                 m_inputFormat.m_sampleRate,
                                 CActiveAEResample::GetAVSampleFormat(m_inputFormat.m_dataFormat),
                                 CAEUtil::DataFormatToUsedBits(m_inputFormat.m_dataFormat),
+                                m_stereoUpmix,
                                 NULL,
                                 m_resampleQuality);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -90,7 +90,7 @@ class CActiveAEBufferPoolResample : public CActiveAEBufferPool
 public:
   CActiveAEBufferPoolResample(AEAudioFormat inputFormat, AEAudioFormat outputFormat, AEQuality quality);
   virtual ~CActiveAEBufferPoolResample();
-  virtual bool Create(unsigned int totaltime, bool remap);
+  virtual bool Create(unsigned int totaltime, bool remap, bool upmix);
   void ChangeResampler();
   bool ResampleBuffers(unsigned int timestamp = 0);
   float GetDelay();
@@ -108,6 +108,7 @@ public:
   double m_resampleRatio;
   AEQuality m_resampleQuality;
   unsigned int m_outSampleRate;
+  bool m_stereoUpmix;
 };
 
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
@@ -36,7 +36,7 @@ CActiveAEResample::~CActiveAEResample()
   m_dllSwResample.Unload();
 }
 
-bool CActiveAEResample::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, CAEChannelInfo *remapLayout, AEQuality quality)
+bool CActiveAEResample::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, bool upmix, CAEChannelInfo *remapLayout, AEQuality quality)
 {
   if (!m_dllAvUtil.Load() || !m_dllSwResample.Load())
     return false;
@@ -109,7 +109,7 @@ bool CActiveAEResample::Init(uint64_t dst_chan_layout, int dst_channels, int dst
     }
   }
   // stereo upmix
-  else if (m_src_channels == 2 && m_dst_channels > 2)
+  else if (upmix && m_src_channels == 2 && m_dst_channels > 2)
   {
     memset(m_rematrix, 0, sizeof(m_rematrix));
     for (int out=0; out<m_dst_channels; out++)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
@@ -34,7 +34,7 @@ class CActiveAEResample
 public:
   CActiveAEResample();
   virtual ~CActiveAEResample();
-  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, CAEChannelInfo *remapLayout, AEQuality quality);
+  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, bool upmix, CAEChannelInfo *remapLayout, AEQuality quality);
   int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples);
   int64_t GetDelay(int64_t base);
   int GetBufferedSamples();


### PR DESCRIPTION
- don't flush engine if stream is already paused, fixes stuttering on start of pvr channels. pvr continuously pauses players while buffering
- don't allow to overwrite sampling rate for transcoding, it is nailed on 48khz
- makes no sense that we reopen a PCM sink when channel layout of input stream changes. instead open PCM sinks with user layout from beginning
