### PR TITLE
properly reset skin-related settings after changing the current skin (fixes #14595)

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -22,6 +22,9 @@
           <constraints>
             <options>skinthemes</options>
           </constraints>
+          <dependencies>
+            <dependency type="update" setting="lookandfeel.skin" />
+          </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
         <setting id="lookandfeel.skincolors" type="string" parent="lookandfeel.skin" label="14078" help="36106">
@@ -30,6 +33,9 @@
           <constraints>
             <options>skincolors</options>
           </constraints>
+          <dependencies>
+            <dependency type="update" setting="lookandfeel.skin" />
+          </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
         <setting id="lookandfeel.font" type="string" parent="lookandfeel.skin" label="13303" help="36107">
@@ -38,6 +44,9 @@
           <constraints>
             <options>skinfonts</options>
           </constraints>
+          <dependencies>
+            <dependency type="update" setting="lookandfeel.skin" />
+          </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
         <setting id="lookandfeel.skinzoom" type="integer" parent="lookandfeel.skin" label="20109" help="36108">
@@ -48,6 +57,9 @@
             <step>2</step>
             <maximum>20</maximum>
           </constraints>
+          <dependencies>
+            <dependency type="update" setting="lookandfeel.skin" />
+          </dependencies>
           <control type="spinner" format="string">
             <formatlabel>14047</formatlabel>
           </control>
@@ -58,6 +70,9 @@
           <constraints>
             <options>startupwindows</options>
           </constraints>
+          <dependencies>
+            <dependency type="update" setting="lookandfeel.skin" />
+          </dependencies>
           <control type="spinner" format="string" />
         </setting>
         <setting id="lookandfeel.soundskin" type="string" label="15108" help="36110">
@@ -66,6 +81,9 @@
           <constraints>
             <options>skinsounds</options>
           </constraints>
+          <dependencies>
+            <dependency type="update" setting="lookandfeel.skin" />
+          </dependencies>
           <control type="spinner" format="string" />
         </setting>
       </group>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1571,7 +1571,15 @@ void CApplication::OnSettingChanged(const CSetting *setting)
   if (settingId == "lookandfeel.skin" ||
       settingId == "lookandfeel.font" ||
       settingId == "lookandfeel.skincolors")
-    CApplicationMessenger::Get().ExecBuiltIn("ReloadSkin");
+  {
+    // if the skin changes and the current theme is not the default one, reset
+    // the theme to the default value (which will also change lookandfeel.skincolors
+    // which in turn will reload the skin
+    if (settingId == "lookandfeel.skin" && CSettings::Get().GetString("lookandfeel.skintheme") != "SKINDEFAULT")
+      CSettings::Get().SetString("lookandfeel.skintheme", "SKINDEFAULT");
+    else
+      CApplicationMessenger::Get().ExecBuiltIn("ReloadSkin");
+  }
   else if (settingId == "lookandfeel.skintheme")
   {
     // also set the default color theme

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -281,6 +281,12 @@ const INFO::CSkinVariableString* CSkinInfo::CreateSkinVariable(const CStdString&
 
 void CSkinInfo::SettingOptionsSkinColorsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
 {
+  CStdString settingValue = ((const CSettingString*)setting)->GetValue();
+  // Remove the .xml extension from the Themes
+  if (URIUtils::HasExtension(settingValue, ".xml"))
+    URIUtils::RemoveExtension(settingValue);
+  current = "SKINDEFAULT";
+
   // There is a default theme (just defaults.xml)
   // any other *.xml files are additional color themes on top of this one.
   
@@ -305,19 +311,18 @@ void CSkinInfo::SettingOptionsSkinColorsFiller(const CSetting *setting, std::vec
   sort(vecColors.begin(), vecColors.end(), sortstringbyname());
 
   for (int i = 0; i < (int) vecColors.size(); ++i)
+  {
     list.push_back(make_pair(vecColors[i], vecColors[i]));
 
-  CStdString settingValue = ((const CSettingString*)setting)->GetValue();
-  // Remove the .xml extension from the Themes
-  if (URIUtils::HasExtension(settingValue, ".xml"))
-    URIUtils::RemoveExtension(settingValue);
-  
-  // Set the choosen theme
-  current = settingValue;
+    if (StringUtils::EqualsNoCase(vecColors[i], settingValue))
+      current = settingValue;
+  }
 }
 
 void CSkinInfo::SettingOptionsSkinFontsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
 {
+  CStdString settingValue = ((const CSettingString*)setting)->GetValue();
+  bool currentValueSet = false;
   std::string strPath = g_SkinInfo->GetSkinPath("Font.xml");
 
   CXBMCTinyXML xmlDoc;
@@ -361,6 +366,9 @@ void CSkinInfo::SettingOptionsSkinFontsFiller(const CSetting *setting, std::vect
             list.push_back(make_pair(g_localizeStrings.Get(atoi(idLocAttr)), idAttr));
           else
             list.push_back(make_pair(idAttr, idAttr));
+
+          if (StringUtils::EqualsNoCase(idAttr, settingValue.c_str()))
+            currentValueSet = true;
         }
       }
 
@@ -371,11 +379,19 @@ void CSkinInfo::SettingOptionsSkinFontsFiller(const CSetting *setting, std::vect
   {
     // Since no fontset is defined, there is no selection of a fontset, so disable the component
     list.push_back(make_pair(g_localizeStrings.Get(13278), ""));
+    current = "";
+    currentValueSet = true;
   }
+
+  if (!currentValueSet)
+    current = list[0].second;
 }
 
 void CSkinInfo::SettingOptionsSkinSoundFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
 {
+  CStdString settingValue = ((const CSettingString*)setting)->GetValue();
+  current = "SKINDEFAULT";
+
   //find skins...
   CFileItemList items;
   CDirectory::GetDirectory("special://xbmc/sounds/", items);
@@ -401,14 +417,23 @@ void CSkinInfo::SettingOptionsSkinSoundFiller(const CSetting *setting, std::vect
 
   sort(vecSoundSkins.begin(), vecSoundSkins.end(), sortstringbyname());
   for (unsigned int i = 0; i < vecSoundSkins.size(); i++)
+  {
     list.push_back(make_pair(vecSoundSkins[i], vecSoundSkins[i]));
+
+    if (StringUtils::EqualsNoCase(vecSoundSkins[i], settingValue))
+      current = settingValue;
+  }
 }
 
 void CSkinInfo::SettingOptionsSkinThemesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
 {
+  // get the choosen theme and remove the extension from the current theme (backward compat)
+  CStdString settingValue = ((const CSettingString*)setting)->GetValue();
+  URIUtils::RemoveExtension(settingValue);
+  current = "SKINDEFAULT";
+
   // there is a default theme (just Textures.xpr/xbt)
   // any other *.xpr|*.xbt files are additional themes on top of this one.
-  const CSettingString *pSettingString = (const CSettingString *)setting;
 
   // add the default Label
   list.push_back(make_pair(g_localizeStrings.Get(15109), "SKINDEFAULT")); // the standard Textures.xpr/xbt will be used
@@ -419,16 +444,19 @@ void CSkinInfo::SettingOptionsSkinThemesFiller(const CSetting *setting, std::vec
 
   // sort the themes for GUI and list them
   for (int i = 0; i < (int) vecTheme.size(); ++i)
+  {
     list.push_back(make_pair(vecTheme[i], vecTheme[i]));
 
-  // set the choosen theme and remove the extension from the current theme (backward compat)
-  CStdString settingValue = pSettingString->GetValue();
-  URIUtils::RemoveExtension(settingValue);
-  current = settingValue;
+    if (StringUtils::EqualsNoCase(vecTheme[i], settingValue))
+      current = settingValue;
+  }
 }
 
 void CSkinInfo::SettingOptionsStartupWindowsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current)
 {
+  int settingValue = ((const CSettingInt *)setting)->GetValue();
+  current = -1;
+
   const vector<CStartupWindow> &startupWindows = g_SkinInfo->GetStartupWindows();
 
   for (vector<CStartupWindow>::const_iterator it = startupWindows.begin(); it != startupWindows.end(); it++)
@@ -439,7 +467,14 @@ void CSkinInfo::SettingOptionsStartupWindowsFiller(const CSetting *setting, std:
     int windowID = it->m_id;
 
     list.push_back(make_pair(windowName, windowID));
+
+    if (settingValue == windowID)
+      current = settingValue;
   }
+
+  // if the current value hasn't been properly set, set it to the first window in the list
+  if (current < 0)
+    current = list[0].second;
 }
 
 } /*namespace ADDON*/


### PR DESCRIPTION
The first commit is a cleanup and makes sure that the settings spinners of skin-related settings are always up-to-date. I ran into this issue only once while debugging issue #14595 and wasn't able to reproduce it afterwards.
The second commit is the real fix for http://trac.xbmc.org/ticket/14595 caused by the settings refactor. The problem is/was that the info labels Skin.CurrentTheme and Skin.CurrentColourTheme didn't return the updated values after changing the current skin.
