### PR TITLE
Allow DVD playback after 'browse into' ISO/IMG file (trac 14778)

### DIFF
--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -50,7 +50,7 @@ CUDFFile::~CUDFFile()
 //*********************************************************************************************
 bool CUDFFile::Open(const CURL& url)
 {
-  if(!m_udfIsoReaderLocal.Open(url.GetHostName()))
+  if(!m_udfIsoReaderLocal.Open(url.GetHostName()) || url.GetFileName().empty())
      return false;
 
   m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName());
@@ -124,6 +124,12 @@ int CUDFFile::Stat(const CURL& url, struct __stat64* buffer)
 {
   if(!m_udfIsoReaderLocal.Open(url.GetHostName()))
      return -1;
+
+  if (url.GetFileName().empty())
+  {
+    buffer->st_mode = _S_IFDIR;
+    return 0;
+  }
 
   m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName());
   if (m_hFile != INVALID_HANDLE_VALUE)

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -718,6 +718,7 @@ int udf25::UDFFindPartition( int partnum, struct Partition *part )
         /* Partition Descriptor */
         UDFPartition( LogBlock, &part->Flags, &part->Number,
                       part->Contents, &part->Start, &part->Length );
+        part->Start_Correction = 0;
         part->valid = ( partnum == part->Number );
       } else if( ( TagID == 6 ) && ( !volvalid ) ) {
         /* Logical Volume Descriptor */
@@ -762,6 +763,8 @@ int udf25::UDFFindPartition( int partnum, struct Partition *part )
       UDFExtFileEntry( LogBlock, &File );
       if (File.Type == 250) {
         part->Start  += File.AD_chain[0].Location;
+        // we need to remember this correction because read positions are relative to the non-indirected partition start
+        part->Start_Correction = File.AD_chain[0].Location;
         part->Length  = File.AD_chain[0].Length;
         break;
       }
@@ -792,6 +795,7 @@ int udf25::UDFMapICB( struct AD ICB, struct Partition *partition, struct FileAD 
   memset(File, 0, sizeof(*File));
   File->Partition       = partition->Number;
   File->Partition_Start = partition->Start;
+  File->Partition_Start_Correction = partition->Start_Correction;
 
   do {
     if( DVDReadLBUDF( lbnum++, 1, LogBlock, 0 ) <= 0 )
@@ -1109,7 +1113,8 @@ long udf25::ReadFile(HANDLE hFile, unsigned char *pBuffer, long lSize)
     if(len == 0)
       break;
 
-    pos -= 32 * DVD_VIDEO_LB_LEN; /* why? */
+    // correct for partition indirection if applicable
+    pos -= bdfile->file->Partition_Start_Correction * DVD_VIDEO_LB_LEN;
 
     if((uint32_t)lSize < len)
       len = lSize;

--- a/xbmc/filesystem/udf25.h
+++ b/xbmc/filesystem/udf25.h
@@ -46,6 +46,7 @@ struct Partition {
   uint32_t AccessType;
   uint32_t Start;
   uint32_t Length;
+  uint32_t Start_Correction;
 };
 
 struct AD {
@@ -75,6 +76,7 @@ struct FileAD {
     uint32_t num_AD;
     uint16_t Partition;
     uint32_t Partition_Start;
+    uint32_t Partition_Start_Correction;
     uint8_t  Type;
     uint16_t Flags;
     struct AD AD_chain[UDF_MAX_AD_CHAINS];


### PR DESCRIPTION
see trac ticket 14778: http://trac.xbmc.org/ticket/14778 : DVD playback now works when browsing into an ISO file using our file manager.

The root cause was that libdvd (css/read/nav) did not recognize the udf://....iso path as the root 'folder', thus did not access the file via our VFS udf reader. 
Also, IFO files weren't read correctly due to a read position error in the code.
@elupus, could you review, as the UDF code was historically yours, and I want to make sure you agree with the changes. I noticed you weren't quite sure yourself as you left this comment 'why ?' in there...

I tried this PR on a number of DVD iso's each time using "Browse Into" and everything works well.
