### PR TITLE
settings: fix conflict of <minimum> and <maximum> for CSettingList

### DIFF
--- a/addons/xbmc.json/addon.xml
+++ b/addons/xbmc.json/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.json" version="6.14.0" provider-name="Team XBMC">
+<addon id="xbmc.json" version="6.14.1" provider-name="Team XBMC">
   <backwards-compatibility abi="6.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -801,8 +801,8 @@
           <constraints>
             <options>languages</options>
             <delimiter>,</delimiter>
-            <minimum>1</minimum>
-            <maximum>3</maximum>
+            <minimumItems>1</minimumItems>
+            <maximumItems>3</maximumItems>
           </constraints>
           <control type="list" format="string">
             <multiselect>true</multiselect>

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.14.0";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.14.1";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -1644,8 +1644,8 @@ namespace JSONRPC
         "\"elementtype\": { \"$ref\": \"Setting.Type\", \"required\": true },"
         "\"definition\": { \"$ref\": \"Setting.Details.Setting\", \"required\": true },"
         "\"delimiter\": { \"type\": \"string\", \"required\": true },"
-        "\"minimum\": { \"type\": \"integer\" },"
-        "\"maximum\": { \"type\": \"integer\" }"
+        "\"minimumItems\": { \"type\": \"integer\" },"
+        "\"maximumItems\": { \"type\": \"integer\" }"
       "},"
       "\"additionalProperties\": false"
     "}",

--- a/xbmc/interfaces/json-rpc/SettingsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.cpp
@@ -593,8 +593,8 @@ bool CSettingsOperations::SerializeSettingList(const CSettingList* setting, CVar
 
   obj["elementtype"] = obj["definition"]["type"];
   obj["delimiter"] = setting->GetDelimiter();
-  obj["minimum"] = setting->GetMinimum();
-  obj["maximum"] = setting->GetMaximum();
+  obj["minimumItems"] = setting->GetMinimumItems();
+  obj["maximumItems"] = setting->GetMaximumItems();
 
   return true;
 }

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -1617,8 +1617,8 @@
       "elementtype": { "$ref": "Setting.Type", "required": true },
       "definition": { "$ref": "Setting.Details.Setting", "required": true },
       "delimiter": { "type": "string", "required": true },
-      "minimum": { "type": "integer" },
-      "maximum": { "type": "integer" }
+      "minimumItems": { "type": "integer" },
+      "maximumItems": { "type": "integer" }
     },
     "additionalProperties": false
   },

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -251,14 +251,14 @@ CSettingList::CSettingList(const std::string &id, CSetting *settingDefinition, C
   : CSetting(id, settingsManager),
     m_definition(settingDefinition),
     m_delimiter("|"),
-    m_minimum(0), m_maximum(-1)
+    m_minimumItems(0), m_maximumItems(-1)
 { }
 
 CSettingList::CSettingList(const std::string &id, const CSettingList &setting)
   : CSetting(id, setting),
     m_definition(NULL),
     m_delimiter("|"),
-    m_minimum(0), m_maximum(-1)
+    m_minimumItems(0), m_maximumItems(-1)
 {
   copy(setting);
 }
@@ -306,15 +306,15 @@ bool CSettingList::Deserialize(const TiXmlNode *node, bool update /* = false */)
     if (XMLUtils::GetString(constraints, SETTING_XML_ELM_DELIMITER, delimiter) && !delimiter.empty())
       m_delimiter = delimiter;
 
-    XMLUtils::GetInt(constraints, SETTING_XML_ELM_MINIMUM, m_minimum);
-    if (m_minimum < 0)
-      m_minimum = 0;
-    XMLUtils::GetInt(constraints, SETTING_XML_ELM_MAXIMUM, m_maximum);
-    if (m_maximum <= 0)
-      m_maximum = -1;
-    else if (m_maximum < m_minimum)
+    XMLUtils::GetInt(constraints, SETTING_XML_ELM_MINIMUM_ITEMS, m_minimumItems);
+    if (m_minimumItems < 0)
+      m_minimumItems = 0;
+    XMLUtils::GetInt(constraints, SETTING_XML_ELM_MAXIMUM_ITEMS, m_maximumItems);
+    if (m_maximumItems <= 0)
+      m_maximumItems = -1;
+    else if (m_maximumItems < m_minimumItems)
     {
-      CLog::Log(LOGWARNING, "CSettingList: invalid <minimum> (%d) and/or <maximum> (%d) of %s", m_minimum, m_maximum, m_id.c_str());
+      CLog::Log(LOGWARNING, "CSettingList: invalid <minimum> (%d) and/or <maximum> (%d) of %s", m_minimumItems, m_maximumItems, m_id.c_str());
       return false;
     }
   }
@@ -407,8 +407,8 @@ bool CSettingList::SetValue(const SettingPtrList &values)
 {
   CExclusiveLock lock(m_critical);
 
-  if ((int)values.size() < m_minimum ||
-     (m_maximum > 0 && (int)values.size() > m_maximum))
+  if ((int)values.size() < m_minimumItems ||
+     (m_maximumItems > 0 && (int)values.size() > m_maximumItems))
     return false;
 
   bool equal = values.size() == m_values.size();
@@ -476,8 +476,8 @@ void CSettingList::copy(const CSettingList &setting)
   }
 
   m_delimiter = setting.m_delimiter;
-  m_minimum = setting.m_minimum;
-  m_maximum = setting.m_maximum;
+  m_minimumItems = setting.m_minimumItems;
+  m_maximumItems = setting.m_maximumItems;
 }
 
 void CSettingList::copy(const SettingPtrList &srcValues, SettingPtrList &dstValues)
@@ -505,8 +505,8 @@ bool CSettingList::fromString(const std::string &strValue, SettingPtrList &value
 
 bool CSettingList::fromValues(const std::vector<std::string> &strValues, SettingPtrList &values) const
 {
-  if ((int)strValues.size() < m_minimum ||
-     (m_maximum > 0 && (int)strValues.size() > m_maximum))
+  if ((int)strValues.size() < m_minimumItems ||
+     (m_maximumItems > 0 && (int)strValues.size() > m_maximumItems))
     return false;
 
   bool ret = true;

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -166,8 +166,8 @@ public:
   const CSetting* GetDefinition() const { return m_definition; }
 
   const std::string& GetDelimiter() const { return m_delimiter; }
-  int GetMinimum() const { return m_minimum; }
-  int GetMaximum() const { return m_maximum; }
+  int GetMinimumItems() const { return m_minimumItems; }
+  int GetMaximumItems() const { return m_maximumItems; }
   
   bool FromString(const std::vector<std::string> &value);
 
@@ -187,8 +187,8 @@ protected:
   SettingPtrList m_defaults;
   CSetting *m_definition;
   std::string m_delimiter;
-  int m_minimum;
-  int m_maximum;
+  int m_minimumItems;
+  int m_maximumItems;
 };
 
 /*!

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -45,6 +45,8 @@
 #define SETTING_XML_ELM_UPDATE        "update"
 #define SETTING_XML_ELM_ACCESS        "access"
 #define SETTING_XML_ELM_DELIMITER     "delimiter"
+#define SETTING_XML_ELM_MINIMUM_ITEMS "minimumitems"
+#define SETTING_XML_ELM_MAXIMUM_ITEMS "maximumitems"
 
 #define SETTING_XML_ATTR_ID           "id"
 #define SETTING_XML_ATTR_LABEL        "label"


### PR DESCRIPTION
While working on the settings system a bit I noticed that there is a conflict in CSettingList. It uses <minimum> and <maximum> to specify the minimum/maxmimum number of items in the list. But the same tags are read by the setting definition (e.g. CSettingInt for a setting of type "list[integer]") and used for the minimum/maximum value of the setting. Obviously this leads to unexpected conflicts.

I renamed the <minimum> and <maximum> tags of CSettingList to <minimumitems> and <maximumitems> to avoid this problem.
