### PR TITLE
Use correct codec names, MPEG is always written in upper-case

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6048,7 +6048,7 @@ msgctxt "#13448"
 msgid "Enable this option to use hardware acceleration for MPEG-(1/2) codecs. If disabled the CPU will be used instead. Some MPEG-2 Videos might have green artifacts."
 msgstr ""
 
-#: system/settings/settings.xm
+#: system/settings/settings.xml
 msgctxt "#13449"
 msgid "Use MPEG-4 VAAPI"
 msgstr ""
@@ -6059,7 +6059,7 @@ msgctxt "#13450"
 msgid "Enable this option to use hardware acceleration for the MPEG-4 codec. If disabled the CPU will be used instead."
 msgstr ""
 
-#: system/settings/settings.xm
+#: system/settings/settings.xml
 msgctxt "#13451"
 msgid "Use VC-1 VAAPI"
 msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6006,24 +6006,24 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13441"
-msgid "Use Mpeg-2 VDPAU"
+msgid "Use MPEG-2 VDPAU"
 msgstr ""
 
-#. Description of setting "Videos -> Playback -> Use Mpeg-2 VDPAU" with label #13441
+#. Description of setting "Videos -> Playback -> Use MPEG-2 VDPAU" with label #13441
 #: system/settings/settings.xml
 msgctxt "#13442"
-msgid "Enable this option to use hardware acceleration for Mpeg-(1/2) codecs. If disabled the CPU will be used instead. Older Radeon Cards tend to segfault with this enabled."
+msgid "Enable this option to use hardware acceleration for MPEG-(1/2) codecs. If disabled the CPU will be used instead. Older Radeon Cards tend to segfault with this enabled."
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13443"
-msgid "Use Mpeg-4 VDPAU"
+msgid "Use MPEG-4 VDPAU"
 msgstr ""
 
-#. Description of setting "Videos -> Playback -> Use Mpeg-4 VDPAU" with label #13443
+#. Description of setting "Videos -> Playback -> Use MPEG-4 VDPAU" with label #13443
 #: system/settings/settings.xml
 msgctxt "#13444"
-msgid "Enable this option to use hardware acceleration for the Mpeg-4 codec. If disabled the CPU will be used instead. Some ION Hardware has problems with this being enabled by default."
+msgid "Enable this option to use hardware acceleration for the MPEG-4 codec. If disabled the CPU will be used instead. Some ION Hardware has problems with this being enabled by default."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -6039,24 +6039,24 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13447"
-msgid "Use Mpeg-2 VAAPI"
+msgid "Use MPEG-2 VAAPI"
 msgstr ""
 
-#. Description of setting "Videos -> Playback -> Use Mpeg-2 VAAPI" with label #13447
+#. Description of setting "Videos -> Playback -> Use MPEG-2 VAAPI" with label #13447
 #: system/settings/settings.xml
 msgctxt "#13448"
-msgid "Enable this option to use hardware acceleration for Mpeg-(1/2) codecs. If disabled the CPU will be used instead. Some Mpeg-2 Videos might have green artifacts."
+msgid "Enable this option to use hardware acceleration for MPEG-(1/2) codecs. If disabled the CPU will be used instead. Some MPEG-2 Videos might have green artifacts."
 msgstr ""
 
 #: system/settings/settings.xm
 msgctxt "#13449"
-msgid "Use Mpeg-4 VAAPI"
+msgid "Use MPEG-4 VAAPI"
 msgstr ""
 
-#. Description of setting "Videos -> Playback -> Use Mpeg-4 VAAPI" with label #13449
+#. Description of setting "Videos -> Playback -> Use MPEG-4 VAAPI" with label #13449
 #: system/settings/settings.xml
 msgctxt "#13450"
-msgid "Enable this option to use hardware acceleration for the Mpeg-4 codec. If disabled the CPU will be used instead."
+msgid "Enable this option to use hardware acceleration for the MPEG-4 codec. If disabled the CPU will be used instead."
 msgstr ""
 
 #: system/settings/settings.xm


### PR DESCRIPTION
See title.
