### PR TITLE
fix: CScraper: Make sure no NULL-pointer is passed to EqualsNoCase()

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -618,7 +618,11 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
 
     // we need to sort if returned results don't specify 'sorted="yes"'
     if (fSort)
-      fSort = !StringUtils::EqualsNoCase(xhResults.Element()->Attribute("sorted"), "yes");
+    {
+      const char *sorted = xhResults.Element()->Attribute("sorted");
+      if (sorted != NULL)
+        fSort = !StringUtils::EqualsNoCase(sorted, "yes");
+    }
 
     for (TiXmlElement *pxeMovie = xhResults.FirstChild("entity").Element();
       pxeMovie; pxeMovie = pxeMovie->NextSiblingElement())


### PR DESCRIPTION
Stumbled upon this while testing with master after the CStdString drop:

Looks like that in https://github.com/xbmc/xbmc/commit/abba6f5dc5e95325db9d88ddfc5da4c55a4d53ba#diff-cd0ebb1146353f99c6dd421a4f733034R621 "xhResults.Element()->Attribute("sorted")" can result in a NULL return. This caused a segfault in StringUtils::EqualsNoCase() during scraping a source as that case is not checked there. This little patch checks that.

EDIT: Changed to check things before passing havoc to StringUtils.
