### PR TITLE
[bluray] Some fixes/improvements of bluray nav mode.

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12151,7 +12151,17 @@ msgctxt "#25007"
 msgid "Chapters: %u - duration: %s"
 msgstr ""
 
-#empty strings from id 25008 to 29799
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25008"
+msgid "Blu-ray Disc playback failed"
+msgstr ""
+
+#: xbmc/cores/dvdplayer/DVDPlayer.cpp
+msgctxt "#25009"
+msgid "The menu of this Blu-ray Disc is not supported"
+msgstr ""
+
+#empty strings from id 25010 to 29799
 #strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code
 
 #: skin.confluence

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -118,6 +118,7 @@ public:
     virtual void OnPrevious() = 0;
     virtual bool OnMouseMove(const CPoint &point) = 0;
     virtual bool OnMouseClick(const CPoint &point) = 0;
+    virtual bool HasMenu() = 0;
     virtual bool IsInMenu() = 0;
     virtual void SkipStill() = 0;
     virtual double GetTimeStampCorrection() = 0;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -556,13 +556,14 @@ void CDVDInputStreamBluray::ProcessEvent() {
     m_player->OnDVDNavResult((void*) &pid, 3);
     break;
 
-#ifdef HAVE_LIBBLURAY_BDJ
+#if (BLURAY_VERSION >= BLURAY_VERSION_CODE(0,2,2))
   case BD_EVENT_MENU:
-    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PG_TEXTST %d",
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_MENU %d",
         m_event.param);
     m_menu = !!m_event.param;
     break;
-
+#endif
+#if (BLURAY_VERSION >= BLURAY_VERSION_CODE(0,3,0))
   case BD_EVENT_IDLE:
     Sleep(100);
     break;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1008,7 +1008,10 @@ void CDVDInputStreamBluray::UserInput(bd_vk_key_e vk)
 void CDVDInputStreamBluray::OnMenu()
 {
   if(m_bd == NULL || !m_navmode)
+  {
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::OnMenu - nav mode is not enabled");
     return;
+  }
 
   if(m_dll->bd_user_input(m_bd, -1, BD_VK_POPUP) >= 0)
     return;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -695,7 +695,7 @@ void CDVDInputStreamBluray::OverlayInit(SPlane& plane, int w, int h)
 void CDVDInputStreamBluray::OverlayClear(SPlane& plane, int x, int y, int w, int h)
 {
 #if(BD_OVERLAY_INTERFACE_VERSION >= 2)
-  CRect ovr(x
+  CRectInt ovr(x
           , y
           , x + w
           , y + h);
@@ -703,12 +703,12 @@ void CDVDInputStreamBluray::OverlayClear(SPlane& plane, int x, int y, int w, int
   /* fixup existing overlays */
   for(SOverlays::iterator it = plane.o.begin(); it != plane.o.end();)
   {
-    CRect old((*it)->x
+    CRectInt old((*it)->x
             , (*it)->y
             , (*it)->x + (*it)->width
             , (*it)->y + (*it)->height);
 
-    vector<CRect> rem = old.SubtractRect(ovr);
+    vector<CRectInt> rem = old.SubtractRect(ovr);
 
     /* if no overlap we are done */
     if(rem.size() == 1 && !(rem[0] != old))
@@ -718,7 +718,7 @@ void CDVDInputStreamBluray::OverlayClear(SPlane& plane, int x, int y, int w, int
     }
 
     SOverlays add;
-    for(vector<CRect>::iterator itr = rem.begin(); itr != rem.end(); ++itr)
+    for(vector<CRectInt>::iterator itr = rem.begin(); itr != rem.end(); ++itr)
     {
       SOverlay overlay(new CDVDOverlayImage(*(*it)
                                             , itr->x1

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -35,6 +35,8 @@
 #include "URL.h"
 #include "guilib/Geometry.h"
 #include "utils/StringUtils.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "guilib/LocalizeStrings.h"
 
 #define LIBBLURAY_BYTESEEK 0
 
@@ -996,8 +998,17 @@ void CDVDInputStreamBluray::GetStreamInfo(int pid, char* language)
 
 CDVDInputStream::ENextStream CDVDInputStreamBluray::NextStream()
 {
-  if(!m_navmode || m_hold == HOLD_ERROR)
+  if(!m_navmode)
     return NEXTSTREAM_NONE;
+
+  if (m_hold == HOLD_ERROR)
+  {
+#if (BLURAY_VERSION < BLURAY_VERSION_CODE(0,3,0))
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray:: - libbluray navmode read error");
+    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25008), g_localizeStrings.Get(25009));
+#endif
+    return NEXTSTREAM_NONE;
+  }
 
   /* process any current event */
   ProcessEvent();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1072,4 +1072,9 @@ void CDVDInputStreamBluray::SkipStill()
   }
 }
 
+bool CDVDInputStreamBluray::HasMenu()
+{
+  return m_navmode;
+}
+
 #endif

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1021,9 +1021,8 @@ void CDVDInputStreamBluray::OnMenu()
     return;
 
   CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::OnMenu - root failed, trying explicit");
-  if(m_dll->bd_menu_call(m_bd, -1) >= 0)
-    return;
-  CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::OnMenu - root failed");
+  if(m_dll->bd_menu_call(m_bd, -1) <= 0)
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::OnMenu - root failed");
 }
 
 bool CDVDInputStreamBluray::IsInMenu()

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -27,6 +27,7 @@
 extern "C"
 {
 #include <libbluray/bluray.h>
+#include <libbluray/bluray-version.h>
 #include <libbluray/keys.h>
 #include <libbluray/overlay.h>
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -78,6 +78,7 @@ public:
   }
   virtual void OnNext()                  {}
   virtual void OnPrevious()              {}
+  virtual bool HasMenu();
   virtual bool IsInMenu();
   virtual bool OnMouseMove(const CPoint &point)  { return false; }
   virtual bool OnMouseClick(const CPoint &point) { return false; }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -117,15 +117,15 @@ protected:
   static void OverlayClear(SPlane& plane, int x, int y, int w, int h);
   static void OverlayInit (SPlane& plane, int w, int h);
 
-  IDVDPlayer*   m_player;
-  DllLibbluray *m_dll;
-  BLURAY* m_bd;
-  BLURAY_TITLE_INFO* m_title;
-  uint32_t           m_playlist;
-  uint32_t           m_clip;
-  uint32_t           m_angle;
-  bool               m_menu;
-  bool m_navmode;
+  IDVDPlayer*         m_player;
+  DllLibbluray*       m_dll;
+  BLURAY*             m_bd;
+  BLURAY_TITLE_INFO*  m_title;
+  uint32_t            m_playlist;
+  uint32_t            m_clip;
+  uint32_t            m_angle;
+  bool                m_menu;
+  bool                m_navmode;
 
   typedef boost::shared_ptr<CDVDOverlayImage> SOverlay;
   typedef std::list<SOverlay>                 SOverlays;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -149,6 +149,7 @@ protected:
     HOLD_HELD,
     HOLD_DATA,
     HOLD_STILL,
+    HOLD_ERROR
   } m_hold;
   BD_EVENT m_event;
 #ifdef HAVE_LIBBLURAY_BDJ

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -106,6 +106,7 @@ public:
   int GetTotalButtons();
   bool GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPicture, CDVDDemuxSPU* pSPU, int iButtonType /* 0 = selection, 1 = action (clicked)*/);
 
+  bool HasMenu() { return true; }
   bool IsInMenu() { return m_bInMenu; }
 
   int GetActiveSubtitleStream();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3432,6 +3432,12 @@ int CDVDPlayer::OnDVDNavResult(void* pData, int iMessage)
                   m_dvd.iDVDStillTime, time / 1000);
       }
     }
+    else if (iMessage == 6)
+    {
+      m_dvd.state = DVDSTATE_NORMAL;
+      CLog::Log(LOGDEBUG, "CDVDPlayer::OnDVDNavResult - libbluray read error (DVDSTATE_NORMAL)");
+      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25008), g_localizeStrings.Get(25009));
+    }
 
     return 0;
   }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3874,7 +3874,7 @@ bool CDVDPlayer::HasMenu()
 {
   CDVDInputStream::IMenus* pStream = dynamic_cast<CDVDInputStream::IMenus*>(m_pInputStream);
   if (pStream)
-    return true;
+    return pStream->HasMenu();
   else
     return false;
 }

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -17,7 +17,8 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-
+#include "system.h"
+#ifdef HAVE_LIBBLURAY
 #include "BlurayDirectory.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -188,3 +189,4 @@ bool CBlurayDirectory::GetDirectory(const CStdString& path, CFileItemList &items
 
 
 } /* namespace XFILE */
+#endif

--- a/xbmc/guilib/Geometry.h
+++ b/xbmc/guilib/Geometry.h
@@ -260,7 +260,7 @@ public:
 
   T x1, y1, x2, y2;
 private:
-  inline static float clamp_range(T x, T l, T h) XBMC_FORCE_INLINE
+  inline static T clamp_range(T x, T l, T h) XBMC_FORCE_INLINE
   {
     return (x > h) ? h : ((x < l) ? l : x);
   }


### PR DESCRIPTION
This series of commits fixes
- wrong interpretation of a return code https://github.com/xbmc/xbmc/commit/6dac8eda4aed5dc2e2cb82d5b14495ca6981f7e8
- unhandled events https://github.com/xbmc/xbmc/commit/d347b6df2a1fdce30b2a13bd4d51d067d37cb8ab
- compiler error in case of unavailable libbluray https://github.com/xbmc/xbmc/commit/e53255746b6328f0c8eb29829d4586d398d7d4e2
- compiler warnings https://github.com/xbmc/xbmc/commit/01b8b386a68ce10b3bbf6141c408e40ba38a2489
- disable menu button if the disc is played in non-nav mode https://github.com/xbmc/xbmc/commit/ea0ee2f50c924b03d078a36dd64b6178e228fc61
- infinite loop if (next) bluray title can not be played https://github.com/xbmc/xbmc/commit/44cca8be3f195835b83964ecfd7ac0cae2aa73c3 and https://github.com/xbmc/xbmc/commit/73cff84345d19d2f682f52f2d0b53e2f602de740
