### PR TITLE
[rbp/omxplayer] potential unguarded null pointer when video has no audio

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -4115,7 +4115,11 @@ void COMXPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
   if (index == GetAudioStream())
     info.bitrate = m_omxPlayerAudio.GetAudioBitrate();
   else
-    info.bitrate = m_pDemuxer->GetStreamFromAudioId(index)->iBitRate;
+  {
+    CDemuxStreamAudio* stream = m_pDemuxer->GetStreamFromAudioId(index);
+    if (stream)
+      info.bitrate = stream->iBitRate;
+  }
 
   OMXSelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, index);
   if(s.language.length() > 0)


### PR DESCRIPTION
... (e.g. stills in dvd menu)

Copy of https://github.com/xbmc/xbmc/pull/3566

@Voyager1
Feel free to edit omxplayer code to match changes to dvdplayer (I'll test if you can't) -
OMXPlayer.cpp and DVDPlayer.cpp are almost identical, so copy+paste (and maybe change dvd to omx) will usually do.
