### PR TITLE
ActiveAE: fix clipping for sinks using AE_FMT_FLOAT

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1649,9 +1649,11 @@ bool CActiveAE::RunStages()
               fadingStep = delta / samples;
             }
 
-            // for streams amplification of turned off downmix normalization
+            // for stream amplification, 
+            // turned off downmix normalization,
+            // or if sink format is float (in order to prevent from clipping)
             // we need to run on a per sample basis
-            if ((*it)->m_amplify != 1.0 || !(*it)->m_resampleBuffers->m_normalize)
+            if ((*it)->m_amplify != 1.0 || !(*it)->m_resampleBuffers->m_normalize || (m_sinkFormat.m_dataFormat == AE_FMT_FLOAT))
             {
               nb_floats = out->pkt->config.channels / out->pkt->planes;
               nb_loops = out->pkt->nb_samples;


### PR DESCRIPTION
@t-nelson I changed it slightly. the first attempt did not cover all cases like stereo upmix.
