### PR TITLE
jsonrpc: add missing GUI.OnScreensaverActivated/OnScreensaverDeactivated notifications to the API definition

### DIFF
--- a/addons/xbmc.json/addon.xml
+++ b/addons/xbmc.json/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.json" version="6.14.1" provider-name="Team XBMC">
+<addon id="xbmc.json" version="6.14.2" provider-name="Team XBMC">
   <backwards-compatibility abi="6.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.14.1";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.14.2";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -4326,6 +4326,24 @@ namespace JSONRPC
     "\"Input.OnInputFinished\": {"
       "\"type\": \"notification\","
       "\"description\": \"The user has provided the requested input.\","
+      "\"params\": ["
+        "{ \"name\": \"sender\", \"type\": \"string\", \"required\": true },"
+        "{ \"name\": \"data\", \"type\": \"null\", \"required\": true }"
+      "],"
+      "\"returns\": null"
+    "}",
+    "\"GUI.OnScreensaverActivated\": {"
+      "\"type\": \"notification\","
+      "\"description\": \"The screensaver has been activated.\","
+      "\"params\": ["
+        "{ \"name\": \"sender\", \"type\": \"string\", \"required\": true },"
+        "{ \"name\": \"data\", \"type\": \"null\", \"required\": true }"
+      "],"
+      "\"returns\": null"
+    "}",
+    "\"GUI.OnScreensaverDeactivated\": {"
+      "\"type\": \"notification\","
+      "\"description\": \"The screensaver has been deactivated.\","
       "\"params\": ["
         "{ \"name\": \"sender\", \"type\": \"string\", \"required\": true },"
         "{ \"name\": \"data\", \"type\": \"null\", \"required\": true }"

--- a/xbmc/interfaces/json-rpc/notifications.json
+++ b/xbmc/interfaces/json-rpc/notifications.json
@@ -321,5 +321,23 @@
       { "name": "data", "type": "null", "required": true }
     ],
     "returns": null
+  },
+  "GUI.OnScreensaverActivated": {
+    "type": "notification",
+    "description": "The screensaver has been activated.",
+    "params": [
+      { "name": "sender", "type": "string", "required": true },
+      { "name": "data", "type": "null", "required": true }
+    ],
+    "returns": null
+  },
+  "GUI.OnScreensaverDeactivated": {
+    "type": "notification",
+    "description": "The screensaver has been deactivated.",
+    "params": [
+      { "name": "sender", "type": "string", "required": true },
+      { "name": "data", "type": "null", "required": true }
+    ],
+    "returns": null
   }
 }


### PR DESCRIPTION
A user in the forums told me that the GUI.OnScreensaverActivated/OnScreensaverDeactivated notifications are missing from the JSON-RPC API definition.
