### PR TITLE
[omxplayer] When setting fullscreen flag we don't want noaspect, try 2

### DIFF
--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -838,24 +838,19 @@ void COMXVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
   configDisplay.fullscreen = OMX_FALSE;
   configDisplay.noaspect   = OMX_TRUE;
 
-  if (configDisplay.dest_rect.width == 0 || configDisplay.dest_rect.height == 0)
-  {
-    configDisplay.set                 = OMX_DISPLAY_SET_FULLSCREEN;
-    configDisplay.fullscreen          = OMX_TRUE;
-  }
-  else
-  {
-    configDisplay.set                 = (OMX_DISPLAYSETTYPE)(OMX_DISPLAY_SET_DEST_RECT|OMX_DISPLAY_SET_SRC_RECT|OMX_DISPLAY_SET_NOASPECT);
-    configDisplay.dest_rect.x_offset  = (int)(DestRect.x1+0.5f);
-    configDisplay.dest_rect.y_offset  = (int)(DestRect.y1+0.5f);
-    configDisplay.dest_rect.width     = (int)(DestRect.Width()+0.5f);
-    configDisplay.dest_rect.height    = (int)(DestRect.Height()+0.5f);
+  configDisplay.set                 = (OMX_DISPLAYSETTYPE)(OMX_DISPLAY_SET_DEST_RECT|OMX_DISPLAY_SET_SRC_RECT|OMX_DISPLAY_SET_FULLSCREEN|OMX_DISPLAY_SET_NOASPECT);
+  configDisplay.dest_rect.x_offset  = (int)(DestRect.x1+0.5f);
+  configDisplay.dest_rect.y_offset  = (int)(DestRect.y1+0.5f);
+  configDisplay.dest_rect.width     = (int)(DestRect.Width()+0.5f);
+  configDisplay.dest_rect.height    = (int)(DestRect.Height()+0.5f);
 
-    configDisplay.src_rect.x_offset   = (int)(SrcRect.x1+0.5f);
-    configDisplay.src_rect.y_offset   = (int)(SrcRect.y1+0.5f);
-    configDisplay.src_rect.width      = (int)(SrcRect.Width()+0.5f);
-    configDisplay.src_rect.height     = (int)(SrcRect.Height()+0.5f);
-  }
+  configDisplay.src_rect.x_offset   = (int)(SrcRect.x1+0.5f);
+  configDisplay.src_rect.y_offset   = (int)(SrcRect.y1+0.5f);
+  configDisplay.src_rect.width      = (int)(SrcRect.Width()+0.5f);
+  configDisplay.src_rect.height     = (int)(SrcRect.Height()+0.5f);
+
+  configDisplay.fullscreen          = configDisplay.dest_rect.width == 0 || configDisplay.dest_rect.width == 0 ? OMX_TRUE : OMX_FALSE;
+
   m_omx_render.SetConfig(OMX_IndexConfigDisplayRegion, &configDisplay);
 
   CLog::Log(LOGDEBUG, "dest_rect.x_offset %d dest_rect.y_offset %d dest_rect.width %d dest_rect.height %d\n",

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -835,9 +835,6 @@ void COMXVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
 
   OMX_INIT_STRUCTURE(configDisplay);
   configDisplay.nPortIndex = m_omx_render.GetInputPort();
-  configDisplay.fullscreen = OMX_FALSE;
-  configDisplay.noaspect   = OMX_TRUE;
-
   configDisplay.set                 = (OMX_DISPLAYSETTYPE)(OMX_DISPLAY_SET_DEST_RECT|OMX_DISPLAY_SET_SRC_RECT|OMX_DISPLAY_SET_FULLSCREEN|OMX_DISPLAY_SET_NOASPECT);
   configDisplay.dest_rect.x_offset  = (int)(DestRect.x1+0.5f);
   configDisplay.dest_rect.y_offset  = (int)(DestRect.y1+0.5f);
@@ -849,7 +846,10 @@ void COMXVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
   configDisplay.src_rect.width      = (int)(SrcRect.Width()+0.5f);
   configDisplay.src_rect.height     = (int)(SrcRect.Height()+0.5f);
 
-  configDisplay.fullscreen          = configDisplay.dest_rect.width == 0 || configDisplay.dest_rect.width == 0 ? OMX_TRUE : OMX_FALSE;
+  if (configDisplay.dest_rect.width == 0 || configDisplay.dest_rect.height == 0)
+    configDisplay.fullscreen = OMX_TRUE;
+  else
+    configDisplay.noaspect = OMX_TRUE;
 
   m_omx_render.SetConfig(OMX_IndexConfigDisplayRegion, &configDisplay);
 


### PR DESCRIPTION
A regression has been reported in https://github.com/xbmc/xbmc/pull/4404
http://forum.xbmc.org/showthread.php?tid=184866&pid=1652187#pid1652187

The logic was flawed, we always want to set all of the zoom options, even the default ones as we might need to set them back to default.

Recommended for Gotham. (although original commit and revert could be dropped).
