### PR TITLE
A couple more bugs fixes from Coverity

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -345,6 +345,7 @@ namespace XBMCAddon
             if (!bResult)
               value = emptyString;
           }
+          break;
         default:
           value = emptyString;
           break;

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -236,7 +236,7 @@ namespace PVR
      * @param version The version to update the database from.
      */
     void UpdateTables(int version);
-    int GetMinSchemaVersion() { return 11; }
+    virtual int GetMinSchemaVersion() const { return 11; }
 
     bool PersistGroupMembers(CPVRChannelGroup &group);
 


### PR DESCRIPTION
Fixing a couple more issues which coverity found.

The more important is the PVR db fix.  I believe that the current code would try and upgrade a very old PVR database due to the signature not matching the base class, and so the base class using it's version which returns 0.
