### PR TITLE
ADD: [droid] backdoor to define XBMC_HOME and HOME on android

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -587,21 +587,32 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
 void CXBMCApp::SetupEnv()
 {
   setenv("XBMC_ANDROID_SYSTEM_LIBS", CJNISystem::getProperty("java.library.path").c_str(), 0);
-  setenv("XBMC_ANDROID_DATA", getApplicationInfo().dataDir.c_str(), 0);
   setenv("XBMC_ANDROID_LIBS", getApplicationInfo().nativeLibraryDir.c_str(), 0);
   setenv("XBMC_ANDROID_APK", getPackageResourcePath().c_str(), 0);
 
-  std::string cacheDir = getCacheDir().getAbsolutePath();
-  setenv("XBMC_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
-  setenv("XBMC_HOME", (cacheDir + "/apk/assets").c_str(), 0);
+  std::string xbmcHome = CJNISystem::getProperty("xbmc.home", "");
+  if (xbmcHome.empty())
+  {
+    std::string cacheDir = getCacheDir().getAbsolutePath();
+    setenv("XBMC_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
+    setenv("XBMC_HOME", (cacheDir + "/apk/assets").c_str(), 0);
+  }
+  else
+  {
+    setenv("XBMC_BIN_HOME", (xbmcHome + "/assets").c_str(), 0);
+    setenv("XBMC_HOME", (xbmcHome + "/assets").c_str(), 0);
+  }
 
-  std::string externalDir;
-  CJNIFile androidPath = getExternalFilesDir("");
-  if (!androidPath)
-    androidPath = getDir("org.xbmc.xbmc", 1);
+  std::string externalDir = CJNISystem::getProperty("xbmc.data", "");
+  if (externalDir.empty())
+  {
+    CJNIFile androidPath = getExternalFilesDir("");
+    if (!androidPath)
+      androidPath = getDir("org.xbmc.xbmc", 1);
 
-  if (androidPath)
-    externalDir = androidPath.getAbsolutePath();
+    if (androidPath)
+      externalDir = androidPath.getAbsolutePath();
+  }
 
   if (!externalDir.empty())
     setenv("HOME", externalDir.c_str(), 0);


### PR DESCRIPTION
Principle: 
Define a `/sdcard/xbmc_env.properties` (hardcoded) with content similar to

```
xbmc.home=/sdcard/xbmc_home
xbmc.data=/sdcard/xbmc_data
```

Assets are cached to xbmc.home, and XBMC_HOME is set accordingly
HOME is set to xbmc.data (created id needed)

/cc @davilla 
