### PR TITLE
[settings]: fix upnp category visibility when built with --disable-upnp

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2009,6 +2009,7 @@
       </group>
     </category>
     <category id="upnp" label="20187" help="36322">
+      <requirement>HAS_UPNP</requirement>
       <group id="1">
         <setting id="services.upnpserver" type="boolean" label="21360" help="36323">
           <level>0</level>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -853,6 +853,9 @@ void CSettings::InitializeConditions()
 {
   // add basic conditions
   m_settingsManager->AddCondition("true");
+#ifdef HAS_UPNP
+  m_settingsManager->AddCondition("has_upnp");
+#endif
 #ifdef HAS_AIRPLAY
   m_settingsManager->AddCondition("has_airplay");
 #endif


### PR DESCRIPTION
cosmetics. as title says. //cc @Montellese
