### PR TITLE
[rbp/omxplayer] Avoid too many calls to GPU

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -378,6 +378,8 @@ protected:
   bool m_stepped;
   int m_video_fifo;
   int m_audio_fifo;
+  double m_last_check_time;         // we periodically check for gpu underrun
+  double m_stamp;                   // last media stamp
 
   CDVDOverlayContainer m_overlayContainer;
 


### PR DESCRIPTION
We currently read the media time once per packet received from demuxer to determine gpu underrun.
We've found that TrueHD audio in particular produces ~1000 packets per second (whether it is the active track or not).
The cost of reading media time (from gpu) is high enough that 1000 calls per second makes us fail to keep up.
So, cache the media time, and only read it at most 50 times per second.
