### PR TITLE
[AE/CA/iOS] - fix CAUOutputDevice::EnableInputOuput() by checking the re...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALIOS.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALIOS.cpp
@@ -434,12 +434,12 @@ bool CAUOutputDevice::EnableInputOuput()
 
   OSStatus ret;
   UInt32 enable;
-  UInt32 hasio;
+  UInt32 hasio = 0;
   UInt32 size=sizeof(UInt32);
 
   ret = AudioUnitGetProperty(m_audioUnit,kAudioOutputUnitProperty_HasIO,kAudioUnitScope_Input, 1, &hasio, &size);
 
-  if (hasio)
+  if (!ret && hasio)
   {
     enable = 1;
     ret =  AudioUnitSetProperty(m_audioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, kInputBus, &enable, sizeof(enable));


### PR DESCRIPTION
...turn value of AudioUnitGetProperty.

This was found by @linusyang when porting for xbmc arm64 - in case the AudioUnitGetProperty fails the SetProperty also would fail which causes EnableInputOutput to fail - which in turn goes up the complete call stack and leads to failing AE and therefore crash XBMC on startup.

@linusyang - i hope i got the reason right here ;)
