### PR TITLE
[osx/mavericks] - on mavericks don't use pbo rendering with intel gpus

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -71,6 +71,9 @@
   #include "osx/CocoaInterface.h"
   #include <CoreVideo/CoreVideo.h>
   #include <OpenGL/CGLIOSurface.h>
+  #ifdef TARGET_DARWIN_OSX
+    #include "osx/DarwinUtils.h"
+  #endif
 #endif
 
 #ifdef HAS_GLX
@@ -318,6 +321,19 @@ bool CLinuxRendererGL::Configure(unsigned int width, unsigned int height, unsign
   m_pixelRatio       = 1.0;
 
   m_pboSupported = glewIsSupported("GL_ARB_pixel_buffer_object") && CSettings::Get().GetBool("videoplayer.usepbo");
+
+#ifdef TARGET_DARWIN_OSX
+  // on osx 10.9 mavericks we get a strange ripple
+  // effect when rendering with pbo
+  // when used on intel gpu - we have to quirk it here
+  if (DarwinIsMavericks())
+  {
+    std::string rendervendor = g_Windowing.GetRenderVendor();
+    StringUtils::ToLower(rendervendor);
+    if (rendervendor.find("intel") != std::string::npos)
+      m_pboSupported = false;
+  }
+#endif
 
   return true;
 }


### PR DESCRIPTION
... as it might result in distorted rendering (ripple). This fixes the distortion seen here:

http://forum.xbmc.org/showthread.php?tid=177426

@davilla - open for better fixes if any. But at leat its already restricted as much as possible (only on 10.9, only with intel gpus ...)
