### PR TITLE
[3D] add support for stereomode detection of other codecs than MKV

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -83,6 +83,8 @@ public:
 #define FFMPEG_FILE_BUFFER_SIZE   32768 // default reading size for ffmpeg
 #define FFMPEG_DVDNAV_BUFFER_SIZE 2048  // for dvd's
 
+struct StereoModeConversionMap;
+
 class CDVDDemuxFFmpeg : public CDVDDemux
 {
 public:
@@ -132,6 +134,9 @@ protected:
   double ConvertTimestamp(int64_t pts, int den, int num);
   void UpdateCurrentPTS();
   bool IsProgramChange();
+
+  std::string GetStereoModeFromMetadata(AVDictionary *pMetadata);
+  std::string ConvertCodecToInternalStereoMode(const std::string &mode, const StereoModeConversionMap *conversionMap);
 
   CCriticalSection m_critSection;
   std::map<int, CDemuxStream*> m_streams;


### PR DESCRIPTION
This PR is abstracting the stereoscopic detection to a separate function and is adding stereoscopic detection for wmv/asf files (see http://www.3dtv.at). Not sure if this is the correct way to go, so @elupus please have a look.
