### PR TITLE
Customisable menu structure for home and beyond

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,6 +57,7 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/interfaces/interfaces.a \
                    xbmc/interfaces/json-rpc/json-rpc.a \
                    xbmc/linux/linux.a \
+                   xbmc/listproviders/listproviders.a \
                    xbmc/music/dialogs/musicdialogs.a \
                    xbmc/music/infoscanner/musicscanner.a \
                    xbmc/music/karaoke/karaoke.a \

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		7CEBD8A80F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEBD8A60F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp */; };
 		7CEE2E5B13D6B71E000ABF2A /* TimeSmoother.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEE2E5913D6B71E000ABF2A /* TimeSmoother.cpp */; };
 		7CF1FB0C123B1AF000B2CBCB /* Variant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF1FB09123B1AF000B2CBCB /* Variant.cpp */; };
+		7CF3F213180A8C9E00DF1FE8 /* DirectoryProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF3F211180A8C9E00DF1FE8 /* DirectoryProvider.cpp */; };
 		810C9F630D67BD2F0095F5DD /* PltMediaConnect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9F600D67BD2F0095F5DD /* PltMediaConnect.cpp */; settings = {COMPILER_FLAGS = "-I$SRCROOT/lib/libUPnP/Platinum/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Platinum -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaConnect -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaRenderer -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaServer -I$SRCROOT/lib/libUPnP/Platinum/Source/Extras -I$SRCROOT/lib/libUPnP/Neptune/Source/System/Posix -I$SRCROOT/lib/libUPnP/Neptune/Source/Core"; }; };
 		810C9FA90D67D1FB0095F5DD /* MythDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA50D67D1FB0095F5DD /* MythDirectory.cpp */; };
 		810C9FAA0D67D1FB0095F5DD /* MythFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA70D67D1FB0095F5DD /* MythFile.cpp */; };
@@ -3785,6 +3786,8 @@
 		7CEE2E5A13D6B71E000ABF2A /* TimeSmoother.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeSmoother.h; sourceTree = "<group>"; };
 		7CF1FB09123B1AF000B2CBCB /* Variant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Variant.cpp; sourceTree = "<group>"; };
 		7CF1FB0A123B1AF000B2CBCB /* Variant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Variant.h; sourceTree = "<group>"; };
+		7CF3F211180A8C9E00DF1FE8 /* DirectoryProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DirectoryProvider.cpp; path = xbmc/listproviders/DirectoryProvider.cpp; sourceTree = SOURCE_ROOT; };
+		7CF3F212180A8C9E00DF1FE8 /* DirectoryProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DirectoryProvider.h; path = xbmc/listproviders/DirectoryProvider.h; sourceTree = SOURCE_ROOT; };
 		810C9F600D67BD2F0095F5DD /* PltMediaConnect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PltMediaConnect.cpp; path = MediaConnect/PltMediaConnect.cpp; sourceTree = "<group>"; };
 		810C9F610D67BD2F0095F5DD /* PltMediaConnect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PltMediaConnect.h; path = MediaConnect/PltMediaConnect.h; sourceTree = "<group>"; };
 		810C9FA50D67D1FB0095F5DD /* MythDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MythDirectory.cpp; sourceTree = "<group>"; };
@@ -6631,6 +6634,8 @@
 		7C430161175C41FE009B82E5 /* listproviders */ = {
 			isa = PBXGroup;
 			children = (
+				7CF3F211180A8C9E00DF1FE8 /* DirectoryProvider.cpp */,
+				7CF3F212180A8C9E00DF1FE8 /* DirectoryProvider.h */,
 				7C7BCDBF17727951004842FB /* IListProvider.cpp */,
 				7C7BCDC417727951004842FB /* IListProvider.h */,
 				7C7BCDC317727951004842FB /* StaticProvider.cpp */,
@@ -10649,6 +10654,7 @@
 				F500E35617F3412C004FC217 /* WinEvents.cpp in Sources */,
 				7C7BCDC517727951004842FB /* IListProvider.cpp in Sources */,
 				7C7BCDC717727951004842FB /* StaticProvider.cpp in Sources */,
+				7CF3F213180A8C9E00DF1FE8 /* DirectoryProvider.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -271,6 +271,12 @@
 		7C779E3F104A57E500F444C4 /* WinSystemOSXGL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E2D104A57E500F444C4 /* WinSystemOSXGL.mm */; };
 		7C779E54104A58F900F444C4 /* GUIWindowTestPatternGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E50104A58F900F444C4 /* GUIWindowTestPatternGL.cpp */; };
 		7C7B2B301134F36400713D6D /* mysqldataset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7B2B2E1134F36400713D6D /* mysqldataset.cpp */; };
+		7C7BCDC517727951004842FB /* IListProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7BCDBF17727951004842FB /* IListProvider.cpp */; };
+		7C7BCDC717727951004842FB /* StaticProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7BCDC317727951004842FB /* StaticProvider.cpp */; };
+		7C7BCDC817727951004842FB /* IListProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7BCDBF17727951004842FB /* IListProvider.cpp */; };
+		7C7BCDCA17727951004842FB /* StaticProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7BCDC317727951004842FB /* StaticProvider.cpp */; };
+		7C7BCDCB17727951004842FB /* IListProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7BCDBF17727951004842FB /* IListProvider.cpp */; };
+		7C7BCDCD17727952004842FB /* StaticProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7BCDC317727951004842FB /* StaticProvider.cpp */; };
 		7C7CEAF1165629530059C9EB /* AELimiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7CEAEF165629530059C9EB /* AELimiter.cpp */; };
 		7C84A59E12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
 		7C87B2CE162CE39600EF897D /* PlayerController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C87B2CC162CE39600EF897D /* PlayerController.cpp */; };
@@ -3724,6 +3730,10 @@
 		7C779E51104A58F900F444C4 /* GUIWindowTestPatternGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowTestPatternGL.h; sourceTree = "<group>"; };
 		7C7B2B2E1134F36400713D6D /* mysqldataset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mysqldataset.cpp; sourceTree = "<group>"; };
 		7C7B2B2F1134F36400713D6D /* mysqldataset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mysqldataset.h; sourceTree = "<group>"; };
+		7C7BCDBF17727951004842FB /* IListProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IListProvider.cpp; path = xbmc/listproviders/IListProvider.cpp; sourceTree = SOURCE_ROOT; };
+		7C7BCDC217727951004842FB /* StaticProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StaticProvider.h; path = xbmc/listproviders/StaticProvider.h; sourceTree = SOURCE_ROOT; };
+		7C7BCDC317727951004842FB /* StaticProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StaticProvider.cpp; path = xbmc/listproviders/StaticProvider.cpp; sourceTree = SOURCE_ROOT; };
+		7C7BCDC417727951004842FB /* IListProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IListProvider.h; path = xbmc/listproviders/IListProvider.h; sourceTree = SOURCE_ROOT; };
 		7C7CEAEF165629530059C9EB /* AELimiter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AELimiter.cpp; sourceTree = "<group>"; };
 		7C7CEAF0165629530059C9EB /* AELimiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AELimiter.h; sourceTree = "<group>"; };
 		7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SourcesDirectory.cpp; path = xbmc/filesystem/SourcesDirectory.cpp; sourceTree = SOURCE_ROOT; };
@@ -6618,6 +6628,18 @@
 			name = main;
 			sourceTree = "<group>";
 		};
+		7C430161175C41FE009B82E5 /* listproviders */ = {
+			isa = PBXGroup;
+			children = (
+				7C7BCDBF17727951004842FB /* IListProvider.cpp */,
+				7C7BCDC417727951004842FB /* IListProvider.h */,
+				7C7BCDC317727951004842FB /* StaticProvider.cpp */,
+				7C7BCDC217727951004842FB /* StaticProvider.h */,
+			);
+			name = listproviders;
+			path = linux;
+			sourceTree = "<group>";
+		};
 		7C5608C30F1754930056433A /* ExternalPlayer */ = {
 			isa = PBXGroup;
 			children = (
@@ -7173,6 +7195,7 @@
 				18B7C8C61294252E009E7A26 /* input */,
 				4367217312D6640E002508E6 /* interfaces */,
 				E38E1D690D25F9FD00618676 /* linux */,
+				7C430161175C41FE009B82E5 /* listproviders */,
 				552A226615F7E11B0015C0D0 /* main */,
 				18B7C853129423A7009E7A26 /* music */,
 				431376F212D6449100680C15 /* network */,
@@ -10624,6 +10647,8 @@
 				DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E917DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35617F3412C004FC217 /* WinEvents.cpp in Sources */,
+				7C7BCDC517727951004842FB /* IListProvider.cpp in Sources */,
+				7C7BCDC717727951004842FB /* StaticProvider.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11654,6 +11679,8 @@
 				DFD882F617DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E717DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35817F3412C004FC217 /* WinEvents.cpp in Sources */,
+				7C7BCDCB17727951004842FB /* IListProvider.cpp in Sources */,
+				7C7BCDCD17727952004842FB /* StaticProvider.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12686,6 +12713,8 @@
 				DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E817DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35717F3412C004FC217 /* WinEvents.cpp in Sources */,
+				7C7BCDC817727951004842FB /* IListProvider.cpp in Sources */,
+				7C7BCDCA17727951004842FB /* StaticProvider.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/configure.in
+++ b/configure.in
@@ -975,7 +975,7 @@ if test "$use_wayland" = "yes" && test "$host_vendor" != "apple"; then
      AC_MSG_ERROR($missing_library))
   PKG_CHECK_MODULES([WAYLAND_EGL],    [wayland-egl],
     [INCLUDES="$INCLUDES $WAYLAND_EGL_CFLAGS";
-     WAYLAND_EGL_LIBRARY_LINE=`LIBRARY=\`${PKG_CONFIG} --libs-only-l wayland-egl\`; echo ${LIBRARY:2}`
+     WAYLAND_EGL_LIBRARY_LINE=`LIBRARY=\`${PKG_CONFIG} --libs-only-l wayland-egl\`; echo ${LIBRARY:2:11}`
      XB_FIND_SONAME([WAYLAND_EGL_LIBRARY], ${WAYLAND_EGL_LIBRARY_LINE})],
     AC_MSG_ERROR($missing_library))
   PKG_CHECK_MODULES([XKBCOMMON],    [xkbcommon],

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -797,6 +797,8 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\interfaces\python\XBPython.cpp" />
     <ClCompile Include="..\..\xbmc\LangInfo.cpp" />
+    <ClCompile Include="..\..\xbmc\listproviders\IListProvider.cpp" />
+    <ClCompile Include="..\..\xbmc\listproviders\StaticProvider.cpp" />
     <ClCompile Include="..\..\xbmc\MediaSource.cpp" />
     <ClCompile Include="..\..\xbmc\music\Album.cpp" />
     <ClCompile Include="..\..\xbmc\music\Artist.cpp" />
@@ -2258,6 +2260,8 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\XBMCOperations.h" />
     <ClInclude Include="..\..\xbmc\IProgressCallback.h" />
     <ClInclude Include="..\..\xbmc\LangInfo.h" />
+    <ClInclude Include="..\..\xbmc\listproviders\IListProvider.h" />
+    <ClInclude Include="..\..\xbmc\listproviders\StaticProvider.h" />
     <ClInclude Include="..\..\xbmc\MediaSource.h" />
     <ClInclude Include="..\..\xbmc\music\Album.h" />
     <ClInclude Include="..\..\xbmc\music\Artist.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -307,6 +307,9 @@
     <Filter Include="cores\AudioEngine\Engines\ActiveAE">
       <UniqueIdentifier>{27f2c647-7b5f-4c49-b2e7-22bf360e58ab}</UniqueIdentifier>
     </Filter>
+    <Filter Include="listproviders">
+      <UniqueIdentifier>{1dfaf73b-2e8d-49d2-87c1-07b1ac203ba0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -3075,6 +3078,12 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\windowing\WinEvents.cpp">
       <Filter>windowing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\listproviders\IListProvider.cpp">
+      <Filter>listproviders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\listproviders\StaticProvider.cpp">
+      <Filter>listproviders</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -6036,9 +6045,14 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\StringValidation.h">
       <Filter>utils</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\uXstrings.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\listproviders\IListProvider.h">
+      <Filter>listproviders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\listproviders\StaticProvider.h">
+      <Filter>listproviders</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1952,7 +1952,7 @@ void CActiveAE::Deamplify(CSoundPacket &dstSample)
       CAEUtil::SSEMulArray(buffer, m_muted ? 0.0 : m_volume, nb_floats);
 #else
       float *fbuffer = buffer;
-      for (unsigned int i = 0; i < nb_floats; i++)
+      for (int i = 0; i < nb_floats; i++)
         *fbuffer++ *= m_volume;
 #endif
     }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1731,7 +1731,7 @@ bool CActiveAE::RunStages()
 #else
                 for (int k = 0; k < nb_floats; ++k)
                 {
-                  dst[k] += src[k] * m_muted ? 0.0 : volume;
+                  dst[k] += src[k] * (m_muted ? 0.0 : volume);
                   if (fabs(dst[k]) > 1.0f)
                     needClamp = true;
                 }

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -149,7 +149,7 @@ bool CFavouritesDirectory::AddOrRemove(CFileItem *item, int contextWindow)
   CFileItemList items;
   Load(items);
 
-  CStdString executePath(GetExecutePath(item, contextWindow));
+  CStdString executePath(GetExecutePath(*item, contextWindow));
 
   CFileItemPtr match = items.Get(executePath);
   if (match)
@@ -175,27 +175,35 @@ bool CFavouritesDirectory::IsFavourite(CFileItem *item, int contextWindow)
   CFileItemList items;
   if (!Load(items)) return false;
 
-  return items.Contains(GetExecutePath(item, contextWindow));
+  return items.Contains(GetExecutePath(*item, contextWindow));
 }
 
-CStdString CFavouritesDirectory::GetExecutePath(const CFileItem *item, int contextWindow)
+CStdString CFavouritesDirectory::GetExecutePath(const CFileItem &item, int contextWindow)
+{
+  return GetExecutePath(item, StringUtils::Format("%i", contextWindow));
+}
+
+CStdString CFavouritesDirectory::GetExecutePath(const CFileItem &item, const std::string &contextWindow)
 {
   CStdString execute;
-  if (item->m_bIsFolder && (g_advancedSettings.m_playlistAsFolders ||
-                            !(item->IsSmartPlayList() || item->IsPlayList())))
-    execute.Format("ActivateWindow(%i,%s)", contextWindow, StringUtils::Paramify(item->GetPath()).c_str());
-  else if (item->IsScript())
-    execute.Format("RunScript(%s)", StringUtils::Paramify(item->GetPath().Mid(9)).c_str());
-  else if (item->IsAndroidApp())
-    execute.Format("StartAndroidActivity(%s)", StringUtils::Paramify(item->GetPath().Mid(26)).c_str());
+  if (item.m_bIsFolder && (g_advancedSettings.m_playlistAsFolders ||
+                            !(item.IsSmartPlayList() || item.IsPlayList())))
+  {
+    if (!contextWindow.empty())
+      execute.Format("ActivateWindow(%s,%s)", contextWindow.c_str(), StringUtils::Paramify(item.GetPath()).c_str());
+  }
+  else if (item.IsScript())
+    execute.Format("RunScript(%s)", StringUtils::Paramify(item.GetPath().Mid(9)).c_str());
+  else if (item.IsAndroidApp())
+    execute.Format("StartAndroidActivity(%s)", StringUtils::Paramify(item.GetPath().Mid(26)).c_str());
   else  // assume a media file
   {
-    if (item->IsVideoDb() && item->HasVideoInfoTag())
-      execute.Format("PlayMedia(%s)", StringUtils::Paramify(item->GetVideoInfoTag()->m_strFileNameAndPath).c_str());
+    if (item.IsVideoDb() && item.HasVideoInfoTag())
+      execute.Format("PlayMedia(%s)", StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
     else
-      execute.Format("PlayMedia(%s)", StringUtils::Paramify(item->GetPath()).c_str());
+      execute.Format("PlayMedia(%s)", StringUtils::Paramify(item.GetPath()).c_str());
   }
   return execute;
 }
-  
+
 }

--- a/xbmc/filesystem/FavouritesDirectory.h
+++ b/xbmc/filesystem/FavouritesDirectory.h
@@ -40,8 +40,10 @@ namespace XFILE
     static bool AddOrRemove(CFileItem *item, int contextWindow);
     static bool Save(const CFileItemList& items);
     static bool IsFavourite(CFileItem *item, int contextWindow);
+
+    static CStdString GetExecutePath(const CFileItem &item, int contextWindow);
+    static CStdString GetExecutePath(const CFileItem &item, const std::string &contextWindow);
   private:
-    static CStdString GetExecutePath(const CFileItem *item, int contextWindow);
   };
   
 }

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -28,6 +28,7 @@
 #include "DirectoryCache.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 
 extern "C" {
@@ -638,7 +639,7 @@ bool CMythFile::PrevChannel(bool preview)
 
 bool CMythFile::SelectChannel(unsigned int channel)
 {
-  return ChangeChannel(CHANNEL_DIRECTION_SAME,""+channel);
+  return ChangeChannel(CHANNEL_DIRECTION_SAME, StringUtils::Format("%d", channel));
 }
 
 bool CMythFile::CanRecord()

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -864,14 +864,21 @@ void CGUIBaseContainer::UpdateListProvider(bool refreshItems)
       m_listProvider->Fetch(m_items);
       SetPageControlRange();
       // update the newly selected item
+      bool found = false;
       for (int i = 0; i < (int)m_items.size(); i++)
       {
-        if (m_items[i].get() == current && i != currentItem)
+        if (m_items[i].get() == current)
         {
-          SelectItem(i);
-          break;
+          found = true;
+          if (i != currentItem)
+          {
+            SelectItem(i);
+            break;
+          }
         }
       }
+      if (!found && currentItem >= (int)m_items.size())
+        SelectItem(m_items.size()-1);
       SetInvalid();
     }
     // always update the scroll by letter, as the list provider may have altered labels

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -27,10 +27,11 @@
 #include "utils/log.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
-#include "GUIStaticItem.h"
+#include "FileItem.h"
 #include "Key.h"
 #include "utils/MathUtils.h"
 #include "utils/XBMCTinyXML.h"
+#include "listproviders/IListProvider.h"
 
 using namespace std;
 
@@ -50,20 +51,18 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, fl
   m_pageControl = 0;
   m_orientation = orientation;
   m_analogScrollCount = 0;
-  m_staticContent = false;
-  m_staticUpdateTime = 0;
-  m_staticDefaultItem = -1;
-  m_staticDefaultAlways = false;
   m_wasReset = false;
   m_layout = NULL;
   m_focusedLayout = NULL;
   m_cacheItems = preloadItems;
   m_scrollItemsPerFrame = 0.0f;
   m_type = VIEW_TYPE_NONE;
+  m_listProvider = NULL;
 }
 
 CGUIBaseContainer::~CGUIBaseContainer(void)
 {
+  delete m_listProvider;
 }
 
 void CGUIBaseContainer::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
@@ -386,7 +385,7 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
 {
   if (message.GetControlId() == GetID() )
   {
-    if (!m_staticContent)
+    if (!m_listProvider)
     {
       if (message.GetMessage() == GUI_MSG_LABEL_BIND && message.GetPointer())
       { // bind our items
@@ -717,14 +716,11 @@ bool CGUIBaseContainer::OnClick(int actionID)
   int subItem = 0;
   if (actionID == ACTION_SELECT_ITEM || actionID == ACTION_MOUSE_LEFT_CLICK)
   {
-    if (m_staticContent)
+    if (m_listProvider)
     { // "select" action
       int selected = GetSelectedItem();
       if (selected >= 0 && selected < (int)m_items.size())
-      {
-        CGUIStaticItemPtr item = boost::static_pointer_cast<CGUIStaticItem>(m_items[selected]);
-        item->GetClickActions().ExecuteActions(GetID(), GetParentID());
-      }
+        m_listProvider->OnClick(m_items[selected]);
       return true;
     }
     // grab the currently focused subitem (if applicable)
@@ -764,7 +760,7 @@ void CGUIBaseContainer::SetFocus(bool bOnOff)
 
 void CGUIBaseContainer::SaveStates(vector<CControlState> &states)
 {
-  if (!m_staticDefaultAlways)
+  if (!m_listProvider || !m_listProvider->AlwaysFocusDefaultItem())
     states.push_back(CControlState(GetID(), GetSelectedItem()));
 }
 
@@ -788,17 +784,18 @@ void CGUIBaseContainer::AllocResources()
 {
   CGUIControl::AllocResources();
   CalculateLayout();
-  UpdateStaticItems(true);
-  if (m_staticDefaultItem != -1) // select default item
-    SelectStaticItemById(m_staticDefaultItem);
+  UpdateListProvider(true);
+  if (m_listProvider)
+    SelectItem(m_listProvider->GetDefaultItem());
 }
 
 void CGUIBaseContainer::FreeResources(bool immediately)
 {
   CGUIControl::FreeResources(immediately);
-  if (m_staticContent)
-  { // free any static content
+  if (m_listProvider)
+  {
     Reset();
+    m_listProvider->Reset();
   }
   m_scroller.Stop();
 }
@@ -851,51 +848,34 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
     SelectItem(itemIndex);
   }
 
-  UpdateStaticItems();
+  UpdateListProvider();
 }
 
-void CGUIBaseContainer::UpdateStaticItems(bool refreshItems)
+void CGUIBaseContainer::UpdateListProvider(bool refreshItems)
 {
-  if (m_staticContent)
-  { // update our item list with our new content, but only add those items that should
-    // be visible.  Save the previous item and keep it if we are adding that one.
-    std::vector<CGUIListItemPtr> items;
-    int reselect = -1;
-    int selected = GetSelectedItem();
-    CGUIListItem* selectedItem = (selected >= 0 && (unsigned int)selected < m_items.size()) ? m_items[selected].get() : NULL;
-    bool updateItemsProperties = false;
-    if (!m_staticUpdateTime)
-      m_staticUpdateTime = CTimeUtils::GetFrameTime();
-    if (CTimeUtils::GetFrameTime() - m_staticUpdateTime > 1000)
+  if (m_listProvider)
+  {
+    if (m_listProvider->Update(refreshItems))
     {
-      m_staticUpdateTime = CTimeUtils::GetFrameTime();
-      updateItemsProperties = true;
-    }
-    for (unsigned int i = 0; i < m_staticItems.size(); ++i)
-    {
-      CGUIStaticItemPtr staticItem = boost::static_pointer_cast<CGUIStaticItem>(m_staticItems[i]);
-      if (staticItem->UpdateVisibility(GetParentID()))
-        refreshItems = true;
-      if (staticItem->IsVisible())
-      {
-        items.push_back(staticItem);
-        // if item is selected and it changed position, re-select it
-        if (staticItem.get() == selectedItem && selected != (int)items.size() - 1)
-          reselect = items.size() - 1;
-      }
-      // update any properties
-      if (updateItemsProperties)
-        staticItem->UpdateProperties(GetParentID());
-    }
-    if (refreshItems)
-    {
+      // save the current item
+      int currentItem = GetSelectedItem();
+      CGUIListItem *current = (currentItem >= 0 && currentItem < (int)m_items.size()) ? m_items[currentItem].get() : NULL;
       Reset();
-      m_items = items;
+      m_listProvider->Fetch(m_items);
       SetPageControlRange();
-      if (reselect >= 0 && reselect < (int)m_items.size())
-        SelectItem(reselect);
+      // update the newly selected item
+      for (int i = 0; i < (int)m_items.size(); i++)
+      {
+        if (m_items[i].get() == current && i != currentItem)
+        {
+          SelectItem(i);
+          break;
+        }
+      }
       SetInvalid();
     }
+    // always update the scroll by letter, as the list provider may have altered labels
+    // while not actually changing the list items.
     UpdateScrollByLetter();
   }
 }
@@ -1034,34 +1014,19 @@ void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)
   }
 }
 
-void CGUIBaseContainer::LoadContent(TiXmlElement *content)
+void CGUIBaseContainer::LoadListProvider(TiXmlElement *content, int defaultItem, bool defaultAlways)
 {
-  TiXmlElement *root = content->FirstChildElement("content");
-  if (!root)
-    return;
-
-  vector<CGUIListItemPtr> items;
-  TiXmlElement *item = root->FirstChildElement("item");
-  while (item)
-  {
-    if (item->FirstChild())
-    {
-      CGUIStaticItemPtr newItem(new CGUIStaticItem(item, GetParentID()));
-      items.push_back(newItem);
-    }
-    item = item->NextSiblingElement("item");
-  }
-  SetStaticContent(items, false);
+  delete m_listProvider;
+  m_listProvider = IListProvider::Create(content, GetParentID());
+  if (m_listProvider)
+    m_listProvider->SetDefaultItem(defaultItem, defaultAlways);
 }
 
-void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items, bool forceUpdate /* = true */)
+void CGUIBaseContainer::SetListProvider(IListProvider *provider)
 {
-  m_staticContent = true;
-  m_staticUpdateTime = 0;
-  m_staticItems.clear();
-  m_staticItems.assign(items.begin(), items.end());
-  if (forceUpdate)
-    UpdateStaticItems(true);
+  delete m_listProvider;
+  m_listProvider = provider;
+  UpdateListProvider(true);
 }
 
 void CGUIBaseContainer::SetRenderOffset(const CPoint &offset)
@@ -1242,26 +1207,10 @@ bool CGUIBaseContainer::CanFocus() const
   return (!m_items.empty() && CGUIControl::CanFocus());
 }
 
-void CGUIBaseContainer::SelectStaticItemById(int id)
-{
-  if (m_staticContent)
-  {
-    for (unsigned int i = 0 ; i < m_items.size() ; i++)
-    {
-      CGUIStaticItemPtr item = boost::static_pointer_cast<CGUIStaticItem>(m_items[i]);
-      if (item->m_iprogramCount == id)
-      {
-        SelectItem(i);
-        return;
-      }
-    }
-  }
-}
-
 void CGUIBaseContainer::OnFocus()
 {
-  if (m_staticDefaultAlways)
-    SelectStaticItemById(m_staticDefaultItem);
+  if (m_listProvider && m_listProvider->AlwaysFocusDefaultItem())
+    SelectItem(m_listProvider->GetDefaultItem());
 
   CGUIControl::OnFocus();
 }

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -34,6 +34,8 @@
  \brief
  */
 
+class IListProvider;
+
 class CGUIBaseContainer : public IGUIContainer
 {
 public:
@@ -68,16 +70,18 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
   void LoadLayout(TiXmlElement *layout);
-  void LoadContent(TiXmlElement *content);
-  void SetDefaultControl(int id, bool always) { m_staticDefaultItem = id; m_staticDefaultAlways = always; };
+  void LoadListProvider(TiXmlElement *content, int defaultItem, bool defaultAlways);
 
   virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
 
   virtual bool GetCondition(int condition, int data) const;
   virtual CStdString GetLabel(int info) const;
 
-  void SetStaticContent(const std::vector<CGUIListItemPtr> &items, bool forceUpdate = true);
-  
+  /*! \brief Set the list provider for this container (for python).
+   \param provider the list provider to use for this container.
+   */
+  void SetListProvider(IListProvider *provider);
+
   /*! \brief Set the offset of the first item in the container from the container's position
    Useful for lists/panels where the focused item may be larger than the non-focused items and thus
    normally cut off from the clipping window defined by the container's position + size.
@@ -107,7 +111,6 @@ protected:
   virtual void UpdatePageControl(int offset);
   virtual void CalculateLayout();
   virtual void SelectItem(int item) {};
-  void SelectStaticItemById(int id);
   virtual bool SelectItemFromPoint(const CPoint &point) { return false; };
   virtual int GetCursorFromPoint(const CPoint &point, CPoint *itemPoint = NULL) const { return -1; };
   virtual void Reset();
@@ -115,7 +118,7 @@ protected:
   virtual int GetCurrentPage() const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
   virtual void OnFocus();
-  void UpdateStaticItems(bool refreshItems = false);
+  void UpdateListProvider(bool refreshItems = false);
 
   int ScrollCorrectionRange() const;
   inline float Size() const;
@@ -150,11 +153,8 @@ protected:
 
   CScroller m_scroller;
 
-  bool m_staticContent;
-  bool m_staticDefaultAlways;
-  int  m_staticDefaultItem;
-  unsigned int m_staticUpdateTime;
-  std::vector<CGUIListItemPtr> m_staticItems;
+  IListProvider *m_listProvider;
+
   bool m_wasReset;  // true if we've received a Reset message until we've rendered once.  Allows
                     // us to make sure we don't tell the infomanager that we've been moving when
                     // the "movement" was simply due to the list being repopulated (thus cursor position

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1230,8 +1230,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
     control = new CGUIListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIListContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIListContainer *)control)->LoadContent(pControlNode);
-    ((CGUIListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIListContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIListContainer *)control)->SetPageControl(pageControl);
     ((CGUIListContainer *)control)->SetRenderOffset(offset);
@@ -1243,8 +1242,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
     control = new CGUIWrappingListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition);
     ((CGUIWrappingListContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIWrappingListContainer *)control)->LoadContent(pControlNode);
-    ((CGUIWrappingListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIWrappingListContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIWrappingListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIWrappingListContainer *)control)->SetPageControl(pageControl);
     ((CGUIWrappingListContainer *)control)->SetRenderOffset(offset);
@@ -1263,8 +1261,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
     control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition, iMovementRange);
     ((CGUIFixedListContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIFixedListContainer *)control)->LoadContent(pControlNode);
-    ((CGUIFixedListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIFixedListContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIFixedListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIFixedListContainer *)control)->SetPageControl(pageControl);
     ((CGUIFixedListContainer *)control)->SetRenderOffset(offset);
@@ -1276,8 +1273,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
     control = new CGUIPanelContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIPanelContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIPanelContainer *)control)->LoadContent(pControlNode);
-    ((CGUIPanelContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIPanelContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIPanelContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIPanelContainer *)control)->SetPageControl(pageControl);
     ((CGUIPanelContainer *)control)->SetRenderOffset(offset);

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -45,7 +45,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     const char *id = item->Attribute("id");
     CStdString condition;
     CGUIControlFactory::GetConditionalVisibility(item, condition);
-    m_visCondition = g_infoManager.Register(condition, parentID);
+    SetVisibleCondition(condition, parentID);
     CGUIControlFactory::GetActions(item, "onclick", m_clickActions);
     SetLabel(label.GetLabel(parentID));
     SetLabel2(label2.GetLabel(parentID));
@@ -134,4 +134,10 @@ bool CGUIStaticItem::IsVisible() const
   if (m_visCondition)
     return m_visState;
   return true;
+}
+
+void CGUIStaticItem::SetVisibleCondition(const std::string &condition, int context)
+{
+  m_visCondition = g_infoManager.Register(condition, context);
+  m_visState = false;
 }

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -87,7 +87,14 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     m_iprogramCount = id ? atoi(id) : 0;
   }
 }
-    
+
+CGUIStaticItem::CGUIStaticItem(const CFileItem &item)
+: CFileItem(item)
+{
+  m_visCondition = 0;
+  m_visState = false;
+}
+
 void CGUIStaticItem::UpdateProperties(int contextWindow)
 {
   for (InfoVector::const_iterator i = m_info.begin(); i != m_info.end(); ++i)

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -79,6 +79,12 @@ public:
    */
   bool IsVisible() const;
 
+  /*! \brief set a visible condition for this item.
+   \param condition the condition to use.
+   \param context the context for the condition (typically a window id).
+   */
+  void SetVisibleCondition(const std::string &condition, int context);
+
   const CGUIAction &GetClickActions() const { return m_clickActions; };
 private:
   typedef std::vector< std::pair<CGUIInfoLabel, CStdString> > InfoVector;

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -58,6 +58,7 @@ public:
    \param contextWindow window context to use for any info labels
    */
   CGUIStaticItem(const TiXmlElement *element, int contextWindow);
+  CGUIStaticItem(const CFileItem &item); // for python
   virtual ~CGUIStaticItem() {};
   virtual CGUIListItem *Clone() const { return new CGUIStaticItem(*this); };
   

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -38,6 +38,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIControlFactory.h"
+#include "listproviders/StaticProvider.h"
 
 #include "utils/XBMCTinyXML.h"
 #include "utils/StringUtils.h"
@@ -1400,22 +1401,21 @@ namespace XBMCAddon
     {
       const ListItemList& vecItems = *pitems;
 
-      std::vector<CGUIListItemPtr> items;
+      std::vector<CGUIStaticItemPtr> items;
 
       for (unsigned int item = 0; item < vecItems.size(); item++)
       {
         ListItem* pItem = vecItems[item];
 
-        // object is a listitem, and we set m_idpeth to 0 as this
-        // is used as the visibility condition for the item in the list
-        ListItem *listItem = (ListItem*)pItem;
-        listItem->item->m_idepth = 0;
-
-        items.push_back((CFileItemPtr &)listItem->item);
+        // NOTE: This code has likely not worked fully correctly for some time
+        //       In particular, the click behaviour won't be working.
+        CGUIStaticItemPtr newItem(new CGUIStaticItem(*pItem->item));
+        items.push_back(newItem);
       }
 
       // set static list
-      ((CGUIBaseContainer *)pGUIControl)->SetStaticContent(items);
+      IListProvider *provider = new CStaticListProvider(items);
+      ((CGUIBaseContainer *)pGUIControl)->SetListProvider(provider);
     }
 
     // ============================================================

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -1,0 +1,194 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DirectoryProvider.h"
+#include "filesystem/Directory.h"
+#include "filesystem/FavouritesDirectory.h"
+#include "utils/JobManager.h"
+#include "utils/StringUtils.h"
+#include "utils/TimeUtils.h"
+#include "utils/XMLUtils.h"
+#include "threads/SingleLock.h"
+#include "ApplicationMessenger.h"
+#include "FileItem.h"
+
+using namespace std;
+using namespace XFILE;
+
+class CDirectoryJob : public CJob
+{
+public:
+  CDirectoryJob(const std::string &url, int parentID) : m_url(url), m_parentID(parentID) { };
+  virtual ~CDirectoryJob() {};
+
+  virtual const char* GetType() const { return "directory"; };
+  virtual bool operator==(const CJob *job) const
+  {
+    if (strcmp(job->GetType(),GetType()) == 0)
+    {
+      const CDirectoryJob* dirJob = dynamic_cast<const CDirectoryJob*>(job);
+      if (dirJob && dirJob->m_url == m_url)
+        return true;
+    }
+    return false;
+  }
+
+  virtual bool DoWork()
+  {
+    CFileItemList items;
+    if (CDirectory::GetDirectory(m_url, items, ""))
+    {
+      // convert to CGUIStaticItem's and set visibility and targets
+      m_items.reserve(items.Size());
+      for (int i = 0; i < items.Size(); i++)
+      {
+        CGUIStaticItemPtr item(new CGUIStaticItem(*items[i]));
+        if (item->HasProperty("node.visible"))
+          item->SetVisibleCondition(item->GetProperty("node.visible").asString(), m_parentID);
+        m_items.push_back(item);
+      }
+      m_target = items.GetProperty("node.target").asString();
+    }
+    return true;    
+  }
+
+  const std::vector<CGUIStaticItemPtr> &GetItems() const { return m_items; }
+  const std::string &GetTarget() const { return m_target; }
+private:
+  std::string m_url;
+  std::string m_target;
+  int m_parentID;
+  std::vector<CGUIStaticItemPtr> m_items;
+};
+
+CDirectoryProvider::CDirectoryProvider(const TiXmlElement *element, int parentID)
+ : IListProvider(parentID),
+   m_updateTime(0),
+   m_invalid(false),
+   m_jobID(0)
+{
+  assert(element);
+
+  if (!element->NoChildren())
+  {
+    const char *target = element->Attribute("target");
+    if (target)
+      m_target.SetLabel(target, "", parentID);
+    m_url.SetLabel(element->FirstChild()->ValueStr(), "", parentID);
+  }
+}
+
+CDirectoryProvider::~CDirectoryProvider()
+{
+  CSingleLock lock(m_section);
+  if (m_jobID)
+    CJobManager::GetInstance().CancelJob(m_jobID);
+}
+
+bool CDirectoryProvider::Update(bool refresh)
+{
+  bool changed = refresh;
+  {
+    CSingleLock lock(m_section);
+    changed |= m_invalid;
+    m_invalid = false;
+  }
+
+  // update our the URL and fire off a new job if needed
+  CStdString value(m_url.GetLabel(m_parentID, false));
+  if (value != m_currentUrl)
+  {
+    m_currentUrl = value;
+
+    if (refresh)
+    { // if refreshing, read the directory synchronously
+      CDirectoryJob job(m_currentUrl, m_parentID);
+      if (job.DoWork())
+      {
+        m_items = job.GetItems();
+        m_currentTarget = job.GetTarget();
+        changed = true;
+      }
+    }
+    else
+    { // fire job
+      CSingleLock lock(m_section);
+      if (m_jobID)
+        CJobManager::GetInstance().CancelJob(m_jobID);
+      m_jobID = CJobManager::GetInstance().AddJob(new CDirectoryJob(m_currentUrl, m_parentID), this);
+    }
+  }
+
+  for (vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
+    changed |= (*i)->UpdateVisibility(m_parentID);
+  return changed; // TODO: Also returned changed if properties are changed (if so, need to update scroll to letter).
+}
+
+void CDirectoryProvider::Fetch(vector<CGUIListItemPtr> &items) const
+{
+  CSingleLock lock(m_section);
+  items.clear();
+  for (vector<CGUIStaticItemPtr>::const_iterator i = m_items.begin(); i != m_items.end(); ++i)
+  {
+    if ((*i)->IsVisible())
+      items.push_back(*i);
+  }
+}
+
+void CDirectoryProvider::Reset()
+{
+  // cancel any pending jobs
+  CSingleLock lock(m_section);
+  if (m_jobID)
+    CJobManager::GetInstance().CancelJob(m_jobID);
+  m_jobID = 0;
+}
+
+void CDirectoryProvider::OnJobComplete(unsigned int jobID, bool success, CJob *job)
+{
+  CSingleLock lock(m_section);
+  if (success)
+  {
+    m_items = ((CDirectoryJob*)job)->GetItems();
+    m_currentTarget = ((CDirectoryJob*)job)->GetTarget();
+    m_invalid = true;
+  }
+  m_jobID = 0;
+}
+
+bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
+{
+  CFileItem fileItem(*boost::static_pointer_cast<CFileItem>(item));
+  string target = fileItem.GetProperty("node.target").asString();
+  if (target.empty())
+    target = m_currentTarget;
+  if (target.empty())
+    target = m_target.GetLabel(m_parentID, false);
+  if (fileItem.HasProperty("node.target_url"))
+    fileItem.SetPath(fileItem.GetProperty("node.target_url").asString());
+  // grab the execute string
+  string execute = CFavouritesDirectory::GetExecutePath(fileItem, target);
+  if (!execute.empty())
+  {
+    CApplicationMessenger::Get().ExecBuiltIn(execute);
+    return true;
+  }
+  return false;
+}

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include "IListProvider.h"
+#include "guilib/GUIStaticItem.h"
+#include "utils/Job.h"
+#include "threads/CriticalSection.h"
+
+class TiXmlElement;
+
+class CDirectoryProvider : public IListProvider, public IJobCallback
+{
+public:
+  CDirectoryProvider(const TiXmlElement *element, int parentID);
+  virtual ~CDirectoryProvider();
+
+  virtual bool Update(bool refresh);
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const;
+  virtual void Reset();
+  virtual bool OnClick(const CGUIListItemPtr &item);
+
+  // callback from directory job
+  virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
+private:
+  unsigned int     m_updateTime;
+  bool             m_invalid;
+  unsigned int     m_jobID;
+  CGUIInfoLabel    m_url;
+  CGUIInfoLabel    m_target;
+  std::string      m_currentUrl;
+  std::string      m_currentTarget;   ///< \brief node.target property on the list as a whole
+  std::vector<CGUIStaticItemPtr> m_items;
+  CCriticalSection m_section;
+};

--- a/xbmc/listproviders/IListProvider.cpp
+++ b/xbmc/listproviders/IListProvider.cpp
@@ -1,0 +1,35 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "IListProvider.h"
+#include "utils/XBMCTinyXML.h"
+#include "StaticProvider.h"
+
+IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
+{
+  const TiXmlElement *root = node->FirstChildElement("content");
+  if (root)
+  {
+    const TiXmlElement *item = root->FirstChildElement("item");
+    if (item)
+      return new CStaticListProvider(root, parentID);
+  }
+  return NULL;
+}

--- a/xbmc/listproviders/IListProvider.cpp
+++ b/xbmc/listproviders/IListProvider.cpp
@@ -21,6 +21,7 @@
 #include "IListProvider.h"
 #include "utils/XBMCTinyXML.h"
 #include "StaticProvider.h"
+#include "DirectoryProvider.h"
 
 IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
 {
@@ -30,6 +31,9 @@ IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
     const TiXmlElement *item = root->FirstChildElement("item");
     if (item)
       return new CStaticListProvider(root, parentID);
+
+    if (!root->NoChildren())
+      return new CDirectoryProvider(root, parentID);
   }
   return NULL;
 }

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -1,0 +1,88 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <vector>
+#include "boost/shared_ptr.hpp"
+
+class TiXmlNode;
+class CGUIListItem;
+typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
+
+/*!
+ \ingroup listproviders
+ \brief An interface for providing lists to UI containers.
+ */
+class IListProvider
+{
+public:
+  IListProvider(int parentID) : m_parentID(parentID) {}
+  virtual ~IListProvider() {}
+
+  /*! \brief Factory to create list providers.
+   \param node a TiXmlNode to create.
+   \param parentID id of parent window for context.
+   \return the list provider, NULL if none.
+   */
+  static IListProvider *Create(const TiXmlNode *node, int parentID);
+
+  /*! \brief Update the list content
+   \return true if the content has changed, false otherwise.
+   */
+  virtual bool Update(bool refresh)=0;
+
+  /*! \brief Fetch the current list of items.
+   \param items [out] the list to be filled.
+   */
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const=0;
+
+  /*! \brief Reset the current list of items.
+   Derived classes may choose to ignore this.
+   */
+  virtual void Reset() {};
+
+  /*! \brief Click event on an item.
+   \param item the item that was clicked.
+   \return true if the click was handled, false otherwise.
+   */
+  virtual bool OnClick(const CGUIListItemPtr &item)=0;
+
+  /*! \brief Set the default item to focus. For backwards compatibility.
+   \param item the item to focus.
+   \param always whether this item should always be used on first focus.
+   \sa GetDefaultItem, AlwaysFocusDefaultItem
+   */
+  virtual void SetDefaultItem(int item, bool always) {};
+
+  /*! \brief The default item to focus.
+   \return the item to focus by default. -1 for none.
+   \sa SetDefaultItem, AlwaysFocusDefaultItem
+   */
+  virtual int GetDefaultItem() const { return -1; }
+
+  /*! \brief Whether to always focus the default item.
+   \return true if the default item should always be the one to receive focus.
+   \sa GetDefaultItem, SetDefaultItem
+   */
+  virtual bool AlwaysFocusDefaultItem() const { return false; }
+protected:
+  int m_parentID;
+};

--- a/xbmc/listproviders/Makefile
+++ b/xbmc/listproviders/Makefile
@@ -1,0 +1,7 @@
+SRCS  = IListProvider.cpp
+SRCS += StaticProvider.cpp
+     
+LIB=listproviders.a
+
+include ../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -1,0 +1,121 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "StaticProvider.h"
+#include "utils/XMLUtils.h"
+#include "utils/TimeUtils.h"
+
+using namespace std;
+
+CStaticListProvider::CStaticListProvider(const TiXmlElement *element, int parentID)
+: IListProvider(parentID),
+  m_defaultItem(-1),
+  m_defaultAlways(false),
+  m_updateTime(0)
+{
+  assert(element);
+
+  const TiXmlElement *item = element->FirstChildElement("item");
+  while (item)
+  {
+    if (item->FirstChild())
+    {
+      CGUIStaticItemPtr newItem(new CGUIStaticItem(item, parentID));
+      m_items.push_back(newItem);
+    }
+    item = item->NextSiblingElement("item");
+  }
+
+  if (XMLUtils::GetInt(element, "default", m_defaultItem))
+  {
+    const char *always = element->FirstChildElement("default")->Attribute("always");
+    if (always && strnicmp(always, "true", 4) == 0)
+      m_defaultAlways = true;
+  }
+}
+
+CStaticListProvider::CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items)
+: IListProvider(0),
+  m_defaultItem(-1),
+  m_defaultAlways(false),
+  m_updateTime(0),
+  m_items(items)
+{
+}
+
+CStaticListProvider::~CStaticListProvider()
+{
+}
+
+bool CStaticListProvider::Update(bool refresh)
+{
+  bool changed = refresh;
+  if (!m_updateTime)
+    m_updateTime = CTimeUtils::GetFrameTime();
+  else if (CTimeUtils::GetFrameTime() - m_updateTime > 1000)
+  {
+    m_updateTime = CTimeUtils::GetFrameTime();
+    for (vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
+      (*i)->UpdateProperties(m_parentID);
+  }
+  for (vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
+    changed |= (*i)->UpdateVisibility(m_parentID);
+  return changed; // TODO: Also returned changed if properties are changed (if so, need to update scroll to letter).
+}
+
+void CStaticListProvider::Fetch(vector<CGUIListItemPtr> &items) const
+{
+  items.clear();
+  for (vector<CGUIStaticItemPtr>::const_iterator i = m_items.begin(); i != m_items.end(); ++i)
+  {
+    if ((*i)->IsVisible())
+      items.push_back(*i);
+  }
+}
+
+void CStaticListProvider::SetDefaultItem(int item, bool always)
+{
+  m_defaultItem = item;
+  m_defaultAlways = always;
+}
+
+int CStaticListProvider::GetDefaultItem() const
+{
+  if (m_defaultItem >= 0)
+  {
+    for (vector<CGUIStaticItemPtr>::const_iterator i = m_items.begin(); i != m_items.end(); ++i)
+    {
+      if ((*i)->m_iprogramCount == m_defaultItem && (*i)->IsVisible())
+        return i - m_items.begin();
+    }
+  }
+  return -1;
+}
+
+bool CStaticListProvider::AlwaysFocusDefaultItem() const
+{
+  return m_defaultAlways;
+}
+
+bool CStaticListProvider::OnClick(const CGUIListItemPtr &item)
+{
+  CGUIStaticItemPtr staticItem = boost::static_pointer_cast<CGUIStaticItem>(item);
+  return staticItem->GetClickActions().ExecuteActions(0, m_parentID);
+}

--- a/xbmc/listproviders/StaticProvider.h
+++ b/xbmc/listproviders/StaticProvider.h
@@ -1,0 +1,44 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "IListProvider.h"
+#include "guilib/GUIStaticItem.h"
+
+class CStaticListProvider : public IListProvider
+{
+public:
+  CStaticListProvider(const TiXmlElement *element, int parentID);
+  CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items); // for python
+  virtual ~CStaticListProvider();
+
+  virtual bool Update(bool refresh);
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const;
+  virtual bool OnClick(const CGUIListItemPtr &item);
+  virtual void SetDefaultItem(int item, bool always);
+  virtual int  GetDefaultItem() const;
+  virtual bool AlwaysFocusDefaultItem() const;
+private:
+  int                            m_defaultItem;
+  bool                           m_defaultAlways;
+  unsigned int                   m_updateTime;
+  std::vector<CGUIStaticItemPtr> m_items;
+};

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -38,7 +38,7 @@ extern "C"
   float       GetIOSVersion(void);
   int         GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize);
   int         GetDarwinExecutablePath(char* path, uint32_t *pathsize);
-  const std::string& DarwinGetXbmcRootFolder(void);
+  const char *DarwinGetXbmcRootFolder(void);
   bool        DarwinIsIosSandboxed(void);
   bool        DarwinHasVideoToolboxDecoder(void);
   int         DarwinBatteryLevel(void);

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -277,7 +277,7 @@ int  GetDarwinExecutablePath(char* path, uint32_t *pathsize)
   return 0;
 }
 
-const std::string& DarwinGetXbmcRootFolder(void)
+const char* DarwinGetXbmcRootFolder(void)
 {
   static std::string rootFolder = "";
   if ( rootFolder.length() == 0)
@@ -294,7 +294,7 @@ const std::string& DarwinGetXbmcRootFolder(void)
       rootFolder = "Library/Preferences";
     }
   }
-  return rootFolder;
+  return rootFolder.c_str();
 }
 
 bool DarwinIsIosSandboxed(void)

--- a/xbmc/osx/IOSEAGLView.mm
+++ b/xbmc/osx/IOSEAGLView.mm
@@ -42,7 +42,11 @@
 #import <OpenGLES/ES2/gl.h>
 #import <OpenGLES/ES2/glext.h>
 #import "IOSEAGLView.h"
-#import "XBMCController.h"
+#if defined(TARGET_DARWIN_IOS_ATV2)
+#import "xbmc/osx/atv2/XBMCController.h"
+#elif defined(TARGET_DARWIN_IOS)
+#import "xbmc/osx/ios/XBMCController.h"
+#endif
 #import "IOSScreenManager.h"
 #import "AutoPool.h"
 #import "DarwinUtils.h"

--- a/xbmc/osx/IOSScreenManager.mm
+++ b/xbmc/osx/IOSScreenManager.mm
@@ -35,7 +35,11 @@
 #include <objc/runtime.h>
 
 #import "IOSScreenManager.h"
-#import "XBMCController.h"
+#if defined(TARGET_DARWIN_IOS_ATV2)
+#import "xbmc/osx/atv2/XBMCController.h"
+#elif defined(TARGET_DARWIN_IOS)
+#import "xbmc/osx/ios/XBMCController.h"
+#endif
 #import "IOSExternalTouchController.h"
 #import "IOSEAGLView.h"
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -420,7 +420,7 @@ void CAdvancedSettings::Initialize()
     #if defined(TARGET_DARWIN_OSX)
     logDir += "/Library/Logs/";
     #else // ios/atv2
-    logDir += "/" + DarwinGetXbmcRootFolder() + "/";
+    logDir += "/" + CStdString(DarwinGetXbmcRootFolder()) + "/";
     #endif
     m_logFolder = logDir;
   #else

--- a/xbmc/windowing/egl/wayland/XBMCConnection.h
+++ b/xbmc/windowing/egl/wayland/XBMCConnection.h
@@ -31,7 +31,7 @@ struct wl_output;
 struct wl_shell;
 struct wl_seat;
 
-typedef struct wl_egl_window * EGLNativeWindowType;
+typedef struct wl_display * EGLNativeDisplayType;
 
 struct RESOLUTION_INFO;
 


### PR DESCRIPTION
This allows the menu system in XBMC to be customised.  It extends the video library XML system to the home menu screen.

There's still a reasonable chunk to be done:
1. Testing with multiple skins to make sure I didn't break (too) much.  Didn't do much testing of music as yet.
2. Cleaning up Confluence (@ronie?)
3. Cleaning up the directory structure a bit (@da-anda?)
4. Various cleanups in the code, such as removing video library flattening, cleaning up the directory starting points of each window etc. (they should now probably be hardcoded).

I'm not particularly happy about the (mis)use of the hidden attribute.  Ideas welcome.
