### PR TITLE
PVR: Resolve channel dummy in GUIWindowPVRTimerSettings

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -46,17 +46,17 @@ namespace PVR
     virtual void SetWeekdaySettingFromTimer(const CPVRTimerInfoTag &timer);
     virtual void SetTimerFromWeekdaySetting(CPVRTimerInfoTag &timer);
 
-    SYSTEMTIME      timerStartTime;
-    SYSTEMTIME      timerEndTime;
-    CStdString      timerStartTimeStr;
-    CStdString      timerEndTimeStr;
-    int             m_tmp_iFirstDay;;
-    int             m_tmp_day;
-    bool            m_bTimerActive;
-    int             m_selectedChannelEntry;
+    SYSTEMTIME                          timerStartTime;
+    SYSTEMTIME                          timerEndTime;
+    CStdString                          timerStartTimeStr;
+    CStdString                          timerEndTimeStr;
+    int                                 m_tmp_iFirstDay;
+    int                                 m_tmp_day;
+    bool                                m_bTimerActive;
+    int                                 m_selectedChannelEntry;
     std::map<std::pair<bool, int>, int> m_channelEntries;
 
-    CFileItem      *m_timerItem;
-    bool            m_cancelled;
+    CFileItem                          *m_timerItem;
+    bool                                m_cancelled;
   };
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -53,6 +53,8 @@ namespace PVR
     int             m_tmp_iFirstDay;;
     int             m_tmp_day;
     bool            m_bTimerActive;
+    int             m_selectedChannelEntry;
+    std::map<std::pair<bool, int>, int> m_channelEntries;
 
     CFileItem      *m_timerItem;
     bool            m_cancelled;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -46,7 +46,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(void)
   m_strSummary         = StringUtils::EmptyString;
   m_iClientId          = g_PVRClients->GetFirstConnectedClientID();
   m_iClientIndex       = -1;
-  m_iClientChannelUid  = -1;
+  m_iClientChannelUid  = PVR_VIRTUAL_CHANNEL_UID;
   m_iPriority          = CSettings::Get().GetInt("pvrrecord.defaultpriority");
   m_iLifetime          = CSettings::Get().GetInt("pvrrecord.defaultlifetime");
   m_bIsRepeating       = false;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -61,6 +61,7 @@ namespace PVR
 
   class CPVRTimerInfoTag;
   typedef boost::shared_ptr<PVR::CPVRTimerInfoTag> CPVRTimerInfoTagPtr;
+  #define PVR_VIRTUAL_CHANNEL_UID (-1)
 
   class CPVRTimerInfoTag
   {


### PR DESCRIPTION
When using Backend channel number , use channel index member instead channel number
