### PR TITLE
Actor order fixes

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -739,9 +739,7 @@ protected:
   void AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
   void RemoveFromLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
 
-  void AddActorToMovie(int idMovie, int idActor, const CStdString& strRole, int order);
-  void AddActorToTvShow(int idTvShow, int idActor, const CStdString& strRole, int order);
-  void AddActorToEpisode(int idEpisode, int idActor, const CStdString& strRole, int order);
+  void AddCast(int idMedia, const char *table, const char *field, const std::vector<SActorInfo> &cast);
   void AddArtistToMusicVideo(int lMVideo, int idArtist);
 
   void AddDirectorToMovie(int idMovie, int idDirector);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -223,18 +223,9 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathIn
     // add a <actor> tag
     TiXmlElement cast("actor");
     TiXmlNode *node = movie->InsertEndChild(cast);
-    TiXmlElement actor("name");
-    TiXmlNode *actorNode = node->InsertEndChild(actor);
-    TiXmlText name(it->strName);
-    actorNode->InsertEndChild(name);
-    TiXmlElement role("role");
-    TiXmlNode *roleNode = node->InsertEndChild(role);
-    TiXmlText character(it->strRole);
-    roleNode->InsertEndChild(character);
-    TiXmlElement thumb("thumb");
-    TiXmlNode *thumbNode = node->InsertEndChild(thumb);
-    TiXmlText th(it->thumbUrl.GetFirstThumb().m_url);
-    thumbNode->InsertEndChild(th);
+    XMLUtils::SetString(node, "name", it->strName);
+    XMLUtils::SetString(node, "role", it->strRole);
+    XMLUtils::SetString(node, "thumb", it->thumbUrl.GetFirstThumb().m_url);
   }
   XMLUtils::SetStringArray(movie, "artist", m_artist);
   XMLUtils::SetStringArray(movie, "showlink", m_showLink);
@@ -648,9 +639,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     {
       SActorInfo info;
       info.strName = actor->FirstChild()->Value();
-      const TiXmlNode *roleNode = node->FirstChild("role");
-      if (roleNode && roleNode->FirstChild())
-        info.strRole = roleNode->FirstChild()->Value();
+      XMLUtils::GetString(node, "role", info.strRole);
       const TiXmlElement* thumb = node->FirstChildElement("thumb");
       while (thumb)
       {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -225,6 +225,7 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathIn
     TiXmlNode *node = movie->InsertEndChild(cast);
     XMLUtils::SetString(node, "name", it->strName);
     XMLUtils::SetString(node, "role", it->strRole);
+    XMLUtils::SetInt(node, "order", it->order);
     XMLUtils::SetString(node, "thumb", it->thumbUrl.GetFirstThumb().m_url);
   }
   XMLUtils::SetStringArray(movie, "artist", m_artist);
@@ -277,6 +278,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     {
       ar << m_cast[i].strName;
       ar << m_cast[i].strRole;
+      ar << m_cast[i].order;
       ar << m_cast[i].thumb;
       ar << m_cast[i].thumbUrl.m_xml;
     }
@@ -351,6 +353,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
       SActorInfo info;
       ar >> info.strName;
       ar >> info.strRole;
+      ar >> info.order;
       ar >> info.thumb;
       CStdString strXml;
       ar >> strXml;
@@ -427,6 +430,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
     CVariant actor;
     actor["name"] = m_cast[i].strName;
     actor["role"] = m_cast[i].strRole;
+    actor["order"] = m_cast[i].order;
     if (!m_cast[i].thumb.IsEmpty())
       actor["thumbnail"] = CTextureCache::GetWrappedImageURL(m_cast[i].thumb);
     value["cast"].push_back(actor);
@@ -640,6 +644,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
       SActorInfo info;
       info.strName = actor->FirstChild()->Value();
       XMLUtils::GetString(node, "role", info.strRole);
+      XMLUtils::GetInt(node, "order", info.order);
       const TiXmlElement* thumb = node->FirstChildElement("thumb");
       while (thumb)
       {

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -33,10 +33,16 @@ class TiXmlElement;
 
 struct SActorInfo
 {
+  SActorInfo() : order(-1) {};
+  bool operator<(const SActorInfo &right) const
+  {
+    return order < right.order;
+  }
   CStdString strName;
   CStdString strRole;
   CScraperUrl thumbUrl;
   CStdString thumb;
+  int        order;
 };
 
 class CVideoInfoTag : public IArchivable, public ISerializable, public ISortable


### PR DESCRIPTION
TheMovieDB.org returns cast information with an explicit order attribute, which the common themoviedb.org scraper now supports.  This adds the necessary glue to associate this ordering with the existing ordering in the video database.

Potentially this could be backported to 12.3, but it's really a cosmetic issue (bad ordering of actors on the movie information page).
