### PR TITLE
dvdpalyer audio: fix delivering the packet in wrong format

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -117,6 +117,9 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_pFrame1 = m_dllAvCodec.avcodec_alloc_frame();
   m_bOpenedCodec = true;
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
+
+  // check if conversion is needed
+  GetDataFormat();
   return true;
 }
 


### PR DESCRIPTION
dvdplayer delivered the first audio packet unconverted. with some codecs like ADPCM this killed the order of bytes of the stream delivered to AE which led to crackling sound.
fixes trac: http://trac.xbmc.org/ticket/14771
