### PR TITLE
Fix infinite loop while viewing "EPG: Timeline" window

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -242,7 +242,11 @@ void CGUIWindowPVRGuide::UpdateViewTimeline(bool bUpdateSelectedFile)
   CDateTime gridStart = CDateTime::GetCurrentDateTime().GetAsUTCDateTime();
   CDateTime firstDate(g_EpgContainer.GetFirstEPGDate());
   CDateTime lastDate(g_EpgContainer.GetLastEPGDate());
-  m_parent->m_guideGrid->SetStartEnd(firstDate > gridStart ? firstDate : gridStart, lastDate);
+  if (!firstDate.IsValid() || firstDate < gridStart)
+    firstDate = gridStart;
+  if (!lastDate.IsValid() || lastDate < firstDate)
+    lastDate = firstDate;
+  m_parent->m_guideGrid->SetStartEnd(firstDate, lastDate);
 
   m_parent->SetLabel(m_iControlButton, g_localizeStrings.Get(19222) + ": " + g_localizeStrings.Get(19032));
   m_parent->SetLabel(CONTROL_LABELGROUP, g_localizeStrings.Get(19032));


### PR DESCRIPTION
With invalid begin/end times, the for loop in [GUIEPGContainer.cpp L#825](https://github.com/xbmc/xbmc/blob/5f33d290e/xbmc/epg/GUIEPGGridContainer.cpp#L825) loops endlessly, freezing XBMC when the user views the "EPG: Timeline" window. Solve this by adding check for invalid end times.

Tested with VDR backend (backend reports epoch for both begin and end times).
