### PR TITLE
CArchive: fix incorrect streaming of size_t (alternative)

### DIFF
--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -83,25 +83,49 @@ CArchive& CArchive::operator<<(double d)
   return *this;
 }
 
-CArchive& CArchive::operator<<(int i)
+CArchive& CArchive::operator<<(int16_t i16)
 {
-  int size = sizeof(int);
+  int size = sizeof(i16);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
-  memcpy(&m_pBuffer[m_BufferPos], &i, size);
+  memcpy(&m_pBuffer[m_BufferPos], &i16, size);
   m_BufferPos += size;
 
   return *this;
 }
 
-CArchive& CArchive::operator<<(unsigned int i)
+CArchive& CArchive::operator<<(uint16_t ui16)
 {
-  int size = sizeof(unsigned int);
+  int size = sizeof(ui16);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
-  memcpy(&m_pBuffer[m_BufferPos], &i, size);
+  memcpy(&m_pBuffer[m_BufferPos], &ui16, size);
+  m_BufferPos += size;
+
+  return *this;
+}
+
+CArchive& CArchive::operator<<(int32_t i32)
+{
+  int size = sizeof(i32);
+  if (m_BufferPos + size >= BUFFER_MAX)
+    FlushBuffer();
+
+  memcpy(&m_pBuffer[m_BufferPos], &i32, size);
+  m_BufferPos += size;
+
+  return *this;
+}
+
+CArchive& CArchive::operator<<(uint32_t ui32)
+{
+  int size = sizeof(ui32);
+  if (m_BufferPos + size >= BUFFER_MAX)
+    FlushBuffer();
+
+  memcpy(&m_pBuffer[m_BufferPos], &ui32, size);
   m_BufferPos += size;
 
   return *this;
@@ -298,16 +322,30 @@ CArchive& CArchive::operator>>(double& d)
   return *this;
 }
 
-CArchive& CArchive::operator>>(int& i)
+CArchive& CArchive::operator>>(int16_t& i16)
 {
-  m_pFile->Read((void*)&i, sizeof(int));
+  m_pFile->Read((void*)&i16, sizeof(i16));
 
   return *this;
 }
 
-CArchive& CArchive::operator>>(unsigned int& i)
+CArchive& CArchive::operator>>(uint16_t& ui16)
 {
-  m_pFile->Read((void*)&i, sizeof(unsigned int));
+  m_pFile->Read((void*)&ui16, sizeof(ui16));
+
+  return *this;
+}
+
+CArchive& CArchive::operator>>(int32_t& i32)
+{
+  m_pFile->Read((void*)&i32, sizeof(i32));
+
+  return *this;
+}
+
+CArchive& CArchive::operator>>(uint32_t& ui32)
+{
+  m_pFile->Read((void*)&ui32, sizeof(ui32));
 
   return *this;
 }

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -61,7 +61,7 @@ bool CArchive::IsStoring()
 
 CArchive& CArchive::operator<<(float f)
 {
-  int size = sizeof(float);
+  const size_t size = sizeof(float);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -73,7 +73,7 @@ CArchive& CArchive::operator<<(float f)
 
 CArchive& CArchive::operator<<(double d)
 {
-  int size = sizeof(double);
+  const size_t size = sizeof(double);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -85,7 +85,7 @@ CArchive& CArchive::operator<<(double d)
 
 CArchive& CArchive::operator<<(int16_t i16)
 {
-  int size = sizeof(i16);
+  const size_t size = sizeof(i16);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -97,7 +97,7 @@ CArchive& CArchive::operator<<(int16_t i16)
 
 CArchive& CArchive::operator<<(uint16_t ui16)
 {
-  int size = sizeof(ui16);
+  const size_t size = sizeof(ui16);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -157,7 +157,7 @@ CArchive& CArchive::operator<<(uint64_t ui64)
 
 CArchive& CArchive::operator<<(bool b)
 {
-  int size = sizeof(bool);
+  const size_t size = sizeof(bool);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -169,7 +169,7 @@ CArchive& CArchive::operator<<(bool b)
 
 CArchive& CArchive::operator<<(char c)
 {
-  int size = sizeof(char);
+  const size_t size = sizeof(char);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -181,7 +181,7 @@ CArchive& CArchive::operator<<(char c)
 
 CArchive& CArchive::operator<<(const std::string& str)
 {
-  *this << (int)str.size();
+  *this << str.size();
 
   int size = str.size();
   if (m_BufferPos + size >= BUFFER_MAX)
@@ -205,7 +205,7 @@ CArchive& CArchive::operator<<(const std::string& str)
 
 CArchive& CArchive::operator<<(const std::wstring& wstr)
 {
-  *this << (unsigned int)wstr.size();
+  *this << wstr.size();
 
   unsigned int size = wstr.size() * sizeof(wchar_t);
   const uint8_t* ptr = (const uint8_t*)wstr.data();
@@ -231,7 +231,7 @@ CArchive& CArchive::operator<<(const std::wstring& wstr)
 
 CArchive& CArchive::operator<<(const SYSTEMTIME& time)
 {
-  int size = sizeof(SYSTEMTIME);
+  const size_t size = sizeof(SYSTEMTIME);
   if (m_BufferPos + size >= BUFFER_MAX)
     FlushBuffer();
 
@@ -292,8 +292,8 @@ CArchive& CArchive::operator<<(const CVariant& variant)
 
 CArchive& CArchive::operator<<(const std::vector<std::string>& strArray)
 {
-  *this << (unsigned int)strArray.size();
-  for (unsigned int index = 0; index < strArray.size(); index++)
+  *this << strArray.size();
+  for (size_t index = 0; index < strArray.size(); index++)
     *this << strArray.at(index);
 
   return *this;
@@ -301,8 +301,8 @@ CArchive& CArchive::operator<<(const std::vector<std::string>& strArray)
 
 CArchive& CArchive::operator<<(const std::vector<int>& iArray)
 {
-  *this << (unsigned int)iArray.size();
-  for (unsigned int index = 0; index < iArray.size(); index++)
+  *this << iArray.size();
+  for (size_t index = 0; index < iArray.size(); index++)
     *this << iArray.at(index);
 
   return *this;
@@ -380,7 +380,7 @@ CArchive& CArchive::operator>>(char& c)
 
 CArchive& CArchive::operator>>(std::string& str)
 {
-  int iLength = 0;
+  size_t iLength = 0;
   *this >> iLength;
 
   char *s = new char[iLength];
@@ -393,7 +393,7 @@ CArchive& CArchive::operator>>(std::string& str)
 
 CArchive& CArchive::operator>>(std::wstring& wstr)
 {
-  unsigned int iLength = 0;
+  size_t iLength = 0;
   *this >> iLength;
 
   wchar_t * const p = new wchar_t[iLength];
@@ -420,7 +420,7 @@ CArchive& CArchive::operator>>(IArchivable& obj)
 
 CArchive& CArchive::operator>>(CVariant& variant)
 {
-  int type;
+  size_t type;
   *this >> type;
   variant = CVariant((CVariant::VariantType)type);
 
@@ -498,10 +498,10 @@ CArchive& CArchive::operator>>(CVariant& variant)
 
 CArchive& CArchive::operator>>(std::vector<std::string>& strArray)
 {
-  int size;
+  size_t size;
   *this >> size;
   strArray.clear();
-  for (int index = 0; index < size; index++)
+  for (size_t index = 0; index < size; index++)
   {
     std::string str;
     *this >> str;
@@ -513,10 +513,10 @@ CArchive& CArchive::operator>>(std::vector<std::string>& strArray)
 
 CArchive& CArchive::operator>>(std::vector<int>& iArray)
 {
-  int size;
+  size_t size;
   *this >> size;
   iArray.clear();
-  for (int index = 0; index < size; index++)
+  for (size_t index = 0; index < size; index++)
   {
     int i;
     *this >> i;

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -47,8 +47,10 @@ public:
   // storing
   CArchive& operator<<(float f);
   CArchive& operator<<(double d);
-  CArchive& operator<<(int i);
-  CArchive& operator<<(unsigned int i);
+  CArchive& operator<<(int16_t i16);
+  CArchive& operator<<(uint16_t ui16);
+  CArchive& operator<<(int32_t i32);
+  CArchive& operator<<(uint32_t ui32);
   CArchive& operator<<(int64_t i64);
   CArchive& operator<<(uint64_t ui64);
   CArchive& operator<<(bool b);
@@ -64,8 +66,10 @@ public:
   // loading
   CArchive& operator>>(float& f);
   CArchive& operator>>(double& d);
-  CArchive& operator>>(int& i);
-  CArchive& operator>>(unsigned int& i);
+  CArchive& operator>>(int16_t& i16);
+  CArchive& operator>>(uint16_t& ui16);
+  CArchive& operator>>(int32_t& i32);
+  CArchive& operator>>(uint32_t& ui32);
   CArchive& operator>>(int64_t& i64);
   CArchive& operator>>(uint64_t& ui64);
   CArchive& operator>>(bool& b);


### PR DESCRIPTION
`size_t` is not equal to `unsigned int` on some platforms.
Instead of narrowing it to smaller size, support correct streaming of all integers sizes.

This is an alternative for PR #3705
