### PR TITLE
[osxsink/iossink] - don't block addpackets if ca didn't do the initial d...

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.cpp
@@ -237,10 +237,16 @@ unsigned int CAAudioUnitSink::write(uint8_t *data, unsigned int frames)
   if (m_buffer->GetWriteSize() < frames * m_frameSize)
   { // no space to write - wait for a bit
     CSingleLock lock(mutex);
+    unsigned int timeout = 900 * frames / m_sampleRate;
     if (!m_started)
-      condVar.wait(lock);
-    else
-      condVar.wait(lock, 900 * frames / m_sampleRate);
+      timeout = 500;
+
+    // we are using a timer here for beeing sure for timeouts
+    // condvar can be woken spuriously as signaled
+    XbmcThreads::EndTime timer(timeout);
+    condVar.wait(lock, timeout);
+    if (!m_started && timer.IsTimePast())
+      return INT_MAX;
   }
 
   unsigned int write_frames = std::min(frames, m_buffer->GetWriteSize() / m_frameSize);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -561,10 +561,16 @@ unsigned int CAESinkDARWINOSX::AddPackets(uint8_t *data, unsigned int frames, bo
   if (m_buffer->GetWriteSize() < frames * m_format.m_frameSize)
   { // no space to write - wait for a bit
     CSingleLock lock(mutex);
+    unsigned int timeout = 900 * frames / m_format.m_sampleRate;
     if (!m_started)
-      condVar.wait(lock);
-    else
-      condVar.wait(lock, 900 * frames / m_format.m_sampleRate);
+      timeout = 500;
+
+    // we are using a timer here for beeing sure for timeouts
+    // condvar can be woken spuriously as signaled
+    XbmcThreads::EndTime timer(timeout);
+    condVar.wait(lock, timeout);
+    if (!m_started && timer.IsTimePast())
+      return INT_MAX;    
   }
 
   unsigned int write_frames = std::min(frames, m_buffer->GetWriteSize() / m_format.m_frameSize);


### PR DESCRIPTION
...ata pull - but timeout gracefully for signaling an error condition to the engine (use a timer for detecting a real timeout as condvar can be signaled by spurious interrupts)

This should fix a race/deadlock when unplugging cables/switching of amp/tv ...

Backport of #4322

Please wait for my go.
