### PR TITLE
workaround: endless loop in win32 when a python screensaver is called during minimize.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5129,6 +5129,12 @@ void CApplication::ProcessSlow()
     CAddonInstaller::Get().UpdateRepos();
 
   CAEFactory::GarbageCollect();
+
+  // if we don't render the gui there's no reason to start the screensaver.
+  // that way the screensaver won't kick in if we maximize the XBMC window
+  // after the screensaver start time.
+  if(!m_renderGUI)
+    ResetScreenSaverTimer();
 }
 
 // Global Idle Time in Seconds


### PR DESCRIPTION
This addresses the issue mentioned here: http://forum.xbmc.org/showthread.php?tid=170462
Unfortunately it doesn't fix the issue itself (need someone with gui knowledge here) but on the other hand I see no reason to run the screensaver when minimized.
