### PR TITLE
fix CHttpHeader::Parse() not handling last header line

### DIFF
--- a/xbmc/utils/test/TestHttpHeader.cpp
+++ b/xbmc/utils/test/TestHttpHeader.cpp
@@ -32,39 +32,39 @@ TEST(TestHttpHeader, General)
                    "User-Agent: XBMC/snapshot (compatible; MSIE 5.5; Windows NT"
                      " 4.0)\r\n"
                    "Connection: Keep-Alive\r\n";
-  std::string refstr, varstr;
+  std::string varstr;
 
   a.Parse(str);
 
   /* Should be in the same order as above */
-  refstr = "\n"
-           "host: xbmc.org\n"
-           "accept: text/*, text/html, text/html;level=1, */*\n"
-           "accept-language: en\n"
-           "accept-encoding: gzip, deflate\n"
-           "content-type: text/html; charset=ISO-8859-4\n"
-           "user-agent: XBMC/snapshot (compatible; MSIE 5.5; Windows NT 4.0)\n"
-           "connection: Keep-Alive\n"
-           "\n";
+  const char *refstr = "\n"
+                       "host: xbmc.org\n"
+                       "accept: text/*, text/html, text/html;level=1, */*\n"
+                       "accept-language: en\n"
+                       "accept-encoding: gzip, deflate\n"
+                       "content-type: text/html; charset=ISO-8859-4\n"
+                       "user-agent: XBMC/snapshot (compatible; MSIE 5.5; Windows NT 4.0)\n"
+                       "connection: Keep-Alive\n"
+                       "\n";
   varstr.clear();
   varstr = a.GetHeader();
-  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  EXPECT_STREQ(refstr, varstr.c_str());
 
   refstr = "XBMC/snapshot (compatible; MSIE 5.5; Windows NT 4.0)";
   varstr = a.GetValue("User-Agent");
-  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  EXPECT_STREQ(refstr, varstr.c_str());
 
   /* No charset should be here */
   refstr = "text/html";
   varstr = a.GetMimeType();
-  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  EXPECT_STREQ(refstr, varstr.c_str());
 
   refstr = "";
   varstr = a.GetProtoLine();
-  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  EXPECT_STREQ(refstr, varstr.c_str());
 
   a.Clear();
   refstr = "";
   varstr = a.GetMimeType();
-  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  EXPECT_STREQ(refstr, varstr.c_str());
 }


### PR DESCRIPTION
While running the unit tests on win32 (which still crash sometimes) I noticed that the test for CHttpHeader failed. After investigation I realized that the code always skipped the last header line in CHttpHeader::Parse().

I'm sure there's a cleaner wayto fix this but I didn't have time to look into it in detail.

PS: The changes in the test method don't change the test or anything, they just improve the console output in case of an error. Before it printed out

```
expected: refstr.c_str()
```

instead of the actually expected value.
