### PR TITLE
Map the BACK button to Back in fullscreen

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -148,7 +148,7 @@
       <right>StepForward</right>
       <up>BigStepForward</up>
       <down>BigStepBack</down>
-      <back>SmallStepBack</back>
+      <back>Back</back>
       <menu>OSD</menu>
       <start>OSD</start>
       <select>OSD</select>
@@ -189,7 +189,7 @@
       <right>NextPreset</right>
       <up>IncreaseRating</up>
       <down>DecreaseRating</down>
-      <back>LockPreset</back>
+      <back>Back</back>
       <title>CodecInfo</title>
       <select>XBMC.ActivateWindow(VisualisationPresetList)</select>
       <menu>OSD</menu>


### PR DESCRIPTION
Rather than smallstepback in fullscreenvideo and lockpreset in visualisation.

@pike2k your opportunity to protest...

This ensures consistent behaviour on the BACK button to always go back.  Other stuff should be mapped to other buttons.
