### PR TITLE
[settings] fixed: set timezone during initialization

### DIFF
--- a/xbmc/linux/LinuxTimezone.cpp
+++ b/xbmc/linux/LinuxTimezone.cpp
@@ -170,6 +170,12 @@ void CLinuxTimezone::OnSettingChanged(const CSetting *setting)
   }
 }
 
+void CLinuxTimezone::OnSettingsLoaded()
+{
+  SetTimezone(CSettings::Get().GetString("locale.timezone"));
+  CDateTime::ResetTimezoneBias();
+}
+
 vector<CStdString> CLinuxTimezone::GetCounties()
 {
    return m_counties;

--- a/xbmc/linux/LinuxTimezone.h
+++ b/xbmc/linux/LinuxTimezone.h
@@ -22,18 +22,21 @@
  */
 
 #include "settings/lib/ISettingCallback.h"
+#include "settings/lib/ISettingsHandler.h"
 #include "utils/StdString.h"
 #include <vector>
 #include <map>
 
 class CSetting;
 
-class CLinuxTimezone : public ISettingCallback
+class CLinuxTimezone : public ISettingCallback, public ISettingsHandler
 {
 public:
    CLinuxTimezone();
 
    virtual void OnSettingChanged(const CSetting *setting);
+
+   virtual void OnSettingsLoaded();
 
    CStdString GetOSConfiguredTimezone();
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -468,6 +468,9 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingsHandler(&CWakeOnAccess::Get());
   m_settingsManager->UnregisterSettingsHandler(&CRssManager::Get());
   m_settingsManager->UnregisterSettingsHandler(&g_application);
+#if defined(TARGET_LINUX)
+  m_settingsManager->UnregisterSettingsHandler(&g_timezone);
+#endif
 
   m_initialized = false;
 }
@@ -976,6 +979,9 @@ void CSettings::InitializeISettingsHandlers()
   m_settingsManager->RegisterSettingsHandler(&CWakeOnAccess::Get());
   m_settingsManager->RegisterSettingsHandler(&CRssManager::Get());
   m_settingsManager->RegisterSettingsHandler(&g_application);
+#if defined(TARGET_LINUX)
+  m_settingsManager->RegisterSettingsHandler(&g_timezone);
+#endif
 }
 
 void CSettings::InitializeISubSettings()


### PR DESCRIPTION
This sets timezone during xbmc loading.
To reproduce the bug:
1. go to settings and set timezone to something different from system one, note the time changed on home screen.
2. restart xbmc.
3. note that time on home screen corresponds to system timezone, but not the selected one.
4. go to settings and reset timezone, note the time changed to selected timezone.
