### PR TITLE
VDPAU on AMD

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -376,7 +376,7 @@
           <default>true</default>
         </setting>
         <setting id="videoplayer.usevdpaumixer" type="boolean" label="13437" help="36421">
-          <visible>HAVE_LIBVDPAU</visible>
+          <requirement>HAVE_LIBVDPAU</requirement>
           <level>2</level>
           <default>true</default>
           <control>

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -38,7 +38,7 @@
 #include "cores/VideoRenderers/RenderFlags.h"
 
 using namespace VDPAU;
-#define NUM_RENDER_PICS 9
+#define NUM_RENDER_PICS 7
 
 #define ARSIZE(x) (sizeof(x) / sizeof((x)[0]))
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -330,7 +330,7 @@ int CDecoder::Check(AVCodecContext* avctx)
   if (state == VDPAU_LOST)
   {
     CLog::Log(LOGNOTICE,"CVDPAU::Check waiting for display reset event");
-    if (!m_DisplayEvent.WaitMSec(2000))
+    if (!m_DisplayEvent.WaitMSec(4000))
     {
       CLog::Log(LOGERROR, "CVDPAU::Check - device didn't reset in reasonable time");
       state = VDPAU_RESET;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -943,7 +943,7 @@ void CDecoder::FFDrawSlice(struct AVCodecContext *s,
       return;
   }
 
-//  uint64_t startTime = CurrentHostCounter();
+  uint64_t startTime = CurrentHostCounter();
   uint16_t decoded, processed, rend;
   vdp->m_bufferStats.Get(decoded, processed, rend);
   vdp_st = vdp->m_vdpauConfig.vdpProcs.vdp_decoder_render(vdp->m_vdpauConfig.vdpDecoder,
@@ -952,10 +952,9 @@ void CDecoder::FFDrawSlice(struct AVCodecContext *s,
                                    vdp->m_hwContext.bitstream_buffers_used,
                                    vdp->m_hwContext.bitstream_buffers);
   vdp->CheckStatus(vdp_st, __LINE__);
-//  uint64_t diff = CurrentHostCounter() - startTime;
-//  if (diff*1000/CurrentHostFrequency() > 30)
-//    CLog::Log(LOGWARNING,"CVDPAU::DrawSlice - VdpDecoderRender long decoding: %d ms, dec: %d, proc: %d, rend: %d", (int)((diff*1000)/CurrentHostFrequency()), decoded, processed, rend);
-
+  uint64_t diff = CurrentHostCounter() - startTime;
+  if (diff*1000/CurrentHostFrequency() > 30)
+    CLog::Log(LOGDEBUG, "CVDPAU::DrawSlice - VdpDecoderRender long decoding: %d ms, dec: %d, proc: %d, rend: %d", (int)((diff*1000)/CurrentHostFrequency()), decoded, processed, rend);
 }
 
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -2312,7 +2312,10 @@ void CMixer::InitCycle()
 
 void CMixer::FiniCycle()
 {
-  while (m_mixerInput.size() > 3)
+  // Keep video surfaces for one 2 cycles longer than used
+  // by mixer. This avoids blocking in decoder.
+  // NVidia recommends num_ref + 5
+  while (m_mixerInput.size() > 5)
   {
     CVdpauDecodedPicture &tmp = m_mixerInput.back();
     if (m_processPicture.DVDPic.format != RENDER_FMT_VDPAU_420)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -289,6 +289,8 @@ void CDecoder::OnLostDevice()
 {
   CLog::Log(LOGNOTICE,"CVDPAU::OnLostDevice event");
 
+  int count = g_graphicsContext.exit();
+
   CSingleLock lock(m_DecoderSection);
   FiniVDPAUOutput();
   FiniVDPAUProcs();
@@ -296,11 +298,15 @@ void CDecoder::OnLostDevice()
   m_DisplayState = VDPAU_LOST;
   lock.Leave();
   m_DisplayEvent.Reset();
+
+  g_graphicsContext.restore(count);
 }
 
 void CDecoder::OnResetDevice()
 {
   CLog::Log(LOGNOTICE,"CVDPAU::OnResetDevice event");
+
+  int count = g_graphicsContext.exit();
 
   CSingleLock lock(m_DecoderSection);
   if (m_DisplayState == VDPAU_LOST)
@@ -309,6 +315,8 @@ void CDecoder::OnResetDevice()
     lock.Leave();
     m_DisplayEvent.Set();
   }
+
+  g_graphicsContext.restore(count);
 }
 
 int CDecoder::Check(AVCodecContext* avctx)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -961,7 +961,6 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic)
 
 void CDecoder::FFReleaseBuffer(AVCodecContext *avctx, AVFrame *pic)
 {
-  //CLog::Log(LOGNOTICE,"%s",__FUNCTION__);
   CDVDVideoCodecFFmpeg* ctx        = (CDVDVideoCodecFFmpeg*)avctx->opaque;
   CDecoder*             vdp        = (CDecoder*)ctx->GetHardware();
 
@@ -1298,7 +1297,7 @@ void CVdpauRenderPicture::Sync()
 // Mixer
 //-----------------------------------------------------------------------------
 CMixer::CMixer(CEvent *inMsgEvent) :
-  CThread("Vdpau Mixer Thread"),
+  CThread("Vdpau Mixer"),
   m_controlPort("ControlPort", inMsgEvent, &m_outMsgEvent),
   m_dataPort("DataPort", inMsgEvent, &m_outMsgEvent)
 {
@@ -1462,11 +1461,6 @@ void CMixer::StateMachine(int signal, Protocol *port, Message *msg)
           }
           else
           {
-//            if (m_extTimeout != 0)
-//            {
-//              SetPostProcFeatures(false);
-//              CLog::Log(LOGWARNING,"CVDPAU::Mixer timeout - decoded: %d, outputSurf: %d", (int)m_decodedPics.size(), (int)m_outputSurfaces.size());
-//            }
             m_extTimeout = 100;
           }
           return;
@@ -1534,11 +1528,6 @@ void CMixer::StateMachine(int signal, Protocol *port, Message *msg)
           }
           else
           {
-//            if (m_extTimeout != 0)
-//            {
-//              SetPostProcFeatures(false);
-//              CLog::Log(LOGNOTICE,"---mixer wait2 decoded: %d, outputSurf: %d", (int)m_decodedPics.size(), (int)m_outputSurfaces.size());
-//            }
             m_extTimeout = 100;
           }
           return;
@@ -2216,7 +2205,6 @@ void CMixer::DisableHQScaling()
   }
 }
 
-
 void CMixer::Init()
 {
   m_Brightness = 0.0;
@@ -2282,10 +2270,9 @@ void CMixer::Flush()
 void CMixer::InitCycle()
 {
   CheckFeatures();
-  uint64_t latency;
   int flags;
+  uint64_t latency;
   m_config.stats->GetParams(latency, flags);
-  latency = (latency*1000)/CurrentHostFrequency();
   // TODO
   if (0) //flags & DVP_FLAG_NO_POSTPROC)
     SetPostProcFeatures(false);
@@ -2404,7 +2391,6 @@ void CMixer::FiniCycle()
       m_config.videoSurfaces->ClearRender(tmp.videoSurface);
     }
     m_mixerInput.pop_back();
-//    m_config.stats->DecDecoded();
   }
 }
 
@@ -2584,7 +2570,7 @@ VdpauBufferPool::~VdpauBufferPool()
 // Output
 //-----------------------------------------------------------------------------
 COutput::COutput(CEvent *inMsgEvent) :
-  CThread("Vdpau Output Thread"),
+  CThread("Vdpau Output"),
   m_controlPort("OutputControlPort", inMsgEvent, &m_outMsgEvent),
   m_dataPort("OutputDataPort", inMsgEvent, &m_outMsgEvent),
   m_mixer(&m_outMsgEvent)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -179,15 +179,11 @@ struct CVdpauConfig
   int vidHeight;
   int outWidth;
   int outHeight;
-  VDPAU_procs vdpProcs;
-  VdpDevice vdpDevice;
   VdpDecoder vdpDecoder;
   VdpChromaType vdpChromaType;
   CVdpauBufferStats *stats;
   CDecoder *vdpau;
-  int featureCount;
   int upscale;
-  VdpVideoMixerFeature vdpFeatures[14];
   CVideoSurfaces *videoSurfaces;
   bool usePixmaps;
   int numRenderBuffers;
@@ -546,22 +542,28 @@ class CVDPAUContext
 public:
   static bool EnsureContext(CVDPAUContext **ctx);
   void Release();
-  void GetProcs(VDPAU_procs &procs);
+  VDPAU_procs& GetProcs();
   VdpDevice GetDevice();
+  bool Supports(VdpVideoMixerFeature feature);
+  VdpVideoMixerFeature* GetFeatures();
+  int GetFeatureCount();
 private:
   CVDPAUContext();
   void Close();
   bool LoadSymbols();
   bool CreateContext();
   void DestroyContext();
+  void QueryProcs();
+  void SpewHardwareAvailable();
   static CVDPAUContext *m_context;
   static CCriticalSection m_section;
   static Display *m_display;
   int m_refCount;
+  VdpVideoMixerFeature m_vdpFeatures[14];
+  int m_featureCount;
   static void *m_dlHandle;
   VdpDevice m_vdpDevice;
-  VdpGetProcAddress *m_vdp_get_proc_address;
-  VdpDeviceDestroy *m_vdp_device_destroy;
+  VDPAU_procs m_vdpProcs;
   VdpStatus (*dl_vdp_device_create_x11)(Display* display, int screen, VdpDevice* device, VdpGetProcAddress **get_proc_address);
 };
 
@@ -619,7 +621,6 @@ public:
 protected:
   void SetWidthHeight(int width, int height);
   bool ConfigVDPAU(AVCodecContext *avctx, int ref_frames);
-  void SpewHardwareAvailable();
   bool CheckStatus(VdpStatus vdp_st, int line);
   void FiniVDPAUOutput();
   void ReturnRenderPicture(CVdpauRenderPicture *renderPic);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -103,15 +103,6 @@ struct VDPAU_procs
 
   VdpGenerateCSCMatrix *                vdp_generate_csc_matrix;
 
-  VdpPresentationQueueTargetDestroy *         vdp_presentation_queue_target_destroy;
-  VdpPresentationQueueCreate *                vdp_presentation_queue_create;
-  VdpPresentationQueueDestroy *               vdp_presentation_queue_destroy;
-  VdpPresentationQueueDisplay *               vdp_presentation_queue_display;
-  VdpPresentationQueueBlockUntilSurfaceIdle * vdp_presentation_queue_block_until_surface_idle;
-  VdpPresentationQueueTargetCreateX11 *       vdp_presentation_queue_target_create_x11;
-  VdpPresentationQueueQuerySurfaceStatus *    vdp_presentation_queue_query_surface_status;
-  VdpPresentationQueueGetTime *               vdp_presentation_queue_get_time;
-
   VdpGetErrorString *                         vdp_get_error_string;
 
   VdpDecoderCreate *             vdp_decoder_create;
@@ -185,7 +176,6 @@ struct CVdpauConfig
   CDecoder *vdpau;
   int upscale;
   CVideoSurfaces *videoSurfaces;
-  bool usePixmaps;
   int numRenderBuffers;
   uint32_t maxReferences;
   bool useInteropYuv;
@@ -363,18 +353,6 @@ struct VdpauBufferPool
 {
   VdpauBufferPool();
   virtual ~VdpauBufferPool();
-  struct Pixmaps
-  {
-    unsigned short id;
-    bool used;
-    DVDVideoPicture DVDPic;
-    GLuint texture;
-    Pixmap pixmap;
-    GLXPixmap  glPixmap;
-    VdpPresentationQueueTarget vdp_flip_target;
-    VdpPresentationQueue vdp_flip_queue;
-    VdpOutputSurface surface;
-  };
   struct GLVideoSurface
   {
     GLuint texture[4];
@@ -386,9 +364,7 @@ struct VdpauBufferPool
   };
   std::vector<CVdpauRenderPicture*> allRenderPics;
   unsigned short numOutputSurfaces;
-  std::vector<Pixmaps> pixmaps;
   std::vector<VdpOutputSurface> outputSurfaces;
-  std::deque<int> notVisiblePixmaps;
   std::map<VdpVideoSurface, GLVideoSurface> glVideoSurfaceMap;
   std::map<VdpOutputSurface, GLVideoSurface> glOutputSurfaceMap;
   std::queue<CVdpauProcessedPicture> processedPics;
@@ -457,7 +433,6 @@ protected:
   void QueueReturnPicture(CVdpauRenderPicture *pic);
   void ProcessReturnPicture(CVdpauRenderPicture *pic);
   bool ProcessSyncPicture();
-  int FindFreePixmap();
   bool Init();
   bool Uninit();
   void Flush();
@@ -470,10 +445,6 @@ protected:
   bool GLInit();
   void GLMapSurfaces();
   void GLUnmapSurfaces();
-  void GLBindPixmaps();
-  void GLUnbindPixmaps();
-  bool MakePixmap(VdpauBufferPool::Pixmaps &pixmap);
-  bool MakePixmapGL(VdpauBufferPool::Pixmaps &pixmap);
   bool CheckStatus(VdpStatus vdp_st, int line);
   CEvent m_outMsgEvent;
   CEvent *m_inMsgEvent;
@@ -494,8 +465,6 @@ protected:
   GLXPixmap m_glPixmap;
 
   // gl functions
-  PFNGLXBINDTEXIMAGEEXTPROC    glXBindTexImageEXT;
-  PFNGLXRELEASETEXIMAGEEXTPROC glXReleaseTexImageEXT;
 #ifdef GL_NV_vdpau_interop
   PFNGLVDPAUINITNVPROC glVDPAUInitNV;
   PFNGLVDPAUFININVPROC glVDPAUFiniNV;


### PR DESCRIPTION
@fritsch and I have worked with the open source devs of AMD who have been implementing vdpau for Radeon. After more than 2 years of pain with XvBA AMD hardware for Linux get attractive again. @Anssi has patched ALSA and made 8 channel bitstreaming work.
The changes for vdpau:
- drop depreciated ffmpeg struct vdpau_render_state and track video surfaces internally, implement buffer reget for ffmpeg
- only use a single vdpau device for all vdpau decoders. create/destroy of vdpau devices made life hard for the OSS devs.
- improved usage vdpau rendering pipeline
- fixed a bug when decoder was flushed
- drop old code path for pixmap magic. according to the OSS devs this was not compliant to the spec and did not work on AMD.
