### PR TITLE
fix multithreaded make

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -549,7 +549,7 @@ lib/ffmpeg/libswscale/libswscale.a: ffmpeg
 ffmpeg: force
 	$(MAKE) -C lib/ffmpeg
 
-xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS) xbmc/main/main.a
+xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)
 
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -o xbmc.bin xbmc/main/main.a -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS) -rdynamic

--- a/Makefile.in
+++ b/Makefile.in
@@ -538,6 +538,17 @@ endif
 xbmc/main/main.a: force
 	$(MAKE) -C xbmc/main
 
+lib/ffmpeg/libavcodec/libavcodec.a: ffmpeg 
+lib/ffmpeg/libavfilter/libavfilter.a: ffmpeg
+lib/ffmpeg/libswresample/libswresample.a: ffmpeg
+lib/ffmpeg/libavformat/libavformat.a: ffmpeg
+lib/ffmpeg/libavutil/libavutil.a: ffmpeg
+lib/ffmpeg/libpostproc/libpostproc.a: ffmpeg
+lib/ffmpeg/libswscale/libswscale.a: ffmpeg
+
+ffmpeg: force
+	$(MAKE) -C lib/ffmpeg
+
 xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS) xbmc/main/main.a
 
 ifeq ($(findstring osx,@ARCH@), osx)


### PR DESCRIPTION
this is supposed to fix a race in our Makefile, which can result in Errors like:
CPP     xbmc/utils/XBMCTinyXML.o
AR      xbmc/pvr/windows/pvrwindows.a
make[2]: Leaving directory `/build/buildd/xbmc-13.0~git20140203.0211-848b0c3/xbmc/pvr/windows'
CPP     xbmc/utils/XMLUtils.o
make[1]: *** No rule to make target`lib/ffmpeg/libavcodec/libavcodec.a', needed by `xbmc.bin'.  Stop.
make[1]: **\* Waiting for unfinished jobs....

@t-nelson: ping
