### PR TITLE
Add caching of text labels at the UTF8 level

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -217,12 +217,14 @@ void CGUITextLayout::RenderOutline(float x, float y, color_t color, color_t outl
 
 bool CGUITextLayout::Update(const CStdString &text, float maxWidth, bool forceUpdate /*= false*/, bool forceLTRReadingOrder /*= false*/)
 {
-  // convert to utf16
+  if (text == m_lastUtf8Text && !forceUpdate)
+    return false;
+
+  m_lastUtf8Text = text;
   CStdStringW utf16;
   utf8ToW(text, utf16);
-
-  // update
-  return UpdateW(utf16, maxWidth, forceUpdate, forceLTRReadingOrder);
+  UpdateCommon(utf16, maxWidth, forceLTRReadingOrder);
+  return true;
 }
 
 bool CGUITextLayout::UpdateW(const CStdStringW &text, float maxWidth /*= 0*/, bool forceUpdate /*= false*/, bool forceLTRReadingOrder /*= false*/)
@@ -230,6 +232,13 @@ bool CGUITextLayout::UpdateW(const CStdStringW &text, float maxWidth /*= 0*/, bo
   if (text == m_lastText && !forceUpdate)
     return false;
 
+  m_lastText = text;
+  UpdateCommon(text, maxWidth, forceLTRReadingOrder);
+  return true;
+}
+
+void CGUITextLayout::UpdateCommon(const CStdStringW &text, float maxWidth, bool forceLTRReadingOrder)
+{
   // parse the text for style information
   vecText parsedText;
   vecColors colors;
@@ -237,8 +246,6 @@ bool CGUITextLayout::UpdateW(const CStdStringW &text, float maxWidth /*= 0*/, bo
 
   // and update
   UpdateStyled(parsedText, colors, maxWidth, forceLTRReadingOrder);
-  m_lastText = text;
-  return true;
 }
 
 void CGUITextLayout::UpdateStyled(const vecText &text, const vecColors &colors, float maxWidth, bool forceLTRReadingOrder)

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -227,7 +227,7 @@ bool CGUITextLayout::Update(const CStdString &text, float maxWidth, bool forceUp
 
 bool CGUITextLayout::UpdateW(const CStdStringW &text, float maxWidth /*= 0*/, bool forceUpdate /*= false*/, bool forceLTRReadingOrder /*= false*/)
 {
-  if (text.Equals(m_lastText) && !forceUpdate)
+  if (text == m_lastText && !forceUpdate)
     return false;
 
   // parse the text for style information

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -116,6 +116,7 @@ protected:
   static void BidiTransform(std::vector<CGUIString> &lines, bool forceLTRReadingOrder);
   static CStdStringW BidiFlip(const CStdStringW &text, bool forceLTRReadingOrder);
   void CalcTextExtent();
+  void UpdateCommon(const CStdStringW &text, float maxWidth, bool forceLTRReadingOrder);
 
   // our text to render
   vecColors m_colors;
@@ -131,6 +132,7 @@ protected:
   // the default color (may differ from the font objects defaults)
   color_t m_textColor;
 
+  std::string m_lastUtf8Text;
   CStdStringW m_lastText;
   float m_textWidth;
   float m_textHeight;


### PR DESCRIPTION
Previously, CGUITextLayout::Update converted its string argument from UTF8 to
UTF16, then passed it to CGUITextLayout::UpdateW, where it was compared
against a cached copy of the string (in its UTF16 form). However, the
conversion itself was taking up a reasonable chunk of CPU time.

This patch adds a similar cache of the string in its UTF8 form to the Update
method, and splits the non-cache part of UpdateW into a separate function, so
we can bypass it the case where we've tested it against the UTF8 cache.

I have also changed the string comparison to be case-sensitive; it seems
likely that it was only case-insensitive due to the the default seting of
CStdStr::Equals. It's unlikely that you'd ever want to update a string with
another which is the same except for the case of one or more characters, but
if you did, I doubt you'd want to use the cached version if so. And you're
slowing down the comparison in all other cases to achieve that dubious
behaviour.

I have measured the effect while the Videos window of the default skin was
open (but idle) on a Raspberry Pi, and this reduced the CPU usage by 2.9%
from 39.1% to 36.2%:

```
          Before          After
          Mean   StdDev   Mean   StdDev  Confidence  Change
IdleCPU%  39.1   0.9      36.2   0.5     100.0%      +8.1%
```
