### PR TITLE
FIX: [droid] Prevent droid from shutting us down when an usb/BT keyboard./gamepad is plugged in/out

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <application android:icon="@drawable/ic_launcher" android:debuggable="true" android:label="@string/app_name" android:hasCode="true">
         <activity
             android:name=".Splash"
-            android:configChanges="orientation|keyboardHidden"
+            android:configChanges="orientation|keyboard|keyboardHidden|navigation"
             android:finishOnTaskLaunch="true"
             android:launchMode="singleInstance"
             android:screenOrientation="sensorLandscape"
@@ -58,7 +58,7 @@
         -->
         <activity
             android:name=".Main"
-            android:configChanges="orientation|keyboardHidden"
+            android:configChanges="orientation|keyboard|keyboardHidden|navigation"
             android:finishOnTaskLaunch="true"
             android:label="XBMC"
             android:launchMode="singleInstance"


### PR DESCRIPTION
This prevents, e.g., to be shut down when a BT remote is awaken while we run.
