### PR TITLE
CHG: [droid] show build properties at startup for easier debug

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -337,6 +337,7 @@
 #if defined(TARGET_ANDROID)
 #include "android/activity/XBMCApp.h"
 #include "android/activity/AndroidFeatures.h"
+#include "android/jni/Build.h"
 #endif
 
 #ifdef TARGET_WINDOWS
@@ -734,6 +735,8 @@ bool CApplication::Create()
   CLog::Log(LOGNOTICE, "Running on Darwin iOS %d-bit %s%s", g_sysinfo.GetKernelBitness(), g_sysinfo.IsAppleTV2() ? "(AppleTV2) " : "", g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_FREEBSD)
   CLog::Log(LOGNOTICE, "Running on FreeBSD %d-bit %s", g_sysinfo.GetKernelBitness(), g_sysinfo.GetUnameVersion().c_str());
+#elif defined(TARGET_ANDROID)
+  CLog::Log(LOGNOTICE, "Running on Android %d-bit API level %d (%s, %s)", g_sysinfo.GetKernelBitness(), CJNIBuild::SDK_INT, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_POSIX)
   CLog::Log(LOGNOTICE, "Running on Linux %d-bit (%s, %s)", g_sysinfo.GetKernelBitness(), g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_WINDOWS)
@@ -746,6 +749,13 @@ bool CApplication::Create()
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");
   CLog::Log(LOGNOTICE, "Aero is %s", (g_sysinfo.IsAeroDisabled() == true) ? "disabled" : "enabled");
 #endif
+#if defined(TARGET_ANDROID)
+  CLog::Log(LOGNOTICE,
+        "Product: %s, Device: %s, Board: %s - Manufacturer: %s, Brand: %s, Model: %s, Hardware: %s",
+        CJNIBuild::PRODUCT.c_str(), CJNIBuild::DEVICE.c_str(), CJNIBuild::BOARD.c_str(),
+        CJNIBuild::MANUFACTURER.c_str(), CJNIBuild::BRAND.c_str(), CJNIBuild::MODEL.c_str(), CJNIBuild::HARDWARE.c_str());
+#endif
+
 #if defined(__arm__)
   if (g_cpuInfo.GetCPUFeatures() & CPU_FEATURE_NEON)
     CLog::Log(LOGNOTICE, "ARM Features: Neon enabled");

--- a/xbmc/android/jni/Build.cpp
+++ b/xbmc/android/jni/Build.cpp
@@ -43,6 +43,7 @@ std::string CJNIBuild::FINGERPRINT;
 int64_t CJNIBuild::TIME;
 std::string CJNIBuild::USER;
 std::string CJNIBuild::HOST;
+int CJNIBuild::SDK_INT;
 
 void CJNIBuild::PopulateStaticFields()
 {
@@ -65,6 +66,7 @@ void CJNIBuild::PopulateStaticFields()
   TIME = get_static_field<jlong>(m_classname,"TIME");
   USER = jcast<std::string>(get_static_field<jhstring>(m_classname,"USER"));
   HOST = jcast<std::string>(get_static_field<jhstring>(m_classname,"HOST"));
+  SDK_INT = get_static_field<jint>((std::string(m_classname)+"$VERSION").c_str(),"SDK_INT");
 }
 
 std::string CJNIBuild::getRadioVersion()

--- a/xbmc/android/jni/Build.h
+++ b/xbmc/android/jni/Build.h
@@ -45,6 +45,7 @@ public:
   static int64_t TIME;
   static std::string USER;
   static std::string HOST;
+  static int SDK_INT;
   static std::string getRadioVersion();
 
   static void PopulateStaticFields();

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.cpp
@@ -396,11 +396,6 @@ bool CStageFrightVideo::Open(CDVDStreamInfo &hints)
   CLog::Log(LOGDEBUG, "%s::Open\n", CLASSNAME);
 #endif
 
-  CLog::Log(LOGDEBUG,
-        "CStageFrightVideo - p:%s, d:%s, b:%s - m:%s, b:%s, m:%s, h:%s",
-        CJNIBuild::PRODUCT.c_str(), CJNIBuild::DEVICE.c_str(), CJNIBuild::BOARD.c_str(),
-        CJNIBuild::MANUFACTURER.c_str(), CJNIBuild::BRAND.c_str(), CJNIBuild::MODEL.c_str(), CJNIBuild::HARDWARE.c_str());
-
   CSingleLock lock(g_graphicsContext);
 
   // stagefright crashes with null size. Trap this...


### PR DESCRIPTION
This will make debugging easier by showing the exact characteristics of an Android device in the log.

/cc @davilla 
