### PR TITLE
[fix] Could not edit/assign movie to movie set after #3642

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1438,8 +1438,7 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
 
 bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPtr &selectedSet)
 {
-  if (movieItem == NULL || !movieItem->HasVideoInfoTag() ||
-      selectedSet == NULL)
+  if (movieItem == NULL || !movieItem->HasVideoInfoTag())
     return false;
 
   CVideoDatabase videodb;


### PR DESCRIPTION
due to https://github.com/Montellese/xbmc/commit/e14fae38dec48cd1cd36f875f1ebde5396f43d57

The "selected movie set" parameter is an OUTPUT parameter, thus will always be null when entering the method.
