### PR TITLE
FIX: [droid] crash when stat'ing /mnt/secure/asec on some devices (fixes #15148)

### DIFF
--- a/xbmc/storage/android/AndroidStorageProvider.cpp
+++ b/xbmc/storage/android/AndroidStorageProvider.cpp
@@ -172,7 +172,8 @@ void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 
         // Ignore sdcards
         if (!StringUtils::StartsWith(device, "/dev/block/vold/") ||
-            mountStr.find("sdcard") != std::string::npos)
+            mountStr.find("sdcard") != std::string::npos ||
+            mountStr.find("secure/asec") != std::string::npos)
           accepted = false;
 
         if(accepted)


### PR DESCRIPTION
/cc @davilla @jmarshallnz 
