### PR TITLE
[win32] Fix win32 VS debugging environment

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -16,6 +16,6 @@ libnfs-1.6.1-win32.7z
 libshairplay-c159ca7-win32.7z
 libssh-0.5.0-1-win32.zip
 pcre-8.33-win32.zip
-python-2.7.5-win32.7z
+python-2.7.5_2-win32.7z
 sqlite-3.7.16.1-win32.7z
 taglib-1.8-win32.7z

--- a/project/BuildDependencies/scripts/libcdio_d.bat
+++ b/project/BuildDependencies/scripts/libcdio_d.bat
@@ -12,8 +12,4 @@ copy libcdio-0.83-win32\lib\libcdio.dll.lib "%CUR_PATH%\lib\" /Y
 copy libcdio-0.83-win32\bin\libcdio-13.dll "%XBMC_PATH%\project\Win32BuildSetup\dependencies\" /Y
 copy libcdio-0.83-win32\bin\libiconv-2.dll "%XBMC_PATH%\project\Win32BuildSetup\dependencies\" /Y
 
-rem for debugging
-copy libcdio-0.83-win32\bin\libcdio-13.dll "%XBMC_PATH%\project\VS2010Express\XBMC\Debug (DirectX)\" /Y
-copy libcdio-0.83-win32\bin\libiconv-2.dll "%XBMC_PATH%\project\VS2010Express\XBMC\Debug (DirectX)\" /Y
-
 cd %LOC_PATH%

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -55,11 +55,7 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup>
-    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
-    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
-    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
-    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
-    <LocalDebuggerEnvironment Condition="'$(Configuration)|$(Platform)'=='Template|Win32'">XBMC_HOME=$(SolutionDir)..\..</LocalDebuggerEnvironment>
+    <LocalDebuggerEnvironment>XBMC_HOME=$(SolutionDir)..\..&#xD;&#xA;PATH=$(SolutionDir)..\Win32BuildSetup\dependencies;%PATH%</LocalDebuggerEnvironment>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
No need anymore to copy dlls to Debug/Release dirs.
