### PR TITLE
Fix make check compilation.

### DIFF
--- a/xbmc/filesystem/test/TestRarFile.cpp
+++ b/xbmc/filesystem/test/TestRarFile.cpp
@@ -290,8 +290,7 @@ TEST(TestRarFile, StoredRAR)
 
   /* /testdir/reffile.txt */
   strpathinrar = itemlist[1]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/reffile.txt",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
@@ -336,8 +335,7 @@ TEST(TestRarFile, StoredRAR)
 
   /* /testdir/testemptysubdir */
   strpathinrar = itemlist[2]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testemptysubdir",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testemptysubdir"));
   /* TODO: Should this set the itemlist to an empty list instead? */
   EXPECT_FALSE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlistemptydir));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
@@ -349,8 +347,7 @@ TEST(TestRarFile, StoredRAR)
 
   /* /testdir/testsymlink -> testsubdir/reffile.txt */
   strpathinrar = itemlist[4]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsymlink",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsymlink"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
@@ -360,8 +357,7 @@ TEST(TestRarFile, StoredRAR)
 
   /* /testdir/testsubdir/ */
   strpathinrar = itemlist[0]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsubdir/",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsubdir/"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
@@ -372,7 +368,7 @@ TEST(TestRarFile, StoredRAR)
   /* /testdir/testsubdir/reffile.txt */
   strpathinrar = itemlist[0]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar,
-                                    "/testdir/testsubdir/reffile.txt", true));
+                                    "/testdir/testsubdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
@@ -512,8 +508,7 @@ TEST(TestRarFile, NormalRAR)
 
   /* /testdir/reffile.txt */
   strpathinrar = itemlist[1]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/reffile.txt",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
 
@@ -558,8 +553,7 @@ TEST(TestRarFile, NormalRAR)
 
   /* /testdir/testemptysubdir */
   strpathinrar = itemlist[2]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testemptysubdir",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testemptysubdir"));
   /* TODO: Should this set the itemlist to an empty list instead? */
   EXPECT_FALSE(XFILE::CDirectory::GetDirectory(strpathinrar, itemlistemptydir));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
@@ -571,8 +565,7 @@ TEST(TestRarFile, NormalRAR)
 
   /* /testdir/testsymlink -> testsubdir/reffile.txt */
   strpathinrar = itemlist[4]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsymlink",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsymlink"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFLNK);
 
@@ -582,8 +575,7 @@ TEST(TestRarFile, NormalRAR)
 
   /* /testdir/testsubdir/ */
   strpathinrar = itemlist[0]->GetPath();
-  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsubdir/",
-                                    true));
+  ASSERT_TRUE(StringUtils::EndsWith(strpathinrar, "/testdir/testsubdir/"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFDIR);
 
@@ -594,7 +586,7 @@ TEST(TestRarFile, NormalRAR)
   /* /testdir/testsubdir/reffile.txt */
   strpathinrar = itemlist[0]->GetPath();
   ASSERT_TRUE(StringUtils::EndsWith(strpathinrar,
-                                    "/testdir/testsubdir/reffile.txt", true));
+                                    "/testdir/testsubdir/reffile.txt"));
   EXPECT_EQ(0, XFILE::CFile::Stat(strpathinrar, &stat_buffer));
   EXPECT_TRUE((stat_buffer.st_mode & S_IFMT) | S_IFREG);
 

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -234,6 +234,14 @@ public:
   void CancelJobs();
 
   /*!
+   \brief Re-start accepting jobs again
+   Called after calling CancelJobs() to allow this manager to accept more jobs
+   \throws std::logic_error if the manager was not previously cancelled
+   \sa CancelJobs()
+   */
+  void Restart();
+
+  /*!
    \brief Checks to see if any jobs of a specific type are currently processing.
    \param type Job type to search for
    \return Number of matching jobs

--- a/xbmc/utils/test/TestCharsetConverter.cpp
+++ b/xbmc/utils/test/TestCharsetConverter.cpp
@@ -20,6 +20,7 @@
 
 #include "settings/Settings.h"
 #include "utils/CharsetConverter.h"
+#include "utils/StdString.h"
 
 #include "gtest/gtest.h"
 
@@ -136,9 +137,12 @@ TEST_F(TestCharsetConverter, utf16LEtoW)
 
 TEST_F(TestCharsetConverter, subtitleCharsetToW)
 {
+  varstra1 = "test subtitleCharsetToW";
   refstrw1 = L"test subtitleCharsetToW";
   varstrw1.clear();
-  g_charsetConverter.subtitleCharsetToW(refstrw1, varstrw1);
+  g_charsetConverter.subtitleCharsetToW(varstra1, varstrw1);
+
+  /* Assign refstra1 to refstrw1 so that we can compare */
   EXPECT_STREQ(refstrw1.c_str(), varstrw1.c_str());
 }
 
@@ -200,14 +204,14 @@ TEST_F(TestCharsetConverter, stringCharsetToUtf8)
 {
   refstra1 = "ｔｅｓｔ＿ｓｔｒｉｎｇＣｈａｒｓｅｔＴｏＵｔｆ８";
   varstra1.clear();
-  g_charsetConverter.stringCharsetToUtf8("UTF-16LE", refutf16LE3, varstra1);
+  g_charsetConverter.ToUtf8("UTF-16LE", refutf16LE3, varstra1);
   EXPECT_STREQ(refstra1.c_str(), varstra1.c_str());
 }
 
 TEST_F(TestCharsetConverter, isValidUtf8_1)
 {
   varstra1.clear();
-  g_charsetConverter.stringCharsetToUtf8("UTF-16LE", refutf16LE3, varstra1);
+  g_charsetConverter.ToUtf8("UTF-16LE", refutf16LE3, varstra1);
   EXPECT_TRUE(g_charsetConverter.isValidUtf8(varstra1.c_str()));
 }
 
@@ -220,7 +224,7 @@ TEST_F(TestCharsetConverter, isValidUtf8_2)
 TEST_F(TestCharsetConverter, isValidUtf8_3)
 {
   varstra1.clear();
-  g_charsetConverter.stringCharsetToUtf8("UTF-16LE", refutf16LE3, varstra1);
+  g_charsetConverter.ToUtf8("UTF-16LE", refutf16LE3, varstra1);
   EXPECT_TRUE(g_charsetConverter.isValidUtf8(varstra1.c_str(),
                                              varstra1.length() + 1));
 }
@@ -317,10 +321,10 @@ TEST_F(TestCharsetConverter, getCharsetLabels)
   reflabels.push_back("Korean");
   reflabels.push_back("Hong Kong (Big5-HKSCS)");
 
-  std::vector<CStdString> varlabels = g_charsetConverter.getCharsetLabels();
+  std::vector<std::string> varlabels = g_charsetConverter.getCharsetLabels();
   ASSERT_EQ(reflabels.size(), varlabels.size());
 
-  std::vector<CStdString>::iterator it;
+  std::vector<std::string>::iterator it;
   for (it = varlabels.begin(); it < varlabels.end(); it++)
   {
     EXPECT_STREQ((reflabels.at(it - varlabels.begin())).c_str(), (*it).c_str());

--- a/xbmc/utils/test/TestSortUtils.cpp
+++ b/xbmc/utils/test/TestSortUtils.cpp
@@ -28,26 +28,26 @@ TEST(TestSortUtils, Sort_SortBy)
   SortItems items;
 
   CVariant variant1("M Artist");
-  SortItem item1;
-  item1[FieldArtist] = variant1;
+  SortItemPtr item1(new SortItem());
+  (*item1)[FieldArtist] = variant1;
   CVariant variant2("B Artist");
-  SortItem item2;
-  item2[FieldArtist] = variant2;
+  SortItemPtr item2(new SortItem());
+  (*item2)[FieldArtist] = variant2;
   CVariant variant3("R Artist");
-  SortItem item3;
-  item3[FieldArtist] = variant3;
+  SortItemPtr item3(new SortItem());
+  (*item3)[FieldArtist] = variant3;
   CVariant variant4("R Artist");
-  SortItem item4;
-  item4[FieldArtist] = variant4;
+  SortItemPtr item4(new SortItem());
+  (*item4)[FieldArtist] = variant4;
   CVariant variant5("I Artist");
-  SortItem item5;
-  item5[FieldArtist] = variant5;
+  SortItemPtr item5(new SortItem());
+  (*item5)[FieldArtist] = variant5;
   CVariant variant6("A Artist");
-  SortItem item6;
-  item6[FieldArtist] = variant6;
+  SortItemPtr item6(new SortItem());
+  (*item6)[FieldArtist] = variant6;
   CVariant variant7("G Artist");
-  SortItem item7;
-  item7[FieldArtist] = variant7;
+  SortItemPtr item7(new SortItem());
+  (*item7)[FieldArtist] = variant7;
 
   items.push_back(item1);
   items.push_back(item2);
@@ -59,13 +59,13 @@ TEST(TestSortUtils, Sort_SortBy)
 
   SortUtils::Sort(SortByArtist, SortOrderAscending, SortAttributeNone, items);
 
-  EXPECT_STREQ("A Artist", items.at(0)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("B Artist", items.at(1)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("G Artist", items.at(2)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("I Artist", items.at(3)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("M Artist", items.at(4)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("R Artist", items.at(5)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("R Artist", items.at(6)[FieldArtist].asString().c_str());
+  EXPECT_STREQ("A Artist", (*items.at(0))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("B Artist", (*items.at(1))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("G Artist", (*items.at(2))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("I Artist", (*items.at(3))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("M Artist", (*items.at(4))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("R Artist", (*items.at(5))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("R Artist", (*items.at(6))[FieldArtist].asString().c_str());
 }
 
 TEST(TestSortUtils, Sort_SortDescription)
@@ -73,26 +73,26 @@ TEST(TestSortUtils, Sort_SortDescription)
   SortItems items;
 
   CVariant variant1("M Artist");
-  SortItem item1;
-  item1[FieldArtist] = variant1;
+  SortItemPtr item1(new SortItem());
+  (*item1)[FieldArtist] = variant1;
   CVariant variant2("B Artist");
-  SortItem item2;
-  item2[FieldArtist] = variant2;
+  SortItemPtr item2(new SortItem());
+  (*item2)[FieldArtist] = variant2;
   CVariant variant3("R Artist");
-  SortItem item3;
-  item3[FieldArtist] = variant3;
+  SortItemPtr item3(new SortItem());
+  (*item3)[FieldArtist] = variant3;
   CVariant variant4("R Artist");
-  SortItem item4;
-  item4[FieldArtist] = variant4;
+  SortItemPtr item4(new SortItem());
+  (*item4)[FieldArtist] = variant4;
   CVariant variant5("I Artist");
-  SortItem item5;
-  item5[FieldArtist] = variant5;
+  SortItemPtr item5(new SortItem());
+  (*item5)[FieldArtist] = variant5;
   CVariant variant6("A Artist");
-  SortItem item6;
-  item6[FieldArtist] = variant6;
+  SortItemPtr item6(new SortItem());
+  (*item6)[FieldArtist] = variant6;
   CVariant variant7("G Artist");
-  SortItem item7;
-  item7[FieldArtist] = variant7;
+  SortItemPtr item7(new SortItem());
+  (*item7)[FieldArtist] = variant7;
 
   items.push_back(item1);
   items.push_back(item2);
@@ -106,13 +106,13 @@ TEST(TestSortUtils, Sort_SortDescription)
   desc.sortBy = SortByArtist;
   SortUtils::Sort(desc, items);
 
-  EXPECT_STREQ("A Artist", items.at(0)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("B Artist", items.at(1)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("G Artist", items.at(2)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("I Artist", items.at(3)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("M Artist", items.at(4)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("R Artist", items.at(5)[FieldArtist].asString().c_str());
-  EXPECT_STREQ("R Artist", items.at(6)[FieldArtist].asString().c_str());
+  EXPECT_STREQ("A Artist", (*items.at(0))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("B Artist", (*items.at(1))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("G Artist", (*items.at(2))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("I Artist", (*items.at(3))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("M Artist", (*items.at(4))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("R Artist", (*items.at(5))[FieldArtist].asString().c_str());
+  EXPECT_STREQ("R Artist", (*items.at(6))[FieldArtist].asString().c_str());
 }
 
 TEST(TestSortUtils, GetFieldsForSorting)

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -80,5 +80,5 @@ TEST(TestStreamDetails, VideoDimsToResolutionDescription)
 
 TEST(TestStreamDetails, VideoAspectToAspectDescription)
 {
-  EXPECT_STREQ("2.35", CStreamDetails::VideoAspectToAspectDescription(2.39f));
+  EXPECT_STREQ("2.40", CStreamDetails::VideoAspectToAspectDescription(2.39f));
 }


### PR DESCRIPTION
TestRarFile: StringUtils::EndsWith no longer takes a third parameter
TestCharsetConverter: CCharsetConverter::subtilteCharsetToW's first
parameter cannot be a std::wstring, ::stringCharsetToUtf8 renamed to
::ToUtf8
TestJobManager: CJobManager::IsPaused renamed to IsProcessing with reverse
effect, s/UnPause/UnPauseJobs. Only PRIORITY_LOW_PAUSABLE jobs can be paused.

 There is a race condition upon calling IsProcessing for the first time
 after AddJob is called - the job may not have been started yet and not
 added to the processing list. As such, the test implements a custom CJob
 that allows the calling thread to block until the job has started processing
 such that IsProcessing can be checked in a deterministic way.

 CancelJobs effectively renders CJobManager useless after it is called,
 because m_running is set to false. A new member "Restart" was added to
 set this variable back to true when appropriate.

 IsProcessing should have returned false when jobs were paused.

TestSortUtils: SortItems is now a std::vectorboost::shared_ptr<SortItem> not
an std::vector<SortItem>
TestStreamDetails: Aspect ratio 2.39 is now within the 2.37 - 2.47 range and
as such snaps to 2.40
