### PR TITLE
Avoid using CSettings to create a blank guisettings.xml for a fresh prof...

### DIFF
--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -329,22 +329,14 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
 
       if (!bExists)
       {
-        // save new profile guisettings
+        // copy masterprofile guisettings to new profile guisettings
+        // If the user selects 'start fresh', do nothing as a fresh
+        // guisettings.xml will be created on first profile use.
         if (CGUIDialogYesNo::ShowAndGetInput(20058,20048,20102,20022,20044,20064))
         {
           CFile::Cache(URIUtils::AddFileToFolder("special://masterprofile/","guisettings.xml"),
                        URIUtils::AddFileToFolder("special://masterprofile/",
                                               dialog->m_strDirectory+"/guisettings.xml"));
-        }
-        else
-        {
-          // create some new settings
-          CStdString path = URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_strDirectory);
-          path = URIUtils::AddFileToFolder(path, "guisettings.xml");
-
-          CSettings settings;
-          settings.Initialize();
-          settings.Save(path);
         }
       }
 
@@ -357,6 +349,8 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       if (!bExists)
       {
         if ((dialog->m_iSourcesMode & 2) == 2)
+          // prompt user to copy masterprofile's sources.xml file
+          // If 'start fresh' (no) is selected, do nothing.
           if (CGUIDialogYesNo::ShowAndGetInput(20058,20071,20102,20022,20044,20064))
           {
             CFile::Cache(URIUtils::AddFileToFolder("special://masterprofile/","sources.xml"),


### PR DESCRIPTION
...ile.  This causes a segmentation fault as documented in issue #14747.

As the file is created 'fresh' on first login of the profile, there seems to be no consequence in not creating before hand.

Relevant analysis & discussion over on trac at http://trac.xbmc.org/ticket/14747

A note that will be cross-posted to the Trac discussion, I had intended to include a second commit to avoid scaling div-by-zero issues, unfortunately simply falling back on a scale of 1.0f had a side-effect of screen blanking - most likely due to other rendering functions getting incorrect information about the size of the screen.

It seems the best path, is just to not let this happen, and after feature freeze consider separating the running m_resolutions configuration from CSettings (as opposed to user resolution preferences).
