### PR TITLE
[configure/airtunes] - fix the fallback to libshairport if libshairplay can't be found...

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1612,18 +1612,12 @@ fi
 # libshairplay for AirTunes (prefered lib)
 USE_AIRTUNES=0
 if test "x$use_airtunes" != "xno"; then
-  AC_CHECK_HEADERS([shairplay/raop.h],,
-   [if test "x$use_airtunes" = "xyes"; then
-      AC_MSG_ERROR($libshairplay_not_found)
-    elif test "x$use_airtunes" != "xno"; then
-      AC_MSG_NOTICE($libshairplay_not_found)
-      use_airtunes="no"
-    fi
+  AC_CHECK_HEADERS([shairplay/raop.h],USE_AIRTUNES=1,
+   [AC_MSG_NOTICE($libshairplay_not_found)
    ])
 
-  if test "x$use_airtunes" != "xno"; then
-    XB_FIND_SONAME([SHAIRPLAY], [shairplay], [use_airtunes])
-    USE_AIRTUNES=1
+  if test "x$USE_AIRTUNES" != "x0"; then
+    XB_FIND_SONAME([SHAIRPLAY], [shairplay], [USE_AIRTUNES])
     USE_LIBSHAIRPLAY=1
     AC_CHECK_MEMBERS([struct raop_callbacks_s.cls],,,
                      [[#include <shairplay/raop.h>]])
@@ -1632,22 +1626,23 @@ if test "x$use_airtunes" != "xno"; then
 
   #libshairport - as a fallback for AirTunes
   if test "x$USE_AIRTUNES" == "x0"; then
-    AC_CHECK_HEADERS([shairport/shairport.h],,
-     [if test "x$use_airtunes" = "xyes"; then
-        AC_MSG_ERROR($libshairport_not_found)
-      elif test "x$use_airtunes" != "xno"; then
-        AC_MSG_NOTICE($libshairport_not_found)
-        use_airtunes="no"
-      fi
+    AC_CHECK_HEADERS([shairport/shairport.h],USE_AIRTUNES=1,
+     [AC_MSG_NOTICE($libshairport_not_found)
      ])
 
-    if test "x$use_airtunes" != "xno"; then
-      XB_FIND_SONAME([SHAIRPORT], [shairport], [use_airtunes])
-      USE_AIRTUNES=1
+    if test "x$USE_AIRTUNES" != "x0"; then
+      XB_FIND_SONAME([SHAIRPORT], [shairport], [USE_AIRTUNES])
       AC_CHECK_MEMBERS([struct AudioOutput.ao_set_metadata],,,
                        [[#include <shairport/shairport.h>]])
       AC_DEFINE([HAVE_LIBSHAIRPORT],[1],["Define to 1 if you have libshairport."])
     fi
+  fi
+
+  if test "x$USE_AIRTUNES" == "x0"; then
+    if test "x$use_airtunes" == "xyes"; then
+      AC_MSG_ERROR("No airtunes library could be found. (libshairport/libshairplay)")
+    fi
+    use_airtunes="no"
   fi
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -1624,7 +1624,7 @@ if test "x$use_airtunes" != "xno"; then
   if test "x$use_airtunes" != "xno"; then
     XB_FIND_SONAME([SHAIRPLAY], [shairplay], [use_airtunes])
     USE_AIRTUNES=1
-    USE_LIBSHAIRPORT=1
+    USE_LIBSHAIRPLAY=1
     AC_CHECK_MEMBERS([struct raop_callbacks_s.cls],,,
                      [[#include <shairplay/raop.h>]])
     AC_DEFINE([HAVE_LIBSHAIRPLAY],[1],["Define to 1 if you have libshairplay."])
@@ -2387,7 +2387,7 @@ else
 fi
 
 if test "x$use_airtunes" != "xno"; then
-  if test "x$USE_LIBSHAIRPORT" == "x1"; then
+  if test "x$USE_LIBSHAIRPLAY" == "x1"; then
     final_message="$final_message\n  AirTunes support (libshairplay):\tYes"  
   else
     final_message="$final_message\n  AirTunes support (libshairport):\tYes"


### PR DESCRIPTION
... as pointed out by FneuFneu the fallback was not working because of poissoned variable use.

This fixes the fallback by tracking USE_AIRTUNES and only at the end of testing changing the use_airtunes variable.

@FneuFneu - can you test please? (i tried all constellations on ubuntu 10.4.2 - worked for me with this pr).
