### PR TITLE
English spelling corrections skin.confluence English/strings.po

### DIFF
--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -201,7 +201,7 @@ msgid "Show \"Paused\" in picture slide show"
 msgstr ""
 
 msgctxt "#31104"
-msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialogue Only)[/COLOR]"
 msgstr ""
 
 #empty string with id 31105
@@ -549,7 +549,7 @@ msgid "First run help...."
 msgstr ""
 
 msgctxt "#31412"
-msgid "This tab signifies that there is a menu off to the side of this window that contains extra options for this section.  To access the menu, navigate to the left with your remote control or keyboard or place your mouse pointer over the tab. [CR][CR]Click \"Ok\" to close this dialog. It will not appear again."
+msgid "This tab signifies that there is a menu off to the side of this window that contains extra options for this section.  To access the menu, navigate to the left with your remote control or keyboard or place your mouse pointer over the tab. [CR][CR]Click \"Ok\" to close this dialogue. It will not appear again."
 msgstr ""
 
 #empty strings from id 31413 to 31420


### PR DESCRIPTION
Fixes in strings.po as per Martijn, English UK (en_GB) cannot be added to Transifex as the main xbmc English source is UK English.

Contains spelling corrections for xbmc/addons
