### PR TITLE
[rbp/omxplayer] Cosmetic: Avoid DVDPlayer in logging message

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -666,7 +666,7 @@ bool COMXPlayer::CloseFile(bool reopen)
   m_HasVideo = false;
   m_HasAudio = false;
 
-  CLog::Log(LOGNOTICE, "DVDPlayer: finished waiting");
+  CLog::Log(LOGNOTICE, "COMXPlayer: finished waiting");
 #if defined(HAS_VIDEO_PLAYBACK)
   g_renderManager.UnInit();
 #endif


### PR DESCRIPTION
It makes people incorrectly think DVDPlayer has been running
