### PR TITLE
Separate out the HttpHeader test function into multiple independently verifiable tests

### DIFF
--- a/xbmc/test/TestTextureCache.cpp
+++ b/xbmc/test/TestTextureCache.cpp
@@ -23,27 +23,42 @@
 
 #include "gtest/gtest.h"
 
-TEST(TestTextureCache, GetWrappedImageURL)
+using ::testing::ValuesIn;
+
+namespace
 {
-  typedef struct
-  {
-    const char *in;
-    const char *type;
-    const char *options;
-    const char *out;
-  } testfiles;
+typedef struct
+{
+  const char *in;
+  const char *type;
+  const char *options;
+  const char *out;
+} TestFiles;
 
-  const testfiles test_files[] = {{ "/path/to/image/file.jpg", "", "", "image://%2fpath%2fto%2fimage%2ffile.jpg/" },
-                                  { "/path/to/image/file.jpg", "", "size=thumb", "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb" },
-                                  { "/path/to/video/file.mkv", "video", "", "image://video@%2fpath%2fto%2fvideo%2ffile.mkv/" },
-                                  { "/path/to/music/file.mp3", "music", "", "image://music@%2fpath%2fto%2fmusic%2ffile.mp3/" },
-                                  { "image://%2fpath%2fto%2fimage%2ffile.jpg/", "", "", "image://%2fpath%2fto%2fimage%2ffile.jpg/" },
-                                  { "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb", "", "size=thumb", "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb" }};
+const TestFiles test_files[] = {{ "/path/to/image/file.jpg", "", "", "image://%2fpath%2fto%2fimage%2ffile.jpg/" },
+                                { "/path/to/image/file.jpg", "", "size=thumb", "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb" },
+                                { "/path/to/video/file.mkv", "video", "", "image://video@%2fpath%2fto%2fvideo%2ffile.mkv/" },
+                                { "/path/to/music/file.mp3", "music", "", "image://music@%2fpath%2fto%2fmusic%2ffile.mp3/" },
+                                { "image://%2fpath%2fto%2fimage%2ffile.jpg/", "", "", "image://%2fpath%2fto%2fimage%2ffile.jpg/" },
+                                { "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb", "", "size=thumb", "image://%2fpath%2fto%2fimage%2ffile.jpg/transform?size=thumb" }};
 
-  for (unsigned int i = 0; i < sizeof(test_files) / sizeof(testfiles); i++)
-  {
-    std::string expected = test_files[i].out;
-    std::string out = CTextureCache::GetWrappedImageURL(test_files[i].in, test_files[i].type, test_files[i].options);
-    EXPECT_EQ(out, expected);
-  }
+
+class TestTextureCache :
+  public ::testing::TestWithParam<TestFiles>
+{
+};
+
+TEST_P(TestTextureCache, GetWrappedImageURL)
+{
+  const TestFiles &testFiles(GetParam());
+
+  std::string expected = testFiles.out;
+  std::string out = CTextureUtils::GetWrappedImageURL(testFiles.in,
+                                                      testFiles.type,
+                                                      testFiles.options);
+  EXPECT_EQ(expected, out);
+}
+
+INSTANTIATE_TEST_CASE_P(SampleFiles, TestTextureCache,
+                        ValuesIn(test_files));
 }

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -130,6 +130,12 @@ std::vector<std::string> CHttpHeader::GetValues(std::string strParam) const
 
 std::string CHttpHeader::GetHeader(void) const
 {
+  /* Only pad with additional \n if there are params
+   * to put into the header or the protocol line has
+   * some data */
+  if (m_params.empty() && m_protoLine.empty())
+    return "";
+
   std::string strHeader(m_protoLine + '\n');
 
   for (HeaderParams::const_iterator iter = m_params.begin(); iter != m_params.end(); ++iter)

--- a/xbmc/utils/test/TestHttpHeader.cpp
+++ b/xbmc/utils/test/TestHttpHeader.cpp
@@ -208,7 +208,7 @@ class TestHttpHeaderParameterizedByInt :
 
 /* In order to test a large spread of spaces, we need to
  * insert N * 10 spaces */
-TEST_P(TestHttpHeaderParameterizedByInt, GetCharsetWithNSpacesBetweenSemicolon)
+TEST_P(TestHttpHeaderParameterizedByInt, GetCharsetWithWhitespaceBetweenSemicolon)
 {
   const char *charset = "ISO-8859-4";
   std::stringstream mimeTypeData;
@@ -218,7 +218,7 @@ TEST_P(TestHttpHeaderParameterizedByInt, GetCharsetWithNSpacesBetweenSemicolon)
 
   for (int i = 0; i < nSpaces; ++i)
   {
-    mimeTypeData << "          ";
+    mimeTypeData << " \t \t \t \t \t";
   }
 
   mimeTypeData << "charset=" << charset;
@@ -229,7 +229,7 @@ TEST_P(TestHttpHeaderParameterizedByInt, GetCharsetWithNSpacesBetweenSemicolon)
 }
 
 /* Check that garbage after the mimetype doesn't get caught either */
-TEST_P(TestHttpHeaderParameterizedByInt, GetCharsetWithNGarbageAfterCharset)
+TEST_P(TestHttpHeaderParameterizedByInt, GetCharsetWithNWhitespaceAfterCharset)
 {
   const char *charset = "ISO-8859-4";
   std::stringstream mimeTypeData;
@@ -239,7 +239,7 @@ TEST_P(TestHttpHeaderParameterizedByInt, GetCharsetWithNGarbageAfterCharset)
 
   for (int i = 0; i < nSpaces; ++i)
   {
-    mimeTypeData << "\n\r\t :!@#$%^";
+    mimeTypeData << " \t \t \t";
   }
 
   Header().Parse(HeaderTokenDataInputString(boost::bind(InsertForContentType, _1, _2,


### PR DESCRIPTION
Added tests for GetValue for each tag, as well as AddParam and GetContentType.

This was wanted from #3545
