### PR TITLE
Put even more information in startup log

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -641,7 +641,8 @@ bool CApplication::Create()
   CProfilesManager::Get().Load();
 
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
-  CLog::Log(LOGNOTICE, "Starting XBMC (%s). Platform: %s", g_infoManager.GetVersion().c_str(), g_sysinfo.GetBuildTargetPlatformName().c_str());
+  CLog::Log(LOGNOTICE, "Starting XBMC (%s). Platform: %s %s %d-bit", g_infoManager.GetVersion().c_str(), g_sysinfo.GetBuildTargetCpuFamily().c_str(),
+      g_sysinfo.GetBuildTargetPlatformName().c_str(), g_sysinfo.GetXbmcBitness());
 
 /* Expand macro before stringify */
 #define STR_MACRO(x) #x
@@ -673,16 +674,17 @@ bool CApplication::Create()
 #else
   buildType = "Unknown";
 #endif
-  CLog::Log(LOGNOTICE, "Using %s XBMC build, compiled " __DATE__ " by %s for %s %s", buildType.c_str(), compilerStr.c_str(), g_sysinfo.GetBuildTargetPlatformName().c_str(), g_sysinfo.GetBuildTargetPlatformVersion().c_str());
+  CLog::Log(LOGNOTICE, "Using %s XBMC x%d build, compiled " __DATE__ " by %s for %s %s %d-bit %s", buildType.c_str(), g_sysinfo.GetXbmcBitness(), compilerStr.c_str(),
+      g_sysinfo.GetBuildTargetCpuFamily().c_str(), g_sysinfo.GetBuildTargetPlatformName().c_str(), g_sysinfo.GetXbmcBitness(), g_sysinfo.GetBuildTargetPlatformVersion().c_str());
 
 #if defined(TARGET_DARWIN_OSX)
-  CLog::Log(LOGNOTICE, "Running on Darwin OSX %s", g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Running on Darwin OSX %d-bit %s", g_sysinfo.GetKernelBitness(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_DARWIN_IOS)
-  CLog::Log(LOGNOTICE, "Running on Darwin iOS%s %s", g_sysinfo.IsAppleTV2() ? " (AppleTV2)" : "", g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Running on Darwin iOS %d-bit %s%s", g_sysinfo.GetKernelBitness(), g_sysinfo.IsAppleTV2() ? "(AppleTV2) " : "", g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_FREEBSD)
-  CLog::Log(LOGNOTICE, "Running on FreeBSD %s", g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Running on FreeBSD %d-bit %s", g_sysinfo.GetKernelBitness(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_POSIX)
-  CLog::Log(LOGNOTICE, "Running on Linux (%s, %s)", g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
+  CLog::Log(LOGNOTICE, "Running on Linux %d-bit (%s, %s)", g_sysinfo.GetKernelBitness(), g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "Running on %s", g_sysinfo.GetKernelVersion().c_str());
 #endif

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -689,7 +689,7 @@ bool CApplication::Create()
   CLog::Log(LOGNOTICE, "Running on %s", g_sysinfo.GetKernelVersion().c_str());
 #endif
   
-  CLog::Log(LOGNOTICE, "Host CPU: %s", g_cpuInfo.getCPUModel().c_str());
+  CLog::Log(LOGNOTICE, "Host CPU: %s, %d core%s available", g_cpuInfo.getCPUModel().c_str(), g_cpuInfo.getCPUCount(), (g_cpuInfo.getCPUCount()==1) ? "" : "s");
 #if defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "%s", CWIN32Util::GetResInfoString().c_str());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -865,6 +865,24 @@ std::string CSysInfo::GetBuildTargetPlatformVersion(void)
 #endif
 }
 
+std::string CSysInfo::GetBuildTargetCpuFamily(void)
+{
+#if defined(__thumb__) || defined(_M_ARMT) 
+  return "ARM (Thumb)";
+#elif defined(__arm__) || defined(_M_ARM) || defined (__aarch64__)
+  return "ARM";
+#elif defined(__mips__) || defined(mips) || defined(__mips)
+  return "MIPS";
+#elif defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64) || \
+   defined(i386) || defined(__i386) || defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(_M_IX86) || defined(_X86_)
+  return "x86";
+#elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__) || defined(__ppc__) || defined(__ppc64__) || defined(_M_PPC)
+  return "PowerPC";
+#else
+  return "unknown CPU family";
+#endif
+}
+
 
 CJob *CSysInfo::GetJob() const
 {

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -425,27 +425,36 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
   return m_WinVer;
 }
 
-bool CSysInfo::IsOS64bit()
+int CSysInfo::GetKernelBitness(void)
 {
 #ifdef TARGET_WINDOWS
   SYSTEM_INFO si;
   GetSystemInfo(&si);
   if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
-    return true;
+    return 64;
   
   BOOL (WINAPI *ptrIsWow64) (HANDLE, PBOOL);
   HMODULE hKernel32 = GetModuleHandleA("kernel32");
   if (hKernel32 == NULL)
-    return false; // Can't detect OS
+    return 0; // Can't detect OS
   ptrIsWow64 = (BOOL (WINAPI *) (HANDLE, PBOOL)) GetProcAddress(hKernel32, "IsWow64Process");
   BOOL wow64proc = FALSE;
   if (ptrIsWow64 == NULL || ptrIsWow64(GetCurrentProcess(), &wow64proc) == FALSE)
-    return false; // Can't detect OS
-  return wow64proc != FALSE;
-#else // TARGET_WINDOWS
-  // TODO: Implement Linux, FreeBSD, Android, OSX
-  return false;
-#endif // TARGET_WINDOWS
+    return 0; // Can't detect OS
+  return (wow64proc == FALSE) ? 32 : 64;
+#elif defined(TARGET_POSIX)
+  struct utsname un;
+  if (uname(&un) == 0)
+  {
+    std::string machine(un.machine);
+    if (machine == "x86_64" || machine == "amd64" || machine == "arm64" || machine == "aarch64" || machine == "ppc64" || machine == "ia64")
+      return 64;
+    return 32;
+  }
+  return 0; // can't detect
+#else
+  return 0; // unknown
+#endif
 }
 
 int CSysInfo::GetXbmcBitness(void)
@@ -492,7 +501,7 @@ CStdString CSysInfo::GetKernelVersion()
         strKernel.append(" Storage Server 2003");
       else if (osvi.wSuiteMask & VER_SUITE_WH_SERVER)
         strKernel.append(" Home Server");
-      else if (osvi.wProductType == VER_NT_WORKSTATION && IsOS64bit())
+      else if (osvi.wProductType == VER_NT_WORKSTATION && GetKernelBitness() == 64)
         strKernel.append(" XP Professional");
       else if (osvi.wProductType != VER_NT_WORKSTATION)
         strKernel.append(" Server 2003");
@@ -537,20 +546,14 @@ CStdString CSysInfo::GetKernelVersion()
       }
     }
 
-    if (IsOS64bit())
-      strKernel.append(" 64-bit");
-    else
-      strKernel.append(" 32-bit");
+    strKernel.append(StringUtils::Format(" %d-bit", GetKernelBitness()));
 
     strKernel.append(StringUtils::Format(", build %d", osvi.dwBuildNumber));
   }
   else
   {
     strKernel.append(" unknown");
-    if (IsOS64bit())
-      strKernel.append(" 64-bit");
-    else
-      strKernel.append(" 32-bit");
+    strKernel.append(StringUtils::Format(" %d-bit", GetKernelBitness()));
   }
 
   return strKernel;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -448,6 +448,19 @@ bool CSysInfo::IsOS64bit()
 #endif // TARGET_WINDOWS
 }
 
+int CSysInfo::GetXbmcBitness(void)
+{
+#if defined (__aarch64__) || defined(__arm64__) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64) || defined(__ppc64__)
+  return 64;
+#elif defined(__thumb__) || defined(_M_ARMT) || defined(__arm__) || defined(_M_ARM) || defined(__mips__) || defined(mips) || defined(__mips) || defined(i386) || \
+  defined(__i386) || defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(_M_IX86) || defined(_X86_) || defined(__powerpc) || \
+  defined(__powerpc__) || defined(__ppc__) || defined(_M_PPC)
+  return 32;
+#else
+  return 0; // Unknown
+#endif
+}
+
 CStdString CSysInfo::GetKernelVersion()
 {
 #if defined(TARGET_DARWIN)

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -121,6 +121,7 @@ public:
   static bool IsWindowsVersionAtLeast(WindowsVersion ver);
   static WindowsVersion GetWindowsVersion();
   static bool IsOS64bit();
+  static int GetXbmcBitness(void);
   static CStdString GetKernelVersion();
   CStdString GetCPUModel();
   CStdString GetCPUBogoMips();

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -120,7 +120,7 @@ public:
   static bool IsWindowsVersion(WindowsVersion ver);
   static bool IsWindowsVersionAtLeast(WindowsVersion ver);
   static WindowsVersion GetWindowsVersion();
-  static bool IsOS64bit();
+  static int GetKernelBitness(void);
   static int GetXbmcBitness(void);
   static CStdString GetKernelVersion();
   CStdString GetCPUModel();

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -136,6 +136,7 @@ public:
 
   static std::string GetBuildTargetPlatformName(void);
   static std::string GetBuildTargetPlatformVersion(void);
+  static std::string GetBuildTargetCpuFamily(void);
 
 protected:
   virtual CJob *GetJob() const;


### PR DESCRIPTION
Fill log with last part of information required to fully identify build and platform:
- target CPU family (x86, ARM...)
- XBMC bitness 32/64
- OS bitness 32/64
- Number of CPU cores
