### PR TITLE
Implements OnSettingsUnloaded

### DIFF
--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -860,6 +860,13 @@ bool CSettingsManager::OnSettingsLoading()
   return true;
 }
 
+void CSettingsManager::OnSettingsUnloaded()
+{
+  CSharedLock lock(m_critical);
+  for (SettingsHandlers::const_iterator it = m_settingsHandlers.begin(); it != m_settingsHandlers.end(); ++it)
+    (*it)->OnSettingsUnloaded();
+}
+
 void CSettingsManager::OnSettingsLoaded()
 {
   CSharedLock lock(m_critical);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -393,6 +393,7 @@ private:
   // implementation of ISettingsHandler
   virtual bool OnSettingsLoading();
   virtual void OnSettingsLoaded();
+  virtual void OnSettingsUnloaded();
   virtual bool OnSettingsSaving() const;
   virtual void OnSettingsSaved() const;
   virtual void OnSettingsCleared();


### PR DESCRIPTION
Various settings handlers did stuff in their callbacks, but the callbacks were never called.

Fixes advancedsettings not clearing between profiles.

@Montellese to comment.
