### PR TITLE
Do not allow non-content stream types to extend the format context's dur...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -790,7 +790,8 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
 
 
         // check if stream has passed full duration, needed for live streams
-        if(m_pkt.pkt.dts != (int64_t)AV_NOPTS_VALUE)
+        bool bAllowDurationExt = (stream->codec && (stream->codec->codec_type == AVMEDIA_TYPE_VIDEO || stream->codec->codec_type == AVMEDIA_TYPE_AUDIO));
+        if(bAllowDurationExt && m_pkt.pkt.dts != (int64_t)AV_NOPTS_VALUE)
         {
           int64_t duration;
           duration = m_pkt.pkt.dts;


### PR DESCRIPTION
...ation as this

affects the UI and therefore seek capabilities.

DVB subtitle/teletext streams are private streams (stream type 0xBD) and may have their
own timebase or PTS values that are widely different than video stream's,
or not set properly. Regardless of any handling of such cases in FFmpeg, XBMC shouldn't
extend play duration unless an actual content stream has passed it's "end".
