### PR TITLE
New touchscreen.xml options and minor adjustments for new ChapterOrBigStepForward/Back

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -482,6 +482,8 @@
   <Favourites>
     <keyboard>
       <backspace>Close</backspace>
+      <u>MoveItemUp</u>
+      <d>MoveItemDown</d>
     </keyboard>
   </Favourites>
   <NumericInput>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -233,8 +233,8 @@
       <l>NextSubtitle</l>
       <left>StepBack</left>
       <right>StepForward</right>
-      <up>BigStepForward</up>
-      <down>BigStepBack</down>
+      <up>ChapterOrBigStepForward</up>
+      <down>ChapterOrBigStepBack</down>
       <a>AudioDelay</a>
       <escape>Fullscreen</escape>
       <c>Playlist</c>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -146,8 +146,8 @@
       <nine>Number9</nine>
       <left>StepBack</left>
       <right>StepForward</right>
-      <up>BigStepForward</up>
-      <down>BigStepBack</down>
+      <up>ChapterOrBigStepForward</up>
+      <down>ChapterOrBigStepBack</down>
       <back>SmallStepBack</back>
       <menu>OSD</menu>
       <start>OSD</start>

--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -13,6 +13,15 @@
       <swipe direction="down">SwipeDown</swipe>
     </touch>
   </global>
+  <FullScreenVideo>
+    <touch>
+      <swipe direction="left">StepBack</swipe>
+      <swipe direction="right">StepForward</swipe>
+      <swipe direction="up">ChapterOrBigStepForward</swipe>
+      <swipe direction="down">ChapterOrBigStepBack</swipe>
+      <swipe direction="left" pointers="2">SmallStepBack</swipe>
+    </touch>
+  </FullScreenVideo>
   <SlideShow>
     <touch>
       <zoom>ZoomGesture</zoom>


### PR DESCRIPTION
touchscreen.xml gets some fullscreen video swipe controls

and

keyboard.xml and remote.xml get up/down changed to ChapterOrBigStepForward/Back, so that defaults are consistent with old behavior. Same logic for remotes with fewer buttons retaining functionality, while the option for specific actions is there. These chances seem to have been missed in https://github.com/xbmc/xbmc/pull/3280 ?
