### PR TITLE
Aefixes

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -127,7 +127,15 @@ IAESink *CAESinkFactory::TrySink(std::string &driver, std::string &device, AEAud
 
   if (sink->Initialize(format, device))
   {
-    return sink;
+    // do some sanity checks
+    if (format.m_sampleRate == 0)
+      CLog::Log(LOGERROR, "Sink %s:%s returned invalid sample rate", driver.c_str(), device.c_str());
+    else if (format.m_channelLayout.Count() == 0)
+      CLog::Log(LOGERROR, "Sink %s:%s returned invalid channel layout", driver.c_str(), device.c_str());
+    else if (format.m_frames < 256)
+      CLog::Log(LOGERROR, "Sink %s:%s returned invalid buffer size: %d", driver.c_str(), device.c_str(), format.m_frames);
+    else
+      return sink;
   }
   sink->Deinitialize();
   delete sink;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -988,7 +988,10 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
                 continue;
               it = find(info.m_dataFormats.begin(), info.m_dataFormats.end(), i);
               if (it == info.m_dataFormats.end())
+              {
                 info.m_dataFormats.push_back(i);
+                CLog::Log(LOGNOTICE, "CAESinkALSA::%s data format \"%s\" on device \"%s\" seems to be not supported.", __FUNCTION__, CAEUtil::DataFormatToStr(i), device.c_str());
+              }
             }
 
             if (badHDMI)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -671,14 +671,24 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
       wfxex.Format.nBlockAlign          = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
       wfxex.Format.nAvgBytesPerSec      = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
       hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
-      if (SUCCEEDED(hr))
+      if (SUCCEEDED(hr) || aeDeviceType == AE_DEVTYPE_HDMI)
+      {
+        if(FAILED(hr))
+          CLog::Log(LOGNOTICE, __FUNCTION__": data format \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::DataFormatToStr(AE_FMT_DTSHD), strFriendlyName.c_str());
+
         deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_DTSHD));
+      }
 
       /* Test format Dolby TrueHD */
       wfxex.SubFormat                   = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_MLP;
       hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
-      if (SUCCEEDED(hr))
+      if (SUCCEEDED(hr) || aeDeviceType == AE_DEVTYPE_HDMI)
+      {
+        if(FAILED(hr))
+          CLog::Log(LOGNOTICE, __FUNCTION__": data format \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::DataFormatToStr(AE_FMT_TRUEHD), strFriendlyName.c_str());
+
         deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_TRUEHD));
+      }
 
       /* Test format Dolby EAC3 */
       wfxex.SubFormat                   = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_DIGITAL_PLUS;
@@ -686,8 +696,13 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
       wfxex.Format.nBlockAlign          = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
       wfxex.Format.nAvgBytesPerSec      = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
       hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
-      if (SUCCEEDED(hr))
+      if (SUCCEEDED(hr) || aeDeviceType == AE_DEVTYPE_HDMI)
+      {
+        if(FAILED(hr))
+          CLog::Log(LOGNOTICE, __FUNCTION__": data format \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::DataFormatToStr(AE_FMT_EAC3), strFriendlyName.c_str());
+
         deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_EAC3));
+      }
 
       /* Test format DTS */
       wfxex.Format.nSamplesPerSec       = 48000;
@@ -696,20 +711,35 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
       wfxex.Format.nBlockAlign          = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
       wfxex.Format.nAvgBytesPerSec      = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
       hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
-      if (SUCCEEDED(hr))
+      if (SUCCEEDED(hr) || aeDeviceType == AE_DEVTYPE_HDMI)
+      {
+        if(FAILED(hr))
+          CLog::Log(LOGNOTICE, __FUNCTION__": data format \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::DataFormatToStr(AE_FMT_DTS), strFriendlyName.c_str());
+
         deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_DTS));
+      }
 
       /* Test format Dolby AC3 */
       wfxex.SubFormat                   = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_DIGITAL;
       hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
-      if (SUCCEEDED(hr))
+      if (SUCCEEDED(hr) || aeDeviceType == AE_DEVTYPE_HDMI)
+      {
+        if(FAILED(hr))
+          CLog::Log(LOGNOTICE, __FUNCTION__": data format \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::DataFormatToStr(AE_FMT_AC3), strFriendlyName.c_str());
+
         deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_AC3));
+      }
 
       /* Test format AAC */
       wfxex.SubFormat                   = KSDATAFORMAT_SUBTYPE_IEC61937_AAC;
       hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
-      if (SUCCEEDED(hr))
+      if (SUCCEEDED(hr) || aeDeviceType == AE_DEVTYPE_HDMI)
+      {
+        if(FAILED(hr))
+          CLog::Log(LOGNOTICE, __FUNCTION__": data format \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::DataFormatToStr(AE_FMT_AAC), strFriendlyName.c_str());
+
         deviceInfo.m_dataFormats.push_back(AEDataFormat(AE_FMT_AAC));
+      }
 
       /* Test format for PCM format iteration */
       wfxex.Format.cbSize               = sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX);
@@ -831,6 +861,12 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
         }
       }
       pClient->Release();
+
+      if (hasLpcm == false && aeDeviceType == AE_DEVTYPE_HDMI)
+      {
+        CLog::Log(LOGNOTICE, __FUNCTION__": data format \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::DataFormatToStr(AE_FMT_LPCM), strFriendlyName.c_str());
+        deviceInfo.m_dataFormats.push_back(AE_FMT_LPCM);
+      }
     }
     else
     {


### PR DESCRIPTION
- fix not available HD options for passthough causes by wrong ELD. Users should have a chance to overrule ELD
- fix potential crash by invalid initialization data returned by sink. thanks to @Memphiz
