### PR TITLE
[sorting] don't apply airdate when sorting by year if airdate is empty.

### DIFF
--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -195,7 +195,7 @@ string ByYear(SortAttribute attributes, const SortItem &values)
 {
   CStdString label;
   const CVariant &airDate = values.at(FieldAirDate);
-  if (!airDate.isNull())
+  if (!airDate.isNull() && !airDate.asString().empty())
     label = airDate.asString() + " ";
 
   label += StringUtils::Format("%i %s", (int)values.at(FieldYear).asInteger(), ByLabel(attributes, values).c_str());


### PR DESCRIPTION
Fixes #14276.

@Montellese: anything I'm missing (alternate would be to not fill the field in ToSortable, given we null check for it).
