### PR TITLE
Win32: fix path slashes (diet version)

### DIFF
--- a/xbmc/filesystem/HDDirectory.cpp
+++ b/xbmc/filesystem/HDDirectory.cpp
@@ -27,8 +27,9 @@
 #include "utils/AliasShortcutUtils.h"
 #include "utils/URIUtils.h"
 
-#ifndef TARGET_POSIX
+#ifdef TARGET_WINDOWS
 #include "utils/CharsetConverter.h"
+#include "win32/WIN32Util.h"
 #endif
 
 #ifndef INVALID_FILE_ATTRIBUTES
@@ -57,6 +58,7 @@ CHDDirectory::~CHDDirectory(void)
 bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items)
 {
   LOCAL_WIN32_FIND_DATA wfd;
+  memset(&wfd, 0, sizeof(wfd));
 
   CStdString strPath=strPath1;
 
@@ -66,11 +68,7 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
   CStdString strRoot = strPath;
   CURL url(strPath);
 
-  memset(&wfd, 0, sizeof(wfd));
   URIUtils::AddSlashAtEnd(strRoot);
-#ifdef TARGET_WINDOWS
-  strRoot.Replace("/", "\\");
-#endif
   if (URIUtils::IsDVD(strRoot) && m_isoReader.IsScanned())
   {
     // Reset iso reader and remount or
@@ -79,12 +77,10 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
   }
 
 #ifdef TARGET_WINDOWS
-  CStdStringW strSearchMask;
-  g_charsetConverter.utf8ToW(strRoot, strSearchMask, false);
-  strSearchMask.Insert(0, L"\\\\?\\");
-  strSearchMask += "*.*";
+  std::wstring strSearchMask(CWIN32Util::ConvertPathToWin32Form(strRoot));
+  strSearchMask += L"*.*";
 #else
-  CStdString strSearchMask = strRoot;
+  CStdString strSearchMask(strRoot);
 #endif
 
   FILETIME localTime;
@@ -102,7 +98,7 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
       {
         CStdString strLabel;
 #ifdef TARGET_WINDOWS
-        g_charsetConverter.wToUTF8(wfd.cFileName,strLabel);
+        g_charsetConverter.wToUTF8(wfd.cFileName,strLabel, true);
 #else
         strLabel = wfd.cFileName;
 #endif
@@ -146,17 +142,15 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
 
 bool CHDDirectory::Create(const char* strPath)
 {
+  if (!strPath || !*strPath)
+    return false;
   CStdString strPath1 = strPath;
   URIUtils::AddSlashAtEnd(strPath1);
 
 #ifdef TARGET_WINDOWS
   if (strPath1.size() == 3 && strPath1[1] == ':')
     return Exists(strPath);  // A drive - we can't "create" a drive
-  CStdStringW strWPath1;
-  strPath1.Replace("/", "\\");
-  g_charsetConverter.utf8ToW(strPath1, strWPath1, false);
-  strWPath1.Insert(0, L"\\\\?\\");
-  if(::CreateDirectoryW(strWPath1, NULL))
+  if(::CreateDirectoryW(CWIN32Util::ConvertPathToWin32Form(strPath1).c_str(), NULL))
 #else
   if(::CreateDirectory(strPath1.c_str(), NULL))
 #endif
@@ -169,12 +163,10 @@ bool CHDDirectory::Create(const char* strPath)
 
 bool CHDDirectory::Remove(const char* strPath)
 {
+  if (!strPath || !*strPath)
+    return false;
 #ifdef TARGET_WINDOWS
-  CStdStringW strWPath;
-  g_charsetConverter.utf8ToW(strPath, strWPath, false);
-  strWPath.Replace(L"/", L"\\");
-  strWPath.Insert(0, L"\\\\?\\");
-  return (::RemoveDirectoryW(strWPath) || GetLastError() == ERROR_PATH_NOT_FOUND) ? true : false;
+  return (::RemoveDirectoryW(CWIN32Util::ConvertPathToWin32Form(strPath).c_str()) || GetLastError() == ERROR_PATH_NOT_FOUND) ? true : false;
 #else
   return ::RemoveDirectory(strPath) ? true : false;
 #endif
@@ -184,16 +176,10 @@ bool CHDDirectory::Exists(const char* strPath)
 {
   if (!strPath || !*strPath)
     return false;
-  CStdString strReplaced=strPath;
 #ifdef TARGET_WINDOWS
-  CStdStringW strWReplaced;
-  strReplaced.Replace("/","\\");
-  URIUtils::AddSlashAtEnd(strReplaced);
-  g_charsetConverter.utf8ToW(strReplaced, strWReplaced, false);
-  strWReplaced.Insert(0, L"\\\\?\\");
-  DWORD attributes = GetFileAttributesW(strWReplaced);
+  DWORD attributes = GetFileAttributesW(CWIN32Util::ConvertPathToWin32Form(strPath).c_str());
 #else
-  DWORD attributes = GetFileAttributes(strReplaced.c_str());
+  DWORD attributes = GetFileAttributes(strPath);
 #endif
   if(attributes == INVALID_FILE_ATTRIBUTES)
     return false;

--- a/xbmc/filesystem/HDFile.h
+++ b/xbmc/filesystem/HDFile.h
@@ -60,7 +60,7 @@ public:
 
   virtual int IoControl(EIoControl request, void* param);
 protected:
-  CStdString GetLocal(const CURL &url); /* crate a properly format path from an url */
+  std::string GetLocal(const CURL &url); /* crate a properly format path from an url */
   AUTOPTR::CAutoPtrHandle m_hFile;
   int64_t m_i64FilePos;
   int64_t m_i64FileLen;

--- a/xbmc/filesystem/windows/WINFileSMB.cpp
+++ b/xbmc/filesystem/windows/WINFileSMB.cpp
@@ -30,6 +30,8 @@
 #include "utils/CharsetConverter.h"
 #include "utils/URIUtils.h"
 #include "WINSMBDirectory.h"
+#include "Util.h"
+#include "win32/WIN32Util.h"
 
 using namespace XFILE;
 
@@ -48,21 +50,11 @@ CWINFileSMB::~CWINFileSMB()
   if (m_hFile != INVALID_HANDLE_VALUE) Close();
 }
 //*********************************************************************************************
-CStdString CWINFileSMB::GetLocal(const CURL &url)
+std::string CWINFileSMB::GetLocal(const CURL &url)
 {
-  CStdString path( url.GetFileName() );
-
-  if( url.GetProtocol().Equals("smb", false) )
-  {
-    CStdString host( url.GetHostName() );
-
-    if(host.size() > 0)
-    {
-      path = "\\\\?\\UNC\\" + host + "\\" + path;
-    }
-  }
-
-  path.Replace('/', '\\');
+  std::string path(url.GetFileName());
+  if (url.GetProtocol().Equals("smb", false) && !url.GetHostName().empty())
+    path = "\\\\?\\UNC\\" + (std::string&)url.GetHostName() + "\\" + path;
 
   return path;
 }
@@ -70,11 +62,9 @@ CStdString CWINFileSMB::GetLocal(const CURL &url)
 //*********************************************************************************************
 bool CWINFileSMB::Open(const CURL& url)
 {
-  CStdString strFile = GetLocal(url);
+  std::wstring wfilename(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
 
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
-  m_hFile.attach(CreateFileW(strWFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
+  m_hFile.attach(CreateFileW(wfilename.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
 
   if (!m_hFile.isValid())
   {
@@ -83,10 +73,10 @@ bool CWINFileSMB::Open(const CURL& url)
 
     XFILE::CWINSMBDirectory smb;
     smb.ConnectToShare(url);
-    m_hFile.attach(CreateFileW(strWFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
+    m_hFile.attach(CreateFileW(wfilename.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL));
     if (!m_hFile.isValid())
     {
-      CLog::Log(LOGERROR,"CWINFileSMB: Unable to open file %s Error: %d", strFile.c_str(), GetLastError());
+      CLog::Log(LOGERROR, "%s: Unable to open file %s Error: %d", __FUNCTION__, url.Get().c_str(), GetLastError());
       return false;
     }
   }
@@ -99,10 +89,8 @@ bool CWINFileSMB::Open(const CURL& url)
 
 bool CWINFileSMB::Exists(const CURL& url)
 {
-  CStdString strFile = GetLocal(url);
-  URIUtils::RemoveSlashAtEnd(strFile);
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
+  std::wstring strWFile(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
+
   DWORD attributes = GetFileAttributesW(strWFile.c_str());
   if(attributes != INVALID_FILE_ATTRIBUTES)
     return true;
@@ -129,14 +117,14 @@ int CWINFileSMB::Stat(struct __stat64* buffer)
   HANDLE hFileDup;
   if (0 == DuplicateHandle(GetCurrentProcess(), (HANDLE)m_hFile, GetCurrentProcess(), &hFileDup, 0, FALSE, DUPLICATE_SAME_ACCESS))
   {
-    CLog::Log(LOGERROR, __FUNCTION__" - DuplicateHandle()");
+    CLog::Log(LOGERROR, "%s: DuplicateHandle() error", __FUNCTION__);
     return -1;
   }
 
   fd = _open_osfhandle((intptr_t)((HANDLE)hFileDup), 0);
   if (fd == -1)
   {
-    CLog::Log(LOGERROR, "CWINFileSMB Stat: fd == -1");
+    CLog::Log(LOGERROR, "%s: _open_osfhandle() error", __FUNCTION__);
     return -1;
   }
 
@@ -147,15 +135,17 @@ int CWINFileSMB::Stat(struct __stat64* buffer)
 
 int CWINFileSMB::Stat(const CURL& url, struct __stat64* buffer)
 {
-  CStdString strFile = GetLocal(url);
+  std::wstring strWFile(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
+
   /* _wstat64 can't handle long paths therefore we remove the \\?\UNC\ */
-  strFile.Replace("\\\\?\\UNC\\", "\\\\");
+  if (strWFile.compare(0, 8, L"\\\\?\\UNC\\", 8) == 0)
+    strWFile.erase(2, 6);
+
   /* _wstat64 calls FindFirstFileEx. According to MSDN, the path should not end in a trailing backslash.
     Remove it before calling _wstat64 */
-  if (strFile.length() > 3 && URIUtils::HasSlashAtEnd(strFile))
-    URIUtils::RemoveSlashAtEnd(strFile);
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
+  if (strWFile[strWFile.length()-1] == L'\\')
+    strWFile.pop_back();
+
   if(_wstat64(strWFile.c_str(), buffer) == 0)
     return 0;
 
@@ -173,10 +163,8 @@ int CWINFileSMB::Stat(const CURL& url, struct __stat64* buffer)
 //*********************************************************************************************
 bool CWINFileSMB::OpenForWrite(const CURL& url, bool bOverWrite)
 {
-  CStdString strPath = GetLocal(url);
+  std::wstring strWPath(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
 
-  CStdStringW strWPath;
-  g_charsetConverter.utf8ToW(strPath, strWPath, false);
   m_hFile.attach(CreateFileW(strWPath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, bOverWrite ? CREATE_ALWAYS : OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL));
 
   if (!m_hFile.isValid())
@@ -189,7 +177,7 @@ bool CWINFileSMB::OpenForWrite(const CURL& url, bool bOverWrite)
     m_hFile.attach(CreateFileW(strWPath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, bOverWrite ? CREATE_ALWAYS : OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL));
     if (!m_hFile.isValid())
     {
-      CLog::Log(LOGERROR,"CWINFileSMB: Unable to open file for writing '%s' Error '%d%",strPath.c_str(), GetLastError());
+      CLog::Log(LOGERROR, "%s: Unable to open file for writing '%s' Error '%d%", __FUNCTION__, url.Get().c_str(), GetLastError());
       return false;
     }
   }
@@ -289,31 +277,17 @@ int64_t CWINFileSMB::GetPosition()
 
 bool CWINFileSMB::Delete(const CURL& url)
 {
-  CStdString strFile=GetLocal(url);
-
-  CStdStringW strWFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
-  return ::DeleteFileW(strWFile.c_str()) ? true : false;
+  return ::DeleteFileW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str()) ? true : false;
 }
 
 bool CWINFileSMB::Rename(const CURL& url, const CURL& urlnew)
 {
-  CStdString strFile=GetLocal(url);
-  CStdString strNewFile=GetLocal(urlnew);
-
-  CStdStringW strWFile;
-  CStdStringW strWNewFile;
-  g_charsetConverter.utf8ToW(strFile, strWFile, false);
-  g_charsetConverter.utf8ToW(strNewFile, strWNewFile, false);
-  return ::MoveFileW(strWFile.c_str(), strWNewFile.c_str()) ? true : false;
+  return ::MoveFileW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str(), CWIN32Util::ConvertPathToWin32Form(GetLocal(urlnew)).c_str()) ? true : false;
 }
 
 bool CWINFileSMB::SetHidden(const CURL &url, bool hidden)
 {
-  CStdStringW path;
-  g_charsetConverter.utf8ToW(GetLocal(url), path, false);
-  DWORD attributes = hidden ? FILE_ATTRIBUTE_HIDDEN : FILE_ATTRIBUTE_NORMAL;
-  if (SetFileAttributesW(path.c_str(), attributes))
+  if (SetFileAttributesW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str(), hidden ? FILE_ATTRIBUTE_HIDDEN : FILE_ATTRIBUTE_NORMAL))
     return true;
   return false;
 }
@@ -334,14 +308,14 @@ int CWINFileSMB::Truncate(int64_t size)
   HANDLE hFileDup;
   if (0 == DuplicateHandle(GetCurrentProcess(), (HANDLE)m_hFile, GetCurrentProcess(), &hFileDup, 0, FALSE, DUPLICATE_SAME_ACCESS))
   {
-    CLog::Log(LOGERROR, __FUNCTION__" - DuplicateHandle()");
+    CLog::Log(LOGERROR, "%s: DuplicateHandle() error", __FUNCTION__);
     return -1;
   }
 
   fd = _open_osfhandle((intptr_t)((HANDLE)hFileDup), 0);
   if (fd == -1)
   {
-    CLog::Log(LOGERROR, "CWINFileSMB Stat: fd == -1");
+    CLog::Log(LOGERROR, "%s: _open_osfhandle() error", __FUNCTION__);
     return -1;
   }
   int result = _chsize_s(fd, (long) size);

--- a/xbmc/filesystem/windows/WINFileSMB.h
+++ b/xbmc/filesystem/windows/WINFileSMB.h
@@ -58,7 +58,7 @@ public:
 
   virtual int IoControl(EIoControl request, void* param);
 protected:
-  CStdString GetLocal(const CURL &url); /* crate a properly format path from an url */
+  std::string GetLocal(const CURL &url); /* create a properly format path from an url */
   AUTOPTR::CAutoPtrHandle m_hFile;
   int64_t m_i64FilePos;
 };

--- a/xbmc/filesystem/windows/WINSMBDirectory.cpp
+++ b/xbmc/filesystem/windows/WINSMBDirectory.cpp
@@ -49,20 +49,13 @@ CWINSMBDirectory::~CWINSMBDirectory(void)
 {
 }
 
-CStdString CWINSMBDirectory::GetLocal(const CStdString& strPath)
+std::string CWINSMBDirectory::GetLocal(const std::string& strPath)
 {
   CURL url(strPath);
-  CStdString path( url.GetFileName() );
-  if( url.GetProtocol().Equals("smb", false) )
-  {
-    CStdString host( url.GetHostName() );
+  std::string path(url.GetFileName());
+  if (url.GetProtocol().Equals("smb", false) && !url.GetHostName().empty())
+    path = "\\\\?\\UNC\\" + (std::string&)url.GetHostName() + "\\" + path;
 
-    if(host.size() > 0)
-    {
-      path = "\\\\?\\UNC\\" + host + "\\" + path;
-    }
-  }
-  path.Replace('/', '\\');
   return path;
 }
 
@@ -70,7 +63,7 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
 {
   WIN32_FIND_DATAW wfd;
 
-  CStdString strPath=strPath1;
+  std::string strPath=strPath1;
 
   CURL url(strPath);
 
@@ -85,9 +78,9 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
         return false;
 
       ConnectToShare(url);
-      CStdString strHost = "\\\\" + url.GetHostName();
-      CStdStringW strHostW;
-      g_charsetConverter.utf8ToW(strHost,strHostW);
+      std::string strHost = "\\\\" + url.GetHostName();
+      std::wstring strHostW;
+      g_charsetConverter.utf8ToW(strHost,strHostW, false, false, true);
       lpnr->lpRemoteName = (LPWSTR)strHostW.c_str();
       m_bHost = true;
       ret = EnumerateFunc(lpnr, items);
@@ -102,14 +95,14 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
 
   memset(&wfd, 0, sizeof(wfd));
   //rebuild the URL
-  CStdString strUNCShare = "\\\\?\\UNC\\" + url.GetHostName() + "\\" + url.GetFileName();
-  strUNCShare.Replace("/", "\\");
+  std::string strUNCShare = "\\\\?\\UNC\\" + (std::string)url.GetHostName() + "\\" + URIUtils::FixSlashesAndDups(url.GetFileName(), '\\');
+  
   if(!URIUtils::HasSlashAtEnd(strUNCShare))
     strUNCShare.append("\\");
 
-  CStdStringW strSearchMask;
-  g_charsetConverter.utf8ToW(strUNCShare, strSearchMask, false);
-  strSearchMask += "*";
+  std::wstring strSearchMask;
+  g_charsetConverter.utf8ToW(strUNCShare, strSearchMask, false, false, true);
+  strSearchMask += L"*";
 
   FILETIME localTime;
   CAutoPtrFind hFind ( FindFirstFileW(strSearchMask.c_str(), &wfd));
@@ -125,7 +118,7 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
       hFind.attach(FindFirstFileW(strSearchMask.c_str(), &wfd));
     }
     else
-      return Exists(strPath1);
+      return Exists(strPath1.c_str());
   }
 
   if (hFind.isValid())
@@ -134,14 +127,14 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
     {
       if (wfd.cFileName[0] != 0)
       {
-        CStdString strLabel;
-        g_charsetConverter.wToUTF8(wfd.cFileName,strLabel);
+        std::string strLabel;
+        g_charsetConverter.wToUTF8(wfd.cFileName,strLabel, true);
         if ( (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) )
         {
           if (strLabel != "." && strLabel != "..")
           {
             CFileItemPtr pItem(new CFileItem(strLabel));
-            CStdString path = URIUtils::AddFileToFolder(strPath, strLabel);
+            std::string path = URIUtils::AddFileToFolder(strPath, strLabel);
             URIUtils::AddSlashAtEnd(path);
             pItem->SetPath(path);
             pItem->m_bIsFolder = true;
@@ -176,10 +169,7 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
 
 bool CWINSMBDirectory::Create(const char* strPath)
 {
-  CStdString strPath1 = GetLocal(strPath);
-  CStdStringW strWPath1;
-  g_charsetConverter.utf8ToW(strPath1, strWPath1, false);
-  if(::CreateDirectoryW(strWPath1, NULL))
+  if(::CreateDirectoryW(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)).c_str(), NULL))
     return true;
   else if(GetLastError() == ERROR_ALREADY_EXISTS)
     return true;
@@ -189,18 +179,12 @@ bool CWINSMBDirectory::Create(const char* strPath)
 
 bool CWINSMBDirectory::Remove(const char* strPath)
 {
-  CStdStringW strWPath;
-  CStdString strPath1 = GetLocal(strPath);
-  g_charsetConverter.utf8ToW(strPath1, strWPath, false);
-  return ::RemoveDirectoryW(strWPath) ? true : false;
+  return ::RemoveDirectoryW(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)).c_str()) ? true : false;
 }
 
 bool CWINSMBDirectory::Exists(const char* strPath)
 {
-  CStdString strReplaced=GetLocal(strPath);
-  CStdStringW strWReplaced;
-  g_charsetConverter.utf8ToW(strReplaced, strWReplaced, false);
-  DWORD attributes = GetFileAttributesW(strWReplaced);
+  DWORD attributes = GetFileAttributesW(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)).c_str());
   if(attributes == INVALID_FILE_ATTRIBUTES)
     return false;
   if (FILE_ATTRIBUTE_DIRECTORY & attributes)
@@ -284,7 +268,7 @@ bool CWINSMBDirectory::EnumerateFunc(LPNETRESOURCEW lpnr, CFileItemList &items)
           CStdStringW strRemoteNameW = lpnrLocal[i].lpRemoteName;
           CStdString  strName,strRemoteName;
 
-          g_charsetConverter.wToUTF8(strRemoteNameW,strRemoteName);
+          g_charsetConverter.wToUTF8(strRemoteNameW,strRemoteName, true);
           CLog::Log(LOGDEBUG,"Found Server/Share: %s", strRemoteName.c_str());
 
           strurl.append(strRemoteName);
@@ -407,11 +391,11 @@ bool CWINSMBDirectory::ConnectToShare(const CURL& url)
   return true;
 }
 
-CStdString CWINSMBDirectory::URLEncode(const CURL &url)
+std::string CWINSMBDirectory::URLEncode(const CURL &url)
 {
   /* due to smb wanting encoded urls we have to build it manually */
 
-  CStdString flat = "smb://";
+  std::string flat = "smb://";
 
   /* samba messes up of password is set but no username is set. don't know why yet */
   /* probably the url parser that goes crazy */

--- a/xbmc/filesystem/windows/WINSMBDirectory.h
+++ b/xbmc/filesystem/windows/WINSMBDirectory.h
@@ -41,7 +41,7 @@ public:
 private:
   bool m_bHost;
   bool EnumerateFunc(LPNETRESOURCEW lpnr, CFileItemList &items);
-  CStdString GetLocal(const CStdString& strPath);
-  CStdString URLEncode(const CURL &url);
+  std::string GetLocal(const std::string& strPath);
+  std::string URLEncode(const CURL &url);
 };
 }

--- a/xbmc/utils/AliasShortcutUtils.cpp
+++ b/xbmc/utils/AliasShortcutUtils.cpp
@@ -27,7 +27,7 @@
 
 #include "AliasShortcutUtils.h"
 
-bool IsAliasShortcut(CStdString &path)
+bool IsAliasShortcut(const std::string& path)
 {
   bool  rtn = false;
 
@@ -65,7 +65,7 @@ bool IsAliasShortcut(CStdString &path)
   return(rtn);
 }
 
-void TranslateAliasShortcut(CStdString &path)
+void TranslateAliasShortcut(std::string& path)
 {
 #if defined(TARGET_DARWIN_OSX)
   FSRef fileRef;

--- a/xbmc/utils/AliasShortcutUtils.h
+++ b/xbmc/utils/AliasShortcutUtils.h
@@ -21,5 +21,5 @@
 
 #include "StdString.h"
 
-bool IsAliasShortcut(CStdString &path);
-void TranslateAliasShortcut(CStdString &path);
+bool IsAliasShortcut(const std::string& path);
+void TranslateAliasShortcut(std::string &path);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -918,9 +918,9 @@ void URIUtils::AddSlashAtEnd(std::string& strFolder)
   }
 }
 
-bool URIUtils::HasSlashAtEnd(const CStdString& strFile, bool checkURL /* = false */)
+bool URIUtils::HasSlashAtEnd(const std::string& strFile, bool checkURL /* = false */)
 {
-  if (strFile.size() == 0) return false;
+  if (strFile.empty()) return false;
   if (checkURL && IsURL(strFile))
   {
     CURL url(strFile);
@@ -935,13 +935,13 @@ bool URIUtils::HasSlashAtEnd(const CStdString& strFile, bool checkURL /* = false
   return false;
 }
 
-void URIUtils::RemoveSlashAtEnd(CStdString& strFolder)
+void URIUtils::RemoveSlashAtEnd(std::string& strFolder)
 {
   if (IsURL(strFolder))
   {
     CURL url(strFolder);
-    CStdString file = url.GetFileName();
-    if (!file.IsEmpty() && file != strFolder)
+    std::string file = url.GetFileName();
+    if (!file.empty() && file != strFolder)
     {
       RemoveSlashAtEnd(file);
       url.SetFileName(file);
@@ -953,7 +953,7 @@ void URIUtils::RemoveSlashAtEnd(CStdString& strFolder)
   }
 
   while (HasSlashAtEnd(strFolder))
-    strFolder.Delete(strFolder.size() - 1);
+    strFolder.erase(strFolder.size()-1, 1);
 }
 
 bool URIUtils::CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -894,13 +894,13 @@ bool URIUtils::IsDOSPath(const CStdString &path)
   return false;
 }
 
-void URIUtils::AddSlashAtEnd(CStdString& strFolder)
+void URIUtils::AddSlashAtEnd(std::string& strFolder)
 {
   if (IsURL(strFolder))
   {
     CURL url(strFolder);
-    CStdString file = url.GetFileName();
-    if(!file.IsEmpty() && file != strFolder)
+    std::string file = url.GetFileName();
+    if(!file.empty() && file != strFolder)
     {
       AddSlashAtEnd(file);
       url.SetFileName(file);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -964,6 +964,37 @@ bool URIUtils::CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdSt
   return strc1.Equals(strc2);
 }
 
+
+std::string URIUtils::FixSlashesAndDups(const std::string& path, const char slashCharacter /* = '/' */, const size_t startFrom /*= 0*/)
+{
+  const size_t len = path.length();
+  if (startFrom >= len)
+    return path;
+
+  std::string result(path, 0, startFrom);
+  result.reserve(len);
+
+  const char* const str = path.c_str();
+  size_t pos = startFrom;
+  do
+  {
+    if (str[pos] == '\\' || str[pos] == '/')
+    {
+      result.push_back(slashCharacter);  // append one slash
+      pos++;
+      // skip any following slashes
+      while (str[pos] == '\\' || str[pos] == '/') // str is null-terminated, no need to check for buffer overrun
+        pos++;
+    }
+    else
+      result.push_back(str[pos++]);   // append current char and advance pos to next char
+
+  } while (pos < len);
+
+  return result;
+}
+
+
 CStdString URIUtils::AddFileToFolder(const CStdString& strFolder, 
                                 const CStdString& strFile)
 {

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -116,8 +116,8 @@ public:
   static bool IsLibraryFolder(const CStdString& strFile);
 
   static void AddSlashAtEnd(std::string& strFolder);
-  static bool HasSlashAtEnd(const CStdString& strFile, bool checkURL = false);
-  static void RemoveSlashAtEnd(CStdString& strFolder);
+  static bool HasSlashAtEnd(const std::string& strFile, bool checkURL = false);
+  static void RemoveSlashAtEnd(std::string& strFolder);
   static bool CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2);
 
   static void CreateArchivePath(CStdString& strUrlPath,

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -119,6 +119,7 @@ public:
   static bool HasSlashAtEnd(const std::string& strFile, bool checkURL = false);
   static void RemoveSlashAtEnd(std::string& strFolder);
   static bool CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2);
+  static std::string FixSlashesAndDups(const std::string& path, const char slashCharacter = '/', const size_t startFrom = 0);
 
   static void CreateArchivePath(CStdString& strUrlPath,
                                 const CStdString& strType,

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -115,7 +115,7 @@ public:
   static bool IsAndroidApp(const CStdString& strFile);
   static bool IsLibraryFolder(const CStdString& strFile);
 
-  static void AddSlashAtEnd(CStdString& strFolder);
+  static void AddSlashAtEnd(std::string& strFolder);
   static bool HasSlashAtEnd(const CStdString& strFile, bool checkURL = false);
   static void RemoveSlashAtEnd(CStdString& strFolder);
   static bool CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2);

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -61,6 +61,7 @@ public:
   static CStdString SmbToUnc(const CStdString &strPath);
   static bool AddExtraLongPathPrefix(std::wstring& path);
   static bool RemoveExtraLongPathPrefix(std::wstring& path);
+  static std::wstring ConvertPathToWin32Form(const std::string& pathUtf8);
   static void ExtendDllPath();
   static HRESULT ToggleTray(const char cDriveLetter='\0');
   static HRESULT EjectTray(const char cDriveLetter='\0');


### PR DESCRIPTION
This is bugfix part of larger PR #3374
Cherry-picked minimal set of commits to fix "slash"-errors. 
