### PR TITLE
CurlFile - update 02

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -587,8 +587,6 @@ void CCurlFile::SetCommonOptions(CReadState* state)
 
   if (m_useOldHttpVersion)
     g_curlInterface.easy_setopt(h, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
-  else
-    SetRequestHeader("Connection", "keep-alive");
 
   if (g_advancedSettings.m_curlDisableIPV6)
     g_curlInterface.easy_setopt(h, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -417,6 +417,7 @@ CCurlFile::CCurlFile()
   m_oldState = NULL;
   m_skipshout = false;
   m_httpresponse = -1;
+  m_acceptCharset = "UTF-8,*;q=0.8"; /* prefer UTF-8 if available */
 }
 
 //Has to be called before Open()
@@ -575,6 +576,9 @@ void CCurlFile::SetCommonOptions(CReadState* state)
   // setup Content-Encoding if requested
   if( m_contentencoding.length() > 0 )
     g_curlInterface.easy_setopt(h, CURLOPT_ENCODING, m_contentencoding.c_str());
+
+  if (!m_useOldHttpVersion && !m_acceptCharset.empty())
+    SetRequestHeader("Accept-Charset", m_acceptCharset);
 
   if (m_userAgent.length() > 0)
     g_curlInterface.easy_setopt(h, CURLOPT_USERAGENT, m_userAgent.c_str());
@@ -783,6 +787,8 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
           m_skipshout = true;
         else if (name.Equals("seekable") && value.Equals("0"))
           m_seekable = false;
+        else if (name.Equals("Accept-Charset"))
+          SetAcceptCharset(value);
         else
           SetRequestHeader(name, value);
       }

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -77,6 +77,7 @@ namespace XFILE
       void SetCustomRequest(CStdString &request)                 { m_customrequest = request; }
       void UseOldHttpVersion(bool bUse)                          { m_useOldHttpVersion = bUse; }
       void SetContentEncoding(CStdString encoding)               { m_contentencoding = encoding; }
+      void SetAcceptCharset(const std::string& charset)          { m_acceptCharset = charset; }
       void SetTimeout(int connecttimeout)                        { m_connecttimeout = connecttimeout; }
       void SetLowSpeedTime(int lowspeedtime)                     { m_lowspeedtime = lowspeedtime; }
       void SetPostData(CStdString postdata)                      { m_postdata = postdata; }
@@ -160,6 +161,7 @@ namespace XFILE
       ProxyType       m_proxytype;
       CStdString      m_customrequest;
       CStdString      m_contentencoding;
+      std::string     m_acceptCharset;
       CStdString      m_ftpauth;
       CStdString      m_ftpport;
       CStdString      m_binary;


### PR DESCRIPTION
This is second part of larger PR #3226 (first part: PR #3462).

In this PR I add ability to request some specific charset from HTTP-server, set default to "UTF-8,*;q=0.8" (means "I want UTF-8, if available, but I'll will accept any other if UTF-8 not available").

And removed explicit addition of "Connection: keep-alive" as cURL lib will do it already (to prevent duplication of request header parameters). 
