### PR TITLE
Fetch TVShow banner data into LatestEpisode list

### DIFF
--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -129,6 +129,7 @@ bool CRecentlyAddedJob::UpdateVideo()
 
       home->SetProperty("LatestEpisode." + value + ".Thumb"         , item->GetArt("thumb"));
       home->SetProperty("LatestEpisode." + value + ".ShowThumb"     , item->GetArt("tvshow.thumb"));
+      home->SetProperty("LatestEpisode." + value + ".ShowBanner"    , item->GetArt("tvshow.banner"));
       home->SetProperty("LatestEpisode." + value + ".SeasonThumb"   , seasonThumb);
       home->SetProperty("LatestEpisode." + value + ".Fanart"        , item->GetArt("fanart"));
     }


### PR DESCRIPTION
Since LatestEpisode list already gets the tvshow's thumbnail artwork, it's only reasonable to get the banner too (for skinning purposes, for eg).
This information is already being fetched by Skin Widgets plugin, and is used by skinners. I think the XBMC core should support this as well.
