### PR TITLE
Fix: Full screen toggle not working sometimes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -440,6 +440,8 @@ CApplication::CApplication(void)
 
   m_muted = false;
   m_volumeLevel = 1.0f;
+
+  m_bFullScreenAdvancedSetting = false;
 }
 
 CApplication::~CApplication(void)
@@ -978,7 +980,10 @@ bool CApplication::CreateGUI()
   g_Windowing.SetWindowResolution(CSettings::Get().GetInt("window.width"), CSettings::Get().GetInt("window.height"));
 
   if (g_advancedSettings.m_startFullScreen && CDisplaySettings::Get().GetCurrentResolution() == RES_WINDOW)
+  {
     CDisplaySettings::Get().SetCurrentResolution(RES_DESKTOP);
+    m_bFullScreenAdvancedSetting = true;
+  }
 
   if (!g_graphicsContext.IsValidResolution(CDisplaySettings::Get().GetCurrentResolution()))
   {
@@ -1529,6 +1534,9 @@ bool CApplication::Initialize()
   g_Joystick.SetEnabled(CSettings::Get().GetBool("input.enablejoystick") &&
                     CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0 );
 #endif
+
+  if(m_bFullScreenAdvancedSetting)
+      CDisplaySettings::Get().SetCurrentResolution(RES_DESKTOP, true);
 
   return true;
 }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -474,6 +474,8 @@ protected:
 #endif
 
   ReplayGainSettings m_replayGainSettings;
+
+  bool m_bFullScreenAdvancedSetting;
 };
 
 XBMC_GLOBAL_REF(CApplication,g_application);


### PR DESCRIPTION
To reproduce: exit XBMC windowed (or with a fresh install), set
<fullscreen>true</fullscreen> in advancedsettings.xml, and start XBMC. It
starts full screen but the full screen toggle doesn't work.

I think that the reason is that in Gotham, resolutions are no longer set
manually, so the code to set it has been removed in favour of changing the
settings. By default, the resolution setting is Windowed. At GUI Creation
time, it checks if the advanced setting for full screen is true and if the
current setting is Windowed. If so, it changes to full screen. This works,
but the argument to save the change is not present so defaults to false.
Therefore, the screen is full screen but the setting stays as windowed. When
toggling, it tries to go from full screen to windowed but the fact that the
setting is already windowed stops the change from happening.

Setting the save option to true causes XBMC to crash because (I think) the
GUI is created before the database is initialised, so it can't save the
setting.

To fix it, I created a flag that notes that the screen has changed and then at
the end of Initialise it checks the flag and if true, it then saves the change.

Tested on Windows.
