### PR TITLE
Add environment variables `XBMC_USER_HOME` and `XBMC_PROFILE_USERDATA`

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1060,11 +1060,20 @@ bool CApplication::InitDirectoriesLinux()
     // map our special drives
     CSpecialProtocol::SetXBMCBinPath(xbmcBinPath);
     CSpecialProtocol::SetXBMCPath(xbmcPath);
-    CSpecialProtocol::SetHomePath(userHome + "/.xbmc");
-    CSpecialProtocol::SetMasterProfilePath(userHome + "/.xbmc/userdata");
 
-    CStdString strTempPath = userHome;
-    strTempPath = URIUtils::AddFileToFolder(strTempPath, ".xbmc/temp");
+    CStdString strHomePath, strProfilePath, strTempPath;
+
+    strHomePath = URIUtils::AddFileToFolder(userHome, ".xbmc");
+    if (getenv("XBMC_USER_HOME"))
+        strHomePath = getenv("XBMC_USER_HOME");
+    CSpecialProtocol::SetHomePath(strHomePath);
+
+    strProfilePath = URIUtils::AddFileToFolder(strHomePath, "userdata");
+    if (getenv("XBMC_PROFILE_USERDATA"))
+        strProfilePath = getenv("XBMC_PROFILE_USERDATA");
+    CSpecialProtocol::SetMasterProfilePath(strProfilePath);
+
+    strTempPath = URIUtils::AddFileToFolder(strHomePath, "temp");
     if (getenv("XBMC_TEMP"))
       strTempPath = getenv("XBMC_TEMP");
     CSpecialProtocol::SetTempPath(strTempPath);


### PR DESCRIPTION
This adds two new environment variables that can be used to configure where XBMC stores the users XBMC home directory and where the masterprofile is stored.
- `XBMC_USER_HOME` - Allows the location of the `~/.xbmc` directory to be configured.
- `XBMC_PROFILE_USERDATA` - Allows the location of the masterprofile `userdata` directory to be configured.

This brings the special directories in line with the temp directory, in the sense that they are all configurable by environment variables.

If the `XBMC_PROFILE_USERDATA` variable is not defined but the `XBMC_USER_HOME` is, then the userdata directory will be located in `$XBMC_USER_HOME/userdata`.
