### PR TITLE
fix "can't scan music plugin items anymore"

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -121,7 +121,8 @@ void CMusicInfoScanner::Process()
       bool cancelled = false;
       for (std::set<std::string>::const_iterator it = m_pathsToScan.begin(); it != m_pathsToScan.end(); it++)
       {
-        if (!CDirectory::Exists(*it) && !m_bClean)
+        CURL url(*it);
+        if ((!CDirectory::Exists(*it) && url.GetProtocol() != "plugin") && !m_bClean)
         {
           /*
            * Note that this will skip scanning (if m_bClean is disabled) if the directory really


### PR DESCRIPTION
the bd385df0 commit from august had removed the possibility of scanning plugin items into musicdb. 
Maybe this can fix it...
