### PR TITLE
settings: lists

### DIFF
--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -246,6 +246,302 @@ void CSetting::Copy(const CSetting &setting)
   m_updates = setting.m_updates;
   m_changed = setting.m_changed;
 }
+
+CSettingList::CSettingList(const std::string &id, CSetting *settingDefinition, CSettingsManager *settingsManager /* = NULL */)
+  : CSetting(id, settingsManager),
+    m_definition(settingDefinition),
+    m_delimiter("|"),
+    m_minimum(0), m_maximum(-1)
+{ }
+
+CSettingList::CSettingList(const std::string &id, const CSettingList &setting)
+  : CSetting(id, setting),
+    m_definition(NULL),
+    m_delimiter("|"),
+    m_minimum(0), m_maximum(-1)
+{
+  copy(setting);
+}
+
+CSettingList::~CSettingList()
+{
+  m_values.clear();
+  m_defaults.clear();
+  delete m_definition;
+}
+
+CSetting* CSettingList::Clone(const std::string &id) const
+{
+  if (m_definition == NULL)
+    return NULL;
+
+  return new CSettingList(id, *this);
+}
+
+bool CSettingList::Deserialize(const TiXmlNode *node, bool update /* = false */)
+{
+  CExclusiveLock lock(m_critical);
+
+  if (m_definition == NULL)
+    return false;
+
+  if (!CSetting::Deserialize(node, update))
+    return false;
+
+  const TiXmlElement *element = node->ToElement();
+  if (element == NULL)
+  {
+    CLog::Log(LOGWARNING, "CSettingList: unable to read type of list setting of %s", m_id.c_str());
+    return false;
+  }
+
+  if (!m_definition->Deserialize(node, update))
+    return false;
+
+  const TiXmlNode *constraints = node->FirstChild(SETTING_XML_ELM_CONSTRAINTS);
+  if (constraints != NULL)
+  {
+    // read the delimiter
+    std::string delimiter;
+    if (XMLUtils::GetString(constraints, SETTING_XML_ELM_DELIMITER, delimiter) && !delimiter.empty())
+      m_delimiter = delimiter;
+
+    XMLUtils::GetInt(constraints, SETTING_XML_ELM_MINIMUM, m_minimum);
+    if (m_minimum < 0)
+      m_minimum = 0;
+    XMLUtils::GetInt(constraints, SETTING_XML_ELM_MAXIMUM, m_maximum);
+    if (m_maximum <= 0)
+      m_maximum = -1;
+    else if (m_maximum < m_minimum)
+    {
+      CLog::Log(LOGWARNING, "CSettingList: invalid <minimum> (%d) and/or <maximum> (%d) of %s", m_minimum, m_maximum, m_id.c_str());
+      return false;
+    }
+  }
+
+  // read the default and initial values
+  std::string values;
+  if (XMLUtils::GetString(node, SETTING_XML_ELM_DEFAULT, values))
+  {
+    if (!fromString(values, m_defaults))
+    {
+      CLog::Log(LOGWARNING, "CSettingList: invalid <default> definition \"%s\" of %s", values.c_str(), m_id.c_str());
+      return false;
+    }
+    Reset();
+  }
+
+  return true;
+}
+
+int CSettingList::GetElementType() const
+{
+  CSharedLock lock(m_critical);
+  
+  if (m_definition == NULL)
+    return SettingTypeNone;
+
+  return m_definition->GetType();
+}
+
+bool CSettingList::FromString(const std::string &value)
+{
+  SettingPtrList values;
+  if (!fromString(value, values))
+    return false;
+
+  return SetValue(values);
+}
+
+std::string CSettingList::ToString() const
+{
+  return toString(m_values);
+}
+
+bool CSettingList::Equals(const std::string &value) const
+{
+  SettingPtrList values;
+  if (!fromString(value, values) ||
+      values.size() != m_values.size())
+    return false;
+
+  bool ret = true;
+  for (size_t index = 0; index < values.size(); index++)
+  {
+    if (!m_values[index]->Equals(values[index]->ToString()))
+    {
+      ret = false;
+      break;
+    }
+  }
+
+  return ret;
+}
+
+bool CSettingList::CheckValidity(const std::string &value) const
+{
+  SettingPtrList values;
+  return fromString(value, values);
+}
+
+void CSettingList::Reset()
+{
+  CExclusiveLock lock(m_critical);
+  SettingPtrList values;
+  for (SettingPtrList::const_iterator it = m_defaults.begin(); it != m_defaults.end(); ++it)
+    values.push_back(SettingPtr((*it)->Clone((*it)->GetId())));
+
+  SetValue(values);
+}
+
+bool CSettingList::FromString(const std::vector<std::string> &value)
+{
+  SettingPtrList values;
+  if (!fromValues(value, values))
+    return false;
+
+  return SetValue(values);
+}
+
+bool CSettingList::SetValue(const SettingPtrList &values)
+{
+  CExclusiveLock lock(m_critical);
+
+  if ((int)values.size() < m_minimum ||
+     (m_maximum > 0 && (int)values.size() > m_maximum))
+    return false;
+
+  bool equal = values.size() == m_values.size();
+  for (size_t index = 0; index < values.size(); index++)
+  {
+    if (values[index]->GetType() != GetElementType())
+      return false;
+
+    if (equal &&
+        !values[index]->Equals(m_values[index]->ToString()))
+      equal = false;
+  }
+
+  if (equal)
+    return true;
+
+  SettingPtrList oldValues = m_values;
+  m_values.clear();
+  m_values.insert(m_values.begin(), values.begin(), values.end());
+
+  if (!OnSettingChanging(this))
+  {
+    m_values = oldValues;
+
+    // the setting couldn't be changed because one of the
+    // callback handlers failed the OnSettingChanging()
+    // callback so we need to let all the callback handlers
+    // know that the setting hasn't changed
+    OnSettingChanging(this);
+    return false;
+  }
+
+  m_changed = (toString(m_values) == toString(m_defaults));
+  OnSettingChanged(this);
+  return true;
+}
+
+void CSettingList::SetDefault(const SettingPtrList &values)
+{
+  CExclusiveLock lock(m_critical);
+
+  m_defaults.clear();
+  m_defaults.insert(m_defaults.begin(), values.begin(), values.end());
+
+  if (!m_changed)
+  {
+    m_values.clear();
+    for (SettingPtrList::const_iterator it = m_defaults.begin(); it != m_defaults.end(); ++it)
+      m_values.push_back(SettingPtr((*it)->Clone((*it)->GetId())));
+  }
+}
+
+void CSettingList::copy(const CSettingList &setting)
+{
+  CSetting::Copy(setting);
+
+  copy(setting.m_values, m_values);
+  copy(setting.m_defaults, m_defaults);
+  
+  if (setting.m_definition != NULL)
+  {
+    CSetting *definitionCopy = setting.m_definition->Clone(m_id + ".definition");
+    if (definitionCopy != NULL)
+      m_definition = definitionCopy;
+  }
+
+  m_delimiter = setting.m_delimiter;
+  m_minimum = setting.m_minimum;
+  m_maximum = setting.m_maximum;
+}
+
+void CSettingList::copy(const SettingPtrList &srcValues, SettingPtrList &dstValues)
+{
+  dstValues.clear();
+
+  for (SettingPtrList::const_iterator itValue = srcValues.begin(); itValue != srcValues.end(); ++itValue)
+  {
+    if (*itValue == NULL)
+      continue;
+
+    CSetting *valueCopy = (*itValue)->Clone((*itValue)->GetId());
+    if (valueCopy == NULL)
+      continue;
+
+    dstValues.push_back(SettingPtr(valueCopy));
+  }
+}
+
+bool CSettingList::fromString(const std::string &strValue, SettingPtrList &values) const
+{
+  std::vector<std::string> strValues = StringUtils::Split(strValue, m_delimiter);
+  return fromValues(strValues, values);
+}
+
+bool CSettingList::fromValues(const std::vector<std::string> &strValues, SettingPtrList &values) const
+{
+  if ((int)strValues.size() < m_minimum ||
+     (m_maximum > 0 && (int)strValues.size() > m_maximum))
+    return false;
+
+  bool ret = true;
+  int index = 0;
+  for (std::vector<std::string>::const_iterator itValue = strValues.begin(); itValue != strValues.end(); ++itValue)
+  {
+    CSetting *settingValue = m_definition->Clone(StringUtils::Format("%s.%d", m_id.c_str(), index++));
+    if (settingValue == NULL ||
+        !settingValue->FromString(*itValue))
+    {
+      delete settingValue;
+      ret = false;
+      break;
+    }
+
+    values.push_back(SettingPtr(settingValue));
+  }
+
+  if (!ret)
+    values.clear();
+
+  return ret;
+}
+
+std::string CSettingList::toString(const SettingPtrList &values) const
+{
+  std::vector<std::string> strValues;
+  for (SettingPtrList::const_iterator it = values.begin(); it != values.end(); ++it)
+  {
+    if (*it != NULL)
+      strValues.push_back((*it)->ToString());
+  }
+
+  return StringUtils::Join(strValues, m_delimiter);
+}
   
 CSettingBool::CSettingBool(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : CSetting(id, settingsManager),

--- a/xbmc/settings/Setting.cpp
+++ b/xbmc/settings/Setting.cpp
@@ -265,6 +265,11 @@ CSettingBool::CSettingBool(const std::string &id, int label, bool value, CSettin
   m_label = label;
 }
 
+CSetting* CSettingBool::Clone(const std::string &id) const
+{
+  return new CSettingBool(id, *this);
+}
+
 bool CSettingBool::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);
@@ -398,6 +403,11 @@ CSettingInt::CSettingInt(const std::string &id, int label, int value, const Stat
     m_options(options)
 {
   m_label = label;
+}
+
+CSetting* CSettingInt::Clone(const std::string &id) const
+{
+  return new CSettingInt(id, *this);
 }
 
 bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
@@ -650,6 +660,11 @@ CSettingNumber::CSettingNumber(const std::string &id, int label, float value, fl
   m_label = label;
 }
 
+CSetting* CSettingNumber::Clone(const std::string &id) const
+{
+  return new CSettingNumber(id, *this);
+}
+
 bool CSettingNumber::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);
@@ -807,6 +822,11 @@ CSettingString::CSettingString(const std::string &id, int label, const std::stri
   m_label = label;
 }
 
+CSetting* CSettingString::Clone(const std::string &id) const
+{
+  return new CSettingString(id, *this);
+}
+
 bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);
@@ -955,6 +975,11 @@ CSettingAction::CSettingAction(const std::string &id, CSettingsManager *settings
 CSettingAction::CSettingAction(const std::string &id, const CSettingAction &setting)
   : CSetting(id, setting)
 { }
+
+CSetting* CSettingAction::Clone(const std::string &id) const
+{
+  return new CSettingAction(id, *this);
+}
 
 bool CSettingAction::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -82,6 +82,8 @@ public:
   CSetting(const std::string &id, const CSetting &setting);
   virtual ~CSetting();
 
+  virtual CSetting* Clone(const std::string &id) const = 0;
+
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 
   virtual int GetType() const = 0;
@@ -144,6 +146,8 @@ public:
   CSettingBool(const std::string &id, int label, bool value, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingBool() { }
 
+  virtual CSetting* Clone(const std::string &id) const;
+
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 
   virtual int GetType() const { return SettingTypeBool; }
@@ -179,6 +183,8 @@ public:
   CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, CSettingsManager *settingsManager = NULL);
   CSettingInt(const std::string &id, int label, int value, const StaticIntegerSettingOptions &options, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingInt() { }
+
+  virtual CSetting* Clone(const std::string &id) const;
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 
@@ -231,6 +237,8 @@ public:
   CSettingNumber(const std::string &id, int label, float value, float minimum, float step, float maximum, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingNumber() { }
 
+  virtual CSetting* Clone(const std::string &id) const;
+
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 
   virtual int GetType() const { return SettingTypeNumber; }
@@ -273,6 +281,8 @@ public:
   CSettingString(const std::string &id, const CSettingString &setting);
   CSettingString(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = NULL);
   virtual ~CSettingString() { }
+
+  virtual CSetting* Clone(const std::string &id) const;
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 
@@ -319,6 +329,8 @@ public:
   CSettingAction(const std::string &id, CSettingsManager *settingsManager = NULL);
   CSettingAction(const std::string &id, const CSettingAction &setting);
   virtual ~CSettingAction() { }
+
+  virtual CSetting* Clone(const std::string &id) const;
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 

--- a/xbmc/settings/Setting.h
+++ b/xbmc/settings/Setting.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/shared_ptr.hpp>
+
 #include "ISetting.h"
 #include "ISettingCallback.h"
 #include "ISettingControl.h"
@@ -41,7 +43,8 @@ typedef enum {
   SettingTypeInteger,
   SettingTypeNumber,
   SettingTypeString,
-  SettingTypeAction
+  SettingTypeAction,
+  SettingTypeList
 } SettingType;
 
 /*!
@@ -131,7 +134,58 @@ protected:
   CSharedSection m_critical;
 };
 
+typedef boost::shared_ptr<CSetting> SettingPtr;
+
 typedef std::vector<CSetting *> SettingList;
+typedef std::vector<SettingPtr> SettingPtrList;
+
+/*!
+ \ingroup settings
+ \brief List setting implementation
+ \sa CSetting
+ */
+class CSettingList : public CSetting
+{
+public:
+  CSettingList(const std::string &id, CSetting *settingDefinition, CSettingsManager *settingsManager = NULL);
+  CSettingList(const std::string &id, const CSettingList &setting);
+  virtual ~CSettingList();
+
+  virtual CSetting* Clone(const std::string &id) const;
+
+  virtual bool Deserialize(const TiXmlNode *node, bool update = false);
+
+  virtual int GetType() const { return SettingTypeList; }
+  virtual bool FromString(const std::string &value);
+  virtual std::string ToString() const;
+  virtual bool Equals(const std::string &value) const;
+  virtual bool CheckValidity(const std::string &value) const;
+  virtual void Reset();
+  
+  int GetElementType() const;
+  const CSetting* GetDefinition() const { return m_definition; }
+  
+  bool FromString(const std::vector<std::string> &value);
+
+  const SettingPtrList& GetValue() const { return m_values; }
+  bool SetValue(const SettingPtrList &values);
+  const SettingPtrList& GetDefault() const { return m_defaults; }
+  void SetDefault(const SettingPtrList &values);
+
+protected:
+  void copy(const CSettingList &setting);
+  static void copy(const SettingPtrList &srcValues, SettingPtrList &dstValues);
+  bool fromString(const std::string &strValue, SettingPtrList &values) const;
+  bool fromValues(const std::vector<std::string> &strValues, SettingPtrList &values) const;
+  std::string toString(const SettingPtrList &values) const;
+
+  SettingPtrList m_values;
+  SettingPtrList m_defaults;
+  CSetting *m_definition;
+  std::string m_delimiter;
+  int m_minimum;
+  int m_maximum;
+};
 
 /*!
  \ingroup settings

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -38,6 +38,11 @@ CSettingAddon::CSettingAddon(const std::string &id, const CSettingAddon &setting
   copy(setting);
 }
 
+CSetting* CSettingAddon::Clone(const std::string &id) const
+{
+  return new CSettingAddon(id, *this);
+}
+
 bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);

--- a/xbmc/settings/SettingAddon.h
+++ b/xbmc/settings/SettingAddon.h
@@ -29,6 +29,8 @@ public:
   CSettingAddon(const std::string &id, const CSettingAddon &setting);
   virtual ~CSettingAddon() { }
 
+  virtual CSetting* Clone(const std::string &id) const;
+
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
 
   ADDON::TYPE GetAddonType() const { return m_addonType; }

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -146,6 +146,7 @@ bool CSettingControlList::Deserialize(const TiXmlNode *node, bool update /* = fa
     return false;
   
   XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
+  XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_MULTISELECT, m_multiselect);
 
   return true;
 }

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -26,6 +26,7 @@
 #define SETTING_XML_ELM_CONTROL_VERIFYNEW    "verifynew"
 #define SETTING_XML_ELM_CONTROL_HEADING      "heading"
 #define SETTING_XML_ELM_CONTROL_HIDEVALUE    "hidevalue"
+#define SETTING_XML_ELM_CONTROL_MULTISELECT  "multiselect"
 
 class CSettingControlCheckmark : public ISettingControl
 {
@@ -134,9 +135,11 @@ public:
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
   
   int GetHeading() const { return m_heading; }
+  bool CanMultiSelect() const { return m_multiselect; }
 
 protected:
   virtual bool SetFormat(const std::string &format);
   
   int m_heading;
+  bool m_multiselect;
 };

--- a/xbmc/settings/SettingDefinitions.h
+++ b/xbmc/settings/SettingDefinitions.h
@@ -44,6 +44,7 @@
 #define SETTING_XML_ELM_UPDATES       "updates"
 #define SETTING_XML_ELM_UPDATE        "update"
 #define SETTING_XML_ELM_ACCESS        "access"
+#define SETTING_XML_ELM_DELIMITER     "delimiter"
 
 #define SETTING_XML_ATTR_ID           "id"
 #define SETTING_XML_ATTR_LABEL        "label"

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -39,6 +39,11 @@ CSettingPath::CSettingPath(const std::string &id, const CSettingPath &setting)
   copy(setting);
 }
 
+CSetting* CSettingPath::Clone(const std::string &id) const
+{
+  return new CSettingPath(id, *this);
+}
+
 bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -30,6 +30,8 @@ public:
   CSettingPath(const std::string &id, const CSettingPath &setting);
   virtual ~CSettingPath() { }
 
+  virtual CSetting* Clone(const std::string &id) const;
+
   virtual bool Deserialize(const TiXmlNode *node, bool update = false);
   virtual bool SetValue(const std::string &value);
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -26,6 +26,7 @@
 #include "settings/ISettingControlCreator.h"
 #include "settings/ISettingCreator.h"
 #include "threads/CriticalSection.h"
+#include "utils/Variant.h"
 
 class CSetting;
 class CSettingSection;
@@ -185,6 +186,13 @@ public:
    \return String value of the setting with the given identifier
    */
   std::string GetString(const std::string &id) const;
+  /*!
+   \brief Gets the values of the list setting with the given identifier.
+
+   \param id Setting identifier
+   \return List of values of the setting with the given identifier
+   */
+  std::vector<CVariant> GetList(const std::string &id) const;
 
   /*!
    \brief Sets the boolean value of the setting with the given identifier.
@@ -225,6 +233,14 @@ public:
    \return True if setting the value was successful, false otherwise
    */
   bool SetString(const std::string &id, const std::string &value);
+  /*!
+   \brief Sets the values of the list setting with the given identifier.
+
+   \param id Setting identifier
+   \param value Values to set
+   \return True if setting the values was successful, false otherwise
+   */
+  bool SetList(const std::string &id, const std::vector<CVariant> &value);
 
   /*!
    \brief Loads the setting being represented by the given XML node with the

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -778,15 +778,24 @@ void CSettingsManager::OnSettingPropertyChanged(const CSetting *setting, const c
 CSetting* CSettingsManager::CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager /* = NULL */) const
 {
   if (StringUtils::EqualsNoCase(settingType, "boolean"))
-    return new CSettingBool(settingId, (CSettingsManager*)this);
+    return new CSettingBool(settingId, const_cast<CSettingsManager*>(this));
   else if (StringUtils::EqualsNoCase(settingType, "integer"))
-    return new CSettingInt(settingId, (CSettingsManager*)this);
+    return new CSettingInt(settingId, const_cast<CSettingsManager*>(this));
   else if (StringUtils::EqualsNoCase(settingType, "number"))
-    return new CSettingNumber(settingId, (CSettingsManager*)this);
+    return new CSettingNumber(settingId, const_cast<CSettingsManager*>(this));
   else if (StringUtils::EqualsNoCase(settingType, "string"))
-    return new CSettingString(settingId, (CSettingsManager*)this);
+    return new CSettingString(settingId, const_cast<CSettingsManager*>(this));
   else if (StringUtils::EqualsNoCase(settingType, "action"))
-    return new CSettingAction(settingId, (CSettingsManager*)this);
+    return new CSettingAction(settingId, const_cast<CSettingsManager*>(this));
+  else if (settingType.size() > 6 &&
+           StringUtils::StartsWith(settingType, "list[") &&
+           StringUtils::EndsWith(settingType, "]"))
+  {
+    std::string elementType = StringUtils::Mid(settingType, 5, settingType.size() - 6);
+    CSetting *elementSetting = CreateSetting(elementType, settingId + ".definition", const_cast<CSettingsManager*>(this));
+    if (elementSetting != NULL)
+      return new CSettingList(settingId, elementSetting, const_cast<CSettingsManager*>(this));
+  }
 
   CSharedLock lock(m_critical);
   SettingCreatorMap::const_iterator creator = m_settingCreators.find(settingType);

--- a/xbmc/settings/SettingsManager.cpp
+++ b/xbmc/settings/SettingsManager.cpp
@@ -575,6 +575,26 @@ bool CSettingsManager::SetString(const std::string &id, const std::string &value
   return ((CSettingString*)setting)->SetValue(value);
 }
 
+std::vector< boost::shared_ptr<CSetting> > CSettingsManager::GetList(const std::string &id) const
+{
+  CSharedLock lock(m_settingsCritical);
+  CSetting *setting = GetSetting(id);
+  if (setting == NULL || setting->GetType() != SettingTypeList)
+    return std::vector< boost::shared_ptr<CSetting> >();
+
+  return ((CSettingList*)setting)->GetValue();
+}
+
+bool CSettingsManager::SetList(const std::string &id, const std::vector< boost::shared_ptr<CSetting> > &value)
+{
+  CSharedLock lock(m_settingsCritical);
+  CSetting *setting = GetSetting(id);
+  if (setting == NULL || setting->GetType() != SettingTypeList)
+    return false;
+
+  return ((CSettingList*)setting)->SetValue(value);
+}
+
 void CSettingsManager::AddCondition(const std::string &condition)
 {
   CExclusiveLock lock(m_critical);

--- a/xbmc/settings/SettingsManager.h
+++ b/xbmc/settings/SettingsManager.h
@@ -294,6 +294,13 @@ public:
    \return String value of the setting with the given identifier
    */
   std::string GetString(const std::string &id) const;
+  /*!
+   \brief Gets the values of the list setting with the given identifier.
+
+   \param id Setting identifier
+   \return List of values of the setting with the given identifier
+   */
+  std::vector< boost::shared_ptr<CSetting> > GetList(const std::string &id) const;
 
   /*!
    \brief Sets the boolean value of the setting with the given identifier.
@@ -334,6 +341,14 @@ public:
    \return True if setting the value was successful, false otherwise
    */
   bool SetString(const std::string &id, const std::string &value);
+  /*!
+   \brief Sets the values of the list setting with the given identifier.
+
+   \param id Setting identifier
+   \param value Values to set
+   \return True if setting the values was successful, false otherwise
+   */
+  bool SetList(const std::string &id, const std::vector< boost::shared_ptr<CSetting> > &value);
 
   /*!
    \brief Gets the setting conditions manager used by the settings manager.

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -124,8 +124,9 @@ public:
   virtual void Update();
   virtual void Clear() { m_pButton = NULL; }
 private:
-  static bool GetItems(CSetting *setting, CFileItemList &items);
-  static bool GetIntegerItems(CSetting *setting, CFileItemList &items);
+  static bool GetItems(const CSetting *setting, CFileItemList &items);
+  static bool GetIntegerItems(const CSetting *setting, CFileItemList &items);
+  static bool GetStringItems(const CSetting *setting, CFileItemList &items);
 
   CGUIButtonControl *m_pButton;
 };


### PR DESCRIPTION
This is a more generic approach at setting list types than #3436 which is special cased for string lists. It adds a new setting type implementation CSettingList and can represent a list containing any of the existing setting types. In the XML definition the type is defined as

```
type="list[string]"
```

and it is possible to use all the tags from the element type and in addition it is possible to specify a delimiter. The settings values are stored as a single string using the specified delimiter.

There are a few things I don't particularly like about this implementation but neither @jmarshallnz nor me had any better ideas:
- GetValue() and SetValue() operate on a vector of CSetting pointers which doesn't make them very convenient.
- GetValues() and SetValues(), the more convenient versions of GetValue() and SetValue() operate on a vector of CVariant objects which is an XBMC-specific class. Same goes for CSettingsManager/CSettings::GetList()/SetList()
- The user is able to choose less/more items in the multiselect dialog than is supported by the actual setting. Closing the dialog with an invalid selection will simply revert the value of the setting without any feedback.

The last of these points can certainly be improved but I'm out of ideas for the first two. The second actually is an improvement for the first but it's not ideal either.
