### PR TITLE
[ios] - add support for bluetooth keyboard

### DIFF
--- a/xbmc/osx/ios/XBMCApplication.m
+++ b/xbmc/osx/ios/XBMCApplication.m
@@ -152,6 +152,69 @@ XBMCController *m_xbmcController;
 }
 @end
 
+@interface XBMCApplication : UIApplication{
+}
+@end
+
+@implementation XBMCApplication
+#define GSEVENT_TYPE 2
+#define GSEVENT_FLAGS 12
+#define GSEVENTKEY_KEYCODE 15
+#define GSEVENT_TYPE_KEYUP 11
+
+- (void)sendEvent:(UIEvent *)event
+{ 
+  [super sendEvent:event];
+
+  if ([event respondsToSelector:@selector(_gsEvent)]) 
+  {
+    // Key events come in form of UIInternalEvents.
+    // They contain a GSEvent object which contains 
+    // a GSEventRecord among other things
+    int *eventMem;
+    eventMem = (int *)[event performSelector:@selector(_gsEvent)];
+    if (eventMem) 
+    {
+      // So far we got a GSEvent :)
+      int eventType = eventMem[GSEVENT_TYPE];
+      if (eventType == GSEVENT_TYPE_KEYUP) 
+      {
+        // Now we got a GSEventKey!
+        
+        // Read flags from GSEvent
+        // for modifier keys if we want to use them somehow at a later time
+        //int eventFlags = eventMem[GSEVENT_FLAGS];
+        // Read keycode from GSEventKey
+        UniChar tmp = (UniChar)eventMem[GSEVENTKEY_KEYCODE];
+        XBMCKey key = XBMCK_UNKNOWN;
+        switch (tmp)
+        {
+          case 0x4f:
+            // right
+            key = XBMCK_RIGHT;
+            break;
+          case 0x50:
+            // left
+            key = XBMCK_LEFT;
+            break;
+          case 0x51:
+            // down
+            key = XBMCK_DOWN;
+            break;
+          case 0x52:
+            // up
+            key = XBMCK_UP;
+            break;
+          default:
+            return; // not supported by us - return...
+        }
+        [g_xbmcController sendKey:key];
+      }
+    }
+  }
+}
+@end
+
 int main(int argc, char *argv[]) {
   NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];	
   int retVal = 0;
@@ -167,7 +230,7 @@ int main(int argc, char *argv[]) {
   
   @try
   {
-    retVal = UIApplicationMain(argc,argv,@"UIApplication",@"XBMCApplicationDelegate");
+    retVal = UIApplicationMain(argc,argv,@"XBMCApplication",@"XBMCApplicationDelegate");
     //UIApplicationMain(argc, argv, nil, nil);
   } 
   @catch (id theException) 

--- a/xbmc/osx/ios/XBMCController.h
+++ b/xbmc/osx/ios/XBMCController.h
@@ -35,7 +35,7 @@ typedef enum
   IOS_PLAYBACK_PLAYING
 } IOSPlaybackState;
 
-@interface XBMCController : UIViewController <UIGestureRecognizerDelegate>
+@interface XBMCController : UIViewController <UIGestureRecognizerDelegate, UIKeyInput>
 {
   UIWindow *m_window;
   IOSEAGLView  *m_glView;

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -252,6 +252,50 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
 @synthesize m_networkAutoSuspendTimer;
 @synthesize nowPlayingInfo;
 //--------------------------------------------------------------
+- (void) sendKeypressEvent: (XBMC_Event) event
+{
+  event.type = XBMC_KEYDOWN;
+  CWinEventsIOS::MessagePush(&event);
+
+  event.type = XBMC_KEYUP;
+  CWinEventsIOS::MessagePush(&event);
+}
+
+// START OF UIKeyInput protocol
+- (BOOL)hasText
+{
+  return NO;
+}
+
+- (void)insertText:(NSString *)text
+{
+  XBMC_Event newEvent;
+  memset(&newEvent, 0, sizeof(newEvent));
+  unichar currentKey = [text characterAtIndex:0];
+
+  // handle upper case letters
+  if (currentKey >= 'A' && currentKey <= 'Z')
+  {
+    newEvent.key.keysym.mod = XBMCKMOD_LSHIFT;
+    currentKey += 0x20;// convert to lower case
+  }
+
+  // handle return
+  if (currentKey == '\n' || currentKey == '\r')
+    currentKey = XBMCK_RETURN;
+
+  newEvent.key.keysym.sym = (XBMCKey)currentKey;
+  newEvent.key.keysym.unicode = currentKey;
+
+  [self sendKeypressEvent:newEvent];
+}
+
+- (void)deleteBackward
+{
+  [self sendKey:XBMCK_BACKSPACE];
+}
+// END OF UIKeyInput protocol
+
 -(BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {  
   //on external screens somehow the logic is rotated by 90°
@@ -312,12 +356,8 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
   
   //newEvent.key.keysym.unicode = key;
   newEvent.key.keysym.sym = key;
+  [self sendKeypressEvent:newEvent];
   
-  newEvent.type = XBMC_KEYDOWN;
-  CWinEventsIOS::MessagePush(&newEvent);
-  
-  newEvent.type = XBMC_KEYUP;
-  CWinEventsIOS::MessagePush(&newEvent);
 }
 //--------------------------------------------------------------
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
@@ -785,6 +825,16 @@ AnnounceReceiver *AnnounceReceiver::g_announceReceiver = NULL;
   [[UIApplication sharedApplication] setIdleTimerDisabled:NO];
 	
   [super viewWillDisappear:animated];
+}
+//--------------------------------------------------------------
+-(UIView *)inputView
+{
+  // override our input view to an empty view
+  // this prevents the on screen keyboard
+  // which would be shown whenever this UIResponder
+  // becomes the first responder (which is always the case!)
+  // caused by implementing the UIKeyInput protocol
+  return [[[UIView alloc] initWithFrame:CGRectZero] autorelease];
 }
 //--------------------------------------------------------------
 - (BOOL) canBecomeFirstResponder


### PR DESCRIPTION
This implements basic support of BT Keyboard for iOS. Since there is no real direct access via public APIS we do the following:
1. Implement the UIKeyInput protocol for receiving all "normal" keys including return and backspace. This gives us nearly all keys of a generic bt keyboard but its lacking the cursor keys
2. Override the sendEvent method in UIApplication for catching the cursor keys. Yeah its really hacked. But i found this approach somewhere in the net and it works. There is no other way for getting those events. I decided to not implement the whole keyboard via this hack because if this breaks somewhen - we at leat keep all the other keys ;)

There is no way for handling the ESC key though. This key acts as home button and is not send via one of those 2 approaches.

Comments requested from @davilla and @ulion.
