### PR TITLE
[dvdplayer] - when starting playback update the playerstate with a possi...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1114,7 +1114,10 @@ void CDVDPlayer::Process()
       if (m_pDemuxer->SeekTime(starttime, false, &startpts))
         CLog::Log(LOGDEBUG, "%s - starting demuxer from: %d", __FUNCTION__, starttime);
       else
+      {
         CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %d", __FUNCTION__, starttime);
+        starttime = 0;
+      }
     }
 
     if(m_pSubtitleDemuxer)
@@ -1132,7 +1135,7 @@ void CDVDPlayer::Process()
 
   // make sure application know our info
   UpdateApplication(0);
-  UpdatePlayState(0);
+  UpdatePlayState(0, starttime);
 
   if(m_PlayerOptions.identify == false)
     m_callback.OnPlayBackStarted();
@@ -4059,7 +4062,7 @@ int CDVDPlayer::AddSubtitleFile(const std::string& filename, const std::string& 
   return m_SelectionStreams.IndexOf(STREAM_SUBTITLE, s.source, s.id);
 }
 
-void CDVDPlayer::UpdatePlayState(double timeout)
+void CDVDPlayer::UpdatePlayState(double timeout, double startTime/* = 0.0*/)
 {
   if(m_StateInput.timestamp != 0
   && m_StateInput.timestamp + DVD_MSEC_TO_TIME(timeout) > CDVDClock::GetAbsoluteClock())
@@ -4184,6 +4187,9 @@ void CDVDPlayer::UpdatePlayState(double timeout)
     state.cache_bytes = 0;
 
   state.timestamp = CDVDClock::GetAbsoluteClock();
+
+  if (startTime > 0.0 && state.time == 0.0)
+    state.time = startTime;
 
   CSingleLock lock(m_StateSection);
   m_StateInput = state;

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -342,7 +342,7 @@ protected:
   void OpenDefaultStreams(bool reset = true);
 
   void UpdateApplication(double timeout);
-  void UpdatePlayState(double timeout);
+  void UpdatePlayState(double timeout, double startTime = 0.0);
   double m_UpdateApplication;
 
   bool m_bAbortRequest;


### PR DESCRIPTION
...ble starttime (e.x. when resuming from a bookmark).

This is one approach to fix a problem where a python addon implements the "OnPlaybackStarted" callback and queries "xbmc.Player.GetTime()" at the very first.

In the case where playback was started from a resume point (this is what the addon wants to figure out) the GetTime() might return 0 (depends on the fact that the video has no valid dts yet).

@elupus for comment - not sure if this is a sane approach for fixing the problem.

See

https://github.com/bossanova808/script.xbmc.unpausejumpback/commit/6edca9671e1249ae0a826f7063278ee99bf252dc#diff-c338917e666d40f7b2684381cdb336f0R142

For reference (i don't want that stupid sleep in there!).
