### PR TITLE
ffmpeg: Correctly handle cookies that specify a sub-domain.

### DIFF
--- a/lib/ffmpeg/libavformat/http.c
+++ b/lib/ffmpeg/libavformat/http.c
@@ -409,8 +409,11 @@ static int get_cookies(HTTPContext *s, char **cookies, const char *path,
                 av_free(cpath);
                 cpath = av_strdup(&param[5]);
             } else if (!av_strncasecmp("domain=", param, 7)) {
+                // if the cookie specifies a sub-domain, skip the leading dot thereby
+                // supporting URLs that point to sub-domains and the master domain
+                int leading_dot = (param[7] == '.');
                 av_free(cdomain);
-                cdomain = av_strdup(&param[7]);
+                cdomain = av_strdup(&param[7+leading_dot]);
             } else if (!av_strncasecmp("secure",  param, 6) ||
                        !av_strncasecmp("comment", param, 7) ||
                        !av_strncasecmp("max-age", param, 7) ||

--- a/lib/ffmpeg/patches/0061-ffmpeg-backport-Correctly-handle-cookies-that-specify-a-sub-domain.patch
+++ b/lib/ffmpeg/patches/0061-ffmpeg-backport-Correctly-handle-cookies-that-specify-a-sub-domain.patch
@@ -1,0 +1,29 @@
+From aa1852f88f769ee438e85cec8552ff545914885c Mon Sep 17 00:00:00 2001
+From: Eli K. <eli@algotec.co.il>
+Date: Thu, 23 Jan 2014 10:27:21 +0200
+Subject: [PATCH] Correctly handle cookies that specify a sub-domain.
+
+---
+ libavformat/http.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/libavformat/http.c b/libavformat/http.c
+index 3b655c6..69c4d6d 100644
+--- a/libavformat/http.c
++++ b/libavformat/http.c
+@@ -490,8 +490,11 @@ static int get_cookies(HTTPContext *s, char **cookies, const char *path,
+                 av_free(cpath);
+                 cpath = av_strdup(&param[5]);
+             } else if (!av_strncasecmp("domain=", param, 7)) {
++                // if the cookie specifies a sub-domain, skip the leading dot thereby
++                // supporting URLs that point to sub-domains and the master domain
++                int leading_dot = (param[7] == '.');
+                 av_free(cdomain);
+-                cdomain = av_strdup(&param[7]);
++                cdomain = av_strdup(&param[7+leading_dot]);
+             } else if (!av_strncasecmp("secure",  param, 6) ||
+                        !av_strncasecmp("comment", param, 7) ||
+                        !av_strncasecmp("max-age", param, 7) ||
+-- 
+1.8.3.msysgit.0
+


### PR DESCRIPTION
This commit fixes domain matching when the cookie specifies a sub-domain but the URL that points to the video file or playlist is pointing to the top-level domain.

A reference scenario to reproduce the original bug can be found in the ffmpeg bug tracker:
https://trac.ffmpeg.org/ticket/3336
(ticket now closed)

Built ffmpeg and tested on Windows - works as expected. Cookie header is filled properly instead of (null).

I suspect this small but subtle bug may affect playing of various sources accessible via HTTP online.
