### PR TITLE
[airtunes] - move the old advanced_settings flag "enableairtunesdebuglog" to the xbmc.debug addon

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2856,7 +2856,12 @@ msgctxt "#676"
 msgid "Verbose logging for AUDIO component"
 msgstr ""
 
-#empty strings from id 677 to 699
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#677"
+msgid "Verbose logging for AirTunes library"
+msgstr ""
+
+#empty strings from id 678 to 699
 
 msgctxt "#700"
 msgid "Cleaning up library"

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -50,6 +50,7 @@
 #define LOGDBUS     (1 << (LOGMASKBIT + 5))
 #define LOGJSONRPC  (1 << (LOGMASKBIT + 6))
 #define LOGAUDIO    (1 << (LOGMASKBIT + 7))
+#define LOGAIRTUNES (1 << (LOGMASKBIT + 8))
 
 #ifdef __GNUC__
 #define ATTRIB_LOG_FORMAT __attribute__((format(printf,3,4)))

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -296,6 +296,8 @@ void  CAirTunesServer::AudioOutputFunctions::audio_destroy(void *cls, void *sess
 void shairplay_log(void *cls, int level, const char *msg)
 {
   int xbmcLevel = LOGINFO;
+  if(!g_advancedSettings.CanLogComponent(LOGAIRTUNES))
+    return;
 
   switch(level)
   {
@@ -455,7 +457,7 @@ bool CAirTunesServer::Initialize(const CStdString &password)
       unsigned short port = (unsigned short)m_port;
       
       m_pLibShairplay->raop_set_log_level(m_pRaop, RAOP_LOG_WARNING);
-      if(g_advancedSettings.m_logEnableAirtunes)
+      if(g_advancedSettings.CanLogComponent(LOGAIRTUNES))
       {
         m_pLibShairplay->raop_set_log_level(m_pRaop, RAOP_LOG_DEBUG);
       }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -380,7 +380,6 @@ void CAdvancedSettings::Initialize()
   m_guiVisualizeDirtyRegions = false;
   m_guiAlgorithmDirtyRegions = 3;
   m_guiDirtyRegionNoFlipTimeout = 0;
-  m_logEnableAirtunes = false;
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;
 
@@ -852,7 +851,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetString(pRootElement, "cddbaddress", m_cddbAddress);
 
   //airtunes + airplay
-  XMLUtils::GetBoolean(pRootElement, "enableairtunesdebuglog", m_logEnableAirtunes);
   XMLUtils::GetInt(pRootElement,     "airtunesport", m_airTunesPort);
   XMLUtils::GetInt(pRootElement,     "airplayport", m_airPlayPort);  
 
@@ -1386,6 +1384,9 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(const CSetting *se
 #endif
 #ifdef HAS_ALSA
   list.push_back(std::make_pair(g_localizeStrings.Get(676), LOGAUDIO));
+#endif
+#ifdef HAS_AIRTUNES
+  list.push_back(std::make_pair(g_localizeStrings.Get(677), LOGAIRTUNES));
 #endif
 }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -215,7 +215,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     CStdString m_cddbAddress;
 
     //airtunes + airplay
-    bool m_logEnableAirtunes;
     int m_airTunesPort;
     int m_airPlayPort;
 


### PR DESCRIPTION
As the title says.

G+1 material

@davilla && montellese something like that for jsonrpc? ^^
