### PR TITLE
[fix] Aspect ratio constructor parameter for ControlImage was being ignored.

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -403,9 +403,9 @@ namespace XBMCAddon
     // ============================================================
     // ============================================================
     ControlImage::ControlImage(long x, long y, long width, long height, 
-                               const char* filename, long aspectRatio,
+                               const char* filename, long aRatio,
                                const char* _colorDiffuse):
-      colorDiffuse(0)
+      colorDiffuse(0), aspectRatio(aRatio)
     {
       dwPosX = x;
       dwPosY = y;


### PR DESCRIPTION
Aspect ratio constructor parameter for ControlImage was being ignored and the member variable was uninitialized. Fixes #14753
