### PR TITLE
Two settings related fixes

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2641,9 +2641,8 @@
     <category id="masterlock" label="12360" help="36395">
       <access>CheckMasterLock</access>
       <group id="1">
-        <setting id="masterlock.lockcode" type="string" label="20100" help="36396">
+        <setting id="masterlock.lockcode" type="action" label="20100" help="36396">
           <level>2</level>
-          <default>-</default>
           <control type="button" format="action">
             <hidevalue>true</hidevalue>
           </control>

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -635,18 +635,16 @@ void CWakeOnAccess::OnSettingsLoaded()
   LoadFromXML();
 }
 
-void CWakeOnAccess::OnSettingsSaved() const
+void CWakeOnAccess::OnSettingsSaved()
 {
   bool enabled = CSettings::Get().GetBool("powermanagement.wakeonaccess");
 
   if (enabled != IsEnabled())
   {
-    CWakeOnAccess& woa = CWakeOnAccess::Get();
-
-    woa.SetEnabled(enabled);
+    SetEnabled(enabled);
 
     if (enabled)
-      woa.QueueMACDiscoveryForAllRemotes();
+      QueueMACDiscoveryForAllRemotes();
   }
 }
 

--- a/xbmc/network/WakeOnAccess.h
+++ b/xbmc/network/WakeOnAccess.h
@@ -35,7 +35,7 @@ public:
 
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
   virtual void OnSettingsLoaded();
-  virtual void OnSettingsSaved() const;
+  virtual void OnSettingsSaved();
 
   // struct to keep per host settings
   struct WakeUpEntry

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -96,10 +96,10 @@ void CProfilesManager::OnSettingsLoaded()
   CDirectory::Create(URIUtils::AddFileToFolder(strDir,"mixed"));
 }
 
-bool CProfilesManager::OnSettingsSaved()
+void CProfilesManager::OnSettingsSaved()
 {
   // save mastercode
-  return Save();
+  Save();
 }
 
 void CProfilesManager::OnSettingsCleared()

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -33,7 +33,7 @@ public:
   static CProfilesManager& Get();
 
   virtual void OnSettingsLoaded();
-  virtual bool OnSettingsSaved();
+  virtual void OnSettingsSaved();
   virtual void OnSettingsCleared();
 
   bool Load();

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -838,11 +838,14 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   { // read the loglevel setting, so set the setting advanced to hide it in GUI
     // as altering it will do nothing - we don't write to advancedsettings.xml
     XMLUtils::GetInt(pRootElement, "loglevel", m_logLevelHint, LOG_LEVEL_NONE, LOG_LEVEL_MAX);
-    CSettingBool *setting = (CSettingBool *)CSettings::Get().GetSetting("debug.showloginfo");
-    if (setting != NULL)
+    const char* hide = pElement->Attribute("hide");
+    if (hide == NULL || strnicmp("false", hide, 4) != 0)
     {
-      const char* hide;
-      if (!((hide = pElement->Attribute("hide")) && strnicmp("false", hide, 4) == 0))
+      CSetting *setting = CSettings::Get().GetSetting("debug.showloginfo");
+      if (setting != NULL)
+        setting->SetVisible(false);
+      setting = CSettings::Get().GetSetting("debug.setextraloglevel");
+      if (setting != NULL)
         setting->SetVisible(false);
     }
     g_advancedSettings.m_logLevel = std::max(g_advancedSettings.m_logLevel, g_advancedSettings.m_logLevelHint);

--- a/xbmc/settings/lib/ISettingsHandler.h
+++ b/xbmc/settings/lib/ISettingsHandler.h
@@ -52,7 +52,7 @@ public:
 
    This callback can be used to trigger saving other settings.
    */
-  virtual void OnSettingsSaved() const { }
+  virtual void OnSettingsSaved() { }
   /*!
    \brief Setting values have been unloaded.
 


### PR DESCRIPTION
Thanks to #4172 I've found a bug in the code of ISettingsHandler with the OnSettingsSaved() method. It doesn't make sense to define that method as const as it is used to read the changed settings and adjust something or to save additional settings (as is the case with profiles.xml). This fixes saving the master lockcode in profiles.xml after it has been changed in Settings -> System -> Master lock.
Furthermore the "masterlock.lockcode" setting is defined as a string setting (because I thought that's where the master lockcode is stored) but it should actually be an action setting as the master lockcode value is stored in profiles.xml and not in guisettings.xml.

Furthermore I've noticed that when <<loglevel>> is set in advancedsettings.xml we hide the "debug.showloginfo" setting but we didn't hide it's child setting "debug.setextraloglevel" which is then disabled and can't be accessed anyway.
