### PR TITLE
FIX: [gles] do not force vsync off if VSYNC_DRIVER

### DIFF
--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -306,7 +306,9 @@ bool CWinSystemEGL::DestroyWindow()
 bool CWinSystemEGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
   CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, true, 0);
-  SetVSyncImpl(m_iVSyncMode);
+  int vsync_mode = CSettings::Get().GetInt("videoscreen.vsync");
+  if (vsync_mode != VSYNC_DRIVER)
+    SetVSyncImpl(m_iVSyncMode);
   return true;
 }
 
@@ -314,7 +316,9 @@ bool CWinSystemEGL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 {
   CreateNewWindow("", fullScreen, res, NULL);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
-  SetVSyncImpl(m_iVSyncMode);
+  int vsync_mode = CSettings::Get().GetInt("videoscreen.vsync");
+  if (vsync_mode != VSYNC_DRIVER)
+    SetVSyncImpl(m_iVSyncMode);
   return true;
 }
 


### PR DESCRIPTION
This solves the bug that we are forcing a vsync mode in "Driver" mode (actually we are disabling vsync as m_iVSyncMode stays at 0, then).

Generally speaking, I wonder if we need this at all, as we are apparently setting the vsync for each and every frame in Application.cpp:2239

/cc @davilla @t-nelson 
