### PR TITLE
Fixed: Update list if item was deleted from database but not from disk

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1306,7 +1306,6 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
   if (!DeleteVideoItemFromDatabase(item, unavailable))
     return false;
 
-  bool result = true;
   // check if the user is allowed to delete the actual file as well
   if ((CProfilesManager::Get().GetCurrentProfile().getLockMode() == LOCK_MODE_EVERYONE ||
        !CProfilesManager::Get().GetCurrentProfile().filesLocked() ||
@@ -1335,13 +1334,13 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
       // HACK: stacked files need to be treated as folders in order to be deleted
       if (item->IsStack())
         item->m_bIsFolder = true;
-      result = CFileUtils::DeleteItem(item);
+      CFileUtils::DeleteItem(item);
     }
   }
 
   CUtil::DeleteVideoDatabaseDirectoryCache();
 
-  return result;
+  return true;
 }
 
 bool CGUIDialogVideoInfo::ManageMovieSets(const CFileItemPtr &item)


### PR DESCRIPTION
After the context menu changes the container wasn't properly refreshed anymore if an item was deleted from the database but not removed from disk. This fixes it as `DeleteVideoItem` needs to return true if `DeleteVideoItemFromDatabase` returns true.
