### PR TITLE
Remove unused xbox string

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1990,11 +1990,7 @@ msgctxt "#470"
 msgid "Credits"
 msgstr ""
 
-msgctxt "#471"
-msgid "Modchip"
-msgstr ""
-
-#empty strings from id 472 to 473
+#empty strings from id 471 to 473
 
 msgctxt "#474"
 msgid "Off"


### PR DESCRIPTION
This strings is linked to
# : xbmc/video/dialogs/GUIDialogVideoSettings.cpp

Since it doesn't exist there it must have been removed at an earlier
date.

Sorry about earlier PR but something weird happened on vm... 
