### PR TITLE
ApplicationPlayer: do Reset() directly on the member instead of the sharedptr

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -42,7 +42,9 @@ void CApplicationPlayer::ClosePlayer()
   if (player)
   {
     CloseFile();
-    player.reset();
+    // we need to do this directly on the member
+    CSingleLock lock(m_player_lock);
+    m_pPlayer.reset();
   }
 }
 


### PR DESCRIPTION
Doing Reset() on the smart/sharedptr didn't really reset things, which resulted in the effect that players (e.g. paplayer->dvdplayer) where not switched anymore when after application start music was played via paplayer, then a video was played (should be done with dvdplayer, but paplayer was kept). This fixes things introduced in PR#3200 by letting ClosePlayer() do it's cleanups with the sharedptr, but then (lock first) reset() the member directly. This still retains the fix #3200 was intended for and makes players switchable again.
