### PR TITLE
[rbp] Fixes for hangs and leaks in jpeg->texture code

### DIFF
--- a/xbmc/cores/omxplayer/OMXImage.h
+++ b/xbmc/cores/omxplayer/OMXImage.h
@@ -79,15 +79,15 @@ public:
   void DestroyTexture(void *userdata);
   void GetTexture(void *userdata, GLuint *texture);
 private:
-  EGLDisplay m_egl_display;
   EGLContext m_egl_context;
 
   void CreateContext();
+  EGLContext GetEGLContext();
   CCriticalSection               m_texqueue_lock;
   XbmcThreads::ConditionVariable m_texqueue_cond;
   std::queue <struct textureinfo *> m_texqueue;
-  void AllocTextureInternal(struct textureinfo *tex);
-  void DestroyTextureInternal(struct textureinfo *tex);
+  void AllocTextureInternal(EGLDisplay egl_display, EGLContext egl_context, struct textureinfo *tex);
+  void DestroyTextureInternal(EGLDisplay egl_display, EGLContext egl_context, struct textureinfo *tex);
 };
 
 class COMXImageFile
@@ -184,9 +184,9 @@ public:
 
   // Required overrides
   void Close(void);
-  bool Decode(const uint8_t *data, unsigned size, unsigned int width, unsigned int height, void *egl_image, void *egl_display);
+  bool Decode(const uint8_t *data, unsigned size, unsigned int width, unsigned int height, void *egl_image);
 protected:
-  bool HandlePortSettingChange(unsigned int resize_width, unsigned int resize_height, void *egl_image, void *egl_display, bool port_settings_changed);
+  bool HandlePortSettingChange(unsigned int resize_width, unsigned int resize_height, void *egl_image, bool port_settings_changed);
 
   // Components
   COMXCoreComponent m_omx_decoder;

--- a/xbmc/cores/omxplayer/OMXImage.h
+++ b/xbmc/cores/omxplayer/OMXImage.h
@@ -46,23 +46,24 @@ class COMXImageFile;
 
 class COMXImage : public CThread
 {
-enum TextureAction {TEXTURE_ALLOC, TEXTURE_DELETE };
-
-struct textureinfo {
-  TextureAction action;
-  int width, height;
-  GLuint texture;
-  EGLImageKHR egl_image;
-  void *parent;
-  const char *filename;
-  CEvent sync;
-};
-
+  struct callbackinfo {
+    CEvent sync;
+    bool (*callback)(EGLDisplay egl_display, EGLContext egl_context, void *cookie);
+    void *cookie;
+    bool result;
+  };
 protected:
   virtual void OnStartup();
   virtual void OnExit();
   virtual void Process();
 public:
+  struct textureinfo {
+    int width, height;
+    GLuint texture;
+    EGLImageKHR egl_image;
+    void *parent;
+    const char *filename;
+  };
   COMXImage();
   virtual ~COMXImage();
   void Initialize();
@@ -75,9 +76,12 @@ public:
       unsigned int format, unsigned int pitch, const CStdString& destFile);
   static bool ClampLimits(unsigned int &width, unsigned int &height, unsigned int m_width, unsigned int m_height, bool transposed = false);
   static bool CreateThumb(const CStdString& srcFile, unsigned int width, unsigned int height, std::string &additional_info, const CStdString& destFile);
+  bool SendMessage(bool (*callback)(EGLDisplay egl_display, EGLContext egl_context, void *cookie), void *cookie);
   bool DecodeJpegToTexture(COMXImageFile *file, unsigned int width, unsigned int height, void **userdata);
   void DestroyTexture(void *userdata);
   void GetTexture(void *userdata, GLuint *texture);
+  bool AllocTextureInternal(EGLDisplay egl_display, EGLContext egl_context, struct textureinfo *tex);
+  bool DestroyTextureInternal(EGLDisplay egl_display, EGLContext egl_context, struct textureinfo *tex);
 private:
   EGLContext m_egl_context;
 
@@ -85,9 +89,7 @@ private:
   EGLContext GetEGLContext();
   CCriticalSection               m_texqueue_lock;
   XbmcThreads::ConditionVariable m_texqueue_cond;
-  std::queue <struct textureinfo *> m_texqueue;
-  void AllocTextureInternal(EGLDisplay egl_display, EGLContext egl_context, struct textureinfo *tex);
-  void DestroyTextureInternal(EGLDisplay egl_display, EGLContext egl_context, struct textureinfo *tex);
+  std::queue <struct callbackinfo *> m_texqueue;
 };
 
 class COMXImageFile


### PR DESCRIPTION
This was reported by @MilhouseVH using his texture cache script:
./texturecache.py stress-test thumbnail 452 0.25 999 10

which stress tests the jpeg->texture code.
On current master this occasionally hangs or crashes.
Also if gpu memory is insufficient such that the error handling code is invoked we may not free the partially allocated resources.

With the patches, the stress test failures no longer occur.
