### PR TITLE
Suspend via logind over UPower if available.

### DIFF
--- a/xbmc/powermanagement/IPowerSyscall.cpp
+++ b/xbmc/powermanagement/IPowerSyscall.cpp
@@ -1,0 +1,23 @@
+/*
+ *      Copyright (C) 2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "IPowerSyscall.h"
+
+const int IPowerSyscall::MAX_COUNT_POWER_FEATURES;

--- a/xbmc/powermanagement/IPowerSyscall.h
+++ b/xbmc/powermanagement/IPowerSyscall.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2015 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -45,6 +45,8 @@ public:
   virtual bool CanSuspend()   = 0;
   virtual bool CanHibernate() = 0;
   virtual bool CanReboot()    = 0;
+
+  virtual int  CountPowerFeatures() = 0;
   
 // Battery related functions
   virtual int  BatteryLevel() = 0;
@@ -60,9 +62,23 @@ public:
    \param callback the callback to signal to
    */
   virtual bool PumpPowerEvents(IPowerEventsCallback *callback) = 0;
+
+  static const int MAX_COUNT_POWER_FEATURES = 4;
 };
 
-class CPowerSyscallWithoutEvents : public IPowerSyscall
+class CAbstractPowerSyscall : public IPowerSyscall
+{
+public:
+  virtual int CountPowerFeatures()
+  {
+      return (CanPowerdown() ? 1 : 0)
+             + (CanSuspend() ? 1 : 0)
+             + (CanHibernate() ? 1 : 0)
+             + (CanReboot() ? 1 : 0);
+  }
+};
+
+class CPowerSyscallWithoutEvents : public CAbstractPowerSyscall
 {
 public:
   CPowerSyscallWithoutEvents() { m_OnResume = false; m_OnSuspend = false; }

--- a/xbmc/powermanagement/Makefile
+++ b/xbmc/powermanagement/Makefile
@@ -1,5 +1,6 @@
 SRCS=DPMSSupport.cpp \
      PowerManager.cpp \
+     IPowerSyscall.cpp \
 
 LIB=powermanagement.a
 

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -41,7 +41,7 @@ enum PowerState
 };
 
 // For systems without PowerSyscalls we have a NullObject
-class CNullPowerSyscall : public IPowerSyscall
+class CNullPowerSyscall : public CAbstractPowerSyscall
 {
 public:
   virtual bool Powerdown()    { return false; }

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.h
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.h
@@ -24,7 +24,7 @@
 #include "powermanagement/IPowerSyscall.h"
 #include "DBusUtil.h"
 
-class CLogindUPowerSyscall : public IPowerSyscall
+class CLogindUPowerSyscall : public CAbstractPowerSyscall
 {
 public:
   CLogindUPowerSyscall();

--- a/xbmc/powermanagement/linux/UPowerSyscall.h
+++ b/xbmc/powermanagement/linux/UPowerSyscall.h
@@ -43,7 +43,7 @@ private:
   double m_batteryLevel;
 };
 
-class CUPowerSyscall : public IPowerSyscall
+class CUPowerSyscall : public CAbstractPowerSyscall
 {
 public:
   CUPowerSyscall();

--- a/xbmc/powermanagement/windows/Win32PowerSyscall.h
+++ b/xbmc/powermanagement/windows/Win32PowerSyscall.h
@@ -25,7 +25,7 @@
 #define _WIN32_POWER_SYSCALL_H_
 #include "powermanagement/IPowerSyscall.h"
 
-class CWin32PowerSyscall : public IPowerSyscall
+class CWin32PowerSyscall : public CAbstractPowerSyscall
 {
 public:
   CWin32PowerSyscall();


### PR DESCRIPTION
From pull request #4168:
The suspend feature of UPower is deprecated. XBMC supports suspending using systemd-logind, however it defaults to a few other UPower methods first before trying Logind. This patch checks for logind first, and uses it if available.

I've updated the HasLogind() method to make sure systemd is at least version 183, or if the systemd version API is missing, that Upstart is at least version 1.11. This way, XBMC will default to suspending via logind if the version supports suspend. If it does not, it will skip logind and try UPower as before.
