### PR TITLE
Split CArchive and IArchivable to seperate headers

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -22,6 +22,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/Archive.h"
 #include "Util.h"
 #include "playlists/PlayListFactory.h"
 #include "utils/Crc32.h"

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -25,7 +25,7 @@
  */
 
 #include "guilib/GUIListItem.h"
-#include "utils/Archive.h"
+#include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
 #include "XBDateTime.h"

--- a/xbmc/Temperature.cpp
+++ b/xbmc/Temperature.cpp
@@ -22,6 +22,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "Temperature.h"
 #include "utils/StringUtils.h"
+#include "utils/Archive.h"
 
 CTemperature::CTemperature()
 {

--- a/xbmc/Temperature.h
+++ b/xbmc/Temperature.h
@@ -20,7 +20,7 @@
  */
 
 #include <string>
-#include "utils/Archive.h"
+#include "utils/IArchivable.h"
 
 class CTemperature : public IArchivable
 {

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -23,6 +23,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "utils/Archive.h"
 #ifdef TARGET_POSIX
 #include "XTimeUtils.h"
 #include "XFileUtils.h"

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -21,7 +21,8 @@
  */
 
 #include "utils/StdString.h"
-#include "utils/Archive.h"
+#include "utils/IArchivable.h"
+#include "system.h"
 
 /*! \brief TIME_FORMAT enum/bitmask used for formatting time strings
  Note the use of bitmasking, e.g.

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIViewStateAddonBrowser.h"
 #include "FileItem.h"
+#include "filesystem/File.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/WindowIDs.h"
 #include "view/ViewState.h"

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -49,6 +49,11 @@ enum DVDStreamType
 #define DVDSTREAM_BLOCK_SIZE_FILE (2048 * 16)
 #define DVDSTREAM_BLOCK_SIZE_DVD  2048
 
+namespace XFILE
+{
+  class CFile;
+}
+
 namespace PVR
 {
   class CPVRChannel;

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -32,6 +32,7 @@
 #include "settings/Settings.h"
 #include "FileItem.h"
 #include "utils/log.h"
+#include "utils/Archive.h"
 #include "Artist.h"
 #include "Album.h"
 #include "MusicThumbLoader.h"

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -24,6 +24,7 @@
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/Variant.h"
+#include "utils/Archive.h"
 
 using namespace MUSIC_INFO;
 

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -27,7 +27,7 @@ class CArtist;
 #include <string>
 #include <stdint.h>
 
-#include "utils/Archive.h"
+#include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
 #include "XBDateTime.h"

--- a/xbmc/osx/smc.h
+++ b/xbmc/osx/smc.h
@@ -19,6 +19,7 @@
 
 #ifndef __SMC_H__
 #define __SMC_H__
+#include <libkern/OSTypes.h>
 #endif
 
 #define SMC_VERSION               "0.01"

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -24,6 +24,7 @@
 #include "utils/Variant.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
+#include "utils/Archive.h"
 
 using namespace std;
 

--- a/xbmc/pictures/PictureInfoTag.h
+++ b/xbmc/pictures/PictureInfoTag.h
@@ -21,7 +21,7 @@
 
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
-#include "utils/Archive.h"
+#include "utils/IArchivable.h"
 #include "DllLibExif.h"
 #include "XBDateTime.h"
 

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -28,6 +28,7 @@
 #include "utils/log.h"
 #include "cdioSupport.h"
 #include "filesystem/iso9660.h"
+#include "filesystem/File.h"
 #include "threads/SingleLock.h"
 #ifdef TARGET_POSIX
 #include <sys/types.h>

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -20,6 +20,7 @@
 
 #include <cstring>
 #include "Archive.h"
+#include "IArchivable.h"
 #include "filesystem/File.h"
 #include "Variant.h"
 #include "utils/log.h"

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -29,15 +29,7 @@ namespace XFILE
   class CFile;
 }
 class CVariant;
-
-class CArchive;
-
-class IArchivable
-{
-public:
-  virtual void Archive(CArchive& ar) = 0;
-  virtual ~IArchivable() {}
-};
+class IArchivable;
 
 class CArchive
 {

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -23,7 +23,6 @@
 
 #include <stdio.h>
 #include <time.h>
-#include "Archive.h"
 #include <string>
 #include <map>
 #include "threads/SystemClock.h"

--- a/xbmc/utils/IArchivable.h
+++ b/xbmc/utils/IArchivable.h
@@ -1,0 +1,31 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class CArchive;
+
+class IArchivable
+{
+public:
+  virtual void Archive(CArchive& ar) = 0;
+  virtual ~IArchivable() {}
+};
+

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -24,6 +24,7 @@
 #include "Variant.h"
 #include "LangInfo.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/Archive.h"
 
 const float VIDEOASPECT_EPSILON = 0.025f;
 

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -20,7 +20,7 @@
  */
 
 #include "utils/StdString.h"
-#include "Archive.h"
+#include "utils/IArchivable.h"
 #include "ISerializable.h"
 #include <vector>
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "utils/Archive.h"
 #include "TextureDatabase.h"
 #include "filesystem/File.h"
 


### PR DESCRIPTION
By splitting out IArchivable from Archive.h a lot of dependency can be removed. Inspired by how ISerialize is split out from Variant.h.

Touching utils/Archive.h now only triggers a rebuild of 10 files. Before there where hundreds.
