### PR TITLE
Allow restart of a PVR addon while it is still creating

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -203,7 +203,7 @@ bool CPVRClients::StopClient(AddonPtr client, bool bRestart)
   CSingleLock lock(m_critSection);  
   int iId = GetClientId(client);
   PVR_CLIENT mappedClient;
-  if (GetConnectedClient(iId, mappedClient))
+  if (GetClient(iId, mappedClient))
   {
     if (bRestart)
       mappedClient->ReCreate();


### PR DESCRIPTION
There's an native addon status ADDON_STATUS_NEED_SETTINGS that means that the addon needs some settings to be set before it will become usable. If ADDON_Create() returns the ADDON_STATUS_NEED_SETTINGS status code and then ADDON_SetSetting() return the same status, XBMC will present the addon settings dialog so the user can enter the missing setting values.

After the user closes the settings dialog XBMC saves settings and requests a restart of the addon (see CAddonStatusHandler::Process()):
    m_addon->SaveSettings();
    CAddonMgr::Get().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);

But because of an issue in CPVRClients::StopClient(AddonPtr client, bool bRestart) the addon is not restarted and continues running. This commit fixes the issue.

See also this thread of the XBMC forum for discussion of this issue: http://forum.xbmc.org/showthread.php?tid=193750
