### PR TITLE
[addonmgr] query addon disabled state once and cache it (fixes #14122)

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -578,10 +578,8 @@ bool CAddonInstallJob::OnPreInstall()
 
   if (m_addon->Type() == ADDON_SERVICE)
   {
-    CAddonDatabase database;
-    database.Open();
-    bool running = !database.IsAddonDisabled(m_addon->ID()); //grab a current state
-    database.DisableAddon(m_addon->ID(),false); // enable it so we can remove it??
+    bool running = !CAddonMgr::Get().IsAddonDisabled(m_addon->ID()); //grab a current state
+    CAddonMgr::Get().DisableAddon(m_addon->ID(),false); // enable it so we can remove it??
     // regrab from manager to have the correct path set
     AddonPtr addon;
     ADDON::CAddonMgr::Get().GetAddon(m_addon->ID(), addon);
@@ -710,9 +708,7 @@ void CAddonInstallJob::OnPostInstall(bool reloadAddon)
 
   if (m_addon->Type() == ADDON_SERVICE)
   {
-    CAddonDatabase database;
-    database.Open();
-    database.DisableAddon(m_addon->ID(),!reloadAddon); //return it into state it was before OnPreInstall()
+    CAddonMgr::Get().DisableAddon(m_addon->ID(),!reloadAddon); //return it into state it was before OnPreInstall()
     if (reloadAddon) // reload/start it if it was running
     {
       // regrab from manager to have the correct path set

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -115,6 +115,21 @@ namespace ADDON
     void FindAddons();
     void RemoveAddon(const CStdString& ID);
 
+    /* \brief Disable an addon
+     Triggers the database routine and saves the current addon state to cache.
+     \param ID id of the addon
+     \param disable whether to enable or disable. Defaults to true (disable)
+     \sa IsAddonDisabled,
+     */
+    bool DisableAddon(const std::string& ID, bool disable = true);
+
+    /* \brief Check whether an addon has been disabled via DisableAddon.
+     In case the disabled cache does not know about the current state the database routine will be used.
+     \param ID id of the addon
+     \sa DisableAddon
+     */
+    bool IsAddonDisabled(const std::string& ID);
+
     /* libcpluff */
     CStdString GetExtValue(cp_cfg_element_t *base, const char *path);
 
@@ -203,6 +218,7 @@ namespace ADDON
     CAddonMgr const& operator=(CAddonMgr const&);
     virtual ~CAddonMgr();
 
+    std::map<std::string, bool> m_disabled;
     static std::map<TYPE, IAddonMgrCallback*> m_managers;
     CCriticalSection m_critSection;
     CAddonDatabase m_database;

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -207,9 +207,8 @@ void CGUIDialogAddonInfo::OnUninstall()
   }
 
   // ensure the addon isn't disabled in our database
-  CAddonDatabase database;
-  database.Open();
-  database.DisableAddon(m_localAddon->ID(), false);
+  CAddonMgr::Get().DisableAddon(m_localAddon->ID(), false);
+
   CJobManager::GetInstance().AddJob(new CAddonUnInstallJob(m_localAddon),
                                     &CAddonInstaller::Get());
   CAddonMgr::Get().RemoveAddon(m_localAddon->ID());
@@ -221,12 +220,7 @@ void CGUIDialogAddonInfo::OnEnable(bool enable)
   if (!m_localAddon.get())
     return;
 
-  CStdString xbmcPath = CSpecialProtocol::TranslatePath("special://xbmc/addons");
-  CAddonDatabase database;
-  database.Open();
-  database.DisableAddon(m_localAddon->ID(), !enable);
-  database.Close();
-
+  CAddonMgr::Get().DisableAddon(m_localAddon->ID(), !enable);
   SetItem(m_item);
   UpdateControls();
   g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -250,7 +250,7 @@ bool CRepositoryUpdateJob::DoWork()
                                              g_localizeStrings.Get(24096),
                                              g_localizeStrings.Get(24097),
                                              ""))
-          database.DisableAddon(addons[i]->ID());
+          CAddonMgr::Get().DisableAddon(addons[i]->ID());
       }
     }
     database.BreakAddon(addons[i]->ID(), addons[i]->Props().broken);

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -203,8 +203,6 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
 {
   CStdString xbmcPath = CSpecialProtocol::TranslatePath("special://xbmc/addons");
   items.ClearItems();
-  CAddonDatabase db;
-  db.Open();
   for (unsigned i=0; i < addons.size(); i++)
   {
     AddonPtr addon = addons[i];
@@ -216,7 +214,7 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
     AddonPtr addon2;
     if (CAddonMgr::Get().GetAddon(addon->ID(),addon2))
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(305));
-    else if (db.IsOpen() && db.IsAddonDisabled(addon->ID()))
+    else if (CAddonMgr::Get().IsAddonDisabled(addon->ID()))
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24023));
 
     if (!addon->Props().broken.IsEmpty())
@@ -229,7 +227,6 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
     CAddonDatabase::SetPropertiesFromAddon(addon,pItem);
     items.Add(pItem);
   }
-  db.Close();
 }
 
 CFileItemPtr CAddonsDirectory::FileItemFromAddon(AddonPtr &addon, const CStdString &basePath, bool folder)

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -142,21 +142,17 @@ JSONRPC_STATUS CAddonsOperations::GetAddonDetails(const CStdString &method, ITra
 
 JSONRPC_STATUS CAddonsOperations::SetAddonEnabled(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  CAddonDatabase addondatabase;
-  if (!addondatabase.Open())
-    return InternalError;
-
   string id = parameterObject["addonid"].asString();
   bool disabled = false;
   if (parameterObject["enabled"].isBoolean())
     disabled = !parameterObject["enabled"].asBoolean();
   // we need to toggle the current disabled state of the addon
   else if (parameterObject["enabled"].isString())
-    disabled = !addondatabase.IsAddonDisabled(id);
+    disabled = !CAddonMgr::Get().IsAddonDisabled(id);
   else
     return InvalidParams;
 
-  if (!addondatabase.DisableAddon(id, disabled))
+  if (!CAddonMgr::Get().DisableAddon(id, disabled))
       return InvalidParams;
 
   return ACK;
@@ -221,9 +217,7 @@ void CAddonsOperations::FillDetails(AddonPtr addon, const CVariant& fields, CVar
     // from the addon database because it can't be read from addon.xml
     if (field == "enabled")
     {
-      if (!addondb.IsOpen() && !addondb.Open())
-        return;
-      object[field] = !addondb.IsAddonDisabled(addon->ID());
+      object[field] = !CAddonMgr::Get().IsAddonDisabled(addon->ID());
     }
     else if (field == "fanart" || field == "thumbnail")
     {

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -176,11 +176,8 @@ bool CPVRDatabase::CreateTables()
       CLog::Log(LOGERROR, "PVR - %s - failed to get add-ons from the add-on manager", __FUNCTION__);
     else
     {
-      CAddonDatabase database;
-      database.Open();
       for (IVECADDONS it = addons.begin(); it != addons.end(); it++)
-        database.DisableAddon(it->get()->ID());
-      database.Close();
+        CAddonMgr::Get().DisableAddon(it->get()->ID());
     }
   }
 
@@ -253,7 +250,7 @@ bool CPVRDatabase::UpdateOldVersion(int iVersion)
           for (IVECADDONS it = addons.begin(); it != addons.end(); it++)
           {
             if (!database.IsSystemPVRAddonEnabled(it->get()->ID()))
-              database.DisableAddon(it->get()->ID());
+              CAddonMgr::Get().DisableAddon(it->get()->ID());
           }
           database.Close();
         }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -894,7 +894,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
   {
     const AddonPtr clientAddon = map.at(iClientPtr);
     bool bEnabled = clientAddon->Enabled() &&
-        !m_addonDb.IsAddonDisabled(clientAddon->ID());
+        !CAddonMgr::Get().IsAddonDisabled(clientAddon->ID());
 
     if (!bEnabled && IsKnownClient(clientAddon))
     {
@@ -970,7 +970,7 @@ bool CPVRClients::UpdateAndInitialiseClients(bool bInitialiseAllClients /* = fal
     for (ADDON::VECADDONS::iterator it = disableAddons.begin(); it != disableAddons.end(); it++)
     {
       // disable in the add-on db
-      m_addonDb.DisableAddon((*it)->ID(), true);
+      CAddonMgr::Get().DisableAddon((*it)->ID(), true);
 
       // remove from the pvr add-on list
       ADDON::VECADDONS::iterator addonPtr = std::find(m_addons.begin(), m_addons.end(), *it);


### PR DESCRIPTION
This implements DisableAddon and IsAddonDisabled in AddonMgr. Both functions will trigger the database routines
and cache the current addon state instead of doing the database query again. In case the disabled cache does not
know about the current state the database routine will be used to retrieve it.
