### PR TITLE
Seconds to hours

### DIFF
--- a/xbmc/utils/StringValidation.cpp
+++ b/xbmc/utils/StringValidation.cpp
@@ -46,14 +46,16 @@ bool StringValidation::IsTime(const std::string &input, void *data)
   }
   else
   {
-    size_t pos = strTime.find(":");
-    // if there's no ":", the value must be in seconds only
-    if (pos == std::string::npos)
-      return IsPositiveInteger(strTime, NULL);
+    // support [[HH:]MM:]SS
+    std::vector<std::string> bits = StringUtils::Split(input, ":");
+    if (bits.size() > 3)
+      return false;
 
-    std::string strMin = StringUtils::Left(strTime, pos);
-    std::string strSec = StringUtils::Mid(strTime, pos + 1);
-    return IsPositiveInteger(strMin, NULL) && IsPositiveInteger(strSec, NULL);
+    for (std::vector<std::string>::const_iterator i = bits.begin(); i != bits.end(); ++i)
+      if (!IsPositiveInteger(*i, NULL))
+        return false;
+
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
Currently duration in smartplaylists is limited to 99:59 in the UI.  It's stored as seconds, so this isn't long enough for most movies.

This changes the INPUT_TYPE_SECONDS mode of the numeric dialog to input HH:MM:SS.  It's not used anywhere other than for time fields in smartplaylists, so should be quite safe, even for Gotham.

Further, it alters the string validator IsTime() to support both HH:MM:SS and MM:SS (and SS).  Note there's no validation on MM and SS being less than 60 in the former two (there wasn't before either) though this could be added if we like?

@Montellese please review.
@t-nelson flagged for Gotham.X
