### PR TITLE
FIX: [stagefright] adjust input mediabuffer size

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/libstagefrightICS/StageFrightVideo.cpp
@@ -621,6 +621,7 @@ int  CStageFrightVideo::Decode(uint8_t *pData, int iSize, double dts, double pts
     }
 
     fast_memcpy(frame->medbuf->data(), demuxer_content, demuxer_bytes);
+    frame->medbuf->set_range(0, demuxer_bytes);
     frame->medbuf->meta_data()->clear();
     frame->medbuf->meta_data()->setInt64(kKeyTime, frame->pts);
 


### PR DESCRIPTION
I guess you'll have to trust me on that one ;)
Apparently fixes playback with libstagefright on Amazon Fire TV

/cc @jmarshallnz @t-nelson 
