### PR TITLE
demuxer ffmpeg, workaround for broken probing of flac format

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -274,6 +274,8 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
       iformat = m_dllAvFormat.av_find_input_format("mpegts");
     else if( content.compare("multipart/x-mixed-replace") == 0 )
       iformat = m_dllAvFormat.av_find_input_format("mjpeg");
+    else if( content.compare("audio/flac") == 0 )
+      iformat = m_dllAvFormat.av_find_input_format("flac");
   }
 
   // open the demuxer


### PR DESCRIPTION
fixes broken playback of some flac files with video content. master with ffmpeg 2 is not afected
