### PR TITLE
Fix: Load AdvancedSettings first

### DIFF
--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -822,16 +822,18 @@ void CSettings::InitializeConditions()
 void CSettings::InitializeISettingsHandlers()
 {
   // register ISettingsHandler implementations
-  m_settingsManager->RegisterSettingsHandler(&g_application);
-  m_settingsManager->RegisterSettingsHandler(&CProfilesManager::Get());
+  // The order of these matters! Handlers are processed in the order they were registered.
   m_settingsManager->RegisterSettingsHandler(&g_advancedSettings);
   m_settingsManager->RegisterSettingsHandler(&CMediaSourceSettings::Get());
   m_settingsManager->RegisterSettingsHandler(&CPlayerCoreFactory::Get());
-  m_settingsManager->RegisterSettingsHandler(&CRssManager::Get());
+  m_settingsManager->RegisterSettingsHandler(&CProfilesManager::Get());
 #ifdef HAS_UPNP
   m_settingsManager->RegisterSettingsHandler(&CUPnPSettings::Get());
 #endif
   m_settingsManager->RegisterSettingsHandler(&CWakeOnAccess::Get());
+  m_settingsManager->RegisterSettingsHandler(&CRssManager::Get());
+  m_settingsManager->RegisterSettingsHandler(&CWakeOnAccess::Get());
+  m_settingsManager->RegisterSettingsHandler(&g_application);
 }
 
 void CSettings::InitializeISubSettings()

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -316,7 +316,8 @@ void CSettingsManager::RegisterSettingsHandler(ISettingsHandler *settingsHandler
     return;
 
   CSingleLock lock(m_critical);
-  m_settingsHandlers.insert(settingsHandler);
+  if (find(m_settingsHandlers.begin(), m_settingsHandlers.end(), settingsHandler) >= m_settingsHandlers.end())
+    m_settingsHandlers.push_back(settingsHandler);
 }
 
 void CSettingsManager::UnregisterSettingsHandler(ISettingsHandler *settingsHandler)
@@ -325,7 +326,7 @@ void CSettingsManager::UnregisterSettingsHandler(ISettingsHandler *settingsHandl
     return;
 
   CSingleLock lock(m_critical);
-  m_settingsHandlers.erase(settingsHandler);
+  m_settingsHandlers.erase(find(m_settingsHandlers.begin(), m_settingsHandlers.end(), settingsHandler));
 }
 
 void CSettingsManager::RegisterSubSettings(ISubSettings *subSettings)

--- a/xbmc/settings/SettingsManager.h
+++ b/xbmc/settings/SettingsManager.h
@@ -396,7 +396,7 @@ private:
   SettingCreatorMap m_settingCreators;
 
   std::set<ISubSettings*> m_subSettings;
-  typedef std::set<ISettingsHandler*> SettingsHandlers;
+  typedef std::vector<ISettingsHandler*> SettingsHandlers;
   SettingsHandlers m_settingsHandlers;
 
   CSettingConditionsManager m_conditions;


### PR DESCRIPTION
Since the new concept of settings after Frodo, the pathsubstitution for - at least - "special://profile/RssFeeds.xml", to a file on a samba share, is broken for me.

After some investigation I found out, that RssFeeds.xml is read before advancedsettings.xml is loaded and not read again when the AdvancedSettings have changed.

To preserve the order the handlers where registered, the container is now std::vector instead of std::map. Duplicates are
avoided in CSettingsManager::RegisterSettingsHandler.

I rearranged the registration of callbacks to the order xbmc decided to load the settings automagicaly, since this doesn't seem to bring up any other problems, but put AdvancedSettings first.
