### PR TITLE
FIX: TAB 3D fixup for ios & libstagefright

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -580,10 +580,21 @@ void CBaseRenderer::ManageDisplay()
   switch(stereo_mode)
   {
     case CONF_FLAGS_STEREO_MODE_TAB:
-      if     (stereo_view == RENDER_STEREO_VIEW_LEFT)
-        m_sourceRect.y2 *= 0.5f;
-      else if(stereo_view == RENDER_STEREO_VIEW_RIGHT)
-        m_sourceRect.y1 += m_sourceRect.y2*0.5f;
+      // Those are flipped in y
+      if (m_format == RENDER_FMT_CVBREF || m_format == RENDER_FMT_EGLIMG || m_format == RENDER_FMT_MEDIACODEC)
+      {
+        if (stereo_view == RENDER_STEREO_VIEW_LEFT)
+          m_sourceRect.y1 += m_sourceRect.y2*0.5f;
+        else if(stereo_view == RENDER_STEREO_VIEW_RIGHT)
+          m_sourceRect.y2 *= 0.5f;
+      }
+      else
+      {
+        if (stereo_view == RENDER_STEREO_VIEW_LEFT)
+          m_sourceRect.y2 *= 0.5f;
+        else if(stereo_view == RENDER_STEREO_VIEW_RIGHT)
+          m_sourceRect.y1 += m_sourceRect.y2*0.5f;
+      }
       break;
 
     case CONF_FLAGS_STEREO_MODE_SBS:

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -140,6 +140,7 @@ protected:
 
   // rendering flags
   unsigned m_iFlags;
+  ERenderFormat m_format;
 
   const void* m_RenderUpdateCallBackCtx;
   RenderUpdateCallBackFn m_RenderUpdateCallBackFn;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -238,7 +238,6 @@ protected:
   bool m_bValidated;
   std::vector<ERenderFormat> m_formats;
   bool m_bImageReady;
-  ERenderFormat m_format;
   GLenum m_textureTarget;
   unsigned short m_renderMethod;
   RenderQuality m_renderQuality;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -233,7 +233,6 @@ protected:
   bool m_bValidated;
   std::vector<ERenderFormat> m_formats;
   bool m_bImageReady;
-  ERenderFormat m_format;
   GLenum m_textureTarget;
   unsigned short m_renderMethod;
   unsigned short m_oldRenderMethod;

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -235,7 +235,6 @@ protected:
 
   // clear colour for "black" bars
   DWORD                m_clearColour;
-  ERenderFormat        m_format;
   unsigned int         m_extended_format;
 
   // Width and height of the render target


### PR DESCRIPTION
@Memphiz There was still an issue in Top-Bottom: As our frames are flipped in y, the left and right eyed were inverted.
Could you retest in top-bottom with ios, please.

@elupus  ok for you?
