### PR TITLE
[rbp/omxplayer] Fix crash on stopping mp3 playback with amplification

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -1087,6 +1087,10 @@ unsigned int COMXAudio::AddPackets(const void* data, unsigned int len, double dt
 
 void COMXAudio::UpdateAttenuation()
 {
+  // always called with m_critSection lock held
+  if (!m_Initialized || m_Passthrough)
+    return;
+
   if (m_amplification == 1.0)
   {
     ApplyVolume();


### PR DESCRIPTION
There is a race condition where we can try to adjust volume after deinitialation
when amplification is enabled, causing a seg fault.

See: http://openelec.tv/forum/124-raspberry-pi/67743-xbmc-restarts-after-playing-mp3-on-3-2-3
