### PR TITLE
FIle/FileUtils refactoring

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -58,6 +58,7 @@ CFile::CFile()
 //*********************************************************************************************
 CFile::~CFile()
 {
+  Close();
   if (m_pFile)
     SAFE_DELETE(m_pFile);
   if (m_pBuffer)

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -73,18 +73,6 @@ CFile::~CFile()
 #define MALLOC_EXCP_MSG
 #endif
 
-class CAutoBuffer
-{
-  char* p;
-public:
-  explicit CAutoBuffer(size_t s) { p = (char*)malloc(s); }
-  ~CAutoBuffer() { free(p); }
-  char* get() { return p; }
-};
-
-
-//*********************************************************************************************
-
 
 auto_buffer::auto_buffer(size_t size) : p(NULL), s(0)
 {
@@ -202,7 +190,7 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
 
     int iBufferSize = 128 * 1024;
 
-    CAutoBuffer buffer(iBufferSize);
+    auto_buffer buffer(iBufferSize);
     int iRead, iWrite;
 
     UINT64 llFileSize = file.GetLength();

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -897,6 +897,102 @@ std::string CFile::GetContentCharset(void)
   return m_pFile->GetContentCharset();
 }
 
+
+unsigned int CFile::LoadFile(const std::string &filename, void* &outputBuffer)
+{
+  static const unsigned int max_file_size = 0x7FFFFFFF;
+  static const unsigned int min_chunk_size = 64 * 1024U;
+  static const unsigned int max_chunk_size = 2048 * 1024U;
+
+  outputBuffer = NULL;
+  if (filename.empty())
+    return 0;
+
+  if (!Open(filename, READ_TRUNCATED))
+    return 0;
+
+  /*
+  GetLength() will typically return values that fall into three cases:
+  1. The real filesize. This is the typical case.
+  2. Zero. This is the case for some http:// streams for example.
+  3. Some value smaller than the real filesize. This is the case for an expanding file.
+
+  In order to handle all three cases, we read the file in chunks, relying on Read()
+  returning 0 at EOF.  To minimize (re)allocation of the buffer, the chunksize in
+  cases 1 and 3 is set to one byte larger than the value returned by GetLength().
+  The chunksize in case 2 is set to the lowest value larger than min_chunk_size aligned
+  to GetChunkSize().
+
+  We fill the buffer entirely before reallocation.  Thus, reallocation never occurs in case 1
+  as the buffer is larger than the file, so we hit EOF before we hit the end of buffer.
+
+  To minimize reallocation, we double the chunksize each read while chunksize is lower
+  than max_chunk_size.
+  */
+  int64_t filesize = GetLength();
+  if (filesize > max_file_size)
+  { /* file is too large for this function */
+    Close();
+    return 0;
+  }
+  unsigned int chunksize = (filesize > 0) ? (unsigned int)(filesize + 1) : GetChunkSize(GetChunkSize(), min_chunk_size);
+  unsigned char *inputBuff = NULL;
+  unsigned int inputBuffSize = 0;
+
+  unsigned int total_read = 0, free_space = 0;
+  while (true)
+  {
+    if (!free_space)
+    { // (re)alloc
+      inputBuffSize += chunksize;
+      unsigned char *tempinputBuff = NULL;
+      if (inputBuffSize <= max_file_size)
+        tempinputBuff = (unsigned char *)realloc(inputBuff, inputBuffSize);
+      if (!tempinputBuff)
+      {
+        CLog::Log(LOGERROR, "%s unable to (re)allocate buffer of size %u for file \"%s\"", __FUNCTION__, inputBuffSize, filename.c_str());
+        free(inputBuff);
+        Close();
+        return 0;
+      }
+      inputBuff = tempinputBuff;
+      free_space = chunksize;
+      if (chunksize < max_chunk_size)
+        chunksize *= 2;
+    }
+    unsigned int read = Read(inputBuff + total_read, free_space);
+    free_space -= read;
+    total_read += read;
+    if (!read)
+      break;
+  }
+
+  Close();
+
+  if (total_read == 0)
+  {
+    free(inputBuff);
+    return 0;
+  }
+
+  if (total_read + 1 < inputBuffSize)
+  {
+    /* free extra memory if more than 1 byte (cases 1 and 3) */
+    unsigned char *tempinputBuff = (unsigned char *)realloc(inputBuff, total_read);
+    if (!tempinputBuff)
+    {
+      /* just a precaution, shouldn't really happen */
+      CLog::Log(LOGERROR, "%s unable to reallocate buffer for file \"%s\"", __FUNCTION__, filename.c_str());
+      free(inputBuff);
+      return 0;
+    }
+    inputBuff = tempinputBuff;
+  }
+
+  outputBuffer = (void *)inputBuff;
+  return total_read;
+}
+
 //*********************************************************************************************
 //*************** Stream IO for CFile objects *************************************************
 //*********************************************************************************************

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -69,6 +69,33 @@ public:
 
 class CFileStreamBuffer;
 
+class auto_buffer
+{
+public:
+  auto_buffer(void) : p(NULL), s(0)
+  { }
+  explicit auto_buffer(size_t size);
+  ~auto_buffer();
+
+  auto_buffer& allocate(size_t size);
+  auto_buffer& resize(size_t newSize);
+  auto_buffer& clear(void);
+
+  inline char* get(void) const { return static_cast<char*>(p); }
+  inline size_t size(void) const { return s; }
+  inline size_t length(void) const { return s; }
+
+  auto_buffer& attach(void* pointer, size_t size);
+  void* detach(void);
+
+private:
+  auto_buffer(const auto_buffer& other); // disallow copy constructor
+  auto_buffer& operator=(const auto_buffer& other); // disallow assignment
+
+  void* p;
+  size_t s;
+};
+
 class CFile
 {
 public:

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -116,6 +116,8 @@ public:
   int GetChunkSize();
   std::string GetContentMimeType(void);
   std::string GetContentCharset(void);
+  unsigned int LoadFile(const std::string &filename, void* &outputBuffer);
+
 
   // will return a size, that is aligned to chunk size
   // but always greater or equal to the file's chunk size

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -116,7 +116,7 @@ public:
   int GetChunkSize();
   std::string GetContentMimeType(void);
   std::string GetContentCharset(void);
-  unsigned int LoadFile(const std::string &filename, void* &outputBuffer);
+  unsigned int LoadFile(const std::string &filename, auto_buffer& outputBuffer);
 
 
   // will return a size, that is aligned to chunk size

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -152,97 +152,12 @@ bool CFileUtils::RemoteAccessAllowed(const CStdString &strPath)
 
 unsigned int CFileUtils::LoadFile(const std::string &filename, void* &outputBuffer)
 {
-  static const unsigned int max_file_size = 0x7FFFFFFF;
-  static const unsigned int min_chunk_size = 64*1024U;
-  static const unsigned int max_chunk_size = 2048*1024U;
-
-  outputBuffer = NULL;
-  if (filename.empty())
-    return 0;
-
+  XFILE::auto_buffer buffer;
   XFILE::CFile file;
-  if (!file.Open(filename, READ_TRUNCATED))
-    return 0;
 
-  /*
-   GetLength() will typically return values that fall into three cases:
-   1. The real filesize. This is the typical case.
-   2. Zero. This is the case for some http:// streams for example.
-   3. Some value smaller than the real filesize. This is the case for an expanding file.
+  const unsigned int total_read = file.LoadFile(filename, buffer);
+  outputBuffer = buffer.detach();
 
-   In order to handle all three cases, we read the file in chunks, relying on Read()
-   returning 0 at EOF.  To minimize (re)allocation of the buffer, the chunksize in
-   cases 1 and 3 is set to one byte larger than the value returned by GetLength().
-   The chunksize in case 2 is set to the lowest value larger than min_chunk_size aligned
-   to GetChunkSize().
-
-   We fill the buffer entirely before reallocation.  Thus, reallocation never occurs in case 1
-   as the buffer is larger than the file, so we hit EOF before we hit the end of buffer.
-
-   To minimize reallocation, we double the chunksize each read while chunksize is lower
-   than max_chunk_size.
-   */
-  int64_t filesize = file.GetLength();
-  if (filesize > max_file_size)
-  { /* file is too large for this function */
-    file.Close();
-    return 0;
-  }
-  unsigned int chunksize = (filesize > 0) ? (unsigned int)(filesize + 1) : CFile::GetChunkSize(file.GetChunkSize(), min_chunk_size);
-  unsigned char *inputBuff = NULL;
-  unsigned int inputBuffSize = 0;
-
-  unsigned int total_read = 0, free_space = 0;
-  while (true)
-  {
-    if (!free_space)
-    { // (re)alloc
-      inputBuffSize += chunksize;
-      unsigned char *tempinputBuff = NULL;
-      if (inputBuffSize <= max_file_size)
-        tempinputBuff = (unsigned char *)realloc(inputBuff, inputBuffSize);
-      if (!tempinputBuff)
-      {
-        CLog::Log(LOGERROR, "%s unable to (re)allocate buffer of size %u for file \"%s\"", __FUNCTION__, inputBuffSize, filename.c_str());
-        free(inputBuff);
-        file.Close();
-        return 0;
-      }
-      inputBuff = tempinputBuff;
-      free_space = chunksize;
-      if (chunksize < max_chunk_size)
-        chunksize *= 2;
-    }
-    unsigned int read = file.Read(inputBuff + total_read, free_space);
-    free_space -= read;
-    total_read += read;
-    if (!read)
-      break;
-  }
-
-  file.Close();
-
-  if (total_read == 0)
-  {
-    free(inputBuff);
-    return 0;
-  }
-
-  if (total_read + 1 < inputBuffSize)
-  {
-    /* free extra memory if more than 1 byte (cases 1 and 3) */
-    unsigned char *tempinputBuff = (unsigned char *)realloc(inputBuff, total_read);
-    if (!tempinputBuff)
-    {
-      /* just a precaution, shouldn't really happen */
-      CLog::Log(LOGERROR, "%s unable to reallocate buffer for file \"%s\"", __FUNCTION__, filename.c_str());
-      free(inputBuff);
-      return 0;
-    }
-    inputBuff = tempinputBuff;
-  }
-
-  outputBuffer = (void *) inputBuff;
   return total_read;
 }
 


### PR DESCRIPTION
- Add CFile::LoadFile function
- Move code logic from FileUtils::LoadFile to CFile::LoadFile
- Implement class auto_buffer
- Replace ugly reference to pointer with reference to auto_buffer for CFile::LoadFile

As result, you can

``` C++
CFile file;
auto_buffer buffer;
file.LoadFile("Some/file.ext", buffer);
file.SomeOtherFunction();
```
