### PR TITLE
[jenkins] - add gtest buildstep for jenkins (osx32, osx64m linux32, linu...

### DIFF
--- a/tools/buildsteps/linux32/run-tests
+++ b/tools/buildsteps/linux32/run-tests
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux32
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE;make -j$BUILDTHREADS testsuite
+cd $WORKSPACE;./xbmc-test --gtest_output=xml:gtestresults.xml
+awk '{ if ($1 == "<testcase" && match($0, "notrun")) print substr($0,0,length($0)-2) "><skipped/></testcase>"; else print $0;}' gtestresults.xml > gtestresults-skipped.xml
+rm gtestresults.xml
+mv gtestresults-skipped.xml gtestresults.xml

--- a/tools/buildsteps/linux64/run-tests
+++ b/tools/buildsteps/linux64/run-tests
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE;make -j$BUILDTHREADS testsuite
+cd $WORKSPACE;./xbmc-test --gtest_output=xml:gtestresults.xml
+awk '{ if ($1 == "<testcase" && match($0, "notrun")) print substr($0,0,length($0)-2) "><skipped/></testcase>"; else print $0;}' gtestresults.xml > gtestresults-skipped.xml
+rm gtestresults.xml
+mv gtestresults-skipped.xml gtestresults.xml

--- a/tools/buildsteps/osx32/run-tests
+++ b/tools/buildsteps/osx32/run-tests
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=osx32
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE;make -j$BUILDTHREADS testsuite
+cd $WORKSPACE;./xbmc-test --gtest_output=xml:gtestresults.xml
+awk '{ if ($1 == "<testcase" && match($0, "notrun")) print substr($0,0,length($0)-2) "><skipped/></testcase>"; else print $0;}' gtestresults.xml > gtestresults-skipped.xml
+rm gtestresults.xml
+mv gtestresults-skipped.xml gtestresults.xml

--- a/tools/buildsteps/osx64/run-tests
+++ b/tools/buildsteps/osx64/run-tests
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=osx64
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE;make -j$BUILDTHREADS testsuite
+cd $WORKSPACE;./xbmc-test --gtest_output=xml:gtestresults.xml
+awk '{ if ($1 == "<testcase" && match($0, "notrun")) print substr($0,0,length($0)-2) "><skipped/></testcase>"; else print $0;}' gtestresults.xml > gtestresults-skipped.xml
+rm gtestresults.xml
+mv gtestresults-skipped.xml gtestresults.xml


### PR DESCRIPTION
...x64).

I missed to PR those scripts when i did the gtest jenkins integration. Those scripts are called by jenkins when the checkbox "RUN_TESTS" is marked on the jenkins job. Those don't influence the normal compile approach or something - but make gtest integration in jenkins work (tests are turned off by default though because they are not passed on all platforms yet iirc ;) ).

Also that way we are able to test compilation of osx using make instead of xcode (cause 99% of xbmc's code is compiled and linked to the gtest binary and this is done via make on osx like on the other platforms)...

There is no script for windows yet - but wsoltys knows about it ...
