### PR TITLE
AE: add settings for ac3 transcode and ac3 upmix

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12592,7 +12592,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#34100"
-msgid "Speaker Configuration"
+msgid "Number of channels"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -14415,7 +14415,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36362"
-msgid "Select the maximum number of audio channels/speakers available for audio decoded."
+msgid "Select the number of channels supported by the audio connection, or the number of speakers if connected by analog connections. This setting does not apply to passthrough audio. Note - SPDIF supports 2.0 channels only but can still output multichannel audio using a format supported by passthrough."
 msgstr ""
 
 #: system/settings/settings.xml

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1046,7 +1046,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#252"
-msgid "Output stereo to all speakers"
+msgid "Stereo upmix"
 msgstr ""
 
 msgctxt "#253"
@@ -2797,7 +2797,12 @@ msgctxt "#666"
 msgid "Verbose logging..."
 msgstr ""
 
-#empty strings from id 667 to 699
+#: system/settings/settings.xml
+msgctxt "#667"
+msgid "Enable Dolby Digital transcoding"
+msgstr ""
+
+#empty strings from id 668 to 699
 
 msgctxt "#700"
 msgid "Cleaning up library"
@@ -14420,7 +14425,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36364"
-msgid "Select to enable upmixing of 2 channel stereo sources to the number of audio channels specified by the speaker configuration."
+msgid "Select to enable upmixing of 2 channel audio to the number of audio channels specified by the speaker configuration."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -14743,7 +14748,12 @@ msgctxt "#36428"
 msgid "Record"
 msgstr ""
 
-#empty strings from id 36429 to 36499
+#: system/settings/settings.xml
+msgctxt "#36429"
+msgid "Select this if the audio out connection only supports multichannel audio as Dolby Digital 5.1, this allows multichannel audio such as AAC5.1 or FLAC5.1 to be listened to in 5.1 surround sound. Note - transcoding can lead to a reduction in sound quality"
+msgstr ""
+
+#empty strings from id 36430 to 36499
 #end reservation
 
 #: system/settings/settings.xml

--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -11,6 +11,9 @@
         <setting id="audiooutput.channels" help="36367" />
       </group>
       <group id="3">
+        <setting id="audiooutput.ac3transcode">
+          <visible>false</visible>
+        </setting>
         <setting id="audiooutput.truehdpassthrough">
           <visible>false</visible>
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2261,13 +2261,7 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
-              <or>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.channels">audiooutput.stereoupmix</condition>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.passthrough">audiooutput.stereoupmix</condition>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.ac3passthrough">audiooutput.stereoupmix</condition>
-              </or>    
-            </dependency>
+            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.channels">audiooutput.stereoupmix</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2347,6 +2341,20 @@
               <and>
                 <condition setting="audiooutput.passthrough" operator="is">true</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="audiooutput.ac3transcode" type="boolean" label="667" help="36429">
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="audiooutput.passthrough" operator="is">true</condition>
+                <condition setting="audiooutput.ac3passthrough" operator="is">true</condition>
+                <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.ac3transcode</condition>
               </and>
             </dependency>
           </dependencies>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -50,6 +50,7 @@ struct AudioSettings
   std::string passthoughdevice;
   int channels;
   bool ac3passthrough;
+  bool ac3transcode;
   bool eac3passthrough;
   bool dtspassthrough;
   bool truehdpassthrough;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -1032,6 +1032,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("audiooutput.guisoundmode");
   settingSet.insert("audiooutput.stereoupmix");
   settingSet.insert("audiooutput.ac3passthrough");
+  settingSet.insert("audiooutput.ac3transcode");
   settingSet.insert("audiooutput.eac3passthrough");
   settingSet.insert("audiooutput.dtspassthrough");
   settingSet.insert("audiooutput.truehdpassthrough");


### PR DESCRIPTION
It turned out that we can't autodetect if AC3 transcoding is desired. We always engaged it in case of no LPCM and enabled AC3. This does harm on the PI.  There we want AC3 only for AC3 content and no transcoding at all.

Also fixes slight regression: missing stereo upmix via AC3 transcoding for HDMI devices.
