### PR TITLE
paplayer: fix mp4 playback

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -91,7 +91,7 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
   if (m_pFile->GetImplemenation() && (content.empty() || content == "application/octet-stream"))
     m_content = m_pFile->GetImplemenation()->GetContent();
 
-  m_eof = true;
+  m_eof = false;
   return true;
 }
 

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -197,8 +197,6 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
   m_bCanSeek = false;
   if (m_pInputStream->Seek(0, SEEK_POSSIBLE))
   {
-    // reset eof flag of stream, with eof set seek returns always success
-    m_pInputStream->Seek(0, SEEK_SET);
     if (Seek(1) != DVD_NOPTS_VALUE)
     {
       // rewind stream to beginning


### PR DESCRIPTION
with the AirPlay fix I reverted the eof change in input stream which tuned out NOT to be responsible for broken YouTube app vie AirPLay https://github.com/quasar1/boxeebox-xbmc/commit/246d78614ead21795ae1abe3cc1151f004e5105f#commitcomment-6191602

paplayer needs to detect if a seek is possible. the alternative method of resetting the flag by seekin the input stream directly made mp4 files fail.
- tested Airplay with iTunes
- tested flac
- wma losless (not seekable)
- mp4
- mp3
- ac3
- dts
- ogg
- wav

@da-anda could you verify please
