### PR TITLE
[depends] update PCRE version, use new configure flags

### DIFF
--- a/tools/depends/native/pcre-native/Makefile
+++ b/tools/depends/native/pcre-native/Makefile
@@ -5,12 +5,15 @@ DEPS= ../../Makefile.include.in Makefile
 
 # lib name, version
 LIBNAME=pcre
-VERSION=7.9
+VERSION=8.33
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
 # configuration settings
-CONFIGURE=./configure --prefix=$(PREFIX) --disable-cpp --disable-shared
+CONFIGURE=./configure --prefix=$(PREFIX) --disable-cpp \
+	--disable-shared --disable-stack-for-recursion \
+	--enable-pcre8 --disable-pcre16 --disable-pcre32 \
+	--enable-jit --enable-utf --enable-unicode-properties
 
 
 LIBDYLIB=$(PLATFORM)/.libs/lib$(LIBNAME).so

--- a/tools/depends/target/pcre/Makefile
+++ b/tools/depends/target/pcre/Makefile
@@ -3,12 +3,16 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=pcre
-VERSION=7.9
+VERSION=8.33
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
 # configuration settings
-CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; ./configure --prefix=$(PREFIX) --disable-stack-for-recursion --disable-shared
+CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; ./configure --prefix=$(PREFIX) \
+	--disable-shared --disable-stack-for-recursion \
+	--enable-pcre8 --disable-pcre16 --disable-pcre32 \
+	--enable-jit --enable-utf --enable-unicode-properties \
+	--enable-newline-is-anycrlf
 
 
 LIBDYLIB=$(PLATFORM)/.libs/lib$(LIBNAME).a


### PR DESCRIPTION
With update of RegExp wrapper class, we need to update PCRE lib.
