### PR TITLE
[ios] fixed, drop org.xbmc.xbmc-iconpack dependancy

### DIFF
--- a/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh
+++ b/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh
@@ -58,7 +58,7 @@ mkdir -p $DIRNAME/$PACKAGE/DEBIAN
 echo "Package: $PACKAGE"                          >  $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Priority: Extra"                            >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Name: XBMC-iOS"                             >> $DIRNAME/$PACKAGE/DEBIAN/control
-echo "Depends: firmware (>= 4.1), curl, org.xbmc.xbmc-iconpack" >> $DIRNAME/$PACKAGE/DEBIAN/control
+echo "Depends: firmware (>= 4.1), curl"           >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Version: $VERSION-$REVISION"                >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Architecture: iphoneos-arm"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Description: XBMC Multimedia Center for 4.x iOS" >> $DIRNAME/$PACKAGE/DEBIAN/control


### PR DESCRIPTION
simple really, drops org.xbmc.xbmc-iconpack dependancy so that deb can be loaded without adding xbmc repo in cydia

@davilla, @memphiz ?

@NedScott check please as well
