### PR TITLE
[ios/atv2] - harmonize the behaviour of builtin "shutdownmenu"

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -392,10 +392,6 @@ int CBuiltins::Execute(const CStdString& execString)
     {
       // disable the screensaver
       g_application.WakeUpScreenSaverAndDPMS();
-#if defined(TARGET_DARWIN_IOS)
-      if (params[0].Equals("shutdownmenu"))
-        CBuiltins::Execute("Quit");
-#endif     
       g_windowManager.ActivateWindow(iWindow, params, !execute.Equals("activatewindow"));
     }
     else
@@ -421,10 +417,6 @@ int CBuiltins::Execute(const CStdString& execString)
     {
       // disable the screensaver
       g_application.WakeUpScreenSaverAndDPMS();
-#if defined(TARGET_DARWIN_IOS)
-      if (params[0].Equals("shutdownmenu"))
-        CBuiltins::Execute("Quit");
-#endif
       vector<CStdString> dummy;
       g_windowManager.ActivateWindow(iWindow, dummy, !execute.Equals("activatewindowandfocus"));
 


### PR DESCRIPTION
It should behave the same on all platforms now that the shutdownmenu only has usefull entries.

Before on ios/atv2 whenever the shutdownmenu was requested we just did a shortcut to quit. But the shutdownmenu is filled with options now so dynamically based on powermanager that it only has usefull entries. There is no reason to prevent this menu from showing on ios/atv2 anymore.

This also allows users to log off from a profile or abandon a shutdown timer now - this was not possible on ios/atv2 with the former shortcut.

Also the same behaviour already works well on android.

@davilla can you think of anything why we should keep this shortcut?

@jmarshallnz @t-nelson - gotham food or not?
