### PR TITLE
fixed: We should't try to xml load favourites:// paths

### DIFF
--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -42,7 +42,7 @@ bool CFavouritesDirectory::GetDirectory(const CStdString& strPath, CFileItemList
   
   if (url.GetProtocol() == "favourites")
   {
-    Load(items); //load the default favourite files
+    return Load(items); //load the default favourite files
   }
   return LoadFavourites(strPath, items); //directly load the given file
 }

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -39,18 +39,18 @@ bool CFavouritesDirectory::GetDirectory(const CStdString& strPath, CFileItemList
 {
   items.Clear();
   CURL url(strPath);
-  
+
   if (url.GetProtocol() == "favourites")
   {
     return Load(items); //load the default favourite files
   }
   return LoadFavourites(strPath, items); //directly load the given file
 }
-  
+
 bool CFavouritesDirectory::Exists(const char* strPath)
 {
   CURL url(strPath);
-  
+
   if (url.GetProtocol() == "favourites")
   {
     return XFILE::CFile::Exists("special://xbmc/system/favourites.xml") 


### PR DESCRIPTION
This fixes errors in our log like:

18:00:27 T:140737353811840   ERROR: Unable to load favourites:// (row 0 column 0)
18:00:27 T:140737353811840   ERROR: GetDirectory - Error getting favourites://

when accessing the favorites menu. Pretty sure this fix is correct but not 100% thus the PR..
