### PR TITLE
[pvr] fix: password prompt appears twice if set icon in channel manager

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -312,8 +312,6 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
     return false;
   if (CProfilesManager::Get().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
     return false;
-  else if (!g_passwordManager.IsMasterLockUnlocked(true))
-    return false;
 
   // setup our thumb list
   CFileItemList items;


### PR DESCRIPTION
If masterlock code is set and an user wants to change the channel icon in channel manager the password dialogs appears twice.

@alexmaloteaux .. i've separated this from #4227, thanks.
