### PR TITLE
fix EPG update job (broke in 5aa9f75ac619a56445a03e1b1a3b68d384c03010)

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1389,10 +1389,10 @@ bool CPVRManager::IsJobPending(const char *strJobName) const
   return bReturn;
 }
 
-void CPVRManager::QueueJob(const char *strJobName, CJob *job, bool bIgnorePending /* = false */)
+void CPVRManager::QueueJob(const char *strJobName, CJob *job, bool bEnsureStarted /*= true*/)
 {
   CSingleLock lock(m_critSectionTriggers);
-  if (!IsStarted() || (!bIgnorePending && IsJobPending(strJobName)))
+  if ((bEnsureStarted && !IsStarted()) || IsJobPending(strJobName))
     return;
 
   m_pendingUpdates.push_back(job);
@@ -1403,7 +1403,7 @@ void CPVRManager::QueueJob(const char *strJobName, CJob *job, bool bIgnorePendin
 
 void CPVRManager::TriggerEpgsCreate(void)
 {
-  QueueJob("pvr-create-epgs", new CPVREpgsCreateJob());
+  QueueJob("pvr-create-epgs", new CPVREpgsCreateJob(), false);
 }
 
 void CPVRManager::TriggerRecordingsUpdate(void)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -632,14 +632,14 @@ namespace PVR
     bool IsJobPending(const char *strJobName) const;
 
     /*!
-     * @brief Adds the job to the list of pending jobs. If bIgnorePending is set
-     * to true the job will be added even if there's an identical job already
-     * queued
+     * @brief Adds the job to the list of pending jobs (unless an equal job is 
+     * already pending)
      * @param strJobName the name of the job
-     * @param bIgnorePending whether to ignore previously queued identical jobs
+     * @param bEnsureStarted when set to false the job will be executed regardless 
+     * of whether the PVR manager has started
      * @param job the job
      */
-    void QueueJob(const char *strJobName, CJob *job, bool bIgnorePending = false);
+    void QueueJob(const char *strJobName, CJob *job, bool bEnsureStarted = true);
 
     ManagerState GetState(void) const;
 


### PR DESCRIPTION
I made a mistake in my cleanup PR, this is the fix for it. I replaced the bIgnorePending parameter with BEnsureStarted since the old parameter wasn't used anyway.
