### PR TITLE
Add volume amplification (a.k.a. dynamic range compression) to pulseaudio backend

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.h
@@ -24,6 +24,7 @@
 #include "Interfaces/AEStream.h"
 #include "threads/Thread.h"
 #include <pulse/pulseaudio.h>
+#include "cores/AudioEngine/Utils/AELimiter.h"
 
 class CPulseAEStream : public IAEStream
 {
@@ -53,10 +54,10 @@ public:
 
   virtual float GetVolume    ();
   virtual float GetReplayGain();
-  virtual float GetAmplification() { return 1.0f; }
+  virtual float GetAmplification() { return m_limiter.GetAmplification(); }
   virtual void  SetVolume    (float volume);
   virtual void  SetReplayGain(float factor);
-  virtual void  SetAmplification(float amplify){}
+  virtual void  SetAmplification(float amplify){ m_limiter.SetAmplification(amplify); }
   void SetMute(const bool muted);
 
   virtual const unsigned int      GetFrameSize   () const;
@@ -116,9 +117,11 @@ private:
   enum AEDataFormat m_format;
   unsigned int      m_sampleRate;
   CAEChannelInfo    m_channelLayout;
+  unsigned int      m_channels;
   unsigned int m_options;
   unsigned int m_frameSize;
   unsigned int m_cacheSize;
+  CAELimiter        m_limiter;       /* volume amplification/limiter*/
 
   pa_operation *m_DrainOperation;
   IAEStream    *m_slave;


### PR DESCRIPTION
Currently the pulseaudio backend doesn't support volume amplification (or dynamic range compression).  This patch fixes that.

I have tested the patch and changing the volume amplification in the gui does now work with the pulseaudio backend, but there are still a couple of things that should be looked at:
- I'm currently allocating a new buffer, copying the current data to the new buffer, changing it, sending it to pulseaudio, and then freeing it.  Attempting to modify the data in-place is causing a segfault and I'm not sure why.
- I've copied the #ifdef **SSE_** line directly from the CoreAudio backend; it is untested.
