### PR TITLE
 [Ext. subs] Use ISO639-2 T language codes for external subtitles details.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -471,15 +471,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const CStdString &path, CStreamD
       CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
       CDemuxStream* stream = v.GetStream(i);
       std::string lang = stream->language;
-      if (lang.length() == 2)
-      {
-        CStdString lang3;
-        g_LangCodeExpander.ConvertToThreeCharCode(lang3, lang);
-        dsub->m_strLanguage = lang3;
-      }
-      else
-        dsub->m_strLanguage = lang;
-
+      dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392T(lang);
       details.AddStream(dsub);
     }
     return true;
@@ -494,7 +486,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const CStdString &path, CStreamD
   CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
   ExternalStreamInfo info;
   CUtil::GetExternalStreamDetailsFromFilename(path, filename, info);
-  dsub->m_strLanguage = info.language;
+  dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392T(info.language);
   details.AddStream(dsub);
 
   return true;

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -480,8 +480,9 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const CStdString &path, CStreamD
       else
         dsub->m_strLanguage = lang;
 
-      return true;
+      details.AddStream(dsub);
     }
+    return true;
   }
   if(ext == ".sub")
   {


### PR DESCRIPTION
This depends on https://github.com/xbmc/xbmc/pull/4435.
