### PR TITLE
FIX: do not popup OSD on DVD menu with touch or mouse (fixes #14906)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2704,6 +2704,10 @@ bool CApplication::OnAction(const CAction &action)
   {
     if (m_pPlayer->OnAction(action))
       return true;
+    // Player ignored action; popup the OSD
+    if ((action.GetID() == ACTION_MOUSE_MOVE && (action.GetAmount(2) || action.GetAmount(3)))  // filter "false" mouse move from touch
+        || action.GetID() == ACTION_MOUSE_LEFT_CLICK)
+      CApplicationMessenger::Get().SendAction(CAction(ACTION_TRIGGER_OSD), WINDOW_INVALID, false);
   }
 
   // stop : stops playing current audio song

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3729,7 +3729,15 @@ bool CDVDPlayer::OnAction(const CAction &action)
           pt.y *= rs.Height() / rd.Height();
           pt += CPoint(rs.x1, rs.y1);
           if (action.GetID() == ACTION_MOUSE_LEFT_CLICK)
-            return pMenus->OnMouseClick(pt);
+          {
+            if (pMenus->OnMouseClick(pt))
+              return true;
+            else
+            {
+              CApplicationMessenger::Get().SendAction(CAction(ACTION_TRIGGER_OSD), WINDOW_INVALID, false); // Trigger the osd
+              return false;
+            }
+          }
           return pMenus->OnMouseMove(pt);
         }
         break;

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3998,7 +3998,15 @@ bool COMXPlayer::OnAction(const CAction &action)
           pt.y *= rs.Height() / rd.Height();
           pt += CPoint(rs.x1, rs.y1);
           if (action.GetID() == ACTION_MOUSE_LEFT_CLICK)
-            return pMenus->OnMouseClick(pt);
+          {
+            if (pMenus->OnMouseClick(pt))
+              return true;
+            else
+            {
+              CApplicationMessenger::Get().SendAction(CAction(ACTION_TRIGGER_OSD), WINDOW_INVALID, false); // Trigger the osd
+              return false;
+            }
+          }
           return pMenus->OnMouseMove(pt);
         }
         break;

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -332,6 +332,8 @@
 #define ACTION_SETTINGS_RESET         241
 #define ACTION_SETTINGS_LEVEL_CHANGE  242
 
+#define ACTION_TRIGGER_OSD            243 // show autoclosing OSD. Can b used in videoFullScreen.xml window id=2005
+
 // touch actions
 #define ACTION_TOUCH_TAP              401
 #define ACTION_TOUCH_TAP_TEN          410

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -142,6 +142,10 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
     ToggleOSD();
     return true;
 
+  case ACTION_TRIGGER_OSD:
+    TriggerOSD();
+    return true;
+
   case ACTION_SHOW_GUI:
     {
       // switch back to the menu
@@ -538,17 +542,6 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
   }
   if (event.m_id >= ACTION_GESTURE_NOTIFY && event.m_id <= ACTION_GESTURE_END) // gestures
     return EVENT_RESULT_UNHANDLED;
-  if (event.m_id != ACTION_MOUSE_MOVE || event.m_offsetX || event.m_offsetY)
-  { // some other mouse action has occurred - bring up the OSD
-    // if it is not already running
-    CGUIDialogVideoOSD *pOSD = (CGUIDialogVideoOSD *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_OSD);
-    if (pOSD && !pOSD->IsDialogRunning())
-    {
-      pOSD->SetAutoClose(3000);
-      pOSD->DoModal();
-    }
-    return EVENT_RESULT_HANDLED;
-  }
   return EVENT_RESULT_UNHANDLED;
 }
 
@@ -860,5 +853,15 @@ void CGUIWindowFullScreen::ToggleOSD()
       pOSD->Close();
     else
       pOSD->DoModal();
+  }
+}
+
+void CGUIWindowFullScreen::TriggerOSD()
+{
+  CGUIDialogVideoOSD *pOSD = (CGUIDialogVideoOSD *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_OSD);
+  if (pOSD && !pOSD->IsDialogRunning())
+  {
+    pOSD->SetAutoClose(3000);
+    pOSD->DoModal();
   }
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -44,6 +44,7 @@ private:
   void SeekChapter(int iChapter);
   void FillInTVGroups();
   void ToggleOSD();
+  void TriggerOSD();
 
   enum SEEK_TYPE { SEEK_ABSOLUTE, SEEK_RELATIVE };
   enum SEEK_DIRECTION { SEEK_FORWARD, SEEK_BACKWARD };


### PR DESCRIPTION
/cc @jmarshallnz @Memphiz 
ref: http://forum.xbmc.org/showthread.php?tid=180952

This prevents the osd to pop up on a tap or mouse move when a dvd menu is displayed.

pro:
- Prevents the dvd menu to be overlapped by the osd
- Leaner

con:
- No way to stop the dvd with touch or mouse when on a menu. You have to leave fullscreen.
