### PR TITLE
[uClibc] Fix compilation on arm

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -686,7 +686,7 @@ case $host in
   powerpc64-*-linux-gnu*|powerpc64-*-linux-uclibc*)
      ARCH="powerpc64-linux"
      ;;
-  arm*-*-linux-gnu*)
+  arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
      ARCH="arm"
      use_arch="arm"
      ffmpeg_target_os=linux

--- a/m4/xbmc_arch.m4
+++ b/m4/xbmc_arch.m4
@@ -29,7 +29,7 @@ case $host in
   powerpc64-*-linux-gnu*|powerpc64-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64")
      ;;
-  arm*-*-linux-gnu*)
+  arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
      ;;
   *-*linux-android*)

--- a/tools/depends/configure.in
+++ b/tools/depends/configure.in
@@ -119,7 +119,7 @@ case $host in
     #android builds are always cross
     cross_compiling="yes"
   ;;
-  arm*-*-linux-gnu*)
+  arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
     if test "x$use_cpu" = "xauto"; then
       use_cpu=$host_cpu
     fi


### PR DESCRIPTION
Tested with:

Target: arm-buildroot-linux-uclibcgnueabi
gcc version 4.7.3 (Buildroot 2014.05-git-00735-gc1618c8)

Please include in master and gotham branch.

In order to successfully compile XBMC this PR is needed as well:
https://github.com/xbmc/xbmc/pull/3760
It is included in OpenELEC since Feb 20th, 2014: https://github.com/OpenELEC/OpenELEC.tv/commits/master/packages/mediacenter/xbmc/patches/xbmc-999.80.003-PR3760.patch

It fixes a compile bug I saw when testing my patch, the bug was already reported in these tickets:
http://trac.xbmc.org/ticket/13941
http://trac.xbmc.org/ticket/14228
