### PR TITLE
[Win32] fix relative paths, fixes #14812

### DIFF
--- a/xbmc/filesystem/windows/WINSMBDirectory.cpp
+++ b/xbmc/filesystem/windows/WINSMBDirectory.cpp
@@ -95,14 +95,11 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
 
   memset(&wfd, 0, sizeof(wfd));
   //rebuild the URL
-  std::string strUNCShare = "\\\\?\\UNC\\" + (std::string)url.GetHostName() + "\\" + URIUtils::FixSlashesAndDups(url.GetFileName(), '\\');
-  
-  if(!URIUtils::HasSlashAtEnd(strUNCShare))
-    strUNCShare.append("\\");
-
-  std::wstring strSearchMask;
-  g_charsetConverter.utf8ToW(strUNCShare, strSearchMask, false, false, true);
-  strSearchMask += L"*";
+  std::wstring strSearchMask(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)));
+  if (!strSearchMask.empty() && strSearchMask[strSearchMask.length() - 1] == '\\')
+    strSearchMask += L'*';
+  else
+    strSearchMask += L"\\*";
 
   FILETIME localTime;
   CAutoPtrFind hFind ( FindFirstFileW(strSearchMask.c_str(), &wfd));

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1059,6 +1059,39 @@ std::string URIUtils::FixSlashesAndDups(const std::string& path, const char slas
 }
 
 
+std::string URIUtils::CanonicalizePath(const std::string& path, const char slashCharacter /*= '\\'*/)
+{
+  assert(slashCharacter == '\\' || slashCharacter == '/');
+
+  if (path.empty())
+    return path;
+
+  const std::string slashStr(1, slashCharacter);
+  vector<std::string> pathVec, resultVec;
+  StringUtils::Tokenize(path, pathVec, slashStr);
+
+  for (vector<std::string>::const_iterator it = pathVec.begin(); it != pathVec.end(); ++it)
+  {
+    if (*it == ".")
+    { /* skip - do nothing */ }
+    else if (*it == ".." && !resultVec.empty() && resultVec.back() != "..")
+      resultVec.pop_back();
+    else
+      resultVec.push_back(*it);
+  }
+
+  std::string result;
+  if (path[0] == slashCharacter)
+    result.push_back(slashCharacter); // add slash at the begin
+
+  result += StringUtils::Join(resultVec, slashStr);
+
+  if (path[path.length() - 1] == slashCharacter  && !result.empty() && result[result.length() - 1] != slashCharacter)
+    result.push_back(slashCharacter); // add slash at the end if result isn't empty and result isn't "/"
+
+  return result;
+}
+
 CStdString URIUtils::AddFileToFolder(const CStdString& strFolder, 
                                 const CStdString& strFile)
 {

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -132,6 +132,18 @@ public:
   static void RemoveSlashAtEnd(std::string& strFolder);
   static bool CompareWithoutSlashAtEnd(const CStdString& strPath1, const CStdString& strPath2);
   static std::string FixSlashesAndDups(const std::string& path, const char slashCharacter = '/', const size_t startFrom = 0);
+  /**
+   * Convert path to form without duplicated slashes and without relative directories
+   * Strip duplicated slashes
+   * Resolve and remove relative directories ("/../" and "/./")
+   * Will ignore slashes with other direction than specified
+   * Will not resolve path starting from relative directory
+   * @warning Don't use with "protocol://path"-style URLs
+   * @param path string to process
+   * @param slashCharacter character to use as directory delimiter
+   * @return transformed path
+   */
+  static std::string CanonicalizePath(const std::string& path, const char slashCharacter = '\\');
 
   static void CreateArchivePath(CStdString& strUrlPath,
                                 const CStdString& strType,


### PR DESCRIPTION
As we are using win32 long path prefix '\\?\', windows don't preprocess filepaths, so any relative paths like "C:\Movies\MovieName\..\someFolder" are failed.
Some addons/skins are using it, so we need to support it properly.
