### PR TITLE
UPnP: quirk to match Samsung's video/x-mkv mime type

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -76,6 +76,22 @@ EClientQuirks GetClientQuirks(const PLT_HttpRequestContext* context)
 }
 
 /*----------------------------------------------------------------------
+|  GetMediaControllerQuirks
++---------------------------------------------------------------------*/
+EMediaControllerQuirks GetMediaControllerQuirks(const PLT_DeviceData *device)
+{
+    if (device == NULL)
+        return EMEDIACONTROLLERQUIRKS_NONE;
+
+    unsigned int quirks = 0;
+
+    if (device->m_Manufacturer.Find("Samsung Electronics") >= 0)
+        quirks |= EMEDIACONTROLLERQUIRKS_X_MKV;
+
+    return (EMediaControllerQuirks)quirks;
+}
+
+/*----------------------------------------------------------------------
 |   GetMimeType
 +---------------------------------------------------------------------*/
 NPT_String

--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -28,6 +28,7 @@
 class CUPnPServer;
 class CFileItem;
 class CThumbLoader;
+class PLT_DeviceData;
 class PLT_HttpRequestContext;
 class PLT_MediaItemResource;
 class PLT_MediaObject;
@@ -63,6 +64,16 @@ namespace UPNP
   };
 
   EClientQuirks GetClientQuirks(const PLT_HttpRequestContext* context);
+
+  enum EMediaControllerQuirks
+  {
+    EMEDIACONTROLLERQUIRKS_NONE   = 0x00
+
+    /* Media Controller expects MIME type video/x-mkv instead of video/x-matroska (Samsung) */
+  , EMEDIACONTROLLERQUIRKS_X_MKV  = 0x01
+  };
+
+  EMediaControllerQuirks GetMediaControllerQuirks(const PLT_DeviceData *device);
 
   const char* GetMimeTypeFromExtension(const char* extension, const PLT_HttpRequestContext* context = NULL);
   NPT_String  GetMimeType(const CFileItem& item, const PLT_HttpRequestContext* context = NULL);

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -251,6 +251,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
   NPT_CHECK_LABEL_SEVERE(m_control->FindBestResource(m_delegate->m_device, *obj, res_index), failed);
 
 
+  timeout.Set(timeout.GetInitialTimeoutValue());
   /* dlna specifies that a return code of 705 should be returned
    * if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT */
   NPT_CHECK_LABEL_SEVERE(m_control->Stop(m_delegate->m_device
@@ -260,6 +261,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
   NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
 
 
+  timeout.Set(timeout.GetInitialTimeoutValue());
   NPT_CHECK_LABEL_SEVERE(m_control->SetAVTransportURI(m_delegate->m_device
                                                     , m_delegate->m_instance
                                                     , obj->m_Resources[res_index].m_Uri
@@ -268,6 +270,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
   NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
   NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
 
+  timeout.Set(timeout.GetInitialTimeoutValue());
   NPT_CHECK_LABEL_SEVERE(m_control->Play(m_delegate->m_device
                                        , m_delegate->m_instance
                                        , "1"
@@ -277,6 +280,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
 
 
   /* wait for PLAYING state */
+  timeout.Set(timeout.GetInitialTimeoutValue());
   do {
     NPT_CHECK_LABEL_SEVERE(m_control->GetTransportInfo(m_delegate->m_device
                                                      , m_delegate->m_instance

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -157,6 +157,7 @@ CUPnPRenderer::SetupServices()
         ",http-get:*:video/xvid:*"
         ",http-get:*:video/x-divx:*"
         ",http-get:*:video/x-matroska:*"
+        ",http-get:*:video/x-mkv:*"
         ",http-get:*:video/x-ms-wmv:*"
         ",http-get:*:video/x-ms-avi:*"
         ",http-get:*:video/x-flv:*"


### PR DESCRIPTION
This is an alternative approach to #3660. Samsung says it supports "video/x-mkv" instead of the expected "video/x-matroska" and therefore "Play using..." to a/my Samsung TV fails.

I decided to add a new GetMediaControllerQuirks() method similar to the existing GetClientQuirks() method to handle this so that we don't have to pollute the code (and especially not the code from the Platinum library we use) with a quick and dirty hack.

The main problem is that I don't really know if this is an issue with all UPnP-capable Samsung devices or if it would hit something that actually provides the proper "video/x-matroska" mime type.

In the last commit I added some calls to reset the timer that is used to wait for a response from the UPnP renderer. Right now we use the same timeout of a total of 10 seconds for all requests/responses which seems to be a bit close in my case. Sometimes it works, sometimes the last callback is received after 11 or 12 seconds. IMO resetting the timer should be done anyway to give every response the same amount if timeout.
