### PR TITLE
fixed: Auto extracted stream details were never stored for stacks

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -135,7 +135,13 @@ bool CThumbExtractor::DoWork()
     if (db.Open())
     {
       if (URIUtils::IsStack(m_listpath))
-        m_item.GetVideoInfoTag()->m_streamDetails.SetVideoDuration(0, 0); // Don't know the total time of the stack, so set duration to zero to avoid confusion
+      {
+        // Don't know the total time of the stack, so set duration to zero to avoid confusion
+        m_item.GetVideoInfoTag()->m_streamDetails.SetVideoDuration(0, 0);
+
+        // Restore original stack path
+        m_item.SetPath(m_listpath);
+      }
 
       if (info->m_iFileId < 0)
         db.SetStreamDetailsForFile(info->m_streamDetails, !info->m_strFileNameAndPath.empty() ? info->m_strFileNameAndPath : m_item.GetPath());


### PR DESCRIPTION
When auto extracting stream details for stacks, we didn't store them in the db for the stack itself but for the first item in the stack instead. Our stack did not only end up without stream details being stored, we also kept extracting the details over and over again for it.

NOTE: We could consider extracting the details for each stack item, allowing us to construct the duration for a stack but I'm not sure it's worth the effort since it's non-trivial to do.
