### PR TITLE
Fix libass ass_read_memory() signature

### DIFF
--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -136,7 +136,7 @@ bool CDVDSubtitlesLibass::DecodeDemuxPkt(char* data, int size, double start, dou
   return true;
 }
 
-bool CDVDSubtitlesLibass::CreateTrack(char* buf, int size)
+bool CDVDSubtitlesLibass::CreateTrack(char* buf, size_t size)
 {
   CSingleLock lock(m_section);
   if(!m_library)

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -39,7 +39,7 @@ public:
 
   bool DecodeHeader(char* data, int size);
   bool DecodeDemuxPkt(char* data, int size, double start, double duration);
-  bool CreateTrack(char* buf, int size);
+  bool CreateTrack(char* buf, size_t size);
 
 private:
   DllLibass m_dll;

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
@@ -53,6 +53,7 @@ public:
   virtual ASS_Image* ass_render_frame(ASS_Renderer *priv, ASS_Track* track, long long now, int* detect_change)=0;
   virtual ASS_Track* ass_new_track(ASS_Library*)=0;
   virtual ASS_Track* ass_read_file(ASS_Library* library, char* fname, char* codepage)=0;
+  virtual ASS_Track* ass_read_memory(ASS_Library* library, char* buf, size_t bufsize, char* codepage)=0;
   virtual void ass_free_track(ASS_Track* track)=0;
   virtual void ass_set_fonts(ASS_Renderer *priv, const char *default_font, const char *default_family, int fc, const char *config, int update) = 0;
   virtual void ass_set_style_overrides(ASS_Library* priv, char** list)=0;
@@ -80,7 +81,7 @@ class DllLibass : public DllDynamic, DllLibassInterface
   DEFINE_METHOD4(ASS_Image *, ass_render_frame, (ASS_Renderer * p1, ASS_Track * p2, long long p3, int * p4))
   DEFINE_METHOD1(ASS_Track *, ass_new_track, (ASS_Library * p1))
   DEFINE_METHOD3(ASS_Track *, ass_read_file, (ASS_Library * p1, char * p2, char * p3))
-  DEFINE_METHOD4(ASS_Track *, ass_read_memory, (ASS_Library * p1, char * p2, int p3, char * p4))
+  DEFINE_METHOD4(ASS_Track *, ass_read_memory, (ASS_Library * p1, char * p2, size_t p3, char * p4))
   DEFINE_METHOD1(void, ass_free_track, (ASS_Track * p1))
   DEFINE_METHOD6(void, ass_set_fonts, (ASS_Renderer* p1, const char* p2, const char* p3, int p4, const char* p5, int p6))
   DEFINE_METHOD2(void, ass_set_style_overrides, (ASS_Library* p1, char** p2))


### PR DESCRIPTION
`size_t` is 8 bytes while `int` is 4 bytes on most 64-bit platforms.
