### PR TITLE
Revert "FIX: [mediacodec] reset if we are out of input buffers"

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -598,12 +598,6 @@ int CDVDVideoCodecAndroidMediaCodec::Decode(uint8_t *pData, int iSize, double dt
         xbmc_jnienv()->ExceptionClear();
       }
     }
-    else
-    {
-      // Bad, we don't have input buffers left. Let's Reset...
-      CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Decode Cannot dequeue input buffer");
-      return VC_FLUSHED;
-    }
   }
 
   return rtn;


### PR DESCRIPTION
As discussed, this reverts https://github.com/xbmc/xbmc/pull/4524

/cc @davilla @t-nelson 
