### PR TITLE
subs: move rendering to text subtitles to overlay renderer

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		5538433415F3685C00CE061B /* NptAppleAutoreleasePool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5538433315F3685C00CE061B /* NptAppleAutoreleasePool.mm */; settings = {COMPILER_FLAGS = "-I$SRCROOT/lib/libUPnP/Platinum/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Platinum -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaConnect -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaRenderer -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaServer -I$SRCROOT/lib/libUPnP/Platinum/Source/Extras -I$SRCROOT/lib/libUPnP/Neptune/Source/System/Posix -I$SRCROOT/lib/libUPnP/Neptune/Source/Core"; }; };
 		5558ED10176396CD00118C35 /* StereoscopicsManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5558ED0E176396CD00118C35 /* StereoscopicsManager.cpp */; };
 		55611BA31766672F00754072 /* RenderFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55611BA21766672F00754072 /* RenderFlags.cpp */; };
+		55D3604E1826CAB900DA66D2 /* OverlayRendererGUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55D3604C1826CAB900DA66D2 /* OverlayRendererGUI.cpp */; };
 		7C0B98A4154B79C30065A238 /* AEDeviceInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0B98A1154B79C30065A238 /* AEDeviceInfo.cpp */; };
 		7C1A492315A962EE004AF4A4 /* SeekHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A492115A962EE004AF4A4 /* SeekHandler.cpp */; };
 		7C1A85661520522500C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
@@ -3686,6 +3687,8 @@
 		5558ED0F176396CD00118C35 /* StereoscopicsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StereoscopicsManager.h; sourceTree = "<group>"; };
 		55611BA21766672F00754072 /* RenderFlags.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderFlags.cpp; sourceTree = "<group>"; };
 		55611BA41766679200754072 /* RenderFlags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderFlags.h; sourceTree = "<group>"; };
+		55D3604C1826CAB900DA66D2 /* OverlayRendererGUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OverlayRendererGUI.cpp; sourceTree = "<group>"; };
+		55D3604D1826CAB900DA66D2 /* OverlayRendererGUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OverlayRendererGUI.h; sourceTree = "<group>"; };
 		6E2FACD20E26E92800DF79EA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6E97BDBF0DA2B620003A2A89 /* EventClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventClient.h; sourceTree = "<group>"; };
 		6E97BDC00DA2B620003A2A89 /* EventPacket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventPacket.h; sourceTree = "<group>"; };
@@ -3846,7 +3849,7 @@
 		88ACB01D0DCF409E0083CFDF /* ASAPCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASAPCodec.h; sourceTree = "<group>"; };
 		88ACB01E0DCF409E0083CFDF /* DllASAP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DllASAP.h; sourceTree = "<group>"; };
 		88ECB6580DE013C4003396A7 /* DiskArbitration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiskArbitration.framework; path = /System/Library/Frameworks/DiskArbitration.framework; sourceTree = "<absolute>"; };
-		8DD76F7E0486A8DE00D96B5E /* XBMC */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "compiled.mach-o.executable"; path = XBMC; sourceTree = BUILT_PRODUCTS_DIR; };
+		8DD76F7E0486A8DE00D96B5E /* XBMC */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = XBMC; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE84CB5915A5B8A600A3810E /* TagLibVFSStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TagLibVFSStream.cpp; sourceTree = "<group>"; };
 		AE84CB5C15A5B8BA00A3810E /* TagLibVFSStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLibVFSStream.h; sourceTree = "<group>"; };
 		AE89ACA41621DAB800E17DBC /* DVDDemuxBXA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDDemuxBXA.cpp; sourceTree = "<group>"; };
@@ -7747,6 +7750,8 @@
 				F5D8D730102BB3B1004A11AB /* OverlayRenderer.h */,
 				F5D8D72F102BB3B1004A11AB /* OverlayRendererGL.cpp */,
 				F5D8D72E102BB3B1004A11AB /* OverlayRendererGL.h */,
+				55D3604C1826CAB900DA66D2 /* OverlayRendererGUI.cpp */,
+				55D3604D1826CAB900DA66D2 /* OverlayRendererGUI.h */,
 				431AE5D7109C1A63007428C3 /* OverlayRendererUtil.cpp */,
 				431AE5D8109C1A63007428C3 /* OverlayRendererUtil.h */,
 				F56579AD13060D1E0085ED7F /* RenderCapture.cpp */,
@@ -10136,6 +10141,7 @@
 				43BF09171080C6BA00E25290 /* NptResults.cpp in Sources */,
 				43BF09181080C6BA00E25290 /* NptRingBuffer.cpp in Sources */,
 				43BF09191080C6BA00E25290 /* NptSimpleMessageQueue.cpp in Sources */,
+				55D3604E1826CAB900DA66D2 /* OverlayRendererGUI.cpp in Sources */,
 				43BF091A1080C6BA00E25290 /* NptSockets.cpp in Sources */,
 				43BF091B1080C6BA00E25290 /* NptStreams.cpp in Sources */,
 				43BF091C1080C6BA00E25290 /* NptStrings.cpp in Sources */,
@@ -12815,7 +12821,7 @@
 					HAS_SPC_CODEC,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = "";
 				GENERATE_PROFILING_CODE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -12948,7 +12954,7 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_UNROLL_LOOPS = YES;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					$SRCROOT,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -414,6 +414,7 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamPVRManager.cpp" />
     <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\VideoRenderers\OverlayRendererGUI.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.cpp" />
     <ClCompile Include="..\..\xbmc\CueDocument.cpp" />
@@ -1080,6 +1081,7 @@
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxBXA.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.h" />
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h" />
+    <ClInclude Include="..\..\xbmc\cores\VideoRenderers\OverlayRendererGUI.h" />
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogKeyboardGeneric.h" />
     <ClInclude Include="..\..\xbmc\DbUrl.h" />
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogMediaFilter.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3083,6 +3083,9 @@
     <ClCompile Include="..\..\xbmc\utils\CharsetDetection.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\VideoRenderers\OverlayRendererGUI.cpp">
+      <Filter>cores\VideoRenderers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6060,6 +6063,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\CharsetDetection.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\VideoRenderers\OverlayRendererGUI.h">
+      <Filter>cores\VideoRenderers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -619,12 +619,6 @@ void CApplicationPlayer::GetGeneralInfo( CStdString& strVideoInfo)
     player->GetGeneralInfo(strVideoInfo);
 }
 
-bool CApplicationPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
-{
-  boost::shared_ptr<IPlayer> player = GetInternal();
-  return (player && player->GetCurrentSubtitle(strSubtitle));
-}
-
 int  CApplicationPlayer::SeekChapter(int iChapter)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -92,7 +92,6 @@ public:
   void  GetChapterName(CStdString& strChapterName);
   void  GetDeinterlaceMethods(std::vector<int> &deinterlaceMethods);
   void  GetDeinterlaceModes(std::vector<int> &deinterlaceModes);
-  bool  GetCurrentSubtitle(CStdString& strSubtitle);
   void  GetGeneralInfo( CStdString& strVideoInfo);
   float GetPercentage() const;
   int   GetPictureHeight();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -209,7 +209,6 @@ public:
   virtual void DoAudioWork(){};
   virtual bool OnAction(const CAction &action) { return false; };
 
-  virtual bool GetCurrentSubtitle(CStdString& strSubtitle) { strSubtitle = ""; return false; }
   //returns a state that is needed for resuming from a specific time
   virtual CStdString GetPlayerState() { return ""; };
   virtual bool SetPlayerState(CStdString state) { return false;};

--- a/xbmc/cores/VideoRenderers/Makefile.in
+++ b/xbmc/cores/VideoRenderers/Makefile.in
@@ -1,6 +1,7 @@
 SRCS  = BaseRenderer.cpp
 SRCS += OverlayRenderer.cpp
 SRCS += OverlayRendererUtil.cpp
+SRCS += OverlayRendererGUI.cpp
 SRCS += RenderCapture.cpp
 SRCS += RenderManager.cpp
 SRCS += RenderFlags.cpp

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -35,12 +35,12 @@
 #include "settings/DisplaySettings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
+#include "OverlayRendererGUI.h"
 #if defined(HAS_GL) || defined(HAS_GLES)
 #include "OverlayRendererGL.h"
 #elif defined(HAS_DX)
 #include "OverlayRendererDX.h"
 #endif
-
 
 using namespace OVERLAY;
 
@@ -331,6 +331,9 @@ COverlay* CRenderer::Convert(CDVDOverlay* o, double pts)
   else if(o->IsOverlayType(DVDOVERLAY_TYPE_SPU))
     r = new COverlayImageDX((CDVDOverlaySpu*)o);
 #endif
+
+  if(!r && o->IsOverlayType(DVDOVERLAY_TYPE_TEXT))
+    r = new COverlayText((CDVDOverlayText*)o);
 
   if(r)
     o->m_overlay = r->Acquire();

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.h
@@ -65,6 +65,7 @@ namespace OVERLAY {
 
     enum EPosition
     { POSITION_ABSOLUTE
+    , POSITION_ABSOLUTE_SCREEN
     , POSITION_RELATIVE
     } m_pos;
 

--- a/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (C) 2005-2013 Team XBMC
+ *  http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+
+#include "OverlayRendererGUI.h"
+#include "settings/Settings.h"
+
+#include "filesystem/File.h"
+#include "Util.h"
+#include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+#include "guilib/GUITextLayout.h"
+#include "guilib/GUIFontManager.h"
+#include "guilib/GUIFont.h"
+#include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayText.h"
+#include "cores/VideoRenderers/RenderManager.h"
+
+using namespace OVERLAY;
+
+static color_t color[8] = { 0xFFFFFF00
+                          , 0xFFFFFFFF
+                          , 0xFF0099FF
+                          , 0xFF00FF00
+                          , 0xFFCCFF00
+                          , 0xFF00FFFF
+                          , 0xFFE5E5E5
+                          , 0xFFC0C0C0 };
+
+static CGUITextLayout* GetFontLayout()
+{
+  if (CUtil::IsUsingTTFSubtitles())
+  { std::string font_file = CSettings::Get().GetString("subtitles.font");
+    std::string font_path = URIUtils::AddFileToFolder("special://home/media/Fonts/", font_file);
+    if (!XFILE::CFile::Exists(font_path))
+      font_path = URIUtils::AddFileToFolder("special://xbmc/media/Fonts/", font_file);
+
+    // We scale based on PAL4x3 - this at least ensures all sizing is constant across resolutions.
+    RESOLUTION_INFO pal(720, 576, 0);
+    CGUIFont *subtitle_font = g_fontManager.LoadTTF("__subtitle__"
+                                                    , font_path
+                                                    , color[CSettings::Get().GetInt("subtitles.color")]
+                                                    , 0
+                                                    , CSettings::Get().GetInt("subtitles.height")
+                                                    , CSettings::Get().GetInt("subtitles.style")
+                                                    , false, 1.0f, 1.0f, &pal, true);
+    CGUIFont *border_font   = g_fontManager.LoadTTF("__subtitleborder__"
+                                                    , font_path
+                                                    , 0xFF000000
+                                                    , 0
+                                                    , CSettings::Get().GetInt("subtitles.height")
+                                                    , CSettings::Get().GetInt("subtitles.style")
+                                                    , true, 1.0f, 1.0f, &pal, true);
+    if (!subtitle_font || !border_font)
+      CLog::Log(LOGERROR, "CGUIWindowFullScreen::OnMessage(WINDOW_INIT) - Unable to load subtitle font");
+    else
+      return new CGUITextLayout(subtitle_font, true, 0, border_font);
+  }
+
+  return NULL;
+}
+
+COverlayText::COverlayText(CDVDOverlayText * src)
+{
+  CDVDOverlayText::CElement* e = src->m_pHead;
+  while (e)
+  {
+    if (e->IsElementType(CDVDOverlayText::ELEMENT_TYPE_TEXT))
+    {
+      CDVDOverlayText::CElementText* t = (CDVDOverlayText::CElementText*)e;
+      m_text += t->m_text;
+      m_text += "\n";
+    }
+    e = e->pNext;
+  }
+
+  // Avoid additional line breaks
+  while(StringUtils::EndsWith(m_text, "\n"))
+    m_text = StringUtils::Left(m_text, m_text.length() - 1);
+
+  // Remove HTML-like tags from the subtitles until
+  StringUtils::Replace(m_text, "\\r", "");
+  StringUtils::Replace(m_text, "\r", "");
+  StringUtils::Replace(m_text, "\\n", "[CR]");
+  StringUtils::Replace(m_text, "\n", "[CR]");
+  StringUtils::Replace(m_text, "<br>", "[CR]");
+  StringUtils::Replace(m_text, "\\N", "[CR]");
+  StringUtils::Replace(m_text, "<i>", "[I]");
+  StringUtils::Replace(m_text, "</i>", "[/I]");
+  StringUtils::Replace(m_text, "<b>", "[B]");
+  StringUtils::Replace(m_text, "</b>", "[/B]");
+  StringUtils::Replace(m_text, "<u>", "");
+  StringUtils::Replace(m_text, "<p>", "");
+  StringUtils::Replace(m_text, "<P>", "");
+  StringUtils::Replace(m_text, "&nbsp;", "");
+  StringUtils::Replace(m_text, "</u>", "");
+  StringUtils::Replace(m_text, "</i", "[/I]"); // handle tags which aren't closed properly (happens).
+  StringUtils::Replace(m_text, "</b", "[/B]");
+  StringUtils::Replace(m_text, "</u", "");
+
+  m_layout = GetFontLayout();
+
+  m_subalign = CSettings::Get().GetInt("subtitles.align");
+  if (m_subalign == SUBTITLE_ALIGN_MANUAL)
+  {
+    m_align  = ALIGN_SUBTITLE;
+    m_pos    = POSITION_RELATIVE;
+    m_x      = 0.0f;
+    m_y      = 0.0f;
+  }
+  else
+  {
+    m_align  = ALIGN_VIDEO;
+    m_pos    = POSITION_RELATIVE;
+    m_x      = 0.5f;
+    if(m_subalign == SUBTITLE_ALIGN_TOP_INSIDE
+    || m_subalign == SUBTITLE_ALIGN_TOP_OUTSIDE)
+      m_y    = 0.0f;
+    else
+      m_y    = 1.0f;
+  }
+  m_width  = 0;
+  m_height = 0;
+}
+
+COverlayText::~COverlayText()
+{
+  delete m_layout;
+}
+
+void COverlayText::Render(OVERLAY::SRenderState &state)
+{
+  if(m_layout == NULL)
+    return;
+
+  CRect rs, rd;
+  g_renderManager.GetVideoRect(rs, rd);
+  RESOLUTION_INFO res = g_graphicsContext.GetResInfo();
+
+  float width_max = (float) res.Overscan.right - res.Overscan.left;
+  float y, width, height;
+  m_layout->Update(m_text, width_max * 0.9f, false, true); // true to force LTR reading order (most Hebrew subs are this format)
+  m_layout->GetTextExtent(width, height);
+
+  if (m_subalign == SUBTITLE_ALIGN_MANUAL
+  ||  m_subalign == SUBTITLE_ALIGN_TOP_OUTSIDE
+  ||  m_subalign == SUBTITLE_ALIGN_BOTTOM_INSIDE)
+    y = state.y - height;
+  else
+    y = state.y;
+
+  // clamp inside screen
+  y = std::max(y, (float) res.Overscan.top);
+  y = std::min(y, res.Overscan.bottom - height);
+
+  m_layout->RenderOutline(state.x, y, 0, 0xFF000000, XBFONT_CENTER_X, width_max);
+}

--- a/xbmc/cores/VideoRenderers/OverlayRendererGUI.h
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGUI.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2005-2013 Team XBMC
+ *  http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "OverlayRenderer.h"
+#include <string>
+
+enum SubtitleAlign
+{
+  SUBTITLE_ALIGN_MANUAL         = 0,
+  SUBTITLE_ALIGN_BOTTOM_INSIDE,
+  SUBTITLE_ALIGN_BOTTOM_OUTSIDE,
+  SUBTITLE_ALIGN_TOP_INSIDE,
+  SUBTITLE_ALIGN_TOP_OUTSIDE
+};
+
+class CGUITextLayout;
+class CDVDOverlayText;
+
+namespace OVERLAY {
+
+class COverlayText
+: public COverlay
+{
+public:
+  COverlayText() {}
+  COverlayText(CDVDOverlayText* src);
+  virtual ~COverlayText();
+  virtual void Render(SRenderState& state);
+
+  CGUITextLayout* m_layout;
+  std::string     m_text;
+  int             m_subalign;
+};
+
+}

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -36,6 +36,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
+#include "guilib/GUIFontManager.h"
 
 #if defined(HAS_GL)
   #include "LinuxRendererGL.h"
@@ -454,6 +455,8 @@ void CXBMCRenderManager::UnInit()
   m_bIsStarted = false;
 
   m_overlays.Flush();
+  g_fontManager.Unload("__subtitle__");
+  g_fontManager.Unload("__subtitleborder__");
 
   // free renderer resources.
   // TODO: we may also want to release the renderer here.
@@ -778,6 +781,7 @@ void CXBMCRenderManager::Render(bool clear, DWORD flags, DWORD alpha)
   else
     PresentSingle(clear, flags, alpha);
 
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetVideoResolution(), false);
   m_overlays.Render(m_presentsource);
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1089,6 +1089,9 @@ void CDVDPlayer::Process()
     // update application with our state
     UpdateApplication(1000);
 
+    // make sure we run subtitle process here
+    m_dvdPlayerSubtitle.Process(m_clock.GetClock() + m_State.time_offset - m_dvdPlayerVideo.GetSubtitleDelay());
+
     if (CheckDelayedChannelEntry())
       continue;
 
@@ -3725,24 +3728,6 @@ bool CDVDPlayer::HasMenu()
     return true;
   else
     return false;
-}
-
-bool CDVDPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
-{
-  double pts = m_clock.GetClock() + m_State.time_offset;
-
-  if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) && m_CurrentSubtitle.source != STREAM_SOURCE_TEXT && m_CurrentSubtitle.source != STREAM_SOURCE_DEMUX_SUB)
-    return false;
-
-  m_dvdPlayerSubtitle.GetCurrentSubtitle(strSubtitle, pts - m_dvdPlayerVideo.GetSubtitleDelay());
-
-  // In case we stalled, don't output any subs
-  if ((m_dvdPlayerVideo.IsStalled() && HasVideo()) || (m_dvdPlayerAudio.IsStalled() && HasAudio()))
-    strSubtitle = m_lastSub;
-  else
-    m_lastSub = strSubtitle;
-
-  return !strSubtitle.IsEmpty();
 }
 
 CStdString CDVDPlayer::GetPlayerState()

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -237,8 +237,6 @@ public:
   virtual bool GetStreamDetails(CStreamDetails &details);
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
 
-  virtual bool GetCurrentSubtitle(CStdString& strSubtitle);
-
   virtual CStdString GetPlayerState();
   virtual bool SetPlayerState(CStdString state);
 

--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
@@ -234,37 +234,3 @@ bool CDVDPlayerSubtitle::AcceptsData()
   return m_pOverlayContainer->GetSize() < 5;
 }
 
-void CDVDPlayerSubtitle::GetCurrentSubtitle(CStdString& strSubtitle, double pts)
-{
-  strSubtitle = "";
-
-  Process(pts); // TODO: move to separate thread?
-
-  CSingleLock lock(*m_pOverlayContainer);
-  VecOverlays* pOverlays = m_pOverlayContainer->GetOverlays();
-  if (pOverlays)
-  {
-    for(vector<CDVDOverlay*>::iterator it = pOverlays->begin();it != pOverlays->end();++it)
-    {
-      CDVDOverlay* pOverlay = *it;
-
-      if (pOverlay->IsOverlayType(DVDOVERLAY_TYPE_TEXT)
-      && (pOverlay->iPTSStartTime <= pts)
-      && (pOverlay->iPTSStopTime >= pts || pOverlay->iPTSStopTime == 0LL))
-      {
-        CDVDOverlayText::CElement* e = ((CDVDOverlayText*)pOverlay)->m_pHead;
-        while (e)
-        {
-          if (e->IsElementType(CDVDOverlayText::ELEMENT_TYPE_TEXT))
-          {
-            CDVDOverlayText::CElementText* t = (CDVDOverlayText::CElementText*)e;
-            strSubtitle += t->m_text;
-            strSubtitle += "\n";
-          }
-          e = e->pNext;
-        }
-      }
-    }
-  }
-  strSubtitle.TrimRight('\n');
-}

--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.h
@@ -41,7 +41,6 @@ public:
   void Process(double pts);
   void Flush();
   void FindSubtitles(const char* strFilename);
-  void GetCurrentSubtitle(CStdString& strSubtitle, double pts);
   int GetSubtitleCount();
 
   void UpdateOverlayInfo(CDVDInputStreamNavigator* pStream, int iAction) { m_pOverlayContainer->UpdateOverlayInfo(pStream, &m_dvdspus, iAction); }

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1274,6 +1274,9 @@ void COMXPlayer::Process()
     // update application with our state
     UpdateApplication(1000);
 
+    // make sure we run subtitle process here
+    m_dvdPlayerSubtitle.Process(m_clock.GetClock() - m_omxPlayerVideo.GetSubtitleDelay());
+
     // OMX emergency exit
     if(HasAudio() && m_omxPlayerAudio.BadState())
     {
@@ -3999,24 +4002,6 @@ bool COMXPlayer::HasMenu()
     return true;
   else
     return false;
-}
-
-bool COMXPlayer::GetCurrentSubtitle(CStdString& strSubtitle)
-{
-  double pts = m_clock.GetClock() + m_State.time_offset;
-
-  if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) && m_CurrentSubtitle.source != STREAM_SOURCE_TEXT && m_CurrentSubtitle.source != STREAM_SOURCE_DEMUX_SUB)
-    return false;
-
-  m_dvdPlayerSubtitle.GetCurrentSubtitle(strSubtitle, pts - m_omxPlayerVideo.GetSubtitleDelay());
-
-  // In case we stalled, don't output any subs
-  if ((m_omxPlayerVideo.IsStalled() && HasVideo()) || (m_omxPlayerAudio.IsStalled() && HasAudio()))
-    strSubtitle = m_lastSub;
-  else
-    m_lastSub = strSubtitle;
-
-  return !strSubtitle.IsEmpty();
 }
 
 CStdString COMXPlayer::GetPlayerState()

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -235,8 +235,6 @@ public:
   virtual bool GetStreamDetails(CStreamDetails &details);
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
 
-  virtual bool GetCurrentSubtitle(CStdString& strSubtitle);
-
   virtual CStdString GetPlayerState();
   virtual bool SetPlayerState(CStdString state);
   

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -33,6 +33,7 @@
 #include "video/windows/GUIWindowFullScreen.h"
 #ifdef HAS_VIDEO_PLAYBACK
 #include "cores/VideoRenderers/RenderManager.h"
+#include "cores/VideoRenderers/OverlayRendererGUI.h"
 #endif
 #include "Application.h"
 #include "utils/LangCodeExpander.h"

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -23,17 +23,6 @@
 #include "guilib/GUIWindow.h"
 #include "threads/CriticalSection.h"
 
-enum SubtitleAlign
-{
-  SUBTITLE_ALIGN_MANUAL         = 0,
-  SUBTITLE_ALIGN_BOTTOM_INSIDE,
-  SUBTITLE_ALIGN_BOTTOM_OUTSIDE,
-  SUBTITLE_ALIGN_TOP_INSIDE,
-  SUBTITLE_ALIGN_TOP_OUTSIDE
-};
-
-class CGUITextLayout; // forward
-
 class CGUIWindowFullScreen : public CGUIWindow
 {
 public:
@@ -52,7 +41,6 @@ protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
 
 private:
-  void RenderTTFSubtitles();
   void SeekChapter(int iChapter);
   void FillInTVGroups();
   void ToggleOSD();
@@ -81,7 +69,4 @@ private:
   unsigned int m_timeCodeTimeout;
   int m_timeCodeStamp[6];
   int m_timeCodePosition;
-  
-  CCriticalSection m_fontLock;
-  CGUITextLayout* m_subsLayout;
 };


### PR DESCRIPTION
This fixes issues with 3d modes where subtitles would apear on
one eye before the other, due to timestamps differing between
render passes.

It's a bug fix, but if it's food for feature-freeze i'm not sure.
