### PR TITLE
[depends] - configure with --enable-gtest for allowing jenkins to build ...

### DIFF
--- a/tools/depends/target/xbmc/Makefile
+++ b/tools/depends/target/xbmc/Makefile
@@ -7,7 +7,7 @@ export CFLAGS+=-O3
 
 # configuration settings
 CONFIGURE = cp -f $(CONFIG_SUB) $(CONFIG_GUESS) build-aux/ ;\
-  ./configure --prefix=$(PREFIX)
+  ./configure --prefix=$(PREFIX) --enable-gtest
 
 ifeq ($(OS),android)
 CONFIGURE += --enable-codec=libstagefright


### PR DESCRIPTION
...and run the gtests when requested (the tests are not turned on by default on jenkins as long as they don't succeed on all platforms though).

what the topic says.

@jmarshallnz @t-nelson - is this acceptable in this phase of gotham?
