### PR TITLE
Don't use SetScalingResolution when loading fonts

### DIFF
--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -53,10 +53,11 @@ GUIFontManager::~GUIFontManager(void)
 
 void GUIFontManager::RescaleFontSizeAndAspect(float *size, float *aspect, const RESOLUTION_INFO &sourceRes, bool preserveAspect)
 {
-  // set scaling resolution so that we can scale our font sizes correctly
+  // get the UI scaling constants so that we can scale our font sizes correctly
   // as fonts aren't scaled at render time (due to aliasing) we must scale
   // the size of the fonts before they are drawn to bitmaps
-  g_graphicsContext.SetScalingResolution(sourceRes, true);
+  float scaleX, scaleY;
+  g_graphicsContext.GetGUIScaling(sourceRes, scaleX, scaleY);
 
   if (preserveAspect)
   {
@@ -70,10 +71,10 @@ void GUIFontManager::RescaleFontSizeAndAspect(float *size, float *aspect, const 
     // adjust aspect ratio
     *aspect *= sourceRes.fPixelRatio;
 
-    *aspect *= g_graphicsContext.GetGUIScaleY() / g_graphicsContext.GetGUIScaleX();
+    *aspect *= scaleY / scaleX;
   }
 
-  *size /= g_graphicsContext.GetGUIScaleY();
+  *size /= scaleY;
 }
 
 static bool CheckFont(CStdString& strPath, const CStdString& newPath,

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -126,6 +126,14 @@ public:
   const RESOLUTION_INFO GetResInfo(RESOLUTION res) const;
   void SetResInfo(RESOLUTION res, const RESOLUTION_INFO& info);
 
+  /* \brief Get UI scaling information from a given resolution to the screen resolution.
+   Takes account of overscan and UI zooming.
+   \param res the resolution to scale from.
+   \param scaleX [out] the scaling amount in the X direction.
+   \param scaleY [out] the scaling amount in the Y direction.
+   \param matrix [out] if non-NULL, a suitable transformation from res to screen resolution is set.
+   */
+  void GetGUIScaling(const RESOLUTION_INFO &res, float &scaleX, float &scaleY, TransformMatrix *matrix = NULL);
 
   void SetRenderingResolution(const RESOLUTION_INFO &res, bool needsScaling);  ///< Sets scaling up for rendering
   void SetScalingResolution(const RESOLUTION_INFO &res, bool needsScaling);    ///< Sets scaling up for skin loading etc.


### PR DESCRIPTION
This fixes LoadTTF() calling into CGraphicsContext and setting state (in particular, setting the scaling resolution and resetting the origin and camera).  All it needs is the scale factors - it doesn't need to set state at all.  Doing so means it can't be done during routines which rely on that state (e.g. from a control during Process() or Render()).

This was noticed during the look into weird UI during text based sub rendering when the video is running in the background via CGUIVideoControl.

More work needed to fix that properly.
