### PR TITLE
Fix subtitle scaling for text based subs during windowed video playback

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -807,7 +807,7 @@ void CGraphicContext::SetScalingResolution(const RESOLUTION_INFO &res, bool need
   m_cameras.push(CPoint(0.5f*m_iScreenWidth, 0.5f*m_iScreenHeight));
 
   // and reset the final transform
-  UpdateFinalTransform(m_guiTransform);
+  m_finalTransform = m_guiTransform;
   Unlock();
 }
 
@@ -817,15 +817,6 @@ void CGraphicContext::SetRenderingResolution(const RESOLUTION_INFO &res, bool ne
   SetScalingResolution(res, needsScaling);
   UpdateCameraPosition(m_cameras.top());
   Unlock();
-}
-
-void CGraphicContext::UpdateFinalTransform(const TransformMatrix &matrix)
-{
-  // We could set the world transform here to GPU-ize the animation system.
-  // trouble is that we require the resulting x,y coords to be rounded to
-  // the nearest pixel (vertex shader perhaps?)
-  m_finalTransform.Reset();
-  m_finalTransform *= matrix;
 }
 
 void CGraphicContext::SetStereoView(RENDER_STEREO_VIEW view)

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -53,15 +53,13 @@ CGraphicContext::CGraphicContext(void) :
   m_bCalibrating(false),
   m_Resolution(RES_INVALID),
   /*m_windowResolution,*/
-  m_guiScaleX(1.0f),
-  m_guiScaleY(1.0f)
   /*,m_cameras, */
   /*m_origins, */
   /*m_clipRegions,*/
   /*m_guiTransform,*/
   /*m_finalTransform, */
   /*m_groupTransform*/
-  , m_stereoView(RENDER_STEREO_VIEW_OFF)
+  m_stereoView(RENDER_STEREO_VIEW_OFF)
   , m_stereoMode(RENDER_STEREO_MODE_OFF)
   , m_nextStereoMode(RENDER_STEREO_MODE_OFF)
 {
@@ -790,12 +788,10 @@ void CGraphicContext::SetScalingResolution(const RESOLUTION_INFO &res, bool need
   Lock();
   m_windowResolution = res;
   if (needsScaling && m_Resolution != RES_INVALID)
-    GetGUIScaling(res, m_guiScaleX, m_guiScaleY, &m_guiTransform);
+    GetGUIScaling(res, m_guiTransform.scaleX, m_guiTransform.scaleY, &m_guiTransform.matrix);
   else
   {
     m_guiTransform.Reset();
-    m_guiScaleX = 1.0f;
-    m_guiScaleY = 1.0f;
   }
 
   // reset our origin and camera
@@ -838,14 +834,14 @@ void CGraphicContext::SetStereoView(RENDER_STEREO_VIEW view)
 
 void CGraphicContext::InvertFinalCoords(float &x, float &y) const
 {
-  m_finalTransform.InverseTransformPosition(x, y);
+  m_finalTransform.matrix.InverseTransformPosition(x, y);
 }
 
 float CGraphicContext::GetScalingPixelRatio() const
 {
   // assume the resolutions are different - we want to return the aspect ratio of the video resolution
   // but only once it's been corrected for the skin -> screen coordinates scaling
-  return GetResInfo().fPixelRatio * (m_guiScaleY / m_guiScaleX);
+  return GetResInfo().fPixelRatio * (m_finalTransform.scaleY / m_finalTransform.scaleX);
 }
 
 void CGraphicContext::SetCameraPosition(const CPoint &camera)
@@ -917,9 +913,9 @@ void CGraphicContext::UpdateCameraPosition(const CPoint &camera)
 
 bool CGraphicContext::RectIsAngled(float x1, float y1, float x2, float y2) const
 { // need only test 3 points, as they must be co-planer
-  if (m_finalTransform.TransformZCoord(x1, y1, 0)) return true;
-  if (m_finalTransform.TransformZCoord(x2, y2, 0)) return true;
-  if (m_finalTransform.TransformZCoord(x1, y2, 0)) return true;
+  if (m_finalTransform.matrix.TransformZCoord(x1, y1, 0)) return true;
+  if (m_finalTransform.matrix.TransformZCoord(x2, y2, 0)) return true;
+  if (m_finalTransform.matrix.TransformZCoord(x1, y2, 0)) return true;
   return false;
 }
 
@@ -1004,7 +1000,7 @@ void CGraphicContext::Flip(const CDirtyRegionList& dirty)
 
 void CGraphicContext::ApplyHardwareTransform()
 {
-  g_Windowing.ApplyHardwareTransform(m_finalTransform);
+  g_Windowing.ApplyHardwareTransform(m_finalTransform.matrix);
 }
 
 void CGraphicContext::RestoreHardwareTransform()

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -214,6 +214,13 @@ public:
    m_transforms.push(m_finalTransform);
    m_finalTransform.matrix = matrix;
   }
+  inline void SetTransform(const TransformMatrix &matrix, float scaleX, float scaleY)
+  {
+    m_transforms.push(m_finalTransform);
+    m_finalTransform.matrix = matrix;
+    m_finalTransform.scaleX = scaleX;
+    m_finalTransform.scaleY = scaleY;
+  }
   inline void RemoveTransform()
   {
     if (!m_transforms.empty())

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -200,34 +200,27 @@ public:
   void ClipRect(CRect &vertex, CRect &texture, CRect *diffuse = NULL);
   inline void AddGUITransform()
   {
-    m_groupTransform.push(m_guiTransform);
-    UpdateFinalTransform(m_groupTransform.top());
+    m_transforms.push(m_finalTransform);
+    m_finalTransform = m_guiTransform;
   }
   inline TransformMatrix AddTransform(const TransformMatrix &matrix)
   {
-    ASSERT(!m_groupTransform.empty());
-    TransformMatrix absoluteMatrix = m_groupTransform.empty() ? matrix : m_groupTransform.top() * matrix;
-    m_groupTransform.push(absoluteMatrix);
-    UpdateFinalTransform(absoluteMatrix);
-    return absoluteMatrix;
+    m_transforms.push(m_finalTransform);
+    m_finalTransform *= matrix;
+    return m_finalTransform;
   }
   inline void SetTransform(const TransformMatrix &matrix)
   {
-    // TODO: We only need to add it to the group transform as other transforms may be added on top of this one later on
-    //       Once all transforms are cached then this can be removed and UpdateFinalTransform can be called directly
-    ASSERT(!m_groupTransform.empty());
-    m_groupTransform.push(matrix);
-    UpdateFinalTransform(m_groupTransform.top());
+   m_transforms.push(m_finalTransform);
+   m_finalTransform = matrix;
   }
   inline void RemoveTransform()
   {
-    ASSERT(!m_groupTransform.empty());
-    if (!m_groupTransform.empty())
-      m_groupTransform.pop();
-    if (!m_groupTransform.empty())
-      UpdateFinalTransform(m_groupTransform.top());
-    else
-      UpdateFinalTransform(TransformMatrix());
+    if (!m_transforms.empty())
+    {
+      m_finalTransform = m_transforms.top();
+      m_transforms.pop();
+    }
   }
 
   /* modifies final coordinates according to stereo mode if needed */
@@ -251,7 +244,6 @@ protected:
 
 private:
   void UpdateCameraPosition(const CPoint &camera);
-  void UpdateFinalTransform(const TransformMatrix &matrix);
   RESOLUTION_INFO m_windowResolution;
   float m_guiScaleX;
   float m_guiScaleY;
@@ -261,7 +253,7 @@ private:
 
   TransformMatrix m_guiTransform;
   TransformMatrix m_finalTransform;
-  std::stack<TransformMatrix> m_groupTransform;
+  std::stack<TransformMatrix> m_transforms;
   RENDER_STEREO_VIEW m_stereoView;
   RENDER_STEREO_MODE m_stereoMode;
   RENDER_STEREO_MODE m_nextStereoMode;


### PR DESCRIPTION
This implements scaling.  It's not perfect, and there's a couple of simple efficiency things that could be explored (e.g. the transform is trivial to write down directly as one of the translations can be dropped, so no need for the matrix computations).

Basically it moves from screen coordinates back to control coordinates, but takes into account the fact that we don't want to scale by the control coords -> screen coords scale factor (as fonts are rendered in the screen space anyway).

A little convoluted, but when we have screen coords to play with, and the font stuff operates in control coords, it was the only way I could see of doing it without doing lots of changes to the font rendering stuff.

Obviously the confluence change needs dropping before this is pulled in.
