### PR TITLE
linux: link ffmpeg statically

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -488,6 +488,17 @@ ifeq ($(findstring freebsd,@ARCH@),freebsd)
 DYNOBJSXBMC+= xbmc/freebsd/freebsd.a
 endif
 
+ifeq (@USE_STATIC_FFMPEG@,1)
+DYNOBJSXBMC += lib/ffmpeg/libavcodec/libavcodec.a \
+               lib/ffmpeg/libavfilter/libavfilter.a \
+               lib/ffmpeg/libswresample/libswresample.a \
+               lib/ffmpeg/libavformat/libavformat.a \
+               lib/ffmpeg/libavutil/libavutil.a \
+               lib/ffmpeg/libpostproc/libpostproc.a \
+               lib/ffmpeg/libswscale/libswscale.a
+LIBS+= @GNUTLS_ALL_LIBS@ @VORBISENC_ALL_LIBS@
+endif
+
 OBJSXBMC:=$(filter-out $(DYNOBJSXBMC), $(OBJSXBMC))
 
 MAINOBJS=xbmc/xbmc.o

--- a/configure.in
+++ b/configure.in
@@ -598,6 +598,7 @@ MAKE="${MAKE:-make}"
 OBJDUMP="${OBJDUMP:-objdump}"
 
 use_external_ffmpeg=no
+use_static_ffmpeg=no
 
 # ffmpeg needs the output of uname -s (e.x. linux, darwin) for the target_os
 # there is no autoconf variable which will give
@@ -627,6 +628,8 @@ case $host in
      if test "$use_cpu" = "no" -a "$cross_compiling" = "yes";  then
         use_arch="x86"
         use_cpu="i686"
+     else
+        target_platform=target_linux
      fi
      ;;
   x86_64-*-linux-gnu*|x86_64-*-linux-uclibc*)
@@ -634,6 +637,8 @@ case $host in
      if test "$use_cpu" = "no" -a "$cross_compiling" = "yes";  then
         use_arch="x86_64"
         use_cpu="x86_64"
+     else
+        target_platform=target_linux
      fi
      ;;
   i386-*-freebsd*)
@@ -867,6 +872,15 @@ elif test "$use_arch" = "arm"; then
     fi
   fi
 fi
+if test "$target_platform" = "target_linux"; then
+  USE_STATIC_FFMPEG=1
+  use_static_ffmpeg=yes
+  AC_DEFINE([USE_STATIC_FFMPEG], [1], [link ffmpeg statically])
+  # ffmpeg may depend on gnutls and vorbisenc, we add those libs at the end of linker
+  # command in order to resolve any missing symbols
+  GNUTLS_ALL_LIBS=`${PKG_CONFIG} --static --libs-only-l --silence-errors gnutls`
+  VORBISENC_ALL_LIBS=`${PKG_CONFIG} --static --libs-only-l --silence-errors vorbisenc`
+fi 
 
 # Checks for library functions.
 AC_FUNC_ALLOCA
@@ -2601,6 +2615,7 @@ AC_SUBST(DISABLE_FISHBMC)
 AC_SUBST(DISABLE_PROJECTM)
 AC_SUBST(USE_SKIN_TOUCHED)
 AC_SUBST(USE_EXTERNAL_FFMPEG)
+AC_SUBST(USE_STATIC_FFMPEG)
 AC_SUBST(USE_LIBAV_HACKS)
 AC_SUBST(PYTHON_VERSION)
 AC_SUBST(OUTPUT_FILES)
@@ -2645,6 +2660,8 @@ AC_SUBST(USE_ANDROID)
 AC_SUBST(GTEST_CONFIGURED)
 AC_SUBST(USE_DOXYGEN)
 AC_SUBST(USE_PVR_ADDONS)
+AC_SUBST(GNUTLS_ALL_LIBS)
+AC_SUBST(VORBISENC_ALL_LIBS)
 
 # pushd and popd are not available in other shells besides bash, so implement
 # our own pushd/popd functions
@@ -2802,7 +2819,7 @@ XB_CONFIG_MODULE([lib/ffmpeg], [
       --disable-ffserver \
       --disable-ffmpeg \
       --disable-crystalhd \
-      --enable-shared \
+      `if test "$use_static_ffmpeg" = "yes"; then echo --enable-static; else echo --enable-shared; fi` \
       --disable-doc \
       --enable-postproc \
       --enable-gpl \

--- a/configure.in
+++ b/configure.in
@@ -188,9 +188,6 @@ libcec_disabled="== libcec disabled. CEC adapter support will not be available. 
 # External library message strings
 external_libraries_enabled="== Use of all supported external libraries enabled. =="
 external_libraries_disabled="== Use of all supported external libraries disabled. =="
-external_ffmpeg_enabled="== Use of external ffmpeg enabled. =="
-external_ffmpeg_disabled="== Use of external ffmpeg disabled. =="
-ffmpeg_vdpau_not_supported="== External ffmpeg doesn't support VDPAU. VDPAU support disabled. =="
 dashes="------------------------"
 final_message="\n  XBMC Configuration:"
 final_message="\n$dashes$final_message\n$dashes"
@@ -569,12 +566,6 @@ AC_ARG_ENABLE([external-libraries],
   [use_external_libraries=$enableval],
   [use_external_libraries=no])
 
-AC_ARG_ENABLE([external-ffmpeg],
-  [AS_HELP_STRING([--enable-external-ffmpeg],
-  [enable use of external ffmpeg libraries (default is no) 'Linux only'])],
-  [use_external_ffmpeg=$enableval],
-  [use_external_ffmpeg=$use_external_libraries])
-
 AC_ARG_ENABLE([libav-compat],
   [AS_HELP_STRING([--enable-libav-compat],
   [build a wrapper around libav to provide the functions needed by XBMC. This is
@@ -605,6 +596,8 @@ AC_PROG_MAKE_SET
 PKG_PROG_PKG_CONFIG
 MAKE="${MAKE:-make}"
 OBJDUMP="${OBJDUMP:-objdump}"
+
+use_external_ffmpeg=no
 
 # ffmpeg needs the output of uname -s (e.x. linux, darwin) for the target_os
 # there is no autoconf variable which will give

--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -94,7 +94,7 @@ public:
   virtual AVDictionary* av_frame_get_metadata(const AVFrame* frame)=0;
 };
 
-#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
+#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) || (defined USE_STATIC_FFMPEG)
 
 // Use direct layer
 class DllAvCodec : public DllDynamic, DllAvCodecInterface
@@ -166,7 +166,7 @@ public:
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {
-#if !defined(TARGET_DARWIN)
+#if !defined(TARGET_DARWIN) && !defined(USE_STATIC_FFMPEG)
     CLog::Log(LOGDEBUG, "DllAvCodec: Using libavcodec system library");
 #endif
     return true;

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -104,7 +104,7 @@ public:
 #endif
 };
 
-#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
+#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) || (defined USE_STATIC_FFMPEG)
 // Use direct mapping
 class DllAvFilter : public DllDynamic, DllAvFilterInterface
 {

--- a/lib/DllAvFormat.h
+++ b/lib/DllAvFormat.h
@@ -41,7 +41,7 @@ extern "C" {
   void xbmc_read_frame_flush(AVFormatContext *s);
 #else
   #include "libavformat/avformat.h"
-  #if defined(TARGET_DARWIN)
+  #if defined(TARGET_DARWIN) || defined(USE_STATIC_FFMPEG)
     void ff_read_frame_flush(AVFormatContext *s);    // internal replacement 
     #define xbmc_read_frame_flush ff_read_frame_flush
   #endif
@@ -73,7 +73,7 @@ public:
   virtual int av_read_play(AVFormatContext *s)=0;
   virtual int av_read_pause(AVFormatContext *s)=0;
   virtual int av_seek_frame(AVFormatContext *s, int stream_index, int64_t timestamp, int flags)=0;
-#if (!defined USE_EXTERNAL_FFMPEG) && (!defined TARGET_DARWIN)
+#if (!defined USE_EXTERNAL_FFMPEG) && (!defined TARGET_DARWIN) && (!defined USE_STATIC_FFMPEG)
   virtual int avformat_find_stream_info_dont_call(AVFormatContext *ic, AVDictionary **options)=0;
 #endif
   virtual int avformat_open_input(AVFormatContext **ps, const char *filename, AVInputFormat *fmt, AVDictionary **options)=0;
@@ -108,7 +108,7 @@ public:
 #endif
 };
 
-#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
+#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) || (defined USE_STATIC_FFMPEG)
 
 // Use direct mapping
 class DllAvFormat : public DllDynamic, DllAvFormatInterface
@@ -170,7 +170,7 @@ public:
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {
-#if !defined(TARGET_DARWIN)
+#if !defined(TARGET_DARWIN) && !defined(USE_STATIC_FFMPEG)
     CLog::Log(LOGDEBUG, "DllAvFormat: Using libavformat system library");
 #endif
     CSingleLock lock(DllAvCodec::m_critSection);

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -116,7 +116,7 @@ public:
 #endif
 };
 
-#if defined (USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
+#if defined (USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) || (defined USE_STATIC_FFMPEG)
 // Use direct layer
 class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
 {
@@ -174,7 +174,7 @@ public:
    // DLL faking.
    virtual bool ResolveExports() { return true; }
    virtual bool Load() {
-#if !defined(TARGET_DARWIN)
+#if !defined(TARGET_DARWIN) && !defined(USE_STATIC_FFMPEG)
      CLog::Log(LOGDEBUG, "DllAvUtilBase: Using libavutil system library");
 #endif
      return true;

--- a/lib/DllPostProc.h
+++ b/lib/DllPostProc.h
@@ -78,7 +78,7 @@ public:
   virtual void pp_free_context(pp_context *ppContext)=0;
 };
 
-#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
+#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) || (defined USE_STATIC_FFMPEG)
 
 // We call directly.
 class DllPostProc : public DllDynamic, DllPostProcInterface

--- a/lib/DllSwResample.h
+++ b/lib/DllSwResample.h
@@ -60,7 +60,7 @@ public:
   virtual int swr_set_compensation(struct SwrContext *s, int sample_delta, int compensation_distance) = 0;
 };
 
-#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
+#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) || (defined USE_STATIC_FFMPEG)
 
 // Use direct mapping
 class DllSwResample : public DllDynamic, DllSwResampleInterface
@@ -71,7 +71,7 @@ public:
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {
-#if !defined(TARGET_DARWIN)
+#if !defined(TARGET_DARWIN) && !defined(USE_STATIC_FFMPEG)
     CLog::Log(LOGDEBUG, "DllAvFormat: Using libswresample system library");
 #endif
     return true;

--- a/lib/DllSwScale.h
+++ b/lib/DllSwScale.h
@@ -87,7 +87,7 @@ public:
    virtual void sws_freeContext(struct SwsContext *context)=0;
 };
 
-#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
+#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) || (defined USE_STATIC_FFMPEG)
 
 // We call into this library directly.
 class DllSwScale : public DllDynamic, public DllSwScaleInterface
@@ -111,7 +111,7 @@ public:
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {
-#if !defined(TARGET_DARWIN)
+#if !defined(TARGET_DARWIN) && !defined(USE_STATIC_FFMPEG)
     CLog::Log(LOGDEBUG, "DllSwScale: Using libswscale system library");
 #endif
     return true;

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -27,6 +27,7 @@ endif
 
 LIBS=
 ifneq (@USE_EXTERNAL_FFMPEG@,1)
+ifneq (@USE_STATIC_FFMPEG@,1)
   LIBS+=$(AVUTIL_SO) \
 	$(AVCODEC_SO) \
 	$(AVFORMAT_SO) \
@@ -35,10 +36,12 @@ ifneq (@USE_EXTERNAL_FFMPEG@,1)
 	$(SWSCALE_SO) \
 	$(SWRESAMPLE_SO)
 endif
+endif
 
 .PHONY: $(DIRS) codecs
 
 ifneq ($(findstring osx,$(ARCH)), osx)
+ifneq (@USE_STATIC_FFMPEG@,1)
 
 codecs: $(addprefix $(SYSDIR)/, $(LIBS));
 
@@ -70,6 +73,17 @@ ffmpeg/libavfilter/libavfilter.so : ffmpeg;
 ffmpeg/libswscale/libswscale.so   : ffmpeg;
 ffmpeg/libpostproc/libpostproc.so : ffmpeg;
 ffmpeg/libswresample/libswresample.so : ffmpeg;
+endif
+endif
+
+ifeq (@USE_STATIC_FFMPEG@,1)
+ffmpeg/libavutil/libavutil.a     : ffmpeg;
+ffmpeg/libavcodec/libavcodec.a   : ffmpeg;
+ffmpeg/libavformat/libavformat.a : ffmpeg;
+ffmpeg/libavfilter/libavfilter.a : ffmpeg;
+ffmpeg/libswscale/libswscale.a   : ffmpeg;
+ffmpeg/libpostproc/libpostproc.a : ffmpeg;
+ffmpeg/libswresample/libswresample.a : ffmpeg;
 endif
 
 ffmpeg:


### PR DESCRIPTION
see title, prevent XBMC from being used with not supported versions of ffmpeg or libav.
