### PR TITLE
FIX: [droid] allow all boxes to enable passthrough (frodo way)

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -230,16 +230,7 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   m_info.m_dataFormats.clear();
   m_info.m_sampleRates.clear();
 
-  m_info.m_deviceType = AE_DEVTYPE_PCM;
-#if defined(HAS_LIBAMCODEC)
-  // AML devices can do passthough
-  if (aml_present())
-  {
-    m_info.m_deviceType = AE_DEVTYPE_HDMI;
-    m_info.m_dataFormats.push_back(AE_FMT_AC3);
-    m_info.m_dataFormats.push_back(AE_FMT_DTS);
-  }
-#endif
+  m_info.m_deviceType = AE_DEVTYPE_HDMI;
   m_info.m_deviceName = "AudioTrack";
   m_info.m_displayName = "android";
   m_info.m_displayNameExtra = "audiotrack";
@@ -247,6 +238,8 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   m_info.m_channels += AE_CH_FR;
   m_info.m_sampleRates.push_back(CJNIAudioTrack::getNativeOutputSampleRate(CJNIAudioManager::STREAM_MUSIC));
   m_info.m_dataFormats.push_back(AE_FMT_S16LE);
+  m_info.m_dataFormats.push_back(AE_FMT_AC3);
+  m_info.m_dataFormats.push_back(AE_FMT_DTS);
 #if 0 //defined(__ARM_NEON__)
   if (g_cpuInfo.GetCPUFeatures() & CPU_FEATURE_NEON)
     m_info.m_dataFormats.push_back(AE_FMT_FLOAT);


### PR DESCRIPTION
This revert to the Frodo way of allowing any droid box to enable passthrough, up to the user to know whether his box supports it or not.

The alternative is, e.g., https://github.com/koying/xbmc/commit/651a3ea4bdd38b757eca64c3564a0dccdebce64f , ie quirking specific boxes, but, imo, it's fugly, impractical and puts the burden on us.

/cc @davilla @t-nelson 
