### PR TITLE
fix flickering music OSD

### DIFF
--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -90,7 +90,8 @@ void CGUIDialogMusicOSD::FrameMove()
     // check for movement of mouse or a submenu open
     if (g_Mouse.IsActive() || g_windowManager.IsWindowActive(WINDOW_DIALOG_VIS_SETTINGS)
                            || g_windowManager.IsWindowActive(WINDOW_DIALOG_VIS_PRESET_LIST))
-      SetAutoClose(100); // enough for 10fps
+      // extend show time by original value
+      SetAutoClose(m_showDuration);
   }
   CGUIDialog::FrameMove();
 }


### PR DESCRIPTION
Sometimes it was impossible to use mouse for seeking on the music OSD. Same fix as we did for video: https://github.com/xbmc/xbmc/commit/e1c150e7a18ffb792b3e352780df53f6f9e7b044
