### PR TITLE
ActiveAE: Fix DTS and AC3 by adding it to the supported formats

### DIFF
--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -48,7 +48,7 @@
       <group id="1">
         <setting id="audiooutput.audiodevice" type="string" label="545" help="36371">
           <level>1</level>
-          <default>DirectSound:default</default>
+          <default>DIRECTSOUND:default</default>
           <constraints>
             <options>audiodevices</options>
           </constraints>
@@ -58,7 +58,7 @@
       <group id="3">
         <setting id="audiooutput.passthroughdevice" type="string" label="546" help="36372">
           <level>2</level>
-          <default>DirectSound:default</default>
+          <default>DIRECTSOUND:default</default>
           <constraints>
             <options>audiodevicespassthrough</options>
           </constraints>

--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -148,7 +148,7 @@ void CAESinkFactory::EnumerateEx(AESinkInfoList &list, bool force)
 #if defined(TARGET_WINDOWS)
 
   info.m_deviceInfoList.clear();
-  info.m_sinkName = "DirectSound";
+  info.m_sinkName = "DIRECTSOUND";
   CAESinkDirectSound::EnumerateDevicesEx(info.m_deviceInfoList, force);
   if(!info.m_deviceInfoList.empty())
     list.push_back(info);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -260,7 +260,11 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 #if defined(HAS_LIBAMCODEC)
   // AML devices can do passthough
   if (aml_present())
+  {
     m_info.m_deviceType = AE_DEVTYPE_HDMI;
+    m_info.m_dataFormats.push_back(AE_FMT_AC3);
+    m_info.m_dataFormats.push_back(AE_FMT_DTS);
+  }
 #endif
   m_info.m_deviceName = "AudioTrack";
   m_info.m_displayName = "android";

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -549,6 +549,8 @@ void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bo
       deviceInfo.m_channels = layoutsByChCount[std::max(std::min(smpwfxex->nChannels, (WORD) DS_SPEAKER_COUNT), (WORD) 2)];
       deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_FLOAT));
       deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_AC3));
+      // DTS is played with the same infrastructure as AC3
+      deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_DTS));
       deviceInfo.m_sampleRates.push_back(std::min(smpwfxex->nSamplesPerSec, (DWORD) 192000));
     }
     else

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -564,7 +564,7 @@ void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bo
 
     deviceInfo.m_deviceName       = strDevName;
     deviceInfo.m_displayName      = strWinDevType.append(strFriendlyName);
-    deviceInfo.m_displayNameExtra = std::string("DirectSound: ").append(strFriendlyName);
+    deviceInfo.m_displayNameExtra = std::string("DIRECTSOUND: ").append(strFriendlyName);
     deviceInfo.m_deviceType       = aeDeviceType;
 
     deviceInfoList.push_back(deviceInfo);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -29,7 +29,7 @@
 class CAESinkDirectSound : public IAESink
 {
 public:
-  virtual const char *GetName() { return "DirectSound"; }
+  virtual const char *GetName() { return "DIRECTSOUND"; }
 
   CAESinkDirectSound();
   virtual ~CAESinkDirectSound();


### PR DESCRIPTION
Basically in http://trac.xbmc.org/ticket/14927 a user chose DirectSound device and asked why DTS is not working. From my knowledge, I think DTS does not work with DirectSound (only AC3 and WM Pro).

So we should also verify those too.

That needs testing - I don't have windows, already pinged @jjd-uk on IRC
