### PR TITLE
Disable channel icon scan when icon path is empty

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -838,7 +838,12 @@
         <setting id="pvrmenu.searchicons" type="action" label="19167" help="36217">
           <level>1</level>
           <dependencies>
-            <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
+            <dependency type="enable">
+              <and>
+                <condition setting="pvrmanager.enabled" operator="is">true</condition>
+                <condition setting="pvrmenu.iconpath" operator="!is"></condition>
+              </and>
+            </dependency>
           </dependencies>
         </setting>
       </group>


### PR DESCRIPTION
XBMC checks the icon path and terminates the scan early if no path is set ([PVRChannelGroup.cpp#L245](https://github.com/xbmc/xbmc/blob/947f666/xbmc/pvr/channels/PVRChannelGroup.cpp#L245)). This commit causes the setting to respect that.
