### PR TITLE
[rbp] Report in log if MPEG2 and VC1 licences are enabled

### DIFF
--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -59,10 +59,18 @@ bool CRBP::Initialize()
   char response[80] = "";
   m_arm_mem = 0;
   m_gpu_mem = 0;
+  m_codec_mpg2_enabled = false;
+  m_codec_wvc1_enabled = false;
+
   if (vc_gencmd(response, sizeof response, "get_mem arm") == 0)
     vc_gencmd_number_property(response, "arm", &m_arm_mem);
   if (vc_gencmd(response, sizeof response, "get_mem gpu") == 0)
     vc_gencmd_number_property(response, "gpu", &m_gpu_mem);
+
+  if (vc_gencmd(response, sizeof response, "codec_enabled MPG2") == 0)
+    m_codec_mpg2_enabled = strcmp("MPG2=enabled", response) == 0;
+  if (vc_gencmd(response, sizeof response, "codec_enabled WVC1") == 0)
+    m_codec_wvc1_enabled = strcmp("WVC1=enabled", response) == 0;
 
   g_OMXImage.Initialize();
   m_omx_image_init = true;
@@ -75,7 +83,7 @@ void CRBP::LogFirmwareVerison()
   m_DllBcmHost->vc_gencmd(response, sizeof response, "version");
   response[sizeof(response) - 1] = '\0';
   CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
-  CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB", m_arm_mem, m_gpu_mem);
+  CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB MPG2:%d WVC1:%d", m_arm_mem, m_gpu_mem, m_codec_mpg2_enabled, m_codec_wvc1_enabled);
 }
 
 void CRBP::GetDisplaySize(int &width, int &height)

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -50,6 +50,8 @@ public:
   void Deinitialize();
   int GetArmMem() { return m_arm_mem; }
   int GetGpuMem() { return m_gpu_mem; }
+  bool GetCodecMpg2() { return m_codec_mpg2_enabled; }
+  bool GetCodecWvc1() { return m_codec_wvc1_enabled; }
   void GetDisplaySize(int &width, int &height);
   // stride can be null for packed output
   unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue, bool video_only = true);
@@ -62,6 +64,8 @@ private:
   bool       m_omx_image_init;
   int        m_arm_mem;
   int        m_gpu_mem;
+  bool       m_codec_mpg2_enabled;
+  bool       m_codec_wvc1_enabled;
   COMXCore   *m_OMX;
   class DllLibOMXCore;
   CCriticalSection m_critSection;


### PR DESCRIPTION
A frequent support question is whether mpeg2/vc1 licences have been enabled correctly.
Put that info in log.
