### PR TITLE
[Confluence] Textbox fixes for ok | yes/no | progress dialog

### DIFF
--- a/addons/skin.confluence/720p/DialogOK.xml
+++ b/addons/skin.confluence/720p/DialogOK.xml
@@ -62,7 +62,7 @@
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>
-			<autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+			<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
 		</control>
 		<control type="button" id="10">
 			<description>OK button</description>

--- a/addons/skin.confluence/720p/DialogOK.xml
+++ b/addons/skin.confluence/720p/DialogOK.xml
@@ -58,7 +58,7 @@
 			<left>30</left>
 			<top>60</top>
 			<width>550</width>
-			<height>80</height>
+			<height>100</height>
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>

--- a/addons/skin.confluence/720p/DialogProgress.xml
+++ b/addons/skin.confluence/720p/DialogProgress.xml
@@ -71,7 +71,7 @@
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>
-			<autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+			<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
 		</control>
 		<control type="progress">
 			<description>Progressbar</description>

--- a/addons/skin.confluence/720p/DialogYesNo.xml
+++ b/addons/skin.confluence/720p/DialogYesNo.xml
@@ -62,7 +62,7 @@
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>
-			<autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
+			<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
 		</control>
 		<control type="button" id="11">
 			<description>Yes button</description>

--- a/addons/skin.confluence/720p/DialogYesNo.xml
+++ b/addons/skin.confluence/720p/DialogYesNo.xml
@@ -58,7 +58,7 @@
 			<left>30</left>
 			<top>60</top>
 			<width>550</width>
-			<height>80</height>
+			<height>100</height>
 			<align>left</align>
 			<label>-</label>
 			<font>font13</font>


### PR DESCRIPTION
This changes the height of the OK and Yes/No dialog to fit one extra line (not for progress as that wont fit). Also I set the autoscroll option to true, as the textboxes should always scroll in those dialogs even if the user disabled auto scroll in skin settings. Fixes #15002.

I PR'd against master as its a trivial change. 
