### PR TITLE
PVR: Fix channel switch dead lock

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -647,7 +647,6 @@ CGUIWindow* CGUIWindowManager::GetWindow(int id) const
     return NULL;
   }
 
-  CSingleLock lock(g_graphicsContext);
   WindowMap::const_iterator it = m_mapWindows.find(id);
   if (it != m_mapWindows.end())
     return (*it).second;


### PR DESCRIPTION
g_graphicContext mutex is held during "videoOSD" and lock notification queue. Removing lock here should be safe until GUIWindowManager::GetWindow() is const. This fix cause of dead lock when channel switch fails (not tunable or other).
