### PR TITLE
Addon improvements

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -12223,7 +12223,12 @@ msgctxt "#24121"
 msgid "Enter search string"
 msgstr ""
 
-#empty strings from id 24122 to 24999
+#: xbmc/filesystem/AddonDirectory.cpp
+msgctxt "#24122"
+msgid "Update all"
+msgstr ""
+
+#empty strings from id 24123 to 24999
 
 msgctxt "#25000"
 msgid "Notifications"

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -371,13 +371,13 @@ bool CAddonMgr::ReloadSettings(const CStdString &id)
   return false;
 }
 
-bool CAddonMgr::GetAllOutdatedAddons(VECADDONS &addons, bool enabled /*= true*/)
+bool CAddonMgr::GetAllOutdatedAddons(VECADDONS &addons, bool getLocalVersion /*= false*/)
 {
   CSingleLock lock(m_critSection);
   for (int i = ADDON_UNKNOWN+1; i < ADDON_VIZ_LIBRARY; ++i)
   {
     VECADDONS temp;
-    if (CAddonMgr::Get().GetAddons((TYPE)i, temp, enabled))
+    if (CAddonMgr::Get().GetAddons((TYPE)i, temp, true))
     {
       AddonPtr repoAddon;
       for (unsigned int j = 0; j < temp.size(); j++)
@@ -396,17 +396,21 @@ bool CAddonMgr::GetAllOutdatedAddons(VECADDONS &addons, bool enabled /*= true*/)
         if (temp[j]->Version() < repoAddon->Version() &&
             !m_database.IsAddonBlacklisted(temp[j]->ID(),
                                            repoAddon->Version().c_str()))
+        {
+          if (getLocalVersion)
+            repoAddon->Props().version = temp[j]->Version();
           addons.push_back(repoAddon);
+        }
       }
     }
   }
   return !addons.empty();
 }
 
-bool CAddonMgr::HasOutdatedAddons(bool enabled /*= true*/)
+bool CAddonMgr::HasOutdatedAddons()
 {
   VECADDONS dummy;
-  return GetAllOutdatedAddons(dummy,enabled);
+  return GetAllOutdatedAddons(dummy);
 }
 
 bool CAddonMgr::GetAddons(const TYPE &type, VECADDONS &addons, bool enabled /* = true */)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -99,15 +99,14 @@ namespace ADDON
     bool ReloadSettings(const CStdString &id);
     /*! \brief Get all addons with available updates
      \param addons List to fill with all outdated addons
-     \param enabled Whether to get only enabled or disabled addons
+     \param getLocalVersion Whether to get the local addon version or the addon verion from the repository
      \return True if there are outdated addons otherwise false
      */
-    bool GetAllOutdatedAddons(VECADDONS &addons, bool enabled = true);
+    bool GetAllOutdatedAddons(VECADDONS &addons, bool getLocalVersion = false);
     /*! \brief Checks if there is any addon with available updates
-     \param enabled Whether to check only enabled or disabled addons
      \return True if there are outdated addons otherwise false
      */
-    bool HasOutdatedAddons(bool enabled = true);
+    bool HasOutdatedAddons();
     CStdString GetString(const CStdString &id, const int number);
 
     const char *GetTranslatedString(const cp_cfg_element_t *root, const char *tag);

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -23,6 +23,7 @@
 #include "addons/Repository.h"
 #include "GUIDialogAddonInfo.h"
 #include "GUIDialogAddonSettings.h"
+#include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogFileBrowser.h"
@@ -208,6 +209,20 @@ bool CGUIWindowAddonBrowser::OnContextButton(int itemNumber,
   return CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
+class UpdateAddons : public IRunnable
+{
+  virtual void Run()
+  {
+    VECADDONS addons;
+    CAddonMgr::Get().GetAllOutdatedAddons(addons, true); // get local
+    for (VECADDONS::iterator i = addons.begin(); i != addons.end(); ++i)
+    {
+      CStdString referer = StringUtils::Format("Referer=%s-%s.zip",(*i)->ID().c_str(),(*i)->Version().c_str());
+      CAddonInstaller::Get().Install((*i)->ID(), true, referer); // force install
+    }
+  }
+};
+
 bool CGUIWindowAddonBrowser::OnClick(int iItem)
 {
   CFileItemPtr item = m_vecItems->Get(iItem);
@@ -220,6 +235,14 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
     CStdString path;
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041), path))
       CAddonInstaller::Get().InstallFromZip(path);
+    return true;
+  }
+  if (item->GetPath() == "addons://update_all/")
+  {
+    // fire off a threaded update of all addons
+    UpdateAddons updater;
+    if (CGUIDialogBusy::Wait(&updater))
+      return Update("addons://downloading/");
     return true;
   }
   if (!item->m_bIsFolder)

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -252,6 +252,7 @@ bool CRepositoryUpdateJob::DoWork()
   CTextureDatabase textureDB;
   textureDB.Open();
   textureDB.BeginMultipleExecute();
+  VECADDONS notifications;
   for (map<string, AddonPtr>::const_iterator i = addons.begin(); i != addons.end(); ++i)
   {
     // manager told us to feck off
@@ -287,12 +288,8 @@ bool CRepositoryUpdateJob::DoWork()
         else
           CAddonInstaller::Get().Install(addon->ID(), true, referer);
       }
-      else if (CSettings::Get().GetBool("general.addonnotifications"))
-      {
-        CGUIDialogKaiToast::QueueNotification(addon->Icon(),
-                                              g_localizeStrings.Get(24061),
-                                              addon->Name(),TOAST_DISPLAY_TIME,false,TOAST_DISPLAY_TIME);
-      }
+      else
+        notifications.push_back(addon);
     }
 
     // Check if we should mark the add-on as broken.  We may have a newer version
@@ -320,6 +317,17 @@ bool CRepositoryUpdateJob::DoWork()
   }
   database.CommitMultipleExecute();
   textureDB.CommitMultipleExecute();
+  if (!notifications.empty() && CSettings::Get().GetBool("general.addonnotifications"))
+  {
+    if (notifications.size() == 1)
+      CGUIDialogKaiToast::QueueNotification(notifications[0]->Icon(),
+                                            g_localizeStrings.Get(24061),
+                                            notifications[0]->Name(),TOAST_DISPLAY_TIME,false,TOAST_DISPLAY_TIME);
+    else
+      CGUIDialogKaiToast::QueueNotification("",
+                                            g_localizeStrings.Get(24001),
+                                            g_localizeStrings.Get(24061),TOAST_DISPLAY_TIME,false,TOAST_DISPLAY_TIME);
+  }
 
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -578,17 +578,9 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
 #endif
 
     Create();
-    if(!m_ready.WaitMSec(g_advancedSettings.m_videoBusyDialogDelay_ms))
-    {
-      CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
-      if(dialog)
-      {
-        dialog->Show();
-        while(!m_ready.WaitMSec(1))
-          g_windowManager.ProcessRenderLoop(false);
-        dialog->Close();
-      }
-    }
+
+    // wait for the ready event
+    CGUIDialogBusy::WaitOnEvent(m_ready, g_advancedSettings.m_videoBusyDialogDelay_ms, false);
 
     // Playback might have been stopped due to some error
     if (m_bStop || m_bAbortRequest)

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -22,6 +22,8 @@
 
 #include "guilib/GUIDialog.h"
 
+class IRunnable;
+class CEvent;
 
 class CGUIDialogBusy: public CGUIDialog
 {
@@ -37,6 +39,23 @@ public:
   void SetProgress(float progress);
 
   bool IsCanceled() { return m_bCanceled; }
+
+  /*! \brief Wait for a runnable to execute off-thread.
+   Creates a thread to run the given runnable, and while waiting
+   it displays the busy dialog.
+   \param runnable the IRunnable to run.
+   \return true if the runnable completes, false if the user cancels early.
+   */
+  static bool Wait(IRunnable *runnable);
+
+  /*! \brief Wait on an event while displaying the busy dialog.
+   Throws up the busy dialog after the given time.
+   \param even the CEvent to wait on.
+   \param displaytime the time in ms to wait prior to showing the busy dialog (defaults to 100ms)
+   \param allowCancel whether the user can cancel the wait, defaults to true.
+   \return true if the event completed, false if cancelled.
+   */
+  static bool WaitOnEvent(CEvent &event, unsigned int timeout = 100, bool allowCancel = true);
 protected:
   virtual void Show_Internal(); // modeless'ish
   bool m_bCanceled;

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -200,6 +200,13 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
     item->SetLabel(g_localizeStrings.Get(24032));
     items.Add(item);
   }
+  else if (path.GetHostName().Equals("outdated") && items.Size() > 1)
+  {
+    CFileItemPtr item(new CFileItem("addons://update_all/", true));
+    item->SetLabel(g_localizeStrings.Get(24122));
+    item->SetSpecialSort(SortSpecialOnTop);
+    items.Add(item);
+  }
 
   return true;
 }

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -58,6 +58,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
 
   VECADDONS addons;
   // get info from repository
+  bool groupAddons = true;
   bool reposAsFolders = true;
   if (path.GetHostName().Equals("enabled"))
   {
@@ -68,6 +69,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
   else if (path.GetHostName().Equals("disabled"))
   { // grab all disabled addons, including disabled repositories
     reposAsFolders = false;
+    groupAddons = false;
     CAddonMgr::Get().GetAllAddons(addons, false, true);
     items.SetProperty("reponame",g_localizeStrings.Get(24039));
     items.SetLabel(g_localizeStrings.Get(24039));
@@ -75,12 +77,14 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
   else if (path.GetHostName().Equals("outdated"))
   {
     reposAsFolders = false;
+    groupAddons = false;
     CAddonMgr::Get().GetAllOutdatedAddons(addons);
     items.SetProperty("reponame",g_localizeStrings.Get(24043));
     items.SetLabel(g_localizeStrings.Get(24043));
   }
   else if (path.GetHostName().Equals("repos"))
   {
+    groupAddons = false;
     CAddonMgr::Get().GetAddons(ADDON_REPOSITORY,addons,true);
     items.SetLabel(g_localizeStrings.Get(24033)); // Get Add-ons
   }
@@ -133,7 +137,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
 
   if (path.GetFileName().empty())
   {
-    if (!path.GetHostName().Equals("repos"))
+    if (groupAddons)
     {
       for (int i=ADDON_UNKNOWN+1;i<ADDON_VIZ_LIBRARY;++i)
       {


### PR DESCRIPTION
As discussed on the forums, this does three things:
1. Reduce to a single notification during repo updates if multiple add-ons need updating.
2. Don't categorise add-ons under the Disabled Add-ons and Available Updates items in the add-on manager.
3. Adds an Update all item to Available Updates.

@elupus to review the busy dialog change.  I suspect this can also be used (perhaps with modification) in CUPNPPlayer, and possibly also (again with modification) in the directory fetcher.  With a general function we may also need to consider how to handle non-app-thread updates (atm all of them are on app-thread I think).
