### PR TITLE
Fix mess with CURL::Decode and CURL::Encode

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2467,7 +2467,7 @@ void CFileItemList::StackFiles()
 
     URIUtils::Split(item1->GetPath(), filePath, file1);
     if (URIUtils::ProtocolHasEncodedFilename(CURL(filePath).GetProtocol() ) )
-      CURL::Decode(file1);
+      file1 = CURL::Decode(file1);
 
     int j;
     while (expr != stackRegExps.end())
@@ -2500,7 +2500,7 @@ void CFileItemList::StackFiles()
           CStdString file2, filePath2;
           URIUtils::Split(item2->GetPath(), filePath2, file2);
           if (URIUtils::ProtocolHasEncodedFilename(CURL(filePath2).GetProtocol() ) )
-            CURL::Decode(file2);
+            file2 = CURL::Decode(file2);
 
           if (expr->RegFind(file2, offset) != -1)
           {
@@ -2901,7 +2901,7 @@ CStdString CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
 
   URIUtils::RemoveSlashAtEnd(strMovieName);
   strMovieName = URIUtils::GetFileName(strMovieName);
-  CURL::Decode(strMovieName);
+  strMovieName = CURL::Decode(strMovieName);
 
   return strMovieName;
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2900,10 +2900,8 @@ CStdString CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
     strMovieName = CStackDirectory::GetStackedTitlePath(strMovieName);
 
   URIUtils::RemoveSlashAtEnd(strMovieName);
-  strMovieName = URIUtils::GetFileName(strMovieName);
-  strMovieName = CURL::Decode(strMovieName);
 
-  return strMovieName;
+  return CURL::Decode(URIUtils::GetFileName(strMovieName));
 }
 
 CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -40,7 +40,7 @@ using namespace ADDON;
 CStdString URLEncodeInline(const CStdString& strData)
 {
   CStdString buffer = strData;
-  CURL::Encode(buffer);
+  buffer = CURL::Encode(buffer);
   return buffer;
 }
 
@@ -128,7 +128,7 @@ void CURL::Parse(const CStdString& strURL1)
         if (!(s.st_mode & S_IFDIR))
 #endif
         {
-          Encode(archiveName);
+          archiveName = Encode(archiveName);
           if (is_apk)
           {
             CURL c("apk://" + archiveName + "/" + strURL.substr(iPos + 1));
@@ -743,9 +743,9 @@ void CURL::Decode(CStdString& strURLData)
   strURLData = strResult;
 }
 
-void CURL::Encode(CStdString& strURLData)
+std::string CURL::Encode(const std::string& strURLData)
 {
-  CStdString strResult;
+  std::string strResult;
 
   /* wonder what a good value is here is, depends on how often it occurs */
   strResult.reserve( strURLData.length() * 2 );
@@ -764,20 +764,14 @@ void CURL::Encode(CStdString& strURLData)
       strResult += strTmp;
     }
   }
-  strURLData = strResult;
+
+  return strResult;
 }
 
 std::string CURL::Decode(const std::string& strURLData)
 {
   CStdString url = strURLData;
   Decode(url);
-  return url;
-}
-
-std::string CURL::Encode(const std::string& strURLData)
-{
-  CStdString url = strURLData;
-  Encode(url);
   return url;
 }
 

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -335,12 +335,12 @@ void CURL::Parse(const CStdString& strURL1)
   /* decode urlencoding on this stuff */
   if(URIUtils::ProtocolHasEncodedHostname(m_strProtocol))
   {
-    Decode(m_strHostName);
+    m_strHostName = Decode(m_strHostName);
     SetHostName(m_strHostName);
   }
 
-  Decode(m_strUserName);
-  Decode(m_strPassword);
+  m_strUserName = Decode(m_strUserName);
+  m_strPassword = Decode(m_strPassword);
 }
 
 void CURL::SetFileName(const CStdString& strFileName)
@@ -706,11 +706,11 @@ bool CURL::IsFullPath(const CStdString &url)
   return false;
 }
 
-void CURL::Decode(CStdString& strURLData)
+std::string CURL::Decode(const std::string& strURLData)
 //modified to be more accomodating - if a non hex value follows a % take the characters directly and don't raise an error.
 // However % characters should really be escaped like any other non safe character (www.rfc-editor.org/rfc/rfc1738.txt)
 {
-  CStdString strResult;
+  std::string strResult;
 
   /* result will always be less than source */
   strResult.reserve( strURLData.length() );
@@ -740,7 +740,8 @@ void CURL::Decode(CStdString& strURLData)
     }
     else strResult += kar;
   }
-  strURLData = strResult;
+  
+  return strResult;
 }
 
 std::string CURL::Encode(const std::string& strURLData)
@@ -766,13 +767,6 @@ std::string CURL::Encode(const std::string& strURLData)
   }
 
   return strResult;
-}
-
-std::string CURL::Decode(const std::string& strURLData)
-{
-  CStdString url = strURLData;
-  Decode(url);
-  return url;
 }
 
 CStdString CURL::TranslateProtocol(const CStdString& prot)

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -37,13 +37,6 @@
 using namespace std;
 using namespace ADDON;
 
-CStdString URLEncodeInline(const CStdString& strData)
-{
-  CStdString buffer = strData;
-  buffer = CURL::Encode(buffer);
-  return buffer;
-}
-
 CURL::CURL(const CStdString& strURL1)
 {
   Parse(strURL1);
@@ -598,7 +591,7 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
       strHostName = m_strHostName;
 
     if (URIUtils::ProtocolHasEncodedHostname(m_strProtocol))
-      strURL += URLEncodeInline(strHostName);
+      strURL += Encode(strHostName);
     else
       strURL += strHostName;
 
@@ -643,11 +636,11 @@ CStdString CURL::GetWithoutFilename() const
   }
   else if (m_strUserName != "")
   {
-    strURL += URLEncodeInline(m_strUserName);
+    strURL += Encode(m_strUserName);
     if (m_strPassword != "")
     {
       strURL += ":";
-      strURL += URLEncodeInline(m_strPassword);
+      strURL += Encode(m_strPassword);
     }
     strURL += "@";
   }
@@ -657,7 +650,7 @@ CStdString CURL::GetWithoutFilename() const
   if (m_strHostName != "")
   {
     if( URIUtils::ProtocolHasEncodedHostname(m_strProtocol) )
-      strURL += URLEncodeInline(m_strHostName);
+      strURL += Encode(m_strHostName);
     else
       strURL += m_strHostName;
     if (HasPort())

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -71,7 +71,6 @@ public:
   bool IsLocalHost() const;
   static bool IsFileOnly(const CStdString &url); ///< return true if there are no directories in the url.
   static bool IsFullPath(const CStdString &url); ///< return true if the url includes the full path
-  static void Decode(CStdString& strURLData);
   static std::string Decode(const std::string& strURLData);
   static std::string Encode(const std::string& strURLData);
   static CStdString TranslateProtocol(const CStdString& prot);

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -72,7 +72,6 @@ public:
   static bool IsFileOnly(const CStdString &url); ///< return true if there are no directories in the url.
   static bool IsFullPath(const CStdString &url); ///< return true if the url includes the full path
   static void Decode(CStdString& strURLData);
-  static void Encode(CStdString& strURLData);
   static std::string Decode(const std::string& strURLData);
   static std::string Encode(const std::string& strURLData);
   static CStdString TranslateProtocol(const CStdString& prot);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -230,7 +230,7 @@ CStdString CUtil::GetTitleFromPath(const CStdString& strFileNameAndPath, bool bI
   }
   
   // URLDecode since the original path may be an URL
-  CURL::Decode(strFilename);
+  strFilename = CURL::Decode(strFilename);
   return strFilename;
 }
 
@@ -2205,7 +2205,7 @@ bool CUtil::FindVobSubPair( const std::vector<CStdString>& vecSubtitles, const C
       CStdString strSubDirectory;
       URIUtils::Split(vecSubtitles[j], strSubDirectory, strSubFile);
       if (URIUtils::IsInArchive(vecSubtitles[j]))
-        CURL::Decode(strSubDirectory);
+        strSubDirectory = CURL::Decode(strSubDirectory);
       if (URIUtils::HasExtension(strSubFile, ".sub") &&
           (URIUtils::ReplaceExtension(strIdxFile,"").Equals(URIUtils::ReplaceExtension(strSubFile,"")) ||
            (strSubDirectory.size() >= 11 &&
@@ -2229,7 +2229,7 @@ bool CUtil::IsVobSub( const std::vector<CStdString>& vecSubtitles, const CStdStr
     CStdString strSubDirectory;
     URIUtils::Split(strSubPath, strSubDirectory, strSubFile);
     if (URIUtils::IsInArchive(strSubPath))
-      CURL::Decode(strSubDirectory);
+      strSubDirectory = CURL::Decode(strSubDirectory);
     for (unsigned int j=0; j < vecSubtitles.size(); j++)
     {
       CStdString strIdxFile;

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -251,7 +251,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
             bEncoded = (strstr(option, "urlencoded") != NULL);
           }
           if (bEncoded)
-            CURL::Decode(value);
+            value = CURL::Decode(value);
 
           if (CGUIKeyboardFactory::ShowAndGetInput(value, label, true, bHidden))
           {
@@ -708,7 +708,7 @@ void CGUIDialogAddonSettings::CreateControls()
           // get any option to test for hidden
           const char *option = setting->Attribute("option");
           if (option && (strstr(option, "urlencoded")))
-            CURL::Decode(value);
+            value = CURL::Decode(value);
           if (option && (strstr(option, "hidden")))
           {
             CStdString hiddenText;

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -265,7 +265,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
             else
               ((CGUIButtonControl*) control)->SetLabel2(value);
             if (bEncoded)
-              CURL::Encode(value);
+              value = CURL::Encode(value);
           }
         }
         else if (strcmp(type, "number") == 0 && CGUIDialogNumeric::ShowAndGetNumber(value, label))

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -576,7 +576,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
 
   vector<CStdString> vcsIn(1);
   g_charsetConverter.utf8To(SearchStringEncoding(), sTitle, vcsIn[0]);
-  CURL::Encode(vcsIn[0]);
+  vcsIn[0] = CURL::Encode(vcsIn[0]);
   if (!sYear.empty())
     vcsIn.push_back(sYear);
 
@@ -702,8 +702,8 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const CStdStr
   std::vector<CStdString> extras(2);
   g_charsetConverter.utf8To(SearchStringEncoding(), sAlbum, extras[0]);
   g_charsetConverter.utf8To(SearchStringEncoding(), sArtist, extras[1]);
-  CURL::Encode(extras[0]);
-  CURL::Encode(extras[1]);
+  extras[0] = CURL::Encode(extras[0]);
+  extras[1] = CURL::Encode(extras[1]);
   CScraperUrl scurl;
   vector<CStdString> vcsOut = RunNoThrow("CreateAlbumSearchUrl", scurl, fcurl, &extras);
   if (vcsOut.size() > 1)
@@ -798,7 +798,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
   // returns an XML <url> element parseable by CScraperUrl
   std::vector<CStdString> extras(1);
   g_charsetConverter.utf8To(SearchStringEncoding(), sArtist, extras[0]);
-  CURL::Encode(extras[0]);
+  extras[0] = CURL::Encode(extras[0]);
   CScraperUrl scurl;
   vector<CStdString> vcsOut = RunNoThrow("CreateArtistSearchUrl", scurl, fcurl, &extras);
 
@@ -1009,7 +1009,7 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl, const CScraperUrl &scurl,
   // pass in the original search string for chaining to search other sites
   vector<CStdString> vcIn;
   vcIn.push_back(sSearch);
-  CURL::Encode(vcIn[0]);
+  vcIn[0] = CURL::Encode(vcIn[0]);
 
   vector<CStdString> vcsOut = RunNoThrow("GetArtistDetails", scurl, fcurl, &vcIn);
 

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -38,13 +38,6 @@ using namespace XFILE;
 
 #define AFP_MAX_READ_SIZE 131072
 
-CStdString URLEncode(const CStdString value)
-{
-  CStdString encoded(value);
-  encoded = CURL::Encode(encoded);
-  return encoded;
-}
-
 void AfpConnectionLog(void *priv, enum loglevels loglevel, int logtype, const char *message)
 {
   if (!message) return;
@@ -466,7 +459,7 @@ bool CAFPFile::Open(const CURL& url)
 
   if (gAfpConnection.GetImpl()->afp_wrap_open(m_pAfpVol, strPath.c_str(), O_RDONLY, &m_pFp))
   {
-    if (gAfpConnection.GetImpl()->afp_wrap_open(m_pAfpVol, URLEncode(strPath.c_str()).c_str(), O_RDONLY, &m_pFp))
+    if (gAfpConnection.GetImpl()->afp_wrap_open(m_pAfpVol, CURL::Encode(strPath.c_str()).c_str(), O_RDONLY, &m_pFp))
     {
       // write error to logfile
       CLog::Log(LOGINFO, "CAFPFile::Open: Unable to open file : '%s'\nunix_err:'%x' error : '%s'", strPath.c_str(), errno, strerror(errno));

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -41,7 +41,7 @@ using namespace XFILE;
 CStdString URLEncode(const CStdString value)
 {
   CStdString encoded(value);
-  CURL::Encode(encoded);
+  encoded = CURL::Encode(encoded);
   return encoded;
 }
 

--- a/xbmc/filesystem/AFPFile.h
+++ b/xbmc/filesystem/AFPFile.h
@@ -38,8 +38,6 @@ extern "C" {
 }
 #endif
 
-CStdString URLEncode(CStdString str);
-
 class CAfpConnection : public CCriticalSection
 {
 public:

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -690,7 +690,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         filename += "/";
 
       partial = *it;
-      CURL::Encode(partial);
+      partial = CURL::Encode(partial);
       filename += partial;
     }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -674,7 +674,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     /* url encoded. if handed from ftpdirectory */
     /* it won't be so let's handle that case    */
 
-    CStdString partial, filename(url2.GetFileName());
+    CStdString filename(url2.GetFileName());
     std::vector<std::string> array;
 
     // if server sent us the filename in non-utf8, we need send back with same encoding.
@@ -689,9 +689,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
       if(it != array.begin())
         filename += "/";
 
-      partial = *it;
-      partial = CURL::Encode(partial);
-      filename += partial;
+      filename += CURL::Encode(*it);
     }
 
     /* make sure we keep slashes */

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -167,7 +167,7 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
       {
         CStdString name(itemPath);
         URIUtils::RemoveSlashAtEnd(name);
-        CURL::Decode(name);
+        name = CURL::Decode(name);
         item.SetLabel(URIUtils::GetFileName(name));
       }
 

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -167,8 +167,7 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
       {
         CStdString name(itemPath);
         URIUtils::RemoveSlashAtEnd(name);
-        name = CURL::Decode(name);
-        item.SetLabel(URIUtils::GetFileName(name));
+        item.SetLabel(URIUtils::GetFileName(CURL::Decode(name)));
       }
 
       if (item.m_bIsFolder)

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -113,7 +113,7 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
       CStdString strLinkTemp = strLinkBase;
 
       URIUtils::RemoveSlashAtEnd(strLinkTemp);
-      CURL::Decode(strLinkTemp);
+      strLinkTemp = CURL::Decode(strLinkTemp);
       if (fileCharset.empty())
         g_charsetConverter.unknownToUTF8(strLinkTemp);
       g_charsetConverter.utf8ToW(strLinkTemp, wLink, false);

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -152,7 +152,7 @@ CStdString CMultiPathDirectory::GetFirstPath(const CStdString &strPath)
   if (pos != std::string::npos)
   {
     CStdString firstPath = strPath.substr(12, pos - 12);
-    CURL::Decode(firstPath);
+    firstPath = CURL::Decode(firstPath);
     return firstPath;
   }
   return "";
@@ -177,7 +177,7 @@ bool CMultiPathDirectory::GetPaths(const CStdString& strPath, vector<CStdString>
   for (unsigned int i = 0; i < vecTemp.size(); i++)
   {
     CStdString tempPath = vecTemp[i];
-    CURL::Decode(tempPath);
+    tempPath = CURL::Decode(tempPath);
     vecPaths.push_back(tempPath);
   }
   return true;
@@ -199,7 +199,7 @@ bool CMultiPathDirectory::HasPath(const CStdString& strPath, const CStdString& s
   for (unsigned int i = 0; i < vecTemp.size(); i++)
   {
     CStdString tempPath = vecTemp[i];
-    CURL::Decode(tempPath);
+    tempPath = CURL::Decode(tempPath);
     if(tempPath == strPathToFind)
       return true;
   }

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -150,11 +150,7 @@ CStdString CMultiPathDirectory::GetFirstPath(const CStdString &strPath)
 {
   size_t pos = strPath.find("/", 12);
   if (pos != std::string::npos)
-  {
-    CStdString firstPath = strPath.substr(12, pos - 12);
-    firstPath = CURL::Decode(firstPath);
-    return firstPath;
-  }
+    return CURL::Decode(strPath.substr(12, pos - 12));
   return "";
 }
 
@@ -176,9 +172,7 @@ bool CMultiPathDirectory::GetPaths(const CStdString& strPath, vector<CStdString>
   // check each item
   for (unsigned int i = 0; i < vecTemp.size(); i++)
   {
-    CStdString tempPath = vecTemp[i];
-    tempPath = CURL::Decode(tempPath);
-    vecPaths.push_back(tempPath);
+    vecPaths.push_back(CURL::Decode(vecTemp[i]));
   }
   return true;
 }
@@ -198,9 +192,7 @@ bool CMultiPathDirectory::HasPath(const CStdString& strPath, const CStdString& s
   // check each item
   for (unsigned int i = 0; i < vecTemp.size(); i++)
   {
-    CStdString tempPath = vecTemp[i];
-    tempPath = CURL::Decode(tempPath);
-    if(tempPath == strPathToFind)
+    if (CURL::Decode(vecTemp[i]) == strPathToFind)
       return true;
   }
   return false;

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -225,7 +225,7 @@ void CMultiPathDirectory::AddToMultiPath(CStdString& strMultiPath, const CStdStr
   CStdString strPath1 = strPath;
   URIUtils::AddSlashAtEnd(strMultiPath);
   //CLog::Log(LOGDEBUG, "-- adding path: %s", strPath.c_str());
-  CURL::Encode(strPath1);
+  strPath1 = CURL::Encode(strPath1);
   strMultiPath += strPath1;
   strMultiPath += "/";
 }

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -222,11 +222,9 @@ CStdString CMultiPathDirectory::ConstructMultiPath(const CFileItemList& items, c
 
 void CMultiPathDirectory::AddToMultiPath(CStdString& strMultiPath, const CStdString& strPath)
 {
-  CStdString strPath1 = strPath;
   URIUtils::AddSlashAtEnd(strMultiPath);
   //CLog::Log(LOGDEBUG, "-- adding path: %s", strPath.c_str());
-  strPath1 = CURL::Encode(strPath1);
-  strMultiPath += strPath1;
+  strMultiPath += CURL::Encode(strPath);
   strMultiPath += "/";
 }
 

--- a/xbmc/filesystem/SAPDirectory.cpp
+++ b/xbmc/filesystem/SAPDirectory.cpp
@@ -365,7 +365,7 @@ bool CSAPSessions::ParseAnnounce(char* data, int len)
 
   // add a new session to our buffer
   CStdString user = origin.username;
-  CURL::Encode(user);
+  user = CURL::Encode(user);
   CStdString path = StringUtils::Format("sap://%s/%s/0x%x.sdp", header.origin.c_str(), desc.origin.c_str(), header.msgid);
   CSession session;
   session.path           = path;

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -417,7 +417,7 @@ void CSMBDirectory::UnMountShare(const CStdString &strType, const CStdString &st
 CStdString CSMBDirectory::GetMountPoint(const CStdString &strType, const CStdString &strName)
 {
   CStdString strPath = strType + strName;
-  CURL::Encode(strPath);
+  strPath = CURL::Encode(strPath);
 
 #if defined(TARGET_DARWIN)
   CStdString str = getenv("HOME");

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -398,8 +398,7 @@ void CSMBDirectory::UnMountShare(const CStdString &strType, const CStdString &st
 {
 #if defined(TARGET_DARWIN)
   // Decode the path.
-  CStdString strMountPoint = GetMountPoint(strType, strName);
-  strMountPoint = CURL::Decode(strMountPoint);
+  CStdString strMountPoint(CURL::Decode(GetMountPoint(strType, strName)));
 
   // Make the unmount command.
   CStdStringArray args;

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -416,8 +416,7 @@ void CSMBDirectory::UnMountShare(const CStdString &strType, const CStdString &st
 
 CStdString CSMBDirectory::GetMountPoint(const CStdString &strType, const CStdString &strName)
 {
-  CStdString strPath = strType + strName;
-  strPath = CURL::Encode(strPath);
+  CStdString strPath(CURL::Encode(strType + strName));
 
 #if defined(TARGET_DARWIN)
   CStdString str = getenv("HOME");

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -349,7 +349,7 @@ CStdString CSMBDirectory::MountShare(const CStdString &smbPath, const CStdString
 
 #if defined(TARGET_DARWIN)
   // Create the directory.
-  CURL::Decode(strMountPoint);
+  strMountPoint = CURL::Decode(strMountPoint);
   CreateDirectory(strMountPoint, NULL);
 
   // Massage the path.
@@ -399,7 +399,7 @@ void CSMBDirectory::UnMountShare(const CStdString &strType, const CStdString &st
 #if defined(TARGET_DARWIN)
   // Decode the path.
   CStdString strMountPoint = GetMountPoint(strType, strName);
-  CURL::Decode(strMountPoint);
+  strMountPoint = CURL::Decode(strMountPoint);
 
   // Make the unmount command.
   CStdStringArray args;

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -244,9 +244,7 @@ CStdString CSMB::URLEncode(const CURL &url)
 
 CStdString CSMB::URLEncode(const CStdString &value)
 {
-  CStdString encoded(value);
-  encoded = CURL::Encode(encoded);
-  return encoded;
+  return CURL::Encode(value);
 }
 
 /* This is called from CApplication::ProcessSlow() and is used to tell if smbclient have been idle for too long */

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -245,7 +245,7 @@ CStdString CSMB::URLEncode(const CURL &url)
 CStdString CSMB::URLEncode(const CStdString &value)
 {
   CStdString encoded(value);
-  CURL::Encode(encoded);
+  encoded = CURL::Encode(encoded);
   return encoded;
 }
 

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -93,8 +93,8 @@ namespace XFILE
       // Check if source path uses URL encoding
       if (URIUtils::ProtocolHasEncodedFilename(CURL(strCommonDir).GetProtocol()))
       {
-        CURL::Decode(File1);
-        CURL::Decode(File2);
+        File1 = CURL::Decode(File1);
+        File2 = CURL::Decode(File2);
       }
 
       std::vector<CRegExp>::iterator itRegExp = RegExps.begin();

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -128,7 +128,7 @@ namespace XFILE
                   strStackTitle = Title1 + Ignore1 + Extension1;
                   // Check if source path uses URL encoding
                   if (URIUtils::ProtocolHasEncodedFilename(CURL(strCommonDir).GetProtocol()))
-                    CURL::Encode(strStackTitle);
+                    strStackTitle = CURL::Encode(strStackTitle);
 
                   itRegExp = RegExps.end();
                   break;

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -152,7 +152,7 @@ bool CUPnPDirectory::GetResource(const CURL& path, CFileItem &item)
     CStdString uuid   = path.GetHostName();
     CStdString object = path.GetFileName();
     StringUtils::TrimRight(object, "/");
-    CURL::Decode(object);
+    object = CURL::Decode(object);
 
     PLT_DeviceDataReference device;
     if(!FindDeviceWait(upnp, uuid.c_str(), device)) {
@@ -226,7 +226,7 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
         object_id.TrimRight("/");
         if (object_id.GetLength()) {
             CStdString tmp = (char*) object_id;
-            CURL::Decode(tmp);
+            tmp = CURL::Decode(tmp);
             object_id = tmp;
         }
 

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -333,7 +333,7 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
             else
                 id = (const char*) (*entry)->m_ReferenceID;
 
-            CURL::Encode(id);
+            id = CURL::Encode(id);
             URIUtils::AddSlashAtEnd(id);
             pItem->SetPath(CStdString((const char*) "upnp://" + uuid + "/" + id.c_str()));
 

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -225,9 +225,7 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
         NPT_String object_id = (next_slash==-1)?"":path.SubString(next_slash+1);
         object_id.TrimRight("/");
         if (object_id.GetLength()) {
-            CStdString tmp = (char*) object_id;
-            tmp = CURL::Decode(tmp);
-            object_id = tmp;
+            object_id = CStdString(CURL::Decode((char*)object_id));
         }
 
         // try to find the device with wait on startup

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -187,7 +187,7 @@ bool CZeroconfDirectory::GetDirectory(const CStdString& strPath, CFileItemList &
         CURL url;
         url.SetProtocol("zeroconf");
         CStdString service_path = CZeroconfBrowser::ZeroconfService::toPath(*it);
-        CURL::Encode(service_path);
+        service_path = CURL::Encode(service_path);
         url.SetFileName(service_path);
         item->SetPath(url.Get());
 

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -186,8 +186,7 @@ bool CZeroconfDirectory::GetDirectory(const CStdString& strPath, CFileItemList &
         CFileItemPtr item(new CFileItem("", true));
         CURL url;
         url.SetProtocol("zeroconf");
-        CStdString service_path = CZeroconfBrowser::ZeroconfService::toPath(*it);
-        service_path = CURL::Encode(service_path);
+        CStdString service_path(CURL::Encode(CZeroconfBrowser::ZeroconfService::toPath(*it)));
         url.SetFileName(service_path);
         item->SetPath(url.Get());
 

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -204,8 +204,7 @@ bool CZeroconfDirectory::GetDirectory(const CStdString& strPath, CFileItemList &
   else
   {
     //decode the path first
-    CStdString decoded = path;
-    decoded = CURL::Decode(decoded);
+    CStdString decoded(CURL::Decode(path));
     try
     {
       CZeroconfBrowser::ZeroconfService zeroconf_service = CZeroconfBrowser::ZeroconfService::fromPath(decoded);

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -206,7 +206,7 @@ bool CZeroconfDirectory::GetDirectory(const CStdString& strPath, CFileItemList &
   {
     //decode the path first
     CStdString decoded = path;
-    CURL::Decode(decoded);
+    decoded = CURL::Decode(decoded);
     try
     {
       CZeroconfBrowser::ZeroconfService zeroconf_service = CZeroconfBrowser::ZeroconfService::fromPath(decoded);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -382,10 +382,8 @@ static void OnDirectoryScanned(const CStdString& strDirectory)
 static CStdString Prettify(const CStdString& strDirectory)
 {
   CURL url(strDirectory);
-  CStdString strStrippedPath = url.GetWithoutUserDetails();
-  strStrippedPath = CURL::Decode(strStrippedPath);
 
-  return strStrippedPath;
+  return CURL::Decode(url.GetWithoutUserDetails());
 }
 
 bool CMusicInfoScanner::DoScan(const CStdString& strDirectory)

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -383,7 +383,7 @@ static CStdString Prettify(const CStdString& strDirectory)
 {
   CURL url(strDirectory);
   CStdString strStrippedPath = url.GetWithoutUserDetails();
-  CURL::Decode(strStrippedPath);
+  strStrippedPath = CURL::Decode(strStrippedPath);
 
   return strStrippedPath;
 }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -767,7 +767,7 @@ void CGUIWindowMusicNav::DisplayEmptyDatabaseMessage(bool bDisplay)
 void CGUIWindowMusicNav::OnSearchUpdate()
 {
   CStdString search(GetProperty("search").asString());
-  CURL::Encode(search);
+  search = CURL::Encode(search);
   if (!search.empty())
   {
     CStdString path = "musicsearch://" + search + "/";

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -766,8 +766,7 @@ void CGUIWindowMusicNav::DisplayEmptyDatabaseMessage(bool bDisplay)
 
 void CGUIWindowMusicNav::OnSearchUpdate()
 {
-  CStdString search(GetProperty("search").asString());
-  search = CURL::Encode(search);
+  CStdString search(CURL::Encode(GetProperty("search").asString()));
   if (!search.empty())
   {
     CStdString path = "musicsearch://" + search + "/";

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -862,8 +862,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
 
     if (status != AIRPLAY_STATUS_NEED_AUTH)
     {
-      CStdString userAgent="AppleCoreMedia/1.0.0.8F455 (AppleTV; U; CPU OS 4_3 like Mac OS X; de_de)";
-      userAgent = CURL::Encode(userAgent);
+      CStdString userAgent(CURL::Encode("AppleCoreMedia/1.0.0.8F455 (AppleTV; U; CPU OS 4_3 like Mac OS X; de_de)"));
       location += "|User-Agent=" + userAgent;
 
       CFileItem fileToPlay(location, false);

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -863,7 +863,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
     if (status != AIRPLAY_STATUS_NEED_AUTH)
     {
       CStdString userAgent="AppleCoreMedia/1.0.0.8F455 (AppleTV; U; CPU OS 4_3 like Mac OS X; de_de)";
-      CURL::Encode(userAgent);
+      userAgent = CURL::Encode(userAgent);
       location += "|User-Agent=" + userAgent;
 
       CFileItem fileToPlay(location, false);

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -853,8 +853,7 @@ bool CWebServer::PrepareDownload(const char *path, CVariant &details, std::strin
       url = "image/";
     else
       url = "vfs/";
-    strPath = CURL::Encode(strPath);
-    url += strPath;
+    url += CURL::Encode(strPath);
     details["path"] = url;
     return true;
   }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -853,7 +853,7 @@ bool CWebServer::PrepareDownload(const char *path, CVariant &details, std::strin
       url = "image/";
     else
       url = "vfs/";
-    CURL::Encode(strPath);
+    strPath = CURL::Encode(strPath);
     url += strPath;
     details["path"] = url;
     return true;

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -184,7 +184,7 @@ public:
         NPT_String path = "upnp://"+device->GetUUID()+"/";
         if (!NPT_StringsEqual(item_id, "0")) {
             CStdString id = item_id;
-            CURL::Encode(id);
+            id = CURL::Encode(id);
             URIUtils::AddSlashAtEnd(id);
             path += id.c_str();
         }

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -183,8 +183,7 @@ public:
     {
         NPT_String path = "upnp://"+device->GetUUID()+"/";
         if (!NPT_StringsEqual(item_id, "0")) {
-            CStdString id = item_id;
-            id = CURL::Encode(id);
+            CStdString id(CURL::Encode(item_id));
             URIUtils::AddSlashAtEnd(id);
             path += id.c_str();
         }

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -210,7 +210,7 @@ CUPnPRenderer::ProcessHttpGetRequest(NPT_HttpRequest&              request,
             }
 
             // open the file
-            CStdString path = CURL::Decode((const char*) filepath);
+            CStdString path (CURL::Decode((const char*) filepath));
             NPT_File file(path.c_str());
             NPT_Result result = file.Open(NPT_FILE_OPEN_MODE_READ);
             if (NPT_FAILED(result)) {

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -225,7 +225,7 @@ NPT_String CUPnPServer::BuildSafeResourceUri(const NPT_HttpUrl &rooturi,
     else
       filename = URIUtils::GetFileName(file_path);
 
-    CURL::Encode(filename);
+    filename = CURL::Encode(filename);
     md5state.append(file_path);
     md5state.getDigest(md5);
     md5 += "/" + filename;

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -988,7 +988,7 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
                             NPT_Map<NPT_String,NPT_String>&  new_vals,
                             const PLT_HttpRequestContext&    context)
 {
-    CStdString path = CURL::Decode(object_id);
+    CStdString path(CURL::Decode(object_id));
     CFileItem updated;
     updated.SetPath(path);
     CLog::Log(LOGINFO, "UPnP: OnUpdateObject: %s from %s", path.c_str(),

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -49,8 +49,7 @@ void CGUIDialogLockSettings::SetupPage()
   // update our settings label
   if (m_bGetUser)
   {
-    CStdString strLabel2=m_strURL;
-    strLabel2 = CURL::Decode(strLabel2);
+    CStdString strLabel2(CURL::Decode(m_strURL));
     CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(20152), strLabel2.c_str());
     SET_CONTROL_LABEL(2, strLabel);
   }
@@ -123,8 +122,7 @@ void CGUIDialogLockSettings::OnSettingChanged(SettingInfo &setting)
     if (m_bGetUser)
     {
       CStdString strHeading;
-      CStdString strDecodeUrl = m_strURL;
-      strDecodeUrl = CURL::Decode(strDecodeUrl);
+      CStdString strDecodeUrl(CURL::Decode(m_strURL));
       strHeading = StringUtils::Format("%s %s", g_localizeStrings.Get(14062).c_str(), strDecodeUrl.c_str());
       if (CGUIKeyboardFactory::ShowAndGetInput(m_strUser,strHeading,true))
       {
@@ -187,8 +185,7 @@ void CGUIDialogLockSettings::OnSettingChanged(SettingInfo &setting)
   }
   if (setting.id == 2 && m_bGetUser)
   {
-    CStdString strDecodeUrl = m_strURL;
-    strDecodeUrl = CURL::Decode(strDecodeUrl);
+    CStdString strDecodeUrl(CURL::Decode(m_strURL));
     CStdString strHeading = StringUtils::Format("%s %s", g_localizeStrings.Get(20143).c_str(), strDecodeUrl.c_str());
     if (CGUIKeyboardFactory::ShowAndGetInput(m_locks.code,strHeading,true,true))
     {

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -50,7 +50,7 @@ void CGUIDialogLockSettings::SetupPage()
   if (m_bGetUser)
   {
     CStdString strLabel2=m_strURL;
-    CURL::Decode(strLabel2);
+    strLabel2 = CURL::Decode(strLabel2);
     CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(20152), strLabel2.c_str());
     SET_CONTROL_LABEL(2, strLabel);
   }
@@ -124,7 +124,7 @@ void CGUIDialogLockSettings::OnSettingChanged(SettingInfo &setting)
     {
       CStdString strHeading;
       CStdString strDecodeUrl = m_strURL;
-      CURL::Decode(strDecodeUrl);
+      strDecodeUrl = CURL::Decode(strDecodeUrl);
       strHeading = StringUtils::Format("%s %s", g_localizeStrings.Get(14062).c_str(), strDecodeUrl.c_str());
       if (CGUIKeyboardFactory::ShowAndGetInput(m_strUser,strHeading,true))
       {
@@ -188,7 +188,7 @@ void CGUIDialogLockSettings::OnSettingChanged(SettingInfo &setting)
   if (setting.id == 2 && m_bGetUser)
   {
     CStdString strDecodeUrl = m_strURL;
-    CURL::Decode(strDecodeUrl);
+    strDecodeUrl = CURL::Decode(strDecodeUrl);
     CStdString strHeading = StringUtils::Format("%s %s", g_localizeStrings.Get(20143).c_str(), strDecodeUrl.c_str());
     if (CGUIKeyboardFactory::ShowAndGetInput(m_locks.code,strHeading,true,true))
     {

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -529,7 +529,7 @@ void CScraperParser::Clean(CStdString& strDirty)
     if ((i2 = strDirty.find("!!!ENCODE!!!",i+12)) != std::string::npos)
     {
       strBuffer = strDirty.substr(i+12,i2-i-12);
-      CURL::Encode(strBuffer);
+      strBuffer = CURL::Encode(strBuffer);
       strDirty.replace(i, i2-i+12, strBuffer);
       i += strBuffer.size();
     }

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -528,8 +528,7 @@ void CScraperParser::Clean(CStdString& strDirty)
     size_t i2;
     if ((i2 = strDirty.find("!!!ENCODE!!!",i+12)) != std::string::npos)
     {
-      strBuffer = strDirty.substr(i+12,i2-i-12);
-      strBuffer = CURL::Encode(strBuffer);
+      strBuffer = CURL::Encode(strDirty.substr(i + 12, i2 - i - 12));
       strDirty.replace(i, i2-i+12, strBuffer);
       i += strBuffer.size();
     }

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -346,9 +346,8 @@ CStdString CScraperUrl::GetThumbURL(const CScraperUrl::SUrlEntry &entry)
 {
   if (entry.m_spoof.empty())
     return entry.m_url;
-  CStdString spoof = entry.m_spoof;
-  spoof = CURL::Encode(spoof);
-  return entry.m_url + "|Referer=" + spoof;
+  
+  return entry.m_url + "|Referer=" + CStdString(CURL::Encode(entry.m_spoof));
 }
 
 void CScraperUrl::GetThumbURLs(std::vector<CStdString> &thumbs, const std::string &type, int season) const

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -347,7 +347,7 @@ CStdString CScraperUrl::GetThumbURL(const CScraperUrl::SUrlEntry &entry)
   if (entry.m_spoof.empty())
     return entry.m_url;
   CStdString spoof = entry.m_spoof;
-  CURL::Encode(spoof);
+  spoof = CURL::Encode(spoof);
   return entry.m_url + "|Referer=" + spoof;
 }
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1113,24 +1113,17 @@ void URIUtils::CreateArchivePath(CStdString& strUrlPath,
                                  const CStdString& strFilePathInArchive,
                                  const CStdString& strPwd)
 {
-  CStdString strBuffer;
-
   strUrlPath = strType+"://";
 
   if( !strPwd.empty() )
   {
-    strBuffer = strPwd;
-    strBuffer = CURL::Encode(strBuffer);
-    strUrlPath += strBuffer;
+    strUrlPath += CURL::Encode(strPwd);
     strUrlPath += "@";
   }
 
-  strBuffer = strArchivePath;
-  strBuffer = CURL::Encode(strBuffer);
+  strUrlPath += CURL::Encode(strArchivePath);
 
-  strUrlPath += strBuffer;
-
-  strBuffer = strFilePathInArchive;
+  CStdString strBuffer(strFilePathInArchive);
   StringUtils::Replace(strBuffer, '\\', '/');
   StringUtils::TrimLeft(strBuffer, "/");
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1120,13 +1120,13 @@ void URIUtils::CreateArchivePath(CStdString& strUrlPath,
   if( !strPwd.empty() )
   {
     strBuffer = strPwd;
-    CURL::Encode(strBuffer);
+    strBuffer = CURL::Encode(strBuffer);
     strUrlPath += strBuffer;
     strUrlPath += "@";
   }
 
   strBuffer = strArchivePath;
-  CURL::Encode(strBuffer);
+  strBuffer = CURL::Encode(strBuffer);
 
   strUrlPath += strBuffer;
 
@@ -1139,7 +1139,7 @@ void URIUtils::CreateArchivePath(CStdString& strUrlPath,
 
 #if 0 // options are not used
   strBuffer = strCachePath;
-  CURL::Encode(strBuffer);
+  strBuffer = CURL::Encode(strBuffer);
 
   strUrlPath += "?cache=";
   strUrlPath += strBuffer;

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -237,7 +237,7 @@ bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdStrin
   {
     strStringValue = pNode->Value();
     if (encoded && strcasecmp(encoded,"yes") == 0)
-      CURL::Decode(strStringValue);
+      strStringValue = CURL::Decode(strStringValue);
     return true;
   }
   strStringValue.clear();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -769,7 +769,7 @@ namespace VIDEO
       if (!EnumerateEpisodeItem(items[i].get(), episodeList))
       {
         CStdString decode(items[i]->GetPath());
-        CURL::Decode(decode);
+        decode = CURL::Decode(decode);
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file %s", CURL::GetRedacted(decode).c_str());
       }
     }
@@ -866,7 +866,7 @@ namespace VIDEO
 
     CStdString strLabel=item->GetPath();
     // URLDecode in case an episode is on a http/https/dav/davs:// source and URL-encoded like foo%201x01%20bar.avi
-    CURL::Decode(strLabel);
+    strLabel = CURL::Decode(strLabel);
 
     for (unsigned int i=0;i<expression.size();++i)
     {
@@ -1073,7 +1073,7 @@ namespace VIDEO
     }
 
     std::string redactPath = pItem->GetPath();
-    CURL::Decode(redactPath);
+    redactPath = CURL::Decode(redactPath);
     redactPath = CURL::GetRedacted(redactPath);
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to %s:%s", TranslateContent(content).c_str(), redactPath.c_str());

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -767,11 +767,7 @@ namespace VIDEO
         continue;
 
       if (!EnumerateEpisodeItem(items[i].get(), episodeList))
-      {
-        CStdString decode(items[i]->GetPath());
-        decode = CURL::Decode(decode);
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file %s", CURL::GetRedacted(decode).c_str());
-      }
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file %s", CURL::GetRedacted(CURL::Decode(items[i]->GetPath())).c_str());
     }
   }
 
@@ -1072,9 +1068,7 @@ namespace VIDEO
       strTitle = StringUtils::Format("%s - %ix%i - %s", showInfo->m_strTitle.c_str(), movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle.c_str());
     }
 
-    std::string redactPath = pItem->GetPath();
-    redactPath = CURL::Decode(redactPath);
-    redactPath = CURL::GetRedacted(redactPath);
+    std::string redactPath(CURL::GetRedacted(CURL::Decode(pItem->GetPath())));
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to %s:%s", TranslateContent(content).c_str(), redactPath.c_str());
     long lResult = -1;


### PR DESCRIPTION
CURL has two overloads for Encode() and Decode(): for CStdString argument and for std::string argument.
This should be fine, but overloads have totally different behavior: CStdString version modified reference in place and return void while std::string version use const ref for argument and return modified string.
This can confuse anyone and leads to hardly discoverable errors like this: https://github.com/xbmc/xbmc/commit/5dc310eb2dd6bee1207cd29b1ce4a7eb5cf57fff#diff-656dceee8727b0777668ecbfd17f76fbR131 - after archiveName type changed to std::string, archiveName stop being encoded.
This PR fix this error and stop overloading functions with different behavior to prevent such errors in future.
