### PR TITLE
FIX: [mediacodec] make sure the output buffer is released from the SurfaceView queue

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -886,7 +886,13 @@ void CLinuxRendererGLES::ReleaseBuffer(int idx)
 #if defined(TARGET_ANDROID)
   if ( m_renderMethod & RENDER_MEDIACODEC )
   {
-    SAFE_RELEASE(buf.mediacodec);
+    if (buf.mediacodec)
+    {
+      // The media buffer has been queued to the SurfaceView but we didn't render it
+      // We have to do to the updateTexImage or it will get stuck
+      buf.mediacodec->UpdateTexImage();
+      SAFE_RELEASE(buf.mediacodec);
+    }
   }
 #endif
 }


### PR DESCRIPTION
This seems to solve the buffers issue.
The reasoning is that, if the renderer skips a frame, as we already released the output buffers for "render" in the libstagefright understanding, it will be locked in the SurfaceView queue until we do the updateTexImage.

@davilla Your thoughts?
