### PR TITLE
Cleanup the AE includes to use paths from root, rather than relative

### DIFF
--- a/Makefile.include.in
+++ b/Makefile.include.in
@@ -49,10 +49,6 @@ ifneq (@USE_EXTERNAL_FFMPEG@,1)
 endif
 INCLUDES+=-I@abs_top_srcdir@/xbmc/linux
 INCLUDES+=-I@abs_top_srcdir@/xbmc/cores/dvdplayer
-ifeq (@USE_OMXPLAYER@,1)
-INCLUDES+=-I@abs_top_srcdir@/xbmc/cores/AudioEngine
-INCLUDES+=-I@abs_top_srcdir@/xbmc/cores/AudioEngine/Utils
-endif
 DEFINES+= \
 	@ARCH_DEFINES@ \
 	-D_FILE_DEFINED \

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include "Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 
 class IAESink;
 

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -21,7 +21,7 @@
 #define AC3_ENCODE_BITRATE 640000
 #define DTS_ENCODE_BITRATE 1411200
 
-#include "AEEncoderFFmpeg.h"
+#include "cores/AudioEngine/Encoders/AEEncoderFFmpeg.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -23,8 +23,8 @@
 using namespace ActiveAE;
 #include "ActiveAESound.h"
 #include "ActiveAEStream.h"
-#include "Utils/AEUtil.h"
-#include "Encoders/AEEncoderFFmpeg.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/AudioEngine/Encoders/AEEncoderFFmpeg.h"
 
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -24,9 +24,9 @@
 
 #include "ActiveAESink.h"
 #include "ActiveAEResample.h"
-#include "Interfaces/AEStream.h"
-#include "Interfaces/AESound.h"
-#include "AEFactory.h"
+#include "cores/AudioEngine/Interfaces/AEStream.h"
+#include "cores/AudioEngine/Interfaces/AESound.h"
+#include "cores/AudioEngine/AEFactory.h"
 #include "guilib/DispResource.h"
 
 // ffmpeg

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -19,9 +19,9 @@
  */
 
 #include "ActiveAEBuffer.h"
-#include "AEFactory.h"
-#include "ActiveAE.h"
-#include "Utils/AEUtil.h"
+#include "cores/AudioEngine/AEFactory.h"
+#include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 
 using namespace ActiveAE;
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -21,8 +21,8 @@
 
 #include "DllAvUtil.h"
 #include "DllSwResample.h"
-#include "Utils/AEAudioFormat.h"
-#include "Interfaces/AE.h"
+#include "cores/AudioEngine/Utils/AEAudioFormat.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
 #include <deque>
 
 namespace ActiveAE

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h
@@ -21,10 +21,10 @@
 
 #include "DllAvUtil.h"
 #include "DllSwResample.h"
-#include "Utils/AEChannelInfo.h"
-#include "Utils/AEAudioFormat.h"
-#include "ActiveAEBuffer.h"
-#include "Interfaces/AE.h"
+#include "cores/AudioEngine/Utils/AEChannelInfo.h"
+#include "cores/AudioEngine/Utils/AEAudioFormat.h"
+#include "cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
 
 namespace ActiveAE
 {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -21,7 +21,7 @@
 #include <sstream>
 
 #include "ActiveAESink.h"
-#include "Utils/AEUtil.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/EndianSwap.h"
 #include "ActiveAE.h"
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -22,11 +22,11 @@
 #include "threads/Event.h"
 #include "threads/Thread.h"
 #include "utils/ActorProtocol.h"
-#include "Interfaces/AE.h"
-#include "Interfaces/AESink.h"
-#include "AESinkFactory.h"
-#include "ActiveAEResample.h"
-#include "Utils/AEConvert.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/AESinkFactory.h"
+#include "cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h"
+#include "cores/AudioEngine/Utils/AEConvert.h"
 
 namespace ActiveAE
 {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.cpp
@@ -18,10 +18,10 @@
  *
  */
 
-#include "Interfaces/AESound.h"
+#include "cores/AudioEngine/Interfaces/AESound.h"
 
-#include "AEFactory.h"
-#include "Utils/AEAudioFormat.h"
+#include "cores/AudioEngine/AEFactory.h"
+#include "cores/AudioEngine/Utils/AEAudioFormat.h"
 #include "ActiveAE.h"
 #include "ActiveAESound.h"
 #include "utils/log.h"

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.h
@@ -20,8 +20,8 @@
  */
 
 #include "utils/StdString.h"
-#include "Interfaces/AESound.h"
-#include "ActiveAEResample.h"
+#include "cores/AudioEngine/Interfaces/AESound.h"
+#include "cores/AudioEngine/Engines/ActiveAE/ActiveAEResample.h"
 #include "filesystem/File.h"
 
 class DllAvUtil;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -23,8 +23,8 @@
 #include "utils/log.h"
 #include "utils/MathUtils.h"
 
-#include "AEFactory.h"
-#include "Utils/AEUtil.h"
+#include "cores/AudioEngine/AEFactory.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 
 #include "ActiveAE.h"
 #include "ActiveAEStream.h"

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -19,10 +19,10 @@
  *
  */
 
-#include "Interfaces/AEStream.h"
-#include "Utils/AEAudioFormat.h"
-#include "Utils/AELimiter.h"
-#include "Utils/AEConvert.h"
+#include "cores/AudioEngine/Interfaces/AEStream.h"
+#include "cores/AudioEngine/Utils/AEAudioFormat.h"
+#include "cores/AudioEngine/Utils/AELimiter.h"
+#include "cores/AudioEngine/Utils/AEConvert.h"
 
 namespace ActiveAE
 {

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAESound.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAESound.cpp
@@ -22,7 +22,7 @@
 #ifdef HAS_PULSEAUDIO
 
 #include "PulseAESound.h"
-#include "AEFactory.h"
+#include "cores/AudioEngine/AEFactory.h"
 #include "utils/log.h"
 #include "MathUtils.h"
 #include "StringUtils.h"

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAESound.h
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAESound.h
@@ -22,8 +22,8 @@
 #include "system.h"
 #ifdef HAS_PULSEAUDIO
 
-#include "Interfaces/AESound.h"
-#include "Utils/AEWAVLoader.h"
+#include "cores/AudioEngine/Interfaces/AESound.h"
+#include "cores/AudioEngine/Utils/AEWAVLoader.h"
 #include <pulse/pulseaudio.h>
 
 class CPulseAESound : public IAESound

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
@@ -22,8 +22,8 @@
 #ifdef HAS_PULSEAUDIO
 
 #include "PulseAEStream.h"
-#include "AEFactory.h"
-#include "Utils/AEUtil.h"
+#include "cores/AudioEngine/AEFactory.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/log.h"
 #include "utils/MathUtils.h"
 #include "threads/SingleLock.h"

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.h
@@ -21,7 +21,7 @@
 
 #ifdef HAS_PULSEAUDIO
 
-#include "Interfaces/AEStream.h"
+#include "cores/AudioEngine/Interfaces/AEStream.h"
 #include "threads/Thread.h"
 #include <pulse/pulseaudio.h>
 

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <stdint.h>
+#include "cores/AudioEngine/Interfaces/AE.h" // for typedef's used in derived classes
 #include "cores/AudioEngine/Utils/AEAudioFormat.h"
 
 class IAESink

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -19,11 +19,9 @@
  *
  */
 
-#include "threads/Thread.h"
-#include "AE.h"
-#include "Utils/AEAudioFormat.h"
-#include "utils/StdString.h"
+#include <string>
 #include <stdint.h>
+#include "cores/AudioEngine/Utils/AEAudioFormat.h"
 
 class IAESink
 {

--- a/xbmc/cores/AudioEngine/Interfaces/AESound.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESound.h
@@ -19,8 +19,7 @@
  *
  */
 
-#include "utils/StdString.h"
-#include "AE.h"
+#include <string>
 
 class IAESound
 {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -26,8 +26,8 @@
 #include <sstream>
 
 #include "AESinkALSA.h"
-#include "Utils/AEUtil.h"
-#include "Utils/AEELDParser.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/AudioEngine/Utils/AEELDParser.h"
 #include "utils/StdString.h"
 #include "utils/log.h"
 #include "utils/MathUtils.h"

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -22,8 +22,8 @@
 #include "system.h"
 #ifdef HAS_ALSA
 
-#include "Interfaces/AESink.h"
-#include "Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include <stdint.h>
 
 #define ALSA_PCM_NEW_HW_PARAMS_API

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -19,8 +19,8 @@
  */
 
 #include "AESinkAUDIOTRACK.h"
-#include "Utils/AEUtil.h"
-#include "Utils/AERingBuffer.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/AudioEngine/Utils/AERingBuffer.h"
 #include "android/activity/XBMCApp.h"
 #include "settings/Settings.h"
 #if defined(HAS_LIBAMCODEC)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -19,8 +19,8 @@
  *
  */
 
-#include "Interfaces/AESink.h"
-#include "Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "threads/CriticalSection.h"
 
 class AERingBuffer;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -26,6 +26,7 @@
 #include <Mmreg.h>
 #include <list>
 #include "threads/SingleLock.h"
+#include "threads/SystemClock.h"
 #include "utils/SystemInfo.h"
 #include "utils/TimeUtils.h"
 #include "utils/CharsetConverter.h"

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -19,10 +19,10 @@
  *
  */
 
-#include "Interfaces/AESink.h"
 #include <stdint.h>
 #include <dsound.h>
-#include "../Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 
 #include "threads/CriticalSection.h"
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
@@ -20,7 +20,7 @@
  */
 
 #include "system.h"
-
+#include "threads/Thread.h"
 #include "cores/AudioEngine/Interfaces/AESink.h"
 
 class CAESinkNULL : public CThread, public IAESink

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <limits.h>
 
-#include "Utils/AEUtil.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/StdString.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
@@ -19,8 +19,8 @@
  *
  */
 
-#include "Interfaces/AESink.h"
-#include "Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include <stdint.h>
 
 #include "threads/CriticalSection.h"

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
@@ -24,7 +24,7 @@
 #if defined(TARGET_RASPBERRY_PI)
 
 #include "cores/AudioEngine/Interfaces/AESink.h"
-#include "Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 
 #include "cores/omxplayer/OMXAudio.h"
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.cpp
@@ -20,11 +20,11 @@
 
 #include "system.h"
 
-#include "AESinkProfiler.h"
 #include <stdint.h>
 #include <limits.h>
 
-#include "Utils/AEUtil.h"
+#include "cores/AudioEngine/Sinks/AESinkProfiler.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/StdString.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"

--- a/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkProfiler.h
@@ -21,7 +21,7 @@
 
 #include "system.h"
 
-#include "Interfaces/AESink.h"
+#include "cores/AudioEngine/Interfaces/AESink.h"
 #include <stdint.h>
 
 class CAESinkProfiler : public IAESink

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -30,6 +30,7 @@
 #include "utils/StdString.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
+#include "threads/SystemClock.h"
 #include "utils/CharsetConverter.h"
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include <Mmreg.h>

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -25,13 +25,13 @@
 #include <Mmreg.h>
 #include <stdint.h>
 
-#include "../Utils/AEUtil.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/StdString.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
 #include "utils/CharsetConverter.h"
-#include "../Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include <Mmreg.h>
 #include <mmdeviceapi.h>
 #include "utils/StringUtils.h"

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -19,11 +19,11 @@
 *
 */
 
-#include "../Interfaces/AESink.h"
 #include <stdint.h>
 #include <mmdeviceapi.h>
 #include <Audioclient.h>
-#include "../Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 
 #include "threads/CriticalSection.h"
 


### PR DESCRIPTION
Allows the removal of the OMXPlayer specific include additions in Makefile.include.

Required for the OSX AE sink (should it ever reach reality).
