### PR TITLE
[dvdplayer] potential unguarded null pointer when video has no audio

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3841,7 +3841,11 @@ void CDVDPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
   if (index == GetAudioStream())
     info.bitrate = m_dvdPlayerAudio.GetAudioBitrate();
   else
-    info.bitrate = m_pDemuxer->GetStreamFromAudioId(index)->iBitRate;
+  {
+    CDemuxStreamAudio* stream = m_pDemuxer->GetStreamFromAudioId(index);
+    if (stream)
+      info.bitrate = stream->iBitRate;
+  }
 
   SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, index);
   if(s.language.length() > 0)


### PR DESCRIPTION
(e.g. stills in dvd menu)

I've been debugging issues with dvd's with menu's having stills without audio and came across this issue where there was no current audio stream. This simple fix will avoid a null dereferencing.
