### PR TITLE
parallel make fixes the 3rd

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -516,7 +516,7 @@ xbmc/xbmc.o: xbmc/xbmc.a
 
 xbmc/android/activity/android_main.o: xbmc/android/activity/activity.a
 
-xbmc/main/main.o: xbmc/main/main.a
+xbmc/main/main.o xbmc/main/main.a: xbmc/main
 
 # sync these entries manually with tools/depends/target/xbmc-addon-bindings/Makefile
 BINDINGS =xbmc/addons/include/xbmc_addon_cpp_dll.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -272,7 +272,8 @@ SKIN_DIRS+=$(TOUCHED_MEDIA)
 endif
 
 DIRS= $(BIN_DIRS) $(EC_DIRS) $(XBMCTEX_DIRS) $(DVDPCODECS_DIRS) $(PAPCODECS_DIRS) \
-	$(LIB_DIRS) $(SS_DIRS) $(VIS_DIRS) $(LIBADDON_DIRS) $(SKIN_DIRS) xbmc/main
+	$(LIB_DIRS) $(SS_DIRS) $(VIS_DIRS) $(LIBADDON_DIRS) $(SKIN_DIRS) \
+        xbmc/main xbmc/android/activity xbmc
 
 LIBS=@LIBS@
 CFLAGS=@CFLAGS@
@@ -512,9 +513,9 @@ ifneq (@USE_LIBXBMC@,1)
 MAINOBJS+=xbmc/main/main.o
 endif
 
-xbmc/xbmc.o: xbmc/xbmc.a
+xbmc/xbmc.o xbmc/xbmc.a: xbmc
 
-xbmc/android/activity/android_main.o: xbmc/android/activity/activity.a
+xbmc/android/activity/android_main.o xbmc/android/activity/activity.a: xbmc/android/activity
 
 xbmc/main/main.o xbmc/main/main.a: xbmc/main
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -512,6 +512,12 @@ ifneq (@USE_LIBXBMC@,1)
 MAINOBJS+=xbmc/main/main.o
 endif
 
+xbmc/xbmc.o: xbmc/xbmc.a
+
+xbmc/android/activity/android_main.o: xbmc/android/activity/activity.a
+
+xbmc/main/main.o: xbmc/main/main.a
+
 # sync these entries manually with tools/depends/target/xbmc-addon-bindings/Makefile
 BINDINGS =xbmc/addons/include/xbmc_addon_cpp_dll.h
 BINDINGS+=xbmc/addons/include/xbmc_addon_dll.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -489,14 +489,17 @@ DYNOBJSXBMC+= xbmc/freebsd/freebsd.a
 endif
 
 ifeq (@USE_STATIC_FFMPEG@,1)
-DYNOBJSXBMC += lib/ffmpeg/libavcodec/libavcodec.a \
-               lib/ffmpeg/libavfilter/libavfilter.a \
-               lib/ffmpeg/libswresample/libswresample.a \
-               lib/ffmpeg/libavformat/libavformat.a \
-               lib/ffmpeg/libavutil/libavutil.a \
-               lib/ffmpeg/libpostproc/libpostproc.a \
-               lib/ffmpeg/libswscale/libswscale.a
+FFMPEGOBJS = lib/ffmpeg/libavcodec/libavcodec.a \
+             lib/ffmpeg/libavfilter/libavfilter.a \
+             lib/ffmpeg/libswresample/libswresample.a \
+             lib/ffmpeg/libavformat/libavformat.a \
+             lib/ffmpeg/libavutil/libavutil.a \
+             lib/ffmpeg/libpostproc/libpostproc.a \
+             lib/ffmpeg/libswscale/libswscale.a
+DYNOBJSXBMC+= $(FFMPEGOBJS)
 LIBS+= @GNUTLS_ALL_LIBS@ @VORBISENC_ALL_LIBS@
+
+$(FFMPEGOBJS): dvdpcodecs
 endif
 
 OBJSXBMC:=$(filter-out $(DYNOBJSXBMC), $(OBJSXBMC))
@@ -534,9 +537,6 @@ ifeq ($(findstring osx,@ARCH@), osx)
 else
 	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ $(MAINOBJS) -Wl,--start-group $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group -Wl,--no-undefined $(NWAOBJSXBMC) $(LIBS)
 endif
-
-xbmc/main/main.a: force
-	$(MAKE) -C xbmc/main
 
 xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS) xbmc/main/main.a
 


### PR DESCRIPTION
parallel building on (at least) linux still fails, even after ad815563a3837bbd9ea73c3645af55ec56cacb9a

@T-nelson: this disables the ffmpeg binary again
