### PR TITLE
[Confluence] move buttons to the right side, improve navigation

### DIFF
--- a/addons/skin.confluence/720p/DialogAddonSettings.xml
+++ b/addons/skin.confluence/720p/DialogAddonSettings.xml
@@ -120,7 +120,7 @@
 			<textureslidernib>ScrollBarNib.png</textureslidernib>
 			<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
 			<onleft>2</onleft>
-			<onright>9</onright>
+			<onright>2</onright>
 			<showonepage>false</showonepage>
 			<orientation>vertical</orientation>
 		</control>
@@ -140,7 +140,7 @@
 				<onleft>12</onleft>
 				<onright>11</onright>
 				<onup>2</onup>
-				<ondown>9</ondown>
+				<ondown>2</ondown>
 			</control>
 			<control type="button" id="11">
 				<description>Cancel Button</description>
@@ -155,7 +155,7 @@
 				<onleft>10</onleft>
 				<onright>12</onright>
 				<onup>2</onup>
-				<ondown>9</ondown>
+				<ondown>2</ondown>
 			</control>
 			<control type="button" id="12">
 				<description>Defaults Button</description>
@@ -170,7 +170,7 @@
 				<onleft>11</onleft>
 				<onright>10</onright>
 				<onup>2</onup>
-				<ondown>9</ondown>
+				<ondown>2</ondown>
 			</control>
 		</control>
 

--- a/addons/skin.confluence/720p/DialogPVRChannelManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelManager.xml
@@ -4,8 +4,8 @@
 	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<system>1</system>
-		<left>190</left>
-		<top>30</top>
+		<left>80</left>
+		<top>65</top>
 	</coordinates>
 	<include>dialogeffect</include>
 
@@ -13,15 +13,15 @@
 		<control type="image">
 			<left>0</left>
 			<top>0</top>
-			<width>900</width>
-			<height>660</height>
+			<width>1120</width>
+			<height>570</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
 			<left>40</left>
 			<top>16</top>
-			<width>820</width>
+			<width>1020</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
@@ -29,7 +29,7 @@
 			<description>header label</description>
 			<left>40</left>
 			<top>20</top>
-			<width>820</width>
+			<width>1020</width>
 			<height>30</height>
 			<font>font13_title</font>
 			<label>$LOCALIZE[19199] - $LOCALIZE[19023]</label>
@@ -43,7 +43,7 @@
 			<description>header label</description>
 			<left>40</left>
 			<top>20</top>
-			<width>820</width>
+			<width>1020</width>
 			<height>30</height>
 			<font>font13_title</font>
 			<label>$LOCALIZE[19199] - $LOCALIZE[19024]</label>
@@ -55,7 +55,7 @@
 		</control>
 		<control type="button">
 			<description>Close Window button</description>
-			<left>810</left>
+			<left>1030</left>
 			<top>15</top>
 			<width>64</width>
 			<height>32</height>
@@ -74,7 +74,7 @@
 			<left>20</left>
 			<top>70</top>
 			<control type="scrollbar" id="60">
-				<left>0</left>
+				<left>440</left>
 				<top>5</top>
 				<width>25</width>
 				<height>470</height>
@@ -83,27 +83,27 @@
 				<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
 				<textureslidernib>ScrollBarNib.png</textureslidernib>
 				<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
-				<onleft>9002</onleft>
-				<onright>20</onright>
+				<onleft>20</onleft>
+				<onright>9002</onright>
 				<showonepage>false</showonepage>
 				<orientation>vertical</orientation>
 			</control>
 			<control type="image">
-				<left>25</left>
+				<left>10</left>
 				<top>0</top>
 				<width>430</width>
 				<height>475</height>
 				<texture border="5">button-nofocus.png</texture>
 			</control>
 			<control type="list" id="20">
-				<left>30</left>
+				<left>15</left>
 				<top>5</top>
 				<width>420</width>
 				<height>470</height>
 				<onup>20</onup>
 				<ondown>20</ondown>
-				<onleft>60</onleft>
-				<onright>9002</onright>
+				<onleft>9002</onleft>
+				<onright>60</onright>
 				<pagecontrol>60</pagecontrol>
 				<scrolltime>200</scrolltime>
 				<itemlayout height="45" width="420">
@@ -240,19 +240,6 @@
 					</control>
 				</focusedlayout>
 			</control>
-			<control type="label">
-				<description>Page Count Label</description>
-				<left>30</left>
-				<top>485</top>
-				<width>420</width>
-				<height>20</height>
-				<font>font12</font>
-				<textcolor>grey</textcolor>
-				<scroll>false</scroll>
-				<align>center</align>
-				<aligny>center</aligny>
-				<label>([COLOR=blue]$INFO[Container(20).NumItems][/COLOR]) $LOCALIZE[19019] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(20).CurrentPage]/$INFO[Container(20).NumPages][/COLOR])</label>
-			</control>
 		</control>
 		<control type="group" id="9002">
 			<control type="group">
@@ -288,8 +275,8 @@
 					<pulseonselect>no</pulseonselect>
 					<label>19074</label>
 					<onleft>20</onleft>
-					<onright>60</onright>
-					<onup>9000</onup>
+					<onright>9000</onright>
+					<onup>33</onup>
 					<ondown>8</ondown>
 				</control>
 				<control type="edit" id="8">
@@ -321,7 +308,7 @@
 					<texturenofocus border="5">button-nofocus.png</texturenofocus>
 					<label>19202</label>
 					<onleft>20</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>8</onup>
 					<ondown>12</ondown>
 				</control>
@@ -351,7 +338,7 @@
 					<pulseonselect>no</pulseonselect>
 					<label>19206</label>
 					<onleft>20</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>9</onup>
 					<ondown>13</ondown>
 				</control>
@@ -365,7 +352,7 @@
 					<texturefocus border="5">button-focus2.png</texturefocus>
 					<texturenofocus border="5">button-nofocus.png</texturenofocus>
 					<label>19200</label>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onleft>20</onleft>
 					<onup>12</onup>
 					<ondown>14</ondown>
@@ -387,7 +374,7 @@
 					<pulseonselect>no</pulseonselect>
 					<label>19267</label>
 					<onleft>20</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>13</onup>
 					<ondown>30</ondown>
 				</control>
@@ -437,7 +424,7 @@
 					<align>center</align>
 					<label>19024</label>
 					<onleft>30</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>14</onup>
 					<ondown>31</ondown>
 				</control>
@@ -454,7 +441,7 @@
 					<align>center</align>
 					<label>19023</label>
 					<onleft>30</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>14</onup>
 					<ondown>31</ondown>
 				</control>
@@ -470,7 +457,7 @@
 					<align>center</align>
 					<label>19203</label>
 					<onleft>20</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>30</onup>
 					<ondown>32</ondown>
 				</control>
@@ -486,7 +473,7 @@
 					<align>center</align>
 					<label>19211</label>
 					<onleft>20</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>31</onup>
 					<ondown>33</ondown>
 				</control>
@@ -502,59 +489,92 @@
 					<align>center</align>
 					<label>19204</label>
 					<onleft>20</onleft>
-					<onright>60</onright>
+					<onright>9000</onright>
 					<onup>32</onup>
-					<ondown>9000</ondown>
+					<ondown>7</ondown>
 				</control>
 			</control>
 		</control>
 		<control type="group" id="9000">
-			<left>70</left>
-			<top>590</top>
+			<left>890</left>
+			<top>95</top>
 			<control type="button" id="4">
 				<description>OK Button</description>
 				<left>0</left>
 				<top>0</top>
-				<width>250</width>
+				<width>200</width>
 				<height>40</height>
 				<label>186</label>
 				<font>font12_title</font>
 				<align>center</align>
 				<aligny>center</aligny>
-				<onleft>6</onleft>
-				<onright>5</onright>
-				<onup>33</onup>
-				<ondown>7</ondown>
+				<onleft>9002</onleft>
+				<onright>20</onright>
+				<onup>6</onup>
+				<ondown>5</ondown>
 			</control>
 			<control type="button" id="5">
 				<description>Apply changes Button</description>
-				<left>260</left>
-				<top>0</top>
-				<width>250</width>
+				<left>0</left>
+				<top>45</top>
+				<width>200</width>
 				<height>40</height>
 				<label>14070</label>
 				<font>font12_title</font>
 				<align>center</align>
 				<aligny>center</aligny>
-				<onleft>4</onleft>
-				<onright>6</onright>
-				<onup>33</onup>
-				<ondown>7</ondown>
+				<onleft>9002</onleft>
+				<onright>20</onright>
+				<onup>4</onup>
+				<ondown>6</ondown>
 			</control>
 			<control type="button" id="6">
 				<description>Cancel Button</description>
-				<left>520</left>
-				<top>0</top>
-				<width>250</width>
+				<left>0</left>
+				<top>90</top>
+				<width>200</width>
 				<height>40</height>
 				<label>222</label>
 				<font>font12_title</font>
 				<align>center</align>
 				<aligny>center</aligny>
-				<onleft>5</onleft>
-				<onright>4</onright>
-				<onup>33</onup>
-				<ondown>7</ondown>
+				<onleft>9002</onleft>
+				<onright>20</onright>
+				<onup>5</onup>
+				<ondown>4</ondown>
+			</control>
+			<control type="group">
+				<left>-5</left>
+				<top>200</top>
+				<control type="image">
+					<left>0</left>
+					<top>0</top>
+					<width>210</width>
+					<height>210</height>
+					<texture border="5">button-nofocus.png</texture>
+				</control>
+				<control type="image">
+					<left>5</left>
+					<top>5</top>
+					<width>200</width>
+					<height>200</height>
+					<aspectratio>keep</aspectratio>
+					<texture background="true">$INFO[Container(20).ListItem.Icon]</texture>
+				</control> 
+			</control>
+			<control type="label">
+				<description>Page Count Label</description>
+				<left>-15</left>
+				<top>418</top>
+				<width>230</width>
+				<height>35</height>
+				<font>font12</font>
+				<textcolor>grey</textcolor>
+				<scroll>false</scroll>
+				<align>center</align>
+				<aligny>center</aligny>
+				<label>([COLOR=blue]$INFO[Container(20).NumItems][/COLOR]) $LOCALIZE[19019] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(20).CurrentPage]/$INFO[Container(20).NumPages][/COLOR])</label>
+				<wrapmultiline>true</wrapmultiline>
 			</control>
 		</control>
 	</controls>

--- a/addons/skin.confluence/720p/DialogPVRGroupManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRGroupManager.xml
@@ -7,15 +7,32 @@
 			<animation effect="slide" start="1150,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1150,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
-				<left>130</left>
+				<left>50</left>
 				<top>0</top>
-				<width>1150</width>
+				<width>1230</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
 			</control>
+			<control type="image">
+				<description>background image</description>
+				<left>1060</left>
+				<top>-10</top>
+				<width>675</width>
+				<height>740</height>
+				<texture border="10">KeyboardEditArea.png</texture>
+				<animation effect="fade" end="30" time="0" condition="true">conditional</animation>
+			</control>
+			<control type="image">
+				<description>Dialog Header image</description>
+				<left>90</left>
+				<top>16</top>
+				<width>930</width>
+				<height>40</height>
+				<texture>dialogheader.png</texture>
+			</control>
 			<control type="button">
 				<description>Close Window button</description>
-				<left>180</left>
+				<left>70</left>
 				<top>0</top>
 				<width>64</width>
 				<height>32</height>
@@ -35,10 +52,10 @@
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<control type="label">
 					<description>header label</description>
-					<left>160</left>
-					<top>40</top>
-					<width>1080</width>
-					<height>30</height>
+					<left>90</left>
+					<top>16</top>
+					<width>930</width>
+					<height>40</height>
 					<font>font24_title</font>
 					<label>19143</label>
 					<align>center</align>
@@ -48,13 +65,13 @@
 				</control>
 				<control type="group">
 					<description>Group list</description>
-					<left>160</left>
+					<left>70</left>
 					<top>80</top>
 					<control type="label">
 						<description>name label</description>
 						<left>0</left>
 						<top>0</top>
-						<width>340</width>
+						<width>310</width>
 						<height>70</height>
 						<font>font13</font>
 						<label>31506</label>
@@ -65,18 +82,18 @@
 					<control type="image">
 						<left>0</left>
 						<top>75</top>
-						<width>340</width>
+						<width>310</width>
 						<height>460</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="list" id="13">
 						<left>5</left>
 						<top>80</top>
-						<width>330</width>
+						<width>300</width>
 						<height>450</height>
 						<onup>13</onup>
 						<ondown>13</ondown>
-						<onleft>29</onleft>
+						<onleft>9000</onleft>
 						<onright>73</onright>
 						<pagecontrol>73</pagecontrol>
 						<scrolltime>200</scrolltime>
@@ -84,14 +101,14 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-nofocus.png</texture>
 							</control>
 							<control type="label">
 								<left>10</left>
 								<top>0</top>
-								<width>310</width>
+								<width>280</width>
 								<height>40</height>
 								<font>font12</font>
 								<align>left</align>
@@ -105,7 +122,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-nofocus.png</texture>
 								<visible>!Control.HasFocus(13)</visible>
@@ -113,7 +130,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-focus2.png</texture>
 								<visible>Control.HasFocus(13)</visible>
@@ -121,7 +138,7 @@
 							<control type="label">
 								<left>10</left>
 								<top>0</top>
-								<width>310</width>
+								<width>280</width>
 								<height>40</height>
 								<font>font12</font>
 								<align>left</align>
@@ -133,7 +150,7 @@
 						</focusedlayout>
 					</control>
 					<control type="scrollbar" id="73">
-						<left>340</left>
+						<left>305</left>
 						<top>75</top>
 						<width>25</width>
 						<height>460</height>
@@ -152,13 +169,13 @@
 				</control>
 				<control type="group">
 					<description>Channels list</description>
-					<left>525</left>
+					<left>400</left>
 					<top>80</top>
 					<control type="label" id="21">
 						<description>name label</description>
 						<left>0</left>
 						<top>0</top>
-						<width>340</width>
+						<width>310</width>
 						<height>70</height>
 						<font>font13</font>
 						<align>center</align>
@@ -168,14 +185,14 @@
 					<control type="image">
 						<left>0</left>
 						<top>75</top>
-						<width>340</width>
+						<width>310</width>
 						<height>460</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="list" id="11">
 						<left>5</left>
 						<top>85</top>
-						<width>330</width>
+						<width>300</width>
 						<height>450</height>
 						<onup>11</onup>
 						<ondown>11</ondown>
@@ -187,7 +204,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-nofocus.png</texture>
 							</control>
@@ -201,7 +218,7 @@
 							<control type="label">
 								<left>40</left>
 								<top>0</top>
-								<width>280</width>
+								<width>250</width>
 								<height>40</height>
 								<font>font12</font>
 								<align>left</align>
@@ -215,7 +232,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-nofocus.png</texture>
 								<visible>!Control.HasFocus(11)</visible>
@@ -223,7 +240,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-focus2.png</texture>
 								<visible>Control.HasFocus(11)</visible>
@@ -238,7 +255,7 @@
 							<control type="label">
 								<left>40</left>
 								<top>0</top>
-								<width>280</width>
+								<width>250</width>
 								<height>40</height>
 								<font>font12</font>
 								<align>left</align>
@@ -250,7 +267,7 @@
 						</focusedlayout>
 					</control>
 					<control type="scrollbar" id="71">
-						<left>340</left>
+						<left>305</left>
 						<top>75</top>
 						<width>25</width>
 						<height>460</height>
@@ -269,13 +286,13 @@
 				</control>
 				<control type="group">
 					<description>Grouped Channels list</description>
-					<left>890</left>
+					<left>730</left>
 					<top>80</top>
 					<control type="label" id="22">
 						<description>name label</description>
 						<left>0</left>
 						<top>0</top>
-						<width>340</width>
+						<width>310</width>
 						<height>70</height>
 						<font>font13</font>
 						<align>center</align>
@@ -285,14 +302,14 @@
 					<control type="image">
 						<left>0</left>
 						<top>75</top>
-						<width>340</width>
+						<width>310</width>
 						<height>460</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="list" id="12">
 						<left>5</left>
 						<top>85</top>
-						<width>330</width>
+						<width>300</width>
 						<height>450</height>
 						<onup>12</onup>
 						<ondown>12</ondown>
@@ -304,7 +321,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-nofocus.png</texture>
 							</control>
@@ -318,7 +335,7 @@
 							<control type="label">
 								<left>40</left>
 								<top>0</top>
-								<width>280</width>
+								<width>250</width>
 								<height>40</height>
 								<font>font12</font>
 								<align>left</align>
@@ -332,7 +349,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-nofocus.png</texture>
 								<visible>!Control.HasFocus(12)</visible>
@@ -340,7 +357,7 @@
 							<control type="image">
 								<left>0</left>
 								<top>0</top>
-								<width>330</width>
+								<width>300</width>
 								<height>40</height>
 								<texture border="5">button-focus2.png</texture>
 								<visible>Control.HasFocus(12)</visible>
@@ -355,7 +372,7 @@
 							<control type="label">
 								<left>40</left>
 								<top>0</top>
-								<width>280</width>
+								<width>250</width>
 								<height>40</height>
 								<font>font12</font>
 								<align>left</align>
@@ -367,7 +384,7 @@
 						</focusedlayout>
 					</control>
 					<control type="scrollbar" id="72">
-						<left>340</left>
+						<left>305</left>
 						<top>75</top>
 						<width>25</width>
 						<height>460</height>
@@ -377,7 +394,7 @@
 						<textureslidernib>ScrollBarNib.png</textureslidernib>
 						<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
 						<onleft>12</onleft>
-						<onright>26</onright>
+						<onright>9000</onright>
 						<ondown>72</ondown>
 						<onup>72</onup>
 						<showonepage>false</showonepage>
@@ -385,40 +402,69 @@
 					</control>
 				</control>
 				<control type="grouplist" id="9000">
-					<left>160</left>
-					<top>660</top>
-					<width>1080</width>
-					<height>40</height>
-					<itemgap>2</itemgap>
+					<left>1070</left>
+					<top>165</top>
+					<width>200</width>
+					<height>175</height>
+					<itemgap>5</itemgap>
 					<align>center</align>
-					<orientation>horizontal</orientation>
-					<onleft>72</onleft>
+					<orientation>vertical</orientation>
+					<onleft>12</onleft>
 					<onright>13</onright>
 					<onup>9000</onup>
 					<ondown>9000</ondown>
 					<control type="button" id="26">
 						<description>Add Group</description>
-						<width>230</width>
+						<width>200</width>
 						<include>ButtonInfoDialogsCommonValues</include>
 						<label>31503</label>
 					</control>
 					<control type="button" id="27">
 						<description>Rename Group</description>
-						<width>230</width>
+						<width>200</width>
 						<include>ButtonInfoDialogsCommonValues</include>
 						<label>31504</label>
 					</control>
 					<control type="button" id="28">
 						<description>Delete Group</description>
-						<width>230</width>
+						<width>200</width>
 						<include>ButtonInfoDialogsCommonValues</include>
 						<label>31505</label>
 					</control>
 					<control type="button" id="29">
 						<description>OK</description>
-						<width>230</width>
+						<width>200</width>
 						<include>ButtonInfoDialogsCommonValues</include>
 						<label>186</label>
+					</control>
+				</control>
+				<control type="group">
+					<left>1065</left>
+					<top>405</top>
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>210</width>
+						<height>210</height>
+						<texture border="5">button-nofocus.png</texture>
+					</control>
+					<control type="image">
+						<left>5</left>
+						<top>5</top>
+						<width>200</width>
+						<height>200</height>
+						<aspectratio>keep</aspectratio>
+						<texture background="true">$INFO[Container(11).ListItem.Icon]</texture>
+						<visible>Control.HasFocus(11) | Control.HasFocus(71)</visible>
+					</control>
+					<control type="image">
+						<left>5</left>
+						<top>5</top>
+						<width>200</width>
+						<height>200</height>
+						<aspectratio>keep</aspectratio>
+						<texture background="true">$INFO[Container(12).ListItem.Icon]</texture>
+						<visible>Control.HasFocus(12) | Control.HasFocus(72)</visible>
 					</control>
 				</control>
 			</control>

--- a/addons/skin.confluence/720p/DialogSelect.xml
+++ b/addons/skin.confluence/720p/DialogSelect.xml
@@ -4,7 +4,7 @@
 	<defaultcontrol always="true">3</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<left>335</left>
+		<left>215</left>
 		<top>35</top>
 	</coordinates>
 	<include>dialogeffect</include>
@@ -13,8 +13,8 @@
 			<description>background image</description>
 			<left>0</left>
 			<top>0</top>
-			<width>610</width>
-			<height>650</height>
+			<width>850</width>
+			<height>600</height>
 			<texture border="40">DialogBack.png</texture>
 			<visible>![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</visible>
 		</control>
@@ -22,8 +22,8 @@
 			<description>background image</description>
 			<left>0</left>
 			<top>0</top>
-			<width>610</width>
-			<height>650</height>
+			<width>850</width>
+			<height>600</height>
 			<texture border="40">DialogBack2.png</texture>
 			<visible>Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)</visible>
 		</control>
@@ -31,7 +31,7 @@
 			<description>Dialog Header image</description>
 			<left>40</left>
 			<top>16</top>
-			<width>530</width>
+			<width>770</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
@@ -39,7 +39,7 @@
 			<description>header label</description>
 			<left>40</left>
 			<top>20</top>
-			<width>530</width>
+			<width>770</width>
 			<height>30</height>
 			<font>font13_title</font>
 			<label>$LOCALIZE[13406]</label>
@@ -50,7 +50,7 @@
 		</control>
 		<control type="button">
 			<description>Close Window button</description>
-			<left>520</left>
+			<left>760</left>
 			<top>15</top>
 			<width>64</width>
 			<height>32</height>
@@ -248,7 +248,7 @@
 			<textureslidernib>ScrollBarNib.png</textureslidernib>
 			<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
 			<onleft>3</onleft>
-			<onright>3</onright>
+			<onright>5</onright>
 			<ondown>61</ondown>
 			<onup>61</onup>
 			<showonepage>false</showonepage>
@@ -270,9 +270,9 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in list text label</description>
-			<left>280</left>
-			<top>587</top>
-			<width>300</width>
+			<left>595</left>
+			<top>542</top>
+			<width>230</width>
 			<height>35</height>
 			<font>font12</font>
 			<align>right</align>
@@ -280,12 +280,13 @@
 			<scroll>true</scroll>
 			<textcolor>grey</textcolor>
 			<label>([COLOR=blue]$INFO[Container(6).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(6).CurrentPage]/$INFO[Container(6).NumPages][/COLOR])</label>
+			<wrapmultiline>true</wrapmultiline>
 			<visible>Control.IsVisible(6)</visible>
 		</control>
 		<control type="button" id="5">
 			<description>Manual button</description>
-			<left>20</left>
-			<top>585</top>
+			<left>615</left>
+			<top>107</top>
 			<width>200</width>
 			<height>40</height>
 			<label>186</label>
@@ -293,10 +294,28 @@
 			<textcolor>white</textcolor>
 			<focusedcolor>white</focusedcolor>
 			<align>center</align>
-			<onleft>61</onleft>
+			<onleft>3</onleft>
 			<onright>3</onright>
-			<onup>3</onup>
-			<ondown>3</ondown>
+		</control>
+		<control type="group">
+			<left>610</left>
+			<top>320</top>
+			<visible>Control.IsVisible(6)</visible>
+			<control type="image">
+				<left>0</left>
+				<top>0</top>
+				<width>210</width>
+				<height>210</height>
+				<texture border="5">button-nofocus.png</texture>
+			</control>
+			<control type="image">
+				<left>5</left>
+				<top>5</top>
+				<width>200</width>
+				<height>200</height>
+				<aspectratio>keep</aspectratio>
+				<texture background="true">$INFO[Container(6).ListItem.Icon]</texture>
+			</control> 
 		</control>
 	</controls>
 </window>

--- a/addons/skin.confluence/720p/FileBrowser.xml
+++ b/addons/skin.confluence/720p/FileBrowser.xml
@@ -9,17 +9,34 @@
 	</coordinates>
 	<controls>
 		<control type="group">
-			<left>580</left>
+			<left>360</left>
 			<animation effect="slide" start="700,0" end="0,0" time="400" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
-			<animation effect="slide" start="-400,0" end="0,0" time="400" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
+			<animation effect="slide" start="-180,0" end="0,0" time="400" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="700,0" time="400" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
 			<animation effect="slide" start="0,0" end="-400,0" time="400" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>
-				<width>1100</width>
+				<width>1320</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
+			</control>
+			<control type="image">
+				<description>background image</description>
+				<left>667</left>
+				<top>-10</top>
+				<width>675</width>
+				<height>740</height>
+				<texture border="10">KeyboardEditArea.png</texture>
+				<animation effect="fade" end="30" time="0" condition="true">conditional</animation>
+			</control>
+			<control type="image">
+				<description>Dialog Header image</description>
+				<left>40</left>
+				<top>16</top>
+				<width>595</width>
+				<height>40</height>
+				<texture>dialogheader.png</texture>
 			</control>
 			<control type="button">
 				<description>Close Window button</description>
@@ -43,22 +60,22 @@
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<control type="label" id="411">
 					<description>header label</description>
-					<left>30</left>
-					<top>40</top>
-					<width>630</width>
+					<left>40</left>
+					<top>20</top>
+					<width>595</width>
 					<height>30</height>
 					<font>font13_title</font>
 					<label>1023</label>
-					<align>right</align>
+					<align>center</align>
 					<aligny>center</aligny>
 					<textcolor>selected</textcolor>
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label" id="412">
 					<description>Path label</description>
-					<left>30</left>
-					<top>70</top>
-					<width>630</width>
+					<left>40</left>
+					<top>680</top>
+					<width>595</width>
 					<height>30</height>
 					<font>font13</font>
 					<haspath>true</haspath>
@@ -68,8 +85,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="grouplist" id="9000">
-					<left>20</left>
-					<top>460</top>
+					<left>685</left>
+					<top>130</top>
 					<width>221</width>
 					<height>225</height>
 					<itemgap>5</itemgap>
@@ -108,17 +125,17 @@
 					</control>
 				</control>
 				<control type="image">
-					<left>245</left>
-					<top>460</top>
-					<width>420</width>
-					<height>210</height>
+					<left>685</left>
+					<top>400</top>
+					<width>221</width>
+					<height>221</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="image"> 
-					<left>250</left> 
-					<top>465</top> 
-					<width>410</width> 
-					<height>200</height> 
+					<left>690</left> 
+					<top>405</top> 
+					<width>211</width> 
+					<height>211</height> 
 					<aspectratio>keep</aspectratio> 
 					<texture background="true">$INFO[ListItem.Icon]</texture> 
 					<visible>!SubString(Control.GetLabel(416),*)</visible> 
@@ -134,20 +151,20 @@
 				</control>
 				<control type="panel" id="450">
 					<left>20</left>
-					<top>120</top>
-					<width>640</width>
-					<height>321</height>
+					<top>90</top>
+					<width>620</width>
+					<height>562</height>
 					<onleft>9000</onleft>
 					<onright>60</onright>
 					<onup>450</onup>
 					<ondown>450</ondown>
 					<pagecontrol>60</pagecontrol>
 					<scrolltime>200</scrolltime>
-					<itemlayout height="40" width="640">
+					<itemlayout height="40" width="620">
 						<control type="image">
 							<left>0</left>
 							<top>0</top>
-							<width>640</width>
+							<width>620</width>
 							<height>41</height>
 							<texture border="5">MenuItemNF.png</texture>
 						</control>
@@ -161,7 +178,7 @@
 						<control type="label">
 							<left>55</left>
 							<top>0</top>
-							<width>580</width>
+							<width>560</width>
 							<height>40</height>
 							<font>font13</font>
 							<align>left</align>
@@ -170,11 +187,11 @@
 							<info>ListItem.Label</info>
 						</control>
 					</itemlayout>
-					<focusedlayout height="40" width="640">
+					<focusedlayout height="40" width="620">
 						<control type="image">
 							<left>0</left>
 							<top>0</top>
-							<width>640</width>
+							<width>620</width>
 							<height>41</height>
 							<visible>!Control.HasFocus(450)</visible>
 							<texture border="5">MenuItemNF.png</texture>
@@ -182,7 +199,7 @@
 						<control type="image">
 							<left>0</left>
 							<top>0</top>
-							<width>640</width>
+							<width>620</width>
 							<height>41</height>
 							<visible>Control.HasFocus(450)</visible>
 							<texture border="5">MenuItemFO.png</texture>
@@ -197,7 +214,7 @@
 						<control type="label">
 							<left>55</left>
 							<top>0</top>
-							<width>580</width>
+							<width>560</width>
 							<height>40</height>
 							<font>font13</font>
 							<align>left</align>
@@ -209,20 +226,20 @@
 				</control>
 				<control type="panel" id="451">
 					<left>20</left>
-					<top>120</top>
-					<width>640</width>
-					<height>321</height>
+					<top>90</top>
+					<width>620</width>
+					<height>562</height>
 					<onleft>9000</onleft>
 					<onright>60</onright>
 					<onup>451</onup>
 					<ondown>451</ondown>
 					<pagecontrol>60</pagecontrol>
 					<scrolltime>200</scrolltime>
-					<itemlayout height="40" width="640">
+					<itemlayout height="40" width="620">
 						<control type="image">
 							<left>0</left>
 							<top>0</top>
-							<width>640</width>
+							<width>620</width>
 							<height>41</height>
 							<texture border="5">MenuItemNF.png</texture>
 						</control>
@@ -236,7 +253,7 @@
 						<control type="label">
 							<left>55</left>
 							<top>0</top>
-							<width>580</width>
+							<width>560</width>
 							<height>40</height>
 							<font>font13</font>
 							<align>left</align>
@@ -245,11 +262,11 @@
 							<info>ListItem.Label</info>
 						</control>
 					</itemlayout>
-					<focusedlayout height="40" width="640">
+					<focusedlayout height="40" width="620">
 						<control type="image">
 							<left>0</left>
 							<top>0</top>
-							<width>640</width>
+							<width>620</width>
 							<height>41</height>
 							<visible>!Control.HasFocus(451)</visible>
 							<texture border="5">MenuItemNF.png</texture>
@@ -257,7 +274,7 @@
 						<control type="image">
 							<left>0</left>
 							<top>0</top>
-							<width>640</width>
+							<width>620</width>
 							<height>41</height>
 							<visible>Control.HasFocus(451)</visible>
 							<texture border="5">MenuItemFO.png</texture>
@@ -272,7 +289,7 @@
 						<control type="label">
 							<left>55</left>
 							<top>0</top>
-							<width>580</width>
+							<width>560</width>
 							<height>40</height>
 							<font>font13</font>
 							<align>left</align>
@@ -284,44 +301,46 @@
 				</control>
 
 				<control type="scrollbar" id="60">
-					<left>650</left>
-					<top>120</top>
+					<left>640</left>
+					<top>90</top>
 					<width>25</width>
-					<height>320</height>
+					<height>561</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
 					<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
 					<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
 					<textureslidernib>ScrollBarNib.png</textureslidernib>
 					<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
 					<onleft>450</onleft>
-					<onright>450</onright>
+					<onright>9000</onright>
 					<showonepage>false</showonepage>
 					<orientation>vertical</orientation>
 				</control>
 				<control type="label">
 					<description>Page label</description>
-					<left>100</left>
+					<left>685</left>
 					<top>680</top>
-					<width>560</width>
+					<width>221</width>
 					<height>30</height>
 					<align>right</align>
 					<aligny>center</aligny>
 					<textcolor>grey</textcolor>
 					<font>font12</font>
 					<label>([COLOR=blue]$INFO[Container(450).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(450).CurrentPage]/$INFO[Container(450).NumPages][/COLOR])</label>
+					<wrapmultiline>true</wrapmultiline>
 					<visible>!Control.IsVisible(451)</visible>
 				</control>
 				<control type="label">
 					<description>Page label</description>
-					<left>100</left>
+					<left>685</left>
 					<top>680</top>
-					<width>560</width>
+					<width>221</width>
 					<height>30</height>
 					<align>right</align>
 					<aligny>center</aligny>
 					<textcolor>grey</textcolor>
 					<font>font12</font>
 					<label>([COLOR=blue]$INFO[Container(451).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(451).CurrentPage]/$INFO[Container(451).NumPages][/COLOR])</label>
+					<wrapmultiline>true</wrapmultiline>
 					<visible>Control.IsVisible(451)</visible>
 				</control>
 			</control>


### PR DESCRIPTION
make navigation in several dialogs more natural by moving the buttons to the right-hand side.

as discussed in: http://forum.xbmc.org/showthread.php?tid=153416

screenshots:
http://i687.photobucket.com/albums/vv237/roniez/workz/browser.jpg
http://i687.photobucket.com/albums/vv237/roniez/workz/select.jpg
http://i687.photobucket.com/albums/vv237/roniez/workz/channel.jpg
http://i687.photobucket.com/albums/vv237/roniez/workz/group.jpg
