### PR TITLE
Add code to support doing finer grained movie updates, and use it with JSON-RPC [ticket #14967]

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -172,5 +172,11 @@ namespace JSONRPC
       CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE, g_windowManager.GetActiveWindow());
       g_windowManager.SendThreadMessage(message);
     }
+    static inline void NotifyFileItemUpdated(CFileItem &fileitem)
+    {      
+      CFileItemPtr msgItem(new CFileItem(fileitem));
+      CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);
+      g_windowManager.SendThreadMessage(message);
+    }
   };
 }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -511,7 +511,12 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const CStdString &method, ITranspo
 
   UpdateResumePoint(parameterObject, infos, videodatabase);
 
-  CJSONRPCUtils::NotifyItemUpdated();
+  if (updatedDetails.size() != 0)
+  {
+    // only send an update if there was something to actually update
+    CFileItem movieFileItem(infos);
+    CJSONRPCUtils::NotifyFileItemUpdated(movieFileItem);
+  }
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -997,98 +997,98 @@ void CVideoLibrary::UpdateResumePoint(const CVariant &parameterObject, CVideoInf
 
 
 // Can these be made generic?  or does the CVariant block that?
-void CVideoLibrary::UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, std::string &FieldToUpdate, std::set<std::string> &updatedDetails)
+void CVideoLibrary::UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, std::string &fieldValue, std::set<std::string> &updatedDetails)
 {
   if (ParameterNotNull(parameterObject, fieldName))
   {
     std::string NewValue = parameterObject[fieldName].asString();
-    if (FieldToUpdate.compare(NewValue))
+    if (fieldValue.compare(NewValue))
     {
-      FieldToUpdate = NewValue;
+      fieldValue = NewValue;
       updatedDetails.insert(fieldName);
     }
   }
 }
 
-void CVideoLibrary::UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, int &FieldToUpdate, std::set<std::string> &updatedDetails)
+void CVideoLibrary::UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, int &fieldValue, std::set<std::string> &updatedDetails)
 {
   if (ParameterNotNull(parameterObject, fieldName))
   {
     int NewValue = (int)parameterObject[fieldName].asInteger();
-    if (FieldToUpdate != NewValue)
+    if (fieldValue != NewValue)
     {
-      FieldToUpdate = NewValue;
+      fieldValue = NewValue;
       updatedDetails.insert(fieldName);
     }
   }
 }
 
-void CVideoLibrary::UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, float &FieldToUpdate, std::set<std::string> &updatedDetails)
+void CVideoLibrary::UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, float &fieldValue, std::set<std::string> &updatedDetails)
 {
   if (ParameterNotNull(parameterObject, fieldName))
   {
     float NewValue = parameterObject[fieldName].asFloat();
-    if (FieldToUpdate != NewValue)
+    if (fieldValue != NewValue)
     {
-      FieldToUpdate = NewValue;
+      fieldValue = NewValue;
       updatedDetails.insert(fieldName);
     }
   }
 }
 
-void CVideoLibrary::UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, std::vector<std::string> &FieldToUpdate, std::set<std::string> &updatedDetails)
+void CVideoLibrary::UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, std::vector<std::string> &fieldValue, std::set<std::string> &updatedDetails)
 {
   if (ParameterNotNull(parameterObject, fieldName))
   {
-    CopyStringArray(parameterObject[fieldName], FieldToUpdate);
+    CopyStringArray(parameterObject[fieldName], fieldValue);
     updatedDetails.insert(fieldName);    
   }
 }
 
-void CVideoLibrary::UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, CDateTime &FieldToUpdate, std::set<std::string> &updatedDetails)
+void CVideoLibrary::UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, CDateTime &fieldValue, std::set<std::string> &updatedDetails)
 {
   if (ParameterNotNull(parameterObject, fieldName))
   {
-    FieldToUpdate.SetFromDBDate(parameterObject[fieldName].asString());
+    fieldValue.SetFromDBDate(parameterObject[fieldName].asString());
     updatedDetails.insert(fieldName);    
   }
 }
 
 void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork,	std::set<std::string> &updatedDetails)
 {
-  UpdateVideoTag(parameterObject, "title", details.m_strTitle, updatedDetails);
-  UpdateVideoTag(parameterObject, "playcount", details.m_playCount, updatedDetails);
-  UpdateVideoTag(parameterObject, "runtime", details.m_duration, updatedDetails);
-  UpdateVideoTag(parameterObject, "director", details.m_director, updatedDetails);
-  UpdateVideoTag(parameterObject, "studio", details.m_studio, updatedDetails);
-  UpdateVideoTag(parameterObject, "year", details.m_iYear, updatedDetails);
-  UpdateVideoTag(parameterObject, "plot", details.m_strPlot, updatedDetails);
-  UpdateVideoTag(parameterObject, "album", details.m_strAlbum, updatedDetails);
-  UpdateVideoTag(parameterObject, "artist", details.m_artist, updatedDetails);
-  UpdateVideoTag(parameterObject, "genre", details.m_genre, updatedDetails);
-  UpdateVideoTag(parameterObject, "track", details.m_iTrack, updatedDetails);
-  UpdateVideoTag(parameterObject, "rating", details.m_fRating, updatedDetails);
-  UpdateVideoTag(parameterObject, "mpaa", details.m_strMPAARating, updatedDetails);
-  UpdateVideoTag(parameterObject, "imdbnumber", details.m_strIMDBNumber, updatedDetails);
-  UpdateVideoTag(parameterObject, "premiered", details.m_premiered, updatedDetails);
-  UpdateVideoTag(parameterObject, "votes", details.m_strVotes, updatedDetails);
-  UpdateVideoTag(parameterObject, "lastplayed", details.m_lastPlayed, updatedDetails);
-  UpdateVideoTag(parameterObject, "firstaired", details.m_firstAired, updatedDetails);
-  UpdateVideoTag(parameterObject, "productioncode", details.m_strProductionCode, updatedDetails);
-  UpdateVideoTag(parameterObject, "season", details.m_iSeason, updatedDetails);
-  UpdateVideoTag(parameterObject, "episode", details.m_iEpisode, updatedDetails);
-  UpdateVideoTag(parameterObject, "originaltitle", details.m_strOriginalTitle, updatedDetails);
-  UpdateVideoTag(parameterObject, "trailer", details.m_strTrailer, updatedDetails);
-  UpdateVideoTag(parameterObject, "tagline", details.m_strTagLine, updatedDetails);
-  UpdateVideoTag(parameterObject, "plotoutline", details.m_strPlotOutline, updatedDetails);
-  UpdateVideoTag(parameterObject, "writer", details.m_writingCredits, updatedDetails);
-  UpdateVideoTag(parameterObject, "country", details.m_country, updatedDetails);
-  UpdateVideoTag(parameterObject, "top250", details.m_iTop250, updatedDetails);
-  UpdateVideoTag(parameterObject, "sorttitle", details.m_strSortTitle, updatedDetails);
-  UpdateVideoTag(parameterObject, "episodeguide", details.m_strEpisodeGuide, updatedDetails);
-  UpdateVideoTag(parameterObject, "set", details.m_strSet, updatedDetails);
-  UpdateVideoTag(parameterObject, "showlink", details.m_showLink, updatedDetails);
-  UpdateVideoTag(parameterObject, "tag", details.m_tags, updatedDetails);
+  UpdateVideoTagField(parameterObject, "title", details.m_strTitle, updatedDetails);
+  UpdateVideoTagField(parameterObject, "playcount", details.m_playCount, updatedDetails);
+  UpdateVideoTagField(parameterObject, "runtime", details.m_duration, updatedDetails);
+  UpdateVideoTagField(parameterObject, "director", details.m_director, updatedDetails);
+  UpdateVideoTagField(parameterObject, "studio", details.m_studio, updatedDetails);
+  UpdateVideoTagField(parameterObject, "year", details.m_iYear, updatedDetails);
+  UpdateVideoTagField(parameterObject, "plot", details.m_strPlot, updatedDetails);
+  UpdateVideoTagField(parameterObject, "album", details.m_strAlbum, updatedDetails);
+  UpdateVideoTagField(parameterObject, "artist", details.m_artist, updatedDetails);
+  UpdateVideoTagField(parameterObject, "genre", details.m_genre, updatedDetails);
+  UpdateVideoTagField(parameterObject, "track", details.m_iTrack, updatedDetails);
+  UpdateVideoTagField(parameterObject, "rating", details.m_fRating, updatedDetails);
+  UpdateVideoTagField(parameterObject, "mpaa", details.m_strMPAARating, updatedDetails);
+  UpdateVideoTagField(parameterObject, "imdbnumber", details.m_strIMDBNumber, updatedDetails);
+  UpdateVideoTagField(parameterObject, "premiered", details.m_premiered, updatedDetails);
+  UpdateVideoTagField(parameterObject, "votes", details.m_strVotes, updatedDetails);
+  UpdateVideoTagField(parameterObject, "lastplayed", details.m_lastPlayed, updatedDetails);
+  UpdateVideoTagField(parameterObject, "firstaired", details.m_firstAired, updatedDetails);
+  UpdateVideoTagField(parameterObject, "productioncode", details.m_strProductionCode, updatedDetails);
+  UpdateVideoTagField(parameterObject, "season", details.m_iSeason, updatedDetails);
+  UpdateVideoTagField(parameterObject, "episode", details.m_iEpisode, updatedDetails);
+  UpdateVideoTagField(parameterObject, "originaltitle", details.m_strOriginalTitle, updatedDetails);
+  UpdateVideoTagField(parameterObject, "trailer", details.m_strTrailer, updatedDetails);
+  UpdateVideoTagField(parameterObject, "tagline", details.m_strTagLine, updatedDetails);
+  UpdateVideoTagField(parameterObject, "plotoutline", details.m_strPlotOutline, updatedDetails);
+  UpdateVideoTagField(parameterObject, "writer", details.m_writingCredits, updatedDetails);
+  UpdateVideoTagField(parameterObject, "country", details.m_country, updatedDetails);
+  UpdateVideoTagField(parameterObject, "top250", details.m_iTop250, updatedDetails);
+  UpdateVideoTagField(parameterObject, "sorttitle", details.m_strSortTitle, updatedDetails);
+  UpdateVideoTagField(parameterObject, "episodeguide", details.m_strEpisodeGuide, updatedDetails);
+  UpdateVideoTagField(parameterObject, "set", details.m_strSet, updatedDetails);
+  UpdateVideoTagField(parameterObject, "showlink", details.m_showLink, updatedDetails);
+  UpdateVideoTagField(parameterObject, "tag", details.m_tags, updatedDetails);
 
   if (ParameterNotNull(parameterObject, "thumbnail"))
   {

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -77,11 +77,11 @@ namespace JSONRPC
     static JSONRPC_STATUS GetAdditionalMusicVideoDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
     static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string> &updatedDetails);
-    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, std::string &FieldToUpdate, std::set<std::string> &updatedDetails);
-    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, int &FieldToUpdate, std::set<std::string> &updatedDetails);
-    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, float &FieldToUpdate, std::set<std::string> &updatedDetails);
-    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, std::vector<std::string> &FieldToUpdate, std::set<std::string> &updatedDetails);
-    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, CDateTime &FieldToUpdate, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, std::string &fieldValue, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, int &fieldValue, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, float &fieldValue, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, std::vector<std::string> &fieldValue, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTagField(const CVariant &parameterObject, const std::string &fieldName, CDateTime &fieldValue, std::set<std::string> &updatedDetails);
 
     static void UpdateResumePoint(const CVariant &parameterObject, CVideoInfoTag &details, CVideoDatabase &videodatabase);
   };

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -76,7 +76,13 @@ namespace JSONRPC
     static JSONRPC_STATUS GetAdditionalEpisodeDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
     static JSONRPC_STATUS GetAdditionalMusicVideoDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
-    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork);
+    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, std::string &FieldToUpdate, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, int &FieldToUpdate, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, float &FieldToUpdate, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, std::vector<std::string> &FieldToUpdate, std::set<std::string> &updatedDetails);
+    static void UpdateVideoTag (const CVariant &parameterObject, std::string fieldName, CDateTime &FieldToUpdate, std::set<std::string> &updatedDetails);
+
     static void UpdateResumePoint(const CVariant &parameterObject, CVideoInfoTag &details, CVideoDatabase &videodatabase);
   };
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1978,7 +1978,7 @@ CStdString CVideoDatabase::GetValueString(const CVideoInfoTag &details, int min,
 // Merge/refactor the above
 CStdString CVideoDatabase::GetValueString(const CVideoInfoTag &details, const std::vector<VIDEODB_IDS> simpleUpdates, const SDbTableOffsets *offsets, std::vector<std::string> conditions) const
 {
-  for (std::vector<VIDEODB_IDS>::const_iterator it = simpleUpdates.cbegin(); it != simpleUpdates.cend(); ++it)
+  for (std::vector<VIDEODB_IDS>::const_iterator it = simpleUpdates.begin(); it != simpleUpdates.end(); ++it)
   {
     int i = *it;
     switch (offsets[i].type)
@@ -2182,14 +2182,14 @@ bool PendingUpdates(const std::set<std::string> &updatedDetails, std::vector<VID
   // I can't help but feel this is a lot of syntatic sugar just to lookup an element and determine what to do with it
   // Probably still better than a massive if statement
 
-    for (std::set<std::string>::const_iterator it = updatedDetails.cbegin(); it!=updatedDetails.cend(); ++it)
+    for (std::set<std::string>::const_iterator it = updatedDetails.begin(); it != updatedDetails.end(); ++it)
     {
       std::string updatedDetail = *it;
 
       // look up in the map.
       std::map<std::string,VIDEODB_IDS>::const_iterator mapIt = MovieUpdateDetails::updateDetails.find(updatedDetail);
 
-      if (mapIt == MovieUpdateDetails::updateDetails.cend())
+      if (mapIt == MovieUpdateDetails::updateDetails.end())
       {
         // we can't do anything with this
         // should trace what we can't use
@@ -2232,7 +2232,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
     BeginTransaction();
 
     // process the simple updates
-    for (vector<VIDEODB_IDS>::const_iterator simpleUpdateIt= simpleUpdates.cbegin() ; simpleUpdateIt != simpleUpdates.cend(); ++simpleUpdateIt)
+    for (vector<VIDEODB_IDS>::const_iterator simpleUpdateIt = simpleUpdates.begin() ; simpleUpdateIt != simpleUpdates.end(); ++simpleUpdateIt)
     {
 
       switch (*simpleUpdateIt)
@@ -2305,6 +2305,9 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
             AddCountryToMovie(idMovie, AddCountry(details.m_country[i]));
         }
         break;
+      default:
+        // Nothing to do for most of the simple changes
+        break;
       }
     }
 
@@ -2313,7 +2316,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
     bool idSetUpdate = false;
 
     // process the simple updates
-    for (vector<std::string>::const_iterator complexUpdateIt= complexUpdates.cbegin() ; complexUpdateIt != complexUpdates.cend(); ++complexUpdateIt)
+    for (vector<std::string>::const_iterator complexUpdateIt = complexUpdates.begin() ; complexUpdateIt != complexUpdates.end(); ++complexUpdateIt)
     {
 
       if (*complexUpdateIt == "set")

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2157,7 +2157,7 @@ bool PendingUpdates(const std::set<std::string> &updatedDetails, std::vector<VID
 
     if (mapIt == MovieUpdateDetails::updateDetails.end())
     {
-      CLog::Log(LOGWARNING, "%s: called with tag it can't optimise: %s", __FUNCTION__, updatedDetail);
+      CLog::Log(LOGWARNING, "%s: called with tag it can't optimise: %s", __FUNCTION__, updatedDetail.c_str());
       return false;
     }
     else if (mapIt->second != VIDEODB_ID_MAX)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7608,7 +7608,7 @@ int CVideoDatabase::GetMatchingMusicVideo(const CStdString& strArtist, const CSt
     else
     { // we want to return the matching musicvideo
       if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-        strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo,files,path,artistlinkmusicvideo,actors where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and artistlinkmusicvideo.idMVideo=musicvideo.idMVideo and artistlinkmusicvideo.idArtist=actors.idActors and actors.strActor like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
+        strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo,files,path,artistlinkmusicvideo,actors where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and artistlinkmusicvideo.idMVideo=musicvideo.idMVideo and artistlinkmusicvideo.idArtist=actors.idActor and actors.strActor like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
       else
         strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo join artistlinkmusicvideo on artistlinkmusicvideo.idMVideo=musicvideo.idMVideo join actors on actors.idActor=artistlinkmusicvideo.idArtist where musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and actors.strActor like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2217,6 +2217,9 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
   if (idMovie < 0)
     return idMovie;
 
+  if (updatedDetails.size() == 0)
+    return idMovie;
+
   vector<VIDEODB_IDS> simpleUpdates;
   vector<std::string> complexUpdates;
   if (!PendingUpdates(updatedDetails, simpleUpdates, complexUpdates))

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1932,7 +1932,7 @@ void CVideoDatabase::AddGenreAndDirectorsAndStudios(const CVideoInfoTag& details
     vecStudios.push_back(AddStudio(details.m_studio[i]));
 }
 
-void CVideoDatabase::ProcessValueString(const CVideoInfoTag &details, const SDbTableOffsets *offsets, std::vector<std::string> &conditions, int i)
+void CVideoDatabase::ProcessValueString(const CVideoInfoTag &details, const SDbTableOffsets *offsets, std::vector<std::string> &conditions, int i) const
 {
   switch (offsets[i].type)
   {
@@ -2106,76 +2106,70 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
 
 // Value of MAX means that it's a complex update
 // Value of MIN means that the item will be handled elsewhere
-struct MovieUpdateDetails{
-    static map<std::string,VIDEODB_IDS> create_map()
-        {
-          map<std::string,VIDEODB_IDS> m;
-          m["title"] = VIDEODB_ID_TITLE;
-          m["playcount"] = VIDEODB_ID_MAX;
-          m["runtime"] = VIDEODB_ID_RUNTIME;
-          m["director"] = VIDEODB_ID_DIRECTOR;
-          m["studio"] = VIDEODB_ID_STUDIOS;
-          m["year"] = VIDEODB_ID_YEAR;
-          m["plot"] = VIDEODB_ID_PLOT;
-          m["genre"] = VIDEODB_ID_GENRE;
-          m["rating"] = VIDEODB_ID_RATING;
-          m["mpaa"] = VIDEODB_ID_MPAA;
-          m["imdbnumber"] = VIDEODB_ID_IDENT;
-          m["votes"] = VIDEODB_ID_VOTES;
-          m["originaltitle"] = VIDEODB_ID_ORIGINALTITLE;
-          m["trailer"] = VIDEODB_ID_TRAILER;
-          m["tagline"] = VIDEODB_ID_TAGLINE;
-          m["plotoutline"] = VIDEODB_ID_PLOTOUTLINE;
-          m["writer"] = VIDEODB_ID_CREDITS;
-          m["country"] = VIDEODB_ID_COUNTRY;
-          m["top250"] = VIDEODB_ID_TOP250;
-          m["sorttitle"] = VIDEODB_ID_SORTTITLE;
-          m["set"] = VIDEODB_ID_MAX;
-          m["showlink"] = VIDEODB_ID_MAX;
-          m["fanart"] = VIDEODB_ID_FANART;
-          m["tag"] = VIDEODB_ID_MAX;
-          m["art.altered"] = VIDEODB_ID_MAX;
-          m["art.removed"] = VIDEODB_ID_MAX;
+struct MovieUpdateDetails {
+  static map<std::string,VIDEODB_IDS> create_map()
+    {
+      map<std::string,VIDEODB_IDS> m;
+      m["title"] = VIDEODB_ID_TITLE;
+      m["playcount"] = VIDEODB_ID_MAX;
+      m["runtime"] = VIDEODB_ID_RUNTIME;
+      m["director"] = VIDEODB_ID_DIRECTOR;
+      m["studio"] = VIDEODB_ID_STUDIOS;
+      m["year"] = VIDEODB_ID_YEAR;
+      m["plot"] = VIDEODB_ID_PLOT;
+      m["genre"] = VIDEODB_ID_GENRE;
+      m["rating"] = VIDEODB_ID_RATING;
+      m["mpaa"] = VIDEODB_ID_MPAA;
+      m["imdbnumber"] = VIDEODB_ID_IDENT;
+      m["votes"] = VIDEODB_ID_VOTES;
+      m["originaltitle"] = VIDEODB_ID_ORIGINALTITLE;
+      m["trailer"] = VIDEODB_ID_TRAILER;
+      m["tagline"] = VIDEODB_ID_TAGLINE;
+      m["plotoutline"] = VIDEODB_ID_PLOTOUTLINE;
+      m["writer"] = VIDEODB_ID_CREDITS;
+      m["country"] = VIDEODB_ID_COUNTRY;
+      m["top250"] = VIDEODB_ID_TOP250;
+      m["sorttitle"] = VIDEODB_ID_SORTTITLE;
+      m["set"] = VIDEODB_ID_MAX;
+      m["showlink"] = VIDEODB_ID_MAX;
+      m["fanart"] = VIDEODB_ID_FANART;
+      m["tag"] = VIDEODB_ID_MAX;
+      m["art.altered"] = VIDEODB_ID_MAX;
+      m["art.removed"] = VIDEODB_ID_MAX;
 
-          // just ignore this
-          m["lastplayed"] = VIDEODB_ID_MIN;
-          return m;
-        }
-    static const map<std::string,VIDEODB_IDS> updateDetails;
+      // just ignore this
+      m["lastplayed"] = VIDEODB_ID_MIN;
+      return m;
+    }
+  static const map<std::string,VIDEODB_IDS> updateDetails;
 };
 
-const map<std::string,VIDEODB_IDS> MovieUpdateDetails::updateDetails =  MovieUpdateDetails::create_map();
+const map<std::string,VIDEODB_IDS> MovieUpdateDetails::updateDetails = MovieUpdateDetails::create_map();
 
 bool PendingUpdates(const std::set<std::string> &updatedDetails, std::vector<VIDEODB_IDS> &simpleUpdates, std::vector<std::string> &complexUpdates)
 {
-  // Each update needs to be looped over and processed
-  // I can't help but feel this is a lot of syntatic sugar just to lookup an element and determine what to do with it
-  // Probably still better than a massive if statement
+  for (std::set<std::string>::const_iterator it = updatedDetails.begin(); it != updatedDetails.end(); ++it)
+  {
+    std::string updatedDetail = *it;
 
-    for (std::set<std::string>::const_iterator it = updatedDetails.begin(); it != updatedDetails.end(); ++it)
+    // look up in the map.
+    std::map<std::string,VIDEODB_IDS>::const_iterator mapIt = MovieUpdateDetails::updateDetails.find(updatedDetail);
+
+    if (mapIt == MovieUpdateDetails::updateDetails.end())
     {
-      std::string updatedDetail = *it;
-
-      // look up in the map.
-      std::map<std::string,VIDEODB_IDS>::const_iterator mapIt = MovieUpdateDetails::updateDetails.find(updatedDetail);
-
-      if (mapIt == MovieUpdateDetails::updateDetails.end())
-      {
-        // we can't do anything with this
-        // should trace what we can't use
-        CLog::Log(LOGWARNING, "%s: called with tag it can't optimise: %s", __FUNCTION__, updatedDetail);
-        return false;
-      }
-      else if (mapIt->second != VIDEODB_ID_MAX)
-      {
-        simpleUpdates.push_back(mapIt->second);
-      }
-      else
-      {
-        complexUpdates.push_back(mapIt->first);
-      }
+      CLog::Log(LOGWARNING, "%s: called with tag it can't optimise: %s", __FUNCTION__, updatedDetail);
+      return false;
     }
-    return true;
+    else if (mapIt->second != VIDEODB_ID_MAX)
+    {
+      simpleUpdates.push_back(mapIt->second);
+    }
+    else
+    {
+      complexUpdates.push_back(mapIt->first);
+    }
+  }
+  return true;
 }
 
 int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails,
@@ -2200,9 +2194,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
     return SetDetailsForMovie(strFilenameAndPath, details, artwork, idMovie);      
   }
 
-  CLog::Log(LOGDEBUG, "%s: starting update run", __FUNCTION__);
-
-  // At this stage we believe that updates can be done...
+  CLog::Log(LOGDEBUG, "%s: starting updates", __FUNCTION__);
   try
   {
     BeginTransaction();
@@ -2210,13 +2202,11 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
     // process the simple updates
     for (vector<VIDEODB_IDS>::const_iterator simpleUpdateIt = simpleUpdates.begin() ; simpleUpdateIt != simpleUpdates.end(); ++simpleUpdateIt)
     {
-
       switch (*simpleUpdateIt)
       {
       case VIDEODB_ID_GENRE:
         {
-          CStdString strSQL;
-          strSQL=PrepareSQL("delete from genrelinkmovie where idMovie=%i", idMovie);
+          CStdString strSQL = PrepareSQL("delete from genrelinkmovie where idMovie=%i", idMovie);
           m_pDS->exec(strSQL.c_str());
 
           for (unsigned int i = 0; i < details.m_genre.size(); ++i)
@@ -2238,11 +2228,9 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
 
       case VIDEODB_ID_DIRECTOR:
         {
-          CStdString strSQL;
-
-          strSQL=PrepareSQL("delete from directorlinkmovie where idMovie=%i", idMovie);
+          CStdString strSQL = PrepareSQL("delete from directorlinkmovie where idMovie=%i", idMovie);
           m_pDS->exec(strSQL.c_str());
-          // add all directors
+
           for (unsigned int i = 0; i < details.m_director.size(); i++)
             AddDirectorToMovie(idMovie, AddActor(details.m_director[i],""));
         }
@@ -2250,8 +2238,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
 
       case VIDEODB_ID_STUDIOS:
         {
-          CStdString strSQL;
-          strSQL=PrepareSQL("delete from studiolinkmovie where idMovie=%i", idMovie);
+          CStdString strSQL = PrepareSQL("delete from studiolinkmovie where idMovie=%i", idMovie);
           m_pDS->exec(strSQL.c_str());
           for (unsigned int i = 0; i < details.m_studio.size(); i++)
             AddStudioToMovie(idMovie, AddStudio(details.m_studio[i]));
@@ -2260,12 +2247,9 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
 
       case VIDEODB_ID_CREDITS:
         {
-          CStdString strSQL;
-          // TODO: this is missing from the movie delete code!
-          strSQL=PrepareSQL("delete from writerlinkmovie where idMovie=%i", idMovie);
+          CStdString strSQL = PrepareSQL("delete from writerlinkmovie where idMovie=%i", idMovie);
           m_pDS->exec(strSQL.c_str());
 
-          // add writers...
           for (unsigned int i = 0; i < details.m_writingCredits.size(); i++)
             AddWriterToMovie(idMovie, AddActor(details.m_writingCredits[i],""));
         }
@@ -2273,10 +2257,9 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
 
       case VIDEODB_ID_COUNTRY:
         {
-          CStdString strSQL; 
-          strSQL=PrepareSQL("delete from countrylinkmovie where idMovie=%i", idMovie);
+          CStdString strSQL = PrepareSQL("delete from countrylinkmovie where idMovie=%i", idMovie);
           m_pDS->exec(strSQL.c_str());
-          // add countries...
+
           for (unsigned int i = 0; i < details.m_country.size(); i++)
             AddCountryToMovie(idMovie, AddCountry(details.m_country[i]));
         }
@@ -2287,7 +2270,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
       }
     }
 
-    // add set...
+    // track if the set was updated
     int idSet = -1;
     bool idSetUpdate = false;
     
@@ -2312,7 +2295,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
       else if (*complexUpdateIt == "tag")
       {
         RemoveTagsFromItem(idMovie, "movie");
-        // add tags...
+
         for (unsigned int i = 0; i < details.m_tags.size(); i++)
         {
           int idTag = AddTag(details.m_tags[i]);
@@ -2327,7 +2310,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
 
     CLog::Log(LOGDEBUG, "%s: creating update sql query", __FUNCTION__);
 
-    // generate the simple updates command.  Note that conditions is passed in, so that there's no magic needed for the idSet
+    // generate the update SQL string.
     std::vector<std::string> conditions;
     if (idSetUpdate)
     {
@@ -2336,7 +2319,7 @@ int CVideoDatabase::UpdateDetailsForMovie(const CStdString& strFilenameAndPath, 
       else
         conditions.push_back("idSet = NULL");
     }
-    string updateQuery = GetValueString(details, simpleUpdates, DbMovieOffsets, conditions);
+    std::string updateQuery = GetValueString(details, simpleUpdates, DbMovieOffsets, conditions);
 
     // if there's nothing to update, don't run the query.
     if (!updateQuery.empty())

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -786,8 +786,8 @@ protected:
   void GetDetailsFromDB(std::auto_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   CStdString GetValueString(const CVideoInfoTag &details, int min, int max, const SDbTableOffsets *offsets) const;
-  CStdString GetValueString(const CVideoInfoTag &details, const std::vector<VIDEODB_IDS> simpleUpdates, const SDbTableOffsets *offsets, std::vector<std::string> conditions) const;
-
+  CStdString GetValueString(const CVideoInfoTag &details, const std::vector<VIDEODB_IDS> simpleUpdates, const SDbTableOffsets *offsets, std::vector<std::string> &conditions) const;
+  void ProcessValueString(const CVideoInfoTag &details, const SDbTableOffsets *offsets, std::vector<std::string> &conditions, int i) const;
 
 private:
   virtual void CreateTables();

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -459,6 +459,9 @@ public:
   bool SetSingleValue(const std::string &table, const std::string &fieldName, const std::string &strValue,
                       const std::string &conditionName = "", int conditionValue = -1);
 
+  int UpdateDetailsForMovie(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails,
+	  int idMovie = -1);
+
   void DeleteMovie(int idMovie, bool bKeepId = false);
   void DeleteMovie(const CStdString& strFilenameAndPath, bool bKeepId = false, int idMovie = -1);
   void DeleteTvShow(int idTvShow, bool bKeepId = false);
@@ -783,6 +786,8 @@ protected:
   void GetDetailsFromDB(std::auto_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   CStdString GetValueString(const CVideoInfoTag &details, int min, int max, const SDbTableOffsets *offsets) const;
+  CStdString GetValueString(const CVideoInfoTag &details, const std::vector<VIDEODB_IDS> simpleUpdates, const SDbTableOffsets *offsets, std::vector<std::string> conditions) const;
+
 
 private:
   virtual void CreateTables();


### PR DESCRIPTION
This request contains updates to support finer grained move updates via the JSON RPC interface SetMovieDetails.

Currently the code deletes most of the existing movie information and rebuilds it.  This causes a lot of unnecessary churn when one item is actually changed.

This code adds the ability to update only the items that have changed.  This reduces the time for carrying out an update dramatically in many cases.  MillhouseVH did some testing on a raspberry pi, and found the timing change for updates in some cases dropped the times from 15s to 150ms:
http://pastebin.com/raw.php?i=7isML2xb

The time improvement varies depending on the updates being done, and the size of the current data.

More details can be seen in the forum thread:
http://forum.xbmc.org/showthread.php?tid=184411

Note the branch being pulled from was a clean branch with the changes cherry picked, and then some tidy up and refactor done.

The code has been tested on windows and compiled on linux.
