### PR TITLE
[pvr] CFileItem: fallback to channel icon if epg icon is empty

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -151,6 +151,8 @@ CFileItem::CFileItem(const CEpgInfoTag& tag)
 
   if (!tag.Icon().empty())
     SetIconImage(tag.Icon());
+  else if (tag.HasPVRChannel() && !tag.ChannelTag()->IconPath().empty())
+    SetIconImage(tag.ChannelTag()->IconPath());
 
   FillInMimeType(false);
 }


### PR DESCRIPTION
If EpgInfoTag icon is empty fallback to channel icon within CFileItem constructor. 
This fix blank icons on epg search results within gui.
