### PR TITLE
FIX: make volup/voldown pure "digital" actions

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2804,7 +2804,7 @@ bool CApplication::OnAction(const CAction &action)
   }
 
   // Check for global volume control
-  if (action.GetAmount() && (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN))
+  if (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN)
   {
     if (!m_pPlayer->IsPassthrough())
     {
@@ -2821,9 +2821,9 @@ bool CApplication::OnAction(const CAction &action)
         step *= action.GetRepeat() * 50; // 50 fps
 #endif
       if (action.GetID() == ACTION_VOLUME_UP)
-        volume += (float)fabs(action.GetAmount()) * action.GetAmount() * step;
+        volume += step;
       else
-        volume -= (float)fabs(action.GetAmount()) * action.GetAmount() * step;
+        volume -= step;
       SetVolume(volume, false);
     }
     // show visual feedback of volume change...


### PR DESCRIPTION
VolUp / VolDown are broken as analog actions, both for gesture and joystick, because GetAmount() contains pears or apples depending on the event origin. 

Rather than trying to get analog working with dirty hacks, with limited use case, let's make them pure digital actions.

Tested with swipe gestures on droid (although that leads to an unrelated bug that swipe and inertial scrolling are conflicting each others) and XBOX360 joystick on Win.

/cc @jmarshallnz @Montellese @Memphiz 
