### PR TITLE
changed: Allow all internet filesystems for flags extraction except http/ftp

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -835,6 +835,22 @@ bool URIUtils::IsFTP(const std::string& strFile)
          IsProtocol(strFile, "ftps");
 }
 
+bool URIUtils::IsHTTP(const std::string& strFile)
+{
+  if (IsStack(strFile))
+    return IsHTTP(CStackDirectory::GetFirstStackedFile(strFile));
+
+  if (IsSpecial(strFile))
+    return IsHTTP(CSpecialProtocol::TranslatePath(strFile));
+
+  CURL url(strFile);
+  if (HasParentInHostname(url))
+    return IsHTTP(url.GetHostName());
+
+  return IsProtocol(strFile, "http") ||
+         IsProtocol(strFile, "https");
+}
+
 bool URIUtils::IsUDP(const std::string& strFile)
 {
   std::string strFile2(strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -121,6 +121,7 @@ public:
   static bool IsDOSPath(const std::string &path);
   static bool IsDVD(const std::string& strFile);
   static bool IsFTP(const std::string& strFile);
+  static bool IsHTTP(const std::string& strFile);
   static bool IsUDP(const std::string& strFile);
   static bool IsTCP(const std::string& strFile);
   static bool IsHD(const std::string& strFileName);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -97,12 +97,12 @@ bool CThumbExtractor::DoWork()
   ||  m_item.IsPlayList())
     return false;
 
-  if (URIUtils::IsRemote(m_item.GetPath()) && !URIUtils::IsOnLAN(m_item.GetPath()))
-  {
-    // A quasi internet filesystem like webdav is generally fast enough for extracting stuff
-    if (!URIUtils::IsDAV(m_item.GetPath()))
-      return false;
-  }
+  // For HTTP/FTP we only allow extraction when on a LAN
+  if (URIUtils::IsRemote(m_item.GetPath()) &&
+     !URIUtils::IsOnLAN(m_item.GetPath())  &&
+     (URIUtils::IsFTP(m_item.GetPath())    ||
+      URIUtils::IsHTTP(m_item.GetPath())))
+    return false;
 
   bool result=false;
   if (m_thumb)


### PR DESCRIPTION
Like the title says. It makes sftp in line with Curl-based filesystems (eg. webdav). This mainly enables file caching and thumb extraction for sftp. 
