### PR TITLE
Allow repositories to have more than one (conditional) addons.xml sources

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -8,6 +8,12 @@
   </requires>
 	<extension point="xbmc.addon.repository"
 		name="Official XBMC.org Add-on Repository">
+		<dir minversion="12.9.0">
+			<info compressed="true">http://mirrors.xbmc.org/addons/gotham/addons.xml</info>
+			<checksum>http://mirrors.xbmc.org/addons/gotham/addons.xml.md5</checksum>
+			<datadir zip="true">http://mirrors.xbmc.org/addons/gotham</datadir>
+			<hashes>true</hashes>
+		</dir>
 		<info compressed="true">http://mirrors.xbmc.org/addons/frodo/addons.xml</info>
 		<checksum>http://mirrors.xbmc.org/addons/frodo/addons.xml.md5</checksum>
 		<datadir zip="true">http://mirrors.xbmc.org/addons/frodo</datadir>

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -392,14 +392,14 @@ int CAddonDatabase::AddRepository(const CStdString& id, const VECADDONS& addons,
   return -1;
 }
 
-int CAddonDatabase::GetRepoChecksum(const CStdString& id, CStdString& checksum)
+int CAddonDatabase::GetRepoChecksum(const std::string& id, std::string& checksum)
 {
   try
   {
     if (NULL == m_pDB.get()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
-    CStdString strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
+    std::string strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
     m_pDS->query(strSQL.c_str());
     if (!m_pDS->eof())
     {
@@ -411,7 +411,7 @@ int CAddonDatabase::GetRepoChecksum(const CStdString& id, CStdString& checksum)
   {
     CLog::Log(LOGERROR, "%s failed on repo '%s'", __FUNCTION__, id.c_str());
   }
-  checksum.Empty();
+  checksum.clear();
   return -1;
 }
 

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -45,7 +45,7 @@ public:
   int AddRepository(const CStdString& id, const ADDON::VECADDONS& addons, const CStdString& checksum);
   void DeleteRepository(const CStdString& id);
   void DeleteRepository(int id);
-  int GetRepoChecksum(const CStdString& id, CStdString& checksum);
+  int GetRepoChecksum(const std::string& id, std::string& checksum);
   bool GetRepository(const CStdString& id, ADDON::VECADDONS& addons);
   bool GetRepository(int id, ADDON::VECADDONS& addons);
   bool SetRepoTimestamp(const CStdString& id, const CStdString& timestamp);

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -19,21 +19,21 @@
  */
 
 #include "Repository.h"
-#include "utils/XBMCTinyXML.h"
-#include "filesystem/File.h"
-#include "AddonDatabase.h"
-#include "settings/Settings.h"
-#include "FileItem.h"
-#include "utils/JobManager.h"
+#include "addons/AddonDatabase.h"
 #include "addons/AddonInstaller.h"
-#include "utils/log.h"
-#include "utils/URIUtils.h"
+#include "addons/AddonManager.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "filesystem/File.h"
+#include "filesystem/PluginDirectory.h"
+#include "pvr/PVRManager.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "FileItem.h"
 #include "TextureDatabase.h"
 #include "URL.h"
-#include "pvr/PVRManager.h"
-#include "filesystem/PluginDirectory.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -35,6 +35,7 @@
 #include "pvr/PVRManager.h"
 #include "filesystem/PluginDirectory.h"
 
+using namespace std;
 using namespace XFILE;
 using namespace ADDON;
 
@@ -46,36 +47,57 @@ AddonPtr CRepository::Clone() const
 CRepository::CRepository(const AddonProps& props) :
   CAddon(props)
 {
-  m_compressed = false;
-  m_zipped = false;
 }
 
 CRepository::CRepository(const cp_extension_t *ext)
   : CAddon(ext)
 {
-  m_compressed = false;
-  m_zipped = false;
   // read in the other props that we need
   if (ext)
   {
-    m_checksum = CAddonMgr::Get().GetExtValue(ext->configuration, "checksum");
-    m_compressed = CAddonMgr::Get().GetExtValue(ext->configuration, "info@compressed").Equals("true");
-    m_info = CAddonMgr::Get().GetExtValue(ext->configuration, "info");
-    m_datadir = CAddonMgr::Get().GetExtValue(ext->configuration, "datadir");
-    m_zipped = CAddonMgr::Get().GetExtValue(ext->configuration, "datadir@zip").Equals("true");
-    m_hashes = CAddonMgr::Get().GetExtValue(ext->configuration, "hashes").Equals("true");
+    AddonVersion version("0.0.0");
+    AddonPtr addonver;
+    if (CAddonMgr::Get().GetAddon("xbmc.addon", addonver))
+      version = addonver->Version();
+    for (size_t i = 0; i < ext->configuration->num_children; ++i)
+    {
+      if(ext->configuration->children[i].name &&
+         strcmp(ext->configuration->children[i].name, "dir") == 0)
+      {
+        AddonVersion min_version(CAddonMgr::Get().GetExtValue(&ext->configuration->children[i], "@minversion"));
+        if (min_version <= version)
+        {
+          DirInfo dir;
+          dir.version    = min_version;
+          dir.checksum   = CAddonMgr::Get().GetExtValue(&ext->configuration->children[i], "checksum");
+          dir.compressed = CAddonMgr::Get().GetExtValue(&ext->configuration->children[i], "info@compressed").Equals("true");
+          dir.info       = CAddonMgr::Get().GetExtValue(&ext->configuration->children[i], "info");
+          dir.datadir    = CAddonMgr::Get().GetExtValue(&ext->configuration->children[i], "datadir");
+          dir.zipped     = CAddonMgr::Get().GetExtValue(&ext->configuration->children[i], "datadir@zip").Equals("true");
+          dir.hashes     = CAddonMgr::Get().GetExtValue(&ext->configuration->children[i], "hashes").Equals("true");
+          m_dirs.push_back(dir);
+        }
+      }
+    }
+    // backward compatibility
+    if (!CAddonMgr::Get().GetExtValue(ext->configuration, "info").empty())
+    {
+      DirInfo info;
+      info.checksum   = CAddonMgr::Get().GetExtValue(ext->configuration, "checksum");
+      info.compressed = CAddonMgr::Get().GetExtValue(ext->configuration, "info@compressed").Equals("true");
+      info.info       = CAddonMgr::Get().GetExtValue(ext->configuration, "info");
+      info.datadir    = CAddonMgr::Get().GetExtValue(ext->configuration, "datadir");
+      info.zipped     = CAddonMgr::Get().GetExtValue(ext->configuration, "datadir@zip").Equals("true");
+      info.hashes     = CAddonMgr::Get().GetExtValue(ext->configuration, "hashes").Equals("true");
+      m_dirs.push_back(info);
+    }
   }
 }
 
 CRepository::CRepository(const CRepository &rhs)
   : CAddon(rhs)
 {
-  m_info       = rhs.m_info;
-  m_checksum   = rhs.m_checksum;
-  m_datadir    = rhs.m_datadir;
-  m_compressed = rhs.m_compressed;
-  m_zipped     = rhs.m_zipped;
-  m_hashes     = rhs.m_hashes;
+  m_dirs = rhs.m_dirs;
 }
 
 CRepository::~CRepository()
@@ -84,9 +106,13 @@ CRepository::~CRepository()
 
 CStdString CRepository::Checksum()
 {
-  if (!m_checksum.IsEmpty())
-    return FetchChecksum(m_checksum);
-  return "";
+  CStdString result;
+  for (DirList::const_iterator it  = m_dirs.begin(); it != m_dirs.end(); ++it)
+  {
+    if (!it->checksum.empty())
+      result += FetchChecksum(it->checksum);
+  }
+  return result;
 }
 
 CStdString CRepository::FetchChecksum(const CStdString& url)
@@ -117,7 +143,11 @@ CStdString CRepository::FetchChecksum(const CStdString& url)
 CStdString CRepository::GetAddonHash(const AddonPtr& addon)
 {
   CStdString checksum;
-  if (m_hashes)
+  DirList::const_iterator it;
+  for (it = m_dirs.begin();it != m_dirs.end(); ++it)
+    if (it->datadir == addon->Path())
+      break;
+  if (it != m_dirs.end() && it->hashes)
   {
     checksum = FetchChecksum(addon->Path()+".md5");
     size_t pos = checksum.find_first_of(" \n");
@@ -133,17 +163,15 @@ CStdString CRepository::GetAddonHash(const AddonPtr& addon)
        x = y; \
   }
 
-VECADDONS CRepository::Parse()
+VECADDONS CRepository::Parse(const DirInfo& dir)
 {
-  CSingleLock lock(m_critSection);
-
   VECADDONS result;
   CXBMCTinyXML doc;
 
-  CStdString file = m_info;
-  if (m_compressed)
+  CStdString file = dir.info;
+  if (dir.compressed)
   {
-    CURL url(m_info);
+    CURL url(dir.info);
     CStdString opts = url.GetProtocolOptions();
     if (!opts.IsEmpty())
       opts += "&";
@@ -157,22 +185,22 @@ VECADDONS CRepository::Parse()
     for (IVECADDONS i = result.begin(); i != result.end(); ++i)
     {
       AddonPtr addon = *i;
-      if (m_zipped)
+      if (dir.zipped)
       {
         CStdString file;
         file.Format("%s/%s-%s.zip", addon->ID().c_str(), addon->ID().c_str(), addon->Version().c_str());
-        addon->Props().path = URIUtils::AddFileToFolder(m_datadir,file);
-        SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/icon.png"))
+        addon->Props().path = URIUtils::AddFileToFolder(dir.datadir,file);
+        SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/icon.png"))
         file.Format("%s/changelog-%s.txt", addon->ID().c_str(), addon->Version().c_str());
-        SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(m_datadir,file))
-        SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/fanart.jpg"))
+        SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(dir.datadir,file))
+        SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/fanart.jpg"))
       }
       else
       {
-        addon->Props().path = URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/");
-        SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/icon.png"))
-        SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/changelog.txt"))
-        SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/fanart.jpg"))
+        addon->Props().path = URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/");
+        SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/icon.png"))
+        SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/changelog.txt"))
+        SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/fanart.jpg"))
       }
     }
   }
@@ -269,8 +297,24 @@ VECADDONS CRepositoryUpdateJob::GrabAddons(RepositoryPtr& repo)
   VECADDONS addons;
   if (!checksum.Equals(reposum) || checksum.empty())
   {
-    addons = repo->Parse();
-    if (addons.empty())
+    map<string, AddonPtr> uniqueAddons;
+    for (CRepository::DirList::const_iterator it = repo->m_dirs.begin(); it != repo->m_dirs.end(); ++it)
+    {
+      VECADDONS addons2 = CRepository::Parse(*it);
+      for (VECADDONS::const_iterator it2 = addons2.begin(); it2 != addons2.end(); ++it2)
+      {
+        map<string, AddonPtr>::iterator existing = uniqueAddons.find((*it2)->ID());
+        if (existing != uniqueAddons.end())
+        { // already got it - replace if we have a newer version
+          if (existing->second->Version() < (*it2)->Version())
+            existing->second = *it2;
+        }
+        else
+          uniqueAddons.insert(make_pair((*it2)->ID(), *it2));
+      }
+    }
+
+    if (uniqueAddons.empty())
     {
       CLog::Log(LOGERROR,"Repository %s returned no add-ons, listing may have failed",repo->Name().c_str());
       reposum = checksum; // don't update the checksum
@@ -286,7 +330,11 @@ VECADDONS CRepositoryUpdateJob::GrabAddons(RepositoryPtr& repo)
         add = CDirectory::GetDirectory(s, dummy);
       }
       if (add)
+      {
+        for (map<string, AddonPtr>::const_iterator i = uniqueAddons.begin(); i != uniqueAddons.end(); ++i)
+          addons.push_back(i->second);
         database.AddRepository(repo->ID(),addons,reposum);
+      }
     }
   }
   else

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -104,7 +104,7 @@ CRepository::~CRepository()
 {
 }
 
-CStdString CRepository::Checksum()
+CStdString CRepository::Checksum() const
 {
   CStdString result;
   for (DirList::const_iterator it  = m_dirs.begin(); it != m_dirs.end(); ++it)
@@ -117,7 +117,6 @@ CStdString CRepository::Checksum()
 
 CStdString CRepository::FetchChecksum(const CStdString& url)
 {
-  CSingleLock lock(m_critSection);
   CFile file;
   try
   {
@@ -140,7 +139,7 @@ CStdString CRepository::FetchChecksum(const CStdString& url)
   }
 }
 
-CStdString CRepository::GetAddonHash(const AddonPtr& addon)
+CStdString CRepository::GetAddonHash(const AddonPtr& addon) const
 {
   CStdString checksum;
   DirList::const_iterator it;

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -20,11 +20,7 @@
  */
 
 #include "Addon.h"
-#include "AddonManager.h"
-#include "XBDateTime.h"
 #include "utils/Job.h"
-#include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
 
 namespace ADDON
 {

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -45,16 +45,27 @@ namespace ADDON
      \return the md5 hash for the given addon, empty if non exists.
      */
     CStdString GetAddonHash(const AddonPtr& addon);
-    VECADDONS Parse();
+
+    struct DirInfo
+    {
+      DirInfo() : version("0.0.0"), compressed(false), zipped(false), hashes(false) {}
+      AddonVersion version;
+      std::string info;
+      std::string checksum;
+      std::string datadir;
+      bool compressed;
+      bool zipped;
+      bool hashes;
+    };
+
+    typedef std::vector<DirInfo> DirList;
+    DirList m_dirs;
+
+    static VECADDONS Parse(const DirInfo& dir);
   private:
     CStdString FetchChecksum(const CStdString& url);
     CRepository(const CRepository &rhs);
-    CStdString m_info;
-    CStdString m_checksum;
-    CStdString m_datadir;
-    bool m_compressed; // gzipped info xml
-    bool m_zipped;     // zipped addons
-    bool m_hashes;     // repo supports hashes. e.g. plugin.i.rule-1.0.5.zip.md5
+
     CCriticalSection m_critSection;
   };
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -38,13 +38,13 @@ namespace ADDON
     CRepository(const cp_extension_t *props);
     virtual ~CRepository();
 
-    CStdString Checksum();
+    CStdString Checksum() const;
 
     /*! \brief Get the md5 hash for an addon.
      \param the addon in question.
      \return the md5 hash for the given addon, empty if non exists.
      */
-    CStdString GetAddonHash(const AddonPtr& addon);
+    CStdString GetAddonHash(const AddonPtr& addon) const;
 
     struct DirInfo
     {
@@ -63,10 +63,8 @@ namespace ADDON
 
     static VECADDONS Parse(const DirInfo& dir);
   private:
-    CStdString FetchChecksum(const CStdString& url);
+    static CStdString FetchChecksum(const CStdString& url);
     CRepository(const CRepository &rhs);
-
-    CCriticalSection m_critSection;
   };
 
   class CRepositoryUpdateJob : public CJob

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -34,13 +34,13 @@ namespace ADDON
     CRepository(const cp_extension_t *props);
     virtual ~CRepository();
 
-    CStdString Checksum() const;
+    std::string Checksum() const;
 
     /*! \brief Get the md5 hash for an addon.
      \param the addon in question.
      \return the md5 hash for the given addon, empty if non exists.
      */
-    CStdString GetAddonHash(const AddonPtr& addon) const;
+    std::string GetAddonHash(const AddonPtr& addon) const;
 
     struct DirInfo
     {
@@ -59,7 +59,7 @@ namespace ADDON
 
     static VECADDONS Parse(const DirInfo& dir);
   private:
-    static CStdString FetchChecksum(const CStdString& url);
+    static std::string FetchChecksum(const std::string& url);
     CRepository(const CRepository &rhs);
   };
 


### PR DESCRIPTION
This allows Gotham to be served using the Frodo addons.xml for most addons in addition to gotham-specific add-ons where needed.  The code is from @cptspiff - I just cleaned it up.

We basically just list the most up to date add-on based on version.

Add-on authors contributing an add-on to both repositories will need to take care to make sure that their versions are kept separate for this reason.

@MartijnKaijser please test again - I made a slight change to the repository.
