### PR TITLE
move timezone settings to basic level

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -145,7 +145,7 @@
       </group>
       <group id="2">
         <setting id="locale.timezonecountry" type="string" label="14079" help="36117">
-          <level>2</level>
+          <level>0</level>
           <default>default</default> <!-- will be properly set on startup -->
           <constraints>
             <options>timezonecountries</options>
@@ -153,7 +153,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="locale.timezone" type="string" label="14080" help="36118">
-          <level>2</level>
+          <level>0</level>
           <default>default</default> <!-- will be properly set on startup -->
           <constraints>
             <options>timezones</options>


### PR DESCRIPTION
OpenELEC relies on timezone settings to setup system timezone. we have a systemd services that reads locale.timezone from guisettings.xml and sets system timezone. 
unfortunately, with the new settings system, many of our users have no idea how to switch settings level to "advanced", so we'd prefer this moved to basic level for easy access.
