### PR TITLE
fixed: PlayerController only does things related to video

### DIFF
--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -51,345 +51,348 @@ bool CPlayerController::OnAction(const CAction &action)
   const unsigned int MsgTime = 300;
   const unsigned int DisplTime = 2000;
 
-  switch (action.GetID())
+  if (g_application.m_pPlayer->IsPlayingVideo())
   {
-    case ACTION_SHOW_SUBTITLES:
+    switch (action.GetID())
     {
-      if (g_application.m_pPlayer->GetSubtitleCount() == 0)
-        return true;
-
-      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = !CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn;
-      g_application.m_pPlayer->SetSubtitleVisible(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn);
-      CStdString sub, lang;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
+      case ACTION_SHOW_SUBTITLES:
       {
-        SPlayerSubtitleStreamInfo info;
-        g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
-        if (!g_LangCodeExpander.Lookup(lang, info.language))
-          lang = g_localizeStrings.Get(13205); // Unknown
+        if (g_application.m_pPlayer->GetSubtitleCount() == 0)
+          return true;
 
-        if (info.name.length() == 0)
-          sub = lang;
-        else
-          sub.Format("%s - %s", lang.c_str(), info.name.c_str());
-      }
-      else
-        sub = g_localizeStrings.Get(1223);
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                            g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
-      return true;
-    }
-
-    case ACTION_NEXT_SUBTITLE:
-    {
-      if (g_application.m_pPlayer->GetSubtitleCount() == 0)
-        return true;
-
-      if(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream < 0)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = g_application.m_pPlayer->GetSubtitle();
-
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
-      {
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream++;
-        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream >= g_application.m_pPlayer->GetSubtitleCount())
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = !CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn;
+        g_application.m_pPlayer->SetSubtitleVisible(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn);
+        CStdString sub, lang;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
         {
-          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = 0;
-          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
-          g_application.m_pPlayer->SetSubtitleVisible(false);
+          SPlayerSubtitleStreamInfo info;
+          g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
+          if (!g_LangCodeExpander.Lookup(lang, info.language))
+            lang = g_localizeStrings.Get(13205); // Unknown
+
+          if (info.name.length() == 0)
+            sub = lang;
+          else
+            sub.Format("%s - %s", lang.c_str(), info.name.c_str());
         }
-        g_application.m_pPlayer->SetSubtitle(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream);
-      }
-      else
-      {
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = true;
-        g_application.m_pPlayer->SetSubtitleVisible(true);
-      }
-
-      CStdString sub, lang;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
-      {
-        SPlayerSubtitleStreamInfo info;
-        g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
-        if (!g_LangCodeExpander.Lookup(lang, info.language))
-          lang = g_localizeStrings.Get(13205); // Unknown
-
-        if (info.name.length() == 0)
-          sub = lang;
         else
-          sub.Format("%s - %s", lang.c_str(), info.name.c_str());
-      }
-      else
-        sub = g_localizeStrings.Get(1223);
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
-      return true;
-    }
-
-    case ACTION_SUBTITLE_DELAY_MIN:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay -= 0.1f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay < -g_advancedSettings.m_videoSubsDelayRange)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = -g_advancedSettings.m_videoSubsDelayRange;
-      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
-
-      ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
-                                        -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
-                                         g_advancedSettings.m_videoSubsDelayRange);
-      return true;
-    }
-
-    case ACTION_SUBTITLE_DELAY_PLUS:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay += 0.1f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay > g_advancedSettings.m_videoSubsDelayRange)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = g_advancedSettings.m_videoSubsDelayRange;
-      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
-
-      ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
-                                        -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
-                                         g_advancedSettings.m_videoSubsDelayRange);
-      return true;
-    }
-
-    case ACTION_SUBTITLE_DELAY:
-    {
-      ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
-                                        -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
-                                         g_advancedSettings.m_videoSubsDelayRange, true);
-      return true;
-    }
-
-    case ACTION_AUDIO_DELAY:
-    {
-      ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
-                                      -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
-                                       g_advancedSettings.m_videoAudioDelayRange, true);
-      return true;
-    }
-
-    case ACTION_AUDIO_DELAY_MIN:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay -= 0.025f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay < -g_advancedSettings.m_videoAudioDelayRange)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = -g_advancedSettings.m_videoAudioDelayRange;
-      g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
-
-      ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
-                                      -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
-                                       g_advancedSettings.m_videoAudioDelayRange);
-      return true;
-    }
-
-    case ACTION_AUDIO_DELAY_PLUS:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay += 0.025f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay > g_advancedSettings.m_videoAudioDelayRange)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = g_advancedSettings.m_videoAudioDelayRange;
-      g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
-
-      ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
-                                      -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
-                                       g_advancedSettings.m_videoAudioDelayRange);
-      return true;
-    }
-
-    case ACTION_AUDIO_NEXT_LANGUAGE:
-    {
-      if (g_application.m_pPlayer->GetAudioStreamCount() == 1)
+          sub = g_localizeStrings.Get(1223);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
+                                              g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
         return true;
-
-      if(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream < 0)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = g_application.m_pPlayer->GetAudioStream();
-
-      CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream++;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream >= g_application.m_pPlayer->GetAudioStreamCount())
-        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = 0;
-      g_application.m_pPlayer->SetAudioStream(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream);    // Set the audio stream to the one selected
-      CStdString aud;
-      CStdString lan;
-      SPlayerAudioStreamInfo info;
-      g_application.m_pPlayer->GetAudioStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream, info);
-      if (!g_LangCodeExpander.Lookup(lan, info.language))
-        lan = g_localizeStrings.Get(13205); // Unknown
-      if (info.name.empty())
-        aud = lan;
-      else
-        aud.Format("%s - %s", lan.c_str(), info.name.c_str());
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(460), aud, DisplTime, false, MsgTime);
-      return true;
-    }
-
-    case ACTION_ZOOM_IN:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount += 0.01f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount > 2.f)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
-      CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-      g_renderManager.SetViewMode(ViewModeCustom);
-      ShowSlider(action.GetID(), 216, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
-      return true;
-    }
-
-    case ACTION_ZOOM_OUT:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount -= 0.01f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 0.5f;
-      CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-      g_renderManager.SetViewMode(ViewModeCustom);
-      ShowSlider(action.GetID(), 216, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
-      return true;
-    }
-
-    case ACTION_INCREASE_PAR:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio += 0.01f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio > 2.f)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
-      CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-      g_renderManager.SetViewMode(ViewModeCustom);
-      ShowSlider(action.GetID(), 217, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
-      return true;
-    }
-
-    case ACTION_DECREASE_PAR:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio -= 0.01f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio = 0.5f;
-      CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-      g_renderManager.SetViewMode(ViewModeCustom);
-      ShowSlider(action.GetID(), 217, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
-      return true;
-    }
-
-    case ACTION_VSHIFT_UP:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift -= 0.01f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift < -2.0f)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift = -2.0f;
-      CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-      g_renderManager.SetViewMode(ViewModeCustom);
-      ShowSlider(action.GetID(), 225, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
-      return true;
-    }
-
-    case ACTION_VSHIFT_DOWN:
-    {
-      CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift += 0.01f;
-      if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift > 2.0f)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift = 2.0f;
-      CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-      g_renderManager.SetViewMode(ViewModeCustom);
-      ShowSlider(action.GetID(), 225, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
-      return true;
-    }
-
-    case ACTION_SUBTITLE_VSHIFT_UP:
-    {
-      RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
-      int subalign = CSettings::Get().GetInt("subtitles.align");
-      if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
-      {
-        res_info.iSubtitles ++;
-        if (res_info.iSubtitles >= res_info.iHeight)
-          res_info.iSubtitles = res_info.iHeight - 1;
-
-        ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
       }
-      else
-      {
-        res_info.iSubtitles --;
-        if (res_info.iSubtitles < 0)
-          res_info.iSubtitles = 0;
 
-        if (subalign == SUBTITLE_ALIGN_MANUAL)
-          ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+      case ACTION_NEXT_SUBTITLE:
+      {
+        if (g_application.m_pPlayer->GetSubtitleCount() == 0)
+          return true;
+
+        if(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream < 0)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = g_application.m_pPlayer->GetSubtitle();
+
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
+        {
+          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream++;
+          if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream >= g_application.m_pPlayer->GetSubtitleCount())
+          {
+            CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = 0;
+            CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
+            g_application.m_pPlayer->SetSubtitleVisible(false);
+          }
+          g_application.m_pPlayer->SetSubtitle(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream);
+        }
         else
-          ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
-      }
-      g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
-      return true;
-    }
+        {
+          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = true;
+          g_application.m_pPlayer->SetSubtitleVisible(true);
+        }
 
-    case ACTION_SUBTITLE_VSHIFT_DOWN:
-    {
-      RESOLUTION_INFO res_info =  g_graphicsContext.GetResInfo();
-      int subalign = CSettings::Get().GetInt("subtitles.align");
-      if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
-      {
-        res_info.iSubtitles--;
-        if (res_info.iSubtitles < 0)
-          res_info.iSubtitles = 0;
+        CStdString sub, lang;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
+        {
+          SPlayerSubtitleStreamInfo info;
+          g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
+          if (!g_LangCodeExpander.Lookup(lang, info.language))
+            lang = g_localizeStrings.Get(13205); // Unknown
 
-        ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
-      }
-      else
-      {
-        res_info.iSubtitles++;
-        if (res_info.iSubtitles >= res_info.iHeight)
-          res_info.iSubtitles = res_info.iHeight - 1;
-
-        if (subalign == SUBTITLE_ALIGN_MANUAL)
-          ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+          if (info.name.length() == 0)
+            sub = lang;
+          else
+            sub.Format("%s - %s", lang.c_str(), info.name.c_str());
+        }
         else
-          ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
+          sub = g_localizeStrings.Get(1223);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+        return true;
       }
-      g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
-      return true;
-    }
 
-    case ACTION_SUBTITLE_ALIGN:
-    {
-      RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
-      int subalign = CSettings::Get().GetInt("subtitles.align");
-
-      subalign++;
-      if (subalign > SUBTITLE_ALIGN_TOP_OUTSIDE)
-        subalign = SUBTITLE_ALIGN_MANUAL;
-
-      res_info.iSubtitles = res_info.iHeight - 1;
-
-      CSettings::Get().SetInt("subtitles.align", subalign);
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                            g_localizeStrings.Get(21460),
-                                            g_localizeStrings.Get(21461 + subalign), 
-                                            TOAST_DISPLAY_TIME, false);
-      g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
-      return true;
-    }
-
-    case ACTION_VOLAMP_UP:
-    case ACTION_VOLAMP_DOWN:
-    {
-      // Don't allow change with passthrough audio
-      if (g_application.m_pPlayer->IsPassthrough())
+      case ACTION_SUBTITLE_DELAY_MIN:
       {
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
-                                              g_localizeStrings.Get(660),
-                                              g_localizeStrings.Get(29802),
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay -= 0.1f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay < -g_advancedSettings.m_videoSubsDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = -g_advancedSettings.m_videoSubsDelayRange;
+        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
+
+        ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
+                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
+                                           g_advancedSettings.m_videoSubsDelayRange);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_DELAY_PLUS:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay += 0.1f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay > g_advancedSettings.m_videoSubsDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = g_advancedSettings.m_videoSubsDelayRange;
+        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
+
+        ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
+                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
+                                           g_advancedSettings.m_videoSubsDelayRange);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_DELAY:
+      {
+        ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
+                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
+                                           g_advancedSettings.m_videoSubsDelayRange, true);
+        return true;
+      }
+
+      case ACTION_AUDIO_DELAY:
+      {
+        ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
+                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
+                                         g_advancedSettings.m_videoAudioDelayRange, true);
+        return true;
+      }
+
+      case ACTION_AUDIO_DELAY_MIN:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay -= 0.025f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay < -g_advancedSettings.m_videoAudioDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = -g_advancedSettings.m_videoAudioDelayRange;
+        g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
+
+        ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
+                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
+                                         g_advancedSettings.m_videoAudioDelayRange);
+        return true;
+      }
+
+      case ACTION_AUDIO_DELAY_PLUS:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay += 0.025f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay > g_advancedSettings.m_videoAudioDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = g_advancedSettings.m_videoAudioDelayRange;
+        g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
+
+        ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
+                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
+                                         g_advancedSettings.m_videoAudioDelayRange);
+        return true;
+      }
+
+      case ACTION_AUDIO_NEXT_LANGUAGE:
+      {
+        if (g_application.m_pPlayer->GetAudioStreamCount() == 1)
+          return true;
+
+        if(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream < 0)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = g_application.m_pPlayer->GetAudioStream();
+
+        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream++;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream >= g_application.m_pPlayer->GetAudioStreamCount())
+          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = 0;
+        g_application.m_pPlayer->SetAudioStream(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream);    // Set the audio stream to the one selected
+        CStdString aud;
+        CStdString lan;
+        SPlayerAudioStreamInfo info;
+        g_application.m_pPlayer->GetAudioStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream, info);
+        if (!g_LangCodeExpander.Lookup(lan, info.language))
+          lan = g_localizeStrings.Get(13205); // Unknown
+        if (info.name.empty())
+          aud = lan;
+        else
+          aud.Format("%s - %s", lan.c_str(), info.name.c_str());
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(460), aud, DisplTime, false, MsgTime);
+        return true;
+      }
+
+      case ACTION_ZOOM_IN:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount += 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount > 2.f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_renderManager.SetViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 216, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_ZOOM_OUT:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount -= 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 0.5f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_renderManager.SetViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 216, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_INCREASE_PAR:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio += 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio > 2.f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_renderManager.SetViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 217, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_DECREASE_PAR:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio -= 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio = 0.5f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_renderManager.SetViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 217, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_VSHIFT_UP:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift -= 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift < -2.0f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift = -2.0f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_renderManager.SetViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 225, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_VSHIFT_DOWN:
+      {
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift += 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift > 2.0f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift = 2.0f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_renderManager.SetViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 225, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_VSHIFT_UP:
+      {
+        RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
+        int subalign = CSettings::Get().GetInt("subtitles.align");
+        if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
+        {
+          res_info.iSubtitles ++;
+          if (res_info.iSubtitles >= res_info.iHeight)
+            res_info.iSubtitles = res_info.iHeight - 1;
+
+          ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+        }
+        else
+        {
+          res_info.iSubtitles --;
+          if (res_info.iSubtitles < 0)
+            res_info.iSubtitles = 0;
+
+          if (subalign == SUBTITLE_ALIGN_MANUAL)
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+          else
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
+        }
+        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_VSHIFT_DOWN:
+      {
+        RESOLUTION_INFO res_info =  g_graphicsContext.GetResInfo();
+        int subalign = CSettings::Get().GetInt("subtitles.align");
+        if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
+        {
+          res_info.iSubtitles--;
+          if (res_info.iSubtitles < 0)
+            res_info.iSubtitles = 0;
+
+          ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+        }
+        else
+        {
+          res_info.iSubtitles++;
+          if (res_info.iSubtitles >= res_info.iHeight)
+            res_info.iSubtitles = res_info.iHeight - 1;
+
+          if (subalign == SUBTITLE_ALIGN_MANUAL)
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+          else
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
+        }
+        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_ALIGN:
+      {
+        RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
+        int subalign = CSettings::Get().GetInt("subtitles.align");
+
+        subalign++;
+        if (subalign > SUBTITLE_ALIGN_TOP_OUTSIDE)
+          subalign = SUBTITLE_ALIGN_MANUAL;
+
+        res_info.iSubtitles = res_info.iHeight - 1;
+
+        CSettings::Get().SetInt("subtitles.align", subalign);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
+                                              g_localizeStrings.Get(21460),
+                                              g_localizeStrings.Get(21461 + subalign), 
                                               TOAST_DISPLAY_TIME, false);
-        return false;
+        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
+        return true;
       }
 
-      float sliderMax = VOLUME_DRC_MAXIMUM / 100.0f;
-      float sliderMin = VOLUME_DRC_MINIMUM / 100.0f;
+      case ACTION_VOLAMP_UP:
+      case ACTION_VOLAMP_DOWN:
+      {
+        // Don't allow change with passthrough audio
+        if (g_application.m_pPlayer->IsPassthrough())
+        {
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
+                                                g_localizeStrings.Get(660),
+                                                g_localizeStrings.Get(29802),
+                                                TOAST_DISPLAY_TIME, false);
+          return false;
+        }
 
-      if (action.GetID() == ACTION_VOLAMP_UP)
-        CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification += 1.0f;
-      else
-        CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification -= 1.0f;
+        float sliderMax = VOLUME_DRC_MAXIMUM / 100.0f;
+        float sliderMin = VOLUME_DRC_MINIMUM / 100.0f;
 
-      CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification =
-        std::max(std::min(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, sliderMax), sliderMin);
+        if (action.GetID() == ACTION_VOLAMP_UP)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification += 1.0f;
+        else
+          CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification -= 1.0f;
 
-      g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification * 100));
+        CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification =
+          std::max(std::min(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, sliderMax), sliderMin);
 
-      ShowSlider(action.GetID(), 660, CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, sliderMin, 1.0f, sliderMax);
-      return true;
+        g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification * 100));
+
+        ShowSlider(action.GetID(), 660, CMediaSettings::Get().GetCurrentVideoSettings().m_VolumeAmplification, sliderMin, 1.0f, sliderMax);
+        return true;
+      }
+
+      default:
+        break;
     }
-
-    default:
-      break;
   }
   return false;
 }


### PR DESCRIPTION
Currently we also try to handle actions in the playercontroller when not playing video which doesn't make much sense as all the actions in there are only video-related.
