### PR TITLE
[Confluence] fix non-intuitive navigation

### DIFF
--- a/addons/skin.confluence/720p/DialogPeripheralManager.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralManager.xml
@@ -73,9 +73,9 @@
 				<top>65</top>
 				<width>550</width>
 				<height>510</height>
-				<onup>20</onup>
-				<ondown>20</ondown>
-				<onleft>10</onleft>
+				<onup>10</onup>
+				<ondown>10</ondown>
+				<onleft>61</onleft>
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
 				<scrolltime>200</scrolltime>
@@ -224,8 +224,6 @@
 				<textcolor>white</textcolor>
 				<focusedcolor>white</focusedcolor>
 				<align>center</align>
-				<onleft>61</onleft>
-				<onright>20</onright>
 				<onup>20</onup>
 				<ondown>20</ondown>
 			</control>


### PR DESCRIPTION
having to press left to reach a button at the bottom is meh.

i'm assuming the number of items in the list will be relatively small
(i don't think people will have tens of peripheral devices)
so just scroll through the list to reach the 'ok' button at the bottom.

for @da-anda
