### PR TITLE
Inform (pa)player about intent to reopen on skipping tracks

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -49,13 +49,13 @@ void CApplicationPlayer::ClosePlayer()
   }
 }
 
-void CApplicationPlayer::CloseFile()
+void CApplicationPlayer::CloseFile(bool reopen)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
   if (player)
   {
     ++m_iPlayerOPSeq;
-    player->CloseFile();
+    player->CloseFile(reopen);
   }
 }
 
@@ -81,7 +81,7 @@ void CApplicationPlayer::ClosePlayerGapless(PLAYERCOREID newCore)
     // but if we do not stop it, we can not distingush callbacks from previous
     // item and current item, it will confused us then we can not make correct delay
     // callback after the starting state.
-    CloseFile();
+    CloseFile(true);
   }
 }
 

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -60,7 +60,7 @@ public:
   int m_iPlaySpeed;
 
   // player management
-  void CloseFile();
+  void CloseFile(bool reopen = false);
   void ClosePlayer();
   void ClosePlayerGapless(PLAYERCOREID newCore);
   void CreatePlayer(PLAYERCOREID newCore, IPlayerCallback& callback);

--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -439,3 +439,9 @@ bool CAEFactory::IsSettingVisible(const std::string &condition, const std::strin
 
   return AE->IsSettingVisible(value);
 }
+
+void CAEFactory::KeepConfiguration(unsigned int millis)
+{
+  if (AE)
+    AE->KeepConfiguration(millis);
+}

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -76,6 +76,7 @@ public:
   static void SettingOptionsAudioQualityLevelsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
   static void SettingOptionsAudioStreamsilenceFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
   static bool IsSettingVisible(const std::string &condition, const std::string &value, const std::string &settingId);
+  static void KeepConfiguration(unsigned int millis);
 
   static void RegisterAudioCallback(IAudioCallback* pCallback);
   static void UnregisterAudioCallback();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -86,6 +86,7 @@ public:
     GETSTATE,
     DISPLAYLOST,
     DISPLAYRESET,
+    KEEPCONFIG,
     TIMEOUT,
   };
   enum InSignal
@@ -219,6 +220,7 @@ public:
   virtual bool SupportsSilenceTimeout();
   virtual bool SupportsQualityLevel(enum AEQuality level);
   virtual bool IsSettingVisible(const std::string &settingId);
+  virtual void KeepConfiguration(unsigned int millis);
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback);
   virtual void UnregisterAudioCallback();
@@ -286,6 +288,7 @@ protected:
   bool m_extError;
   bool m_extDrain;
   XbmcThreads::EndTime m_extDrainTimer;
+  unsigned int m_extKeepConfig;
   bool m_extDeferData;
 
   enum

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -226,5 +226,11 @@ public:
    * @return true if AudioEngine wants to display this setting
    */
   virtual bool IsSettingVisible(const std::string &settingId) {return false; }
+
+  /**
+   * Instruct AE to keep configuration for a specified time
+   * @param millis time for which old configuration should be kept
+   */
+  virtual void KeepConfiguration(unsigned int millis) {return; }
 };
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -120,7 +120,7 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
   }
 }
 
-bool CExternalPlayer::CloseFile()
+bool CExternalPlayer::CloseFile(bool reopen)
 {
   m_bAbortRequest = true;
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -36,7 +36,7 @@ public:
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) {}
   virtual void UnRegisterAudioCallback()                        {}
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options);
-  virtual bool CloseFile();
+  virtual bool CloseFile(bool reopen = false);
   virtual bool IsPlaying() const;
   virtual void Pause();
   virtual bool IsPaused() const;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -133,7 +133,7 @@ public:
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options){ return false;}
   virtual bool QueueNextFile(const CFileItem &file) { return false; }
   virtual void OnNothingToQueueNotify() {}
-  virtual bool CloseFile(){ return true;}
+  virtual bool CloseFile(bool reopen = false) = 0;
   virtual bool IsPlaying() const { return false;}
   virtual bool CanPause() { return true; };
   virtual void Pause() = 0;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -590,7 +590,7 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
   }
 }
 
-bool CDVDPlayer::CloseFile()
+bool CDVDPlayer::CloseFile(bool reopen)
 {
   CLog::Log(LOGNOTICE, "CDVDPlayer::CloseFile()");
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -181,7 +181,7 @@ public:
   CDVDPlayer(IPlayerCallback& callback);
   virtual ~CDVDPlayer();
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options);
-  virtual bool CloseFile();
+  virtual bool CloseFile(bool reopen = false);
   virtual bool IsPlaying() const;
   virtual void Pause();
   virtual bool IsPaused() const;

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -636,7 +636,7 @@ bool COMXPlayer::OpenFile(const CFileItem &file, const CPlayerOptions &options)
   }
 }
 
-bool COMXPlayer::CloseFile()
+bool COMXPlayer::CloseFile(bool reopen)
 {
   CLog::Log(LOGDEBUG, "COMXPlayer::CloseFile");
 

--- a/xbmc/cores/omxplayer/OMXPlayer.h
+++ b/xbmc/cores/omxplayer/OMXPlayer.h
@@ -177,7 +177,7 @@ public:
   virtual ~COMXPlayer();
   
   virtual bool  OpenFile(const CFileItem &file, const CPlayerOptions &options);
-  virtual bool  CloseFile();
+  virtual bool  CloseFile(bool reopen = false);
   virtual bool  IsPlaying() const;
   virtual void  Pause();
   virtual bool  IsPaused() const;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -509,7 +509,7 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
   return true;
 }
 
-bool PAPlayer::CloseFile()
+bool PAPlayer::CloseFile(bool reopen)
 {
   if (!m_isPaused)
     SoftStop(true, true);

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -511,6 +511,9 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
 
 bool PAPlayer::CloseFile(bool reopen)
 {
+  if (reopen)
+    CAEFactory::KeepConfiguration(3000);
+
   if (!m_isPaused)
     SoftStop(true, true);
   CloseAllStreams(false);

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -46,7 +46,7 @@ public:
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions &options);
   virtual bool QueueNextFile(const CFileItem &file);
   virtual void OnNothingToQueueNotify();
-  virtual bool CloseFile();
+  virtual bool CloseFile(bool reopen = false);
   virtual bool IsPlaying() const;
   virtual void Pause();
   virtual bool IsPaused() const;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -357,7 +357,7 @@ failed:
   return false;
 }
 
-bool CUPnPPlayer::CloseFile()
+bool CUPnPPlayer::CloseFile(bool reopen)
 {
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
   NPT_CHECK_LABEL(m_control->Stop(m_delegate->m_device

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -37,7 +37,7 @@ public:
 
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options);
   virtual bool QueueNextFile(const CFileItem &file);
-  virtual bool CloseFile();
+  virtual bool CloseFile(bool reopen = false);
   virtual bool IsPlaying() const;
   virtual void Pause();
   virtual bool IsPaused() const;


### PR DESCRIPTION
Skipping back and forth through audio tracks can take a long time, application closes and reopens player. During that time audio engine has no stream and switches back to gui sound mode. Informing player about the intent to reopen gives it a chance to inform AE to keep current configuration for a while. 
