### PR TITLE
Remove view flickering (view cycle) on addon launch

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -462,7 +462,6 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, int scri
   unsigned int startTime = XbmcThreads::SystemClockMillis();
   CGUIDialogProgress *progressBar = NULL;
   bool cancelled = false;
-  bool inMainAppThread = g_application.IsCurrentThread();
 
   CLog::Log(LOGDEBUG, "%s - waiting on the %s (id=%d) plugin...", __FUNCTION__, scriptName.c_str(), scriptId);
   while (true)
@@ -518,10 +517,6 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, int scri
         m_cancelled = true;
       }
     }
-    else // if the progressBar exists and we call StartModal or Progress we get the
-         //  ProcessRenderLoop call anyway.
-      if (inMainAppThread) 
-        g_windowManager.ProcessRenderLoop();
 
     if (!cancelled && m_cancelled)
     {


### PR DESCRIPTION
There was some ugly flickering if an add-on was run via RunAddon etc. which was caused by `g_windowManager.ProcessRenderLoop()` in the `WaitOnScriptResult` method. Removing it fixed the issue. Everything works just fine but I don't know if there may be some special cases where it has to be there.
