### PR TITLE
videolibrary: fix crash when entering an empty tvshow

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -285,12 +285,12 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
       VIDEODATABASEDIRECTORY::NODE_TYPE node = dir.GetDirectoryChildType(items.GetPath());
 
       // perform the flattening logic for tvshows with a single (unwatched) season (+ optional special season)
-      if (node == NODE_TYPE_SEASONS)
+      if (node == NODE_TYPE_SEASONS && !items.IsEmpty())
       {
         int itemsSize = items.GetObjectCount();
         int firstIndex = items.Size() - itemsSize;
         // check if the last item is the "All seasons" item which should be ignored for flattening
-        if (items[items.Size() - 1]->GetVideoInfoTag()->m_iSeason < 0)
+        if (!items[items.Size() - 1]->HasVideoInfoTag() || items[items.Size() - 1]->GetVideoInfoTag()->m_iSeason < 0)
           itemsSize -= 1;
 
         int iFlatten = CSettings::Get().GetInt("videolibrary.flattentvshows");


### PR DESCRIPTION
This fixes a crash in the videolibrary when entering a tvshow with no seasons/episodes and with "Show parent folder item" disabled which results in an empty list and an out of bounds array access on line 293. Thanks to @kib for reporting it.
