### PR TITLE
ActiveAE: Stream noise slidely louder. An AVR of a user already ignored it

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -819,7 +819,7 @@ void CActiveAESink::GenerateNoise()
     }
     while(R1 == 0.0f);
     
-    noise[i] = (float) sqrt( -2.0f * log( R1 )) * cos( 2.0f * PI * R2 ) * 0.00001;
+    noise[i] = (float) sqrt( -2.0f * log( R1 )) * cos( 2.0f * PI * R2 ) * 0.00001f;
   }
 
   AEDataFormat fmt = CActiveAEResample::GetAESampleFormat(m_sampleOfSilence.pkt->config.fmt, m_sampleOfSilence.pkt->config.bits_per_sample);


### PR DESCRIPTION
So, as you see in the code. We have to be as small as possible, but too small the avr will filter out and won't get the signal anymore. Too high, you might hear it.

I think that this pr is a good average. I cannot hear it anywhere on my setups.

If the next user complains, we have to include another av.xml setting to scale it with 10.0 (louder) and 0.0 (off)
