### PR TITLE
paplayer: rewind stream after init (ffmpeg codec)

### DIFF
--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -200,7 +200,8 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
     return false;
   }
 
-  m_nDecodedLen = 0;
+  // rewind stream to beginning
+  Seek(0);
 
   if (m_Channels == 0) // no data - just guess and hope for the best
     m_Channels = 2;


### PR DESCRIPTION
fixes ticket http://trac.xbmc.org/ticket/15080
the fist few milliseconds were cut because stream was not set back after ananysis

needs to go in with https://github.com/xbmc/xbmc/pull/4500
