### PR TITLE
ignore articles when sorting lists in smartplaylist rule dialog

### DIFF
--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -325,7 +325,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   }
 
   // sort the items
-  items.Sort(SortByLabel, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrderAscending, SortAttributeIgnoreArticle);
 
   CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
   pDialog->Reset();


### PR DESCRIPTION
This fixes sorting of the lists (e.g. tags, sets or genres) provided in the smartplaylist rule editor to ignore articles like we do in the library as well. This was brought up in http://trac.xbmc.org/ticket/14815.
