### PR TITLE
settings: remember whether a setting has its default value or not

### DIFF
--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -101,6 +101,7 @@ public:
   int GetHelp() const { return m_help; }
   void SetHelp(int help) { m_help = help; }
   bool IsEnabled() const;
+  bool IsDefault() const { return !m_changed; }
   const std::string& GetParent() const { return m_parentSetting; }
   SettingLevel GetLevel() const { return m_level; }
   const ISettingControl* GetControl() const { return m_control; }


### PR DESCRIPTION
This change writes a

```
default="true"
```

attribute into guisettings.xml if the value of the setting still matches the default value of the setting. This allows us not to read the actual value stored in guisettings.xml when that attribute is set. This is especially useful when we want to change the default value of a setting. Up until now changing the default value was possible but it didn't have any effect on existing installations because the new default value was always overwritten with the old default value stored in guisettings.xml.
