### PR TITLE
AESinkALSA: Use the sink in blocking fashion

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -36,7 +36,7 @@
 #include "utils/AMLUtils.h"
 #endif
 
-#define ALSA_OPTIONS (SND_PCM_NONBLOCK | SND_PCM_NO_AUTO_FORMAT | SND_PCM_NO_AUTO_CHANNELS | SND_PCM_NO_AUTO_RESAMPLE)
+#define ALSA_OPTIONS (SND_PCM_NO_AUTO_FORMAT | SND_PCM_NO_AUTO_CHANNELS | SND_PCM_NO_AUTO_RESAMPLE)
 
 #define ALSA_MAX_CHANNELS 16
 static enum AEChannel ALSAChannelMap[ALSA_MAX_CHANNELS + 1] = {
@@ -196,7 +196,8 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
   if (!InitializeHW(format) || !InitializeSW(format))
     return false;
 
-  snd_pcm_nonblock(m_pcm, 1);
+  // we want it blocking
+  snd_pcm_nonblock(m_pcm, 0);
   snd_pcm_prepare (m_pcm);
 
   m_format              = format;
@@ -446,7 +447,6 @@ void CAESinkALSA::Deinitialize()
 {
   if (m_pcm)
   {
-    snd_pcm_nonblock(m_pcm, 0);
     Stop();
     snd_pcm_close(m_pcm);
     m_pcm = NULL;
@@ -516,28 +516,7 @@ unsigned int CAESinkALSA::AddPackets(uint8_t *data, unsigned int frames, bool ha
     CLog::Log(LOGDEBUG, "CAESinkALSA - the grAEken is hunger, feed it (I am the downmost fallback - fix your code)");
   }
 
-  int ret;
-
-  ret = snd_pcm_avail(m_pcm);
-  if (ret < 0) 
-  {
-    HandleError("snd_pcm_avail", ret);
-    ret = 0;
-  }
-
-  if ((unsigned int)ret < frames)
-  {
-    if(blocking)
-    {
-      ret = snd_pcm_wait(m_pcm, m_timeout);
-      if (ret < 0)
-        HandleError("snd_pcm_wait", ret);
-    }
-    else
-      return 0;
-  }
-
-  ret = snd_pcm_writei(m_pcm, (void*)data, frames);
+  int ret = snd_pcm_writei(m_pcm, (void*)data, frames);
   if (ret < 0)
   {
     HandleError("snd_pcm_writei(1)", ret);
@@ -589,10 +568,8 @@ void CAESinkALSA::Drain()
   if (!m_pcm)
     return;
 
-  snd_pcm_nonblock(m_pcm, 0);
   snd_pcm_drain(m_pcm);
   snd_pcm_prepare(m_pcm);
-  snd_pcm_nonblock(m_pcm, 1);
 }
 
 void CAESinkALSA::AppendParams(std::string &device, const std::string &params)


### PR DESCRIPTION
We want to use the Alsa Sink in a blocking fashion. This remove snd_pcm_available and therefore also the need of snd_pcm_wait as snd_pcm_writei cares for this behaviour.

ActiveAE design allows this. This should care for underruns and make adding packages more failsafe also when CPU is fully loaded.
