### PR TITLE
[WIN32] hook up CAEFactory::DeviceChange() to audio device changes

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -2487,6 +2487,7 @@
     <ClInclude Include="..\..\xbmc\view\ViewDatabase.h" />
     <ClInclude Include="..\..\xbmc\view\ViewState.h" />
     <ClInclude Include="..\..\xbmc\view\ViewStateSettings.h" />
+    <ClInclude Include="..\..\xbmc\win32\IMMNotificationClient.h" />
     <ClInclude Include="..\..\xbmc\win32\pch.h" />
     <ClInclude Include="..\..\xbmc\win32\PlatformDefs.h" />
     <ClInclude Include="..\..\xbmc\XBDateTime.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -6112,6 +6112,9 @@
     <ClInclude Include="..\..\xbmc\utils\XSLTUtils.h">
       <Filter>utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\win32\IMMNotificationClient.h">
+      <Filter>win32</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -21,7 +21,7 @@
 #define INITGUID
 
 #include "AESinkDirectSound.h"
-#include "utils/Log.h"
+#include "utils/log.h"
 #include <initguid.h>
 #include <list>
 #include "threads/SingleLock.h"

--- a/xbmc/win32/IMMNotificationClient.h
+++ b/xbmc/win32/IMMNotificationClient.h
@@ -1,0 +1,167 @@
+//#pragma once
+/*
+ *      Copyright (C) 2014 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <Audioclient.h>
+#include <mmdeviceapi.h>
+#include "system.h" // for SAFE_RELEASE
+#include "utils/log.h"
+#include "cores/AudioEngine/AEFactory.h"
+
+class CMMNotificationClient : public IMMNotificationClient
+{
+  LONG _cRef;
+  IMMDeviceEnumerator *_pEnumerator;
+
+
+public:
+  CMMNotificationClient() : _cRef(1), _pEnumerator(NULL)
+  {
+  }
+
+  ~CMMNotificationClient()
+  {
+    SAFE_RELEASE(_pEnumerator);
+  }
+
+  // IUnknown methods -- AddRef, Release, and QueryInterface
+
+  ULONG STDMETHODCALLTYPE AddRef()
+  {
+    return InterlockedIncrement(&_cRef);
+  }
+
+  ULONG STDMETHODCALLTYPE Release()
+  {
+    ULONG ulRef = InterlockedDecrement(&_cRef);
+    if (0 == ulRef)
+    {
+      delete this;
+    }
+    return ulRef;
+  }
+
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, VOID **ppvInterface)
+  {
+    if (IID_IUnknown == riid)
+    {
+      AddRef();
+      *ppvInterface = (IUnknown*)this;
+    }
+    else if (__uuidof(IMMNotificationClient) == riid)
+    {
+      AddRef();
+      *ppvInterface = (IMMNotificationClient*)this;
+    }
+    else
+    {
+      *ppvInterface = NULL;
+      return E_NOINTERFACE;
+    }
+    return S_OK;
+  }
+
+  // Callback methods for device-event notifications.
+
+  HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR pwstrDeviceId)
+  {
+    // if the default device changes this function is called four times.
+    // therefore we call CAEFactory::DeviceChange() only for one role.
+    char  *pszFlow = "?????";
+    char  *pszRole = "?????";
+
+    switch (flow)
+    {
+    case eRender:
+      pszFlow = "eRender";
+      break;
+    case eCapture:
+      pszFlow = "eCapture";
+      break;
+    }
+
+    switch (role)
+    {
+    case eConsole:
+      pszRole = "eConsole";
+      break;
+    case eMultimedia:
+      pszRole = "eMultimedia";
+      break;
+    case eCommunications:
+      pszRole = "eCommunications";
+      CAEFactory::DeviceChange();
+      break;
+    }
+
+    CLog::Log(LOGDEBUG, "%s: New default device: flow = %s, role = %s", __FUNCTION__, pszFlow, pszRole);
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR pwstrDeviceId)
+  {
+    CLog::Log(LOGDEBUG, "%s: Added device: %s", __FUNCTION__, pwstrDeviceId);
+    CAEFactory::DeviceChange();
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR pwstrDeviceId)
+  {
+    CLog::Log(LOGDEBUG, "%s: Removed device: %s", __FUNCTION__, pwstrDeviceId);
+    CAEFactory::DeviceChange();
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE OnDeviceStateChanged(LPCWSTR pwstrDeviceId, DWORD dwNewState)
+  {
+    char  *pszState = "?????";
+
+    switch (dwNewState)
+    {
+    case DEVICE_STATE_ACTIVE:
+      pszState = "ACTIVE";
+      break;
+    case DEVICE_STATE_DISABLED:
+      pszState = "DISABLED";
+      break;
+    case DEVICE_STATE_NOTPRESENT:
+      pszState = "NOTPRESENT";
+      break;
+    case DEVICE_STATE_UNPLUGGED:
+      pszState = "UNPLUGGED";
+      break;
+    }
+    CLog::Log(LOGDEBUG, "%s: New device state is DEVICE_STATE_%s", __FUNCTION__, pszState);
+    CAEFactory::DeviceChange();
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(LPCWSTR pwstrDeviceId, const PROPERTYKEY key)
+  {
+    CLog::Log(LOGDEBUG, "%s: Changed device property of %s is {%8.8x-%4.4x-%4.4x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x}#%d", 
+              __FUNCTION__, pwstrDeviceId, key.fmtid.Data1, key.fmtid.Data2, key.fmtid.Data3,
+                                           key.fmtid.Data4[0], key.fmtid.Data4[1],
+                                           key.fmtid.Data4[2], key.fmtid.Data4[3],
+                                           key.fmtid.Data4[4], key.fmtid.Data4[5],
+                                           key.fmtid.Data4[6], key.fmtid.Data4[7],
+                                           key.pid);
+    return S_OK;
+  }
+};

--- a/xbmc/win32/XBMC_PC.cpp
+++ b/xbmc/win32/XBMC_PC.cpp
@@ -32,6 +32,8 @@
 #include "GUIInfoManager.h"
 #include "utils/StringUtils.h"
 #include "utils/CPUInfo.h"
+#include <mmdeviceapi.h>
+#include "win32/IMMNotificationClient.h"
 
 #ifndef _DEBUG
 #define XBMC_TRACK_EXCEPTIONS
@@ -221,12 +223,28 @@ INT WINAPI WinMain( HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT )
   }
 #endif
 
+  HRESULT hr = E_FAIL;
+  IMMDeviceEnumerator *pEnumerator = NULL;
+  CMMNotificationClient cMMNC;
+  hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void**)&pEnumerator);
+  if(SUCCEEDED(hr))
+  {
+    pEnumerator->RegisterEndpointNotificationCallback(&cMMNC);
+    SAFE_RELEASE(pEnumerator);
+  }
+
   g_application.Run();
 
   // clear previously set timer resolution
   timeEndPeriod(1);		
 
   // the end
+  hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void**)&pEnumerator);
+  if(SUCCEEDED(hr))
+  {
+    pEnumerator->UnregisterEndpointNotificationCallback(&cMMNC);
+    SAFE_RELEASE(pEnumerator);
+  }
   WSACleanup();
   CoUninitialize();
 


### PR DESCRIPTION
Not sure if this is a feature for G+1 or just an addition as https://github.com/xbmc/xbmc/commit/994210e14975df65b38364b1df3f4f3f3bce15a1 went also in.
As the title says it calls CAEFactory::DeviceChange() when an audio device change occurs. I dunno if the callback register in XBMC_PC is the right place or if there's a better place. Putting it in the sinks would make us blind to device changes during ae idle.
