### PR TITLE
Improved settings level integration into confluence

### DIFF
--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -71,10 +71,44 @@
 				<width>260</width>
 				<height>481</height>
 				<itemgap>-1</itemgap>
-				<onleft>9000</onleft>
+				<onleft>5</onleft>
+				<onright>5</onright>
+				<onup>20</onup>
+				<ondown>20</ondown>
+			</control>
+			<control type="button" id="20">
+				<description>Setting level button</description>
+				<posx>10</posx>
+				<posy>562</posy>
+				<height>60</height>
+				<width>260</width>
+				<label>10037</label>>
+				<textoffsetx>20</textoffsetx>
+				<textoffsety>28</textoffsety>
+				<align>right</align>
+				<aligny>top</aligny>
+				<font>font13caps</font>
+				<textcolor>selected</textcolor>
+				<focusedcolor>selected</focusedcolor>
+				<texturefocus border="5">MenuItemFO.png</texturefocus>
+				<texturenofocus border="5">MenuItemNF.png</texturenofocus>
+				<pulseonselect>false</pulseonselect>
+				<onleft>5</onleft>
 				<onright>5</onright>
 				<onup>3</onup>
 				<ondown>3</ondown>
+				<onclick>SettingsLevelChange</onclick>
+			</control>
+			<control type="label">
+				<posx>250</posx>
+				<posy>566</posy>
+				<height>25</height>
+				<width>230</width> 
+				<label>31142</label> 
+				<font>font13_title</font> 
+				<textcolor>white</textcolor> 
+				<align>right</align> 
+				<aligny>center</aligny>
 			</control>
 			<control type="image">
 				<posx>268</posx>
@@ -132,11 +166,20 @@
 				<showonepage>false</showonepage>
 				<orientation>vertical</orientation>
 			</control>
+			<control type="image">
+				<description>separator image</description>
+				<posx>290</posx>
+				<posy>525</posy>
+				<width>750</width>
+				<height>2</height>
+				<texture>separator2.png</texture>
+				<colordiffuse>40FFFFFF</colordiffuse>
+			</control>
 			<control type="textbox" id="6">
 				<description>description area</description>
-				<posx>290</posx>
-				<posy>515</posy>
-				<width>750</width>
+				<posx>297</posx>
+				<posy>530</posy>
+				<width>736</width>
 				<height>85</height>
 				<font>font12</font>
 				<align>justify</align>
@@ -159,6 +202,7 @@
 			<texturefocus border="5">MenuItemFO.png</texturefocus>
 			<texturenofocus border="5">MenuItemNF.png</texturenofocus>
 			<pulseonselect>false</pulseonselect>
+      <onleft>20</onleft>
 		</control>
 		<control type="button" id="7">
 			<description>Default Button</description>
@@ -236,44 +280,6 @@
 			<control type="label">
 				<include>WindowTitleCommons</include>
 				<label>[COLOR=blue] - [/COLOR]$INFO[Control.GetLabel(2)]</label>
-			</control>
-		</control>
-		<control type="group">
-			<posx>-250</posx>
-			<include>SideBladeLeft</include>
-			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
-				<width>250</width>
-				<height>600</height>
-				<onleft>9000</onleft>
-				<onright>3</onright>
-				<onup>9000</onup>
-				<ondown>9000</ondown>
-				<onback>3</onback>
-				<itemgap>0</itemgap>
-				<control type="label" id="200">
-					<width>250</width>
-					<height>35</height>
-					<font>font12</font>
-					<label>31007</label>
-					<textcolor>blue</textcolor>
-					<align>center</align>
-					<aligny>center</aligny>
-				</control>
-				<control type="button" id="20">
-					<description>Setting level button</description>
-					<textwidth>235</textwidth>
-					<include>ButtonCommonValues</include>
-					<label>10037</label>
-					<onclick>SettingsLevelChange</onclick>
-				</control>
-				<control type="button" id="21">
-					<description>Reset button</description>
-					<include>ButtonCommonValues</include>
-					<label>10035</label>
-					<onclick>SettingsReset</onclick>
-				</control>
 			</control>
 		</control>
 		<include>Clock</include>

--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -40,9 +40,7 @@ msgctxt "#31006"
 msgid "View Options"
 msgstr ""
 
-msgctxt "#31007"
-msgid "Settings Options"
-msgstr ""
+#empty string with id 31007
 
 msgctxt "#31008"
 msgid "Full screen"
@@ -308,6 +306,10 @@ msgstr ""
 
 msgctxt "#31141"
 msgid "Video OSD"
+msgstr ""
+
+msgctxt "#31142"
+msgid "Settings level"
 msgstr ""
 
 #empty strings from id 31142 to 31199

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -4204,7 +4204,17 @@ msgctxt "#10045"
 msgid "Resets all the visible settings to their default values."
 msgstr ""
 
-#empty strings from id 10046 to 10099
+#: xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+msgctxt "#10046"
+msgid "No categories available"
+msgstr ""
+
+#: xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+msgctxt "#10047"
+msgid "Try changing the setting level to see additional categories and settings."
+msgstr ""
+
+#empty strings from id 10048 to 10099
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10100"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -4162,19 +4162,19 @@ msgid "Reset"
 msgstr ""
 
 msgctxt "#10036"
-msgid "Level: Basic"
+msgid "Basic"
 msgstr ""
 
 msgctxt "#10037"
-msgid "Level: Standard"
+msgid "Standard"
 msgstr ""
 
 msgctxt "#10038"
-msgid "Level: Advanced"
+msgid "Advanced"
 msgstr ""
 
 msgctxt "#10039"
-msgid "Level: Expert"
+msgid "Expert"
 msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
@@ -4182,10 +4182,12 @@ msgctxt "#10040"
 msgid "Add-on browser"
 msgstr ""
 
+#: xbmc/settings/windows/GUIWindowSettingsCategory.cpp
 msgctxt "#10041"
-msgid "Reset settings"
+msgid "Reset above settings to default"
 msgstr ""
 
+#: xbmc/settings/windows/GUIWindowSettingsCategory.cpp
 msgctxt "#10042"
 msgid "Are you sure you want to reset the settings in this category?"
 msgstr ""
@@ -4198,7 +4200,11 @@ msgctxt "#10044"
 msgid "No help available"
 msgstr ""
 
-#empty strings from id 10045 to 10099
+msgctxt "#10045"
+msgid "Resets all the visible settings to their default values."
+msgstr ""
+
+#empty strings from id 10046 to 10099
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10100"

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -92,7 +92,9 @@ public:
   virtual void Reset() = 0;
 
   int GetLabel() const { return m_label; }
+  void SetLabel(int label) { m_label = label; }
   int GetHelp() const { return m_help; }
+  void SetHelp(int help) { m_help = help; }
   bool IsEnabled() const;
   const std::string& GetParent() const { return m_parentSetting; }
   SettingLevel GetLevel() const { return m_level; }

--- a/xbmc/settings/SettingSection.h
+++ b/xbmc/settings/SettingSection.h
@@ -99,11 +99,23 @@ public:
    */
   const int GetLabel() const { return m_label; }
   /*!
+   \brief Sets the localizeable label ID of the setting category.
+
+   \param label Localizeable label ID of the setting category
+   */
+  void SetLabel(int label) { m_label = label; }
+  /*!
    \brief Gets the localizeable help ID of the setting category.
 
    \return Localizeable help ID of the setting category
    */
   const int GetHelp() const { return m_help; }
+  /*!
+   \brief Sets the localizeable help ID of the setting category.
+
+   \param label Localizeable help ID of the setting category
+   */
+  void SetHelp(int help) { m_help = help; }
   /*!
    \brief Gets the full list of setting groups belonging to the setting
    category.
@@ -165,11 +177,23 @@ public:
    */
   const int GetLabel() const { return m_label; }
   /*!
+   \brief Sets the localizeable label ID of the setting section.
+
+   \param label Localizeable label ID of the setting section
+   */
+  void SetLabel(int label) { m_label = label; }
+  /*!
    \brief Gets the localizeable help ID of the setting section.
 
    \return Localizeable help ID of the setting section
    */
   const int GetHelp() const { return m_help; }
+  /*!
+   \brief Sets the localizeable help ID of the setting section.
+
+   \param label Localizeable help ID of the setting section
+   */
+  void SetHelp(int help) { m_help = help; }
   /*!
    \brief Gets the full list of setting categories belonging to the setting
    section.

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -73,6 +73,7 @@ using namespace std;
 #define CONTRL_BTN_LEVELS               20
 
 #define RESET_SETTING_ID                "settings.reset"
+#define EMPTY_CATEGORY_ID               "categories.empty"
 
 typedef struct {
   int id;
@@ -96,6 +97,7 @@ CGUIWindowSettingsCategory::CGUIWindowSettingsCategory(void)
       m_settings(CSettings::Get()),
       m_iSetting(0), m_iCategory(0), m_iSection(0),
       m_resetSetting(NULL),
+      m_dummyCategory(NULL),
       m_pOriginalSpin(NULL),
       m_pOriginalRadioButton(NULL),
       m_pOriginalCategoryButton(NULL),
@@ -132,6 +134,7 @@ CGUIWindowSettingsCategory::~CGUIWindowSettingsCategory(void)
   }
 
   delete m_resetSetting;
+  delete m_dummyCategory;
 }
 
 bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
@@ -152,6 +155,9 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
       m_resetSetting->SetLabel(10041);
       m_resetSetting->SetHelp(10045);
 
+      m_dummyCategory = new CSettingCategory(EMPTY_CATEGORY_ID);
+      m_dummyCategory->SetLabel(10046);
+      m_dummyCategory->SetHelp(10047);
       
       m_iSection = (int)message.GetParam2() - (int)CGUIWindow::GetID();
       CGUIWindow::OnMessage(message);
@@ -461,6 +467,8 @@ void CGUIWindowSettingsCategory::SetupControls(bool createSettings /* = true */)
 
   // get the categories we need
   m_categories = section->GetCategories(CViewStateSettings::Get().GetSettingLevel());
+  if (m_categories.empty())
+    m_categories.push_back(m_dummyCategory);
 
   // go through the categories and create the necessary buttons
   int buttonIdOffset = 0;

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -72,6 +72,8 @@ using namespace std;
 #define CONTROL_START_CONTROL           -80
 #define CONTRL_BTN_LEVELS               20
 
+#define RESET_SETTING_ID                "settings.reset"
+
 typedef struct {
   int id;
   string name;
@@ -93,6 +95,7 @@ CGUIWindowSettingsCategory::CGUIWindowSettingsCategory(void)
     : CGUIWindow(WINDOW_SETTINGS_MYPICTURES, "SettingsCategory.xml"),
       m_settings(CSettings::Get()),
       m_iSetting(0), m_iCategory(0), m_iSection(0),
+      m_resetSetting(NULL),
       m_pOriginalSpin(NULL),
       m_pOriginalRadioButton(NULL),
       m_pOriginalCategoryButton(NULL),
@@ -127,6 +130,8 @@ CGUIWindowSettingsCategory::~CGUIWindowSettingsCategory(void)
     delete m_pOriginalEdit;
     m_pOriginalEdit = NULL;
   }
+
+  delete m_resetSetting;
 }
 
 bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
@@ -142,6 +147,11 @@ bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)
         m_iCategory = 0;
         ResetControlStates();
       }
+
+      m_resetSetting = new CSettingAction(RESET_SETTING_ID);
+      m_resetSetting->SetLabel(10041);
+      m_resetSetting->SetHelp(10045);
+
       
       m_iSection = (int)message.GetParam2() - (int)CGUIWindow::GetID();
       CGUIWindow::OnMessage(message);
@@ -593,6 +603,13 @@ void CGUIWindowSettingsCategory::CreateSettings()
 
   if (!settingMap.empty())
     m_settings.RegisterCallback(this, settingMap);
+
+  if (!settingMap.empty())
+  {
+    // add "Reset" control
+    AddSeparator(group->GetWidth(), iControlID);
+    AddSetting(m_resetSetting, group->GetWidth(), iControlID);
+  }
   
   // update our settings (turns controls on/off as appropriate)
   UpdateSettings();
@@ -758,6 +775,12 @@ CGUIControl* CGUIWindowSettingsCategory::AddSettingControl(CGUIControl *pControl
 
 void CGUIWindowSettingsCategory::OnClick(BaseSettingControlPtr pSettingControl)
 {
+  if (pSettingControl->GetSetting()->GetId() == RESET_SETTING_ID)
+  {
+    OnAction(CAction(ACTION_SETTINGS_RESET));
+    return;
+  }
+
   // we need to first set the delayed setting and then execute OnClick()
   // because OnClick() triggers OnSettingChanged() and there we need to
   // know if the changed setting is delayed or not

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.h
@@ -90,6 +90,7 @@ protected:
   int m_iCategory;
   int m_iSection;
   CSettingAction *m_resetSetting;
+  CSettingCategory *m_dummyCategory;
   
   CGUISpinControlEx *m_pOriginalSpin;
   CGUIRadioButtonControl *m_pOriginalRadioButton;

--- a/xbmc/settings/windows/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.h
@@ -89,6 +89,7 @@ protected:
   int m_iSetting;
   int m_iCategory;
   int m_iSection;
+  CSettingAction *m_resetSetting;
   
   CGUISpinControlEx *m_pOriginalSpin;
   CGUIRadioButtonControl *m_pOriginalRadioButton;


### PR DESCRIPTION
With the help of @ronie this is another attempt at getting rid of the sidebar in the settings window in confluence.
With this we always add a "Reset above settings to default" button at the end of the settings list. Furthermore the settings level switch has been moved to the bottom of the category list.
You can see an example screenshot here: http://i687.photobucket.com/albums/vv237/roniez/workz/settingslevels.jpg
