### PR TITLE
FIX: [droid;python] implement hack to bypass locale not implemented in NDK

### DIFF
--- a/tools/depends/target/python26/Makefile
+++ b/tools/depends/target/python26/Makefile
@@ -38,7 +38,12 @@ endif
 	cp modules.setup $(PLATFORM)/Modules/Setup.dist
 
 #Add -liconv as needed, and add the _scproxy module for darwin
+#  disable locale altogether for Android
+ifeq ($(OS),android)
+	cd $(PLATFORM); sed -ie 's|_locale _localemodule.c   -lintl|#_locale _localemodule.c   -lintl|' Modules/Setup.dist
+else
 	cd $(PLATFORM); sed -ie 's|_locale _localemodule.c   -lintl|_locale _localemodule.c   -lintl $(LINK_ICONV) |' Modules/Setup.dist
+endif
 ifeq ($(OS),osx)
 	echo "_scproxy \$$(srcdir)/Mac/Modules/_scproxy.c -framework SystemConfiguration -framework CoreFoundation" >> $(PLATFORM)/Modules/Setup.dist
 endif


### PR DESCRIPTION
NDK r8e (nor 9b according to AlTheKiller) does not implement locale in bionic, so all python scripts using it fail. This disables the python _locale modules and trigger python builtin fallback.
