### PR TITLE
CArchive cleanup and fix

### DIFF
--- a/xbmc/Temperature.cpp
+++ b/xbmc/Temperature.cpp
@@ -483,7 +483,7 @@ double CTemperature::ToLocale() const
 }
 
 // Returns temperature as localized string
-CStdString CTemperature::ToString() const
+std::string CTemperature::ToString() const
 {
   if (!IsValid())
     return g_localizeStrings.Get(13205); // "Unknown"

--- a/xbmc/Temperature.h
+++ b/xbmc/Temperature.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <string>
 #include "utils/Archive.h"
 
 class CTemperature : public IArchivable
@@ -95,7 +96,7 @@ public:
   double ToNewton() const;
 
   double ToLocale() const;
-  CStdString ToString() const;
+  std::string ToString() const;
 
 protected:
   CTemperature(double value);

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "utils/StdString.h"
 #include "utils/Archive.h"
 
 /*! \brief TIME_FORMAT enum/bitmask used for formatting time strings

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -179,30 +179,6 @@ CArchive& CArchive::operator<<(const std::string& str)
   return *this;
 }
 
-CArchive& CArchive::operator<<(const CStdString& str)
-{
-  *this << (unsigned int)str.size();
-
-  int size = str.size();
-  if (m_BufferPos + size >= BUFFER_MAX)
-    FlushBuffer();
-
-  int iBufferMaxParts=size/BUFFER_MAX;
-  for (int i=0; i<iBufferMaxParts; i++)
-  {
-    memcpy(&m_pBuffer[m_BufferPos], str.c_str()+(i*BUFFER_MAX), BUFFER_MAX);
-    m_BufferPos+=BUFFER_MAX;
-    FlushBuffer();
-  }
-
-  int iPos=iBufferMaxParts*BUFFER_MAX;
-  int iSizeLeft=size-iPos;
-  memcpy(&m_pBuffer[m_BufferPos], str.c_str()+iPos, iSizeLeft);
-  m_BufferPos+=iSizeLeft;
-
-  return *this;
-}
-
 CArchive& CArchive::operator<<(const CStdStringW& str)
 {
   *this << (unsigned int)str.size();
@@ -371,18 +347,6 @@ CArchive& CArchive::operator>>(std::string& str)
   m_pFile->Read(s, iLength);
   str.assign(s, iLength);
   delete[] s;
-
-  return *this;
-}
-
-CArchive& CArchive::operator>>(CStdString& str)
-{
-  unsigned int iLength = 0;
-  *this >> iLength;
-
-  m_pFile->Read((void*)str.GetBufferSetLength(iLength), iLength);
-  str.ReleaseBuffer();
-
 
   return *this;
 }

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -53,7 +53,6 @@ public:
   CArchive& operator<<(bool b);
   CArchive& operator<<(char c);
   CArchive& operator<<(const std::string &str);
-  CArchive& operator<<(const CStdString& str);
   CArchive& operator<<(const CStdStringW& str);
   CArchive& operator<<(const SYSTEMTIME& time);
   CArchive& operator<<(IArchivable& obj);
@@ -71,7 +70,6 @@ public:
   CArchive& operator>>(bool& b);
   CArchive& operator>>(char& c);
   CArchive& operator>>(std::string &str);
-  CArchive& operator>>(CStdString& str);
   CArchive& operator>>(CStdStringW& str);
   CArchive& operator>>(SYSTEMTIME& time);
   CArchive& operator>>(IArchivable& obj);

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -53,7 +53,7 @@ public:
   CArchive& operator<<(bool b);
   CArchive& operator<<(char c);
   CArchive& operator<<(const std::string &str);
-  CArchive& operator<<(const CStdStringW& str);
+  CArchive& operator<<(const std::wstring& wstr);
   CArchive& operator<<(const SYSTEMTIME& time);
   CArchive& operator<<(IArchivable& obj);
   CArchive& operator<<(const CVariant& variant);
@@ -70,7 +70,7 @@ public:
   CArchive& operator>>(bool& b);
   CArchive& operator>>(char& c);
   CArchive& operator>>(std::string &str);
-  CArchive& operator>>(CStdStringW& str);
+  CArchive& operator>>(std::wstring& wstr);
   CArchive& operator>>(SYSTEMTIME& time);
   CArchive& operator>>(IArchivable& obj);
   CArchive& operator>>(CVariant& variant);

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -20,7 +20,8 @@
  *
  */
 
-#include "StdString.h"
+#include <string>
+#include <vector>
 #include "system.h" // for SYSTEMTIME
 
 namespace XFILE

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -731,13 +731,13 @@ bool CCPUInfo::readProcStat(unsigned long long& user, unsigned long long& nice,
   return true;
 }
 
-CStdString CCPUInfo::GetCoresUsageString() const
+std::string CCPUInfo::GetCoresUsageString() const
 {
-  CStdString strCores;
+  std::string strCores;
   map<int, CoreInfo>::const_iterator iter = m_cores.begin();
   while (iter != m_cores.end())
   {
-    CStdString strCore;
+    std::string strCore;
 #ifdef TARGET_WINDOWS
     // atm we get only the average over all cores
     strCore = StringUtils::Format("CPU %d core(s) average: %3.1f%% ", m_cpuCount, iter->second.m_fPct);

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -53,12 +53,12 @@ struct CoreInfo
   unsigned long long m_system;
   unsigned long long m_idle;
   unsigned long long m_io;
-  CStdString m_strVendor;
-  CStdString m_strModel;
-  CStdString m_strBogoMips;
-  CStdString m_strHardware;
-  CStdString m_strRevision;
-  CStdString m_strSerial;
+  std::string m_strVendor;
+  std::string m_strModel;
+  std::string m_strBogoMips;
+  std::string m_strHardware;
+  std::string m_strRevision;
+  std::string m_strSerial;
   CoreInfo() : m_id(0), m_fSpeed(.0), m_fPct(.0), m_user(0LL), m_nice(0LL), m_system(0LL), m_idle(0LL), m_io(0LL) {}
 };
 
@@ -81,7 +81,7 @@ public:
   const CoreInfo &GetCoreInfo(int nCoreId);
   bool HasCoreId(int nCoreId) const;
 
-  CStdString GetCoresUsageString() const;
+  std::string GetCoresUsageString() const;
 
   unsigned int GetCPUFeatures() { return m_cpuFeatures; }
 

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include "utils/StdString.h"
 #include "Archive.h"
 #include "ISerializable.h"
 #include <vector>


### PR DESCRIPTION
- remove CStdString
- fix stream in for wide string (long string has buffer overrun)

After removal of `#include "StdString.h"` from CArchive header, I was forced to update some headers to include "StdString.h" or remove of "CStdString"
