### PR TITLE
seperate 'devinput' section from 'linux-input-layer'. While 'linux-input...

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -410,7 +410,6 @@
 
 	<remote device="linux-input-layer">
 	<altname>cx23885_remote</altname>
-	<altname>devinput</altname>
 		<left>KEY_LEFT</left>
 		<right>KEY_RIGHT</right>
 		<up>KEY_UP</up>
@@ -534,5 +533,62 @@
 		<mymusic>green</mymusic>
 		<mypictures>yellow</mypictures>
 		<myvideo>blue</myvideo>
+	</remote>
+
+	<remote device="devinput">
+		<left>KEY_LEFT</left>
+		<right>KEY_RIGHT</right>
+		<up>KEY_UP</up>
+		<down>KEY_DOWN</down>
+		<select>KEY_OK</select>
+		<enter>KEY_ENTER</enter>
+		<clear>KEY_DELETE</clear>
+		<start>KEY_MEDIA</start>
+		<back>KEY_EXIT</back>
+		<record>KEY_RECORD</record>
+		<play>KEY_PLAY</play>
+		<pause>KEY_PAUSE</pause>
+		<stop>KEY_STOP</stop>
+		<forward>KEY_FASTFORWARD</forward>
+		<reverse>KEY_REWIND</reverse>
+		<volumeplus>KEY_VOLUMEUP</volumeplus>
+		<volumeminus>KEY_VOLUMEDOWN</volumeminus>
+		<channelplus>KEY_CHANNELUP</channelplus>
+		<channelminus>KEY_CHANNELDOWN</channelminus>
+		<skipplus>KEY_NEXT</skipplus>
+		<skipminus>KEY_PREVIOUS</skipminus>
+		<title>KEY_EPG</title>
+		<subtitle>KEY_SUBTITLE</subtitle>
+		<language>KEY_LANGUAGE</language>
+		<info>KEY_INFO</info>
+		<display>KEY_ZOOM</display>
+		<mute>KEY_MUTE</mute>
+		<power>KEY_POWER</power>
+		<eject>KEY_EJECT</eject>
+		<menu>KEY_DVD</menu>
+		<menu>KEY_MENU</menu>
+		<myvideo>KEY_VIDEO</myvideo>
+		<mymusic>KEY_AUDIO</mymusic>
+		<mypictures>KEY_CAMERA</mypictures>
+		<mytv>KEY_TUNER</mytv>
+		<teletext>KEY_TEXT</teletext>
+		<one>KEY_NUMERIC_1</one>
+		<two>KEY_NUMERIC_2</two>
+		<three>KEY_NUMERIC_3</three>
+		<four>KEY_NUMERIC_4</four>
+		<five>KEY_NUMERIC_5</five>
+		<six>KEY_NUMERIC_6</six>
+		<seven>KEY_NUMERIC_7</seven>
+		<eight>KEY_NUMERIC_8</eight>
+		<nine>KEY_NUMERIC_9</nine>
+		<zero>KEY_NUMERIC_0</zero>
+		<star>KEY_NUMERIC_STAR</star>
+		<hash>KEY_NUMERIC_POUND</hash>
+		<red>KEY_RED</red>
+		<green>KEY_GREEN</green>
+		<yellow>KEY_YELLOW</yellow>
+		<blue>KEY_BLUE</blue>
+		<recordedtv>KEY_PVR</recordedtv> 
+		<liveradio>KEY_RADIO</liveradio> 
 	</remote>
 </lircmap>


### PR DESCRIPTION
...-layer' is used from Lirc with the own (deprecated) Lirc drivers, 'devinput' is used by kernels own event drivers. There the Buttonnames are reworked and almost synced

this replaces #4000
