### PR TITLE
[ios/arm64] - fix bt keyboard cursor keys when compiled for 64bit arm

### DIFF
--- a/xbmc/osx/ios/XBMCApplication.m
+++ b/xbmc/osx/ios/XBMCApplication.m
@@ -168,7 +168,7 @@ XBMCController *m_xbmcController;
 #define GSEVENT_FLAGS 12
 #define GSEVENTKEY_KEYCODE 15
 #define GSEVENTKEY_KEYCODE_IOS7 17
-#define GSEVENTKEY_KEYCODE_64_BIT 19
+#define GSEVENTKEY_KEYCODE_64_BIT 13
 #define GSEVENT_TYPE_KEYUP 11
 
 #define MSHookMessageEx(class, selector, replacement, result) \
@@ -217,13 +217,13 @@ static void XBMCsendEvent(id _self, SEL _cmd, UIEvent *event)
     // a GSEventRecord among other things
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    int *eventMem = (int *)[event performSelector:@selector(_gsEvent)];
+    NSInteger *eventMem = (NSInteger *)[event performSelector:@selector(_gsEvent)];
 #pragma clang diagnostic pop
 
     if (eventMem) 
     {
       // So far we got a GSEvent :)
-      int eventType = eventMem[GSEVENT_TYPE];
+      NSInteger eventType = eventMem[GSEVENT_TYPE];
       if (eventType == GSEVENT_TYPE_KEYUP) 
       {
         // support 32 and 64bit arm here...
@@ -252,10 +252,6 @@ __attribute__((constructor)) static void HookKeyboard(void)
 {
   if (sizeof(NSUInteger) == 8)
   {
-    kGKKeyboardDirectionDown = 31;
-    kGKKeyboardDirectionUp = 30;
-    kGKKeyboardDirectionRight = 29;
-    kGKKeyboardDirectionLeft = 28;
     LOG(@"Detected 64bit system!!!");
   }
   else


### PR DESCRIPTION
fix bt cursor keys for 64bit ios - i knew my offset shit was wrong ;)

Just in case we will accept the PR from linusyang at one point for beeing able to compile for ios 64bit - this is the correct bt keyboard cursor key thingy.

tested on ios7arm64 (xbmc 32bit), ios7arm64 (xbmc 64bit), ios6arm32 (xbmc 32bit), ios5arm32 (xbmc 32bit).

Its all about NSInteger beeing 32bit when compiled for arm32 and 64bit when compiled for arm64.

This can be G+1 material - just don't wanna loose the findings ...
