### PR TITLE
Cache font vertices, GPU-side when possible

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -168,6 +168,9 @@
 		1D638128161E211E003603ED /* PeripheralImon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D638126161E211E003603ED /* PeripheralImon.cpp */; };
 		1DAFDB7C16DFDCA7007F8C68 /* PeripheralBusCEC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DAFDB7A16DFDCA7007F8C68 /* PeripheralBusCEC.cpp */; };
 		1DE0443515828F4B005DDB4D /* Exception.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DE0443315828F4B005DDB4D /* Exception.cpp */; };
+		2F4564D51970129A00396109 /* GUIFontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F4564D31970129A00396109 /* GUIFontCache.cpp */; };
+		2F4564D61970129A00396109 /* GUIFontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F4564D31970129A00396109 /* GUIFontCache.cpp */; };
+		2F4564D71970129A00396109 /* GUIFontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F4564D31970129A00396109 /* GUIFontCache.cpp */; };
 		32C631281423A90F00F18420 /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32C631261423A90F00F18420 /* JpegIO.cpp */; };
 		36A9443D15821E2800727135 /* DatabaseUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9443B15821E2800727135 /* DatabaseUtils.cpp */; };
 		36A9444115821E7C00727135 /* SortUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9443F15821E7C00727135 /* SortUtils.cpp */; };
@@ -4024,6 +4027,8 @@
 		1DAFDB7B16DFDCA7007F8C68 /* PeripheralBusCEC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PeripheralBusCEC.h; sourceTree = "<group>"; };
 		1DE0443315828F4B005DDB4D /* Exception.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Exception.cpp; path = commons/Exception.cpp; sourceTree = "<group>"; };
 		1DE0443415828F4B005DDB4D /* Exception.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Exception.h; path = commons/Exception.h; sourceTree = "<group>"; };
+		2F4564D31970129A00396109 /* GUIFontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIFontCache.cpp; sourceTree = "<group>"; };
+		2F4564D41970129A00396109 /* GUIFontCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIFontCache.h; sourceTree = "<group>"; };
 		32C631261423A90F00F18420 /* JpegIO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JpegIO.cpp; sourceTree = "<group>"; };
 		32C631271423A90F00F18420 /* JpegIO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JpegIO.h; sourceTree = "<group>"; };
 		36A9443B15821E2800727135 /* DatabaseUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseUtils.cpp; sourceTree = "<group>"; };
@@ -6543,6 +6548,8 @@
 				18B7C7101294222D009E7A26 /* GUIFixedListContainer.h */,
 				18B7C76B1294222E009E7A26 /* GUIFont.cpp */,
 				18B7C7111294222D009E7A26 /* GUIFont.h */,
+				2F4564D31970129A00396109 /* GUIFontCache.cpp */,
+				2F4564D41970129A00396109 /* GUIFontCache.h */,
 				18B7C76C1294222E009E7A26 /* GUIFontManager.cpp */,
 				18B7C7121294222D009E7A26 /* GUIFontManager.h */,
 				18B7C76D1294222E009E7A26 /* GUIFontTTF.cpp */,
@@ -11055,6 +11062,7 @@
 				7C5608C70F1754930056433A /* ExternalPlayer.cpp in Sources */,
 				F584E12E0F257C5100DB26A5 /* HTTPDirectory.cpp in Sources */,
 				F54C51D20F1E783200D46E3C /* GUIDialogKaraokeSongSelector.cpp in Sources */,
+				2F4564D51970129A00396109 /* GUIFontCache.cpp in Sources */,
 				F54C51D50F1E784800D46E3C /* karaokelyricscdg.cpp in Sources */,
 				F54C51D80F1E785700D46E3C /* karaokelyrics.cpp in Sources */,
 				F54C51E50F1E787700D46E3C /* karaokelyricstextkar.cpp in Sources */,
@@ -12731,6 +12739,7 @@
 				DFF0F45B17528350002DA3A4 /* Control.cpp in Sources */,
 				DFF0F45C17528350002DA3A4 /* Dialog.cpp in Sources */,
 				DFF0F45D17528350002DA3A4 /* File.cpp in Sources */,
+				2F4564D71970129A00396109 /* GUIFontCache.cpp in Sources */,
 				DFF0F45E17528350002DA3A4 /* InfoTagMusic.cpp in Sources */,
 				DFF0F45F17528350002DA3A4 /* InfoTagVideo.cpp in Sources */,
 				DFF0F46017528350002DA3A4 /* Keyboard.cpp in Sources */,
@@ -13529,6 +13538,7 @@
 				E499131D174E5DAD00741B6D /* GUIVisualisationControl.cpp in Sources */,
 				E499131E174E5DAD00741B6D /* GUIWindow.cpp in Sources */,
 				E499131F174E5DAD00741B6D /* GUIWindowManager.cpp in Sources */,
+				2F4564D61970129A00396109 /* GUIFontCache.cpp in Sources */,
 				E4991320174E5DAD00741B6D /* GUIWrappingListContainer.cpp in Sources */,
 				E4991321174E5DAD00741B6D /* imagefactory.cpp in Sources */,
 				E4991322174E5DAD00741B6D /* IWindowManagerCallback.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -434,6 +434,7 @@
     <ClCompile Include="..\..\xbmc\guilib\GUIFadeLabelControl.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GUIFixedListContainer.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GUIFont.cpp" />
+    <ClCompile Include="..\..\xbmc\guilib\GUIFontCache.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GUIFontManager.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GUIFontTTF.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GUIFontTTFDX.cpp" />
@@ -1744,6 +1745,7 @@
     <ClInclude Include="..\..\xbmc\guilib\GUIFadeLabelControl.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIFixedListContainer.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIFont.h" />
+    <ClInclude Include="..\..\xbmc\guilib\GUIFontCache.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIFontManager.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIFontTTF.h" />
     <ClInclude Include="..\..\xbmc\guilib\GUIFontTTFDX.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -988,6 +988,9 @@
     <ClCompile Include="..\..\xbmc\guilib\GUIFont.cpp">
       <Filter>guilib</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\guilib\GUIFontCache.cpp">
+      <Filter>guilib</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\guilib\GUIFontManager.cpp">
       <Filter>guilib</Filter>
     </ClCompile>
@@ -3865,6 +3868,9 @@
       <Filter>guilib</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\guilib\GUIFont.h">
+      <Filter>guilib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\guilib\GUIFontCache.h">
       <Filter>guilib</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\guilib\GUIFontManager.h">

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -109,18 +109,14 @@ void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &d
     bool moveToNextLabel = false;
     if (!m_scrollOut)
     {
-      vecText text;
-      m_textLayout.GetFirstText(text);
-      if (m_scrollInfo.characterPos && m_scrollInfo.characterPos < text.size())
-        text.erase(text.begin(), text.begin() + min((int)m_scrollInfo.characterPos - 1, (int)text.size()));
-      if (m_label.font->GetTextWidth(text) < m_width)
+      if (m_scrollInfo.pixelPos + m_width > m_scrollInfo.m_textWidth)
       {
         if (m_fadeAnim.GetProcess() != ANIM_PROCESS_NORMAL)
           m_fadeAnim.QueueAnimation(ANIM_PROCESS_NORMAL);
         moveToNextLabel = true;
       }
     }
-    else if (m_scrollInfo.characterPos > m_textLayout.GetTextLength())
+    else if (m_scrollInfo.pixelPos > m_scrollInfo.m_textWidth)
       moveToNextLabel = true;
     
     // apply the fading animation

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -36,7 +36,12 @@ CScrollInfo::CScrollInfo(unsigned int wait /* = 50 */, float pos /* = 0 */,
     initialWait = wait;
     initialPos = pos;
     SetSpeed(speed ? speed : defaultSpeed);
-    g_charsetConverter.utf8ToW(scrollSuffix, suffix);
+    std::wstring wsuffix;
+    g_charsetConverter.utf8ToW(scrollSuffix, wsuffix);
+    suffix.clear();
+    suffix.reserve(wsuffix.size());
+    for (vecText::size_type i = 0; i < wsuffix.size(); i++)
+      suffix.push_back(wsuffix[i]);
     Reset();
 }
 
@@ -115,11 +120,12 @@ bool CGUIFont::UpdateScrollInfo(const vecText &text, CScrollInfo &scrollInfo)
 {
   // draw at our scroll position
   // we handle the scrolling as follows:
-  //   We scroll on a per-pixel basis up until we have scrolled the first character outside
-  //   of our viewport, whereby we cycle the string around, and reset the scroll position.
-  //
-  //   pixelPos is the amount in pixels to move the string by.
-  //   characterPos is the amount in characters to rotate the string by.
+  //   We scroll on a per-pixel basis (eschewing the use of character indices
+  //   which were also in use previously). The complete string, including suffix,
+  //   is plotted to achieve the desired effect - normally just the one time, but
+  //   if there is a wrap point within the viewport then it will be plotted twice.
+  //   If the string is smaller than the viewport, then it may be plotted even
+  //   more times than that.
   //
   if (scrollInfo.waitTime)
   {
@@ -135,54 +141,19 @@ bool CGUIFont::UpdateScrollInfo(const vecText &text, CScrollInfo &scrollInfo)
   // move along by the appropriate scroll amount
   float scrollAmount = fabs(scrollInfo.GetPixelsPerFrame() * g_graphicsContext.GetGUIScaleX());
 
-  if (scrollInfo.pixelSpeed > 0)
+  if (!scrollInfo.m_widthValid)
   {
-    // we want to move scrollAmount, grab the next character
-    float charWidth = GetCharWidth(scrollInfo.GetCurrentChar(text));
-    if (scrollInfo.pixelPos + scrollAmount < charWidth)
-      scrollInfo.pixelPos += scrollAmount;  // within the current character
-    else
-    { // past the current character, decrement scrollAmount by the charWidth and move to the next character
-      while (scrollInfo.pixelPos + scrollAmount >= charWidth)
-      {
-        scrollAmount -= (charWidth - scrollInfo.pixelPos);
-        scrollInfo.pixelPos = 0;
-        scrollInfo.characterPos++;
-        if (scrollInfo.characterPos >= text.size() + scrollInfo.suffix.size())
-        {
-          scrollInfo.Reset();
-          break;
-        }
-        charWidth = GetCharWidth(scrollInfo.GetCurrentChar(text));
-      }
-    }
+    /* Calculate the pixel width of the complete string */
+    scrollInfo.m_textWidth = GetTextWidth(text);
+    scrollInfo.m_totalWidth = scrollInfo.m_textWidth + GetTextWidth(scrollInfo.suffix);
+    scrollInfo.m_widthValid = true;
   }
-  else if (scrollInfo.pixelSpeed < 0)
-  { // scrolling backwards
-    // we want to move scrollAmount, grab the next character
-    float charWidth = GetCharWidth(scrollInfo.GetCurrentChar(text));
-    if (scrollInfo.pixelPos + scrollAmount < charWidth)
-      scrollInfo.pixelPos += scrollAmount;  // within the current character
-    else
-    { // past the current character, decrement scrollAmount by the charWidth and move to the next character
-      while (scrollInfo.pixelPos + scrollAmount >= charWidth)
-      {
-        scrollAmount -= (charWidth - scrollInfo.pixelPos);
-        scrollInfo.pixelPos = 0;
-        if (scrollInfo.characterPos == 0)
-        {
-          scrollInfo.Reset();
-          scrollInfo.characterPos = text.size() + scrollInfo.suffix.size() - 1;
-          break;
-        }
-        scrollInfo.characterPos--;
-        charWidth = GetCharWidth(scrollInfo.GetCurrentChar(text));
-      }
-    }
-  }
+  scrollInfo.pixelPos += scrollAmount;
+  assert(scrollInfo.m_totalWidth != 0);
+  while (scrollInfo.pixelPos >= scrollInfo.m_totalWidth)
+    scrollInfo.pixelPos -= scrollInfo.m_totalWidth;
 
-  if(scrollInfo.characterPos != old.characterPos
-  || scrollInfo.pixelPos     != old.pixelPos)
+  if (scrollInfo.pixelPos != old.pixelPos)
     return true;
   else
     return false;
@@ -194,39 +165,27 @@ void CGUIFont::DrawScrollingText(float x, float y, const vecColors &colors, colo
   if (!m_font) return;
   if (!shadowColor) shadowColor = m_shadowColor;
 
-  float spaceWidth = GetCharWidth(L' ');
-  // max chars on screen + extra margin chars
-  vecText::size_type maxChars =
-    std::min<vecText::size_type>(
-      (text.size() + (vecText::size_type)scrollInfo.suffix.size()),
-      (vecText::size_type)((maxWidth * 1.05f) / spaceWidth));
-
   if (!text.size() || ClippedRegionIsEmpty(x, y, maxWidth, alignment))
     return; // nothing to render
 
-  maxWidth = ROUND((maxWidth + scrollInfo.pixelPos) / g_graphicsContext.GetGUIScaleX());
+  if (!scrollInfo.m_widthValid)
+  {
+    /* Calculate the pixel width of the complete string */
+    scrollInfo.m_textWidth = GetTextWidth(text);
+    scrollInfo.m_totalWidth = scrollInfo.m_textWidth + GetTextWidth(scrollInfo.suffix);
+    scrollInfo.m_widthValid = true;
+  }
 
-  float charWidth = GetCharWidth(scrollInfo.GetCurrentChar(text));
+  assert(scrollInfo.m_totalWidth != 0);
+
+  float textPixelWidth = ROUND(scrollInfo.m_textWidth / g_graphicsContext.GetGUIScaleX());
+  float suffixPixelWidth = ROUND((scrollInfo.m_totalWidth - scrollInfo.m_textWidth) / g_graphicsContext.GetGUIScaleX());
+
   float offset;
   if(scrollInfo.pixelSpeed >= 0)
     offset = scrollInfo.pixelPos;
   else
-    offset = charWidth - scrollInfo.pixelPos;
-
-  // Now rotate our string as needed, only take a slightly larger then visible part of the text.
-  unsigned int pos = scrollInfo.characterPos;
-  vecText renderText;
-  renderText.reserve(maxChars);
-  for (vecText::size_type i = 0; i < maxChars; i++)
-  {
-    if (pos >= text.size() + scrollInfo.suffix.size())
-      pos = 0;
-    if (pos < text.size())
-      renderText.push_back(text[pos]);
-    else
-      renderText.push_back(scrollInfo.suffix[pos - text.size()]);
-    pos++;
-  }
+    offset = scrollInfo.m_totalWidth - scrollInfo.pixelPos;
 
   vecColors renderColors;
   for (unsigned int i = 0; i < colors.size(); i++)
@@ -239,9 +198,17 @@ void CGUIFont::DrawScrollingText(float x, float y, const vecColors &colors, colo
     vecColors shadowColors;
     for (unsigned int i = 0; i < renderColors.size(); i++)
       shadowColors.push_back((renderColors[i] & 0xff000000) != 0 ? shadowColor : 0);
-    m_font->DrawTextInternal(x - offset + 1, y + 1, shadowColors, renderText, alignment, maxWidth + m_font->GetLineHeight(2.0f), scroll);
+    for (float dx = -offset; dx < maxWidth; dx += scrollInfo.m_totalWidth)
+    {
+      m_font->DrawTextInternal(x + dx + 1, y + 1, shadowColors, text, alignment, textPixelWidth, scroll);
+      m_font->DrawTextInternal(x + dx + scrollInfo.m_textWidth + 1, y + 1, shadowColors, scrollInfo.suffix, alignment, suffixPixelWidth, scroll);
+    }
   }
-  m_font->DrawTextInternal(x - offset, y, renderColors, renderText, alignment, maxWidth + m_font->GetLineHeight(2.0f), scroll);
+  for (float dx = -offset; dx < maxWidth; dx += scrollInfo.m_totalWidth)
+  {
+    m_font->DrawTextInternal(x + dx, y, renderColors, text, alignment, textPixelWidth, scroll);
+    m_font->DrawTextInternal(x + dx + scrollInfo.m_textWidth, y, renderColors, scrollInfo.suffix, alignment, suffixPixelWidth, scroll);
+  }
 
   g_graphicsContext.RestoreClipRegion();
 }

--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -67,7 +67,6 @@ public:
   void Reset()
   {
     waitTime = initialWait;
-    characterPos = 0;
     // pixelPos is where we start the current letter, so is measured
     // to the left of the text rendering's left edge.  Thus, a negative
     // value will mean the text starts to the right
@@ -75,25 +74,19 @@ public:
     // privates:
     m_averageFrameTime = 1000.f / fabs((float)defaultSpeed);
     m_lastFrameTime = 0;
-  }
-  uint32_t GetCurrentChar(const vecText &text) const
-  {
-    assert(text.size());
-    if (characterPos < text.size())
-      return text[characterPos];
-    else if (characterPos < text.size() + suffix.size())
-      return suffix[characterPos - text.size()];
-    return text[0];
+    m_widthValid = false;
   }
   float GetPixelsPerFrame();
 
   float pixelPos;
   float pixelSpeed;
   unsigned int waitTime;
-  unsigned int characterPos;
   unsigned int initialWait;
   float initialPos;
-  std::wstring suffix;
+  vecText suffix;
+  mutable float m_textWidth;
+  mutable float m_totalWidth;
+  mutable bool m_widthValid;
 
   static const int defaultSpeed = 60;
 private:

--- a/xbmc/guilib/GUIFontCache.cpp
+++ b/xbmc/guilib/GUIFontCache.cpp
@@ -84,6 +84,9 @@ Value &CGUIFontCache<Position, Value>::Lookup(Position &pos,
   else
   {
     /* Cache hit */
+    /* Update the translation arguments so that they hold the offset to apply
+     * to the cached values (but only in the dynamic case) */
+    pos.UpdateWithOffsets(i->m_key.m_pos, scrolling);
     /* Update time in entry and move to the back of the list */
     i->m_lastUsedMillis = nowMillis;
     m_list.template get<Age>().relocate(m_list.template get<Age>().end(), m_list.template project<Age>(i));
@@ -102,3 +105,8 @@ template void CGUIFontCacheEntry<CGUIFontCacheStaticPosition, CGUIFontCacheStati
 template CGUIFontCacheEntry<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::~CGUIFontCacheEntry();
 template CGUIFontCacheStaticValue &CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Lookup(CGUIFontCacheStaticPosition &, const vecColors &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
 template void CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Flush();
+
+template void CGUIFontCacheEntry<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Reassign::operator()(CGUIFontCacheEntry<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue> &entry);
+template CGUIFontCacheEntry<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::~CGUIFontCacheEntry();
+template CGUIFontCacheDynamicValue &CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Lookup(CGUIFontCacheDynamicPosition &, const vecColors &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
+template void CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Flush();

--- a/xbmc/guilib/GUIFontCache.cpp
+++ b/xbmc/guilib/GUIFontCache.cpp
@@ -1,0 +1,104 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdint.h>
+#include <vector>
+#include "GUIFontTTF.h"
+#include "GraphicContext.h"
+
+template<class Position, class Value>
+void CGUIFontCacheEntry<Position, Value>::Reassign::operator()(CGUIFontCacheEntry<Position, Value> &entry)
+{
+  entry.m_key.m_pos = m_key.m_pos;
+  entry.m_key.m_colors.assign(m_key.m_colors.begin(), m_key.m_colors.end());
+  entry.m_key.m_text.assign(m_key.m_text.begin(), m_key.m_text.end());
+  entry.m_key.m_alignment = m_key.m_alignment;
+  entry.m_key.m_maxPixelWidth = m_key.m_maxPixelWidth;
+  entry.m_key.m_scrolling = m_key.m_scrolling;
+  entry.m_matrix = m_key.m_matrix;
+  entry.m_key.m_scaleX = m_key.m_scaleX;
+  entry.m_key.m_scaleY = m_key.m_scaleY;
+
+  entry.m_lastUsedMillis = m_nowMillis;
+  entry.m_value.clear();
+}
+
+template<class Position, class Value>
+CGUIFontCacheEntry<Position, Value>::~CGUIFontCacheEntry()
+{
+  delete &m_key.m_colors;
+  delete &m_key.m_text;
+  m_value.clear();
+}
+
+template<class Position, class Value>
+Value &CGUIFontCache<Position, Value>::Lookup(Position &pos,
+                                              const vecColors &colors, const vecText &text,
+                                              uint32_t alignment, float maxPixelWidth,
+                                              bool scrolling,
+                                              unsigned int nowMillis, bool &dirtyCache)
+{
+  const CGUIFontCacheKey<Position> key(pos,
+                                       const_cast<vecColors &>(colors), const_cast<vecText &>(text),
+                                       alignment, maxPixelWidth,
+                                       scrolling, g_graphicsContext.GetGUIMatrix(),
+                                       g_graphicsContext.GetGUIScaleX(), g_graphicsContext.GetGUIScaleY());
+  EntryHashIterator i = m_list.template get<Hash>().find(key);
+  if (i == m_list.template get<Hash>().end())
+  {
+    /* Cache miss */
+    EntryAgeIterator oldest = m_list.template get<Age>().begin();
+    if (!m_list.template get<Age>().empty() && nowMillis - oldest->m_lastUsedMillis > FONT_CACHE_TIME_LIMIT)
+    {
+      /* The oldest existing entry is old enough to expire and reuse */
+      m_list.template get<Hash>().modify(m_list.template project<Hash>(oldest), typename CGUIFontCacheEntry<Position, Value>::Reassign(key, nowMillis));
+      m_list.template get<Age>().relocate(m_list.template get<Age>().end(), oldest);
+    }
+    else
+    {
+      /* We need a new entry instead */
+      /* Yes, this causes the creation an destruction of a temporary entry, but
+       * this code ought to only be used infrequently, when the cache needs to grow */
+      m_list.template get<Age>().push_back(CGUIFontCacheEntry<Position, Value>(*this, key, nowMillis));
+    }
+    dirtyCache = true;
+    return (--m_list.template get<Age>().end())->m_value;
+  }
+  else
+  {
+    /* Cache hit */
+    /* Update time in entry and move to the back of the list */
+    i->m_lastUsedMillis = nowMillis;
+    m_list.template get<Age>().relocate(m_list.template get<Age>().end(), m_list.template project<Age>(i));
+    dirtyCache = false;
+    return i->m_value;
+  }
+}
+
+template<class Position, class Value>
+void CGUIFontCache<Position, Value>::Flush()
+{
+  m_list.template get<Age>().clear();
+}
+
+template void CGUIFontCacheEntry<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Reassign::operator()(CGUIFontCacheEntry<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue> &entry);
+template CGUIFontCacheEntry<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::~CGUIFontCacheEntry();
+template CGUIFontCacheStaticValue &CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Lookup(CGUIFontCacheStaticPosition &, const vecColors &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
+template void CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Flush();

--- a/xbmc/guilib/GUIFontCache.cpp
+++ b/xbmc/guilib/GUIFontCache.cpp
@@ -110,3 +110,9 @@ template void CGUIFontCacheEntry<CGUIFontCacheDynamicPosition, CGUIFontCacheDyna
 template CGUIFontCacheEntry<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::~CGUIFontCacheEntry();
 template CGUIFontCacheDynamicValue &CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Lookup(CGUIFontCacheDynamicPosition &, const vecColors &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
 template void CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Flush();
+
+void CVertexBuffer::clear()
+{
+  if (m_font != NULL)
+    m_font->DestroyVertexBuffer(*this);
+}

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -242,14 +242,35 @@ struct CGUIFontCacheDynamicPosition
   }
 };
 
-struct CGUIFontCacheDynamicValue : public boost::shared_ptr<std::vector<SVertex> >
+struct CVertexBuffer
 {
-  void clear()
+  void *bufferHandle;
+  size_t size;
+  CVertexBuffer() : bufferHandle(NULL), size(0), m_font(NULL) {}
+  CVertexBuffer(void *bufferHandle, size_t size, const CGUIFontTTFBase *font) : bufferHandle(bufferHandle), size(size), m_font(font) {}
+  CVertexBuffer(const CVertexBuffer &other) : bufferHandle(other.bufferHandle), size(other.size), m_font(other.m_font)
   {
-    if (*this)
-      (*this)->clear();
+    /* In practice, the copy constructor is only called before a vertex buffer
+     * has been attached. If this should ever change, we'll need another support
+     * function in GUIFontTTFGL/DX to duplicate a buffer, given its handle. */
+    assert(other.bufferHandle == 0);
   }
+  CVertexBuffer &operator=(CVertexBuffer &other)
+  {
+    /* This is used with move-assignment semantics for initialising the object in the font cache */
+    assert(bufferHandle == 0);
+    bufferHandle = other.bufferHandle;
+    other.bufferHandle = 0;
+    size = other.size;
+    m_font = other.m_font;
+    return *this;
+  }
+  void clear();
+private:
+  const CGUIFontTTFBase *m_font;
 };
+
+typedef CVertexBuffer CGUIFontCacheDynamicValue;
 
 inline bool Match(const CGUIFontCacheDynamicPosition &a, const TransformMatrix &a_m,
                   const CGUIFontCacheDynamicPosition &b, const TransformMatrix &b_m,

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -1,0 +1,225 @@
+/*!
+\file GUIFontCache.h
+\brief
+*/
+
+#ifndef CGUILIB_GUIFONTCACHE_H
+#define CGUILIB_GUIFONTCACHE_H
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <cstddef>
+#include <cstring>
+#include <stdint.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "boost/multi_index_container.hpp"
+#include "boost/multi_index/sequenced_index.hpp"
+#include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/member.hpp"
+#include "boost/shared_ptr.hpp"
+
+#include "TransformMatrix.h"
+
+using namespace boost::multi_index;
+
+#define FONT_CACHE_TIME_LIMIT (1000)
+
+template<class Position, class Value> class CGUIFontCache;
+class CGUIFontTTFBase;
+
+template<class Position>
+struct CGUIFontCacheKey
+{
+  Position m_pos;
+  vecColors &m_colors;
+  vecText &m_text;
+  uint32_t m_alignment;
+  float m_maxPixelWidth;
+  bool m_scrolling;
+  const TransformMatrix &m_matrix;
+  float m_scaleX;
+  float m_scaleY;
+
+  CGUIFontCacheKey(Position pos,
+                   vecColors &colors, vecText &text,
+                   uint32_t alignment, float maxPixelWidth,
+                   bool scrolling, const TransformMatrix &matrix,
+                   float scaleX, float scaleY) :
+    m_pos(pos),
+    m_colors(colors), m_text(text),
+    m_alignment(alignment), m_maxPixelWidth(maxPixelWidth),
+    m_scrolling(scrolling), m_matrix(matrix),
+    m_scaleX(scaleX), m_scaleY(scaleY)
+  {}
+};
+
+template<class Position, class Value>
+struct CGUIFontCacheEntry
+{
+  const CGUIFontCache<Position, Value> &m_cache;
+  CGUIFontCacheKey<Position> m_key;
+  TransformMatrix m_matrix;
+
+  /* These need to be declared as mutable to get round the fact that only
+   * const iterators are available. These fields do not affect comparison or
+   * hash functors, so from the container's point of view, they are mutable. */
+  mutable unsigned int m_lastUsedMillis;
+  mutable Value m_value;
+
+  CGUIFontCacheEntry(const CGUIFontCache<Position, Value> &cache, const CGUIFontCacheKey<Position> &key, unsigned int nowMillis) :
+    m_cache(cache),
+    m_key(key.m_pos,
+          *new vecColors, *new vecText,
+          key.m_alignment, key.m_maxPixelWidth,
+          key.m_scrolling, m_matrix,
+          key.m_scaleX, key.m_scaleY),
+    m_lastUsedMillis(nowMillis)
+  {
+    m_key.m_colors.assign(key.m_colors.begin(), key.m_colors.end());
+    m_key.m_text.assign(key.m_text.begin(), key.m_text.end());
+    m_matrix = key.m_matrix;
+  }
+
+  CGUIFontCacheEntry(const CGUIFontCacheEntry &other) :
+    m_cache(other.m_cache),
+    m_key(other.m_key.m_pos,
+          *new vecColors, *new vecText,
+          other.m_key.m_alignment, other.m_key.m_maxPixelWidth,
+          other.m_key.m_scrolling, m_matrix,
+          other.m_key.m_scaleX, other.m_key.m_scaleY),
+    m_lastUsedMillis(other.m_lastUsedMillis),
+    m_value(other.m_value)
+  {
+    m_key.m_colors.assign(other.m_key.m_colors.begin(), other.m_key.m_colors.end());
+    m_key.m_text.assign(other.m_key.m_text.begin(), other.m_key.m_text.end());
+    m_matrix = other.m_key.m_matrix;
+  }
+
+  struct Reassign
+  {
+    Reassign(const CGUIFontCacheKey<Position> &key, unsigned int nowMillis) : m_key(key), m_nowMillis(nowMillis) {}
+    void operator()(CGUIFontCacheEntry &entry);
+  private:
+    const CGUIFontCacheKey<Position> &m_key;
+    unsigned int m_nowMillis;
+  };
+
+  ~CGUIFontCacheEntry();
+};
+
+template<class Position>
+struct CGUIFontCacheHash
+{
+  size_t operator()(const CGUIFontCacheKey<Position> &key) const
+  {
+    /* Not much effort has gone into choosing this hash function */
+    size_t hash = 0, i;
+    for (i = 0; i < 3 && i < key.m_text.size(); ++i)
+      hash += key.m_text[i];
+    if (key.m_colors.size())
+      hash += key.m_colors[0];
+    hash += MatrixHashContribution(key);
+    return hash;
+  }
+};
+
+template<class Position>
+struct CGUIFontCacheKeysMatch
+{
+  bool operator()(const CGUIFontCacheKey<Position> &a, const CGUIFontCacheKey<Position> &b) const
+  {
+    return a.m_text == b.m_text &&
+           a.m_colors == b.m_colors &&
+           a.m_alignment == b.m_alignment &&
+           a.m_scrolling == b.m_scrolling &&
+           a.m_maxPixelWidth == b.m_maxPixelWidth &&
+           Match(a.m_pos, a.m_matrix, b.m_pos, b.m_matrix, a.m_scrolling) &&
+           a.m_scaleX == b.m_scaleX &&
+           a.m_scaleY == b.m_scaleY;
+  }
+};
+
+template<class Position, class Value>
+class CGUIFontCache
+{
+  /* Empty structs used as tags to identify indexes */
+  struct Age {};
+  struct Hash {};
+
+  typedef multi_index_container<
+      CGUIFontCacheEntry<Position, Value>,
+      indexed_by<
+          sequenced<tag<Age> >,
+          hashed_unique<tag<Hash>, member<CGUIFontCacheEntry<Position, Value>, CGUIFontCacheKey<Position>, &CGUIFontCacheEntry<Position, Value>::m_key>, CGUIFontCacheHash<Position>, CGUIFontCacheKeysMatch<Position> >
+      >
+  > EntryList;
+
+  typedef typename EntryList::template index<Age>::type::iterator EntryAgeIterator;
+  typedef typename EntryList::template index<Hash>::type::iterator EntryHashIterator;
+
+  EntryList m_list;
+
+public:
+  const CGUIFontTTFBase &m_font;
+
+  CGUIFontCache(CGUIFontTTFBase &font) : m_font(font) {}
+  Value &Lookup(Position &pos,
+                const vecColors &colors, const vecText &text,
+                uint32_t alignment, float maxPixelWidth,
+                bool scrolling,
+                unsigned int nowMillis, bool &dirtyCache);
+  void Flush();
+};
+
+struct CGUIFontCacheStaticPosition
+{
+  float m_x;
+  float m_y;
+  CGUIFontCacheStaticPosition(float x, float y) : m_x(x), m_y(y) {}
+};
+
+struct CGUIFontCacheStaticValue : public boost::shared_ptr<std::vector<SVertex> >
+{
+  void clear()
+  {
+    if (*this)
+      (*this)->clear();
+  }
+};
+
+inline bool Match(const CGUIFontCacheStaticPosition &a, const TransformMatrix &a_m,
+                  const CGUIFontCacheStaticPosition &b, const TransformMatrix &b_m,
+                  bool scrolling)
+{
+  return a.m_x == b.m_x && a.m_y == b.m_y && a_m == b_m;
+}
+
+inline float MatrixHashContribution(const CGUIFontCacheKey<CGUIFontCacheStaticPosition> &a)
+{
+  /* Ensure horizontally translated versions end up in different buckets */
+  return a.m_matrix.m[0][3];
+}
+
+#endif

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -354,6 +354,8 @@ void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors
 {
   Begin();
 
+  std::vector<SVertex> &vertices = m_vertex;
+
   // save the origin, which is scaled separately
   m_originX = x;
   m_originY = y;
@@ -434,7 +436,7 @@ void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors
 
         for (int i = 0; i < 3; i++)
         {
-          RenderCharacter(startX + cursorX, startY, period, color, !scrolling);
+          RenderCharacter(startX + cursorX, startY, period, color, !scrolling, vertices);
           cursorX += period->advance;
         }
         break;
@@ -443,7 +445,7 @@ void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors
     else if (maxPixelWidth > 0 && cursorX > maxPixelWidth)
       break;  // exceeded max allowed width - stop rendering
 
-    RenderCharacter(startX + cursorX, startY, ch, color, !scrolling);
+    RenderCharacter(startX + cursorX, startY, ch, color, !scrolling, vertices);
     if ( alignment & XBFONT_JUSTIFIED )
     {
       if ((*pos & 0xffff) == L' ')
@@ -700,7 +702,7 @@ bool CGUIFontTTFBase::CacheCharacter(wchar_t letter, uint32_t style, Character *
   return true;
 }
 
-void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *ch, color_t color, bool roundX)
+void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *ch, color_t color, bool roundX, std::vector<SVertex> &vertices)
 {
   // actual image width isn't same as the character width as that is
   // just baseline width and height should include the descent
@@ -766,8 +768,8 @@ void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *c
   float tt = texture.y1 * m_textureScaleY;
   float tb = texture.y2 * m_textureScaleY;
 
-  m_vertex.resize(m_vertex.size() + 4);
-  SVertex* v = &m_vertex[m_vertex.size() - 4];
+  vertices.resize(vertices.size() + 4);
+  SVertex* v = &vertices[vertices.size() - 4];
   m_color = color;
 
   unsigned char r = GET_R(color)

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -745,7 +745,8 @@ void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *c
                (posY + ch->offsetY + height) * g_graphicsContext.GetGUIScaleY());
   vertex += CPoint(m_originX, m_originY);
   CRect texture(ch->left, ch->top, ch->right, ch->bottom);
-  g_graphicsContext.ClipRect(vertex, texture);
+  if (!g_Windowing.ScissorsCanEffectClipping())
+    g_graphicsContext.ClipRect(vertex, texture);
 
   // transform our positions - note, no scaling due to GUI calibration/resolution occurs
   float x[4], y[4], z[4];

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -493,7 +493,7 @@ void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors
                             scrolling,
                             XbmcThreads::SystemClockMillis(),
                             dirtyCache) = *static_cast<CGUIFontCacheDynamicValue *>(&tempVertices);
-      m_vertexTrans.push_back(CTranslatedVertices(0, 0, 0, tempVertices));
+      m_vertexTrans.push_back(CTranslatedVertices(0, 0, 0, tempVertices, g_graphicsContext.GetClipRegion()));
     }
     else
     {
@@ -510,7 +510,7 @@ void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors
   else
   {
     if (hardwareClipping)
-      m_vertexTrans.push_back(CTranslatedVertices(dynamicPos.m_x, dynamicPos.m_y, dynamicPos.m_z, vertices));
+      m_vertexTrans.push_back(CTranslatedVertices(dynamicPos.m_x, dynamicPos.m_y, dynamicPos.m_z, vertices, g_graphicsContext.GetClipRegion()));
     else
       /* Append the vertices from the cache to the set collected since the first Begin() call */
       m_vertex.insert(m_vertex.end(), vertices->begin(), vertices->end());

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -333,6 +333,27 @@ bool CGUIFontTTFBase::Load(const std::string& strFilename, float height, float a
   return true;
 }
 
+void CGUIFontTTFBase::Begin()
+{
+  if (m_nestedBeginCount == 0 && m_texture != NULL && FirstBegin())
+  {
+    m_vertex_count = 0;
+  }
+  // Keep track of the nested begin/end calls.
+  m_nestedBeginCount++;
+}
+
+void CGUIFontTTFBase::End()
+{
+  if (m_nestedBeginCount == 0)
+    return;
+
+  if (--m_nestedBeginCount > 0)
+    return;
+
+  LastEnd();
+}
+
 void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors, const vecText &text, uint32_t alignment, float maxPixelWidth, bool scrolling)
 {
   Begin();

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -89,6 +89,9 @@ public:
 
   void Begin();
   void End();
+  /* The next two should only be called if we've declared we can do hardware clipping */
+  virtual CVertexBuffer CreateVertexBuffer(const std::vector<SVertex> &vertices) const { assert(false); return CVertexBuffer(); }
+  virtual void DestroyVertexBuffer(CVertexBuffer &bufferHandle) const {}
 
   const std::string& GetFileName() const { return m_strFileName; };
 
@@ -171,9 +174,9 @@ protected:
     float translateX;
     float translateY;
     float translateZ;
-    boost::shared_ptr<std::vector<SVertex> > vertexBuffer;
+    const CVertexBuffer *vertexBuffer;
     CRect clip;
-    CTranslatedVertices(float translateX, float translateY, float translateZ, boost::shared_ptr<std::vector<SVertex> > vertexBuffer, const CRect &clip) : translateX(translateX), translateY(translateY), translateZ(translateZ), vertexBuffer(vertexBuffer), clip(clip) {}
+    CTranslatedVertices(float translateX, float translateY, float translateZ, const CVertexBuffer *vertexBuffer, const CRect &clip) : translateX(translateX), translateY(translateY), translateZ(translateZ), vertexBuffer(vertexBuffer), clip(clip) {}
   };
   std::vector<CTranslatedVertices> m_vertexTrans;
   std::vector<SVertex> m_vertex;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -162,9 +162,7 @@ protected:
 
   unsigned int m_nTexture;
 
-  SVertex* m_vertex;
-  int      m_vertex_count;
-  int      m_vertex_size;
+  std::vector<SVertex> m_vertex;
 
   float    m_textureScaleX;
   float    m_textureScaleY;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -115,7 +115,7 @@ protected:
   // Stuff for pre-rendering for speed
   inline Character *GetCharacter(character_t letter);
   bool CacheCharacter(wchar_t letter, uint32_t style, Character *ch);
-  void RenderCharacter(float posX, float posY, const Character *ch, color_t color, bool roundX);
+  void RenderCharacter(float posX, float posY, const Character *ch, color_t color, bool roundX, std::vector<SVertex> &vertices);
   void ClearCharacterCache();
 
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight) = 0;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -83,8 +83,8 @@ public:
 
   bool Load(const std::string& strFilename, float height = 20.0f, float aspect = 1.0f, float lineSpacing = 1.0f, bool border = false);
 
-  virtual void Begin() = 0;
-  virtual void End() = 0;
+  void Begin();
+  void End();
 
   const std::string& GetFileName() const { return m_strFileName; };
 
@@ -175,6 +175,8 @@ protected:
   XUTILS::auto_buffer m_fontFileInMemory; // used only in some cases, see CFreeTypeLibrary::GetFont()
 
 private:
+  virtual bool FirstBegin() = 0;
+  virtual void LastEnd() = 0;
   CGUIFontTTFBase(const CGUIFontTTFBase&);
   CGUIFontTTFBase& operator=(const CGUIFontTTFBase&);
   int m_referenceCount;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "utils/auto_buffer.h"
+#include "Geometry.h"
 
 // forward definition
 class CBaseTexture;
@@ -171,7 +172,8 @@ protected:
     float translateY;
     float translateZ;
     boost::shared_ptr<std::vector<SVertex> > vertexBuffer;
-    CTranslatedVertices(float translateX, float translateY, float translateZ, boost::shared_ptr<std::vector<SVertex> > vertexBuffer) : translateX(translateX), translateY(translateY), translateZ(translateZ), vertexBuffer(vertexBuffer) {}
+    CRect clip;
+    CTranslatedVertices(float translateX, float translateY, float translateZ, boost::shared_ptr<std::vector<SVertex> > vertexBuffer, const CRect &clip) : translateX(translateX), translateY(translateY), translateZ(translateZ), vertexBuffer(vertexBuffer), clip(clip) {}
   };
   std::vector<CTranslatedVertices> m_vertexTrans;
   std::vector<SVertex> m_vertex;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -67,14 +67,6 @@ struct SVertex
   unsigned char r, g, b, a;
 #endif
   float u, v;
-  struct SVertex Offset(float translate[3]) const
-  {
-    SVertex out = *this;
-    out.x += translate[0];
-    out.y += translate[1];
-    out.z += translate[2];
-    return out;
-  }
 };
 
 

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -67,6 +67,14 @@ struct SVertex
   unsigned char r, g, b, a;
 #endif
   float u, v;
+  struct SVertex Offset(float translate[3]) const
+  {
+    SVertex out = *this;
+    out.x += translate[0];
+    out.y += translate[1];
+    out.z += translate[2];
+    return out;
+  }
 };
 
 
@@ -165,6 +173,15 @@ protected:
 
   unsigned int m_nTexture;
 
+  struct CTranslatedVertices
+  {
+    float translateX;
+    float translateY;
+    float translateZ;
+    boost::shared_ptr<std::vector<SVertex> > vertexBuffer;
+    CTranslatedVertices(float translateX, float translateY, float translateZ, boost::shared_ptr<std::vector<SVertex> > vertexBuffer) : translateX(translateX), translateY(translateY), translateZ(translateZ), vertexBuffer(vertexBuffer) {}
+  };
+  std::vector<CTranslatedVertices> m_vertexTrans;
   std::vector<SVertex> m_vertex;
 
   float    m_textureScaleX;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -176,6 +176,7 @@ protected:
   XUTILS::auto_buffer m_fontFileInMemory; // used only in some cases, see CFreeTypeLibrary::GetFont()
 
   CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue> m_staticCache;
+  CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue> m_dynamicCache;
 
 private:
   virtual bool FirstBegin() = 0;

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -70,6 +70,9 @@ struct SVertex
 };
 
 
+#include "GUIFontCache.h"
+
+
 class CGUIFontTTFBase
 {
   friend class CGUIFont;
@@ -171,6 +174,8 @@ protected:
 
   std::string m_strFileName;
   XUTILS::auto_buffer m_fontFileInMemory; // used only in some cases, see CFreeTypeLibrary::GetFont()
+
+  CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue> m_staticCache;
 
 private:
   virtual bool FirstBegin() = 0;

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -51,64 +51,55 @@ CGUIFontTTFDX::~CGUIFontTTFDX(void)
   free(m_index);
 }
 
-void CGUIFontTTFDX::Begin()
+bool CGUIFontTTFDX::FirstBegin()
 {
   LPDIRECT3DDEVICE9 pD3DDevice = g_Windowing.Get3DDevice();
 
   if (pD3DDevice == NULL)
-    CLog::Log(LOGERROR, __FUNCTION__" - failed to get Direct3D device");
-
-  if (m_nestedBeginCount == 0 && pD3DDevice != NULL && m_texture != NULL)
   {
-    int unit = 0;
-    // just have to blit from our texture.
-    m_texture->BindToUnit(unit);
-    pD3DDevice->SetTextureStageState( unit, D3DTSS_COLOROP, D3DTOP_SELECTARG1 ); // only use diffuse
-    pD3DDevice->SetTextureStageState( unit, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
-    pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAOP, D3DTOP_MODULATE );
-    pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-    pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
-    unit++;
-
-    if(g_Windowing.UseLimitedColor())
-    {
-      pD3DDevice->SetTextureStageState( unit, D3DTSS_COLOROP  , D3DTOP_ADD );
-      pD3DDevice->SetTextureStageState( unit, D3DTSS_COLORARG1, D3DTA_CURRENT) ;
-      pD3DDevice->SetRenderState( D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(16,16,16,0) );
-      pD3DDevice->SetTextureStageState( unit, D3DTSS_COLORARG2, D3DTA_TFACTOR );
-      unit++;
-    }
-
-    // no other texture stages needed
-    pD3DDevice->SetTextureStageState( unit, D3DTSS_COLOROP, D3DTOP_DISABLE);
-    pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-
-    pD3DDevice->SetRenderState( D3DRS_ZENABLE, FALSE );
-    pD3DDevice->SetRenderState( D3DRS_FOGENABLE, FALSE );
-    pD3DDevice->SetRenderState( D3DRS_FILLMODE, D3DFILL_SOLID );
-    pD3DDevice->SetRenderState( D3DRS_CULLMODE, D3DCULL_NONE );
-    pD3DDevice->SetRenderState( D3DRS_ALPHABLENDENABLE, TRUE );
-    pD3DDevice->SetRenderState( D3DRS_SRCBLEND, D3DBLEND_SRCALPHA );
-    pD3DDevice->SetRenderState( D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA );
-    pD3DDevice->SetRenderState( D3DRS_LIGHTING, FALSE);
-
-    pD3DDevice->SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1);
-    m_vertex_count = 0;
+    CLog::Log(LOGERROR, __FUNCTION__" - failed to get Direct3D device");
+    return false;
   }
 
-  // Keep track of the nested begin/end calls.
-  m_nestedBeginCount++;
+  int unit = 0;
+  // just have to blit from our texture.
+  m_texture->BindToUnit(unit);
+  pD3DDevice->SetTextureStageState( unit, D3DTSS_COLOROP, D3DTOP_SELECTARG1 ); // only use diffuse
+  pD3DDevice->SetTextureStageState( unit, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
+  pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAOP, D3DTOP_MODULATE );
+  pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+  pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+  unit++;
+
+  if(g_Windowing.UseLimitedColor())
+  {
+    pD3DDevice->SetTextureStageState( unit, D3DTSS_COLOROP  , D3DTOP_ADD );
+    pD3DDevice->SetTextureStageState( unit, D3DTSS_COLORARG1, D3DTA_CURRENT) ;
+    pD3DDevice->SetRenderState( D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(16,16,16,0) );
+    pD3DDevice->SetTextureStageState( unit, D3DTSS_COLORARG2, D3DTA_TFACTOR );
+    unit++;
+  }
+
+  // no other texture stages needed
+  pD3DDevice->SetTextureStageState( unit, D3DTSS_COLOROP, D3DTOP_DISABLE);
+  pD3DDevice->SetTextureStageState( unit, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+
+  pD3DDevice->SetRenderState( D3DRS_ZENABLE, FALSE );
+  pD3DDevice->SetRenderState( D3DRS_FOGENABLE, FALSE );
+  pD3DDevice->SetRenderState( D3DRS_FILLMODE, D3DFILL_SOLID );
+  pD3DDevice->SetRenderState( D3DRS_CULLMODE, D3DCULL_NONE );
+  pD3DDevice->SetRenderState( D3DRS_ALPHABLENDENABLE, TRUE );
+  pD3DDevice->SetRenderState( D3DRS_SRCBLEND, D3DBLEND_SRCALPHA );
+  pD3DDevice->SetRenderState( D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA );
+  pD3DDevice->SetRenderState( D3DRS_LIGHTING, FALSE);
+
+  pD3DDevice->SetFVF(D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1);
+  return true;
 }
 
-void CGUIFontTTFDX::End()
+void CGUIFontTTFDX::LastEnd()
 {
   LPDIRECT3DDEVICE9 pD3DDevice = g_Windowing.Get3DDevice();
-
-  if (m_nestedBeginCount == 0)
-    return;
-
-  if (--m_nestedBeginCount > 0)
-    return;
 
   if (m_vertex_count == 0)
     return;

--- a/xbmc/guilib/GUIFontTTFDX.h
+++ b/xbmc/guilib/GUIFontTTFDX.h
@@ -41,8 +41,8 @@ public:
   CGUIFontTTFDX(const std::string& strFileName);
   virtual ~CGUIFontTTFDX(void);
 
-  virtual void Begin();
-  virtual void End();
+  virtual bool FirstBegin();
+  virtual void LastEnd();
 
 protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -221,6 +221,7 @@ CBaseTexture* CGUIFontTTFGL::ReallocTexture(unsigned int& newHeight)
   m_textureScaleX = 1.0f / m_textureWidth;
   if (m_textureHeight < newHeight)
     CLog::Log(LOGWARNING, "%s: allocated new texture with height of %d, requested %d", __FUNCTION__, m_textureHeight, newHeight);
+  m_staticCache.Flush();
 
   memset(newTexture->GetPixels(), 0, m_textureHeight * newTexture->GetPitch());
   if (m_texture)

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -146,13 +146,13 @@ void CGUIFontTTFGL::LastEnd()
 #ifdef HAS_GL
   glPushClientAttrib(GL_CLIENT_VERTEX_ARRAY_BIT);
 
-  glColorPointer   (4, GL_UNSIGNED_BYTE, sizeof(SVertex), (char*)m_vertex + offsetof(SVertex, r));
-  glVertexPointer  (3, GL_FLOAT        , sizeof(SVertex), (char*)m_vertex + offsetof(SVertex, x));
-  glTexCoordPointer(2, GL_FLOAT        , sizeof(SVertex), (char*)m_vertex + offsetof(SVertex, u));
+  glColorPointer   (4, GL_UNSIGNED_BYTE, sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, r));
+  glVertexPointer  (3, GL_FLOAT        , sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, x));
+  glTexCoordPointer(2, GL_FLOAT        , sizeof(SVertex), (char*)&m_vertex[0] + offsetof(SVertex, u));
   glEnableClientState(GL_COLOR_ARRAY);
   glEnableClientState(GL_VERTEX_ARRAY);
   glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-  glDrawArrays(GL_QUADS, 0, m_vertex_count);
+  glDrawArrays(GL_QUADS, 0, m_vertex.size());
   glPopClientAttrib();
 
   glActiveTexture(GL_TEXTURE1);
@@ -168,10 +168,10 @@ void CGUIFontTTFGL::LastEnd()
   GLint tex0Loc = g_Windowing.GUIShaderGetCoord0();
 
   // stack object until VBOs will be used
-  std::vector<SVertex> vecVertices( 6 * (m_vertex_count / 4) );
+  std::vector<SVertex> vecVertices( 6 * (m_vertex.size() / 4) );
   SVertex *vertices = &vecVertices[0];
 
-  for (int i=0; i<m_vertex_count; i+=4)
+  for (size_t i=0; i<m_vertex.size(); i+=4)
   {
     *vertices++ = m_vertex[i];
     *vertices++ = m_vertex[i+1];

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -206,6 +206,10 @@ void CGUIFontTTFGL::LastEnd()
     std::vector<SVertex> vecVertices;
     for (size_t i = 0; i < m_vertexTrans.size(); i++)
     {
+      // Apply the clip rectangle
+      CRect clip = g_Windowing.ClipRectToScissorRect(m_vertexTrans[i].clip);
+      g_Windowing.SetScissors(clip);
+
       // Apply the translation to the currently active (top-of-stack) model view matrix
       glMatrixModview.Push();
       glMatrixModview.Get().Translatef(m_vertexTrans[i].translateX, m_vertexTrans[i].translateY, m_vertexTrans[i].translateZ);
@@ -232,6 +236,8 @@ void CGUIFontTTFGL::LastEnd()
 
       glMatrixModview.Pop();
     }
+    // Restore the original scissor rectangle
+    g_Windowing.ResetScissors();
     // Restore the original model view matrix
     glUniformMatrix4fv(modelLoc, 1, GL_FALSE, glMatrixModview.Get());
   }

--- a/xbmc/guilib/GUIFontTTFGL.h
+++ b/xbmc/guilib/GUIFontTTFGL.h
@@ -29,6 +29,7 @@
 
 
 #include "GUIFontTTF.h"
+#include "system.h"
 
 
 /*!
@@ -43,6 +44,10 @@ public:
 
   virtual bool FirstBegin();
   virtual void LastEnd();
+#if HAS_GLES
+  virtual CVertexBuffer CreateVertexBuffer(const std::vector<SVertex> &vertices) const;
+  virtual void DestroyVertexBuffer(CVertexBuffer &bufferHandle) const;
+#endif
 
 protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);

--- a/xbmc/guilib/GUIFontTTFGL.h
+++ b/xbmc/guilib/GUIFontTTFGL.h
@@ -30,6 +30,7 @@
 
 #include "GUIFontTTF.h"
 #include "system.h"
+#include "system_gl.h"
 
 
 /*!
@@ -47,13 +48,21 @@ public:
 #if HAS_GLES
   virtual CVertexBuffer CreateVertexBuffer(const std::vector<SVertex> &vertices) const;
   virtual void DestroyVertexBuffer(CVertexBuffer &bufferHandle) const;
+  static void CreateStaticVertexBuffers(void);
+  static void DestroyStaticVertexBuffers(void);
 #endif
 
 protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);
   virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2);
   virtual void DeleteHardwareTexture();
-    
+
+#if HAS_GLES
+#define ELEMENT_ARRAY_MAX_CHAR_INDEX (1000)
+
+  static GLuint m_elementArrayHandle;
+#endif
+
 private:
   unsigned int m_updateY1;
   unsigned int m_updateY2;

--- a/xbmc/guilib/GUIFontTTFGL.h
+++ b/xbmc/guilib/GUIFontTTFGL.h
@@ -41,8 +41,8 @@ public:
   CGUIFontTTFGL(const std::string& strFileName);
   virtual ~CGUIFontTTFGL(void);
 
-  virtual void Begin();
-  virtual void End();
+  virtual bool FirstBegin();
+  virtual void LastEnd();
 
 protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -119,7 +119,9 @@ void CGUIRSSControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyre
       dirty = true;
 
       if (CRssManager::Get().GetReader(GetID(), GetParentID(), this, m_pReader))
-        m_scrollInfo.characterPos = m_pReader->m_SavedScrollPos;
+      {
+        m_scrollInfo.pixelPos = m_pReader->m_savedScrollPixelPos;
+      }
       else
       {
         if (m_strRSSTags != "")
@@ -174,7 +176,7 @@ void CGUIRSSControl::Render()
     if (m_pReader)
     {
       m_pReader->CheckForUpdates();
-      m_pReader->m_SavedScrollPos = m_scrollInfo.characterPos;
+      m_pReader->m_savedScrollPixelPos = m_scrollInfo.pixelPos;
     }
   }
   CGUIControl::Render();

--- a/xbmc/guilib/GUIShader.cpp
+++ b/xbmc/guilib/GUIShader.cpp
@@ -26,6 +26,8 @@
 #include "GUIShader.h"
 #include "MatrixGLES.h"
 #include "utils/log.h"
+#include "windowing/WindowingFactory.h"
+#include "guilib/GraphicContext.h"
 
 using namespace Shaders;
 
@@ -96,8 +98,83 @@ bool CGUIShader::OnEnabled()
 {
   // This is called after glUseProgram()
 
-  glUniformMatrix4fv(m_hProj,  1, GL_FALSE, glMatrixProject.Get());
-  glUniformMatrix4fv(m_hModel, 1, GL_FALSE, glMatrixModview.Get());
+  GLfloat *projMatrix = glMatrixProject.Get().m_pMatrix;
+  GLfloat *modelMatrix = glMatrixModview.Get().m_pMatrix;
+  glUniformMatrix4fv(m_hProj,  1, GL_FALSE, projMatrix);
+  glUniformMatrix4fv(m_hModel, 1, GL_FALSE, modelMatrix);
+
+  const TransformMatrix &guiMatrix = g_graphicsContext.GetGUIMatrix();
+  CRect viewPort; // absolute positions of corners
+  g_Windowing.GetViewPort(viewPort);
+
+  /* glScissor operates in window coordinates. In order that we can use it to
+   * perform clipping, we must ensure that there is an independent linear
+   * transformation from the coordinate system used by CGraphicContext::ClipRect
+   * to window coordinates, separately for X and Y (in other words, no
+   * rotation or shear is introduced at any stage). To do, this, we need to
+   * check that zeros are present in the following locations:
+   *
+   * GUI matrix:
+   * / * 0 * * \
+   * | 0 * * * |
+   * \ 0 0 * * /
+   *       ^ TransformMatrix::TransformX/Y/ZCoord are only ever called with
+   *         input z = 0, so this column doesn't matter
+   * Model-view matrix:
+   * / * 0 0 * \
+   * | 0 * 0 * |
+   * | 0 0 * * |
+   * \ * * * * /  <- eye w has no influence on window x/y (last column below
+   *                                                       is either 0 or ignored)
+   * Projection matrix:
+   * / * 0 0 0 \
+   * | 0 * 0 0 |
+   * | * * * * |  <- normalised device coordinate z has no influence on window x/y
+   * \ 0 0 * 0 /
+   *
+   * Some of these zeros are not strictly required to ensure this, but they tend
+   * to be zeroed in the common case, so by checking for zeros here, we simplify
+   * the calculation of the window x/y coordinates further down the line.
+   *
+   * (Minor detail: we don't quite deal in window coordinates as defined by
+   * OpenGL, because CRenderSystemGLES::SetScissors flips the Y axis. But all
+   * that's needed to handle that is an effective negation at the stage where
+   * Y is in normalised device coordinates.)
+   */
+  m_clipPossible = guiMatrix.m[0][1] == 0 &&
+      guiMatrix.m[1][0] == 0 &&
+      guiMatrix.m[2][0] == 0 &&
+      guiMatrix.m[2][1] == 0 &&
+      modelMatrix[0+1*4] == 0 &&
+      modelMatrix[0+2*4] == 0 &&
+      modelMatrix[1+0*4] == 0 &&
+      modelMatrix[1+2*4] == 0 &&
+      modelMatrix[2+0*4] == 0 &&
+      modelMatrix[2+1*4] == 0 &&
+      projMatrix[0+1*4] == 0 &&
+      projMatrix[0+2*4] == 0 &&
+      projMatrix[0+3*4] == 0 &&
+      projMatrix[1+0*4] == 0 &&
+      projMatrix[1+2*4] == 0 &&
+      projMatrix[1+3*4] == 0 &&
+      projMatrix[3+0*4] == 0 &&
+      projMatrix[3+1*4] == 0 &&
+      projMatrix[3+3*4] == 0;
+  if (m_clipPossible)
+  {
+    m_clipXFactor = guiMatrix.m[0][0] * modelMatrix[0+0*4] * projMatrix[0+0*4];
+    m_clipXOffset = (guiMatrix.m[0][3] * modelMatrix[0+0*4] + modelMatrix[0+3*4]) * projMatrix[0+0*4];
+    m_clipYFactor = guiMatrix.m[1][1] * modelMatrix[1+1*4] * projMatrix[1+1*4];
+    m_clipYOffset = (guiMatrix.m[1][3] * modelMatrix[1+1*4] + modelMatrix[1+3*4]) * projMatrix[1+1*4];
+    float clipW = (guiMatrix.m[2][3] * modelMatrix[2+2*4] + modelMatrix[2+3*4]) * projMatrix[3+2*4];
+    float xMult = (viewPort.x2 - viewPort.x1) / (2 * clipW);
+    float yMult = (viewPort.y1 - viewPort.y2) / (2 * clipW); // correct for inverted window coordinate scheme
+    m_clipXFactor = m_clipXFactor * xMult;
+    m_clipXOffset = m_clipXOffset * xMult + (viewPort.x2 + viewPort.x1) / 2;
+    m_clipYFactor = m_clipYFactor * yMult;
+    m_clipYOffset = m_clipYOffset * yMult + (viewPort.y2 + viewPort.y1) / 2;
+  }
+
   glUniform1f(m_hBrightness, 0.0f);
   glUniform1f(m_hContrast, 1.0f);
 

--- a/xbmc/guilib/GUIShader.h
+++ b/xbmc/guilib/GUIShader.h
@@ -43,6 +43,7 @@ public:
   GLint GetStepLoc() { return m_hStep; }
   GLint GetContrastLoc() { return m_hContrast; }
   GLint GetBrightnessLoc() { return m_hBrightness; }
+  GLint GetModelLoc() { return m_hModel; }
   bool HardwareClipIsPossible() { return m_clipPossible; }
   GLfloat GetClipXFactor() { return m_clipXFactor; }
   GLfloat GetClipXOffset() { return m_clipXOffset; }

--- a/xbmc/guilib/GUIShader.h
+++ b/xbmc/guilib/GUIShader.h
@@ -43,6 +43,11 @@ public:
   GLint GetStepLoc() { return m_hStep; }
   GLint GetContrastLoc() { return m_hContrast; }
   GLint GetBrightnessLoc() { return m_hBrightness; }
+  bool HardwareClipIsPossible() { return m_clipPossible; }
+  GLfloat GetClipXFactor() { return m_clipXFactor; }
+  GLfloat GetClipXOffset() { return m_clipXOffset; }
+  GLfloat GetClipYFactor() { return m_clipYFactor; }
+  GLfloat GetClipYOffset() { return m_clipYOffset; }
 
 protected:
   GLint m_hTex0;
@@ -62,6 +67,12 @@ protected:
 
   GLfloat *m_proj;
   GLfloat *m_model;
+
+  bool m_clipPossible;
+  GLfloat m_clipXFactor;
+  GLfloat m_clipXOffset;
+  GLfloat m_clipYFactor;
+  GLfloat m_clipYOffset;
 };
 
 #endif // GUI_SHADER_H

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -167,6 +167,16 @@ void CGraphicContext::ClipRect(CRect &vertex, CRect &texture, CRect *texture2)
   }
 }
 
+CRect CGraphicContext::GetClipRegion()
+{
+  if (m_clipRegions.empty())
+    return CRect(0, 0, m_iScreenWidth, m_iScreenHeight);
+  CRect clipRegion(m_clipRegions.top());
+  if (!m_origins.empty())
+    clipRegion -= m_origins.top();
+  return clipRegion;
+}
+
 bool CGraphicContext::SetViewPort(float fx, float fy, float fwidth, float fheight, bool intersectPrevious /* = false */)
 {
   // transform coordinates - we may have a rotation which changes the positioning of the

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -199,6 +199,7 @@ public:
   void ApplyHardwareTransform();
   void RestoreHardwareTransform();
   void ClipRect(CRect &vertex, CRect &texture, CRect *diffuse = NULL);
+  CRect GetClipRegion();
   inline void AddGUITransform()
   {
     m_transforms.push(m_finalTransform);

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -146,6 +146,7 @@ public:
   inline void ScaleFinalCoords(float &x, float &y, float &z) const XBMC_FORCE_INLINE { m_finalTransform.matrix.TransformPosition(x, y, z); }
   bool RectIsAngled(float x1, float y1, float x2, float y2) const;
 
+  inline const TransformMatrix &GetGUIMatrix() const XBMC_FORCE_INLINE { return m_finalTransform.matrix; }
   inline float GetGUIScaleX() const XBMC_FORCE_INLINE { return m_finalTransform.scaleX; }
   inline float GetGUIScaleY() const XBMC_FORCE_INLINE { return m_finalTransform.scaleY; }
   inline color_t MergeAlpha(color_t color) const XBMC_FORCE_INLINE

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -23,6 +23,7 @@ SRCS += GUIEditControl.cpp
 SRCS += GUIFadeLabelControl.cpp
 SRCS += GUIFixedListContainer.cpp
 SRCS += GUIFont.cpp
+SRCS += GUIFontCache.cpp
 SRCS += GUIFontManager.cpp
 SRCS += GUIFontTTF.cpp
 SRCS += GUIImage.cpp

--- a/xbmc/guilib/TransformMatrix.h
+++ b/xbmc/guilib/TransformMatrix.h
@@ -245,3 +245,14 @@ public:
   float alpha;
   bool identity;
 };
+
+inline bool operator==(const TransformMatrix &a, const TransformMatrix &b)
+{
+  return a.alpha == b.alpha && ((a.identity && b.identity) ||
+      (!a.identity && !b.identity && std::equal(&a.m[0][0], &a.m[0][0] + sizeof (a.m) / sizeof (a.m[0][0]), &b.m[0][0])));
+}
+
+inline bool operator!=(const TransformMatrix &a, const TransformMatrix &b)
+{
+  return !operator==(a, b);
+}

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -110,6 +110,8 @@ public:
   virtual void GetViewPort(CRect& viewPort) = 0;
   virtual void RestoreViewPort() {};
 
+  virtual bool ScissorsCanEffectClipping() { return false; }
+  virtual CRect ClipRectToScissorRect(const CRect &rect) { return CRect(); }
   virtual void SetScissors(const CRect &rect) = 0;
   virtual void ResetScissors() = 0;
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -528,6 +528,28 @@ void CRenderSystemGLES::SetViewPort(CRect& viewPort)
   m_viewPort[3] = viewPort.Height();
 }
 
+bool CRenderSystemGLES::ScissorsCanEffectClipping()
+{
+  if (m_pGUIshader[m_method])
+    return m_pGUIshader[m_method]->HardwareClipIsPossible();
+
+  return false;
+}
+
+CRect CRenderSystemGLES::ClipRectToScissorRect(const CRect &rect)
+{
+  if (!m_pGUIshader[m_method])
+    return CRect();
+  float xFactor = m_pGUIshader[m_method]->GetClipXFactor();
+  float xOffset = m_pGUIshader[m_method]->GetClipXOffset();
+  float yFactor = m_pGUIshader[m_method]->GetClipYFactor();
+  float yOffset = m_pGUIshader[m_method]->GetClipYOffset();
+  return CRect(rect.x1 * xFactor + xOffset,
+               rect.y1 * yFactor + yOffset,
+               rect.x2 * xFactor + xOffset,
+               rect.y2 * yFactor + yOffset);
+}
+
 void CRenderSystemGLES::SetScissors(const CRect &rect)
 {
   if (!m_bRenderCreated)

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -718,4 +718,12 @@ bool CRenderSystemGLES::SupportsStereo(RENDER_STEREO_MODE mode)
   }
 }
 
+GLint CRenderSystemGLES::GUIShaderGetModel()
+{
+  if (m_pGUIshader[m_method])
+    return m_pGUIshader[m_method]->GetModelLoc();
+
+  return -1;
+}
+
 #endif

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -97,6 +97,7 @@ public:
   GLint GUIShaderGetStep();
   GLint GUIShaderGetContrast();
   GLint GUIShaderGetBrightness();
+  GLint GUIShaderGetModel();
 
 protected:
   virtual void SetVSyncImpl(bool enable) = 0;

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -65,6 +65,8 @@ public:
   virtual void SetViewPort(CRect& viewPort);
   virtual void GetViewPort(CRect& viewPort);
 
+  virtual bool ScissorsCanEffectClipping();
+  virtual CRect ClipRectToScissorRect(const CRect &rect);
   virtual void SetScissors(const CRect& rect);
   virtual void ResetScissors();
 

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -55,7 +55,7 @@ CRssReader::CRssReader() : CThread("RSSReader")
   m_pObserver = NULL;
   m_spacesBetweenFeeds = 0;
   m_bIsRunning = false;
-  m_SavedScrollPos = 0;
+  m_savedScrollPixelPos = 0;
   m_rtlText = false;
   m_requestRefresh = false;
 }

--- a/xbmc/utils/RssReader.h
+++ b/xbmc/utils/RssReader.h
@@ -43,7 +43,7 @@ public:
   void SetObserver(IRssObserver* observer);
   void CheckForUpdates();
   void requestRefresh();
-  unsigned int m_SavedScrollPos;
+  float m_savedScrollPixelPos;
 
 private:
   void Process();

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -31,6 +31,7 @@
 #include "settings/DisplaySettings.h"
 #include "guilib/DispResource.h"
 #include "threads/SingleLock.h"
+#include "guilib/GUIFontTTFGL.h"
 #include "utils/log.h"
 #include "EGLWrapper.h"
 #include "EGLQuirks.h"
@@ -207,6 +208,9 @@ bool CWinSystemEGL::CreateWindow(RESOLUTION_INFO &res)
     return false;
   }
 
+#if HAS_GLES
+  bool newContext = false;
+#endif
   if (m_context == EGL_NO_CONTEXT)
   {
     if (!m_egl->CreateContext(m_display, m_config, contextAttrs, &m_context))
@@ -214,6 +218,9 @@ bool CWinSystemEGL::CreateWindow(RESOLUTION_INFO &res)
       CLog::Log(LOGERROR, "%s: Could not create context",__FUNCTION__);
       return false;
     }
+#if HAS_GLES
+    newContext = true;
+#endif
   }
 
   if (!m_egl->BindContext(m_display, m_surface, m_context))
@@ -221,6 +228,11 @@ bool CWinSystemEGL::CreateWindow(RESOLUTION_INFO &res)
     CLog::Log(LOGERROR, "%s: Could not bind to context",__FUNCTION__);
     return false;
   }
+
+#if HAS_GLES
+  if (newContext)
+    CGUIFontTTFGL::CreateStaticVertexBuffers();
+#endif
 
   // for the non-trivial dirty region modes, we need the EGL buffer to be preserved across updates
   if (g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
@@ -243,7 +255,12 @@ bool CWinSystemEGL::DestroyWindowSystem()
   DestroyWindow();
 
   if (m_context != EGL_NO_CONTEXT)
+  {
+#if HAS_GLES
+    CGUIFontTTFGL::DestroyStaticVertexBuffers();
+#endif
     m_egl->DestroyContext(m_display, m_context);
+  }
   m_context = EGL_NO_CONTEXT;
 
   if (m_display != EGL_NO_DISPLAY)


### PR DESCRIPTION
This is quite a complex change, so I've formulated it as a series of dependent patches.

The aim is to reduce CPU/GPU bandwidth by keeping the vertices describing each string of font glyphs in a cache on the GPU side. Simple transformations (just translations in practice) are also performed on the GPU without needing to re-transfer the vertices.

At the moment, the main benefit is only available to OpenGL ES clients (such as the Raspberry Pi). However, there is a lesser benefit to be gained by the use of a CPU-side version of the cache, which is used in other cases, as well as in OpenGL ES cases where the selected transformation matrices rule out the use of hardware clipping.

I've benchmarked the typical rendering time of each frame on the main page of Confluence with RSS ticker and debug window enabled, on a non-overclocked Raspberry Pi:

```
      Before          After
      Mean   StdDev   Mean   StdDev  Confidence  Change
Time  20.5   3.8      18.2   3.8     100.0%      +12.5%
```

In FPS terms, 20.5 ms is 48.8 FPS, 18.2 ms is 54.9 FPS.
