### PR TITLE
JSON-RPC: Extend EPG functions to be more convenient to client applications

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -175,7 +175,8 @@ JSONRPC_STATUS CPVROperations::GetBroadcasts(const std::string &method, ITranspo
   if (!parameterObject["startdate"].asString().empty())
   {
     CDateTime startDate;
-    if (startDate.SetFromDateString(parameterObject["startdate"].asString()))
+    if (startDate.SetFromDBDateTime(parameterObject["startdate"].asString()) ||
+    	startDate.SetFromDBDate(parameterObject["startdate"].asString()))
       epgFilter.m_startDateTime = startDate;
     else
       return InvalidParams;
@@ -183,7 +184,8 @@ JSONRPC_STATUS CPVROperations::GetBroadcasts(const std::string &method, ITranspo
   if (!parameterObject["enddate"].asString().empty())
   {
     CDateTime endDate;
-    if (endDate.SetFromDateString(parameterObject["enddate"].asString()))
+    if (endDate.SetFromDBDateTime(parameterObject["enddate"].asString()) ||
+        endDate.SetFromDBDate(parameterObject["enddate"].asString()))
       epgFilter.m_endDateTime = endDate;
     else
       return InvalidParams;

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -170,7 +170,25 @@ JSONRPC_STATUS CPVROperations::GetBroadcasts(const std::string &method, ITranspo
     return InternalError;
 
   CFileItemList programFull;
-  channelEpg->Get(programFull);
+  EpgSearchFilter epgFilter;
+  epgFilter.Reset();
+  if (!parameterObject["startdate"].asString().empty())
+  {
+    CDateTime startDate;
+    if (startDate.SetFromDateString(parameterObject["startdate"].asString()))
+      epgFilter.m_startDateTime = startDate;
+    else
+      return InvalidParams;
+  }
+  if (!parameterObject["enddate"].asString().empty())
+  {
+    CDateTime endDate;
+    if (endDate.SetFromDateString(parameterObject["enddate"].asString()))
+      epgFilter.m_endDateTime = endDate;
+    else
+      return InvalidParams;
+  }
+  channelEpg->Get(programFull, epgFilter);
 
   HandleFileItemList("broadcastid", false, "broadcasts", programFull, parameterObject, result, programFull.Size(), true);
 

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -172,6 +172,7 @@ JSONRPC_STATUS CPVROperations::GetBroadcasts(const std::string &method, ITranspo
   CFileItemList programFull;
   EpgSearchFilter epgFilter;
   epgFilter.Reset();
+  epgFilter.m_bIsRadio = channel->IsRadio();
   if (!parameterObject["startdate"].asString().empty())
   {
     CDateTime startDate;

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -1769,7 +1769,9 @@
     "params": [
       { "name": "channelid", "$ref": "Library.Id", "required": true },
       { "name": "properties", "$ref": "PVR.Fields.Broadcast" },
-      { "name": "limits", "$ref": "List.Limits" }
+      { "name": "limits", "$ref": "List.Limits" },
+      { "name": "startdate", "type": "string" },
+      { "name": "enddate", "type": "string" }
     ],
     "returns": { "type": "object",
       "properties": {

--- a/xbmc/interfaces/json-rpc/schema/types.json
+++ b/xbmc/interfaces/json-rpc/schema/types.json
@@ -768,7 +768,7 @@
   "PVR.Fields.Channel": {
     "extends": "Item.Fields.Base",
     "items": { "type": "string",
-      "enum": [ "thumbnail", "channeltype", "hidden", "locked", "channel", "lastplayed" ]
+      "enum": [ "thumbnail", "channeltype", "hidden", "locked", "channel", "lastplayed", "broadcastnow", "broadcastnext" ]
     }
   },
   "PVR.Details.Channel": {
@@ -780,7 +780,9 @@
       "hidden": { "type": "boolean" },
       "locked": { "type": "boolean" },
       "thumbnail": { "type": "string" },
-      "lastplayed": { "type": "string" }
+      "lastplayed": { "type": "string" },
+      "broadcastnow": { "$ref": "PVR.Details.Broadcast" },
+      "broadcastnext": { "$ref": "PVR.Details.Broadcast" }
     }
   },
   "PVR.Details.ChannelGroup": {

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -163,7 +163,10 @@ void CPVRChannel::Serialize(CVariant& value) const
   
   CEpgInfoTag epg;
   if (GetEPGNow(epg))
-    epg.Serialize(value);
+    epg.Serialize(value["broadcastnow"]);
+
+  if (GetEPGNext(epg))
+    epg.Serialize(value["broadcastnext"]);
 }
 
 /********** XBMC related channel methods **********/


### PR DESCRIPTION
Added EPG information to PVR.GetChannels, so that the active broadcasts for a long channel list can be retrieved much faster.
Also added a start- and enddate filter to PVR.GetBroadcasts, to reduce the amount of unneeded data.

I am not completely sure, that changing the serialization of CPVRChannel does not break anything else, but testing did not reveal any problems.

This is also a plea for ideas on how to filter the fields of "broadcastnow" and "broadcastnext", because likely applications will only need a couple of them.
