### PR TITLE
Activeae fix reliance on settings that may not be correct

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -961,6 +961,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
     AEAudioFormat outputFormat;
     if (m_mode == MODE_RAW)
     {
+      inputFormat.m_frames = m_sinkFormat.m_frames;
       outputFormat = inputFormat;
       sinkInputFormat = m_sinkFormat;
     }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2034,6 +2034,8 @@ void CActiveAE::LoadSettings()
   m_settings.guisoundmode = CSettings::Get().GetInt("audiooutput.guisoundmode");
 
   m_settings.passthrough = m_settings.config == AE_CONFIG_FIXED ? false : CSettings::Get().GetBool("audiooutput.passthrough");
+  if (!m_sink.HasPassthroughDevice())
+    m_settings.passthrough = false;
   m_settings.ac3passthrough = CSettings::Get().GetBool("audiooutput.ac3passthrough");
   m_settings.ac3transcode = CSettings::Get().GetBool("audiooutput.ac3transcode");
   m_settings.eac3passthrough = CSettings::Get().GetBool("audiooutput.eac3passthrough");

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -118,7 +118,7 @@ void CActiveAEStream::InitRemapper()
       for(unsigned int j=0; j<m_format.m_channelLayout.Count(); j++)
       {
         idx = m_remapper->GetAVChannelIndex(m_format.m_channelLayout[j], avLayout);
-        if (idx == i)
+        if (idx == (int)i)
         {
           ffmpegLayout += m_format.m_channelLayout[j];
           break;
@@ -134,7 +134,7 @@ void CActiveAEStream::InitRemapper()
       for(unsigned int j=0; j<m_format.m_channelLayout.Count(); j++)
       {
         idx = m_remapper->GetAVChannelIndex(m_format.m_channelLayout[j], avLayout);
-        if (idx == i)
+        if (idx == (int)i)
         {
           remapLayout += ffmpegLayout[j];
           break;


### PR DESCRIPTION
While working on the darwin sink for OSX, I found an issue where we rely on settings when they may not be correct.  To reproduce, simply hook a laptop up to a device with passthrough and switch to that device.

Then unplug and restart XBMC: The passthrough setting will still be set, even though no devices allow passthrough.  The user can't fix this as the setting is (correctly) hidden.

This won't fix every case - e.g. it may be that the sink selects a device other than passthrough in a particular case, but it's better than nothing maybe?

@FernetMenta: Please feel free to school me onto where to fix it properly ;)

Second commit is a simple compile warning (signed vs unsigned) fix.
