### PR TITLE
XBMC-PVR: Add "Find similar programs" to Timers context menu

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -867,6 +867,8 @@ bool CGUIWindowPVRCommon::OnContextButtonFind(CFileItem *item, CONTEXT_BUTTON bu
         m_parent->m_windowSearch->m_searchfilter.m_strSearchTerm = "\"" + tag.Title() + "\"";
       else if (item->IsPVRRecording())
         m_parent->m_windowSearch->m_searchfilter.m_strSearchTerm = "\"" + item->GetPVRRecordingInfoTag()->m_strTitle + "\"";
+      else if (item->IsPVRTimer())
+        m_parent->m_windowSearch->m_searchfilter.m_strSearchTerm = "\"" + item->GetPVRTimerInfoTag()->m_strTitle + "\"";
 
       m_parent->m_windowSearch->m_bSearchConfirmed = true;
       m_parent->SetLabel(m_iControlButton, 0);

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -70,11 +70,12 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
   }
   else
   {
-    buttons.Add(CONTEXT_BUTTON_EDIT, 19057);            /* edit timer */
-    buttons.Add(CONTEXT_BUTTON_ADD, 19056);             /* new timer */
+    buttons.Add(CONTEXT_BUTTON_FIND, 19003);            /* Find similar program */
     buttons.Add(CONTEXT_BUTTON_ACTIVATE, 19058);        /* activate/deactivate */
-    buttons.Add(CONTEXT_BUTTON_RENAME, 118);            /* rename timer */
     buttons.Add(CONTEXT_BUTTON_DELETE, 117);            /* delete timer */
+    buttons.Add(CONTEXT_BUTTON_EDIT, 19057);            /* edit timer */
+    buttons.Add(CONTEXT_BUTTON_RENAME, 118);            /* rename timer */
+    buttons.Add(CONTEXT_BUTTON_ADD, 19056);             /* new timer */
     buttons.Add(CONTEXT_BUTTON_SORTBY_NAME, 103);       /* sort by name */
     buttons.Add(CONTEXT_BUTTON_SORTBY_DATE, 104);       /* sort by date */
     if (g_PVRClients->HasMenuHooks(pItem->GetPVRTimerInfoTag()->m_iClientId, PVR_MENUHOOK_TIMER))


### PR DESCRIPTION
By adding the "Find similar programs" option, users are able to search
for upcoming showings of the same title.  This is particularly useful
for timers that are in "Conflict Error" with one another.  This provides
a quick method to re-shedule a conflicting timer.  The order of options
in the context menu has been re-ordered to reflect the most common actions
to resolve timer conflicts.
