### PR TITLE
[rbp] Avoid crash when useddsfanart is enabled

### DIFF
--- a/xbmc/guilib/DDSImage.cpp
+++ b/xbmc/guilib/DDSImage.cpp
@@ -119,6 +119,8 @@ bool CDDSImage::ReadFile(const std::string &inputFile)
 
 bool CDDSImage::Create(const std::string &outputFile, unsigned int width, unsigned int height, unsigned int pitch, unsigned char const *brga, double maxMSE)
 {
+  if (!brga)
+    return false;
   if (!Compress(width, height, pitch, brga, maxMSE))
   { // use ARGB
     Allocate(width, height, XB_FMT_A8R8G8B8);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1040,8 +1040,9 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetFloat(pRootElement, "controllerdeadzone", m_controllerDeadzone, 0.0f, 1.0f);
   XMLUtils::GetUInt(pRootElement, "fanartres", m_fanartRes, 0, 1080);
   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 1080);
+#if !defined(TARGET_RASPBERRY_PI)
   XMLUtils::GetBoolean(pRootElement, "useddsfanart", m_useDDSFanart);
-
+#endif
   XMLUtils::GetBoolean(pRootElement, "playlistasfolders", m_playlistAsFolders);
   XMLUtils::GetBoolean(pRootElement, "detectasudf", m_detectAsUdf);
 


### PR DESCRIPTION
Pi textures don't contain pixels on the arm, and the dds encode path wasn't protected against that.
Also don't allow dds to be enabled, as it is undesirable on Pi
