### PR TITLE
changed: Make (dvdplayer) network buffer more flexible/configurable

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -54,29 +54,8 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
 
   unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
 
-  /* 
-   * There are 4 buffer modes available (configurable in as.xml)
-   * 0) Buffer all internet filesystems (like 2 but additionally also ftp, webdav, etc.) (default)
-   * 1) Buffer all filesystems (including local)
-   * 2) Only buffer true internet filesystems (streams) (http, etc.)
-   * 3) No buffer
-   */
-
-  if (g_advancedSettings.m_networkBufferMode == 3)
-  {
-    flags |= READ_NO_CACHE;
-  }
-  else if (g_advancedSettings.m_networkBufferMode == 0 || g_advancedSettings.m_networkBufferMode == 2)
-  {
-    if (URIUtils::IsInternetStream(CURL(strFile), (g_advancedSettings.m_networkBufferMode == 0) ) )
-      flags |= READ_CACHED;
-    else
-      flags |= READ_NO_CACHE;
-  }
-  else if (!URIUtils::IsOnDVD(strFile) && !URIUtils::IsBluray(strFile))
-  {
-    flags |= READ_CACHED; // Force cache for all others (in buffer mode 3)
-  }
+  if (URIUtils::IsOnDVD(strFile) || URIUtils::IsBluray(strFile))
+    flags |= READ_NO_CACHE; // Never cache these
 
   if (content == "video/mp4" || content == "video/x-msvideo" || content == "video/avi")
     flags |= READ_MULTI_STREAM;

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -334,7 +334,7 @@ bool CFile::OpenForWrite(const CStdString& strFileName, bool bOverWrite)
 {
   try
   {
-	CStdString storedFileName = URIUtils::SubstitutePath(strFileName);
+    CStdString storedFileName = URIUtils::SubstitutePath(strFileName);
     CURL url(storedFileName);
 
     m_pFile = CFileFactory::CreateLoader(url);

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -33,6 +33,7 @@
 #include "Util.h"
 #include "URL.h"
 #include "utils/StringUtils.h"
+#include "settings/AdvancedSettings.h"
 
 #include "commons/Exception.h"
 
@@ -229,14 +230,31 @@ bool CFile::Open(const CStdString& strFileName, unsigned int flags)
     }
 
     CURL url(URIUtils::SubstitutePath(strFileName));
-    bool isInternetStream = URIUtils::IsInternetStream(url, true);
-    if ( (flags & READ_NO_CACHE) == 0 && isInternetStream && !CUtil::IsPicture(strFileName) )
-      m_flags |= READ_CACHED;
+
+    /* 
+     * There are 4 buffer modes available (configurable in as.xml)
+     * 0) Buffer all internet filesystems (like 2 but additionally also ftp, webdav, etc.) (default)
+     * 1) Buffer all filesystems (including local)
+     * 2) Only buffer true internet filesystems (streams) (http, etc.)
+     * 3) No buffer
+     */
+    if ( (flags & READ_NO_CACHE) == 0 && !CUtil::IsPicture(strFileName) )
+    {
+      if (g_advancedSettings.m_networkBufferMode == 0 || g_advancedSettings.m_networkBufferMode == 2)
+      {
+        if (URIUtils::IsInternetStream(url, (g_advancedSettings.m_networkBufferMode == 0) ) )
+          flags |= READ_CACHED;
+      }
+      else if (g_advancedSettings.m_networkBufferMode == 1)
+      {
+        flags |= READ_CACHED; // Force cache for all others (in buffer mode 1)
+      }
+    }
 
     if (m_flags & READ_CACHED)
     {
       // for internet stream, if it contains multiple stream, file cache need handle it specially.
-      m_pFile = new CFileCache((m_flags & READ_MULTI_STREAM)!=0 && isInternetStream);
+      m_pFile = new CFileCache((m_flags & READ_MULTI_STREAM) != 0 && URIUtils::IsInternetStream(url, true));
       return m_pFile->Open(url);
     }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -374,7 +374,7 @@ void CAdvancedSettings::Initialize()
   m_measureRefreshrate = false;
 
   m_cacheMemBufferSize = 1024 * 1024 * 20;
-  m_alwaysForceBuffer = false;
+  m_networkBufferMode = 0; // Default (buffer all internet streams/filesystems)
   // the following setting determines the readRate of a player data
   // as multiply of the default data read rate
   m_readBufferFactor = 1.0f;
@@ -807,7 +807,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
-    XMLUtils::GetBoolean(pElement, "alwaysforcebuffer", m_alwaysForceBuffer);
+    XMLUtils::GetUInt(pElement, "buffermode", m_networkBufferMode, 0, 3);
     XMLUtils::GetFloat(pElement, "readbufferfactor", m_readBufferFactor);
   }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -376,7 +376,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     unsigned int m_addonPackageFolderSize;
 
     unsigned int m_cacheMemBufferSize;
-    bool m_alwaysForceBuffer;
+    unsigned int m_networkBufferMode;
     float m_readBufferFactor;
 
     bool m_jsonOutputCompact;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -36,6 +36,7 @@
 #include "video/VideoInfoScanner.h"
 #include "music/MusicDatabase.h"
 #include "utils/StringUtils.h"
+#include "settings/AdvancedSettings.h"
 
 using namespace XFILE;
 using namespace std;
@@ -466,7 +467,7 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
      thumbloader thread accesses the streamed filesystem at the same time as the
      App thread and the latter has to wait for it.
    */
-  if (item.m_bIsFolder && item.IsInternetStream(true))
+  if (item.m_bIsFolder && (item.IsInternetStream(true) || g_advancedSettings.m_networkBufferMode == 1))
   {
     CFileItemList items; // Dummy list
     CDirectory::GetDirectory(item.GetPath(), items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);


### PR DESCRIPTION
This is an improvement/change to the alwaysforcebuffer as.xml option that was implemented some time ago. I've changed the as.xml setting into an uint to allow us to set different buffer modes:
- 0) No buffer
- 1) Only buffer true internet filesystems (streams) (http, etc.)
- 2) Buffer all internet filesystems (like 2 but additionally also ftp, webdav, etc.) (default)
- 3) Buffer all filesystems (including local)

They idea about this as that on platforms like ARM like RPi, using buffering (in combination with certain filesystems) may cause too much drain (cpu usage) on the system. This setting allows the user to tweak this to their liking/setup.
