### PR TITLE
X11: Drop stoneold vsync methods

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -129,16 +129,14 @@ void CWinSystemX11GL::SetVSyncImpl(bool enable)
     return;
 
   bool vendor_nvidia = strVendor.find("nvidia") != std::string::npos;
-  bool vendor_ati    = StringUtils::StartsWith(strVendor, "ati");
 
-  if (m_glXSwapIntervalMESA && !m_iVSyncMode && vendor_ati)
+  if (m_glXSwapIntervalMESA && !m_iVSyncMode && !vendor_nvidia)
   {
     if(m_glXSwapIntervalMESA(1) == 0)
       m_iVSyncMode = 2;
     else
       CLog::Log(LOGWARNING, "%s - glXSwapIntervalMESA failed", __FUNCTION__);
   }
-
   if (m_glXWaitVideoSyncSGI && m_glXGetVideoSyncSGI && !m_iVSyncMode && !vendor_nvidia)
   {
     unsigned int count;
@@ -154,14 +152,6 @@ void CWinSystemX11GL::SetVSyncImpl(bool enable)
     else
       CLog::Log(LOGWARNING, "%s - glXSwapIntervalSGI failed", __FUNCTION__);
   }
-  if (m_glXSwapIntervalMESA && !m_iVSyncMode && !vendor_ati)
-  {
-    if(m_glXSwapIntervalMESA(1) == 0)
-      m_iVSyncMode = 2;
-    else
-      CLog::Log(LOGWARNING, "%s - glXSwapIntervalMESA failed", __FUNCTION__);
-  }
-
 }
 
 bool CWinSystemX11GL::IsExtSupported(const char* extension)

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -29,7 +29,6 @@ CWinSystemX11GL::CWinSystemX11GL()
 {
   m_glXGetVideoSyncSGI   = NULL;
   m_glXWaitVideoSyncSGI  = NULL;
-  m_glXSwapIntervalSGI   = NULL;
   m_glXSwapIntervalMESA  = NULL;
   m_glXSwapIntervalEXT   = NULL;
 
@@ -120,8 +119,6 @@ void CWinSystemX11GL::SetVSyncImpl(bool enable)
     m_glXSwapIntervalEXT(m_dpy, m_glWindow, 0);
   else if(m_glXSwapIntervalMESA)
     m_glXSwapIntervalMESA(0);
-  else if(m_glXSwapIntervalSGI)
-    m_glXSwapIntervalSGI(0);
 
   m_iVSyncErrors = 0;
 
@@ -147,13 +144,6 @@ void CWinSystemX11GL::SetVSyncImpl(bool enable)
         m_iVSyncMode = 3;
     else
       CLog::Log(LOGWARNING, "%s - glXGetVideoSyncSGI failed, glcontext probably not direct", __FUNCTION__);
-  }
-  if (m_glXSwapIntervalSGI && !m_iVSyncMode)
-  {
-    if(m_glXSwapIntervalSGI(1) == 0)
-      m_iVSyncMode = 2;
-    else
-      CLog::Log(LOGWARNING, "%s - glXSwapIntervalSGI failed", __FUNCTION__);
   }
 }
 
@@ -191,11 +181,6 @@ bool CWinSystemX11GL::CreateNewWindow(const CStdString& name, bool fullScreen, R
     m_glXGetVideoSyncSGI = (int (*)(unsigned int*))glXGetProcAddress((const GLubyte*)"glXGetVideoSyncSGI");
   else
     m_glXGetVideoSyncSGI = NULL;
-
-  if (IsExtSupported("GLX_SGI_swap_control") )
-    m_glXSwapIntervalSGI = (int (*)(int))glXGetProcAddress((const GLubyte*)"glXSwapIntervalSGI");
-  else
-    m_glXSwapIntervalSGI = NULL;
 
   if (IsExtSupported("GLX_MESA_swap_control"))
     m_glXSwapIntervalMESA = (int (*)(int))glXGetProcAddress((const GLubyte*)"glXSwapIntervalMESA");

--- a/xbmc/windowing/X11/WinSystemX11GL.h
+++ b/xbmc/windowing/X11/WinSystemX11GL.h
@@ -48,8 +48,6 @@ protected:
   int (*m_glXSwapIntervalSGI)(int);
   int (*m_glXSwapIntervalMESA)(int);
 
-  Bool    (*m_glXGetSyncValuesOML)(Display* dpy, GLXDrawable drawable, int64_t* ust, int64_t* msc, int64_t* sbc);
-  int64_t (*m_glXSwapBuffersMscOML)(Display* dpy, GLXDrawable drawable, int64_t target_msc, int64_t divisor,int64_t remainder);
 
   int m_iVSyncErrors;
 };

--- a/xbmc/windowing/X11/WinSystemX11GL.h
+++ b/xbmc/windowing/X11/WinSystemX11GL.h
@@ -45,7 +45,6 @@ protected:
 
   int (*m_glXGetVideoSyncSGI)(unsigned int*);
   int (*m_glXWaitVideoSyncSGI)(int, int, unsigned int*);
-  int (*m_glXSwapIntervalSGI)(int);
   int (*m_glXSwapIntervalMESA)(int);
   PFNGLXSWAPINTERVALEXTPROC m_glXSwapIntervalEXT;
 

--- a/xbmc/windowing/X11/WinSystemX11GL.h
+++ b/xbmc/windowing/X11/WinSystemX11GL.h
@@ -47,7 +47,7 @@ protected:
   int (*m_glXWaitVideoSyncSGI)(int, int, unsigned int*);
   int (*m_glXSwapIntervalSGI)(int);
   int (*m_glXSwapIntervalMESA)(int);
-
+  PFNGLXSWAPINTERVALEXTPROC m_glXSwapIntervalEXT;
 
   int m_iVSyncErrors;
 };


### PR DESCRIPTION
After debugging with @FernetMenta @grigorig and @ckoenig we found out, that Mesa still implements those old Vsync Methods. They don't seem to work as well as they did 10 years ago.

This fixes by accident the SlideShow, which did not show any image with intel display drivers an vertical blank sync = always enabled. It also chose this method. Furthermore it it improves number of skips we got while testing vdpau with uvd radeons.
