### PR TITLE
[db] improve/remove of pvr related database methods

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -788,7 +788,7 @@ bool CAddonDatabase::GetPackageHash(const CStdString& addonID,
                                     const CStdString& packageFileName,
                                     CStdString&       hash)
 {
-  CStdString where = FormatSQL( "addonID='%s' and filename='%s'",
+  CStdString where = PrepareSQL("addonID='%s' and filename='%s'",
                                 addonID.c_str(), packageFileName.c_str());
   hash = GetSingleValue("package", "hash", where);
   return !hash.empty();

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -135,30 +135,6 @@ uint32_t CDatabase::ComputeCRC(const CStdString &text)
   return crc;
 }
 
-
-CStdString CDatabase::FormatSQL(CStdString strStmt, ...)
-{
-  //  %q is the sqlite format string for %s.
-  //  Any bad character, like "'", will be replaced with a proper one
-  StringUtils::Replace(strStmt, "%s", "%q");
-  //  the %I64 enhancement is not supported by sqlite3_vmprintf
-  //  must be %ll instead
-  StringUtils::Replace(strStmt, "%I64", "%ll");
-
-  va_list args;
-  va_start(args, strStmt);
-  char *szSql = sqlite3_vmprintf(strStmt.c_str(), args);
-  va_end(args);
-
-  CStdString strResult;
-  if (szSql) {
-    strResult = szSql;
-    sqlite3_free(szSql);
-  }
-
-  return strResult;
-}
-
 CStdString CDatabase::PrepareSQL(CStdString strStmt, ...) const
 {
   CStdString strResult = "";

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -210,19 +210,11 @@ CStdString CDatabase::GetSingleValue(const CStdString &query)
   return GetSingleValue(query, m_pDS);
 }
 
-bool CDatabase::DeleteValues(const CStdString &strTable, const CStdString &strWhereClause /* = CStdString() */)
+bool CDatabase::DeleteValues(const CStdString &strTable, const Filter &filter /* = Filter() */)
 {
-  bool bReturn = true;
-
-  CStdString strQueryBase = "DELETE FROM %s";
-  if (!strWhereClause.empty())
-    strQueryBase += StringUtils::Format(" WHERE %s", strWhereClause.c_str());
-
-  CStdString strQuery = FormatSQL(strQueryBase, strTable.c_str());
-
-  bReturn = ExecuteQuery(strQuery);
-
-  return bReturn;
+  CStdString strQuery;
+  BuildSQL(PrepareSQL("DELETE FROM %s ", strTable.c_str()), filter, strQuery);
+  return ExecuteQuery(strQuery);
 }
 
 bool CDatabase::ExecuteQuery(const CStdString &strQuery)

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -71,7 +71,6 @@ public:
   void RollbackTransaction();
   bool InTransaction();
 
-  static CStdString FormatSQL(CStdString strStmt, ...);
   CStdString PrepareSQL(CStdString strStmt, ...) const;
 
   /*!

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -95,12 +95,11 @@ public:
 
   /*!
    * @brief Delete values from a table.
-   * @remarks The value of the strWhereClause parameter has to be FormatSQL'ed when used.
    * @param strTable The table to delete the values from.
-   * @param strWhereClause If set, use this WHERE clause.
+   * @param filter The Filter to apply to this query.
    * @return True if the query was executed successfully, false otherwise.
    */
-  bool DeleteValues(const CStdString &strTable, const CStdString &strWhereClause = CStdString());
+  bool DeleteValues(const CStdString &strTable, const Filter &filter = Filter());
 
   /*!
    * @brief Execute a query that does not return any result.

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -170,10 +170,10 @@ bool CEpgDatabase::Delete(const CEpg &table)
     return false;
   }
 
-  CStdString strWhereClause;
-  strWhereClause = FormatSQL("idEpg = %u", table.EpgID());
+  Filter filter;
+  filter.AppendWhere(PrepareSQL("idEpg = %u", table.EpgID()));
 
-  return DeleteValues("epg", strWhereClause);
+  return DeleteValues("epg", filter);
 }
 
 bool CEpgDatabase::DeleteOldEpgEntries(void)
@@ -183,9 +183,10 @@ bool CEpgDatabase::DeleteOldEpgEntries(void)
       CDateTimeSpan(0, g_advancedSettings.m_iEpgLingerTime / 60, g_advancedSettings.m_iEpgLingerTime % 60, 0);
   cleanupTime.GetAsTime(iCleanupTime);
 
-  CStdString strWhereClause = FormatSQL("iEndTime < %u", iCleanupTime);
+  Filter filter;
+  filter.AppendWhere(PrepareSQL("iEndTime < %u", iCleanupTime));
 
-  return DeleteValues("epgtags", strWhereClause);
+  return DeleteValues("epgtags", filter);
 }
 
 bool CEpgDatabase::Delete(const CEpgInfoTag &tag)
@@ -194,9 +195,10 @@ bool CEpgDatabase::Delete(const CEpgInfoTag &tag)
   if (tag.BroadcastId() <= 0)
     return false;
 
-  CStdString strWhereClause = FormatSQL("idBroadcast = %u", tag.BroadcastId());
+  Filter filter;
+  filter.AppendWhere(PrepareSQL("idBroadcast = %u", tag.BroadcastId()));
 
-  return DeleteValues("epgtags", strWhereClause);
+  return DeleteValues("epgtags", filter);
 }
 
 int CEpgDatabase::Get(CEpgContainer &container)

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -205,7 +205,7 @@ int CEpgDatabase::Get(CEpgContainer &container)
 {
   int iReturn(-1);
 
-  CStdString strQuery = FormatSQL("SELECT idEpg, sName, sScraperName FROM epg;");
+  CStdString strQuery = PrepareSQL("SELECT idEpg, sName, sScraperName FROM epg;");
   if (ResultQuery(strQuery))
   {
     iReturn = 0;
@@ -237,7 +237,7 @@ int CEpgDatabase::Get(CEpg &epg)
 {
   int iReturn(-1);
 
-  CStdString strQuery = FormatSQL("SELECT * FROM epgtags WHERE idEpg = %u;", epg.EpgID());
+  CStdString strQuery = PrepareSQL("SELECT * FROM epgtags WHERE idEpg = %u;", epg.EpgID());
   if (ResultQuery(strQuery))
   {
     iReturn = 0;
@@ -294,7 +294,7 @@ int CEpgDatabase::Get(CEpg &epg)
 bool CEpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime *lastScan)
 {
   bool bReturn = false;
-  CStdString strWhereClause = FormatSQL("idEpg = %u", iEpgId);
+  CStdString strWhereClause = PrepareSQL("idEpg = %u", iEpgId);
   CStdString strValue = GetSingleValue("lastepgscan", "sLastScan", strWhereClause);
 
   if (!strValue.empty())
@@ -312,7 +312,7 @@ bool CEpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime *lastScan)
 
 bool CEpgDatabase::PersistLastEpgScanTime(int iEpgId /* = 0 */, bool bQueueWrite /* = false */)
 {
-  CStdString strQuery = FormatSQL("REPLACE INTO lastepgscan(idEpg, sLastScan) VALUES (%u, '%s');",
+  CStdString strQuery = PrepareSQL("REPLACE INTO lastepgscan(idEpg, sLastScan) VALUES (%u, '%s');",
       iEpgId, CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsDBDateTime().c_str());
 
   return bQueueWrite ? QueueInsertQuery(strQuery) : ExecuteQuery(strQuery);
@@ -336,10 +336,10 @@ int CEpgDatabase::Persist(const CEpg &epg, bool bQueueWrite /* = false */)
 
   CStdString strQuery;
   if (epg.EpgID() > 0)
-    strQuery = FormatSQL("REPLACE INTO epg (idEpg, sName, sScraperName) "
+    strQuery = PrepareSQL("REPLACE INTO epg (idEpg, sName, sScraperName) "
         "VALUES (%u, '%s', '%s');", epg.EpgID(), epg.Name().c_str(), epg.ScraperName().c_str());
   else
-    strQuery = FormatSQL("INSERT INTO epg (sName, sScraperName) "
+    strQuery = PrepareSQL("INSERT INTO epg (sName, sScraperName) "
         "VALUES ('%s', '%s');", epg.Name().c_str(), epg.ScraperName().c_str());
 
   if (bQueueWrite)
@@ -379,7 +379,7 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
 
   if (iBroadcastId < 0)
   {
-    strQuery = FormatSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
+    strQuery = PrepareSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
         "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, sGenre, "
         "iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid) "
@@ -392,7 +392,7 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
   }
   else
   {
-    strQuery = FormatSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
+    strQuery = PrepareSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
         "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, sGenre, "
         "iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid, idBroadcast) "
@@ -420,7 +420,7 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
 
 int CEpgDatabase::GetLastEPGId(void)
 {
-  CStdString strQuery = FormatSQL("SELECT MAX(idEpg) FROM epg");
+  CStdString strQuery = PrepareSQL("SELECT MAX(idEpg) FROM epg");
   CStdString strValue = GetSingleValue(strQuery);
   if (!strValue.empty())
     return atoi(strValue.c_str());

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -291,6 +291,7 @@ int CPVRDatabase::GetLastChannelId(void)
     {
       if (!m_pDS->eof())
         iReturn = m_pDS->fv("iMaxChannel").get_asInt();
+      m_pDS->close();
     }
     catch (...) {}
   }


### PR DESCRIPTION
This PR gets rid of two database helper methods (FormatSQL and ResultQuery) which are unnecessary 
because they could replaced by PrepareSQL() and dataset query() method. The methods are only used in the pvr/epg database derivation.

I also change the signature/implementation of the database method DeleteValues() to use Database::Filter as parameter to limit the set of values to delete.
