### PR TITLE
English spelling corrections English/strings.po

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1382,7 +1382,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#338"
-msgid "Analog"
+msgid "Analogue"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -4151,12 +4151,12 @@ msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10100"
-msgid "Yes/No dialog"
+msgid "Yes/No dialogue"
 msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10101"
-msgid "Progress dialog"
+msgid "Progress dialogue"
 msgstr ""
 
 #empty strings from id 10102 to 10125
@@ -4340,7 +4340,7 @@ msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12000"
-msgid "Select dialog"
+msgid "Select dialogue"
 msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
@@ -4350,7 +4350,7 @@ msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12002"
-msgid "Dialog OK"
+msgid "Dialogue OK"
 msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
@@ -4376,7 +4376,7 @@ msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12008"
-msgid "File stacking dialog"
+msgid "File stacking dialogue"
 msgstr ""
 
 #. Does not match window ID description
@@ -12738,7 +12738,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36130"
-msgid "Select the screensaver. XBMC will force the 'Dim' screensaver when fullscreen video playback is paused or a dialog box is active."
+msgid "Select the screensaver. XBMC will force the 'Dim' screensaver when fullscreen video playback is paused or a dialogue box is active."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -14063,7 +14063,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36395"
-msgid "Open the Master Lock dialog, where you can configure your Master Lock options."
+msgid "Open the Master Lock dialogue, where you can configure your Master Lock options."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -14348,7 +14348,7 @@ msgstr ""
 
 #: system/settings/rbp.xml
 msgctxt "#36542"
-msgid "Output to both analog (headphones) and HDMI"
+msgid "Output to both analogue (headphones) and HDMI"
 msgstr ""
 
 #: system/settings/rbp.xml


### PR DESCRIPTION
dialog      -> dialogue
analog      -> analogue

A dialogue box (GUI - Yes/No/Informational or otherwise) contains dialogue, and as such should be correctly spelt, this project has a en_US strings.po of which this spelling would be correct, but not here).
"dialog" has not become an accepted form in English like "program" has instead of "programme" for use in computing terms.
http://oxforddictionaries.com/definition/english/dialogue

analogue, the in use of opposite of digital, should be spelt -logue at the end.
(the spelling analog is American / en_US).
http://oxforddictionaries.com/definition/english/analogue

Once merges are made with Transifex, en_US can be correctly localised.

I know a lot of people feel that dialog should be used instead of dialogue because of years of en_US only Windows, however finally with multilingual support even in Windows 8, these have now changed to be correct.

My vote, based on over 300,000 strings personally committed via Launchpad.
