### PR TITLE
[build] enable gtest configure by default.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -531,9 +531,9 @@ AC_ARG_ENABLE([player],
 
 AC_ARG_ENABLE([gtest],
   [AS_HELP_STRING([--enable-gtest],
-  [configure Google Test Framework (default is no)])],
+  [configure Google Test Framework (default is yes)])],
   [configure_gtest=$enableval],
-  [configure_gtest=no])
+  [configure_gtest=yes])
 
 AC_ARG_ENABLE([codec],
   [AS_HELP_STRING([--enable-codec],


### PR DESCRIPTION
@wsnipex, @t-nelson, @davilla, @wsoltys etc.

It would be nice to have gtest configured by default so we can actually regression test stuff.

This works, but may well need finessing?
