### PR TITLE
[osxsink] - fix deadloop in drain

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.cpp
@@ -244,7 +244,7 @@ unsigned int CAAudioUnitSink::write(uint8_t *data, unsigned int frames)
     // we are using a timer here for beeing sure for timeouts
     // condvar can be woken spuriously as signaled
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(lock, timeout);
+    condVar.wait(mutex, timeout);
     if (!m_started && timer.IsTimePast())
       return INT_MAX;
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -632,7 +632,7 @@ unsigned int CAESinkDARWINOSX::AddPackets(uint8_t *data, unsigned int frames, bo
     // we are using a timer here for beeing sure for timeouts
     // condvar can be woken spuriously as signaled
     XbmcThreads::EndTime timer(timeout);
-    condVar.wait(lock, timeout);
+    condVar.wait(mutex, timeout);
     if (!m_started && timer.IsTimePast())
       return INT_MAX;    
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -647,11 +647,21 @@ unsigned int CAESinkDARWINOSX::AddPackets(uint8_t *data, unsigned int frames, bo
 void CAESinkDARWINOSX::Drain()
 {
   int bytes = m_buffer->GetReadSize();
-  while (bytes)
+  int totalBytes = bytes;
+  int maxNumTimeouts = 3;
+  unsigned int timeout = 900 * bytes / (m_format.m_sampleRate * m_format.m_frameSize);
+  while (bytes && maxNumTimeouts > 0)
   {
     CSingleLock lock(mutex);
-    condVar.wait(mutex, 900 * bytes / (m_format.m_sampleRate * m_format.m_frameSize));
+    XbmcThreads::EndTime timer(timeout);
+    condVar.wait(mutex, timeout);
+
     bytes = m_buffer->GetReadSize();
+    // if we timeout and don't
+    // consum bytes - decrease maxNumTimeouts
+    if (timer.IsTimePast() && bytes == totalBytes)
+      maxNumTimeouts--;
+    totalBytes = bytes;
   }
 }
 


### PR DESCRIPTION
When cables are unplugged or tv is powered down the device vanishes and we might end up in an endless loop when the Engine tries to drain the sink.

This was confirmed fixing some tv poweroff/cable unplug issues as described here:

http://forum.xbmc.org/showthread.php?tid=185395
