### PR TITLE
PulseAudio: Rework Volume

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -533,6 +533,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     CLog::Log(LOGERROR, "PulseAudio: Sink %s not found", device.c_str());
     pa_threaded_mainloop_unlock(m_MainLoop);
     Deinitialize();
+    return false;
   }
 
   // Pulse can resample everything between 1 hz and 192000 hz

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -23,6 +23,7 @@
 #include "utils/log.h"
 #include "Util.h"
 #include "guilib/LocalizeStrings.h"
+#include "Application.h"
 
 using namespace std;
 
@@ -232,6 +233,21 @@ struct SinkInfoStruct
   }
 };
 
+struct SinkInputInfoStruct
+{
+  bool is_valid;
+  int mute;
+  int index;
+  pa_cvolume volume;
+  pa_threaded_mainloop *mainloop;
+  SinkInputInfoStruct()
+  {
+    is_valid = false;
+    mute = 0;
+    mainloop = NULL;
+  }
+};
+
 static void SinkInfoCallback(pa_context *c, const pa_sink_info *i, int eol, void *userdata)
 {
   SinkInfoStruct *sinkStruct = (SinkInfoStruct *)userdata;
@@ -243,6 +259,19 @@ static void SinkInfoCallback(pa_context *c, const pa_sink_info *i, int eol, void
     sinkStruct->device_found = true;
   }
   pa_threaded_mainloop_signal(sinkStruct->mainloop, 0);
+}
+
+static void SinkInputInfoCallback(pa_context *c, const pa_sink_input_info *i, int eol, void *userdata)
+{
+  SinkInputInfoStruct *siiStruct = (SinkInputInfoStruct *)userdata;
+  if(i && i->has_volume)
+  {
+    siiStruct->is_valid = true;
+    siiStruct->volume = i->volume;
+    siiStruct->mute = i->mute;
+    siiStruct->index = i->index;
+  }
+  pa_threaded_mainloop_signal(siiStruct->mainloop, 0);
 }
 
 static AEChannel PAChannelToAEChannel(pa_channel_position_t channel)
@@ -483,8 +512,6 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   }
   m_Channels = format.m_channelLayout.Count();
 
-  pa_cvolume_reset(&m_Volume, m_Channels);
-
   pa_format_info *info[1];
   info[0] = pa_format_info_new();
   info[0]->encoding = AEFormatToPulseEncoding(format.m_dataFormat);
@@ -598,7 +625,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     buffer_attr.fragsize = (uint32_t) latency;
   }
 
-  if (pa_stream_connect_playback(m_Stream, isDefaultDevice ? NULL : device.c_str(), sinkStruct.isHWDevice ? &buffer_attr : NULL, ((pa_stream_flags)(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY)), m_passthrough ? NULL : &m_Volume, NULL) < 0)
+  if (pa_stream_connect_playback(m_Stream, isDefaultDevice ? NULL : device.c_str(), sinkStruct.isHWDevice ? &buffer_attr : NULL, ((pa_stream_flags)(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY)), NULL, NULL) < 0)
   {
     CLog::Log(LOGERROR, "PulseAudio: Failed to connect stream to output");
     pa_threaded_mainloop_unlock(m_MainLoop);
@@ -620,6 +647,31 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     pa_threaded_mainloop_unlock(m_MainLoop);
     Deinitialize();
     return false;
+  }
+
+  //update local volume if we are in non passthrough mode
+  if (!m_passthrough)
+  {
+    unsigned int devidx = pa_stream_get_index(m_Stream);
+    SinkInputInfoStruct sii;
+    sii.mainloop = m_MainLoop;
+    bool success = WaitForOperation(pa_context_get_sink_input_info(m_Context, devidx, SinkInputInfoCallback, &sii), m_MainLoop, "Get Sink Input Info");
+    if(success && sii.is_valid)
+    {
+      // we don't have per channel values so average them
+      pa_volume_t p_vol = pa_cvolume_avg(&sii.volume);
+      // store it internally
+      m_Volume = sii.volume;
+      float sValue = std::min(p_vol / (float) PA_VOLUME_NORM, 1.0f);
+      CLog::Log(LOGDEBUG, "Restored Stream value to %f", sValue);
+      sValue = std::min(sValue, 1.0f);
+      g_application.SetVolume(sValue, false);
+      if (sii.mute && sValue > 0)
+      {
+        CLog::Log(LOGDEBUG, "PulseAudio: Stream is muted - perhaps was a user wish - if volume is changed we unmute");
+      }
+    }
+    
   }
 
   const pa_buffer_attr *a;
@@ -761,17 +813,50 @@ void CAESinkPULSE::SetVolume(float volume)
   if (m_IsAllocated && !m_passthrough)
   {
     pa_threaded_mainloop_lock(m_MainLoop);
-    pa_volume_t pavolume = pa_sw_volume_from_linear(volume);
-    if ( pavolume <= 0 )
-      pa_cvolume_mute(&m_Volume, m_Channels);
-    else
-      pa_cvolume_set(&m_Volume, m_Channels, pavolume);
-    pa_operation *op = pa_context_set_sink_input_volume(m_Context, pa_stream_get_index(m_Stream), &m_Volume, NULL, NULL);
-    if (op == NULL)
-      CLog::Log(LOGERROR, "PulseAudio: Failed to set volume");
-    else
-      pa_operation_unref(op);
-
+    bool external_change = false;
+    //check if internal volume does not match sink volume
+    unsigned int devidx = pa_stream_get_index(m_Stream);
+    SinkInputInfoStruct sii;
+    sii.mainloop = m_MainLoop;
+    bool success = WaitForOperation(pa_context_get_sink_input_info(m_Context, devidx, SinkInputInfoCallback, &sii), m_MainLoop, "Get Sink Input Info");
+    float sValue = 0.0f;
+    if(success && sii.is_valid)
+    {
+      // we don't have per channel values so average them
+      pa_volume_t n_vol = pa_cvolume_avg(&sii.volume);
+      pa_volume_t o_vol = pa_cvolume_avg(&m_Volume);
+      sValue = std::min(n_vol / (float) PA_VOLUME_NORM, 1.0f);
+      if (n_vol != o_vol)
+      {
+        external_change = true;
+        // update internal volume
+        m_Volume = sii.volume;
+        CLog::Log(LOGDEBUG, "Restored Volume cause of external change to value to %f", sValue);
+        g_application.SetVolume(sValue, false);
+      }
+    }
+    // unmute if we should not be muted
+    if (sii.mute && sValue > 0)
+    {
+      pa_operation *op = pa_context_set_sink_input_mute(m_Context, sii.index, 0, NULL, NULL);
+      if (op == NULL)
+        CLog::Log(LOGERROR, "PulseAudio: Failed to unmute the stream");
+      else
+        pa_operation_unref(op);
+    }
+    if (!external_change)
+    {
+      pa_volume_t pavolume = pa_sw_volume_from_linear(volume);
+      if ( pavolume <= 0 )
+        pa_cvolume_mute(&m_Volume, m_Channels);
+      else
+        pa_cvolume_set(&m_Volume, m_Channels, pavolume);
+      pa_operation *op = pa_context_set_sink_input_volume(m_Context, devidx, &m_Volume, NULL, NULL);
+      if (op == NULL)
+        CLog::Log(LOGERROR, "PulseAudio: Failed to set volume");
+      else
+        pa_operation_unref(op);
+    }
     pa_threaded_mainloop_unlock(m_MainLoop);
   }
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -483,6 +483,8 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   }
   m_Channels = format.m_channelLayout.Count();
 
+  pa_cvolume_reset(&m_Volume, m_Channels);
+
   pa_format_info *info[1];
   info[0] = pa_format_info_new();
   info[0]->encoding = AEFormatToPulseEncoding(format.m_dataFormat);
@@ -596,7 +598,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     buffer_attr.fragsize = (uint32_t) latency;
   }
 
-  if (pa_stream_connect_playback(m_Stream, isDefaultDevice ? NULL : device.c_str(), sinkStruct.isHWDevice ? &buffer_attr : NULL, ((pa_stream_flags)(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY)), NULL, NULL) < 0)
+  if (pa_stream_connect_playback(m_Stream, isDefaultDevice ? NULL : device.c_str(), sinkStruct.isHWDevice ? &buffer_attr : NULL, ((pa_stream_flags)(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY)), m_passthrough ? NULL : &m_Volume, NULL) < 0)
   {
     CLog::Log(LOGERROR, "PulseAudio: Failed to connect stream to output");
     pa_threaded_mainloop_unlock(m_MainLoop);
@@ -752,6 +754,26 @@ void CAESinkPULSE::Drain()
   pa_threaded_mainloop_lock(m_MainLoop);
   WaitForOperation(pa_stream_drain(m_Stream, NULL, NULL), m_MainLoop, "Drain");
   pa_threaded_mainloop_unlock(m_MainLoop);
+}
+
+void CAESinkPULSE::SetVolume(float volume)
+{
+  if (m_IsAllocated && !m_passthrough)
+  {
+    pa_threaded_mainloop_lock(m_MainLoop);
+    pa_volume_t pavolume = pa_sw_volume_from_linear(volume);
+    if ( pavolume <= 0 )
+      pa_cvolume_mute(&m_Volume, m_Channels);
+    else
+      pa_cvolume_set(&m_Volume, m_Channels, pavolume);
+    pa_operation *op = pa_context_set_sink_input_volume(m_Context, pa_stream_get_index(m_Stream), &m_Volume, NULL, NULL);
+    if (op == NULL)
+      CLog::Log(LOGERROR, "PulseAudio: Failed to set volume");
+    else
+      pa_operation_unref(op);
+
+    pa_threaded_mainloop_unlock(m_MainLoop);
+  }
 }
 
 void CAESinkPULSE::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -44,6 +44,9 @@ public:
   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio, bool blocking = false);
   virtual void         Drain           ();
 
+  virtual bool HasVolume() { return true; };
+  virtual void SetVolume(float volume);
+
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
   bool IsInitialized();
   CCriticalSection m_sec;
@@ -61,6 +64,7 @@ private:
   unsigned int m_Channels;
   
   pa_stream *m_Stream;
+  pa_cvolume m_Volume;
 
   pa_context *m_Context;
   pa_threaded_mainloop *m_MainLoop;


### PR DESCRIPTION
This intends to introduce some desktop feeling.
- When we start a new stream - it is not (!) unmuted. If user has muted it, we honor this until user wants to change volume.
- When user changes volume, we read in the external volume first and sync our internal volume to it, then user can press + or minus, cause he might have adjusted it with e.g. pavucontrol
- xbmc changes the stream's volume directly, you can see that in pavucontrol
- xbmc's volume state is synced, when next xbmc volume change happens

Edit: Splitted up into bugfixes and features with https://github.com/xbmc/xbmc/pull/4457
