### PR TITLE
Cleanup

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -1258,7 +1258,7 @@
 		DF93D6AA1444A8B1007C6459 /* SFTPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6851444A8B0007C6459 /* SFTPFile.cpp */; };
 		DF93D6AB1444A8B1007C6459 /* ShoutcastFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6871444A8B0007C6459 /* ShoutcastFile.cpp */; };
 		DF93D6AC1444A8B1007C6459 /* SlingboxFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6891444A8B0007C6459 /* SlingboxFile.cpp */; };
-		DF93D6AD1444A8B1007C6459 /* SmbFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68B1444A8B0007C6459 /* SmbFile.cpp */; };
+		DF93D6AD1444A8B1007C6459 /* SMBFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68B1444A8B0007C6459 /* SMBFile.cpp */; };
 		DF93D6AE1444A8B1007C6459 /* SpecialProtocolFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68D1444A8B0007C6459 /* SpecialProtocolFile.cpp */; };
 		DF93D6AF1444A8B1007C6459 /* TuxBoxDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68F1444A8B0007C6459 /* TuxBoxDirectory.cpp */; };
 		DF93D6B01444A8B1007C6459 /* TuxBoxFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6911444A8B0007C6459 /* TuxBoxFile.cpp */; };
@@ -1687,7 +1687,7 @@
 		DFF0F24817528350002DA3A4 /* SlingboxFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6891444A8B0007C6459 /* SlingboxFile.cpp */; };
 		DFF0F24917528350002DA3A4 /* SmartPlaylistDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17530D25F9FA00618676 /* SmartPlaylistDirectory.cpp */; };
 		DFF0F24A17528350002DA3A4 /* SMBDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DAAF8B0D6E1B0500F17647 /* SMBDirectory.cpp */; };
-		DFF0F24B17528350002DA3A4 /* SmbFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68B1444A8B0007C6459 /* SmbFile.cpp */; };
+		DFF0F24B17528350002DA3A4 /* SMBFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68B1444A8B0007C6459 /* SMBFile.cpp */; };
 		DFF0F24C17528350002DA3A4 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
 		DFF0F24D17528350002DA3A4 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		DFF0F24E17528350002DA3A4 /* SpecialProtocolDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEBD8A60F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp */; };
@@ -2950,7 +2950,7 @@
 		E49912B1174E5D9900741B6D /* SlingboxFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6891444A8B0007C6459 /* SlingboxFile.cpp */; };
 		E49912B2174E5D9900741B6D /* SmartPlaylistDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17530D25F9FA00618676 /* SmartPlaylistDirectory.cpp */; };
 		E49912B3174E5D9900741B6D /* SMBDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DAAF8B0D6E1B0500F17647 /* SMBDirectory.cpp */; };
-		E49912B4174E5D9900741B6D /* SmbFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68B1444A8B0007C6459 /* SmbFile.cpp */; };
+		E49912B4174E5D9900741B6D /* SMBFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68B1444A8B0007C6459 /* SMBFile.cpp */; };
 		E49912B5174E5D9900741B6D /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
 		E49912B6174E5D9900741B6D /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		E49912B7174E5D9900741B6D /* SpecialProtocolDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEBD8A60F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp */; };
@@ -4964,8 +4964,8 @@
 		DF93D6881444A8B0007C6459 /* ShoutcastFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShoutcastFile.h; sourceTree = "<group>"; };
 		DF93D6891444A8B0007C6459 /* SlingboxFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SlingboxFile.cpp; sourceTree = "<group>"; };
 		DF93D68A1444A8B0007C6459 /* SlingboxFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SlingboxFile.h; sourceTree = "<group>"; };
-		DF93D68B1444A8B0007C6459 /* SmbFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SmbFile.cpp; sourceTree = "<group>"; };
-		DF93D68C1444A8B0007C6459 /* SmbFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmbFile.h; sourceTree = "<group>"; };
+		DF93D68B1444A8B0007C6459 /* SMBFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SMBFile.cpp; sourceTree = "<group>"; };
+		DF93D68C1444A8B0007C6459 /* SMBFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMBFile.h; sourceTree = "<group>"; };
 		DF93D68D1444A8B0007C6459 /* SpecialProtocolFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocolFile.cpp; sourceTree = "<group>"; };
 		DF93D68E1444A8B0007C6459 /* SpecialProtocolFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocolFile.h; sourceTree = "<group>"; };
 		DF93D68F1444A8B0007C6459 /* TuxBoxDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TuxBoxDirectory.cpp; sourceTree = "<group>"; };
@@ -9233,8 +9233,8 @@
 				E38E17540D25F9FA00618676 /* SmartPlaylistDirectory.h */,
 				E3DAAF8B0D6E1B0500F17647 /* SMBDirectory.cpp */,
 				E38E17560D25F9FA00618676 /* SMBDirectory.h */,
-				DF93D68B1444A8B0007C6459 /* SmbFile.cpp */,
-				DF93D68C1444A8B0007C6459 /* SmbFile.h */,
+				DF93D68B1444A8B0007C6459 /* SMBFile.cpp */,
+				DF93D68C1444A8B0007C6459 /* SMBFile.h */,
 				7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */,
 				7C84A59D12FA3C1600CD1714 /* SourcesDirectory.h */,
 				7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */,
@@ -11311,7 +11311,7 @@
 				DF93D6AA1444A8B1007C6459 /* SFTPFile.cpp in Sources */,
 				DF93D6AB1444A8B1007C6459 /* ShoutcastFile.cpp in Sources */,
 				DF93D6AC1444A8B1007C6459 /* SlingboxFile.cpp in Sources */,
-				DF93D6AD1444A8B1007C6459 /* SmbFile.cpp in Sources */,
+				DF93D6AD1444A8B1007C6459 /* SMBFile.cpp in Sources */,
 				DF93D6AE1444A8B1007C6459 /* SpecialProtocolFile.cpp in Sources */,
 				DF93D6AF1444A8B1007C6459 /* TuxBoxDirectory.cpp in Sources */,
 				DF93D6B01444A8B1007C6459 /* TuxBoxFile.cpp in Sources */,
@@ -12142,7 +12142,7 @@
 				DFF0F24817528350002DA3A4 /* SlingboxFile.cpp in Sources */,
 				DFF0F24917528350002DA3A4 /* SmartPlaylistDirectory.cpp in Sources */,
 				DFF0F24A17528350002DA3A4 /* SMBDirectory.cpp in Sources */,
-				DFF0F24B17528350002DA3A4 /* SmbFile.cpp in Sources */,
+				DFF0F24B17528350002DA3A4 /* SMBFile.cpp in Sources */,
 				DFF0F24C17528350002DA3A4 /* SourcesDirectory.cpp in Sources */,
 				DFF0F24D17528350002DA3A4 /* SpecialProtocol.cpp in Sources */,
 				DFF0F24E17528350002DA3A4 /* SpecialProtocolDirectory.cpp in Sources */,
@@ -13339,7 +13339,7 @@
 				E49912B1174E5D9900741B6D /* SlingboxFile.cpp in Sources */,
 				E49912B2174E5D9900741B6D /* SmartPlaylistDirectory.cpp in Sources */,
 				E49912B3174E5D9900741B6D /* SMBDirectory.cpp in Sources */,
-				E49912B4174E5D9900741B6D /* SmbFile.cpp in Sources */,
+				E49912B4174E5D9900741B6D /* SMBFile.cpp in Sources */,
 				E49912B5174E5D9900741B6D /* SourcesDirectory.cpp in Sources */,
 				E49912B6174E5D9900741B6D /* SpecialProtocol.cpp in Sources */,
 				E49912B7174E5D9900741B6D /* SpecialProtocolDirectory.cpp in Sources */,

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -34,7 +34,7 @@
 #ifdef TARGET_WINDOWS
 #include "windows/WINFileSmb.h"
 #else
-#include "SmbFile.h"
+#include "SMBFile.h"
 #endif
 #endif
 #ifdef HAS_FILESYSTEM_CDDA
@@ -169,7 +169,7 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
 #ifdef TARGET_WINDOWS
     else if (url.IsProtocol("smb")) return new CWINFileSMB();
 #else
-    else if (url.IsProtocol("smb")) return new CSmbFile();
+    else if (url.IsProtocol("smb")) return new CSMBFile();
 #endif
 #endif
 #ifdef HAS_FILESYSTEM

--- a/xbmc/filesystem/Makefile.in
+++ b/xbmc/filesystem/Makefile.in
@@ -105,7 +105,7 @@ SRCS += RarManager.cpp
 endif
 
 ifeq (@USE_LIBSMBCLIENT@,1)
-SRCS += SmbFile.cpp
+SRCS += SMBFile.cpp
 SRCS += SMBDirectory.cpp
 endif
 

--- a/xbmc/filesystem/SMBDirectory.h
+++ b/xbmc/filesystem/SMBDirectory.h
@@ -20,7 +20,7 @@
  */
 
 #include "IDirectory.h"
-#include "SmbFile.h"
+#include "SMBFile.h"
 #include "MediaSource.h"
 
 namespace XFILE

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -18,12 +18,12 @@
  *
  */
 
-// FileSmb.cpp: implementation of the CSmbFile class.
+// SMBFile.cpp: implementation of the CSMBFile class.
 //
 //////////////////////////////////////////////////////////////////////
 
 #include "system.h"
-#include "SmbFile.h"
+#include "SMBFile.h"
 #include "PasswordManager.h"
 #include "SMBDirectory.h"
 #include <libsmbclient.h>
@@ -295,20 +295,20 @@ void CSMB::AddIdleConnection()
 
 CSMB smb;
 
-CSmbFile::CSmbFile()
+CSMBFile::CSMBFile()
 {
   smb.Init();
   m_fd = -1;
   smb.AddActiveConnection();
 }
 
-CSmbFile::~CSmbFile()
+CSMBFile::~CSMBFile()
 {
   Close();
   smb.AddIdleConnection();
 }
 
-int64_t CSmbFile::GetPosition()
+int64_t CSMBFile::GetPosition()
 {
   if (m_fd == -1) return 0;
   smb.Init();
@@ -319,13 +319,13 @@ int64_t CSmbFile::GetPosition()
   return pos;
 }
 
-int64_t CSmbFile::GetLength()
+int64_t CSMBFile::GetLength()
 {
   if (m_fd == -1) return 0;
   return m_fileSize;
 }
 
-bool CSmbFile::Open(const CURL& url)
+bool CSMBFile::Open(const CURL& url)
 {
   Close();
 
@@ -333,7 +333,7 @@ bool CSmbFile::Open(const CURL& url)
   // if a file matches the if below return false, it can't exist on a samba share.
   if (!IsValidFile(url.GetFileName()))
   {
-      CLog::Log(LOGNOTICE,"FileSmb->Open: Bad URL : '%s'",url.GetFileName().c_str());
+      CLog::Log(LOGNOTICE,"SMBFile->Open: Bad URL : '%s'",url.GetFileName().c_str());
       return false;
   }
   m_url = url;
@@ -345,11 +345,11 @@ bool CSmbFile::Open(const CURL& url)
   std::string strFileName;
   m_fd = OpenFile(url, strFileName);
 
-  CLog::Log(LOGDEBUG,"CSmbFile::Open - opened %s, fd=%d",url.GetFileName().c_str(), m_fd);
+  CLog::Log(LOGDEBUG,"CSMBFile::Open - opened %s, fd=%d",url.GetFileName().c_str(), m_fd);
   if (m_fd == -1)
   {
     // write error to logfile
-    CLog::Log(LOGINFO, "FileSmb->Open: Unable to open file : '%s'\nunix_err:'%x' error : '%s'", CURL::GetRedacted(strFileName).c_str(), errno, strerror(errno));
+    CLog::Log(LOGINFO, "SMBFile->Open: Unable to open file : '%s'\nunix_err:'%x' error : '%s'", CURL::GetRedacted(strFileName).c_str(), errno, strerror(errno));
     return false;
   }
 
@@ -380,7 +380,7 @@ bool CSmbFile::Open(const CURL& url)
 /// \param strAuth The SMB style path
 /// \return SMB file descriptor
 /*
-int CSmbFile::OpenFile(std::string& strAuth)
+int CSMBFile::OpenFile(std::string& strAuth)
 {
   int fd = -1;
 
@@ -401,7 +401,7 @@ int CSmbFile::OpenFile(std::string& strAuth)
 }
 */
 
-int CSmbFile::OpenFile(const CURL &url, std::string& strAuth)
+int CSMBFile::OpenFile(const CURL &url, std::string& strAuth)
 {
   int fd = -1;
   smb.Init();
@@ -420,7 +420,7 @@ int CSmbFile::OpenFile(const CURL &url, std::string& strAuth)
   return fd;
 }
 
-bool CSmbFile::Exists(const CURL& url)
+bool CSMBFile::Exists(const CURL& url)
 {
   // we can't open files like smb://file.f or smb://server/file.f
   // if a file matches the if below return false, it can't exist on a samba share.
@@ -438,7 +438,7 @@ bool CSmbFile::Exists(const CURL& url)
   return true;
 }
 
-int CSmbFile::Stat(struct __stat64* buffer)
+int CSMBFile::Stat(struct __stat64* buffer)
 {
   if (m_fd == -1)
     return -1;
@@ -464,7 +464,7 @@ int CSmbFile::Stat(struct __stat64* buffer)
   return iResult;
 }
 
-int CSmbFile::Stat(const CURL& url, struct __stat64* buffer)
+int CSMBFile::Stat(const CURL& url, struct __stat64* buffer)
 {
   smb.Init();
   std::string strFileName = GetAuthenticatedPath(url);
@@ -489,7 +489,7 @@ int CSmbFile::Stat(const CURL& url, struct __stat64* buffer)
   return iResult;
 }
 
-int CSmbFile::Truncate(int64_t size)
+int CSMBFile::Truncate(int64_t size)
 {
   if (m_fd == -1) return 0;
 /* 
@@ -508,7 +508,7 @@ int CSmbFile::Truncate(int64_t size)
   return 0;
 }
 
-unsigned int CSmbFile::Read(void *lpBuf, int64_t uiBufSize)
+unsigned int CSMBFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (m_fd == -1) return 0;
   CSingleLock lock(smb); // Init not called since it has to be "inited" by now
@@ -540,7 +540,7 @@ unsigned int CSmbFile::Read(void *lpBuf, int64_t uiBufSize)
   return (unsigned int)bytesRead;
 }
 
-int64_t CSmbFile::Seek(int64_t iFilePosition, int iWhence)
+int64_t CSMBFile::Seek(int64_t iFilePosition, int iWhence)
 {
   if (m_fd == -1) return -1;
 
@@ -557,18 +557,18 @@ int64_t CSmbFile::Seek(int64_t iFilePosition, int iWhence)
   return (int64_t)pos;
 }
 
-void CSmbFile::Close()
+void CSMBFile::Close()
 {
   if (m_fd != -1)
   {
-    CLog::Log(LOGDEBUG,"CSmbFile::Close closing fd %d", m_fd);
+    CLog::Log(LOGDEBUG,"CSMBFile::Close closing fd %d", m_fd);
     CSingleLock lock(smb);
     smbc_close(m_fd);
   }
   m_fd = -1;
 }
 
-int CSmbFile::Write(const void* lpBuf, int64_t uiBufSize)
+int CSMBFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   if (m_fd == -1) return -1;
   DWORD dwNumberOfBytesWritten = 0;
@@ -581,7 +581,7 @@ int CSmbFile::Write(const void* lpBuf, int64_t uiBufSize)
   return (int)dwNumberOfBytesWritten;
 }
 
-bool CSmbFile::Delete(const CURL& url)
+bool CSMBFile::Delete(const CURL& url)
 {
   smb.Init();
   std::string strFile = GetAuthenticatedPath(url);
@@ -596,7 +596,7 @@ bool CSmbFile::Delete(const CURL& url)
   return (result == 0);
 }
 
-bool CSmbFile::Rename(const CURL& url, const CURL& urlnew)
+bool CSMBFile::Rename(const CURL& url, const CURL& urlnew)
 {
   smb.Init();
   std::string strFile = GetAuthenticatedPath(url);
@@ -611,7 +611,7 @@ bool CSmbFile::Rename(const CURL& url, const CURL& urlnew)
   return (result == 0);
 }
 
-bool CSmbFile::OpenForWrite(const CURL& url, bool bOverWrite)
+bool CSMBFile::OpenForWrite(const CURL& url, bool bOverWrite)
 {
   m_fileSize = 0;
 
@@ -626,7 +626,7 @@ bool CSmbFile::OpenForWrite(const CURL& url, bool bOverWrite)
 
   if (bOverWrite)
   {
-    CLog::Log(LOGWARNING, "FileSmb::OpenForWrite() called with overwriting enabled! - %s", strFileName.c_str());
+    CLog::Log(LOGWARNING, "SMBFile::OpenForWrite() called with overwriting enabled! - %s", strFileName.c_str());
     m_fd = smbc_creat(strFileName.c_str(), 0);
   }
   else
@@ -637,7 +637,7 @@ bool CSmbFile::OpenForWrite(const CURL& url, bool bOverWrite)
   if (m_fd == -1)
   {
     // write error to logfile
-    CLog::Log(LOGERROR, "FileSmb->Open: Unable to open file : '%s'\nunix_err:'%x' error : '%s'", strFileName.c_str(), errno, strerror(errno));
+    CLog::Log(LOGERROR, "SMBFile->Open: Unable to open file : '%s'\nunix_err:'%x' error : '%s'", strFileName.c_str(), errno, strerror(errno));
     return false;
   }
 
@@ -645,7 +645,7 @@ bool CSmbFile::OpenForWrite(const CURL& url, bool bOverWrite)
   return true;
 }
 
-bool CSmbFile::IsValidFile(const std::string& strFileName)
+bool CSMBFile::IsValidFile(const std::string& strFileName)
 {
   if (strFileName.find('/') == std::string::npos || /* doesn't have sharename */
       StringUtils::EndsWith(strFileName, "/.") || /* not current folder */
@@ -654,7 +654,7 @@ bool CSmbFile::IsValidFile(const std::string& strFileName)
   return true;
 }
 
-std::string CSmbFile::GetAuthenticatedPath(const CURL &url)
+std::string CSMBFile::GetAuthenticatedPath(const CURL &url)
 {
   CURL authURL(url);
   CPasswordManager::GetInstance().AuthenticateURL(authURL);

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -20,7 +20,7 @@
  *
  */
 
-// FileSmb.h: interface for the CSmbFile class.
+// SMBFile.h: interface for the CSMBFile class.
 
 //
 
@@ -71,12 +71,12 @@ extern CSMB smb;
 
 namespace XFILE
 {
-class CSmbFile : public IFile
+class CSMBFile : public IFile
 {
 public:
-  CSmbFile();
+  CSMBFile();
   int OpenFile(const CURL &url, std::string& strAuth);
-  virtual ~CSmbFile();
+  virtual ~CSMBFile();
   virtual void Close();
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -493,7 +493,8 @@ void iso9660::Scan()
     WORD wSectorSize = from_723(m_info.iso.logical_block_size);
 
     // first check if first file in the current VD has a rock-ridge NM. if it has, disable joliet
-    ::SetFilePointer( m_info.ISO_HANDLE, wSectorSize * from_733(((iso9660_Directory*)(&m_info.iso.szRootDir))->extent), 0, FILE_BEGIN );
+    iso9660_Directory *dirPointer = reinterpret_cast<iso9660_Directory*>(&m_info.iso.szRootDir);
+    ::SetFilePointer( m_info.ISO_HANDLE, wSectorSize * from_733(dirPointer->extent), 0, FILE_BEGIN );
 
     DWORD lpNumberOfBytesRead;
     char* pCurr_dir_cache = (char*)malloc( 16*wSectorSize );


### PR DESCRIPTION
This is a series of small fixes for various small problems, I've discovered when looking into other parts of the code.

I've sorted them in sequence of least to most controversial.

The first patch, chooses a consistent naming scheme for all Samba related files, it is a bit invasive, but I don't think it should be controversial

The two next are small warning fixes.

The 4th introduces BOOST_STATIC_ASSERT, which IMHO is a good way to make the cast safe and removing the warning

The 5th changes VideoSurfaces API to use size_t over int in apropriate places, which effectively squelches the warnings.
