### PR TITLE
[rbp] Remove 720p GUI limit by default

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -14920,6 +14920,11 @@ msgctxt "#36546"
 msgid "Sets the visual depth of subtitles for stereoscopic videos. The higher the value, the closer the subtitles will appear to the viewer."
 msgstr ""
 
+#: system/settings/rbp.xml
+msgctxt "#36547"
+msgid "Use higher quality textures for covers and fanart (uses more memory)"
+msgstr ""
+
 #empty strings from id 36547 to 36999
 #reserved strings 365XX
 
@@ -14983,4 +14988,8 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#37019"
 msgid "Enables system keys like printscreen, alt-tab and volume keys when in fullscreen"
+
+#: system/settings/rbp.xml
+msgctxt "#37020"
+msgid "Enable higher colour depth artwork"
 msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -14925,6 +14925,11 @@ msgctxt "#36547"
 msgid "Use higher quality textures for covers and fanart (uses more memory)"
 msgstr ""
 
+#: system/settings/rbp.xml
+msgctxt "#36548"
+msgid "Limits resolution of GUI to save memory. Does not affect video playback. Use 1080 for unlimited. Requires restart."
+msgstr ""
+
 #empty strings from id 36547 to 36999
 #reserved strings 365XX
 
@@ -14992,4 +14997,9 @@ msgid "Enables system keys like printscreen, alt-tab and volume keys when in ful
 #: system/settings/rbp.xml
 msgctxt "#37020"
 msgid "Enable higher colour depth artwork"
+msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#37021"
+msgid "Set GUI resolution limit"
 msgstr ""

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -31,6 +31,11 @@
         <setting id="videoscreen.fakefullscreen">
           <visible>false</visible>
         </setting>
+        <setting id="videoscreen.textures32" type="boolean" label="37020" help="36547">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="3">
         <setting id="videoscreen.vsync">

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -36,6 +36,16 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoscreen.limitgui" type="integer" label="37021" help="36548">
+          <level>2</level>
+          <default>1080</default>
+          <constraints>
+            <minimum>540</minimum>
+            <step>16</step>
+            <maximum>1080</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
       </group>
       <group id="3">
         <setting id="videoscreen.vsync">

--- a/xbmc/cores/omxplayer/OMXImage.cpp
+++ b/xbmc/cores/omxplayer/OMXImage.cpp
@@ -206,7 +206,8 @@ void COMXImage::AllocTextureInternal(struct textureinfo *tex)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, tex->width, tex->height, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, 0);
+  GLenum type = CSettings::Get().GetBool("videoscreen.textures32") ? GL_UNSIGNED_BYTE:GL_UNSIGNED_SHORT_5_6_5;
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, tex->width, tex->height, 0, GL_RGB, type, 0);
   tex->egl_image = eglCreateImageKHR(m_egl_display, m_egl_context, EGL_GL_TEXTURE_2D_KHR, (EGLClientBuffer)tex->texture, NULL);
   tex->sync.Set();
   GLint m_result;

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -25,6 +25,7 @@
 #include "guilib/gui3d.h"
 #include "linux/DllBCM.h"
 #include "utils/StringUtils.h"
+#include "settings/Settings.h"
 
 #ifndef __VIDEOCORE4__
 #define __VIDEOCORE4__
@@ -354,19 +355,24 @@ static float get_display_aspect_ratio(SDTV_ASPECT_T aspect)
 
 static bool ClampToGUIDisplayLimits(int &width, int &height)
 {
-  const int max_width = 1280, max_height = 720;
+  float max_height = (float)CSettings::Get().GetInt("videoscreen.limitgui");
+  float default_ar = 16.0f/9.0f;
+  if (max_height < 540.0f || max_height > 1080.0f)
+    max_height = 1080.0f;
+
   float ar = (float)width/(float)height;
+  float max_width = max_height * default_ar;
   // bigger than maximum, so need to clamp
   if (width > max_width || height > max_height) {
     // wider than max, so clamp width first
-    if (ar > (float)max_width/(float)max_height)
+    if (ar > default_ar)
     {
       width = max_width;
-      height = (float)max_width / ar + 0.5f;
+      height = max_width / ar + 0.5f;
     // taller than max, so clamp height first
     } else {
       height = max_height;
-      width = (float)max_height * ar + 0.5f;
+      width = max_height * ar + 0.5f;
     }
     return true;
   }


### PR DESCRIPTION
The initial Pi port of xbmc limited the GUI to 720p.
This was mainly to save memory, although it has a small effect on performance.

Since the recent "speed" commits the performance is much better, and also the memory usage is much lower.
This was due to:
  ARM never owns pixel buffers of textures
  GPU doesn't require whole frames of decoded jpegs as it decodes/converts in stripes
  GPU artwork textures are stored as 16-bit

So, this commit allows the GUI resolution to specified in settings, and it defaults to 1080p.
I've also added a switch to allow the artwork textures be 32bit. This improves artwork quality, with some memory cost, but is viable on 512M devices.
