### PR TITLE
don't combine strings in a label - fixes #14885

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9846,7 +9846,12 @@ msgctxt "#20321"
 msgid "Scanning albums using %s"
 msgstr ""
 
-#empty strings from id 20322 to 20323
+#empty string with id 20322
+
+#: xbmc/video/windows/GUIWindowVideoNav.cpp
+msgctxt "#20323"
+msgid "Movie plot"
+msgstr ""
 
 msgctxt "#20324"
 msgid "Play part..."

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -600,7 +600,6 @@ void CGUIWindowVideoNav::DoSearch(const CStdString& strSearch, CFileItemList& it
   CStdString strGenre = g_localizeStrings.Get(515); // Genre
   CStdString strActor = g_localizeStrings.Get(20337); // Actor
   CStdString strDirector = g_localizeStrings.Get(20339); // Director
-  CStdString strMovie = g_localizeStrings.Get(20338); // Movie
 
   //get matching names
   m_database.GetMoviesByName(strSearch, tempItems);
@@ -653,7 +652,7 @@ void CGUIWindowVideoNav::DoSearch(const CStdString& strSearch, CFileItemList& it
   AppendAndClearSearchItems(tempItems, "[" + g_localizeStrings.Get(20365) + "] ", items);
 
   m_database.GetMoviesByPlot(strSearch, tempItems);
-  AppendAndClearSearchItems(tempItems, "[" + strMovie + " " + g_localizeStrings.Get(207) + "] ", items);
+  AppendAndClearSearchItems(tempItems, "[" + g_localizeStrings.Get(20323) + "] ", items);
 }
 
 void CGUIWindowVideoNav::PlayItem(int iItem)


### PR DESCRIPTION
combining the string 'movie' and the string 'plot' to create a 'movie plot' label makes it difficult to translate it properly to certain languages.

fixes trac #14885
