### PR TITLE
changed: Always show subtitle custom path option

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -940,9 +940,6 @@
               <source>videos</source>
             </sources>
           </constraints>
-          <dependencies>
-            <dependency type="enable" setting="subtitles.storagemode" operator="is">1</dependency>
-          </dependencies>
           <control type="button" format="path">
             <heading>657</heading>
           </control>


### PR DESCRIPTION
We also use the subtitle custom path setting when storage mode suggests we don't store in the custom path by default. Since this is confusing behavior, always enable for now (at least till #4411 is sorted) to fix this for Gotham.
