### PR TITLE
Remove a superfluous call to RequestStreams()

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -128,7 +128,6 @@ bool CDVDDemuxPVRClient::Open(CDVDInputStream* pInput)
   if (!g_PVRClients->GetPlayingClient(m_pvrClient))
     return false;
 
-  RequestStreams();
   return true;
 }
 


### PR DESCRIPTION
Currently RequestStreams is called twice in a row when opening a live stream. This is because when starting a channel there will always be a DMX_SPECIALID_STREAMCHANGE packet, which will trigger RequestStreams(). I removed one of the calls.
