### PR TITLE
[confluence] epg: adds genre to timeline info area

### DIFF
--- a/addons/skin.confluence/720p/ViewsPVR.xml
+++ b/addons/skin.confluence/720p/ViewsPVR.xml
@@ -1070,7 +1070,7 @@
 					<left>280</left>
 					<top>0</top>
 					<width>840</width>
-					<height>86</height>
+					<height>20</height>
 					<label>[B]$INFO[ListItem.Label][/B]</label>
 					<font>font13</font>
 					<textcolor>white</textcolor>
@@ -1079,8 +1079,8 @@
 					<left>280</left>
 					<top>25</top>
 					<width>840</width>
-					<height>86</height>
-					<label>$INFO[ListItem.StartTime]$INFO[ListItem.EndTime, - ]$INFO[ListItem.Duration, (,)]</label>
+					<height>20</height>
+					<label>$INFO[ListItem.StartTime]$INFO[ListItem.EndTime, - ]$INFO[ListItem.Genre, • ]</label>
 					<font>font12</font>
 					<textcolor>grey</textcolor>
 				</control>


### PR DESCRIPTION
A small addition, which adds the genre name after the start/end time in the new epg timeline info area instead of the duration time.

![screenshot000](https://f.cloud.github.com/assets/1878991/1850310/7a6c108a-76cd-11e3-8f43-bf3b15693fd2.png)
