### PR TITLE
Fix redirected stream content-length. Fix #14647

### DIFF
--- a/tools/depends/target/curl/0001-HTTP-reset-expected-DL-UL-sizes-on-redirects.patch
+++ b/tools/depends/target/curl/0001-HTTP-reset-expected-DL-UL-sizes-on-redirects.patch
@@ -1,0 +1,83 @@
+From c44d45db86b880df5facd6b560491e03530f876e Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 23 Mar 2012 23:42:37 +0100
+Subject: [PATCH] HTTP: reset expected DL/UL sizes on redirects
+
+With FOLLOWLOCATION enabled. When a 3xx page is downloaded and the
+download size was known (like with a Content-Length header), but the
+subsequent URL (transfered after the 3xx page) was chunked encoded, then
+the previous "known download size" would linger and cause the progress
+meter to get incorrect information, ie the former value would remain
+being sent in. This could easily result in downloads that were WAY
+larger than "expected" and would cause >100% outputs with the curl
+command line tool.
+
+Test case 599 was created and it was used to repeat the bug and then
+verify the fix.
+
+Bug: http://curl.haxx.se/bug/view.cgi?id=3510057
+Reported by: Michael Wallner
+---
+ lib/progress.c             |  9 +++--
+ lib/progress.h             |  4 +--
+ lib/transfer.c             |  2 +-
+ tests/data/Makefile.am     |  2 +-
+ tests/data/test599         | 83 +++++++++++++++++++++++++++++++++++++++++++
+ tests/libtest/Makefile.inc |  4 ++-
+ tests/libtest/lib599.c     | 88 ++++++++++++++++++++++++++++++++++++++++++++++
+ 7 files changed, 184 insertions(+), 8 deletions(-)
+ create mode 100644 tests/data/test599
+ create mode 100644 tests/libtest/lib599.c
+
+diff --git a/lib/progress.c b/lib/progress.c
+index 1eeb780..4c9a63a 100644
+--- a/lib/progress.c
++++ b/lib/progress.c
+@@ -146,13 +146,16 @@ void Curl_pgrsDone(struct connectdata *conn)
+   data->progress.speeder_c = 0; /* reset the progress meter display */
+ }
+ 
+-/* reset all times except redirect */
+-void Curl_pgrsResetTimes(struct SessionHandle *data)
++/* reset all times except redirect, and reset the known transfer sizes */
++void Curl_pgrsResetTimesSizes(struct SessionHandle *data)
+ {
+   data->progress.t_nslookup = 0.0;
+   data->progress.t_connect = 0.0;
+   data->progress.t_pretransfer = 0.0;
+   data->progress.t_starttransfer = 0.0;
++
++  Curl_pgrsSetDownloadSize(data, 0);
++  Curl_pgrsSetUploadSize(data, 0);
+ }
+ 
+ void Curl_pgrsTime(struct SessionHandle *data, timerid timer)
+diff --git a/lib/progress.h b/lib/progress.h
+index f5cc540..a41d5f9 100644
+--- a/lib/progress.h
++++ b/lib/progress.h
+@@ -46,7 +46,7 @@ void Curl_pgrsSetUploadSize(struct SessionHandle *data, curl_off_t size);
+ void Curl_pgrsSetDownloadCounter(struct SessionHandle *data, curl_off_t size);
+ void Curl_pgrsSetUploadCounter(struct SessionHandle *data, curl_off_t size);
+ int Curl_pgrsUpdate(struct connectdata *);
+-void Curl_pgrsResetTimes(struct SessionHandle *data);
++void Curl_pgrsResetTimesSizes(struct SessionHandle *data);
+ void Curl_pgrsTime(struct SessionHandle *data, timerid timer);
+ 
+ 
+diff --git a/lib/transfer.c b/lib/transfer.c
+index d6061be..d872719 100644
+--- a/lib/transfer.c
++++ b/lib/transfer.c
+@@ -1924,7 +1924,7 @@ CURLcode Curl_follow(struct SessionHandle *data,
+     break;
+   }
+   Curl_pgrsTime(data, TIMER_REDIRECT);
+-  Curl_pgrsResetTimes(data);
++  Curl_pgrsResetTimesSizes(data);
+ 
+   return CURLE_OK;
+ #endif /* CURL_DISABLE_HTTP */
+-- 
+1.8.4.3
+

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 0001-HTTP-reset-expected-DL-UL-sizes-on-redirects.patch
 
 # lib name, version
 LIBNAME=curl
@@ -22,6 +22,7 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 < ../0001-HTTP-reset-expected-DL-UL-sizes-on-redirects.patch
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
It is an old bug of curl which already fixed in curl 2 years ago, but we are using the 3 years old version of curl.

this is the backport to fix the specific problem.
