### PR TITLE
Reduce the amount of false positives while detecting stereo mode

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -401,8 +401,9 @@ void CAdvancedSettings::Initialize()
   // internal video extensions
   m_videoExtensions += "|.pvr";
 
-  m_stereoscopicflags_sbs = "3DSBS|3D.SBS|HSBS|H.SBS|H-SBS| SBS |FULL-SBS|FULL.SBS|FULLSBS|FSBS|HALF-SBS";
-  m_stereoscopicflags_tab = "3DTAB|3D.TAB|HTAB|H.TAB|3DOU|3D.OU|3D.HOU| HOU | OU |HALF-TAB";
+  m_stereoscopicregex_3d = "[-. _]3d[-. _]";
+  m_stereoscopicregex_sbs = "[-. _]h?sbs[-. _]";
+  m_stereoscopicregex_tab = "[-. _]h?tab[-. _]";
 
   m_logLevelHint = m_logLevel = LOG_LEVEL_NORMAL;
   m_extraLogLevels = 0;
@@ -544,8 +545,9 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   pElement = pRootElement->FirstChildElement("video");
   if (pElement)
   {
-    XMLUtils::GetString(pElement, "stereoscopicflagssbs", m_stereoscopicflags_sbs);
-    XMLUtils::GetString(pElement, "stereoscopicflagstab", m_stereoscopicflags_tab);
+    XMLUtils::GetString(pElement, "stereoscopicregex3d", m_stereoscopicregex_3d);
+    XMLUtils::GetString(pElement, "stereoscopicregexsbs", m_stereoscopicregex_sbs);
+    XMLUtils::GetString(pElement, "stereoscopicregextab", m_stereoscopicregex_tab);
     XMLUtils::GetFloat(pElement, "subsdelayrange", m_videoSubsDelayRange, 10, 600);
     XMLUtils::GetFloat(pElement, "audiodelayrange", m_videoAudioDelayRange, 10, 600);
     XMLUtils::GetInt(pElement, "blackbarcolour", m_videoBlackBarColour, 0, 255);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -400,8 +400,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     CStdString m_discStubExtensions;
     CStdString m_subtitlesExtensions;
 
-    CStdString m_stereoscopicflags_sbs;
-    CStdString m_stereoscopicflags_tab;
+    CStdString m_stereoscopicregex_3d;
+    CStdString m_stereoscopicregex_sbs;
+    CStdString m_stereoscopicregex_tab;
 
     CStdString m_logFolder;
 


### PR DESCRIPTION
In the Netherlands there are TV channels called 'SBS 6' and 'SBS6 HD'
which broadcast regular non-3D content. When trying to open a PVR
recording from one of these channels make sure the content isn't
automatically being marked as 3D content
