### PR TITLE
dvdplayer audio: fix invalid format after 5852fd70705b7c23141b1672a24d83...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -50,8 +50,7 @@ protected:
   SwrContext*         m_pConvert;
   enum AVSampleFormat m_iSampleFormat;  
   CAEChannelInfo      m_channelLayout;
-  bool                m_bLpcmMode;  
-  bool                m_bNeedConversion;
+  bool                m_bLpcmMode;
 
   AVFrame* m_pFrame1;
   int      m_iBufferSize1;


### PR DESCRIPTION
now I know why need_conversion was checked that late. I removed the silly flag and check at that point in time we need to know
