### PR TITLE
UPnP player disconnect/attach improvements

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -15014,3 +15014,13 @@ msgstr ""
 msgctxt "#37021"
 msgid "Set GUI resolution limit"
 msgstr ""
+
+#: xbmc/network/upnp/UPnPPlayer.cpp
+msgctxt "#37022"
+msgid "UPnP Player"
+msgstr ""
+
+#: xbmc/network/upnp/UPnPPlayer.cpp
+msgctxt "#37023"
+msgid "Do you wish to stop playback on the remote device?"
+msgstr ""

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2630,7 +2630,8 @@ bool CApplication::OnAction(const CAction &action)
 
   // Now check with the player if action can be handled.
   if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
-      (g_windowManager.GetActiveWindow() == WINDOW_DIALOG_VIDEO_OSD && (action.GetID() == ACTION_NEXT_ITEM || action.GetID() == ACTION_PREV_ITEM || action.GetID() == ACTION_CHANNEL_UP || action.GetID() == ACTION_CHANNEL_DOWN)))
+      (g_windowManager.GetActiveWindow() == WINDOW_DIALOG_VIDEO_OSD && (action.GetID() == ACTION_NEXT_ITEM || action.GetID() == ACTION_PREV_ITEM || action.GetID() == ACTION_CHANNEL_UP || action.GetID() == ACTION_CHANNEL_DOWN)) ||
+      action.GetID() == ACTION_STOP)
   {
     if (m_pPlayer->OnAction(action))
       return true;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -220,47 +220,47 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
 
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
 
-    if (file.IsVideoDb())
-      thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-    else if (item.IsMusicDb())
-      thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
+  if (file.IsVideoDb())
+    thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
+  else if (item.IsMusicDb())
+    thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
-    obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer());
-    if(obj.IsNull()) goto failed;
+  obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer());
+  if(obj.IsNull()) goto failed;
 
-    NPT_CHECK_LABEL_SEVERE(PLT_Didl::ToDidl(*obj, "", tmp), failed);
-    tmp.Insert(didl_header, 0);
-    tmp.Append(didl_footer);
+  NPT_CHECK_LABEL_SEVERE(PLT_Didl::ToDidl(*obj, "", tmp), failed);
+  tmp.Insert(didl_header, 0);
+  tmp.Append(didl_footer);
 
-    /* The resource uri's are stored in the Didl. We must choose the best resource
-     * for the playback device */
-    NPT_Cardinal res_index;
-    NPT_CHECK_LABEL_SEVERE(m_control->FindBestResource(m_delegate->m_device, *obj, res_index), failed);
-
-
-    /* dlna specifies that a return code of 705 should be returned
-     * if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT */
-    NPT_CHECK_LABEL_SEVERE(m_control->Stop(m_delegate->m_device
-                                           , m_delegate->m_instance
-                                           , m_delegate), failed);
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
-    NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
+  /* The resource uri's are stored in the Didl. We must choose the best resource
+   * for the playback device */
+  NPT_Cardinal res_index;
+  NPT_CHECK_LABEL_SEVERE(m_control->FindBestResource(m_delegate->m_device, *obj, res_index), failed);
 
 
-    NPT_CHECK_LABEL_SEVERE(m_control->SetAVTransportURI(m_delegate->m_device
-                                                      , m_delegate->m_instance
-                                                      , obj->m_Resources[res_index].m_Uri
-                                                      , (const char*)tmp
-                                                      , m_delegate), failed);
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
-    NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
-
-    NPT_CHECK_LABEL_SEVERE(m_control->Play(m_delegate->m_device
+  /* dlna specifies that a return code of 705 should be returned
+   * if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT */
+  NPT_CHECK_LABEL_SEVERE(m_control->Stop(m_delegate->m_device
                                          , m_delegate->m_instance
-                                         , "1"
                                          , m_delegate), failed);
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
-    NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
+  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
+
+
+  NPT_CHECK_LABEL_SEVERE(m_control->SetAVTransportURI(m_delegate->m_device
+                                                    , m_delegate->m_instance
+                                                    , obj->m_Resources[res_index].m_Uri
+                                                    , (const char*)tmp
+                                                    , m_delegate), failed);
+  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
+
+  NPT_CHECK_LABEL_SEVERE(m_control->Play(m_delegate->m_device
+                                       , m_delegate->m_instance
+                                       , "1"
+                                       , m_delegate), failed);
+  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
+  NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
 
 
   /* wait for PLAYING state */

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -22,6 +22,10 @@
 #include "cores/IPlayer.h"
 
 class PLT_MediaController;
+class CGUIDialogBusy;
+
+namespace XbmcThreads { class EndTime; }
+
 
 namespace UPNP
 {
@@ -71,6 +75,8 @@ public:
   virtual bool OnAction(const CAction &action);
 
   virtual CStdString GetPlayingTitle();
+
+  int PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout);
 
 private:
   PLT_MediaController*   m_control;

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -68,7 +68,7 @@ public:
   virtual bool IsCaching() const {return false;};
   virtual int GetCacheLevel() const {return -1;};
   virtual void DoAudioWork();
-
+  virtual bool OnAction(const CAction &action);
 
   virtual CStdString GetPlayingTitle();
 
@@ -78,6 +78,7 @@ private:
   CStdString             m_current_uri;
   CStdString             m_current_meta;
   bool                   m_started;
+  bool                   m_stopremote;
 };
 
 } /* namespace UPNP */


### PR DESCRIPTION
This improves the behavior of the upnp player regarding attach/disconnect. It is now possible to detach from a upnp renderer by pressing stop.
