### PR TITLE
[pvr] fix: wrong database table for column iLastWatched in CreateTable()

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -103,7 +103,8 @@ void CPVRDatabase::CreateTables()
         "idGroup         integer primary key,"
         "bIsRadio        bool, "
         "iGroupType      integer, "
-        "sName           varchar(64)"
+        "sName           varchar(64), "
+        "iLastWatched    integer"
       ")"
   );
 
@@ -112,8 +113,7 @@ void CPVRDatabase::CreateTables()
       "CREATE TABLE map_channelgroups_channels ("
         "idChannel      integer, "
         "idGroup        integer, "
-        "iChannelNumber integer, "
-        "iLastWatched   integer"
+        "iChannelNumber integer"
       ")"
   );
 


### PR DESCRIPTION
This moves the column _iLastWatched_ to the valid table _channelgroups_.
Reported at http://forum.xbmc.org/showthread.php?tid=194922
Thanks @koying ;)
