### PR TITLE
Add http cookie passthrough to FFMPEG

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -42,6 +42,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "filesystem/File.h"
+#include "filesystem/CurlFile.h"
 #include "filesystem/Directory.h"
 #include "utils/log.h"
 #include "threads/Thread.h"
@@ -620,6 +621,11 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromURL(const CURL &url)
 
     if (!headers.empty())
       m_dllAvUtil.av_dict_set(&options, "headers", headers.c_str(), 0);
+
+    std::string cookies;
+    if (XFILE::CCurlFile::GetCookies(url, cookies))
+      m_dllAvUtil.av_dict_set(&options, "cookies", cookies.c_str(), 0);
+
   }
   return options;
 }

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1603,6 +1603,64 @@ bool CCurlFile::GetMimeType(const CURL &url, CStdString &content, CStdString use
   return false;
 }
 
+bool CCurlFile::GetCookies(const CURL &url, std::string &cookies)
+{
+  std::string cookiesStr;
+  struct curl_slist*     curlCookies;
+  XCURL::CURL_HANDLE*    easyHandle;
+  XCURL::CURLM*          multiHandle;
+
+  // get the cookies list
+  g_curlInterface.easy_aquire(url.GetProtocol(), url.GetHostName(), &easyHandle, &multiHandle);
+  if (CURLE_OK == g_curlInterface.easy_getinfo(easyHandle, CURLINFO_COOKIELIST, &curlCookies))
+  {
+    // iterate over each cookie and format it into an RFC 2109 formatted Set-Cookie string
+    struct curl_slist* curlCookieIter = curlCookies;
+    while(curlCookieIter)
+    {
+      // tokenize the CURL cookie string
+      std::vector<std::string> valuesVec;
+      StringUtils::Tokenize(curlCookieIter->data, valuesVec, "\t");
+
+      // ensure the length is valid
+      if (valuesVec.size() < 7)
+      {
+        CLog::Log(LOGERROR, "CCurlFile::GetCookies - invalid cookie: '%s'", curlCookieIter->data);
+        continue;
+      }
+
+      // create a http-header formatted cookie string
+      std::string cookieStr = valuesVec[5] + "=" + valuesVec[6] +
+                              "; path=" + valuesVec[2] +
+                              "; domain=" + valuesVec[0];
+
+      // append this cookie to the string containing all cookies
+      if (!cookiesStr.empty())
+        cookiesStr += "\n";
+      cookiesStr += cookieStr;
+
+      // move on to the next cookie
+      curlCookieIter = curlCookieIter->next;
+    }
+
+    // free the curl cookies
+    g_curlInterface.slist_free_all(curlCookies);
+
+    // release our handles
+    g_curlInterface.easy_release(&easyHandle, &multiHandle);
+
+    // if we have a non-empty cookie string, return it
+    if (!cookiesStr.empty())
+    {
+      cookies = cookiesStr;
+      return true;
+    }
+  }
+
+  // no cookies to return
+  return false;
+}
+
 int CCurlFile::IoControl(EIoControl request, void* param)
 {
   if(request == IOCTRL_SEEK_POSSIBLE)

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -95,6 +95,9 @@ namespace XFILE
       static bool GetHttpHeader(const CURL &url, CHttpHeader &headers);
       static bool GetMimeType(const CURL &url, CStdString &content, CStdString useragent="");
 
+      /* static function that will get cookies stored by CURL in RFC 2109 format */
+      static bool GetCookies(const CURL &url, std::string &cookies);
+
       class CReadState
       {
       public:

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -191,8 +191,13 @@ CStdString CPlayListM3U::GetBestBandwidthStream(const CStdString &strFileName, s
   CStdString strPlaylist = strFileName;
   size_t maxBandwidth = 0;
 
+  // first strip off any query string
+  size_t baseEnd = strPlaylist.find('?');
+  if (baseEnd != std::string::npos)
+    strPlaylist = strPlaylist.substr(0, baseEnd);
+
   // if we cannot get the last / we wont be able to determine the sub-playlists
-  size_t baseEnd = strPlaylist.rfind('/');
+  baseEnd = strPlaylist.rfind('/');
   if (baseEnd == std::string::npos)
     return strPlaylist;
 


### PR DESCRIPTION
- Fixes a small issue with m3u8 files ending in a query string (eg http://domain.com/test.m3u8?name=value)
- Passes curl cookies to ffmpeg demuxer (required to play some HLS streams, such has NHL gamecenter)
