### PR TITLE
[WIN32][rfc] hack: load databases if appdata is redirected to a smb share.

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -36,6 +36,10 @@
 #include "mysqldataset.h"
 #endif
 
+#if defined(TARGET_WINDOWS)
+#include "win32/WIN32Util.h"
+#endif
+
 using namespace AUTOPTR;
 using namespace dbiplus;
 
@@ -356,7 +360,14 @@ void CDatabase::InitSettings(DatabaseSettings &dbSettings)
   {
     dbSettings.type = "sqlite3";
     if (dbSettings.host.IsEmpty())
+#if defined(TARGET_WINDOWS)
+      // Required if the appdata is redirected to an UNC path. Sqlite isn't wrapped. if it would be wrapped
+      // we would need CreatefileW to support our vfs. Optionally we could create a shim: http://sqlite.org/vfs.html
+      // but this seems to be to much effort for too little gain.
+      dbSettings.host = CWIN32Util::SmbToUnc(CSpecialProtocol::TranslatePath(CProfilesManager::Get().GetDatabaseFolder()));
+#else
       dbSettings.host = CSpecialProtocol::TranslatePath(CProfilesManager::Get().GetDatabaseFolder());
+#endif
   }
 
   // use separate, versioned database


### PR DESCRIPTION
Problem is that sqlite.dll isn't wrapped and thus won't understand our vfs like smb://....
Wrapping the delayed loading dlls seems not such a good idea as I get random crashes on exit. Even if wrapped we would need to write a CreatefileW which supports our vfs.
Another option would be to write a shim: http://sqlite.org/vfs.html
But this looks like too much effort for such a little problem.
The below "hack" works but feels not good as somewhere in between host will be validated and all backslashes are converted to slashes.
Another option would be to just convert it when open the database:
