### PR TITLE
FIX: [droid] proper unicode with physical keyboard

### DIFF
--- a/xbmc/android/activity/AndroidKey.h
+++ b/xbmc/android/activity/AndroidKey.h
@@ -32,6 +32,6 @@ public:
  ~CAndroidKey() {};
 
   bool onKeyboardEvent(AInputEvent *event);
-  void XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, bool up);
+  void XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, uint16_t unicode, bool up);
   void XBMC_JoyButton(uint8_t id, uint8_t button, bool up);
 };

--- a/xbmc/android/jni/KeyCharacterMap.cpp
+++ b/xbmc/android/jni/KeyCharacterMap.cpp
@@ -1,0 +1,38 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "KeyCharacterMap.h"
+#include "jutils/jutils-details.hpp"
+
+using namespace jni;
+
+CJNIKeyCharacterMap CJNIKeyCharacterMap::load(int deviceId)
+{
+  return (CJNIKeyCharacterMap)call_static_method<jhobject>("android/view/KeyCharacterMap",
+    "load", "(I)Landroid/view/KeyCharacterMap;",
+    deviceId);
+}
+
+int CJNIKeyCharacterMap::get(int keyCode, int metaState)
+{
+  return call_method<int>(m_object,
+    "get", "(II)I",
+    keyCode, metaState);
+}

--- a/xbmc/android/jni/KeyCharacterMap.h
+++ b/xbmc/android/jni/KeyCharacterMap.h
@@ -1,0 +1,33 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "JNIBase.h"
+
+class CJNIURI;
+class CJNIKeyCharacterMap : public CJNIBase
+{
+public:
+  CJNIKeyCharacterMap(const jni::jhobject &object) : CJNIBase(object) {}
+  ~CJNIKeyCharacterMap() {}
+
+  static CJNIKeyCharacterMap load(int deviceId);
+  int get(int keyCode, int metaState);
+};

--- a/xbmc/android/jni/Makefile.in
+++ b/xbmc/android/jni/Makefile.in
@@ -49,6 +49,7 @@ SRCS      += SurfaceTexture.cpp
 SRCS      += View.cpp
 SRCS      += Window.cpp
 SRCS      += Build.cpp
+SRCS      += KeyCharacterMap.cpp
 
 LIB        = jni.a
 


### PR DESCRIPTION
This fixes the fact that meta keys are ignored when entering text with a physical keyboard.

/cc @davilla 
