### PR TITLE
[pisink] Report supported passthrough formats

### DIFF
--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -62,12 +62,6 @@
         </setting>
       </group>
       <group id="3">
-        <setting id="audiooutput.truehdpassthrough">
-          <visible>false</visible>
-        </setting>
-        <setting id="audiooutput.dtshdpassthrough">
-          <visible>false</visible>
-        </setting>
         <setting id="audiooutput.ac3transcode" help="37024">
         </setting>
       </group>

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
@@ -284,6 +284,9 @@ void CAESinkPi::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   m_info.m_channels += AE_CH_FR;
   m_info.m_sampleRates.push_back(48000);
   m_info.m_dataFormats.push_back(AE_FMT_S16LE);
+  m_info.m_dataFormats.push_back(AE_FMT_AC3);
+  m_info.m_dataFormats.push_back(AE_FMT_DTS);
+  m_info.m_dataFormats.push_back(AE_FMT_EAC3);
 
   list.push_back(m_info);
 


### PR DESCRIPTION
This goes in after #4177
We can remove the hiding of hd audio passthrough from settings, and only report the support of non-hd passthrough.
