### PR TITLE
Fix memory leakage in python bindings

### DIFF
--- a/xbmc/interfaces/python/typemaps/python.vector.outtm
+++ b/xbmc/interfaces/python/typemaps/python.vector.outtm
@@ -41,6 +41,7 @@
         PyObject* pyentry${seq};
         ${helper.getOutConversion(vectype,'result',method,[ 'result' : 'pyentry' + seq, 'api' : 'entry' + seq, 'sequence' : sequence ])}
         PyList_Append(${result}, pyentry${seq});
+        Py_DECREF(pyentry${seq});
       }
 <%
     if (ispointer)


### PR DESCRIPTION
The python bindings generated by the groovy code generator contain a reference counting bug which results in a memory leak whenever a std::vector is converted to a python list.  The following member functions are affected:
- xbmcvfs.listdir
- xbmc.Player.getAvailableSubtitleStreams
- xbmc.Player.getAvailableAudioStreams
- xbmcgui.Control.getPosition
- xbmcgui.Dialog.browse
- xbmcgui.Dialog.browseMultiple

The reference counting bug occurs because PyList_Append() increments the reference count of the item, so the caller needs to call Py_DECREF() because it no longer owns the object.

This bug is especially problematic when running the Watchdog Service Addon since it may result in frequent calls to xbmcvfs.listdir, and each call can leak many kilobytes of data when listing directories containing many files.
