### PR TITLE
Add support for mov reference playlists

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -501,6 +501,9 @@
 		DFB25D46163D4743006C4A48 /* WindowDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD1E215FCE77900E10810 /* WindowDialog.cpp */; };
 		DFB25D47163D4743006C4A48 /* WindowDialogMixin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD1E615FCE77900E10810 /* WindowDialogMixin.cpp */; };
 		DFB25D48163D4743006C4A48 /* WindowXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1AD1EC15FCE77900E10810 /* WindowXML.cpp */; };
+		DFB594921815D441006DA1C0 /* PlayListMov.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB594901815D441006DA1C0 /* PlayListMov.cpp */; };
+		DFB594931815D441006DA1C0 /* PlayListMov.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB594901815D441006DA1C0 /* PlayListMov.cpp */; };
+		DFB594941815D441006DA1C0 /* PlayListMov.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB594901815D441006DA1C0 /* PlayListMov.cpp */; };
 		DFB65FB515373AE7006B8FF1 /* AEFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6515373AE7006B8FF1 /* AEFactory.cpp */; };
 		DFB65FB715373AE7006B8FF1 /* AEEncoderFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6A15373AE7006B8FF1 /* AEEncoderFFmpeg.cpp */; };
 		DFB65FB815373AE7006B8FF1 /* CoreAudioAE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6D15373AE7006B8FF1 /* CoreAudioAE.cpp */; };
@@ -4180,6 +4183,8 @@
 		DFB0F471161B747500D744F4 /* AddonsOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddonsOperations.h; sourceTree = "<group>"; };
 		DFB15B2015F8FB8100CDF0DE /* SDLMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLMain.h; sourceTree = "<group>"; };
 		DFB15B2115F8FB8100CDF0DE /* SDLMain.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SDLMain.mm; sourceTree = "<group>"; };
+		DFB594901815D441006DA1C0 /* PlayListMov.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlayListMov.cpp; sourceTree = "<group>"; };
+		DFB594911815D441006DA1C0 /* PlayListMov.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlayListMov.h; sourceTree = "<group>"; };
 		DFB65F6415373AE7006B8FF1 /* AEAudioFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEAudioFormat.h; sourceTree = "<group>"; };
 		DFB65F6515373AE7006B8FF1 /* AEFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AEFactory.cpp; sourceTree = "<group>"; };
 		DFB65F6615373AE7006B8FF1 /* AEFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFactory.h; sourceTree = "<group>"; };
@@ -6036,6 +6041,8 @@
 				18B7C922129428CA009E7A26 /* PlayListFactory.h */,
 				18B7C923129428CA009E7A26 /* PlayListM3U.cpp */,
 				18B7C924129428CA009E7A26 /* PlayListM3U.h */,
+				DFB594901815D441006DA1C0 /* PlayListMov.cpp */,
+				DFB594911815D441006DA1C0 /* PlayListMov.h */,
 				18B7C925129428CA009E7A26 /* PlayListPLS.cpp */,
 				18B7C926129428CA009E7A26 /* PlayListPLS.h */,
 				18B7C927129428CA009E7A26 /* PlayListURL.cpp */,
@@ -10624,6 +10631,7 @@
 				DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E917DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35617F3412C004FC217 /* WinEvents.cpp in Sources */,
+				DFB594921815D441006DA1C0 /* PlayListMov.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11654,6 +11662,7 @@
 				DFD882F617DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E717DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35817F3412C004FC217 /* WinEvents.cpp in Sources */,
+				DFB594941815D441006DA1C0 /* PlayListMov.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12686,6 +12695,7 @@
 				DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E817DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35717F3412C004FC217 /* WinEvents.cpp in Sources */,
+				DFB594931815D441006DA1C0 /* PlayListMov.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -914,6 +914,7 @@
     <ClCompile Include="..\..\xbmc\playlists\PlayListB4S.cpp" />
     <ClCompile Include="..\..\xbmc\playlists\PlayListFactory.cpp" />
     <ClCompile Include="..\..\xbmc\playlists\PlayListM3U.cpp" />
+    <ClCompile Include="..\..\xbmc\playlists\PlayListMOV.cpp" />
     <ClCompile Include="..\..\xbmc\playlists\PlayListPLS.cpp" />
     <ClCompile Include="..\..\xbmc\playlists\PlayListURL.cpp" />
     <ClCompile Include="..\..\xbmc\playlists\PlayListWPL.cpp" />
@@ -2354,6 +2355,7 @@
     <ClInclude Include="..\..\xbmc\playlists\PlayListB4S.h" />
     <ClInclude Include="..\..\xbmc\playlists\PlayListFactory.h" />
     <ClInclude Include="..\..\xbmc\playlists\PlayListM3U.h" />
+    <ClInclude Include="..\..\xbmc\playlists\PlayListMOV.h" />
     <ClInclude Include="..\..\xbmc\playlists\PlayListPLS.h" />
     <ClInclude Include="..\..\xbmc\playlists\PlayListURL.h" />
     <ClInclude Include="..\..\xbmc\playlists\PlayListWPL.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1375,6 +1375,9 @@
     <ClCompile Include="..\..\xbmc\playlists\PlayListM3U.cpp">
       <Filter>playlists</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\playlists\PlayListMOV.cpp">
+      <Filter>playlists</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\playlists\PlayListPLS.cpp">
       <Filter>playlists</Filter>
     </ClCompile>
@@ -4356,6 +4359,9 @@
       <Filter>playlists</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\playlists\PlayListM3U.h">
+      <Filter>playlists</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\playlists\PlayListMOV.h">
       <Filter>playlists</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\playlists\PlayListPLS.h">

--- a/xbmc/playlists/Makefile
+++ b/xbmc/playlists/Makefile
@@ -2,6 +2,7 @@ SRCS=PlayListB4S.cpp \
      PlayList.cpp \
      PlayListFactory.cpp \
      PlayListM3U.cpp \
+     PlayListMov.cpp \
      PlayListPLS.cpp \
      PlayListURL.cpp \
      PlayListWPL.cpp \

--- a/xbmc/playlists/PlayListFactory.h
+++ b/xbmc/playlists/PlayListFactory.h
@@ -22,6 +22,7 @@
 #include "utils/StdString.h"
 
 class CFileItem;
+class CDVDInputStream;
 
 namespace PLAYLIST
 {
@@ -34,5 +35,10 @@ namespace PLAYLIST
     static CPlayList* Create(const CFileItem& item);
     static bool IsPlaylist(const CStdString& filename);
     static bool IsPlaylist(const CFileItem& item);
+    
+    // if the input stream points to some sort of playlist with bandwidth information
+    // this method will redirect the inputstream to the best fit (e.x. m3u8 or mov reference playlist)
+    // the inputStream has to be opened already for this method!
+    static bool HandleRedirects(CDVDInputStream *inputStream, unsigned int bandwidth);
   };
 }

--- a/xbmc/playlists/PlayListM3U.h
+++ b/xbmc/playlists/PlayListM3U.h
@@ -20,6 +20,8 @@
  */
 #include "PlayList.h"
 
+class CDVDInputStream;
+
 namespace PLAYLIST
 {
 class CPlayListM3U :
@@ -31,7 +33,7 @@ public:
   virtual bool Load(const CStdString& strFileName);
   virtual void Save(const CStdString& strFileName) const;
 
-  static CStdString GetBestBandwidthStream(const CStdString &strFileName, size_t bandwidth);
+  static bool HandleRedirects(CDVDInputStream *inputStream, unsigned int bandwidth);
 
 protected:
 

--- a/xbmc/playlists/PlayListMov.cpp
+++ b/xbmc/playlists/PlayListMov.cpp
@@ -1,0 +1,155 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PlayListMov.h"
+#include "URL.h"
+#include "utils/URIUtils.h"
+#include "DVDInputStreams/DVDInputStream.h"
+#include "utils/log.h"
+#include "filesystem/File.h"
+#include "PlayListM3U.h"
+
+using namespace PLAYLIST;
+
+// parse mov refernce files based on http://wiki.multimedia.cx/index.php?title=QuickTime_container#rmcd
+bool CPlayListMov::HandleRedirects(CDVDInputStream *inputStream, unsigned int bandwidth)
+{
+  unsigned int maxBandwidth = 0;
+  bool redirected = false;
+
+  if (!inputStream)
+    return redirected;
+
+  CURL url= CURL(inputStream->GetURL());
+
+  // convert bandwidth specified in kbps to bps used by the mov reference
+  bandwidth *= 1000;
+                                                
+  if (url.GetFileType() == "mov")
+  {
+    
+    int64_t size = inputStream->GetLength();;
+    if (size < 1000000)// allow a max of 1000000 bytes for a reference mov - treat others as real movs
+    {
+      uint8_t *buff = new uint8_t[size];
+      unsigned int readbytes = 0;
+      
+      readbytes = inputStream->Read(buff, size);
+      unsigned int offset = 0;
+      bool moovHeaderFound = false;
+      bool referencHeaderFound = false;
+      while (readbytes && offset < readbytes)
+      {
+        if (!moovHeaderFound)
+        {
+          if (buff[offset++] == 'm' && buff[offset++] == 'o' && buff[offset++] == 'o' && buff[offset++] == 'v')
+          {
+            offset += 4;//skip size info
+            moovHeaderFound = true;
+          }
+        }
+        
+        if(moovHeaderFound && !referencHeaderFound)
+        {
+          if (buff[offset++] == 'r' && buff[offset++] == 'm' && buff[offset++] == 'r' && buff[offset++] == 'a')
+          {
+            offset += 4;//skip size info
+            referencHeaderFound = true;
+          }
+        }
+        
+        if(referencHeaderFound)
+        {
+          if (buff[offset++] == 'r' && buff[offset++] == 'm' && buff[offset++] == 'd' && buff[offset++] == 'a')
+          {
+            offset += 4;//skip size info
+            char fourcc[4] = {buff[offset++], buff[offset++], buff[offset++], buff[offset++]};
+            // rmda can contain 
+            // 'rdrf' for urls/alias, 
+            // 'rmdr' minimum datarate in bits per sec
+            if (fourcc[0] == 'r' && fourcc[1] == 'd' && fourcc[2] == 'r' && fourcc[3] == 'f')
+            {
+              offset += 4;//skip size info
+              if (buff[offset++] == 'u' && buff[offset++] == 'r' && buff[offset++] == 'l' && buff[offset++] == ' ')
+              {
+                unsigned  int urlLength = ((unsigned  int)buff[offset++] << 24);//get url length
+                urlLength |= ((unsigned  int)buff[offset++] << 16);
+                urlLength |= ((unsigned  int)buff[offset++] << 8);
+                urlLength |= ((unsigned  int)buff[offset++]);
+                
+                if (urlLength > 0)
+                {
+                  //get the url data which is null terminated!
+                  std::string urlStr = (const char *)&buff[offset];
+                  if (CURL::IsFullPath(urlStr))// if its absolute - exchange hostname and filename
+                  {
+                    CURL tmpUrl = CURL(urlStr);
+                    url.SetHostName(tmpUrl.GetHostName());
+                    url.SetFileName(tmpUrl.GetFileName());
+                  }
+                  else // relative url
+                  {
+                    std::string tmpStr = URIUtils::GetDirectory(url.GetFileName());
+                    url.SetFileName(URIUtils::AddFileToFolder(tmpStr, urlStr));// replace filename
+                  }
+                  offset += urlLength;
+                }
+                offset += 4;//skip size info
+              }
+              fourcc[0] = buff[offset++];
+              fourcc[1] = buff[offset++];
+              fourcc[2] = buff[offset++];
+              fourcc[3] = buff[offset++];                  
+            }
+            
+            unsigned  int dataRate = 0;
+            // minimum datarate
+            if (fourcc[0] == 'r' && fourcc[1] == 'm' && fourcc[2] == 'd' && fourcc[3] == 'r')
+            {
+              offset += 4; //skip size info
+              dataRate = ((unsigned int)buff[offset++] << 24);//get datarate
+              dataRate |= ((unsigned  int)buff[offset++] << 16);
+              dataRate |= ((unsigned  int)buff[offset++] << 8);
+              dataRate |= ((unsigned  int)buff[offset++]);
+            }
+            
+            if ((maxBandwidth < dataRate) && (dataRate <= bandwidth))
+            {
+              // store the max bandwidth
+              maxBandwidth = dataRate;
+              redirected = true;
+            }
+          }
+        }
+      }
+      delete [] buff;
+    }
+
+    if (!redirected)
+      inputStream->Seek(0, SEEK_SET);
+    else 
+    {
+      CLog::Log(LOGINFO, "Auto-selecting %s based on configured bandwidth.", url.Get().c_str());
+      inputStream->Open(url.Get(), "");
+    }
+  }                                               
+
+  return redirected;
+}

--- a/xbmc/playlists/PlayListMov.h
+++ b/xbmc/playlists/PlayListMov.h
@@ -1,0 +1,31 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <string>
+class CDVDInputStream;
+
+namespace PLAYLIST
+{
+  class CPlayListMov
+  {
+  public:
+    static bool HandleRedirects(CDVDInputStream *inputStream, unsigned int bandwidth);
+  };
+}


### PR DESCRIPTION
As discussed with @elupus at devcon. This adds support for mov reference files. Those can be found a lot with apple events live stream (just google apple events - playback on your iDevice and try to airplay to xbmc).

This also refactors all the redirection stuff (we had it already with m3u8 before) into the playlistfactory.

In my testcase the mov reference even linked to a m3u8 playlist which we need to check for further redirects afterwards. But we don't play the ping pong game - first we check for mov reference lists - and afterwards for m3u8 - thats it - i didn't see any other constellations yet...

@elupus for review - its a bit rough i fear - hope you have some good comments for cleaning it up.
