### PR TITLE
Handle AV_CODEC_ID_SUBRIP only when it is defined.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -388,7 +388,9 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
   switch (hint.codec)
   {
     case AV_CODEC_ID_TEXT:
+#ifdef AV_CODEC_ID_SUBRIP
     case AV_CODEC_ID_SUBRIP:
+#endif
       pCodec = OpenCodec(new CDVDOverlayCodecText(), hint, options);
       if( pCodec ) return pCodec;
       break;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -44,8 +44,10 @@ bool CDVDOverlayCodecText::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_bIsSSA = (hints.codec == AV_CODEC_ID_SSA);
   if(hints.codec == AV_CODEC_ID_TEXT || hints.codec == AV_CODEC_ID_SSA)
     return true;
+#ifdef AV_CODEC_ID_SUBRIP
   if(hints.codec == AV_CODEC_ID_SUBRIP)
     return true;
+#endif
   return false;
 }
 


### PR DESCRIPTION
Not all FFmpeg versions have AV_CODEC_ID_SUBRIP,
but when it is present it works like AV_CODEC_ID_TEXT.

Being able to compile XBMC with older FFmpeg versions would help tracking down regressions.
