### PR TITLE
Optimization of StringUtils::EqualsNoCase 

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -125,13 +125,12 @@ bool StringUtils::EqualsNoCase(const std::string &str1, const char *s2)
 
 bool StringUtils::EqualsNoCase(const char *s1, const char *s2)
 {
-  int c1, c2; // Yes, because the return type of tolower() is int.
-              // To make these chars would be to introduce an unnecesary extra bitmask/zero-extend (effectively caller-narowing) into the binary.
+  char c2; // we need only one char outside the loop
   do
   {
-    c1 = ::tolower(*s1++);
-    c2 = ::tolower(*s2++);
-    if (c1 != c2) // This includes the possibility that one of the characters is the null-terminator, which implies a string mismatch.
+    const char c1 = *s1++; // const local variable should help compiler to optimize
+    c2 = *s2++;
+    if (c1 != c2 && ::tolower(c1) != ::tolower(c2)) // This includes the possibility that one of the characters is the null-terminator, which implies a string mismatch.
       return false;
   } while (c2 != '\0'); // At this point, we know c1 == c2, so there's no need to test them both.
   return true;


### PR DESCRIPTION
Almost equal speed (compared to old version) when strings are full different case.
Much faster if some chars in strings have same case.

Bonus: if strings have same case, this function as fast as case-sensitive comparison.

@jmarshallnz ?
