### PR TITLE
[python] ensure we lock the GUI prior to calling ClearItems. Fixes #14780

### DIFF
--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -249,6 +249,7 @@ namespace XBMCAddon
     void WindowXML::clearList()
     {
       XBMC_TRACE;
+      LOCKGUI;
       A(ClearFileItems());
 
       A(m_viewControl).SetItems(*(A(m_vecItems)));


### PR DESCRIPTION
@jimfcarroll please check - should be sane enough.

(What was happening is that ClearFileItems() locks the CFileItemList lock, then iterates through and free's each item, which eventually calls into the texturemanager to release textures.  Ofcourse, the texturemanager attempts to grab the graphics lock (why not, right?  It's not as if we abuse it too much anyway...) to protect it's objects rather than having more fine-grained locks.  Meanwhile, the UI is rendering which holds graphics lock and needs to query the CFileItemList (thus attempts to grab that lock) -> deadlock.

Ideally the usage of g_graphicsContext as a mutex needs to be severely trimmed, but in the meantime, ensuring that python grabs it first will do the trick here.
