### PR TITLE
ActiveAE: set the scaled volume to zero if the volume is zero

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -108,7 +108,13 @@ public:
    */
   static inline const float GainToScale(const float dB)
   {
-    float val = pow(10.0f, dB/20);
+    float val = 0.0f; 
+    // we need to make sure that our lowest db returns plain zero
+    if (dB > -60.0f) 
+      val = pow(10.0f, dB/20); 
+
+    // in order to not introduce computing overhead for nearly zero
+    // values of dB e.g. -0.01 or -0.001 we clamp to top
     if (val >= 0.99f)
       val = 1.0f;
 


### PR DESCRIPTION
@fritsch helped me to find out the solution to the issue that the zero volume isn't a real zero volume. As he pointed out we need to check if m_volume > 0.0 and only then do something here otherwise we have at zero volume:

PercentToGain(0.0) = -60;

GainToScale(-60) = pow(10.0f, -3) = 1.0 / (10^3) = 1.0 / 1000 = 0.001

and  0.001 != 0.0f
