### PR TITLE
Allow HLS streams without m3u8 extension

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -88,8 +88,7 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, 
        || file.substr(0, 6) == "tcp://"
        || file.substr(0, 6) == "mms://"
        || file.substr(0, 7) == "mmst://"
-       || file.substr(0, 7) == "mmsh://"
-       || (item.IsInternetStream() && item.IsType(".m3u8")))
+       || file.substr(0, 7) == "mmsh://")
     return new CDVDInputStreamFFmpeg();
   else if(file.substr(0, 8) == "sling://"
        || file.substr(0, 7) == "myth://"
@@ -113,6 +112,14 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, 
   else if(file.substr(0, 7) == "htsp://")
     return new CDVDInputStreamHTSP();
 #endif
+  else if (item.IsInternetStream())
+  {
+    if (item.IsType(".m3u8"))
+      return new CDVDInputStreamFFmpeg();
+    item.FillInMimeType();
+    if (item.GetMimeType() == "application/vnd.apple.mpegurl")
+      return new CDVDInputStreamFFmpeg();
+  }
 
   // our file interface handles all these types of streams
   return (new CDVDInputStreamFile());

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -52,7 +52,7 @@ bool CDVDInputStreamFFmpeg::Open(const char* strFile, const std::string& content
 {
   CFileItem item(strFile, false);
   std::string selected;
-  if (item.IsInternetStream() && item.IsType(".m3u8"))
+  if (item.IsInternetStream() && (item.IsType(".m3u8") || content == "application/vnd.apple.mpegurl"))
   {
     // get the available bandwidth and  determine the most appropriate stream
     int bandwidth = CSettings::Get().GetInt("network.bandwidth");


### PR DESCRIPTION
According to draft, having either .m3u8 extension or the correct HTTP content type is sufficient.
