### PR TITLE
Change playback error notification from dialog to a toast

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4127,9 +4127,11 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
     // we send this if it isn't playlistplayer that is doing this
     int next = g_playlistPlayer.GetNextSong();
     int size = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist()).size();
-    if(next < 0
-    || next >= size)
+    if (next < 0 || next >= size)
+    {
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(16026), g_localizeStrings.Get(16027));
       OnPlayBackStopped();
+    }
     m_ePlayState = PLAY_STATE_NONE;
   }
 

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -299,8 +299,8 @@ bool CPlayListPlayer::Play(int iSong, bool bAutoPlay /* = false */, bool bPlayPr
     {
       CLog::Log(LOGDEBUG,"Playlist Player: one or more items failed to play... aborting playback");
 
-      // open error dialog
-      CGUIDialogOK::ShowAndGetInput(16026, 16027, 16029, 0);
+      // display error toast
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(16026), g_localizeStrings.Get(16027));
 
       CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_STOPPED, 0, 0, m_iCurrentPlayList, m_iCurrentSong);
       g_windowManager.SendThreadMessage(msg);


### PR DESCRIPTION
Playback error doesn't require any input from user, hence I think it should be a toast
just to notify user something failed.

Also added same toast for when an item fails to play but isn't reaching playlistplayer::play

This should also fix an issue where you try to play a file with android/ios remote app and error dialog pops up. You then try to play another file and it starts but the error dialog is still in front, dismissing the dialog stops the new video that's playing
