### PR TITLE
Only show albums of the selected musicvideo artist

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -21,6 +21,7 @@
 #include "DirectoryNodeGrouped.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoDbUrl.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
@@ -68,7 +69,12 @@ bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
   if (itemType.empty())
     return false;
 
-  return videodatabase.GetItems(BuildPath(), (VIDEODB_CONTENT_TYPE)params.GetContentType(), itemType, items);
+  // make sure to translate all IDs in the path into URL parameters
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(BuildPath()))
+    return false;
+
+  return videodatabase.GetItems(videoUrl.ToString(), (VIDEODB_CONTENT_TYPE)params.GetContentType(), itemType, items);
 }
 
 std::string CDirectoryNodeGrouped::GetContentType() const

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -77,6 +77,7 @@ bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
 
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);
+    pItem->SetSpecialSort(SortSpecialOnTop);
     items.Add(pItem);
   }
 

--- a/xbmc/video/VideoDbUrl.cpp
+++ b/xbmc/video/VideoDbUrl.cpp
@@ -161,7 +161,13 @@ bool CVideoDbUrl::parse()
 
   // add options based on the QueryParams
   if (queryParams.GetActorId() != -1)
-    AddOption("actorid", (int)queryParams.GetActorId());
+  {
+    std::string optionName = "actorid";
+    if (m_type == "musicvideos")
+      optionName = "artistid";
+
+    AddOption(optionName, (int)queryParams.GetActorId());
+  }
   if (queryParams.GetAlbumId() != -1)
     AddOption("albumid", (int)queryParams.GetAlbumId());
   if (queryParams.GetCountryId() != -1)


### PR DESCRIPTION
This fixes the problem described in http://trac.xbmc.org/ticket/14333 that when accessing a specific musicvideo artist (either through the video library or the music library) all musicvideo albums are listed instead of just the ones from the the previously selected artist. The first three commits also fix special (and probably rare) cases which might be hit by specific smartplaylist filter rules.

The last commit makes sure that the order of the list in the musicvideo library node when accessed through the music library is the same as the default order in the video library. Right now it's alphabetical which IMO doesn't make much sense. This only happens when accessed through the music library because when accessed through the video library we use the custom library node defined in library://video/musicvideos/ instead of videodb://musicvideos/ which is used by the music library. I'm happy to drop the last commit if it isn't accepted for Gotham.
