### PR TITLE
FIX: [gesture] only detect swipe if the current window doesn't want inertial scrolling

### DIFF
--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -31,10 +31,13 @@ CGenericTouchActionHandler &CGenericTouchActionHandler::Get()
 }
 
 void CGenericTouchActionHandler::OnTouchAbort()
-{ }
+{
+  m_gestures = 0;
+}
 
 bool CGenericTouchActionHandler::OnSingleTouchStart(float x, float y)
 {
+  m_gestures = QuerySupportedGestures((float)x, (float)y);
   focusControl(x, y);
 
   return true;
@@ -52,6 +55,7 @@ bool CGenericTouchActionHandler::OnSingleTouchMove(float x, float y, float offse
 
 bool CGenericTouchActionHandler::OnSingleTouchEnd(float x, float y)
 {
+  m_gestures = 0;
   return true;
 }
 
@@ -115,6 +119,13 @@ void CGenericTouchActionHandler::OnLongPress(float x, float y, int32_t pointers 
 void CGenericTouchActionHandler::OnSwipe(TouchMoveDirection direction, float xDown, float yDown, float xUp, float yUp, float velocityX, float velocityY, int32_t pointers /* = 1 */)
 {
   if (pointers <= 0 || pointers > 10)
+    return;
+
+  if (m_gestures == EVENT_RESULT_PAN_HORIZONTAL && (direction == TouchMoveDirectionLeft
+                                                  || direction == TouchMoveDirectionRight ))
+    return;
+  else if (m_gestures == EVENT_RESULT_PAN_VERTICAL && (direction == TouchMoveDirectionUp
+                                                  || direction == TouchMoveDirectionDown ))
     return;
 
   int actionId = 0;

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.h
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.h
@@ -72,7 +72,7 @@ public:
 
 private:
   // private construction, and no assignements; use the provided singleton methods
-  CGenericTouchActionHandler() { }
+  CGenericTouchActionHandler() : m_gestures(0) { }
   CGenericTouchActionHandler(const CGenericTouchActionHandler&);
   CGenericTouchActionHandler const& operator=(CGenericTouchActionHandler const&);
   virtual ~CGenericTouchActionHandler() { }
@@ -80,4 +80,6 @@ private:
   void touch(uint8_t type, uint8_t button, uint16_t x, uint16_t y);
   void sendEvent(int actionId, float x, float y, float x2 = 0.0f, float y2 = 0.0f, int pointers = 1);
   void focusControl(float x, float y);
+
+  int m_gestures;
 };


### PR DESCRIPTION
/cc @jmarshallnz @Montellese @Memphiz 

This prevent a conflict between swipe gestures and inertial scrolling, in-line with how CInertialScrollingHandler triggers itself.

The downside is that 2-fingers-swipe-left for "Back" won't work on scrollable lists, anymore.
This could be maybe mitigated by limiting inertial scrolling to 1 finger, which is not the case, currently.
