### PR TITLE
[Confluence] fix usage of "next" label in mismatching contexts

### DIFF
--- a/addons/skin.confluence/720p/MusicKaraokeLyrics.xml
+++ b/addons/skin.confluence/720p/MusicKaraokeLyrics.xml
@@ -37,7 +37,7 @@
 				<height>25</height>
 				<font>font13_title</font>
 				<textcolor>blue</textcolor>
-				<label>[COLOR=blue]$LOCALIZE[209] :[/COLOR] [COLOR=selected]$INFO[MusicPlayer.offset(1).Title][/COLOR]</label>
+				<label>[COLOR=blue]$LOCALIZE[19031] :[/COLOR] [COLOR=selected]$INFO[MusicPlayer.offset(1).Title][/COLOR]</label>
 				<align>center</align>
 				<aligny>center</aligny>
 			</control>

--- a/addons/skin.confluence/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence/720p/MusicVisualisation.xml
@@ -174,7 +174,7 @@
 					<top>120</top>
 					<width>910</width>
 					<height>25</height>
-					<label>$LOCALIZE[209]: $INFO[MusicPlayer.offset(1).Artist,, - ]$INFO[MusicPlayer.offset(1).Title]</label>
+					<label>$LOCALIZE[19031]: $INFO[MusicPlayer.offset(1).Artist,, - ]$INFO[MusicPlayer.offset(1).Title]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<font>font12</font>

--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -281,7 +281,7 @@
 					<top>120</top>
 					<width>910</width>
 					<height>25</height>
-					<label>$INFO[VideoPlayer.NextTitle,$LOCALIZE[209]: ]</label>
+					<label>$INFO[VideoPlayer.NextTitle,$LOCALIZE[19031]: ]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<font>font12</font>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -444,7 +444,7 @@
 			<top>120</top>
 			<height>30</height>
 			<width>325</width>
-			<label>[COLOR=blue]$LOCALIZE[209] :[/COLOR] $INFO[MusicPlayer.offset(1).Title]</label>
+			<label>[COLOR=blue]$LOCALIZE[19031] :[/COLOR] $INFO[MusicPlayer.offset(1).Title]</label>
 			<align>right</align>
 			<aligny>center</aligny>
 			<font>font12</font>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -852,10 +852,12 @@ msgctxt "#208"
 msgid "Play"
 msgstr ""
 
+#. used as label for an action/button to play or navigate to the next item
 msgctxt "#209"
 msgid "Next"
 msgstr ""
 
+#. used as label for an action/button to play or navigate to the previous item
 msgctxt "#210"
 msgid "Previous"
 msgstr ""
@@ -7411,6 +7413,7 @@ msgctxt "#19030"
 msgid "Now"
 msgstr ""
 
+#. Label prefix for the next playing tv-show (PVR) or media, like "Next: The Simpsons", "Next: AC/DC - Thunderstruck". It's also used as EPG display mode (EPG: timeline / now / next)
 msgctxt "#19031"
 msgid "Next"
 msgstr ""


### PR DESCRIPTION
This caused trouble in translations for some languages. IMO Gotham material.
