### PR TITLE
Move to SQLite 3080600 (aka 3.8.6)

### DIFF
--- a/tools/depends/target/sqlite3/Makefile
+++ b/tools/depends/target/sqlite3/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=sqlite
-VERSION=3071000
+VERSION=3080600
 SOURCE=$(LIBNAME)-autoconf-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
This new version of SQLite offers significant speed improvements in my testing. For example, the time it takes to issue

```
SELECT * FROM tvshowview  GROUP BY tvshowview.idShow
```

(the first time the TV Shows library is opened) with 344 TV shows on a non-overclocked Raspberry Pi changed as follows. Times are in seconds:

```
      Before          After
      Mean   StdDev   Mean   StdDev  Confidence  Change
Time  2935.6 6.2      2774.1 38.3    100.0%      +5.8%
```
