### PR TITLE
Faster sorting of CFileItemLists, step 1

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1890,8 +1890,9 @@ void CFileItemList::Sort(SortDescription sortDescription)
   SortItems sortItems((size_t)Size());
   for (int index = 0; index < Size(); index++)
   {
-    m_items[index]->ToSortable(sortItems[index]);
-    sortItems[index][FieldId] = index;
+    sortItems[index] = boost::shared_ptr<SortItem>(new SortItem);
+    m_items[index]->ToSortable(*sortItems[index]);
+    (*sortItems[index])[FieldId] = index;
   }
 
   // do the sorting
@@ -1902,9 +1903,9 @@ void CFileItemList::Sort(SortDescription sortDescription)
   sortedFileItems.reserve(Size());
   for (SortItems::const_iterator it = sortItems.begin(); it != sortItems.end(); it++)
   {
-    CFileItemPtr item = m_items[(int)it->at(FieldId).asInteger()];
+    CFileItemPtr item = m_items[(int)(*it)->at(FieldId).asInteger()];
     // Set the sort label in the CFileItem
-    item->SetSortLabel(CStdStringW(it->at(FieldSort).asWideString()));
+    item->SetSortLabel(CStdStringW((*it)->at(FieldSort).asWideString()));
 
     sortedFileItems.push_back(item);
   }

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -522,6 +522,26 @@ bool SorterIgnoreFoldersDescending(const SortItem &left, const SortItem &right)
   return StringUtils::AlphaNumericCompare(labelLeft.c_str(), labelRight.c_str()) > 0;
 }
 
+bool SorterIndirectAscending(const SortItemPtr &left, const SortItemPtr &right)
+{
+  return SorterAscending(*left, *right);
+}
+
+bool SorterIndirectDescending(const SortItemPtr &left, const SortItemPtr &right)
+{
+  return SorterDescending(*left, *right);
+}
+
+bool SorterIndirectIgnoreFoldersAscending(const SortItemPtr &left, const SortItemPtr &right)
+{
+  return SorterIgnoreFoldersAscending(*left, *right);
+}
+
+bool SorterIndirectIgnoreFoldersDescending(const SortItemPtr &left, const SortItemPtr &right)
+{
+  return SorterIgnoreFoldersDescending(*left, *right);
+}
+
 map<SortBy, SortUtils::SortPreparator> fillPreparators()
 {
   map<SortBy, SortUtils::SortPreparator> preparators;
@@ -649,7 +669,7 @@ map<SortBy, Fields> fillSortingFields()
 map<SortBy, SortUtils::SortPreparator> SortUtils::m_preparators = fillPreparators();
 map<SortBy, Fields> SortUtils::m_sortingFields = fillSortingFields();
 
-void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attributes, SortItems& items, int limitEnd /* = -1 */, int limitStart /* = 0 */)
+void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attributes, DatabaseResults& items, int limitEnd /* = -1 */, int limitStart /* = 0 */)
 {
   if (sortBy != SortByNone)
   {
@@ -660,7 +680,7 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
       Fields sortingFields = GetFieldsForSorting(sortBy);
 
       // Prepare the string used for sorting and store it under FieldSort
-      for (SortItems::iterator item = items.begin(); item != items.end(); item++)
+      for (DatabaseResults::iterator item = items.begin(); item != items.end(); item++)
       {
         // add all fields to the item that are required for sorting if they are currently missing
         for (Fields::const_iterator field = sortingFields.begin(); field != sortingFields.end(); field++)
@@ -686,6 +706,50 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
   }
   if (limitEnd > 0 && (size_t)limitEnd < items.size())
     items.erase(items.begin() + limitEnd, items.end());
+}
+
+void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attributes, SortItems& items, int limitEnd /* = -1 */, int limitStart /* = 0 */)
+{
+  if (sortBy != SortByNone)
+  {
+    // get the matching SortPreparator
+    SortPreparator preparator = getPreparator(sortBy);
+    if (preparator != NULL)
+    {
+      Fields sortingFields = GetFieldsForSorting(sortBy);
+
+      // Prepare the string used for sorting and store it under FieldSort
+      for (SortItems::iterator item = items.begin(); item != items.end(); item++)
+      {
+        // add all fields to the item that are required for sorting if they are currently missing
+        for (Fields::const_iterator field = sortingFields.begin(); field != sortingFields.end(); field++)
+        {
+          if ((*item)->find(*field) == (*item)->end())
+            (*item)->insert(pair<Field, CVariant>(*field, CVariant::ConstNullVariant));
+        }
+
+        CStdStringW sortLabel;
+        g_charsetConverter.utf8ToW(preparator(attributes, **item), sortLabel, false);
+        (*item)->insert(pair<Field, CVariant>(FieldSort, CVariant(sortLabel)));
+      }
+
+      // Do the sorting
+      std::stable_sort(items.begin(), items.end(), getSorterIndirect(sortOrder, attributes));
+    }
+  }
+
+  if (limitStart > 0 && (size_t)limitStart < items.size())
+  {
+    items.erase(items.begin(), items.begin() + limitStart);
+    limitEnd -= limitStart;
+  }
+  if (limitEnd > 0 && (size_t)limitEnd < items.size())
+    items.erase(items.begin() + limitEnd, items.end());
+}
+
+void SortUtils::Sort(const SortDescription &sortDescription, DatabaseResults& items)
+{
+  Sort(sortDescription.sortBy, sortDescription.sortOrder, sortDescription.sortAttributes, items, sortDescription.limitEnd, sortDescription.limitStart);
 }
 
 void SortUtils::Sort(const SortDescription &sortDescription, SortItems& items)
@@ -729,6 +793,14 @@ SortUtils::Sorter SortUtils::getSorter(SortOrder sortOrder, SortAttribute attrib
     return sortOrder == SortOrderDescending ? SorterIgnoreFoldersDescending : SorterIgnoreFoldersAscending;
 
   return sortOrder == SortOrderDescending ? SorterDescending : SorterAscending;
+}
+
+SortUtils::SorterIndirect SortUtils::getSorterIndirect(SortOrder sortOrder, SortAttribute attributes)
+{
+  if (attributes & SortAttributeIgnoreFolders)
+    return sortOrder == SortOrderDescending ? SorterIndirectIgnoreFoldersDescending : SorterIndirectIgnoreFoldersAscending;
+
+  return sortOrder == SortOrderDescending ? SorterIndirectDescending : SorterIndirectAscending;
 }
 
 const Fields& SortUtils::GetFieldsForSorting(SortBy sortBy)

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <string>
+#include "boost/shared_ptr.hpp"
 
 #include "DatabaseUtils.h"
 #include "SortFileItem.h"
@@ -114,7 +115,8 @@ typedef struct
 } SORT_METHOD_DETAILS;
 
 typedef DatabaseResult SortItem;
-typedef DatabaseResults SortItems;
+typedef boost::shared_ptr<SortItem> SortItemPtr;
+typedef std::vector<SortItemPtr> SortItems;
 
 class SortUtils
 {
@@ -128,7 +130,9 @@ public:
    */
   static int GetSortLabel(SortBy sortBy);
 
+  static void Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attributes, DatabaseResults& items, int limitEnd = -1, int limitStart = 0);
   static void Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attributes, SortItems& items, int limitEnd = -1, int limitStart = 0);
+  static void Sort(const SortDescription &sortDescription, DatabaseResults& items);
   static void Sort(const SortDescription &sortDescription, SortItems& items);
   static bool SortFromDataset(const SortDescription &sortDescription, MediaType mediaType, const std::auto_ptr<dbiplus::Dataset> &dataset, DatabaseResults &results);
   
@@ -136,11 +140,13 @@ public:
   static std::string RemoveArticles(const std::string &label);
   
   typedef std::string (*SortPreparator) (SortAttribute, const SortItem&);
-  typedef bool (*Sorter) (const SortItem&, const SortItem&);
+  typedef bool (*Sorter) (const DatabaseResult &, const DatabaseResult &);
+  typedef bool (*SorterIndirect) (const SortItemPtr &, const SortItemPtr &);
   
 private:
   static const SortPreparator& getPreparator(SortBy sortBy);
   static Sorter getSorter(SortOrder sortOrder, SortAttribute attributes);
+  static SorterIndirect getSorterIndirect(SortOrder sortOrder, SortAttribute attributes);
 
   static std::map<SortBy, SortPreparator> m_preparators;
   static std::map<SortBy, Fields> m_sortingFields;


### PR DESCRIPTION
CFileItemLists are sorted by first constructing a SortItems object that refers
back to each CFileItem by index, sorting the SortItems object, then rebuilding
CSortItemList::m_items (a vector of pointers to CFileItems) by examination of
the sorted version of the SortItems object.

It might be more sensible, long-term, to sort m_items directly, but in the
meantime, there are a couple of simple ways to make sorting with SortItems
sufficiently efficient that it's not a problem any more.

Previously, SortItems was a vector of SortItem objects, held by value; each
SortItem was a std::map (implemented as a red-black tree) which ended up
being constructed and destructed as each element of SortItems was moved.
This patch changes SortItems to be a vector of pointers to SortItems instead.

Benchmarks for CFileItemList::Sort() on a Raspberry Pi with a library of
600 movies:
Before patch: 4.6 seconds
After patch:  1.1 seconds
