### PR TITLE
[guilib] Drop back compatibility code and inconsistencies

### DIFF
--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.0.2" provider-name="Team XBMC">
+<addon id="xbmc.gui" version="5.1.0" provider-name="Team XBMC">
   <backwards-compatibility abi="5.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -605,6 +605,15 @@ const CStdString CAddon::LibPath() const
   return URIUtils::AddFileToFolder(m_props.path, m_strLibName);
 }
 
+AddonVersion CAddon::GetDependencyVersion(const std::string &dependencyID) const
+{
+  const ADDON::ADDONDEPS &deps = GetDeps();
+  ADDONDEPS::const_iterator it = deps.find(dependencyID);
+  if (it != deps.end())
+    return it->second.first;
+  return AddonVersion("0.0.0");
+}
+
 /**
  * CAddonLibrary
  *
@@ -634,26 +643,6 @@ TYPE CAddonLibrary::SetAddonType()
   else
     return ADDON_UNKNOWN;
 }
-
-CStdString GetXbmcApiVersionDependency(ADDON::AddonPtr addon)
-{
-  CStdString version("1.0");
-  if (addon.get() != NULL)
-  {
-    const ADDON::ADDONDEPS &deps = addon->GetDeps();
-    ADDON::ADDONDEPS::const_iterator it;
-    CStdString key("xbmc.python");
-    it = deps.find(key);
-    if (!(it == deps.end()))
-    {
-      const ADDON::AddonVersion * xbmcApiVersion = &(it->second.first);
-      version = xbmcApiVersion->asString();
-    }
-  }
-
-  return version;
-}
-
 
 } /* namespace ADDON */
 

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -162,6 +162,12 @@ public:
   const InfoMap &ExtraInfo() const { return m_props.extrainfo; }
   const ADDONDEPS &GetDeps() const { return m_props.dependencies; }
 
+  /*! \brief get the required version of a dependency.
+   \param dependencyID the addon ID of the dependency.
+   \return the version this addon requires.
+   */
+  AddonVersion GetDependencyVersion(const std::string &dependencyID) const;
+
   /*! \brief return whether or not this addon satisfies the given version requirements
    \param version the version to meet.
    \return true if  min_version <= version <= current_version, false otherwise.

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -40,8 +40,6 @@ namespace ADDON
 const CStdString    TranslateType(const TYPE &type, bool pretty=false);
 const CStdString    GetIcon(const TYPE &type);
       TYPE          TranslateType(const CStdString &string);
-const CStdString    UpdateVideoScraper(const CStdString &scraper);
-const CStdString    UpdateMusicScraper(const CStdString &scraper);
 
 class AddonProps : public ISerializable
 {

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -93,7 +93,7 @@ AddonPtr CAddonMgr::Factory(const cp_extension_t *props)
       {
         // Eden (API v2.0) broke old weather add-ons
         AddonPtr result(new CAddon(props));
-        AddonVersion ver1 = AddonVersion(GetXbmcApiVersionDependency(result));
+        AddonVersion ver1 = result->GetDependencyVersion("xbmc.python");
         AddonVersion ver2 = AddonVersion("2.0");
         if (ver1 < ver2)
         {

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -109,6 +109,7 @@ namespace ADDON
     virtual TiXmlElement* GetSettingsXML() =0;
     virtual CStdString GetString(uint32_t id) =0;
     virtual const ADDONDEPS &GetDeps() const =0;
+    virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;
     virtual bool MeetsVersion(const AddonVersion &version) const =0;
     virtual bool ReloadSettings() =0;
 
@@ -123,15 +124,5 @@ namespace ADDON
     virtual bool LoadStrings() =0;
     virtual void ClearStrings() =0;
   };
-
-  // some utilitiy methods
-
-  /**
-   * This function will extract the Addon's currently assigned xbmc.python
-   * API version. If addon is NULL, or there is no xbmc.python dependency defined,
-   * then the version is assumed to be "1.0"
-   */
-  CStdString GetXbmcApiVersionDependency(ADDON::AddonPtr addon);
-
 };
 

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -37,8 +37,6 @@
 using namespace std;
 using namespace XFILE;
 
-#define SKIN_MIN_VERSION 2.1f
-
 boost::shared_ptr<ADDON::CSkinInfo> g_SkinInfo;
 
 namespace ADDON
@@ -182,11 +180,6 @@ CStdString CSkinInfo::GetSkinPath(const CStdString& strFile, RESOLUTION_INFO *re
 bool CSkinInfo::HasSkinFile(const CStdString &strFile) const
 {
   return CFile::Exists(GetSkinPath(strFile));
-}
-
-double CSkinInfo::GetMinVersion()
-{
-  return SKIN_MIN_VERSION;
 }
 
 void CSkinInfo::LoadIncludes()

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -45,12 +45,12 @@ namespace ADDON
 {
 
 CSkinInfo::CSkinInfo(const AddonProps &props, const RESOLUTION_INFO &resolution)
-  : CAddon(props), m_defaultRes(resolution)
+  : CAddon(props), m_defaultRes(resolution), m_version("")
 {
 }
 
 CSkinInfo::CSkinInfo(const cp_extension_t *ext)
-  : CAddon(ext)
+  : CAddon(ext), m_version("")
 {
   ELEMENTS elements;
   if (CAddonMgr::Get().GetExtElements(ext->configuration, "res", elements))
@@ -95,7 +95,9 @@ CSkinInfo::CSkinInfo(const cp_extension_t *ext)
   m_debugging = !strcmp(str.c_str(), "true");
 
   LoadStartupWindows(ext);
-  m_Version = 2.11;
+
+  // figure out the version
+  m_version = GetDependencyVersion("xbmc.gui");
 }
 
 CSkinInfo::~CSkinInfo()

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -68,7 +68,7 @@ public:
    */
   CStdString GetSkinPath(const CStdString& file, RESOLUTION_INFO *res = NULL, const CStdString& baseDir = "") const;
 
-  double GetVersion() const { return m_Version; };
+  AddonVersion APIVersion() const { return m_version; };
 
   /*! \brief Return whether skin debugging is enabled
    \return true if skin debugging (set via <debugging>true</debugging> in skin.xml) is enabled.
@@ -141,7 +141,7 @@ protected:
   RESOLUTION_INFO m_defaultRes;
   std::vector<RESOLUTION_INFO> m_resolutions;
 
-  double m_Version;
+  AddonVersion m_version;
 
   float m_effectsSlowDown;
   CGUIIncludes m_includes;

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -110,8 +110,6 @@ public:
 
   const CStdString& GetCurrentAspect() const { return m_currentAspect; }
 
-//  static bool Check(const CStdString& strSkinDir); // checks if everything is present and accounted for without loading the skin
-  static double GetMinVersion();
   void LoadIncludes();
   const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name, int context);
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -53,11 +53,6 @@
 using namespace std;
 
 #define BACKGROUND_IMAGE       999
-#if PRE_SKIN_VERSION_11_COMPATIBILITY
-#define BACKGROUND_BOTTOM      998
-#define BACKGROUND_TOP         997
-#define SPACE_BETWEEN_BUTTONS    2
-#endif
 #define GROUP_LIST             996
 #define BUTTON_TEMPLATE       1000
 #define BUTTON_START          1001
@@ -150,36 +145,11 @@ void CGUIDialogContextMenu::SetupButtons()
         if (!pGroupList->InsertControl(pButton, pButtonTemplate))
           pGroupList->AddControl(pButton);
       }
-#if PRE_SKIN_VERSION_11_COMPATIBILITY
-      else
-      {
-        pButton->SetPosition(pButtonTemplate->GetXPosition(), i*(pButtonTemplate->GetHeight() + SPACE_BETWEEN_BUTTONS));
-        pButton->SetNavigationAction(ACTION_MOVE_UP, id - 1 );
-        pButton->SetNavigationAction(ACTION_MOVE_DOWN, id + 1);
-        pButton->SetNavigationAction(ACTION_MOVE_LEFT, id);
-        pButton->SetNavigationAction(ACTION_MOVE_RIGHT, id);
-        AddControl(pButton);
-      }
-#endif
     }
   }
 
-  CGUIControl *pControl = NULL;
-#if PRE_SKIN_VERSION_11_COMPATIBILITY
-  if (!pGroupList)
-  {
-    // if we don't have grouplist update the navigation of the first and last buttons
-    pControl = GetControl(BUTTON_START);
-    if (pControl)
-      pControl->SetNavigationAction(ACTION_MOVE_UP, BUTTON_END);
-    pControl = GetControl(BUTTON_END);
-    if (pControl)
-      pControl->SetNavigationAction(ACTION_MOVE_DOWN, BUTTON_START);
-  }
-#endif
-
   // fix up background images placement and size
-  pControl = GetControl(BACKGROUND_IMAGE);
+  CGUIControl *pControl = (CGUIControl *)GetControl(BACKGROUND_IMAGE);
   if (pControl)
   {
     // first set size of background image
@@ -196,43 +166,11 @@ void CGUIDialogContextMenu::SetupButtons()
         pControl->SetWidth(m_backgroundImageSize - pGroupList->Size() + pGroupList->GetWidth());
       }
     }
-#if PRE_SKIN_VERSION_11_COMPATIBILITY
-    else
-      pControl->SetHeight(m_buttons.size() * (pButtonTemplate->GetHeight() + SPACE_BETWEEN_BUTTONS));
-
-    if (pGroupList && pGroupList->GetOrientation() == HORIZONTAL)
-    {
-      // if there is grouplist control with horizontal orientation - adjust width of top and bottom background
-      CGUIControl* pControl2 = GetControl(BACKGROUND_TOP);
-      if (pControl2)
-        pControl2->SetWidth(pControl->GetWidth());
-
-      pControl2 = GetControl(BACKGROUND_BOTTOM);
-      if (pControl2)
-        pControl2->SetWidth(pControl->GetWidth());
-    }
-    else
-    {
-      // adjust position of bottom background
-      CGUIControl* pControl2 = GetControl(BACKGROUND_BOTTOM);
-      if (pControl2)
-        pControl2->SetPosition(pControl2->GetXPosition(), pControl->GetYPosition() + pControl->GetHeight());
-    }
-#endif
   }
 
   // update our default control
   if (pGroupList)
     m_defaultControl = pGroupList->GetID();
-#if PRE_SKIN_VERSION_11_COMPATIBILITY
-  else
-  {
-    if (m_defaultControl < BUTTON_START || m_defaultControl > BUTTON_END)
-      m_defaultControl = BUTTON_START;
-    while (m_defaultControl <= BUTTON_END && !(GetControl(m_defaultControl)->CanFocus()))
-      m_defaultControl++;
-  }
-#endif
 }
 
 void CGUIDialogContextMenu::SetPosition(float posX, float posY)
@@ -243,14 +181,6 @@ void CGUIDialogContextMenu::SetPosition(float posX, float posY)
   if (posX + GetWidth() > m_coordsRes.iWidth)
     posX = m_coordsRes.iWidth - GetWidth();
   if (posX < 0) posX = 0;
-#if PRE_SKIN_VERSION_11_COMPATIBILITY
-  // we currently hack the positioning of the buttons from y position 0, which
-  // forces skinners to place the top image at a negative y value.  Thus, we offset
-  // the y coordinate by the height of the top image.
-  const CGUIControl *top = GetControl(BACKGROUND_TOP);
-  if (top)
-    posY += top->GetHeight();
-#endif
   CGUIDialog::SetPosition(posX, posY);
 }
 
@@ -258,20 +188,7 @@ float CGUIDialogContextMenu::GetHeight() const
 {
   const CGUIControl *backMain = GetControl(BACKGROUND_IMAGE);
   if (backMain)
-#if PRE_SKIN_VERSION_11_COMPATIBILITY
-  {
-    float height = backMain->GetHeight();
-    const CGUIControl *backBottom = GetControl(BACKGROUND_BOTTOM);
-    if (backBottom)
-      height += backBottom->GetHeight();
-    const CGUIControl *backTop = GetControl(BACKGROUND_TOP);
-    if (backTop)
-      height += backTop->GetHeight();
-    return height;
-  }
-#else
-  return backMain->GetHeight();
-#endif
+    return backMain->GetHeight();
   else
     return CGUIDialog::GetHeight();
 }

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -474,12 +474,6 @@ void CGUIDialogMediaSource::SetTypeOfMedia(const CStdString &type, bool editNotA
   SET_CONTROL_LABEL(CONTROL_HEADING, format);
 }
 
-void CGUIDialogMediaSource::OnWindowLoaded()
-{
-  CGUIDialog::OnWindowLoaded();
-  ChangeButtonToEdit(CONTROL_NAME, true);  // true for single label
-}
-
 int CGUIDialogMediaSource::GetSelectedItem()
 {
   CGUIMessage message(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_PATH);

--- a/xbmc/dialogs/GUIDialogMediaSource.h
+++ b/xbmc/dialogs/GUIDialogMediaSource.h
@@ -34,7 +34,6 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual void OnDeinitWindow(int nextWindowID);
   virtual bool OnBack(int actionID);
-  virtual void OnWindowLoaded();
   static bool ShowAndAddMediaSource(const CStdString &type);
   static bool ShowAndEditMediaSource(const CStdString &type, const CMediaSource &share);
   static bool ShowAndEditMediaSource(const CStdString &type, const CStdString &share);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -383,7 +383,6 @@ void CGUIDialogSmartPlaylistEditor::UpdateRuleControlButtons()
 void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
 {
   CGUIDialog::OnWindowLoaded();
-  ChangeButtonToEdit(CONTROL_NAME, true); // true for single label
   SendMessage(GUI_MSG_SET_TYPE, CONTROL_NAME, 0, 16012);
   // setup the match spinner
   {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -480,12 +480,6 @@ void CGUIDialogSmartPlaylistRule::AddOperatorLabel(CDatabaseQueryRule::SEARCH_OP
   OnMessage(select);
 }
 
-void CGUIDialogSmartPlaylistRule::OnWindowLoaded()
-{
-  CGUIWindow::OnWindowLoaded();
-  ChangeButtonToEdit(CONTROL_VALUE, true); // true for single label
-}
-
 void CGUIDialogSmartPlaylistRule::OnInitWindow()
 {
   CGUIDialog::OnInitWindow();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
@@ -32,7 +32,6 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
-  virtual void OnWindowLoaded();
   virtual void OnDeinitWindow(int nextWindowID);
 
   static bool EditRule(CSmartPlaylistRule &rule, const CStdString& type="songs");

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -56,6 +56,7 @@
 #include "GUIListGroup.h"
 #include "GUIInfoManager.h"
 #include "Key.h"
+#include "addons/Skin.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
 #include "utils/XMLUtils.h"
@@ -736,10 +737,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   float buttonGap = 5;
   int iMovementRange = 0;
   CAspectRatio aspect;
-#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
-  if (insideContainer)  // default for inside containers is keep
-    aspect.ratio = CAspectRatio::AR_KEEP;
-#endif
+  if (g_SkinInfo && g_SkinInfo->APIVersion() < ADDON::AddonVersion("5.1.0"))
+  {
+    if (insideContainer)  // default for inside containers is keep
+      aspect.ratio = CAspectRatio::AR_KEEP;
+  }
 
   CStdString allowHiddenFocus;
   CStdString enableCondition;
@@ -967,10 +969,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   // the <texture> tag can be overridden by the <info> tag
   GetInfoTexture(pControlNode, "texture", texture, textureFile, parentID);
-#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
-  if (type == CGUIControl::GUICONTROL_IMAGE && insideContainer && textureFile.IsConstant())
-    aspect.ratio = CAspectRatio::AR_STRETCH;
-#endif
+  if (g_SkinInfo && g_SkinInfo->APIVersion() < ADDON::AddonVersion("5.1.0"))
+  {
+    if (type == CGUIControl::GUICONTROL_IMAGE && insideContainer && textureFile.IsConstant())
+      aspect.ratio = CAspectRatio::AR_STRETCH;
+  }
 
   GetTexture(pControlNode, "bordertexture", borderTexture);
 

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -285,7 +285,7 @@ bool CGUIListContainer::SelectItemFromPoint(const CPoint &point)
   return true;
 }
 
-//#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
+//#ifdef GUILIB_PYTHON_COMPATIBILITY
 CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height,
                                  const CLabelInfo& labelInfo, const CLabelInfo& labelInfo2,
                                  const CTextureInfo& textureButton, const CTextureInfo& textureButtonFocus,

--- a/xbmc/guilib/GUIListContainer.h
+++ b/xbmc/guilib/GUIListContainer.h
@@ -35,7 +35,7 @@ class CGUIListContainer : public CGUIBaseContainer
 {
 public:
   CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
-//#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
+//#ifdef GUILIB_PYTHON_COMPATIBILITY
   CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height,
                          const CLabelInfo& labelInfo, const CLabelInfo& labelInfo2,
                          const CTextureInfo& textureButton, const CTextureInfo& textureButtonFocus,

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -191,7 +191,7 @@ void CGUIListItemLayout::LoadLayout(TiXmlElement *layout, int context, bool focu
   m_height = std::max(1.0f, m_height);
 }
 
-//#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
+//#ifdef GUILIB_PYTHON_COMPATIBILITY
 void CGUIListItemLayout::CreateListControlLayouts(float width, float height, bool focused, const CLabelInfo &labelInfo, const CLabelInfo &labelInfo2, const CTextureInfo &texture, const CTextureInfo &textureFocus, float texHeight, float iconWidth, float iconHeight, const CStdString &nofocusCondition, const CStdString &focusCondition)
 {
   m_width = width;

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -45,7 +45,7 @@ public:
   void SetInvalid() { m_invalidated = true; };
   void FreeResources(bool immediately = false);
 
-//#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
+//#ifdef GUILIB_PYTHON_COMPATIBILITY
   void CreateListControlLayouts(float width, float height, bool focused, const CLabelInfo &labelInfo, const CLabelInfo &labelInfo2, const CTextureInfo &texture, const CTextureInfo &textureFocus, float texHeight, float iconWidth, float iconHeight, const CStdString &nofocusCondition, const CStdString &focusCondition);
 //#endif
 

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIListLabel.h"
 #include <limits>
+#include "addons/Skin.h"
 
 CGUIListLabel::CGUIListLabel(int parentID, int controlID, float posX, float posY, float width, float height, const CLabelInfo& labelInfo, const CGUIInfoLabel &info, bool alwaysScroll)
     : CGUIControl(parentID, controlID, posX, posY, width, height)
@@ -27,11 +28,13 @@ CGUIListLabel::CGUIListLabel(int parentID, int controlID, float posX, float posY
     , m_info(info)
 {
   m_alwaysScroll = alwaysScroll;
-  // TODO: Remove this "correction"
-  if (labelInfo.align & XBFONT_RIGHT)
-    m_label.SetMaxRect(m_posX - m_width, m_posY, m_width, m_height);
-  else if (labelInfo.align & XBFONT_CENTER_X)
-    m_label.SetMaxRect(m_posX - m_width*0.5f, m_posY, m_width, m_height);
+  if (g_SkinInfo && g_SkinInfo->APIVersion() < ADDON::AddonVersion("5.1.0"))
+  {
+    if (labelInfo.align & XBFONT_RIGHT)
+      m_label.SetMaxRect(m_posX - m_width, m_posY, m_width, m_height);
+    else if (labelInfo.align & XBFONT_CENTER_X)
+      m_label.SetMaxRect(m_posX - m_width*0.5f, m_posY, m_width, m_height);
+  }
   if (m_info.IsConstant())
     SetLabel(m_info.GetLabel(m_parentID, true));
   ControlType = GUICONTROL_LISTLABEL;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -26,9 +26,6 @@
 #include "GUIControlFactory.h"
 #include "GUIControlGroup.h"
 #include "GUIControlProfiler.h"
-#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
-#include "GUIEditControl.h"
-#endif
 
 #include "addons/Skin.h"
 #include "GUIInfoManager.h"
@@ -1001,26 +998,6 @@ void CGUIWindow::DumpTextureUse()
 #ifdef _DEBUG
   CLog::Log(LOGDEBUG, "%s for window %u", __FUNCTION__, GetID());
   CGUIControlGroup::DumpTextureUse();
-#endif
-}
-
-void CGUIWindow::ChangeButtonToEdit(int id, bool singleLabel /* = false*/)
-{
-#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
-  CGUIControl *name = GetControl(id);
-  if (name && name->GetControlType() == CGUIControl::GUICONTROL_BUTTON)
-  { // change it to an edit control
-    CGUIEditControl *edit = new CGUIEditControl(*(const CGUIButtonControl *)name);
-    if (edit)
-    {
-      if (singleLabel)
-        edit->SetLabel("");
-      InsertControl(edit, name);
-      RemoveControl(name);
-      name->FreeResources();
-      delete name;
-    }
-  }
 #endif
 }
 

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -232,10 +232,6 @@ protected:
 
   void LoadControl(TiXmlElement* pControl, CGUIControlGroup *pGroup, const CRect &rect);
 
-//#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
-  void ChangeButtonToEdit(int id, bool singleLabel = false);
-//#endif
-
   std::vector<int> m_idRange;
   OVERLAY_STATE m_overlayState;
   RESOLUTION_INFO m_coordsRes; // resolution that the window coordinates are in.

--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -129,8 +129,7 @@ std::map<std::string, CPythonInvoker::PythonModuleInitialization> CAddonPythonIn
 
 const char* CAddonPythonInvoker::getInitializationScript() const
 {
-  CStdString addonVer = ADDON::GetXbmcApiVersionDependency(m_addon);
   bool bwcompatMode = (m_addon.get() == NULL ||
-                       ADDON::AddonVersion(addonVer) <= ADDON::AddonVersion("1.0"));
+                       m_addon->GetDependencyVersion("xbmc.python") <= ADDON::AddonVersion("1.0"));
   return bwcompatMode ? RUNSCRIPT_BWCOMPATIBLE : RUNSCRIPT_COMPLIANT;
 }

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -538,12 +538,12 @@ void CPythonInvoker::onPythonModuleInitialization(void* moduleDict)
   PyObject *pyaddonid = PyString_FromString(m_addon->ID().c_str());
   PyDict_SetItemString(moduleDictionary, "__xbmcaddonid__", pyaddonid);
 
-  CStdString version = ADDON::GetXbmcApiVersionDependency(m_addon);
-  PyObject *pyxbmcapiversion = PyString_FromString(version.c_str());
+  ADDON::AddonVersion version = m_addon->GetDependencyVersion("xbmc.python");
+  PyObject *pyxbmcapiversion = PyString_FromString(version.asString().c_str());
   PyDict_SetItemString(moduleDictionary, "__xbmcapiversion__", pyxbmcapiversion);
 
   CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): instantiating addon using automatically obtained id of \"%s\" dependent on version %s of the xbmc.python api",
-            GetId(), m_sourceFile.c_str(), m_addon->ID().c_str(), version.c_str());
+            GetId(), m_sourceFile.c_str(), m_addon->ID().c_str(), version.asString().c_str());
 }
 
 void CPythonInvoker::onDeinitialization()

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -107,18 +107,6 @@ bool CGUIDialogNetworkSetup::ShowAndGetNetworkAddress(CStdString &path)
   return dialog->IsConfirmed();
 }
 
-void CGUIDialogNetworkSetup::OnWindowLoaded()
-{
-  // replace our buttons with edits
-  ChangeButtonToEdit(CONTROL_SERVER_ADDRESS);
-  ChangeButtonToEdit(CONTROL_REMOTE_PATH);
-  ChangeButtonToEdit(CONTROL_USERNAME);
-  ChangeButtonToEdit(CONTROL_PORT_NUMBER);
-  ChangeButtonToEdit(CONTROL_PASSWORD);
-
-  CGUIDialog::OnWindowLoaded();
-}
-
 void CGUIDialogNetworkSetup::OnInitWindow()
 {
   // start as unconfirmed

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -48,7 +48,6 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
-  virtual void OnWindowLoaded();
   virtual void OnDeinitWindow(int nextWindowID);
 
   static bool ShowAndGetNetworkAddress(CStdString &path);

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -25,8 +25,6 @@
 #define DECLARE_UNUSED(a,b) a __attribute__((unused)) b;
 #endif
 
-#define PRE_SKIN_VERSION_9_10_COMPATIBILITY 1
-
 /*****************
  * All platforms
  *****************/

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -26,7 +26,6 @@
 #endif
 
 #define PRE_SKIN_VERSION_9_10_COMPATIBILITY 1
-#define PRE_SKIN_VERSION_11_COMPATIBILITY 1
 
 /*****************
  * All platforms


### PR DESCRIPTION
This drops some old backward compatibility code for skins.  The aspect ratio change and label positioning changes are kept but are now switched based on the API version the skin requires, allowing a bit of time for skinners to adapt (the skins still work, but they look a bit odd in places).

I'm fairly sure no skin is using the old context menu stuff (context menu without a grouplist), so didn't bother with backward compatibility there.

@ronie, @BigNoid, @Black09, @JezzX please feel free to comment.  Confluence will need updating for the label change (labels in lists now have `<left>` meaning left) and the aspect ratio change (all images default to `stretch` now - before infoimages in lists defaulted to `keep`).

Closer to release of Helix we can decide whether to drop the backward compatibility completely or not.  e.g. if there's other, breaking changes made.
