### PR TITLE
FIX: [touch] workaround double-click in file manager

### DIFF
--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -28,4 +28,11 @@
       <rotate>RotateGesture</rotate>
     </touch>
   </SlideShow>
+  <MyFiles>
+    <touch>
+      <tap>Select</tap>
+      <swipe direction="left">Highlight</swipe>
+      <swipe direction="right">Highlight</swipe>
+    </touch>
+  </MyFiles>
 </keymap>


### PR DESCRIPTION
Workaround the fact that we don't support double-tap (only necessary in file manager, apparently).
Ref: http://forum.xbmc.org/showthread.php?tid=188315

/cc @Memphiz @Montellese
