### PR TITLE
[GLES] Fix for SBS rendering and cached viewport

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1115,8 +1115,8 @@ void CLinuxRendererGLES::RenderMultiPass(int index, int field)
   g_matrices.LoadIdentity();
   VerifyGLState();
   g_matrices.Ortho2D(0, m_sourceWidth, 0, m_sourceHeight);
-  glViewport(0, 0, m_sourceWidth, m_sourceHeight);
-  glScissor(0, 0, m_sourceWidth, m_sourceHeight);
+  CRect viewport(0, 0, m_sourceWidth, m_sourceHeight);
+  g_Windowing.SetViewPort(viewport);
   g_matrices.MatrixMode(MM_MODELVIEW);
   VerifyGLState();
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -528,9 +528,9 @@ void CRenderSystemGLES::SetViewPort(CRect& viewPort)
   glScissor((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
   glViewport((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
   m_viewPort[0] = viewPort.x1;
-  m_viewPort[1] = viewPort.y1;
-  m_viewPort[2] = viewPort.x2;
-  m_viewPort[3] = viewPort.y2;
+  m_viewPort[1] = m_height - viewPort.y1 - viewPort.Height();
+  m_viewPort[2] = viewPort.Width();
+  m_viewPort[3] = viewPort.Height();
 }
 
 void CRenderSystemGLES::SetScissors(const CRect &rect)


### PR DESCRIPTION
I've also changed the unused function CLinuxRendererGLES::RenderMultiPass
to use the caching wrapper for SetViewPort.
Makes no odds now, but may avoid a problem if it's enabled in future.

Reported by @Memphiz - can you test?
