### PR TITLE
build: make bootstrap script fail properly on failure

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,3 +1,3 @@
 #!/bin/sh
-BOOTSTRAP_STANDALONE=1 make -f bootstrap.mk
+BOOTSTRAP_STANDALONE=1 make -f bootstrap.mk &&
 BOOTSTRAP_STANDALONE=1 make -f codegenerator.mk


### PR DESCRIPTION
If the first command in the bootstrap script fails, exit with non-zero
exit status instead of silently continuing to the next command.
