### PR TITLE
Load channel settings properly when <cacheindvdplayer> is disabled

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4453,9 +4453,6 @@ void CApplication::StopPlaying()
       m_pKaraokeMgr->Stop();
 #endif
 
-    if (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio())
-      g_PVRManager.SaveCurrentChannelSettings();
-
     m_pPlayer->CloseFile();
 
     // turn off visualisation window when stopping
@@ -5763,10 +5760,6 @@ void CApplication::SaveCurrentFileSettings()
       dbs.SetVideoSettings(m_itemCurrentFile->GetPath(), CMediaSettings::Get().GetCurrentVideoSettings());
       dbs.Close();
     }
-  }
-  else if (m_itemCurrentFile->IsPVRChannel())
-  {
-    g_PVRManager.SaveCurrentChannelSettings();
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1596,10 +1596,6 @@ void CDVDPlayer::HandlePlaySpeed()
           bGotAudio, m_dvdPlayerAudio.GetLevel(),
           bGotVideo, m_dvdPlayerVideo.GetLevel());
 
-      CFileItem currentItem(g_application.CurrentFileItem());
-      if (currentItem.HasPVRChannelInfoTag())
-        g_PVRManager.LoadCurrentChannelSettings();
-
       caching = CACHESTATE_DONE;
     }
     else

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1830,10 +1830,6 @@ void COMXPlayer::HandlePlaySpeed()
           bGotAudio, m_omxPlayerAudio.GetLevel(),
           bGotVideo, m_omxPlayerVideo.GetLevel());
 
-      CFileItem currentItem(g_application.CurrentFileItem());
-      if (currentItem.HasPVRChannelInfoTag())
-        g_PVRManager.LoadCurrentChannelSettings();
-
       caching = CACHESTATE_DONE;
     }
     else

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -894,7 +894,7 @@ bool CPVRManager::CheckParentalPIN(const char *strTitle /* = NULL */)
   return bValidPIN;
 }
 
-void CPVRManager::SaveCurrentChannelSettings(const CPVRChannel &channel)
+void CPVRManager::SaveChannelSettings(const CPVRChannel &channel)
 {
   CPVRDatabase *database = GetPVRDatabase();
   if (!database)
@@ -1015,7 +1015,7 @@ bool CPVRManager::OpenLiveStream(const CFileItem &channel)
     m_currentFile = new CFileItem(channel);
 
     // load channel settings
-    LoadCurrentChannelSettings(*channel.GetPVRChannelInfoTag());
+    LoadChannelSettings(*channel.GetPVRChannelInfoTag());
 
     if (m_addons->GetPlayingChannel(playingChannel))
     {
@@ -1071,7 +1071,7 @@ void CPVRManager::CloseStream(void)
       m_channelGroups->SetLastPlayedGroup(GetPlayingGroup(channel->IsRadio()));
   
       // store channel settings
-      SaveCurrentChannelSettings(*channel);
+      SaveChannelSettings(*channel);
     }
 
     m_addons->CloseStream();
@@ -1304,8 +1304,8 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
     bSwitched = true;
 
     // save previous and load new channel's settings
-    SaveCurrentChannelSettings(*currentChannel);
-    LoadCurrentChannelSettings(channel);
+    SaveChannelSettings(*currentChannel);
+    LoadChannelSettings(channel);
 
     CSingleLock lock(m_critSection);
     m_currentFile = new CFileItem(channel);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -900,18 +900,9 @@ void CPVRManager::SaveChannelSettings(const CPVRChannel &channel)
   if (!database)
     return;
 
-  if (CMediaSettings::Get().GetCurrentVideoSettings() != CMediaSettings::Get().GetDefaultVideoSettings())
-  {
-    CLog::Log(LOGDEBUG, "PVR - %s - persisting custom channel settings for channel '%s'",
-        __FUNCTION__, channel.ChannelName().c_str());
-    database->PersistChannelSettings(channel, CMediaSettings::Get().GetCurrentVideoSettings());
-  }
-  else
-  {
-    CLog::Log(LOGDEBUG, "PVR - %s - no custom channel settings for channel '%s'",
-        __FUNCTION__, channel.ChannelName().c_str());
-    database->DeleteChannelSettings(channel);
-  }
+  CLog::Log(LOGDEBUG, "PVR - %s - persisting custom channel settings for channel '%s'",
+	  __FUNCTION__, channel.ChannelName().c_str());
+  database->PersistChannelSettings(channel, CMediaSettings::Get().GetCurrentVideoSettings());
 }
 
 void CPVRManager::LoadChannelSettings(const CPVRChannel &channel)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -940,12 +940,6 @@ bool CPVRChannelGroupsUpdateJob::DoWork(void)
   return g_PVRChannelGroups->Update(false);
 }
 
-bool CPVRChannelSettingsSaveJob::DoWork(void)
-{
-  g_PVRManager.SaveCurrentChannelSettings();
-  return true;
-}
-
 bool CPVRManager::OpenLiveStream(const CFileItem &channel)
 {
   bool bReturn(false);
@@ -1438,11 +1432,6 @@ void CPVRManager::TriggerChannelsUpdate(void)
 void CPVRManager::TriggerChannelGroupsUpdate(void)
 {
   QueueJob(new CPVRChannelGroupsUpdateJob());
-}
-
-void CPVRManager::TriggerSaveChannelSettings(void)
-{
-  QueueJob(new CPVRChannelSettingsSaveJob());
 }
 
 void CPVRManager::ExecutePendingJobs(void)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -492,13 +492,15 @@ namespace PVR
 
     /*!
      * @brief Persist the current channel settings in the database.
+     * @param channel the channel which settings should be saved.
      */
-    void SaveCurrentChannelSettings(void);
+    void SaveCurrentChannelSettings(const CPVRChannel &channel);
 
     /*!
      * @brief Load the settings for the current channel from the database.
+     * @param channel the channel which settings should be loaded.
      */
-    void LoadCurrentChannelSettings(void);
+    void LoadCurrentChannelSettings(const CPVRChannel &channel);
 
     /*!
      * @brief Check if channel is parental locked. Ask for PIN if neccessary.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -389,11 +389,6 @@ namespace PVR
     void TriggerChannelGroupsUpdate(void);
 
     /*!
-     * @brief Let the background thread save the current video settings.
-     */
-    void TriggerSaveChannelSettings(void);
-
-    /*!
      * @brief Update the channel that is currently active.
      * @param item The new channel.
      * @return True if it was updated correctly, false otherwise.
@@ -718,16 +713,6 @@ namespace PVR
     virtual const char *GetType() const { return "pvr-update-channelgroups"; }
 
     virtual bool DoWork();
-  };
-
-  class CPVRChannelSettingsSaveJob : public CJob
-  {
-  public:
-    CPVRChannelSettingsSaveJob(void) {}
-    virtual ~CPVRChannelSettingsSaveJob() {}
-    virtual const char *GetType() const { return "pvr-save-channelsettings"; }
-
-    bool DoWork();
   };
 
   class CPVRChannelSwitchJob : public CJob

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -491,18 +491,6 @@ namespace PVR
     void SearchMissingChannelIcons(void);
 
     /*!
-     * @brief Persist the current channel settings in the database.
-     * @param channel the channel which settings should be saved.
-     */
-    void SaveCurrentChannelSettings(const CPVRChannel &channel);
-
-    /*!
-     * @brief Load the settings for the current channel from the database.
-     * @param channel the channel which settings should be loaded.
-     */
-    void LoadCurrentChannelSettings(const CPVRChannel &channel);
-
-    /*!
      * @brief Check if channel is parental locked. Ask for PIN if neccessary.
      * @param channel The channel to open.
      * @return True if channel is unlocked (by default or PIN unlocked), false otherwise.
@@ -562,6 +550,18 @@ namespace PVR
      * @return If at least one client and all pvr data was loaded, false otherwise.
      */
     bool Load(void);
+    
+    /*!
+     * @brief Persist the current channel settings in the database.
+     * @param channel the channel which settings should be saved.
+     */
+    void SaveChannelSettings(const CPVRChannel &channel);
+
+    /*!
+     * @brief Load the settings for the current channel from the database.
+     * @param channel the channel which settings should be loaded.
+     */
+    void LoadChannelSettings(const CPVRChannel &channel);
 
     /*!
      * @brief Update all recordings.

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -44,7 +44,6 @@ CPVRClients::CPVRClients(void) :
     CThread("PVRClient"),
     m_bChannelScanRunning(false),
     m_bIsSwitchingChannels(false),
-    m_bIsValidChannelSettings(false),
     m_playingClientId(-EINVAL),
     m_bIsPlayingLiveTV(false),
     m_bIsPlayingRecording(false),
@@ -335,8 +334,6 @@ bool CPVRClients::SwitchChannel(const CPVRChannel &channel)
   {
     CSingleLock lock(m_critSection);
     m_bIsSwitchingChannels = false;
-    if (bSwitchSuccessful)
-      m_bIsValidChannelSettings = false;
   }
 
   if (!bSwitchSuccessful)

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -622,7 +622,6 @@ namespace PVR
 
     bool                  m_bChannelScanRunning;      /*!< true when a channel scan is currently running, false otherwise */
     bool                  m_bIsSwitchingChannels;        /*!< true while switching channels */
-    bool                  m_bIsValidChannelSettings;  /*!< true if current channel settings are valid and can be saved */
     int                   m_playingClientId;          /*!< the ID of the client that is currently playing */
     bool                  m_bIsPlayingLiveTV;
     bool                  m_bIsPlayingRecording;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -72,16 +72,6 @@ namespace PVR
      */
     void Stop(void);
 
-    /*!
-     * @brief Load the settings for the current channel from the database.
-     */
-    void LoadCurrentChannelSettings(void);
-
-    /*!
-     * @brief Persist the current channel settings in the database.
-     */
-    void SaveCurrentChannelSettings(void);
-
     /*! @name Backend methods */
     //@{
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -37,7 +37,6 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
-#include "pvr/PVRManager.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/IPlayer.h"
 #include "utils/LangCodeExpander.h"
@@ -45,7 +44,6 @@
 
 using namespace std;
 using namespace XFILE;
-using namespace PVR;
 
 CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings(void)
     : CGUIDialogSettings(WINDOW_DIALOG_AUDIO_OSD_SETTINGS, "VideoOSDSettings.xml")
@@ -362,9 +360,6 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
       CSettings::Get().Save();
     }
   }
-
-  if (g_PVRManager.IsPlayingRadio() || g_PVRManager.IsPlayingTV())
-    g_PVRManager.TriggerSaveChannelSettings();
 }
 
 void CGUIDialogAudioSubtitleSettings::FrameMove()

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -34,10 +34,8 @@
 #include "settings/Settings.h"
 #include "settings/MediaSettings.h"
 #include "addons/Skin.h"
-#include "pvr/PVRManager.h"
 
 using namespace std;
-using namespace PVR;
 
 CGUIDialogVideoSettings::CGUIDialogVideoSettings(void)
     : CGUIDialogSettings(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "VideoOSDSettings.xml")
@@ -263,9 +261,6 @@ void CGUIDialogVideoSettings::OnSettingChanged(SettingInfo &setting)
   {
     EnableSettings(VIDEO_SETTINGS_INTERLACEMETHOD, CMediaSettings::Get().GetCurrentVideoSettings().m_DeinterlaceMode != VS_DEINTERLACEMODE_OFF);
   }
-
-  if (g_PVRManager.IsPlayingRadio() || g_PVRManager.IsPlayingTV())
-    g_PVRManager.TriggerSaveChannelSettings();
 }
 
 CStdString CGUIDialogVideoSettings::FormatInteger(float value, float minimum)


### PR DESCRIPTION
There is currently a bug in XBMC which causes channel settings to not be loaded at all when pvr.cacheindvdplayer is disabled. The setting is used to dramatically speed up the time it takes to switch channels on backends with an internal demuxer. The problem is that the call to load the settings is done in a block that is never reached when the setting is disabled.

Because standard files and PVR channels work quite differently I've opted to contain loading/saving of channel settings in PVRManager. Currently they're loaded in Open/CloseLiveStream() and PerformChannelSwitch(). They were previously loaded in DVDPlayer and sometimes stored in Application in addition to whenever the current audio/video settings were changed.

I've also changed the Save/Load methods to take the channel in question as a parameter, this way it is easier to put the call in the proper location. It also alleviates the need to defer to PVRClients to handle the logic.

@opdenkamp @FernetMenta would be nice if you could chip in
@margro can you check for regressions with some backend other than tvheadend/vdr?
