### PR TITLE
[fix] make sure video playlist is empty and current when starting video disc

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -175,14 +175,18 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
           CStdString path = URIUtils::AddFileToFolder(pItem->GetPath(), "VIDEO_TS.IFO");
           if(!CFile::Exists(path))
             path = URIUtils::AddFileToFolder(pItem->GetPath(), "video_ts.ifo");
-          CFileItem item(path, false);
-          item.SetLabel(g_mediaManager.GetDiskLabel(strDrive));
-          item.GetVideoInfoTag()->m_strFileNameAndPath = g_mediaManager.GetDiskUniqueId(strDrive);
+          CFileItemPtr item(new CFileItem(path, false));
+          item->SetLabel(g_mediaManager.GetDiskLabel(strDrive));
+          item->GetVideoInfoTag()->m_strFileNameAndPath = g_mediaManager.GetDiskUniqueId(strDrive);
 
-          if (!startFromBeginning && !item.GetVideoInfoTag()->m_strFileNameAndPath.empty())
-            item.m_lStartOffset = STARTOFFSET_RESUME;
+          if (!startFromBeginning && !item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
+            item->m_lStartOffset = STARTOFFSET_RESUME;
 
-          g_application.PlayFile(item, false);
+          g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
+          g_playlistPlayer.SetShuffle (PLAYLIST_VIDEO, false);
+          g_playlistPlayer.Add(PLAYLIST_VIDEO, item);
+          g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
+          g_playlistPlayer.Play(0);
           return true;
         }
 
@@ -192,14 +196,18 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
         if (name.Equals("BDMV") && bAllowVideo
         && (bypassSettings || CSettings::Get().GetBool("dvds.autorun")))
         {
-          CFileItem item(URIUtils::AddFileToFolder(pItem->GetPath(), "index.bdmv"), false);
-          item.SetLabel(g_mediaManager.GetDiskLabel(strDrive));
-          item.GetVideoInfoTag()->m_strFileNameAndPath = g_mediaManager.GetDiskUniqueId(strDrive);
+          CFileItemPtr item(new CFileItem(URIUtils::AddFileToFolder(pItem->GetPath(), "index.bdmv"), false));
+          item->SetLabel(g_mediaManager.GetDiskLabel(strDrive));
+          item->GetVideoInfoTag()->m_strFileNameAndPath = g_mediaManager.GetDiskUniqueId(strDrive);
 
-          if (!startFromBeginning && !item.GetVideoInfoTag()->m_strFileNameAndPath.empty())
-            item.m_lStartOffset = STARTOFFSET_RESUME;
+          if (!startFromBeginning && !item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
+            item->m_lStartOffset = STARTOFFSET_RESUME;
 
-          g_application.PlayFile(item, false);
+          g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
+          g_playlistPlayer.SetShuffle (PLAYLIST_VIDEO, false);
+          g_playlistPlayer.Add(PLAYLIST_VIDEO, item);
+          g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
+          g_playlistPlayer.Play(0);
           return true;
         }
 


### PR DESCRIPTION
as reported here: http://trac.xbmc.org/ticket/15163

this ticket required an additional fix to make sure that media disc playback properly (re)sets the video playlist and makes it current. The problem was that while playing the video, the active playlist was still the music playlist, so that "next item" suddenly started a music item again.

The old call to g_application.PlayFile() has been replaced by playlist calls more appropriately in line with how the rest of xbmc does this.

@jmarshallnz - also a Gotham fix.
