### PR TITLE
[nfs] Fix syncing issue from Trac #14727

### DIFF
--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -245,7 +245,7 @@ bool CNfsConnection::splitUrlIntoExportAndPath(const CURL& url, CStdString &expo
       //GetFileName returns path without leading "/"
       //but we need it because the export paths start with "/"
       //and path.Find(*it) wouldn't work else
-      if(!path.empty() && path[0] != '/')
+      if(path[0] != '/')
       {
         path = "/" + path;
       }
@@ -257,11 +257,20 @@ bool CNfsConnection::splitUrlIntoExportAndPath(const CURL& url, CStdString &expo
         //if path starts with the current export path
         if(StringUtils::StartsWith(path, *it))
         {
+          //its possible that StartsWith may not find the correct match first
+          //as an example, if /path/ & and /path/sub/ are exported, but
+          //the user specifies the path /path/subdir/ (from /path/ export).
+          //If the path is longer than the exportpath, make sure / is next.
+          if( (path.length() > (*it).length()) &&
+              (path[(*it).length()] != '/') && (*it) != "/")
+            continue;
           exportPath = *it;
           //handle special case where root is exported
           //in that case we don't want to stripp off to
           //much from the path
-          if( exportPath == "/" )
+          if( exportPath == path )
+            relativePath = "//";
+          else if( exportPath == "/" )
             relativePath = "//" + path.substr(exportPath.length());
           else
             relativePath = "//" + path.substr(exportPath.length()+1);

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -95,11 +95,13 @@ std::list<std::string> CNfsConnection::GetExportList(const CURL &url)
       for(tmp = exportlist; tmp!=NULL; tmp=tmp->ex_next)
       {
         std::string exportStr = std::string(tmp->ex_dir);
-        URIUtils::AddSlashAtEnd(exportStr);
+        
         retList.push_back(exportStr);
       }      
 
       gNfsConnection.GetImpl()->mount_free_export_list(exportlist);
+      retList.sort();
+      retList.reverse();
     }
     
     return retList;
@@ -260,9 +262,9 @@ bool CNfsConnection::splitUrlIntoExportAndPath(const CURL& url, CStdString &expo
           //in that case we don't want to stripp off to
           //much from the path
           if( exportPath == "/" )
-            relativePath = "//" + path.substr(exportPath.length()-1);
-          else
             relativePath = "//" + path.substr(exportPath.length());
+          else
+            relativePath = "//" + path.substr(exportPath.length()+1);
           ret = true;
           break;          
         }


### PR DESCRIPTION
Corrected branch & patches for trac #14727. This replaces pull request 3769 (sorry my bad for filing that under the master branch).

84fe9debee920dc329298b3a319bc34a1e01b69b - Revert's Memphiz fix for the Trac ticket for several reasons, basically:
- Adding a slash to the end of export strings in CNfsConnection::GetExportList would mean per trac discussion having to add slashes during comparison, and potentially in places that shouldn't have a slash.
- Reversing the returned list of exports from the NFS host meant that we looked at longest match first, which is correct for matching exports against paths.  The commit undid the behaviour which is wrong/bad.

61fb6f567f0a229c1869bbb76524706914574ba9 - This is my fix for the original issue, which basically shortcircuits the substr processes if path is the same as the exportPath.

a43d40673887965041939181dab8dcd077049c92 - This is an additional fix for an issue which I've identified in comments 13 & 15 of the trac ticket, where StartsWith could pick an export as matching that was incorrect (for instance /srv/test/tv/ as the export matching the path /srv/test/tvmedia/, which is technically impossible.

This would cause a error to the user that the path was not accessible and report in the logs:
00:06:12 T:140737274222784   ERROR: Failed to open(//edia) opendir call failed with "NFS: Lookup of //edia failed with NFS3ERR_NOENT(-2)"
00:06:12 T:140737274222784   ERROR: GetDirectory - Error getting nfs://172.31.10.1/srv/test/tvmedia
