### PR TITLE
[omxplayer] When setting fullscreen flag we don't want noaspect

### DIFF
--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -838,19 +838,24 @@ void COMXVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
   configDisplay.fullscreen = OMX_FALSE;
   configDisplay.noaspect   = OMX_TRUE;
 
-  configDisplay.set                 = (OMX_DISPLAYSETTYPE)(OMX_DISPLAY_SET_DEST_RECT|OMX_DISPLAY_SET_SRC_RECT|OMX_DISPLAY_SET_FULLSCREEN|OMX_DISPLAY_SET_NOASPECT);
-  configDisplay.dest_rect.x_offset  = (int)(DestRect.x1+0.5f);
-  configDisplay.dest_rect.y_offset  = (int)(DestRect.y1+0.5f);
-  configDisplay.dest_rect.width     = (int)(DestRect.Width()+0.5f);
-  configDisplay.dest_rect.height    = (int)(DestRect.Height()+0.5f);
+  if (configDisplay.dest_rect.width == 0 || configDisplay.dest_rect.height == 0)
+  {
+    configDisplay.set                 = OMX_DISPLAY_SET_FULLSCREEN;
+    configDisplay.fullscreen          = OMX_TRUE;
+  }
+  else
+  {
+    configDisplay.set                 = (OMX_DISPLAYSETTYPE)(OMX_DISPLAY_SET_DEST_RECT|OMX_DISPLAY_SET_SRC_RECT|OMX_DISPLAY_SET_NOASPECT);
+    configDisplay.dest_rect.x_offset  = (int)(DestRect.x1+0.5f);
+    configDisplay.dest_rect.y_offset  = (int)(DestRect.y1+0.5f);
+    configDisplay.dest_rect.width     = (int)(DestRect.Width()+0.5f);
+    configDisplay.dest_rect.height    = (int)(DestRect.Height()+0.5f);
 
-  configDisplay.src_rect.x_offset   = (int)(SrcRect.x1+0.5f);
-  configDisplay.src_rect.y_offset   = (int)(SrcRect.y1+0.5f);
-  configDisplay.src_rect.width      = (int)(SrcRect.Width()+0.5f);
-  configDisplay.src_rect.height     = (int)(SrcRect.Height()+0.5f);
-
-  configDisplay.fullscreen          = configDisplay.dest_rect.width == 0 || configDisplay.dest_rect.width == 0 ? OMX_TRUE : OMX_FALSE;
-
+    configDisplay.src_rect.x_offset   = (int)(SrcRect.x1+0.5f);
+    configDisplay.src_rect.y_offset   = (int)(SrcRect.y1+0.5f);
+    configDisplay.src_rect.width      = (int)(SrcRect.Width()+0.5f);
+    configDisplay.src_rect.height     = (int)(SrcRect.Height()+0.5f);
+  }
   m_omx_render.SetConfig(OMX_IndexConfigDisplayRegion, &configDisplay);
 
   CLog::Log(LOGDEBUG, "dest_rect.x_offset %d dest_rect.y_offset %d dest_rect.width %d dest_rect.height %d\n",


### PR DESCRIPTION
We set the fullscreen on 3d videos to avoid scaling breaking the 3d affect.
However we also set the noaspect flag which means widescreen videos (e.g. 1920x800) will get stretched vertically which is unwanted.

For Gotham. See http://forum.xbmc.org/showthread.php?tid=184866&pid=1650640#pid1650640 for bug report that is fixed with this patch.
