### PR TITLE
jsonrpc: add support for multiple items to Playlist.Add/Insert

### DIFF
--- a/addons/xbmc.json/addon.xml
+++ b/addons/xbmc.json/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.json" version="6.10.0" provider-name="Team XBMC">
+<addon id="xbmc.json" version="6.11.0" provider-name="Team XBMC">
   <backwards-compatibility abi="6.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -95,15 +95,15 @@ JSONRPC_STATUS CPlaylistOperations::GetItems(const CStdString &method, ITranspor
   return OK;
 }
 
-bool CPlaylistOperations::CheckMediaParameter(int playlist, const CVariant &parameterObject)
+bool CPlaylistOperations::CheckMediaParameter(int playlist, const CVariant &itemObject)
 {
-  if (parameterObject["item"].isMember("media") && parameterObject["item"]["media"].asString().compare("files") != 0)
+  if (itemObject.isMember("media") && itemObject["media"].asString().compare("files") != 0)
   {
-    if (playlist == PLAYLIST_VIDEO && parameterObject["item"]["media"].asString().compare("video") != 0)
+    if (playlist == PLAYLIST_VIDEO && itemObject["media"].asString().compare("video") != 0)
       return false;
-    if (playlist == PLAYLIST_MUSIC && parameterObject["item"]["media"].asString().compare("music") != 0)
+    if (playlist == PLAYLIST_MUSIC && itemObject["media"].asString().compare("music") != 0)
       return false;
-    if (playlist == PLAYLIST_PICTURE && parameterObject["item"]["media"].asString().compare("video") != 0 && parameterObject["item"]["media"].asString().compare("pictures") != 0)
+    if (playlist == PLAYLIST_PICTURE && itemObject["media"].asString().compare("video") != 0 && itemObject["media"].asString().compare("pictures") != 0)
       return false;
   }
   return true;
@@ -112,38 +112,27 @@ bool CPlaylistOperations::CheckMediaParameter(int playlist, const CVariant &para
 JSONRPC_STATUS CPlaylistOperations::Add(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
   int playlist = GetPlaylist(parameterObject["playlistid"]);
-  CFileItemList list;
-  CVariant params = parameterObject;
-
-  if (!CheckMediaParameter(playlist, parameterObject))
-    return InvalidParams;
 
   CGUIWindowSlideShow *slideshow = NULL;
+  if (playlist == PLAYLIST_PICTURE)
+  {
+    slideshow = (CGUIWindowSlideShow*)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
+    if (slideshow == NULL)
+      return FailedToExecute;
+  }
+
+  CFileItemList list;
+  if (!HandleItemsParameter(playlist, parameterObject["item"], list))
+    return InvalidParams;
+
   switch (playlist)
   {
     case PLAYLIST_VIDEO:
     case PLAYLIST_MUSIC:
-      if (playlist == PLAYLIST_VIDEO)
-        params["item"]["media"] = "video";
-      else if (playlist == PLAYLIST_MUSIC)
-        params["item"]["media"] = "music";
-
-      if (!FillFileItemList(params["item"], list))
-        return InvalidParams;
-
       CApplicationMessenger::Get().PlayListPlayerAdd(playlist, list);
-      
       break;
 
     case PLAYLIST_PICTURE:
-      slideshow = (CGUIWindowSlideShow*)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
-      if (!slideshow)
-        return FailedToExecute;
-      if (!parameterObject["item"].isMember("media"))
-        params["item"]["media"] = "pictures";
-      if (!FillFileItemList(params["item"], list))
-        return InvalidParams;
-
       for (int index = 0; index < list.Size(); index++)
       {
         CPictureInfoTag picture = CPictureInfoTag();
@@ -154,6 +143,9 @@ JSONRPC_STATUS CPlaylistOperations::Add(const CStdString &method, ITransportLaye
         slideshow->Add(list[index].get());
       }
       break;
+
+    default:
+      return InvalidParams;
   }
   
   NotifyAll();
@@ -166,19 +158,8 @@ JSONRPC_STATUS CPlaylistOperations::Insert(const CStdString &method, ITransportL
   if (playlist == PLAYLIST_PICTURE)
     return FailedToExecute;
 
-  if (!CheckMediaParameter(playlist, parameterObject))
-    return InvalidParams;
-
   CFileItemList list;
-  CVariant params = parameterObject;
-  if (playlist == PLAYLIST_VIDEO)
-    params["item"]["media"] = "video";
-  else if (playlist == PLAYLIST_MUSIC)
-    params["item"]["media"] = "music";
-  else
-    return FailedToExecute;
-
-  if (!FillFileItemList(params["item"], list))
+  if (!HandleItemsParameter(playlist, parameterObject["item"], list))
     return InvalidParams;
 
   CApplicationMessenger::Get().PlayListPlayerInsert(GetPlaylist(parameterObject["playlistid"]), list, (int)parameterObject["position"].asInteger());
@@ -306,4 +287,37 @@ JSONRPC_STATUS CPlaylistOperations::GetPropertyValue(int playlist, const CStdStr
     return InvalidParams;
 
   return OK;
+}
+
+bool CPlaylistOperations::HandleItemsParameter(int playlistid, const CVariant &itemParam, CFileItemList &items)
+{
+  vector<CVariant> vecItems;
+  if (itemParam.isArray())
+    vecItems.assign(itemParam.begin_array(), itemParam.end_array());
+  else
+    vecItems.push_back(itemParam);
+
+  bool success = false;
+  for (vector<CVariant>::iterator itemIt = vecItems.begin(); itemIt != vecItems.end(); ++itemIt)
+  {
+    if (!CheckMediaParameter(playlistid, *itemIt))
+      continue;
+
+    switch (playlistid)
+    {
+    case PLAYLIST_VIDEO:
+      (*itemIt)["media"] = "video";
+      break;
+    case PLAYLIST_MUSIC:
+      (*itemIt)["media"] = "music";
+      break;
+    case PLAYLIST_PICTURE:
+      (*itemIt)["media"] = "pictures";
+      break;
+    }
+
+    success |= FillFileItemList(*itemIt, items);
+  }
+
+  return success;
 }

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.h
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.h
@@ -22,6 +22,7 @@
 #include "utils/StdString.h"
 #include "JSONRPC.h"
 #include "FileItemHandler.h"
+#include "FileItem.h"
 
 namespace JSONRPC
 {
@@ -41,6 +42,7 @@ namespace JSONRPC
     static int GetPlaylist(const CVariant &playlist);
     static inline void NotifyAll();
     static JSONRPC_STATUS GetPropertyValue(int playlist, const CStdString &property, CVariant &result);
-    static bool CheckMediaParameter(int playlist, const CVariant &parameterObject);
+    static bool CheckMediaParameter(int playlist, const CVariant &itemObject);
+    static bool HandleItemsParameter(int playlistid, const CVariant &itemParam, CFileItemList &items);
   };
 }

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.10.0";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.11.0";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -1834,7 +1834,12 @@ namespace JSONRPC
       "\"permission\": \"ControlPlayback\","
       "\"params\": ["
         "{ \"name\": \"playlistid\", \"$ref\": \"Playlist.Id\", \"required\": true },"
-        "{ \"name\": \"item\", \"$ref\": \"Playlist.Item\", \"required\": true }"
+        "{ \"name\": \"item\","
+          "\"type\": ["
+            "{ \"$ref\": \"Playlist.Item\", \"required\": true },"
+            "{ \"type\": \"array\", \"items\": { \"$ref\": \"Playlist.Item\" }, \"required\": true }"
+          "],"
+          "\"required\": true }"
       "],"
       "\"returns\": \"string\""
     "}",
@@ -1846,7 +1851,12 @@ namespace JSONRPC
       "\"params\": ["
         "{ \"name\": \"playlistid\", \"$ref\": \"Playlist.Id\", \"required\": true },"
         "{ \"name\": \"position\", \"$ref\": \"Playlist.Position\", \"required\": true },"
-        "{ \"name\": \"item\", \"$ref\": \"Playlist.Item\", \"required\": true }"
+        "{ \"name\": \"item\","
+          "\"type\": ["
+            "{ \"$ref\": \"Playlist.Item\", \"required\": true },"
+            "{ \"type\": \"array\", \"items\": { \"$ref\": \"Playlist.Item\" }, \"required\": true }"
+          "],"
+          "\"required\": true }"
       "],"
       "\"returns\": \"string\""
     "}",

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -441,7 +441,12 @@
     "permission": "ControlPlayback",
     "params": [
       { "name": "playlistid", "$ref": "Playlist.Id", "required": true },
-      { "name": "item", "$ref": "Playlist.Item", "required": true }
+      { "name": "item",
+        "type": [
+          { "$ref": "Playlist.Item", "required": true },
+          { "type": "array", "items": { "$ref": "Playlist.Item" }, "required": true }
+        ],
+        "required": true }
     ],
     "returns": "string"
   },
@@ -453,7 +458,12 @@
     "params": [
       { "name": "playlistid", "$ref": "Playlist.Id", "required": true },
       { "name": "position", "$ref": "Playlist.Position", "required": true },
-      { "name": "item", "$ref": "Playlist.Item", "required": true }
+      { "name": "item",
+        "type": [
+          { "$ref": "Playlist.Item", "required": true },
+          { "type": "array", "items": { "$ref": "Playlist.Item" }, "required": true }
+        ],
+        "required": true }
     ],
     "returns": "string"
   },


### PR DESCRIPTION
As requested at DevCon I've added support for multiple items to Playlist.Add and Playlist.Insert. The change is implemented in the existing methods without breaking backwards compatibility. The implementation works in a way that it returns OK if at least one of the passed in items was successfully processed. It only returns "Invalid params" if all of the items failed. I'm happy to change that behaviour to completely fail if one of the items can't be handled.
