### PR TITLE
fix addon uninstall yesno dialog behaviour

### DIFF
--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -216,7 +216,7 @@ void CGUIDialogAddonInfo::OnUninstall()
     return;
 
   // prompt user to be sure
-  if (CGUIDialogYesNo::ShowAndGetInput(24037, 750, 0, 0))
+  if (!CGUIDialogYesNo::ShowAndGetInput(24037, 750, 0, 0))
     return;
 
   // ensure the addon isn't disabled in our database


### PR DESCRIPTION
introduced in 333025f

addon uninstall yesno dialog behaviour is broken:
yes = does nothing. no = uninstalls the addon

//cc @jmarshallnz
