### PR TITLE
[ios] - only use the native keyboard if tvout is not used (native keyboa...

### DIFF
--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -32,6 +32,7 @@
 #include "dialogs/GUIDialogKeyboardGeneric.h"
 #if defined(TARGET_DARWIN_IOS)
 #include "osx/ios/IOSKeyboard.h"
+#include "windowing/WindowingFactory.h"
 #endif
 
 CGUIKeyboard *CGUIKeyboardFactory::g_activedKeyboard = NULL;
@@ -93,7 +94,8 @@ bool CGUIKeyboardFactory::ShowAndGetInput(CStdString& aTextString, const CVarian
     headingStr = g_localizeStrings.Get((uint32_t)heading.asInteger());
 
 #if defined(TARGET_DARWIN_IOS) && !defined(TARGET_DARWIN_IOS_ATV2)
-  kb = new CIOSKeyboard();
+  if (g_Windowing.GetCurrentScreen() == 0)
+    kb = new CIOSKeyboard();
 #endif
 
   if(!kb)


### PR DESCRIPTION
...rd doesn't work with hdmi/tvout on ios) - fixes #14966

This basically uses our generic keyboard when xbmc is used on a big screen via tvout.

Definitly gotham material (before branch if possible).
