### PR TITLE
Fix 36Hour.#.ChancePrecipitation alignment

### DIFF
--- a/addons/skin.confluence/720p/weather/36HourForecast.xml
+++ b/addons/skin.confluence/720p/weather/36HourForecast.xml
@@ -80,7 +80,7 @@
 						<label>[COLOR=grey2]$INFO[Window.Property(36Hour.1.TemperatureHeading)][CR][/COLOR]$INFO[Window.Property(36Hour.1.Temperature),[B] ,[/B]]</label>
 					</control>
 					<control type="label">
-						<right>590</right>
+						<right>90</right>
 						<top>60</top>
 						<width>390</width>
 						<height>20</height>
@@ -145,7 +145,7 @@
 						<label>[COLOR=grey2]$INFO[Window.Property(36Hour.2.TemperatureHeading)][CR][/COLOR]$INFO[Window.Property(36Hour.2.Temperature),[B] ,[/B]]</label>
 					</control>
 					<control type="label">
-						<right>590</right>
+						<right>90</right>
 						<top>60</top>
 						<width>390</width>
 						<height>20</height>
@@ -210,7 +210,7 @@
 						<label>[COLOR=grey2]$INFO[Window.Property(36Hour.3.TemperatureHeading)][CR][/COLOR]$INFO[Window.Property(36Hour.3.Temperature),[B] ,[/B]]</label>
 					</control>
 					<control type="label">
-						<right>590</right>
+						<right>90</right>
 						<top>60</top>
 						<width>390</width>
 						<height>20</height>


### PR DESCRIPTION
ATM there are 3 label 36Hour.#.ChancePrecipitation where # is 1, 2 or 3, and this is shown in middle of screen with `<right>590</right>`

idk what correct alignment is supposed to be but `<right>90</right>` seems to be more or less correct.

It worked when it was `<posx>590</posx>` but now it doesn't and I though I'd have a stab at fixing it.

See screenshot of bug.

![incorrect](https://f.cloud.github.com/assets/3521959/1774507/df2266b0-67f9-11e3-99e2-33705e7abecd.png)
And with this "fix"
![correct](https://f.cloud.github.com/assets/3521959/1774509/ecaa1152-67f9-11e3-9437-dc292edc1313.png)
