### PR TITLE
Speed improvement for opening the movies library

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -346,9 +346,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_strPlot;
     ar >> m_strPictureURL.m_spoof;
     ar >> m_strPictureURL.m_xml;
-    m_strPictureURL.Parse();
     ar >> m_fanart.m_xml;
-    m_fanart.Unpack();
     ar >> m_strTitle;
     ar >> m_strSortTitle;
     ar >> m_strVotes;
@@ -356,6 +354,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_strTrailer;
     int iCastSize;
     ar >> iCastSize;
+    m_cast.reserve(iCastSize);
     for (int i=0;i<iCastSize;++i)
     {
       SActorInfo info;


### PR DESCRIPTION
On all but the first time of opening the movies library, the CFileItemList
is built using CArchive. A large proportion of the time taken to do this is
actually spent in CVideoInfoTag::Archive() where it calls
CScraperUrl::Parse() and CFanart::Unpack(). Unless I've overlooked something,
these calls are unnecessary - the XML parsing they do is not performed the
first time the movies library is opened (when instead the virtual directory
videodb://movies/titles/ is enumerated using a database query). Also, the
Parse() method is called again when you do something like open the Movie
Information window, irrespective of whether it was called when the library
was opened.

Also note, it is unusual for any implementation of IArchivable::Archive() to
do anything other than read or write a data member from/to a CArchive, so
these calls to Parse() and Unpack() feel like an anomaly.

Additionally, inserted a call to std::vector::reserve() before reading the
cast list, because it was an obvious speed win.

Here are some benchmarks for the function CGUIMediaWindow::GetDirectory()
on a library of 600 movies, running on a Raspberry Pi:
- First call (before or after):    3.4 seconds
- Subsequent calls (before patch): 7.3 seconds
- Subsequent calls (after patch):  2.9 seconds
