### PR TITLE
Addon version cleanup

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -289,12 +289,14 @@ GTEST_DIR = lib/gtest
 GTEST_INCLUDES = -I$(GTEST_DIR)/include
 GTEST_LIBS = $(GTEST_DIR)/lib/.libs/libgtest.a
 
-CHECK_DIRS = xbmc/filesystem/test \
+CHECK_DIRS = xbmc/addons/test \
+             xbmc/filesystem/test \
              xbmc/utils/test \
              xbmc/threads/test \
              xbmc/interfaces/python/test \
              xbmc/test
-CHECK_LIBS = xbmc/filesystem/test/filesystemTest.a \
+CHECK_LIBS = xbmc/addons/test/addonsTest.a \
+             xbmc/filesystem/test/filesystemTest.a \
              xbmc/utils/test/utilsTest.a \
              xbmc/threads/test/threadTest.a \
              xbmc/interfaces/python/test/pythonSwigTest.a \

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1941,7 +1941,7 @@ bool CApplication::LoadSkin(const SkinPtr& skin)
 
   UnloadSkin();
 
-  CLog::Log(LOGINFO, "  load skin from: %s (version: %s)", skin->Path().c_str(), skin->Version().c_str());
+  CLog::Log(LOGINFO, "  load skin from: %s (version: %s)", skin->Path().c_str(), skin->Version().asString().c_str());
   g_SkinInfo = skin;
   g_SkinInfo->Start();
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3314,7 +3314,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     if (addon && info.m_info == SYSTEM_ADDON_ICON)
       return addon->Icon();
     if (addon && info.m_info == SYSTEM_ADDON_VERSION)
-      return addon->Version().c_str();
+      return addon->Version().asString();
   }
   else if (info.m_info == PLAYLIST_LENGTH ||
            info.m_info == PLAYLIST_POSITION ||

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -134,10 +134,12 @@ const CStdString GetIcon(const ADDON::TYPE& type)
       y.clear(); \
   }
 
+#define SS(x) (x) ? x : ""
+
 AddonProps::AddonProps(const cp_extension_t *ext)
   : id(ext->plugin->identifier)
-  , version(ext->plugin->version)
-  , minversion(ext->plugin->abi_bw_compatibility)
+  , version(SS(ext->plugin->version))
+  , minversion(SS(ext->plugin->abi_bw_compatibility))
   , name(ext->plugin->name)
   , path(ext->plugin->plugin_path)
   , author(ext->plugin->provider_name)
@@ -171,8 +173,8 @@ AddonProps::AddonProps(const cp_extension_t *ext)
 
 AddonProps::AddonProps(const cp_plugin_info_t *plugin)
   : id(plugin->identifier)
-  , version(plugin->version)
-  , minversion(plugin->abi_bw_compatibility)
+  , version(SS(plugin->version))
+  , minversion(SS(plugin->abi_bw_compatibility))
   , name(plugin->name)
   , path(plugin->plugin_path)
   , author(plugin->provider_name)
@@ -240,7 +242,7 @@ void AddonProps::BuildDependencies(const cp_plugin_info_t *plugin)
     return;
   for (unsigned int i = 0; i < plugin->num_imports; ++i)
     dependencies.insert(make_pair(CStdString(plugin->imports[i].plugin_id),
-                        make_pair(AddonVersion(plugin->imports[i].version), plugin->imports[i].optional != 0)));
+                                  make_pair(AddonVersion(SS(plugin->imports[i].version)), plugin->imports[i].optional != 0)));
 }
 
 /**

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -187,8 +187,8 @@ void AddonProps::Serialize(CVariant &variant) const
 {
   variant["addonid"] = id;
   variant["type"] = TranslateType(type);
-  variant["version"] = version.c_str();
-  variant["minversion"] = minversion.c_str();
+  variant["version"] = version.asString();
+  variant["minversion"] = minversion.asString();
   variant["name"] = name;
   variant["license"] = license;
   variant["summary"] = summary;
@@ -217,7 +217,7 @@ void AddonProps::Serialize(CVariant &variant) const
   {
     CVariant dep(CVariant::VariantTypeObject);
     dep["addonid"] = it->first;
-    dep["version"] = it->second.first.c_str();
+    dep["version"] = it->second.first.asString();
     dep["optional"] = it->second.second;
     variant["dependencies"].push_back(dep);
   }
@@ -647,7 +647,7 @@ CStdString GetXbmcApiVersionDependency(ADDON::AddonPtr addon)
     if (!(it == deps.end()))
     {
       const ADDON::AddonVersion * xbmcApiVersion = &(it->second.first);
-      version = xbmcApiVersion->c_str();
+      version = xbmcApiVersion->asString();
     }
   }
 

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -121,9 +121,9 @@ int CAddonDatabase::AddAddon(const AddonPtr& addon,
                                addon->Description().c_str(),addon->Stars(),
                                addon->Path().c_str(), addon->Props().icon.c_str(),
                                addon->ChangeLog().c_str(),addon->FanArt().c_str(),
-                               addon->ID().c_str(), addon->Version().c_str(),
+                               addon->ID().c_str(), addon->Version().asString().c_str(),
                                addon->Author().c_str(),addon->Disclaimer().c_str(),
-                               addon->MinVersion().c_str());
+                               addon->MinVersion().asString().c_str());
     m_pDS->exec(sql.c_str());
     int idAddon = (int)m_pDS->lastinsertid();
 
@@ -139,7 +139,7 @@ int CAddonDatabase::AddAddon(const AddonPtr& addon,
     const ADDONDEPS &deps = addon->GetDeps();
     for (ADDONDEPS::const_iterator i = deps.begin(); i != deps.end(); ++i)
     {
-      sql = PrepareSQL("insert into dependencies(id, addon, version, optional) values (%i, '%s', '%s', %i)", idAddon, i->first.c_str(), i->second.first.c_str(), i->second.second ? 1 : 0);
+      sql = PrepareSQL("insert into dependencies(id, addon, version, optional) values (%i, '%s', '%s', %i)", idAddon, i->first.c_str(), i->second.first.asString().c_str(), i->second.second ? 1 : 0);
       m_pDS->exec(sql.c_str());
     }
     // these need to be configured

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -561,7 +561,7 @@ void CAddonDatabase::SetPropertiesFromAddon(const AddonPtr& addon,
   pItem->SetProperty("Addon.Type", TranslateType(addon->Type(),true));
   pItem->SetProperty("Addon.intType", TranslateType(addon->Type()));
   pItem->SetProperty("Addon.Name", addon->Name());
-  pItem->SetProperty("Addon.Version", addon->Version().c_str());
+  pItem->SetProperty("Addon.Version", addon->Version().asString());
   pItem->SetProperty("Addon.Summary", addon->Summary());
   pItem->SetProperty("Addon.Description", addon->Description());
   pItem->SetProperty("Addon.Creator", addon->Author());

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -336,7 +336,7 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
     { // we have it but our version isn't good enough, or we don't have it and we need it
       if (!database.GetAddon(addonID, dep) || !dep->MeetsVersion(version))
       { // we don't have it in a repo, or we have it but the version isn't good enough, so dep isn't satisfied.
-        CLog::Log(LOGDEBUG, "Addon %s requires %s version %s which is not available", addon->ID().c_str(), addonID.c_str(), version.c_str());
+        CLog::Log(LOGDEBUG, "Addon %s requires %s version %s which is not available", addon->ID().c_str(), addonID.c_str(), version.asString().c_str());
         database.Close();
         return false;
       }
@@ -645,7 +645,7 @@ bool CAddonInstallJob::Install(const CStdString &installFrom, const AddonPtr& re
 {
   // The first thing we do is install dependencies
   ADDONDEPS deps = m_addon->GetDeps();
-  CStdString referer = StringUtils::Format("Referer=%s-%s.zip",m_addon->ID().c_str(),m_addon->Version().c_str());
+  CStdString referer = StringUtils::Format("Referer=%s-%s.zip",m_addon->ID().c_str(),m_addon->Version().asString().c_str());
   for (ADDONDEPS::iterator it  = deps.begin(); it != deps.end(); ++it)
   {
     if (it->first.Equals("xbmc.metadata"))
@@ -681,7 +681,7 @@ bool CAddonInstallJob::Install(const CStdString &installFrom, const AddonPtr& re
     CStdString s = StringUtils::Format("plugin://%s/?action=install"
                                        "&package=%s&version=%s", repo->ID().c_str(),
                                        m_addon->ID().c_str(),
-                                       m_addon->Version().c_str());
+                                       m_addon->Version().asString().c_str());
     if (!CDirectory::GetDirectory(s, dummy))
       return false;
   }

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -396,7 +396,7 @@ bool CAddonMgr::GetAllOutdatedAddons(VECADDONS &addons, bool getLocalVersion /*=
 
         if (temp[j]->Version() < repoAddon->Version() &&
             !m_database.IsAddonBlacklisted(temp[j]->ID(),
-                                           repoAddon->Version().c_str()))
+                                           repoAddon->Version().asString().c_str()))
         {
           if (getLocalVersion)
             repoAddon->Props().version = temp[j]->Version();

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -25,7 +25,6 @@
 
 #include "AddonVersion.h"
 #include "utils/StringUtils.h"
-#include "guilib/LocalizeStrings.h"
 
 namespace ADDON
 {
@@ -112,11 +111,6 @@ namespace ADDON
   bool AddonVersion::empty() const
   {
     return mEpoch == 0 && mUpstream == "0.0.0" && mRevision.empty();
-  }
-
-  CStdString AddonVersion::Print() const
-  {
-    return StringUtils::Format("%s %s", g_localizeStrings.Get(24051).c_str(), m_originalVersion.c_str());
   }
 
   bool AddonVersion::SplitFileName(CStdString& ID, CStdString& version,

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -29,9 +29,8 @@
 namespace ADDON
 {
   AddonVersion::AddonVersion(const std::string& version)
-  : m_originalVersion(version.empty() ? "0.0.0" : version), mEpoch(0)
+  : mEpoch(0), mUpstream(version.empty() ? "0.0.0" : version)
   {
-    mUpstream = m_originalVersion;
     size_t pos = mUpstream.find(':');
     if (pos != std::string::npos)
     {

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -146,29 +146,4 @@ namespace ADDON
 
     return true;
   }
-
-  bool AddonVersion::Test()
-  {
-    AddonVersion v1_0("1.0");
-    AddonVersion v1_00("1.00");
-    AddonVersion v1_0_0("1.0.0");
-    AddonVersion v1_1("1.1");
-    AddonVersion v1_01("1.01");
-    AddonVersion v1_0_1("1.0.1");
-
-    bool ret = false;
-
-    // These are totally sane
-    ret = (v1_0 < v1_1) && (v1_0 < v1_01) && (v1_0 < v1_0_1) &&
-          (v1_1 > v1_0_1) && (v1_01 > v1_0_1);
-
-    // These are rather sane
-    ret &= (v1_0 != v1_0_0) && (v1_0 < v1_0_0) && (v1_0_0 > v1_0) &&
-           (v1_00 != v1_0_0) && (v1_00 < v1_0_0) && (v1_0_0 > v1_00);
-
-    ret &= (v1_0 == v1_00) && !(v1_0 < v1_00) && !(v1_0 > v1_00);
-    ret &= (v1_1 == v1_01) && !(v1_1 < v1_01) && !(v1_1 > v1_01);
-
-    return ret;
-  }
 }

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -111,7 +111,7 @@ namespace ADDON
 
   bool AddonVersion::empty() const
   {
-    return m_originalVersion.empty() || m_originalVersion == "0.0.0";
+    return mEpoch == 0 && mUpstream == "0.0.0" && mRevision.empty();
   }
 
   CStdString AddonVersion::Print() const

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -113,6 +113,17 @@ namespace ADDON
     return mEpoch == 0 && mUpstream == "0.0.0" && mRevision.empty();
   }
 
+  std::string AddonVersion::asString() const
+  {
+    std::string out;
+    if (mEpoch)
+      out = StringUtils::Format("%i:", mEpoch);
+    out += mUpstream;
+    if (!mRevision.empty())
+      out += "-" + mRevision;
+    return out;
+  }
+
   bool AddonVersion::SplitFileName(CStdString& ID, CStdString& version,
                                    const CStdString& filename)
   {

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -58,7 +58,7 @@ namespace ADDON
     mUpstream[upstream_size] = '\0';
 
     if (upstream_end == NULL)
-      mRevision = strdup("0");
+      mRevision = strdup("");
     else
       mRevision = strdup(upstream_end + 1);
   }

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -58,7 +58,6 @@ namespace ADDON
     static bool SplitFileName(CStdString& ID, CStdString& version,
                               const CStdString& filename);
 
-    static bool Test();
   protected:
     CStdString m_originalVersion;
     int mEpoch;

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -49,7 +49,6 @@ namespace ADDON
     AddonVersion& operator=(const AddonVersion& other);
     bool operator<(const AddonVersion& other) const;
     bool operator==(const AddonVersion& other) const;
-    const char *c_str() const { return m_originalVersion.c_str(); };
     std::string asString() const;
     bool empty() const;
 

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -56,7 +56,6 @@ namespace ADDON
                               const CStdString& filename);
 
   protected:
-    std::string m_originalVersion;
     int mEpoch;
     std::string mUpstream;
     std::string mRevision;

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -50,6 +50,7 @@ namespace ADDON
     bool operator<(const AddonVersion& other) const;
     bool operator==(const AddonVersion& other) const;
     const char *c_str() const { return m_originalVersion.c_str(); };
+    std::string asString() const;
     bool empty() const;
 
     static bool SplitFileName(CStdString& ID, CStdString& version,

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -18,9 +18,7 @@
  *
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <iostream>
+#include <string>
 #include <boost/operators.hpp>
 #include "utils/StdString.h"
 
@@ -40,13 +38,13 @@ namespace ADDON
     */
   class AddonVersion : public boost::totally_ordered<AddonVersion> {
   public:
-    AddonVersion(const AddonVersion& other) : mUpstream(NULL), mRevision(NULL) { *this = other; }
-    explicit AddonVersion(const CStdString& version);
-    ~AddonVersion();
+    AddonVersion(const AddonVersion& other) { *this = other; }
+    explicit AddonVersion(const std::string& version);
+    ~AddonVersion() {};
 
     int Epoch() const { return mEpoch; }
-    const char *Upstream() const { return mUpstream; }
-    const char *Revision() const { return mRevision; }
+    const std::string &Upstream() const { return mUpstream; }
+    const std::string &Revision() const { return mRevision; }
 
     AddonVersion& operator=(const AddonVersion& other);
     bool operator<(const AddonVersion& other) const;
@@ -59,28 +57,19 @@ namespace ADDON
                               const CStdString& filename);
 
   protected:
-    CStdString m_originalVersion;
+    std::string m_originalVersion;
     int mEpoch;
-    char *mUpstream;
-    char *mRevision;
+    std::string mUpstream;
+    std::string mRevision;
 
     static int CompareComponent(const char *a, const char *b);
   };
 
-  inline AddonVersion::~AddonVersion()
-  {
-    free(mUpstream);
-    free(mRevision);
-  }
-
   inline AddonVersion& AddonVersion::operator=(const AddonVersion& other)
   {
-    free(mUpstream);
-    free(mRevision);
-    mEpoch = other.Epoch();
-    mUpstream = strdup(other.Upstream());
-    mRevision = strdup(other.Revision());
-    m_originalVersion = other.m_originalVersion;
+    mEpoch = other.mEpoch;
+    mUpstream = other.mUpstream;
+    mRevision = other.mRevision;
     return *this;
   }
 }

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -49,7 +49,6 @@ namespace ADDON
     AddonVersion& operator=(const AddonVersion& other);
     bool operator<(const AddonVersion& other) const;
     bool operator==(const AddonVersion& other) const;
-    CStdString Print() const;
     const char *c_str() const { return m_originalVersion.c_str(); };
     bool empty() const;
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -307,7 +307,7 @@ void CGUIDialogAddonInfo::OnRollback()
   for (unsigned int i=0;i<m_rollbackVersions.size();++i)
   {
     CStdString label(m_rollbackVersions[i]);
-    if (m_rollbackVersions[i].Equals(m_localAddon->Version().c_str()))
+    if (m_rollbackVersions[i] == m_localAddon->Version().asString())
      label += " "+g_localizeStrings.Get(24094);
    if (database.IsAddonBlacklisted(m_localAddon->ID(),label))
      label += " "+g_localizeStrings.Get(24095);

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -180,7 +180,7 @@ void CGUIDialogAddonInfo::UpdateControls()
 
 void CGUIDialogAddonInfo::OnUpdate()
 {
-  CStdString referer = StringUtils::Format("Referer=%s-%s.zip",m_localAddon->ID().c_str(),m_localAddon->Version().c_str());
+  CStdString referer = StringUtils::Format("Referer=%s-%s.zip",m_localAddon->ID().c_str(),m_localAddon->Version().asString().c_str());
   CAddonInstaller::Get().Install(m_addon->ID(), true, referer); // force install
   Close();
 }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -217,7 +217,7 @@ class UpdateAddons : public IRunnable
     CAddonMgr::Get().GetAllOutdatedAddons(addons, true); // get local
     for (VECADDONS::iterator i = addons.begin(); i != addons.end(); ++i)
     {
-      CStdString referer = StringUtils::Format("Referer=%s-%s.zip",(*i)->ID().c_str(),(*i)->Version().c_str());
+      CStdString referer = StringUtils::Format("Referer=%s-%s.zip",(*i)->ID().c_str(),(*i)->Version().asString().c_str());
       CAddonInstaller::Get().Install((*i)->ID(), true, referer); // force install
     }
   }

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -190,10 +190,10 @@ VECADDONS CRepository::Parse(const DirInfo& dir)
       AddonPtr addon = *i;
       if (dir.zipped)
       {
-        string file = StringUtils::Format("%s/%s-%s.zip", addon->ID().c_str(), addon->ID().c_str(), addon->Version().c_str());
+        string file = StringUtils::Format("%s/%s-%s.zip", addon->ID().c_str(), addon->ID().c_str(), addon->Version().asString().c_str());
         addon->Props().path = URIUtils::AddFileToFolder(dir.datadir,file);
         SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/icon.png"))
-        file = StringUtils::Format("%s/changelog-%s.txt", addon->ID().c_str(), addon->Version().c_str());
+        file = StringUtils::Format("%s/changelog-%s.txt", addon->ID().c_str(), addon->Version().asString().c_str());
         SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(dir.datadir,file))
         SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(dir.datadir,addon->ID()+"/fanart.jpg"))
       }
@@ -273,14 +273,14 @@ bool CRepositoryUpdateJob::DoWork()
     AddonPtr addon;
     CAddonMgr::Get().GetAddon(newAddon->ID(),addon);
     if (addon && newAddon->Version() > addon->Version() &&
-        !database.IsAddonBlacklisted(newAddon->ID(),newAddon->Version().c_str()) &&
+        !database.IsAddonBlacklisted(newAddon->ID(),newAddon->Version().asString()) &&
         deps_met)
     {
       if (CSettings::Get().GetBool("general.addonautoupdate") || addon->Type() >= ADDON_VIZ_LIBRARY)
       {
         string referer;
         if (URIUtils::IsInternetStream(newAddon->Path()))
-          referer = StringUtils::Format("Referer=%s-%s.zip",addon->ID().c_str(),addon->Version().c_str());
+          referer = StringUtils::Format("Referer=%s-%s.zip",addon->ID().c_str(),addon->Version().asString().c_str());
 
         if (newAddon->Type() == ADDON_PVRDLL &&
             !PVR::CPVRManager::Get().InstallAddonAllowed(newAddon->ID()))

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -564,7 +564,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
   CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
     "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sTitle.c_str(),
     Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   std::vector<CScraperUrl> vcscurl;
   if (IsNoop())
@@ -690,7 +690,7 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const CStdStr
   CLog::Log(LOGDEBUG, "%s: Searching for '%s - %s' using %s scraper "
     "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
     sAlbum.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   std::vector<CMusicAlbumInfo> vcali;
   if (IsNoop())
@@ -787,7 +787,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
   CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
     Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   std::vector<CMusicArtistInfo> vcari;
   if (IsNoop())
@@ -870,7 +870,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
   CLog::Log(LOGDEBUG, "%s: Searching '%s' using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
     scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   vector<CStdString> vcsIn;
   vcsIn.push_back(scurl.m_url[0].m_url);
@@ -932,7 +932,7 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl
   CLog::Log(LOGDEBUG, "%s: Reading %s '%s' using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
     fMovie ? MediaTypeMovie : MediaTypeEpisode, scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   video.Reset();
   CStdString sFunc = fMovie ? "GetDetails" : "GetEpisodeDetails";
@@ -972,7 +972,7 @@ bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbu
   CLog::Log(LOGDEBUG, "%s: Reading '%s' using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
     scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   vector<CStdString> vcsOut = RunNoThrow("GetAlbumDetails", scurl, fcurl);
 
@@ -1003,7 +1003,7 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl, const CScraperUrl &scurl,
   CLog::Log(LOGDEBUG, "%s: Reading '%s' ('%s') using %s scraper "
     "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
     scurl.m_url[0].m_url.c_str(), sSearch.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   // pass in the original search string for chaining to search other sites
   vector<CStdString> vcIn;

--- a/xbmc/addons/test/Makefile
+++ b/xbmc/addons/test/Makefile
@@ -1,0 +1,9 @@
+SRCS=	\
+	TestAddonVersion.cpp
+
+LIB=addonsTest.a
+
+INCLUDES += -I../../../lib/gtest/include
+
+include ../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/addons/test/TestAddonVersion.cpp
+++ b/xbmc/addons/test/TestAddonVersion.cpp
@@ -69,73 +69,73 @@ public:
 
 TEST_F(TestAddonVersion, Constructor)
 {
-  EXPECT_STREQ(v1_0.Upstream(), "1.0");
+  EXPECT_EQ(v1_0.Upstream(), "1.0");
   EXPECT_EQ(v1_0.Epoch(), 0);
-  EXPECT_STREQ(v1_0.Revision(), "");
+  EXPECT_TRUE(v1_0.Revision().empty());
 
-  EXPECT_STREQ(v1_00.Upstream(), "1.00");
+  EXPECT_EQ(v1_00.Upstream(), "1.00");
   EXPECT_EQ(v1_00.Epoch(), 0);
-  EXPECT_STREQ(v1_00.Revision(), "");
+  EXPECT_TRUE(v1_00.Revision().empty());
 
-  EXPECT_STREQ(v1_0_0.Upstream(), "1.0.0");
+  EXPECT_EQ(v1_0_0.Upstream(), "1.0.0");
   EXPECT_EQ(v1_0_0.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0.Revision(), "");
+  EXPECT_TRUE(v1_0_0.Revision().empty());
 
-  EXPECT_STREQ(v1_1.Upstream(), "1.1");
+  EXPECT_EQ(v1_1.Upstream(), "1.1");
   EXPECT_EQ(v1_1.Epoch(), 0);
-  EXPECT_STREQ(v1_1.Revision(), "");
+  EXPECT_TRUE(v1_1.Revision().empty());
 
-  EXPECT_STREQ(v1_01.Upstream(), "1.01");
+  EXPECT_EQ(v1_01.Upstream(), "1.01");
   EXPECT_EQ(v1_01.Epoch(), 0);
-  EXPECT_STREQ(v1_01.Revision(), "");
+  EXPECT_TRUE(v1_01.Revision().empty());
 
-  EXPECT_STREQ(v1_0_1.Upstream(), "1.0.1");
+  EXPECT_EQ(v1_0_1.Upstream(), "1.0.1");
   EXPECT_EQ(v1_0_1.Epoch(), 0);
-  EXPECT_STREQ(v1_0_1.Revision(), "");
+  EXPECT_TRUE(v1_0_1.Revision().empty());
 
-  EXPECT_STREQ(e1_v1_0_0.Upstream(), "1.0.0");
+  EXPECT_EQ(e1_v1_0_0.Upstream(), "1.0.0");
   EXPECT_EQ(e1_v1_0_0.Epoch(), 1);
-  EXPECT_STREQ(e1_v1_0_0.Revision(), "");
+  EXPECT_TRUE(e1_v1_0_0.Revision().empty());
 
-  EXPECT_STREQ(e1_v1_0_1.Upstream(), "1.0.1");
+  EXPECT_EQ(e1_v1_0_1.Upstream(), "1.0.1");
   EXPECT_EQ(e1_v1_0_1.Epoch(), 1);
-  EXPECT_STREQ(e1_v1_0_1.Revision(), "");
+  EXPECT_TRUE(e1_v1_0_1.Revision().empty());
 
-  EXPECT_STREQ(e2_v1_0_0.Upstream(), "1.0.0");
+  EXPECT_EQ(e2_v1_0_0.Upstream(), "1.0.0");
   EXPECT_EQ(e2_v1_0_0.Epoch(), 2);
-  EXPECT_STREQ(e2_v1_0_0.Revision(), "");
+  EXPECT_TRUE(e2_v1_0_0.Revision().empty());
 
-  EXPECT_STREQ(e1_v1_0_0_r1.Upstream(), "1.0.0");
+  EXPECT_EQ(e1_v1_0_0_r1.Upstream(), "1.0.0");
   EXPECT_EQ(e1_v1_0_0_r1.Epoch(), 1);
-  EXPECT_STREQ(e1_v1_0_0_r1.Revision(), "1");
+  EXPECT_EQ(e1_v1_0_0_r1.Revision(), "1");
 
-  EXPECT_STREQ(e1_v1_0_1_r1.Upstream(), "1.0.1");
+  EXPECT_EQ(e1_v1_0_1_r1.Upstream(), "1.0.1");
   EXPECT_EQ(e1_v1_0_1_r1.Epoch(), 1);
-  EXPECT_STREQ(e1_v1_0_1_r1.Revision(), "1");
+  EXPECT_EQ(e1_v1_0_1_r1.Revision(), "1");
 
-  EXPECT_STREQ(e1_v1_0_0_r2.Upstream(), "1.0.0");
+  EXPECT_EQ(e1_v1_0_0_r2.Upstream(), "1.0.0");
   EXPECT_EQ(e1_v1_0_0_r2.Epoch(), 1);
-  EXPECT_STREQ(e1_v1_0_0_r2.Revision(), "2");
+  EXPECT_EQ(e1_v1_0_0_r2.Revision(), "2");
 
-  EXPECT_STREQ(v1_0_0_beta.Upstream(), "1.0.0~beta");
+  EXPECT_EQ(v1_0_0_beta.Upstream(), "1.0.0~beta");
   EXPECT_EQ(v1_0_0_beta.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_beta.Revision(), "");
+  EXPECT_TRUE(v1_0_0_beta.Revision().empty());
 
-  EXPECT_STREQ(v1_0_0_alpha.Upstream(), "1.0.0~alpha");
+  EXPECT_EQ(v1_0_0_alpha.Upstream(), "1.0.0~alpha");
   EXPECT_EQ(v1_0_0_alpha.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha.Revision(), "");
+  EXPECT_TRUE(v1_0_0_alpha.Revision().empty());
 
-  EXPECT_STREQ(v1_0_0_alpha2.Upstream(), "1.0.0~alpha2");
+  EXPECT_EQ(v1_0_0_alpha2.Upstream(), "1.0.0~alpha2");
   EXPECT_EQ(v1_0_0_alpha2.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha2.Revision(), "");
+  EXPECT_TRUE(v1_0_0_alpha2.Revision().empty());
 
-  EXPECT_STREQ(v1_0_0_alpha3.Upstream(), "1.0.0~alpha3");
+  EXPECT_EQ(v1_0_0_alpha3.Upstream(), "1.0.0~alpha3");
   EXPECT_EQ(v1_0_0_alpha3.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha3.Revision(), "");
+  EXPECT_TRUE(v1_0_0_alpha3.Revision().empty());
 
-  EXPECT_STREQ(v1_0_0_alpha10.Upstream(), "1.0.0~alpha10");
+  EXPECT_EQ(v1_0_0_alpha10.Upstream(), "1.0.0~alpha10");
   EXPECT_EQ(v1_0_0_alpha10.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha10.Revision(), "");
+  EXPECT_TRUE(v1_0_0_alpha10.Revision().empty());
 }
 
 TEST_F(TestAddonVersion, Equals)

--- a/xbmc/addons/test/TestAddonVersion.cpp
+++ b/xbmc/addons/test/TestAddonVersion.cpp
@@ -1,0 +1,233 @@
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "addons/AddonVersion.h"
+
+#include "gtest/gtest.h"
+
+using namespace ADDON;
+
+class TestAddonVersion : public testing::Test
+{
+public:
+  TestAddonVersion()
+  : v1_0("1.0"),
+    v1_00("1.00"),
+    v1_0_0("1.0.0"),
+    v1_1("1.1"),
+    v1_01("1.01"),
+    v1_0_1("1.0.1"),
+    e1_v1_0_0("1:1.0.0"),
+    e1_v1_0_1("1:1.0.1"),
+    e2_v1_0_0("2:1.0.0"),
+    e1_v1_0_0_r1("1:1.0.0-1"),
+    e1_v1_0_1_r1("1:1.0.1-1"),
+    e1_v1_0_0_r2("1:1.0.0-2"),
+    v1_0_0_beta("1.0.0~beta"),
+    v1_0_0_alpha("1.0.0~alpha"),
+    v1_0_0_alpha2("1.0.0~alpha2"),
+    v1_0_0_alpha3("1.0.0~alpha3"),
+    v1_0_0_alpha10("1.0.0~alpha10")
+  {
+  }
+
+  AddonVersion v1_0;
+  AddonVersion v1_00;
+  AddonVersion v1_0_0;
+  AddonVersion v1_1;
+  AddonVersion v1_01;
+  AddonVersion v1_0_1;
+  AddonVersion e1_v1_0_0;
+  AddonVersion e1_v1_0_1;
+  AddonVersion e2_v1_0_0;
+  AddonVersion e1_v1_0_0_r1;
+  AddonVersion e1_v1_0_1_r1;
+  AddonVersion e1_v1_0_0_r2;
+  AddonVersion v1_0_0_beta;
+  AddonVersion v1_0_0_alpha;
+  AddonVersion v1_0_0_alpha2;
+  AddonVersion v1_0_0_alpha3;
+  AddonVersion v1_0_0_alpha10;
+};
+
+TEST_F(TestAddonVersion, Constructor)
+{
+  EXPECT_STREQ(v1_0.Upstream(), "1.0");
+  EXPECT_EQ(v1_0.Epoch(), 0);
+  EXPECT_STREQ(v1_0.Revision(), "0");
+
+  EXPECT_STREQ(v1_00.Upstream(), "1.00");
+  EXPECT_EQ(v1_00.Epoch(), 0);
+  EXPECT_STREQ(v1_00.Revision(), "0");
+
+  EXPECT_STREQ(v1_0_0.Upstream(), "1.0.0");
+  EXPECT_EQ(v1_0_0.Epoch(), 0);
+  EXPECT_STREQ(v1_0_0.Revision(), "0");
+
+  EXPECT_STREQ(v1_1.Upstream(), "1.1");
+  EXPECT_EQ(v1_1.Epoch(), 0);
+  EXPECT_STREQ(v1_1.Revision(), "0");
+
+  EXPECT_STREQ(v1_01.Upstream(), "1.01");
+  EXPECT_EQ(v1_01.Epoch(), 0);
+  EXPECT_STREQ(v1_01.Revision(), "0");
+
+  EXPECT_STREQ(v1_0_1.Upstream(), "1.0.1");
+  EXPECT_EQ(v1_0_1.Epoch(), 0);
+  EXPECT_STREQ(v1_0_1.Revision(), "0");
+
+  EXPECT_STREQ(e1_v1_0_0.Upstream(), "1.0.0");
+  EXPECT_EQ(e1_v1_0_0.Epoch(), 1);
+  EXPECT_STREQ(e1_v1_0_0.Revision(), "0");
+
+  EXPECT_STREQ(e1_v1_0_1.Upstream(), "1.0.1");
+  EXPECT_EQ(e1_v1_0_1.Epoch(), 1);
+  EXPECT_STREQ(e1_v1_0_1.Revision(), "0");
+
+  EXPECT_STREQ(e2_v1_0_0.Upstream(), "1.0.0");
+  EXPECT_EQ(e2_v1_0_0.Epoch(), 2);
+  EXPECT_STREQ(e2_v1_0_0.Revision(), "0");
+
+  EXPECT_STREQ(e1_v1_0_0_r1.Upstream(), "1.0.0");
+  EXPECT_EQ(e1_v1_0_0_r1.Epoch(), 1);
+  EXPECT_STREQ(e1_v1_0_0_r1.Revision(), "1");
+
+  EXPECT_STREQ(e1_v1_0_1_r1.Upstream(), "1.0.1");
+  EXPECT_EQ(e1_v1_0_1_r1.Epoch(), 1);
+  EXPECT_STREQ(e1_v1_0_1_r1.Revision(), "1");
+
+  EXPECT_STREQ(e1_v1_0_0_r2.Upstream(), "1.0.0");
+  EXPECT_EQ(e1_v1_0_0_r2.Epoch(), 1);
+  EXPECT_STREQ(e1_v1_0_0_r2.Revision(), "2");
+
+  EXPECT_STREQ(v1_0_0_beta.Upstream(), "1.0.0~beta");
+  EXPECT_EQ(v1_0_0_beta.Epoch(), 0);
+  EXPECT_STREQ(v1_0_0_beta.Revision(), "0");
+
+  EXPECT_STREQ(v1_0_0_alpha.Upstream(), "1.0.0~alpha");
+  EXPECT_EQ(v1_0_0_alpha.Epoch(), 0);
+  EXPECT_STREQ(v1_0_0_alpha.Revision(), "0");
+
+  EXPECT_STREQ(v1_0_0_alpha2.Upstream(), "1.0.0~alpha2");
+  EXPECT_EQ(v1_0_0_alpha2.Epoch(), 0);
+  EXPECT_STREQ(v1_0_0_alpha2.Revision(), "0");
+
+  EXPECT_STREQ(v1_0_0_alpha3.Upstream(), "1.0.0~alpha3");
+  EXPECT_EQ(v1_0_0_alpha3.Epoch(), 0);
+  EXPECT_STREQ(v1_0_0_alpha3.Revision(), "0");
+
+  EXPECT_STREQ(v1_0_0_alpha10.Upstream(), "1.0.0~alpha10");
+  EXPECT_EQ(v1_0_0_alpha10.Epoch(), 0);
+  EXPECT_STREQ(v1_0_0_alpha10.Revision(), "0");
+}
+
+TEST_F(TestAddonVersion, Equals)
+{
+  EXPECT_EQ(v1_0, AddonVersion("1.0"));
+  EXPECT_EQ(v1_00, AddonVersion("1.00"));
+  EXPECT_EQ(v1_0_0, AddonVersion("1.0.0"));
+  EXPECT_EQ(v1_1, AddonVersion("1.1"));
+  EXPECT_EQ(v1_01, AddonVersion("1.01"));
+  EXPECT_EQ(v1_0_1, AddonVersion("1.0.1"));
+  EXPECT_EQ(e1_v1_0_0, AddonVersion("1:1.0.0"));
+  EXPECT_EQ(e1_v1_0_1, AddonVersion("1:1.0.1"));
+  EXPECT_EQ(e2_v1_0_0, AddonVersion("2:1.0.0"));
+  EXPECT_EQ(e1_v1_0_0_r1, AddonVersion("1:1.0.0-1"));
+  EXPECT_EQ(e1_v1_0_1_r1, AddonVersion("1:1.0.1-1"));
+  EXPECT_EQ(e1_v1_0_0_r2, AddonVersion("1:1.0.0-2"));
+  EXPECT_EQ(v1_0_0_beta, AddonVersion("1.0.0~beta"));
+  EXPECT_EQ(v1_0_0_alpha, AddonVersion("1.0.0~alpha"));
+  EXPECT_EQ(v1_0_0_alpha2, AddonVersion("1.0.0~alpha2"));
+  EXPECT_EQ(v1_0_0_alpha3, AddonVersion("1.0.0~alpha3"));
+  EXPECT_EQ(v1_0_0_alpha10, AddonVersion("1.0.0~alpha10"));
+}
+
+TEST_F(TestAddonVersion, Equivalent)
+{
+  EXPECT_FALSE(v1_0 != v1_00);
+  EXPECT_FALSE(v1_0 < v1_00);
+  EXPECT_FALSE(v1_0 > v1_00);
+  EXPECT_TRUE(v1_0 == v1_00);
+
+  EXPECT_FALSE(v1_01 != v1_1);
+  EXPECT_FALSE(v1_01 < v1_1);
+  EXPECT_FALSE(v1_01 > v1_1);
+  EXPECT_TRUE(v1_01 == v1_1);
+}
+
+TEST_F(TestAddonVersion, LessThan)
+{
+  EXPECT_LT(v1_0, v1_0_0);
+  EXPECT_LT(v1_0, v1_1);
+  EXPECT_LT(v1_0, v1_01);
+  EXPECT_LT(v1_0, v1_0_1);
+
+  EXPECT_LT(v1_00, v1_0_0);
+  EXPECT_LT(v1_00, v1_1);
+  EXPECT_LT(v1_00, v1_01);
+  EXPECT_LT(v1_00, v1_0_1);
+
+  EXPECT_LT(v1_0_0, v1_1);
+  EXPECT_LT(v1_0_0, v1_01);
+  EXPECT_LT(v1_0_0, v1_0_1);
+
+  EXPECT_LT(v1_0_1, v1_01);
+  EXPECT_LT(v1_0_1, v1_1);
+
+  // epochs
+  EXPECT_LT(v1_0_0, e1_v1_0_0);
+  EXPECT_LT(v1_0_0, e1_v1_0_1);
+  EXPECT_LT(v1_0_0, e2_v1_0_0);
+  EXPECT_LT(v1_0_1, e1_v1_0_1);
+  EXPECT_LT(v1_0_1, e2_v1_0_0);
+
+  EXPECT_LT(e1_v1_0_0, e1_v1_0_1);
+  EXPECT_LT(e1_v1_0_0, e2_v1_0_0);
+  EXPECT_LT(e1_v1_0_1, e2_v1_0_0);
+
+  // revisions
+  EXPECT_LT(e1_v1_0_0, e1_v1_0_0_r1);
+  EXPECT_LT(e1_v1_0_0, e1_v1_0_1_r1);
+  EXPECT_LT(e1_v1_0_0, e1_v1_0_0_r2);
+  EXPECT_LT(e1_v1_0_1, e1_v1_0_1_r1);
+  EXPECT_LT(e1_v1_0_0_r1, e1_v1_0_1);
+  EXPECT_LT(e1_v1_0_0_r1, e1_v1_0_1_r1);
+  EXPECT_LT(e1_v1_0_0_r1, e1_v1_0_0_r2);
+  EXPECT_LT(e1_v1_0_0_r2, e1_v1_0_1);
+  EXPECT_LT(e1_v1_0_0_r2, e1_v1_0_1_r1);
+  EXPECT_LT(e1_v1_0_1_r1, e2_v1_0_0);
+
+  // alpha, beta
+  EXPECT_LT(v1_0_0_beta, v1_0_0);
+  EXPECT_LT(v1_0_0_alpha, v1_0_0);
+  EXPECT_LT(v1_0_0_alpha, v1_0_0_beta);
+  EXPECT_LT(v1_0_0_alpha, v1_0_0_alpha2);
+  EXPECT_LT(v1_0_0_alpha, v1_0_0_alpha3);
+  EXPECT_LT(v1_0_0_alpha, v1_0_0_alpha10);
+  EXPECT_LT(v1_0_0_alpha2, v1_0_0);
+  EXPECT_LT(v1_0_0_alpha2, v1_0_0_beta);
+  EXPECT_LT(v1_0_0_alpha2, v1_0_0_alpha3);
+  EXPECT_LT(v1_0_0_alpha2, v1_0_0_alpha10);
+  EXPECT_LT(v1_0_0_alpha3, v1_0_0);
+  EXPECT_LT(v1_0_0_alpha3, v1_0_0_beta);
+  EXPECT_LT(v1_0_0_alpha3, v1_0_0_alpha10);
+  EXPECT_LT(v1_0_0_alpha10, v1_0_0);
+  EXPECT_LT(v1_0_0_alpha10, v1_0_0_beta);
+}

--- a/xbmc/addons/test/TestAddonVersion.cpp
+++ b/xbmc/addons/test/TestAddonVersion.cpp
@@ -138,6 +138,27 @@ TEST_F(TestAddonVersion, Constructor)
   EXPECT_TRUE(v1_0_0_alpha10.Revision().empty());
 }
 
+TEST_F(TestAddonVersion, asString)
+{
+  EXPECT_EQ(v1_0.asString(), "1.0");
+  EXPECT_EQ(v1_00.asString(), "1.00");
+  EXPECT_EQ(v1_0_0.asString(), "1.0.0");
+  EXPECT_EQ(v1_1.asString(), "1.1");
+  EXPECT_EQ(v1_01.asString(), "1.01");
+  EXPECT_EQ(v1_0_1.asString(), "1.0.1");
+  EXPECT_EQ(e1_v1_0_0.asString(), "1:1.0.0");
+  EXPECT_EQ(e1_v1_0_1.asString(), "1:1.0.1");
+  EXPECT_EQ(e2_v1_0_0.asString(), "2:1.0.0");
+  EXPECT_EQ(e1_v1_0_0_r1.asString(), "1:1.0.0-1");
+  EXPECT_EQ(e1_v1_0_1_r1.asString(), "1:1.0.1-1");
+  EXPECT_EQ(e1_v1_0_0_r2.asString(), "1:1.0.0-2");
+  EXPECT_EQ(v1_0_0_beta.asString(), "1.0.0~beta");
+  EXPECT_EQ(v1_0_0_alpha.asString(), "1.0.0~alpha");
+  EXPECT_EQ(v1_0_0_alpha2.asString(), "1.0.0~alpha2");
+  EXPECT_EQ(v1_0_0_alpha3.asString(), "1.0.0~alpha3");
+  EXPECT_EQ(v1_0_0_alpha10.asString(), "1.0.0~alpha10");
+}
+
 TEST_F(TestAddonVersion, Equals)
 {
   EXPECT_EQ(v1_0, AddonVersion("1.0"));

--- a/xbmc/addons/test/TestAddonVersion.cpp
+++ b/xbmc/addons/test/TestAddonVersion.cpp
@@ -71,39 +71,39 @@ TEST_F(TestAddonVersion, Constructor)
 {
   EXPECT_STREQ(v1_0.Upstream(), "1.0");
   EXPECT_EQ(v1_0.Epoch(), 0);
-  EXPECT_STREQ(v1_0.Revision(), "0");
+  EXPECT_STREQ(v1_0.Revision(), "");
 
   EXPECT_STREQ(v1_00.Upstream(), "1.00");
   EXPECT_EQ(v1_00.Epoch(), 0);
-  EXPECT_STREQ(v1_00.Revision(), "0");
+  EXPECT_STREQ(v1_00.Revision(), "");
 
   EXPECT_STREQ(v1_0_0.Upstream(), "1.0.0");
   EXPECT_EQ(v1_0_0.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0.Revision(), "0");
+  EXPECT_STREQ(v1_0_0.Revision(), "");
 
   EXPECT_STREQ(v1_1.Upstream(), "1.1");
   EXPECT_EQ(v1_1.Epoch(), 0);
-  EXPECT_STREQ(v1_1.Revision(), "0");
+  EXPECT_STREQ(v1_1.Revision(), "");
 
   EXPECT_STREQ(v1_01.Upstream(), "1.01");
   EXPECT_EQ(v1_01.Epoch(), 0);
-  EXPECT_STREQ(v1_01.Revision(), "0");
+  EXPECT_STREQ(v1_01.Revision(), "");
 
   EXPECT_STREQ(v1_0_1.Upstream(), "1.0.1");
   EXPECT_EQ(v1_0_1.Epoch(), 0);
-  EXPECT_STREQ(v1_0_1.Revision(), "0");
+  EXPECT_STREQ(v1_0_1.Revision(), "");
 
   EXPECT_STREQ(e1_v1_0_0.Upstream(), "1.0.0");
   EXPECT_EQ(e1_v1_0_0.Epoch(), 1);
-  EXPECT_STREQ(e1_v1_0_0.Revision(), "0");
+  EXPECT_STREQ(e1_v1_0_0.Revision(), "");
 
   EXPECT_STREQ(e1_v1_0_1.Upstream(), "1.0.1");
   EXPECT_EQ(e1_v1_0_1.Epoch(), 1);
-  EXPECT_STREQ(e1_v1_0_1.Revision(), "0");
+  EXPECT_STREQ(e1_v1_0_1.Revision(), "");
 
   EXPECT_STREQ(e2_v1_0_0.Upstream(), "1.0.0");
   EXPECT_EQ(e2_v1_0_0.Epoch(), 2);
-  EXPECT_STREQ(e2_v1_0_0.Revision(), "0");
+  EXPECT_STREQ(e2_v1_0_0.Revision(), "");
 
   EXPECT_STREQ(e1_v1_0_0_r1.Upstream(), "1.0.0");
   EXPECT_EQ(e1_v1_0_0_r1.Epoch(), 1);
@@ -119,23 +119,23 @@ TEST_F(TestAddonVersion, Constructor)
 
   EXPECT_STREQ(v1_0_0_beta.Upstream(), "1.0.0~beta");
   EXPECT_EQ(v1_0_0_beta.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_beta.Revision(), "0");
+  EXPECT_STREQ(v1_0_0_beta.Revision(), "");
 
   EXPECT_STREQ(v1_0_0_alpha.Upstream(), "1.0.0~alpha");
   EXPECT_EQ(v1_0_0_alpha.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha.Revision(), "0");
+  EXPECT_STREQ(v1_0_0_alpha.Revision(), "");
 
   EXPECT_STREQ(v1_0_0_alpha2.Upstream(), "1.0.0~alpha2");
   EXPECT_EQ(v1_0_0_alpha2.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha2.Revision(), "0");
+  EXPECT_STREQ(v1_0_0_alpha2.Revision(), "");
 
   EXPECT_STREQ(v1_0_0_alpha3.Upstream(), "1.0.0~alpha3");
   EXPECT_EQ(v1_0_0_alpha3.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha3.Revision(), "0");
+  EXPECT_STREQ(v1_0_0_alpha3.Revision(), "");
 
   EXPECT_STREQ(v1_0_0_alpha10.Upstream(), "1.0.0~alpha10");
   EXPECT_EQ(v1_0_0_alpha10.Epoch(), 0);
-  EXPECT_STREQ(v1_0_0_alpha10.Revision(), "0");
+  EXPECT_STREQ(v1_0_0_alpha10.Revision(), "");
 }
 
 TEST_F(TestAddonVersion, Equals)

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -187,7 +187,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
       AddonPtr addon2;
       database.GetAddon(items[i]->GetProperty("Addon.ID").asString(),addon2);
       if (addon2 && addon2->Version() > AddonVersion(items[i]->GetProperty("Addon.Version").asString())
-                 && !database.IsAddonBlacklisted(addon2->ID(),addon2->Version().c_str()))
+                 && !database.IsAddonBlacklisted(addon2->ID(),addon2->Version().asString()))
       {
         items[i]->SetProperty("Addon.Status",g_localizeStrings.Get(24068));
         items[i]->SetProperty("Addon.UpdateAvail", true);
@@ -264,7 +264,7 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon, const CS
   item->SetLabel(strLabel);
 
   if (!(basePath.Equals("addons://") && addon->Type() == ADDON_REPOSITORY))
-    item->SetLabel2(addon->Version().c_str());
+    item->SetLabel2(addon->Version().asString());
   item->SetArt("thumb", addon->Icon());
   item->SetLabelPreformated(true);
   item->SetIconImage("DefaultAddon.png");

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -71,7 +71,7 @@ namespace XBMCAddon
         {
           throw AddonException("Could not get AddonPtr given a script id of %s."
                                "If you are trying to use 'os.getcwd' to set the path, you cannot do that in a version %s plugin.", 
-                               id.c_str(), version.c_str());
+                               id.c_str(), version.asString().c_str());
         }
       }
 

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -158,7 +158,7 @@ namespace XBMCAddon
       else if (strcmpi(id, "type") == 0)
         return ADDON::TranslateType(pAddon->Type());
       else if (strcmpi(id, "version") == 0)
-        return String(pAddon->Version().c_str());
+        return pAddon->Version().asString();
       else
         throw AddonException("'%s' is an invalid Id", id);
     }

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -70,8 +70,8 @@ namespace XBMCAddon
         else
         {
           throw AddonException("Could not get AddonPtr given a script id of %s."
-                               "If you are trying to use 'os.getcwd' to set the path, you cannot do that in a %s plugin.", 
-                               id.c_str(), version.Print().c_str());
+                               "If you are trying to use 'os.getcwd' to set the path, you cannot do that in a version %s plugin.", 
+                               id.c_str(), version.c_str());
         }
       }
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -274,7 +274,7 @@ bool CPVRClient::CheckAPIVersion(void)
 
   if (!IsCompatibleAPIVersion(minVersion, m_apiVersion))
   {
-    CLog::Log(LOGERROR, "PVR - Add-on '%s' is using an incompatible API version. XBMC minimum API version = '%s', add-on API version '%s'", Name().c_str(), minVersion.c_str(), m_apiVersion.c_str());
+    CLog::Log(LOGERROR, "PVR - Add-on '%s' is using an incompatible API version. XBMC minimum API version = '%s', add-on API version '%s'", Name().c_str(), minVersion.asString().c_str(), m_apiVersion.asString().c_str());
     return false;
   }
 
@@ -286,7 +286,7 @@ bool CPVRClient::CheckAPIVersion(void)
 
   if (!IsCompatibleGUIAPIVersion(minVersion, guiVersion))
   {
-    CLog::Log(LOGERROR, "PVR - Add-on '%s' is using an incompatible GUI API version. XBMC minimum GUI API version = '%s', add-on GUI API version '%s'", Name().c_str(), minVersion.c_str(), guiVersion.c_str());
+    CLog::Log(LOGERROR, "PVR - Add-on '%s' is using an incompatible GUI API version. XBMC minimum GUI API version = '%s', add-on GUI API version '%s'", Name().c_str(), minVersion.asString().c_str(), guiVersion.asString().c_str());
     return false;
   }
 


### PR DESCRIPTION
This cleans up the AddonVersion code, dropping the strdup/free/malloc stuff for a std::string implementation.

Not sure about the dropping of .c_str() in favour of .asString().c_str() - we seem to use the former a bit more than we do the .asString() but ofcourse you need to do it if we're dropping m_originalVersion.

The advantage of doing so is you drop the potential for internal inconsistency, the disadvantage is it's a bit more to type.

Note: Added test cases as well to make sure I didn't screw up (I did initially, so it's kinda good that I took the time to do the tests!)
