### PR TITLE
"Now playling..." fix

### DIFF
--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -30,8 +30,8 @@
 		<value condition="IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="PlayList">
-		<value condition="Player.HasVideo">ActivateWindow(videoplaylist)</value>
-		<value condition="Player.HasAudio">ActivateWindow(musicplaylist)</value>
+		<value condition="Window.IsActive(videolibrary) + !StringCompare(Playlist.Length(video),0)">ActivateWindow(videoplaylist)</value>
+		<value condition="[Window.IsActive(musiclibrary) | Window.IsActive(musicfiles)] + !StringCompare(Playlist.Length(music),0)">ActivateWindow(musicplaylist)</value>
 	</variable>
 
 	<include name="BehindDialogFadeOut">
@@ -896,8 +896,7 @@
 			<include>ButtonCommonValues</include>
 			<label>13350</label>
 			<onclick>$VAR[PlayList]</onclick>
-			<visible>Player.HasMedia</visible>
-			<visible>!VideoPlayer.Content(LiveTV)</visible>
+			<visible>[Window.IsActive(videolibrary) + !StringCompare(Playlist.Length(video),0)] | [[Window.IsActive(musiclibrary) | Window.IsActive(musicfiles)] + !StringCompare(Playlist.Length(music),0)]</visible>
 			<visible>!Window.IsVisible(MusicPlaylist) + !Window.IsVisible(VideoPlaylist)</visible>
 		</control>
 	</include>

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -775,7 +775,7 @@ public:
   CStdString GetMusicLabel(int item);
   CStdString GetMusicTagLabel(int info, const CFileItem *item);
   CStdString GetVideoLabel(int item);
-  CStdString GetPlaylistLabel(int item) const;
+  CStdString GetPlaylistLabel(int item, int playlistid = -1 /* PLAYLIST_NONE */) const;
   CStdString GetMusicPartyModeLabel(int item);
   const CStdString GetMusicPlaylistInfo(const GUIInfo& info);
   CStdString GetPictureLabel(int item);


### PR DESCRIPTION
This is an attempt at a fix for the "Now playing..." button only showing in the confluence sidebar when something is playing. As pointed out by @NedScott and others it should also show when nothing is playing but the playlist isn't empty.

Because it wasn't possible to access a specific playlist through the info manager I extended the Playlist.Foo info labels/bools to be able to take a parameter, e.g.

```
Playlist.Length(video)
```

where the parameter can either not be specified, or be "video" or "music". If nothing is specified the currently playling playlist is used. Otherwise the specified playlist is used.

Since this is my first time really hacking around in CGUIInfoManager I appreciate any feedback. Same goes for the skinning changes as the visibility conditions look pretty ugly now but I couldn't find another way to access that information.
