### PR TITLE
Add default screenshot button for remote

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -87,6 +87,7 @@
       <seven>JumpSMS7</seven>
       <eight>JumpSMS8</eight>
       <nine>JumpSMS9</nine>
+      <teletext>Screenshot</teletext>
     </remote>
   </global>
   <Home>


### PR DESCRIPTION
This addresses a problem introduced by removing the screenshot button from remote.

imo xbmc needs a default button for screenshots, its both useful for providing support -> debugging and taking screenshots for wiki documentation and other valid use cases.
Not every user uses Windows or Desktops environments or keyboards attached to their HTPCs

iirc teletext function never worked or is incomplete anywho. but other suggestions would be welcome.
