### PR TITLE
Revert "Ensure that the decoder is init once only."

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -107,11 +107,6 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
     if(*cur == PIX_FMT_VAAPI_VLD && CSettings::Get().GetBool("videoplayer.usevaapi") 
     && (avctx->codec_id != AV_CODEC_ID_MPEG4 || g_advancedSettings.m_videoAllowMpeg4VAAPI)) 
     {
-      if (ctx->GetHardware() != NULL)
-      {
-        ctx->SetHardware(NULL);
-      }
-
       VAAPI::CDecoder* dec = new VAAPI::CDecoder();
       if(dec->Open(avctx, *cur, ctx->m_uSurfacesCount))
       {


### PR DESCRIPTION
This reverts commit 6d637d4801095acfe5b6a7e56f446aa2e4602bfa.

It caused Heap corruption when opening vc-1 files which has an mpeg context and therefore needs to init twice. We cannot NULL it, because it was still in use. Let's do it as we do for all the other hw decoders.
