### PR TITLE
[coreSubs] set default services for Tv Shows and Movies

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12046,7 +12046,27 @@ msgctxt "#24115"
 msgid "Save subtitles to movie folder"
 msgstr ""
 
-#empty strings from id 24116 to 24999
+#: system/settings/settings.xml
+msgctxt "#24116"
+msgid "Default TV Service"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#24117"
+msgid "Select service that will be used as default to search for TV Show subtitles"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#24118"
+msgid "Default Movie Service"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#24119"
+msgid "Select service that will be used as default to search for Movie subtitles"
+msgstr ""
+
+#empty strings from id 24120 to 24999
 
 msgctxt "#25000"
 msgid "Notifications"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -759,6 +759,22 @@
             <multiselect>true</multiselect>
           </control>
         </setting>
+        <setting id="subtitles.tv" type="addon" label="24116" help="24117">
+          <level>1</level>
+          <default>-</default>
+          <constraints>
+            <addontype>xbmc.subtitle.module</addontype>
+          </constraints>
+          <control type="button" format="addon" />
+        </setting>
+        <setting id="subtitles.movie" type="addon" label="24118" help="24119">
+          <level>1</level>
+          <default>-</default>
+          <constraints>
+            <addontype>xbmc.subtitle.module</addontype>
+          </constraints>
+          <control type="button" format="addon" />
+        </setting>
         <setting id="subtitles.custompath" type="path" label="21366" help="36191">
           <level>1</level>
           <default></default>


### PR DESCRIPTION
this allows us to specify which subtitle service to use for tv Shows and which for movies. its handy to have as some services are TV only and will return no subs for movies.

@jmarshallnz please check
