### PR TITLE
Ensuring libbluray doesn't overwrite distro files on non-Darwin systems

### DIFF
--- a/lib/libbluray/Makefile
+++ b/lib/libbluray/Makefile
@@ -25,7 +25,7 @@ ifeq ($(OSTYPE),Darwin)
   LDFLAGS=-mmacosx-version-min=10.4 -isysroot /Developer/SDKs/MacOSX10.4u.sdk -L/opt/local/lib
   CPPFLAGS=-mmacosx-version-min=10.4 -isysroot /Developer/SDKs/MacOSX10.4u.sdk -I /opt/local/include
 else
-  prefix=/usr
+  prefix=/usr/local
 endif
 
 ifeq ($(OSTYPE),Darwin)


### PR DESCRIPTION
Currently, installing libbluray from the lib/ dir overwrites the distro libbluray-dev package (as of Ubuntu 12.04 LTS, anyway). Additionally, locally compiled packages should live in /usr/local, not /usr.
