### PR TITLE
[confluence] Add support for customized default library nodes.

### DIFF
--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -921,14 +921,14 @@
 					</item>
 					<item id="10">
 						<label>31954</label>
-						<onclick>ActivateWindow(Videos,MovieTitles,return)</onclick>
+						<onclick>ActivateWindow(Videos,library://video/movies/titles.xml,return)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoMovieButton) + Library.HasContent(Movies)</visible>
 					</item>
 					<item id="11">
 						<label>31955</label>
-						<onclick>ActivateWindow(Videos,TVShowTitles,return)</onclick>
+						<onclick>ActivateWindow(Videos,library://video/tvshows/titles.xml,return)</onclick>
 						<icon>-</icon>
 						<thumb>-</thumb>
 						<visible>!Skin.HasSetting(HomeMenuNoTVShowButton) + Library.HasContent(TVShows)</visible>

--- a/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
@@ -9,19 +9,19 @@
 		<control type="button" id="90102">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>342</label>
-			<onclick>ActivateWindow(Videos,MovieTitles,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/movies/titles.xml,return)</onclick>
 			<visible>Library.HasContent(Movies) + Skin.HasSetting(HomeMenuNoMovieButton)</visible>
 		</control>
 		<control type="button" id="90103">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>20343</label>
-			<onclick>ActivateWindow(Videos,TvShowTitles,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/tvshows/titles.xml,return)</onclick>
 			<visible>Library.HasContent(TVShows) + Skin.HasSetting(HomeMenuNoTVShowButton)</visible>
 		</control>
 		<control type="button" id="90104">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>20389</label>
-			<onclick>ActivateWindow(Videos,MusicVideoTitles,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/musicvideos/titles.xml,return)</onclick>
 			<visible>Library.HasContent(MusicVideos)</visible>
 		</control>
 		<control type="button" id="90105">
@@ -55,33 +55,33 @@
 		<control type="button" id="90162">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>31328</label>
-			<onclick>ActivateWindow(Videos,RecentlyAddedMovies,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/recentlyaddedmovies.xml,return)</onclick>
 		</control>
 		<control type="button" id="90163">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>20434</label>
-			<onclick>ActivateWindow(Videos,MovieSets,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/movies/sets.xml,return)</onclick>
 			<visible>Library.HasContent(MovieSets)</visible>
 		</control>
 		<control type="button" id="90164">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>369</label>
-			<onclick>ActivateWindow(Videos,MovieTitles,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/movies/titles.xml,return)</onclick>
 		</control>
 		<control type="button" id="90165">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>135</label>
-			<onclick>ActivateWindow(Videos,MovieGenres,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/movies/genres.xml,return)</onclick>
 		</control>
 		<control type="button" id="90166">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>652</label>
-			<onclick>ActivateWindow(Videos,MovieYears,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/movies/years.xml,return)</onclick>
 		</control>
 		<control type="button" id="90167">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>344</label>
-			<onclick>ActivateWindow(Videos,MovieActors,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/movies/actors.xml,return)</onclick>
 		</control>
 		<control type="image" id="90168">
 			<width>35</width>
@@ -98,27 +98,27 @@
 		<control type="button" id="90172">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>31328</label>
-			<onclick>ActivateWindow(Videos,RecentlyAddedEpisodes,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/recentlyaddedepisodes.xml,return)</onclick>
 		</control>
 		<control type="button" id="90173">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>369</label>
-			<onclick>ActivateWindow(Videos,TVShowTitles,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/tvshows/titles.xml,return)</onclick>
 		</control>
 		<control type="button" id="90174">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>135</label>
-			<onclick>ActivateWindow(Videos,TVShowGenres,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/tvshows/genres.xml,return)</onclick>
 		</control>
 		<control type="button" id="90175">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>652</label>
-			<onclick>ActivateWindow(Videos,TVShowYears,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/tvshows/years.xml,return)</onclick>
 		</control>
 		<control type="button" id="90176">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>344</label>
-			<onclick>ActivateWindow(Videos,TVShowActors,return)</onclick>
+			<onclick>ActivateWindow(Videos,library://video/tvshows/actors.xml,return)</onclick>
 		</control>
 		<control type="image" id="90177">
 			<width>35</width>


### PR DESCRIPTION
This changes the onclick actions in the home (sub) menu to open the xml library nodes instead of forcing the built in library nodes. If a user edits the default node xmls the changes are now active also when entering the library directly from home, instead of having to go through the root library.
