### PR TITLE
Fix "Manage movie sets..." doing nothing when there are no sets available

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -132,6 +132,14 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_SETFOCUS:
     {
+      // make sure the additional button is focused in case the list is empty
+      // (otherwise it is impossible to navigate to the additional button)
+      if (m_vecList->IsEmpty() && m_bButtonEnabled &&
+          m_viewControl.HasControl(message.GetControlId()))
+      {
+        SET_CONTROL_FOCUS(CONTROL_BUTTON, 0);
+        return true;
+      }
       if (m_viewControl.HasControl(message.GetControlId()) && m_viewControl.GetCurrentControl() != message.GetControlId())
       {
         m_viewControl.SetFocused();

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -36,8 +36,12 @@ typedef map<int, set<CFileItemPtr> > SetMap;
 
 bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileItemList &items, CFileItemList &groupedItems, GroupAttribute groupAttributes /* = GroupAttributeNone */)
 {
-  if (items.Size() <= 0 || groupBy == GroupByNone)
+  if (groupBy == GroupByNone)
     return false;
+
+  // nothing to do if there are no items to group
+  if (items.Size() <= 0)
+    return true;
 
   SetMap setMap;
   for (int index = 0; index < items.Size(); index++)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1449,7 +1449,7 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
 
   CFileItemList listItems;
   CStdString baseDir = "videodb://movies/sets/";
-  if (!CDirectory::GetDirectory(baseDir, listItems) || listItems.Size() <= 0)
+  if (!CDirectory::GetDirectory(baseDir, listItems))
     return false;
   listItems.Sort(SortByLabel, SortOrderAscending, SortAttributeIgnoreArticle);
 


### PR DESCRIPTION
These commits fix http://trac.xbmc.org/ticket/14922. As stated the problem is that when there are no sets defined yet in the video library, using the "Manage movie sets..." becomes a no-op instead of showing the select dialog with the "Add new movie set" button to allow creating a new set and adding the movie to that new set.

The first commit fixes the behaviour in GroupUtils::Group() to return true when grouping an empty list. IMO this is correct as the empty list has been grouped (nothing to group).

The second commit fixes CGUIDialogVideoInfo::GetSetForMovie() to not fail if there are no sets available.

The last commit fixes the focus problem in CGUIDialogSelect which happens when the dialog is opened with an empty list. By default an item in the list is auto-focused but that doesn't work properly if the list is empty. As a result nothing is focused and using arrow keys to focus something else (the extra button) does not work either. The fix sets focus to the extra button (if visible) if the list is empty.
