### PR TITLE
[dvdplayer] prevent rendering of frames with negative pts

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -645,10 +645,13 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   else if (m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
     starttime = (double)m_pFormatContext->start_time / AV_TIME_BASE;
 
-  if(timestamp > starttime)
-    timestamp -= starttime;
+  // keep timestamp negative (required to prevent negative pts to render)
+  if (starttime < 0)
+    starttime = 0;
+
+  timestamp -= starttime;
   // allow for largest possible difference in pts and dts for a single packet
-  else if( timestamp + 0.5f > starttime )
+  if( timestamp > 0 && timestamp < starttime && timestamp + 0.5f > starttime )
     timestamp = 0;
 
   return timestamp*DVD_TIME_BASE;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1454,6 +1454,9 @@ void CDVDPlayer::ProcessVideoData(CDemuxStream* pStream, DemuxPacket* pPacket)
   if (CheckSceneSkip(m_CurrentVideo))
     drop = true;
 
+  if (pPacket->pts < 0)
+    drop = true;
+
   m_dvdPlayerVideo.SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
 }
 


### PR DESCRIPTION
I have a kinda strange video file:
https://dl.dropboxusercontent.com/u/27828013/cur_vid1.mov

I've exported it via iPhone AVAssetExportSession and told it to extract from second 30 to second 60.
When I play the file with XBMC it's seeking at the beginning of the video.
This does not happen with Quicktimeplayer.

After some investigation I found following reason:
The video is h264 encoded and there is no IDR-Frame at second 30. So the AVAssetExportSession extracts from the first IDR-Frame before second 30. Which is in my case second 23.
If I check the file with ffprobe it shows starttime = -7,6.
I guessed XBMC starts playing from -7,6 which seems not right to me, IMO it should start at 0.
So I tried to skip rendering for frames with a pts < 0.

I'm pretty sure my changes break something. Can anyone give me feedback, I don't understand the logic in ConvertTimestamp.
