### PR TITLE
Added error recovery if snd_pcm_writei fails

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -531,12 +531,17 @@ unsigned int CAESinkALSA::AddPackets(uint8_t *data, unsigned int frames, bool ha
   int ret = snd_pcm_writei(m_pcm, (void*)data, frames);
   if (ret < 0)
   {
-    HandleError("snd_pcm_writei(1)", ret);
-    ret = snd_pcm_writei(m_pcm, (void*)data, frames);
-    if (ret < 0)
+    CLog::Log(LOGERROR, "CAESinkALSA - snd_pcm_writei(%d) %s - trying to recover", ret, snd_strerror(ret));
+    ret = snd_pcm_recover(m_pcm, ret, 1);
+    if(ret < 0)
     {
-      HandleError("snd_pcm_writei(2)", ret);
-      ret = 0;
+      HandleError("snd_pcm_writei(1)", ret);
+      ret = snd_pcm_writei(m_pcm, (void*)data, frames);
+      if (ret < 0)
+      {
+        HandleError("snd_pcm_writei(2)", ret);
+        ret = 0;
+      }
     }
   }
 


### PR DESCRIPTION
This prevents alsa reinitialisation in some cases, preventing a reset of the audio device.
