### PR TITLE
fix broken comparisons

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -83,7 +83,7 @@ void CAutorun::ExecuteAutorun(const CStdString& path, bool bypassSettings, bool 
 
 bool CAutorun::PlayDisc(const CStdString& path, bool bypassSettings, bool startFromBeginning)
 {
-  if ( !bypassSettings && !CSettings::Get().GetInt("audiocds.autoaction") == AUTOCD_PLAY && !CSettings::Get().GetBool("dvds.autorun"))
+  if ( !bypassSettings && CSettings::Get().GetInt("audiocds.autoaction") != AUTOCD_PLAY && !CSettings::Get().GetBool("dvds.autorun"))
     return false;
 
   int nSize = g_playlistPlayer.GetPlaylist( PLAYLIST_MUSIC ).size();

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -160,7 +160,7 @@ namespace XBMCAddon
       if (!shares) 
         throw WindowException("Error: GetSources given %s is NULL.",s_shares.c_str());
 
-      if (useFileDirectories && (!maskparam.empty() && maskparam.size() != 0))
+      if (useFileDirectories && !maskparam.empty())
         mask += "|.rar|.zip";
 
       value = defaultt;
@@ -184,7 +184,7 @@ namespace XBMCAddon
       if (!shares) 
         throw WindowException("Error: GetSources given %s is NULL.",s_shares.c_str());
 
-      if (useFileDirectories && (!lmask.empty() && !(lmask.size() == 0)))
+      if (useFileDirectories && !lmask.empty())
         lmask += "|.rar|.zip";
 
       if (type == 1)

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -160,7 +160,7 @@ namespace XBMCAddon
       if (!shares) 
         throw WindowException("Error: GetSources given %s is NULL.",s_shares.c_str());
 
-      if (useFileDirectories && (!maskparam.empty() && !maskparam.size() == 0))
+      if (useFileDirectories && (!maskparam.empty() && maskparam.size() != 0))
         mask += "|.rar|.zip";
 
       value = defaultt;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -533,7 +533,7 @@ bool CGUIControlButtonSetting::OnClick()
       // prompt for the addon
       CSettingAddon *setting = (CSettingAddon *)m_pSetting;
       CStdString addonID = setting->GetValue();
-      if (!CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonID, setting->AllowEmpty()) == 1)
+      if (CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonID, setting->AllowEmpty()) != 1)
         return false;
 
       SetValid(setting->SetValue(addonID));


### PR DESCRIPTION
These are fixes for three broken comparisons taken from https://github.com/notspiff/xbmc-cmake/commit/f66398523382bae1d6c46eafba2a8e738a3f57fe (thanks @notspiff). I didn't cherry-pick the original commit because I've stopped an additional simplification/optimization in it.

They might be harmless enough for 13.x.
