### PR TITLE
fix: woa -no progress dialog when start playing from main menu

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3383,7 +3383,7 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
 
   m_pPlayer->CreatePlayer(newPlayer, *this);
 
-  PlayBackRet iResult;
+  PlayBackRet iResult = PLAYBACK_FAIL;
   if (m_pPlayer->HasPlayer())
   {
     /* When playing video pause any low priority jobs, they will be unpaused  when playback stops.
@@ -3399,13 +3399,14 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
     // may wait on another thread, that requires gfx
     CSingleExit ex(g_graphicsContext);
 
-    iResult = m_pPlayer->OpenFile(item, options);
+    if (item.Exists()) // this is also an implicit call to CWakeOnAccess::WakeUpHost() if enabled
+      iResult = m_pPlayer->OpenFile(item, options);
+    else
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(16026), g_localizeStrings.Get(16027));
   }
-  else
-  {
+
+  if (iResult == PLAYBACK_FAIL)
     CLog::Log(LOGERROR, "Error creating player for item %s (File doesn't exist?)", item.GetPath().c_str());
-    iResult = PLAYBACK_FAIL;
-  }
 
   if (iResult == PLAYBACK_OK)
   {


### PR DESCRIPTION
ref http://trac.xbmc.org/ticket/14954

playback is started in background-thread therefore woa does not give visual feedback (progress-dialog).

suggested solution ; access file from gui-thread (using File::Exists()) to have woa activated before spawning playback-thread.
I don have a deep overview of the playback system (very little, in fact;-), so ;
- is there any danger or drawback in doing it where I suggest in this PR?
- are there other similar places where some of the same scenario can pop up?
