### PR TITLE
[RFC] changed: set background mode when minimized. prevents screen saver to kick in.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5130,11 +5130,6 @@ void CApplication::ProcessSlow()
 
   CAEFactory::GarbageCollect();
 
-  // if we don't render the gui there's no reason to start the screensaver.
-  // that way the screensaver won't kick in if we maximize the XBMC window
-  // after the screensaver start time.
-  if(!m_renderGUI)
-    ResetScreenSaverTimer();
 }
 
 // Global Idle Time in Seconds

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -473,7 +473,10 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           }
         }
         if (g_application.GetRenderGUI() != active)
+        {
           g_Windowing.NotifyAppActiveChange(g_application.GetRenderGUI());
+          g_application.SetInBackground(!g_application.GetRenderGUI());
+        }
         CLog::Log(LOGDEBUG, __FUNCTION__"Window is %s", g_application.GetRenderGUI() ? "active" : "inactive");
       }
       break;


### PR DESCRIPTION
Thats another approach to avoid another if statement. This is windows only and uses SetInBackground() which seems to be used only by ios. If m_bInBackground is true it prevents the screen saver and dpms to kick in.
Usable or is the former solution better suited?
