### PR TITLE
[pvr] fix: duplicate parent dir item for recordings

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -223,16 +223,6 @@ void CPVRRecordings::GetSubDirectories(const CStdString &strBase, CFileItemList 
     }
     results->AddFront(pItem, 0);
   }
-
-  // Add parent directory item
-  if (!strUseBase.empty() && (subDirectories > 0 || files.Size() > 0) && CSettings::Get().GetBool("filelists.showparentdiritems"))
-  {
-    CStdString strLabel("..");
-    CFileItemPtr pItem(new CFileItem(strLabel));
-    pItem->SetPath("pvr://recordings");
-    pItem->m_bIsShareOrDrive = false;
-    results->AddFront(pItem, 0);
-  }
 }
 
 bool CPVRRecordings::HasAllRecordingsPathExtension(const CStdString &strDirectory)

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -65,3 +65,8 @@ void CGUIViewStatePVR::SaveViewState(void)
   PVRWindow ActiveView = GetActiveView();
   SaveViewToDb(m_items.GetPath(), ActiveView == PVR_WINDOW_UNKNOWN ? WINDOW_PVR : WINDOW_PVR + 100 - ActiveView, NULL);
 }
+
+bool CGUIViewStatePVR::HideParentDirItems(void)
+{
+  return (CGUIViewState::HideParentDirItems() || PVR_WINDOW_RECORDINGS != GetActiveView() || m_items.GetPath() == "pvr://recordings/");
+}

--- a/xbmc/pvr/windows/GUIViewStatePVR.h
+++ b/xbmc/pvr/windows/GUIViewStatePVR.h
@@ -33,7 +33,7 @@ namespace PVR
     PVRWindow GetActiveView(void);
   protected:
     bool AutoPlayNextItem(void) { return false; };
-    bool HideParentDirItems(void) { return true; }
+    bool HideParentDirItems(void);
     void SaveViewState(void);
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVR.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVR.cpp
@@ -34,7 +34,6 @@
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "threads/SingleLock.h"
-#include "utils/StringUtils.h"
 
 using namespace PVR;
 

--- a/xbmc/pvr/windows/GUIWindowPVR.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVR.cpp
@@ -34,6 +34,7 @@
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "threads/SingleLock.h"
+#include "utils/StringUtils.h"
 
 using namespace PVR;
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -402,6 +402,9 @@ bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &ite
 
 void CGUIWindowPVRRecordings::BeforeUpdate(const CStdString &strDirectory)
 {
+  // set items path to current directory
+  m_parent->m_vecItems->SetPath(strDirectory);
+
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 }


### PR DESCRIPTION
The current integration of the parent dir item for recordings results in a duplicate parent dir item if you add pvr://recordings as video source. This implements a more safer way for handling the parent dir item.

Discussed at http://forum.xbmc.org/showthread.php?tid=187320

@FernetMenta ping
