### PR TITLE
Introduce SWCodec - these are codecs that don't have any GPU accel

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -116,7 +116,7 @@ protected:
 
   std::string m_name;
   bool              m_bSoftware;
-  bool  m_isHi10p;
+  bool  m_isSWCodec;
   IHardwareDecoder *m_pHardware;
   int m_iLastKeyframe;
   double m_dts;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -180,7 +180,7 @@ void CAdvancedSettings::Initialize()
   m_stagefrightConfig.useInputDTS = false;
 
   m_videoDefaultLatency = 0.0;
-  m_videoDisableHi10pMultithreading = false;
+  m_videoDisableSWMultithreading = false;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -597,7 +597,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetFloat(pElement, "nonlinearstretchratio", m_videoNonLinStretchRatio, 0.01f, 1.0f);
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
-    XMLUtils::GetBoolean(pElement,"disablehi10pmultithreading",m_videoDisableHi10pMultithreading);
+    XMLUtils::GetBoolean(pElement,"disableswmultithreading",m_videoDisableSWMultithreading);
     XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
     XMLUtils::GetBoolean(pElement,"vdpauInvTelecine",m_videoVDPAUtelecine);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -192,7 +192,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_DXVANoDeintProcForProgressive;
     int  m_videoFpsDetect;
     int  m_videoBusyDialogDelay_ms;
-    bool m_videoDisableHi10pMultithreading;
+    bool m_videoDisableSWMultithreading;
     StagefrightConfig m_stagefrightConfig;
 
     CStdString m_videoDefaultPlayer;


### PR DESCRIPTION
This replaces the hi10p workaround by a more general swcodec flag. We can add more codecs at will. This is especially useful for the now integrated ffmpeg 2.2.x with hevc aka h265 support.

This was tested since months in the famous wsnipex fernetmenta-master ppa.
