### PR TITLE
droid: enable immersive full-screen mode if available

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
+++ b/tools/android/packaging/xbmc/src/org/xbmc/xbmc/Main.java
@@ -2,6 +2,7 @@ package org.xbmc.xbmc;
 
 import android.app.NativeActivity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -19,6 +20,32 @@ public class Main extends NativeActivity
   public void onCreate(Bundle savedInstanceState) 
   {
     super.onCreate(savedInstanceState);
+  }
+
+  @Override
+  public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
+    if (!hasFocus) {
+        return;
+    }
+
+    // enable immersive full-screen mode
+    // only available on Android 4.4(KitKat, API 19) and higher
+    // check the runtime version to enable or not
+    if (Build.VERSION.SDK_INT >= 19) {
+        // XXX Some flags not available on lower version SDK
+        // so need to hardcode the value to "5894" temporarily.
+        /*
+        int uiOptions = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+        */
+        int uiOptions = 5894;
+        getWindow().getDecorView().setSystemUiVisibility(uiOptions);
+    }
   }
 
   @Override


### PR DESCRIPTION
Android 4.4 add a very useful feature call "Immersive Full-Screen Mode"

http://developer.android.com/training/system-ui/immersive.html

It is the perfect solution to hide the system status-bar and nav-bar, hide them in the whole App session. And it doesn't need to root the device and use third-party ROM/App.

After some hacking, I found add it to XBMC is easy, it even doesn't need to touch the C/C++ code, just add a simple Java function.

I make a build base on the snapshot Gotham_alpha10, and test on my Nexus 4, which use official image and not rooted. It work perfect.

 Here is some previews.

After the splash initialization, it will show popup to notice about the hiding

![screenshot_2014-01-01-13-06-30](https://f.cloud.github.com/assets/330812/1829361/7862eef6-72a6-11e3-9375-ccdce660cfe5.jpg)

Truly full screen

![screenshot_2014-01-01-13-07-23](https://f.cloud.github.com/assets/330812/1829362/7d473b48-72a6-11e3-8ab3-8cf58a5eab1b.jpg)

I use the Sticky flag, when swip to show the status-bar/nav-bar, it won't make XBMC to scale the video to a new resolution.

![screenshot_2014-01-01-13-12-24](https://f.cloud.github.com/assets/330812/1829372/189aff80-72a7-11e3-9a71-7bb9ecfa8dbf.jpg)
