### PR TITLE
[osx/ae/ca] - fix ResetAudioDevices

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioHardware.h
@@ -35,7 +35,7 @@ public:
   static AudioStreamBasicDescription* FormatsList(AudioStreamID stream);
   static AudioStreamID* StreamsList(AudioDeviceID device);
   static void           ResetAudioDevices();
-  static void           ResetStream(AudioStreamID stream);
+  static void           ResetStream(AudioStreamID streamId);
   static AudioDeviceID  FindAudioDevice(const std::string &deviceName);
   static AudioDeviceID  GetDefaultOutputDevice();
   static void           GetOutputDeviceName(std::string &name);

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioStream.cpp
@@ -61,7 +61,7 @@ bool CCoreAudioStream::Open(AudioStreamID streamId)
 
 // TODO: Should it even be possible to change both the 
 // physical and virtual formats, since the devices do it themselves?
-void CCoreAudioStream::Close()
+void CCoreAudioStream::Close(bool restore)
 {
   if (!m_StreamId)
     return;
@@ -84,7 +84,7 @@ void CCoreAudioStream::Close()
     CLog::Log(LOGDEBUG, "CCoreAudioStream::Close: Couldn't remove property listener.");
 
   // Revert any format changes we made
-  if (m_OriginalVirtualFormat.mFormatID && m_StreamId)
+  if (restore && m_OriginalVirtualFormat.mFormatID && m_StreamId)
   {
     CLog::Log(LOGDEBUG, "CCoreAudioStream::Close: "
       "Restoring original virtual format for stream 0x%04x. (%s)",
@@ -92,7 +92,7 @@ void CCoreAudioStream::Close()
     AudioStreamBasicDescription setFormat = m_OriginalVirtualFormat;
     SetVirtualFormat(&setFormat);
   }
-  if (m_OriginalPhysicalFormat.mFormatID && m_StreamId)
+  if (restore && m_OriginalPhysicalFormat.mFormatID && m_StreamId)
   {
     CLog::Log(LOGDEBUG, "CCoreAudioStream::Close: "
       "Restoring original physical format for stream 0x%04x. (%s)",

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioStream.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioStream.h
@@ -38,7 +38,7 @@ public:
   virtual ~CCoreAudioStream();
   
   bool    Open(AudioStreamID streamId);
-  void    Close();
+  void    Close(bool restore = true);
   
   AudioStreamID GetId() {return m_StreamId;}
   UInt32  GetDirection();


### PR DESCRIPTION
thx to @tru for this fix - original message from him:

----snip----
I noticed that at times the audio device would be stuck in Encoded mode, turns out that ResetAudioDevices was not really working, so I spent some time debugging that and rewrote it to not duplicate tons of code.
----snip----

@davilla i think it can't get worse when it was already broken before ... any comment on that though?
