### PR TITLE
[Confluence] next/previous fixes for livetv - fixes #15076

### DIFF
--- a/addons/skin.confluence/720p/Home.xml
+++ b/addons/skin.confluence/720p/Home.xml
@@ -625,7 +625,7 @@
 						<onright>602</onright>
 						<onup>9003</onup>
 						<ondown>9000</ondown>
-						<onclick>XBMC.PlayerControl(Previous)</onclick>
+						<onclick>ChannelDown</onclick>
 					</control>
 					<control type="button" id="602">
 						<left>40</left>
@@ -639,7 +639,7 @@
 						<onright>603</onright>
 						<onup>9003</onup>
 						<ondown>9000</ondown>
-						<onclick>XBMC.PlayerControl(Next)</onclick>
+						<onclick>ChannelUp</onclick>
 					</control>
 					<control type="button" id="603">
 						<left>70</left>

--- a/addons/skin.confluence/720p/PlayerControls.xml
+++ b/addons/skin.confluence/720p/PlayerControls.xml
@@ -341,7 +341,7 @@
 				<onright>705</onright>
 				<onup>300</onup>
 				<ondown>200</ondown>
-				<onclick>XBMC.PlayerControl(Previous)</onclick>
+				<onclick>ChannelDown</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="button" id="705">
@@ -356,7 +356,7 @@
 				<onright>706</onright>
 				<onup>300</onup>
 				<ondown>200</ondown>
-				<onclick>XBMC.PlayerControl(Next)</onclick>
+				<onclick>ChannelUp</onclick>
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 			</control>
 			<control type="button" id="706">

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -618,7 +618,7 @@
 				<onright>601</onright>
 				<onup>610</onup>
 				<ondown>611</ondown>
-				<onclick>XBMC.PlayerControl(Previous)</onclick>
+				<onclick>ChannelDown</onclick>
 			</control>
 			<control type="button" id="601">
 				<left>60</left>
@@ -632,7 +632,7 @@
 				<onright>603</onright>
 				<onup>610</onup>
 				<ondown>611</ondown>
-				<onclick>XBMC.PlayerControl(Next)</onclick>
+				<onclick>ChannelUp</onclick>
 			</control>
 			<control type="button" id="603">
 				<left>100</left>


### PR DESCRIPTION
the next/previous buttons didn't work for livetv outside of the fullscreen video window.

see: http://forum.xbmc.org/showthread.php?tid=190909

gotham stuff.

@xhaggi: up to you.
