### PR TITLE
jsonrpc: expose specialsortseason and specialsortepisode for episodes

### DIFF
--- a/addons/xbmc.json/addon.xml
+++ b/addons/xbmc.json/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.json" version="6.14.3" provider-name="Team XBMC">
+<addon id="xbmc.json" version="6.15.0" provider-name="Team XBMC">
   <backwards-compatibility abi="6.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -22,7 +22,7 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://xbmc.org/jsonrpc/ServiceDescription.json";
-  const char* const JSONRPC_SERVICE_VERSION     = "6.14.3";
+  const char* const JSONRPC_SERVICE_VERSION     = "6.15.0";
   const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
@@ -567,7 +567,7 @@ namespace JSONRPC
                   "\"productioncode\", \"season\", \"episode\", \"originaltitle\","
                   "\"showtitle\", \"cast\", \"streamdetails\", \"lastplayed\", \"fanart\","
                   "\"thumbnail\", \"file\", \"resume\", \"tvshowid\", \"dateadded\","
-                  "\"uniqueid\", \"art\" ]"
+                  "\"uniqueid\", \"art\", \"specialsortseason\", \"specialsortepisode\" ]"
       "}"
     "}",
     "\"Video.Fields.MusicVideo\": {"
@@ -756,7 +756,9 @@ namespace JSONRPC
         "\"originaltitle\": { \"type\": \"string\" },"
         "\"showtitle\": { \"type\": \"string\" },"
         "\"cast\": { \"$ref\": \"Video.Cast\" },"
-        "\"tvshowid\": { \"$ref\": \"Library.Id\" }"
+        "\"tvshowid\": { \"$ref\": \"Library.Id\" },"
+        "\"specialsortseason\": { \"type\": \"integer\" },"
+        "\"specialsortepisode\": { \"type\": \"integer\" }"
       "}"
     "}",
     "\"Video.Details.MusicVideo\": {"
@@ -1251,7 +1253,9 @@ namespace JSONRPC
         "\"theme\": { \"$ref\": \"Array.String\" },"
         "\"mood\": { \"$ref\": \"Array.String\" },"
         "\"style\": { \"$ref\": \"Array.String\" },"
-        "\"albumlabel\": { \"type\": \"string\" }"
+        "\"albumlabel\": { \"type\": \"string\" },"
+        "\"specialsortseason\": { \"type\": \"integer\" },"
+        "\"specialsortepisode\": { \"type\": \"integer\" }"
       "}"
     "}",
     "\"List.Fields.All\": {"
@@ -1269,7 +1273,8 @@ namespace JSONRPC
                   "\"disc\", \"tag\", \"art\", \"genreid\", \"displayartist\", \"albumartistid\","
                   "\"description\", \"theme\", \"mood\", \"style\", \"albumlabel\", \"sorttitle\","
                   "\"episodeguide\", \"uniqueid\", \"dateadded\", \"channel\", \"channeltype\", \"hidden\","
-                  "\"locked\", \"channelnumber\", \"starttime\", \"endtime\" ]"
+                  "\"locked\", \"channelnumber\", \"starttime\", \"endtime\", \"specialsortseason\","
+                  "\"specialsortepisode\" ]"
       "}"
     "}",
     "\"List.Item.All\": {"
@@ -1298,7 +1303,8 @@ namespace JSONRPC
                   "\"resume\", \"artistid\", \"albumid\", \"tvshowid\", \"setid\", \"watchedepisodes\","
                   "\"disc\", \"tag\", \"art\", \"genreid\", \"displayartist\", \"albumartistid\","
                   "\"description\", \"theme\", \"mood\", \"style\", \"albumlabel\", \"sorttitle\","
-                  "\"episodeguide\", \"uniqueid\", \"dateadded\", \"size\", \"lastmodified\", \"mimetype\" ]"
+                  "\"episodeguide\", \"uniqueid\", \"dateadded\", \"size\", \"lastmodified\", \"mimetype\","
+                  "\"specialsortseason\", \"specialsortepisode\" ]"
       "}"
     "}",
     "\"List.Item.File\": {"

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -540,7 +540,7 @@
                 "productioncode", "season", "episode", "originaltitle",
                 "showtitle", "cast", "streamdetails", "lastplayed", "fanart",
                 "thumbnail", "file", "resume", "tvshowid", "dateadded",
-                "uniqueid", "art" ]
+                "uniqueid", "art", "specialsortseason", "specialsortepisode" ]
     }
   },
   "Video.Fields.MusicVideo": {
@@ -729,7 +729,9 @@
       "originaltitle": { "type": "string" },
       "showtitle": { "type": "string" },
       "cast": { "$ref": "Video.Cast" },
-      "tvshowid": { "$ref": "Library.Id" }
+      "tvshowid": { "$ref": "Library.Id" },
+      "specialsortseason": { "type": "integer" },
+      "specialsortepisode": { "type": "integer" }
     }
   },
   "Video.Details.MusicVideo": {
@@ -1224,7 +1226,9 @@
       "theme": { "$ref": "Array.String" },
       "mood": { "$ref": "Array.String" },
       "style": { "$ref": "Array.String" },
-      "albumlabel": { "type": "string" }
+      "albumlabel": { "type": "string" },
+      "specialsortseason": { "type": "integer" },
+      "specialsortepisode": { "type": "integer" }
     }
   },
   "List.Fields.All": {
@@ -1242,7 +1246,8 @@
                 "disc", "tag", "art", "genreid", "displayartist", "albumartistid",
                 "description", "theme", "mood", "style", "albumlabel", "sorttitle",
                 "episodeguide", "uniqueid", "dateadded", "channel", "channeltype", "hidden",
-                "locked", "channelnumber", "starttime", "endtime" ]
+                "locked", "channelnumber", "starttime", "endtime", "specialsortseason",
+                "specialsortepisode" ]
     }
   },
   "List.Item.All": {
@@ -1271,7 +1276,8 @@
                 "resume", "artistid", "albumid", "tvshowid", "setid", "watchedepisodes",
                 "disc", "tag", "art", "genreid", "displayartist", "albumartistid",
                 "description", "theme", "mood", "style", "albumlabel", "sorttitle",
-                "episodeguide", "uniqueid", "dateadded", "size", "lastmodified", "mimetype" ]
+                "episodeguide", "uniqueid", "dateadded", "size", "lastmodified", "mimetype",
+                "specialsortseason", "specialsortepisode" ]
     }
   },
   "List.Item.File": {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -477,6 +477,8 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["dateadded"] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::EmptyString;
   value["type"] = m_type;
   value["seasonid"] = m_iIdSeason;
+  value["specialsortseason"] = m_iSpecialSortSeason;
+  value["specialsortepisode"] = m_iSpecialSortEpisode;
 }
 
 void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const


### PR DESCRIPTION
This commit exposes the "specialsortseason" and "specialsortepisode" properties for episodes. This has been requested a few times in the last weeks and was simply overlooked in the past.
