### PR TITLE
changed: Don't try to sort subtitles, it screws up eg. sync priority

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -73,8 +73,6 @@ public:
   virtual bool DoWork()
   {
     CDirectory::GetDirectory(m_url.Get(), *m_items);
-    // Sort items by path so they properly order for eg. stacks
-    m_items->Sort(SortByPath, SortOrderAscending);
     return true;
   }
   virtual bool operator==(const CJob *job) const


### PR DESCRIPTION
This is a partial revert of #4274. See discussion https://github.com/xbmc/xbmc/pull/4274/files#r11480321 . I see no other way to do this properly, so for now just remove the sorting. Gotham material IMO.
