### PR TITLE
add RSS feeds from our addon website

### DIFF
--- a/userdata/RssFeeds.xml
+++ b/userdata/RssFeeds.xml
@@ -4,5 +4,7 @@
   <!-- To use different sets in your skin, each must be called from skin with a unique id.             	!-->
   <set id="1">
     <feed updateinterval="30">http://feeds.xbmc.org/xbmc</feed>
+    <feed updateinterval="30">http://feeds.xbmc.org/latest_xbmc_addons</feed>
+    <feed updateinterval="30">http://feeds.xbmc.org/updated_xbmc_addons</feed>
   </set>
 </rssfeeds>


### PR DESCRIPTION
should only have redirects added on xbmc.org to:
http://feeds.feedburner.com/latest_xbmc_addons
http://feeds.feedburner.com/updated_xbmc_addons

this is also what we did for http://feeds.xbmc.org/
