### PR TITLE
Masterclock

### DIFF
--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -28,7 +28,6 @@
 int64_t CDVDClock::m_systemOffset;
 int64_t CDVDClock::m_systemFrequency;
 CCriticalSection CDVDClock::m_systemsection;
-bool CDVDClock::m_ismasterclock;
 CDVDClock *CDVDClock::m_playerclock = NULL;;
 
 CDVDClock::CDVDClock()
@@ -43,7 +42,6 @@ CDVDClock::CDVDClock()
   m_maxspeedadjust = 0.0;
   m_speedadjust = false;
 
-  m_ismasterclock = true;
   m_startClock = 0;
 
   m_playerclock = this;

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -31,6 +31,7 @@ CCriticalSection CDVDClock::m_systemsection;
 CDVDClock *CDVDClock::m_playerclock = NULL;;
 
 CDVDClock::CDVDClock()
+  :  m_master(MASTER_CLOCK_NONE)
 {
   CSingleLock lock(m_systemsection);
   CheckSystemClock();
@@ -256,3 +257,14 @@ double CDVDClock::SystemToPlaying(int64_t system)
   return DVD_TIME_BASE * (double)(current - m_startClock) / m_systemUsed + m_iDisc;
 }
 
+EMasterClock CDVDClock::GetMaster()
+{
+  CSharedLock lock(m_critSection);
+  return m_master;
+}
+
+void CDVDClock::SetMaster(EMasterClock master)
+{
+  CExclusiveLock lock(m_critSection);
+  m_master = master;
+}

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -24,6 +24,7 @@
 #include "utils/MathUtils.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "settings/Settings.h"
 
 int64_t CDVDClock::m_systemOffset;
 int64_t CDVDClock::m_systemFrequency;
@@ -41,7 +42,6 @@ CDVDClock::CDVDClock()
   m_bReset = true;
   m_iDisc = 0;
   m_maxspeedadjust = 0.0;
-  m_speedadjust = false;
 
   m_startClock = 0;
 
@@ -175,12 +175,11 @@ void CDVDClock::Resume()
   }
 }
 
-bool CDVDClock::SetMaxSpeedAdjust(double speed)
+void CDVDClock::SetMaxSpeedAdjust(double speed)
 {
   CSingleLock lock(m_speedsection);
 
   m_maxspeedadjust = speed;
-  return m_speedadjust;
 }
 
 //returns the refreshrate if the videoreferenceclock is running, -1 otherwise
@@ -188,11 +187,7 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
 {
   //sent with fps of 0 means we are not playing video
   if(fps == 0.0)
-  {
-    CSingleLock lock(m_speedsection);
-    m_speedadjust = false;
     return -1;
-  }
 
   //check if the videoreferenceclock is running, will return -1 if not
   int rate = g_VideoReferenceClock.GetRefreshRate(interval);
@@ -201,8 +196,6 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
     return -1;
 
   CSingleLock lock(m_speedsection);
-
-  m_speedadjust = true;
 
   double weight = (double)rate / (double)MathUtils::round_int(fps);
 
@@ -266,5 +259,13 @@ EMasterClock CDVDClock::GetMaster()
 void CDVDClock::SetMaster(EMasterClock master)
 {
   CExclusiveLock lock(m_critSection);
+
+  if(m_master != master)
+  {
+    /* if we switched from video ref clock, we need to normalize speed */
+    if(m_master == MASTER_CLOCK_AUDIO_VIDEOREF)
+      g_VideoReferenceClock.SetSpeed(1.0);
+  }
+
   m_master = master;
 }

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -269,3 +269,8 @@ void CDVDClock::SetMaster(EMasterClock master)
 
   m_master = master;
 }
+
+double CDVDClock::GetClockSpeed()
+{
+  return g_VideoReferenceClock.GetSpeed();
+}

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -145,19 +145,25 @@ void CDVDClock::SetSpeed(int iSpeed)
   m_systemUsed = newfreq;
 }
 
-void CDVDClock::Discontinuity(double clock, double absolute, const char* log)
+bool CDVDClock::Update(double clock, double absolute, double limit, const char* log)
 {
   CExclusiveLock lock(m_critSection);
   double was_absolute = SystemToAbsolute(m_startClock);
   double was_clock    = m_iDisc + absolute - was_absolute;
-  Discontinuity(clock, absolute);
   lock.Leave();
+  if(std::abs(clock - was_clock) > limit)
+  {
+    Discontinuity(clock, absolute);
 
-  CLog::Log(LOGDEBUG, "CDVDClock::Discontinuity - %s - was:%f, should be:%f, error:%f"
-            , log
-            , was_clock
-            , clock
-            , clock - was_clock);
+    CLog::Log(LOGDEBUG, "CDVDClock::Discontinuity - %s - was:%f, should be:%f, error:%f"
+                      , log
+                      , was_clock
+                      , clock
+                      , clock - was_clock);
+    return true;
+  }
+  else
+    return false;
 }
 
 void CDVDClock::Discontinuity(double clock, double absolute)

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -81,6 +81,5 @@ protected:
   double           m_maxspeedadjust;
   bool             m_speedadjust;
   CCriticalSection m_speedsection;
-  static bool      m_ismasterclock;
   static CDVDClock *m_playerclock;
 };

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -65,6 +65,8 @@ public:
   void Resume();
   void SetSpeed(int iSpeed);
 
+  double GetClockSpeed(); /**< get the current speed of the clock relative normal system time */
+
   /* tells clock at what framerate video is, to  *
    * allow it to adjust speed for a better match */
   int UpdateFramerate(double fps, double* interval = NULL);

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -35,11 +35,24 @@
 #define DVD_PLAYSPEED_PAUSE       0       // frame stepping
 #define DVD_PLAYSPEED_NORMAL      1000
 
+enum EMasterClock
+{
+  MASTER_CLOCK_NONE,
+  MASTER_CLOCK_AUDIO,
+  MASTER_CLOCK_VIDEO,
+  MASTER_CLOCK_INPUT,
+};
+
 class CDVDClock
 {
 public:
+
   CDVDClock();
   ~CDVDClock();
+
+  EMasterClock GetMaster();
+  void         SetMaster(EMasterClock master);
+
 
   double GetClock(bool interpolated = true);
   double GetClock(double& absolute, bool interpolated = true);
@@ -73,6 +86,7 @@ protected:
   int64_t m_pauseClock;
   double m_iDisc;
   bool m_bReset;
+  EMasterClock m_master;
 
   static int64_t m_systemFrequency;
   static int64_t m_systemOffset;

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -39,6 +39,7 @@ enum EMasterClock
 {
   MASTER_CLOCK_NONE,
   MASTER_CLOCK_AUDIO,
+  MASTER_CLOCK_AUDIO_VIDEOREF,
   MASTER_CLOCK_VIDEO,
   MASTER_CLOCK_INPUT,
 };
@@ -68,7 +69,7 @@ public:
    * allow it to adjust speed for a better match */
   int UpdateFramerate(double fps, double* interval = NULL);
 
-  bool   SetMaxSpeedAdjust(double speed);
+  void   SetMaxSpeedAdjust(double speed);
 
   static double GetAbsoluteClock(bool interpolated = true);
   static double GetFrequency() { return (double)m_systemFrequency ; }
@@ -93,7 +94,6 @@ protected:
   static CCriticalSection m_systemsection;
 
   double           m_maxspeedadjust;
-  bool             m_speedadjust;
   CCriticalSection m_speedsection;
   static CDVDClock *m_playerclock;
 };

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -58,7 +58,12 @@ public:
   double GetClock(bool interpolated = true);
   double GetClock(double& absolute, bool interpolated = true);
 
-  void Discontinuity(double currentPts = 0LL);
+  void Discontinuity(double clock, double absolute, const char* log);
+  void Discontinuity(double clock, double absolute);
+  void Discontinuity(double clock = 0LL)
+  {
+    Discontinuity(clock, GetAbsoluteClock());
+  }
 
   void Reset() { m_bReset = true; }
   void Pause();
@@ -81,6 +86,7 @@ public:
 protected:
   static void   CheckSystemClock();
   static double SystemToAbsolute(int64_t system);
+  static int64_t AbsoluteToSystem(double absolute);
   double        SystemToPlaying(int64_t system);
 
   CSharedSection m_critSection;

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -58,7 +58,7 @@ public:
   double GetClock(bool interpolated = true);
   double GetClock(double& absolute, bool interpolated = true);
 
-  void Discontinuity(double clock, double absolute, const char* log);
+  bool Update(double clock, double absolute, double limit, const char* log);
   void Discontinuity(double clock, double absolute);
   void Discontinuity(double clock = 0LL)
   {

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1744,9 +1744,10 @@ bool CDVDPlayer::CheckPlayerInit(CCurrentStream& current, unsigned int source)
     if(m_playSpeed == DVD_PLAYSPEED_NORMAL)
     {
       if(     source == DVDPLAYER_AUDIO)
-        setclock = !m_CurrentVideo.inited;
+        setclock = m_clock.GetMaster() == MASTER_CLOCK_AUDIO
+                || m_clock.GetMaster() == MASTER_CLOCK_AUDIO_VIDEOREF;
       else if(source == DVDPLAYER_VIDEO)
-        setclock = !m_CurrentAudio.inited;
+        setclock = m_clock.GetMaster() == MASTER_CLOCK_VIDEO;
     }
     else
     {

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2956,6 +2956,8 @@ bool CDVDPlayer::OpenAudioStream(int iStream, int source, bool reset)
   m_CurrentAudio.started = false;
   m_HasAudio = true;
 
+  UpdateClockMaster();
+
   /* we are potentially going to be waiting on this */
   m_dvdPlayerAudio.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
 
@@ -3032,6 +3034,8 @@ bool CDVDPlayer::OpenVideoStream(int iStream, int source, bool reset)
   m_CurrentVideo.stream = (void*)pStream;
   m_CurrentVideo.started = false;
   m_HasVideo = true;
+
+  UpdateClockMaster();
 
   /* we are potentially going to be waiting on this */
   m_dvdPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::PLAYER_STARTED), 1);
@@ -3240,6 +3244,7 @@ bool CDVDPlayer::CloseAudioStream(bool bWaitForBuffers)
   m_dvdPlayerAudio.CloseStream(bWaitForBuffers);
 
   m_CurrentAudio.Clear();
+  UpdateClockMaster();
   return true;
 }
 
@@ -3256,6 +3261,7 @@ bool CDVDPlayer::CloseVideoStream(bool bWaitForBuffers)
   m_dvdPlayerVideo.CloseStream(bWaitForBuffers);
 
   m_CurrentVideo.Clear();
+  UpdateClockMaster();
   return true;
 }
 
@@ -3286,6 +3292,19 @@ bool CDVDPlayer::CloseTeletextStream(bool bWaitForBuffers)
 
   m_CurrentTeletext.Clear();
   return true;
+}
+
+void CDVDPlayer::UpdateClockMaster()
+{
+  EMasterClock clock;
+  if(m_CurrentAudio.id >= 0)
+    clock = MASTER_CLOCK_AUDIO;
+  else if(m_CurrentVideo.id >= 0)
+    clock = MASTER_CLOCK_VIDEO;
+  else
+    clock = MASTER_CLOCK_NONE;
+
+  m_clock.SetMaster(clock);
 }
 
 void CDVDPlayer::FlushBuffers(bool queued, double pts, bool accurate)

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -85,6 +85,7 @@
 #include "LangInfo.h"
 #include "URL.h"
 #include "utils/LangCodeExpander.h"
+#include "video/VideoReferenceClock.h"
 
 using namespace std;
 using namespace PVR;
@@ -3298,7 +3299,12 @@ void CDVDPlayer::UpdateClockMaster()
 {
   EMasterClock clock;
   if(m_CurrentAudio.id >= 0)
-    clock = MASTER_CLOCK_AUDIO;
+  {
+    if(m_CurrentVideo.id >= 0 && g_VideoReferenceClock.GetRefreshRate() > 0)
+      clock = MASTER_CLOCK_AUDIO_VIDEOREF;
+    else
+      clock = MASTER_CLOCK_AUDIO;
+  }
   else if(m_CurrentVideo.id >= 0)
     clock = MASTER_CLOCK_VIDEO;
   else

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -336,6 +336,7 @@ protected:
 
   void UpdateApplication(double timeout);
   void UpdatePlayState(double timeout);
+  void UpdateClockMaster();
   double m_UpdateApplication;
 
   bool m_bAbortRequest;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -605,6 +605,9 @@ void CDVDPlayerAudio::SetSyncType(bool passthrough)
   if (!m_pClock->SetMaxSpeedAdjust(maxspeedadjust))
     m_synctype = SYNC_DISCON;
 
+  if(m_synctype == SYNC_DISCON && m_pClock->GetMaster() != MASTER_CLOCK_AUDIO)
+    m_synctype = SYNC_SKIPDUP;
+
   if (m_synctype != m_prevsynctype)
   {
     const char *synctypes[] = {"clock feedback", "skip/duplicate", "resample", "invalid"};
@@ -619,7 +622,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
   double clock = m_pClock->GetClock();
   double error = m_dvdAudio.GetPlayingPts() - clock;
 
-  if( fabs(error) > DVD_MSEC_TO_TIME(100) || m_syncclock )
+  if( (fabs(error) > DVD_MSEC_TO_TIME(100) || m_syncclock) && m_pClock->GetMaster() == MASTER_CLOCK_AUDIO )
   {
     m_pClock->Discontinuity(clock+error);
     CLog::Log(LOGDEBUG, "CDVDPlayerAudio:: Discontinuity1 - was:%f, should be:%f, error:%f", clock, clock+error, error);
@@ -657,7 +660,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
         error = m_error;
       }
 
-      if (fabs(error) > limit - 0.001)
+      if (fabs(error) > limit - 0.001 && m_pClock->GetMaster() == MASTER_CLOCK_AUDIO)
       {
         m_pClock->Discontinuity(clock+error);
         CLog::Log(LOGDEBUG, "CDVDPlayerAudio:: Discontinuity2 - was:%f, should be:%f, error:%f", clock, clock+error, error);

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -629,7 +629,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
   &&  (master == MASTER_CLOCK_AUDIO
     || master == MASTER_CLOCK_AUDIO_VIDEOREF) )
   {
-    m_pClock->Discontinuity(clock+error, absolute, "CDVDPlayerAudio::HandleSyncError1");
+    m_pClock->Update(clock+error, absolute, 0.0, "CDVDPlayerAudio::HandleSyncError1");
     m_errors.Flush();
     m_error = 0;
     m_syncclock = false;
@@ -663,8 +663,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
         error = m_error;
       }
 
-      if (fabs(error) > limit - 0.001)
-        m_pClock->Discontinuity(clock+error, absolute, "CDVDPlayerAudio::HandleSyncError2");
+      m_pClock->Update(clock+error, absolute, limit - 0.001, "CDVDPlayerAudio::HandleSyncError2");
     }
     else if (m_synctype == SYNC_RESAMPLE)
     {

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -689,7 +689,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
 
         proportional = m_error / DVD_TIME_BASE / proportionaldiv;
       }
-      m_resampleratio = 1.0 / g_VideoReferenceClock.GetSpeed() + proportional + m_integral;
+      m_resampleratio = 1.0 / m_pClock->GetClockSpeed() + proportional + m_integral;
     }
   }
 }

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -620,7 +620,8 @@ void CDVDPlayerAudio::SetSyncType(bool passthrough)
 
 void CDVDPlayerAudio::HandleSyncError(double duration)
 {
-  double clock = m_pClock->GetClock();
+  double absolute;
+  double clock = m_pClock->GetClock(absolute);
   double error = m_dvdAudio.GetPlayingPts() - clock;
   EMasterClock master = m_pClock->GetMaster();
 
@@ -628,9 +629,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
   &&  (master == MASTER_CLOCK_AUDIO
     || master == MASTER_CLOCK_AUDIO_VIDEOREF) )
   {
-    m_pClock->Discontinuity(clock+error);
-    CLog::Log(LOGDEBUG, "CDVDPlayerAudio:: Discontinuity1 - was:%f, should be:%f, error:%f", clock, clock+error, error);
-
+    m_pClock->Discontinuity(clock+error, absolute, "CDVDPlayerAudio::HandleSyncError1");
     m_errors.Flush();
     m_error = 0;
     m_syncclock = false;
@@ -665,10 +664,7 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
       }
 
       if (fabs(error) > limit - 0.001)
-      {
-        m_pClock->Discontinuity(clock+error);
-        CLog::Log(LOGDEBUG, "CDVDPlayerAudio:: Discontinuity2 - was:%f, should be:%f, error:%f", clock, clock+error, error);
-      }
+        m_pClock->Discontinuity(clock+error, absolute, "CDVDPlayerAudio::HandleSyncError2");
     }
     else if (m_synctype == SYNC_RESAMPLE)
     {

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -286,9 +286,6 @@ void CDVDPlayerVideo::CloseStream(bool bWaitForBuffers)
     CDVDCodecUtils::FreePicture(m_pTempOverlayPicture);
     m_pTempOverlayPicture = NULL;
   }
-
-  //tell the clock we stopped playing video
-  m_pClock->UpdateFramerate(0.0);
 }
 
 void CDVDPlayerVideo::OnStartup()

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1162,10 +1162,10 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   // sync clock if we are master
   if(m_pClock->GetMaster() == MASTER_CLOCK_VIDEO)
   {
-    double error = iClockSleep - iFrameSleep;
-    if( abs(error)  > DVD_MSEC_TO_TIME(10) )
-      m_pClock->Discontinuity(iPlayingClock + error, iCurrentClock, "CDVDPlayerVideo::OutputPicture");
-
+    m_pClock->Update( iPlayingClock + iClockSleep - iFrameSleep
+                    , iCurrentClock
+                    , DVD_MSEC_TO_TIME(10)
+                    , "CDVDPlayerVideo::OutputPicture");
   }
 
   // present the current pts of this frame to user, and include the actual

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -386,7 +386,8 @@ void CDVDPlayerVideo::Process()
       if(pMsgGeneralResync->m_timestamp != DVD_NOPTS_VALUE)
         pts = pMsgGeneralResync->m_timestamp;
 
-      double delay = m_FlipTimeStamp - m_pClock->GetAbsoluteClock();
+      double absolute = m_pClock->GetAbsoluteClock();
+      double delay = m_FlipTimeStamp - absolute;
       if( delay > frametime ) delay = frametime;
       else if( delay < 0 )    delay = 0;
       m_FlipTimePts = pts -frametime;
@@ -394,7 +395,7 @@ void CDVDPlayerVideo::Process()
       if(pMsgGeneralResync->m_clock)
       {
         CLog::Log(LOGDEBUG, "CDVDPlayerVideo - CDVDMsg::GENERAL_RESYNC(%f, 1)", pts);
-        m_pClock->Discontinuity(m_FlipTimePts);
+        m_pClock->Discontinuity(m_FlipTimePts, absolute);
       }
       else
         CLog::Log(LOGDEBUG, "CDVDPlayerVideo - CDVDMsg::GENERAL_RESYNC(%f, 0)", pts);
@@ -1163,12 +1164,8 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   {
     double error = iClockSleep - iFrameSleep;
     if( abs(error)  > DVD_MSEC_TO_TIME(10) )
-    {
-      CLog::Log(LOGDEBUG, "CDVDPlayerVideo:: Discontinuity - was:%f, should be:%f, error:%f"
-                        , iPlayingClock, iPlayingClock + error, error);
-      m_pClock->Discontinuity(iPlayingClock + error);
+      m_pClock->Discontinuity(iPlayingClock + error, iCurrentClock, "CDVDPlayerVideo::OutputPicture");
 
-    }
   }
 
   // present the current pts of this frame to user, and include the actual

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -122,6 +122,7 @@ protected:
   double m_iVideoDelay;
   double m_iSubtitleDelay;
   double m_FlipTimeStamp; // time stamp of last flippage. used to play at a forced framerate
+  double m_FlipTimePts;   // pts of the last flipped page
 
   int m_iLateFrames;
   int m_iDroppedFrames;


### PR DESCRIPTION
This pull moves the control of what that is in charge of current playback clock and adds support for video being fully in control.

Also avoids some scheduling problems with sync calculations by keeping track of the absolute clock that was used when calculations started.
