### PR TITLE
Date time validation

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -687,13 +687,13 @@ void CDateTime::FromULargeInt(const ULARGE_INTEGER& time)
   m_time.dwLowDateTime=time.u.LowPart;
 }
 
-void CDateTime::SetFromDateString(const CStdString &date)
+bool CDateTime::SetFromDateString(const CStdString &date)
 {
   /* TODO:STRING_CLEANUP */
   if (date.empty())
   {
     SetValid(false);
-    return;
+    return false;
   }
 
   const char* months[] = {"january","february","march","april","may","june","july","august","september","october","november","december",NULL};
@@ -710,10 +710,7 @@ void CDateTime::SetFromDateString(const CStdString &date)
 
   CStdString strMonth = date.substr(iDayPos, iPos - iDayPos);
   if (strMonth.empty()) // assume dbdate format
-  {
-    SetFromDBDate(date);
-    return;
-  }
+    return SetFromDBDate(date);
 
   size_t iPos2 = date.find(",");
   CStdString strDay = (date.size() >= iPos) ? date.substr(iPos, iPos2-iPos) : "";
@@ -721,9 +718,9 @@ void CDateTime::SetFromDateString(const CStdString &date)
   while (months[j] && stricmp(strMonth.c_str(),months[j]) != 0)
     j++;
   if (!months[j])
-    return;
+    return false;
 
-  SetDateTime(atol(strYear.c_str()),j+1,atol(strDay.c_str()),0,0,0);
+  return SetDateTime(atol(strYear.c_str()),j+1,atol(strDay.c_str()),0,0,0);
 }
 
 int CDateTime::GetDay() const
@@ -789,7 +786,7 @@ int CDateTime::GetMinuteOfDay() const
   return st.wHour*60+st.wMinute;
 }
 
-void CDateTime::SetDateTime(int year, int month, int day, int hour, int minute, int second)
+bool CDateTime::SetDateTime(int year, int month, int day, int hour, int minute, int second)
 {
   SYSTEMTIME st;
   ZeroMemory(&st, sizeof(SYSTEMTIME));
@@ -802,17 +799,18 @@ void CDateTime::SetDateTime(int year, int month, int day, int hour, int minute, 
   st.wSecond=second;
 
   m_state = ToFileTime(st, m_time) ? valid : invalid;
+  return m_state == valid;
 }
 
-void CDateTime::SetDate(int year, int month, int day)
+bool CDateTime::SetDate(int year, int month, int day)
 {
-  SetDateTime(year, month, day, 0, 0, 0);
+  return SetDateTime(year, month, day, 0, 0, 0);
 }
 
-void CDateTime::SetTime(int hour, int minute, int second)
+bool CDateTime::SetTime(int hour, int minute, int second)
 {
   // 01.01.1601 00:00:00 is 0 as filetime
-  SetDateTime(1601, 1, 1, hour, minute, second);
+  return SetDateTime(1601, 1, 1, hour, minute, second);
 }
 
 void CDateTime::GetAsSystemTime(SYSTEMTIME& time) const
@@ -873,13 +871,14 @@ CStdString CDateTime::GetAsSaveString() const
   return StringUtils::Format("%04i%02i%02i_%02i%02i%02i", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);;
 }
 
-void CDateTime::SetFromUTCDateTime(const CDateTime &dateTime)
+bool CDateTime::SetFromUTCDateTime(const CDateTime &dateTime)
 {
   CDateTime tmp(dateTime);
   tmp -= GetTimezoneBias();
 
   m_time = tmp.m_time;
   m_state = tmp.m_state;
+  return m_state == valid;
 }
 
 static bool bGotTimezoneBias = false;
@@ -914,13 +913,13 @@ CDateTimeSpan CDateTime::GetTimezoneBias(void)
   return timezoneBias;
 }
 
-void CDateTime::SetFromUTCDateTime(const time_t &dateTime)
+bool CDateTime::SetFromUTCDateTime(const time_t &dateTime)
 {
   CDateTime tmp(dateTime);
-  SetFromUTCDateTime(tmp);
+  return SetFromUTCDateTime(tmp);
 }
 
-void CDateTime::SetFromW3CDate(const CStdString &dateTime)
+bool CDateTime::SetFromW3CDate(const CStdString &dateTime)
 {
   CStdString date, time, zone;
 
@@ -960,10 +959,10 @@ void CDateTime::SetFromW3CDate(const CStdString &dateTime)
   if (time.length() >= 8)
     sec  = atoi(time.substr(6, 2).c_str());
 
-  SetDateTime(year, month, day, hour, min, sec);
+  return SetDateTime(year, month, day, hour, min, sec);
 }
 
-void CDateTime::SetFromDBDateTime(const CStdString &dateTime)
+bool CDateTime::SetFromDBDateTime(const CStdString &dateTime)
 {
   // assumes format YYYY-MM-DD HH:MM:SS
   if (dateTime.size() == 19)
@@ -974,14 +973,15 @@ void CDateTime::SetFromDBDateTime(const CStdString &dateTime)
     int hour  = atoi(dateTime.substr(11, 2).c_str());
     int min   = atoi(dateTime.substr(14, 2).c_str());
     int sec   = atoi(dateTime.substr(17, 2).c_str());
-    SetDateTime(year, month, day, hour, min, sec);
+    return SetDateTime(year, month, day, hour, min, sec);
   }
+  return false;
 }
 
-void CDateTime::SetFromDBDate(const CStdString &date)
+bool CDateTime::SetFromDBDate(const CStdString &date)
 {
   if (date.size() < 10)
-    return;
+    return false;
   // assumes format:
   // YYYY-MM-DD or DD-MM-YYYY
   int year = 0, month = 0, day = 0;
@@ -997,13 +997,13 @@ void CDateTime::SetFromDBDate(const CStdString &date)
     month = atoi(date.substr(5, 2).c_str());
     day = atoi(date.substr(8, 2).c_str());
   }
-  SetDate(year, month, day);
+  return SetDate(year, month, day);
 }
 
-void CDateTime::SetFromDBTime(const CStdString &time)
+bool CDateTime::SetFromDBTime(const CStdString &time)
 {
   if (time.size() < 8)
-    return;
+    return false;
   // assumes format:
   // HH:MM:SS
   int hour, minute, second;
@@ -1012,16 +1012,16 @@ void CDateTime::SetFromDBTime(const CStdString &time)
   minute = atoi(time.substr(3, 2).c_str());
   second = atoi(time.substr(6, 2).c_str());
 
-  SetTime(hour, minute, second);
+  return SetTime(hour, minute, second);
 }
 
-void CDateTime::SetFromRFC1123DateTime(const CStdString &dateTime)
+bool CDateTime::SetFromRFC1123DateTime(const CStdString &dateTime)
 {
   CStdString date = dateTime;
   StringUtils::Trim(date);
 
   if (date.size() != 29)
-    return;
+    return false;
 
   int day  = strtol(date.substr(5, 2).c_str(), NULL, 10);
 
@@ -1037,14 +1037,14 @@ void CDateTime::SetFromRFC1123DateTime(const CStdString &dateTime)
   }
 
   if (month < 1)
-    return;
+    return false;
 
   int year = strtol(date.substr(12, 4).c_str(), NULL, 10);
   int hour = strtol(date.substr(17, 2).c_str(), NULL, 10);
   int min  = strtol(date.substr(20, 2).c_str(), NULL, 10);
   int sec  = strtol(date.substr(23, 2).c_str(), NULL, 10);
 
-  SetDateTime(year, month, day, hour, min, sec);
+  return SetDateTime(year, month, day, hour, min, sec);
 }
 
 CStdString CDateTime::GetAsLocalizedTime(const CStdString &format, bool withSeconds) const

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -696,6 +696,9 @@ bool CDateTime::SetFromDateString(const CStdString &date)
     return false;
   }
 
+  if (SetFromDBDate(date))
+    return true;
+
   const char* months[] = {"january","february","march","april","may","june","july","august","september","october","november","december",NULL};
   int j=0;
   size_t iDayPos = date.find("day");
@@ -709,8 +712,8 @@ bool CDateTime::SetFromDateString(const CStdString &date)
     iDayPos = 0;
 
   CStdString strMonth = date.substr(iDayPos, iPos - iDayPos);
-  if (strMonth.empty()) // assume dbdate format
-    return SetFromDBDate(date);
+  if (strMonth.empty())
+    return false;
 
   size_t iPos2 = date.find(",");
   CStdString strDay = (date.size() >= iPos) ? date.substr(iPos, iPos2-iPos) : "";

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -984,14 +984,15 @@ bool CDateTime::SetFromDBDate(const CStdString &date)
     return false;
   // assumes format:
   // YYYY-MM-DD or DD-MM-YYYY
+  const static std::string sep_chars = "-./";
   int year = 0, month = 0, day = 0;
-  if (date[2] == '-' || date[2] == '.')
+  if (sep_chars.find(date[2]) != std::string::npos)
   {
     day = atoi(date.substr(0, 2).c_str());
     month = atoi(date.substr(3, 2).c_str());
     year = atoi(date.substr(6, 4).c_str());
   }
-  else
+  else if (sep_chars.find(date[4]) != std::string::npos)
   {
     year = atoi(date.substr(0, 4).c_str());
     month = atoi(date.substr(5, 2).c_str());

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -98,7 +98,7 @@ public:
   CDateTime(int year, int month, int day, int hour, int minute, int second);
   virtual ~CDateTime() {}
 
-  void SetFromDateString(const CStdString &date);
+  bool SetFromDateString(const CStdString &date);
 
   static CDateTime GetCurrentDateTime();
   static CDateTime GetUTCDateTime();
@@ -167,20 +167,20 @@ public:
   int GetDayOfWeek() const;
   int GetMinuteOfDay() const;
 
-  void SetDateTime(int year, int month, int day, int hour, int minute, int second);
-  void SetDate(int year, int month, int day);
-  void SetTime(int hour, int minute, int second);
-  void SetFromDBDate(const CStdString &date);
-  void SetFromDBTime(const CStdString &time);
-  void SetFromW3CDate(const CStdString &date);
-  void SetFromUTCDateTime(const CDateTime &dateTime);
-  void SetFromUTCDateTime(const time_t &dateTime);
-  void SetFromRFC1123DateTime(const CStdString &dateTime);
+  bool SetDateTime(int year, int month, int day, int hour, int minute, int second);
+  bool SetDate(int year, int month, int day);
+  bool SetTime(int hour, int minute, int second);
+  bool SetFromDBDate(const CStdString &date);
+  bool SetFromDBTime(const CStdString &time);
+  bool SetFromW3CDate(const CStdString &date);
+  bool SetFromUTCDateTime(const CDateTime &dateTime);
+  bool SetFromUTCDateTime(const time_t &dateTime);
+  bool SetFromRFC1123DateTime(const CStdString &dateTime);
 
   /*! \brief set from a database datetime format YYYY-MM-DD HH:MM:SS
    \sa GetAsDBDateTime()
    */
-  void SetFromDBDateTime(const CStdString &dateTime);
+  bool SetFromDBDateTime(const CStdString &dateTime);
 
   void GetAsSystemTime(SYSTEMTIME& time) const;
   void GetAsTime(time_t& time) const;


### PR DESCRIPTION
The goal here is to fix the (broken) SetFromDateString() function, which broke with the string merge, as Mid(0, -1) returns an empty string, whilst substr(0, -1) returns the full string.

In addition, as SetFromDateString() is supposed to attempt a 2005-06-18 style date if no day is found, we mayaswell just validate dates a little better and check for that first.

This fixes #3863 in an alternate manner.

@BigNoid: Mind testing?
