### PR TITLE
paplayer: fix display of bits per sample for dvdplayer codecs

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1078,7 +1078,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
         st->iSampleRate = pStream->codec->sample_rate;
         st->iBlockAlign = pStream->codec->block_align;
         st->iBitRate = pStream->codec->bit_rate;
-        st->iBitsPerSample = pStream->codec->bits_per_coded_sample;
+        st->iBitsPerSample = pStream->codec->bits_per_raw_sample;
 	
         if(m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0))
           st->m_description = m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0)->value;

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -205,7 +205,7 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
   m_Bitrate = m_pAudioCodec->GetBitRate();
   if (!m_Bitrate && m_TotalTime)
   {
-    m_Bitrate = ((m_pInputStream->GetLength()*1000) / m_TotalTime) * 8;
+    m_Bitrate = (int)(((m_pInputStream->GetLength()*1000) / m_TotalTime) * 8);
   }
   m_pDemuxer->GetStreamCodecName(m_nAudioStream,m_CodecName);
 

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -185,7 +185,7 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
     m_EncodedSampleRate = m_pAudioCodec->GetEncodedSampleRate();
     m_Channels = m_pAudioCodec->GetChannels();
     m_ChannelInfo = m_pAudioCodec->GetChannelMap();
-
+    m_BitsPerCodedSample = static_cast<CDemuxStreamAudio*>(pStream)->iBitsPerSample;
   }
   if (nErrors >= 10)
   {

--- a/xbmc/cores/paplayer/ICodec.h
+++ b/xbmc/cores/paplayer/ICodec.h
@@ -39,6 +39,7 @@ public:
     m_SampleRate = 0;
     m_EncodedSampleRate = 0;
     m_BitsPerSample = 0;
+    m_BitsPerCodedSample = 0;
     m_DataFormat = AE_FMT_INVALID;
     m_Channels = 0;
     m_Bitrate = 0;
@@ -101,6 +102,7 @@ public:
   int m_SampleRate;
   int m_EncodedSampleRate;
   int m_BitsPerSample;
+  int m_BitsPerCodedSample;
   enum AEDataFormat m_DataFormat;
   int m_Bitrate;
   CStdString m_CodecName;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -1045,7 +1045,6 @@ void PAPlayer::UpdateGUIData(StreamInfo *si)
   CSharedLock lock(m_streamsLock);
 
   m_playerGUIData.m_sampleRate    = si->m_sampleRate;
-  m_playerGUIData.m_bitsPerSample = si->m_bytesPerSample << 3;
   m_playerGUIData.m_channelCount  = si->m_channelInfo.Count();
   m_playerGUIData.m_canSeek       = si->m_decoder.CanSeek();
 
@@ -1054,6 +1053,7 @@ void PAPlayer::UpdateGUIData(StreamInfo *si)
   m_playerGUIData.m_audioBitrate = codec ? codec->m_Bitrate : 0;
   strncpy(m_playerGUIData.m_codec,codec ? codec->m_CodecName : "",20);
   m_playerGUIData.m_cacheLevel   = codec ? codec->GetCacheLevel() : 0;
+  m_playerGUIData.m_bitsPerSample = (codec && codec->m_BitsPerCodedSample) ? codec->m_BitsPerCodedSample : si->m_bytesPerSample << 3;
 
   int64_t total = si->m_decoder.TotalTime();
   if (si->m_endOffset)


### PR DESCRIPTION
see title

DVDDemuxFFmpeg set iBitsPerSample incorrent. see avcodec.h bits_per_raw_sample is set by codec, bits_per_coded_sample is set by user.
