### PR TITLE
settings: fix not being able to overwrite the default value of string/addon settings with an empty value

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -1145,7 +1145,8 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
 
   // get the default value
   CStdString value;
-  if (XMLUtils::GetString(node, SETTING_XML_ELM_DEFAULT, value) && !value.empty())
+  if (XMLUtils::GetString(node, SETTING_XML_ELM_DEFAULT, value) &&
+     (!value.empty() || m_allowEmpty))
     m_value = m_default = value;
   else if (!update && !m_allowEmpty)
   {


### PR DESCRIPTION
This fixes the problem (that @davilla encountered) that it's not possible to overwrite the default value of a string (or string-derived) setting with an empty value even when

```
<allowempty>true</allowempty>
```

is set.

It however doesn't cover the case where there already is a guisettings.xml with a value for the setting which has its default value overwritten (even if the value is set to the default value) because we can't know if the user specifically set that value or not.
