### PR TITLE
deinitialize CAnnouncementManager before stopping all (network) services

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3555,6 +3555,8 @@ void CApplication::Stop(int exitCode)
     CLog::Log(LOGNOTICE, "stop player");
     m_pPlayer->ClosePlayer();
 
+    CAnnouncementManager::Deinitialize();
+
     StopPVRManager();
     StopServices();
     //Sleep(5000);

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -39,6 +39,12 @@ using namespace ANNOUNCEMENT;
 #define m_announcers XBMC_GLOBAL_USE(ANNOUNCEMENT::CAnnouncementManager::Globals).m_announcers
 #define m_critSection XBMC_GLOBAL_USE(ANNOUNCEMENT::CAnnouncementManager::Globals).m_critSection
 
+void CAnnouncementManager::Deinitialize()
+{
+  CSingleLock lock (m_critSection);
+  m_announcers.clear();
+}
+
 void CAnnouncementManager::AddAnnouncer(IAnnouncer *listener)
 {
   if (!listener)

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -38,6 +38,8 @@ namespace ANNOUNCEMENT
        std::vector<IAnnouncer *> m_announcers;
      };
 
+    static void Deinitialize();
+
     static void AddAnnouncer(IAnnouncer *listener);
     static void RemoveAnnouncer(IAnnouncer *listener);
     static void Announce(AnnouncementFlag flag, const char *sender, const char *message);


### PR DESCRIPTION
This is the partial backport of #4725. I thought I'd take the work off your plate. This only really needs merging if 198c45e465e113bd170ec8c5f47770c4fefb88d9 is backported because it causes a crash on win32 during shutdown.
