### PR TITLE
upnp: executing AVTransport's Stop action in state NO_MEDIA_PRESENT is not allowed

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -261,14 +261,14 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
   if (m_delegate->m_trainfo.cur_transport_state != "NO_MEDIA_PRESENT" &&
       m_delegate->m_trainfo.cur_transport_state != "STOPPED")
   {
-  timeout.Set(timeout.GetInitialTimeoutValue());
-  /* dlna specifies that a return code of 705 should be returned
-   * if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT */
-  NPT_CHECK_LABEL_SEVERE(m_control->Stop(m_delegate->m_device
-                                         , m_delegate->m_instance
-                                         , m_delegate), failed);
-  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
-  NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
+    timeout.Set(timeout.GetInitialTimeoutValue());
+    /* dlna specifies that a return code of 705 should be returned
+     * if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT */
+    NPT_CHECK_LABEL_SEVERE(m_control->Stop(m_delegate->m_device
+                                           , m_delegate->m_instance
+                                           , m_delegate), failed);
+    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
+    NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
   }
 
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -250,7 +250,17 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
   NPT_Cardinal res_index;
   NPT_CHECK_LABEL_SEVERE(m_control->FindBestResource(m_delegate->m_device, *obj, res_index), failed);
 
+  // get the transport info to evaluate the TransportState to be able to
+  // determine whether we first need to call Stop()
+  timeout.Set(timeout.GetInitialTimeoutValue());
+  NPT_CHECK_LABEL_SEVERE(m_control->GetTransportInfo(m_delegate->m_device
+                                                     , m_delegate->m_instance
+                                                     , m_delegate), failed);
+  NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_traevnt, timeout, dialog), failed);
 
+  if (m_delegate->m_trainfo.cur_transport_state != "NO_MEDIA_PRESENT" &&
+      m_delegate->m_trainfo.cur_transport_state != "STOPPED")
+  {
   timeout.Set(timeout.GetInitialTimeoutValue());
   /* dlna specifies that a return code of 705 should be returned
    * if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT */
@@ -259,6 +269,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
                                          , m_delegate), failed);
   NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout, dialog), failed);
   NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed);
+  }
 
 
   timeout.Set(timeout.GetInitialTimeoutValue());

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -262,8 +262,6 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
       m_delegate->m_trainfo.cur_transport_state != "STOPPED")
   {
     timeout.Set(timeout.GetInitialTimeoutValue());
-    /* dlna specifies that a return code of 705 should be returned
-     * if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT */
     NPT_CHECK_LABEL_SEVERE(m_control->Stop(m_delegate->m_device
                                            , m_delegate->m_instance
                                            , m_delegate), failed);


### PR DESCRIPTION
There was a report on the forum (see http://forum.xbmc.org/showthread.php?tid=186512) that "Play using" to the AV receiver's UPnP renderer wasn't working from XBMC. I tracked it down to the fact that XBMC blindly sending a Stop action whenever playback of a new file is being started. I checked the AVTransport:1 UPnP specification and it states that executing the Stop action is not allowed if the renderer is in the state NO_MEDIA_PRESENT (which is e.g. the case when the renderer was just started). Therefore we first need to check the state of the renderer before sending (or not sending) the Stop action otherwise we may get a 701 "Transistion not available" error (as dictated by the specification) and the result of the Stop action is handled as an error and the whole playback is being aborted.

Furthermore I've removed the comment saying that

```
dlna specifies that a return code of 705 should be returned if TRANSPORT_STATE is not STOPPED or NO_MEDIA_PRESENT
```

I don't know the DLNA restrictions imposed upon UPnP but the UPnP specification says that 701 is returned in case of a wrong state (only NO_MEDIA_PRESENT) whereas 705 is in case of a "playback lock" (remember those mechanical locks on "old" MP3 players?) where it is not allowed to change the currently playing item.

@elupus and @alcoheca for comments.
