### PR TITLE
[epg] adjust title to the left edge for the first items in timeline view

### DIFF
--- a/addons/skin.confluence/720p/ViewsPVR.xml
+++ b/addons/skin.confluence/720p/ViewsPVR.xml
@@ -983,9 +983,9 @@
 						<texture border="3">epg-genres/$INFO[ListItem.Property(GenreType)].png</texture>
 					</control>
 					<control type="label" id="1">
-						<left>6</left>
+						<left>10</left>
 						<top>3</top>
-						<width>30</width>
+						<width>20</width>
 						<height>25</height>
 						<font>font12</font>
 						<aligny>center</aligny>
@@ -1027,9 +1027,9 @@
 						<texture border="3">epg-genres/$INFO[ListItem.Property(GenreType)].png</texture>
 					</control>
 					<control type="label" id="1">
-						<left>6</left>
+						<left>10</left>
 						<top>3</top>
-						<width>30</width>
+						<width>20</width>
 						<height>25</height>
 						<font>font12</font>
 						<aligny>center</aligny>

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -411,21 +411,35 @@ void CGUIEPGGridContainer::ProcessProgrammeGrid(unsigned int currentTime, CDirty
 
       bool focused = (channel == m_channelOffset + m_channelCursor) && (item == m_gridIndex[m_channelOffset + m_channelCursor][m_blockOffset + m_blockCursor].item);
 
-      if (m_orientation == VERTICAL)
-        ProcessItem(posA2, posB, item.get(), m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridIndex[channel][block].width);
-      else
-        ProcessItem(posB, posA2, item.get(), m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridIndex[channel][block].height);
+      // calculate the size to truncate if item is out of grid view
+      float truncateSize = 0;
+      if (posA2 < posA)
+      {
+        truncateSize = posA - posA2;
+        posA2 = posA; // reset to grid start position
+      }
 
-      // increment our X position
       if (m_orientation == VERTICAL)
       {
+        // truncate item's width
+        m_gridIndex[channel][block].width = m_gridIndex[channel][block].originWidth - truncateSize;
+
+        ProcessItem(posA2, posB, item.get(), m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridIndex[channel][block].width);
+
+        // increment our X position
         posA2 += m_gridIndex[channel][block].width; // assumes focused & unfocused layouts have equal length
-        block += (int)(m_gridIndex[channel][block].width / m_blockSize);
+        block += (int)(m_gridIndex[channel][block].originWidth / m_blockSize);
       }
       else
       {
+        // truncate item's height
+        m_gridIndex[channel][block].height = m_gridIndex[channel][block].originHeight - truncateSize;
+
+        ProcessItem(posB, posA2, item.get(), m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridIndex[channel][block].height);
+
+        // increment our X position
         posA2 += m_gridIndex[channel][block].height; // assumes focused & unfocused layouts have equal length
-        block += (int)(m_gridIndex[channel][block].height / m_blockSize);
+        block += (int)(m_gridIndex[channel][block].originHeight / m_blockSize);
       }
     }
 
@@ -494,6 +508,10 @@ void CGUIEPGGridContainer::RenderProgrammeGrid()
 
       bool focused = (channel == m_channelOffset + m_channelCursor) && (item == m_gridIndex[m_channelOffset + m_channelCursor][m_blockOffset + m_blockCursor].item);
 
+      // reset to grid start position if first item is out of grid view
+      if (posA2 < posA)
+        posA2 = posA;
+
       // render our item
       if (focused)
       {
@@ -521,12 +539,12 @@ void CGUIEPGGridContainer::RenderProgrammeGrid()
       if (m_orientation == VERTICAL)
       {
         posA2 += m_gridIndex[channel][block].width; // assumes focused & unfocused layouts have equal length
-        block += (int)(m_gridIndex[channel][block].width / m_blockSize);
+        block += (int)(m_gridIndex[channel][block].originWidth / m_blockSize);
       }
       else
       {
         posA2 += m_gridIndex[channel][block].height; // assumes focused & unfocused layouts have equal length
-        block += (int)(m_gridIndex[channel][block].height / m_blockSize);
+        block += (int)(m_gridIndex[channel][block].originHeight / m_blockSize);
       }
     }
 
@@ -596,17 +614,18 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, CGUIListItem* ite
     if (!item->GetFocusedLayout())
     {
       CGUIListItemLayout *layout = new CGUIListItemLayout(*focusedlayout);
-      if (resize != -1.0f)
-      {
-        if (m_orientation == VERTICAL)
-          layout->SetWidth(resize);
-        else
-          layout->SetHeight(resize);
-      }
       item->SetFocusedLayout(layout);
     }
     if (item->GetFocusedLayout())
     {
+      if (resize != -1.0f)
+      {
+        if (m_orientation == VERTICAL)
+          item->GetFocusedLayout()->SetWidth(resize);
+        else
+          item->GetFocusedLayout()->SetHeight(resize);
+      }
+
       if (item != lastitem || !HasFocus())
       {
         item->GetFocusedLayout()->SetFocusedItem(0);
@@ -630,15 +649,17 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, CGUIListItem* ite
     if (!item->GetLayout())
     {
       CGUIListItemLayout *layout = new CGUIListItemLayout(*normallayout);
-      if (resize != -1.0f)
-      {
-        if (m_orientation == VERTICAL)
-          layout->SetWidth(resize);
-        else
-          layout->SetHeight(resize);
-      }
       item->SetLayout(layout);
     }
+
+    if (resize != -1.0f)
+    {
+      if (m_orientation == VERTICAL)
+        item->GetLayout()->SetWidth(resize);
+      else
+        item->GetLayout()->SetHeight(resize);
+    }
+
     if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
       item->GetFocusedLayout()->Process(item,m_parentID,currentTime,dirtyregions);
     else if (item->GetLayout())
@@ -983,14 +1004,17 @@ void CGUIEPGGridContainer::UpdateItems()
 
         if (m_orientation == VERTICAL)
         {
-          m_gridIndex[row][savedBlock].width   = itemSize*m_blockSize;
-          m_gridIndex[row][savedBlock].height  = m_channelHeight;
+          m_gridIndex[row][savedBlock].originWidth = itemSize*m_blockSize;
+          m_gridIndex[row][savedBlock].originHeight = m_channelHeight;
         }
         else
         {
-          m_gridIndex[row][savedBlock].width   = m_channelWidth;
-          m_gridIndex[row][savedBlock].height  = itemSize*m_blockSize;
+          m_gridIndex[row][savedBlock].originWidth = m_channelWidth;
+          m_gridIndex[row][savedBlock].originHeight = itemSize*m_blockSize;
         }
+
+        m_gridIndex[row][savedBlock].width = m_gridIndex[row][savedBlock].originWidth;
+        m_gridIndex[row][savedBlock].height = m_gridIndex[row][savedBlock].originHeight;
 
         itemSize = 1;
         savedBlock = block+1;

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -616,36 +616,32 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, CGUIListItem* ite
       CGUIListItemLayout *layout = new CGUIListItemLayout(*focusedlayout);
       item->SetFocusedLayout(layout);
     }
-    if (item->GetFocusedLayout())
-    {
-      if (resize != -1.0f)
-      {
-        if (m_orientation == VERTICAL)
-          item->GetFocusedLayout()->SetWidth(resize);
-        else
-          item->GetFocusedLayout()->SetHeight(resize);
-      }
 
-      if (item != lastitem || !HasFocus())
-      {
-        item->GetFocusedLayout()->SetFocusedItem(0);
-      }
-      if (item != lastitem && HasFocus())
-      {
-        item->GetFocusedLayout()->ResetAnimation(ANIM_TYPE_UNFOCUS);
-        unsigned int subItem = 1;
-        if (lastitem && lastitem->GetFocusedLayout())
-          subItem = lastitem->GetFocusedLayout()->GetFocusedItem();
-        item->GetFocusedLayout()->SetFocusedItem(subItem ? subItem : 1);
-      }
-      item->GetFocusedLayout()->Process(item,m_parentID,currentTime,dirtyregions);
+    if (resize != -1.0f)
+    {
+      if (m_orientation == VERTICAL)
+        item->GetFocusedLayout()->SetWidth(resize);
+      else
+        item->GetFocusedLayout()->SetHeight(resize);
     }
+
+    if (item != lastitem || !HasFocus())
+      item->GetFocusedLayout()->SetFocusedItem(0);
+
+    if (item != lastitem && HasFocus())
+    {
+      item->GetFocusedLayout()->ResetAnimation(ANIM_TYPE_UNFOCUS);
+      unsigned int subItem = 1;
+      if (lastitem && lastitem->GetFocusedLayout())
+        subItem = lastitem->GetFocusedLayout()->GetFocusedItem();
+      item->GetFocusedLayout()->SetFocusedItem(subItem ? subItem : 1);
+    }
+
+    item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
     lastitem = item;
   }
   else
   {
-    if (item->GetFocusedLayout())
-      item->GetFocusedLayout()->SetFocusedItem(0);  // focus is not set
     if (!item->GetLayout())
     {
       CGUIListItemLayout *layout = new CGUIListItemLayout(*normallayout);
@@ -660,10 +656,13 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, CGUIListItem* ite
         item->GetLayout()->SetHeight(resize);
     }
 
+    if (item->GetFocusedLayout())
+      item->GetFocusedLayout()->SetFocusedItem(0);
+
     if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
-      item->GetFocusedLayout()->Process(item,m_parentID,currentTime,dirtyregions);
-    else if (item->GetLayout())
-      item->GetLayout()->Process(item,m_parentID,currentTime,dirtyregions);
+      item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
+    else
+      item->GetLayout()->Process(item, m_parentID, currentTime, dirtyregions);
   }
   g_graphicsContext.RestoreOrigin();
 }

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -39,6 +39,8 @@ namespace EPG
   struct GridItemsPtr
   {
     CGUIListItemPtr item;
+    float originWidth;
+    float originHeight;
     float width;
     float height;
   };

--- a/xbmc/guilib/GUIListGroup.cpp
+++ b/xbmc/guilib/GUIListGroup.cpp
@@ -126,7 +126,7 @@ void CGUIListGroup::EnlargeWidth(float difference)
     {
       if (child->GetID() == 1) // label
       {
-        child->SetWidth(child->GetWidth() + difference - 10);
+        child->SetWidth(child->GetWidth() + difference);
         child->SetVisible(child->GetWidth() > 10); ///
       }
       else

--- a/xbmc/guilib/GUIListGroup.cpp
+++ b/xbmc/guilib/GUIListGroup.cpp
@@ -118,16 +118,16 @@ void CGUIListGroup::UpdateInfo(const CGUIListItem *item)
 
 void CGUIListGroup::EnlargeWidth(float difference)
 {
-  // Alters the width of the controls that have an ID of 1
+  // Alters the width of the controls that have an ID of 1 to 14
   for (iControls it = m_children.begin(); it != m_children.end(); it++)
   {
     CGUIControl *child = *it;
     if (child->GetID() >= 1 && child->GetID() <= 14)
     {
-      if (child->GetID() == 1) // label
+      if (child->GetID() == 1)
       {
         child->SetWidth(child->GetWidth() + difference);
-        child->SetVisible(child->GetWidth() > 10); ///
+        child->SetVisible(child->GetWidth() > 10);
       }
       else
       {
@@ -140,16 +140,16 @@ void CGUIListGroup::EnlargeWidth(float difference)
 
 void CGUIListGroup::EnlargeHeight(float difference)
 {
-  // Alters the width of the controls that have an ID of 1
+  // Alters the height of the controls that have an ID of 1 to 14
   for (iControls it = m_children.begin(); it != m_children.end(); it++)
   {
     CGUIControl *child = *it;
     if (child->GetID() >= 1 && child->GetID() <= 14)
     {
-      if (child->GetID() == 1) // label
+      if (child->GetID() == 1)
       {
         child->SetHeight(child->GetHeight() + difference);
-        child->SetVisible(child->GetHeight() > 10); ///
+        child->SetVisible(child->GetHeight() > 10);
       }
       else
       {

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -111,7 +111,7 @@ void CGUIListLabel::SetWidth(float width)
   else if (m_label.GetLabelInfo().align & XBFONT_CENTER_X)
     m_label.SetMaxRect(m_posX - m_width*0.5f, m_posY, m_width, m_height);
   else
-    m_label.SetMaxRect(m_posX, m_posY, m_posX + m_width, m_posY + m_height);
+    m_label.SetMaxRect(m_posX, m_posY, m_width, m_height);
   CGUIControl::SetWidth(m_width);
 }
 


### PR DESCRIPTION
This adjust the title of the first item in EPG timeline view if you scroll so it always starts at the left edge of the programme grid.

![screenshot000](https://f.cloud.github.com/assets/1878991/2365875/bc24bf4a-a6e3-11e3-8148-79eff91d70c2.png)

Hell, it's done ;)
