### PR TITLE
upnp: some fixes

### DIFF
--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -173,6 +173,7 @@ public:
   bool SetFromDBDate(const CStdString &date);
   bool SetFromDBTime(const CStdString &time);
   bool SetFromW3CDate(const CStdString &date);
+  bool SetFromW3CDateTime(const CStdString &date, bool ignoreTimezone = false);
   bool SetFromUTCDateTime(const CDateTime &dateTime);
   bool SetFromUTCDateTime(const time_t &dateTime);
   bool SetFromRFC1123DateTime(const CStdString &dateTime);
@@ -196,6 +197,8 @@ public:
   CStdString GetAsLocalizedTime(const CStdString &format, bool withSeconds=true) const;
   CStdString GetAsLocalizedDateTime(bool longDate=false, bool withSeconds=true) const;
   CStdString GetAsRFC1123DateTime() const;
+  CStdString GetAsW3CDate() const;
+  CStdString GetAsW3CDateTime(bool asUtc = false) const;
 
   void SetValid(bool yesNo);
   bool IsValid() const;

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -244,7 +244,7 @@ PopulateObjectFromTag(CMusicInfoTag&         tag,
     if (object.m_ReferenceID == object.m_ObjectID)
         object.m_ReferenceID = "";
 
-    object.m_MiscInfo.last_time = tag.GetLastPlayed().GetAsDBDate();
+    object.m_MiscInfo.last_time = tag.GetLastPlayed().GetAsW3CDateTime();
     object.m_MiscInfo.play_count = tag.GetPlayCount();
 
     if (resource) resource->m_Duration = tag.GetDuration();
@@ -277,7 +277,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
         } else if (tag.m_type == "movie") {
           object.m_ObjectClass.type = "object.item.videoItem.movie";
           object.m_Title = tag.m_strTitle;
-          object.m_Date = NPT_String::FromInteger(tag.m_iYear) + "-01-01";
+          object.m_Date = CDateTime(tag.m_iYear, 0, 0, 0, 0, 0).GetAsW3CDate();
           object.m_ReferenceID = NPT_String::Format("videodb://movies/titles/%i", tag.m_iDbId);
         } else {
           object.m_ObjectClass.type = "object.item.videoItem.videoBroadcast";
@@ -288,7 +288,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
           int season = tag.m_iSeason > 1 ? tag.m_iSeason : 1;
           object.m_Recorded.episode_number = season * 100 + tag.m_iEpisode;
           object.m_Title = object.m_Recorded.series_title + " - " + object.m_Recorded.program_title;
-          object.m_Date = tag.m_firstAired.GetAsDBDate();
+          object.m_Date = tag.m_firstAired.GetAsW3CDate();
           if(tag.m_iSeason != -1)
               object.m_ReferenceID = NPT_String::Format("videodb://tvshows/0/%i", tag.m_iDbId);
         }
@@ -317,7 +317,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     object.m_Description.long_description = tag.m_strPlot;
     object.m_Description.rating = tag.m_strMPAARating;
     object.m_MiscInfo.last_position = (NPT_UInt32)tag.m_resumePoint.timeInSeconds;
-    object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsDBDate();
+    object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsW3CDateTime();
     object.m_MiscInfo.play_count = tag.m_playCount;
     if (resource) {
         resource->m_Duration = tag.GetDuration();
@@ -638,7 +638,7 @@ PopulateTagFromObject(CMusicInfoTag&          tag,
 
     tag.SetAlbum((const char*)object.m_Affiliation.album);
     CDateTime last;
-    last.SetFromDateString((const char*)object.m_MiscInfo.last_time);
+    last.SetFromW3CDateTime((const char*)object.m_MiscInfo.last_time);
     tag.SetLastPlayed(last);
     tag.SetPlayCount(object.m_MiscInfo.play_count);
     if(resource)
@@ -706,7 +706,7 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     tag.m_strPlot     = object.m_Description.long_description;
     tag.m_strMPAARating = object.m_Description.rating;
     tag.m_strShowTitle = object.m_Recorded.series_title;
-    tag.m_lastPlayed.SetFromDateString((const char*)object.m_MiscInfo.last_time);
+    tag.m_lastPlayed.SetFromW3CDateTime((const char*)object.m_MiscInfo.last_time);
     tag.m_playCount = object.m_MiscInfo.play_count;
 
     if(resource)

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -627,8 +627,14 @@ PopulateTagFromObject(CMusicInfoTag&          tag,
     }
     tag.SetTrackNumber(object.m_MiscInfo.original_track_number);
 
-    for (NPT_List<NPT_String>::Iterator it = object.m_Affiliation.genres.GetFirstItem(); it; it++)
+    for (NPT_List<NPT_String>::Iterator it = object.m_Affiliation.genres.GetFirstItem(); it; it++) {
+        // ignore single "Unknown" genre inserted by Platinum
+        if (it == object.m_Affiliation.genres.GetFirstItem() && object.m_Affiliation.genres.GetItemCount() == 1 &&
+            *it == "Unknown")
+            break;
+
         tag.SetGenre((const char*) *it);
+    }
 
     tag.SetAlbum((const char*)object.m_Affiliation.album);
     CDateTime last;
@@ -684,7 +690,14 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     }
     tag.m_iYear       = date.GetYear();
     for (unsigned int index = 0; index < object.m_Affiliation.genres.GetItemCount(); index++)
+    {
+      // ignore single "Unknown" genre inserted by Platinum
+      if (index == 0 && object.m_Affiliation.genres.GetItemCount() == 1 &&
+          *object.m_Affiliation.genres.GetItem(index) == "Unknown")
+          break;
+
       tag.m_genre.push_back(object.m_Affiliation.genres.GetItem(index)->GetChars());
+    }
     for (unsigned int index = 0; index < object.m_People.directors.GetItemCount(); index++)
       tag.m_director.push_back(object.m_People.directors.GetItem(index)->name.GetChars());
     for (unsigned int index = 0; index < object.m_People.authors.GetItemCount(); index++)

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -1233,7 +1233,7 @@ CUPnPServer::SortItems(CFileItemList& items, const char* sort_criteria)
     else if (method.Equals("upnp:originalTrackNumber"))
       sorting.sortBy = SortByTrackNumber;
     else if(method.Equals("upnp:rating"))
-      sorting.sortBy = SortByRating;
+      sorting.sortBy = SortByMPAA;
     else {
       CLog::Log(LOGINFO, "UPnP: unsupported sort criteria '%s' passed", method.c_str());
       continue; // needed so unidentified sort methods don't re-sort by label


### PR DESCRIPTION
These are some fixes from my media import work which IMO are worth submitting already.
- The first commit fixes sorting by upnp:rating. In the upnp specification "upnp:rating" means a "parental rating" and not a "star rating" so mapping it to SortByRating is false and it should be SortByMPAA.
- Platinum adds an "Unknown" genre if there's no genre available so we should remove that again when we parse genres as a client.
- all the date/datetime values we are currently providing/parsing are pretty wrong. The upnp specification uses the W3C datetime format. Unfortunately our W3C datetime serialization/deserialization is incomplete so I added the necessary code to make it complete. Then I made sure that all date/datetime values are serialized/deserialized in/to W3C format.
