### PR TITLE
FIX: set logger to NULL when the XBMC::Context is deleted

### DIFF
--- a/xbmc/XbmcContext.cpp
+++ b/xbmc/XbmcContext.cpp
@@ -50,6 +50,8 @@ namespace XBMC
   Context::~Context()
   {
     // cleanup
+    XbmcCommons::Exception::SetLogger(NULL);
+    CThread::SetLogger(NULL);
     delete impl->loggerImpl;
 
     delete impl;


### PR DESCRIPTION
Ref:
- http://forum.xbmc.org/showthread.php?tid=188059
- http://xbmclogs.com/show.php?id=142667
