### PR TITLE
Revert PR#3231 and make "visualisation as screensaver" behave as having fullscreen manually toggled (so it won't trigger screensaver state at all)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4517,14 +4517,17 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
     m_iScreenSaveLock = 0;
     ResetScreenSaverTimer();
 
-    if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim" || m_screenSaver->ID() == "screensaver.xbmc.builtin.black" || m_screenSaver->ID().empty())
+    if (m_screenSaver->ID() == "visualization")
+    {
+      // we can just continue as usual from vis mode
+      return false;
+    }
+    else if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim" || m_screenSaver->ID() == "screensaver.xbmc.builtin.black" || m_screenSaver->ID().empty())
       return true;
     else if (!m_screenSaver->ID().empty())
     { // we're in screensaver window
-      if (g_windowManager.GetActiveWindow() == WINDOW_SCREENSAVER
-          || g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION)
+      if (g_windowManager.GetActiveWindow() == WINDOW_SCREENSAVER)
         g_windowManager.PreviousWindow();  // show the previous window
-
       if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW)
         CApplicationMessenger::Get().SendAction(CAction(ACTION_STOP), WINDOW_SLIDESHOW);
     }
@@ -4595,6 +4598,12 @@ void CApplication::CheckScreenSaverAndDPMS()
 // the type of screensaver displayed
 void CApplication::ActivateScreenSaver(bool forceType /*= false */)
 {
+  if (m_pPlayer->IsPlayingAudio() && CSettings::Get().GetBool("screensaver.usemusicvisinstead") && !CSettings::Get().GetString("musicplayer.visualisation").empty())
+  { // just activate the visualisation if user toggled the usemusicvisinstead option
+    g_windowManager.ActivateWindow(WINDOW_VISUALISATION);
+    return;
+  }
+
   m_bScreenSave = true;
 
   // Get Screensaver Mode
@@ -4613,15 +4622,6 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     {
       if (!CAddonMgr::Get().GetAddon("screensaver.xbmc.builtin.dim", m_screenSaver))
         m_screenSaver.reset(new CScreenSaver(""));
-    }
-    // Check if we are Playing Audio and Vis instead Screensaver!
-    else if (m_pPlayer->IsPlayingAudio() && CSettings::Get().GetBool("screensaver.usemusicvisinstead") && !CSettings::Get().GetString("musicplayer.visualisation").empty())
-    { // activate the visualisation
-      m_screenSaver.reset(new CScreenSaver("visualization"));
-      // prevent music info popup if vis is already running
-      if (g_windowManager.GetActiveWindow() != WINDOW_VISUALISATION)
-        g_windowManager.ActivateWindow(WINDOW_VISUALISATION);
-      return;
     }
   }
   if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim" || m_screenSaver->ID().empty())


### PR DESCRIPTION
So since https://github.com/xbmc/xbmc/pull/3231 seemed to cause more irritation and troubles than it helped, this does the following change:
- Restore the old behaviour by reverting the commit
- Move the check for IsAudio+usevisasscreensaver above the screensaver-enabling processing and don't tamper with screensaving triggers when the condition applies

With this, when idle-time exceeds the screensaver wait time, one plays music and has the flag set in the options, XBMC behaves as if the user manually pushed the fullscreen key (TAB, SHIFT+Fx on nyxboard etc.) and doesn't do any screensaving handling at all. This still fixes the missing "onScreenSaverDeactivated" announcement (not required as it won't send the ScreenSaverActivated announcement anymore for musicvis-as-saver) and makes XBMC-Music users happy again as it seems they liked the old behaviour.

Probably for @jmarshallnz to review. Build-tested on Linux.
