### PR TITLE
Fix for bug 14899

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1375,6 +1375,8 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     if (window)
     {
       CFileItemPtr item = window->GetCurrentListItem();
+      if (item && info >= LISTITEM_PICTURE_START && info <= LISTITEM_PICTURE_END && item->IsPicture() && !item->HasPictureInfoTag())
+        item->GetPictureInfoTag()->Load(item->GetPath());
       strLabel = GetItemLabel(item.get(), info, fallback);
     }
 


### PR DESCRIPTION
This is a fix for bug 14899 -  http://trac.xbmc.org/ticket/14899
When asking for Picture InfoLabels, the information is not available until it has been loaded from the exif and iptc tags in a file. When a list of pictures is built, the info is not loaded, so the $INFO[ListItem.Picture...] labels will be blank, until some other mechanism loads the info from the file. The tags should not be loaded when the list is built, as this could be a very big performance hit for large picture lists. However, once the list of pictures is displayed, I think the info should be available for the currently selected picture. This fix implements logic so that if Picture... Info is requested for a currently selected ListItem, and the ListItem is a picture, and the tags have not yet been loaded, then the tags will be loaded from the file before the info is retrieved.
Need for this fix is in http://forum.xbmc.org/showthread.php?tid=184976
