### PR TITLE
FIX: [amc] add omx.exynos to white list

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -59,6 +59,7 @@ static bool CanSurfaceRenderWhiteList(const std::string &name)
     "OMX.rk",
     "OMX.qcom",
     "OMX.Intel",
+    "OMX.Exynos",
     NULL
   };
   for (const char **ptr = cansurfacerender_decoders; *ptr; ptr++)


### PR DESCRIPTION
Ref: http://forum.xbmc.org/showthread.php?tid=187974&pid=1650396#pid1650396

Apparently, omx.exynos is lying on stride/slice, but works ok in Surface mode.

@davilla I know you had issues on Odroid / Exynos with Surface mode, but apparently they fixed it, at least on the Samsung tablets. Too bad we have no way (that I know) to check the version of an omx component... 
Probably an exynos4 vs. exynos5 difference, too...
