### PR TITLE
[addons] various fixes/improvements

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11891,7 +11891,12 @@ msgctxt "#24090"
 msgid "Lock Add-on manager"
 msgstr ""
 
-#empty strings from id 24091 to 24093
+#: xbmc\addons\GUIDialogAddonInfo.cpp
+msgctxt "#24091"
+msgid "This Add-on cannot be disabled"
+msgstr ""
+
+#empty strings from id 24092 to 24093
 
 #: xbmc/addons/guidialogaddoninfo.cpp
 msgctxt "#24094"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11734,8 +11734,8 @@ msgctxt "#24043"
 msgid "Available Updates"
 msgstr ""
 
-#: xbmc/addons/addoninstaller.cpp
-#: xbmc/addons/Repository.cpp
+#: xbmc/addons/AddonInstaller.cpp
+#: xbmc/addons/AddonsDatabase.cpp
 msgctxt "#24044"
 msgid "Dependencies not met. Please contact Add-on author."
 msgstr ""
@@ -11760,7 +11760,10 @@ msgctxt "#24048"
 msgid "Rollback"
 msgstr ""
 
-#empty string with id 24049
+#: xbmc/addons/AddonsDirectory.cpp
+msgctxt "#24049"
+msgid "Incompatible"
+msgstr ""
 
 #: unknown
 msgctxt "#24050"
@@ -11940,7 +11943,12 @@ msgctxt "#24103"
 msgid "Skin is missing some files"
 msgstr ""
 
-#empty strings from id 24104 to 24999
+#: xbmc/addons/Repository.cpp
+msgctxt "#24104"
+msgid "Add-on is incompatible due to unmet dependencies."
+msgstr ""
+
+#empty strings from id 24105 to 24999
 
 msgctxt "#25000"
 msgid "Notifications"

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -550,7 +550,10 @@ void CAddonDatabase::SetPropertiesFromAddon(const AddonPtr& addon,
   starrating.Format("rating%d.png", addon->Stars());
   pItem->SetProperty("Addon.StarRating",starrating);
   pItem->SetProperty("Addon.Path", addon->Path());
-  pItem->SetProperty("Addon.Broken", addon->Props().broken);
+  if (addon->Props().broken == "DEPSNOTMET")
+    pItem->SetProperty("Addon.Broken", g_localizeStrings.Get(24044));
+  else
+    pItem->SetProperty("Addon.Broken", addon->Props().broken);
   std::map<CStdString,CStdString>::iterator it = 
                     addon->Props().extrainfo.find("language");
   if (it != addon->Props().extrainfo.end())

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -87,7 +87,7 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
           OnInstall();
           return true;
         }
-        else if (CGUIDialogYesNo::ShowAndGetInput(24037, 750, 0, 0))
+        else
         {
           OnUninstall();
           return true;
@@ -205,6 +205,10 @@ void CGUIDialogAddonInfo::OnUninstall()
     CGUIDialogOK::ShowAndGetInput(24037, strLine0, strLine1, 24047);
     return;
   }
+
+  // prompt user to be sure
+  if (CGUIDialogYesNo::ShowAndGetInput(24037, 750, 0, 0))
+    return;
 
   // ensure the addon isn't disabled in our database
   CAddonMgr::Get().DisableAddon(m_localAddon->ID(), false);

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -192,11 +192,12 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
   for (VECADDONS::iterator it  = addons.begin();
                            it != addons.end();++it)
   {
-    if ((*it)->GetDeps().find(m_localAddon->ID()) != (*it)->GetDeps().end())
+    ADDONDEPS::const_iterator i = (*it)->GetDeps().find(m_localAddon->ID());
+    if (i != (*it)->GetDeps().end() && !i->second.second) // non-optional dependency
       deps.push_back((*it)->Name());
   }
 
-  if (!CAddonInstaller::Get().CheckDependencies(m_localAddon) && deps.size())
+  if (!deps.empty())
   {
     CStdString strLine0, strLine1;
     StringUtils::JoinString(deps, ", ", strLine1);

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -187,10 +187,10 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
     return false;
 
   VECADDONS addons;
-  CStdStringArray deps;
+  vector<string> deps;
   CAddonMgr::Get().GetAllAddons(addons);
-  for (VECADDONS::iterator it  = addons.begin();
-                           it != addons.end();++it)
+  for (VECADDONS::const_iterator it  = addons.begin();
+       it != addons.end();++it)
   {
     ADDONDEPS::const_iterator i = (*it)->GetDeps().find(m_localAddon->ID());
     if (i != (*it)->GetDeps().end() && !i->second.second) // non-optional dependency
@@ -199,10 +199,9 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
 
   if (!deps.empty())
   {
-    CStdString strLine0, strLine1;
-    StringUtils::JoinString(deps, ", ", strLine1);
-    strLine0.Format(g_localizeStrings.Get(24046), m_localAddon->Name().c_str());
-    CGUIDialogOK::ShowAndGetInput(heading, strLine0, strLine1, line2);
+    string line0 = StringUtils::Format(g_localizeStrings.Get(24046), m_localAddon->Name().c_str());
+    string line1 = StringUtils::Join(deps, ", ");
+    CGUIDialogOK::ShowAndGetInput(heading, line0, line1, line2);
     return true;
   }
   return false;

--- a/xbmc/addons/GUIDialogAddonInfo.h
+++ b/xbmc/addons/GUIDialogAddonInfo.h
@@ -59,6 +59,13 @@ protected:
   void OnChangeLog();
   void OnRollback();
 
+  /*! \brief check if the add-on is a dependency of others, and if so prompt the user.
+   \param heading the label for the heading of the prompt dialog
+   \param line2 the action that could not be completed.
+   \return true if prompted, false otherwise.
+   */
+  bool PromptIfDependency(int heading, int line2);
+
   CFileItemPtr m_item;
   ADDON::AddonPtr m_addon;
   ADDON::AddonPtr m_localAddon;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -237,7 +237,7 @@ bool CRepositoryUpdateJob::DoWork()
       break;
 
     if (!CAddonInstaller::Get().CheckDependencies(addons[i]))
-      addons[i]->Props().broken = g_localizeStrings.Get(24044);
+      addons[i]->Props().broken = "DEPSNOTMET";
 
     // invalidate the art associated with this item
     if (!addons[i]->Props().fanart.empty())
@@ -273,8 +273,11 @@ bool CRepositoryUpdateJob::DoWork()
     {
       if (database.IsAddonBroken(addons[i]->ID()).IsEmpty())
       {
+        std::string line = g_localizeStrings.Get(24096);
+        if (addons[i]->Props().broken == "DEPSNOTMET")
+          line = g_localizeStrings.Get(24104);
         if (addon && CGUIDialogYesNo::ShowAndGetInput(addons[i]->Name(),
-                                             g_localizeStrings.Get(24096),
+                                             line,
                                              g_localizeStrings.Get(24097),
                                              ""))
           CAddonMgr::Get().DisableAddon(addons[i]->ID());

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -217,7 +217,9 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
     else if (CAddonMgr::Get().IsAddonDisabled(addon->ID()))
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24023));
 
-    if (!addon->Props().broken.IsEmpty())
+    if (addon->Props().broken == "DEPSNOTMET")
+      pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24049));
+    else if (!addon->Props().broken.empty())
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24098));
     if (addon2 && addon2->Version() < addon->Version())
     {


### PR DESCRIPTION
1. Splits "Broken" status away from "Unmet dependencies" as per http://forum.xbmc.org/showthread.php?tid=177482
2. Fixes issue with dependencies being allowed to be uninstalled unless they themselves are broken.
3. Prompts and doesn't allow disabling of add-ons that are dependencies.
4. Reorders prompts on uninstall so user doesn't get unnecessarily prompted with "are you sure" when the add-on in question can't be uninstalled anyway.
