### PR TITLE
Make URIUtils::IsInPath case insensitive

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -42,7 +42,7 @@ bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
 {
   CStdString uriPath = CSpecialProtocol::TranslatePath(uri);
   CStdString basePath = CSpecialProtocol::TranslatePath(baseURI);
-  return StringUtils::StartsWith(uriPath, basePath);
+  return StringUtils::StartsWithNoCase(uriPath, basePath);
 }
 
 /* returns filename extension including period of filename */


### PR DESCRIPTION
This fix mainly /vfs http handler to allow access to file in sources that where recreated with a different case.
(In this case an update / rescrape will not update the path if only the case changes)

This keep the behavior in sync with CUtil::GetMatchingSource and all other use case.

@Montellese for review (and if possible Gotham include)
