### PR TITLE
[omxplayer] Always enable timestamp fifo mode.

### DIFF
--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -591,7 +591,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, EDEINTERLACEMODE de
   // broadcom omx entension:
   // When enabled, the timestamp fifo mode will change the way incoming timestamps are associated with output images.
   // In this mode the incoming timestamps get used without re-ordering on output images.
-  if(hints.ptsinvalid)
+  // recent firmware will actually automatically choose the timestamp stream with the least variance, so always enable
   {
     OMX_CONFIG_BOOLEANTYPE timeStampMode;
     OMX_INIT_STRUCTURE(timeStampMode);


### PR DESCRIPTION
hints.ptsinvalid is only set for h264 in avi files. However it also can affect any videos with B frames in any container (we have reports of mp4 and mkv stuttering because of invalid pts values).

To solve this we always enable the timestamp fifo mode, and the gpu treats this as an optional flag, and falls back to non-fifo timestamp mode if the variance of that timestamp stream is better.

See here for information:
http://forum.stmlabs.com/showthread.php?tid=12535

I think this is suitable for Gotham.
