### PR TITLE
Two UPnP controller related fixes

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2023,12 +2023,15 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="services.upnprenderer" type="boolean" label="21881" help="36325">
+        <setting id="services.upnpcontroller" type="boolean" label="21361" help="36326">
           <level>1</level>
           <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="services.upnpserver">true</dependency>
+          </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="services.upnpcontroller" type="boolean" label="21361" help="36326">
+        <setting id="services.upnprenderer" type="boolean" label="21881" help="36325">
           <level>1</level>
           <default>false</default>
           <control type="toggle" />

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -22,6 +22,8 @@
  *
  */
 
+#include <set>
+
 #include "threads/SystemClock.h"
 #include "UPnP.h"
 #include "UPnPInternal.h"
@@ -287,6 +289,9 @@ public:
 
   ~CMediaController()
   {
+    for (std::set<std::string>::const_iterator itRenderer = m_registeredRenderers.begin(); itRenderer != m_registeredRenderers.end(); ++itRenderer)
+      unregisterRenderer(*itRenderer);
+    m_registeredRenderers.clear();
   }
 
 #define CHECK_USERDATA_RETURN(userdata) do {     \
@@ -351,16 +356,33 @@ public:
 
   virtual bool OnMRAdded(PLT_DeviceDataReference& device )
   {
+    if (device->GetUUID().IsEmpty() || device->GetUUID().GetChars() == NULL)
+      return false;
+
     CPlayerCoreFactory::Get().OnPlayerDiscovered((const char*)device->GetUUID()
                                           ,(const char*)device->GetFriendlyName()
                                           , EPC_UPNPPLAYER);
+    m_registeredRenderers.insert(std::string(device->GetUUID().GetChars()));
     return true;
   }
 
   virtual void OnMRRemoved(PLT_DeviceDataReference& device )
   {
-    CPlayerCoreFactory::Get().OnPlayerRemoved((const char*)device->GetUUID());
+    if (device->GetUUID().IsEmpty() || device->GetUUID().GetChars() == NULL)
+      return;
+
+    std::string uuid(device->GetUUID().GetChars());
+    unregisterRenderer(uuid);
+    m_registeredRenderers.erase(uuid);
   }
+
+private:
+  void unregisterRenderer(const std::string &deviceUUID)
+  {
+    CPlayerCoreFactory::Get().OnPlayerRemoved(deviceUUID);
+  }
+
+  std::set<std::string> m_registeredRenderers;
 };
 
 /*----------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -496,7 +496,8 @@ CUPnP::StartClient()
     m_MediaBrowser = new CMediaBrowser(m_CtrlPointHolder->m_CtrlPoint);
 
     // start controller
-    if (CSettings::Get().GetBool("services.upnpcontroller")) {
+    if (CSettings::Get().GetBool("services.upnpcontroller") &&
+        CSettings::Get().GetBool("services.upnpserver")) {
         m_MediaController = new CMediaController(m_CtrlPointHolder->m_CtrlPoint);
     }
 }


### PR DESCRIPTION
The first commit fixes http://trac.xbmc.org/ticket/15050 where the user can choose a remote UPnP player (renderer) but the action doesn't work (and there is no feedback about the failure) because the UPnP controller needs the UPnP server running to be able to serve the necessary files to the renderer. Therefore I've changed the settings so that the controller can only be enabled if the server is enabled as well.

The second commit fixes the fact that when disabling the UPnP controller in the settings, any previously discovered remote renderers are still registered in CPlayerCoreFactory and are therefore still listed in the "Play using..." dialog. When selecting one of those remote renderers XBMC will crash because it tries to access a member variable from the UPnP controller which doesn't exist anymore. I've added a set to remember all discovered remote renderers and unregister them from the CPlayerCoreFactory when destroying the UPnP controller.
