### PR TITLE
Audio fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
@@ -93,8 +93,10 @@ bool CActiveAEResample::Init(uint64_t dst_chan_layout, int dst_channels, int dst
     // remapLayout is the layout of the sink, if the channel is in our src layout
     // the channel is mapped by setting coef 1.0
     memset(m_rematrix, 0, sizeof(m_rematrix));
+    m_dst_chan_layout = 0;
     for (unsigned int out=0; out<remapLayout->Count(); out++)
     {
+      m_dst_chan_layout += (1 << out);
       int idx = GetAVChannelIndex((*remapLayout)[out], m_src_chan_layout);
       if (idx >= 0)
       {
@@ -102,7 +104,6 @@ bool CActiveAEResample::Init(uint64_t dst_chan_layout, int dst_channels, int dst
       }
     }
 
-    m_dst_chan_layout = m_dllAvUtil.av_get_default_channel_layout(m_dst_channels);
     m_dllAvUtil.av_opt_set_int(m_pContext, "out_channel_count", m_dst_channels, 0);
     m_dllAvUtil.av_opt_set_int(m_pContext, "out_channel_layout", m_dst_chan_layout, 0);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -92,6 +92,8 @@ protected:
   IAEStream *m_streamSlave;
   CAEConvert::AEConvertToFn m_convertFn;
   CCriticalSection m_streamLock;
+  uint8_t *m_leftoverBuffer;
+  int m_leftoverBytes;
 
   // only accessed by engine
   CActiveAEBufferPool *m_inputBuffers;

--- a/xbmc/cores/paplayer/FLACcodec.cpp
+++ b/xbmc/cores/paplayer/FLACcodec.cpp
@@ -311,17 +311,19 @@ void FLACCodec::DecoderMetadataCallback(const FLAC__StreamDecoder *decoder, cons
 
   if (metadata->type==FLAC__METADATA_TYPE_STREAMINFO)
   {
-    static enum AEChannel map[6][7] = {
+    static enum AEChannel map[8][9] = {
       {AE_CH_FC, AE_CH_NULL},
       {AE_CH_FL, AE_CH_FR, AE_CH_NULL},
       {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_NULL},
       {AE_CH_FL, AE_CH_FR, AE_CH_BL, AE_CH_BR, AE_CH_NULL},
       {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_BL, AE_CH_BR, AE_CH_NULL},
-      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BL, AE_CH_BR, AE_CH_NULL}
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BL, AE_CH_BR, AE_CH_NULL}, // 6 channels
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BC, AE_CH_BL, AE_CH_BR, AE_CH_NULL}, // 7 channels
+      {AE_CH_FL, AE_CH_FR, AE_CH_FC, AE_CH_LFE, AE_CH_BL, AE_CH_BR, AE_CH_SL, AE_CH_SR, AE_CH_NULL} // 8 channels
     };
 
     /* channel counts greater then 6 are undefined */
-    if (metadata->data.stream_info.channels > 6)
+    if (metadata->data.stream_info.channels > 8)
       pThis->m_ChannelInfo = CAEUtil::GuessChLayout(metadata->data.stream_info.channels);
     else
       pThis->m_ChannelInfo = CAEChannelInfo(map[metadata->data.stream_info.channels - 1]);


### PR DESCRIPTION
after scanning the forums for user reports, here are some more fixes:
- fix paplayer's flac codec, it did not handle 7 and 8 channels
- fix hang of ActiveAE if stream provided data which did not fit exactly in a multiple of framesize
- another fix remapping to sink format with more than 8 channels. ffmpeg has no default layout for this case.

for the protocol: thanks to @fritsch for working with me on this
