### PR TITLE
[omxplayer] Reduce rate of clock change to reduce video stutters

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1100,7 +1100,7 @@ void COMXPlayer::Process()
     m_bAbortRequest = true;
     return;
   }
-  if(CSettings::Get().GetBool("videoplayer.adjustrefreshrate"))
+  if(CSettings::Get().GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF)
     m_av_clock.HDMIClockSync();
   m_av_clock.OMXStateIdle();
   m_av_clock.OMXStop();

--- a/xbmc/linux/OMXClock.cpp
+++ b/xbmc/linux/OMXClock.cpp
@@ -508,7 +508,7 @@ bool OMXClock::HDMIClockSync(bool lock /* = true */)
   latencyTarget.nFilter = 10;
   latencyTarget.nTarget = 0;
   latencyTarget.nShift = 3;
-  latencyTarget.nSpeedFactor = -200;
+  latencyTarget.nSpeedFactor = -60;
   latencyTarget.nInterFactor = 100;
   latencyTarget.nAdjCap = 100;
 


### PR DESCRIPTION
After analysing some files with video stutter, it was found that the filter coefficients used
for adjusting the clock were set higher than the maximum hdmi clock deviation allowed.

This means when gpu makes small clock adjustments to correct for lip-sync, the video drops frames.

With this patch the frame drops are fixed.

See here for investigation:
http://forum.xbmc.org/showthread.php?tid=185665

I think this is suitable for Gotham
