### PR TITLE
[coreSubs] restore default subtitle offset

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -554,8 +554,8 @@ void CGUIDialogSubtitles::SetSubtitles(const std::string &subtitle)
     {
       g_application.m_pPlayer->SetSubtitle(nStream);
       g_application.m_pPlayer->SetSubtitleVisible(true);
-      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = 0.0f;
-      g_application.m_pPlayer->SetSubTitleDelay(0);
+      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = CMediaSettings::Get().GetDefaultVideoSettings().m_SubtitleDelay;
+      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
     }
   }
 }


### PR DESCRIPTION
apparently we need this, beats me...

code by constantine109 on XBMC forums http://forum.xbmc.org/showthread.php?tid=194597&pid=1705815#pid1705815
