### PR TITLE
[Droid]Fix: make clean dependencies and clean-apk added

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -670,6 +670,9 @@ clean-codecs: clean-dvdpcodecs clean-papcodecs
 clean-externals: clean-codecs clean-eventclients clean-xbmctex clean-libs \
 	clean-screensavers clean-visualisations clean-libaddons clean-pvraddons
 
+clean-apk: 
+	make -C tools/android/packaging clean
+
 ifeq (1,@GTEST_CONFIGURED@)
 check: testsuite
 	for check_program in $(CHECK_PROGRAMS); do $(CURDIR)/$$check_program; done

--- a/lib/addons/library.xbmc.addon/Makefile.in
+++ b/lib/addons/library.xbmc.addon/Makefile.in
@@ -19,7 +19,7 @@ else
 endif
 
 CLEAN_FILES = \
-	$(LIBNAME).so \
+	$(LIB_SHARED) \
 
 DISTCLEAN_FILES= \
 	Makefile \

--- a/tools/android/packaging/Makefile
+++ b/tools/android/packaging/Makefile
@@ -110,4 +110,14 @@ armeabi-v7a: $(XBMC_ARM_TOOLCHAIN) force
 x86: $(XBMC_X86_TOOLCHAIN) force
 	XBMC_OVERRIDE_PLATFORM=$@ $(X86OVERRIDES) $(MAKE) package
 
+clean:
+	rm -rf images
+	rm -rf xbmc/lib
+	rm -rf xbmc/libs
+	rm -rf xbmc/assets
+	rm -rf xbmc/obj
+	rm xbmc/res/drawable/splash.png
+	rm xbmc/src/R.java
+	rm xbmc/classes.dex
+
 .PHONY: arm armeabi-v7a x86 force extras libs


### PR DESCRIPTION
there was no clean in tools/android/packaging/Makefile, added one
And one little fix in lib/addons/library.xbmc.addon/Makefile.in
