### PR TITLE
pvr: Fix missing field initialization CPVRChannelGroup contructor

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -51,6 +51,7 @@ CPVRChannelGroup::CPVRChannelGroup(void) :
     m_bLoaded(false),
     m_bChanged(false),
     m_bUsingBackendChannelOrder(false),
+    m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false)
 {
 }
@@ -63,6 +64,7 @@ CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const CSt
     m_bLoaded(false),
     m_bChanged(false),
     m_bUsingBackendChannelOrder(false),
+    m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false)
 {
 }
@@ -75,6 +77,7 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
     m_bLoaded(false),
     m_bChanged(false),
     m_bUsingBackendChannelOrder(false),
+    m_bSelectedGroup(false),
     m_bPreventSortAndRenumber(false)
 {
 }


### PR DESCRIPTION
The method ResetChannelNumberCache reads the field m_bSelectedGroup before it
is initialized. The field needs to be initialized in the constructor.

Conditional jump or move depends on uninitialised value(s)
  in PVR::CPVRChannelGroup::ResetChannelNumberCache() in xbmc/pvr/channels/PVRChannelGroup.cpp:921
  1: PVR::CPVRChannelGroup::ResetChannelNumberCache() in xbmc/pvr/channels/PVRChannelGroup.cpp:921
  2: PVR::CPVRChannelGroup::Renumber() in xbmc/pvr/channels/PVRChannelGroup.cpp:913
  3: PVR::CPVRChannelGroupInternal::Renumber() in xbmc/pvr/channels/PVRChannelGroupInternal.cpp:253
  4: PVR::CPVRChannelGroup::SortAndRenumber() in xbmc/pvr/channels/PVRChannelGroup.cpp:316
  5: PVR::CPVRChannelGroup::Load() in xbmc/pvr/channels/PVRChannelGroup.cpp:139
  6: PVR::CPVRChannelGroupInternal::Load() in xbmc/pvr/channels/PVRChannelGroupInternal.cpp:60
  7: PVR::CPVRChannelGroups::Load() in xbmc/pvr/channels/PVRChannelGroups.cpp:282
  8: PVR::CPVRChannelGroupsContainer::Load() in xbmc/pvr/channels/PVRChannelGroupsContainer.cpp:69
  9: PVR::CPVRManager::Load() in xbmc/pvr/PVRManager.cpp:542
  10: PVR::CPVRManager::Process() in xbmc/pvr/PVRManager.cpp:406
  11: CThread::Action() in xbmc/threads/Thread.cpp:220
  12: CThread::staticThread(void_) in xbmc/threads/Thread.cpp:130
  13: start_thread in /build/buildd/eglibc-2.17/nptl/pthread_create.c:311
  14: clone in /build/buildd/eglibc-2.17/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:113
Uninitialised value was created by a heap allocation  1: operator new(unsigned long) in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so
  2: PVR::CPVRChannelGroups::Load() in xbmc/pvr/channels/PVRChannelGroups.cpp:280
  3: PVR::CPVRChannelGroupsContainer::Load() in xbmc/pvr/channels/PVRChannelGroupsContainer.cpp:69
  4: PVR::CPVRManager::Load() in xbmc/pvr/PVRManager.cpp:542
  5: PVR::CPVRManager::Process() in xbmc/pvr/PVRManager.cpp:406
  6: CThread::Action() in xbmc/threads/Thread.cpp:220
  7: CThread::staticThread(void_) in xbmc/threads/Thread.cpp:130
  8: start_thread in /build/buildd/eglibc-2.17/nptl/pthread_create.c:311
  9: clone in /build/buildd/eglibc-2.17/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:113
