### PR TITLE
[confluence] Add In progress to tvshow submenu

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2510,6 +2510,7 @@ msgctxt "#574"
 msgid "Country"
 msgstr ""
 
+#: addons/skin.confluence/720p/IncludesHomeMenuItems.xml#L105
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#575"

--- a/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
@@ -102,25 +102,30 @@
 		</control>
 		<control type="button" id="90173">
 			<include>ButtonHomeSubCommonValues</include>
+			<label>575</label>
+			<onclick>ActivateWindow(Videos,library://video_flat/inprogressshows.xml,return)</onclick>
+		</control>
+		<control type="button" id="90174">
+			<include>ButtonHomeSubCommonValues</include>
 			<label>369</label>
 			<onclick>ActivateWindow(Videos,TVShowTitles,return)</onclick>
 		</control>
-		<control type="button" id="90174">
+		<control type="button" id="90175">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>135</label>
 			<onclick>ActivateWindow(Videos,TVShowGenres,return)</onclick>
 		</control>
-		<control type="button" id="90175">
+		<control type="button" id="90176">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>652</label>
 			<onclick>ActivateWindow(Videos,TVShowYears,return)</onclick>
 		</control>
-		<control type="button" id="90176">
+		<control type="button" id="90177">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>344</label>
 			<onclick>ActivateWindow(Videos,TVShowActors,return)</onclick>
 		</control>
-		<control type="image" id="90177">
+		<control type="image" id="90178">
 			<width>35</width>
 			<height>35</height>
 			<texture border="0,0,0,3">HomeSubEnd.png</texture>


### PR DESCRIPTION
See http://forum.xbmc.org/showthread.php?tid=189038

I found it helpful not to have to aimlessly try to find such a nice often used node and place it in easy to access under the tvshow main menu entry.

![capture](https://f.cloud.github.com/assets/3521959/2506390/88683e46-b3a6-11e3-8f15-6c145a9602ee.PNG)

Reused label for this made note of such.

There probably is a better smarter more efficient way to implemented this. I hope it at least is right, after a few days of testing seems acceptable.

Hoping i doesn't shot down as works really well.

@ronie @jmarshallnz please review.
