### PR TITLE
Gui action cleanup

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -158,7 +158,10 @@ void CGUIDialogContextMenu::SetupButtons()
       else
       {
         pButton->SetPosition(pButtonTemplate->GetXPosition(), i*(pButtonTemplate->GetHeight() + SPACE_BETWEEN_BUTTONS));
-        pButton->SetNavigation(id - 1, id + 1, id, id);
+        pButton->SetNavigationAction(ACTION_MOVE_UP, id - 1 );
+        pButton->SetNavigationAction(ACTION_MOVE_DOWN, id + 1);
+        pButton->SetNavigationAction(ACTION_MOVE_LEFT, id);
+        pButton->SetNavigationAction(ACTION_MOVE_RIGHT, id);
         AddControl(pButton);
       }
 #endif
@@ -172,10 +175,10 @@ void CGUIDialogContextMenu::SetupButtons()
     // if we don't have grouplist update the navigation of the first and last buttons
     pControl = (CGUIControl *)GetControl(BUTTON_START);
     if (pControl)
-      pControl->SetNavigation(BUTTON_END, pControl->GetControlIdDown(), pControl->GetControlIdLeft(), pControl->GetControlIdRight());
+      pControl->SetNavigationAction(ACTION_MOVE_UP, BUTTON_END);
     pControl = (CGUIControl *)GetControl(BUTTON_END);
     if (pControl)
-      pControl->SetNavigation(pControl->GetControlIdUp(), BUTTON_START, pControl->GetControlIdLeft(), pControl->GetControlIdRight());
+      pControl->SetNavigationAction(ACTION_MOVE_DOWN, BUTTON_START);
   }
 #endif
 

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -957,6 +957,7 @@ void CGUIEPGGridContainer::ProgrammesScroll(int amount)
 
 void CGUIEPGGridContainer::OnUp()
 {
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_UP);
   if (m_channelCursor > 0)
   {
     SetChannel(m_channelCursor - 1);
@@ -966,7 +967,7 @@ void CGUIEPGGridContainer::OnUp()
     ScrollToChannelOffset(m_channelOffset - 1);
     SetChannel(0);
   }
-  else if (m_actionUp.GetNavigation() == GetID() || !m_actionUp.HasActionsMeetingCondition()) // wrap around
+  else if (action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition()) // wrap around
   {
     int offset = m_channels - m_channelsPerPage;
 
@@ -982,6 +983,7 @@ void CGUIEPGGridContainer::OnUp()
 
 void CGUIEPGGridContainer::OnDown()
 {
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_DOWN);
   if (m_channelOffset + m_channelCursor + 1 < m_channels)
   {
     if (m_channelCursor + 1 < m_channelsPerPage)
@@ -994,7 +996,7 @@ void CGUIEPGGridContainer::OnDown()
       SetChannel(m_channelsPerPage - 1);
     }
   }
-  else if (m_actionDown.GetNavigation() == GetID() || !m_actionDown.HasActionsMeetingCondition()) // wrap around
+  else if (action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition()) // wrap around
   {
     SetChannel(0);
     ScrollToChannelOffset(0);

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -466,7 +466,8 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
 
 void CGUIBaseContainer::OnUp()
 {
-  bool wrapAround = m_actionUp.GetNavigation() == GetID() || !m_actionUp.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_UP);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == VERTICAL && MoveUp(wrapAround))
     return;
   // with horizontal lists it doesn't make much sense to have multiselect labels
@@ -475,7 +476,8 @@ void CGUIBaseContainer::OnUp()
 
 void CGUIBaseContainer::OnDown()
 {
-  bool wrapAround = m_actionDown.GetNavigation() == GetID() || !m_actionDown.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_DOWN);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == VERTICAL && MoveDown(wrapAround))
     return;
   // with horizontal lists it doesn't make much sense to have multiselect labels
@@ -484,7 +486,8 @@ void CGUIBaseContainer::OnDown()
 
 void CGUIBaseContainer::OnLeft()
 {
-  bool wrapAround = m_actionLeft.GetNavigation() == GetID() || !m_actionLeft.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_LEFT);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == HORIZONTAL && MoveUp(wrapAround))
     return;
   else if (m_orientation == VERTICAL)
@@ -498,7 +501,8 @@ void CGUIBaseContainer::OnLeft()
 
 void CGUIBaseContainer::OnRight()
 {
-  bool wrapAround = m_actionRight.GetNavigation() == GetID() || !m_actionRight.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_RIGHT);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == HORIZONTAL && MoveDown(wrapAround))
     return;
   else if (m_orientation == VERTICAL)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -459,55 +459,35 @@ CRect CGUIControl::CalcRenderRegion() const
 
 void CGUIControl::SetNavigation(int up, int down, int left, int right, int back)
 {
-  m_actionUp.SetNavigation(up);
-  m_actionDown.SetNavigation(down);
-  m_actionLeft.SetNavigation(left);
-  m_actionRight.SetNavigation(right);
-  m_actionBack.SetNavigation(back);
+  m_actions[ACTION_MOVE_UP].SetNavigation(up);
+  m_actions[ACTION_MOVE_DOWN].SetNavigation(down);
+  m_actions[ACTION_MOVE_LEFT].SetNavigation(left);
+  m_actions[ACTION_MOVE_RIGHT].SetNavigation(right);
+  m_actions[ACTION_NAV_BACK].SetNavigation(back);
 }
 
 void CGUIControl::SetTabNavigation(int next, int prev)
 {
-  m_actionNext.SetNavigation(next);
-  m_actionPrev.SetNavigation(prev);
+  m_actions[ACTION_NEXT_CONTROL].SetNavigation(next);
+  m_actions[ACTION_PREV_CONTROL].SetNavigation(prev);
 }
 
 void CGUIControl::SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
                                        const CGUIAction &left, const CGUIAction &right,
                                        const CGUIAction &back, bool replace)
 {
-  if (!m_actionLeft.HasAnyActions()  || replace) m_actionLeft  = left;
-  if (!m_actionRight.HasAnyActions() || replace) m_actionRight = right;
-  if (!m_actionUp.HasAnyActions()    || replace) m_actionUp    = up;
-  if (!m_actionDown.HasAnyActions()  || replace) m_actionDown  = down;
-  if (!m_actionBack.HasAnyActions()  || replace) m_actionBack  = back;
+  SetNavigationAction(ACTION_MOVE_LEFT,   left, replace);
+  SetNavigationAction(ACTION_MOVE_RIGHT, right, replace);
+  SetNavigationAction(ACTION_MOVE_UP,       up, replace);
+  SetNavigationAction(ACTION_MOVE_DOWN,   down, replace);
+  SetNavigationAction(ACTION_NAV_BACK,    back, replace);
 }
 
-void CGUIControl::SetNavigationAction(int direction, const CGUIAction &action, bool replace /*= true*/)
+void CGUIControl::SetNavigationAction(int actionID, const CGUIAction &action, bool replace /*= true*/)
 {
-  switch (direction)
-  {
-  case ACTION_MOVE_UP:
-    if (!m_actionUp.HasAnyActions() || replace)
-      m_actionUp = action;
-    break;
-  case ACTION_MOVE_DOWN:
-    if (!m_actionDown.HasAnyActions() || replace)
-      m_actionDown = action;
-    break;
-  case ACTION_MOVE_LEFT:
-    if (!m_actionLeft.HasAnyActions() || replace)
-      m_actionLeft = action;
-    break;
-  case ACTION_MOVE_RIGHT:
-    if (!m_actionRight.HasAnyActions() || replace)
-      m_actionRight = action;
-    break;
-  case ACTION_NAV_BACK:
-    if (!m_actionBack.HasAnyActions() || replace)
-      m_actionBack = action;
-    break;
-  }
+  ActionMap::iterator i = m_actions.find(actionID);
+  if (i == m_actions.end() || !i->second.HasAnyActions() || replace)
+    m_actions[actionID] = action;
 }
 
 void CGUIControl::SetWidth(float width)
@@ -900,28 +880,12 @@ bool CGUIControl::IsAnimating(ANIMATION_TYPE animType)
   return false;
 }
 
-bool CGUIControl::GetNavigationAction(int direction, CGUIAction& action) const
+CGUIAction CGUIControl::GetNavigateAction(int actionID) const
 {
-  switch (direction)
-  {
-  case ACTION_MOVE_UP:
-    action = m_actionUp;
-    return true;
-  case ACTION_MOVE_DOWN:
-    action = m_actionDown;
-    return true;
-  case ACTION_MOVE_LEFT:
-    action = m_actionLeft;
-    return true;
-  case ACTION_MOVE_RIGHT:
-    action = m_actionRight;
-    return true;
-  case ACTION_NAV_BACK:
-    action = m_actionBack;
-    return true;
-  default:
-    return false;
-  }
+  ActionMap::const_iterator i = m_actions.find(actionID);
+  if (i != m_actions.end())
+    return i->second;
+  return CGUIAction();
 }
 
 bool CGUIControl::CanFocusFromPoint(const CPoint &point) const

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -457,21 +457,6 @@ CRect CGUIControl::CalcRenderRegion() const
   return CRect(tl.x, tl.y, br.x, br.y);
 }
 
-void CGUIControl::SetNavigation(int up, int down, int left, int right, int back)
-{
-  m_actions[ACTION_MOVE_UP].SetNavigation(up);
-  m_actions[ACTION_MOVE_DOWN].SetNavigation(down);
-  m_actions[ACTION_MOVE_LEFT].SetNavigation(left);
-  m_actions[ACTION_MOVE_RIGHT].SetNavigation(right);
-  m_actions[ACTION_NAV_BACK].SetNavigation(back);
-}
-
-void CGUIControl::SetTabNavigation(int next, int prev)
-{
-  m_actions[ACTION_NEXT_CONTROL].SetNavigation(next);
-  m_actions[ACTION_PREV_CONTROL].SetNavigation(prev);
-}
-
 void CGUIControl::SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
                                        const CGUIAction &left, const CGUIAction &right,
                                        const CGUIAction &back, bool replace)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -457,15 +457,9 @@ CRect CGUIControl::CalcRenderRegion() const
   return CRect(tl.x, tl.y, br.x, br.y);
 }
 
-void CGUIControl::SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
-                                       const CGUIAction &left, const CGUIAction &right,
-                                       const CGUIAction &back, bool replace)
+void CGUIControl::SetNavigationActions(const ActionMap &actions)
 {
-  SetNavigationAction(ACTION_MOVE_LEFT,   left, replace);
-  SetNavigationAction(ACTION_MOVE_RIGHT, right, replace);
-  SetNavigationAction(ACTION_MOVE_UP,       up, replace);
-  SetNavigationAction(ACTION_MOVE_DOWN,   down, replace);
-  SetNavigationAction(ACTION_NAV_BACK,    back, replace);
+  m_actions = actions;
 }
 
 void CGUIControl::SetNavigationAction(int actionID, const CGUIAction &action, bool replace /*= true*/)

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -179,20 +179,20 @@ public:
    */
   virtual CRect CalcRenderRegion() const;
 
+  /*! \brief Set actions to perform on navigation
+   \param actions ActionMap of actions
+   \sa SetNavigationAction
+   */
+  typedef std::map<int, CGUIAction> ActionMap;
+  void SetNavigationActions(const ActionMap &actions);
 
   /*! \brief Set actions to perform on navigation
    Navigations are set if replace is true or if there is no previously set action
-   \param up CGUIAction to execute on up
-   \param down CGUIAction to execute on down
-   \param left CGUIAction to execute on left
-   \param right CGUIAction to execute on right
-   \param back CGUIAction to execute on back
+   \param actionID id of the nagivation action
+   \param actions CGUIAction to set
    \param replace Actions are set only if replace is true or there is no previously set action.  Defaults to true
-   \sa SetNavigation
+   \sa SetNavigationActions
    */
-  virtual void SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
-                                    const CGUIAction &left, const CGUIAction &right,
-                                    const CGUIAction &back, bool replace = true);
   void SetNavigationAction(int actionID, const CGUIAction &action, bool replace = true);
 
   /*! \brief Get an action the control can be perform.
@@ -312,7 +312,6 @@ protected:
   bool SendWindowMessage(CGUIMessage &message) const;
 
   // navigation and actions
-  typedef std::map<int, CGUIAction> ActionMap;
   ActionMap m_actions;
 
   float m_posX;

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -179,8 +179,6 @@ public:
    */
   virtual CRect CalcRenderRegion() const;
 
-  virtual void SetNavigation(int up, int down, int left, int right, int back = 0);
-  virtual void SetTabNavigation(int next, int prev);
 
   /*! \brief Set actions to perform on navigation
    Navigations are set if replace is true or if there is no previously set action

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -195,13 +195,13 @@ public:
   virtual void SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
                                     const CGUIAction &left, const CGUIAction &right,
                                     const CGUIAction &back, bool replace = true);
-  void SetNavigationAction(int direction, const CGUIAction &action, bool replace = true);
-  int GetControlIdUp() const { return m_actionUp.GetNavigation(); };
-  int GetControlIdDown() const { return  m_actionDown.GetNavigation(); };
-  int GetControlIdLeft() const { return m_actionLeft.GetNavigation(); };
-  int GetControlIdRight() const { return m_actionRight.GetNavigation(); };
-  int GetControlIdBack() const { return m_actionBack.GetNavigation(); };
-  bool GetNavigationAction(int direction, CGUIAction& action) const;
+  void SetNavigationAction(int actionID, const CGUIAction &action, bool replace = true);
+
+  /*! \brief Get an action the control can be perform.
+   \param action the actionID to retrieve.
+   */
+  CGUIAction GetNavigateAction(int actionID) const;
+
   /*! \brief  Start navigating in given direction.
    */
   bool Navigate(int direction) const;
@@ -314,13 +314,8 @@ protected:
   bool SendWindowMessage(CGUIMessage &message) const;
 
   // navigation and actions
-  CGUIAction m_actionLeft;
-  CGUIAction m_actionRight;
-  CGUIAction m_actionUp;
-  CGUIAction m_actionDown;
-  CGUIAction m_actionBack;
-  CGUIAction m_actionNext;
-  CGUIAction m_actionPrev;
+  typedef std::map<int, CGUIAction> ActionMap;
+  ActionMap m_actions;
 
   float m_posX;
   float m_posY;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -55,6 +55,7 @@
 #include "GUIListLabel.h"
 #include "GUIListGroup.h"
 #include "GUIInfoManager.h"
+#include "Key.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
 #include "utils/XMLUtils.h"
@@ -677,7 +678,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   float width = 0, height = 0;
   float minHeight = 0, minWidth = 0;
 
-  CGUIAction leftActions, rightActions, upActions, downActions, backActions, nextActions, prevActions;
+  CGUIControl::ActionMap actions;
 
   int pageControl = 0;
   CGUIInfoColor colorDiffuse(0xFFFFFFFF);
@@ -822,13 +823,13 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   hitRect.SetRect(posX, posY, posX + width, posY + height);
   GetHitRect(pControlNode, hitRect);
 
-  GetActions(pControlNode, "onup",    upActions);
-  GetActions(pControlNode, "ondown",  downActions);
-  GetActions(pControlNode, "onleft",  leftActions);
-  GetActions(pControlNode, "onright", rightActions);
-  GetActions(pControlNode, "onnext",  nextActions);
-  GetActions(pControlNode, "onprev",  prevActions);
-  GetActions(pControlNode, "onback",  backActions);
+  GetActions(pControlNode, "onup",    actions[ACTION_MOVE_UP]);
+  GetActions(pControlNode, "ondown",  actions[ACTION_MOVE_DOWN]);
+  GetActions(pControlNode, "onleft",  actions[ACTION_MOVE_LEFT]);
+  GetActions(pControlNode, "onright", actions[ACTION_MOVE_RIGHT]);
+  GetActions(pControlNode, "onnext",  actions[ACTION_NEXT_CONTROL]);
+  GetActions(pControlNode, "onprev",  actions[ACTION_PREV_CONTROL]);
+  GetActions(pControlNode, "onback",  actions[ACTION_NAV_BACK]);
 
   if (XMLUtils::GetInt(pControlNode, "defaultcontrol", defaultControl))
   {
@@ -1438,7 +1439,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     control->SetEnableCondition(enableCondition);
     control->SetAnimations(animations);
     control->SetColorDiffuse(colorDiffuse);
-    control->SetNavigationActions(upActions, downActions, leftActions, rightActions, backActions);
+    control->SetNavigationActions(actions);
     control->SetPulseOnSelect(bPulse);
     if (hasCamera)
       control->SetCamera(camera);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -225,8 +225,8 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
 
   if (control)
   { // set the navigation of items so that they form a list
-    CGUIAction beforeAction = (m_orientation == VERTICAL) ? m_actionUp : m_actionLeft;
-    CGUIAction afterAction = (m_orientation == VERTICAL) ? m_actionDown : m_actionRight;
+    CGUIAction beforeAction = GetNavigateAction((m_orientation == VERTICAL) ? ACTION_MOVE_UP : ACTION_MOVE_LEFT);
+    CGUIAction afterAction = GetNavigateAction((m_orientation == VERTICAL) ? ACTION_MOVE_DOWN : ACTION_MOVE_RIGHT);
     if (m_children.size())
     {
       // we're inserting at the given position, so grab the items above and below and alter
@@ -281,17 +281,17 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
     {
       control->SetNavigationAction(ACTION_MOVE_UP, beforeAction);
       control->SetNavigationAction(ACTION_MOVE_DOWN, afterAction);
-      control->SetNavigationAction(ACTION_MOVE_LEFT, m_actionLeft, false);
-      control->SetNavigationAction(ACTION_MOVE_RIGHT, m_actionRight, false);
+      control->SetNavigationAction(ACTION_MOVE_LEFT, GetNavigateAction(ACTION_MOVE_LEFT), false);
+      control->SetNavigationAction(ACTION_MOVE_RIGHT, GetNavigateAction(ACTION_MOVE_RIGHT), false);
     }
     else
     {
       control->SetNavigationAction(ACTION_MOVE_LEFT, beforeAction);
       control->SetNavigationAction(ACTION_MOVE_RIGHT, afterAction);
-      control->SetNavigationAction(ACTION_MOVE_UP, m_actionUp, false);
-      control->SetNavigationAction(ACTION_MOVE_DOWN, m_actionDown, false);
+      control->SetNavigationAction(ACTION_MOVE_UP, GetNavigateAction(ACTION_MOVE_UP), false);
+      control->SetNavigationAction(ACTION_MOVE_DOWN, GetNavigateAction(ACTION_MOVE_DOWN), false);
     }
-    control->SetNavigationAction(ACTION_NAV_BACK, m_actionBack, false);
+    control->SetNavigationAction(ACTION_NAV_BACK, GetNavigateAction(ACTION_NAV_BACK), false);
 
     if (!m_useControlPositions)
       control->SetPosition(0,0);

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -214,9 +214,10 @@ void CGUIMultiSelectTextControl::OnRight()
 // movement functions (callable from lists)
 bool CGUIMultiSelectTextControl::MoveLeft()
 {
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_LEFT);
   if (m_selectedItem > 0)
     ScrollToItem(m_selectedItem - 1);
-  else if (GetNumSelectable() && m_actionLeft.GetNavigation() && m_actionLeft.GetNavigation() == m_controlID)
+  else if (GetNumSelectable() && action.GetNavigation() && action.GetNavigation() == m_controlID)
     ScrollToItem(GetNumSelectable() - 1);
   else
     return false;
@@ -225,9 +226,10 @@ bool CGUIMultiSelectTextControl::MoveLeft()
 
 bool CGUIMultiSelectTextControl::MoveRight()
 {
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_RIGHT);
   if (GetNumSelectable() && m_selectedItem < GetNumSelectable() - 1)
     ScrollToItem(m_selectedItem + 1);
-  else if (m_actionRight.GetNavigation() && m_actionRight.GetNavigation() == m_controlID)
+  else if (action.GetNavigation() && action.GetNavigation() == m_controlID)
     ScrollToItem(0);
   else
     return false;

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -259,7 +259,8 @@ bool CGUIPanelContainer::OnMessage(CGUIMessage& message)
 
 void CGUIPanelContainer::OnLeft()
 {
-  bool wrapAround = m_actionLeft.GetNavigation() == GetID() || !m_actionLeft.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_LEFT);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == VERTICAL && MoveLeft(wrapAround))
     return;
   if (m_orientation == HORIZONTAL && MoveUp(wrapAround))
@@ -269,7 +270,8 @@ void CGUIPanelContainer::OnLeft()
 
 void CGUIPanelContainer::OnRight()
 {
-  bool wrapAround = m_actionRight.GetNavigation() == GetID() || !m_actionRight.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_RIGHT);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == VERTICAL && MoveRight(wrapAround))
     return;
   if (m_orientation == HORIZONTAL && MoveDown(wrapAround))
@@ -279,7 +281,8 @@ void CGUIPanelContainer::OnRight()
 
 void CGUIPanelContainer::OnUp()
 {
-  bool wrapAround = m_actionUp.GetNavigation() == GetID() || !m_actionUp.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_UP);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == VERTICAL && MoveUp(wrapAround))
     return;
   if (m_orientation == HORIZONTAL && MoveLeft(wrapAround))
@@ -289,7 +292,8 @@ void CGUIPanelContainer::OnUp()
 
 void CGUIPanelContainer::OnDown()
 {
-  bool wrapAround = m_actionDown.GetNavigation() == GetID() || !m_actionDown.HasActionsMeetingCondition();
+  CGUIAction action = GetNavigateAction(ACTION_MOVE_DOWN);
+  bool wrapAround = action.GetNavigation() == GetID() || !action.HasActionsMeetingCondition();
   if (m_orientation == VERTICAL && MoveDown(wrapAround))
     return;
   if (m_orientation == HORIZONTAL && MoveRight(wrapAround))

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -932,9 +932,7 @@ bool CGUIWindow::OnMove(int fromControl, int moveAction)
   while (control)
   { // grab the next control direction
     moveHistory.push_back(nextControl);
-    CGUIAction action;
-    if (!control->GetNavigationAction(moveAction, action))
-      return false;
+    CGUIAction action = control->GetNavigateAction(moveAction);
     action.ExecuteActions(nextControl, GetParentID());
     nextControl = action.GetNavigation();
     if (!nextControl) // 0 isn't valid control id

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -857,15 +857,15 @@ namespace XBMCAddon
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
 
-      iControlUp = up->iControlId;
-      iControlDown = down->iControlId;
-      iControlLeft = left->iControlId;
-      iControlRight = right->iControlId;
-
       {
         LOCKGUI;
         if (pGUIControl)
-          pGUIControl->SetNavigation(iControlUp,iControlDown,iControlLeft,iControlRight);
+        {
+          pGUIControl->SetNavigationAction(ACTION_MOVE_UP,    up->iControlId);
+          pGUIControl->SetNavigationAction(ACTION_MOVE_DOWN,  down->iControlId);
+          pGUIControl->SetNavigationAction(ACTION_MOVE_LEFT,  left->iControlId);
+          pGUIControl->SetNavigationAction(ACTION_MOVE_RIGHT, right->iControlId);
+        }
       }
     }
 
@@ -874,11 +874,10 @@ namespace XBMCAddon
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
 
-      iControlUp = control->iControlId;
       {
         LOCKGUI;
         if (pGUIControl) 
-          pGUIControl->SetNavigation(iControlUp,iControlDown,iControlLeft,iControlRight);
+          pGUIControl->SetNavigationAction(ACTION_MOVE_UP, control->iControlId);
       }
     }
 
@@ -887,11 +886,10 @@ namespace XBMCAddon
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
 
-      iControlDown = control->iControlId;
       {
         LOCKGUI;
-        if (pGUIControl) 
-          pGUIControl->SetNavigation(iControlUp,iControlDown,iControlLeft,iControlRight);
+        if (pGUIControl)
+          pGUIControl->SetNavigationAction(ACTION_MOVE_DOWN, control->iControlId);
       }
     }
 
@@ -900,11 +898,10 @@ namespace XBMCAddon
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
 
-      iControlLeft = control->iControlId;
       {
         LOCKGUI;
-        if (pGUIControl) 
-          pGUIControl->SetNavigation(iControlUp,iControlDown,iControlLeft,iControlRight);
+        if (pGUIControl)
+          pGUIControl->SetNavigationAction(ACTION_MOVE_LEFT, control->iControlId);
       }
     }
 
@@ -913,11 +910,10 @@ namespace XBMCAddon
       if(iControlId == 0)
         throw WindowException("Control has to be added to a window first");
 
-      iControlRight = control->iControlId;
       {
         LOCKGUI;
-        if (pGUIControl) 
-          pGUIControl->SetNavigation(iControlUp,iControlDown,iControlLeft,iControlRight);
+        if (pGUIControl)
+          pGUIControl->SetNavigationAction(ACTION_MOVE_RIGHT, control->iControlId);
       }
     }
 

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -373,10 +373,10 @@ namespace XBMCAddon
       pControl->dwWidth = (int)pGUIControl->GetWidth();
       pControl->dwPosX = (int)pGUIControl->GetXPosition();
       pControl->dwPosY = (int)pGUIControl->GetYPosition();
-      pControl->iControlUp = pGUIControl->GetControlIdUp();
-      pControl->iControlDown = pGUIControl->GetControlIdDown();
-      pControl->iControlLeft = pGUIControl->GetControlIdLeft();
-      pControl->iControlRight = pGUIControl->GetControlIdRight();
+      pControl->iControlUp = pGUIControl->GetNavigateAction(ACTION_MOVE_UP).GetNavigation();
+      pControl->iControlDown = pGUIControl->GetNavigateAction(ACTION_MOVE_DOWN).GetNavigation();
+      pControl->iControlLeft = pGUIControl->GetNavigateAction(ACTION_MOVE_LEFT).GetNavigation();
+      pControl->iControlRight = pGUIControl->GetNavigateAction(ACTION_MOVE_RIGHT).GetNavigation();
 
       // It got this far so means the control isn't actually in the vector of controls
       // so lets add it to save doing all that next time

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -762,8 +762,10 @@ namespace XBMCAddon
       pControl->iControlLeft = pControl->iControlId;
       pControl->iControlRight = pControl->iControlId;
 
-      pControl->pGUIControl->SetNavigation(pControl->iControlUp,
-          pControl->iControlDown, pControl->iControlLeft, pControl->iControlRight);
+      pControl->pGUIControl->SetNavigationAction(ACTION_MOVE_UP,    pControl->iControlUp);
+      pControl->pGUIControl->SetNavigationAction(ACTION_MOVE_DOWN,  pControl->iControlDown);
+      pControl->pGUIControl->SetNavigationAction(ACTION_MOVE_LEFT,  pControl->iControlLeft);
+      pControl->pGUIControl->SetNavigationAction(ACTION_MOVE_RIGHT, pControl->iControlRight);
 
       // add control to list and allocate recources for the control
       vecControls.push_back(AddonClass::Ref<Control>(pControl));


### PR DESCRIPTION
This cleans up the silly 7 action members in CGUIControl, replacing them with a map, thus reducing the amount of code.  I also took the opportunity to kill off the SetNavigation/SetTabNavigation routines.

@Black09 mind taking a look?  Once this is in the OnInfo stuff should be a bit less copy n paste - feel free to  do a PR against my branch here if you want to get it in with this.
