### PR TITLE
VDPAU: improve error handling (ffmpeg 2.2)

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -608,6 +608,7 @@ protected:
   } m_DisplayState;
   CCriticalSection m_DecoderSection;
   CEvent         m_DisplayEvent;
+  int m_ErrorCount;
 
   ThreadIdentifier m_decoderThread;
   bool          m_vdpauConfigured;


### PR DESCRIPTION
With ffmpeg bump interface to vdpau changed to pure hwaccel which calls actual decoding earlier. In particular when playing live TV it may happen that decoder is called with invalid data. This change allows two errors in a row before decoder resources are cleared down.

Fixes continuous close/reopen of vdpau on corrupted tv streams. @joethefox could you test this with your setup please.
