### PR TITLE
[epg] fix scrolling in grid if last item ends on next page

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -43,6 +43,7 @@ using namespace std;
 #define SHORTGAP     5 // how many blocks is considered a short-gap in nav logic
 #define MINSPERBLOCK 5 /// would be nice to offer zooming of busy schedules /// performance cost to increase resolution 5 fold?
 #define BLOCKJUMP    4 // how many blocks are jumped with each analogue scroll action
+#define BLOCK_SCROLL_OFFSET 60 / MINSPERBLOCK // how many blocks are jumped if we are at left/right edge of grid
 
 CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width,
                                            float height, ORIENTATION orientation, int scrollTime,
@@ -1128,41 +1129,12 @@ bool CGUIEPGGridContainer::MoveProgrammes(bool direction)
     }
     else if (m_blockCursor <= 0 && m_blockOffset)
     {
-      // we're at the left edge and offset
-      int itemSize = GetItemSize(m_item);
-      int block = GetRealBlock(m_item->item, m_channelCursor);
+      if (m_blockOffset - BLOCK_SCROLL_OFFSET < 0)
+        return false;
 
-      if (block < m_blockOffset) /* current item begins before current offset, keep selected */
-      {
-        if (itemSize > m_blocksPerPage) /* current item is longer than one page, scroll one page left */
-        {
-          m_blockOffset < m_blocksPerPage ? block = 0 : block = m_blockOffset - m_blocksPerPage; // number blocks left < m_blocksPerPAge
-          ScrollToBlockOffset(block);
-          SetBlock(0);
-        }
-        else /* current item is shorter than one page, scroll left to start of item */
-        {
-          ScrollToBlockOffset(block); // -1?
-          SetBlock(0); // align cursor to left edge
-        }
-      }
-      else /* current item starts on this page's edge, select the previous item */
-      {
-        m_item = GetPrevItem(m_channelCursor);
-        itemSize = GetItemSize(m_item);
-
-        if (itemSize > m_blocksPerPage) // previous item is longer than one page, scroll left to last page of item */
-        {
-          ScrollToBlockOffset(m_blockOffset - m_blocksPerPage); // left one whole page
-          //SetBlock(m_blocksPerPage -1 ); // helps navigation by setting cursor to far right edge
-          SetBlock(0); // align cursor to left edge
-        }
-        else /* previous item is shorter than one page, scroll left to start of item */
-        {
-          ScrollToBlockOffset(m_blockOffset - itemSize);
-          SetBlock(0); //should be zero
-        }
-      }
+      // this is the first item on page
+      ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
+      SetBlock(GetBlock(m_item->item, m_channelCursor));
     }
     else
       return false;
@@ -1177,45 +1149,12 @@ bool CGUIEPGGridContainer::MoveProgrammes(bool direction)
     }
     else if ((m_blockOffset != m_blocks - m_blocksPerPage) && m_blocks > m_blocksPerPage)
     {
-      // at right edge, more than one page and not at maximum offset
-      int itemSize = GetItemSize(m_item);
-      int block = GetRealBlock(m_item->item, m_channelCursor);
-
-      if (itemSize > m_blocksPerPage - m_blockCursor) // current item extends into next page, keep selected
-      {
-        if (itemSize > m_blocksPerPage) // current item is longer than one page, scroll one page right
-        {
-          if (m_blockOffset && m_blockOffset + m_blocksPerPage > m_blocks)
-            block = m_blocks - m_blocksPerPage;
-          else
-            block = m_blockOffset + m_blocksPerPage;
-
-          ScrollToBlockOffset(block);
-
-          SetBlock(0);
-        }
-        else // current item is shorter than one page, scroll so end of item sits on end of grid
-        {
-          ScrollToBlockOffset(block + itemSize - m_blocksPerPage);
-          SetBlock(GetBlock(m_item->item, m_channelCursor)); /// change to middle block of item?
-        }
-      }
-      else // current item finishes on this page's edge, select the next item
-      {
-        m_item = GetNextItem(m_channelCursor);
-        itemSize = GetItemSize(m_item);
-
-        if (itemSize > m_blocksPerPage) // next item is longer than one page, scroll to first page of this item
-        {
-          ScrollToBlockOffset(m_blockOffset + m_blocksPerPage);
-          SetBlock(0);
-        }
-        else // next item is shorter than one page, scroll so end of item sits on end of grid
-        {
-          ScrollToBlockOffset(m_blockOffset + itemSize);
-          SetBlock(m_blocksPerPage - itemSize); /// change to middle block of item?
-        }
-      }
+      if (m_blockOffset + BLOCK_SCROLL_OFFSET > m_blocks)
+        return false;
+      
+      // this is the last item on page
+      ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
+      SetBlock(GetBlock(m_item->item, m_channelCursor));
     }
     else
       return false;


### PR DESCRIPTION
This improves the navigation in epg timeline grid and solves the issue that you can't scroll an item which ends on the next page.

Bug report at http://forum.xbmc.org/showthread.php?tid=178697
