### PR TITLE
Clean up convert_quad slightly and fix subtitle corruption with new libass

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
@@ -205,8 +205,8 @@ bool convert_quad(ASS_Image* images, SQuads& quads)
   if (quads.count == 0)
     return false;
 
-  while(quads.size_x > (int)g_Windowing.GetMaxTextureSize())
-    quads.size_x /= 2;
+  if (quads.size_x > (int)g_Windowing.GetMaxTextureSize())
+    quads.size_x = g_Windowing.GetMaxTextureSize();
 
   int curr_x = 0;
   int curr_y = 0;

--- a/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
@@ -198,7 +198,7 @@ bool convert_quad(ASS_Image* images, SQuads& quads)
     if((img->color & 0xff) == 0xff || img->w == 0 || img->h == 0)
       continue;
 
-    quads.size_x += img->w;
+    quads.size_x += img->w + 1;
     quads.count++;
   }
 


### PR DESCRIPTION
For a screenshot of the corruption, see OpenELEC/OpenELEC.tv#3059. In that particular case, there are three ASS_Images with width 1773, 1777 and 1777. The sum is 5327 (or with padding, 5330), which is larger than the maximum texture width of 2048. The current code halves it to 2663 (2665) and then halves it again to 1331 (1332). But 1331 and 1332 pixels are not enough to fit in a 1777-pixel bitmap. The third loop detects this, but the only action it takes is skip a line in the texture; it then proceeds to memcpy the 1777-pixels-wide bitmap into the 1331-pixels-wide buffer. The result is a visual effect as shown in the screenshot and possibly some corrupted memory.
