### PR TITLE
[shairplay] - upstream backports - fix password protection and socket race condition

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -14,7 +14,7 @@ libass-0.10.2-win32.7z
 libbluray-0.4.0-win32.zip
 libjpeg-turbo-1.2.0-win32.7z
 libnfs-1.3.0-win32.7z
-libshairplay-c159ca7-win32.7z
+libshairplay-41a66c9-win32.7z
 libssh-0.5.0-1-win32.zip
 libxml2-2.7.8_1-win32.7z
 libxslt-1.1.26_1-win32.7z

--- a/tools/depends/target/libshairplay/02-fixipv4ipv6race.patch
+++ b/tools/depends/target/libshairplay/02-fixipv4ipv6race.patch
@@ -1,0 +1,27 @@
+From ac9240fa569df5a10d534a4cd45740a44ee00f63 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20V=C3=A4h=C3=A4-Herttua?= <juhovh@iki.fi>
+Date: Mon, 24 Mar 2014 20:35:29 +0200
+Subject: [PATCH] Fix #23 on issue tracker.
+
+There is a race condition if IPv4 and IPv6 connections come at the same time.
+---
+ src/lib/httpd.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/lib/httpd.c b/src/lib/httpd.c
+index 1d9e7e2..f081c5e 100644
+--- a/src/lib/httpd.c
++++ b/src/lib/httpd.c
+@@ -237,7 +237,8 @@ struct httpd_s {
+ 				continue;
+ 			}
+ 		}
+-		if (httpd->server_fd6 != -1 && FD_ISSET(httpd->server_fd6, &rfds)) {
++		if (httpd->open_connections < httpd->max_connections &&
++		    httpd->server_fd6 != -1 && FD_ISSET(httpd->server_fd6, &rfds)) {
+ 			ret = httpd_accept_connection(httpd, httpd->server_fd6, 1);
+ 			if (ret == -1) {
+ 				break;
+-- 
+1.8.5.5
+

--- a/tools/depends/target/libshairplay/03-fixpasswordauthitunes.patch
+++ b/tools/depends/target/libshairplay/03-fixpasswordauthitunes.patch
@@ -1,0 +1,22 @@
+From 8e6795779558d2828aef14078fefbcadd5323fa6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20V=C3=A4h=C3=A4-Herttua?= <juhovh@iki.fi>
+Date: Mon, 24 Mar 2014 21:43:59 +0200
+Subject: [PATCH] Make password authentication work on iTunes again, fixes #20.
+
+---
+ src/lib/raop.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/src/lib/raop.c b/src/lib/raop.c
+index e5c6539..a58e92f 100644
+--- a/src/lib/raop.c.orig	2013-04-17 15:17:49.000000000 +0200
++++ b/src/lib/raop.c	2014-03-24 23:22:30.000000000 +0100
+@@ -139,7 +139,7 @@
+ 	}
+ 
+ 	res = http_response_init("RTSP/1.0", 200, "OK");
+-	if (strlen(raop->password)) {
++	if (strcmp(method, "OPTIONS") && strlen(raop->password)) {
+ 		const char *authorization;
+ 
+ 		authorization = http_request_get_header(request, "Authorization");

--- a/tools/depends/target/libshairplay/Makefile
+++ b/tools/depends/target/libshairplay/Makefile
@@ -25,6 +25,7 @@ ifeq ($(OS),ios)
 	cd $(PLATFORM); patch -p1 < ../xcode-llmvfix.patch
 endif
 	cd $(PLATFORM); patch -p1 < ../02-fixipv4ipv6race.patch
+	cd $(PLATFORM); patch -p1 < ../03-fixpasswordauthitunes.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 

--- a/tools/depends/target/libshairplay/Makefile
+++ b/tools/depends/target/libshairplay/Makefile
@@ -24,6 +24,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 ifeq ($(OS),ios)
 	cd $(PLATFORM); patch -p1 < ../xcode-llmvfix.patch
 endif
+	cd $(PLATFORM); patch -p1 < ../02-fixipv4ipv6race.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 


### PR DESCRIPTION
Here are 2 non intrusive backports from the libshairplay upstream developer
1. Fixes password protection with iTunes clients
2. Fixed a race condition when ios7.x devices try to connect via ipv4 and ipv6 nearly at the same time

Win32 package is uploaded and i tested both use cases.

There might be one more fix in the queue for ios7.1 clients where apple seems to have added new DRM functionality which bites into libshairplays ass - but atm its unclear if this is even fixable - so i don't wait on that and will bring up a new PR if a fix appears and looks non-intrusive enough.
