### PR TITLE
[CEC] bump to libCEC 2.1.4

### DIFF
--- a/lib/libcec/Makefile
+++ b/lib/libcec/Makefile
@@ -7,8 +7,8 @@
 
 # lib name, version
 LIBNAME=libcec
-VERSION=2.1.1
-SOURCE=$(LIBNAME)-$(VERSION)
+VERSION=2.1.4
+SOURCE=$(LIBNAME)-$(VERSION)-2
 
 # download location and format
 BASE_URL=http://mirrors.xbmc.org/build-deps/darwin-libs

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec-2.1.1.zip                  http://mirrors.xbmc.org/build-deps/win32/
+libcec-2.1.4.zip                  http://mirrors.xbmc.org/build-deps/win32/

--- a/tools/depends/target/libcec/Makefile
+++ b/tools/depends/target/libcec/Makefile
@@ -3,8 +3,8 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libcec
-VERSION=2.1.1
-SOURCE=$(LIBNAME)-$(VERSION)
+VERSION=2.1.4
+SOURCE=$(LIBNAME)-$(VERSION)-2
 ARCHIVE=$(SOURCE).tar.gz
 
 # configuration settings


### PR DESCRIPTION
fixes only. changelog can be found here: https://github.com/Pulse-Eight/libcec/blob/release/ChangeLog
