### PR TITLE
[PVR] Feature: Confirm shutdown if PVR backend is not idle.

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9295,7 +9295,19 @@ msgctxt "#19684"
 msgid "Adult"
 msgstr ""
 
-#empty strings from id 19685 to 19999
+#. Title for shutdown confirmation dialog
+#: xbmc/ApplicationMessenger.cpp
+msgctxt "#19685"
+msgid "Confirm shutdown"
+msgstr ""
+
+#. Text for shutdown confirmation dialog
+#: xbmc/ApplicationMessenger.cpp
+msgctxt "#19686"
+msgid "The PVR backend is busy. Shutdown anyway?"
+msgstr ""
+
+#empty strings from id 19687 to 19999
 
 #: system/settings/settings.xml
 msgctxt "#20000"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1921,7 +1921,11 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     {
       std::string friendlyName = CSettings::Get().GetString("services.devicename");
       if (StringUtils::EqualsNoCase(friendlyName, CCompileInfo::GetAppName()))
-        strLabel = StringUtils::Format("%s (%s)", friendlyName.c_str(), g_application.getNetwork().GetHostName().c_str());
+      {
+        std::string hostname("[unknown]");
+        g_application.getNetwork().GetHostName(hostname);
+        strLabel = StringUtils::Format("%s (%s)", friendlyName.c_str(), hostname.c_str());
+      }
       else
         strLabel = friendlyName;
     }

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "URL.h"
+#include "Application.h"
 #include "utils/RegExp.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -29,6 +30,7 @@
 #include "filesystem/StackDirectory.h"
 #include "addons/Addon.h"
 #include "utils/StringUtils.h"
+#include "network/Network.h"
 #ifndef TARGET_POSIX
 #include <sys\types.h>
 #include <sys\stat.h>
@@ -679,14 +681,12 @@ std::string CURL::GetRedacted(const std::string& path)
 
 bool CURL::IsLocal() const
 {
-  return (IsLocalHost() || m_strProtocol.empty());
+  return (m_strProtocol.empty() || IsLocalHost());
 }
 
 bool CURL::IsLocalHost() const
 {
-  // localhost is case-insensitive
-  return (StringUtils::EqualsNoCase(m_strHostName, "localhost") ||
-          m_strHostName == "127.0.0.1");
+  return g_application.getNetwork().IsLocalHost(m_strHostName);
 }
 
 bool CURL::IsFileOnly(const std::string &url)

--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -595,6 +595,13 @@ extern "C"
   time_t GetBufferTimeEnd();
 
   /*!
+   *  Get the hostname of the pvr backend server
+   *  @return hostname as ip address or alias. If backend does not
+   *          utilize a server, return empty string.
+   */
+  const char* GetBackendHostname();
+
+  /*!
    * Called by XBMC to assign the function pointers of this add-on to pClient.
    * @param pClient The struct to assign the function pointers to.
    */
@@ -674,6 +681,8 @@ extern "C"
     pClient->GetPlayingTime                 = GetPlayingTime;
     pClient->GetBufferTimeStart             = GetBufferTimeStart;
     pClient->GetBufferTimeEnd               = GetBufferTimeEnd;
+
+    pClient->GetBackendHostname             = GetBackendHostname;
   };
 };
 

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -75,10 +75,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "1.9.2"
+#define XBMC_PVR_API_VERSION "1.9.3"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "1.9.2"
+#define XBMC_PVR_MIN_API_VERSION "1.9.3"
 
 #ifdef __cplusplus
 extern "C" {
@@ -399,6 +399,7 @@ extern "C" {
     time_t       (__cdecl* GetPlayingTime)(void);
     time_t       (__cdecl* GetBufferTimeStart)(void);
     time_t       (__cdecl* GetBufferTimeEnd)(void);
+    const char*  (__cdecl* GetBackendHostname)(void);
   } PVRClient;
 
 #ifdef __cplusplus

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -96,6 +96,7 @@
 #include <vector>
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
+#include "powermanagement/PowerManager.h"
 
 using namespace std;
 using namespace XFILE;
@@ -240,6 +241,39 @@ bool CBuiltins::HasCommand(const std::string& execString)
   {
     if (StringUtils::EqualsNoCase(function, commands[i].command) && (!commands[i].needsParameters || parameters.size()))
       return true;
+  }
+  return false;
+}
+
+bool CBuiltins::IsSystemPowerdownCommand(const std::string& execString)
+{
+  std::string execute;
+  vector<string> params;
+  CUtil::SplitExecFunction(execString, execute, params);
+  StringUtils::ToLower(execute);
+
+  // Check if action is resulting in system powerdown.
+  if (execute == "reboot"    ||
+      execute == "restart"   ||
+      execute == "reset"     ||
+      execute == "powerdown" ||
+      execute == "hibernate" ||
+      execute == "suspend" )
+  {
+    return true;
+  }
+  else if (execute == "shutdown")
+  {
+    switch (CSettings::Get().GetInt("powermanagement.shutdownstate"))
+    {
+      case POWERSTATE_SHUTDOWN:
+      case POWERSTATE_SUSPEND:
+      case POWERSTATE_HIBERNATE:
+        return true;
+
+      default:
+        return false;
+    }
   }
   return false;
 }

--- a/xbmc/interfaces/Builtins.h
+++ b/xbmc/interfaces/Builtins.h
@@ -26,6 +26,7 @@ class CBuiltins
 {
 public:
   static bool HasCommand(const std::string& execString);
+  static bool IsSystemPowerdownCommand(const std::string& execString);
   static void GetHelp(std::string &help);
   static int Execute(const std::string& execString);
 };

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -110,7 +110,7 @@ public:
    virtual ~CNetwork();
 
    // Return our hostname
-   virtual std::string GetHostName(void);
+   virtual bool GetHostName(std::string& hostname);
 
    // Return the list of interfaces
    virtual std::vector<CNetworkInterface*>& GetInterfaceList(void) = 0;
@@ -146,6 +146,9 @@ public:
    void StopServices(bool bWait);
 
    static int ParseHex(char *str, unsigned char *addr);
+
+   // Return true if given name or ip address corresponds to localhost
+   bool IsLocalHost(const std::string& hostname);
 };
 
 #ifdef HAS_LINUX_NETWORK

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -628,9 +628,9 @@ int CPeripheralCecAdapter::CecCommand(void *cbParam, const cec_command command)
       {
         adapter->m_bStarted = false;
         if (adapter->m_configuration.bPowerOffOnStandby == 1)
-          CApplicationMessenger::Get().Suspend();
+          g_application.ExecuteXBMCAction("Suspend");
         else if (adapter->m_configuration.bShutdownOnStandby == 1)
-          CApplicationMessenger::Get().Shutdown();
+          g_application.ExecuteXBMCAction("Shutdown");
       }
       break;
     case CEC_OPCODE_SET_MENU_LANGUAGE:

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1414,6 +1414,26 @@ bool CPVRManager::IsIdle(void) const
   return true;
 }
 
+bool CPVRManager::CanSystemPowerdown(bool bAskUser /*= true*/) const
+{
+  bool bReturn(true);
+  if (IsStarted())
+  {
+    if (!m_addons->AllLocalBackendsIdle())
+    {
+      if (bAskUser)
+      {
+        // Inform user about PVR being busy. Ask if user wants to powerdown anyway.
+        bool bCanceled = false;
+        bReturn = CGUIDialogYesNo::ShowAndGetInput(19685, 19686, 0, 0, -1, -1, bCanceled, 10000);
+      }
+      else
+        bReturn = false; // do not powerdown (busy, but no user interaction requested).
+    }
+  }
+  return bReturn;
+}
+
 void CPVRManager::ShowPlayerInfo(int iTimeout)
 {
   if (IsStarted() && m_guiInfo)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -372,6 +372,18 @@ namespace PVR
     bool IsIdle(void) const;
 
     /*!
+     * @brief Check whether the system Kodi is running on can be powered down
+     *        (shutdown/reboot/suspend/hibernate) without stopping any active
+     *        recordings and/or without preventing the start of recordings
+     *        sheduled for now + pvrpowermanagement.backendidletime.
+     * @param bAskUser True to informs user in case of potential
+     *        data loss. User can decide to allow powerdown anyway. False to
+     *        not to ask user and to not confirm power down.
+     * @return True if system can be safely powered down, false otherwise.
+     */
+    bool CanSystemPowerdown(bool bAskUser = true) const;
+
+    /*!
      * @brief Set the current playing group, used to load the right channel.
      * @param group The new group.
      */

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -132,6 +132,7 @@ void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
   m_strConnectionString   = DEFAULT_INFO_STRING_VALUE;
   m_strFriendlyName       = DEFAULT_INFO_STRING_VALUE;
   m_strBackendName        = DEFAULT_INFO_STRING_VALUE;
+  m_strBackendHostname.clear();
   m_bIsPlayingTV          = false;
   m_bIsPlayingRecording   = false;
   memset(&m_addonCapabilities, 0, sizeof(m_addonCapabilities));
@@ -353,7 +354,7 @@ bool CPVRClient::CheckAPIVersion(void)
 
 bool CPVRClient::GetAddonProperties(void)
 {
-  std::string strBackendName, strConnectionString, strFriendlyName, strBackendVersion;
+  std::string strBackendName, strConnectionString, strFriendlyName, strBackendVersion, strBackendHostname;
   PVR_ADDON_CAPABILITIES addonCapabilities;
 
   /* get the capabilities */
@@ -384,12 +385,17 @@ bool CPVRClient::GetAddonProperties(void)
   try { strBackendVersion = m_pStruct->GetBackendVersion(); }
   catch (std::exception &e) { LogException(e, "GetBackendVersion()"); return false;  }
 
+  /* backend hostname */
+  try { strBackendHostname = m_pStruct->GetBackendHostname(); }
+  catch (std::exception &e) { LogException(e, "GetBackendHostname()"); return false; }
+
   /* update the members */
   m_strBackendName      = strBackendName;
   m_strConnectionString = strConnectionString;
   m_strFriendlyName     = strFriendlyName;
   m_strBackendVersion   = strBackendVersion;
   m_addonCapabilities   = addonCapabilities;
+  m_strBackendHostname  = strBackendHostname;
 
   return true;
 }
@@ -408,6 +414,11 @@ const std::string& CPVRClient::GetBackendName(void) const
 const std::string& CPVRClient::GetBackendVersion(void) const
 {
   return m_strBackendVersion;
+}
+
+const std::string& CPVRClient::GetBackendHostname(void) const
+{
+  return m_strBackendHostname;
 }
 
 const std::string& CPVRClient::GetConnectionString(void) const

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -129,6 +129,11 @@ namespace PVR
     const std::string& GetBackendVersion(void) const;
 
     /*!
+     * @brief the ip address or alias of the pvr backend server
+     */
+    const std::string& GetBackendHostname(void) const;
+
+    /*!
      * @return The connection string reported by the backend.
      */
     const std::string& GetConnectionString(void) const;
@@ -625,6 +630,7 @@ namespace PVR
     PVR_ADDON_CAPABILITIES m_addonCapabilities;     /*!< the cached add-on capabilities */
     bool                   m_bGotAddonCapabilities; /*!< true if the add-on capabilities have already been fetched */
     PVR_SIGNAL_STATUS      m_qualityInfo;           /*!< stream quality information */
+    std::string            m_strBackendHostname;    /*!< the cached backend hostname */
 
     /* stored strings to make sure const char* members in PVR_PROPERTIES stay valid */
     std::string m_strUserPath;    /*!< @brief translated path to the user profile */

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -552,6 +552,12 @@ namespace PVR
 
     bool GetPlayingClient(PVR_CLIENT &client) const;
 
+    /*!
+     * @brief Checks whether all local pvr backends (if any) are idle (no recording active, ...).
+     * @return True if all local backends are idle or no local backends are connected, false otherwise.
+     */
+    bool AllLocalBackendsIdle() const;
+
     time_t GetPlayingTime() const;
     time_t GetBufferTimeStart() const;
     time_t GetBufferTimeEnd() const;
@@ -620,6 +626,8 @@ namespace PVR
     int RegisterClient(ADDON::AddonPtr client, bool* newRegistration = NULL);
 
     int GetClientId(const ADDON::AddonPtr client) const;
+
+    static bool NextEventWithinBackendIdleTime(const CPVRTimers& timers);
 
     bool                  m_bChannelScanRunning;      /*!< true when a channel scan is currently running, false otherwise */
     bool                  m_bIsSwitchingChannels;        /*!< true while switching channels */

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -47,6 +47,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "addons/AddonManager.h"
 #include "view/ViewState.h"
+#include "pvr/PVRManager.h"
 
 #define CONTROL_BIG_LIST               52
 #define CONTROL_LABEL_HEADER            2
@@ -141,7 +142,8 @@ bool CGUIWindowLoginScreen::OnAction(const CAction &action)
   {
     std::string actionName = action.GetName();
     StringUtils::ToLower(actionName);
-    if (actionName.find("shutdown") != std::string::npos)
+    if ((actionName.find("shutdown") != std::string::npos) &&
+        PVR::g_PVRManager.CanSystemPowerdown())
       CBuiltins::Execute(action.GetName());
     return true;
   }


### PR DESCRIPTION
User story: In case shutdown is requested by the user while PVR is recordig or a  recording will start very soon (and XBMC machine potentially cannot restart fast enough), XBMC refuses to shutdown, but shows a Yes/No dialog to the user explaining that PVR is currently not idle and asking the user to shut down anyway. If user does nothing for 10 secs, the dialog will autoclose and shutdown will be cancelled.

Purpose: This is very useful to prevent accidentally stopped recordings.

BTW: This feature has been discussed from time to time in the forums and there were some (hacky) addons around to implement this, but no clean implementation (which IMO can only be done inXBMC itself.)
