### PR TITLE
AESinkPULSE: Do not change global pulse volume

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -483,7 +483,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   }
   m_Channels = format.m_channelLayout.Count();
 
-  pa_cvolume_reset(&m_Volume, m_Channels);
+  pa_cvolume_init(&m_Volume);
 
   pa_format_info *info[1];
   info[0] = pa_format_info_new();


### PR DESCRIPTION
@bobon1on1 had a problem with sink volume getting reset on initialization, which is what pa_cvolume_reset does. This would always reset volume when "Best" is chosen and the sink is reinitialized.
