### PR TITLE
fixed: Don't try to delete file when it doesn't exist

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1004,9 +1004,8 @@ bool CCurlFile::OpenForWrite(const CURL& url, bool bOverWrite)
 
   g_curlInterface.multi_add_handle(m_state->m_multiHandle, m_state->m_easyHandle);
 
-  m_state->SetReadBuffer(NULL, 0);
-
-  return true;
+  // Make sure we can write:
+  return (Write(NULL, 0) != -1);
 }
 
 int CCurlFile::Write(const void* lpBuf, int64_t uiBufSize)

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -149,7 +149,6 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
     url.SetOptions("?cache=no");
   if (file.Open(url.Get(), READ_TRUNCATED))
   {
-
     CFile newFile;
     if (URIUtils::IsHD(strDest)) // create possible missing dirs
     {
@@ -260,7 +259,11 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
     /* verify that we managed to completed the file */
     if (llFileSize && llPos != llFileSize)
     {
-      CFile::Delete(strDest);
+      // If file *really* exists, delete it, else just remove from dircache
+      if (CFile::Exists(strDest, true))
+        CFile::Delete(strDest);
+      else
+        g_directoryCache.ClearFile(strDest);
       return false;
     }
     return true;


### PR DESCRIPTION
I found this one by accident. No biggie, but it's nice to get rid of the log spam.
