### PR TITLE
[RFC] change keymaps for FullscreenLiveTV section

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -511,8 +511,8 @@
   </Favourites>
   <FullscreenLiveTV>
     <remote>
-      <left>PreviousChannelGroup</left>
-      <right>NextChannelGroup</right>
+      <left>StepBack</left>
+      <right>StepForward</right>
       <up>ChannelUp</up>
       <down>ChannelDown</down>
     </remote>


### PR DESCRIPTION
I want to discuss if we should change the default key mappings for FullscreenLiveTV section in remote.xml.
Currently we use _left/right_ to change the channel group which i think is unnecessary as we could do this in channel osd instead. Now we could use _left/right_ for timeshift seeking. Furthermore we should change _select_ to open the channel osd because we all need quick access to the channel list.
