### PR TITLE
Fix Wiimote battery problem

### DIFF
--- a/tools/EventClients/Clients/WiiRemote/WiiUse_WiiRemote.cpp
+++ b/tools/EventClients/Clients/WiiRemote/WiiUse_WiiRemote.cpp
@@ -130,6 +130,7 @@ int connectWiimote(wiimote** wiimotes)
     wiiuse_set_leds(wm, WIIMOTE_LED_1);
     wiiuse_rumble(wm, 1);
     wiiuse_set_orient_threshold(wm,1);
+    DisableMotionSensing(wm);
     #ifndef WIN32
       usleep(200000);
     #else
@@ -221,6 +222,7 @@ int main(int argc, char** argv)
       for (int i = 0; i < MAX_WIIMOTES; ++i)
       //MAX_WIIMOTES hardcoded at 1.
       {
+        DisableMotionSensing(wm);
         switch (wiimotes[i]->event) 
         {
         case WIIUSE_EVENT:
@@ -231,7 +233,6 @@ int main(int argc, char** argv)
           {
             //Prepare to repeat or hold. Do this only once.
             timeout = getTicks();
-            EnableMotionSensing(wm);
             controller.m_abs_roll = 0;
             controller.m_abs_pitch = 0;
             controller.m_start_roll = 0;


### PR DESCRIPTION
Hello,
I'm using a Raspberry Pi with XBMC on it as media center for my TV (raspbmc distrib to be precise). After being bored to use my smartphone as remote to control XBMC, I realised I could use my old Wiimote, and enjoy the package ready for that.
But I don't know what happen, after 6 hours of use, my wiimote batteries were flat. They were completely new at the start. I thought it was a one time problem, so I tried again : same problem. But this solution was so great, I wanted to find a solution.
After many searches, I realised it was using WiiUse, and I mention that motion sensors are constantly sending data. It explain why the batteries are quickly flat. After some changes on `WiiUse_WiiRemote.cpp` to disable this feature (because in our case we don't use the motion sensor, we just want to use buttons), re-compile, test. Now a good battery charge last for weeks.

This is why I would like to ask if we could make small changes on `xbmc/tools/EventClients/Clients/WiiRemote/WiiUse_WiiRemote.cpp`.

I don't know if my problem is recurrent, or if my solution is relevant.
Thanks,
