### PR TITLE
[Fix] Memory leak and language retrieval of ext. vob subs

### DIFF
--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -480,8 +480,9 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const CStdString &path, CStreamD
       else
         dsub->m_strLanguage = lang;
 
-      return true;
+      details.AddStream(dsub);
     }
+    return true;
   }
   if(ext == ".sub")
   {


### PR DESCRIPTION
Store the language of external vob subtitles. This also fixes a memory leak.

Reported by @cg110, thx!.
