### PR TITLE
VFS addition - 02

### DIFF
--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -61,6 +61,7 @@ namespace XFILE
       virtual CStdString GetMimeType()                           { return m_state->m_httpheader.GetMimeType(); }
       virtual CStdString GetContent()                            { return GetMimeType(); }
       virtual int IoControl(EIoControl request, void* param);
+      virtual std::string GetContentCharset(void)                { return GetServerReportedCharset(); }
 
       bool Post(const CStdString& strURL, const CStdString& strPostData, CStdString& strHTML);
       bool Get(const CStdString& strURL, CStdString& strHTML);

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -809,6 +809,21 @@ int CFile::GetChunkSize()
     return m_pFile->GetChunkSize();
   return 0;
 }
+
+std::string CFile::GetContentMimeType(void)
+{
+  if (!m_pFile)
+    return "";
+  return m_pFile->GetContent();
+}
+
+std::string CFile::GetContentCharset(void)
+{
+  if (!m_pFile)
+    return "";
+  return m_pFile->GetContentCharset();
+}
+
 //*********************************************************************************************
 //*************** Stream IO for CFile objects *************************************************
 //*********************************************************************************************

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -87,6 +87,8 @@ public:
   int64_t GetLength();
   void Close();
   int GetChunkSize();
+  std::string GetContentMimeType(void);
+  std::string GetContentCharset(void);
 
   // will return a size, that is aligned to chunk size
   // but always greater or equal to the file's chunk size

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -483,6 +483,15 @@ CStdString CFileCache::GetContent()
   return m_source.GetImplemenation()->GetContent();
 }
 
+std::string CFileCache::GetContentCharset(void)
+{
+  IFile* impl = m_source.GetImplemenation();
+  if (!impl)
+    return IFile::GetContentCharset();
+
+  return impl->GetContentCharset();
+}
+
 int CFileCache::IoControl(EIoControl request, void* param)
 {
   if (request == IOCTRL_CACHE_STATUS)

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -59,6 +59,7 @@ namespace XFILE
     IFile *GetFileImp();
 
     virtual CStdString GetContent();
+    virtual std::string GetContentCharset(void);
 
   private:
     CCacheStrategy *m_pCache;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -83,6 +83,7 @@ public:
   virtual int IoControl(EIoControl request, void* param) { return -1; }
 
   virtual CStdString GetContent()                            { return "application/octet-stream"; }
+  virtual std::string GetContentCharset(void)                { return ""; }
 };
 
 class CRedirectException


### PR DESCRIPTION
Added transparent CFile::GetContentCharset() - IFile::GetContentCharset() - CurlFile/CFileCache::GetContentCharset().
Now charset can be requested for any open file, just like GetLength()
Also added GetContentMimeType(), but only wrapper of CFile class, as base IFile class already has GetContent().
