### PR TITLE
[coreSubs] option to manually entering search string

### DIFF
--- a/addons/skin.confluence/720p/DialogSubtitles.xml
+++ b/addons/skin.confluence/720p/DialogSubtitles.xml
@@ -8,7 +8,7 @@
 	<controls>
 		<control type="group" id="250">
 			<animation effect="slide" start="0,0" end="900,0" time="500" tween="quadratic" easing="out">WindowClose</animation> 
-			<animation type="Conditional" condition="Control.HasFocus(150)" reversible="true">
+			<animation type="Conditional" condition="Control.HasFocus(150) | Control.HasFocus(160)" reversible="true">
 				<effect type="slide" end="-250,0" time="400"/>
 			</animation>
 			<control type="button" id="8999">
@@ -350,11 +350,11 @@
 					<left>900</left>
 					<top>206</top>
 					<width>250</width>
-					<height>434</height>
+					<height>399</height>
 					<onleft>120</onleft>
 					<onright>120</onright>
-					<onup>150</onup>
-					<ondown>150</ondown>
+					<onup>160</onup>
+					<ondown>160</ondown>
 					<viewtype label="535">list</viewtype>
 					<scrolltime>200</scrolltime>
 					<itemlayout width="400" height="36">
@@ -407,6 +407,22 @@
 							<info>ListItem.Label</info>
 						</control>
 					</focusedlayout>
+				</control>
+				<control type="button" id="160">
+					<description>Manual search button</description>
+					<left>925</left>
+					<top>640</top>
+					<width>200</width>
+					<height>40</height>
+					<onleft>120</onleft>
+					<onright>120</onright>
+					<onup>150</onup>
+					<ondown>150</ondown>
+					<label>$LOCALIZE[24120]</label>
+					<font>font12_title</font>
+					<textcolor>white</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<align>center</align>
 				</control>
 			</control>
 		</control>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12082,7 +12082,17 @@ msgctxt "#24119"
 msgid "Select service that will be used as default to search for Movie subtitles"
 msgstr ""
 
-#empty strings from id 24120 to 24999
+#: xbmc/dialogs/GUIDialogSubtitles.cpp
+msgctxt "#24120"
+msgid "Manual search string"
+msgstr ""
+
+#: xbmc/dialogs/GUIDialogSubtitles.cpp
+msgctxt "#24121"
+msgid "Enter search string"
+msgstr ""
+
+#empty strings from id 24121 to 24999
 
 msgctxt "#25000"
 msgid "Notifications"

--- a/xbmc/video/dialogs/GUIDialogSubtitles.h
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.h
@@ -49,7 +49,7 @@ protected:
   enum STATUS { NO_SERVICES = 0, SEARCHING, SEARCH_COMPLETE, DOWNLOADING };
   void UpdateStatus(STATUS status);
 
-  void Search();
+  void Search(const std::string &search="");
   void OnSearchComplete(const CFileItemList *items);
 
   void Download(const CFileItem &subtitle);
@@ -62,6 +62,7 @@ protected:
   CFileItemList* m_serviceItems;
   std::string    m_currentService;
   std::string    m_status;
+  CStdString     m_strManualSearch;
   bool           m_pausedOnRun;
   bool           m_updateSubsList; ///< true if we need to update our subs list
 };


### PR DESCRIPTION
apparently manual search string option is needed in subs search/download, dont ask me why but I think its to do with incorrectly named files or files that are not scanned into library.

I have left out the setting to enable this, we dont need more settings in Subtitle section, and doesnt hurt to have this listed all the time.

if anyone wants to test, https://github.com/amet/service.subtitles.opensubtitles/tree/ManualSearch has the changes
