### PR TITLE
No nagging of broken add-ons

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -236,7 +236,8 @@ bool CRepositoryUpdateJob::DoWork()
     if (ShouldCancel(0,0))
       break;
 
-    if (!CAddonInstaller::Get().CheckDependencies(addons[i]))
+    bool deps_met = CAddonInstaller::Get().CheckDependencies(addons[i]);
+    if (!deps_met && addons[i]->Props().broken.empty())
       addons[i]->Props().broken = "DEPSNOTMET";
 
     // invalidate the art associated with this item

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -249,7 +249,8 @@ bool CRepositoryUpdateJob::DoWork()
     AddonPtr addon;
     CAddonMgr::Get().GetAddon(addons[i]->ID(),addon);
     if (addon && addons[i]->Version() > addon->Version() &&
-        !database.IsAddonBlacklisted(addons[i]->ID(),addons[i]->Version().c_str()))
+        !database.IsAddonBlacklisted(addons[i]->ID(),addons[i]->Version().c_str()) &&
+        deps_met)
     {
       if (CSettings::Get().GetBool("general.addonautoupdate") || addon->Type() >= ADDON_VIZ_LIBRARY)
       {


### PR DESCRIPTION
No longer attempts to auto-install add-ons that are broken due to unmet dependencies.

Also don't override repository-set <broken> reasons.
