### PR TITLE
AESinkPULSE: Start stream corked. Resume when starting to add packets

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -51,12 +51,13 @@ public:
   bool IsInitialized();
   CCriticalSection m_sec;
 private:
-  bool Pause(bool pause);
+  void Pause(bool pause);
   static inline bool WaitForOperation(pa_operation *op, pa_threaded_mainloop *mainloop, const char *LogEntry);
   static bool SetupContext(const char *host, pa_context **context, pa_threaded_mainloop **mainloop);
 
   bool m_IsAllocated;
   bool m_passthrough;
+  bool m_IsStreamPaused;
 
   AEAudioFormat m_format;
   unsigned int m_BytesPerSecond;


### PR DESCRIPTION
This should make some AVRs work, when after creating the stream we get an underrun, cause of the time between creating and start of adding packets.
