### PR TITLE
XBMCTinyXml small refactoring

### DIFF
--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -68,7 +68,7 @@ public:
       g_charsetConverter.ToUtf8(encoding, strDoc, strUtf8);
 
     doc.Clear();
-    doc.Parse(strUtf8.c_str(),0,TIXML_ENCODING_UTF8);
+    doc.Parse(strUtf8, TIXML_ENCODING_UTF8);
     return details.Load(doc.RootElement(), true, prioritise);
   }
 

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -187,7 +187,7 @@ bool CScraper::SetPathSettings(CONTENT_TYPE content, const CStdString& xml)
     return true;
 
   CXBMCTinyXML doc;
-  doc.Parse(xml.c_str());
+  doc.Parse(xml);
   m_userSettingsLoaded = SettingsFromXML(doc);
 
   return m_userSettingsLoaded;
@@ -259,7 +259,7 @@ vector<CStdString> CScraper::Run(const CStdString& function,
     g_charsetConverter.unknownToUTF8(strXML);
 
   CXBMCTinyXML doc;
-  doc.Parse(strXML.c_str(),0,TIXML_ENCODING_UTF8);
+  doc.Parse(strXML, TIXML_ENCODING_UTF8);
   if (!doc.RootElement())
   {
     CLog::Log(LOGERROR, "%s: Unable to parse XML",__FUNCTION__);
@@ -445,7 +445,7 @@ CScraperUrl CScraper::NfoUrl(const CStdString &sNfoContent)
   for (unsigned int i=0; i < vcsOut.size(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(vcsOut[i], 0, TIXML_ENCODING_UTF8);
+    doc.Parse(vcsOut[i], TIXML_ENCODING_UTF8);
     CheckScraperError(doc.RootElement());
 
     if (doc.RootElement())
@@ -507,7 +507,7 @@ CScraperUrl CScraper::ResolveIDToUrl(const CStdString& externalID)
   for (unsigned int i=0; i < vcsOut.size(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(vcsOut[i], 0, TIXML_ENCODING_UTF8);
+    doc.Parse(vcsOut[i], TIXML_ENCODING_UTF8);
     CheckScraperError(doc.RootElement());
 
     if (doc.RootElement())
@@ -604,7 +604,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
       CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
@@ -730,7 +730,7 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const CStdStr
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    doc.Parse(*i, TIXML_ENCODING_UTF8);
     TiXmlHandle xhDoc(&doc);
 
     for (TiXmlElement* pxeAlbum = xhDoc.FirstChild("results").FirstChild("entity").Element();
@@ -822,7 +822,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
       CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
@@ -946,7 +946,7 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
       CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
@@ -981,7 +981,7 @@ bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbu
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
       CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
@@ -1017,7 +1017,7 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl, const CScraperUrl &scurl,
   for (vector<CStdString>::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
   {
     CXBMCTinyXML doc;
-    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
       CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDStateSerializer.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDStateSerializer.cpp
@@ -212,7 +212,7 @@ bool CDVDStateSerializer::XMLToDVDState( dvd_state_t *state, const std::string &
 {
   CXBMCTinyXML xmlDoc;
 
-  xmlDoc.Parse(xmlstate.c_str());
+  xmlDoc.Parse(xmlstate);
 
   if( xmlDoc.Error() )
     return false;

--- a/xbmc/filesystem/DAVCommon.cpp
+++ b/xbmc/filesystem/DAVCommon.cpp
@@ -29,7 +29,7 @@ using namespace XFILE;
  *
  * if pElement is <DAV:foo> and value is foo then ValueWithoutNamespace is true
  */
-bool CDAVCommon::ValueWithoutNamespace(const TiXmlNode *pNode, const CStdString& value)
+bool CDAVCommon::ValueWithoutNamespace(const TiXmlNode *pNode, const std::string& value)
 {
   CStdStringArray tag;
   const TiXmlElement *pElement;
@@ -67,7 +67,7 @@ bool CDAVCommon::ValueWithoutNamespace(const TiXmlNode *pNode, const CStdString&
 /*
  * Search for <status> and return its content
  */
-CStdString CDAVCommon::GetStatusTag(const TiXmlElement *pElement)
+std::string CDAVCommon::GetStatusTag(const TiXmlElement *pElement)
 {
   const TiXmlElement *pChild;
 
@@ -75,7 +75,7 @@ CStdString CDAVCommon::GetStatusTag(const TiXmlElement *pElement)
   {
     if (ValueWithoutNamespace(pChild, "status"))
     {
-      return CStdString(pChild->GetText());
+      return pChild->GetText();
     }
   }
 

--- a/xbmc/filesystem/DAVCommon.h
+++ b/xbmc/filesystem/DAVCommon.h
@@ -26,7 +26,7 @@ namespace XFILE
   class CDAVCommon
   {
     public:
-      static bool ValueWithoutNamespace(const TiXmlNode *pNode, const CStdString& value);
-      static CStdString GetStatusTag(const TiXmlElement *pElement);
+      static bool ValueWithoutNamespace(const TiXmlNode *pNode, const std::string& value);
+      static std::string GetStatusTag(const TiXmlElement *pElement);
   };
 }

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -140,7 +140,7 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
   dav.ReadData(strResponse);
 
   CXBMCTinyXML davResponse;
-  davResponse.Parse(strResponse.c_str());
+  davResponse.Parse(strResponse);
 
   if (!davResponse.Parse(strResponse))
   {

--- a/xbmc/filesystem/DAVFile.cpp
+++ b/xbmc/filesystem/DAVFile.cpp
@@ -71,7 +71,7 @@ bool CDAVFile::Execute(const CURL& url)
     ReadData(strResponse);
 
     CXBMCTinyXML davResponse;
-    davResponse.Parse(strResponse.c_str());
+    davResponse.Parse(strResponse);
 
     if (!davResponse.Parse(strResponse))
     {

--- a/xbmc/filesystem/TuxBoxDirectory.cpp
+++ b/xbmc/filesystem/TuxBoxDirectory.cpp
@@ -129,7 +129,7 @@ bool CTuxBoxDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
       // parse returned xml
       CXBMCTinyXML doc;
       data.Replace("></",">-</"); //FILL EMPTY ELEMENTS WITH "-"!
-      doc.Parse(data.c_str());
+      doc.Parse(data);
       TiXmlElement *root = doc.RootElement();
       if(root == NULL)
       {

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <string>
+#include <stdint.h>
 #include "settings/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -452,7 +452,7 @@ namespace XBMCAddon
       delete[] buffer;
 
       CXBMCTinyXML xmlDoc;
-      xmlDoc.Parse(xml.c_str());
+      xmlDoc.Parse(xml);
 
       if (xmlDoc.Error())
         return false;

--- a/xbmc/utils/BitstreamStats.h
+++ b/xbmc/utils/BitstreamStats.h
@@ -24,6 +24,8 @@
 #include <string>
 #ifdef TARGET_POSIX
 #include "linux/PlatformDefs.h"
+#else
+#include <stdint.h>
 #endif
 
 class BitstreamStats

--- a/xbmc/utils/Fanart.cpp
+++ b/xbmc/utils/Fanart.cpp
@@ -55,7 +55,7 @@ void CFanart::Pack()
 bool CFanart::Unpack()
 {
   CXBMCTinyXML doc;
-  doc.Parse(m_xml.c_str());
+  doc.Parse(m_xml);
 
   m_fanart.clear();
 

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -327,7 +327,7 @@ void CRssReader::fromRSSToUTF16(const CStdStringA& strSource, CStdStringW& strDe
 bool CRssReader::Parse(LPSTR szBuffer, int iFeed)
 {
   m_xml.Clear();
-  m_xml.Parse((LPCSTR)szBuffer, 0, TIXML_ENCODING_LEGACY);
+  m_xml.Parse((LPCSTR)szBuffer, TIXML_ENCODING_LEGACY);
 
   m_encoding = "UTF-8";
   if (m_xml.RootElement())

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -126,7 +126,7 @@ bool CScraperUrl::ParseString(CStdString strUrl)
     g_charsetConverter.unknownToUTF8(strUrl);
 
   CXBMCTinyXML doc;
-  doc.Parse(strUrl.c_str(),0,TIXML_ENCODING_UTF8);
+  doc.Parse(strUrl, TIXML_ENCODING_UTF8);
 
   TiXmlElement* pElement = doc.RootElement();
   if (!pElement)
@@ -278,7 +278,7 @@ bool CScraperUrl::ParseEpisodeGuide(CStdString strUrls)
     g_charsetConverter.unknownToUTF8(strUrls);
 
   CXBMCTinyXML doc;
-  doc.Parse(strUrls.c_str(),0,TIXML_ENCODING_UTF8);
+  doc.Parse(strUrls, TIXML_ENCODING_UTF8);
   if (doc.RootElement())
   {
     TiXmlHandle docHandle( &doc );

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -772,7 +772,7 @@ bool CTuxBoxUtil::GetHttpXML(CURL url,CStdString strRequestType)
       CXBMCTinyXML doc;
       TiXmlElement *XMLRoot=NULL;
       strTmp.Replace("></",">-</"); //FILL EMPTY ELEMENTS WITH "-"!
-      doc.Parse(strTmp.c_str());
+      doc.Parse(strTmp);
       strTmp.Empty();
 
       XMLRoot = doc.RootElement();

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -36,7 +36,7 @@ CXBMCTinyXML::CXBMCTinyXML(const char *documentName)
 {
 }
 
-CXBMCTinyXML::CXBMCTinyXML(const CStdString &documentName)
+CXBMCTinyXML::CXBMCTinyXML(const std::string& documentName)
 : TiXmlDocument(documentName)
 {
 }
@@ -48,11 +48,10 @@ bool CXBMCTinyXML::LoadFile(TiXmlEncoding encoding)
 
 bool CXBMCTinyXML::LoadFile(const char *_filename, TiXmlEncoding encoding)
 {
-  CStdString filename(_filename);
-  return LoadFile(filename, encoding);
+  return LoadFile(std::string(_filename), encoding);
 }
 
-bool CXBMCTinyXML::LoadFile(const CStdString &_filename, TiXmlEncoding encoding)
+bool CXBMCTinyXML::LoadFile(const std::string& _filename, TiXmlEncoding encoding)
 {
   value = _filename.c_str();
 
@@ -68,7 +67,7 @@ bool CXBMCTinyXML::LoadFile(const CStdString &_filename, TiXmlEncoding encoding)
   Clear();
   location.Clear();
 
-  CStdString data ((char*) buffPtr, (size_t) buffSize);
+  std::string data ((char*) buffPtr, (size_t) buffSize);
   free(buffPtr);
 
   Parse(data, NULL, encoding);
@@ -80,7 +79,7 @@ bool CXBMCTinyXML::LoadFile(const CStdString &_filename, TiXmlEncoding encoding)
 
 bool CXBMCTinyXML::LoadFile(FILE *f, TiXmlEncoding encoding)
 {
-  CStdString data("");
+  std::string data;
   char buf[BUFFER_SIZE];
   memset(buf, 0, BUFFER_SIZE);
   int result;
@@ -91,11 +90,10 @@ bool CXBMCTinyXML::LoadFile(FILE *f, TiXmlEncoding encoding)
 
 bool CXBMCTinyXML::SaveFile(const char *_filename) const
 {
-  CStdString filename(_filename);
-  return SaveFile(filename);
+  return SaveFile(std::string(_filename));
 }
 
-bool CXBMCTinyXML::SaveFile(const CStdString &filename) const
+bool CXBMCTinyXML::SaveFile(const std::string& filename) const
 {
   XFILE::CFile file;
   if (file.OpenForWrite(filename, true))
@@ -110,17 +108,17 @@ bool CXBMCTinyXML::SaveFile(const CStdString &filename) const
 
 const char *CXBMCTinyXML::Parse(const char *_data, TiXmlParsingData *prevData, TiXmlEncoding encoding)
 {
-  CStdString data(_data);
+  std::string data(_data);
   return Parse(data, prevData, encoding);
 }
 
-const char *CXBMCTinyXML::Parse(CStdString &data, TiXmlParsingData *prevData, TiXmlEncoding encoding)
+const char *CXBMCTinyXML::Parse(std::string& data, TiXmlParsingData *prevData, TiXmlEncoding encoding)
 {
   // Preprocess string, replacing '&' with '&amp; for invalid XML entities
   size_t pos = 0;
   CRegExp re(true);
   re.RegComp("^&(amp|lt|gt|quot|apos|#x[a-fA-F0-9]{1,4}|#[0-9]{1,5});.*");
-  while ((pos = data.find("&", pos)) != CStdString::npos)
+  while ((pos = data.find("&", pos)) != std::string::npos)
   {
     if (re.RegFind(data, pos, MAX_ENTITY_LENGTH) < 0)
       data.insert(pos + 1, "amp;");
@@ -133,7 +131,7 @@ bool CXBMCTinyXML::Test()
 {
   // scraper results with unescaped &
   CXBMCTinyXML doc;
-  CStdString data("<details><url function=\"ParseTMDBRating\" "
+  std::string data("<details><url function=\"ParseTMDBRating\" "
                   "cache=\"tmdb-en-12244.json\">"
                   "http://api.themoviedb.org/3/movie/12244"
                   "?api_key=57983e31fb435df4df77afb854740ea9"

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -70,7 +70,7 @@ bool CXBMCTinyXML::LoadFile(const std::string& _filename, TiXmlEncoding encoding
   std::string data ((char*) buffPtr, (size_t) buffSize);
   free(buffPtr);
 
-  Parse(data, NULL, encoding);
+  Parse(data, encoding);
 
   if (Error())
     return false;
@@ -85,7 +85,7 @@ bool CXBMCTinyXML::LoadFile(FILE *f, TiXmlEncoding encoding)
   int result;
   while ((result = fread(buf, 1, BUFFER_SIZE, f)) > 0)
     data.append(buf, result);
-  return Parse(data, NULL, encoding) != NULL;
+  return Parse(data, encoding) != NULL;
 }
 
 bool CXBMCTinyXML::SaveFile(const char *_filename) const
@@ -106,17 +106,17 @@ bool CXBMCTinyXML::SaveFile(const std::string& filename) const
   return false;
 }
 
-const char *CXBMCTinyXML::Parse(const char *_data, TiXmlParsingData *prevData, TiXmlEncoding encoding)
+const char *CXBMCTinyXML::Parse(const char *_data, TiXmlEncoding encoding)
 {
-  return Parse(std::string(_data), prevData, encoding);
+  return Parse(std::string(_data), encoding);
 }
 
-const char *CXBMCTinyXML::Parse(const std::string& rawdata, TiXmlParsingData *prevData, TiXmlEncoding encoding)
+const char *CXBMCTinyXML::Parse(const std::string& rawdata, TiXmlEncoding encoding)
 {
   // Preprocess string, replacing '&' with '&amp; for invalid XML entities
   size_t pos = rawdata.find('&');
   if (pos == std::string::npos)
-    return TiXmlDocument::Parse(rawdata.c_str(), prevData, encoding); // nothing to fix, process data directly
+    return TiXmlDocument::Parse(rawdata.c_str(), NULL, encoding); // nothing to fix, process data directly
 
   std::string data(rawdata);
   CRegExp re(true, false, "^&(amp|lt|gt|quot|apos|#x[a-fA-F0-9]{1,4}|#[0-9]{1,5});.*");
@@ -127,7 +127,7 @@ const char *CXBMCTinyXML::Parse(const std::string& rawdata, TiXmlParsingData *pr
     pos = data.find('&', pos + 1);
   } while (pos != std::string::npos);
 
-  return TiXmlDocument::Parse(data.c_str(), prevData, encoding);
+  return TiXmlDocument::Parse(data.c_str(), NULL, encoding);
 }
 
 bool CXBMCTinyXML::Test()

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -119,7 +119,7 @@ const char *CXBMCTinyXML::Parse(const std::string& rawdata, TiXmlEncoding encodi
     return TiXmlDocument::Parse(rawdata.c_str(), NULL, encoding); // nothing to fix, process data directly
 
   std::string data(rawdata);
-  CRegExp re(true, false, "^&(amp|lt|gt|quot|apos|#x[a-fA-F0-9]{1,4}|#[0-9]{1,5});.*");
+  CRegExp re(false, false, "^&(amp|lt|gt|quot|apos|#x[a-fA-F0-9]{1,4}|#[0-9]{1,5});.*");
   do
   {
     if (re.RegFind(data, pos, MAX_ENTITY_LENGTH) < 0)

--- a/xbmc/utils/XBMCTinyXML.h
+++ b/xbmc/utils/XBMCTinyXML.h
@@ -73,6 +73,6 @@ public:
   bool SaveFile(const char*) const;
   bool SaveFile(const std::string& filename) const;
   const char *Parse(const char*, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
-  const char *Parse(std::string& data, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
+  const char *Parse(const std::string& data, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   static bool Test();
 };

--- a/xbmc/utils/XBMCTinyXML.h
+++ b/xbmc/utils/XBMCTinyXML.h
@@ -72,7 +72,7 @@ public:
   bool LoadFile(FILE*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   bool SaveFile(const char*) const;
   bool SaveFile(const std::string& filename) const;
-  const char *Parse(const char*, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
-  const char *Parse(const std::string& data, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
+  const char *Parse(const char*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
+  const char *Parse(const std::string& rawdata, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   static bool Test();
 };

--- a/xbmc/utils/XBMCTinyXML.h
+++ b/xbmc/utils/XBMCTinyXML.h
@@ -50,6 +50,7 @@
 #endif
 
 #include <tinyxml.h>
+#include <string>
 
 #undef DOCUMENT
 #undef ELEMENT
@@ -59,21 +60,19 @@
 #undef DECLARATION
 #undef TYPECOUNT
 
-#include "StdString.h"
-
 class CXBMCTinyXML : public TiXmlDocument
 {
 public:
   CXBMCTinyXML();
   CXBMCTinyXML(const char*);
-  CXBMCTinyXML(const CStdString&);
+  CXBMCTinyXML(const std::string& documentName);
   bool LoadFile(TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   bool LoadFile(const char*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
-  bool LoadFile(const CStdString&, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
+  bool LoadFile(const std::string& _filename, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   bool LoadFile(FILE*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   bool SaveFile(const char*) const;
-  bool SaveFile(const CStdString&) const;
+  bool SaveFile(const std::string& filename) const;
   const char *Parse(const char*, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
-  const char *Parse(CStdString&, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
+  const char *Parse(std::string& data, TiXmlParsingData *prevData = NULL, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   static bool Test();
 };

--- a/xbmc/win32/pch.h
+++ b/xbmc/win32/pch.h
@@ -44,4 +44,4 @@
 #include "boost/shared_ptr.hpp"
 // anything below here should be headers that very rarely (hopefully never)
 // change yet are included almost everywhere.
-#include "utils/StdString.h"
+/* empty */


### PR DESCRIPTION
- Finally remove CStdString
- Remove unused parameter of 'Parse' 
- Optimized refactoring of 'Parse' - generate RegExp only when needed
- Optimization of 'Parse' calls - no need for '.c_str()'
