### PR TITLE
Allow remote access to special://skin and special://profile/addon_data

### DIFF
--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -134,6 +134,8 @@ bool CFileUtils::RemoteAccessAllowed(const CStdString &strPath)
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "special://skin"))
     return true;
+  else if (StringUtils::StartsWithNoCase(realPath, "special://profile/addon_data"))
+    return true;
   else if (StringUtils::StartsWithNoCase(realPath, "addons://sources"))
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "upnp://"))

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -132,6 +132,8 @@ bool CFileUtils::RemoteAccessAllowed(const CStdString &strPath)
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "special://videoplaylists"))
     return true;
+  else if (StringUtils::StartsWithNoCase(realPath, "special://skin"))
+    return true;
   else if (StringUtils::StartsWithNoCase(realPath, "addons://sources"))
     return true;
   else if (StringUtils::StartsWithNoCase(realPath, "upnp://"))


### PR DESCRIPTION
I've gotten some reports from addon developers using JSON-RPCs Files.GetDirectory that their addons don't work anymore because of the restrictions we put in place for remote access to the filesystem through XBMC. Two paths that don't work anymore and that I think are reasonable to allow are
- special://skin
- special://profile/addon_data

In both cases the addon tries to access some kind of smartplaylist provided by the skin or generated by the addon.
