### PR TITLE
Speedup FileItem::IsSamePath

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1430,6 +1430,12 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       return (item->GetProperty("item_start") == GetProperty("item_start"));
     return true;
   }
+  if (HasVideoInfoTag() && item->HasVideoInfoTag())
+  {
+    if (m_videoInfoTag->m_iDbId != -1 && item->m_videoInfoTag->m_iDbId != -1)
+      return ((m_videoInfoTag->m_iDbId == item->m_videoInfoTag->m_iDbId) &&
+        (m_videoInfoTag->m_type == item->m_videoInfoTag->m_type));        
+  }
   if (IsMusicDb() && HasMusicInfoTag())
   {
     CFileItem dbItem(m_musicInfoTag->GetURL(), false);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1185,14 +1185,12 @@ bool CFileItem::IsHD() const
 
 bool CFileItem::IsMusicDb() const
 {
-  CURL url(m_strPath);
-  return url.GetProtocol().Equals("musicdb");
+  return URIUtils::IsMusicDb(m_strPath);
 }
 
 bool CFileItem::IsVideoDb() const
 {
-  CURL url(m_strPath);
-  return url.GetProtocol().Equals("videodb");
+  return URIUtils::IsVideoDb(m_strPath);
 }
 
 bool CFileItem::IsVirtualDirectoryRoot() const


### PR DESCRIPTION
IsSamePath has been found to be expensive if PR #4301 is applied and
used.  This is due to the high number of update events generated.

If the user is in the movie view, then the CFileItemList is scanned for every updated item, and the way the code detects it's a matching movie is to use IsSamePath.

By optimizing the IsSamePath code, the stall/overhead of processing the events (depending on collection size) is reduced.

See this post/thread for more details:
http://forum.xbmc.org/showthread.php?tid=184411&pid=1641764#pid1641764
