### PR TITLE
[players] Skip picture attachments in video players

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3012,7 +3012,8 @@ bool CDVDPlayer::OpenVideoStream(int iStream, int source, bool reset)
   if(m_CurrentVideo.id    < 0
   || m_CurrentVideo.hint != hint)
   {
-    if (!m_dvdPlayerVideo.OpenStream(hint))
+    // discard if it's a picture attachment (e.g. album art embedded in MP3 or AAC)
+    if ((pStream->flags & AV_DISPOSITION_ATTACHED_PIC) || !m_dvdPlayerVideo.OpenStream(hint))
     {
       /* mark stream as disabled, to disallaw further attempts */
       CLog::Log(LOGWARNING, "%s - Unsupported stream %d. Stream disabled.", __FUNCTION__, iStream);

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3291,7 +3291,8 @@ bool COMXPlayer::OpenVideoStream(int iStream, int source, bool reset)
   if(m_CurrentVideo.id    < 0
   || m_CurrentVideo.hint != hint)
   {
-    if (!m_omxPlayerVideo.OpenStream(hint))
+    // discard if it's a picture attachment (e.g. album art embedded in MP3 or AAC)
+    if ((pStream->flags & AV_DISPOSITION_ATTACHED_PIC) || !m_omxPlayerVideo.OpenStream(hint))
     {
       /* mark stream as disabled, to disallaw further attempts */
       CLog::Log(LOGWARNING, "%s - Unsupported stream %d. Stream disabled.", __FUNCTION__, iStream);


### PR DESCRIPTION
Picture attachments get reported by ffmpeg as a video stream with the flag AV_DISPOSITION_ATTACHED_PIC.
You generally don't want to play these as video.
omxplayer hangs when trying to play a picture as video (as it never gets enough frames to startup).
The players also get confused with a video file with artwork, and try to play the artwork. E.g.

21:23:53  47.576946 T:2831643728    INFO: ffmpeg[A8C77450]:     Stream #0:0: Video: mjpeg, yuvj420p, 1920x1080, 90k tbr, 90k tbn, 90k tbc
21:23:53  47.578365 T:2831643728    INFO: ffmpeg[A8C77450]:     Stream #0:1: Audio: wmav2 (a[1][0][0] / 0x0161), 48000 Hz, 2 channels, fltp, 192 kb/s
21:23:53  47.579159 T:2831643728    INFO: ffmpeg[A8C77450]:     Stream #0:2: Video: wmv3 (Main) (WMV3 / 0x33564D57), yuv420p, 1920x1080, 12000 kb/s, 29.97 tbr, 1k tbn, 1k tbc

I think this is suitable for Gotham if accepted.

This bug was reported fixed with this patch:
http://forum.xbmc.org/showthread.php?tid=184866&pid=1645333#pid1645333
