### PR TITLE
[airplay] - fix regression introduced by ios7 clients

### DIFF
--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -210,12 +210,7 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
       }
 #endif //HAS_ZEROCONF
 
-      if (!StartAirPlayServer())
-      {
-        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(1273), "", g_localizeStrings.Get(33100), "");
-        return false;
-      }
-
+      // note - airtunesserver has to start before airplay server (ios7 client detection bug)
 #ifdef HAS_AIRTUNES
       if (!StartAirTunesServer())
       {
@@ -223,6 +218,12 @@ bool CNetworkServices::OnSettingChanging(const CSetting *setting)
         return false;
       }
 #endif //HAS_AIRTUNES
+      
+      if (!StartAirPlayServer())
+      {
+        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(1273), "", g_localizeStrings.Get(33100), "");
+        return false;
+      }      
     }
     else
     {
@@ -402,8 +403,10 @@ void CNetworkServices::Start()
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
   if (CSettings::Get().GetBool("services.esenabled") && !StartJSONRPCServer())
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33103), g_localizeStrings.Get(33100));
-  StartAirPlayServer();
+  
+  // note - airtunesserver has to start before airplay server (ios7 client detection bug)
   StartAirTunesServer();
+  StartAirPlayServer();
   StartRss();
 }
 

--- a/xbmc/network/Zeroconf.cpp
+++ b/xbmc/network/Zeroconf.cpp
@@ -45,6 +45,8 @@ class CZeroconfDummy : public CZeroconf
   {
     return false;
   }
+
+  virtual bool doForceReAnnounceService(const std::string&){return false;} 
   virtual bool doRemoveService(const std::string& fcr_ident){return false;}
   virtual void doStop(){}
 };
@@ -91,6 +93,15 @@ bool CZeroconf::RemoveService(const std::string& fcr_identifier)
     return doRemoveService(fcr_identifier);
   else
     return true;
+}
+
+bool CZeroconf::ForceReAnnounceService(const std::string& fcr_identifier)
+{
+  if (HasService(fcr_identifier) && m_started)
+  {
+    return doForceReAnnounceService(fcr_identifier);
+  }
+  return false;
 }
 
 bool CZeroconf::HasService(const std::string& fcr_identifier) const

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -40,7 +40,7 @@ class CZeroconf
 public:
 
   //tries to publish this service via zeroconf
-  //fcr_identifier can be used to stop this service later
+  //fcr_identifier can be used to stop or reannounce this service later
   //fcr_type is the zeroconf service type to publish (e.g. _http._tcp for webserver)
   //fcr_name is the name of the service to publish. The hostname is currently automatically appended
   //         and used for name collisions. e.g. XBMC would get published as fcr_name@Martn or, after collision fcr_name@Martn-2
@@ -51,6 +51,14 @@ public:
                       const std::string& fcr_name,
                       unsigned int f_port,
                       std::vector<std::pair<std::string, std::string> > txt /*= std::vector<std::pair<std::string, std::string> >()*/);
+  
+  //tries to rebroadcast that service on the network without removing/readding
+  //this can be achieved by changing a fake txt record. Implementations should
+  //implement it by doing so.
+  //
+  //fcr_identifier - the identifier of the already published service which should be reannounced
+  // returns true on successfull reannonuce - false if this service isn't published yet
+  bool ForceReAnnounceService(const std::string& fcr_identifier);
 
   ///removes the specified service
   ///returns false if fcr_identifier does not exist
@@ -90,6 +98,11 @@ protected:
                                 const std::string& fcr_name,
                                 unsigned int f_port,
                                 const std::vector<std::pair<std::string, std::string> >& txt) = 0;
+
+  //methods to implement for concrete implementations
+  //update this service
+  virtual bool doForceReAnnounceService(const std::string& fcr_identifier) = 0;
+  
   //removes the service if published
   virtual bool doRemoveService(const std::string& fcr_ident) = 0;
 

--- a/xbmc/network/linux/ZeroconfAvahi.h
+++ b/xbmc/network/linux/ZeroconfAvahi.h
@@ -50,6 +50,7 @@ protected:
                                 unsigned int f_port,
                                 const std::vector<std::pair<std::string, std::string> >& txt);
 
+  virtual bool doForceReAnnounceService(const std::string& fcr_identifier);
   virtual bool doRemoveService(const std::string& fcr_ident);
 
   virtual void doStop();

--- a/xbmc/network/mdns/ZeroconfMDNS.h
+++ b/xbmc/network/mdns/ZeroconfMDNS.h
@@ -44,6 +44,7 @@ protected:
                         unsigned int f_port,
                         const std::vector<std::pair<std::string, std::string> >& txt);
 
+  bool doForceReAnnounceService(const std::string& fcr_identifier);
   bool doRemoveService(const std::string& fcr_ident);
 
   virtual void doStop();
@@ -65,7 +66,13 @@ private:
 
   //lock + data (accessed from runloop(main thread) + the rest)
   CCriticalSection m_data_guard;
-  typedef std::map<std::string, DNSServiceRef> tServiceMap;
+  struct tServiceRef
+  {
+    DNSServiceRef serviceRef;
+    TXTRecordRef txtRecordRef;
+    int updateNumber;
+  };
+  typedef std::map<std::string, struct tServiceRef> tServiceMap;
   tServiceMap m_services;
   DNSServiceRef m_service;
 };

--- a/xbmc/network/osx/ZeroconfOSX.cpp
+++ b/xbmc/network/osx/ZeroconfOSX.cpp
@@ -125,6 +125,32 @@ bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
   return result;
 }
 
+bool CZeroconfOSX::doForceReAnnounceService(const std::string& fcr_identifier)
+{
+  bool ret = false;
+  CSingleLock lock(m_data_guard);
+  tServiceMap::iterator it = m_services.find(fcr_identifier);
+  if(it != m_services.end())
+  {
+    CFNetServiceRef service = it->second;
+
+    CFDataRef txtData = CFNetServiceGetTXTData(service);
+    // convert the txtdata back and forth is enough to trigger a reannounce later
+    CFDictionaryRef txtDict = CFNetServiceCreateDictionaryWithTXTData(NULL, txtData);
+    CFMutableDictionaryRef txtDictMutable =CFDictionaryCreateMutableCopy(NULL, 0, txtDict);
+    txtData = CFNetServiceCreateTXTDataWithDictionary(NULL, txtDictMutable);
+
+    // this triggers the reannounce
+    ret = CFNetServiceSetTXTData(service, txtData);
+
+    CFRelease(txtDictMutable);
+    CFRelease(txtDict);
+    CFRelease(txtData);
+  } 
+  return ret;
+}
+
+
 bool CZeroconfOSX::doRemoveService(const std::string& fcr_ident)
 {
   CSingleLock lock(m_data_guard);

--- a/xbmc/network/osx/ZeroconfOSX.h
+++ b/xbmc/network/osx/ZeroconfOSX.h
@@ -45,6 +45,8 @@ protected:
                         unsigned int f_port,
                         const std::vector<std::pair<std::string, std::string> >& txt);
 
+  bool doForceReAnnounceService(const std::string& fcr_identifier);
+
   bool doRemoveService(const std::string& fcr_ident);
 
   virtual void doStop();


### PR DESCRIPTION
This fix is not yet confirmed by many users but in my test case it is 100% working.

Background. When using iOS7 clients or newer they might show XBMC as audio-only target. This can happen randomly and switching wifi on the ios7 device on and off might fix the problem for a while (until the wifi goes to sleep again).

I tried to find out the root cause with a lot of user help but we really didn't get any stable results until this post came up:

http://forum.xbmc.org/showthread.php?tid=179961&pid=1648329#pid1648329

Shortly - it matters in which order the ios7 device sees the zeroconf announcements. If it sees the airplay announcement (video/pictures) before the airtunes announcement (audio) then it shows XBMC as audio-only target. If it sees the announcements the other way around - it sees the full target (monitor symbol).

This fix adds the ability to force reannounce a zeroconf service without remove/add the service from zeroconf. As this isn't supported directly in the zeroconf protocol we achieve this by changing txt records. Depending on the zeroconf implementation the following leads to an reannouncement:
1. MDNS - add a fake txtrecord and diddle its value
2. OSX - take the txtrecord dicftionary parse it to data and back to dictionary and set it to the service
3. avahi - reverse the txtrecord list and set it to the service

We do this each 10 seconds (cause osx will throttle announcements if done more then 10 a minute) for the airplay announcement.

In wireshark this results in a "txt-record flush" message to the 224.0.0.251 multicast address. I have verified those network packages on all platforms.

Exception: Androids version of the embedded mdns has no implementation for the needed API call (returns "not implemented" which we just ignore). So android will not benefit from this fix. I have found one evidence in the interwebs that someone implemented that call - i tried to contact that person (not sure if i even got the right email address). If we don't hear anything back from him - this fix is not achievable for android until someone digs into apples mdnsresponder sources.

Since this regression is there since ios7 was released and airplay might be a wider used feature in XBMC - i propose it for gotham - but its up to the RMs. (doing a pr against Gotham branch only if approved).
