### PR TITLE
Fix compiler warning

### DIFF
--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -465,7 +465,7 @@ JSONRPC_STATUS CAudioLibrary::SetAlbumDetails(const CStdString &method, ITranspo
   if (ParameterNotNull(parameterObject, "year"))
     album.iYear = (int)parameterObject["year"].asInteger();
 
-  if (musicdatabase.UpdateAlbum(album) <= 0)
+  if (!musicdatabase.UpdateAlbum(album))
     return InternalError;
 
   CJSONRPCUtils::NotifyItemUpdated();


### PR DESCRIPTION
Fix compiler warning:
xbmc\interfaces\json-rpc\AudioLibrary.cpp(468): warning C4804: '<=' :
unsafe use of type 'bool' in operation
UpdateAlbum(album) returns a bool, the other overload returns an int.
