### PR TITLE
Add selective caching of infobools in list items

### DIFF
--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -723,22 +723,14 @@ public:
    \param expression the boolean condition or expression
    \param context the context window
    \return an identifier used to reference this expression
-
-   \sa GetBoolValue
    */
-  unsigned int Register(const CStdString &expression, int context = 0);
-
-  /*! \brief Get a previously registered boolean expression's value
-   Checks the cache and evaluates the boolean expression if required.
-   \sa Register
-   */
-  bool GetBoolValue(unsigned int expression, const CGUIListItem *item = NULL);
+  INFO::InfoPtr Register(const CStdString &expression, int context = 0);
 
   /*! \brief Evaluate a boolean expression
    \param expression the expression to evaluate
    \param context the context in which to evaluate the expression (currently windows)
    \return the value of the evaluated expression.
-   \sa Register, GetBoolValue
+   \sa Register
    */
   bool EvaluateBool(const CStdString &expression, int context = 0);
 
@@ -845,7 +837,7 @@ public:
   CStdString GetSkinVariableString(int info, bool preferImage = false, const CGUIListItem *item=NULL);
 
   /// \brief iterates through boolean conditions and compares their stored values to current values. Returns true if any condition changed value.
-  bool ConditionsChangedValues(const std::map<int, bool>& map);
+  bool ConditionsChangedValues(const std::map<INFO::InfoPtr, bool>& map);
 
   bool m_AVInfoValid;
 
@@ -942,9 +934,8 @@ protected:
   int m_nextWindowID;
   int m_prevWindowID;
 
-  std::vector<INFO::InfoBool*> m_bools;
+  std::vector<INFO::InfoPtr> m_bools;
   std::vector<INFO::CSkinVariableString> m_skinVariableStrings;
-  unsigned int m_updateTime;
 
   int m_libraryHasMusic;
   int m_libraryHasMovies;

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -844,6 +844,7 @@ public:
 protected:
   friend class INFO::InfoSingle;
   bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item=NULL);
+  int TranslateSingleString(const CStdString &strCondition, bool &listItemDependent);
 
   // routines for window retrieval
   bool CheckWindowCondition(CGUIWindow *window, int condition) const;

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -195,7 +195,7 @@ void CSkinInfo::LoadIncludes()
   m_includes.LoadIncludes(includesPath);
 }
 
-void CSkinInfo::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
+void CSkinInfo::ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions /* = NULL */)
 {
   if(xmlIncludeConditions)
     xmlIncludeConditions->clear();

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -95,7 +95,7 @@ public:
    */
   static bool TranslateResolution(const CStdString &name, RESOLUTION_INFO &res);
 
-  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
+  void ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions = NULL);
 
   float GetEffectsSlowdown() const { return m_effectsSlowDown; };
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -40,8 +40,6 @@ CGUIControl::CGUIControl() :
   m_visible = VISIBLE;
   m_visibleFromSkinCondition = true;
   m_forceHidden = false;
-  m_visibleCondition = 0;
-  m_enableCondition = 0;
   m_enabled = true;
   m_posX = 0;
   m_posY = 0;
@@ -71,8 +69,6 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
   m_visible = VISIBLE;
   m_visibleFromSkinCondition = true;
   m_forceHidden = false;
-  m_visibleCondition = 0;
-  m_enableCondition = 0;
   m_enabled = true;
   ControlType = GUICONTROL_UNKNOWN;
   m_bInvalidated = true;
@@ -543,7 +539,7 @@ void CGUIControl::SetVisible(bool bVisible, bool setVisState)
      //       otherwise we just set m_forceHidden
     GUIVISIBLE visible;
     if (m_visibleCondition)
-      visible = g_infoManager.GetBoolValue(m_visibleCondition) ? VISIBLE : HIDDEN;
+      visible = m_visibleCondition->Get() ? VISIBLE : HIDDEN;
     else
       visible = VISIBLE;
     if (visible != m_visible)
@@ -606,7 +602,7 @@ void CGUIControl::UpdateVisibility(const CGUIListItem *item)
   if (m_visibleCondition)
   {
     bool bWasVisible = m_visibleFromSkinCondition;
-    m_visibleFromSkinCondition = g_infoManager.GetBoolValue(m_visibleCondition, item);
+    m_visibleFromSkinCondition = m_visibleCondition->Get(item);
     if (!bWasVisible && m_visibleFromSkinCondition)
     { // automatic change of visibility - queue the in effect
   //    CLog::Log(LOGDEBUG, "Visibility changed to visible for control id %i", m_controlID);
@@ -629,7 +625,7 @@ void CGUIControl::UpdateVisibility(const CGUIListItem *item)
   // this may need to be reviewed at a later date
   bool enabled = m_enabled;
   if (m_enableCondition)
-    m_enabled = g_infoManager.GetBoolValue(m_enableCondition, item);
+    m_enabled = m_enableCondition->Get(item);
 
   if (m_enabled != enabled)
     MarkDirtyRegion();
@@ -651,7 +647,7 @@ void CGUIControl::SetInitialVisibility()
 {
   if (m_visibleCondition)
   {
-    m_visibleFromSkinCondition = g_infoManager.GetBoolValue(m_visibleCondition);
+    m_visibleFromSkinCondition = m_visibleCondition->Get();
     m_visible = m_visibleFromSkinCondition ? VISIBLE : HIDDEN;
   //  CLog::Log(LOGDEBUG, "Set initial visibility for control %i: %s", m_controlID, m_visible == VISIBLE ? "visible" : "hidden");
   }
@@ -667,7 +663,7 @@ void CGUIControl::SetInitialVisibility()
   // and check for conditional enabling - note this overrides SetEnabled() from the code currently
   // this may need to be reviewed at a later date
   if (m_enableCondition)
-    m_enabled = g_infoManager.GetBoolValue(m_enableCondition);
+    m_enabled = m_enableCondition->Get();
   m_allowHiddenFocus.Update();
   UpdateColors();
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -210,7 +210,7 @@ public:
   virtual void SetHeight(float height);
   virtual void SetVisible(bool bVisible, bool setVisState = false);
   void SetVisibleCondition(const CStdString &expression, const CStdString &allowHiddenFocus = "");
-  unsigned int GetVisibleCondition() const { return m_visibleCondition; };
+  INFO::InfoPtr GetVisibleCondition() const { return m_visibleCondition; };
   void SetEnableCondition(const CStdString &expression);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void SetInitialVisibility();
@@ -339,14 +339,14 @@ protected:
   CGUIControl *m_parentControl;   // our parent control if we're part of a group
 
   // visibility condition/state
-  unsigned int m_visibleCondition;
+  INFO::InfoPtr m_visibleCondition;
   GUIVISIBLE m_visible;
   bool m_visibleFromSkinCondition;
   bool m_forceHidden;       // set from the code when a hidden operation is given - overrides m_visible
   CGUIInfoBool m_allowHiddenFocus;
   bool m_hasProcessed;
   // enable/disable state
-  unsigned int m_enableCondition;
+  INFO::InfoPtr m_enableCondition;
   bool m_enabled;
 
   bool m_pushedUpdates;

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -22,7 +22,6 @@
 #include "GUIWindowManager.h"
 #include "GUILabelControl.h"
 #include "GUIAudioManager.h"
-#include "GUIInfoManager.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 #include "Application.h"
@@ -137,7 +136,7 @@ void CGUIDialog::UpdateVisibility()
 {
   if (m_visibleCondition)
   {
-    if (g_infoManager.GetBoolValue(m_visibleCondition))
+    if (m_visibleCondition->Get())
       Show();
     else
       Close();

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -180,7 +180,7 @@ bool CGUIIncludes::HasIncludeFile(const CStdString &file) const
   return false;
 }
 
-void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
+void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions /* = NULL */)
 {
   if (!node)
     return;
@@ -194,7 +194,7 @@ void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlI
   }
 }
 
-void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
+void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions /* = NULL */)
 {
   // we have a node, find any <include file="fileName">tagName</include> tags and replace
   // recursively with their real includes
@@ -242,8 +242,8 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool
     const char *condition = include->Attribute("condition");
     if (condition)
     { // check this condition
-      int conditionID = g_infoManager.Register(condition);
-      bool value = g_infoManager.GetBoolValue(conditionID);
+      INFO::InfoPtr conditionID = g_infoManager.Register(condition);
+      bool value = conditionID->Get();
 
       if (xmlIncludeConditions)
         (*xmlIncludeConditions)[conditionID] = value;

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -24,6 +24,7 @@
 
 #include <map>
 #include <set>
+#include "interfaces/info/InfoBool.h"
 
 // forward definitions
 class TiXmlElement;
@@ -47,11 +48,11 @@ public:
    "bar" from the include file "foo".
    \param node an XML Element - all child elements are traversed.
    */
-  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
+  void ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions = NULL);
   const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name, int context);
 
 private:
-  void ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
+  void ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions = NULL);
   CStdString ResolveConstant(const CStdString &constant) const;
   bool HasIncludeFile(const CStdString &includeFile) const;
   std::map<CStdString, TiXmlElement> m_includes;

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -33,7 +33,6 @@ using ADDON::CAddonMgr;
 
 CGUIInfoBool::CGUIInfoBool(bool value)
 {
-  m_info = 0;
   m_value = value;
 }
 
@@ -57,7 +56,7 @@ void CGUIInfoBool::Parse(const CStdString &expression, int context)
 void CGUIInfoBool::Update(const CGUIListItem *item /*= NULL*/)
 {
   if (m_info)
-    m_value = g_infoManager.GetBoolValue(m_info, item);
+    m_value = m_info->Get(item);
 }
 
 

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -29,6 +29,7 @@
  */
 
 #include "utils/StdString.h"
+#include "interfaces/info/InfoBool.h"
 
 class CGUIListItem;
 
@@ -43,7 +44,7 @@ public:
   void Update(const CGUIListItem *item = NULL);
   void Parse(const CStdString &expression, int context);
 private:
-  unsigned int m_info;
+  INFO::InfoPtr m_info;
   bool m_value;
 };
 

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -34,7 +34,6 @@ CGUIListItemLayout::CGUIListItemLayout()
 {
   m_width = 0;
   m_height = 0;
-  m_condition = 0;
   m_focused = false;
   m_invalidated = true;
   m_group.SetPushUpdates(true);
@@ -143,7 +142,7 @@ bool CGUIListItemLayout::MoveRight()
 
 bool CGUIListItemLayout::CheckCondition()
 {
-  return !m_condition || g_infoManager.GetBoolValue(m_condition);
+  return !m_condition || m_condition->Get();
 }
 
 void CGUIListItemLayout::LoadControl(TiXmlElement *child, CGUIControlGroup *group)

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -70,7 +70,7 @@ protected:
   bool m_focused;
   bool m_invalidated;
 
-  unsigned int m_condition;
+  INFO::InfoPtr m_condition;
   CGUIInfoBool m_isPlaying;
 };
 

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -36,7 +36,6 @@ CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID, int controlID, floa
 {
   m_radioPosX = 0;
   m_radioPosY = 0;
-  m_toggleSelect = 0;
   m_imgRadioOnFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
   m_imgRadioOnNoFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
   m_imgRadioOffFocus.SetAspectRatio(CAspectRatio::AR_KEEP);
@@ -72,7 +71,7 @@ void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList 
   if (m_toggleSelect)
   {
     // ask our infoManager whether we are selected or not...
-    bool selected = g_infoManager.GetBoolValue(m_toggleSelect);
+    bool selected = m_toggleSelect->Get();
 
     if (selected != m_bSelected)
     {

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -68,5 +68,5 @@ protected:
   CGUITexture m_imgRadioOffNoFocus;
   float m_radioPosX;
   float m_radioPosY;
-  unsigned int m_toggleSelect;
+  INFO::InfoPtr m_toggleSelect;
 };

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -28,7 +28,6 @@ using namespace std;
 
 CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileItem()
 {
-  m_visCondition = 0;
   m_visState = false;
 
   assert(item);
@@ -91,7 +90,6 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
 CGUIStaticItem::CGUIStaticItem(const CFileItem &item)
 : CFileItem(item)
 {
-  m_visCondition = 0;
   m_visState = false;
 }
 
@@ -120,7 +118,7 @@ bool CGUIStaticItem::UpdateVisibility(int contextWindow)
 {
   if (!m_visCondition)
     return false;
-  bool state = g_infoManager.GetBoolValue(m_visCondition);
+  bool state = m_visCondition->Get();
   if (state != m_visState)
   {
     m_visState = state;

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -89,7 +89,7 @@ public:
 private:
   typedef std::vector< std::pair<CGUIInfoLabel, CStdString> > InfoVector;
   InfoVector m_info;
-  unsigned int m_visCondition;
+  INFO::InfoPtr m_visCondition;
   bool m_visState;
   CGUIAction m_clickActions;
 };

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -41,7 +41,6 @@ CGUITextBox::CGUITextBox(int parentID, int controlID, float posX, float posY, fl
   m_pageControl = 0;
   m_lastRenderTime = 0;
   m_scrollTime = scrollTime;
-  m_autoScrollCondition = 0;
   m_autoScrollTime = 0;
   m_autoScrollDelay = 3000;
   m_autoScrollDelayTime = 0;
@@ -124,7 +123,7 @@ void CGUITextBox::Process(unsigned int currentTime, CDirtyRegionList &dirtyregio
   // update our auto-scrolling as necessary
   if (m_autoScrollTime && m_lines.size() > m_itemsPerPage)
   {
-    if (!m_autoScrollCondition || g_infoManager.GetBoolValue(m_autoScrollCondition))
+    if (!m_autoScrollCondition || m_autoScrollCondition->Get())
     {
       if (m_lastRenderTime)
         m_autoScrollDelayTime += currentTime - m_lastRenderTime;

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -86,7 +86,7 @@ protected:
   TransformMatrix m_cachedTextMatrix;
 
   // autoscrolling
-  unsigned int m_autoScrollCondition;
+  INFO::InfoPtr m_autoScrollCondition;
   int          m_autoScrollTime;      // time to scroll 1 line (ms)
   int          m_autoScrollDelay;     // delay before scroll (ms)
   unsigned int m_autoScrollDelayTime; // current offset into the delay

--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -30,7 +30,6 @@ CGUIToggleButtonControl::CGUIToggleButtonControl(int parentID, int controlID, fl
     : CGUIButtonControl(parentID, controlID, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo)
     , m_selectButton(parentID, controlID, posX, posY, width, height, altTextureFocus, altTextureNoFocus, labelInfo)
 {
-  m_toggleSelect = 0;
   ControlType = GUICONTROL_TOGGLEBUTTON;
 }
 
@@ -43,7 +42,7 @@ void CGUIToggleButtonControl::Process(unsigned int currentTime, CDirtyRegionList
   // ask our infoManager whether we are selected or not...
   bool selected = m_bSelected;
   if (m_toggleSelect)
-    selected = g_infoManager.GetBoolValue(m_toggleSelect);
+    selected = m_toggleSelect->Get();
   if (selected != m_bSelected)
   {
     MarkDirtyRegion();

--- a/xbmc/guilib/GUIToggleButtonControl.h
+++ b/xbmc/guilib/GUIToggleButtonControl.h
@@ -61,6 +61,6 @@ protected:
   virtual bool UpdateColors();
   virtual void OnClick();
   CGUIButtonControl m_selectButton;
-  unsigned int m_toggleSelect;
+  INFO::InfoPtr m_toggleSelect;
 };
 #endif

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -447,7 +447,7 @@ CPoint CGUIWindow::GetPosition() const
   for (unsigned int i = 0; i < m_origins.size(); i++)
   {
     // no condition implies true
-    if (!m_origins[i].condition || g_infoManager.GetBoolValue(m_origins[i].condition))
+    if (!m_origins[i].condition || m_origins[i].condition->Get())
     { // found origin
       return CPoint(m_origins[i].x, m_origins[i].y);
     }
@@ -967,7 +967,6 @@ void CGUIWindow::SetDefaults()
   m_defaultControl = 0;
   m_posX = m_posY = m_width = m_height = 0;
   m_overlayState = OVERLAY_STATE_PARENT_WINDOW;   // Use parent or previous window's state
-  m_visibleCondition = 0;
   m_previousWindow = WINDOW_INVALID;
   m_animations.clear();
   m_origins.clear();

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -63,11 +63,10 @@ public:
   COrigin()
   {
     x = y = 0;
-    condition = 0;
   };
   float x;
   float y;
-  unsigned int condition;
+  INFO::InfoPtr condition;
 };
 
 /*!
@@ -281,7 +280,7 @@ protected:
 
 private:
   std::map<CStdString, CVariant, icompare> m_mapProperties;
-  std::map<int, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
+  std::map<INFO::InfoPtr, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
 };
 
 #endif

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -360,7 +360,6 @@ CAnimation::CAnimation()
 {
   m_type = ANIM_TYPE_NONE;
   m_reversible = true;
-  m_condition = 0;
   m_repeatAnim = ANIM_REPEAT_NONE;
   m_currentState = ANIM_STATE_NONE;
   m_currentProcess = ANIM_PROCESS_NONE;
@@ -389,7 +388,7 @@ CAnimation &CAnimation::operator =(const CAnimation &src)
   if (this == &src) return *this; // same
   m_type = src.m_type;
   m_reversible = src.m_reversible;
-  m_condition = src.m_condition; // TODO: register/unregister
+  m_condition = src.m_condition;
   m_repeatAnim = src.m_repeatAnim;
   m_lastCondition = src.m_lastCondition;
   m_queuedProcess = src.m_queuedProcess;
@@ -581,12 +580,14 @@ CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, u
 
 bool CAnimation::CheckCondition()
 {
-  return !m_condition || g_infoManager.GetBoolValue(m_condition);
+  return !m_condition || m_condition->Get();
 }
 
 void CAnimation::UpdateCondition(const CGUIListItem *item)
 {
-  bool condition = g_infoManager.GetBoolValue(m_condition, item);
+  if (!m_condition)
+    return;
+  bool condition = m_condition->Get(item);
   if (condition && !m_lastCondition)
     QueueAnimation(ANIM_PROCESS_NORMAL);
   else if (!condition && m_lastCondition)
@@ -601,7 +602,7 @@ void CAnimation::UpdateCondition(const CGUIListItem *item)
 
 void CAnimation::SetInitialCondition()
 {
-  m_lastCondition = g_infoManager.GetBoolValue(m_condition);
+  m_lastCondition = m_condition ? m_condition->Get() : false;
   if (m_lastCondition)
     ApplyAnimation();
   else

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -33,6 +33,7 @@ class CGUIListItem;
 #include "Geometry.h"         // for CPoint, CRect
 #include "utils/StdString.h"
 #include "boost/shared_ptr.hpp"
+#include "interfaces/info/InfoBool.h"
 
 enum ANIMATION_TYPE
 {
@@ -184,7 +185,7 @@ private:
   // type of animation
   ANIMATION_TYPE m_type;
   bool m_reversible;
-  unsigned int m_condition;
+  INFO::InfoPtr m_condition;
 
   // conditional anims can repeat
   ANIM_REPEAT m_repeatAnim;

--- a/xbmc/interfaces/info/InfoBool.cpp
+++ b/xbmc/interfaces/info/InfoBool.cpp
@@ -88,7 +88,7 @@ void InfoExpression::Parse(const CStdString &expression)
       // cleanup any operand, translate and put into our expression list
       if (!operand.empty())
       {
-        unsigned int info = g_infoManager.Register(operand, m_context);
+        InfoPtr info = g_infoManager.Register(operand, m_context);
         if (info)
         {
           m_postfix.push_back(m_operands.size());
@@ -134,7 +134,7 @@ void InfoExpression::Parse(const CStdString &expression)
 
   if (!operand.empty())
   {
-    unsigned int info = g_infoManager.Register(operand, m_context);
+    InfoPtr info = g_infoManager.Register(operand, m_context);
     if (info)
     {
       m_postfix.push_back(m_operands.size());
@@ -183,7 +183,7 @@ bool InfoExpression::Evaluate(const CGUIListItem *item, bool &result)
       save.push(left || right);
     }
     else  // operand
-      save.push(g_infoManager.GetBoolValue(m_operands[expr], item));
+      save.push(m_operands[expr]->Get(item));
   }
   if (save.size() != 1)
     return false;

--- a/xbmc/interfaces/info/InfoBool.cpp
+++ b/xbmc/interfaces/info/InfoBool.cpp
@@ -36,7 +36,7 @@ bool InfoBool::operator==(const InfoBool &right) const
 InfoSingle::InfoSingle(const CStdString &expression, int context)
 : InfoBool(expression, context)
 {
-  m_condition = g_infoManager.TranslateSingleString(expression);
+  m_condition = g_infoManager.TranslateSingleString(expression, m_listItemDependent);
 }
 
 void InfoSingle::Update(const CGUIListItem *item)
@@ -91,6 +91,7 @@ void InfoExpression::Parse(const CStdString &expression)
         InfoPtr info = g_infoManager.Register(operand, m_context);
         if (info)
         {
+          m_listItemDependent |= info->m_listItemDependent;
           m_postfix.push_back(m_operands.size());
           m_operands.push_back(info);
         }
@@ -137,6 +138,7 @@ void InfoExpression::Parse(const CStdString &expression)
     InfoPtr info = g_infoManager.Register(operand, m_context);
     if (info)
     {
+      m_listItemDependent |= info->m_listItemDependent;
       m_postfix.push_back(m_operands.size());
       m_operands.push_back(info);
     }

--- a/xbmc/interfaces/info/InfoBool.h
+++ b/xbmc/interfaces/info/InfoBool.h
@@ -37,7 +37,8 @@ class InfoBool
 {
 public:
   InfoBool(const CStdString &expression, int context)
-    : m_value(false),
+    : m_listItemDependent(false),
+      m_value(false),
       m_context(context),
       m_expression(expression),
       m_dirty(true)
@@ -59,7 +60,7 @@ public:
    */
   inline bool Get(const CGUIListItem *item = NULL)
   {
-    if (item)
+    if (item && m_listItemDependent)
       Update(item);
     else if (m_dirty)
     {
@@ -77,6 +78,8 @@ public:
   virtual void Update(const CGUIListItem *item) {};
 
   const std::string &GetExpression() const { return m_expression; }
+
+  bool m_listItemDependent;    ///< do not cache if a listitem pointer is given
 
 protected:
 

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -25,8 +25,6 @@
 using namespace std;
 using namespace INFO;
 
-#define DEFAULT_VALUE -1
-
 const CSkinVariableString* CSkinVariable::CreateFromXML(const TiXmlElement& node, int context)
 {
   const char* name = node.Attribute("name");
@@ -43,12 +41,10 @@ const CSkinVariableString* CSkinVariable::CreateFromXML(const TiXmlElement& node
         CSkinVariableString::ConditionLabelPair pair;
         if (valuenode->Attribute("condition"))
           pair.m_condition = g_infoManager.Register(valuenode->Attribute("condition"), context);
-        else
-          pair.m_condition = DEFAULT_VALUE;
 
         pair.m_label = CGUIInfoLabel(valuenode->FirstChild()->Value());
         tmp->m_conditionLabelPairs.push_back(pair);
-        if (pair.m_condition == DEFAULT_VALUE)
+        if (!pair.m_condition)
           break; // once we reach default value (without condition) break iterating
       }
       valuenode = valuenode->NextSiblingElement("value");
@@ -78,7 +74,7 @@ CStdString CSkinVariableString::GetValue(bool preferImage /* = false*/, const CG
 {
   for (VECCONDITIONLABELPAIR::const_iterator it = m_conditionLabelPairs.begin() ; it != m_conditionLabelPairs.end(); ++it)
   {
-    if (it->m_condition == DEFAULT_VALUE || g_infoManager.GetBoolValue(it->m_condition, item))
+    if (!it->m_condition || it->m_condition->Get(item))
     {
       if (item)
         return it->m_label.GetItemLabel(item, preferImage);

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -20,6 +20,7 @@
  */
 
 #include "guilib/GUIInfoTypes.h"
+#include "interfaces/info/InfoBool.h"
 
 class TiXmlElement;
 
@@ -47,7 +48,7 @@ private:
 
   struct ConditionLabelPair
   {
-    int m_condition;
+    INFO::InfoPtr m_condition;
     CGUIInfoLabel m_label;
   };
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -339,7 +339,7 @@ void CGUIWindowFullScreen::OnWindowLoaded()
   CGUIProgressControl* pProgress = (CGUIProgressControl*)GetControl(CONTROL_PROGRESS);
   if(pProgress)
   {
-    if( pProgress->GetInfo() == 0 || pProgress->GetVisibleCondition() == 0)
+    if( pProgress->GetInfo() == 0 || !pProgress->GetVisibleCondition())
     {
       pProgress->SetInfo(PLAYER_PROGRESS);
       pProgress->SetVisibleCondition("player.displayafterseek");
@@ -348,14 +348,14 @@ void CGUIWindowFullScreen::OnWindowLoaded()
   }
 
   CGUILabelControl* pLabel = (CGUILabelControl*)GetControl(LABEL_BUFFERING);
-  if(pLabel && pLabel->GetVisibleCondition() == 0)
+  if(pLabel && !pLabel->GetVisibleCondition())
   {
     pLabel->SetVisibleCondition("player.caching");
     pLabel->SetVisible(true);
   }
 
   pLabel = (CGUILabelControl*)GetControl(LABEL_CURRENT_TIME);
-  if(pLabel && pLabel->GetVisibleCondition() == 0)
+  if(pLabel && !pLabel->GetVisibleCondition())
   {
     pLabel->SetVisibleCondition("player.displayafterseek");
     pLabel->SetVisible(true);


### PR DESCRIPTION
As noted in a TODO comment attached to CGUIInfoManager::GetBoolValue, caching
of infobools (both expression and single bools) is disabled whenever a
CGUIListItem pointer is provided. This is true whenever visibility is
evaluated for a control which is part of a list item (which is responsible
for a large portion of the controls in many windows), which obviously hurts
caceh efficiency. However, many of the bools (including the leaf nodes of
expression infobools) aren't actually dependent upon which list item they're
attached to.

This patch adds a flag to each InfoBool object to indicate whether its value
depends upon the list item; if this isn't set, then the cache is re-enabled
even if a CGUIListItem pointer is provided. The flag is calculated at parse
time because it's quite tricky to evaluate - it applies to bools in any of
the following categories:
- a statically definied boolean condition in the range LISTITEM_START to
  LISTITEM_END - for example, "ListItem.IsResumable"
- a (dynamically allocated) multi-info bool, that is to say, the result of a
  string or integer operation on a list item attribute - for example
  "substring(Listitem.mpaa,Rated R)"
- an expression that uses one or more of the above - for example
  "Window.IsVisible(Videos) + !ListItem.IsResumable"

I measured the effect while the Videos window of the default skin was open
(but idle) on a Raspberry Pi, and this reduced the CPU usage by 3.2% from
45.1% to 41.9%:

```
          Before          After
          Mean   StdDev   Mean   StdDev  Confidence  Change
IdleCPU%  45.1   1.2      41.9   0.5     100.0%      +7.7%
```
