### PR TITLE
settings: custom setting controls

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -257,6 +257,9 @@
 		7C2612711825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
 		7C2612721825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
 		7C2612731825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
+		7C2612671820667C0086E04D /* ISettingControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2612631820667C0086E04D /* ISettingControl.cpp */; };
+		7C2612681820667C0086E04D /* ISettingControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2612631820667C0086E04D /* ISettingControl.cpp */; };
+		7C2612691820667C0086E04D /* ISettingControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2612631820667C0086E04D /* ISettingControl.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		7C4458BD161E203800A905F6 /* Screenshot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C4458BB161E203800A905F6 /* Screenshot.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
@@ -3699,6 +3702,10 @@
 		7C1F6EBA13ECCFA7001726AB /* LibraryDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryDirectory.h; sourceTree = "<group>"; };
 		7C26126F1825B6340086E04D /* DatabaseQuery.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseQuery.cpp; sourceTree = "<group>"; };
 		7C2612701825B6340086E04D /* DatabaseQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DatabaseQuery.h; sourceTree = "<group>"; };
+		7C2612631820667C0086E04D /* ISettingControl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISettingControl.cpp; sourceTree = "<group>"; };
+		7C2612641820667C0086E04D /* ISettingControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISettingControl.h; sourceTree = "<group>"; };
+		7C2612651820667C0086E04D /* ISettingControlCreator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISettingControlCreator.h; sourceTree = "<group>"; };
+		7C2612661820667C0086E04D /* SettingDefinitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingDefinitions.h; sourceTree = "<group>"; };
 		7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocol.cpp; sourceTree = "<group>"; };
 		7C2D6AE30F35453E00DD2E85 /* SpecialProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocol.h; sourceTree = "<group>"; };
 		7C4458BB161E203800A905F6 /* Screenshot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Screenshot.cpp; sourceTree = "<group>"; };
@@ -8548,6 +8555,9 @@
 				DFECFAEE172D9CAB00A43CF7 /* ISetting.cpp */,
 				DFECFAEF172D9CAB00A43CF7 /* ISetting.h */,
 				DFECFAF0172D9CAB00A43CF7 /* ISettingCallback.h */,
+				7C2612631820667C0086E04D /* ISettingControl.cpp */,
+				7C2612641820667C0086E04D /* ISettingControl.h */,
+				7C2612651820667C0086E04D /* ISettingControlCreator.h */,
 				DFECFAF1172D9CAB00A43CF7 /* ISettingCreator.h */,
 				DF8990141709BB2D00B35C21 /* ISettingsHandler.h */,
 				DF8990151709BB2D00B35C21 /* ISubSettings.h */,
@@ -8565,6 +8575,7 @@
 				DFECFAF9172D9CAB00A43CF7 /* SettingConditions.h */,
 				DFECFAFA172D9CAB00A43CF7 /* SettingControl.cpp */,
 				DFECFAFB172D9CAB00A43CF7 /* SettingControl.h */,
+				7C2612661820667C0086E04D /* SettingDefinitions.h */,
 				DFECFAFC172D9CAB00A43CF7 /* SettingDependency.cpp */,
 				DFECFAFD172D9CAB00A43CF7 /* SettingDependency.h */,
 				DFECFAFE172D9CAB00A43CF7 /* SettingPath.cpp */,
@@ -10656,6 +10667,7 @@
 				7C920CF9181669FF00DA1477 /* TextureOperations.cpp in Sources */,
 				DFEF0BAC180ADE6400AEAED1 /* FileItemListModification.cpp in Sources */,
 				DFEF0BC1180ADEDA00AEAED1 /* SmartPlaylistFileItemListModifier.cpp in Sources */,
+				7C2612671820667C0086E04D /* ISettingControl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11690,6 +11702,7 @@
 				7C920CFB181669FF00DA1477 /* TextureOperations.cpp in Sources */,
 				DFEF0BAE180ADE6400AEAED1 /* FileItemListModification.cpp in Sources */,
 				DFEF0BC3180ADEDA00AEAED1 /* SmartPlaylistFileItemListModifier.cpp in Sources */,
+				7C2612691820667C0086E04D /* ISettingControl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12726,6 +12739,7 @@
 				7C920CFA181669FF00DA1477 /* TextureOperations.cpp in Sources */,
 				DFEF0BAD180ADE6400AEAED1 /* FileItemListModification.cpp in Sources */,
 				DFEF0BC2180ADEDA00AEAED1 /* SmartPlaylistFileItemListModifier.cpp in Sources */,
+				7C2612681820667C0086E04D /* ISettingControl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -979,6 +979,7 @@
     <ClCompile Include="..\..\xbmc\settings\dialogs\GUIDialogSettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\DisplaySettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\ISetting.cpp" />
+    <ClCompile Include="..\..\xbmc\settings\ISettingControl.cpp" />
     <ClCompile Include="..\..\xbmc\settings\MediaSettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\MediaSourceSettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\Setting.cpp" />
@@ -1180,6 +1181,8 @@
     <ClInclude Include="..\..\xbmc\settings\DisplaySettings.h" />
     <ClInclude Include="..\..\xbmc\settings\ISetting.h" />
     <ClInclude Include="..\..\xbmc\settings\ISettingCallback.h" />
+    <ClInclude Include="..\..\xbmc\settings\ISettingControl.h" />
+    <ClInclude Include="..\..\xbmc\settings\ISettingControlCreator.h" />
     <ClInclude Include="..\..\xbmc\settings\ISettingCreator.h" />
     <ClInclude Include="..\..\xbmc\settings\ISettingsHandler.h" />
     <ClInclude Include="..\..\xbmc\settings\ISubSettings.h" />
@@ -1190,6 +1193,7 @@
     <ClInclude Include="..\..\xbmc\settings\SettingCategoryAccess.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingConditions.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingControl.h" />
+    <ClInclude Include="..\..\xbmc\settings\SettingDefinitions.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingDependency.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingPath.h" />
     <ClInclude Include="..\..\xbmc\settings\SettingSection.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3077,6 +3077,9 @@
       <Filter>playlists</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\FileItemListModification.cpp" />
+    <ClCompile Include="..\..\xbmc\settings\ISettingControl.cpp">
+      <Filter>settings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6043,6 +6046,15 @@
       <Filter>playlists</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\FileItemListModification.h" />
+    <ClInclude Include="..\..\xbmc\settings\ISettingControl.h">
+      <Filter>settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\settings\ISettingControlCreator.h">
+      <Filter>settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\settings\SettingDefinitions.h">
+      <Filter>settings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -9,12 +9,14 @@
           <constraints>
             <addontype>xbmc.gui.skin</addontype>
           </constraints>
+          <control type="button" format="addon" />
         </setting>
         <setting id="lookandfeel.skinsettings" type="action" parent="lookandfeel.skin" label="21417" help="36104">
           <level>0</level>
           <dependencies>
             <dependency type="enable" on="property" name="AddonHasSettings" setting="lookandfeel.skin" />
           </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="lookandfeel.skintheme" type="string" parent="lookandfeel.skin" label="15111" help="36105">
           <level>1</level>
@@ -91,6 +93,7 @@
         <setting id="lookandfeel.enablerssfeeds" type="boolean" label="13305" help="36111">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="lookandfeel.rssedit" type="string" parent="lookandfeel.enablerssfeeds" label="21450" help="36112">
           <level>1</level>
@@ -101,7 +104,9 @@
           <dependencies>
             <dependency type="enable" setting="lookandfeel.enablerssfeeds">true</dependency>
           </dependencies>
-          <control type="button" format="action" attributes="hide_value" />
+          <control type="button" format="action">
+            <hidevalue>true</hidevalue>
+          </control>
         </setting>
       </group>
     </category>
@@ -183,14 +188,17 @@
         <setting id="filelists.showparentdiritems" type="boolean" label="13306" help="36122">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="filelists.showextensions" type="boolean" label="497" help="36123">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="filelists.ignorethewhensorting" type="boolean" label="13399" help="36124">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="filelists.allowfiledeletion" type="boolean" label="14071" help="36125">
           <level>1</level>
@@ -203,6 +211,7 @@
               </or>
             </dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="filelists.showaddsourcebuttons" type="boolean" label="21382" help="36126">
           <level>1</level>
@@ -215,10 +224,12 @@
               </or>
             </dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="filelists.showhidden" type="boolean" label="21330" help="36127">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -234,6 +245,7 @@
           <updates>
             <update type="change" />
           </updates>
+          <control type="button" format="addon" />
         </setting>
         <setting id="screensaver.settings" parent="screensaver.mode" type="action" label="21417" help="36130">
           <level>0</level>
@@ -245,12 +257,14 @@
               </and>
             </dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="screensaver.preview" type="action" parent="screensaver.mode" label="1000" help="36131">
           <level>0</level>
           <dependencies>
             <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="screensaver.time" type="integer" label="355" help="36132">
           <level>0</level>
@@ -275,6 +289,7 @@
           <dependencies>
             <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="screensaver.usedimonpause" type="boolean" label="22014" help="36134">
           <level>1</level>
@@ -287,6 +302,7 @@
               </and>
             </dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -310,18 +326,22 @@
         <setting id="videolibrary.enabled" type="boolean" label="24022" help="36140">
           <level>4</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videolibrary.showunwatchedplots" type="boolean" label="20369" help="36141">
           <level>0</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videolibrary.seasonthumbs" type="boolean" label="20382" help="36142">
           <level>4</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videolibrary.actorthumbs" type="boolean" label="20402" help="36143">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videolibrary.flattentvshows" type="integer" label="20412" help="36144">
           <level>1</level>
@@ -338,25 +358,31 @@
         <setting id="videolibrary.groupmoviesets" type="boolean" label="20458" help="36145">
           <level>0</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="videolibrary.backgroundupdate" type="boolean" label="22001" help="36147">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
         <setting id="videolibrary.cleanup" type="action" label="334" help="36148">
           <level>2</level>
+          <control type="button" format="action" />
         </setting>
         <setting id="videolibrary.export" type="action" label="647" help="36149">
           <level>2</level>
+          <control type="button" format="action" />
         </setting>
         <setting id="videolibrary.import" type="action" label="648" help="36150">
           <level>2</level>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -365,6 +391,7 @@
         <setting id="videoplayer.autoplaynextitem" type="boolean" label="13433" help="36152">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -392,6 +419,7 @@
           <requirement>HAVE_LIBVDPAU</requirement>
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.usevdpaumixer" type="boolean" label="13437" help="36421">
           <requirement>HAVE_LIBVDPAU</requirement>
@@ -400,36 +428,43 @@
           <dependencies>
             <dependency type="enable" setting="videoplayer.usevdpau" operator="is">true</dependency> <!-- USE VDPAU -->
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.usevaapi" type="boolean" label="13426" help="36156">
           <requirement>HAVE_LIBVA</requirement>
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.usedxva2" type="boolean" label="13427" help="36158">
           <requirement>HasDXVA2</requirement>
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.usechd" type="boolean" label="13428" help="36159">
           <requirement>HasCrystalHDDevice</requirement>
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.useomx" type="boolean" label="13430" help="36161">
           <requirement>HAVE_LIBOPENMAX</requirement>
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.usevideotoolbox" type="boolean" label="13432" help="36162">
           <requirement>HasVideoToolBoxDecoder</requirement>
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.usepbo" type="boolean" label="13424" help="36163">
           <requirement>HAS_GL</requirement>
           <level>4</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.adjustrefreshrate" type="integer" label="170" help="36164">
           <level>2</level>
@@ -457,6 +492,7 @@
         <setting id="videoplayer.usedisplayasclock" type="boolean" label="13510" help="36166">
           <level>2</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.synctype" type="integer" label="13500" help="36167">
           <level>2</level>
@@ -520,6 +556,7 @@
           <requirement>HAVE_LIBVDPAU</requirement>
           <level>4</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="3">
@@ -535,16 +572,19 @@
         <setting id="videoplayer.vdpauUpscalingLevel" type="boolean" label="13121" help="36173">
           <level>4</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="4">
         <setting id="videoplayer.teletextenabled" type="boolean" label="23050" help="36174">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="videoplayer.teletextscale" type="boolean" label="23055" help="36175">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="5">
@@ -562,6 +602,7 @@
         <setting id="videoplayer.quitstereomodeonstop" type="boolean" label="36526" help="36538">
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -583,14 +624,17 @@
         <setting id="myvideos.extractflags" type="boolean" label="20433" help="36178">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="myvideos.replacelabels" type="boolean" label="20419" help="36179">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="myvideos.extractthumb" type="boolean" label="20433" help="36180">
           <level>4</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -601,10 +645,12 @@
         <setting id="myvideos.stackvideos" type="boolean" label="20435" help="36182">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="myvideos.flatten" type="boolean" label="20456" help="36183">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -681,6 +727,7 @@
         <setting id="subtitles.overrideassfonts" type="boolean" label="21368" help="36190">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -719,6 +766,7 @@
         <setting id="dvds.autorun" type="boolean" label="14088" help="36194">
           <level>0</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="dvds.playerregion" type="integer" label="21372" help="36195">
           <level>2</level>
@@ -733,6 +781,7 @@
         <setting id="dvds.automenu" type="boolean" label="21882" help="36196">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -772,20 +821,24 @@
         <setting id="pvrmanager.enabled" type="boolean" label="449" help="36203">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
         <setting id="pvrmanager.syncchannelgroups" type="boolean" label="19221" help="36204">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrmanager.backendchannelorder" type="boolean" label="19231" help="36205">
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrmanager.usebackendchannelnumbers" type="boolean" label="19234" help="36206">
           <level>2</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="3">
@@ -794,21 +847,25 @@
           <dependencies>
             <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="pvrmanager.channelscan" type="action" label="19117" help="36208">
           <level>1</level>
           <dependencies>
             <dependency type="enable" setting="pvrmanager.enabled">true</dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="pvrmanager.resetdb" type="action" label="19185" help="36209">
           <level>2</level>
+          <control type="button" format="action" />
         </setting>
       </group>
       <group id="4">
         <setting id="pvrmanager.hideconnectionlostwarning" type="boolean" label="19269" help="36210">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -817,14 +874,17 @@
         <setting id="pvrmenu.infoswitch" type="boolean" label="19178" help="36212">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrmenu.infotimeout" type="boolean" label="19179" help="36213">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrmenu.closechannelosdonswitch" type="boolean" label="19229" help="36214">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrmenu.infotime" type="integer" label="19184" help="36215">
           <level>1</level>
@@ -861,6 +921,7 @@
               </and>
             </dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -906,17 +967,21 @@
         <setting id="epg.preventupdateswhileplayingtv" type="boolean" label="19230" help="36222">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="epg.ignoredbforclient" type="boolean" label="19072" help="36223">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="epg.hidenoinfoavailable" type="boolean" label="19268" help="36224">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="epg.resetepg" type="action" label="19187" help="36225">
           <level>1</level>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -925,6 +990,7 @@
         <setting id="pvrplayback.playminimized" type="boolean" label="19171" help="36227">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrplayback.startlast" type="integer" label="19189" help="36228">
           <level>1</level>
@@ -940,6 +1006,7 @@
         <setting id="pvrplayback.signalquality" type="boolean" label="19037" help="36229">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -958,6 +1025,7 @@
         <setting id="pvrplayback.confirmchannelswitch" type="boolean" label="19281" help="36231">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrplayback.channelentrytimeout" type="integer" label="19073" help="36232">
           <level>1</level>
@@ -1038,6 +1106,7 @@
         <setting id="pvrrecord.timernotifications" type="boolean" label="19233" help="36239">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -1046,6 +1115,7 @@
         <setting id="pvrpowermanagement.enabled" type="boolean" label="305" help="36241">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -1086,6 +1156,7 @@
         <setting id="pvrpowermanagement.dailywakeup" type="boolean" label="19247" help="36245">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="pvrpowermanagement.dailywakeuptime" type="string" label="19248" help="36246">
           <level>1</level>
@@ -1100,6 +1171,7 @@
         <setting id="pvrparental.enabled" type="boolean" label="449" help="36248">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -1112,7 +1184,10 @@
           <dependencies>
             <dependency type="enable" setting="pvrparental.enabled">true</dependency>
           </dependencies>
-          <control type="edit" format="integer" attributes="hidden,new" delayed="false" />
+          <control type="edit" format="integer" delayed="false">
+            <hidden>true</hidden>
+            <verifynew>true</verifynew>
+          </control>
         </setting>
         <setting id="pvrparental.duration" type="integer" label="19260" help="36250">
           <level>1</level>
@@ -1135,6 +1210,7 @@
       <group id="1">
         <setting id="pvrclient.menuhook" type="action" label="19280" help="36252">
           <level>1</level>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -1145,16 +1221,19 @@
         <setting id="musiclibrary.enabled" type="boolean" label="24022" help="36254">
           <level>4</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="musiclibrary.showcompilationartists" type="boolean" label="13414" help="36255">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
         <setting id="musiclibrary.downloadinfo" type="boolean" label="20192" help="36256">
           <level>0</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="musiclibrary.albumsscraper" type="addon" label="20193" help="36257">
           <level>1</level>
@@ -1162,6 +1241,7 @@
           <constraints>
             <addontype>xbmc.metadata.scraper.albums</addontype>
           </constraints>
+          <control type="button" format="addon" />
         </setting>
         <setting id="musiclibrary.artistsscraper" type="addon" label="20194" help="36258">
           <level>1</level>
@@ -1169,25 +1249,31 @@
           <constraints>
             <addontype>xbmc.metadata.scraper.artists</addontype>
           </constraints>
+          <control type="button" format="addon" />
         </setting>
         <setting id="musiclibrary.updateonstartup" type="boolean" label="22000" help="36259">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="musiclibrary.backgroundupdate" type="boolean" label="22001" help="36147">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="3">
         <setting id="musiclibrary.cleanup" type="action" label="334" help="36148">
           <level>2</level>
+          <control type="button" format="action" />
         </setting>
         <setting id="musiclibrary.export" type="action" label="20196" help="36262">
           <level>2</level>
+          <control type="button" format="action" />
         </setting>
         <setting id="musiclibrary.import" type="action" label="20197" help="36263">
           <level>2</level>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -1196,10 +1282,12 @@
         <setting id="musicplayer.autoplaynextitem" type="boolean" label="489" help="36265">
           <level>0</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="musicplayer.queuebydefault" type="boolean" label="14084" help="36266">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -1242,6 +1330,7 @@
         <setting id="musicplayer.replaygainavoidclipping" type="boolean" label="643" help="36270">
           <level>2</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="3">
@@ -1267,6 +1356,7 @@
               </and>
             </dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="4">
@@ -1277,6 +1367,7 @@
             <addontype>xbmc.player.musicviz</addontype>
             <allowempty>true</allowempty>
           </constraints>
+          <control type="button" format="addon" />
         </setting>
       </group>
     </category>
@@ -1285,6 +1376,7 @@
         <setting id="musicfiles.usetags" type="boolean" label="258" help="36274">
           <level>0</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="musicfiles.trackformat" type="string" label="13307" help="36275">
           <level>2</level>
@@ -1343,6 +1435,7 @@
         <setting id="musicfiles.findremotethumbs" type="boolean" label="14059" help="36281">
           <level>0</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -1359,6 +1452,7 @@
         <setting id="audiocds.usecddb" type="boolean" label="227" help="36284">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -1445,6 +1539,7 @@
         <setting id="audiocds.ejectonrip" type="boolean" label="14099" help="36291">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -1454,6 +1549,7 @@
         <setting id="karaoke.enabled" type="boolean" label="13323" help="36293">
           <level>2</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="karaoke.autopopupselector" type="boolean" label="22037" help="36294">
           <level>2</level>
@@ -1461,6 +1557,7 @@
           <dependencies>
             <dependency type="enable" setting="karaoke.enabled">true</dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -1523,12 +1620,14 @@
           <dependencies>
             <dependency type="enable" setting="karaoke.enabled">true</dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="karaoke.importcsv" type="action" label="22036" help="36300">
           <level>2</level>
           <dependencies>
             <dependency type="enable" setting="karaoke.enabled">true</dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -1558,18 +1657,22 @@
         <setting id="pictures.usetags" type="boolean" label="14082" help="36306">
           <level>0</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pictures.generatethumbs" type="boolean" label="13360" help="36307">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pictures.useexifrotation" type="boolean" label="20184" help="36308">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pictures.showvideos" type="boolean" label="22022" help="36309">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="pictures.displayresolution" type="integer" label="169" help="36310">
           <visible>false</visible> <!-- not properly respected -->
@@ -1599,10 +1702,12 @@
         <setting id="slideshow.displayeffects" type="boolean" label="12379" help="36313">
           <level>0</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="slideshow.shuffle" type="boolean" label="13319" help="36314">
           <level>2</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -1622,12 +1727,14 @@
             <addontype>xbmc.python.weather</addontype>
             <allowempty>true</allowempty>
           </constraints>
+          <control type="button" format="addon" />
         </setting>
         <setting id="weather.addonsettings" type="action" parent="weather.addon" label="21417" help="36419">
           <level>0</level>
           <dependencies>
             <dependency type="enable" on="property" name="AddonHasSettings" setting="weather.addon" />
           </dependencies>
+          <control type="button" format="action" />
         </setting>
       </group>
     </category>
@@ -1647,6 +1754,7 @@
         <setting id="services.upnpserver" type="boolean" label="21360" help="36323">
           <level>0</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="services.upnpannounce" type="boolean" label="20188" help="36324">
           <level>2</level>
@@ -1654,14 +1762,17 @@
           <dependencies>
             <dependency type="enable" setting="services.upnpserver">true</dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="services.upnprenderer" type="boolean" label="21881" help="36325">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="services.upnpcontroller" type="boolean" label="21361" help="36326">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -1671,6 +1782,7 @@
         <setting id="services.webserver" type="boolean" label="263" help="36328">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="services.webserverport" type="integer" parent="services.webserver" label="730" help="36329">
           <level>2</level>
@@ -1702,7 +1814,9 @@
           <dependencies>
             <dependency type="enable" setting="services.webserver">true</dependency>
           </dependencies>
-          <control type="edit" format="string" attributes="hidden" />
+          <control type="edit" format="string">
+            <hidden>true</hidden>
+          </control>
         </setting>
         <setting id="services.webskin" type="addon" label="199" help="36332">
           <level>1</level>
@@ -1710,6 +1824,7 @@
           <constraints>
             <addontype>xbmc.gui.webinterface</addontype>
           </constraints>
+          <control type="button" format="addon" />
         </setting>
       </group>
     </category>
@@ -1724,6 +1839,7 @@
         <setting id="services.esenabled" type="boolean" label="791" help="36334">
           <level>1</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="services.esport" type="integer" label="792" help="36335">
           <requirement>HAS_EVENT_SERVER</requirement>
@@ -1773,6 +1889,7 @@
           <dependencies>
             <dependency type="enable" setting="services.esenabled">true</dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="services.esinitialdelay" type="integer" label="795" help="36339">
           <requirement>HAS_EVENT_SERVER</requirement>
@@ -1810,6 +1927,7 @@
         <setting id="services.zeroconf" type="boolean" label="1260" help="36342">
           <level>2</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -1819,6 +1937,7 @@
         <setting id="services.airplay" type="boolean" label="1270" help="36343">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="services.airplayvolumecontrol" type="boolean" parent="services.airplay" label="1269" help="36541">
           <level>2</level>
@@ -1826,6 +1945,7 @@
           <dependencies>
             <dependency type="enable" setting="services.airplay">true</dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="services.useairplaypassword" type="boolean" parent="services.airplay" label="1272" help="36344">
           <level>1</level>
@@ -1833,6 +1953,7 @@
           <dependencies>
             <dependency type="enable" setting="services.airplay">true</dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="services.airplaypassword" type="string" parent="services.useairplaypassword" label="733" help="36345">
           <level>1</level>
@@ -1843,7 +1964,9 @@
           <dependencies>
             <dependency type="enable" setting="services.useairplaypassword">true</dependency>
           </dependencies>
-          <control type="edit" format="string" attributes="hidden" />
+          <control type="edit" format="string">
+            <hidden>true</hidden>
+          </control>
         </setting>
       </group>
     </category>
@@ -1912,6 +2035,7 @@
           <dependencies>
             <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="videoscreen.blankdisplays" type="boolean" label="13130" help="36355">
           <level>1</level>
@@ -1919,6 +2043,7 @@
           <dependencies>
             <dependency type="enable" on="property" name="IsFullscreen" />
           </dependencies>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -1950,10 +2075,12 @@
         </setting>
         <setting id="videoscreen.guicalibration" type="action" label="214" help="36357">
           <level>1</level>
+          <control type="button" format="action" />
         </setting>
         <setting id="videoscreen.testpattern" type="action" label="226" help="36358">
           <requirement>HAS_GL</requirement>
           <level>1</level>
+          <control type="button" format="action" />
         </setting>
         <setting id="videoscreen.limitedrange" type="boolean" label="36042" help="36359">
           <requirement>
@@ -1967,6 +2094,7 @@
           <updates>
             <update type="rename">videoplayer.vdpaustudiolevel</update>
           </updates>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -2023,7 +2151,7 @@
                 <condition on="property" name="aesettingvisible" setting="audiooutput.audiodevice">audiooutput.samplerate</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.samplerate</condition>
               </and>
-            </dependency>  
+            </dependency>
           </dependencies>
           <constraints>
             <options>
@@ -2042,6 +2170,7 @@
           <dependencies>
             <dependency type="visible" setting="audiooutput.channels" operator="!is">1</dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="audiooutput.processquality" type="integer" label="13505" help="36169">
           <requirement>HAS_AE_QUALITY_LEVELS</requirement>
@@ -2087,6 +2216,7 @@
               </and>
             </dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="audiooutput.passthroughdevice" type="string" label="546" help="36372">
           <level>2</level>
@@ -2104,7 +2234,7 @@
             <options>audiodevicespassthrough</options>
           </constraints>
           <control type="list" format="string" />
-        </setting>        
+        </setting>
         <setting id="audiooutput.ac3passthrough" type="boolean" label="364" help="36365">
           <level>2</level>
           <default>true</default>
@@ -2116,6 +2246,7 @@
               </and>
             </dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="audiooutput.eac3passthrough" type="boolean" label="448" help="37016">
           <level>2</level>
@@ -2127,7 +2258,8 @@
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
               </and>
             </dependency>
-          </dependencies>      
+          </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="audiooutput.dtspassthrough" type="boolean" label="254" help="36366">
           <level>2</level>
@@ -2139,7 +2271,8 @@
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
               </and>
             </dependency>
-          </dependencies>       
+          </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="audiooutput.truehdpassthrough" type="boolean" label="349" help="36369">
           <level>2</level>
@@ -2152,7 +2285,8 @@
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthroughdevice">audiooutput.truehdpassthrough</condition>
               </and>
             </dependency>
-          </dependencies>      
+          </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="audiooutput.dtshdpassthrough" type="boolean" label="347" help="36370">
           <level>2</level>
@@ -2165,7 +2299,8 @@
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthroughdevice">audiooutput.dtshdpassthrough</condition>
               </and>
             </dependency>
-          </dependencies>      
+          </dependencies>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -2176,21 +2311,25 @@
           <dependencies>
             <dependency type="enable" on="property" name="HasPeripherals" />
           </dependencies>
+          <control type="button" format="action" />
         </setting>
       </group>
       <group id="2">
         <setting id="input.remoteaskeyboard" type="boolean" label="21449" help="36376">
           <level>2</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="input.enablemouse" type="boolean" label="21369" help="36377">
           <level>0</level>
+          <control type="toggle" />
           <default>true</default>
         </setting>
         <setting id="input.enablejoystick" type="boolean" label="35100" help="36378">
           <requirement>HAS_SDL_JOYSTICK</requirement>
           <level>0</level>
           <default>true</default>
+          <control type="toggle" />
         </setting>
         <setting id="input.enablesystemkeys" type="boolean" label="35103" help="37019">
           <and>
@@ -2199,6 +2338,7 @@
           </and>
           <level>2</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -2207,6 +2347,7 @@
         <setting id="network.usehttpproxy" type="boolean" label="708" help="36380">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="network.httpproxytype" type="integer" parent="network.usehttpproxy" label="1180" help="36381">
           <level>1</level>
@@ -2269,7 +2410,9 @@
           <dependencies>
             <dependency type="enable" setting="network.usehttpproxy">true</dependency>
           </dependencies>
-          <control type="edit" format="string" attributes="hidden" />
+          <control type="edit" format="string">
+            <hidden>true</hidden>
+          </control>
         </setting>
       </group>
       <group id="2">
@@ -2326,6 +2469,7 @@
         <setting id="powermanagement.wakeonaccess" type="boolean" label="13026" help="36350">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -2334,12 +2478,14 @@
         <setting id="debug.showloginfo" type="boolean" label="20191" help="36392">
           <level>1</level>
           <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="debug.setextraloglevel" type="action" parent="debug.showloginfo" label="666" help="36394">
           <level>1</level>
           <dependencies>
             <dependency type="enable" setting="debug.showloginfo">true</dependency>
           </dependencies>
+          <control type="button" format="action" />
         </setting>
         <setting id="debug.screenshotpath" type="path" label="20004" help="36261">
           <level>1</level>
@@ -2359,7 +2505,9 @@
         <setting id="masterlock.lockcode" type="string" label="20100" help="36396">
           <level>2</level>
           <default>-</default>
-          <control type="button" format="action" attributes="hide_value"/>
+          <control type="button" format="action">
+            <hidevalue>true</hidevalue>
+          </control>
         </setting>
         <setting id="masterlock.startuplock" type="boolean" label="20076" help="36397">
           <level>2</level>
@@ -2367,6 +2515,7 @@
           <dependencies>
             <dependency type="enable" on="property" name="ProfileLockMode" operator="!is">0</dependency>
           </dependencies>
+          <control type="toggle" />
         </setting>
         <setting id="masterlock.maxretries" type="integer" label="12364" help="36398">
           <level>4</level>

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -493,8 +493,7 @@ void CPeripherals::GetSettingsFromMappingsFile(TiXmlElement *xmlNode, map<CStdSt
       int iMin   = currentNode->Attribute("min") ? atoi(currentNode->Attribute("min")) : 0;
       int iStep  = currentNode->Attribute("step") ? atoi(currentNode->Attribute("step")) : 1;
       int iMax   = currentNode->Attribute("max") ? atoi(currentNode->Attribute("max")) : 255;
-      CStdString strFormat(currentNode->Attribute("format"));
-      setting = new CSettingInt(strKey, iLabelId, iValue, iMin, iStep, iMax, strFormat);
+      setting = new CSettingInt(strKey, iLabelId, iValue, iMin, iStep, iMax);
     }
     else if (strSettingsType.Equals("float"))
     {

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -97,12 +97,12 @@ void CGUIDialogPeripheralSettings::CreateSettings()
             CSettingInt *intSetting = (CSettingInt *) setting;
             if (intSetting)
             {
-              if (intSetting->GetControl().GetFormat() == SettingControlFormatInteger)
+              if (intSetting->GetControl()->GetFormat() == "integer")
               {
                 m_intSettings.insert(make_pair(CStdString(intSetting->GetId()), (float) intSetting->GetValue()));
                 AddSlider(m_settingId++, intSetting->GetLabel(), &m_intSettings[intSetting->GetId()], (float)intSetting->GetMinimum(), (float)intSetting->GetStep(), (float)intSetting->GetMaximum(), CGUIDialogVideoSettings::FormatInteger, false);
               }
-              else if (intSetting->GetControl().GetFormat() == SettingControlFormatString)
+              else if (intSetting->GetControl()->GetFormat() == "string")
               {
                 m_intTextSettings.insert(make_pair(CStdString(intSetting->GetId()), intSetting->GetValue()));
                 vector<pair<int, int> > entries;

--- a/xbmc/settings/ISetting.cpp
+++ b/xbmc/settings/ISetting.cpp
@@ -19,13 +19,10 @@
  */
 
 #include "ISetting.h"
+#include "SettingDefinitions.h"
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
-
-#define XML_VISIBLE     "visible"
-#define XML_REQUIREMENT "requirement"
-#define XML_CONDITION   "condition"
 
 using namespace std;
 
@@ -43,10 +40,10 @@ bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
     return false;
 
   bool value;
-  if (XMLUtils::GetBoolean(node, XML_VISIBLE, value))
+  if (XMLUtils::GetBoolean(node, SETTING_XML_ELM_VISIBLE, value))
     m_visible = value;
 
-  const TiXmlNode *requirementNode = node->FirstChild(XML_REQUIREMENT);
+  const TiXmlNode *requirementNode = node->FirstChild(SETTING_XML_ELM_REQUIREMENT);
   if (requirementNode == NULL)
     return true;
 
@@ -62,7 +59,7 @@ bool ISetting::DeserializeIdentification(const TiXmlNode *node, std::string &ide
   if (element == NULL)
     return false;
 
-  const char *idAttribute = element->Attribute(XML_ATTR_ID);
+  const char *idAttribute = element->Attribute(SETTING_XML_ATTR_ID);
   if (idAttribute == NULL || strlen(idAttribute) <= 0)
     return false;
 

--- a/xbmc/settings/ISetting.h
+++ b/xbmc/settings/ISetting.h
@@ -23,13 +23,6 @@
 
 #include "SettingRequirement.h"
 
-#define XML_SETTING     "setting"
-
-#define XML_ATTR_ID     "id"
-#define XML_ATTR_LABEL  "label"
-#define XML_ATTR_HELP   "help"
-#define XML_ATTR_TYPE   "type"
-
 class CSettingsManager;
 class TiXmlNode;
 

--- a/xbmc/settings/ISettingControl.cpp
+++ b/xbmc/settings/ISettingControl.cpp
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ISettingControl.h"
+#include "SettingDefinitions.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+
+bool ISettingControl::Deserialize(const TiXmlNode *node, bool update /* = false */)
+{
+  if (node == NULL)
+    return false;
+
+  const TiXmlElement *elem = node->ToElement();
+  if (elem == NULL)
+    return false;
+
+  const char *strTmp = elem->Attribute(SETTING_XML_ATTR_FORMAT);
+  std::string format;
+  if (strTmp != NULL)
+    format = strTmp;
+  if (!SetFormat(format))
+  {
+    CLog::Log(LOGERROR, "ISettingControl: error reading \"format\" attribute of <control>");
+    return false;
+  }
+
+  if ((strTmp = elem->Attribute(SETTING_XML_ATTR_DELAYED)) != NULL)
+  {
+    if (!StringUtils::EqualsNoCase(strTmp, "false") && !StringUtils::EqualsNoCase(strTmp, "true"))
+    {
+      CLog::Log(LOGERROR, "ISettingControl: error reading \"delayed\" attribute of <control>");
+      return false;
+    }
+    else
+      m_delayed = StringUtils::EqualsNoCase(strTmp, "true");
+  }
+
+  return true;
+}

--- a/xbmc/settings/ISettingControl.h
+++ b/xbmc/settings/ISettingControl.h
@@ -1,0 +1,45 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+class TiXmlNode;
+
+class ISettingControl
+{
+public:
+  ISettingControl()
+    : m_delayed(false)
+  { }
+  virtual ~ISettingControl() { }
+
+  virtual std::string GetType() const = 0;
+  const std::string& GetFormat() const { return m_format; }
+  bool GetDelayed() const { return m_delayed; }
+
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+
+protected:
+  virtual bool SetFormat(const std::string &format) { return true; }
+
+  bool m_delayed;
+  std::string m_format;
+};

--- a/xbmc/settings/ISettingControlCreator.h
+++ b/xbmc/settings/ISettingControlCreator.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+class ISettingControl;
+
+/*!
+ \ingroup settings
+ \brief Interface for creating a new setting control of a custom setting control type.
+ */
+class ISettingControlCreator
+{
+public:
+  virtual ~ISettingControlCreator() { }
+
+  /*!
+   \brief Creates a new setting control of the given custom setting control type.
+
+   \param controlType string representation of the setting control type
+   \return A new setting control object of the given (custom) setting control type or NULL if the setting control type is unknown
+   */
+  virtual ISettingControl* CreateControl(const std::string &controlType) const = 0;
+};

--- a/xbmc/settings/Makefile
+++ b/xbmc/settings/Makefile
@@ -1,6 +1,7 @@
 SRCS=AdvancedSettings.cpp \
      DisplaySettings.cpp \
      ISetting.cpp \
+     ISettingControl.cpp \
      MediaSettings.cpp \
      MediaSourceSettings.cpp \
      Setting.cpp \

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -26,7 +26,7 @@
 
 #include "ISetting.h"
 #include "ISettingCallback.h"
-#include "SettingControl.h"
+#include "ISettingControl.h"
 #include "SettingDependency.h"
 #include "SettingUpdate.h"
 #include "threads/SharedSection.h"
@@ -80,7 +80,7 @@ class CSetting : public ISetting,
 public:
   CSetting(const std::string &id, CSettingsManager *settingsManager = NULL);
   CSetting(const std::string &id, const CSetting &setting);
-  virtual ~CSetting() { }
+  virtual ~CSetting();
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 
@@ -98,7 +98,8 @@ public:
   bool IsEnabled() const;
   const std::string& GetParent() const { return m_parentSetting; }
   SettingLevel GetLevel() const { return m_level; }
-  const CSettingControl& GetControl() const { return m_control; }
+  const ISettingControl* GetControl() const { return m_control; }
+  void SetControl(ISettingControl* control) { m_control = control; }
   const SettingDependencies& GetDependencies() const { return m_dependencies; }
   const std::set<CSettingUpdate>& GetUpdates() const { return m_updates; }
 
@@ -121,7 +122,7 @@ protected:
   int m_help;
   std::string m_parentSetting;
   SettingLevel m_level;
-  CSettingControl m_control;
+  ISettingControl *m_control;
   SettingDependencies m_dependencies;
   std::set<CSettingUpdate> m_updates;
   bool m_changed;
@@ -175,8 +176,7 @@ class CSettingInt : public CSetting
 public:
   CSettingInt(const std::string &id, CSettingsManager *settingsManager = NULL);
   CSettingInt(const std::string &id, const CSettingInt &setting);
-  CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, int format, int minimumLabel, CSettingsManager *settingsManager = NULL);
-  CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, const std::string &format, CSettingsManager *settingsManager = NULL);
+  CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, CSettingsManager *settingsManager = NULL);
   CSettingInt(const std::string &id, int label, int value, const StaticIntegerSettingOptions &options, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingInt() { }
 
@@ -199,9 +199,6 @@ public:
   int GetStep() const { return m_step; }
   int GetMaximum() const { return m_max; }
 
-  int GetFormat() const { return m_format; }
-  int GetMinimumLabel() const { return m_labelMin; }
-  const std::string& GetFormatString() const { return m_strFormat; }
   SettingOptionsType GetOptionsType() const;
   const StaticIntegerSettingOptions& GetOptions() const { return m_options; }
   const std::string& GetOptionsFiller() const { return m_optionsFiller; }
@@ -216,9 +213,6 @@ private:
   int m_min;
   int m_step;
   int m_max;
-  int m_format;
-  int m_labelMin;
-  std::string m_strFormat;
   StaticIntegerSettingOptions m_options;
   std::string m_optionsFiller;
   DynamicIntegerSettingOptions m_dynamicOptions;
@@ -295,7 +289,6 @@ public:
   virtual void SetDefault(const std::string &value);
 
   virtual bool AllowEmpty() const { return m_allowEmpty; }
-  virtual int GetHeading() const { return m_heading; }
 
   SettingOptionsType GetOptionsType() const;
   const std::string& GetOptionsFiller() const { return m_optionsFiller; }
@@ -307,7 +300,6 @@ protected:
   std::string m_value;
   std::string m_default;
   bool m_allowEmpty;
-  int m_heading;
   std::string m_optionsFiller;
   DynamicStringSettingOptions m_dynamicOptions;
 };

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -30,11 +30,7 @@
 CSettingAddon::CSettingAddon(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : CSettingString(id, settingsManager),
     m_addonType(ADDON::ADDON_UNKNOWN)
-{
-  m_control.SetType(SettingControlTypeButton);
-  m_control.SetFormat(SettingControlFormatAddon);
-  m_control.SetAttributes(SettingControlAttributeNone);
-}
+{ }
   
 CSettingAddon::CSettingAddon(const std::string &id, const CSettingAddon &setting)
   : CSettingString(id, setting)
@@ -49,9 +45,8 @@ bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */
   if (!CSettingString::Deserialize(node, update))
     return false;
     
-  if (m_control.GetType() != SettingControlTypeButton ||
-      m_control.GetFormat() != SettingControlFormatAddon ||
-      m_control.GetAttributes() != SettingControlAttributeNone)
+  if (m_control != NULL &&
+     (m_control->GetType() != "button" || m_control->GetFormat() != "addon"))
   {
     CLog::Log(LOGERROR, "CSettingAddon: invalid <control> of \"%s\"", m_id.c_str());
     return false;

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "SettingConditions.h"
+#include "SettingDefinitions.h"
 #include "SettingsManager.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -33,12 +34,12 @@ bool CSettingConditionItem::Deserialize(const TiXmlNode *node)
     return false;
 
   // get the "name" attribute
-  const char *strAttribute = elem->Attribute("name");
+  const char *strAttribute = elem->Attribute(SETTING_XML_ATTR_NAME);
   if (strAttribute != NULL)
     m_name = strAttribute;
 
   // get the "setting" attribute
-  strAttribute = elem->Attribute("setting");
+  strAttribute = elem->Attribute(SETTING_XML_ATTR_SETTING);
   if (strAttribute != NULL)
     m_setting = strAttribute;
 

--- a/xbmc/settings/SettingConditions.h
+++ b/xbmc/settings/SettingConditions.h
@@ -23,6 +23,7 @@
 #include <set>
 #include <string>
 
+#include "SettingDefinitions.h"
 #include "utils/BooleanLogic.h"
 
 class CSettingsManager;
@@ -52,7 +53,7 @@ public:
   virtual ~CSettingConditionItem() { }
   
   virtual bool Deserialize(const TiXmlNode *node);
-  virtual const char* GetTag() const { return "condition"; }
+  virtual const char* GetTag() const { return SETTING_XML_ELM_CONDITION; }
   virtual bool Check() const;
 
 protected:

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -21,117 +21,143 @@
 #include <vector>
 
 #include "SettingControl.h"
+#include "settings/SettingDefinitions.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
 
-bool CSettingControl::Deserialize(const TiXmlNode *node, bool update /* = false */)
+bool CSettingControlCheckmark::SetFormat(const std::string &format)
 {
-  if (node == NULL)
+  return format.empty() || StringUtils::EqualsNoCase(format, "boolean");
+}
+
+bool CSettingControlSpinner::Deserialize(const TiXmlNode *node, bool update /* = false */)
+{
+  if (!ISettingControl::Deserialize(node, update))
     return false;
 
-  const TiXmlElement *elem = node->ToElement();
-  if (elem == NULL)
-    return false;
-
-  const char *strTmp = elem->Attribute("type");
-  if ((strTmp == NULL && !update && m_type == SettingControlTypeNone) || (strTmp != NULL && !setType(strTmp)))
+  if (m_format == "string")
   {
-    CLog::Log(LOGERROR, "CSetting: error reading \"type\" attribute of <control>");
-    return false;
-  }
+    XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_FORMATLABEL, m_formatLabel);
 
-  strTmp = elem->Attribute("format");
-  if ((strTmp == NULL && !update && m_format == SettingControlFormatNone) || (strTmp != NULL && !setFormat(strTmp)))
-  {
-    CLog::Log(LOGERROR, "CSetting: error reading \"format\" attribute of <control>");
-    return false;
-  }
-
-  if ((strTmp = elem->Attribute("attributes")) != NULL && !setAttributes(strTmp))
-  {
-    CLog::Log(LOGERROR, "CSetting: error reading \"attributes\" attribute of <control>");
-    return false;
-  }
-
-  if ((strTmp = elem->Attribute("delayed")) != NULL)
-  {
-    if (!StringUtils::EqualsNoCase(strTmp, "false") && !StringUtils::EqualsNoCase(strTmp, "true"))
+    // get the minimum label from <setting><constraints><minimum label="X" />
+    const TiXmlNode *settingNode = node->Parent();
+    if (settingNode != NULL)
     {
-      CLog::Log(LOGERROR, "CSetting: error reading \"delayed\" attribute of <control>");
-      return false;
+      const TiXmlNode *contraintsNode = settingNode->FirstChild(SETTING_XML_ELM_CONSTRAINTS);
+      if (contraintsNode != NULL)
+      {
+        const TiXmlNode *minimumNode = contraintsNode->FirstChild(SETTING_XML_ELM_MINIMUM);
+        if (minimumNode != NULL)
+        {
+          const TiXmlElement *minimumElem = minimumNode->ToElement();
+          if (minimumElem != NULL)
+          {
+            if (minimumElem->QueryIntAttribute(SETTING_XML_ATTR_LABEL, &m_minimumLabel) != TIXML_SUCCESS)
+              m_minimumLabel = -1;
+          }
+        }
+      }
     }
-    else
-      m_delayed = StringUtils::EqualsNoCase(strTmp, "true");
+
+    if (m_minimumLabel < 0)
+    {
+      std::string strFormat;
+      if (XMLUtils::GetString(node, SETTING_XML_ATTR_FORMAT, strFormat) && !strFormat.empty())
+        m_formatString = strFormat;
+    }
   }
+
+  return true;
+}
+
+bool CSettingControlSpinner::SetFormat(const std::string &format)
+{
+  if (!StringUtils::EqualsNoCase(format, "string") &&
+      !StringUtils::EqualsNoCase(format, "integer") &&
+      !StringUtils::EqualsNoCase(format, "number"))
+    return false;
+
+  m_format = format;
+  StringUtils::ToLower(m_format);
+
+  return true;
+}
+
+bool CSettingControlEdit::Deserialize(const TiXmlNode *node, bool update /* = false */)
+{
+  if (!ISettingControl::Deserialize(node, update))
+    return false;
+
+  XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_HIDDEN, m_hidden);
+  XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_VERIFYNEW, m_verifyNewValue);
+  XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
+
+  return true;
+}
+
+bool CSettingControlEdit::SetFormat(const std::string &format)
+{
+  if (!StringUtils::EqualsNoCase(format, "string") &&
+      !StringUtils::EqualsNoCase(format, "integer") &&
+      !StringUtils::EqualsNoCase(format, "number") &&
+      !StringUtils::EqualsNoCase(format, "ip") &&
+      !StringUtils::EqualsNoCase(format, "md5") &&
+      !StringUtils::EqualsNoCase(format, "path")) // TODO
+    return false;
+
+  m_format = format;
+  StringUtils::ToLower(m_format);
+
+  return true;
+}
+
+bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = false */)
+{
+  if (!ISettingControl::Deserialize(node, update))
+    return false;
   
+  XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
+  XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_HIDEVALUE, m_hideValue);
+
   return true;
 }
 
-bool CSettingControl::setType(const std::string &strType)
+bool CSettingControlButton::SetFormat(const std::string &format)
 {
-  if (StringUtils::EqualsNoCase(strType, "toggle"))
-    m_type = SettingControlTypeCheckmark;
-  else if (StringUtils::EqualsNoCase(strType, "spinner"))
-    m_type = SettingControlTypeSpinner;
-  else if (StringUtils::EqualsNoCase(strType, "edit"))
-  {
-    m_type = SettingControlTypeEdit;
-    m_delayed = true;
-  }
-  else if (StringUtils::EqualsNoCase(strType, "list"))
-    m_type = SettingControlTypeList;
-  else if (StringUtils::EqualsNoCase(strType, "button"))
-    m_type = SettingControlTypeButton;
-  else
+  if (!StringUtils::EqualsNoCase(format, "string") &&  // TODO
+      !StringUtils::EqualsNoCase(format, "integer") &&  // TODO
+      !StringUtils::EqualsNoCase(format, "number") &&  // TODO
+      !StringUtils::EqualsNoCase(format, "path") &&
+      !StringUtils::EqualsNoCase(format, "addon") &&  // TODO
+      !StringUtils::EqualsNoCase(format, "action"))
     return false;
 
+  m_format = format;
+  StringUtils::ToLower(m_format);
+
   return true;
 }
 
-bool CSettingControl::setFormat(const std::string &strFormat)
+bool CSettingControlList::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  if (StringUtils::EqualsNoCase(strFormat, "boolean"))
-    m_format = SettingControlFormatBoolean;
-  else if (StringUtils::EqualsNoCase(strFormat, "string"))
-    m_format = SettingControlFormatString;
-  else if (StringUtils::EqualsNoCase(strFormat, "integer"))
-    m_format = SettingControlFormatInteger;
-  else if (StringUtils::EqualsNoCase(strFormat, "number"))
-    m_format = SettingControlFormatNumber;
-  else if (StringUtils::EqualsNoCase(strFormat, "ip"))
-    m_format = SettingControlFormatIP;
-  else if (StringUtils::EqualsNoCase(strFormat, "md5"))
-    m_format = SettingControlFormatMD5;
-  else if (StringUtils::EqualsNoCase(strFormat, "path"))
-    m_format = SettingControlFormatPath;
-  else if (StringUtils::EqualsNoCase(strFormat, "addon"))
-    m_format = SettingControlFormatAddon;
-  else if (StringUtils::EqualsNoCase(strFormat, "action"))
-    m_format = SettingControlFormatAction;
-  else
+  if (!ISettingControl::Deserialize(node, update))
+    return false;
+  
+  XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
+
+  return true;
+}
+
+bool CSettingControlList::SetFormat(const std::string &format)
+{
+  if (!StringUtils::EqualsNoCase(format, "string") &&
+      !StringUtils::EqualsNoCase(format, "integer"))
     return false;
 
-  return true;
-}
+  m_format = format;
+  StringUtils::ToLower(m_format);
 
-bool CSettingControl::setAttributes(const std::string &strAttributes)
-{
-  std::vector<std::string> attributeList = StringUtils::Split(strAttributes, ",");
-
-  int controlAttributes = SettingControlAttributeNone;
-  for (std::vector<std::string>::const_iterator attribute = attributeList.begin(); attribute != attributeList.end(); ++attribute)
-  {
-    if (StringUtils::EqualsNoCase(*attribute, "hidden"))
-      controlAttributes |= (int)SettingControlAttributeHidden;
-    else if (StringUtils::EqualsNoCase(*attribute, "new"))
-      controlAttributes |= (int)SettingControlAttributeVerifyNew;
-    else if (StringUtils::EqualsNoCase(*attribute, "hide_value"))
-      controlAttributes |= (int)SettingControlAttributeHideValue;
-    else
-      return false;
-  }
-
-  m_attributes = (SettingControlAttribute)controlAttributes;
   return true;
 }

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -19,68 +19,124 @@
  *
  */
 
-#include <string>
+#include "ISettingControl.h"
 
-class TiXmlNode;
+#define SETTING_XML_ELM_CONTROL_FORMATLABEL  "formatlabel"
+#define SETTING_XML_ELM_CONTROL_HIDDEN       "hidden"
+#define SETTING_XML_ELM_CONTROL_VERIFYNEW    "verifynew"
+#define SETTING_XML_ELM_CONTROL_HEADING      "heading"
+#define SETTING_XML_ELM_CONTROL_HIDEVALUE    "hidevalue"
 
-typedef enum {
-  SettingControlTypeNone =  0,
-  SettingControlTypeCheckmark,
-  SettingControlTypeSpinner,
-  SettingControlTypeEdit,
-  SettingControlTypeList,
-  SettingControlTypeButton
-} SettingControlType;
-
-typedef enum {
-  SettingControlFormatNone = 0,
-  SettingControlFormatBoolean,
-  SettingControlFormatString,
-  SettingControlFormatInteger,
-  SettingControlFormatNumber,
-  SettingControlFormatIP,
-  SettingControlFormatMD5,
-  SettingControlFormatPath,
-  SettingControlFormatAddon,
-  SettingControlFormatAction
-} SettingControlFormat;
-
-typedef enum {
-  SettingControlAttributeNone       = 0x0,
-  SettingControlAttributeHidden     = 0x1,
-  SettingControlAttributeVerifyNew  = 0x2,
-  SettingControlAttributeHideValue  = 0x4
-} SettingControlAttribute;
-
-class CSettingControl
+class CSettingControlCheckmark : public ISettingControl
 {
 public:
-  CSettingControl(SettingControlType type = SettingControlTypeNone,
-                  SettingControlFormat format = SettingControlFormatNone,
-                  SettingControlAttribute attribute = SettingControlAttributeNone)
-    : m_type(type), m_format(format), m_attributes(attribute),
-      m_delayed(false)
-  { }
-  virtual ~CSettingControl() { }
+  CSettingControlCheckmark()
+  {
+    m_format = "boolean";
+  }
+  virtual ~CSettingControlCheckmark() { }
 
-  bool Deserialize(const TiXmlNode *node, bool update = false);
-
-  SettingControlType GetType() const { return m_type; }
-  SettingControlFormat GetFormat() const { return m_format; }
-  SettingControlAttribute GetAttributes() const { return m_attributes; }
-  bool GetDelayed() const { return m_delayed; }
-
-  void SetType(SettingControlType type) { m_type = type; }
-  void SetFormat(SettingControlFormat format) { m_format = format; }
-  void SetAttributes(SettingControlAttribute attributes) { m_attributes = attributes; }
+  // implementation of ISettingControl
+  virtual std::string GetType() const { return "toggle"; }
 
 protected:
-  bool setType(const std::string &strType);
-  bool setFormat(const std::string &strFormat);
-  bool setAttributes(const std::string &strAttributes);
+  virtual bool SetFormat(const std::string &format);
+};
 
-  SettingControlType m_type;
-  SettingControlFormat m_format;
-  SettingControlAttribute m_attributes;
-  bool m_delayed;
+class CSettingControlSpinner : public ISettingControl
+{
+public:
+  CSettingControlSpinner()
+    : m_formatLabel(-1),
+      m_formatString("%i"),
+      m_minimumLabel(-1)
+  { }
+  virtual ~CSettingControlSpinner() { }
+
+  // implementation of ISettingControl
+  virtual std::string GetType() const { return "spinner"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+
+  int GetFormatLabel() const { return m_formatLabel; }
+  const std::string& GetFormatString() const { return m_formatString; }
+  int GetMinimumLabel() const { return m_minimumLabel; }
+
+protected:
+  virtual bool SetFormat(const std::string &format);
+
+  int m_formatLabel;
+  std::string m_formatString;
+  int m_minimumLabel;
+
+};
+
+class CSettingControlEdit : public ISettingControl
+{
+public:
+  CSettingControlEdit()
+    : m_hidden(false),
+      m_verifyNewValue(false),
+      m_heading(-1)
+  {
+    m_delayed = true;
+  }
+  virtual ~CSettingControlEdit() { }
+
+  // implementation of ISettingControl
+  virtual std::string GetType() const { return "edit"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+
+  bool IsHidden() const { return m_hidden; }
+  bool VerifyNewValue() const { return m_verifyNewValue; }
+  int GetHeading() const { return m_heading; }
+
+protected:
+  virtual bool SetFormat(const std::string &format);
+
+  bool m_hidden;
+  bool m_verifyNewValue;
+  int m_heading;
+};
+
+class CSettingControlButton : public ISettingControl
+{
+public:
+  CSettingControlButton()
+    : m_heading(-1),
+      m_hideValue(false)
+  { }
+  virtual ~CSettingControlButton() { }
+
+  // implementation of ISettingControl
+  virtual std::string GetType() const { return "button"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+
+  int GetHeading() const { return m_heading; }
+  bool HideValue() const { return m_hideValue; }
+
+protected:
+  virtual bool SetFormat(const std::string &format);
+
+  int m_heading;
+  bool m_hideValue;
+};
+
+class CSettingControlList : public ISettingControl
+{
+public:
+  CSettingControlList()
+    : m_heading(-1)
+  { }
+  virtual ~CSettingControlList() { }
+
+  // implementation of ISettingControl
+  virtual std::string GetType() const { return "list"; }
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+  
+  int GetHeading() const { return m_heading; }
+
+protected:
+  virtual bool SetFormat(const std::string &format);
+  
+  int m_heading;
 };

--- a/xbmc/settings/SettingDefinitions.h
+++ b/xbmc/settings/SettingDefinitions.h
@@ -1,0 +1,60 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define SETTING_XML_ROOT              "settings"
+
+#define SETTING_XML_ELM_SECTION       "section"
+#define SETTING_XML_ELM_CATEGORY      "category"
+#define SETTING_XML_ELM_GROUP         "group"
+#define SETTING_XML_ELM_SETTING       "setting"
+#define SETTING_XML_ELM_VISIBLE       "visible"
+#define SETTING_XML_ELM_REQUIREMENT   "requirement"
+#define SETTING_XML_ELM_CONDITION     "condition"
+#define SETTING_XML_ELM_LEVEL         "level"
+#define SETTING_XML_ELM_DEFAULT       "default"
+#define SETTING_XML_ELM_VALUE         "value"
+#define SETTING_XML_ELM_CONTROL       "control"
+#define SETTING_XML_ELM_CONSTRAINTS   "constraints"
+#define SETTING_XML_ELM_OPTIONS       "options"
+#define SETTING_XML_ELM_OPTION        "option"
+#define SETTING_XML_ELM_MINIMUM       "minimum"
+#define SETTING_XML_ELM_STEP          "step"
+#define SETTING_XML_ELM_MAXIMUM       "maximum"
+#define SETTING_XML_ELM_ALLOWEMPTY    "allowempty"
+#define SETTING_XML_ELM_DEPENDENCIES  "dependencies"
+#define SETTING_XML_ELM_DEPENDENCY    "dependency"
+#define SETTING_XML_ELM_UPDATES       "updates"
+#define SETTING_XML_ELM_UPDATE        "update"
+#define SETTING_XML_ELM_ACCESS        "access"
+
+#define SETTING_XML_ATTR_ID           "id"
+#define SETTING_XML_ATTR_LABEL        "label"
+#define SETTING_XML_ATTR_HELP         "help"
+#define SETTING_XML_ATTR_TYPE         "type"
+#define SETTING_XML_ATTR_PARENT       "parent"
+#define SETTING_XML_ATTR_FORMAT       "format"
+#define SETTING_XML_ATTR_DELAYED      "delayed"
+#define SETTING_XML_ATTR_ON           "on"
+#define SETTING_XML_ATTR_OPERATOR     "operator"
+#define SETTING_XML_ATTR_NAME         "name"
+#define SETTING_XML_ATTR_SETTING      "setting"
+#define SETTING_XML_ATTR_BEFORE       "before"
+#define SETTING_XML_ATTR_AFTER        "after"

--- a/xbmc/settings/SettingDependency.cpp
+++ b/xbmc/settings/SettingDependency.cpp
@@ -22,6 +22,7 @@
 
 #include "SettingDependency.h"
 #include "Setting.h"
+#include "SettingDefinitions.h"
 #include "SettingsManager.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -37,7 +38,7 @@ bool CSettingDependencyCondition::Deserialize(const TiXmlNode *node)
     return false;
 
   m_target = SettingDependencyTargetSetting;
-  const char *strTarget = elem->Attribute("on");
+  const char *strTarget = elem->Attribute(SETTING_XML_ATTR_ON);
   if (strTarget != NULL && !setTarget(strTarget))
   {
     CLog::Log(LOGWARNING, "CSettingDependencyCondition: unknown target \"%s\"", strTarget);
@@ -62,7 +63,7 @@ bool CSettingDependencyCondition::Deserialize(const TiXmlNode *node)
   }
 
   m_operator = SettingDependencyOperatorEquals;
-  const char *strOperator = elem->Attribute("operator");
+  const char *strOperator = elem->Attribute(SETTING_XML_ATTR_OPERATOR);
   if (strOperator != NULL && !setOperator(strOperator))
   {
     CLog::Log(LOGWARNING, "CSettingDependencyCondition: unknown operator \"%s\"", strOperator);
@@ -217,7 +218,7 @@ bool CSettingDependency::Deserialize(const TiXmlNode *node)
   if (elem == NULL)
     return false;
   
-  const char *strType = elem->Attribute("type");
+  const char *strType = elem->Attribute(SETTING_XML_ATTR_TYPE);
   if (strType == NULL || strlen(strType) <= 0 || !setType(strType))
   {
     CLog::Log(LOGWARNING, "CSettingDependency: missing or unknown dependency type definition");

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -31,11 +31,7 @@
 CSettingPath::CSettingPath(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : CSettingString(id, settingsManager),
     m_writable(true)
-{
-  m_control.SetType(SettingControlTypeButton);
-  m_control.SetFormat(SettingControlFormatPath);
-  m_control.SetAttributes(SettingControlAttributeNone);
-}
+{ }
   
 CSettingPath::CSettingPath(const std::string &id, const CSettingPath &setting)
   : CSettingString(id, setting)
@@ -50,9 +46,8 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (!CSettingString::Deserialize(node, update))
     return false;
     
-  if (m_control.GetType() != SettingControlTypeButton ||
-      m_control.GetFormat() != SettingControlFormatPath ||
-      m_control.GetAttributes() != SettingControlAttributeNone)
+  if (m_control != NULL &&
+     (m_control->GetType() != "button" || m_control->GetFormat() != "path"))
   {
     CLog::Log(LOGERROR, "CSettingPath: invalid <control> of \"%s\"", m_id.c_str());
     return false;

--- a/xbmc/settings/SettingSection.cpp
+++ b/xbmc/settings/SettingSection.cpp
@@ -19,13 +19,11 @@
  */
 
 #include "SettingSection.h"
+#include "SettingDefinitions.h"
 #include "SettingsManager.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
-
-#define XML_CATEGORY    "category"
-#define XML_GROUP       "group"
 
 template<class T> void addISetting(const TiXmlNode *node, const T &item, std::vector<T> &items)
 {
@@ -38,10 +36,10 @@ template<class T> void addISetting(const TiXmlNode *node, const T &item, std::ve
 
   // check if there is a "before" or "after" attribute to place the setting at a specific position
   int position = -1; // -1 => end, 0 => before, 1 => after
-  const char *positionId = element->Attribute("before");
+  const char *positionId = element->Attribute(SETTING_XML_ATTR_BEFORE);
   if (positionId != NULL && strlen(positionId) > 0)
     position = 0;
-  else if ((positionId = element->Attribute("after")) != NULL && strlen(positionId) > 0)
+  else if ((positionId = element->Attribute(SETTING_XML_ATTR_AFTER)) != NULL && strlen(positionId) > 0)
     position = 1;
 
   if (positionId != NULL && strlen(positionId) > 0 && position >= 0)
@@ -80,7 +78,7 @@ bool CSettingGroup::Deserialize(const TiXmlNode *node, bool update /* = false */
   if (!ISetting::Deserialize(node, update))
     return false;
 
-  const TiXmlElement *settingElement = node->FirstChildElement(XML_SETTING);
+  const TiXmlElement *settingElement = node->FirstChildElement(SETTING_XML_ELM_SETTING);
   while (settingElement != NULL)
   {
     std::string settingId;
@@ -99,7 +97,7 @@ bool CSettingGroup::Deserialize(const TiXmlNode *node, bool update /* = false */
       update = (setting != NULL);
       if (!update)
       {
-        const char* settingType = settingElement->Attribute(XML_ATTR_TYPE);
+        const char* settingType = settingElement->Attribute(SETTING_XML_ATTR_TYPE);
         if (settingType == NULL || strlen(settingType) <= 0)
         {
           CLog::Log(LOGERROR, "CSettingGroup: unable to read setting type of \"%s\"", settingId.c_str());
@@ -123,7 +121,7 @@ bool CSettingGroup::Deserialize(const TiXmlNode *node, bool update /* = false */
         addISetting(settingElement, setting, m_settings);
     }
       
-    settingElement = settingElement->NextSiblingElement(XML_SETTING);
+    settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);
   }
     
   return true;
@@ -167,16 +165,16 @@ bool CSettingCategory::Deserialize(const TiXmlNode *node, bool update /* = false
     return false;
     
   int tmp = -1;
-  if (element->QueryIntAttribute(XML_ATTR_LABEL, &tmp) == TIXML_SUCCESS && tmp > 0)
+  if (element->QueryIntAttribute(SETTING_XML_ATTR_LABEL, &tmp) == TIXML_SUCCESS && tmp > 0)
     m_label = tmp;
-  if (element->QueryIntAttribute(XML_ATTR_HELP, &tmp) == TIXML_SUCCESS && tmp > 0)
+  if (element->QueryIntAttribute(SETTING_XML_ATTR_HELP, &tmp) == TIXML_SUCCESS && tmp > 0)
     m_help = tmp;
 
-  const TiXmlNode *accessNode = node->FirstChild("access");
+  const TiXmlNode *accessNode = node->FirstChild(SETTING_XML_ELM_ACCESS);
   if (accessNode != NULL && !m_accessCondition.Deserialize(accessNode))
     return false;
     
-  const TiXmlNode *groupNode = node->FirstChildElement(XML_GROUP);
+  const TiXmlNode *groupNode = node->FirstChildElement(SETTING_XML_ELM_GROUP);
   while (groupNode != NULL)
   {
     std::string groupId;
@@ -209,7 +207,7 @@ bool CSettingCategory::Deserialize(const TiXmlNode *node, bool update /* = false
       }
     }
       
-    groupNode = groupNode->NextSibling(XML_GROUP);
+    groupNode = groupNode->NextSibling(SETTING_XML_ELM_GROUP);
   }
     
   return true;
@@ -257,12 +255,12 @@ bool CSettingSection::Deserialize(const TiXmlNode *node, bool update /* = false 
     return false;
 
   int tmp = -1;
-  if (element->QueryIntAttribute(XML_ATTR_LABEL, &tmp) == TIXML_SUCCESS && tmp > 0)
+  if (element->QueryIntAttribute(SETTING_XML_ATTR_LABEL, &tmp) == TIXML_SUCCESS && tmp > 0)
     m_label = tmp;
-  if (element->QueryIntAttribute(XML_ATTR_HELP, &tmp) == TIXML_SUCCESS && tmp > 0)
+  if (element->QueryIntAttribute(SETTING_XML_ATTR_HELP, &tmp) == TIXML_SUCCESS && tmp > 0)
     m_help = tmp;
     
-  const TiXmlNode *categoryNode = node->FirstChild(XML_CATEGORY);
+  const TiXmlNode *categoryNode = node->FirstChild(SETTING_XML_ELM_CATEGORY);
   while (categoryNode != NULL)
   {
     std::string categoryId;
@@ -295,7 +293,7 @@ bool CSettingSection::Deserialize(const TiXmlNode *node, bool update /* = false 
       }
     }
       
-    categoryNode = categoryNode->NextSibling(XML_CATEGORY);
+    categoryNode = categoryNode->NextSibling(SETTING_XML_ELM_CATEGORY);
   }
     
   return true;

--- a/xbmc/settings/SettingUpdate.cpp
+++ b/xbmc/settings/SettingUpdate.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "SettingUpdate.h"
+#include "SettingDefinitions.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -41,7 +42,7 @@ bool CSettingUpdate::Deserialize(const TiXmlNode *node)
   if (elem == NULL)
     return false;
   
-  const char *strType = elem->Attribute("type");
+  const char *strType = elem->Attribute(SETTING_XML_ATTR_TYPE);
   if (strType == NULL || strlen(strType) <= 0 || !setType(strType))
   {
     CLog::Log(LOGWARNING, "CSettingUpdate: missing or unknown update type definition");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -69,6 +69,7 @@
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingAddon.h"
+#include "settings/SettingControl.h"
 #include "settings/SettingsManager.h"
 #include "settings/SettingPath.h"
 #include "settings/SkinSettings.h"
@@ -252,6 +253,22 @@ CSetting* CSettings::CreateSetting(const std::string &settingType, const std::st
   return NULL;
 }
 
+ISettingControl* CSettings::CreateControl(const std::string &controlType) const
+{
+  if (StringUtils::EqualsNoCase(controlType, "toggle"))
+    return new CSettingControlCheckmark();
+  else if (StringUtils::EqualsNoCase(controlType, "spinner"))
+    return new CSettingControlSpinner();
+  else if (StringUtils::EqualsNoCase(controlType, "edit"))
+    return new CSettingControlEdit();
+  else if (StringUtils::EqualsNoCase(controlType, "button"))
+    return new CSettingControlButton();
+  else if (StringUtils::EqualsNoCase(controlType, "list"))
+    return new CSettingControlList();
+
+  return NULL;
+}
+
 bool CSettings::Initialize()
 {
   CSingleLock lock(m_critical);
@@ -260,6 +277,8 @@ bool CSettings::Initialize()
 
   // register custom setting types
   InitializeSettingTypes();
+  // register custom setting controls
+  InitializeControls();
 
   // option fillers and conditions need to be
   // initialized before the setting definitions
@@ -607,6 +626,15 @@ void CSettings::InitializeSettingTypes()
   // register "addon" and "path" setting types implemented by CSettingAddon
   m_settingsManager->RegisterSettingType("addon", this);
   m_settingsManager->RegisterSettingType("path", this);
+}
+
+void CSettings::InitializeControls()
+{
+  m_settingsManager->RegisterSettingControl("toggle", this);
+  m_settingsManager->RegisterSettingControl("spinner", this);
+  m_settingsManager->RegisterSettingControl("edit", this);
+  m_settingsManager->RegisterSettingControl("button", this);
+  m_settingsManager->RegisterSettingControl("list", this);
 }
 
 void CSettings::InitializeVisibility()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "settings/ISettingCallback.h"
+#include "settings/ISettingControlCreator.h"
 #include "settings/ISettingCreator.h"
 #include "threads/CriticalSection.h"
 
@@ -38,7 +39,7 @@ class TiXmlNode;
  setting types.
  \sa CSettingsManager
  */
-class CSettings : public ISettingCreator
+class CSettings : public ISettingCreator, public ISettingControlCreator
 {
 public:
   /*!
@@ -59,6 +60,9 @@ public:
 
   // implementation of ISettingCreator
   virtual CSetting* CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const;
+
+  // implementation of ISettingControlCreator
+  virtual ISettingControl* CreateControl(const std::string &controlType) const;
 
   /*!
    \brief Initializes the setting system with the generic
@@ -239,6 +243,7 @@ private:
   bool Initialize(const std::string &file);
   bool InitializeDefinitions();
   void InitializeSettingTypes();
+  void InitializeControls();
   void InitializeVisibility();
   void InitializeDefaults();
   void InitializeOptionFillers();

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -19,14 +19,12 @@
  */
 
 #include "SettingsManager.h"
+#include "SettingDefinitions.h"
 #include "SettingSection.h"
 #include "Setting.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
-
-#define XML_ROOT        "settings"
-#define XML_SECTION     "section"
 
 
 CSettingsManager::CSettingsManager()
@@ -40,6 +38,7 @@ CSettingsManager::~CSettingsManager()
   m_settingsHandlers.clear();
   m_subSettings.clear();
   m_settingCreators.clear();
+  m_settingControlCreators.clear();
 
   Clear();
 }
@@ -51,13 +50,13 @@ bool CSettingsManager::Initialize(const TiXmlElement *root)
   if (m_initialized || root == NULL)
     return false;
 
-  if (!StringUtils::EqualsNoCase(root->ValueStr(), XML_ROOT))
+  if (!StringUtils::EqualsNoCase(root->ValueStr(), SETTING_XML_ROOT))
   {
     CLog::Log(LOGERROR, "CSettingsManager: error reading settings definition: doesn't contain <settings> tag");
     return false;
   }
 
-  const TiXmlNode *sectionNode = root->FirstChild(XML_SECTION);
+  const TiXmlNode *sectionNode = root->FirstChild(SETTING_XML_ELM_SECTION);
   while (sectionNode != NULL)
   {
     std::string sectionId;
@@ -114,7 +113,7 @@ bool CSettingsManager::Initialize(const TiXmlElement *root)
       }
     }
       
-    sectionNode = sectionNode->NextSibling(XML_SECTION);
+    sectionNode = sectionNode->NextSibling(SETTING_XML_ELM_SECTION);
   }
 
   for (SettingMap::iterator itSettingDep = m_settings.begin(); itSettingDep != m_settings.end(); ++itSettingDep)
@@ -310,6 +309,17 @@ void CSettingsManager::RegisterSettingType(const std::string &settingType, ISett
   SettingCreatorMap::const_iterator creatorIt = m_settingCreators.find(settingType);
   if (creatorIt == m_settingCreators.end())
     m_settingCreators.insert(make_pair(settingType, settingCreator));
+}
+
+void CSettingsManager::RegisterSettingControl(const std::string &controlType, ISettingControlCreator *settingControlCreator)
+{
+  if (controlType.empty() || settingControlCreator == NULL)
+    return;
+
+  CExclusiveLock lock(m_critical);
+  SettingControlCreatorMap::const_iterator creatorIt = m_settingControlCreators.find(controlType);
+  if (creatorIt == m_settingControlCreators.end())
+    m_settingControlCreators.insert(make_pair(controlType, settingControlCreator));
 }
 
 void CSettingsManager::RegisterSettingsHandler(ISettingsHandler *settingsHandler)
@@ -780,6 +790,19 @@ CSetting* CSettingsManager::CreateSetting(const std::string &settingType, const 
   SettingCreatorMap::const_iterator creator = m_settingCreators.find(settingType);
   if (creator != m_settingCreators.end())
     return creator->second->CreateSetting(settingType, settingId, (CSettingsManager*)this);
+
+  return NULL;
+}
+
+ISettingControl* CSettingsManager::CreateControl(const std::string &controlType) const
+{
+  if (controlType.empty())
+    return NULL;
+
+  CSharedLock lock(m_critical);
+  SettingControlCreatorMap::const_iterator creator = m_settingControlCreators.find(controlType);
+  if (creator != m_settingControlCreators.end() && creator->second != NULL)
+    return creator->second->CreateControl(controlType);
 
   return NULL;
 }

--- a/xbmc/settings/SettingsManager.h
+++ b/xbmc/settings/SettingsManager.h
@@ -25,6 +25,7 @@
 
 #include "ISetting.h"
 #include "ISettingCallback.h"
+#include "ISettingControlCreator.h"
 #include "ISettingCreator.h"
 #include "ISettingsHandler.h"
 #include "ISubSettings.h"
@@ -46,7 +47,8 @@ typedef void (*StringSettingOptionsFiller)(const CSetting *setting, std::vector<
  \brief Settings manager responsible for initializing, loading and handling
  all settings.
  */
-class CSettingsManager : public ISettingCreator, private ISettingCallback,
+class CSettingsManager : public ISettingCreator, public ISettingControlCreator,
+                         private ISettingCallback,
                          private ISettingsHandler, private ISubSettings
 {
 public:
@@ -58,6 +60,9 @@ public:
 
   // implementation of ISettingCreator
   virtual CSetting* CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const;
+
+  // implementation of ISettingControlCreator
+  virtual ISettingControl* CreateControl(const std::string &controlType) const;
 
   /*!
    \brief Initializes the settings manager using the setting definitions
@@ -152,6 +157,19 @@ public:
    \param settingCreator ISettingCreator implementation
    */
   void RegisterSettingType(const std::string &settingType, ISettingCreator *settingCreator);
+
+  /*!
+   \brief Registers a custom setting control type and its
+   ISettingControlCreator implementation
+
+   When a setting control definition for a registered custom setting control
+   type is found its ISettingControlCreator implementation is called to create
+   and deserialize the setting control definition.
+   
+   \param controlType String representation of the custom setting control type
+   \param settingControlCreator ISettingControlCreator implementation
+   */
+  void RegisterSettingControl(const std::string &controlType, ISettingControlCreator *settingControlCreator);
 
   /*!
    \brief Registers the given ISettingsHandler implementation.
@@ -394,6 +412,9 @@ private:
 
   typedef std::map<std::string, ISettingCreator*> SettingCreatorMap;
   SettingCreatorMap m_settingCreators;
+
+  typedef std::map<std::string, ISettingControlCreator*> SettingControlCreatorMap;
+  SettingControlCreatorMap m_settingControlCreators;
 
   std::set<ISubSettings*> m_subSettings;
   typedef std::vector<ISettingsHandler*> SettingsHandlers;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <set>
+
 #include "GUIControlSettings.h"
 #include "FileItem.h"
 #include "Util.h"
@@ -33,6 +35,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/SettingAddon.h"
+#include "settings/SettingControl.h"
 #include "settings/SettingPath.h"
 #include "settings/Settings.h"
 #include "settings/MediaSourceSettings.h"
@@ -145,49 +148,39 @@ void CGUIControlSpinExSetting::FillControl()
 {
   m_pSpin->Clear();
 
-  switch (m_pSetting->GetControl().GetFormat())
+  const std::string &controlFormat = m_pSetting->GetControl()->GetFormat();
+  if (controlFormat == "number")
   {
-    case SettingControlFormatNumber:
-    {
-      CSettingNumber *pSettingNumber = (CSettingNumber *)m_pSetting;
-      m_pSpin->SetType(SPIN_CONTROL_TYPE_FLOAT);
-      m_pSpin->SetFloatRange((float)pSettingNumber->GetMinimum(), (float)pSettingNumber->GetMaximum());
-      m_pSpin->SetFloatInterval((float)pSettingNumber->GetStep());
+    CSettingNumber *pSettingNumber = (CSettingNumber *)m_pSetting;
+    m_pSpin->SetType(SPIN_CONTROL_TYPE_FLOAT);
+    m_pSpin->SetFloatRange((float)pSettingNumber->GetMinimum(), (float)pSettingNumber->GetMaximum());
+    m_pSpin->SetFloatInterval((float)pSettingNumber->GetStep());
 
-      m_pSpin->SetFloatValue((float)pSettingNumber->GetValue());
-      break;
-    }
+    m_pSpin->SetFloatValue((float)pSettingNumber->GetValue());
+  }
+  else if (controlFormat == "integer")
+  {
+    m_pSpin->SetType(SPIN_CONTROL_TYPE_TEXT);
+    FillIntegerSettingControl();
+  }
+  else if (controlFormat == "string")
+  {
+    m_pSpin->SetType(SPIN_CONTROL_TYPE_TEXT);
 
-    case SettingControlFormatInteger:
-    {
-      m_pSpin->SetType(SPIN_CONTROL_TYPE_TEXT);
+    if (m_pSetting->GetType() == SettingTypeInteger)
       FillIntegerSettingControl();
-      break;
-    }
-
-    case SettingControlFormatString:
+    else if (m_pSetting->GetType() == SettingTypeString)
     {
-      m_pSpin->SetType(SPIN_CONTROL_TYPE_TEXT);
-
-      if (m_pSetting->GetType() == SettingTypeInteger)
-        FillIntegerSettingControl();
-      else if (m_pSetting->GetType() == SettingTypeString)
+      CSettingString *pSettingString = (CSettingString *)m_pSetting;
+      if (pSettingString->GetOptionsType() == SettingOptionsTypeDynamic)
       {
-        CSettingString *pSettingString = (CSettingString *)m_pSetting;
-        if (pSettingString->GetOptionsType() == SettingOptionsTypeDynamic)
-        {
-          DynamicStringSettingOptions options = pSettingString->UpdateDynamicOptions();
-          for (std::vector< std::pair<std::string, std::string> >::const_iterator option = options.begin(); option != options.end(); ++option)
-            m_pSpin->AddLabel(option->first, option->second);
+        DynamicStringSettingOptions options = pSettingString->UpdateDynamicOptions();
+        for (std::vector< std::pair<std::string, std::string> >::const_iterator option = options.begin(); option != options.end(); ++option)
+          m_pSpin->AddLabel(option->first, option->second);
 
-          m_pSpin->SetStringValue(pSettingString->GetValue());
-        }
+        m_pSpin->SetStringValue(pSettingString->GetValue());
       }
-      break;
     }
-
-    default:
-      break;
   }
 }
 
@@ -219,18 +212,20 @@ void CGUIControlSpinExSetting::FillIntegerSettingControl()
     {
       std::string strLabel;
       int i = pSettingInt->GetMinimum();
-      if (pSettingInt->GetMinimumLabel() > -1)
+      const CSettingControlSpinner *control = static_cast<const CSettingControlSpinner*>(pSettingInt->GetControl());
+      if (control->GetMinimumLabel() > -1)
       {
-        strLabel = g_localizeStrings.Get(pSettingInt->GetMinimumLabel());
+        strLabel = g_localizeStrings.Get(control->GetMinimumLabel());
         m_pSpin->AddLabel(strLabel, pSettingInt->GetMinimum());
         i += pSettingInt->GetStep();
       }
+
       for (; i <= pSettingInt->GetMaximum(); i += pSettingInt->GetStep())
       {
-        if (pSettingInt->GetFormat() > -1)
-          strLabel = StringUtils::Format(g_localizeStrings.Get(pSettingInt->GetFormat()).c_str(), i);
+        if (control->GetFormatLabel() > -1)
+          strLabel = StringUtils::Format(g_localizeStrings.Get(control->GetFormatLabel()).c_str(), i);
         else
-          strLabel = StringUtils::Format(pSettingInt->GetFormatString().c_str(), i);
+          strLabel = StringUtils::Format(control->GetFormatString().c_str(), i);
         m_pSpin->AddLabel(strLabel, i);
       }
 
@@ -265,6 +260,8 @@ bool CGUIControlListSetting::OnClick()
   if (!GetItems(m_pSetting, options) || options.Size() <= 1)
     return false;
   
+  const CSettingControlList *control = static_cast<const CSettingControlList*>(m_pSetting->GetControl());
+
   dialog->Reset();
   dialog->SetHeading(g_localizeStrings.Get(m_pSetting->GetLabel()));
   dialog->SetItems(&options);
@@ -330,38 +327,34 @@ static CFileItemPtr GetItem(const std::string &label, const CVariant &value)
 
 bool CGUIControlListSetting::GetItems(CSetting *setting, CFileItemList &items)
 {
-  switch (setting->GetControl().GetFormat())
+  const CSettingControlList *control = static_cast<const CSettingControlList*>(setting->GetControl());
+  const std::string &controlFormat = control->GetFormat();
+  if (controlFormat == "integer")
+    return GetIntegerItems(setting, items);
+  else if (controlFormat == "string")
   {
-    case SettingControlFormatInteger:
+    if (setting->GetType() == SettingTypeInteger)
       return GetIntegerItems(setting, items);
-
-    case SettingControlFormatString:
+    else if (setting->GetType() == SettingTypeString)
     {
-      if (setting->GetType() == SettingTypeInteger)
-        return GetIntegerItems(setting, items);
-      else if (setting->GetType() == SettingTypeString)
+      CSettingString *pSettingString = (CSettingString *)setting;
+      if (pSettingString->GetOptionsType() == SettingOptionsTypeDynamic)
       {
-        CSettingString *pSettingString = (CSettingString *)setting;
-        if (pSettingString->GetOptionsType() == SettingOptionsTypeDynamic)
+        DynamicStringSettingOptions options = pSettingString->UpdateDynamicOptions();
+        for (DynamicStringSettingOptions::const_iterator option = options.begin(); option != options.end(); ++option)
         {
-          DynamicStringSettingOptions options = pSettingString->UpdateDynamicOptions();
-          for (DynamicStringSettingOptions::const_iterator option = options.begin(); option != options.end(); ++option)
-          {
-            CFileItemPtr pItem = GetItem(option->first, option->second);
+          CFileItemPtr pItem = GetItem(option->first, option->second);
 
-            if (StringUtils::EqualsNoCase(option->second, pSettingString->GetValue()))
-              pItem->Select(true);
+          if (StringUtils::EqualsNoCase(option->second, pSettingString->GetValue()))
+            pItem->Select(true);
 
-            items.Add(pItem);
-          }
+          items.Add(pItem);
         }
       }
-      break;
     }
-
-    default:
-      return false;
   }
+  else
+    return false;
 
   return true;
 }
@@ -425,42 +418,29 @@ bool CGUIControlButtonSetting::OnClick()
   if (m_pButton == NULL)
     return false;
 
-  bool success = false;
-  switch (m_pSetting->GetControl().GetFormat())
+  const std::string &controlFormat = m_pSetting->GetControl()->GetFormat();
+  if (controlFormat == "addon")
   {
-    case SettingControlFormatAddon:
-    {
-      // prompt for the addon
-      CSettingAddon *setting = (CSettingAddon *)m_pSetting;
-      CStdString addonID = setting->GetValue();
-      if (!CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonID, setting->AllowEmpty()) == 1)
-        return false;
-
-      success = setting->SetValue(addonID);
-      break;
-    }
-
-    case SettingControlFormatPath:
-    {
-      success = GetPath((CSettingPath *)m_pSetting);
-      break;
-    }
-
-    case SettingControlFormatAction:
-    {
-      // simply call the OnSettingAction callback and whoever knows what to
-      // do can do so (based on the setting's identification
-      CSettingAction *pSettingAction = (CSettingAction *)m_pSetting;
-      pSettingAction->OnSettingAction(pSettingAction);
-      success = true;
-      break;
-    }
-
-    default:
+    // prompt for the addon
+    CSettingAddon *setting = (CSettingAddon *)m_pSetting;
+    CStdString addonID = setting->GetValue();
+    if (!CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonID, setting->AllowEmpty()) == 1)
       return false;
+
+    return setting->SetValue(addonID);
+  }
+  if (controlFormat == "path")
+    return GetPath((CSettingPath *)m_pSetting);
+  if (controlFormat == "action")
+  {
+    // simply call the OnSettingAction callback and whoever knows what to
+    // do can do so (based on the setting's identification
+    CSettingAction *pSettingAction = (CSettingAction *)m_pSetting;
+    pSettingAction->OnSettingAction(pSettingAction);
+    return true;
   }
 
-  return success;
+  return false;
 }
 
 void CGUIControlButtonSetting::Update()
@@ -471,31 +451,23 @@ void CGUIControlButtonSetting::Update()
   CGUIControlBaseSetting::Update();
 
   if (m_pSetting->GetType() == SettingTypeString &&
-      !(m_pSetting->GetControl().GetAttributes() & SettingControlAttributeHideValue))
+      !static_cast<const CSettingControlButton*>(m_pSetting->GetControl())->HideValue())
   {
     std::string strText = ((CSettingString *)m_pSetting)->GetValue();
-    switch (m_pSetting->GetControl().GetFormat())
+    const std::string &controlFormat = m_pSetting->GetControl()->GetFormat();
+    if (controlFormat == "addon")
     {
-      case SettingControlFormatAddon:
-      {
-        ADDON::AddonPtr addon;
-        if (ADDON::CAddonMgr::Get().GetAddon(strText, addon))
-          strText = addon->Name();
-        if (strText.empty())
-          strText = g_localizeStrings.Get(231); // None
-        break;
-      }
-
-      case SettingControlFormatPath:
-      {
-        CStdString shortPath;
-        if (CUtil::MakeShortenPath(strText, shortPath, 30))
-          strText = shortPath;
-        break;
-      }
-
-      default:
-        break;
+      ADDON::AddonPtr addon;
+      if (ADDON::CAddonMgr::Get().GetAddon(strText, addon))
+        strText = addon->Name();
+      if (strText.empty())
+        strText = g_localizeStrings.Get(231); // None
+    }
+    else if (controlFormat == "path")
+    {
+      CStdString shortPath;
+      if (CUtil::MakeShortenPath(strText, shortPath, 30))
+        strText = shortPath;
     }
 
     m_pButton->SetLabel2(strText);
@@ -521,7 +493,7 @@ bool CGUIControlButtonSetting::GetPath(CSettingPath *pathSetting)
   g_mediaManager.GetNetworkLocations(shares);
   g_mediaManager.GetLocalDrives(shares);
 
-  if (!CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(pathSetting->GetHeading()), path, pathSetting->Writable()))
+  if (!CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(static_cast<const CSettingControlButton*>(pathSetting->GetControl())->GetHeading()), path, pathSetting->Writable()))
     return false;
 
   return pathSetting->SetValue(path);
@@ -530,45 +502,34 @@ bool CGUIControlButtonSetting::GetPath(CSettingPath *pathSetting)
 CGUIControlEditSetting::CGUIControlEditSetting(CGUIEditControl *pEdit, int id, CSetting *pSetting)
   : CGUIControlBaseSetting(id, pSetting)
 {
+  const CSettingControlEdit* control = static_cast<const CSettingControlEdit*>(pSetting->GetControl());
   m_pEdit = pEdit;
   m_pEdit->SetID(id);
   int heading = m_pSetting->GetLabel();
-  if (m_pSetting->GetType() == SettingTypeString)
-  {
-    CSettingString *pSettingString = (CSettingString *)m_pSetting;
-    if (pSettingString->GetHeading() > 0)
-      heading = pSettingString->GetHeading();
-  }
+  if (control->GetHeading() > 0)
+    heading = control->GetHeading();
   if (heading < 0)
     heading = 0;
 
   CGUIEditControl::INPUT_TYPE inputType = CGUIEditControl::INPUT_TYPE_TEXT;
-  const CSettingControl& control = pSetting->GetControl();
-  switch (control.GetFormat())
+  const std::string &controlFormat = control->GetFormat();
+  if (controlFormat == "string")
   {
-    case SettingControlFormatString:
-      if (control.GetAttributes() & SettingControlAttributeHidden)
-        inputType = CGUIEditControl::INPUT_TYPE_PASSWORD;
-      break;
-      
-    case SettingControlFormatInteger:
-      if (control.GetAttributes() & SettingControlAttributeVerifyNew)
-        inputType = CGUIEditControl::INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW;
-      else
-        inputType = CGUIEditControl::INPUT_TYPE_NUMBER;
-      break;
-      
-    case SettingControlFormatIP:
-      inputType = CGUIEditControl::INPUT_TYPE_IPADDRESS;
-      break;
-      
-    case SettingControlFormatMD5:
-      inputType = CGUIEditControl::INPUT_TYPE_PASSWORD_MD5;
-      break;
-
-    default:
-      break;
+    if (control->IsHidden())
+      inputType = CGUIEditControl::INPUT_TYPE_PASSWORD;
   }
+  else if (controlFormat == "integer")
+  {
+    if (control->VerifyNewValue())
+      inputType = CGUIEditControl::INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW;
+    else
+      inputType = CGUIEditControl::INPUT_TYPE_NUMBER;
+  }
+  else if (controlFormat == "ip")
+    inputType = CGUIEditControl::INPUT_TYPE_IPADDRESS;
+  else if (controlFormat == "md5")
+    inputType = CGUIEditControl::INPUT_TYPE_PASSWORD_MD5;
+
   m_pEdit->SetInputType(inputType, heading);
 
   Update();

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -154,6 +154,7 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
       m_resetSetting = new CSettingAction(RESET_SETTING_ID);
       m_resetSetting->SetLabel(10041);
       m_resetSetting->SetHelp(10045);
+      m_resetSetting->SetControl(m_settings.CreateControl("button"));
 
       m_dummyCategory = new CSettingCategory(EMPTY_CATEGORY_ID);
       m_dummyCategory->SetLabel(10046);
@@ -678,69 +679,56 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
   }
 
   // create the proper controls
-  switch (pSetting->GetControl().GetType())
+  std::string controlType = pSetting->GetControl()->GetType();
+  if (controlType == "toggle")
   {
-    case SettingControlTypeCheckmark:
-    {
-      pControl = new CGUIRadioButtonControl(*m_pOriginalRadioButton);
-      if (pControl == NULL)
-        return NULL;
-
-      ((CGUIRadioButtonControl *)pControl)->SetLabel(label);
-      pSettingControl.reset(new CGUIControlRadioButtonSetting((CGUIRadioButtonControl *)pControl, iControlID, pSetting));
-      break;
-    }
-    
-    case SettingControlTypeSpinner:
-    {
-      pControl = new CGUISpinControlEx(*m_pOriginalSpin);
-      if (pControl == NULL)
-        return NULL;
-
-      ((CGUISpinControlEx *)pControl)->SetText(label);
-      pSettingControl.reset(new CGUIControlSpinExSetting((CGUISpinControlEx *)pControl, iControlID, pSetting));
-      break;
-    }
-    
-    case SettingControlTypeEdit:
-    {
-      pControl = new CGUIEditControl(*m_pOriginalEdit);
-      if (pControl == NULL)
-        return NULL;
-      
-      ((CGUIEditControl *)pControl)->SetLabel(label);
-      pSettingControl.reset(new CGUIControlEditSetting((CGUIEditControl *)pControl, iControlID, pSetting));
-      break;
-    }
-    
-    case SettingControlTypeList:
-    {
-      pControl = new CGUIButtonControl(*m_pOriginalButton);
-      if (pControl == NULL)
-        return NULL;
-
-      ((CGUIButtonControl *)pControl)->SetLabel(label);
-      pSettingControl.reset(new CGUIControlListSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
-      break;
-    }
-    
-    case SettingControlTypeButton:
-    {
-      pControl = new CGUIButtonControl(*m_pOriginalButton);
-      if (pControl == NULL)
-        return NULL;
-      
-      ((CGUIButtonControl *)pControl)->SetLabel(label);
-      pSettingControl.reset(new CGUIControlButtonSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
-      break;
-    }
-    
-    case SettingControlTypeNone:
-    default:
+    pControl = new CGUIRadioButtonControl(*m_pOriginalRadioButton);
+    if (pControl == NULL)
       return NULL;
-  }
 
-  if (pSetting->GetControl().GetDelayed())
+    ((CGUIRadioButtonControl *)pControl)->SetLabel(label);
+    pSettingControl.reset(new CGUIControlRadioButtonSetting((CGUIRadioButtonControl *)pControl, iControlID, pSetting));
+  }
+  else if (controlType == "spinner")
+  {
+    pControl = new CGUISpinControlEx(*m_pOriginalSpin);
+    if (pControl == NULL)
+      return NULL;
+
+    ((CGUISpinControlEx *)pControl)->SetText(label);
+    pSettingControl.reset(new CGUIControlSpinExSetting((CGUISpinControlEx *)pControl, iControlID, pSetting));
+  }
+  else if (controlType == "edit")
+  {
+    pControl = new CGUIEditControl(*m_pOriginalEdit);
+    if (pControl == NULL)
+      return NULL;
+      
+    ((CGUIEditControl *)pControl)->SetLabel(label);
+    pSettingControl.reset(new CGUIControlEditSetting((CGUIEditControl *)pControl, iControlID, pSetting));
+  }
+  else if (controlType == "list")
+  {
+    pControl = new CGUIButtonControl(*m_pOriginalButton);
+    if (pControl == NULL)
+      return NULL;
+
+    ((CGUIButtonControl *)pControl)->SetLabel(label);
+    pSettingControl.reset(new CGUIControlListSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
+  }
+  else if (controlType == "button")
+  {
+    pControl = new CGUIButtonControl(*m_pOriginalButton);
+    if (pControl == NULL)
+      return NULL;
+      
+    ((CGUIButtonControl *)pControl)->SetLabel(label);
+    pSettingControl.reset(new CGUIControlButtonSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
+  }
+  else
+    return NULL;
+
+  if (pSetting->GetControl()->GetDelayed())
     pSettingControl->SetDelayed();
 
   return AddSettingControl(pControl, pSettingControl, width, iControlID);


### PR DESCRIPTION
This implements one of the things that were on the "future work" slide of my settings system presentation: custom setting controls. This moves all the logic for setting control definitions, i.e. the <control> tag in the settings XML definition describing how to present the setting in a GUI, out of the settings library and into the settings integration code (i.e. xbmc-specific code). Every new control is implemented in a class deriving from ISettingControl and has a unique "type". CSettingsManager has a new method RegisterSettingControl() which takes a type string and an implementation of ISettingControlCreator (which is implemented by CSettings and works the same as ISettingCreator).

This refactor will allow us in the future to easily add new control types without having to touch any of the code in the settings library. We "lose" a bit of sanity checks (i.e. a "edit" control probably doesn't make much sense for a boolean setting) but IMO we shouldn't put any limitation on combinations of setting types and setting controls.

There is one thing I'm unhappy with: In the definition of a setting with predefined options or a range of values we use

```
<option label="123">1</option>
```

to define both the value and the GUI label of the option. IMO that label doesn't really belong there as it is only useful for GUI representation of the setting option. The same problem applies to

```
<minimum label="123">0</minimum>
```

For the latter I have added a new tag <minimumlabel> to the spinnder control type but it's not really ideal either. And duplicating the whole <option> list just to be able to define the labels in the <control> tag doesn't sound right either. We should either go with one ("label" attribute polluting the setting definition) or the other (moving all label definitions into <control> but basically duplicating some information) and not the way it is in the PR right now. I only did that to be able to better show the problem.
