### PR TITLE
[addons] revert adding Gotham repo

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -13,13 +13,6 @@
 		<datadir zip="true">http://mirrors.xbmc.org/addons/frodo</datadir>
 		<hashes>true</hashes>
 	</extension>
-	<extension point="xbmc.addon.repository"
-		name="XBMC.org Gotham Repository">
-		<info compressed="true">http://mirrors.xbmc.org/addons/gotham/addons.xml</info>
-		<checksum>http://mirrors.xbmc.org/addons/gotham/addons.xml.md5</checksum>
-		<datadir zip="true">http://mirrors.xbmc.org/addons/gotham</datadir>
-		<hashes>true</hashes>
-	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="af">Installeer Byvoegsels vanaf XBMC.org</summary>
 		<summary lang="am">ከ XBMC.org ተጨማ-ሪዎች መግጠሚያ </summary>


### PR DESCRIPTION
since having multiple extension points only use the last one addon.xml

@cptspiff or do you have another idea how to solve this?
other option would be like done with Frodo just pushing every compatible addon to both repos
