### PR TITLE
FIX: [droid] do not package non-standard joystick keymap

### DIFF
--- a/tools/android/packaging/Makefile
+++ b/tools/android/packaging/Makefile
@@ -74,6 +74,7 @@ extras: libs
 	find `pwd`/xbmc/assets/ -depth -name ".git" -exec rm -rf {} \;
 	find `pwd`/xbmc/assets/system/ -name "*.so" -exec rm {} \;
 	find `pwd`/xbmc/assets/addons/skin.*/media/* -depth -not -iname "Textures.xbt" -exec rm -rf {} \;
+	find `pwd`/xbmc/assets/system/keymaps/ -depth -name "joystick*.xml" ! -name "joystick.xml" -exec rm {} \;
 	@echo "native_arch=$(ARCH)" > xbmc/res/raw/xbmc.properties
 	cd xbmc/assets/addons; rm -rf $(EXCLUDED_ADDONS)
 	cp -rfp $(PREFIX)/lib/python2.6 xbmc/assets/python2.6/lib/


### PR DESCRIPTION
Ref: http://forum.xbmc.org/showthread.php?tid=173413&pid=1551731#pid1551731

Apparently, on non-droid platforms, the buttons and axises number change from joystick to joystick, while they are fixed at OS level in droid.
Result is that using, e.g., a PS3 gamepad, on droid doesn't work because the buttons number are wrong.

All droid needs is the default map, so do not pack the others.

/cc @davilla @garbear 
