### PR TITLE
Don't run ValidatePath() on hostnames where the protocol is encoded

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -336,8 +336,7 @@ void CURL::Parse(const CStdString& strURL1)
   if(URIUtils::ProtocolHasEncodedHostname(m_strProtocol))
   {
     Decode(m_strHostName);
-    // Validate it as it is likely to contain a filename
-    SetHostName(CUtil::ValidatePath(m_strHostName));
+    SetHostName(m_strHostName);
   }
 
   Decode(m_strUserName);


### PR DESCRIPTION
This has been around since r20269, which was originally added by @arnova.

Ideally CURL::Parse() should not validate/correct slash direction at all, however, removing the main validation at the beginning of CURL::Parse() might break more than it fixes at this point.

This particular instance occurs only in the case where the protocol has an encoded hostname, i.e. rar://, zip://, apk://, bluray://, udf://, image:// and musicsearch://.  In constructing these URLs, we almost always don't want to 'fix' the parent (in the case of the first 5) or wrapped (in the case of the last two) paths.  They'll either already have consistent slashes due to passing through CURL previously, or would be fixed when CURL processing is done on the parent or wrapped URLs when processing the path in the hostname.

Fixes http://trac.xbmc.org/ticket/14699

@arnova and @elupus your comments would be good.
