### PR TITLE
[PVR][language] use "icon" for all channel icon related settings and dialogs instead of "thumbnail"

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7262,9 +7262,10 @@ msgctxt "#19017"
 msgid "TV recordings"
 msgstr ""
 
+#. Name of a setting, asking to enter the path to a folder that contains icons for TV channels
 #: system/settings/settings.xml
 msgctxt "#19018"
-msgid "Default folder for PVR thumbnails"
+msgid "Folder with channel icons"
 msgstr ""
 
 #: xbmc/windows/GUIWindowSystemInfo.cpp
@@ -7461,7 +7462,12 @@ msgctxt "#19065"
 msgid "Default EPG window"
 msgstr ""
 
-#empty string with id 19066
+#. Name of a shortcut to a custom folder for channel icons
+#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+msgctxt "#19066"
+msgid "Channel icons"
+msgstr ""
 
 msgctxt "#19067"
 msgid "This event is already being recorded."
@@ -8361,7 +8367,35 @@ msgctxt "#19281"
 msgid "Confirm channel switches by pressing OK"
 msgstr ""
 
-#empty strings from id 19282 to 19498
+#. Label for a select option or list item, representing an icon graphic (like a TV channel icon)
+#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+msgctxt "#19282"
+msgid "Current icon"
+msgstr ""
+
+#. Label for a select option or list item, representing an icon graphic (like a TV channel icon)
+#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+msgctxt "#19283"
+msgid "No icon"
+msgstr ""
+
+#. Label for a select/menu option to select an icon graphic
+#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+msgctxt "#19284"
+msgid "Choose icon"
+msgstr ""
+
+#. Label for a select/menu option to select an icon graphic
+#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+msgctxt "#19285"
+msgid "Browse for icon"
+msgstr ""
+
+#empty strings from id 19286 to 19498
 
 #: xbmc/epg/Epg.cpp
 msgctxt "#19499"

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -323,21 +323,21 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
   {
     CFileItemPtr current(new CFileItem("thumb://Current", false));
     current->SetArt("thumb", pItem->GetPVRChannelInfoTag()->IconPath());
-    current->SetLabel(g_localizeStrings.Get(20016));
+    current->SetLabel(g_localizeStrings.Get(19282));
     items.Add(current);
   }
   else if (pItem->HasArt("thumb"))
   { // already have a thumb that the share doesn't know about - must be a local one, so we mayaswell reuse it.
     CFileItemPtr current(new CFileItem("thumb://Current", false));
     current->SetArt("thumb", pItem->GetArt("thumb"));
-    current->SetLabel(g_localizeStrings.Get(20016));
+    current->SetLabel(g_localizeStrings.Get(19282));
     items.Add(current);
   }
 
   // and add a "no thumb" entry as well
   CFileItemPtr nothumb(new CFileItem("thumb://None", false));
   nothumb->SetIconImage(pItem->GetIconImage());
-  nothumb->SetLabel(g_localizeStrings.Get(20018));
+  nothumb->SetLabel(g_localizeStrings.Get(19283));
   items.Add(nothumb);
 
   CStdString strThumb;
@@ -346,11 +346,11 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
   {
     CMediaSource share1;
     share1.strPath = CSettings::Get().GetString("pvrmenu.iconpath");
-    share1.strName = g_localizeStrings.Get(19018);
+    share1.strName = g_localizeStrings.Get(19066);
     shares.push_back(share1);
   }
   g_mediaManager.GetLocalDrives(shares);
-  if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(1030), strThumb))
+  if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(19285), strThumb, NULL, 19285))
     return false;
 
   if (strThumb == "thumb://Current")

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -94,7 +94,7 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
     buttons.Add(CONTEXT_BUTTON_FIND, 19003);                                          /* find similar program */
     buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 19000);                                     /* switch to channel */
     buttons.Add(CONTEXT_BUTTON_RECORD_ITEM, channel->IsRecording() ? 19256 : 19255);  /* start/stop recording on channel */
-    buttons.Add(CONTEXT_BUTTON_SET_THUMB, 20019);                                     /* change icon */
+    buttons.Add(CONTEXT_BUTTON_SET_THUMB, 19284);                                     /* change icon */
     buttons.Add(CONTEXT_BUTTON_GROUP_MANAGER, 19048);                                 /* group manager */
     buttons.Add(CONTEXT_BUTTON_HIDE, m_bShowHiddenChannels ? 19049 : 19054);          /* show/hide channel */
 
@@ -458,10 +458,10 @@ bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUT
 
     if (!channel->IconPath().empty())
     {
-      /* add the current thumb, if available */
+      /* add the current icon, if available */
       CFileItemPtr current(new CFileItem("thumb://Current", false));
       current->SetArt("thumb", channel->IconPath());
-      current->SetLabel(g_localizeStrings.Get(20016));
+      current->SetLabel(g_localizeStrings.Get(19282));
       items.Add(current);
     }
     else if (item->HasArt("thumb"))
@@ -469,14 +469,14 @@ bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUT
       /* already have a thumb that the share doesn't know about - must be a local one, so we may as well reuse it */
       CFileItemPtr current(new CFileItem("thumb://Current", false));
       current->SetArt("thumb", item->GetArt("thumb"));
-      current->SetLabel(g_localizeStrings.Get(20016));
+      current->SetLabel(g_localizeStrings.Get(19282));
       items.Add(current);
     }
 
     /* and add a "no thumb" entry as well */
     CFileItemPtr nothumb(new CFileItem("thumb://None", false));
     nothumb->SetIconImage(item->GetIconImage());
-    nothumb->SetLabel(g_localizeStrings.Get(20018));
+    nothumb->SetLabel(g_localizeStrings.Get(19283));
     items.Add(nothumb);
 
     CStdString strThumb;
@@ -485,11 +485,11 @@ bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUT
     {
       CMediaSource share1;
       share1.strPath = CSettings::Get().GetString("pvrmenu.iconpath");
-      share1.strName = g_localizeStrings.Get(19018);
+      share1.strName = g_localizeStrings.Get(19066);
       shares.push_back(share1);
     }
     g_mediaManager.GetLocalDrives(shares);
-    if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(1030), strThumb))
+    if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(19285), strThumb, NULL, 19285))
       return bReturn;
 
     if (strThumb != "thumb://Current")


### PR DESCRIPTION
what title says. Was part of #3985 and moved to it's own PR so that it can be merged already. @opdenkamp and @xhaggy gave green light already.
