### PR TITLE
Faster channel switching for addons with built-in demuxer

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -128,7 +128,6 @@ bool CDVDDemuxPVRClient::Open(CDVDInputStream* pInput)
   if (!g_PVRClients->GetPlayingClient(m_pvrClient))
     return false;
 
-  RequestStreams();
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1056,7 +1056,10 @@ void CDVDPlayer::Process()
   // allow renderer to switch to fullscreen if requested
   m_dvdPlayerVideo.EnableFullscreen(m_PlayerOptions.fullscreen);
 
-  OpenDefaultStreams();
+  // don't open default streams here for demxued PVR streams, it is done 
+  // when the DMX_SPECIALID_STREAMCHANGE packet comes in
+  if (!m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
+    OpenDefaultStreams();
 
   // look for any EDL files
   m_Edl.Clear();
@@ -1173,7 +1176,10 @@ void CDVDPlayer::Process()
         break;
       }
 
-      OpenDefaultStreams();
+      // don't open default streams here for demxued PVR streams, it is done 
+      // when the DMX_SPECIALID_STREAMCHANGE packet comes in
+      if (!m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
+        OpenDefaultStreams();
 
       // never allow first frames after open to be skipped
       if( m_dvdPlayerVideo.IsInited() )

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1176,15 +1176,13 @@ void CDVDPlayer::Process()
       // never allow first frames after open to be skipped
       if( m_dvdPlayerVideo.IsInited() )
         m_dvdPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
-
-      // load channel settings
-      CFileItem currentItem(g_application.CurrentFileItem());
-      if (currentItem.HasPVRChannelInfoTag())
-        g_PVRManager.LoadCurrentChannelSettings();
   
       UpdateApplication(0);
       UpdatePlayState(0);
     }
+    
+    // update channel settings for PVR streams
+    UpdateChannelSettings();
 
     // handle eventual seeks due to playspeed
     HandlePlaySpeed();
@@ -4140,6 +4138,13 @@ void CDVDPlayer::UpdateApplication(double timeout)
     }
   }
   m_UpdateApplication = CDVDClock::GetAbsoluteClock();
+}
+
+void CDVDPlayer::UpdateChannelSettings()
+{
+  CFileItem currentItem(g_application.CurrentFileItem());
+  if (currentItem.HasPVRChannelInfoTag())
+    g_PVRManager.LoadCurrentChannelSettings();
 }
 
 bool CDVDPlayer::CanRecord()

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -340,6 +340,7 @@ protected:
   void OpenDefaultStreams(bool reset = true);
 
   void UpdateApplication(double timeout);
+  void UpdateChannelSettings();
   void UpdatePlayState(double timeout);
   double m_UpdateApplication;
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -249,18 +249,16 @@ public:
   virtual CStdString GetPlayingTitle();
 
   virtual bool SwitchChannel(const PVR::CPVRChannel &channel);
-  virtual bool CachePVRStream(void) const;
 
   enum ECacheState
   { CACHESTATE_DONE = 0
   , CACHESTATE_FULL     // player is filling up the demux queue
-  , CACHESTATE_PVR      // player is waiting for some data in each buffer
   , CACHESTATE_INIT     // player is waiting for first packet of each stream
   , CACHESTATE_PLAY     // player is waiting for players to not be stalled
   , CACHESTATE_FLUSH    // temporary state player will choose startup between init or full
   };
 
-  virtual bool IsCaching() const { return m_caching == CACHESTATE_FULL || m_caching == CACHESTATE_PVR; }
+  virtual bool IsCaching() const { return m_caching == CACHESTATE_FULL; }
   virtual int GetCacheLevel() const ;
 
   virtual int OnDVDNavResult(void* pData, int iMessage);


### PR DESCRIPTION
I've been experimenting with reducing the amount of stuff that happens when switching channels in an attempt to speed up the process, and this is what I have so far. These changes rely on https://github.com/opdenkamp/xbmc-pvr-addons/pull/259 for maximum efficiency. We already started the discussion over there but I think it's better to keep it here so people can more easily comment on specific changes etc.

All in all, the idea is to refrain from closing the demuxer and decoders when switching channels, unless it's necessary. Another part of speeding things up is removing the CACHESTATE_PVR caching state. This has been possible all along by using advancedsettings.xml and I'd like some feedback on what its purpose actually is (since stuff works fine without it)?

I am using this branch myself and while there seems to be some random issues with subtitles overall it works great. @amet also tested it successfully.

To start of the discussion I have two questions that I haven't gotten a clear answer on:
1. Why is the demuxer (m_pDemuxer) deleted all the time? 
2. What's the implication of reusing a decoder? @FernetMenta said something about extradata. Could someone shine on a light on all of this?

@elupus I take it all of this is somewhat your domain?
