### PR TITLE
Avoid locking other Python threads when calling xbmc.executeJSONRPC

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -122,6 +122,7 @@ namespace XBMCAddon
     String executeJSONRPC(const char* jsonrpccommand)
     {
       TRACE;
+      DelayedCallGuard dg;
 #ifdef HAS_JSONRPC
       String ret;
 


### PR DESCRIPTION
Hello,

This one-liner fixes some Python locking issues that happen when calling executeJSONRPC on some specific situations.

If a call to executeJSONRPC triggers activity on another Python thread running on the same process space as XBMC (e.g. a query to an embedded HTTP server started from an addon), it will be blocked until the call to executeJSONRPC returns. Furthermore, the call will take some time to complete (probably due to a timeout), and will block processing on all Python threads for a while.

The addition of the DelayedCallGuard attempts to prevent that situation allowing Python threads to run while executeJSONRPC is being called.
