### PR TITLE
Speedup for opening music song library

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -434,10 +434,9 @@ private:
   CAlbum GetAlbumFromDataset(dbiplus::Dataset* pDS, bool imageURL=false);
   CAlbum GetAlbumFromDataset(const dbiplus::sql_record* const record, bool imageURL=false);
   CArtistCredit GetAlbumArtistCreditFromDataset(const dbiplus::sql_record* const record);
-  void ParseBaseUrl(const CStdString &strMusicDBbasePath, CMusicDbUrl &baseUrl, CMusicDbUrl *&pBaseUrl);
-  void DuplicateUrl(const CMusicDbUrl *pBaseUrl, CMusicDbUrl &itemUrl, CMusicDbUrl *&pItemUrl);
-  void GetFileItemFromDataset(CFileItem* item, const CStdString& strMusicDBbasePath, CMusicDbUrl *itemUrl);
-  void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CStdString& strMusicDBbasePath, CMusicDbUrl *itemUrl);
+  void ParseBaseUrl(const CStdString &strMusicDBbasePath, CMusicDbUrl &baseUrl, const CMusicDbUrl *&pBaseUrl);
+  void GetFileItemFromDataset(CFileItem* item, const CStdString& strMusicDBbasePath, const CMusicDbUrl *baseUrl);
+  void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CStdString& strMusicDBbasePath, const CMusicDbUrl *baseUrl);
   bool CleanupSongs();
   bool CleanupSongsByIds(const CStdString &strSongIds);
   bool CleanupPaths();

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -434,8 +434,9 @@ private:
   CAlbum GetAlbumFromDataset(dbiplus::Dataset* pDS, bool imageURL=false);
   CAlbum GetAlbumFromDataset(const dbiplus::sql_record* const record, bool imageURL=false);
   CArtistCredit GetAlbumArtistCreditFromDataset(const dbiplus::sql_record* const record);
-  void GetFileItemFromDataset(CFileItem* item, const CStdString& strMusicDBbasePath);
-  void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CStdString& strMusicDBbasePath);
+  void ParseBaseUrl(const CStdString &strMusicDBbasePath, CMusicDbUrl &baseUrl, CMusicDbUrl *&pBaseUrl);
+  void DuplicateUrl(const CMusicDbUrl *pBaseUrl, CMusicDbUrl &itemUrl, CMusicDbUrl *&pItemUrl);
+  void GetFileItemFromDataset(CFileItem* item, const CStdString& strMusicDBbasePath, CMusicDbUrl *itemUrl);
   void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CStdString& strMusicDBbasePath, CMusicDbUrl *itemUrl);
   bool CleanupSongs();
   bool CleanupSongsByIds(const CStdString &strSongIds);

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -436,6 +436,7 @@ private:
   CArtistCredit GetAlbumArtistCreditFromDataset(const dbiplus::sql_record* const record);
   void GetFileItemFromDataset(CFileItem* item, const CStdString& strMusicDBbasePath);
   void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CStdString& strMusicDBbasePath);
+  void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CStdString& strMusicDBbasePath, CMusicDbUrl *itemUrl);
   bool CleanupSongs();
   bool CleanupSongsByIds(const CStdString &strSongIds);
   bool CleanupPaths();


### PR DESCRIPTION
Previously, this repeatedly parsed the same URL string over and over again
for every song, each time the list of songs was opened.

Benchmarks for CMusicDatabase::GetSongsByWhere() on a Raspberry Pi with a
library of 4115 songs:

Before patch: 14.5 seconds
After patch:   4.0 seconds
