### PR TITLE
Controller button repeat rate made customisable

### DIFF
--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -364,9 +364,9 @@ bool CJoystick::GetHat(int &id, int &position,bool consider_repeat)
       return true;
     }
     nowTicks = SDL_GetTicks();
-    if ((nowTicks-m_pressTicksHat)<500) // 500ms delay before we repeat
+    if ((nowTicks-m_pressTicksHat)<g_advancedSettings.m_buttonFirstTickRate) // Delay before we repeat, default 500ms, can be set in advancedsettings.xml
       return false;
-    if ((nowTicks-lastTicks)<100) // 100ms delay before successive repeats
+    if ((nowTicks-lastTicks)<g_advancedSettings.m_buttonConsecutiveTicksRate) // Delay before successive repeats, default 100ms, can be set in advancedsettings.xml
       return false;
 
     lastTicks = nowTicks;
@@ -402,11 +402,11 @@ bool CJoystick::GetButton(int &id, bool consider_repeat)
       return true;
     }
     nowTicks = SDL_GetTicks();
-    if ((nowTicks-m_pressTicksButton)<500) // 500ms delay before we repeat
+    if ((nowTicks-m_pressTicksButton)<g_advancedSettings.m_buttonFirstTickRate) // Delay before we repeat, default 500ms, can be set in advancedsettings.xml
     {
       return false;
     }
-    if ((nowTicks-lastTicks)<100) // 100ms delay before successive repeats
+    if ((nowTicks-lastTicks)<g_advancedSettings.m_buttonConsecutiveTicksRate) // Delay before successive repeats, default 100ms, can be set in advancedsettings.xml
     {
       return false;
     }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -249,6 +249,8 @@ void CAdvancedSettings::Initialize()
 
   m_remoteDelay = 3;
   m_controllerDeadzone = 0.2f;
+  m_buttonFirstTickRate = 500;
+  m_buttonConsecutiveTicksRate = 100;
 
   m_playlistAsFolders = true;
   m_detectAsUdf = false;
@@ -1037,6 +1039,14 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
 
   XMLUtils::GetInt(pRootElement, "remotedelay", m_remoteDelay, 1, 20);
   XMLUtils::GetFloat(pRootElement, "controllerdeadzone", m_controllerDeadzone, 0.0f, 1.0f);
+
+  pElement = pRootElement->FirstChildElement("buttontickrate");
+  if (pElement)
+  {
+    XMLUtils::GetInt(pElement, "firsttick", m_buttonFirstTickRate, 5, 5000);
+    XMLUtils::GetInt(pElement, "consecutiveticks", m_buttonConsecutiveTicksRate, 5, 5000);
+    }
+
   XMLUtils::GetUInt(pRootElement, "fanartres", m_fanartRes, 0, 1080);
   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 1080);
 #if !defined(TARGET_RASPBERRY_PI)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -237,6 +237,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     StringMapping m_pathSubstitutions;
     int m_remoteDelay; ///< \brief number of remote messages to ignore before repeating
     float m_controllerDeadzone;
+    int m_buttonFirstTickRate;
+    int m_buttonConsecutiveTicksRate;
 
     bool m_playlistAsFolders;
     bool m_detectAsUdf;


### PR DESCRIPTION
Added code which now allows the controller button repeat tick rate to be modified through the use of advancedsettings.xml file.

The default tick rate remains unchanged (500ms for initial button repeat, 100ms for subsequent repeats).

To change the button repeat rate add the following code to the advancedsetting.xml.

> <advancedsettings>
>       <buttontickrate>
>              <firsttick>#VALUE</firsttick>
>              <consecutiveticks>#VALUE</consecutiveticks>
>       </buttontickrate>
> </advancedsettings>

Where #VALUE is the time in milliseconds and can be between 5 and 5000
