### PR TITLE
jsonrpc: fix mixup of "rating" and "parentalrating" for PVR broadcasts

### DIFF
--- a/addons/xbmc.json/addon.xml
+++ b/addons/xbmc.json/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.json" version="6.13.4" provider-name="Team XBMC">
+<addon id="xbmc.json" version="6.13.5" provider-name="Team XBMC">
   <backwards-compatibility abi="6.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -204,6 +204,7 @@ CEpgInfoTag &CEpgInfoTag::operator =(const CEpgInfoTag &other)
 void CEpgInfoTag::Serialize(CVariant &value) const
 {
   value["broadcastid"] = m_iUniqueBroadcastID;
+  value["parentalrating"] = m_iParentalRating;
   value["rating"] = m_iStarRating;
   value["title"] = m_strTitle;
   value["plotoutline"] = m_strPlotOutline;

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.13.4";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.13.5";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -826,7 +826,7 @@ namespace JSONRPC
                   "\"endtime\", \"runtime\", \"progress\", \"progresspercentage\","
                   "\"genre\", \"episodename\", \"episodenum\", \"episodepart\","
                   "\"firstaired\", \"hastimer\", \"isactive\", \"parentalrating\","
-                  "\"wasactive\", \"thumbnail\" ]"
+                  "\"wasactive\", \"thumbnail\", \"rating\" ]"
       "}"
     "}",
     "\"PVR.Details.Broadcast\": {"
@@ -848,9 +848,10 @@ namespace JSONRPC
         "\"firstaired\": { \"type\": \"string\" },"
         "\"hastimer\": { \"type\": \"boolean\" },"
         "\"isactive\": { \"type\": \"boolean\" },"
-        "\"rating\": { \"type\": \"integer\" },"
+        "\"parentalrating\": { \"type\": \"integer\" },"
         "\"wasactive\": { \"type\": \"boolean\" },"
-        "\"thumbnail\": { \"type\": \"string\" }"
+        "\"thumbnail\": { \"type\": \"string\" },"
+        "\"rating\": { \"type\": \"integer\" }"
       "}"
     "}",
     "\"Textures.Details.Size\": {"

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -799,7 +799,7 @@
                 "endtime", "runtime", "progress", "progresspercentage",
                 "genre", "episodename", "episodenum", "episodepart",
                 "firstaired", "hastimer", "isactive", "parentalrating",
-                "wasactive", "thumbnail" ]
+                "wasactive", "thumbnail", "rating" ]
     }
   },
   "PVR.Details.Broadcast": {
@@ -821,9 +821,10 @@
       "firstaired": { "type": "string" },
       "hastimer": { "type": "boolean" },
       "isactive": { "type": "boolean" },
-      "rating": { "type": "integer" },
+      "parentalrating": { "type": "integer" },
       "wasactive": { "type": "boolean" },
-      "thumbnail": { "type": "string" }
+      "thumbnail": { "type": "string" },
+      "rating": { "type": "integer" }
     }
   },
   "Textures.Details.Size": {


### PR DESCRIPTION
This fixes a mixup in the JSON-RPC API for PVR reported by @Tolriq where as a property for EPG items only "parentalrating" could be requested but only "rating" was part of the available properties even though both exist.
