### PR TITLE
Add oninfo control action

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -160,7 +160,6 @@
   </LoginScreen>
   <Home>
     <keyboard>
-      <i>info</i>
       <end mod="ctrl">XBMC.ShutDown()</end>
     </keyboard>
   </Home>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -91,7 +91,6 @@
   </global>
   <Home>
     <remote>
-      <info>XBMC.ActivateWindow(SystemInfo)</info>
       <clear>XBMC.ActivateWindow(Weather)</clear>
       <hash>XBMC.ActivateWindow(Settings)</hash>
     </remote>

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -746,7 +746,14 @@ bool CGUIBaseContainer::OnClick(int actionID)
   }
   // Don't know what to do, so send to our parent window.
   CGUIMessage msg(GUI_MSG_CLICKED, GetID(), GetParentID(), actionID, subItem);
-  return SendWindowMessage(msg);
+  if (SendWindowMessage(msg))
+    return true;
+
+  // Return custom info action if there was no info action in our parent window
+  if (actionID == ACTION_SHOW_INFO)
+    return OnInfo();
+
+  return false;
 }
 
 CStdString CGUIBaseContainer::GetDescription() const

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -213,6 +213,9 @@ bool CGUIControl::OnAction(const CAction &action)
     case ACTION_NAV_BACK:
       return OnBack();
 
+    case ACTION_SHOW_INFO:
+      return OnInfo();
+
     case ACTION_NEXT_CONTROL:
       OnNextControl();
       return true;
@@ -259,6 +262,11 @@ void CGUIControl::OnRight()
 bool CGUIControl::OnBack()
 {
   return Navigate(ACTION_NAV_BACK);
+}
+
+bool CGUIControl::OnInfo()
+{
+  return Navigate(ACTION_SHOW_INFO);
 }
 
 void CGUIControl::OnNextControl()
@@ -457,13 +465,14 @@ CRect CGUIControl::CalcRenderRegion() const
   return CRect(tl.x, tl.y, br.x, br.y);
 }
 
-void CGUIControl::SetNavigation(int up, int down, int left, int right, int back)
+void CGUIControl::SetNavigation(int up, int down, int left, int right, int back, int info)
 {
   m_actionUp.SetNavigation(up);
   m_actionDown.SetNavigation(down);
   m_actionLeft.SetNavigation(left);
   m_actionRight.SetNavigation(right);
   m_actionBack.SetNavigation(back);
+  m_actionInfo.SetNavigation(info);
 }
 
 void CGUIControl::SetTabNavigation(int next, int prev)
@@ -474,13 +483,15 @@ void CGUIControl::SetTabNavigation(int next, int prev)
 
 void CGUIControl::SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
                                        const CGUIAction &left, const CGUIAction &right,
-                                       const CGUIAction &back, bool replace)
+                                       const CGUIAction &back, const CGUIAction &info,
+                                       bool replace)
 {
   if (!m_actionLeft.HasAnyActions()  || replace) m_actionLeft  = left;
   if (!m_actionRight.HasAnyActions() || replace) m_actionRight = right;
   if (!m_actionUp.HasAnyActions()    || replace) m_actionUp    = up;
   if (!m_actionDown.HasAnyActions()  || replace) m_actionDown  = down;
   if (!m_actionBack.HasAnyActions()  || replace) m_actionBack  = back;
+  if (!m_actionInfo.HasAnyActions()  || replace) m_actionInfo  = info;
 }
 
 void CGUIControl::SetNavigationAction(int direction, const CGUIAction &action, bool replace /*= true*/)
@@ -506,6 +517,9 @@ void CGUIControl::SetNavigationAction(int direction, const CGUIAction &action, b
   case ACTION_NAV_BACK:
     if (!m_actionBack.HasAnyActions() || replace)
       m_actionBack = action;
+  case ACTION_SHOW_INFO:
+    if (!m_actionInfo.HasAnyActions() || replace)
+      m_actionInfo = action;
     break;
   }
 }
@@ -918,6 +932,9 @@ bool CGUIControl::GetNavigationAction(int direction, CGUIAction& action) const
     return true;
   case ACTION_NAV_BACK:
     action = m_actionBack;
+    return true;
+  case ACTION_SHOW_INFO:
+    action = m_actionInfo;
     return true;
   default:
     return false;

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -102,6 +102,7 @@ public:
   virtual void OnLeft();
   virtual void OnRight();
   virtual bool OnBack();
+  virtual bool OnInfo();
   virtual void OnNextControl();
   virtual void OnPrevControl();
   virtual void OnFocus() {};
@@ -179,7 +180,7 @@ public:
    */
   virtual CRect CalcRenderRegion() const;
 
-  virtual void SetNavigation(int up, int down, int left, int right, int back = 0);
+  virtual void SetNavigation(int up, int down, int left, int right, int back = 0, int info = 0);
   virtual void SetTabNavigation(int next, int prev);
 
   /*! \brief Set actions to perform on navigation
@@ -194,13 +195,15 @@ public:
    */
   virtual void SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
                                     const CGUIAction &left, const CGUIAction &right,
-                                    const CGUIAction &back, bool replace = true);
+                                    const CGUIAction &back, const CGUIAction &info,
+                                    bool replace = true);
   void SetNavigationAction(int direction, const CGUIAction &action, bool replace = true);
   int GetControlIdUp() const { return m_actionUp.GetNavigation(); };
   int GetControlIdDown() const { return  m_actionDown.GetNavigation(); };
   int GetControlIdLeft() const { return m_actionLeft.GetNavigation(); };
   int GetControlIdRight() const { return m_actionRight.GetNavigation(); };
   int GetControlIdBack() const { return m_actionBack.GetNavigation(); };
+  int GetControlIdInfo() const { return m_actionInfo.GetNavigation(); };
   bool GetNavigationAction(int direction, CGUIAction& action) const;
   /*! \brief  Start navigating in given direction.
    */
@@ -321,6 +324,7 @@ protected:
   CGUIAction m_actionBack;
   CGUIAction m_actionNext;
   CGUIAction m_actionPrev;
+  CGUIAction m_actionInfo;
 
   float m_posX;
   float m_posY;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -677,7 +677,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   float width = 0, height = 0;
   float minHeight = 0, minWidth = 0;
 
-  CGUIAction leftActions, rightActions, upActions, downActions, backActions, nextActions, prevActions;
+  CGUIAction leftActions, rightActions, upActions, downActions, backActions, infoActions, nextActions, prevActions;
 
   int pageControl = 0;
   CGUIInfoColor colorDiffuse(0xFFFFFFFF);
@@ -829,6 +829,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetActions(pControlNode, "onnext",  nextActions);
   GetActions(pControlNode, "onprev",  prevActions);
   GetActions(pControlNode, "onback",  backActions);
+  GetActions(pControlNode, "oninfo",  infoActions);
 
   if (XMLUtils::GetInt(pControlNode, "defaultcontrol", defaultControl))
   {
@@ -1437,7 +1438,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     control->SetEnableCondition(enableCondition);
     control->SetAnimations(animations);
     control->SetColorDiffuse(colorDiffuse);
-    control->SetNavigationActions(upActions, downActions, leftActions, rightActions, backActions);
+    control->SetNavigationActions(upActions, downActions, leftActions, rightActions, backActions, infoActions);
     control->SetPulseOnSelect(bPulse);
     if (hasCamera)
       control->SetCamera(camera);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -292,6 +292,7 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
       control->SetNavigationAction(ACTION_MOVE_DOWN, m_actionDown, false);
     }
     control->SetNavigationAction(ACTION_NAV_BACK, m_actionBack, false);
+    control->SetNavigationAction(ACTION_SHOW_INFO, m_actionInfo, false);
 
     if (!m_useControlPositions)
       control->SetPosition(0,0);


### PR DESCRIPTION
This adds a new action `oninfo` for controls. The action will only be executed if there is no default info action, e.g. show movie information. Skinners will be able to do some nice things with it and won't need to sacrifice a navigation action (left, right, up, down).

Some examples:
- Show extended info for recently added lists on the home screen
- Open metadata actors info in the actors list
- Show application information in the advanced launcher add-on

Hope this will be added to Gotham.
