### PR TITLE
[rbp/omxplayer] Fix stall on seek with deinterlace

### DIFF
--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -815,6 +815,8 @@ void COMXVideo::Reset(void)
 
   m_setStartTime = true;
   m_omx_decoder.FlushInput();
+  if(m_deinterlace)
+    m_omx_image_fx.FlushInput();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Need to flush image_fx input port when seeking - this got lost in #3397
