### PR TITLE
fix incorrect logging when using static ffmpeg

### DIFF
--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -174,7 +174,7 @@ public:
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {
-#if !defined(TARGET_DARWIN)
+#if !defined(TARGET_DARWIN) && !defined(USE_STATIC_FFMPEG)
     CLog::Log(LOGDEBUG, "DllAvFilter: Using libavfilter system library");
 #endif
     return true;

--- a/lib/DllPostProc.h
+++ b/lib/DllPostProc.h
@@ -97,7 +97,9 @@ public:
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {
+#if !defined(TARGET_DARWIN) && !defined(USE_STATIC_FFMPEG)
     CLog::Log(LOGDEBUG, "DllPostProc: Using libpostproc system library");
+#endif
     return true;
   }
   virtual void Unload() {}


### PR DESCRIPTION
Don't pretend to be using external ffmpeg, when in fact we have compiled our internal one statically
