### PR TITLE
fix toggle fullscreen during video playback

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -952,6 +952,8 @@ bool CGraphicContext::IsFullScreenRoot () const
 bool CGraphicContext::ToggleFullScreenRoot ()
 {
   RESOLUTION uiRes;  ///< resolution to save - not necessarily the same as the one we switch to (e.g. during video playback)
+  RESOLUTION videoRes;
+  bool setVideoRes = false;
 
   if (m_bFullScreenRoot)
   {
@@ -965,17 +967,30 @@ bool CGraphicContext::ToggleFullScreenRoot ()
       uiRes = (RESOLUTION) g_Windowing.DesktopResolution(g_Windowing.GetCurrentScreen());
 
 #if defined(HAS_VIDEO_PLAYBACK)
-    if (IsFullScreenVideo() || IsCalibrating())
+    if (IsCalibrating())
     {
       /* we need to trick renderer that we are fullscreen already so it gives us a valid value */
       m_bFullScreenRoot = true;
       uiRes = g_renderManager.GetResolution();
       m_bFullScreenRoot = false;
     }
+    // if video is playing we need to switch to resolution chosen by RenderManager
+    if (IsFullScreenVideo())
+    {
+      m_bFullScreenRoot = true;
+      videoRes = g_renderManager.GetResolution();
+      m_bFullScreenRoot = false;
+      setVideoRes = true;
+    }
 #endif
   }
 
   CDisplaySettings::Get().SetCurrentResolution(uiRes, true);
+
+  if (setVideoRes)
+  {
+    SetVideoResolution(videoRes);
+  }
 
   return m_bFullScreenRoot;
 }

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -225,7 +225,16 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
     if (settingId == "videoscreen.resolution")
       newRes = (RESOLUTION)((CSettingInt*)setting)->GetValue();
     else if (settingId == "videoscreen.screen")
+    {
+      int screen = ((CSettingInt*)setting)->GetValue();
+
+      // if triggered by a change of screenmode, screen may not have changed
+      if (screen == GetCurrentDisplayMode())
+        return true;
+
+      // get desktop resolution for screen
       newRes = GetResolutionForScreen();
+    }
 
     string screenmode = GetStringFromResolution(newRes);
     CSettings::Get().SetString("videoscreen.screenmode", screenmode);


### PR DESCRIPTION
toggling fullscreen during video playback ended up with incorrect resolution stored in video settings and unwanted display of confirmation dialog
