### PR TITLE
Include system.h in TestCPUInfo.cpp

### DIFF
--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "system.h" // For Sleep()
 #include "utils/CPUInfo.h"
 #include "Temperature.h"
 #include "settings/AdvancedSettings.h"


### PR DESCRIPTION
Commit fcae34ab6be9e938b35a54d27e7ead843d0e1dce breaks building of TestCPUInfo. "system.h" needs to be included for Sleep.
