### PR TITLE
[rendercapture] Fix passthrough rendercapture interface

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1421,6 +1421,14 @@ bool CLinuxRendererGLES::RenderCapture(CRenderCapture* capture)
   if (!m_bValidated)
     return false;
 
+  // If rendered directly by the hardware
+  if (m_renderMethod & RENDER_BYPASS)
+  {
+    capture->BeginRender();
+    capture->EndRender();
+    return true;
+  }
+
   // save current video rect
   CRect saveSize = m_destRect;
   saveRotatedCoords();//backup current m_rotatedDestCoords

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -51,7 +51,7 @@ public:
   int GetGpuMem() { return m_gpu_mem; }
   void GetDisplaySize(int &width, int &height);
   // stride can be null for packed output
-  unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue);
+  unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue, bool video_only = true);
 
 private:
   DllBcmHost *m_DllBcmHost;

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -62,7 +62,7 @@ bool CScreenshotSurface::capture()
 {
 #if defined(TARGET_RASPBERRY_PI)
   g_RBP.GetDisplaySize(m_width, m_height);
-  m_buffer = g_RBP.CaptureDisplay(m_width, m_height, &m_stride, true);
+  m_buffer = g_RBP.CaptureDisplay(m_width, m_height, &m_stride, true, false);
   if (!m_buffer)
     return false;
 #elif defined(HAS_DX)


### PR DESCRIPTION
The RenderCapture function doesn't behave correctly for passthough video renderers,
and in fact segfaults on Pi when setting a bookmark.

There is no need to do a glReadPixels to get a video snapshot in the passthrough case,
so provide a shortcut.
