### PR TITLE
videodb: speed up CleanDatabase()

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8060,8 +8060,12 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
 
       if (handle == NULL && progress != NULL)
       {
-        progress->SetPercentage(current * 100 / total);
-        progress->Progress();
+        int percentage = current * 100 / total;
+        if (percentage > progress->GetPercentage())
+        {
+          progress->SetPercentage(percentage);
+          progress->Progress();
+        }
         if (progress->IsCanceled())
         {
           progress->Close();


### PR DESCRIPTION
These simple changes speedup CVideoDatabase::CleanDatabase() a lot when manually triggered from Settings -> Video -> Library -> Clean database ... In my tests (nothing to clean, all files and sources exist) the execution of the method takes around 55 seconds with the current code. With this simple change it only takes 2 seconds.

It looks like calling CGUIDialogProgress::Progress() takes a considerable amount of time especially when called thousands of times even though the state of the dialog (i.e. title, text and progress value) haven't changed.

Is this done intentionally so that users have more time to cancel the process? If not this improvement might actually be possible from inside CGUIDialogProgress::Progress() by only triggering the render-loop when something has changed.
