### PR TITLE
Runaddon fix - allows secondary extension points to be run

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -556,45 +556,45 @@ int CBuiltins::Execute(const CStdString& execString)
       if (CAddonMgr::Get().GetAddon(params[0],addon,ADDON_PLUGIN))
       {
         PluginPtr plugin = boost::dynamic_pointer_cast<CPluginSource>(addon);
-          CStdString addonid = params[0];
-          CStdString urlParameters;
-          CStdStringArray parameters;
-          if (params.size() == 2 &&
-             (StringUtils::StartsWith(params[1], "/") || StringUtils::StartsWith(params[1], "?")))
-            urlParameters = params[1];
-          else if (params.size() > 1)
-          {
-            parameters.insert(parameters.begin(), params.begin() + 1, params.end());
-            urlParameters = "?" + StringUtils::JoinString(parameters, "&");
-          }
-          else
-          {
-            // Add '/' if addon is run without params (will be removed later so it's safe)
-            // Otherwise there are 2 entries for the same plugin in ViewModesX.db
-            urlParameters = "/";
-          }
-
-          if (plugin->Provides(CPluginSource::VIDEO))
-            cmd = StringUtils::Format("ActivateWindow(Videos,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
-          else if (plugin->Provides(CPluginSource::AUDIO))
-            cmd = StringUtils::Format("ActivateWindow(Music,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
-          else if (plugin->Provides(CPluginSource::EXECUTABLE))
-            cmd = StringUtils::Format("ActivateWindow(Programs,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
-          else if (plugin->Provides(CPluginSource::IMAGE))
-            cmd = StringUtils::Format("ActivateWindow(Pictures,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
-          else
-            // Pass the script name (params[0]) and all the parameters
-            // (params[1] ... params[x]) separated by a comma to RunPlugin
-            cmd = StringUtils::Format("RunPlugin(%s)", StringUtils::JoinString(params, ",").c_str());
+        CStdString addonid = params[0];
+        CStdString urlParameters;
+        CStdStringArray parameters;
+        if (params.size() == 2 &&
+           (StringUtils::StartsWith(params[1], "/") || StringUtils::StartsWith(params[1], "?")))
+          urlParameters = params[1];
+        else if (params.size() > 1)
+        {
+          parameters.insert(parameters.begin(), params.begin() + 1, params.end());
+          urlParameters = "?" + StringUtils::JoinString(parameters, "&");
         }
-        else if (CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT) ||
-                 CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER) ||
-                 CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS))
-          // Pass the script name (params[0]) and all the parameters
-          // (params[1] ... params[x]) separated by a comma to RunScript
-          cmd = StringUtils::Format("RunScript(%s)", StringUtils::JoinString(params, ",").c_str());
+        else
+        {
+          // Add '/' if addon is run without params (will be removed later so it's safe)
+          // Otherwise there are 2 entries for the same plugin in ViewModesX.db
+          urlParameters = "/";
+        }
 
-        return Execute(cmd);
+        if (plugin->Provides(CPluginSource::VIDEO))
+          cmd = StringUtils::Format("ActivateWindow(Videos,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        else if (plugin->Provides(CPluginSource::AUDIO))
+          cmd = StringUtils::Format("ActivateWindow(Music,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        else if (plugin->Provides(CPluginSource::EXECUTABLE))
+          cmd = StringUtils::Format("ActivateWindow(Programs,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        else if (plugin->Provides(CPluginSource::IMAGE))
+          cmd = StringUtils::Format("ActivateWindow(Pictures,plugin://%s%s,return)", addonid.c_str(), urlParameters.c_str());
+        else
+          // Pass the script name (params[0]) and all the parameters
+          // (params[1] ... params[x]) separated by a comma to RunPlugin
+          cmd = StringUtils::Format("RunPlugin(%s)", StringUtils::JoinString(params, ",").c_str());
+      }
+      else if (CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT) ||
+               CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER) ||
+               CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS))
+        // Pass the script name (params[0]) and all the parameters
+        // (params[1] ... params[x]) separated by a comma to RunScript
+        cmd = StringUtils::Format("RunScript(%s)", StringUtils::JoinString(params, ",").c_str());
+
+      return Execute(cmd);
     }
     else
     {

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -552,12 +552,10 @@ int CBuiltins::Execute(const CStdString& execString)
     if (params.size())
     {
       AddonPtr addon;
-      if (CAddonMgr::Get().GetAddon(params[0],addon) && addon)
+      CStdString cmd;
+      if (CAddonMgr::Get().GetAddon(params[0],addon,ADDON_PLUGIN))
       {
         PluginPtr plugin = boost::dynamic_pointer_cast<CPluginSource>(addon);
-        CStdString cmd;
-        if (plugin && addon->Type() == ADDON_PLUGIN)
-        {
           CStdString addonid = params[0];
           CStdString urlParameters;
           CStdStringArray parameters;
@@ -589,13 +587,14 @@ int CBuiltins::Execute(const CStdString& execString)
             // (params[1] ... params[x]) separated by a comma to RunPlugin
             cmd = StringUtils::Format("RunPlugin(%s)", StringUtils::JoinString(params, ",").c_str());
         }
-        else if (addon->Type() >= ADDON_SCRIPT && addon->Type() <= ADDON_SCRIPT_LYRICS)
+        else if (CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT) ||
+                 CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER) ||
+                 CAddonMgr::Get().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS))
           // Pass the script name (params[0]) and all the parameters
           // (params[1] ... params[x]) separated by a comma to RunScript
           cmd = StringUtils::Format("RunScript(%s)", StringUtils::JoinString(params, ",").c_str());
 
         return Execute(cmd);
-      }
     }
     else
     {


### PR DESCRIPTION
This assumes that RunAddon() applies only to scripts, plugins, lyrics, weather which is what the code did before.

IMO we need to reconsider the existing multiple-addon support.  There's a number of issues with it, primarily that once you have an add-on object you have no idea if that add-on object has other things associated with it.  i.e. addon->Type() is basically useless except to tell you the particular sub-addon that you have.

I'm not sure that extending CAddon so that you know the other types would be enough to resolve the existing issues (e.g. http://trac.xbmc.org/ticket/14609)

@ronie, @BigNoid, @Black09 needs some decent testing :)
