### PR TITLE
[ios] - strip off trailing carriage return when inserting text frome rem...

### DIFF
--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -73,7 +73,15 @@ bool CGUIKeyboardFactory::SendTextToActiveKeyboard(const std::string &aTextStrin
 {
   if (!g_activedKeyboard)
     return false;
-  return g_activedKeyboard->SetTextToKeyboard(aTextString, closeKeyboard);
+
+  std::string sendStr = aTextString;
+
+  // strip off trailing carriage return if this is the "closekeyboard" text
+  // we normally never want the carriage return in the string here
+  if (closeKeyboard && StringUtils::EndsWith(aTextString, "\n"))
+    sendStr = aTextString.substr(0, aTextString.length() - 1);
+
+  return g_activedKeyboard->SetTextToKeyboard(sendStr, closeKeyboard);
 }
 
 


### PR DESCRIPTION
...ote to current active(native) keyboard.

@ulion for a comment. Before we always received the trailing carriage return which gets send from the official remote app when "closing" the keyboard by hitting the "enter" key. 

I think we never want that trailing carriage return (in my test case it prevents from inserting a valid new source for example cause the added path ends with "carriage" return and so the vfs will never be able to open it...).
