### PR TITLE
RegExp rework - part 05

### DIFF
--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -53,6 +53,11 @@ int CRegExp::m_JitSupported  = -1;
 
 CRegExp::CRegExp(bool caseless /*= false*/, bool utf8 /*= false*/)
 {
+  InitValues(caseless, utf8);
+}
+
+void CRegExp::InitValues(bool caseless /*= false*/, bool utf8 /*= false*/)
+{
   m_re          = NULL;
   m_sd          = NULL;
   m_iOptions    = PCRE_DOTALL | PCRE_NEWLINE_ANY;
@@ -73,6 +78,12 @@ CRegExp::CRegExp(bool caseless /*= false*/, bool utf8 /*= false*/)
   m_jitStack    = NULL;
 
   memset(m_iOvector, 0, sizeof(m_iOvector));
+}
+
+CRegExp::CRegExp(bool caseless, bool utf8, const char *re, studyMode study /*= NoStudy*/)
+{
+  InitValues(caseless, utf8);
+  RegComp(re, study);
 }
 
 CRegExp::CRegExp(const CRegExp& re)

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -50,6 +50,11 @@ public:
   };
 
   static const int m_MaxNumOfBackrefrences = 20;
+  /**
+   * @param caseless (optional) Matching will be case insensitive if set to true
+   *                            or case sensitive if set to false
+   * @param utf8 (optional) If set to true all string will be processed as UTF-8 strings 
+   */
   CRegExp(bool caseless = false, bool utf8 = false);
   CRegExp(const CRegExp& re);
   ~CRegExp();

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -56,6 +56,18 @@ public:
    * @param utf8 (optional) If set to true all string will be processed as UTF-8 strings 
    */
   CRegExp(bool caseless = false, bool utf8 = false);
+  /**
+   * Create new CRegExp object and compile regexp expression in one step
+   * @warning Use only with hardcoded regexp when you're sure that regexp is compiled without errors
+   * @param caseless    Matching will be case insensitive if set to true 
+   *                    or case sensitive if set to false
+   * @param utf8        If set to true all string will be processed as UTF-8 strings
+   * @param re          The regular expression
+   * @param study (optional) Controls study of expression, useful if expression will be used
+   *                         several times
+   */
+  CRegExp(bool caseless, bool utf8, const char *re, studyMode study = NoStudy);
+
   CRegExp(const CRegExp& re);
   ~CRegExp();
 
@@ -125,6 +137,7 @@ public:
 
 private:
   int PrivateRegFind(size_t bufferLen, const char *str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1);
+  void InitValues(bool caseless = false, bool utf8 = false);
 
   void Cleanup();
   inline bool IsValidSubNumber(int iSub) const;

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -129,6 +129,12 @@ public:
   bool GetNamedSubPattern(const char* strName, std::string& strMatch) const;
   int GetNamedSubPatternNumber(const char* strName) const;
   void DumpOvector(int iLog);
+  /**
+   * Check is RegExp object is ready for matching
+   * @return true if RegExp object is ready for matching, false otherwise
+   */
+  inline bool IsCompiled(void)
+  { return !m_pattern.empty(); }
   const CRegExp& operator= (const CRegExp& re);
   static bool IsUtf8Supported(void);
   static bool AreUnicodePropertiesSupported(void);

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -78,7 +78,23 @@ public:
   bool RegComp(const std::string& re, studyMode study = NoStudy)
   { return RegComp(re.c_str(), study); }
 
+  /**
+   * Find first match of regular expression in given string
+   * @param str         The string to match against regular expression
+   * @param startoffset (optional) The string offset to start matching
+   * @param maxNumberOfCharsToTest (optional) The maximum number of characters to test (match) in 
+   *                                          string. If set to -1 string checked up to the end.
+   * @return staring position of match in string, negative value in case of error or no match
+   */
   int RegFind(const char* str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1);
+  /**
+   * Find first match of regular expression in given string
+   * @param str         The string to match against regular expression
+   * @param startoffset (optional) The string offset to start matching
+   * @param maxNumberOfCharsToTest (optional) The maximum number of characters to test (match) in
+   *                                          string. If set to -1 string checked up to the end.
+   * @return staring position of match in string, negative value in case of error or no match
+   */
   int RegFind(const std::string& str, unsigned int startoffset = 0, int maxNumberOfCharsToTest = -1)
   { return PrivateRegFind(str.length(), str.c_str(), startoffset, maxNumberOfCharsToTest); }
   std::string GetReplaceString(const std::string& sReplaceExp) const;


### PR DESCRIPTION
This is a final part of PR #3223. (Other part are PRs #3433, #3434, #3435, #3442)

This PR add some doxy and constructor overload to create CRegExp object and compile regexp at the same time (most common scenario in XBMC code - create and immediately call RegComp, now it combined in one step).
