### PR TITLE
[rbp/omxplayer] Fix leak when playing multiple files from playlist

### DIFF
--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -141,7 +141,7 @@ void OMXClock::OMXDeinitialize()
   if(m_omx_clock.GetComponent() == NULL)
     return;
 
-  m_omx_clock.Deinitialize();
+  m_omx_clock.Deinitialize(true);
 
   m_omx_speed = DVD_PLAYSPEED_NORMAL;
 }


### PR DESCRIPTION
When omxplayer plays a second file from a playlist (i.e. without being shut down) a clock component gets leaked.
Eventually enough of these leaked components will stop further playback
