### PR TITLE
[PVR] : 4 fixes related to chanel icons

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -299,7 +299,7 @@ bool CPVRChannel::IsRecording(void) const
   return g_PVRTimers->IsRecordingOnChannel(*this);
 }
 
-bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon /* = false */)
+bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon /* = false */, bool bForceUserSetIconUpdate /* = false*/)
 {
   CSingleLock lock(m_critSection);
 
@@ -310,8 +310,10 @@ bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon
     SetChanged();
     m_bChanged = true;
 
+    if (bForceUserSetIconUpdate )
+      m_bIsUserSetIcon = bIsUserSetIcon;
     /* did the user change the icon? */
-    if (bIsUserSetIcon)
+    else if (bIsUserSetIcon)
       m_bIsUserSetIcon = !m_strIconPath.empty();
 	  
     return true;

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -299,7 +299,7 @@ bool CPVRChannel::IsRecording(void) const
   return g_PVRTimers->IsRecordingOnChannel(*this);
 }
 
-bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon /* = false */, bool bForceUserSetIconUpdate /* = false*/)
+bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon /* = false */)
 {
   CSingleLock lock(m_critSection);
 
@@ -309,12 +309,7 @@ bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon
     m_strIconPath = StringUtils::Format("%s", strIconPath.c_str());
     SetChanged();
     m_bChanged = true;
-
-    if (bForceUserSetIconUpdate )
-      m_bIsUserSetIcon = bIsUserSetIcon;
-    /* did the user change the icon? */
-    else if (bIsUserSetIcon)
-      m_bIsUserSetIcon = !m_strIconPath.empty();
+    m_bIsUserSetIcon = bIsUserSetIcon;
 	  
     return true;
   }
@@ -753,6 +748,11 @@ bool CPVRChannel::IsUserSetIcon(void) const
 {
   CSingleLock lock(m_critSection);
   return m_bIsUserSetIcon;
+}
+
+bool CPVRChannel::IsIconExists() const
+{
+  return  CFile::Exists(IconPath());
 }
 
 CStdString CPVRChannel::ChannelName(void) const

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -160,9 +160,10 @@ namespace PVR
      * @brief Set the path to the icon for this channel.
      * @param strIconPath The new path.
      * @param bIsUserSetIcon true if user changed the icon via GUI, false otherwise.
+     * @param bForceUserSetIconUpdate true if UserSetIcon need to be updated even if IconPath is Empty
      * @return True if the something changed, false otherwise.
      */
-    bool SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon = false);
+    bool SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon = false, bool bForceUserSetIconUpdate = false);
 
     /*!
      * @return The name for this channel used by XBMC.

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -155,15 +155,19 @@ namespace PVR
      * @return True if this user changed icon via GUI. False if not.
      */
     bool IsUserSetIcon(void) const;
-	  
+
+     /*!
+     * @return True if the channel icon path exists
+     */
+    bool IsIconExists(void) const;
+    
     /*!
      * @brief Set the path to the icon for this channel.
      * @param strIconPath The new path.
      * @param bIsUserSetIcon true if user changed the icon via GUI, false otherwise.
-     * @param bForceUserSetIconUpdate true if UserSetIcon need to be updated even if IconPath is Empty
      * @return True if the something changed, false otherwise.
      */
-    bool SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon = false, bool bForceUserSetIconUpdate = false);
+    bool SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon = false);
 
     /*!
      * @return The name for this channel used by XBMC.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -240,6 +240,17 @@ bool CPVRChannelGroup::SetChannelIconPath(CPVRChannelPtr channel, const std::str
   return false;
 }
 
+bool CPVRChannelGroup::VerifyChannelIconPath(CPVRChannelPtr channel)
+{
+  if (CFile::Exists(channel->IconPath()))
+    return true;
+  else
+  {
+    channel->SetIconPath(std::string(), false, true);
+    return false;
+  }
+}
+
 void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
 {
   if (CSettings::Get().GetString("pvrmenu.iconpath").empty())
@@ -257,7 +268,11 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
 
     /* skip if an icon is already set */
     if (!groupMember.channel->IconPath().empty())
-      continue;
+    {
+      //check if the file exist or empty it
+      if(VerifyChannelIconPath(groupMember.channel))
+        continue;
+    }
 
     CStdString strBasePath = CSettings::Get().GetString("pvrmenu.iconpath");
     CStdString strSanitizedChannelName = CUtil::MakeLegalFileName(groupMember.channel->ClientChannelName());

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1207,7 +1207,7 @@ void CPVRChannelGroup::SetPreventSortAndRenumber(bool bPreventSortAndRenumber /*
   m_bPreventSortAndRenumber = bPreventSortAndRenumber;
 }
 
-bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool bVirtual, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const CStdString &strChannelName, const CStdString &strIconPath, const CStdString &strStreamURL)
+bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool bVirtual, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const CStdString &strChannelName, const CStdString &strIconPath, const CStdString &strStreamURL, bool bUserSetIcon)
 {
   if (!item.HasPVRChannelInfoTag())
     return false;
@@ -1222,7 +1222,7 @@ bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool b
   channel->SetChannelName(strChannelName);
   channel->SetHidden(bHidden);
   channel->SetLocked(bParentalLocked);
-  channel->SetIconPath(strIconPath);
+  channel->SetIconPath(strIconPath, bUserSetIcon);
 
   if (bVirtual)
     channel->SetStreamURL(strStreamURL);

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -257,7 +257,7 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
 
     /* skip if an icon is already set  and exists*/
     if (!groupMember.channel->IsIconExists())
-      groupMember.channel->SetIconPath(std::string(), false);
+      groupMember.channel->SetIconPath(StringUtils::Empty, false);
     else
         continue;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -259,7 +259,7 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
     if (!groupMember.channel->IsIconExists())
       groupMember.channel->SetIconPath(StringUtils::Empty, false);
     else
-        continue;
+      continue;
 
     CStdString strBasePath = CSettings::Get().GetString("pvrmenu.iconpath");
     CStdString strSanitizedClientChannelName = CUtil::MakeLegalFileName(groupMember.channel->ClientChannelName());

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -384,7 +384,7 @@ namespace PVR
      */
     CDateTime GetLastEPGDate(void) const;
 
-    bool UpdateChannel(const CFileItem &channel, bool bHidden, bool bVirtual, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const CStdString &strChannelName, const CStdString &strIconPath, const CStdString &strStreamURL);
+    bool UpdateChannel(const CFileItem &channel, bool bHidden, bool bVirtual, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const CStdString &strChannelName, const CStdString &strIconPath, const CStdString &strStreamURL, bool bUserSetIcon = false);
 
     bool ToggleChannelLocked(const CFileItem &channel);
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -417,14 +417,6 @@ namespace PVR
      */
     bool SetChannelIconPath(CPVRChannelPtr channel, const std::string& strIconPath);
 
-     /*!
-      * @brief Verify that Icon path exists and empty it if not
-      * @param channel The channel to verify
-      * @return True if the path exists and is not updated, false otherwise
-      */
-
-     bool VerifyChannelIconPath(CPVRChannelPtr channel);
-
     /*!
      * @brief Load the channels stored in the database.
      * @param bCompress If true, compress the database after storing the channels.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -417,6 +417,14 @@ namespace PVR
      */
     bool SetChannelIconPath(CPVRChannelPtr channel, const std::string& strIconPath);
 
+     /*!
+      * @brief Verify that Icon path exists and empty it if not
+      * @param channel The channel to verify
+      * @return True if the path exists and is not updated, false otherwise
+      */
+
+     bool VerifyChannelIconPath(CPVRChannelPtr channel);
+
     /*!
      * @brief Load the channels stored in the database.
      * @param bCompress If true, compress the database after storing the channels.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -361,6 +361,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
 
   pItem->SetProperty("Icon", strThumb);
   pItem->SetProperty("Changed", true);
+  pItem->SetProperty("UserSetIcon", true);
   m_bContainsChanges = true;
   return true;
 }
@@ -775,8 +776,9 @@ bool CGUIDialogPVRChannelManager::PersistChannel(CFileItemPtr pItem, CPVRChannel
   CStdString strChannelName = pItem->GetProperty("Name").asString();
   CStdString strIconPath    = pItem->GetProperty("Icon").asString();
   CStdString strStreamURL   = pItem->GetProperty("StreamURL").asString();
+  bool bUserSetIcon         = pItem->GetProperty("UserSetIcon").asBoolean();
 
-  return group->UpdateChannel(*pItem, bHidden, bVirtual, bEPGEnabled, bParentalLocked, iEPGSource, ++(*iChannelNumber), strChannelName, strIconPath, strStreamURL);
+  return group->UpdateChannel(*pItem, bHidden, bVirtual, bEPGEnabled, bParentalLocked, iEPGSource, ++(*iChannelNumber), strChannelName, strIconPath, strStreamURL, bUserSetIcon);
 }
 
 void CGUIDialogPVRChannelManager::SaveList(void)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -500,7 +500,7 @@ bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUT
       CPVRChannelGroupPtr group = g_PVRChannelGroups->GetGroupAll(channel->IsRadio());
       CPVRChannelPtr channelPtr = group->GetByUniqueID(channel->UniqueID());
 
-      channelPtr->SetIconPath(strThumb, true);
+      channelPtr->SetIconPath(strThumb, strThumb != "");
       channelPtr->Persist();
       UpdateData();
     }


### PR DESCRIPTION
This pr fixes 4 issues related to  pvr channels icon : 

1) When masterlockcode is set and user click on the logo button in channel manager, the password dialog box is shown twice and user need to enter the password 2 times.
This is resolved by removing and uneeded call to  g_passwordManager.IsMasterLockUnlocked in CGUIDialogPVRChannelManager::OnClickButtonChannelLogo

2)When user set a user defined logo; the iconpath is emptied upon xbmc restart. This is fixed by setting the userseticon flag to true when user choose its own icon.

3) When the icon path  related file does not exists anymore, it should be emptied. This is particulary boring when UserSetIcon is set because it will never been emptied regarding how updatefromclient works. This is fixed by veryfing if the file exists in CPVRChannelGroup::SearchAndSetChannelIcons

4) When user set a custom name for a channel in Channel manager, SearchAndSetChannelIcons should also search for  an icon file based on that name.
