### PR TITLE
paplayer: proper handling of non seekable streams

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -91,7 +91,7 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
   if (m_pFile->GetImplemenation() && (content.empty() || content == "application/octet-stream"))
     m_content = m_pFile->GetImplemenation()->GetContent();
 
-  m_eof = true;
+  m_eof = false;
   return true;
 }
 

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -193,8 +193,19 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
     return false;
   }
 
-  // rewind stream to beginning
-  Seek(0);
+  // test if seeking is supported
+  if (Seek(1) != DVD_NOPTS_VALUE)
+  {
+    // rewind stream to beginning
+    Seek(0);
+    m_bCanSeek = true;
+  }
+  else
+  {
+    m_pInputStream->Seek(0, SEEK_SET);
+    m_pDemuxer->Reset();
+    m_bCanSeek = false;
+  }
 
   if (m_Channels == 0) // no data - just guess and hope for the best
     m_Channels = 2;
@@ -263,11 +274,14 @@ int64_t DVDPlayerCodec::Seek(int64_t iSeekTime)
     CDVDDemuxUtils::FreeDemuxPacket(m_pPacket);
   m_pPacket = NULL;
 
-  m_pDemuxer->SeekTime((int)iSeekTime, false);
+  bool ret = m_pDemuxer->SeekTime((int)iSeekTime, false);
   m_pAudioCodec->Reset();
 
   m_decoded = NULL;
   m_nDecodedLen = 0;
+
+  if (!ret)
+    return DVD_NOPTS_VALUE;
 
   return iSeekTime;
 }
@@ -350,5 +364,5 @@ bool DVDPlayerCodec::CanInit()
 
 bool DVDPlayerCodec::CanSeek()
 {
-  return true;
+  return m_bCanSeek;
 }

--- a/xbmc/cores/paplayer/DVDPlayerCodec.h
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.h
@@ -63,6 +63,7 @@ private:
   CAEChannelInfo m_ChannelInfo;
 
   bool m_bInited;
+  bool m_bCanSeek;
 };
 
 #endif


### PR DESCRIPTION
some formats like WMA lossless are not seekable. player/gui need be to informed

1dca25f fixes incorrect state of eof. imo it makes no sense setting the stream eof right after open. ffmpeg demuxer is able able to detect a seek error in this case.
