### PR TITLE
[Fix] Fix preferred audio/subtitle language mechanism.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -763,6 +763,8 @@ bool CApplication::Create()
 
   CLog::Log(LOGINFO, "load language info file: %s", strLangInfoPath.c_str());
   g_langInfo.Load(strLangInfoPath);
+  g_langInfo.SetAudioLanguage(CSettings::Get().GetString("locale.audiolanguage"));
+  g_langInfo.SetSubtitleLanguage(CSettings::Get().GetString("locale.subtitlelanguage"));
 
   CStdString strLanguagePath = "special://xbmc/language/";
 

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -213,6 +213,15 @@ bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, con
   }
   else if (strCharCode.size() > 3)
   {
+    for(unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
+    {
+      if (strCharCode.Equals(g_iso639_2[i].name))
+      {
+        CodeToString(g_iso639_2[i].code, strThreeCharCode);
+        return true;
+      }
+    }
+
     CStdString strLangInfoPath;
     strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", strCharCode.c_str());
     CLangInfo langInfo;


### PR DESCRIPTION
It seems that the automatic selection of tracks with a language which has no langinfo.xml never worked.
The two commits offer two different approaches to solve this issue. Please vote for one of them.
