### PR TITLE
[pvr] fix: missing action mapping for ACTION_RECORD

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -59,7 +59,7 @@
       <skipminus>SkipPrevious</skipminus>
       <display>FullScreen</display>
       <start>PreviousMenu</start>
-      <record>Screenshot</record>
+      <record>Record</record>
       <volumeplus>VolumeUp</volumeplus>
       <volumeminus>VolumeDown</volumeminus>
       <mute>Mute</mute>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2748,6 +2748,13 @@ bool CApplication::OnAction(const CAction &action)
       }
     }
 
+    // record current file
+    if (action.GetID() == ACTION_RECORD)
+    {
+      if (m_pPlayer->CanRecord())
+        m_pPlayer->Record(!m_pPlayer->IsRecording());
+    }
+
     if (m_playerController->OnAction(action))
       return true;
   }

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -242,6 +242,7 @@ static const ActionMapping actions[] =
         {"playpvr"               , ACTION_PVR_PLAY},
         {"playpvrtv"             , ACTION_PVR_PLAY_TV},
         {"playpvrradio"          , ACTION_PVR_PLAY_RADIO},
+        {"record"                , ACTION_RECORD},
 
         // Mouse actions
         {"leftclick"         , ACTION_MOUSE_LEFT_CLICK},


### PR DESCRIPTION
This adds the missing button translator action "record" poiting to ACTION_RECORD which is currently used in several PVR related windows, but could not be used in key mappings. 

It also adds a default implementation to GUIWindow which calls the application player record functionality, so there is no need to use XBMC.PlayerControls(record) in key mapping anymore.

Furthermore the default mapping for the record button in remote.xml is changed to this new action.

This is discussed at http://forum.xbmc.org/showthread.php?tid=185107.

@opdenkamp it's up to you if this is a fix or feature for G+1.
