### PR TITLE
Fix memory leak in QueueJob and drop useless parameter

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1393,7 +1393,10 @@ void CPVRManager::QueueJob(const char *strJobName, CJob *job, bool bIgnorePendin
 {
   CSingleLock lock(m_critSectionTriggers);
   if (!IsStarted() || (!bIgnorePending && IsJobPending(strJobName)))
+  {
+    delete job;
     return;
+  }
 
   m_pendingUpdates.push_back(job);
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1389,10 +1389,10 @@ bool CPVRManager::IsJobPending(const char *strJobName) const
   return bReturn;
 }
 
-void CPVRManager::QueueJob(const char *strJobName, CJob *job, bool bIgnorePending /* = false */)
+void CPVRManager::QueueJob(CJob *job, bool bIgnorePending /* = false */)
 {
   CSingleLock lock(m_critSectionTriggers);
-  if (!IsStarted() || (!bIgnorePending && IsJobPending(strJobName)))
+  if (!IsStarted() || (!bIgnorePending && IsJobPending(job->GetType())))
   {
     delete job;
     return;
@@ -1406,32 +1406,32 @@ void CPVRManager::QueueJob(const char *strJobName, CJob *job, bool bIgnorePendin
 
 void CPVRManager::TriggerEpgsCreate(void)
 {
-  QueueJob("pvr-create-epgs", new CPVREpgsCreateJob());
+  QueueJob(new CPVREpgsCreateJob());
 }
 
 void CPVRManager::TriggerRecordingsUpdate(void)
 {
-  QueueJob("pvr-update-recordings", new CPVRRecordingsUpdateJob());
+  QueueJob(new CPVRRecordingsUpdateJob());
 }
 
 void CPVRManager::TriggerTimersUpdate(void)
 {
-  QueueJob("pvr-update-timers", new CPVRTimersUpdateJob());
+  QueueJob(new CPVRTimersUpdateJob());
 }
 
 void CPVRManager::TriggerChannelsUpdate(void)
 {
-  QueueJob("pvr-update-channels", new CPVRChannelsUpdateJob());
+  QueueJob(new CPVRChannelsUpdateJob());
 }
 
 void CPVRManager::TriggerChannelGroupsUpdate(void)
 {
-  QueueJob("pvr-update-channelgroups", new CPVRChannelGroupsUpdateJob());
+  QueueJob(new CPVRChannelGroupsUpdateJob());
 }
 
 void CPVRManager::TriggerSaveChannelSettings(void)
 {
-  QueueJob("pvr-save-channelsettings", new CPVRChannelSettingsSaveJob());
+  QueueJob(new CPVRChannelSettingsSaveJob());
 }
 
 void CPVRManager::ExecutePendingJobs(void)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1389,10 +1389,10 @@ bool CPVRManager::IsJobPending(const char *strJobName) const
   return bReturn;
 }
 
-void CPVRManager::QueueJob(CJob *job, bool bIgnorePending /* = false */)
+void CPVRManager::QueueJob(CJob *job)
 {
   CSingleLock lock(m_critSectionTriggers);
-  if (!IsStarted() || (!bIgnorePending && IsJobPending(job->GetType())))
+  if (!IsStarted() || IsJobPending(job->GetType()))
   {
     delete job;
     return;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -635,11 +635,10 @@ namespace PVR
      * @brief Adds the job to the list of pending jobs. If bIgnorePending is set
      * to true the job will be added even if there's an identical job already
      * queued
-     * @param strJobName the name of the job
      * @param bIgnorePending whether to ignore previously queued identical jobs
      * @param job the job
      */
-    void QueueJob(const char *strJobName, CJob *job, bool bIgnorePending = false);
+    void QueueJob(CJob *job, bool bIgnorePending = false);
 
     ManagerState GetState(void) const;
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -632,13 +632,11 @@ namespace PVR
     bool IsJobPending(const char *strJobName) const;
 
     /*!
-     * @brief Adds the job to the list of pending jobs. If bIgnorePending is set
-     * to true the job will be added even if there's an identical job already
-     * queued
-     * @param bIgnorePending whether to ignore previously queued identical jobs
+     * @brief Adds the job to the list of pending jobs unless an identical 
+     * job is already queued
      * @param job the job
      */
-    void QueueJob(CJob *job, bool bIgnorePending = false);
+    void QueueJob(CJob *job);
 
     ManagerState GetState(void) const;
 


### PR DESCRIPTION
This fixes the memory leak @opdenkamp pointed out in https://github.com/xbmc/xbmc/pull/3770. It also removes the job name parameter since it can be deduced from the job itself.
