### PR TITLE
[addons] add Gotham repositoy

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.xbmc.org"
 		name="XBMC.org Add-ons"
-		version="2.0.10"
+		version="2.1.10"
 		provider-name="Team XBMC">
   <requires>
     <import addon="xbmc.addon" version="12.0.0"/>
@@ -11,6 +11,13 @@
 		<info compressed="true">http://mirrors.xbmc.org/addons/frodo/addons.xml</info>
 		<checksum>http://mirrors.xbmc.org/addons/frodo/addons.xml.md5</checksum>
 		<datadir zip="true">http://mirrors.xbmc.org/addons/frodo</datadir>
+		<hashes>true</hashes>
+	</extension>
+	<extension point="xbmc.addon.repository"
+		name="XBMC.org Gotham Repository">
+		<info compressed="true">http://mirrors.xbmc.org/addons/gotham/addons.xml</info>
+		<checksum>http://mirrors.xbmc.org/addons/gotham/addons.xml.md5</checksum>
+		<datadir zip="true">http://mirrors.xbmc.org/addons/gotham</datadir>
 		<hashes>true</hashes>
 	</extension>
 	<extension point="xbmc.addon.metadata">


### PR DESCRIPTION
This allows us to start having Gotham specific addons. Especially for skins this will be needed.
By just adding another repo to the same file we avoid duplicating the entire repo and also needing to push to each one if it's frodo/gotham compatible.

If we deem needed we can always switch to a gotham only repo.
