### PR TITLE
jsonrpc: fix Files.GetDirectory returning wrong type "song" instead of "unknown"

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -304,7 +304,7 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
           std::string type = item->GetMusicInfoTag()->GetType();
           if (type == "album" || type == "song" || type == "artist")
             object["type"] = type;
-          else
+          else if (!item->m_bIsFolder)
             object["type"] = "song";
         }
         else if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_type.empty())


### PR DESCRIPTION
This fixes the case where JSON-RPC's Files.GetDirectory would return items with the type "song" even though they aren't songs e.g. when retrieving a list of album years using the "musicdb://years/" path. Years obviously aren't songs so the returned type should be unknown.
