### PR TITLE
FIX: [mediacodec] properly release output buffer if AddProcessor is not called

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -73,6 +73,7 @@ private:
 
   long                m_refs;
   bool                m_valid;
+  bool                m_isReleased;
   int                 m_index;
   unsigned int        m_texture;
   int64_t             m_timestamp;


### PR DESCRIPTION
There is apparently a player/renderer path where AddProcessor is not called but the drop state is false.
In that case, the output buffer is never released, leading to exhaustion.

/cc @davilla @t-nelson 
