### PR TITLE
platinum: add missing patch file

### DIFF
--- a/lib/libUPnP/patches/0025-platinum-lastPlaybackTime-is-in-the-upnp-and-not-in-the-dc-namespace.patch
+++ b/lib/libUPnP/patches/0025-platinum-lastPlaybackTime-is-in-the-upnp-and-not-in-the-dc-namespace.patch
@@ -1,0 +1,26 @@
+From 80dfacb5ec2ff32cdd07d9d897cf2ac5048d0719 Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Thu, 23 Jan 2014 19:36:06 +0100
+Subject: [PATCH] platinum: lastPlaybackTime is in the "upnp" and not in the
+ "dc" namespace
+
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index a6566eb..85b5856 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -559,7 +559,7 @@
+     if (NPT_FAILED(str.ToInteger(value))) value = 0;
+     m_MiscInfo.last_position = value;
+ 
+-    PLT_XmlHelper::GetChildText(entry, "lastPlaybackTime", m_MiscInfo.last_time, didl_namespace_dc, 256);
++    PLT_XmlHelper::GetChildText(entry, "lastPlaybackTime", m_MiscInfo.last_time, didl_namespace_upnp, 256);
+     NPT_String parsed_last_time;
+     for (int format=0; format<=NPT_DateTime::FORMAT_RFC_1036; format++) {
+         NPT_DateTime date;
+-- 
+1.9.1
+


### PR DESCRIPTION
I just noticed that I missed to add a patch file to libPlatinum for a commit which was added while the PR for adding all patch files was open.
