### PR TITLE
Add caching of infolabels

### DIFF
--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -83,7 +83,7 @@ public:
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
    */  
-  CStdString GetLabel(int contextWindow, bool preferImage = false, CStdString *fallback = NULL) const;
+  const std::string &GetLabel(int contextWindow, bool preferImage = false, CStdString *fallback = NULL) const;
 
   /*!
    \brief Gets a label (or image) for a given listitem from the info manager.
@@ -92,7 +92,7 @@ public:
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
    */
-  CStdString GetItemLabel(const CGUIListItem *item, bool preferImage = false, CStdString *fallback = NULL) const;
+  const std::string &GetItemLabel(const CGUIListItem *item, bool preferImage = false, CStdString *fallback = NULL) const;
 
   bool IsConstant() const;
   bool IsEmpty() const;
@@ -132,6 +132,11 @@ private:
 
   CStdString m_fallback;
   std::vector<CInfoPortion> m_info;
+
+  mutable bool m_isLabelOfListItem;
+  mutable bool m_labelDirty;
+  mutable std::string m_label;
+  mutable std::vector<std::string> m_labelPortions;
 };
 
 #endif


### PR DESCRIPTION
The functions CGUIInfoLabel::GetLabel and CGUIInfoLabel::GetItemLabel take
a number of strings returned from CGUIInfoManager::GetImage or
CGUIInfoManager::GetLabel, and combine them with various constant strings
which were determined during CGUIInfoLabel::Parse.

Rather than perform all the string operations on every call, this patch
changes to use a two-pass process: first it queries all the GetImage/GetLabel
strings, and then only if at least one of them has changed does it bother
rebuilding the resultant string - otherwise it re-uses the copy built on a
preceding call.

CGUIInfoLabel::GetLabel/GetItemLabel are also changed to return string
references, rather than forcing an additional string copy.

I have measured the effect while the Videos window of the default skin was
open (but idle) on a Raspberry Pi, and this reduced the CPU usage by 0.8%
from 36.2% to 35.4%:

```
          Before          After
          Mean   StdDev   Mean   StdDev  Confidence  Change
IdleCPU%  36.2   0.5      35.4   0.5     99.9%       +2.2%
```
