### PR TITLE
[rbp/omxplayer] Avoid segfault when switching fullscreen

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -1198,6 +1198,7 @@ int COMXAudio::SetPlaySpeed(int iSpeed)
 
 void COMXAudio::RegisterAudioCallback(IAudioCallback *pCallback)
 {
+  CSingleLock lock (m_critSection);
   if(!m_Passthrough && !m_HWDecode)
   {
     m_pCallback = pCallback;
@@ -1210,6 +1211,7 @@ void COMXAudio::RegisterAudioCallback(IAudioCallback *pCallback)
 
 void COMXAudio::UnRegisterAudioCallback()
 {
+  CSingleLock lock (m_critSection);
   m_pCallback = NULL;
 }
 


### PR DESCRIPTION
Switching fullscreen causes a brief UnregisterAudioCallback/RegsisterAudioCallback.
If this occurs while audio thread is inside VizPacket then we segfault on dereferencing m_pCallback.

Using the m_critSection lock means the higher level test for m_pCallback will protect us.
