### PR TITLE
[scrapers] Replace Buffers before parsing XSLT nodes

### DIFF
--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -346,6 +346,7 @@ void CScraperParser::ParseXSLT(const CStdString& input, CStdString& dest, TiXmlE
     XSLTUtils xsltUtils;
     CStdString strXslt;
     strXslt << *pSheet;
+    ReplaceBuffers(strXslt);
 
     if (!xsltUtils.SetInput(input))
       CLog::Log(LOGDEBUG, "could not parse input XML");


### PR DESCRIPTION
Had a chance to play around a little with the new XSLT scraping with the tvdb scraper, but one thing I noticed was that I was unable to refer to any buffers or settings within the XSLT code.  

This makes it pretty difficult, for example, to refer to a specific episode in GetEpisodeDetails, where we need the episode id stored in $$2 to determine which Episode node to parse.  Or for grabbing posters, where we want to prioritize posters which match $INFO[language].

I can't see any specific harm in replacing the buffers - $foo in XSLT refers to a variable, so at worst it only makes $INFO and $LOCALIZE "reserved" terms, and scraper developers would be free to pick a different variable name to use.  I don't think $$1-$$20 have any special meaning either.

(Ideally for Gotham... It's, uh, a "fix" for an already added feature...)

@night199uk and @jmarshallnz
