### PR TITLE
Path subst encode + slash fix

### DIFF
--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -158,11 +158,6 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
       URIUtils::RemoveSlashAtEnd(strNoSlash);
       CStdString strFileName = URIUtils::GetFileName(strNoSlash);
 
-      // URL Decode for cases where source uses URL encoding and target does not 
-      if ( URIUtils::ProtocolHasEncodedFilename(CURL(pItem->GetPath()).GetProtocol() )
-       && !URIUtils::ProtocolHasEncodedFilename(CURL(strDestFile).GetProtocol() ) )
-        CURL::Decode(strFileName);
-
       // special case for upnp
       if (URIUtils::IsUPnP(items.GetPath()) || URIUtils::IsUPnP(pItem->GetPath()))
       {
@@ -181,7 +176,7 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
 
       CStdString strnewDestFile;
       if(!strDestFile.empty()) // only do this if we have a destination
-        strnewDestFile = URIUtils::AddFileToFolder(strDestFile, strFileName);
+        strnewDestFile = URIUtils::ChangeBasePath(pItem->GetPath(), strFileName, strDestFile); // Convert (URL) encoding + slashes (if source / target differ)
 
       if (pItem->m_bIsFolder)
       {

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -68,6 +68,16 @@ public:
   static void GetCommonPath(CStdString& strPath, const CStdString& strPath2);
   static CStdString GetParentPath(const CStdString& strPath);
   static bool GetParentPath(const CStdString& strPath, CStdString& strParent);
+
+  /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
+    Handles changes in path separator and filename URL encoding if necessary to derive toFile.
+    \param fromPath the base path of the original URL
+    \param fromFile the filename portion of the original URL
+    \param toPath the base path of the resulting URL
+    \return the full path.
+   */
+  static std::string ChangeBasePath(const std::string &fromPath, const std::string &fromFile, const std::string &toPath);
+
   static CStdString SubstitutePath(const CStdString& strPath, bool reverse = false);
 
   static bool IsAddonsPath(const CStdString& strFile);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -178,12 +178,56 @@ TEST_F(TestURIUtils, SubstitutePath)
 {
   CStdString from, to, ref, var;
 
-  from = "/somepath";
-  to = "/someotherpath";
+  from = "C:\\My Videos";
+  to = "https://myserver/some%20other%20path";
   g_advancedSettings.m_pathSubstitutions.push_back(std::make_pair(from, to));
 
-  ref = "/someotherpath/to/movie.avi";
-  var = URIUtils::SubstitutePath("/somepath/to/movie.avi");
+  from = "/this/path1";
+  to = "/some/other/path2";
+  g_advancedSettings.m_pathSubstitutions.push_back(std::make_pair(from, to));
+
+  from = "davs://otherserver/my%20music%20path";
+  to = "D:\\Local Music\\MP3 Collection";
+  g_advancedSettings.m_pathSubstitutions.push_back(std::make_pair(from, to));
+
+  ref = "https://myserver/some%20other%20path/sub%20dir/movie%20name.avi";
+  var = URIUtils::SubstitutePath("C:\\My Videos\\sub dir\\movie name.avi");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "C:\\My Videos\\sub dir\\movie name.avi";
+  var = URIUtils::SubstitutePath("https://myserver/some%20other%20path/sub%20dir/movie%20name.avi", true);
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "D:\\Local Music\\MP3 Collection\\Phil Collins\\Some CD\\01 - Two Hearts.mp3";
+  var = URIUtils::SubstitutePath("davs://otherserver/my%20music%20path/Phil%20Collins/Some%20CD/01%20-%20Two%20Hearts.mp3");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "davs://otherserver/my%20music%20path/Phil%20Collins/Some%20CD/01%20-%20Two%20Hearts.mp3";
+  var = URIUtils::SubstitutePath("D:\\Local Music\\MP3 Collection\\Phil Collins\\Some CD\\01 - Two Hearts.mp3", true);
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "/some/other/path2/to/movie.avi";
+  var = URIUtils::SubstitutePath("/this/path1/to/movie.avi");
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "/this/path1/to/movie.avi";
+  var = URIUtils::SubstitutePath("/some/other/path2/to/movie.avi", true);
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "/no/translation path/";
+  var = URIUtils::SubstitutePath(ref);
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "/no/translation path/";
+  var = URIUtils::SubstitutePath(ref, true);
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "c:\\no\\translation path";
+  var = URIUtils::SubstitutePath(ref);
+  EXPECT_STREQ(ref.c_str(), var.c_str());
+
+  ref = "c:\\no\\translation path";
+  var = URIUtils::SubstitutePath(ref, true);
   EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 


### PR DESCRIPTION
This is a followup for the previous path substitution fixes. This fixes usage of cases where source and target use different slash types for path separation and/or use url-encoded vs. not encoded.
