### PR TITLE
[settings] check control types - the id's have changed so old skins crash

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -558,7 +558,7 @@ void CGUIDialogAddonSettings::SaveSettings(void)
 
 void CGUIDialogAddonSettings::FreeSections()
 {
-  CGUIControlGroupList *group = (CGUIControlGroupList *)GetControl(CONTROL_SECTION_AREA);
+  CGUIControlGroupList *group = dynamic_cast<CGUIControlGroupList *>(GetControl(CONTROL_SECTION_AREA));
   if (group)
   {
     group->FreeResources();
@@ -572,7 +572,7 @@ void CGUIDialogAddonSettings::FreeSections()
 void CGUIDialogAddonSettings::FreeControls()
 {
   // clear the category group
-  CGUIControlGroupList *control = (CGUIControlGroupList *)GetControl(CONTROL_SETTINGS_AREA);
+  CGUIControlGroupList *control = dynamic_cast<CGUIControlGroupList *>(GetControl(CONTROL_SETTINGS_AREA));
   if (control)
   {
     control->FreeResources();
@@ -582,8 +582,8 @@ void CGUIDialogAddonSettings::FreeControls()
 
 void CGUIDialogAddonSettings::CreateSections()
 {
-  CGUIControlGroupList *group = (CGUIControlGroupList *)GetControl(CONTROL_SECTION_AREA);
-  CGUIButtonControl *originalButton = (CGUIButtonControl *)GetControl(CONTROL_DEFAULT_SECTION_BUTTON);
+  CGUIControlGroupList *group = dynamic_cast<CGUIControlGroupList *>(GetControl(CONTROL_SECTION_AREA));
+  CGUIButtonControl *originalButton = dynamic_cast<CGUIButtonControl *>(GetControl(CONTROL_DEFAULT_SECTION_BUTTON));
   if (!m_addon)
     return;
 
@@ -634,12 +634,12 @@ void CGUIDialogAddonSettings::CreateControls()
 {
   FreeControls();
 
-  CGUISpinControlEx *pOriginalSpin = (CGUISpinControlEx*)GetControl(CONTROL_DEFAULT_SPIN);
-  CGUIRadioButtonControl *pOriginalRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_DEFAULT_RADIOBUTTON);
-  CGUIButtonControl *pOriginalButton = (CGUIButtonControl *)GetControl(CONTROL_DEFAULT_BUTTON);
-  CGUIImage *pOriginalImage = (CGUIImage *)GetControl(CONTROL_DEFAULT_SEPARATOR);
-  CGUILabelControl *pOriginalLabel = (CGUILabelControl *)GetControl(CONTROL_DEFAULT_LABEL_SEPARATOR);
-  CGUISettingsSliderControl *pOriginalSlider = (CGUISettingsSliderControl *)GetControl(CONTROL_DEFAULT_SLIDER);
+  CGUISpinControlEx *pOriginalSpin = dynamic_cast<CGUISpinControlEx*>(GetControl(CONTROL_DEFAULT_SPIN));
+  CGUIRadioButtonControl *pOriginalRadioButton = dynamic_cast<CGUIRadioButtonControl *>(GetControl(CONTROL_DEFAULT_RADIOBUTTON));
+  CGUIButtonControl *pOriginalButton = dynamic_cast<CGUIButtonControl *>(GetControl(CONTROL_DEFAULT_BUTTON));
+  CGUIImage *pOriginalImage = dynamic_cast<CGUIImage *>(GetControl(CONTROL_DEFAULT_SEPARATOR));
+  CGUILabelControl *pOriginalLabel = dynamic_cast<CGUILabelControl *>(GetControl(CONTROL_DEFAULT_LABEL_SEPARATOR));
+  CGUISettingsSliderControl *pOriginalSlider = dynamic_cast<CGUISettingsSliderControl *>(GetControl(CONTROL_DEFAULT_SLIDER));
 
   if (!m_addon || !pOriginalSpin || !pOriginalRadioButton || !pOriginalButton || !pOriginalImage
                || !pOriginalLabel || !pOriginalSlider)
@@ -652,8 +652,7 @@ void CGUIDialogAddonSettings::CreateControls()
   pOriginalLabel->SetVisible(false);
   pOriginalSlider->SetVisible(false);
 
-  // clear the category group
-  CGUIControlGroupList *group = (CGUIControlGroupList *)GetControl(CONTROL_SETTINGS_AREA);
+  CGUIControlGroupList *group = dynamic_cast<CGUIControlGroupList *>(GetControl(CONTROL_SETTINGS_AREA));
   if (!group)
     return;
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -169,17 +169,17 @@ void CGUIDialogContextMenu::SetupButtons()
   if (!pGroupList)
   {
     // if we don't have grouplist update the navigation of the first and last buttons
-    pControl = (CGUIControl *)GetControl(BUTTON_START);
+    pControl = GetControl(BUTTON_START);
     if (pControl)
       pControl->SetNavigationAction(ACTION_MOVE_UP, BUTTON_END);
-    pControl = (CGUIControl *)GetControl(BUTTON_END);
+    pControl = GetControl(BUTTON_END);
     if (pControl)
       pControl->SetNavigationAction(ACTION_MOVE_DOWN, BUTTON_START);
   }
 #endif
 
   // fix up background images placement and size
-  pControl = (CGUIControl *)GetControl(BACKGROUND_IMAGE);
+  pControl = GetControl(BACKGROUND_IMAGE);
   if (pControl)
   {
     // first set size of background image
@@ -203,18 +203,18 @@ void CGUIDialogContextMenu::SetupButtons()
     if (pGroupList && pGroupList->GetOrientation() == HORIZONTAL)
     {
       // if there is grouplist control with horizontal orientation - adjust width of top and bottom background
-      CGUIControl* pControl2 = (CGUIControl *)GetControl(BACKGROUND_TOP);
+      CGUIControl* pControl2 = GetControl(BACKGROUND_TOP);
       if (pControl2)
         pControl2->SetWidth(pControl->GetWidth());
 
-      pControl2 = (CGUIControl *)GetControl(BACKGROUND_BOTTOM);
+      pControl2 = GetControl(BACKGROUND_BOTTOM);
       if (pControl2)
         pControl2->SetWidth(pControl->GetWidth());
     }
     else
     {
       // adjust position of bottom background
-      CGUIControl* pControl2 = (CGUIControl *)GetControl(BACKGROUND_BOTTOM);
+      CGUIControl* pControl2 = GetControl(BACKGROUND_BOTTOM);
       if (pControl2)
         pControl2->SetPosition(pControl2->GetXPosition(), pControl->GetYPosition() + pControl->GetHeight());
     }
@@ -278,7 +278,7 @@ float CGUIDialogContextMenu::GetHeight() const
 
 float CGUIDialogContextMenu::GetWidth() const
 {
-  CGUIControl *pControl = (CGUIControl *)GetControl(BACKGROUND_IMAGE);
+  const CGUIControl *pControl = GetControl(BACKGROUND_IMAGE);
   if (pControl)
     return pControl->GetWidth();
   else

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -122,18 +122,14 @@ void CGUIDialogContextMenu::SetupButtons()
     return;
 
   // disable the template button control
-  CGUIButtonControl *pButtonTemplate = (CGUIButtonControl *)GetFirstFocusableControl(BUTTON_TEMPLATE);
-  if (!pButtonTemplate) pButtonTemplate = (CGUIButtonControl *)GetControl(BUTTON_TEMPLATE);
+  CGUIButtonControl *pButtonTemplate = dynamic_cast<CGUIButtonControl *>(GetFirstFocusableControl(BUTTON_TEMPLATE));
+  if (!pButtonTemplate)
+    pButtonTemplate = dynamic_cast<CGUIButtonControl *>(GetControl(BUTTON_TEMPLATE));
   if (!pButtonTemplate)
     return;
   pButtonTemplate->SetVisible(false);
 
-  CGUIControlGroupList* pGroupList = NULL;
-  {
-    const CGUIControl* pControl = GetControl(GROUP_LIST);
-    if (pControl && pControl->GetControlType() == GUICONTROL_GROUPLIST)
-      pGroupList = (CGUIControlGroupList*)pControl;
-  }
+  CGUIControlGroupList* pGroupList = dynamic_cast<CGUIControlGroupList *>(GetControl(GROUP_LIST));
 
   // add our buttons
   for (unsigned int i = 0; i < m_buttons.size(); i++)
@@ -678,12 +674,8 @@ void CGUIDialogContextMenu::OnWindowLoaded()
   m_coordX = m_posX;
   m_coordY = m_posY;
   
-  const CGUIControlGroupList* pGroupList = NULL;
-  const CGUIControl* pControl = GetControl(GROUP_LIST);
-  if (pControl && pControl->GetControlType() == GUICONTROL_GROUPLIST)
-    pGroupList = (CGUIControlGroupList*)pControl;
-
-  pControl = (CGUIControl *)GetControl(BACKGROUND_IMAGE);
+  const CGUIControlGroupList* pGroupList = dynamic_cast<const CGUIControlGroupList *>(GetControl(GROUP_LIST));
+  const CGUIControl *pControl = GetControl(BACKGROUND_IMAGE);
   if (pControl && pGroupList)
   {
     if (pGroupList->GetOrientation() == VERTICAL)

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -87,7 +87,7 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   // set alphabetic (capitals)
   UpdateButtons();
 
-  CGUILabelControl* pEdit = ((CGUILabelControl*)GetControl(CTL_LABEL_EDIT));
+  CGUILabelControl* pEdit = dynamic_cast<CGUILabelControl*>(GetControl(CTL_LABEL_EDIT));
   if (pEdit)
   {
     pEdit->ShowCursor();
@@ -376,7 +376,7 @@ void CGUIDialogKeyboardGeneric::FrameMove()
 
 void CGUIDialogKeyboardGeneric::UpdateLabel() // FIXME seems to be called twice for one USB SDL keyboard action/character
 {
-  CGUILabelControl* pEdit = ((CGUILabelControl*)GetControl(CTL_LABEL_EDIT));
+  CGUILabelControl* pEdit = dynamic_cast<CGUILabelControl*>(GetControl(CTL_LABEL_EDIT));
   if (pEdit)
   {
     CStdStringW edit = m_strEdit;
@@ -623,7 +623,7 @@ void CGUIDialogKeyboardGeneric::SetCursorPos(int iPos)
   else if (iPos > (int)m_strEdit.size())
     iPos = (int)m_strEdit.size();
   m_iCursorPos = iPos;
-  CGUILabelControl* pEdit = ((CGUILabelControl*)GetControl(CTL_LABEL_EDIT));
+  CGUILabelControl* pEdit = dynamic_cast<CGUILabelControl*>(GetControl(CTL_LABEL_EDIT));
   if (pEdit)
   {
     pEdit->SetCursorPos(m_iCursorPos + (m_hiddenInput ? 0 : m_iEditingOffset));
@@ -673,7 +673,7 @@ void CGUIDialogKeyboardGeneric::OnIPAddress()
     utf8String = utf8String.substr(0, start) + ip.c_str() + utf8String.substr(start + length);
     g_charsetConverter.utf8ToW(utf8String, m_strEdit);
     UpdateLabel();
-    CGUILabelControl* pEdit = ((CGUILabelControl*)GetControl(CTL_LABEL_EDIT));
+    CGUILabelControl* pEdit = dynamic_cast<CGUILabelControl*>(GetControl(CTL_LABEL_EDIT));
     if (pEdit)
       pEdit->SetCursorPos(m_strEdit.size());
   }

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -526,36 +526,10 @@ char CGUIDialogKeyboardGeneric::GetCharacter(int iButton)
 
 void CGUIDialogKeyboardGeneric::UpdateButtons()
 {
-  if (m_bShift)
-  { // show the button depressed
-    CGUIMessage msg(GUI_MSG_SELECTED, GetID(), CTL_BUTTON_SHIFT);
-    OnMessage(msg);
-  }
-  else
-  {
-    CGUIMessage msg(GUI_MSG_DESELECTED, GetID(), CTL_BUTTON_SHIFT);
-    OnMessage(msg);
-  }
-  if (m_keyType == CAPS)
-  {
-    CGUIMessage msg(GUI_MSG_SELECTED, GetID(), CTL_BUTTON_CAPS);
-    OnMessage(msg);
-  }
-  else
-  {
-    CGUIMessage msg(GUI_MSG_DESELECTED, GetID(), CTL_BUTTON_CAPS);
-    OnMessage(msg);
-  }
-  if (m_keyType == SYMBOLS)
-  {
-    CGUIMessage msg(GUI_MSG_SELECTED, GetID(), CTL_BUTTON_SYMBOLS);
-    OnMessage(msg);
-  }
-  else
-  {
-    CGUIMessage msg(GUI_MSG_DESELECTED, GetID(), CTL_BUTTON_SYMBOLS);
-    OnMessage(msg);
-  }
+  SET_CONTROL_SELECTED(GetID(), CTL_BUTTON_SHIFT, m_bShift);
+  SET_CONTROL_SELECTED(GetID(), CTL_BUTTON_CAPS, m_keyType == CAPS);
+  SET_CONTROL_SELECTED(GetID(), CTL_BUTTON_SYMBOLS, m_keyType == SYMBOLS);
+
   char szLabel[2];
   szLabel[0] = 32;
   szLabel[1] = 0;

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -338,7 +338,7 @@ void CGUIDialogNumeric::FrameMove()
     start = m_block * 4;
     end = m_block * 4 + 3;
   }
-  CGUILabelControl *pLabel = (CGUILabelControl *)GetControl(CONTROL_INPUT_LABEL);
+  CGUILabelControl *pLabel = dynamic_cast<CGUILabelControl *>(GetControl(CONTROL_INPUT_LABEL));
   if (pLabel)
   {
     pLabel->SetLabel(strLabel);

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -86,7 +86,7 @@ void CGUIDialogNumeric::OnInitWindow()
     break;
   }
 
-  const CGUILabelControl *control = (const CGUILabelControl *)GetControl(CONTROL_HEADING_LABEL);
+  const CGUIControl *control = GetControl(CONTROL_HEADING_LABEL);
   if (control != NULL)
     data["title"] = control->GetDescription();
 

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -57,7 +57,7 @@ bool CGUIDialogSlider::OnMessage(CGUIMessage& message)
   case GUI_MSG_CLICKED:
     if (message.GetSenderId() == CONTROL_SLIDER)
     {
-      CGUISliderControl *slider = (CGUISliderControl *)GetControl(CONTROL_SLIDER);
+      CGUISliderControl *slider = dynamic_cast<CGUISliderControl *>(GetControl(CONTROL_SLIDER));
       if (slider && m_callback)
       {
         m_callback->OnSliderChange(m_callbackData, slider);
@@ -76,7 +76,7 @@ bool CGUIDialogSlider::OnMessage(CGUIMessage& message)
 void CGUIDialogSlider::SetSlider(const CStdString &label, float value, float min, float delta, float max, ISliderCallback *callback, void *callbackData)
 {
   SET_CONTROL_LABEL(CONTROL_HEADING, label);
-  CGUISliderControl *slider = (CGUISliderControl *)GetControl(CONTROL_SLIDER);
+  CGUISliderControl *slider = dynamic_cast<CGUISliderControl *>(GetControl(CONTROL_SLIDER));
   m_callback = callback;
   m_callbackData = callbackData;
   if (slider)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -501,7 +501,7 @@ void CGUIDialogSmartPlaylistRule::OnInitWindow()
   }
   UpdateButtons();
 
-  CGUIEditControl *editControl = (CGUIEditControl*)GetControl(CONTROL_VALUE);
+  CGUIEditControl *editControl = dynamic_cast<CGUIEditControl*>(GetControl(CONTROL_VALUE));
   if (editControl != NULL)
     editControl->SetInputValidation(CSmartPlaylistRule::Validate, &m_rule);
 }

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -434,16 +434,35 @@ bool CGUIControlGroup::HasVisibleID(int id) const
   return false;
 }
 
-const CGUIControl* CGUIControlGroup::GetControl(int iControl) const
+CGUIControl *CGUIControlGroup::GetControl(int iControl)
 {
   CGUIControl *pPotential = NULL;
+  LookupMap::iterator first = m_lookup.find(iControl);
+  if (first != m_lookup.end())
+  {
+    LookupMap::iterator last = m_lookup.upper_bound(iControl);
+    for (LookupMap::iterator i = first; i != last; ++i)
+    {
+      CGUIControl *control = i->second;
+      if (control->IsVisible())
+        return control;
+      else if (!pPotential)
+        pPotential = control;
+    }
+  }
+  return pPotential;
+}
+
+const CGUIControl* CGUIControlGroup::GetControl(int iControl) const
+{
+  const CGUIControl *pPotential = NULL;
   LookupMap::const_iterator first = m_lookup.find(iControl);
   if (first != m_lookup.end())
   {
     LookupMap::const_iterator last = m_lookup.upper_bound(iControl);
     for (LookupMap::const_iterator i = first; i != last; ++i)
     {
-      CGUIControl *control = i->second;
+      const CGUIControl *control = i->second;
       if (control->IsVisible())
         return control;
       else if (!pPotential)

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -68,6 +68,7 @@ public:
   int GetFocusedControlID() const;
   CGUIControl *GetFocusedControl() const;
   const CGUIControl *GetControl(int id) const;
+  CGUIControl *GetControl(int id);
   virtual CGUIControl *GetFirstFocusableControl(int id);
   void GetContainers(std::vector<CGUIControl *> &containers) const;
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -461,7 +461,7 @@ EVENT_RESULT CGUIWindow::OnMouseAction(const CAction &action)
   CMouseEvent event(action.GetID(), action.GetHoldTime(), action.GetAmount(2), action.GetAmount(3));
   if (m_exclusiveMouseControl)
   {
-    CGUIControl *child = (CGUIControl *)GetControl(m_exclusiveMouseControl);
+    CGUIControl *child = GetControl(m_exclusiveMouseControl);
     if (child)
     {
       CPoint renderPos = child->GetRenderPosition() - CPoint(child->GetXPosition(), child->GetYPosition());
@@ -641,7 +641,7 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
 
         // get the control to focus
         CGUIControl* pFocusedControl = GetFirstFocusableControl(message.GetControlId());
-        if (!pFocusedControl) pFocusedControl = (CGUIControl *)GetControl(message.GetControlId());
+        if (!pFocusedControl) pFocusedControl = GetControl(message.GetControlId());
 
         // and focus it
         if (pFocusedControl)
@@ -866,7 +866,7 @@ bool CGUIWindow::ControlGroupHasFocus(int groupID, int controlID)
   // 1.  Run through and get control with groupID (assume unique)
   // 2.  Get it's selected item.
   CGUIControl *group = GetFirstFocusableControl(groupID);
-  if (!group) group = (CGUIControl *)GetControl(groupID);
+  if (!group) group = GetControl(groupID);
 
   if (group && group->IsGroup())
   {
@@ -1007,7 +1007,7 @@ void CGUIWindow::DumpTextureUse()
 void CGUIWindow::ChangeButtonToEdit(int id, bool singleLabel /* = false*/)
 {
 #ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
-  CGUIControl *name = (CGUIControl *)GetControl(id);
+  CGUIControl *name = GetControl(id);
   if (name && name->GetControlType() == CGUIControl::GUICONTROL_BUTTON)
   { // change it to an edit control
     CGUIEditControl *edit = new CGUIEditControl(*(const CGUIButtonControl *)name);

--- a/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
@@ -54,7 +54,7 @@ bool CGUIDialogMusicOverlay::OnMessage(CGUIMessage& message)
 
 EVENT_RESULT CGUIDialogMusicOverlay::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
-  CGUIControl *pControl = (CGUIControl *)GetControl(CONTROL_LOGO_PIC);
+  CGUIControl *pControl = GetControl(CONTROL_LOGO_PIC);
   if (pControl && pControl->HitTest(point))
   {
     // send highlight message

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -122,7 +122,7 @@ bool CGUIWindowVisualisation::OnAction(const CAction &action)
 
   if (passToVis)
   {
-    CGUIControl *control = (CGUIControl *)GetControl(CONTROL_VIS);
+    CGUIControl *control = GetControl(CONTROL_VIS);
     if (control)
       return control->OnAction(action);
   }
@@ -138,7 +138,7 @@ bool CGUIWindowVisualisation::OnMessage(CGUIMessage& message)
   case GUI_MSG_VISUALISATION_RELOAD:
   case GUI_MSG_PLAYBACK_STARTED:
     {
-      CGUIControl *control = (CGUIControl *)GetControl(CONTROL_VIS);
+      CGUIControl *control = GetControl(CONTROL_VIS);
       if (control)
         return control->OnMessage(message);
     }

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -177,16 +177,7 @@ void CGUIWindowPictures::UpdateButtons()
   CGUIMediaWindow::UpdateButtons();
 
   // Update the shuffle button
-  if (CSettings::Get().GetBool("slideshow.shuffle"))
-  {
-    CGUIMessage msg2(GUI_MSG_SELECTED, GetID(), CONTROL_SHUFFLE);
-    g_windowManager.SendMessage(msg2);
-  }
-  else
-  {
-    CGUIMessage msg2(GUI_MSG_DESELECTED, GetID(), CONTROL_SHUFFLE);
-    g_windowManager.SendMessage(msg2);
-  }
+  SET_CONTROL_SELECTED(GetID(), CONTROL_SHUFFLE, CSettings::Get().GetBool("slideshow.shuffle"));
 
   // check we can slideshow or recursive slideshow
   int nFolders = m_vecItems->GetFolderCount();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -667,7 +667,6 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
 void CGUIDialogPVRChannelManager::SetData(int iItem)
 {
   CGUIEditControl        *pEdit;
-  CGUIRadioButtonControl *pRadioButton;
 
   /* Check file item is in list range and get his pointer */
   if (iItem < 0 || iItem >= (int)m_channelItems->Size()) return;
@@ -683,14 +682,9 @@ void CGUIDialogPVRChannelManager::SetData(int iItem)
     pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TEXT, 19208);
   }
 
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_ACTIVE);
-  if (pRadioButton) pRadioButton->SetSelected(pItem->GetProperty("ActiveChannel").asBoolean());
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_USEEPG);
-  if (pRadioButton) pRadioButton->SetSelected(pItem->GetProperty("UseEPG").asBoolean());
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_PARENTAL_LOCK);
-  if (pRadioButton) pRadioButton->SetSelected(pItem->GetProperty("ParentalLocked").asBoolean());
+  SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_ACTIVE, pItem->GetProperty("ActiveChannel").asBoolean());
+  SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_USEEPG, pItem->GetProperty("UseEPG").asBoolean());
+  SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_PARENTAL_LOCK, pItem->GetProperty("ParentalLocked").asBoolean());
 }
 
 void CGUIDialogPVRChannelManager::Update()

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -305,7 +305,6 @@ void CGUIDialogPVRGuideSearch::OnSearch()
 void CGUIDialogPVRGuideSearch::Update()
 {
   CGUIEditControl        *pEdit;
-  CGUIRadioButtonControl *pRadioButton;
 
   if (!m_searchFilter)
     return;
@@ -317,26 +316,13 @@ void CGUIDialogPVRGuideSearch::Update()
     pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TEXT, 16017);
   }
 
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_CASE_SENS);
-  if (pRadioButton) pRadioButton->SetSelected(m_searchFilter->m_bIsCaseSensitive);
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_INC_DESC);
-  if (pRadioButton) pRadioButton->SetSelected(m_searchFilter->m_bSearchInDescription);
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_FTA_ONLY);
-  if (pRadioButton) pRadioButton->SetSelected(m_searchFilter->m_bFTAOnly);
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_UNK_GENRE);
-  if (pRadioButton) pRadioButton->SetSelected(m_searchFilter->m_bIncludeUnknownGenres);
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_IGNORE_REC);
-  if (pRadioButton) pRadioButton->SetSelected(m_searchFilter->m_bIgnorePresentRecordings);
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_IGNORE_TMR);
-  if (pRadioButton) pRadioButton->SetSelected(m_searchFilter->m_bIgnorePresentTimers);
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_SPIN_NO_REPEATS);
-  if (pRadioButton) pRadioButton->SetSelected(m_searchFilter->m_bPreventRepeats);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_CASE_SENS, m_searchFilter->m_bIsCaseSensitive);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_INC_DESC, m_searchFilter->m_bSearchInDescription);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_FTA_ONLY, m_searchFilter->m_bFTAOnly);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_UNK_GENRE, m_searchFilter->m_bIncludeUnknownGenres);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_IGNORE_REC, m_searchFilter->m_bIgnorePresentRecordings);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_IGNORE_TMR, m_searchFilter->m_bIgnorePresentTimers);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_SPIN_NO_REPEATS, m_searchFilter->m_bPreventRepeats);
 
   /* Set time fields */
   pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_TIME);

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -344,16 +344,16 @@ void CGUIDialogSettingsBase::SetupControls(bool createSettings /* = true */)
     m_categories.push_back(m_dummyCategory);
 
   // get all controls
-  m_pOriginalSpin = (CGUISpinControlEx*)GetControl(CONTROL_DEFAULT_SPIN);
-  m_pOriginalSlider = (CGUISettingsSliderControl*)GetControl(CONTROL_DEFAULT_SLIDER);
-  m_pOriginalRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_DEFAULT_RADIOBUTTON);
-  m_pOriginalCategoryButton = (CGUIButtonControl *)GetControl(CONTROL_DEFAULT_CATEGORY_BUTTON);
-  m_pOriginalButton = (CGUIButtonControl *)GetControl(CONTROL_DEFAULT_BUTTON);
-  m_pOriginalImage = (CGUIImage *)GetControl(CONTROL_DEFAULT_SEPARATOR);
-  m_pOriginalEdit = (CGUIEditControl *)GetControl(CONTROL_DEFAULT_EDIT);
-  if (!m_pOriginalEdit || m_pOriginalEdit->GetControlType() != CGUIControl::GUICONTROL_EDIT)
+  m_pOriginalSpin = dynamic_cast<CGUISpinControlEx*>(GetControl(CONTROL_DEFAULT_SPIN));
+  m_pOriginalSlider = dynamic_cast<CGUISettingsSliderControl*>(GetControl(CONTROL_DEFAULT_SLIDER));
+  m_pOriginalRadioButton = dynamic_cast<CGUIRadioButtonControl *>(GetControl(CONTROL_DEFAULT_RADIOBUTTON));
+  m_pOriginalCategoryButton = dynamic_cast<CGUIButtonControl *>(GetControl(CONTROL_DEFAULT_CATEGORY_BUTTON));
+  m_pOriginalButton = dynamic_cast<CGUIButtonControl *>(GetControl(CONTROL_DEFAULT_BUTTON));
+  m_pOriginalImage = dynamic_cast<CGUIImage *>(GetControl(CONTROL_DEFAULT_SEPARATOR));
+  m_pOriginalEdit = dynamic_cast<CGUIEditControl *>(GetControl(CONTROL_DEFAULT_EDIT));
+
+  if (!m_pOriginalEdit && m_pOriginalButton)
   {
-    delete m_pOriginalEdit;
     m_pOriginalEdit = new CGUIEditControl(*m_pOriginalButton);
     m_newOriginalEdit = true;
   }
@@ -369,7 +369,7 @@ void CGUIDialogSettingsBase::SetupControls(bool createSettings /* = true */)
   if (m_pOriginalCategoryButton != NULL)
   {
     // setup our control groups...
-    CGUIControlGroupList *group = (CGUIControlGroupList *)GetControl(CATEGORY_GROUP_ID);
+    CGUIControlGroupList *group = dynamic_cast<CGUIControlGroupList *>(GetControl(CATEGORY_GROUP_ID));
     if (!group)
       return;
 
@@ -402,7 +402,7 @@ void CGUIDialogSettingsBase::SetupControls(bool createSettings /* = true */)
 void CGUIDialogSettingsBase::FreeControls()
 {
   // clear the category group
-  CGUIControlGroupList *control = (CGUIControlGroupList *)GetControl(CATEGORY_GROUP_ID);
+  CGUIControlGroupList *control = dynamic_cast<CGUIControlGroupList *>(GetControl(CATEGORY_GROUP_ID));
   if (control)
   {
     control->FreeResources();
@@ -429,7 +429,7 @@ void CGUIDialogSettingsBase::DeleteControls()
 void CGUIDialogSettingsBase::FreeSettingsControls()
 {
   // clear the settings group
-  CGUIControlGroupList *control = (CGUIControlGroupList *)GetControl(SETTINGS_GROUP_ID);
+  CGUIControlGroupList *control = dynamic_cast<CGUIControlGroupList *>(GetControl(SETTINGS_GROUP_ID));
   if (control)
   {
     control->FreeResources();
@@ -486,7 +486,7 @@ std::set<std::string> CGUIDialogSettingsBase::CreateSettings()
   if (m_iCategory < 0 || m_iCategory >= (int)m_categories.size())
     m_iCategory = 0;
 
-  CGUIControlGroupList *group = (CGUIControlGroupList *)GetControl(SETTINGS_GROUP_ID);
+  CGUIControlGroupList *group = dynamic_cast<CGUIControlGroupList *>(GetControl(SETTINGS_GROUP_ID));
   if (group == NULL)
     return settingMap;
 
@@ -688,7 +688,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSettingControl(CGUIControl *pControl, Ba
   pControl->SetVisible(true);
   pControl->SetWidth(width);
   
-  CGUIControlGroupList *group = (CGUIControlGroupList *)GetControl(SETTINGS_GROUP_ID);
+  CGUIControlGroupList *group = dynamic_cast<CGUIControlGroupList *>(GetControl(SETTINGS_GROUP_ID));
   if (group != NULL)
   {
     pControl->AllocResources();

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -219,7 +219,7 @@ unsigned int CGUIWindowSettingsScreenCalibration::FindCurrentResolution()
 
 void CGUIWindowSettingsScreenCalibration::NextControl()
 { // set the old control invisible and not focused, and choose the next control
-  CGUIControl *pControl = (CGUIControl *)GetControl(m_iControl);
+  CGUIControl *pControl = GetControl(m_iControl);
   if (pControl)
   {
     pControl->SetVisible(false);
@@ -306,7 +306,7 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
 
   if (iControl == CONTROL_PIXEL_RATIO)
   {
-    CGUIResizeControl *pControl = (CGUIResizeControl*)GetControl(CONTROL_PIXEL_RATIO);
+    CGUIControl *pControl = GetControl(CONTROL_PIXEL_RATIO);
     if (pControl)
     {
       float fWidth = (float)pControl->GetWidth();
@@ -412,7 +412,7 @@ void CGUIWindowSettingsScreenCalibration::DoProcess(unsigned int currentTime, CD
   for (int i = CONTROL_TOP_LEFT; i <= CONTROL_PIXEL_RATIO; i++)
   {
     SET_CONTROL_VISIBLE(i);
-    CGUIControl *control = (CGUIControl *)GetControl(i);
+    CGUIControl *control = GetControl(i);
     if (control)
       control->DoProcess(currentTime, dirtyregions);
   }

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -249,7 +249,7 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
   // disable the UI calibration for our controls
   // and set their limits
   // also, set them to invisible if they don't have focus
-  CGUIMoverControl *pControl = (CGUIMoverControl*)GetControl(CONTROL_TOP_LEFT);
+  CGUIMoverControl *pControl = dynamic_cast<CGUIMoverControl*>(GetControl(CONTROL_TOP_LEFT));
   RESOLUTION_INFO info = g_graphicsContext.GetResInfo(m_Res[m_iCurRes]);
   if (pControl)
   {
@@ -262,7 +262,7 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
     pControl->SetLocation(info.Overscan.left,
                           info.Overscan.top, false);
   }
-  pControl = (CGUIMoverControl*)GetControl(CONTROL_BOTTOM_RIGHT);
+  pControl = dynamic_cast<CGUIMoverControl*>(GetControl(CONTROL_BOTTOM_RIGHT));
   if (pControl)
   {
     pControl->SetLimits(info.iWidth*3 / 4,
@@ -275,7 +275,7 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
                           info.Overscan.bottom, false);
   }
   // Subtitles and OSD controls can only move up and down
-  pControl = (CGUIMoverControl*)GetControl(CONTROL_SUBTITLES);
+  pControl = dynamic_cast<CGUIMoverControl*>(GetControl(CONTROL_SUBTITLES));
   if (pControl)
   {
     pControl->SetLimits(0, info.iHeight*3 / 4,
@@ -285,7 +285,7 @@ void CGUIWindowSettingsScreenCalibration::ResetControls()
     pControl->SetLocation(0, info.iSubtitles, false);
   }
   // lastly the pixel ratio control...
-  CGUIResizeControl *pResize = (CGUIResizeControl*)GetControl(CONTROL_PIXEL_RATIO);
+  CGUIResizeControl *pResize = dynamic_cast<CGUIResizeControl*>(GetControl(CONTROL_PIXEL_RATIO));
   if (pResize)
   {
     pResize->SetLimits(info.iWidth*0.25f, info.iHeight*0.5f,
@@ -321,7 +321,7 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
   }
   else
   {
-    CGUIMoverControl *pControl = (CGUIMoverControl*)GetControl(iControl);
+    const CGUIMoverControl *pControl = dynamic_cast<const CGUIMoverControl*>(GetControl(iControl));
     if (pControl)
     {
       switch (iControl)

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -41,7 +41,6 @@
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
-#include "guilib/GUISelectButtonControl.h"
 #include "FileItem.h"
 #include "video/VideoReferenceClock.h"
 #include "settings/AdvancedSettings.h"
@@ -828,7 +827,7 @@ void CGUIWindowFullScreen::ChangetheTVGroup(bool next)
   if (!g_PVRManager.IsStarted())
     return;
 
-  CGUISelectButtonControl* pButton = (CGUISelectButtonControl*)GetControl(CONTROL_GROUP_CHOOSER);
+  CGUIControl* pButton = GetControl(CONTROL_GROUP_CHOOSER);
   if (!pButton)
     return;
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -358,7 +358,7 @@ void CGUIWindowFullScreen::OnWindowLoaded()
   // override the clear colour - we must never clear fullscreen
   m_clearBackground = 0;
 
-  CGUIProgressControl* pProgress = (CGUIProgressControl*)GetControl(CONTROL_PROGRESS);
+  CGUIProgressControl* pProgress = dynamic_cast<CGUIProgressControl*>(GetControl(CONTROL_PROGRESS));
   if(pProgress)
   {
     if( pProgress->GetInfo() == 0 || !pProgress->HasVisibleCondition())
@@ -369,14 +369,14 @@ void CGUIWindowFullScreen::OnWindowLoaded()
     }
   }
 
-  CGUILabelControl* pLabel = (CGUILabelControl*)GetControl(LABEL_BUFFERING);
+  CGUILabelControl* pLabel = dynamic_cast<CGUILabelControl*>(GetControl(LABEL_BUFFERING));
   if(pLabel && !pLabel->HasVisibleCondition())
   {
     pLabel->SetVisibleCondition("player.caching");
     pLabel->SetVisible(true);
   }
 
-  pLabel = (CGUILabelControl*)GetControl(LABEL_CURRENT_TIME);
+  pLabel = dynamic_cast<CGUILabelControl*>(GetControl(LABEL_CURRENT_TIME));
   if(pLabel && !pLabel->HasVisibleCondition())
   {
     pLabel->SetVisibleCondition("player.displayafterseek");

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -123,7 +123,7 @@ void CGUIMediaWindow::LoadAdditionalTags(TiXmlElement *root)
     for (unsigned int i = 0; i < views.size(); i++)
     {
       int controlID = atol(views[i].c_str());
-      CGUIControl *control = (CGUIControl *)GetControl(controlID);
+      CGUIControl *control = GetControl(controlID);
       if (control && control->IsContainer())
         m_viewControl.AddView(control);
     }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -533,16 +533,7 @@ void CGUIMediaWindow::UpdateButtons()
     else
     {
       CONTROL_ENABLE(CONTROL_BTNSORTASC);
-      if (m_guiState->GetDisplaySortOrder() == SortOrderAscending)
-      {
-        CGUIMessage msg(GUI_MSG_DESELECTED, GetID(), CONTROL_BTNSORTASC);
-        g_windowManager.SendMessage(msg);
-      }
-      else
-      {
-        CGUIMessage msg(GUI_MSG_SELECTED, GetID(), CONTROL_BTNSORTASC);
-        g_windowManager.SendMessage(msg);
-      }
+      SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSORTASC, m_guiState->GetDisplaySortOrder() != SortOrderAscending);
     }
 
     // Update list/thumb control

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -42,12 +42,12 @@ void CGUIWindowPointer::SetPointer(int pointer)
 {
   if (m_pointer == pointer) return;
   // set the new pointer visible
-  CGUIControl *pControl = (CGUIControl *)GetControl(pointer);
+  CGUIControl *pControl = GetControl(pointer);
   if (pControl)
   {
     pControl->SetVisible(true);
     // disable the old pointer
-    pControl = (CGUIControl *)GetControl(m_pointer);
+    pControl = GetControl(m_pointer);
     if (pControl) pControl->SetVisible(false);
     // set pointer to the new one
     m_pointer = pointer;


### PR DESCRIPTION
Fairly straight forward, though I'm thinking of two changes to make things cleaner:
1. Make a non-const version of GetControl() to save the insane copy n pasting of c-style casts all over the show.
2. Use dynamic_cast where we need to upcast, so we can NULL check on type anyway.
