### PR TITLE
[Win32] Add detection for Win 8.1 and remove XP detection

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -168,7 +168,7 @@
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>VC90.CRT.x86.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <AdditionalManifestFiles>VC90.CRT.x86.manifest;win81.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -212,7 +212,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>VC90.CRT.x86.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <AdditionalManifestFiles>VC90.CRT.x86.manifest;win81.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -258,7 +258,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>VC90.CRT.x86.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <AdditionalManifestFiles>VC90.CRT.x86.manifest;win81.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -306,7 +306,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>VC90.CRT.x86.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <AdditionalManifestFiles>VC90.CRT.x86.manifest;win81.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -349,7 +349,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>VC90.CRT.x86.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <AdditionalManifestFiles>VC90.CRT.x86.manifest;win81.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>

--- a/project/VS2010Express/win81.manifest
+++ b/project/VS2010Express/win81.manifest
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+    <description>XBMC</description>
+    <compatibility xmlns='urn:schemas-microsoft-com:compatibility.v1'> 
+        <application> 
+            <!-- Windows 8.1 -->
+            <supportedOS Id='{1f676c76-80e1-4239-95bb-83d0f6d0da78}'/>
+            <!-- Windows Vista -->
+            <supportedOS Id='{e2011457-1546-43c5-a5fe-008deee3d3f0}'/> 
+            <!-- Windows 7 -->
+            <supportedOS Id='{35138b9a-5d96-4fbd-8e2d-a2440225f93a}'/>
+            <!-- Windows 8 -->
+            <supportedOS Id='{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}'/>
+        </application> 
+    </compatibility>
+</assembly>

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -437,8 +437,10 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin7;
       else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 2)
         m_WinVer = WindowsVersionWin8;
+      else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3) 
+        m_WinVer = WindowsVersionWin8_1;
       /* Insert checks for new Windows versions here */
-      else if ( (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion > 2) || osvi.dwMajorVersion > 6)
+      else if ( (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion > 3) || osvi.dwMajorVersion > 6)
         m_WinVer = WindowsVersionFuture;
     }
   }
@@ -532,6 +534,12 @@ CStdString CSysInfo::GetKernelVersion()
         strKernel.append(" 8");
       else
         strKernel.append(" Server 2012");
+      break;
+    case WindowsVersionWin8_1:
+      if (osvi.wProductType == VER_NT_WORKSTATION)
+        strKernel.append(" 8.1");
+      else
+        strKernel.append(" Server 2012 R2");
       break;
     case WindowsVersionFuture:
       strKernel.append(" Unknown Future Version");

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -431,9 +431,7 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
     osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
     if (GetVersionEx((OSVERSIONINFO *)&osvi))
     {
-      if (osvi.dwMajorVersion == 5 && (osvi.dwMinorVersion == 1 || osvi.dwMinorVersion == 2 ))
-        m_WinVer = WindowsVersionWinXP;
-      else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 0)
+      if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 0)
         m_WinVer = WindowsVersionVista;
       else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 1)
         m_WinVer = WindowsVersionWin7;
@@ -517,22 +515,6 @@ CStdString CSysInfo::GetKernelVersion()
   {
     switch (GetWindowsVersion())
     {
-    case WindowsVersionWinXP:
-      if (GetSystemMetrics(SM_SERVERR2))
-        strKernel.append(" Server 2003 R2");
-      else if (osvi.wSuiteMask & VER_SUITE_STORAGE_SERVER)
-        strKernel.append(" Storage Server 2003");
-      else if (osvi.wSuiteMask & VER_SUITE_WH_SERVER)
-        strKernel.append(" Home Server");
-      else if (osvi.wProductType == VER_NT_WORKSTATION && GetKernelBitness() == 64)
-        strKernel.append(" XP Professional");
-      else if (osvi.wProductType != VER_NT_WORKSTATION)
-        strKernel.append(" Server 2003");
-      else if (osvi.wSuiteMask & VER_SUITE_PERSONAL)
-        strKernel.append("XP Home Edition" );
-      else
-        strKernel.append("XP Professional" );
-      break;
     case WindowsVersionVista:
       if (osvi.wProductType == VER_NT_WORKSTATION)
         strKernel.append(" Vista");

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -86,6 +86,7 @@ public:
     WindowsVersionVista,        // Windows Vista, Windows Server 2008
     WindowsVersionWin7,         // Windows 7, Windows Server 2008 R2
     WindowsVersionWin8,         // Windows 8, Windows Server 2012
+    WindowsVersionWin8_1,       // Windows 8.1
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code
   };

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -83,7 +83,6 @@ public:
   enum WindowsVersion
   {
     WindowsVersionUnknown = -1, // Undetected, unsupported Windows version or OS in not Windows
-    WindowsVersionWinXP,        // Windows XP, Windows Server 2003 (R2), Windows Home Server
     WindowsVersionVista,        // Windows Vista, Windows Server 2008
     WindowsVersionWin7,         // Windows 7, Windows Server 2008 R2
     WindowsVersionWin8,         // Windows 8, Windows Server 2012


### PR DESCRIPTION
as title.

Note that this requires a special manifest file, otherwise Win 8.1 will be detected as Win 8.0.
See : http://msdn.microsoft.com/en-us/library/windows/desktop/dn302074%28v=vs.85%29.aspx
