### PR TITLE
[WIN32] fixed: exit on build failure with pvr addons

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -245,6 +245,10 @@ IF %comp%==vs2010 (
   
   ECHO ------------------------------------------------------------
   call buildpvraddons.bat %NET%
+  IF %errorlevel%==1 (
+    set DIETEXT="failed to build pvr addons"
+    goto DIE
+  )
     
   IF EXIST error.log del error.log > NUL
   SET build_path=%CD%

--- a/project/Win32BuildSetup/buildpvraddons.bat
+++ b/project/Win32BuildSetup/buildpvraddons.bat
@@ -64,6 +64,10 @@ REM build xbmc-pvr-addons.sln
 ECHO Building PVR addons
 %1 %OPTS_EXE%
 
+IF %errorlevel%==1 (
+  goto fail
+)
+
 REM copy the built pvr addons into ADDONS_DIR
 CD "%BUILT_ADDONS_DIR%"
 SET ADDONS_DIR=..\..\..\..\Win32BuildSetup\BUILD_WIN32\Xbmc\xbmc-pvr-addons
@@ -89,6 +93,10 @@ GOTO done
 
 :error
 ECHO No git command available. Unable to fetch and build xbmc-pvr-addons.
+SET EXITCODE=1
+
+:fail
+ECHO Failed to build one or more pvr addons
 SET EXITCODE=1
 
 :done


### PR DESCRIPTION
this should wait until this https://github.com/opdenkamp/xbmc-pvr-addons/pull/263 went in. Otherwise jenkins will stop after the current pvr build errors.
