### PR TITLE
changed: Add logic to handle subtitles for stacked files

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5214,6 +5214,14 @@ CFileItem& CApplication::CurrentFileItem()
   return *m_itemCurrentFile;
 }
 
+CFileItem& CApplication::CurrentUnstackedItem()
+{
+  if (m_itemCurrentFile->IsStack() && m_currentStack->Size() > 0)
+    return *(*m_currentStack)[m_currentStackPosition];
+  else
+    return *m_itemCurrentFile;
+}
+
 void CApplication::ShowVolumeBar(const CAction *action)
 {
   CGUIDialog *volumeBar = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VOLUME_BAR);

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -156,6 +156,7 @@ public:
   void ReloadSkin(bool confirm = false);
   const CStdString& CurrentFile();
   CFileItem& CurrentFileItem();
+  CFileItem& CurrentUnstackedItem();
   virtual bool OnMessage(CGUIMessage& message);
   PLAYERCOREID GetCurrentPlayer();
   virtual void OnPlayBackEnded();

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -222,7 +222,7 @@ void CGUIDialogSubtitles::FillServices()
   }
 
   std::string defaultService;
-  const CFileItem &item = g_application.CurrentFileItem();
+  const CFileItem &item = g_application.CurrentUnstackedItem();
   if (item.GetVideoContentType() == VIDEODB_CONTENT_TVSHOWS ||
       item.GetVideoContentType() == VIDEODB_CONTENT_EPISODES)
     // Set default service for tv shows
@@ -386,6 +386,8 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
 
   CStdString strFileName;
   CStdString strDestPath;
+#if 0
+  // TODO: Code to download all subtitles for all stack items in one run
   if (g_application.CurrentFileItem().IsStack())
   {
     for (int i = 0; i < items->Size(); i++)
@@ -394,17 +396,22 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
 //    CLog::Log(LOGDEBUG, "Stack Subs [%s} Found", vecItems[i]->GetLabel().c_str());
     }
   }
-  else if (StringUtils::StartsWith(g_application.CurrentFile(), "http://"))
+#endif
+
+  // Get (unstacked) path
+  const CStdString &strCurrentFile = g_application.CurrentUnstackedItem().GetPath();
+
+  if (StringUtils::StartsWith(strCurrentFile, "http://"))
   {
     strFileName = "TemporarySubs";
     strDestPath = "special://temp/";
   }
   else
   {
-    strFileName = URIUtils::GetFileName(g_application.CurrentFile());
+    strFileName = URIUtils::GetFileName(strCurrentFile);
     if (CSettings::Get().GetBool("subtitles.savetomoviefolder"))
     {
-      strDestPath = URIUtils::GetDirectory(g_application.CurrentFile());
+      strDestPath = URIUtils::GetDirectory(strCurrentFile);
       if (!CUtil::SupportsWriteFileOperations(strDestPath))
         strDestPath.clear();
     }


### PR DESCRIPTION
Subtitles for stacked items require additional work besides this but at least one can download subtitles again for each stack item separately. In order to improve this further there are 3 options (I think):
- Assume subtitle services provide zip's for multipart (aka stacked) movies and act accordingly;
- Show a dialog for each stack item;
- Automatically try obtain additional subtitles according to the volume name (eg. for .cd1.srt, also try to download .cd2.srt)

Not sure what the best approach is. @amet / @jmarshallnz: Your thoughts?
