### PR TITLE
mysql: replace all "cast(foo as integer)" to "cast(foo as signed integer)" and not just the first one

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1484,7 +1484,7 @@ bool MysqlDataset::query(const char *query) {
   size_t loc;
 
   // mysql doesn't understand CAST(foo as integer) => change to CAST(foo as signed integer)
-  if ((loc = ci_find(qry, "as integer)")) != string::npos)
+  while ((loc = ci_find(qry, "as integer)")) != string::npos)
     qry = qry.insert(loc + 3, "signed ");
 
   MYSQL_RES *stmt = NULL;


### PR DESCRIPTION
The current code in the MySQL db wrapper has some logic to replace

```
cast(foo as integer)
```

with

```
cast(foo as signed integer)
```

in SQL queries because MySQL doesn't understand the first one (SQLite does). But the logic that takes care of this is only applied once so if there are multiple occurances that need to be fixed only the first is caught and the rest isn't which results in invalid SQL queries on MySQL.

@koying: Would you mind testing this? Easiest is probably to create a smartplaylist for movies and add two rules for the runtime/duration (which is movie.c11 and results in the usage of above SQL snippets).
