### PR TITLE
CharsetConverter: fix for logicalToVisualBiDi

### DIFF
--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -299,6 +299,8 @@ static bool logicalToVisualBiDi(const std::string& stringSrc, std::string& strin
   for (size_t i = 0; i < numLines; i++)
   {
     int sourceLen = lines[i].length();
+    if (sourceLen == 0)
+      continue;
 
     // Convert from the selected charset to Unicode
     FriBidiChar* logical = (FriBidiChar*) malloc((sourceLen + 1) * sizeof(FriBidiChar));


### PR DESCRIPTION
Don't flip empty strings, fix [new[] for zero length](https://github.com/xbmc/xbmc/commit/e2631343ee6522683094d5efb2b0ba23097a83cb#commitcomment-4153718)
