### PR TITLE
Use NULL from cstddef

### DIFF
--- a/xbmc/GitRevision.cpp
+++ b/xbmc/GitRevision.cpp
@@ -20,6 +20,8 @@
 
 #include "GitRevision.h"
 
+#include <cstddef>
+
 #if defined(TARGET_DARWIN) || (defined(TARGET_WINDOWS) && !defined(_DEBUG))
 #include "../git_revision.h" // generated file
 #endif


### PR DESCRIPTION
This fixes build when GIT_REV is not defined.
