### PR TITLE
RegExp rework - part 03

### DIFF
--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -212,7 +212,7 @@ void CExternalPlayer::Process()
         while ((iStart = regExp.RegFind(mainFile, iStart)) > -1)
         {
           int iLength = regExp.GetFindLen();
-          mainFile = mainFile.Left(iStart) + regExp.GetReplaceString(strRep.c_str()).c_str() + mainFile.Mid(iStart+iLength);
+          mainFile = mainFile.Left(iStart) + regExp.GetReplaceString(strRep).c_str() + mainFile.Mid(iStart + iLength);
           if (!bGlobal)
             break;
         }

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -236,6 +236,9 @@ std::string CRegExp::GetMatch(int iSub /* = 0 */)
 
   int pos = m_iOvector[(iSub*2)];
   int len = m_iOvector[(iSub*2)+1] - pos;
+  if (pos < 0 || len <= 0)
+    return "";
+
   return m_subject.substr(pos, len);
 }
 

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -76,10 +76,10 @@ CRegExp::~CRegExp()
   Cleanup();
 }
 
-CRegExp* CRegExp::RegComp(const char *re)
+bool CRegExp::RegComp(const char *re)
 {
   if (!re)
-    return NULL;
+    return false;
 
   m_bMatched         = false;
   m_iMatchCount      = 0;
@@ -94,12 +94,12 @@ CRegExp* CRegExp::RegComp(const char *re)
     m_pattern.clear();
     CLog::Log(LOGERROR, "PCRE: %s. Compilation failed at offset %d in expression '%s'",
               errMsg, errOffset, re);
-    return NULL;
+    return false;
   }
 
   m_pattern = re;
 
-  return this;
+  return true;
 }
 
 int CRegExp::RegFind(const char* str, int startoffset)

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -64,6 +64,8 @@ const CRegExp& CRegExp::operator=(const CRegExp& re)
         m_subject = re.m_subject;
         m_iOptions = re.m_iOptions;
       }
+      else
+        CLog::Log(LOGSEVERE, "%s: Failed to allocate memory", __FUNCTION__);
     }
   }
   return *this;
@@ -189,7 +191,10 @@ std::string CRegExp::GetReplaceString( const char* sReplaceExp )
   // Now allocate buf
   buf = (char *)malloc((replacelen + 1)*sizeof(char));
   if( buf == NULL )
+  {
+    CLog::Log(LOGSEVERE, "%s: Failed to allocate memory", __FUNCTION__);
     return std::string();
+  }
 
   char* sReplaceStr = buf;
 

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -234,9 +234,25 @@ std::string CRegExp::GetReplaceString( const char* sReplaceExp )
   return replaceStr;
 }
 
+int CRegExp::GetSubStart(int iSub)
+{
+  if (!IsValidSubNumber(iSub))
+    return -1;
+
+  return m_iOvector[iSub*2];
+}
+
+int CRegExp::GetSubLength(int iSub)
+{
+  if (!IsValidSubNumber(iSub))
+    return -1;
+
+  return m_iOvector[(iSub*2)+1] - m_iOvector[(iSub*2)];
+}
+
 std::string CRegExp::GetMatch(int iSub /* = 0 */)
 {
-  if (iSub < 0 || iSub > m_iMatchCount)
+  if (!IsValidSubNumber(iSub))
     return "";
 
   int pos = m_iOvector[(iSub*2)];
@@ -251,7 +267,7 @@ bool CRegExp::GetNamedSubPattern(const char* strName, std::string& strMatch)
 {
   strMatch.clear();
   int iSub = pcre_get_stringnumber(m_re, strName);
-  if (iSub < 0)
+  if (!IsValidSubNumber(iSub))
     return false;
   strMatch = GetMatch(iSub);
   return true;

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -252,6 +252,11 @@ bool CRegExp::GetNamedSubPattern(const char* strName, std::string& strMatch)
   return true;
 }
 
+int CRegExp::GetNamedSubPatternNumber(const char* strName)
+{
+  return pcre_get_stringnumber(m_re, strName);
+}
+
 void CRegExp::DumpOvector(int iLog /* = LOGDEBUG */)
 {
   if (iLog < LOGDEBUG || iLog > LOGNONE)

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -242,12 +242,22 @@ int CRegExp::GetSubStart(int iSub) const
   return m_iOvector[iSub*2];
 }
 
+int CRegExp::GetSubStart(const std::string& subName) const
+{
+  return GetSubStart(GetNamedSubPatternNumber(subName.c_str()));
+}
+
 int CRegExp::GetSubLength(int iSub) const
 {
   if (!IsValidSubNumber(iSub))
     return -1;
 
   return m_iOvector[(iSub*2)+1] - m_iOvector[(iSub*2)];
+}
+
+int CRegExp::GetSubLength(const std::string& subName) const
+{
+  return GetSubLength(GetNamedSubPatternNumber(subName.c_str()));
 }
 
 std::string CRegExp::GetMatch(int iSub /* = 0 */) const
@@ -261,6 +271,11 @@ std::string CRegExp::GetMatch(int iSub /* = 0 */) const
     return "";
 
   return m_subject.substr(pos, len);
+}
+
+std::string CRegExp::GetMatch(const std::string& subName) const
+{
+  return GetMatch(GetNamedSubPatternNumber(subName.c_str()));
 }
 
 bool CRegExp::GetNamedSubPattern(const char* strName, std::string& strMatch) const

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -143,7 +143,7 @@ int CRegExp::RegFind(const char* str, int startoffset)
   return m_iOvector[0];
 }
 
-int CRegExp::GetCaptureTotal()
+int CRegExp::GetCaptureTotal() const
 {
   int c = -1;
   if (m_re)
@@ -151,7 +151,7 @@ int CRegExp::GetCaptureTotal()
   return c;
 }
 
-std::string CRegExp::GetReplaceString( const char* sReplaceExp )
+std::string CRegExp::GetReplaceString( const char* sReplaceExp ) const
 {
   char *src = (char *)sReplaceExp;
   char *buf;
@@ -234,7 +234,7 @@ std::string CRegExp::GetReplaceString( const char* sReplaceExp )
   return replaceStr;
 }
 
-int CRegExp::GetSubStart(int iSub)
+int CRegExp::GetSubStart(int iSub) const
 {
   if (!IsValidSubNumber(iSub))
     return -1;
@@ -242,7 +242,7 @@ int CRegExp::GetSubStart(int iSub)
   return m_iOvector[iSub*2];
 }
 
-int CRegExp::GetSubLength(int iSub)
+int CRegExp::GetSubLength(int iSub) const
 {
   if (!IsValidSubNumber(iSub))
     return -1;
@@ -250,7 +250,7 @@ int CRegExp::GetSubLength(int iSub)
   return m_iOvector[(iSub*2)+1] - m_iOvector[(iSub*2)];
 }
 
-std::string CRegExp::GetMatch(int iSub /* = 0 */)
+std::string CRegExp::GetMatch(int iSub /* = 0 */) const
 {
   if (!IsValidSubNumber(iSub))
     return "";
@@ -263,7 +263,7 @@ std::string CRegExp::GetMatch(int iSub /* = 0 */)
   return m_subject.substr(pos, len);
 }
 
-bool CRegExp::GetNamedSubPattern(const char* strName, std::string& strMatch)
+bool CRegExp::GetNamedSubPattern(const char* strName, std::string& strMatch) const
 {
   strMatch.clear();
   int iSub = pcre_get_stringnumber(m_re, strName);
@@ -273,7 +273,7 @@ bool CRegExp::GetNamedSubPattern(const char* strName, std::string& strMatch)
   return true;
 }
 
-int CRegExp::GetNamedSubPatternNumber(const char* strName)
+int CRegExp::GetNamedSubPatternNumber(const char* strName) const
 {
   return pcre_get_stringnumber(m_re, strName);
 }

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -280,3 +280,9 @@ void CRegExp::DumpOvector(int iLog /* = LOGDEBUG */)
   str += "}";
   CLog::Log(iLog, "regexp ovector=%s", str.c_str());
 }
+
+inline bool CRegExp::IsValidSubNumber(int iSub) const
+{
+  return iSub >= 0 && iSub <= m_iMatchCount && iSub <= m_MaxNumOfBackrefrences;
+}
+

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -29,7 +29,7 @@ using namespace PCRE;
 CRegExp::CRegExp(bool caseless)
 {
   m_re          = NULL;
-  m_iOptions    = PCRE_DOTALL;
+  m_iOptions    = PCRE_DOTALL | PCRE_NEWLINE_ANY;
   if(caseless)
     m_iOptions |= PCRE_CASELESS;
 

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -49,22 +49,22 @@ public:
   CRegExp* RegComp(const std::string& re) { return RegComp(re.c_str()); }
   int RegFind(const char *str, int startoffset = 0);
   int RegFind(const std::string& str, int startoffset = 0) { return RegFind(str.c_str(), startoffset); }
-  std::string GetReplaceString( const char* sReplaceExp );
-  int GetFindLen()
+  std::string GetReplaceString( const char* sReplaceExp ) const;
+  int GetFindLen() const
   {
     if (!m_re || !m_bMatched)
       return 0;
 
     return (m_iOvector[1] - m_iOvector[0]);
   };
-  int GetSubCount() { return m_iMatchCount - 1; } // PCRE returns the number of sub-patterns + 1
-  int GetSubStart(int iSub);
-  int GetSubLength(int iSub);
-  int GetCaptureTotal();
-  std::string GetMatch(int iSub = 0);
-  const std::string& GetPattern() { return m_pattern; }
-  bool GetNamedSubPattern(const char* strName, std::string& strMatch);
-  int GetNamedSubPatternNumber(const char* strName);
+  int GetSubCount() const { return m_iMatchCount - 1; } // PCRE returns the number of sub-patterns + 1
+  int GetSubStart(int iSub) const;
+  int GetSubLength(int iSub) const;
+  int GetCaptureTotal() const;
+  std::string GetMatch(int iSub = 0) const;
+  const std::string& GetPattern() const { return m_pattern; }
+  bool GetNamedSubPattern(const char* strName, std::string& strMatch) const;
+  int GetNamedSubPatternNumber(const char* strName) const;
   void DumpOvector(int iLog);
   const CRegExp& operator= (const CRegExp& re);
 

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -59,9 +59,12 @@ public:
   };
   int GetSubCount() const { return m_iMatchCount - 1; } // PCRE returns the number of sub-patterns + 1
   int GetSubStart(int iSub) const;
+  int GetSubStart(const std::string& subName) const;
   int GetSubLength(int iSub) const;
+  int GetSubLength(const std::string& subName) const;
   int GetCaptureTotal() const;
   std::string GetMatch(int iSub = 0) const;
+  std::string GetMatch(const std::string& subName) const;
   const std::string& GetPattern() const { return m_pattern; }
   bool GetNamedSubPattern(const char* strName, std::string& strMatch) const;
   int GetNamedSubPatternNumber(const char* strName) const;

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -74,7 +74,6 @@ public:
 private:
   void Cleanup() { if (m_re) { PCRE::pcre_free(m_re); m_re = NULL; } }
 
-private:
   PCRE::pcre* m_re;
   int         m_iOvector[OVECCOUNT];
   int         m_iMatchCount;

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -50,7 +50,7 @@ public:
   int RegFind(const char* str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1);
   int RegFind(const std::string& str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1)
   { return PrivateRegFind(str.length(), str.c_str(), startoffset, maxNumberOfCharsToTest); }
-  std::string GetReplaceString( const char* sReplaceExp ) const;
+  std::string GetReplaceString(const std::string& sReplaceExp) const;
   int GetFindLen() const
   {
     if (!m_re || !m_bMatched)

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -67,6 +67,7 @@ public:
   std::string GetMatch(int iSub = 0);
   const std::string& GetPattern() { return m_pattern; }
   bool GetNamedSubPattern(const char* strName, std::string& strMatch);
+  int GetNamedSubPatternNumber(const char* strName);
   void DumpOvector(int iLog);
   const CRegExp& operator= (const CRegExp& re);
 

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -47,8 +47,9 @@ public:
 
   bool RegComp(const char *re);
   bool RegComp(const std::string& re) { return RegComp(re.c_str()); }
-  int RegFind(const char *str, int startoffset = 0);
-  int RegFind(const std::string& str, int startoffset = 0) { return RegFind(str.c_str(), startoffset); }
+  int RegFind(const char* str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1);
+  int RegFind(const std::string& str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1)
+  { return PrivateRegFind(str.length(), str.c_str(), startoffset, maxNumberOfCharsToTest); }
   std::string GetReplaceString( const char* sReplaceExp ) const;
   int GetFindLen() const
   {
@@ -72,11 +73,14 @@ public:
   const CRegExp& operator= (const CRegExp& re);
 
 private:
+  int PrivateRegFind(size_t bufferLen, const char *str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1);
+
   void Cleanup() { if (m_re) { PCRE::pcre_free(m_re); m_re = NULL; } }
   inline bool IsValidSubNumber(int iSub) const;
 
   PCRE::pcre* m_re;
   static const int OVECCOUNT=(m_MaxNumOfBackrefrences + 1) * 3;
+  unsigned int m_offset;
   int         m_iOvector[OVECCOUNT];
   int         m_iMatchCount;
   int         m_iOptions;

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -37,13 +37,10 @@ namespace PCRE {
 #include <pcre.h>
 }
 
-// maximum of 20 backreferences
-// OVEVCOUNT must be a multiple of 3
-const int OVECCOUNT=(20+1)*3;
-
 class CRegExp
 {
 public:
+  static const int m_MaxNumOfBackrefrences = 20;
   CRegExp(bool caseless = false);
   CRegExp(const CRegExp& re);
   ~CRegExp();
@@ -75,6 +72,7 @@ private:
   void Cleanup() { if (m_re) { PCRE::pcre_free(m_re); m_re = NULL; } }
 
   PCRE::pcre* m_re;
+  static const int OVECCOUNT=(m_MaxNumOfBackrefrences + 1) * 3;
   int         m_iOvector[OVECCOUNT];
   int         m_iMatchCount;
   int         m_iOptions;

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -45,8 +45,8 @@ public:
   CRegExp(const CRegExp& re);
   ~CRegExp();
 
-  CRegExp* RegComp(const char *re);
-  CRegExp* RegComp(const std::string& re) { return RegComp(re.c_str()); }
+  bool RegComp(const char *re);
+  bool RegComp(const std::string& re) { return RegComp(re.c_str()); }
   int RegFind(const char *str, int startoffset = 0);
   int RegFind(const std::string& str, int startoffset = 0) { return RegFind(str.c_str(), startoffset); }
   std::string GetReplaceString( const char* sReplaceExp ) const;

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -70,6 +70,7 @@ public:
 
 private:
   void Cleanup() { if (m_re) { PCRE::pcre_free(m_re); m_re = NULL; } }
+  inline bool IsValidSubNumber(int iSub) const;
 
   PCRE::pcre* m_re;
   static const int OVECCOUNT=(m_MaxNumOfBackrefrences + 1) * 3;

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -58,8 +58,8 @@ public:
     return (m_iOvector[1] - m_iOvector[0]);
   };
   int GetSubCount() { return m_iMatchCount - 1; } // PCRE returns the number of sub-patterns + 1
-  int GetSubStart(int iSub) { return m_iOvector[iSub*2]; } // normalized to match old engine
-  int GetSubLength(int iSub) { return (m_iOvector[(iSub*2)+1] - m_iOvector[(iSub*2)]); } // correct spelling
+  int GetSubStart(int iSub);
+  int GetSubLength(int iSub);
   int GetCaptureTotal();
   std::string GetMatch(int iSub = 0);
   const std::string& GetPattern() { return m_pattern; }

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -122,8 +122,7 @@ const char *CXBMCTinyXML::Parse(CStdString &data, TiXmlParsingData *prevData, Ti
   re.RegComp("^&(amp|lt|gt|quot|apos|#x[a-fA-F0-9]{1,4}|#[0-9]{1,5});.*");
   while ((pos = data.find("&", pos)) != CStdString::npos)
   {
-    CStdString tmp = data.substr(pos, MAX_ENTITY_LENGTH);
-    if (re.RegFind(tmp) < 0)
+    if (re.RegFind(data, pos, MAX_ENTITY_LENGTH) < 0)
       data.insert(pos + 1, "amp;");
     pos++;
   }


### PR DESCRIPTION
This is a third part of splitted PR #3223. (Other part are PR #3433, PR #3434)
This PR contains:
- general CRegExp optimizations, 
- addition of overloaded functions to deal with named submatches like with numbered, 
- some fixes, like checking submatches length and not trying to create string with negative length,
- RegFind improvement: now RegFind can be called with offset and max len limits,
- other enhancements.
