### PR TITLE
[WIN32] fix/workaround: process events even when minimized and the scree...

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2803,7 +2803,11 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 {
   MEASURE_FUNCTION;
 
+  // windows needs the call to MessagePump in order to receive window messages
+  // calling MessagePump before or after the loop gives undesired behavior
+#if !defined(TARGET_WINDOWS)
   if (processEvents)
+#endif
   {
     // currently we calculate the repeat time (ie time from last similar keypress) just global as fps
     float frameTime = m_frameTime.GetElapsedSeconds();


### PR DESCRIPTION
...nsaver is running. Windows needs the call to the messagepump in order to receive the maximize event.
Calling MessagePump in an else branch of processEvents shows some screen corruption for a short time.
See: http://forum.xbmc.org/showthread.php?tid=170462
