### PR TITLE
[pvr] fix: no channel numbers in channel-osd if continue last channel

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -294,8 +294,7 @@ bool CPVRChannelGroups::Load(void)
   }
 
   // set the internal group as selected at startup
-  internalChannels->SetSelectedGroup(true);
-  m_selectedGroup = internalChannels;
+  SetSelectedGroup(internalChannels);
 
   CLog::Log(LOGDEBUG, "PVR - %s - %d %s channel groups loaded", __FUNCTION__, (int) m_groups.size(), m_bRadio ? "radio" : "TV");
 


### PR DESCRIPTION
If you open up the channel osd after continue the last channel on startup there are no channel numbers assigned to channels. Now if you want to switch to a channel the playback stops and you are thrown back to the home menu. This resets the channel number cache before continue last channel on startup.
