### PR TITLE
FIX: [droid] cleanup assets before build and reinstall (possible fix for #14565)

### DIFF
--- a/tools/android/packaging/Makefile
+++ b/tools/android/packaging/Makefile
@@ -68,7 +68,7 @@ package: extras
 	@echo "$(XBMCROOT)/xbmcapp-$(CPU)-debug.apk created"
 
 extras: libs
-	rm -rf xbmc/assets/python2.6/lib/
+	rm -rf xbmc/assets
 	mkdir -p xbmc/assets xbmc/res xbmc/res/raw xbmc/assets/python2.6/lib/
 	cp -rfp $(PREFIX)/share/xbmc/* ./xbmc/assets
 	find `pwd`/xbmc/assets/ -depth -name ".git" -exec rm -rf {} \;

--- a/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Splash.java
+++ b/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Splash.java
@@ -88,8 +88,21 @@ public class Splash extends Activity {
       this.mSplash = splash;
     }
 
+    void DeleteRecursive(File fileOrDirectory) {
+      if (fileOrDirectory.isDirectory())
+        for (File child : fileOrDirectory.listFiles())
+          DeleteRecursive(child);
+
+      fileOrDirectory.delete();
+    }
+
     @Override
     protected Integer doInBackground(Void... param) {
+      if (fApkDir.exists()) {
+        // Remove existing files
+        Log.d(TAG, "Removing existing " + fApkDir.toString());
+        DeleteRecursive(fApkDir);
+      }
       fApkDir.mkdirs();
 
       // Log.d(TAG, "apk: " + sPackagePath);
@@ -125,15 +138,6 @@ public class Splash extends Activity {
             continue;
           }
 
-          // Log.d(TAG,
-          // "time: " + e.getTime() + ";"
-          // + fFullPath.lastModified());
-
-          // If file exists and has same time, skip
-          if (e.getTime() == fFullPath.lastModified())
-            continue;
-
-          // Log.d(TAG, "writing: " + sFullPath);
           fFullPath.getParentFile().mkdirs();
 
           try {
@@ -145,11 +149,6 @@ public class Splash extends Activity {
 
             in.close();
             out.close();
-
-            // save the zip time. this way we know for certain
-            // if we
-            // need to refresh.
-            fFullPath.setLastModified(e.getTime());
           } catch (IOException e1) {
             e1.printStackTrace();
           }


### PR DESCRIPTION
This cleanup the assets before building the apk.
It also completely removes the cached files when reinstalling upgrading, to avoid leftovers.
