### PR TITLE
IPlayer: use callbacks for current subtitle and audio stream index

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4360,6 +4360,16 @@ void CApplication::OnPlayBackSeekChapter(int iChapter)
 #endif
 }
 
+void CApplication::OnSetAudioStream(int stream)
+{
+  m_pPlayer->m_iAudioStream = stream;
+}
+
+void CApplication::OnSetSubtitleStream(int stream)
+{
+  m_pPlayer->m_iSubtitleStream = stream;
+}
+
 bool CApplication::IsPlayingFullScreenVideo() const
 {
   return m_pPlayer->IsPlayingVideo() && g_graphicsContext.IsFullScreenVideo();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -168,6 +168,8 @@ public:
   virtual void OnPlayBackSeek(int iTime, int seekOffset);
   virtual void OnPlayBackSeekChapter(int iChapter);
   virtual void OnPlayBackSpeedChanged(int iSpeed);
+  virtual void OnSetAudioStream(int stream);
+  virtual void OnSetSubtitleStream(int stream);
   bool PlayMedia(const CFileItem& item, int iPlaylist = PLAYLIST_MUSIC);
   bool PlayMediaSync(const CFileItem& item, int iPlaylist = PLAYLIST_MUSIC);
   bool ProcessAndStartPlaylist(const CStdString& strPlayList, PLAYLIST::CPlayList& playlist, int iPlaylist, int track=0);

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -320,7 +320,7 @@ int CApplicationPlayer::GetAudioStream()
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    return player->GetAudioStream();
+    return m_iAudioStream;
   else
     return 0;
 }
@@ -329,7 +329,7 @@ int CApplicationPlayer::GetSubtitle()
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    return player->GetSubtitle();
+    return m_iSubtitleStream;
   else
     return 0;
 }

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -58,6 +58,8 @@ public:
   CApplicationPlayer();
 
   int m_iPlaySpeed;
+  int m_iAudioStream;
+  int m_iSubtitleStream;
 
   // player management
   void CloseFile(bool reopen = false);
@@ -81,7 +83,6 @@ public:
   void  DoAudioWork();
   void  GetAudioCapabilities(std::vector<int> &audioCaps);
   void  GetAudioInfo( CStdString& strAudioInfo);
-  int   GetAudioStream();
   int   GetAudioStreamCount();
   void  GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
   int   GetCacheLevel() const;
@@ -98,7 +99,6 @@ public:
   void  GetRenderFeatures(std::vector<int> &renderFeatures);
   void  GetScalingMethods(std::vector<int> &scalingMethods);
   bool  GetStreamDetails(CStreamDetails &details);
-  int   GetSubtitle();
   void  GetSubtitleCapabilities(std::vector<int> &subCaps);
   int   GetSubtitleCount();
   void  GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
@@ -144,4 +144,8 @@ public:
   bool  SwitchChannel(const PVR::CPVRChannel &channel);
   void  ToFFRW(int iSpeed = 0);
   void  UnRegisterAudioCallback();
+
+  // information kept by proxy
+  int   GetSubtitle();
+  int   GetAudioStream();
 };

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -164,7 +164,6 @@ public:
   virtual void SetSubTitleDelay(float fValue = 0.0f){};
   virtual float GetSubTitleDelay()    { return 0.0f; }
   virtual int  GetSubtitleCount()     { return 0; }
-  virtual int  GetSubtitle()          { return -1; }
   virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info){};
   virtual void SetSubtitle(int iStream){};
   virtual bool GetSubtitleVisible(){ return false;};
@@ -172,7 +171,6 @@ public:
   virtual int  AddSubtitle(const CStdString& strSubPath) {return -1;};
 
   virtual int  GetAudioStreamCount()  { return 0; }
-  virtual int  GetAudioStream()       { return -1; }
   virtual void SetAudioStream(int iStream){};
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info){};
 

--- a/xbmc/cores/IPlayerCallback.h
+++ b/xbmc/cores/IPlayerCallback.h
@@ -33,4 +33,6 @@ public:
   virtual void OnPlayBackSeek(int iTime, int seekOffset) {};
   virtual void OnPlayBackSeekChapter(int iChapter) {};
   virtual void OnPlayBackSpeedChanged(int iSpeed) {};
+  virtual void OnSetAudioStream(int stream) {};
+  virtual void OnSetSubtitleStream(int stream) {};
 };

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -769,6 +769,9 @@ void CDVDPlayer::OpenDefaultStreams(bool reset)
   SelectionStreams streams;
   bool valid;
 
+  m_callback.OnSetAudioStream(-1);
+  m_callback.OnSetSubtitleStream(-1);
+
   // open video stream
   streams = m_SelectionStreams.Get(STREAM_VIDEO, PredicateVideoPriority);
   valid   = false;
@@ -2962,6 +2965,8 @@ bool CDVDPlayer::OpenAudioStream(int iStream, int source, bool reset)
   /* audio normally won't consume full cpu, so let it have prio */
   m_dvdPlayerAudio.SetPriority(GetPriority()+1);
   CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = GetAudioStream();
+
+  m_callback.OnSetAudioStream(GetAudioStream());
   return true;
 }
 
@@ -3148,6 +3153,8 @@ bool CDVDPlayer::OpenSubtitleStream(int iStream, int source)
   m_CurrentSubtitle.started = false;
 
   CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = GetSubtitle();
+
+  m_callback.OnSetSubtitleStream(GetSubtitle());
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -204,7 +204,6 @@ public:
   virtual void SetSubTitleDelay(float fValue = 0.0f);
   virtual float GetSubTitleDelay();
   virtual int GetSubtitleCount();
-  virtual int GetSubtitle();
   virtual void GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info);
   virtual void SetSubtitle(int iStream);
   virtual bool GetSubtitleVisible();
@@ -212,7 +211,6 @@ public:
   virtual int  AddSubtitle(const CStdString& strSubPath);
 
   virtual int GetAudioStreamCount();
-  virtual int GetAudioStream();
   virtual void SetAudioStream(int iStream);
 
   virtual TextCacheStruct_t* GetTeletextCache();
@@ -329,6 +327,8 @@ protected:
   bool IsValidStream(CCurrentStream& stream);
   bool IsBetterStream(CCurrentStream& current, CDemuxStream* stream);
   bool CheckDelayedChannelEntry(void);
+  int GetAudioStream();
+  int GetSubtitle();
 
   bool OpenInputStream();
   bool OpenDemuxStream();


### PR DESCRIPTION
setting audio and subtitle streams are asynchronous. an read immediately followed by a set returns wrong values.

@Montellese I noticed there are some other classes like Python which implement IPlayercallback. Not sure if those are interested in this info. If so we should define the callbacks as pure virtual.

(OMX needs to be done)
