### PR TITLE
Add xbmc.stopSFX() to the python xbmc module.

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -337,6 +337,13 @@ namespace XBMCAddon
       }
     }
 
+    void stopSFX()
+    {
+      XBMC_TRACE;
+      DelayedCallGuard dg;
+      g_audioManager.Stop();
+    }
+    
     void enableNavSounds(bool yesNo)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -230,6 +230,14 @@ namespace XBMCAddon
     void playSFX(const char* filename);
 
     /**
+     * stopSFX() -- Stops wav file
+     *
+     * example:
+     *   - xbmc.stopSFX()
+     */
+    void stopSFX();
+    
+    /**
      * enableNavSounds(yesNo) -- Enables/Disables nav sounds
      * 
      * yesNo          : integer - enable (True) or disable (False) nav sounds


### PR DESCRIPTION
This addition was provided to me in a patch from @amet. @pvagner and I are developing a text to speech addon to allow blind users to use XBMC. We needed to be able to play the sound via XBMC for some setups. playSFX works for this but is not interruptible. This patch addresses that by allowing wavs previously started by playSFX to be stopped. 
