### PR TITLE
Allow xbmc to handle cue tags without quotes

### DIFF
--- a/xbmc/CueDocument.h
+++ b/xbmc/CueDocument.h
@@ -79,7 +79,7 @@ private:
   std::vector<CCueTrack> m_Track;
 
   bool ReadNextLine(CStdString &strLine);
-  bool ExtractQuoteInfo(const CStdString &line, CStdString &quote);
+  CStdString ExtractInfo(const CStdString &line);
   int ExtractTimeFromIndex(const CStdString &index);
   int ExtractNumericInfo(const CStdString &info);
   bool ResolvePath(CStdString &strPath, const CStdString &strBase);


### PR DESCRIPTION
With the old code only some of the cue tags was working without quote in the attribute.
So things like
PERFORMER DIDO
wasn't working and xbmc needed PERFORMER "DIDO".
I removed the old checks and I added the handling direcly in the function.
