### PR TITLE
PVR: FIx crash in GUIEPGGridContainer

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -216,7 +216,7 @@ namespace EPG
 
     CGUITexture m_guiProgressIndicatorTexture;
 
-    struct GridItemsPtr **m_gridIndex;
+    std::vector<std::vector<GridItemsPtr> > m_gridIndex;
     GridItemsPtr *m_item;
     CGUIListItem *m_lastItem;
     CGUIListItem *m_lastChannel;


### PR DESCRIPTION
Program terminated with signal 11, Segmentation fault.
#0  EPG::CGUIEPGGridContainer::SelectItemFromPoint (this=this@entry=0x354fd00, point=..., justGrid=justGrid@entry=false) at GUIEPGGridContainer.cpp:1326

1326      if (!m_gridIndex[channelIndex][blockIndex].item)

Don't use operator!() of item. But check attribute 'item' of pointed struct.
