### PR TITLE
[pvr] show gaps on epg timeline grid

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -628,7 +628,7 @@ bool CEpg::FixOverlappingEvents(bool bUpdateDb /* = false */)
       it->second->ClearTimer();
       m_tags.erase(it++);
     }
-    else if (previousTag->EndAsUTC() != currentTag->StartAsUTC())
+    else if (previousTag->EndAsUTC() > currentTag->StartAsUTC())
     {
       previousTag->SetEndFromUTC(currentTag->StartAsUTC());
       if (bUpdateDb)

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -961,22 +961,25 @@ void CGUIEPGGridContainer::UpdateItems()
 
     for (int block = 0; block < m_blocks; block++)
     {
-      if (m_gridIndex[row][block].item != m_gridIndex[row][block+1].item)
+      CGUIListItemPtr item = m_gridIndex[row][block].item;
+
+      if (item != m_gridIndex[row][block+1].item)
       {
-        if (!m_gridIndex[row][block].item)
+        if (!item)
         {
-          CEpgInfoTag broadcast;
-          CFileItemPtr unknown(new CFileItem(broadcast));
+          CEpgInfoTag gapTag;
+          CFileItemPtr gapItem(new CFileItem(gapTag));
           for (int i = block ; i > block - itemSize; i--)
           {
-            m_gridIndex[row][i].item = unknown;
+            m_gridIndex[row][i].item = gapItem;
           }
         }
+        else
+        {
+          const CEpgInfoTag* tag = ((CFileItem *)item.get())->GetEPGInfoTag();
+          m_gridIndex[row][savedBlock].item->SetProperty("GenreType", tag->GenreType());
+        }
 
-        CGUIListItemPtr item = m_gridIndex[row][block].item;
-        CFileItem *fileItem = (CFileItem *)item.get();
-
-        m_gridIndex[row][savedBlock].item->SetProperty("GenreType", fileItem->GetEPGInfoTag()->GenreType());
         if (m_orientation == VERTICAL)
         {
           m_gridIndex[row][savedBlock].width   = itemSize*m_blockSize;


### PR DESCRIPTION
This shows gaps between programmes on EPG timeline if previous programme end time less than current one start time. In other cases end time modified only (wrt explanations given by @janbar in #3111).
Genre doesn't set for the gap items to show them as an empty space between programmes.
The additional info can be found on thread http://forum.xbmc.org/showthread.php?tid=177880
