### PR TITLE
[Util] Add "(External)" to the name of an external subtitle.

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -10988,7 +10988,12 @@ msgctxt "#21601"
 msgid "Prefer external subtitles to internal ones"
 msgstr ""
 
-#empty strings from id 21602 to 21799
+#: xbmc/Util.cpp
+msgctxt "#21602"
+msgid "(External)"
+msgstr ""
+
+#empty strings from id 21603 to 21799
 
 msgctxt "#21800"
 msgid "File name"

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2188,6 +2188,8 @@ void CUtil::GetExternalStreamDetailsFromFilename(const CStdString& strVideo, con
     }
     StringUtils::Trim(name);
     info.name = StringUtils::RemoveDuplicatedSpacesAndTabs(name);
+    info.name += " ";
+    info.name += g_localizeStrings.Get(21602); // External
   }
   if (info.flag == 0x1111)
     info.flag = CDemuxStream::FLAG_NONE;


### PR DESCRIPTION
Since we treat external and internal subtitles as equal, it's impossible to distinguish between them.
Therefore I propose to add "(External)" to the name of an external subtitles.
