### PR TITLE
Linux: Gui Settings for HW Decoders

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -3122,6 +3122,9 @@
 		F58E293911FFC103006F4D46 /* DVDInputStreamBluray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F58E293711FFC103006F4D46 /* DVDInputStreamBluray.cpp */; };
 		F592568810FBF2E100D2C91D /* ConvolutionKernels.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F592568710FBF2E100D2C91D /* ConvolutionKernels.cpp */; };
 		F595994510E9F322004B58B3 /* DVDVideoCodecCrystalHD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F595994410E9F322004B58B3 /* DVDVideoCodecCrystalHD.cpp */; };
+		F597B05B18A804E0005AADAE /* DVDVideoCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F597B05A18A804E0005AADAE /* DVDVideoCodec.cpp */; };
+		F597B05C18A804E0005AADAE /* DVDVideoCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F597B05A18A804E0005AADAE /* DVDVideoCodec.cpp */; };
+		F597B05D18A804E0005AADAE /* DVDVideoCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F597B05A18A804E0005AADAE /* DVDVideoCodec.cpp */; };
 		F59876C00FBA351D008EF4FB /* VideoReferenceClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59876BF0FBA351D008EF4FB /* VideoReferenceClock.cpp */; };
 		F59879080FBAA0C3008EF4FB /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F59879070FBAA0C3008EF4FB /* QuartzCore.framework */; };
 		F5987F050FBDF274008EF4FB /* DPMSSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987F040FBDF274008EF4FB /* DPMSSupport.cpp */; };
@@ -5464,6 +5467,7 @@
 		F592568710FBF2E100D2C91D /* ConvolutionKernels.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConvolutionKernels.cpp; sourceTree = "<group>"; };
 		F595994310E9F322004B58B3 /* DVDVideoCodecCrystalHD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DVDVideoCodecCrystalHD.h; sourceTree = "<group>"; };
 		F595994410E9F322004B58B3 /* DVDVideoCodecCrystalHD.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDVideoCodecCrystalHD.cpp; sourceTree = "<group>"; };
+		F597B05A18A804E0005AADAE /* DVDVideoCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDVideoCodec.cpp; sourceTree = "<group>"; };
 		F59876BE0FBA351D008EF4FB /* VideoReferenceClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoReferenceClock.h; sourceTree = "<group>"; };
 		F59876BF0FBA351D008EF4FB /* VideoReferenceClock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoReferenceClock.cpp; sourceTree = "<group>"; };
 		F59879070FBAA0C3008EF4FB /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = /System/Library/Frameworks/QuartzCore.framework; sourceTree = "<absolute>"; };
@@ -7630,6 +7634,7 @@
 				F5F240EB110A4F76009126C6 /* CrystalHD.cpp */,
 				F5F240EC110A4F76009126C6 /* CrystalHD.h */,
 				E38E153B0D25F9F900618676 /* DllLibMpeg2.h */,
+				F597B05A18A804E0005AADAE /* DVDVideoCodec.cpp */,
 				E38E153C0D25F9F900618676 /* DVDVideoCodec.h */,
 				F595994410E9F322004B58B3 /* DVDVideoCodecCrystalHD.cpp */,
 				F595994310E9F322004B58B3 /* DVDVideoCodecCrystalHD.h */,
@@ -9835,6 +9840,7 @@
 				E38E20440D25F9FD00618676 /* DirectoryNodeTop100.cpp in Sources */,
 				E38E20460D25F9FD00618676 /* DirectoryNodeYearAlbum.cpp in Sources */,
 				E38E20470D25F9FD00618676 /* DirectoryNodeYearSong.cpp in Sources */,
+				F597B05B18A804E0005AADAE /* DVDVideoCodec.cpp in Sources */,
 				E38E20490D25F9FD00618676 /* QueryParams.cpp in Sources */,
 				E38E204A0D25F9FD00618676 /* MusicDatabaseDirectory.cpp in Sources */,
 				E38E204B0D25F9FD00618676 /* MusicSearchDirectory.cpp in Sources */,
@@ -11312,6 +11318,7 @@
 				DFF0F2C417528350002DA3A4 /* TextureGL.cpp in Sources */,
 				DFF0F2C517528350002DA3A4 /* TextureManager.cpp in Sources */,
 				DFF0F2C617528350002DA3A4 /* VisibleEffect.cpp in Sources */,
+				F597B05D18A804E0005AADAE /* DVDVideoCodec.cpp in Sources */,
 				DFF0F2C717528350002DA3A4 /* XBTF.cpp in Sources */,
 				DFF0F2C817528350002DA3A4 /* XBTFReader.cpp in Sources */,
 				DFF0F2C917528350002DA3A4 /* GenericTouchActionHandler.cpp in Sources */,
@@ -12032,6 +12039,7 @@
 				E49911E1174E5D3700741B6D /* DVDInputStreamHTSP.cpp in Sources */,
 				E49911E2174E5D3700741B6D /* DVDInputStreamHttp.cpp in Sources */,
 				E49911E3174E5D3700741B6D /* DVDInputStreamMemory.cpp in Sources */,
+				F597B05C18A804E0005AADAE /* DVDVideoCodec.cpp in Sources */,
 				E49911E4174E5D3700741B6D /* DVDInputStreamNavigator.cpp in Sources */,
 				E49911E5174E5D3700741B6D /* DVDInputStreamPVRManager.cpp in Sources */,
 				E49911E6174E5D3700741B6D /* DVDInputStreamRTMP.cpp in Sources */,

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6000,32 +6000,79 @@ msgctxt "#13440"
 msgid "Allow frame-multi-threaded decoding"
 msgstr ""
 
+#. Description of Mpeg-2 Codec for VDPAU
+#: system/settings/settings.xml
 msgctxt "#13441"
 msgid "Use Mpeg-2 VDPAU"
 msgstr ""
 
+#. Description of setting #13441 'Use Mpeg-2 VDPAU'
+#: system/settings/settings.xml
 msgctxt "#13442"
+msgid "Enable this option to use hardware acceleration for Mpeg-(1/2) codecs. If disabled the CPU will be used instead. Older Radeon Cards tend to segfault with this enabled."
+msgstr ""
+
+#. Description of Mpeg-4 Codec for VDPAU
+#: system/settings/settings.xml
+msgctxt "#13443"
 msgid "Use Mpeg-4 VDPAU"
 msgstr ""
 
-msgctxt "#13443"
+#. Description of setting #13443 'Use Mpeg-4 VDPAU'
+#: system/settings/settings.xml
+msgctxt "#13444"
+msgid "Enable this option to use hardware acceleration for the Mpeg-4 codec. If disabled the CPU will be used instead. Some ION Hardware has problems with this being enabled by default."
+msgstr ""
+
+#. Description of VC-1 Codec for VDPAU
+#: system/settings/settings.xml
+msgctxt "#13445"
 msgid "Use VC-1 VDPAU"
 msgstr ""
 
-#empty strings from 13444 to 13446
+#. Description of setting #13445 'Use VC-1 VDPAU'
+#: system/settings/settings.xml
+msgctxt "#13446"
+msgid "Enable this option to use hardware acceleration for VC-1 based codecs. If disabled the CPU will be used instead. AMD Hardware with VDPAU cannot decode VC-1 Simple."
+msgstr ""
+
+#. Description of Mpeg-2 Codec for VAAPI
+#: system/settings/settings.xml
 msgctxt "#13447"
 msgid "Use Mpeg-2 VAAPI"
 msgstr ""
 
+#. Description of setting #13447 'Use Mpeg-2 VAAPI'
+#: system/settings/settings.xml
 msgctxt "#13448"
+msgid "Enable this option to use hardware acceleration for Mpeg-(1/2) codecs. If disabled the CPU will be used instead. Some Mpeg-2 Videos might have green artifacts."
+msgstr ""
+
+#. Description of Mpeg-4 Codec for VAAPI
+#: system/settings/settings.xm
+msgctxt "#13449"
 msgid "Use Mpeg-4 VAAPI"
 msgstr ""
 
-msgctxt "#13449"
+#. Description of setting #13449 'Use Mpeg-4 VAAPI'
+#: system/settings/settings.xml
+msgctxt "#13450"
+msgid "Enable this option to use hardware acceleration for the Mpeg-4 codec. If disabled the CPU will be used instead."
+msgstr ""
+
+#. Description of VC-1 Codec for VAAPI
+#: system/settings/settings.xm
+msgctxt "#13451"
 msgid "Use VC-1 VAAPI"
 msgstr ""
 
-#empty strings from id 13449 to 13499
+#. Description of setting #13451 'Use VC-1 VAAPI'
+#: system/settings/settings.xml
+msgctxt "#13452"
+msgid "Enable this option to use hardware acceleration for VC-1 based codecs. If disabled the CPU will be used instead. Especially VC-1 Interlaced fails hard on Intel hardware."
+msgstr ""
+
+#empty strings from id 13453 to 13499
 
 #: system/settings/settings.xml
 msgctxt "#13500"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6000,7 +6000,19 @@ msgctxt "#13440"
 msgid "Allow frame-multi-threaded decoding"
 msgstr ""
 
-#empty strings from id 13441 to 13499
+msgctxt "#13441"
+msgid "Use Mpeg-2 VDPAU"
+msgstr ""
+
+msgctxt "#13442"
+msgid "Use Mpeg-4 VDPAU"
+msgstr ""
+
+msgctxt "#13443"
+msgid "Use VC-1 VDPAU"
+msgstr ""
+
+#empty strings from id 13444 to 13499
 
 #: system/settings/settings.xml
 msgctxt "#13500"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6012,7 +6012,20 @@ msgctxt "#13443"
 msgid "Use VC-1 VDPAU"
 msgstr ""
 
-#empty strings from id 13444 to 13499
+#empty strings from 13444 to 13446
+msgctxt "#13447"
+msgid "Use Mpeg-2 VAAPI"
+msgstr ""
+
+msgctxt "#13448"
+msgid "Use Mpeg-4 VAAPI"
+msgstr ""
+
+msgctxt "#13449"
+msgid "Use VC-1 VAAPI"
+msgstr ""
+
+#empty strings from id 13449 to 13499
 
 #: system/settings/settings.xml
 msgctxt "#13500"

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -317,6 +317,7 @@
     <ClCompile Include="..\..\xbmc\cores\AudioEngine\Utils\AEWAVLoader.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Audio\DVDAudioCodecPassthrough.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Video\CrystalHD.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Video\DVDVideoCodec.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxBXA.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxPVRClient.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3113,6 +3113,9 @@
     <ClCompile Include="..\..\xbmc\utils\XSLTUtils.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Video\DVDVideoCodec.cpp">
+      <Filter>cores\dvdplayer\DVDCodecs\Video</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -453,6 +453,7 @@
           <default>true</default>
           <dependencies>
             <dependency type="enable" setting="videoplayer.usevdpau" operator="is">true</dependency> <!-- USE VDPAU -->
+            <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevdpaumpeg2" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -462,6 +463,7 @@
           <default>false</default>
           <dependencies>
             <dependency type="enable" setting="videoplayer.usevdpau" operator="is">true</dependency> <!-- USE VDPAU -->
+            <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevdpaumpeg4" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -471,6 +473,7 @@
           <default>true</default>
           <dependencies>
             <dependency type="enable" setting="videoplayer.usevdpau" operator="is">true</dependency> <!-- USE VDPAU -->
+            <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevdpauvc1" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -487,6 +490,7 @@
           <requirement>HAVE_LIBVA</requirement>
           <dependencies>
             <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
+            <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevaapimpeg2" operator="is">true</dependency>
           </dependencies>
           <level>3</level>
           <default>true</default>
@@ -496,6 +500,7 @@
           <requirement>HAVE_LIBVA</requirement>
           <dependencies>
             <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
+            <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevaapimpeg4" operator="is">true</dependency>
           </dependencies>
           <level>3</level>
           <default>true</default>
@@ -505,6 +510,7 @@
           <requirement>HAVE_LIBVA</requirement>
           <dependencies>
             <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
+            <dependency type="visible" on="property" name="codecoptionvisible" setting="videoplayer.usevaapivc1" operator="is">true</dependency>
           </dependencies>
           <level>3</level>
           <default>false</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -447,7 +447,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.usevdpaumpeg2" type="boolean" label="13441" help="36102">
+        <setting id="videoplayer.usevdpaumpeg2" type="boolean" parent="videoplayer.usevdpau" label="13441" help="13442">
           <requirement>HAVE_LIBVDPAU</requirement>
           <level>3</level>
           <default>true</default>
@@ -457,7 +457,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.usevdpaumpeg4" type="boolean" label="13442" help="36102">
+        <setting id="videoplayer.usevdpaumpeg4" type="boolean" parent="videoplayer.usevdpau" label="13443" help="13444">
           <requirement>HAVE_LIBVDPAU</requirement>
           <level>3</level>
           <default>false</default>
@@ -467,7 +467,7 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.usevdpauvc1" type="boolean" label="13443" help="36102">
+        <setting id="videoplayer.usevdpauvc1" type="boolean" parent="videoplayer.usevdpau" label="13445" help="13446">
           <requirement>HAVE_LIBVDPAU</requirement>
           <level>3</level>
           <default>true</default>
@@ -486,7 +486,7 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-       <setting id="videoplayer.usevaapimpeg2" type="boolean" label="13447" help="36102">
+       <setting id="videoplayer.usevaapimpeg2" type="boolean" parent="videoplayer.usevaapi" label="13447" help="13448">
           <requirement>HAVE_LIBVA</requirement>
           <dependencies>
             <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
@@ -496,7 +496,7 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.usevaapimpeg4" type="boolean" label="13448" help="36102">
+        <setting id="videoplayer.usevaapimpeg4" type="boolean" parent="videoplayer.usevaapi" label="13449" help="13450">
           <requirement>HAVE_LIBVA</requirement>
           <dependencies>
             <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
@@ -506,7 +506,7 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="videoplayer.usevaapivc1" type="boolean" label="13449" help="36102">
+        <setting id="videoplayer.usevaapivc1" type="boolean" parent="videoplayer.usevaapi" label="13451" help="13452">
           <requirement>HAVE_LIBVA</requirement>
           <dependencies>
             <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -483,6 +483,33 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+       <setting id="videoplayer.usevaapimpeg2" type="boolean" label="13447" help="36102">
+          <requirement>HAVE_LIBVA</requirement>
+          <dependencies>
+            <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
+          </dependencies>
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevaapimpeg4" type="boolean" label="13448" help="36102">
+          <requirement>HAVE_LIBVA</requirement>
+          <dependencies>
+            <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
+          </dependencies>
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevaapivc1" type="boolean" label="13449" help="36102">
+          <requirement>HAVE_LIBVA</requirement>
+          <dependencies>
+            <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
+          </dependencies>
+          <level>3</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usedxva2" type="boolean" label="13427" help="36158">
           <requirement>HasDXVA2</requirement>
           <dependencies>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -447,6 +447,33 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.usevdpaumpeg2" type="boolean" label="13441" help="36102">
+          <requirement>HAVE_LIBVDPAU</requirement>
+          <level>3</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.usevdpau" operator="is">true</dependency> <!-- USE VDPAU -->
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevdpaumpeg4" type="boolean" label="13442" help="36102">
+          <requirement>HAVE_LIBVDPAU</requirement>
+          <level>3</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.usevdpau" operator="is">true</dependency> <!-- USE VDPAU -->
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoplayer.usevdpauvc1" type="boolean" label="13443" help="36102">
+          <requirement>HAVE_LIBVDPAU</requirement>
+          <level>3</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.usevdpau" operator="is">true</dependency> <!-- USE VDPAU -->
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usevaapi" type="boolean" label="13426" help="36156">
           <requirement>HAVE_LIBVA</requirement>
           <dependencies>

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -1,0 +1,80 @@
+/*
+ *      Copyright (C) 2010-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDVideoCodec.h"
+#include "windowing/WindowingFactory.h"
+#include "settings/Settings.h"
+
+bool CDVDVideoCodec::IsSettingVisible(const std::string &condition, const std::string &value, const std::string &settingId)
+{
+  if (settingId.empty() || value.empty())
+    return false;
+
+  // check if we are running on nvidia hardware
+  std::string gpuvendor = g_Windowing.GetRenderVendor();
+  std::transform(gpuvendor.begin(), gpuvendor.end(), gpuvendor.begin(), ::tolower);
+  bool isNvidia = (gpuvendor.compare(0, 6, "nvidia") == 0);
+  bool isIntel = (gpuvendor.compare(0, 5, "intel") == 0);
+
+  // nvidia does only need mpeg-4 setting
+  if (isNvidia) 
+  {
+    if (settingId == "videoplayer.usevdpaumpeg4")
+      return true;
+
+    return false; //will also hide intel settings on nvidia hardware
+  }
+  else if (isIntel) // intel needs vc1, mpeg-2 and mpeg4 setting
+  {
+    if (settingId == "videoplayer.usevaapimpeg4")
+      return true;
+    if (settingId == "videoplayer.usevaapivc1")
+      return true;
+    if (settingId == "videoplayer.usevaapimpeg2")
+      return true;
+
+    return false; //this will also hide nvidia settings on intel hardware
+  }
+  // if we don't know the hardware we are running on e.g. amd oss vdpau 
+  // or fglrx with xvba-driver we show everything
+  return true;
+}
+
+bool CDVDVideoCodec::IsCodecDisabled(DVDCodecAvailableType* map, unsigned int size, AVCodecID id)
+{
+  std::string gpuvendor = g_Windowing.GetRenderVendor();
+  std::transform(gpuvendor.begin(), gpuvendor.end(), gpuvendor.begin(), ::tolower);
+  if (gpuvendor.compare(0, 6, "nvidia") == 0) // all is fine on nvidia
+    return false;
+
+  int index = -1;
+  for (unsigned int i = 0; i < size; ++i)
+  {
+    if(map[i].codec == id)
+    {
+      index = (int) i;
+      break;
+    }
+  }
+  if(index > -1)
+    return (!CSettings::Get().GetBool(map[index].setting) || !CDVDVideoCodec::IsSettingVisible("unused", "unused", map[index].setting));
+
+  return false; //don't disable what we don't have
+}

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -21,9 +21,18 @@
  */
 
 #include "system.h"
+#include "DllAvFormat.h"
+#include "DllAvCodec.h"
 
 #include <vector>
+#include <string>
 #include "cores/VideoRenderers/RenderFormats.h"
+
+struct DVDCodecAvailableType 
+{
+  AVCodecID codec;
+  const char* setting;
+};
 
 // when modifying these structures, make sure you update all codecs accordingly
 #define FRAME_TYPE_UNDEF 0
@@ -263,4 +272,15 @@ public:
    * be retained when calling decode on the next demux packet
    */
   virtual unsigned GetAllowedReferences() { return 0; }
+
+  /**
+   * Hide or Show Settings depending on the currently running hardware 
+   *
+   */
+   static bool IsSettingVisible(const std::string &condition, const std::string &value, const std::string &settingId);
+
+  /**
+  * Interact with user settings so that user disabled codecs are disabled
+  */
+  static bool IsCodecDisabled(DVDCodecAvailableType* map, unsigned int size, AVCodecID id);
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -105,8 +105,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #endif
 #ifdef HAVE_LIBVA
     // mpeg4 vaapi decoding is disabled
-    if(*cur == PIX_FMT_VAAPI_VLD && CSettings::Get().GetBool("videoplayer.usevaapi") 
-    && (avctx->codec_id != AV_CODEC_ID_MPEG4 || g_advancedSettings.m_videoAllowMpeg4VAAPI)) 
+    if(*cur == PIX_FMT_VAAPI_VLD && CSettings::Get().GetBool("videoplayer.usevaapi"))
     {
       VAAPI::CDecoder* dec = new VAAPI::CDecoder();
       if(dec->Open(avctx, *cur, ctx->m_uSurfacesCount))

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
@@ -1,6 +1,7 @@
 INCLUDES+=-I@abs_top_srcdir@/xbmc/cores/dvdplayer
 
-SRCS  = DVDVideoCodecFFmpeg.cpp
+SRCS  = DVDVideoCodec.cpp
+SRCS += DVDVideoCodecFFmpeg.cpp
 SRCS += DVDVideoCodecLibMpeg2.cpp
 SRCS += DVDVideoPPFFmpeg.cpp
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -42,6 +42,16 @@ using namespace VDPAU;
 
 #define ARSIZE(x) (sizeof(x) / sizeof((x)[0]))
 
+// settings codecs mapping
+DVDCodecAvailableType g_vdpau_available[] = {
+  { AV_CODEC_ID_H263, "videoplayer.usevdpaumpeg4" },
+  { AV_CODEC_ID_MPEG4, "videoplayer.usevdpaumpeg4" },
+  { AV_CODEC_ID_WMV3, "videoplayer.usevdpauvc1" },
+  { AV_CODEC_ID_VC1, "videoplayer.usevdpauvc1" },
+  { AV_CODEC_ID_MPEG2VIDEO, "videoplayer.usevdpaumpeg2" },
+};
+const size_t settings_count = sizeof(g_vdpau_available) / sizeof(DVDCodecAvailableType);
+
 CDecoder::Desc decoder_profiles[] = {
 {"MPEG1",        VDP_DECODER_PROFILE_MPEG1},
 {"MPEG2_SIMPLE", VDP_DECODER_PROFILE_MPEG2_SIMPLE},
@@ -483,8 +493,12 @@ CDecoder::CDecoder() : m_vdpauOutput(&m_inMsgEvent)
   m_vdpauConfig.context = 0;
 }
 
-bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces)
+bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat fmt, unsigned int surfaces)
 {
+  // check if user wants to decode this format with VDPAU
+  if (CDVDVideoCodec::IsCodecDisabled(g_vdpau_available, settings_count, avctx->codec_id))
+    return false;
+
 #ifndef GL_NV_vdpau_interop
   CLog::Log(LOGNOTICE, "VDPAU: compilation without required extension GL_NV_vdpau_interop");
   return false;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -504,9 +504,6 @@ bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int 
   m_vdpauConfig.numRenderBuffers = surfaces;
   m_decoderThread = CThread::GetCurrentThreadId();
 
-  if ((avctx->codec_id == AV_CODEC_ID_MPEG4) && !g_advancedSettings.m_videoAllowMpeg4VDPAU)
-    return false;
-
   if (!CVDPAUContext::EnsureContext(&m_vdpauConfig.context))
     return false;
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -161,7 +161,6 @@ void CAdvancedSettings::Initialize()
   m_videoNonLinStretchRatio = 0.5f;
   m_videoEnableHighQualityHwScalers = false;
   m_videoAutoScaleMaxFps = 30.0f;
-  m_videoAllowMpeg4VDPAU = false;
   m_videoAllowMpeg4VAAPI = false;  
   m_videoDisableBackgroundDeinterlace = false;
   m_videoCaptureUseOcclusionQuery = -1; //-1 is auto detect
@@ -597,7 +596,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetFloat(pElement, "nonlinearstretchratio", m_videoNonLinStretchRatio, 0.01f, 1.0f);
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
-    XMLUtils::GetBoolean(pElement,"allowmpeg4vdpau",m_videoAllowMpeg4VDPAU);
     XMLUtils::GetBoolean(pElement,"disablehi10pmultithreading",m_videoDisableHi10pMultithreading);
     XMLUtils::GetBoolean(pElement,"allowmpeg4vaapi",m_videoAllowMpeg4VAAPI);    
     XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -161,7 +161,6 @@ void CAdvancedSettings::Initialize()
   m_videoNonLinStretchRatio = 0.5f;
   m_videoEnableHighQualityHwScalers = false;
   m_videoAutoScaleMaxFps = 30.0f;
-  m_videoAllowMpeg4VAAPI = false;  
   m_videoDisableBackgroundDeinterlace = false;
   m_videoCaptureUseOcclusionQuery = -1; //-1 is auto detect
   m_videoVDPAUtelecine = false;
@@ -597,7 +596,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
     XMLUtils::GetBoolean(pElement,"disablehi10pmultithreading",m_videoDisableHi10pMultithreading);
-    XMLUtils::GetBoolean(pElement,"allowmpeg4vaapi",m_videoAllowMpeg4VAAPI);    
     XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
     XMLUtils::GetBoolean(pElement,"vdpauInvTelecine",m_videoVDPAUtelecine);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -181,7 +181,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoNonLinStretchRatio;
     bool  m_videoEnableHighQualityHwScalers;
     float m_videoAutoScaleMaxFps;
-    bool  m_videoAllowMpeg4VAAPI;
     std::vector<RefreshOverride> m_videoAdjustRefreshOverrides;
     std::vector<RefreshVideoLatency> m_videoRefreshLatency;
     float m_videoDefaultLatency;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -181,7 +181,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoNonLinStretchRatio;
     bool  m_videoEnableHighQualityHwScalers;
     float m_videoAutoScaleMaxFps;
-    bool  m_videoAllowMpeg4VDPAU;
     bool  m_videoAllowMpeg4VAAPI;
     std::vector<RefreshOverride> m_videoAdjustRefreshOverrides;
     std::vector<RefreshVideoLatency> m_videoRefreshLatency;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -29,6 +29,7 @@
 #include "addons/AddonManager.h"
 #include "addons/Skin.h"
 #include "cores/AudioEngine/AEFactory.h"
+#include "cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h"
 #if defined(HAVE_LIBCRYSTALHD)
 #include "cores/dvdplayer/DVDCodecs/Video/CrystalHD.h"
 #endif // defined(HAVE_LIBCRYSTALHD)
@@ -960,6 +961,7 @@ void CSettings::InitializeConditions()
   m_settingsManager->AddCondition("profilehasvideoslocked", ProfileHasVideosLocked);
   m_settingsManager->AddCondition("profilelockmode", ProfileLockMode);
   m_settingsManager->AddCondition("aesettingvisible", CAEFactory::IsSettingVisible);
+  m_settingsManager->AddCondition("codecoptionvisible", CDVDVideoCodec::IsSettingVisible);
 }
 
 void CSettings::InitializeISettingsHandlers()


### PR DESCRIPTION
Add Settings to Expert Menu to make it easy for a user to disable certain codecs.

VAAPI:
VC1 interlaced is heavily broken. The driver crashes with doing an assert. A new driver might fix that, but currently it's wip.
Mpeg-2 has for some videos green artifacts.
Mpeg-4 was handled as advanced setting before.

VDPAU:
Radeon OSS with <= HD5xxx has a driver bug when doing mpeg-2 decoding -> segfault in radeon_dri.so. New drivers might fix that issue, but problem still exists.
Mpeg4 was handled via advancedsettings.xml before

Changes:
VAAPI: Disable VC1 by default
VDPAU: nothing
