### PR TITLE
Add auto scrolling for containers

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -60,7 +60,6 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, fl
   m_cacheItems = preloadItems;
   m_scrollItemsPerFrame = 0.0f;
   m_type = VIEW_TYPE_NONE;
-  m_autoScrollCondition = 1;
   m_autoScrollMoveTime = 0;
   m_autoScrollDelayTime = 0;
   m_autoScrollIsReversed = false;
@@ -1023,7 +1022,7 @@ void CGUIBaseContainer::ResetAutoScrolling()
 
 void CGUIBaseContainer::UpdateAutoScrolling(unsigned int currentTime)
 {
-  if (!m_autoScrollCondition || g_infoManager.GetBoolValue(m_autoScrollCondition))
+  if (m_autoScrollCondition && m_autoScrollCondition->Get())
   {
     if (m_lastRenderTime)
       m_autoScrollDelayTime += currentTime - m_lastRenderTime;
@@ -1034,7 +1033,7 @@ void CGUIBaseContainer::UpdateAutoScrolling(unsigned int currentTime)
       m_autoScrollIsReversed ? MoveUp(true) : MoveDown(true);
     }
   }
-  else if (m_autoScrollCondition)
+  else if (!m_autoScrollCondition)
     ResetAutoScrolling();  // conditional is false, so reset the autoscrolling
 }
 

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -84,6 +84,10 @@ public:
    \param offset CPoint holding the offset in skin coordinates.
    */
   void SetRenderOffset(const CPoint &offset);
+  
+  void SetAutoScrolling(const TiXmlNode *node);
+  void ResetAutoScrolling();
+  void UpdateAutoScrolling(unsigned int currentTime);
 
 #ifdef _DEBUG
   virtual void DumpTextureUse();
@@ -193,6 +197,14 @@ protected:
    \sa GetOffset
   */
   inline int GetItemOffset() const { return CorrectOffset(GetOffset(), 0); }
+  
+  // autoscrolling
+  unsigned int m_autoScrollCondition;
+  int          m_autoScrollMoveTime;   // time between to moves
+  unsigned int m_autoScrollDelayTime;  // current offset into the delay
+  bool         m_autoScrollIsReversed; // scroll backwards
+  
+  unsigned int m_lastRenderTime;
 
 private:
   int m_cursor;

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -199,10 +199,10 @@ protected:
   inline int GetItemOffset() const { return CorrectOffset(GetOffset(), 0); }
   
   // autoscrolling
-  unsigned int m_autoScrollCondition;
-  int          m_autoScrollMoveTime;   // time between to moves
-  unsigned int m_autoScrollDelayTime;  // current offset into the delay
-  bool         m_autoScrollIsReversed; // scroll backwards
+  INFO::InfoPtr m_autoScrollCondition;
+  int           m_autoScrollMoveTime;   // time between to moves
+  unsigned int  m_autoScrollDelayTime;  // current offset into the delay
+  bool          m_autoScrollIsReversed; // scroll backwards
   
   unsigned int m_lastRenderTime;
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1319,6 +1319,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIListContainer *)control)->SetPageControl(pageControl);
     ((CGUIListContainer *)control)->SetRenderOffset(offset);
+    ((CGUIBaseContainer *)control)->SetAutoScrolling(pControlNode);
   }
   else if (type == CGUIControl::GUICONTAINER_WRAPLIST)
   {
@@ -1332,6 +1333,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIWrappingListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIWrappingListContainer *)control)->SetPageControl(pageControl);
     ((CGUIWrappingListContainer *)control)->SetRenderOffset(offset);
+    ((CGUIBaseContainer *)control)->SetAutoScrolling(pControlNode);
   }
   else if (type == CGUIControl::GUICONTAINER_EPGGRID)
   {
@@ -1352,6 +1354,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIFixedListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIFixedListContainer *)control)->SetPageControl(pageControl);
     ((CGUIFixedListContainer *)control)->SetRenderOffset(offset);
+    ((CGUIBaseContainer *)control)->SetAutoScrolling(pControlNode);
   }
   else if (type == CGUIControl::GUICONTAINER_PANEL)
   {
@@ -1365,6 +1368,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIPanelContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIPanelContainer *)control)->SetPageControl(pageControl);
     ((CGUIPanelContainer *)control)->SetRenderOffset(offset);
+    ((CGUIBaseContainer *)control)->SetAutoScrolling(pControlNode);
   }
   else if (type == CGUIControl::GUICONTROL_TEXTBOX)
   {


### PR DESCRIPTION
This is basically copy/paste work from the auto scrolling for text boxes. It adds the same feature for containers which would make my home screen in Xperience1080 a little bit easier because I could get rid of all the AlarmClocks and just add

`<autoscoll time="4000">Container(20).HasFocus(id) + !Control.HasFocus(list_id)</autoscoll>`

to all the widgets.

I tested this a while ago and it worked fine but I couldn't get XBMC to build with Xcode 5 and OS X Mavericks so I haven't tested this recently. Maybe someone could have a look at this.

Thanks
`Black
