### PR TITLE
Memory leak when playing stream with xbmc in android platform

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/StageFrightVideoPrivate.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/StageFrightVideoPrivate.cpp
@@ -334,6 +334,7 @@ void CStageFrightVideoPrivate::UninitStagefrightSurface()
   if (mVideoNativeWindow == NULL)
     return;
 
+  native_window_api_disconnect(mVideoNativeWindow.get(), NATIVE_WINDOW_API_MEDIA);
   ANativeWindow_release(mVideoNativeWindow.get());
   mVideoNativeWindow = NULL;
 


### PR DESCRIPTION
We built xbmc for android, and runs in JB 4.2.2.
Each time when xbmc plays a stream, the surfaceflinger occupies more memory.
It's found that the OMX video decoder's output buffer allocated from native window is not released after each play.

As a result, after playing several streams, there is OOM.
