### PR TITLE
[omxplayer] Ignore occasionally valid pts values

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -484,7 +484,7 @@ void OMXPlayerVideo::Process()
         // if a stream has had more than 4 valid pts values in the last 16, the use UNKNOWN, otherwise use dts
         m_history_valid_pts = (m_history_valid_pts << 1) | (pPacket->pts != DVD_NOPTS_VALUE);
         double pts = pPacket->pts;
-        if(pPacket->pts == DVD_NOPTS_VALUE && count_bits(m_history_valid_pts & 0xffff) < 4)
+        if(count_bits(m_history_valid_pts & 0xffff) < 4)
           pts = pPacket->dts;
 
         if (pts != DVD_NOPTS_VALUE)


### PR DESCRIPTION
They cause live tv stutter.

See: http://forum.xbmc.org/showthread.php?tid=148646&pid=1662307#pid1662307
