### PR TITLE
AE: fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -38,6 +38,8 @@ void CEngineStats::Reset(unsigned int sampleRate)
   CSingleLock lock(m_lock);
   m_sinkUpdate = XbmcThreads::SystemClockMillis();
   m_sinkDelay = 0;
+  m_sinkCacheTotal = 0;
+  m_sinkLatency = 0;
   m_sinkSampleRate = sampleRate;
   m_bufferedSamples = 0;
   m_suspended = false;
@@ -89,11 +91,13 @@ float CEngineStats::GetDelay()
   return delay;
 }
 
+// this is used to sync a/v so we need to add sink latency here
 float CEngineStats::GetDelay(CActiveAEStream *stream)
 {
   CSingleLock lock(m_lock);
   unsigned int now = XbmcThreads::SystemClockMillis();
   float delay = m_sinkDelay - (double)(now-m_sinkUpdate) / 1000;
+  delay += m_sinkLatency;
   delay += (float)m_bufferedSamples / m_sinkSampleRate;
 
   if (delay < 0)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -852,6 +852,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
 
   AEAudioFormat sinkInputFormat, inputFormat;
   AEAudioFormat oldInternalFormat = m_internalFormat;
+  AEAudioFormat oldSinkRequestFormat = m_sinkRequestFormat;
 
   inputFormat = GetInputFormat(desiredFmt);
 
@@ -862,11 +863,14 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
   std::string device = AE_IS_RAW(m_sinkRequestFormat.m_dataFormat) ? m_settings.passthoughdevice : m_settings.device;
   std::string driver;
   CAESinkFactory::ParseDevice(device, driver);
-  if (!IsSinkCompatible(m_sinkRequestFormat, device) || m_settings.driver.compare(driver) != 0)
+  if ((!CompareFormat(m_sinkRequestFormat, m_sinkFormat) && !CompareFormat(m_sinkRequestFormat, oldSinkRequestFormat)) ||
+      m_currDevice.compare(device) != 0 ||
+      m_settings.driver.compare(driver) != 0)
   {
     if (!InitSink())
       return;
     m_settings.driver = driver;
+    m_currDevice = device;
     initSink = true;
     m_stats.Reset(m_sinkFormat.m_sampleRate);
     m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::VOLUME, &m_volume, sizeof(float));
@@ -1399,10 +1403,10 @@ bool CActiveAE::NeedReconfigureSink()
   std::string device = AE_IS_RAW(newFormat.m_dataFormat) ? m_settings.passthoughdevice : m_settings.device;
   std::string driver;
   CAESinkFactory::ParseDevice(device, driver);
-  if (m_settings.driver.compare(driver) != 0)
-    return true;
 
-  if (!IsSinkCompatible(newFormat, device))
+  if (!CompareFormat(newFormat, m_sinkFormat) ||
+      m_currDevice.compare(device) != 0 ||
+      m_settings.driver.compare(driver) != 0)
     return true;
 
   return false;
@@ -1475,40 +1479,6 @@ void CActiveAE::DrainSink()
     m_extError = true;
     return;
   }
-}
-
-bool CActiveAE::IsSinkCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  bool compatible = false;
-  SinkConfig config;
-  config.format = format;
-  config.device = &device;
-
-  // send message to sink
-  Message *reply;
-  if (m_sink.m_controlPort.SendOutMessageSync(CSinkControlProtocol::ISCOMPATIBLE,
-                                                 &reply,
-                                                 1000,
-                                                 &config, sizeof(config)))
-  {
-    bool success = reply->signal == CSinkControlProtocol::ACC ? true : false;
-    if (!success)
-    {
-      reply->Release();
-      CLog::Log(LOGERROR, "ActiveAE::%s - returned error", __FUNCTION__);
-      m_extError = true;
-      return false;
-    }
-    compatible = *(bool*)reply->data;
-    reply->Release();
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "ActiveAE::%s - failed to query compatibility", __FUNCTION__);
-    m_extError = true;
-    return false;
-  }
-  return compatible;
 }
 
 void CActiveAE::UnconfigureSink()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -250,7 +250,6 @@ protected:
   bool InitSink();
   void DrainSink();
   void UnconfigureSink();
-  bool IsSinkCompatible(const AEAudioFormat &format, const std::string &device);
   void Start();
   void Dispose();
   void LoadSettings();
@@ -307,6 +306,7 @@ protected:
   AudioSettings m_settings;
   CEngineStats m_stats;
   IAEEncoder *m_encoder;
+  std::string m_currDevice;
 
   // buffers
   CActiveAEBufferPoolResample *m_sinkBuffers;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -163,11 +163,13 @@ public:
   float GetWaterLevel();
   void SetSuspended(bool state);
   void SetSinkCacheTotal(float time) { m_sinkCacheTotal = time; }
+  void SetSinkLatency(float time) { m_sinkLatency = time; }
   bool IsSuspended();
   CCriticalSection *GetLock() { return &m_lock; }
 protected:
   float m_sinkDelay;
   float m_sinkCacheTotal;
+  float m_sinkLatency;
   int m_bufferedSamples;
   unsigned int m_sinkSampleRate;
   unsigned int m_sinkUpdate;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -163,6 +163,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           if (!m_extError)
           {
             m_stats->SetSinkCacheTotal(m_sink->GetCacheTotal());
+            m_stats->SetSinkLatency(m_sink->GetLatency());
             m_state = S_TOP_CONFIGURED_IDLE;
             m_extTimeout = 10000;
             msg->Reply(CSinkControlProtocol::ACC, &m_sinkFormat, sizeof(AEAudioFormat));

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -76,13 +76,6 @@ void CActiveAESink::Dispose()
   }
 }
 
-bool CActiveAESink::IsCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  if (!m_sink)
-    return false;
-  return m_sink->IsCompatible(format, device);
-}
-
 bool CActiveAESink::HasVolume()
 {
   if (!m_sink)
@@ -197,13 +190,6 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
         case CSinkControlProtocol::FLUSH:
           ReturnBuffers();
           msg->Reply(CSinkControlProtocol::ACC);
-          return;
-
-        case CSinkControlProtocol::ISCOMPATIBLE:
-          data = (SinkConfig*)msg->data;
-          bool compatible;
-          compatible = IsCompatible(data->format, *(data->device));
-          msg->Reply(CSinkControlProtocol::ACC, &compatible, sizeof(bool));
           return;
 
         default:
@@ -652,73 +638,58 @@ void CActiveAESink::OpenSink()
   if (driver.empty() && m_sink)
     driver = m_sink->GetName();
 
-  std::string sinkName;
+  CLog::Log(LOGINFO, "CActiveAE::OpenSink - initialize sink");
+
   if (m_sink)
   {
-    sinkName = m_sink->GetName();
-    std::transform(sinkName.begin(), sinkName.end(), sinkName.begin(), ::toupper);
+    m_sink->Drain();
+    m_sink->Deinitialize();
+    delete m_sink;
+    m_sink = NULL;
   }
 
-  if (!m_sink || sinkName != driver || !m_sink->IsCompatible(m_requestedFormat, device))
+  // get the display name of the device
+  GetDeviceFriendlyName(device);
+
+  // if we already have a driver, prepend it to the device string
+  if (!driver.empty())
+    device = driver + ":" + device;
+
+  // WARNING: this changes format and does not use passthrough
+  m_sinkFormat = m_requestedFormat;
+  CLog::Log(LOGDEBUG, "CActiveAE::OpenSink - trying to open device %s", device.c_str());
+  m_sink = CAESinkFactory::Create(device, m_sinkFormat, passthrough);
+
+  if (!m_sink)
   {
-    CLog::Log(LOGINFO, "CActiveAE::OpenSink - sink incompatible, re-starting");
+    CLog::Log(LOGERROR, "CActiveAE::OpenSink - no sink was returned");
+    m_extError = true;
+    return;
+  }
 
-    if (m_sink)
-    {
-      m_sink->Drain();
-      m_sink->Deinitialize();
-      delete m_sink;
-      m_sink = NULL;
-    }
-
-    // get the display name of the device
-    GetDeviceFriendlyName(device);
-
-    // if we already have a driver, prepend it to the device string
-    if (!driver.empty())
-      device = driver + ":" + device;
-
-    // WARNING: this changes format and does not use passthrough
-    m_sinkFormat = m_requestedFormat;
-    CLog::Log(LOGDEBUG, "CActiveAE::OpenSink - trying to open device %s", device.c_str());
-    m_sink = CAESinkFactory::Create(device, m_sinkFormat, passthrough);
-
-    if (!m_sink)
-    {
-      CLog::Log(LOGERROR, "CActiveAE::OpenSink - no sink was returned");
-      m_extError = true;
-      return;
-    }
-
-    m_sink->SetVolume(m_volume);
+  m_sink->SetVolume(m_volume);
 
 #ifdef WORDS_BIGENDIAN
-    if (m_sinkFormat.m_dataFormat == AE_FMT_S16BE)
-      m_sinkFormat.m_dataFormat = AE_FMT_S16NE;
-    else if (m_sinkFormat.m_dataFormat == AE_FMT_S32BE)
-      m_sinkFormat.m_dataFormat = AE_FMT_S32NE;
+  if (m_sinkFormat.m_dataFormat == AE_FMT_S16BE)
+    m_sinkFormat.m_dataFormat = AE_FMT_S16NE;
+  else if (m_sinkFormat.m_dataFormat == AE_FMT_S32BE)
+    m_sinkFormat.m_dataFormat = AE_FMT_S32NE;
 #else
-    if (m_sinkFormat.m_dataFormat == AE_FMT_S16LE)
-      m_sinkFormat.m_dataFormat = AE_FMT_S16NE;
-    else if (m_sinkFormat.m_dataFormat == AE_FMT_S32LE)
-      m_sinkFormat.m_dataFormat = AE_FMT_S32NE;
+  if (m_sinkFormat.m_dataFormat == AE_FMT_S16LE)
+    m_sinkFormat.m_dataFormat = AE_FMT_S16NE;
+  else if (m_sinkFormat.m_dataFormat == AE_FMT_S32LE)
+    m_sinkFormat.m_dataFormat = AE_FMT_S32NE;
 #endif
 
-    CLog::Log(LOGDEBUG, "CActiveAE::OpenSink - %s Initialized:", m_sink->GetName());
-    CLog::Log(LOGDEBUG, "  Output Device : %s", m_deviceFriendlyName.c_str());
-    CLog::Log(LOGDEBUG, "  Sample Rate   : %d", m_sinkFormat.m_sampleRate);
-    CLog::Log(LOGDEBUG, "  Sample Format : %s", CAEUtil::DataFormatToStr(m_sinkFormat.m_dataFormat));
-    CLog::Log(LOGDEBUG, "  Channel Count : %d", m_sinkFormat.m_channelLayout.Count());
-    CLog::Log(LOGDEBUG, "  Channel Layout: %s", ((std::string)m_sinkFormat.m_channelLayout).c_str());
-    CLog::Log(LOGDEBUG, "  Frames        : %d", m_sinkFormat.m_frames);
-    CLog::Log(LOGDEBUG, "  Frame Samples : %d", m_sinkFormat.m_frameSamples);
-    CLog::Log(LOGDEBUG, "  Frame Size    : %d", m_sinkFormat.m_frameSize);
-  }
-  else
-    CLog::Log(LOGINFO, "CActiveAE::OpenSink - keeping old sink with : %s, %s, %dhz",
-                          CAEUtil::DataFormatToStr(m_sinkFormat.m_dataFormat),
-                          ((std::string)m_sinkFormat.m_channelLayout).c_str(),
-                          m_sinkFormat.m_sampleRate);
+  CLog::Log(LOGDEBUG, "CActiveAE::OpenSink - %s Initialized:", m_sink->GetName());
+  CLog::Log(LOGDEBUG, "  Output Device : %s", m_deviceFriendlyName.c_str());
+  CLog::Log(LOGDEBUG, "  Sample Rate   : %d", m_sinkFormat.m_sampleRate);
+  CLog::Log(LOGDEBUG, "  Sample Format : %s", CAEUtil::DataFormatToStr(m_sinkFormat.m_dataFormat));
+  CLog::Log(LOGDEBUG, "  Channel Count : %d", m_sinkFormat.m_channelLayout.Count());
+  CLog::Log(LOGDEBUG, "  Channel Layout: %s", ((std::string)m_sinkFormat.m_channelLayout).c_str());
+  CLog::Log(LOGDEBUG, "  Frames        : %d", m_sinkFormat.m_frames);
+  CLog::Log(LOGDEBUG, "  Frame Samples : %d", m_sinkFormat.m_frameSamples);
+  CLog::Log(LOGDEBUG, "  Frame Size    : %d", m_sinkFormat.m_frameSize);
 
   // init sample of silence
   SampleConfig config;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -50,7 +50,6 @@ public:
     CONFIGURE,
     UNCONFIGURE,
     SILENCEMODE,
-    ISCOMPATIBLE,
     VOLUME,
     FLUSH,
     TIMEOUT,
@@ -101,7 +100,6 @@ protected:
   void GetDeviceFriendlyName(std::string &device);
   void OpenSink();
   void ReturnBuffers();
-  bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
   unsigned int OutputSamples(CSampleBuffer* samples);
   void ConvertInit(CSampleBuffer* samples);

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -58,6 +58,11 @@ public:
   virtual double GetCacheTotal() = 0;
 
   /*
+    This method returns latency of hardware.
+  */
+  virtual double GetLatency() { return 0.0; };
+
+  /*
     Adds packets to be sent out, this routine MUST block or sleep.
   */
   virtual unsigned int AddPackets(uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false) = 0;

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -47,21 +47,10 @@ public:
   virtual void Deinitialize() = 0;
 
   /*
-    Return true if the supplied format and device are compatible with the current open sink
-  */
-  virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device) = 0;
-
-  /*
     This method returns the time in seconds that it will take
     for the next added packet to be heard from the speakers.
   */
   virtual double GetDelay() = 0;
-
-  /*
-    This method returns the time in seconds that it will take
-    to underrun the cache if no sample is added.
-  */
-  virtual double GetCacheTime() = 0;
 
   /*
     This method returns the total time in seconds of the cache.

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -255,17 +255,6 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
   return true;
 }
 
-bool CAESinkALSA::IsCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  return (
-      /* compare against the requested format and the real format */
-      (m_initFormat.m_sampleRate    == format.m_sampleRate    || m_format.m_sampleRate    == format.m_sampleRate   ) &&
-      (m_initFormat.m_dataFormat    == format.m_dataFormat    || m_format.m_dataFormat    == format.m_dataFormat   ) &&
-      (m_initFormat.m_channelLayout == format.m_channelLayout || m_format.m_channelLayout == format.m_channelLayout) &&
-      (m_initDevice == device)
-  );
-}
-
 snd_pcm_format_t CAESinkALSA::AEFormatToALSAFormat(const enum AEDataFormat format)
 {
   if (AE_IS_RAW(format))
@@ -524,28 +513,6 @@ double CAESinkALSA::GetDelay()
   }
 
   return (double)frames * m_formatSampleRateMul;
-}
-
-double CAESinkALSA::GetCacheTime()
-{
-  if (!m_pcm)
-    return 0.0;
-
-  int space = snd_pcm_avail_update(m_pcm);
-  if (space == 0)
-  {
-    snd_pcm_state_t state = snd_pcm_state(m_pcm);
-    if (state < 0)
-    {
-      HandleError("snd_pcm_state", state);
-      space = m_bufferSize;
-    }
-
-    if (state != SND_PCM_STATE_RUNNING && state != SND_PCM_STATE_PREPARED)
-      space = m_bufferSize;
-  }
-
-  return (double)(m_bufferSize - space) * m_formatSampleRateMul;
 }
 
 double CAESinkALSA::GetCacheTotal()

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -41,11 +41,9 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
   virtual void         Stop            ();
   virtual double       GetDelay        ();
-  virtual double       GetCacheTime    ();
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   virtual void         Drain           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -166,11 +166,6 @@ void CAESinkAUDIOTRACK::Deinitialize()
   m_at_jni = NULL;
 }
 
-bool CAESinkAUDIOTRACK::IsCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  return m_lastFormat == format || m_format == format;
-}
-
 double CAESinkAUDIOTRACK::GetDelay()
 {
   if (!m_at_jni)
@@ -184,12 +179,6 @@ double CAESinkAUDIOTRACK::GetDelay()
   double delay = (double)(m_frames_written - head_pos) / m_format.m_sampleRate;
 
   return delay;
-}
-
-double CAESinkAUDIOTRACK::GetCacheTime()
-{
-  // depreciated, not used by ActiveAE
-  return 0;
 }
 
 double CAESinkAUDIOTRACK::GetCacheTotal()

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -39,10 +39,8 @@ public:
 
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
   virtual double       GetDelay        ();
-  virtual double       GetCacheTime    ();
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   virtual void         Drain           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -334,47 +334,6 @@ void CAESinkDirectSound::Deinitialize()
   m_dwBufferLen = 0;
 }
 
-bool CAESinkDirectSound::IsCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  if (!m_initialized || m_isDirtyDS)
-    return false;
-
-  u_int notCompatible         = 0;
-  const u_int numTests        = 6;
-  std::string strDiffBecause ("");
-  static const char* compatibleParams[numTests] = {":Devices",
-                                                   ":Channels",
-                                                   ":Sample Rates",
-                                                   ":Data Formats",
-                                                   ":Bluray Formats",
-                                                   ":Passthrough Formats"};
-
-  notCompatible = (notCompatible  +!((AE_IS_RAW(format.m_dataFormat)  == AE_IS_RAW(m_encodedFormat))        ||
-                                     (!AE_IS_RAW(format.m_dataFormat) == !AE_IS_RAW(m_encodedFormat))))     << 1;
-  notCompatible = (notCompatible  + ((format.m_dataFormat             == AE_FMT_EAC3)                       ||
-                                     (format.m_dataFormat             == AE_FMT_DTSHD                       ||
-                                     (format.m_dataFormat             == AE_FMT_TRUEHD))))                  << 1;
-  notCompatible = (notCompatible  + !(format.m_dataFormat             == m_format.m_dataFormat))            << 1;
-  notCompatible = (notCompatible  + !(format.m_sampleRate             == m_format.m_sampleRate))            << 1;
-  notCompatible = (notCompatible  + !(format.m_channelLayout.Count()  == m_format.m_channelLayout.Count())) << 1;
-  notCompatible = (notCompatible  + !(m_device                        == device));
-
-  if (!notCompatible)
-  {
-    CLog::Log(LOGDEBUG, __FUNCTION__": Formats compatible - reusing existing sink");
-    return true;
-  }
-
-  for (int i = 0; i < numTests ; i++)
-  {
-    strDiffBecause += (notCompatible & 0x01) ? (std::string) compatibleParams[i] : "";
-    notCompatible    = notCompatible >> 1;
-  }
-
-  CLog::Log(LOGDEBUG, __FUNCTION__": Formats Incompatible due to different %s", strDiffBecause.c_str());
-  return false;
-}
-
 unsigned int CAESinkDirectSound::AddPackets(uint8_t *data, unsigned int frames, bool hasAudio, bool blocking)
 {
   if (!m_initialized)
@@ -475,19 +434,6 @@ double CAESinkDirectSound::GetDelay()
   /* Make sure we know how much data is in the cache */
   if (!UpdateCacheStatus())
     m_isDirtyDS = true;
-
-  /** returns current cached data duration in seconds */
-  double delay = (double)m_CacheLen / (double)m_AvgBytesPerSec;
-  return delay;
-}
-
-double CAESinkDirectSound::GetCacheTime()
-{
-  if (!m_initialized)
-    return 0.0;
-
-  /* Make sure we know how much data is in the cache */
-  UpdateCacheStatus();
 
   /** returns current cached data duration in seconds */
   double delay = (double)m_CacheLen / (double)m_AvgBytesPerSec;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -36,12 +36,10 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
   virtual void         Stop               ();
   virtual void         Drain              ();
   virtual double       GetDelay           ();
-  virtual double       GetCacheTime       ();
   virtual double       GetCacheTotal      ();
   virtual unsigned int AddPackets         (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   static  std::string  GetDefaultDevice   ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
@@ -75,20 +75,7 @@ void CAESinkNULL::Deinitialize()
   StopThread();
 }
 
-bool CAESinkNULL::IsCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  return ((m_format.m_sampleRate    == format.m_sampleRate) &&
-          (m_format.m_dataFormat    == format.m_dataFormat) &&
-          (m_format.m_channelLayout == format.m_channelLayout));
-}
-
 double CAESinkNULL::GetDelay()
-{
-  double sinkbuffer_seconds_to_empty = m_sinkbuffer_sec_per_byte * (double)m_sinkbuffer_level;
-  return sinkbuffer_seconds_to_empty;
-}
-
-double CAESinkNULL::GetCacheTime()
 {
   double sinkbuffer_seconds_to_empty = m_sinkbuffer_sec_per_byte * (double)m_sinkbuffer_level;
   return sinkbuffer_seconds_to_empty;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
@@ -33,10 +33,8 @@ public:
 
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
   virtual double       GetDelay        ();
-  virtual double       GetCacheTime    ();
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   virtual void         Drain           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -374,19 +374,6 @@ inline CAEChannelInfo CAESinkOSS::GetChannelLayout(AEAudioFormat format)
   return info;
 }
 
-bool CAESinkOSS::IsCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  AEAudioFormat tmp  = format;
-  tmp.m_channelLayout = GetChannelLayout(format);
-
-  return (
-    tmp.m_sampleRate    == m_initFormat.m_sampleRate    &&
-    tmp.m_dataFormat    == m_initFormat.m_dataFormat    &&
-    tmp.m_channelLayout == m_initFormat.m_channelLayout &&
-    GetDeviceUse(tmp, device) == m_device
-  );
-}
-
 void CAESinkOSS::Stop()
 {
 #ifdef SNDCTL_DSP_RESET

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
@@ -35,11 +35,9 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
   virtual void         Stop            ();
   virtual double       GetDelay        ();
-  virtual double       GetCacheTime    () { return 0.0; } /* FIXME */
   virtual double       GetCacheTotal   () { return 0.0; } /* FIXME */
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   virtual void         Drain           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.cpp
@@ -55,17 +55,6 @@ void CAESinkProfiler::Deinitialize()
 {
 }
 
-bool CAESinkProfiler::IsCompatible(const AEAudioFormat &format, const std::string &device)
-{
-  if (AE_IS_RAW(format.m_dataFormat))
-    return false;
-
-  if (format.m_dataFormat != AE_FMT_FLOAT)
-    return false;
-
-  return true;
-}
-
 double CAESinkProfiler::GetDelay()
 {
   return 0.0f;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.h
@@ -34,10 +34,8 @@ public:
 
   virtual bool Initialize  (AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
-  virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
   virtual double       GetDelay        ();
-  virtual double       GetCacheTime    () { return 0.0; }
   virtual double       GetCacheTotal   () { return 0.0; }
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   virtual void         Drain           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -37,10 +37,8 @@ public:
 
     virtual bool Initialize  (AEAudioFormat &format, std::string &device);
     virtual void Deinitialize();
-    virtual bool IsCompatible(const AEAudioFormat &format, const std::string &device);
 
     virtual double       GetDelay                    ();
-    virtual double       GetCacheTime                ();
     virtual double       GetCacheTotal               ();
     virtual unsigned int AddPackets                  (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
     virtual void         Drain                       ();


### PR DESCRIPTION
- drops useless and wrong method IsCompatible
- clean-up interface for sink
- add latency parameter for sinks, needed for audiotrack

should go in with https://github.com/xbmc/xbmc/pull/3814. the additional latency may not work with the old calculation in paplayer
@t-nelson could you test this on audiotrack? 
