### PR TITLE
Subs search fixes

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -140,10 +140,11 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
       OnMessage(msg);
 
       int item = msg.GetParam1();
-      if (item >= 0 && item < m_serviceItems->Size() &&
-          SetService(m_serviceItems->Get(item)->GetProperty("Addon.ID").asString()))
+      if (item >= 0 && item < m_serviceItems->Size())
+      {
+        SetService(m_serviceItems->Get(item)->GetProperty("Addon.ID").asString());
         Search();
-
+      }
       return true;
     }
     else if (iControl == CONTROL_MANUALSEARCH)

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -204,6 +204,12 @@ void CGUIDialogSubtitles::Process(unsigned int currentTime, CDirtyRegionList &di
     {
       CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_SUBLIST, 0, 0, &subs);
       OnMessage(message);
+      if (!subs.IsEmpty())
+      {
+        // focus subtitles list
+        CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), CONTROL_SUBLIST);
+        OnMessage(msg);
+      }
       m_updateSubsList = false;
     }
     


### PR DESCRIPTION
this fixes some minor cosmetics and bugs in subs search. 
- focus the list of subs after we populate it
- allow searching on same service, previously you could only search on service once. not usefull if you only have one service instaled and it fails for some reason, you cant retry

@jmarshallnz , @t-nelson please check ... Gotham material if you ask me
