### PR TITLE
Two fixes in the settings system

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -1092,7 +1092,7 @@ bool CSettingNumber::fromString(const std::string &strValue, double &value)
     return false;
 
   char *end = NULL;
-  value = (int)strtod(strValue.c_str(), &end);
+  value = strtod(strValue.c_str(), &end);
   if (end != NULL && *end != '\0')
     return false;
 

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -648,7 +648,7 @@ bool CGUIControlEditSetting::InputValidation(const std::string &input, void *dat
   if (editControl == NULL || editControl->GetSetting() == NULL)
     return true;
 
-  return editControl->GetSetting()->FromString(input);
+  return editControl->GetSetting()->CheckValidity(input);
 }
 
 CGUIControlSeparatorSetting::CGUIControlSeparatorSetting(CGUIImage *pImage, int id)


### PR DESCRIPTION
I came across these two fixes while working on some magic in the settings system.
- The first commit fixes the fact that currently there is no delay in setting edit controls (which guards against temporary invalid input) because the automatic input validation calls CSetting::FromString() which actually changes the value of the setting immediately. It should instead call CSetting::CheckValidity() which simply performs a validity check of the new value but doesn't change the setting's current value. That will happen once the user has stopped typing and the delay timeout expires.
- The second commit fixes the CSettingNumber::fromString() implementation which was broken for any non-integer values and can result in odd setting values being stored for settings of type "number".
