### PR TITLE
Fixed: read up to 4095 chars per line from a strm/m3u file (and use the ...

### DIFF
--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -86,7 +86,7 @@ bool CPlayListM3U::Load(const CStdString& strFileName)
     return false;
   }
 
-  while (file.ReadString(szLine, 1024))
+  while (file.ReadString(szLine, 4095))
   {
     strLine = szLine;
     StringUtils::Trim(strLine);


### PR DESCRIPTION
...full buffer)

Somebody had some issues running my add-on from a strm file but had no issues playing it from a favourite. Turned out that the URL was cut of. I did some debugging and noticed that XBMC only reads 1024 chars per line of a m3u/strm file, even though it's buffer is 4095 chars. 

I changed it to read the full buffer size and it does fix the problem (up to 4095 chars in an url). 
