### PR TITLE
URIUtils: fix out of range exception in resolvePath()

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1226,10 +1226,12 @@ std::string URIUtils::resolvePath(const std::string &path)
   CStdString realPath;
   int i = 0;
   // re-add any / or \ at the beginning
-  while (path.at(i) == delim.at(0))
+  for (std::string::const_iterator itPath = path.begin(); itPath != path.end(); ++itPath)
   {
+    if (*itPath != delim.at(0))
+      break;
+
     realPath += delim;
-    i++;
   }
   // put together the path
   realPath += StringUtils::Join(realParts, delim);


### PR DESCRIPTION
This fixes an out of range exception from

```
path.at(i)
```

in the case where the content of path only consists of the delimiter character (e.g. the linux root path "/"). This has been reported in the forum: http://forum.xbmc.org/showthread.php?tid=188031.

Obviously Gotham material if accepted.
