### PR TITLE
Support WTW/BTB display in test patterns

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -146,8 +146,12 @@ void CGUIFontTTFGL::End()
   glDrawArrays(GL_QUADS, 0, m_vertex_count);
   glPopClientAttrib();
 
+  glActiveTexture(GL_TEXTURE1);
   glBindTexture(GL_TEXTURE_2D, 0);
+  glDisable(GL_TEXTURE_2D);
   glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glDisable(GL_TEXTURE_2D);
 #else
   // GLES 2.0 version. Cannot draw quads. Convert to triangles.
   GLint posLoc  = g_Windowing.GUIShaderGetPos();

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -118,9 +118,14 @@ void CGUITextureGL::Begin(color_t color)
 void CGUITextureGL::End()
 {
   glEnd();
-  if (m_diffuse.size())
-    glDisable(GL_TEXTURE_2D);
+  glActiveTexture(GL_TEXTURE2_ARB);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glDisable(GL_TEXTURE_2D);
+  glActiveTexture(GL_TEXTURE1_ARB);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glDisable(GL_TEXTURE_2D);
   glActiveTexture(GL_TEXTURE0_ARB);
+  glBindTexture(GL_TEXTURE_2D, 0);
   glDisable(GL_TEXTURE_2D);
 }
 

--- a/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
+++ b/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
@@ -199,14 +199,14 @@ void CGUIWindowTestPatternDX::DrawContrastBrightnessPattern(int top, int left, i
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
     color = D3DCOLOR_COLORVALUE(m_black + 0.05f, m_black + 0.05f, m_black + 0.05f, 1.0f);
   else
-    color = D3DCOLOR_COLORVALUE(m_black, m_black, m_black, 1.0f);
+    color = D3DCOLOR_COLORVALUE(0.0f, 0.0f, 0.0f, 1.0f); // BTB
   DrawCircleEx(x25p, y75p, (y37p - y12p) / 3, color);
   DrawCircleEx(x75p, y25p, (y37p - y12p) / 3, color);
 
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
     color = D3DCOLOR_COLORVALUE(m_white - 0.05f, m_white - 0.05f, m_white - 0.05f, 1.0f);
   else
-    color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
+    color = D3DCOLOR_COLORVALUE(1.0f, 1.0f, 1.0f, 1.0f); // WTW
   DrawCircleEx(x25p, y25p, (y37p - y12p) / 3, color);
   DrawCircleEx(x75p, y75p, (y37p - y12p) / 3, color);
 }

--- a/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
+++ b/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
@@ -46,13 +46,13 @@ void CGUIWindowTestPatternDX::DrawVerticalLines(int top, int left, int bottom, i
     vert[p].y = (float)top;
     vert[p].z = 0.5f;
     vert[p].rhw = 1.0f;
-    vert[p].color = 0xffffffff;
+    vert[p].color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
     ++p;
     vert[p].x = (float)i;
     vert[p].y = (float)bottom;
     vert[p].z = 0.5f;
     vert[p].rhw = 1.0f;
-    vert[p].color = 0xffffffff;
+    vert[p].color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
     ++p;
   }
   g_Windowing.Get3DDevice()->SetFVF(D3DFVF_CUSTOMVERTEX);
@@ -71,13 +71,13 @@ void CGUIWindowTestPatternDX::DrawHorizontalLines(int top, int left, int bottom,
     vert[p].y = (float)i;
     vert[p].z = 0.5f;
     vert[p].rhw = 1.0f;
-    vert[p].color = 0xffffffff;
+    vert[p].color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
     ++p;
     vert[p].x = (float)right;
     vert[p].y = (float)i;
     vert[p].z = 0.5f;
     vert[p].rhw = 1.0f;
-    vert[p].color = 0xffffffff;
+    vert[p].color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
     ++p;
   }
   g_Windowing.Get3DDevice()->SetFVF(D3DFVF_CUSTOMVERTEX);
@@ -101,7 +101,7 @@ void CGUIWindowTestPatternDX::DrawCheckers(int top, int left, int bottom, int ri
         vert[i].y = (float)y;
         vert[i].z = 0.5f;
         vert[i].rhw = 1.0f;
-        vert[i].color = 0xffffffff;
+        vert[i].color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
       }
       else
       {
@@ -109,7 +109,7 @@ void CGUIWindowTestPatternDX::DrawCheckers(int top, int left, int bottom, int ri
         vert[i].y = (float)y;
         vert[i].z = 0.5f;
         vert[i].rhw = 1.0f;
-        vert[i].color = 0xffffffff;
+        vert[i].color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
       }
       ++i;
     }
@@ -131,12 +131,14 @@ void CGUIWindowTestPatternDX::DrawBouncingRectangle(int top, int left, int botto
   if ((m_bounceDirectionY == 1 && m_bounceY + TEST_PATTERNS_BOUNCE_SQUARE_SIZE == bottom) || (m_bounceDirectionY == -1 && m_bounceY == top))
     m_bounceDirectionY = -m_bounceDirectionY;
 
-  DrawRectangle((float)m_bounceX, (float)m_bounceY, (float)(m_bounceX + TEST_PATTERNS_BOUNCE_SQUARE_SIZE), (float)(m_bounceY + TEST_PATTERNS_BOUNCE_SQUARE_SIZE), 0xffffffff);
+  DrawRectangle((float)m_bounceX, (float)m_bounceY, (float)(m_bounceX + TEST_PATTERNS_BOUNCE_SQUARE_SIZE), (float)(m_bounceY + TEST_PATTERNS_BOUNCE_SQUARE_SIZE), D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f));
 }
 
 void CGUIWindowTestPatternDX::DrawContrastBrightnessPattern(int top, int left, int bottom, int right)
 {
-  DWORD color = 0xffffffff;
+  DWORD color;
+  DWORD color_white = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
+  DWORD color_black = D3DCOLOR_COLORVALUE(m_black, m_black, m_black, 1.0f);
   float x5p = (float) (left + (0.05f * (right - left)));
   float y5p = (float) (top + (0.05f * (bottom - top)));
   float x12p = (float) (left + (0.125f * (right - left)));
@@ -159,59 +161,59 @@ void CGUIWindowTestPatternDX::DrawContrastBrightnessPattern(int top, int left, i
   m_blinkFrame = (m_blinkFrame + 1) % TEST_PATTERNS_BLINK_CYCLE;
 
   // draw main quadrants
-  DrawRectangle(x50p, (float)top, (float)right, y50p, 0xffffffff);
-  DrawRectangle((float)left, (float)y50p, x50p, (float)bottom, 0xffffffff);
+  DrawRectangle(x50p, (float)top, (float)right, y50p, color_white);
+  DrawRectangle((float)left, (float)y50p, x50p, (float)bottom, color_white);
 
   // draw border lines
   CUSTOMVERTEX vert[] = 
   {
-    {(float)left, y5p, 0.5f, 1.0f, 0xffffffff},
-    {x50p, y5p, 0.5f, 1.0f, 0xffffffff},
-    {x5p, (float)top, 0.5f, 1.0f, 0xffffffff},
-    {x5p, y50p, 0.5f, 1.0f, 0xffffffff},
-    {x50p, y95p, 0.5f, 1.0f, 0xffffffff},
-    {(float)right, y95p, 0.5f, 1.0f, 0xffffffff},
-    {x95p, y50p, 0.5f, 1.0f, 0xffffffff},
-    {x95p, (float)bottom, 0.5f, 1.0f, 0xffffffff},
+    {(float)left, y5p, 0.5f, 1.0f, color_white},
+    {x50p, y5p, 0.5f, 1.0f, color_white},
+    {x5p, (float)top, 0.5f, 1.0f, color_white},
+    {x5p, y50p, 0.5f, 1.0f, color_white},
+    {x50p, y95p, 0.5f, 1.0f, color_white},
+    {(float)right, y95p, 0.5f, 1.0f, color_white},
+    {x95p, y50p, 0.5f, 1.0f, color_white},
+    {x95p, (float)bottom, 0.5f, 1.0f, color_white},
 
-    {x50p, y5p, 0.5f, 1.0f, 0xff000000},
-    {(float)right, y5p, 0.5f, 1.0f, 0xff000000},
-    {x5p, y50p, 0.5f, 1.0f, 0xff000000},
-    {x5p, (float)bottom, 0.5f, 1.0f, 0xff000000},
-    {(float)left, y95p, 0.5f, 1.0f, 0xff000000},
-    {x50p, y95p, 0.5f, 1.0f, 0xff000000},
-    {x95p, (float)top, 0.5f, 1.0f, 0xff000000},
-    {x95p, y50p, 0.5f, 1.0f, 0xff000000}
+    {x50p, y5p, 0.5f, 1.0f, color_black},
+    {(float)right, y5p, 0.5f, 1.0f, color_black},
+    {x5p, y50p, 0.5f, 1.0f, color_black},
+    {x5p, (float)bottom, 0.5f, 1.0f, color_black},
+    {(float)left, y95p, 0.5f, 1.0f, color_black},
+    {x50p, y95p, 0.5f, 1.0f, color_black},
+    {x95p, (float)top, 0.5f, 1.0f, color_black},
+    {x95p, y50p, 0.5f, 1.0f, color_black}
   };
   g_Windowing.Get3DDevice()->SetFVF(D3DFVF_CUSTOMVERTEX);
   g_Windowing.Get3DDevice()->DrawPrimitiveUP(D3DPT_LINELIST, 8, vert, sizeof(CUSTOMVERTEX));
 
   // draw inner rectangles
-  DrawRectangle(x12p, y12p, x37p, y37p, 0xffffffff);
-  DrawRectangle(x62p, y62p, x87p, y87p, 0xffffffff);
+  DrawRectangle(x12p, y12p, x37p, y37p, color_white);
+  DrawRectangle(x62p, y62p, x87p, y87p, color_white);
 
-  DrawRectangle(x62p, y12p, x87p, y37p, 0xff000000);
-  DrawRectangle(x12p, y62p, x37p, y87p, 0xff000000);
+  DrawRectangle(x62p, y12p, x87p, y37p, color_black);
+  DrawRectangle(x12p, y62p, x37p, y87p, color_black);
 
   // draw inner circles
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
-    color = D3DCOLOR_COLORVALUE(0.05f, 0.05f, 0.05f, 1.0f);
+    color = D3DCOLOR_COLORVALUE(m_black + 0.05f, m_black + 0.05f, m_black + 0.05f, 1.0f);
   else
-    color = D3DCOLOR_COLORVALUE(0.0f, 0.0f, 0.0f, 1.0f);
+    color = D3DCOLOR_COLORVALUE(m_black, m_black, m_black, 1.0f);
   DrawCircleEx(x25p, y75p, (y37p - y12p) / 3, color);
   DrawCircleEx(x75p, y25p, (y37p - y12p) / 3, color);
 
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
-    color = D3DCOLOR_COLORVALUE(0.95f, 0.95f, 0.95f, 1.0f);
+    color = D3DCOLOR_COLORVALUE(m_white - 0.05f, m_white - 0.05f, m_white - 0.05f, 1.0f);
   else
-    color = D3DCOLOR_COLORVALUE(1.0f, 1.0f, 1.0f, 1.0f);
+    color = D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f);
   DrawCircleEx(x25p, y25p, (y37p - y12p) / 3, color);
   DrawCircleEx(x75p, y75p, (y37p - y12p) / 3, color);
 }
 
 void CGUIWindowTestPatternDX::DrawCircle(int originX, int originY, int radius)
 {
-  DrawCircleEx((float)originX, (float)originY, (float)radius, 0xffffffff);
+  DrawCircleEx((float)originX, (float)originY, (float)radius, D3DCOLOR_COLORVALUE(m_white, m_white, m_white, 1.0f));
 }
 
 void CGUIWindowTestPatternDX::DrawCircleEx(float originX, float originY, float radius, DWORD color)

--- a/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
+++ b/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
@@ -37,7 +37,7 @@ CGUIWindowTestPatternGL::~CGUIWindowTestPatternGL(void)
 void CGUIWindowTestPatternGL::DrawVerticalLines(int top, int left, int bottom, int right)
 {
   glBegin(GL_LINES);
-  glColor3f(1, 1, 1);
+  glColor3f(m_white, m_white, m_white);
   for (int i = left; i <= right; i += 2)
   {
     glVertex2d(i, top);
@@ -49,7 +49,7 @@ void CGUIWindowTestPatternGL::DrawVerticalLines(int top, int left, int bottom, i
 void CGUIWindowTestPatternGL::DrawHorizontalLines(int top, int left, int bottom, int right)
 {
   glBegin(GL_LINES);
-  glColor3f(1, 1, 1);
+  glColor3f(m_white, m_white, m_white);
   for (int i = top; i <= bottom; i += 2)
   {
     glVertex2d(left, i);
@@ -61,7 +61,7 @@ void CGUIWindowTestPatternGL::DrawHorizontalLines(int top, int left, int bottom,
 void CGUIWindowTestPatternGL::DrawCheckers(int top, int left, int bottom, int right)
 {
   glBegin(GL_POINTS);
-  glColor3f(1, 1, 1);
+  glColor3f(m_white, m_white, m_white);
   for (int y = top; y <= bottom; y++)
   {
     for (int x = left; x <= right; x += 2)
@@ -86,7 +86,7 @@ void CGUIWindowTestPatternGL::DrawBouncingRectangle(int top, int left, int botto
   if ((m_bounceDirectionY == 1 && m_bounceY + TEST_PATTERNS_BOUNCE_SQUARE_SIZE == bottom) || (m_bounceDirectionY == -1 && m_bounceY == top))
     m_bounceDirectionY = -m_bounceDirectionY;
 
-  glColor3f(1, 1, 1);
+  glColor3f(m_white, m_white, m_white);
   glRecti(m_bounceX, m_bounceY, m_bounceX + TEST_PATTERNS_BOUNCE_SQUARE_SIZE, m_bounceY + TEST_PATTERNS_BOUNCE_SQUARE_SIZE);
 }
 
@@ -114,13 +114,13 @@ void CGUIWindowTestPatternGL::DrawContrastBrightnessPattern(int top, int left, i
   m_blinkFrame = (m_blinkFrame + 1) % TEST_PATTERNS_BLINK_CYCLE;
 
   // draw main quadrants
-  glColor3f(1, 1, 1);
+  glColor3f(m_white, m_white, m_white);
   glRecti(x50p, top, right, y50p);
   glRecti(left, y50p, x50p, bottom);
 
   // draw border lines
   glBegin(GL_LINES);
-    glColor3f(1, 1, 1);
+    glColor3f(m_white, m_white, m_white);
     glVertex2d(left, y5p);
     glVertex2d(x50p, y5p);
     glVertex2d(x5p, top);
@@ -130,7 +130,7 @@ void CGUIWindowTestPatternGL::DrawContrastBrightnessPattern(int top, int left, i
     glVertex2d(x95p, y50p);
     glVertex2d(x95p, bottom);
 
-    glColor3f(0, 0, 0);
+    glColor3f(m_black, m_black, m_black);
     glVertex2d(x50p, y5p);
     glVertex2d(right, y5p);
     glVertex2d(x5p, y50p);
@@ -142,26 +142,26 @@ void CGUIWindowTestPatternGL::DrawContrastBrightnessPattern(int top, int left, i
   glEnd();
 
   // draw inner rectangles
-  glColor3f(1, 1, 1);
+  glColor3f(m_white, m_white, m_white);
   glRecti(x12p, y12p, x37p, y37p);
   glRecti(x62p, y62p, x87p, y87p);
 
-  glColor3f(0, 0, 0);
+  glColor3f(m_black, m_black, m_black);
   glRecti(x62p, y12p, x87p, y37p);
   glRecti(x12p, y62p, x37p, y87p);
 
   // draw inner circles
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
-    glColor3f(0.05f, 0.05f, 0.05f);
+    glColor3f(m_black + 0.05f, m_black + 0.05f, m_black + 0.05f);
   else
-    glColor3f(0, 0, 0);
+    glColor3f(m_black, m_black, m_black);
   DrawCircle(x25p, y75p, (y37p - y12p) / 3);
   DrawCircle(x75p, y25p, (y37p - y12p) / 3);
 
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
-    glColor3f(0.95f, 0.95f, 0.95f);
+    glColor3f(m_white - 0.05f, m_white - 0.05f, m_white - 0.05f);
   else
-    glColor3f(1, 1, 1);
+    glColor3f(m_white, m_white, m_white);
   DrawCircle(x25p, y25p, (y37p - y12p) / 3);
   DrawCircle(x75p, y75p, (y37p - y12p) / 3);
 }
@@ -192,6 +192,7 @@ void CGUIWindowTestPatternGL::DrawCircle(int originX, int originY, int radius)
 void CGUIWindowTestPatternGL::BeginRender()
 {
   glDisable(GL_TEXTURE_2D);
+  glDisable(GL_BLEND);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 

--- a/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
+++ b/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
@@ -154,14 +154,14 @@ void CGUIWindowTestPatternGL::DrawContrastBrightnessPattern(int top, int left, i
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
     glColor3f(m_black + 0.05f, m_black + 0.05f, m_black + 0.05f);
   else
-    glColor3f(m_black, m_black, m_black);
+    glColor3f(0.0f, 0.0f, 0.0f); //BTB
   DrawCircle(x25p, y75p, (y37p - y12p) / 3);
   DrawCircle(x75p, y25p, (y37p - y12p) / 3);
 
   if (m_blinkFrame < TEST_PATTERNS_BLINK_CYCLE / 2)
     glColor3f(m_white - 0.05f, m_white - 0.05f, m_white - 0.05f);
   else
-    glColor3f(m_white, m_white, m_white);
+    glColor3f(1.0f, 1.0f, 1.0f); //WTW
   DrawCircle(x25p, y25p, (y37p - y12p) / 3);
   DrawCircle(x75p, y75p, (y37p - y12p) / 3);
 }

--- a/xbmc/settings/windows/GUIWindowTestPattern.cpp
+++ b/xbmc/settings/windows/GUIWindowTestPattern.cpp
@@ -23,9 +23,13 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "guilib/WindowIDs.h"
+#include "windowing/WindowingFactory.h"
+
 
 CGUIWindowTestPattern::CGUIWindowTestPattern(void)
     : CGUIWindow(WINDOW_TEST_PATTERN, "")
+    , m_white(1.0)
+    , m_black(0.0)
 {
   m_pattern = 0;
   m_bounceX = 0;
@@ -82,6 +86,18 @@ void CGUIWindowTestPattern::Process(unsigned int currentTime, CDirtyRegionList &
     MarkDirtyRegion();
   CGUIWindow::Process(currentTime, dirtyregions);
   m_renderRegion.SetRect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
+
+
+  if(g_Windowing.UseLimitedColor())
+  {
+    m_white = 235.0f / 255;
+    m_black =  16.0f / 255;
+  }
+  else
+  {
+    m_white = 1.0f;
+    m_black = 0.0f;
+  }
 }
 
 void CGUIWindowTestPattern::Render()

--- a/xbmc/settings/windows/GUIWindowTestPattern.h
+++ b/xbmc/settings/windows/GUIWindowTestPattern.h
@@ -52,6 +52,9 @@ protected:
   int m_bounceDirectionX;
   int m_bounceDirectionY;
   int m_blinkFrame;
+
+  float m_white;
+  float m_black;
 };
 
 


### PR DESCRIPTION
This fixes test patterns to properly display correct white level and black level, including WTW and BTB when possible.
