### PR TITLE
[pvr] fix: epg data limited to 8 days although 14 days are supported

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -34,7 +34,7 @@ namespace PVR
 namespace EPG
 {
   #define MAXCHANNELS 20
-  #define MAXBLOCKS   2304 //! !!_EIGHT_!! days of 5 minute blocks
+  #define MAXBLOCKS   (16 * 24 * 60 / 5) //! 16 days of 5 minute blocks (14 days for upcoming data + 1 day for past data + 1 day for fillers)
 
   struct GridItemsPtr
   {


### PR DESCRIPTION
This increase the number of days to display in epg timeline view to 14 days as it's possible to select in settings.
