### PR TITLE
Fix 14546 - ListItem.setInfo can handle additional types. Fixes #1456

### DIFF
--- a/tools/codegenerator/Helper.groovy
+++ b/tools/codegenerator/Helper.groovy
@@ -221,6 +221,11 @@ public class Helper
 
       if (!convertTemplate)
       {
+        // check the typedef resolution
+        String apiTypeResolved = SwigTypeParser.SwigType_resolve_all_typedefs(apiType)
+        if (!apiTypeResolved.equals(apiType))
+          return getOutConversion(apiTypeResolved, apiName, method, overrideBindings, recurse)
+
         if (recurse)
           return getOutConversion(SwigTypeParser.SwigType_ltype(apiType),apiName,method,overrideBindings,false)
         else if (!isKnownApiType(apiType,method))
@@ -339,7 +344,13 @@ public class Helper
       if (convertTemplate == null)
         convertTemplate = inTypemap.find({ key, value -> (key instanceof Pattern && key.matcher(apiLType).matches()) })?.value
 
-      if (!convertTemplate){
+      if (!convertTemplate)
+      {
+         // check the typedef resolution
+         String apiTypeResolved = SwigTypeParser.SwigType_resolve_all_typedefs(apiType)
+         if (!apiTypeResolved.equals(apiType))
+           return getInConversion(apiTypeResolved, apiName, paramName, slName, method, overrideBindings)
+
          // it's ok if this is a known type
          if (!isKnownApiType(apiType,method) && !isKnownApiType(apiLType,method))
            System.out.println("WARNING: Unknown parameter type: ${apiType} (or ${apiLType}) for the call ${Helper.findFullClassName(method) + '::' + Helper.callingName(method)}")

--- a/tools/codegenerator/SwigTypeParser.groovy
+++ b/tools/codegenerator/SwigTypeParser.groovy
@@ -348,6 +348,12 @@ public class SwigTypeParser
       return t.substring(start,c)
    }
 
+  public static List SwigType_templateparmlist(String t)
+  {
+    int i = t.indexOf('<');
+    return SwigType_parmlist(t.substring(i))
+  }
+
    /* -----------------------------------------------------------------------------
     * SwigType_parmlist()
     *

--- a/xbmc/interfaces/legacy/Dictionary.h
+++ b/xbmc/interfaces/legacy/Dictionary.h
@@ -25,6 +25,11 @@
 
 namespace XBMCAddon
 {
+  // This is a hack in order to handle int's as strings. The correct fix for
+  // this is to get rid of Alternative all togther and make the codegenerator
+  // finally handle overloading correctly.
+  typedef String StringOrInt;
+
   /**
    * This is a bit of a hack for dynamically typed languages. In somce
    * cases python addon api calls handle dictionaries with variable
@@ -36,5 +41,5 @@ namespace XBMCAddon
    */
   template<class T> class Dictionary : public std::map<String,T> {};
 
-  typedef Dictionary<String> Properties;
+  typedef Dictionary<StringOrInt> Properties;
 }

--- a/xbmc/interfaces/legacy/Dictionary.h
+++ b/xbmc/interfaces/legacy/Dictionary.h
@@ -34,5 +34,7 @@ namespace XBMCAddon
    * native api handles these calls by converting the string to the
    * appropriate types.
    */
-  typedef std::map<String,String> Dictionary;
+  template<class T> class Dictionary : public std::map<String,T> {};
+
+  typedef Dictionary<String> Properties;
 }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -45,10 +45,10 @@ namespace XBMCAddon
     XBMCCOMMONS_STANDARD_EXCEPTION(ListItemException);
 
     // This is a type that represents either a String or a String Tuple
-    typedef Alternative<String,Tuple<String, String> > InfoLabelStringOrTuple;
+    typedef Alternative<StringOrInt,Tuple<String, StringOrInt> > InfoLabelStringOrTuple;
 
     // This type is either a String or a list of InfoLabelStringOrTuple types
-    typedef Alternative<String, std::vector<InfoLabelStringOrTuple> > InfoLabelValue;
+    typedef Alternative<StringOrInt, std::vector<InfoLabelStringOrTuple> > InfoLabelValue;
 
     // The type contains the dictionary values for the ListItem::setInfo call. 
     // The values in the dictionary can be either a String, or a list of items.

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -26,7 +26,9 @@
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 
 #include "AddonClass.h"
+#include "Tuple.h"
 #include "Dictionary.h"
+#include "Alternative.h"
 #include "CallbackHandler.h"
 #include "ListItem.h"
 #include "music/tags/MusicInfoTag.h"
@@ -41,6 +43,17 @@ namespace XBMCAddon
   namespace xbmcgui
   {
     XBMCCOMMONS_STANDARD_EXCEPTION(ListItemException);
+
+    // This is a type that represents either a String or a String Tuple
+    typedef Alternative<String,Tuple<String, String> > InfoLabelStringOrTuple;
+
+    // This type is either a String or a list of InfoLabelStringOrTuple types
+    typedef Alternative<String, std::vector<InfoLabelStringOrTuple> > InfoLabelValue;
+
+    // The type contains the dictionary values for the ListItem::setInfo call. 
+    // The values in the dictionary can be either a String, or a list of items.
+    // If it's a list of items then the items can be either a String or a Tuple.
+    typedef Dictionary<InfoLabelValue> InfoLabelDict;
 
     class ListItem : public AddonClass
     {
@@ -141,7 +154,7 @@ namespace XBMCAddon
        * example:
        *   - self.list.getSelectedItem().setArt({ 'poster': 'poster.png', 'banner' : 'banner.png' })
        */
-      void setArt(const Dictionary& dictionary);
+      void setArt(const Properties& dictionary);
 
       /**
        * select(selected) -- Sets the listitem's selected status.\n
@@ -234,7 +247,7 @@ namespace XBMCAddon
        * example:\n
        *   - self.list.getSelectedItem().setInfo('video', { 'Genre': 'Comedy' })n\n
        */
-      void setInfo(const char* type, const Dictionary& infoLabels);
+      void setInfo(const char* type, const InfoLabelDict& infoLabels) throw (WrongTypeException);
 
       /**
        * addStreamInfo(type, values) -- Add a stream with details.\n
@@ -258,7 +271,7 @@ namespace XBMCAddon
        * example:
        *   - self.list.getSelectedItem().addStreamInfo('video', { 'Codec': 'h264', 'Width' : 1280 })
        */
-      void addStreamInfo(const char* cType, const Dictionary& dictionary);
+      void addStreamInfo(const char* cType, const Properties& dictionary);
 
       /**
        * addContextMenuItems([(label, action,)*], replaceItems) -- Adds item(s) to the context menu for media lists.\n

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -56,7 +56,6 @@ Helper.setup(this,classes,
      * This is meant to contain mini-templates for converting the return type
      * of the native call to be returned to the python caller.
      */
-//      'p.void' : '${result} = Py_BuildValue((char*)"s#",${api},readBytes);',
     [ 'void' : 'Py_INCREF(Py_None);\n    ${result} = Py_None;',
       'long': '${result} = PyInt_FromLong(${api});',
       'unsigned long': '${result} = PyInt_FromLong(${api});',
@@ -96,7 +95,8 @@ Helper.setup(this,classes,
       'unsigned long long' : '${api} = PyLong_AsUnsignedLongLong(${slarg});',
       'int' : '${api} = (int)PyInt_AsLong(${slarg});',
       'double' : '${api} = PyFloat_AsDouble(${slarg});',
-      'float' : '${api} = (float)PyFloat_AsDouble(${slarg});'
+      'float' : '${api} = (float)PyFloat_AsDouble(${slarg});',
+      'XBMCAddon::StringOrInt' : 'if (${slarg}) PyXBMCGetUnicodeString(${api},${slarg},PyInt_Check(${slarg}) || PyLong_Check(${slarg}),"${api}","${method.@name}");'
     ], '${api} = (${swigTypeParser.SwigType_str(ltype)})retrieveApiInstance(${slarg},"${ltype}","${helper.findNamespace(method)}","${helper.callingName(method)}");')
 // ---------------------------------------------------------
 

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -65,7 +65,7 @@ Helper.setup(this,classes,
       'int': '${result} = Py_BuildValue((char*)"i", ${api});',
       'double': '${result} = PyFloat_FromDouble(${api});',
       'float': '${result} = Py_BuildValue((char*)"f", ${api});',
-      'String' : new File('typemaps/python.string.outtm'),
+      'std::string' : new File('typemaps/python.string.outtm'),
       'p.q(const).char' : '${result} = PyString_FromString(${api});',
       (Pattern.compile('''(p.){0,1}XbmcCommons::Buffer''')) : new File('typemaps/python.buffer.outtm'),
       (Pattern.compile('''boost::shared_ptr<\\(.*\\)>''')) : new File('typemaps/python.boost_shared_ptr.outtm'),
@@ -82,16 +82,13 @@ Helper.setup(this,classes,
      * call.
      */
     [ 
-      'String' : 'if (${slarg}) PyXBMCGetUnicodeString(${api},${slarg},false,"${api}","${method.@name}");',
+      'std::string' : 'if (${slarg}) PyXBMCGetUnicodeString(${api},${slarg},false,"${api}","${method.@name}");',
       (Pattern.compile('''(p.){0,1}std::vector<\\(.*\\)>''')) : new File('typemaps/python.vector.intm'),
       (Pattern.compile('''(p.){0,1}Tuple(3){0,1}<\\(.*\\)>''')) : new File('typemaps/python.Tuple.intm'),
       (Pattern.compile('''(p.){0,1}Alternative<\\(.*\\)>''')) : new File('typemaps/python.Alternative.intm'),
-      // I shouldn't need both of these but my parser doesn't resolve namespaces within
-      //  parameter declarations. TODO: Maybe I should fix this.
-      'r.q(const).Dictionary' : new File('typemaps/python.dict.intm'),
-      'r.q(const).XBMCAddon::Dictionary' : new File('typemaps/python.dict.intm'),
       (Pattern.compile('''(r.){0,1}XbmcCommons::Buffer''')) : new File('typemaps/python.buffer.intm'),
       (Pattern.compile('''(p.){0,1}std::map<\\(.*\\)>''')) : new File('typemaps/python.map.intm'),
+      (Pattern.compile('''(r.){0,1}XBMCAddon::Dictionary<\\(.*\\)>''')) : new File('typemaps/python.dict.intm'),
       'bool' : '${api} = (PyInt_AsLong(${slarg}) == 0L ? false : true);',
       'long' : '${api} = PyInt_AsLong(${slarg});',
       'unsigned long' : '${api} = PyLong_AsUnsignedLong(${slarg});',

--- a/xbmc/interfaces/python/typemaps/python.Alternative.intm
+++ b/xbmc/interfaces/python/typemaps/python.Alternative.intm
@@ -20,16 +20,13 @@
  */
 %>
 <%
-    type = swigTypeParser.SwigType_resolve_all_typedefs(type)
-    matcher = type =~ /Alternative<\((.*)\)>/
-    vectype = '(' + matcher[0][1] + ')'
-    boolean ispointer = swigTypeParser.SwigType_ispointer(type)
+    boolean ispointer = swigTypeParser.SwigType_ispointer(ltype)
     String accessor = ispointer ? '->' : '.'
     int seq = sequence.increment()
     altAccess = [ 'former', 'later' ]
     altSwitch = [ 'first', 'second' ]
 
-    List types = swigTypeParser.SwigType_parmlist(vectype)
+    List types = swigTypeParser.SwigType_templateparmlist(ltype)
 %>
     {
       // we need to check the parameter type and see if it matches
@@ -38,10 +35,7 @@
       {
         ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(types[0]))} entry0_${seq};
         ${helper.getInConversion(types[0], 'entry0' + '_' + seq, 'pyentry' + '_' + seq, method,
-                                 [ 'type' : vectype,
-                                   'ltype' : swigTypeParser.SwigType_ltype(types[0]),
-                                   'sequence' : sequence
-                                   ])}
+                                 [ 'sequence' : sequence ])}
         ${api}${accessor}${altAccess[0]}() = entry0_${seq};
       }
       catch (XBMCAddon::WrongTypeException wte)
@@ -50,10 +44,7 @@
         {
           ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(types[1]))} entry1_${seq};
           ${helper.getInConversion(types[1], 'entry1' + '_' + seq, 'pyentry' + '_' + seq, method,
-                                   [ 'type' : vectype,
-                                     'ltype' : swigTypeParser.SwigType_ltype(types[1]),
-                                     'sequence' : sequence
-                                     ])}
+                                   [ 'sequence' : sequence ])}
           ${api}${accessor}${altAccess[1]}() = entry1_${seq};
         }
         catch (XBMCAddon::WrongTypeException wte2)

--- a/xbmc/interfaces/python/typemaps/python.Alternative.outtm
+++ b/xbmc/interfaces/python/typemaps/python.Alternative.outtm
@@ -20,8 +20,7 @@
  */
 %>
 <%
-    matcher = type =~ /Alternative<\((.*)\)>/
-    vectype = '(' + matcher[0][1] + ')'
+    List types = swigTypeParser.SwigType_templateparmlist(type)
     boolean ispointer = swigTypeParser.SwigType_ispointer(type)
     int seq = sequence.increment()
     String accessor = ispointer ? '->' : '.'
@@ -32,7 +31,7 @@
 
     if (<%if (ispointer) { %>${api} != NULL && <%}%>pos != XBMCAddon::none)
     { <%
-      swigTypeParser.SwigType_parmlist(vectype).eachWithIndex { curType, entryIndex -> 
+      types.eachWithIndex { curType, entryIndex -> 
 %>
       if (pos == XBMCAddon::${altSwitch[entryIndex]})
       {

--- a/xbmc/interfaces/python/typemaps/python.Tuple.intm
+++ b/xbmc/interfaces/python/typemaps/python.Tuple.intm
@@ -20,8 +20,7 @@
  */
 %>
 <%
-matcher = ltype =~ /Tuple<\((.*)\)>/
-    vectype = '(' + matcher[0][1] + ')'
+    List types = swigTypeParser.SwigType_templateparmlist(ltype)
     boolean ispointer = swigTypeParser.SwigType_ispointer(type)
     String accessor = ispointer ? '->' : '.'
     int seq = sequence.increment()
@@ -30,24 +29,17 @@ matcher = ltype =~ /Tuple<\((.*)\)>/
     {
       bool isTuple = PyObject_TypeCheck(${slarg},&PyTuple_Type);
       if (!isTuple && !PyObject_TypeCheck(${slarg},&PyList_Type))
-      {
-        PyErr_SetString(PyExc_TypeError, "the parameter \"${api}\" must be either a Tuple or a List.");
-        return NULL; // short circuit the rest of this python method
-      }
+        throw WrongTypeException("The parameter \"${api}\" must be either a Tuple or a List.");
       int vecSize = (isTuple ? PyTuple_Size(${slarg}) : PyList_Size(${slarg}));
 <%
-      swigTypeParser.SwigType_parmlist(vectype).eachWithIndex { curType, entryIndex -> 
+      types.eachWithIndex { curType, entryIndex -> 
 %>
       if (vecSize > ${entryIndex})
       {
         PyObject *pyentry${entryIndex}_${seq} = NULL;
         pyentry${entryIndex}_${seq} = (isTuple ? PyTuple_GetItem(${slarg}, ${entryIndex}) : PyList_GetItem(${slarg}, ${entryIndex}));
         ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(curType))} entry${entryIndex}_${seq};
-        ${helper.getInConversion(curType, 'entry' + entryIndex + '_' + seq, 'pyentry' + entryIndex + '_' + seq, method,
-                                 [ 'type' : vectype,
-                                   'ltype' : swigTypeParser.SwigType_ltype(curType),
-                                   'sequence' : sequence
-                                   ])}
+        ${helper.getInConversion(curType, 'entry' + entryIndex + '_' + seq, 'pyentry' + entryIndex + '_' + seq, method,[ 'sequence' : sequence ])}
         ${api}${accessor}${tupleAccess[entryIndex]}() = entry${entryIndex}_${seq};
       }
 <%

--- a/xbmc/interfaces/python/typemaps/python.Tuple.outtm
+++ b/xbmc/interfaces/python/typemaps/python.Tuple.outtm
@@ -20,8 +20,7 @@
  */
 %>
 <%
-    matcher = type =~ /Tuple<\((.*)\)>/
-    vectype = '(' + matcher[0][1] + ')'
+    List types = swigTypeParser.SwigType_templateparmlist(type)
     boolean ispointer = swigTypeParser.SwigType_ispointer(type)
     int seq = sequence.increment()
     String accessor = ispointer ? '->' : '.'
@@ -38,7 +37,7 @@
 <%  }  // this ends the if (ispointer)
 %>    {
       PyObject* pyentry${seq}; <%
-      swigTypeParser.SwigType_parmlist(vectype).eachWithIndex { curType, entryIndex -> 
+      types.eachWithIndex { curType, entryIndex -> 
 %>
 
       if (vecSize > ${entryIndex})

--- a/xbmc/interfaces/python/typemaps/python.boost_shared_ptr.outtm
+++ b/xbmc/interfaces/python/typemaps/python.boost_shared_ptr.outtm
@@ -20,8 +20,7 @@
  */
 %>
 <%
-    matcher = type =~ /shared_ptr<\((.*)\)>/
-    itype = matcher[0][1]
+    itype = swigTypeParser.SwigType_templateparmlist(type)[0]
     pointertype = swigTypeParser.SwigType_makepointer(itype)
     int seq = sequence.increment()
 %>

--- a/xbmc/interfaces/python/typemaps/python.dict.intm
+++ b/xbmc/interfaces/python/typemaps/python.dict.intm
@@ -19,15 +19,19 @@
  *
  */
 %>
+<%
+    List templateArgs = swigTypeParser.SwigType_templateparmlist(ltype)
+    valtype = templateArgs[0]
+%>
     {
       PyObject *pykey, *pyvalue;
       Py_ssize_t pos = 0;
       while(PyDict_Next(${slarg}, &pos, &pykey, &pyvalue))
       {
-        CStdString key;
-        CStdString value;
+        std::string key;
         PyXBMCGetUnicodeString(key,pykey,false,"${api}","${method.@name}");
-        PyXBMCGetUnicodeString(value,pyvalue,true,"${api}","${method.@name}");
+        ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(valtype))} value;
+        ${helper.getInConversion(valtype, 'value', 'pyvalue' ,method)}
         ${api}[key] = value;
       }
     }

--- a/xbmc/interfaces/python/typemaps/python.map.intm
+++ b/xbmc/interfaces/python/typemaps/python.map.intm
@@ -20,9 +20,9 @@
  */
 %>
 <%
-    matcher = ltype =~ /std::map<\((.*),(.*)\)>/
-    keytype = matcher[0][1]
-    valtype = matcher[0][2]
+    List templateArgs = swigTypeParser.SwigType_templateparmlist(ltype)
+    keytype = templateArgs[0]
+    valtype = templateArgs[1]
 %>
 
     {
@@ -32,14 +32,8 @@
       {
         ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(keytype))} key;
         ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(valtype))} value;
-        ${helper.getInConversion(keytype, 'key', 'pykey', method,
-                                 [ 'type' : swigTypeParser.SwigType_str(keytype),
-                                   'ltype' : swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(keytype))
-                                   ])}
-        ${helper.getInConversion(valtype, 'value', 'pyvalue' ,method,
-                                 [ 'type' : swigTypeParser.SwigType_str(valtype),
-                                   'ltype' : swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(valtype))
-                                   ])}
+        ${helper.getInConversion(keytype, 'key', 'pykey', method)}
+        ${helper.getInConversion(valtype, 'value', 'pyvalue' ,method)}
         ${api}[key] = value;
       }
     }

--- a/xbmc/interfaces/python/typemaps/python.vector.intm
+++ b/xbmc/interfaces/python/typemaps/python.vector.intm
@@ -20,8 +20,8 @@
  */
 %>
 <%
-    matcher = ltype =~ /std::vector<\((.*)\)>/
-    vectype = matcher[0][1]
+    List templateArgs = swigTypeParser.SwigType_templateparmlist(ltype)
+    vectype = templateArgs[0]
     boolean ispointer = swigTypeParser.SwigType_ispointer(type)
     String accessor = ispointer ? '->' : '.'
     int seq = sequence.increment()
@@ -29,10 +29,7 @@
     {
       bool isTuple = PyObject_TypeCheck(${slarg},&PyTuple_Type);
       if (!isTuple && !PyObject_TypeCheck(${slarg},&PyList_Type))
-      {
-        PyErr_SetString(PyExc_TypeError, "the parameter \"${api}\" must be either a Tuple or a List.");
-        return NULL; // short circuit the rest of this python method
-      }
+        throw WrongTypeException("The parameter \"${api}\" must be either a Tuple or a List.");
 
       <%  if (ispointer) print("${api} = new std::vector<${swigTypeParser.SwigType_str(vectype)}>();") %>
       PyObject *pyentry${seq} = NULL;

--- a/xbmc/interfaces/python/typemaps/python.vector.outtm
+++ b/xbmc/interfaces/python/typemaps/python.vector.outtm
@@ -20,8 +20,8 @@
  */
 %>
 <%
-    matcher = type =~ /std::vector<\((.*)\)>/
-    vectype = matcher[0][1]
+    List templateArgs = swigTypeParser.SwigType_templateparmlist(type)
+    vectype = templateArgs[0]
     boolean ispointer = swigTypeParser.SwigType_ispointer(type)
     String accessor = ispointer ? '->' : '.'
     seq = sequence.increment()

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -44,6 +44,7 @@ using namespace xbmc;
 
 %feature("python:coerceToUnicode") XBMCAddon::xbmc::getLocalizedString "true"
 
+%include "interfaces/legacy/AddonString.h"
 %include "interfaces/legacy/ModuleXbmc.h"
 
 %feature("director") Player;

--- a/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
@@ -37,6 +37,7 @@ using namespace xbmcaddon;
 %feature("knownbasetypes") XBMCAddon::xbmcaddon "AddonClass"
 
 %include "interfaces/legacy/swighelper.h"
+%include "interfaces/legacy/AddonString.h"
 
 %feature("python:coerceToUnicode") XBMCAddon::xbmcaddon::Addon::getLocalizedString "true"
 %include "interfaces/legacy/Addon.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -44,10 +44,13 @@ using namespace xbmcgui;
 %feature("knownbasetypes") XBMCAddon::xbmcgui "AddonClass,AddonCallback"
 
 %include "interfaces/legacy/swighelper.h"
+%include "interfaces/legacy/AddonString.h"
 
 %include "interfaces/legacy/ModuleXbmcgui.h"
 
 %include "interfaces/legacy/Exception.h"
+
+%include "interfaces/legacy/Dictionary.h"
 
 %include "interfaces/legacy/ListItem.h"
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcplugin.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcplugin.i
@@ -35,5 +35,6 @@ using namespace xbmcplugin;
 %feature("knownapitypes") XBMCAddon::xbmcplugin "XBMCAddon::xbmcgui::ListItem"
 
 %include "interfaces/legacy/swighelper.h"
+%include "interfaces/legacy/AddonString.h"
 %include "interfaces/legacy/ModuleXbmcplugin.h"
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
@@ -36,7 +36,7 @@ using namespace xbmcvfs;
 %}
 
 %include "interfaces/legacy/swighelper.h"
-
+%include "interfaces/legacy/AddonString.h"
 %include "interfaces/legacy/File.h"
 
 %rename ("st_atime") XBMCAddon::xbmcvfs::Stat::atime;


### PR DESCRIPTION
The codegenerator can now handle typedefs - needed for String and Dictionary changes.

Make the Dictionary a template and handle String as a typedef of std::string. Apply the use to the ListItem to handle #14546. Fixes #14546
