### PR TITLE
bump addon dependencies to reflect changes done so far

### DIFF
--- a/addons/xbmc.json/addon.xml
+++ b/addons/xbmc.json/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.json" version="6.0.0" provider-name="Team XBMC">
+<addon id="xbmc.json" version="6.6.0" provider-name="Team XBMC">
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.python" version="2.1.0" provider-name="Team XBMC">
-  <backwards-compatibility abi="1.0"/>
+<addon id="xbmc.python" version="2.12.0" provider-name="Team XBMC">
+  <backwards-compatibility abi="2.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -777,7 +777,7 @@ namespace PythonBindings
    // constants
    PyModule_AddStringConstant(module, (char*)"__author__", (char*)"Team XBMC <http://xbmc.org>");
    PyModule_AddStringConstant(module, (char*)"__date__", (char*)"${new Date().toString()}");
-   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.1.0");
+   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.12.0");
    PyModule_AddStringConstant(module, (char*)"__credits__", (char*)"Team XBMC");
    PyModule_AddStringConstant(module, (char*)"__platform__", (char*)"ALL");
 


### PR DESCRIPTION
sync xbmc.json with the internal JSON-RPC service version
set xbmc.python version to the amount of additions done so far simular like has been done for JSON-RPC
