### PR TITLE
Change Enable HQ scalers above setting steps from 10% to 1%

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -408,7 +408,7 @@
           <default>0</default>
           <constraints>
             <minimum>0</minimum>
-            <step>10</step>
+            <step>1</step>
             <maximum>100</maximum>
           </constraints>
           <control type="spinner" format="string">


### PR DESCRIPTION
As a result of conversation starting at post 49 here: http://forum.xbmc.org/showthread.php?tid=170855&page=5

With 1% steps it is quite a bit more work to reach 100%, but a large value can still be entered directly with keyboard (and I guess with remote too - cannot test since I have no remote).
