### PR TITLE
dvdplayer: [fix] subtitle priority for multiple external subtitles

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -168,7 +168,7 @@ public:
 
     if (preferexternal)
     {
-      if(ss.source == STREAM_SOURCE_DEMUX_SUB || ss.source == STREAM_SOURCE_TEXT)
+      if(STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_TEXT)
         return false;
     }
 
@@ -257,11 +257,11 @@ public:
 
     if (preferextsubs)
     {
-      PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
-                     , rh.source == STREAM_SOURCE_DEMUX_SUB);
+      PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB
+                     , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB);
 
-      PREDICATE_RETURN(lh.source == STREAM_SOURCE_TEXT
-                     , rh.source == STREAM_SOURCE_TEXT);
+      PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT
+                     , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT);
     }
 
     if(!subson || original)
@@ -276,15 +276,15 @@ public:
     CStdString subtitle_language = g_langInfo.GetSubtitleLanguage();
     if(!original)
     {
-      PREDICATE_RETURN((lh.source == STREAM_SOURCE_DEMUX_SUB || lh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
-                     , (rh.source == STREAM_SOURCE_DEMUX_SUB || rh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
+      PREDICATE_RETURN((STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
+                     , (STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
     }
 
-    PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
-                   , rh.source == STREAM_SOURCE_DEMUX_SUB);
+    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB
+                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB);
 
-    PREDICATE_RETURN(lh.source == STREAM_SOURCE_TEXT
-                   , rh.source == STREAM_SOURCE_TEXT);
+    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT
+                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT);
 
     if(!original)
     {

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -208,7 +208,7 @@ public:
 
     if (preferexternal)
     {
-      if(ss.source == STREAM_SOURCE_DEMUX_SUB || ss.source == STREAM_SOURCE_TEXT)
+      if(STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_TEXT)
         return false;
     }
 
@@ -301,11 +301,11 @@ public:
 
     if (preferextsubs)
     {
-      PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
-                     , rh.source == STREAM_SOURCE_DEMUX_SUB);
+      PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB
+                     , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB);
 
-      PREDICATE_RETURN(lh.source == STREAM_SOURCE_TEXT
-                     , rh.source == STREAM_SOURCE_TEXT);
+      PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT
+                     , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT);
     }
 
     if(!subson || original)
@@ -320,15 +320,15 @@ public:
     CStdString subtitle_language = g_langInfo.GetSubtitleLanguage();
     if(!original)
     {
-      PREDICATE_RETURN((lh.source == STREAM_SOURCE_DEMUX_SUB || lh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
-                     , (rh.source == STREAM_SOURCE_DEMUX_SUB || rh.source == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
+      PREDICATE_RETURN((STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, lh.language)
+                     , (STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB || STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT) && g_LangCodeExpander.CompareLangCodes(subtitle_language, rh.language));
     }
 
-    PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
-                   , rh.source == STREAM_SOURCE_DEMUX_SUB);
+    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_DEMUX_SUB
+                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_DEMUX_SUB);
 
-    PREDICATE_RETURN(lh.source == STREAM_SOURCE_TEXT
-                   , rh.source == STREAM_SOURCE_TEXT);
+    PREDICATE_RETURN(STREAM_SOURCE_MASK(lh.source) == STREAM_SOURCE_TEXT
+                   , STREAM_SOURCE_MASK(rh.source) == STREAM_SOURCE_TEXT);
 
     if(!original)
     {


### PR DESCRIPTION
Until now, always the first external subtitle has been selected, even if there was a forced one (i.e. MOVIE.EN.forced.idx) in the list of available external subtitles.

With this fix the subtitle prioritisation behaviour is the same as when using muxed subtitles.
