### PR TITLE
[rbp] Disable frame multi threaded decoded settings option

### DIFF
--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -12,6 +12,9 @@
         <setting id="videoplayer.synctype">
           <visible>false</visible>
         </setting>
+        <setting id="videoplayer.useframemtdec">
+          <visible>false</visible>
+        </setting>
       </group>
     </category>
   </section>


### PR DESCRIPTION
Makes no sense on Pi
