### PR TITLE
Validation substr() usage prior to plowing ahead.

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -145,7 +145,7 @@ CStdString CTextureCacheJob::DecodeImageURL(const CStdString &url, unsigned int 
 
     image = thumbURL.GetHostName();
 
-    CStdString optionString = thumbURL.GetOptions().substr(1);
+    CStdString optionString = thumbURL.GetOptions().empty() ? "" : thumbURL.GetOptions().substr(1);
     StringUtils::TrimRight(optionString, "/"); // In case XBMC adds a slash.
 
     std::vector<CStdString> options;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2205,7 +2205,8 @@ bool CUtil::FindVobSubPair( const std::vector<CStdString>& vecSubtitles, const C
         CURL::Decode(strSubDirectory);
       if (URIUtils::HasExtension(strSubFile, ".sub") &&
           (URIUtils::ReplaceExtension(strIdxFile,"").Equals(URIUtils::ReplaceExtension(strSubFile,"")) ||
-           StringUtils::EqualsNoCase(strSubDirectory.substr(6, strSubDirectory.length()-11), URIUtils::ReplaceExtension(strIdxPath,""))))
+           (strSubDirectory.size() >= 11 &&
+            StringUtils::EqualsNoCase(strSubDirectory.substr(6, strSubDirectory.length()-11), URIUtils::ReplaceExtension(strIdxPath,"")))))
       {
         strSubPath = vecSubtitles[j];
         return true;
@@ -2233,7 +2234,8 @@ bool CUtil::IsVobSub( const std::vector<CStdString>& vecSubtitles, const CStdStr
       URIUtils::Split(vecSubtitles[j], strIdxDirectory, strIdxFile);
       if (URIUtils::HasExtension(strIdxFile, ".idx") &&
           (URIUtils::ReplaceExtension(strIdxFile,"").Equals(URIUtils::ReplaceExtension(strSubFile,"")) ||
-           StringUtils::EqualsNoCase(strSubDirectory.substr(6, strSubDirectory.length()-11), URIUtils::ReplaceExtension(vecSubtitles[j],""))))
+           (strSubDirectory.size() >= 11 &&
+            StringUtils::EqualsNoCase(strSubDirectory.substr(6, strSubDirectory.length()-11), URIUtils::ReplaceExtension(vecSubtitles[j],"")))))
         return true;
     }
   }

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -175,9 +175,12 @@ void CDateTimeSpan::SetDateTimeSpan(int day, int hour, int minute, int second)
 
 void CDateTimeSpan::SetFromTimeString(const CStdString& time) // hh:mm
 {
-  int hour    = atoi(time.substr(0, 2).c_str());
-  int minutes = atoi(time.substr(3, 2).c_str());
-  SetDateTimeSpan(0,hour,minutes,0);
+  if (time.size() >= 5 && time[2] == ':')
+  {
+    int hour    = atoi(time.substr(0, 2).c_str());
+    int minutes = atoi(time.substr(3, 2).c_str());
+    SetDateTimeSpan(0,hour,minutes,0);
+  }
 }
 
 int CDateTimeSpan::GetDays() const
@@ -706,7 +709,7 @@ void CDateTime::SetFromDateString(const CStdString &date)
   }
 
   size_t iPos2 = date.find(",");
-  CStdString strDay = date.substr(iPos, iPos2-iPos);
+  CStdString strDay = (date.size() >= iPos) ? date.substr(iPos, iPos2-iPos) : "";
   CStdString strYear = date.substr(date.find(" ", iPos2) + 1);
   while (months[j] && stricmp(strMonth.c_str(),months[j]) != 0)
     j++;
@@ -970,10 +973,12 @@ void CDateTime::SetFromDBDateTime(const CStdString &dateTime)
 
 void CDateTime::SetFromDBDate(const CStdString &date)
 {
+  if (date.size() < 10)
+    return;
   // assumes format:
   // YYYY-MM-DD or DD-MM-YYYY
   int year = 0, month = 0, day = 0;
-  if (date.size() > 2 && (date[2] == '-' || date[2] == '.'))
+  if (date[2] == '-' || date[2] == '.')
   {
     day = atoi(date.substr(0, 2).c_str());
     month = atoi(date.substr(3, 2).c_str());
@@ -990,6 +995,8 @@ void CDateTime::SetFromDBDate(const CStdString &date)
 
 void CDateTime::SetFromDBTime(const CStdString &time)
 {
+  if (time.size() < 8)
+    return;
   // assumes format:
   // HH:MM:SS
   int hour, minute, second;

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -683,6 +683,7 @@ void CDateTime::FromULargeInt(const ULARGE_INTEGER& time)
 
 void CDateTime::SetFromDateString(const CStdString &date)
 {
+  /* TODO:STRING_CLEANUP */
   if (date.empty())
   {
     SetValid(false);

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -438,7 +438,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
         else if (strcmp(type, "time") == 0)
         {
           SYSTEMTIME timedate;
-          if (!value.empty())
+          if (value.size() >= 5)
           {
             // assumes HH:MM
             timedate.wHour = atoi(value.substr(0, 2).c_str());

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -761,7 +761,9 @@ void CGUIDialogKeyboardGeneric::OnPasteClipboard(void)
   {
     g_charsetConverter.utf8ToW(utf8_text, unicode_text);
 
-    int i = GetCursorPos();
+    size_t i = GetCursorPos();
+    if (i > m_strEdit.size())
+      i = m_strEdit.size();
     CStdStringW left_end = m_strEdit.substr(0, i);
     CStdStringW right_end = m_strEdit.substr(i);
 

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -192,9 +192,9 @@ CStdString CFavouritesDirectory::GetExecutePath(const CFileItem &item, const std
     if (!contextWindow.empty())
       execute = StringUtils::Format("ActivateWindow(%s,%s,return)", contextWindow.c_str(), StringUtils::Paramify(item.GetPath()).c_str());
   }
-  else if (item.IsScript())
+  else if (item.IsScript() && item.GetPath().size() > 9) // plugin://<foo>
     execute = StringUtils::Format("RunScript(%s)", StringUtils::Paramify(item.GetPath().substr(9)).c_str());
-  else if (item.IsAndroidApp())
+  else if (item.IsAndroidApp() && item.GetPath().size() > 26) // androidapp://sources/apps/<foo>
     execute = StringUtils::Format("StartAndroidActivity(%s)", StringUtils::Paramify(item.GetPath().substr(26)).c_str());
   else  // assume a media file
   {

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -192,6 +192,7 @@ CStdString CFavouritesDirectory::GetExecutePath(const CFileItem &item, const std
     if (!contextWindow.empty())
       execute = StringUtils::Format("ActivateWindow(%s,%s,return)", contextWindow.c_str(), StringUtils::Paramify(item.GetPath()).c_str());
   }
+  /* TODO:STRING_CLEANUP */
   else if (item.IsScript() && item.GetPath().size() > 9) // plugin://<foo>
     execute = StringUtils::Format("RunScript(%s)", StringUtils::Paramify(item.GetPath().substr(9)).c_str());
   else if (item.IsAndroidApp() && item.GetPath().size() > 26) // androidapp://sources/apps/<foo>

--- a/xbmc/filesystem/FileReaderFile.cpp
+++ b/xbmc/filesystem/FileReaderFile.cpp
@@ -43,6 +43,7 @@ CFileReaderFile::~CFileReaderFile()
 //*********************************************************************************************
 bool CFileReaderFile::Open(const CURL& url)
 {
+  // URL is of the form filereader://<foo>
   CStdString strURL = url.Get();
   strURL = strURL.substr(13);
   return m_reader.Open(strURL,READ_CACHED);

--- a/xbmc/filesystem/HTSPDirectory.cpp
+++ b/xbmc/filesystem/HTSPDirectory.cpp
@@ -406,7 +406,9 @@ bool CHTSPDirectory::GetTag(const CURL &base, CFileItemList &items)
 {
   CURL url(base);
 
-  int id = atoi(url.GetFileName().substr(5).c_str());
+  int id = 0;
+  if (url.GetFileName().size() >= 5)
+    id = atoi(url.GetFileName().substr(5).c_str());
 
   SChannels channels = m_session->GetChannels(id);
   if(channels.empty())

--- a/xbmc/filesystem/RTVDirectory.cpp
+++ b/xbmc/filesystem/RTVDirectory.cpp
@@ -190,22 +190,26 @@ bool CRTVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
         if (recordedNode)
         {
           CStdString strRecorded = recordedNode->FirstChild()->Value();
-          int iYear, iMonth, iDay;
 
-          iYear = atoi(strRecorded.substr(0, 4).c_str());
-          iMonth = atoi(strRecorded.substr(5, 2).c_str());
-          iDay = atoi(strRecorded.substr(8, 2).c_str());
-          dtDateTime.wYear = iYear;
-          dtDateTime.wMonth = iMonth;
-          dtDateTime.wDay = iDay;
+          if (strRecorded.size() >= 19)
+          {
+            /* TODO:STRING_CLEANUP */
+            int iYear, iMonth, iDay;
+            iYear = atoi(strRecorded.substr(0, 4).c_str());
+            iMonth = atoi(strRecorded.substr(5, 2).c_str());
+            iDay = atoi(strRecorded.substr(8, 2).c_str());
+            dtDateTime.wYear = iYear;
+            dtDateTime.wMonth = iMonth;
+            dtDateTime.wDay = iDay;
 
-          int iHour, iMin, iSec;
-          iHour = atoi(strRecorded.substr(11, 2).c_str());
-          iMin = atoi(strRecorded.substr(14, 2).c_str());
-          iSec = atoi(strRecorded.substr(17, 2).c_str());
-          dtDateTime.wHour = iHour;
-          dtDateTime.wMinute = iMin;
-          dtDateTime.wSecond = iSec;
+            int iHour, iMin, iSec;
+            iHour = atoi(strRecorded.substr(11, 2).c_str());
+            iMin = atoi(strRecorded.substr(14, 2).c_str());
+            iSec = atoi(strRecorded.substr(17, 2).c_str());
+            dtDateTime.wHour = iHour;
+            dtDateTime.wMinute = iMin;
+            dtDateTime.wSecond = iSec;
+          }
         }
 
         // PATH

--- a/xbmc/filesystem/SFTPFile.cpp
+++ b/xbmc/filesystem/SFTPFile.cpp
@@ -50,7 +50,9 @@ using namespace std;
 
 static CStdString CorrectPath(const CStdString path)
 {
-  if(path == "~" || path.substr(0, 2) == "~/")
+  if (path == "~")
+    return "./";
+  else if (path.substr(0, 2) == "~/")
     return "./" + path.substr(2);
   else
     return "/" + path;

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -105,7 +105,7 @@ void CGUIInfoColor::Parse(const CStdString &label, int context)
   if (label.Equals("-", false))
     return;
 
-  if (StringUtils::StartsWithNoCase(label, "$var"))
+  if (StringUtils::StartsWithNoCase(label, "$var["))
   {
     label2 = label.substr(5, label.length() - 6);
     m_info = g_infoManager.TranslateSkinVariableString(label2, context);
@@ -114,7 +114,7 @@ void CGUIInfoColor::Parse(const CStdString &label, int context)
     return;
   }
 
-  if (StringUtils::StartsWithNoCase(label, "$info"))
+  if (StringUtils::StartsWithNoCase(label, "$info["))
     label2 = label.substr(6, label.length()-7);
 
   m_info = g_infoManager.TranslateString(label2);
@@ -208,7 +208,7 @@ CStdString CGUIInfoLabel::ReplaceLocalize(const CStdString &label)
   while (pos1 != std::string::npos)
   {
     size_t pos2 = StringUtils::FindEndBracket(work, '[', ']', pos1 + 10);
-    if (pos2 > pos1)
+    if (pos2 != std::string::npos)
     {
       CStdString left = work.substr(0, pos1);
       CStdString right = work.substr(pos2 + 1);
@@ -236,7 +236,7 @@ CStdString CGUIInfoLabel::ReplaceAddonStrings(const CStdString &label)
   while (pos1 != std::string::npos)
   {
     size_t pos2 = StringUtils::FindEndBracket(work, '[', ']', pos1 + 7);
-    if (pos2 > pos1)
+    if (pos2 != std::string::npos)
     {
       CStdString left = work.substr(0, pos1);
       CStdString right = work.substr(pos2 + 1);
@@ -300,7 +300,7 @@ void CGUIInfoLabel::Parse(const CStdString &label, int context)
         m_info.push_back(CInfoPortion(0, work.substr(0, pos1), ""));
 
       pos2 = StringUtils::FindEndBracket(work, '[', ']', pos1 + len);
-      if (pos2 > pos1)
+      if (pos2 != std::string::npos)
       {
         // decipher the block
         CStdString block = work.substr(pos1 + len, pos2 - pos1 - len);

--- a/xbmc/linux/LinuxTimezone.cpp
+++ b/xbmc/linux/LinuxTimezone.cpp
@@ -116,6 +116,7 @@ CLinuxTimezone::CLinuxTimezone() : m_IsDST(0)
          s = line;
          StringUtils::Trim(s);
 
+        /* TODO:STRING_CLEANUP */
          if (s.length() == 0)
             continue;
 

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -556,7 +556,7 @@ void Xcddb::parseData(const char *buffer)
       {
         // Extract Year from extended info
         // as a fallback
-        size_t iPos = strExtd.find("YEAR:");
+        size_t iPos = strExtd.find("YEAR: ");
         if (iPos != std::string::npos) // You never know if you really get UTF-8 strings from cddb
           g_charsetConverter.unknownToUTF8(strExtd.substr(iPos + 6, 4), m_strYear);
       }
@@ -565,7 +565,7 @@ void Xcddb::parseData(const char *buffer)
       {
         // Extract ID3 Genre
         // as a fallback
-        size_t iPos = strExtd.find("ID3G:");
+        size_t iPos = strExtd.find("ID3G: ");
         if (iPos != std::string::npos)
         {
           CStdString strGenre = strExtd.substr(iPos + 5, 4);

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -523,6 +523,7 @@ void Xcddb::parseData(const char *buffer)
     CStdString strKeyword = *it;
     CStdString strValue = keywords[strKeyword];
 
+    /* TODO:STRING_CLEANUP */
     if (strKeyword == "DTITLE")
     {
       // DTITLE may contain artist and disc title, separated with " / ",

--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -209,14 +209,13 @@ CStdString CNetworkInterfaceLinux::GetCurrentDefaultGateway(void)
     if (fread(buffer, sizeof(char), sizeof(buffer), pipe) > 0 && !ferror(pipe))
     {
       tmpStr = buffer;
-      result = tmpStr.substr(11);
-    }
-    else
-    {
-      CLog::Log(LOGWARNING, "Unable to determine gateway");
+      if (tmpStr.length() >= 11)
+        result = tmpStr.substr(11);
     }
     pclose(pipe);
   }
+  if (result.empty())
+    CLog::Log(LOGWARNING, "Unable to determine gateway");
 #elif defined(TARGET_FREEBSD)
    size_t needed;
    int mib[6];
@@ -482,14 +481,13 @@ std::vector<CStdString> CNetworkLinux::GetNameServers(void)
     if (fread(buffer, sizeof(char), sizeof(buffer), pipe) > 0 && !ferror(pipe))
     {
       tmpStr = buffer;
-      result.push_back(tmpStr.substr(17));
-    }
-    else
-    {
-      CLog::Log(LOGWARNING, "Unable to determine nameserver");
+      if (tmpStr.length() >= 17)
+        result.push_back(tmpStr.substr(17));
     }
     pclose(pipe);
   } 
+  if (result.empty())
+    CLog::Log(LOGWARNING, "Unable to determine nameserver");
 #elif defined(TARGET_ANDROID)
   char nameserver[PROP_VALUE_MAX];
 

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -1199,11 +1199,10 @@ CUPnPServer::SortItems(CFileItemList& items, const char* sort_criteria)
   bool sorted = false;
   CStdStringArray tokens = StringUtils::SplitString(criteria, ",");
   for (vector<CStdString>::reverse_iterator itr = tokens.rbegin(); itr != tokens.rend(); itr++) {
-    CStdString method = itr->substr(1);
-
     SortDescription sorting;
     /* Platinum guarantees 1st char is - or + */
     sorting.sortOrder = StringUtils::StartsWith(*itr, "+") ? SortOrderAscending : SortOrderDescending;
+    CStdString method = itr->substr(1);
 
     /* resource specific */
     if (method.Equals("res@duration"))

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -92,7 +92,7 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
       g_windowManager.SendMessage(msg);
       int iSelected = msg.GetParam1();
       if (iSelected == m_vecItems->Size() - 1)
-      { // Get More... item.
+      { // Get More... item, path 'addons://more/<content>'
         // This is tricky - ideally we want to completely save the state of this dialog,
         // close it while linking to the addon manager, then reopen it on return.
         // For now, we just close the dialog + send the GetPath() to open the addons window

--- a/xbmc/utils/Fanart.cpp
+++ b/xbmc/utils/Fanart.cpp
@@ -107,7 +107,8 @@ CStdString CFanart::GetPreviewURL(unsigned int index) const
 
 const CStdString CFanart::GetColor(unsigned int index) const
 {
-  if (index >= max_fanart_colors || m_fanart.size() == 0)
+  if (index >= max_fanart_colors || m_fanart.size() == 0 ||
+      m_fanart[0].strColors.size() < index*9+8)
     return "FFFFFFFF";
 
   // format is AARRGGBB,AARRGGBB etc.

--- a/xbmc/utils/HTMLUtil.cpp
+++ b/xbmc/utils/HTMLUtil.cpp
@@ -287,6 +287,7 @@ static const HTMLMapping mappings[] =
 
 void CHTMLUtil::ConvertHTMLToW(const CStdStringW& strHTML, CStdStringW& strStripped)
 {
+  /* TODO:STRING_CLEANUP */
   if (strHTML.size() == 0)
   {
     strStripped.clear();

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -561,7 +561,7 @@ bool CTuxBoxUtil::GetZapUrl(const CStdString& strPath, CFileItem &items )
         {
           for (vector<sAudioChannel>::iterator sChannel = sCurSrvData.audio_channels.begin(); sChannel!=sCurSrvData.audio_channels.end(); ++sChannel)
           {
-            if (sChannel->pid != sRequestedAudioChannel.pid)
+            if (sChannel->pid != sRequestedAudioChannel.pid && sChannel->pid.size() >= 4)
               strAPids += "," + sChannel->pid.substr(sChannel->pid.size() - 4);
           }
           CLog::Log(LOGDEBUG, "%s - Sending all audio pids: %s%s", __FUNCTION__, strAudioChannelPid.c_str(), strAPids.c_str());

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -460,7 +460,7 @@ bool URIUtils::IsRemote(const CStdString& strFile)
 bool URIUtils::IsOnDVD(const CStdString& strFile)
 {
 #ifdef TARGET_WINDOWS
-  if (strFile.substr(1,1) == ":")
+  if (strFile.size() >= 2 && strFile.substr(1,1) == ":")
     return (GetDriveType(strFile.substr(0, 3).c_str()) == DRIVE_CDROM);
 #endif
 
@@ -593,8 +593,7 @@ bool URIUtils::IsDVD(const CStdString& strFile)
   if (StringUtils::StartsWithNoCase(strFile, "dvd://"))
     return true;
 
-  if(strFile.substr(1) != ":\\"
-  && strFile.substr(1) != ":")
+  if(strFile.size() < 2 || (strFile.substr(1) != ":\\" && strFile.substr(1) != ":"))
     return false;
 
   if(GetDriveType(strFile.c_str()) == DRIVE_CDROM)

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -138,6 +138,7 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(unsigned int id)
   {
     CStdString strAudioInfo;
     g_application.m_pPlayer->GetAudioInfo(strAudioInfo);
+    /* TODO:STRING_CLEANUP */
     int iNumChannels = 0;
     size_t pos = strAudioInfo.find("chns:");
     if (pos != std::string::npos)

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -138,8 +138,13 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(unsigned int id)
   {
     CStdString strAudioInfo;
     g_application.m_pPlayer->GetAudioInfo(strAudioInfo);
-    int iNumChannels = atoi(strAudioInfo.substr(strAudioInfo.find("chns:") + 5).c_str());
-    CStdString strAudioCodec = strAudioInfo.substr(7, strAudioInfo.find(") VBR") - 5);
+    int iNumChannels = 0;
+    size_t pos = strAudioInfo.find("chns:");
+    if (pos != std::string::npos)
+      iNumChannels = atoi(strAudioInfo.substr(pos + 5).c_str());
+    CStdString strAudioCodec;
+    if (strAudioInfo.size() > 7)
+      strAudioCodec = strAudioInfo.substr(7, strAudioInfo.find(") VBR") - 5);
     bool bDTS = strstr(strAudioCodec.c_str(), "DTS") != 0;
     bool bAC3 = strstr(strAudioCodec.c_str(), "AC3") != 0;
     if (iNumChannels == 2 && !(bDTS || bAC3))

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -866,7 +866,7 @@ void CWIN32Util::GetDrivesByType(VECSOURCES &localDrives, Drive_Types eDriveType
       UINT uDriveType= GetDriveTypeW( strWdrive.c_str()  );
       // don't use GetVolumeInformation on fdd's as the floppy controller may be enabled in Bios but
       // no floppy HW is attached which causes huge delays.
-      if(strWdrive.substr(0,2) != L"A:" && strWdrive.substr(0,2) != L"B:")
+      if(strWdrive.size() >= 2 && strWdrive.substr(0,2) != L"A:" && strWdrive.substr(0,2) != L"B:")
         nResult= GetVolumeInformationW( strWdrive.c_str() , cVolumeName, 100, 0, 0, 0, NULL, 25);
       if(nResult == 0 && bonlywithmedia)
       {
@@ -1592,6 +1592,9 @@ extern "C"
 
 bool CWIN32Util::IsUsbDevice(const CStdStringW &strWdrive)
 {
+  if (strWdrive.size() < 2)
+    return false;
+
   CStdStringW strWDevicePath = StringUtils::Format(L"\\\\.\\%s",strWdrive.substr(0, 2).c_str());
 
   HANDLE deviceHandle = CreateFileW(


### PR DESCRIPTION
In the .Mid()/Left()/Right() removal, replacement with .substr() was done in some circumstances without checking the first parameter (pos) of substr().  If pos is greater than the string length, substr() will throw.

This fixes those locations associated with .Mid() -> substr() conversion.

I've specifically noted areas of the code that could do with a cleanup.  Am confident about all commits, but would appreciate another eye.

@Montellese: An eye over the musicvideoalbum change in CVideoDatabase would be appreciated.

EDIT: Done Right/Left, so this _should_ cover any throw'ing due to substr changes.
