### PR TITLE
Fix for #2049 : Fixed uninitialized boolean in ProfilesOperations.cpp.

### DIFF
--- a/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
@@ -96,7 +96,7 @@ JSONRPC_STATUS CProfilesOperations::LoadProfile(const CStdString &method, ITrans
 	bool bPrompt = false;
 	bPrompt = parameterObject["prompt"].asBoolean();
     
-	bool bCanceled;
+	bool bCanceled(false);
   bool bLoadProfile(false);
 
   if (CProfilesManager::Get().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||            // Password not needed


### PR DESCRIPTION
While trying to help yallah with an issue with the JSON-API load profile feature (http://forum.xbmc.org/showthread.php?tid=176988), I came across uninitialized boolean which might (and actually is) break the feature.
I have no idea how it worked until now but obviously, it must be fixed.

A fix for PR #2049 

@Montellese Please review it.

Thanks
