### PR TITLE
[settings] Only need a confirmation dialogue when resolution has changed

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -240,7 +240,7 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
 
     // check if the old or the new resolution was/is windowed
     // in which case we don't show any prompt to the user
-    if (oldRes != RES_WINDOW && newRes != RES_WINDOW)
+    if (oldRes != RES_WINDOW && newRes != RES_WINDOW && oldRes != newRes)
     {
       if (!m_resolutionChangeAborted)
       {


### PR DESCRIPTION
This fixes a bug when every time video output settings page is opened it asks if you would like to keep this change

Reported as fixed here:
http://forum.xbmc.org/showthread.php?tid=184866&pid=1668782#pid1668782
