### PR TITLE
videodb: SQL query fixes for clean database

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8217,7 +8217,11 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     }
 
     CLog::Log(LOGDEBUG, "%s: Cleaning paths that don't exist and have content set...", __FUNCTION__);
-    sql = "select * from path where not (strContent='' and strSettings='' and strHash='' and exclude!=1)";
+    sql = "select * from path "
+            "where not ((strContent IS NULL OR strContent='') "
+                   "and (strSettings IS NULL OR strSettings='') "
+                   "and (strHash IS NULL OR strHash='') "
+                   "and (exclude IS NULL OR exclude!=1))";
     m_pDS->query(sql.c_str());
     CStdString strIds;
     while (!m_pDS->eof())
@@ -8248,7 +8252,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
             "join tvshowlinkpath on tvshow.idShow=tvshowlinkpath.idShow "
             "join path on path.idPath=tvshowlinkpath.idPath "
           "where tvshow.idShow not in (select idShow from episode) "
-            "and path.strContent=''";
+            "and (path.strContent IS NULL OR path.strContent='')";
     m_pDS->query(sql.c_str());
     while (!m_pDS->eof())
     {
@@ -8315,7 +8319,11 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     }
 
     CLog::Log(LOGDEBUG, "%s: Cleaning path table", __FUNCTION__);
-    sql = StringUtils::Format("delete from path where strContent='' and strSettings='' and strHash='' and exclude!=1 "
+    sql = StringUtils::Format("delete from path "
+                                "where (strContent is null or strContent='') "
+                                  "and (strSettings is null or strSettings='') "
+                                  "and (strHash is null or strHash='') "
+                                  "and (exclude is null or exclude!=1) "
                                   "and idPath not in (select distinct idPath from files) "
                                   "and idPath not in (select distinct idPath from tvshowlinkpath) "
                                   "and idPath not in (select distinct c%02d from movie) "


### PR DESCRIPTION
These are two SQL query fixes I came across while looking into an improved database clean logic.
- The first commit adds missing handling for NULLed fields because otherwise those paths aren't deleted even though they don't exist anymore.
- The second commit removes the condition on strHash. I don't see why we would want to keep around a non-existing path just because we already calculated its fast hash?

I'm not 100% sure about the second commit which is why I made this a PR.
