### PR TITLE
Allow ffmpeg multi-core decoding when hardware accelerate switches are all off

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -253,7 +253,17 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
     CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading for Hi10p: %d",
                         m_pCodecContext->thread_type);
   }
-  else
+  else if(false
+#ifdef HAVE_LIBVDPAU
+    || CSettings::Get().GetBool("videoplayer.usevdpau")
+#endif
+#ifdef HAS_DX
+    || CSettings::Get().GetBool("videoplayer.usedxva2")
+#endif
+#ifdef HAVE_LIBVA
+    || CSettings::Get().GetBool("videoplayer.usevaapi")
+#endif
+    )
     m_pCodecContext->thread_type = FF_THREAD_SLICE;
 
 #if defined(TARGET_DARWIN_IOS)


### PR DESCRIPTION
ffmpeg-mt should be used when no hardware accelerate available or usable. but current code only allow it for hi10p.

it's possible to apply ffmpeg-mt when no hardware accelerate switch is on, that means either the system does not support hardware accelerate, or user switched off the hw accel manually. on both situations, user can benefit from the multi-core decoding.
