### PR TITLE
AESinkPULSE: Don't set stored volume when opening in passthrough mode

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -390,6 +390,7 @@ static void SinkInfoRequestCallback(pa_context *c, const pa_sink_info *i, int eo
 CAESinkPULSE::CAESinkPULSE()
 {
   m_IsAllocated = false;
+  m_passthrough = false;
   m_MainLoop = NULL;
   m_BytesPerSecond = 0;
   m_BufferSize = 0;
@@ -406,6 +407,7 @@ CAESinkPULSE::~CAESinkPULSE()
 bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
 {
   m_IsAllocated = false;
+  m_passthrough = false;
   m_BytesPerSecond = 0;
   m_BufferSize = 0;
   m_Channels = 0;
@@ -424,9 +426,9 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   struct pa_channel_map map;
   pa_channel_map_init(&map);
 
-  bool passthrough = AE_IS_RAW(format.m_dataFormat);
+  m_passthrough = AE_IS_RAW(format.m_dataFormat);
 
-  if(passthrough)
+  if(m_passthrough)
   {
     map.channels = 2;
     format.m_channelLayout = AE_CH_LAYOUT_2_0;
@@ -445,7 +447,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   pa_format_info *info[1];
   info[0] = pa_format_info_new();
   info[0]->encoding = AEFormatToPulseEncoding(format.m_dataFormat);
-  if(!passthrough)
+  if(!m_passthrough)
   {
     pa_format_info_set_sample_format(info[0], AEFormatToPulseFormat(format.m_dataFormat));
     pa_format_info_set_channel_map(info[0], &map);
@@ -454,7 +456,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
 
   // PA requires m_encodedRate in order to do EAC3
   unsigned int samplerate;
-  if (passthrough)
+  if (m_passthrough)
   {
     if (format.m_encodedRate == 0)
     {
@@ -551,7 +553,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     buffer_attr.fragsize = (uint32_t) latency;
   }
 
-  if (pa_stream_connect_playback(m_Stream, isDefaultDevice ? NULL : device.c_str(), sinkStruct.isHWDevice ? &buffer_attr : NULL, ((pa_stream_flags)(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY)), &m_Volume, NULL) < 0)
+  if (pa_stream_connect_playback(m_Stream, isDefaultDevice ? NULL : device.c_str(), sinkStruct.isHWDevice ? &buffer_attr : NULL, ((pa_stream_flags)(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY)), m_passthrough ? NULL : &m_Volume, NULL) < 0)
   {
     CLog::Log(LOGERROR, "PulseAudio: Failed to connect stream to output");
     pa_threaded_mainloop_unlock(m_MainLoop);
@@ -598,7 +600,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   format.m_frameSize = frameSize;
   format.m_frameSamples = format.m_frames * format.m_channelLayout.Count();
   m_format = format;
-  format.m_dataFormat = passthrough ? AE_FMT_S16NE : format.m_dataFormat;
+  format.m_dataFormat = m_passthrough ? AE_FMT_S16NE : format.m_dataFormat;
 
   Pause(false);
 
@@ -608,6 +610,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
 void CAESinkPULSE::Deinitialize()
 {
   m_IsAllocated = false;
+  m_passthrough = false;
 
   if (m_Stream)
     Drain();
@@ -706,7 +709,7 @@ void CAESinkPULSE::Drain()
 
 void CAESinkPULSE::SetVolume(float volume)
 {
-  if (m_IsAllocated)
+  if (m_IsAllocated && !m_passthrough)
   {
     pa_threaded_mainloop_lock(m_MainLoop);
     pa_volume_t pavolume = pa_sw_volume_from_linear(volume);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -52,6 +52,7 @@ private:
   static bool SetupContext(const char *host, pa_context **context, pa_threaded_mainloop **mainloop);
 
   bool m_IsAllocated;
+  bool m_passthrough;
 
   AEAudioFormat m_format;
   unsigned int m_BytesPerSecond;


### PR DESCRIPTION
@topfs2 and @FernetMenta for review and additional thoughts.

We still have time and can make PAESink more "se*y".

jenkins build this please
