### PR TITLE
fixed: Newly added subs would not auto enable on previously played items

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -721,6 +721,12 @@ bool CDVDPlayer::OpenInputStream()
       }
     } // end loop over all subtitle files
 
+    /* In case we played this item before without external subs, enable here else
+     * they will not auto enable when external subs got added in the meantime
+     */
+    if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream < 0)
+      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = true;
+
     CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleCached = true;
   }
 

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -771,6 +771,12 @@ bool COMXPlayer::OpenInputStream()
       }
     } // end loop over all subtitle files
 
+    /* In case we played this item before without external subs, enable here else
+     * they will not auto enable when external subs got added in the meantime
+     */
+    if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream < 0)
+      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = true;
+
     CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleCached = true;
   }
 


### PR DESCRIPTION
If a video item doesn't have any subs the first time it is played, its "subtitleOn"-setting will be stored as off (disabled). If a user adds an external sub later on, it will never auto-enable when the user plays the item again. This PR fixes this behavior.
