### PR TITLE
[Fix] Some fixes for our gif decode implementation

### DIFF
--- a/xbmc/guilib/AnimatedGif.cpp
+++ b/xbmc/guilib/AnimatedGif.cpp
@@ -29,6 +29,7 @@
 #include "AnimatedGif.h"
 #include "filesystem/SpecialProtocol.h"
 #include "utils/EndianSwap.h"
+#include "utils/log.h"
 
 #ifdef TARGET_WINDOWS
 extern "C" FILE *fopen_utf8(const char *_Filename, const char *_Mode);
@@ -464,6 +465,7 @@ int CAnimatedGifSet::LoadGIF (const char * szFileName)
       else
       {
         delete NextImage;
+        CLog::Log(LOGERROR, "CAnimatedGifSet::LoadGIF: gif file corrupt: %s", szFileName);
         ERRORMSG("GIF File Corrupt");
       }
 
@@ -505,6 +507,8 @@ int LZWDecoder (char * bufIn, char * bufOut,
                 short InitCodeSize, int AlignedWidth,
                 int Width, int Height, const int Interlace)
 {
+  if (InitCodeSize < 1 || InitCodeSize >= LZW_MAXBITS)
+    return 0;
   int n;
   int row = 0, col = 0;    // used to point output if Interlaced
   int nPixels, maxPixels; // Output pixel counter
@@ -520,12 +524,12 @@ int LZWDecoder (char * bufIn, char * bufOut,
   short OutCode;      // Code to output
 
   // Translation Table:
-  short Prefix[4096] = {};    // Prefix: index of another Code
-  unsigned char Suffix[4096] = {};    // Suffix: terminating character
+  short Prefix[LZW_SIZETABLE] = {};    // Prefix: index of another Code
+  unsigned char Suffix[LZW_SIZETABLE] = {};    // Suffix: terminating character
   short FirstEntry;     // Index of first free entry in table
   short NextEntry;     // Index of next free entry in table
 
-  unsigned char OutStack[4097];   // Output buffer
+  unsigned char OutStack[LZW_SIZETABLE + 1];   // Output buffer
   int OutIndex;      // Characters in OutStack
 
   int RowOffset;     // Offset in output buffer for current row
@@ -583,14 +587,14 @@ int LZWDecoder (char * bufIn, char * bufOut,
     // - Table Suffices contain the raw codes to be output
     while (OutCode >= FirstEntry)
     {
-      if (OutIndex > 4096 || OutCode >= 4096)
+      if (OutIndex > LZW_SIZETABLE || OutCode >= LZW_SIZETABLE)
         return 0;
       OutStack[OutIndex++] = Suffix[OutCode]; // Add suffix to Output Stack
       OutCode = Prefix[OutCode];       // Loop with preffix
     }
 
     // NOW OutCode IS A RAW CODE, ADD IT TO OUTPUT STACK.
-    if (OutIndex > 4096)
+    if (OutIndex > LZW_SIZETABLE)
       return 0;
     OutStack[OutIndex++] = (unsigned char) OutCode;
 
@@ -603,13 +607,13 @@ int LZWDecoder (char * bufIn, char * bufOut,
       NextEntry++;
 
       // Prevent Translation table overflow:
-      if (NextEntry >= 4096)
+      if (NextEntry >= LZW_SIZETABLE)
         return 0;
 
       // INCREASE CodeSize IF NextEntry IS INVALID WITH CURRENT CodeSize
       if (NextEntry >= (1 << CodeSize))
       {
-        if (CodeSize < 12) CodeSize++;
+        if (CodeSize < LZW_MAXBITS) CodeSize++;
         else
         {
           ;

--- a/xbmc/guilib/AnimatedGif.cpp
+++ b/xbmc/guilib/AnimatedGif.cpp
@@ -403,6 +403,10 @@ int CAnimatedGifSet::LoadGIF (const char * szFileName)
 
       NextImage->Init(gifid.Width, gifid.Height, LocalColorMap ? (gifid.PackedFields&7) + 1 : GlobalBPP);
 
+      /* verify that all the image is inside the screen dimensions */
+      if (gifid.xPos + gifid.Width > giflsd.ScreenWidth || gifid.yPos + gifid.Height > giflsd.ScreenHeight)
+        return 0;
+
       // Fill NextImage Data
       NextImage->xPos = gifid.xPos;
       NextImage->yPos = gifid.yPos;

--- a/xbmc/guilib/AnimatedGif.cpp
+++ b/xbmc/guilib/AnimatedGif.cpp
@@ -602,13 +602,13 @@ int LZWDecoder (char * bufIn, char * bufOut,
     // (EXCEPT IF PREVIOUS CODE WAS A CLEARCODE)
     if (PrevCode != ClearCode)
     {
-      Prefix[NextEntry] = PrevCode;
-      Suffix[NextEntry] = (unsigned char) OutCode;
-      NextEntry++;
-
       // Prevent Translation table overflow:
       if (NextEntry >= LZW_SIZETABLE)
         return 0;
+
+      Prefix[NextEntry] = PrevCode;
+      Suffix[NextEntry] = (unsigned char) OutCode;
+      NextEntry++;
 
       // INCREASE CodeSize IF NextEntry IS INVALID WITH CURRENT CodeSize
       if (NextEntry >= (1 << CodeSize))

--- a/xbmc/guilib/AnimatedGif.h
+++ b/xbmc/guilib/AnimatedGif.h
@@ -37,6 +37,9 @@
 
 #pragma pack(1)
 
+#define LZW_MAXBITS   12
+#define LZW_SIZETABLE (1<<LZW_MAXBITS)
+
 /*!
  \ingroup textures
  \brief


### PR DESCRIPTION
Found these while testing gif backgrounds.

Our gif implementation lacks in quite a few features, like using the disposal method. We should think about substitute it for another implementation/library.
