### PR TITLE
[AE] Added AC3 Core passthrough for E-AC3 tracks that support it

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -52,6 +52,7 @@ public:
   int AddData(uint8_t *data, unsigned int size, uint8_t **buffer = NULL, unsigned int *bufferSize = 0);
 
   void                      SetCoreOnly      (bool value) { m_coreOnly = value; }
+  void                      SetAC3Only       (bool value) { m_ac3Only = value; }
   unsigned int              IsValid          () { return m_hasSync       ; }
   unsigned int              GetSampleRate    () { return m_sampleRate    ; }
   unsigned int              GetOutputRate    () { return m_outputRate    ; }
@@ -67,6 +68,14 @@ public:
   CAEPackIEC61937::PackFunc GetPackFunc      () { return m_packFunc      ; }
   unsigned int              GetBufferSize    () { return m_bufferSize    ; }
 private:
+  enum AC3Type
+  {
+     AC3TYPE_INVALID,
+     AC3TYPE_AC3,
+     AC3TYPE_EAC3_WITH_AC3MAIN,
+     AC3TYPE_EAC3_INDEPENDENT_STREAM_ONLY,
+     AC3TYPE_EAC3_WITH_DEPENDENT_STREAM
+  };
   DllAvUtil m_dllAvUtil;
 
   uint8_t      m_buffer[MAX_IEC61937_PACKET];
@@ -95,6 +104,8 @@ private:
   DataType                  m_dataType;
   bool                      m_dataIsLE;
   CAEPackIEC61937::PackFunc m_packFunc;
+  bool                      m_ac3Only;
+  AC3Type                   m_ac3Type;
 
   void GetPacket(uint8_t **buffer, unsigned int *bufferSize);
   unsigned int DetectType(uint8_t *data, unsigned int size);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -41,13 +41,16 @@ CDVDAudioCodecPassthrough::~CDVDAudioCodecPassthrough(void)
 bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
   bool bSupportsAC3Out    = CAEFactory::SupportsRaw(AE_FMT_AC3, hints.samplerate);
-  bool bSupportsEAC3Out   = CAEFactory::SupportsRaw(AE_FMT_EAC3, 192000);
+  bool bSupportsEAC3Out   = CAEFactory::SupportsRaw(AE_FMT_EAC3, 4*hints.samplerate); // E-AC3 is 4 times sample rate once packed into IEC 61937 format
   bool bSupportsDTSOut    = CAEFactory::SupportsRaw(AE_FMT_DTS, hints.samplerate);
   bool bSupportsTrueHDOut = CAEFactory::SupportsRaw(AE_FMT_TRUEHD, 192000);
   bool bSupportsDTSHDOut  = CAEFactory::SupportsRaw(AE_FMT_DTSHD, 192000);
 
   /* only get the dts core from the parser if we don't support dtsHD */
   m_info.SetCoreOnly(!bSupportsDTSHDOut);
+  /* only get the ac3 core for e-ac3 if possible from the parser */
+  m_info.SetAC3Only(!bSupportsEAC3Out);
+
   m_bufferSize = 0;
 
   /* 32kHz E-AC-3 passthrough requires 128kHz IEC 60958 stream

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -85,6 +85,7 @@
 #include "LangInfo.h"
 #include "URL.h"
 #include "utils/LangCodeExpander.h"
+#include "cores/AudioEngine/AEFactory.h"
 
 using namespace std;
 using namespace PVR;
@@ -2936,7 +2937,11 @@ bool CDVDPlayer::OpenAudioStream(int iStream, int source, bool reset)
   if(m_CurrentAudio.id    < 0
   || m_CurrentAudio.hint != hint)
   {
-    if (!m_dvdPlayerAudio.OpenStream( hint ))
+    if (m_CurrentAudio.hint.codec == AV_CODEC_ID_AC3 && hint.codec == AV_CODEC_ID_EAC3 && m_dvdPlayerAudio.IsPassthrough() && !CAEFactory::SupportsRaw(AE_FMT_EAC3, 4*hint.samplerate))
+    {
+       // if we were using AC3 and now transitioning to EAC3 with no support for EAC3 try to extract the AC3 core by continuing to use the existing stream as AC3
+    }
+    else if (!m_dvdPlayerAudio.OpenStream( hint ))
     {
       /* mark stream as disabled, to disallaw further attempts*/
       CLog::Log(LOGWARNING, "%s - Unsupported stream %d. Stream disabled.", __FUNCTION__, iStream);


### PR DESCRIPTION
Added the ability to passthrough AC3 for E-AC3 tracks that have an AC3 core stream.  This only affects devices that can not passthrough E-AC3 (SPDIF, some TV's, etc).  

In addition I also added the ability to have a dependent stream with an E-AC3 core.  Currently the only dependent streams that are supported are with an AC3 core main stream.  This now allows for a dependent stream with an E-AC3 core main stream.  I however have not tested this thoroughly as I have not found a sample that actually contains this.  Any 7.1 non AC3 core samples out there?  This could still be improved as I believe the spec allows for up to 8 dependent streams and currently there is only support for 1 (have seen no samples with more than 1).

This change also affects the number of channels reported for E-AC3 streams.  Currently E-AC3 plus streams are hard coded to 7.1.  I now use the main stream as the number of channels and then modify the number of channels once a dependent stream is found.  This delayed update however does not seem to affect what is displayed.

Open to suggestions or opinions for improvements.  I am not a huge fan of the DVDPlayer change but could not see another way to handle this.
