### PR TITLE
[gui] fix auto-width labels not wrapping properly with <wrapmultiline>

### DIFF
--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -161,7 +161,7 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
         ch |= (3 << 16);
       text.insert(text.begin() + m_iCursorPos, ch);
     }
-    changed |= m_label.SetMaxRect(m_posX, m_posY, GetWidth(), m_height);
+    changed |= m_label.SetMaxRect(m_posX, m_posY, GetMaxWidth(), m_height);
     changed |= m_label.SetStyledText(text, colors);
   }
   else
@@ -169,7 +169,7 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
     if (m_bHasPath)
       label = ShortenPath(label);
 
-    changed |= m_label.SetMaxRect(m_posX, m_posY, GetWidth(), m_height);
+    changed |= m_label.SetMaxRect(m_posX, m_posY, GetMaxWidth(), m_height);
     changed |= m_label.SetText(label);
   }
   if (changed)
@@ -244,10 +244,7 @@ void CGUILabelControl::SetAlignment(uint32_t align)
 float CGUILabelControl::GetWidth() const
 {
   if (m_minWidth && m_minWidth != m_width)
-  {
-    float maxWidth = m_width ? m_width : m_label.GetTextWidth();
-    return CLAMP(m_label.GetTextWidth(), m_minWidth, maxWidth);
-  }
+    return CLAMP(m_label.GetTextWidth(), m_minWidth, GetMaxWidth());
   return m_width;
 }
 

--- a/xbmc/guilib/GUILabelControl.h
+++ b/xbmc/guilib/GUILabelControl.h
@@ -68,6 +68,11 @@ protected:
   bool UpdateColors();
   CStdString ShortenPath(const CStdString &path);
 
+  /*! \brief Return the maximum width of this label control.
+   \return Return the width of the control if available, else the width of the current text.
+   */
+  float GetMaxWidth() const { return m_width ? m_width : m_label.GetTextWidth(); }
+
   CGUILabel m_label;
 
   bool m_bHasPath;


### PR DESCRIPTION
Fairly non-controversial.  Ideally requires backport to Gotham.  Bug was introduced during Gotham release cycle.

@t-nelson please cast your eagle-eye on it.  As I'm obviously biased, it's your call as to whether this is 13.1 or 13.2.
