### PR TITLE
fixed exception because of accessing an uninitialized playingChannel object

### DIFF
--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -237,7 +237,8 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       if (g_application.CurrentFileItem().IsLiveTV())
       {
         CPVRChannelPtr playingChannel;
-        g_PVRManager.GetCurrentChannel(playingChannel);
+        if(!g_PVRManager.GetCurrentChannel(playingChannel))
+          return false;
 
         if (action.GetID() == REMOTE_0)
         {


### PR DESCRIPTION
This fixes the crash mentioned in #14961 but the root cause is still unknown and under investigation.
