### PR TITLE
[osx] - connect the hide to the cmd+h shortcut as it was ment to be sinc...

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -436,7 +436,10 @@ bool CWinEventsSDL::ProcessOSXShortcuts(SDL_Event& event)
       g_application.OnAction(CAction(ACTION_TAKE_SCREENSHOT));
       return true;
 
-    case SDLK_h: // CMD-h to hide (but we minimize for now)
+    case SDLK_h: // CMD-h to hide
+      g_Windowing.Hide();
+      return true;
+
     case SDLK_m: // CMD-m to minimize
       CApplicationMessenger::Get().Minimize();
       return true;


### PR DESCRIPTION
...e ages ...

As pointed out by a user the cmd+h shortcut doesn't work. This was because it was hardcoded to minimize which doesn't work when in fullscreen mode. Connecting it to the hide of osx windowing allows XBMC to be hidden even when in fullscreen.

@t-nelson @jmarshallnz - i didn't add a "fix" to the commit - but somehow i consider it one if no objections ...
