### PR TITLE
Remove some unused code, reuse existing methods, and remove duplicate logging

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2397,7 +2397,7 @@ void CDVDPlayer::Pause()
     return;
   lock.Leave();
 
-  if(m_playSpeed != DVD_PLAYSPEED_PAUSE && (m_caching == CACHESTATE_FULL || m_caching == CACHESTATE_PVR))
+  if(m_playSpeed != DVD_PLAYSPEED_PAUSE && IsCaching())
   {
     SetCaching(CACHESTATE_DONE);
     return;
@@ -2418,7 +2418,7 @@ void CDVDPlayer::Pause()
 
 bool CDVDPlayer::IsPaused() const
 {
-  return m_playSpeed == DVD_PLAYSPEED_PAUSE || m_caching == CACHESTATE_FULL || m_caching == CACHESTATE_PVR;
+  return m_playSpeed == DVD_PLAYSPEED_PAUSE || IsCaching();
 }
 
 bool CDVDPlayer::HasVideo() const

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2724,7 +2724,7 @@ void COMXPlayer::Pause()
     return;
   lock.Leave();
 
-  if(m_playSpeed != DVD_PLAYSPEED_PAUSE && (m_caching == CACHESTATE_FULL || m_caching == CACHESTATE_PVR))
+  if(m_playSpeed != DVD_PLAYSPEED_PAUSE && IsCaching())
   {
     SetCaching(CACHESTATE_DONE);
     return;
@@ -2745,7 +2745,7 @@ void COMXPlayer::Pause()
 
 bool COMXPlayer::IsPaused() const
 {
-  return m_playSpeed == DVD_PLAYSPEED_PAUSE || m_caching == CACHESTATE_FULL || m_caching == CACHESTATE_PVR;
+  return m_playSpeed == DVD_PLAYSPEED_PAUSE || IsCaching();
 }
 
 bool COMXPlayer::HasVideo() const

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2243,25 +2243,14 @@ void COMXPlayer::OnExit()
     // close each stream
     if (!m_bAbortRequest) CLog::Log(LOGNOTICE, "OMXPlayer: eof, waiting for queues to empty");
     if (m_CurrentAudio.id >= 0)
-    {
-      CLog::Log(LOGNOTICE, "OMXPlayer: closing audio stream");
       CloseAudioStream(!m_bAbortRequest);
-    }
     if (m_CurrentVideo.id >= 0)
-    {
-      CLog::Log(LOGNOTICE, "OMXPlayer: closing video stream");
       CloseVideoStream(!m_bAbortRequest);
-    }
     if (m_CurrentSubtitle.id >= 0)
-    {
-      CLog::Log(LOGNOTICE, "OMXPlayer: closing subtitle stream");
       CloseSubtitleStream(!m_bAbortRequest);
-    }
     if (m_CurrentTeletext.id >= 0)
-    {
-      CLog::Log(LOGNOTICE, "OMXPlayer: closing teletext stream");
       CloseTeletextStream(!m_bAbortRequest);
-    }
+    
     // destroy the demuxer
     if (m_pDemuxer)
     {


### PR DESCRIPTION
This is some things I found while working on another thing. @elupus can you confirm the DEMUXER_RESET really isn't used anywhere? At least a grep returns nothing.
