### PR TITLE
tools: android: Allow xbmc to be launched as a home launcher

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -23,6 +23,9 @@
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.MONKEY" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
@@ -70,6 +73,12 @@
                 android:name="android.app.lib_name"
                 android:value="xbmc" />
         </activity>
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
     </application>
 
 </manifest><!-- END_INCLUDE(manifest) -->


### PR DESCRIPTION
Signed-off-by: Brandon McAnsh brandonm@matricom.net
