### PR TITLE
removed unneeded config.h include in AddonString.h.

### DIFF
--- a/xbmc/interfaces/legacy/AddonString.h
+++ b/xbmc/interfaces/legacy/AddonString.h
@@ -21,7 +21,9 @@
 #pragma once
 
 #include <string>
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 
 namespace XBMCAddon
 {


### PR DESCRIPTION
this fixes the build error on windows. I can make it windows only but its probably not needed for the other platforms as well.
Windows seemed to use the config.h from pcre which is no longer and thus the builds fails.
