### PR TITLE
paplayer: fix caching of streams into AE

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -147,9 +147,9 @@ private:
   void SoftStart(bool wait = false);
   void SoftStop(bool wait = false, bool close = true);
   void CloseAllStreams(bool fade = true);
-  void ProcessStreams(double &delay, double &buffer);
+  void ProcessStreams(double &freeBufferTime);
   bool PrepareStream(StreamInfo *si);
-  bool ProcessStream(StreamInfo *si, double &delay, double &buffer);
+  bool ProcessStream(StreamInfo *si, double &freeBufferTime);
   bool QueueData(StreamInfo *si);
   int64_t GetTotalTime64();
   void UpdateCrossfadeTime(const CFileItem& file);


### PR DESCRIPTION
@t-nelson @popcornmix this should fix your issues with paplayer. it incorrectly queried delay instead of cached time of stream. delay may be large on sinks with large internal buffer. paplayer went to sleep and audio engine ran dry, then feeding silence into the sink.
