### PR TITLE
[AE/CA] Make the mixmap invalid when we have the same number of channels...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioMixMap.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioMixMap.cpp
@@ -56,6 +56,13 @@ void CCoreAudioMixMap::Rebuild(AudioChannelLayout& inLayout, AudioChannelLayout&
   m_inChannels  = CCoreAudioChannelLayout::GetChannelCountForLayout(inLayout);
   m_outChannels = CCoreAudioChannelLayout::GetChannelCountForLayout(outLayout);
 
+  // No need to use the mixing matrix if we have the same number of channels on both sides.
+  if (m_inChannels == m_outChannels)
+  {
+    m_isValid = false;
+    return;
+  }
+
   // Try to find a 'well-known' matrix
   const AudioChannelLayout* layouts[] = {&inLayout, &outLayout};
   UInt32 propSize = 0;


### PR DESCRIPTION
... on both sides.

thx to @tru who provided me with the fix. This is ment to fix trac http://trac.xbmc.org/ticket/13753 - will do a test build and let the reporter verify the fix before merging.
