### PR TITLE
[GLES] Avoid getting viewport so often

### DIFF
--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -395,11 +395,8 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
   
   CPoint offset = camera - CPoint(screenWidth*0.5f, screenHeight*0.5f);
   
-  GLint viewport[4];
-  glGetIntegerv(GL_VIEWPORT, viewport);
-
-  float w = (float)viewport[2]*0.5f;
-  float h = (float)viewport[3]*0.5f;
+  float w = (float)m_viewPort[2]*0.5f;
+  float h = (float)m_viewPort[3]*0.5f;
 
   g_matrices.MatrixMode(MM_MODELVIEW);
   g_matrices.LoadIdentity();
@@ -410,7 +407,6 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
   g_matrices.Frustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
   g_matrices.MatrixMode(MM_MODELVIEW);
 
-  glGetIntegerv(GL_VIEWPORT, m_viewPort);
   GLfloat* matx;
   matx = g_matrices.GetMatrix(MM_MODELVIEW);
   memcpy(m_view, matx, 16 * sizeof(GLfloat));
@@ -516,14 +512,11 @@ void CRenderSystemGLES::GetViewPort(CRect& viewPort)
 {
   if (!m_bRenderCreated)
     return;
-  
-  GLint glvp[4];
-  glGetIntegerv(GL_VIEWPORT, glvp);
-  
-  viewPort.x1 = glvp[0];
-  viewPort.y1 = m_height - glvp[1] - glvp[3];
-  viewPort.x2 = glvp[0] + glvp[2];
-  viewPort.y2 = viewPort.y1 + glvp[3];
+
+  viewPort.x1 = m_viewPort[0];
+  viewPort.y1 = m_height - m_viewPort[1] - m_viewPort[3];
+  viewPort.x2 = m_viewPort[0] + m_viewPort[2];
+  viewPort.y2 = viewPort.y1 + m_viewPort[3];
 }
 
 // FIXME make me const so that I can accept temporary objects
@@ -534,6 +527,10 @@ void CRenderSystemGLES::SetViewPort(CRect& viewPort)
 
   glScissor((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
   glViewport((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
+  m_viewPort[0] = viewPort.x1;
+  m_viewPort[1] = viewPort.y1;
+  m_viewPort[2] = viewPort.x2;
+  m_viewPort[3] = viewPort.y2;
 }
 
 void CRenderSystemGLES::SetScissors(const CRect &rect)


### PR DESCRIPTION
GLES is generally offloaded to a GPU and fed a stream of commands.
These can be executed asynchronously by GPU and there is no need for the host to block.
Whenever a gl call requires a result back that may be affected by previous commands
the queue needs to be drained and a result returned from GPU. This acts as a bottleneck.

Looking closely at what xbmc does, there is only one call that requires a result that is
executed every frame. That is glGetIntegerv(GL_VIEWPORT).
However xbcm is perfectly capable of remembering what it set this to.

By using a cached version of this value, on a Pi, the framerate improves from 69fps to 95fps,
with vsync disabled, and RSS feed showing in home screen.
