### PR TITLE
[spectrum] Avoid zero height bars that cause display artefacts

### DIFF
--- a/xbmc/visualizations/OpenGLSpectrum/opengl_spectrum.cpp
+++ b/xbmc/visualizations/OpenGLSpectrum/opengl_spectrum.cpp
@@ -160,6 +160,8 @@ void draw_bar(GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, G
 
 void draw_bar(GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, GLfloat green, GLfloat blue )
 {
+  // avoid zero sized bars, which results in overlapping triangles of same depth and display artefacts
+  height = std::max(height, 1e-3f);
   GLfloat col[] =  {
                       red * 0.1f, green * 0.1f, blue * 0.1f,
                       red * 0.2f, green * 0.2f, blue * 0.2f,


### PR DESCRIPTION
The spectrum visualization displays glitchy colours when audio is quiet and bar heights are zero.
This is because two different coloured triangles are drawn at exactly the same coordinates.

See:
https://dl.dropboxusercontent.com/u/3669512/temp/screenshot005.png

Don't allow a zero height bar and it looks like this:
https://dl.dropboxusercontent.com/u/3669512/temp/screenshot006.png
