### PR TITLE
[pvr] refactor lingertime from advanced settings to settings

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -13693,7 +13693,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36220"
-msgid "Number of days of EPG data to import from backends. Defaults to 2 days."
+msgid "Number of days of EPG data to import from backends. Defaults to 3 days."
 msgstr ""
 
 #: system/settings/settings.xml

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7180,7 +7180,12 @@ msgctxt "#17999"
 msgid "%i days"
 msgstr ""
 
-#empty strings from id 18000 to 18999
+#: system/settings/settings.xml
+msgctxt "#18000"
+msgid "%i day"
+msgstr ""
+
+#empty strings from id 18001 to 18999
 
 msgctxt "#19000"
 msgid "Switch to channel"
@@ -7931,7 +7936,10 @@ msgctxt "#19182"
 msgid "Days to display in the EPG"
 msgstr ""
 
-#empty string with id 19183
+#: system/settings/settings.xml
+msgctxt "#19183"
+msgid "Past days to display in the EPG"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#19184"
@@ -14728,7 +14736,11 @@ msgctxt "#36428"
 msgid "Record"
 msgstr ""
 
-#empty strings from id 36429 to 36499
+msgctxt "#36429"
+msgid "Number of past days of EPG data to import from backends. Defaults to 1 day."
+msgstr ""
+
+#empty strings from id 36430 to 36499
 #end reservation
 
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1011,6 +1011,14 @@
             <formatlabel>17999</formatlabel>
           </control>
         </setting>
+        <setting id="epg.pastdaystodisplay" type="integer" label="19183" help="36429">
+          <level>1</level>
+          <default>1</default>
+          <constraints>
+            <options>pvrepgpastdaystodisplay</options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
       </group>
       <group id="2">
         <setting id="epg.epgupdate" type="integer" label="19071" help="36221">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1003,13 +1003,9 @@
           <level>1</level>
           <default>3</default>
           <constraints>
-            <minimum>1</minimum>
-            <step>1</step>
-            <maximum>14</maximum>
+            <options>pvrepgdaystodisplay</options>
           </constraints>
-          <control type="spinner" format="string">
-            <formatlabel>17999</formatlabel>
-          </control>
+          <control type="spinner" format="string" />
         </setting>
         <setting id="epg.pastdaystodisplay" type="integer" label="19183" help="36429">
           <level>1</level>

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -163,7 +163,7 @@ void CEpg::Clear(void)
 void CEpg::Cleanup(void)
 {
   CDateTime cleanupTime = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() -
-      CDateTimeSpan(0, g_advancedSettings.m_iEpgLingerTime / 60, g_advancedSettings.m_iEpgLingerTime % 60, 0);
+      CDateTimeSpan(CSettings::Get().GetInt("epg.pastdaystodisplay"), 0, 0, 0);
   Cleanup(cleanupTime);
 }
 

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -269,7 +269,8 @@ namespace EPG
     /** @name Configuration */
     //@{
     bool         m_bIgnoreDbForClient; /*!< don't save the EPG data in the database */
-    int          m_iDisplayTime;       /*!< hours of EPG data to fetch */
+    int          m_iDisplayTime;       /*!< seconds of EPG data to fetch */
+    int          m_iPastDisplayTime;   /*!< seconds of past EPG data to fetch  */
     int          m_iUpdateTime;        /*!< update the full EPG after this period */
     //@}
 

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -21,6 +21,7 @@
 #include "dbwrappers/dataset.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/VideoSettings.h"
+#include "settings/Settings.h"
 #include "utils/log.h"
 #include "addons/include/xbmc_pvr_types.h"
 
@@ -180,7 +181,7 @@ bool CEpgDatabase::DeleteOldEpgEntries(void)
 {
   time_t iCleanupTime;
   CDateTime cleanupTime = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() -
-      CDateTimeSpan(0, g_advancedSettings.m_iEpgLingerTime / 60, g_advancedSettings.m_iEpgLingerTime % 60, 0);
+      CDateTimeSpan(CSettings::Get().GetInt("epg.pastdaystodisplay"), 0, 0, 0);
   cleanupTime.GetAsTime(iCleanupTime);
 
   CStdString strWhereClause = FormatSQL("iEndTime < %u", iCleanupTime);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1508,6 +1508,12 @@ void CPVRManager::SettingOptionsPvrEPGPastDaysToDisplayFiller(const CSetting *se
     list.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(i == 1 ? 18000 : 17999), i), i));
 }
 
+void CPVRManager::SettingOptionsPvrEPGDaysToDisplayFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current)
+{
+  for(int i = 1; i < 15; i++)
+    list.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(i == 1 ? 18000 : 17999), i), i));
+}
+
 bool CPVRChannelSwitchJob::DoWork(void)
 {
   // announce OnStop and delete m_previous when done

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1501,6 +1501,13 @@ void CPVRManager::SettingOptionsPvrStartLastChannelFiller(const CSetting *settin
   list.push_back(make_pair(g_localizeStrings.Get(107),   PVR::START_LAST_CHANNEL_ON));
 }
 
+void CPVRManager::SettingOptionsPvrEPGPastDaysToDisplayFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current)
+{
+  list.push_back(make_pair(g_localizeStrings.Get(1223), 0));
+  for(int i = 1; i < 8; i++)
+    list.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(i == 1 ? 18000 : 17999), i), i));
+}
+
 bool CPVRChannelSwitchJob::DoWork(void)
 {
   // announce OnStop and delete m_previous when done

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -122,6 +122,14 @@ namespace PVR
      */
     static void SettingOptionsPvrEPGPastDaysToDisplayFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
 
+    /*!
+     * @brief Fills the option list for the setting epg.daystodisplay
+     * @param setting Setting
+     * @param list Option list
+     * @param current Current index
+     */
+    static void SettingOptionsPvrEPGDaysToDisplayFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
+
     virtual void OnSettingChanged(const CSetting *setting);
     virtual void OnSettingAction(const CSetting *setting);
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -106,6 +106,22 @@ namespace PVR
      */
     static CPVRManager &Get(void);
 
+    /*!
+     * @brief Fills the option list for the setting pvrplayback.startlast
+     * @param setting Setting
+     * @param list Option list
+     * @param current Current index
+     */
+    static void SettingOptionsPvrStartLastChannelFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
+
+    /*!
+     * @brief Fills the option list for the setting epg.pastdaystodisplay
+     * @param setting Setting
+     * @param list Option list
+     * @param current Current index
+     */
+    static void SettingOptionsPvrEPGPastDaysToDisplayFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
+
     virtual void OnSettingChanged(const CSetting *setting);
     virtual void OnSettingAction(const CSetting *setting);
 
@@ -543,8 +559,6 @@ namespace PVR
      * @return True if action could be handled, false otherwise.
      */
     bool OnAction(const CAction &action);
-
-    static void SettingOptionsPvrStartLastChannelFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
 
     /*!
      * @brief Create EPG tags for all channels in internal channel groups

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -256,7 +256,7 @@ void CGUIWindowPVRGuide::UpdateViewTimeline(bool bUpdateSelectedFile)
     endDate = startDate;
   
   // limit start to linger time
-  CDateTime maxPastDate = currentDate - CDateTimeSpan(0, 0, g_advancedSettings.m_iEpgLingerTime, 0);
+  CDateTime maxPastDate = currentDate - CDateTimeSpan(CSettings::Get().GetInt("epg.pastdaystodisplay"), 0, 0, 0);
   if(startDate < maxPastDate)
     startDate = maxPastDate;
   

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -304,7 +304,6 @@ void CAdvancedSettings::Initialize()
 
   m_iMythMovieLength = 0; // 0 == Off
 
-  m_iEpgLingerTime = 60 * 24;           /* keep 24 hours by default */
   m_iEpgUpdateCheckInterval = 300; /* check if tables need to be updated every 5 minutes */
   m_iEpgCleanupInterval = 900;     /* remove old entries from the EPG every 15 minutes */
   m_iEpgActiveTagCheckInterval = 60; /* check for updated active tags every minute */
@@ -909,7 +908,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   pElement = pRootElement->FirstChildElement("epg");
   if (pElement)
   {
-    XMLUtils::GetInt(pElement, "lingertime", m_iEpgLingerTime);
     XMLUtils::GetInt(pElement, "updatecheckinterval", m_iEpgUpdateCheckInterval);
     XMLUtils::GetInt(pElement, "cleanupinterval", m_iEpgCleanupInterval);
     XMLUtils::GetInt(pElement, "activetagcheckinterval", m_iEpgActiveTagCheckInterval);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -300,7 +300,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     int m_iMythMovieLength;         // minutes
 
-    int m_iEpgLingerTime;           // minutes
     int m_iEpgUpdateCheckInterval;  // seconds
     int m_iEpgCleanupInterval;      // seconds
     int m_iEpgActiveTagCheckInterval; // seconds

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -831,6 +831,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("languages", CLangInfo::SettingOptionsLanguagesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("pvrstartlastchannel", PVR::CPVRManager::SettingOptionsPvrStartLastChannelFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("pvrepgdaystodisplay", PVR::CPVRManager::SettingOptionsPvrEPGDaysToDisplayFiller);
   m_settingsManager->RegisterSettingOptionsFiller("pvrepgpastdaystodisplay", PVR::CPVRManager::SettingOptionsPvrEPGPastDaysToDisplayFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -831,6 +831,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("languages", CLangInfo::SettingOptionsLanguagesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("pvrstartlastchannel", PVR::CPVRManager::SettingOptionsPvrStartLastChannelFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("pvrepgpastdaystodisplay", PVR::CPVRManager::SettingOptionsPvrEPGPastDaysToDisplayFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);


### PR DESCRIPTION
This moves the advanced setting lingertime to settings so the user take control about how many days of past epg data will be imported from the backend.
