### PR TITLE
Ensure we invalidate items when updating them

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1477,12 +1477,18 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
     if (HasPVRRecordingInfoTag())
       GetPVRRecordingInfoTag()->CopyClientInfo(GetVideoInfoTag());
     SetOverlayImage(ICON_OVERLAY_UNWATCHED, GetVideoInfoTag()->m_playCount > 0);
+    SetInvalid();
   }
   if (item.HasMusicInfoTag())
+  {
     *GetMusicInfoTag() = *item.GetMusicInfoTag();
+    SetInvalid();
+  }
   if (item.HasPictureInfoTag())
+  {
     *GetPictureInfoTag() = *item.GetPictureInfoTag();
-
+    SetInvalid();
+  }
   if (replaceLabels && !item.GetLabel().empty())
     SetLabel(item.GetLabel());
   if (replaceLabels && !item.GetLabel2().empty())

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -327,6 +327,7 @@ void CGUIListItem::Archive(CArchive &ar)
       ar >> value;
       m_artFallbacks.insert(make_pair(key, value));
     }
+    SetInvalid();
   }
 }
 void CGUIListItem::Serialize(CVariant &value)
@@ -400,7 +401,17 @@ void CGUIListItem::SetInvalid()
 
 void CGUIListItem::SetProperty(const CStdString &strKey, const CVariant &value)
 {
-  m_mapProperties[strKey] = value;
+  PropertyMap::iterator iter = m_mapProperties.find(strKey);
+  if (iter == m_mapProperties.end())
+  {
+    m_mapProperties.insert(make_pair(strKey, value));
+    SetInvalid();
+  }
+  else if (iter->second != value)
+  {
+    iter->second = value;
+    SetInvalid();
+  }
 }
 
 CVariant CGUIListItem::GetProperty(const CStdString &strKey) const
@@ -425,12 +436,19 @@ void CGUIListItem::ClearProperty(const CStdString &strKey)
 {
   PropertyMap::iterator iter = m_mapProperties.find(strKey);
   if (iter != m_mapProperties.end())
+  {
     m_mapProperties.erase(iter);
+    SetInvalid();
+  }
 }
 
 void CGUIListItem::ClearProperties()
 {
-  m_mapProperties.clear();
+  if (!m_mapProperties.empty())
+  {
+    m_mapProperties.clear();
+    SetInvalid();
+  }
 }
 
 void CGUIListItem::IncrementProperty(const CStdString &strKey, int nVal)

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -95,6 +95,7 @@ public:
 
   CVariant &operator=(const CVariant &rhs);
   bool operator==(const CVariant &rhs) const;
+  bool operator!=(const CVariant &rhs) const { return !(*this == rhs); }
 
   void push_back(const CVariant &variant);
   void append(const CVariant &variant);


### PR DESCRIPTION
This handles Set/ClearProperty() and UpdateInfo().

Fixes #14742.

@Montellese - I presume you're OK with the CVariant change?  (Compiler doesn't generate these ofc).
