### PR TITLE
CharsetConverter UTF-32 fix

### DIFF
--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -32,8 +32,7 @@
 #include <iconv.h>
 
 #if defined(TARGET_DARWIN)
-  #define WCHAR_IS_UTF32 1
-  #undef WCHAR_IS_UTF16
+  #define WCHAR_IS_UCS_4 1
   #ifdef __POWERPC__
     #define WCHAR_CHARSET "UTF-32BE"
   #else
@@ -41,15 +40,13 @@
   #endif
   #define UTF8_SOURCE "UTF-8-MAC"
 #elif defined(TARGET_WINDOWS)
-  #undef WCHAR_IS_UTF32
   #define WCHAR_IS_UTF16 1
   #define WCHAR_CHARSET "UTF-16LE"
   #define UTF8_SOURCE "UTF-8"
   #pragma comment(lib, "libfribidi.lib")
   #pragma comment(lib, "libiconv.lib")
 #elif defined(TARGET_ANDROID)
-  #define WCHAR_IS_UTF32 1
-  #undef WCHAR_IS_UTF16
+  #define WCHAR_IS_UCS_4 1
   #define UTF8_SOURCE "UTF-8"
   #ifdef __BIG_ENDIAN__
     #define WCHAR_CHARSET "UTF-32BE"
@@ -59,16 +56,16 @@
 #else
   #define WCHAR_CHARSET "WCHAR_T"
   #define UTF8_SOURCE "UTF-8"
-  #ifdef HAVE_CONFIG_H
-    #include "config.h"
-  #endif // HAVE_CONFIG_H
-  #undef WCHAR_IS_UTF32
-  #undef WCHAR_IS_UTF16
-  #ifdef SIZEOF_WCHAR_T
-    #if SIZEOF_WCHAR_T == 4
-      #define WCHAR_IS_UTF32 1
-    #elif SIZEOF_WCHAR_T == 2
-      #define WCHAR_IS_UTF16 1
+  #if __STDC_ISO_10646__
+    #ifdef HAVE_CONFIG_H
+      #include "config.h"
+    #endif // HAVE_CONFIG_H
+    #ifdef SIZEOF_WCHAR_T
+      #if SIZEOF_WCHAR_T == 4
+        #define WCHAR_IS_UCS_4 1
+      #elif SIZEOF_WCHAR_T == 2
+        #define WCHAR_IS_UCS_2 1
+      #endif
     #endif
   #endif
 #endif
@@ -518,13 +515,13 @@ std::string CCharsetConverter::utf32ToUtf8(const std::u32string& utf32StringSrc,
 
 bool CCharsetConverter::utf32ToW(const std::u32string& utf32StringSrc, std::wstring& wStringDst, bool failOnBadChar /*= true*/)
 {
-#ifdef WCHAR_IS_UTF32
+#ifdef WCHAR_IS_UCS_4
   wStringDst.assign((const wchar_t*)utf32StringSrc.c_str(), utf32StringSrc.length());
   return true;
-#else // !WCHAR_IS_UTF32
+#else // !WCHAR_IS_UCS_4
   CSingleLock lock(m_critSection);
   return convert(m_iconvUtf32ToW, 1, "UTF-32", WCHAR_CHARSET, utf32StringSrc, wStringDst, failOnBadChar);
-#endif // !WCHAR_IS_UTF32
+#endif // !WCHAR_IS_UCS_4
 }
 
 bool CCharsetConverter::utf32logicalToVisualBiDi(const std::u32string& logicalStringSrc, std::u32string& visualStringDst, bool forceLTRReadingOrder /*= false*/)
@@ -539,13 +536,12 @@ bool CCharsetConverter::utf32logicalToVisualBiDi(const std::u32string& logicalSt
 
 bool CCharsetConverter::wToUtf32(const std::wstring& wStringSrc, std::u32string& utf32StringDst, bool failOnBadChar /*= true*/)
 {
-#ifdef WCHAR_IS_UTF32
-  utf32StringDst.assign((const char32_t*)wStringSrc.c_str(), wStringSrc.length());
-  return true;
-#else // !WCHAR_IS_UTF32
+#ifdef WCHAR_IS_UCS_4
+  /* UCS-4 is almost equal to UTF-32, but UTF-32 has strict limits on possible values, while UCS-4 is usually unchecked.
+   * With this "conversion" we ensure that output will be valid UTF-32 string. */
+#endif
   CSingleLock lock(m_critSection);
   return convert(m_iconvWToUtf32, 1, WCHAR_CHARSET, "UTF-32", wStringSrc, utf32StringDst, failOnBadChar);
-#endif // !WCHAR_IS_UTF32
 }
 
 // The bVisualBiDiFlip forces a flip of characters for hebrew/arabic languages, only set to false if the flipping


### PR DESCRIPTION
- Most common implementation of iconv (GNU libiconv) use big endian and BOM when output is UTF-32. Most other (but not all) iconv implementations usually works similar. To ensure that conversion will be correct, we need to explicitly specify output endianness.
- On some platforms (FreeBSD) wchar_t isn't in Unicode, so code checks **STDC_ISO_10646** macro before using wchar_t as UTF.
- If wchar_t is 4 bytes wide and in Unicode, do proper convert from wchar_t to UTF-32 (instead of copy), as wchar_t in UCS-4 (superset of UTF-32). UTF-32 can be simply copied to wchar_t

This PR is alternative for #3351 and #3342
