### PR TITLE
Check versions when marking as broken - no point marking old versions as broken when new versions exist

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -272,6 +272,17 @@ bool CRepositoryUpdateJob::DoWork()
                                               addon->Name(),TOAST_DISPLAY_TIME,false,TOAST_DISPLAY_TIME);
       }
     }
+
+    // Check if we should mark the add-on as broken.  We may have a newer version
+    // of this add-on in the database or installed - if so, we keep it unbroken.
+    bool haveNewer = addon && addon->Version() > newAddon->Version();
+    if (!haveNewer)
+    {
+      AddonPtr dbAddon;
+      haveNewer = database.GetAddon(newAddon->ID(), dbAddon) && dbAddon->Version() > newAddon->Version();
+    }
+    if (!haveNewer)
+    {
     if (!newAddon->Props().broken.empty())
     {
       if (database.IsAddonBroken(newAddon->ID()).empty())
@@ -287,6 +298,7 @@ bool CRepositoryUpdateJob::DoWork()
       }
     }
     database.BreakAddon(newAddon->ID(), newAddon->Props().broken);
+    }
   }
 
   return true;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -283,21 +283,21 @@ bool CRepositoryUpdateJob::DoWork()
     }
     if (!haveNewer)
     {
-    if (!newAddon->Props().broken.empty())
-    {
-      if (database.IsAddonBroken(newAddon->ID()).empty())
+      if (!newAddon->Props().broken.empty())
       {
-        std::string line = g_localizeStrings.Get(24096);
-        if (newAddon->Props().broken == "DEPSNOTMET")
-          line = g_localizeStrings.Get(24104);
-        if (addon && CGUIDialogYesNo::ShowAndGetInput(newAddon->Name(),
-                                             line,
-                                             g_localizeStrings.Get(24097),
-                                             ""))
-          CAddonMgr::Get().DisableAddon(newAddon->ID());
+        if (database.IsAddonBroken(newAddon->ID()).empty())
+        {
+          std::string line = g_localizeStrings.Get(24096);
+          if (newAddon->Props().broken == "DEPSNOTMET")
+            line = g_localizeStrings.Get(24104);
+          if (addon && CGUIDialogYesNo::ShowAndGetInput(newAddon->Name(),
+                                               line,
+                                               g_localizeStrings.Get(24097),
+                                               ""))
+            CAddonMgr::Get().DisableAddon(newAddon->ID());
+        }
       }
-    }
-    database.BreakAddon(newAddon->ID(), newAddon->Props().broken);
+      database.BreakAddon(newAddon->ID(), newAddon->Props().broken);
     }
   }
 


### PR DESCRIPTION
1. When updating repositories, only bother parsing the most up to date version (across repositories).  A bunch of users have the superrepo (frodo) repository installed, which duplicates all the add-ons in the main XBMC repo.  If this is a bit out of date, then the new versions from the XBMC repo will be parsed and marked as not broken (as they're not) and then the old ones from superrepo will be parsed and the add-ons marked as broken (unmet deps).  This is clearly wrong.

We already do this when parsing a multi-repo repository (e.g. the gotham/frodo mixed repo at XBMC.org) - extend this same idea to when parsing multiple repositories.

Note that this means that only the most up to date version will ever be considered.  This is consistent with how basically everything works in XBMC add-ons anyway (i.e. there's no way to install an old version of an add-on other than installing directly from a package zip).
1. Only mark add-ons as broken (or as fixed) if we're processing the most up to date version.  i.e. if we have a newer version available, don't touch it.

This should get rid of the last of the "this add-on is marked as broken, would you like to disable" popups.
