### PR TITLE
[fix] only check video playlist status to determine fullscreen playback

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4043,7 +4043,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   // this really aught to be inside !bRestart, but since PlayStack
   // uses that to init playback, we have to keep it outside
   int playlist = g_playlistPlayer.GetCurrentPlaylist();
-  if (item.IsVideo() && g_playlistPlayer.GetPlaylist(playlist).size() > 1)
+  if (item.IsVideo() && playlist == PLAYLIST_VIDEO && g_playlistPlayer.GetPlaylist(playlist).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
     options.fullscreen = !g_playlistPlayer.HasPlayedFirstFile() && g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::Get().DoesVideoStartWindowed();


### PR DESCRIPTION
as reported here: http://trac.xbmc.org/ticket/15163

the underlying issue is that the logic confuses the current playlist (in case of the reported issue, the music playlist) with the video playlist to determine the full screen playback status. The logic was supposed to assume that the current playlist is the video playlist, so adding the explicit test.

@jmarshallnz - this is also a Gotham fix!!
