### PR TITLE
LIRC map: add mappings for more keys

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -95,6 +95,8 @@
 		<eight>KEY_8</eight>
 		<nine>KEY_9</nine>
 		<zero>KEY_0</zero>
+		<star>KEY_NUMERIC_STAR</star>
+		<hash>KEY_NUMERIC_POUND</hash>
 		<red>KEY_RED</red>
 		<green>KEY_GREEN</green>
 		<yellow>KEY_YELLOW</yellow>
@@ -419,6 +421,7 @@
 		<enter>KEY_ENTER</enter>
 		<clear>KEY_DELETE</clear>
 		<start>KEY_SELECT</start>
+		<start>KEY_MEDIA</start>
 		<start>KEY_PROG1</start>
 		<start>KEY_HOME</start>
 		<back>KEY_ESC</back>
@@ -447,6 +450,7 @@
 		<language>KEY_LANGUAGE</language>
 		<mute>KEY_MUTE</mute>
 		<power>KEY_POWER</power>
+		<power>KEY_SLEEP</power>
 		<myvideo>KEY_VIDEO</myvideo>
 		<mymusic>KEY_AUDIO</mymusic>
 		<mypictures>KEY_MHP</mypictures>
@@ -543,7 +547,10 @@
 		<select>KEY_OK</select>
 		<enter>KEY_ENTER</enter>
 		<clear>KEY_DELETE</clear>
+		<start>KEY_SELECT</start>
 		<start>KEY_MEDIA</start>
+		<start>KEY_PROG1</start>
+		<start>KEY_HOME</start>
 		<back>KEY_EXIT</back>
 		<record>KEY_RECORD</record>
 		<play>KEY_PLAY</play>
@@ -564,6 +571,7 @@
 		<display>KEY_ZOOM</display>
 		<mute>KEY_MUTE</mute>
 		<power>KEY_POWER</power>
+		<power>KEY_SLEEP</power>
 		<eject>KEY_EJECT</eject>
 		<menu>KEY_DVD</menu>
 		<menu>KEY_MENU</menu>
@@ -572,6 +580,16 @@
 		<mypictures>KEY_CAMERA</mypictures>
 		<mytv>KEY_TUNER</mytv>
 		<teletext>KEY_TEXT</teletext>
+		<one>KEY_1</one>
+		<two>KEY_2</two>
+		<three>KEY_3</three>
+		<four>KEY_4</four>
+		<five>KEY_5</five>
+		<six>KEY_6</six>
+		<seven>KEY_7</seven>
+		<eight>KEY8</eight>
+		<nine>KEY_9</nine>
+		<zero>KEY_0</zero>
 		<one>KEY_NUMERIC_1</one>
 		<two>KEY_NUMERIC_2</two>
 		<three>KEY_NUMERIC_3</three>


### PR DESCRIPTION
This patch adds to Lircmap.xml two numpad keys, plus the MEDIA and SLEEP keys.

The patch comes from Raspbmc, forward ported by me from Frodo to master.
