### PR TITLE
[osx/ffmpeg] disable spew of sdl compile/link flags

### DIFF
--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -40,6 +40,7 @@ ifeq ($(OS), ios)
   ffmpg_config += --target-os=darwin
 endif
 ifeq ($(OS), osx)
+  ffmpg_config += --disable-outdev=sdl
   ffmpg_config += --disable-decoder=mpeg_xvmc --enable-vda --disable-crystalhd
   ffmpg_config += --target-os=darwin
 endif


### PR DESCRIPTION
This needs this go in first and a bump of FFMPEG-VERSION):

https://github.com/xbmc/FFmpeg/pull/1

This replaces #4688
