### PR TITLE
[pvr] use ACTION_PREVIOUS_MENU to access the menu sidebar

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -198,16 +198,19 @@ void CGUIWindowPVRCommon::OnWindowUnload(void)
 
 bool CGUIWindowPVRCommon::OnAction(const CAction &action)
 {
-  bool bReturn = false;
 
-  if (action.GetID() == ACTION_NAV_BACK ||
-      action.GetID() == ACTION_PREVIOUS_MENU)
+  switch(action.GetID())
   {
-    g_windowManager.PreviousWindow();
-    bReturn = true;
+    case ACTION_NAV_BACK:
+      g_windowManager.PreviousWindow();
+      return true;
+    case ACTION_PREVIOUS_MENU:
+      CGUIMessage msg = CGUIMessage(GUI_MSG_SETFOCUS, m_parent->GetID(), m_iControlButton);
+      m_parent->OnMessage(msg);
+      return true;
   }
 
-  return bReturn;
+  return false;
 }
 
 bool CGUIWindowPVRCommon::OnContextButton(int itemNumber, CONTEXT_BUTTON button)


### PR DESCRIPTION
As already discussed in the forum, this improves the usability to access the menu sidebar while in EPG grid and all PVR related windows. Currently if you stay in epg grid it's only possible to reach the sidebar if you move to left/right end of the epg grid. So this adds the use of the action ACTION_PREVIOUS_MENU to quickly access the sidebar.
