### PR TITLE
fixed: compile with old versions of libdbus 

### DIFF
--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
@@ -38,6 +38,8 @@
 
 CLogindUPowerSyscall::CLogindUPowerSyscall()
 {
+  m_delayLockFd = -1;
+
   CLog::Log(LOGINFO, "Selected Logind/UPower as PowerSyscall");
 
   // Check if we have UPower. If not, we avoid any battery related operations.
@@ -264,6 +266,7 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
 
 void CLogindUPowerSyscall::InhibitDelayLock()
 {
+#ifdef DBUS_TYPE_UNIX_FD
   CDBusMessage message("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", "Inhibit");
   message.AppendArgument("sleep"); // what to inhibit
   message.AppendArgument("XBMC"); // who
@@ -287,6 +290,9 @@ void CLogindUPowerSyscall::InhibitDelayLock()
   }
 
     CLog::Log(LOGDEBUG, "LogindUPowerSyscall - inhibit lock taken, fd %i", m_delayLockFd);
+#else
+    CLog::Log(LOGWARNING, "LogindUPowerSyscall - inhibit lock support not compiled in");
+#endif
 }
 
 void CLogindUPowerSyscall::ReleaseDelayLock()


### PR DESCRIPTION
Fixed compile with old versions of libdbus that don't have DBUS_TYPE_UNIX_FD defined.
