### PR TITLE
UserAgent fixes

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -259,6 +259,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "usedspacepercent", SYSTEM_USED_SPACE_PERCENT },
                                   { "freespacepercent", SYSTEM_FREE_SPACE_PERCENT },
                                   { "buildversion",     SYSTEM_BUILD_VERSION },
+                                  { "buildversionshort",SYSTEM_BUILD_VERSION_SHORT },
                                   { "builddate",        SYSTEM_BUILD_DATE },
                                   { "fps",              SYSTEM_FPS },
                                   { "dvdtraystate",     SYSTEM_DVD_TRAY_STATE },
@@ -1811,6 +1812,9 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
           return StringUtils::SecondsToTimeString(duration);
       }
     }
+    break;
+  case SYSTEM_BUILD_VERSION_SHORT:
+    strLabel = GetVersionShort();
     break;
   case SYSTEM_BUILD_VERSION:
     strLabel = GetVersion();
@@ -4206,14 +4210,17 @@ CTemperature CGUIInfoManager::GetGPUTemperature()
 
 // Version string MUST NOT contain spaces.  It is used
 // in the HTTP request user agent.
+std::string CGUIInfoManager::GetVersionShort(void)
+{
+  return StringUtils::Format("%d.%d%s", VERSION_MAJOR, VERSION_MINOR, VERSION_TAG);
+}
+
 CStdString CGUIInfoManager::GetVersion()
 {
-  CStdString tmp;
   if (GetXbmcGitRevision())
-    tmp = StringUtils::Format("%d.%d%s Git:%s", VERSION_MAJOR, VERSION_MINOR, VERSION_TAG, GetXbmcGitRevision());
-  else
-    tmp = StringUtils::Format("%d.%d%s", VERSION_MAJOR, VERSION_MINOR, VERSION_TAG);
-  return tmp;
+    return GetVersionShort() + " Git:" + GetXbmcGitRevision();
+
+  return GetVersionShort();
 }
 
 CStdString CGUIInfoManager::GetBuild()

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -174,6 +174,7 @@ namespace INFO
 #define SYSTEM_HAS_PVR              186
 #define SYSTEM_STARTUP_WINDOW       187
 #define SYSTEM_STEREOSCOPIC_MODE    188
+#define SYSTEM_BUILD_VERSION_SHORT  189
 
 #define NETWORK_IP_ADDRESS          190
 #define NETWORK_MAC_ADDRESS         191
@@ -784,6 +785,7 @@ public:
   int GetPlayTimeRemaining() const;
   int GetTotalPlayTime() const;
   CStdString GetCurrentPlayTimeRemaining(TIME_FORMAT format) const;
+  std::string GetVersionShort(void);
   CStdString GetVersion();
   CStdString GetBuild();
 

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -39,6 +39,7 @@ extern "C"
   const char *GetDarwinVersionString(void);
   float       GetIOSVersion(void);
   const char *GetIOSVersionString(void);
+  const char *GetOSXVersionString(void); 
   int         GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize);
   int         GetDarwinExecutablePath(char* path, uint32_t *pathsize);
   const char *DarwinGetXbmcRootFolder(void);

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -31,6 +31,7 @@ typedef const struct __CFString * CFStringRef;
 extern "C"
 {
 #endif
+  const char *getIosPlatformString(void);
   bool        DarwinIsAppleTV2(void);
   bool        DarwinIsMavericks(void);
   bool        DarwinHasRetina(void);

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -38,6 +38,7 @@ extern "C"
   const char *GetDarwinOSReleaseString(void);
   const char *GetDarwinVersionString(void);
   float       GetIOSVersion(void);
+  const char *GetIOSVersionString(void);
   int         GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize);
   int         GetDarwinExecutablePath(char* path, uint32_t *pathsize);
   const char *DarwinGetXbmcRootFolder(void);

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -85,60 +85,79 @@ enum iosPlatform
 };
 
 // platform strings are based on http://theiphonewiki.com/wiki/Models
+const char* getIosPlatformString(void)
+{
+  static std::string iOSPlatformString;
+  if (iOSPlatformString.empty())
+  {
+#if defined(TARGET_DARWIN_IOS)
+    // Gets a string with the device model
+    size_t size;  
+    sysctlbyname("hw.machine", NULL, &size, NULL, 0);  
+    char *machine = new char[size];  
+    if (sysctlbyname("hw.machine", machine, &size, NULL, 0) == 0 && machine[0])
+      iOSPlatformString.assign(machine, size -1);
+   else
+#endif
+      iOSPlatformString = "unknown0,0";
+
+#if defined(TARGET_DARWIN_IOS)
+    delete [] machine;
+#endif
+  }
+
+  return iOSPlatformString.c_str();
+}
+
 enum iosPlatform getIosPlatform()
 {
+  static enum iosPlatform eDev = iDeviceUnknown;
 #if defined(TARGET_DARWIN_IOS)
-  // Gets a string with the device model
-  size_t size;  
-  sysctlbyname("hw.machine", NULL, &size, NULL, 0);  
-  char *machine = new char[size];  
-  sysctlbyname("hw.machine", machine, &size, NULL, 0);  
-  NSString *platform = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];  
-  delete [] machine; 
-  
-  if ([platform isEqualToString:@"iPhone1,1"])    return iPhone2G;
-  if ([platform isEqualToString:@"iPhone1,2"])    return iPhone3G;
-  if ([platform isEqualToString:@"iPhone2,1"])    return iPhone3GS;
-  if ([platform isEqualToString:@"iPhone3,1"])    return iPhone4;
-  if ([platform isEqualToString:@"iPhone3,2"])    return iPhone4;
-  if ([platform isEqualToString:@"iPhone3,3"])    return iPhone4CDMA;    
-  if ([platform isEqualToString:@"iPhone4,1"])    return iPhone4S;
-  if ([platform isEqualToString:@"iPhone5,1"])    return iPhone5;
-  if ([platform isEqualToString:@"iPhone5,2"])    return iPhone5GSMCDMA;
-  if ([platform isEqualToString:@"iPhone5,3"])    return iPhone5CGSM;
-  if ([platform isEqualToString:@"iPhone5,4"])    return iPhone5CGlobal;
-  if ([platform isEqualToString:@"iPhone6,1"])    return iPhone5SGSM;
-  if ([platform isEqualToString:@"iPhone6,2"])    return iPhone5SGlobal;
-  
-  if ([platform isEqualToString:@"iPod1,1"])      return iPodTouch1G;
-  if ([platform isEqualToString:@"iPod2,1"])      return iPodTouch2G;
-  if ([platform isEqualToString:@"iPod3,1"])      return iPodTouch3G;
-  if ([platform isEqualToString:@"iPod4,1"])      return iPodTouch4G;
-  if ([platform isEqualToString:@"iPod5,1"])      return iPodTouch5G;
-  
-  if ([platform isEqualToString:@"iPad1,1"])      return iPad;
-  if ([platform isEqualToString:@"iPad1,2"])      return iPad;
-  if ([platform isEqualToString:@"iPad2,1"])      return iPad2WIFI;
-  if ([platform isEqualToString:@"iPad2,2"])      return iPad2;
-  if ([platform isEqualToString:@"iPad2,3"])      return iPad2CDMA;
-  if ([platform isEqualToString:@"iPad2,4"])      return iPad2;
-  if ([platform isEqualToString:@"iPad2,5"])      return iPadMiniWIFI;
-  if ([platform isEqualToString:@"iPad2,6"])      return iPadMini;
-  if ([platform isEqualToString:@"iPad2,7"])      return iPadMiniGSMCDMA;
-  if ([platform isEqualToString:@"iPad3,1"])      return iPad3WIFI;
-  if ([platform isEqualToString:@"iPad3,2"])      return iPad3GSMCDMA;
-  if ([platform isEqualToString:@"iPad3,3"])      return iPad3;
-  if ([platform isEqualToString:@"iPad3,4"])      return iPad4WIFI;
-  if ([platform isEqualToString:@"iPad3,5"])      return iPad4;
-  if ([platform isEqualToString:@"iPad3,6"])      return iPad4GSMCDMA;
-  if ([platform isEqualToString:@"iPad4,1"])      return iPadAirWifi;
-  if ([platform isEqualToString:@"iPad4,2"])      return iPadAirCellular;
-  if ([platform isEqualToString:@"iPad4,4"])      return iPadMini2Wifi;
-  if ([platform isEqualToString:@"iPad4,5"])      return iPadMini2Cellular;
-  
-  if ([platform isEqualToString:@"AppleTV2,1"])   return AppleTV2;
+  if (eDev == iDeviceUnknown)
+  {
+    std::string devStr(getIosPlatformString());
+    
+    if (devStr == "iPhone1,1") eDev = iPhone2G;
+    else if (devStr == "iPhone1,2") eDev = iPhone3G;
+    else if (devStr == "iPhone2,1") eDev = iPhone3GS;
+    else if (devStr == "iPhone3,1") eDev = iPhone4;
+    else if (devStr == "iPhone3,2") eDev = iPhone4;
+    else if (devStr == "iPhone3,3") eDev = iPhone4CDMA;    
+    else if (devStr == "iPhone4,1") eDev = iPhone4S;
+    else if (devStr == "iPhone5,1") eDev = iPhone5;
+    else if (devStr == "iPhone5,2") eDev = iPhone5GSMCDMA;
+    else if (devStr == "iPhone5,3") eDev = iPhone5CGSM;
+    else if (devStr == "iPhone5,4") eDev = iPhone5CGlobal;
+    else if (devStr == "iPhone6,1") eDev = iPhone5SGSM;
+    else if (devStr == "iPhone6,2") eDev = iPhone5SGlobal;
+    else if (devStr == "iPod1,1") eDev = iPodTouch1G;
+    else if (devStr == "iPod2,1") eDev = iPodTouch2G;
+    else if (devStr == "iPod3,1") eDev = iPodTouch3G;
+    else if (devStr == "iPod4,1") eDev = iPodTouch4G;
+    else if (devStr == "iPod5,1") eDev = iPodTouch5G;
+    else if (devStr == "iPad1,1") eDev = iPad;
+    else if (devStr == "iPad1,2") eDev = iPad;
+    else if (devStr == "iPad2,1") eDev = iPad2WIFI;
+    else if (devStr == "iPad2,2") eDev = iPad2;
+    else if (devStr == "iPad2,3") eDev = iPad2CDMA;
+    else if (devStr == "iPad2,4") eDev = iPad2;
+    else if (devStr == "iPad2,5") eDev = iPadMiniWIFI;
+    else if (devStr == "iPad2,6") eDev = iPadMini;
+    else if (devStr == "iPad2,7") eDev = iPadMiniGSMCDMA;
+    else if (devStr == "iPad3,1") eDev = iPad3WIFI;
+    else if (devStr == "iPad3,2") eDev = iPad3GSMCDMA;
+    else if (devStr == "iPad3,3") eDev = iPad3;
+    else if (devStr == "iPad3,4") eDev = iPad4WIFI;
+    else if (devStr == "iPad3,5") eDev = iPad4;
+    else if (devStr == "iPad3,6") eDev = iPad4GSMCDMA;
+    else if (devStr == "iPad4,1") eDev = iPadAirWifi;
+    else if (devStr == "iPad4,2") eDev = iPadAirCellular;
+    else if (devStr == "iPad4,4") eDev = iPadMini2Wifi;
+    else if (devStr == "iPad4,5") eDev = iPadMini2Cellular;
+    else if (devStr == "AppleTV2,1") eDev = AppleTV2;
+  }
 #endif
-  return iDeviceUnknown;
+  return eDev;
 }
 
 bool DarwinIsAppleTV2(void)

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -251,6 +251,23 @@ const char *GetIOSVersionString(void)
 #endif
 }
 
+const char *GetOSXVersionString(void)
+{
+#if defined(TARGET_DARWIN_OSX)
+  static std::string OSXVersionString;
+  if (OSXVersionString.empty())
+  {
+    CCocoaAutoPool pool;
+    OSXVersionString.assign((const char*)[[[NSDictionary dictionaryWithContentsOfFile:
+                         @"/System/Library/CoreServices/SystemVersion.plist"] objectForKey:@"ProductVersion"] UTF8String]);
+  }
+  
+  return OSXVersionString.c_str();
+#else
+  return "0.0";
+#endif
+}
+
 int  GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize)
 {
   CCocoaAutoPool pool;

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -236,6 +236,21 @@ float GetIOSVersion(void)
   return(version);
 }
 
+const char *GetIOSVersionString(void)
+{
+#if defined(TARGET_DARWIN_IOS)
+  static std::string iOSVersionString;
+  if (iOSVersionString.empty())
+  {
+    CCocoaAutoPool pool;
+    iOSVersionString.assign((const char*)[[[UIDevice currentDevice] systemVersion] UTF8String]);
+  }
+  return iOSVersionString.c_str();
+#else
+  return "0.0";
+#endif
+}
+
 int  GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize)
 {
   CCocoaAutoPool pool;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -978,6 +978,10 @@ std::string CSysInfo::GetUserAgent()
 #else
   result += "Unknown";
 #endif
+  result += ")";
+#ifdef TARGET_RASPBERRY_PI
+  result += " XBMC_HW_RaspberryPi/1.0";
+#endif
 
 #if defined(TARGET_ANDROID)
   // Android has no CPU string by default, so add it as additional parameter
@@ -992,7 +996,7 @@ std::string CSysInfo::GetUserAgent()
 
   std::string fullVer(g_infoManager.GetLabel(SYSTEM_BUILD_VERSION));
   StringUtils::Replace(fullVer, ' ', '-');
-  result += ") Version/" + fullVer;
+  result += " Version/" + fullVer;
 
   return result;
 }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -842,16 +842,18 @@ CStdString CSysInfo::GetUAWindowsVersion()
   {
     if (bIsWow)
     {
-      strVersion.append(";WOW64");
+      strVersion.append("; WOW64");
       GetNativeSystemInfo(&si);     // different function to read the info under Wow
     }
   }
 
-  if (si.wProcessorArchitecture==PROCESSOR_ARCHITECTURE_AMD64)
-    strVersion.append(";Win64;x64");
-  else if (si.wProcessorArchitecture==PROCESSOR_ARCHITECTURE_IA64)
-    strVersion.append(";Win64;IA64");
-
+  if (!bIsWow)
+  {
+    if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
+      strVersion.append("; Win64; x64");
+    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64)
+      strVersion.append("; Win64; IA64");
+  }
   return strVersion;
 }
 #endif

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -846,6 +846,21 @@ std::string CSysInfo::GetAndroidVersionString(void)
   
   return versionString;
 }
+
+std::string CSysInfo::GetAndroidDeviceName(void)
+{
+  static std::string deviceName;
+  static bool inited = false;
+  if (!inited)
+  {
+    char deviceCStr[PROP_VALUE_MAX];
+    int propLen = __system_property_get("ro.product.model", deviceCStr);
+    deviceName.assign(deviceCStr, (propLen > 0 && propLen <= PROP_VALUE_MAX) ? propLen : 0);
+    inited = true;
+  }
+
+  return deviceName;
+}
 #endif // TARGET_ANDROID
 
 #if defined(TARGET_WINDOWS)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -961,14 +961,22 @@ std::string CSysInfo::GetUserAgent()
 
   if (!deviceInfo.empty())
     result += "; " + deviceInfo;
-#elif defined(TARGET_FREEBSD)
-  result += "FreeBSD; ";
-  result += GetUnameVersion();
 #elif defined(TARGET_POSIX)
-  result += "Linux; ";
-  result += GetLinuxDistro();
-  result += "; ";
-  result += GetUnameVersion();
+  result += "X11; ";
+  struct utsname un;
+  if (uname(&un) == 0)
+  {
+    std::string cpuStr(un.machine);
+    if (cpuStr == "x86_64" && GetXbmcBitness() == 32)
+      cpuStr = "i686 (x86_64)";
+    result += un.sysname;
+    result += " ";
+    result += cpuStr;
+  }
+  else
+    result += "Unknown";
+#else
+  result += "Unknown";
 #endif
 
 #if defined(TARGET_ANDROID)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -881,6 +881,10 @@ CStdString CSysInfo::GetUserAgent()
 #endif
   result += "; http://xbmc.org)";
 
+  std::string fullVer(g_infoManager.GetLabel(SYSTEM_BUILD_VERSION));
+  StringUtils::Replace(fullVer, ' ', '-');
+  result += ") Version/" + fullVer;
+
   return result;
 }
 

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -860,7 +860,7 @@ CStdString CSysInfo::GetUAWindowsVersion()
 CStdString CSysInfo::GetUserAgent()
 {
   CStdString result;
-  result = "XBMC/" + g_infoManager.GetLabel(SYSTEM_BUILD_VERSION) + " (";
+  result = "XBMC/" + g_infoManager.GetLabel(SYSTEM_BUILD_VERSION_SHORT) + " (";
 #if defined(TARGET_WINDOWS)
   result += GetUAWindowsVersion();
 #elif defined(TARGET_DARWIN)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -905,7 +905,10 @@ std::string CSysInfo::GetUAWindowsVersion()
 
 std::string CSysInfo::GetUserAgent()
 {
-  std::string result;
+  static std::string result;
+  if (!result.empty())
+    return result;
+
   result = "XBMC/" + g_infoManager.GetLabel(SYSTEM_BUILD_VERSION_SHORT) + " (";
 #if defined(TARGET_WINDOWS)
   result += GetUAWindowsVersion();

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -981,6 +981,14 @@ std::string CSysInfo::GetUserAgent()
   result += ")";
 #ifdef TARGET_RASPBERRY_PI
   result += " XBMC_HW_RaspberryPi/1.0";
+#elif defined (TARGET_DARWIN_IOS)
+  std::string iDevVer;
+  if (iDevStrDigit == std::string::npos)
+    iDevVer = "0.0";
+  else
+    iDevVer.assign(iDevStr, iDevStrDigit, std::string::npos);
+  StringUtils::Replace(iDevVer, ',', '.');
+  result += " XBMC_HW_" + iDev + "/" + iDevVer;
 #endif
 
 #if defined(TARGET_ANDROID)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -940,6 +940,27 @@ std::string CSysInfo::GetUserAgent()
   StringUtils::Replace(OSXVersion, '.', '_');
   result += OSXVersion;
 #endif
+#elif defined(TARGET_ANDROID)
+  result += "Linux; Android ";
+  std::string versionStr(GetAndroidVersionString());
+  const size_t verLen = versionStr.length();
+  if (verLen >= 2 && versionStr.compare(verLen - 2, 2, ".0", 2) == 0)
+    versionStr.erase(verLen - 2); // remove last ".0" if any
+  result += versionStr;
+  std::string deviceInfo(GetAndroidDeviceName());
+
+  char buildId[PROP_VALUE_MAX];
+  int propLen = __system_property_get("ro.build.id", buildId);
+  if (propLen > 0 && propLen <= PROP_VALUE_MAX)
+  {
+    if (!deviceInfo.empty())
+      deviceInfo += " ";
+    deviceInfo += "Build/";
+    deviceInfo.append(buildId, propLen);
+  }
+
+  if (!deviceInfo.empty())
+    result += "; " + deviceInfo;
 #elif defined(TARGET_FREEBSD)
   result += "FreeBSD; ";
   result += GetUnameVersion();

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -971,6 +971,17 @@ std::string CSysInfo::GetUserAgent()
   result += GetUnameVersion();
 #endif
 
+#if defined(TARGET_ANDROID)
+  // Android has no CPU string by default, so add it as additional parameter
+  struct utsname un1;
+  if (uname(&un1) == 0)
+  {
+    std::string cpuStr(un1.machine);
+    StringUtils::Replace(cpuStr, ' ', '_');
+    result += " XBMC_CPU/" + cpuStr;
+  }
+#endif
+
   std::string fullVer(g_infoManager.GetLabel(SYSTEM_BUILD_VERSION));
   StringUtils::Replace(fullVer, ' ', '-');
   result += ") Version/" + fullVer;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -853,6 +853,8 @@ CStdString CSysInfo::GetUAWindowsVersion()
       strVersion.append("; Win64; x64");
     else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64)
       strVersion.append("; Win64; IA64");
+    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
+      strVersion.append("; ARM");
   }
   return strVersion;
 }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -979,6 +979,8 @@ std::string CSysInfo::GetUserAgent()
   result += "Unknown";
 #endif
   result += ")";
+  // add fork ID here in form:
+  // result += " XBMC_FORK_" + "forkname" + "/" + "1.0"; // default fork number is '1.0'
 #ifdef TARGET_RASPBERRY_PI
   result += " XBMC_HW_RaspberryPi/1.0";
 #elif defined (TARGET_DARWIN_IOS)
@@ -990,6 +992,9 @@ std::string CSysInfo::GetUserAgent()
   StringUtils::Replace(iDevVer, ',', '.');
   result += " XBMC_HW_" + iDev + "/" + iDevVer;
 #endif
+  // add more device IDs here if needed. 
+  // keep only one device ID in result! Form:
+  // result += " XBMC_HW_" + "deviceID" + "/" + "1.0"; // '1.0' if device has no version
 
 #if defined(TARGET_ANDROID)
   // Android has no CPU string by default, so add it as additional parameter

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -822,12 +822,12 @@ CStdString CSysInfo::GetUnameVersion()
 #endif
 
 #if defined(TARGET_WINDOWS)
-CStdString CSysInfo::GetUAWindowsVersion()
+std::string CSysInfo::GetUAWindowsVersion()
 {
   OSVERSIONINFOEX osvi = {};
 
   osvi.dwOSVersionInfoSize = sizeof(osvi);
-  CStdString strVersion = "Windows NT";
+  std::string strVersion = "Windows NT";
 
   if (GetVersionEx((OSVERSIONINFO *)&osvi))
   {
@@ -861,7 +861,7 @@ CStdString CSysInfo::GetUAWindowsVersion()
 #endif
 
 
-CStdString CSysInfo::GetUserAgent()
+std::string CSysInfo::GetUserAgent()
 {
   std::string result;
   result = "XBMC/" + g_infoManager.GetLabel(SYSTEM_BUILD_VERSION_SHORT) + " (";

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -1007,6 +1007,8 @@ std::string CSysInfo::GetUserAgent()
   }
 #endif
 
+  result += " XBMC_BITNESS/" + StringUtils::Format("%d", GetXbmcBitness());
+
   std::string fullVer(g_infoManager.GetLabel(SYSTEM_BUILD_VERSION));
   StringUtils::Replace(fullVer, ' ', '-');
   result += " Version/" + fullVer;

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -110,9 +110,9 @@ public:
   CStdString GetUnameVersion();
 #endif
 #if defined(TARGET_WINDOWS)
-  CStdString GetUAWindowsVersion();
+  std::string GetUAWindowsVersion();
 #endif
-  CStdString GetUserAgent();
+  std::string GetUserAgent();
   bool HasInternet();
   bool IsAppleTV2();
   bool HasVideoToolBoxDecoder();

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -111,6 +111,7 @@ public:
 #endif
 #ifdef TARGET_ANDROID
   std::string GetAndroidVersionString(void);
+  std::string GetAndroidDeviceName(void);
 #endif
 #if defined(TARGET_WINDOWS)
   std::string GetUAWindowsVersion();

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -109,6 +109,9 @@ public:
 #ifdef TARGET_POSIX
   CStdString GetUnameVersion();
 #endif
+#ifdef TARGET_ANDROID
+  std::string GetAndroidVersionString(void);
+#endif
 #if defined(TARGET_WINDOWS)
   std::string GetUAWindowsVersion();
 #endif


### PR DESCRIPTION
As discussed with @kibje at LinuxTag2014, we need to fix XBMC useragent to allow automatic detection of OS by various web tools. 
With this patch XBMC will try to imitate Chromium identification of OS.
I need some help from darwin developers as darwin code was blind-edited. @jmarshallnz @davilla @Memphiz ?
