### PR TITLE
[osx] vsync should default to always

### DIFF
--- a/system/settings/freebsd.xml
+++ b/system/settings/freebsd.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings>
-
+  <section id="system">
+    <category id="videoscreen">
+      <group id="3">
+        <setting id="videoscreen.vsync">
+          <default>3</default> <!-- VSYNC_DRIVER -->
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -7,6 +7,11 @@
           <visible>false</visible>
         </setting>
       </group>
+      <group id="3">
+        <setting id="videoscreen.vsync">
+          <default>3</default> <!-- VSYNC_DRIVER -->
+        </setting>
+      </group>
     </category>
     <category id="input">
       <group id="2">

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -48,11 +48,6 @@
           <control type="edit" format="integer" />
         </setting>
       </group>
-      <group id="3">
-        <setting id="videoscreen.vsync">
-          <default>2</default> <!-- VSYNC_ALWAYS -->
-        </setting>
-      </group>
     </category>
     <category id="audiooutput">
       <group id="1">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2330,6 +2330,9 @@
           <constraints>
             <options>verticalsyncs</options>
           </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
           <control type="spinner" format="string" />
         </setting>
         <setting id="videoscreen.guicalibration" type="action" label="214" help="36357">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2326,7 +2326,7 @@
       <group id="3">
         <setting id="videoscreen.vsync" type="integer" label="13105" help="36356">
           <level>2</level>
-          <default>3</default> <!-- VSYNC_DRIVER -->
+          <default>2</default> <!-- VSYNC_ALWAYS -->
           <constraints>
             <options>verticalsyncs</options>
           </constraints>

--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -38,11 +38,6 @@
           <requirement negated="true">HAS_GL</requirement>
         </setting>
       </group>
-      <group id="3">
-        <setting id="videoscreen.vsync">
-          <default>2</default> <!-- VSYNC_ALWAYS -->
-        </setting>
-      </group>
     </category>
     <category id="audiooutput" label="772" help="36360">
       <group id="1">

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -277,6 +277,16 @@ bool CDisplaySettings::OnSettingUpdate(CSetting* &setting, const char *oldSettin
     if (screenmode.size() == 21)
       return screenmodeSetting->SetValue(screenmode + "std");
   }
+  else if (settingId == "videoscreen.vsync")
+  {
+    // This ifdef is intended to catch everything except Linux and FreeBSD
+#if !defined(TARGET_LINUX) || defined(TARGET_DARWIN) || defined(TARGET_ANDROID) || defined(TARGET_RASPBERRY_PI)
+    // in the Gotham alphas through beta3 the default value for darwin and android was set incorrectly.
+    CSettingInt *vsyncSetting = (CSettingInt*)setting;
+    if (vsyncSetting->GetValue() == VSYNC_DRIVER)
+      return vsyncSetting->SetValue(VSYNC_ALWAYS);
+#endif
+  }
 
   return false;
 }
@@ -640,7 +650,8 @@ void CDisplaySettings::SettingOptionsScreensFiller(const CSetting *setting, std:
 
 void CDisplaySettings::SettingOptionsVerticalSyncsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current)
 {
-#if defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
+  // This ifdef is intended to catch everything except Linux and FreeBSD
+#if defined(TARGET_LINUX) && !defined(TARGET_DARWIN) && !defined(TARGET_ANDROID) && !defined(TARGET_RASPBERRY_PI)
   list.push_back(make_pair(g_localizeStrings.Get(13101), VSYNC_DRIVER));
 #endif
   list.push_back(make_pair(g_localizeStrings.Get(13106), VSYNC_DISABLED));

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -1017,6 +1017,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert("videoscreen.screen");
   settingSet.insert("videoscreen.resolution");
   settingSet.insert("videoscreen.screenmode");
+  settingSet.insert("videoscreen.vsync");
   m_settingsManager->RegisterCallback(&CDisplaySettings::Get(), settingSet);
 
   settingSet.clear();


### PR DESCRIPTION
@Montellese I'm not sure if there's a universal way to solve this.

I just copy n pasted the existing win32/android override.

It may also need overriding elsewhere, not sure.  @popcornmix rpi maybe?
