### PR TITLE
The default subs service for tvshows/movies is allowed to be empty

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -796,6 +796,7 @@
           <default>-</default>
           <constraints>
             <addontype>xbmc.subtitle.module</addontype>
+            <allowempty>true</allowempty>
           </constraints>
           <control type="button" format="addon" />
         </setting>
@@ -804,6 +805,7 @@
           <default>-</default>
           <constraints>
             <addontype>xbmc.subtitle.module</addontype>
+            <allowempty>true</allowempty>
           </constraints>
           <control type="button" format="addon" />
         </setting>


### PR DESCRIPTION
Fixes #13135

@amet Any issues you see here?  (If "None" is set it'll just return no service, thus just use the first)
