### PR TITLE
ActiveAE: fix setting resample ratio

### DIFF
--- a/lib/DllSwResample.h
+++ b/lib/DllSwResample.h
@@ -57,6 +57,7 @@ public:
   virtual int64_t swr_get_delay(struct SwrContext *s, int64_t base) = 0;
   virtual int swr_set_channel_mapping(struct SwrContext *s, const int *channel_map) = 0;
   virtual int swr_set_matrix(struct SwrContext *s, const double *matrix, int stride) = 0;
+  virtual int swr_set_compensation(struct SwrContext *s, int sample_delta, int compensation_distance) = 0;
 };
 
 #if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
@@ -83,6 +84,7 @@ public:
   virtual int64_t swr_get_delay(struct SwrContext *s, int64_t base) { return ::swr_get_delay(s, base); }
   virtual int swr_set_channel_mapping (struct SwrContext *s, const int *channel_map) { return ::swr_set_channel_mapping(s, channel_map); }
   virtual int swr_set_matrix(struct SwrContext *s, const double *matrix, int stride) { return ::swr_set_matrix(s, matrix, stride); }
+  virtual int swr_set_compensation(struct SwrContext *s, int sample_delta, int compensation_distance) { return ::int swr_set_compensation(s, sample_delta, compensation_distance); }
 };
 
 #else
@@ -100,6 +102,7 @@ class DllSwResample : public DllDynamic, DllSwResampleInterface
   DEFINE_METHOD2(int64_t, swr_get_delay, (struct SwrContext *p1, int64_t p2))
   DEFINE_METHOD2(int, swr_set_channel_mapping, (struct SwrContext *p1, const int *p2))
   DEFINE_METHOD3(int, swr_set_matrix, (struct SwrContext *p1, const double *p2, int p3))
+  DEFINE_METHOD3(int, swr_set_compensation, (struct SwrContext *p1, int p2, int p3))
 
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(swr_alloc_set_opts)
@@ -109,6 +112,7 @@ class DllSwResample : public DllDynamic, DllSwResampleInterface
     RESOLVE_METHOD(swr_get_delay)
     RESOLVE_METHOD(swr_set_channel_mapping)
     RESOLVE_METHOD(swr_set_matrix)
+    RESOLVE_METHOD(swr_set_compensation)
   END_METHOD_RESOLVE()
 
   /* dependencies of libavformat */

--- a/lib/xbmc-libav-hacks/libav_hacks.h
+++ b/lib/xbmc-libav-hacks/libav_hacks.h
@@ -75,6 +75,8 @@ int swr_set_channel_mapping(struct SwrContext *s, const int *channel_map);
 
 int swr_set_matrix(struct SwrContext *s, const double *matrix, int stride);
 
+int swr_set_compensation(struct SwrContext *s, int sample_delta, int compensation_distance);
+
 // libavfilter
 
 #define LIBAVFILTER_AVFRAME_BASED

--- a/lib/xbmc-libav-hacks/swresample.c
+++ b/lib/xbmc-libav-hacks/swresample.c
@@ -73,3 +73,8 @@ int swr_set_matrix(struct SwrContext *s, const double *matrix, int stride)
 {
     return avresample_set_matrix(s, matrix, stride);
 }
+
+int swr_set_compensation(struct SwrContext *s, int sample_delta, int compensation_distance)
+{
+    return avresample_set_compensation(s, sample_delta, compensation_distance);
+}

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -458,12 +458,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           par = (MsgStreamParameter*)msg->data;
           if (par->stream->m_resampleBuffers)
           {
-            if ((unsigned int)(par->stream->m_resampleBuffers->m_format.m_sampleRate * par->parameter.double_par) != par->stream->m_resampleBuffers->m_outSampleRate)
-            {
-              par->stream->m_resampleBuffers->m_resampleRatio = par->parameter.double_par;
-              par->stream->m_resampleBuffers->m_resampleQuality = AE_QUALITY_LOW;
-              par->stream->m_resampleBuffers->m_changeResampler = true;
-            }
+            par->stream->m_resampleBuffers->m_resampleRatio = par->parameter.double_par;
           }
           return;
         case CActiveAEControlProtocol::STREAMFADE:
@@ -2333,7 +2328,8 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
   }
   int samples = resampler->Resample(dst_buffer, dst_samples,
                                     sound->GetSound(true)->data,
-                                    sound->GetSound(true)->nb_samples);
+                                    sound->GetSound(true)->nb_samples,
+                                    1.0);
 
   sound->GetSound(false)->nb_samples = samples;
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -107,7 +107,6 @@ public:
   bool m_changeResampler;
   double m_resampleRatio;
   AEQuality m_resampleQuality;
-  unsigned int m_outSampleRate;
   bool m_stereoUpmix;
 };
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
@@ -159,8 +159,19 @@ bool CActiveAEResample::Init(uint64_t dst_chan_layout, int dst_channels, int dst
   return true;
 }
 
-int CActiveAEResample::Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples)
+int CActiveAEResample::Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio)
 {
+  if (ratio != 1.0)
+  {
+    if (m_dllSwResample.swr_set_compensation(m_pContext,
+                                            (dst_samples*ratio-dst_samples)*m_dst_rate/m_src_rate,
+                                             dst_samples*m_dst_rate/m_src_rate) < 0)
+    {
+      CLog::Log(LOGERROR, "CActiveAEResample::Resample - set compensation failed");
+      return 0;
+    }
+  }
+
   int ret = m_dllSwResample.swr_convert(m_pContext, dst_buffer, dst_samples, (const uint8_t**)src_buffer, src_samples);
   if (ret < 0)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
@@ -35,7 +35,7 @@ public:
   CActiveAEResample();
   virtual ~CActiveAEResample();
   bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, bool upmix, CAEChannelInfo *remapLayout, AEQuality quality);
-  int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples);
+  int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio);
   int64_t GetDelay(int64_t base);
   int GetBufferedSamples();
   int CalcDstSampleCount(int src_samples, int dst_rate, int src_rate);


### PR DESCRIPTION
using swr_set_compensation allows to change resampling ratio on the fly. also fixes audio drop outs when changing ratio while transcoding because resampler had to be drained.
@Karlson2k does this work for you?
