### PR TITLE
ADD: [droid] implement immersive mode on kitkat

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
+++ b/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
@@ -4,6 +4,7 @@ import android.app.NativeActivity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
 
 public class Main extends NativeActivity 
 {
@@ -28,6 +29,32 @@ public class Main extends NativeActivity
       _onNewIntent(intent);
     } catch (UnsatisfiedLinkError e) {
       Log.e("Main", "Native not registered");
+    }
+  }
+
+  @Override
+  public void onResume()
+  {
+    super.onResume();
+
+    if (android.os.Build.VERSION.SDK_INT >= 19) {
+      // Immersive mode
+
+      // Constants from API > 14
+      final int API_SYSTEM_UI_FLAG_LAYOUT_STABLE = 0x00000100;
+      final int API_SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION = 0x00000200;
+      final int API_SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN = 0x00000400;
+      final int API_SYSTEM_UI_FLAG_FULLSCREEN = 0x00000004;
+      final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
+
+      View thisView = getWindow().getDecorView();
+      thisView.setSystemUiVisibility(
+                API_SYSTEM_UI_FLAG_LAYOUT_STABLE
+              | API_SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+              | API_SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+              | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+              | API_SYSTEM_UI_FLAG_FULLSCREEN
+              | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
     }
   }
 


### PR DESCRIPTION
This one allows to hide the bottom bar on Android 4.4+ (kitkat), i.e. having true fullscreen, using a standard api.

Does not need a minimum api bump, low risk.

/cc @davilla 
