### PR TITLE
[depends] - add missing dependency for python native (needs libz-native)

### DIFF
--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -36,6 +36,7 @@ libsdl_image-native: libsdl-native libpng-native libjpeg-turbo-native tiff-nativ
 distribute-native: python26-native
 distutilscross-native: python26-native distribute-native
 tar-native: xz-native
+python26-native: zlib-native
 
 #liblzo2 has stale packaged automake files that cause borked host/build detection
 liblzo2-native: automake-native


### PR DESCRIPTION
Found by @garbear when compiling - i tag it gotham though it might be treated as "nice to have fix" ... not sure ;)
