### PR TITLE
[fixed] Fullscreen lost on alt-tab with non-masterprofile

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -50,6 +50,7 @@ using namespace std;
 CAdvancedSettings::CAdvancedSettings()
 {
   m_initialized = false;
+  m_fullScreen = false;
 }
 
 void CAdvancedSettings::OnSettingsLoaded()
@@ -325,7 +326,7 @@ void CAdvancedSettings::Initialize()
   m_curlDisableIPV6 = false;      //Certain hardware/OS combinations have trouble
                                   //with ipv6.
 
-  m_fullScreen = m_startFullScreen = false;
+  m_startFullScreen = false;
   m_showExitButton = true;
   m_splashImage = true;
 


### PR DESCRIPTION
g_advancedSettings.m_fullScreen is calculated in CGraphicContext::SetVideoResolution(). It should not be reinitialized on a profile change; this led to losing fullscreen status and switching to windowed mode on window resize events like alt-tab between XBMC and desktop with the non-masterprofile user.
