### PR TITLE
[3d] fix stretched gui in sbs/ou mode when using hq scalers

### DIFF
--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -203,6 +203,10 @@ bool CWinShader::Execute(std::vector<LPDIRECT3DSURFACE9> *vecRT, unsigned int ve
     oldRT->Release();
   }
 
+  // MSDN says: Setting a new render target will cause the viewport 
+  // to be set to the full size of the new render target.
+  // So we need restore our viewport
+  g_Windowing.RestoreViewPort();
   return true;
 }
 
@@ -769,6 +773,10 @@ bool CConvolutionShaderSeparable::ClearIntermediateRenderTarget()
   currentRT->Release();
   intermediateRT->Release();
 
+  // MSDN says: Setting a new render target will cause the viewport 
+  // to be set to the full size of the new render target.
+  // So we need restore our viewport
+  g_Windowing.RestoreViewPort();
   return true;
 }
 

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -954,6 +954,11 @@ void CWinRenderer::Stage1()
     // Restore the render target
     pD3DDevice->SetRenderTarget(0, oldRT);
 
+    // MSDN says: Setting a new render target will cause the viewport 
+    // to be set to the full size of the new render target.
+    // So we need restore our viewport
+    g_Windowing.RestoreViewPort();
+
     oldRT->Release();
     newRT->Release();
   }

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -108,6 +108,7 @@ public:
 
   virtual void SetViewPort(CRect& viewPort) = 0;
   virtual void GetViewPort(CRect& viewPort) = 0;
+  virtual void RestoreViewPort() {};
 
   virtual void SetScissors(const CRect &rect) = 0;
   virtual void ResetScissors() = 0;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -954,6 +954,14 @@ void CRenderSystemDX::SetViewPort(CRect& viewPort)
   m_pD3DDevice->SetViewport(&m_viewPort);
 }
 
+void CRenderSystemDX::RestoreViewPort()
+{
+  if (!m_bRenderCreated)
+    return;
+
+  m_pD3DDevice->SetViewport(&m_viewPort);
+}
+
 void CRenderSystemDX::SetScissors(const CRect& rect)
 {
   if (!m_bRenderCreated)

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -61,6 +61,7 @@ public:
 
   virtual void SetViewPort(CRect& viewPort);
   virtual void GetViewPort(CRect& viewPort);
+  virtual void RestoreViewPort();
 
   virtual void SetScissors(const CRect &rect);
   virtual void ResetScissors();


### PR DESCRIPTION
Try to fix the issue described here https://github.com/xbmc/xbmc/pull/3596#issuecomment-32717006

@da-anda, @elupus, please take a look.
