### PR TITLE
allow access to special://skin through the webserver's VFS handler

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1154,6 +1154,9 @@ int CUtil::GetMatchingSource(const CStdString& strPath1, VECSOURCES& VECSOURCES,
   // Check for special protocols
   CURL checkURL(strPath);
 
+  if (StringUtils::StartsWith(strPath, "special://skin/"))
+    return 1;
+
   // stack://
   if (checkURL.GetProtocol() == "stack")
     strPath.erase(0, 8); // remove the stack protocol


### PR DESCRIPTION
There has been a report in the JSON-RPC thread (see http://forum.xbmc.org/showthread.php?tid=68263&pid=1554858#pid1554858) that addons can't access files from special://skin anymore through JSON-RPCs Files.GetDirectory. Scripts use this to allow skins to provide their own smartplaylists etc and then provide that information for widgets etc.

Obviously the reason is that we have limited access to the filesystem for JSON-RPC and the webserver. IMO this use case sounds like something that we should keep supporting.
