### PR TITLE
Input: Set Joystick's Gui Setting to disable by default

### DIFF
--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -8,5 +8,14 @@
         </setting>
       </group>
     </category>
+    <category id="input">
+      <group id="2">
+        <setting id="input.enablejoystick">
+          <requirement>HAS_SDL_JOYSTICK</requirement>
+          <level>0</level>
+          <default>false</default>
+        </setting>      
+      </group>
+    </category>
   </section>
 </settings>


### PR DESCRIPTION
After recent problems with keyboards detected as SDL Joysticks I think it's useful to disable Joysticks by default on linux. They can be enabled easily again via the menu.
