### PR TITLE
[json] - fix jsonbuilder was not found when added to "PATH" from outside...

### DIFF
--- a/xbmc/interfaces/json-rpc/Makefile
+++ b/xbmc/interfaces/json-rpc/Makefile
@@ -29,7 +29,10 @@ all: $(GENERATED_JSON) $(GENERATED_ADDON_JSON) $(LIB)
 
 -include ../../../Makefile.include
 ifeq ($(wildcard $(JSON_BUILDER)),)
+  JSON_BUILDER = $(shell which JsonSchemaBuilder)
+ifeq ($(JSON_BUILDER),)
   JSON_BUILDER = ../../../tools/depends/native/JsonSchemaBuilder/JsonSchemaBuilder
+endif
 endif
 
 $(GENERATED_JSON): $(JSON_SRC)


### PR DESCRIPTION
.... Add the same approach like done in codegenerator.mk - fixes json generation when compiling from xcode

@montellese @wsnipex for review ...

imo the right thing for the xbmc/interfaces/json-rpc/Makefile would be to use a Makefile.in and use @abs_top_srcdir@ - see xbmc/interfaces/python/Makefile but iirc someone also proposed that too.

PS: this is a build fix for all developers building from inside xcode (jenkins doesn't it uses xcodebuild which somehow doesn't seem to suffer from this issue).
