### PR TITLE
[Fix] Fullscreen toggle during playback deadlock

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -235,6 +235,8 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
     RESOLUTION oldRes = GetCurrentResolution();
     RESOLUTION newRes = GetResolutionFromString(((CSettingString*)setting)->GetValue());
 
+    if (oldRes == newRes)
+      return true;
     SetCurrentResolution(newRes, false);
     g_graphicsContext.SetVideoResolution(newRes);
 


### PR DESCRIPTION
This PR fix the deadlock for toggle fullscreen during play video, at least for osx, should be a common problem.

according the callstacks, it should not popup to ask user confirm the resolution change, it maybe caused by the double callback of the onsettingchanging. A simple double check fixed it.

```
#18     0x00000001003196d6 in CGUIDialogYesNo::ShowAndGetInput(int, int, int, int, int, int, bool&, unsigned int) at /Users/ulion/Develop/xbmc.osx/xbmc/dialogs/GUIDialogYesNo.cpp:106
#19     0x00000001016b6223 in CDisplaySettings::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/DisplaySettings.cpp:227
#20     0x00000001016f645e in CSettingsManager::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:657
#21     0x00000001016f6230 in non-virtual thunk to CSettingsManager::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:696
#22     0x00000001016c8fdc in CSetting::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Setting.cpp:170
#23     0x00000001016cbbaf in CSettingString::SetValue(std::string const&) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Setting.cpp:934
#24     0x00000001016f85d3 in CSettingsManager::SetString(std::string const&, std::string const&) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:558
#25     0x0000000100caf56f in CSettings::SetString(std::string const&, std::string const&) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Settings.cpp:502
#26     0x00000001016b5ffe in CDisplaySettings::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/DisplaySettings.cpp:210
#27     0x00000001016f645e in CSettingsManager::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:657
#28     0x00000001016f6230 in non-virtual thunk to CSettingsManager::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:696
#29     0x00000001016c8fdc in CSetting::OnSettingChanging(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Setting.cpp:170
#30     0x00000001016cc500 in CSettingInt::SetValue(int) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Setting.cpp:573
#31     0x00000001016cceb2 in CSettingInt::UpdateDynamicOptions() at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Setting.cpp:623
#32     0x00000001016f7dc4 in CSettingsManager::UpdateSettingByDependency(std::string const&, CSettingDependency const&) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:938
#33     0x00000001016f821e in CSettingsManager::OnSettingChanged(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:688
#34     0x00000001016f7e70 in non-virtual thunk to CSettingsManager::OnSettingChanged(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:920
#35     0x00000001016c907f in CSetting::OnSettingChanged(CSetting const*) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Setting.cpp:178
#36     0x00000001016cbc7e in CSettingString::SetValue(std::string const&) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Setting.cpp:947
#37     0x00000001016f85d3 in CSettingsManager::SetString(std::string const&, std::string const&) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/SettingsManager.cpp:558
#38     0x0000000100caf56f in CSettings::SetString(std::string const&, std::string const&) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/Settings.cpp:502
#39     0x00000001016b7382 in CDisplaySettings::SetCurrentResolution(RESOLUTION, bool) at /Users/ulion/Develop/xbmc.osx/xbmc/settings/DisplaySettings.cpp:265
#40     0x0000000100cd9d2a in CGraphicContext::ToggleFullScreenRoot() at /Users/ulion/Develop/xbmc.osx/xbmc/guilib/GraphicContext.cpp:861
```
