### PR TITLE
[Confluence] add weather provider logo

### DIFF
--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -98,6 +98,14 @@
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
 				</control>
+				<control type="image">
+					<posx>70</posx>
+					<posy>40</posy>
+					<width>360</width>
+					<height>90</height>
+					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<texture>$INFO[Window.Property(WeatherProviderLogo)]</texture>
+				</control>
 				<control type="label">
 					<description>Provider Text</description>
 					<posx>20</posx>
@@ -111,80 +119,84 @@
 					<aligny>center</aligny>
 					<label>$LOCALIZE[31303] : [COLOR=orange]$INFO[Window.Property(WeatherProvider)][/COLOR]</label>
 					<include>Window_OpenClose_Animation</include>
+					<visible>IsEmpty(Window.Property(WeatherProviderLogo))</visible>
 				</control>
-				<control type="label">
-					<description>weather location label</description>
-					<posx>20</posx>
-					<posy>80</posy>
-					<width>460</width>
-					<height>30</height>
-					<font>font13_title</font>
-					<textcolor>white</textcolor>
-					<scroll>false</scroll>
-					<align>center</align>
-					<aligny>center</aligny>
-					<label>$INFO[Window.Property(Location)]</label>
-				</control>
-				<control type="label">
-					<description>update label</description>
-					<posx>20</posx>
-					<posy>100</posy>
-					<width>460</width>
-					<height>35</height>
-					<font>font12</font>
-					<label>$LOCALIZE[31301] - $INFO[Window.Property(Updated)]</label>
-					<align>center</align>
-					<aligny>center</aligny>
-					<textcolor>grey2</textcolor>
-				</control>
-				<control type="label">
-					<description>current temp Value</description>
-					<posx>195</posx>
-					<posy>175</posy>
-					<width>180</width>
-					<height>40</height>
-					<font>WeatherTemp</font>
-					<align>right</align>
-					<aligny>top</aligny>
-					<label>$INFO[Window.Property(Current.Temperature)]</label>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
-				</control>
-				<control type="label">
-					<description>current temp Value Units</description>
-					<posx>190</posx>
-					<posy>185</posy>
-					<width>100</width>
-					<height>40</height>
-					<font>font16</font>
-					<align>left</align>
-					<aligny>top</aligny>
-					<label>$INFO[System.TemperatureUnits]</label>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
-				</control>
-				<control type="image">
-					<description>current weather icon</description>
-					<posx>230</posx>
-					<posy>120</posy>
-					<width>230</width>
-					<height>230</height>
-					<info>Window.Property(Current.ConditionIcon)</info>
-					<aspectratio>keep</aspectratio>
-				</control>
-				<control type="label">
-					<description>current condition label</description>
-					<posx>20</posx>
-					<posy>320</posy>
-					<width>460</width>
-					<height>30</height>
-					<info>Window.Property(Current.Condition)</info>
-					<wrapmultiline>true</wrapmultiline>
-					<font>font13</font>
-					<align>center</align>
-					<aligny>center</aligny>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
+				<control type="group">
+					<animation effect="slide" start="0,0" end="0,30" condition="!IsEmpty(Window.Property(WeatherProviderLogo))">Conditional</animation>
+					<control type="label">
+						<description>weather location label</description>
+						<posx>20</posx>
+						<posy>100</posy>
+						<width>460</width>
+						<height>30</height>
+						<font>font13_title</font>
+						<textcolor>white</textcolor>
+						<scroll>false</scroll>
+						<align>center</align>
+						<aligny>center</aligny>
+						<label>$INFO[Window.Property(Location)]</label>
+					</control>
+					<control type="label">
+						<description>update label</description>
+						<posx>20</posx>
+						<posy>120</posy>
+						<width>460</width>
+						<height>35</height>
+						<font>font12</font>
+						<label>$LOCALIZE[31301] - $INFO[Window.Property(Updated)]</label>
+						<align>center</align>
+						<aligny>center</aligny>
+						<textcolor>grey2</textcolor>
+					</control>
+					<control type="label">
+						<description>current temp Value</description>
+						<posx>195</posx>
+						<posy>175</posy>
+						<width>180</width>
+						<height>40</height>
+						<font>WeatherTemp</font>
+						<align>right</align>
+						<aligny>top</aligny>
+						<label>$INFO[Window.Property(Current.Temperature)]</label>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+					</control>
+					<control type="label">
+						<description>current temp Value Units</description>
+						<posx>190</posx>
+						<posy>185</posy>
+						<width>100</width>
+						<height>40</height>
+						<font>font16</font>
+						<align>left</align>
+						<aligny>top</aligny>
+						<label>$INFO[System.TemperatureUnits]</label>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+					</control>
+					<control type="image">
+						<description>current weather icon</description>
+						<posx>230</posx>
+						<posy>120</posy>
+						<width>230</width>
+						<height>230</height>
+						<info>Window.Property(Current.ConditionIcon)</info>
+						<aspectratio>keep</aspectratio>
+					</control>
+					<control type="label">
+						<description>current condition label</description>
+						<posx>20</posx>
+						<posy>320</posy>
+						<width>460</width>
+						<height>30</height>
+						<info>Window.Property(Current.Condition)</info>
+						<wrapmultiline>true</wrapmultiline>
+						<font>font13</font>
+						<align>center</align>
+						<aligny>center</aligny>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+					</control>
 				</control>
 				<control type="image">
 					<posx>20</posx>


### PR DESCRIPTION
give weather addons the abillity to display a weather provider logo in the skin.

wu example: http://i687.photobucket.com/albums/vv237/roniez/tmp/weatherproviderlogo.jpg
