### PR TITLE
[rbp/omxplayer] When reencoding thumbnails preserve orientation

### DIFF
--- a/xbmc/cores/omxplayer/OMXImage.h
+++ b/xbmc/cores/omxplayer/OMXImage.h
@@ -163,7 +163,7 @@ public:
   void Close();
   bool ReEncode(COMXImageFile &srcFile, unsigned int width, unsigned int height, void * &pDestBuffer, unsigned int &nDestSize);
 protected:
-  bool HandlePortSettingChange(unsigned int resize_width, unsigned int resize_height, bool port_settings_changed);
+  bool HandlePortSettingChange(unsigned int resize_width, unsigned int resize_height, int orientation, bool port_settings_changed);
   // Components
   COMXCoreComponent             m_omx_decoder;
   COMXCoreComponent             m_omx_resize;


### PR DESCRIPTION
Currently reencoded thumbnails are displayed without original orientation flag applied.
However we can write the Orientation field of IFD0 data, which means the cached thumbnail will be displayed correctly when decoded
