### PR TITLE
[rbp] Disable unsupport HD audio passthrough options

### DIFF
--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -61,6 +61,14 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="3">
+        <setting id="audiooutput.truehdpassthrough">
+          <visible>false</visible>
+        </setting>
+        <setting id="audiooutput.dtshdpassthrough">
+          <visible>false</visible>
+        </setting>
+      </group>
     </category>
   </section>
 </settings>


### PR DESCRIPTION
The hardware can't support HD audio, so remove them from settings
