### PR TITLE
Don't fail CEC configuration with a CEC capable amplifier but no CEC capable TV

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1455,11 +1455,8 @@ bool CPeripheralCecAdapterUpdateThread::WaitReady(void)
   if (m_configuration.wakeDevices.IsEmpty() && m_configuration.bActivateSource == 0)
     return true;
 
-  // wait for the TV if we're configured to become the active source.
-  // wait for the first device in the wake list otherwise.
-  cec_logical_address waitFor = (m_configuration.bActivateSource == 1) ?
-      CECDEVICE_TV :
-      m_configuration.wakeDevices.primary;
+  // wait for the first device in the wake list
+  cec_logical_address waitFor = m_configuration.wakeDevices.primary;
 
   cec_power_status powerStatus(CEC_POWER_STATUS_UNKNOWN);
   bool bContinue(true);


### PR DESCRIPTION
I have a CEC capable amplifier but my TV is not CEC capable. XBMC is plugged into the amplifier, and I use the amplifier remote to control XBMC via CEC. The current code assumes that if we are powering on CEC devices (I want my amplifier to power on) and are setting XBMC as the active source (my amplifier has multiple inputs, so I do), then we must wait for the TV to power on (which in my case never happens because it doesn't talk CEC) instead of the configured device to power on. The result is that CEC keypresses aren't handled because initialisation is never completed.

This change respects the configured wakeDevices instead of assuming that there's a CEC capable TV.
