### PR TITLE
[Langinfo] Use preferred audio/subtitle language for dvds and blurays.

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -53,6 +53,7 @@ CLangInfo::CRegion::CRegion(const CRegion& region)
   m_strDVDAudioLanguage=region.m_strDVDAudioLanguage;
   m_strDVDSubtitleLanguage=region.m_strDVDSubtitleLanguage;
   m_strLangLocaleName = region.m_strLangLocaleName;
+  m_strLangLocaleCodeTwoChar = region.m_strLangLocaleCodeTwoChar;
   m_strRegionLocaleName = region.m_strRegionLocaleName;
 
   m_strDateFormatShort=region.m_strDateFormatShort;
@@ -86,6 +87,7 @@ void CLangInfo::CRegion::SetDefaults()
   m_strDVDAudioLanguage="en";
   m_strDVDSubtitleLanguage="en";
   m_strLangLocaleName = "English";
+  m_strLangLocaleCodeTwoChar = "en";
 
   m_strDateFormatShort="DD/MM/YYYY";
   m_strDateFormatLong="DDDD, D MMMM YYYY";
@@ -269,6 +271,10 @@ bool CLangInfo::Load(const CStdString& strFileName)
   else
     m_languageCodeGeneral = m_defaultRegion.m_strLangLocaleName;
 #endif
+
+  CStdString tmp;
+  if (g_LangCodeExpander.ConvertToTwoCharCode(tmp, m_defaultRegion.m_strLangLocaleName))
+    m_defaultRegion.m_strLangLocaleCodeTwoChar = tmp;
 
   const TiXmlNode *pCharSets = pRootElement->FirstChild("charsets");
   if (pCharSets && !pCharSets->NoChildren())
@@ -512,8 +518,11 @@ const std::string CLangInfo::GetDVDSubtitleLanguage() const
   return code;
 }
 
-const CStdString& CLangInfo::GetLanguageLocale() const
+const std::string CLangInfo::GetLanguageLocale(bool twochar /* = false */) const
 {
+  if (twochar)
+    return m_currentRegion->m_strLangLocaleCodeTwoChar;
+
   return m_currentRegion->m_strLangLocaleName;
 }
 

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -489,15 +489,23 @@ const CStdString& CLangInfo::GetDVDMenuLanguage() const
 }
 
 // two character codes as defined in ISO639
-const CStdString& CLangInfo::GetDVDAudioLanguage() const
+const std::string CLangInfo::GetDVDAudioLanguage() const
 {
-  return m_currentRegion->m_strDVDAudioLanguage;
+  CStdString code;
+  if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_audioLanguage))
+    code = m_currentRegion->m_strDVDAudioLanguage;
+  
+  return code;
 }
 
 // two character codes as defined in ISO639
-const CStdString& CLangInfo::GetDVDSubtitleLanguage() const
+const std::string CLangInfo::GetDVDSubtitleLanguage() const
 {
-  return m_currentRegion->m_strDVDSubtitleLanguage;
+  CStdString code;
+  if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_subtitleLanguage))
+    code = m_currentRegion->m_strDVDSubtitleLanguage;
+  
+  return code;
 }
 
 const CStdString& CLangInfo::GetLanguageLocale() const

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -483,9 +483,13 @@ void CLangInfo::SetSubtitleLanguage(const CStdString &language)
 }
 
 // two character codes as defined in ISO639
-const CStdString& CLangInfo::GetDVDMenuLanguage() const
+const std::string CLangInfo::GetDVDMenuLanguage() const
 {
-  return m_currentRegion->m_strDVDMenuLanguage;
+  CStdString code;
+  if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_currentRegion->m_strLangLocaleName))
+    code = m_currentRegion->m_strDVDMenuLanguage;
+  
+  return code;
 }
 
 // two character codes as defined in ISO639

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -58,8 +58,8 @@ public:
   void SetSubtitleLanguage(const CStdString &language);
 
   const CStdString& GetDVDMenuLanguage() const;
-  const CStdString& GetDVDAudioLanguage() const;
-  const CStdString& GetDVDSubtitleLanguage() const;
+  const std::string GetDVDAudioLanguage() const;
+  const std::string GetDVDSubtitleLanguage() const;
   const CStdString& GetTimeZone() const;
 
   const CStdString& GetRegionLocale() const;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -63,7 +63,7 @@ public:
   const CStdString& GetTimeZone() const;
 
   const CStdString& GetRegionLocale() const;
-  const CStdString& GetLanguageLocale() const;
+  const std::string GetLanguageLocale(bool twochar = false) const;
 
   bool ForceUnicodeFont() const { return m_currentRegion->m_forceUnicodeFont; }
 
@@ -144,6 +144,7 @@ protected:
     CStdString m_strDVDAudioLanguage;
     CStdString m_strDVDSubtitleLanguage;
     CStdString m_strLangLocaleName;
+    std::string m_strLangLocaleCodeTwoChar;
     CStdString m_strRegionLocaleName;
     bool m_forceUnicodeFont;
     CStdString m_strName;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -57,7 +57,7 @@ public:
   // or a language name in english (as used by XBMC)
   void SetSubtitleLanguage(const CStdString &language);
 
-  const CStdString& GetDVDMenuLanguage() const;
+  const std::string GetDVDMenuLanguage() const;
   const std::string GetDVDAudioLanguage() const;
   const std::string GetDVDSubtitleLanguage() const;
   const CStdString& GetTimeZone() const;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -587,7 +587,7 @@ const char *CAddonMgr::GetTranslatedString(const cp_cfg_element_t *root, const c
     if (strcmp(tag, child.name) == 0)
     { // see if we have a "lang" attribute
       const char *lang = m_cpluff->lookup_cfg_value((cp_cfg_element_t*)&child, "@lang");
-      if (lang && 0 == strcmp(lang,g_langInfo.GetDVDAudioLanguage().c_str()))
+      if (lang && 0 == strcmp(lang,g_langInfo.GetLanguageLocale(true).c_str()))
         return child.value;
       if (!lang || 0 == strcmp(lang, "en"))
         eng = &child;


### PR DESCRIPTION
This fixes ticket http://trac.xbmc.org/ticket/13927 .
