### PR TITLE
[pvr] Fix EPG hookdata: Return UniqueBroadcastID

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -409,7 +409,7 @@ void CPVRClient::CallMenuHook(const PVR_MENUHOOK &hook, const CFileItem *item)
       if (item->IsEPG())
       {
         hookData.cat = PVR_MENUHOOK_EPG;
-        hookData.data.iEpgUid = item->GetEPGInfoTag()->BroadcastId();
+        hookData.data.iEpgUid = item->GetEPGInfoTag()->UniqueBroadcastID();
       }
       else if (item->IsPVRChannel())
       {


### PR DESCRIPTION
I would like to add new hook from epg screen but currently epg hook data is unusable by pvr client. This commit allow to return epgUid known by client instead unset data.
