### PR TITLE
[pvr] fix: hide loading pvr data progress dialog if error occured in pvr clients

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -285,6 +285,8 @@ void CPVRManager::Cleanup(void)
     delete m_pendingUpdates.at(iJobPtr);
   m_pendingUpdates.clear();
 
+  HideProgressDialog();
+
   SetState(ManagerStateStopped);
 }
 


### PR DESCRIPTION
When pvr manager starts it tries to load data from pvr clients. If one of the connected clients fails to load data, pvr manager performs cleanup actions and unloads all of the clients. But progress window which appeared when loading data remains open. This fix closes the window on pvr manager cleanup.
