### PR TITLE
[linux] enable android hw codecs in linux on arm devices, e.g. amlogic

### DIFF
--- a/system/settings/android.xml
+++ b/system/settings/android.xml
@@ -10,15 +10,6 @@
   <section id="videos">
     <category id="videoplayer">
       <group id="2">
-        <setting id="videoplayer.useamcodec" type="boolean" label="13438" help="36422">
-          <requirement>HAVE_AMCODEC</requirement>
-          <level>2</level>
-          <default>true</default>
-          <updates>
-            <update type="change" />
-          </updates>
-          <control type="toggle" />
-        </setting>
         <setting id="videoplayer.usestagefright" type="boolean" label="13436" help="36260">
           <requirement>HAVE_LIBSTAGEFRIGHTDECODER</requirement>
           <level>2</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -415,6 +415,15 @@
             <formatlabel>14047</formatlabel>
           </control>
         </setting>
+        <setting id="videoplayer.useamcodec" type="boolean" label="13438" help="36422">
+          <requirement>HAVE_AMCODEC</requirement>
+          <level>2</level>
+          <default>true</default>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usevdpau" type="boolean" label="13425" help="36155">
           <requirement>HAVE_LIBVDPAU</requirement>
           <level>2</level>

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1415,7 +1415,9 @@ CAMLCodec::~CAMLCodec()
 
 bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
 {
+#ifdef TARGET_ANDROID
   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder, android version %d", CAndroidFeatures::GetVersion());
+#endif
 
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_1st_pts = 0;


### PR DESCRIPTION
This enables hardware acceleration for AMlogic chipsets on linux for XBMC built with --enable-codec=amcodec
