### PR TITLE
Skin position fix

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -276,7 +276,7 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
         hasLeft = hasWidth = true;
       }
     }
-    else // neither right nor center specified
+    else if (hasLeft) // neither right nor center specified
     {
       width = max(0.0f, parentSize - left); // if left=0, this fills to parent
     }


### PR DESCRIPTION
Controls that use the old `<posx>, <posy>` and were missing `<width>` or `<height>` had their width and height computed from the parent before the x and y position were applied.

@MartijnKaijser This should fix the touched issue.
