### PR TITLE
AESinkPULSE: Initialize pause flag to be on safe side

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -457,6 +457,7 @@ CAESinkPULSE::CAESinkPULSE()
   m_Channels = 0;
   m_Stream = NULL;
   m_Context = NULL;
+  m_IsStreamPaused = false;
 }
 
 CAESinkPULSE::~CAESinkPULSE()
@@ -725,6 +726,7 @@ void CAESinkPULSE::Deinitialize()
     pa_stream_disconnect(m_Stream);
     pa_stream_unref(m_Stream);
     m_Stream = NULL;
+    m_IsStreamPaused = false;
   }
 
   if (m_Context)


### PR DESCRIPTION
As talked with @jmarshallnz here: https://github.com/xbmc/xbmc/pull/4670/files#r12515767 he wants to have it inited in constructor. So let's do it.
