### PR TITLE
Setting to disable keyboard grabbing when in fullscreen on platforms that use SDL on X11

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12357,7 +12357,12 @@ msgctxt "#35102"
 msgid "Disable joystick when this device is present"
 msgstr ""
 
-#empty strings from id 35103 to 35499
+#: system/settings/settings.xml
+msgctxt "#35103"
+msgid "Enable system keys in fullscreen"
+msgstr ""
+
+#empty strings from id 35104 to 35499
 
 #: Unknown
 msgctxt "#35500"
@@ -14432,4 +14437,9 @@ msgstr ""
 #: system/settings/rbp.xml
 msgctxt "#37018"
 msgid "Boost centre channel when downmixing"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#37019"
+msgid "Enables system keys like printscreen, alt-tab and volume keys when in fullscreen"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2142,6 +2142,14 @@
           <level>0</level>
           <default>true</default>
         </setting>
+        <setting id="input.enablesystemkeys" type="boolean" label="35103" help="37019">
+          <and>
+            <requirement>HAS_GL</requirement>
+            <requirement>HAVE_X11</requirement>
+          </and>
+          <level>2</level>
+          <default>false</default>
+        </setting>
       </group>
     </category>
     <category id="network" label="798" help="36379">

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -721,6 +721,9 @@ void CSettings::InitializeConditions()
 #ifdef HAS_EVENT_SERVER
   m_settingsManager->AddCondition("has_event_server");
 #endif
+#ifdef HAVE_X11
+  m_settingsManager->AddCondition("have_x11");
+#endif
 #ifdef HAS_GL
   m_settingsManager->AddCondition("has_gl");
 #endif
@@ -943,6 +946,12 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.clear();
   settingSet.insert("input.enablemouse");
   m_settingsManager->RegisterCallback(&g_Mouse, settingSet);
+
+#if defined(HAS_GL) && defined(HAVE_X11)
+  settingSet.clear();
+  settingSet.insert("input.enablesystemkeys");
+  m_settingsManager->RegisterCallback(&g_Windowing, settingSet);
+#endif
 
   settingSet.clear();
   settingSet.insert("services.webserver");

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -30,10 +30,11 @@
 #include "windowing/WinSystem.h"
 #include "utils/Stopwatch.h"
 #include "threads/CriticalSection.h"
+#include "settings/ISettingCallback.h"
 
 class IDispResource;
 
-class CWinSystemX11 : public CWinSystemBase
+class CWinSystemX11 : public CWinSystemBase, public ISettingCallback
 {
 public:
   CWinSystemX11();
@@ -65,6 +66,7 @@ public:
   Display*  GetDisplay() { return m_dpy; }
   GLXWindow GetWindow() { return m_glWindow; }
   GLXContext GetGlxContext() { return m_glContext; }
+  virtual void OnSettingChanged(const CSetting *setting);
 
 protected:
   bool RefreshGlxContext();
@@ -86,6 +88,7 @@ protected:
 private:
   bool IsSuitableVisual(XVisualInfo *vInfo);
   static int XErrorHandler(Display* dpy, XErrorEvent* error);
+  void SetGrabMode(const CSetting *setting = NULL);
 
   CStopWatch m_screensaverReset;
 };


### PR DESCRIPTION
added: setting to disable keyboard grabbing when in fullscreen on platforms that use SDL on X11, so you can alt-tab out of XBMC, and use the volume keys on the keyboard, very useful for notebooks.
