### PR TITLE
[omxplayer] Avoid choosing TrueHD as default audio track

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -234,6 +234,10 @@ static bool PredicateAudioPriority(const OMXSelectionStream& lh, const OMXSelect
   PREDICATE_RETURN(lh.type_index == CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream
                  , rh.type_index == CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream);
 
+  // TrueHD never has enough cpu to decode on Pi, so prefer to avoid that
+  PREDICATE_RETURN(lh.codec != "truehd"
+                 , rh.codec != "truehd");
+
   if(!StringUtils::EqualsNoCase(CSettings::Get().GetString("locale.audiolanguage"), "original"))
   {
     CStdString audio_language = g_langInfo.GetAudioLanguage();


### PR DESCRIPTION
The Pi cannot decode TrueHD audio successfully, so make the default audio avoid choosing that.
It can still be switched to manually
