### PR TITLE
make sure gl textures are deleted by render thread

### DIFF
--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -23,6 +23,7 @@
 #include "windowing/WindowingFactory.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
+#include "guilib/TextureManager.h"
 
 #if defined(HAS_GL) || defined(HAS_GLES)
 
@@ -50,7 +51,7 @@ void CGLTexture::CreateTextureObject()
 void CGLTexture::DestroyTextureObject()
 {
   if (m_texture)
-    glDeleteTextures(1, (GLuint*) &m_texture);
+    g_TextureManager.ReleaseHwTexture(m_texture);
 }
 
 void CGLTexture::LoadToGPU()

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -487,6 +487,7 @@ void CGUITextureManager::FreeUnusedTextures(unsigned int timeDelay)
 
 void CGUITextureManager::ReleaseHwTexture(unsigned int texture)
 {
+  CSingleLock lock(g_graphicsContext);
   m_unusedHwTextures.push_back(texture);
 }
 


### PR DESCRIPTION
credits to @popcornmix for tracking this down. The destructor of CImageLoader called from a job tried to delete gl textures.
