### PR TITLE
fix flickering video OSD

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -55,7 +55,8 @@ void CGUIDialogVideoOSD::FrameMove()
                            || g_windowManager.IsWindowActive(WINDOW_DIALOG_PVR_OSD_DIRECTOR)
                            || g_windowManager.IsWindowActive(WINDOW_DIALOG_PVR_OSD_CUTTER)
                            || g_windowManager.IsWindowActive(WINDOW_DIALOG_OSD_TELETEXT))
-      SetAutoClose(100); // enough for 10fps
+      // extend show time by original value
+      SetAutoClose(m_showDuration);
   }
   CGUIDialog::FrameMove();
 }


### PR DESCRIPTION
the video OSD was opened with m_showDuratio set to 3 secs, then immediately after m_showDuration was reduced to 100ms. Does not make much sense, does it? Sometimes fps drops when starting a video or after seeking which made it hard using the mouse to push the buttons.
