### PR TITLE
[language] change "now playing.." in sidemenu

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -5646,7 +5646,7 @@ msgid "Scan for new content"
 msgstr ""
 
 msgctxt "#13350"
-msgid "Now playing..."
+msgid "Current playlist"
 msgstr ""
 
 msgctxt "#13351"


### PR DESCRIPTION
the "now playing.." playing button in the sidemenu doesn't only display when something is playing but also when something is in the playlist or when playback has finished.
at the moment this just looks odd that it says now playing when actually there isn't anything playing.
