### PR TITLE
videolibrary: add choice to resume video when using "Play using..." (fixes #14358)

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1371,7 +1371,18 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         CPlayerCoreFactory::Get().GetPlayers(*item, vecCores);
       g_application.m_eForcedNextPlayer = CPlayerCoreFactory::Get().SelectPlayerDialog(vecCores);
       if (g_application.m_eForcedNextPlayer != EPC_NONE)
-        OnClick(itemNumber);
+      {
+        // any other select actions but play or resume, resume, play or playpart
+        // don't make any sense here since the user already decided that he'd
+        // like to play the item (just with a specific player)
+        VideoSelectAction selectAction = (VideoSelectAction)CSettings::Get().GetInt("myvideos.selectaction");
+        if (selectAction != SELECT_ACTION_PLAY_OR_RESUME &&
+            selectAction != SELECT_ACTION_RESUME &&
+            selectAction != SELECT_ACTION_PLAY &&
+            selectAction != SELECT_ACTION_PLAYPART)
+          selectAction = SELECT_ACTION_PLAY_OR_RESUME;
+        return OnFileAction(itemNumber, selectAction);
+      }
       return true;
     }
 


### PR DESCRIPTION
This change adds the possibility for the user to choose whether to resume a video or start from the beginning when manually choosing the player through "Play using...". It makes use of the "myvideos.selectaction" setting and either automatically plays the movie from the beginning, resumes it or asks the user whether to resume or to start from the beginning (same as when playing the video with the default player). Because the other possible values of "myvideos.selectaction" don't make any sense (the user has already decided that he wants to play the video) they are replaced with the SELECT_ACTION_PLAY_OR_RESUME option.

This has been mentioned/requested in http://trac.xbmc.org/ticket/14358.
