### PR TITLE
JSON-RPC: fix resetting a datetime property through VideoLibrary.SetFooDetails

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONUtils.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 
 #include "JSONRPCUtils.h"
+#include "XBDateTime.h"
 #include "utils/SortUtils.h"
 #include "interfaces/IAnnouncer.h"
 #include "playlists/SmartPlayList.h"
@@ -517,6 +518,28 @@ namespace JSONRPC
       stringArray.clear();
       for (CVariant::const_iterator_array it = jsonStringArray.begin_array(); it != jsonStringArray.end_array(); it++)
         stringArray.push_back(it->asString());
+    }
+
+    static void SetFromDBDate(const CVariant &jsonDate, CDateTime &date)
+    {
+      if (!jsonDate.isString())
+        return;
+
+      if (jsonDate.empty())
+        date.Reset();
+      else
+        date.SetFromDBDate(jsonDate.asString());
+    }
+
+    static void SetFromDBDateTime(const CVariant &jsonDate, CDateTime &date)
+    {
+      if (!jsonDate.isString())
+        return;
+
+      if (jsonDate.empty())
+        date.Reset();
+      else
+        date.SetFromDBDateTime(jsonDate.asString());
     }
 
     static bool GetXspFiltering(const CStdString &type, const CVariant &filter, CStdString &xsp)

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -568,9 +568,6 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const CStdString &method, ITransp
   std::map<int, std::map<std::string, std::string> > seasonArt;
   videodatabase.GetTvShowSeasonArt(infos.m_iDbId, seasonArt);
 
-  int playcount = infos.m_playCount;
-  CDateTime lastPlayed = infos.m_lastPlayed;
-
   std::set<std::string> removedArtwork;
   UpdateVideoTag(parameterObject, infos, artwork, removedArtwork);
 
@@ -583,14 +580,6 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const CStdString &method, ITransp
 
   if (!videodatabase.RemoveArtForItem(infos.m_iDbId, "tvshow", removedArtwork))
     return InternalError;
-
-  if (playcount != infos.m_playCount || lastPlayed != infos.m_lastPlayed)
-  {
-    // restore original playcount or the new one won't be announced
-    int newPlaycount = infos.m_playCount;
-    infos.m_playCount = playcount;
-    videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
-  }
 
   CJSONRPCUtils::NotifyItemUpdated();
   return ACK;

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -507,7 +507,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const CStdString &method, ITranspo
     // restore original playcount or the new one won't be announced
     int newPlaycount = infos.m_playCount;
     infos.m_playCount = playcount;
-    videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
+    videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed);
   }
 
   UpdateResumePoint(parameterObject, infos, videodatabase);
@@ -662,7 +662,7 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const CStdString &method, ITrans
     // restore original playcount or the new one won't be announced
     int newPlaycount = infos.m_playCount;
     infos.m_playCount = playcount;
-    videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
+    videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed);
   }
 
   UpdateResumePoint(parameterObject, infos, videodatabase);
@@ -712,7 +712,7 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const CStdString &method, ITr
     // restore original playcount or the new one won't be announced
     int newPlaycount = infos.m_playCount;
     infos.m_playCount = playcount;
-    videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed.IsValid() ? infos.m_lastPlayed : CDateTime::GetCurrentDateTime());
+    videodatabase.SetPlayCount(CFileItem(infos), newPlaycount, infos.m_lastPlayed);
   }
 
   UpdateResumePoint(parameterObject, infos, videodatabase);
@@ -1012,13 +1012,13 @@ void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTa
   if (ParameterNotNull(parameterObject, "imdbnumber"))
     details.m_strIMDBNumber = parameterObject["imdbnumber"].asString();
   if (ParameterNotNull(parameterObject, "premiered"))
-    details.m_premiered.SetFromDBDate(parameterObject["premiered"].asString());
+    SetFromDBDate(parameterObject["premiered"], details.m_premiered);
   if (ParameterNotNull(parameterObject, "votes"))
     details.m_strVotes = parameterObject["votes"].asString();
   if (ParameterNotNull(parameterObject, "lastplayed"))
-    details.m_lastPlayed.SetFromDBDateTime(parameterObject["lastplayed"].asString());
+    SetFromDBDateTime(parameterObject["lastplayed"], details.m_lastPlayed);
   if (ParameterNotNull(parameterObject, "firstaired"))
-    details.m_firstAired.SetFromDBDateTime(parameterObject["firstaired"].asString());
+    SetFromDBDateTime(parameterObject["firstaired"], details.m_firstAired);
   if (ParameterNotNull(parameterObject, "productioncode"))
     details.m_strProductionCode = parameterObject["productioncode"].asString();
   if (ParameterNotNull(parameterObject, "season"))


### PR DESCRIPTION
I've got a report on the forum that it's not possible to e.g. reset the "lastplayed" property of a movie to nothing (which may make sense when resetting playcount to 0, similar to "Mark unwatched"). I looked at the code and all properties stored in a CDateTime object are affected because CDateTime::SetFromDBDate()/SetFromDBDateTime() fails on an empty string. Therefore I have added some extra logic to reset the CDateTime object when the value of the property is provided as empty.

Furthermore I've removed the code to set playcount/lastplayed for tvshows through JSON-RPC because it doesn't make sense as CVideoDatabase::SetPlaycount operates on the files table which is not used for tvshows.
