### PR TITLE
changed: Extend Python/CApp GetCurrentFile to obtain Player's unstacked file

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5204,9 +5204,12 @@ void CApplication::Restart(bool bSamePosition)
     m_pPlayer->SetPlayerState(state);
 }
 
-const CStdString& CApplication::CurrentFile()
+const CStdString& CApplication::CurrentFile(bool unstacked /* = false */)
 {
-  return m_itemCurrentFile->GetPath();
+  if (unstacked && m_itemCurrentFile->IsStack() && m_currentStack->Size() > 0)
+    return (*m_currentStack)[m_currentStackPosition]->GetPath(); // Return the unstacked current file
+
+  return m_itemCurrentFile->GetPath(); // Return current (possibly stacked) file
 }
 
 CFileItem& CApplication::CurrentFileItem()

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -154,7 +154,7 @@ public:
   void UnloadSkin(bool forReload = false);
   bool LoadUserWindows();
   void ReloadSkin(bool confirm = false);
-  const CStdString& CurrentFile();
+  const CStdString& CurrentFile(bool unstacked = false);
   CFileItem& CurrentFileItem();
   virtual bool OnMessage(CGUIMessage& message);
   PLAYERCOREID GetCurrentPlayer();

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -317,13 +317,13 @@ namespace XBMCAddon
       return g_application.m_pPlayer->IsPlayingVideo();
     }
 
-    String Player::getPlayingFile() throw (PlayerException)
+    String Player::getPlayingFile(bool unstacked /* = false */) throw (PlayerException)
     {
       XBMC_TRACE;
       if (!g_application.m_pPlayer->IsPlaying())
         throw PlayerException("XBMC is not playing any file");
 
-      return g_application.CurrentFile();
+      return g_application.CurrentFile(unstacked);
     }
 
     InfoTagVideo* Player::getVideoInfoTag() throw (PlayerException)

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -224,7 +224,7 @@ namespace XBMCAddon
        * Throws: Exception, if player is not playing a file.
        */
       // Player_GetPlayingFile
-      String getPlayingFile() throw (PlayerException);
+      String getPlayingFile(bool unstacked = false) throw (PlayerException);
 
       /**
        * getTime() -- Returns the current time of the current playing media as fractional seconds.


### PR DESCRIPTION
This extension is especially useful for our subtitles addon which currently doesn't properly handle stacked file (it currently always uses the name of the first item in the stack to create the subtitles filename).

@Amet: PR for the subtitles addon will follow as soon as this has been merged
