### PR TITLE
Win32: fix path slashes

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -495,8 +495,8 @@ const CStdString CURL::GetFileNameWithoutPath() const
 
 char CURL::GetDirectorySeparator() const
 {
-#ifndef TARGET_POSIX
-  if ( IsLocal() )
+#ifdef TARGET_WINDOWS
+  if (m_strProtocol.empty() || m_strProtocol == "file")
     return '\\';
   else
 #endif

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -43,7 +43,7 @@ CStdString URLEncodeInline(const CStdString& strData)
   return buffer;
 }
 
-CURL::CURL(const CStdString& strURL1)
+CURL::CURL(const std::string& strURL1)
 {
   Parse(strURL1);
 }
@@ -74,11 +74,11 @@ void CURL::Reset()
   m_iPort = 0;
 }
 
-void CURL::Parse(const CStdString& strURL1)
+void CURL::Parse(const std::string& strURL1)
 {
   Reset();
   // start by validating the path
-  CStdString strURL = CUtil::ValidatePath(strURL1);
+  std::string strURL(CUtil::ValidatePath(strURL1));
 
   // strURL can be one of the following:
   // format 1: protocol://[username:password]@hostname[:port]/directoryandfile
@@ -86,38 +86,39 @@ void CURL::Parse(const CStdString& strURL1)
   // format 3: drive:directoryandfile
   //
   // first need 2 check if this is a protocol or just a normal drive & path
-  if (!strURL.size()) return ;
-  if (strURL.Equals("?", true)) return;
+  if (strURL.empty())
+    return;
+  if (strURL == "?")
+    return;
 
   // form is format 1 or 2
   // format 1: protocol://[domain;][username:password]@hostname[:port]/directoryandfile
   // format 2: protocol://file
 
   // decode protocol
-  int iPos = strURL.Find("://");
-  if (iPos < 0)
+  size_t iPos = strURL.find("://");
+  if (iPos == std::string::npos)
   {
     // This is an ugly hack that needs some work.
     // example: filename /foo/bar.zip/alice.rar/bob.avi
     // This should turn into zip://rar:///foo/bar.zip/alice.rar/bob.avi
     iPos = 0;
-    bool is_apk = (strURL.Find(".apk/", iPos) > 0);
     while (1)
     {
-      if (is_apk)
-        iPos = strURL.Find(".apk/", iPos);
-      else
-        iPos = strURL.Find(".zip/", iPos);
+      iPos = strURL.find(".apk/", iPos);
+      const bool is_apk = (iPos != std::string::npos);
 
-      int extLen = 3;
-      if (iPos < 0)
+      if (!is_apk)
+        iPos = strURL.find(".zip/", iPos);
+
+      if (iPos == std::string::npos)
       {
         /* set filename and update extension*/
         SetFileName(strURL);
-        return ;
+        return;
       }
-      iPos += extLen + 1;
-      CStdString archiveName = strURL.Left(iPos);
+      iPos += 4; // length of ".apk" or ".zip"
+      std::string archiveName(strURL, 0, iPos);
       struct __stat64 s;
       if (XFILE::CFile::Stat(archiveName, &s) == 0)
       {
@@ -130,12 +131,12 @@ void CURL::Parse(const CStdString& strURL1)
           Encode(archiveName);
           if (is_apk)
           {
-            CURL c((CStdString)"apk" + "://" + archiveName + '/' + strURL.Right(strURL.size() - iPos - 1));
+            CURL c((std::string)"apk" + "://" + archiveName + '/' + strURL.substr(iPos + 1));
             *this = c;
           }
           else
           {
-            CURL c((CStdString)"zip" + "://" + archiveName + '/' + strURL.Right(strURL.size() - iPos - 1));
+            CURL c((std::string)"zip" + "://" + archiveName + '/' + strURL.substr(iPos + 1));
             *this = c;
           }
           return;
@@ -145,7 +146,7 @@ void CURL::Parse(const CStdString& strURL1)
   }
   else
   {
-    SetProtocol(strURL.Left(iPos));
+    SetProtocol(strURL.substr(0, iPos));
     iPos += 3;
   }
 
@@ -162,50 +163,50 @@ void CURL::Parse(const CStdString& strURL1)
     m_strProtocol.Equals("special")
     )
   {
-    SetFileName(strURL.Mid(iPos));
+    SetFileName(strURL.substr(iPos));
     return;
   }
 
   // check for username/password - should occur before first /
-  if (iPos == -1) iPos = 0;
+  if (iPos == std::string::npos) 
+    iPos = 0;
 
   // for protocols supporting options, chop that part off here
   // maybe we should invert this list instead?
-  int iEnd = strURL.length();
+  size_t iEnd = strURL.length();
   const char* sep = NULL;
 
   //TODO fix all Addon paths
-  CStdString strProtocol2 = GetTranslatedProtocol();
-  if(m_strProtocol.Equals("rss") ||
-     m_strProtocol.Equals("rar") ||
-     m_strProtocol.Equals("addons") ||
-     m_strProtocol.Equals("image") ||
-     m_strProtocol.Equals("videodb") ||
-     m_strProtocol.Equals("musicdb") ||
-     m_strProtocol.Equals("androidapp"))
+  std::string strProtocol2(GetTranslatedProtocol());
+  if (m_strProtocol == "rss" ||
+       m_strProtocol == "rar" ||
+       m_strProtocol == "addons" ||
+       m_strProtocol == "image" ||
+       m_strProtocol == "videodb" ||
+       m_strProtocol == "musicdb" ||
+       m_strProtocol == "androidapp")
     sep = "?";
-  else
-  if(strProtocol2.Equals("http")
-    || strProtocol2.Equals("https")
-    || strProtocol2.Equals("plugin")
-    || strProtocol2.Equals("addons")
-    || strProtocol2.Equals("hdhomerun")
-    || strProtocol2.Equals("rtsp")
-    || strProtocol2.Equals("apk")
-    || strProtocol2.Equals("zip"))
+  else if (strProtocol2 == "http"
+            || strProtocol2 == "https"
+            || strProtocol2 == "plugin"
+            || strProtocol2 == "addons"
+            || strProtocol2 == "hdhomerun"
+            || strProtocol2 == "rtsp"
+            || strProtocol2 == "apk"
+            || strProtocol2 == "zip")
     sep = "?;#|";
-  else if(strProtocol2.Equals("ftp")
-       || strProtocol2.Equals("ftps"))
+  else if (strProtocol2 == "ftp"
+        || strProtocol2 == "ftps")
     sep = "?;|";
 
-  if(sep)
+  if (sep)
   {
-    int iOptions = strURL.find_first_of(sep, iPos);
-    if (iOptions >= 0 )
+    const size_t iOptions = strURL.find_first_of(sep, iPos);
+    if (iOptions != std::string::npos)
     {
       // we keep the initial char as it can be any of the above
-      int iProto = strURL.find_first_of("|",iOptions);
-      if (iProto >= 0)
+      const size_t iProto = strURL.find('|', iOptions);
+      if (iProto != std::string::npos)
       {
         SetProtocolOptions(strURL.substr(iProto+1));
         SetOptions(strURL.substr(iOptions,iProto-iOptions));
@@ -216,129 +217,119 @@ void CURL::Parse(const CStdString& strURL1)
     }
   }
 
-  int iSlash = strURL.Find("/", iPos);
-  if(iSlash >= iEnd)
-    iSlash = -1; // was an invalid slash as it was contained in options
+  size_t iSlash = strURL.find('/', iPos);
+  if (iSlash != std::string::npos && iSlash >= iEnd)
+    iSlash = std::string::npos; // was an invalid slash as it was contained in options
 
-  if( !m_strProtocol.Equals("iso9660") )
+  if ( !m_strProtocol.Equals("iso9660") )
   {
-    int iAlphaSign = strURL.Find("@", iPos);
-    if (iAlphaSign >= 0 && iAlphaSign < iEnd && (iAlphaSign < iSlash || iSlash < 0))
+    const size_t iAlphaSign = strURL.find('@', iPos);
+    if (iAlphaSign != std::string::npos && iAlphaSign < iEnd && iAlphaSign < iSlash)
     {
       // username/password found
-      CStdString strUserNamePassword = strURL.Mid(iPos, iAlphaSign - iPos);
+      std::string strUserNamePassword(strURL, iPos, iAlphaSign - iPos);
 
       // first extract domain, if protocol is smb
       if (m_strProtocol.Equals("smb"))
       {
-        int iSemiColon = strUserNamePassword.Find(";");
+        const size_t iSemiColon = strUserNamePassword.find(';');
 
-        if (iSemiColon >= 0)
+        if (iSemiColon != std::string::npos)
         {
-          m_strDomain = strUserNamePassword.Left(iSemiColon);
-          strUserNamePassword.Delete(0, iSemiColon + 1);
+          m_strDomain = strUserNamePassword.substr(0, iSemiColon);
+          strUserNamePassword.erase(0, iSemiColon + 1);
         }
       }
 
-      // username:password
-      int iColon = strUserNamePassword.Find(":");
-      if (iColon >= 0)
-      {
-        m_strUserName = strUserNamePassword.Left(iColon);
-        iColon++;
-        m_strPassword = strUserNamePassword.Right(strUserNamePassword.size() - iColon);
+      const size_t iColon = strUserNamePassword.find(':');
+      if (iColon != std::string::npos)
+      {   // username:password
+        m_strUserName = strUserNamePassword.substr(0, iColon);
+        m_strPassword = strUserNamePassword.substr(iColon + 1);
       }
-      // username
-      else
-      {
+      else // username
         m_strUserName = strUserNamePassword;
-      }
 
       iPos = iAlphaSign + 1;
-      iSlash = strURL.Find("/", iAlphaSign);
+      iSlash = strURL.find('/', iAlphaSign);
 
-      if(iSlash >= iEnd)
-        iSlash = -1;
+      if (iSlash >= iEnd)
+        iSlash = std::string::npos;
     }
   }
 
   // detect hostname:port/
-  if (iSlash < 0)
+  if (iSlash == std::string::npos)
   {
-    CStdString strHostNameAndPort = strURL.Mid(iPos, iEnd - iPos);
-    int iColon = strHostNameAndPort.Find(":");
-    if (iColon >= 0)
+    std::string strHostNameAndPort(strURL, iPos, iEnd - iPos);
+    const size_t iColon = strHostNameAndPort.find(':');
+    if (iColon != std::string::npos)
     {
-      m_strHostName = strHostNameAndPort.Left(iColon);
-      iColon++;
-      CStdString strPort = strHostNameAndPort.Right(strHostNameAndPort.size() - iColon);
+      m_strHostName = strHostNameAndPort.substr(0, iColon);
+      std::string strPort(strHostNameAndPort, iColon + 1);
       m_iPort = atoi(strPort.c_str());
     }
     else
-    {
       m_strHostName = strHostNameAndPort;
-    }
 
   }
   else
   {
-    CStdString strHostNameAndPort = strURL.Mid(iPos, iSlash - iPos);
-    int iColon = strHostNameAndPort.Find(":");
-    if (iColon >= 0)
+    std::string strHostNameAndPort(strURL, iPos, iSlash - iPos);
+    const size_t iColon = strHostNameAndPort.find(':');
+    if (iColon != std::string::npos)
     {
-      m_strHostName = strHostNameAndPort.Left(iColon);
-      iColon++;
-      CStdString strPort = strHostNameAndPort.Right(strHostNameAndPort.size() - iColon);
+      m_strHostName = strHostNameAndPort.substr(iColon);
+      std::string strPort(strHostNameAndPort, 0, iColon + 1);
       m_iPort = atoi(strPort.c_str());
     }
     else
-    {
       m_strHostName = strHostNameAndPort;
-    }
+
     iPos = iSlash + 1;
     if (iEnd > iPos)
     {
-      m_strFileName = strURL.Mid(iPos, iEnd - iPos);
+      m_strFileName = strURL.substr(iPos, iEnd - iPos);
 
-      iSlash = m_strFileName.Find("/");
-      if(iSlash < 0)
+      iSlash = m_strFileName.find('/');
+      if (iSlash == std::string::npos)
         m_strShareName = m_strFileName;
       else
-        m_strShareName = m_strFileName.Left(iSlash);
+        m_strShareName = m_strFileName.substr(0, iSlash);
     }
   }
 
   // iso9960 doesnt have an hostname;-)
-  if (m_strProtocol.CompareNoCase("iso9660") == 0
-    || m_strProtocol.CompareNoCase("musicdb") == 0
-    || m_strProtocol.CompareNoCase("videodb") == 0
-    || m_strProtocol.CompareNoCase("sources") == 0
-    || m_strProtocol.CompareNoCase("pvr") == 0
-    || m_strProtocol.Left(3).CompareNoCase("mem") == 0)
+  if (m_strProtocol == "iso9660"
+    || m_strProtocol == "musicdb"
+    || m_strProtocol == "videodb"
+    || m_strProtocol == "sources"
+    || m_strProtocol == "pvr"
+    || m_strProtocol.substr(0, 3) == "mem")
   {
     if (m_strHostName != "" && m_strFileName != "")
     {
-      CStdString strFileName = m_strFileName;
-      m_strFileName.Format("%s/%s", m_strHostName.c_str(), strFileName.c_str());
-      m_strHostName = "";
+      std::string strFileName(m_strFileName);
+      m_strFileName = m_strHostName + "/" + m_strFileName;
+      m_strHostName.clear();
     }
     else
     {
-      if (!m_strHostName.IsEmpty() && strURL[iEnd-1]=='/')
+      if (!m_strHostName.empty() && strURL[iEnd-1]=='/')
         m_strFileName = m_strHostName + "/";
       else
         m_strFileName = m_strHostName;
-      m_strHostName = "";
+      m_strHostName.clear();
     }
   }
 
-  m_strFileName.Replace("\\", "/");
+  StringUtils::Replace(m_strFileName, "\\", "/");
 
   /* update extension */
   SetFileName(m_strFileName);
 
   /* decode urlencoding on this stuff */
-  if(URIUtils::ProtocolHasEncodedHostname(m_strProtocol))
+  if (URIUtils::ProtocolHasEncodedHostname(m_strProtocol))
   {
     Decode(m_strHostName);
     // Validate it as it is likely to contain a filename
@@ -349,18 +340,20 @@ void CURL::Parse(const CStdString& strURL1)
   Decode(m_strPassword);
 }
 
-void CURL::SetFileName(const CStdString& strFileName)
+void CURL::SetFileName(const std::string& strFileName)
 {
   m_strFileName = strFileName;
 
-  int slash = m_strFileName.find_last_of(GetDirectorySeparator());
-  int period = m_strFileName.find_last_of('.');
-  if(period != -1 && (slash == -1 || period > slash))
+  size_t slash = m_strFileName.find_last_of(GetDirectorySeparator());
+  size_t period = m_strFileName.find_last_of('.');
+  if (period != std::string::npos && (slash == std::string::npos || period > slash))
+  {
     m_strFileType = m_strFileName.substr(period+1);
+    StringUtils::Trim(m_strFileType);
+    StringUtils::ToLower(m_strFileType);
+  }
   else
-    m_strFileType = "";
-
-  m_strFileType.Normalize();
+    m_strFileType.clear();
 }
 
 void CURL::SetHostName(const CStdString& strHostName)
@@ -726,28 +719,22 @@ void CURL::Decode(CStdString& strURLData)
   strURLData = strResult;
 }
 
-void CURL::Encode(CStdString& strURLData)
+void CURL::Encode(std::string& strURLData)
 {
-  CStdString strResult;
+  std::string strResult;
 
   /* wonder what a good value is here is, depends on how often it occurs */
-  strResult.reserve( strURLData.length() * 2 );
+  strResult.reserve(strURLData.length() * 2);
 
-  for (int i = 0; i < (int)strURLData.size(); ++i)
+  for (size_t i = 0; i < strURLData.length(); ++i)
   {
-    int kar = (unsigned char)strURLData[i];
-    //if (kar == ' ') strResult += '+'; // obsolete
+    const int kar = (unsigned char)strURLData[i];
     if (isalnum(kar) || strchr("-_.!()" , kar) ) // Don't URL encode these according to RFC1738
-    {
-      strResult += kar;
-    }
+      strResult.push_back((unsigned char)kar);
     else
-    {
-      CStdString strTmp;
-      strTmp.Format("%%%02.2x", kar);
-      strResult += strTmp;
-    }
+      strResult += StringUtils::Format("%%%02.2x", kar);
   }
+
   strURLData = strResult;
 }
 
@@ -760,7 +747,7 @@ std::string CURL::Decode(const std::string& strURLData)
 
 std::string CURL::Encode(const std::string& strURLData)
 {
-  CStdString url = strURLData;
+  std::string url = strURLData;
   Encode(url);
   return url;
 }

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -29,13 +29,13 @@
 class CURL
 {
 public:
-  CURL(const CStdString& strURL);
+  CURL(const std::string& strURL);
   CURL();
   virtual ~CURL(void);
 
   void Reset();
-  void Parse(const CStdString& strURL);
-  void SetFileName(const CStdString& strFileName);
+  void Parse(const std::string& strURL);
+  void SetFileName(const std::string& strFileName);
   void SetHostName(const CStdString& strHostName);
   void SetUserName(const CStdString& strUserName);
   void SetPassword(const CStdString& strPassword);
@@ -70,7 +70,7 @@ public:
   static bool IsFileOnly(const CStdString &url); ///< return true if there are no directories in the url.
   static bool IsFullPath(const CStdString &url); ///< return true if the url includes the full path
   static void Decode(CStdString& strURLData);
-  static void Encode(CStdString& strURLData);
+  static void Encode(std::string& strURLData);
   static std::string Decode(const std::string& strURLData);
   static std::string Encode(const std::string& strURLData);
   static CStdString TranslateProtocol(const CStdString& prot);

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -24,6 +24,9 @@
 
 #ifdef TARGET_WINDOWS
 #undef SetPort // WIN32INCLUDES this is defined as SetPortA in WinSpool.h which is being included _somewhere_
+#ifdef GetUserName
+#undef GetUserName
+#endif // GetUserName
 #endif
 
 class CURL

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -976,15 +976,15 @@ CStdString CUtil::MakeLegalPath(const CStdString &strPathAndFile, int LegalType)
   return dir;
 }
 
-CStdString CUtil::ValidatePath(const CStdString &path, bool bFixDoubleSlashes /* = false */)
+std::string CUtil::ValidatePath(const std::string& path, bool bFixDoubleSlashes /* = false */)
 {
-  CStdString result = path;
+  std::string result(path);
 
   // Don't do any stuff on URLs containing %-characters or protocols that embed
   // filenames. NOTE: Don't use IsInZip or IsInRar here since it will infinitely
   // recurse and crash XBMC
   if (URIUtils::IsURL(path) && 
-     (path.Find('%') >= 0 ||
+     (path.find('%') != std::string::npos ||
       StringUtils::StartsWithNoCase(path, "apk:") ||
       StringUtils::StartsWithNoCase(path, "zip:") ||
       StringUtils::StartsWithNoCase(path, "rar:") ||
@@ -995,41 +995,14 @@ CStdString CUtil::ValidatePath(const CStdString &path, bool bFixDoubleSlashes /*
 
   // check the path for incorrect slashes
 #ifdef TARGET_WINDOWS
-  if (URIUtils::IsDOSPath(path))
-  {
-    result.Replace('/', '\\');
-    /* The double slash correction should only be used when *absolutely*
-       necessary! This applies to certain DLLs or use from Python DLLs/scripts
-       that incorrectly generate double (back) slashes.
-    */
-    if (bFixDoubleSlashes)
-    {
-      // Fixup for double back slashes (but ignore the \\ of unc-paths)
-      for (int x = 1; x < result.GetLength() - 1; x++)
-      {
-        if (result[x] == '\\' && result[x+1] == '\\')
-          result.Delete(x);
-      }
-    }
-  }
-  else if (path.Find("://") >= 0 || path.Find(":\\\\") >= 0)
+  if (result.length() >= 2 && result[1] == ':' && (result.length() == 2 || result[2] == '\\' || result[2] == '/')) // path in form "x:\"...
+    result = FixSlashes(result, bFixDoubleSlashes, false);
+  else if (result.compare(0, 2, "\\\\", 2) == 0) // 'result' starts with "\\": it's ether "\\server\share\ or "\\?\"
+    result = FixSlashes(result, bFixDoubleSlashes, false, 2);
+  else if (path.find("://") != std::string::npos || path.find(":\\\\") != std::string::npos)
 #endif
-  {
-    result.Replace('\\', '/');
-    /* The double slash correction should only be used when *absolutely*
-       necessary! This applies to certain DLLs or use from Python DLLs/scripts
-       that incorrectly generate double (back) slashes.
-    */
-    if (bFixDoubleSlashes)
-    {
-      // Fixup for double forward slashes(/) but don't touch the :// of URLs
-      for (int x = 2; x < result.GetLength() - 1; x++)
-      {
-        if ( result[x] == '/' && result[x + 1] == '/' && !(result[x - 1] == ':' || (result[x - 1] == '/' && result[x - 2] == ':')) )
-          result.Delete(x);
-      }
-    }
-  }
+    result = FixSlashes(result, bFixDoubleSlashes);
+
   return result;
 }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -897,6 +897,38 @@ bool CUtil::CreateDirectoryEx(const CStdString& strPath)
   return true;
 }
 
+std::string CUtil::FixSlashes(const std::string& path, const bool removeDuplicated /*= false*/, const bool useForwardSlashes /*= true*/, const size_t startFrom /*= 0*/)
+{
+  const size_t len = path.length();
+  if (startFrom >= len)
+    return path;
+
+  std::string result(path, 0, startFrom);
+  result.reserve(len);
+  
+  const char targetSlash = useForwardSlashes ? '/' : '\\';
+  const char* const str = path.c_str();
+  size_t pos = startFrom;
+  do
+  {
+    if (str[pos] == '\\' || str[pos] == '/')
+    {
+      result.push_back(targetSlash);  // append one slash
+      pos++;
+      if (removeDuplicated)
+      { // skip any following slashes
+        while (str[pos] == '\\' || str[pos] == '/') // str is null-terminated, no need to check for buffer overrun
+          pos++;
+      }
+    }
+    else
+      result.push_back(str[pos++]);   // append current char and advance pos to next char
+
+  } while(pos < len);
+
+  return result;
+}
+
 CStdString CUtil::MakeLegalFileName(const CStdString &strFile, int LegalType)
 {
   CStdString result = strFile;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -36,7 +36,6 @@
 // A list of filesystem types for LegalPath/FileName
 #define LEGAL_NONE            0
 #define LEGAL_WIN32_COMPAT    1
-#define LEGAL_FATX            2
 
 namespace XFILE
 {

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -27,6 +27,12 @@
 
 #include "MediaSource.h"
 
+#ifdef TARGET_WINDOWS
+#ifdef CreateDirectoryEx
+#undef CreateDirectoryEx
+#endif // CreateDirectoryEx
+#endif // TARGET_WINDOWS
+
 // A list of filesystem types for LegalPath/FileName
 #define LEGAL_NONE            0
 #define LEGAL_WIN32_COMPAT    1

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -123,7 +123,7 @@ public:
   static CStdString MakeLegalFileName(const CStdString &strFile, int LegalType=LEGAL_NONE);
   static CStdString MakeLegalPath(const CStdString &strPath, int LegalType=LEGAL_NONE);
 #endif
-  static CStdString ValidatePath(const CStdString &path, bool bFixDoubleSlashes = false); ///< return a validated path, with correct directory separators.
+  static std::string ValidatePath(const std::string& path, bool bFixDoubleSlashes = false); ///< return a validated path, with correct directory separators.
   
   static bool IsUsingTTFSubtitles();
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -110,6 +110,7 @@ public:
 #endif
   static bool CreateDirectoryEx(const CStdString& strPath);
 
+  static std::string FixSlashes(const std::string& path, const bool removeDuplicated = false, const bool useForwardSlashes = true, const size_t startFrom = 0);
 #ifdef TARGET_WINDOWS
   static CStdString MakeLegalFileName(const CStdString &strFile, int LegalType=LEGAL_WIN32_COMPAT);
   static CStdString MakeLegalPath(const CStdString &strPath, int LegalType=LEGAL_WIN32_COMPAT);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -950,7 +950,7 @@ extern "C"
     CURL url(CSpecialProtocol::TranslatePath(file));
     if (url.IsLocal())
     { // Make sure the slashes are correct & translate the path
-      return opendir(CUtil::ValidatePath(url.Get().c_str()));
+      return opendir(CUtil::ValidatePath(url.Get()).c_str());
     }
 
     // locate next free directory

--- a/xbmc/filesystem/HDDirectory.cpp
+++ b/xbmc/filesystem/HDDirectory.cpp
@@ -27,8 +27,9 @@
 #include "utils/AliasShortcutUtils.h"
 #include "utils/URIUtils.h"
 
-#ifndef TARGET_POSIX
+#ifdef TARGET_WINDOWS
 #include "utils/CharsetConverter.h"
+#include "win32/WIN32Util.h"
 #endif
 
 #ifndef INVALID_FILE_ATTRIBUTES
@@ -57,6 +58,7 @@ CHDDirectory::~CHDDirectory(void)
 bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items)
 {
   LOCAL_WIN32_FIND_DATA wfd;
+  memset(&wfd, 0, sizeof(wfd));
 
   CStdString strPath=strPath1;
 
@@ -66,11 +68,7 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
   CStdString strRoot = strPath;
   CURL url(strPath);
 
-  memset(&wfd, 0, sizeof(wfd));
   URIUtils::AddSlashAtEnd(strRoot);
-#ifdef TARGET_WINDOWS
-  strRoot.Replace("/", "\\");
-#endif
   if (URIUtils::IsDVD(strRoot) && m_isoReader.IsScanned())
   {
     // Reset iso reader and remount or
@@ -79,12 +77,10 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
   }
 
 #ifdef TARGET_WINDOWS
-  CStdStringW strSearchMask;
-  g_charsetConverter.utf8ToW(strRoot, strSearchMask, false);
-  strSearchMask.Insert(0, L"\\\\?\\");
-  strSearchMask += "*.*";
+  std::wstring strSearchMask(CWIN32Util::ConvertPathToWin32Form(strRoot));
+  strSearchMask += L"*.*";
 #else
-  CStdString strSearchMask = strRoot;
+  CStdString strSearchMask(strRoot);
 #endif
 
   FILETIME localTime;
@@ -102,7 +98,7 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
       {
         CStdString strLabel;
 #ifdef TARGET_WINDOWS
-        g_charsetConverter.wToUTF8(wfd.cFileName,strLabel);
+        g_charsetConverter.wToUTF8(wfd.cFileName,strLabel, true);
 #else
         strLabel = wfd.cFileName;
 #endif
@@ -146,17 +142,15 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
 
 bool CHDDirectory::Create(const char* strPath)
 {
+  if (!strPath || !*strPath)
+    return false;
   CStdString strPath1 = strPath;
   URIUtils::AddSlashAtEnd(strPath1);
 
 #ifdef TARGET_WINDOWS
   if (strPath1.size() == 3 && strPath1[1] == ':')
     return Exists(strPath);  // A drive - we can't "create" a drive
-  CStdStringW strWPath1;
-  strPath1.Replace("/", "\\");
-  g_charsetConverter.utf8ToW(strPath1, strWPath1, false);
-  strWPath1.Insert(0, L"\\\\?\\");
-  if(::CreateDirectoryW(strWPath1, NULL))
+  if(::CreateDirectoryW(CWIN32Util::ConvertPathToWin32Form(strPath1).c_str(), NULL))
 #else
   if(::CreateDirectory(strPath1.c_str(), NULL))
 #endif
@@ -169,12 +163,10 @@ bool CHDDirectory::Create(const char* strPath)
 
 bool CHDDirectory::Remove(const char* strPath)
 {
+  if (!strPath || !*strPath)
+    return false;
 #ifdef TARGET_WINDOWS
-  CStdStringW strWPath;
-  g_charsetConverter.utf8ToW(strPath, strWPath, false);
-  strWPath.Replace(L"/", L"\\");
-  strWPath.Insert(0, L"\\\\?\\");
-  return (::RemoveDirectoryW(strWPath) || GetLastError() == ERROR_PATH_NOT_FOUND) ? true : false;
+  return (::RemoveDirectoryW(CWIN32Util::ConvertPathToWin32Form(strPath).c_str()) || GetLastError() == ERROR_PATH_NOT_FOUND) ? true : false;
 #else
   return ::RemoveDirectory(strPath) ? true : false;
 #endif
@@ -184,16 +176,10 @@ bool CHDDirectory::Exists(const char* strPath)
 {
   if (!strPath || !*strPath)
     return false;
-  CStdString strReplaced=strPath;
 #ifdef TARGET_WINDOWS
-  CStdStringW strWReplaced;
-  strReplaced.Replace("/","\\");
-  URIUtils::AddSlashAtEnd(strReplaced);
-  g_charsetConverter.utf8ToW(strReplaced, strWReplaced, false);
-  strWReplaced.Insert(0, L"\\\\?\\");
-  DWORD attributes = GetFileAttributesW(strWReplaced);
+  DWORD attributes = GetFileAttributesW(CWIN32Util::ConvertPathToWin32Form(strPath).c_str());
 #else
-  DWORD attributes = GetFileAttributes(strReplaced.c_str());
+  DWORD attributes = GetFileAttributes(strPath);
 #endif
   if(attributes == INVALID_FILE_ATTRIBUTES)
     return false;

--- a/xbmc/filesystem/HDFile.cpp
+++ b/xbmc/filesystem/HDFile.cpp
@@ -181,7 +181,6 @@ bool CHDFile::SetHidden(const CURL &url, bool hidden)
 //*********************************************************************************************
 bool CHDFile::OpenForWrite(const CURL& url, bool bOverWrite)
 {
-  // make sure it's a legal FATX filename (we are writing to the harddisk)
   std::string strPath(GetLocal(url));
 
 #ifdef TARGET_WINDOWS

--- a/xbmc/filesystem/HDFile.h
+++ b/xbmc/filesystem/HDFile.h
@@ -60,7 +60,7 @@ public:
 
   virtual int IoControl(EIoControl request, void* param);
 protected:
-  CStdString GetLocal(const CURL &url); /* crate a properly format path from an url */
+  std::string GetLocal(const CURL &url); /* crate a properly format path from an url */
   AUTOPTR::CAutoPtrHandle m_hFile;
   int64_t m_i64FilePos;
   int64_t m_i64FileLen;

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -150,8 +150,8 @@ bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
 #endif
         if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && g_advancedSettings.m_sambastatfiles)
         {
-          // make sure we use the authenticated path wich contains any default username
-          CStdString strFullName = strAuth + smb.URLEncode(strFile);
+          // make sure we use the authenticated path which contains any default username
+          std::string strFullName((std::string&)strAuth + smb.URLEncode(strFile));
 
           lock.Enter();
 
@@ -165,7 +165,7 @@ bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
             char value[20];
             // We poll for extended attributes which symbolizes bits but split up into a string. Where 0x02 is hidden and 0x12 is hidden directory.
             // According to the libsmbclient.h it's supposed to return 0 if ok, or the length of the string. It seems always to return the length wich is 4
-            if (smbc_getxattr(strFullName, "system.dos_attr.mode", value, sizeof(value)) > 0)
+            if (smbc_getxattr(strFullName.c_str(), "system.dos_attr.mode", value, sizeof(value)) > 0)
             {
               long longvalue = strtol(value, NULL, 16);
               if (longvalue & SMBC_DOS_MODE_HIDDEN)

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -240,11 +240,11 @@ void CSMB::PurgeEx(const CURL& url)
   m_strLastHost = url.GetHostName();
 }
 
-CStdString CSMB::URLEncode(const CURL &url)
+std::string CSMB::URLEncode(const CURL &url)
 {
   /* due to smb wanting encoded urls we have to build it manually */
 
-  CStdString flat = "smb://";
+  std::string flat = "smb://";
 
   if(url.GetDomain().length() > 0)
   {
@@ -278,9 +278,9 @@ CStdString CSMB::URLEncode(const CURL &url)
   return flat;
 }
 
-CStdString CSMB::URLEncode(const CStdString &value)
+std::string CSMB::URLEncode(const std::string &value)
 {
-  CStdString encoded(value);
+  std::string encoded(value);
   CURL::Encode(encoded);
   return encoded;
 }

--- a/xbmc/filesystem/SmbFile.h
+++ b/xbmc/filesystem/SmbFile.h
@@ -67,8 +67,8 @@ public:
   void AddActiveConnection();
   void AddIdleConnection();
 #endif
-  CStdString URLEncode(const CStdString &value);
-  CStdString URLEncode(const CURL &url);
+  std::string URLEncode(const std::string &value);
+  std::string URLEncode(const CURL &url);
 
   DWORD ConvertUnixToNT(int error);
 private:

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -83,14 +83,13 @@ bool CSpecialProtocol::ComparePath(const CStdString &path1, const CStdString &pa
   return TranslatePath(path1) == TranslatePath(path2);
 }
 
-CStdString CSpecialProtocol::TranslatePath(const CStdString &path)
+CStdString CSpecialProtocol::TranslatePath(const std::string& path)
 {
   CURL url(path);
   // check for special-protocol, if not, return
-  if (!url.GetProtocol().Equals("special"))
-  {
+  if (url.GetProtocol() != "special")
     return path;
-  }
+
   return TranslatePath(url);
 }
 

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -64,7 +64,7 @@ public:
   static bool ComparePath(const CStdString &path1, const CStdString &path2);
   static void LogPaths();
 
-  static CStdString TranslatePath(const CStdString &path);
+  static CStdString TranslatePath(const std::string& path);
   static CStdString TranslatePath(const CURL &url);
   static CStdString TranslatePathConvertCase(const CStdString& path);
 

--- a/xbmc/filesystem/windows/WINFileSMB.cpp
+++ b/xbmc/filesystem/windows/WINFileSMB.cpp
@@ -30,6 +30,8 @@
 #include "utils/CharsetConverter.h"
 #include "utils/URIUtils.h"
 #include "WINSMBDirectory.h"
+#include "Util.h"
+#include "win32/WIN32Util.h"
 
 using namespace XFILE;
 
@@ -48,21 +50,11 @@ CWINFileSMB::~CWINFileSMB()
   if (m_hFile != INVALID_HANDLE_VALUE) Close();
 }
 //*********************************************************************************************
-CStdString CWINFileSMB::GetLocal(const CURL &url)
+std::string CWINFileSMB::GetLocal(const CURL &url)
 {
-  CStdString path( url.GetFileName() );
-
-  if( url.GetProtocol().Equals("smb", false) )
-  {
-    CStdString host( url.GetHostName() );
-
-    if(host.size() > 0)
-    {
-      path = "\\\\?\\UNC\\" + host + "\\" + path;
-    }
-  }
-
-  path.Replace('/', '\\');
+  std::string path(url.GetFileName());
+  if (url.GetProtocol().Equals("smb", false) && !url.GetHostName().empty())
+    path = "\\\\?\\UNC\\" + (std::string&)url.GetHostName() + "\\" + path;
 
   return path;
 }
@@ -70,11 +62,9 @@ CStdString CWINFileSMB::GetLocal(const CURL &url)
 //*********************************************************************************************
 bool CWINFileSMB::Open(const CURL& url)
 {
-  CStdString strFile = GetLocal(url);
+  std::wstring wfilename(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
 
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
-  m_hFile.attach(CreateFileW(strWFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
+  m_hFile.attach(CreateFileW(wfilename.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
 
   if (!m_hFile.isValid())
   {
@@ -83,10 +73,10 @@ bool CWINFileSMB::Open(const CURL& url)
 
     XFILE::CWINSMBDirectory smb;
     smb.ConnectToShare(url);
-    m_hFile.attach(CreateFileW(strWFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
+    m_hFile.attach(CreateFileW(wfilename.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
     if (!m_hFile.isValid())
     {
-      CLog::Log(LOGERROR,"CWINFileSMB: Unable to open file %s Error: %d", strFile.c_str(), GetLastError());
+      CLog::Log(LOGERROR, __FUNCTION__ ": Unable to open file %s Error: %d", url.Get().c_str(), GetLastError());
       return false;
     }
   }
@@ -99,10 +89,8 @@ bool CWINFileSMB::Open(const CURL& url)
 
 bool CWINFileSMB::Exists(const CURL& url)
 {
-  CStdString strFile = GetLocal(url);
-  URIUtils::RemoveSlashAtEnd(strFile);
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
+  std::wstring strWFile(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
+
   DWORD attributes = GetFileAttributesW(strWFile.c_str());
   if(attributes != INVALID_FILE_ATTRIBUTES)
     return true;
@@ -129,14 +117,14 @@ int CWINFileSMB::Stat(struct __stat64* buffer)
   HANDLE hFileDup;
   if (0 == DuplicateHandle(GetCurrentProcess(), (HANDLE)m_hFile, GetCurrentProcess(), &hFileDup, 0, FALSE, DUPLICATE_SAME_ACCESS))
   {
-    CLog::Log(LOGERROR, __FUNCTION__" - DuplicateHandle()");
+    CLog::Log(LOGERROR, __FUNCTION__ ": - DuplicateHandle()");
     return -1;
   }
 
   fd = _open_osfhandle((intptr_t)((HANDLE)hFileDup), 0);
   if (fd == -1)
   {
-    CLog::Log(LOGERROR, "CWINFileSMB Stat: fd == -1");
+    CLog::Log(LOGERROR, __FUNCTION__ ": Stat: fd == -1");
     return -1;
   }
 
@@ -147,15 +135,17 @@ int CWINFileSMB::Stat(struct __stat64* buffer)
 
 int CWINFileSMB::Stat(const CURL& url, struct __stat64* buffer)
 {
-  CStdString strFile = GetLocal(url);
+  std::wstring strWFile(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
+
   /* _wstat64 can't handle long paths therefore we remove the \\?\UNC\ */
-  strFile.Replace("\\\\?\\UNC\\", "\\\\");
+  if (strWFile.compare(0, 8, L"\\\\?\\UNC\\", 8) == 0)
+    strWFile.erase(2, 6);
+
   /* _wstat64 calls FindFirstFileEx. According to MSDN, the path should not end in a trailing backslash.
     Remove it before calling _wstat64 */
-  if (strFile.length() > 3 && URIUtils::HasSlashAtEnd(strFile))
-    URIUtils::RemoveSlashAtEnd(strFile);
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
+  if (strWFile[strWFile.length()-1] == L'\\')
+    strWFile.pop_back();
+
   if(_wstat64(strWFile.c_str(), buffer) == 0)
     return 0;
 
@@ -173,10 +163,8 @@ int CWINFileSMB::Stat(const CURL& url, struct __stat64* buffer)
 //*********************************************************************************************
 bool CWINFileSMB::OpenForWrite(const CURL& url, bool bOverWrite)
 {
-  CStdString strPath = GetLocal(url);
+  std::wstring strWPath(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
 
-  CStdStringW strWPath;
-  g_charsetConverter.utf8ToW(strPath, strWPath, false);
   m_hFile.attach(CreateFileW(strWPath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, bOverWrite ? CREATE_ALWAYS : OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL));
 
   if (!m_hFile.isValid())
@@ -189,7 +177,7 @@ bool CWINFileSMB::OpenForWrite(const CURL& url, bool bOverWrite)
     m_hFile.attach(CreateFileW(strWPath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, bOverWrite ? CREATE_ALWAYS : OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL));
     if (!m_hFile.isValid())
     {
-      CLog::Log(LOGERROR,"CWINFileSMB: Unable to open file for writing '%s' Error '%d%",strPath.c_str(), GetLastError());
+      CLog::Log(LOGERROR,__FUNCTION__ ": Unable to open file for writing '%s' Error '%d%", url.Get().c_str(), GetLastError());
       return false;
     }
   }
@@ -289,31 +277,17 @@ int64_t CWINFileSMB::GetPosition()
 
 bool CWINFileSMB::Delete(const CURL& url)
 {
-  CStdString strFile=GetLocal(url);
-
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
-  return ::DeleteFileW(strWFile.c_str()) ? true : false;
+  return ::DeleteFileW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str()) ? true : false;
 }
 
 bool CWINFileSMB::Rename(const CURL& url, const CURL& urlnew)
 {
-  CStdString strFile=GetLocal(url);
-  CStdString strNewFile=GetLocal(urlnew);
-
-  CStdStringW strWFile;
-  CStdStringW strWNewFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
-  g_charsetConverter.utf8ToW(strNewFile, strWNewFile, false);
-  return ::MoveFileW(strWFile.c_str(), strWNewFile.c_str()) ? true : false;
+  return ::MoveFileW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str(), CWIN32Util::ConvertPathToWin32Form(GetLocal(urlnew)).c_str()) ? true : false;
 }
 
 bool CWINFileSMB::SetHidden(const CURL &url, bool hidden)
 {
-  CStdStringW path;
-  g_charsetConverter.utf8ToW(GetLocal(url), path, false);
-  DWORD attributes = hidden ? FILE_ATTRIBUTE_HIDDEN : FILE_ATTRIBUTE_NORMAL;
-  if (SetFileAttributesW(path.c_str(), attributes))
+  if (SetFileAttributesW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str(), hidden ? FILE_ATTRIBUTE_HIDDEN : FILE_ATTRIBUTE_NORMAL))
     return true;
   return false;
 }
@@ -334,14 +308,14 @@ int CWINFileSMB::Truncate(int64_t size)
   HANDLE hFileDup;
   if (0 == DuplicateHandle(GetCurrentProcess(), (HANDLE)m_hFile, GetCurrentProcess(), &hFileDup, 0, FALSE, DUPLICATE_SAME_ACCESS))
   {
-    CLog::Log(LOGERROR, __FUNCTION__" - DuplicateHandle()");
+    CLog::Log(LOGERROR, __FUNCTION__ ": - DuplicateHandle()");
     return -1;
   }
 
   fd = _open_osfhandle((intptr_t)((HANDLE)hFileDup), 0);
   if (fd == -1)
   {
-    CLog::Log(LOGERROR, "CWINFileSMB Stat: fd == -1");
+    CLog::Log(LOGERROR, __FUNCTION__ ": Stat: fd == -1");
     return -1;
   }
   int result = _chsize_s(fd, (long) size);

--- a/xbmc/filesystem/windows/WINFileSMB.h
+++ b/xbmc/filesystem/windows/WINFileSMB.h
@@ -58,7 +58,7 @@ public:
 
   virtual int IoControl(EIoControl request, void* param);
 protected:
-  CStdString GetLocal(const CURL &url); /* crate a properly format path from an url */
+  std::string GetLocal(const CURL &url); /* create a properly format path from an url */
   AUTOPTR::CAutoPtrHandle m_hFile;
   int64_t m_i64FilePos;
 };

--- a/xbmc/filesystem/windows/WINSMBDirectory.cpp
+++ b/xbmc/filesystem/windows/WINSMBDirectory.cpp
@@ -367,13 +367,13 @@ bool CWINSMBDirectory::ConnectToShare(const CURL& url)
   while(dwRet != NO_ERROR)
   {
     strPath = URLEncode(urlIn);
-    LPCTSTR pUser = urlIn.GetUserNameA().empty() ? NULL : (LPCTSTR)urlIn.GetUserNameA().c_str();
+    LPCTSTR pUser = urlIn.GetUserName().empty() ? NULL : (LPCTSTR)urlIn.GetUserName().c_str();
     LPCTSTR pPass = urlIn.GetPassWord().empty() ? NULL : (LPCTSTR)urlIn.GetPassWord().c_str();
     dwRet = WNetAddConnection2(&nr, pPass, pUser, CONNECT_TEMPORARY);
 #ifdef _DEBUG
-    CLog::Log(LOGDEBUG,"Trying to connect to %s with username(%s) and password(%s)", strUNC.c_str(), urlIn.GetUserNameA().c_str(), urlIn.GetPassWord().c_str());
+    CLog::Log(LOGDEBUG,"Trying to connect to %s with username(%s) and password(%s)", strUNC.c_str(), urlIn.GetUserName().c_str(), urlIn.GetPassWord().c_str());
 #else
-    CLog::Log(LOGDEBUG,"Trying to connect to %s with username(%s) and password(%s)", strUNC.c_str(), urlIn.GetUserNameA().c_str(), "XXXX");
+    CLog::Log(LOGDEBUG,"Trying to connect to %s with username(%s) and password(%s)", strUNC.c_str(), urlIn.GetUserName().c_str(), "XXXX");
 #endif
     if(dwRet == ERROR_ACCESS_DENIED || dwRet == ERROR_INVALID_PASSWORD || dwRet == ERROR_LOGON_FAILURE)
     {

--- a/xbmc/filesystem/windows/WINSMBDirectory.h
+++ b/xbmc/filesystem/windows/WINSMBDirectory.h
@@ -41,7 +41,7 @@ public:
 private:
   bool m_bHost;
   bool EnumerateFunc(LPNETRESOURCEW lpnr, CFileItemList &items);
-  CStdString GetLocal(const CStdString& strPath);
-  CStdString URLEncode(const CURL &url);
+  std::string GetLocal(const std::string& strPath);
+  std::string URLEncode(const CURL &url);
 };
 }

--- a/xbmc/utils/AliasShortcutUtils.cpp
+++ b/xbmc/utils/AliasShortcutUtils.cpp
@@ -27,7 +27,7 @@
 
 #include "AliasShortcutUtils.h"
 
-bool IsAliasShortcut(CStdString &path)
+bool IsAliasShortcut(const std::string& path)
 {
   bool  rtn = false;
 
@@ -65,7 +65,7 @@ bool IsAliasShortcut(CStdString &path)
   return(rtn);
 }
 
-void TranslateAliasShortcut(CStdString &path)
+void TranslateAliasShortcut(std::string& path)
 {
 #if defined(TARGET_DARWIN_OSX)
   FSRef fileRef;

--- a/xbmc/utils/AliasShortcutUtils.h
+++ b/xbmc/utils/AliasShortcutUtils.h
@@ -21,5 +21,5 @@
 
 #include "StdString.h"
 
-bool IsAliasShortcut(CStdString &path);
-void TranslateAliasShortcut(CStdString &path);
+bool IsAliasShortcut(const std::string& path);
+void TranslateAliasShortcut(std::string &path);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -721,9 +721,9 @@ bool URIUtils::IsSmb(const CStdString& strFile)
   return StringUtils::StartsWithNoCase(strFile2, "smb:");
 }
 
-bool URIUtils::IsURL(const CStdString& strFile)
+bool URIUtils::IsURL(const std::string& strFile)
 {
-  return strFile.Find("://") >= 0;
+  return strFile.find("://") != std::string::npos;
 }
 
 bool URIUtils::IsFTP(const CStdString& strFile)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -931,9 +931,9 @@ void URIUtils::AddSlashAtEnd(std::string& strFolder)
   }
 }
 
-bool URIUtils::HasSlashAtEnd(const CStdString& strFile, bool checkURL /* = false */)
+bool URIUtils::HasSlashAtEnd(const std::string& strFile, bool checkURL /* = false */)
 {
-  if (strFile.size() == 0) return false;
+  if (strFile.empty()) return false;
   if (checkURL && IsURL(strFile))
   {
     CURL url(strFile);
@@ -948,13 +948,13 @@ bool URIUtils::HasSlashAtEnd(const CStdString& strFile, bool checkURL /* = false
   return false;
 }
 
-void URIUtils::RemoveSlashAtEnd(CStdString& strFolder)
+void URIUtils::RemoveSlashAtEnd(std::string& strFolder)
 {
   if (IsURL(strFolder))
   {
     CURL url(strFolder);
-    CStdString file = url.GetFileName();
-    if (!file.IsEmpty() && file != strFolder)
+    std::string file = url.GetFileName();
+    if (!file.empty() && file != strFolder)
     {
       RemoveSlashAtEnd(file);
       url.SetFileName(file);
@@ -966,7 +966,7 @@ void URIUtils::RemoveSlashAtEnd(CStdString& strFolder)
   }
 
   while (HasSlashAtEnd(strFolder))
-    strFolder.Delete(strFolder.size() - 1);
+    strFolder.erase(strFolder.size()-1, 1);
 }
 
 bool URIUtils::CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -567,24 +567,37 @@ bool URIUtils::IsHD(const CStdString& strFileName)
   return url.GetProtocol().IsEmpty() || url.GetProtocol() == "file";
 }
 
-bool URIUtils::IsDVD(const CStdString& strFile)
+bool URIUtils::IsDVD(const std::string& strFile)
 {
-  CStdString strFileLow = strFile;
-  strFileLow.MakeLower();
-  if (strFileLow.Find("video_ts.ifo") != -1 && IsOnDVD(strFile))
+  if (strFile.empty())
+    return false;
+
+  std::string strFileLow (strFile);
+  StringUtils::ToLower(strFileLow);
+  if (strFileLow.find("video_ts.ifo") != std::string::npos && IsOnDVD(strFile))
     return true;
 
 #if defined(TARGET_WINDOWS)
-  if (StringUtils::StartsWithNoCase(strFile, "dvd://"))
+  if (strFileLow.compare(0, 5, "dvd://", 5) == 0 || strFileLow.compare(0, 5, "dvd:\\\\", 5) == 0)
     return true;
 
-  if(strFile.Mid(1) != ":\\"
-  && strFile.Mid(1) != ":")
+  if (strFileLow.compare(0, 4, "\\\\?\\", 4) == 0)
+    strFileLow.erase(0, 4);
+
+  if (strFileLow.length() < 2 || strFileLow.length() > 3)
     return false;
 
-  if(GetDriveType(strFile.c_str()) == DRIVE_CDROM)
+  if (strFileLow.compare(1, std::string::npos, ":\\", 2) != 0
+   && strFileLow.compare(1, std::string::npos, ":/",  2) != 0
+   && strFileLow.compare(1, std::string::npos, ":",   1) != 0)
+    return false;
+
+  if(GetDriveType((strFileLow.substr(0, 2) + "\\").c_str()) == DRIVE_CDROM)
     return true;
 #else
+  if (strFileLow.length() < 6 || strFileLow.length() > 10)
+    return false;
+
   if (strFileLow == "iso9660://" || strFileLow == "udf://" || strFileLow == "dvd://1" )
     return true;
 #endif

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -442,23 +442,23 @@ bool URIUtils::IsRemote(const CStdString& strFile)
   return false;
 }
 
-bool URIUtils::IsOnDVD(const CStdString& strFile)
+bool URIUtils::IsOnDVD(const std::string& strFile)
 {
+  if (strFile.length() < 2)
+    return false;
+
+  std::string str(strFile);
 #ifdef TARGET_WINDOWS
-  if (strFile.Mid(1,1) == ":")
-    return (GetDriveType(strFile.Left(3)) == DRIVE_CDROM);
+  if (str.compare(0, 4, "\\\\?\\", 4) == 0)
+    str.erase(0, 4);
+
+  if (str.length() >= 2 && str[1] == ':')
+    return (GetDriveType((str.substr(0, 2) + "\\").c_str()) == DRIVE_CDROM);
 #endif
+  StringUtils::ToLower(str);
 
-  if (strFile.Left(4).CompareNoCase("dvd:") == 0)
-    return true;
-
-  if (strFile.Left(4).CompareNoCase("udf:") == 0)
-    return true;
-
-  if (strFile.Left(8).CompareNoCase("iso9660:") == 0)
-    return true;
-
-  if (strFile.Left(5).CompareNoCase("cdda:") == 0)
+  if (str.compare(0, 4, "dvd:", 4) == 0 || str.compare(0, 4, "udf:", 4) == 0 ||
+      str.compare(0, 8, "iso9660:", 8) == 0 || str.compare(0, 5, "cdda:", 5) == 0)
     return true;
 
   return false;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -894,13 +894,13 @@ bool URIUtils::IsDOSPath(const CStdString &path)
   return false;
 }
 
-void URIUtils::AddSlashAtEnd(CStdString& strFolder)
+void URIUtils::AddSlashAtEnd(std::string& strFolder)
 {
   if (IsURL(strFolder))
   {
     CURL url(strFolder);
-    CStdString file = url.GetFileName();
-    if(!file.IsEmpty() && file != strFolder)
+    std::string file = url.GetFileName();
+    if(!file.empty() && file != strFolder)
     {
       AddSlashAtEnd(file);
       url.SetFileName(file);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -887,7 +887,7 @@ bool URIUtils::IsDOSPath(const CStdString &path)
   if (path.size() > 1 && path[1] == ':' && isalpha(path[0]))
     return true;
 
-  // windows network drives
+  // long win32 path ("\\?\") or win32 UNC path ("\\server\")
   if (path.size() > 1 && path[0] == '\\' && path[1] == '\\')
     return true;
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -116,8 +116,8 @@ public:
   static bool IsLibraryFolder(const CStdString& strFile);
 
   static void AddSlashAtEnd(std::string& strFolder);
-  static bool HasSlashAtEnd(const CStdString& strFile, bool checkURL = false);
-  static void RemoveSlashAtEnd(CStdString& strFolder);
+  static bool HasSlashAtEnd(const std::string& strFile, bool checkURL = false);
+  static void RemoveSlashAtEnd(std::string& strFolder);
   static bool CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2);
 
   static void CreateArchivePath(CStdString& strUrlPath,

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -105,7 +105,7 @@ public:
   static bool IsStack(const CStdString& strFile);
   static bool IsTuxBox(const CStdString& strFile);
   static bool IsUPnP(const CStdString& strFile);
-  static bool IsURL(const CStdString& strFile);
+  static bool IsURL(const std::string& strFile);
   static bool IsVideoDb(const CStdString& strFile);
   static bool IsVTP(const CStdString& strFile);
   static bool IsAPK(const CStdString& strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -93,7 +93,7 @@ public:
   static bool IsMythTV(const CStdString& strFile);
   static bool IsNfs(const CStdString& strFile);  
   static bool IsAfp(const CStdString& strFile);    
-  static bool IsOnDVD(const CStdString& strFile);
+  static bool IsOnDVD(const std::string& strFile);
   static bool IsOnLAN(const CStdString& strFile);
   static bool IsHostOnLAN(const CStdString& hostName, bool offLineCheck = false);
   static bool IsPlugin(const CStdString& strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -115,7 +115,7 @@ public:
   static bool IsAndroidApp(const CStdString& strFile);
   static bool IsLibraryFolder(const CStdString& strFile);
 
-  static void AddSlashAtEnd(CStdString& strFolder);
+  static void AddSlashAtEnd(std::string& strFolder);
   static bool HasSlashAtEnd(const CStdString& strFile, bool checkURL = false);
   static void RemoveSlashAtEnd(CStdString& strFolder);
   static bool CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -74,7 +74,7 @@ public:
   static bool IsDAAP(const CStdString& strFile);
   static bool IsDAV(const CStdString& strFile);
   static bool IsDOSPath(const CStdString &path);
-  static bool IsDVD(const CStdString& strFile);
+  static bool IsDVD(const std::string& strFile);
   static bool IsFTP(const CStdString& strFile);
   static bool IsHD(const CStdString& strFileName);
   static bool IsHDHomeRun(const CStdString& strFile);

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -439,7 +439,6 @@ CStdString CWIN32Util::GetSpecialFolder(int csidl)
   {
     buf[bufSize-1] = 0;
     g_charsetConverter.wToUTF8(buf, strProfilePath);
-    strProfilePath = UncToSmb(strProfilePath);
   }
   else
     strProfilePath = "";
@@ -471,13 +470,6 @@ CStdString CWIN32Util::GetProfilePath()
   URIUtils::AddSlashAtEnd(strProfilePath);
 
   return strProfilePath;
-}
-
-std::string CWIN32Util::UncToSmb(const std::string& strPath)
-{
-  if (strPath.length() > 2 && strPath.compare(0, 2, "\\\\", 2) == 0 && strPath.compare(2, 2, "?\\", 2) != 0)
-    return "smb://" + strPath.substr(2);
-  return strPath;
 }
 
 std::string CWIN32Util::SmbToUnc(const std::string& strPath)

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -473,26 +473,18 @@ CStdString CWIN32Util::GetProfilePath()
   return strProfilePath;
 }
 
-CStdString CWIN32Util::UncToSmb(const CStdString &strPath)
+std::string CWIN32Util::UncToSmb(const std::string& strPath)
 {
-  CStdString strRetPath(strPath);
-  if(StringUtils::StartsWith(strRetPath, "\\\\"))
-  {
-    strRetPath = "smb:" + strPath;
-    strRetPath.Replace("\\","/");
-  }
-  return strRetPath;
+  if (strPath.length() > 2 && strPath.compare(0, 2, "\\\\", 2) == 0 && strPath.compare(2, 2, "?\\", 2) != 0)
+    return "smb://" + strPath.substr(2);
+  return strPath;
 }
 
-CStdString CWIN32Util::SmbToUnc(const CStdString &strPath)
+std::string CWIN32Util::SmbToUnc(const std::string& strPath)
 {
-  CStdString strRetPath(strPath);
-  if(StringUtils::StartsWithNoCase(strRetPath, "smb://"))
-  {
-    strRetPath.Replace("smb://","\\\\");
-    strRetPath.Replace("/","\\");
-  }
-  return strRetPath;
+  if(StringUtils::StartsWithNoCase(strPath, "smb://"))
+    return "\\\\" + strPath.substr(6);
+  return strPath;
 }
 
 bool CWIN32Util::AddExtraLongPathPrefix(std::wstring& path)

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -57,7 +57,6 @@ public:
   static CStdString GetSpecialFolder(int csidl);
   static CStdString GetSystemPath();
   static CStdString GetProfilePath();
-  static std::string UncToSmb(const std::string& strPath);
   static std::string SmbToUnc(const std::string& strPath);
   static bool AddExtraLongPathPrefix(std::wstring& path);
   static bool RemoveExtraLongPathPrefix(std::wstring& path);

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -57,8 +57,8 @@ public:
   static CStdString GetSpecialFolder(int csidl);
   static CStdString GetSystemPath();
   static CStdString GetProfilePath();
-  static CStdString UncToSmb(const CStdString &strPath);
-  static CStdString SmbToUnc(const CStdString &strPath);
+  static std::string UncToSmb(const std::string& strPath);
+  static std::string SmbToUnc(const std::string& strPath);
   static bool AddExtraLongPathPrefix(std::wstring& path);
   static bool RemoveExtraLongPathPrefix(std::wstring& path);
   static void ExtendDllPath();

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -61,6 +61,7 @@ public:
   static std::string SmbToUnc(const std::string& strPath);
   static bool AddExtraLongPathPrefix(std::wstring& path);
   static bool RemoveExtraLongPathPrefix(std::wstring& path);
+  static std::wstring ConvertPathToWin32Form(const std::string& pathUtf8);
   static void ExtendDllPath();
   static HRESULT ToggleTray(const char cDriveLetter='\0');
   static HRESULT EjectTray(const char cDriveLetter='\0');


### PR DESCRIPTION
Allow to correctly process libbluray-generated filenames with several back- and forwardslashes.

Also contain some removal of CStdString.

This PR was done thanks to original @koying idea (original PR #3267).
