### PR TITLE
[dvdplayer] use correct byte-order for HTSP

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
@@ -143,11 +143,11 @@ htsmsg_t* CDVDDemuxHTSP::ReadStream()
   if(m_Input->IsStreamType(DVDSTREAM_TYPE_HTSP))
     return ((CDVDInputStreamHTSP*)m_Input)->ReadStream();
 
-  uint32_t l;
-  if(!ReadStream((uint8_t*)&l, 4))
+  uint8_t lb[4];
+  if(!ReadStream(lb, 4))
     return NULL;
 
-  l = ntohl(l);
+  uint32_t l = htstohl(lb);
   if(l == 0)
     return htsmsg_create_map();
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.h
@@ -58,6 +58,13 @@ protected:
   htsmsg_t* ReadStream();
   bool      ReadStream(uint8_t* buf, int len);
 
+  inline uint32_t htstohl(uint8_t *buf) {
+    return ((uint32_t) buf[0] << 24) + 
+           ((uint32_t) buf[1] << 16) + 
+           ((uint32_t) buf[2] << 8) + 
+           (uint32_t) buf[3];
+  }
+
   typedef std::vector<CDemuxStream*> TStreams;
 
   CDVDInputStream*     m_Input;


### PR DESCRIPTION
@elupus: I just stumbled upon this while investigating the subtitle regression. I barely know what I'm doing so please correct me if this is wrong. I basically copied the logic from https://github.com/opdenkamp/xbmc-pvr-addons/pull/181.
