### PR TITLE
[osx/mavericks] - fixups for mavericks 10.9

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -42,6 +42,7 @@ public:
   virtual bool CreateNewWindow(const CStdString& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction);
   virtual bool DestroyWindow();
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop);
+  bool         ResizeWindowInternal(int newWidth, int newHeight, int newLeft, int newTop, void *additional);
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual void UpdateResolutions();
   virtual void NotifyAppFocusChange(bool bGaining);


### PR DESCRIPTION
Those are 2 regressions which were introduced by Apple when bumping to OSX 10.9 Mavericks. No Crash & Burn - but both are limiting usability of XBMC on 10.9.
1. The mouse was only working in a limited area when XBMC was in fullscreen window (e.x. left upper area).
2. When using XBMC on secondary screen the apple menubar was visible and lurking on top of the XBMC fullscreen window (as there is a menubar on each screen now with mavericks).

Those fixes are runtime limited to mavericks only and have low potential of breaking anything which wasn't broken before.

Up to the RM.
