### PR TITLE
[rbp] Avoid resizing 1080p fanart

### DIFF
--- a/xbmc/cores/omxplayer/OMXImage.h
+++ b/xbmc/cores/omxplayer/OMXImage.h
@@ -125,7 +125,7 @@ public:
   unsigned int GetDecodedHeight() { return (unsigned int)m_decoded_format.format.image.nFrameHeight; };
   unsigned int GetDecodedStride() { return (unsigned int)m_decoded_format.format.image.nStride; };
 protected:
-  bool HandlePortSettingChange(unsigned int resize_width, unsigned int resize_height);
+  bool HandlePortSettingChange(unsigned int resize_width, unsigned int resize_height, unsigned int resize_stride);
   // Components
   COMXCoreComponent             m_omx_decoder;
   COMXCoreComponent             m_omx_resize;


### PR DESCRIPTION
Currently all re-encoded jpgs are resized to multiples of 16 widths and heights.
This causes additional blurring, especially for 1080p (which becomes 1088), as well as subtle aspect ratio errors.

Remove the alignment clamping, and fix up the heights/strides where needed
