### PR TITLE
[gui] angled labels didn't calculate the appropriate dirty region. 

### DIFF
--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -170,10 +170,11 @@ public:
   bool UpdateColors();
   
   /*! \brief Returns the precalculated final layout of the current text
+   \param withRotation if true, applies the rotation transform to the render rect. Defaults to false.
    \return CRect containing the extents of the current text
    \sa SetRenderRect, UpdateRenderRect
    */
-  const CRect &GetRenderRect() const { return m_renderRect; };
+  const CRect &GetRenderRect(bool withRotation = false) const;
   
   /*! \brief Returns the precalculated full width of the current text, regardless of layout
    \return full width of the current text
@@ -239,6 +240,7 @@ private:
   bool           m_selected;
   CScrollInfo    m_scrollInfo;
   CRect          m_renderRect;   ///< actual sizing of text
+  CRect          m_rotatedRect;  ///< rotated rect of text (if m_label.angle is non-zero)
   CRect          m_maxRect;      ///< maximum sizing of text
   bool           m_invalid;      ///< if true, the label needs recomputing
   COLOR          m_color;        ///< color to render text \sa SetColor, GetColor

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -192,7 +192,7 @@ void CGUILabelControl::Process(unsigned int currentTime, CDirtyRegionList &dirty
 
 CRect CGUILabelControl::CalcRenderRegion() const
 {
-  return m_label.GetRenderRect();
+  return m_label.GetRenderRect(true);
 }
 
 void CGUILabelControl::Render()

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -61,7 +61,7 @@ void CGUIListLabel::SetFocus(bool focus)
 
 CRect CGUIListLabel::CalcRenderRegion() const
 {
-  return m_label.GetRenderRect();
+  return m_label.GetRenderRect(true);
 }
 
 bool CGUIListLabel::UpdateColors()


### PR DESCRIPTION
This is quite ugly, but fixes a bug with DR mode 1.

Ideally the <angle> facility would be removed post-Gotham.  I don't believe there is any need for it as the rotatez animation should be able to accomplish the same thing, whereby this would automatically be taken care of.

Fixes #14242.

@ronie: Any idea if `<angle>` goes (post-Gotham) whether it would be missed?
