### PR TITLE
when deleting files, make sure we display the path

### DIFF
--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -55,7 +55,7 @@ bool CFileUtils::DeleteItem(const CFileItemPtr &item, bool force)
   {
     pDialog->SetHeading(122);
     pDialog->SetLine(0, 125);
-    pDialog->SetLine(1, URIUtils::GetFileName(item->GetPath()));
+    pDialog->SetLine(1, CURL(item->GetPath()).GetWithoutUserDetails());
     pDialog->SetLine(2, "");
     pDialog->DoModal();
     if (!pDialog->IsConfirmed()) return false;


### PR DESCRIPTION
 so the user has a chance to verify what's actually happening. closes #14468.

@NedScott would appreciate you giving it a test run to make sure it catches your case (it does here, but may be filesystem dependent).
