### PR TITLE
FIX: [droid;x86;ffmpeg] disabling mmx on recent gcc actually causes crashes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2836,7 +2836,6 @@ XB_CONFIG_MODULE([lib/ffmpeg], [
       --enable-pthreads \
       --enable-runtime-cpudetect \
       `if test "$use_hardcoded_tables" = "yes"; then echo --enable-hardcoded-tables; else echo --disable-hardcoded-tables; fi`\
-      `if test "$target_platform" = "target_android" && test "$host_cpu" = "i686"; then echo --disable-mmx; fi #workaround for gcc 4.6 bug` \
       `if test "$target_platform" = "target_android"; then echo "--custom-libname-with-major=\\$(SLIBPREF)\\$(FULLNAME)-\\$(LIBMAJOR)-${ARCH}\\$(SLIBSUF)"; \
        else echo "--custom-libname-with-major=\\$(FULLNAME)-\\$(LIBMAJOR)-${ARCH}\\$(SLIBSUF)"; fi` \
       `case $host_cpu in i?86*) echo --disable-pic ;; *) echo --enable-pic ;; esac` \


### PR DESCRIPTION
I don't know what was the original issue, but not enabling mmx (on gcc 4.8) surely causes crashes when playing, e.g., wmv, avi, ...

Reverts https://github.com/xbmc/xbmc/commit/be07e097e5be70cec0293bd56e04231011938d6c
Adds a build time dependency on yasm.

/cc @davilla 
