### PR TITLE
Aefixes

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2222,7 +2222,13 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible" setting="audiooutput.channels" operator="!is">1</dependency>
+            <dependency type="visible">
+              <or>
+                <condition on="property" name="aesettingvisible" setting="audiooutput.channels">audiooutput.stereoupmix</condition>
+                <condition on="property" name="aesettingvisible" setting="audiooutput.passthrough">audiooutput.stereoupmix</condition>
+                <condition on="property" name="aesettingvisible" setting="audiooutput.ac3passthrough">audiooutput.stereoupmix</condition>
+              </or>    
+            </dependency>
           </dependencies>
           <control type="toggle" />
         </setting>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -865,6 +865,14 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
     initSink = true;
     m_stats.Reset(m_sinkFormat.m_sampleRate);
     m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::VOLUME, &m_volume, sizeof(float));
+
+    // limit buffer size in case of sink returns large buffer
+    unsigned int buffertime = (m_sinkFormat.m_frames*1000) / m_sinkFormat.m_sampleRate;
+    if (buffertime > 80)
+    {
+      CLog::Log(LOGWARNING, "ActiveAE::%s - sink returned large buffer of %d ms, reducing to 80 ms", __FUNCTION__, buffertime);
+      m_sinkFormat.m_frames = 80 * m_sinkFormat.m_sampleRate / 1000;
+    }
   }
 
   if (m_silenceBuffers)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1999,7 +1999,7 @@ void CActiveAE::LoadSettings()
   m_settings.channels = (m_sink.GetDeviceType(m_settings.device) == AE_DEVTYPE_IEC958) ? AE_CH_LAYOUT_2_0 : CSettings::Get().GetInt("audiooutput.channels");
   m_settings.samplerate = CSettings::Get().GetInt("audiooutput.samplerate");
 
-  m_settings.stereoupmix = (m_settings.channels > AE_CH_LAYOUT_2_0) ? CSettings::Get().GetBool("audiooutput.stereoupmix") : false;
+  m_settings.stereoupmix = IsSettingVisible("audiooutput.stereoupmix") ? CSettings::Get().GetBool("audiooutput.stereoupmix") : false;
   m_settings.normalizelevels = CSettings::Get().GetBool("audiooutput.normalizelevels");
 
   m_settings.passthrough = m_settings.config == AE_CONFIG_FIXED ? false : CSettings::Get().GetBool("audiooutput.passthrough");
@@ -2145,6 +2145,21 @@ bool CActiveAE::IsSettingVisible(const std::string &settingId)
         CSettings::Get().GetInt("audiooutput.config") != AE_CONFIG_FIXED &&
         m_sink.GetDeviceType(CSettings::Get().GetString("audiooutput.passthroughdevice")) == AE_DEVTYPE_HDMI)
       return true;
+  }
+  else if (settingId == "audiooutput.stereoupmix")
+  {
+    if (m_sink.GetDeviceType(CSettings::Get().GetString("audiooutput.audiodevice")) != AE_DEVTYPE_IEC958)
+    {
+      if (CSettings::Get().GetInt("audiooutput.channels") > AE_CH_LAYOUT_2_0)
+        return true;
+    }
+    else
+    {
+      if (m_sink.HasPassthroughDevice() &&
+          CSettings::Get().GetBool("audiooutput.passthrough") &&
+          CSettings::Get().GetBool("audiooutput.ac3passthrough"))
+        return true;
+    }
   }
   return false;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1001,6 +1001,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
         // create buffer pool
         (*it)->m_inputBuffers = new CActiveAEBufferPool((*it)->m_format);
         (*it)->m_inputBuffers->Create(MAX_CACHE_LEVEL*1000);
+        (*it)->m_streamSpace = (*it)->m_format.m_frameSize * (*it)->m_format.m_frames;
       }
       if (initSink && (*it)->m_resampleBuffers)
       {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -877,8 +877,6 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
   if (m_streams.empty())
   {
     inputFormat = m_sinkFormat;
-    inputFormat.m_channelLayout = m_sinkRequestFormat.m_channelLayout;
-    inputFormat.m_channelLayout.ResolveChannels(m_sinkFormat.m_channelLayout);
     inputFormat.m_dataFormat = AE_FMT_FLOAT;
     inputFormat.m_frameSize = inputFormat.m_channelLayout.Count() *
                               (CAEUtil::DataFormatToBits(inputFormat.m_dataFormat) >> 3);
@@ -967,8 +965,6 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
     else
     {
       outputFormat = m_sinkFormat;
-      outputFormat.m_channelLayout = m_sinkRequestFormat.m_channelLayout;
-      outputFormat.m_channelLayout.ResolveChannels(m_sinkFormat.m_channelLayout);
       outputFormat.m_dataFormat = AE_FMT_FLOAT;
       outputFormat.m_frameSize = outputFormat.m_channelLayout.Count() *
                                  (CAEUtil::DataFormatToBits(outputFormat.m_dataFormat) >> 3);
@@ -1325,7 +1321,7 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
       if (m_settings.config == AE_CONFIG_FIXED || (settings.stereoupmix && format.m_channelLayout.Count() <= 2))
         format.m_channelLayout = stdLayout;
       else
-        format.m_channelLayout.ResolveChannels(stdLayout);;
+        format.m_channelLayout.ResolveChannels(stdLayout);
     }
     // don't change from multi to stereo in AUTO mode
     else if ((settings.config == AE_CONFIG_AUTO) &&

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
@@ -530,6 +530,11 @@ bool CCoreAudioAE::IsSettingVisible(const std::string &settingId)
     else
       return false;
   }
+  else if (settingId == "audiooutput.stereoupmix")
+  {
+    if (CSettings::Get().GetInt("audiooutput.channels") > AE_CH_LAYOUT_2_0)
+      return true;
+  }
 
   return true;
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -52,7 +52,7 @@ public:
 
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 private:
-  CAEChannelInfo GetChannelLayout(AEAudioFormat format);
+  CAEChannelInfo GetChannelLayout(AEAudioFormat format, unsigned int maxChannels);
   void           GetAESParams(const AEAudioFormat format, std::string& params);
   void           HandleError(const char* name, int err);
 
@@ -66,10 +66,19 @@ private:
   snd_pcm_t        *m_pcm;
   int               m_timeout;
 
+  struct ALSAConfig
+  {
+    unsigned int sampleRate;
+    unsigned int periodSize;
+    unsigned int frameSize;
+    unsigned int channels;
+    AEDataFormat format;
+  };
+
   static snd_pcm_format_t AEFormatToALSAFormat(const enum AEDataFormat format);
 
-  bool InitializeHW(AEAudioFormat &format);
-  bool InitializeSW(AEAudioFormat &format);
+  bool InitializeHW(const ALSAConfig &inconfig, ALSAConfig &outconfig);
+  bool InitializeSW(const ALSAConfig &inconfig);
 
   static void AppendParams(std::string &device, const std::string &params);
   static bool TryDevice(const std::string &name, snd_pcm_t **pcmp, snd_config_t *lconf);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -1060,51 +1060,72 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
   CLog::Log(LOGERROR, __FUNCTION__": IsFormatSupported failed (%s) - trying to find a compatible format", WASAPIErrToStr(hr));
 
   int closestMatch;
+  unsigned int requestedChannels = wfxex.Format.nChannels;
+  unsigned int noOfCh;
 
   /* The requested format is not supported by the device.  Find something that works */
-  for (int j = 0; j < sizeof(testFormats)/sizeof(sampleFormat); j++)
+  for (int layout = -1; layout <= (int)ARRAYSIZE(layoutsList); layout++)
   {
-    closestMatch = -1;
-
-    wfxex.Format.wFormatTag           = WAVE_FORMAT_EXTENSIBLE;
-    wfxex.SubFormat                   = testFormats[j].subFormat;
-    wfxex.Format.wBitsPerSample       = testFormats[j].bitsPerSample;
-    wfxex.Samples.wValidBitsPerSample = testFormats[j].validBitsPerSample;
-    wfxex.Format.nBlockAlign          = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
-
-    for (int i = 0 ; i < WASAPISampleRateCount; i++)
+    // if requested layout is not suppported, try standard layouts with at least
+    // the number of channels as requested
+    // as the last resort try stereo
+    if (layout == ARRAYSIZE(layoutsList))
     {
-      wfxex.Format.nSamplesPerSec    = WASAPISampleRates[i];
-      wfxex.Format.nAvgBytesPerSec   = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
-
-      /* Trace format match iteration loop via log */
-      #if 0
-      CLog::Log(LOGDEBUG, "WASAPI: Trying Format: %s, %d, %d, %d", CAEUtil::DataFormatToStr(testFormats[j].subFormatType),
-                                                                   wfxex.Format.nSamplesPerSec,
-                                                                   wfxex.Format.wBitsPerSample,
-                                                                   wfxex.Samples.wValidBitsPerSample);
-      #endif
-
-      hr = m_pAudioClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
-
-      if (SUCCEEDED(hr))
-      {
-        /* If the current sample rate matches the source then stop looking and use it */
-        if ((WASAPISampleRates[i] == format.m_sampleRate) && (testFormats[j].subFormatType <= format.m_dataFormat))
-          goto initialize;
-        /* If this rate is closer to the source then the previous one, save it */
-        else if (closestMatch < 0 || abs((int)WASAPISampleRates[i] - (int)format.m_sampleRate) < abs((int)WASAPISampleRates[closestMatch] - (int)format.m_sampleRate))
-          closestMatch = i;
-      }
-      else if (hr != AUDCLNT_E_UNSUPPORTED_FORMAT)
-          CLog::Log(LOGERROR, __FUNCTION__": IsFormatSupported failed (%s)", WASAPIErrToStr(hr));
+      wfxex.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
+      wfxex.Format.nChannels = 2;
+    }
+    else if (layout >= 0)
+    {
+      wfxex.dwChannelMask = ChLayoutToChMask(layoutsList[layout], &noOfCh);
+      wfxex.Format.nChannels = noOfCh;
+      if (noOfCh < requestedChannels)
+        continue;
     }
 
-    if (closestMatch >= 0)
+    for (int j = 0; j < sizeof(testFormats)/sizeof(sampleFormat); j++)
     {
-      wfxex.Format.nSamplesPerSec    = WASAPISampleRates[closestMatch];
-      wfxex.Format.nAvgBytesPerSec   = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
-      goto initialize;
+      closestMatch = -1;
+
+      wfxex.Format.wFormatTag           = WAVE_FORMAT_EXTENSIBLE;
+      wfxex.SubFormat                   = testFormats[j].subFormat;
+      wfxex.Format.wBitsPerSample       = testFormats[j].bitsPerSample;
+      wfxex.Samples.wValidBitsPerSample = testFormats[j].validBitsPerSample;
+      wfxex.Format.nBlockAlign          = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
+
+      for (int i = 0 ; i < WASAPISampleRateCount; i++)
+      {
+        wfxex.Format.nSamplesPerSec    = WASAPISampleRates[i];
+        wfxex.Format.nAvgBytesPerSec   = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
+
+        /* Trace format match iteration loop via log */
+#if 0
+        CLog::Log(LOGDEBUG, "WASAPI: Trying Format: %s, %d, %d, %d", CAEUtil::DataFormatToStr(testFormats[j].subFormatType),
+          wfxex.Format.nSamplesPerSec,
+          wfxex.Format.wBitsPerSample,
+          wfxex.Samples.wValidBitsPerSample);
+#endif
+
+        hr = m_pAudioClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
+
+        if (SUCCEEDED(hr))
+        {
+          /* If the current sample rate matches the source then stop looking and use it */
+          if ((WASAPISampleRates[i] == format.m_sampleRate) && (testFormats[j].subFormatType <= format.m_dataFormat))
+            goto initialize;
+          /* If this rate is closer to the source then the previous one, save it */
+          else if (closestMatch < 0 || abs((int)WASAPISampleRates[i] - (int)format.m_sampleRate) < abs((int)WASAPISampleRates[closestMatch] - (int)format.m_sampleRate))
+            closestMatch = i;
+        }
+        else if (hr != AUDCLNT_E_UNSUPPORTED_FORMAT)
+          CLog::Log(LOGERROR, __FUNCTION__": IsFormatSupported failed (%s)", WASAPIErrToStr(hr));
+      }
+
+      if (closestMatch >= 0)
+      {
+        wfxex.Format.nSamplesPerSec    = WASAPISampleRates[closestMatch];
+        wfxex.Format.nAvgBytesPerSec   = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
+        goto initialize;
+      }
     }
   }
 

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -55,11 +55,13 @@ void CAEChannelInfo::ResolveChannels(const CAEChannelInfo& rhs)
   bool srcHasSR = false;
   bool srcHasRL = false;
   bool srcHasRR = false;
+  bool srcHasBC = false;
 
   bool dstHasSL = false;
   bool dstHasSR = false;
   bool dstHasRL = false;
   bool dstHasRR = false;
+  bool dstHasBC = false;
 
   for (unsigned int c = 0; c < rhs.m_channelCount; ++c)
     switch(rhs.m_channels[c])
@@ -68,6 +70,7 @@ void CAEChannelInfo::ResolveChannels(const CAEChannelInfo& rhs)
       case AE_CH_SR: dstHasSR = true; break;
       case AE_CH_BL: dstHasRL = true; break;
       case AE_CH_BR: dstHasRR = true; break;
+      case AE_CH_BC: dstHasBC = true; break;
       default:
         break;
     }
@@ -81,6 +84,7 @@ void CAEChannelInfo::ResolveChannels(const CAEChannelInfo& rhs)
       case AE_CH_SR: srcHasSR = true; break;
       case AE_CH_BL: srcHasRL = true; break;
       case AE_CH_BR: srcHasRR = true; break;
+      case AE_CH_BC: srcHasBC = true; break;
       default:
         break;
     }
@@ -106,6 +110,21 @@ void CAEChannelInfo::ResolveChannels(const CAEChannelInfo& rhs)
     newInfo += AE_CH_SL;
   if (srcHasRR && !dstHasRR && dstHasSR)
     newInfo += AE_CH_SR;
+
+  // mix back center if not available in destination layout
+  // prefer mixing into backs if available
+  if (srcHasBC && !dstHasBC)
+  {
+    if (dstHasRL && !newInfo.HasChannel(AE_CH_BL))
+      newInfo += AE_CH_BL;
+    else if (dstHasSL && !newInfo.HasChannel(AE_CH_SL))
+      newInfo += AE_CH_SL;
+
+    if (dstHasRR && !newInfo.HasChannel(AE_CH_BR))
+      newInfo += AE_CH_BR;
+    else if (dstHasSR && !newInfo.HasChannel(AE_CH_SR))
+      newInfo += AE_CH_SR;
+  }
 
   *this = newInfo;
 }

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -101,6 +101,10 @@ void CAEChannelInfo::ResolveChannels(const CAEChannelInfo& rhs)
       newInfo += m_channels[i];
   }
 
+  // we let the sink do the mapping later on
+  if (m_channelCount == 8 && m_channelCount == rhs.Count())
+    return;
+
   /* we need to ensure we end up with rear or side channels for downmix to work */
   if (srcHasSL && !dstHasSL && dstHasRL)
     newInfo += AE_CH_BL;


### PR DESCRIPTION
- fix hidden setting stereo upmix for spdif.
  @memphiz could you please check that things still work for CoreAE.
- back center channel was ignored on stream without BL/BR or SL/SR
- fix 7.1 wide speaker layout for ALSA and WASAPI
