### PR TITLE
CurlFile - update 03

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1546,6 +1546,14 @@ void CCurlFile::SetRequestHeader(CStdString header, long value)
   m_requestheaders[header] = buffer;
 }
 
+std::string CCurlFile::GetServerReportedCharset(void)
+{
+  if (!m_state)
+    return "";
+
+  return m_state->m_httpheader.GetCharset();
+}
+
 /* STATIC FUNCTIONS */
 bool CCurlFile::GetHttpHeader(const CURL &url, CHttpHeader &headers)
 {

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -147,24 +147,19 @@ size_t CCurlFile::CReadState::HeaderCallback(void *ptr, size_t size, size_t nmem
     m_headerdone = false;
   }
 
+  std::string inString;
   // libcurl doc says that this info is not always \0 terminated
-  char* strData = (char*)ptr;
-  int iSize = size * nmemb;
+  const char* strBuf = (const char*)ptr;
+  const size_t iSize = size * nmemb;
+  if (strBuf[iSize - 1] == 0)
+    inString.assign(strBuf, iSize - 1); // skip last char if it's zero
+  else
+    inString.append(strBuf, iSize);
 
-  if (strData[iSize] != 0)
-  {
-    strData = (char*)malloc(iSize + 1);
-    strncpy(strData, (char*)ptr, iSize);
-    strData[iSize] = 0;
-  }
-  else strData = strdup((char*)ptr);
-
-  if(strcmp(strData, "\r\n") == 0)
+  if(inString == "\r\n")
     m_headerdone = true;
 
-  m_httpheader.Parse(strData);
-
-  free(strData);
+  m_httpheader.Parse(inString);
 
   return iSize;
 }

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -652,7 +652,7 @@ void CCurlFile::SetCorrectHeaders(CReadState* state)
     if( !h.GetValue("icy-notice1").empty()
     || !h.GetValue("icy-name").empty()
     || !h.GetValue("icy-br").empty() )
-    h.Parse("Content-Type: audio/mpeg\r\n");
+      h.AddParam("Content-Type", "audio/mpeg");
   }
 
   /* hack for google video */
@@ -661,7 +661,7 @@ void CCurlFile::SetCorrectHeaders(CReadState* state)
   {
     CStdString strValue = h.GetValue("Content-Disposition");
     if (strValue.Find("filename=") > -1 && strValue.Find(".flv") > -1)
-      h.Parse("Content-Type: video/flv\r\n");
+      h.AddParam("Content-Type", "video/flv");
   }
 }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -140,13 +140,6 @@ static inline void* realloc_simple(void *ptr, size_t size)
 
 size_t CCurlFile::CReadState::HeaderCallback(void *ptr, size_t size, size_t nmemb)
 {
-  // clear any previous header
-  if(m_headerdone)
-  {
-    m_httpheader.Clear();
-    m_headerdone = false;
-  }
-
   std::string inString;
   // libcurl doc says that this info is not always \0 terminated
   const char* strBuf = (const char*)ptr;
@@ -155,9 +148,6 @@ size_t CCurlFile::CReadState::HeaderCallback(void *ptr, size_t size, size_t nmem
     inString.assign(strBuf, iSize - 1); // skip last char if it's zero
   else
     inString.append(strBuf, iSize);
-
-  if(inString == "\r\n")
-    m_headerdone = true;
 
   m_httpheader.Parse(inString);
 
@@ -243,7 +233,6 @@ CCurlFile::CReadState::CReadState()
   m_cancelled = false;
   m_bFirstLoop = true;
   m_sendRange = true;
-  m_headerdone = false;
   m_readBuffer = 0;
   m_isPaused = false;
   m_curlHeaderList = NULL;
@@ -327,7 +316,7 @@ long CCurlFile::CReadState::Connect(unsigned int size)
   m_bufferSize = size;
   m_buffer.Destroy();
   m_buffer.Create(size * 3);
-  m_headerdone = false;
+  m_httpheader.Clear();
 
   // read some data in to try and obtain the length
   // maybe there's a better way to get this info??

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -90,6 +90,7 @@ namespace XFILE
       void SetBufferSize(unsigned int size);
 
       const CHttpHeader& GetHttpHeader() { return m_state->m_httpheader; }
+      std::string GetServerReportedCharset(void);
 
       /* static function that will get content type of a file */
       static bool GetHttpHeader(const CURL &url, CHttpHeader &headers);

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -120,7 +120,8 @@ namespace XFILE
 
           /* returned http header */
           CHttpHeader m_httpheader;
-          bool        m_headerdone;
+          bool        IsHeaderDone(void)
+          { return m_httpheader.IsHeaderDone(); }
 
           struct XCURL::curl_slist* m_curlHeaderList;
           struct XCURL::curl_slist* m_curlAliasList;

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -94,10 +94,16 @@ void CHttpHeader::AddParam(const std::string& param, const std::string& value, c
   m_params.push_back(HeaderParams::value_type(paramLower, value));
 }
 
-std::string CHttpHeader::GetValue(std::string strParam) const
+std::string CHttpHeader::GetValue(const std::string& strParam) const
 {
-  StringUtils::ToLower(strParam);
+  std::string paramLower(strParam);
+  StringUtils::ToLower(paramLower);
 
+  return GetValueRaw(paramLower);
+}
+
+std::string CHttpHeader::GetValueRaw(const std::string& strParam) const
+{
   // look in reverse to find last parameter (probably most important)
   for (HeaderParams::const_reverse_iterator iter = m_params.rbegin(); iter != m_params.rend(); ++iter)
   {

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -61,6 +61,30 @@ void CHttpHeader::Parse(const std::string& strData)
   }
 }
 
+void CHttpHeader::AddParam(const std::string& param, const std::string& value, const bool overwrite /*= false*/)
+{
+  if (param.empty() || value.empty())
+    return;
+
+  std::string paramLower(param);
+  if (overwrite)
+  { // delete ALL parameters with the same name
+    // note: 'GetValue' always returns last added parameter,
+    //       so you probably don't need to overwrite 
+    for (size_t i = 0; i < m_params.size();)
+    {
+      if (m_params[i].first == param)
+        m_params.erase(m_params.begin() + i);
+      else
+        ++i;
+    }
+  }
+
+  StringUtils::ToLower(paramLower);
+
+  m_params.push_back(HeaderParams::value_type(paramLower, value));
+}
+
 std::string CHttpHeader::GetValue(std::string strParam) const
 {
   StringUtils::ToLower(strParam);

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -139,6 +139,13 @@ std::string CHttpHeader::GetHeader(void) const
   return strHeader;
 }
 
+std::string CHttpHeader::GetMimeType(void) const
+{
+  std::string strValue(GetValueRaw("content-type"));
+
+  return strValue.substr(0, strValue.find(';'));
+}
+
 void CHttpHeader::Clear()
 {
   m_params.clear();

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -23,6 +23,7 @@
 
 CHttpHeader::CHttpHeader()
 {
+  m_headerdone = false;
 }
 
 CHttpHeader::~CHttpHeader()
@@ -31,6 +32,9 @@ CHttpHeader::~CHttpHeader()
 
 void CHttpHeader::Parse(const std::string& strData)
 {
+  if (m_headerdone)
+    Clear();
+
   size_t pos = 0;
   const size_t len = strData.length();
   while (pos < len)
@@ -41,7 +45,12 @@ void CHttpHeader::Parse(const std::string& strData)
     if (lineEnd == std::string::npos)
       break;
 
-    if (valueStart != std::string::npos && valueStart < lineEnd)
+    if (lineEnd == pos)
+    {
+      m_headerdone = true;
+      break;
+    }
+    else if (valueStart != std::string::npos && valueStart < lineEnd)
     {
       std::string strParam(strData, pos, valueStart - pos);
       std::string strValue(strData, valueStart + 1, lineEnd - valueStart - 1);
@@ -128,4 +137,5 @@ void CHttpHeader::Clear()
 {
   m_params.clear();
   m_protoLine.clear();
+  m_headerdone = false;
 }

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -146,6 +146,28 @@ std::string CHttpHeader::GetMimeType(void) const
   return strValue.substr(0, strValue.find(';'));
 }
 
+std::string CHttpHeader::GetCharset(void) const
+{
+  std::string strValue(GetValueRaw("content-type"));
+  if (strValue.empty())
+    return strValue;
+
+  const size_t semicolonPos = strValue.find(';');
+  if (semicolonPos == std::string::npos)
+    return "";
+
+  StringUtils::ToUpper(strValue);
+  size_t posCharset;
+  if ((posCharset = strValue.find("; CHARSET=", semicolonPos)) != std::string::npos)
+    posCharset += 10;
+  else if ((posCharset = strValue.find(";CHARSET=", semicolonPos)) != std::string::npos)
+    posCharset += 9;
+  else
+    return "";
+
+  return strValue.substr(posCharset, strValue.find(';', posCharset) - posCharset);
+}
+
 void CHttpHeader::Clear()
 {
   m_params.clear();

--- a/xbmc/utils/HttpHeader.h
+++ b/xbmc/utils/HttpHeader.h
@@ -47,10 +47,14 @@ public:
   std::string GetMimeType() { return GetValue(HTTPHEADER_CONTENT_TYPE); }
   std::string GetProtoLine() { return m_protoLine; }
 
+  inline bool IsHeaderDone(void) const
+  { return m_headerdone; }
+
   void Clear();
 
 protected:
   HeaderParams m_params;
   std::string   m_protoLine;
+  bool m_headerdone;
 };
 

--- a/xbmc/utils/HttpHeader.h
+++ b/xbmc/utils/HttpHeader.h
@@ -43,6 +43,7 @@ public:
   std::string GetHeader(void) const;
 
   std::string GetMimeType(void) const;
+  std::string GetCharset(void) const;
   std::string GetProtoLine() { return m_protoLine; }
 
   inline bool IsHeaderDone(void) const

--- a/xbmc/utils/HttpHeader.h
+++ b/xbmc/utils/HttpHeader.h
@@ -44,7 +44,8 @@ public:
 
   std::string GetMimeType(void) const;
   std::string GetCharset(void) const;
-  std::string GetProtoLine() { return m_protoLine; }
+  inline std::string GetProtoLine() const
+  { return m_protoLine; }
 
   inline bool IsHeaderDone(void) const
   { return m_headerdone; }

--- a/xbmc/utils/HttpHeader.h
+++ b/xbmc/utils/HttpHeader.h
@@ -24,8 +24,6 @@
 #include <vector>
 #include <string>
 
-#define HTTPHEADER_CONTENT_TYPE "Content-Type"
-
 class CHttpHeader
 {
 public:
@@ -44,7 +42,7 @@ public:
 
   std::string GetHeader(void) const;
 
-  std::string GetMimeType() { return GetValue(HTTPHEADER_CONTENT_TYPE); }
+  std::string GetMimeType(void) const;
   std::string GetProtoLine() { return m_protoLine; }
 
   inline bool IsHeaderDone(void) const

--- a/xbmc/utils/HttpHeader.h
+++ b/xbmc/utils/HttpHeader.h
@@ -39,7 +39,7 @@ public:
   void Parse(const std::string& strData);
   void AddParam(const std::string& param, const std::string& value, const bool overwrite = false);
 
-  std::string GetValue(std::string strParam) const;
+  std::string GetValue(const std::string& strParam) const;
   std::vector<std::string> GetValues(std::string strParam) const;
 
   std::string GetHeader(void) const;
@@ -53,6 +53,8 @@ public:
   void Clear();
 
 protected:
+  std::string GetValueRaw(const std::string& strParam) const;
+
   HeaderParams m_params;
   std::string   m_protoLine;
   bool m_headerdone;

--- a/xbmc/utils/HttpHeader.h
+++ b/xbmc/utils/HttpHeader.h
@@ -37,6 +37,8 @@ public:
   ~CHttpHeader();
 
   void Parse(const std::string& strData);
+  void AddParam(const std::string& param, const std::string& value, const bool overwrite = false);
+
   std::string GetValue(std::string strParam) const;
   std::vector<std::string> GetValues(std::string strParam) const;
 


### PR DESCRIPTION
This is part of larger PR #3226 (other parts: #3462, #3464).

This PR will move header parsing logic from CurlFile directly to HttpHeader, add 'AddParam' and 'GetCharset' functions to HttpHeader and add 'GetServerReportedCharset' function to CurlFile.

Some fixes and refactoring included.
