### PR TITLE
[dxva] Close the DXVA2 decoder before opening again

### DIFF
--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -213,6 +213,8 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
   DEFINE_METHOD1(AVCodec*, av_codec_next, (AVCodec *p1))
   DEFINE_METHOD1(int, av_codec_is_decoder, (const AVCodec *p1))
   DEFINE_METHOD1(AVDictionary*, av_frame_get_metadata, (const AVFrame* p1))
+  DEFINE_METHOD_FP(int, avcodec_default_get_buffer, (AVCodecContext *p1, AVFrame *p2))
+  DEFINE_METHOD_FP(void, avcodec_default_release_buffer, (AVCodecContext *p1, AVFrame *p2))
 
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(avcodec_flush_buffers)
@@ -248,6 +250,8 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
     RESOLVE_METHOD(avcodec_free_frame)
     RESOLVE_METHOD(av_codec_is_decoder)
     RESOLVE_METHOD(av_frame_get_metadata)
+    RESOLVE_METHOD_FP(avcodec_default_get_buffer)
+    RESOLVE_METHOD_FP(avcodec_default_release_buffer)
   END_METHOD_RESOLVE()
 
   /* dependencies of libavcodec */

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -94,6 +94,14 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #ifdef HAS_DX
   if(DXVA::CDecoder::Supports(*cur) && CSettings::Get().GetBool("videoplayer.usedxva2"))
   {
+    // throw away any current DXVA2 hardware context
+    // this should help DXVA hardware that can't be opened more than once without error
+    IHardwareDecoder *currentDec = ctx->GetHardware();
+    if (currentDec && currentDec->Name() == "dxva2")
+    {
+      ctx->SetHardware(NULL);
+    }
+
     DXVA::CDecoder* dec = new DXVA::CDecoder();
     if(dec->Open(avctx, *cur, ctx->m_uSurfacesCount))
     {


### PR DESCRIPTION
@cg110 found a workaround for fix the issue described here: http://forum.xbmc.org/showthread.php?tid=190254

Basically if the current hardware context is dxva2, close it, as we're
about to open a fresh context.  I suspect something about ffmpeg is
causing a double call into GetFormat, which isn't present in frodo.

Perhaps a bug/change in behaviour with ffmpeg 1.2?

@FernetMenta, @elupus, @jmarshallnz, please review this.
