### PR TITLE
Expose the texture cache to JSON-RPC.

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -254,6 +254,9 @@
 		7C1A85661520522500C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
 		7C1D682915A7D2FD00658B65 /* DatabaseManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1D682715A7D2FD00658B65 /* DatabaseManager.cpp */; };
 		7C1F6EBB13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */; };
+		7C2612711825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
+		7C2612721825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
+		7C2612731825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		7C4458BD161E203800A905F6 /* Screenshot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C4458BB161E203800A905F6 /* Screenshot.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
@@ -3685,6 +3688,8 @@
 		7C1D682815A7D2FD00658B65 /* DatabaseManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DatabaseManager.h; sourceTree = "<group>"; };
 		7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LibraryDirectory.cpp; sourceTree = "<group>"; };
 		7C1F6EBA13ECCFA7001726AB /* LibraryDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryDirectory.h; sourceTree = "<group>"; };
+		7C26126F1825B6340086E04D /* DatabaseQuery.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseQuery.cpp; sourceTree = "<group>"; };
+		7C2612701825B6340086E04D /* DatabaseQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DatabaseQuery.h; sourceTree = "<group>"; };
 		7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocol.cpp; sourceTree = "<group>"; };
 		7C2D6AE30F35453E00DD2E85 /* SpecialProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocol.h; sourceTree = "<group>"; };
 		7C4458BB161E203800A905F6 /* Screenshot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Screenshot.cpp; sourceTree = "<group>"; };
@@ -6359,6 +6364,8 @@
 			children = (
 				E38E16800D25F9FA00618676 /* Database.cpp */,
 				E38E16810D25F9FA00618676 /* Database.h */,
+				7C26126F1825B6340086E04D /* DatabaseQuery.cpp */,
+				7C2612701825B6340086E04D /* DatabaseQuery.h */,
 				E38E1CD70D25F9FC00618676 /* dataset.cpp */,
 				E38E1CD80D25F9FC00618676 /* dataset.h */,
 				7C7B2B2E1134F36400713D6D /* mysqldataset.cpp */,
@@ -10622,6 +10629,7 @@
 				DFD882F817DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E917DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35617F3412C004FC217 /* WinEvents.cpp in Sources */,
+				7C2612711825B6340086E04D /* DatabaseQuery.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11652,6 +11660,7 @@
 				DFD882F617DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E717DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35817F3412C004FC217 /* WinEvents.cpp in Sources */,
+				7C2612731825B6340086E04D /* DatabaseQuery.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12684,6 +12693,7 @@
 				DFD882F717DD1A5B001516FE /* AddonPythonInvoker.cpp in Sources */,
 				DFD882E817DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35717F3412C004FC217 /* WinEvents.cpp in Sources */,
+				7C2612721825B6340086E04D /* DatabaseQuery.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -281,6 +281,9 @@
 		7C89674613C03B22003631FE /* InfoBool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89674313C03B22003631FE /* InfoBool.cpp */; };
 		7C8A14571154CB2600E5FCFA /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		7C8A187D115B2A8200E5FCFA /* TextureDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */; };
+		7C920CF9181669FF00DA1477 /* TextureOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C920CF7181669FF00DA1477 /* TextureOperations.cpp */; };
+		7C920CFA181669FF00DA1477 /* TextureOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C920CF7181669FF00DA1477 /* TextureOperations.cpp */; };
+		7C920CFB181669FF00DA1477 /* TextureOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C920CF7181669FF00DA1477 /* TextureOperations.cpp */; };
 		7C99B6A4133D342100FC2B16 /* CircularCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6A2133D342100FC2B16 /* CircularCache.cpp */; };
 		7C99B7951340723F00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7931340723F00FC2B16 /* GUIDialogPlayEject.cpp */; };
 		7CAA20511079C8160096DE39 /* BaseRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA204F1079C8160096DE39 /* BaseRenderer.cpp */; };
@@ -3743,6 +3746,8 @@
 		7C8A14551154CB2600E5FCFA /* TextureCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCache.h; sourceTree = "<group>"; };
 		7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureDatabase.cpp; sourceTree = "<group>"; };
 		7C8A187B115B2A8200E5FCFA /* TextureDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureDatabase.h; sourceTree = "<group>"; };
+		7C920CF7181669FF00DA1477 /* TextureOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureOperations.cpp; sourceTree = "<group>"; };
+		7C920CF8181669FF00DA1477 /* TextureOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureOperations.h; sourceTree = "<group>"; };
 		7C99B6A2133D342100FC2B16 /* CircularCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CircularCache.cpp; sourceTree = "<group>"; };
 		7C99B6A3133D342100FC2B16 /* CircularCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CircularCache.h; sourceTree = "<group>"; };
 		7C99B7931340723F00FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -9030,6 +9035,8 @@
 				DF00492C162DAEA200A971AD /* PVROperations.h */,
 				F5AE409613415D9E0004BD79 /* SystemOperations.cpp */,
 				F5AE409713415D9E0004BD79 /* SystemOperations.h */,
+				7C920CF7181669FF00DA1477 /* TextureOperations.cpp */,
+				7C920CF8181669FF00DA1477 /* TextureOperations.h */,
 				F5AE409813415D9E0004BD79 /* VideoLibrary.cpp */,
 				F5AE409913415D9E0004BD79 /* VideoLibrary.h */,
 				F5AE409A13415D9E0004BD79 /* XBMCOperations.cpp */,
@@ -10630,6 +10637,7 @@
 				DFD882E917DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35617F3412C004FC217 /* WinEvents.cpp in Sources */,
 				7C2612711825B6340086E04D /* DatabaseQuery.cpp in Sources */,
+				7C920CF9181669FF00DA1477 /* TextureOperations.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11661,6 +11669,7 @@
 				DFD882E717DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35817F3412C004FC217 /* WinEvents.cpp in Sources */,
 				7C2612731825B6340086E04D /* DatabaseQuery.cpp in Sources */,
+				7C920CFB181669FF00DA1477 /* TextureOperations.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12694,6 +12703,7 @@
 				DFD882E817DD189E001516FE /* StringValidation.cpp in Sources */,
 				F500E35717F3412C004FC217 /* WinEvents.cpp in Sources */,
 				7C2612721825B6340086E04D /* DatabaseQuery.cpp in Sources */,
+				7C920CFA181669FF00DA1477 /* TextureOperations.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -747,6 +747,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\SystemOperations.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\VideoLibrary.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\XBMCOperations.cpp" />
+    <ClCompile Include="..\..\xbmc\interfaces\json-rpc\TextureOperations.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\legacy\Addon.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\legacy\AddonCallback.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\legacy\AddonClass.cpp" />
@@ -2250,6 +2251,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\SystemOperations.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\VideoLibrary.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\XBMCOperations.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\json-rpc\TextureOperations.h" />
     <ClInclude Include="..\..\xbmc\IProgressCallback.h" />
     <ClInclude Include="..\..\xbmc\LangInfo.h" />
     <ClInclude Include="..\..\xbmc\MediaSource.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -419,6 +419,7 @@
     <ClCompile Include="..\..\xbmc\CueDocument.cpp" />
     <ClCompile Include="..\..\xbmc\DbUrl.cpp" />
     <ClCompile Include="..\..\xbmc\dbwrappers\Database.cpp" />
+    <ClCompile Include="..\..\xbmc\dbwrappers\DatabaseQuery.cpp" />
     <ClCompile Include="..\..\xbmc\dbwrappers\dataset.cpp" />
     <ClCompile Include="..\..\xbmc\dbwrappers\mysqldataset.cpp" />
     <ClCompile Include="..\..\xbmc\dbwrappers\qry_dat.cpp" />
@@ -2051,6 +2052,7 @@
     <ClInclude Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.h" />
     <ClInclude Include="..\..\xbmc\CueDocument.h" />
     <ClInclude Include="..\..\xbmc\dbwrappers\Database.h" />
+    <ClInclude Include="..\..\xbmc\dbwrappers\DatabaseQuery.h" />
     <ClInclude Include="..\..\xbmc\dbwrappers\dataset.h" />
     <ClInclude Include="..\..\xbmc\dbwrappers\mysqldataset.h" />
     <ClInclude Include="..\..\xbmc\dbwrappers\qry_dat.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2450,6 +2450,9 @@
     <ClCompile Include="..\..\xbmc\dbwrappers\Database.cpp">
       <Filter>dbwrappers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\dbwrappers\DatabaseQuery.cpp">
+      <Filter>dbwrappers</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\dbwrappers\dataset.cpp">
       <Filter>dbwrappers</Filter>
     </ClCompile>
@@ -5518,6 +5521,9 @@
       <Filter>video</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\dbwrappers\Database.h">
+      <Filter>dbwrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\dbwrappers\DatabaseQuery.h">
       <Filter>dbwrappers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\dbwrappers\dataset.h">

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1219,6 +1219,9 @@
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\XBMCOperations.cpp">
       <Filter>interfaces\json-rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\json-rpc\TextureOperations.cpp">
+      <Filter>interfaces\json-rpc</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\music\dialogs\GUIDialogMusicInfo.cpp">
       <Filter>music\dialogs</Filter>
     </ClCompile>
@@ -4185,6 +4188,9 @@
       <Filter>interfaces\json-rpc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\XBMCOperations.h">
+      <Filter>interfaces\json-rpc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\json-rpc\TextureOperations.h">
       <Filter>interfaces\json-rpc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\music\dialogs\GUIDialogMusicInfo.h">

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -221,6 +221,22 @@ void CTextureCache::ClearCachedImage(const CStdString &url, bool deleteSource /*
     CFile::Delete(path);
 }
 
+bool CTextureCache::ClearCachedImage(int id)
+{
+  CStdString cachedFile;
+  if (ClearCachedTexture(id, cachedFile))
+  {
+    cachedFile = GetCachedPath(cachedFile);
+    if (CFile::Exists(cachedFile))
+      CFile::Delete(cachedFile);
+    cachedFile = URIUtils::ReplaceExtension(cachedFile, ".dds");
+    if (CFile::Exists(cachedFile))
+      CFile::Delete(cachedFile);
+    return true;
+  }
+  return false;
+}
+
 bool CTextureCache::GetCachedTexture(const CStdString &url, CTextureDetails &details)
 {
   CSingleLock lock(m_databaseSection);
@@ -256,6 +272,12 @@ bool CTextureCache::ClearCachedTexture(const CStdString &url, CStdString &cached
 {
   CSingleLock lock(m_databaseSection);
   return m_database.ClearCachedTexture(url, cachedURL);
+}
+
+bool CTextureCache::ClearCachedTexture(int id, CStdString &cachedURL)
+{
+  CSingleLock lock(m_databaseSection);
+  return m_database.ClearCachedTexture(id, cachedURL);
 }
 
 CStdString CTextureCache::GetCacheFile(const CStdString &url)

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -80,7 +80,7 @@ bool CTextureCache::HasCachedImage(const CStdString &url)
 
 CStdString CTextureCache::GetCachedImage(const CStdString &image, CTextureDetails &details, bool trackUsage)
 {
-  CStdString url = UnwrapImageURL(image);
+  CStdString url = CTextureUtils::UnwrapImageURL(image);
 
   if (IsCachedImage(url))
     return url;
@@ -93,39 +93,6 @@ CStdString CTextureCache::GetCachedImage(const CStdString &image, CTextureDetail
     return GetCachedPath(details.file);
   }
   return "";
-}
-
-CStdString CTextureCache::GetWrappedImageURL(const CStdString &image, const CStdString &type, const CStdString &options)
-{
-  if (StringUtils::StartsWith(image, "image://"))
-    return image; // already wrapped
-
-  CURL url;
-  url.SetProtocol("image");
-  url.SetUserName(type);
-  url.SetHostName(image);
-  if (!options.IsEmpty())
-  {
-    url.SetFileName("transform");
-    url.SetOptions("?" + options);
-  }
-  return url.Get();
-}
-
-CStdString CTextureCache::GetWrappedThumbURL(const CStdString &image)
-{
-  return GetWrappedImageURL(image, "", "size=thumb");
-}
-
-CStdString CTextureCache::UnwrapImageURL(const CStdString &image)
-{
-  if (StringUtils::StartsWith(image, "image://"))
-  {
-    CURL url(image);
-    if (url.GetUserName().IsEmpty() && url.GetOptions().IsEmpty())
-      return url.GetHostName();
-  }
-  return image;
 }
 
 bool CTextureCache::CanCacheImageURL(const CURL &url)
@@ -161,7 +128,7 @@ void CTextureCache::BackgroundCacheImage(const CStdString &url)
     return; // image is already cached and doesn't need to be checked further
 
   // needs (re)caching
-  AddJob(new CTextureCacheJob(UnwrapImageURL(url), details.hash));
+  AddJob(new CTextureCacheJob(CTextureUtils::UnwrapImageURL(url), details.hash));
 }
 
 bool CTextureCache::CacheImage(const CStdString &image, CTextureDetails &details)
@@ -175,7 +142,7 @@ bool CTextureCache::CacheImage(const CStdString &image, CTextureDetails &details
 
 CStdString CTextureCache::CacheImage(const CStdString &image, CBaseTexture **texture, CTextureDetails *details)
 {
-  CStdString url = UnwrapImageURL(image);
+  CStdString url = CTextureUtils::UnwrapImageURL(image);
   CSingleLock lock(m_processingSection);
   if (m_processing.find(url) == m_processing.end())
   {

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -115,6 +115,12 @@ public:
    */
   void ClearCachedImage(const CStdString &image, bool deleteSource = false);
 
+  /*! \brief clear the cached version of the image with given id
+   \param database id of the image
+   \sa GetCachedImage
+   */
+  bool ClearCachedImage(int textureID);
+
   /*! \brief retrieve a cache file (relative to the cache path) to associate with the given image, excluding extension
    Use GetCachedPath(GetCacheFile(url)+extension) for the full path to the file.
    \param url location of the image
@@ -203,6 +209,7 @@ private:
    \return true if we had a cached version of this image, false otherwise.
    */
   bool ClearCachedTexture(const CStdString &url, CStdString &cacheFile);
+  bool ClearCachedTexture(int textureID, CStdString &cacheFile);
 
   /*! \brief Increment the use count of a texture
    Stores locally before calling CTextureDatabase::IncrementUseCount via a CUseCountJob

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -134,22 +134,6 @@ public:
    */
   static CStdString GetCachedPath(const CStdString &file);
 
-  /*! \brief retrieve a wrapped URL for a image file
-   \param image name of the file
-   \param type signifies a special type of image (eg embedded video thumb, picture folder thumb)
-   \param options which options we need (eg size=thumb)
-   \return full wrapped URL of the image file
-   */
-  static CStdString GetWrappedImageURL(const CStdString &image, const CStdString &type = "", const CStdString &options = "");
-  static CStdString GetWrappedThumbURL(const CStdString &image);
-
-  /*! \brief Unwrap an image://<url_encoded_path> style URL
-   Such urls are used for art over the webserver or other users of the VFS
-   \param image url of the image
-   \return the unwrapped URL, or the original URL if unwrapping is inappropriate.
-   */
-  static CStdString UnwrapImageURL(const CStdString &image);
-
   /*! \brief check whether an image:// URL may be cached
    \param url the URL to the image
    \return true if the given URL may be cached, false otherwise

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -107,6 +107,39 @@ void CTextureRule::GetAvailableFields(std::vector<std::string> &fieldList)
     fieldList.push_back(fields[i].string);
 }
 
+CStdString CTextureUtils::GetWrappedImageURL(const CStdString &image, const CStdString &type, const CStdString &options)
+{
+  if (StringUtils::StartsWith(image, "image://"))
+    return image; // already wrapped
+
+  CURL url;
+  url.SetProtocol("image");
+  url.SetUserName(type);
+  url.SetHostName(image);
+  if (!options.IsEmpty())
+  {
+    url.SetFileName("transform");
+    url.SetOptions("?" + options);
+  }
+  return url.Get();
+}
+
+CStdString CTextureUtils::GetWrappedThumbURL(const CStdString &image)
+{
+  return GetWrappedImageURL(image, "", "size=thumb");
+}
+
+CStdString CTextureUtils::UnwrapImageURL(const CStdString &image)
+{
+  if (StringUtils::StartsWith(image, "image://"))
+  {
+    CURL url(image);
+    if (url.GetUserName().IsEmpty() && url.GetOptions().IsEmpty())
+      return url.GetHostName();
+  }
+  return image;
+}
+
 CTextureDatabase::CTextureDatabase()
 {
 }

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -52,7 +52,7 @@ typedef struct
 
 static const translateField fields[] = {
   { "none",          TF_None,          CDatabaseQueryRule::TEXT_FIELD    },
-  { "id",            TF_Id,            CDatabaseQueryRule::NUMERIC_FIELD },
+  { "textureid",     TF_Id,            CDatabaseQueryRule::NUMERIC_FIELD },
   { "url",           TF_Url,           CDatabaseQueryRule::TEXT_FIELD    },
   { "cachedurl",     TF_CachedUrl,     CDatabaseQueryRule::TEXT_FIELD    },
   { "lasthashcheck", TF_LastHashCheck, CDatabaseQueryRule::TEXT_FIELD    },
@@ -98,6 +98,14 @@ CDatabaseQueryRule::FIELD_TYPE CTextureRule::GetFieldType(int field) const
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (field == fields[i].field) return fields[i].type;
   return TEXT_FIELD;
+}
+
+CStdString CTextureRule::FormatParameter(const CStdString &operatorString, const CStdString &param, const CDatabase &db, const CStdString &strType) const
+{
+  CStdString parameter(param);
+  if (m_field == TF_Url)
+    parameter = CTextureUtils::UnwrapImageURL(param);
+  return CDatabaseQueryRule::FormatParameter(operatorString, parameter, db, strType);
 }
 
 void CTextureRule::GetAvailableFields(std::vector<std::string> &fieldList)
@@ -312,7 +320,7 @@ bool CTextureDatabase::GetTextures(CVariant &items, const Filter &filter)
     while (!m_pDS->eof())
     {
       CVariant texture;
-      texture["id"] = m_pDS->fv(0).get_asInt();
+      texture["textureid"] = m_pDS->fv(0).get_asInt();
       texture["url"] = m_pDS->fv(1).get_asString();
       texture["cachedurl"] = m_pDS->fv(2).get_asString();
       texture["imagehash"] = m_pDS->fv(3).get_asString();

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -22,8 +22,25 @@
 
 #include "dbwrappers/Database.h"
 #include "TextureCacheJob.h"
+#include "playlists/SmartPlayList.h"
 
-class CTextureDatabase : public CDatabase
+class CVariant;
+
+class CTextureRule : public CDatabaseQueryRule
+{
+public:
+  CTextureRule() {};
+  virtual ~CTextureRule() {};
+
+  static void GetAvailableFields(std::vector<std::string> &fieldList);
+protected:
+  virtual int                 TranslateField(const char *field) const;
+  virtual CStdString          TranslateField(int field) const;
+  virtual CStdString          GetField(int field, const CStdString& type) const;
+  virtual FIELD_TYPE          GetFieldType(int field) const;
+};
+
+class CTextureDatabase : public CDatabase, public IDatabaseQueryRuleFactory
 {
 public:
   CTextureDatabase();
@@ -72,6 +89,11 @@ public:
    */
   void ClearTextureForPath(const CStdString &url, const CStdString &type);
 
+  bool GetTextures(CVariant &items, const Filter &filter);
+
+  // rule creation
+  virtual CDatabaseQueryRule *CreateRule() const;
+  virtual CDatabaseQueryRuleCombination *CreateCombination() const;
 protected:
   /*! \brief retrieve a hash for the given url
    Computes a hash of the current url to use for lookups in the database

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -34,6 +34,7 @@ public:
   bool AddCachedTexture(const CStdString &originalURL, const CTextureDetails &details);
   bool SetCachedTextureValid(const CStdString &originalURL, bool updateable);
   bool ClearCachedTexture(const CStdString &originalURL, CStdString &cacheFile);
+  bool ClearCachedTexture(int textureID, CStdString &cacheFile);
   bool IncrementUseCount(const CTextureDetails &details);
 
   /*! \brief Invalidate a previously cached texture

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -40,6 +40,26 @@ protected:
   virtual FIELD_TYPE          GetFieldType(int field) const;
 };
 
+class CTextureUtils
+{
+public:
+  /*! \brief retrieve a wrapped URL for a image file
+   \param image name of the file
+   \param type signifies a special type of image (eg embedded video thumb, picture folder thumb)
+   \param options which options we need (eg size=thumb)
+   \return full wrapped URL of the image file
+   */
+  static CStdString GetWrappedImageURL(const CStdString &image, const CStdString &type = "", const CStdString &options = "");
+  static CStdString GetWrappedThumbURL(const CStdString &image);
+
+  /*! \brief Unwrap an image://<url_encoded_path> style URL
+   Such urls are used for art over the webserver or other users of the VFS
+   \param image url of the image
+   \return the unwrapped URL, or the original URL if unwrapping is inappropriate.
+   */
+  static CStdString UnwrapImageURL(const CStdString &image);
+};
+
 class CTextureDatabase : public CDatabase, public IDatabaseQueryRuleFactory
 {
 public:

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -38,6 +38,7 @@ protected:
   virtual CStdString          TranslateField(int field) const;
   virtual CStdString          GetField(int field, const CStdString& type) const;
   virtual FIELD_TYPE          GetFieldType(int field) const;
+  virtual CStdString          FormatParameter(const CStdString &negate, const CStdString &oper, const CDatabase &db, const CStdString &type) const;
 };
 
 class CTextureUtils

--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -1,0 +1,529 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DatabaseQuery.h"
+#include "Database.h"
+#include "XBDateTime.h"
+#include "guilib/LocalizeStrings.h"
+#include "utils/CharsetConverter.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+#include "utils/XBMCTinyXML.h"
+
+using namespace std;
+
+typedef struct
+{
+  char string[15];
+  CDatabaseQueryRule::SEARCH_OPERATOR op;
+  int localizedString;
+} operatorField;
+
+static const operatorField operators[] = {
+  { "contains",        CDatabaseQueryRule::OPERATOR_CONTAINS,          21400 },
+  { "doesnotcontain",  CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN,  21401 },
+  { "is",              CDatabaseQueryRule::OPERATOR_EQUALS,            21402 },
+  { "isnot",           CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL,    21403 },
+  { "startswith",      CDatabaseQueryRule::OPERATOR_STARTS_WITH,       21404 },
+  { "endswith",        CDatabaseQueryRule::OPERATOR_ENDS_WITH,         21405 },
+  { "greaterthan",     CDatabaseQueryRule::OPERATOR_GREATER_THAN,      21406 },
+  { "lessthan",        CDatabaseQueryRule::OPERATOR_LESS_THAN,         21407 },
+  { "after",           CDatabaseQueryRule::OPERATOR_AFTER,             21408 },
+  { "before",          CDatabaseQueryRule::OPERATOR_BEFORE,            21409 },
+  { "inthelast",       CDatabaseQueryRule::OPERATOR_IN_THE_LAST,       21410 },
+  { "notinthelast",    CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST,   21411 },
+  { "true",            CDatabaseQueryRule::OPERATOR_TRUE,              20122 },
+  { "false",           CDatabaseQueryRule::OPERATOR_FALSE,             20424 },
+  { "between",         CDatabaseQueryRule::OPERATOR_BETWEEN,           21456 }
+};
+
+static const size_t NUM_OPERATORS = sizeof(operators) / sizeof(operatorField);
+
+#define RULE_VALUE_SEPARATOR  " / "
+
+CDatabaseQueryRule::CDatabaseQueryRule()
+{
+  m_field = 0;
+  m_operator = OPERATOR_CONTAINS;
+}
+
+bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding /* = "UTF-8" */)
+{
+  if (node == NULL)
+    return false;
+
+  const TiXmlElement *element = node->ToElement();
+  if (element == NULL)
+    return false;
+
+  // format is:
+  // <rule field="Genre" operator="contains">parameter</rule>
+  // where parameter can either be a string or a list of
+  // <value> tags containing a string
+  const char *field = element->Attribute("field");
+  const char *oper = element->Attribute("operator");
+  if (field == NULL || oper == NULL)
+    return false;
+
+  m_field = TranslateField(field);
+  m_operator = TranslateOperator(oper);
+
+  if (m_operator == OPERATOR_TRUE || m_operator == OPERATOR_FALSE)
+    return true;
+
+  const TiXmlNode *parameter = element->FirstChild();
+  if (parameter == NULL)
+    return false;
+
+  if (parameter->Type() == TiXmlNode::TINYXML_TEXT)
+  {
+    CStdString utf8Parameter;
+    if (encoding.empty()) // utf8
+      utf8Parameter = parameter->ValueStr();
+    else
+      g_charsetConverter.ToUtf8(encoding, parameter->ValueStr(), utf8Parameter);
+
+    if (!utf8Parameter.empty())
+      m_parameter.push_back(utf8Parameter);
+  }
+  else if (parameter->Type() == TiXmlNode::TINYXML_ELEMENT)
+  {
+    const TiXmlNode *valueNode = element->FirstChild("value");
+    while (valueNode != NULL)
+    {
+      const TiXmlNode *value = valueNode->FirstChild();
+      if (value != NULL && value->Type() == TiXmlNode::TINYXML_TEXT)
+      {
+        CStdString utf8Parameter;
+        if (encoding.empty()) // utf8
+          utf8Parameter = value->ValueStr();
+        else
+          g_charsetConverter.ToUtf8(encoding, value->ValueStr(), utf8Parameter);
+
+        if (!utf8Parameter.empty())
+          m_parameter.push_back(utf8Parameter);
+      }
+
+      valueNode = valueNode->NextSibling("value");
+    }
+  }
+  else
+    return false;
+
+  return true;
+}
+
+bool CDatabaseQueryRule::Load(const CVariant &obj)
+{
+  if (!obj.isObject() ||
+      !obj.isMember("field") || !obj["field"].isString() ||
+      !obj.isMember("operator") || !obj["operator"].isString())
+    return false;
+
+  m_field = TranslateField(obj["field"].asString().c_str());
+  m_operator = TranslateOperator(obj["operator"].asString().c_str());
+
+  if (m_operator == OPERATOR_TRUE || m_operator == OPERATOR_FALSE)
+    return true;
+
+  if (!obj.isMember("value") || (!obj["value"].isString() && !obj["value"].isArray()))
+    return false;
+
+  const CVariant &value = obj["value"];
+  if (value.isString() && !value.asString().empty())
+    m_parameter.push_back(value.asString());
+  else if (value.isArray())
+  {
+    for (CVariant::const_iterator_array val = value.begin_array(); val != value.end_array(); val++)
+    {
+      if (val->isString() && !val->asString().empty())
+        m_parameter.push_back(val->asString());
+    }
+  }
+  else
+    return false;
+
+  return true;
+}
+
+bool CDatabaseQueryRule::Save(TiXmlNode *parent) const
+{
+  if (parent == NULL || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
+    return false;
+
+  TiXmlElement rule("rule");
+  rule.SetAttribute("field", TranslateField(m_field).c_str());
+  rule.SetAttribute("operator", TranslateOperator(m_operator).c_str());
+
+  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); it++)
+  {
+    TiXmlElement value("value");
+    TiXmlText text(it->c_str());
+    value.InsertEndChild(text);
+    rule.InsertEndChild(value);
+  }
+
+  parent->InsertEndChild(rule);
+
+  return true;
+}
+
+bool CDatabaseQueryRule::Save(CVariant &obj) const
+{
+  if (obj.isNull() || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
+    return false;
+
+  obj["field"] = TranslateField(m_field);
+  obj["operator"] = TranslateOperator(m_operator);
+
+  obj["value"] = CVariant(CVariant::VariantTypeArray);
+  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); it++)
+    obj["value"].push_back(*it);
+
+  return true;
+}
+
+CDatabaseQueryRule::SEARCH_OPERATOR CDatabaseQueryRule::TranslateOperator(const char *oper)
+{
+  for (unsigned int i = 0; i < NUM_OPERATORS; i++)
+    if (StringUtils::EqualsNoCase(oper, operators[i].string)) return operators[i].op;
+  return OPERATOR_CONTAINS;
+}
+
+CStdString CDatabaseQueryRule::TranslateOperator(SEARCH_OPERATOR oper)
+{
+  for (unsigned int i = 0; i < NUM_OPERATORS; i++)
+    if (oper == operators[i].op) return operators[i].string;
+  return "contains";
+}
+
+CStdString CDatabaseQueryRule::GetLocalizedOperator(SEARCH_OPERATOR oper)
+{
+  for (unsigned int i = 0; i < NUM_OPERATORS; i++)
+    if (oper == operators[i].op) return g_localizeStrings.Get(operators[i].localizedString);
+  return g_localizeStrings.Get(16018);
+}
+
+void CDatabaseQueryRule::GetAvailableOperators(std::vector<std::string> &operatorList)
+{
+  for (unsigned int index = 0; index < NUM_OPERATORS; index++)
+    operatorList.push_back(operators[index].string);
+}
+
+CStdString CDatabaseQueryRule::GetParameter() const
+{
+  return StringUtils::JoinString(m_parameter, RULE_VALUE_SEPARATOR);
+}
+
+void CDatabaseQueryRule::SetParameter(const CStdString &value)
+{
+  m_parameter.clear();
+  StringUtils::SplitString(value, RULE_VALUE_SEPARATOR, m_parameter);
+}
+
+void CDatabaseQueryRule::SetParameter(const std::vector<CStdString> &values)
+{
+  m_parameter.assign(values.begin(), values.end());
+}
+
+CStdString CDatabaseQueryRule::FormatParameter(const CStdString &operatorString, const CStdString &param, const CDatabase &db, const CStdString &strType) const
+{
+  CStdString parameter;
+  if (GetFieldType(m_field) == TEXTIN_FIELD)
+  {
+    CStdStringArray split;
+    StringUtils::SplitString(param, ",", split);
+    for (CStdStringArray::iterator itIn = split.begin(); itIn != split.end(); ++itIn)
+    {
+      if (!parameter.IsEmpty())
+        parameter += ",";
+      parameter += db.PrepareSQL("'%s'", (*itIn).Trim().c_str());
+    }
+    parameter = " IN (" + parameter + ")";
+  }
+  else
+    parameter = db.PrepareSQL(operatorString.c_str(), param.c_str());
+
+  if (GetFieldType(m_field) == DATE_FIELD)
+  {
+    if (m_operator == OPERATOR_IN_THE_LAST || m_operator == OPERATOR_NOT_IN_THE_LAST)
+    { // translate time period
+      CDateTime date=CDateTime::GetCurrentDateTime();
+      CDateTimeSpan span;
+      span.SetFromPeriod(param);
+      date-=span;
+      parameter = db.PrepareSQL(operatorString.c_str(), date.GetAsDBDate().c_str());
+    }
+  }
+  return parameter;
+}
+
+CStdString CDatabaseQueryRule::GetOperatorString(SEARCH_OPERATOR op) const
+{
+  CStdString operatorString;
+  if (GetFieldType(m_field) != TEXTIN_FIELD)
+  {
+    // the comparison piece
+    switch (op)
+    {
+    case OPERATOR_CONTAINS:
+      operatorString = " LIKE '%%%s%%'"; break;
+    case OPERATOR_DOES_NOT_CONTAIN:
+      operatorString = " LIKE '%%%s%%'"; break;
+    case OPERATOR_EQUALS:
+      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
+        operatorString = " = %s";
+      else
+        operatorString = " LIKE '%s'";
+      break;
+    case OPERATOR_DOES_NOT_EQUAL:
+      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
+        operatorString = " != %s";
+      else
+        operatorString = " LIKE '%s'";
+      break;
+    case OPERATOR_STARTS_WITH:
+      operatorString = " LIKE '%s%%'"; break;
+    case OPERATOR_ENDS_WITH:
+      operatorString = " LIKE '%%%s'"; break;
+    case OPERATOR_AFTER:
+    case OPERATOR_GREATER_THAN:
+    case OPERATOR_IN_THE_LAST:
+      operatorString = " > ";
+      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
+        operatorString += "%s";
+      else
+        operatorString += "'%s'";
+      break;
+    case OPERATOR_BEFORE:
+    case OPERATOR_LESS_THAN:
+    case OPERATOR_NOT_IN_THE_LAST:
+      operatorString = " < ";
+      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
+        operatorString += "%s";
+      else
+        operatorString += "'%s'";
+      break;
+    case OPERATOR_TRUE:
+      operatorString = " = 1"; break;
+    case OPERATOR_FALSE:
+      operatorString = " = 0"; break;
+    default:
+      break;
+    }
+  }
+  return operatorString;
+}
+
+CStdString CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const CStdString& strType) const
+{
+  SEARCH_OPERATOR op = GetOperator(strType);
+
+  CStdString operatorString = GetOperatorString(op);
+  CStdString negate;
+  if (op == OPERATOR_DOES_NOT_CONTAIN || op == OPERATOR_FALSE ||
+     (op == OPERATOR_DOES_NOT_EQUAL && GetFieldType(m_field) != NUMERIC_FIELD && GetFieldType(m_field) != SECONDS_FIELD))
+    negate = " NOT";
+
+  // boolean operators don't have any values in m_parameter, they work on the operator
+  if (m_operator == OPERATOR_FALSE || m_operator == OPERATOR_TRUE)
+    return GetBooleanQuery(negate, strType);
+
+  // The BETWEEN operator is handled special
+  if (op == OPERATOR_BETWEEN)
+  {
+    if (m_parameter.size() != 2)
+      return "";
+
+    FIELD_TYPE fieldType = GetFieldType(m_field);
+    if (fieldType == NUMERIC_FIELD)
+      return db.PrepareSQL("CAST(%s as DECIMAL(5,1)) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
+    else if (fieldType == SECONDS_FIELD)
+      return db.PrepareSQL("CAST(%s as INTEGER) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
+    else
+      return db.PrepareSQL("%s BETWEEN '%s' AND '%s'", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
+  }
+
+  // now the query parameter
+  CStdString wholeQuery;
+  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); ++it)
+  {
+    CStdString query = "(" + FormatWhereClause(negate, operatorString, *it, db, strType) + ")";
+
+    if (it+1 != m_parameter.end())
+      query += " OR ";
+
+    wholeQuery += query;
+  }
+
+  return wholeQuery;
+}
+
+CStdString CDatabaseQueryRule::FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
+                                                 const CDatabase &db, const CStdString &strType) const
+{
+  CStdString parameter = FormatParameter(oper, param, db, strType);
+
+  CStdString query;
+  if (m_field != 0)
+  {
+    string fmt = "%s";
+    if (GetFieldType(m_field) == NUMERIC_FIELD)
+      fmt = "CAST(%s as DECIMAL(5,1))";
+    else if (GetFieldType(m_field) == SECONDS_FIELD)
+      fmt = "CAST(%s as INTEGER)";
+
+    query.Format(fmt.c_str(), GetField(m_field,strType).c_str());
+    query += negate + parameter;
+  }
+
+  if (query.Equals(negate + parameter))
+    query = "1";
+  return query;
+}
+
+CDatabaseQueryRuleCombination::CDatabaseQueryRuleCombination()
+  : m_type(CombinationAnd)
+{ }
+
+void CDatabaseQueryRuleCombination::clear()
+{
+  m_combinations.clear();
+  m_rules.clear();
+  m_type = CombinationAnd;
+}
+
+CStdString CDatabaseQueryRuleCombination::GetWhereClause(const CDatabase &db, const CStdString& strType) const
+{
+  CStdString rule, currentRule;
+
+  // translate the combinations into SQL
+  for (CDatabaseQueryRuleCombinations::const_iterator it = m_combinations.begin(); it != m_combinations.end(); ++it)
+  {
+    if (it != m_combinations.begin())
+      rule += m_type == CombinationAnd ? " AND " : " OR ";
+    rule += "(" + (*it)->GetWhereClause(db, strType) + ")";
+  }
+
+  // translate the rules into SQL
+  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+  {
+    if (!rule.empty())
+      rule += m_type == CombinationAnd ? " AND " : " OR ";
+    rule += "(";
+    CStdString currentRule = (*it)->GetWhereClause(db, strType);
+    // if we don't get a rule, we add '1' or '0' so the query is still valid and doesn't fail
+    if (currentRule.IsEmpty())
+      currentRule = m_type == CombinationAnd ? "'1'" : "'0'";
+    rule += currentRule;
+    rule += ")";
+  }
+
+  return rule;
+}
+
+bool CDatabaseQueryRuleCombination::Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory)
+{
+  if (!obj.isObject() && !obj.isArray())
+    return false;
+  
+  CVariant child;
+  if (obj.isObject())
+  {
+    if (obj.isMember("and") && obj["and"].isArray())
+    {
+      m_type = CombinationAnd;
+      child = obj["and"];
+    }
+    else if (obj.isMember("or") && obj["or"].isArray())
+    {
+      m_type = CombinationOr;
+      child = obj["or"];
+    }
+    else
+      return false;
+  }
+  else
+    child = obj;
+
+  for (CVariant::const_iterator_array it = child.begin_array(); it != child.end_array(); it++)
+  {
+    if (!it->isObject())
+      continue;
+
+    if (it->isMember("and") || it->isMember("or"))
+    {
+      boost::shared_ptr<CDatabaseQueryRuleCombination> combo(factory->CreateCombination());
+      if (combo && combo->Load(*it, factory))
+        m_combinations.push_back(combo);
+    }
+    else
+    {
+      boost::shared_ptr<CDatabaseQueryRule> rule(factory->CreateRule());
+      if (rule && rule->Load(*it))
+        m_rules.push_back(rule);
+    }
+  }
+
+  return true;
+}
+
+bool CDatabaseQueryRuleCombination::Save(TiXmlNode *parent) const
+{
+  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+    (*it)->Save(parent);
+  return true;
+}
+
+bool CDatabaseQueryRuleCombination::Save(CVariant &obj) const
+{
+  if (!obj.isObject() || (m_combinations.empty() && m_rules.empty()))
+    return false;
+
+  CVariant comboArray(CVariant::VariantTypeArray);
+  if (!m_combinations.empty())
+  {
+    for (CDatabaseQueryRuleCombinations::const_iterator combo = m_combinations.begin(); combo != m_combinations.end(); combo++)
+    {
+      CVariant comboObj(CVariant::VariantTypeObject);
+      if ((*combo)->Save(comboObj))
+        comboArray.push_back(comboObj);
+    }
+
+  }
+  if (!m_rules.empty())
+  {
+    for (CDatabaseQueryRules::const_iterator rule = m_rules.begin(); rule != m_rules.end(); rule++)
+    {
+      CVariant ruleObj(CVariant::VariantTypeObject);
+      if ((*rule)->Save(ruleObj))
+        comboArray.push_back(ruleObj);
+    }
+  }
+
+  obj[TranslateCombinationType()] = comboArray;
+
+  return true;
+}
+
+std::string CDatabaseQueryRuleCombination::TranslateCombinationType() const
+{
+  return m_type == CombinationAnd ? "and" : "or";
+}

--- a/xbmc/dbwrappers/DatabaseQuery.h
+++ b/xbmc/dbwrappers/DatabaseQuery.h
@@ -1,0 +1,144 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <set>
+#include <vector>
+#include <boost/shared_ptr.hpp>
+
+#include "utils/StdString.h"
+
+class CDatabase;
+class CVariant;
+class TiXmlNode;
+
+class CDatabaseQueryRule
+{
+public:
+  CDatabaseQueryRule();
+  virtual ~CDatabaseQueryRule() { };
+
+  enum SEARCH_OPERATOR { OPERATOR_START = 0,
+                         OPERATOR_CONTAINS,
+                         OPERATOR_DOES_NOT_CONTAIN,
+                         OPERATOR_EQUALS,
+                         OPERATOR_DOES_NOT_EQUAL,
+                         OPERATOR_STARTS_WITH,
+                         OPERATOR_ENDS_WITH,
+                         OPERATOR_GREATER_THAN,
+                         OPERATOR_LESS_THAN,
+                         OPERATOR_AFTER,
+                         OPERATOR_BEFORE,
+                         OPERATOR_IN_THE_LAST,
+                         OPERATOR_NOT_IN_THE_LAST,
+                         OPERATOR_TRUE,
+                         OPERATOR_FALSE,
+                         OPERATOR_BETWEEN,
+                         OPERATOR_END
+                       };
+
+  enum FIELD_TYPE { TEXT_FIELD = 0,
+                    NUMERIC_FIELD,
+                    DATE_FIELD,
+                    PLAYLIST_FIELD,
+                    SECONDS_FIELD,
+                    BOOLEAN_FIELD,
+                    TEXTIN_FIELD
+                  };
+
+  virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8");
+  virtual bool Load(const CVariant &obj);
+  virtual bool Save(TiXmlNode *parent) const;
+  virtual bool Save(CVariant &obj) const;
+
+  static CStdString           GetLocalizedOperator(SEARCH_OPERATOR oper);
+  static void                 GetAvailableOperators(std::vector<std::string> &operatorList);
+
+  CStdString                  GetParameter() const;
+  void                        SetParameter(const CStdString &value);
+  void                        SetParameter(const std::vector<CStdString> &values);
+
+  virtual CStdString          GetWhereClause(const CDatabase &db, const CStdString& strType) const;
+
+  int                         m_field;
+  SEARCH_OPERATOR             m_operator;
+  std::vector<CStdString>     m_parameter;
+
+protected:
+  virtual CStdString          GetField(int field, const CStdString& type) const=0;
+  virtual FIELD_TYPE          GetFieldType(int field) const=0;
+  virtual int                 TranslateField(const char *field) const=0;
+  virtual CStdString          TranslateField(int field) const=0;
+  virtual CStdString          FormatParameter(const CStdString &negate, const CStdString &oper, const CDatabase &db, const CStdString &type) const;
+  virtual CStdString          FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
+                                                const CDatabase &db, const CStdString &type) const;
+  virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const { return m_operator; };
+  virtual CStdString          GetOperatorString(SEARCH_OPERATOR op) const;
+  virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const { return ""; }
+
+  static SEARCH_OPERATOR      TranslateOperator(const char *oper);
+  static CStdString           TranslateOperator(SEARCH_OPERATOR oper);
+};
+
+class CDatabaseQueryRuleCombination;
+
+typedef std::vector< boost::shared_ptr<CDatabaseQueryRule> > CDatabaseQueryRules;
+typedef std::vector< boost::shared_ptr<CDatabaseQueryRuleCombination> > CDatabaseQueryRuleCombinations;
+
+class IDatabaseQueryRuleFactory
+{
+public:
+  virtual CDatabaseQueryRule *CreateRule() const=0;
+  virtual CDatabaseQueryRuleCombination *CreateCombination() const=0;
+};
+
+class CDatabaseQueryRuleCombination
+{
+public:
+  CDatabaseQueryRuleCombination();
+  virtual ~CDatabaseQueryRuleCombination() { };
+
+  typedef enum {
+    CombinationOr = 0,
+    CombinationAnd
+  } Combination;
+
+  void clear();
+  virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8") { return false; }
+  virtual bool Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory);
+  virtual bool Save(TiXmlNode *parent) const;
+  virtual bool Save(CVariant &obj) const;
+
+  CStdString GetWhereClause(const CDatabase &db, const CStdString& strType) const;
+  std::string TranslateCombinationType() const;
+
+  Combination GetType() const { return m_type; }
+  void SetType(Combination combination) { m_type = combination; }
+
+  bool empty() const { return m_combinations.empty() && m_rules.empty(); }
+
+protected:
+  friend class CGUIDialogSmartPlaylistEditor;
+  friend class CGUIDialogMediaFilter;
+
+  Combination m_type;
+  CDatabaseQueryRuleCombinations m_combinations;
+  CDatabaseQueryRules m_rules;
+};

--- a/xbmc/dbwrappers/Makefile
+++ b/xbmc/dbwrappers/Makefile
@@ -1,4 +1,5 @@
 SRCS=Database.cpp \
+     DatabaseQuery.cpp \
      dataset.cpp \
      mysqldataset.cpp \
      qry_dat.cpp \

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -254,11 +254,11 @@ void CGUIDialogMediaFilter::CreateSettings()
     filter.controlIndex = CONTROL_START + m_settings.size();
 
     // check the smartplaylist if it contains a matching rule
-    for (CSmartPlaylistRules::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
+    for (CDatabaseQueryRules::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
     {
       if ((*rule)->m_field == filter.field)
       {
-        filter.rule = rule->get();
+        filter.rule = (CSmartPlaylistRule *)rule->get();
         handledRules++;
         break;
       }
@@ -676,7 +676,7 @@ void CGUIDialogMediaFilter::OnBrowse(const Filter &filter, CFileItemList &items,
       return;
 
     CSmartPlaylist tmpFilter = *m_filter;
-    for (CSmartPlaylistRules::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
+    for (CDatabaseQueryRules::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
     {
       if ((*rule)->m_field == filter.field)
       {
@@ -717,7 +717,7 @@ void CGUIDialogMediaFilter::OnBrowse(const Filter &filter, CFileItemList &items,
       return;
 
     CSmartPlaylist tmpFilter = *m_filter;
-    for (CSmartPlaylistRules::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
+    for (CDatabaseQueryRules::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
     {
       if ((*rule)->m_field == filter.field)
       {
@@ -780,12 +780,12 @@ CSmartPlaylistRule* CGUIDialogMediaFilter::AddRule(Field field, CDatabaseQueryRu
   rule.m_operator = ruleOperator;
 
   m_filter->m_ruleCombination.AddRule(rule);
-  return m_filter->m_ruleCombination.m_rules.back().get();
+  return (CSmartPlaylistRule *)m_filter->m_ruleCombination.m_rules.back().get();
 }
 
 void CGUIDialogMediaFilter::DeleteRule(Field field)
 {
-  for (CSmartPlaylistRules::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
+  for (CDatabaseQueryRules::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
   {
     if ((*rule)->m_field == field)
     {

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -57,73 +57,73 @@
 using namespace std;
 
 static const CGUIDialogMediaFilter::Filter filterList[] = {
-  { "movies",       FieldTitle,         556,    SettingInfo::EDIT,        CSmartPlaylistRule::OPERATOR_CONTAINS },
-  { "movies",       FieldRating,        563,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  //{ "movies",       FieldTime,          180,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
-  { "movies",       FieldInProgress,    575,    SettingInfo::CHECK,       CSmartPlaylistRule::OPERATOR_FALSE },
-  { "movies",       FieldYear,          562,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "movies",       FieldTag,           20459,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "movies",       FieldGenre,         515,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "movies",       FieldActor,         20337,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "movies",       FieldDirector,      20339,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "movies",       FieldStudio,        572,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  //{ "movies",       FieldLastPlayed,    568,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
-  //{ "movies",       FieldDateAdded,     570,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
+  { "movies",       FieldTitle,         556,    SettingInfo::EDIT,        CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "movies",       FieldRating,        563,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  //{ "movies",       FieldTime,          180,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
+  { "movies",       FieldInProgress,    575,    SettingInfo::CHECK,       CDatabaseQueryRule::OPERATOR_FALSE },
+  { "movies",       FieldYear,          562,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "movies",       FieldTag,           20459,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldGenre,         515,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldActor,         20337,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldDirector,      20339,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldStudio,        572,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  //{ "movies",       FieldLastPlayed,    568,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
+  //{ "movies",       FieldDateAdded,     570,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
 
-  { "tvshows",      FieldTitle,         556,    SettingInfo::EDIT,        CSmartPlaylistRule::OPERATOR_CONTAINS },
-  //{ "tvshows",      FieldTvShowStatus,  126,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
-  { "tvshows",      FieldRating,        563,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "tvshows",      FieldInProgress,    575,    SettingInfo::CHECK,       CSmartPlaylistRule::OPERATOR_FALSE },
-  { "tvshows",      FieldYear,          562,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "tvshows",      FieldTag,           20459,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldGenre,         515,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldActor,         20337,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldDirector,      20339,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldStudio,        572,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  //{ "tvshows",      FieldDateAdded,     570,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
+  { "tvshows",      FieldTitle,         556,    SettingInfo::EDIT,        CDatabaseQueryRule::OPERATOR_CONTAINS },
+  //{ "tvshows",      FieldTvShowStatus,  126,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
+  { "tvshows",      FieldRating,        563,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "tvshows",      FieldInProgress,    575,    SettingInfo::CHECK,       CDatabaseQueryRule::OPERATOR_FALSE },
+  { "tvshows",      FieldYear,          562,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "tvshows",      FieldTag,           20459,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldGenre,         515,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldActor,         20337,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldDirector,      20339,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldStudio,        572,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  //{ "tvshows",      FieldDateAdded,     570,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
 
-  { "episodes",     FieldTitle,         556,    SettingInfo::EDIT,        CSmartPlaylistRule::OPERATOR_CONTAINS },
-  { "episodes",     FieldRating,        563,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "episodes",     FieldAirDate,       20416,  SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "episodes",     FieldInProgress,    575,    SettingInfo::CHECK,       CSmartPlaylistRule::OPERATOR_FALSE },
-  { "episodes",     FieldActor,         20337,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "episodes",     FieldDirector,      20339,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  //{ "episodes",     FieldLastPlayed,    568,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
-  //{ "episodes",     FieldDateAdded,     570,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
+  { "episodes",     FieldTitle,         556,    SettingInfo::EDIT,        CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "episodes",     FieldRating,        563,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "episodes",     FieldAirDate,       20416,  SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "episodes",     FieldInProgress,    575,    SettingInfo::CHECK,       CDatabaseQueryRule::OPERATOR_FALSE },
+  { "episodes",     FieldActor,         20337,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "episodes",     FieldDirector,      20339,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  //{ "episodes",     FieldLastPlayed,    568,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
+  //{ "episodes",     FieldDateAdded,     570,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
 
-  { "musicvideos",  FieldTitle,         556,    SettingInfo::EDIT,        CSmartPlaylistRule::OPERATOR_CONTAINS },
-  { "musicvideos",  FieldArtist,        557,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldAlbum,         558,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  //{ "musicvideos",  FieldTime,          180,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
-  { "musicvideos",  FieldYear,          562,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "musicvideos",  FieldTag,           20459,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldGenre,         515,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldDirector,      20339,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldStudio,        572,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  //{ "musicvideos",  FieldLastPlayed,    568,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
-  //{ "musicvideos",  FieldDateAdded,     570,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
+  { "musicvideos",  FieldTitle,         556,    SettingInfo::EDIT,        CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "musicvideos",  FieldArtist,        557,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldAlbum,         558,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  //{ "musicvideos",  FieldTime,          180,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
+  { "musicvideos",  FieldYear,          562,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "musicvideos",  FieldTag,           20459,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldGenre,         515,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldDirector,      20339,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldStudio,        572,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  //{ "musicvideos",  FieldLastPlayed,    568,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
+  //{ "musicvideos",  FieldDateAdded,     570,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
 
-  { "artists",      FieldArtist,        557,    SettingInfo::EDIT,        CSmartPlaylistRule::OPERATOR_CONTAINS },
-  { "artists",      FieldGenre,         515,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
+  { "artists",      FieldArtist,        557,    SettingInfo::EDIT,        CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "artists",      FieldGenre,         515,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
 
-  { "albums",       FieldAlbum,         556,    SettingInfo::EDIT,        CSmartPlaylistRule::OPERATOR_CONTAINS },
-  { "albums",       FieldArtist,        557,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "albums",       FieldRating,        563,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "albums",       FieldAlbumType,     564,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "albums",       FieldYear,          562,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "albums",       FieldGenre,         515,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "albums",       FieldMusicLabel,    21899,  SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
+  { "albums",       FieldAlbum,         556,    SettingInfo::EDIT,        CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "albums",       FieldArtist,        557,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldRating,        563,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "albums",       FieldAlbumType,     564,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldYear,          562,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "albums",       FieldGenre,         515,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldMusicLabel,    21899,  SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
 
-  { "songs",        FieldTitle,         556,    SettingInfo::EDIT,        CSmartPlaylistRule::OPERATOR_CONTAINS },
-  { "songs",        FieldAlbum,         558,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "songs",        FieldArtist,        557,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "songs",        FieldTime,          180,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "songs",        FieldRating,        563,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "songs",        FieldYear,          562,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  { "songs",        FieldGenre,         515,    SettingInfo::BUTTON,      CSmartPlaylistRule::OPERATOR_EQUALS },
-  { "songs",        FieldPlaycount,     567,    SettingInfo::RANGE,       CSmartPlaylistRule::OPERATOR_BETWEEN },
-  //{ "songs",        FieldLastPlayed,    568,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
-  //{ "songs",        FieldDateAdded,     570,    SettingInfo::TODO,        CSmartPlaylistRule::TODO },
+  { "songs",        FieldTitle,         556,    SettingInfo::EDIT,        CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "songs",        FieldAlbum,         558,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "songs",        FieldArtist,        557,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "songs",        FieldTime,          180,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldRating,        563,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldYear,          562,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldGenre,         515,    SettingInfo::BUTTON,      CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "songs",        FieldPlaycount,     567,    SettingInfo::RANGE,       CDatabaseQueryRule::OPERATOR_BETWEEN },
+  //{ "songs",        FieldLastPlayed,    568,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
+  //{ "songs",        FieldDateAdded,     570,    SettingInfo::TODO,        CDatabaseQueryRule::TODO },
 };
 
 #define NUM_FILTERS sizeof(filterList) / sizeof(CGUIDialogMediaFilter::Filter)
@@ -286,7 +286,7 @@ void CGUIDialogMediaFilter::CreateSettings()
         if (filter.rule == NULL)
           filter.data = new int(CHECK_ALL);
         else
-          filter.data = new int(filter.rule->m_operator == CSmartPlaylistRule::OPERATOR_TRUE ? CHECK_YES : CHECK_NO);
+          filter.data = new int(filter.rule->m_operator == CDatabaseQueryRule::OPERATOR_TRUE ? CHECK_YES : CHECK_NO);
 
         vector<pair<int, int> > entries;
         entries.push_back(pair<int, int>(CHECK_ALL, CHECK_LABEL_ALL));
@@ -437,7 +437,7 @@ void CGUIDialogMediaFilter::OnSettingChanged(SettingInfo &setting)
       int choice = *(int *)setting.data;
       if (choice > CHECK_ALL)
       {
-        CSmartPlaylistRule::SEARCH_OPERATOR ruleOperator = choice == CHECK_YES ? CSmartPlaylistRule::OPERATOR_TRUE : CSmartPlaylistRule::OPERATOR_FALSE;
+        CDatabaseQueryRule::SEARCH_OPERATOR ruleOperator = choice == CHECK_YES ? CDatabaseQueryRule::OPERATOR_TRUE : CDatabaseQueryRule::OPERATOR_FALSE;
         if (filter.rule == NULL)
           filter.rule = AddRule(filter.field, ruleOperator);
         else
@@ -773,7 +773,7 @@ void CGUIDialogMediaFilter::OnBrowse(const Filter &filter, CFileItemList &items,
   pDialog->Reset();
 }
 
-CSmartPlaylistRule* CGUIDialogMediaFilter::AddRule(Field field, CSmartPlaylistRule::SEARCH_OPERATOR ruleOperator /* = CSmartPlaylistRule::OPERATOR_CONTAINS */)
+CSmartPlaylistRule* CGUIDialogMediaFilter::AddRule(Field field, CDatabaseQueryRule::SEARCH_OPERATOR ruleOperator /* = CDatabaseQueryRule::OPERATOR_CONTAINS */)
 {
   CSmartPlaylistRule rule;
   rule.m_field = field;

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -254,11 +254,11 @@ void CGUIDialogMediaFilter::CreateSettings()
     filter.controlIndex = CONTROL_START + m_settings.size();
 
     // check the smartplaylist if it contains a matching rule
-    for (vector<CSmartPlaylistRule>::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
+    for (CSmartPlaylistRules::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
     {
-      if (rule->m_field == filter.field)
+      if ((*rule)->m_field == filter.field)
       {
-        filter.rule = &(*rule);
+        filter.rule = rule->get();
         handledRules++;
         break;
       }
@@ -676,9 +676,9 @@ void CGUIDialogMediaFilter::OnBrowse(const Filter &filter, CFileItemList &items,
       return;
 
     CSmartPlaylist tmpFilter = *m_filter;
-    for (vector<CSmartPlaylistRule>::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
+    for (CSmartPlaylistRules::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
     {
-      if (rule->m_field == filter.field)
+      if ((*rule)->m_field == filter.field)
       {
         tmpFilter.m_ruleCombination.m_rules.erase(rule);
         break;
@@ -717,9 +717,9 @@ void CGUIDialogMediaFilter::OnBrowse(const Filter &filter, CFileItemList &items,
       return;
 
     CSmartPlaylist tmpFilter = *m_filter;
-    for (vector<CSmartPlaylistRule>::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
+    for (CSmartPlaylistRules::iterator rule = tmpFilter.m_ruleCombination.m_rules.begin(); rule != tmpFilter.m_ruleCombination.m_rules.end(); rule++)
     {
-      if (rule->m_field == filter.field)
+      if ((*rule)->m_field == filter.field)
       {
         tmpFilter.m_ruleCombination.m_rules.erase(rule);
         break;
@@ -779,15 +779,15 @@ CSmartPlaylistRule* CGUIDialogMediaFilter::AddRule(Field field, CDatabaseQueryRu
   rule.m_field = field;
   rule.m_operator = ruleOperator;
 
-  m_filter->m_ruleCombination.m_rules.push_back(rule);
-  return &m_filter->m_ruleCombination.m_rules.at(m_filter->m_ruleCombination.m_rules.size() - 1);
+  m_filter->m_ruleCombination.AddRule(rule);
+  return m_filter->m_ruleCombination.m_rules.back().get();
 }
 
 void CGUIDialogMediaFilter::DeleteRule(Field field)
 {
-  for (vector<CSmartPlaylistRule>::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
+  for (CSmartPlaylistRules::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)
   {
-    if (rule->m_field == field)
+    if ((*rule)->m_field == field)
     {
       m_filter->m_ruleCombination.m_rules.erase(rule);
       break;

--- a/xbmc/dialogs/GUIDialogMediaFilter.h
+++ b/xbmc/dialogs/GUIDialogMediaFilter.h
@@ -47,7 +47,7 @@ public:
     Field field;
     uint32_t label;
     SettingInfo::SETTING_TYPE type;
-    CSmartPlaylistRule::SEARCH_OPERATOR ruleOperator;
+    CDatabaseQueryRule::SEARCH_OPERATOR ruleOperator;
     void *data;
     CSmartPlaylistRule *rule;
     int controlIndex;
@@ -68,7 +68,7 @@ protected:
   void TriggerFilter() const;
 
   void OnBrowse(const Filter &filter, CFileItemList &items, bool countOnly = false);
-  CSmartPlaylistRule* AddRule(Field field, CSmartPlaylistRule::SEARCH_OPERATOR ruleOperator = CSmartPlaylistRule::OPERATOR_CONTAINS);
+  CSmartPlaylistRule* AddRule(Field field, CDatabaseQueryRule::SEARCH_OPERATOR ruleOperator = CDatabaseQueryRule::OPERATOR_CONTAINS);
   void DeleteRule(Field field);
   void GetRange(const Filter &filter, float &min, float &interval, float &max, RANGEFORMATFUNCTION &formatFunction);
   bool GetMinMax(const CStdString &table, const CStdString &field, float &min, float &max, const CDatabase::Filter &filter = CDatabase::Filter());

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -150,10 +150,10 @@ void CGUIDialogSmartPlaylistEditor::OnRuleList(int item)
 {
   if (item < 0 || item >= (int)m_playlist.m_ruleCombination.m_rules.size()) return;
 
-  CSmartPlaylistRule rule = m_playlist.m_ruleCombination.m_rules[item];
+  CSmartPlaylistRule rule = *m_playlist.m_ruleCombination.m_rules[item];
 
   if (CGUIDialogSmartPlaylistRule::EditRule(rule,m_playlist.GetType()))
-    m_playlist.m_ruleCombination.m_rules[item] = rule;
+    *m_playlist.m_ruleCombination.m_rules[item] = rule;
 
   UpdateButtons();
 }
@@ -272,7 +272,7 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   
   // if there's no rule available, add a dummy one the user can edit
   if (m_playlist.m_ruleCombination.m_rules.size() <= 0)
-    m_playlist.m_ruleCombination.m_rules.push_back(CSmartPlaylistRule());
+    m_playlist.m_ruleCombination.AddRule(CSmartPlaylistRule());
 
   // name
   if (m_mode == "partyvideo" || m_mode == "partymusic")
@@ -294,10 +294,10 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   for (unsigned int i = 0; i < m_playlist.m_ruleCombination.m_rules.size(); i++)
   {
     CFileItemPtr item(new CFileItem("", false));
-    if (m_playlist.m_ruleCombination.m_rules[i].m_field == FieldNone)
+    if (m_playlist.m_ruleCombination.m_rules[i]->m_field == FieldNone)
       item->SetLabel(g_localizeStrings.Get(21423));
     else
-      item->SetLabel(m_playlist.m_ruleCombination.m_rules[i].GetLocalizedRule());
+      item->SetLabel(m_playlist.m_ruleCombination.m_rules[i]->GetLocalizedRule());
     m_ruleLabels->Add(item);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_RULE_LIST, 0, 0, m_ruleLabels);
@@ -376,7 +376,7 @@ void CGUIDialogSmartPlaylistEditor::UpdateRuleControlButtons()
   CONTROL_ENABLE_ON_CONDITION(CONTROL_RULE_REMOVE,
                               iSize > 0 && // there is at least one item
                               iItem >= 0 && iItem < iSize && // and a valid item is selected
-                              m_playlist.m_ruleCombination.m_rules[iItem].m_field != FieldNone); // and it is not be empty
+                              m_playlist.m_ruleCombination.m_rules[iItem]->m_field != FieldNone); // and it is not be empty
 }
 
 void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
@@ -540,10 +540,10 @@ void CGUIDialogSmartPlaylistEditor::OnRuleAdd()
   CSmartPlaylistRule rule;
   if (CGUIDialogSmartPlaylistRule::EditRule(rule,m_playlist.GetType()))
   {
-    if (m_playlist.m_ruleCombination.m_rules.size() == 1 && m_playlist.m_ruleCombination.m_rules[0].m_field == FieldNone)
-      m_playlist.m_ruleCombination.m_rules[0] = rule;
+    if (m_playlist.m_ruleCombination.m_rules.size() == 1 && m_playlist.m_ruleCombination.m_rules[0]->m_field == FieldNone)
+      *m_playlist.m_ruleCombination.m_rules[0] = rule;
     else
-      m_playlist.m_ruleCombination.m_rules.push_back(rule);
+      m_playlist.m_ruleCombination.AddRule(rule);
   }
   UpdateButtons();
 }

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -150,7 +150,7 @@ void CGUIDialogSmartPlaylistEditor::OnRuleList(int item)
 {
   if (item < 0 || item >= (int)m_playlist.m_ruleCombination.m_rules.size()) return;
 
-  CSmartPlaylistRule rule = *m_playlist.m_ruleCombination.m_rules[item];
+  CSmartPlaylistRule rule = *boost::static_pointer_cast<CSmartPlaylistRule>(m_playlist.m_ruleCombination.m_rules[item]);
 
   if (CGUIDialogSmartPlaylistRule::EditRule(rule,m_playlist.GetType()))
     *m_playlist.m_ruleCombination.m_rules[item] = rule;
@@ -297,7 +297,7 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
     if (m_playlist.m_ruleCombination.m_rules[i]->m_field == FieldNone)
       item->SetLabel(g_localizeStrings.Get(21423));
     else
-      item->SetLabel(m_playlist.m_ruleCombination.m_rules[i]->GetLocalizedRule());
+      item->SetLabel(boost::static_pointer_cast<CSmartPlaylistRule>(m_playlist.m_ruleCombination.m_rules[i])->GetLocalizedRule());
     m_ruleLabels->Add(item);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_RULE_LIST, 0, 0, m_ruleLabels);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -391,7 +391,7 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   else
     CONTROL_DISABLE(CONTROL_BROWSE);
 
-  switch (CSmartPlaylistRule::GetFieldType(m_rule.m_field))
+  switch (m_rule.GetFieldType(m_rule.m_field))
   {
   case CSmartPlaylistRule::TEXT_FIELD:
     // text fields - add the usual comparisons
@@ -447,7 +447,7 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   // update the parameter edit control appropriately
   SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetParameter());
   CGUIEditControl::INPUT_TYPE type = CGUIEditControl::INPUT_TYPE_TEXT;
-  CSmartPlaylistRule::FIELD_TYPE fieldType = CSmartPlaylistRule::GetFieldType(m_rule.m_field);
+  CSmartPlaylistRule::FIELD_TYPE fieldType = m_rule.GetFieldType(m_rule.m_field);
   switch (fieldType)
   {
   case CSmartPlaylistRule::TEXT_FIELD:

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -369,7 +369,7 @@ void CGUIDialogSmartPlaylistRule::OnOperator()
 {
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_OPERATOR);
   OnMessage(msg);
-  m_rule.m_operator = (CSmartPlaylistRule::SEARCH_OPERATOR)msg.GetParam1();
+  m_rule.m_operator = (CDatabaseQueryRule::SEARCH_OPERATOR)msg.GetParam1();
 
   UpdateButtons();
 }
@@ -393,48 +393,48 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
 
   switch (m_rule.GetFieldType(m_rule.m_field))
   {
-  case CSmartPlaylistRule::TEXT_FIELD:
+  case CDatabaseQueryRule::TEXT_FIELD:
     // text fields - add the usual comparisons
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_DOES_NOT_EQUAL);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_CONTAINS);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_DOES_NOT_CONTAIN);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_STARTS_WITH);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_ENDS_WITH);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_CONTAINS);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_STARTS_WITH);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_ENDS_WITH);
     break;
 
-  case CSmartPlaylistRule::NUMERIC_FIELD:
-  case CSmartPlaylistRule::SECONDS_FIELD:
+  case CDatabaseQueryRule::NUMERIC_FIELD:
+  case CDatabaseQueryRule::SECONDS_FIELD:
     // numerical fields - less than greater than
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_DOES_NOT_EQUAL);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_GREATER_THAN);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_LESS_THAN);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_GREATER_THAN);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_LESS_THAN);
     break;
 
-  case CSmartPlaylistRule::DATE_FIELD:
+  case CDatabaseQueryRule::DATE_FIELD:
     // date field
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_AFTER);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_BEFORE);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_IN_THE_LAST);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_NOT_IN_THE_LAST);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_AFTER);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_BEFORE);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_IN_THE_LAST);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST);
     break;
 
-  case CSmartPlaylistRule::PLAYLIST_FIELD:
+  case CDatabaseQueryRule::PLAYLIST_FIELD:
     CONTROL_ENABLE(CONTROL_BROWSE);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_DOES_NOT_EQUAL);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
     break;
 
-  case CSmartPlaylistRule::BOOLEAN_FIELD:
+  case CDatabaseQueryRule::BOOLEAN_FIELD:
     CONTROL_DISABLE(CONTROL_VALUE);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_TRUE);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_FALSE);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_TRUE);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_FALSE);
     break;
 
-  case CSmartPlaylistRule::TEXTIN_FIELD:
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CSmartPlaylistRule::OPERATOR_DOES_NOT_EQUAL);
+  case CDatabaseQueryRule::TEXTIN_FIELD:
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
+    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
     break;
   }
 
@@ -442,38 +442,38 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_OPERATOR, m_rule.m_operator);
   CGUIMessage selected(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_OPERATOR);
   OnMessage(selected);
-  m_rule.m_operator = (CSmartPlaylistRule::SEARCH_OPERATOR)selected.GetParam1();
+  m_rule.m_operator = (CDatabaseQueryRule::SEARCH_OPERATOR)selected.GetParam1();
 
   // update the parameter edit control appropriately
   SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetParameter());
   CGUIEditControl::INPUT_TYPE type = CGUIEditControl::INPUT_TYPE_TEXT;
-  CSmartPlaylistRule::FIELD_TYPE fieldType = m_rule.GetFieldType(m_rule.m_field);
+  CDatabaseQueryRule::FIELD_TYPE fieldType = m_rule.GetFieldType(m_rule.m_field);
   switch (fieldType)
   {
-  case CSmartPlaylistRule::TEXT_FIELD:
-  case CSmartPlaylistRule::PLAYLIST_FIELD:
-  case CSmartPlaylistRule::TEXTIN_FIELD:
-  case CSmartPlaylistRule::NUMERIC_FIELD:
+  case CDatabaseQueryRule::TEXT_FIELD:
+  case CDatabaseQueryRule::PLAYLIST_FIELD:
+  case CDatabaseQueryRule::TEXTIN_FIELD:
+  case CDatabaseQueryRule::NUMERIC_FIELD:
     type = CGUIEditControl::INPUT_TYPE_TEXT;
     break;
-  case CSmartPlaylistRule::DATE_FIELD:
-    if (m_rule.m_operator == CSmartPlaylistRule::OPERATOR_IN_THE_LAST ||
-        m_rule.m_operator == CSmartPlaylistRule::OPERATOR_NOT_IN_THE_LAST)
+  case CDatabaseQueryRule::DATE_FIELD:
+    if (m_rule.m_operator == CDatabaseQueryRule::OPERATOR_IN_THE_LAST ||
+        m_rule.m_operator == CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST)
       type = CGUIEditControl::INPUT_TYPE_TEXT;
     else
       type = CGUIEditControl::INPUT_TYPE_DATE;
     break;
-  case CSmartPlaylistRule::SECONDS_FIELD:
+  case CDatabaseQueryRule::SECONDS_FIELD:
     type = CGUIEditControl::INPUT_TYPE_SECONDS;
     break;
-  case CSmartPlaylistRule::BOOLEAN_FIELD:
+  case CDatabaseQueryRule::BOOLEAN_FIELD:
     type = CGUIEditControl::INPUT_TYPE_NUMBER;
     break;
   }
   SendMessage(GUI_MSG_SET_TYPE, CONTROL_VALUE, type, 21420);
 }
 
-void CGUIDialogSmartPlaylistRule::AddOperatorLabel(CSmartPlaylistRule::SEARCH_OPERATOR op)
+void CGUIDialogSmartPlaylistRule::AddOperatorLabel(CDatabaseQueryRule::SEARCH_OPERATOR op)
 {
   CGUIMessage select(GUI_MSG_LABEL_ADD, GetID(), CONTROL_OPERATOR, op);
   select.SetLabel(CSmartPlaylistRule::GetLocalizedOperator(op));

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
@@ -43,7 +43,7 @@ protected:
   void OnOK();
   void OnCancel();
   void UpdateButtons();
-  void AddOperatorLabel(CSmartPlaylistRule::SEARCH_OPERATOR op);
+  void AddOperatorLabel(CDatabaseQueryRule::SEARCH_OPERATOR op);
   void OnBrowse();
 
   CSmartPlaylistRule m_rule;

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -227,7 +227,7 @@ void CAddonsOperations::FillDetails(AddonPtr addon, const CVariant& fields, CVar
       bool needsRecaching;
       CStdString image = CTextureCache::Get().CheckCachedImage(url, false, needsRecaching);
       if (!image.empty() || CFile::Exists(url))
-        object[field] = CTextureCache::Get().GetWrappedImageURL(url);
+        object[field] = CTextureUtils::GetWrappedImageURL(url);
       else
         object[field] = "";
     }

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -35,7 +35,7 @@
 #include "video/VideoDatabase.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "TextureCache.h"
+#include "TextureDatabase.h"
 #include "video/VideoThumbLoader.h"
 #include "music/MusicThumbLoader.h"
 #include "Util.h"
@@ -117,7 +117,7 @@ bool CFileItemHandler::GetField(const std::string &field, const CVariant &info, 
       for (CGUIListItem::ArtMap::const_iterator artIt = artMap.begin(); artIt != artMap.end(); ++artIt)
       {
         if (!artIt->second.empty())
-          artObj[artIt->first] = CTextureCache::GetWrappedImageURL(artIt->second);
+          artObj[artIt->first] = CTextureUtils::GetWrappedImageURL(artIt->second);
       }
 
       result["art"] = artObj;
@@ -133,10 +133,10 @@ bool CFileItemHandler::GetField(const std::string &field, const CVariant &info, 
         fetchedArt = true;
       }
       else if (item->HasPictureInfoTag() && !item->HasArt("thumb"))
-        item->SetArt("thumb", CTextureCache::GetWrappedThumbURL(item->GetPath()));
+        item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(item->GetPath()));
       
       if (item->HasArt("thumb"))
-        result["thumbnail"] = CTextureCache::GetWrappedImageURL(item->GetArt("thumb"));
+        result["thumbnail"] = CTextureUtils::GetWrappedImageURL(item->GetArt("thumb"));
       else
         result["thumbnail"] = "";
       
@@ -153,7 +153,7 @@ bool CFileItemHandler::GetField(const std::string &field, const CVariant &info, 
       }
       
       if (item->HasArt("fanart"))
-        result["fanart"] = CTextureCache::GetWrappedImageURL(item->GetArt("fanart"));
+        result["fanart"] = CTextureUtils::GetWrappedImageURL(item->GetArt("fanart"));
       else
         result["fanart"] = "";
       

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -22,6 +22,7 @@
 
 #include "JSONRPC.h"
 #include "ServiceDescription.h"
+#include "dbwrappers/DatabaseQuery.h"
 #include "input/ButtonTranslator.h"
 #include "interfaces/AnnouncementManager.h"
 #include "playlists/SmartPlayList.h"
@@ -52,7 +53,7 @@ void CJSONRPC::Initialize()
 
   // filter-related enums
   vector<string> smartplaylistList;
-  CSmartPlaylist::GetAvailableOperators(smartplaylistList);
+  CDatabaseQueryRule::GetAvailableOperators(smartplaylistList);
   CJSONServiceDescription::AddEnum("List.Filter.Operators", smartplaylistList);
 
   smartplaylistList.clear();

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "TextureDatabase.h"
 
 using namespace ANNOUNCEMENT;
 using namespace JSONRPC;
@@ -83,6 +84,10 @@ void CJSONRPC::Initialize()
   smartplaylistList.clear();
   CSmartPlaylist::GetAvailableFields("songs", smartplaylistList);
   CJSONServiceDescription::AddEnum("List.Filter.Fields.Songs", smartplaylistList);
+
+  smartplaylistList.clear();
+  CTextureRule::GetAvailableFields(smartplaylistList);
+  CJSONServiceDescription::AddEnum("List.Filter.Fields.Textures", smartplaylistList);
 
   unsigned int size = sizeof(JSONRPC_SERVICE_TYPES) / sizeof(char*);
 

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -38,6 +38,7 @@
 #include "PVROperations.h"
 #include "ProfilesOperations.h"
 #include "FavouritesOperations.h"
+#include "TextureOperations.h"
 
 using namespace std;
 using namespace JSONRPC;
@@ -205,6 +206,10 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
 // Favourites operations
   { "Favourites.GetFavourites",                     CFavouritesOperations::GetFavourites },
   { "Favourites.AddFavourite",                      CFavouritesOperations::AddFavourite },
+
+// Textures operations
+  { "Textures.GetTextures",                         CTextureOperations::GetTextures },
+  { "Textures.RemoveTexture",                       CTextureOperations::RemoveTexture },
 
 // XBMC operations
   { "XBMC.GetInfoLabels",                           CXBMCOperations::GetInfoLabels },

--- a/xbmc/interfaces/json-rpc/Makefile
+++ b/xbmc/interfaces/json-rpc/Makefile
@@ -13,6 +13,7 @@ SRCS=AddonsOperations.cpp \
      ProfilesOperations.cpp \
      PVROperations.cpp \
      SystemOperations.cpp \
+     TextureOperations.cpp \
      VideoLibrary.cpp \
      XBMCOperations.cpp \
 

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.8.0";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.9.0";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -842,6 +842,33 @@ namespace JSONRPC
         "\"thumbnail\": { \"type\": \"string\" }"
       "}"
     "}",
+    "\"Textures.Details.Size\": {"
+      "\"type\": \"object\","
+      "\"properties\": {"
+        "\"size\": { \"type\": \"integer\", \"description\": \"Size of texture (1 == largest)\" },"
+        "\"width\": { \"type\": \"integer\", \"description\": \"Width of texture\" },"
+        "\"height\": { \"type\": \"integer\", \"description\": \"Height of texture\" },"
+        "\"usecount\": { \"type\": \"integer\", \"description\": \"Number of uses\" },"
+        "\"lastused\": { \"type\": \"string\", \"description\": \"Time of last use\" }"
+      "}"
+    "}",
+    "\"Textures.Fields.Texture\": {"
+      "\"extends\": \"Item.Fields.Base\","
+      "\"items\": { \"type\": \"string\","
+        "\"enum\": [ \"url\", \"cachedurl\", \"lasthashcheck\", \"imagehash\", \"sizes\" ]"
+      "}"
+    "}",
+    "\"Textures.Details.Texture\": {"
+      "\"type\": \"object\","
+      "\"properties\": {"
+        "\"textureid\": { \"$ref\": \"Library.Id\", \"required\": true },"
+        "\"url\": { \"type\": \"string\", \"description\": \"Original source URL\" },"
+        "\"cachedurl\": { \"type\": \"string\", \"description\": \"Cached URL on disk\" },"
+        "\"lasthashcheck\": { \"type\": \"string\", \"description\": \"Last time source was checked for changes\" },"
+        "\"imagehash\": { \"type\": \"string\", \"description\": \"Hash of image\" },"
+        "\"sizes\": { \"type\": \"array\", \"items\": { \"$ref\": \"Textures.Details.Size\" } }"
+      "}"
+    "}",
     "\"Profiles.Password\": {"
       "\"type\": \"object\","
       "\"properties\": {"
@@ -912,6 +939,12 @@ namespace JSONRPC
       "\"extends\": \"List.Filter.Rule\","
       "\"properties\": {"
         "\"field\": { \"$ref\": \"List.Filter.Fields.Songs\", \"required\": true }"
+      "}"
+    "}",
+    "\"List.Filter.Rule.Textures\": {"
+      "\"extends\": \"List.Filter.Rule\","
+      "\"properties\": {"
+        "\"field\": { \"$ref\": \"List.Filter.Fields.Textures\", \"required\": true }"
       "}"
     "}",
     "\"List.Filter.Movies\": {"
@@ -1059,6 +1092,27 @@ namespace JSONRPC
           "}"
         "},"
         "{ \"$ref\": \"List.Filter.Rule.Songs\" }"
+      "]"
+    "}",
+    "\"List.Filter.Textures\": {"
+      "\"type\": ["
+        "{ \"type\": \"object\","
+          "\"properties\": {"
+            "\"and\": { \"type\": \"array\","
+              "\"items\": { \"$ref\": \"List.Filter.Textures\" },"
+              "\"minItems\": 1, \"required\": true"
+            "}"
+          "}"
+        "},"
+        "{ \"type\": \"object\","
+          "\"properties\": {"
+            "\"or\": { \"type\": \"array\","
+              "\"items\": { \"$ref\": \"List.Filter.Textures\" },"
+              "\"minItems\": 1, \"required\": true"
+            "}"
+          "}"
+        "},"
+        "{ \"$ref\": \"List.Filter.Rule.Textures\" }"
       "]"
     "}",
     "\"List.Item.Base\": {"
@@ -3053,6 +3107,34 @@ namespace JSONRPC
       "\"permission\": \"ControlPVR\","
       "\"params\": [ ],"
       "\"returns\":  \"string\""
+    "}",
+    "\"Textures.GetTextures\": {"
+      "\"type\": \"method\","
+      "\"description\": \"Retrieve all textures\","
+      "\"transport\": \"Response\","
+      "\"permission\": \"ReadData\","
+      "\"params\": ["
+        "{ \"name\": \"properties\", \"$ref\": \"Textures.Fields.Texture\" },"
+        "{ \"name\": \"filter\", \"$ref\": \"List.Filter.Textures\" }"
+      "],"
+      "\"returns\": {"
+        "\"type\": \"object\","
+        "\"properties\": {"
+          "\"textures\": { \"type\": \"array\", \"required\": true,"
+            "\"items\": { \"$ref\": \"Textures.Details.Texture\" }"
+          "}"
+        "}"
+      "}"
+    "}",
+    "\"Textures.RemoveTexture\": {"
+      "\"type\": \"method\","
+      "\"description\": \"Remove the specified texture\","
+      "\"transport\": \"Response\","
+      "\"permission\": \"RemoveData\","
+      "\"params\": ["
+        "{ \"name\": \"textureid\", \"$ref\": \"Library.Id\", \"required\": true, \"description\": \"Texture database identifier\" }"
+      "],"
+      "\"returns\": \"string\""
     "}",
     "\"Profiles.GetProfiles\": {"
       "\"type\": \"method\","

--- a/xbmc/interfaces/json-rpc/TextureOperations.cpp
+++ b/xbmc/interfaces/json-rpc/TextureOperations.cpp
@@ -1,0 +1,103 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "TextureOperations.h"
+#include "TextureDatabase.h"
+#include "TextureCache.h"
+
+using namespace JSONRPC;
+
+JSONRPC_STATUS CTextureOperations::GetTextures(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
+{
+  CFileItemList listItems;
+
+  CTextureDatabase db;
+  if (!db.Open())
+    return InternalError;
+
+  CDatabase::Filter dbFilter;
+  const CVariant &filter = parameterObject["filter"];
+  if (filter.isObject())
+  {
+    CVariant xspObj(CVariant::VariantTypeObject);
+
+    if (filter.isMember("field"))
+    {
+      xspObj["and"] = CVariant(CVariant::VariantTypeArray);
+      xspObj["and"].push_back(filter);
+    }
+    else
+      xspObj = filter;
+
+    // decipher the rules
+    CDatabaseQueryRuleCombination rule;
+    if (!rule.Load(xspObj, &db))
+      return InvalidParams;
+
+    dbFilter.AppendWhere(rule.GetWhereClause(db, ""));
+  }
+
+  // fetch textures from the database
+  CVariant items = CVariant(CVariant::VariantTypeArray);
+  if (!db.GetTextures(items, dbFilter))
+    return InternalError;
+
+  // return only what was asked for, plus textureid
+  CVariant prop = parameterObject["properties"];
+  prop.push_back("textureid");
+  if (!items.empty() && prop.isArray())
+  {
+    std::set<std::string> fields;
+    CVariant &item = items[0];
+    for (CVariant::const_iterator_map field = item.begin_map(); field != item.end_map(); ++field)
+    {
+      if (std::find(prop.begin_array(), prop.end_array(), field->first) == prop.end_array())
+        fields.insert(field->first);
+    }
+    // erase these fields
+    for (CVariant::iterator_array item = items.begin_array(); item != items.end_array(); ++item)
+    {
+      for (std::set<std::string>::const_iterator i = fields.begin(); i != fields.end(); ++i)
+        item->erase(*i);
+    }
+    if (fields.find("url") == fields.end())
+    {
+      // wrap cached url to something retrieval from Files.GetFiles()
+      for (CVariant::iterator_array item = items.begin_array(); item != items.end_array(); ++item)
+      {
+        CVariant &cachedUrl = (*item)["url"];
+        cachedUrl = CTextureUtils::GetWrappedImageURL(cachedUrl.asString());
+      }
+    }
+  }
+
+  result["textures"] = items;
+  return OK;
+}
+
+JSONRPC_STATUS CTextureOperations::RemoveTexture(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
+{
+  int id = (int)parameterObject["textureid"].asInteger();
+
+  if (!CTextureCache::Get().ClearCachedImage(id))
+    return InvalidParams;
+
+  return ACK;
+}

--- a/xbmc/interfaces/json-rpc/TextureOperations.h
+++ b/xbmc/interfaces/json-rpc/TextureOperations.h
@@ -1,0 +1,33 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "utils/StdString.h"
+#include "JSONRPC.h"
+
+namespace JSONRPC
+{
+  class CTextureOperations
+  {
+  public:
+    static JSONRPC_STATUS GetTextures(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
+    static JSONRPC_STATUS RemoveTexture(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
+  };
+}

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -20,7 +20,7 @@
 
 #include "VideoLibrary.h"
 #include "ApplicationMessenger.h"
-#include "TextureCache.h"
+#include "TextureDatabase.h"
 #include "Util.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -973,7 +973,7 @@ void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTa
     for (CVariant::const_iterator_map artIt = art.begin_map(); artIt != art.end_map(); artIt++)
     {
       if (!artIt->second.asString().empty())
-        artwork[artIt->first] = CTextureCache::UnwrapImageURL(artIt->second.asString());
+        artwork[artIt->first] = CTextureUtils::UnwrapImageURL(artIt->second.asString());
     }
   }
 }

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -1725,6 +1725,34 @@
     "params": [ ],
     "returns":  "string"
   },
+  "Textures.GetTextures": {
+    "type": "method",
+    "description": "Retrieve all textures",
+    "transport": "Response",
+    "permission": "ReadData",
+    "params": [
+      { "name": "properties", "$ref": "Textures.Fields.Texture" },
+      { "name": "filter", "$ref": "List.Filter.Textures" }
+    ],
+    "returns": {
+      "type": "object",
+      "properties": {
+        "textures": { "type": "array", "required": true,
+          "items": { "$ref": "Textures.Details.Texture" }
+        }
+      }
+    }
+  },
+  "Textures.RemoveTexture": {
+    "type": "method",
+    "description": "Remove the specified texture",
+    "transport": "Response",
+    "permission": "RemoveData",
+    "params": [
+      { "name": "textureid", "$ref": "Library.Id", "required": true, "description": "Texture database identifier" }
+    ],
+    "returns": "string"
+  },
   "Profiles.GetProfiles": {
     "type": "method",
     "description": "Retrieve all profiles",

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -814,6 +814,33 @@
       "thumbnail": { "type": "string" }
     }
   },
+  "Textures.Details.Size": {
+    "type": "object",
+    "properties": {
+      "size": { "type": "integer", "description": "Size of the texture (1 == largest)" },
+      "width": { "type": "integer", "description": "Width of texture" },
+      "height": { "type": "integer", "description": "Height of texture" },
+      "usecount": { "type": "integer", "description": "Number of uses" },
+      "lastused": { "type": "string", "description": "Date of last use" }
+    }
+  },
+  "Textures.Fields.Texture": {
+    "extends": "Item.Fields.Base",
+    "items": { "type": "string",
+      "enum": [ "url", "cachedurl", "lasthashcheck", "imagehash", "sizes" ]
+    }
+  },
+  "Textures.Details.Texture": {
+    "type": "object",
+    "properties": {
+      "textureid": { "$ref": "Library.Id", "required": "true" },
+      "url": { "type": "string", "description": "Original source URL" },
+      "cachedurl": { "type": "string", "description": "Cached URL on disk" },
+      "lasthashcheck": { "type": "string", "description": "Last time source was checked for changes" },
+      "imagehash": { "type": "string", "description": "Hash of image" },
+      "sizes": { "type": "array", "items": { "$ref": "Textures.Details.Size" } }
+    }
+  },
   "Profiles.Password": {
     "type": "object",
     "properties": {
@@ -884,6 +911,12 @@
     "extends": "List.Filter.Rule",
     "properties": {
       "field": { "$ref": "List.Filter.Fields.Songs", "required": true }
+    }
+  },
+  "List.Filter.Rule.Textures": {
+    "extends": "List.Filter.Rule",
+    "properties": {
+      "field": { "$ref": "List.Filter.Fields.Textures", "required": true }
     }
   },
   "List.Filter.Movies": {
@@ -1031,6 +1064,27 @@
         }
       },
       { "$ref": "List.Filter.Rule.Songs" }
+    ]
+  },
+  "List.Filter.Textures": {
+    "type": [
+      { "type": "object",
+        "properties": {
+          "and": { "type": "array",
+            "items": { "$ref": "List.Filter.Textures" },
+            "minItems": 1, "required": true
+          }
+        }
+      },
+      { "type": "object",
+        "properties": {
+          "or": { "type": "array",
+            "items": { "$ref": "List.Filter.Textures" },
+            "minItems": 1, "required": true
+          }
+        }
+      },
+      { "$ref": "List.Filter.Rule.Textures" }
     ]
   },
   "List.Item.Base": {

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -20,7 +20,7 @@
 
 #include "MusicThumbLoader.h"
 #include "FileItem.h"
-#include "TextureCache.h"
+#include "TextureDatabase.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "music/infoscanner/MusicInfoScanner.h"
@@ -159,7 +159,7 @@ bool CMusicThumbLoader::LoadItemLookup(CFileItem* pItem)
       if (!FillThumb(*pItem, false)) // Check for user thumbs but ignore folder thumbs
       {
         // No user thumb, use embedded art
-        CStdString thumb = CTextureCache::GetWrappedImageURL(pItem->GetPath(), "music");
+        CStdString thumb = CTextureUtils::GetWrappedImageURL(pItem->GetPath(), "music");
         pItem->SetArt("thumb", thumb);
       }
     }

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -459,7 +459,7 @@ void CGUIDialogMusicInfo::OnGetFanart()
     strItemPath.Format("fanart://Remote%i",i);
     CFileItemPtr item(new CFileItem(strItemPath, false));
     CStdString thumb = m_artist.fanart.GetPreviewURL(i);
-    item->SetArt("thumb", CTextureCache::GetWrappedThumbURL(thumb));
+    item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(thumb));
     item->SetIconImage("DefaultPicture.png");
     item->SetLabel(g_localizeStrings.Get(20441));
 
@@ -518,7 +518,7 @@ void CGUIDialogMusicInfo::OnGetFanart()
     result.clear();
 
   if (flip && !result.empty())
-    result = CTextureCache::GetWrappedImageURL(result, "", "flipped");
+    result = CTextureUtils::GetWrappedImageURL(result, "", "flipped");
 
   // update thumb in the database
   CMusicDatabase db;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -954,7 +954,7 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const CStdString &pa
       if (!art->strThumb.empty())
         albumArt = art->strThumb;
       else
-        albumArt = CTextureCache::GetWrappedImageURL(art->strFileName, "music");
+        albumArt = CTextureUtils::GetWrappedImageURL(art->strFileName, "music");
     }
 
     if (!albumArt.empty())
@@ -970,7 +970,7 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const CStdString &pa
       for (VECSONGS::iterator k = album.songs.begin(); k != album.songs.end(); ++k)
       {
         if (k->strThumb.empty() && !k->embeddedArt.empty())
-          k->strThumb = CTextureCache::GetWrappedImageURL(k->strFileName, "music");
+          k->strThumb = CTextureUtils::GetWrappedImageURL(k->strFileName, "music");
       }
     }
   }

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -36,7 +36,7 @@
 #include "video/VideoInfoTag.h"
 #include "music/MusicDatabase.h"
 #include "music/tags/MusicInfoTag.h"
-#include "TextureCache.h"
+#include "TextureDatabase.h"
 #include "ThumbLoader.h"
 #include "utils/URIUtils.h"
 
@@ -559,7 +559,7 @@ BuildObject(CFileItem&                    item,
         art.uri = upnp_server->BuildSafeResourceUri(
             rooturi,
             (*ips.GetFirstItem()).ToString(),
-            CTextureCache::GetWrappedImageURL(thumb).c_str());
+            CTextureUtils::GetWrappedImageURL(thumb).c_str());
 
         // Set DLNA profileID by extension, defaulting to JPEG.
         if (URIUtils::HasExtension(thumb, ".png")) {
@@ -572,7 +572,7 @@ BuildObject(CFileItem&                    item,
 
     fanart = item.GetArt("fanart");
     if (upnp_server && !fanart.empty())
-        upnp_server->AddSafeResourceUri(object, rooturi, ips, CTextureCache::GetWrappedImageURL(fanart), "xbmc.org:*:fanart:*");
+        upnp_server->AddSafeResourceUri(object, rooturi, ips, CTextureUtils::GetWrappedImageURL(fanart), "xbmc.org:*:fanart:*");
 
     return object;
 

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -33,7 +33,7 @@
 #include "pictures/PictureInfoTag.h"
 #include "interfaces/AnnouncementManager.h"
 #include "settings/Settings.h"
-#include "TextureCache.h"
+#include "TextureDatabase.h"
 #include "ThumbLoader.h"
 #include "URL.h"
 #include "utils/URIUtils.h"
@@ -395,7 +395,7 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
         else
             thumb = g_infoManager.GetImage(VIDEOPLAYER_COVER, -1);
 
-        thumb = CTextureCache::GetWrappedImageURL(thumb);
+        thumb = CTextureUtils::GetWrappedImageURL(thumb);
 
         NPT_String ip;
         if (g_application.getNetwork().GetFirstConnectedInterface()) {

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -79,7 +79,7 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
   CStdString thumb;
   if (pItem->IsPicture() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
   { // load the thumb from the image file
-    thumb = pItem->HasArt("thumb") ? pItem->GetArt("thumb") : CTextureCache::GetWrappedThumbURL(pItem->GetPath());
+    thumb = pItem->HasArt("thumb") ? pItem->GetArt("thumb") : CTextureUtils::GetWrappedThumbURL(pItem->GetPath());
   }
   else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
   { // video
@@ -223,7 +223,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       if (items.Size() < 4 || pItem->IsCBR() || pItem->IsCBZ())
       { // less than 4 items, so just grab the first thumb
         items.Sort(SortByLabel, SortOrderAscending);
-        CStdString thumb = CTextureCache::GetWrappedThumbURL(items[0]->GetPath());
+        CStdString thumb = CTextureUtils::GetWrappedThumbURL(items[0]->GetPath());
         db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
         CTextureCache::Get().BackgroundCacheImage(thumb);
         pItem->SetArt("thumb", thumb);
@@ -235,7 +235,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         vector<string> files;
         for (int thumb = 0; thumb < 4; thumb++)
           files.push_back(items[thumb]->GetPath());
-        CStdString thumb = CTextureCache::GetWrappedImageURL(pItem->GetPath(), "picturefolder");
+        CStdString thumb = CTextureUtils::GetWrappedImageURL(pItem->GetPath(), "picturefolder");
         CStdString relativeCacheFile = CTextureCache::GetCacheFile(thumb) + ".png";
         if (CPicture::CreateTiledThumb(files, CTextureCache::GetCachedPath(relativeCacheFile)))
         {

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -578,11 +578,6 @@ std::vector<Field> CSmartPlaylistRule::GetGroups(const CStdString &type)
   return groups;
 }
 
-CStdString CSmartPlaylistRule::GetLocalizedOperator(SEARCH_OPERATOR oper)
-{
-  return CDatabaseQueryRule::GetLocalizedOperator(oper);
-}
-
 CStdString CSmartPlaylistRule::GetLocalizedGroup(Field group)
 {
   for (unsigned int i = 0; i < NUM_GROUPS; i++)
@@ -1340,11 +1335,6 @@ void CSmartPlaylist::GetAvailableFields(const std::string &type, std::vector<std
         fieldList.push_back(fields[i].string);
     }
   }
-}
-
-void CSmartPlaylist::GetAvailableOperators(std::vector<std::string> &operatorList)
-{
-  CDatabaseQueryRule::GetAvailableOperators(operatorList);
 }
 
 bool CSmartPlaylist::IsEmpty(bool ignoreSortAndLimit /* = true */) const

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -174,7 +174,6 @@ CSmartPlaylistRule::CSmartPlaylistRule()
 {
   m_field = FieldNone;
   m_operator = OPERATOR_CONTAINS;
-  m_parameter.clear();
 }
 
 bool CSmartPlaylistRule::Load(const TiXmlNode *node, const std::string &encoding /* = "UTF-8" */)

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -925,13 +925,8 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
 {
   SEARCH_OPERATOR op = GetOperator(strType);
 
-  CStdString operatorString, negate;
-  if (GetFieldType(m_field) == TEXTIN_FIELD)
-  {
-    if (op == OPERATOR_DOES_NOT_EQUAL)
-      negate = " NOT";
-  }
-  else
+  CStdString operatorString;
+  if (GetFieldType(m_field) != TEXTIN_FIELD)
   {
     // the comparison piece
     switch (op)
@@ -939,7 +934,7 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
     case OPERATOR_CONTAINS:
       operatorString = " LIKE '%%%s%%'"; break;
     case OPERATOR_DOES_NOT_CONTAIN:
-      negate = " NOT"; operatorString = " LIKE '%%%s%%'"; break;
+      operatorString = " LIKE '%%%s%%'"; break;
     case OPERATOR_EQUALS:
       if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
         operatorString = " = %s";
@@ -950,10 +945,7 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
       if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
         operatorString = " != %s";
       else
-      {
-        negate = " NOT";
         operatorString = " LIKE '%s'";
-      }
       break;
     case OPERATOR_STARTS_WITH:
       operatorString = " LIKE '%s%%'"; break;
@@ -980,11 +972,16 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
     case OPERATOR_TRUE:
       operatorString = " = 1"; break;
     case OPERATOR_FALSE:
-      negate = " NOT "; operatorString = " = 0"; break;
+      operatorString = " = 0"; break;
     default:
       break;
     }
   }
+
+  CStdString negate;
+  if (op == OPERATOR_DOES_NOT_CONTAIN || op == OPERATOR_FALSE ||
+     (op == OPERATOR_DOES_NOT_EQUAL && GetFieldType(m_field) != NUMERIC_FIELD && GetFieldType(m_field) != SECONDS_FIELD))
+    negate = " NOT";
 
   // boolean operators don't have any values in m_parameter, they work on the operator
   if (m_operator == OPERATOR_FALSE || m_operator == OPERATOR_TRUE)

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1009,7 +1009,7 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
 
   // now the query parameter
   CStdString wholeQuery;
-  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); /* it++ is done further down */)
+  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); ++it)
   {
     CStdString parameter = FormatParameter(operatorString, *it, db, strType);
 
@@ -1161,12 +1161,11 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
       query += negate + parameter;
     }
     
-    it++;
     if (query.Equals(negate + parameter))
       query = "1";
 
     query = "(" + query + ")";
-    if (it != m_parameter.end())
+    if (it+1 != m_parameter.end())
       query += " OR ";
 
     wholeQuery += query;

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1217,6 +1217,35 @@ void CDatabaseQueryRuleCombination::clear()
   m_type = CombinationAnd;
 }
 
+CStdString CDatabaseQueryRuleCombination::GetWhereClause(const CDatabase &db, const CStdString& strType) const
+{
+  CStdString rule, currentRule;
+
+  // translate the combinations into SQL
+  for (CDatabaseQueryRuleCombinations::const_iterator it = m_combinations.begin(); it != m_combinations.end(); ++it)
+  {
+    if (it != m_combinations.begin())
+      rule += m_type == CombinationAnd ? " AND " : " OR ";
+    rule += "(" + (*it)->GetWhereClause(db, strType) + ")";
+  }
+
+  // translate the rules into SQL
+  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+  {
+    if (!rule.empty())
+      rule += m_type == CombinationAnd ? " AND " : " OR ";
+    rule += "(";
+    CStdString currentRule = (*it)->GetWhereClause(db, strType);
+    // if we don't get a rule, we add '1' or '0' so the query is still valid and doesn't fail
+    if (currentRule.IsEmpty())
+      currentRule = m_type == CombinationAnd ? "'1'" : "'0'";
+    rule += currentRule;
+    rule += ")";
+  }
+
+  return rule;
+}
+
 CStdString CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, const CStdString& strType, std::set<CStdString> &referencedPlaylists) const
 {
   CStdString rule, currentRule;

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -312,14 +312,14 @@ bool CSmartPlaylistRule::Save(CVariant &obj) const
   return true;
 }
 
-Field CSmartPlaylistRule::TranslateField(const char *field)
+int CSmartPlaylistRule::TranslateField(const char *field) const
 {
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (StringUtils::EqualsNoCase(field, fields[i].string)) return fields[i].field;
   return FieldNone;
 }
 
-CStdString CSmartPlaylistRule::TranslateField(Field field)
+CStdString CSmartPlaylistRule::TranslateField(int field) const
 {
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (field == fields[i].field) return fields[i].string;
@@ -376,7 +376,7 @@ CStdString CSmartPlaylistRule::TranslateGroup(Field group)
   return "";
 }
 
-CStdString CSmartPlaylistRule::GetLocalizedField(Field field)
+CStdString CSmartPlaylistRule::GetLocalizedField(int field)
 {
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (field == fields[i].field) return g_localizeStrings.Get(fields[i].localizedString);
@@ -390,7 +390,7 @@ CSmartPlaylistRule::FIELD_TYPE CSmartPlaylistRule::GetFieldType(int field) const
   return TEXT_FIELD;
 }
 
-bool CSmartPlaylistRule::IsFieldBrowseable(Field field)
+bool CSmartPlaylistRule::IsFieldBrowseable(int field)
 {
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (field == fields[i].field) return fields[i].browseable;
@@ -1156,9 +1156,11 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
   return wholeQuery;
 }
 
-CStdString CSmartPlaylistRule::GetField(Field field, const CStdString& type)
+CStdString CSmartPlaylistRule::GetField(int field, const CStdString &type) const
 {
-  return DatabaseUtils::GetField(field, DatabaseUtils::MediaTypeFromString(type), DatabaseQueryPartWhere);
+  if (field >= FieldUnknown && field < FieldMax)
+    return DatabaseUtils::GetField((Field)field, DatabaseUtils::MediaTypeFromString(type), DatabaseQueryPartWhere);
+  return "";
 }
 
 CSmartPlaylistRuleCombination::CSmartPlaylistRuleCombination()

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -118,33 +118,6 @@ static const size_t NUM_FIELDS = sizeof(fields) / sizeof(translateField);
 
 typedef struct
 {
-  char string[15];
-  CDatabaseQueryRule::SEARCH_OPERATOR op;
-  int localizedString;
-} operatorField;
-
-static const operatorField operators[] = {
-  { "contains",        CDatabaseQueryRule::OPERATOR_CONTAINS,          21400 },
-  { "doesnotcontain",  CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN,  21401 },
-  { "is",              CDatabaseQueryRule::OPERATOR_EQUALS,            21402 },
-  { "isnot",           CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL,    21403 },
-  { "startswith",      CDatabaseQueryRule::OPERATOR_STARTS_WITH,       21404 },
-  { "endswith",        CDatabaseQueryRule::OPERATOR_ENDS_WITH,         21405 },
-  { "greaterthan",     CDatabaseQueryRule::OPERATOR_GREATER_THAN,      21406 },
-  { "lessthan",        CDatabaseQueryRule::OPERATOR_LESS_THAN,         21407 },
-  { "after",           CDatabaseQueryRule::OPERATOR_AFTER,             21408 },
-  { "before",          CDatabaseQueryRule::OPERATOR_BEFORE,            21409 },
-  { "inthelast",       CDatabaseQueryRule::OPERATOR_IN_THE_LAST,       21410 },
-  { "notinthelast",    CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST,   21411 },
-  { "true",            CDatabaseQueryRule::OPERATOR_TRUE,              20122 },
-  { "false",           CDatabaseQueryRule::OPERATOR_FALSE,             20424 },
-  { "between",         CDatabaseQueryRule::OPERATOR_BETWEEN,           21456 }
-};
-
-static const size_t NUM_OPERATORS = sizeof(operators) / sizeof(operatorField);
-
-typedef struct
-{
   std::string name;
   Field field;
   bool canMix;
@@ -169,148 +142,6 @@ static const group groups[] = { { "",           FieldUnknown,   false,    571 },
 static const size_t NUM_GROUPS = sizeof(groups) / sizeof(group);
 
 #define RULE_VALUE_SEPARATOR  " / "
-
-CDatabaseQueryRule::CDatabaseQueryRule()
-{
-  m_field = FieldNone;
-  m_operator = OPERATOR_CONTAINS;
-}
-
-bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding /* = "UTF-8" */)
-{
-  if (node == NULL)
-    return false;
-
-  const TiXmlElement *element = node->ToElement();
-  if (element == NULL)
-    return false;
-
-  // format is:
-  // <rule field="Genre" operator="contains">parameter</rule>
-  // where parameter can either be a string or a list of
-  // <value> tags containing a string
-  const char *field = element->Attribute("field");
-  const char *oper = element->Attribute("operator");
-  if (field == NULL || oper == NULL)
-    return false;
-
-  m_field = TranslateField(field);
-  m_operator = TranslateOperator(oper);
-
-  if (m_operator == OPERATOR_TRUE || m_operator == OPERATOR_FALSE)
-    return true;
-
-  const TiXmlNode *parameter = element->FirstChild();
-  if (parameter == NULL)
-    return false;
-
-  if (parameter->Type() == TiXmlNode::TINYXML_TEXT)
-  {
-    CStdString utf8Parameter;
-    if (encoding.empty()) // utf8
-      utf8Parameter = parameter->ValueStr();
-    else
-      g_charsetConverter.ToUtf8(encoding, parameter->ValueStr(), utf8Parameter);
-
-    if (!utf8Parameter.empty())
-      m_parameter.push_back(utf8Parameter);
-  }
-  else if (parameter->Type() == TiXmlNode::TINYXML_ELEMENT)
-  {
-    const TiXmlNode *valueNode = element->FirstChild("value");
-    while (valueNode != NULL)
-    {
-      const TiXmlNode *value = valueNode->FirstChild();
-      if (value != NULL && value->Type() == TiXmlNode::TINYXML_TEXT)
-      {
-        CStdString utf8Parameter;
-        if (encoding.empty()) // utf8
-          utf8Parameter = value->ValueStr();
-        else
-          g_charsetConverter.ToUtf8(encoding, value->ValueStr(), utf8Parameter);
-
-        if (!utf8Parameter.empty())
-          m_parameter.push_back(utf8Parameter);
-      }
-
-      valueNode = valueNode->NextSibling("value");
-    }
-  }
-  else
-    return false;
-
-  return true;
-}
-
-bool CDatabaseQueryRule::Load(const CVariant &obj)
-{
-  if (!obj.isObject() ||
-      !obj.isMember("field") || !obj["field"].isString() ||
-      !obj.isMember("operator") || !obj["operator"].isString())
-    return false;
-
-  m_field = TranslateField(obj["field"].asString().c_str());
-  m_operator = TranslateOperator(obj["operator"].asString().c_str());
-
-  if (m_operator == OPERATOR_TRUE || m_operator == OPERATOR_FALSE)
-    return true;
-
-  if (!obj.isMember("value") || (!obj["value"].isString() && !obj["value"].isArray()))
-    return false;
-
-  const CVariant &value = obj["value"];
-  if (value.isString() && !value.asString().empty())
-    m_parameter.push_back(value.asString());
-  else if (value.isArray())
-  {
-    for (CVariant::const_iterator_array val = value.begin_array(); val != value.end_array(); val++)
-    {
-      if (val->isString() && !val->asString().empty())
-        m_parameter.push_back(val->asString());
-    }
-  }
-  else
-    return false;
-
-  return true;
-}
-
-bool CDatabaseQueryRule::Save(TiXmlNode *parent) const
-{
-  if (parent == NULL || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
-    return false;
-
-  TiXmlElement rule("rule");
-  rule.SetAttribute("field", TranslateField(m_field).c_str());
-  rule.SetAttribute("operator", TranslateOperator(m_operator).c_str());
-
-  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); it++)
-  {
-    TiXmlElement value("value");
-    TiXmlText text(it->c_str());
-    value.InsertEndChild(text);
-    rule.InsertEndChild(value);
-  }
-
-  parent->InsertEndChild(rule);
-
-  return true;
-}
-
-bool CDatabaseQueryRule::Save(CVariant &obj) const
-{
-  if (obj.isNull() || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
-    return false;
-
-  obj["field"] = TranslateField(m_field);
-  obj["operator"] = TranslateOperator(m_operator);
-
-  obj["value"] = CVariant(CVariant::VariantTypeArray);
-  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); it++)
-    obj["value"].push_back(*it);
-
-  return true;
-}
 
 CSmartPlaylistRule::CSmartPlaylistRule()
 {
@@ -342,20 +173,6 @@ CStdString CSmartPlaylistRule::TranslateOrder(SortBy order)
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (order == fields[i].sort) return fields[i].string;
   return "none";
-}
-
-CDatabaseQueryRule::SEARCH_OPERATOR CDatabaseQueryRule::TranslateOperator(const char *oper)
-{
-  for (unsigned int i = 0; i < NUM_OPERATORS; i++)
-    if (StringUtils::EqualsNoCase(oper, operators[i].string)) return operators[i].op;
-  return OPERATOR_CONTAINS;
-}
-
-CStdString CDatabaseQueryRule::TranslateOperator(SEARCH_OPERATOR oper)
-{
-  for (unsigned int i = 0; i < NUM_OPERATORS; i++)
-    if (oper == operators[i].op) return operators[i].string;
-  return "contains";
 }
 
 Field CSmartPlaylistRule::TranslateGroup(const char *group)
@@ -763,9 +580,7 @@ std::vector<Field> CSmartPlaylistRule::GetGroups(const CStdString &type)
 
 CStdString CSmartPlaylistRule::GetLocalizedOperator(SEARCH_OPERATOR oper)
 {
-  for (unsigned int i = 0; i < NUM_OPERATORS; i++)
-    if (oper == operators[i].op) return g_localizeStrings.Get(operators[i].localizedString);
-  return g_localizeStrings.Get(16018);
+  return CDatabaseQueryRule::GetLocalizedOperator(oper);
 }
 
 CStdString CSmartPlaylistRule::GetLocalizedGroup(Field group)
@@ -795,22 +610,6 @@ CStdString CSmartPlaylistRule::GetLocalizedRule() const
   CStdString rule;
   rule.Format("%s %s %s", GetLocalizedField(m_field).c_str(), GetLocalizedOperator(m_operator).c_str(), GetParameter().c_str());
   return rule;
-}
-
-CStdString CDatabaseQueryRule::GetParameter() const
-{
-  return StringUtils::JoinString(m_parameter, RULE_VALUE_SEPARATOR);
-}
-
-void CDatabaseQueryRule::SetParameter(const CStdString &value)
-{
-  m_parameter.clear();
-  StringUtils::SplitString(value, RULE_VALUE_SEPARATOR, m_parameter);
-}
-
-void CDatabaseQueryRule::SetParameter(const std::vector<CStdString> &values)
-{
-  m_parameter.assign(values.begin(), values.end());
 }
 
 CStdString CSmartPlaylistRule::GetVideoResolutionQuery(const CStdString &parameter) const
@@ -887,38 +686,6 @@ CDatabaseQueryRule::SEARCH_OPERATOR CSmartPlaylistRule::GetOperator(const CStdSt
   return op;
 }
 
-CStdString CDatabaseQueryRule::FormatParameter(const CStdString &operatorString, const CStdString &param, const CDatabase &db, const CStdString &strType) const
-{
-  CStdString parameter;
-  if (GetFieldType(m_field) == TEXTIN_FIELD)
-  {
-    CStdStringArray split;
-    StringUtils::SplitString(param, ",", split);
-    for (CStdStringArray::iterator itIn = split.begin(); itIn != split.end(); ++itIn)
-    {
-      if (!parameter.IsEmpty())
-        parameter += ",";
-      parameter += db.PrepareSQL("'%s'", (*itIn).Trim().c_str());
-    }
-    parameter = " IN (" + parameter + ")";
-  }
-  else
-    parameter = db.PrepareSQL(operatorString.c_str(), param.c_str());
-
-  if (GetFieldType(m_field) == DATE_FIELD)
-  {
-    if (m_operator == OPERATOR_IN_THE_LAST || m_operator == OPERATOR_NOT_IN_THE_LAST)
-    { // translate time period
-      CDateTime date=CDateTime::GetCurrentDateTime();
-      CDateTimeSpan span;
-      span.SetFromPeriod(param);
-      date-=span;
-      parameter = db.PrepareSQL(operatorString.c_str(), date.GetAsDBDate().c_str());
-    }
-  }
-  return parameter;
-}
-
 CStdString CSmartPlaylistRule::FormatParameter(const CStdString &operatorString, const CStdString &param, const CDatabase &db, const CStdString &strType) const
 {
   // special-casing
@@ -928,107 +695,6 @@ CStdString CSmartPlaylistRule::FormatParameter(const CStdString &operatorString,
     return db.PrepareSQL(operatorString.c_str(), seconds.c_str());
   }
   return CDatabaseQueryRule::FormatParameter(operatorString, param, db, strType);
-}
-
-CStdString CDatabaseQueryRule::GetOperatorString(SEARCH_OPERATOR op) const
-{
-  CStdString operatorString;
-  if (GetFieldType(m_field) != TEXTIN_FIELD)
-  {
-    // the comparison piece
-    switch (op)
-    {
-    case OPERATOR_CONTAINS:
-      operatorString = " LIKE '%%%s%%'"; break;
-    case OPERATOR_DOES_NOT_CONTAIN:
-      operatorString = " LIKE '%%%s%%'"; break;
-    case OPERATOR_EQUALS:
-      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString = " = %s";
-      else
-        operatorString = " LIKE '%s'";
-      break;
-    case OPERATOR_DOES_NOT_EQUAL:
-      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString = " != %s";
-      else
-        operatorString = " LIKE '%s'";
-      break;
-    case OPERATOR_STARTS_WITH:
-      operatorString = " LIKE '%s%%'"; break;
-    case OPERATOR_ENDS_WITH:
-      operatorString = " LIKE '%%%s'"; break;
-    case OPERATOR_AFTER:
-    case OPERATOR_GREATER_THAN:
-    case OPERATOR_IN_THE_LAST:
-      operatorString = " > ";
-      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString += "%s";
-      else
-        operatorString += "'%s'";
-      break;
-    case OPERATOR_BEFORE:
-    case OPERATOR_LESS_THAN:
-    case OPERATOR_NOT_IN_THE_LAST:
-      operatorString = " < ";
-      if (GetFieldType(m_field) == NUMERIC_FIELD || GetFieldType(m_field) == SECONDS_FIELD)
-        operatorString += "%s";
-      else
-        operatorString += "'%s'";
-      break;
-    case OPERATOR_TRUE:
-      operatorString = " = 1"; break;
-    case OPERATOR_FALSE:
-      operatorString = " = 0"; break;
-    default:
-      break;
-    }
-  }
-  return operatorString;
-}
-
-CStdString CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const CStdString& strType) const
-{
-  SEARCH_OPERATOR op = GetOperator(strType);
-
-  CStdString operatorString = GetOperatorString(op);
-  CStdString negate;
-  if (op == OPERATOR_DOES_NOT_CONTAIN || op == OPERATOR_FALSE ||
-     (op == OPERATOR_DOES_NOT_EQUAL && GetFieldType(m_field) != NUMERIC_FIELD && GetFieldType(m_field) != SECONDS_FIELD))
-    negate = " NOT";
-
-  // boolean operators don't have any values in m_parameter, they work on the operator
-  if (m_operator == OPERATOR_FALSE || m_operator == OPERATOR_TRUE)
-    return GetBooleanQuery(negate, strType);
-
-  // The BETWEEN operator is handled special
-  if (op == OPERATOR_BETWEEN)
-  {
-    if (m_parameter.size() != 2)
-      return "";
-
-    FIELD_TYPE fieldType = GetFieldType(m_field);
-    if (fieldType == NUMERIC_FIELD)
-      return db.PrepareSQL("CAST(%s as DECIMAL(5,1)) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
-    else if (fieldType == SECONDS_FIELD)
-      return db.PrepareSQL("CAST(%s as INTEGER) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
-    else
-      return db.PrepareSQL("%s BETWEEN '%s' AND '%s'", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
-  }
-
-  // now the query parameter
-  CStdString wholeQuery;
-  for (vector<CStdString>::const_iterator it = m_parameter.begin(); it != m_parameter.end(); ++it)
-  {
-    CStdString query = "(" + FormatWhereClause(negate, operatorString, *it, db, strType) + ")";
-
-    if (it+1 != m_parameter.end())
-      query += " OR ";
-
-    wholeQuery += query;
-  }
-
-  return wholeQuery;
 }
 
 CStdString CSmartPlaylistRule::FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
@@ -1176,74 +842,11 @@ CStdString CSmartPlaylistRule::FormatWhereClause(const CStdString &negate, const
   return query;
 }
 
-CStdString CDatabaseQueryRule::FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
-                                                 const CDatabase &db, const CStdString &strType) const
-{
-  CStdString parameter = FormatParameter(oper, param, db, strType);
-
-  CStdString query;
-  if (m_field != FieldNone)
-  {
-    string fmt = "%s";
-    if (GetFieldType(m_field) == NUMERIC_FIELD)
-      fmt = "CAST(%s as DECIMAL(5,1))";
-    else if (GetFieldType(m_field) == SECONDS_FIELD)
-      fmt = "CAST(%s as INTEGER)";
-
-    query.Format(fmt.c_str(), GetField(m_field,strType).c_str());
-    query += negate + parameter;
-  }
-
-  if (query.Equals(negate + parameter))
-    query = "1";
-  return query;
-}
-
 CStdString CSmartPlaylistRule::GetField(int field, const CStdString &type) const
 {
   if (field >= FieldUnknown && field < FieldMax)
     return DatabaseUtils::GetField((Field)field, DatabaseUtils::MediaTypeFromString(type), DatabaseQueryPartWhere);
   return "";
-}
-
-CDatabaseQueryRuleCombination::CDatabaseQueryRuleCombination()
-  : m_type(CombinationAnd)
-{ }
-
-void CDatabaseQueryRuleCombination::clear()
-{
-  m_combinations.clear();
-  m_rules.clear();
-  m_type = CombinationAnd;
-}
-
-CStdString CDatabaseQueryRuleCombination::GetWhereClause(const CDatabase &db, const CStdString& strType) const
-{
-  CStdString rule, currentRule;
-
-  // translate the combinations into SQL
-  for (CDatabaseQueryRuleCombinations::const_iterator it = m_combinations.begin(); it != m_combinations.end(); ++it)
-  {
-    if (it != m_combinations.begin())
-      rule += m_type == CombinationAnd ? " AND " : " OR ";
-    rule += "(" + (*it)->GetWhereClause(db, strType) + ")";
-  }
-
-  // translate the rules into SQL
-  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
-  {
-    if (!rule.empty())
-      rule += m_type == CombinationAnd ? " AND " : " OR ";
-    rule += "(";
-    CStdString currentRule = (*it)->GetWhereClause(db, strType);
-    // if we don't get a rule, we add '1' or '0' so the query is still valid and doesn't fail
-    if (currentRule.IsEmpty())
-      currentRule = m_type == CombinationAnd ? "'1'" : "'0'";
-    rule += currentRule;
-    rule += ")";
-  }
-
-  return rule;
 }
 
 CStdString CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, const CStdString& strType, std::set<CStdString> &referencedPlaylists) const
@@ -1341,95 +944,6 @@ void CSmartPlaylistRuleCombination::GetVirtualFolders(const CStdString& strType,
         playlist.GetVirtualFolders(virtualFolders);
     }
   }
-}
-
-bool CDatabaseQueryRuleCombination::Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory)
-{
-  if (!obj.isObject() && !obj.isArray())
-    return false;
-  
-  CVariant child;
-  if (obj.isObject())
-  {
-    if (obj.isMember("and") && obj["and"].isArray())
-    {
-      m_type = CombinationAnd;
-      child = obj["and"];
-    }
-    else if (obj.isMember("or") && obj["or"].isArray())
-    {
-      m_type = CombinationOr;
-      child = obj["or"];
-    }
-    else
-      return false;
-  }
-  else
-    child = obj;
-
-  for (CVariant::const_iterator_array it = child.begin_array(); it != child.end_array(); it++)
-  {
-    if (!it->isObject())
-      continue;
-
-    if (it->isMember("and") || it->isMember("or"))
-    {
-      boost::shared_ptr<CDatabaseQueryRuleCombination> combo(factory->CreateCombination());
-      if (combo && combo->Load(*it, factory))
-        m_combinations.push_back(combo);
-    }
-    else
-    {
-      boost::shared_ptr<CDatabaseQueryRule> rule(factory->CreateRule());
-      if (rule && rule->Load(*it))
-        m_rules.push_back(rule);
-    }
-  }
-
-  return true;
-}
-
-bool CDatabaseQueryRuleCombination::Save(TiXmlNode *parent) const
-{
-  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
-    (*it)->Save(parent);
-  return true;
-}
-
-bool CDatabaseQueryRuleCombination::Save(CVariant &obj) const
-{
-  if (!obj.isObject() || (m_combinations.empty() && m_rules.empty()))
-    return false;
-
-  CVariant comboArray(CVariant::VariantTypeArray);
-  if (!m_combinations.empty())
-  {
-    for (CDatabaseQueryRuleCombinations::const_iterator combo = m_combinations.begin(); combo != m_combinations.end(); combo++)
-    {
-      CVariant comboObj(CVariant::VariantTypeObject);
-      if ((*combo)->Save(comboObj))
-        comboArray.push_back(comboObj);
-    }
-
-  }
-  if (!m_rules.empty())
-  {
-    for (CDatabaseQueryRules::const_iterator rule = m_rules.begin(); rule != m_rules.end(); rule++)
-    {
-      CVariant ruleObj(CVariant::VariantTypeObject);
-      if ((*rule)->Save(ruleObj))
-        comboArray.push_back(ruleObj);
-    }
-  }
-
-  obj[TranslateCombinationType()] = comboArray;
-
-  return true;
-}
-
-std::string CDatabaseQueryRuleCombination::TranslateCombinationType() const
-{
-  return m_type == CombinationAnd ? "and" : "or";
 }
 
 void CSmartPlaylistRuleCombination::AddRule(const CSmartPlaylistRule &rule)
@@ -1830,8 +1344,7 @@ void CSmartPlaylist::GetAvailableFields(const std::string &type, std::vector<std
 
 void CSmartPlaylist::GetAvailableOperators(std::vector<std::string> &operatorList)
 {
-  for (unsigned int index = 0; index < NUM_OPERATORS; index++)
-    operatorList.push_back(operators[index].string);
+  CDatabaseQueryRule::GetAvailableOperators(operatorList);
 }
 
 bool CSmartPlaylist::IsEmpty(bool ignoreSortAndLimit /* = true */) const

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1230,7 +1230,7 @@ CStdString CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, co
   }
 
   // translate the rules into SQL
-  for (CSmartPlaylistRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
   {
     // don't include playlists that are meant to be displayed
     // as a virtual folders in the SQL WHERE clause
@@ -1284,7 +1284,7 @@ void CSmartPlaylistRuleCombination::GetVirtualFolders(const CStdString& strType,
   for (CSmartPlaylistRuleCombinations::const_iterator it = m_combinations.begin(); it != m_combinations.end(); ++it)
     (*it)->GetVirtualFolders(strType, virtualFolders);
 
-  for (CSmartPlaylistRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
   {
     if (((*it)->m_field != FieldVirtualFolder && (*it)->m_field != FieldPlaylist) || (*it)->m_operator != CDatabaseQueryRule::OPERATOR_EQUALS)
       continue;
@@ -1345,7 +1345,7 @@ bool CSmartPlaylistRuleCombination::Load(const CVariant &obj)
     }
     else
     {
-      boost::shared_ptr<CSmartPlaylistRule> rule(new CSmartPlaylistRule());
+      boost::shared_ptr<CDatabaseQueryRule> rule(new CSmartPlaylistRule());
       if (rule && rule->Load(*it))
         m_rules.push_back(rule);
     }
@@ -1356,7 +1356,7 @@ bool CSmartPlaylistRuleCombination::Load(const CVariant &obj)
 
 bool CSmartPlaylistRuleCombination::Save(TiXmlNode *parent) const
 {
-  for (CSmartPlaylistRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+  for (CDatabaseQueryRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
     (*it)->Save(parent);
   return true;
 }
@@ -1379,7 +1379,7 @@ bool CSmartPlaylistRuleCombination::Save(CVariant &obj) const
   }
   if (!m_rules.empty())
   {
-    for (CSmartPlaylistRules::const_iterator rule = m_rules.begin(); rule != m_rules.end(); rule++)
+    for (CDatabaseQueryRules::const_iterator rule = m_rules.begin(); rule != m_rules.end(); rule++)
     {
       CVariant ruleObj(CVariant::VariantTypeObject);
       if ((*rule)->Save(ruleObj))

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1388,11 +1388,6 @@ void CSmartPlaylistRuleCombination::AddRule(const CSmartPlaylistRule &rule)
   m_rules.push_back(rule);
 }
 
-void CSmartPlaylistRuleCombination::AddCombination(const CSmartPlaylistRuleCombination &combination)
-{
-  m_combinations.push_back(combination);
-}
-
 CSmartPlaylist::CSmartPlaylist()
 {
   Reset();

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -44,74 +44,74 @@ typedef struct
   char string[17];
   Field field;
   SortBy sort;
-  CSmartPlaylistRule::FIELD_TYPE type;
+  CDatabaseQueryRule::FIELD_TYPE type;
   StringValidation::Validator validator;
   bool browseable;
   int localizedString;
 } translateField;
 
 static const translateField fields[] = {
-  { "none",              FieldNone,                    SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 231 },
-  { "filename",          FieldFilename,                SortByFile,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 561 },
-  { "path",              FieldPath,                    SortByPath,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  573 },
-  { "album",             FieldAlbum,                   SortByAlbum,                    CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  558 },
-  { "albumartist",       FieldAlbumArtist,             SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  566 },
-  { "artist",            FieldArtist,                  SortByArtist,                   CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  557 },
-  { "tracknumber",       FieldTrackNumber,             SortByTrackNumber,              CSmartPlaylistRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 554 },
-  { "comment",           FieldComment,                 SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 569 },
-  { "review",            FieldReview,                  SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 183 },
-  { "themes",            FieldThemes,                  SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21895 },
-  { "moods",             FieldMoods,                   SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 175 },
-  { "styles",            FieldStyles,                  SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 176 },
-  { "type",              FieldAlbumType,               SortByAlbumType,                CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 564 },
-  { "label",             FieldMusicLabel,              SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21899 },
-  { "title",             FieldTitle,                   SortByTitle,                    CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  556 },
-  { "sorttitle",         FieldSortTitle,               SortBySortTitle,                CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 171 },
-  { "year",              FieldYear,                    SortByYear,                     CSmartPlaylistRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  true,  562 },
-  { "time",              FieldTime,                    SortByTime,                     CSmartPlaylistRule::SECONDS_FIELD,  StringValidation::IsTime,             false, 180 },
-  { "playcount",         FieldPlaycount,               SortByPlaycount,                CSmartPlaylistRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 567 },
-  { "lastplayed",        FieldLastPlayed,              SortByLastPlayed,               CSmartPlaylistRule::DATE_FIELD,     NULL,                                 false, 568 },
-  { "inprogress",        FieldInProgress,              SortByNone,                     CSmartPlaylistRule::BOOLEAN_FIELD,  NULL,                                 false, 575 },
-  { "rating",            FieldRating,                  SortByRating,                   CSmartPlaylistRule::NUMERIC_FIELD,  CSmartPlaylistRule::ValidateRating,   false, 563 },
-  { "votes",             FieldVotes,                   SortByVotes,                    CSmartPlaylistRule::TEXT_FIELD,     StringValidation::IsPositiveInteger,  false, 205 },
-  { "top250",            FieldTop250,                  SortByTop250,                   CSmartPlaylistRule::NUMERIC_FIELD,  NULL,                                 false, 13409 },
-  { "mpaarating",        FieldMPAA,                    SortByMPAA,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 20074 },
-  { "dateadded",         FieldDateAdded,               SortByDateAdded,                CSmartPlaylistRule::DATE_FIELD,     NULL,                                 false, 570 },
-  { "genre",             FieldGenre,                   SortByGenre,                    CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  515 },
-  { "plot",              FieldPlot,                    SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 207 },
-  { "plotoutline",       FieldPlotOutline,             SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 203 },
-  { "tagline",           FieldTagline,                 SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 202 },
-  { "set",               FieldSet,                     SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  20457 },
-  { "director",          FieldDirector,                SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  20339 },
-  { "actor",             FieldActor,                   SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  20337 },
-  { "writers",           FieldWriter,                  SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  20417 },
-  { "airdate",           FieldAirDate,                 SortByYear,                     CSmartPlaylistRule::DATE_FIELD,     NULL,                                 false, 20416 },
-  { "hastrailer",        FieldTrailer,                 SortByNone,                     CSmartPlaylistRule::BOOLEAN_FIELD,  NULL,                                 false, 20423 },
-  { "studio",            FieldStudio,                  SortByStudio,                   CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  572 },
-  { "country",           FieldCountry,                 SortByCountry,                  CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  574 },
-  { "tvshow",            FieldTvShowTitle,             SortByTvShowTitle,              CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  20364 },
-  { "status",            FieldTvShowStatus,            SortByTvShowStatus,             CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 126 },
-  { "season",            FieldSeason,                  SortBySeason,                   CSmartPlaylistRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20373 },
-  { "episode",           FieldEpisodeNumber,           SortByEpisodeNumber,            CSmartPlaylistRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20359 },
-  { "numepisodes",       FieldNumberOfEpisodes,        SortByNumberOfEpisodes,         CSmartPlaylistRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20360 },
-  { "numwatched",        FieldNumberOfWatchedEpisodes, SortByNumberOfWatchedEpisodes,  CSmartPlaylistRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 21457 },
-  { "videoresolution",   FieldVideoResolution,         SortByVideoResolution,          CSmartPlaylistRule::NUMERIC_FIELD,  NULL,                                 false, 21443 },
-  { "videocodec",        FieldVideoCodec,              SortByVideoCodec,               CSmartPlaylistRule::TEXTIN_FIELD,   NULL,                                 false, 21445 },
-  { "videoaspect",       FieldVideoAspectRatio,        SortByVideoAspectRatio,         CSmartPlaylistRule::NUMERIC_FIELD,  NULL,                                 false, 21374 },
-  { "audiochannels",     FieldAudioChannels,           SortByAudioChannels,            CSmartPlaylistRule::NUMERIC_FIELD,  NULL,                                 false, 21444 },
-  { "audiocodec",        FieldAudioCodec,              SortByAudioCodec,               CSmartPlaylistRule::TEXTIN_FIELD,   NULL,                                 false, 21446 },
-  { "audiolanguage",     FieldAudioLanguage,           SortByAudioLanguage,            CSmartPlaylistRule::TEXTIN_FIELD,   NULL,                                 false, 21447 },
-  { "subtitlelanguage",  FieldSubtitleLanguage,        SortBySubtitleLanguage,         CSmartPlaylistRule::TEXTIN_FIELD,   NULL,                                 false, 21448 },
-  { "random",            FieldRandom,                  SortByRandom,                   CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 590 },
-  { "playlist",          FieldPlaylist,                SortByPlaylistOrder,            CSmartPlaylistRule::PLAYLIST_FIELD, NULL,                                 true,  559 },
-  { "virtualfolder",     FieldVirtualFolder,           SortByNone,                     CSmartPlaylistRule::PLAYLIST_FIELD, NULL,                                 true,  614 },
-  { "tag",               FieldTag,                     SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 true,  20459 },
-  { "instruments",       FieldInstruments,             SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21892 },
-  { "biography",         FieldBiography,               SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21887 },
-  { "born",              FieldBorn,                    SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21893 },
-  { "bandformed",        FieldBandFormed,              SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21894 },
-  { "disbanded",         FieldDisbanded,               SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21896 },
-  { "died",              FieldDied,                    SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,     NULL,                                 false, 21897 }
+  { "none",              FieldNone,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 231 },
+  { "filename",          FieldFilename,                SortByFile,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 561 },
+  { "path",              FieldPath,                    SortByPath,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  573 },
+  { "album",             FieldAlbum,                   SortByAlbum,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  558 },
+  { "albumartist",       FieldAlbumArtist,             SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  566 },
+  { "artist",            FieldArtist,                  SortByArtist,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  557 },
+  { "tracknumber",       FieldTrackNumber,             SortByTrackNumber,              CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 554 },
+  { "comment",           FieldComment,                 SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 569 },
+  { "review",            FieldReview,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 183 },
+  { "themes",            FieldThemes,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21895 },
+  { "moods",             FieldMoods,                   SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 175 },
+  { "styles",            FieldStyles,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 176 },
+  { "type",              FieldAlbumType,               SortByAlbumType,                CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 564 },
+  { "label",             FieldMusicLabel,              SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21899 },
+  { "title",             FieldTitle,                   SortByTitle,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  556 },
+  { "sorttitle",         FieldSortTitle,               SortBySortTitle,                CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 171 },
+  { "year",              FieldYear,                    SortByYear,                     CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  true,  562 },
+  { "time",              FieldTime,                    SortByTime,                     CDatabaseQueryRule::SECONDS_FIELD,  StringValidation::IsTime,             false, 180 },
+  { "playcount",         FieldPlaycount,               SortByPlaycount,                CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 567 },
+  { "lastplayed",        FieldLastPlayed,              SortByLastPlayed,               CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 568 },
+  { "inprogress",        FieldInProgress,              SortByNone,                     CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 575 },
+  { "rating",            FieldRating,                  SortByRating,                   CDatabaseQueryRule::NUMERIC_FIELD,  CSmartPlaylistRule::ValidateRating,   false, 563 },
+  { "votes",             FieldVotes,                   SortByVotes,                    CDatabaseQueryRule::TEXT_FIELD,     StringValidation::IsPositiveInteger,  false, 205 },
+  { "top250",            FieldTop250,                  SortByTop250,                   CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 13409 },
+  { "mpaarating",        FieldMPAA,                    SortByMPAA,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 20074 },
+  { "dateadded",         FieldDateAdded,               SortByDateAdded,                CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 570 },
+  { "genre",             FieldGenre,                   SortByGenre,                    CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  515 },
+  { "plot",              FieldPlot,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 207 },
+  { "plotoutline",       FieldPlotOutline,             SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 203 },
+  { "tagline",           FieldTagline,                 SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 202 },
+  { "set",               FieldSet,                     SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20457 },
+  { "director",          FieldDirector,                SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20339 },
+  { "actor",             FieldActor,                   SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20337 },
+  { "writers",           FieldWriter,                  SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20417 },
+  { "airdate",           FieldAirDate,                 SortByYear,                     CDatabaseQueryRule::DATE_FIELD,     NULL,                                 false, 20416 },
+  { "hastrailer",        FieldTrailer,                 SortByNone,                     CDatabaseQueryRule::BOOLEAN_FIELD,  NULL,                                 false, 20423 },
+  { "studio",            FieldStudio,                  SortByStudio,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  572 },
+  { "country",           FieldCountry,                 SortByCountry,                  CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  574 },
+  { "tvshow",            FieldTvShowTitle,             SortByTvShowTitle,              CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20364 },
+  { "status",            FieldTvShowStatus,            SortByTvShowStatus,             CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 126 },
+  { "season",            FieldSeason,                  SortBySeason,                   CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20373 },
+  { "episode",           FieldEpisodeNumber,           SortByEpisodeNumber,            CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20359 },
+  { "numepisodes",       FieldNumberOfEpisodes,        SortByNumberOfEpisodes,         CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 20360 },
+  { "numwatched",        FieldNumberOfWatchedEpisodes, SortByNumberOfWatchedEpisodes,  CDatabaseQueryRule::NUMERIC_FIELD,  StringValidation::IsPositiveInteger,  false, 21457 },
+  { "videoresolution",   FieldVideoResolution,         SortByVideoResolution,          CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21443 },
+  { "videocodec",        FieldVideoCodec,              SortByVideoCodec,               CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21445 },
+  { "videoaspect",       FieldVideoAspectRatio,        SortByVideoAspectRatio,         CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21374 },
+  { "audiochannels",     FieldAudioChannels,           SortByAudioChannels,            CDatabaseQueryRule::NUMERIC_FIELD,  NULL,                                 false, 21444 },
+  { "audiocodec",        FieldAudioCodec,              SortByAudioCodec,               CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21446 },
+  { "audiolanguage",     FieldAudioLanguage,           SortByAudioLanguage,            CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21447 },
+  { "subtitlelanguage",  FieldSubtitleLanguage,        SortBySubtitleLanguage,         CDatabaseQueryRule::TEXTIN_FIELD,   NULL,                                 false, 21448 },
+  { "random",            FieldRandom,                  SortByRandom,                   CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 590 },
+  { "playlist",          FieldPlaylist,                SortByPlaylistOrder,            CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  559 },
+  { "virtualfolder",     FieldVirtualFolder,           SortByNone,                     CDatabaseQueryRule::PLAYLIST_FIELD, NULL,                                 true,  614 },
+  { "tag",               FieldTag,                     SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 true,  20459 },
+  { "instruments",       FieldInstruments,             SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21892 },
+  { "biography",         FieldBiography,               SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21887 },
+  { "born",              FieldBorn,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21893 },
+  { "bandformed",        FieldBandFormed,              SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21894 },
+  { "disbanded",         FieldDisbanded,               SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21896 },
+  { "died",              FieldDied,                    SortByNone,                     CDatabaseQueryRule::TEXT_FIELD,     NULL,                                 false, 21897 }
 };
 
 static const size_t NUM_FIELDS = sizeof(fields) / sizeof(translateField);
@@ -119,26 +119,26 @@ static const size_t NUM_FIELDS = sizeof(fields) / sizeof(translateField);
 typedef struct
 {
   char string[15];
-  CSmartPlaylistRule::SEARCH_OPERATOR op;
+  CDatabaseQueryRule::SEARCH_OPERATOR op;
   int localizedString;
 } operatorField;
 
 static const operatorField operators[] = {
-  { "contains",        CSmartPlaylistRule::OPERATOR_CONTAINS,          21400 },
-  { "doesnotcontain",  CSmartPlaylistRule::OPERATOR_DOES_NOT_CONTAIN,  21401 },
-  { "is",              CSmartPlaylistRule::OPERATOR_EQUALS,            21402 },
-  { "isnot",           CSmartPlaylistRule::OPERATOR_DOES_NOT_EQUAL,    21403 },
-  { "startswith",      CSmartPlaylistRule::OPERATOR_STARTS_WITH,       21404 },
-  { "endswith",        CSmartPlaylistRule::OPERATOR_ENDS_WITH,         21405 },
-  { "greaterthan",     CSmartPlaylistRule::OPERATOR_GREATER_THAN,      21406 },
-  { "lessthan",        CSmartPlaylistRule::OPERATOR_LESS_THAN,         21407 },
-  { "after",           CSmartPlaylistRule::OPERATOR_AFTER,             21408 },
-  { "before",          CSmartPlaylistRule::OPERATOR_BEFORE,            21409 },
-  { "inthelast",       CSmartPlaylistRule::OPERATOR_IN_THE_LAST,       21410 },
-  { "notinthelast",    CSmartPlaylistRule::OPERATOR_NOT_IN_THE_LAST,   21411 },
-  { "true",            CSmartPlaylistRule::OPERATOR_TRUE,              20122 },
-  { "false",           CSmartPlaylistRule::OPERATOR_FALSE,             20424 },
-  { "between",         CSmartPlaylistRule::OPERATOR_BETWEEN,           21456 }
+  { "contains",        CDatabaseQueryRule::OPERATOR_CONTAINS,          21400 },
+  { "doesnotcontain",  CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN,  21401 },
+  { "is",              CDatabaseQueryRule::OPERATOR_EQUALS,            21402 },
+  { "isnot",           CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL,    21403 },
+  { "startswith",      CDatabaseQueryRule::OPERATOR_STARTS_WITH,       21404 },
+  { "endswith",        CDatabaseQueryRule::OPERATOR_ENDS_WITH,         21405 },
+  { "greaterthan",     CDatabaseQueryRule::OPERATOR_GREATER_THAN,      21406 },
+  { "lessthan",        CDatabaseQueryRule::OPERATOR_LESS_THAN,         21407 },
+  { "after",           CDatabaseQueryRule::OPERATOR_AFTER,             21408 },
+  { "before",          CDatabaseQueryRule::OPERATOR_BEFORE,            21409 },
+  { "inthelast",       CDatabaseQueryRule::OPERATOR_IN_THE_LAST,       21410 },
+  { "notinthelast",    CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST,   21411 },
+  { "true",            CDatabaseQueryRule::OPERATOR_TRUE,              20122 },
+  { "false",           CDatabaseQueryRule::OPERATOR_FALSE,             20424 },
+  { "between",         CDatabaseQueryRule::OPERATOR_BETWEEN,           21456 }
 };
 
 static const size_t NUM_OPERATORS = sizeof(operators) / sizeof(operatorField);
@@ -170,13 +170,13 @@ static const size_t NUM_GROUPS = sizeof(groups) / sizeof(group);
 
 #define RULE_VALUE_SEPARATOR  " / "
 
-CSmartPlaylistRule::CSmartPlaylistRule()
+CDatabaseQueryRule::CDatabaseQueryRule()
 {
   m_field = FieldNone;
   m_operator = OPERATOR_CONTAINS;
 }
 
-bool CSmartPlaylistRule::Load(const TiXmlNode *node, const std::string &encoding /* = "UTF-8" */)
+bool CDatabaseQueryRule::Load(const TiXmlNode *node, const std::string &encoding /* = "UTF-8" */)
 {
   if (node == NULL)
     return false;
@@ -242,7 +242,7 @@ bool CSmartPlaylistRule::Load(const TiXmlNode *node, const std::string &encoding
   return true;
 }
 
-bool CSmartPlaylistRule::Load(const CVariant &obj)
+bool CDatabaseQueryRule::Load(const CVariant &obj)
 {
   if (!obj.isObject() ||
       !obj.isMember("field") || !obj["field"].isString() ||
@@ -275,7 +275,7 @@ bool CSmartPlaylistRule::Load(const CVariant &obj)
   return true;
 }
 
-bool CSmartPlaylistRule::Save(TiXmlNode *parent) const
+bool CDatabaseQueryRule::Save(TiXmlNode *parent) const
 {
   if (parent == NULL || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
     return false;
@@ -297,7 +297,7 @@ bool CSmartPlaylistRule::Save(TiXmlNode *parent) const
   return true;
 }
 
-bool CSmartPlaylistRule::Save(CVariant &obj) const
+bool CDatabaseQueryRule::Save(CVariant &obj) const
 {
   if (obj.isNull() || (m_parameter.empty() && m_operator != OPERATOR_TRUE && m_operator != OPERATOR_FALSE))
     return false;
@@ -310,6 +310,10 @@ bool CSmartPlaylistRule::Save(CVariant &obj) const
     obj["value"].push_back(*it);
 
   return true;
+}
+
+CSmartPlaylistRule::CSmartPlaylistRule()
+{
 }
 
 int CSmartPlaylistRule::TranslateField(const char *field) const
@@ -340,14 +344,14 @@ CStdString CSmartPlaylistRule::TranslateOrder(SortBy order)
   return "none";
 }
 
-CSmartPlaylistRule::SEARCH_OPERATOR CSmartPlaylistRule::TranslateOperator(const char *oper)
+CDatabaseQueryRule::SEARCH_OPERATOR CDatabaseQueryRule::TranslateOperator(const char *oper)
 {
   for (unsigned int i = 0; i < NUM_OPERATORS; i++)
     if (StringUtils::EqualsNoCase(oper, operators[i].string)) return operators[i].op;
   return OPERATOR_CONTAINS;
 }
 
-CStdString CSmartPlaylistRule::TranslateOperator(SEARCH_OPERATOR oper)
+CStdString CDatabaseQueryRule::TranslateOperator(SEARCH_OPERATOR oper)
 {
   for (unsigned int i = 0; i < NUM_OPERATORS; i++)
     if (oper == operators[i].op) return operators[i].string;
@@ -383,7 +387,7 @@ CStdString CSmartPlaylistRule::GetLocalizedField(int field)
   return g_localizeStrings.Get(16018);
 }
 
-CSmartPlaylistRule::FIELD_TYPE CSmartPlaylistRule::GetFieldType(int field) const
+CDatabaseQueryRule::FIELD_TYPE CSmartPlaylistRule::GetFieldType(int field) const
 {
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (field == fields[i].field) return fields[i].type;
@@ -793,18 +797,18 @@ CStdString CSmartPlaylistRule::GetLocalizedRule() const
   return rule;
 }
 
-CStdString CSmartPlaylistRule::GetParameter() const
+CStdString CDatabaseQueryRule::GetParameter() const
 {
   return StringUtils::JoinString(m_parameter, RULE_VALUE_SEPARATOR);
 }
 
-void CSmartPlaylistRule::SetParameter(const CStdString &value)
+void CDatabaseQueryRule::SetParameter(const CStdString &value)
 {
   m_parameter.clear();
   StringUtils::SplitString(value, RULE_VALUE_SEPARATOR, m_parameter);
 }
 
-void CSmartPlaylistRule::SetParameter(const std::vector<CStdString> &values)
+void CDatabaseQueryRule::SetParameter(const std::vector<CStdString> &values)
 {
   m_parameter.assign(values.begin(), values.end());
 }
@@ -869,9 +873,9 @@ CStdString CSmartPlaylistRule::GetBooleanQuery(const CStdString &negate, const C
   return "";
 }
 
-CSmartPlaylistRule::SEARCH_OPERATOR CSmartPlaylistRule::GetOperator(const CStdString &strType) const
+CDatabaseQueryRule::SEARCH_OPERATOR CSmartPlaylistRule::GetOperator(const CStdString &strType) const
 {
-  SEARCH_OPERATOR op = m_operator;
+  SEARCH_OPERATOR op = CDatabaseQueryRule::GetOperator(strType);
   if ((strType == "tvshows" || strType == "episodes") && m_field == FieldYear)
   { // special case for premiered which is a date rather than a year
     // TODO: SMARTPLAYLISTS do we really need this, or should we just make this field the premiered date and request a date?
@@ -883,7 +887,7 @@ CSmartPlaylistRule::SEARCH_OPERATOR CSmartPlaylistRule::GetOperator(const CStdSt
   return op;
 }
 
-CStdString CSmartPlaylistRule::FormatParameter(const CStdString &operatorString, const CStdString &param, const CDatabase &db, const CStdString &strType) const
+CStdString CDatabaseQueryRule::FormatParameter(const CStdString &operatorString, const CStdString &param, const CDatabase &db, const CStdString &strType) const
 {
   CStdString parameter;
   if (GetFieldType(m_field) == TEXTIN_FIELD)
@@ -912,16 +916,21 @@ CStdString CSmartPlaylistRule::FormatParameter(const CStdString &operatorString,
       parameter = db.PrepareSQL(operatorString.c_str(), date.GetAsDBDate().c_str());
     }
   }
+  return parameter;
+}
+
+CStdString CSmartPlaylistRule::FormatParameter(const CStdString &operatorString, const CStdString &param, const CDatabase &db, const CStdString &strType) const
+{
   // special-casing
   if (m_field == FieldTime)
   { // translate time to seconds
     CStdString seconds; seconds.Format("%i", StringUtils::TimeStringToSeconds(param));
-    parameter = db.PrepareSQL(operatorString.c_str(), seconds.c_str());
+    return db.PrepareSQL(operatorString.c_str(), seconds.c_str());
   }
-  return parameter;
+  return CDatabaseQueryRule::FormatParameter(operatorString, param, db, strType);
 }
 
-CStdString CSmartPlaylistRule::GetOperatorString(SEARCH_OPERATOR op) const
+CStdString CDatabaseQueryRule::GetOperatorString(SEARCH_OPERATOR op) const
 {
   CStdString operatorString;
   if (GetFieldType(m_field) != TEXTIN_FIELD)
@@ -978,7 +987,7 @@ CStdString CSmartPlaylistRule::GetOperatorString(SEARCH_OPERATOR op) const
   return operatorString;
 }
 
-CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdString& strType) const
+CStdString CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const CStdString& strType) const
 {
   SEARCH_OPERATOR op = GetOperator(strType);
 
@@ -1162,8 +1171,18 @@ CStdString CSmartPlaylistRule::FormatWhereClause(const CStdString &negate, const
       query = field + " IS NULL OR " + field + parameter;
     }
   }
+  if (query.IsEmpty())
+    query = CDatabaseQueryRule::FormatWhereClause(negate, oper, param, db, strType);
+  return query;
+}
 
-  if (query.IsEmpty() && m_field != FieldNone)
+CStdString CDatabaseQueryRule::FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
+                                                 const CDatabase &db, const CStdString &strType) const
+{
+  CStdString parameter = FormatParameter(oper, param, db, strType);
+
+  CStdString query;
+  if (m_field != FieldNone)
   {
     string fmt = "%s";
     if (GetFieldType(m_field) == NUMERIC_FIELD)
@@ -1233,7 +1252,7 @@ CStdString CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, co
           }
           if (playlist.GetType().Equals(strType))
           {
-            if (it->m_operator == CSmartPlaylistRule::OPERATOR_DOES_NOT_EQUAL)
+            if (it->m_operator == CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL)
               currentRule.Format("NOT (%s)", playlistQuery.c_str());
             else
               currentRule = playlistQuery;
@@ -1260,7 +1279,7 @@ void CSmartPlaylistRuleCombination::GetVirtualFolders(const CStdString& strType,
 
   for (CSmartPlaylistRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
   {
-    if ((it->m_field != FieldVirtualFolder && it->m_field != FieldPlaylist) || it->m_operator != CSmartPlaylistRule::OPERATOR_EQUALS)
+    if ((it->m_field != FieldVirtualFolder && it->m_field != FieldPlaylist) || it->m_operator != CDatabaseQueryRule::OPERATOR_EQUALS)
       continue;
 
     CStdString playlistFile = CSmartPlaylistDirectory::GetPlaylistByName(it->m_parameter.at(0), strType);

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1210,6 +1210,13 @@ CSmartPlaylistRuleCombination::CSmartPlaylistRuleCombination()
   : m_type(CombinationAnd)
 { }
 
+void CSmartPlaylistRuleCombination::clear()
+{
+  m_combinations.clear();
+  m_rules.clear();
+  m_type = CombinationAnd;
+}
+
 CStdString CSmartPlaylistRuleCombination::GetWhereClause(const CDatabase &db, const CStdString& strType, std::set<CStdString> &referencedPlaylists) const
 {
   CStdString rule, currentRule;
@@ -1344,6 +1351,13 @@ bool CSmartPlaylistRuleCombination::Load(const CVariant &obj)
     }
   }
 
+  return true;
+}
+
+bool CSmartPlaylistRuleCombination::Save(TiXmlNode *parent) const
+{
+  for (CSmartPlaylistRules::const_iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+    (*it)->Save(parent);
   return true;
 }
 
@@ -1624,8 +1638,7 @@ bool CSmartPlaylist::Save(const CStdString &path) const
   XMLUtils::SetString(pRoot, "match", m_ruleCombination.GetType() == CSmartPlaylistRuleCombination::CombinationAnd ? "all" : "one");
 
   // add <rule> tags
-  for (CSmartPlaylistRules::const_iterator it = m_ruleCombination.m_rules.begin(); it != m_ruleCombination.m_rules.end(); ++it)
-    (*it)->Save(pRoot);
+  m_ruleCombination.Save(pRoot);
 
   // add <group> tag if necessary
   if (!m_group.empty())
@@ -1705,9 +1718,7 @@ bool CSmartPlaylist::SaveAsJson(CStdString &json, bool full /* = true */) const
 
 void CSmartPlaylist::Reset()
 {
-  m_ruleCombination.m_combinations.clear();
-  m_ruleCombination.m_rules.clear();
-  m_ruleCombination.SetType(CSmartPlaylistRuleCombination::CombinationAnd);
+  m_ruleCombination.clear();
   m_limit = 0;
   m_orderField = SortByNone;
   m_orderDirection = SortOrderNone;
@@ -1790,7 +1801,7 @@ void CSmartPlaylist::GetAvailableOperators(std::vector<std::string> &operatorLis
 
 bool CSmartPlaylist::IsEmpty(bool ignoreSortAndLimit /* = true */) const
 {
-  bool empty = m_ruleCombination.m_rules.empty() && m_ruleCombination.m_combinations.empty();
+  bool empty = m_ruleCombination.empty();
   if (empty && !ignoreSortAndLimit)
     empty = m_limit <= 0 && m_orderField == SortByNone && m_orderDirection == SortOrderNone;
 

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -384,7 +384,7 @@ CStdString CSmartPlaylistRule::GetLocalizedField(Field field)
   return g_localizeStrings.Get(16018);
 }
 
-CSmartPlaylistRule::FIELD_TYPE CSmartPlaylistRule::GetFieldType(Field field)
+CSmartPlaylistRule::FIELD_TYPE CSmartPlaylistRule::GetFieldType(int field) const
 {
   for (unsigned int i = 0; i < NUM_FIELDS; i++)
     if (field == fields[i].field) return fields[i].type;

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1025,158 +1025,158 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
 CStdString CSmartPlaylistRule::FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
                                                  const CDatabase &db, const CStdString &strType) const
 {
-    CStdString parameter = FormatParameter(oper, param, db, strType);
+  CStdString parameter = FormatParameter(oper, param, db, strType);
 
-    CStdString query;
-    CStdString table;
-    if (strType == "songs")
+  CStdString query;
+  CStdString table;
+  if (strType == "songs")
+  {
+    table = "songview";
+
+    if (m_field == FieldGenre)
+      query = negate + " EXISTS (SELECT 1 FROM song_genre, genre WHERE song_genre.idSong = " + GetField(FieldId, strType) + " AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
+    else if (m_field == FieldArtist)
+      query = negate + " EXISTS (SELECT 1 FROM song_artist, artist WHERE song_artist.idSong = " + GetField(FieldId, strType) + " AND song_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
+    else if (m_field == FieldAlbumArtist)
+      query = negate + " EXISTS (SELECT 1 FROM album_artist, artist WHERE album_artist.idAlbum = " + table + "idAlbum AND album_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
+    else if (m_field == FieldLastPlayed && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
+      query = GetField(m_field, strType) + " is NULL or " + GetField(m_field, strType) + parameter;
+  }
+  else if (strType == "albums")
+  {
+    table = "albumview";
+
+    if (m_field == FieldGenre)
+      query = negate + " EXISTS (SELECT 1 FROM song, song_genre, genre WHERE song.idAlbum = " + GetField(FieldId, strType) + " AND song.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
+    else if (m_field == FieldArtist)
+      query = negate + " EXISTS (SELECT 1 FROM song, song_artist, artist WHERE song.idAlbum = " + GetField(FieldId, strType) + " AND song.idSong = song_artist.idSong AND song_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
+    else if (m_field == FieldAlbumArtist)
+      query = negate + " EXISTS (SELECT 1 FROM album_artist, artist WHERE album_artist.idAlbum = " + GetField(FieldId, strType) + " AND album_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
+  }
+  else if (strType == "artists")
+  {
+    table = "artistview";
+
+    if (m_field == FieldGenre)
+      query = negate + " EXISTS (SELECT DISTINCT song_artist.idArtist FROM song_artist, song_genre, genre WHERE song_artist.idArtist = " + GetField(FieldId, strType) + " AND song_artist.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
+  }
+  else if (strType == "movies")
+  {
+    table = "movieview";
+
+    if (m_field == FieldGenre)
+      query = negate + " EXISTS (SELECT 1 FROM genrelinkmovie JOIN genre ON genre.idGenre=genrelinkmovie.idGenre WHERE genrelinkmovie.idMovie = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
+    else if (m_field == FieldDirector)
+      query = negate + " EXISTS (SELECT 1 FROM directorlinkmovie JOIN actors ON actors.idActor=directorlinkmovie.idDirector WHERE directorlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldActor)
+      query = negate + " EXISTS (SELECT 1 FROM actorlinkmovie JOIN actors ON actors.idActor=actorlinkmovie.idActor WHERE actorlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldWriter)
+      query = negate + " EXISTS (SELECT 1 FROM writerlinkmovie JOIN actors ON actors.idActor=writerlinkmovie.idWriter WHERE writerlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldStudio)
+      query = negate + " EXISTS (SELECT 1 FROM studiolinkmovie JOIN studio ON studio.idStudio=studiolinkmovie.idStudio WHERE studiolinkmovie.idMovie = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
+    else if (m_field == FieldCountry)
+      query = negate + " EXISTS (SELECT 1 FROM countrylinkmovie JOIN country ON country.idCountry=countrylinkmovie.idCountry WHERE countrylinkmovie.idMovie = " + GetField(FieldId, strType) + " AND country.strCountry" + parameter + ")";
+    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
+      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldTag)
+      query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'movie')";
+  }
+  else if (strType == "musicvideos")
+  {
+    table = "musicvideoview";
+
+    if (m_field == FieldGenre)
+      query = negate + " EXISTS (SELECT 1 FROM genrelinkmusicvideo JOIN genre ON genre.idGenre=genrelinkmusicvideo.idGenre WHERE genrelinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
+    else if (m_field == FieldArtist)
+      query = negate + " EXISTS (SELECT 1 FROM artistlinkmusicvideo JOIN actors ON actors.idActor=artistlinkmusicvideo.idArtist WHERE artistlinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldStudio)
+      query = negate + " EXISTS (SELECT 1 FROM studiolinkmusicvideo JOIN studio ON studio.idStudio=studiolinkmusicvideo.idStudio WHERE studiolinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
+    else if (m_field == FieldDirector)
+      query = negate + " EXISTS (SELECT 1 FROM directorlinkmusicvideo JOIN actors ON actors.idActor=directorlinkmusicvideo.idDirector WHERE directorlinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
+      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldTag)
+      query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'musicvideo')";
+  }
+  else if (strType == "tvshows")
+  {
+    table = "tvshowview";
+
+    if (m_field == FieldGenre)
+      query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
+    else if (m_field == FieldDirector)
+      query = negate + " EXISTS (SELECT 1 FROM directorlinktvshow JOIN actors ON actors.idActor=directorlinktvshow.idDirector WHERE directorlinktvshow.idShow = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldActor)
+      query = negate + " EXISTS (SELECT 1 FROM actorlinktvshow JOIN actors ON actors.idActor=actorlinktvshow.idActor WHERE actorlinktvshow.idShow = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldStudio)
+      query = negate + " (" + GetField(m_field, strType) + parameter + ")";
+    else if (m_field == FieldMPAA)
+      query = negate + " (" + GetField(m_field, strType) + parameter + ")";
+    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
+      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldPlaycount)
+      query = "CASE WHEN COALESCE(" + GetField(FieldNumberOfEpisodes, strType) + " - " + GetField(FieldNumberOfWatchedEpisodes, strType) + ", 0) > 0 THEN 0 ELSE 1 END " + parameter;
+    else if (m_field == FieldTag)
+      query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'tvshow')";
+  }
+  else if (strType == "episodes")
+  {
+    table = "episodeview";
+
+    if (m_field == FieldGenre)
+      query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + table + ".idShow AND genre.strGenre" + parameter + ")";
+    else if (m_field == FieldDirector)
+      query = negate + " EXISTS (SELECT 1 FROM directorlinkepisode JOIN actors ON actors.idActor=directorlinkepisode.idDirector WHERE directorlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldActor)
+      query = negate + " EXISTS (SELECT 1 FROM actorlinkepisode JOIN actors ON actors.idActor=actorlinkepisode.idActor WHERE actorlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if (m_field == FieldWriter)
+      query = negate + " EXISTS (SELECT 1 FROM writerlinkepisode JOIN actors ON actors.idActor=writerlinkepisode.idWriter WHERE writerlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+    else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
+      query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
+    else if (m_field == FieldStudio)
+      query = negate + " (" + GetField(FieldId, strType) + parameter + ")";
+    else if (m_field == FieldMPAA)
+      query = negate + " (" + GetField(FieldId, strType) +  parameter + ")";
+  }
+  if (m_field == FieldVideoResolution)
+    query = table + ".idFile" + negate + GetVideoResolutionQuery(param);
+  else if (m_field == FieldAudioChannels)
+    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND iAudioChannels " + parameter + ")";
+  else if (m_field == FieldVideoCodec)
+    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strVideoCodec " + parameter + ")";
+  else if (m_field == FieldAudioCodec)
+    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strAudioCodec " + parameter + ")";
+  else if (m_field == FieldAudioLanguage)
+    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strAudioLanguage " + parameter + ")";
+  else if (m_field == FieldSubtitleLanguage)
+    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strSubtitleLanguage " + parameter + ")";
+  else if (m_field == FieldVideoAspectRatio)
+    query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND fVideoAspect " + parameter + ")";
+  if (m_field == FieldPlaycount && strType != "songs" && strType != "albums" && strType != "tvshows")
+  { // playcount IS stored as NULL OR number IN video db
+    if ((m_operator == OPERATOR_EQUALS && param == "0") ||
+        (m_operator == OPERATOR_DOES_NOT_EQUAL && param != "0") ||
+        (m_operator == OPERATOR_LESS_THAN))
     {
-      table = "songview";
-
-      if (m_field == FieldGenre)
-        query = negate + " EXISTS (SELECT 1 FROM song_genre, genre WHERE song_genre.idSong = " + GetField(FieldId, strType) + " AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
-      else if (m_field == FieldArtist)
-        query = negate + " EXISTS (SELECT 1 FROM song_artist, artist WHERE song_artist.idSong = " + GetField(FieldId, strType) + " AND song_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
-      else if (m_field == FieldAlbumArtist)
-        query = negate + " EXISTS (SELECT 1 FROM album_artist, artist WHERE album_artist.idAlbum = " + table + "idAlbum AND album_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
-      else if (m_field == FieldLastPlayed && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
-        query = GetField(m_field, strType) + " is NULL or " + GetField(m_field, strType) + parameter;
+      CStdString field = GetField(FieldPlaycount, strType);
+      query = field + " IS NULL OR " + field + parameter;
     }
-    else if (strType == "albums")
-    {
-      table = "albumview";
+  }
 
-      if (m_field == FieldGenre)
-        query = negate + " EXISTS (SELECT 1 FROM song, song_genre, genre WHERE song.idAlbum = " + GetField(FieldId, strType) + " AND song.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
-      else if (m_field == FieldArtist)
-        query = negate + " EXISTS (SELECT 1 FROM song, song_artist, artist WHERE song.idAlbum = " + GetField(FieldId, strType) + " AND song.idSong = song_artist.idSong AND song_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
-      else if (m_field == FieldAlbumArtist)
-        query = negate + " EXISTS (SELECT 1 FROM album_artist, artist WHERE album_artist.idAlbum = " + GetField(FieldId, strType) + " AND album_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
-    }
-    else if (strType == "artists")
-    {
-      table = "artistview";
+  if (query.IsEmpty() && m_field != FieldNone)
+  {
+    string fmt = "%s";
+    if (GetFieldType(m_field) == NUMERIC_FIELD)
+      fmt = "CAST(%s as DECIMAL(5,1))";
+    else if (GetFieldType(m_field) == SECONDS_FIELD)
+      fmt = "CAST(%s as INTEGER)";
 
-      if (m_field == FieldGenre)
-        query = negate + " EXISTS (SELECT DISTINCT song_artist.idArtist FROM song_artist, song_genre, genre WHERE song_artist.idArtist = " + GetField(FieldId, strType) + " AND song_artist.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
-    }
-    else if (strType == "movies")
-    {
-      table = "movieview";
+    query.Format(fmt.c_str(), GetField(m_field,strType).c_str());
+    query += negate + parameter;
+  }
 
-      if (m_field == FieldGenre)
-        query = negate + " EXISTS (SELECT 1 FROM genrelinkmovie JOIN genre ON genre.idGenre=genrelinkmovie.idGenre WHERE genrelinkmovie.idMovie = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
-      else if (m_field == FieldDirector)
-        query = negate + " EXISTS (SELECT 1 FROM directorlinkmovie JOIN actors ON actors.idActor=directorlinkmovie.idDirector WHERE directorlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldActor)
-        query = negate + " EXISTS (SELECT 1 FROM actorlinkmovie JOIN actors ON actors.idActor=actorlinkmovie.idActor WHERE actorlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldWriter)
-        query = negate + " EXISTS (SELECT 1 FROM writerlinkmovie JOIN actors ON actors.idActor=writerlinkmovie.idWriter WHERE writerlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldStudio)
-        query = negate + " EXISTS (SELECT 1 FROM studiolinkmovie JOIN studio ON studio.idStudio=studiolinkmovie.idStudio WHERE studiolinkmovie.idMovie = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
-      else if (m_field == FieldCountry)
-        query = negate + " EXISTS (SELECT 1 FROM countrylinkmovie JOIN country ON country.idCountry=countrylinkmovie.idCountry WHERE countrylinkmovie.idMovie = " + GetField(FieldId, strType) + " AND country.strCountry" + parameter + ")";
-      else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
-        query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
-      else if (m_field == FieldTag)
-        query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'movie')";
-    }
-    else if (strType == "musicvideos")
-    {
-      table = "musicvideoview";
-
-      if (m_field == FieldGenre)
-        query = negate + " EXISTS (SELECT 1 FROM genrelinkmusicvideo JOIN genre ON genre.idGenre=genrelinkmusicvideo.idGenre WHERE genrelinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
-      else if (m_field == FieldArtist)
-        query = negate + " EXISTS (SELECT 1 FROM artistlinkmusicvideo JOIN actors ON actors.idActor=artistlinkmusicvideo.idArtist WHERE artistlinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldStudio)
-        query = negate + " EXISTS (SELECT 1 FROM studiolinkmusicvideo JOIN studio ON studio.idStudio=studiolinkmusicvideo.idStudio WHERE studiolinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
-      else if (m_field == FieldDirector)
-        query = negate + " EXISTS (SELECT 1 FROM directorlinkmusicvideo JOIN actors ON actors.idActor=directorlinkmusicvideo.idDirector WHERE directorlinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
-        query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
-      else if (m_field == FieldTag)
-        query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'musicvideo')";
-    }
-    else if (strType == "tvshows")
-    {
-      table = "tvshowview";
-
-      if (m_field == FieldGenre)
-        query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
-      else if (m_field == FieldDirector)
-        query = negate + " EXISTS (SELECT 1 FROM directorlinktvshow JOIN actors ON actors.idActor=directorlinktvshow.idDirector WHERE directorlinktvshow.idShow = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldActor)
-        query = negate + " EXISTS (SELECT 1 FROM actorlinktvshow JOIN actors ON actors.idActor=actorlinktvshow.idActor WHERE actorlinktvshow.idShow = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldStudio)
-        query = negate + " (" + GetField(m_field, strType) + parameter + ")";
-      else if (m_field == FieldMPAA)
-        query = negate + " (" + GetField(m_field, strType) + parameter + ")";
-      else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
-        query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
-      else if (m_field == FieldPlaycount)
-        query = "CASE WHEN COALESCE(" + GetField(FieldNumberOfEpisodes, strType) + " - " + GetField(FieldNumberOfWatchedEpisodes, strType) + ", 0) > 0 THEN 0 ELSE 1 END " + parameter;
-      else if (m_field == FieldTag)
-        query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'tvshow')";
-    }
-    else if (strType == "episodes")
-    {
-      table = "episodeview";
-
-      if (m_field == FieldGenre)
-        query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + table + ".idShow AND genre.strGenre" + parameter + ")";
-      else if (m_field == FieldDirector)
-        query = negate + " EXISTS (SELECT 1 FROM directorlinkepisode JOIN actors ON actors.idActor=directorlinkepisode.idDirector WHERE directorlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldActor)
-        query = negate + " EXISTS (SELECT 1 FROM actorlinkepisode JOIN actors ON actors.idActor=actorlinkepisode.idActor WHERE actorlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if (m_field == FieldWriter)
-        query = negate + " EXISTS (SELECT 1 FROM writerlinkepisode JOIN actors ON actors.idActor=writerlinkepisode.idWriter WHERE writerlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
-      else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
-        query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
-      else if (m_field == FieldStudio)
-        query = negate + " (" + GetField(FieldId, strType) + parameter + ")";
-      else if (m_field == FieldMPAA)
-        query = negate + " (" + GetField(FieldId, strType) +  parameter + ")";
-    }
-    if (m_field == FieldVideoResolution)
-      query = table + ".idFile" + negate + GetVideoResolutionQuery(param);
-    else if (m_field == FieldAudioChannels)
-      query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND iAudioChannels " + parameter + ")";
-    else if (m_field == FieldVideoCodec)
-      query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strVideoCodec " + parameter + ")";
-    else if (m_field == FieldAudioCodec)
-      query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strAudioCodec " + parameter + ")";
-    else if (m_field == FieldAudioLanguage)
-      query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strAudioLanguage " + parameter + ")";
-    else if (m_field == FieldSubtitleLanguage)
-      query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND strSubtitleLanguage " + parameter + ")";
-    else if (m_field == FieldVideoAspectRatio)
-      query = negate + " EXISTS (SELECT 1 FROM streamdetails WHERE streamdetails.idFile = " + table + ".idFile AND fVideoAspect " + parameter + ")";
-    if (m_field == FieldPlaycount && strType != "songs" && strType != "albums" && strType != "tvshows")
-    { // playcount IS stored as NULL OR number IN video db
-      if ((m_operator == OPERATOR_EQUALS && param == "0") ||
-          (m_operator == OPERATOR_DOES_NOT_EQUAL && param != "0") ||
-          (m_operator == OPERATOR_LESS_THAN))
-      {
-        CStdString field = GetField(FieldPlaycount, strType);
-        query = field + " IS NULL OR " + field + parameter;
-      }
-    }
-
-    if (query.IsEmpty() && m_field != FieldNone)
-    {
-      string fmt = "%s";
-      if (GetFieldType(m_field) == NUMERIC_FIELD)
-        fmt = "CAST(%s as DECIMAL(5,1))";
-      else if (GetFieldType(m_field) == SECONDS_FIELD)
-        fmt = "CAST(%s as INTEGER)";
-
-      query.Format(fmt.c_str(), GetField(m_field,strType).c_str());
-      query += negate + parameter;
-    }
-    
-    if (query.Equals(negate + parameter))
-      query = "1";
+  if (query.Equals(negate + parameter))
+    query = "1";
   return query;
 }
 

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1308,7 +1308,7 @@ void CSmartPlaylistRuleCombination::GetVirtualFolders(const CStdString& strType,
   }
 }
 
-bool CSmartPlaylistRuleCombination::Load(const CVariant &obj)
+bool CSmartPlaylistRuleCombination::Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory)
 {
   if (!obj.isObject() && !obj.isArray())
     return false;
@@ -1339,13 +1339,13 @@ bool CSmartPlaylistRuleCombination::Load(const CVariant &obj)
 
     if (it->isMember("and") || it->isMember("or"))
     {
-      boost::shared_ptr<CSmartPlaylistRuleCombination> combo(new CSmartPlaylistRuleCombination());
-      if (combo && combo->Load(*it))
+      boost::shared_ptr<CSmartPlaylistRuleCombination> combo(factory->CreateCombination());
+      if (combo && combo->Load(*it, factory))
         m_combinations.push_back(combo);
     }
     else
     {
-      boost::shared_ptr<CDatabaseQueryRule> rule(new CSmartPlaylistRule());
+      boost::shared_ptr<CDatabaseQueryRule> rule(factory->CreateRule());
       if (rule && rule->Load(*it))
         m_rules.push_back(rule);
     }
@@ -1526,7 +1526,7 @@ bool CSmartPlaylist::Load(const CVariant &obj)
     m_playlistName = obj["name"].asString();
 
   if (obj.isMember("rules"))
-    m_ruleCombination.Load(obj["rules"]);
+    m_ruleCombination.Load(obj["rules"], this);
 
   if (obj.isMember("group") && obj["group"].isMember("type") && obj["group"]["type"].isString())
   {
@@ -1822,4 +1822,13 @@ bool CSmartPlaylist::CheckTypeCompatibility(const CStdString &typeLeft, const CS
     return true;
 
   return false;
+}
+
+CDatabaseQueryRule *CSmartPlaylist::CreateRule() const
+{
+  return new CSmartPlaylistRule();
+}
+CSmartPlaylistRuleCombination *CSmartPlaylist::CreateCombination() const
+{
+  return new CSmartPlaylistRuleCombination();
 }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -949,7 +949,7 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
       return "";
 
     FIELD_TYPE fieldType = GetFieldType(m_field);
-    if (fieldType == NUMERIC_FIELD || m_field == FieldYear)
+    if (fieldType == NUMERIC_FIELD)
       return db.PrepareSQL("CAST(%s as DECIMAL(5,1)) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());
     else if (fieldType == SECONDS_FIELD)
       return db.PrepareSQL("CAST(%s as INTEGER) BETWEEN %s AND %s", GetField(m_field, strType).c_str(), m_parameter[0].c_str(), m_parameter[1].c_str());

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -921,10 +921,8 @@ CStdString CSmartPlaylistRule::FormatParameter(const CStdString &operatorString,
   return parameter;
 }
 
-CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdString& strType) const
+CStdString CSmartPlaylistRule::GetOperatorString(SEARCH_OPERATOR op) const
 {
-  SEARCH_OPERATOR op = GetOperator(strType);
-
   CStdString operatorString;
   if (GetFieldType(m_field) != TEXTIN_FIELD)
   {
@@ -977,7 +975,14 @@ CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdStr
       break;
     }
   }
+  return operatorString;
+}
 
+CStdString CSmartPlaylistRule::GetWhereClause(const CDatabase &db, const CStdString& strType) const
+{
+  SEARCH_OPERATOR op = GetOperator(strType);
+
+  CStdString operatorString = GetOperatorString(op);
   CStdString negate;
   if (op == OPERATOR_DOES_NOT_CONTAIN || op == OPERATOR_FALSE ||
      (op == OPERATOR_DOES_NOT_EQUAL && GetFieldType(m_field) != NUMERIC_FIELD && GetFieldType(m_field) != SECONDS_FIELD))

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -85,16 +85,13 @@ public:
   CStdString                  GetLocalizedRule() const;
   CStdString                  GetWhereClause(const CDatabase &db, const CStdString& strType) const;
 
-  static Field                TranslateField(const char *field);
-  static CStdString           TranslateField(Field field);
   static SortBy               TranslateOrder(const char *order);
   static CStdString           TranslateOrder(SortBy order);
-  static CStdString           GetField(Field field, const CStdString& strType);
   static CStdString           TranslateOperator(SEARCH_OPERATOR oper);
   static Field                TranslateGroup(const char *group);
   static CStdString           TranslateGroup(Field group);
 
-  static CStdString           GetLocalizedField(Field field);
+  static CStdString           GetLocalizedField(int field);
   static CStdString           GetLocalizedOperator(SEARCH_OPERATOR oper);
   static CStdString           GetLocalizedGroup(Field group);
   static bool                 CanGroupMix(Field group);
@@ -103,14 +100,18 @@ public:
   static std::vector<SortBy>  GetOrders(const CStdString &type);
   static std::vector<Field>   GetGroups(const CStdString &type);
   virtual FIELD_TYPE          GetFieldType(int field) const;
-  static bool                 IsFieldBrowseable(Field field);
+  static bool                 IsFieldBrowseable(int field);
 
   static bool Validate(const std::string &input, void *data);
   static bool ValidateRating(const std::string &input, void *data);
 
-  Field                       m_field;
+  int                         m_field;
   SEARCH_OPERATOR             m_operator;
   std::vector<CStdString>     m_parameter;
+protected:
+  virtual CStdString          GetField(int field, const CStdString& type) const;
+  virtual int                 TranslateField(const char *field) const;
+  virtual CStdString          TranslateField(int field) const;
 private:
   static SEARCH_OPERATOR TranslateOperator(const char *oper);
 

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -113,6 +113,8 @@ protected:
   virtual int                 TranslateField(const char *field) const;
   virtual CStdString          TranslateField(int field) const;
   virtual CStdString          FormatParameter(const CStdString &negate, const CStdString &oper, const CDatabase &db, const CStdString &type) const;
+  virtual CStdString          FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
+                                                const CDatabase &db, const CStdString &type) const;
   virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const;
   virtual CStdString          GetOperatorString(SEARCH_OPERATOR op) const;
   virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const;

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -165,6 +165,7 @@ public:
   virtual bool Save(TiXmlNode *parent) const;
   virtual bool Save(CVariant &obj) const;
 
+  CStdString GetWhereClause(const CDatabase &db, const CStdString& strType) const;
   std::string TranslateCombinationType() const;
 
   Combination GetType() const { return m_type; }

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -163,9 +163,10 @@ public:
     CombinationAnd
   } Combination;
 
+  void clear();
   virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8") { return false; }
   virtual bool Load(const CVariant &obj);
-  virtual bool Save(TiXmlNode *parent) const { return false; }
+  virtual bool Save(TiXmlNode *parent) const;
   virtual bool Save(CVariant &obj) const;
 
   CStdString GetWhereClause(const CDatabase &db, const CStdString& strType, std::set<CStdString> &referencedPlaylists) const;
@@ -177,8 +178,9 @@ public:
 
   void AddRule(const CSmartPlaylistRule &rule);
 
+  bool empty() const { return m_combinations.empty() && m_rules.empty(); }
+
 private:
-  friend class CSmartPlaylist;
   friend class CGUIDialogSmartPlaylistEditor;
   friend class CGUIDialogMediaFilter;
 

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -112,6 +112,8 @@ protected:
   virtual CStdString          GetField(int field, const CStdString& type) const;
   virtual int                 TranslateField(const char *field) const;
   virtual CStdString          TranslateField(int field) const;
+  virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const;
+  virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const;
 private:
   static SEARCH_OPERATOR TranslateOperator(const char *oper);
 

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -40,11 +40,11 @@ public:
   virtual bool Save(CVariant &obj) const = 0;
 };
 
-class CSmartPlaylistRule : public ISmartPlaylistRule
+class CDatabaseQueryRule : public ISmartPlaylistRule
 {
 public:
-  CSmartPlaylistRule();
-  virtual ~CSmartPlaylistRule() { }
+  CDatabaseQueryRule();
+  virtual ~CDatabaseQueryRule() { };
 
   enum SEARCH_OPERATOR { OPERATOR_START = 0,
                          OPERATOR_CONTAINS,
@@ -82,12 +82,39 @@ public:
   CStdString                  GetParameter() const;
   void                        SetParameter(const CStdString &value);
   void                        SetParameter(const std::vector<CStdString> &values);
+
+  virtual CStdString          GetWhereClause(const CDatabase &db, const CStdString& strType) const;
+
+  int                         m_field;
+  SEARCH_OPERATOR             m_operator;
+  std::vector<CStdString>     m_parameter;
+
+protected:
+  virtual CStdString          GetField(int field, const CStdString& type) const=0;
+  virtual FIELD_TYPE          GetFieldType(int field) const=0;
+  virtual int                 TranslateField(const char *field) const=0;
+  virtual CStdString          TranslateField(int field) const=0;
+  virtual CStdString          FormatParameter(const CStdString &negate, const CStdString &oper, const CDatabase &db, const CStdString &type) const;
+  virtual CStdString          FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
+                                                const CDatabase &db, const CStdString &type) const;
+  virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const { return m_operator; };
+  virtual CStdString          GetOperatorString(SEARCH_OPERATOR op) const;
+  virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const { return ""; }
+
+  static SEARCH_OPERATOR      TranslateOperator(const char *oper);
+  static CStdString           TranslateOperator(SEARCH_OPERATOR oper);
+};
+
+class CSmartPlaylistRule : public CDatabaseQueryRule
+{
+public:
+  CSmartPlaylistRule();
+  virtual ~CSmartPlaylistRule() { }
+
   CStdString                  GetLocalizedRule() const;
-  CStdString                  GetWhereClause(const CDatabase &db, const CStdString& strType) const;
 
   static SortBy               TranslateOrder(const char *order);
   static CStdString           TranslateOrder(SortBy order);
-  static CStdString           TranslateOperator(SEARCH_OPERATOR oper);
   static Field                TranslateGroup(const char *group);
   static CStdString           TranslateGroup(Field group);
 
@@ -105,9 +132,6 @@ public:
   static bool Validate(const std::string &input, void *data);
   static bool ValidateRating(const std::string &input, void *data);
 
-  int                         m_field;
-  SEARCH_OPERATOR             m_operator;
-  std::vector<CStdString>     m_parameter;
 protected:
   virtual CStdString          GetField(int field, const CStdString& type) const;
   virtual int                 TranslateField(const char *field) const;
@@ -116,11 +140,9 @@ protected:
   virtual CStdString          FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
                                                 const CDatabase &db, const CStdString &type) const;
   virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const;
-  virtual CStdString          GetOperatorString(SEARCH_OPERATOR op) const;
   virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const;
-private:
-  static SEARCH_OPERATOR TranslateOperator(const char *oper);
 
+private:
   CStdString GetVideoResolutionQuery(const CStdString &parameter) const;
 };
 

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -30,18 +30,7 @@
 class CDatabase;
 class CVariant;
 
-class ISmartPlaylistRule
-{
-public:
-  virtual ~ISmartPlaylistRule() { }
-
-  virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8") = 0;
-  virtual bool Load(const CVariant &obj) = 0;
-  virtual bool Save(TiXmlNode *parent) const = 0;
-  virtual bool Save(CVariant &obj) const = 0;
-};
-
-class CDatabaseQueryRule : public ISmartPlaylistRule
+class CDatabaseQueryRule
 {
 public:
   CDatabaseQueryRule();
@@ -152,7 +141,7 @@ class CSmartPlaylistRuleCombination;
 typedef std::vector< boost::shared_ptr<CDatabaseQueryRule> > CDatabaseQueryRules;
 typedef std::vector< boost::shared_ptr<CSmartPlaylistRuleCombination> > CSmartPlaylistRuleCombinations;
 
-class CSmartPlaylistRuleCombination : public ISmartPlaylistRule
+class CSmartPlaylistRuleCombination
 {
 public:
   CSmartPlaylistRuleCombination();

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -44,7 +44,6 @@ public:
   static CStdString           TranslateGroup(Field group);
 
   static CStdString           GetLocalizedField(int field);
-  static CStdString           GetLocalizedOperator(SEARCH_OPERATOR oper);
   static CStdString           GetLocalizedGroup(Field group);
   static bool                 CanGroupMix(Field group);
 
@@ -142,7 +141,6 @@ public:
   CStdString GetSaveLocation() const;
 
   static void GetAvailableFields(const std::string &type, std::vector<std::string> &fieldList);
-  static void GetAvailableOperators(std::vector<std::string> &operatorList);
 
   static bool IsVideoType(const CStdString &type);
   static bool IsMusicType(const CStdString &type);

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -112,6 +112,7 @@ protected:
   virtual CStdString          GetField(int field, const CStdString& type) const;
   virtual int                 TranslateField(const char *field) const;
   virtual CStdString          TranslateField(int field) const;
+  virtual CStdString          FormatParameter(const CStdString &negate, const CStdString &oper, const CDatabase &db, const CStdString &type) const;
   virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const;
   virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const;
 private:

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -175,7 +175,6 @@ public:
   void SetType(Combination combination) { m_type = combination; }
 
   void AddRule(const CSmartPlaylistRule &rule);
-  void AddCombination(const CSmartPlaylistRuleCombination &rule);
 
 private:
   friend class CSmartPlaylist;

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -102,7 +102,7 @@ public:
   static std::vector<Field>   GetFields(const CStdString &type);
   static std::vector<SortBy>  GetOrders(const CStdString &type);
   static std::vector<Field>   GetGroups(const CStdString &type);
-  static FIELD_TYPE           GetFieldType(Field field);
+  virtual FIELD_TYPE          GetFieldType(int field) const;
   static bool                 IsFieldBrowseable(Field field);
 
   static bool Validate(const std::string &input, void *data);

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -23,77 +23,12 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
+#include "dbwrappers/DatabaseQuery.h"
 #include "utils/SortUtils.h"
 #include "utils/StdString.h"
 #include "utils/XBMCTinyXML.h"
 
-class CDatabase;
 class CVariant;
-
-class CDatabaseQueryRule
-{
-public:
-  CDatabaseQueryRule();
-  virtual ~CDatabaseQueryRule() { };
-
-  enum SEARCH_OPERATOR { OPERATOR_START = 0,
-                         OPERATOR_CONTAINS,
-                         OPERATOR_DOES_NOT_CONTAIN,
-                         OPERATOR_EQUALS,
-                         OPERATOR_DOES_NOT_EQUAL,
-                         OPERATOR_STARTS_WITH,
-                         OPERATOR_ENDS_WITH,
-                         OPERATOR_GREATER_THAN,
-                         OPERATOR_LESS_THAN,
-                         OPERATOR_AFTER,
-                         OPERATOR_BEFORE,
-                         OPERATOR_IN_THE_LAST,
-                         OPERATOR_NOT_IN_THE_LAST,
-                         OPERATOR_TRUE,
-                         OPERATOR_FALSE,
-                         OPERATOR_BETWEEN,
-                         OPERATOR_END
-                       };
-
-  enum FIELD_TYPE { TEXT_FIELD = 0,
-                    NUMERIC_FIELD,
-                    DATE_FIELD,
-                    PLAYLIST_FIELD,
-                    SECONDS_FIELD,
-                    BOOLEAN_FIELD,
-                    TEXTIN_FIELD
-                  };
-
-  virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8");
-  virtual bool Load(const CVariant &obj);
-  virtual bool Save(TiXmlNode *parent) const;
-  virtual bool Save(CVariant &obj) const;
-
-  CStdString                  GetParameter() const;
-  void                        SetParameter(const CStdString &value);
-  void                        SetParameter(const std::vector<CStdString> &values);
-
-  virtual CStdString          GetWhereClause(const CDatabase &db, const CStdString& strType) const;
-
-  int                         m_field;
-  SEARCH_OPERATOR             m_operator;
-  std::vector<CStdString>     m_parameter;
-
-protected:
-  virtual CStdString          GetField(int field, const CStdString& type) const=0;
-  virtual FIELD_TYPE          GetFieldType(int field) const=0;
-  virtual int                 TranslateField(const char *field) const=0;
-  virtual CStdString          TranslateField(int field) const=0;
-  virtual CStdString          FormatParameter(const CStdString &negate, const CStdString &oper, const CDatabase &db, const CStdString &type) const;
-  virtual CStdString          FormatWhereClause(const CStdString &negate, const CStdString &oper, const CStdString &param,
-                                                const CDatabase &db, const CStdString &type) const;
-  virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const { return m_operator; };
-  virtual CStdString          GetOperatorString(SEARCH_OPERATOR op) const;
-  virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const { return ""; }
-
-  static SEARCH_OPERATOR      TranslateOperator(const char *oper);
-  static CStdString           TranslateOperator(SEARCH_OPERATOR oper);
-};
 
 class CSmartPlaylistRule : public CDatabaseQueryRule
 {
@@ -134,52 +69,6 @@ protected:
 
 private:
   CStdString GetVideoResolutionQuery(const CStdString &parameter) const;
-};
-
-class CDatabaseQueryRuleCombination;
-
-typedef std::vector< boost::shared_ptr<CDatabaseQueryRule> > CDatabaseQueryRules;
-typedef std::vector< boost::shared_ptr<CDatabaseQueryRuleCombination> > CDatabaseQueryRuleCombinations;
-
-class IDatabaseQueryRuleFactory
-{
-public:
-  virtual CDatabaseQueryRule *CreateRule() const=0;
-  virtual CDatabaseQueryRuleCombination *CreateCombination() const=0;
-};
-
-class CDatabaseQueryRuleCombination
-{
-public:
-  CDatabaseQueryRuleCombination();
-  virtual ~CDatabaseQueryRuleCombination() { };
-
-  typedef enum {
-    CombinationOr = 0,
-    CombinationAnd
-  } Combination;
-
-  void clear();
-  virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8") { return false; }
-  virtual bool Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory);
-  virtual bool Save(TiXmlNode *parent) const;
-  virtual bool Save(CVariant &obj) const;
-
-  CStdString GetWhereClause(const CDatabase &db, const CStdString& strType) const;
-  std::string TranslateCombinationType() const;
-
-  Combination GetType() const { return m_type; }
-  void SetType(Combination combination) { m_type = combination; }
-
-  bool empty() const { return m_combinations.empty() && m_rules.empty(); }
-
-protected:
-  friend class CGUIDialogSmartPlaylistEditor;
-  friend class CGUIDialogMediaFilter;
-
-  Combination m_type;
-  CDatabaseQueryRuleCombinations m_combinations;
-  CDatabaseQueryRules m_rules;
 };
 
 class CSmartPlaylistRuleCombination : public CDatabaseQueryRuleCombination

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -149,7 +149,7 @@ private:
 
 class CSmartPlaylistRuleCombination;
 
-typedef std::vector< boost::shared_ptr<CSmartPlaylistRule> > CSmartPlaylistRules;
+typedef std::vector< boost::shared_ptr<CDatabaseQueryRule> > CDatabaseQueryRules;
 typedef std::vector< boost::shared_ptr<CSmartPlaylistRuleCombination> > CSmartPlaylistRuleCombinations;
 
 class CSmartPlaylistRuleCombination : public ISmartPlaylistRule
@@ -186,7 +186,7 @@ private:
 
   Combination m_type;
   CSmartPlaylistRuleCombinations m_combinations;
-  CSmartPlaylistRules m_rules;
+  CDatabaseQueryRules m_rules;
 };
 
 class CSmartPlaylist

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -21,6 +21,7 @@
 
 #include <set>
 #include <vector>
+#include <boost/shared_ptr.hpp>
 
 #include "utils/SortUtils.h"
 #include "utils/StdString.h"
@@ -148,8 +149,8 @@ private:
 
 class CSmartPlaylistRuleCombination;
 
-typedef std::vector<CSmartPlaylistRule> CSmartPlaylistRules;
-typedef std::vector<CSmartPlaylistRuleCombination> CSmartPlaylistRuleCombinations;
+typedef std::vector< boost::shared_ptr<CSmartPlaylistRule> > CSmartPlaylistRules;
+typedef std::vector< boost::shared_ptr<CSmartPlaylistRuleCombination> > CSmartPlaylistRuleCombinations;
 
 class CSmartPlaylistRuleCombination : public ISmartPlaylistRule
 {

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -114,6 +114,7 @@ protected:
   virtual CStdString          TranslateField(int field) const;
   virtual CStdString          FormatParameter(const CStdString &negate, const CStdString &oper, const CDatabase &db, const CStdString &type) const;
   virtual SEARCH_OPERATOR     GetOperator(const CStdString &type) const;
+  virtual CStdString          GetOperatorString(SEARCH_OPERATOR op) const;
   virtual CStdString          GetBooleanQuery(const CStdString &negate, const CStdString &strType) const;
 private:
   static SEARCH_OPERATOR TranslateOperator(const char *oper);

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -136,23 +136,23 @@ private:
   CStdString GetVideoResolutionQuery(const CStdString &parameter) const;
 };
 
-class CSmartPlaylistRuleCombination;
+class CDatabaseQueryRuleCombination;
 
 typedef std::vector< boost::shared_ptr<CDatabaseQueryRule> > CDatabaseQueryRules;
-typedef std::vector< boost::shared_ptr<CSmartPlaylistRuleCombination> > CSmartPlaylistRuleCombinations;
+typedef std::vector< boost::shared_ptr<CDatabaseQueryRuleCombination> > CDatabaseQueryRuleCombinations;
 
 class IDatabaseQueryRuleFactory
 {
 public:
   virtual CDatabaseQueryRule *CreateRule() const=0;
-  virtual CSmartPlaylistRuleCombination *CreateCombination() const=0;
+  virtual CDatabaseQueryRuleCombination *CreateCombination() const=0;
 };
 
-class CSmartPlaylistRuleCombination
+class CDatabaseQueryRuleCombination
 {
 public:
-  CSmartPlaylistRuleCombination();
-  virtual ~CSmartPlaylistRuleCombination() { }
+  CDatabaseQueryRuleCombination();
+  virtual ~CDatabaseQueryRuleCombination() { };
 
   typedef enum {
     CombinationOr = 0,
@@ -165,24 +165,32 @@ public:
   virtual bool Save(TiXmlNode *parent) const;
   virtual bool Save(CVariant &obj) const;
 
-  CStdString GetWhereClause(const CDatabase &db, const CStdString& strType, std::set<CStdString> &referencedPlaylists) const;
-  void GetVirtualFolders(const CStdString& strType, std::vector<CStdString> &virtualFolders) const;
   std::string TranslateCombinationType() const;
 
   Combination GetType() const { return m_type; }
   void SetType(Combination combination) { m_type = combination; }
 
-  void AddRule(const CSmartPlaylistRule &rule);
-
   bool empty() const { return m_combinations.empty() && m_rules.empty(); }
 
-private:
+protected:
   friend class CGUIDialogSmartPlaylistEditor;
   friend class CGUIDialogMediaFilter;
 
   Combination m_type;
-  CSmartPlaylistRuleCombinations m_combinations;
+  CDatabaseQueryRuleCombinations m_combinations;
   CDatabaseQueryRules m_rules;
+};
+
+class CSmartPlaylistRuleCombination : public CDatabaseQueryRuleCombination
+{
+public:
+  CSmartPlaylistRuleCombination() { }
+  virtual ~CSmartPlaylistRuleCombination() { }
+
+  CStdString GetWhereClause(const CDatabase &db, const CStdString& strType, std::set<CStdString> &referencedPlaylists) const;
+  void GetVirtualFolders(const CStdString& strType, std::vector<CStdString> &virtualFolders) const;
+
+  void AddRule(const CSmartPlaylistRule &rule);
 };
 
 class CSmartPlaylist : public IDatabaseQueryRuleFactory
@@ -254,7 +262,7 @@ public:
 
   // rule creation
   virtual CDatabaseQueryRule *CreateRule() const;
-  virtual CSmartPlaylistRuleCombination *CreateCombination() const;
+  virtual CDatabaseQueryRuleCombination *CreateCombination() const;
 private:
   friend class CGUIDialogSmartPlaylistEditor;
   friend class CGUIDialogMediaFilter;

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -141,6 +141,13 @@ class CSmartPlaylistRuleCombination;
 typedef std::vector< boost::shared_ptr<CDatabaseQueryRule> > CDatabaseQueryRules;
 typedef std::vector< boost::shared_ptr<CSmartPlaylistRuleCombination> > CSmartPlaylistRuleCombinations;
 
+class IDatabaseQueryRuleFactory
+{
+public:
+  virtual CDatabaseQueryRule *CreateRule() const=0;
+  virtual CSmartPlaylistRuleCombination *CreateCombination() const=0;
+};
+
 class CSmartPlaylistRuleCombination
 {
 public:
@@ -154,7 +161,7 @@ public:
 
   void clear();
   virtual bool Load(const TiXmlNode *node, const std::string &encoding = "UTF-8") { return false; }
-  virtual bool Load(const CVariant &obj);
+  virtual bool Load(const CVariant &obj, const IDatabaseQueryRuleFactory *factory);
   virtual bool Save(TiXmlNode *parent) const;
   virtual bool Save(CVariant &obj) const;
 
@@ -178,7 +185,7 @@ private:
   CDatabaseQueryRules m_rules;
 };
 
-class CSmartPlaylist
+class CSmartPlaylist : public IDatabaseQueryRuleFactory
 {
 public:
   CSmartPlaylist();
@@ -244,6 +251,10 @@ public:
   static bool CheckTypeCompatibility(const CStdString &typeLeft, const CStdString &typeRight);
 
   bool IsEmpty(bool ignoreSortAndLimit = true) const;
+
+  // rule creation
+  virtual CDatabaseQueryRule *CreateRule() const;
+  virtual CSmartPlaylistRuleCombination *CreateCombination() const;
 private:
   friend class CGUIDialogSmartPlaylistEditor;
   friend class CGUIDialogMediaFilter;

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -121,7 +121,8 @@ typedef enum {
   FieldBorn,
   FieldBandFormed,
   FieldDisbanded,
-  FieldDied
+  FieldDied,
+  FieldMax
 } Field;
 
 typedef std::set<Field> Fields;

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -25,7 +25,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
-#include "TextureCache.h"
+#include "TextureDatabase.h"
 #include "filesystem/File.h"
 
 #include <sstream>
@@ -432,7 +432,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
     actor["role"] = m_cast[i].strRole;
     actor["order"] = m_cast[i].order;
     if (!m_cast[i].thumb.IsEmpty())
-      actor["thumbnail"] = CTextureCache::GetWrappedImageURL(m_cast[i].thumb);
+      actor["thumbnail"] = CTextureUtils::GetWrappedImageURL(m_cast[i].thumb);
     value["cast"].push_back(actor);
   }
   value["set"] = m_strSet;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -500,7 +500,7 @@ CStdString CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
   if (URIUtils::IsStack(path))
     path = CStackDirectory::GetFirstStackedFile(path);
 
-  return CTextureCache::GetWrappedImageURL(path, "video");
+  return CTextureUtils::GetWrappedImageURL(path, "video");
 }
 
 void CVideoThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* job)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -800,7 +800,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
     strItemPath.Format("fanart://Remote%i",i);
     CFileItemPtr item(new CFileItem(strItemPath, false));
     CStdString thumb = m_movieItem->GetVideoInfoTag()->m_fanart.GetPreviewURL(i);
-    item->SetArt("thumb", CTextureCache::GetWrappedThumbURL(thumb));
+    item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(thumb));
     item->SetIconImage("DefaultPicture.png");
     item->SetLabel(g_localizeStrings.Get(20441));
 
@@ -857,7 +857,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
 
   // set the fanart image
   if (flip && !result.IsEmpty())
-    result = CTextureCache::GetWrappedImageURL(result, "", "flipped");
+    result = CTextureUtils::GetWrappedImageURL(result, "", "flipped");
   CVideoDatabase db;
   if (db.Open())
   {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1407,7 +1407,7 @@ void CGUIWindowVideoNav::OnChooseFanart(const CFileItem &videoItem)
   if (result.Equals("fanart://None") || !CFile::Exists(result))
     result.clear();
   if (!result.IsEmpty() && flip)
-    result = CTextureCache::GetWrappedImageURL(result, "", "flipped");
+    result = CTextureUtils::GetWrappedImageURL(result, "", "flipped");
 
   // update the db
   CVideoDatabase db;


### PR DESCRIPTION
As requested (ages ago) by MilhouseVH and others on the forum.  Allows various cleanup scripts to do their cleanup jobs without messing with the database directly.

Currently this PR also contains significant re-work of CSmartPlaylistRule et. al. which this depends on.  Obviously I'll move out the new CDatabaseQueryRule\* classes to a new file (in db_wrappers most likely).

@Montellese to review.  Ideally this is Gotham material, as having well-used scripts accessing the database directly is a bad idea for user systems.

Will bump JSON-RPC version once we know what else is going in.
