### PR TITLE
Label and settings UX cleanups

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRGuideSearch.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideSearch.xml
@@ -416,7 +416,7 @@
 				<align>center</align>
 				<aligny>center</aligny>
 				<font>font12_title</font>
-				<label>409</label>
+				<label>10035</label>
 				<onleft>26</onleft>
 				<onright>25</onright>
 				<onup>24</onup>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -5992,15 +5992,35 @@ msgctxt "#13438"
 msgid "Allow hardware acceleration (amcodec)"
 msgstr ""
 
+#: system/settings/settings.xml
 msgctxt "#13439"
 msgid "Allow hardware acceleration (MediaCodec)"
 msgstr ""
 
+#: system/settings/settings.xml
 msgctxt "#13440"
 msgid "Allow frame-multi-threaded decoding"
 msgstr ""
 
-#empty strings from id 13441 to 13499
+#. Label for a setting to confiure the video decoding method
+#: system/settings/settings.xml
+msgctxt "#13441"
+msgid "Decoding method"
+msgstr ""
+
+#. Option for video related setting #13441: Decoding method
+#: system/settings/settings.xml
+msgctxt "#13442"
+msgid "Software"
+msgstr ""
+
+#. Option for video related setting #13441: Decoding method
+#: system/settings/settings.xml
+msgctxt "#13443"
+msgid "Hardware accelerated"
+msgstr ""
+
+#empty strings from id 13444 to 13499
 
 #: system/settings/settings.xml
 msgctxt "#13500"
@@ -6595,7 +6615,13 @@ msgctxt "#14100"
 msgid "Stop ripping CD"
 msgstr ""
 
-#empty strings from id 14101 to 15011
+#. Name of a settings category related to video playback
+#: system/settings/settings.xml
+msgctxt "#14101"
+msgid "Processing"
+msgstr ""
+
+#empty strings from id 14102 to 15011
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15012"
@@ -14765,7 +14791,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36423"
-msgid "Use frame-multi-threaded decoding instead of hardware accelerated decoding (less reliable than default single thread mode)."
+msgid "Enables frame-multi-threaded decoding. Please note that it's less reliable than default single threaded mode."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -14798,7 +14824,19 @@ msgctxt "#36429"
 msgid "Select this if the audio out connection only supports multichannel audio as Dolby Digital 5.1, this allows multichannel audio such as AAC5.1 or FLAC5.1 to be listened to in 5.1 surround sound. Note - transcoding can lead to a reduction in sound quality"
 msgstr ""
 
-#empty strings from id 36430 to 36499
+#. Description for setting category #14101: Video Processing
+#: system/settings/settings.xml
+msgctxt "#36430"
+msgid "Configure how videos will be processed. This includes things like decoding and scaling."
+msgstr ""
+
+#. Description for video related setting #13441: Decoding mode 
+#: system/settings/settings.xml
+msgctxt "#36431"
+msgid "Defines how video decoding should be performed in software (requires more CPU) or with hardware acceleration. Please not that [Hardware accelerated] might not apply for all video sources played, even if enabled."
+msgstr ""
+
+#empty strings from id 36432 to 36499
 #end reservation
 
 #: system/settings/settings.xml

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8097,7 +8097,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#19221"
-msgid "Synchronise channel groups with backends"
+msgid "Synchronise channel groups with backend(s)"
 msgstr ""
 
 msgctxt "#19222"
@@ -10589,7 +10589,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21366"
-msgid "Subtitle folder"
+msgid "Custom subtitle folder"
 msgstr ""
 
 msgctxt "#21367"
@@ -11003,7 +11003,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21460"
-msgid "Subtitle location"
+msgid "Subtitle position"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -11055,12 +11055,12 @@ msgstr ""
 
 #: xbmc/cores/dvdplayer/DVDPlayer.cpp
 msgctxt "#21600"
-msgid "Prefer external subtitles"
+msgid "Prefer downloaded subtitles"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21601"
-msgid "Prefer external subtitles to internal ones"
+msgid "Prefer downloaded subtitles to default ones"
 msgstr ""
 
 #: xbmc/Util.cpp
@@ -13675,7 +13675,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36205"
-msgid "Sort the channels by channel number on the server, but uses XBMC's own numbering for channels."
+msgid "Sort the channels by channel number on the backend, but use XBMC's own numbering for channels."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -13790,7 +13790,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36228"
-msgid "Show the last viewed channel if switching to live tv."
+msgid "Continue with the last viewed channel on startup."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -13820,7 +13820,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36234"
-msgid "Duration of the recording when pressing the record button, or when creating a new manual timer. Defaults to 180 minutes."
+msgid "Duration of instant recordings when pressing the record button. Defaults to 120 minutes."
 msgstr ""
 
 #: system/settings/settings.xml

--- a/system/settings/android.xml
+++ b/system/settings/android.xml
@@ -8,10 +8,13 @@
     </category>
   </section>
   <section id="videos">
-    <category id="videoplayer">
-      <group id="2">
-        <setting id="videoplayer.usestagefright" type="boolean" label="13436" help="36260">
+    <category id="videoprocessing">
+      <group id="3">
+        <setting id="videoplayer.usestagefright" type="boolean" parent="videoplayer.decodingmethod" label="13436" help="36260">
           <requirement>HAVE_LIBSTAGEFRIGHTDECODER</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
           <level>2</level>
           <default>true</default>
           <updates>
@@ -19,8 +22,11 @@
           </updates>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.usemediacodec" type="boolean" label="13439" help="36544">
+        <setting id="videoplayer.usemediacodec" type="boolean" parent="videoplayer.decodingmethod" label="13439" help="36544">
           <visible>HAS_MEDIACODEC</visible>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
           <level>2</level>
           <default>true</default>
           <updates>

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -11,6 +11,12 @@
         </setting>
       </group>
     </category>
+    <category id="videoprocessing">
+      <group id="1">
+        <setting id="videoplayer.hqscalers">
+          <visible>false</visible>
+        </setting>
+    </category>
   </section>
   <section id="music">
     <category id="audiocds">

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -3,9 +3,6 @@
   <section id="videos">
     <category id="videoplayer">
       <group id="2">
-        <setting id="videoplayer.hqscalers">
-          <visible>false</visible>
-        </setting>
         <setting id="videoplayer.adjustrefreshrate">
           <visible>false</visible>
         </setting>
@@ -44,6 +41,12 @@
           <visible>false</visible>
         </setting>
         <setting id="audiooutput.ac3passthrough">
+          <requirement>IsAppleTV2</requirement>
+        </setting>
+        <setting id="audiooutput.ac3transcode">
+          <requirement>IsAppleTV2</requirement>
+        </setting>
+        <setting id="audiooutput.eac3passthrough">
           <requirement>IsAppleTV2</requirement>
         </setting>
         <setting id="audiooutput.dtspassthrough">

--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -10,9 +10,12 @@
     </category>
   </section>
   <section id="videos">
-    <category id="videoplayer">
-      <group id="2">
-        <setting id="videoplayer.usevda" type="boolean" label="13429" help="36160">
+    <category id="videoprocessing">
+      <group id="3">
+        <setting id="videoplayer.usevda" type="boolean" parent="videoplayer.decodingmethod" label="13429" help="36160">
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
           <level>2</level>
           <default>true</default>
           <control type="toggle" />

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -3,15 +3,16 @@
   <section id="videos">
     <category id="videoplayer">
       <group id="2">
-        <setting id="videoplayer.rendermethod">
-          <visible>false</visible>
-        </setting>
-        <setting id="videoplayer.hqscalers">
-          <visible>false</visible>
-        </setting>
         <setting id="videoplayer.synctype">
           <visible>false</visible>
         </setting>
+      </group>
+    </category>
+    <category id="videoprocessing">
+      <group id="1">
+        <visible>false</visible>
+      </group>
+      <group id="3">
         <setting id="videoplayer.useframemtdec">
           <visible>false</visible>
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -387,114 +387,6 @@
         </setting>
       </group>
       <group id="2">
-        <setting id="videoplayer.rendermethod" type="integer" label="13415" help="36153">
-          <level>2</level>
-          <default>0</default> <!-- RENDER_METHOD_AUTO -->
-          <constraints>
-            <options>rendermethods</options>
-          </constraints>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="videoplayer.hqscalers" type="integer" label="13435" help="36154">
-          <level>2</level>
-          <default>0</default>
-          <constraints>
-            <minimum>0</minimum>
-            <step>10</step>
-            <maximum>100</maximum>
-          </constraints>
-          <control type="spinner" format="string">
-            <formatlabel>14047</formatlabel>
-          </control>
-        </setting>
-        <setting id="videoplayer.useframemtdec" type="boolean" label="13440" help="36423">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.useamcodec" type="boolean" label="13438" help="36422">
-          <requirement>HAVE_AMCODEC</requirement>
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.useframemtdec" operator="is">false</dependency> <!-- disable when frame threading is active -->
-          </dependencies>
-          <level>2</level>
-          <default>true</default>
-          <updates>
-            <update type="change" />
-          </updates>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.usevdpau" type="boolean" label="13425" help="36155">
-          <requirement>HAVE_LIBVDPAU</requirement>
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.useframemtdec" operator="is">false</dependency> <!-- disable when frame threading is active -->
-          </dependencies>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.usevdpaumixer" type="boolean" label="13437" help="36421">
-          <requirement>HAVE_LIBVDPAU</requirement>
-          <level>2</level>
-          <default>true</default>
-          <dependencies>
-            <dependency type="enable">
-              <and>
-                <condition setting="videoplayer.usevdpau" operator="is">true</condition> <!-- USE VDPAU -->
-                <condition setting="videoplayer.useframemtdec" operator="is">false</condition> <!-- disable when frame threading is active -->
-              </and>
-            </dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.usevaapi" type="boolean" label="13426" help="36156">
-          <requirement>HAVE_LIBVA</requirement>
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.useframemtdec" operator="is">false</dependency> <!-- disable when frame threading is active -->
-          </dependencies>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.usedxva2" type="boolean" label="13427" help="36158">
-          <requirement>HasDXVA2</requirement>
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.useframemtdec" operator="is">false</dependency> <!-- disable when frame threading is active -->
-          </dependencies>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.usechd" type="boolean" label="13428" help="36159">
-          <requirement>HasCrystalHDDevice</requirement>
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.useframemtdec" operator="is">false</dependency> <!-- disable when frame threading is active -->
-          </dependencies>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.useomx" type="boolean" label="13430" help="36161">
-          <requirement>HAVE_LIBOPENMAX</requirement>
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.useframemtdec" operator="is">false</dependency> <!-- disable when frame threading is active -->
-          </dependencies>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.usevideotoolbox" type="boolean" label="13432" help="36162">
-          <requirement>HasVideoToolBoxDecoder</requirement>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.usepbo" type="boolean" label="13424" help="36163">
-          <requirement>HAS_GL</requirement>
-          <level>4</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
         <setting id="videoplayer.adjustrefreshrate" type="integer" label="170" help="36164">
           <level>2</level>
           <default>0</default> <!-- ADJUST_REFRESHRATE_OFF -->
@@ -581,14 +473,71 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="videoplayer.vdpau_allow_xrandr" type="boolean" label="13122" help="36172">
-          <requirement>HAVE_LIBVDPAU</requirement>
-          <level>4</level>
-          <default>false</default>
+      </group>
+      <group id="3">
+        <setting id="videoplayer.teletextenabled" type="boolean" label="23050" help="36174">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.teletextscale" type="boolean" label="23055" help="36175">
+          <level>1</level>
+          <default>true</default>
           <control type="toggle" />
         </setting>
       </group>
-      <group id="3">
+      <group id="4">
+        <setting id="videoplayer.stereoscopicplaybackmode" type="integer" label="36520" help="36537">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="36521">0</option> <!-- ASK     -->
+              <option label="36522">1</option> <!-- Preferred mode -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" delayed="true"/>
+        </setting>
+        <setting id="videoplayer.quitstereomodeonstop" type="boolean" label="36526" help="36538">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="videoprocessing" label="14101" help="36430">
+      <group id="1">
+        <setting id="videoplayer.rendermethod" type="integer" label="13415" help="36153">
+          <level>2</level>
+          <default>0</default> <!-- RENDER_METHOD_AUTO -->
+          <constraints>
+            <options>rendermethods</options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="videoplayer.hqscalers" type="integer" parent="videoplayer.rendermethod" label="13435" help="36154">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>10</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="spinner" format="string">
+            <formatlabel>14047</formatlabel>
+          </control>
+        </setting>
+        <setting id="videoplayer.usepbo" type="boolean" parent="videoplayer.rendermethod" label="13424" help="36163">
+          <requirement>HAS_GL</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.rendermethod" operator="is">1</dependency> <!-- only supported with ARB -->
+          </dependencies>
+          <level>4</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="2">
         <requirement>
           <and>
             <or>
@@ -603,32 +552,108 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-      </group>
-      <group id="4">
-        <setting id="videoplayer.teletextenabled" type="boolean" label="23050" help="36174">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="videoplayer.teletextscale" type="boolean" label="23055" help="36175">
-          <level>1</level>
-          <default>true</default>
+        <setting id="videoplayer.vdpau_allow_xrandr" type="boolean" label="13122" help="36172">
+          <level>4</level>
+          <default>false</default>
           <control type="toggle" />
         </setting>
       </group>
-      <group id="5">
-        <setting id="videoplayer.stereoscopicplaybackmode" type="integer" label="36520" help="36537">
+      <group id="3">
+        <setting id="videoplayer.decodingmethod" type="integer" label="13441" help="36431">
           <level>2</level>
-          <default>0</default>
+          <default>1</default>
           <constraints>
             <options>
-              <option label="36521">0</option> <!-- ASK     -->
-              <option label="36522">1</option> <!-- Preferred mode -->
+              <option label="13442">0</option> <!-- Software     -->
+              <option label="13443">1</option> <!-- Hardware     -->
             </options>
           </constraints>
-          <control type="spinner" format="integer" delayed="true"/>
+          <control type="spinner" format="integer" />
         </setting>
-        <setting id="videoplayer.quitstereomodeonstop" type="boolean" label="36526" help="36538">
+        <setting id="videoplayer.useframemtdec" type="boolean" parent="videoplayer.decodingmethod" label="13440" help="36423">
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">0</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.useamcodec" type="boolean" parent="videoplayer.decodingmethod" label="13438" help="36422">
+          <requirement>HAVE_AMCODEC</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevdpau" type="boolean" parent="videoplayer.decodingmethod" label="13425" help="36155">
+          <requirement>HAVE_LIBVDPAU</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevdpaumixer" type="boolean" parent="videoplayer.usevdpau" label="13437" help="36421">
+          <requirement>HAVE_LIBVDPAU</requirement>
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="videoplayer.usevdpau" operator="is">true</condition> <!-- USE VDPAU -->
+                <condition setting="videoplayer.decodingmethod" operator="is">1</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevaapi" type="boolean" parent="videoplayer.decodingmethod" label="13426" help="36156">
+          <requirement>HAVE_LIBVA</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usedxva2" type="boolean" parent="videoplayer.decodingmethod" label="13427" help="36158">
+          <requirement>HasDXVA2</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usechd" type="boolean" parent="videoplayer.decodingmethod" label="13428" help="36159">
+          <requirement>HasCrystalHDDevice</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.useomx" type="boolean" parent="videoplayer.decodingmethod" label="13430" help="36161">
+          <requirement>HAVE_LIBOPENMAX</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevideotoolbox" type="boolean" parent="videoplayer.decodingmethod" label="13432" help="36162">
+          <requirement>HasVideoToolBoxDecoder</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
           <level>2</level>
           <default>true</default>
           <control type="toggle" />

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -164,24 +164,6 @@
           <control type="list" format="string" />
         </setting>
       </group>
-      <group id="4">
-        <setting id="locale.audiolanguage" type="string" label="285" help="36119">
-          <level>1</level>
-          <default>original</default>
-          <constraints>
-            <options>streamlanguages</options>
-          </constraints>
-          <control type="list" format="string" />
-        </setting>
-        <setting id="locale.subtitlelanguage" type="string" label="286" help="36120">
-          <level>1</level>
-          <default>original</default>
-          <constraints>
-            <options>streamlanguages</options>
-          </constraints>
-          <control type="list" format="string" />
-        </setting>
-      </group>
     </category>
     <category id="filelists" label="14081" help="36121">
       <group id="1">
@@ -360,6 +342,8 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+      </group>
+      <group id="2">
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">
           <level>1</level>
           <default>false</default>
@@ -371,7 +355,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="2">
+      <group id="3">
         <setting id="videolibrary.cleanup" type="action" label="334" help="36148">
           <level>2</level>
           <control type="button" format="action" />
@@ -388,6 +372,14 @@
     </category>
     <category id="videoplayer" label="14086" help="36151">
       <group id="1">
+        <setting id="locale.audiolanguage" type="string" label="285" help="36119">
+          <level>1</level>
+          <default>original</default>
+          <constraints>
+            <options>streamlanguages</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="videoplayer.autoplaynextitem" type="boolean" label="13433" help="36152">
           <level>1</level>
           <default>false</default>
@@ -515,7 +507,7 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="videoplayer.pauseafterrefreshchange" type="integer" label="13550" help="36165">
+        <setting id="videoplayer.pauseafterrefreshchange" type="integer" parent="videoplayer.adjustrefreshrate" label="13550" help="36165">
           <level>2</level>
           <default>0</default>
           <constraints>
@@ -531,7 +523,7 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.synctype" type="integer" label="13500" help="36167">
+        <setting id="videoplayer.synctype" type="integer" parent="videoplayer.usedisplayasclock" label="13500" help="36167">
           <level>2</level>
           <default>2</default> <!-- SYNC_RESAMPLE -->
           <constraints>
@@ -693,6 +685,45 @@
     </category>
     <category id="subtitles" label="287" help="36184">
       <group id="1">
+        <setting id="locale.subtitlelanguage" type="string" label="286" help="36120">
+          <level>1</level>
+          <default>original</default>
+          <constraints>
+            <options>streamlanguages</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="subtitles.align" type="integer" label="21460" help="36192">
+          <level>1</level>
+          <default>0</default> <!-- SUBTITLE_ALIGN_MANUAL -->
+          <constraints>
+            <options>
+              <option label="21461">0</option> <!-- SUBTITLE_ALIGN_MANUAL -->
+              <option label="21462">1</option> <!-- SUBTITLE_ALIGN_BOTTOM_INSIDE -->
+              <option label="21463">2</option> <!-- SUBTITLE_ALIGN_BOTTOM_OUTSIDE -->
+              <option label="21464">3</option> <!-- SUBTITLE_ALIGN_TOP_INSIDE -->
+              <option label="21465">4</option> <!-- SUBTITLE_ALIGN_TOP_OUTSIDE -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="subtitles.stereoscopicdepth" type="integer" label="36545" help="36546">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>10</maximum>
+          </constraints>
+          <control type="spinner" format="integer" delayed="true"/>
+        </setting>
+        <setting id="subtitles.preferexternal" type="boolean" label="21600" help="21601">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="2">
         <setting id="subtitles.font" type="string" label="14089" help="36185">
           <level>1</level>
           <default>arial.ttf</default>
@@ -767,29 +798,30 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="2">
+      <group id="3">
         <setting id="subtitles.savetomoviefolder" type="boolean" label="24115" help="24106">
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="subtitles.custompath" type="path" label="21366" help="36191">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+            <writable>false</writable>
+            <sources>
+              <source>videos</source>
+            </sources>
+          </constraints>
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
+        </setting>
         <setting id="subtitles.pauseonsearch" type="boolean" label="24105" help="">
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
-        </setting>
-        <setting id="subtitles.languages" type="list[string]" label="24111" help="24112">
-          <level>1</level>
-          <default>English</default>
-          <constraints>
-            <options>languages</options>
-            <delimiter>,</delimiter>
-            <minimum>1</minimum>
-            <maximum>3</maximum>
-          </constraints>
-          <control type="list" format="string">
-            <multiselect>true</multiselect>
-          </control>
         </setting>
         <setting id="subtitles.tv" type="addon" label="24116" help="24117">
           <level>1</level>
@@ -806,51 +838,6 @@
             <addontype>xbmc.subtitle.module</addontype>
           </constraints>
           <control type="button" format="addon" />
-        </setting>
-        <setting id="subtitles.custompath" type="path" label="21366" help="36191">
-          <level>1</level>
-          <default></default>
-          <constraints>
-            <allowempty>true</allowempty>
-            <writable>false</writable>
-            <sources>
-              <source>videos</source>
-            </sources>
-          </constraints>
-          <control type="button" format="path">
-            <heading>657</heading>
-          </control>
-        </setting>
-        <setting id="subtitles.align" type="integer" label="21460" help="36192">
-          <level>1</level>
-          <default>0</default> <!-- SUBTITLE_ALIGN_MANUAL -->
-          <constraints>
-            <options>
-              <option label="21461">0</option> <!-- SUBTITLE_ALIGN_MANUAL -->
-              <option label="21462">1</option> <!-- SUBTITLE_ALIGN_BOTTOM_INSIDE -->
-              <option label="21463">2</option> <!-- SUBTITLE_ALIGN_BOTTOM_OUTSIDE -->
-              <option label="21464">3</option> <!-- SUBTITLE_ALIGN_TOP_INSIDE -->
-              <option label="21465">4</option> <!-- SUBTITLE_ALIGN_TOP_OUTSIDE -->
-            </options>
-          </constraints>
-          <control type="spinner" format="string" />
-        </setting>
-        <setting id="subtitles.preferexternal" type="boolean" label="21600" help="21601">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-      </group>
-      <group id="3">
-        <setting id="subtitles.stereoscopicdepth" type="integer" label="36545" help="36546">
-          <level>0</level>
-          <default>0</default>
-          <constraints>
-            <minimum>0</minimum>
-            <step>1</step>
-            <maximum>10</maximum>
-          </constraints>
-          <control type="spinner" format="integer" delayed="true"/>
         </setting>
       </group>
     </category>
@@ -969,17 +956,17 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="pvrmenu.infotimeout" type="boolean" label="19179" help="36213">
+        <setting id="pvrmenu.infotimeout" type="boolean" parent="pvrmenu.infoswitch" label="19179" help="36213">
           <level>2</level>
           <default>true</default>
           <control type="toggle" />
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="pvrmenu.infoswitch" operator="is">true</condition>
+            </dependency>
+          </dependencies>
         </setting>
-        <setting id="pvrmenu.closechannelosdonswitch" type="boolean" label="19229" help="36214">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="pvrmenu.infotime" type="integer" label="19184" help="36215">
+        <setting id="pvrmenu.infotime" type="integer" parent="pvrmenu.infoswitch" label="19184" help="36215">
           <level>2</level>
           <default>5</default>
           <constraints>
@@ -990,6 +977,19 @@
           <control type="spinner" format="string">
             <formatlabel>14045</formatlabel>
           </control>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="pvrmenu.infoswitch" operator="is">true</condition>
+                <condition setting="pvrmenu.infotimeout" operator="is">true</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="pvrmenu.closechannelosdonswitch" type="boolean" label="19229" help="36214">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
       <group id="2">
@@ -1362,6 +1362,8 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+      </group>
+      <group id="3">
         <setting id="musiclibrary.updateonstartup" type="boolean" label="22000" help="36259">
           <level>1</level>
           <default>false</default>
@@ -1373,7 +1375,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="3">
+      <group id="4">
         <setting id="musiclibrary.cleanup" type="action" label="334" help="36148">
           <level>2</level>
           <control type="button" format="action" />
@@ -1414,7 +1416,7 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="musicplayer.replaygainpreamp" type="integer" label="641" help="36268">
+        <setting id="musicplayer.replaygainpreamp" type="integer" parent="musicplayer.replaygaintype" label="641" help="36268">
           <level>2</level>
           <default>89</default>
           <constraints>
@@ -1425,8 +1427,11 @@
           <control type="spinner" format="string">
             <formatlabel>14050</formatlabel>
           </control>
+          <dependencies>
+            <dependency type="enable" setting="musicplayer.replaygaintype" operator="!is">0</dependency>
+          </dependencies>
         </setting>
-        <setting id="musicplayer.replaygainnogainpreamp" type="integer" label="642" help="36269">
+        <setting id="musicplayer.replaygainnogainpreamp" type="integer" parent="musicplayer.replaygaintype" label="642" help="36269">
           <level>2</level>
           <default>89</default>
           <constraints>
@@ -1437,11 +1442,17 @@
           <control type="spinner" format="string">
             <formatlabel>14050</formatlabel>
           </control>
+          <dependencies>
+            <dependency type="enable" setting="musicplayer.replaygaintype" operator="!is">0</dependency>
+          </dependencies>
         </setting>
-        <setting id="musicplayer.replaygainavoidclipping" type="boolean" label="643" help="36270">
+        <setting id="musicplayer.replaygainavoidclipping" type="boolean" parent="musicplayer.replaygaintype" label="643" help="36270">
           <level>2</level>
           <default>false</default>
           <control type="toggle" />
+          <dependencies>
+            <dependency type="enable" setting="musicplayer.replaygaintype" operator="!is">0</dependency>
+          </dependencies>
         </setting>
       </group>
       <group id="3">
@@ -1457,15 +1468,11 @@
             <formatlabel>14045</formatlabel>
           </control>
         </setting>
-        <setting id="musicplayer.crossfadealbumtracks" type="boolean" label="13400" help="36272">
+        <setting id="musicplayer.crossfadealbumtracks" type="boolean" parent="musicplayer.crossfade" label="13400" help="36272">
           <level>1</level>
           <default>true</default>
           <dependencies>
-            <dependency type="enable">
-              <and>
-                <condition setting="musicplayer.crossfade" operator="!is">0</condition>
-              </and>
-            </dependency>
+            <dependency type="enable" setting="musicplayer.crossfade" operator="!is">0</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -1592,7 +1599,7 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="audiocds.quality" type="integer" label="622" help="36288">
+        <setting id="audiocds.quality" type="integer" parent="audiocds.encoder" label="622" help="36288">
           <level>2</level>
           <default>0</default> <!-- CDDARIP_QUALITY_CBR -->
           <constraints>
@@ -1613,7 +1620,7 @@
           </dependencies>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="audiocds.bitrate" type="integer" label="623" help="36289">
+        <setting id="audiocds.bitrate" type="integer" parent="audiocds.encoder" label="623" help="36289">
           <level>2</level>
           <default>192</default>
           <constraints>
@@ -1634,7 +1641,7 @@
             <formatlabel>14048</formatlabel>
           </control>
         </setting>
-        <setting id="audiocds.compressionlevel" type="integer" label="665" help="36290">
+        <setting id="audiocds.compressionlevel" type="integer" parent="audiocds.encoder" label="665" help="36290">
           <level>2</level>
           <default>5</default>
           <constraints>
@@ -1867,7 +1874,7 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="services.upnpannounce" type="boolean" label="20188" help="36324">
+        <setting id="services.upnpannounce" type="boolean" parent="services.upnpserver" label="20188" help="36324">
           <level>2</level>
           <default>true</default>
           <dependencies>
@@ -2110,7 +2117,7 @@
           </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
-        <setting id="videoscreen.resolution" type="integer" label="169" help="36352">
+        <setting id="videoscreen.resolution" type="integer" parent="videoscreen.screen" label="169" help="36352">
           <level>0</level>
           <default>16</default> <!-- RES_DESKTOP -->
           <constraints>
@@ -2123,7 +2130,7 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
-        <setting id="videoscreen.screenmode" type="string" label="243" help="36353">
+        <setting id="videoscreen.screenmode" type="string" parent="videoscreen.screen" label="243" help="36353">
           <requirement>IsStandAlone</requirement>
           <level>0</level>
           <default>DESKTOP</default>
@@ -2140,7 +2147,7 @@
           </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
-        <setting id="videoscreen.fakefullscreen" type="boolean" label="14083" help="36354">
+        <setting id="videoscreen.fakefullscreen" type="boolean" parent="videoscreen.screen" label="14083" help="36354">
           <level>2</level>
           <default>true</default>
           <dependencies>
@@ -2148,7 +2155,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="videoscreen.blankdisplays" type="boolean" label="13130" help="36355">
+        <setting id="videoscreen.blankdisplays" type="boolean" parent="videoscreen.screen" label="13130" help="36355">
           <level>1</level>
           <default>false</default>
           <dependencies>
@@ -2345,11 +2352,11 @@
           <dependencies>
             <dependency type="visible">
               <and>
-                <condition setting="audiooutput.passthrough" operator="is">true</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthrough">audiooutput.passthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
               </and>
             </dependency>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <constraints>
             <options>audiodevicespassthrough</options>
@@ -2360,26 +2367,22 @@
           <level>2</level>
           <default>true</default>
           <dependencies>
-            <dependency type="visible">
-              <and>
-                <condition setting="audiooutput.passthrough" operator="is">true</condition>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
-              </and>
-            </dependency>
+            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="audiooutput.ac3transcode" type="boolean" label="667" help="36429">
+        <setting id="audiooutput.ac3transcode" type="boolean" parent="audiooutput.ac3passthrough" label="667" help="36429">
           <level>2</level>
           <default>true</default>
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition setting="audiooutput.passthrough" operator="is">true</condition>
                 <condition setting="audiooutput.ac3passthrough" operator="is">true</condition>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.ac3transcode</condition>
               </and>
             </dependency>
+            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.ac3transcode</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2387,12 +2390,8 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
-              <and>
-                <condition setting="audiooutput.passthrough" operator="is">true</condition>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
-              </and>
-            </dependency>
+            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2400,12 +2399,8 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
-              <and>
-                <condition setting="audiooutput.passthrough" operator="is">true</condition>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
-              </and>
-            </dependency>
+            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2415,11 +2410,11 @@
           <dependencies>
             <dependency type="visible">
               <and>
-                <condition setting="audiooutput.passthrough" operator="is">true</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.truehdpassthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthroughdevice">audiooutput.truehdpassthrough</condition>
               </and>
             </dependency>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2429,11 +2424,11 @@
           <dependencies>
             <dependency type="visible">
               <and>
-                <condition setting="audiooutput.passthrough" operator="is">true</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.dtshdpassthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthroughdevice">audiooutput.dtshdpassthrough</condition>
               </and>
             </dependency>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2644,7 +2639,7 @@
             <hidevalue>true</hidevalue>
           </control>
         </setting>
-        <setting id="masterlock.startuplock" type="boolean" label="20076" help="36397">
+        <setting id="masterlock.startuplock" type="boolean" parent="masterlock.lockcode" label="20076" help="36397">
           <level>2</level>
           <default>false</default>
           <dependencies>

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -34,6 +34,7 @@
 #endif
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "settings/VideoSettings.h"
 #include "utils/log.h"
 #include "boost/shared_ptr.hpp"
 #include "threads/Atomics.h"
@@ -70,7 +71,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
   CDVDVideoCodecFFmpeg* ctx  = (CDVDVideoCodecFFmpeg*)avctx->opaque;
 
   // if frame threading is enabled hw accel is not allowed
-  if(!ctx->IsHardwareAllowed() || CSettings::Get().GetBool("videoplayer.useframemtdec"))
+  if((EDECODEMETHOD) CSettings::Get().GetInt("videoplayer.decodingmethod") != VS_DECODEMETHOD_HARDWARE || !ctx->IsHardwareAllowed())
     return ctx->m_dllAvCodec.avcodec_default_get_format(avctx, fmt);
 
   const PixelFormat * cur = fmt;
@@ -250,7 +251,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
     CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading for Hi10p: %d",
                         m_pCodecContext->thread_type);
   }
-  else if (CSettings::Get().GetBool("videoplayer.useframemtdec"))
+  else if ((EDECODEMETHOD) CSettings::Get().GetInt("videoplayer.decodingmethod") == VS_DECODEMETHOD_SOFTWARE && CSettings::Get().GetBool("videoplayer.useframemtdec"))
   {
     CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading %d by videoplayer.useframemtdec",
                         m_pCodecContext->thread_type);

--- a/xbmc/settings/VideoSettings.h
+++ b/xbmc/settings/VideoSettings.h
@@ -92,6 +92,12 @@ enum ESCALINGMETHOD
   VS_SCALINGMETHOD_MAX // do not use and keep as last enum value.
 };
 
+enum EDECODEMETHOD
+{
+  VS_DECODEMETHOD_SOFTWARE=0,
+  VS_DECODEMETHOD_HARDWARE=1
+};
+
 typedef enum {
   ViewModeNormal      = 0,
   ViewModeZoom,


### PR DESCRIPTION
I took the time to go thorugh all settings and check them for usability issues. Doing so I found some wrong, inconsistent and/or misleading labels, i.e. in PVR settings and subtitles. Also the arrangement and visibility of certain settings didn't make sense to me, which is why I shuffled things around (like the "prefered audio/subtitle language" settings) and defined "parents" for settings which I though are apropriate to visualize the dependencies for better understanding (indention). Additionally I added some "enable" dependencies to settings where they where missing (i.e. ReplayGain and Crossfade settings).
