### PR TITLE
[pvr] fix: wrong condition while getting first/last epg date

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1135,13 +1135,13 @@ CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
         {
           case EPG_FIRST_DATE:
             epgDate = epg->GetFirstDate();
-            if (epgDate.IsValid() && (date.IsValid() || epgDate < date))
+            if (epgDate.IsValid() && (!date.IsValid() || epgDate < date))
               date = epgDate;
             break;
             
           case EPG_LAST_DATE:
             epgDate = epg->GetLastDate();
-            if (epgDate.IsValid() && (date.IsValid() || epgDate > date))
+            if (epgDate.IsValid() && (!date.IsValid() || epgDate > date))
               date = epgDate;
             break;
         }


### PR DESCRIPTION
This PR fixes the epg issue that you can't go back in time. 
The first date is always invalid, because of the wrong condition used while getting it.
