### PR TITLE
Minor changes to enable c++11 compilation

### DIFF
--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -99,7 +99,7 @@ void CAppParamParser::DisplayHelp()
   printf("  -p or --portable\tXBMC will look for configurations in install folder instead of ~/.xbmc\n");
   printf("  --legacy-res\t\tEnables screen resolutions such as PAL, NTSC, etc.\n");
 #ifdef HAS_LIRC
-  printf("  -l or --lircdev\tLircDevice to use default is "LIRC_DEVICE" .\n");
+  printf("  -l or --lircdev\tLircDevice to use default is " LIRC_DEVICE " .\n");
   printf("  -n or --nolirc\tdo not use Lirc, i.e. no remote input.\n");
 #endif
   printf("  --debug\t\tEnable debug logging\n");

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -79,8 +79,8 @@ using namespace PERIPHERALS;
 CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay) : CThread("DelayedMessage")
 {
   m_msg.dwMessage  = msg.dwMessage;
-  m_msg.dwParam1   = msg.dwParam1;
-  m_msg.dwParam2   = msg.dwParam2;
+  m_msg.param1     = msg.param1;
+  m_msg.param2     = msg.param2;
   m_msg.waitEvent  = msg.waitEvent;
   m_msg.lpVoid     = msg.lpVoid;
   m_msg.strParam   = msg.strParam;
@@ -171,8 +171,8 @@ void CApplicationMessenger::SendMessage(ThreadMessage& message, bool wait)
 
   ThreadMessage* msg = new ThreadMessage();
   msg->dwMessage = message.dwMessage;
-  msg->dwParam1 = message.dwParam1;
-  msg->dwParam2 = message.dwParam2;
+  msg->param1   = message.param1;
+  msg->param2   = message.param2;
   msg->waitEvent = message.waitEvent;
   msg->lpVoid = message.lpVoid;
   msg->strParam = message.strParam;
@@ -302,7 +302,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
     case TMSG_INHIBITIDLESHUTDOWN:
       {
-        g_application.InhibitIdleShutdown(pMsg->dwParam1 != 0);
+        g_application.InhibitIdleShutdown(pMsg->param1 != 0);
       }
       break;
 
@@ -315,10 +315,10 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
     case TMSG_MEDIA_PLAY:
       {
         // first check if we were called from the PlayFile() function
-        if (pMsg->lpVoid && pMsg->dwParam2 == 0)
+        if (pMsg->lpVoid && pMsg->param2 == 0)
         {
           CFileItem *item = (CFileItem *)pMsg->lpVoid;
-          g_application.PlayFile(*item, pMsg->dwParam1 != 0);
+          g_application.PlayFile(*item, pMsg->param1 != 0);
           delete item;
           return;
         }
@@ -365,18 +365,18 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
                 g_playlistPlayer.SetRepeat(playlist, (PLAYLIST::REPEAT_STATE)list->GetProperty("repeat").asInteger(), false);
 
               g_playlistPlayer.Add(playlist, (*list));
-              g_playlistPlayer.Play(pMsg->dwParam1);
+              g_playlistPlayer.Play(pMsg->param1);
             }
           }
 
           delete list;
         }
-        else if (pMsg->dwParam1 == PLAYLIST_MUSIC || pMsg->dwParam1 == PLAYLIST_VIDEO)
+        else if (pMsg->param1 == PLAYLIST_MUSIC || pMsg->param1 == PLAYLIST_VIDEO)
         {
-          if (g_playlistPlayer.GetCurrentPlaylist() != (int)pMsg->dwParam1)
-            g_playlistPlayer.SetCurrentPlaylist(pMsg->dwParam1);
+          if (g_playlistPlayer.GetCurrentPlaylist() != pMsg->param1)
+            g_playlistPlayer.SetCurrentPlaylist(pMsg->param1);
 
-          PlayListPlayerPlay(pMsg->dwParam2);
+          PlayListPlayerPlay(pMsg->param2);
         }
       }
       break;
@@ -448,7 +448,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         CFileItemList items;
         CStdString strPath = pMsg->strParam;
         CStdString extensions = g_advancedSettings.m_pictureExtensions;
-        if (pMsg->dwParam1)
+        if (pMsg->param1)
           extensions += "|.tbn";
         CUtil::GetRecursiveListing(strPath, items, extensions);
 
@@ -483,11 +483,11 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         bool stopSlideshow = true;
         bool stopVideo = true;
         bool stopMusic = true;
-        if (pMsg->dwParam1 >= PLAYLIST_MUSIC && pMsg->dwParam1 <= PLAYLIST_PICTURE)
+        if (pMsg->param1 >= PLAYLIST_MUSIC && pMsg->param1 <= PLAYLIST_PICTURE)
         {
-          stopSlideshow = (pMsg->dwParam1 == PLAYLIST_PICTURE);
-          stopVideo = (pMsg->dwParam1 == PLAYLIST_VIDEO);
-          stopMusic = (pMsg->dwParam1 == PLAYLIST_MUSIC);
+          stopSlideshow = (pMsg->param1 == PLAYLIST_PICTURE);
+          stopVideo = (pMsg->param1 == PLAYLIST_VIDEO);
+          stopMusic = (pMsg->param1 == PLAYLIST_MUSIC);
         }
 
         if ((stopSlideshow && g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) ||
@@ -553,9 +553,9 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         CLog::Log(LOGNOTICE, "%s: Failed to suspend AudioEngine before launching external program",__FUNCTION__);
       }
 #if defined( TARGET_POSIX) && !defined(TARGET_DARWIN)
-      CUtil::RunCommandLine(pMsg->strParam.c_str(), (pMsg->dwParam1 == 1));
+      CUtil::RunCommandLine(pMsg->strParam.c_str(), (pMsg->param1 == 1));
 #elif defined(TARGET_WINDOWS)
-      CWIN32Util::XBMCShellExecute(pMsg->strParam.c_str(), (pMsg->dwParam1 == 1));
+      CWIN32Util::XBMCShellExecute(pMsg->strParam.c_str(), (pMsg->param1 == 1));
 #endif
       /* Resume AE processing of XBMC native audio */
       if (!CAEFactory::Resume())
@@ -573,17 +573,17 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       break;
 
     case TMSG_PLAYLISTPLAYER_PLAY:
-      if (pMsg->dwParam1 != (unsigned int) -1)
-        g_playlistPlayer.Play(pMsg->dwParam1);
+      if (pMsg->param1 != -1)
+        g_playlistPlayer.Play(pMsg->param1);
       else
         g_playlistPlayer.Play();
       break;
 
     case TMSG_PLAYLISTPLAYER_PLAY_SONG_ID:
-      if (pMsg->dwParam1 != (unsigned int) -1)
+      if (pMsg->param1 != -1)
       {
         bool *result = (bool*)pMsg->lpVoid;
-        *result = g_playlistPlayer.PlaySongId(pMsg->dwParam1);
+        *result = g_playlistPlayer.PlaySongId(pMsg->param1);
       }
       else
         g_playlistPlayer.Play();
@@ -602,7 +602,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       {
         CFileItemList *list = (CFileItemList *)pMsg->lpVoid;
 
-        g_playlistPlayer.Add(pMsg->dwParam1, (*list));
+        g_playlistPlayer.Add(pMsg->param1, (*list));
         delete list;
       }
       break;
@@ -611,32 +611,32 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       if (pMsg->lpVoid)
       {
         CFileItemList *list = (CFileItemList *)pMsg->lpVoid;
-        g_playlistPlayer.Insert(pMsg->dwParam1, (*list), pMsg->dwParam2);
+        g_playlistPlayer.Insert(pMsg->param1, (*list), pMsg->param2);
         delete list;
       }
       break;
 
     case TMSG_PLAYLISTPLAYER_REMOVE:
-      if (pMsg->dwParam1 != (unsigned int) -1)
-        g_playlistPlayer.Remove(pMsg->dwParam1,pMsg->dwParam2);
+      if (pMsg->param1 != -1)
+        g_playlistPlayer.Remove(pMsg->param1,pMsg->param2);
       break;
 
     case TMSG_PLAYLISTPLAYER_CLEAR:
-      g_playlistPlayer.ClearPlaylist(pMsg->dwParam1);
+      g_playlistPlayer.ClearPlaylist(pMsg->param1);
       break;
 
     case TMSG_PLAYLISTPLAYER_SHUFFLE:
-      g_playlistPlayer.SetShuffle(pMsg->dwParam1, pMsg->dwParam2 > 0);
+      g_playlistPlayer.SetShuffle(pMsg->param1, pMsg->param2 > 0);
       break;
 
     case TMSG_PLAYLISTPLAYER_REPEAT:
-      g_playlistPlayer.SetRepeat(pMsg->dwParam1, (PLAYLIST::REPEAT_STATE)pMsg->dwParam2);
+      g_playlistPlayer.SetRepeat(pMsg->param1, (PLAYLIST::REPEAT_STATE)pMsg->param2);
       break;
 
     case TMSG_PLAYLISTPLAYER_GET_ITEMS:
       if (pMsg->lpVoid)
       {
-        PLAYLIST::CPlayList playlist = g_playlistPlayer.GetPlaylist(pMsg->dwParam1);
+        PLAYLIST::CPlayList playlist = g_playlistPlayer.GetPlaylist(pMsg->param1);
         CFileItemList *list = (CFileItemList *)pMsg->lpVoid;
 
         for (int i = 0; i < playlist.size(); i++)
@@ -649,7 +649,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       {
         vector<int> *indexes = (vector<int> *)pMsg->lpVoid;
         if (indexes->size() == 2)
-          g_playlistPlayer.Swap(pMsg->dwParam1, indexes->at(0), indexes->at(1));
+          g_playlistPlayer.Swap(pMsg->param1, indexes->at(0), indexes->at(1));
         delete indexes;
       }
       break;
@@ -657,7 +657,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
     // Window messages below here...
     case TMSG_DIALOG_DOMODAL:  //doModel of window
       {
-        CGUIDialog* pDialog = (CGUIDialog*)g_windowManager.GetWindow(pMsg->dwParam1);
+        CGUIDialog* pDialog = (CGUIDialog*)g_windowManager.GetWindow(pMsg->param1);
         if (!pDialog) return ;
         pDialog->DoModal();
       }
@@ -665,7 +665,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
     case TMSG_NETWORKMESSAGE:
       {
-        g_application.getNetwork().NetworkMessage((CNetwork::EMESSAGE)pMsg->dwParam1, (int)pMsg->dwParam2);
+        g_application.getNetwork().NetworkMessage((CNetwork::EMESSAGE)pMsg->param1, pMsg->param2);
       }
       break;
 
@@ -673,7 +673,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       {
         CGUIDialog *pDialog = (CGUIDialog *)pMsg->lpVoid;
         if (pDialog)
-          pDialog->DoModal((int)pMsg->dwParam1, pMsg->strParam);
+          pDialog->DoModal(pMsg->param1, pMsg->strParam);
       }
       break;
 
@@ -689,13 +689,13 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       {
         CGUIWindow *window = (CGUIWindow *)pMsg->lpVoid;
         if (window)
-          window->Close(pMsg->dwParam2 & 0x1 ? true : false, pMsg->dwParam1, pMsg->dwParam2 & 0x2 ? true : false);
+          window->Close(pMsg->param1 & 0x1 ? true : false, pMsg->param1, pMsg->param1 & 0x2 ? true : false);
       }
       break;
 
     case TMSG_GUI_ACTIVATE_WINDOW:
       {
-        g_windowManager.ActivateWindow(pMsg->dwParam1, pMsg->params, pMsg->dwParam2 > 0);
+        g_windowManager.ActivateWindow(pMsg->param1, pMsg->params, pMsg->param2 > 0);
       }
       break;
 
@@ -703,7 +703,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       {
         if (pMsg->lpVoid)
         { // TODO: This is ugly - really these python dialogs should just be normal XBMC dialogs
-          ((ADDON::CGUIAddonWindowDialog *) pMsg->lpVoid)->Show_Internal(pMsg->dwParam2 > 0);
+          ((ADDON::CGUIAddonWindowDialog *) pMsg->lpVoid)->Show_Internal(pMsg->param2 > 0);
         }
       }
       break;
@@ -713,7 +713,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       {
         // This hack is not much better but at least I don't need to make ApplicationMessenger
         //  know about Addon (Python) specific classes.
-        CAction caction(pMsg->dwParam1);
+        CAction caction(pMsg->param1);
         ((CGUIWindow*)pMsg->lpVoid)->OnAction(caction);
       }
       break;
@@ -724,15 +724,15 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         if (pMsg->lpVoid)
         {
           CAction *action = (CAction *)pMsg->lpVoid;
-          if (pMsg->dwParam1 == WINDOW_INVALID)
+          if (pMsg->param1 == WINDOW_INVALID)
             g_application.OnAction(*action);
           else
           {
-            CGUIWindow *pWindow = g_windowManager.GetWindow(pMsg->dwParam1);  
+            CGUIWindow *pWindow = g_windowManager.GetWindow(pMsg->param1);
             if (pWindow)
               pWindow->OnAction(*action);
             else
-              CLog::Log(LOGWARNING, "Failed to get window with ID %i to send an action to", pMsg->dwParam1);
+              CLog::Log(LOGWARNING, "Failed to get window with ID %i to send an action to", pMsg->param1);
           }
           delete action;
         }
@@ -744,7 +744,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         if (pMsg->lpVoid)
         {
           CGUIMessage *message = (CGUIMessage *)pMsg->lpVoid;
-          g_windowManager.SendMessage(*message, pMsg->dwParam1);
+          g_windowManager.SendMessage(*message, pMsg->param1);
           delete message;
         }
       }
@@ -780,7 +780,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
     case TMSG_VOLUME_SHOW:
       {
-        CAction action((int)pMsg->dwParam1);
+        CAction action(pMsg->param1);
         g_application.ShowVolumeBar(&action);
       }
       break;
@@ -811,9 +811,9 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       CFileItem* item = (CFileItem*)pMsg->lpVoid;
       if (!item)
         return;
-      if (pMsg->dwParam1 == 1 && item->HasMusicInfoTag()) // only grab music tag
+      if (pMsg->param1 == 1 && item->HasMusicInfoTag()) // only grab music tag
         g_infoManager.SetCurrentSongTag(*item->GetMusicInfoTag());
-      else if (pMsg->dwParam1 == 2 && item->HasVideoInfoTag()) // only grab video tag
+      else if (pMsg->param1 == 2 && item->HasVideoInfoTag()) // only grab video tag
         g_infoManager.SetCurrentVideoTag(*item->GetVideoInfoTag());
       else
         g_infoManager.SetCurrentItem(*item);
@@ -823,7 +823,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
     case TMSG_LOADPROFILE:
     {
-      CGUIWindowLoginScreen::LoadProfile(pMsg->dwParam1);
+      CGUIWindowLoginScreen::LoadProfile(pMsg->param1);
       break;
     }
     case TMSG_CECTOGGLESTATE:
@@ -925,8 +925,8 @@ void CApplicationMessenger::MediaPlay(const CFileItemList &list, int song)
   CFileItemList* listcopy = new CFileItemList();
   listcopy->Copy(list);
   tMsg.lpVoid = (void*)listcopy;
-  tMsg.dwParam1 = song;
-  tMsg.dwParam2 = 1;
+  tMsg.param1 = song;
+  tMsg.param1 = 2;
   SendMessage(tMsg, true);
 }
 
@@ -934,8 +934,8 @@ void CApplicationMessenger::MediaPlay(int playlistid, int song /* = -1 */)
 {
   ThreadMessage tMsg = {TMSG_MEDIA_PLAY};
   tMsg.lpVoid = NULL;
-  tMsg.dwParam1 = playlistid;
-  tMsg.dwParam2 = song;
+  tMsg.param1 = playlistid;
+  tMsg.param2 = song;
   SendMessage(tMsg, true);
 }
 
@@ -944,15 +944,15 @@ void CApplicationMessenger::PlayFile(const CFileItem &item, bool bRestart /*= fa
   ThreadMessage tMsg = {TMSG_MEDIA_PLAY};
   CFileItem *pItem = new CFileItem(item);
   tMsg.lpVoid = (void *)pItem;
-  tMsg.dwParam1 = bRestart ? 1 : 0;
-  tMsg.dwParam2 = 0;
+  tMsg.param1 = bRestart ? 1 : 0;
+  tMsg.param2 = 0;
   SendMessage(tMsg, false);
 }
 
 void CApplicationMessenger::MediaStop(bool bWait /* = true */, int playlistid /* = -1 */)
 {
   ThreadMessage tMsg = {TMSG_MEDIA_STOP};
-  tMsg.dwParam1 = playlistid;
+  tMsg.param1 = playlistid;
   SendMessage(tMsg, bWait);
 }
 
@@ -1027,7 +1027,7 @@ void CApplicationMessenger::PlayListPlayerAdd(int playlist, const CFileItemList 
   CFileItemList* listcopy = new CFileItemList();
   listcopy->Copy(list);
   tMsg.lpVoid = (void*)listcopy;
-  tMsg.dwParam1 = playlist;
+  tMsg.param1 = playlist;
   SendMessage(tMsg, true);
 }
 
@@ -1044,8 +1044,8 @@ void CApplicationMessenger::PlayListPlayerInsert(int playlist, const CFileItemLi
   CFileItemList* listcopy = new CFileItemList();
   listcopy->Copy(list);
   tMsg.lpVoid = (void *)listcopy;
-  tMsg.dwParam1 = playlist;
-  tMsg.dwParam2 = index;
+  tMsg.param1 = playlist;
+  tMsg.param2 = index;
   SendMessage(tMsg, true);
 }
 
@@ -1058,22 +1058,22 @@ void CApplicationMessenger::PlayListPlayerRemove(int playlist, int position)
 void CApplicationMessenger::PlayListPlayerClear(int playlist)
 {
   ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_CLEAR};
-  tMsg.dwParam1 = playlist;
+  tMsg.param1 = playlist;
   SendMessage(tMsg, true);
 }
 
 void CApplicationMessenger::PlayListPlayerShuffle(int playlist, bool shuffle)
 {
   ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_SHUFFLE};
-  tMsg.dwParam1 = playlist;
-  tMsg.dwParam2 = shuffle ? 1 : 0;
+  tMsg.param1 = playlist;
+  tMsg.param2 = shuffle ? 1 : 0;
   SendMessage(tMsg, true);
 }
 
 void CApplicationMessenger::PlayListPlayerGetItems(int playlist, CFileItemList &list)
 {
   ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_GET_ITEMS};
-  tMsg.dwParam1 = playlist;
+  tMsg.param1 = playlist;
   tMsg.lpVoid = (void *)&list;
   SendMessage(tMsg, true);
 }
@@ -1081,7 +1081,7 @@ void CApplicationMessenger::PlayListPlayerGetItems(int playlist, CFileItemList &
 void CApplicationMessenger::PlayListPlayerSwap(int playlist, int indexItem1, int indexItem2)
 {
   ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_SWAP};
-  tMsg.dwParam1 = playlist;
+  tMsg.param1 = playlist;
   vector<int> *indexes = new vector<int>();
   indexes->push_back(indexItem1);
   indexes->push_back(indexItem2);
@@ -1092,8 +1092,8 @@ void CApplicationMessenger::PlayListPlayerSwap(int playlist, int indexItem1, int
 void CApplicationMessenger::PlayListPlayerRepeat(int playlist, int repeatState)
 {
   ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_REPEAT};
-  tMsg.dwParam1 = playlist;
-  tMsg.dwParam2 = repeatState;
+  tMsg.param1 = playlist;
+  tMsg.param2 = repeatState;
   SendMessage(tMsg, true);
 }
 
@@ -1109,7 +1109,7 @@ void CApplicationMessenger::PictureSlideShow(string pathname, bool addTBN /* = f
   unsigned int dwMessage = TMSG_PICTURE_SLIDESHOW;
   ThreadMessage tMsg = {dwMessage};
   tMsg.strParam = pathname;
-  tMsg.dwParam1 = addTBN ? 1 : 0;
+  tMsg.param1 = addTBN ? 1 : 0;
   SendMessage(tMsg);
 }
 
@@ -1205,7 +1205,7 @@ void CApplicationMessenger::DoModal(CGUIDialog *pDialog, int iWindowID, const CS
 {
   ThreadMessage tMsg = {TMSG_GUI_DO_MODAL};
   tMsg.lpVoid = pDialog;
-  tMsg.dwParam1 = (unsigned int)iWindowID;
+  tMsg.param1 = iWindowID;
   tMsg.strParam = param;
   SendMessage(tMsg, true);
 }
@@ -1214,7 +1214,7 @@ void CApplicationMessenger::ExecOS(const CStdString &command, bool waitExit)
 {
   ThreadMessage tMsg = {TMSG_EXECUTE_OS};
   tMsg.strParam = command;
-  tMsg.dwParam1 = (unsigned int)waitExit;
+  tMsg.param1 = waitExit ? 1 : 0;
   SendMessage(tMsg, false);
 }
 
@@ -1234,7 +1234,7 @@ void CApplicationMessenger::Show(CGUIDialog *pDialog)
 void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose, bool waitResult /*= true*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
   ThreadMessage tMsg = {TMSG_GUI_WINDOW_CLOSE, (unsigned int)nextWindowID};
-  tMsg.dwParam2 = (unsigned int)((forceClose ? 0x01 : 0) | (enableSound ? 0x02 : 0));
+  tMsg.param2 = (forceClose ? 0x01 : 0) | (enableSound ? 0x02 : 0);
   tMsg.lpVoid = window;
   SendMessage(tMsg, waitResult);
 }
@@ -1249,7 +1249,7 @@ void CApplicationMessenger::ActivateWindow(int windowID, const vector<string> &p
 void CApplicationMessenger::SendAction(const CAction &action, int windowID, bool waitResult)
 {
   ThreadMessage tMsg = {TMSG_GUI_ACTION};
-  tMsg.dwParam1 = windowID;
+  tMsg.param1 = windowID;
   tMsg.lpVoid = new CAction(action);
   SendMessage(tMsg, waitResult);
 }
@@ -1257,7 +1257,7 @@ void CApplicationMessenger::SendAction(const CAction &action, int windowID, bool
 void CApplicationMessenger::SendGUIMessage(const CGUIMessage &message, int windowID, bool waitResult)
 {
   ThreadMessage tMsg = {TMSG_GUI_MESSAGE};
-  tMsg.dwParam1 = windowID == WINDOW_INVALID ? 0 : windowID;
+  tMsg.param1 = windowID == WINDOW_INVALID ? 0 : windowID;
   tMsg.lpVoid = new CGUIMessage(message);
   SendMessage(tMsg, waitResult);
 }
@@ -1302,7 +1302,7 @@ vector<bool> CApplicationMessenger::GetInfoBooleans(const vector<string> &proper
 void CApplicationMessenger::ShowVolumeBar(bool up)
 {
   ThreadMessage tMsg = {TMSG_VOLUME_SHOW};
-  tMsg.dwParam1 = up ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN;
+  tMsg.param1 = up ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN;
   SendMessage(tMsg, false);
 }
 
@@ -1344,7 +1344,7 @@ void CApplicationMessenger::SetCurrentSongTag(const CMusicInfoTag& tag)
 {
   CFileItem* item = new CFileItem(tag);
   ThreadMessage tMsg = {TMSG_UPDATE_CURRENT_ITEM};
-  tMsg.dwParam1 = 1;
+  tMsg.param1 = 1;
   tMsg.lpVoid = (void*)item;
   SendMessage(tMsg, false);
 }
@@ -1353,7 +1353,7 @@ void CApplicationMessenger::SetCurrentVideoTag(const CVideoInfoTag& tag)
 {
   CFileItem* item = new CFileItem(tag);
   ThreadMessage tMsg = {TMSG_UPDATE_CURRENT_ITEM};
-  tMsg.dwParam1 = 2;
+  tMsg.param1 = 2;
   tMsg.lpVoid = (void*)item;
   SendMessage(tMsg, false);
 }
@@ -1369,7 +1369,7 @@ void CApplicationMessenger::SetCurrentItem(const CFileItem& item)
 void CApplicationMessenger::LoadProfile(unsigned int idx)
 {
   ThreadMessage tMsg = {TMSG_LOADPROFILE};
-  tMsg.dwParam1 = idx;
+  tMsg.param1 = idx;
   SendMessage(tMsg, false);
 }
 

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -119,8 +119,8 @@ namespace MUSIC_INFO
 typedef struct
 {
   unsigned int dwMessage;
-  unsigned int dwParam1;
-  unsigned int dwParam2;
+  int param1;
+  int param2;
   CStdString strParam;
   std::vector<std::string> params;
   boost::shared_ptr<CEvent> waitEvent;

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -201,7 +201,7 @@ CStdString CTextureCacheJob::GetImageHash(const CStdString &url)
     if (!time)
       time = st.st_ctime;
     if (time || st.st_size)
-      return StringUtils::Format("d%"PRId64"s%"PRId64, time, st.st_size);;
+      return StringUtils::Format("d%" PRId64"s%" PRId64, time, st.st_size);;
 
   }
   CLog::Log(LOGDEBUG, "%s - unable to stat url %s", __FUNCTION__, url.c_str());

--- a/xbmc/cores/DllLoader/dll_tracker_file.cpp
+++ b/xbmc/cores/DllLoader/dll_tracker_file.cpp
@@ -75,7 +75,7 @@ extern "C" void tracker_file_free_all(DllTrackInfo* pInfo)
   if (!pInfo->fileList.empty())
   {
     CSingleLock lock(g_trackerLock);
-    CLog::Log(LOGDEBUG, "%s: Detected open files: %"PRIdS"", pInfo->pDll->GetFileName(), pInfo->fileList.size());
+    CLog::Log(LOGDEBUG, "%s: Detected open files: %" PRIdS"", pInfo->pDll->GetFileName(), pInfo->fileList.size());
     for (FileListIter it = pInfo->fileList.begin(); it != pInfo->fileList.end(); ++it)
     {
       TrackedFile* file = *it;

--- a/xbmc/cores/DllLoader/dll_tracker_library.cpp
+++ b/xbmc/cores/DllLoader/dll_tracker_library.cpp
@@ -59,7 +59,7 @@ extern "C" void tracker_library_free_all(DllTrackInfo* pInfo)
   if (!pInfo->dllList.empty())
   {
     CSingleLock lock(g_trackerLock);
-    CLog::Log(LOGDEBUG,"%s: Detected %"PRIdS" unloaded dll's", pInfo->pDll->GetFileName(), pInfo->dllList.size());
+    CLog::Log(LOGDEBUG,"%s: Detected %" PRIdS" unloaded dll's", pInfo->pDll->GetFileName(), pInfo->dllList.size());
     for (DllListIter it = pInfo->dllList.begin(); it != pInfo->dllList.end(); ++it)
     {
       LibraryLoader* pDll = DllLoaderContainer::GetModule((HMODULE)*it);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -297,7 +297,7 @@ extern "C"
     void* pBlock = malloc(size);
     if (!pBlock)
     {
-      CLog::Log(LOGSEVERE, "malloc %"PRIdS" bytes failed, crash imminent", size);
+      CLog::Log(LOGSEVERE, "malloc %" PRIdS" bytes failed, crash imminent", size);
     }
     return pBlock;
   }
@@ -312,7 +312,7 @@ extern "C"
     void* pBlock = calloc(num, size);
     if (!pBlock)
     {
-      CLog::Log(LOGSEVERE, "calloc %"PRIdS" bytes failed, crash imminent", size);
+      CLog::Log(LOGSEVERE, "calloc %" PRIdS" bytes failed, crash imminent", size);
     }
     return pBlock;
   }
@@ -322,7 +322,7 @@ extern "C"
     void* pBlock =  realloc(memblock, size);
     if (!pBlock)
     {
-      CLog::Log(LOGSEVERE, "realloc %"PRIdS" bytes failed, crash imminent", size);
+      CLog::Log(LOGSEVERE, "realloc %" PRIdS" bytes failed, crash imminent", size);
     }
     return pBlock;
   }

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -68,7 +68,7 @@ double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
   {
     static int64_t old;
     if(old > current)
-      CLog::Log(LOGWARNING, "CurrentHostCounter() moving backwords by %"PRId64" ticks with freq of %"PRId64, old - current, m_systemFrequency);
+      CLog::Log(LOGWARNING, "CurrentHostCounter() moving backwords by %" PRId64" ticks with freq of %" PRId64, old - current, m_systemFrequency);
     old = current;
   }
 #endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecCC.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecCC.cpp
@@ -97,7 +97,7 @@ int CDVDOverlayCodecCC::Decode(DemuxPacket *pPacket)
     m_pCurrentOverlay->iPTSStopTime = 0LL;
 
     char test[64];
-    sprintf(test, "cc data : %"PRId64, pts);
+    sprintf(test, "cc data : %" PRId64, pts);
     CDVDOverlayText::CElementText* pText = new CDVDOverlayText::CElementText(test);
     m_pCurrentOverlay->AddElement(pText);
     return OC_OVERLAY;*/

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
@@ -967,7 +967,7 @@ bool CMPCOutputThread::GetDecoderOutput(void)
         else
         {
           if (m_PictureNumber != procOut.PicInfo.picture_number)
-            CLog::Log(LOGDEBUG, "%s: No timestamp detected: %"PRIu64, __MODULE_NAME__, procOut.PicInfo.timeStamp);
+            CLog::Log(LOGDEBUG, "%s: No timestamp detected: %" PRIu64, __MODULE_NAME__, procOut.PicInfo.timeStamp);
           m_PictureNumber = procOut.PicInfo.picture_number;
         }
       }
@@ -1990,7 +1990,7 @@ void CCrystalHD::bitstream_alloc_and_copy(
 void PrintFormat(BCM::BC_PIC_INFO_BLOCK &pib)
 {
   CLog::Log(LOGDEBUG, "----------------------------------\n%s","");
-  CLog::Log(LOGDEBUG, "\tTimeStamp: %"PRIu64"\n", pib.timeStamp);
+  CLog::Log(LOGDEBUG, "\tTimeStamp: %" PRIu64"\n", pib.timeStamp);
   CLog::Log(LOGDEBUG, "\tPicture Number: %d\n", pib.picture_number);
   CLog::Log(LOGDEBUG, "\tWidth: %d\n", pib.width);
   CLog::Log(LOGDEBUG, "\tHeight: %d\n", pib.height);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -85,7 +85,7 @@ static inline VASurfaceID GetSurfaceID(AVFrame *pic)
 
 static CDisplayPtr GetGlobalDisplay()
 {
-  static weak_ptr<CDisplay> display_global;
+  static boost::weak_ptr<CDisplay> display_global;
 
   CDisplayPtr display(display_global.lock());
   if(display)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -236,7 +236,7 @@ bool CDVDDemuxVobsub::ParseTimestamp(SState& state, char* line)
   STimestamp timestamp;
 
   while(*line == ' ') line++;
-  if(sscanf(line, "%d:%d:%d:%d, filepos:%"PRIx64, &h, &m, &s, &ms, &timestamp.pos) != 5)
+  if(sscanf(line, "%d:%d:%d:%d, filepos:%" PRIx64, &h, &m, &s, &ms, &timestamp.pos) != 5)
     return false;
 
   timestamp.id  = state.id;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -945,12 +945,12 @@ int64_t CDVDInputStreamBluray::Seek(int64_t offset, int whence)
   int64_t pos = m_dll->bd_seek(m_bd, offset);
   if(pos < 0)
   {
-    CLog::Log(LOGERROR, "CDVDInputStreamBluray::Seek - seek to %"PRId64", failed with %"PRId64, offset, pos);
+    CLog::Log(LOGERROR, "CDVDInputStreamBluray::Seek - seek to %" PRId64", failed with %" PRId64, offset, pos);
     return -1;
   }
 
   if(pos != offset)
-    CLog::Log(LOGWARNING, "CDVDInputStreamBluray::Seek - seek to %"PRId64", ended at %"PRId64, offset, pos);
+    CLog::Log(LOGWARNING, "CDVDInputStreamBluray::Seek - seek to %" PRId64", ended at %" PRId64, offset, pos);
 
   return offset;
 #else

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -528,7 +528,7 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
           }
           m_iVobUnitCorrection += gap;
 
-          CLog::Log(LOGDEBUG, "DVDNAV_NAV_PACKET - DISCONTINUITY FROM:%"PRId64" TO:%"PRId64" DIFF:%"PRId64, (m_iVobUnitStop * 1000)/90, ((int64_t)pci->pci_gi.vobu_s_ptm*1000)/90, (gap*1000)/90);
+          CLog::Log(LOGDEBUG, "DVDNAV_NAV_PACKET - DISCONTINUITY FROM:%" PRId64" TO:%" PRId64" DIFF:%" PRId64, (m_iVobUnitStop * 1000)/90, ((int64_t)pci->pci_gi.vobu_s_ptm*1000)/90, (gap*1000)/90);
         }
 
         m_iVobUnitStart = pci->pci_gi.vobu_s_ptm;

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -333,7 +333,7 @@ bool CEdl::ReadEdl(const CStdString& strMovie, const float fFramesPerSecond)
 
   if (HasCut() || HasSceneMarker())
   {
-    CLog::Log(LOGDEBUG, "%s - Read %"PRIuS" cuts and %"PRIuS" scene markers in EDL file: %s", __FUNCTION__,
+    CLog::Log(LOGDEBUG, "%s - Read %" PRIuS" cuts and %" PRIuS" scene markers in EDL file: %s", __FUNCTION__,
               m_vecCuts.size(), m_vecSceneMarkers.size(), edlFilename.c_str());
     return true;
   }
@@ -414,7 +414,7 @@ bool CEdl::ReadComskip(const CStdString& strMovie, const float fFramesPerSecond)
   }
   else if (HasCut())
   {
-    CLog::Log(LOGDEBUG, "%s - Read %"PRIuS" commercial breaks from Comskip file: %s", __FUNCTION__, m_vecCuts.size(),
+    CLog::Log(LOGDEBUG, "%s - Read %" PRIuS" commercial breaks from Comskip file: %s", __FUNCTION__, m_vecCuts.size(),
               comskipFilename.c_str());
     return true;
   }
@@ -504,7 +504,7 @@ bool CEdl::ReadVideoReDo(const CStdString& strMovie)
   }
   else if (HasCut() || HasSceneMarker())
   {
-    CLog::Log(LOGDEBUG, "%s - Read %"PRIuS" cuts and %"PRIuS" scene markers in VideoReDo file: %s", __FUNCTION__,
+    CLog::Log(LOGDEBUG, "%s - Read %" PRIuS" cuts and %" PRIuS" scene markers in VideoReDo file: %s", __FUNCTION__,
               m_vecCuts.size(), m_vecSceneMarkers.size(), videoReDoFilename.c_str());
     return true;
   }
@@ -587,7 +587,7 @@ bool CEdl::ReadBeyondTV(const CStdString& strMovie)
   }
   else if (HasCut())
   {
-    CLog::Log(LOGDEBUG, "%s - Read %"PRIuS" commercial breaks from Beyond TV file: %s", __FUNCTION__, m_vecCuts.size(),
+    CLog::Log(LOGDEBUG, "%s - Read %" PRIuS" commercial breaks from Beyond TV file: %s", __FUNCTION__, m_vecCuts.size(),
               beyondTVFilename.c_str());
     return true;
   }
@@ -1010,7 +1010,7 @@ bool CEdl::ReadMythCommBreakList(const CStdString& strMovie, const float fFrames
 
   if (HasCut())
   {
-    CLog::Log(LOGDEBUG, "%s - Added %"PRIuS" commercial breaks from MythTV for: %s. Used detected frame rate of %.3f fps to calculate times from the frame markers.",
+    CLog::Log(LOGDEBUG, "%s - Added %" PRIuS" commercial breaks from MythTV for: %s. Used detected frame rate of %.3f fps to calculate times from the frame markers.",
               __FUNCTION__, m_vecCuts.size(), url.GetFileName().c_str(), fFramesPerSecond);
     return true;
   }
@@ -1063,7 +1063,7 @@ bool CEdl::ReadMythCutList(const CStdString& strMovie, const float fFramesPerSec
 
   if (found)
   {
-    CLog::Log(LOGDEBUG, "%s - Added %"PRIuS" cuts from MythTV for: %s. Used detected frame rate of %.3f fps to calculate times from the frame markers.",
+    CLog::Log(LOGDEBUG, "%s - Added %" PRIuS" cuts from MythTV for: %s. Used detected frame rate of %.3f fps to calculate times from the frame markers.",
               __FUNCTION__, m_vecCuts.size(), url.GetFileName().c_str(), fFramesPerSecond);
     return true;
   }

--- a/xbmc/cores/paplayer/OGGcodec.cpp
+++ b/xbmc/cores/paplayer/OGGcodec.cpp
@@ -121,7 +121,7 @@ bool OGGCodec::Init(const CStdString &strFile1, unsigned int filecache)
 
   if (m_SampleRate==0 || m_Channels==0 || m_BitsPerSample==0 || m_TotalTime==0)
   {
-    CLog::Log(LOGERROR, "OGGCodec: incomplete stream info from %s, SampleRate=%i, Channels=%i, BitsPerSample=%i, TotalTime=%"PRIu64, strFile1.c_str(), m_SampleRate, m_Channels, m_BitsPerSample, m_TotalTime);
+    CLog::Log(LOGERROR, "OGGCodec: incomplete stream info from %s, SampleRate=%i, Channels=%i, BitsPerSample=%i, TotalTime=%" PRIu64, strFile1.c_str(), m_SampleRate, m_Channels, m_BitsPerSample, m_TotalTime);
     return false;
   }
 

--- a/xbmc/cores/paplayer/WAVcodec.cpp
+++ b/xbmc/cores/paplayer/WAVcodec.cpp
@@ -189,7 +189,7 @@ bool WAVCodec::Init(const CStdString &strFile, unsigned int filecache)
       // sanity check on the data length
       if (m_iDataLen > length - m_iDataStart)
       {
-        CLog::Log(LOGWARNING, "WAVCodec::Init - Wave has corrupt data length of %i when it can't be longer then %"PRId64"", m_iDataLen, length - m_iDataStart);
+        CLog::Log(LOGWARNING, "WAVCodec::Init - Wave has corrupt data length of %i when it can't be longer then %" PRId64"", m_iDataLen, length - m_iDataStart);
         m_iDataLen = (long)(length - m_iDataStart);
       }
 

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -171,7 +171,7 @@ void CPlayerCoreFactory::GetPlayers( const CFileItem& item, VECPLAYERCORES &vecC
   for(unsigned int i = 0; i < m_vecCoreSelectionRules.size(); i++)
     m_vecCoreSelectionRules[i]->GetPlayers(item, vecCores);
 
-  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: matched %"PRIuS" rules with players", vecCores.size());
+  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: matched %" PRIuS" rules with players", vecCores.size());
 
   if( PAPlayer::HandlesType(url.GetFileType()) )
   {
@@ -239,7 +239,7 @@ void CPlayerCoreFactory::GetPlayers( const CFileItem& item, VECPLAYERCORES &vecC
   /* make our list unique, preserving first added players */
   unique(vecCores);
 
-  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: added %"PRIuS" players", vecCores.size());
+  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: added %" PRIuS" players", vecCores.size());
 }
 
 void CPlayerCoreFactory::GetRemotePlayers( VECPLAYERCORES &vecCores ) const

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -216,7 +216,7 @@ string field_value::get_asString() const {
     }
     case ft_Int64: {
       char t[23];
-      sprintf(t,"%"PRId64,int64_value);
+      sprintf(t,"%" PRId64,int64_value);
       return tmp = t;
     }
     default:
@@ -317,7 +317,7 @@ char field_value::get_asChar() const {
     }
     case ft_Int64: {
       char t[24];
-      sprintf(t,"%"PRId64,int64_value);
+      sprintf(t,"%" PRId64,int64_value);
       return t[0];
     }
     default:

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -843,7 +843,7 @@ void CEpg::SetChannel(PVR::CPVRChannelPtr channel)
 bool CEpg::HasPVRChannel(void) const
 {
   CSingleLock lock(m_critSection);
-  return m_pvrChannel;
+  return m_pvrChannel != NULL;
 }
 
 bool CEpg::UpdatePending(void) const

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -584,7 +584,7 @@ int64_t CAFPFile::Seek(int64_t iFilePosition, int iWhence)
 
   if ( newOffset < 0 || newOffset > m_fileSize)
   {
-    CLog::Log(LOGERROR, "%s - Error( %"PRId64")", __FUNCTION__, newOffset);
+    CLog::Log(LOGERROR, "%s - Error( %" PRId64")", __FUNCTION__, newOffset);
     return -1;
   }
 

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -169,7 +169,7 @@ int CSimpleFileCache::ReadFromCache(char *pBuffer, size_t iMaxSize)
 
   DWORD iRead = 0;
   if (!ReadFile(m_hCacheFileRead, pBuffer, iMaxSize, &iRead, NULL)) {
-    CLog::Log(LOGERROR,"CSimpleFileCache::ReadFromCache - failed to read %"PRIdS" bytes.", iMaxSize);
+    CLog::Log(LOGERROR,"CSimpleFileCache::ReadFromCache - failed to read %" PRIdS" bytes.", iMaxSize);
     return CACHE_RC_ERROR;
   }
   m_nReadPosition += iRead;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -306,7 +306,7 @@ void CCurlFile::CReadState::SetResume(void)
 long CCurlFile::CReadState::Connect(unsigned int size)
 {
   if (m_filePos != 0)
-    CLog::Log(LOGDEBUG,"CurlFile::CReadState::Connect - Resume from position %"PRId64, m_filePos);
+    CLog::Log(LOGDEBUG,"CurlFile::CReadState::Connect - Resume from position %" PRId64, m_filePos);
 
   SetResume();
   g_curlInterface.multi_add_handle(m_multiHandle, m_easyHandle);
@@ -1060,7 +1060,7 @@ bool CCurlFile::CReadState::ReadString(char *szLine, int iLineLength)
   if (!m_stillRunning && (m_fileSize == 0 || m_filePos != m_fileSize) && !want)
   {
     if (m_fileSize != 0)
-      CLog::Log(LOGWARNING, "%s - Transfer ended before entire file was retrieved pos %"PRId64", size %"PRId64, __FUNCTION__, m_filePos, m_fileSize);
+      CLog::Log(LOGWARNING, "%s - Transfer ended before entire file was retrieved pos %" PRId64", size %" PRId64, __FUNCTION__, m_filePos, m_fileSize);
 
     return false;
   }
@@ -1387,7 +1387,7 @@ unsigned int CCurlFile::CReadState::Read(void* lpBuf, int64_t uiBufSize)
   /* check if we finished prematurely */
   if (!m_stillRunning && (m_fileSize == 0 || m_filePos != m_fileSize))
   {
-    CLog::Log(LOGWARNING, "%s - Transfer ended before entire file was retrieved pos %"PRId64", size %"PRId64, __FUNCTION__, m_filePos, m_fileSize);
+    CLog::Log(LOGWARNING, "%s - Transfer ended before entire file was retrieved pos %" PRId64", size %" PRId64, __FUNCTION__, m_filePos, m_fileSize);
     return 0;
   }
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -226,7 +226,7 @@ void CFileCache::Process()
         m_nSeekResult = m_source.Seek(cacheMaxPos, SEEK_SET);
         if (m_nSeekResult != cacheMaxPos)
         {
-          CLog::Log(LOGERROR,"CFileCache::Process - Error %d seeking. Seek returned %"PRId64, (int)GetLastError(), m_nSeekResult);
+          CLog::Log(LOGERROR,"CFileCache::Process - Error %d seeking. Seek returned %" PRId64, (int)GetLastError(), m_nSeekResult);
           m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
           sourceSeekFailed = true;
         }
@@ -422,14 +422,14 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     m_seekEvent.Set();
     if (!m_seekEnded.Wait())
     {
-      CLog::Log(LOGWARNING,"%s - seek to %"PRId64" failed.", __FUNCTION__, m_seekPos);
+      CLog::Log(LOGWARNING,"%s - seek to %" PRId64" failed.", __FUNCTION__, m_seekPos);
       return -1;
     }
 
     /* wait for any remainin data */
     if(m_seekPos < iTarget)
     {
-      CLog::Log(LOGDEBUG,"%s - waiting for position %"PRId64".", __FUNCTION__, iTarget);
+      CLog::Log(LOGDEBUG,"%s - waiting for position %" PRId64".", __FUNCTION__, iTarget);
       if(m_pCache->WaitForData((unsigned)(iTarget - m_seekPos), 10000) < iTarget - m_seekPos)
       {
         CLog::Log(LOGWARNING,"%s - failed to get remaining data", __FUNCTION__);

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -309,7 +309,7 @@ bool CMythFile::Open(const CURL& url)
     if(!SetupRecording(url))
       return false;
 
-    CLog::Log(LOGDEBUG, "%s - file: size %"PRIu64", start %"PRIu64", ", __FUNCTION__,  (int64_t)m_dll->file_length(m_file), (int64_t)m_dll->file_start(m_file));
+    CLog::Log(LOGDEBUG, "%s - file: size %" PRIu64", start %" PRIu64", ", __FUNCTION__,  (int64_t)m_dll->file_length(m_file), (int64_t)m_dll->file_start(m_file));
   }
   else if (StringUtils::StartsWith(path, "channels/"))
   {
@@ -324,7 +324,7 @@ bool CMythFile::Open(const CURL& url)
     if(!SetupFile(url))
       return false;
 
-    CLog::Log(LOGDEBUG, "%s - file: size %"PRId64", start %"PRId64", ", __FUNCTION__,  (int64_t)m_dll->file_length(m_file), (int64_t)m_dll->file_start(m_file));
+    CLog::Log(LOGDEBUG, "%s - file: size %" PRId64", start %" PRId64", ", __FUNCTION__,  (int64_t)m_dll->file_length(m_file), (int64_t)m_dll->file_start(m_file));
   }
   else
   {
@@ -461,7 +461,7 @@ bool CMythFile::Delete(const CURL& url)
 
 int64_t CMythFile::Seek(int64_t pos, int whence)
 {
-  CLog::Log(LOGDEBUG, "%s - seek to pos %"PRId64", whence %d", __FUNCTION__, pos, whence);
+  CLog::Log(LOGDEBUG, "%s - seek to pos %" PRId64", whence %d", __FUNCTION__, pos, whence);
 
   if(m_recorder) // Live TV
     return -1; // Seeking not possible. Eventually will use m_dll->livetv_seek(m_recorder, pos, whence);

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -171,7 +171,7 @@ struct nfs_context *CNfsConnection::getContextFromMap(const CStdString &exportna
       //refresh access time of that
       //context and return it
       if (!forceCacheHit) // only log it if this isn't the resetkeepalive on each read ;)
-        CLog::Log(LOGDEBUG, "NFS: Refreshing context for %s, old: %"PRId64", new: %"PRId64, exportname.c_str(), it->second.lastAccessedTime, now);
+        CLog::Log(LOGDEBUG, "NFS: Refreshing context for %s, old: %" PRId64", new: %" PRId64, exportname.c_str(), it->second.lastAccessedTime, now);
       it->second.lastAccessedTime = now;
       pRet = it->second.pContext;
     }
@@ -668,7 +668,7 @@ int64_t CNFSFile::Seek(int64_t iFilePosition, int iWhence)
   ret = (int)gNfsConnection.GetImpl()->nfs_lseek(m_pNfsContext, m_pFileHandle, iFilePosition, iWhence, &offset);
   if (ret < 0) 
   {
-    CLog::Log(LOGERROR, "%s - Error( seekpos: %"PRId64", whence: %i, fsize: %"PRId64", %s)", __FUNCTION__, iFilePosition, iWhence, m_fileSize, gNfsConnection.GetImpl()->nfs_get_error(m_pNfsContext));
+    CLog::Log(LOGERROR, "%s - Error( seekpos: %" PRId64", whence: %i, fsize: %" PRId64", %s)", __FUNCTION__, iFilePosition, iWhence, m_fileSize, gNfsConnection.GetImpl()->nfs_get_error(m_pNfsContext));
     return -1;
   }
   return (int64_t)offset;
@@ -685,7 +685,7 @@ int CNFSFile::Truncate(int64_t iSize)
   ret = (int)gNfsConnection.GetImpl()->nfs_ftruncate(m_pNfsContext, m_pFileHandle, iSize);
   if (ret < 0) 
   {
-    CLog::Log(LOGERROR, "%s - Error( ftruncate: %"PRId64", fsize: %"PRId64", %s)", __FUNCTION__, iSize, m_fileSize, gNfsConnection.GetImpl()->nfs_get_error(m_pNfsContext));
+    CLog::Log(LOGERROR, "%s - Error( ftruncate: %" PRId64", fsize: %" PRId64", %s)", __FUNCTION__, iSize, m_fileSize, gNfsConnection.GetImpl()->nfs_get_error(m_pNfsContext));
     return -1;
   }
   return ret;

--- a/xbmc/filesystem/RTVFile.cpp
+++ b/xbmc/filesystem/RTVFile.cpp
@@ -101,7 +101,7 @@ bool CRTVFile::Open(const char* strHostName, const char* strFileName, int iport)
   }
   m_bOpened = true;
 
-  CLog::Log(LOGDEBUG, "%s - Opened %s on %s, Size %"PRIu64", Position %"PRIu64"", __FUNCTION__, strHostName, strFileName, m_fileSize, m_filePos);
+  CLog::Log(LOGDEBUG, "%s - Opened %s on %s, Size %" PRIu64", Position %" PRIu64"", __FUNCTION__, strHostName, strFileName, m_fileSize, m_filePos);
   return true;
 }
 
@@ -132,7 +132,7 @@ unsigned int CRTVFile::Read(void *lpBuf, int64_t uiBufSize)
   // Read uiBufSize bytes from the m_rtvd connection
   lenread = rtv_read_file(m_rtvd, (char *) lpBuf, (size_t) uiBufSize);
 
-  CLog::Log(LOGDEBUG, "%s - Requested %"PRIdS", Received %"PRIdS"", __FUNCTION__, (size_t)uiBufSize, lenread);
+  CLog::Log(LOGDEBUG, "%s - Requested %" PRIdS", Received %" PRIdS"", __FUNCTION__, (size_t)uiBufSize, lenread);
 
   // Some extra checking so library behaves
   if(m_filePos + lenread > m_fileSize)

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -550,7 +550,7 @@ int64_t CSmbFile::Seek(int64_t iFilePosition, int iWhence)
 
   if ( pos < 0 )
   {
-    CLog::Log(LOGERROR, "%s - Error( %"PRId64", %d, %s )", __FUNCTION__, pos, errno, strerror(errno));
+    CLog::Log(LOGERROR, "%s - Error( %" PRId64", %d, %s )", __FUNCTION__, pos, errno, strerror(errno));
     return -1;
   }
 

--- a/xbmc/filesystem/VTPFile.cpp
+++ b/xbmc/filesystem/VTPFile.cpp
@@ -137,7 +137,7 @@ unsigned int CVTPFile::Read(void* buffer, int64_t size)
 
 int64_t CVTPFile::Seek(int64_t pos, int whence)
 {
-  CLog::Log(LOGDEBUG, "CVTPFile::Seek - seek to pos %"PRId64", whence %d", pos, whence);
+  CLog::Log(LOGDEBUG, "CVTPFile::Seek - seek to pos %" PRId64", whence %d", pos, whence);
   return -1;
 }
 

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -63,7 +63,7 @@ bool CZipManager::GetZipList(const CURL& url, vector<SZipEntry>& items)
   if (it != mZipMap.end()) // already listed, just return it if not changed, else release and reread
   {
     map<CStdString,int64_t>::iterator it2=mZipDate.find(strFile);
-    CLog::Log(LOGDEBUG,"statdata: %"PRId64" new: %"PRIu64, it2->second, (uint64_t)m_StatData.st_mtime);
+    CLog::Log(LOGDEBUG,"statdata: %" PRId64" new: %" PRIu64, it2->second, (uint64_t)m_StatData.st_mtime);
 
       if (m_StatData.st_mtime == it2->second)
       {

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -208,7 +208,7 @@ public:
   virtual void SetHeight(float height);
   virtual void SetVisible(bool bVisible, bool setVisState = false);
   void SetVisibleCondition(const CStdString &expression, const CStdString &allowHiddenFocus = "");
-  bool HasVisibleCondition() const { return m_visibleCondition; };
+  bool HasVisibleCondition() const { return m_visibleCondition != NULL; };
   void SetEnableCondition(const CStdString &expression);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void SetInitialVisibility();

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -734,7 +734,7 @@ void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *c
     if (!m_vertex)
     {
       free(old);
-      CLog::Log(LOGSEVERE, "%s: can't allocate %"PRIdS" bytes for texture", __FUNCTION__ , m_vertex_size * sizeof(SVertex));
+      CLog::Log(LOGSEVERE, "%s: can't allocate %" PRIdS" bytes for texture", __FUNCTION__ , m_vertex_size * sizeof(SVertex));
       return;
     }
   }

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -53,7 +53,7 @@ bool CGUIVisualisationControl::OnMessage(CGUIMessage &message)
   {
   case GUI_MSG_GET_VISUALISATION:
     message.SetPointer(m_addon.get());
-    return m_addon;
+    return m_addon != NULL;
   case GUI_MSG_VISUALISATION_RELOAD:
     FreeResources(true);
     return true;

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -198,7 +198,7 @@ bool CTextureBundleXBT::ConvertFrameToTexture(const CStdString& name, CXBTFFrame
   squish::u8 *buffer = new squish::u8[(size_t)frame.GetPackedSize()];
   if (buffer == NULL)
   {
-    CLog::Log(LOGERROR, "Out of memory loading texture: %s (need %"PRIu64" bytes)", name.c_str(), frame.GetPackedSize());
+    CLog::Log(LOGERROR, "Out of memory loading texture: %s (need %" PRIu64" bytes)", name.c_str(), frame.GetPackedSize());
     return false;
   }
 
@@ -216,7 +216,7 @@ bool CTextureBundleXBT::ConvertFrameToTexture(const CStdString& name, CXBTFFrame
     squish::u8 *unpacked = new squish::u8[(size_t)frame.GetUnpackedSize()];
     if (unpacked == NULL)
     {
-      CLog::Log(LOGERROR, "Out of memory unpacking texture: %s (need %"PRIu64" bytes)", name.c_str(), frame.GetUnpackedSize());
+      CLog::Log(LOGERROR, "Out of memory unpacking texture: %s (need %" PRIu64" bytes)", name.c_str(), frame.GetUnpackedSize());
       delete[] buffer;
       return false;
     }

--- a/xbmc/guilib/TextureBundleXPR.cpp
+++ b/xbmc/guilib/TextureBundleXPR.cpp
@@ -286,7 +286,7 @@ bool CTextureBundleXPR::LoadFile(const CStdString& Filename, CAutoTexBuffer& Unp
     MEMORYSTATUSEX stat;
     stat.dwLength = sizeof(MEMORYSTATUSEX);
     GlobalMemoryStatusEx(&stat);
-    CLog::Log(LOGERROR, "Out of memory loading texture: %s (need %lu bytes, have %"PRIu64" bytes)", name.c_str(),
+    CLog::Log(LOGERROR, "Out of memory loading texture: %s (need %lu bytes, have %" PRIu64" bytes)", name.c_str(),
               file->second.UnpackedSize + file->second.PackedSize, stat.ullAvailPhys);
 #elif defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
     CLog::Log(LOGERROR, "Out of memory loading texture: %s (need %d bytes)", name.c_str(),

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -131,7 +131,7 @@ bool CXBTFReader::Open(const CStdString& fileName)
   int64_t pos = ftell(m_file);
   if (pos != (int64_t)m_xbtf.GetHeaderSize())
   {
-    printf("Expected header size (%"PRId64") != actual size (%"PRId64")\n", m_xbtf.GetHeaderSize(), pos);
+    printf("Expected header size (%" PRId64") != actual size (%" PRId64")\n", m_xbtf.GetHeaderSize(), pos);
     return false;
   }
 

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -344,7 +344,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
     }
     if (old != s)
     {
-      CLog::Log(LOGINFO, "CPythonInvoker(%d, %s): waiting on thread %"PRIu64, GetId(), m_sourceFile.c_str(), (uint64_t)s->thread_id);
+      CLog::Log(LOGINFO, "CPythonInvoker(%d, %s): waiting on thread %" PRIu64, GetId(), m_sourceFile.c_str(), (uint64_t)s->thread_id);
       old = s;
     }
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4603,7 +4603,7 @@ bool CMusicDatabase::GetScraperForPath(const CStdString& strPath, ADDON::Scraper
       if(ADDON::CAddonMgr::Get().GetDefault(type, addon))
       {
         info = boost::dynamic_pointer_cast<ADDON::CScraper>(addon);
-        return (info);
+        return info != NULL;
       }
       else
         return false;

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -940,7 +940,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       {
         int64_t position = (int64_t) (atof(found + strlen("position=")) * 1000.0);
         g_application.m_pPlayer->SeekTime(position);
-        CLog::Log(LOGDEBUG, "AIRPLAY: got POST request %s with pos %"PRId64, uri.c_str(), position);
+        CLog::Log(LOGDEBUG, "AIRPLAY: got POST request %s with pos %" PRId64, uri.c_str(), position);
       }
     }
   }

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -194,7 +194,7 @@ string Xcddb::Recv(bool wait4point)
 
   //##########################################################
   // Write captured data information to the xbmc log file
-  CLog::Log(LOGDEBUG,"Xcddb::Recv Captured %d bytes // Buffer= %"PRIdS" bytes. Captured data follows on next line\n%s", counter, str_buffer.size(),(char *)str_buffer.c_str());
+  CLog::Log(LOGDEBUG,"Xcddb::Recv Captured %d bytes // Buffer= %" PRIdS" bytes. Captured data follows on next line\n%s", counter, str_buffer.size(),(char *)str_buffer.c_str());
 
 
   return str_buffer;

--- a/xbmc/network/osx/ZeroconfBrowserOSX.cpp
+++ b/xbmc/network/osx/ZeroconfBrowserOSX.cpp
@@ -180,7 +180,7 @@ void CZeroconfBrowserOSX::BrowserCallback(CFNetServiceBrowserRef browser, CFOpti
   } else
   {
     CLog::Log(LOGERROR, "CZeroconfBrowserOSX::BrowserCallback returned"
-      "(domain = %d, error = %"PRId64")", (int)error->domain, (int64_t)error->error);
+      "(domain = %d, error = %" PRId64")", (int)error->domain, (int64_t)error->error);
   }
 }
 
@@ -261,7 +261,7 @@ bool CZeroconfBrowserOSX::doAddServiceType(const CStdString& fcr_service_type)
     CFRelease(p_browser);
     p_browser = NULL;
     CLog::Log(LOGERROR, "CFNetServiceBrowserSearchForServices returned"
-      "(domain = %d, error = %"PRId64")", (int)error.domain, (int64_t)error.error);
+      "(domain = %d, error = %" PRId64")", (int)error.domain, (int64_t)error.error);
   }
   else
   {

--- a/xbmc/network/osx/ZeroconfOSX.cpp
+++ b/xbmc/network/osx/ZeroconfOSX.cpp
@@ -115,7 +115,7 @@ bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
     CFRelease(netService);
     netService = NULL;
     CLog::Log(LOGERROR, "CZeroconfOSX::doPublishService CFNetServiceRegister returned "
-      "(domain = %d, error = %"PRId64")", (int)error.domain, (int64_t)error.error);
+      "(domain = %d, error = %" PRId64")", (int)error.domain, (int64_t)error.error);
   } else
   {
     CSingleLock lock(m_data_guard);
@@ -184,7 +184,7 @@ void CZeroconfOSX::registerCallback(CFNetServiceRef theService, CFStreamError* e
         break;
       default:
         CLog::Log(LOGERROR, "CZeroconfOSX::registerCallback returned "
-          "(domain = %d, error = %"PRId64")", (int)error->domain, (int64_t)error->error);
+          "(domain = %d, error = %" PRId64")", (int)error->domain, (int64_t)error->error);
         break;
     }
     p_this->cancelRegistration(theService);

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -140,12 +140,12 @@ THREADFUNC CThread::staticThread(void* data)
 
   if (autodelete)
   {
-    LOG(LOGDEBUG,"Thread %s %"PRIu64" terminating (autodelete)", name.c_str(), (uint64_t)id);
+    LOG(LOGDEBUG,"Thread %s %" PRIu64" terminating (autodelete)", name.c_str(), (uint64_t)id);
     delete pThread;
     pThread = NULL;
   }
   else
-    LOG(LOGDEBUG,"Thread %s %"PRIu64" terminating", name.c_str(), (uint64_t)id);
+    LOG(LOGDEBUG,"Thread %s %" PRIu64" terminating", name.c_str(), (uint64_t)id);
 
   return 0;
 }

--- a/xbmc/utils/PerformanceStats.cpp
+++ b/xbmc/utils/PerformanceStats.cpp
@@ -69,7 +69,7 @@ void CPerformanceStats::DumpStats()
     double dAvg = iter->second->m_time / (double)iter->second->m_samples;
     double dAvgUser = iter->second->m_user / (double)iter->second->m_samples;
     double dAvgSys  = iter->second->m_sys / (double)iter->second->m_samples;
-    CLog::Log(LOGINFO, "%s - counter <%s>. avg duration: <%f sec>, avg user: <%f>, avg sys: <%f> (%"PRIu64" samples)",
+    CLog::Log(LOGINFO, "%s - counter <%s>. avg duration: <%f sec>, avg user: <%f>, avg sys: <%f> (%" PRIu64" samples)",
       __FUNCTION__, iter->first.c_str(), dAvg, dAvgUser, dAvgSys, iter->second->m_samples);
     ++iter;
   }

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -98,7 +98,7 @@ string ByDateAdded(SortAttribute attributes, const SortItem &values)
 
 string BySize(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%"PRId64, values.at(FieldSize).asInteger());
+  return StringUtils::Format("%" PRId64, values.at(FieldSize).asInteger());
 }
 
 string ByDriveType(SortAttribute attributes, const SortItem &values)
@@ -265,7 +265,7 @@ string ByEpisodeNumber(SortAttribute attributes, const SortItem &values)
   if (title.empty())
     title = ByLabel(attributes, values);
 
-  return StringUtils::Format("%"PRIu64" %s", num, title.c_str());
+  return StringUtils::Format("%" PRIu64" %s", num, title.c_str());
 }
 
 string BySeason(SortAttribute attributes, const SortItem &values)
@@ -340,7 +340,7 @@ string BySubtitleLanguage(SortAttribute attributes, const SortItem &values)
 
 string ByBitrate(SortAttribute attributes, const SortItem &values)
 {
-  return StringUtils::Format("%"PRId64, values.at(FieldBitrate).asInteger());
+  return StringUtils::Format("%" PRId64, values.at(FieldBitrate).asInteger());
 }
 
 string ByListeners(SortAttribute attributes, const SortItem &values)

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -64,7 +64,7 @@ void CLog::Close()
 
 void CLog::Log(int loglevel, const char *format, ... )
 {
-  static const char* prefixFormat = "%02.2d:%02.2d:%02.2d T:%"PRIu64" %7s: ";
+  static const char* prefixFormat = "%02.2d:%02.2d:%02.2d T:%" PRIu64" %7s: ";
   CSingleLock waitLock(critSec);
   int extras = (loglevel >> LOGMASKBIT) << LOGMASKBIT;
   loglevel = loglevel & LOGMASK;

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -352,7 +352,7 @@ void CWinSystemX11::UpdateResolutions()
   if (out != NULL)
   {
     vector<XMode>::iterator modeiter;
-    CLog::Log(LOGINFO, "Output '%s' has %"PRIdS" modes", out->name.c_str(), out->modes.size());
+    CLog::Log(LOGINFO, "Output '%s' has %" PRIdS" modes", out->name.c_str(), out->modes.size());
 
     for (modeiter = out->modes.begin() ; modeiter!=out->modes.end() ; modeiter++)
     {

--- a/xbmc/windowing/X11/WinSystemX11GLES.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLES.cpp
@@ -279,14 +279,14 @@ void CWinSystemX11GLES::UpdateResolutions()
   vector<XOutput>::iterator outiter;
   vector<XOutput> outs;
   outs = g_xrandr.GetModes();
-  CLog::Log(LOGINFO, "Number of connected outputs: %"PRIdS"", outs.size());
+  CLog::Log(LOGINFO, "Number of connected outputs: %" PRIdS"", outs.size());
   string modename = "";
 
   for (outiter = outs.begin() ; outiter != outs.end() ; outiter++)
   {
     XOutput out = *outiter;
     vector<XMode>::iterator modeiter;
-    CLog::Log(LOGINFO, "Output '%s' has %"PRIdS" modes", out.name.c_str(), out.modes.size());
+    CLog::Log(LOGINFO, "Output '%s' has %" PRIdS" modes", out.name.c_str(), out.modes.size());
 
     for (modeiter = out.modes.begin() ; modeiter!=out.modes.end() ; modeiter++)
     {

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -104,11 +104,11 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     CStdString profiling = CGUIControlProfiler::IsRunning() ? " (profiling)" : "";
     CStdString strCores = g_cpuInfo.GetCoresUsageString();
 #if !defined(TARGET_POSIX)
-    info = StringUtils::Format("LOG: %sxbmc.log\nMEM: %"PRIu64"/%"PRIu64" KB - FPS: %2.1f fps\nCPU: %s%s", g_advancedSettings.m_logFolder.c_str(),
+    info = StringUtils::Format("LOG: %sxbmc.log\nMEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\nCPU: %s%s", g_advancedSettings.m_logFolder.c_str(),
                                stat.ullAvailPhys/1024, stat.ullTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), profiling.c_str());
 #else
     double dCPU = m_resourceCounter.GetCPUUsage();
-    info = StringUtils::Format("LOG: %sxbmc.log\nMEM: %"PRIu64"/%"PRIu64" KB - FPS: %2.1f fps\nCPU: %s (CPU-XBMC %4.2f%%%s)", g_advancedSettings.m_logFolder.c_str(),
+    info = StringUtils::Format("LOG: %sxbmc.log\nMEM: %" PRIu64"/%" PRIu64" KB - FPS: %2.1f fps\nCPU: %s (CPU-XBMC %4.2f%%%s)", g_advancedSettings.m_logFolder.c_str(),
                                stat.ullAvailPhys/1024, stat.ullTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), dCPU, profiling.c_str());
 #endif
   }


### PR DESCRIPTION
This adds several minor changes to allow compilation of xbmc with -std=c++11 (tested with clang-3.4).

Almost all changes are just syntax changes, which shouldn't change anything in the result. Only exception is commit 4feadca which changed the type of two macros from unsigned to signed, because it would lead to impossible narrowing
