### PR TITLE
Fix: Header guard in GUIControlFactor.h had a typo.

### DIFF
--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -4,7 +4,7 @@
 */
 
 #ifndef GUI_CONTROL_FACTORY_H
-#define GIU_CONTROL_FACTORY_H
+#define GUI_CONTROL_FACTORY_H
 
 #pragma once
 


### PR DESCRIPTION
This was found by a new warning class in clang5.1
