### PR TITLE
LinuxRendererGL: make sure we have a shader defined

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -830,6 +830,15 @@ void CLinuxRendererGL::UpdateVideoFilter()
         break;
       }
     }
+    else
+    {
+      m_pVideoFilterShader = new DefaultFilterShader();
+      if (!m_pVideoFilterShader->CompileAndLink())
+      {
+        CLog::Log(LOGERROR, "GL: Error compiling and linking video filter shader");
+        break;
+      }
+    }
     return;
 
   case VS_SCALINGMETHOD_LANCZOS2:

--- a/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.cpp
@@ -65,6 +65,16 @@ BaseVideoFilterShader::BaseVideoFilterShader()
     "gl_FrontColor = gl_Color;"
     "}";
   VertexShader()->SetSource(shaderv);
+
+  string shaderp =
+    "uniform sampler2D img;"
+    "varying vec2 cord;"
+    "void main()"
+    "{"
+    "gl_FragColor.rgb = texture2D(img, cord).rgb;"
+    "gl_FragColor.a = gl_Color.a;"
+    "}";
+  PixelShader()->SetSource(shaderp);
 }
 
 ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool stretch)
@@ -226,6 +236,18 @@ bool StretchFilterShader::OnEnabled()
 {
   glUniform1i(m_hSourceTex, m_sourceTexUnit);
   glUniform1f(m_hStretch, m_stretch);
+  VerifyGLState();
+  return true;
+}
+
+void DefaultFilterShader::OnCompiledAndLinked()
+{
+  m_hSourceTex = glGetUniformLocation(ProgramHandle(), "img");
+}
+
+bool DefaultFilterShader::OnEnabled()
+{
+  glUniform1i(m_hSourceTex, m_sourceTexUnit);
   VerifyGLState();
   return true;
 }

--- a/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.h
@@ -87,6 +87,13 @@ namespace Shaders {
       bool  OnEnabled();
   };
 
+  class DefaultFilterShader : public BaseVideoFilterShader
+  {
+    public:
+      void  OnCompiledAndLinked();
+      bool  OnEnabled();
+  };
+
 } // end namespace
 
 #endif


### PR DESCRIPTION
fixes Limited Color range (trac 14733) when used with vdpau which does its own yuv to rgb conversion. It did work with convolution shader active but colors were wrong when no shader was defined. 
