### PR TITLE
Add SmallStepForward to match SmallStepBack, bind to forward slash and a...

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -223,6 +223,7 @@
       <comma>StepBack</comma>
       <backspace>Fullscreen</backspace>
       <quote>SmallStepBack</quote>
+      <forwardslash>SmallStepForward</forwardslash>
       <opensquarebracket>BigStepForward</opensquarebracket>
       <closesquarebracket>BigStepBack</closesquarebracket>
       <return>OSD</return>

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -174,6 +174,7 @@
 #define ACTION_OSD_SHOW_VALUE_PLUS  74  // increase value of current option in OSD. Can b used in videoFullScreen.xml window id=2005
 #define ACTION_OSD_SHOW_VALUE_MIN   75  // decrease value of current option in OSD. Can b used in videoFullScreen.xml window id=2005
 #define ACTION_SMALL_STEP_BACK      76  // jumps a few seconds back during playback of movie. Can b used in videoFullScreen.xml window id=2005
+#define ACTION_SMALL_STEP_FORWARD   243  // jumps a few seconds forward during playback of movie. Can b used in videoFullScreen.xml window id=2005
 
 #define ACTION_PLAYER_FORWARD        77  // FF in current file played. global action, can be used anywhere
 #define ACTION_PLAYER_REWIND         78  // RW in current file played. global action, can be used anywhere

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -143,6 +143,7 @@ static const ActionMapping actions[] =
         {"osdvalueplus"      , ACTION_OSD_SHOW_VALUE_PLUS},
         {"osdvalueminus"     , ACTION_OSD_SHOW_VALUE_MIN},
         {"smallstepback"     , ACTION_SMALL_STEP_BACK},
+        {"smallstepforward"  , ACTION_SMALL_STEP_FORWARD},
         {"fastforward"       , ACTION_PLAYER_FORWARD},
         {"rewind"            , ACTION_PLAYER_REWIND},
         {"play"              , ACTION_PLAYER_PLAY},

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -138,6 +138,7 @@ void CAdvancedSettings::Initialize()
   m_videoSubsDelayRange = 10;
   m_videoAudioDelayRange = 10;
   m_videoSmallStepBackSeconds = 7;
+  m_videoSmallStepForwardSeconds = 7;
   m_videoSmallStepBackTries = 3;
   m_videoSmallStepBackDelay = 300;
   m_videoUseTimeSeeking = true;
@@ -560,6 +561,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetFloat(pElement, "ignorepercentatend", m_videoIgnorePercentAtEnd, 0, 100.0f);
 
     XMLUtils::GetInt(pElement, "smallstepbackseconds", m_videoSmallStepBackSeconds, 1, INT_MAX);
+    XMLUtils::GetInt(pElement, "smallstepforwardseconds", m_videoSmallStepForwardSeconds, 1, INT_MAX);
     XMLUtils::GetInt(pElement, "smallstepbacktries", m_videoSmallStepBackTries, 1, 10);
     XMLUtils::GetInt(pElement, "smallstepbackdelay", m_videoSmallStepBackDelay, 100, 5000); //MS
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -147,6 +147,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoSubsDelayRange;
     float m_videoAudioDelayRange;
     int m_videoSmallStepBackSeconds;
+    int m_videoSmallStepForwardSeconds;
     int m_videoSmallStepBackTries;
     int m_videoSmallStepBackDelay;
     bool m_videoUseTimeSeeking;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -309,6 +309,18 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     }
     return true;
     break;
+  case ACTION_SMALL_STEP_FORWARD:
+    if (m_timeCodePosition > 0)
+      SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_FORWARD);
+    else
+    {
+      int orgpos = (int)g_application.GetTime();
+      int jumpsize = g_advancedSettings.m_videoSmallStepForwardSeconds; // secs
+      int setpos = orgpos + jumpsize;
+      g_application.SeekTime((double)setpos);
+    }
+    return true;
+    break;  
   case ACTION_SMALL_STEP_BACK:
     if (m_timeCodePosition > 0)
       SeekToTimeCodeStamp(SEEK_RELATIVE, SEEK_BACKWARD);


### PR DESCRIPTION
...dd appropriate advanced setting.

It's handy to be able to skip a small amount forward too - e.g. if you have gone back a bit too far with step back default 30 secs).

I am not sure if it is ok to change all the key numbers in hey.h so have used a higher available value for now.

There are several requests in the forums but latest is here:
http://forum.xbmc.org/showthread.php?tid=85373
