### PR TITLE
[pvr] Enable channel name updates from the client

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -64,6 +64,7 @@ void CPVRDatabase::CreateTables()
         "bIsRadio             bool, "
         "bIsHidden            bool, "
         "bIsUserSetIcon       bool, "
+        "bIsUserSetName       bool, "
         "bIsLocked            bool, "
         "sIconPath            varchar(255), "
         "sChannelName         varchar(64), "
@@ -223,6 +224,9 @@ void CPVRDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 23)
     m_pDS->exec("ALTER TABLE channelgroups ADD iLastWatched integer");
+
+  if (iVersion < 24)
+    m_pDS->exec("ALTER TABLE channels ADD bIsUserSetName bool");
 }
 
 int CPVRDatabase::GetLastChannelId(void)
@@ -287,7 +291,7 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
 {
   int iReturn(0);
 
-  CStdString strQuery = PrepareSQL("SELECT channels.idChannel, channels.iUniqueId, channels.bIsRadio, channels.bIsHidden, channels.bIsUserSetIcon, "
+  CStdString strQuery = PrepareSQL("SELECT channels.idChannel, channels.iUniqueId, channels.bIsRadio, channels.bIsHidden, channels.bIsUserSetIcon, channels.bIsUserSetName, "
       "channels.sIconPath, channels.sChannelName, channels.bIsVirtual, channels.bEPGEnabled, channels.sEPGScraper, channels.iLastWatched, channels.iClientId, channels.bIsLocked, "
       "channels.iClientChannelNumber, channels.sInputFormat, channels.sInputFormat, channels.sStreamURL, channels.iEncryptionSystem, map_channelgroups_channels.iChannelNumber, channels.idEpg "
       "FROM map_channelgroups_channels "
@@ -307,6 +311,7 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
         channel->m_bIsRadio                = m_pDS->fv("bIsRadio").get_asBool();
         channel->m_bIsHidden               = m_pDS->fv("bIsHidden").get_asBool();
         channel->m_bIsUserSetIcon          = m_pDS->fv("bIsUserSetIcon").get_asBool();
+        channel->m_bIsUserSetName          = m_pDS->fv("bIsUserSetName").get_asBool();
         channel->m_bIsLocked               = m_pDS->fv("bIsLocked").get_asBool();
         channel->m_strIconPath             = m_pDS->fv("sIconPath").get_asString();
         channel->m_strChannelName          = m_pDS->fv("sChannelName").get_asString();
@@ -907,11 +912,11 @@ bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
   {
     /* new channel */
     strQuery = PrepareSQL("INSERT INTO channels ("
-        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsLocked, "
+        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsUserSetName, bIsLocked, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idEpg) "
-        "VALUES (%i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i)",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
+        "VALUES (%i, %i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i)",
+        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(),
         channel.EpgID());
@@ -920,11 +925,11 @@ bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
   {
     /* update channel */
     strQuery = PrepareSQL("REPLACE INTO channels ("
-        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsLocked, "
+        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsUserSetName, bIsLocked, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idChannel, idEpg) "
-        "VALUES (%i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i)",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
+        "VALUES (%i, %i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i)",
+        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(), channel.ChannelID(),
         channel.EpgID());

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -59,7 +59,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion() const { return 23; };
+    virtual int GetSchemaVersion() const { return 24; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -54,6 +54,7 @@ CPVRChannel::CPVRChannel(bool bRadio /* = false */)
   m_bIsRadio                = bRadio;
   m_bIsHidden               = false;
   m_bIsUserSetIcon          = false;
+  m_bIsUserSetName          = false;
   m_bIsLocked               = false;
   m_strIconPath             = StringUtils::EmptyString;
   m_strChannelName          = StringUtils::EmptyString;
@@ -84,6 +85,7 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL &channel, unsigned int iClientId)
   m_bIsRadio                = channel.bIsRadio;
   m_bIsHidden               = channel.bIsHidden;
   m_bIsUserSetIcon          = false;
+  m_bIsUserSetName          = false;
   m_bIsLocked               = false;
   m_strIconPath             = channel.strIconPath;
   m_strChannelName          = channel.strChannelName;
@@ -121,6 +123,7 @@ CPVRChannel &CPVRChannel::operator=(const CPVRChannel &channel)
   m_bIsRadio                = channel.m_bIsRadio;
   m_bIsHidden               = channel.m_bIsHidden;
   m_bIsUserSetIcon          = channel.m_bIsUserSetIcon;
+  m_bIsUserSetName          = channel.m_bIsUserSetName;
   m_bIsLocked               = channel.m_bIsLocked;
   m_strIconPath             = channel.m_strIconPath;
   m_strChannelName          = channel.m_strChannelName;
@@ -209,7 +212,9 @@ bool CPVRChannel::UpdateFromClient(const CPVRChannel &channel)
   SetClientChannelName(channel.ClientChannelName());
 
   CSingleLock lock(m_critSection);
-  if (m_strChannelName.empty())
+  
+  // only update the channel name and icon if the user hasn't changed them manually
+  if (m_strChannelName.empty() || !IsUserSetName())
     SetChannelName(channel.ClientChannelName());
   if (m_strIconPath.empty() || !IsUserSetIcon())
     SetIconPath(channel.IconPath());
@@ -317,7 +322,7 @@ bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bIsUserSetIcon
   return false;
 }
 
-bool CPVRChannel::SetChannelName(const CStdString &strChannelName)
+bool CPVRChannel::SetChannelName(const CStdString &strChannelName, bool bIsUserSetName /*= false*/)
 {
   CStdString strName(strChannelName);
 
@@ -327,8 +332,17 @@ bool CPVRChannel::SetChannelName(const CStdString &strChannelName)
   CSingleLock lock(m_critSection);
   if (m_strChannelName != strName)
   {
-    /* update the channel name */
     m_strChannelName = strName;
+    m_bIsUserSetName = bIsUserSetName;
+    
+    /* if the user changes the name manually to an empty string we reset the 
+       flag and use the name from the client instead */
+    if (bIsUserSetName && strChannelName.empty())
+    {
+      m_bIsUserSetName = false;
+      m_strChannelName = ClientChannelName();
+    }
+    
     SetChanged();
     m_bChanged = true;
 
@@ -753,6 +767,12 @@ bool CPVRChannel::IsUserSetIcon(void) const
 bool CPVRChannel::IsIconExists() const
 {
   return  CFile::Exists(IconPath());
+}
+
+bool CPVRChannel::IsUserSetName() const
+{
+  CSingleLock lock(m_critSection);
+  return m_bIsUserSetName;
 }
 
 CStdString CPVRChannel::ChannelName(void) const

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -211,7 +211,7 @@ bool CPVRChannel::UpdateFromClient(const CPVRChannel &channel)
   CSingleLock lock(m_critSection);
   if (m_strChannelName.empty())
     SetChannelName(channel.ClientChannelName());
-  if (m_strIconPath.empty()||(!m_strIconPath.Equals(channel.IconPath()) && !IsUserSetIcon()))
+  if (m_strIconPath.empty() || !IsUserSetIcon())
     SetIconPath(channel.IconPath());
 
   return m_bChanged;

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -162,6 +162,11 @@ namespace PVR
     bool IsIconExists(void) const;
 
     /*!
+     * @return whether the user has changed the channel name through the GUI
+     */
+    bool IsUserSetName(void) const;
+
+    /*!
      * @brief Set the path to the icon for this channel.
      * @param strIconPath The new path.
      * @param bIsUserSetIcon true if user changed the icon via GUI, false otherwise.
@@ -177,9 +182,10 @@ namespace PVR
     /*!
      * @brief Set the name for this channel used by XBMC.
      * @param strChannelName The new channel name.
+     * @param bIsUserSetName whether the change was triggered by the user directly
      * @return True if the something changed, false otherwise.
      */
-    bool SetChannelName(const CStdString &strChannelName);
+    bool SetChannelName(const CStdString &strChannelName, bool bIsUserSetName = false);
 
     /*!
      * @return True if this channel is marked as virtual. False if not.
@@ -471,6 +477,7 @@ namespace PVR
     int              m_iChannelId;              /*!< the identifier given to this channel by the TV database */
     bool             m_bIsRadio;                /*!< true if this channel is a radio channel, false if not */
     bool             m_bIsHidden;               /*!< true if this channel is hidden, false if not */
+    bool             m_bIsUserSetName;          /*!< true if user set the channel name via GUI, false if not */
     bool             m_bIsUserSetIcon;          /*!< true if user set the icon via GUI, false if not */
     bool             m_bIsLocked;               /*!< true if channel is locked, false if not */
     CStdString       m_strIconPath;             /*!< the path to the icon for this channel */

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1265,7 +1265,7 @@ bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool b
   if (!channel)
     return false;
 
-  channel->SetChannelName(strChannelName);
+  channel->SetChannelName(strChannelName, true);
   channel->SetHidden(bHidden);
   channel->SetLocked(bParentalLocked);
   channel->SetIconPath(strIconPath, bUserSetIcon);


### PR DESCRIPTION
Fixes http://trac.xbmc.org/ticket/14930

This fixes the above mentioned ticket (that channel name changes on the backend aren't ever reflected in XBMC unless the PVR database is reset). Now the name is updated from the client automagically except when it has been changed through the channel manager. If it is later changed to an empty string it will again be updated by the backend the next time XBMC is restarted.

@xhaggi and @opdenkamp please review.

If in the future we find that we need another "isUserSet" column we should consider changing them all into a single bitflag column which indicates what has been changed. For now though I think this is a good enough solution.
