### PR TITLE
json-rpc: auto-generate xbmc.json/addon.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ config.log
 /addons/visualization.fishbmc/fishbmc.vis
 /addons/script.module.pil/
 /addons/pvr.*
+/addons/xbmc.json/addon.xml
 
 # /lib/
 /lib/Makefile

--- a/addons/xbmc.json/addon.xml.in
+++ b/addons/xbmc.json/addon.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.json" version="6.15.2" provider-name="Team XBMC">
+<addon id="xbmc.json" version="@jsonrpc_version@" provider-name="Team XBMC">
   <backwards-compatibility abi="6.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/codegenerator.mk
+++ b/codegenerator.mk
@@ -18,7 +18,7 @@ else
 DOXY_XML_PATH=$(GENDIR)/doxygenxml
 endif
 
-GENERATED_JSON = $(INTERFACES_DIR)/json-rpc/ServiceDescription.h
+GENERATED_JSON = $(INTERFACES_DIR)/json-rpc/ServiceDescription.h addons/xbmc.json/addon.xml
 ifeq ($(wildcard $(JSON_BUILDER)),)
   JSON_BUILDER = $(shell which JsonSchemaBuilder)
 ifeq ($(JSON_BUILDER),)
@@ -51,7 +51,7 @@ $(GENDIR)/%.xml: %.i $(SWIG) $(JAVA) $(GENERATE_DEPS)
 	mkdir -p $(GENDIR)
 	$(SWIG) -w401 -c++ -o $@ -xml -I$(TOPDIR)/xbmc -xmllang python $<
 
-codegenerated: $(DOXYGEN) $(SWIG) $(JAVA) $(GENERATED) $(GENERATED_JSON)
+codegenerated: $(DOXYGEN) $(SWIG) $(JAVA) $(GENERATED) $(GENERATED_JSON) $(GENERATED_ADDON_JSON)
 
 $(DOXY_XML_PATH): $(SWIG) $(JAVA)
 	cd $(INTERFACES_DIR)/python; ($(DOXYGEN) Doxyfile > /dev/null) 2>&1 | grep -v " warning: "

--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -9,7 +9,7 @@ boost-1.46.1-headers-win32.7z
 dnssd-541-win32.zip
 doxygen-1.8.2-win32.7z
 gnutls-3.2.3-win32.zip
-jsonschemabuilder-1.0.0-win32-2.7z
+jsonschemabuilder-1.0.0-win32-3.7z
 lame_enc-3.99.5-win32.7z
 libass-0.10.2-win32.7z
 libbluray-0.4.0-win32.zip

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -2914,17 +2914,17 @@
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\xbmc\interfaces\json-rpc\schema\license.txt">
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
@@ -2932,17 +2932,17 @@
     </CustomBuild>
     <CustomBuild Include="..\..\xbmc\interfaces\json-rpc\schema\methods.json">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
@@ -2950,17 +2950,17 @@
     </CustomBuild>
     <CustomBuild Include="..\..\xbmc\interfaces\json-rpc\schema\notifications.json">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
@@ -2968,34 +2968,34 @@
     </CustomBuild>
     <CustomBuild Include="..\..\xbmc\interfaces\json-rpc\schema\types.json">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\..\xbmc\interfaces\json-rpc\schema\version.txt">
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">Generating ServiceDescription.h for JSON-RPC API</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\BuildDependencies\bin\json-rpc\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release (OpenGL)|Win32'">CALL ..\..\tools\windows\JsonSchemaBuilder.bat</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">%(RelativeDir)..\ServiceDescription.h</Outputs>

--- a/tools/windows/JsonSchemaBuilder.bat
+++ b/tools/windows/JsonSchemaBuilder.bat
@@ -3,10 +3,18 @@
 SET cur_dir=%CD%
 
 SET base_dir=%cur_dir%\..\..
-SET bin_dir=%cur_dir%\..\BuildDependencies\bin\json-rpc
+SET builddeps_dir=%cur_dir%\..\BuildDependencies
+SET bin_dir=%builddeps_dir%\bin
+SET msys_bin_dir=%builddeps_dir%\msys\bin
 SET jsonrpc_path=%base_dir%\xbmc\interfaces\json-rpc
 SET jsonrpc_schema_path=%jsonrpc_path%\schema
-SET output=ServiceDescription.h
+SET jsonrpc_output=ServiceDescription.h
 
-"%bin_dir%\JsonSchemaBuilder.exe" "%jsonrpc_schema_path%\version.txt" "%jsonrpc_schema_path%\license.txt" "%jsonrpc_schema_path%\methods.json" "%jsonrpc_schema_path%\types.json" "%jsonrpc_schema_path%\notifications.json"
-MOVE /Y %output% "%jsonrpc_path%\%output%"
+SET xbmc_json_path=%base_Dir%\addons\xbmc.json
+SET xbmc_json_output=addon.xml
+
+SET /p version=<"%jsonrpc_schema_path%\version.txt"
+"%msys_bin_dir%\sed.exe" s/@jsonrpc_version@/%version%/g "%xbmc_json_path%\%xbmc_json_output%.in" > "%xbmc_json_path%\%xbmc_json_output%"
+
+"%bin_dir%\json-rpc\JsonSchemaBuilder.exe" "%jsonrpc_schema_path%\version.txt" "%jsonrpc_schema_path%\license.txt" "%jsonrpc_schema_path%\methods.json" "%jsonrpc_schema_path%\types.json" "%jsonrpc_schema_path%\notifications.json"
+MOVE /Y %jsonrpc_output% "%jsonrpc_path%\%jsonrpc_output%"

--- a/tools/windows/JsonSchemaBuilder.bat
+++ b/tools/windows/JsonSchemaBuilder.bat
@@ -1,0 +1,12 @@
+@ECHO OFF
+
+SET cur_dir=%CD%
+
+SET base_dir=%cur_dir%\..\..
+SET bin_dir=%cur_dir%\..\BuildDependencies\bin\json-rpc
+SET jsonrpc_path=%base_dir%\xbmc\interfaces\json-rpc
+SET jsonrpc_schema_path=%jsonrpc_path%\schema
+SET output=ServiceDescription.h
+
+"%bin_dir%\JsonSchemaBuilder.exe" "%jsonrpc_schema_path%\version.txt" "%jsonrpc_schema_path%\license.txt" "%jsonrpc_schema_path%\methods.json" "%jsonrpc_schema_path%\types.json" "%jsonrpc_schema_path%\notifications.json"
+MOVE /Y %output% "%jsonrpc_path%\%output%"

--- a/xbmc/interfaces/json-rpc/Makefile
+++ b/xbmc/interfaces/json-rpc/Makefile
@@ -21,9 +21,11 @@ SRCS=AddonsOperations.cpp \
 LIB=json-rpc.a
 
 GENERATED_JSON = ServiceDescription.h
-JSON_SRC =  schema/version.txt schema/license.txt schema/methods.json schema/types.json schema/notifications.json
+GENERATED_ADDON_JSON = ../../../addons/xbmc.json/addon.xml
+JSON_VERSION_SRC = schema/version.txt
+JSON_SRC =  $(JSON_VERSION_SRC) schema/license.txt schema/methods.json schema/types.json schema/notifications.json
 
-all: $(GENERATED_JSON) $(LIB)
+all: $(GENERATED_JSON) $(GENERATED_ADDON_JSON) $(LIB)
 
 -include ../../../Makefile.include
 ifeq ($(wildcard $(JSON_BUILDER)),)
@@ -32,5 +34,11 @@ endif
 
 $(GENERATED_JSON): $(JSON_SRC)
 	$(JSON_BUILDER) $(JSON_SRC)
+
+.PHONY: $(notdir $(GENERATED_ADDON_JSON))
+$(notdir $(GENERATED_ADDON_JSON)): $(GENERATED_ADDON_JSON)
+
+$(GENERATED_ADDON_JSON): $(JSON_VERSION_SRC)
+	sed s/@jsonrpc_version@/`cat $(JSON_VERSION_SRC)`/g $@.in > $@
 
 -include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))


### PR DESCRIPTION
Now that we auto-generate the JSON-RPC API schema during bootstrap/build I figured we could extend that logic to also auto-generate the addon.xml of the xbmc.json extension point which currently needs manual updating with the updated version of the JSON-RPC API (and which I and others forget almost all the time).

I've testd this with jenkins (see http://jenkins.xbmc.org/view/All/job/XBMC-BuildMulti-All/159/) and it works on all platforms but for linux et al. I've pretty much hacked this into the codegenerator.mk and I'm very unhappy with the implementation (specifically the unintuitive path to addon.xml passed into the json-rpc Makefile as a build target) of the $(GENERATED_ADDON_JSON) target in codegenerator.mk so maybe @wsnipex or someone else has a better approach/idea.
