### PR TITLE
[settings]: fix video -> dvd visibility when built with --disable-optica...

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -968,6 +968,7 @@
       </group>
     </category>
     <category id="dvds" label="14087" help="36193">
+      <requirement>HAS_DVD_DRIVE</requirement>
       <group id="1">
         <setting id="dvds.autorun" type="boolean" label="14088" help="36194">
           <level>0</level>

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -182,6 +182,9 @@ void CSettingConditions::Initialize()
 
   // add simple conditions
   m_simpleConditions.insert("true");
+#ifdef HAS_DVD_DRIVE
+  m_simpleConditions.insert("has_dvd_drive");
+#endif
 #ifdef HAS_UPNP
   m_simpleConditions.insert("has_upnp");
 #endif


### PR DESCRIPTION
...l-drive

as title says, cosmetics, nothing really important but nice to have
/cc @Montellese
