### PR TITLE
Add ability to get text from ControlTextBox via python and infolabels

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -387,6 +387,11 @@ CStdString CGUITextBox::GetLabel(int info) const
   return label;
 }
 
+CStdString CGUITextBox::GetDescription() const
+{
+  return GetText();
+}
+
 void CGUITextBox::UpdateVisibility(const CGUIListItem *item)
 {
   // we have to update the page control when we become visible

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -62,6 +62,7 @@ public:
   void SetAutoScrolling(const TiXmlNode *node);
   void ResetAutoScrolling();
   CStdString GetLabel(int info) const;
+  CStdString GetDescription() const;
 
   void Scroll(unsigned int offset);
 

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -630,6 +630,17 @@ float CGUITextLayout::GetTextWidth(const CStdStringW &text) const
   return m_font->GetTextWidth(utf32);
 }
 
+std::string CGUITextLayout::GetText() const
+{
+  if (m_lastUpdateW)
+  {
+    std::string utf8;
+    g_charsetConverter.wToUTF8(m_lastText, utf8);
+    return utf8;
+  }
+  return m_lastUtf8Text;
+}
+
 void CGUITextLayout::DrawText(CGUIFont *font, float x, float y, color_t color, color_t shadowColor, const CStdString &text, uint32_t align)
 {
   if (!font) return;

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -117,7 +117,12 @@ protected:
   static CStdStringW BidiFlip(const CStdStringW &text, bool forceLTRReadingOrder);
   void CalcTextExtent();
   void UpdateCommon(const CStdStringW &text, float maxWidth, bool forceLTRReadingOrder);
-
+  
+  /*! \brief Returns the text, utf8 encoded
+   \return utf8 text
+   */
+  std::string GetText() const;
+  
   // our text to render
   vecColors m_colors;
   std::vector<CGUIString> m_lines;

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -141,6 +141,14 @@ namespace XBMCAddon
       g_windowManager.SendThreadMessage(msg, iParentId);
     }
 
+    String ControlTextBox::getText() throw (UnimplementedException)
+    {
+      if (!pGUIControl) return NULL;
+
+      LOCKGUI;
+      return ((CGUITextBox*) pGUIControl)->GetDescription();
+    }
+
     void ControlTextBox::reset() throw(UnimplementedException)
     {
       // create message

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -891,6 +891,15 @@ namespace XBMCAddon
        */
       virtual void setText(const String& text) throw(UnimplementedException);
 
+      // getText() Method
+      /**
+       * getText() -- Returns the text value for this textbox.
+       *
+       * example:
+       *   - text = self.text.getText()
+       */
+      virtual String getText() throw(UnimplementedException);
+
       // reset() Method
       /**
        * reset() -- Clear's this textbox.


### PR DESCRIPTION
Added GetDescription() to CGUITextBox which allows xbmc.getInfoLabel("Control.GetLabel(100)") to return TextBox texts.
Add getText() to ControlTextBox which allows <control>.getText() to return the textbox text in python.

Everything works fine, but I have to wonder if there is some reason this was never done before because it was so simple :)
