### PR TITLE
[rbp/omxplayer] Fix live tv regression from #3212

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -104,11 +104,22 @@ bool OMXPlayerAudio::OpenStream(CDVDStreamInfo &hints)
   if(!m_DllBcmHost.Load())
     return false;
 
+  m_bad_state = false;
+
+  COMXAudioCodecOMX *codec = new COMXAudioCodecOMX();
+
+  if(!codec || !codec->Open(hints))
+  {
+    CLog::Log(LOGERROR, "Unsupported audio codec");
+    delete codec; codec = NULL;
+    return false;
+  }
+
   if(m_messageQueue.IsInited())
-    m_messageQueue.Put(new COMXMsgAudioCodecChange(hints, NULL), 0);
+    m_messageQueue.Put(new COMXMsgAudioCodecChange(hints, codec), 0);
   else
   {
-    OpenStream(hints, NULL);
+    OpenStream(hints, codec);
     m_messageQueue.Init();
     CLog::Log(LOGNOTICE, "Creating audio thread");
     Create();
@@ -117,56 +128,30 @@ bool OMXPlayerAudio::OpenStream(CDVDStreamInfo &hints)
   return true;
 }
 
-void OMXPlayerAudio::OpenStream(CDVDStreamInfo &hints, COMXAudioCodecOMX *dummy)
+void OMXPlayerAudio::OpenStream(CDVDStreamInfo &hints, COMXAudioCodecOMX *codec)
 {
-  bool codec_change = false;
-
-  m_bad_state = false;
-  m_use_passthrough = (CSettings::Get().GetInt("audiooutput.mode") == AUDIO_HDMI &&
-                      !CSettings::Get().GetBool("audiooutput.dualaudio")) ? true : false ;
-  m_use_hw_decode   = g_advancedSettings.m_omxHWAudioDecode;
-  m_format.m_dataFormat    = GetDataFormat(hints);
-
-  if (m_hints.codec != hints.codec || m_hints.samplerate != hints.samplerate || !m_passthrough )
-    codec_change = true;
-
-  if (codec_change)
-  {
-    delete m_pAudioCodec;
-    m_pAudioCodec = NULL;
-
-    m_format.m_sampleRate    = 0;
-    m_format.m_channelLayout = 0;
-    m_speed           = DVD_PLAYSPEED_NORMAL;
-    m_audioClock      = DVD_NOPTS_VALUE;
-    m_hw_decode       = false;
-    m_silence         = false;
-    m_started         = false;
-    m_flush           = false;
-    m_nChannels       = 0;
-    m_stalled         = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET) == 0;
-  }
-
-  if (!m_passthrough && !m_pAudioCodec)
-  {
-    m_pAudioCodec = new COMXAudioCodecOMX();
-
-    if(!m_pAudioCodec || !m_pAudioCodec->Open(hints))
-    {
-      CLog::Log(LOGERROR, "Unsupported audio codec");
-      delete m_pAudioCodec; m_pAudioCodec = NULL;
-      m_bad_state = true;
-      return;
-    }
-  }
+  SAFE_DELETE(m_pAudioCodec);
 
   m_hints           = hints;
+  m_pAudioCodec     = codec;
 
   if(m_hints.bitspersample == 0)
     m_hints.bitspersample = 16;
 
-  if (codec_change)
-    m_DecoderOpen = OpenDecoder();
+  m_speed           = DVD_PLAYSPEED_NORMAL;
+  m_audioClock      = DVD_NOPTS_VALUE;
+  m_hw_decode       = false;
+  m_silence         = false;
+  m_started         = false;
+  m_flush           = false;
+  m_nChannels       = 0;
+  m_stalled         = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET) == 0;
+  m_use_passthrough = (CSettings::Get().GetInt("audiooutput.mode") == AUDIO_HDMI &&
+                      !CSettings::Get().GetBool("audiooutput.dualaudio")) ? true : false ;
+  m_use_hw_decode   = g_advancedSettings.m_omxHWAudioDecode;
+  m_format.m_dataFormat    = GetDataFormat(m_hints);
+  m_format.m_sampleRate    = 0;
+  m_format.m_channelLayout = 0;
 }
 
 bool OMXPlayerAudio::CloseStream(bool bWaitForBuffers)
@@ -205,9 +190,38 @@ void OMXPlayerAudio::OnExit()
   CLog::Log(LOGNOTICE, "thread end: OMXPlayerAudio::OnExit()");
 }
 
+bool OMXPlayerAudio::CodecChange()
+{
+  unsigned int old_bitrate = m_hints.bitrate;
+  unsigned int new_bitrate = m_hints_current.bitrate;
+
+  if(m_pAudioCodec)
+  {
+    m_hints.channels = m_pAudioCodec->GetChannels();
+    m_hints.samplerate = m_pAudioCodec->GetSampleRate();
+  }
+
+  /* only check bitrate changes on AV_CODEC_ID_DTS, AV_CODEC_ID_AC3, AV_CODEC_ID_EAC3 */
+  if(m_hints.codec != AV_CODEC_ID_DTS && m_hints.codec != AV_CODEC_ID_AC3 && m_hints.codec != AV_CODEC_ID_EAC3)
+    new_bitrate = old_bitrate = 0;
+
+  if(m_hints_current.codec          != m_hints.codec ||
+     m_hints_current.channels       != m_hints.channels ||
+     m_hints_current.samplerate     != m_hints.samplerate ||
+     m_hints_current.bitspersample  != m_hints.bitspersample ||
+     old_bitrate                    != new_bitrate ||
+     !m_DecoderOpen)
+  {
+    m_hints_current = m_hints;
+    return true;
+  }
+
+  return false;
+}
+
 bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket)
 {
-  if(!pkt || m_bad_state)
+  if(!pkt || m_bad_state || !m_pAudioCodec)
     return false;
 
   if(pkt->dts != DVD_NOPTS_VALUE)
@@ -216,7 +230,7 @@ bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket)
   const uint8_t *data_dec = pkt->pData;
   int            data_len = pkt->iSize;
 
-  if(m_pAudioCodec && !OMX_IS_RAW(m_format.m_dataFormat) && !bDropPacket)
+  if(!OMX_IS_RAW(m_format.m_dataFormat) && !bDropPacket)
   {
     while(!m_bStop && data_len > 0)
     {
@@ -239,6 +253,13 @@ bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket)
       int ret = 0;
 
       m_audioStats.AddSampleBytes(decoded_size);
+
+      if(CodecChange())
+      {
+        m_DecoderOpen = OpenDecoder();
+        if(!m_DecoderOpen)
+          return false;
+      }
 
       while(!m_bStop)
       {
@@ -271,8 +292,15 @@ bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket)
       }
     }
   }
-  else if(OMX_IS_RAW(m_format.m_dataFormat) && !bDropPacket)
+  else if(!bDropPacket)
   {
+    if(CodecChange())
+    {
+      m_DecoderOpen = OpenDecoder();
+      if(!m_DecoderOpen)
+        return false;
+    }
+
     while(!m_bStop)
     {
       if(m_flush)
@@ -445,7 +473,6 @@ void OMXPlayerAudio::Process()
     else if (pMsg->IsType(CDVDMsg::GENERAL_STREAMCHANGE))
     {
       COMXMsgAudioCodecChange* msg(static_cast<COMXMsgAudioCodecChange*>(pMsg));
-      CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::GENERAL_STREAMCHANGE");
       OpenStream(msg->m_hints, msg->m_codec);
       msg->m_codec = NULL;
     }
@@ -493,6 +520,7 @@ AEDataFormat OMXPlayerAudio::GetDataFormat(CDVDStreamInfo hints)
   m_hw_decode   = false;
 
   /* check our audio capabilties */
+
   /* pathrought is overriding hw decode*/
   if(AUDIO_IS_BITSTREAM(CSettings::Get().GetInt("audiooutput.mode")) && m_use_passthrough)
   {
@@ -537,6 +565,10 @@ AEDataFormat OMXPlayerAudio::GetDataFormat(CDVDStreamInfo hints)
 
 bool OMXPlayerAudio::OpenDecoder()
 {
+  m_nChannels   = m_hints.channels;
+  m_passthrough = false;
+  m_hw_decode   = false;
+
   if(m_DecoderOpen)
   {
     WaitCompletion();
@@ -544,14 +576,13 @@ bool OMXPlayerAudio::OpenDecoder()
     m_DecoderOpen = false;
   }
 
-  m_nChannels   = m_hints.channels;
-  m_format.m_dataFormat    = GetDataFormat(m_hints);
-
   /* setup audi format for audio render */
   m_format.m_sampleRate    = m_hints.samplerate;
+  /* GetDataFormat is setting up evrything */
+  m_format.m_dataFormat = GetDataFormat(m_hints);
 
   m_format.m_channelLayout.Reset();
-  if (m_pAudioCodec)
+  if (m_pAudioCodec && !m_passthrough)
     m_format.m_channelLayout = m_pAudioCodec->GetChannelMap();
   else if (m_passthrough)
   {

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -55,7 +55,6 @@ protected:
   bool                      m_use_hw_decode;
   bool                      m_hw_decode;
   AEAudioFormat             m_format;
-  CAEChannelInfo            m_channelLayout;
   COMXAudioCodecOMX         *m_pAudioCodec;
   int                       m_speed;
   bool                      m_silence;

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.h
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.h
@@ -55,6 +55,7 @@ protected:
   bool                      m_use_hw_decode;
   bool                      m_hw_decode;
   AEAudioFormat             m_format;
+  CAEChannelInfo            m_channelLayout;
   COMXAudioCodecOMX         *m_pAudioCodec;
   int                       m_speed;
   bool                      m_silence;


### PR DESCRIPTION
#3212 breaks streams with no hints set when codec is opened. This can occur with live tv.

There's not an easy fix for this, so I've reverted it and got the cleaner audio codec change a simpler way.
Avoiding opening ffmpeg's audio codec when in passthrough modes will be revisited at a later date.
