### PR TITLE
AESinkPULSE: Let PA handle whatever samplerate we have

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -523,12 +523,8 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   // get real sample rate of the device we want to open - to avoid resampling
   bool isDefaultDevice = (device == "Default");
   WaitForOperation(pa_context_get_sink_info_by_name(m_Context, isDefaultDevice ? NULL : device.c_str(), SinkInfoCallback, &sinkStruct), m_MainLoop, "Get Sink Info");
-  if (sinkStruct.device_found)
-  {
-    if (!m_passthrough)
-      format.m_sampleRate = sinkStruct.samplerate;
-  }
-  else
+  // only check if the device is existing - don't alter the sample rate
+  if (!sinkStruct.device_found)
   {
     CLog::Log(LOGERROR, "PulseAudio: Sink %s not found", device.c_str());
     pa_threaded_mainloop_unlock(m_MainLoop);


### PR DESCRIPTION
PA has an alternate sample concept, which allows a sink that is normally running with 44.1 khz to switch to 48 khz.

In order to easy upsample / downsample we use 48000 whenever it makes sense.

Best case: Audio gets to the sink without resampling in 48 khz and in 44.1 khz

Worst case: someone resamples actively to 48 khz and that will be resample later by pulse, cause it is not using the device exclusively and cannot resample therefore.
