### PR TITLE
[osx] - fixed linkage of libxbmc.so, xbmc.bin and xbmc-test

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -518,7 +518,7 @@ BINDINGS+=xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPacket.h
 
 libxbmc.so: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)
 ifeq ($(findstring osx,@ARCH@), osx)
-	$(SILENT_LD) $(CXX) $(LDFLAGS) -bundle -o $@ -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS)
+	$(SILENT_LD) $(CXX) $(LDFLAGS) -bundle -o $@ -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS) -read_only_relocs suppress
 else
 	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $(MAINOBJS) -Wl,--start-group $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group -Wl,--no-undefined $(NWAOBJSXBMC) $(LIBS)
 endif
@@ -526,10 +526,10 @@ endif
 xbmc/main/main.a: force
 	$(MAKE) -C xbmc/main
 
-xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)
+xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS) xbmc/main/main.a
 
 ifeq ($(findstring osx,@ARCH@), osx)
-	$(SILENT_LD) $(CXX) $(LDFLAGS) -o xbmc.bin -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS) -rdynamic
+	$(SILENT_LD) $(CXX) $(LDFLAGS) -o xbmc.bin xbmc/main/main.a -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS) -rdynamic
 else
 	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o xbmc.bin $(MAINOBJS) -Wl,--start-group $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group $(NWAOBJSXBMC) $(LIBS) -rdynamic
 endif

--- a/configure.in
+++ b/configure.in
@@ -843,6 +843,7 @@ if test "$host_vendor" = "apple" ; then
     LIBS="$LIBS -framework IOSurface"
     LIBS="$LIBS -framework QuartzCore"
     LIBS="$LIBS -framework SystemConfiguration"
+    LIBS="$LIBS -framework VideoDecodeAcceleration"
   fi
   USE_EXTERNAL_FFMPEG=1
 elif test "$target_platform" = "target_raspberry_pi"; then

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
@@ -16,6 +16,7 @@ SRCS += DVDVideoCodecCrystalHD.cpp
 endif
 ifeq ($(findstring osx,@ARCH@),osx)
 SRCS += DVDVideoCodecVDA.cpp
+SRCS += VDA.cpp
 endif
 ifeq (@USE_OPENMAX@,1)
 SRCS += OpenMax.cpp

--- a/xbmc/osx/Makefile.in
+++ b/xbmc/osx/Makefile.in
@@ -10,6 +10,10 @@ SRCS += DarwinUtils.mm
 SRCS += CocoaInterface.mm
 SRCS += HotKeyController.m
 SRCS += OSXGNUReplacements.c
+SRCS += OSXTextInputResponder.mm
+ifeq ($(findstring osx,@ARCH@), osx)
+SRCS += smc.c
+endif
 	
 LIB = osx.a
 


### PR DESCRIPTION
As the title says.

See commit messages for further description.

This already passed jenkins testing.

This is needed for getting gtest hoooked up on jenkins ... another pr for this might follow soon ...

IMO this mainobjs thingy is something that should go into xbmc/main/Makefile.in and we use main.a instead - but somehow we mix xbmc/xbmc.o in here which would be a nogo in xbmc/main/Makefile.in. So i am not sure how to get rid of main.a here. All other gccs might support the --start-group/--end-group syntax which prevents duplicated symbols during linkage - but on osx it is not available and using MAINOBJS on osx would lead to dupe definition of xbmc.o.

So this mainly is a partly revert of what was a try to fix things (without paying attention to osx...).

For discussion (don't overdo this...) with the buildsystem pro's ...
