### PR TITLE
FIX: [mediacodec] reset if we are out of input buffers

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -598,6 +598,12 @@ int CDVDVideoCodecAndroidMediaCodec::Decode(uint8_t *pData, int iSize, double dt
         xbmc_jnienv()->ExceptionClear();
       }
     }
+    else
+    {
+      // Bad, we don't have input buffers left. Let's Reset...
+      CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Decode Cannot dequeue input buffer");
+      return VC_FLUSHED;
+    }
   }
 
   return rtn;


### PR DESCRIPTION
I've seen instances where we run out of input buffers for some unknown reason.
I haven't been able to pinpoint a single root cause, but this allows to recover by forcing a flush.

/cc @davilla 
