### PR TITLE
[AE/CA] - Fix optical 3fps issue. This was caused by a problem with dd-w...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.cpp
@@ -85,7 +85,7 @@ CCoreAudioAEHALOSX::~CCoreAudioAEHALOSX()
   delete m_OutputStream;
 }
 
-bool CCoreAudioAEHALOSX::InitializePCM(ICoreAudioSource *pSource, AEAudioFormat &format, bool allowMixing, AudioDeviceID outputDevice)
+bool CCoreAudioAEHALOSX::InitializePCM(ICoreAudioSource *pSource, AEAudioFormat &format, bool allowMixing, AudioDeviceID outputDevice, bool encoded)
 {
   if (m_audioGraph)
     m_audioGraph->Close(), delete m_audioGraph;
@@ -98,7 +98,7 @@ bool CCoreAudioAEHALOSX::InitializePCM(ICoreAudioSource *pSource, AEAudioFormat 
   if (!m_Passthrough && CSettings::Get().GetInt("audiooutput.channels") ==  AE_CH_LAYOUT_2_0)
     layout = g_LayoutMap[1];
 
-  if (!m_audioGraph->Open(pSource, format, outputDevice, allowMixing, layout, m_initVolume ))
+  if (!m_audioGraph->Open(pSource, format, outputDevice, allowMixing, layout, m_initVolume, encoded ))
   {
     CLog::Log(LOGDEBUG, "CCoreAudioAEHALOSX::Initialize: "
       "Unable to initialize audio due a missconfiguration. Try 2.0 speaker configuration.");
@@ -121,7 +121,7 @@ bool CCoreAudioAEHALOSX::InitializePCMEncoded(ICoreAudioSource *pSource, AEAudio
   // Set the Sample Rate as defined by the spec.
   m_AudioDevice->SetNominalSampleRate((float)format.m_sampleRate);
 
-  if (!InitializePCM(pSource, format, false, outputDevice))
+  if (!InitializePCM(pSource, format, false, outputDevice, true))
     return false;
 
   return true;

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALOSX.h
@@ -55,7 +55,7 @@ public:
   CCoreAudioAEHALOSX();
   virtual ~CCoreAudioAEHALOSX();
 
-  virtual bool  InitializePCM(ICoreAudioSource *pSource, AEAudioFormat &format, bool allowMixing, AudioDeviceID outputDevice);
+  virtual bool  InitializePCM(ICoreAudioSource *pSource, AEAudioFormat &format, bool allowMixing, AudioDeviceID outputDevice, bool encoded = false);
   virtual bool  InitializePCMEncoded(ICoreAudioSource *pSource, AEAudioFormat &format, AudioDeviceID outputDevice);
   virtual bool  InitializeEncoded(AudioDeviceID outputDevice, AEAudioFormat &format);
   virtual bool  Initialize(ICoreAudioSource *ae, bool passThrough, AEAudioFormat &format, AEDataFormat rawDataFormat, std::string &device, float initVolume);

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioGraph.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioGraph.cpp
@@ -51,7 +51,7 @@ CCoreAudioGraph::~CCoreAudioGraph()
 }
 
 bool CCoreAudioGraph::Open(ICoreAudioSource *pSource, AEAudioFormat &format,
-  AudioDeviceID deviceId, bool allowMixing, AudioChannelLayoutTag layoutTag, float initVolume)
+  AudioDeviceID deviceId, bool allowMixing, AudioChannelLayoutTag layoutTag, float initVolume, bool encoded)
 {
   AudioStreamBasicDescription fmt = {0};
   AudioStreamBasicDescription inputFormat = {0};
@@ -89,7 +89,7 @@ bool CCoreAudioGraph::Open(ICoreAudioSource *pSource, AEAudioFormat &format,
     return false;
   m_audioUnit->SetBus(GetFreeBus());
 
-  m_audioUnit->GetFormatDesc(format, &inputFormat, &fmt);
+  m_audioUnit->GetFormatDesc(format, &inputFormat, &fmt, encoded);
 
   if (!m_audioUnit->EnableInputOuput())
     return false;

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioGraph.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioGraph.h
@@ -42,7 +42,7 @@ public:
   ~CCoreAudioGraph();
 
   bool             Open(ICoreAudioSource *pSource, AEAudioFormat &format, AudioDeviceID deviceId,
-                     bool allowMixing, AudioChannelLayoutTag layoutTag, float initVolume);
+                     bool allowMixing, AudioChannelLayoutTag layoutTag, float initVolume, bool encoded);
   bool             Close();
   bool             Start();
   bool             Stop();

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioUnit.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioUnit.cpp
@@ -278,7 +278,7 @@ OSStatus CCoreAudioUnit::RenderCallback(void *inRefCon, AudioUnitRenderActionFla
 }
 
 void CCoreAudioUnit::GetFormatDesc(AEAudioFormat format,
-  AudioStreamBasicDescription *streamDesc, AudioStreamBasicDescription *coreaudioDesc)
+  AudioStreamBasicDescription *streamDesc, AudioStreamBasicDescription *coreaudioDesc, bool encoded)
 {
   unsigned int bps = CAEUtil::DataFormatToBits(format.m_dataFormat);
 
@@ -303,15 +303,24 @@ void CCoreAudioUnit::GetFormatDesc(AEAudioFormat format,
       streamDesc->mFormatFlags |= kAudioFormatFlagsAudioUnitCanonical;
       break;
     case AE_FMT_S16LE:
-      streamDesc->mFormatFlags |= kAudioFormatFlagsAudioUnitCanonical;
+      if (encoded)
+        streamDesc->mFormatFlags |= kAudioFormatFlagIsSignedInteger;
+      else
+        streamDesc->mFormatFlags |= kAudioFormatFlagsAudioUnitCanonical;
       break;
     case AE_FMT_S16BE:
       streamDesc->mFormatFlags |= kAudioFormatFlagIsBigEndian;
-      streamDesc->mFormatFlags |= kAudioFormatFlagsAudioUnitCanonical;
+      if (encoded)
+        streamDesc->mFormatFlags |= kAudioFormatFlagIsSignedInteger;
+      else
+        streamDesc->mFormatFlags |= kAudioFormatFlagsAudioUnitCanonical;
       break;
     default:
       streamDesc->mFormatFlags |= kAudioFormatFlagsNativeEndian;
-      streamDesc->mFormatFlags |= kAudioFormatFlagsAudioUnitCanonical;
+      if (encoded)
+        streamDesc->mFormatFlags |= kAudioFormatFlagIsSignedInteger;
+      else
+        streamDesc->mFormatFlags |= kAudioFormatFlagsAudioUnitCanonical;
       break;
   }
   streamDesc->mChannelsPerFrame = format.m_channelLayout.Count();               // Number of interleaved audiochannels

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioUnit.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioUnit.h
@@ -50,7 +50,7 @@ public:
   virtual bool      SetMaxFramesPerSlice(UInt32 maxFrames);
   virtual bool      GetSupportedChannelLayouts(AudioChannelLayoutList* pLayouts);
   virtual void      GetFormatDesc(AEAudioFormat format, 
-                      AudioStreamBasicDescription *streamDesc, AudioStreamBasicDescription *coreaudioDesc);
+                      AudioStreamBasicDescription *streamDesc, AudioStreamBasicDescription *coreaudioDesc, bool encoded = false);
   virtual float     GetLatency();
   virtual bool      Stop();
   virtual bool      Start();


### PR DESCRIPTION
...av. When falling back on systems that doesn’t provide a encoded stream it was erroneously advertising the stream as Float instead of signed integers. We know open the output as integers if we are falling back on encoded data.

Fixes a regression introduced in 12.3 and master due to the mavericks startup fix.

Waiting for feedback from the user here:

http://forum.xbmc.org/showthread.php?tid=182326&pid=1597127#pid1597127

before merging ...

@tru i guess you tested this in mavericks right? Because the commit that broke this was needed for proper startup of xbmc on mavericks - see:

https://github.com/xbmc/xbmc/commit/3fc41bf8b7e3fddf3ae6d33cf21a7eab3f799415
