### PR TITLE
JSON-RPC: make logging of incoming requests optional and configurable

### DIFF
--- a/addons/xbmc.debug/resources/language/English/strings.po
+++ b/addons/xbmc.debug/resources/language/English/strings.po
@@ -39,3 +39,7 @@ msgstr ""
 msgctxt "#30005"
 msgid "Verbose logging for DBUS calls"
 msgstr ""
+
+msgctxt "#30006"
+msgid "Verbose logging for JSON-RPC requests"
+msgstr ""

--- a/addons/xbmc.debug/resources/settings.xml
+++ b/addons/xbmc.debug/resources/settings.xml
@@ -6,4 +6,5 @@
 	<setting id="bit4" type="bool" label="30003" default="0"/>
 	<setting id="bit5" type="bool" label="30004" default="0"/>
 	<setting id="bit6" type="bool" label="30005" default="0"/>
+	<setting id="bit7" type="bool" label="30006" default="0"/>
 </settings>

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -48,6 +48,7 @@
 #define LOGFFMPEG (1 << (LOGMASKBIT+3))
 #define LOGRTMP   (1 << (LOGMASKBIT+4))
 #define LOGDBUS   (1 << (LOGMASKBIT+5))
+#define LOGJSONRPC   (1 << (LOGMASKBIT+6))
 
 #ifdef __GNUC__
 #define ATTRIB_LOG_FORMAT __attribute__((format(printf,3,4)))

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -232,7 +232,9 @@ CStdString CJSONRPC::MethodCall(const CStdString &inputString, ITransportLayer *
   CVariant inputroot, outputroot, result;
   bool hasResponse = false;
 
-  CLog::Log(LOGDEBUG, "JSONRPC: Incoming request: %s", inputString.c_str());
+  if(g_advancedSettings.m_extraLogLevels & LOGJSONRPC)
+    CLog::Log(LOGDEBUG, "JSONRPC: Incoming request: %s", inputString.c_str());
+
   inputroot = CJSONVariantParser::Parse((unsigned char *)inputString.c_str(), inputString.length());
   if (!inputroot.isNull())
   {

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -1515,7 +1515,7 @@ bool CJSONServiceDescription::AddType(const std::string &jsonType)
 
   if (!globalType->Parse(descriptionObject[typeName]))
   {
-    CLog::Log(LOGERROR, "JSONRPC: Could not parse type \"%s\"", typeName.c_str());
+    CLog::Log(LOGWARNING, "JSONRPC: Could not parse type \"%s\"", typeName.c_str());
     CJSONServiceDescription::removeReferenceTypeDefinition(typeName);
     if (!globalType->missingReference.empty())
     {


### PR DESCRIPTION
As discussed in the forums the first commit makes the logging of incoming JSON-RPC requests optional. For JSON-RPC requests over HTTP there is still a debug log message from the webserver (which is not JSON-RPC specific) but I guess most of the JSON-RPC log spam comes from JSON-RPC requests of python addons. And a lot of remotes use JSON-RPC over TCP.

The second commit reduces the log level of a log JSON-RPC log message from ERROR to WARNING. The problem is that at the time we don't know if it's actually an error or not. There are cases where it will be an error and others where it can resolved later on. So logging it as a WARNING should be less confusing.
