### PR TITLE
Multiselect setting

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3,6 +3,16 @@
   <section id="appearance" label="480" help="36101">
     <category id="lookandfeel" label="166" help="36102">
       <group id="1">
+        <setting id="lookandfeel.abc" type="stringlist" label="15111" 
+help="36105">
+          <level>0</level>
+          <default>English</default>
+          <constraints>
+            <options>languages</options>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="list" format="stringlist" />
+        </setting>
         <setting id="lookandfeel.skin" type="addon" label="166" help="36103">
           <level>0</level>
           <default>skin.confluence</default>

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -1039,7 +1039,204 @@ void CSettingString::copy(const CSettingString &setting)
   m_allowEmpty = setting.m_allowEmpty;
   m_heading = setting.m_heading;
 }
-  
+
+CSettingStringList::CSettingStringList(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
+: CSetting(id, settingsManager),
+m_allowEmpty(false), m_heading(-1)
+{ }
+
+CSettingStringList::CSettingStringList(const std::string &id, const CSettingStringList &setting)
+: CSetting(id, setting)
+{
+  copy(setting);
+}
+
+CSettingStringList::CSettingStringList(const std::string &id, int label, const std::vector<std::string> &value, CSettingsManager *settingsManager /* = NULL */)
+: CSetting(id, settingsManager),
+m_value(value), m_default(value),
+m_allowEmpty(false), m_heading(-1)
+{
+  m_label = label;
+
+  m_control.SetType(SettingControlTypeList);
+  m_control.SetFormat(SettingControlFormatStringList);
+  m_control.SetAttributes(SettingControlAttributeNone);
+}
+
+bool CSettingStringList::Deserialize(const TiXmlNode *node, bool update /* = false */)
+{
+  CSingleLock lock(m_critical);
+
+  if (!CSetting::Deserialize(node, update))
+    return false;
+
+  if (m_control.GetType() != SettingControlTypeList || m_control.GetFormat() != SettingControlFormatStringList)
+  {
+    CLog::Log(LOGERROR, "CSettingString: invalid <control> of \"%s\"", m_id.c_str());
+    return false;
+  }
+
+  const TiXmlNode *control = node->FirstChild(XML_ELM_CONTROL);
+  if (control != NULL)
+  {
+    // get heading
+    XMLUtils::GetInt(control, "heading", m_heading);
+  }
+
+  const TiXmlNode *constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
+  if (constraints != NULL)
+  {
+    // get allowempty (needs to be parsed before parsing the default value)
+    XMLUtils::GetBoolean(constraints, "allowempty", m_allowEmpty);
+
+    // get the entries
+    const TiXmlNode *options = constraints->FirstChild(XML_ELM_OPTIONS);
+    if (options != NULL && options->FirstChild() != NULL &&
+        options->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT)
+      m_optionsFiller = options->FirstChild()->ValueStr();
+  }
+
+  // get the default value
+  CStdString value;
+  if (XMLUtils::GetString(node, XML_ELM_DEFAULT, value) && !value.empty())
+    m_value = m_default = fromString(value);
+  else if (!update && !m_allowEmpty)
+  {
+    CLog::Log(LOGERROR, "CSettingString: error reading the default value of \"%s\"", m_id.c_str());
+    return false;
+  }
+
+  return true;
+}
+
+bool CSettingStringList::FromString(const std::string &value)
+{
+  return SetValue(fromString(value));
+}
+
+std::string CSettingStringList::ToString() const
+{
+  return StringUtils::Join(m_value, "|");
+}
+
+std::vector<std::string> CSettingStringList::fromString(const std::string &value)
+{
+  return StringUtils::Split(value, "|");
+}
+
+bool CSettingStringList::Equals(const std::string &value) const
+{
+  return fromString(value) == m_value;
+}
+
+bool CSettingStringList::CheckValidity(const std::string &value) const
+{
+  return CheckValidity(fromString(value));
+}
+
+bool CSettingStringList::CheckValidity(const std::vector<std::string> &value) const
+{
+  if (!m_allowEmpty && value.empty())
+    return false;
+
+  return true;
+}
+
+bool CSettingStringList::SetValue(const std::vector<std::string> &value)
+{
+  CSingleLock lock(m_critical);
+
+  if (value == m_value)
+    return true;
+
+  if (!CheckValidity(value))
+    return false;
+
+  std::vector<std::string> oldValue = m_value;
+  m_value = value;
+
+  if (!OnSettingChanging(this))
+  {
+    m_value = oldValue;
+
+    // the setting couldn't be changed because one of the
+    // callback handlers failed the OnSettingChanging()
+    // callback so we need to let all the callback handlers
+    // know that the setting hasn't changed
+    OnSettingChanging(this);
+    return false;
+  }
+
+  m_changed = m_value != m_default;
+  OnSettingChanged(this);
+  return true;
+}
+
+void CSettingStringList::SetDefault(const std::vector<std::string> &value)
+{
+  CSingleLock lock(m_critical);
+
+  m_default = value;
+  if (!m_changed)
+    m_value = m_default;
+}
+
+SettingOptionsType CSettingStringList::GetOptionsType() const
+{
+  if (!m_optionsFiller.empty())
+    return SettingOptionsTypeDynamic;
+
+  return SettingOptionsTypeNone;
+}
+
+DynamicStringSettingOptions CSettingStringList::UpdateDynamicOptions()
+{
+  DynamicStringSettingOptions options;
+  if (m_optionsFiller.empty() || m_settingsManager == NULL)
+    return options;
+
+  StringSettingOptionsFiller filler = (StringSettingOptionsFiller)m_settingsManager->GetSettingOptionsFiller(this);
+  if (filler == NULL)
+    return options;
+
+  /* NOTE: no checks for validity of current option here */
+  std::string bestMatchingValue = "";
+  filler(this, options, bestMatchingValue);
+
+  // check if the list of items has changed
+  bool changed = m_dynamicOptions.size() != options.size();
+  if (!changed)
+  {
+    for (size_t index = 0; index < options.size(); index++)
+    {
+      if (options[index].first.compare(m_dynamicOptions[index].first) != 0 ||
+          options[index].second.compare(m_dynamicOptions[index].second) != 0)
+      {
+        changed = true;
+        break;
+      }
+    }
+  }
+
+  if (changed)
+  {
+    m_dynamicOptions = options;
+    OnSettingPropertyChanged(this, "options");
+  }
+
+  return options;
+}
+
+void CSettingStringList::copy(const CSettingStringList &setting)
+{
+  CSetting::Copy(setting);
+
+  m_value = setting.m_value;
+  m_default = setting.m_default;
+  m_allowEmpty = setting.m_allowEmpty;
+  m_heading = setting.m_heading;
+}
+
 CSettingAction::CSettingAction(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : CSetting(id, settingsManager)
 {

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -41,6 +41,7 @@ typedef enum {
   SettingTypeInteger,
   SettingTypeNumber,
   SettingTypeString,
+  SettingTypeStringList,
   SettingTypeAction
 } SettingType;
 
@@ -304,6 +305,53 @@ protected:
 
   std::string m_value;
   std::string m_default;
+  bool m_allowEmpty;
+  int m_heading;
+  std::string m_optionsFiller;
+  DynamicStringSettingOptions m_dynamicOptions;
+};
+
+/*!
+ \ingroup settings
+ \brief String setting implementation.
+ \sa CSetting
+ */
+class CSettingStringList : public CSetting
+{
+public:
+  CSettingStringList(const std::string &id, CSettingsManager *settingsManager = NULL);
+  CSettingStringList(const std::string &id, const CSettingStringList &setting);
+  CSettingStringList(const std::string &id, int label, const std::vector<std::string> &value, CSettingsManager *settingsManager = NULL);
+  virtual ~CSettingStringList() { }
+
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+
+  virtual int GetType() const { return SettingTypeStringList; }
+  virtual bool FromString(const std::string &value);
+  virtual std::string ToString() const;
+  virtual bool Equals(const std::string &value) const;
+  virtual bool CheckValidity(const std::string &value) const;
+  virtual void Reset() { SetValue(m_default); }
+
+  const std::vector<std::string>& GetValue() const { return m_value; }
+  bool SetValue(const std::vector<std::string> &value);
+  const std::vector<std::string>& GetDefault() const { return m_default; }
+  void SetDefault(const std::vector<std::string> &value);
+
+  virtual bool AllowEmpty() const { return m_allowEmpty; }
+  virtual int GetHeading() const { return m_heading; }
+
+  SettingOptionsType GetOptionsType() const;
+  const std::string& GetOptionsFiller() const { return m_optionsFiller; }
+  DynamicStringSettingOptions UpdateDynamicOptions();
+
+protected:
+  void copy(const CSettingStringList &setting);
+  bool CheckValidity(const std::vector<std::string> &value) const;
+  static std::vector<std::string> fromString(const std::string &value);
+
+  std::vector<std::string> m_value;
+  std::vector<std::string> m_default;
   bool m_allowEmpty;
   int m_heading;
   std::string m_optionsFiller;

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -95,6 +95,8 @@ bool CSettingControl::setFormat(const std::string &strFormat)
     m_format = SettingControlFormatBoolean;
   else if (StringUtils::EqualsNoCase(strFormat, "string"))
     m_format = SettingControlFormatString;
+  else if (StringUtils::EqualsNoCase(strFormat, "stringlist"))
+    m_format = SettingControlFormatStringList;
   else if (StringUtils::EqualsNoCase(strFormat, "integer"))
     m_format = SettingControlFormatInteger;
   else if (StringUtils::EqualsNoCase(strFormat, "number"))

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -36,6 +36,7 @@ typedef enum {
   SettingControlFormatNone = 0,
   SettingControlFormatBoolean,
   SettingControlFormatString,
+  SettingControlFormatStringList,
   SettingControlFormatInteger,
   SettingControlFormatNumber,
   SettingControlFormatIP,

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -378,6 +378,8 @@ void* CSettingsManager::GetSettingOptionsFiller(const CSetting *setting)
     filler = ((const CSettingInt*)setting)->GetOptionsFiller();
   else if (setting->GetType() == SettingTypeString)
     filler = ((const CSettingString*)setting)->GetOptionsFiller();
+  else if (setting->GetType() == SettingTypeStringList)
+    filler = ((const CSettingStringList*)setting)->GetOptionsFiller();
 
   if (filler.empty())
     return NULL;
@@ -403,7 +405,8 @@ void* CSettingsManager::GetSettingOptionsFiller(const CSetting *setting)
     
     case SettingOptionsFillerTypeString:
     {
-      if (setting->GetType() != SettingTypeString)
+      if (setting->GetType() != SettingTypeString &&
+          setting->GetType() != SettingTypeStringList)
         return NULL;
 
       break;
@@ -563,6 +566,26 @@ bool CSettingsManager::SetString(const std::string &id, const std::string &value
     return false;
 
   return ((CSettingString*)setting)->SetValue(value);
+}
+
+std::vector<std::string> CSettingsManager::GetStringList(const std::string &id) const
+{
+  CSingleLock lock(m_critical);
+  CSetting *setting = GetSetting(id);
+  if (setting == NULL || setting->GetType() != SettingTypeStringList)
+    return std::vector<std::string>();
+
+  return ((CSettingStringList*)setting)->GetValue();
+}
+
+bool CSettingsManager::SetStringList(const std::string &id, const std::vector<std::string> &value)
+{
+  CSingleLock lock(m_critical);
+  CSetting *setting = GetSetting(id);
+  if (setting == NULL || setting->GetType() != SettingTypeStringList)
+    return false;
+
+  return ((CSettingStringList*)setting)->SetValue(value);
 }
 
 void CSettingsManager::AddCondition(const std::string &condition)
@@ -769,6 +792,8 @@ CSetting* CSettingsManager::CreateSetting(const std::string &settingType, const 
     return new CSettingNumber(settingId, (CSettingsManager*)this);
   else if (StringUtils::EqualsNoCase(settingType, "string"))
     return new CSettingString(settingId, (CSettingsManager*)this);
+  else if (StringUtils::EqualsNoCase(settingType, "stringlist"))
+    return new CSettingStringList(settingId, (CSettingsManager*)this);
   else if (StringUtils::EqualsNoCase(settingType, "action"))
     return new CSettingAction(settingId, (CSettingsManager*)this);
 

--- a/xbmc/settings/SettingsManager.h
+++ b/xbmc/settings/SettingsManager.h
@@ -276,6 +276,13 @@ public:
    \return String value of the setting with the given identifier
    */
   std::string GetString(const std::string &id) const;
+  /*!
+   \brief Gets the stringlist value of the setting with the given identifier.
+
+   \param id Setting identifier
+   \return String list value of the setting with the given identifier
+   */
+  std::vector<std::string> GetStringList(const std::string &id) const;
 
   /*!
    \brief Sets the boolean value of the setting with the given identifier.
@@ -316,6 +323,14 @@ public:
    \return True if setting the value was successful, false otherwise
    */
   bool SetString(const std::string &id, const std::string &value);
+  /*!
+   \brief Sets the stringlist value of the setting with the given identifier.
+
+   \param id Setting identifier
+   \param value String list value to set
+   \return True if setting the value was successful, false otherwise
+   */
+  bool SetStringList(const std::string &id, const std::vector<std::string> &value);
 
   /*!
    \brief Gets the setting conditions manager used by the settings manager.


### PR DESCRIPTION
Allows the multi-select dialog for settings.

Currently saves the settings as a pipe-separated string.  Could perhaps be configured in settings.xml?

Also used the string options filler, as that didn't currently check for fixing up the current item, so I just send it a dummy string.

(Obviously dummy setting is just there as an example).

@Montellese to review.
