### PR TITLE
XBMCTinyXML: put warnings to log if suspicious charset is used for XML processing

### DIFF
--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -157,19 +157,52 @@ bool CXBMCTinyXML::Parse(const std::string& data, TiXmlEncoding encoding /*= TIX
 
   std::string detectedCharset;
   if (CCharsetDetection::DetectXmlEncoding(data, detectedCharset) && TryParse(data, detectedCharset))
+  {
+    if (!m_SuggestedCharset.empty())
+      CLog::Log(LOGWARNING, "%s: \"%s\" charset was used instead of suggested charset \"%s\" for %s", __FUNCTION__, m_UsedCharset.c_str(), m_SuggestedCharset.c_str(),
+                  (value.empty() ? "XML data" : ("file \"" + value + "\"").c_str()));
+
     return true;
+  }
 
   // check for valid UTF-8
   if (m_SuggestedCharset != "UTF-8" && detectedCharset != "UTF-8" && CUtf8Utils::isValidUtf8(data) &&
       TryParse(data, "UTF-8"))
-      return true;
+  {
+    if (!m_SuggestedCharset.empty())
+      CLog::Log(LOGWARNING, "%s: \"%s\" charset was used instead of suggested charset \"%s\" for %s", __FUNCTION__, m_UsedCharset.c_str(), m_SuggestedCharset.c_str(),
+                  (value.empty() ? "XML data" : ("file \"" + value + "\"").c_str()));
+    else if (!detectedCharset.empty())
+      CLog::Log(LOGWARNING, "%s: \"%s\" charset was used instead of detected charset \"%s\" for %s", __FUNCTION__, m_UsedCharset.c_str(), detectedCharset.c_str(),
+                  (value.empty() ? "XML data" : ("file \"" + value + "\"").c_str()));
+    return true;
+  }
 
   // fallback: try user GUI charset
   if (TryParse(data, g_langInfo.GetGuiCharSet()))
+  {
+    if (!m_SuggestedCharset.empty())
+      CLog::Log(LOGWARNING, "%s: \"%s\" charset was used instead of suggested charset \"%s\" for %s", __FUNCTION__, m_UsedCharset.c_str(), m_SuggestedCharset.c_str(),
+                  (value.empty() ? "XML data" : ("file \"" + value + "\"").c_str()));
+    else if (!detectedCharset.empty())
+      CLog::Log(LOGWARNING, "%s: \"%s\" charset was used instead of detected charset \"%s\" for %s", __FUNCTION__, m_UsedCharset.c_str(), detectedCharset.c_str(),
+                  (value.empty() ? "XML data" : ("file \"" + value + "\"").c_str()));
     return true;
+  }
 
   // can't detect correct data charset, try to process data as is
-  return InternalParse(data, TIXML_ENCODING_UNKNOWN);
+  if (InternalParse(data, TIXML_ENCODING_UNKNOWN))
+  {
+    if (!m_SuggestedCharset.empty())
+      CLog::Log(LOGWARNING, "%s: Processed %s as unknown encoding instead of suggested \"%s\"", __FUNCTION__, 
+                  (value.empty() ? "XML data" : ("file \"" + value + "\"").c_str()), m_SuggestedCharset.c_str());
+    else if (!detectedCharset.empty())
+      CLog::Log(LOGWARNING, "%s: Processed %s as unknown encoding instead of detected \"%s\"", __FUNCTION__,
+                  (value.empty() ? "XML data" : ("file \"" + value + "\"").c_str()), detectedCharset.c_str());
+    return true;
+  }
+
+  return false;
 }
 
 bool CXBMCTinyXML::TryParse(const std::string& data, const std::string& tryDataCharset)
@@ -199,10 +232,6 @@ bool CXBMCTinyXML::TryParse(const std::string& data, const std::string& tryDataC
   }
 
   m_UsedCharset = tryDataCharset;
-  if (!m_SuggestedCharset.empty() && m_UsedCharset != m_SuggestedCharset)
-    CLog::Log(LOGWARNING, "%s: Using \"%s\" charset instead of \"%s\" charset%s", __FUNCTION__, m_UsedCharset.c_str(), m_SuggestedCharset.c_str(),
-                (value.empty() ? "" : (" for file " + value).c_str()));
-
   return true;
 }
 


### PR DESCRIPTION
For simpler problem detection.
As addition for PR #4418.
