### PR TITLE
Change default lingertime to zero

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -302,7 +302,7 @@ void CAdvancedSettings::Initialize()
 
   m_iMythMovieLength = 0; // 0 == Off
 
-  m_iEpgLingerTime = 60 * 24;           /* keep 24 hours by default */
+  m_iEpgLingerTime = 0;
   m_iEpgUpdateCheckInterval = 300; /* check if tables need to be updated every 5 minutes */
   m_iEpgCleanupInterval = 900;     /* remove old entries from the EPG every 15 minutes */
   m_iEpgActiveTagCheckInterval = 60; /* check for updated active tags every minute */


### PR DESCRIPTION
This effectively disabling past EPG data by default. Judging by http://forum.xbmc.org/showthread.php?tid=175135&page=12 it seems most users don't want or use that feature anyway, so this default is more sensible.
