### PR TITLE
Typos fix try 2

### DIFF
--- a/tools/EventClients/Clients/WiiRemote/CWIID_WiiRemote.cpp
+++ b/tools/EventClients/Clients/WiiRemote/CWIID_WiiRemote.cpp
@@ -83,7 +83,7 @@ void CWiiRemote::MessageCallback(cwiid_wiimote_t *wiiremote, int mesg_count, uni
                                           mesg[i].ir_mesg.src[1].pos[CWIID_Y]);
       }
       else if (valid_source > 2)
-      { //TODO Make this care with the strenght of the sources
+      { //TODO Make this care with the strength of the sources
         g_WiiRemote.CalculateMousePointer(mesg[i].ir_mesg.src[0].pos[CWIID_X],
                                           mesg[i].ir_mesg.src[0].pos[CWIID_Y],
                                           mesg[i].ir_mesg.src[1].pos[CWIID_X],
@@ -97,7 +97,7 @@ void CWiiRemote::MessageCallback(cwiid_wiimote_t *wiiremote, int mesg_count, uni
       g_WiiRemote.ProcessKey(mesg[i].btn_mesg.buttons);
     break;	  
     case CWIID_MESG_STATUS:
-      //Here we can figure out Extensiontypes and such
+      //Here we can figure out Extension types and such
     break;
     case CWIID_MESG_NUNCHUK:
       g_WiiRemote.ProcessNunchuck(mesg[i].nunchuk_mesg);
@@ -237,12 +237,12 @@ void CWiiRemote::Initialize(CAddress Addr, int Socket)
   ToggleBit(m_ledState, CWIID_LED4_ON);
 }
 
-/* Update is run regulary and we gather the state of the Wiiremote and see if the user have pressed on a button or moved the wiiremote
+/* Update is run regularly and we gather the state of the Wiiremote and see if the user have pressed on a button or moved the wiiremote
    This could have been done with callbacks instead but it doesn't look nice in C++*/
 void CWiiRemote::Update()
 {
   if (m_DisconnectWhenPossible)
-  {//If the user have choosen to disconnect or lost comunication
+  {//If the user has chosen to disconnect or lost communication
     DisconnectNow(true);
     m_DisconnectWhenPossible = false;
   }
@@ -311,7 +311,7 @@ void CWiiRemote::Disconnect()
 		
 #ifdef CWIID_OLD		
 /* This function is mostly a hack as CWIID < 6.0 doesn't report on disconnects, this function is called everytime
-   a message is sent to the callback (Will be once every 10 ms or so) this is to see if the connection is interupted. */
+   a message is sent to the callback (Will be once every 10 ms or so) this is to see if the connection is interrupted. */
 void CWiiRemote::CheckIn()
 { //This is always called from a criticalsection
   m_LastMsgTime = getTicks();
@@ -357,12 +357,12 @@ bool CWiiRemote::Connect()
       }
 #ifdef CWIID_OLD
       /* CheckIn to say that this is the last msg, If this isn't called it could give issues if we Connects -> Disconnect and then try to connect again 
-         the CWIID_OLD hack would automaticly disconnect the wiiremote as the lastmsg is too old. */
+         the CWIID_OLD hack would automatically disconnect the wiiremote as the lastmsg is too old. */
       CheckIn();
 #endif      
       m_connected = true;
 
-      CPacketLOG log(LOGNOTICE, "Sucessfully connected a WiiRemote");
+      CPacketLOG log(LOGNOTICE, "Successfully connected a WiiRemote");
       log.Send(m_Socket, m_MyAddr);
       return true;
     }
@@ -390,7 +390,7 @@ void CWiiRemote::DisconnectNow(bool startConnectThread)
       notification.Send(m_Socket, m_MyAddr);
     }
 
-    CPacketLOG log(LOGNOTICE, "Sucessfully disconnected a WiiRemote");
+    CPacketLOG log(LOGNOTICE, "Successfully disconnected a WiiRemote");
     log.Send(m_Socket, m_MyAddr);
   }
   m_connected = false;
@@ -415,7 +415,7 @@ bool CWiiRemote::CheckConnection()
 
 /* Sets rpt mode when a new wiiremote is connected */
 void CWiiRemote::SetupWiiRemote()
-{ //Lights up the apropriate led and setups the rapport mode, so buttons and IR work
+{ //Lights up the appropriate led and setups the rapport mode, so buttons and IR work
   SetRptMode();
   SetLedState();
 

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -221,7 +221,7 @@ CAfpConnection::afpConnnectError CAfpConnection::Connect(const CURL& url)
     CLog::Log(LOGDEBUG, "AFP: Could not parse url: %s!\n", nonConstUrl.Get().c_str());
     return AfpFailed;
   }
-  else // parsed successfull
+  else // parsed successfully
   {
     // this is our current url object whe are connected to (at least we try)
     *m_pAfpUrl = tmpurl;

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -168,7 +168,7 @@ void CRemoteControl::Initialize()
                   if ((m_inotify_wd = inotify_add_watch(m_inotify_fd, m_deviceName.c_str(), IN_DELETE_SELF)) != -1)
                   {
                     m_bInitialized = true;
-                    CLog::Log(LOGINFO, "LIRC %s: sucessfully started", __FUNCTION__);
+                    CLog::Log(LOGINFO, "LIRC %s: successfully started", __FUNCTION__);
                   }
                   else
                     CLog::Log(LOGDEBUG, "LIRC: Failed to initialize Inotify. LIRC device will not be monitored.");
@@ -177,7 +177,7 @@ void CRemoteControl::Initialize()
             }
 #else
             m_bInitialized = true;
-            CLog::Log(LOGINFO, "LIRC %s: sucessfully started", __FUNCTION__);
+            CLog::Log(LOGINFO, "LIRC %s: successfully started", __FUNCTION__);
 #endif
           }
           else

--- a/xbmc/linux/HALManager.cpp
+++ b/xbmc/linux/HALManager.cpp
@@ -175,7 +175,7 @@ void CHALManager::Initialize()
 
   GenerateGDL();
 
-  CLog::Log(LOGINFO, "HAL: Sucessfully initialized");
+  CLog::Log(LOGINFO, "HAL: Successfully initialized");
   m_Notifications = true;
 }
 

--- a/xbmc/storage/linux/DeviceKitDisksProvider.cpp
+++ b/xbmc/storage/linux/DeviceKitDisksProvider.cpp
@@ -126,7 +126,7 @@ bool CDeviceKitDiskDevice::Mount()
       if (dbus_message_get_args (reply, NULL, DBUS_TYPE_STRING, &mountPoint, DBUS_TYPE_INVALID))
       {
         m_MountPath = mountPoint;
-        CLog::Log(LOGDEBUG, "DeviceKit.Disks: Sucessfully mounted %s on %s", m_DeviceKitUDI.c_str(), mountPoint);
+        CLog::Log(LOGDEBUG, "DeviceKit.Disks: Successfully mounted %s on %s", m_DeviceKitUDI.c_str(), mountPoint);
         m_isMountedByUs = m_isMounted = true;
       }
     }

--- a/xbmc/storage/linux/UDisksProvider.cpp
+++ b/xbmc/storage/linux/UDisksProvider.cpp
@@ -101,7 +101,7 @@ bool CUDiskDevice::Mount()
       if (dbus_message_get_args (reply, NULL, DBUS_TYPE_STRING, &mountPoint, DBUS_TYPE_INVALID))
       {
         m_MountPath = mountPoint;
-        CLog::Log(LOGDEBUG, "UDisks: Sucessfully mounted %s on %s", m_DeviceKitUDI.c_str(), mountPoint);
+        CLog::Log(LOGDEBUG, "UDisks: Successfully mounted %s on %s", m_DeviceKitUDI.c_str(), mountPoint);
         m_isMountedByUs = m_isMounted = true;
       }
     }


### PR DESCRIPTION
Only typos that are not part of 3rd party libs

Main reason is to correct typos in debug log entries all else is not intended but a side effect.

https://github.com/xbmc/xbmc/pull/3862 went pear-shaped this is best
attempt.

Fingers crossed.
