### PR TITLE
Various addon/repository improvements, mostly efficiency

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -315,8 +315,7 @@ bool CAddon::MeetsVersion(const AddonVersion &version) const
   // if the addon is one of xbmc's extension point definitions (addonid starts with "xbmc.")
   // and the minversion is "0.0.0" i.e. no <backwards-compatibility> tag has been specified
   // we need to assume that the current version is not backwards-compatible and therefore check against the actual version
-  if (StringUtils::StartsWithNoCase(m_props.id, "xbmc.") &&
-     (strlen(m_props.minversion.c_str()) == 0 || StringUtils::EqualsNoCase(m_props.minversion.c_str(), "0.0.0")))
+  if (StringUtils::StartsWithNoCase(m_props.id, "xbmc.") && m_props.minversion.empty())
     return m_props.version == version;
 
   return m_props.minversion <= version && version <= m_props.version;

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -310,10 +310,8 @@ bool CAddonDatabase::GetAddons(VECADDONS& addons)
     m_pDS->query(sql.c_str());
     while (!m_pDS->eof())
     {
-      sql = PrepareSQL("select id from addon where addonID='%s' order by version desc",m_pDS->fv(0).get_asString().c_str());
-      m_pDS2->query(sql.c_str());
       AddonPtr addon;
-      if (GetAddon(m_pDS2->fv(0).get_asInt(),addon))
+      if (GetAddon(m_pDS->fv(0).get_asString(),addon))
         addons.push_back(addon);
       m_pDS->next();
     }
@@ -519,7 +517,7 @@ bool CAddonDatabase::Search(const CStdString& search, VECADDONS& addons)
     if (NULL == m_pDS.get()) return false;
 
     CStdString strSQL;
-    strSQL=PrepareSQL("SELECT id FROM addon WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
+    strSQL=PrepareSQL("SELECT addonID FROM addon WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
 
     if (!m_pDS->query(strSQL.c_str())) return false;
@@ -528,7 +526,7 @@ bool CAddonDatabase::Search(const CStdString& search, VECADDONS& addons)
     while (!m_pDS->eof())
     {
       AddonPtr addon;
-      GetAddon(m_pDS->fv(0).get_asInt(),addon);
+      GetAddon(m_pDS->fv(0).get_asString(),addon);
       if (addon->Type() >= ADDON_UNKNOWN+1 && addon->Type() < ADDON_SCRAPER_LIBRARY)
         addons.push_back(addon);
       m_pDS->next();

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -204,6 +204,11 @@ int CAddonDatabase::AddAddon(const AddonPtr& addon,
   return -1;
 }
 
+AddonVersion CAddonDatabase::GetAddonVersion(const std::string &id)
+{
+  return AddonVersion(GetSingleValue(PrepareSQL("SELECT MAX(version) FROM addon WHERE addonID='%s'", id.c_str())));
+}
+
 bool CAddonDatabase::GetAddon(const CStdString& id, AddonPtr& addon)
 {
   int row = atoi(GetSingleValue(PrepareSQL("SELECT id FROM addon "

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -138,5 +138,31 @@ protected:
   const char *GetBaseDBName() const { return "Addons"; }
 
   bool GetAddon(int id, ADDON::AddonPtr& addon);
+
+  /* keep in sync with the select in GetAddon */
+  enum _AddonFields
+  {
+    addon_id=0,
+    addon_type,
+    addon_name,
+    addon_summary,
+    addon_description,
+    addon_stars,
+    addon_path,
+    addon_addonID,
+    addon_icon,
+    addon_version,
+    addon_changelog,
+    addon_fanart,
+    addon_author,
+    addon_disclaimer,
+    addon_minversion,
+    broken_reason,
+    addonextra_key,
+    addonextra_value,
+    dependencies_addon,
+    dependencies_version,
+    dependencies_optional
+  } AddonFields;
 };
 

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -35,6 +35,9 @@ public:
   bool GetAddon(const CStdString& addonID, ADDON::AddonPtr& addon);
   bool GetAddons(ADDON::VECADDONS& addons);
 
+  /*! \brief grab the (largest) add-on version for an add-on */
+  ADDON::AddonVersion GetAddonVersion(const std::string &id);
+
   /*! \brief Grab the repository from which a given addon came
    \param addonID - the id of the addon in question
    \param repo [out] - the id of the repository

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -34,7 +34,6 @@ public:
   int AddAddon(const ADDON::AddonPtr& item, int idRepo);
   bool GetAddon(const CStdString& addonID, ADDON::AddonPtr& addon);
   bool GetAddons(ADDON::VECADDONS& addons);
-  bool GetAddon(int id, ADDON::AddonPtr& addon);
 
   /*! \brief Grab the repository from which a given addon came
    \param addonID - the id of the addon in question
@@ -137,5 +136,7 @@ protected:
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 16; }
   const char *GetBaseDBName() const { return "Addons"; }
+
+  bool GetAddon(int id, ADDON::AddonPtr& addon);
 };
 

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -132,9 +132,10 @@ public:
   */
   bool RemovePackage(const CStdString& packageFileName);
 protected:
+  virtual void OnConnect();
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 16; }
+  virtual int GetMinVersion() const { return 17; }
   const char *GetBaseDBName() const { return "Addons"; }
 
   bool GetAddon(int id, ADDON::AddonPtr& addon);

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -24,6 +24,8 @@
 #include "utils/Stopwatch.h"
 #include "threads/Event.h"
 
+class CAddonDatabase;
+
 class CAddonInstaller : public IJobCallback
 {
 public:
@@ -68,9 +70,10 @@ public:
    Iterates through the addon's dependencies, checking they're installed or installable.
    Each dependency must also satisfies CheckDependencies in turn.
    \param addon the addon to check
+   \param database the database instance to update. Defaults to NULL.
    \return true if dependencies are available, false otherwise.
    */
-  bool CheckDependencies(const ADDON::AddonPtr &addon);
+  bool CheckDependencies(const ADDON::AddonPtr &addon, CAddonDatabase *database = NULL);
 
   /*! \brief Update all repositories (if needed)
    Runs through all available repositories and queues an update of them if they
@@ -127,10 +130,11 @@ private:
    Each dependency must also satisfies CheckDependencies in turn.
    \param addon the addon to check
    \param preDeps previous dependencies encountered during recursion. aids in avoiding infinite recursion
+   \param database database instance to update
    \return true if dependencies are available, false otherwise.
    */
   bool CheckDependencies(const ADDON::AddonPtr &addon,
-                         std::vector<std::string>& preDeps);
+                         std::vector<std::string>& preDeps, CAddonDatabase &database);
 
   void PrunePackageCache();
   int64_t EnumeratePackageFolder(std::map<CStdString,CFileItemList*>& result);

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -124,6 +124,11 @@ namespace ADDON
       && CompareComponent(Revision(), other.Revision()) == 0;
   }
 
+  bool AddonVersion::empty() const
+  {
+    return m_originalVersion.empty() || m_originalVersion == "0.0.0";
+  }
+
   CStdString AddonVersion::Print() const
   {
     return StringUtils::Format("%s %s", g_localizeStrings.Get(24051).c_str(), m_originalVersion.c_str());

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -107,21 +107,23 @@ namespace ADDON
 
   bool AddonVersion::operator<(const AddonVersion& other) const
   {
-    if (Epoch() != other.Epoch())
-      return Epoch() < other.Epoch();
-
-    int result = CompareComponent(Upstream(), other.Upstream());
-    if (result)
-      return (result < 0);
-
-    return (CompareComponent(Revision(), other.Revision()) < 0);
+    return compare(other) < 0;
   }
 
   bool AddonVersion::operator==(const AddonVersion& other) const
   {
-    return Epoch() == other.Epoch()
-      && CompareComponent(Upstream(), other.Upstream()) == 0
-      && CompareComponent(Revision(), other.Revision()) == 0;
+    return compare(other) == 0;
+  }
+
+  int AddonVersion::compare(const AddonVersion& other) const
+  {
+    int result = Epoch() - other.Epoch();
+    if (result)
+      return result;
+    result = CompareComponent(Upstream(), other.Upstream());
+    if (result)
+      return result;
+    return CompareComponent(Revision(), other.Revision());
   }
 
   bool AddonVersion::empty() const

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -53,6 +53,7 @@ namespace ADDON
     bool operator==(const AddonVersion& other) const;
     CStdString Print() const;
     const char *c_str() const { return m_originalVersion.c_str(); };
+    bool empty() const;
 
     static bool SplitFileName(CStdString& ID, CStdString& version,
                               const CStdString& filename);

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -51,6 +51,7 @@ namespace ADDON
     AddonVersion& operator=(const AddonVersion& other);
     bool operator<(const AddonVersion& other) const;
     bool operator==(const AddonVersion& other) const;
+    int compare(const AddonVersion& other) const;
     CStdString Print() const;
     const char *c_str() const { return m_originalVersion.c_str(); };
     bool empty() const;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -252,7 +252,7 @@ bool CRepositoryUpdateJob::DoWork()
       break;
 
     AddonPtr newAddon = i->second;
-    bool deps_met = CAddonInstaller::Get().CheckDependencies(newAddon);
+    bool deps_met = CAddonInstaller::Get().CheckDependencies(newAddon, &database);
     if (!deps_met && newAddon->Props().broken.empty())
       newAddon->Props().broken = "DEPSNOTMET";
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -246,6 +246,7 @@ bool CRepositoryUpdateJob::DoWork()
 
   CTextureDatabase textureDB;
   textureDB.Open();
+  textureDB.BeginMultipleExecute();
   for (map<string, AddonPtr>::const_iterator i = addons.begin(); i != addons.end(); ++i)
   {
     // manager told us to feck off
@@ -313,6 +314,7 @@ bool CRepositoryUpdateJob::DoWork()
     }
   }
   database.CommitMultipleExecute();
+  textureDB.CommitMultipleExecute();
 
   return true;
 }

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -242,7 +242,8 @@ bool CRepositoryUpdateJob::DoWork()
   // check for updates
   CAddonDatabase database;
   database.Open();
-  
+  database.BeginMultipleExecute();
+
   CTextureDatabase textureDB;
   textureDB.Open();
   for (map<string, AddonPtr>::const_iterator i = addons.begin(); i != addons.end(); ++i)
@@ -315,6 +316,7 @@ bool CRepositoryUpdateJob::DoWork()
       database.BreakAddon(newAddon->ID(), newAddon->Props().broken);
     }
   }
+  database.CommitMultipleExecute();
 
   return true;
 }

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -291,12 +291,8 @@ bool CRepositoryUpdateJob::DoWork()
 
     // Check if we should mark the add-on as broken.  We may have a newer version
     // of this add-on in the database or installed - if so, we keep it unbroken.
-    bool haveNewer = addon && addon->Version() > newAddon->Version();
-    if (!haveNewer)
-    {
-      AddonPtr dbAddon;
-      haveNewer = database.GetAddon(newAddon->ID(), dbAddon) && dbAddon->Version() > newAddon->Version();
-    }
+    bool haveNewer = (addon && addon->Version() > newAddon->Version()) ||
+                     database.GetAddonVersion(newAddon->ID()) > newAddon->Version();
     if (!haveNewer)
     {
       if (!newAddon->Props().broken.empty())

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -106,6 +106,7 @@ CDatabase::CDatabase(void)
   m_openCount = 0;
   m_sqlite = true;
   m_bMultiWrite = false;
+  m_multipleExecute = false;
 }
 
 CDatabase::~CDatabase(void)
@@ -193,8 +194,35 @@ bool CDatabase::DeleteValues(const CStdString &strTable, const Filter &filter /*
   return ExecuteQuery(strQuery);
 }
 
+bool CDatabase::BeginMultipleExecute()
+{
+  m_multipleExecute = true;
+  return true;
+}
+
+bool CDatabase::CommitMultipleExecute()
+{
+  m_multipleExecute = false;
+  BeginTransaction();
+  for (std::vector<std::string>::const_iterator i = m_multipleQueries.begin(); i != m_multipleQueries.end(); ++i)
+  {
+    if (!ExecuteQuery(*i))
+    {
+      RollbackTransaction();
+      return false;
+    }
+  }
+  return true;
+}
+
 bool CDatabase::ExecuteQuery(const CStdString &strQuery)
 {
+  if (m_multipleExecute)
+  {
+    m_multipleQueries.push_back(strQuery);
+    return true;
+  }
+
   bool bReturn = false;
 
   try
@@ -547,6 +575,7 @@ void CDatabase::Close()
   }
 
   m_openCount = 0;
+  m_multipleExecute = false;
 
   if (NULL == m_pDB.get() ) return ;
   if (NULL != m_pDS.get()) m_pDS->close();

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -472,6 +472,9 @@ bool CDatabase::Connect(const CStdString &dbName, const DatabaseSettings &dbSett
   if (m_pDB->connect(create) != DB_CONNECTION_OK)
     return false;
 
+  // allow subclasses to modify the connection once connected
+  OnConnect();
+
   try
   {
     // test if db already exists, if not we need to create the tables

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -102,8 +102,11 @@ public:
 
   /*!
    * @brief Execute a query that does not return any result.
+   *        Note that if BeginMultipleExecute() has been called, the
+   *        query will be queued until CommitMultipleExecute() is called.
    * @param strQuery The query to execute.
    * @return True if the query was executed successfully, false otherwise.
+   * @sa BeginMultipleExecute, CommitMultipleExecute
    */
   bool ExecuteQuery(const CStdString &strQuery);
 
@@ -114,6 +117,26 @@ public:
    * @return True if the query was executed successfully, false otherwise.
    */
   bool ResultQuery(const CStdString &strQuery);
+
+  /*!
+   * @brief Start a multiple execution queue. Any ExecuteQuery() function
+   *        following this call will be queued rather than executed until
+   *        CommitMultipleExecute() is performed.
+   *          NOTE: Queries that rely on any queued execute query will not
+   *                function as expected during this period!
+   * @return true if we could start a multiple execution queue, false otherwise.
+   * @sa CommitMultipleExecute, ExecuteQuery
+   */
+  bool BeginMultipleExecute();
+
+  /*!
+   * @brief Commit the multiple execution queue to the database.
+   *        Queries are performed within a transaction, and the transaction
+   *        is rolled back should any one query fail.
+   * @return True if the queries were executed successfully, false otherwise.
+   * @sa BeginMultipleExecute, ExecuteQuery
+   */
+  bool CommitMultipleExecute();
 
   /*!
    * @brief Open a new dataset.
@@ -171,4 +194,7 @@ private:
 
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */
   unsigned int m_openCount;
+
+  bool m_multipleExecute;
+  std::vector<std::string> m_multipleQueries;
 };

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -169,6 +169,10 @@ protected:
   uint32_t ComputeCRC(const CStdString &text);
 
   virtual bool Open();
+  /* \brief Callback executed once the database has been connected.
+     Custom database functions may be added during this call.
+   */
+  virtual void OnConnect() {};
   virtual bool CreateTables();
   virtual void CreateViews() {};
   virtual bool UpdateOldVersion(int version) { return true; };

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -60,6 +60,9 @@ class Dataset;		// forward declaration of class Dataset
 #define DB_UNEXPECTED		7	// This shouldn't ever happen
 #define DB_UNEXPECTED_RESULT   -1       //For integer functions
 
+/* comparator function for collation */
+typedef int (*compare_function)(const std::string &str1, const std::string &str2);
+
 /******************* Class Database definition ********************
 
    represents  connection with database server;
@@ -145,6 +148,9 @@ public:
   virtual void start_transaction() {};
   virtual void commit_transaction() {};
   virtual void rollback_transaction() {};
+
+/* virtual methods for collation */
+  virtual void add_collation(const char *type, compare_function function) {};
 
 /* virtual methods for formatting */
 

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -371,6 +371,19 @@ void SqliteDatabase::rollback_transaction() {
   }  
 }
 
+int comparator(void *func, int len1, const void *val1, int len2, const void *val2)
+{
+  compare_function f = (compare_function)func;
+  std::string l((const char *)val1, len1);
+  std::string r((const char *)val2, len2);
+  return f(l, r);
+}
+
+void SqliteDatabase::add_collation(const char *type, compare_function function) {
+  if (active) {
+    sqlite3_create_collation(conn, type, SQLITE_UTF8, (void *)function, comparator);
+  }
+}
 
 // methods for formatting
 // ---------------------------------------------

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -89,6 +89,8 @@ public:
   virtual void commit_transaction();
   virtual void rollback_transaction();
 
+  virtual void add_collation(const char *type, compare_function function);
+
 /* virtual methods for formatting */
   virtual std::string vprepare(const char *format, va_list args);
 


### PR DESCRIPTION
Quite a few commits here, aimed at speeding up repository processing.

The main gain is the dependency speedup on my machine (passing the database object into the function) - I have an SSD though, so it may be different on other machines.

The next largest gain is the broken status updating (the addition of Begin/CommitMultipleExecute and calling that from CRepository::DoWork()), as well as the addition of GetAddonVersion().

The rest allows reduced queries, in particular by utilizing a custom collator within SQLite to ensure that sorting by version works as you'd expect.  This is not implemented for mysql, but that's OK as the addons database is SQL-only anyway.  I'm sure there's a version that could be done for mysql as well though.  Note that it doesn't offer anything much in the way of speedup, so we could drop the four commits implementing this if it doesn't offer much in the way of speedup for others.

There is a possibility to perform GetAddon() single query via

```
SELECT * FROM addon WHERE id=(SELECT id FROM addon WHERE addonID='my.addon.id' ORDER BY version DESC LIMIT 1)
```

but this didn't seem to be any faster.  Any ideas for improvement most welcome!

(One thing we could consider post-Gotham is just storing the highest version in the database anyway.  I'm not sure what the implications here are though - some thought would be needed to make sure we get this right, particularly in regard to the linking of repository and addons)

Lastly, I've included some timing logs for @MartijnKaijser to test with.
