### PR TITLE
[info] don't URL decode paths and filenames - pass them as-is (save user/pass)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4747,7 +4747,6 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdSt
         URIUtils::RemoveSlashAtEnd(path);
         path=URIUtils::GetFileName(path);
       }
-      CURL::Decode(path);
       return path;
     }
   case LISTITEM_FILENAME_AND_PATH:
@@ -4760,7 +4759,6 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdSt
       else
         path = item->GetPath();
       path = CURL(path).GetWithoutUserDetails();
-      CURL::Decode(path);
       return path;
     }
   case LISTITEM_PICTURE_PATH:


### PR DESCRIPTION
Fixes #13823

One presume the URL decoding is to make the labels "pretty" for the UI.  However, they're used for more than just displaying stuff, so if we want prettiness, it would be better to have a Prettify() function in the infomanager instead.

IMO Gotham material.
