### PR TITLE
Fix deletion of URL string for variable length playlists.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -51,13 +51,14 @@ bool CDVDInputStreamFFmpeg::IsEOF()
 bool CDVDInputStreamFFmpeg::Open(const char* strFile, const std::string& content)
 {
   CFileItem item(strFile, false);
+  std::string selected;
   if (item.IsInternetStream() && item.IsType(".m3u8"))
   {
     // get the available bandwidth and  determine the most appropriate stream
     int bandwidth = CSettings::Get().GetInt("network.bandwidth");
     if(bandwidth <= 0)
       bandwidth = INT_MAX;
-    std::string selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(strFile, bandwidth);
+    selected = PLAYLIST::CPlayListM3U::GetBestBandwidthStream(strFile, bandwidth);
     if (selected.compare(strFile) != 0)
     {
       CLog::Log(LOGINFO, "CDVDInputStreamFFmpeg: Auto-selecting %s based on configured bandwidth.", selected.c_str());


### PR DESCRIPTION
When the playlist M3U helper selects a specific M3U/8 playlist it will
overwrite the strFile pointer with the internal contents of selected.
However, selected then goes out of scope leaving garbage as the URL.

The scope of this bug is that any variable length m3u/m3u8 playlist cannot be played.
The changes were made in commits c0f4ccb3afa66cb21b1a9b08fdf21af5e371e38d and
326951012f65b74bb5f70e21f5972598de400079.
