### PR TITLE
[dvdplayer][AE] only Flush once when going into stall - fixes cycling audio in AE Sink

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -554,10 +554,11 @@ void CDVDPlayerAudio::Process()
 
     if( result & DECODE_FLAG_TIMEOUT )
     {
+      bool transitioningToStalled = !m_stalled;
       m_stalled = true;
 
       // Flush as the audio output may keep looping if we don't
-      if(m_speed == DVD_PLAYSPEED_NORMAL)
+      if(m_speed == DVD_PLAYSPEED_NORMAL && transitioningToStalled)
       {
         m_dvdAudio.Drain();
         m_dvdAudio.Flush();


### PR DESCRIPTION
This tries to address the phenomenon witnessed when transitioning from a DVD title or menu with audio to a menu without audio (usually a still). I root cause analyzed this and found that DVDPlayerAudio keeps bombarding the AE with Flush messages. Because of this, the AE Sink refuses (in some cases, it seems to be a race condition) to go in TIMEOUT, and as such the last bit of audio keeps cycling.

The solution is rather simple, only Flush once, i.e. when transitioning to stalled.
Flushing once is better, also for the environment (kidding :-) ).

@elupus @FernetMenta @fritsch - you guys are the experts - please take a look and let me know what you think.

Furthermore, I have of course only seen this issue with ActiveAE, and I don't know if the other audio engines will be happy with this change in DVDPlayerAudio. Normally they should, but just wanted to check.
