### PR TITLE
Control positioning: Make <right>, <bottom> measure from right and bottom

### DIFF
--- a/addons/skin.confluence/720p/DialogAddonInfo.xml
+++ b/addons/skin.confluence/720p/DialogAddonInfo.xml
@@ -86,7 +86,7 @@
 				<top>130</top>
 				<control type="label">
 					<description>Type txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>0</top>
 					<width>140</width>
 					<height>25</height>
@@ -110,7 +110,7 @@
 				</control>
 				<control type="label">
 					<description>Author txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>30</top>
 					<width>140</width>
 					<height>25</height>
@@ -134,7 +134,7 @@
 				</control>
 				<control type="label">
 					<description>Version txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>60</top>
 					<width>140</width>
 					<height>25</height>
@@ -158,7 +158,7 @@
 				</control>
 				<control type="label">
 					<description>Rating txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>90</top>
 					<width>140</width>
 					<height>25</height>
@@ -179,7 +179,7 @@
 				</control>
 				<control type="label">
 					<description>Summary txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>120</top>
 					<width>140</width>
 					<height>25</height>
@@ -225,7 +225,7 @@
 					<visible>!IsEmpty(ListItem.Property(Addon.Disclaimer))</visible>
 					<control type="label">
 						<description>Description Page Count</description>
-						<right>610</right>
+						<left>310</left>
 						<top>170</top>
 						<width>300</width>
 						<height>25</height>
@@ -291,7 +291,7 @@
 					<visible>IsEmpty(ListItem.Property(Addon.Disclaimer))</visible>
 					<control type="label">
 						<description>Description Page Count</description>
-						<right>610</right>
+						<left>310</left>
 						<top>170</top>
 						<width>300</width>
 						<height>25</height>

--- a/addons/skin.confluence/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence/720p/DialogAlbumInfo.xml
@@ -414,7 +414,7 @@
 					</control>
 				</control>
 				<control type="label">
-					<right>130r</right>
+					<right>130</right>
 					<top>480</top>
 					<width>400</width>
 					<height>30</height>
@@ -428,7 +428,7 @@
 					<visible>Control.IsVisible(4)</visible>
 				</control>
 				<control type="label">
-					<right>130r</right>
+					<right>130</right>
 					<top>480</top>
 					<width>400</width>
 					<height>30</height>
@@ -442,7 +442,7 @@
 					<visible>Control.IsVisible(50) + Container.Content(Albums)</visible>
 				</control>
 				<control type="label">
-					<right>130r</right>
+					<right>130</right>
 					<top>480</top>
 					<width>400</width>
 					<height>30</height>

--- a/addons/skin.confluence/720p/DialogFavourites.xml
+++ b/addons/skin.confluence/720p/DialogFavourites.xml
@@ -108,7 +108,7 @@
 			</control>
 			<control type="label">
 				<description>Page label</description>
-				<right>30r</right>
+				<right>30</right>
 				<top>670</top>
 				<width>350</width>
 				<height>30</height>

--- a/addons/skin.confluence/720p/DialogPVRChannelsOSD.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelsOSD.xml
@@ -343,7 +343,7 @@
 			</control>
 			<control type="label">
 				<description>Page Count Label</description>
-				<right>450</right>
+				<left>50</left>
 				<top>610</top>
 				<width>400</width>
 				<height>20</height>

--- a/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
@@ -85,7 +85,7 @@
 					<top>120</top>
 					<control type="label">
 						<description>Time description</description>
-						<right>170</right>
+						<left>0</left>
 						<top>0</top>
 						<width>170</width>
 						<height>25</height>
@@ -109,7 +109,7 @@
 					</control>
 					<control type="label">
 						<description>Duration</description>
-						<right>170</right>
+						<left>0</left>
 						<top>35</top>
 						<width>170</width>
 						<height>25</height>
@@ -133,7 +133,7 @@
 					</control>
 					<control type="label">
 						<description>Channel Name</description>
-						<right>170</right>
+						<left>0</left>
 						<top>70</top>
 						<width>170</width>
 						<height>25</height>
@@ -157,7 +157,7 @@
 					</control>
 					<control type="label">
 						<description>Genre</description>
-						<right>170</right>
+						<left>0</left>
 						<top>105</top>
 						<width>170</width>
 						<height>25</height>

--- a/addons/skin.confluence/720p/DialogPVRGuideOSD.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideOSD.xml
@@ -237,7 +237,7 @@
 			</control>
 			<control type="label">
 				<description>Page Count Label</description>
-				<right>450</right>
+				<left>50</left>
 				<top>610</top>
 				<width>400</width>
 				<height>20</height>

--- a/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRRecordingInfo.xml
@@ -82,7 +82,7 @@
 			<top>140</top>
 			<control type="label">
 				<description>Start Date</description>
-				<right>170</right>
+				<left>10</left>
 				<top>0</top>
 				<width>160</width>
 				<height>25</height>
@@ -106,7 +106,7 @@
 			</control>
 			<control type="label">
 				<description>Start time</description>
-				<right>170</right>
+				<left>10</left>
 				<top>35</top>
 				<width>160</width>
 				<height>25</height>
@@ -130,7 +130,7 @@
 			</control>
 			<control type="label">
 				<description>Channel Name</description>
-				<right>170</right>
+				<left>10</left>
 				<top>70</top>
 				<width>160</width>
 				<height>25</height>
@@ -154,7 +154,7 @@
 			</control>
 			<control type="label">
 				<description>Duration</description>
-				<right>170</right>
+				<left>10</left>
 				<top>105</top>
 				<width>160</width>
 				<height>25</height>
@@ -176,7 +176,7 @@
 			</control>
 			<control type="label">
 				<description>Genre</description>
-				<right>170</right>
+				<left>10</left>
 				<top>140</top>
 				<width>160</width>
 				<height>25</height>
@@ -210,7 +210,7 @@
 			</control>
 		</control>
 		<control type="label">
-			<right>610</right>
+			<left>210</left>
 			<top>370</top>
 			<width>400</width>
 			<height>30</height>

--- a/addons/skin.confluence/720p/DialogPeripheralManager.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralManager.xml
@@ -202,7 +202,7 @@
 			</control>
 			<control type="label">
 				<description>number of files/pages in list text label</description>
-				<right>580</right>
+				<left>280</left>
 				<top>585</top>
 				<width>300</width>
 				<height>35</height>

--- a/addons/skin.confluence/720p/DialogPictureInfo.xml
+++ b/addons/skin.confluence/720p/DialogPictureInfo.xml
@@ -174,7 +174,7 @@
 			</control>
 			<control type="label">
 				<description>number of files/pages in list text label</description>
-				<right>760</right>
+				<left>460</left>
 				<top>570</top>
 				<width>300</width>
 				<height>35</height>

--- a/addons/skin.confluence/720p/DialogSelect.xml
+++ b/addons/skin.confluence/720p/DialogSelect.xml
@@ -256,7 +256,7 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in list text label</description>
-			<right>580</right>
+			<left>280</left>
 			<top>585</top>
 			<width>300</width>
 			<height>35</height>
@@ -270,7 +270,7 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in list text label</description>
-			<right>580</right>
+			<left>280</left>
 			<top>587</top>
 			<width>300</width>
 			<height>35</height>

--- a/addons/skin.confluence/720p/DialogSlider.xml
+++ b/addons/skin.confluence/720p/DialogSlider.xml
@@ -29,7 +29,7 @@
 		</control>
 		<control type="label" id="12">
 			<description>Slider Value</description>
-			<right>440</right>
+			<left>220</left>
 			<top>10</top>
 			<width>220</width>
 			<height>20</height>

--- a/addons/skin.confluence/720p/DialogSongInfo.xml
+++ b/addons/skin.confluence/720p/DialogSongInfo.xml
@@ -91,7 +91,7 @@
 				<top>120</top>
 				<control type="label">
 					<description>Artist Title</description>
-					<right>150</right>
+					<left>0</left>
 					<top>0</top>
 					<width>150</width>
 					<height>25</height>
@@ -117,7 +117,7 @@
 				</control>
 				<control type="label">
 					<description>Album Title</description>
-					<right>150</right>
+					<left>0</left>
 					<top>30</top>
 					<width>150</width>
 					<height>25</height>
@@ -143,7 +143,7 @@
 				</control>
 				<control type="label">
 					<description>Genre Title</description>
-					<right>150</right>
+					<left>0</left>
 					<top>60</top>
 					<width>150</width>
 					<height>25</height>
@@ -169,7 +169,7 @@
 				</control>
 				<control type="label">
 					<description>Year Title</description>
-					<right>150</right>
+					<left>0</left>
 					<top>90</top>
 					<width>150</width>
 					<height>25</height>
@@ -193,7 +193,7 @@
 				</control>
 				<control type="label">
 					<description>Track Number Title</description>
-					<right>150</right>
+					<left>0</left>
 					<top>120</top>
 					<width>150</width>
 					<height>25</height>
@@ -217,7 +217,7 @@
 				</control>
 				<control type="label">
 					<description>Rating Title</description>
-					<right>150</right>
+					<left>0</left>
 					<top>150</top>
 					<width>150</width>
 					<height>25</height>
@@ -270,7 +270,7 @@
 				</control>
 				<control type="label">
 					<description>Comment Title</description>
-					<right>150</right>
+					<left>0</left>
 					<top>180</top>
 					<width>150</width>
 					<height>25</height>

--- a/addons/skin.confluence/720p/DialogSubtitles.xml
+++ b/addons/skin.confluence/720p/DialogSubtitles.xml
@@ -52,7 +52,7 @@
 			<control type="group">
 				<control type="label" id="100">
 					<description>header label</description>
-					<right>880</right>
+					<left>330</left>
 					<top>80</top>
 					<width>550</width>
 					<height>30</height>
@@ -64,7 +64,7 @@
 				</control>
 				<control type="label">
 					<description>Video label</description>
-					<right>880</right>
+					<left>330</left>
 					<top>110</top>
 					<width>550</width>
 					<height>30</height>

--- a/addons/skin.confluence/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence/720p/DialogVideoInfo.xml
@@ -806,7 +806,7 @@
 					</control>
 				</control>
 				<control type="label">
-					<right>130r</right>
+					<right>130</right>
 					<top>480</top>
 					<width>400</width>
 					<height>30</height>
@@ -820,7 +820,7 @@
 					<visible>Control.IsVisible(400)</visible>
 				</control>
 				<control type="label">
-					<right>130r</right>
+					<right>130</right>
 					<top>480</top>
 					<width>400</width>
 					<height>30</height>

--- a/addons/skin.confluence/720p/FileBrowser.xml
+++ b/addons/skin.confluence/720p/FileBrowser.xml
@@ -43,7 +43,7 @@
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<control type="label" id="411">
 					<description>header label</description>
-					<right>660</right>
+					<left>30</left>
 					<top>40</top>
 					<width>630</width>
 					<height>30</height>
@@ -56,7 +56,7 @@
 				</control>
 				<control type="label" id="412">
 					<description>Path label</description>
-					<right>660</right>
+					<left>30</left>
 					<top>70</top>
 					<width>630</width>
 					<height>30</height>
@@ -300,7 +300,7 @@
 				</control>
 				<control type="label">
 					<description>Page label</description>
-					<right>660</right>
+					<left>100</left>
 					<top>680</top>
 					<width>560</width>
 					<height>30</height>
@@ -313,7 +313,7 @@
 				</control>
 				<control type="label">
 					<description>Page label</description>
-					<right>660</right>
+					<left>100</left>
 					<top>680</top>
 					<width>560</width>
 					<height>30</height>

--- a/addons/skin.confluence/720p/FileManager.xml
+++ b/addons/skin.confluence/720p/FileManager.xml
@@ -246,7 +246,7 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<right>580</right>
+				<left>110</left>
 				<top>30</top>
 				<width>470</width>
 				<height>30</height>
@@ -259,7 +259,7 @@
 			</control>
 			<control type="label" id="102">
 				<description>current directory text label</description>
-				<right>580</right>
+				<left>110</left>
 				<top>70</top>
 				<width>470</width>
 				<height>30</height>
@@ -397,7 +397,7 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in left list text label</description>
-			<right>40r</right>
+			<right>40</right>
 			<top>53r</top>
 			<width>570</width>
 			<font>font12</font>

--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -123,7 +123,7 @@
 				</control>
 				<control type="label">
 					<description>Next Timer Header label</description>
-					<right>355</right>
+					<left>-45</left>
 					<top>5</top>
 					<height>25</height>
 					<width>400</width>
@@ -136,7 +136,7 @@
 				</control>
 				<control type="label">
 					<description>NextRecordingDateTime</description>
-					<right>390</right>
+					<left>-10</left>
 					<top>30</top>
 					<height>25</height>
 					<width>400</width>
@@ -149,7 +149,7 @@
 				</control>
 				<control type="label">
 					<description>NextRecordingTitle Channel</description>
-					<right>390</right>
+					<left>-410</left>
 					<top>50</top>
 					<height>25</height>
 					<width>800</width>
@@ -190,7 +190,7 @@
 				</control>
 				<control type="label">
 					<description>Is Recording Header label</description>
-					<right>350</right>
+					<left>-50</left>
 					<top>5</top>
 					<height>25</height>
 					<width>400</width>
@@ -203,7 +203,7 @@
 				</control>
 				<control type="label">
 					<description>NextRecordingDateTime</description>
-					<right>390</right>
+					<left>-10</left>
 					<top>30</top>
 					<height>25</height>
 					<width>400</width>
@@ -216,7 +216,7 @@
 				</control>
 				<control type="label">
 					<description>NextRecordingTitle Channel</description>
-					<right>390</right>
+					<left>-410</left>
 					<top>50</top>
 					<height>30</height>
 					<width>800</width>
@@ -1183,7 +1183,7 @@
 		<include>Clock</include>
 		<control type="label">
 			<description>Date label</description>
-			<right>20r</right>
+			<right>20</right>
 			<top>35</top>
 			<width>200</width>
 			<height>15</height>

--- a/addons/skin.confluence/720p/LoginScreen.xml
+++ b/addons/skin.confluence/720p/LoginScreen.xml
@@ -172,7 +172,7 @@
 				<left>940</left>
 				<top>600</top>
 				<control type="label">
-					<right>0</right>
+					<left>-580</left>
 					<top>0</top>
 					<width>580</width>
 					<height>45</height>
@@ -221,7 +221,7 @@
 		<include>Clock</include>
 		<control type="label">
 			<description>Date label</description>
-			<right>20r</right>
+			<right>20</right>
 			<top>35</top>
 			<width>200</width>
 			<height>15</height>

--- a/addons/skin.confluence/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence/720p/MusicVisualisation.xml
@@ -63,7 +63,7 @@
 			</control>
 			<control type="label">
 				<description>Clock label</description>
-				<right>1250</right>
+				<left>450</left>
 				<top>5</top>
 				<width>800</width>
 				<height>25</height>
@@ -206,7 +206,7 @@
 					<info>Player.Progress</info>
 				</control>
 				<control type="label">
-					<right>920</right>
+					<left>820</left>
 					<top>0</top>
 					<width>100</width>
 					<height>40</height>

--- a/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
@@ -268,7 +268,7 @@
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
 			</control>
 			<control type="label">
-				<right>440</right>
+				<left>30</left>
 				<top>40</top>
 				<width>410</width>
 				<height>30</height>
@@ -295,7 +295,7 @@
 			</control>
 			<control type="label">
 				<description>Page Count Label</description>
-				<right>440</right>
+				<left>140</left>
 				<top>38r</top>
 				<width>300</width>
 				<height>20</height>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -149,7 +149,7 @@
 					</control>
 					<control type="label">
 						<description>current temp Value</description>
-						<right>195</right>
+						<left>15</left>
 						<top>185</top>
 						<width>180</width>
 						<height>40</height>
@@ -206,7 +206,7 @@
 				</control>
 				<control type="label">
 					<description>current feels like label</description>
-					<right>170</right>
+					<left>0</left>
 					<top>400</top>
 					<width>170</width>
 					<height>35</height>
@@ -219,7 +219,7 @@
 				</control>
 				<control type="label">
 					<description>current dew label</description>
-					<right>170</right>
+					<left>0</left>
 					<top>430</top>
 					<width>170</width>
 					<height>35</height>
@@ -232,7 +232,7 @@
 				</control>
 				<control type="label">
 					<description>current humidity label</description>
-					<right>170</right>
+					<left>0</left>
 					<top>460</top>
 					<width>170</width>
 					<height>35</height>
@@ -245,7 +245,7 @@
 				</control>
 				<control type="label">
 					<description>current UV Index label</description>
-					<right>170</right>
+					<left>0</left>
 					<top>490</top>
 					<width>170</width>
 					<height>35</height>
@@ -258,7 +258,7 @@
 				</control>
 				<control type="label">
 					<description>current Wind label</description>
-					<right>170</right>
+					<left>0</left>
 					<top>520</top>
 					<width>170</width>
 					<height>35</height>
@@ -351,7 +351,7 @@
 					</control>
 					<control type="label">
 						<description>Sunset label</description>
-						<right>470</right>
+						<left>170</left>
 						<top>570</top>
 						<width>300</width>
 						<height>35</height>
@@ -682,7 +682,7 @@
 				<control type="label">
 					<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 					<description>number of files/pages</description>
-					<right>660</right>
+					<left>90</left>
 					<top>627</top>
 					<width>570</width>
 					<font>font12</font>

--- a/addons/skin.confluence/720p/SettingsCategory.xml
+++ b/addons/skin.confluence/720p/SettingsCategory.xml
@@ -100,7 +100,7 @@
 				<onclick>SettingsLevelChange</onclick>
 			</control>
 			<control type="label">
-				<right>250</right>
+				<left>20</left>
 				<top>566</top>
 				<height>25</height>
 				<width>230</width> 

--- a/addons/skin.confluence/720p/SettingsProfile.xml
+++ b/addons/skin.confluence/720p/SettingsProfile.xml
@@ -84,7 +84,7 @@
 				<enable>!Window.IsVisible(ProfileSettings)</enable>
 			</control>
 			<control type="label">
-				<right>250</right>
+				<left>10</left>
 				<top>130</top>
 				<width>240</width>
 				<height>25</height>
@@ -96,7 +96,7 @@
 				<visible>System.HasLoginScreen</visible>
 			</control>
 			<control type="label">
-				<right>250</right>
+				<left>10</left>
 				<top>130</top>
 				<width>240</width>
 				<height>25</height>
@@ -149,7 +149,7 @@
 				<enable>false</enable> 
 			</control> 
 			<control type="label"> 
-				<right>247</right> 
+				<left>47</left>
 				<top>201</top> 
 				<width>200</width> 
 				<height>25</height> 

--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -276,7 +276,7 @@
 				</control>
 				<control type="label" id="52">
 					<description>XBMC BUILD Version</description>
-					<right>750</right>
+					<left>20</left>
 					<top>400</top>
 					<width>730</width>
 					<label>144</label>
@@ -287,7 +287,7 @@
 				</control>
 				<control type="label">
 					<description>CPU Text</description>
-					<right>420</right>
+					<left>70</left>
 					<top>450</top>
 					<width>350</width>
 					<height>25</height>
@@ -308,7 +308,7 @@
 				</control>
 				<control type="label">
 					<description>Memory Text</description>
-					<right>420</right>
+					<left>70</left>
 					<top>480</top>
 					<width>350</width>
 					<height>25</height>

--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -43,7 +43,7 @@
 			</control>
 			<control type="label" id="1">
 				<description>Clock label</description>
-				<right>1250</right>
+				<left>450</left>
 				<top>5</top>
 				<width>800</width>
 				<height>25</height>
@@ -336,7 +336,7 @@
 				</control>
 				<control type="label" id="1">
 					<visible>!VideoPlayer.Content(LiveTV)</visible>
-					<right>920</right>
+					<left>820</left>
 					<top>0</top>
 					<width>100</width>
 					<height>40</height>
@@ -347,7 +347,7 @@
 				</control>
 				<control type="label" id="1">
 					<visible>VideoPlayer.Content(LiveTV)</visible>
-					<right>920</right>
+					<left>820</left>
 					<top>0</top>
 					<width>100</width>
 					<height>40</height>

--- a/addons/skin.confluence/720p/VideoOSDBookmarks.xml
+++ b/addons/skin.confluence/720p/VideoOSDBookmarks.xml
@@ -56,7 +56,7 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in list text label</description>
-			<right>760</right>
+			<left>460</left>
 			<top>495</top>
 			<width>300</width>
 			<height>35</height>

--- a/addons/skin.confluence/720p/ViewsAddonBrowser.xml
+++ b/addons/skin.confluence/720p/ViewsAddonBrowser.xml
@@ -152,7 +152,7 @@
 					<top>280</top>
 					<control type="label">
 						<description>Author txt</description>
-						<right>150</right>
+						<left>10</left>
 						<top>0</top>
 						<width>140</width>
 						<height>25</height>
@@ -177,7 +177,7 @@
 					</control>
 					<control type="label">
 						<description>Version txt</description>
-						<right>150</right>
+						<left>10</left>
 						<top>30</top>
 						<width>140</width>
 						<height>25</height>
@@ -201,7 +201,7 @@
 					</control>
 					<control type="label">
 						<description>Rating txt</description>
-						<right>150</right>
+						<left>10</left>
 						<top>60</top>
 						<width>140</width>
 						<height>25</height>
@@ -401,7 +401,7 @@
 					<top>40</top>
 					<control type="label">
 						<description>Author txt</description>
-						<right>130</right>
+						<left>10</left>
 						<top>0</top>
 						<width>120</width>
 						<height>25</height>
@@ -426,7 +426,7 @@
 					</control>
 					<control type="label">
 						<description>Version txt</description>
-						<right>130</right>
+						<left>10</left>
 						<top>30</top>
 						<width>120</width>
 						<height>25</height>
@@ -450,7 +450,7 @@
 					</control>
 					<control type="label">
 						<description>Rating txt</description>
-						<right>130</right>
+						<left>10</left>
 						<top>60</top>
 						<width>120</width>
 						<height>25</height>

--- a/addons/skin.confluence/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsMusicLibrary.xml
@@ -813,7 +813,7 @@
 					<top>310</top>
 					<control type="label">
 						<description>Born txt</description>
-						<right>140</right>
+						<left>0</left>
 						<top>0</top>
 						<width>140</width>
 						<height>25</height>
@@ -839,7 +839,7 @@
 					</control>
 					<control type="label">
 						<description>Formed txt</description>
-						<right>140</right>
+						<left>0</left>
 						<top>0</top>
 						<width>140</width>
 						<height>25</height>
@@ -865,7 +865,7 @@
 					</control>
 					<control type="label">
 						<description>Genre txt</description>
-						<right>140</right>
+						<left>0</left>
 						<top>30</top>
 						<width>140</width>
 						<height>25</height>

--- a/addons/skin.confluence/720p/ViewsPVR.xml
+++ b/addons/skin.confluence/720p/ViewsPVR.xml
@@ -22,7 +22,7 @@
 					<label>[B]$INFO[Container(11).ListItem.Title][/B]</label>
 				</control>
 				<control type="label">
-					<right>80</right>
+					<left>0</left>
 					<top>22</top>
 					<width>80</width>
 					<height>20</height>
@@ -69,7 +69,7 @@
 					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
 				</control>
 				<control type="label">
-					<right>690</right>
+					<left>0</left>
 					<top>140</top>
 					<width>690</width>
 					<height>20</height>
@@ -293,7 +293,7 @@
 			<control type="label">
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
@@ -330,7 +330,7 @@
 					<label>[B]$INFO[Container(12).ListItem.Title][/B]</label>
 				</control>
 				<control type="label">
-					<right>80</right>
+					<left>0</left>
 					<top>22</top>
 					<width>80</width>
 					<height>20</height>
@@ -377,7 +377,7 @@
 					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
 				</control>
 				<control type="label">
-					<right>690</right>
+					<left>0</left>
 					<top>140</top>
 					<width>690</width>
 					<height>20</height>
@@ -601,7 +601,7 @@
 			<control type="label">
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
@@ -784,7 +784,7 @@
 			<control type="label">
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
@@ -1354,7 +1354,7 @@
 			<control type="label">
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
@@ -1405,7 +1405,7 @@
 				</control>
 				<control type="label">
 					<description>Time label</description>
-					<right>920</right>
+					<left>620</left>
 					<top>20</top>
 					<width>300</width>
 					<height>20</height>
@@ -1709,7 +1709,7 @@
 			<control type="label">
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
@@ -2033,7 +2033,7 @@
 			<control type="label">
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
@@ -2408,7 +2408,7 @@
 			<control type="label">
 				<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>

--- a/addons/skin.confluence/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence/720p/ViewsVideoLibrary.xml
@@ -963,7 +963,7 @@
 				</control>
 				<control type="label">
 					<description>Episodes txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>120</top>
 					<width>140</width>
 					<height>25</height>
@@ -987,7 +987,7 @@
 				</control>
 				<control type="label">
 					<description>Aired txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>145</top>
 					<width>140</width>
 					<height>25</height>
@@ -1011,7 +1011,7 @@
 				</control>
 				<control type="label">
 					<description>Genre txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>170</top>
 					<width>140</width>
 					<height>25</height>
@@ -1448,7 +1448,7 @@
 				</control>
 				<control type="label">
 					<description>Year txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>335</top>
 					<width>140</width>
 					<height>25</height>
@@ -1472,7 +1472,7 @@
 				</control>
 				<control type="label">
 					<description>Genre txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>360</top>
 					<width>140</width>
 					<height>25</height>
@@ -1554,7 +1554,7 @@
 				</control>
 				<control type="label">
 					<description>Aired txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>335</top>
 					<width>140</width>
 					<height>25</height>
@@ -1578,7 +1578,7 @@
 				</control>
 				<control type="label">
 					<description>Episode txt</description>
-					<right>150</right>
+					<left>10</left>
 					<top>360</top>
 					<width>140</width>
 					<height>25</height>

--- a/addons/skin.confluence/720p/VisualisationPresetList.xml
+++ b/addons/skin.confluence/720p/VisualisationPresetList.xml
@@ -148,7 +148,7 @@
 			</control>
 			<control type="label">
 				<description>number of files/pages in list text label</description>
-				<right>760</right>
+				<left>460</left>
 				<top>548</top>
 				<width>300</width>
 				<height>35</height>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -334,7 +334,7 @@
 			<animation effect="slide" start="0,0" end="-90,0" time="0" condition="system.getbool(input.enablemouse)">Conditional</animation>
 			<control type="label">
 				<description>Page Count Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
@@ -348,7 +348,7 @@
 			</control>
 			<control type="label">
 				<description>Container Duration Label</description>
-				<right>40r</right>
+				<right>40</right>
 				<top>32r</top>
 				<width>500</width>
 				<height>20</height>
@@ -436,7 +436,7 @@
 		</control>
 		<control type="label">
 			<description>Next Label</description>
-			<right>485</right>
+			<left>160</left>
 			<top>120</top>
 			<height>30</height>
 			<width>325</width>
@@ -930,7 +930,7 @@
 	<include name="Clock">
 		<control type="label">
 			<description>time label</description>
-			<right>20r</right>
+			<right>20</right>
 			<top>5</top>
 			<width>200</width>
 			<height>30</height>

--- a/addons/skin.confluence/720p/script-XBMC_Lyrics-main.xml
+++ b/addons/skin.confluence/720p/script-XBMC_Lyrics-main.xml
@@ -35,7 +35,7 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<right>580</right>
+				<left>30</left>
 				<top>30</top>
 				<width>550</width>
 				<height>30</height>
@@ -48,7 +48,7 @@
 			</control>
 			<control type="label">
 				<description>Artist label</description>
-				<right>580</right>
+				<left>30</left>
 				<top>60</top>
 				<width>550</width>
 				<height>30</height>
@@ -61,7 +61,7 @@
 			</control>
 			<control type="label">
 				<description>Song label</description>
-				<right>580</right>
+				<left>30</left>
 				<top>85</top>
 				<width>550</width>
 				<height>30</height>
@@ -247,7 +247,7 @@
 			</control>
 			<control type="label">
 				<description>Scraper label</description>
-				<right>580</right>
+				<left>30</left>
 				<top>680</top>
 				<width>550</width>
 				<height>30</height>

--- a/addons/skin.confluence/720p/script-globalsearch-main.xml
+++ b/addons/skin.confluence/720p/script-globalsearch-main.xml
@@ -620,7 +620,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>
@@ -794,7 +794,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>
@@ -925,7 +925,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>
@@ -1093,7 +1093,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>
@@ -1282,7 +1282,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>
@@ -1435,7 +1435,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>
@@ -1588,7 +1588,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>
@@ -1761,7 +1761,7 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<right>750</right>
+							<left>250</left>
 							<top>530</top>
 							<width>500</width>
 							<height>35</height>

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -224,7 +224,12 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
   // read from the XML
   bool hasLeft = GetPosition(node, leftTag, parentSize, left);
   bool hasCenter = GetPosition(node, centerTag, parentSize, center);
-  bool hasRight = GetPosition(node, rightTag, parentSize, right);
+  bool hasRight = false;
+  if (GetPosition(node, rightTag, parentSize, right))
+  {
+    right = parentSize - right;
+    hasRight = true;
+  }
   bool hasWidth = GetDimension(node, widthTag, parentSize, width, min_width);
 
   if (!hasLeft)

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -241,7 +241,7 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
         if (hasRight)
         {
           width = (right - center) * 2;
-          left = right - center;
+          left = right - width;
           hasLeft = true;
         }
       }

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -216,14 +216,20 @@ bool CGUIControlFactory::GetDimension(const TiXmlNode *pRootNode, const char* st
   return true;
 }
 
-bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTag, const char *rightTag, const char *centerTag,
-                                       const char *widthTag, const float parentSize, float &left, float &width, float &min_width)
+bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTag, const char *rightTag, const char *centerLeftTag,
+                                       const char *centerRightTag, const char *widthTag, const float parentSize, float &left,
+                                       float &width, float &min_width)
 {
   float center = 0, right = 0;
 
   // read from the XML
   bool hasLeft = GetPosition(node, leftTag, parentSize, left);
-  bool hasCenter = GetPosition(node, centerTag, parentSize, center);
+  bool hasCenter = GetPosition(node, centerLeftTag, parentSize, center);
+  if (!hasCenter && GetPosition(node, centerRightTag, parentSize, center))
+  {
+    center = parentSize - center;
+    hasCenter = true;
+  }
   bool hasRight = false;
   if (GetPosition(node, rightTag, parentSize, right))
   {
@@ -791,7 +797,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   // such as buttons etc.  For labels/fadelabels/images it does not matter
 
   GetAlignment(pControlNode, "align", labelInfo.align);
-  if (!GetDimensions(pControlNode, "left", "right", "centerx", "width", rect.Width(), posX, width, minWidth))
+  if (!GetDimensions(pControlNode, "left", "right", "centerleft", "centerright", "width", rect.Width(), posX, width, minWidth))
   { // didn't get 2 dimensions, so test for old <posx> as well
     if (GetPosition(pControlNode, "posx", rect.Width(), posX))
     { // <posx> available, so use it along with any hacks we used to support
@@ -803,7 +809,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     if (!width)
       width = max(rect.Width() - posX, 0.0f);
   }
-  if (!GetDimensions(pControlNode, "top", "bottom", "centery", "height", rect.Height(), posY, height, minHeight))
+  if (!GetDimensions(pControlNode, "top", "bottom", "centertop", "centerbottom", "height", rect.Height(), posY, height, minHeight))
   {
     GetPosition(pControlNode, "posy", rect.Height(), posY);
     if (!height)

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -138,7 +138,8 @@ private:
    \param node the <control> node describing the control.
    \param leftTag the tag that holds the left field.
    \param rightTag the tag that holds the right field.
-   \param centerTag the tag that holds the right field.
+   \param centerLeftTag the tag that holds the center left field.
+   \param centerRightTag the tag that holds the center right field.
    \param widthTag the tag holding the width.
    \param parentSize the size of the parent, for relative sizing.
    \param pos [out] the discovered position.
@@ -147,7 +148,8 @@ private:
    \return true if we can successfully derive the position and size, false otherwise.
    \sa GetDimension, GetPosition, ParsePosition.
    */
-  static bool GetDimensions(const TiXmlNode *node, const char *leftTag, const char *rightTag, const char *centerTag,
-                            const char *widthTag, const float parentSize, float &pos, float &width, float &min_width);
+  static bool GetDimensions(const TiXmlNode *node, const char *leftTag, const char *rightTag, const char *centerLeftTag,
+                            const char *centerRightTag, const char *widthTag, const float parentSize, float &left,
+                            float &width, float &min_width);
 };
 #endif


### PR DESCRIPTION
This fixes a bug where only `<right>` and `<centerx>` were given.

In addition, we change so that `<right>` and `<bottom>` are measure from right and bottom respectively.  This makes some positioning easier (I want it 10 pix from the right edge of the screen/parent) and some slightly harder (I want to position a right aligned label so that the right edge is 100px from the left).

@ronie: Unfortunately fixing this in confluence is non-trivial.  I could do a hack, where I change all the existing `<right>` measurements to use 56r for example - the r would be interpreted as measured from the LEFT hand side in this instance (i.e. it doesn't really make sense, but support is left in for back compat).  Ofcourse, some of the `<right>` stuff already uses r positioning, so these should just drop the r.

Instead of fixing these automatically in this way, and having code that is unintuitive, I thought it was better to mark them as clearly needing fixing, and then give you the opportunity to fix in whichever manner you deem most appropriate.  Thus, 52bda4a does this.  Let me know if you'd prefer me to mark them in some other way.
