### PR TITLE
Mediacodec fixes

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -56,6 +56,7 @@ static bool CanSurfaceRenderWhiteList(const std::string &name)
   // cannot surface render.
     static const char *cansurfacerender_decoders[] = {
       "OMX.Nvidia",
+      "OMX.rk",
       NULL
     };
     for (const char **ptr = cansurfacerender_decoders; *ptr; ptr++)


### PR DESCRIPTION
- Add a black list for software components (VP8 s/w omx crashes on my N7)
- Add rockchip to hardware components, because software just plain crashes ;) (on Minix)

/cc @davilla 
