### PR TITLE
[epg] Fix navigating to the sidebar with cursor keys

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1263,8 +1263,8 @@ void CGUIEPGGridContainer::SetChannel(int channel)
     m_item          = GetItem(channel);
     if (m_item)
     {
-      SetBlock(GetBlock(m_item->item, channel));
       m_channelCursor = channel;
+      SetBlock(GetBlock(m_item->item, channel));
     }
     return;
   }


### PR DESCRIPTION
When setting epg.lingertime to zero (which means past EPG data is disabled and you can access the sidebar by pressing left when you're at the leftmost item) two Left-presses are required to open the sidebar if you've previously moved up or down in the timeline. If you move one programme to the right on a channel and then start going left the sidebar opens on the first attempt as expected.

This is because m_item is wrongly set when changing channels (ie. moving up and down) because the m_channelCursor variable is only updated after the new item has been determined, which causes the wrong item to end up as m_item.

@xhaggi could you review?

If https://github.com/xbmc/xbmc/pull/4526 gets merged for Gotham I think this should too.
