### PR TITLE
[subsCore] close search window if playback is stopped

### DIFF
--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -424,6 +424,8 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       if (pDialog) pDialog->Close(true);
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CUTTER);
       if (pDialog) pDialog->Close(true);
+      pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_SUBTITLES);
+      if (pDialog) pDialog->Close(true);
 
       CGUIWindow::OnMessage(message);
 


### PR DESCRIPTION
as the title says, this closes the subtitle search window if player has stopped playing the file. Currently window stays open and user needs to close it manually.

@jmarshallnz thoughts please if you have a sec. it does seem to "fix" stuff but I am not sure that you would want it in Gotham.... up to you and @t-nelson
