### PR TITLE
FIX: [windows] When generating "\\?\..." filenames, be sure to remove double backslashes, as this leads to an invalid filename

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -396,8 +396,7 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
   {
     //expand potential relative path to full path
     CStdStringW strPathW;
-    g_charsetConverter.utf8ToW(strPath, strPathW, false);
-    CWIN32Util::AddExtraLongPathPrefix(strPathW);
+    CWIN32Util::AddExtraLongPathPrefix(strPath, strPathW);
     const unsigned int bufSize = GetFullPathNameW(strPathW, 0, NULL, NULL);
     if (bufSize != 0)
     {

--- a/xbmc/filesystem/windows/WINFileSMB.cpp
+++ b/xbmc/filesystem/windows/WINFileSMB.cpp
@@ -51,6 +51,8 @@ CWINFileSMB::~CWINFileSMB()
 CStdString CWINFileSMB::GetLocal(const CURL &url)
 {
   CStdString path( url.GetFileName() );
+  path.Replace('/', '\\');
+  path.Replace("\\\\", "\\");
 
   if( url.GetProtocol().Equals("smb", false) )
   {
@@ -61,8 +63,6 @@ CStdString CWINFileSMB::GetLocal(const CURL &url)
       path = "\\\\?\\UNC\\" + host + "\\" + path;
     }
   }
-
-  path.Replace('/', '\\');
 
   return path;
 }

--- a/xbmc/filesystem/windows/WINSMBDirectory.cpp
+++ b/xbmc/filesystem/windows/WINSMBDirectory.cpp
@@ -52,6 +52,9 @@ CStdString CWINSMBDirectory::GetLocal(const CStdString& strPath)
 {
   CURL url(strPath);
   CStdString path( url.GetFileName() );
+  path.Replace('/', '\\');
+  path.Replace("\\\\", "\\");
+
   if( url.GetProtocol().Equals("smb", false) )
   {
     CStdString host( url.GetHostName() );
@@ -61,7 +64,6 @@ CStdString CWINSMBDirectory::GetLocal(const CStdString& strPath)
       path = "\\\\?\\UNC\\" + host + "\\" + path;
     }
   }
-  path.Replace('/', '\\');
   return path;
 }
 

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -495,12 +495,21 @@ CStdString CWIN32Util::SmbToUnc(const CStdString &strPath)
   return strRetPath;
 }
 
-bool CWIN32Util::AddExtraLongPathPrefix(std::wstring& path)
+bool CWIN32Util::AddExtraLongPathPrefix(const CStdString& path, CStdStringW& retpath)
 {
-  const wchar_t* const str = path.c_str();
-  if (path.length() < 4 || str[0] != L'\\' || str[1] != L'\\' || str[3] != L'\\' || str[2] != L'?')
+  g_charsetConverter.utf8ToW(path, retpath, false);
+  return AddExtraLongPathPrefix(retpath);
+}
+
+bool CWIN32Util::AddExtraLongPathPrefix(CStdStringW& path)
+{
+  if (path.length() < 4 || path[0] != L'\\' || path[1] != L'\\' || path[3] != L'\\' || path[2] != L'?')
   {
-    path.insert(0, L"\\\\?\\");
+    // Ensure valid path
+    path.Replace(L'/', L'\\');
+    path.Replace(L"\\\\", L"\\");
+
+    path.Insert(0, L"\\\\?\\");
     return true;
   }
   return false;

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -59,7 +59,8 @@ public:
   static CStdString GetProfilePath();
   static CStdString UncToSmb(const CStdString &strPath);
   static CStdString SmbToUnc(const CStdString &strPath);
-  static bool AddExtraLongPathPrefix(std::wstring& path);
+  static bool AddExtraLongPathPrefix(CStdStringW& path);
+  static bool AddExtraLongPathPrefix(const CStdString& path, CStdStringW& retpath);
   static bool RemoveExtraLongPathPrefix(std::wstring& path);
   static void ExtendDllPath();
   static HRESULT ToggleTray(const char cDriveLetter='\0');


### PR DESCRIPTION
From the win doc: "For file I/O, the "\?\" prefix to a path string tells the Windows APIs to disable all string parsing and to send the string that follows it straight to the file system"

This popped up when trying to play a filesystem-based bluray. 
libblueray generates paths like "v:\whatever\/BDMV/index.bdmv", leading to "\?\v:\whatever\BDMV\index.bdmv".
Windows fails to open the file with an "invalid syntax" error due to double backslash.
