### PR TITLE
livetv: dvb subtitle identifiers should be written big endian (fixes 14520)

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
@@ -317,8 +317,10 @@ void CDVDDemuxHTSP::SubscriptionStart (htsmsg_t *m)
       {
         st.s->ExtraData = new uint8_t[4];
         st.s->ExtraSize = 4;
-        ((uint16_t*)st.s->ExtraData)[0] = composition_id;
-        ((uint16_t*)st.s->ExtraData)[1] = ancillary_id;
+        st.s->ExtraData[0] = (composition_id >> 8) & 0xff;
+        st.s->ExtraData[1] = composition_id & 0xff;
+        st.s->ExtraData[2] = (ancillary_id   >> 8) & 0xff;
+        st.s->ExtraData[3] = ancillary_id   & 0xff;
       }
     } else if(!strcmp(type, "TEXTSUB")) {
       st.s = new CDemuxStreamSubtitle();

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -414,8 +414,10 @@ void CDVDDemuxPVRClient::RequestStreams()
       {
         st->ExtraData = new uint8_t[4];
         st->ExtraSize = 4;
-        ((uint16_t*)st->ExtraData)[0] = (props.stream[i].iIdentifier >> 0) & 0xFFFFu;
-        ((uint16_t*)st->ExtraData)[1] = (props.stream[i].iIdentifier >> 4) & 0xFFFFu;
+        st->ExtraData[0] = (props.stream[i].iIdentifier >> 8) & 0xff;
+        st->ExtraData[1] = props.stream[i].iIdentifier & 0xff;
+        st->ExtraData[2] = (props.stream[i].iIdentifier >> 24) & 0xff;
+        st->ExtraData[3] = (props.stream[i].iIdentifier >> 16) & 0xff;
       }
       m_streams[i] = st;
     }


### PR DESCRIPTION
Thanks @elupus, this works at least for HTSP!

This fixes subtitles when watching live TV (has been broken for half a year).

References:

http://forum.xbmc.org/showthread.php?tid=169386
http://trac.xbmc.org/ticket/14520
https://github.com/xbmc/xbmc/pull/3839#issuecomment-30626519
