### PR TITLE
AESinkPULSE: Enable automatically if required headers are available

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -371,9 +371,9 @@ AC_ARG_ENABLE([alsa],
 
 AC_ARG_ENABLE([pulse],
   [AS_HELP_STRING([--enable-pulse],
-  [enable PulseAudio support (default is no)])],
+  [enable PulseAudio support (default is auto)])],
   [use_pulse=$enableval],
-  [use_pulse=no])
+  [use_pulse=auto])
 
 AC_ARG_ENABLE([ssh],
   [AS_HELP_STRING([--disable-ssh],

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -527,7 +527,12 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   const pa_buffer_attr *a;
 
   if (!(a = pa_stream_get_buffer_attr(m_Stream)))
-      CLog::Log(LOGERROR, "PulseAudio: %s", pa_strerror(pa_context_errno(m_Context)));
+  {
+    CLog::Log(LOGERROR, "PulseAudio: %s", pa_strerror(pa_context_errno(m_Context)));
+    pa_threaded_mainloop_unlock(m_MainLoop);
+    Deinitialize();
+    return false;
+  }
   else
   {
     unsigned int packetSize = a->minreq;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -195,6 +195,13 @@ struct SinkInfoStruct
   bool isHWDevice;
   bool device_not_found;
   pa_threaded_mainloop *mainloop;
+  SinkInfoStruct()
+  {
+    list = NULL;
+    isHWDevice = false;
+    device_not_found = false;
+    mainloop = NULL;
+  }
 };
 
 static void SinkInfoCallback(pa_context *c, const pa_sink_info *i, int eol, void *userdata)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -398,7 +398,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
 
   if (!SetupContext(NULL, &m_Context, &m_MainLoop))
   {
-    CLog::Log(LOGERROR, "PulseAudio: Failed to create context");
+    CLog::Log(LOGNOTICE, "PulseAudio might not be running. Context was not created.");
     Deinitialize();
     return false;
   }
@@ -680,7 +680,7 @@ void CAESinkPULSE::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 
   if (!SetupContext(NULL, &context, &mainloop))
   {
-    CLog::Log(LOGERROR, "PulseAudio: Failed to create context");
+    CLog::Log(LOGNOTICE, "PulseAudio might not be running. Context was not created.");
     return;
   }
 


### PR DESCRIPTION
Linux will fallback on ALSA if no PASinks can be enumerated.

If you want to have normal ALSA behaviour _though_ running pulseaudio, you need to do pulseaudio -k and create .pulse/client.conf with autospawn =no
