### PR TITLE
[rbp] Ensure resolution infos have unique names

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
@@ -70,7 +70,6 @@ private:
   static void CallbackTvServiceCallback(void *userdata, uint32_t reason, uint32_t param1, uint32_t param2);
 
   void DestroyDispmaxWindow();
-  bool ClampToGUIDisplayLimits(int &width, int &height);
   int FindMatchingResolution(const RESOLUTION_INFO &res, const std::vector<RESOLUTION_INFO> &resolutions);
   int AddUniqueResolution(const RESOLUTION_INFO &res, std::vector<RESOLUTION_INFO> &resolutions);
 #endif


### PR DESCRIPTION
Currently the strMode for 2D and 3D resolutions have the same name.
This means the calibration info for a 2D mode can get replaced with a 3D mode
which can result in the pixel aspect ratio being reset to 0.5.

Also when using gui resolution clamping (i.e. 720p gui on 1080p display)
the calibration settings are scaled to gui resolution, but there is no indictation
of what the clamped resolution was when the settings were saved.

This means disabling gui clamping results in a minature gui.
(And I'd like to remove the gui clamping in the future).

Make sure all these resolutions have unique names by adding the gui resolution
and 3DSBS/3DTB to the resolution string.

Note: this will result in current calibration settings being lost.
