### PR TITLE
DVD various fixes related to libdvdnav issues and skip to menu

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -187,8 +187,14 @@ bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& cont
     m_dll.dvdnav_get_next_cache_block(m_dvdnav,&buf_ptr,&event,&len);
     m_dll.dvdnav_sector_search(m_dvdnav, 0, SEEK_SET);
 
+    // first try title menu
     if(m_dll.dvdnav_menu_call(m_dvdnav, DVD_MENU_Title) != DVDNAV_STATUS_OK)
+    {
       CLog::Log(LOGERROR,"Error on dvdnav_menu_call(Title): %s\n", m_dll.dvdnav_err_to_string(m_dvdnav));
+      // next try root menu
+      if(m_dll.dvdnav_menu_call(m_dvdnav, DVD_MENU_Root) != DVDNAV_STATUS_OK )
+        CLog::Log(LOGERROR,"Error on dvdnav_menu_call(Root): %s\n", m_dll.dvdnav_err_to_string(m_dvdnav));
+    }
   }
 
   m_bEOF = false;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3560,6 +3560,7 @@ int CDVDPlayer::OnDVDNavResult(void* pData, int iMessage)
       {
         CLog::Log(LOGDEBUG, "DVDNAV_STOP");
         m_dvd.state = DVDSTATE_NORMAL;
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026), g_localizeStrings.Get(16029));
       }
       break;
     default:

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3831,6 +3831,7 @@ int COMXPlayer::OnDVDNavResult(void* pData, int iMessage)
       {
         CLog::Log(LOGDEBUG, "DVDNAV_STOP");
         m_dvd.state = DVDSTATE_NORMAL;
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026), g_localizeStrings.Get(16029));
       }
       break;
     default:


### PR DESCRIPTION
- ~~first commit is to make the "skip to DVD menu" setting an expert setting with a default value of true:
  See: http://forum.xbmc.org/showthread.php?tid=187379~~
- first commit is to align the skip to DVD menu functionality with VLC code. Essentially they also try to fallback to the root menu if title menu wasn't found. 
  See: https://github.com/videolan/vlc/blob/master/modules/access/dvdnav.c#L324
- second commit is to attempt a fix for http://trac.xbmc.org/ticket/14957 - not so much the fact that that DVD doesn't play, but rather that it blocks/freezes XBMC. The root cause is a badly authored dvd and libdvdnav can't properly handle it, but down the road it causes an endless cycle between NAVRESULT_NOP type actions _inside_ DVDInputStreamNavigator.
  It constantly cycles between DVDNAV_SPU_STREAM_CHANGE, DVDNAV_AUDIO_STREAM_CHANGE
  DVDNAV_NAV_PACKET, DVDNAV_CELL_CHANGE, DVDNAV_SPU_CLUT_CHANGE, DVDNAV_SPU_STREAM_CHANGE ...
  and never returns. The brute-force solution is to put a limit to the amount we can cycle through the "while(true)" loop and allow this Read() method to return back to ffmpeg and yield control back to xbmc so that it can process keystrokes (e.g. to press STOP). 
  I chose an arbitrary of 1000 NOPs before the brute force return, but I'm open to alternative suggestions.

@elupus, I'd appreciate your input on these.
