### PR TITLE
fix HLS variant selection

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -22,6 +22,7 @@
 #include "xbmc/playlists/PlayListM3U.h"
 #include "settings/Settings.h"
 #include "Util.h"
+#include "utils/log.h"
 
 using namespace XFILE;
 
@@ -56,7 +57,12 @@ bool CDVDInputStreamFFmpeg::Open(const char* strFile, const std::string& content
     int bandwidth = CSettings::Get().GetInt("network.bandwidth");
     if(bandwidth <= 0)
       bandwidth = INT_MAX;
-    strFile = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(strFile, bandwidth);
+    std::string selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(strFile, bandwidth);
+    if (selected.compare(strFile) != 0)
+    {
+      CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.c_str());
+      strFile = selected.c_str();
+    }
   }
 
   if (!CDVDInputStream::Open(strFile, content))

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -19,6 +19,9 @@
  */
 
 #include "DVDInputStreamFFmpeg.h"
+#include "xbmc/playlists/PlayListM3U.h"
+#include "settings/Settings.h"
+#include "Util.h"
 
 using namespace XFILE;
 
@@ -46,6 +49,16 @@ bool CDVDInputStreamFFmpeg::IsEOF()
 
 bool CDVDInputStreamFFmpeg::Open(const char* strFile, const std::string& content)
 {
+  CFileItem item(strFile, false);
+  if (item.IsInternetStream() && item.IsType(".m3u8"))
+  {
+    // get the available bandwidth and  determine the most appropriate stream
+    int bandwidth = CSettings::Get().GetInt("network.bandwidth");
+    if(bandwidth <= 0)
+      bandwidth = INT_MAX;
+    strFile = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(strFile, bandwidth);
+  }
+
   if (!CDVDInputStream::Open(strFile, content))
     return false;
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -662,20 +662,6 @@ bool CDVDPlayer::OpenInputStream()
     m_filename = g_mediaManager.TranslateDevicePath("");
   }
 
-  // before creating the input stream, if this is an HLS playlist then get the
-  // most appropriate bitrate based on our network settings
-  // ensure to strip off the url options by using a temp CURL object
-  if (StringUtils::StartsWith(filename, "http://") &&
-      StringUtils::EndsWith(CURL(filename).GetFileName(), ".m3u8"))
-  {
-    // get the available bandwidth (as per user settings)
-    int maxrate = CSettings::Get().GetInt("network.bandwidth");
-    if(maxrate <= 0)
-      maxrate = INT_MAX;
-
-    // determine the most appropriate stream
-    m_filename = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(m_filename, (size_t)maxrate);
-  }
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_filename, m_mimetype);
   if(m_pInputStream == NULL)
   {

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -708,19 +708,6 @@ bool COMXPlayer::OpenInputStream()
     m_filename = g_mediaManager.TranslateDevicePath("");
   }
 
-  // before creating the input stream, if this is an HLS playlist then get the
-  // most appropriate bitrate based on our network settings
-  // ensure to strip off the url options by using a temp CURL object
-  if (StringUtils::StartsWith(filename, "http://") && StringUtils::EndsWith(CURL(filename).GetFileName(), ".m3u8"))
-  {
-    // get the available bandwidth (as per user settings)
-    int maxrate = CSettings::Get().GetInt("network.bandwidth");
-    if(maxrate <= 0)
-      maxrate = INT_MAX;
-
-    // determine the most appropriate stream
-    m_filename = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(m_filename, (size_t)maxrate);
-  }
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_filename, m_mimetype);
   if(m_pInputStream == NULL)
   {

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -261,10 +261,7 @@ CStdString CPlayListM3U::GetBestBandwidthStream(const CStdString &strFileName, s
 
   // if any protocol options were set, restore them
   subStreamUrl.SetProtocolOptions(playlistUrl.GetProtocolOptions());
-  CStdString subStream = subStreamUrl.Get();
-
-  CLog::Log(LOGINFO, "Auto-selecting %s based on configured bandwidth.", subStream.c_str());
-  return subStream;
+  return subStreamUrl.Get();
 }
 
 std::map< CStdString, CStdString > CPlayListM3U::ParseStreamLine(const CStdString &streamLine)


### PR DESCRIPTION
This patch moves the (duplicated) stream selection code from dvdplayer/omxplayer to a separate input stream

This solves the following problems:
- Variant selection when using pvr never worked (the path passed to DVDPlayer is pvr://) The problem is detailed [here](http://forum.xbmc.org/showthread.php?tid=169674&pid=1604524#pid1604524)
- Not working for https. This patch fixes the same as #3875 
