### PR TITLE
[AirTunes] - fix coverart

### DIFF
--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -462,10 +462,10 @@ void CGUITextureBase::FreeResources(bool immediately /* = false */)
   if (m_isAllocated == LARGE || m_isAllocated == LARGE_FAILED)
     g_largeTextureManager.ReleaseImage(m_info.filename, immediately || (m_isAllocated == LARGE_FAILED));
   else if (m_isAllocated == NORMAL && m_texture.size())
-    g_TextureManager.ReleaseTexture(m_info.filename);
+    g_TextureManager.ReleaseTexture(m_info.filename, immediately);
 
   if (m_diffuse.size())
-    g_TextureManager.ReleaseTexture(m_info.diffuse);
+    g_TextureManager.ReleaseTexture(m_info.diffuse, immediately);
   m_diffuse.Reset();
 
   m_texture.Reset();

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -302,7 +302,7 @@ const CTextureArray& CGUITextureManager::Load(const CStdString& strTextureName, 
   for (ilistUnused i = m_unusedTextures.begin(); i != m_unusedTextures.end(); ++i)
   {
     CTextureMap* pMap = i->first;
-    if (pMap->GetName() == strTextureName)
+    if (pMap->GetName() == strTextureName && i->second > 0)
     {
       m_vecTextures.push_back(pMap);
       m_unusedTextures.erase(i);
@@ -435,7 +435,7 @@ const CTextureArray& CGUITextureManager::Load(const CStdString& strTextureName, 
 }
 
 
-void CGUITextureManager::ReleaseTexture(const CStdString& strTextureName)
+void CGUITextureManager::ReleaseTexture(const CStdString& strTextureName, bool immediately /*= false */)
 {
   CSingleLock lock(g_graphicsContext);
 
@@ -450,7 +450,7 @@ void CGUITextureManager::ReleaseTexture(const CStdString& strTextureName)
       {
         //CLog::Log(LOGINFO, "  cleanup:%s", strTextureName.c_str());
         // add to our textures to free
-        m_unusedTextures.push_back(make_pair(pMap, XbmcThreads::SystemClockMillis()));
+        m_unusedTextures.push_back(make_pair(pMap, immediately ? 0 : XbmcThreads::SystemClockMillis()));
         i = m_vecTextures.erase(i);
       }
       return;

--- a/xbmc/guilib/TextureManager.h
+++ b/xbmc/guilib/TextureManager.h
@@ -110,7 +110,7 @@ public:
   bool HasTexture(const CStdString &textureName, CStdString *path = NULL, int *bundle = NULL, int *size = NULL);
   static bool CanLoad(const CStdString &texturePath); ///< Returns true if the texture manager can load this texture
   const CTextureArray& Load(const CStdString& strTextureName, bool checkBundleOnly = false);
-  void ReleaseTexture(const CStdString& strTextureName);
+  void ReleaseTexture(const CStdString& strTextureName, bool immediately = false);
   void Cleanup();
   void Dump() const;
   uint32_t GetMemoryUsage() const;

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -57,6 +57,8 @@
 #include <map>
 #include <string>
 
+#define TMP_COVERART_PATH "special://temp/airtunes_album_thumb.jpg"
+
 using namespace XFILE;
 using namespace ANNOUNCEMENT;
 
@@ -67,6 +69,9 @@ DllLibShairport *CAirTunesServer::m_pLibShairport = NULL;
 #endif
 CAirTunesServer *CAirTunesServer::ServerInstance = NULL;
 CStdString CAirTunesServer::m_macAddress;
+std::string CAirTunesServer::m_metadata[3];
+CCriticalSection CAirTunesServer::m_metadataLock;
+bool CAirTunesServer::m_streamStarted = false;
 
 //parse daap metadata - thx to project MythTV
 std::map<std::string, std::string> decodeDMAP(const char *buffer, unsigned int size)
@@ -88,38 +93,75 @@ std::map<std::string, std::string> decodeDMAP(const char *buffer, unsigned int s
   return result;
 }
 
+void CAirTunesServer::RefreshMetadata()
+{
+  CSingleLock lock(m_metadataLock);
+  MUSIC_INFO::CMusicInfoTag tag;
+  if (m_metadata[0].length())
+    tag.SetAlbum(m_metadata[0]);//album
+  if (m_metadata[1].length())
+    tag.SetTitle(m_metadata[1]);//title
+  if (m_metadata[2].length())
+    tag.SetArtist(m_metadata[2]);//artist
+  
+  CApplicationMessenger::Get().SetCurrentSongTag(tag);
+}
+
+void CAirTunesServer::RefreshCoverArt()
+{
+  CSingleLock lock(m_metadataLock);
+  //reset to empty before setting the new one
+  //else it won't get refreshed because the name didn't change
+  g_infoManager.SetCurrentAlbumThumb("");
+  //update the ui
+  g_infoManager.SetCurrentAlbumThumb(TMP_COVERART_PATH);
+  //update the ui
+  CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_REFRESH_THUMBS);
+  g_windowManager.SendThreadMessage(msg);
+}
+
 void CAirTunesServer::SetMetadataFromBuffer(const char *buffer, unsigned int size)
 {
-  MUSIC_INFO::CMusicInfoTag tag;
+
   std::map<std::string, std::string> metadata = decodeDMAP(buffer, size);
+  CSingleLock lock(m_metadataLock);
+
   if(metadata["asal"].length())
-    tag.SetAlbum(metadata["asal"]);//album
+    m_metadata[0] = metadata["asal"];//album
   if(metadata["minm"].length())    
-    tag.SetTitle(metadata["minm"]);//title
+    m_metadata[1] = metadata["minm"];//title
   if(metadata["asar"].length())    
-    tag.SetArtist(metadata["asar"]);//artist
-  CApplicationMessenger::Get().SetCurrentSongTag(tag);
+    m_metadata[2] = metadata["asar"];//artist
+  
+  RefreshMetadata();
 }
 
 void CAirTunesServer::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
 {
-  if ( (flag & Player) && strcmp(sender, "xbmc") == 0 && strcmp(message, "OnStop") == 0)
+  if ( (flag & Player) && strcmp(sender, "xbmc") == 0)
   {
 #ifdef HAS_AIRPLAY
-    CAirPlayServer::restoreVolume();
+    if (strcmp(message, "OnStop") == 0)
+      CAirPlayServer::restoreVolume();
 #endif
+    if (strcmp(message, "OnPlay") == 0 && m_streamStarted)
+    {
+      RefreshMetadata();
+      RefreshCoverArt();
+    }
   }
 }
 
 void CAirTunesServer::SetCoverArtFromBuffer(const char *buffer, unsigned int size)
 {
   XFILE::CFile tmpFile;
-  const char *tmpFileName = "special://temp/airtunes_album_thumb.jpg";
 
   if(!size)
     return;
 
-  if (tmpFile.OpenForWrite(tmpFileName, true))
+  CSingleLock lock(m_metadataLock);
+  
+  if (tmpFile.OpenForWrite(TMP_COVERART_PATH, true))
   {
     int writtenBytes=0;
     writtenBytes = tmpFile.Write(buffer, size);
@@ -127,13 +169,7 @@ void CAirTunesServer::SetCoverArtFromBuffer(const char *buffer, unsigned int siz
 
     if(writtenBytes)
     {
-      //reset to empty before setting the new one
-      //else it won't get refreshed because the name didn't change
-      g_infoManager.SetCurrentAlbumThumb("");
-      g_infoManager.SetCurrentAlbumThumb(tmpFileName);
-      //update the ui
-      CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_REFRESH_THUMBS);
-      g_windowManager.SendThreadMessage(msg);
+      RefreshCoverArt();
     }
   }
 }
@@ -199,6 +235,7 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
   CFileItem item;
   item.SetPath(pipe->GetName());
   item.SetMimeType("audio/x-xbmc-pcm");
+  m_streamStarted = true;
 
   CApplicationMessenger::Get().PlayFile(item);
 
@@ -261,6 +298,8 @@ void  CAirTunesServer::AudioOutputFunctions::audio_destroy(void *cls, void *sess
     CApplicationMessenger::Get().SendMessage(tMsg, true);
     CLog::Log(LOGDEBUG, "AIRTUNES: AirPlay not running - stopping player");
   }
+  
+  m_streamStarted = false;
 }
 
 void shairplay_log(void *cls, int level, const char *msg)
@@ -394,6 +433,8 @@ ao_device* CAirTunesServer::AudioOutputFunctions::ao_open_live(int driver_id, ao
   if (ao_get_option(option, "name"))
     item.GetMusicInfoTag()->SetTitle(ao_get_option(option, "name"));
 
+  m_streamStarted = true;
+
   CApplicationMessenger::Get().PlayFile(item);
 
   return (ao_device*) device;
@@ -422,6 +463,7 @@ int CAirTunesServer::AudioOutputFunctions::ao_close(ao_device *device)
   }
 
   delete device_xbmc;
+  m_streamStarted = false;
 
   return 0;
 }

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -65,6 +65,8 @@ private:
   ~CAirTunesServer();
   bool Initialize(const CStdString &password);
   void Deinitialize();
+  static void RefreshCoverArt();
+  static void RefreshMetadata();
 
   int m_port;
 #if defined(HAVE_LIBSHAIRPLAY)
@@ -76,6 +78,9 @@ private:
 #endif
   static CAirTunesServer *ServerInstance;
   static CStdString m_macAddress;
+  static CCriticalSection m_metadataLock;
+  static std::string m_metadata[3];//0 - album, 1 - title, 2 - artist
+  static bool m_streamStarted;
 
   class AudioOutputFunctions
   {

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -179,8 +179,6 @@ bool CGUIWindowHome::OnMessage(CGUIMessage& message)
         AddRecentlyAddedJobs(updateRA);
       else
         m_updateRA |= updateRA;
-
-      return true;
     }
     break;
 


### PR DESCRIPTION
The coverart which is streamed from airtunes clients to XBMC had issues a long time. Finally i found some time to fix it.
1. When the stream started - no coverart was shown. The first commit addresses this bug (basically we got the coverart before our player was in the playing state - so we had no item to at it too - fixed by delaying the coverart assignment to the OnPlay event)
2. When changing tracks on the airtunes client the coverart was not refreshed in XBMC. The last 2 commits fix this. (1. the texture was cached in the unused texture list and since the filename doesn't change but only the content - we always got the same texture, 2. in guiwindowhome the message for refreshing thumbs wasn't send to the base class).

Thx jmarshallnz for helping to find the proper code changes.
