### PR TITLE
Playback of a DVD as files in a folder should not create a playlist

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1543,6 +1543,40 @@ void CFileItem::SetFromSong(const CSong &song)
   FillInMimeType(false);
 }
 
+std::string CFileItem::GetOpticalMediaPath() const
+{
+  std::string path;
+  std::string dvdPath;
+  path = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS.IFO");
+  if (CFile::Exists(path))
+    dvdPath = path;
+  else
+  {
+    dvdPath = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS");
+    path = URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO");
+    dvdPath.clear();
+    if (CFile::Exists(path))
+      dvdPath = path;
+  }
+#ifdef HAVE_LIBBLURAY
+  if (dvdPath.empty())
+  {
+    path = URIUtils::AddFileToFolder(GetPath(), "index.bdmv");
+    if (CFile::Exists(path))
+      dvdPath = path;
+    else
+    {
+      dvdPath = URIUtils::AddFileToFolder(GetPath(), "BDMV");
+      path = URIUtils::AddFileToFolder(dvdPath, "index.bdmv");
+      dvdPath.clear();
+      if (CFile::Exists(path))
+        dvdPath = path;
+    }
+  }
+#endif
+  return dvdPath;
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 /////
 ///// CFileItemList
@@ -2359,35 +2393,8 @@ void CFileItemList::StackFolders()
         // check for dvd folders
         if (!bMatch)
         {
-          CStdString path;
-          CStdString dvdPath;
-          path = URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS.IFO");
-          if (CFile::Exists(path))
-            dvdPath = path;
-          else
-          {
-            dvdPath = URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS");
-            path = URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO");
-            dvdPath.clear();
-            if (CFile::Exists(path))
-              dvdPath = path;
-          }
-#ifdef HAVE_LIBBLURAY
-          if (dvdPath.empty())
-          {
-            path = URIUtils::AddFileToFolder(item->GetPath(), "index.bdmv");
-            if (CFile::Exists(path))
-              dvdPath = path;
-            else
-            {
-              dvdPath = URIUtils::AddFileToFolder(item->GetPath(), "BDMV");
-              path = URIUtils::AddFileToFolder(dvdPath, "index.bdmv");
-              dvdPath.clear();
-              if (CFile::Exists(path))
-                dvdPath = path;
-            }
-          }
-#endif
+          std::string dvdPath = item->GetOpticalMediaPath();
+
           if (!dvdPath.empty())
           {
             // NOTE: should this be done for the CD# folders too?

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -120,6 +120,14 @@ public:
   bool Exists(bool bUseCache = true) const;
   
   /*!
+   \brief Check whether an item is an optical media folder or its parent. 
+    This will return the non-empty path to the playable entry point of the media
+    one or two levels down (VIDEO_TS.IFO for DVDs or index.bdmv for BDs). 
+    The returned path will be empty if folder does not meet this criterion.
+   \return non-empty string if item is optical media folder, empty otherwise. 
+   */
+  std::string GetOpticalMediaPath() const;
+  /*!
    \brief Check whether an item is a video item. Note that this returns true for
     anything with a video info tag, so that may include eg. folders.
    \return true if item is video, false otherwise. 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -755,6 +755,15 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     if (pItem->IsParentFolder())
       return;
 
+    // check if it's a folder with dvd or bluray files, then just add the relevant file
+    std::string mediapath(pItem->GetOpticalMediaPath());
+    if (!mediapath.empty())
+    {
+      CFileItemPtr item(new CFileItem(mediapath, false));
+      queuedItems.Add(item);
+      return;
+    }
+
     // Check if we add a locked share
     if ( pItem->m_bIsShareOrDrive )
     {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1336,6 +1336,21 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item)
     g_playlistPlayer.ClearPlaylist(iPlaylist);
     g_playlistPlayer.Reset();
     int mediaToPlay = 0;
+    
+    // first try to find mainDVD file (VIDEO_TS.IFO). 
+    // If we find this we should not allow to queue VOB files
+    std::string mainDVD; 
+    for (int i = 0; i < m_vecItems->Size(); i++) 
+    { 
+      std::string path = URIUtils::GetFileName(m_vecItems->Get(i)->GetPath()); 
+      if (StringUtils::EqualsNoCase(path, "VIDEO_TS.IFO")) 
+      { 
+        mainDVD = path; 
+        break; 
+      } 
+    }
+
+    // now queue...
     for ( int i = 0; i < m_vecItems->Size(); i++ )
     {
       CFileItemPtr nItem = m_vecItems->Get(i);
@@ -1343,7 +1358,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item)
       if (nItem->m_bIsFolder)
         continue;
 
-      if (!nItem->IsPlayList() && !nItem->IsZIP() && !nItem->IsRAR())
+      if (!nItem->IsPlayList() && !nItem->IsZIP() && !nItem->IsRAR() && (!nItem->IsDVDFile() || (URIUtils::GetFileName(nItem->GetPath()) == mainDVD)))
         g_playlistPlayer.Add(iPlaylist, nItem);
 
       if (item->IsSamePath(nItem.get()))


### PR DESCRIPTION
See discussion here:
https://github.com/xbmc/xbmc/pull/2855#issuecomment-28204668
and here:
http://forum.xbmc.org/showthread.php?tid=176066&pid=1547884#pid1547884

The issue at hand is that choosing PLAY on a DVD folder creates a playlist of the items in that folder instead of just playing the DVD. This causes the dvd to be played several times plus the chapters prev/next don't work correctly, since after #2855 playlist prev/next takes precedence if there's more than one item in the playlist...

Easiest solution was to only add the VIDEO_TS.IFO file to the playlist in this situation.
