### PR TITLE
peripherals: don't show notifications for new devices during the initial scan

### DIFF
--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -322,7 +322,9 @@ void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &p
 
   SetChanged();
 
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35005), peripheral.DeviceName());
+  // don't show a notification for devices detected during the initial scan
+  if (bus.IsInitialised())
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35005), peripheral.DeviceName());
 }
 
 void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral &peripheral)

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -148,6 +148,8 @@ namespace PERIPHERALS
 
     virtual bool FindComPort(CStdString &strLocation) { return false; }
 
+    virtual bool IsInitialised(void) const { return m_bInitialised; }
+
   protected:
     virtual void Process(void);
     virtual bool ScanForDevices(void);


### PR DESCRIPTION
This change gets rid of the "New device detected" notification on every start of xbmc when e.g. the nyxboard dongle is plugged in a USB port by simply supressing any "New device detected" notification during the initial peripheral scan. See http://forum.xbmc.org/showthread.php?tid=181803 for the complaints in the forum.
