### PR TITLE
Fix Blu-Ray external subtitle load from movie folder BDMV/index.srt

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1906,7 +1906,19 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     URIUtils::Split(strArchive, strPath, strMovieFileName);
     strLookInPaths.push_back(strPath);
   }
-  
+ 
+  if (StringUtils::StartsWith(strMovie, "bluray://"))
+  {
+    CURL url(strMovie);
+    CStdString strArchive = url.GetHostName();
+    URIUtils::Split(strArchive, strPath, strMovieFileName);
+    CStdString strPath2 = URIUtils::AddFileToFolder(strPath, "BDMV/");
+    strLookInPaths.push_back(strPath2);
+
+    // set the subtitle lookup name to be able to locate "BDMV/index.srt" in the blu-ray movie folder
+    strMovieFileNameNoExt = "index";
+  }
+ 
   int iSize = strLookInPaths.size();
   for (int i=0; i<iSize; ++i)
   {


### PR DESCRIPTION
Currently the Blu-Ray folder playback does not support external subtitle automatic load.
XBMC Eden did support the load of the BDMV/index.srt but it got broken due to the bluray:// url change.

This fix was tested on few BDMV folders and it now load the index.srt correctly.
