### PR TITLE
vdpau: Improve detection of supported files.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1833,17 +1833,18 @@ if test "x$use_vdpau" != "xno"; then
     fi
     USE_VDPAU=0
   else
-    USE_VDPAU=1
-    AC_CHECK_HEADER([vdpau/vdpau.h],AC_DEFINE([HAVE_LIBVDPAU], [],
-      [Define to 1 if you have the 'vdpau' library (-lvdpau).]),
-    [if test "x$use_vdpau" = "xyes"; then
-      USE_VDPAU=0
-      AC_MSG_ERROR([$vdpau_not_found])
-    else
-      use_vdpau="no"
-      USE_VDPAU=0
-      AC_MSG_RESULT($vdpau_not_found)
-    fi])
+    if test "x$use_vdpau" = xyes; then
+      PKG_CHECK_EXISTS([vdpau], [use_vdpau=yes], [use_vdpau=no])
+      if test "x$use_vdpau" = "xyes"; then
+        PKG_CHECK_MODULES([VDPAU], [vdpau >= 0.4.1], [use_vdpau=yes], [use_vdpau=no])
+      fi
+      if test "x$use_vdpau" = "xyes"; then
+        USE_VDPAU=1
+      else
+        USE_VDPAU=0
+        AC_MSG_ERROR([$vdpau_not_found])
+      fi   
+	fi
   fi
 else
   USE_VDPAU=0

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -52,9 +52,7 @@ CDecoder::Desc decoder_profiles[] = {
 {"VC1_SIMPLE",   VDP_DECODER_PROFILE_VC1_SIMPLE},
 {"VC1_MAIN",     VDP_DECODER_PROFILE_VC1_MAIN},
 {"VC1_ADVANCED", VDP_DECODER_PROFILE_VC1_ADVANCED},
-#ifdef VDP_DECODER_PROFILE_MPEG4_PART2_ASP
 {"MPEG4_PART2_ASP", VDP_DECODER_PROFILE_MPEG4_PART2_ASP},
-#endif
 };
 const size_t decoder_profile_count = sizeof(decoder_profiles)/sizeof(CDecoder::Desc);
 
@@ -849,12 +847,10 @@ void CDecoder::ReadFormatOf( AVCodecID codec
       vdp_decoder_profile = VDP_DECODER_PROFILE_VC1_ADVANCED;
       vdp_chroma_type     = VDP_CHROMA_TYPE_420;
       break;
-#ifdef VDP_DECODER_PROFILE_MPEG4_PART2_ASP
     case AV_CODEC_ID_MPEG4:
       vdp_decoder_profile = VDP_DECODER_PROFILE_MPEG4_PART2_ASP;
       vdp_chroma_type     = VDP_CHROMA_TYPE_420;
       break;
-#endif
     default:
       vdp_decoder_profile = 0;
       vdp_chroma_type     = 0;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -531,7 +531,7 @@ bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int 
       vdp_st = m_vdpauConfig.context->GetProcs().vdp_decoder_query_caps(m_vdpauConfig.context->GetDevice(),
        profile, &is_supported, &max_level, &max_macroblocks, &max_width, &max_height);
       /* Test to make Sure there is a Possibility the Codec will Work */
-      if(vdp_st != VDP_STATUS_OK)
+      if(CheckStatus(vdp_st, __LINE__))
       {
         CLog::Log(LOGERROR, " (VDPAU) Error: %s(%d) checking for decoder support\n", m_vdpauConfig.context->GetProcs().vdp_get_error_string(vdp_st), vdp_st);
         return false;
@@ -548,7 +548,7 @@ bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int 
       /* attempt to create a decoder with this width/height, some sizes are not supported by hw */
       vdp_st = m_vdpauConfig.context->GetProcs().vdp_decoder_create(m_vdpauConfig.context->GetDevice(), profile, avctx->coded_width, avctx->coded_height, 5, &m_vdpauConfig.vdpDecoder);
 
-      if(vdp_st != VDP_STATUS_OK)
+      if(CheckStatus(vdp_st, __LINE__))
       {
         CLog::Log(LOGERROR, " (VDPAU) Error: %s(%d) checking for decoder support\n", m_vdpauConfig.context->GetProcs().vdp_get_error_string(vdp_st), vdp_st);
         return false;


### PR DESCRIPTION
A minor improvement on the detection of whether or not a video will
play. It is a good idea to at least make sure that the video codec
is supported and that the resolution does not exceed the supported
resolution. A good example of this is that there is an ever increasing
number of 4K videos and not all devices are capable of using the
hardware decoder to decode these.
