### PR TITLE
[pvr] Fix missing recordings

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -92,7 +92,8 @@ bool CPVRRecordings::IsDirectoryMember(const CStdString &strDirectory, const CSt
   CStdString strUseDirectory = TrimSlashes(strDirectory);
   CStdString strUseEntryDirectory = TrimSlashes(strEntryDirectory);
 
-  return StringUtils::StartsWith(strUseEntryDirectory, strUseDirectory) &&
+  /* Case-insensitive comparison since sub folders are created with case-insensitive matching (GetSubDirectories) */
+  return StringUtils::StartsWithNoCase(strUseEntryDirectory, strUseDirectory) &&
       (!bDirectMember || strUseEntryDirectory.Equals(strUseDirectory));
 }
 


### PR DESCRIPTION
This fixes an issue with missing recordings that occurs under following
circumstances:
- Recording A in subdirectory "TV Show XY"
- Recording B in subdirectory "TV show xy"

Because of the difference in case, recording B won't show up in any
sub folder. This can happen due to EPG inconsistencies.

The sub folders are created case insensitive (CFileItemList::Contains)
in GetSubDirectories. But when determining if a recording belongs into
a directory, the comparison is case sensitive (in IsDirectoryMember).

This commit changes the IsDirecroryMember check to be case insensitive.
