### PR TITLE
Switch library:// URLs to 'real' URLs on fetch, rather than list

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -645,7 +645,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
 CMediaSource *CGUIDialogContextMenu::GetShare(const CStdString &type, const CFileItem *item)
 {
   VECSOURCES *shares = CMediaSourceSettings::Get().GetSources(type);
-  if (!shares) return NULL;
+  if (!shares || !item) return NULL;
   for (unsigned int i = 0; i < shares->size(); i++)
   {
     CMediaSource &testShare = shares->at(i);

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -75,6 +75,7 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
             CSmartPlaylistDirectory::GetDirectory(playlist, items))
         {
           items.SetProperty("library.filter", "true");
+          items.SetPath(items.GetProperty("path.db").asString());
           return true;
         }
       }

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -52,7 +52,7 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
     return false;
 
   if (URIUtils::HasExtension(libNode, ".xml"))
-  { // a filter node
+  { // a filter or folder node
     TiXmlElement *node = LoadXML(libNode);
     if (node)
     {
@@ -77,6 +77,13 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
           items.SetProperty("library.filter", "true");
           return true;
         }
+      }
+      else if (type == "folder")
+      {
+        CStdString path;
+        XMLUtils::GetPath(node, "path", path);
+        if (!path.IsEmpty())
+          return CDirectory::GetDirectory(path, items, m_strFileMask, m_flags);
       }
     }
     return false;
@@ -112,27 +119,14 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
       if (XMLUtils::GetString(node, "label", label))
         label = CGUIControlFactory::FilterLabel(label);
       XMLUtils::GetString(node, "icon", icon);
-      CStdString type = node->Attribute("type");
       int order = 0;
       node->Attribute("order", &order);
-      CFileItemPtr item;
-      if (type == "folder")
-      { // folder type - grab our path
-        CStdString path;
-        XMLUtils::GetPath(node, "path", path);
-        if (path.IsEmpty())
-        {
-          CLog::Log(LOGERROR, "<path> tag must be not be empty for type=\"folder\" node '%s'", xml.c_str());
-          continue;
-        }
-        item.reset(new CFileItem(path, true));
-      }
-      else
-      { // virtual folder or filter
-        URIUtils::RemoveSlashAtEnd(xml);
-        CStdString folder = URIUtils::GetFileName(xml);
-        item.reset(new CFileItem(URIUtils::AddFileToFolder(strPath, folder), true));
-      }
+
+      // create item
+      URIUtils::RemoveSlashAtEnd(xml);
+      CStdString folder = URIUtils::GetFileName(xml);
+      CFileItemPtr item(new CFileItem(URIUtils::AddFileToFolder(strPath, folder), true));
+
       item->SetLabel(label);
       if (!icon.IsEmpty() && g_TextureManager.HasTexture(icon))
         item->SetIconImage(icon);

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -47,8 +47,8 @@ CLibraryDirectory::~CLibraryDirectory(void)
 
 bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
 {
-  CStdString libNode = GetNode(strPath);
-  if (libNode.IsEmpty())
+  std::string libNode = GetNode(strPath);
+  if (libNode.empty())
     return false;
 
   if (URIUtils::HasExtension(libNode, ".xml"))
@@ -138,7 +138,7 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
   return true;
 }
 
-TiXmlElement *CLibraryDirectory::LoadXML(const CStdString &xmlFile)
+TiXmlElement *CLibraryDirectory::LoadXML(const std::string &xmlFile)
 {
   if (!CFile::Exists(xmlFile))
     return NULL;
@@ -151,8 +151,9 @@ TiXmlElement *CLibraryDirectory::LoadXML(const CStdString &xmlFile)
     return NULL;
 
   // check the condition
-  CStdString condition = xml->Attribute("visible");
-  if (condition.IsEmpty() || g_infoManager.EvaluateBool(condition))
+  std::string condition;
+  xml->QueryStringAttribute("visible", &condition);
+  if (condition.empty() || g_infoManager.EvaluateBool(condition))
     return xml;
 
   return NULL;
@@ -160,10 +161,12 @@ TiXmlElement *CLibraryDirectory::LoadXML(const CStdString &xmlFile)
 
 bool CLibraryDirectory::Exists(const char* strPath)
 {
-  return !GetNode(strPath).IsEmpty();
+  if (strPath)
+    return !GetNode(std::string(strPath)).empty();
+  return false;
 }
 
-CStdString CLibraryDirectory::GetNode(const CStdString &path)
+std::string CLibraryDirectory::GetNode(const std::string &path)
 {
   CURL url(path);
   CStdString libDir = URIUtils::AddFileToFolder(CProfilesManager::Get().GetLibraryFolder(), url.GetHostName() + "/");

--- a/xbmc/filesystem/LibraryDirectory.h
+++ b/xbmc/filesystem/LibraryDirectory.h
@@ -37,14 +37,14 @@ namespace XFILE
      \param path the library:// path to parse
      \return path to the XML file or directory corresponding to this path
      */
-    CStdString GetNode(const CStdString &path);
+    std::string GetNode(const std::string &path);
 
     /*! \brief load the XML file and return a pointer to the <node> root element.
      Checks visible attribute and only returns non-NULL for valid nodes that should be visible.
      \param xmlFile the XML file to load and parse
      \return the TiXmlElement pointer to the node, if it should be visible.
      */
-    TiXmlElement *LoadXML(const CStdString &xmlFile);
+    TiXmlElement *LoadXML(const std::string &xmlFile);
 
     CXBMCTinyXML m_doc;
   };

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -294,7 +294,7 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
     bool inPlaylists = m_vecItems->GetPath().Equals(CUtil::MusicPlaylistsLocation()) ||
                        m_vecItems->GetPath().Equals("special://musicplaylists/");
 
-    if (m_vecItems->IsVirtualDirectoryRoot())
+    if (m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->GetPath() == "sources://music/")
     {
       // get the usual music shares, and anything for all media windows
       CGUIDialogContextMenu::GetContextButtons("music", item, buttons);
@@ -387,16 +387,13 @@ bool CGUIWindowMusicSongs::OnContextButton(int itemNumber, CONTEXT_BUTTON button
   CFileItemPtr item;
   if (itemNumber >= 0 && itemNumber < m_vecItems->Size())
     item = m_vecItems->Get(itemNumber);
-  if ( m_vecItems->IsVirtualDirectoryRoot() && item)
+  if (CGUIDialogContextMenu::OnContextButton("music", item, button))
   {
-    if (CGUIDialogContextMenu::OnContextButton("music", item, button))
-    {
-      if (button == CONTEXT_BUTTON_REMOVE_SOURCE)
-        OnRemoveSource(itemNumber);
+    if (button == CONTEXT_BUTTON_REMOVE_SOURCE)
+      OnRemoveSource(itemNumber);
 
-      Update("");
-      return true;
-    }
+    Update("");
+    return true;
   }
 
   switch (button)

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -470,7 +470,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
 
   if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
   {
-    if ( m_vecItems->IsVirtualDirectoryRoot() && item)
+    if ( m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->GetPath() == "sources://pictures/" )
     {
       CGUIDialogContextMenu::GetContextButtons("pictures", item, buttons);
     }
@@ -514,13 +514,10 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
 bool CGUIWindowPictures::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   CFileItemPtr item = (itemNumber >= 0 && itemNumber < m_vecItems->Size()) ? m_vecItems->Get(itemNumber) : CFileItemPtr();
-  if (m_vecItems->IsVirtualDirectoryRoot() && item)
+  if (CGUIDialogContextMenu::OnContextButton("pictures", item, button))
   {
-    if (CGUIDialogContextMenu::OnContextButton("pictures", item, button))
-    {
-      Update("");
-      return true;
-    }
+    Update("");
+    return true;
   }
   switch (button)
   {

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -103,7 +103,7 @@ void CGUIWindowPrograms::GetContextButtons(int itemNumber, CContextButtons &butt
   CFileItemPtr item = m_vecItems->Get(itemNumber);
   if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
   {
-    if ( m_vecItems->IsVirtualDirectoryRoot() )
+    if ( m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->GetPath() == "sources://programs/" )
     {
       CGUIDialogContextMenu::GetContextButtons("programs", item, buttons);
     }
@@ -124,13 +124,10 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   CFileItemPtr item = (itemNumber >= 0 && itemNumber < m_vecItems->Size()) ? m_vecItems->Get(itemNumber) : CFileItemPtr();
 
-  if (item && m_vecItems->IsVirtualDirectoryRoot())
+  if (CGUIDialogContextMenu::OnContextButton("programs", item, button))
   {
-    if (CGUIDialogContextMenu::OnContextButton("programs", item, button))
-    {
-      Update("");
-      return true;
-    }
+    Update("");
+    return true;
   }
   switch (button)
   {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1478,7 +1478,13 @@ void CGUIMediaWindow::OnInitWindow()
 {
   // initial fetch is done unthreaded to ensure the items are setup prior to skin animations kicking off
   m_rootDir.SetAllowThreads(false);
+
+  // the start directory may change during Refresh
+  bool updateStartDirectory = (m_startDirectory == m_vecItems->GetPath());
   Refresh();
+  if (updateStartDirectory)
+    m_startDirectory = m_vecItems->GetPath();
+
   m_rootDir.SetAllowThreads(true);
 
   if (m_iSelectedItem > -1)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -831,6 +831,13 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
   }
   if (m_vecItems->GetPath().Equals("sources://video/"))
     showLabel = 999;
+  else if (m_vecItems->GetPath().Equals("sources://music/"))
+    showLabel = 998;
+  else if (m_vecItems->GetPath().Equals("sources://pictures/"))
+    showLabel = 997;
+  else if (m_vecItems->GetPath().Equals("sources://programs/") ||
+           m_vecItems->GetPath().Equals("sources://files/"))
+    showLabel = 1026;
   if (showLabel && (m_vecItems->Size() == 0 || !m_guiState->DisableAddSourceButtons())) // add 'add source button'
   {
     CStdString strLabel = g_localizeStrings.Get(showLabel);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -829,7 +829,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
     else if (iWindow == WINDOW_FILES || iWindow == WINDOW_PROGRAMS)
       showLabel = 1026;
   }
-  if (strDirectory.Equals("sources://video/"))
+  if (m_vecItems->GetPath().Equals("sources://video/"))
     showLabel = 999;
   if (showLabel && (m_vecItems->Size() == 0 || !m_guiState->DisableAddSourceButtons())) // add 'add source button'
   {


### PR DESCRIPTION
Up 'til now, when we list a library:// URL we return translated resulting URLs (e.g. we might return videodb://movies/titles/ ) in the list.

This changes it so that we return the corresponding library://movies/titles URL in the list, and when fetching that URL we translate, fetch the directory, and set the new path in the CFileItemList::m_strPath.

Why would we do this?  Simple.  We currently have two ways to get into a particular videodb:// URL:
1. Via another videodb:// URL.
2. Via a library:// URL.

If we translate when listing a library:// URL, a direct library:// URL is different to the corresponding videodb:// URL.  If on the other hand we translate when fetching, it doesn't matter whether we fetch a library:// URL or a videodb:// URL - in either case you'll end up with a videodb:// in the CFileItemList.

@Montellese: this fixes #14573.

I've tested various filtering things and didn't notice any weirdness.
