### PR TITLE
fix: FileItem::FindLocalArt: don't try to find fanart for "add" button

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1288,6 +1288,8 @@ namespace VIDEO
 
   std::string CVideoInfoScanner::GetFanart(CFileItem *pItem, bool useLocal)
   {
+    if (!pItem)
+      return "";
     std::string fanart = pItem->GetArt("fanart");
     if (fanart.empty() && useLocal)
       fanart = pItem->FindLocalArt("fanart.jpg", true);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -295,8 +295,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
 
 bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
 {
-  if (pItem->m_bIsShareOrDrive
-  ||  pItem->IsParentFolder())
+  if (pItem->m_bIsShareOrDrive || pItem->IsParentFolder() || pItem->GetPath() == "add")
     return false;
 
   if (pItem->HasVideoInfoTag()                         &&


### PR DESCRIPTION
This will prevent checking "add\folder.jpg" and similar (notice path not related to anything).
Done in the same way as in other parts of codebase.
