### PR TITLE
Weather -Header label- attempt legibility improvement

### DIFF
--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -95,8 +95,8 @@
 					<label>31300</label>
 					<align>center</align>
 					<aligny>center</aligny>
-					<textcolor>white</textcolor>
-					<shadowcolor>black</shadowcolor>
+					<textcolor>black</textcolor>
+					<shadowcolor>white</shadowcolor>
 				</control>
 				<control type="image">
 					<left>70</left>

--- a/addons/skin.confluence/720p/weather/10DayForecast.xml
+++ b/addons/skin.confluence/720p/weather/10DayForecast.xml
@@ -14,8 +14,8 @@
 				<label>31904</label>
 				<align>center</align>
 				<aligny>center</aligny>
-				<textcolor>white</textcolor>
-				<shadowcolor>black</shadowcolor>
+				<textcolor>black</textcolor>
+				<shadowcolor>white</shadowcolor>
 			</control>
 			<control type="list" id="51">
 				<left>15</left>

--- a/addons/skin.confluence/720p/weather/36HourForecast.xml
+++ b/addons/skin.confluence/720p/weather/36HourForecast.xml
@@ -25,8 +25,8 @@
 				<label>31901</label>
 				<align>center</align>
 				<aligny>center</aligny>
-				<textcolor>white</textcolor>
-				<shadowcolor>black</shadowcolor>
+				<textcolor>black</textcolor>
+				<shadowcolor>white</shadowcolor>
 			</control>
 			<control type="label">
 				<left>0</left>

--- a/addons/skin.confluence/720p/weather/HourlyForecast.xml
+++ b/addons/skin.confluence/720p/weather/HourlyForecast.xml
@@ -14,8 +14,8 @@
 				<label>31902</label>
 				<align>center</align>
 				<aligny>center</aligny>
-				<textcolor>white</textcolor>
-				<shadowcolor>black</shadowcolor>
+				<textcolor>black</textcolor>
+				<shadowcolor>white</shadowcolor>
 			</control>
 			<control type="list" id="52">
 				<left>15</left>

--- a/addons/skin.confluence/720p/weather/MapAlerts.xml
+++ b/addons/skin.confluence/720p/weather/MapAlerts.xml
@@ -25,8 +25,8 @@
 				<label>31910</label>
 				<align>center</align>
 				<aligny>center</aligny>
-				<textcolor>white</textcolor>
-				<shadowcolor>black</shadowcolor>
+				<textcolor>black</textcolor>
+				<shadowcolor>white</shadowcolor>
 			</control>
 			<control type="image">
 				<description>Background image</description>

--- a/addons/skin.confluence/720p/weather/WeekendForecast.xml
+++ b/addons/skin.confluence/720p/weather/WeekendForecast.xml
@@ -25,8 +25,8 @@
 				<label>31903</label>
 				<align>center</align>
 				<aligny>center</aligny>
-				<textcolor>white</textcolor>
-				<shadowcolor>black</shadowcolor>
+				<textcolor>black</textcolor>
+				<shadowcolor>white</shadowcolor>
 			</control>
 			<control type="label">
 				<left>0</left>


### PR DESCRIPTION
Currently The Header label is white, and the background in Confluence on
this area is sort of White as well, makes for terrible legibility.

This PR Fixes that, though a better solution is likely to exist.
In that case this PR offers one solution suggestion.
