### PR TITLE
Album info files view was broken

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -321,6 +321,17 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
     return;
   }
 
+  int albumID = m_musicdatabase.GetAlbumIdByPath(pItem->GetPath());
+  if (albumID != -1)
+  {
+    CAlbum album;
+    if (!m_musicdatabase.GetAlbum(albumID, album))
+      return;
+    CFileItem item(StringUtils::Format("musicdb://albums/%ld/", albumID), album);
+    if (ShowAlbumInfo(&item))
+      return;
+  }
+
   CFileItemList items;
   GetDirectory(pItem->GetPath(), items);
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -332,43 +332,7 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
       return;
   }
 
-  CFileItemList items;
-  GetDirectory(pItem->GetPath(), items);
-
-  // show dialog box indicating we're searching the album name
-  if (m_dlgProgress && bShowInfo)
-  {
-    m_dlgProgress->SetHeading(185);
-    m_dlgProgress->SetLine(0, 501);
-    m_dlgProgress->SetLine(1, "");
-    m_dlgProgress->SetLine(2, "");
-    m_dlgProgress->StartModal();
-    m_dlgProgress->Progress();
-    if (m_dlgProgress->IsCanceled())
-    {
-      return;
-    }
-  }
-
-  // check the first song we find in the folder, and grab its album info
-  for (int i = 0; i < items.Size(); i++)
-  {
-    CFileItemPtr pItem = items[i];
-    pItem->LoadMusicTag();
-    if (pItem->HasMusicInfoTag() && pItem->GetMusicInfoTag()->Loaded() &&
-       !pItem->GetMusicInfoTag()->GetAlbum().empty())
-    {
-      if (m_dlgProgress && bShowInfo)
-        m_dlgProgress->Close();
-
-      if (!ShowAlbumInfo(pItem.get())) // Something went wrong, so bail for the rest
-        break;
-    }
-  }
-
-  CLog::Log(LOGINFO, "%s called on a folder containing no songs with tag info - nothing can be done", __FUNCTION__);
-  if (m_dlgProgress && bShowInfo)
-      m_dlgProgress->Close();
+  CLog::Log(LOGINFO, "%s called on a folder containing no songs in the library - nothing can be done", __FUNCTION__);
 }
 
 void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo /* = true */)

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -329,9 +329,7 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
         else if (!item->IsParentFolder() &&
                  !StringUtils::StartsWithNoCase(item->GetPath(), "new") && item->m_bIsFolder)
         {
-#if 0
           if (m_musicdatabase.GetAlbumIdByPath(item->GetPath()) > -1)
-#endif
             buttons.Add(CONTEXT_BUTTON_INFO, 13351); // Album Info
         }
       }


### PR DESCRIPTION
With the new library stuff, albums require songs in the library.  Thus, only show the album information item in context if this is the case.

Further, drop the old code as it's no longer needed.

@t-nelson please take a look.

@night199uk if you have time, a look would be good.
