### PR TITLE
[rbp] Disable ac3transcode by default

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -15084,3 +15084,8 @@ msgstr ""
 msgctxt "#37023"
 msgid "Do you wish to stop playback on the remote device?"
 msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#37024"
+msgid "Select this if the audio out connection only supports multichannel audio as Dolby Digital 5.1, this allows multichannel audio such as AAC5.1 or FLAC5.1 to be listened to in 5.1 surround sound. Note - Not recommended on Pi as this requires a lot of CPU."
+msgstr ""

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -68,6 +68,8 @@
         <setting id="audiooutput.dtshdpassthrough">
           <visible>false</visible>
         </setting>
+        <setting id="audiooutput.ac3transcode" help="37024">
+        </setting>
       </group>
     </category>
   </section>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2375,7 +2375,7 @@
         </setting>
         <setting id="audiooutput.ac3transcode" type="boolean" label="667" help="36429">
           <level>2</level>
-          <default>true</default>
+          <default>false</default>
           <dependencies>
             <dependency type="visible">
               <and>


### PR DESCRIPTION
ac3transcode is too expensive for the Pi and never keeps up.
Don't enable it by default.
