### PR TITLE
Profiles tab is not deselected

### DIFF
--- a/addons/webinterface.default/js/MediaLibrary.js
+++ b/addons/webinterface.default/js/MediaLibrary.js
@@ -44,7 +44,7 @@ MediaLibrary.prototype = {
     $('#tvshowLibrary').removeClass('selected');
     $('#remoteControl').removeClass('selected');
     $('#pictureLibrary').removeClass('selected');
-    $('#profilesLibrary').removeClass('selected');
+    $('#profiles').removeClass('selected');
     this.hideOverlay();
   },
   replaceAll: function (haystack, needle, thread) {


### PR DESCRIPTION
When clicking on Profiles tab and then clicking on a different tab, Profiles tab is still selected.
The fix is to resetPage function to deselect the right tab name.
