### PR TITLE
[WIN32] clean build dirs and allow parallel solutions build

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -50,8 +50,8 @@ IF %comp%==vs2010 (
 
 	IF EXIST "!NET!" (
 		set msbuildemitsolution=1
-		set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Build /p:Configuration="%buildconfig%"
-		set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Clean /p:Configuration="%buildconfig%"
+		set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /m:4 /t:Build /p:Configuration="%buildconfig%"
+		set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /m:4 /t:Clean /p:Configuration="%buildconfig%"
 	) ELSE (
 		IF EXIST "%VS100COMNTOOLS%\..\IDE\devenv.com" (
 			set NET="%VS100COMNTOOLS%\..\IDE\devenv.com"

--- a/project/Win32BuildSetup/buildpvraddons.bat
+++ b/project/Win32BuildSetup/buildpvraddons.bat
@@ -17,7 +17,7 @@ SET BUILT_ADDONS_DIR=%SOURCE_DIR%\addons
 
 REM check if MSBuild.exe is used because it requires different command line switches
 IF "%msbuildemitsolution%" == "1" (
-  set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /t:Build /p:Configuration="Release"
+  set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /m:4 /t:Build /p:Configuration="Release"
 ) ELSE (
   set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /build Release
 )

--- a/tools/buildsteps/win32/prepare-env.bat
+++ b/tools/buildsteps/win32/prepare-env.bat
@@ -7,8 +7,8 @@ rem to keep the downloaded dependencies
 rem we assume git in path as this is a requirement
 
 cd %WORKSPACE%
-ECHO running git clean -xf
-git clean -xf
+ECHO running git clean -xfd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
+git clean -xfd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
 
 rem cleaning additional directories
 ECHO delete build directories


### PR DESCRIPTION
Not directly a fix but doesn't harm (according to jenkins) and saves as 5 minutes build time.
@t-nelson ?
