### PR TITLE
Only write dates/date times to XML if they're valid - fixes #14159

### DIFF
--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -336,10 +336,10 @@ void XMLUtils::SetPath(TiXmlNode* pRootNode, const char *strTag, const CStdStrin
 
 void XMLUtils::SetDate(TiXmlNode* pRootNode, const char *strTag, const CDateTime& date)
 {
-  SetString(pRootNode, strTag, date.GetAsDBDate());
+  SetString(pRootNode, strTag, date.IsValid() ? date.GetAsDBDate() : "");
 }
 
 void XMLUtils::SetDateTime(TiXmlNode* pRootNode, const char *strTag, const CDateTime& dateTime)
 {
-  SetString(pRootNode, strTag, dateTime.GetAsDBDateTime());
+  SetString(pRootNode, strTag, dateTime.IsValid() ? dateTime.GetAsDBDateTime() : "");
 }

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -237,7 +237,7 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathIn
   XMLUtils::SetFloat(&resume, "total", (float)m_resumePoint.totalTimeInSeconds);
   movie->InsertEndChild(resume);
 
-  XMLUtils::SetString(movie, "dateadded", m_dateAdded.GetAsDBDateTime());
+  XMLUtils::SetDateTime(movie, "dateadded", m_dateAdded);
 
   if (additionalNode)
     movie->InsertEndChild(*additionalNode);
@@ -769,10 +769,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     XMLUtils::GetDouble(resume, "total", m_resumePoint.totalTimeInSeconds);
   }
 
-  // dateAdded
-  CStdString dateAdded;
-  XMLUtils::GetString(movie, "dateadded", dateAdded);
-  m_dateAdded.SetFromDBDateTime(dateAdded);
+  XMLUtils::GetDateTime(movie, "dateadded", m_dateAdded);
 }
 
 bool CVideoInfoTag::HasStreamDetails() const


### PR DESCRIPTION
Pretty straight-forward - passing through jenkins as sanity.

This fixes #14159 - ensure a date/datetime is valid before writing it to XML, as I think we're past the start of the 17th century...
