### PR TITLE
settings: fix detection of value changes in CSettingList

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -441,7 +441,7 @@ bool CSettingList::SetValue(const SettingPtrList &values)
     return false;
   }
 
-  m_changed = (toString(m_values) == toString(m_defaults));
+  m_changed = (toString(m_values) != toString(m_defaults));
   OnSettingChanged(this);
   return true;
 }


### PR DESCRIPTION
This fixes the detection of whether the value of a CSettingList setting is the default value or not. This is relevant in combination with the fact that we now store whether a value is the default value or not in guisettings.xml. Because of the inverted logic right now we don't load changed CSettingList setting values because we think they are default values.
