### PR TITLE
Load channel settings properly when <cacheindvdplayer> is disabled

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4478,9 +4478,6 @@ void CApplication::StopPlaying()
       m_pKaraokeMgr->Stop();
 #endif
 
-    if (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio())
-      g_PVRManager.SaveCurrentChannelSettings();
-
     m_pPlayer->CloseFile();
 
     // turn off visualisation window when stopping
@@ -5760,10 +5757,6 @@ void CApplication::SaveCurrentFileSettings()
       dbs.SetVideoSettings(m_itemCurrentFile->GetPath(), CMediaSettings::Get().GetCurrentVideoSettings());
       dbs.Close();
     }
-  }
-  else if (m_itemCurrentFile->IsPVRChannel())
-  {
-    g_PVRManager.SaveCurrentChannelSettings();
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1596,10 +1596,6 @@ void CDVDPlayer::HandlePlaySpeed()
           bGotAudio, m_dvdPlayerAudio.GetLevel(),
           bGotVideo, m_dvdPlayerVideo.GetLevel());
 
-      CFileItem currentItem(g_application.CurrentFileItem());
-      if (currentItem.HasPVRChannelInfoTag())
-        g_PVRManager.LoadCurrentChannelSettings();
-
       caching = CACHESTATE_DONE;
     }
     else

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1822,10 +1822,6 @@ void COMXPlayer::HandlePlaySpeed()
           bGotAudio, m_omxPlayerAudio.GetLevel(),
           bGotVideo, m_omxPlayerVideo.GetLevel());
 
-      CFileItem currentItem(g_application.CurrentFileItem());
-      if (currentItem.HasPVRChannelInfoTag())
-        g_PVRManager.LoadCurrentChannelSettings();
-
       caching = CACHESTATE_DONE;
     }
     else

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -914,7 +914,7 @@ bool CPVRManager::CheckParentalPIN(const char *strTitle /* = NULL */)
   return bValidPIN;
 }
 
-void CPVRManager::SaveCurrentChannelSettings(const CPVRChannel &channel)
+void CPVRManager::SaveChannelSettings(const CPVRChannel &channel)
 {
   CPVRDatabase *database = GetPVRDatabase();
   if (!database)
@@ -934,7 +934,7 @@ void CPVRManager::SaveCurrentChannelSettings(const CPVRChannel &channel)
   }
 }
 
-void CPVRManager::LoadCurrentChannelSettings(const CPVRChannel &channel)
+void CPVRManager::LoadChannelSettings(const CPVRChannel &channel)
 {
   CPVRDatabase *database = GetPVRDatabase();
   if (!database)
@@ -1036,7 +1036,7 @@ bool CPVRManager::OpenLiveStream(const CFileItem &channel)
     m_currentFile = new CFileItem(channel);
 
     // load channel settings
-    LoadCurrentChannelSettings(*channel.GetPVRChannelInfoTag());
+    LoadChannelSettings(*channel.GetPVRChannelInfoTag());
 
     if (m_addons->GetPlayingChannel(playingChannel))
     {
@@ -1107,7 +1107,7 @@ void CPVRManager::CloseStream(void)
       bPersistChanges = true;
       
       // store channel settings
-      SaveCurrentChannelSettings(*channel);
+      SaveChannelSettings(*channel);
     }
 
     m_addons->CloseStream();
@@ -1343,8 +1343,8 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
     bSwitched = true;
 
     // save previous and load new channel's settings
-    SaveCurrentChannelSettings(*currentChannel);
-    LoadCurrentChannelSettings(channel);
+    SaveChannelSettings(*currentChannel);
+    LoadChannelSettings(channel);
 
     CSingleLock lock(m_critSection);
     m_currentFile = new CFileItem(channel);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -59,6 +59,10 @@
 #include "guilib/Key.h"
 #include "dialogs/GUIDialogPVRChannelManager.h"
 
+#ifdef HAS_VIDEO_PLAYBACK
+#include "cores/VideoRenderers/RenderManager.h"
+#endif
+
 using namespace std;
 using namespace MUSIC_INFO;
 using namespace PVR;
@@ -910,14 +914,62 @@ bool CPVRManager::CheckParentalPIN(const char *strTitle /* = NULL */)
   return bValidPIN;
 }
 
-void CPVRManager::SaveCurrentChannelSettings(void)
+void CPVRManager::SaveCurrentChannelSettings(const CPVRChannel &channel)
 {
-  m_addons->SaveCurrentChannelSettings();
+  CPVRDatabase *database = GetPVRDatabase();
+  if (!database)
+    return;
+
+  if (CMediaSettings::Get().GetCurrentVideoSettings() != CMediaSettings::Get().GetDefaultVideoSettings())
+  {
+    CLog::Log(LOGDEBUG, "PVR - %s - persisting custom channel settings for channel '%s'",
+        __FUNCTION__, channel.ChannelName().c_str());
+    database->PersistChannelSettings(channel, CMediaSettings::Get().GetCurrentVideoSettings());
+  }
+  else
+  {
+    CLog::Log(LOGDEBUG, "PVR - %s - no custom channel settings for channel '%s'",
+        __FUNCTION__, channel.ChannelName().c_str());
+    database->DeleteChannelSettings(channel);
+  }
 }
 
-void CPVRManager::LoadCurrentChannelSettings()
+void CPVRManager::LoadCurrentChannelSettings(const CPVRChannel &channel)
 {
-  m_addons->LoadCurrentChannelSettings();
+  CPVRDatabase *database = GetPVRDatabase();
+  if (!database)
+    return;
+  
+  CLog::Log(LOGDEBUG, "PVR - %s - loading custom channel settings for channel '%s'",
+        __FUNCTION__, channel.ChannelName().c_str());
+
+  if (g_application.m_pPlayer->HasPlayer())
+  {
+    /* store the current settings so we can compare if anything has changed */
+    CVideoSettings previousSettings = CMediaSettings::Get().GetCurrentVideoSettings();
+
+    /* load the persisted channel settings and set them as current */
+    CVideoSettings loadedChannelSettings = CMediaSettings::Get().GetDefaultVideoSettings();
+    database->GetChannelSettings(channel, loadedChannelSettings);
+    CMediaSettings::Get().GetCurrentVideoSettings() = loadedChannelSettings;
+
+    /* update the view mode if it set to custom or differs from the previous mode */
+    if (previousSettings.m_ViewMode != loadedChannelSettings.m_ViewMode || loadedChannelSettings.m_ViewMode == ViewModeCustom)
+      g_renderManager.SetViewMode(loadedChannelSettings.m_ViewMode);
+
+    /* only change the subtitle stream, if it's different */
+    if (previousSettings.m_SubtitleStream != loadedChannelSettings.m_SubtitleStream)
+      g_application.m_pPlayer->SetSubtitle(loadedChannelSettings.m_SubtitleStream);
+
+    /* only change the audio stream if it's different */
+    if (g_application.m_pPlayer->GetAudioStream() != loadedChannelSettings.m_AudioStream && loadedChannelSettings.m_AudioStream >= 0)
+      g_application.m_pPlayer->SetAudioStream(loadedChannelSettings.m_AudioStream);
+
+    g_application.m_pPlayer->SetAVDelay(loadedChannelSettings.m_AudioDelay);
+    g_application.m_pPlayer->SetDynamicRangeCompression((long)(loadedChannelSettings.m_VolumeAmplification * 100));
+    g_application.m_pPlayer->SetSubtitleVisible(loadedChannelSettings.m_SubtitleOn);
+    g_application.m_pPlayer->SetSubTitleDelay(loadedChannelSettings.m_SubtitleDelay);
+  }
 }
 
 void CPVRManager::SetPlayingGroup(CPVRChannelGroupPtr group)
@@ -982,6 +1034,9 @@ bool CPVRManager::OpenLiveStream(const CFileItem &channel)
     if(m_currentFile)
       delete m_currentFile;
     m_currentFile = new CFileItem(channel);
+
+    // load channel settings
+    LoadCurrentChannelSettings(*channel.GetPVRChannelInfoTag());
 
     if (m_addons->GetPlayingChannel(playingChannel))
     {
@@ -1050,6 +1105,9 @@ void CPVRManager::CloseStream(void)
       m_channelGroups->SetLastPlayedGroup(group);
 
       bPersistChanges = true;
+      
+      // store channel settings
+      SaveCurrentChannelSettings(*channel);
     }
 
     m_addons->CloseStream();
@@ -1259,9 +1317,6 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
     m_channelGroups->SetLastPlayedGroup(GetPlayingGroup(currentChannel->IsRadio()));
   }
 
-  // store channel settings
-  SaveCurrentChannelSettings();
-
   // will be deleted by CPVRChannelSwitchJob::DoWork()
   CFileItem* previousFile = m_currentFile;
   m_currentFile = NULL;
@@ -1286,6 +1341,10 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
   {
     // switch successful
     bSwitched = true;
+
+    // save previous and load new channel's settings
+    SaveCurrentChannelSettings(*currentChannel);
+    LoadCurrentChannelSettings(channel);
 
     CSingleLock lock(m_critSection);
     m_currentFile = new CFileItem(channel);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -960,12 +960,6 @@ bool CPVRChannelGroupsUpdateJob::DoWork(void)
   return g_PVRChannelGroups->Update(false);
 }
 
-bool CPVRChannelSettingsSaveJob::DoWork(void)
-{
-  g_PVRManager.SaveCurrentChannelSettings();
-  return true;
-}
-
 bool CPVRManager::OpenLiveStream(const CFileItem &channel)
 {
   bool bReturn(false);
@@ -1477,11 +1471,6 @@ void CPVRManager::TriggerChannelsUpdate(void)
 void CPVRManager::TriggerChannelGroupsUpdate(void)
 {
   QueueJob(new CPVRChannelGroupsUpdateJob());
-}
-
-void CPVRManager::TriggerSaveChannelSettings(void)
-{
-  QueueJob(new CPVRChannelSettingsSaveJob());
 }
 
 void CPVRManager::TriggerSearchMissingChannelIcons(void)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -500,13 +500,15 @@ namespace PVR
 
     /*!
      * @brief Persist the current channel settings in the database.
+     * @param channel the channel which settings should be saved.
      */
-    void SaveCurrentChannelSettings(void);
+    void SaveCurrentChannelSettings(const CPVRChannel &channel);
 
     /*!
      * @brief Load the settings for the current channel from the database.
+     * @param channel the channel which settings should be loaded.
      */
-    void LoadCurrentChannelSettings(void);
+    void LoadCurrentChannelSettings(const CPVRChannel &channel);
 
     /*!
      * @brief Check if channel is parental locked. Ask for PIN if neccessary.
@@ -568,7 +570,7 @@ namespace PVR
      * @return If at least one client and all pvr data was loaded, false otherwise.
      */
     bool Load(void);
-
+    
     /*!
      * @brief Update all recordings.
      */

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -392,11 +392,6 @@ namespace PVR
     void TriggerChannelGroupsUpdate(void);
 
     /*!
-     * @brief Let the background thread save the current video settings.
-     */
-    void TriggerSaveChannelSettings(void);
-
-    /*!
      * @brief Let the background thread search for missing channel icons.
      */
     void TriggerSearchMissingChannelIcons(void);
@@ -726,16 +721,6 @@ namespace PVR
     virtual const char *GetType() const { return "pvr-update-channelgroups"; }
 
     virtual bool DoWork();
-  };
-
-  class CPVRChannelSettingsSaveJob : public CJob
-  {
-  public:
-    CPVRChannelSettingsSaveJob(void) {}
-    virtual ~CPVRChannelSettingsSaveJob() {}
-    virtual const char *GetType() const { return "pvr-save-channelsettings"; }
-
-    bool DoWork();
   };
 
   class CPVRChannelSwitchJob : public CJob

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -499,18 +499,6 @@ namespace PVR
     void SearchMissingChannelIcons(void);
 
     /*!
-     * @brief Persist the current channel settings in the database.
-     * @param channel the channel which settings should be saved.
-     */
-    void SaveCurrentChannelSettings(const CPVRChannel &channel);
-
-    /*!
-     * @brief Load the settings for the current channel from the database.
-     * @param channel the channel which settings should be loaded.
-     */
-    void LoadCurrentChannelSettings(const CPVRChannel &channel);
-
-    /*!
      * @brief Check if channel is parental locked. Ask for PIN if neccessary.
      * @param channel The channel to open.
      * @return True if channel is unlocked (by default or PIN unlocked), false otherwise.
@@ -571,6 +559,18 @@ namespace PVR
      */
     bool Load(void);
     
+    /*!
+     * @brief Persist the current channel settings in the database.
+     * @param channel the channel which settings should be saved.
+     */
+    void SaveChannelSettings(const CPVRChannel &channel);
+
+    /*!
+     * @brief Load the settings for the current channel from the database.
+     * @param channel the channel which settings should be loaded.
+     */
+    void LoadChannelSettings(const CPVRChannel &channel);
+
     /*!
      * @brief Update all recordings.
      */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -44,7 +44,6 @@ CPVRClients::CPVRClients(void) :
     CThread("PVRClient"),
     m_bChannelScanRunning(false),
     m_bIsSwitchingChannels(false),
-    m_bIsValidChannelSettings(false),
     m_playingClientId(-EINVAL),
     m_bIsPlayingLiveTV(false),
     m_bIsPlayingRecording(false),
@@ -335,8 +334,6 @@ bool CPVRClients::SwitchChannel(const CPVRChannel &channel)
   {
     CSingleLock lock(m_critSection);
     m_bIsSwitchingChannels = false;
-    if (bSwitchSuccessful)
-      m_bIsValidChannelSettings = false;
   }
 
   if (!bSwitchSuccessful)

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -28,18 +28,12 @@
 #include "pvr/PVRManager.h"
 #include "pvr/PVRDatabase.h"
 #include "guilib/GUIWindowManager.h"
-#include "settings/DisplaySettings.h"
-#include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
 #include "cores/IPlayer.h"
-
-#ifdef HAS_VIDEO_PLAYBACK
-#include "cores/VideoRenderers/RenderManager.h"
-#endif
 
 using namespace std;
 using namespace ADDON;
@@ -1027,78 +1021,6 @@ void CPVRClients::ShowDialogNoClientsEnabled(void)
   params.push_back("addons://disabled/xbmc.pvrclient");
   params.push_back("return");
   g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
-}
-
-void CPVRClients::SaveCurrentChannelSettings(void)
-{
-  CPVRChannelPtr channel;
-  {
-    CSingleLock lock(m_critSection);
-    if (!GetPlayingChannel(channel) || !m_bIsValidChannelSettings)
-      return;
-  }
-
-  CPVRDatabase *database = GetPVRDatabase();
-  if (!database)
-    return;
-
-  if (CMediaSettings::Get().GetCurrentVideoSettings() != CMediaSettings::Get().GetDefaultVideoSettings())
-  {
-    CLog::Log(LOGDEBUG, "PVR - %s - persisting custom channel settings for channel '%s'",
-        __FUNCTION__, channel->ChannelName().c_str());
-    database->PersistChannelSettings(*channel, CMediaSettings::Get().GetCurrentVideoSettings());
-  }
-  else
-  {
-    CLog::Log(LOGDEBUG, "PVR - %s - no custom channel settings for channel '%s'",
-        __FUNCTION__, channel->ChannelName().c_str());
-    database->DeleteChannelSettings(*channel);
-  }
-}
-
-void CPVRClients::LoadCurrentChannelSettings(void)
-{
-  CPVRChannelPtr channel;
-  {
-    CSingleLock lock(m_critSection);
-    if (!GetPlayingChannel(channel))
-      return;
-  }
-
-  CPVRDatabase *database = GetPVRDatabase();
-  if (!database)
-    return;
-
-  if (g_application.m_pPlayer->HasPlayer())
-  {
-    /* store the current settings so we can compare if anything has changed */
-    CVideoSettings previousSettings = CMediaSettings::Get().GetCurrentVideoSettings();
-
-    /* load the persisted channel settings and set them as current */
-    CVideoSettings loadedChannelSettings = CMediaSettings::Get().GetDefaultVideoSettings();
-    database->GetChannelSettings(*channel, loadedChannelSettings);
-    CMediaSettings::Get().GetCurrentVideoSettings() = loadedChannelSettings;
-
-    /* update the view mode if it set to custom or differs from the previous mode */
-    if (previousSettings.m_ViewMode != loadedChannelSettings.m_ViewMode || loadedChannelSettings.m_ViewMode == ViewModeCustom)
-      g_renderManager.SetViewMode(loadedChannelSettings.m_ViewMode);
-
-    /* only change the subtitle stream, if it's different */
-    if (previousSettings.m_SubtitleStream != loadedChannelSettings.m_SubtitleStream)
-      g_application.m_pPlayer->SetSubtitle(loadedChannelSettings.m_SubtitleStream);
-
-    /* only change the audio stream if it's different */
-    if (g_application.m_pPlayer->GetAudioStream() != loadedChannelSettings.m_AudioStream && loadedChannelSettings.m_AudioStream >= 0)
-      g_application.m_pPlayer->SetAudioStream(loadedChannelSettings.m_AudioStream);
-
-    g_application.m_pPlayer->SetAVDelay(loadedChannelSettings.m_AudioDelay);
-    g_application.m_pPlayer->SetDynamicRangeCompression((long)(loadedChannelSettings.m_VolumeAmplification * 100));
-    g_application.m_pPlayer->SetSubtitleVisible(loadedChannelSettings.m_SubtitleOn);
-    g_application.m_pPlayer->SetSubTitleDelay(loadedChannelSettings.m_SubtitleDelay);
-
-    /* settings can be saved on next channel switch */
-    m_bIsValidChannelSettings = true;
-  }
 }
 
 bool CPVRClients::UpdateAddons(void)

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -622,7 +622,6 @@ namespace PVR
 
     bool                  m_bChannelScanRunning;      /*!< true when a channel scan is currently running, false otherwise */
     bool                  m_bIsSwitchingChannels;        /*!< true while switching channels */
-    bool                  m_bIsValidChannelSettings;  /*!< true if current channel settings are valid and can be saved */
     int                   m_playingClientId;          /*!< the ID of the client that is currently playing */
     bool                  m_bIsPlayingLiveTV;
     bool                  m_bIsPlayingRecording;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -72,16 +72,6 @@ namespace PVR
      */
     void Stop(void);
 
-    /*!
-     * @brief Load the settings for the current channel from the database.
-     */
-    void LoadCurrentChannelSettings(void);
-
-    /*!
-     * @brief Persist the current channel settings in the database.
-     */
-    void SaveCurrentChannelSettings(void);
-
     /*! @name Backend methods */
     //@{
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -31,7 +31,6 @@
 #include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "profiles/ProfilesManager.h"
-#include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -59,7 +58,6 @@
 #define SETTING_AUDIO_MAKE_DEFAULT             "audio.makedefault"
 
 using namespace std;
-using namespace PVR;
 
 CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_OSD_SETTINGS, "VideoOSDSettings.xml"),
@@ -186,9 +184,6 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(const CSetting *setting)
     m_subtitleStream = videoSettings.m_SubtitleStream = static_cast<const CSettingInt*>(setting)->GetValue();
     g_application.m_pPlayer->SetSubtitle(m_subtitleStream);
   }
-
-  if (g_PVRManager.IsPlayingRadio() || g_PVRManager.IsPlayingTV())
-    g_PVRManager.TriggerSaveChannelSettings();
 }
 
 void CGUIDialogAudioSubtitleSettings::OnSettingAction(const CSetting *setting)

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -29,7 +29,6 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "profiles/ProfilesManager.h"
-#include "pvr/PVRManager.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
@@ -62,7 +61,6 @@
 #define SETTING_VIDEO_CALIBRATION         "video.calibration"
 
 using namespace std;
-using namespace PVR;
 
 CGUIDialogVideoSettings::CGUIDialogVideoSettings()
     : CGUIDialogSettingsManualBase(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "VideoOSDSettings.xml"),
@@ -145,9 +143,6 @@ void CGUIDialogVideoSettings::OnSettingChanged(const CSetting *setting)
     videoSettings.m_StereoMode = static_cast<const CSettingInt*>(setting)->GetValue();
   else if (settingId == SETTING_VIDEO_STEREOSCOPICINVERT)
     videoSettings.m_StereoInvert = static_cast<const CSettingBool*>(setting)->GetValue();
-
-  if (g_PVRManager.IsPlayingRadio() || g_PVRManager.IsPlayingTV())
-    g_PVRManager.TriggerSaveChannelSettings();
 }
 
 void CGUIDialogVideoSettings::OnSettingAction(const CSetting *setting)


### PR DESCRIPTION
There is currently a bug in XBMC which causes channel settings to not be loaded at all when pvr.cacheindvdplayer is disabled. The setting is used to dramatically speed up the time it takes to switch channels on backends with an internal demuxer. The problem is that the call to load the settings is done in a block that is never reached when the setting is disabled.

Because standard files and PVR channels work quite differently I've opted to contain loading/saving of channel settings in PVRManager. Currently they're loaded in Open/CloseLiveStream() and PerformChannelSwitch(). They were previously loaded in DVDPlayer and sometimes stored in Application in addition to whenever the current audio/video settings were changed.

I've also changed the Save/Load methods to take the channel in question as a parameter, this way it is easier to put the call in the proper location. It also alleviates the need to defer to PVRClients to handle the logic.

@opdenkamp @FernetMenta would be nice if you could chip in
@margro can you check for regressions with some backend other than tvheadend/vdr?
