### PR TITLE
videolibrary: add setting to not group movies into a set if it contains a single item

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -10996,7 +10996,10 @@ msgctxt "#21415"
 msgid "Default music video scraper"
 msgstr ""
 
-#empty string with id 21416
+#: system/settings/settings.xml
+msgctxt "#21416"
+msgid "Hide sets containing a single movie"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21417"
@@ -13699,7 +13702,11 @@ msgctxt "#36156"
 msgid "Enable VAAPI hardware decoding of video files, mainly used for Intel graphics and in some circumstances AMD graphics."
 msgstr ""
 
-#empty string with id 36157
+#. Description of setting "Hide sets containing a single movie" with label #21416
+#: system/settings/settings.xml
+msgctxt "#36157"
+msgid "Don't group movies into a set if it only contains a single movie."
+msgstr ""
 
 #. Description of setting "Videos -> Playback -> Allow hardware acceleration (DXVA2)" with label #13427
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -337,13 +337,20 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+      </group>
+      <group id="2">
         <setting id="videolibrary.groupmoviesets" type="boolean" label="20458" help="36145">
           <level>0</level>
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.hidesingleitemsets" type="boolean" label="21416" help="36157">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
-      <group id="2">
+      <group id="3">
         <setting id="videolibrary.updateonstartup" type="boolean" label="22000" help="36146">
           <level>1</level>
           <default>false</default>
@@ -355,7 +362,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="3">
+      <group id="4">
         <setting id="videolibrary.cleanup" type="action" label="334" help="36148">
           <level>2</level>
           <control type="button" format="action" />

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4921,8 +4921,26 @@ bool CVideoDatabase::GetSetsByWhere(const CStdString& strBaseDir, const Filter &
       return false;
 
     CFileItemList sets;
-    if (!GroupUtils::Group(GroupBySet, strBaseDir, items, sets))
+    GroupAttribute groupingAttributes = ignoreSingleMovieSets ? GroupAttributeIgnoreSingleItems : GroupAttributeNone;
+    if (!GroupUtils::Group(GroupBySet, strBaseDir, items, sets, groupingAttributes))
       return false;
+
+    // if we want to ignore single movie sets we have to look through the
+    // resulting list because GroupUtils re-adds movies that would be alone
+    // in a set, so we have to manually remove them
+    if (ignoreSingleMovieSets)
+    {
+      for (int index = 0; index < sets.Size(); ++index)
+      {
+        const CFileItemPtr set = sets.Get(index);
+        if (!set->HasVideoInfoTag() ||
+            set->GetVideoInfoTag()->m_type != MediaTypeVideoCollection)
+        {
+          sets.Remove(index);
+          --index;
+        }
+      }
+    }
 
     items.ClearItems();
     items.Append(sets);
@@ -5786,7 +5804,7 @@ bool CVideoDatabase::GetItems(const CStdString &strBaseDir, VIDEODB_CONTENT_TYPE
   else if (itemType.Equals("studios"))
     return GetStudiosNav(strBaseDir, items, mediaType, filter);
   else if (itemType.Equals("sets"))
-    return GetSetsNav(strBaseDir, items, mediaType, filter);
+    return GetSetsNav(strBaseDir, items, mediaType, filter, CSettings::Get().GetBool("videolibrary.hidesingleitemsets"));
   else if (itemType.Equals("countries"))
     return GetCountriesNav(strBaseDir, items, mediaType, filter);
   else if (itemType.Equals("tags"))

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1788,7 +1788,10 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
        (CSettings::Get().GetBool("videolibrary.groupmoviesets") || (StringUtils::EqualsNoCase(group, "sets") && mixed)))
     {
       CFileItemList groupedItems;
-      if (GroupUtils::Group(GroupBySet, m_strFilterPath, items, groupedItems, GroupAttributeIgnoreSingleItems))
+      GroupAttribute groupingAttributes = GroupAttributeNone;
+      if (CSettings::Get().GetBool("videolibrary.hidesingleitemsets"))
+        groupingAttributes = GroupAttributeIgnoreSingleItems;
+      if (GroupUtils::Group(GroupBySet, m_strFilterPath, items, groupedItems, groupingAttributes))
       {
         items.ClearItems();
         items.Append(groupedItems);


### PR DESCRIPTION
This functionality has been requested ever since movie set support has been added to TheMovieDb and the scrapers which results in a lot of movies being part of a set. The problem is that a lot of sets only contain a single movie either because the other movies belonging to that set are not in the library or because there are no other movies belonging to that set yet (but are already anticipated).

These sets are hidden in the movie list (i.e. we show the movie and not the set) but that logic doesn't exist in the Movie Sets view. There, depending on the use case, it may make sense that we should only show sets that contain more than one movie or to show all sets to be able to manage them by hand.

Ideally that toggle would only be available in the Movie Sets view but IMO that's too much specific work for this use case so I added a global setting which will affect both sets in movie listings and sets in the Movie Sets view.
