### PR TITLE
Allow ZIP root to be viewed as directory to enable playback of files contained

### DIFF
--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -266,7 +266,15 @@ int CZipFile::Stat(struct __stat64 *buffer)
 int CZipFile::Stat(const CURL& url, struct __stat64* buffer)
 {
   if (!g_ZipManager.GetZipEntry(url.Get(),mZipItem))
-    return -1;
+  {
+    if (url.GetFileName().empty() && CFile::Exists(url.GetHostName()))
+    { // when accessing the zip "root" recognize it as a directory
+      buffer->st_mode = _S_IFDIR;
+      return 0;
+    }
+    else
+      return -1;
+  }
 
   memset(buffer, 0, sizeof(struct __stat64));
   buffer->st_gid = 0;


### PR DESCRIPTION
as title says, make ZIP file viewed as root dir through our VFS, so that libdvd works properly when trying to play back zipped dvd files.
