### PR TITLE
Don't assume VIDEO_TS dir is in it's own dir.

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1319,8 +1319,31 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
       strDeletePath = URIUtils::GetDirectory(strDeletePath);
       if (StringUtils::EndsWithNoCase(strDeletePath, "video_ts/"))
       {
-        URIUtils::RemoveSlashAtEnd(strDeletePath);
-        strDeletePath = URIUtils::GetDirectory(strDeletePath);
+        CFileItemList items;
+        CStdString    candidatePath = strDeletePath;
+
+        URIUtils::RemoveSlashAtEnd(candidatePath);
+        candidatePath = URIUtils::GetDirectory(candidatePath);
+
+        if (CDirectory::GetDirectory(candidatePath, items))
+        {
+          int   nitems    = items.Size();
+          if (nitems <= 2)
+          {
+            bool  only_dvd  = true;
+            for (int i = 0; i < nitems; i++)
+            {
+              if (!StringUtils::CompareNoCase(items[i]->GetAsUrl().GetFileName().c_str(), "AUDIO_TS") &&
+                  !StringUtils::CompareNoCase(items[i]->GetAsUrl().GetFileName().c_str(), "VIDEO_TS"))
+              {
+                only_dvd = false;
+                break;
+              }
+            }
+            if (only_dvd)
+              strDeletePath = candidatePath;
+          }
+        }
       }
     }
     if (URIUtils::HasSlashAtEnd(strDeletePath))


### PR DESCRIPTION
Fixes #14468.  A dir structure like...

```
/movies
- VIDEO_TS/
- Movie3/
- movie1.avi
- movie2.avi
```

...would result in the entire /movies dir being deleted upon request
to delete /movies/VIDEO_TS.
