### PR TITLE
Suspend via logind over UPower if available.

### DIFF
--- a/addons/skin.confluence/720p/DialogSubtitles.xml
+++ b/addons/skin.confluence/720p/DialogSubtitles.xml
@@ -284,27 +284,25 @@
 				</control>
 				<control type="group" id="130">
 					<control type="grouplist">
-						<left>20</left>
-						<top>660</top>
-						<width>305</width>
-						<height>40</height>
-						<align>right</align>
+						<left>50</left>
+						<top>659</top>
+						<width>605</width>
+						<height>30</height>
 						<orientation>horizontal</orientation>
 						<itemgap>5</itemgap>
 						<control type="image">
-							<width>40</width>
-							<height>40</height>
+							<width>30</width>
+							<height>30</height>
 							<texture>DefaultIconInfo.png</texture>
 						</control>
 						<control type="label">
 							<description>notification</description>
-							<width min="10" max="260">auto</width>
-							<height>40</height>
+							<width min="10" max="560">auto</width>
+							<height>30</height>
 							<font>font13</font>
 							<textcolor>white</textcolor>
-							<label>31413</label>
+							<label>$LOCALIZE[31413]</label>
 							<aligny>center</aligny>
-							<wrapmultiline>true</wrapmultiline>
 						</control>
 					</control>
 				</control>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11832,9 +11832,10 @@ msgctxt "#24022"
 msgid "Enable"
 msgstr ""
 
+#. Defines the state of the add-on in the add-on manager window
 #: xbmc/filesystem/AddonsDirectory.cpp
 msgctxt "#24023"
-msgid "Add-on disabled"
+msgid "Disabled"
 msgstr ""
 
 #empty strings from id 24024 to 24026

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2100,7 +2100,7 @@
       <requirement>HAS_ZEROCONF</requirement>
       <group id="1">
         <setting id="services.zeroconf" type="boolean" label="1260" help="36342">
-          <level>2</level>
+          <level>1</level>
           <default>true</default>
           <control type="toggle" />
         </setting>

--- a/tools/Linux/xbmc.sh.in
+++ b/tools/Linux/xbmc.sh.in
@@ -23,6 +23,7 @@ prefix="@prefix@"
 exec_prefix="@exec_prefix@"
 datarootdir="@datarootdir@"
 LIBDIR="@libdir@"
+CRASHLOG_DIR=${CRASHLOG_DIR:-$HOME}
 
 # Check for some options used by this script
 while [ "$#" -gt "0" ]
@@ -52,7 +53,7 @@ single_stacktrace()
 
 print_crash_report()
 {
-  FILE="$HOME/xbmc_crashlog-`date +%Y%m%d_%H%M%S`.log"
+  FILE="$CRASHLOG_DIR/xbmc_crashlog-`date +%Y%m%d_%H%M%S`.log"
   echo "############## XBMC CRASH LOG ###############" >> $FILE
   echo >> $FILE
   echo "################ SYSTEM INFO ################" >> $FILE

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -733,7 +733,10 @@ void CAddonInstallJob::OnPostInstall(bool reloadAddon)
         toast->ResetTimer();
         toast->Close(true);
       }
-      CSettings::Get().SetString("lookandfeel.skin",m_addon->ID().c_str());
+      if (CSettings::Get().GetString("lookandfeel.skin") == m_addon->ID())
+        CApplicationMessenger::Get().ExecBuiltIn("ReloadSkin", true);
+      else
+        CSettings::Get().SetString("lookandfeel.skin",m_addon->ID().c_str());
     }
   }
 

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -140,10 +140,11 @@ void CWinRenderer::SelectRenderMethod()
   {
     CLog::Log(LOGNOTICE, "D3D: rendering method forced to DXVA processor");
     m_renderMethod = RENDER_DXVA;
-    if (!m_processor->Open(m_sourceWidth, m_sourceHeight, m_iFlags, m_format, m_extended_format))
+    if (!m_processor || !m_processor->Open(m_sourceWidth, m_sourceHeight, m_iFlags, m_format, m_extended_format))
     {
       CLog::Log(LOGNOTICE, "D3D: unable to open DXVA processor");
-      m_processor->Close();
+      if (m_processor)  
+        m_processor->Close();
       m_renderMethod = RENDER_INVALID;
     }
   }
@@ -155,13 +156,16 @@ void CWinRenderer::SelectRenderMethod()
     {
       case RENDER_METHOD_DXVAHD:
       case RENDER_METHOD_DXVA:
-        m_renderMethod = RENDER_DXVA;
-        if (m_processor->Open(m_sourceWidth, m_sourceHeight, m_iFlags, m_format, m_extended_format))
-            break;
-        else
+        if (!m_processor || !m_processor->Open(m_sourceWidth, m_sourceHeight, m_iFlags, m_format, m_extended_format))
         {
           CLog::Log(LOGNOTICE, "D3D: unable to open DXVA processor");
-          m_processor->Close();
+          if (m_processor)
+            m_processor->Close();
+        }
+        else
+        {
+          m_renderMethod = RENDER_DXVA;
+          break;
         }
       // Drop through to pixel shader
       case RENDER_METHOD_AUTO:
@@ -396,8 +400,9 @@ unsigned int CWinRenderer::PreInit()
 
   m_iRequestedMethod = CSettings::Get().GetInt("videoplayer.rendermethod");
 
-  if (g_advancedSettings.m_DXVAForceProcessorRenderer || m_iRequestedMethod == RENDER_METHOD_DXVA
-      || m_iRequestedMethod == RENDER_METHOD_DXVAHD)
+  if (g_advancedSettings.m_DXVAForceProcessorRenderer
+  ||  m_iRequestedMethod == RENDER_METHOD_DXVA
+  ||  m_iRequestedMethod == RENDER_METHOD_DXVAHD)
   {
     if (m_iRequestedMethod != RENDER_METHOD_DXVA && CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin7))
     {
@@ -406,29 +411,30 @@ unsigned int CWinRenderer::PreInit()
       {
         CLog::Log(LOGNOTICE, "CWinRenderer::Preinit - could not init DXVA-HD processor - skipping");
         SAFE_DELETE(m_processor);
-        m_processor = new DXVA::CProcessor();
       }
-      else
-        return 0;
     }
-    else
+    if (!m_processor)
+    {
       m_processor = new DXVA::CProcessor();
-
-    if (!m_processor->PreInit())
-      CLog::Log(LOGNOTICE, "CWinRenderer::Preinit - could not init DXVA2 processor - skipping");
-    else
-      return 0;
+      if (!m_processor->PreInit())
+      {
+        CLog::Log(LOGNOTICE, "CWinRenderer::Preinit - could not init DXVA2 processor - skipping");
+        SAFE_DELETE(m_processor);
+      }
+    }
   }
-  
-  if (g_Windowing.IsTextureFormatOk(D3DFMT_L16, 0))
+  // allow other color spaces besides YV12 in case DXVA rendering is not used or not available
+  if (!m_processor || (m_iRequestedMethod != RENDER_METHOD_DXVA && m_iRequestedMethod != RENDER_METHOD_DXVAHD))
   {
-    m_formats.push_back(RENDER_FMT_YUV420P10);
-    m_formats.push_back(RENDER_FMT_YUV420P16);
+    if (g_Windowing.IsTextureFormatOk(D3DFMT_L16, 0))
+    {
+      m_formats.push_back(RENDER_FMT_YUV420P10);
+      m_formats.push_back(RENDER_FMT_YUV420P16);
+    }
+    m_formats.push_back(RENDER_FMT_NV12);
+    m_formats.push_back(RENDER_FMT_YUYV422);
+    m_formats.push_back(RENDER_FMT_UYVY422);
   }
-  m_formats.push_back(RENDER_FMT_NV12);
-  m_formats.push_back(RENDER_FMT_YUYV422);
-  m_formats.push_back(RENDER_FMT_UYVY422);
-
   return 0;
 }
 

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -286,13 +286,13 @@ void CGUIScrollBar::SetFromPosition(const CPoint &point)
 {
   float fPercent;
   if (m_orientation == VERTICAL)
-    fPercent = (point.y - m_guiBackground.GetYPosition() - 0.5f*m_guiBarFocus.GetHeight()) / m_guiBackground.GetHeight();
+    fPercent = (point.y - m_guiBackground.GetYPosition() - 0.5f*m_guiBarFocus.GetHeight()) / (m_guiBackground.GetHeight() - m_guiBarFocus.GetHeight());
   else
-    fPercent = (point.x - m_guiBackground.GetXPosition() - 0.5f*m_guiBarFocus.GetWidth()) / m_guiBackground.GetWidth();
+    fPercent = (point.x - m_guiBackground.GetXPosition() - 0.5f*m_guiBarFocus.GetWidth()) / (m_guiBackground.GetWidth() - m_guiBarFocus.GetWidth());
   if (fPercent < 0) fPercent = 0;
   if (fPercent > 1) fPercent = 1;
 
-  int offset = (int)(floor(fPercent * m_numItems + 0.5f));
+  int offset = (int)(floor(fPercent * (m_numItems - m_pageSize) + 0.5f));
 
   if (m_offset != offset)
   {

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -115,11 +115,16 @@ void CJoystick::Initialize()
         // Details: Total Axis: 37 Total Hats: 0 Total Buttons: 57
         // NOTICE: Enabled Joystick: Microsoft Microsoft® 2.4GHz Transceiver v6.0
         // Details: Total Axis: 37 Total Hats: 0 Total Buttons: 57
+        // also checks if we have at least 1 button, fixes 
+        // NOTICE: Enabled Joystick: ST LIS3LV02DL Accelerometer
+        // Details: Total Axis: 3 Total Hats: 0 Total Buttons: 0
         int num_axis = SDL_JoystickNumAxes(joy);
         int num_buttons = SDL_JoystickNumButtons(joy);
-        if (num_axis > 20 && num_buttons > 50)
-          CLog::Log(LOGNOTICE, "Your Joystick seems to be a Keyboard, ignoring it: %s Axis: %d Buttons: %d", 
-            SDL_JoystickName(i), num_axis, num_buttons);
+        if ((num_axis > 20 && num_buttons > 50) || num_buttons == 0)
+        {
+          CLog::Log(LOGNOTICE, "Ignoring Joystick %s Axis: %d Buttons: %d: invalid device properties",
+           SDL_JoystickName(i), num_axis, num_buttons);
+        }
         else
         {
           m_JoystickNames.push_back(string(SDL_JoystickName(i)));

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -29,6 +29,7 @@
 #ifdef TARGET_WINDOWS
 #include "utils/SystemInfo.h"
 #include "win32/WIN32Util.h"
+#include "utils/CharsetConverter.h"
 #endif
 
 /* slightly modified in_ether taken from the etherboot project (http://sourceforge.net/projects/etherboot) */
@@ -162,8 +163,14 @@ CStdString CNetwork::GetHostName(void)
   char hostName[128];
   if (gethostname(hostName, sizeof(hostName)))
     return CStdString("unknown");
-  else
-    return CStdString(hostName);
+
+  std::string hostStr;
+#ifdef TARGET_WINDOWS
+  g_charsetConverter.systemToUtf8(hostName, hostStr);
+#else
+  hostStr = hostName;
+#endif
+  return hostStr;
 }
 
 CNetworkInterface* CNetwork::GetFirstConnectedInterface()

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -78,12 +78,12 @@ void CPowerManager::Initialize()
   m_instance = new CAndroidPowerSyscall();
 #elif defined(TARGET_POSIX)
 #if defined(HAS_DBUS)
-  if (CConsoleUPowerSyscall::HasConsoleKitAndUPower())
+  if (CLogindUPowerSyscall::HasLogind())
+    m_instance = new CLogindUPowerSyscall();
+  else if (CConsoleUPowerSyscall::HasConsoleKitAndUPower())
     m_instance = new CConsoleUPowerSyscall();
   else if (CConsoleDeviceKitPowerSyscall::HasDeviceConsoleKit())
     m_instance = new CConsoleDeviceKitPowerSyscall();
-  else if (CLogindUPowerSyscall::HasLogind())
-    m_instance = new CLogindUPowerSyscall();
   else if (CUPowerSyscall::HasUPower())
     m_instance = new CUPowerSyscall();
 #if defined(HAS_HAL)

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -860,6 +860,13 @@ bool CSettingsManager::OnSettingsLoading()
   return true;
 }
 
+void CSettingsManager::OnSettingsUnloaded()
+{
+  CSharedLock lock(m_critical);
+  for (SettingsHandlers::const_iterator it = m_settingsHandlers.begin(); it != m_settingsHandlers.end(); ++it)
+    (*it)->OnSettingsUnloaded();
+}
+
 void CSettingsManager::OnSettingsLoaded()
 {
   CSharedLock lock(m_critical);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -393,6 +393,7 @@ private:
   // implementation of ISettingsHandler
   virtual bool OnSettingsLoading();
   virtual void OnSettingsLoaded();
+  virtual void OnSettingsUnloaded();
   virtual bool OnSettingsSaving() const;
   virtual void OnSettingsSaved() const;
   virtual void OnSettingsCleared();

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -22,6 +22,7 @@
 #define WINDOW_SYSTEM_WIN32_H
 
 #include "windowing/WinSystem.h"
+#include <string>
 
 struct MONITOR_DETAILS
 {
@@ -33,9 +34,9 @@ struct MONITOR_DETAILS
   bool      Interlaced;
 
   HMONITOR  hMonitor;
-  char      MonitorName[128];
-  char      CardName[128];
-  char      DeviceName[128];
+  std::wstring MonitorNameW;
+  std::wstring CardNameW;
+  std::wstring DeviceNameW;
   int       ScreenNumber; // XBMC POV, not Windows. Windows primary is XBMC #0, then each secondary is +1.
 };
 


### PR DESCRIPTION
The suspend feature of UPower is deprecated. XBMC supports suspending using systemd-logind, however it defaults to a few other UPower methods first before trying Logind. This patch checks for logind first, and uses it if available.
