### PR TITLE
[Players] Avoid jumping volume to maximum after trickplay

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -20,6 +20,7 @@
 
 #include "ApplicationPlayer.h"
 #include "cores/IPlayer.h"
+#include "Application.h"
 
 #define VOLUME_MINIMUM 0.0f        // -60dB
 #define VOLUME_MAXIMUM 1.0f        // 0dB
@@ -693,7 +694,7 @@ void CApplicationPlayer::SetPlaySpeed(int iSpeed, bool bApplicationMuted)
   {
     if (m_iPlaySpeed == 1)
     { // restore volume
-      player->SetVolume(VOLUME_MAXIMUM);
+      player->SetVolume(g_application.GetVolume(false));
     }
     else
     { // mute volume


### PR DESCRIPTION
For players that control volume, if the speed changes (e.g. with ff/rew) the volume gets reset to maximum.
This change sets it back to current value, although I question why it is being changed at all.
Do any players require muting during trickplay?
