### PR TITLE
Add paging to list and panel container

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1233,6 +1233,16 @@ int CGUIBaseContainer::GetCurrentPage() const
   return GetOffset() / m_itemsPerPage + 1;
 }
 
+int CGUIBaseContainer::GetPagingOffset(bool movedown) const
+{
+  if (movedown) {
+    int offset = GetOffset() + 2*m_itemsPerPage;
+    int nrOfItems = (int)GetRows();
+    return (offset > nrOfItems) ? (m_itemsPerPage + nrOfItems - offset) : m_itemsPerPage;
+  }
+  return (GetOffset() >= m_itemsPerPage) ? m_itemsPerPage : GetOffset();
+}
+
 void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter) const
 {
   if (m_scroller.IsScrollingDown())

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -198,6 +198,8 @@ protected:
   */
   inline int GetItemOffset() const { return CorrectOffset(GetOffset(), 0); }
 
+  virtual int GetPagingOffset(bool movedown) const;
+
   // autoscrolling
   INFO::InfoPtr m_autoScrollCondition;
   int           m_autoScrollMoveTime;   // time between to moves

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -536,6 +536,9 @@ bool CGUIControlFactory::GetScroller(const TiXmlNode *control, const CStdString 
     if (XMLUtils::GetUInt(control, scrollerTag, scrollTime))
     {
       scroller = CScroller(scrollTime, CAnimEffect::GetTweener(node));
+      const char *paging = node->Attribute("paging");
+      if (paging && strnicmp(paging, "true", 4) == 0)
+        scroller.setPaging(true);
       return true;
     }
   }

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -138,7 +138,16 @@ bool CGUIListContainer::MoveUp(bool wrapAround)
   }
   else if (GetCursor() == 0 && GetOffset())
   {
-    ScrollToOffset(GetOffset() - 1);
+    if (m_scroller.isPagingEnabled())
+    {
+      int pagingOffset = GetPagingOffset(false);
+      SetCursor(GetCursor() - 1 + pagingOffset);
+      ScrollToOffset(GetOffset() - pagingOffset);
+    }
+    else
+    {
+      ScrollToOffset(GetOffset() - 1);
+    }
   }
   else if (wrapAround)
   {
@@ -166,7 +175,16 @@ bool CGUIListContainer::MoveDown(bool wrapAround)
     }
     else
     {
-      ScrollToOffset(GetOffset() + 1);
+      if (m_scroller.isPagingEnabled())
+      {
+        int pagingOffset = GetPagingOffset(true);
+        SetCursor(GetCursor() + 1 - pagingOffset);
+        ScrollToOffset(GetOffset() + pagingOffset);
+      }
+      else
+      {
+        ScrollToOffset(GetOffset() + 1);
+      }
     }
   }
   else if(wrapAround)

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -307,10 +307,29 @@ bool CGUIPanelContainer::MoveDown(bool wrapAround)
       SetCursor(GetCursor() + m_itemsPerRow);
   }
   else if ((GetOffset() + 1 + GetCursor() / m_itemsPerRow) * m_itemsPerRow < (int)m_items.size())
-  { // we scroll to the next row, and move to last item if necessary
-    if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= (int)m_items.size())
-      SetCursor((int)m_items.size() - 1 - (GetOffset() + 1)*m_itemsPerRow);
-    ScrollToOffset(GetOffset() + 1);
+  {
+    if (m_scroller.isPagingEnabled())
+    {
+      int pagingOffset = GetPagingOffset(true);
+      int cursorOffset = (pagingOffset - 1)*m_itemsPerRow;
+      // move to last item if necessary
+      if ((GetOffset() + pagingOffset)*m_itemsPerRow + GetCursor() - cursorOffset >= (int)m_items.size())
+      {
+        SetCursor((int)m_items.size() - 1 - (GetOffset() + 1)*m_itemsPerRow);
+      }
+      else
+      {
+        SetCursor(GetCursor() - cursorOffset);
+      }
+      ScrollToOffset(GetOffset() + pagingOffset);
+    }
+    else
+    {
+      // we scroll to the next row, and move to last item if necessary
+      if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= (int)m_items.size())
+        SetCursor((int)m_items.size() - 1 - (GetOffset() + 1)*m_itemsPerRow);
+      ScrollToOffset(GetOffset() + 1);
+    }
   }
   else if (wrapAround)
   { // move first item in list
@@ -326,9 +345,23 @@ bool CGUIPanelContainer::MoveDown(bool wrapAround)
 bool CGUIPanelContainer::MoveUp(bool wrapAround)
 {
   if (GetCursor() >= m_itemsPerRow)
+  {
     SetCursor(GetCursor() - m_itemsPerRow);
+  }
   else if (GetOffset() > 0)
-    ScrollToOffset(GetOffset() - 1);
+  {
+    if (m_scroller.isPagingEnabled())
+    {
+      int pagingOffset = GetPagingOffset(false);
+      int cursorOffset = (pagingOffset - 1)*m_itemsPerRow;
+      SetCursor(GetCursor() + cursorOffset);
+      ScrollToOffset(GetOffset() - pagingOffset);
+    }
+    else
+    {
+      ScrollToOffset(GetOffset() - 1);
+    }
+  }
   else if (wrapAround)
   { // move last item in list in this column
     SetCursor((GetCursor() % m_itemsPerRow) + (m_itemsPerPage - 1) * m_itemsPerRow);

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -733,6 +733,7 @@ CScroller& CScroller::operator=(const CScroller &right)
   m_lastTime = right.m_lastTime;
   m_duration = right.m_duration;
   m_pTweener = right.m_pTweener;
+  m_paging = right.m_paging;
   return *this;
 }
 

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -248,6 +248,15 @@ public:
   bool IsScrollingDown() const { return m_delta > 0; };
 
   unsigned int GetDuration() const { return m_duration; };
+
+  /**
+   * Paging
+   * If the selected item is on the beginning/end of a page and the user scrolls up/down,
+   * the list scrolls to the previous/next page of items instead of just to the next item
+   */
+  bool isPagingEnabled() const { return m_paging; };
+  void setPaging(bool paging) { m_paging = paging; };
+
 private:
   float Tween(float progress);
 
@@ -260,4 +269,6 @@ private:
 
   unsigned int m_duration;                //!< Brief duration of scroll
   boost::shared_ptr<Tweener> m_pTweener;
+
+  bool         m_paging;
 };


### PR DESCRIPTION
This adds the ability to have a list or panel container scroll a whole page instead of just one item when reaching the start/end of a page.

`<scrolltime paging="true">300</scrolltime>`
