### PR TITLE
FIX: [mediacodec] proper initialization of output format

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -32,6 +32,7 @@
 class CJNISurface;
 class CJNISurfaceTexture;
 class CJNIMediaCodec;
+class CJNIMediaFormat;
 class CDVDMediaCodecOnFrameAvailable;
 class CJNIByteBuffer;
 class CBitstreamConverter;
@@ -106,7 +107,7 @@ protected:
   void            FlushInternal(void);
   bool            ConfigureMediaCodec(void);
   int             GetOutputPicture(void);
-  void            OutputFormatChanged(void);
+  void            ConfigureOutputFormat(CJNIMediaFormat* mediaformat);
 
   // surface handling functions
   static void     CallbackInitSurfaceTexture(void*);


### PR DESCRIPTION
I've seen at least 2 devices when we don't get an INFO_OUTPUT_FORMAT_CHANGED and I haven't seen in the doc any indication we are guaranteed to get one.

Indeed, it makes sense we wouldn't get one if the mediaformat we request is the one we get.
In those cases, we end up passing no format to the renderer.

This initialize the output format based upon the one we request.

/cc @davilla
