### PR TITLE
[osx] - fix issues with turning off/on tv when playback is paused

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -433,6 +433,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
         case CActiveAEControlProtocol::DEVICECHANGE:
           time_t now;
           time(&now);
+          CLog::Log(LOGDEBUG,"CActiveAE - device change event");
           while (!m_extLastDeviceChange.empty() && (now - m_extLastDeviceChange.front() > 0))
           {
             m_extLastDeviceChange.pop();
@@ -444,6 +445,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           }
           m_extLastDeviceChange.push(now);
           UnconfigureSink();
+          m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
           m_sink.EnumerateSinkList(true);
           LoadSettings();
           m_extError = false;
@@ -458,7 +460,6 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             m_state = AE_TOP_ERROR;
             m_extTimeout = 500;
           }
-          m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
           return;
         case CActiveAEControlProtocol::PAUSESTREAM:
           CActiveAEStream *stream;
@@ -632,11 +633,13 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
         switch (signal)
         {
         case CActiveAEControlProtocol::DISPLAYRESET:
+          CLog::Log(LOGDEBUG,"CActiveAE - display reset event");
           displayReset = true;
         case CActiveAEControlProtocol::INIT:
           m_extError = false;
           if (!displayReset)
           {
+            m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
             m_sink.EnumerateSinkList(true);
             LoadSettings();
           }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -414,18 +414,21 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   if (StringUtils::EqualsNoCase(device, "default"))
   {
     CCoreAudioHardware::GetOutputDeviceName(device);
+    deviceID = CCoreAudioHardware::GetDefaultOutputDevice();
     CLog::Log(LOGNOTICE, "%s: Opening default device %s", __PRETTY_FUNCTION__, device.c_str());
   }
-      
-  for (size_t i = 0; i < devices.size(); i++)
+  else
   {
-    if (device.find(devices[i].second.m_deviceName) != std::string::npos)
+    for (size_t i = 0; i < devices.size(); i++)
     {
-      m_info = devices[i].second;
-      deviceID = devices[i].first;
-      break;
+      if (device.find(devices[i].second.m_deviceName) != std::string::npos)
+      {
+        deviceID = devices[i].first;
+        break;
+      }
     }
   }
+
   if (!deviceID)
   {
     CLog::Log(LOGERROR, "%s: Unable to find device %s", __FUNCTION__, device.c_str());

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -24,17 +24,22 @@
 
 #include "windowing/WinSystem.h"
 #include "threads/CriticalSection.h"
+#include "threads/Timer.h"
 
 typedef struct SDL_Surface SDL_Surface;
 
 class IDispResource;
 class CWinEventsOSX;
 
-class CWinSystemOSX : public CWinSystemBase
+class CWinSystemOSX : public CWinSystemBase, public ITimerCallback
 {
 public:
+
   CWinSystemOSX();
   virtual ~CWinSystemOSX();
+
+  // ITimerCallback interface
+  virtual void OnTimeout();
 
   // CWinSystemBase
   virtual bool InitWindowSystem();
@@ -69,7 +74,10 @@ public:
   
   void        WindowChangedScreen();
 
-  void CheckDisplayChanging(u_int32_t flags);
+  void        AnnounceOnLostDevice();
+  void        AnnounceOnResetDevice();
+  void        StartLostDeviceTimer();
+  void        StopLostDeviceTimer();
   
   void* GetCGLContextObj();
 
@@ -104,6 +112,7 @@ protected:
 
   CCriticalSection             m_resourceSection;
   std::vector<IDispResource*>  m_resources;
+  CTimer                       m_lostDeviceTimer;
 };
 
 #endif


### PR DESCRIPTION
This fixes issues which users pointed out when turning off the amp or tv over night and try to continue where left of on the next day.

This change does the following
1. In ActiveAE there was a race condition when lostdevice (from windowing) occured with devicechanged callbacks (something like that i think :) ).
2. When we open the default device in the osx sink we need to query the device from CoreAudio instead of using our maybe outdated deviceid in the deviceslist (this is needed because in some constellations we only get windowing callbacks - but not devicechange callbacks rom osx).
3. The windowing code that fires OnDeviceLost and OnDeviceReset callbacks had a flawed logic. Now that those callbacks are used by ActiveAE those issues resulted in AE-Sleep-Of-Death - this needed a tiny refactor and fix

The last one looks a bit ugly in the diff but it is really easy what it does:
a. Adds a timer which is started whenever osx tells us "lost device"
aa. that timer is canceled when we get a proper "device reset" callback from osx
ab. if this is not the case the timeout of this timer will fire that callback (after 3secs with lost device) - and so wakes up AE again.
b. The callbacks we fire are refactored into 2 methods which are dumb (not checking flags or anything)
c. The logic of when those callbacks are called is completely in the "DisplayReconfigured" method
d. In addition to the kCGDisplayBeginConfigurationFlag and kCGDisplaySetModeFlag flags we also fire the onresetdevice callback when flags == 0. This is something which is not documented in Apples API but it is definitly happening (verified with a user)
e. Before this we only fired onresetdevice when there was a valid screen given in the callback from the os. But this assumption is not true. Because when the tv is turned off osx calls us without valid screen. In that case we still need to fire the onresetdevice for AE - else the engine never wakes up again.

Lot of text - hopefully it helps in understanding what this does - and that it is really needed for gotham :)

The bug hunting can be followed here:

http://forum.xbmc.org/showthread.php?tid=185395

Thx to repstein and gigantur who really did a great job in providing logs with a dozens of testbuilds over the last weeks for tracking the issue down (and having a response time which was only a couple of hours each time!).

Also thx to @FernetMenta who did a great job in interpreting that log files and finding the race and its fix.
