### PR TITLE
[Gotham] Crash fix: Add check for negative file length.

### DIFF
--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -28,7 +28,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dg(languageHook);
       int64_t size = file->GetLength();
-      if (!numBytes || (((int64_t)numBytes) > size))
+      if ((!numBytes || (((int64_t)numBytes) > size)) && (size >= 0))
         numBytes = (unsigned long) size;
 
       


### PR DESCRIPTION
This prevents a crash when querying the length of a PVR live stream from Python.
PVR addons can return -1 for LengthLiveStream() which originally resulted in a
request for 4294967295 bytes due to the -1 to (unsigned long) type cast on line 32.
The actual memory request in Buffer.h will fail with this value.

The crash occurred under Windows 7 x64. To reproduce:
- Select skin.transparency as active skin.
- Start listening to a PVR radio channel (web stream, e.g. using pvr.demo)
- Switch to full screen (tab) => crash
