### PR TITLE
[PlayerController] Don't disable subs with ACTION_NEXT_SUBTITLE

### DIFF
--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -96,11 +96,8 @@ bool CPlayerController::OnAction(const CAction &action)
         {
           CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream++;
           if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream >= g_application.m_pPlayer->GetSubtitleCount())
-          {
             CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = 0;
-            CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
-            g_application.m_pPlayer->SetSubtitleVisible(false);
-          }
+
           g_application.m_pPlayer->SetSubtitle(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream);
         }
         else


### PR DESCRIPTION
Currently subtitles can be disabled via ACTION_NEXT_SUBTITLE if if `#current_sub++ >= #available_subs`.
This PR adapts ACTION_NEXT_SUBTITLE to the behaviour of rpc and internal, i.e. cycle through.
