### PR TITLE
Fix high cpu usage when minimized and rendering is required

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2200,8 +2200,10 @@ void CApplication::Render()
   // do not render if we are stopped or in background
   if (m_bStop)
     return;
-  if (m_bInBackground)
+  if (m_bInBackground){
     Sleep(100);
+    return;
+  }
 
   MEASURE_FUNCTION;
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2198,8 +2198,10 @@ float CApplication::GetDimScreenSaverLevel() const
 void CApplication::Render()
 {
   // do not render if we are stopped or in background
-  if (m_bStop || m_bInBackground)
+  if (m_bStop)
     return;
+  if (m_bInBackground)
+    Sleep(100);
 
   MEASURE_FUNCTION;
 


### PR DESCRIPTION
When there is a CGUIDialog shown like OSD or resume dialog and then you minimize the window there is a high cpu usage.
In CGUIDialog::DoModal_Internal there is an infinite loop with basically nothing to do.
Looks like its like this since https://github.com/xbmc/xbmc/commit/872d58c73dcb40f5f7bf71a2d1e4509e676f07e0
Don't know if this is the right way to fix it for xbmc, but it works.
