### PR TITLE
settings: show settings to enable/disable RSS in 'Basic' group, this is ...

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -91,7 +91,7 @@
       </group>
       <group id="2">
         <setting id="lookandfeel.enablerssfeeds" type="boolean" label="13305" help="36111">
-          <level>1</level>
+          <level>0</level>
           <default>true</default>
           <control type="toggle" />
         </setting>


### PR DESCRIPTION
...a option which is widely used (to disable RSS on RPi for example) so give users easy access to this setting
