### PR TITLE
dvdplayer: fix accurate seek

### DIFF
--- a/lib/ffmpeg/libavcodec/h264.c
+++ b/lib/ffmpeg/libavcodec/h264.c
@@ -4523,8 +4523,7 @@ static int decode_nal_units(H264Context *h, const uint8_t *buf, int buf_size,
                     first_slice = hx->nal_unit_type;
                 }
 
-            // FIXME do not discard SEI id
-            if (avctx->skip_frame >= AVDISCARD_NONREF && h->nal_ref_idc == 0)
+            if (avctx->skip_frame >= AVDISCARD_NONREF && h->nal_ref_idc == 0 && h->nal_unit_type != NAL_SEI)
                 continue;
 
 again:

--- a/lib/ffmpeg/patches/0056-backport-h264-do-not-discard-NAL_SEI-when-skipping-frames.patch
+++ b/lib/ffmpeg/patches/0056-backport-h264-do-not-discard-NAL_SEI-when-skipping-frames.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/ffmpeg/libavcodec/h264.c b/lib/ffmpeg/libavcodec/h264.c
+index 85f2372..1cab49f 100644
+--- a/lib/ffmpeg/libavcodec/h264.c
++++ b/lib/ffmpeg/libavcodec/h264.c
+@@ -4523,8 +4523,7 @@ static int decode_nal_units(H264Context *h, const uint8_t *buf, int buf_size,
+                     first_slice = hx->nal_unit_type;
+                 }
+ 
+-            // FIXME do not discard SEI id
+-            if (avctx->skip_frame >= AVDISCARD_NONREF && h->nal_ref_idc == 0)
++            if (avctx->skip_frame >= AVDISCARD_NONREF && h->nal_ref_idc == 0 && h->nal_unit_type != NAL_SEI)
+                 continue;
+ 
+ again:


### PR DESCRIPTION
this is follow up from #3179
if we instruct ffmpeg to drop first frame, it also drops an I-Frame
