### PR TITLE
[pvr] fix: wrong condition in PVRManager::IsIdle (Ticket #14630)

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1323,10 +1323,8 @@ bool CPVRManager::IsIdle(void) const
     const CDateTime next = m_timers->GetNextEventTime();
     const CDateTimeSpan delta = next - now;
 
-    if (delta < idle)
-    {
+    if (delta <= idle)
       return false;
-    }
   }
 
   return true;


### PR DESCRIPTION
IsIdle() returns the wrong state (true) if delta between next timer and now is equal to the backend idle time setting. In this condition XBMC shuts down with a wrong wakeup time for the next timer.

For more details see http://trac.xbmc.org/ticket/14630
