### PR TITLE
textbox for GUIDialogOK

### DIFF
--- a/addons/skin.confluence/720p/DialogOK.xml
+++ b/addons/skin.confluence/720p/DialogOK.xml
@@ -86,6 +86,17 @@
 			<label>-</label>
 			<font>font13</font>
 		</control>
+		<control type="textbox" id="5">
+			<description>text</description>
+			<posx>30</posx>
+			<posy>60</posy>
+			<width>550</width>
+			<height>80</height>
+			<align>left</align>
+			<label>-</label>
+			<font>font13</font>
+			<autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+		</control>
 		<control type="button" id="10">
 			<description>OK button</description>
 			<posx>205</posx>

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -42,7 +42,8 @@ CGUIDialogBoxBase::~CGUIDialogBoxBase(void)
 {
 }
 
-void CGUIDialogBoxBase::UseTextbox(bool bEnable) {
+void CGUIDialogBoxBase::UseTextbox(bool bEnable)
+{
   for (int ptr = 0; ptr < DIALOG_MAX_LINES; ptr++)
   {
     if (bEnable)
@@ -102,7 +103,8 @@ void CGUIDialogBoxBase::SetTextBox(const CVariant& line)
 {
   m_strLines[DIALOG_MAX_LINES] = GetLocalized(line);
   m_bShowingTextBox = true;
-  if (IsActive()) {
+  if (IsActive())
+  {
     UseTextbox(true);
     SET_CONTROL_VISIBLE(CONTROL_TEXTBOX);
     SET_CONTROL_LABEL_THREAD_SAFE(CONTROL_TEXTBOX, m_strLines[DIALOG_MAX_LINES]);
@@ -130,7 +132,8 @@ void CGUIDialogBoxBase::OnInitWindow()
 
   UseTextbox(m_bShowingTextBox);
 
-  if (!m_bShowingTextBox) {
+  if (!m_bShowingTextBox)
+  {
     for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i)
       SET_CONTROL_LABEL(CONTROL_LINES_START + i, !m_bShowingTextBox && !m_strLines[i].empty() ? m_strLines[i] : GetDefaultLabel(CONTROL_LINES_START + i));
   }

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -37,6 +37,7 @@ public:
   void SetLine(int iLine, const CVariant &line);
   void SetHeading(const CVariant &heading);
   void SetChoice(int iButton, const CVariant &choice);
+  void SetTextBox(const CVariant& line);
 protected:
   CStdString GetDefaultLabel(int controlId) const;
   virtual int GetDefaultLabelID(int controlId) const;
@@ -49,11 +50,13 @@ protected:
 
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
+  void UseTextbox(bool bEnable);
 
   bool m_bConfirmed;
+  bool m_bShowingTextBox;
 
   // actual strings
   std::string m_strHeading;
-  std::string m_strLines[DIALOG_MAX_LINES];
+  std::string m_strLines[DIALOG_MAX_LINES + 1];
   std::string m_strChoices[DIALOG_MAX_CHOICES];
 };

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -59,6 +59,17 @@ void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &line
   dialog->DoModal();
 }
 
+// \brief Show CGUIDialogOK dialog, then wait for user to dismiss it.
+void CGUIDialogOK::ShowAndGetInputTextbox(const CVariant &heading, const CVariant &line)
+{
+  CGUIDialogOK *dialog = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
+  if (!dialog)
+    return;
+  dialog->SetHeading(heading);
+  dialog->SetTextBox(line);
+  dialog->DoModal();
+}
+
 int CGUIDialogOK::GetDefaultLabelID(int controlId) const
 {
   if (controlId == ID_BUTTON_OK)

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -30,6 +30,7 @@ public:
   virtual ~CGUIDialogOK(void);
   virtual bool OnMessage(CGUIMessage& message);
   static void ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2);
+  static void ShowAndGetInputTextbox(const CVariant &heading, const CVariant &line);
 protected:
   virtual int GetDefaultLabelID(int controlId) const;
 };


### PR DESCRIPTION
I got annoyed by having to split up strings in code and the language xml to make it fit in the ok dialog. This adds a textbox to the dialog for larger strings.

either the textbox or text lines will be shown, so when you call SetTextBox() it will hide the lines, and if you call SetLine() it will hide the textbox.
