### PR TITLE
Check source existence on clean

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -10610,7 +10610,16 @@ msgctxt "#20469"
 msgid "Keep current set (%s)"
 msgstr ""
 
-#empty strings from id 20470 to 21329
+#: xbmc/video/VideoInfoScanner.cpp
+msgctxt "#20470"
+msgid "Retry"
+msgstr ""
+
+msgctxt "#20471"
+msgid "Skip"
+msgstr ""
+
+#empty strings from id 20472 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -45,6 +45,17 @@ bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
   return StringUtils::StartsWith(uriPath, basePath);
 }
 
+bool URIUtils::IsInPath(const CStdString &uri, const std::vector<CStdString> &baseURIs)
+{
+  std::vector<CStdString>::const_iterator it;
+  for (it = baseURIs.begin(); it != baseURIs.end(); ++it)
+  {
+    if (URIUtils::IsInPath(uri, *it))
+      return true;
+  }
+  return false;
+}
+
 /* returns filename extension including period of filename */
 CStdString URIUtils::GetExtension(const CStdString& strFileName)
 {

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -29,6 +29,7 @@ public:
   URIUtils(void);
   virtual ~URIUtils(void);
   static bool IsInPath(const CStdString &uri, const CStdString &baseURI);
+  static bool IsInPath(const CStdString &uri, const std::vector<CStdString> &baseURIs);
 
   static CStdString GetDirectory(const CStdString &strFilePath);
   static const CStdString GetFileName(const CStdString& strFileNameAndPath);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8185,23 +8185,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
         if (silent)
           del = false;
         else
-        {
-          CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-          if (pDialog != NULL)
-          {
-            CURL parentUrl(parentPath);
-            pDialog->SetHeading(15012);
-            pDialog->SetText(StringUtils::Format(g_localizeStrings.Get(15013), parentUrl.GetWithoutUserDetails().c_str()));
-            pDialog->SetChoice(0, 15015);
-            pDialog->SetChoice(1, 15014);
-
-            //send message and wait for user input
-            ThreadMessage tMsg = { TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, (unsigned int)g_windowManager.GetActiveWindow() };
-            CApplicationMessenger::Get().SendMessage(tMsg, true);
-
-            del = !pDialog->IsConfirmed();
-          }
-        }
+          del = QueryUserToRemoveMissingPath(parentPath);
       }
 
       parentPathsDeleteDecisions.insert(make_pair(parentPathID, make_pair(parentPathNotExists, del)));
@@ -8226,6 +8210,28 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
   m_pDS->close();
 
   return cleanedIDs;
+}
+
+bool CVideoDatabase::QueryUserToRemoveMissingPath(const CStdString& path)
+{
+  bool              rc      = false;
+  CGUIDialogYesNo*  pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
+
+  if (pDialog != NULL)
+  {
+    CURL parentUrl(path);
+    pDialog->SetHeading(15012);
+    pDialog->SetText(StringUtils::Format(g_localizeStrings.Get(15013), parentUrl.GetWithoutUserDetails().c_str()));
+    pDialog->SetChoice(0, 15015);
+    pDialog->SetChoice(1, 15014);
+
+    //send message and wait for user input
+    ThreadMessage tMsg = { TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, (unsigned int)g_windowManager.GetActiveWindow() };
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
+    rc = !pDialog->IsConfirmed();
+  }
+
+  return rc;
 }
 
 void CVideoDatabase::DumpToDummyFiles(const CStdString &path)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -827,7 +827,8 @@ private:
   CStdString GetSafeFile(const CStdString &dir, const CStdString &name) const;
 
   std::vector<int> CleanMediaType(const std::string &mediaType, const std::string &cleanableFileIDs,
-                                  std::map<int, bool> &pathsDeleteDecisions, std::string &deletedFileIDs, bool silent);
+                                  std::map<int, bool> &pathsDeleteDecisions, std::string &deletedFileIDs, bool silent,
+                                  const std::vector<CStdString>& missingSources);
 
   void AnnounceRemove(std::string content, int id);
   void AnnounceUpdate(std::string content, int id);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -831,4 +831,5 @@ private:
 
   void AnnounceRemove(std::string content, int id);
   void AnnounceUpdate(std::string content, int id);
+  static bool QueryUserToRemoveMissingPath(const CStdString& path);
 };


### PR DESCRIPTION
Avoid stat() calls where we can by checking whether the sources are available and asking the user what to do about it.  This ameliorates the pain of cleaning a library with a missing source, SMB in particular, where we have to wait the timeout period for every stat() call.
