### PR TITLE
fix: Use replaygain tags for .m4a type family files too, closes Ticket #13948 

### DIFF
--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -126,18 +126,14 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
     pcm_codec->SetMimeParams(strContent);
     return pcm_codec;
   }
-  else if( strContent.Equals("audio/aac")
-    || strContent.Equals("audio/aacp") )
+  else if( strContent.Equals("audio/aac") || strContent.Equals("audio/aacp") ||
+      strContent.Equals("audio/x-ms-wma") ||
+      strContent.Equals("audio/x-ape") || strContent.Equals("audio/ape"))
   {
     DVDPlayerCodec *pCodec = new DVDPlayerCodec;
-    if (urlFile.GetProtocol() == "shout" )
-      pCodec->SetContentType(strContent);
+    pCodec->SetContentType(strContent);
     return pCodec;
   }
-  else if( strContent.Equals("audio/x-ms-wma") )
-    return new DVDPlayerCodec();
-  else if( strContent.Equals("audio/x-ape") || strContent.Equals("audio/ape") )
-    return new DVDPlayerCodec();
   else if( strContent.Equals("application/ogg") || strContent.Equals("audio/ogg"))
     return CreateOGGCodec(strFile,filecache);
   else if (strContent.Equals("audio/x-xbmc-pcm"))

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -26,6 +26,7 @@
 #include "cores/dvdplayer/DVDDemuxers/DVDDemuxUtils.h"
 #include "cores/dvdplayer/DVDStreamInfo.h"
 #include "cores/dvdplayer/DVDCodecs/DVDFactoryCodec.h"
+#include "music/tags/TagLoaderTagLib.h"
 #include "utils/log.h"
 #include "settings/Settings.h"
 #include "URL.h"
@@ -155,6 +156,18 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
     m_pInputStream = NULL;
     return false;
   }
+
+  //  Extract ReplayGain info
+  // tagLoaderTagLib.Load will try to determine tag type by file extension, so set fallback by contentType
+  CStdString strFallbackFileExtension = "";
+  if (m_strContentType.Equals("audio/aacp") || m_strContentType.Equals("audio/aacp" "audio/aac"))
+    strFallbackFileExtension = "m4a";
+  else if (m_strContentType.Equals("audio/x-ms-wma"))
+    strFallbackFileExtension = "wma";
+  else if (m_strContentType.Equals("audio/x-ape") || m_strContentType.Equals("audio/ape"))
+    strFallbackFileExtension = "ape";
+  CTagLoaderTagLib tagLoaderTagLib;
+  tagLoaderTagLib.Load(strFile, m_tag, strFallbackFileExtension);
 
   // we have to decode initial data in order to get channels/samplerate
   // for sanity - we read no more than 10 packets

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -608,6 +608,14 @@ bool CTagLoaderTagLib::ParseMP4Tag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTa
     else if (it->first == "trkn")    tag.SetTrackNumber(it->second.toIntPair().first);
     else if (it->first == "disk")    tag.SetPartOfSet(it->second.toIntPair().first);
     else if (it->first == "\251day") tag.SetYear(it->second.toStringList().front().toInt());
+    else if (it->first == "----:com.apple.iTunes:replaygain_track_gain")
+      tag.SetReplayGainTrackGain((int)(atof(it->second.toStringList().front().toCString()) * 100 + 0.5));
+    else if (it->first == "----:com.apple.iTunes:replaygain_album_gain")
+      tag.SetReplayGainAlbumGain((int)(atof(it->second.toStringList().front().toCString()) * 100 + 0.5));
+    else if (it->first == "----:com.apple.iTunes:replaygain_track_peak")
+      tag.SetReplayGainTrackPeak((float)(atof(it->second.toStringList().front().toCString())));
+    else if (it->first == "----:com.apple.iTunes:replaygain_album_peak")
+      tag.SetReplayGainAlbumPeak((float)(atof(it->second.toStringList().front().toCString())));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Artist Id")
       tag.SetMusicBrainzArtistID(StringListToVectorString(it->second.toStringList()));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Artist Id")


### PR DESCRIPTION
Log file extract after pach applied:

13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]: Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/home/userx/shared/Archive/recit16bit.m4a':
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:   Metadata:
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     major_brand     : mp42
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     minor_version   : 0
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     compatible_brands: M4A mp42isom
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     creation_time   : 2013-01-10 20:23:34
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     track           : 2/2
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     title           : Example Trac AAC
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     encoder         : Nero AAC codec / 1.5.4.0
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:   Duration: 00:00:09.08, start: 0.000000, bitrate: 243 kb/s
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     Chapter #0.0: start 0.059501, end 9.079000
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     Metadata:
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:       title           : Example Trac AAC
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     Stream #0:0(und): Audio: aac (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 240 kb/s
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:     Metadata:
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:       creation_time   : 2013-01-10 20:23:34
13:04:48 T:140262136039296    INFO: ffmpeg[52CB4780]:       handler_name    : Sound Media Handler
13:04:48 T:140262136039296   DEBUG: CDVDDemuxFFmpeg::AddStream(0, ...) -> 0
13:04:48 T:140262136039296   DEBUG: FactoryCodec - Audio: passthrough - Opening
13:04:48 T:140262136039296   DEBUG: FactoryCodec - Audio: passthrough - Failed
13:04:48 T:140262136039296   DEBUG: FactoryCodec - Audio: FFmpeg - Opening
13:04:48 T:140262136039296   DEBUG: FactoryCodec - Audio: FFmpeg - Opened
13:04:48 T:140262136039296    INFO: AudioDecoder: File is queued
13:04:48 T:140262136039296   DEBUG: AudioDecoder::GetReplayGain - Final Replaygain applied: 1.823896, Track/Album Gain 94.220001, Peak 0.320437
