### PR TITLE
[Fix][Util] Fix format of external subtitles' name

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2143,6 +2143,7 @@ void CUtil::GetExternalStreamDetailsFromFilename(const CStdString& strVideo, con
   // trim any non-alphanumeric char in the begining
   std::string::iterator result = std::find_if(toParse.begin(), toParse.end(), ::isalnum);
 
+  std::string name;
   if (result != toParse.end()) // if we have anything to parse
   {
     std::string inputString(result, toParse.end());
@@ -2150,7 +2151,6 @@ void CUtil::GetExternalStreamDetailsFromFilename(const CStdString& strVideo, con
     std::vector<std::string> tokens;
     StringUtils::Tokenize(inputString, tokens, delimiters);
 
-    std::string name;
     for (std::vector<std::string>::iterator it = tokens.begin(); it != tokens.end(); ++it)
     {
       if (info.language.empty())
@@ -2186,11 +2186,11 @@ void CUtil::GetExternalStreamDetailsFromFilename(const CStdString& strVideo, con
       }
       name += " " + (*it);
     }
-    StringUtils::Trim(name);
-    info.name = StringUtils::RemoveDuplicatedSpacesAndTabs(name);
-    info.name += " ";
-    info.name += g_localizeStrings.Get(21602); // External
   }
+  name += " ";
+  name += g_localizeStrings.Get(21602); // External
+  StringUtils::Trim(name);
+  info.name = StringUtils::RemoveDuplicatedSpacesAndTabs(name);
   if (info.flag == 0x1111)
     info.flag = CDemuxStream::FLAG_NONE;
 


### PR DESCRIPTION
1.) Removes a superfluous space character that was introduced in 9d05b21f6255705982087e33b986fe724b45dd57.
2.) Adds "(External)" to (external) subtitles having no token in there file name, e.g., test.srt
