### PR TITLE
[osx] - fix windowed/fullscreen transitions with multi screen setups

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -64,6 +64,9 @@ public:
   virtual void Unregister(IDispResource *resource);
   
   virtual int GetNumScreens();
+  virtual int GetCurrentScreen();
+  
+  void        WindowChangedScreen();
 
   void CheckDisplayChanging(u_int32_t flags);
   
@@ -92,8 +95,11 @@ protected:
 
   bool                         m_use_system_screensaver;
   bool                         m_can_display_switch;
+  bool                         m_movedToOtherScreen;
+  int                          m_lastDisplayNr;
   void                        *m_windowDidMove;
   void                        *m_windowDidReSize;
+  void                        *m_windowChangedScreen;
 
   CCriticalSection             m_resourceSection;
   std::vector<IDispResource*>  m_resources;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -147,6 +147,31 @@
   */
 }
 @end
+
+//------------------------------------------------------------------------------------------
+// special object-c class for handling the NSWindowDidChangeScreenNotification callback.
+@interface windowDidChangeScreenNoteClass : NSObject
+{
+  void *m_userdata;
+}
++ initWith: (void*) userdata;
+- (void) windowDidChangeScreenNotification:(NSNotification*) note;
+@end
+@implementation windowDidChangeScreenNoteClass
++ initWith: (void*) userdata;
+{
+    windowDidChangeScreenNoteClass *windowDidChangeScreen = [windowDidChangeScreenNoteClass new];
+    windowDidChangeScreen->m_userdata = userdata;
+    return [windowDidChangeScreen autorelease];
+}
+- (void) windowDidChangeScreenNotification:(NSNotification*) note;
+{
+  CWinSystemOSX *winsys = (CWinSystemOSX*)m_userdata;
+	if (!winsys)
+    return;
+  winsys->WindowChangedScreen();
+}
+@end
 //------------------------------------------------------------------------------------------
 
 
@@ -532,6 +557,8 @@ CWinSystemOSX::CWinSystemOSX() : CWinSystemBase()
   m_use_system_screensaver = true;
   // check runtime, we only allow this on 10.5+
   m_can_display_switch = (floor(NSAppKitVersionNumber) >= 949);
+  m_lastDisplayNr = -1;
+  m_movedToOtherScreen = false;
 }
 
 CWinSystemOSX::~CWinSystemOSX()
@@ -570,6 +597,13 @@ bool CWinSystemOSX::InitWindowSystem()
     name:NSWindowDidResizeNotification object:nil];
   m_windowDidReSize = windowDidReSize;
 
+  windowDidChangeScreenNoteClass *windowDidChangeScreen;
+  windowDidChangeScreen = [windowDidChangeScreenNoteClass initWith: this];
+  [center addObserver:windowDidChangeScreen
+    selector:@selector(windowDidChangeScreenNotification:)
+    name:NSWindowDidChangeScreenNotification object:nil];
+  m_windowChangedScreen = windowDidChangeScreen;
+
   return true;
 }
 
@@ -578,6 +612,7 @@ bool CWinSystemOSX::DestroyWindowSystem()
   NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
   [center removeObserver:(windowDidMoveNoteClass*)m_windowDidMove name:NSWindowDidMoveNotification object:nil];
   [center removeObserver:(windowDidReSizeNoteClass*)m_windowDidReSize name:NSWindowDidResizeNotification object:nil];
+  [center removeObserver:(windowDidChangeScreenNoteClass*)m_windowChangedScreen name:NSWindowDidChangeScreenNotification object:nil];  
 
   if (m_can_display_switch)
     CGDisplayRemoveReconfigurationCallback(DisplayReconfigured, (void*)this);
@@ -713,8 +748,10 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   static NSPoint last_view_origin;
   static NSInteger last_window_level = NSNormalWindowLevel;
   bool was_fullscreen = m_bFullScreen;
-  static int lastDisplayNr = res.iScreen;
   NSOpenGLContext* cur_context;
+  
+  if (m_lastDisplayNr == -1)
+    m_lastDisplayNr = res.iScreen;
 
   // Fade to black to hide resolution-switching flicker and garbage.
   CGDisplayFadeReservationToken fade_token = DisplayFadeToBlack(needtoshowme);
@@ -751,7 +788,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
       // switch videomode
       SwitchToVideoMode(res.iWidth, res.iHeight, res.fRefreshRate, res.iScreen);
-      lastDisplayNr = res.iScreen;
+      m_lastDisplayNr = res.iScreen;
     }
   }
 
@@ -1599,6 +1636,44 @@ int CWinSystemOSX::GetNumScreens()
 {
   int numDisplays = [[NSScreen screens] count];
   return(numDisplays);
+}
+
+int CWinSystemOSX::GetCurrentScreen()
+{
+  NSOpenGLContext* context = [NSOpenGLContext currentContext];
+  
+  // if user hasn't moved us in windowed mode - return the
+  // last display we were fullscreened at
+  if (!m_movedToOtherScreen)
+    return m_lastDisplayNr;
+  
+  // if we are here the user dragged the window to a different
+  // screen and we return the screen of the window
+  if (context)
+  {
+    NSView* view;
+
+    view = [context view];
+    if (view)
+    {
+      NSWindow* window;
+      window = [view window];
+      if (window)
+      {
+        m_movedToOtherScreen = false;
+        return GetDisplayIndex(GetDisplayIDFromScreen( [window screen] ));
+      }
+        
+    }
+  }
+  return 0;
+}
+
+void CWinSystemOSX::WindowChangedScreen()
+{
+  // user has moved the window to a
+  // different screen
+  m_movedToOtherScreen = true;
 }
 
 void CWinSystemOSX::CheckDisplayChanging(u_int32_t flags)


### PR DESCRIPTION
This fixes the issue that XBMC always was fullscreened at screen 0 when going from windowed to fullscreen.

What we do know. We register for screenchanged callbacks - those are fired whenever xbmc is dragged to a different screen in windowed mode.

If we noticed that we moved screens in windowed mode - the next call to WinSysemBase::GetCurrentScreen will return the current screen our window is at.

In all other cases we return the last screen we were fullscreened at.

Use cases i have tested:

Use case 1
1. Windowed on Screen 0 -> go to fullscreen (apple+f) -> goes to fullscreen on screen 0
2. From fullscreen on screen 0 switch to fullscreen to screen 1 in settings (e.x. Fullscreen #2)
3. Switch to windowed (apple + f) - we get windowed where we were before on screen 0
4. Switch to full screen (apple + f) - we get fullscreened where we were before on screen 1

Use case 2:
1. Windowed on Screen 0 -> go to fullscreen (apple+f) -> goes to fullscreen on screen 0
2. Go to windowed mode (apple + f ) -> goes to windowed where we were before on screen 0
3. Drag the window to screen 1
4. Go to fullscreen (apple + f) -> we get fullscreened on screen 1 now (not on 0 where we were before).

@jmarshallnz this should fix the thing we realised on devcon properly now ... could you test it please?
