### PR TITLE
Add an element onitemchanged to the 4 types of container

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1258,16 +1258,16 @@ void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter) const
 
 void CGUIBaseContainer::SetCursor(int cursor)
 {
-   int previous_cursor = m_cursor;
-   m_cursor = cursor;
-   if(previous_cursor != m_cursor)
+  int previous_cursor = m_cursor;
+  m_cursor = cursor;
+  if(previous_cursor != m_cursor)
     RunItemChangedActions(); 
 }
 
 void CGUIBaseContainer::SetOffset(int offset)
 {
   int previous_offset = m_offset;
-  if (m_offset != offset)
+  if(m_offset != offset)
     MarkDirtyRegion();
   m_offset = offset;
   if(previous_offset != m_offset)
@@ -1297,10 +1297,10 @@ void CGUIBaseContainer::OnFocus()
 
 void CGUIBaseContainer::RunItemChangedActions()
 {
-   m_itemchangedActions.ExecuteActions(GetID(), GetParentID());
+  m_itemchangedActions.ExecuteActions(GetID(), GetParentID());
 }
 
 void CGUIBaseContainer::SetItemChangedActions(const CGUIAction &itemchanged)
 {
-    m_itemchangedActions = itemchanged;
+  m_itemchangedActions = itemchanged;
 }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1258,14 +1258,20 @@ void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter) const
 
 void CGUIBaseContainer::SetCursor(int cursor)
 {
-  m_cursor = cursor;
+   int previous_cursor = m_cursor;
+   m_cursor = cursor;
+   if(previous_cursor != m_cursor)
+    RunItemChangedActions(); 
 }
 
 void CGUIBaseContainer::SetOffset(int offset)
 {
+  int previous_offset = m_offset;
   if (m_offset != offset)
     MarkDirtyRegion();
   m_offset = offset;
+  if(previous_offset != m_offset)
+    RunItemChangedActions(); 
 }
 
 bool CGUIBaseContainer::CanFocus() const
@@ -1287,4 +1293,14 @@ void CGUIBaseContainer::OnFocus()
     SelectItem(m_listProvider->GetDefaultItem());
 
   CGUIControl::OnFocus();
+}
+
+void CGUIBaseContainer::RunItemChangedActions()
+{
+   m_itemchangedActions.ExecuteActions(GetID(), GetParentID());
+}
+
+void CGUIBaseContainer::SetItemChangedActions(const CGUIAction &itemchanged)
+{
+    m_itemchangedActions = itemchanged;
 }

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -92,6 +92,10 @@ public:
   void SetAutoScrolling(const TiXmlNode *node);
   void ResetAutoScrolling();
   void UpdateAutoScrolling(unsigned int currentTime);
+  
+  void SetItemChangedActions(const CGUIAction &itemchanged);
+  
+  CGUIAction m_itemchangedActions;
 
 #ifdef _DEBUG
   virtual void DumpTextureUse();
@@ -101,7 +105,7 @@ protected:
   bool OnClick(int actionID);
 
   virtual void ProcessItem(float posX, float posY, CGUIListItemPtr& item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions);
-
+  virtual void RunItemChangedActions();
   virtual void Render();
   virtual void RenderItem(float posX, float posY, CGUIListItem *item, bool focused);
   virtual void Scroll(int amount);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -677,7 +677,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   float width = 0, height = 0;
   float minHeight = 0, minWidth = 0;
 
-  CGUIAction leftActions, rightActions, upActions, downActions, backActions, nextActions, prevActions;
+  CGUIAction leftActions, rightActions, upActions, downActions, backActions, nextActions, prevActions, itemchangedActions;
 
   int pageControl = 0;
   CGUIInfoColor colorDiffuse(0xFFFFFFFF);
@@ -829,6 +829,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetActions(pControlNode, "onnext",  nextActions);
   GetActions(pControlNode, "onprev",  prevActions);
   GetActions(pControlNode, "onback",  backActions);
+  GetActions(pControlNode, "onitemchanged",  itemchangedActions);
 
   if (XMLUtils::GetInt(pControlNode, "defaultcontrol", defaultControl))
   {
@@ -1329,6 +1330,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIListContainer *)control)->SetPageControl(pageControl);
     ((CGUIListContainer *)control)->SetRenderOffset(offset);
     ((CGUIListContainer *)control)->SetAutoScrolling(pControlNode);
+    ((CGUIListContainer *)control)->SetItemChangedActions(itemchangedActions);
   }
   else if (type == CGUIControl::GUICONTAINER_WRAPLIST)
   {
@@ -1342,6 +1344,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIWrappingListContainer *)control)->SetPageControl(pageControl);
     ((CGUIWrappingListContainer *)control)->SetRenderOffset(offset);
     ((CGUIWrappingListContainer *)control)->SetAutoScrolling(pControlNode);
+    ((CGUIWrappingListContainer *)control)->SetItemChangedActions(itemchangedActions);
   }
   else if (type == CGUIControl::GUICONTAINER_EPGGRID)
   {
@@ -1362,6 +1365,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIFixedListContainer *)control)->SetPageControl(pageControl);
     ((CGUIFixedListContainer *)control)->SetRenderOffset(offset);
     ((CGUIFixedListContainer *)control)->SetAutoScrolling(pControlNode);
+    ((CGUIFixedListContainer *)control)->SetItemChangedActions(itemchangedActions);
   }
   else if (type == CGUIControl::GUICONTAINER_PANEL)
   {
@@ -1375,6 +1379,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     ((CGUIPanelContainer *)control)->SetPageControl(pageControl);
     ((CGUIPanelContainer *)control)->SetRenderOffset(offset);
     ((CGUIPanelContainer *)control)->SetAutoScrolling(pControlNode);
+    ((CGUIPanelContainer *)control)->SetItemChangedActions(itemchangedActions);
   }
   else if (type == CGUIControl::GUICONTROL_TEXTBOX)
   {


### PR DESCRIPTION
This pr add an element onitemchanged to the 4 containers that can trigger  actions each time a new item is selected, similar to onload for window.

Actually several add-ons do it in a hackish way; for instance next-aired and others  launch a background process that start a thread that continuously check for the active window with a sleep between checks .... Some other add-ons launch a prescan then use ListItem.DBID with a value store in an extra add-on cache in addon_data....

WIth this, it is possible to launch a script each time the item changes.

For instance i use it like this to display an extras flag in my custom skin in movie mode : 

``` xml
<control type="list" id="50">
<onitemchanged condition="blah..">XBMC.RunScript(script.videoextras,check,"$INFO[ListItem.FilenameAndPath]")</onitemchanged>
<posx>200</posx>
<width>355</width>
...
```

!!!TODO!!! : 

The itemchanged is triggered each time cursor or offset is changed; so in some situation, cursor and offset are changed one after the other. this will trigger 2 times the actions for one change.

While this do not disturb me personaly so far, this can be fixed pretty easily i just want to have some review from the big devs guru before spending more time on this.
