### PR TITLE
fixed xbmc.python version for Gotham alpha10

### DIFF
--- a/addons/script.module.pil/addon.xml
+++ b/addons/script.module.pil/addon.xml
@@ -4,7 +4,7 @@
        version="1.1.7"
        provider-name="PythonWare">
   <requires>
-    <import addon="xbmc.python" version="2.0.0"/>
+    <import addon="xbmc.python" version="2.1.0"/>
   </requires>
   <extension point="xbmc.python.module"
              library="lib" />


### PR DESCRIPTION
set xbmc.python to version 2.1.0 now gotham alpha10
with this fix and my fix on cdartmanager git, you can install and use cdartmanager on gotham alpha10
