### PR TITLE
DVDCodecs: Condense and update HAS_LIBAMCODEC

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -193,17 +193,20 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
 #endif
 
   CLog::Log(LOGDEBUG, "CDVDFactoryCodec: compiled in hardware support: %s", hwSupport.c_str());
+
+  if (hint.stills && (hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_MPEG1VIDEO))
+  {
+     // If dvd is an mpeg2 and hint.stills
+     if ( (pCodec = OpenCodec(new CDVDVideoCodecLibMpeg2(), hint, options)) ) return pCodec;
+  }
+
 #if defined(HAS_LIBAMCODEC)
   // amcodec can handle dvd playback.
-  if (!CSettings::Get().GetBool("videoplayer.useamcodec"))
-#endif
+  if (!hint.software && CSettings::Get().GetBool("videoplayer.useamcodec"))
   {
-    // dvd's have weird still-frames in it, which is not fully supported in ffmpeg
-    if(hint.stills && (hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_MPEG1VIDEO))
-    {
-      if( (pCodec = OpenCodec(new CDVDVideoCodecLibMpeg2(), hint, options)) ) return pCodec;
-    }
+     if ( (pCodec = OpenCodec(new CDVDVideoCodecAmlogic(), hint, options)) ) return pCodec;
   }
+#endif
 
 #if defined(TARGET_DARWIN_OSX)
   if (!hint.software && CSettings::Get().GetBool("videoplayer.usevda"))
@@ -255,14 +258,6 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
         break;
       }
     }
-  }
-#endif
-
-#if defined(HAS_LIBAMCODEC)
-  if (!hint.software && CSettings::Get().GetBool("videoplayer.useamcodec"))
-  {
-    CLog::Log(LOGINFO, "Amlogic Video Decoder...");
-    if ( (pCodec = OpenCodec(new CDVDVideoCodecAmlogic(), hint, options)) ) return pCodec;
   }
 #endif
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -69,6 +69,13 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_MPEG1VIDEO:
     case AV_CODEC_ID_MPEG2VIDEO:
     case AV_CODEC_ID_MPEG2VIDEO_XVMC:
+      if (m_hints.width <= 1280)
+      {
+        // amcodec struggles with VOB playback
+        // which can be handled via software
+        return false;
+        break;
+      }
       m_mpeg2_sequence_pts = 0;
       m_mpeg2_sequence = new mpeg2_sequence;
       m_mpeg2_sequence->width  = m_hints.width;
@@ -116,7 +123,9 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_RV20:
     case AV_CODEC_ID_RV30:
     case AV_CODEC_ID_RV40:
-      m_pFormatName = "am-rv";
+      // m_pFormatName = "am-rv";
+      // rmvb is not handled well by amcodec
+      return false;
       break;
     case AV_CODEC_ID_VC1:
       m_pFormatName = "am-vc1";


### PR DESCRIPTION
- AM Video Codec cannot properly handle the still-frames within DVDs

Signed-off-by: Brandon McAnsh brandonm@matricom.net
