### PR TITLE
[GUI] - fix execution of window specific mapped actions which are not ha...

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -729,7 +729,10 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
           {
             CGUIWindow *pWindow = g_windowManager.GetWindow(pMsg->dwParam1);  
             if (pWindow)
-              pWindow->OnAction(*action);
+            {
+              if (!pWindow->OnAction(*action))
+                g_application.OnAction(*action);
+            }
             else
               CLog::Log(LOGWARNING, "Failed to get window with ID %i to send an action to", pMsg->dwParam1);
           }


### PR DESCRIPTION
...ndled in the corresponding window by passing them into CApplication::OnAction as a fallback (fixes mapping from Stop, Pause, VolumeUp, VolumeDown and others via touchscreen.xml to FullScreenVideo which doesn't handle those actions).

There is another issue when mapping VolumeUp and VolumeDown where GetAmount() is used to judge how much the volume has to be changed. When mapping it via a swipe gesture GetAmount returns the X coordinate of the swipe end point. This leads to big volume steps (basically you can only get volume 0% or volume 100% ;) ).

But this will hopefully be resolved in another PR.

@jmarshallnz && @Montellese for review and comment on this one.
