### PR TITLE
[WIP/RFC] add missing infolabels for better playlist data support in video GUI

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1277,6 +1277,21 @@ int CGUIInfoManager::TranslateSingleString(const CStdString &strCondition, bool 
         return AddMultiInfo(GUIInfo(value, 1, position));
       }
     }
+    else if (info[0].name == "videoplayer")
+    { // TODO: these two don't allow duration(foo) and also don't allow more than this number of levels...
+      if (info[1].name == "position")
+      {
+        int position = atoi(info[1].param().c_str());
+        int value = TranslateVideoPlayerString(info[2].name); // videoplayer.position(foo).bar
+        return AddMultiInfo(GUIInfo(value, 0, position));
+      }
+      else if (info[1].name == "offset")
+      {
+        int position = atoi(info[1].param().c_str());
+        int value = TranslateVideoPlayerString(info[2].name); // videoplayer.offset(foo).bar
+        return AddMultiInfo(GUIInfo(value, 1, position));
+      }
+    }
     else if (info[0].name == "container")
     {
       int id = atoi(info[0].param().c_str());
@@ -1326,6 +1341,16 @@ int CGUIInfoManager::TranslateMusicPlayerString(const CStdString &info) const
   {
     if (info == musicplayer[i].str)
       return musicplayer[i].val;
+  }
+  return 0;
+}
+
+int CGUIInfoManager::TranslateVideoPlayerString(const CStdString &info) const
+{
+  for (size_t i = 0; i < sizeof(videoplayer) / sizeof(infomap); i++)
+  {
+    if (info == videoplayer[i].str)
+      return videoplayer[i].val;
   }
   return 0;
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3950,6 +3950,39 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
           strPlayCount = StringUtils::Format("%i", m_currentFile->GetVideoInfoTag()->m_playCount);
         return strPlayCount;
       }
+    case VIDEOPLAYER_ENDTIME:
+      {
+        CDateTime time = CDateTime::GetCurrentDateTime();
+        time += CDateTimeSpan(0, 0, 0, GetPlayTimeRemaining());
+        return time.GetAsLocalizedTime("", false);
+      }
+    }
+
+    /* Next playing infos in case of valid playlist */
+    if (m_currentFile->HasProperty("playlistposition") && (int)m_currentFile->GetProperty("playlisttype").asInteger() == g_playlistPlayer.GetCurrentPlaylist())
+    {
+      int iNextItem = g_playlistPlayer.GetNextSong();
+      if (iNextItem)
+      {
+        CPlayList& playlist = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist());
+        CFileItemPtr nextItem = playlist[iNextItem];
+
+        switch (item)
+        {
+          case VIDEOPLAYER_NEXT_TITLE:
+            return nextItem->GetVideoInfoTag()->m_strOriginalTitle;
+          case VIDEOPLAYER_NEXT_GENRE:
+            return StringUtils::Join(nextItem->GetVideoInfoTag()->m_genre, g_advancedSettings.m_videoItemSeparator);
+          case VIDEOPLAYER_NEXT_PLOT:
+            return nextItem->GetVideoInfoTag()->m_strPlot;
+          case VIDEOPLAYER_NEXT_PLOT_OUTLINE:
+            return nextItem->GetVideoInfoTag()->m_strPlotOutline;
+          case VIDEOPLAYER_NEXT_DURATION:
+            if (nextItem->GetVideoInfoTag()->GetDuration() > 0)
+             return StringUtils::Format("%d", nextItem->GetVideoInfoTag()->GetDuration() / 60);
+            break;
+        }
+      }
     }
   }
   return "";

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -871,6 +871,7 @@ protected:
   CStdString GetMultiInfoLabel(const GUIInfo &info, int contextWindow = 0, CStdString *fallback = NULL);
   int TranslateListItem(const Property &info);
   int TranslateMusicPlayerString(const CStdString &info) const;
+  int TranslateVideoPlayerString(const CStdString &info) const;
   TIME_FORMAT TranslateTimeFormat(const CStdString &format);
   bool GetItemBool(const CGUIListItem *item, int condition) const;
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -666,6 +666,7 @@ namespace INFO
 // forward
 class CInfoLabel;
 class CGUIWindow;
+class CPlayList;
 namespace EPG { class CEpgInfoTag; }
 
 // Info Flags


### PR DESCRIPTION
This PR is aimed at adding missing infolabel support for videoplaylist handling in GUI. Currently all "videoplayer.next_" only work for PVR and videoplayer.offset(1)._ is not possible at all (which is available for musicplayer).

This is WIP and RFC. Code is untested. Would like to get feedback if this is wanted in general or how to solve it more properly (best would be to unify how skins interact with players, regardless of video- or musicplayer).

ping @jmarshallnz, @ronie, @opdenkamp (for the labels initially added for PVR)
