### PR TITLE
[RFC] improve subtitle settings and their handling

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12046,12 +12046,12 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#24111"
-msgid "Languages to download subtitles for"
+msgid "Spoken languages"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#24112"
-msgid "Set languages to use when searching for subtitles. Not all subtitle services will use all languages."
+msgid "Specify the languages you speak or can understand. These languages will f.e. be used when downloading missing subtitles."
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogSubtitles.cpp

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12021,7 +12021,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#24106"
-msgid "If not saved to movie folder subtitles will be downloaded to custom subtitle folder"
+msgid "Specify where downloaded subtitles should be saved in, the same location as the movie or a custom location."
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogSubtitles.cpp
@@ -12066,7 +12066,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#24115"
-msgid "Save subtitles to movie folder"
+msgid "Subtitle storage location"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -12089,7 +12089,17 @@ msgctxt "#24119"
 msgid "Select service that will be used as default to search for Movie subtitles"
 msgstr ""
 
-#empty strings from id 24120 to 24999
+#: system/settings/settings.xml
+msgctxt "#24120"
+msgid "same as movie"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#24121"
+msgid "custom"
+msgstr ""
+
+#empty strings from id 24122 to 24999
 
 msgctxt "#25000"
 msgid "Notifications"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -10951,7 +10951,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21460"
-msgid "Subtitle location"
+msgid "Subtitle position"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -11002,13 +11002,14 @@ msgstr ""
 #empty strings from id 21470 to 21599
 
 #: xbmc/cores/dvdplayer/DVDPlayer.cpp
+#: system/settings/settings.xml
 msgctxt "#21600"
-msgid "Prefer external subtitles"
+msgid "Prefer downloaded subtitles"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21601"
-msgid "Prefer external subtitles to internal ones"
+msgid "Prefer downloaded subtitles to default ones"
 msgstr ""
 
 #: xbmc/Util.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -165,6 +165,19 @@
         </setting>
       </group>
       <group id="4">
+        <setting id="locale.spokenlanguages" type="list[string]" label="24111" help="24112">
+          <level>1</level>
+          <default>English</default>
+          <constraints>
+            <options>languages</options>
+            <delimiter>,</delimiter>
+            <minimum>1</minimum>
+            <maximum>4</maximum>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+          </control>
+        </setting>
         <setting id="locale.audiolanguage" type="string" label="285" help="36119">
           <level>1</level>
           <default>original</default>
@@ -745,19 +758,6 @@
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
-        </setting>
-        <setting id="subtitles.languages" type="list[string]" label="24111" help="24112">
-          <level>1</level>
-          <default>English</default>
-          <constraints>
-            <options>languages</options>
-            <delimiter>,</delimiter>
-            <minimum>1</minimum>
-            <maximum>3</maximum>
-          </constraints>
-          <control type="list" format="string">
-            <multiselect>true</multiselect>
-          </control>
         </setting>
         <setting id="subtitles.tv" type="addon" label="24116" help="24117">
           <level>1</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -749,10 +749,33 @@
         </setting>
       </group>
       <group id="2">
-        <setting id="subtitles.savetomoviefolder" type="boolean" label="24115" help="24106">
+        <setting id="subtitles.storagemode" type="integer" label="24115" help="24106">
           <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="24120">0</option> <!-- SUBTITLE_STORAGEMODE_MOVIEPATH -->
+              <option label="24121">1</option> <!-- SUBTITLE_STORAGEMODE_CUSTOMPATH -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="subtitles.custompath" parent="subtitles.storagemode" type="path" label="21366" help="36191">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+            <writable>false</writable>
+            <sources>
+              <source>videos</source>
+            </sources>
+          </constraints>
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="subtitles.storagemode" operator="is">1</dependency>
+          </dependencies>
         </setting>
         <setting id="subtitles.pauseonsearch" type="boolean" label="24105" help="">
           <level>1</level>
@@ -774,20 +797,6 @@
             <addontype>xbmc.subtitle.module</addontype>
           </constraints>
           <control type="button" format="addon" />
-        </setting>
-        <setting id="subtitles.custompath" type="path" label="21366" help="36191">
-          <level>1</level>
-          <default></default>
-          <constraints>
-            <allowempty>true</allowempty>
-            <writable>false</writable>
-            <sources>
-              <source>videos</source>
-            </sources>
-          </constraints>
-          <control type="button" format="path">
-            <heading>657</heading>
-          </control>
         </setting>
         <setting id="subtitles.align" type="integer" label="21460" help="36192">
           <level>1</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -674,6 +674,37 @@
     </category>
     <category id="subtitles" label="287" help="36184">
       <group id="1">
+        <setting id="subtitles.align" type="integer" label="21460" help="36192">
+          <level>1</level>
+          <default>0</default> <!-- SUBTITLE_ALIGN_MANUAL -->
+          <constraints>
+            <options>
+              <option label="21461">0</option> <!-- SUBTITLE_ALIGN_MANUAL -->
+              <option label="21462">1</option> <!-- SUBTITLE_ALIGN_BOTTOM_INSIDE -->
+              <option label="21463">2</option> <!-- SUBTITLE_ALIGN_BOTTOM_OUTSIDE -->
+              <option label="21464">3</option> <!-- SUBTITLE_ALIGN_TOP_INSIDE -->
+              <option label="21465">4</option> <!-- SUBTITLE_ALIGN_TOP_OUTSIDE -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="subtitles.stereoscopicdepth" type="integer" label="36545" help="36546">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>10</maximum>
+          </constraints>
+          <control type="spinner" format="integer" delayed="true"/>
+        </setting>
+        <setting id="subtitles.preferexternal" type="boolean" label="21600" help="21601">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="2">
         <setting id="subtitles.font" type="string" label="14089" help="36185">
           <level>1</level>
           <default>arial.ttf</default>
@@ -748,7 +779,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="2">
+      <group id="3">
         <setting id="subtitles.storagemode" type="integer" label="24115" help="24106">
           <level>1</level>
           <default>0</default>
@@ -797,37 +828,6 @@
             <addontype>xbmc.subtitle.module</addontype>
           </constraints>
           <control type="button" format="addon" />
-        </setting>
-        <setting id="subtitles.align" type="integer" label="21460" help="36192">
-          <level>1</level>
-          <default>0</default> <!-- SUBTITLE_ALIGN_MANUAL -->
-          <constraints>
-            <options>
-              <option label="21461">0</option> <!-- SUBTITLE_ALIGN_MANUAL -->
-              <option label="21462">1</option> <!-- SUBTITLE_ALIGN_BOTTOM_INSIDE -->
-              <option label="21463">2</option> <!-- SUBTITLE_ALIGN_BOTTOM_OUTSIDE -->
-              <option label="21464">3</option> <!-- SUBTITLE_ALIGN_TOP_INSIDE -->
-              <option label="21465">4</option> <!-- SUBTITLE_ALIGN_TOP_OUTSIDE -->
-            </options>
-          </constraints>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="subtitles.preferexternal" type="boolean" label="21600" help="21601">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-      </group>
-      <group id="3">
-        <setting id="subtitles.stereoscopicdepth" type="integer" label="36545" help="36546">
-          <level>0</level>
-          <default>0</default>
-          <constraints>
-            <minimum>0</minimum>
-            <step>1</step>
-            <maximum>10</maximum>
-          </constraints>
-          <control type="spinner" format="integer" delayed="true"/>
         </setting>
       </group>
     </category>

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -301,7 +301,7 @@ void CGUIDialogSubtitles::Search()
   CURL url("plugin://" + m_currentService + "/");
   url.SetOption("action", "search");
 
-  const CSetting *setting = CSettings::Get().GetSetting("subtitles.languages");
+  const CSetting *setting = CSettings::Get().GetSetting("locale.spokenlanguages");
   if (setting)
     url.SetOption("languages", setting->ToString());
 

--- a/xbmc/video/dialogs/GUIDialogSubtitles.h
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.h
@@ -25,6 +25,12 @@
 #include "threads/CriticalSection.h"
 #include "utils/JobManager.h"
 
+enum SUBTITLE_STORAGEMODE
+{
+  SUBTITLE_STORAGEMODE_MOVIEPATH = 0,
+  SUBTITLE_STORAGEMODE_CUSTOMPATH
+};
+
 class CFileItem;
 class CFileItemList;
 


### PR DESCRIPTION
This is not meant to be merged yet as it's entirely untested. It's for now just a RFC to get your opinions if those changes would work for everyone.

Changes done:
a) move "subtitles.languages" to a more generic "locale.spokenlanguages" setting
My main intention to do this is to have more generic setting to store the languages the user speaks or understands that can be used for other things as well. I plan to add a setting to limit subtitles and audio tracks to spoken languages only, which comes in quite handy if you i.e. watch blurays with 8 audio tracks and 18 subtitle tracks and you cycle through them.

b) change subtitle storage configuration
I didn't like the "Save subtitles to movie folder" checkbox together with the "Custom subtitle folder" as they where not grouped and it was not really obvious how those two interact. Now I added a "subtitle storage location" spinner with two options: "use movie folder" and "custom folder". And once custom folder is chosen, the according setting will be enabled.

c) rearranging settings
well, to me it was way to cluttered and settings where not in logical groups and some IMO had wrong labels

A next step would be to move the "prefered subtitle language" from "Appearance -> Localization" to "Video -> Subtitles" and do the same for "prefered audio language" ("Video -> Playback")
