### PR TITLE
PVR: A couple of fixes in guide search dialog

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -71,7 +71,7 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
   if (!pSpin || !pSpinGroups)
     return;
 
-  int iChannelGroup = pSpin->GetValue();
+  int iChannelGroup = pSpinGroups->GetValue();
 
   pSpin->Clear();
   pSpin->AddLabel(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -103,6 +103,8 @@ void CGUIDialogPVRGuideSearch::UpdateGroupsSpin(void)
   std::vector<CPVRChannelGroupPtr> group;
   std::vector<CPVRChannelGroupPtr>::const_iterator it;
 
+  pSpin->Clear();
+
   /* tv groups */
   group = g_PVRChannelGroups->GetTV()->GetMembers();
   for (it = group.begin(); it != group.end(); ++it)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -342,13 +342,13 @@ void CGUIDialogPVRGuideSearch::Update()
   pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_TIME);
   if (pEdit)
   {
-    pEdit->SetLabel2(m_searchFilter->m_endDateTime.GetAsLocalizedTime("", false));
+    pEdit->SetLabel2(m_searchFilter->m_startDateTime.GetAsLocalizedTime("", false));
     pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TIME, 14066);
   }
   pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_STOP_TIME);
   if (pEdit)
   {
-    pEdit->SetLabel2(m_searchFilter->m_startDateTime.GetAsLocalizedTime("", false));
+    pEdit->SetLabel2(m_searchFilter->m_endDateTime.GetAsLocalizedTime("", false));
     pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TIME, 14066);
   }
   pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_DATE);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -92,6 +92,8 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
     int iChannelNumber = group->GetChannelNumber(*channel->GetPVRChannelInfoTag());
     pSpin->AddLabel(channel->GetPVRChannelInfoTag()->ChannelName().c_str(), iChannelNumber);
   }
+
+  pSpin->SetValue(m_searchFilter->m_iChannelNumber);
 }
 
 void CGUIDialogPVRGuideSearch::UpdateGroupsSpin(void)


### PR DESCRIPTION
These are pretty straight forward bugs.  The only one I'm not sure about is the spinner setting of current channel number (atm it's by omission setting the first channel I think, though it may depend on what was in the spinner before the call to UpdateChannelSpin)

@opdenkamp, @Jalle19, @xhaggi yours to review
