### PR TITLE
ActiveAE decides whether to open a fallback sink

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -41,5 +41,8 @@ public:
   static void     ParseDevice(std::string &device, std::string &driver);
   static IAESink *Create(std::string &device, AEAudioFormat &desiredFormat, bool rawPassthrough);
   static void     EnumerateEx(AESinkInfoList &list, bool force = false); /* The force flag can be used to indicate the rescan devices */
+
+protected:
+  static IAESink *TrySink(std::string &driver, std::string &device, AEAudioFormat &format);
 };
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -657,6 +657,29 @@ void CActiveAESink::OpenSink()
   CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device %s", device.c_str());
   m_sink = CAESinkFactory::Create(device, m_sinkFormat, passthrough);
 
+  // try first device in out list
+  if (!m_sink && !m_sinkInfoList.empty())
+  {
+    driver = m_sinkInfoList.front().m_sinkName;
+    device = m_sinkInfoList.front().m_deviceInfoList.front().m_deviceName;
+    GetDeviceFriendlyName(device);
+    if (!driver.empty())
+      device = driver + ":" + device;
+    m_sinkFormat = m_requestedFormat;
+    CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device %s", device.c_str());
+    m_sink = CAESinkFactory::Create(device, m_sinkFormat, passthrough);
+  }
+
+  // open NULL sink
+  // TODO: should not be required by ActiveAE
+  if (!m_sink)
+  {
+    device = "NULL:NULL";
+    m_sinkFormat = m_requestedFormat;
+    CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - open NULL sink");
+    m_sink = CAESinkFactory::Create(device, m_sinkFormat, passthrough);
+  }
+
   if (!m_sink)
   {
     CLog::Log(LOGERROR, "CActiveAESink::OpenSink - no sink was returned");


### PR DESCRIPTION
currently the sink factory returns a NULL sink in case of error. this behavior has always been bad but now with new PA sink it is an issue. The engine has the change to fall back to a device of the enumerated list.
