### PR TITLE
[pvr] refactor advanced setting showepginfoonselect to setting

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -14705,7 +14705,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36424"
-msgid "No description available"
+msgid "Select what will happen when an EPG item is selected: [Show context menu] will trigger the contextual menu from where you can choose further actions; [Switch to channel] will instantly tune to the related channel; [Show information] will display a detailed information with plot and further options; [Record] will create a recording timer for the selected item."
 msgstr ""
 
 #: system/settings/settings.xml

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -14703,7 +14703,32 @@ msgctxt "#36423"
 msgid "Use ffmpeg frame multiple thread decoding when hardware decoding not working or disabled. (less reliable than default single thread mode)"
 msgstr ""
 
-#empty strings from id 36424 to 36499
+#: system/settings/settings.xml
+msgctxt "#36424"
+msgid "No description available"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#36425"
+msgid "Show context menu"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#36426"
+msgid "Switch to channel"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#36427"
+msgid "Show information"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#36428"
+msgid "Record"
+msgstr ""
+
+#empty strings from id 36429 to 36499
 #end reservation
 
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1027,7 +1027,7 @@
         </setting>
         <setting id="epg.selectaction" type="integer" label="22079" help="36424">
           <level>1</level>
-          <default>0</default> <!-- EPG_SELECT_ACTION_CONTEXT_MENU -->
+          <default>2</default> <!-- EPG_SELECT_ACTION_INFO -->
           <constraints>
             <options>
               <option label="36425">0</option> <!-- EPG_SELECT_ACTION_CONTEXT_MENU -->

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1025,6 +1025,19 @@
             <formatlabel>14044</formatlabel>
           </control>
         </setting>
+        <setting id="epg.selectaction" type="integer" label="22079" help="36424">
+          <level>1</level>
+          <default>0</default> <!-- EPG_SELECT_ACTION_CONTEXT_MENU -->
+          <constraints>
+            <options>
+              <option label="36425">0</option> <!-- EPG_SELECT_ACTION_CONTEXT_MENU -->
+              <option label="36426">1</option> <!-- EPG_SELECT_ACTION_SWITCH -->
+              <option label="36427">2</option> <!-- EPG_SELECT_ACTION_INFO -->
+              <option label="36428">3</option> <!-- EPG_SELECT_ACTION_RECORD -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
         <setting id="epg.preventupdateswhileplayingtv" type="boolean" label="19230" help="36222">
           <level>1</level>
           <default>false</default>

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.h
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.h
@@ -38,6 +38,14 @@ namespace PVR
     PVR_WINDOW_SEARCH          = 6
   };
 
+  enum EPGSelectAction
+  {
+    EPG_SELECT_ACTION_CONTEXT_MENU    = 0,
+    EPG_SELECT_ACTION_SWITCH          = 1,
+    EPG_SELECT_ACTION_INFO            = 2,
+    EPG_SELECT_ACTION_RECORD          = 3
+  };
+
   #define CONTROL_LIST_TIMELINE        10
   #define CONTROL_LIST_CHANNELS_TV     11
   #define CONTROL_LIST_CHANNELS_RADIO  12

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -87,6 +87,8 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
     return;
   CFileItemPtr pItem = m_parent->m_vecItems->Get(itemNumber);
 
+  buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 19000);         /* switch channel */
+
   CFileItemPtr timer = g_PVRTimers->GetTimerForEpgTag(pItem.get());
   if (timer && timer->HasPVRTimerInfoTag())
   {
@@ -104,14 +106,15 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
   }
 
   buttons.Add(CONTEXT_BUTTON_INFO, 19047);              /* epg info */
-  buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 19000);         /* switch channel */
   buttons.Add(CONTEXT_BUTTON_FIND, 19003);              /* find similar program */
+
   if (m_iGuideView == GUIDE_VIEW_TIMELINE)
   {
     buttons.Add(CONTEXT_BUTTON_BEGIN, 19063);           /* go to begin */
     buttons.Add(CONTEXT_BUTTON_NOW, 19070);             /* go to now */
     buttons.Add(CONTEXT_BUTTON_END, 19064);             /* go to end */
   }
+
   if (pItem->GetEPGInfoTag()->HasPVRChannel() &&
       g_PVRClients->HasMenuHooks(pItem->GetEPGInfoTag()->ChannelTag()->ClientID(), PVR_MENUHOOK_EPG))
     buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);      /* PVR client specific action */

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -369,10 +369,21 @@ bool CGUIWindowPVRGuide::OnClickList(CGUIMessage &message)
     {
       case ACTION_SELECT_ITEM:
       case ACTION_MOUSE_LEFT_CLICK:
-        if (!g_advancedSettings.m_bPVRShowEpgInfoOnEpgItemSelect && pItem->GetEPGInfoTag()->IsActive())
-          ActionPlayEpg(pItem.get());
-        else
-          ShowEPGInfo(pItem.get());
+        switch(CSettings::Get().GetInt("epg.selectaction"))
+        {
+          case EPG_SELECT_ACTION_CONTEXT_MENU:
+            m_parent->OnPopupMenu(iItem);
+            break;
+          case EPG_SELECT_ACTION_SWITCH:
+            ActionPlayEpg(pItem.get());
+            break;
+          case EPG_SELECT_ACTION_INFO:
+            ShowEPGInfo(pItem.get());
+            break;
+          case EPG_SELECT_ACTION_RECORD:
+            ActionRecord(pItem.get());
+            break;
+        }
         break;
       case ACTION_SHOW_INFO:
         ShowEPGInfo(pItem.get());

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -361,7 +361,6 @@ void CAdvancedSettings::Initialize()
 
   m_iPVRTimeCorrection             = 0;
   m_iPVRInfoToggleInterval         = 3000;
-  m_bPVRShowEpgInfoOnEpgItemSelect = false;
   m_iPVRMinVideoCacheLevel         = 5;
   m_iPVRMinAudioCacheLevel         = 10;
   m_bPVRCacheInDvdPlayer           = true;
@@ -1096,7 +1095,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   {
     XMLUtils::GetInt(pPVR, "timecorrection", m_iPVRTimeCorrection, 0, 1440);
     XMLUtils::GetInt(pPVR, "infotoggleinterval", m_iPVRInfoToggleInterval, 0, 30000);
-    XMLUtils::GetBoolean(pPVR, "showepginfoonselect", m_bPVRShowEpgInfoOnEpgItemSelect);
     XMLUtils::GetInt(pPVR, "minvideocachelevel", m_iPVRMinVideoCacheLevel, 0, 100);
     XMLUtils::GetInt(pPVR, "minaudiocachelevel", m_iPVRMinAudioCacheLevel, 0, 100);
     XMLUtils::GetBoolean(pPVR, "cacheindvdplayer", m_bPVRCacheInDvdPlayer);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -358,7 +358,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     /* PVR/TV related advanced settings */
     int m_iPVRTimeCorrection;     /*!< @brief correct all times (epg tags, timer tags, recording tags) by this amount of minutes. defaults to 0. */
     int m_iPVRInfoToggleInterval; /*!< @brief if there are more than 1 pvr gui info item available (e.g. multiple recordings active at the same time), use this toggle delay in milliseconds. defaults to 3000. */
-    bool m_bPVRShowEpgInfoOnEpgItemSelect; /*!< @brief when selecting an EPG fileitem, show the EPG info dialog if this setting is true. start playback on the selected channel if false AND fileitem has started */
     int m_iPVRMinVideoCacheLevel;      /*!< @brief cache up to this level in the video buffer buffer before resuming playback if the buffers run dry */
     int m_iPVRMinAudioCacheLevel;      /*!< @brief cache up to this level in the audio buffer before resuming playback if the buffers run dry */
     bool m_bPVRCacheInDvdPlayer; /*!< @brief true to use "CACHESTATE_PVR" in CDVDPlayer (default) */


### PR DESCRIPTION
This removes the advanced setting showepginfoonselect and adds it to settings, so users can change it within the gui. In addition, the setting is extended and you can now select the following values:
- Show context menu
- Switch to channel
- Show information
- Record
