### PR TITLE
Support a textbox in dialogs derived from dialogboxbase (ok, yes/no, progress etc.)

### DIFF
--- a/addons/skin.confluence/720p/DialogOK.xml
+++ b/addons/skin.confluence/720p/DialogOK.xml
@@ -53,38 +53,16 @@
 			<ondown>10</ondown>
 			<visible>system.getbool(input.enablemouse)</visible>
 		</control>
-		<control type="label" id="2">
-			<description>dialog line 1</description>
+		<control type="textbox" id="9">
+			<description>text</description>
 			<left>30</left>
 			<top>60</top>
 			<width>550</width>
-			<height>30</height>
+			<height>80</height>
 			<align>left</align>
-			<aligny>center</aligny>
 			<label>-</label>
 			<font>font13</font>
-		</control>
-		<control type="label" id="3">
-			<description>dialog line 2</description>
-			<left>30</left>
-			<top>85</top>
-			<width>550</width>
-			<height>30</height>
-			<align>left</align>
-			<aligny>center</aligny>
-			<label>-</label>
-			<font>font13</font>
-		</control>
-		<control type="label" id="4">
-			<description>dialog line 3</description>
-			<left>30</left>
-			<top>110</top>
-			<width>550</width>
-			<height>30</height>
-			<align>left</align>
-			<aligny>center</aligny>
-			<label>-</label>
-			<font>font13</font>
+			<autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
 		</control>
 		<control type="button" id="10">
 			<description>OK button</description>

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -27,6 +27,7 @@ using namespace std;
 
 #define CONTROL_HEADING 1
 #define CONTROL_LINES_START 2
+#define CONTROL_TEXTBOX     9
 #define CONTROL_CHOICES_START 10
 
 CGUIDialogBoxBase::CGUIDialogBoxBase(int id, const CStdString &xmlFile)
@@ -34,6 +35,7 @@ CGUIDialogBoxBase::CGUIDialogBoxBase(int id, const CStdString &xmlFile)
 {
   m_bConfirmed = false;
   m_loadType = KEEP_IN_MEMORY;
+  m_hasTextbox = false;
 }
 
 CGUIDialogBoxBase::~CGUIDialogBoxBase(void)
@@ -117,8 +119,18 @@ void CGUIDialogBoxBase::Process(unsigned int currentTime, CDirtyRegionList &dirt
         choices.push_back(m_strChoices[i]);
     }
     SET_CONTROL_LABEL(CONTROL_HEADING, heading);
-    for (size_t i = 0 ; i < lines.size(); ++i)
-      SET_CONTROL_LABEL(CONTROL_LINES_START + i, lines[i]);
+    if (m_hasTextbox)
+    {
+      std::string text = lines[0];
+      for (size_t i = 1; i < lines.size(); ++i)
+        text += "\n" + lines[i];
+      SET_CONTROL_LABEL(CONTROL_TEXTBOX, text);
+    }
+    else
+    {
+      for (size_t i = 0 ; i < lines.size(); ++i)
+        SET_CONTROL_LABEL(CONTROL_LINES_START + i, lines[i]);
+    }
     for (size_t i = 0 ; i < choices.size() ; ++i)
       SET_CONTROL_LABEL(CONTROL_CHOICES_START + i, choices[i]);
   }
@@ -129,6 +141,11 @@ void CGUIDialogBoxBase::OnInitWindow()
 {
   // set focus to default
   m_lastControlID = m_defaultControl;
+
+  m_hasTextbox = false;
+  const CGUIControl *control = GetControl(CONTROL_TEXTBOX);
+  if (control && control->GetControlType() == CGUIControl::GUICONTROL_TEXTBOX)
+    m_hasTextbox = true;
 
   // set initial labels
   {

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -87,6 +87,18 @@ void CGUIDialogBoxBase::SetLine(unsigned int iLine, const CVariant& line)
   }
 }
 
+void CGUIDialogBoxBase::SetText(const CVariant& text)
+{
+  std::string label = GetLocalized(text);
+  CSingleLock lock(m_section);
+  std::string joined = StringUtils::Join(m_lines, "\n");
+  if (label != joined)
+  {
+    m_lines = StringUtils::Split(label, "\n");
+    SetInvalid();
+  }
+}
+
 void CGUIDialogBoxBase::SetChoice(int iButton, const CVariant &choice) // iButton == 0 for no, 1 for yes
 {
   if (iButton < 0 || iButton >= DIALOG_MAX_CHOICES)

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -161,15 +161,6 @@ void CGUIDialogBoxBase::OnInitWindow()
   // set initial labels
   {
     CSingleLock lock(m_section);
-    if (m_strHeading.empty())
-      m_strHeading = GetDefaultLabel(CONTROL_HEADING);
-
-    m_lines.resize(DIALOG_MAX_LINES);
-    for (size_t i = 0; i < m_lines.size() && i < DIALOG_MAX_LINES ; ++i)
-    {
-      if (m_lines[i].empty())
-        m_lines[i] = GetDefaultLabel(CONTROL_LINES_START + i);
-    }
     for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
     {
       if (m_strChoices[i].empty())

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -22,6 +22,7 @@
 
 #include "guilib/GUIDialog.h"
 #include "utils/Variant.h"
+#include "threads/CriticalSection.h"
 
 #define DIALOG_MAX_LINES 3
 #define DIALOG_MAX_CHOICES 2
@@ -47,12 +48,14 @@ protected:
    */
   CStdString GetLocalized(const CVariant &var) const;
 
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
 
   bool m_bConfirmed;
 
   // actual strings
+  CCriticalSection m_section;
   std::string m_strHeading;
   std::string m_strLines[DIALOG_MAX_LINES];
   std::string m_strChoices[DIALOG_MAX_CHOICES];

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -61,6 +61,6 @@ protected:
   // actual strings
   CCriticalSection m_section;
   std::string m_strHeading;
-  std::vector<std::string> m_lines;
+  std::string m_text;
   std::string m_strChoices[DIALOG_MAX_CHOICES];
 };

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -38,6 +38,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   bool IsConfirmed() const;
   void SetLine(unsigned int iLine, const CVariant &line);
+  void SetText(const CVariant &text);
   void SetHeading(const CVariant &heading);
   void SetChoice(int iButton, const CVariant &choice);
 protected:

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -53,6 +53,7 @@ protected:
   virtual void OnDeinitWindow(int nextWindowID);
 
   bool m_bConfirmed;
+  bool m_hasTextbox;
 
   // actual strings
   CCriticalSection m_section;

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -20,6 +20,8 @@
  *
  */
 
+#include <vector>
+
 #include "guilib/GUIDialog.h"
 #include "utils/Variant.h"
 #include "threads/CriticalSection.h"
@@ -35,7 +37,7 @@ public:
   virtual ~CGUIDialogBoxBase(void);
   virtual bool OnMessage(CGUIMessage& message);
   bool IsConfirmed() const;
-  void SetLine(int iLine, const CVariant &line);
+  void SetLine(unsigned int iLine, const CVariant &line);
   void SetHeading(const CVariant &heading);
   void SetChoice(int iButton, const CVariant &choice);
 protected:
@@ -58,6 +60,6 @@ protected:
   // actual strings
   CCriticalSection m_section;
   std::string m_strHeading;
-  std::string m_strLines[DIALOG_MAX_LINES];
+  std::vector<std::string> m_lines;
   std::string m_strChoices[DIALOG_MAX_CHOICES];
 };

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -47,6 +47,17 @@ bool CGUIDialogOK::OnMessage(CGUIMessage& message)
 }
 
 // \brief Show CGUIDialogOK dialog, then wait for user to dismiss it.
+void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &text)
+{
+  CGUIDialogOK *dialog = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
+  if (!dialog)
+    return;
+  dialog->SetHeading(heading);
+  dialog->SetText(text);
+  dialog->DoModal();
+}
+
+// \brief Show CGUIDialogOK dialog, then wait for user to dismiss it.
 void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2)
 {
   CGUIDialogOK *dialog = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -29,6 +29,7 @@ public:
   CGUIDialogOK(void);
   virtual ~CGUIDialogOK(void);
   virtual bool OnMessage(CGUIMessage& message);
+  static void ShowAndGetInput(const CVariant &heading, const CVariant &text);
   static void ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2);
 protected:
   virtual int GetDefaultLabelID(int controlId) const;

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -114,26 +114,30 @@ bool CGUIDialogYesNo::ShowAndGetInput(const CStdString& heading, const CStdStrin
   return ShowAndGetInput(heading,line0,line1,line2,bDummy,noLabel,yesLabel);
 }
 
-bool CGUIDialogYesNo::ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2, bool& bCanceled, const CStdString& noLabel, const CStdString& yesLabel)
+bool CGUIDialogYesNo::ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel)
 {
   CGUIDialogYesNo *dialog = (CGUIDialogYesNo *)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!dialog) return false;
   dialog->SetHeading(heading);
-  dialog->SetLine(0, line0);
-  dialog->SetLine(1, line1);
-  dialog->SetLine(2, line2);
+  dialog->SetText(text);
   dialog->m_bCanceled = false;
-  if (!noLabel.IsEmpty())
+  if (!noLabel.empty())
     dialog->SetChoice(0,noLabel);
   else
     dialog->SetChoice(0,106);
-  if (!yesLabel.IsEmpty())
+  if (!yesLabel.empty())
     dialog->SetChoice(1,yesLabel);
   else
     dialog->SetChoice(1,107);
   dialog->DoModal();
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;
+}
+
+bool CGUIDialogYesNo::ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2, bool& bCanceled, const CStdString& noLabel, const CStdString& yesLabel)
+{
+  std::string text = line0 + "\n" + line1 + "\n" + line2;
+  return ShowAndGetInput(heading, text, bCanceled, noLabel, yesLabel);
 }
 
 int CGUIDialogYesNo::GetDefaultLabelID(int controlId) const

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <string>
 #include "GUIDialogBoxBase.h"
 
 class CGUIDialogYesNo :
@@ -35,6 +36,7 @@ public:
   static bool ShowAndGetInput(int heading, int line0, int line1, int line2, bool& bCanceled);
   static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel, int iYesLabel, bool& bCanceled, unsigned int autoCloseTime = 0);
   static bool ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2, const CStdString& noLabel="", const CStdString& yesLabel="");
+  static bool ShowAndGetInput(const std::string& heading, const std::string& text, bool& bCanceled, const std::string& noLabel, const std::string& yesLabel);
   static bool ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2, bool &bCanceled, const CStdString& noLabel="", const CStdString& yesLabel="");
 protected:
   virtual int GetDefaultLabelID(int controlId) const;


### PR DESCRIPTION
This is an alternate implementation to #3416 which gets rid of the silliness of having 3 lines in these dialogs rather than using a textbox.  Note that the functionality to set text directly on these dialogs is currently unused - this simply lays the groundwork.

The most obvious advantage is that we can fully specify the text for dialog rather than splitting it up - this allows much better translation as translators aren't as constrained in terms of the width of the labels or the English splitting.

If a skin has a textbox we'll use it.  If not, it continues to display the first 3 lines.  Obviously we should encourage skinners to adopt this.

Two things need review:
8b8b46a  I've moved the setting of heading/label etc. to use guarded members, and update them in the dialog in Process().  Previously it was done through (thread-safe) UI messages as well as setting unguarded members.  The new implementation is safer, but it does mean a critical section.

7b10532 switches to a single string rather than a vector of lines.  It's a little more cumbersome given we always call these routines currently using SetLine().  This may change later for some dialogs, but not for others (e.g. progress dialog we almost always update one line at a time) so pros 'n cons.

Comments welcome.
