### PR TITLE
screensaver: make musicviz triggered by screensaver-logic behave like a screensaver

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4483,17 +4483,14 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
     m_iScreenSaveLock = 0;
     ResetScreenSaverTimer();
 
-    if (m_screenSaver->ID() == "visualization")
-    {
-      // we can just continue as usual from vis mode
-      return false;
-    }
-    else if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim" || m_screenSaver->ID() == "screensaver.xbmc.builtin.black" || m_screenSaver->ID().empty())
+    if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim" || m_screenSaver->ID() == "screensaver.xbmc.builtin.black" || m_screenSaver->ID().empty())
       return true;
     else if (!m_screenSaver->ID().IsEmpty())
     { // we're in screensaver window
-      if (g_windowManager.GetActiveWindow() == WINDOW_SCREENSAVER)
+      if (g_windowManager.GetActiveWindow() == WINDOW_SCREENSAVER
+          || g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION)
         g_windowManager.PreviousWindow();  // show the previous window
+
       if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW)
         CApplicationMessenger::Get().SendAction(CAction(ACTION_STOP), WINDOW_SLIDESHOW);
     }
@@ -4587,7 +4584,9 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     else if (m_pPlayer->IsPlayingAudio() && CSettings::Get().GetBool("screensaver.usemusicvisinstead") && !CSettings::Get().GetString("musicplayer.visualisation").empty())
     { // activate the visualisation
       m_screenSaver.reset(new CScreenSaver("visualization"));
-      g_windowManager.ActivateWindow(WINDOW_VISUALISATION);
+      // prevent music info popup if vis is already running
+      if (g_windowManager.GetActiveWindow() != WINDOW_VISUALISATION)
+        g_windowManager.ActivateWindow(WINDOW_VISUALISATION);
       return;
     }
   }


### PR DESCRIPTION
This on one side will change the behaviour of the screensaver.usemusicvisinstead - System/Appearance/Screensaver/Use vis if playing audio - setting, but on the other side fix an inconsistency regarding application announcements:

The patch makes musicvisualisations activated via the screensaver logic behave like a "real" screensaver, in that any keyboard input or mouse movement will cancel it and return to the previous window. Manually triggered music vis isn't affected and will (still) prevent the screensaver and dpms stuff from kicking in.

Regarding the mentioned fix: I stumbled upon this while playing around with the python xbmc.Monitor.onScreensaver*() callbacks. All worked as expected, but as soon as a screensaver was triggered as music vis, I received the onScreensaverActivated() callback, but wouldn't ever receive an onScreensaverDeactivated() call when I stopped the screensaving/vis. The System.ScreenSaverActive bool however always returned the correct state.

The patch/PR should be taken as proposal/RFC and should receive some testing. Builds and seems to work good so far on linux.
