### PR TITLE
fixed: loading of images from urls which don't have an extension...

### DIFF
--- a/lib/cximage-6.0/CxImage/DllInterface.cpp
+++ b/lib/cximage-6.0/CxImage/DllInterface.cpp
@@ -94,6 +94,8 @@ int DetectFileType(const BYTE* pBuffer, int nBufSize)
     // don't include the last APP0 byte (0xE0), as some (non-conforming) JPEG/JFIF files might have some other
     // APPn-specific data here, and we should skip over this.
     return CXIMAGE_FORMAT_JPG;
+  if (pBuffer[0] == 'G' && pBuffer[1] == 'I' && pBuffer[2] == 'F')
+    return CXIMAGE_FORMAT_GIF;
   return CXIMAGE_FORMAT_UNKNOWN;
 }
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1377,6 +1377,7 @@ bool CFileItem::IsParentFolder() const
 
 void CFileItem::FillInMimeType(bool lookup /*= true*/)
 {
+  // TODO: adapt this to use CMime::GetMimeType()
   if (m_mimetype.empty())
   {
     if( m_bIsFolder )

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -193,7 +193,7 @@ CBaseTexture *CTextureCacheJob::LoadImage(const CStdString &image, unsigned int 
       && !StringUtils::StartsWithNoCase(file.GetMimeType(), "image/") && !file.GetMimeType().Equals("application/octet-stream")) // ignore non-pictures
     return NULL;
 
-  CBaseTexture *texture = CBaseTexture::LoadFromFile(image, width, height, CSettings::Get().GetBool("pictures.useexifrotation"));
+  CBaseTexture *texture = CBaseTexture::LoadFromFile(image, width, height, CSettings::Get().GetBool("pictures.useexifrotation"), false, file.GetMimeType());
   if (!texture)
     return NULL;
 

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -175,7 +175,7 @@ void CBaseTexture::ClampToEdge()
   }
 }
 
-CBaseTexture *CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int idealWidth, unsigned int idealHeight, bool autoRotate, bool requirePixels)
+CBaseTexture *CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int idealWidth, unsigned int idealHeight, bool autoRotate, bool requirePixels, const std::string& strMimeType)
 {
 #if defined(TARGET_ANDROID)
   CURL url(texturePath);
@@ -203,7 +203,7 @@ CBaseTexture *CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned
   }
 #endif
   CTexture *texture = new CTexture();
-  if (texture->LoadFromFileInternal(texturePath, idealWidth, idealHeight, autoRotate, requirePixels))
+  if (texture->LoadFromFileInternal(texturePath, idealWidth, idealHeight, autoRotate, requirePixels, strMimeType))
     return texture;
   delete texture;
   return NULL;
@@ -218,7 +218,7 @@ CBaseTexture *CBaseTexture::LoadFromFileInMemory(unsigned char *buffer, size_t b
   return NULL;
 }
 
-bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels)
+bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels, const std::string& strMimeType)
 {
   if (URIUtils::HasExtension(texturePath, ".dds"))
   { // special case for DDS images
@@ -241,8 +241,13 @@ bool CBaseTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned 
   if (inputBuffSize == 0)
     return false;
 
-  CURL url(texturePath);
-  IImage* pImage = ImageFactory::CreateLoader(url);
+  IImage* pImage;
+
+  if(strMimeType.empty())
+    pImage = ImageFactory::CreateLoader(texturePath);
+  else
+    pImage = ImageFactory::CreateLoaderFromMimeType(strMimeType);
+
   if(!LoadIImage(pImage, (unsigned char *) inputBuff, inputBuffSize, width, height, autoRotate))
   {
     delete pImage;

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -54,10 +54,11 @@ public:
    \param idealWidth the ideal width of the texture (defaults to 0, no ideal width).
    \param idealHeight the ideal height of the texture (defaults to 0, no ideal height).
    \param autoRotate whether the textures should be autorotated based on EXIF information (defaults to false).
+   \param strMimeType mimetype of the given texture if available (defaults to empty)
    \return a CBaseTexture pointer to the created texture - NULL if the texture failed to load.
    */
   static CBaseTexture *LoadFromFile(const CStdString& texturePath, unsigned int idealWidth = 0, unsigned int idealHeight = 0,
-                                    bool autoRotate = false, bool requirePixels = false);
+                                    bool autoRotate = false, bool requirePixels = false, const std::string& strMimeType = "");
 
   /*! \brief Load a texture from a file in memory
    Loads a texture from a file in memory, restricting in size if needed based on maxHeight and maxWidth.
@@ -111,7 +112,7 @@ private:
 protected:
   bool LoadFromFileInMem(unsigned char* buffer, size_t size, const std::string& mimeType,
                          unsigned int maxWidth, unsigned int maxHeight);
-  bool LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels);
+  bool LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels, const std::string& strMimeType = "");
   bool LoadIImage(IImage* pImage, unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height, bool autoRotate=false);
   // helpers for computation of texture parameters for compressed textures
   unsigned int GetPitch(unsigned int width) const;

--- a/xbmc/guilib/TexturePi.cpp
+++ b/xbmc/guilib/TexturePi.cpp
@@ -112,7 +112,7 @@ void CPiTexture::Update(unsigned int width, unsigned int height, unsigned int pi
   CGLTexture::Update(width, height, pitch, format, pixels, loadToGPU);
 }
 
-bool CPiTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels)
+bool CPiTexture::LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels, const std::string& strMimeType)
 {
   if (URIUtils::HasExtension(texturePath, ".jpg|.tbn"))
   {

--- a/xbmc/guilib/TexturePi.h
+++ b/xbmc/guilib/TexturePi.h
@@ -38,7 +38,7 @@ public:
   void LoadToGPU();
   void Update(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, bool loadToGPU);
   void Allocate(unsigned int width, unsigned int height, unsigned int format);
-  bool LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels);
+  bool LoadFromFileInternal(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight, bool autoRotate, bool requirePixels, const std::string& strMimeType = "");
 
 protected:
 

--- a/xbmc/guilib/imagefactory.cpp
+++ b/xbmc/guilib/imagefactory.cpp
@@ -44,8 +44,3 @@ IImage* ImageFactory::CreateFallbackLoader(const std::string& strMimeType)
 {
   return new CXImage(strMimeType);
 }
-
-IImage* ImageFactory::CreateFallbackLoader(const CURL& url)
-{
-  return new CXImage("image/"+url.GetFileType());
-}

--- a/xbmc/guilib/imagefactory.cpp
+++ b/xbmc/guilib/imagefactory.cpp
@@ -21,6 +21,7 @@
 #include "imagefactory.h"
 #include "guilib/JpegIO.h"
 #include "guilib/cximage.h"
+#include "utils/Mime.h"
 
 IImage* ImageFactory::CreateLoader(const std::string& strFileName)
 {
@@ -30,7 +31,10 @@ IImage* ImageFactory::CreateLoader(const std::string& strFileName)
 
 IImage* ImageFactory::CreateLoader(const CURL& url)
 {
-  return CreateLoaderFromMimeType("image/"+url.GetFileType());
+  if(!url.GetFileType().empty())
+    return CreateLoaderFromMimeType("image/"+url.GetFileType());
+
+  return CreateLoaderFromMimeType(CMime::GetMimeType(url));
 }
 
 IImage* ImageFactory::CreateLoaderFromMimeType(const std::string& strMimeType)

--- a/xbmc/guilib/imagefactory.h
+++ b/xbmc/guilib/imagefactory.h
@@ -32,5 +32,4 @@ public:
   static IImage* CreateLoader(const CURL& url);
   static IImage* CreateLoaderFromMimeType(const std::string& strMimeType);
   static IImage* CreateFallbackLoader(const std::string& strMimeType);
-  static IImage* CreateFallbackLoader(const CURL& url);
 };

--- a/xbmc/utils/Mime.h
+++ b/xbmc/utils/Mime.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <map>
 
+class CURL;
+
 class CFileItem;
 
 class CMime
@@ -29,6 +31,7 @@ class CMime
 public:
   static std::string GetMimeType(const std::string &extension);
   static std::string GetMimeType(const CFileItem &item);
+  static std::string GetMimeType(const CURL &url, bool lookup = true);
 
 private:
   static std::map<std::string, std::string> m_mimetypes;


### PR DESCRIPTION
... and thus we weren't able to determine the mimetype. This will fix #14781.
The downside is that we had the mimetype in CBaseTexture *CTextureCacheJob::LoadImage already but won't pass it along. But I don't think this is much overhead and we should check for the mimetype there in any case.

Additional I removed an unused method.
