### PR TITLE
[win32/libnfs] - downgrade to 1.3.0 because of issues with 1.6 on window...

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -13,7 +13,7 @@ lame_enc-3.99.5-win32.7z
 libass-0.10.2-win32.7z
 libbluray-0.4.0-win32.zip
 libjpeg-turbo-1.2.0-win32.7z
-libnfs-1.6.2-win32.7z
+libnfs-1.3.0-win32.7z
 libshairplay-c159ca7-win32.7z
 libssh-0.5.0-1-win32.zip
 libxml2-2.7.8_1-win32.7z


### PR DESCRIPTION
...s

(not able to reproduce - not able to fix)

The whole issue is discussed here:

http://forum.xbmc.org/showthread.php?tid=182638

I tried some stuff - also with the help of the upstream dev - but we didn't get it working correctly on windows. So this is the save(? hopefully) decision to downgrade libnfs for windows. Nobody really maintains that library and everytime i do anything on windows i get hairs on my teeth.

In the future the problem has to be analysed a bit more by adding printouts to the exists method i guess to see which pathes are returned to be non-existent (leading to the mass deletiion in the database) - i guess @bossanova808 would be available for doing those tests - once provided with test builds - he is the only one i know off who is able to reproduce the issue.

Gotham material or hell might brake loose after release ...

Backport of #4352
