### PR TITLE
LangInfo - Fix overriding default language when checking for language presence

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -264,7 +264,7 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
 #else
   if (m_defaultRegion.m_strLangLocaleName.length() != 3)
   {
-    if (!g_LangCodeExpander.ConvertToThreeCharCode(m_languageCodeGeneral, m_defaultRegion.m_strLangLocaleName))
+    if (!g_LangCodeExpander.ConvertToThreeCharCode(m_languageCodeGeneral, m_defaultRegion.m_strLangLocaleName, !onlyCheckLanguage))
       m_languageCodeGeneral = "";
   }
   else

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -434,7 +434,7 @@ CStdString CLangInfo::GetSubtitleCharSet() const
 bool CLangInfo::SetLanguage(const std::string &strLanguage)
 {
   string strLangInfoPath = StringUtils::Format("special://xbmc/language/%s/langinfo.xml", strLanguage.c_str());
-  if (!g_langInfo.Load(strLangInfoPath))
+  if (!Load(strLangInfoPath))
     return false;
 
   if (ForceUnicodeFont() && !g_fontManager.IsFontSetUnicode())

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -230,22 +230,21 @@ void CLangInfo::OnSettingChanged(const CSetting *setting)
   }
 }
 
-bool CLangInfo::Load(const CStdString& strFileName)
+bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= false*/)
 {
   SetDefaults();
 
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(strFileName))
   {
-    CLog::Log(LOGERROR, "unable to load %s: %s at line %d", strFileName.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    CLog::Log(onlyCheckLanguage ? LOGDEBUG : LOGERROR, "unable to load %s: %s at line %d", strFileName.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
   }
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
-  CStdString strValue = pRootElement->Value();
-  if (strValue != CStdString("language"))
+  if (pRootElement->ValueStr() == "language")
   {
-    CLog::Log(LOGERROR, "%s Doesn't contain <language>", strFileName.c_str());
+    CLog::Log(onlyCheckLanguage ? LOGDEBUG : LOGERROR, "%s Doesn't contain <language>", strFileName.c_str());
     return false;
   }
 
@@ -367,11 +366,15 @@ bool CLangInfo::Load(const CStdString& strFileName)
       pRegion=pRegion->NextSiblingElement("region");
     }
 
-    const CStdString& strName=CSettings::Get().GetString("locale.country");
-    SetCurrentRegion(strName);
+    if (!onlyCheckLanguage)
+    {
+      const CStdString& strName = CSettings::Get().GetString("locale.country");
+      SetCurrentRegion(strName);
+    }
   }
 
-  LoadTokens(pRootElement->FirstChild("sorttokens"),g_advancedSettings.m_vecTokens);
+  if (!onlyCheckLanguage)
+    LoadTokens(pRootElement->FirstChild("sorttokens"), g_advancedSettings.m_vecTokens);
 
   return true;
 }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -379,6 +379,12 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
   return true;
 }
 
+bool CLangInfo::CheckLanguage(const std::string& language)
+{
+  CLangInfo li;
+  return li.Load("special://xbmc/language/" + language + "/langinfo.xml", true);
+}
+
 void CLangInfo::LoadTokens(const TiXmlNode* pTokens, vector<CStdString>& vecTokens)
 {
   if (pTokens && !pTokens->NoChildren())
@@ -459,6 +465,11 @@ bool CLangInfo::SetLanguage(const std::string &strLanguage)
   g_application.ReloadSkin();
 
   return true;
+}
+
+bool CLangInfo::CheckLoadLanguage(const std::string &language)
+{
+  return Load("special://xbmc/language/" + language + "/langinfo.xml", true);
 }
 
 // three char language code (not win32 specific)

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -24,6 +24,15 @@
 
 #include <map>
 
+#ifdef TARGET_WINDOWS
+#ifdef GetDateFormat
+#undef GetDateFormat
+#endif // GetDateFormat
+#ifdef GetTimeFormat
+#undef GetTimeFormat
+#endif // GetTimeFormat
+#endif // TARGET_WINDOWS
+
 class TiXmlNode;
 
 class CLangInfo : public ISettingCallback

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -52,6 +52,7 @@ public:
   const CStdString& GetLanguageCode() const { return m_languageCodeGeneral; }
 
   bool SetLanguage(const std::string &strLanguage);
+  bool CheckLoadLanguage(const std::string &language);
 
   const CStdString& GetAudioLanguage() const;
   // language can either be a two char language code as defined in ISO639
@@ -126,6 +127,8 @@ public:
   void GetRegionNames(CStdStringArray& array);
   void SetCurrentRegion(const CStdString& strName);
   const CStdString& GetCurrentRegion() const;
+
+  static bool CheckLanguage(const std::string& language);
 
   static void LoadTokens(const TiXmlNode* pTokens, std::vector<CStdString>& vecTokens);
 

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -43,7 +43,7 @@ public:
 
   virtual void OnSettingChanged(const CSetting *setting);
 
-  bool Load(const CStdString& strFileName);
+  bool Load(const std::string& strFileName, bool onlyCheckLanguage = false);
 
   CStdString GetGuiCharSet() const;
   CStdString GetSubtitleCharSet() const;

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -141,11 +141,7 @@ bool CLangCodeExpander::Lookup(CStdString& desc, const int code)
   return Lookup(desc, lang);
 }
 
-#ifdef TARGET_WINDOWS
-bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool localeHack /*= false*/)
-#else
-bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode)
-#endif
+bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool checkWin32Locales /*= false*/)
 {       
   if ( strTwoCharCode.length() == 2 )
   {
@@ -158,13 +154,11 @@ bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, 
     {
       if (strTwoCharCodeLower.Equals(CharCode2To3[index].old))
       {
-#ifdef TARGET_WINDOWS
-        if (localeHack && CharCode2To3[index].win_id)
+        if (checkWin32Locales && CharCode2To3[index].win_id)
         {
           strThreeCharCode = CharCode2To3[index].win_id;
           return true;
         }
-#endif
         strThreeCharCode = CharCode2To3[index].id;
         return true;
       }
@@ -175,28 +169,16 @@ bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, 
   return false;
 }
 
-#ifdef TARGET_WINDOWS
-bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool localeHack /*= false*/)
-#else
-bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode)
-#endif
+bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool checkXbmcLocales /*= true*/, bool checkWin32Locales /*= false*/)
 {
   if (strCharCode.size() == 2)
-#ifdef TARGET_WINDOWS
-    return g_LangCodeExpander.ConvertTwoToThreeCharCode(strThreeCharCode, strCharCode, localeHack);
-#else
-    return g_LangCodeExpander.ConvertTwoToThreeCharCode(strThreeCharCode, strCharCode);
-#endif
+    return g_LangCodeExpander.ConvertTwoToThreeCharCode(strThreeCharCode, strCharCode, checkWin32Locales);
   else if (strCharCode.size() == 3)
   {
     for (unsigned int index = 0; index < sizeof(CharCode2To3) / sizeof(CharCode2To3[0]); ++index)
     {
-#ifdef TARGET_WINDOWS
       if (strCharCode.Equals(CharCode2To3[index].id) ||
-         (localeHack && CharCode2To3[index].win_id != NULL && strCharCode.Equals(CharCode2To3[index].win_id)))
-#else
-      if (strCharCode.Equals(CharCode2To3[index].id))
-#endif
+           (checkWin32Locales && CharCode2To3[index].win_id != NULL && strCharCode.Equals(CharCode2To3[index].win_id)) )
       {
         strThreeCharCode = strCharCode;
         return true;
@@ -222,14 +204,15 @@ bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, con
       }
     }
 
-    CStdString strLangInfoPath;
-    strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", strCharCode.c_str());
-    CLangInfo langInfo;
-    if (!langInfo.Load(strLangInfoPath))
-      return false;
+    if (checkXbmcLocales)
+    {
+      CLangInfo langInfo;
+      if (!langInfo.CheckLoadLanguage(strCharCode))
+        return false;
 
-    strThreeCharCode = langInfo.GetLanguageCode();
-    return true;
+      strThreeCharCode = langInfo.GetLanguageCode();
+      return !strThreeCharCode.empty();
+    }
   }
 
   return false;

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -261,7 +261,7 @@ bool CLangCodeExpander::ConvertWindowsToGeneralCharCode(const CStdString& strWin
 }
 #endif
 
-bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString& lang)
+bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString& lang, bool checkXbmcLocales /*= true*/)
 {
   if (lang.empty())
     return false;
@@ -309,14 +309,15 @@ bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString&
       return ConvertToTwoCharCode(code, tmp);
   }
 
-  // try xbmc specific language names
-  CStdString strLangInfoPath;
-  strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", lang.c_str());
-  CLangInfo langInfo;
-  if (!langInfo.Load(strLangInfoPath))
+  if (!checkXbmcLocales)
     return false;
 
-  return ConvertToTwoCharCode(code, langInfo.GetLanguageCode());
+  // try xbmc specific language names
+  CLangInfo langInfo;
+  if (!langInfo.CheckLoadLanguage(lang))
+    return false;
+
+  return ConvertToTwoCharCode(code, langInfo.GetLanguageCode(), false);
 }
 
 bool CLangCodeExpander::ReverseLookup(const CStdString& desc, CStdString& code)

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -73,13 +73,8 @@ public:
   *   \return The 3-Char ISO 639-2/T code of lang if that code exists, lang otherwise.
   */
   CStdString ConvertToISO6392T(const CStdString& lang);
-#ifdef TARGET_WINDOWS
-  bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool localeHack = false);
-  bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool localeHack = false);
-#else
-  bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode);
-  bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode);
-#endif
+  bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool checkWin32Locales = false);
+  bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool checkXbmcLocales = true, bool checkWin32Locales = false);
 
 #ifdef TARGET_WINDOWS
   bool ConvertLinuxToWindowsRegionCodes(const CStdString& strTwoCharCode, CStdString& strThreeCharCode);

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -62,9 +62,10 @@ public:
   *          or full english name string to a 2-Char (ISO 639-1) code.  
   *   \param[out] code The 2-Char language code of the given language lang.
   *   \param[in] lang The language that should be converted.
+  *   \param[in] checkXbmcLocales Try to find in XBMC specific locales
   *   \return true if the conversion succeeded, false otherwise. 
   */ 
-  bool ConvertToTwoCharCode(CStdString& code, const CStdString& lang);
+  bool ConvertToTwoCharCode(CStdString& code, const CStdString& lang, bool checkXbmcLocales = true);
 
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),


### PR DESCRIPTION
LanguageCodeExpander can try to load language when trying to resolve language code.
Without this patch, every language load (even in local LangInfo object) cause reset global locale.
