### PR TITLE
VDPAU: fix segfault if vdpau fails to open context

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -134,6 +134,7 @@ bool CVDPAUContext::EnsureContext(CVDPAUContext **ctx)
     {
       delete m_context;
       m_context = 0;
+      *ctx = NULL;
       return false;
     }
   }


### PR DESCRIPTION
fix segfault if vdpau fails to open i.e. due to missing libvdpau
