### PR TITLE
Fix memory leak in SurfaceFlinger.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/StageFrightVideoPrivate.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/StageFrightVideoPrivate.cpp
@@ -334,6 +334,7 @@ void CStageFrightVideoPrivate::UninitStagefrightSurface()
   if (mVideoNativeWindow == NULL)
     return;
 
+  native_window_api_disconnect(mVideoNativeWindow.get(), NATIVE_WINDOW_API_MEDIA);
   ANativeWindow_release(mVideoNativeWindow.get());
   mVideoNativeWindow = NULL;
 


### PR DESCRIPTION
Call native_window_api_disconnect to free the memory used by OMX video decoder.
Or, there is memory leak in SurfaceFlinger after a stream playback is stopped.
