### PR TITLE
Implement a window ID cache

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -186,6 +186,7 @@ void CGUIWindowManager::Add(CGUIWindow* pWindow)
   }
   // push back all the windows if there are more than one covered by this class
   CSingleLock lock(g_graphicsContext);
+  m_idCache.Invalidate();
   const vector<int>& idRange = pWindow->GetIDRange();
   for (vector<int>::const_iterator idIt = idRange.begin(); idIt != idRange.end() ; ++idIt)
   {
@@ -219,6 +220,7 @@ void CGUIWindowManager::AddModeless(CGUIWindow* dialog)
 void CGUIWindowManager::Remove(int id)
 {
   CSingleLock lock(g_graphicsContext);
+  m_idCache.Invalidate();
   WindowMap::iterator it = m_mapWindows.find(id);
   if (it != m_mapWindows.end())
   {
@@ -642,16 +644,20 @@ void CGUIWindowManager::FrameMove()
 
 CGUIWindow* CGUIWindowManager::GetWindow(int id) const
 {
-  if (id == WINDOW_INVALID)
-  {
+  CGUIWindow *window;
+  if (m_idCache.Get(id, window))
+    return window;
+  if (id == 0 || id == WINDOW_INVALID)
     return NULL;
-  }
 
   CSingleLock lock(g_graphicsContext);
   WindowMap::const_iterator it = m_mapWindows.find(id);
   if (it != m_mapWindows.end())
-    return (*it).second;
-  return NULL;
+    window = (*it).second;
+  else
+    window = NULL;
+  m_idCache.Set(id, window);
+  return window;
 }
 
 void CGUIWindowManager::ProcessRenderLoop(bool renderOnly /*= false*/)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -645,10 +645,11 @@ void CGUIWindowManager::FrameMove()
 CGUIWindow* CGUIWindowManager::GetWindow(int id) const
 {
   CGUIWindow *window;
-  if (m_idCache.Get(id, window))
-    return window;
   if (id == 0 || id == WINDOW_INVALID)
     return NULL;
+  window = m_idCache.Get(id);
+  if (window)
+    return window;
 
   CSingleLock lock(g_graphicsContext);
   WindowMap::const_iterator it = m_mapWindows.find(id);

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -33,11 +33,37 @@
 #include "IMsgTargetCallback.h"
 #include "DirtyRegionTracker.h"
 #include "utils/GlobalsHandling.h"
+#include "guilib/WindowIDs.h"
 #include <list>
 
 class CGUIDialog;
 
 #define WINDOW_ID_MASK 0xffff
+
+class CGUIWindowManagerIdCache
+{
+public:
+  CGUIWindowManagerIdCache(void) : m_id(WINDOW_INVALID) {}
+  bool Get(int id, CGUIWindow *&window)
+  {
+    if (id != m_id)
+      return false;
+    window = m_window;
+    return true;
+  }
+  void Set(int id, CGUIWindow *window)
+  {
+    m_id = id;
+    m_window = window;
+  }
+  void Invalidate(void)
+  {
+    m_id = WINDOW_INVALID;
+  }
+private:
+  int m_id;
+  CGUIWindow *m_window;
+};
 
 /*!
  \ingroup winman
@@ -157,6 +183,7 @@ private:
 
   typedef std::map<int, CGUIWindow *> WindowMap;
   WindowMap m_mapWindows;
+  mutable CGUIWindowManagerIdCache m_idCache;
   std::vector <CGUIWindow*> m_vecCustomWindows;
   std::vector <CGUIWindow*> m_activeDialogs;
   std::vector <CGUIWindow*> m_deleteWindows;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -40,31 +40,6 @@ class CGUIDialog;
 
 #define WINDOW_ID_MASK 0xffff
 
-class CGUIWindowManagerIdCache
-{
-public:
-  CGUIWindowManagerIdCache(void) : m_id(WINDOW_INVALID) {}
-  bool Get(int id, CGUIWindow *&window)
-  {
-    if (id != m_id)
-      return false;
-    window = m_window;
-    return true;
-  }
-  void Set(int id, CGUIWindow *window)
-  {
-    m_id = id;
-    m_window = window;
-  }
-  void Invalidate(void)
-  {
-    m_id = WINDOW_INVALID;
-  }
-private:
-  int m_id;
-  CGUIWindow *m_window;
-};
-
 /*!
  \ingroup winman
  \brief
@@ -183,7 +158,6 @@ private:
 
   typedef std::map<int, CGUIWindow *> WindowMap;
   WindowMap m_mapWindows;
-  mutable CGUIWindowManagerIdCache m_idCache;
   std::vector <CGUIWindow*> m_vecCustomWindows;
   std::vector <CGUIWindow*> m_activeDialogs;
   std::vector <CGUIWindow*> m_deleteWindows;
@@ -204,6 +178,32 @@ private:
   bool m_initialized;
 
   CDirtyRegionTracker m_tracker;
+
+private:
+  class CGUIWindowManagerIdCache
+  {
+  public:
+    CGUIWindowManagerIdCache(void) : m_id(WINDOW_INVALID) {}
+    CGUIWindow *Get(int id)
+    {
+      if (id == m_id)
+        return m_window;
+      return NULL;
+    }
+    void Set(int id, CGUIWindow *window)
+    {
+      m_id = id;
+      m_window = window;
+    }
+    void Invalidate(void)
+    {
+      m_id = WINDOW_INVALID;
+    }
+  private:
+    int m_id;
+    CGUIWindow *m_window;
+  };
+  mutable CGUIWindowManagerIdCache m_idCache;
 };
 
 /*!


### PR DESCRIPTION
In the course of each refresh of the visibility of controls (which is
performed every frame), there are many calls to CGUIWindowManager::GetWindow
to convert from a window's integer ID to a pointer to the corresponding
CGUIWindow pointer. This involves acquiring a lock and performing a tree walk.
Yet in practice, the same ID is looked up many times in succession, so this
benefits from a simple cache of the most recently checked ID.

I measured the effect while the Videos window of the default skin was open
(but idle) on a Raspberry Pi, and this simple change alone reduced the CPU
usage by 1.5% from 46.6% to 45.1%:

```
          Before          After
          Mean   StdDev   Mean   StdDev  Confidence  Change
IdleCPU%  46.6   0.9      45.1   1.2     99.8%       +3.3%
```
