### PR TITLE
CArchive: fix incorrect streaming of size_t

### DIFF
--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -22,6 +22,10 @@
 #include "filesystem/File.h"
 #include "Variant.h"
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wlong-long"
+#endif
+
 using namespace XFILE;
 
 #define BUFFER_MAX 4096
@@ -83,6 +87,30 @@ CArchive& CArchive::operator<<(double d)
   return *this;
 }
 
+CArchive& CArchive::operator<<(short int s)
+{
+  int size = sizeof(s);
+  if (m_BufferPos + size >= BUFFER_MAX)
+    FlushBuffer();
+
+  memcpy(&m_pBuffer[m_BufferPos], &s, size);
+  m_BufferPos += size;
+
+  return *this;
+}
+
+CArchive& CArchive::operator<<(unsigned short int us)
+{
+  int size = sizeof(us);
+  if (m_BufferPos + size >= BUFFER_MAX)
+    FlushBuffer();
+
+  memcpy(&m_pBuffer[m_BufferPos], &us, size);
+  m_BufferPos += size;
+
+  return *this;
+}
+
 CArchive& CArchive::operator<<(int i)
 {
   int size = sizeof(int);
@@ -107,25 +135,49 @@ CArchive& CArchive::operator<<(unsigned int i)
   return *this;
 }
 
-CArchive& CArchive::operator<<(int64_t i64)
+CArchive& CArchive::operator<<(long int l)
 {
-  int size = sizeof(int64_t);
+  const size_t size = sizeof(l);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
-  memcpy(&m_pBuffer[m_BufferPos], &i64, size);
+  memcpy(&m_pBuffer[m_BufferPos], &l, size);
   m_BufferPos += size;
 
   return *this;
 }
 
-CArchive& CArchive::operator<<(uint64_t ui64)
+CArchive& CArchive::operator<<(unsigned long int ul)
 {
-  int size = sizeof(uint64_t);
+  const size_t size = sizeof(ul);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
-  memcpy(&m_pBuffer[m_BufferPos], &ui64, size);
+  memcpy(&m_pBuffer[m_BufferPos], &ul, size);
+  m_BufferPos += size;
+
+  return *this;
+}
+
+CArchive& CArchive::operator<<(long long int ll)
+{
+  const size_t size = sizeof(ll);
+  if (m_BufferPos + size >= BUFFER_MAX)
+    FlushBuffer();
+
+  memcpy(&m_pBuffer[m_BufferPos], &ll, size);
+  m_BufferPos += size;
+
+  return *this;
+}
+
+CArchive& CArchive::operator<<(unsigned long long int ull)
+{
+  const size_t size = sizeof(ull);
+  if (m_BufferPos + size >= BUFFER_MAX)
+    FlushBuffer();
+
+  memcpy(&m_pBuffer[m_BufferPos], &ull, size);
   m_BufferPos += size;
 
   return *this;
@@ -301,6 +353,20 @@ CArchive& CArchive::operator>>(double& d)
   return *this;
 }
 
+CArchive& CArchive::operator>>(short int& s)
+{
+  m_pFile->Read((void*)&s, sizeof(s));
+
+  return *this;
+}
+
+CArchive& CArchive::operator>>(unsigned short int& us)
+{
+  m_pFile->Read((void*)&us, sizeof(us));
+
+  return *this;
+}
+
 CArchive& CArchive::operator>>(int& i)
 {
   m_pFile->Read((void*)&i, sizeof(int));
@@ -315,16 +381,30 @@ CArchive& CArchive::operator>>(unsigned int& i)
   return *this;
 }
 
-CArchive& CArchive::operator>>(int64_t& i64)
+CArchive& CArchive::operator>>(long int& l)
 {
-  m_pFile->Read((void*)&i64, sizeof(int64_t));
+  m_pFile->Read((void*)&l, sizeof(long));
 
   return *this;
 }
 
-CArchive& CArchive::operator>>(uint64_t& ui64)
+CArchive& CArchive::operator>>(unsigned long int& ul)
 {
-  m_pFile->Read((void*)&ui64, sizeof(uint64_t));
+  m_pFile->Read((void*)&ul, sizeof(unsigned long));
+
+  return *this;
+}
+
+CArchive& CArchive::operator>>(long long int& ll)
+{
+  m_pFile->Read((void*)&ll, sizeof(ll));
+
+  return *this;
+}
+
+CArchive& CArchive::operator>>(unsigned long long int& ull)
+{
+  m_pFile->Read((void*)&ull, sizeof(ull));
 
   return *this;
 }

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -65,7 +65,7 @@ bool CArchive::IsStoring()
 
 CArchive& CArchive::operator<<(float f)
 {
-  int size = sizeof(float);
+  const size_t size = sizeof(float);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -77,7 +77,7 @@ CArchive& CArchive::operator<<(float f)
 
 CArchive& CArchive::operator<<(double d)
 {
-  int size = sizeof(double);
+  const size_t size = sizeof(double);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -113,7 +113,7 @@ CArchive& CArchive::operator<<(unsigned short int us)
 
 CArchive& CArchive::operator<<(int i)
 {
-  int size = sizeof(int);
+  const size_t size = sizeof(int);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -125,7 +125,7 @@ CArchive& CArchive::operator<<(int i)
 
 CArchive& CArchive::operator<<(unsigned int i)
 {
-  int size = sizeof(unsigned int);
+  const size_t size = sizeof(unsigned int);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -185,7 +185,7 @@ CArchive& CArchive::operator<<(unsigned long long int ull)
 
 CArchive& CArchive::operator<<(bool b)
 {
-  int size = sizeof(bool);
+  const size_t size = sizeof(bool);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -197,7 +197,7 @@ CArchive& CArchive::operator<<(bool b)
 
 CArchive& CArchive::operator<<(char c)
 {
-  int size = sizeof(char);
+  const size_t size = sizeof(char);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -209,7 +209,7 @@ CArchive& CArchive::operator<<(char c)
 
 CArchive& CArchive::operator<<(const std::string& str)
 {
-  *this << (int)str.size();
+  *this << str.size();
 
   int size = str.size();
   if (m_BufferPos + size >= BUFFER_MAX)
@@ -233,7 +233,7 @@ CArchive& CArchive::operator<<(const std::string& str)
 
 CArchive& CArchive::operator<<(const std::wstring& wstr)
 {
-  *this << (unsigned int)wstr.size();
+  *this << wstr.size();
 
   unsigned int size = wstr.size() * sizeof(wchar_t);
   const uint8_t* ptr = (const uint8_t*)wstr.data();
@@ -259,7 +259,7 @@ CArchive& CArchive::operator<<(const std::wstring& wstr)
 
 CArchive& CArchive::operator<<(const SYSTEMTIME& time)
 {
-  int size = sizeof(SYSTEMTIME);
+  const size_t size = sizeof(SYSTEMTIME);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -323,8 +323,8 @@ CArchive& CArchive::operator<<(const CVariant& variant)
 
 CArchive& CArchive::operator<<(const std::vector<std::string>& strArray)
 {
-  *this << (unsigned int)strArray.size();
-  for (unsigned int index = 0; index < strArray.size(); index++)
+  *this << strArray.size();
+  for (size_t index = 0; index < strArray.size(); index++)
     *this << strArray.at(index);
 
   return *this;
@@ -332,8 +332,8 @@ CArchive& CArchive::operator<<(const std::vector<std::string>& strArray)
 
 CArchive& CArchive::operator<<(const std::vector<int>& iArray)
 {
-  *this << (unsigned int)iArray.size();
-  for (unsigned int index = 0; index < iArray.size(); index++)
+  *this << iArray.size();
+  for (size_t index = 0; index < iArray.size(); index++)
     *this << iArray.at(index);
 
   return *this;
@@ -425,7 +425,7 @@ CArchive& CArchive::operator>>(char& c)
 
 CArchive& CArchive::operator>>(std::string& str)
 {
-  int iLength = 0;
+  size_t iLength = 0;
   *this >> iLength;
 
   char *s = new char[iLength];
@@ -438,7 +438,7 @@ CArchive& CArchive::operator>>(std::string& str)
 
 CArchive& CArchive::operator>>(std::wstring& wstr)
 {
-  unsigned int iLength = 0;
+  size_t iLength = 0;
   *this >> iLength;
 
   wchar_t * const p = new wchar_t[iLength];
@@ -465,7 +465,7 @@ CArchive& CArchive::operator>>(IArchivable& obj)
 
 CArchive& CArchive::operator>>(CVariant& variant)
 {
-  int type;
+  size_t type;
   *this >> type;
   variant = CVariant((CVariant::VariantType)type);
 
@@ -550,10 +550,10 @@ CArchive& CArchive::operator>>(CVariant& variant)
 
 CArchive& CArchive::operator>>(std::vector<std::string>& strArray)
 {
-  int size;
+  size_t size;
   *this >> size;
   strArray.clear();
-  for (int index = 0; index < size; index++)
+  for (size_t index = 0; index < size; index++)
   {
     std::string str;
     *this >> str;
@@ -565,10 +565,10 @@ CArchive& CArchive::operator>>(std::vector<std::string>& strArray)
 
 CArchive& CArchive::operator>>(std::vector<int>& iArray)
 {
-  int size;
+  size_t size;
   *this >> size;
   iArray.clear();
-  for (int index = 0; index < size; index++)
+  for (size_t index = 0; index < size; index++)
   {
     int i;
     *this >> i;

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -44,13 +44,28 @@ class CArchive
 public:
   CArchive(XFILE::CFile* pFile, int mode);
   ~CArchive();
+
+  /* CArchive support storing and loading of all C basic integer types
+   * C basic types was chosen instead of fixed size ints (int16_t - int64_t) to support all integer typedefs
+   * For example size_t can be typedef of unsigned int, long or long long depending on platform 
+   * while int32_t and int64_t are usually unsigned short, int or long long, but not long 
+   * and even if int and long can have same binary representation they are different types for compiler 
+   * According to section 5.2.4.2.1 of C99 http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf
+   * minimal size of short int is 16 bits
+   * minimal size of int is 16 bits (usually 32 or 64 bits, larger or equal to short int)
+   * minimal size of long int is 32 bits (larger or equal to int)
+   * minimal size of long long int is 64 bits (larger or equal to long int) */
   // storing
   CArchive& operator<<(float f);
   CArchive& operator<<(double d);
+  CArchive& operator<<(short int s);
+  CArchive& operator<<(unsigned short int us);
   CArchive& operator<<(int i);
   CArchive& operator<<(unsigned int i);
-  CArchive& operator<<(int64_t i64);
-  CArchive& operator<<(uint64_t ui64);
+  CArchive& operator<<(long int l);
+  CArchive& operator<<(unsigned long int ul);
+  CArchive& operator<<(long long int ll);
+  CArchive& operator<<(unsigned long long int ull);
   CArchive& operator<<(bool b);
   CArchive& operator<<(char c);
   CArchive& operator<<(const std::string &str);
@@ -64,10 +79,14 @@ public:
   // loading
   CArchive& operator>>(float& f);
   CArchive& operator>>(double& d);
+  CArchive& operator>>(short int& i);
+  CArchive& operator>>(unsigned short int& i);
   CArchive& operator>>(int& i);
   CArchive& operator>>(unsigned int& i);
-  CArchive& operator>>(int64_t& i64);
-  CArchive& operator>>(uint64_t& ui64);
+  CArchive& operator>>(long int& l);
+  CArchive& operator>>(unsigned long int& ul);
+  CArchive& operator>>(long long int& ll);
+  CArchive& operator>>(unsigned long long int& ull);
   CArchive& operator>>(bool& b);
   CArchive& operator>>(char& c);
   CArchive& operator>>(std::string &str);


### PR DESCRIPTION
`size_t` is not equal to `unsigned int` on some platforms.
Instead of narrowing it to smaller size, support correct streaming of all integers types.
