### PR TITLE
Add new apache date format for file listings in http sources

### DIFF
--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -62,6 +62,9 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
   CRegExp reDateTimeNginx(true);
   reDateTimeNginx.RegComp("</a> +([0-9]{2})-([A-Z]{3})-([0-9]{4}) ([0-9]{2}):([0-9]{2}) ");
 
+  CRegExp reDateTimeApacheNewFormat(true);
+  reDateTimeApacheNewFormat.RegComp("<td align=\"right\">([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}) +</td>");
+
   CRegExp reSize(true);
   reSize.RegComp("> *([0-9.]+)(B|K|M|G| )</td>");
 
@@ -138,6 +141,7 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
           pItem->m_bIsFolder = true;
 
         CStdString day, month, year, hour, minute;
+        int monthNum = 0;
 
         if (reDateTime.RegFind(strBuffer.c_str()) >= 0)
         {
@@ -163,10 +167,21 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
           hour = reDateTimeLighttp.GetMatch(4);
           minute = reDateTimeLighttp.GetMatch(5);
         }
-
-        if (day.length() > 0 && month.length() > 0 && year.length() > 0)
+        else if (reDateTimeApacheNewFormat.RegFind(strBuffer.c_str()) >= 0)
         {
-          pItem->m_dateTime = CDateTime(atoi(year.c_str()), CDateTime::MonthStringToMonthNum(month), atoi(day.c_str()), atoi(hour.c_str()), atoi(minute.c_str()), 0);
+          day = reDateTimeApacheNewFormat.GetMatch(3);
+          monthNum = atoi(reDateTimeApacheNewFormat.GetMatch(2).c_str());
+          year = reDateTimeApacheNewFormat.GetMatch(1);
+          hour = reDateTimeApacheNewFormat.GetMatch(4);
+          minute = reDateTimeApacheNewFormat.GetMatch(5);
+        }
+
+        if (month.length() > 0)
+          monthNum = CDateTime::MonthStringToMonthNum(month);
+
+        if (day.length() > 0 && monthNum > 0 && year.length() > 0)
+        {
+          pItem->m_dateTime = CDateTime(atoi(year.c_str()), monthNum, atoi(day.c_str()), atoi(hour.c_str()), atoi(minute.c_str()), 0);
         }
 
         if (!pItem->m_bIsFolder)


### PR DESCRIPTION
According to Apache source code ( http://svn.apache.org/repos/asf/httpd/httpd/trunk/modules/generators/mod_autoindex.c ), the date format changed long time ago from "10-jan-2014" to "2014-01-10" .

```
apr_strftime(time_str, &rv, sizeof(time_str),
                                 "%Y-%m-%d %H:%M  ",
                                 &ts);
```

Before the date format was: "%d-%b-%Y %H:%M  "

I didn't find the specific svn revision where this changed, but Apache 2.2 already had this date format for a long time.

This patch adds a new apache date file format so it's compatible with old and new versions of mod_autoindex. 
I added CDateTime::MonthNumToMonthString in order to not touch the rest of the code.
