### PR TITLE
[Droid x86] Additions for Android x86 architecture

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -606,13 +606,19 @@ ffmpeg_target_os=$(tolower $(uname -s))
 
 # host detection and setup
 case $host in
-  i*86*-android-linux-gnu*)
+  i*86*-linux-android*)
      target_platform=target_android
      ARCH="i486-linux"
      use_arch="x86"
      use_cpu="i686"
      ffmpeg_target_os=linux
-     ;;
+     use_joystick=no
+     use_gles=yes
+     use_optical_drive=no
+     use_sdl=no
+     use_x11=no
+     build_shared_lib=yes    
+    ;;
   i*86*-linux-gnu*)
      ARCH="i486-linux"
      ;;

--- a/docs/README.android
+++ b/docs/README.android
@@ -89,20 +89,7 @@ specifies where the resulting toolchain should be installed (your choice).
      --toolchain=arm-linux-androideabi-4.7
 
 Make sure to pick a toolchain for your desired architecture. Currently only
-gcc 4.7 toolchains are supported, anything else will likely fail to build.
-
-ATTENTION FOR X86 BUILDS - THIS DOES NOT APPLY TO 99% OF BUILDS:
-If you want to build for the x86 platform there is a flaw in the mentioned
-NDK. See http://code.google.com/p/android/issues/detail?id=19851 which results
-in linker errors mentioning "sigsetjmp and siglongjmp".
-In that case you have to download the libc.tar.bz2 from that google issue
-entry:
-
-http://android.googlecode.com/issues/attachment?aid=198510003000&name=libc.tar.bz2&token=6uNpHc1v8ixmVOTq3y6-ohUfb0o%3A1341156659947
-
-And extract it to <android-toolchain>/android-<x>/sysroot/usr/lib/ and overwrite
-the libc.so there. (where <android-toolchain>/android-<x>/ is the path you have given on the
---install-dir option above)
+gcc 4.7 and gcc 4.8 toolchains are supported, anything else will likely fail to build.
 
 --------------------------------------------------------------------
 3.4. Create a (new) debug key to sign debug APKs

--- a/m4/xbmc_arch.m4
+++ b/m4/xbmc_arch.m4
@@ -32,7 +32,7 @@ case $host in
   arm*-*-linux-gnu*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
      ;;
-  arm*-*linux-android*)
+  *-*linux-android*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -DTARGET_ANDROID")
      ;;
   *)

--- a/tools/android/packaging/Makefile
+++ b/tools/android/packaging/Makefile
@@ -22,7 +22,7 @@ ARMOVERRIDES=XBMC_OVERRIDE_HOST=arm-linux-androideabi XBMC_OVERRIDE_TOOLCHAIN=$(
 #this fixes a android ndk fuckup where the pathes to 
 #prebuilt stuff follow different name shemes for
 #arm and x86
-ifeq ($(findstring x86,$$(CPU)),x86)
+ifeq ($(findstring i686,$(CPU)),i686)
 ARCH=x86
 endif
 ifeq ($(findstring arm,$(CPU)),arm)

--- a/tools/android/packaging/Makefile
+++ b/tools/android/packaging/Makefile
@@ -24,6 +24,7 @@ ARMOVERRIDES=XBMC_OVERRIDE_HOST=arm-linux-androideabi XBMC_OVERRIDE_TOOLCHAIN=$(
 #arm and x86
 ifeq ($(findstring i686,$(CPU)),i686)
 ARCH=x86
+CPU=x86
 endif
 ifeq ($(findstring arm,$(CPU)),arm)
 ARCH=arm

--- a/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Splash.java
+++ b/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Splash.java
@@ -14,6 +14,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.app.Activity;
 import android.app.ActivityManager;
@@ -261,16 +262,18 @@ public class Splash extends Activity {
       }
 
     mState = State.Checking;
-
-    boolean ret = ParseCpuFeature();
+    boolean ret = Build.CPU_ABI.equals("x86");
     if (!ret) {
-      mErrorMsg = "Error! Cannot parse CPU features.";
-      mState = State.InError;
-    } else {
-      ret = CheckCpuFeature("neon");
+      ret = ParseCpuFeature();
       if (!ret) {
-        mErrorMsg = "This XBMC package is not compatible with your device.\nPlease check the <a href=\"http://wiki.xbmc.org/index.php?title=XBMC_for_Android_specific_FAQ\">XBMC Android wiki</a> for more information.";
+        mErrorMsg = "Error! Cannot parse CPU features.";
         mState = State.InError;
+      } else {
+        ret = CheckCpuFeature("neon");
+        if (!ret) {
+          mErrorMsg = "This XBMC package is not compatible with your device.\nPlease check the <a href=\"http://wiki.xbmc.org/index.php?title=XBMC_for_Android_specific_FAQ\">XBMC Android wiki</a> for more information.";
+          mState = State.InError;
+        }
       }
     }
     if (mState != State.InError) {

--- a/tools/depends/configure.in
+++ b/tools/depends/configure.in
@@ -102,7 +102,7 @@ case $host in
     #android builds are always cross
     cross_compiling="yes"
   ;;     
-  i*86*-android-linux-gnu*)
+  i*86*-linux-android*)
     if test "x$use_cpu" = "xauto"; then
       use_cpu=$host_cpu
     fi


### PR DESCRIPTION
Sorry, but I'm very new to this pull request thing. Sending the request form my branch to Memphiz's droid-x86 branch shows too many changes, that's why I decided  to send it to the original xbmc repo. (I hope this is right)
Original discussion and pull request: https://github.com/xbmc/xbmc/pull/3098
And forum thread: http://forum.xbmc.org/showthread.php?tid=173313

My changes disables the neon check on Android x86 architecture and renames the lib<arch> folder of the android apk (has to be x86 and not i686)
