### PR TITLE
AESinkALSA: Workarounds for formats don't belong to the sink

### DIFF
--- a/lib/ffmpeg/libavcodec/aacdec.c
+++ b/lib/ffmpeg/libavcodec/aacdec.c
@@ -505,6 +505,25 @@ static int set_default_channel_config(AVCodecContext *avctx,
     }
     *tags = tags_per_config[channel_config];
     memcpy(layout_map, aac_channel_layout_map[channel_config-1], *tags * sizeof(*layout_map));
+
+    /*
+     * AAC specification has 7.1(wide) as a default layout for 8-channel streams.
+     * However, at least Nero AAC encoder encodes 7.1 streams using the default
+     * channel config 7, mapping the side channels of the original audio stream
+     * to the second AAC_CHANNEL_FRONT pair in the AAC stream. Similarly, e.g. FAAD
+     * decodes the second AAC_CHANNEL_FRONT pair as side channels, therefore decoding
+     * the incorrect streams as if they were correct (and as the encoder intended).
+     *
+     * As actual intended 7.1(wide) streams are very rare, default to assuming a
+     * 7.1 layout was intended.
+     */
+    if (channel_config == 7 && avctx->strict_std_compliance < FF_COMPLIANCE_STRICT) {
+        av_log(avctx, AV_LOG_INFO, "Assuming an incorrectly encoded 7.1 channel layout"
+               " instead of a spec-compliant 7.1(wide) layout, use -strict %d to decode"
+               " according to the specification instead.\n", FF_COMPLIANCE_STRICT);
+        layout_map[2][2] = AAC_CHANNEL_SIDE;
+    }
+
     return 0;
 }
 

--- a/lib/ffmpeg/patches/0060-ffmpeg-backport-avcodec-aacdec-default-to-non-wide-7.patch
+++ b/lib/ffmpeg/patches/0060-ffmpeg-backport-avcodec-aacdec-default-to-non-wide-7.patch
@@ -1,0 +1,67 @@
+From 59f16d529fdcb4c5db53ce3bd289aa8148a13de4 Mon Sep 17 00:00:00 2001
+From: Anssi Hannula <anssi.hannula@iki.fi>
+Date: Tue, 17 Dec 2013 23:04:31 +0200
+Subject: [PATCH] [ffmpeg] - backport - avcodec/aacdec: default to non-wide 7.1
+ in non-strict mode
+
+Upstream commit e10fccf62a36e09b54ad6ea3d5fa6638f298d5ae, for
+http://trac.xbmc.org/ticket/13758.
+
+AAC specification has 7.1(wide) as a default layout for 8-channel
+streams (channel config 7). However, at least Nero AAC encoder encodes
+non-wide 7.1 streams using the default channel config 7, mapping the
+side channels of the original audio stream to the second
+AAC_CHANNEL_FRONT pair in the AAC stream. Similarly, e.g. FAAD decodes
+the second AAC_CHANNEL_FRONT pair as side channels, therefore decoding
+the incorrect streams as if they were correct (and as the encoder
+intended).
+
+FFmpeg currently decodes such files by-the-spec, i.e. after decoding the
+original front pair will be in AV_CH_FRONT_x_OF_CENTER and the original
+side pair will be in AV_CH_FRONT_x.
+
+As actual intended 7.1(wide) streams are very rare while misencoded 7.1
+files actually exist in the wild, default to assuming a 7.1 layout was
+intended unless in strict mode.
+
+Fixes playback of e.g. 8_Channel_ID.m4a in samples.
+
+Signed-off-by: Anssi Hannula <anssi.hannula@iki.fi>
+Signed-off-by: Michael Niedermayer <michaelni@gmx.at>
+---
+ lib/ffmpeg/libavcodec/aacdec.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/lib/ffmpeg/libavcodec/aacdec.c b/lib/ffmpeg/libavcodec/aacdec.c
+index 7a871c4..12dbfcf 100644
+--- a/lib/ffmpeg/libavcodec/aacdec.c
++++ b/lib/ffmpeg/libavcodec/aacdec.c
+@@ -505,6 +505,25 @@ static int set_default_channel_config(AVCodecContext *avctx,
+     }
+     *tags = tags_per_config[channel_config];
+     memcpy(layout_map, aac_channel_layout_map[channel_config-1], *tags * sizeof(*layout_map));
++
++    /*
++     * AAC specification has 7.1(wide) as a default layout for 8-channel streams.
++     * However, at least Nero AAC encoder encodes 7.1 streams using the default
++     * channel config 7, mapping the side channels of the original audio stream
++     * to the second AAC_CHANNEL_FRONT pair in the AAC stream. Similarly, e.g. FAAD
++     * decodes the second AAC_CHANNEL_FRONT pair as side channels, therefore decoding
++     * the incorrect streams as if they were correct (and as the encoder intended).
++     *
++     * As actual intended 7.1(wide) streams are very rare, default to assuming a
++     * 7.1 layout was intended.
++     */
++    if (channel_config == 7 && avctx->strict_std_compliance < FF_COMPLIANCE_STRICT) {
++        av_log(avctx, AV_LOG_INFO, "Assuming an incorrectly encoded 7.1 channel layout"
++               " instead of a spec-compliant 7.1(wide) layout, use -strict %d to decode"
++               " according to the specification instead.\n", FF_COMPLIANCE_STRICT);
++        layout_map[2][2] = AAC_CHANNEL_SIDE;
++    }
++
+     return 0;
+ }
+ 
+-- 
+1.8.1.5
+

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -51,12 +51,6 @@ static enum AEChannel ALSAChannelMap51Wide[ALSA_MAX_CHANNELS + 1] = {
   AE_CH_NULL
 };
 
-static enum AEChannel ALSAChannelMap71Wide[ALSA_MAX_CHANNELS + 1] = {
-  AE_CH_FLOC    , AE_CH_FROC    , AE_CH_BL      , AE_CH_BR      , AE_CH_FC      , AE_CH_LFE     , AE_CH_FL        , AE_CH_FR        ,
-  AE_CH_UNKNOWN1, AE_CH_UNKNOWN2, AE_CH_UNKNOWN3, AE_CH_UNKNOWN4, AE_CH_UNKNOWN5, AE_CH_UNKNOWN6, AE_CH_UNKNOWN7, AE_CH_UNKNOWN8, /* for p16v devices */
-  AE_CH_NULL
-};
-
 static enum AEChannel ALSAChannelMapPassthrough[ALSA_MAX_CHANNELS + 1] = {
   AE_CH_RAW     , AE_CH_RAW     , AE_CH_RAW     , AE_CH_RAW     , AE_CH_RAW     , AE_CH_RAW     , AE_CH_RAW      , AE_CH_RAW      ,
   AE_CH_UNKNOWN1, AE_CH_UNKNOWN2, AE_CH_UNKNOWN3, AE_CH_UNKNOWN4, AE_CH_UNKNOWN5, AE_CH_UNKNOWN6, AE_CH_UNKNOWN7, AE_CH_UNKNOWN8, /* for p16v devices */
@@ -125,10 +119,6 @@ inline CAEChannelInfo CAESinkALSA::GetChannelLayout(AEAudioFormat format, unsign
     if (format.m_channelLayout.HasChannel(AE_CH_SL) && !format.m_channelLayout.HasChannel(AE_CH_BL))
     {
       channelMap = ALSAChannelMap51Wide;
-    }
-    else if (maxChannels >= 8 && format.m_channelLayout.HasChannel(AE_CH_FLOC) && !format.m_channelLayout.HasChannel(AE_CH_SL))
-    {
-      channelMap = ALSAChannelMap71Wide;
     }
     for (unsigned int c = 0; c < 8; ++c)
     {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -1017,18 +1017,9 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
 {
   WAVEFORMATEXTENSIBLE_IEC61937 wfxex_iec61937;
   WAVEFORMATEXTENSIBLE &wfxex = wfxex_iec61937.FormatExt;
-  bool obsolete71Wide = false;
 
   if (format.m_dataFormat <= AE_FMT_FLOAT)
-  {
     BuildWaveFormatExtensible(format, wfxex);
-    // handle obsolete 7.1 wide
-    if (wfxex.dwChannelMask == KSAUDIO_SPEAKER_7POINT1)
-    {
-      obsolete71Wide = true;
-      wfxex.dwChannelMask = KSAUDIO_SPEAKER_7POINT1_SURROUND;
-    }
-  }
   else
     BuildWaveFormatExtensibleIEC61397(format, wfxex_iec61937);
 
@@ -1146,22 +1137,7 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
 
 initialize:
 
-  // check if 7.1 wide was requested and we were able to open 8 channels
-  if (obsolete71Wide && (wfxex.dwChannelMask == KSAUDIO_SPEAKER_7POINT1_SURROUND))
-  {
-    // build layout for 7.1 Wide and map it into KSAUDIO_SPEAKER_7POINT1_SURROUND
-    m_channelLayout.Reset();
-    m_channelLayout += AE_CH_FLOC;  // FLOC/FROC go into FL/FR
-    m_channelLayout += AE_CH_FROC;
-    m_channelLayout += AE_CH_FC;
-    m_channelLayout += AE_CH_LFE;
-    m_channelLayout += AE_CH_FL;    // FL/FR go into SL/SR
-    m_channelLayout += AE_CH_FR;
-    m_channelLayout += AE_CH_BL;
-    m_channelLayout += AE_CH_BR;
-  }
-  else
-    AEChannelsFromSpeakerMask(wfxex.dwChannelMask);
+  AEChannelsFromSpeakerMask(wfxex.dwChannelMask);
   format.m_channelLayout = m_channelLayout;
 
   /* When the stream is raw, the values in the format structure are set to the link    */

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -101,10 +101,6 @@ void CAEChannelInfo::ResolveChannels(const CAEChannelInfo& rhs)
       newInfo += m_channels[i];
   }
 
-  // we let the sink do the mapping later on
-  if (m_channelCount == 8 && m_channelCount == rhs.Count())
-    return;
-
   /* we need to ensure we end up with rear or side channels for downmix to work */
   if (srcHasSL && !dstHasSL && dstHasRL)
     newInfo += AE_CH_BL;


### PR DESCRIPTION
That worked around AAC issues with Channel Mapping. It does not belong into the sink. If we want to correct AAC 7.1 mapping, which is: Center Left center Right center Left Right Left surround Right surround Low-frequency effects

we should do this in: CDVDAudioCodecFFmpeg::BuildChannelMap()
