### PR TITLE
[Fix][StringUtils] Prevent infinite loop or crash.

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -209,6 +209,9 @@ int StringUtils::Replace(string &str, char oldChar, char newChar)
 
 int StringUtils::Replace(std::string &str, const std::string &oldStr, const std::string &newStr)
 {
+  if (oldStr.empty())
+    return 0;
+
   int replacedChars = 0;
   size_t index = 0;
   


### PR DESCRIPTION
Example:

  std::string rep = "1";
  StringUtils::Replace(rep,"",""); //infinite loop
  StringUtils::Replace(rep,"","1"); //crash std::bad_alloc
