### PR TITLE
Add missing back-out for context menu via switchplayer

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -444,6 +444,7 @@
   </MyPictures>
   <ContextMenu>
     <keyboard>
+      <y>Back</y>
       <c>Back</c>
       <menu>Back</menu>
     </keyboard>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -444,7 +444,7 @@
   </MyPictures>
   <ContextMenu>
     <keyboard>
-      <y>Back</y>
+      <y>Back</y> <!-- For easy "SwitchPlayer" window closing when using the Y key -->
       <c>Back</c>
       <menu>Back</menu>
     </keyboard>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -444,6 +444,7 @@
   </MyPictures>
   <ContextMenu>
     <keyboard>
+      <y>Back</y> <!-- For easy "SwitchPlayer" window closing when using the Y key -->
       <c>Back</c>
       <menu>Back</menu>
     </keyboard>


### PR DESCRIPTION
When you press <y> to bring up the switchplayer menu, which is a context menu, it was missing the ability to back out of the menu by pressing <y> again.
