### PR TITLE
Fix Tests for November 2, 2013

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -303,8 +303,10 @@ CHECK_LIBS = xbmc/filesystem/test/filesystemTest.a \
              xbmc/utils/test/utilsTest.a \
              xbmc/threads/test/threadTest.a \
              xbmc/interfaces/python/test/pythonSwigTest.a \
-             xbmc/windowing/tests/wayland/test_wayland.a \
              xbmc/test/xbmc-test.a
+
+ifeq (@USE_WAYLAND@,1)
+CHECK_LIBS += xbmc/windowing/tests/wayland/test_wayland.a
 
 ifeq (@USE_WAYLAND_TEST_EXTENSION@,1)
 WAYLAND_TEST_MODULE = xbmc/windowing/tests/wayland/xbmc-wayland-test-extension.so
@@ -312,6 +314,7 @@ $(WAYLAND_TEST_MODULE): force
 	$(MAKE) -C $(@D) $(@F)
 CHECK_EXTENSIONS = $(WAYLAND_TEST_MODULE)
 CHECK_LIBADD=@WAYLAND_TEST_LIBS@
+endif
 endif
 
 CHECK_PROGRAMS = xbmc-test

--- a/configure.in
+++ b/configure.in
@@ -2554,8 +2554,11 @@ OUTPUT_FILES="Makefile \
     xbmc/android/jni/Makefile \
     xbmc/utils/Makefile \
     xbmc/main/Makefile \
-    xbmc/windowing/tests/wayland/Makefile \
     project/cmake/xbmc-config.cmake"
+
+if $use_wayland = "yes"; then
+OUTPUT_FILES="$OUTPUT_FILES xbmc/windowing/tests/wayland/Makefile"
+fi
 
 if test "$use_skin_touched" = "yes"; then
 OUTPUT_FILES="$OUTPUT_FILES addons/skin.touched/media/Makefile"

--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -20,6 +20,7 @@
 
 #include "utils/CPUInfo.h"
 #include "Temperature.h"
+#include "settings/AdvancedSettings.h"
 
 #include "gtest/gtest.h"
 
@@ -38,8 +39,34 @@ TEST(TestCPUInfo, getCPUFrequency)
   EXPECT_GE(g_cpuInfo.getCPUFrequency(), 0.f);
 }
 
+namespace
+{
+class TemporarySetting
+{
+public:
+
+  TemporarySetting(std::string &setting, const char *newValue) :
+    m_Setting(setting),
+    m_OldValue(setting)
+  {
+    m_Setting = newValue;
+  }
+
+  ~TemporarySetting()
+  {
+    m_Setting = m_OldValue;
+  }
+
+private:
+
+  std::string &m_Setting;
+  std::string m_OldValue;
+};
+}
+
 TEST(TestCPUInfo, getTemperature)
 {
+  TemporarySetting command(g_advancedSettings.m_cpuTempCmd, "echo '50 c'");
   CTemperature t;
   EXPECT_TRUE(g_cpuInfo.getTemperature(t));
   EXPECT_TRUE(t.IsValid());

--- a/xbmc/utils/test/TestCharsetConverter.cpp
+++ b/xbmc/utils/test/TestCharsetConverter.cpp
@@ -351,12 +351,6 @@ TEST_F(TestCharsetConverter, getCharsetNameByLabel)
   EXPECT_STREQ("", varstr.c_str());
 }
 
-TEST_F(TestCharsetConverter, isBidiCharset)
-{
-  EXPECT_TRUE(g_charsetConverter.isBidiCharset("ISO-8859-6"));
-  EXPECT_FALSE(g_charsetConverter.isBidiCharset("Bogus"));
-}
-
 TEST_F(TestCharsetConverter, unknownToUTF8_1)
 {
   refstra1 = "ｔｅｓｔ＿ｕｎｋｎｏｗｎＴｏＵＴＦ８";

--- a/xbmc/utils/test/TestHttpHeader.cpp
+++ b/xbmc/utils/test/TestHttpHeader.cpp
@@ -19,13 +19,12 @@
  */
 
 #include "utils/HttpHeader.h"
-
 #include "gtest/gtest.h"
 
 TEST(TestHttpHeader, General)
 {
   CHttpHeader a;
-  CStdString str = "Host: xbmc.org\r\n"
+  std::string str = "Host: xbmc.org\r\n"
                    "Accept: text/*, text/html, text/html;level=1, */*\r\n"
                    "Accept-Language: en\r\n"
                    "Accept-Encoding: gzip, deflate\r\n"
@@ -33,27 +32,30 @@ TEST(TestHttpHeader, General)
                    "User-Agent: XBMC/snapshot (compatible; MSIE 5.5; Windows NT"
                      " 4.0)\r\n"
                    "Connection: Keep-Alive\r\n";
-  CStdString refstr, varstr;
+  std::string refstr, varstr;
 
   a.Parse(str);
 
-  refstr = "accept: text/*, text/html, text/html;level=1, */*\n"
-           "accept-encoding: gzip, deflate\n"
-           "accept-language: en\n"
-           "connection: Keep-Alive\n"
-           "content-type: text/html; charset=ISO-8859-4\n"
+  /* Should be in the same order as above */
+  refstr = "\n"
            "host: xbmc.org\n"
+           "accept: text/*, text/html, text/html;level=1, */*\n"
+           "accept-language: en\n"
+           "accept-encoding: gzip, deflate\n"
+           "content-type: text/html; charset=ISO-8859-4\n"
            "user-agent: XBMC/snapshot (compatible; MSIE 5.5; Windows NT 4.0)\n"
+           "connection: Keep-Alive\n"
            "\n";
   varstr.clear();
-  a.GetHeader(varstr);
+  varstr = a.GetHeader();
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
   refstr = "XBMC/snapshot (compatible; MSIE 5.5; Windows NT 4.0)";
   varstr = a.GetValue("User-Agent");
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 
-  refstr = "text/html; charset=ISO-8859-4";
+  /* No charset should be here */
+  refstr = "text/html";
   varstr = a.GetMimeType();
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 


### PR DESCRIPTION
1. We were building libwayland_test.a unconditionally if testing was enabled. Mea culpa.
2. It seems like the command for the CPU temperature is being unset at some point. In any event, in a VM, this information isn't available, so we should replace the command with a dummy one so that the test still passes.
3. isBidiCharset was dropped from the API with no replacement. We should drop the test too.
4. HttpHeader was substantially changed recently
   a. The return headers are in the same order as the input headers
   b. The charset is dropped from the return mimetype
   c. It uses std::string now instead of CStdString
