### PR TITLE
Allow passing extra flags to configure with depends builds.

### DIFF
--- a/tools/depends/target/xbmc/Makefile
+++ b/tools/depends/target/xbmc/Makefile
@@ -13,6 +13,8 @@ ifeq ($(OS),android)
 CONFIGURE += --enable-codec=libstagefright
 endif
 
+CONFIGURE += $(CONFIG_EXTRA)
+
 all: $(SOURCE)/libxbmc.so
 
 


### PR DESCRIPTION
For #3802
