### PR TITLE
RFC: [gui][confluence] support for international on-screen keyboards

### DIFF
--- a/addons/skin.confluence/720p/DialogKeyboard.xml
+++ b/addons/skin.confluence/720p/DialogKeyboard.xml
@@ -4,8 +4,8 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>2</system>
-		<left>255</left>
-		<top>145</top>
+		<left>205</left>
+		<top>120</top>
 	</coordinates>
 	<controls>
 		<control type="group">
@@ -14,7 +14,7 @@
 			<control type="image">
 				<left>0</left>
 				<top>0</top>
-				<width>760</width>
+				<width>860</width>
 				<height>430</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
@@ -22,7 +22,7 @@
 				<description>Dialog Header image</description>
 				<left>40</left>
 				<top>16</top>
-				<width>680</width>
+				<width>780</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
@@ -30,7 +30,7 @@
 				<description>header label</description>
 				<left>40</left>
 				<top>20</top>
-				<width>720</width>
+				<width>820</width>
 				<height>30</height>
 				<font>font13_title</font>
 				<align>center</align>
@@ -40,7 +40,7 @@
 			</control>
 			<control type="button">
 				<description>Close Window button</description>
-				<left>670</left>
+				<left>770</left>
 				<top>15</top>
 				<width>64</width>
 				<height>32</height>
@@ -58,7 +58,7 @@
 			<control type="image">
 				<left>50</left>
 				<top>60</top>
-				<width>660</width>
+				<width>760</width>
 				<height>50</height>
 				<aspectratio>stretch</aspectratio>
 				<texture border="20">KeyboardEditArea.png</texture>
@@ -67,7 +67,7 @@
 				<description>Edit Text</description>
 				<left>55</left>
 				<top>60</top>
-				<width>650</width>
+				<width>750</width>
 				<height>50</height>
 				<font>font13</font>
 				<align>center</align>
@@ -76,7 +76,7 @@
 			<control type="image">
 				<left>130</left>
 				<top>110</top>
-				<width>500</width>
+				<width>600</width>
 				<height>30</height>
 				<aspectratio>stretch</aspectratio>
 				<texture>DialogHeader.png</texture>
@@ -84,6 +84,7 @@
 			<control type="group">
 				<left>30</left>
 				<top>140</top>
+				<!-- 1st row -->
 				<control type="button" id="300">
 					<description>DONE button</description>
 					<left>0</left>
@@ -91,8 +92,8 @@
 					<width>200</width>
 					<height>50</height>
 					<label>20177</label>
-					<onleft>57</onleft>
-					<onright>48</onright>
+					<onleft>111</onleft>
+					<onright>100</onright>
 					<onup>307</onup>
 					<ondown>302</ondown>
 					<texturenofocus border="25,25,5,5">KeyboardCornerTopNF.png</texturenofocus>
@@ -102,176 +103,129 @@
 					<font>font13</font>
 					<focusedcolor>black</focusedcolor>
 				</control>
-				<control type="button" id="48">
-					<description>'0' button</description>
+				<control type="button" id="100">
+					<description>(0,0) key button</description>
 					<left>200</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
 					<onleft>300</onleft>
-					<onright>49</onright>
+					<onright>101</onright>
 					<onup>32</onup>
-					<ondown>65</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<ondown>120</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="49">
-					<description>'1' button</description>
+				<control type="button" id="101">
+					<description>(0,1) key button</description>
 					<left>250</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>48</onleft>
-					<onright>50</onright>
+					<onleft>100</onleft>
+					<onright>102</onright>
 					<onup>32</onup>
-					<ondown>66</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<ondown>121</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="50">
-					<description>'2' button</description>
+				<control type="button" id="102">
+					<description>(0,2) key button</description>
 					<left>300</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>49</onleft>
-					<onright>51</onright>
+					<onleft>101</onleft>
+					<onright>103</onright>
 					<onup>32</onup>
-					<ondown>67</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<ondown>122</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="51">
-					<description>'3' button</description>
+				<control type="button" id="103">
+					<description>(0,3) key button</description>
 					<left>350</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>50</onleft>
-					<onright>52</onright>
+					<onleft>102</onleft>
+					<onright>104</onright>
 					<onup>32</onup>
-					<ondown>68</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<ondown>123</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="52">
-					<description>'4' button</description>
+				<control type="button" id="104">
+					<description>(0,4) key button</description>
 					<left>400</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>51</onleft>
-					<onright>53</onright>
-					<onup>32</onup>
-					<ondown>69</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>103</onleft>
+					<onright>105</onright>
+					<onup>8</onup>
+					<ondown>124</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="53">
-					<description>'5' button</description>
+				<control type="button" id="105">
+					<description>(0,5) key button</description>
 					<left>450</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>52</onleft>
-					<onright>54</onright>
-					<onup>32</onup>
-					<ondown>70</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>104</onleft>
+					<onright>106</onright>
+					<onup>8</onup>
+					<ondown>125</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="54">
-					<description>'6' button</description>
+				<control type="button" id="106">
+					<description>(0,6) key button</description>
 					<left>500</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>53</onleft>
-					<onright>55</onright>
-					<onup>305</onup>
-					<ondown>71</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>105</onleft>
+					<onright>107</onright>
+					<onup>8</onup>
+					<ondown>126</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="55">
-					<description>'7' button</description>
+				<control type="button" id="107">
+					<description>(0,7) key button</description>
 					<left>550</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>54</onleft>
-					<onright>56</onright>
-					<onup>305</onup>
-					<ondown>72</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>106</onleft>
+					<onright>108</onright>
+					<onup>8</onup>
+					<ondown>127</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="56">
-					<description>'8' button</description>
+				<control type="button" id="108">
+					<description>(0,8) key button</description>
 					<left>600</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>55</onleft>
-					<onright>57</onright>
-					<onup>306</onup>
-					<ondown>73</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>107</onleft>
+					<onright>109</onright>
+					<onup>305</onup>
+					<ondown>128</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="57">
-					<description>'9' button</description>
+				<control type="button" id="109">
+					<description>(0,9) key button</description>
 					<left>650</left>
 					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>56</onleft>
+					<onleft>108</onleft>
+					<onright>110</onright>
+					<onup>305</onup>
+					<ondown>129</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="110">
+					<description>(0,10) key button</description>
+					<left>700</left>
+					<top>0</top>
+					<onleft>109</onleft>
+					<onright>111</onright>
+					<onup>306</onup>
+					<ondown>130</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="111">
+					<description>(0,11) key button</description>
+					<left>750</left>
+					<top>0</top>
+					<onleft>110</onleft>
 					<onright>300</onright>
 					<onup>306</onup>
-					<ondown>74</ondown>
+					<ondown>131</ondown>
 					<texturenofocus flipx="true" border="5,25,25,5">KeyboardCornerTopNF.png</texturenofocus>
 					<texturefocus flipx="true" border="5,25,25,5">KeyboardCornerTop.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<include>KeyboardButton</include>
 				</control>
+				<!-- 2nd row -->
 				<control type="radiobutton" id="302">
 					<description>SHIFT button</description>
 					<left>0</left>
@@ -279,8 +233,8 @@
 					<width>200</width>
 					<height>50</height>
 					<label>20178</label>
-					<onleft>74</onleft>
-					<onright>65</onright>
+					<onleft>131</onleft>
+					<onright>120</onright>
 					<onup>300</onup>
 					<ondown>303</ondown>
 					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
@@ -293,176 +247,127 @@
 					<font>font13</font>
 					<focusedcolor>black</focusedcolor>
 				</control>
-				<control type="button" id="65">
-					<description>'A' button</description>
+				<control type="button" id="120">
+					<description>(1,0) key button</description>
 					<left>200</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
 					<onleft>302</onleft>
-					<onright>66</onright>
-					<onup>48</onup>
-					<ondown>75</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onright>121</onright>
+					<onup>100</onup>
+					<ondown>140</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="66">
-					<description>'B' button</description>
+				<control type="button" id="121">
+					<description>(1,1) key button</description>
 					<left>250</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>65</onleft>
-					<onright>67</onright>
-					<onup>49</onup>
-					<ondown>76</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>120</onleft>
+					<onright>122</onright>
+					<onup>101</onup>
+					<ondown>141</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="67">
-					<description>'C' button</description>
+				<control type="button" id="122">
+					<description>(1,2) key button</description>
 					<left>300</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>66</onleft>
-					<onright>68</onright>
-					<onup>50</onup>
-					<ondown>77</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>121</onleft>
+					<onright>123</onright>
+					<onup>102</onup>
+					<ondown>142</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="68">
-					<description>'D' button</description>
+				<control type="button" id="123">
+					<description>(1,3) key button</description>
 					<left>350</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>67</onleft>
-					<onright>69</onright>
-					<onup>51</onup>
-					<ondown>78</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>122</onleft>
+					<onright>124</onright>
+					<onup>103</onup>
+					<ondown>143</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="69">
-					<description>'E' button</description>
+				<control type="button" id="124">
+					<description>(1,4) key button</description>
 					<left>400</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>68</onleft>
-					<onright>70</onright>
-					<onup>52</onup>
-					<ondown>79</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>123</onleft>
+					<onright>125</onright>
+					<onup>104</onup>
+					<ondown>144</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="70">
-					<description>'F' button</description>
+				<control type="button" id="125">
+					<description>(1,5) key button</description>
 					<left>450</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>69</onleft>
-					<onright>71</onright>
-					<onup>53</onup>
-					<ondown>80</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>124</onleft>
+					<onright>126</onright>
+					<onup>105</onup>
+					<ondown>145</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="71">
-					<description>'G' button</description>
+				<control type="button" id="126">
+					<description>(1,6) key button</description>
 					<left>500</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>70</onleft>
-					<onright>72</onright>
-					<onup>54</onup>
-					<ondown>81</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>125</onleft>
+					<onright>127</onright>
+					<onup>106</onup>
+					<ondown>146</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="72">
-					<description>'H' button</description>
+				<control type="button" id="127">
+					<description>(1,7) key button</description>
 					<left>550</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>71</onleft>
-					<onright>73</onright>
-					<onup>55</onup>
-					<ondown>82</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>126</onleft>
+					<onright>128</onright>
+					<onup>107</onup>
+					<ondown>147</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="73">
-					<description>'I' button</description>
+				<control type="button" id="128">
+					<description>(1,8) key button</description>
 					<left>600</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>72</onleft>
-					<onright>74</onright>
-					<onup>56</onup>
-					<ondown>83</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>127</onleft>
+					<onright>129</onright>
+					<onup>108</onup>
+					<ondown>148</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="74">
-					<description>'J' button</description>
+				<control type="button" id="129">
+					<description>(1,9) key button</description>
 					<left>650</left>
 					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>73</onleft>
-					<onright>302</onright>
-					<onup>57</onup>
-					<ondown>84</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>128</onleft>
+					<onright>130</onright>
+					<onup>109</onup>
+					<ondown>149</ondown>
+					<include>KeyboardButton</include>
 				</control>
+				<control type="button" id="130">
+					<description>(1,10) key button</description>
+					<left>700</left>
+					<top>50</top>
+					<onleft>129</onleft>
+					<onright>131</onright>
+					<onup>110</onup>
+					<ondown>150</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="131">
+					<description>(1,11) key button</description>
+					<left>750</left>
+					<top>50</top>
+					<onleft>130</onleft>
+					<onright>302</onright>
+					<onup>111</onup>
+					<ondown>151</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<!-- 3rd row -->
 				<control type="radiobutton" id="303">
 					<description>CAPS LOCK button</description>
 					<left>0</left>
@@ -470,8 +375,8 @@
 					<width>200</width>
 					<height>50</height>
 					<label>20179</label>
-					<onleft>84</onleft>
-					<onright>75</onright>
+					<onleft>151</onleft>
+					<onright>140</onright>
 					<onup>302</onup>
 					<ondown>304</ondown>
 					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
@@ -484,185 +389,169 @@
 					<font>font13</font>
 					<focusedcolor>black</focusedcolor>
 				</control>
-				<control type="button" id="75">
-					<description>'K' button</description>
+				<control type="button" id="140">
+					<description>(2,0) key button</description>
 					<left>200</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
 					<onleft>303</onleft>
-					<onright>76</onright>
-					<onup>65</onup>
-					<ondown>85</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onright>141</onright>
+					<onup>120</onup>
+					<ondown>160</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="76">
-					<description>'L' button</description>
+				<control type="button" id="141">
+					<description>(2,1) key button</description>
 					<left>250</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>75</onleft>
-					<onright>77</onright>
-					<onup>66</onup>
-					<ondown>86</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>140</onleft>
+					<onright>142</onright>
+					<onup>121</onup>
+					<ondown>161</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="77">
-					<description>'M' button</description>
+				<control type="button" id="142">
+					<description>(2,2) key button</description>
 					<left>300</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>76</onleft>
-					<onright>78</onright>
-					<onup>67</onup>
-					<ondown>87</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>141</onleft>
+					<onright>143</onright>
+					<onup>122</onup>
+					<ondown>162</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="78">
-					<description>'N' button</description>
+				<control type="button" id="143">
+					<description>(2,3) key button</description>
 					<left>350</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>77</onleft>
-					<onright>79</onright>
-					<onup>68</onup>
-					<ondown>88</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>142</onleft>
+					<onright>144</onright>
+					<onup>123</onup>
+					<ondown>163</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="79">
-					<description>'O' button</description>
+				<control type="button" id="144">
+					<description>(2,4) key button</description>
 					<left>400</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>78</onleft>
-					<onright>80</onright>
-					<onup>69</onup>
-					<ondown>89</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>143</onleft>
+					<onright>145</onright>
+					<onup>124</onup>
+					<ondown>164</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="80">
-					<description>'P' button</description>
+				<control type="button" id="145">
+					<description>(2,5) key button</description>
 					<left>450</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>79</onleft>
-					<onright>81</onright>
-					<onup>70</onup>
-					<ondown>90</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>144</onleft>
+					<onright>146</onright>
+					<onup>125</onup>
+					<ondown>165</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="81">
-					<description>'Q' button</description>
+				<control type="button" id="146">
+					<description>(2,6) key button</description>
 					<left>500</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>80</onleft>
-					<onright>82</onright>
-					<onup>71</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>145</onleft>
+					<onright>147</onright>
+					<onup>126</onup>
+					<ondown>166</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="82">
-					<description>'R' button</description>
+				<control type="button" id="147">
+					<description>(2,7) key button</description>
 					<left>550</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>81</onleft>
-					<onright>83</onright>
-					<onup>72</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>146</onleft>
+					<onright>148</onright>
+					<onup>127</onup>
+					<ondown>167</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="83">
-					<description>'S' button</description>
+				<control type="button" id="148">
+					<description>(2,8) key button</description>
 					<left>600</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>82</onleft>
-					<onright>84</onright>
-					<onup>73</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>147</onleft>
+					<onright>149</onright>
+					<onup>128</onup>
+					<ondown>168</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="84">
-					<description>'T' button</description>
+				<control type="button" id="149">
+					<description>(2,9) key button</description>
 					<left>650</left>
 					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>83</onleft>
+					<onleft>148</onleft>
+					<onright>150</onright>
+					<onup>129</onup>
+					<ondown>169</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="150">
+					<description>(2,10) key button</description>
+					<left>700</left>
+					<top>100</top>
+					<onleft>149</onleft>
+					<onright>151</onright>
+					<onup>130</onup>
+					<ondown>170</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="151">
+					<description>(2,11) key button</description>
+					<left>750</left>
+					<top>100</top>
+					<onleft>150</onleft>
 					<onright>303</onright>
-					<onup>74</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onup>131</onup>
+					<ondown>171</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<!-- 4th row -->
+				<control type="group">
+					<left>0</left>
+					<top>150</top>
+					<enable>IntegerGreaterThan(Window.Property(HasAltLayout), 0)</enable>
+					<control type="radiobutton" id="312">
+						<description>Layout button</description>
+						<left>0</left>
+						<top>0</top>
+						<width>100</width>
+						<height>50</height>
+						<onleft>171</onleft>
+						<onright>304</onright>
+						<onup>303</onup>
+						<ondown>307</ondown>
+						<label>-</label>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<radioposy>5</radioposy>
+						<radiowidth>20</radiowidth>
+						<radioheight>20</radioheight>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="image">
+						<left>32</left>
+						<top>9</top>
+						<width>32</width>
+						<height>32</height>
+						<texture>Subtitles/flags/$INFO[Window.Property(LocaleLanguage)].png</texture>
+					</control>
 				</control>
 				<control type="radiobutton" id="304">
 					<description>Symbols button</description>
-					<left>0</left>
+					<left>100</left>
 					<top>150</top>
-					<width>200</width>
+					<width>100</width>
 					<height>50</height>
 					<label>20180</label>
-					<onleft>8</onleft>
-					<onright>85</onright>
+					<onleft>312</onleft>
+					<onright>160</onright>
 					<onup>303</onup>
 					<ondown>307</ondown>
 					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
@@ -675,126 +564,127 @@
 					<font>font13</font>
 					<focusedcolor>black</focusedcolor>
 				</control>
-				<control type="button" id="85">
-					<description>'U' button</description>
+				<control type="button" id="160">
+					<description>(3,0) key button</description>
 					<left>200</left>
 					<top>150</top>
-					<width>50</width>
-					<height>50</height>
 					<onleft>304</onleft>
-					<onright>86</onright>
-					<onup>75</onup>
+					<onright>161</onright>
+					<onup>140</onup>
 					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="86">
-					<description>'V' button</description>
+				<control type="button" id="161">
+					<description>(3,1) key button</description>
 					<left>250</left>
 					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>85</onleft>
-					<onright>87</onright>
-					<onup>76</onup>
+					<onleft>160</onleft>
+					<onright>162</onright>
+					<onup>141</onup>
 					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="87">
-					<description>'W' button</description>
+				<control type="button" id="162">
+					<description>(3,2) key button</description>
 					<left>300</left>
 					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>86</onleft>
-					<onright>88</onright>
-					<onup>77</onup>
+					<onleft>161</onleft>
+					<onright>163</onright>
+					<onup>142</onup>
 					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="88">
-					<description>'X' button</description>
+				<control type="button" id="163">
+					<description>(3,3) key button</description>
 					<left>350</left>
 					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>87</onleft>
-					<onright>89</onright>
-					<onup>78</onup>
+					<onleft>162</onleft>
+					<onright>164</onright>
+					<onup>143</onup>
 					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="89">
-					<description>'Y' button</description>
+				<control type="button" id="164">
+					<description>(3,4) key button</description>
 					<left>400</left>
 					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>88</onleft>
-					<onright>90</onright>
-					<onup>79</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>163</onleft>
+					<onright>165</onright>
+					<onup>144</onup>
+					<ondown>8</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="90">
-					<description>'Z' button</description>
+				<control type="button" id="165">
+					<description>(3,5) key button</description>
 					<left>450</left>
 					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>89</onleft>
-					<onright>8</onright>
-					<onup>80</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>164</onleft>
+					<onright>166</onright>
+					<onup>145</onup>
+					<ondown>8</ondown>
+					<include>KeyboardButton</include>
 				</control>
-				<control type="button" id="8">
-					<description>BACKSPACE button</description>
+				<control type="button" id="166">
+					<description>(3,6) key button</description>
 					<left>500</left>
 					<top>150</top>
-					<width>200</width>
-					<height>50</height>
-					<label>20181</label>
-					<onleft>90</onleft>
-					<onright>304</onright>
-					<onup>81</onup>
-					<ondown>305</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<onleft>165</onleft>
+					<onright>167</onright>
+					<onup>146</onup>
+					<ondown>8</ondown>
+					<include>KeyboardButton</include>
 				</control>
+				<control type="button" id="167">
+					<description>(3,7) key button</description>
+					<left>550</left>
+					<top>150</top>
+					<onleft>166</onleft>
+					<onright>168</onright>
+					<onup>147</onup>
+					<ondown>8</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="168">
+					<description>(3,8) key button</description>
+					<left>600</left>
+					<top>150</top>
+					<onleft>167</onleft>
+					<onright>169</onright>
+					<onup>148</onup>
+					<ondown>305</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="169">
+					<description>(3,9) key button</description>
+					<left>650</left>
+					<top>150</top>
+					<onleft>168</onleft>
+					<onright>170</onright>
+					<onup>149</onup>
+					<ondown>305</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="170">
+					<description>(3,10) key button</description>
+					<left>700</left>
+					<top>150</top>
+					<onleft>169</onleft>
+					<onright>171</onright>
+					<onup>150</onup>
+					<ondown>306</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<control type="button" id="171">
+					<description>(3,11) key button</description>
+					<left>750</left>
+					<top>150</top>
+					<onleft>170</onleft>
+					<onright>312</onright>
+					<onup>151</onup>
+					<ondown>306</ondown>
+					<include>KeyboardButton</include>
+				</control>
+				<!-- 5th row -->
 				<control type="button" id="307">
 					<description>IP Input button</description>
 					<left>0</left>
@@ -817,7 +707,7 @@
 					<description>SPACE button</description>
 					<left>200</left>
 					<top>200</top>
-					<width>300</width>
+					<width>200</width>
 					<height>50</height>
 					<label>20182</label>
 					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
@@ -827,13 +717,31 @@
 					<font>font13</font>
 					<focusedcolor>black</focusedcolor>
 					<onleft>307</onleft>
+					<onright>8</onright>
+					<onup>161</onup>
+					<ondown>101</ondown>
+				</control>
+				<control type="button" id="8">
+					<description>BACKSPACE button</description>
+					<left>400</left>
+					<top>200</top>
+					<width>200</width>
+					<height>50</height>
+					<label>20181</label>
+					<onleft>32</onleft>
 					<onright>305</onright>
-					<onup>85</onup>
-					<ondown>48</ondown>
+					<onup>165</onup>
+					<ondown>105</ondown>
+					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+					<texturefocus border="5">KeyboardKey.png</texturefocus>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font13</font>
+					<focusedcolor>black</focusedcolor>
 				</control>
 				<control type="button" id="305">
 					<description>previous button</description>
-					<left>500</left>
+					<left>600</left>
 					<top>200</top>
 					<width>100</width>
 					<height>50</height>
@@ -844,14 +752,14 @@
 					<texturefocus border="5">KeyboardKey.png</texturefocus>
 					<font>font30</font>
 					<focusedcolor>black</focusedcolor>
-					<onleft>32</onleft>
+					<onleft>8</onleft>
 					<onright>306</onright>
-					<onup>8</onup>
-					<ondown>54</ondown>
+					<onup>168</onup>
+					<ondown>108</ondown>
 				</control>
 				<control type="button" id="306">
 					<description>next button</description>
-					<left>600</left>
+					<left>700</left>
 					<top>200</top>
 					<width>100</width>
 					<height>50</height>
@@ -864,8 +772,8 @@
 					<focusedcolor>black</focusedcolor>
 					<onleft>305</onleft>
 					<onright>307</onright>
-					<onup>8</onup>
-					<ondown>56</ondown>
+					<onup>170</onup>
+					<ondown>110</ondown>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -1239,4 +1239,14 @@
 		<animation effect="fade" time="300">Visible</animation>
 		<animation effect="fade" time="300">Hidden</animation>
 	</include>
+	<include name="KeyboardButton">
+		<width>50</width>
+		<height>50</height>
+		<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+		<texturefocus border="5">KeyboardKey.png</texturefocus>
+		<align>center</align>
+		<aligny>center</aligny>
+		<font>font13</font>
+		<focusedcolor>black</focusedcolor>
+	</include>
 </includes>

--- a/language/English/langinfo.xml
+++ b/language/English/langinfo.xml
@@ -151,4 +151,47 @@
   <sorttokens>
     <token>The</token>
   </sorttokens>
+  
+  <keyboardlayouts>
+    <layout name="English ABC">
+      <keyboard>
+        <row>0123456789</row>
+        <row>abcdefghij</row>
+        <row>klmnopqrst</row>
+        <row>uvwxyz</row>
+      </keyboard>
+      <keyboard modifiers="shift">
+        <row>0123456789</row>
+        <row>ABCDEFGHIJ</row>
+        <row>KLMNOPQRST</row>
+        <row>UVWXYZ</row>
+      </keyboard>
+      <keyboard modifiers="symbol,shift+symbol">
+        <row>)!@#$%^&*(</row>
+        <row>[]{}-_=+;:</row>
+        <row>'",.&lt;&gt;/?\|</row>
+        <row>`~</row>
+      </keyboard>
+    </layout>
+    <layout name="English QWERTY">
+      <keyboard>
+        <row>1234567890</row>
+        <row>qwertyuiop</row>
+        <row>asdfghjkl</row>
+        <row>zxcvbnm</row>
+      </keyboard>
+      <keyboard modifiers="shift">
+        <row>1234567890</row>
+        <row>QWERTYUIOP</row>
+        <row>ASDFGHJKL</row>
+        <row>ZXCVBNM</row>
+      </keyboard>
+      <keyboard modifiers="symbol,shift+symbol">
+        <row>)!@#$%^&*(</row>
+        <row>[]{}-_=+;:</row>
+        <row>'",.&lt;&gt;/?\|</row>
+        <row>`~</row>
+      </keyboard>
+    </layout>
+  </keyboardlayouts>
 </language>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1287,7 +1287,15 @@ msgctxt "#309"
 msgid "User interface language"
 msgstr ""
 
-#empty strings from id 310 to 311
+#: system/settings/settings.xml
+msgctxt "#310"
+msgid "Main keyboard layout"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#311"
+msgid "Alternative keyboard layout"
+msgstr ""
 
 msgctxt "#312"
 msgid "(0=auto)"
@@ -15168,9 +15176,18 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36431"
 msgid "Defines whether video decoding should be performed in software (requires more CPU) or with hardware acceleration where possible."
+
+#: system/settings/settings.xml
+msgctxt "#36432"
+msgid "Select main virtual keyboard layout."
 msgstr ""
 
-#empty strings from id 36432 to 36499
+#: system/settings/settings.xml
+msgctxt "#36433"
+msgid "Select alternative virtual keyboard layout."
+msgstr ""
+
+#empty strings from id 36434 to 36499
 #end reservation
 
 #: system/settings/settings.xml

--- a/language/Russian/langinfo.xml
+++ b/language/Russian/langinfo.xml
@@ -38,4 +38,47 @@
     <token>Uno</token>
     <token>Una</token>
   </sorttokens>
+
+  <keyboardlayouts>
+    <layout name="Русская АБВ">
+      <keyboard>
+        <row>0123456789</row>
+        <row>абвгдеёжзий</row>
+        <row>клмнопрстуф</row>
+        <row>хцчшщъыьэюя</row>
+      </keyboard>
+      <keyboard modifiers="shift">
+        <row>0123456789</row>
+        <row>АБВГДЕЁЖЗИЙ</row>
+        <row>КЛМНОПРСТУФ</row>
+        <row>ХЦЧШЩЪЫЬЭЮЯ</row>
+      </keyboard>
+      <keyboard modifiers="symbol,shift+symbol">
+        <row>)!@#$%^&*(</row>
+        <row>[]{}-_=+;:</row>
+        <row>'",.&lt;&gt;/?\|</row>
+        <row>`~</row>
+      </keyboard>
+    </layout>
+    <layout name="Русская ЙЦУКЕН">
+      <keyboard>
+        <row>ё1234567890</row>
+        <row>йцукенгшщзхъ</row>
+        <row>фывапролджэ</row>
+        <row>ячсмитьбю</row>
+      </keyboard>
+      <keyboard modifiers="shift">
+        <row>Ё1234567890</row>
+        <row>ЙЦУКЕНГШЩЗХЪ</row>
+        <row>ФЫВАПРОЛДЖЭ</row>
+        <row>ЯЧСМИТЬБЮ</row>
+      </keyboard>
+      <keyboard modifiers="symbol,shift+symbol">
+        <row>)!@#$%^&*(</row>
+        <row>[]{}-_=+;:</row>
+        <row>'",.&lt;&gt;/?\|</row>
+        <row>`~</row>
+      </keyboard>
+    </layout>
+  </keyboardlayouts>
 </language>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -142,6 +142,22 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="locale.mainkeyboardlayout" type="string" label="310" help="36432">
+          <level>1</level>
+          <default>default</default>
+          <constraints>
+            <options>keyboardlayouts</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="locale.altkeyboardlayout" type="string" label="311" help="36433">
+          <level>1</level>
+          <default>default</default>
+          <constraints>
+            <options>keyboardlayouts</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
       </group>
       <group id="2">
         <setting id="locale.timezonecountry" type="string" label="14079" help="36117">

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -236,6 +236,17 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
 {
   SetDefaults();
 
+  if (!onlyCheckLanguage)
+  {
+    std::string strMainLangInfoPath = StringUtils::Format("special://xbmc/language/%s/langinfo.xml", m_defaultRegion.m_strLangLocaleName.c_str());
+    LoadKeyboardLayouts(strMainLangInfoPath, m_mainKeyboardLayouts);
+    if (!m_mainKeyboardLayout)
+    {
+      const std::string strName = CSettings::Get().GetString("locale.mainkeyboardlayout");
+      SetMainKeyboardLayout(strName);
+    }
+  }
+
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(strFileName))
   {
@@ -377,7 +388,11 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
   g_charsetConverter.reinitCharsetsFromSettings();
 
   if (!onlyCheckLanguage)
+  {
     LoadTokens(pRootElement->FirstChild("sorttokens"), g_advancedSettings.m_vecTokens);
+
+    LoadKeyboardLayouts(pRootElement->FirstChild("keyboardlayouts"), m_altKeyboardLayouts);
+  }
 
   return true;
 }
@@ -407,6 +422,95 @@ void CLangInfo::LoadTokens(const TiXmlNode* pTokens, vector<CStdString>& vecToke
             vecTokens.push_back(CStdString(pToken->FirstChild()->Value())+strSep[i]);
       }
       pToken = pToken->NextSiblingElement();
+    }
+  }
+}
+
+void CLangInfo::LoadKeyboardLayouts(const std::string& strFileName, KeyboardLayoutMap &keyboardLayouts)
+{
+  CXBMCTinyXML xmlDoc;
+  if (!xmlDoc.LoadFile(strFileName))
+  {
+    CLog::Log(LOGERROR, "unable to load %s: %s at line %d", strFileName.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    return;
+  }
+  TiXmlElement* pRootElement = xmlDoc.RootElement();
+  LoadKeyboardLayouts(pRootElement->FirstChild("keyboardlayouts"), keyboardLayouts);
+}
+
+void CLangInfo::LoadKeyboardLayouts(const TiXmlNode* pKeyboardLayouts, KeyboardLayoutMap &keyboardLayouts)
+{
+  keyboardLayouts.clear();
+
+  if (pKeyboardLayouts && !pKeyboardLayouts->NoChildren())
+  {
+    const TiXmlElement *pKeyboardLayout = pKeyboardLayouts->FirstChildElement("layout");
+
+    while (pKeyboardLayout)
+    {
+      // skip nameless layouts
+      if (!pKeyboardLayout->Attribute("name"))
+      {
+        pKeyboardLayout = pKeyboardLayout->NextSiblingElement();
+        continue;
+      }
+
+      CKeyboardLayout layout(pKeyboardLayout->Attribute("name"));
+      const TiXmlElement *pKeyboard = pKeyboardLayout->FirstChildElement("keyboard");
+
+      while (pKeyboard)
+      {
+        // parse modifiers keys
+        std::set<unsigned int> modifierKeysSet;
+
+        if (pKeyboard->Attribute("modifiers"))
+        {
+          std::string strModifiers = pKeyboard->Attribute("modifiers");
+          StringUtils::ToLower(strModifiers);
+
+          std::vector<string> variants = StringUtils::Split(strModifiers, ",");
+          for (std::vector<std::string>::const_iterator itv = variants.begin(); itv != variants.end(); itv++)
+          {
+            unsigned int iKeys = MODIFIER_KEY_NONE;
+            std::vector<std::string> keys = StringUtils::Split(*itv, "+");
+            for (std::vector<std::string>::const_iterator it = keys.begin(); it != keys.end(); it++)
+            {
+              std::string strKey = *it;
+              if (strKey == "shift")
+                iKeys |= MODIFIER_KEY_SHIFT;
+              else if (strKey == "symbol")
+                iKeys |= MODIFIER_KEY_SYMBOL;
+            }
+            modifierKeysSet.insert(iKeys);
+          }
+        }
+
+        // parse keyboard rows
+        const TiXmlNode *pKeyboardRow = pKeyboard->FirstChild("row");
+        while (pKeyboardRow)
+        {
+          if (!pKeyboardRow->NoChildren())
+          {
+            std::string strRow = pKeyboardRow->FirstChild()->ValueStr();
+            std::wstring wstrRow;
+            g_charsetConverter.utf8ToW(strRow, wstrRow);
+            if (!modifierKeysSet.empty())
+            {
+              for (std::set<unsigned int>::const_iterator it = modifierKeysSet.begin(); it != modifierKeysSet.end(); it++)
+                layout.AddKeyboardRow(wstrRow, *it);
+            }
+            else
+              layout.AddKeyboardRow(wstrRow);
+          }
+          pKeyboardRow = pKeyboardRow->NextSibling();
+        }
+
+        pKeyboard = pKeyboard->NextSiblingElement();
+      }
+
+      keyboardLayouts.insert(std::make_pair(layout.GetName(), layout));
+
+      pKeyboardLayout = pKeyboardLayout->NextSiblingElement();
     }
   }
 }
@@ -631,6 +735,55 @@ CLangInfo::SPEED_UNIT CLangInfo::GetSpeedUnit() const
 const CStdString& CLangInfo::GetSpeedUnitString() const
 {
   return g_localizeStrings.Get(SPEED_UNIT_STRINGS+m_currentRegion->m_speedUnit);
+}
+
+CKeyboardLayout* CLangInfo::GetMainKeyboardLayout()
+{
+  return m_mainKeyboardLayout;
+}
+
+void CLangInfo::SetMainKeyboardLayout(const std::string &strName)
+{
+  KeyboardLayoutMap::iterator it = m_mainKeyboardLayouts.find(strName);
+  if (it != m_mainKeyboardLayouts.end())
+    m_mainKeyboardLayout = &it->second;
+  else if (!m_mainKeyboardLayouts.empty())
+    m_mainKeyboardLayout = &m_mainKeyboardLayouts.begin()->second;
+  else
+    m_mainKeyboardLayout = NULL;
+}
+
+void CLangInfo::GetMainKeyboardLayoutNames(std::vector<std::string> &array)
+{
+  for (KeyboardLayoutMap::const_iterator it = m_mainKeyboardLayouts.begin(); it != m_mainKeyboardLayouts.end(); it++)
+  {
+    array.push_back(it->first);
+  }
+}
+
+CKeyboardLayout* CLangInfo::GetAltKeyboardLayout()
+{
+  return m_altKeyboardLayout;
+}
+
+bool CLangInfo::HasAltKeyboardLayout()
+{
+  return m_altKeyboardLayout != NULL;
+}
+
+void CLangInfo::SetAltKeyboardLayout(const std::string &strName)
+{
+  KeyboardLayoutMap::iterator it = m_altKeyboardLayouts.find(strName);
+  if (it != m_altKeyboardLayouts.end())
+    m_altKeyboardLayout = &it->second;
+  else if (!m_altKeyboardLayouts.empty())
+    m_altKeyboardLayout = &m_altKeyboardLayouts.begin()->second;
+}
+
+void CLangInfo::GetAltKeyboardLayoutNames(std::vector<std::string> &array)
+{
+  for (KeyboardLayoutMap::const_iterator it = m_altKeyboardLayouts.begin(); it != m_altKeyboardLayouts.end(); it++)
+    array.push_back(it->first);
 }
 
 void CLangInfo::SettingOptionsLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -230,6 +230,10 @@ void CLangInfo::OnSettingChanged(const CSetting *setting)
     g_langInfo.SetCurrentRegion(((CSettingString*)setting)->GetValue());
     g_weatherManager.Refresh(); // need to reset our weather, as temperatures need re-translating.
   }
+  else if (settingId == "locale.mainkeyboardlayout")
+    g_langInfo.SetMainKeyboardLayout(((CSettingString*)setting)->GetValue());
+  else if (settingId == "locale.altkeyboardlayout")
+    g_langInfo.SetAltKeyboardLayout(((CSettingString*)setting)->GetValue());
 }
 
 bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= false*/)
@@ -392,6 +396,8 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
     LoadTokens(pRootElement->FirstChild("sorttokens"), g_advancedSettings.m_vecTokens);
 
     LoadKeyboardLayouts(pRootElement->FirstChild("keyboardlayouts"), m_altKeyboardLayouts);
+    const std::string strName = CSettings::Get().GetString("locale.altkeyboardlayout");
+    SetAltKeyboardLayout(strName);
   }
 
   return true;
@@ -846,4 +852,31 @@ void CLangInfo::SettingOptionsRegionsFiller(const CSetting *setting, std::vector
 
   if (!match && regions.size() > 0)
     current = regions[0];
+}
+
+void CLangInfo::SettingOptionsKeyboardLayoutsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current)
+{
+  std::vector<std::string> names;
+  if (setting->GetId() == "locale.mainkeyboardlayout")
+    g_langInfo.GetMainKeyboardLayoutNames(names);
+  else if (setting->GetId() == "locale.altkeyboardlayout")
+    g_langInfo.GetAltKeyboardLayoutNames(names);
+  else
+    return;
+
+  bool match = false;
+  for (std::vector<std::string>::const_iterator it = names.begin(); it != names.end(); it++)
+  {
+    std::string strName = *it;
+    list.push_back(make_pair(strName, strName));
+
+    if (!match && strName == ((CSettingString*)setting)->GetValue())
+    {
+      match = true;
+      current = strName;
+    }
+  }
+
+  if (!match && !names.empty())
+    current = names[0];
 }

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -133,10 +133,12 @@ public:
 
   CKeyboardLayout* GetMainKeyboardLayout();
   void SetMainKeyboardLayout(const std::string &strName);
+  void GetMainKeyboardLayoutNames(std::vector<std::string> &array);
 
   CKeyboardLayout* GetAltKeyboardLayout();
   bool HasAltKeyboardLayout();
   void SetAltKeyboardLayout(const std::string &strName);
+  void GetAltKeyboardLayoutNames(std::vector<std::string> &array);
 
   static bool CheckLanguage(const std::string& language);
 
@@ -148,6 +150,7 @@ public:
   static void SettingOptionsLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
   static void SettingOptionsRegionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
+  static void SettingOptionsKeyboardLayoutsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
 
 protected:
   void SetDefaults();

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include "guilib/KeyboardLayout.h"
 #include "settings/lib/ISettingCallback.h"
 #include "utils/StdString.h"
 
@@ -34,6 +35,8 @@
 #endif // TARGET_WINDOWS
 
 class TiXmlNode;
+
+typedef std::map<std::string, CKeyboardLayout> KeyboardLayoutMap;
 
 class CLangInfo : public ISettingCallback
 {
@@ -128,9 +131,19 @@ public:
   void SetCurrentRegion(const CStdString& strName);
   const CStdString& GetCurrentRegion() const;
 
+  CKeyboardLayout* GetMainKeyboardLayout();
+  void SetMainKeyboardLayout(const std::string &strName);
+
+  CKeyboardLayout* GetAltKeyboardLayout();
+  bool HasAltKeyboardLayout();
+  void SetAltKeyboardLayout(const std::string &strName);
+
   static bool CheckLanguage(const std::string& language);
 
   static void LoadTokens(const TiXmlNode* pTokens, std::vector<CStdString>& vecTokens);
+
+  static void LoadKeyboardLayouts(const std::string& strFileName, KeyboardLayoutMap &keyboardLayouts);
+  static void LoadKeyboardLayouts(const TiXmlNode* pKeyboardLayouts, KeyboardLayoutMap &keyboardLayouts);
 
   static void SettingOptionsLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current);
@@ -182,6 +195,11 @@ protected:
   CStdString m_subtitleLanguage;
   // this is the general (not win32-specific) three char language code
   CStdString m_languageCodeGeneral;
+
+  KeyboardLayoutMap m_mainKeyboardLayouts;
+  KeyboardLayoutMap m_altKeyboardLayouts;
+  CKeyboardLayout *m_mainKeyboardLayout;
+  CKeyboardLayout *m_altKeyboardLayout;
 };
 
 

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.h
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.h
@@ -24,7 +24,8 @@
 #include "guilib/GUIDialog.h"
 #include "utils/Variant.h"
 
-enum KEYBOARD {CAPS, LOWER, SYMBOLS };
+enum KEYBOARD {CAPS, LOWER, SYMBOLS};
+enum LAYOUT {MAIN, ALT};
 
 class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
 {
@@ -58,6 +59,7 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void MoveCursor(int iAmount);
     void SetCursorPos(int iPos);
     int GetCursorPos() const;
+    void OnLayout();
     void OnSymbols();
     void OnIPAddress();
     void OnOK();
@@ -66,7 +68,6 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void OnClickButton(int iButtonControl);
     void OnRemoteNumberClick(int key);
     void UpdateButtons();
-    char GetCharacter(int iButton);
     void UpdateLabel();
     void ResetShiftAndSymbols();
     void Backspace();
@@ -82,7 +83,7 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
 
     bool m_bIsConfirmed;
     KEYBOARD m_keyType;
-    int m_iMode;
+    LAYOUT m_keyLayout;
     bool m_bShift;
     bool m_hiddenInput;
 
@@ -91,7 +92,6 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     int m_indexInSeries;
     std::string m_strHeading;
     static const char* s_charsSeries[10];
-
 
     char_callback_t m_pCharCallback;
 };

--- a/xbmc/guilib/KeyboardLayout.cpp
+++ b/xbmc/guilib/KeyboardLayout.cpp
@@ -1,0 +1,73 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "KeyboardLayout.h"
+
+CKeyboardLayout::CKeyboardLayout(const std::string &name)
+{
+  m_strName = name;
+}
+
+CKeyboardLayout::~CKeyboardLayout(void)
+{
+
+}
+
+std::string CKeyboardLayout::GetName() const
+{
+  return m_strName;
+}
+
+void CKeyboardLayout::AddKeyboardRow(const std::wstring &wstrKeyboardRow, unsigned int iModifierKeys)
+{
+  m_keyboards[iModifierKeys].push_back(wstrKeyboardRow);
+}
+
+WCHAR CKeyboardLayout::GetCharAt(unsigned int iRow, unsigned int iColumn, unsigned int iModifierKeys)
+{
+  KeyboardRows rows = m_keyboards[iModifierKeys];
+  if (iModifierKeys != MODIFIER_KEY_NONE && rows.empty())
+  {
+    // fallback to basic keyboard
+    rows = m_keyboards[MODIFIER_KEY_NONE];
+  }
+
+  if (iRow < rows.size())
+  {
+    if (iColumn < rows[iRow].size())
+    {
+      WCHAR ch = rows[iRow][iColumn];
+      if (ch != L' ')
+        return ch;
+    }
+  }
+
+  return L'\0';
+}
+
+void CKeyboardLayout::Clear()
+{
+  for (Keyboards::const_iterator it = m_keyboards.begin(); it != m_keyboards.end(); it++)
+  {
+    KeyboardRows rows = it->second;
+    rows.clear();
+  }
+  m_keyboards.clear();
+}

--- a/xbmc/guilib/KeyboardLayout.h
+++ b/xbmc/guilib/KeyboardLayout.h
@@ -1,0 +1,66 @@
+/*!
+\file KeyboardLayout.h
+\brief
+*/
+
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#include <string>
+#include <map>
+#include <vector>
+
+/*!
+ \ingroup keyboardlayouts
+ \brief
+ */
+
+enum MODIFIER_KEYS
+{
+  MODIFIER_KEY_NONE  = 0x00,
+  MODIFIER_KEY_SHIFT = 0x01,
+  MODIFIER_KEY_SYMBOL = 0x02
+};
+
+class CKeyboardLayout
+{
+public:
+  CKeyboardLayout(const std::string &name);
+  virtual ~CKeyboardLayout(void);
+  std::string GetName() const;
+  void AddKeyboardRow(const std::wstring &strKeyboardRow, unsigned int iModifierKeys = 0);
+  WCHAR GetCharAt(unsigned int iRow, unsigned int iColumn, unsigned int iModifierKeys = 0);
+  void Clear();
+
+protected:
+  typedef std::vector<std::wstring> KeyboardRows;
+  typedef std::map<unsigned int, KeyboardRows> Keyboards;
+
+  std::string m_strName;
+  Keyboards m_keyboards;
+};
+
+/*!
+ \ingroup keyboardlayouts
+ \brief
+ */

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -66,6 +66,7 @@ SRCS += imagefactory.cpp
 SRCS += IWindowManagerCallback.cpp
 SRCS += JpegIO.cpp
 SRCS += Key.cpp
+SRCS += KeyboardLayout.cpp
 SRCS += LocalizeStrings.cpp
 SRCS += Shader.cpp
 SRCS += StereoscopicsManager.cpp

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -418,6 +418,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("timezones");
 #endif // defined(TARGET_LINUX)
   m_settingsManager->UnregisterSettingOptionsFiller("verticalsyncs");
+  m_settingsManager->UnregisterSettingOptionsFiller("keyboardlayouts");
 
   // unregister ISettingCallback implementations
   m_settingsManager->UnregisterCallback(&g_advancedSettings);
@@ -847,6 +848,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("timezones", CLinuxTimezone::SettingOptionsTimezonesFiller);
 #endif
   m_settingsManager->RegisterSettingOptionsFiller("verticalsyncs", CDisplaySettings::SettingOptionsVerticalSyncsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("keyboardlayouts", CLangInfo::SettingOptionsKeyboardLayoutsFiller);
 }
 
 void CSettings::InitializeConditions()
@@ -1084,6 +1086,8 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("locale.subtitlelanguage");
   settingSet.insert("locale.language");
   settingSet.insert("locale.country");
+  settingSet.insert("locale.mainkeyboardlayout");
+  settingSet.insert("locale.altkeyboardlayout");
   m_settingsManager->RegisterCallback(&g_langInfo, settingSet);
 
 #if defined(HAS_SDL_JOYSTICK)


### PR DESCRIPTION
There are many cases and requests for i18l on-screen keyboard. This is an attempt to support it.
The keyboard layout and contents are defined in static data section of hidden container control in DialogKeyboard.xml, so it's up to a skinner to change it the way he wants (ABCDE, QWERTY, etc.). I did the definitions for default language (English) and for Russian.
User can switch layout between default language and local one. If local language equals to default then the switch button is disabled.
I don't know if this technique covers hieroglyphic languages, but at least it's a start of the keyboard internationalization.
Here are some screenshots:
![en-en](https://f.cloud.github.com/assets/28398/2209331/a2f2bb14-998a-11e3-884b-af60042b0299.png)
![ru-eng](https://f.cloud.github.com/assets/28398/2209335/aedafb6c-998a-11e3-847f-e4c02f8d853e.png)
![ru-ru](https://f.cloud.github.com/assets/28398/2209338/b39e271e-998a-11e3-9a86-598aec2a34cc.png)
