### PR TITLE
[Confluence] get rid of SCRIPTXXX labels

### DIFF
--- a/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
+++ b/addons/skin.confluence/720p/script-NextAired-TVGuide.xml
@@ -126,7 +126,7 @@
 			<itemgap>5</itemgap>
 			<control type="label">
 				<include>WindowTitleCommons</include>
-				<label>$LOCALIZE[SCRIPT450]</label>
+				<label>$ADDON[script.tv.show.next.aired 450]</label>
 			</control>
 			<control type="label">
 				<include>WindowTitleCommons</include>

--- a/addons/skin.confluence/720p/script-XBMC_Lyrics-main.xml
+++ b/addons/skin.confluence/720p/script-XBMC_Lyrics-main.xml
@@ -45,7 +45,7 @@
 				<width>550</width>
 				<height>30</height>
 				<font>font30_title</font>
-				<label>$LOCALIZE[SCRIPT0]</label>
+				<label>$ADDON[script.cu.lrclyrics 0]</label>
 				<align>right</align>
 				<aligny>center</aligny>
 				<textcolor>white</textcolor>


### PR DESCRIPTION
remove deprecated SCRIPTXXX labels and replace them by their 'addon id' equivalents.
