### PR TITLE
FIX resume playing PVR recordings from the exact lastplayed position

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4004,8 +4004,8 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
          should the playerState be required, it is fetched from the database.
          See the note in CGUIWindowVideoBase::ShowResumeMenu.
          */
-        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_resumePoint.IsSet())
-          options.starttime = item.GetVideoInfoTag()->m_resumePoint.timeInSeconds;
+        if (item.IsResumePointSet())
+          options.starttime = item.GetCurrentResumeTime();
       }
       else if (item.HasVideoInfoTag())
       {

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3320,18 +3320,26 @@ int CFileItem::GetVideoContentType() const
   return type;
 }
 
-
 bool CFileItem::IsResumePointSet() const
 {
-  return (HasVideoInfoTag() && GetVideoInfoTag()->m_resumePoint.IsSet());
+  return (HasVideoInfoTag() && GetVideoInfoTag()->m_resumePoint.IsSet()) ||
+      (HasPVRRecordingInfoTag() && GetPVRRecordingInfoTag()->GetLastPlayedPosition() > 0);
 }
 
 double CFileItem::GetCurrentResumeTime() const
 {
+  if (HasPVRRecordingInfoTag())
+  {
+    // This will retrieve 'fresh' resume information from the PVR server
+    int rc = GetPVRRecordingInfoTag()->GetLastPlayedPosition();
+    if (rc > 0)
+      return rc;
+    // Fall through to default value
+  }
   if (HasVideoInfoTag() && GetVideoInfoTag()->m_resumePoint.IsSet())
   {
     return GetVideoInfoTag()->m_resumePoint.timeInSeconds;
   }
-  // Resume from start when resume point is invalid
+  // Resume from start when resume points are invalid or the PVR server returns an error
   return 0;
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3320,3 +3320,18 @@ int CFileItem::GetVideoContentType() const
   return type;
 }
 
+
+bool CFileItem::IsResumePointSet() const
+{
+  return (HasVideoInfoTag() && GetVideoInfoTag()->m_resumePoint.IsSet());
+}
+
+double CFileItem::GetCurrentResumeTime() const
+{
+  if (HasVideoInfoTag() && GetVideoInfoTag()->m_resumePoint.IsSet())
+  {
+    return GetVideoInfoTag()->m_resumePoint.timeInSeconds;
+  }
+  // Resume from start when resume point is invalid
+  return 0;
+}

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -295,6 +295,18 @@ public:
     return m_pvrTimerInfoTag;
   }
 
+  /*!
+   \brief Test if this item has a valid resume point set.
+   \return True if this item has a resume point and it is set, false otherwise.
+   */
+  bool IsResumePointSet() const;
+
+  /*!
+   \brief Return the current resume time.
+   \return The time in seconds from the start to resume playing from.
+   */
+  double GetCurrentResumeTime() const;
+
   inline bool HasPictureInfoTag() const
   {
     return m_pictureInfoTag != NULL;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -70,21 +70,8 @@ CStdString CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
 
     // First try to find the resume position on the back-end, if that fails use video database
     int positionInSeconds = item.GetPVRRecordingInfoTag()->GetLastPlayedPosition();
-    // If the back-end does report a saved position then make sure there is a corresponding resume bookmark
-    if (positionInSeconds > 0)
-    {
-      CBookmark bookmark;
-      bookmark.timeInSeconds = positionInSeconds;
-      bookmark.totalTimeInSeconds = (double)item.GetPVRRecordingInfoTag()->GetDuration();
-      CVideoDatabase db;
-      if (db.Open())
-      {
-        CStdString itemPath(item.GetPVRRecordingInfoTag()->m_strFileNameAndPath);
-        db.AddBookMarkToFile(itemPath, bookmark, CBookmark::RESUME);
-        db.Close();
-      }
-    }
-    else if (positionInSeconds < 0)
+    // If the back-end does report a saved position it will be picked up by FileItem
+    if (positionInSeconds < 0)
     {
       CVideoDatabase db;
       if (db.Open())


### PR DESCRIPTION
 on PVR Servers that support the get/set lastplayedposition API

@opdenkamp 

Lars, I've found an annoying bug on RC1 that breaks resuming PVR recordings on PVR servers that support the get/set lastplayedposition PVR API:
- In CGUIWindowPVRRecording::GetResumeString, there is a check if 'lastplayedposition' is supported by the PVR server;
- If the PVR supports lastplayedposition, then the last played position is retrieved from the PVR server and a RESUME bookmark is addd to the video database for this fileitem

**However**
- When the file is played via CApplication::PlayFile, this method first retrieves the RESUME bookmark from the database (see xbmc/Application.cpp line 3990) to set the options.starttime....
- Then the fileitem is checked to see if it has a VideoInfoTag and the resumePoint is set in that tag (xbmc/Application.cpp line 4001), if so then the options.starttime is overwritten
- This causes the options.starttime to be **never** equal to the position retrieved by the GetLastPlayedPosition API

This PR has a slightly changed implementation of CGUIWindowPVRRecording::GetResumeString that will update the m_resumePoint with the new resume position retrieved by GetLastPlayedPosition.

To minimise impact this method has now been made private to this class.

Please let me know any omissions, errors, oversights and I will update, squash and re-base accordingly.

Kind regards,
Fred
