### PR TITLE
VDA decoder fix: add pts to picture buffer

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDA.cpp
@@ -63,6 +63,7 @@ int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic)
 {
   pic->type = FF_BUFFER_TYPE_USER;
   pic->data[0] = (uint8_t *)1;
+  pic->reordered_opaque = avctx->reordered_opaque;
   return 0;
 }
 


### PR DESCRIPTION
frames coming out from VDA decoder had no pts attached which led to large a/v desync
