### PR TITLE
ActiveAE: check input stream for ffmpeg channel order, remap if it does ...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1007,6 +1007,9 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
         (*it)->m_inputBuffers = new CActiveAEBufferPool((*it)->m_format);
         (*it)->m_inputBuffers->Create(MAX_CACHE_LEVEL*1000);
         (*it)->m_streamSpace = (*it)->m_format.m_frameSize * (*it)->m_format.m_frames;
+
+        // if input format does not follow ffmpeg channel mask, we may need to remap channels
+        (*it)->InitRemapper();
       }
       if (initSink && (*it)->m_resampleBuffers)
       {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.cpp
@@ -25,6 +25,9 @@ using namespace ActiveAE;
 CActiveAEResample::CActiveAEResample()
 {
   m_pContext = NULL;
+  m_loaded = false;
+  if (m_dllAvUtil.Load() && m_dllSwResample.Load())
+    m_loaded = true;
 }
 
 CActiveAEResample::~CActiveAEResample()
@@ -38,7 +41,7 @@ CActiveAEResample::~CActiveAEResample()
 
 bool CActiveAEResample::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality)
 {
-  if (!m_dllAvUtil.Load() || !m_dllSwResample.Load())
+  if (!m_loaded)
     return false;
 
   m_dst_chan_layout = dst_chan_layout;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
@@ -51,6 +51,7 @@ public:
 protected:
   DllAvUtil m_dllAvUtil;
   DllSwResample m_dllSwResample;
+  bool m_loaded;
   uint64_t m_src_chan_layout, m_dst_chan_layout;
   int m_src_rate, m_dst_rate;
   int m_src_channels, m_dst_channels;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -38,6 +38,8 @@ protected:
   void IncFreeBuffers();
   void DecFreeBuffers();
   void ResetFreeBuffers();
+  void InitRemapper();
+  void RemapBuffer();
 
 public:
   virtual unsigned int GetSpace();
@@ -94,12 +96,14 @@ protected:
   CCriticalSection m_streamLock;
   uint8_t *m_leftoverBuffer;
   int m_leftoverBytes;
+  CSampleBuffer *m_currentBuffer;
+  CSoundPacket *m_remapBuffer;
+  CActiveAEResample *m_remapper;
 
   // only accessed by engine
   CActiveAEBufferPool *m_inputBuffers;
   CActiveAEBufferPoolResample *m_resampleBuffers;
   std::deque<CSampleBuffer*> m_processingSamples;
-  CSampleBuffer *m_currentBuffer;
   CActiveAEDataProtocol *m_streamPort;
   CEvent m_inMsgEvent;
   CCriticalSection *m_statsLock;


### PR DESCRIPTION
@fritsch @anssih according to discussion https://github.com/xbmc/xbmc/pull/3838 this checks input channels layout for ffmpeg format.
But as long dvdplayer delivers interleaved and not planar format I would do rematrix for AAC right after decode.
