### PR TITLE
Use FF_LEVEL_UNKNOWN by default (prevents some common mismatches in

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -76,7 +76,7 @@ public:
     codec = (AVCodecID)0; // AV_CODEC_ID_NONE
     codec_fourcc = 0;
     profile = FF_PROFILE_UNKNOWN;
-    level = 0;
+    level = FF_LEVEL_UNKNOWN;
     type = STREAM_NONE;
     source = STREAM_SOURCE_NONE;
     iDuration = 0;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -252,7 +252,7 @@ void CDVDDemuxPVRClient::ParsePacket(DemuxPacket* pkt)
 
 
     CHECK_UPDATE(st, profile, pvr->m_context->profile , FF_PROFILE_UNKNOWN);
-    CHECK_UPDATE(st, level  , pvr->m_context->level   , 0);
+    CHECK_UPDATE(st, level  , pvr->m_context->level   , FF_LEVEL_UNKNOWN);
 
     switch (st->type)
     {


### PR DESCRIPTION
This prevents some common mismatches in ParsePacket() which trigger reopening of streams (e.g. `ParsePacket - {1} level changed from 0 to -99`).
