### PR TITLE
fixed: some cd names were displayed as weird characters.

### DIFF
--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -400,8 +400,8 @@ void CCdIoSupport::PrintAnalysis(int fs, int num_audio)
   case FS_ISO_9660_INTERACTIVE:
   case FS_ISO_HFS:
   case FS_ISO_UDF:
-    CLog::Log(LOGINFO, "ISO 9660: %i blocks, label `%.32s'\n",
-              m_nIsofsSize, buffer[0] + 40);
+    CLog::Log(LOGINFO, "ISO 9660: %i blocks, label %s",
+              m_nIsofsSize, m_strDiscLabel.c_str());
     break;
   }
 
@@ -882,8 +882,8 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
                   " ISO 9660 blocks: %6i",
                   j++, i, m_nStartTrack, m_nIsofsSize);
 
-        CLog::Log(LOGINFO, "ISO 9660: %i blocks, label '%.32s'\n",
-                  m_nIsofsSize, buffer[0] + 40);
+        CLog::Log(LOGINFO, "ISO 9660: %i blocks, label %s",
+                  m_nIsofsSize, m_strDiscLabel.c_str());
         m_nFs |= MULTISESSION;
         ti.nfsInfo = m_nFs;
       }


### PR DESCRIPTION
Don't play buffer games just use the label we've obtain already.
