### PR TITLE
[vfs] CFile: remove 'virtual' from destructor

### DIFF
--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -73,7 +73,7 @@ class CFile
 {
 public:
   CFile();
-  virtual ~CFile();
+  ~CFile();
 
   bool Open(const CStdString& strFileName, unsigned int flags = 0);
   bool OpenForWrite(const CStdString& strFileName, bool bOverWrite = false);


### PR DESCRIPTION
no class is derived from CFile, no need for virtual function
