### PR TITLE
[confluence] adds onback to epggrip control to access sidebar

### DIFF
--- a/addons/skin.confluence/720p/ViewsPVR.xml
+++ b/addons/skin.confluence/720p/ViewsPVR.xml
@@ -869,6 +869,7 @@
 				<onright>31</onright>
 				<onup>10</onup>
 				<ondown>10</ondown>
+				<onback>9000</onback> 
 				<rulerlayout height="35" width="40">
 					<control type="label" id="2">
 						<left>10</left>


### PR DESCRIPTION
As discussed at #3885 and the forum this solves the epg navigation usability issue that you can't quick access the sidebar menu in confluence, because left action is used to navigate inside the epg grid. This adds an onback action to focus the menu control (id=9000).
