### PR TITLE
videodb: make sure to return the same playcount (0 or 1) for tvshows (fixes #14703)

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -770,8 +770,8 @@ protected:
   CVideoInfoTag GetDetailsByTypeAndId(VIDEODB_CONTENT_TYPE type, int id);
   CVideoInfoTag GetDetailsForMovie(std::auto_ptr<dbiplus::Dataset> &pDS, bool getDetails = false);
   CVideoInfoTag GetDetailsForMovie(const dbiplus::sql_record* const record, bool getDetails = false);
-  CVideoInfoTag GetDetailsForTvShow(std::auto_ptr<dbiplus::Dataset> &pDS, bool getDetails = false);
-  CVideoInfoTag GetDetailsForTvShow(const dbiplus::sql_record* const record, bool getDetails = false);
+  CVideoInfoTag GetDetailsForTvShow(std::auto_ptr<dbiplus::Dataset> &pDS, bool getDetails = false, CFileItem* item = NULL);
+  CVideoInfoTag GetDetailsForTvShow(const dbiplus::sql_record* const record, bool getDetails = false, CFileItem* item = NULL);
   CVideoInfoTag GetDetailsForEpisode(std::auto_ptr<dbiplus::Dataset> &pDS, bool getDetails = false);
   CVideoInfoTag GetDetailsForEpisode(const dbiplus::sql_record* const record, bool getDetails = false);
   CVideoInfoTag GetDetailsForMusicVideo(std::auto_ptr<dbiplus::Dataset> &pDS, bool getDetails = false);


### PR DESCRIPTION
This change makes sure that the playcount value of a tvshow retrieved from the database is always 0 or 1. Right now depending on how a tvshow is retrieved from the database (e.g. GetTvShowsNav or GetTvShowInfo) the m_playCount value of the CVideoInfoTag object can be either 0 or 1 or it can be the total number of watched episodes. This problem also results in inconsistent data being returned through JSON-RPC (see http://trac.xbmc.org/ticket/14703).

TBH I don't really care whether the playcount always is 0 or 1 or the total number of watched episodes as long as it is consistent. Are there any places that rely on playcount being one of the two possible implementations? I just went with the former (0 or 1) because it means less logic duplication (i.e. comparing the total number of episodes with the number of watched episodes).
