### PR TITLE
FIX: crash with missing controls in DialogKaiToast

### DIFF
--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -145,10 +145,14 @@ bool CGUIDialogKaiToast::DoWork()
         else
           typeImage = image;
 
-        strTypeImage = typeImage->GetFileName();
+        if (typeImage)
+          strTypeImage = typeImage->GetFileName();
+        else
+          CLog::Log(LOGWARNING, "Missing control in DialogKaiToast: %d", toast.eType);
       }
 
-      image->SetFileName(strTypeImage);
+      if (!strTypeImage.IsEmpty())
+        image->SetFileName(strTypeImage);
     }
 
     //  Play the window specific init sound for each notification queued

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -38,6 +38,7 @@ CCriticalSection CGUIDialogKaiToast::m_critical;
 CGUIDialogKaiToast::CGUIDialogKaiToast(void)
 : CGUIDialog(WINDOW_DIALOG_KAI_TOAST, "DialogKaiToast.xml")
 {
+  m_defaultIcon = "";
   m_loadType = LOAD_ON_GUI_INIT;
   m_timer = 0;
   m_toastDisplayTime = 0;
@@ -71,6 +72,9 @@ bool CGUIDialogKaiToast::OnMessage(CGUIMessage& message)
 void CGUIDialogKaiToast::OnWindowLoaded()
 {
   CGUIDialog::OnWindowLoaded();
+  CGUIImage *image = (CGUIImage *)GetControl(POPUP_ICON);
+  if (image)
+    m_defaultIcon = image->GetFileName();
 }
 
 void CGUIDialogKaiToast::QueueNotification(eMessageType eType, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
@@ -148,11 +152,10 @@ bool CGUIDialogKaiToast::DoWork()
         if (typeImage)
           strTypeImage = typeImage->GetFileName();
         else
-          CLog::Log(LOGWARNING, "Missing control in DialogKaiToast: %d", toast.eType);
+          strTypeImage = m_defaultIcon;
       }
 
-      if (!strTypeImage.IsEmpty())
-        image->SetFileName(strTypeImage);
+      image->SetFileName(strTypeImage);
     }
 
     //  Play the window specific init sound for each notification queued

--- a/xbmc/dialogs/GUIDialogKaiToast.h
+++ b/xbmc/dialogs/GUIDialogKaiToast.h
@@ -66,6 +66,8 @@ protected:
   unsigned int m_toastDisplayTime;
   unsigned int m_toastMessageTime;
 
+  CStdString m_defaultIcon;
+  
   static TOASTQUEUE m_notifications;
   static CCriticalSection m_critical;
 };


### PR DESCRIPTION
Detected by Martijn with the Droid skin, which miss the Error, ... icons.
