### PR TITLE
[tvshows] don't set scraper if we find a tvshow.nfo file.

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -497,13 +497,6 @@ namespace VIDEO
     // handle .nfo files
     if (useLocal)
       result = CheckForNFOFile(pItem, bDirNames, info2, scrUrl);
-    if (result != CNfoFile::NO_NFO && result != CNfoFile::ERROR_NFO)
-    { // check for preconfigured scraper; if found, overwrite with interpreted scraper (from Nfofile)
-      // but keep current scan settings
-      SScanSettings settings;
-      if (m_database.GetScraperForPath(pItem->GetPath(), settings))
-        m_database.SetScraperForPath(pItem->GetPath(), info2, settings);
-    }
     if (result == CNfoFile::FULL_NFO)
     {
       pItem->GetVideoInfoTag()->Reset();


### PR DESCRIPTION
This is some long-standing code (since tvshows were first added in r12462).

I don't see any need to set the scraper based on the .nfo file at the show level - in all cases (as far as I can tell) we just use the object given by the show, which will be whatever we have here already anyway.

At later scans, we'll either retrieve the information for the show out of the library if previously scanned, or re-grab the information from the .nfo file anyway.

Potential fix for Gotham.  Obviously as it touches the scanner, it needs to be well reviewed first!
