### PR TITLE
RegExp rework - part 01

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -254,8 +254,8 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
   {
     if (reYear.RegFind(strTitleAndYear.c_str()) >= 0)
     {
-      strTitleAndYear = reYear.GetReplaceString("\\1");
-      strYear = reYear.GetReplaceString("\\2");
+      strTitleAndYear = reYear.GetMatch(1);
+      strYear = reYear.GetMatch(2);
     }
   }
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
@@ -63,8 +63,8 @@ bool CDVDSubtitleParserMPL2::Open(CDVDStreamInfo &hints)
     if (pos > -1)
     {
       const char* text = line + pos + reg.GetFindLen();
-      std::string startFrame = reg.GetReplaceString("\\1");
-      std::string endFrame   = reg.GetReplaceString("\\2");
+      std::string startFrame(reg.GetMatch(1));
+      std::string endFrame  (reg.GetMatch(2));
       CDVDOverlayText* pOverlay = new CDVDOverlayText();
       pOverlay->Acquire(); // increase ref count with one so that we can hold a handle to this overlay
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
@@ -70,8 +70,8 @@ bool CDVDSubtitleParserMicroDVD::Open(CDVDStreamInfo &hints)
     if (pos > -1)
     {
       const char* text = line + pos + reg.GetFindLen();
-      std::string startFrame = reg.GetReplaceString("\\1");
-      std::string endFrame   = reg.GetReplaceString("\\2");
+      std::string startFrame(reg.GetMatch(1));
+      std::string endFrame  (reg.GetMatch(2));
       CDVDOverlayText* pOverlay = new CDVDOverlayText();
       pOverlay->Acquire(); // increase ref count with one so that we can hold a handle to this overlay
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
@@ -61,13 +61,13 @@ bool CDVDSubtitleParserVplayer::Open(CDVDStreamInfo &hints)
   {
     if (reg.RegFind(line) > -1)
     {
-      std::string hour = reg.GetReplaceString("\\1");
-      std::string min  = reg.GetReplaceString("\\2");
-      std::string sec  = reg.GetReplaceString("\\3");
+      std::string hour(reg.GetMatch(1));
+      std::string min (reg.GetMatch(2));
+      std::string sec (reg.GetMatch(3));
       std::string lines[3];
-      lines[0] = reg.GetReplaceString("\\4");
-      lines[1] = reg.GetReplaceString("\\6");
-      lines[2] = reg.GetReplaceString("\\8");
+      lines[0] = reg.GetMatch(4);
+      lines[1] = reg.GetMatch(6);
+      lines[2] = reg.GetMatch(8);
 
       CDVDOverlayText* pOverlay = new CDVDOverlayText();
       pOverlay->Acquire(); // increase ref count with one so that we can hold a handle to this overlay

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -77,8 +77,8 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
 
     if (reItem.RegFind(strBuffer.c_str()) >= 0)
     {
-      strLink = reItem.GetReplaceString("\\1");
-      strName = reItem.GetReplaceString("\\2");
+      strLink = reItem.GetMatch(1);
+      strName = reItem.GetMatch(2);
 
       if(strLink[0] == '/')
         strLink = strLink.Mid(1);
@@ -131,27 +131,27 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
 
         if (reDateTime.RegFind(strBuffer.c_str()) >= 0)
         {
-          day = reDateTime.GetReplaceString("\\1");
-          month = reDateTime.GetReplaceString("\\2");
-          year = reDateTime.GetReplaceString("\\3");
-          hour = reDateTime.GetReplaceString("\\4");
-          minute = reDateTime.GetReplaceString("\\5");
+          day = reDateTime.GetMatch(1);
+          month = reDateTime.GetMatch(2);
+          year = reDateTime.GetMatch(3);
+          hour = reDateTime.GetMatch(4);
+          minute = reDateTime.GetMatch(5);
         }
         else if (reDateTimeNginx.RegFind(strBuffer.c_str()) >= 0)
         {
-          day = reDateTimeNginx.GetReplaceString("\\1");
-          month = reDateTimeNginx.GetReplaceString("\\2");
-          year = reDateTimeNginx.GetReplaceString("\\3");
-          hour = reDateTimeNginx.GetReplaceString("\\4");
-          minute = reDateTimeNginx.GetReplaceString("\\5");
+          day = reDateTimeNginx.GetMatch(1);
+          month = reDateTimeNginx.GetMatch(2);
+          year = reDateTimeNginx.GetMatch(3);
+          hour = reDateTimeNginx.GetMatch(4);
+          minute = reDateTimeNginx.GetMatch(5);
         }
         else if (reDateTimeLighttp.RegFind(strBuffer.c_str()) >= 0)
         {
-          day = reDateTimeLighttp.GetReplaceString("\\3");
-          month = reDateTimeLighttp.GetReplaceString("\\2");
-          year = reDateTimeLighttp.GetReplaceString("\\1");
-          hour = reDateTimeLighttp.GetReplaceString("\\4");
-          minute = reDateTimeLighttp.GetReplaceString("\\5");
+          day = reDateTimeLighttp.GetMatch(3);
+          month = reDateTimeLighttp.GetMatch(2);
+          year = reDateTimeLighttp.GetMatch(1);
+          hour = reDateTimeLighttp.GetMatch(4);
+          minute = reDateTimeLighttp.GetMatch(5);
         }
 
         if (day.length() > 0 && month.length() > 0 && year.length() > 0)
@@ -163,8 +163,8 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
         {
           if (reSize.RegFind(strBuffer.c_str()) >= 0)
           {
-            double Size = atof(reSize.GetReplaceString("\\1").c_str());
-            CStdString strUnit = reSize.GetReplaceString("\\2");
+            double Size = atof(reSize.GetMatch(1).c_str());
+            std::string strUnit(reSize.GetMatch(2));
 
             if (strUnit == "K")
               Size = Size * 1024;
@@ -177,8 +177,8 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
           }
           else if (reSizeNginx.RegFind(strBuffer.c_str()) >= 0)
           {
-            double Size = atof(reSizeNginx.GetReplaceString("\\1").c_str());
-            CStdString strUnit = reSizeNginx.GetReplaceString("\\2");
+            double Size = atof(reSizeNginx.GetMatch(1).c_str());
+            std::string strUnit(reSize.GetMatch(2));
 
             if (strUnit == "K")
               Size = Size * 1024;

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -153,7 +153,7 @@ bool CShoutcastFile::ExtractTagInfo(const char* buf)
 
   if (reTitle.RegFind(strBuffer.c_str()) != -1)
   {
-    std::string newtitle = reTitle.GetReplaceString("\\1");
+    std::string newtitle(reTitle.GetMatch(1));
     result = (m_tag.GetTitle() != newtitle);
     m_tag.SetTitle(newtitle);
   }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -316,7 +316,7 @@ CStdString CPVRRecording::GetTitleFromURL(const CStdString &url)
       "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9].pvr"))
   {
     if (reg.RegFind(url.c_str()) >= 0)
-      return reg.GetReplaceString("\\2");
+      return reg.GetMatch(2);
   }
   return StringUtils::EmptyString;
 }

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -336,7 +336,7 @@ void CLabelFormatter::SplitMask(unsigned int label, const CStdString &mask)
   { // we've found a match
     m_staticContent[label].push_back(work.Left(findStart));
     m_dynamicContent[label].push_back(CMaskString("", 
-          reg.GetReplaceString("\\1")[0], ""));
+          reg.GetMatch(1)[0], ""));
     work = work.Mid(findStart + reg.GetFindLen());
   }
   m_staticContent[label].push_back(work);
@@ -358,11 +358,11 @@ void CLabelFormatter::AssembleMask(unsigned int label, const CStdString& mask)
   while ((findStart = reg.RegFind(work.c_str())) >= 0)
   { // we've found a match for a pre/postfixed string
     // send anything
-    SplitMask(label, work.Left(findStart) + reg.GetReplaceString("\\1").c_str());
+    SplitMask(label, work.Left(findStart) + reg.GetMatch(1).c_str());
     m_dynamicContent[label].push_back(CMaskString(
-            reg.GetReplaceString("\\2"),
-            reg.GetReplaceString("\\4")[0],
-            reg.GetReplaceString("\\5")));
+            reg.GetMatch(2),
+            reg.GetMatch(4)[0],
+            reg.GetMatch(5)));
     work = work.Mid(findStart + reg.GetFindLen());
   }
   SplitMask(label, work);

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -280,7 +280,7 @@ void CScraperParser::ParseExpression(const CStdString& input, CStdString& dest, 
         int i2=reg2.RegFind(strCurOutput.c_str());
         while (i2 > -1)
         {
-          std::string szRemove = reg2.GetReplaceString("\\2");
+          std::string szRemove(reg2.GetMatch(2));
           int iRemove = szRemove.size();
           int i3 = strCurOutput.find(szRemove);
           if (!szParam.empty())
@@ -501,7 +501,7 @@ void CScraperParser::ConvertJSON(CStdString &string)
   while (reg.RegFind(string.c_str()) > -1)
   {
     int pos = reg.GetSubStart(1);
-    std::string szReplace = reg.GetReplaceString("\\1");
+    std::string szReplace(reg.GetMatch(1));
 
     CStdString replace;
     replace.Format("&#x%s;", szReplace.c_str());
@@ -514,7 +514,7 @@ void CScraperParser::ConvertJSON(CStdString &string)
   {
     int pos1 = reg2.GetSubStart(1);
     int pos2 = reg2.GetSubStart(2);
-    std::string szHexValue = reg2.GetReplaceString("\\1");
+    std::string szHexValue(reg2.GetMatch(1));
 
     CStdString replace;
     replace.Format("%c", strtol(szHexValue.c_str(), NULL, 16));

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -907,7 +907,7 @@ namespace VIDEO
 
       // Grab the remainder from first regexp run
       // as second run might modify or empty it.
-      std::string remainder = reg.GetReplaceString("\\3");
+      std::string remainder(reg.GetMatch(3));
 
       /*
        * Check if the files base path is a dedicated folder that contains
@@ -957,13 +957,13 @@ namespace VIDEO
                       g_advancedSettings.m_tvshowMultiPartEnumRegExp.c_str());
 
             episodeList.push_back(episode);
-            remainder = reg.GetReplaceString("\\3");
+            remainder = reg.GetMatch(3);
             offset = 0;
           }
           else if (((regexp2pos < regexppos) && regexp2pos != -1) ||
                    (regexp2pos >= 0 && regexppos == -1))
           {
-            episode.iEpisode = atoi(reg2.GetReplaceString("\\1").c_str());
+            episode.iEpisode = atoi(reg2.GetMatch(1).c_str());
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding multipart episode %u [%s]",
                       episode.iEpisode, g_advancedSettings.m_tvshowMultiPartEnumRegExp.c_str());
             episodeList.push_back(episode);
@@ -978,8 +978,8 @@ namespace VIDEO
 
   bool CVideoInfoScanner::GetEpisodeAndSeasonFromRegExp(CRegExp &reg, EPISODE &episodeInfo, int defaultSeason)
   {
-    std::string season = reg.GetReplaceString("\\1");
-    std::string episode = reg.GetReplaceString("\\2");
+    std::string season(reg.GetMatch(1));
+    std::string episode(reg.GetMatch(2));
 
     if (!season.empty() || !episode.empty())
     {
@@ -1015,9 +1015,9 @@ namespace VIDEO
 
   bool CVideoInfoScanner::GetAirDateFromRegExp(CRegExp &reg, EPISODE &episodeInfo)
   {
-    std::string param1 = reg.GetReplaceString("\\1");
-    std::string param2 = reg.GetReplaceString("\\2");
-    std::string param3 = reg.GetReplaceString("\\3");
+    std::string param1(reg.GetMatch(1));
+    std::string param2(reg.GetMatch(2));
+    std::string param3(reg.GetMatch(3));
 
     if (!param1.empty() && !param2.empty() && !param3.empty())
     {
@@ -1709,7 +1709,7 @@ namespace VIDEO
         CStdString name = URIUtils::GetFileName(items[i]->GetPath());
         if (reg.RegFind(name) > -1)
         {
-          int season = atoi(reg.GetReplaceString("\\1").c_str());
+          int season = atoi(reg.GetMatch(1).c_str());
           if (season > maxSeasons)
             maxSeasons = season;
         }


### PR DESCRIPTION
This is a first part of splitted PR #3223. (Actually part number zero was already merged #3251).
This part is simple replace '.GetReplaceString("\x")' -> '.GetMatch(x);'
