### PR TITLE
fix issues with iOS 7 AirPlay streaming

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -125,9 +125,9 @@ const char *eventStrings[] = {"playing", "paused", "loading", "stopped"};
 "<key>deviceid</key>\r\n"\
 "<string>%s</string>\r\n"\
 "<key>features</key>\r\n"\
-"<integer>119</integer>\r\n"\
+"<integer>4294969855</integer>\r\n"\
 "<key>model</key>\r\n"\
-"<string>Xbmc,1</string>\r\n"\
+"<string>AppleTV3,2</string>\r\n"\
 "<key>protovers</key>\r\n"\
 "<string>1.0</string>\r\n"\
 "<key>srcvers</key>\r\n"\

--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -35,7 +35,7 @@
 
 class DllLibPlist;
 
-#define AIRPLAY_SERVER_VERSION_STR "101.28"
+#define AIRPLAY_SERVER_VERSION_STR "160.10"
 
 class CAirPlayServer : public CThread, public ANNOUNCEMENT::IAnnouncer
 {

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -556,9 +556,9 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
     txt.push_back(std::make_pair("pw",  usePassword?"true":"false"));
     txt.push_back(std::make_pair("vn",  "3"));
     txt.push_back(std::make_pair("da",  "true"));
-    txt.push_back(std::make_pair("vs",  "130.14"));
+    txt.push_back(std::make_pair("vs",  "160.10"));
     txt.push_back(std::make_pair("md",  "0,1,2"));
-    txt.push_back(std::make_pair("am",  "Xbmc,1"));
+    txt.push_back(std::make_pair("am",  "AppleTV3,1"));
 
     CZeroconf::GetInstance()->PublishService("servers.airtunes", "_raop._tcp", appName, port, txt);
   }

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -518,8 +518,8 @@ bool CNetworkServices::StartAirPlayServer()
   std::vector<std::pair<std::string, std::string> > txt;
   CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
   txt.push_back(make_pair("deviceid", iface != NULL ? iface->GetMacAddress() : "FF:FF:FF:FF:FF:F2"));
-  txt.push_back(make_pair("features", "0x77"));
-  txt.push_back(make_pair("model", "Xbmc,1"));
+  txt.push_back(make_pair("features", "0x1000009FF"));
+  txt.push_back(make_pair("model", "AppleTV3,1"));
   txt.push_back(make_pair("srcvers", AIRPLAY_SERVER_VERSION_STR));
   CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME), g_advancedSettings.m_airPlayPort, txt);
 #endif // HAS_ZEROCONF


### PR DESCRIPTION
I have looked at the working implementation of AirPlay on Raspberry Pi, rPlay by vmlite. Using a Zeroconf browser it is apparent there are three key differences with the way they broadcast to the client:

Device name is "AppleTV3,1", not "Xbmc1,1"

Server version is 160.10 not 130.14

List of advertised features is much greater in the bitmask: namely, AP mirroring is enable. vmLite also have this working -- maybe when I get some more time I'll look at how this was done.

Changing all these things for Frodo seems to work. I see that the StartAirPlayServer function is no longer present in xbmc/Application.cpp for Gotham -- so maybe wherever that moved to in Gotham needs fixing to.

It would be good to rule out these changes to work out what is absolutely necessary, but users report good success on Raspbmc builds running Frodo (with backported libshairplay) and this combination of changes. I also suggest we backport libshairplay to Frodo for stability and maintenace purposes: https://github.com/xbmc/xbmc/pull/3788
