### PR TITLE
[DTS-HD MA] Accurately detect channel number, bit depth, SR and LFE extended details

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -89,16 +89,352 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
       lfe_channel = UNKNOW;
       iExtendedSampleRate = 0;
       iExtendedResolution = 0;
-      iExtendedBitRate = 0;
     }
   }
 
   bool CDemuxStreamAudio::Parse_dts_audio_header(pFrame pframe)
   {
-      //TESTING
+    CLog::Log(LOGINFO, "%s : Started DTS-HD MA extended info parsing", __FUNCTION__);
+    
+    if(pframe == NULL) //minimum FSIZE allowded
+    {
+      CLog::Log(LOGERROR, "%s : pframe should not be null", __FUNCTION__);
+      return false;
+    }
+    
+    if(pframe->size < 94) //minimum FSIZE allowded
+    {
+      CLog::Log(LOGERROR, "%s : Frame s ize is smaller then 94 (size : %d)", __FUNCTION__, pframe->size);
+      return false;
+    }
+    
+    bits_reader_t bitstream;
+    CBitstreamConverter::bits_reader_set( &bitstream, pframe->data, pframe->size );
+    int ibyteread = 0;
+    
+    // 1) CORE STREAM
+    ////////////////////////
+    
+    //SYNC CORE = ExtractBits(32)
+    uint32_t SYNC_CORE = CBitstreamConverter::read_bits( &bitstream, 32 ); ibyteread += 32;
+    if(SYNC_CORE == 0x7ffe8001)
+      CLog::Log(LOGDEBUG, "%s : Correctly detected CORE Sync Word : 0x%08x ", __FUNCTION__, SYNC_CORE);
+    else
+    {
+      CLog::Log(LOGERROR, "%s : CORE Sync Word not detected : 0x%08x ", __FUNCTION__, SYNC_CORE);
+      return false;
+    }
+ 	//FTYPE = ExtractBits(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1 ); ibyteread += 1;
+	//SHORT = ExtractBits(5);
+	CBitstreamConverter::skip_bits( &bitstream, 5 ); ibyteread += 5;
+	//CPF = ExtractBits(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1 ); ibyteread += 1;
+	//NBLKS = ExtractBits(7);
+	CBitstreamConverter::skip_bits( &bitstream, 7); ibyteread += 7;  
+	//FSIZE = ExtractBits(14);
+	uint16_t FSIZE = CBitstreamConverter::read_bits( &bitstream, 14 ) + 1; ibyteread += 14;
+    CLog::Log(LOGDEBUG, "%s : Core Stream size (FSIZE)  is  : %d ", __FUNCTION__, FSIZE);
+	
+    int bcheckextendedstream = 0;
+	if(FSIZE > pframe->size)
+	{
+      CLog::Log(LOGERROR, "%s : Core Stream size (FSIZE)  is bigger then frame size  : %d / %d", __FUNCTION__, FSIZE, pframe->size);
+      return false;
+	}
+	else if (FSIZE == pframe->size)
+      CLog::Log(LOGDEBUG, "%s : Core Stream size (FSIZE)  is the same as the frame size  (no extension stream) : %d / %d, ", __FUNCTION__, FSIZE, pframe->size);
+	else //fsize is smaller then frame size so there is certainly an extension stream
+	  bcheckextendedstream = 1;  
+  
+ 	//AMODE = ExtractBits(6);
+	CBitstreamConverter::skip_bits( &bitstream, 6); ibyteread += 6;
+	//SFREQ = ExtractBits(4);
+	CBitstreamConverter::skip_bits( &bitstream, 4); ibyteread += 4;
+	//RATE = ExtractBits(5);
+	CBitstreamConverter::skip_bits( &bitstream, 5); ibyteread += 5;
+	//FixedBit = ExtractBit(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+	//DYNF = ExtractBits(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+	//TIMEF = ExtractBits(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+	//AUXF = ExtractBits(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+	//HDCD = ExtractBits(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1; 
+  	//EXT_AUDIO_ID = ExtractBits(3);
+	uint8_t EXT_AUDIO_ID = CBitstreamConverter::read_bits( &bitstream, 3 ); ibyteread += 3;
+	//EXT_AUDIO = ExtractBits(1);
+	uint8_t EXT_AUDIO = CBitstreamConverter::read_bits( &bitstream, 1 );  ibyteread += 1;
+	//ASPF = ExtractBits(1);
+	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+	//LFF = ExtractBits(2);
+	uint8_t LFF = CBitstreamConverter::read_bits( &bitstream, 2 );  ibyteread += 2;
+		
+	/// Lot more ........... but we don't need anything more for the moment
+		
+	// 2) CORE STREAM EXTENSIONS
+	////////////////////////////
+  
+	//REM : for the moment core streams extensions are not handled
+    //TODO : found a real case and implement this or even continue .... (not found a dts-hd ma with core extension ...))
+	if(EXT_AUDIO == 1)
+	{
+      std::string Extension_id_txt;
+      if(EXT_AUDIO_ID == 0)
+        Extension_id_txt =  "Channel Extension (XCh)";
+      else if(EXT_AUDIO_ID == 2)
+        Extension_id_txt = "Frequency Extension (X96)";
+      else if(EXT_AUDIO_ID == 6)
+        Extension_id_txt = "Channel Extension (XXCH)";
+      else
+        Extension_id_txt = "Reserved";
+
+      CLog::Log(LOGERROR, "%s : Core stream extension have been detected, those are not yet handled by xbmc at the moment. Extension type : %s", __FUNCTION__, Extension_id_txt.c_str());
+      return false;
+	}  
+  
+	// 3) EXTENSION SUBSTREAM
+    ///////////////////////////////////////////
+
+	if(bcheckextendedstream)
+	{
+      uint8_t nuBitResolution  = 0;
+      uint8_t nuMaxSampleRate  = 0;
+      uint8_t nuTotalNumChs  = 0;
+      CLog::Log(LOGDEBUG, "%s : Parsing Extended substream", __FUNCTION__);
+      if( pframe->size < FSIZE + 12) //Enough to get up to the extended frame size where further check is done 
+      {
+        CLog::Log(LOGERROR, "%s : Frame size is not big enough to get up to the extended stream size   : %d / %d", __FUNCTION__, FSIZE + 12, pframe->size);
+        return false;
+      }
+      
+      //jump to the beginning of the extension substream
+      CBitstreamConverter::skip_bits(&bitstream, (FSIZE * 8)  - ibyteread); ibyteread = FSIZE * 8;
+                
+      //SYNC SUBSTREAM (32)
+      uint32_t SYNCEXTSSH = CBitstreamConverter::read_bits( &bitstream, 32 ); ibyteread += 32;
+      if(SYNCEXTSSH == 0x64582025)
+      {
+        CLog::Log(LOGDEBUG, "%s : Correctly detected SUBSTREAM Sync Word : 0x%08x ", __FUNCTION__, SYNCEXTSSH);
+      }
+      else
+      {
+  		CLog::Log(LOGERROR, "%s : SUBSTREAM Sync Word not detected : 0x%08x ", __FUNCTION__, SYNCEXTSSH);
+        return false;
+      }
+      //UserDefinedBits = ExtractBits(8)
+      CBitstreamConverter::skip_bits( &bitstream, 8); ibyteread += 8;
+      //nExtSSIndex = ExtractBits(2);
+      uint8_t nExtSSIndex  = CBitstreamConverter::read_bits( &bitstream, 2 );  ibyteread += 2;
+      CLog::Log(LOGDEBUG, "%s : nExtSSIndex is %u", __FUNCTION__, nExtSSIndex);
+      //bHeaderSizeType = ExtractBits(1);
+      uint8_t bHeaderSizeType  = CBitstreamConverter::read_bits( &bitstream, 1 );  ibyteread += 1;
+      CLog::Log(LOGDEBUG, "%s : bHeaderSizeType is %u", __FUNCTION__, bHeaderSizeType);
+      uint32_t nuBits4Header = 0;
+      uint32_t nuBits4ExSSFsize = 0;
+      if (bHeaderSizeType == 0)
+      {
+        nuBits4Header = 8;
+		nuBits4ExSSFsize = 16;
+      }
+      else
+      {
+        nuBits4Header = 12;
+        nuBits4ExSSFsize = 20;
+      }		          	
+      //nuExtSSHeaderSize = ExtractBits(nuBits4Header) + 1; //Could be used for CRC checksum ...
+      uint16_t nuExtSSHeaderSize  = CBitstreamConverter::read_bits( &bitstream, nuBits4Header) + 1;  ibyteread += nuBits4Header; 
+      CLog::Log(LOGDEBUG, "%s : Extended stream header size (nuExtSSHeaderSize) : %u", __FUNCTION__, nuExtSSHeaderSize);
+      //nuExtSSFsize = ExtractBits(nuBits4ExSSFsize) + 1;
+      uint32_t nuExtSSFsize  = CBitstreamConverter::read_bits( &bitstream, nuBits4ExSSFsize ) + 1;  ibyteread += nuBits4ExSSFsize; 
+      CLog::Log(LOGDEBUG, "%s : Extended stream  size (nuExtSSFsize) : %u", __FUNCTION__, nuExtSSFsize);
+      if(nuExtSSFsize + FSIZE < (uint32_t)pframe->size)
+      {
+        CLog::Log(LOGERROR, "%s : Core stream + Substream length is bigger then frame size; (bade frame ???) : %d / %u / %d", __FUNCTION__,FSIZE, nuExtSSFsize, pframe->size);
+        return false;
+      }
+      //REM : for the moment multiple substreams are not handled
+      // TODO : found a real case and implement this or even continue .... (will be hard to find a real case on classic media ...))
+      if(nuExtSSFsize + FSIZE > (uint32_t)pframe->size)
+      {
+        CLog::Log(LOGERROR, "%s : Core stream + Substream length is smaller then frame size, this usually mean that other extension streams are present but this is not handled by xbmc : %d / %u / %d - StreamIndex : %u", 
+                          __FUNCTION__,FSIZE, nuExtSSFsize, pframe->size, nExtSSIndex);
+        return false;
+      }
+      
+      //bStaticFieldsPresent = ExtractBits(1);
+      uint8_t bStaticFieldsPresent  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1; 
+      CLog::Log(LOGDEBUG, "%s : bStaticFieldsPresent : %u", __FUNCTION__, bStaticFieldsPresent);
+
+      uint8_t  nuNumAudioPresnt = -1;
+      uint8_t  nuNumAssets = -1;
+      
+      //REM : for the moment substreams without bStaticFieldsPresent are not handled
+      // TODO : found a real case and implement this or even continue ....
+      if(!bStaticFieldsPresent)
+      {
+        //nuNumAudioPresnt = 1;
+        //nuNumAssets = 1;
+        CLog::Log(LOGERROR, "%s : Substream without bStaticFieldsPresent flag set can not be handled for the moment", __FUNCTION__);
+      }
+      else
+      {
+        //nuRefClockCode = ExtractBits(2);
+		CBitstreamConverter::skip_bits( &bitstream, 2); ibyteread += 2;
+		//nuExSSFrameDurationCode = 512*(ExtractBits(3)+1);
+		CBitstreamConverter::skip_bits( &bitstream, 3); ibyteread += 3;
+		//bTimeStampFlag = ExtractBits(1);
+		uint8_t bTimeStampFlag  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1;
+		CLog::Log(LOGDEBUG, "%s : bTimeStampFlag : %u", __FUNCTION__, bTimeStampFlag);
+		if(bTimeStampFlag)
+		{
+          //nuTimeStamp = ExtractBits(32);
+          CBitstreamConverter::skip_bits( &bitstream, 32); ibyteread += 32;
+          //nLSB = ExtractBits(4);
+          CBitstreamConverter::skip_bits( &bitstream, 4); ibyteread += 4;
+		}
+		//nuNumAudioPresnt = ExtractBits(3)+1;
+		nuNumAudioPresnt  = CBitstreamConverter::read_bits( &bitstream, 3) + 1 ;  ibyteread += 3;
+        CLog::Log(LOGDEBUG, "%s : nuNumAudioPresnt : %u", __FUNCTION__, nuNumAudioPresnt);
+		//nuNumAssets = ExtractBits(3)+1;
+		nuNumAssets  = CBitstreamConverter::read_bits( &bitstream, 3) + 1 ;  ibyteread += 3;					
+		CLog::Log(LOGDEBUG, "%s : nuNumAssets : %u", __FUNCTION__, nuNumAssets);
+		//nuActiveExSSMask & nuActiveAssetMask
+		uint32_t* nuActiveExSSMask = (uint32_t *) malloc(nuNumAudioPresnt * sizeof(uint32_t)); //needed temporary too skip some bits
+		for (int nAuPr=0; nAuPr<nuNumAudioPresnt; nAuPr++){
+          nuActiveExSSMask[nAuPr] = CBitstreamConverter::read_bits( &bitstream, nExtSSIndex + 1) ;  ibyteread += (nExtSSIndex + 1);}
+		for (int nAuPr=0; nAuPr<nuNumAudioPresnt; nAuPr++)
+		{
+          for (int nSS=0; nSS<nExtSSIndex+1; nSS++)
+          {
+            if (((nuActiveExSSMask[nAuPr]>>nSS) & 0x1) == 1){
+              //nuActiveAssetMask[nAuPr][nSS] = ExtractBits(8);
+              CBitstreamConverter::skip_bits( &bitstream, 8); ibyteread += 8; } //else //nuActiveAssetMask[nAuPr][nSS]= 0;
+          }
+		}
+		free(nuActiveExSSMask);
+
+		//bMixMetadataEnbl = ExtractBits(1);
+		uint8_t bMixMetadataEnbl  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1;
+		CLog::Log(LOGDEBUG, "%s : bMixMetadataEnbl : %u", __FUNCTION__, bMixMetadataEnbl);
+		if (bMixMetadataEnbl)
+		{
+          //nuMixMetadataAdjLevel = ExtractBits(2);
+          CBitstreamConverter::skip_bits( &bitstream, 2); ibyteread += 2; 
+          //nuBits4MixOutMask = (ExtractBits(2)+1)<<2;
+          uint8_t nuBits4MixOutMask  = (CBitstreamConverter::read_bits( &bitstream, 2) + 1) << 2 ;  ibyteread += 2;
+          //nuNumMixOutConfigs = ExtractBits(2) + 1;
+          uint8_t nuNumMixOutConfigs  = CBitstreamConverter::read_bits( &bitstream, 2) + 1 ;  ibyteread += 2; 
+          // Output Mixing Configuration Loop
+          for (int ns=0; ns<nuNumMixOutConfigs; ns++)
+          {
+            //nuMixOutChMask[ns]= ExtractBits(nBits4MixOutMask);
+			CBitstreamConverter::skip_bits( &bitstream, nuBits4MixOutMask); ibyteread += nuBits4MixOutMask;  //nNumMixOutCh[ns] = NumSpkrTableLookUp(nuMixOutChMask[ns]);
+          }
+		}
+      }//bStaticFieldsPresent
+
+      //REM : for the moment substreams with multiple audio presentation and/or audio assets are not handled  
+      // TODO : found a real case and implement this or even continue .... (may be available in blurays with additional director description content ...)
+      if( nuNumAudioPresnt != 1 || nuNumAssets !=1 )
+      {
+        CLog::Log(LOGERROR, "%s : Substream with mutiple audio presentations and/or mumltiple audio assets are not yet handled by xbmc : %u / %u", __FUNCTION__, nuNumAudioPresnt, nuNumAssets);
+        return false;
+      } 
+     
+      for (int nAst=0; nAst< nuNumAssets; nAst++){
+        //nuAssetFsize[nAst] = ExtractBits(nuBits4ExSSFsize)+1;
+		CBitstreamConverter::skip_bits( &bitstream, nuBits4ExSSFsize); ibyteread += nuBits4ExSSFsize;}
+
+      for (int nAst=0; nAst< nuNumAssets; nAst++)
+      {
+        //nuAssetDescriptFsize = ExtractBits(9)+1;
+		CBitstreamConverter::skip_bits( &bitstream, 9); ibyteread += 9;
+		//nuAssetIndex = ExtractBits(3);
+		CBitstreamConverter::skip_bits( &bitstream, 3); ibyteread += 3;
+		if (bStaticFieldsPresent)
+		{
+          //bAssetTypeDescrPresent = ExtractBits(1);
+          uint8_t bAssetTypeDescrPresent  = CBitstreamConverter::read_bits( &bitstream, 1)  ;  ibyteread += 1;
+          CLog::Log(LOGDEBUG, "%s : Asset :  %u - bAssetTypeDescrPresent : %u", __FUNCTION__, nAst, bAssetTypeDescrPresent);
+          if (bAssetTypeDescrPresent){
+            //nuAssetTypeDescriptor = ExtractBits(4);
+            CBitstreamConverter::skip_bits( &bitstream, 4); ibyteread += 4;}
+
+          //bLanguageDescrPresent = ExtractBits(1);
+          uint8_t bLanguageDescrPresent  = CBitstreamConverter::read_bits( &bitstream, 1)  ;  ibyteread += 1;
+          CLog::Log(LOGDEBUG, "%s : Asset :  %u - bLanguageDescrPresent : %u", __FUNCTION__, nAst, bLanguageDescrPresent);
+          if (bLanguageDescrPresent){
+            //LanguageDescriptor = ExtractBits(24);
+			//unsigned int LanguageDescriptor  = read_bits( &bitstream, 24)  ;  ibyteread += 24;//not yet found in a real case ;(
+			CBitstreamConverter::skip_bits( &bitstream, 24); ibyteread += 24;}
+
+          //bInfoTextPresent = ExtractBits(1);
+          uint8_t bInfoTextPresent  = CBitstreamConverter::read_bits( &bitstream, 1)  ;  ibyteread += 1;
+          CLog::Log(LOGDEBUG, "%s : Asset :  %u - bInfoTextPresent : %u", __FUNCTION__, nAst, bInfoTextPresent);
+          if (bInfoTextPresent)
+          {
+            //nuInfoTextByteSize = ExtractBits(10)+1;
+			uint16_t nuInfoTextByteSize  = CBitstreamConverter::read_bits( &bitstream, 10) + 1 ;  ibyteread += 10;
+			//InfoTextString = ExtractBits(nuInfoTextByteSize*8);
+			CBitstreamConverter::skip_bits( &bitstream, nuInfoTextByteSize * 8); ibyteread += (nuInfoTextByteSize * 8);
+          }
+          
+          //REM : we do not handle Substreams EXtension and take those fields for extended infos
+          //Works pretty well for DTS_HD MA :)
+          
+          //nuBitResolution = ExtractBits(5) + 1;
+          nuBitResolution  = CBitstreamConverter::read_bits( &bitstream, 5) + 1 ;  ibyteread += 5;
+          CLog::Log(LOGDEBUG, "%s : Asset :  %u - nuBitResolution : %u", __FUNCTION__, nAst, nuBitResolution);
+          //nuMaxSampleRate = ExtractBits(4)
+          nuMaxSampleRate  = CBitstreamConverter::read_bits( &bitstream, 4) ;  ibyteread += 4;
+          CLog::Log(LOGDEBUG, "%s : Asset :  %u - nuMaxSampleRate : %u", __FUNCTION__, nAst, nuMaxSampleRate);
+          //nuTotalNumChs = ExtractBits(8)+1;
+          nuTotalNumChs  = CBitstreamConverter::read_bits( &bitstream, 8) + 1 ;  ibyteread += 8;
+          CLog::Log(LOGDEBUG, "%s : Asset :  %u - nuTotalNumChs : %u", __FUNCTION__, nAst, nuTotalNumChs);
+            
+          /// Lot more ........... but we don't need anything more for the moment
+        }//bStaticFieldsPresent
+        /// Lot more ........... but we don't need anything more for the moment
+      }//for (int nAst=0; nAst< nuNumAssets; nAst++)
+      /// Lot more ........... but we don't need anything more for the moment
+      
+      //TODO : Move the crc verification upper ...
+      //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      int bits_to_crc = ((FSIZE + nuExtSSHeaderSize) * 8)  - ibyteread - 16;
+      CBitstreamConverter::skip_bits( &bitstream, bits_to_crc); ibyteread += bits_to_crc;
+      //nCRC16ExtSSHeader = ExtractBits(16);
+      unsigned short nCRC16ExtSSHeader  = CBitstreamConverter::read_bits( &bitstream, 16) ;  ibyteread += 16;
+      const AVCRC *ctx;
+      ctx = av_crc_get_table(AV_CRC_16_CCITT);	
+      uint16_t crc =  av_crc(ctx, 0xffff, pframe->data + FSIZE + 5 ,  nuExtSSHeaderSize - 2 - 5);
+      crc = (crc << 8) & 0xFF00 + (crc >> 8); //crc = htons(crc);
+      CLog::Log(LOGDEBUG, "%s : calculated CRC16 checksum : %04x", __FUNCTION__, crc);
+      if( nCRC16ExtSSHeader != crc)
+      {
+        CLog::Log(LOGERROR, "%s : CRC16 checksum mismatch %04x / %04x", __FUNCTION__, nCRC16ExtSSHeader, crc);
+        return false;
+      }
+      else
+		CLog::Log(LOGDEBUG, "%s : Checksum verification succeded", __FUNCTION__);
+      
       bExtendedStreamInfo = true;
-      iExtendedChannels = 8;
-      return true;
+      iExtendedChannels = nuTotalNumChs;  
+      iExtendedResolution = nuBitResolution;
+      iExtendedSampleRate = DTS_HD_MaxSampleRate[nuMaxSampleRate];
+      
+      if(LFF == 0)
+        lfe_channel = PRESENT;
+      else if(LFF == 1 || LFF == 2)
+        lfe_channel = PRESENT;
+      else
+        lfe_channel = UNKNOW;
+      
+    }//bcheckextendedstream   
+
+    return true;
   }
   
 int CDVDDemux::GetNrOfAudioStreams()

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -48,7 +48,7 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
 
   int ilocalChannels = iChannels;
   if(bExtendedStreamInfo)
-      ilocalChannels = iExtendedChannels;
+    ilocalChannels = iExtendedChannels;
   
   if (ilocalChannels == 1) strcat(sInfo, "Mono");
   else if (ilocalChannels == 2) strcat(sInfo, "Stereo");
@@ -131,63 +131,64 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
       CLog::Log(LOGERROR, "%s : CORE Sync Word not detected : 0x%08x ", __FUNCTION__, SYNC_CORE);
       return false;
     }
- 	//FTYPE = ExtractBits(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1 ); ibyteread += 1;
-	//SHORT = ExtractBits(5);
-	CBitstreamConverter::skip_bits( &bitstream, 5 ); ibyteread += 5;
-	//CPF = ExtractBits(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1 ); ibyteread += 1;
-	//NBLKS = ExtractBits(7);
-	CBitstreamConverter::skip_bits( &bitstream, 7); ibyteread += 7;  
-	//FSIZE = ExtractBits(14);
+    
+    //FTYPE = ExtractBits(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1 ); ibyteread += 1;
+    //SHORT = ExtractBits(5);
+    CBitstreamConverter::skip_bits( &bitstream, 5 ); ibyteread += 5;
+    //CPF = ExtractBits(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1 ); ibyteread += 1;
+    //NBLKS = ExtractBits(7);
+    CBitstreamConverter::skip_bits( &bitstream, 7); ibyteread += 7;  
+    //FSIZE = ExtractBits(14);
 	uint16_t FSIZE = CBitstreamConverter::read_bits( &bitstream, 14 ) + 1; ibyteread += 14;
-    CLog::Log(LOGDEBUG, "%s : Core Stream size (FSIZE)  is  : %d ", __FUNCTION__, FSIZE);
+    CLog::Log(LOGDEBUG, "%s : Core Stream size (FSIZE) is  : %d ", __FUNCTION__, FSIZE);
 	
     int bcheckextendedstream = 0;
-	if(FSIZE > pframe->size)
-	{
-      CLog::Log(LOGERROR, "%s : Core Stream size (FSIZE)  is bigger then frame size  : %d / %d", __FUNCTION__, FSIZE, pframe->size);
+    if(FSIZE > pframe->size)
+    {
+      CLog::Log(LOGERROR, "%s : Core Stream size (FSIZE) is bigger then frame size : %d / %d", __FUNCTION__, FSIZE, pframe->size);
       return false;
-	}
-	else if (FSIZE == pframe->size)
-      CLog::Log(LOGDEBUG, "%s : Core Stream size (FSIZE)  is the same as the frame size  (no extension stream) : %d / %d, ", __FUNCTION__, FSIZE, pframe->size);
-	else //fsize is smaller then frame size so there is certainly an extension stream
-	  bcheckextendedstream = 1;  
+    }
+    else if (FSIZE == pframe->size)
+      CLog::Log(LOGDEBUG, "%s : Core Stream size (FSIZE)  is the same as the frame size (no extension stream) : %d / %d, ", __FUNCTION__, FSIZE, pframe->size);
+    else //fsize is smaller then frame size so there is certainly an extension stream
+      bcheckextendedstream = 1;  
   
- 	//AMODE = ExtractBits(6);
-	CBitstreamConverter::skip_bits( &bitstream, 6); ibyteread += 6;
-	//SFREQ = ExtractBits(4);
-	CBitstreamConverter::skip_bits( &bitstream, 4); ibyteread += 4;
-	//RATE = ExtractBits(5);
-	CBitstreamConverter::skip_bits( &bitstream, 5); ibyteread += 5;
-	//FixedBit = ExtractBit(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
-	//DYNF = ExtractBits(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
-	//TIMEF = ExtractBits(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
-	//AUXF = ExtractBits(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
-	//HDCD = ExtractBits(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1; 
-  	//EXT_AUDIO_ID = ExtractBits(3);
-	uint8_t EXT_AUDIO_ID = CBitstreamConverter::read_bits( &bitstream, 3 ); ibyteread += 3;
-	//EXT_AUDIO = ExtractBits(1);
-	uint8_t EXT_AUDIO = CBitstreamConverter::read_bits( &bitstream, 1 );  ibyteread += 1;
-	//ASPF = ExtractBits(1);
-	CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
-	//LFF = ExtractBits(2);
-	uint8_t LFF = CBitstreamConverter::read_bits( &bitstream, 2 );  ibyteread += 2;
+    //AMODE = ExtractBits(6);
+    CBitstreamConverter::skip_bits( &bitstream, 6); ibyteread += 6;
+    //SFREQ = ExtractBits(4);
+    CBitstreamConverter::skip_bits( &bitstream, 4); ibyteread += 4;
+    //RATE = ExtractBits(5);
+    CBitstreamConverter::skip_bits( &bitstream, 5); ibyteread += 5;
+    //FixedBit = ExtractBit(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+    //DYNF = ExtractBits(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+    //TIMEF = ExtractBits(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+    //AUXF = ExtractBits(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+    //HDCD = ExtractBits(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1; 
+    //EXT_AUDIO_ID = ExtractBits(3);
+    uint8_t EXT_AUDIO_ID = CBitstreamConverter::read_bits( &bitstream, 3 ); ibyteread += 3;
+    //EXT_AUDIO = ExtractBits(1);
+    uint8_t EXT_AUDIO = CBitstreamConverter::read_bits( &bitstream, 1 );  ibyteread += 1;
+    //ASPF = ExtractBits(1);
+    CBitstreamConverter::skip_bits( &bitstream, 1); ibyteread += 1;
+    //LFF = ExtractBits(2);
+    uint8_t LFF = CBitstreamConverter::read_bits( &bitstream, 2 );  ibyteread += 2;
 		
-	/// Lot more ........... but we don't need anything more for the moment
+    /// Lot more ........... but we don't need anything more for the moment
 		
-	// 2) CORE STREAM EXTENSIONS
-	////////////////////////////
+    // 2) CORE STREAM EXTENSIONS
+    ////////////////////////////
   
-	//REM : for the moment core streams extensions are not handled
+    //REM : for the moment core streams extensions are not handled
     //TODO : found a real case and implement this or even continue .... (not found a dts-hd ma with core extension ...))
-	if(EXT_AUDIO == 1)
-	{
+    if(EXT_AUDIO == 1)
+    {
       std::string Extension_id_txt;
       if(EXT_AUDIO_ID == 0)
         Extension_id_txt =  "Channel Extension (XCh)";
@@ -200,20 +201,20 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
 
       CLog::Log(LOGERROR, "%s : Core stream extension have been detected, those are not yet handled by xbmc at the moment. Extension type : %s", __FUNCTION__, Extension_id_txt.c_str());
       return false;
-	}  
+    }  
   
-	// 3) EXTENSION SUBSTREAM
+    // 3) EXTENSION SUBSTREAM
     ///////////////////////////////////////////
 
-	if(bcheckextendedstream)
-	{
+    if(bcheckextendedstream)
+    {
       uint8_t nuBitResolution  = 0;
       uint8_t nuMaxSampleRate  = 0;
       uint8_t nuTotalNumChs  = 0;
       CLog::Log(LOGDEBUG, "%s : Parsing Extended substream", __FUNCTION__);
       if( pframe->size < FSIZE + 12) //Enough to get up to the extended frame size where further check is done 
       {
-        CLog::Log(LOGERROR, "%s : Frame size is not big enough to get up to the extended stream size   : %d / %d", __FUNCTION__, FSIZE + 12, pframe->size);
+        CLog::Log(LOGERROR, "%s : Frame size is not big enough to get up to the extended stream size  : %d / %d", __FUNCTION__, FSIZE + 12, pframe->size);
         return false;
       }
       
@@ -228,7 +229,7 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
       }
       else
       {
-  		CLog::Log(LOGERROR, "%s : SUBSTREAM Sync Word not detected : 0x%08x ", __FUNCTION__, SYNCEXTSSH);
+        CLog::Log(LOGERROR, "%s : SUBSTREAM Sync Word not detected : 0x%08x ", __FUNCTION__, SYNCEXTSSH);
         return false;
       }
       //UserDefinedBits = ExtractBits(8)
@@ -244,7 +245,7 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
       if (bHeaderSizeType == 0)
       {
         nuBits4Header = 8;
-		nuBits4ExSSFsize = 16;
+        nuBits4ExSSFsize = 16;
       }
       else
       {
@@ -259,7 +260,7 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
       CLog::Log(LOGDEBUG, "%s : Extended stream  size (nuExtSSFsize) : %u", __FUNCTION__, nuExtSSFsize);
       if(nuExtSSFsize + FSIZE < (uint32_t)pframe->size)
       {
-        CLog::Log(LOGERROR, "%s : Core stream + Substream length is bigger then frame size; (bade frame ???) : %d / %u / %d", __FUNCTION__,FSIZE, nuExtSSFsize, pframe->size);
+        CLog::Log(LOGERROR, "%s : Core stream + Substream length is bigger then frame size; (bade frame ???) : %d / %u / %d", __FUNCTION__, FSIZE, nuExtSSFsize, pframe->size);
         return false;
       }
       //REM : for the moment multiple substreams are not handled
@@ -270,6 +271,34 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
                           __FUNCTION__,FSIZE, nuExtSSFsize, pframe->size, nExtSSIndex);
         return false;
       }
+      
+      //CRC
+
+      uint16_t nCRC16ExtSSHeader = 0;
+      int icrc_position = FSIZE + nuExtSSHeaderSize  - 2;
+#if defined(WORDS_BIGENDIAN) //don't know if this is correct ???
+      for(int i =1; i >= 0; i--)
+#else
+      for(int i =0; i <= 1; i++)
+#endif
+      {
+        nCRC16ExtSSHeader = (nCRC16ExtSSHeader << 8) + pframe->data[icrc_position + i];
+      }
+      
+      const AVCRC *ctx;
+      ctx = av_crc_get_table(AV_CRC_16_CCITT);	
+      uint16_t crc =  av_crc(ctx, 0xffff, pframe->data + FSIZE + 5 ,  nuExtSSHeaderSize - 2 - 5);
+      //should not be inverted likely a ffmpeg error ??
+      crc = ((crc << 8) & 0xFF00) + (crc >> 8); //crc = htons(crc);
+      CLog::Log(LOGDEBUG, "%s : calculated CRC16 checksum : %04x", __FUNCTION__, crc);
+      
+      if( nCRC16ExtSSHeader != crc)
+      {
+        CLog::Log(LOGERROR, "%s : CRC16 checksum mismatch %04x / %04x", __FUNCTION__, nCRC16ExtSSHeader, crc);
+        return false;
+      }
+      else
+        CLog::Log(LOGDEBUG, "%s : Checksum verification succeded", __FUNCTION__);
       
       //bStaticFieldsPresent = ExtractBits(1);
       uint8_t bStaticFieldsPresent  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1; 
@@ -289,45 +318,45 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
       else
       {
         //nuRefClockCode = ExtractBits(2);
-		CBitstreamConverter::skip_bits( &bitstream, 2); ibyteread += 2;
-		//nuExSSFrameDurationCode = 512*(ExtractBits(3)+1);
-		CBitstreamConverter::skip_bits( &bitstream, 3); ibyteread += 3;
-		//bTimeStampFlag = ExtractBits(1);
-		uint8_t bTimeStampFlag  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1;
-		CLog::Log(LOGDEBUG, "%s : bTimeStampFlag : %u", __FUNCTION__, bTimeStampFlag);
-		if(bTimeStampFlag)
-		{
+        CBitstreamConverter::skip_bits( &bitstream, 2); ibyteread += 2;
+        //nuExSSFrameDurationCode = 512*(ExtractBits(3)+1);
+        CBitstreamConverter::skip_bits( &bitstream, 3); ibyteread += 3;
+        //bTimeStampFlag = ExtractBits(1);
+        uint8_t bTimeStampFlag  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1;
+        CLog::Log(LOGDEBUG, "%s : bTimeStampFlag : %u", __FUNCTION__, bTimeStampFlag);
+        if(bTimeStampFlag)
+        {
           //nuTimeStamp = ExtractBits(32);
           CBitstreamConverter::skip_bits( &bitstream, 32); ibyteread += 32;
           //nLSB = ExtractBits(4);
           CBitstreamConverter::skip_bits( &bitstream, 4); ibyteread += 4;
-		}
-		//nuNumAudioPresnt = ExtractBits(3)+1;
-		nuNumAudioPresnt  = CBitstreamConverter::read_bits( &bitstream, 3) + 1 ;  ibyteread += 3;
+        }
+        //nuNumAudioPresnt = ExtractBits(3)+1;
+        nuNumAudioPresnt  = CBitstreamConverter::read_bits( &bitstream, 3) + 1 ;  ibyteread += 3;
         CLog::Log(LOGDEBUG, "%s : nuNumAudioPresnt : %u", __FUNCTION__, nuNumAudioPresnt);
-		//nuNumAssets = ExtractBits(3)+1;
-		nuNumAssets  = CBitstreamConverter::read_bits( &bitstream, 3) + 1 ;  ibyteread += 3;					
-		CLog::Log(LOGDEBUG, "%s : nuNumAssets : %u", __FUNCTION__, nuNumAssets);
-		//nuActiveExSSMask & nuActiveAssetMask
-		uint32_t* nuActiveExSSMask = (uint32_t *) malloc(nuNumAudioPresnt * sizeof(uint32_t)); //needed temporary too skip some bits
-		for (int nAuPr=0; nAuPr<nuNumAudioPresnt; nAuPr++){
+        //nuNumAssets = ExtractBits(3)+1;
+        nuNumAssets  = CBitstreamConverter::read_bits( &bitstream, 3) + 1 ;  ibyteread += 3;					
+        CLog::Log(LOGDEBUG, "%s : nuNumAssets : %u", __FUNCTION__, nuNumAssets);
+        //nuActiveExSSMask & nuActiveAssetMask
+        uint32_t* nuActiveExSSMask = (uint32_t *) malloc(nuNumAudioPresnt * sizeof(uint32_t)); //needed temporary too skip some bits
+        for (int nAuPr=0; nAuPr<nuNumAudioPresnt; nAuPr++){
           nuActiveExSSMask[nAuPr] = CBitstreamConverter::read_bits( &bitstream, nExtSSIndex + 1) ;  ibyteread += (nExtSSIndex + 1);}
-		for (int nAuPr=0; nAuPr<nuNumAudioPresnt; nAuPr++)
-		{
+        for (int nAuPr=0; nAuPr<nuNumAudioPresnt; nAuPr++)
+        {
           for (int nSS=0; nSS<nExtSSIndex+1; nSS++)
           {
             if (((nuActiveExSSMask[nAuPr]>>nSS) & 0x1) == 1){
               //nuActiveAssetMask[nAuPr][nSS] = ExtractBits(8);
               CBitstreamConverter::skip_bits( &bitstream, 8); ibyteread += 8; } //else //nuActiveAssetMask[nAuPr][nSS]= 0;
           }
-		}
-		free(nuActiveExSSMask);
+        }
+        free(nuActiveExSSMask);
 
-		//bMixMetadataEnbl = ExtractBits(1);
-		uint8_t bMixMetadataEnbl  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1;
-		CLog::Log(LOGDEBUG, "%s : bMixMetadataEnbl : %u", __FUNCTION__, bMixMetadataEnbl);
-		if (bMixMetadataEnbl)
-		{
+        //bMixMetadataEnbl = ExtractBits(1);
+        uint8_t bMixMetadataEnbl  = CBitstreamConverter::read_bits( &bitstream, 1) ;  ibyteread += 1;
+        CLog::Log(LOGDEBUG, "%s : bMixMetadataEnbl : %u", __FUNCTION__, bMixMetadataEnbl);
+        if (bMixMetadataEnbl)
+        {
           //nuMixMetadataAdjLevel = ExtractBits(2);
           CBitstreamConverter::skip_bits( &bitstream, 2); ibyteread += 2; 
           //nuBits4MixOutMask = (ExtractBits(2)+1)<<2;
@@ -338,9 +367,9 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
           for (int ns=0; ns<nuNumMixOutConfigs; ns++)
           {
             //nuMixOutChMask[ns]= ExtractBits(nBits4MixOutMask);
-			CBitstreamConverter::skip_bits( &bitstream, nuBits4MixOutMask); ibyteread += nuBits4MixOutMask;  //nNumMixOutCh[ns] = NumSpkrTableLookUp(nuMixOutChMask[ns]);
+            CBitstreamConverter::skip_bits( &bitstream, nuBits4MixOutMask); ibyteread += nuBits4MixOutMask;  //nNumMixOutCh[ns] = NumSpkrTableLookUp(nuMixOutChMask[ns]);
           }
-		}
+        }
       }//bStaticFieldsPresent
 
       //REM : for the moment substreams with multiple audio presentation and/or audio assets are not handled  
@@ -353,16 +382,16 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
      
       for (int nAst=0; nAst< nuNumAssets; nAst++){
         //nuAssetFsize[nAst] = ExtractBits(nuBits4ExSSFsize)+1;
-		CBitstreamConverter::skip_bits( &bitstream, nuBits4ExSSFsize); ibyteread += nuBits4ExSSFsize;}
+        CBitstreamConverter::skip_bits( &bitstream, nuBits4ExSSFsize); ibyteread += nuBits4ExSSFsize;}
 
       for (int nAst=0; nAst< nuNumAssets; nAst++)
       {
         //nuAssetDescriptFsize = ExtractBits(9)+1;
-		CBitstreamConverter::skip_bits( &bitstream, 9); ibyteread += 9;
-		//nuAssetIndex = ExtractBits(3);
-		CBitstreamConverter::skip_bits( &bitstream, 3); ibyteread += 3;
-		if (bStaticFieldsPresent)
-		{
+        CBitstreamConverter::skip_bits( &bitstream, 9); ibyteread += 9;
+        //nuAssetIndex = ExtractBits(3);
+        CBitstreamConverter::skip_bits( &bitstream, 3); ibyteread += 3;
+        if (bStaticFieldsPresent)
+        {
           //bAssetTypeDescrPresent = ExtractBits(1);
           uint8_t bAssetTypeDescrPresent  = CBitstreamConverter::read_bits( &bitstream, 1)  ;  ibyteread += 1;
           CLog::Log(LOGDEBUG, "%s : Asset :  %u - bAssetTypeDescrPresent : %u", __FUNCTION__, nAst, bAssetTypeDescrPresent);
@@ -375,8 +404,8 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
           CLog::Log(LOGDEBUG, "%s : Asset :  %u - bLanguageDescrPresent : %u", __FUNCTION__, nAst, bLanguageDescrPresent);
           if (bLanguageDescrPresent){
             //LanguageDescriptor = ExtractBits(24);
-			//unsigned int LanguageDescriptor  = read_bits( &bitstream, 24)  ;  ibyteread += 24;//not yet found in a real case ;(
-			CBitstreamConverter::skip_bits( &bitstream, 24); ibyteread += 24;}
+            //unsigned int LanguageDescriptor  = read_bits( &bitstream, 24)  ;  ibyteread += 24;//not yet found in a real case ;(
+            CBitstreamConverter::skip_bits( &bitstream, 24); ibyteread += 24;}
 
           //bInfoTextPresent = ExtractBits(1);
           uint8_t bInfoTextPresent  = CBitstreamConverter::read_bits( &bitstream, 1)  ;  ibyteread += 1;
@@ -384,9 +413,9 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
           if (bInfoTextPresent)
           {
             //nuInfoTextByteSize = ExtractBits(10)+1;
-			uint16_t nuInfoTextByteSize  = CBitstreamConverter::read_bits( &bitstream, 10) + 1 ;  ibyteread += 10;
-			//InfoTextString = ExtractBits(nuInfoTextByteSize*8);
-			CBitstreamConverter::skip_bits( &bitstream, nuInfoTextByteSize * 8); ibyteread += (nuInfoTextByteSize * 8);
+            uint16_t nuInfoTextByteSize  = CBitstreamConverter::read_bits( &bitstream, 10) + 1 ;  ibyteread += 10;
+            //InfoTextString = ExtractBits(nuInfoTextByteSize*8);
+            CBitstreamConverter::skip_bits( &bitstream, nuInfoTextByteSize * 8); ibyteread += (nuInfoTextByteSize * 8);
           }
           
           //REM : we do not handle Substreams EXtension and take those fields for extended infos
@@ -403,29 +432,17 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
           CLog::Log(LOGDEBUG, "%s : Asset :  %u - nuTotalNumChs : %u", __FUNCTION__, nAst, nuTotalNumChs);
             
           /// Lot more ........... but we don't need anything more for the moment
+          
         }//bStaticFieldsPresent
+    
         /// Lot more ........... but we don't need anything more for the moment
+    
       }//for (int nAst=0; nAst< nuNumAssets; nAst++)
+      
       /// Lot more ........... but we don't need anything more for the moment
       
-      //TODO : Move the crc verification upper ...
-      //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      int bits_to_crc = ((FSIZE + nuExtSSHeaderSize) * 8)  - ibyteread - 16;
-      CBitstreamConverter::skip_bits( &bitstream, bits_to_crc); ibyteread += bits_to_crc;
-      //nCRC16ExtSSHeader = ExtractBits(16);
-      uint16_t nCRC16ExtSSHeader  = CBitstreamConverter::read_bits( &bitstream, 16) ;  ibyteread += 16;
-      const AVCRC *ctx;
-      ctx = av_crc_get_table(AV_CRC_16_CCITT);	
-      uint16_t crc =  av_crc(ctx, 0xffff, pframe->data + FSIZE + 5 ,  nuExtSSHeaderSize - 2 - 5);
-      crc = ((crc << 8) & 0xFF00) + (crc >> 8); //crc = htons(crc);
-      CLog::Log(LOGDEBUG, "%s : calculated CRC16 checksum : %04x", __FUNCTION__, crc);
-      if( nCRC16ExtSSHeader != crc)
-      {
-        CLog::Log(LOGERROR, "%s : CRC16 checksum mismatch %04x / %04x", __FUNCTION__, nCRC16ExtSSHeader, crc);
-        return false;
-      }
-      else
-		CLog::Log(LOGDEBUG, "%s : Checksum verification succeded", __FUNCTION__);
+      //int bits_to_end_header = ((FSIZE + nuExtSSHeaderSize) * 8)  - ibyteread ;
+      //CBitstreamConverter::skip_bits( &bitstream, bits_to_end_header); ibyteread += bits_to_end_header;
       
       bExtendedStreamInfo = true;
       iExtendedChannels = nuTotalNumChs;  

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -46,11 +46,15 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
   else if (codec == AV_CODEC_ID_TRUEHD) strcpy(sInfo, "Dolby TrueHD ");
   else strcpy(sInfo, "");
 
-  if (iChannels == 1) strcat(sInfo, "Mono");
-  else if (iChannels == 2) strcat(sInfo, "Stereo");
-  else if (iChannels == 6) strcat(sInfo, "5.1");
-  else if (iChannels == 8) strcat(sInfo, "7.1");
-  else if (iChannels != 0)
+  int ilocalChannels = iChannels;
+  if(bExtendedStreamInfo)
+      ilocalChannels = iExtendedChannels;
+  
+  if (ilocalChannels == 1) strcat(sInfo, "Mono");
+  else if (ilocalChannels == 2) strcat(sInfo, "Stereo");
+  else if (ilocalChannels == 6) strcat(sInfo, "5.1");
+  else if (ilocalChannels == 8) strcat(sInfo, "7.1");
+  else if (ilocalChannels != 0)
   {
     char temp[32];
     sprintf(temp, " %d%s", iChannels, "-chs");
@@ -58,6 +62,14 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
   }
   strInfo = sInfo;
 }
+
+  void CDemuxStreamAudio::GetExtendedStreamInfo()
+  {
+     bExtendedStreamInfo = false;
+     iExtendedChannels = 0;
+     //iExtendedSampleRate = 0;
+     //iExtendedBitRate = 0;
+  }
 
 int CDVDDemux::GetNrOfAudioStreams()
 {

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -63,7 +63,7 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
   strInfo = sInfo;
 }
 
-  void CDemuxStreamAudio::GetExtendedStreamInfo()
+  void CDemuxStreamAudio::GetExtendedStreamInfo(pFrame pframe )
   {
      bExtendedStreamInfo = false;
      iExtendedChannels = 0;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.cpp
@@ -63,14 +63,44 @@ void CDemuxStreamAudio::GetStreamType(std::string& strInfo)
   strInfo = sInfo;
 }
 
-  void CDemuxStreamAudio::GetExtendedStreamInfo(pFrame pframe )
+  void CDemuxStreamAudio::GetExtendedStreamInfo(AVCodecID codectype, pFrame pframe )
   {
-     bExtendedStreamInfo = false;
-     iExtendedChannels = 0;
-     //iExtendedSampleRate = 0;
-     //iExtendedBitRate = 0;
+    if(pframe == NULL)
+      return;
+    
+    bool bset_default_value = true;
+    if(codectype == AV_CODEC_ID_DTS)
+    {
+      if(this->Parse_dts_audio_header(pframe))
+      {
+        CLog::Log(LOGINFO, "%s : Correctly detected DTS-HD MA extended info", __FUNCTION__);
+        bset_default_value = false;
+      }
+      else
+      {
+        CLog::Log(LOGERROR, "%s : DTS-HD MA extended info not correctly detected", __FUNCTION__);
+      }
+    }
+    
+    if(bset_default_value)
+    {
+      bExtendedStreamInfo = false;
+      iExtendedChannels = 0;
+      lfe_channel = UNKNOW;
+      iExtendedSampleRate = 0;
+      iExtendedResolution = 0;
+      iExtendedBitRate = 0;
+    }
   }
 
+  bool CDemuxStreamAudio::Parse_dts_audio_header(pFrame pframe)
+  {
+      //TESTING
+      bExtendedStreamInfo = true;
+      iExtendedChannels = 8;
+      return true;
+  }
+  
 int CDVDDemux::GetNrOfAudioStreams()
 {
   int iCounter = 0;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -225,9 +225,9 @@ public:
   uint8_t iExtendedResolution;
   
 protected:
-    const int DTS_HD_MaxSampleRate[16]= {   8000, 16000, 32000, 64000, 128000, 22050, 44100, 88200,
+  const int DTS_HD_MaxSampleRate[16]= {   8000, 16000, 32000, 64000, 128000, 22050, 44100, 88200,
                                                             176400, 352800, 12000, 24000, 48000, 96000, 192000, 384000};
-    bool Parse_dts_audio_header(pFrame pframe);
+  bool Parse_dts_audio_header(pFrame pframe);
 };
 
 class CDemuxStreamSubtitle : public CDemuxStream

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -21,6 +21,7 @@
  */
 
 #include "utils/StdString.h"
+#include "utils/BitstreamConverter.h"
 #include "system.h"
 #include "DVDDemuxPacket.h"
 
@@ -201,7 +202,6 @@ public:
     lfe_channel = UNKNOW;
     iExtendedSampleRate = 0;
     iExtendedResolution = 0;
-    iExtendedBitRate = 0;
     
     type = STREAM_AUDIO;
   }
@@ -219,15 +219,15 @@ public:
   int iBitsPerSample;
   
   bool bExtendedStreamInfo;
-  int iExtendedChannels;
+  uint8_t iExtendedChannels;
   LFE_Channel lfe_channel;
-  int iExtendedSampleRate;
-  int iExtendedResolution;
-  int iExtendedBitRate;
+  uint8_t iExtendedSampleRate;
+  uint8_t iExtendedResolution;
   
 protected:
-    bool Parse_dts_audio_header(pFrame pframe); 
-
+    int DTS_HD_MaxSampleRate[16]= {   8000, 16000, 32000, 64000, 128000, 22050, 44100, 88200,
+                                                            176400, 352800, 12000, 24000, 48000, 96000, 192000, 384000};
+    bool Parse_dts_audio_header(pFrame pframe);
 };
 
 class CDemuxStreamSubtitle : public CDemuxStream

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -31,6 +31,10 @@ class CDVDInputStream;
 #pragma warning(disable:4244)
 #endif
 
+#if !defined(TARGET_WINDOWS) && !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__) 
+#include <stddef.h>
+#endif
+
 #if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
   #include "config.h"
 #endif
@@ -61,6 +65,8 @@ enum StreamSource {
 };
 
 #define STREAM_SOURCE_MASK(a) ((a) & 0xf00)
+
+typedef struct { unsigned char * data; int size; } Frame, *pFrame;
 
 /*
  * CDemuxStream
@@ -195,7 +201,7 @@ public:
 
   void GetStreamType(std::string& strInfo);
 
-  virtual void GetExtendedStreamInfo();
+  virtual void GetExtendedStreamInfo(pFrame pframe = NULL);
   
   int iChannels;
   int iSampleRate;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -68,6 +68,11 @@ enum StreamSource {
 
 typedef struct { unsigned char * data; int size; } Frame, *pFrame;
 
+enum LFE_Channel {
+  UNKNOW        = 0,
+  PRESENT         = 1,
+  NOT_PRESENT = 2,
+};
 /*
  * CDemuxStream
  * Base class for all demuxer streams
@@ -190,18 +195,22 @@ public:
     iBlockAlign = 0;
     iBitRate = 0;
     iBitsPerSample = 0;
+    
     bExtendedStreamInfo = false;
     iExtendedChannels = 0;
-    //iExtendedSampleRate = 0;
-    //iExtendedBitRate = 0;
+    lfe_channel = UNKNOW;
+    iExtendedSampleRate = 0;
+    iExtendedResolution = 0;
+    iExtendedBitRate = 0;
+    
     type = STREAM_AUDIO;
   }
 
   virtual ~CDemuxStreamAudio() {}
 
   void GetStreamType(std::string& strInfo);
-
-  virtual void GetExtendedStreamInfo(pFrame pframe = NULL);
+  
+  virtual void GetExtendedStreamInfo(AVCodecID codectype = AV_CODEC_ID_NONE, pFrame pframe = NULL);
   
   int iChannels;
   int iSampleRate;
@@ -211,8 +220,14 @@ public:
   
   bool bExtendedStreamInfo;
   int iExtendedChannels;
-  //int iExtendedSampleRate;
-  //int iExtendedBitRate;
+  LFE_Channel lfe_channel;
+  int iExtendedSampleRate;
+  int iExtendedResolution;
+  int iExtendedBitRate;
+  
+protected:
+    bool Parse_dts_audio_header(pFrame pframe); 
+
 };
 
 class CDemuxStreamSubtitle : public CDemuxStream

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -184,6 +184,10 @@ public:
     iBlockAlign = 0;
     iBitRate = 0;
     iBitsPerSample = 0;
+    bExtendedStreamInfo = false;
+    iExtendedChannels = 0;
+    //iExtendedSampleRate = 0;
+    //iExtendedBitRate = 0;
     type = STREAM_AUDIO;
   }
 
@@ -191,11 +195,18 @@ public:
 
   void GetStreamType(std::string& strInfo);
 
+  virtual void GetExtendedStreamInfo();
+  
   int iChannels;
   int iSampleRate;
   int iBlockAlign;
   int iBitRate;
   int iBitsPerSample;
+  
+  bool bExtendedStreamInfo;
+  int iExtendedChannels;
+  //int iExtendedSampleRate;
+  //int iExtendedBitRate;
 };
 
 class CDemuxStreamSubtitle : public CDemuxStream

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -221,11 +221,11 @@ public:
   bool bExtendedStreamInfo;
   uint8_t iExtendedChannels;
   LFE_Channel lfe_channel;
-  uint8_t iExtendedSampleRate;
+  int iExtendedSampleRate;
   uint8_t iExtendedResolution;
   
 protected:
-    int DTS_HD_MaxSampleRate[16]= {   8000, 16000, 32000, 64000, 128000, 22050, 44100, 88200,
+    const int DTS_HD_MaxSampleRate[16]= {   8000, 16000, 32000, 64000, 128000, 22050, 44100, 88200,
                                                             176400, 352800, 12000, 24000, 48000, 96000, 192000, 384000};
     bool Parse_dts_audio_header(pFrame pframe);
 };

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1127,7 +1127,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
         
         if(g_advancedSettings.m_searchextendedstreaminfo)
         {
-          //TODO : if (profile == FF_PROFILE_DTS_HD_HRA)
+          //REM: ffmpeg correctly detects channel number for 
+          //        DTS_HD_HRA, however still me be usefull for more accurate lfe/bitrate/resolution ... 
           if(pStream->codec->profile == FF_PROFILE_DTS_HD_MA)
           {
             CLog::Log(LOGINFO, "%s : Searching for extended stream info", __FUNCTION__);

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -79,22 +79,6 @@ void CDemuxStreamAudioFFmpeg::GetStreamName(std::string& strInfo)
     CDemuxStream::GetStreamName(strInfo);
 }
 
-  void CDemuxStreamAudioFFmpeg::GetExtendedStreamInfo(pFrame pframe )
-  {
-      if(pframe == __null)
-          return;
-      
-      //FILE * audio_dst_file = fopen("test.bin", "wb");
-      //fwrite(pframe->data, 1, pframe->size, audio_dst_file);
-      //fclose(audio_dst_file);
-     
-     //TESTING
-     bExtendedStreamInfo = true;
-     iExtendedChannels = 8;
-     //iExtendedSampleRate = 96000;
-     //iExtendedBitRate = 99999;
-  }
-
 void CDemuxStreamSubtitleFFmpeg::GetStreamName(std::string& strInfo)
 {
   if(!m_stream) return;
@@ -1154,7 +1138,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
               frame.size = pkt->size;
               frame.data = (unsigned char *)malloc(frame.size * sizeof(unsigned char));
               fast_memcpy(frame.data, pkt->data, frame.size);
-              st->GetExtendedStreamInfo(&frame);
+              st->GetExtendedStreamInfo(AV_CODEC_ID_DTS , &frame);
               free(frame.data);
               av_free_packet(pkt);
             }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -196,12 +196,6 @@ static int interrupt_cb(void* ctx)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////
-/*
-static int dvd_file_open(URLContext *h, const char *filename, int flags)
-{
-  return -1;
-}
-*/
 
 static AVPacket* get_single_frame( AVFormatContext* fmt_ctx, int streamid)
 {
@@ -227,6 +221,13 @@ static AVPacket* get_single_frame( AVFormatContext* fmt_ctx, int streamid)
     
   return &pkt;
 }
+
+/*
+static int dvd_file_open(URLContext *h, const char *filename, int flags)
+{
+  return -1;
+}
+*/
 
 static int dvd_file_read(void *h, uint8_t* buf, int size)
 {
@@ -541,6 +542,9 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
 
   CreateStreams();
 
+  //Needed cause we picked some frame for dts-hd ma extended info ....
+  SeekTime(0,false);
+  
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -57,6 +57,16 @@ void CDemuxStreamAudioFFmpeg::GetStreamInfo(std::string& strInfo)
   char temp[128];
   m_parent->m_dllAvCodec.avcodec_string(temp, 128, m_stream->codec, 0);
   strInfo = temp;
+  if(bExtendedStreamInfo)
+  {
+     std::string strExtendedInfo = " - Extended : ";
+     //TODO add lfe ...
+     if (iExtendedChannels == 6) strExtendedInfo += " 5.1";
+     else if (iExtendedChannels == 8) strExtendedInfo += "7.1";
+     else strExtendedInfo = StringUtils::Format("%s %d", strExtendedInfo.c_str(), iExtendedChannels);
+  
+     strInfo += strExtendedInfo;
+  }
 }
 
 void CDemuxStreamAudioFFmpeg::GetStreamName(std::string& strInfo)
@@ -67,6 +77,15 @@ void CDemuxStreamAudioFFmpeg::GetStreamName(std::string& strInfo)
   else
     CDemuxStream::GetStreamName(strInfo);
 }
+
+  void CDemuxStreamAudioFFmpeg::GetExtendedStreamInfo()
+  {
+      //TESTING
+     bExtendedStreamInfo = true;
+     iExtendedChannels = 8;
+     //iExtendedSampleRate = 96000;
+     //iExtendedBitRate = 99999;
+  }
 
 void CDemuxStreamSubtitleFFmpeg::GetStreamName(std::string& strInfo)
 {
@@ -1083,7 +1102,13 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
 	
         if(m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0))
           st->m_description = m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0)->value;
-
+        
+        //TODO : if (profile == FF_PROFILE_DTS_HD_HRA)
+        if(pStream->codec->profile == FF_PROFILE_DTS_HD_MA)
+        {
+            st->GetExtendedStreamInfo();
+        }
+        
         break;
       }
     case AVMEDIA_TYPE_VIDEO:

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -61,11 +61,35 @@ void CDemuxStreamAudioFFmpeg::GetStreamInfo(std::string& strInfo)
   if(bExtendedStreamInfo)
   {
      std::string strExtendedInfo = " - Extended : ";
-     //TODO add lfe ...
-     if (iExtendedChannels == 6) strExtendedInfo += " 5.1";
+     
+     if(iExtendedChannels == 3)
+     {
+       if(lfe_channel == PRESENT)
+         strExtendedInfo += " 2.1";
+       else
+         strExtendedInfo += " 3.0";
+     }
+     else if (iExtendedChannels == 6) strExtendedInfo += " 5.1";
      else if (iExtendedChannels == 8) strExtendedInfo += "7.1";
      else strExtendedInfo = StringUtils::Format("%s %d", strExtendedInfo.c_str(), iExtendedChannels);
   
+     if(iExtendedSampleRate != 0)
+     {
+       std::string sFormat;
+       if(iExtendedSampleRate % 100)
+         sFormat = " / %3.2f Khz";
+       else if(iExtendedSampleRate % 10)
+         sFormat = " / %3.1f Khz";
+       else
+         sFormat = " / %g Khz";
+                 
+       strExtendedInfo += StringUtils::Format(sFormat.c_str(), (float)(iExtendedSampleRate / 1000));
+     }
+       
+     
+     if(iExtendedResolution != 0)
+      strExtendedInfo += StringUtils::Format(" / %d Bits", iExtendedResolution);
+     
      strInfo += strExtendedInfo;
   }
 }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -85,8 +85,7 @@ void CDemuxStreamAudioFFmpeg::GetStreamInfo(std::string& strInfo)
                  
        strExtendedInfo += StringUtils::Format(sFormat.c_str(), (float)(iExtendedSampleRate / 1000));
      }
-       
-     
+
      if(iExtendedResolution != 0)
       strExtendedInfo += StringUtils::Format(" / %d Bits", iExtendedResolution);
      

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -61,6 +61,7 @@ public:
 
   virtual void GetStreamInfo(std::string& strInfo);
   virtual void GetStreamName(std::string& strInfo);
+  virtual void GetExtendedStreamInfo();
 };
 
 class CDemuxStreamSubtitleFFmpeg

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -61,7 +61,7 @@ public:
 
   virtual void GetStreamInfo(std::string& strInfo);
   virtual void GetStreamName(std::string& strInfo);
-  virtual void GetExtendedStreamInfo();
+  virtual void GetExtendedStreamInfo(pFrame pframe = NULL);
 };
 
 class CDemuxStreamSubtitleFFmpeg

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -61,7 +61,6 @@ public:
 
   virtual void GetStreamInfo(std::string& strInfo);
   virtual void GetStreamName(std::string& strInfo);
-  virtual void GetExtendedStreamInfo(pFrame pframe = NULL);
 };
 
 class CDemuxStreamSubtitleFFmpeg

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -421,7 +421,11 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
     else if (stream->type == STREAM_AUDIO)
     {
       CStreamDetailAudio *p = new CStreamDetailAudio();
-      p->m_iChannels = ((CDemuxStreamAudio *)stream)->iChannels;
+      if(((CDemuxStreamAudio *)stream)->bExtendedStreamInfo)
+        p->m_iChannels = ((CDemuxStreamAudio *)stream)->iExtendedChannels;
+      else
+        p->m_iChannels = ((CDemuxStreamAudio *)stream)->iChannels;
+      
       p->m_strLanguage = stream->language;
       pDemux->GetStreamCodecName(iStream, p->m_strCodec);
       details.AddStream(p);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3981,7 +3981,8 @@ void CDVDPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
     CDemuxStreamAudio* stream = static_cast<CDemuxStreamAudio*>(m_pDemuxer->GetStreamFromAudioId(index));
     if (stream)
     {
-      if(stream->bExtendedStreamInfo && stream->iExtendedChannels != 0)
+      //For videoplayer.audiochannels
+      if(stream->bExtendedStreamInfo)
         info.channels = stream->iExtendedChannels;
       else
         info.channels = stream->iChannels;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -477,7 +477,10 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
             s.name += " - ";
           s.name += type;
         }
-        s.channels = ((CDemuxStreamAudio*)stream)->iChannels;
+        if(((CDemuxStreamAudio*)stream)->bExtendedStreamInfo)
+          s.channels = ((CDemuxStreamAudio*)stream)->iExtendedChannels;
+        else
+          s.channels = ((CDemuxStreamAudio*)stream)->iChannels;
       }
       Update(s);
     }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3981,7 +3981,11 @@ void CDVDPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
     CDemuxStreamAudio* stream = static_cast<CDemuxStreamAudio*>(m_pDemuxer->GetStreamFromAudioId(index));
     if (stream)
     {
-      info.channels = stream->iChannels;
+      if(stream->bExtendedStreamInfo && stream->iExtendedChannels != 0)
+        info.channels = stream->iExtendedChannels;
+      else
+        info.channels = stream->iChannels;
+      
       CStdString codecName;
       m_pDemuxer->GetStreamCodecName(stream->iId, codecName);
       info.audioCodecName = codecName;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -169,6 +169,7 @@ void CDVDPlayerAudio::OpenStream( CDVDStreamInfo &hints, CDVDAudioCodec* codec )
   int samplerateFromCodec = m_pAudioCodec->GetEncodedSampleRate();
 
   if (channelsFromCodec > 0)
+    //REM: not necessary to assign dts-hd-ma extendedchannel here
     m_streaminfo.channels = channelsFromCodec;
   if (samplerateFromCodec > 0)
     m_streaminfo.samplerate = samplerateFromCodec;

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
@@ -198,6 +198,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
   if( right.type == STREAM_AUDIO )
   {
     const CDemuxStreamAudio *stream = static_cast<const CDemuxStreamAudio*>(&right);
+    //REM: not necessary to assign dts-hd-ma extendedchannel here
     channels      = stream->iChannels;
     samplerate    = stream->iSampleRate;
     blockalign    = stream->iBlockAlign;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -111,6 +111,7 @@ void CAdvancedSettings::Initialize()
   if (m_initialized)
     return;
 
+  m_searchextendedstreaminfo = true;
   m_audioHeadRoom = 0;
   m_ac3Gain = 12.0f;
   m_audioApplyDrc = true;
@@ -478,6 +479,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   TiXmlElement *pElement = pRootElement->FirstChildElement("audio");
   if (pElement)
   {
+    XMLUtils::GetBoolean(pElement, "searchextendedstreaminfo", m_searchextendedstreaminfo);
     XMLUtils::GetFloat(pElement, "ac3downmixgain", m_ac3Gain, -96.0f, 96.0f);
     XMLUtils::GetInt(pElement, "headroom", m_audioHeadRoom, 0, 12);
     XMLUtils::GetString(pElement, "defaultplayer", m_audioDefaultPlayer);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -133,6 +133,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     static void GetCustomRegexpReplacers(TiXmlElement *pRootElement, CStdStringArray& settings);
     static void GetCustomExtensions(TiXmlElement *pRootElement, CStdString& extensions);
 
+    bool m_searchextendedstreaminfo;
     int m_audioHeadRoom;
     float m_ac3Gain;
     CStdString m_audioDefaultPlayer;


### PR DESCRIPTION
As ffmpeg do not parse extended substreams for dts-hd ma; this patch add a dts-hd ma header parser and extract the channel number; resolution, sampling rate and lfe presence.
If found the extended channel number will be used instead of the core one for Lisitem.audiochannels and videoplayer.audiochannels.
The other information are displayed on the video info osd when pressin O/Title. and used in some other places around the code

After writing the parser and testing, i noticed that ffmpeg correctly parse dts-hd HR; basically it means that there already is a full dts-hd ma parser in ffmpeg (didn't look)...... Maybe a more elegant way would have been to patch ffmpeg to expose the parser as a function and use it like this.... At least, like this it was fun to code and it works :)
