### PR TITLE
FIX: [droid] logging of python exception (fixes #14314)

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -46,6 +46,7 @@
 #include "ApplicationMessenger.h"
 #include "utils/StringUtils.h"
 #include "AppParamParser.h"
+#include "XbmcContext.h"
 #include <android/bitmap.h>
 #include "android/jni/JNIThreading.h"
 #include "android/jni/BroadcastReceiver.h"
@@ -251,7 +252,8 @@ void CXBMCApp::run()
   int status = 0;
 
   SetupEnv();
-  
+  XBMC::Context context;
+
   m_initialVolume = GetSystemVolume();
 
   CJNIIntent startIntent = getIntent();


### PR DESCRIPTION
Was plainly due to the static ILogger interface not being instanciated, so everything ok... besides the actual logging ;)

/cc @davilla @t-nelson 
