### PR TITLE
fix crash when changing language from non-GUI thread (fixes #15113)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1669,7 +1669,10 @@ void CApplication::OnSettingChanged(const CSetting *setting)
       CApplicationMessenger::Get().ExecBuiltIn("ReloadSkin");
   }
   else if (settingId == "lookandfeel.skinzoom")
-    g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
+  {
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
+    g_windowManager.SendThreadMessage(msg);
+  }
   else if (StringUtils::StartsWithNoCase(settingId, "audiooutput."))
   {
     // AE is master of audio settings and needs to be informed first

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -20,6 +20,7 @@
 
 #include "LangInfo.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "FileItem.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
@@ -462,7 +463,7 @@ bool CLangInfo::SetLanguage(const std::string &strLanguage)
   // also tell our weather and skin to reload as these are localized
   g_weatherManager.Refresh();
   g_PVRManager.LocalizationChanged();
-  g_application.ReloadSkin();
+  CApplicationMessenger::Get().ExecBuiltIn("ReloadSkin", false);
 
   return true;
 }


### PR DESCRIPTION
This fixes a crash when someone tries to change the language from a non-GUI thread (e.g. python or JSON-RPC) as reported by @joethefox in http://trac.xbmc.org/ticket/15113.
It might also take care of an occasional hang when changing the language from the settings window (but I was never able to reproduce that myself).
