### PR TITLE
Fix empty player art when playing songs from favourites...

### DIFF
--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -29,6 +29,7 @@
 #include "utils/URIUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "video/VideoInfoTag.h"
+#include "music/tags/MusicInfoTag.h"
 #include "URL.h"
 
 namespace XFILE
@@ -201,6 +202,8 @@ CStdString CFavouritesDirectory::GetExecutePath(const CFileItem &item, const std
   {
     if (item.IsVideoDb() && item.HasVideoInfoTag())
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
+    else if (item.IsMusicDb() && item.HasMusicInfoTag())
+      execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()).c_str());
     else
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetPath()).c_str());
   }


### PR DESCRIPTION
... or when playing songs from lists with directory content as mentioned in #4094 by adding full path to favourites for songs instead of musicdb path. 

before:
`<favourite name="song" thumb="folder.jpg">PlayMedia(&quot;musicdb://songs/1456.flac&quot;)</favourite>`
after:
`<favourite name="song" thumb="folder.jpg">PlayMedia(&quot;smb://<music_share>/<track>.flac&quot;)</favourite>`
