### PR TITLE
Added limit attribute for the directory provider

### DIFF
--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -130,6 +130,15 @@ CGUIInfoLabel::CGUIInfoLabel(const std::string &label, const std::string &fallba
   SetLabel(label, fallback, context);
 }
 
+int CGUIInfoLabel::GetIntValue(int contextWindow) const
+{
+  std::string label = GetLabel(contextWindow);
+  if (!label.empty())
+    return strtol(label.c_str(), NULL, 10);
+
+  return 0;
+}
+
 void CGUIInfoLabel::SetLabel(const std::string &label, const std::string &fallback, int context /*= 0*/)
 {
   m_fallback = fallback;

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -88,6 +88,14 @@ public:
   const std::string &GetLabel(int contextWindow, bool preferImage = false, std::string *fallback = NULL) const;
 
   /*!
+   \brief Gets the label and returns it as an int value
+   \param contextWindow the context in which to evaluate the expression.
+   \return int value.
+   \sa GetLabel
+   */
+  int GetIntValue(int contextWindow) const;
+
+  /*!
    \brief Gets a label (or image) for a given listitem from the info manager.
    \param item listitem in question.
    \param preferImage caller is specifically wanting an image rather than a label. Defaults to false.

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -69,8 +69,10 @@ private:
   unsigned int     m_jobID;
   CGUIInfoLabel    m_url;
   CGUIInfoLabel    m_target;
+  CGUIInfoLabel    m_limit;
   std::string      m_currentUrl;
   std::string      m_currentTarget;   ///< \brief node.target property on the list as a whole
+  unsigned int     m_currentLimit;
   std::vector<CGUIStaticItemPtr> m_items;
   std::vector<InfoTagType> m_itemTypes;
   CCriticalSection m_section;
@@ -78,4 +80,5 @@ private:
   void FireJob();
   void RegisterListProvider(bool hasLibraryContent);
   bool UpdateURL();
+  bool UpdateLimit();
 };

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -78,5 +78,4 @@ private:
   void FireJob();
   void RegisterListProvider(bool hasLibraryContent);
   bool UpdateURL();
-  static bool HasLibraryContent(const std::string &url);
 };


### PR DESCRIPTION
This adds the ability to limit directory content to a certain amount of items.

```
<content target="videos" limit="10">videodb://movies/titles</content>
```

Default value is 0 which will show all available items.

PS: Would be nice to have in Gotham but +1 is also fine.
