### PR TITLE
FIX: [depends]: boost: actually enable spinlock for shared_ptr multithread on arm

### DIFF
--- a/tools/depends/target/boost/Makefile
+++ b/tools/depends/target/boost/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include add-arm-mem-barrier.patch fix-deprecated-swp.patch Makefile
+DEPS= ../../Makefile.include add-arm-mem-barrier.patch fix-deprecated-swp.patch fix_shared_ptr_multithread.patch Makefile
 
 #Headers Only!
 LIBNAME=boost
@@ -21,6 +21,9 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	echo '	;' >> $(PLATFORM)/tools/build/v2/user-config.jam
 	cd $(PLATFORM); patch -p1 < ../add-arm-mem-barrier.patch
 	cd $(PLATFORM); patch -p1 < ../fix-deprecated-swp.patch
+ifeq (arm, $(findstring arm, $(CPU)))
+	cd $(PLATFORM); patch -p0 < ../fix_shared_ptr_multithread.patch
+endif
 	cd $(PLATFORM); ./bootstrap.sh --prefix=$(PREFIX)
 
 .installed-$(PLATFORM): $(PLATFORM)

--- a/tools/depends/target/boost/fix_shared_ptr_multithread.patch
+++ b/tools/depends/target/boost/fix_shared_ptr_multithread.patch
@@ -1,0 +1,8 @@
+--- boost/config/user.hpp.orig	2014-01-20 11:45:10.048976867 +0100
++++ boost/config/user.hpp	2014-01-20 11:45:34.244568535 +0100
+@@ -121,4 +121,4 @@
+ // #define BOOST_WHATEVER_NO_LIB
+  
+ 
+-
++#define BOOST_SP_USE_SPINLOCK


### PR DESCRIPTION
AFAICT, the fallback was no protection at all

/cc @davilla 
