### PR TITLE
FIX: [mediacodec] blacklist rockchip non-standard components

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -74,6 +74,16 @@ static bool IsBlacklisted(const std::string &name)
   static const char *blacklisted_decoders[] = {
     // No software decoders
     "OMX.google",
+    // For Rockchip non-standard components
+    "AVCDecoder",
+    "AVCDecoder_FLASH",
+    "FLVDecoder",
+    "M2VDecoder",
+    "M4vH263Decoder",
+    "RVDecoder",
+    "VC1Decoder",
+    "VPXDecoder",
+    // End of Rockchip
     NULL
   };
   for (const char **ptr = blacklisted_decoders; *ptr; ptr++)


### PR DESCRIPTION
Ref (e.g.): http://forum.xbmc.org/showthread.php?tid=168268&pid=1646828#pid1646828
I know from experience those rockchip components use the mediacodec interface but return proprietary, non-compliant, strctures pointing to vpu buffers.

/cc @davilla 
