### PR TITLE
This fixes xbmcgui.ListItem.setInfo for the "premiered" key.

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -365,13 +365,13 @@ namespace XBMCAddon
           else if (key == "tvshowtitle")
             item->GetVideoInfoTag()->m_strShowTitle = value;
           else if (key == "premiered")
-            item->GetVideoInfoTag()->m_premiered.SetFromDateString(value);
+            item->GetVideoInfoTag()->m_premiered.SetFromDBDate(value);
           else if (key == "status")
             item->GetVideoInfoTag()->m_strStatus = value;
           else if (key == "code")
             item->GetVideoInfoTag()->m_strProductionCode = value;
           else if (key == "aired")
-            item->GetVideoInfoTag()->m_firstAired.SetFromDateString(value);
+            item->GetVideoInfoTag()->m_firstAired.SetFromDBDate(value);
           else if (key == "credits")
             item->GetVideoInfoTag()->m_writingCredits = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
           else if (key == "lastplayed")

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -370,8 +370,6 @@ namespace XBMCAddon
             item->GetVideoInfoTag()->m_strStatus = value;
           else if (key == "code")
             item->GetVideoInfoTag()->m_strProductionCode = value;
-          else if (key == "aired")
-            item->GetVideoInfoTag()->m_firstAired.SetFromDBDate(value);
           else if (key == "credits")
             item->GetVideoInfoTag()->m_writingCredits = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
           else if (key == "lastplayed")

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -206,7 +206,6 @@ namespace XBMCAddon
        *     - premiered     : string (2005-03-04)
        *     - status        : string (Continuing) - status of a TVshow
        *     - code          : string (tt0110293) - IMDb code
-       *     - aired         : string (2008-12-07)
        *     - credits       : string (Andy Kaufman) - writing credits
        *     - lastplayed    : string (%Y-%m-%d %h:%m:%s = 2009-04-05 23:16:04)
        *     - album         : string (The Joshua Tree)


### PR DESCRIPTION
And removes the "aired" key as there's no infolabel for it.
