### PR TITLE
[osxsink] - for devices which report samplerate 0hz - allow user overrid...

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -199,6 +199,18 @@ static void EnumerateDevices(CADeviceList &list)
             }
 
             // add sample rate info
+            // quirk devices which don't report a valid samplerate
+            // add 44.1khz and 48khz in that case - user can use
+            // the "fixed" audio config to force one of them
+            if (desc.mSampleRate == 0)
+            {
+              CLog::Log(LOGWARNING, "%s no valid samplerate - adding 44.1khz and 48khz quirk", __FUNCTION__);
+              desc.mSampleRate = 44100;
+              if (!HasSampleRate(device.m_sampleRates, desc.mSampleRate))
+                device.m_sampleRates.push_back(desc.mSampleRate);
+              desc.mSampleRate = 48000;
+            }
+
             if (!HasSampleRate(device.m_sampleRates, desc.mSampleRate))
               device.m_sampleRates.push_back(desc.mSampleRate);
           }
@@ -460,7 +472,14 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
     CCoreAudioStream::GetAvailablePhysicalFormats(*i, &formats);
     for (StreamFormatList::const_iterator j = formats.begin(); j != formats.end(); ++j)
     {
-      const AudioStreamBasicDescription &desc = j->mFormat;
+      AudioStreamBasicDescription desc = j->mFormat;
+
+      // quirk devices with invalid sample rate
+      // assume that the user uses a fixed config
+      // and knows what he is doing - so we use
+      // the requested samplerate here
+      if (desc.mSampleRate == 0)
+        desc.mSampleRate = format.m_sampleRate;
 
       float score = ScoreStream(desc, format);
 


### PR DESCRIPTION
...e

with 44.1khz and 48khz

There are broken coreaudio drivers out there for third party audio hardware on osx. E.x. HarmonKardon Soundsticks.

Those report "0" as samplerate. In that case ActiveAE just crashes @fernetmenta maybe something to cure?

Long story short. For the osx sink if we don't get a valid samplerate we add 44100 and 48000 and hope the user will chose the correct setting via "fixed" configuration.

@jmarshallnz - this is the quirk for http://forum.xbmc.org/showthread.php?tid=189472&pid=1661359#pid1661359
