### PR TITLE
Added optional parameter 'useCached' to xbmc.playSFX()

### DIFF
--- a/xbmc/guilib/GUIAudioManager.h
+++ b/xbmc/guilib/GUIAudioManager.h
@@ -66,7 +66,7 @@ public:
 
   void PlayActionSound(const CAction& action);
   void PlayWindowSound(int id, WINDOW_SOUND event);
-  void PlayPythonSound(const CStdString& strFileName);
+  void PlayPythonSound(const CStdString& strFileName, bool useCached = true);
 
   void Enable(bool bEnable);
   void SetVolume(float level);
@@ -89,6 +89,7 @@ private:
 
   IAESound* LoadSound(const CStdString &filename);
   void      FreeSound(IAESound *sound);
+  void      FreeSoundAllUsage(IAESound *sound);
   IAESound* LoadWindowSound(TiXmlNode* pWindowNode, const CStdString& strIdentifier);
 };
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -325,7 +325,7 @@ namespace XBMCAddon
       return g_infoManager.GetImage(ret, WINDOW_INVALID);
     }
 
-    void playSFX(const char* filename)
+    void playSFX(const char* filename, bool useCached)
     {
       XBMC_TRACE;
       if (!filename)
@@ -333,7 +333,7 @@ namespace XBMCAddon
 
       if (XFILE::CFile::Exists(filename))
       {
-        g_audioManager.PlayPythonSound(filename);
+        g_audioManager.PlayPythonSound(filename,useCached);
       }
     }
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -223,11 +223,12 @@ namespace XBMCAddon
      * playSFX(filename) -- Plays a wav file by filename
      * 
      * filename       : string - filename of the wav file to play.
+     * useCached      : [opt] bool - False = Dump any previously cached wav associated with filename
      * 
      * example:
      *   - xbmc.playSFX('special://xbmc/scripts/dingdong.wav')
      */
-    void playSFX(const char* filename);
+    void playSFX(const char* filename, bool useCached = true);
 
     /**
      * stopSFX() -- Stops wav file


### PR DESCRIPTION
This allows calling playSFX() on the same file without it using a cached sound.

There are two reasons to do this:
1. For my purposes, I am calling playSFX() many times with different wavs. Currently I have to update the file name every time and delete the old one. It would be much simpler to just use one file name.
2. If I am reading the code correctly, each call to playSFX() stores the sound in a map for later retrieval and cleanup. Most importantly though, I don't see any mechanism that ever clears old entries regularly. This would be fine for normal usage, but when calling it continually as I need to, it ends up just filling memory.

If there is some mechanism I missed that clears this, feel free to point it out. I have a Raspberry Pi user who continually gets out of memory errors when running our TTS addon and I think this is the cause. Even if I'm wrong and this cache is getting cleared, there is no point filling it at all if I don't need to.
