### PR TITLE
Gotham fix: masterlockcode is not saved

### DIFF
--- a/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsCategory.cpp
@@ -32,6 +32,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "profiles/ProfilesManager.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -378,6 +379,8 @@ bool CGUIWindowSettingsCategory::OnAction(const CAction &action)
 bool CGUIWindowSettingsCategory::OnBack(int actionID)
 {
   m_settings.Save();
+  // For mastercode
+  CProfilesManager::Get().Save();
   m_lastControlID = 0; // don't save the control as we go to a different window each time
   
   return CGUIWindow::OnBack(actionID);

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -126,7 +126,7 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(unsigned int id)
   setting.min = 0;
   setting.data = &m_audioStream;
 
-  // get the number of audio strams for the current movie
+  // get the number of audio streams for the current movie
   setting.max = (float)g_application.m_pPlayer->GetAudioStreamCount() - 1;
   m_audioStream = g_application.m_pPlayer->GetAudioStream();
 


### PR DESCRIPTION
masterlockcode is never saved and not set upon xbmc restart cause one do not save profiles.xml when leaving WindowsSettingsCategory.
