### PR TITLE
videodb: fix getting streamdetails in GetFileInfo()

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1909,6 +1909,9 @@ bool CVideoDatabase::GetFileInfo(const CStdString& strFilenameAndPath, CVideoInf
       details.m_resumePoint.type = CBookmark::RESUME;
     }
 
+    // get streamdetails
+    GetStreamDetails(details);
+
     return !details.IsEmpty();
   }
   catch (...)


### PR DESCRIPTION
While looking for a bug in JSON-RPC where the runtime and the streamdetails were missing for the currently playing item (if the item is not part of the library) I realized that CVideoDatabase::GetFileInfo() does not retrieve the streamdetails of the file. For GetMovieInfo() et al. the streamdetails are however retrieved so this should keep GetFileInfo() more in line and will fix the mentioned JSON-RPC bug.

Furthermore this should also fix http://trac.xbmc.org/ticket/13749 where streamdetails are missing from the result of JSON-RPC's Files.GetDirectory.

I checked and CVideoDatabase::GetFileInfo() is only called from CVideoDatabase::LoadVideoInfo() which in turn is only used by the announcement manager, the info manager, upnp and json-rpc. In case of upnp it's only used for library items so that leaves the announcement manager, the info manager and json-rpc.
