### PR TITLE
FIX: Parsing of SMB URLs when a domain is supplied

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -634,7 +634,8 @@ CStdString CURL::GetWithoutFilename() const
     strURL += m_strDomain;
     strURL += ";";
   }
-  else if (m_strUserName != "")
+
+  if (m_strUserName != "")
   {
     strURL += Encode(m_strUserName);
     if (m_strPassword != "")


### PR DESCRIPTION
When a domain name is supplied in a smb-protocol url (e.g. smb://domain;user:pass@server/path), invoking CURL::GetWithoutFilename breaks the url, as username and password are omitted in the returned url string.
