### PR TITLE
Do not scroll list label if <scroll>false</scroll>

### DIFF
--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -281,6 +281,8 @@ public:
 
   enum GUIVISIBLE { HIDDEN = 0, DELAYED, VISIBLE };
 
+  enum GUISCROLLVALUE { FOCUS = 0, NEVER, ALWAYS };
+
 #ifdef _DEBUG
   virtual void DumpTextureUse() {};
 #endif

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -744,7 +744,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   vector<CAnimation> animations;
 
-  bool bScrollLabel = false;
+  CGUIControl::GUISCROLLVALUE scrollValue = CGUIControl::FOCUS;
   bool bPulse = true;
   unsigned int timePerImage = 0;
   unsigned int fadeTime = 0;
@@ -996,7 +996,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   XMLUtils::GetFloat(pControlNode, "itemgap", buttonGap);
   XMLUtils::GetInt(pControlNode, "movement", iMovementRange);
   GetAspectRatio(pControlNode, "aspectratio", aspect);
-  XMLUtils::GetBoolean(pControlNode, "scroll", bScrollLabel);
+
+  bool alwaysScroll;
+  if (XMLUtils::GetBoolean(pControlNode, "scroll", alwaysScroll))
+    scrollValue = alwaysScroll ? CGUIControl::ALWAYS : CGUIControl::NEVER;
+
   XMLUtils::GetBoolean(pControlNode,"pulseonselect", bPulse);
   XMLUtils::GetInt(pControlNode, "timeblocks", timeBlocks);
   XMLUtils::GetInt(pControlNode, "rulerunit", rulerUnit);
@@ -1127,7 +1131,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     const CGUIInfoLabel &content = (infoLabels.size()) ? infoLabels[0] : CGUIInfoLabel("");
     if (insideContainer)
     { // inside lists we use CGUIListLabel
-      control = new CGUIListLabel(parentID, id, posX, posY, width, height, labelInfo, content, bScrollLabel);
+      control = new CGUIListLabel(parentID, id, posX, posY, width, height, labelInfo, content, scrollValue);
     }
     else
     {
@@ -1135,7 +1139,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
         parentID, id, posX, posY, width, height,
         labelInfo, wrapMultiLine, bHasPath);
       ((CGUILabelControl *)control)->SetInfo(content);
-      ((CGUILabelControl *)control)->SetWidthControl(minWidth, bScrollLabel);
+      ((CGUILabelControl *)control)->SetWidthControl(minWidth, (scrollValue == CGUIControl::ALWAYS) ? true : false);
     }
   }
   else if (type == CGUIControl::GUICONTROL_EDIT)

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -212,10 +212,10 @@ void CGUIListItemLayout::CreateListControlLayouts(float width, float height, boo
   image->SetAspectRatio(CAspectRatio::AR_KEEP);
   m_group.AddControl(image);
   float x = iconWidth + labelInfo.offsetX + 10;
-  CGUIListLabel *label = new CGUIListLabel(0, 0, x, labelInfo.offsetY, width - x - 18, height, labelInfo, CGUIInfoLabel("$INFO[ListItem.Label]", "", m_group.GetParentID()), false);
+  CGUIListLabel *label = new CGUIListLabel(0, 0, x, labelInfo.offsetY, width - x - 18, height, labelInfo, CGUIInfoLabel("$INFO[ListItem.Label]", "", m_group.GetParentID()), CGUIControl::FOCUS);
   m_group.AddControl(label);
   x = labelInfo2.offsetX ? labelInfo2.offsetX : m_width - 16;
-  label = new CGUIListLabel(0, 0, x, labelInfo2.offsetY, x - iconWidth - 20, height, labelInfo2, CGUIInfoLabel("$INFO[ListItem.Label2]", "", m_group.GetParentID()), false);
+  label = new CGUIListLabel(0, 0, x, labelInfo2.offsetY, x - iconWidth - 20, height, labelInfo2, CGUIInfoLabel("$INFO[ListItem.Label2]", "", m_group.GetParentID()), CGUIControl::FOCUS);
   m_group.AddControl(label);
 }
 //#endif

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -22,12 +22,12 @@
 #include <limits>
 #include "addons/Skin.h"
 
-CGUIListLabel::CGUIListLabel(int parentID, int controlID, float posX, float posY, float width, float height, const CLabelInfo& labelInfo, const CGUIInfoLabel &info, bool alwaysScroll)
+CGUIListLabel::CGUIListLabel(int parentID, int controlID, float posX, float posY, float width, float height, const CLabelInfo& labelInfo, const CGUIInfoLabel &info, CGUIControl::GUISCROLLVALUE scroll)
     : CGUIControl(parentID, controlID, posX, posY, width, height)
-    , m_label(posX, posY, width, height, labelInfo, alwaysScroll ? CGUILabel::OVER_FLOW_SCROLL : CGUILabel::OVER_FLOW_TRUNCATE)
+    , m_label(posX, posY, width, height, labelInfo, (scroll == CGUIControl::ALWAYS) ? CGUILabel::OVER_FLOW_SCROLL : CGUILabel::OVER_FLOW_TRUNCATE)
     , m_info(info)
 {
-  m_alwaysScroll = alwaysScroll;
+  m_scroll = scroll;
   if (g_SkinInfo && g_SkinInfo->APIVersion() < ADDON::AddonVersion("5.1.0"))
   {
     if (labelInfo.align & XBFONT_RIGHT)
@@ -46,7 +46,10 @@ CGUIListLabel::~CGUIListLabel(void)
 
 void CGUIListLabel::SetScrolling(bool scrolling)
 {
-  m_label.SetScrolling(scrolling || m_alwaysScroll);
+  if (m_scroll == CGUIControl::FOCUS)
+    m_label.SetScrolling(scrolling);
+  else
+    m_label.SetScrolling((m_scroll == CGUIControl::ALWAYS) ? true : false);
 }
 
 void CGUIListLabel::SetSelected(bool selected)

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -36,7 +36,7 @@ class CGUIListLabel :
       public CGUIControl
 {
 public:
-  CGUIListLabel(int parentID, int controlID, float posX, float posY, float width, float height, const CLabelInfo& labelInfo, const CGUIInfoLabel &label, bool alwaysScroll);
+  CGUIListLabel(int parentID, int controlID, float posX, float posY, float width, float height, const CLabelInfo& labelInfo, const CGUIInfoLabel &label, CGUIControl::GUISCROLLVALUE scroll);
   virtual ~CGUIListLabel(void);
   virtual CGUIListLabel *Clone() const { return new CGUIListLabel(*this); };
 
@@ -64,5 +64,5 @@ protected:
 
   CGUILabel     m_label;
   CGUIInfoLabel m_info;
-  bool          m_alwaysScroll;
+  CGUIControl::GUISCROLLVALUE m_scroll;
 };


### PR DESCRIPTION
With the recent change of commit https://github.com/xbmc/xbmc/commit/e4753e8aaae90dc764435c1dec0c08aea533ea18 it wasn't possible anymore to disable scrolling with `<scroll>false</scroll>`. This fixes it.
