### PR TITLE
AESinkPULSE: Make clear what we open - makes logfiles better readable

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -694,6 +694,10 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
   m_format = format;
   format.m_dataFormat = m_passthrough ? AE_FMT_S16NE : format.m_dataFormat;
 
+  CLog::Log(LOGNOTICE, "PulseAudio: Opened device %s in %s mode with Buffersize %u ms",
+                      device.c_str(), m_passthrough ? "passthrough" : "pcm",
+                      (unsigned int) ((m_BufferSize / (float) m_BytesPerSecond) * 1000));
+
   // Cork stream will resume when adding first package
   Pause(true);
   {


### PR DESCRIPTION
Most of the time when debugging PA issues - I need to calculate the relevant things byself. I think it's quite useful to know if we are in passthrough mode or not. Also the computed buffersize is quite intereseting to know.

I left out the channel map, cause ActiveAE already has that, including Format and SampleRate.
