### PR TITLE
Change FLAC MIME type

### DIFF
--- a/lib/libUPnP/Neptune/Source/Core/NptHttp.cpp
+++ b/lib/libUPnP/Neptune/Source/Core/NptHttp.cpp
@@ -2880,6 +2880,7 @@ NPT_HttpFileRequestHandler_DefaultFileTypeMap[] = {
     {"aif",  "audio/x-aiff"},
     {"aifc", "audio/x-aiff"},
     {"aiff", "audio/x-aiff"},
+    {"flac", "audio/x-flac"},
     {"mka",  "audio/x-matroska"},
     {"mpa",  "audio/mpeg"},
     {"mp2",  "audio/mpeg"},

--- a/lib/libUPnP/patches/0024-Neptune-Add-audio-x-flac-MIME-type.patch
+++ b/lib/libUPnP/patches/0024-Neptune-Add-audio-x-flac-MIME-type.patch
@@ -1,0 +1,32 @@
+From 0308017deff74d962190b9621d4dfeaa1df20ef8 Mon Sep 17 00:00:00 2001
+From: mossywell <mark@mossywell.com>
+Date: Fri, 28 Mar 2014 07:26:49 +0000
+Subject: [PATCH 24/24] Neptune Add audio/x-flac MIME type
+
+Change streaming FLAC MIME type from application/octet to audio/x-flac to
+support Frontier Silicon systems (such as the Axis X3) that require
+this. (Others don't care.)
+
+FLAC not added to DefaultDlnaMap as * suffices.
+
+(Commit amend: tabs --> spaces)
+(Commit amend: flac --> x-flac)
+---
+ lib/libUPnP/Neptune/Source/Core/NptHttp.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/libUPnP/Neptune/Source/Core/NptHttp.cpp b/lib/libUPnP/Neptune/Source/Core/NptHttp.cpp
+index 07586f9..d2e36b1 100644
+--- a/lib/libUPnP/Neptune/Source/Core/NptHttp.cpp
++++ b/lib/libUPnP/Neptune/Source/Core/NptHttp.cpp
+@@ -2880,6 +2880,7 @@ NPT_HttpFileRequestHandler_DefaultFileTypeMap[] = {
+     {"aif",  "audio/x-aiff"},
+     {"aifc", "audio/x-aiff"},
+     {"aiff", "audio/x-aiff"},
++    {"flac", "audio/x-flac"},
+     {"mka",  "audio/x-matroska"},
+     {"mpa",  "audio/mpeg"},
+     {"mp2",  "audio/mpeg"},
+-- 
+1.8.4.msysgit.0
+


### PR DESCRIPTION
Change streaming FLAC MIME type from application/octet to audio/flac to
support Frontier Silicon systems (such as the Axis X3) that require
this. (Others don't care.)

Only affects UPNP streaming.

(Might be worth updating the Neptune / Platinum code as well. It is currently running 0.6.9.1 but the latest is 1.0.4.11.)
