### PR TITLE
Add auto-height for textbox controls

### DIFF
--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -83,17 +83,14 @@ void CGUIDialogBoxBase::SetLine(unsigned int iLine, const CVariant& line)
     lines.resize(iLine+1);
   lines[iLine] = label;
   std::string text = StringUtils::Join(lines, "\n");
-  if (text != m_text)
-  {
-    m_text = text;
-    SetInvalid();
-  }
+  SetText(text);
 }
 
 void CGUIDialogBoxBase::SetText(const CVariant& text)
 {
   std::string label = GetLocalized(text);
   CSingleLock lock(m_section);
+  StringUtils::Trim(label, "\n");
   if (label != m_text)
   {
     m_text = label;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1386,6 +1386,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     if (infoLabels.size())
       ((CGUITextBox *)control)->SetInfo(infoLabels[0]);
     ((CGUITextBox *)control)->SetAutoScrolling(pControlNode);
+    ((CGUITextBox *)control)->SetMinHeight(minHeight);
   }
   else if (type == CGUIControl::GUICONTROL_SELECTBUTTON)
   {

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -52,6 +52,8 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnMessage(CGUIMessage& message);
+  virtual float GetHeight() const;
+  void SetMinHeight(float minHeight);
 
   void SetPageControl(int pageControl);
 
@@ -71,6 +73,10 @@ protected:
   void ScrollToOffset(int offset, bool autoScroll = false);
   unsigned int GetRows() const;
   int GetCurrentPage() const;
+
+  // auto-height
+  float m_minHeight;
+  float m_renderHeight;
 
   // offset of text in the control for scrolling
   unsigned int m_offset;


### PR DESCRIPTION
This adds the possibility to have auto-sized textboxes. Works the same way as with labels. Additionally it's possible to also resize the corresponding pagecontrol together with the textbox with `<resizepagecontrol>true</resizepagecontrol>`.

Mainly it makes it possible to keep old designs in DialogYesNo, DialogOK etc. with the new textbox control instead of the old labels. 

One thing which I recognized is that there is a new line in the textbox in some dialogs, e.g. if you delete a source, it says

"

Are you sure?
"

instead of just

"
Are you sure?
"

in the DialogYesNo. Now there are two ways this could be fixed:
1. Change calls of `CGUIDialogYesNo::ShowAndGetInput(751, 0, 750, 0)` to `CGUIDialogYesNo::ShowAndGetInput(751, 750, 0, 0)` so there is no empty first line.
2. Always remove any whitespace from the text which is added to the textbox.

Which one is preferred?
