### PR TITLE
[configure] get git revision from xbmc git root

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -759,7 +759,7 @@ AC_CHECK_PROG(HAVE_GIT,git,"yes","no",)
 if test "$GIT_REV" = ""; then
   if test -f VERSION ; then
     GIT_REV=$(awk 'END{print substr($1,1,16)}' VERSION)
-  elif test "$HAVE_GIT" = "yes"; then
+  elif test "$HAVE_GIT" = "yes" -a -d $(abs_top_srcdir)/.git; then
     GIT_REV=$(git --no-pager log --abbrev=7 -n 1 --pretty=format:"%h %ci" HEAD | awk '{gsub("-", "");print $2"-"$1}')
   else
     GIT_REV="Unknown"


### PR DESCRIPTION
It checks .git directory in order to set XBMC GIT_REV env var.
This fixes the case when XBMC is built by buildroot from *.mk file. In this case XBMC hasn't .git directory, so 'git log' returns commits from topmost repository which is buildroot.
