### PR TITLE
pvr: Fix crash when opening PVROSDChannels while playing a recording

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -95,8 +95,8 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
 
 void CGUIDialogPVRChannelsOSD::OnInitWindow()
 {
-  /* Close dialog immediately if now TV or radio channel is playing */
-  if (!g_PVRManager.IsPlaying())
+  /* Close dialog immediately if neither a TV nor a radio channel is playing */
+  if (!g_PVRManager.IsPlayingTV() && !g_PVRManager.IsPlayingRadio())
   {
     Close();
     return;


### PR DESCRIPTION
This fixes a crash when sending the action XBMC.ActivateWindow(PVROSDChannels)
to open the channel view while playing back a PVR recording.
