### PR TITLE
CGUISliderControl: some cleanup and fixes

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -873,11 +873,11 @@ void CGUIDialogAddonSettings::CreateControls()
         int iType=0;
 
         if (option.size() == 0 || StringUtils::EqualsNoCase(option, "float"))
-          iType = SPIN_CONTROL_TYPE_FLOAT;
+          iType = SLIDER_CONTROL_TYPE_FLOAT;
         else if (StringUtils::EqualsNoCase(option, "int"))
-          iType = SPIN_CONTROL_TYPE_INT;
+          iType = SLIDER_CONTROL_TYPE_INT;
         else if (StringUtils::EqualsNoCase(option, "percent"))
-          iType = 0;
+          iType = SLIDER_CONTROL_TYPE_PERCENTAGE;
 
         ((CGUISettingsSliderControl *)pControl)->SetType(iType);
         ((CGUISettingsSliderControl *)pControl)->SetFloatRange(fMin, fMax);

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -81,7 +81,7 @@ void CGUIDialogSlider::SetSlider(const CStdString &label, float value, float min
   m_callbackData = callbackData;
   if (slider)
   {
-    slider->SetType(SPIN_CONTROL_TYPE_FLOAT);
+    slider->SetType(SLIDER_CONTROL_TYPE_FLOAT);
     slider->SetFloatRange(min, max);
     slider->SetFloatInterval(delta);
     slider->SetFloatValue(value);

--- a/xbmc/dialogs/GUIDialogSlider.h
+++ b/xbmc/dialogs/GUIDialogSlider.h
@@ -21,28 +21,7 @@
  */
 
 #include "guilib/GUIDialog.h"
-
-class CGUISliderControl;
-
-/*! \brief Interface class for callback from the slider dialog
- Used to pass feedback from the slider dialog to a caller.  Users of the
- slider dialog should derive from this class if they wish to respond to changes
- in the slider by the user as they happen.  OnSliderChange is called in response
- to the user moving the slider.  The caller may then update the text on the slider
- and update anything that should be changed as the slider is adjusted.
- \sa CGUIDialogSlider
- */
-class ISliderCallback
-{
-public:
-  virtual ~ISliderCallback() {}
-  
-  /*! \brief Callback function called whenever the user moves the slider
-   \param data pointer of callbackData passed into CGUIDialogSlider::ShowAndGetInput()
-   \param slider pointer to the slider control on the dialog 
-   */
-  virtual void OnSliderChange(void *data, CGUISliderControl *slider)=0;
-};
+#include "guilib/ISliderCallback.h"
 
 class CGUIDialogSlider : public CGUIDialog
 {

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1265,7 +1265,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   {
     control = new CGUISliderControl(
       parentID, id, posX, posY, width, height,
-      textureBar, textureNib, textureNibFocus, SPIN_CONTROL_TYPE_TEXT);
+      textureBar, textureNib, textureNibFocus, SLIDER_CONTROL_TYPE_PERCENTAGE);
 
     ((CGUISliderControl *)control)->SetInfo(singleInfo);
     ((CGUISliderControl *)control)->SetAction(action);
@@ -1274,7 +1274,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   {
     control = new CGUISettingsSliderControl(
       parentID, id, posX, posY, width, height, sliderWidth, sliderHeight, textureFocus, textureNoFocus,
-      textureBar, textureNib, textureNibFocus, labelInfo, SPIN_CONTROL_TYPE_TEXT);
+      textureBar, textureNib, textureNibFocus, labelInfo, SLIDER_CONTROL_TYPE_PERCENTAGE);
 
     ((CGUISettingsSliderControl *)control)->SetText(strLabel);
     ((CGUISettingsSliderControl *)control)->SetInfo(singleInfo);

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -31,10 +31,6 @@
 #include "GUISliderControl.h"
 #include "GUIButtonControl.h"
 
-#define SPIN_CONTROL_TYPE_INT    1
-#define SPIN_CONTROL_TYPE_FLOAT  2
-#define SPIN_CONTROL_TYPE_TEXT   3
-
 /*!
  \ingroup controls
  \brief

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -319,7 +319,7 @@ float CGUISliderControl::GetPercentage(RangeSelector selector /* = RangeSelector
 void CGUISliderControl::SetIntValue(int iValue, RangeSelector selector /* = RangeSelectorLower */, bool updateCurrent /* = false */)
 {
   if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
-    SetFloatValue((float)iValue);
+    SetFloatValue((float)iValue, selector, updateCurrent);
   else if (m_iType == SLIDER_CONTROL_TYPE_INT)
   {
     if (iValue > m_iEnd) iValue = m_iEnd;
@@ -344,7 +344,7 @@ void CGUISliderControl::SetIntValue(int iValue, RangeSelector selector /* = Rang
     }
   }
   else
-    SetPercentage((float)iValue);
+    SetPercentage((float)iValue, selector, updateCurrent);
 }
 
 int CGUISliderControl::GetIntValue(RangeSelector selector /* = RangeSelectorLower */) const
@@ -383,9 +383,9 @@ void CGUISliderControl::SetFloatValue(float fValue, RangeSelector selector /* = 
     }
   }
   else if (m_iType == SLIDER_CONTROL_TYPE_INT)
-    SetIntValue((int)fValue);
+    SetIntValue((int)fValue, selector, updateCurrent);
   else
-    SetPercentage(fValue);
+    SetPercentage(fValue, selector, updateCurrent);
 }
 
 float CGUISliderControl::GetFloatValue(RangeSelector selector /* = RangeSelectorLower */) const

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -191,7 +191,7 @@ void CGUISliderControl::Move(int iNumSteps)
   bool rangeSwap = false;
   switch (m_iType)
   {
-  case SPIN_CONTROL_TYPE_FLOAT:
+  case SLIDER_CONTROL_TYPE_FLOAT:
     {
       float &value = m_floatValues[m_currentSelector];
       value += m_fInterval * iNumSteps;
@@ -207,7 +207,7 @@ void CGUISliderControl::Move(int iNumSteps)
       break;
     }
 
-  case SPIN_CONTROL_TYPE_INT:
+  case SLIDER_CONTROL_TYPE_INT:
     {
       int &value = m_intValues[m_currentSelector];
       value += m_iInterval * iNumSteps;
@@ -223,6 +223,7 @@ void CGUISliderControl::Move(int iNumSteps)
       break;
     }
 
+  case SLIDER_CONTROL_TYPE_PERCENTAGE:
   default:
     {
       float &value = m_percentValues[m_currentSelector];
@@ -317,9 +318,9 @@ float CGUISliderControl::GetPercentage(RangeSelector selector /* = RangeSelector
 
 void CGUISliderControl::SetIntValue(int iValue, RangeSelector selector /* = RangeSelectorLower */, bool updateCurrent /* = false */)
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
     SetFloatValue((float)iValue);
-  else if (m_iType == SPIN_CONTROL_TYPE_INT)
+  else if (m_iType == SLIDER_CONTROL_TYPE_INT)
   {
     if (iValue > m_iEnd) iValue = m_iEnd;
     else if (iValue < m_iStart) iValue = m_iStart;
@@ -348,9 +349,9 @@ void CGUISliderControl::SetIntValue(int iValue, RangeSelector selector /* = Rang
 
 int CGUISliderControl::GetIntValue(RangeSelector selector /* = RangeSelectorLower */) const
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
     return (int)m_floatValues[selector];
-  else if (m_iType == SPIN_CONTROL_TYPE_INT)
+  else if (m_iType == SLIDER_CONTROL_TYPE_INT)
     return m_intValues[selector];
   else
     return MathUtils::round_int(m_percentValues[selector]);
@@ -358,7 +359,7 @@ int CGUISliderControl::GetIntValue(RangeSelector selector /* = RangeSelectorLowe
 
 void CGUISliderControl::SetFloatValue(float fValue, RangeSelector selector /* = RangeSelectorLower */, bool updateCurrent /* = false */)
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
   {
     if (fValue > m_fEnd) fValue = m_fEnd;
     else if (fValue < m_fStart) fValue = m_fStart;
@@ -381,7 +382,7 @@ void CGUISliderControl::SetFloatValue(float fValue, RangeSelector selector /* = 
         m_currentSelector = (selector == RangeSelectorLower ? RangeSelectorUpper : RangeSelectorLower);
     }
   }
-  else if (m_iType == SPIN_CONTROL_TYPE_INT)
+  else if (m_iType == SLIDER_CONTROL_TYPE_INT)
     SetIntValue((int)fValue);
   else
     SetPercentage(fValue);
@@ -389,9 +390,9 @@ void CGUISliderControl::SetFloatValue(float fValue, RangeSelector selector /* = 
 
 float CGUISliderControl::GetFloatValue(RangeSelector selector /* = RangeSelectorLower */) const
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
     return m_floatValues[selector];
-  else if (m_iType == SPIN_CONTROL_TYPE_INT)
+  else if (m_iType == SLIDER_CONTROL_TYPE_INT)
     return (float)m_intValues[selector];
   else
     return m_percentValues[selector];
@@ -399,7 +400,7 @@ float CGUISliderControl::GetFloatValue(RangeSelector selector /* = RangeSelector
 
 void CGUISliderControl::SetIntInterval(int iInterval)
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
     m_fInterval = (float)iInterval;
   else
     m_iInterval = iInterval;
@@ -407,7 +408,7 @@ void CGUISliderControl::SetIntInterval(int iInterval)
 
 void CGUISliderControl::SetFloatInterval(float fInterval)
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
     m_fInterval = fInterval;
   else
     m_iInterval = (int)fInterval;
@@ -415,7 +416,7 @@ void CGUISliderControl::SetFloatInterval(float fInterval)
 
 void CGUISliderControl::SetRange(int iStart, int iEnd)
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
     SetFloatRange((float)iStart,(float)iEnd);
   else
   {
@@ -426,7 +427,7 @@ void CGUISliderControl::SetRange(int iStart, int iEnd)
 
 void CGUISliderControl::SetFloatRange(float fStart, float fEnd)
 {
-  if (m_iType == SPIN_CONTROL_TYPE_INT)
+  if (m_iType == SLIDER_CONTROL_TYPE_INT)
     SetRange((int)fStart, (int)fEnd);
   else
   {
@@ -500,20 +501,21 @@ void CGUISliderControl::SetFromPosition(const CPoint &point, bool guessSelector 
 
   switch (m_iType)
   {
-  case SPIN_CONTROL_TYPE_FLOAT:
+  case SLIDER_CONTROL_TYPE_FLOAT:
     {
       float fValue = m_fStart + (m_fEnd - m_fStart) * fPercent;
       SetFloatValue(fValue, m_currentSelector, true);
       break;
     }
 
-  case SPIN_CONTROL_TYPE_INT:
+  case SLIDER_CONTROL_TYPE_INT:
     {
       int iValue = (int)(m_iStart + (float)(m_iEnd - m_iStart) * fPercent + 0.49f);
       SetIntValue(iValue, m_currentSelector, true);
       break;
     }
 
+  case SLIDER_CONTROL_TYPE_PERCENTAGE:
   default:
     {
       SetPercentage(fPercent * 100, m_currentSelector, true);
@@ -594,14 +596,14 @@ CStdString CGUISliderControl::GetDescription() const
   if (!m_textValue.empty())
     return m_textValue;
   CStdString description;
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
   {
     if (m_rangeSelection)
       description = StringUtils::Format("[%2.2f, %2.2f]", m_floatValues[0], m_floatValues[1]);
     else
       description = StringUtils::Format("%2.2f", m_floatValues[0]);
   }
-  else if (m_iType == SPIN_CONTROL_TYPE_INT)
+  else if (m_iType == SLIDER_CONTROL_TYPE_INT)
   {
     if (m_rangeSelection)
       description = StringUtils::Format("[%i, %i]", m_intValues[0], m_intValues[1]);
@@ -632,9 +634,9 @@ bool CGUISliderControl::UpdateColors()
 
 float CGUISliderControl::GetProportion(RangeSelector selector /* = RangeSelectorLower */) const
 {
-  if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
+  if (m_iType == SLIDER_CONTROL_TYPE_FLOAT)
     return (GetFloatValue(selector) - m_fStart) / (m_fEnd - m_fStart);
-  else if (m_iType == SPIN_CONTROL_TYPE_INT)
+  else if (m_iType == SLIDER_CONTROL_TYPE_INT)
     return (float)(GetIntValue(selector) - m_iStart) / (float)(m_iEnd - m_iStart);
   return 0.01f * GetPercentage(selector);
 }

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -31,9 +31,9 @@
 #include "GUIControl.h"
 #include "GUITexture.h"
 
-#define SPIN_CONTROL_TYPE_INT       1
-#define SPIN_CONTROL_TYPE_FLOAT     2
-#define SPIN_CONTROL_TYPE_TEXT      3
+#define SLIDER_CONTROL_TYPE_INT         1
+#define SLIDER_CONTROL_TYPE_FLOAT       2
+#define SLIDER_CONTROL_TYPE_PERCENTAGE  3
 
 typedef struct
 {

--- a/xbmc/guilib/ISliderCallback.h
+++ b/xbmc/guilib/ISliderCallback.h
@@ -1,0 +1,48 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class CGUISliderControl;
+
+/*!
+ \brief Interface class for callback from the slider dialog
+
+ Used to pass feedback from the slider dialog to a caller.  Users of the
+ slider dialog should derive from this class if they wish to respond to changes
+ in the slider by the user as they happen.  OnSliderChange is called in response
+ to the user moving the slider.  The caller may then update the text on the slider
+ and update anything that should be changed as the slider is adjusted.
+
+ \sa CGUIDialogSlider
+ */
+class ISliderCallback
+{
+public:
+  virtual ~ISliderCallback() {}
+  
+  /*!
+   \brief Callback function called whenever the user moves the slider
+
+   \param data pointer of callbackData
+   \param slider pointer to the slider control
+   */
+  virtual void OnSliderChange(void *data, CGUISliderControl *slider) = 0;
+};

--- a/xbmc/settings/dialogs/GUIDialogSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettings.cpp
@@ -429,7 +429,7 @@ void CGUIDialogSettings::AddSetting(SettingInfo &setting, float width, int iCont
     ((CGUISettingsSliderControl *)pControl)->SetText(setting.name);
     if (setting.formatFunction.standard)
       ((CGUISettingsSliderControl *)pControl)->SetTextValue(setting.formatFunction.standard(*(float *)setting.data, setting.interval));
-    ((CGUISettingsSliderControl *)pControl)->SetType(SPIN_CONTROL_TYPE_FLOAT);
+    ((CGUISettingsSliderControl *)pControl)->SetType(SLIDER_CONTROL_TYPE_FLOAT);
     ((CGUISettingsSliderControl *)pControl)->SetFloatRange(setting.min, setting.max);
     ((CGUISettingsSliderControl *)pControl)->SetFloatInterval(setting.interval);
     if (setting.data) ((CGUISettingsSliderControl *)pControl)->SetFloatValue(*(float *)setting.data);
@@ -454,7 +454,7 @@ void CGUIDialogSettings::AddSetting(SettingInfo &setting, float width, int iCont
     ((CGUISettingsSliderControl *)pControl)->SetText(setting.name);
     if (setting.formatFunction.range)
       ((CGUISettingsSliderControl *)pControl)->SetTextValue(setting.formatFunction.range(*((float **)setting.data)[0], *((float **)setting.data)[1], setting.interval));
-    ((CGUISettingsSliderControl *)pControl)->SetType(SPIN_CONTROL_TYPE_FLOAT);
+    ((CGUISettingsSliderControl *)pControl)->SetType(SLIDER_CONTROL_TYPE_FLOAT);
     ((CGUISettingsSliderControl *)pControl)->SetRangeSelection(true);
     ((CGUISettingsSliderControl *)pControl)->SetFloatRange(setting.min, setting.max);
     ((CGUISettingsSliderControl *)pControl)->SetFloatInterval(setting.interval);

--- a/xbmc/settings/dialogs/GUIDialogSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettings.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIDialogSettings.h"
+#include "dialogs/GUIDialogSlider.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIRadioButtonControl.h"

--- a/xbmc/settings/dialogs/GUIDialogSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogSettings.h
@@ -21,7 +21,7 @@
  */
 
 #include "guilib/GUIDialog.h"
-#include "dialogs/GUIDialogSlider.h"
+#include "guilib/ISliderCallback.h"
 
 class CGUISpinControlEx;
 class CGUIButtonControl;

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "PlayerController.h"
+#include "dialogs/GUIDialogSlider.h"
 #include "utils/StdString.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -20,7 +20,8 @@
  *
  */
 
-#include "dialogs/GUIDialogSlider.h"
+#include "guilib/ISliderCallback.h"
+#include "guilib/Key.h"
 
 /*! \brief Player controller class to handle user actions.
 


### PR DESCRIPTION
These are some cleanups and a fix concerning CGUISliderControl which I came across as part of #4512 which are isolated enough to go in separately.
- The first commit moves ISliderCallback into its own header file which is immer a better separation.
- The second commits cleans up the SPIN_CONTROL_TYPE_FOO mess which are defined in 3 different header files and are also "abused" for slider controls.
- The third commit fixes SetIntValue() and SetFloatValue()
