### PR TITLE
[peripherals] fixed a ambiguous variable and replaced .size() by .empty()

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -453,14 +453,14 @@ void CPeripheralCecAdapter::ProcessVolumeChange(void)
   CecVolumeChange pendingVolumeChange = VOLUME_CHANGE_NONE;
   {
     CSingleLock lock(m_critSection);
-    if (m_volumeChangeQueue.size() > 0)
+    if (!m_volumeChangeQueue.empty())
     {
       /* get the first change from the queue */
       pendingVolumeChange = m_volumeChangeQueue.front();
       m_volumeChangeQueue.pop();
 
       /* remove all dupe entries */
-      while (m_volumeChangeQueue.size() > 0 && m_volumeChangeQueue.front() == pendingVolumeChange)
+      while (!m_volumeChangeQueue.empty() && m_volumeChangeQueue.front() == pendingVolumeChange)
         m_volumeChangeQueue.pop();
 
       /* send another keypress after VOLUME_REFRESH_TIMEOUT ms */

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -27,8 +27,7 @@ using namespace PERIPHERALS;
 using namespace std;
 
 CPeripheralHID::CPeripheralHID(const PeripheralScanResult& scanResult) :
-  CPeripheral(scanResult),
-  m_bInitialised(false)
+  CPeripheral(scanResult)
 {
   m_strDeviceName = scanResult.m_strDeviceName.empty() ? g_localizeStrings.Get(35001) : scanResult.m_strDeviceName;
   m_features.push_back(FEATURE_HID);

--- a/xbmc/peripherals/devices/PeripheralHID.h
+++ b/xbmc/peripherals/devices/PeripheralHID.h
@@ -34,7 +34,6 @@ namespace PERIPHERALS
     virtual void OnSettingChanged(const CStdString &strChangedSetting);
 
   protected:
-    bool       m_bInitialised;
     CStdString m_strKeymap;
   };
 }


### PR DESCRIPTION
just some minors.
@opdenkamp ?
