### PR TITLE
Music search bugfix

### DIFF
--- a/xbmc/filesystem/DirectoryHistory.cpp
+++ b/xbmc/filesystem/DirectoryHistory.cpp
@@ -118,13 +118,14 @@ void CDirectoryHistory::ClearPathHistory()
   m_vecPathHistory.clear();
 }
 
+bool CDirectoryHistory::IsMusicSearchUrl(CPathHistoryItem &i)
+{
+  return i.GetPath().Left(14) == "musicsearch://";
+}
+
 void CDirectoryHistory::ClearSearchHistory()
 {
-  for (vector<CPathHistoryItem>::iterator it = m_vecPathHistory.begin(); it != m_vecPathHistory.end(); ++it)
-  {
-    if (it->GetPath().Left(14) == "musicsearch://")
-      it = m_vecPathHistory.erase(it);
-  }
+  m_vecPathHistory.erase(remove_if(m_vecPathHistory.begin(), m_vecPathHistory.end(), IsMusicSearchUrl), m_vecPathHistory.end());
 }
 
 void CDirectoryHistory::DumpPathHistory()

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -68,4 +68,5 @@ private:
   typedef std::map<CStdString, CHistoryItem> HistoryMap;
   HistoryMap m_vecHistory;
   std::vector<CPathHistoryItem> m_vecPathHistory; ///< History of traversed directories
+  static bool IsMusicSearchUrl(CPathHistoryItem &i);
 };


### PR DESCRIPTION
CDirectoryHistory::ClearSearchHistory misused vector::iterator::operator++
in conjunction with vector::erase such that it iterated beyond the end of
the vector if there was a previous music search, resulting in a segfault.
End effect: you could only do one search.
