### PR TITLE
[Confluence] Change plot textboxes to font13.

### DIFF
--- a/addons/skin.confluence/720p/DialogAddonInfo.xml
+++ b/addons/skin.confluence/720p/DialogAddonInfo.xml
@@ -240,8 +240,8 @@
 						<left>10</left>
 						<top>195</top>
 						<width>600</width>
-						<height>160</height>
-						<font>font12</font>
+						<height>170</height>
+						<font>font13</font>
 						<align>justify</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
@@ -249,9 +249,9 @@
 					</control>
 					<control type="scrollbar" id="60">
 						<left>610</left>
-						<top>190</top>
+						<top>195</top>
 						<width>25</width>
-						<height>175</height>
+						<height>170</height>
 						<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
 						<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
 						<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
@@ -281,7 +281,7 @@
 						<width>600</width>
 						<height>40</height>
 						<font>font12</font>
-						<align>justify</align>
+						<align>left</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Disclaimer)]</label>
 						<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
@@ -304,10 +304,10 @@
 					<control type="textbox" id="401">
 						<description>Description</description>
 						<left>10</left>
-						<top>195</top>
+						<top>205</top>
 						<width>600</width>
-						<height>250</height>
-						<font>font12</font>
+						<height>240</height>
+						<font>font13</font>
 						<align>justify</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
@@ -315,9 +315,9 @@
 					</control>
 					<control type="scrollbar" id="61">
 						<left>610</left>
-						<top>190</top>
+						<top>205</top>
 						<width>25</width>
-						<height>250</height>
+						<height>240</height>
 						<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
 						<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
 						<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>

--- a/addons/skin.confluence/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence/720p/DialogAlbumInfo.xml
@@ -473,8 +473,8 @@
 					<left>210</left>
 					<top>515</top>
 					<width>1030</width>
-					<height>120</height>
-					<font>font12</font>
+					<height>124</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<pagecontrol>61</pagecontrol>

--- a/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
@@ -183,8 +183,8 @@
 					<left>40</left>
 					<top>275</top>
 					<width>650</width>
-					<height>295</height>
-					<font>font12</font>
+					<height>285</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>

--- a/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
@@ -241,7 +241,7 @@
 			<top>400</top>
 			<width>650</width>
 			<height>180</height>
-			<font>font12</font>
+			<font>font13</font>
 			<align>justify</align>
 			<pagecontrol>60</pagecontrol>
 			<label fallback="161">$INFO[ListItem.Plot]</label>

--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -848,10 +848,10 @@
 				<control type="textbox" id="400">
 					<description>Description Value for Movies</description>
 					<left>210</left>
-					<top>515</top>
+					<top>525</top>
 					<width>1030</width>
 					<height>120</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<pagecontrol>61</pagecontrol>

--- a/addons/skin.confluence/720p/ViewsAddonBrowser.xml
+++ b/addons/skin.confluence/720p/ViewsAddonBrowser.xml
@@ -230,10 +230,10 @@
 					<control type="textbox">
 						<description>Description</description>
 						<left>10</left>
-						<top>100</top>
+						<top>95</top>
 						<width>490</width>
-						<height>180</height>
-						<font>font12</font>
+						<height>192</height>
+						<font>font13</font>
 						<align>justify</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>
@@ -482,7 +482,7 @@
 						<top>110</top>
 						<width>290</width>
 						<height>400</height>
-						<font>font12</font>
+						<font>font13</font>
 						<align>justify</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Addon.Description)]</label>

--- a/addons/skin.confluence/720p/ViewsLiveTV.xml
+++ b/addons/skin.confluence/720p/ViewsLiveTV.xml
@@ -154,7 +154,7 @@
 					<top>330</top>
 					<width>290</width>
 					<height>220</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>

--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -469,8 +469,8 @@
 					<left>0</left>
 					<top>150</top>
 					<width>850</width>
-					<height>140</height>
-					<font>font12</font>
+					<height>146</height>
+					<font>font13</font>
 					<align>justify</align>
 					<pagecontrol>-</pagecontrol>
 					<textcolor>white</textcolor>
@@ -897,10 +897,10 @@
 					<control type="textbox">
 						<description>Description Value for Artist</description>
 						<left>10</left>
-						<top>65</top>
+						<top>70</top>
 						<width>490</width>
-						<height>190</height>
-						<font>font12</font>
+						<height>192</height>
+						<font>font13</font>
 						<align>justify</align>
 						<textcolor>white</textcolor>
 						<label>$INFO[ListItem.Property(Artist_Description)]</label>
@@ -1062,7 +1062,7 @@
 					<top>270</top>
 					<width>290</width>
 					<height>300</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<pagecontrol>-</pagecontrol>
 					<textcolor>white</textcolor>

--- a/addons/skin.confluence/720p/ViewsPVR.xml
+++ b/addons/skin.confluence/720p/ViewsPVR.xml
@@ -57,10 +57,10 @@
 				<control type="textbox">
 					<description>Plot Value for TVShow</description>
 					<left>0</left>
-					<top>43</top>
+					<top>50</top>
 					<width>690</width>
-					<height>80</height>
-					<font>font12</font>
+					<height>74</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
@@ -365,10 +365,10 @@
 				<control type="textbox">
 					<description>Plot Value for TVShow</description>
 					<left>0</left>
-					<top>43</top>
+					<top>50</top>
 					<width>690</width>
-					<height>80</height>
-					<font>font12</font>
+					<height>74</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
@@ -830,7 +830,7 @@
 					<top>270</top>
 					<width>290</width>
 					<height>280</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[Container(13).ListItem.Plot]</label>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -720,8 +720,8 @@
 					<left>0</left>
 					<top>30</top>
 					<width>850</width>
-					<height>120</height>
-					<font>font12</font>
+					<height>100</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1046,8 +1046,8 @@
 					<left>10</left>
 					<top>210</top>
 					<width>510</width>
-					<height>180</height>
-					<font>font12</font>
+					<height>190</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1089,10 +1089,10 @@
 					<left>10</left>
 					<top>245</top>
 					<width>510</width>
-					<height>25</height>
+					<height>30</height>
 					<label>$INFO[ListItem.Season,[COLOR=blue] $LOCALIZE[20373] :[/COLOR] ] $INFO[ListItem.episode,[COLOR=blue] $LOCALIZE[20359] :[/COLOR] ] $INFO[ListItem.premiered,[COLOR=blue] $LOCALIZE[31322] :[/COLOR] ]</label>
 					<align>center</align>
-					<aligny>top</aligny>
+					<aligny>center</aligny>
 					<font>font12</font>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
@@ -1111,7 +1111,7 @@
 					<top>280</top>
 					<width>510</width>
 					<height>120</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1139,7 +1139,7 @@
 					<top>0</top>
 					<width>250</width>
 					<height>355</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[Container.ShowPlot]</label>
@@ -1196,7 +1196,7 @@
 					<top>0</top>
 					<width>250</width>
 					<height>355</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1508,7 +1508,7 @@
 					<top>395</top>
 					<width>490</width>
 					<height>170</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1614,7 +1614,7 @@
 					<top>395</top>
 					<width>490</width>
 					<height>170</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1770,10 +1770,10 @@
 				<control type="textbox">
 					<description>Description Value for Video</description>
 					<left>10</left>
-					<top>425</top>
+					<top>430</top>
 					<width>540</width>
-					<height>105</height>
-					<font>font12</font>
+					<height>100</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1834,10 +1834,10 @@
 				<control type="textbox">
 					<description>Description Value for Video</description>
 					<left>10</left>
-					<top>425</top>
+					<top>430</top>
 					<width>540</width>
 					<height>145</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>
@@ -1883,10 +1883,10 @@
 				<control type="textbox">
 					<description>Description Value for Video</description>
 					<left>10</left>
-					<top>425</top>
+					<top>430</top>
 					<width>540</width>
 					<height>145</height>
-					<font>font12</font>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[Container.ShowPlot]</label>
@@ -1932,10 +1932,10 @@
 				<control type="textbox">
 					<description>Description Value for Video</description>
 					<left>10</left>
-					<top>425</top>
+					<top>430</top>
 					<width>400</width>
-					<height>105</height>
-					<font>font12</font>
+					<height>100</height>
+					<font>font13</font>
 					<align>justify</align>
 					<textcolor>white</textcolor>
 					<label>$INFO[ListItem.Plot]</label>


### PR DESCRIPTION
This changes the media and addon textboxes (+info dialogs) to a slightly bigger fontsize and adjusts some positions to better accommodate that font size. Effectively this costs 1 line of text, but it unifies the label font sizes and improves readability.
