### PR TITLE
ActiveAE: remove group transitions from CONFIGURED to CONFIGURED_PLAY, f...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -435,14 +435,12 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
         case CActiveAEControlProtocol::RESUMESTREAM:
           stream = *(CActiveAEStream**)msg->data;
           stream->m_paused = false;
-          m_state = AE_TOP_CONFIGURED_PLAY;
           m_extTimeout = 0;
           return;
         case CActiveAEControlProtocol::FLUSHSTREAM:
           stream = *(CActiveAEStream**)msg->data;
           SFlushStream(stream);
           msg->Reply(CActiveAEControlProtocol::ACC);
-          m_state = AE_TOP_CONFIGURED_PLAY;
           m_extTimeout = 0;
           return;
         case CActiveAEControlProtocol::STREAMAMP:
@@ -655,6 +653,20 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
       {
         switch (signal)
         {
+        case CActiveAEControlProtocol::RESUMESTREAM:
+          CActiveAEStream *stream;
+          stream = *(CActiveAEStream**)msg->data;
+          stream->m_paused = false;
+          m_state = AE_TOP_CONFIGURED_PLAY;
+          m_extTimeout = 0;
+          return;
+        case CActiveAEControlProtocol::FLUSHSTREAM:
+          stream = *(CActiveAEStream**)msg->data;
+          SFlushStream(stream);
+          msg->Reply(CActiveAEControlProtocol::ACC);
+          m_state = AE_TOP_CONFIGURED_PLAY;
+          m_extTimeout = 0;
+          return;
         case CActiveAEControlProtocol::TIMEOUT:
           ResampleSounds();
           ClearDiscardedBuffers();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -353,7 +353,6 @@ void CActiveAEStream::Drain(bool wait)
         MsgStreamSample msgData;
         msgData.stream = this;
         msgData.buffer = *((CSampleBuffer**)msg->data);
-        RemapBuffer();
         msg->Reply(CActiveAEDataProtocol::STREAMSAMPLE, &msgData, sizeof(MsgStreamSample));
         DecFreeBuffers();
         continue;


### PR DESCRIPTION
another fix for ActiveAE. Resume stream triggered a transition from suspend to play after a change of refresh rate.

forum thread: http://forum.xbmc.org/showthread.php?tid=182335&page=3
