### PR TITLE
Stereoscopic subtitle offsets

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -35,6 +35,7 @@
 #include "settings/DisplaySettings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
+#include "OverlayRendererUtil.h"
 #include "OverlayRendererGUI.h"
 #if defined(HAS_GL) || defined(HAS_GLES)
 #include "OverlayRendererGL.h"
@@ -273,6 +274,8 @@ void CRenderer::Render(COverlay* o)
     }
 
   }
+
+  state.x += GetStereoscopicDepth();
 
   o->Render(state);
 }

--- a/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
@@ -166,7 +166,7 @@ void COverlayText::Render(OVERLAY::SRenderState &state)
   mat.m[0][3] = rd.x1;
   mat.m[1][3] = rd.y1;
 
-  float x = state.x + GetStereoscopicDepth(), y = state.y;
+  float x = state.x, y = state.y;
   mat.InverseTransformPosition(x, y);
 
   g_graphicsContext.SetTransform(mat, 1.0f, 1.0f);

--- a/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
@@ -299,9 +299,14 @@ bool convert_quad(ASS_Image* images, SQuads& quads)
 
 int GetStereoscopicDepth()
 {
-  int depth = CSettings::Get().GetInt("subtitles.stereoscopicdepth");
-  if (depth && g_graphicsContext.GetStereoMode() && g_graphicsContext.GetStereoMode() != RENDER_STEREO_MODE_MONO)
+  int depth = 0;
+
+  if(g_graphicsContext.GetStereoMode() != RENDER_STEREO_MODE_MONO
+  && g_graphicsContext.GetStereoMode() != RENDER_STEREO_MODE_OFF)
+  {
+    depth  = CSettings::Get().GetInt("subtitles.stereoscopicdepth");
     depth *= (g_graphicsContext.GetStereoView() == RENDER_STEREO_VIEW_LEFT ? 1 : -1);
+  }
 
   return depth;
 }


### PR DESCRIPTION
This fixes some issues with subtitles/overlays when a stereoscopic depth have been configured.

It introduce a bug/sideeffect, but imho worth the tradeoff for now. After this pull dvd/bluray menu's will also get the offset applied if xbmc has been switched into a stereoscopic mode.

It should not be impossible to solve, but involves some changes that get's tricker to get in for gotham.
