### PR TITLE
[gui] new ACTION_MENU key to focus sidebar menu

### DIFF
--- a/addons/skin.confluence/720p/AddonBrowser.xml
+++ b/addons/skin.confluence/720p/AddonBrowser.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,550,551</views>

--- a/addons/skin.confluence/720p/MyMusicNav.xml
+++ b/addons/skin.confluence/720p/MyMusicNav.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,500,550,551,509,506,511,512,513</views>

--- a/addons/skin.confluence/720p/MyMusicPlaylist.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylist.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,506</views>

--- a/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
+++ b/addons/skin.confluence/720p/MyMusicPlaylistEditor.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">6</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.confluence/720p/MyMusicSongs.xml
+++ b/addons/skin.confluence/720p/MyMusicSongs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,550,551,500,506</views>

--- a/addons/skin.confluence/720p/MyPVRChannels.xml
+++ b/addons/skin.confluence/720p/MyPVRChannels.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyPVRGuide.xml
+++ b/addons/skin.confluence/720p/MyPVRGuide.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">10</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<views>10,11,12,13</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyPVRRecordings.xml
+++ b/addons/skin.confluence/720p/MyPVRRecordings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyPVRSearch.xml
+++ b/addons/skin.confluence/720p/MyPVRSearch.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyPVRTimers.xml
+++ b/addons/skin.confluence/720p/MyPVRTimers.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<views>50</views>
 	<controls>

--- a/addons/skin.confluence/720p/MyPics.xml
+++ b/addons/skin.confluence/720p/MyPics.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,550,551,500,514,510</views>

--- a/addons/skin.confluence/720p/MyPrograms.xml
+++ b/addons/skin.confluence/720p/MyPrograms.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51,500,550,551</views>

--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<views>50,51,500,550,551,560,501,508,504,503,515,505,511</views>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>

--- a/addons/skin.confluence/720p/MyVideoPlaylist.xml
+++ b/addons/skin.confluence/720p/MyVideoPlaylist.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<views>50,51</views>

--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
+	<menucontrol>9000</menucontrol>
 	<allowoverlay>no</allowoverlay>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(1112)</onload>
 	<controls>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -62,11 +62,13 @@
       <backspace>Back</backspace>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
       <key id='65446'>Back</key>
-      <m>ActivateWindow(PlayerControls)</m>
+      <m>Menu</m>
+      <m mod="ctrl">ActivateWindow(PlayerControls)</m>
       <s>ActivateWindow(shutdownmenu)</s>
       <escape>PreviousMenu</escape>
       <i>Info</i>
-      <menu>ContextMenu</menu>
+      <menu>Menu</menu>
+      <menu mod="longpress">ContextMenu</menu>
       <c>ContextMenu</c>
       <space>Pause</space>
       <x>Stop</x>
@@ -183,7 +185,7 @@
   </VirtualKeyboard>
   <MyTVChannels>
     <keyboard>
-      <m>Move</m>
+      <m mod="ctrl">Move</m>
     </keyboard>
   </MyTVChannels>
   <MyTVRecordings>
@@ -200,7 +202,7 @@
   </MyTVTimers>
   <MyRadioChannels>
     <keyboard>
-      <m>Move</m>
+      <m mod="ctrl">Move</m>
     </keyboard>
   </MyRadioChannels>
   <MyRadioRecordings>
@@ -303,7 +305,7 @@
   </FullscreenInfo>
   <PlayerControls>
     <keyboard>
-      <m>Back</m>
+      <m mod="ctrl">Back</m>
     </keyboard>
   </PlayerControls>
   <Visualisation>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -35,6 +35,10 @@
 <!--                                                                                          -->
 <!--  Axis Ids / Analog Controls                                                              -->
 <!--   Coming soon.                                                                           -->
+<!--                                                                                          -->
+<!--  Long presses                                                                            -->
+<!--   A limitation is that if a single press is mapped in a section, a global "longpress"    -->
+<!--   will be ignored. The workaround is to duplicate the long mapping in the section.       -->
 <keymap>
   <global>
     <remote>
@@ -52,7 +56,8 @@
       <pageplus>PageUp</pageplus>
       <pageminus>PageDown</pageminus>
       <back>Back</back>
-      <menu>PreviousMenu</menu>
+      <menu>Menu</menu>
+      <menu mod="logpress">PreviousMenu</menu>
       <contentsmenu>PreviousMenu</contentsmenu>
       <rootmenu>PreviousMenu</rootmenu>
       <title>ContextMenu</title>

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -71,6 +71,8 @@ CGUIWindow::CGUIWindow(int id, const std::string &xmlFile)
   m_exclusiveMouseControl = 0;
   m_clearBackground = 0xff000000; // opaque black -> always clear
   m_windowXMLRootElement = NULL;
+  m_menuControlID = 0;
+  m_menuLastFocusedControlID = 0;
 }
 
 CGUIWindow::~CGUIWindow(void)
@@ -204,6 +206,10 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
       if (always && strcmpi(always, "true") == 0)
         m_defaultAlways = true;
       m_defaultControl = atoi(pChild->FirstChild()->Value());
+    }
+    else if(strValue == "menucontrol" && pChild->FirstChild())
+    {
+      m_menuControlID = atoi(pChild->FirstChild()->Value());
     }
     else if (strValue == "visible" && pChild->FirstChild())
     {
@@ -432,8 +438,39 @@ bool CGUIWindow::OnAction(const CAction &action)
   }
 
   // default implementations
-  if (action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU)
-    return OnBack(action.GetID());
+  switch(action.GetID())
+  {
+    case ACTION_NAV_BACK:
+    case ACTION_PREVIOUS_MENU:
+      return OnBack(action.GetID());
+    case ACTION_MENU:
+      if (m_menuControlID > 0)
+      {
+        CGUIControl *menu = GetControl(m_menuControlID);
+        if (menu)
+        {
+          int focusControlId;
+          if (!menu->HasFocus())
+          {
+            // focus the menu control
+            focusControlId = m_menuControlID;
+            // To support a toggle behaviour we store the last focused control id
+            // to restore (focus) this control if the menu control has the focus
+            // while you press the menu button again.
+            m_menuLastFocusedControlID = GetFocusedControlID();
+          }
+          else
+          {
+            // restore the last focused control or if not exists use the default control
+            focusControlId = m_menuLastFocusedControlID > 0 ? m_menuLastFocusedControlID : m_defaultControl;
+          }
+
+          CGUIMessage msg = CGUIMessage(GUI_MSG_SETFOCUS, GetID(), focusControlId);
+          return OnMessage(msg);
+        }
+      }
+      break;
+  }
 
   return false;
 }
@@ -970,6 +1007,8 @@ void CGUIWindow::SetDefaults()
   m_animationsEnabled = true;
   m_clearBackground = 0xff000000; // opaque black -> clear
   m_hitRect.SetRect(0, 0, (float)m_coordsRes.iWidth, (float)m_coordsRes.iHeight);
+  m_menuControlID = 0;
+  m_menuLastFocusedControlID = 0;
 }
 
 CRect CGUIWindow::GetScaledBounds() const

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -272,6 +272,9 @@ protected:
 
   int m_exclusiveMouseControl; ///< \brief id of child control that wishes to receive all mouse events \sa GUI_MSG_EXCLUSIVE_MOUSE
 
+  int m_menuControlID;
+  int m_menuLastFocusedControlID;
+
 private:
   std::map<std::string, CVariant, icompare> m_mapProperties;
   std::map<INFO::InfoPtr, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -75,6 +75,7 @@ static const ActionMapping actions[] =
     { "parentdir"                , ACTION_NAV_BACK },                   // backward compatibility
     { "parentfolder"             , ACTION_PARENT_DIR },
     { "back"                     , ACTION_NAV_BACK },
+    { "menu"                     , ACTION_MENU},
     { "previousmenu"             , ACTION_PREVIOUS_MENU },
     { "info"                     , ACTION_SHOW_INFO },
     { "pause"                    , ACTION_PAUSE },

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -296,6 +296,7 @@
 
 #define ACTION_AUDIO_DELAY            161
 #define ACTION_SUBTITLE_DELAY         162
+#define ACTION_MENU                   163
 
 #define ACTION_RECORD                 170
 


### PR DESCRIPTION
This adds a new key ACTION_MENU which is translated to "menu" to use in keymaps. The key is used to focus the first button control and in pvr the corresponding button control of the current view within our sidebar menu. 

The initial intention was to quick access the sidebar menu if you stay in epg grid, because top/buttom/left/right is used for scrolling and you can't access the menu quickly. As @da-anda said, it would be make more sense if we could get this in all related windows, so here it is.
