### PR TITLE
Minor Codegenerator Doxygen Fix

### DIFF
--- a/tools/codegenerator/Helper.groovy
+++ b/tools/codegenerator/Helper.groovy
@@ -153,6 +153,11 @@ public class Helper
             ret += newline
           else if (it.name() == 'ndash')
             ret += "--"
+          else if (it.name() == 'emphasis')
+          {
+            ret += '*'
+            it.children().each handleDoc
+          }
           else
             System.out.println("WARNING: Cannot parse the following as part of the doxygen processing:" + XmlUtil.serialize(it))
         }


### PR DESCRIPTION
Fix codegenerator to handle the <emphasis> doxygen generated tags by just putting back the markdown.
