### PR TITLE
fix-builtin-resolution

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -510,8 +510,6 @@ int CBuiltins::Execute(const CStdString& execString)
       // format: SWWWWWHHHHHRRR.RRRRRP, where,
       //  S = screen, W = width, H = height, R = refresh, P = interlace
       res = CDisplaySettings::GetResolutionFromString(parameter);
-      const char *strMode = CDisplaySettings::Get().GetResolutionInfo(res).strMode.c_str();
-      CLog::Log(LOGERROR,"resolution:res(%d), parameter(%s), strMode(%s)", res, parameter.c_str(), strMode);
     }
     if (g_graphicsContext.IsValidResolution(res))
     {

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -495,16 +495,24 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("resolution"))
   {
     RESOLUTION res = RES_PAL_4x3;
-    if (parameter.Equals("pal")) res = RES_PAL_4x3;
-    else if (parameter.Equals("pal16x9")) res = RES_PAL_16x9;
-    else if (parameter.Equals("ntsc")) res = RES_NTSC_4x3;
-    else if (parameter.Equals("ntsc16x9")) res = RES_NTSC_16x9;
-    else if (parameter.Equals("720p")) res = RES_HDTV_720p;
-    else if (parameter.Equals("720pSBS")) res = RES_HDTV_720pSBS;
-    else if (parameter.Equals("720pTB")) res = RES_HDTV_720pTB;
-    else if (parameter.Equals("1080pSBS")) res = RES_HDTV_1080pSBS;
-    else if (parameter.Equals("1080pTB")) res = RES_HDTV_1080pTB;
-    else if (parameter.Equals("1080i")) res = RES_HDTV_1080i;
+    if (parameter.Equals("pal"))            res = RES_PAL_4x3;
+    else if (parameter.Equals("pal16x9"))   res = RES_PAL_16x9;
+    else if (parameter.Equals("ntsc"))      res = RES_NTSC_4x3;
+    else if (parameter.Equals("ntsc16x9"))  res = RES_NTSC_16x9;
+    else if (parameter.Equals("720p"))      res = RES_HDTV_720p;
+    else if (parameter.Equals("720pSBS"))   res = RES_HDTV_720pSBS;
+    else if (parameter.Equals("720pTB"))    res = RES_HDTV_720pTB;
+    else if (parameter.Equals("1080pSBS"))  res = RES_HDTV_1080pSBS;
+    else if (parameter.Equals("1080pTB"))   res = RES_HDTV_1080pTB;
+    else if (parameter.Equals("1080i"))     res = RES_HDTV_1080i;
+    else
+    {
+      // format: SWWWWWHHHHHRRR.RRRRRP, where,
+      //  S = screen, W = width, H = height, R = refresh, P = interlace
+      res = CDisplaySettings::GetResolutionFromString(parameter);
+      const char *strMode = CDisplaySettings::Get().GetResolutionInfo(res).strMode.c_str();
+      CLog::Log(LOGERROR,"resolution:res(%d), parameter(%s), strMode(%s)", res, parameter.c_str(), strMode);
+    }
     if (g_graphicsContext.IsValidResolution(res))
     {
       CDisplaySettings::Get().SetCurrentResolution(res, true);

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -96,6 +96,8 @@ public:
   static void SettingOptionsStereoscopicModesFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
   static void SettingOptionsPreferredStereoscopicViewModesFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current);
 
+  static RESOLUTION GetResolutionFromString(const std::string &strResolution);
+
 protected:
   CDisplaySettings();
   CDisplaySettings(const CDisplaySettings&);
@@ -104,7 +106,6 @@ protected:
 
   DisplayMode GetCurrentDisplayMode() const;
 
-  static RESOLUTION GetResolutionFromString(const std::string &strResolution);
   static std::string GetStringFromResolution(RESOLUTION resolution, float refreshrate = 0.0f);
   static RESOLUTION GetResolutionForScreen();
 


### PR DESCRIPTION
Setting the display resolution from builtins (addon) relies on predefined resolutions that might or might not be present. Allow setting the display resolution using the resolution string format that CDisplaySettings uses.
