### PR TITLE
fixed: (Video) resume didn't work for play-using from context menu

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1371,7 +1371,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         CPlayerCoreFactory::Get().GetPlayers(*item, vecCores);
       g_application.m_eForcedNextPlayer = CPlayerCoreFactory::Get().SelectPlayerDialog(vecCores);
       if (g_application.m_eForcedNextPlayer != EPC_NONE)
-        OnClick(itemNumber);
+        OnResumeItem(itemNumber);
       return true;
     }
 


### PR DESCRIPTION
Previously eg. video resuming when using "Play using" from the context menu didn't work. This PR makes the behavior the same as when using just "Play" allowing resume.
