### PR TITLE
fixed: SFTP stat didn't set directory/file type

### DIFF
--- a/xbmc/filesystem/SFTPFile.cpp
+++ b/xbmc/filesystem/SFTPFile.cpp
@@ -272,6 +272,11 @@ int CSFTPSession::Stat(const char *path, struct __stat64* buffer)
       buffer->st_mtime = attributes->mtime;
       buffer->st_atime = attributes->atime;
 
+      if S_ISDIR(attributes->permissions)
+        buffer->st_mode = _S_IFDIR;
+      else if S_ISREG(attributes->permissions)
+        buffer->st_mode = _S_IFREG;
+
       sftp_attributes_free(attributes);
       return 0;
     }


### PR DESCRIPTION
This caused eg. libdvd to fail when playing ISOs
