### PR TITLE
configure: use pkgconfig to detect samba

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1522,9 +1522,12 @@ fi
 
 # samba
 if test "x$use_samba" != "xno"; then
-  AC_CHECK_LIB([smbclient], [main],,
-    use_samba=no;AC_MSG_ERROR($missing_library))
-    USE_LIBSMBCLIENT=0
+  PKG_CHECK_MODULES([SAMBA], [smbclient],
+    [INCLUDES="$INCLUDES $SAMBA_CFLAGS"; LIBS="$LIBS $SAMBA_LIBS"],
+    [AC_CHECK_LIB([smbclient], [main],,
+      use_samba=no;AC_MSG_ERROR($missing_library))
+      USE_LIBSMBCLIENT=0
+    ])
 else
   AC_MSG_RESULT($samba_disabled)
   USE_LIBSMBCLIENT=0


### PR DESCRIPTION
I'm just the messenger for this, all credits go to @ncopa from irc.

Recent Samba versions require pkg-config. We try that first but fall
back to old behaviour if smbclient.pc is missing.

This solves also an 'issue' with samba4 that correctly detects the
libsmbclient in the link test in configure, but fails to compile later
due to missing headers.
