### PR TITLE
paplayer: use position based seeks for ffmpeg demuxer

### DIFF
--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -24,6 +24,7 @@
 #include "cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h"
 #include "cores/dvdplayer/DVDDemuxers/DVDFactoryDemuxer.h"
 #include "cores/dvdplayer/DVDDemuxers/DVDDemuxUtils.h"
+#include "cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h"
 #include "cores/dvdplayer/DVDStreamInfo.h"
 #include "cores/dvdplayer/DVDCodecs/DVDFactoryCodec.h"
 #include "music/tags/TagLoaderTagLib.h"
@@ -60,6 +61,12 @@ void DVDPlayerCodec::SetContentType(const CStdString &strContent)
 
 bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
 {
+  if (!m_dllAvUtil.Load())
+  {
+    CLog::Log(LOGERROR, "DVDPlayerCodec::Init - failed to load avutil");
+    return false;
+  }
+
   // take precaution if Init()ialized earlier
   if (m_bInited)
   {
@@ -239,6 +246,8 @@ void DVDPlayerCodec::DeInit()
     m_pAudioCodec = NULL;
   }
 
+  m_dllAvUtil.Unload();
+
   // cleanup format information
   m_TotalTime = 0;
   m_SampleRate = 0;
@@ -262,7 +271,11 @@ int64_t DVDPlayerCodec::Seek(int64_t iSeekTime)
     CDVDDemuxUtils::FreeDemuxPacket(m_pPacket);
   m_pPacket = NULL;
 
-  m_pDemuxer->SeekTime((int)iSeekTime, false);
+  CDVDDemuxFFmpeg *ffmpegDemuxer = dynamic_cast<CDVDDemuxFFmpeg*>(m_pDemuxer);
+  if (ffmpegDemuxer)
+    ffmpegDemuxer->SeekByte(m_dllAvUtil.av_rescale_rnd(iSeekTime, m_pInputStream->GetLength(), m_TotalTime, AV_ROUND_NEAR_INF));
+  else
+    m_pDemuxer->SeekTime((int)iSeekTime, false);
   m_pAudioCodec->Reset();
 
   m_decoded = NULL;

--- a/xbmc/cores/paplayer/DVDPlayerCodec.h
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.h
@@ -26,6 +26,7 @@
 #include "cores/dvdplayer/DVDDemuxers/DVDDemux.h"
 #include "cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodec.h"
 #include "cores/dvdplayer/DVDInputStreams/DVDInputStream.h"
+#include "DllAvUtil.h"
 
 class DVDPlayerCodec : public ICodec
 {
@@ -63,6 +64,8 @@ private:
   CAEChannelInfo m_ChannelInfo;
 
   bool m_bInited;
+
+  DllAvUtil m_dllAvUtil;
 };
 
 #endif


### PR DESCRIPTION
fixes trac 'av_seek_frame' is slow for single music file using cue sheet through network http://trac.xbmc.org/ticket/15059

timestamp based seeks don't work well on audio files
