### PR TITLE
ffmpeg demuxer: faster channel change for PVR addons ...

### DIFF
--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -56,7 +56,7 @@ public:
   virtual ~DllAvCodecInterface() {}
   virtual void avcodec_register_all(void)=0;
   virtual void avcodec_flush_buffers(AVCodecContext *avctx)=0;
-  virtual int avcodec_open2_dont_call(AVCodecContext *avctx, AVCodec *codec, AVDictionary **options)=0;
+  virtual int avcodec_open2_dont_call(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options)=0;
   virtual AVCodec *avcodec_find_decoder(enum AVCodecID id)=0;
   virtual AVCodec *avcodec_find_encoder(enum AVCodecID id)=0;
   virtual int avcodec_close_dont_call(AVCodecContext *avctx)=0;
@@ -109,12 +109,12 @@ public:
     ::avcodec_register_all();
   }
   virtual void avcodec_flush_buffers(AVCodecContext *avctx) { ::avcodec_flush_buffers(avctx); }
-  virtual int avcodec_open2(AVCodecContext *avctx, AVCodec *codec, AVDictionary **options)
+  virtual int avcodec_open2(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options)
   {
     CSingleLock lock(DllAvCodec::m_critSection);
     return ::avcodec_open2(avctx, codec, options);
   }
-  virtual int avcodec_open2_dont_call(AVCodecContext *avctx, AVCodec *codec, AVDictionary **options) { *(volatile int *)0x0 = 0; return 0; }
+  virtual int avcodec_open2_dont_call(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options) { *(volatile int *)0x0 = 0; return 0; }
   virtual int avcodec_close_dont_call(AVCodecContext *avctx) { *(volatile int *)0x0 = 0; return 0; }
   virtual AVCodec *avcodec_find_decoder(enum AVCodecID id) { return ::avcodec_find_decoder(id); }
   virtual AVCodec *avcodec_find_encoder(enum AVCodecID id) { return ::avcodec_find_encoder(id); }
@@ -178,7 +178,7 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
 {
   DECLARE_DLL_WRAPPER(DllAvCodec, DLL_PATH_LIBAVCODEC)
   DEFINE_FUNC_ALIGNED1(void, __cdecl, avcodec_flush_buffers, AVCodecContext*)
-  DEFINE_FUNC_ALIGNED3(int, __cdecl, avcodec_open2_dont_call, AVCodecContext*, AVCodec *, AVDictionary **)
+  DEFINE_FUNC_ALIGNED3(int, __cdecl, avcodec_open2_dont_call, AVCodecContext*, const AVCodec *, AVDictionary **)
   DEFINE_FUNC_ALIGNED4(int, __cdecl, avcodec_decode_video2, AVCodecContext*, AVFrame*, int*, AVPacket*)
   DEFINE_FUNC_ALIGNED4(int, __cdecl, avcodec_decode_audio4, AVCodecContext*, AVFrame*, int*, AVPacket*)
   DEFINE_FUNC_ALIGNED4(int, __cdecl, avcodec_decode_subtitle2, AVCodecContext*, AVSubtitle*, int*, AVPacket*)
@@ -255,7 +255,7 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
 
 public:
     static CCriticalSection m_critSection;
-    int avcodec_open2(AVCodecContext *avctx, AVCodec *codec, AVDictionary **options)
+    int avcodec_open2(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options)
     {
       CSingleLock lock(DllAvCodec::m_critSection);
       return avcodec_open2_dont_call(avctx,codec, options);

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -129,6 +129,7 @@ protected:
   void DisposeStreams();
   void ParsePacket(AVPacket *pkt);
   bool IsVideoReady();
+  void ResetVideoStreams();
 
   AVDictionary *GetFFMpegOptionsFromURL(const CURL &url);
   double ConvertTimestamp(int64_t pts, int den, int num);

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -89,7 +89,7 @@ public:
   CDVDDemuxFFmpeg();
   virtual ~CDVDDemuxFFmpeg();
 
-  bool Open(CDVDInputStream* pInput);
+  bool Open(CDVDInputStream* pInput, bool streaminfo = true);
   void Dispose();
   void Reset();
   void Flush();
@@ -127,6 +127,8 @@ protected:
   CDemuxStream* GetStreamInternal(int iStreamId);
   void CreateStreams(unsigned int program = UINT_MAX);
   void DisposeStreams();
+  void ParsePacket(AVPacket *pkt);
+  bool IsVideoReady();
 
   AVDictionary *GetFFMpegOptionsFromURL(const CURL &url);
   double ConvertTimestamp(int64_t pts, int den, int num);
@@ -158,5 +160,7 @@ protected:
     AVPacket pkt;       // packet ffmpeg returned
     int      result;    // result from av_read_packet
   }m_pkt;
+
+  bool m_streaminfo;
 };
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -737,6 +737,36 @@ bool URIUtils::IsFTP(const CStdString& strFile)
          StringUtils::StartsWithNoCase(strFile2, "ftps:");
 }
 
+bool URIUtils::IsUDP(const CStdString& strFile)
+{
+  CStdString strFile2(strFile);
+
+  if (IsStack(strFile))
+    strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
+
+  return StringUtils::StartsWithNoCase(strFile2, "udp:");
+}
+
+bool URIUtils::IsTCP(const CStdString& strFile)
+{
+  CStdString strFile2(strFile);
+
+  if (IsStack(strFile))
+    strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
+
+  return StringUtils::StartsWithNoCase(strFile2, "tcp:");
+}
+
+bool URIUtils::IsPVRChannel(const CStdString& strFile)
+{
+  CStdString strFile2(strFile);
+
+  if (IsStack(strFile))
+    strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
+
+  return StringUtils::StartsWithNoCase(strFile2, "pvr://channels");
+}
+
 bool URIUtils::IsDAV(const CStdString& strFile)
 {
   CStdString strFile2(strFile);
@@ -1197,4 +1227,9 @@ bool URIUtils::UpdateUrlEncoding(std::string &strFilename)
   
   strFilename = newFilename;
   return true;
+}
+
+bool URIUtils::IsUsingFastSwitch(const CStdString& strFile)
+{
+  return IsUDP(strFile) || IsTCP(strFile) || IsPVRChannel(strFile);
 }

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -78,6 +78,8 @@ public:
   static bool IsDOSPath(const CStdString &path);
   static bool IsDVD(const CStdString& strFile);
   static bool IsFTP(const CStdString& strFile);
+  static bool IsUDP(const CStdString& strFile);
+  static bool IsTCP(const CStdString& strFile);
   static bool IsHD(const CStdString& strFileName);
   static bool IsHDHomeRun(const CStdString& strFile);
   static bool IsSlingbox(const CStdString& strFile);
@@ -116,6 +118,8 @@ public:
   static bool IsBluray(const CStdString& strFile);
   static bool IsAndroidApp(const CStdString& strFile);
   static bool IsLibraryFolder(const CStdString& strFile);
+  static bool IsPVRChannel(const CStdString& strFile);
+  static bool IsUsingFastSwitch(const CStdString& strFile);
 
   static void AddSlashAtEnd(std::string& strFolder);
   static bool HasSlashAtEnd(const std::string& strFile, bool checkURL = false);


### PR DESCRIPTION
 without internal demuxing

(such as MediaPortal, ArgusTV, MythTV, NextPVR)

This pull request contains a Gotham port of the original work from @FernetMenta with a few changes from @Davilla
(https://github.com/FernetMenta/xbmc/commit/bf753ebec5f231bc7d85b6404c0841cf0307422d

It is a follow-up for #1757

FernetMenta asked me to port and test his work because he couldn't test it as a VDR user.
