### PR TITLE
[coreSubs] fix manual search button after 618cff753d20628920bb39d28ec40ba2619745f7

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -115,13 +115,13 @@ CGUIDialogSubtitles::~CGUIDialogSubtitles(void)
 
 bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
 {
-  if  (message.GetMessage() == GUI_MSG_CLICKED &&
-       (message.GetParam1() == ACTION_SELECT_ITEM ||
-        message.GetParam1() == ACTION_MOUSE_LEFT_CLICK))
+  if (message.GetMessage() == GUI_MSG_CLICKED)
   {
     int iControl = message.GetSenderId();
+    bool selectAction = (message.GetParam1() == ACTION_SELECT_ITEM ||
+                         message.GetParam1() == ACTION_MOUSE_LEFT_CLICK);
 
-    if (iControl == CONTROL_SUBLIST)
+    if (selectAction && iControl == CONTROL_SUBLIST)
     {
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_SUBLIST);
       OnMessage(msg);
@@ -131,7 +131,7 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
         Download(*m_subtitles->Get(item));
       return true;
     }
-    else if (iControl == CONTROL_SERVICELIST)
+    else if (selectAction && iControl == CONTROL_SERVICELIST)
     {
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_SERVICELIST);
       OnMessage(msg);


### PR DESCRIPTION
as title says, this fixes manual search button regression introduced in 618cff753d20628920bb39d28ec40ba2619745f7.

http://forum.xbmc.org/showthread.php?tid=185392

@jmarshallnz please check
