### PR TITLE
[epg] fix: incorrect timeline grid for first program of channels (Trac #11479)

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -937,26 +937,16 @@ void CGUIEPGGridContainer::UpdateItems()
           continue;
         }
 
-        if (tag->EpgID() != iEpgId)
+        if (tag->EpgID() != iEpgId || gridCursor < tag->StartAsUTC() || m_gridEnd <= tag->StartAsUTC())
           break;
 
-        if (m_gridEnd <= tag->StartAsUTC())
-        {
-          break;
-        }
-        else if (gridCursor >= tag->EndAsUTC())
-        {
-          progIdx++;
-        }
-        else if (gridCursor < tag->EndAsUTC())
+        if (gridCursor < tag->EndAsUTC())
         {
           m_gridIndex[row][block].item = item;
           break;
         }
-        else
-        {
-          progIdx++;
-        }
+        
+        progIdx++;
       }
 
       gridCursor += blockDuration;


### PR DESCRIPTION
As discussed in the forum http://forum.xbmc.org/showthread.php?tid=177880 and described in trac ticket #11479, this fix the issue with the first program of channels within epg timeline.
