### PR TITLE
changed: Large step should not skip chapters instead

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -105,8 +105,8 @@
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
       <dpadleft>StepBack</dpadleft>
       <dpadright>StepForward</dpadright>
-      <dpadup>BigStepForward</dpadup>
-      <dpaddown>BigStepBack</dpaddown>
+      <dpadup>ChapterOrBigStepForward</dpadup>
+      <dpaddown>ChapterOrBigStepBack</dpaddown>
     </gamepad>
   </FullscreenVideo>
   <FullscreenLiveTV>

--- a/system/keymaps/joystick.AppleRemote.xml
+++ b/system/keymaps/joystick.AppleRemote.xml
@@ -99,8 +99,8 @@
       <button id="8">Fullscreen</button>
       <button id="9">Rewind</button>
       <button id="10">FastForward</button>
-      <!-- pageup     -->      <button id="13">BigStepForward</button>
-      <!-- pagedown   -->      <button id="14">BigStepBack</button>
+      <!-- pageup     -->      <button id="13">ChapterOrBigStepForward</button>
+      <!-- pagedown   -->      <button id="14">ChapterOrBigStepBack</button>
       <!-- SwipeLeft  -->      <button id="80">StepBack</button>
       <!-- SwipeRight -->      <button id="81">StepForward</button>
       <!-- SwipeUp    -->      <button id="82">BigStepForward</button>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -161,8 +161,8 @@
   </MyMusicLibrary>
   <FullscreenVideo>
     <joystick name="Harmony">
-      <!-- up       	-->      <button id="1">BigStepForward</button>
-      <!-- down      	-->      <button id="2">BigStepBack</button>
+      <!-- up       	-->      <button id="1">ChapterOrBigStepForward</button>
+      <!-- down      	-->      <button id="2">ChapterOrBigStepBack</button>
       <!-- left       	-->      <button id="3">StepBack</button>
       <!-- right      	-->      <button id="4">StepForward</button>
       <!-- menu       	-->      <button id="6">OSD</button>

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -63,8 +63,8 @@
 
       <hat    id="1" position="left">StepBack</hat>
       <hat    id="1" position="right">StepForward</hat>
-      <hat    id="1" position="up">BigStepForward</hat>
-      <hat    id="1" position="down">BigStepBack</hat>
+      <hat    id="1" position="up">ChapterOrBigStepForward</hat>
+      <hat    id="1" position="down">ChapterOrBigStepBack</hat>
     </joystick>
   </FullscreenVideo>
 

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -305,8 +305,8 @@
       <button id="7">SmallStepBack</button>
       <button id="8">Info</button>
       <button id="10">AudioNextLanguage</button>
-      <button id="11">BigStepForward</button>
-      <button id="12">BigStepBack</button>
+      <button id="11">ChapterOrBigStepForward</button>
+      <button id="12">ChapterOrBigStepBack</button>
       <button id="13">StepBack</button>
       <button id="14">StepForward</button>
       <!-- D-pad does what you'd expect. Triggers fast forward and rewind. Left stick scans forward and back. -->
@@ -339,8 +339,8 @@
       <button id="11">AudioNextLanguage</button>  <!-- right stick -->
       <button id="12">StepBack</button>
       <button id="13">StepForward</button>
-      <button id="14">BigStepForward</button>
-      <button id="15">BigStepBack</button>
+      <button id="14">ChapterOrBigStepForward</button>
+      <button id="15">ChapterOrBigStepBack</button>
       <axis id="6" limit="-1">AnalogRewind</axis>
       <axis id="6" limit="+1">AnalogFastForward</axis>
       <hat id="1" position="up">BigStepForward</hat>

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -119,8 +119,8 @@
       <button id="5">AspectRatio</button>
       <button id="6">Info</button>
       <button id="9">OSD</button>
-      <button id="13">BigStepForward</button>
-      <button id="14">StepForward</button>
+      <button id="13">ChapterOrBigStepForward</button>
+      <button id="14">ChapterOrStepForward</button>
       <button id="15">BigStepBack</button>
       <button id="16">StepBack</button>
       <button id="17">SmallStepBack</button>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -97,8 +97,8 @@
       <button id="8">FastForward</button>
       <hat    id="1" position="left">StepBack</hat>
       <hat    id="1" position="right">StepForward</hat>
-      <hat    id="1" position="up">BigStepForward</hat>
-      <hat    id="1" position="down">BigStepBack</hat>
+      <hat    id="1" position="up">ChapterOrBigStepForward</hat>
+      <hat    id="1" position="down">ChapterOrBigStepBack</hat>
     </joystick>
   </FullscreenVideo>
 

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -222,11 +222,11 @@ void CApplicationPlayer::SetVolume(float volume)
     player->SetVolume(volume);
 }
 
-void CApplicationPlayer::Seek(bool bPlus, bool bLargeStep)
+void CApplicationPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    player->Seek(bPlus, bLargeStep);
+    player->Seek(bPlus, bLargeStep, bChapterOverride);
 }
 
 void CApplicationPlayer::SeekPercentage(float fPercent)

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -132,7 +132,7 @@ public:
   bool  QueueNextFile(const CFileItem &file);
   bool  Record(bool bOnOff);
   void  RegisterAudioCallback(IAudioCallback* pCallback);
-  void  Seek(bool bPlus = true, bool bLargeStep = false);
+  void  Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false);
   int   SeekChapter(int iChapter);
   void  SeekPercentage(float fPercent = 0);
   bool  SeekScene(bool bPlus = true);

--- a/xbmc/cores/DummyVideoPlayer.cpp
+++ b/xbmc/cores/DummyVideoPlayer.cpp
@@ -141,7 +141,7 @@ bool CDummyVideoPlayer::CanSeek()
   return GetTotalTime() > 0;
 }
 
-void CDummyVideoPlayer::Seek(bool bPlus, bool bLargeStep)
+void CDummyVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
   if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2000*g_advancedSettings.m_videoTimeSeekForwardBig)
   {

--- a/xbmc/cores/DummyVideoPlayer.h
+++ b/xbmc/cores/DummyVideoPlayer.h
@@ -41,7 +41,7 @@ public:
   virtual void SwitchToNextLanguage();
   virtual void ToggleSubtitles();
   virtual bool CanSeek();
-  virtual void Seek(bool bPlus, bool bLargeStep);
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();
   virtual void SetVolume(float volume) {}

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -527,7 +527,7 @@ bool CExternalPlayer::CanSeek()
   return false;
 }
 
-void CExternalPlayer::Seek(bool bPlus, bool bLargeStep)
+void CExternalPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 }
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -46,7 +46,7 @@ public:
   virtual void SwitchToNextLanguage();
   virtual void ToggleSubtitles();
   virtual bool CanSeek();
-  virtual void Seek(bool bPlus, bool bLargeStep);
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();
   virtual void SetVolume(float volume) {}

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -134,7 +134,7 @@ public:
   virtual bool HasAudio() const = 0;
   virtual bool IsPassthrough() const { return false;}
   virtual bool CanSeek() {return true;}
-  virtual void Seek(bool bPlus = true, bool bLargeStep = false) = 0;
+  virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) = 0;
   virtual bool SeekScene(bool bPlus = true) {return false;}
   virtual void SeekPercentage(float fPercent = 0){}
   virtual float GetPercentage(){ return 0;}

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -734,7 +734,7 @@ bool CAMLPlayer::CanSeek()
   return GetTotalTime() > 0;
 }
 
-void CAMLPlayer::Seek(bool bPlus, bool bLargeStep)
+void CAMLPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
   // force updated to m_elapsed_ms, m_duration_ms.
   GetStatus();
@@ -742,9 +742,10 @@ void CAMLPlayer::Seek(bool bPlus, bool bLargeStep)
   CSingleLock lock(m_aml_csection);
 
   // try chapter seeking first, chapter_index is ones based.
-  int chapter_index = GetChapter();
-  if (bLargeStep)
+  if (bLargeStep && bChapterOverride)
   {
+    int chapter_index = GetChapter();
+
     // seek to next chapter
     if (bPlus && (chapter_index < GetChapterCount()))
     {

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2448,7 +2448,7 @@ bool CDVDPlayer::CanSeek()
   return m_State.canseek;
 }
 
-void CDVDPlayer::Seek(bool bPlus, bool bLargeStep)
+void CDVDPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 #if 0
   // sadly this doesn't work for now, audio player must
@@ -2462,14 +2462,17 @@ void CDVDPlayer::Seek(bool bPlus, bool bLargeStep)
   if (!m_State.canseek)
     return;
 
-  if(((bPlus && GetChapter() < GetChapterCount())
-  || (!bPlus && GetChapter() > 1)) && bLargeStep)
+  if (bLargeStep && bChapterOverride)
   {
-    if(bPlus)
-      SeekChapter(GetChapter() + 1);
-    else
-      SeekChapter(GetChapter() - 1);
-    return;
+    if ((bPlus && GetChapter() < GetChapterCount())
+    || (!bPlus && GetChapter() > 1))
+    {
+      if(bPlus)
+        SeekChapter(GetChapter() + 1);
+      else
+        SeekChapter(GetChapter() - 1);
+      return;
+    }
   }
 
   int64_t seek;
@@ -3790,9 +3793,9 @@ int CDVDPlayer::SeekChapter(int iChapter)
   {
     // Do a regular big jump.
     if (GetChapter() > 0 && iChapter > GetChapter())
-      Seek(true, true);
+      Seek(true, true, true);
     else
-      Seek(false, true);
+      Seek(false, true, true);
   }
   return 0;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -179,7 +179,7 @@ public:
   virtual bool HasAudio() const;
   virtual bool IsPassthrough() const;
   virtual bool CanSeek();
-  virtual void Seek(bool bPlus, bool bLargeStep);
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual bool SeekScene(bool bPlus = true);
   virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2702,7 +2702,7 @@ bool COMXPlayer::CanSeek()
   return m_State.canseek;
 }
 
-void COMXPlayer::Seek(bool bPlus, bool bLargeStep)
+void COMXPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
   // Single step
   if( m_playSpeed == DVD_PLAYSPEED_PAUSE && bPlus && !bLargeStep)
@@ -2714,14 +2714,17 @@ void COMXPlayer::Seek(bool bPlus, bool bLargeStep)
   if (!m_State.canseek)
     return;
 
-  if(((bPlus && GetChapter() < GetChapterCount())
-  || (!bPlus && GetChapter() > 1)) && bLargeStep)
+  if (bLargeStep && bChapterOverride)
   {
-    if(bPlus)
-      SeekChapter(GetChapter() + 1);
-    else
-      SeekChapter(GetChapter() - 1);
-    return;
+    if ((bPlus && GetChapter() < GetChapterCount())
+    || (!bPlus && GetChapter() > 1))
+    {
+      if(bPlus)
+        SeekChapter(GetChapter() + 1);
+      else
+        SeekChapter(GetChapter() - 1);
+      return;
+    }
   }
 
   int64_t seek;

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -177,7 +177,7 @@ public:
   virtual bool  HasAudio() const;
   virtual bool  IsPassthrough() const;
   virtual bool  CanSeek();
-  virtual void Seek(bool bPlus, bool bLargeStep);
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual bool  SeekScene(bool bPlus = true);
   virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -887,7 +887,7 @@ bool PAPlayer::CanSeek()
   return m_playerGUIData.m_canSeek;
 }
 
-void PAPlayer::Seek(bool bPlus, bool bLargeStep)
+void PAPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
   if (!CanSeek()) return;
 

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -53,7 +53,7 @@ public:
   virtual bool HasVideo() const { return false; }
   virtual bool HasAudio() const { return true; }
   virtual bool CanSeek();
-  virtual void Seek(bool bPlus = true, bool bLargeStep = false);
+  virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false);
   virtual void SeekPercentage(float fPercent = 0.0f);
   virtual float GetPercentage();
   virtual void SetVolume(float volume);

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -197,6 +197,9 @@
 #define ACTION_CREATE_EPISODE_BOOKMARK 95 //Creates an episode bookmark on the currently playing video file containing more than one episode
 #define ACTION_CREATE_BOOKMARK         96 //Creates a bookmark of the currently playing video file
 
+#define ACTION_CHAPTER_OR_BIG_STEP_FORWARD       97 // Goto the next chapter, if not available perform a big step forward
+#define ACTION_CHAPTER_OR_BIG_STEP_BACK          98 // Goto the previous chapter, if not available perform a big step back
+
 #define ACTION_MOUSE_START            100
 #define ACTION_MOUSE_LEFT_CLICK       100
 #define ACTION_MOUSE_RIGHT_CLICK      101

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -81,6 +81,8 @@ static const ActionMapping actions[] =
         {"stepback"          , ACTION_STEP_BACK},
         {"bigstepforward"    , ACTION_BIG_STEP_FORWARD},
         {"bigstepback"       , ACTION_BIG_STEP_BACK},
+        {"chapterorbigstepforward", ACTION_CHAPTER_OR_BIG_STEP_FORWARD},
+        {"chapterorbigstepback"   , ACTION_CHAPTER_OR_BIG_STEP_BACK},
         {"osd"               , ACTION_SHOW_OSD},
         {"showsubtitles"     , ACTION_SHOW_SUBTITLES},
         {"nextsubtitle"      , ACTION_NEXT_SUBTITLE},

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -415,7 +415,7 @@ void CUPnPPlayer::SeekPercentage(float percent)
     SeekTime((int64_t)(tot * percent / 100));
 }
 
-void CUPnPPlayer::Seek(bool bPlus, bool bLargeStep)
+void CUPnPPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 }
 

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -43,7 +43,7 @@ public:
   virtual bool IsPaused() const;
   virtual bool HasVideo() const { return false; }
   virtual bool HasAudio() const { return false; }
-  virtual void Seek(bool bPlus, bool bLargeStep);
+  virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual void SeekPercentage(float fPercent = 0);
   virtual float GetPercentage();
   virtual void SetVolume(float volume);

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -176,17 +176,19 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     return true;
 
   case ACTION_BIG_STEP_BACK:
+  case ACTION_CHAPTER_OR_BIG_STEP_BACK:
     if (m_timeCodePosition > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);
     else
-      g_application.m_pPlayer->Seek(false, true);
+      g_application.m_pPlayer->Seek(false, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_BACK);
     return true;
 
   case ACTION_BIG_STEP_FORWARD:
+  case ACTION_CHAPTER_OR_BIG_STEP_FORWARD:
     if (m_timeCodePosition > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_FORWARD);
     else
-      g_application.m_pPlayer->Seek(true, true);
+      g_application.m_pPlayer->Seek(true, true, action.GetID() == ACTION_CHAPTER_OR_BIG_STEP_FORWARD);
     return true;
 
   case ACTION_NEXT_SCENE:


### PR DESCRIPTION
Currently we skip chapters, if available, when we perform a large skip in DVDPlayer. This is counter-intuitive and we already have separate actions/buttons that handle chapter skipping. Furthermore chapter skipping for a majority of mp4 files is broken (probably an ffmpeg problem) which is also (sort of) resolved by this :-)
