### PR TITLE
AESinkPULSE: Let Engine handle our volume

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -44,9 +44,6 @@ public:
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   virtual void         Drain           ();
 
-  virtual bool HasVolume() { return true; };
-  virtual void SetVolume(float volume);
-
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
   bool IsInitialized();
   CCriticalSection m_sec;
@@ -64,7 +61,6 @@ private:
   unsigned int m_Channels;
   
   pa_stream *m_Stream;
-  pa_cvolume m_Volume;
 
   pa_context *m_Context;
   pa_threaded_mainloop *m_MainLoop;


### PR DESCRIPTION
This removes the Volume Handling from the PAESink. One reason was the possible flatten volumes in pulse daemon. This would have reset the user set volume to 100% which is not good at all.
