### PR TITLE
Libnfs 1.8.0 Version Bump, needs help from platform devs.

### DIFF
--- a/lib/libnfs/Makefile
+++ b/lib/libnfs/Makefile
@@ -6,10 +6,10 @@
 
 # lib name, version
 LIBNAME=libnfs
-VERSION=1.3.0
+VERSION=1.8.0
 SOURCE=$(LIBNAME)-$(VERSION)
 # download location and format
-BASE_URL=http://mirrors.xbmc.org/build-deps/darwin-libs
+BASE_URL=https://sites.google.com/site/libnfstarballs/li
 ARCHIVE=$(SOURCE).tar.gz
 TARBALLS_LOCATION=.
 RETRIEVE_TOOL=/usr/bin/curl


### PR DESCRIPTION
We need to think about why after nearly a year Linux has no libnfs love, while Windows and everyone else already at version 1.6.1

This is a partial PR to maybe show the improvements that long overdue into making this jump.

I realize more code is required into the compile and makefiles.

Please help with those guys where possible.

Thank you.
