### PR TITLE
mysql: set engine to InnoDB to ensure the use of constraints

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1377,7 +1377,7 @@ int MysqlDataset::exec(const string &sql) {
   // force the charset and collation to UTF-8
   if ( ci_find(qry, "CREATE TABLE") != string::npos )
   {
-    qry += " CHARACTER SET utf8 COLLATE utf8_general_ci";
+    qry += " ENGINE InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci";
   }
 
   CLog::Log(LOGDEBUG,"Mysql execute: %s", qry.c_str());


### PR DESCRIPTION
This sets the database engine used for created MySQL tables to InnoDB. I'm lazy so I'll just copy the reasoning from http://trac.xbmc.org/ticket/14814 :

> It seems when auto-creating the MySQL database schemas the option "ENGINE=" isn't explicitly set in the CREATE TABLE statements. Therefor MySQL uses the default engine set on the MySQL server.
> 
> This is bad for several reasons:
> 
> 1) You cannot know which engine is the default on every server; Might be MEMORY or even BLACKHOLE. Either of these will break XBMC completely.
> 
> 2) Both DB schemas rely heavily on constrains, wich is a good thing (MyVideo75 has 380 constraints, MyMusic32 has 159). But constraints are only possible with the InnoDB engine.
> 
> 3) Many home users use the MySQL DBMS running on their NAS. Many of these boxes still have MySQL 5.1 running (example: Synology), even with the latest firmware. In MySQL 5.1 the default engine was still MyISAM which cannot make use of the 539 constraints xbmc uses in its two schemas.
> 
> 4) Falling back to MyISAM is bad for performance reasons. With every INSERT/UPDATE/DELETE operation the whole table gets locked; so whenever there is a write operation on a table, every read operation has to wait. This is bad for performance, especially when you have multiple HTPCs which is what having a central MySQL database is all about.
> 
> 5) Having 539 constraints in the two schemas suggests that they are made use of; i.e. relying upon the "ON DELETE CASCADE" statements to cascade DELETE operations into referencing tables. If so, falling back to MyISAM silently descards the constraints and therefor could leave the database corrupt as reference integrity is no longer ensured.

The only issue I see is that existing MySQL databases won't necessarily have InnoDB set as the engine.
