### PR TITLE
CArchive include cleanup

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -23,6 +23,12 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#ifdef TARGET_POSIX
+#include "XTimeUtils.h"
+#include "XFileUtils.h"
+#else
+#include <Windows.h>
+#endif
 
 #define SECONDS_PER_DAY 86400UL
 #define SECONDS_PER_HOUR 3600UL

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "CDDARipJob.h"
+#include "system.h"
 #ifdef HAVE_LIBMP3LAME
 #include "EncoderLame.h"
 #endif

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -26,6 +26,7 @@
 
 #include "EpgDatabase.h"
 #include "EpgContainer.h"
+#include "system.h"
 
 using namespace std;
 using namespace dbiplus;

--- a/xbmc/filesystem/UPnPFile.cpp
+++ b/xbmc/filesystem/UPnPFile.cpp
@@ -47,7 +47,7 @@ bool CUPnPFile::Open(const CURL& url)
     {
       throw new CRedirectException(pNewImp, pNewUrl);
     }
-    SAFE_DELETE(pNewUrl);    
+    delete pNewUrl;    
   }
   return false;
 }
@@ -64,7 +64,7 @@ int CUPnPFile::Stat(const CURL& url, struct __stat64* buffer)
     {
       throw new CRedirectException(pNewImp, pNewUrl);
     }
-    SAFE_DELETE(pNewUrl);
+    delete pNewUrl;
   }
   return -1;
 }
@@ -81,7 +81,7 @@ bool CUPnPFile::Exists(const CURL& url)
     {
       throw new CRedirectException(pNewImp, pNewUrl);
     }
-    SAFE_DELETE(pNewUrl);
+    delete pNewUrl;
   }
   return false;
 }

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -22,7 +22,7 @@
 
 #include <string>
 #include <vector>
-#include "system.h" // for SYSTEMTIME
+#include "PlatformDefs.h" // for SYSTEMTIME
 
 namespace XFILE
 {


### PR DESCRIPTION
CArchive.h is included in many **header** files, and inclusion of "system.h" in CArchive.h leads to significant overhead.

This PR replace #include "PlatformDefs.h" with #include "system.h" in CArchive.h and fix some depends files.
