### PR TITLE
[WIN32] fixed: missing dlls for the mingw environment

### DIFF
--- a/project/BuildDependencies/scripts/get_mingw_env.txt
+++ b/project/BuildDependencies/scripts/get_mingw_env.txt
@@ -5,6 +5,7 @@ w32api-4.0.3-1-mingw32-dev.tar.lzma         http://mirrors.xbmc.org/build-deps/w
 gcc-core-4.6.2-1-mingw32-bin.tar.lzma       http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.6.2-1/
 gcc-c++-4.6.2-1-mingw32-bin.tar.lzma        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.6.2-1/
 libstdc++-4.6.2-1-mingw32-dll-6.tar.lzma    http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.6.2-1/
+libgcc-4.6.2-1-mingw32-dll-1.tar.lzma       http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.6.2-1/
 binutils-2.22-1-mingw32-bin.tar.lzma        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GNU-Binutils/binutils-2.22/
 yasm-1.2.0-win32.exe                        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://www.tortall.net/projects/yasm/releases/
 dlfcn-win32-static-r19.tar.bz2              http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://code.google.com/p/dlfcn-win32/downloads/list
@@ -21,6 +22,7 @@ plibc-0.1.6.zip                             http://mirrors.xbmc.org/build-deps/w
 pthreads-w32-2.9.0-mingw32-pre-20110507-2-dev.tar.lzma   http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/pthreads-w32/pthreads-w32-2.9.0-pre-20110507-2/pthreads-w32-2.9.0-mingw32-pre-20110507-2-dev.tar.lzma
 libpthreadgc-2.9.0-mingw32-pre-20110507-2-dll-2.tar.lzma	http://mirrors.xbmc.org/build-deps/win32/mingw-msys/	http://downloads.sourceforge.net/project/mingw/MinGW/Base/pthreads-w32/pthreads-w32-2.9.0-pre-20110507-2/libpthreadgc-2.9.0-mingw32-pre-20110507-2-dll-2.tar.lzma
 gettext-0.17-1-mingw32-dev.tar.lzma         http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/gettext/gettext-0.17-1/gettext-0.17-1-mingw32-dev.tar.lzma
+libgettextpo-0.17-1-mingw32-dll-0.tar.lzma  http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://downloads.sourceforge.net/project/mingw/MinGW/gettext/gettext-0.17-1/libgettextpo-0.17-1-mingw32-dll-0.tar.lzma
 libintl-0.17-1-mingw32-dll-8.tar.lzma       http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://sourceforge.net/projects/mingw/files/MinGW/gettext/gettext-0.17-1/
 libiconv-1.13.1-1-mingw32-dll-2.tar.lzma    http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://sourceforge.net/projects/mingw/files/MinGW/libiconv/libiconv-1.13.1-1/
 libiconv-1.13.1-1-mingw32-dev.tar.lzma      http://mirrors.xbmc.org/build-deps/win32/mingw-msys/        http://sourceforge.net/projects/mingw/files/MinGW/libiconv/libiconv-1.13.1-1/


### PR DESCRIPTION
while working on another project I noticed that some progs under mingw won't work as some dlls are missing. This PR will add those dlls. Even though it looks like that the not working progs aren't required to compile our mingw libs its better to have those.
Test build is running here:
http://jenkins.xbmc.org/job/XBMC-WIN-32/302/console
