### PR TITLE
depends: use -isystem instead of -I to add system includes

### DIFF
--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -46,10 +46,10 @@ READELF=@READELF@
 OBJDUMP=@OBJDUMP@
 
 CMAKE=@prefix@/@tool_dir@/bin/cmake -DCMAKE_TOOLCHAIN_FILE=$(PREFIX)/share/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=$(PREFIX)
-CFLAGS=@platform_cflags@ @platform_includes@ -I@prefix@/@deps_dir@/include
+CFLAGS=@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include
 LDFLAGS=-L@prefix@/@deps_dir@/lib @platform_ldflags@
-CXXFLAGS=@platform_cxxflags@ @platform_includes@ -I@prefix@/@deps_dir@/include
-CPPFLAGS=@platform_cflags@ @platform_includes@ -I@prefix@/@deps_dir@/include
+CXXFLAGS=@platform_cxxflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include
+CPPFLAGS=@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include
 
 PATH:=@prefix@/@tool_dir@/bin:$(PATH)
 ifneq (@use_build_toolchain@,)

--- a/tools/depends/target/config.site.in
+++ b/tools/depends/target/config.site.in
@@ -20,10 +20,10 @@ if test "@platform_os@" = "ios" ; then
   export CCAS="--tag CC @prefix@/@tool_dir@/bin/gas-preprocessor.pl @CC@ -arch @use_cpu@"
 fi
 
-CFLAGS="@platform_cflags@ @platform_includes@ -I@prefix@/@deps_dir@/include $CFLAGS"
+CFLAGS="@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include $CFLAGS"
 LDFLAGS="-L@prefix@/@deps_dir@/lib @platform_ldflags@ $LDFLAGS"
-CXXFLAGS="@platform_cxxflags@ @platform_includes@ -I@prefix@/@deps_dir@/include $CXXFLAGS"
-CPPFLAGS="@platform_cflags@ @platform_includes@ -I@prefix@/@deps_dir@/include $CPPFLAGS"
+CXXFLAGS="@platform_cxxflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include $CXXFLAGS"
+CPPFLAGS="@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include $CPPFLAGS"
 
 export PKG_CONFIG=@prefix@/@tool_dir@/bin/pkg-config
 export PKG_CONFIG_LIBDIR=@prefix@/@deps_dir@/lib/pkgconfig


### PR DESCRIPTION
This avoids libs using already installed system headers when
building themselves.
