### PR TITLE
Keep viewtype consistent for addons and remove view flickering on add-on launch

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -569,9 +569,15 @@ int CBuiltins::Execute(const CStdString& execString)
             parameters.insert(parameters.begin(), params.begin() + 1, params.end());
             urlParameters = "?" + StringUtils::JoinString(parameters, "&");
           }
+          else
+          {
+            // Add '/' if addon is run without params (will be removed later so it's safe)
+            // Otherwise there are 2 entries for the same plugin in ViewModesX.db
+            urlParameters = "/";
+          }
 
           if (plugin->Provides(CPluginSource::VIDEO))
-            cmd = StringUtils::Format("ActivateWindow(Video,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+            cmd = StringUtils::Format("ActivateWindow(Videos,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
           else if (plugin->Provides(CPluginSource::AUDIO))
             cmd = StringUtils::Format("ActivateWindow(Music,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
           else if (plugin->Provides(CPluginSource::EXECUTABLE))


### PR DESCRIPTION
Two small fixes:
1. Since XBMC adds a slash to add-ons if they are run from e.g. video add-ons, there are two different entries in the ViewModesX.db. By also adding a slash if an add-on is run via RunAddon / RunPlugin, there is just one entry.
2. There was some ugly flickering if an add-on was run via RunAddon etc. which was caused by `g_windowManager.ProcessRenderLoop()` in the `WaitOnScriptResult` method. Removing it fixed the issue. Everything works just fine but I don't know if there may be some special cases where it has to be there. -> https://github.com/xbmc/xbmc/pull/4189
