### PR TITLE
[settings] switch zeroconf setting to standard level

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2100,7 +2100,7 @@
       <requirement>HAS_ZEROCONF</requirement>
       <group id="1">
         <setting id="services.zeroconf" type="boolean" label="1260" help="36342">
-          <level>2</level>
+          <level>1</level>
           <default>true</default>
           <control type="toggle" />
         </setting>


### PR DESCRIPTION
ATM Airplay is at standard level, but as it relies on zeroconf, we also need to make sure that is visible as well.  See:

http://forum.xbmc.org/showthread.php?tid=187209

for example.  Not sure if this applies only to win32.

@Montellese / @Memphiz ?
