### PR TITLE
[PiSink] Set hdmi stream channels when in passthrough mode

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
@@ -66,6 +66,19 @@ void CAESinkPi::SetAudioDest()
 
 bool CAESinkPi::Initialize(AEAudioFormat &format, std::string &device)
 {
+  char response[80];
+  /* if we are raw need to let gpu know */
+  if (AE_IS_RAW(format.m_dataFormat))
+  {
+    vc_gencmd(response, sizeof response, "hdmi_stream_channels 1");
+    m_passthrough = true;
+  }
+  else
+  {
+    vc_gencmd(response, sizeof response, "hdmi_stream_channels 0");
+    m_passthrough = false;
+  }
+
   m_initDevice = device;
   m_initFormat = format;
   // setup for a 50ms sink feed from SoftAE

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.h
@@ -60,6 +60,7 @@ private:
   uint32_t             m_submitted;
   OMX_AUDIO_PARAM_PCMMODETYPE m_pcm_input;
   COMXCoreComponent    m_omx_render;
+  bool                 m_passthrough;
 };
 
 #endif


### PR DESCRIPTION
The GPU needs to know when in passthrough mode to set the number of channels
in the AV info frame to "refer to stream", so let it know.

This fixes AC3/DTS passthrough with Pi Sink. (Needs recent firmware).
