### PR TITLE
[rbp/omxplayer] Use an omx decode to texture pipeline

### DIFF
--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -86,6 +86,7 @@ endif
 
 ifeq (@USE_OPENGLES@,1)
 SRCS += TextureGL.cpp
+SRCS += TexturePi.cpp
 SRCS += GUIFontTTFGL.cpp
 SRCS += GUITextureGLES.cpp
 SRCS += MatrixGLES.cpp

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -36,10 +36,6 @@
 #include "filesystem/AndroidAppFile.h"
 #endif
 
-#if defined(HAS_OMXPLAYER)
-#include "xbmc/cores/omxplayer/OMXImage.h"
-#endif
-
 /************************************************************************/
 /*                                                                      */
 /************************************************************************/
@@ -101,8 +97,13 @@ void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned in
   CLAMP(m_textureHeight, g_Windowing.GetMaxTextureSize());
   CLAMP(m_imageWidth, m_textureWidth);
   CLAMP(m_imageHeight, m_textureHeight);
+
   delete[] m_pixels;
-  m_pixels = new unsigned char[GetPitch() * GetRows()];
+  m_pixels = NULL;
+  if (GetPitch() * GetRows() > 0)
+  {
+    m_pixels = new unsigned char[GetPitch() * GetRows()];
+  }
 }
 
 void CBaseTexture::Update(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, bool loadToGPU)
@@ -219,31 +220,6 @@ CBaseTexture *CBaseTexture::LoadFromFileInMemory(unsigned char *buffer, size_t b
 
 bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate)
 {
-#if defined(HAS_OMXPLAYER)
-  if (URIUtils::HasExtension(texturePath, ".jpg|.tbn")
-      /*|| URIUtils::HasExtension(texturePath, ".png")*/)
-  {
-    COMXImageFile *file = COMXImage::LoadJpeg(texturePath);
-    if (file)
-    {
-      bool okay = false;
-      int orientation = file->GetOrientation();
-      // limit the sizes of jpegs (even if we fail to decode)
-      COMXImage::ClampLimits(maxWidth, maxHeight, file->GetWidth(), file->GetHeight(), orientation & 4);
-      Allocate(maxWidth, maxHeight, XB_FMT_A8R8G8B8);
-      if (m_pixels && COMXImage::DecodeJpeg(file, maxWidth, GetRows(), GetPitch(), (void *)m_pixels))
-      {
-        m_hasAlpha = false;
-        if (autoRotate && orientation)
-          m_orientation = orientation - 1;
-        okay = true;
-      }
-      COMXImage::CloseJpeg(file);
-      if (okay)
-        return true;
-    }
-  }
-#endif
   if (URIUtils::HasExtension(texturePath, ".dds"))
   { // special case for DDS images
     CDDSImage image;

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -32,6 +32,7 @@ struct COLOR {unsigned char b,g,r,x;};	// Windows GDI expects 4bytes per color
 
 class CTexture;
 class CGLTexture;
+class CPiTexture;
 class CDXTexture;
 
 /*!
@@ -131,7 +132,10 @@ protected:
   bool m_hasAlpha;
 };
 
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(HAS_OMXPLAYER)
+#include "TexturePi.h"
+#define CTexture CPiTexture
+#elif defined(HAS_GL) || defined(HAS_GLES)
 #include "TextureGL.h"
 #define CTexture CGLTexture
 #elif defined(HAS_DX)

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "system.h"
-#include "TextureGL.h"
+#include "Texture.h"
 #include "windowing/WindowingFactory.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"

--- a/xbmc/guilib/TexturePi.cpp
+++ b/xbmc/guilib/TexturePi.cpp
@@ -1,0 +1,142 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#include "Texture.h"
+#include "windowing/WindowingFactory.h"
+#include "utils/log.h"
+#include "utils/GLUtils.h"
+#include "guilib/TextureManager.h"
+#include "utils/URIUtils.h"
+
+#if defined(HAS_OMXPLAYER)
+#include "cores/omxplayer/OMXImage.h"
+
+using namespace std;
+
+/************************************************************************/
+/*    CPiTexture                                                       */
+/************************************************************************/
+
+CPiTexture::CPiTexture(unsigned int width, unsigned int height, unsigned int format)
+: CGLTexture(width, height, format)
+{
+  m_egl_image = NULL;
+}
+
+CPiTexture::~CPiTexture()
+{
+  if (m_egl_image)
+  {
+    g_OMXImage.DestroyTexture(m_egl_image);
+    m_egl_image = NULL;
+  }
+}
+
+void CPiTexture::Allocate(unsigned int width, unsigned int height, unsigned int format)
+{
+  if (m_egl_image)
+  {
+    m_imageWidth = m_originalWidth = width;
+    m_imageHeight = m_originalHeight = height;
+    m_format = format;
+    m_orientation = 0;
+
+    m_textureWidth = m_imageWidth;
+    m_textureHeight = m_imageHeight;
+    return;
+  }
+  return CGLTexture::Allocate(width, height, format);
+}
+
+void CPiTexture::CreateTextureObject()
+{
+  if (m_egl_image && !m_texture)
+  {
+    g_OMXImage.GetTexture(m_egl_image, &m_texture);
+    return;
+  }
+  CGLTexture::CreateTextureObject();
+}
+
+void CPiTexture::LoadToGPU()
+{
+  if (m_egl_image)
+  {
+    if (m_loadedToGPU)
+    {
+      // nothing to load - probably same image (no change)
+      return;
+    }
+    if (m_texture == 0)
+    {
+      // Have OpenGL generate a texture object handle for us
+      // this happens only one time - the first time the texture is loaded
+      CreateTextureObject();
+    }
+
+    // Bind the texture object
+    glBindTexture(GL_TEXTURE_2D, m_texture);
+
+    m_loadedToGPU = true;
+    return;
+  }
+  CGLTexture::LoadToGPU();
+}
+
+void CPiTexture::Update(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, bool loadToGPU)
+{
+  if (m_egl_image)
+  {
+    if (loadToGPU)
+      LoadToGPU();
+    return;
+  }
+  CGLTexture::Update(width, height, pitch, format, pixels, loadToGPU);
+}
+
+bool CPiTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate)
+{
+  if (URIUtils::HasExtension(texturePath, ".jpg|.tbn"))
+  {
+    COMXImageFile *file = g_OMXImage.LoadJpeg(texturePath);
+    if (file)
+    {
+      bool okay = false;
+      int orientation = file->GetOrientation();
+      // limit the sizes of jpegs (even if we fail to decode)
+      g_OMXImage.ClampLimits(maxWidth, maxHeight, file->GetWidth(), file->GetHeight(), orientation & 4);
+      if (g_OMXImage.DecodeJpegToTexture(file, maxWidth, maxHeight, &m_egl_image) && m_egl_image)
+      {
+        m_hasAlpha = false;
+        if (autoRotate && orientation)
+          m_orientation = orientation - 1;
+        Allocate(maxWidth, maxHeight, XB_FMT_A8R8G8B8);
+        okay = true;
+      }
+      g_OMXImage.CloseJpeg(file);
+      if (okay)
+        return true;
+    }
+  }
+  return CGLTexture::LoadFromFileInternal(texturePath, maxWidth, maxHeight, autoRotate);
+}
+
+#endif

--- a/xbmc/guilib/TexturePi.h
+++ b/xbmc/guilib/TexturePi.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2013 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -20,28 +20,30 @@
 
 #pragma once
 
-#include "Texture.h"
+#include "TextureGL.h"
 
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(HAS_OMXPLAYER)
 
 #include "system_gl.h"
 
 /************************************************************************/
 /*    CGLTexture                                                       */
 /************************************************************************/
-class CGLTexture : public CBaseTexture
+class CPiTexture : public CGLTexture
 {
 public:
-  CGLTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_A8R8G8B8);
-  virtual ~CGLTexture();
-
+  CPiTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_A8R8G8B8);
+  virtual ~CPiTexture();
   void CreateTextureObject();
-  virtual void DestroyTextureObject();
   void LoadToGPU();
-  void BindToUnit(unsigned int unit);
+  void Update(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, bool loadToGPU);
+  void Allocate(unsigned int width, unsigned int height, unsigned int format);
+  bool LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate);
 
 protected:
-  GLuint m_texture;
+
+private:
+  void *m_egl_image;
 };
 
 #endif

--- a/xbmc/linux/OMXCore.cpp
+++ b/xbmc/linux/OMXCore.cpp
@@ -1322,17 +1322,79 @@ OMX_ERRORTYPE COMXCoreComponent::DisablePort(unsigned int port, bool wait)
 
 OMX_ERRORTYPE COMXCoreComponent::UseEGLImage(OMX_BUFFERHEADERTYPE** ppBufferHdr, OMX_U32 nPortIndex, OMX_PTR pAppPrivate, void* eglImage)
 {
+  OMX_ERRORTYPE omx_err = OMX_ErrorNone;
+
   if(!m_handle)
     return OMX_ErrorUndefined;
 
-  OMX_ERRORTYPE omx_err;
+  m_omx_output_use_buffers = false;
 
-  omx_err = OMX_UseEGLImage(m_handle, ppBufferHdr, nPortIndex, pAppPrivate, eglImage);
-  if(omx_err != OMX_ErrorNone) 
+  OMX_PARAM_PORTDEFINITIONTYPE portFormat;
+  OMX_INIT_STRUCTURE(portFormat);
+  portFormat.nPortIndex = m_output_port;
+
+  omx_err = OMX_GetParameter(m_handle, OMX_IndexParamPortDefinition, &portFormat);
+  if(omx_err != OMX_ErrorNone)
+    return omx_err;
+
+  if(GetState() != OMX_StateIdle)
   {
-    CLog::Log(LOGERROR, "COMXCoreComponent::UseEGLImage - %s failed with omx_err(0x%x)\n", 
-              m_componentName.c_str(), omx_err);
+    if(GetState() != OMX_StateLoaded)
+      SetStateForComponent(OMX_StateLoaded);
+
+    SetStateForComponent(OMX_StateIdle);
   }
+
+  omx_err = EnablePort(m_output_port, false);
+  if(omx_err != OMX_ErrorNone)
+  {
+    CLog::Log(LOGERROR, "%s::%s - %s EnablePort failed with omx_err(0x%x)", CLASSNAME, __func__,
+              m_componentName.c_str(), omx_err);
+    return omx_err;
+  }
+
+  m_output_alignment     = portFormat.nBufferAlignment;
+  m_output_buffer_count  = portFormat.nBufferCountActual;
+  m_output_buffer_size   = portFormat.nBufferSize;
+
+  if (portFormat.nBufferCountActual != 1)
+  {
+    CLog::Log(LOGERROR, "%s::%s - %s nBufferCountActual unexpected %d", CLASSNAME, __func__,
+              m_componentName.c_str(), portFormat.nBufferCountActual);
+    return omx_err;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s component(%s) - port(%d), nBufferCountMin(%u), nBufferCountActual(%u), nBufferSize(%u) nBufferAlignmen(%u)\n",
+            CLASSNAME, __func__, m_componentName.c_str(), m_output_port, portFormat.nBufferCountMin,
+            portFormat.nBufferCountActual, portFormat.nBufferSize, portFormat.nBufferAlignment);
+
+  for (size_t i = 0; i < portFormat.nBufferCountActual; i++)
+  {
+    omx_err = OMX_UseEGLImage(m_handle, ppBufferHdr, nPortIndex, pAppPrivate, eglImage);
+    if(omx_err != OMX_ErrorNone)
+    {
+      CLog::Log(LOGERROR, "%s::%s - %s failed with omx_err(0x%x)\n",
+                CLASSNAME, __func__, m_componentName.c_str(), omx_err);
+      return omx_err;
+    }
+
+    OMX_BUFFERHEADERTYPE *buffer = *ppBufferHdr;
+    buffer->nOutputPortIndex = m_output_port;
+    buffer->nFilledLen       = 0;
+    buffer->nOffset          = 0;
+    buffer->pAppPrivate      = (void*)i;
+    m_omx_output_buffers.push_back(buffer);
+    m_omx_output_available.push(buffer);
+  }
+
+  omx_err = WaitForCommand(OMX_CommandPortEnable, m_output_port);
+  if(omx_err != OMX_ErrorNone)
+  {
+    CLog::Log(LOGERROR, " %s::%s - %s EnablePort failed with omx_err(0x%x)\n",
+              CLASSNAME, __func__, m_componentName.c_str(), omx_err);
+      return omx_err;
+  }
+  m_flush_output = false;
 
   return omx_err;
 }

--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -23,6 +23,8 @@
 
 #include "utils/log.h"
 
+#include "cores/omxplayer/OMXImage.h"
+
 CRBP::CRBP()
 {
   m_initialized     = false;
@@ -58,6 +60,8 @@ bool CRBP::Initialize()
   if (vc_gencmd(response, sizeof response, "get_mem gpu") == 0)
     vc_gencmd_number_property(response, "gpu", &m_gpu_mem);
 
+  g_OMXImage.Initialize();
+  m_omx_image_init = true;
   return true;
 }
 
@@ -128,6 +132,9 @@ unsigned char *CRBP::CaptureDisplay(int width, int height, int *pstride, bool sw
 
 void CRBP::Deinitialize()
 {
+  if (m_omx_image_init)
+    g_OMXImage.Deinitialize();
+
   if(m_omx_initialized)
     m_OMX->Deinitialize();
 
@@ -136,6 +143,7 @@ void CRBP::Deinitialize()
   if(m_initialized)
     m_DllBcmHost->Unload();
 
+  m_omx_image_init  = false;
   m_initialized     = false;
   m_omx_initialized = false;
 }

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -58,6 +58,7 @@ private:
   DllBcmHost *m_DllBcmHost;
   bool       m_initialized;
   bool       m_omx_initialized;
+  bool       m_omx_image_init;
   int        m_arm_mem;
   int        m_gpu_mem;
   COMXCore   *m_OMX;

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -60,13 +60,13 @@ public:
 
   EGLConfig     GetEGLConfig();
 
+  EGLDisplay    GetEGLDisplay();
+  EGLContext    GetEGLContext();
 protected:
   virtual bool  PresentRenderImpl(const CDirtyRegionList &dirty);
   virtual void  SetVSyncImpl(bool enable);
 
   bool          CreateWindow(RESOLUTION_INFO &res);
-  EGLDisplay    GetEGLDisplay();
-  EGLContext    GetEGLContext();
 
   int                   m_displayWidth;
   int                   m_displayHeight;


### PR DESCRIPTION
This PR uses an openmax pipeline to handle jpeg decode/resize/convert to texture
in a pipeline without the decoded pixels being returned to the arm.

The jpeg is decoded in stripes which saves memory. There is no need for the RGBA32 pixel buffer to ever exist on the arm.
It is straightforward to choose whether the textures are 16bpp or 32bpp which could be a useful option on 256M Pi.

This scheme is _much_ faster, and is the main factor in the recent raspberry-pi "speed" video.

Consider this an RFC, as this code is ugly. The requirement to bind to the texture before decoding the jpeg is the main reason for the ugliness.

I would like to get it into mainline code before the Gotham feature freeze as it is such a significant improvement.
I am quite prepared to restructure or refactor this if guidance is provided.
