### PR TITLE
Fullscreen switching fixes

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -723,7 +723,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   // or if we are still on the same display - it might be only a refreshrate/resolution
   // change request.
   // Recurse to reset fullscreen mode and then continue.
-  if (was_fullscreen && fullScreen && lastDisplayNr != res.iScreen)
+  if (was_fullscreen && fullScreen)
   {
     needtoshowme = false;
     ShowHideNSWindow([last_view window], needtoshowme);


### PR DESCRIPTION
Two fullscreen switching fixes.  I'm not happy with either, but as I don't know the code...

@Montellese: Please review the first.  Problem is in a window->desktop (fullscreen) switch it first switches to DESKTOP then switches to 0013600768asdfkaljsdflkjvz.  It then switches from 0012353543t9sdf back to DESKTOP.  One presumes in order to make sure refresh rates and the like are all good.  This means 2 prompts with the Yes/No.  There may be a more suitable fix?

@davilla, @Memphiz Please review the second.  Reproduce fault in master by starting in window, switching to fullscreen, then change resolution while in fullscreen, say "No" to dialog (to revert to desktop res) then switch back to window -> bam, lost the window decoration/state.  Reason is that the recursing magic to reset to window mode before switching res is ignored as we're not switching displays.  Given the comment there, I suspect this is unintended??
