### PR TITLE
Start in history - fixes ActivateWindow() links with 'return' specified

### DIFF
--- a/xbmc/filesystem/DirectoryHistory.cpp
+++ b/xbmc/filesystem/DirectoryHistory.cpp
@@ -103,6 +103,20 @@ CStdString CDirectoryHistory::GetParentPath(bool filter /* = false */)
   return m_vecPathHistory.back().GetPath(filter);
 }
 
+bool CDirectoryHistory::IsInHistory(const std::string &path) const
+{
+  std::string slashEnded(path);
+  URIUtils::AddSlashAtEnd(slashEnded);
+  for (vector<CPathHistoryItem>::const_iterator i = m_vecPathHistory.begin(); i != m_vecPathHistory.end(); ++i)
+  {
+    std::string testPath(i->GetPath());
+    URIUtils::AddSlashAtEnd(testPath);
+    if (slashEnded == testPath)
+      return true;
+  }
+  return false;
+}
+
 CStdString CDirectoryHistory::RemoveParentPath(bool filter /* = false */)
 {
   if (m_vecPathHistory.empty())

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -62,6 +62,12 @@ public:
   void ClearSearchHistory();
   void DumpPathHistory();
 
+  /*! \brief Returns whether a path is in the history.
+   \param path to test
+   \return true if the path is in the history, false otherwise.
+   */
+  bool IsInHistory(const std::string &path) const;
+
 private:
   static CStdString preparePath(const CStdString &strDirectory, bool tolower = true);
   

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -490,17 +490,22 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       bool returning = StringUtils::EqualsNoCase(ret, "return");
       if (!dir.empty())
       {
-        m_history.ClearPathHistory();
         // ensure our directory is valid
         dir = GetStartFolder(dir);
-        if (!returning || !StringUtils::StartsWith(m_vecItems->GetPath(), dir))
+        bool resetHistory = false;
+        if (!returning || !m_history.IsInHistory(dir))
         { // we're not returning to the same path, so set our directory to the requested path
           m_vecItems->SetPath(dir);
+          resetHistory = true;
         }
         // check for network up
         if (URIUtils::IsRemote(m_vecItems->GetPath()) && !WaitForNetwork())
+        {
           m_vecItems->SetPath("");
-        SetHistoryForPath(m_vecItems->GetPath());
+          resetHistory = true;
+        }
+        if (resetHistory)
+          SetHistoryForPath(m_vecItems->GetPath());
       }
       if (message.GetParam1() != WINDOW_INVALID)
       { // first time to this window - make sure we set the root path


### PR DESCRIPTION
See http://trac.xbmc.org/ticket/15015

IMO the potential impact is enough that this minor issue doesn't need to make it into Gotham until it's well tested in master (i.e. potentially a 13.1 fix).

@Montellese, @arnova to take a looksee please.
