### PR TITLE
CharsetСonverter rework - Part 2

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -920,6 +920,7 @@ fi
 AC_LANG_PUSH([C++])
 AC_CHECK_TYPES([std::u16string, std::u32string], [], [], [[#include <string>]])
 AC_CHECK_TYPES([char16_t, char32_t])
+AC_CHECK_SIZEOF([wchar_t])
 AC_LANG_POP([C++])
 
 # Add top source directory for all builds so we can use config.h

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -480,6 +480,13 @@ bool CCharsetConverter::utf8ToUtf32(const std::string& utf8StringSrc, std::u32st
   return convert(m_iconvUtf8ToUtf32, 1, UTF8_SOURCE, "UTF-32", utf8StringSrc, utf32StringDst, failOnBadChar);
 }
 
+std::u32string CCharsetConverter::utf8ToUtf32(const std::string& utf8StringSrc, bool failOnBadChar /*= true*/)
+{
+  std::u32string converted;
+  utf8ToUtf32(utf8StringSrc, converted, failOnBadChar);
+  return converted;
+}
+
 bool CCharsetConverter::utf8ToUtf32Visual(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool bVisualBiDiFlip /*= false*/, bool forceLTRReadingOrder /*= false*/, bool failOnBadChar /*= false*/)
 {
   if (bVisualBiDiFlip)
@@ -498,6 +505,13 @@ bool CCharsetConverter::utf32ToUtf8(const std::u32string& utf32StringSrc, std::s
 {
   CSingleLock lock(m_critSection);
   return convert(m_iconvUtf32ToUtf8, m_Utf8CharMaxSize, "UTF-32", "UTF-8", utf32StringSrc, utf8StringDst, failOnBadChar);
+}
+
+std::string CCharsetConverter::utf32ToUtf8(const std::u32string& utf32StringSrc, bool failOnBadChar /*= false*/)
+{
+  std::string converted;
+  utf32ToUtf8(utf32StringSrc, converted, failOnBadChar);
+  return converted;
 }
 
 bool CCharsetConverter::utf32ToW(const std::u32string& utf32StringSrc, std::wstring& wStringDst, bool failOnBadChar /*= true*/)

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -42,6 +42,69 @@ public:
 
   void clear();
 
+  /**
+   * Convert UTF-8 string to UTF-32 string.
+   * No RTL logical-visual transformation is performed.
+   * @param utf8StringSrc       is source UTF-8 string to convert
+   * @param utf32StringDst      is output UTF-32 string, empty on any error
+   * @param failOnBadChar       if set to true function will fail on invalid character,
+   *                            otherwise invalid character will be skipped
+   * @return true on successful conversion, false on any error
+   */
+  bool utf8ToUtf32(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool failOnBadChar = true);
+  /**
+   * Convert UTF-8 string to UTF-32 string.
+   * RTL logical-visual transformation is optionally performed.
+   * Use it for readable text, GUI strings etc.
+   * @param utf8StringSrc       is source UTF-8 string to convert
+   * @param utf32StringDst      is output UTF-32 string, empty on any error
+   * @param bVisualBiDiFlip     allow RTL visual-logical transformation if set to true, must be set
+   *                            to false is logical-visual transformation is already done
+   * @param forceLTRReadingOrder        force LTR reading order
+   * @param failOnBadChar       if set to true function will fail on invalid character,
+   *                            otherwise invalid character will be skipped
+   * @return true on successful conversion, false on any error
+   */
+  bool utf8ToUtf32Visual(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool bVisualBiDiFlip = false, bool forceLTRReadingOrder = false, bool failOnBadChar = false);
+  /**
+   * Convert UTF-32 string to UTF-8 string.
+   * No RTL visual-logical transformation is performed.
+   * @param utf32StringSrc      is source UTF-32 string to convert
+   * @param utf8StringDst       is output UTF-8 string, empty on any error
+   * @param failOnBadChar       if set to true function will fail on invalid character,
+   *                            otherwise invalid character will be skipped
+   * @return true on successful conversion, false on any error
+   */
+  bool utf32ToUtf8(const std::u32string& utf32StringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
+  /**
+   * Convert UTF-32 string to wchar_t string (wstring).
+   * No RTL visual-logical transformation is performed.
+   * @param utf32StringSrc      is source UTF-32 string to convert
+   * @param wStringDst          is output wchar_t string, empty on any error
+   * @param failOnBadChar       if set to true function will fail on invalid character,
+   *                            otherwise invalid character will be skipped
+   * @return true on successful conversion, false on any error
+   */
+  bool utf32ToW(const std::u32string& utf32StringSrc, std::wstring& wStringDst, bool failOnBadChar = false);
+  /**
+   * Perform logical to visual flip.
+   * @param logicalStringSrc    is source string with logical characters order
+   * @param visualStringDst     is output string with visual characters order, empty on any error
+   * @param forceLTRReadingOrder        force LTR reading order
+   * @return true on success, false otherwise
+   */
+  bool utf32logicalToVisualBiDi(const std::u32string& logicalStringSrc, std::u32string& visualStringDst, bool forceLTRReadingOrder = false);
+  /**
+   * Strictly convert wchar_t string (wstring) to UTF-32 string.
+   * No RTL visual-logical transformation is performed.
+   * @param wStringSrc          is source wchar_t string to convert
+   * @param utf32StringDst      is output UTF-32 string, empty on any error
+   * @param failOnBadChar       if set to true function will fail on invalid character,
+   *                            otherwise invalid character will be skipped
+   * @return true on successful conversion, false on any error
+   */
+  bool wToUtf32(const std::wstring& wStringSrc, std::u32string& utf32StringDst, bool failOnBadChar = false);
+
   bool utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst,
                 bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false,
                 bool failOnBadChar = false, bool* bWasFlipped = NULL);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -54,6 +54,15 @@ public:
   bool utf8ToUtf32(const std::string& utf8StringSrc, std::u32string& utf32StringDst, bool failOnBadChar = true);
   /**
    * Convert UTF-8 string to UTF-32 string.
+   * No RTL logical-visual transformation is performed.
+   * @param utf8StringSrc       is source UTF-8 string to convert
+   * @param failOnBadChar       if set to true function will fail on invalid character,
+   *                            otherwise invalid character will be skipped
+   * @return converted string on successful conversion, empty string on any error
+   */
+  std::u32string utf8ToUtf32(const std::string& utf8StringSrc, bool failOnBadChar = true);
+  /**
+   * Convert UTF-8 string to UTF-32 string.
    * RTL logical-visual transformation is optionally performed.
    * Use it for readable text, GUI strings etc.
    * @param utf8StringSrc       is source UTF-8 string to convert
@@ -76,6 +85,15 @@ public:
    * @return true on successful conversion, false on any error
    */
   bool utf32ToUtf8(const std::u32string& utf32StringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
+  /**
+   * Convert UTF-32 string to UTF-8 string.
+   * No RTL visual-logical transformation is performed.
+   * @param utf32StringSrc      is source UTF-32 string to convert
+   * @param failOnBadChar       if set to true function will fail on invalid character,
+   *                            otherwise invalid character will be skipped
+   * @return converted string on successful conversion, empty string on any error
+   */
+  std::string utf32ToUtf8(const std::u32string& utf32StringSrc, bool failOnBadChar = false);
   /**
    * Convert UTF-32 string to wchar_t string (wstring).
    * No RTL visual-logical transformation is performed.


### PR DESCRIPTION
As std::u32string will be widely used across the code, we need convenient framework for UTF-32 conversions.
This PR will add support for easy conversion UTF-32<->UTF-8 and UTF-32<->wide string.
On platforms with UTF-32 == wide string, wide<->UTF-32 conversion is done by simple assignment.
