### PR TITLE
[pvr] Fix some things found by cppcheck and remove unused methods

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -77,7 +77,6 @@ void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
   m_bIsPlayingTV          = false;
   m_bIsPlayingRecording   = false;
   memset(&m_addonCapabilities, 0, sizeof(m_addonCapabilities));
-  ResetQualityData(m_qualityInfo);
   m_apiVersion = AddonVersion("0.0.0");
 }
 
@@ -1024,7 +1023,6 @@ bool CPVRClient::SwitchChannel(const CPVRChannel &channel)
   {
     CPVRChannelPtr currentChannel = g_PVRChannelGroups->GetByUniqueID(channel.UniqueID(), channel.ClientID());
     CSingleLock lock(m_critSection);
-    ResetQualityData(m_qualityInfo);
     m_playingChannel = currentChannel;
   }
 
@@ -1455,51 +1453,6 @@ bool CPVRClient::CanSeekStream(void) const
     catch (exception &e) { LogException(e, __FUNCTION__); }
   }
   return bReturn;
-}
-
-void CPVRClient::ResetQualityData(PVR_SIGNAL_STATUS &qualityInfo)
-{
-  memset(&qualityInfo, 0, sizeof(qualityInfo));
-  if (CSettings::Get().GetBool("pvrplayback.signalquality"))
-  {
-    strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13205).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
-    strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13205).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
-  }
-  else
-  {
-    strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
-    strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
-  }
-}
-
-void CPVRClient::GetQualityData(PVR_SIGNAL_STATUS *status) const
-{
-  CSingleLock lock(m_critSection);
-  *status = m_qualityInfo;
-}
-
-int CPVRClient::GetSignalLevel(void) const
-{
-  CSingleLock lock(m_critSection);
-  return (int) ((float) m_qualityInfo.iSignal / 0xFFFF * 100);
-}
-
-int CPVRClient::GetSNR(void) const
-{
-  CSingleLock lock(m_critSection);
-  return (int) ((float) m_qualityInfo.iSNR / 0xFFFF * 100);
-}
-
-void CPVRClient::UpdateCharInfoSignalStatus(void)
-{
-  PVR_SIGNAL_STATUS qualityInfo;
-  ResetQualityData(qualityInfo);
-
-  if (CSettings::Get().GetBool("pvrplayback.signalquality"))
-    SignalQuality(qualityInfo);
-
-  CSingleLock lock(m_critSection);
-  m_qualityInfo = qualityInfo;
 }
 
 time_t CPVRClient::GetPlayingTime(void) const

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -210,7 +210,6 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIM
 
   memset(&addonTimer, 0, sizeof(addonTimer));
 
-  addonTimer.iClientIndex      = xbmcTimer.m_iClientIndex;
   addonTimer.state             = xbmcTimer.m_state;
   addonTimer.iClientIndex      = xbmcTimer.m_iClientIndex;
   addonTimer.iClientChannelUid = xbmcTimer.m_iClientChannelUid;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -483,32 +483,6 @@ namespace PVR
     bool GetPlayingChannel(CPVRChannelPtr &channel) const;
     bool GetPlayingRecording(CPVRRecording &recording) const;
 
-    /*! @name Signal status methods */
-    //@{
-
-    /*!
-     * @brief Get the quality data for the live stream that is currently playing.
-     * @param status A copy of the quality data.
-     */
-    void GetQualityData(PVR_SIGNAL_STATUS *status) const;
-
-    /*!
-     * @return The current signal quality level.
-     */
-    int GetSignalLevel(void) const;
-
-    /*!
-     * @return The current signal/noise ratio.
-     */
-    int GetSNR(void) const;
-
-    /*!
-     * @brief Update the signal status for the tv stream that's currently being read.
-     */
-    void UpdateCharInfoSignalStatus(void);
-
-    //@}
-
     static const char *ToString(const PVR_ERROR error);
 
     /*!
@@ -548,11 +522,6 @@ namespace PVR
      * @return True when compatible, false otherwise.
      */
     bool CheckAPIVersion(void);
-
-    /*!
-     * @brief Reset the signal quality data to the initial values.
-     */
-    void ResetQualityData(PVR_SIGNAL_STATUS &qualityInfo);
 
     /*!
      * @brief Resets all class members to their defaults. Called by the constructors.
@@ -615,7 +584,6 @@ namespace PVR
     bool                   m_bGotFriendlyName;     /*!< true if the friendly name has already been fetched */
     PVR_ADDON_CAPABILITIES m_addonCapabilities;     /*!< the cached add-on capabilities */
     bool                   m_bGotAddonCapabilities; /*!< true if the add-on capabilities have already been fetched */
-    PVR_SIGNAL_STATUS      m_qualityInfo;           /*!< stream quality information */
 
     /* stored strings to make sure const char* members in PVR_PROPERTIES stay valid */
     std::string m_strUserPath;    /*!< @brief translated path to the user profile */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -688,8 +688,6 @@ bool CPVRClients::GetMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, PVR_MENUHOOK
 
 void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CFileItem *item)
 {
-  PVR_MENUHOOKS *hooks = NULL;
-
   // get client id
   if (iClientID < 0 && cat == PVR_MENUHOOK_SETTING)
   {
@@ -731,7 +729,7 @@ void CPVRClients::ProcessMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat, const CF
   PVR_CLIENT client;
   if (GetConnectedClient(iClientID, client) && client->HaveMenuHooks(cat))
   {
-    hooks = client->GetMenuHooks();
+    PVR_MENUHOOKS *hooks = client->GetMenuHooks();
     std::vector<int> hookIDs;
 
     CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1004,9 +1004,6 @@ void CPVRClients::Process(void)
         ShowDialogNoClientsEnabled();
     }
 
-    PVR_CLIENT client;
-    if (GetPlayingClient(client))
-      client->UpdateCharInfoSignalStatus();
     Sleep(1000);
   }
 }

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -192,19 +192,14 @@ bool CPVRChannelGroup::MoveChannel(unsigned int iOldChannelNumber, unsigned int 
   if (iOldChannelNumber == iNewChannelNumber)
     return true;
 
-  bool bReturn(false);
   CSingleLock lock(m_critSection);
 
   /* make sure the list is sorted by channel number */
   SortByChannelNumber();
 
-  /* old channel number out of range */
-  if (iOldChannelNumber > m_members.size())
-    return bReturn;
-
-  /* new channel number out of range */
-  if (iNewChannelNumber < 1)
-    return bReturn;
+  /* old or new channel number out of range */
+  if (iOldChannelNumber > m_members.size() || iNewChannelNumber < 1)
+    return false;
 
   if (iNewChannelNumber > m_members.size())
     iNewChannelNumber = m_members.size();
@@ -220,9 +215,7 @@ bool CPVRChannelGroup::MoveChannel(unsigned int iOldChannelNumber, unsigned int 
   m_bChanged = true;
 
   if (bSaveInDb)
-    bReturn = Persist();
-  else
-    bReturn = true;
+    Persist();
 
   CLog::Log(LOGNOTICE, "CPVRChannelGroup - %s - %s channel '%s' moved to channel number '%d'",
       __FUNCTION__, (m_bRadio ? "radio" : "tv"), entry.channel->ChannelName().c_str(), iNewChannelNumber);

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -324,12 +324,10 @@ bool CPVRRecordings::DeleteRecording(const CFileItem &item)
 
 bool CPVRRecordings::RenameRecording(CFileItem &item, CStdString &strNewName)
 {
-  bool bReturn = false;
-
   if (!item.IsPVRRecording())
   {
     CLog::Log(LOGERROR, "CPVRRecordings - %s - cannot rename file: no valid recording tag", __FUNCTION__);
-    return bReturn;
+    return false;
   }
 
   CPVRRecording* tag = item.GetPVRRecordingInfoTag();


### PR DESCRIPTION
The first four commits are fixes for minor things that I found when running cppcheck. The last commit removes a whole bunch of obsolete methods that aren't called anywhere (the functionality has always resided in PVRGUIInfo). This means the signal quality is no longer queried unnecessarily once per second.
