### PR TITLE
network: fix detection of ipv6 availability

### DIFF
--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -435,16 +435,7 @@ bool CNetwork::PingHost(unsigned long ipaddr, unsigned short port, unsigned int 
 int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlog, const char *callerName)
 {
   struct sockaddr_storage addr;
-  struct sockaddr_in6 *s6;
-  struct sockaddr_in  *s4;
-  int    sock;
-  bool   v4_fallback = false;
-#ifdef TARGET_WINDOWS
-  // Windows XP and earlier don't support the IPV6_V6ONLY socket option
-  // so always fall back to IPv4 directly to keep old functionality
-  if (CSysInfo::GetWindowsVersion() <= CSysInfo::WindowsVersionWinXP)
-    v4_fallback = true;
-#endif
+  int    sock = -1;
 
 #ifdef WINSOCK_VERSION
   int yes = 1;
@@ -454,10 +445,8 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
   unsigned int no = 0;
 #endif
   
-  memset(&addr, 0, sizeof(addr));
-  
-  if (!v4_fallback &&
-     (sock = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP)) >= 0)
+  // first try ipv6
+  if ((sock = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP)) >= 0)
   {
     // in case we're on ipv6, make sure the socket is dual stacked
     if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&no, sizeof(no)) < 0)
@@ -469,50 +458,53 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
 #endif
       CLog::Log(LOGWARNING, "%s Server: Only IPv6 supported (%s)", callerName, sock_err.c_str());
     }
-  }
-  else
-  {
-    v4_fallback = true;
-    sock = socket(PF_INET, SOCK_STREAM, 0);
-  }
-  
-  if (sock == INVALID_SOCKET)
-  {
-    CLog::Log(LOGERROR, "%s Server: Failed to create serversocket", callerName);
-    return INVALID_SOCKET;
-  }
 
-  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&yes, sizeof(yes));
-  
-  if (v4_fallback)
-  {
-    addr.ss_family = AF_INET;
-    s4 = (struct sockaddr_in *) &addr;
-    s4->sin_port = htons(port);
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&yes, sizeof(yes));
 
-    if (bindLocal)
-      s4->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    else
-      s4->sin_addr.s_addr = htonl(INADDR_ANY);
-  }
-  else
-  {
+    struct sockaddr_in6 *s6;
+    memset(&addr, 0, sizeof(addr));
     addr.ss_family = AF_INET6;
     s6 = (struct sockaddr_in6 *) &addr;
     s6->sin6_port = htons(port);
-
     if (bindLocal)
       s6->sin6_addr = in6addr_loopback;
     else
       s6->sin6_addr = in6addr_any;
-  }
 
-  if (::bind( sock, (struct sockaddr *) &addr,
-            (addr.ss_family == AF_INET6) ? sizeof(struct sockaddr_in6) :
-                                           sizeof(struct sockaddr_in)  ) < 0)
+    if (bind( sock, (struct sockaddr *) &addr, sizeof(struct sockaddr_in6)) < 0)
+    {
+      closesocket(sock);
+      sock = -1;
+      CLog::Log(LOGDEBUG, "%s Server: Failed to bind ipv6 serversocket, trying ipv4", callerName);
+    }
+  }
+  
+  // ipv4 fallback
+  if (sock < 0 && (sock = socket(PF_INET, SOCK_STREAM, 0)) >= 0)
   {
-    closesocket(sock);
-    CLog::Log(LOGERROR, "%s Server: Failed to bind serversocket", callerName);
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&yes, sizeof(yes));
+
+    struct sockaddr_in  *s4;
+    memset(&addr, 0, sizeof(addr));
+    addr.ss_family = AF_INET;
+    s4 = (struct sockaddr_in *) &addr;
+    s4->sin_port = htons(port);
+    if (bindLocal)
+      s4->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    else
+      s4->sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind( sock, (struct sockaddr *) &addr, sizeof(struct sockaddr_in)) < 0)
+    {
+      closesocket(sock);
+      int err = errno;
+      CLog::Log(LOGERROR, "%s Server: Failed to bind ipv4 serversocket", callerName);
+      return INVALID_SOCKET;
+    }
+  }
+  else if (sock < 0)
+  {
+    CLog::Log(LOGERROR, "%s Server: Failed to create serversocket", callerName);
     return INVALID_SOCKET;
   }
 


### PR DESCRIPTION
fix ipv4 fallback method introduced here: c5dccafff423b30904a97fe1013ed6b4f1180fe9
Until you bind a socket you don't know whether ipv6 is supported or not.
