### PR TITLE
ActiveAE: correct time of buffered samples by resample ratio

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -102,7 +102,7 @@ float CEngineStats::GetDelay(CActiveAEStream *stream)
   if (delay < 0)
     delay = 0.0;
 
-  delay += stream->m_bufferedTime;
+  delay += stream->m_bufferedTime / stream->m_streamResampleRatio;
   return delay;
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -58,6 +58,7 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat *format)
   m_forceResampler = false;
   m_remapper = NULL;
   m_remapBuffer = NULL;
+  m_streamResampleRatio = 1.0;
 }
 
 CActiveAEStream::~CActiveAEStream()


### PR DESCRIPTION
As proxy for @fernetmenta who is currently busy with X11 stuff - we don't want to miss that for gotham.
