### PR TITLE
dvdplayer: make sure we restore output timestamps for text based subs

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1199,7 +1199,7 @@ void CDVDPlayer::Process()
     UpdateApplication(1000);
 
     // make sure we run subtitle process here
-    m_dvdPlayerSubtitle.Process(m_clock.GetClock() + m_State.time_offset - m_dvdPlayerVideo.GetSubtitleDelay());
+    m_dvdPlayerSubtitle.Process(m_clock.GetClock() + m_State.time_offset - m_dvdPlayerVideo.GetSubtitleDelay(), m_State.time_offset);
 
     if (CheckDelayedChannelEntry())
       continue;

--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
@@ -198,7 +198,7 @@ void CDVDPlayerSubtitle::CloseStream(bool flush)
     m_pOverlayContainer->Clear();
 }
 
-void CDVDPlayerSubtitle::Process(double pts)
+void CDVDPlayerSubtitle::Process(double pts, double offset)
 {
   CSingleLock lock(m_section);
 
@@ -220,6 +220,10 @@ void CDVDPlayerSubtitle::Process(double pts)
     // add all overlays which fit the pts
     while(pOverlay)
     {
+      pOverlay->iPTSStartTime -= offset;
+      if(pOverlay->iPTSStopTime != 0.0)
+        pOverlay->iPTSStopTime -= offset;
+
       m_pOverlayContainer->Add(pOverlay);
       pOverlay->Release();
       pOverlay = m_pSubtitleFileParser->Parse(pts);

--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.h
@@ -38,7 +38,7 @@ public:
   CDVDPlayerSubtitle(CDVDOverlayContainer* pOverlayContainer);
   ~CDVDPlayerSubtitle();
 
-  void Process(double pts);
+  void Process(double pts, double offset);
   void Flush();
   void FindSubtitles(const char* strFilename);
   int GetSubtitleCount();

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1384,7 +1384,7 @@ void COMXPlayer::Process()
     UpdateApplication(1000);
 
     // make sure we run subtitle process here
-    m_dvdPlayerSubtitle.Process(m_clock.GetClock() - m_omxPlayerVideo.GetSubtitleDelay());
+    m_dvdPlayerSubtitle.Process(m_clock.GetClock() + m_State.time_offset - m_omxPlayerVideo.GetSubtitleDelay(), m_State.time_offset);
 
     // OMX emergency exit
     if(HasAudio() && m_omxPlayerAudio.BadState())


### PR DESCRIPTION
This fixes external text based subtitles going out of sync with video files where we detect discontinuities.
