### PR TITLE
[win32/nfs] - fix wrong struct stat size when running on win8 64

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -13,7 +13,7 @@ lame_enc-3.99.5-win32.7z
 libass-0.10.2-win32.7z
 libbluray-0.4.0-win32.zip
 libjpeg-turbo-1.2.0-win32.7z
-libnfs-1.6.1-win32.7z
+libnfs-1.6.2-win32.7z
 libshairplay-c159ca7-win32.7z
 libssh-0.5.0-1-win32.zip
 libxml2-2.7.8_1-win32.7z

--- a/xbmc/filesystem/DllLibNfs.h
+++ b/xbmc/filesystem/DllLibNfs.h
@@ -30,6 +30,13 @@ extern "C" {
 }
 #endif
 
+#if defined(TARGET_WINDOWS)
+struct __stat64;
+#define NFSSTAT struct __stat64
+#else
+#define NFSSTAT struct stat
+#endif
+
 class DllLibNfsInterface
 {
 public:
@@ -54,8 +61,8 @@ public:
   virtual void nfs_closedir(struct nfs_context *nfs,      struct nfsdir *nfsdir)=0;      
   virtual struct nfsdirent *nfs_readdir(struct nfs_context *nfs, struct nfsdir *nfsdir)=0;  
   virtual int nfs_mount(struct nfs_context *nfs,     const char *server,   const char *exportname)=0;
-  virtual int nfs_stat(struct nfs_context *nfs,      const char *path,     struct stat *st)=0;
-  virtual int nfs_fstat(struct nfs_context *nfs,     struct nfsfh *nfsfh,  struct stat *st)=0;
+  virtual int nfs_stat(struct nfs_context *nfs,      const char *path,     NFSSTAT *st)=0;
+  virtual int nfs_fstat(struct nfs_context *nfs,     struct nfsfh *nfsfh,  NFSSTAT *st)=0;
   virtual int nfs_truncate(struct nfs_context *nfs,  const char *path,     uint64_t length)=0;
   virtual int nfs_ftruncate(struct nfs_context *nfs, struct nfsfh *nfsfh,  uint64_t length)=0;
   virtual int nfs_opendir(struct nfs_context *nfs,   const char *path,     struct nfsdir **nfsdir)=0;
@@ -100,8 +107,8 @@ class DllLibNfs : public DllDynamic, DllLibNfsInterface
   DEFINE_METHOD2(void,nfs_closedir,  (struct nfs_context *p1, struct nfsdir *p2))        
   DEFINE_METHOD2(int, nfs_close,     (struct nfs_context *p1, struct nfsfh *p2)) 
   DEFINE_METHOD3(int, nfs_mount,     (struct nfs_context *p1, const char *p2,    const char *p3))
-  DEFINE_METHOD3(int, nfs_stat,      (struct nfs_context *p1, const char *p2,    struct stat *p3))
-  DEFINE_METHOD3(int, nfs_fstat,     (struct nfs_context *p1, struct nfsfh *p2,  struct stat *p3))
+  DEFINE_METHOD3(int, nfs_stat,      (struct nfs_context *p1, const char *p2,    NFSSTAT *p3))
+  DEFINE_METHOD3(int, nfs_fstat,     (struct nfs_context *p1, struct nfsfh *p2,  NFSSTAT *p3))
   DEFINE_METHOD3(int, nfs_truncate,  (struct nfs_context *p1, const char *p2,    uint64_t p3))
   DEFINE_METHOD3(int, nfs_ftruncate, (struct nfs_context *p1, struct nfsfh *p2,  uint64_t p3))
   DEFINE_METHOD3(int, nfs_opendir,   (struct nfs_context *p1, const char *p2,    struct nfsdir **p3))

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -127,7 +127,7 @@ bool CNFSDirectory::ResolveSymlink( const CStdString &dirName, struct nfsdirent 
   
   if(ret == 0)
   {
-    struct stat tmpBuffer = {0};      
+    NFSSTAT tmpBuffer = {0};
     fullpath = dirName;
     URIUtils::AddSlashAtEnd(fullpath);
     fullpath.append(resolvedLink);
@@ -350,7 +350,7 @@ bool CNFSDirectory::Exists(const char* strPath)
   if(!gNfsConnection.Connect(url,folderName))
     return false;
   
-  struct stat info;
+  NFSSTAT info;
   ret = gNfsConnection.GetImpl()->nfs_stat(gNfsConnection.GetNfsContext(), folderName.c_str(), &info);
   
   if (ret != 0)

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -28,6 +28,7 @@
 #include <list>
 #include "SectionLoader.h"
 #include <map>
+#include "DllLibNfs.h" // for define NFSSTAT
 
 #ifdef TARGET_WINDOWS
 #define S_IRGRP 0
@@ -80,7 +81,7 @@ public:
   
   //special stat which uses its own context
   //needed for getting intervolume symlinks to work
-  int stat(const CURL &url, struct stat *statbuff);
+  int stat(const CURL &url, NFSSTAT *statbuff);
 
   void AddActiveConnection();
   void AddIdleConnection();


### PR DESCRIPTION
As the title says. This is an isolated bugfix to the fact that struct stat on windows expands to the 32bit version even if FILE_OFFSET_BITS=64 is set. This leads to wrong filesizes and wrong seeks after wards - resulting in non playable files if they are bigger then 4gb ...

Issue discussed and bugfix tested here:

https://github.com/sahlberg/libnfs/issues/46

I hate windows ... I hate windows ... I hate windows ... I hate windows...
