### PR TITLE
[AE/CA] - allow a reinit on lost device. should harden our recover when ...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -148,6 +148,7 @@ private:
 
   // Prevent multiple init/deinit
   bool              m_Initialized;
+  bool              m_deviceLost;
   bool              m_callbackRunning;
 
   AEAudioFormat     m_format;


### PR DESCRIPTION
...hdmi input is switched away / should fix issues especially found on mavericks when doing so (e.x. switching the TV input away from xbmc and back)

Basically after the device list changes we are not able to determine the default device. Then there is a second callback for changed devicelist and this is possible again. In that case we need to allow a reinit - else we don't even try to find it again.
