### PR TITLE
Linking fix [fixes #15139]

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -481,7 +481,7 @@ FFMPEGOBJS = lib/ffmpeg/libavcodec/libavcodec.a \
              lib/ffmpeg/libpostproc/libpostproc.a \
              lib/ffmpeg/libswscale/libswscale.a
 DYNOBJSXBMC+= $(FFMPEGOBJS)
-LIBS+= @GNUTLS_ALL_LIBS@ @VORBISENC_ALL_LIBS@
+LIBS+= @GNUTLS_ALL_LIBS@ @VORBISENC_ALL_LIBS@ @HOGWEED_ALL_LIBS@
 
 $(FFMPEGOBJS): dvdpcodecs
 endif

--- a/configure.in
+++ b/configure.in
@@ -880,6 +880,7 @@ if test "$use_static_ffmpeg" = "yes"; then
   # ffmpeg may depend on gnutls and vorbisenc, we add those libs at the end of linker
   # command in order to resolve any missing symbols
   GNUTLS_ALL_LIBS=`${PKG_CONFIG} --static --libs-only-l --silence-errors gnutls`
+  HOGWEED_ALL_LIBS=`${PKG_CONFIG} --static --libs-only-l --silence-errors hogweed nettle`
   VORBISENC_ALL_LIBS=`${PKG_CONFIG} --static --libs-only-l --silence-errors vorbisenc`
 fi 
 
@@ -1530,7 +1531,9 @@ fi
 if test "$use_librtmp" != "no"; then
   PKG_CHECK_MODULES([LIBRTMP], [librtmp],
     [INCLUDES="$INCLUDES $LIBRTMP_CFLAGS"; LIBS="$LIBS $LIBRTMP_LIBS";
-      AC_DEFINE([HAS_LIBRTMP], [1], [Whether to use libRTMP library.])],
+      AC_DEFINE([HAS_LIBRTMP], [1], [Whether to use libRTMP library.])
+      RTMP_ALL_LIBS=$(${PKG_CONFIG} --static --libs-only-l --silence-errors librtmp)
+      test "$use_static_ffmpeg" = "yes" && LIBS="$LIBS $RTMP_ALL_LIBS"],
     [AC_CHECK_HEADERS([librtmp/log.h librtmp/amf.h librtmp/rtmp.h],,
       [if test "$use_librtmp" = "yes"; then
         AC_MSG_ERROR($librtmp_not_found)
@@ -2671,6 +2674,7 @@ AC_SUBST(GTEST_CONFIGURED)
 AC_SUBST(USE_DOXYGEN)
 AC_SUBST(USE_PVR_ADDONS)
 AC_SUBST(GNUTLS_ALL_LIBS)
+AC_SUBST(HOGWEED_ALL_LIBS)
 AC_SUBST(VORBISENC_ALL_LIBS)
 
 # pushd and popd are not available in other shells besides bash, so implement

--- a/configure.in
+++ b/configure.in
@@ -1528,20 +1528,24 @@ fi
 
 # libRTMP
 if test "$use_librtmp" != "no"; then
-  AC_CHECK_HEADERS([librtmp/log.h librtmp/amf.h librtmp/rtmp.h],,
-   [if test "$use_librtmp" = "yes"; then
-      AC_MSG_ERROR($librtmp_not_found)
-    elif test "$use_librtmp" != "no"; then
-      AC_MSG_NOTICE($librtmp_not_found)
-      use_librtmp="no"
-    fi
-   ])
-  if test "$use_librtmp" != "no"; then
-    XB_FIND_SONAME([RTMP], [rtmp], [use_librtmp])
-  fi
-  if test "$use_librtmp" != "no"; then
-    AC_DEFINE([HAS_LIBRTMP], [1], [Whether to use libRTMP library.])
-  fi
+  PKG_CHECK_MODULES([LIBRTMP], [librtmp],
+    [INCLUDES="$INCLUDES $LIBRTMP_CFLAGS"; LIBS="$LIBS $LIBRTMP_LIBS";
+      AC_DEFINE([HAS_LIBRTMP], [1], [Whether to use libRTMP library.])],
+    [AC_CHECK_HEADERS([librtmp/log.h librtmp/amf.h librtmp/rtmp.h],,
+      [if test "$use_librtmp" = "yes"; then
+        AC_MSG_ERROR($librtmp_not_found)
+      elif test "$use_librtmp" != "no"; then
+        AC_MSG_NOTICE($librtmp_not_found)
+        use_librtmp="no"
+      fi
+      ])
+      if test "$use_librtmp" != "no"; then
+        XB_FIND_SONAME([RTMP], [rtmp], [use_librtmp])
+      fi
+      if test "$use_librtmp" != "no"; then
+        AC_DEFINE([HAS_LIBRTMP], [1], [Whether to use libRTMP library.])
+      fi
+    ])
 else
   AC_MSG_NOTICE($librtmp_disabled)
 fi


### PR DESCRIPTION
Gotham build is currently broken on debian >=testing as well as other "bleeding edge" distros due to linking ffmpeg statically. To fix it we must make sure to link against all libs ffmpeg linked against.
Newer rtmp versions require nettle/hogweed and some other stuff that we don't check for.
Its a bit finicky to get that right, as we can't ask ffmpegs pkg-config files like we do on master since ffmpeg2

@t-nelson @jmarshall this really should go in before relase
