### PR TITLE
[rbp/omxplayer] Add missing omxplayer changes to previous commits

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3947,6 +3947,9 @@ void COMXPlayer::UpdatePlayState(double timeout)
 
   }
 
+  state.canpause     = true;
+  state.canseek      = true;
+
   if(m_pInputStream)
   {
     // override from input stream if needed
@@ -3975,16 +3978,10 @@ void COMXPlayer::UpdatePlayState(double timeout)
       }
     }
 
-    if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
+    if (CDVDInputStream::ISeekable* ptr = dynamic_cast<CDVDInputStream::ISeekable*>(m_pInputStream))
     {
-      CDVDInputStreamPVRManager* pvrinputstream = static_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
-      state.canpause = pvrinputstream->CanPause();
-      state.canseek  = pvrinputstream->CanSeek();
-    }
-    else
-    {
-      state.canseek  = state.time_total > 0 ? true : false;
-      state.canpause = true;
+      state.canpause = ptr->CanPause();
+      state.canseek  = ptr->CanSeek();
     }
   }
 
@@ -3994,10 +3991,13 @@ void COMXPlayer::UpdatePlayState(double timeout)
     state.time_total  = m_Edl.RemoveCutTime(llrint(state.time_total));
   }
 
+  if(state.time_total <= 0)
+    state.canseek  = false;
+
   state.player_state = "";
-  if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
+  if(CDVDInputStreamNavigator* ptr = dynamic_cast<CDVDInputStreamNavigator*>(m_pInputStream))
   {
-    if(!((CDVDInputStreamNavigator*)m_pInputStream)->GetNavigatorState(state.player_state))
+    if(!ptr->GetNavigatorState(state.player_state))
       state.player_state = "";
   }
 


### PR DESCRIPTION
The move CanSeek/CanPause and move navigator commits break rpi build.
This adds the same changes to omxplayer.
