### PR TITLE
[airplay] - fix unwanted volume restore

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -160,7 +160,13 @@ void CAirPlayServer::Announce(AnnouncementFlag flag, const char *sender, const c
   {
     if (strcmp(message, "OnStop") == 0)
     {
-      restoreVolume();
+      bool shouldRestoreVolume = true;
+      if (data.isMember("player") && data["player"].isMember("playerid"))
+        shouldRestoreVolume = (data["player"]["playerid"] != PLAYLIST_PICTURE);
+
+      if (shouldRestoreVolume)
+        restoreVolume();
+
       ServerInstance->AnnounceToClients(EVENT_STOPPED);
     }
     else if (strcmp(message, "OnPlay") == 0)

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -140,10 +140,6 @@ void CAirTunesServer::Announce(AnnouncementFlag flag, const char *sender, const 
 {
   if ( (flag & Player) && strcmp(sender, "xbmc") == 0)
   {
-#ifdef HAS_AIRPLAY
-    if (strcmp(message, "OnStop") == 0)
-      CAirPlayServer::restoreVolume();
-#endif
     if (strcmp(message, "OnPlay") == 0 && m_streamStarted)
     {
       RefreshMetadata();


### PR DESCRIPTION
As reported by a user when streaming music via airplay and in addition streaming a photo via airplay - after dismissing the photo app (meaning we return to the music visualisation) the volume was restored to the xbmc volume in accident. This is the case because stopping the picture in XBMC sends an "OnStop" event which airplayserver uses for restoring the volume.

Fix this by checking if "PLAYLIST_PICTURE" was the source of the "OnStop" event.
