### PR TITLE
ActiveAE: update buffered time of streams on resume after suspend

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1049,6 +1049,9 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       (*it)->m_limiter.SetSamplerate(outputFormat.m_sampleRate);
     }
 
+    // update buffered time of streams
+    m_stats.AddSamples(0, m_streams);
+
     // buffers for viz
     if (!AE_IS_RAW(inputFormat.m_dataFormat))
     {


### PR DESCRIPTION
fixes "timeout adding data to renderer" after suspend/resume of HDMI audio after a change of refresh rate.
