### PR TITLE
Control access cleanup

### DIFF
--- a/xbmc/dialogs/GUIDialogButtonMenu.cpp
+++ b/xbmc/dialogs/GUIDialogButtonMenu.cpp
@@ -19,9 +19,6 @@
  */
 
 #include "GUIDialogButtonMenu.h"
-#include "guilib/GUILabelControl.h"
-#include "guilib/GUIButtonControl.h"
-
 
 #define CONTROL_BUTTON_LABEL  3100
 
@@ -48,17 +45,11 @@ bool CGUIDialogButtonMenu::OnMessage(CGUIMessage &message)
 
 void CGUIDialogButtonMenu::FrameMove()
 {
-  // get the label control
-  CGUILabelControl *pLabel = (CGUILabelControl *)GetControl(CONTROL_BUTTON_LABEL);
-  if (pLabel)
+  // get the active control, and put it's label into the label control
+  const CGUIControl *pControl = GetFocusedControl();
+  if (pControl && (pControl->GetControlType() == CGUIControl::GUICONTROL_BUTTON || pControl->GetControlType() == CGUIControl::GUICONTROL_TOGGLEBUTTON))
   {
-    // get the active window, and put it's label into the label control
-    const CGUIControl *pControl = GetFocusedControl();
-    if (pControl && (pControl->GetControlType() == CGUIControl::GUICONTROL_BUTTON || pControl->GetControlType() == CGUIControl::GUICONTROL_TOGGLEBUTTON))
-    {
-      CGUIButtonControl *pButton = (CGUIButtonControl *)pControl;
-      pLabel->SetLabel(pButton->GetLabel());
-    }
+    SET_CONTROL_LABEL(CONTROL_BUTTON_LABEL, pControl->GetDescription());
   }
   CGUIDialog::FrameMove();
 }

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -163,7 +163,6 @@ void CGUIDialogExtendedProgressBar::UpdateState(unsigned int currentTime)
   if (fProgress > -1.0f)
   {
     SET_CONTROL_VISIBLE(CONTROL_PROGRESS);
-    CGUIProgressControl* pProgressCtrl=(CGUIProgressControl*)GetControl(CONTROL_PROGRESS);
-    if (pProgressCtrl) pProgressCtrl->SetPercentage(fProgress);
+    CONTROL_SELECT_ITEM(CONTROL_PROGRESS, (unsigned int)fProgress);
   }
 }

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "GUIDialogKaiToast.h"
-#include "guilib/GUIImage.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "threads/SingleLock.h"
@@ -72,9 +71,8 @@ bool CGUIDialogKaiToast::OnMessage(CGUIMessage& message)
 void CGUIDialogKaiToast::OnWindowLoaded()
 {
   CGUIDialog::OnWindowLoaded();
-  CGUIImage *image = (CGUIImage *)GetControl(POPUP_ICON);
-  if (image)
-    m_defaultIcon = image->GetFileName();
+  CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), POPUP_ICON);
+  m_defaultIcon = msg.GetLabel();
 }
 
 void CGUIDialogKaiToast::QueueNotification(eMessageType eType, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
@@ -131,31 +129,29 @@ bool CGUIDialogKaiToast::DoWork()
 
     SET_CONTROL_LABEL(POPUP_NOTIFICATION_BUTTON, toast.description);
 
-    CGUIImage *image = (CGUIImage *)GetControl(POPUP_ICON);
-    if (image)
+    // set the appropriate icon
     {
-      CStdString strTypeImage = toast.imagefile;
+      std::string strTypeImage = toast.imagefile;
 
       if (strTypeImage.empty())
       {
-        CGUIImage *typeImage = NULL;
+        int imageControl = POPUP_ICON;
 
         if (toast.eType == Info)
-          typeImage = (CGUIImage *)GetControl(POPUP_ICON_INFO);
+          imageControl = POPUP_ICON_INFO;
         else if (toast.eType == Warning)
-          typeImage = (CGUIImage *)GetControl(POPUP_ICON_WARNING);
+          imageControl = POPUP_ICON_WARNING;
         else if (toast.eType == Error)
-          typeImage = (CGUIImage *)GetControl(POPUP_ICON_ERROR);
-        else
-          typeImage = image;
+          imageControl = POPUP_ICON_ERROR;
 
-        if (typeImage)
-          strTypeImage = typeImage->GetFileName();
+        CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), imageControl);
+        if (OnMessage(msg))
+          strTypeImage = msg.GetLabel();
         else
           strTypeImage = m_defaultIcon;
       }
 
-      image->SetFileName(strTypeImage);
+      SET_CONTROL_FILENAME(POPUP_ICON, strTypeImage);
     }
 
     //  Play the window specific init sound for each notification queued

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "GUIDialogSeekBar.h"
-#include "guilib/GUISliderControl.h"
 #include "Application.h"
 #include "GUIInfoManager.h"
 #include "utils/TimeUtils.h"
@@ -71,23 +70,13 @@ void CGUIDialogSeekBar::FrameMove()
   // update controls
   if (!g_application.GetSeekHandler()->InProgress() && !g_infoManager.m_performingSeek)
   { // position the bar at our current time
-    CGUISliderControl *pSlider = (CGUISliderControl*)GetControl(POPUP_SEEK_SLIDER);
-    if (pSlider && g_infoManager.GetTotalPlayTime())
-      pSlider->SetPercentage((float)g_infoManager.GetPlayTime()/g_infoManager.GetTotalPlayTime() * 0.1f);
-
-    CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), POPUP_SEEK_LABEL);
-    msg.SetLabel(g_infoManager.GetCurrentPlayTime());
-    OnMessage(msg);
+    CONTROL_SELECT_ITEM(POPUP_SEEK_LABEL, (unsigned int)(g_infoManager.GetPlayTime()/g_infoManager.GetTotalPlayTime() * 0.1f));
+    SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentPlayTime());
   }
   else
   {
-    CGUISliderControl *pSlider = (CGUISliderControl*)GetControl(POPUP_SEEK_SLIDER);
-    if (pSlider)
-      pSlider->SetPercentage(g_application.GetSeekHandler()->GetPercent());
-
-    CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), POPUP_SEEK_LABEL);
-    msg.SetLabel(g_infoManager.GetCurrentSeekTime());
-    OnMessage(msg);
+    CONTROL_SELECT_ITEM(POPUP_SEEK_LABEL, (unsigned int)g_application.GetSeekHandler()->GetPercent());
+    SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentSeekTime());
   }
 
   CGUIDialog::FrameMove();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -315,39 +315,19 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   }
 
   // sort out the order fields
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_ORDER_FIELD);
-    OnMessage(msg);
-  }
+  std::vector< std::pair<std::string, int> > labels;
   vector<SortBy> orders = CSmartPlaylistRule::GetOrders(m_playlist.GetType());
   for (unsigned int i = 0; i < orders.size(); i++)
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_ORDER_FIELD, orders[i]);
-    msg.SetLabel(SortUtils::GetSortLabel(orders[i]));
-    OnMessage(msg);
-  }
-  {
-    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), CONTROL_ORDER_FIELD, m_playlist.m_orderField);
-    OnMessage(msg);
-  }
+    labels.push_back(make_pair(g_localizeStrings.Get(SortUtils::GetSortLabel(orders[i])), orders[i]));
+  SET_CONTROL_LABELS(CONTROL_ORDER_FIELD, m_playlist.m_orderField, &labels);
 
   // setup groups
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_GROUP_BY);
-    OnMessage(msg);
-  }
+  labels.clear();
   vector<Field> groups = CSmartPlaylistRule::GetGroups(m_playlist.GetType());
   Field currentGroup = CSmartPlaylistRule::TranslateGroup(m_playlist.GetGroup());
   for (unsigned int i = 0; i < groups.size(); i++)
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_GROUP_BY, groups[i]);
-    msg.SetLabel(CSmartPlaylistRule::GetLocalizedGroup(groups[i]));
-    OnMessage(msg);
-  }
-  {
-    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), CONTROL_GROUP_BY, currentGroup);
-    OnMessage(msg);
-  }
+    labels.push_back(make_pair(CSmartPlaylistRule::GetLocalizedGroup(groups[i]), groups[i]));
+  SET_CONTROL_LABELS(CONTROL_GROUP_BY, currentGroup, &labels);
 
   if (m_playlist.IsGroupMixed())
     CONTROL_SELECT(CONTROL_GROUP_MIXED);
@@ -383,33 +363,21 @@ void CGUIDialogSmartPlaylistEditor::UpdateRuleControlButtons()
 void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
 {
   CGUIDialog::OnWindowLoaded();
+
   SendMessage(GUI_MSG_SET_TYPE, CONTROL_NAME, 0, 16012);
   // setup the match spinner
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_MATCH, 0);
-    msg.SetLabel(21425);
-    OnMessage(msg);
-  }
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_MATCH, 1);
-    msg.SetLabel(21426);
-    OnMessage(msg);
-  }
-  SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_MATCH, m_playlist.m_ruleCombination.GetType() == CSmartPlaylistRuleCombination::CombinationAnd ? 0 : 1);
+  std::vector< std::pair<std::string, int> > labels;
+  labels.push_back(make_pair(g_localizeStrings.Get(21425), 0));
+  labels.push_back(make_pair(g_localizeStrings.Get(21426), 1));
+  SET_CONTROL_LABELS(CONTROL_MATCH, m_playlist.m_ruleCombination.GetType() == CSmartPlaylistRuleCombination::CombinationAnd ? 0 : 1, &labels);
+
   // and now the limit spinner
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_LIMIT, 0);
-    msg.SetLabel(21428);
-    OnMessage(msg);
-  }
+  labels.clear();
+  labels.push_back(make_pair(g_localizeStrings.Get(21428), 0));
   const int limits[] = { 10, 25, 50, 100, 250, 500, 1000 };
   for (unsigned int i = 0; i < sizeof(limits) / sizeof(int); i++)
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_LIMIT, limits[i]);
-    CStdString label = StringUtils::Format(g_localizeStrings.Get(21436).c_str(), limits[i]);
-    msg.SetLabel(label);
-    OnMessage(msg);
-  }
+    labels.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(21436).c_str(), limits[i]), limits[i]));
+  SET_CONTROL_LABELS(CONTROL_LIMIT, 0, &labels);
 }
 
 void CGUIDialogSmartPlaylistEditor::OnInitWindow()
@@ -445,12 +413,9 @@ void CGUIDialogSmartPlaylistEditor::OnInitWindow()
     allowedTypes.push_back(TYPE_MIXED);
   }
   // add to the spinner
+  std::vector< std::pair<std::string, int> > labels;
   for (unsigned int i = 0; i < allowedTypes.size(); i++)
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_TYPE, allowedTypes[i]);
-    msg.SetLabel(GetLocalizedType(allowedTypes[i]));
-    OnMessage(msg);
-  }
+    labels.push_back(make_pair(GetLocalizedType(allowedTypes[i]), allowedTypes[i]));
   // check our playlist type is allowed
   PLAYLIST_TYPE type = ConvertType(m_playlist.GetType());
   bool allowed = false;
@@ -460,7 +425,7 @@ void CGUIDialogSmartPlaylistEditor::OnInitWindow()
   if (!allowed && allowedTypes.size())
     type = allowedTypes[0];
 
-  SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_TYPE, type);
+  SET_CONTROL_LABELS(CONTROL_TYPE, type, &labels);
   m_playlist.SetType(ConvertType(type));
   UpdateButtons();
 
@@ -484,13 +449,13 @@ CGUIDialogSmartPlaylistEditor::PLAYLIST_TYPE CGUIDialogSmartPlaylistEditor::Conv
   return TYPE_SONGS;
 }
 
-int CGUIDialogSmartPlaylistEditor::GetLocalizedType(PLAYLIST_TYPE type)
+std::string CGUIDialogSmartPlaylistEditor::GetLocalizedType(PLAYLIST_TYPE type)
 {
   for (unsigned int i = 0; i < NUM_TYPES; i++)
     if (types[i].type == type)
-      return types[i].localizedString;
+      return g_localizeStrings.Get(types[i].localizedString);
   assert(false);
-  return 0;
+  return "";
 }
 
 CStdString CGUIDialogSmartPlaylistEditor::ConvertType(PLAYLIST_TYPE type)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -61,7 +61,7 @@ protected:
   void HighlightItem(int item);
   PLAYLIST_TYPE ConvertType(const CStdString &type);
   CStdString ConvertType(PLAYLIST_TYPE type);
-  int GetLocalizedType(PLAYLIST_TYPE type);
+  std::string GetLocalizedType(PLAYLIST_TYPE type);
 
   CSmartPlaylist m_playlist;
 

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -374,6 +374,11 @@ void CGUIDialogSmartPlaylistRule::OnOperator()
   UpdateButtons();
 }
 
+std::pair<std::string, int> OperatorLabel(CDatabaseQueryRule::SEARCH_OPERATOR op)
+{
+  return make_pair(CSmartPlaylistRule::GetLocalizedOperator(op), op);
+}
+
 void CGUIDialogSmartPlaylistRule::UpdateButtons()
 {
   // update the field control
@@ -391,55 +396,57 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   else
     CONTROL_DISABLE(CONTROL_BROWSE);
 
+  std::vector< std::pair<std::string, int> > labels;
   switch (m_rule.GetFieldType(m_rule.m_field))
   {
   case CDatabaseQueryRule::TEXT_FIELD:
     // text fields - add the usual comparisons
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_CONTAINS);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_STARTS_WITH);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_ENDS_WITH);
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_CONTAINS));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_CONTAIN));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_STARTS_WITH));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_ENDS_WITH));
     break;
 
   case CDatabaseQueryRule::NUMERIC_FIELD:
   case CDatabaseQueryRule::SECONDS_FIELD:
     // numerical fields - less than greater than
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_GREATER_THAN);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_LESS_THAN);
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_GREATER_THAN));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_LESS_THAN));
     break;
 
   case CDatabaseQueryRule::DATE_FIELD:
     // date field
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_AFTER);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_BEFORE);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_IN_THE_LAST);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST);
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_AFTER));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_BEFORE));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_IN_THE_LAST));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_NOT_IN_THE_LAST));
     break;
 
   case CDatabaseQueryRule::PLAYLIST_FIELD:
     CONTROL_ENABLE(CONTROL_BROWSE);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL));
     break;
 
   case CDatabaseQueryRule::BOOLEAN_FIELD:
     CONTROL_DISABLE(CONTROL_VALUE);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_TRUE);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_FALSE);
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_TRUE));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_FALSE));
     break;
 
   case CDatabaseQueryRule::TEXTIN_FIELD:
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS);
-    AddOperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL);
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_EQUALS));
+    labels.push_back(OperatorLabel(CDatabaseQueryRule::OPERATOR_DOES_NOT_EQUAL));
     break;
   }
 
+  SET_CONTROL_LABELS(CONTROL_OPERATOR, m_rule.m_operator, &labels);
+
   // check our operator is valid, and update if not
-  SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_OPERATOR, m_rule.m_operator);
   CGUIMessage selected(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_OPERATOR);
   OnMessage(selected);
   m_rule.m_operator = (CDatabaseQueryRule::SEARCH_OPERATOR)selected.GetParam1();
@@ -473,26 +480,18 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   SendMessage(GUI_MSG_SET_TYPE, CONTROL_VALUE, type, 21420);
 }
 
-void CGUIDialogSmartPlaylistRule::AddOperatorLabel(CDatabaseQueryRule::SEARCH_OPERATOR op)
-{
-  CGUIMessage select(GUI_MSG_LABEL_ADD, GetID(), CONTROL_OPERATOR, op);
-  select.SetLabel(CSmartPlaylistRule::GetLocalizedOperator(op));
-  OnMessage(select);
-}
-
 void CGUIDialogSmartPlaylistRule::OnInitWindow()
 {
   CGUIDialog::OnInitWindow();
 
-  SendMessage(GUI_MSG_LABEL_RESET, CONTROL_FIELD);
   // add the fields to the field spincontrol
+  std::vector< std::pair<std::string, int> > labels;
   vector<Field> fields = CSmartPlaylistRule::GetFields(m_type);
   for (unsigned int i = 0; i < fields.size(); i++)
-  {
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_FIELD, fields[i]);
-    msg.SetLabel(CSmartPlaylistRule::GetLocalizedField(fields[i]));
-    OnMessage(msg);
-  }
+    labels.push_back(make_pair(CSmartPlaylistRule::GetLocalizedField(fields[i]), fields[i]));
+
+  SET_CONTROL_LABELS(CONTROL_FIELD, 0, &labels);
+
   UpdateButtons();
 
   CGUIEditControl *editControl = dynamic_cast<CGUIEditControl*>(GetControl(CONTROL_VALUE));

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
@@ -42,7 +42,6 @@ protected:
   void OnOK();
   void OnCancel();
   void UpdateButtons();
-  void AddOperatorLabel(CDatabaseQueryRule::SEARCH_OPERATOR op);
   void OnBrowse();
 
   CSmartPlaylistRule m_rule;

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -169,14 +169,14 @@ bool CGUIButtonControl::OnMessage(CGUIMessage& message)
       SetLabel2(message.GetLabel());
       return true;
     }
-    if (message.GetMessage() == GUI_MSG_SELECTED)
+    if (message.GetMessage() == GUI_MSG_SET_SELECTED)
     {
       if (!m_bSelected)
         SetInvalid();
       m_bSelected = true;
       return true;
     }
-    if (message.GetMessage() == GUI_MSG_DESELECTED)
+    if (message.GetMessage() == GUI_MSG_SET_DESELECTED)
     {
       if (m_bSelected)
         SetInvalid();

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -169,6 +169,11 @@ bool CGUIButtonControl::OnMessage(CGUIMessage& message)
       SetLabel2(message.GetLabel());
       return true;
     }
+    if (message.GetMessage() == GUI_MSG_IS_SELECTED)
+    {
+      message.SetParam1(m_bSelected ? 1 : 0);
+      return true;
+    }
     if (message.GetMessage() == GUI_MSG_SET_SELECTED)
     {
       if (!m_bSelected)

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -217,6 +217,16 @@ bool CGUIImage::OnMessage(CGUIMessage& message)
       FreeTextures(true); // true as we want to free the texture immediately
     return true;
   }
+  else if (message.GetMessage() == GUI_MSG_SET_FILENAME)
+  {
+    SetFileName(message.GetLabel());
+    return true;
+  }
+  else if (message.GetMessage() == GUI_MSG_GET_FILENAME)
+  {
+    message.SetLabel(GetFileName());
+    return true;
+  }
   return CGUIControl::OnMessage(message);
 }
 

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -135,6 +135,11 @@
 
 #define GUI_MSG_VALIDITY_CHANGED  44
 
+/*!
+ \brief Check whether a button is selected
+ */
+#define GUI_MSG_IS_SELECTED    45
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -140,6 +140,11 @@
  */
 #define GUI_MSG_IS_SELECTED    45
 
+/*!
+ \brief Bind a set of labels to a spin (or similar) control
+ */
+#define GUI_MSG_SET_LABELS     46
+
 #define GUI_MSG_USER         1000
 
 /*!
@@ -239,6 +244,17 @@ do { \
  CGUIMessage msg(GUI_MSG_LABEL2_SET, GetID(), controlID); \
  msg.SetLabel(label); \
  OnMessage(msg); \
+} while(0)
+
+/*!
+ \ingroup winmsg
+ \brief Set a bunch of labels on the given control
+ */
+#define SET_CONTROL_LABELS(controlID, defaultValue, labels) \
+do { \
+CGUIMessage msg(GUI_MSG_SET_LABELS, GetID(), controlID, defaultValue); \
+msg.SetPointer(labels); \
+OnMessage(msg); \
 } while(0)
 
 /*!

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -145,6 +145,17 @@
  */
 #define GUI_MSG_SET_LABELS     46
 
+/*!
+ \brief Set the filename for an image control
+ */
+#define GUI_MSG_SET_FILENAME   47
+
+/*!
+ \brief Get the filename of an image control
+ */
+
+#define GUI_MSG_GET_FILENAME   48
+
 #define GUI_MSG_USER         1000
 
 /*!
@@ -254,6 +265,17 @@ do { \
 do { \
 CGUIMessage msg(GUI_MSG_SET_LABELS, GetID(), controlID, defaultValue); \
 msg.SetPointer(labels); \
+OnMessage(msg); \
+} while(0)
+
+/*!
+ \ingroup winmsg
+ \brief Set the label of the current control
+ */
+#define SET_CONTROL_FILENAME(controlID,label) \
+do { \
+CGUIMessage msg(GUI_MSG_SET_FILENAME, GetID(), controlID); \
+msg.SetLabel(label); \
 OnMessage(msg); \
 } while(0)
 

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -43,8 +43,8 @@
 #define GUI_MSG_ENABLED         8   // enable control
 #define GUI_MSG_DISABLED        9   // disable control
 
-#define GUI_MSG_SELECTED       10   // control = selected
-#define GUI_MSG_DESELECTED     11   // control = not selected
+#define GUI_MSG_SET_SELECTED   10   // control = selected
+#define GUI_MSG_SET_DESELECTED 11   // control = not selected
 
 #define GUI_MSG_LABEL_ADD      12   // add label control (for controls supporting more then 1 label)
 
@@ -143,7 +143,7 @@
  */
 #define CONTROL_SELECT(controlID) \
 do { \
- CGUIMessage msg(GUI_MSG_SELECTED, GetID(), controlID); \
+ CGUIMessage msg(GUI_MSG_SET_SELECTED, GetID(), controlID); \
  OnMessage(msg); \
 } while(0)
 
@@ -153,7 +153,7 @@ do { \
  */
 #define CONTROL_DESELECT(controlID) \
 do { \
- CGUIMessage msg(GUI_MSG_DESELECTED, GetID(), controlID); \
+ CGUIMessage msg(GUI_MSG_SET_DESELECTED, GetID(), controlID); \
  OnMessage(msg); \
 } while(0)
 
@@ -268,7 +268,7 @@ do { \
 
 #define SET_CONTROL_SELECTED(dwSenderId, controlID, bSelect) \
 do { \
- CGUIMessage msg(bSelect?GUI_MSG_SELECTED:GUI_MSG_DESELECTED, dwSenderId, controlID); \
+ CGUIMessage msg(bSelect?GUI_MSG_SET_SELECTED:GUI_MSG_SET_DESELECTED, dwSenderId, controlID); \
  OnMessage(msg); \
 } while(0)
 

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -293,11 +293,6 @@ do { \
  OnMessage(msg); \
 } while(0)
 
-#define BIND_CONTROL(i,c,pv) \
-do { \
- pv = ((c*)GetControl(i));\
-} while(0)
-
 /*!
 \ingroup winmsg
 \brief Click message sent from controls to windows.

--- a/xbmc/guilib/GUIProgressControl.cpp
+++ b/xbmc/guilib/GUIProgressControl.cpp
@@ -126,6 +126,11 @@ bool CGUIProgressControl::CanFocus() const
 
 bool CGUIProgressControl::OnMessage(CGUIMessage& message)
 {
+  if (message.GetMessage() == GUI_MSG_ITEM_SELECT)
+  {
+    SetPercentage((float)message.GetParam1());
+    return true;
+  }
   return CGUIControl::OnMessage(message);
 }
 

--- a/xbmc/guilib/GUISelectButtonControl.cpp
+++ b/xbmc/guilib/GUISelectButtonControl.cpp
@@ -208,6 +208,14 @@ bool CGUISelectButtonControl::OnMessage(CGUIMessage& message)
       m_iDefaultItem = m_iCurrentItem = message.GetParam1();
       return true;
     }
+    else if (message.GetMessage() == GUI_MSG_SET_LABELS && message.GetPointer())
+    {
+      const std::vector< std::pair<std::string, int> > *labels = (const std::vector< std::pair<std::string, int> > *)message.GetPointer();
+      m_vecItems.clear();
+      for (std::vector< std::pair<std::string, int> >::const_iterator i = labels->begin(); i != labels->end(); ++i)
+        m_vecItems.push_back(i->first);
+      m_iDefaultItem = m_iCurrentItem = message.GetParam1();
+    }
   }
 
   return CGUIButtonControl::OnMessage(message);

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -254,6 +254,17 @@ bool CGUISpinControl::OnMessage(CGUIMessage& message)
         m_bShowRange = false;
       break;
 
+    case GUI_MSG_SET_LABELS:
+      if (message.GetPointer())
+      {
+        const vector< pair<string, int> > *labels = (const vector< pair<string, int> > *)message.GetPointer();
+        Clear();
+        for (vector< pair<string, int> >::const_iterator i = labels->begin(); i != labels->end(); ++i)
+          AddLabel(i->first, i->second);
+        SetValue( message.GetParam1());
+      }
+      break;
+
     case GUI_MSG_LABEL_ADD:
       {
         AddLabel(message.GetLabel(), message.GetParam1());

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -21,7 +21,6 @@
 #include "GUIDialogVisualisationPresetList.h"
 #include "addons/Visualisation.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/GUIListContainer.h"
 #include "GUIUserMessages.h"
 #include "FileItem.h"
 #include "guilib/Key.h"
@@ -58,10 +57,10 @@ bool CGUIDialogVisualisationPresetList::OnMessage(CGUIMessage &message)
                                                     message.GetParam1() == ACTION_MOUSE_LEFT_CLICK))
       {
         //clicked - ask for the preset to be changed to the new one
-        CGUIListContainer *pList = (CGUIListContainer *)GetControl(CONTROL_LIST);
-        if (pList)
+        CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_LIST);
+        if (OnMessage(msg))
         {
-          int iItem = pList->GetSelectedItem();
+          int iItem = (int)msg.GetParam1();
           if (m_viz)
             m_viz->OnAction(VIS_ACTION_LOAD_PRESET, (void *)&iItem);
         }

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -153,9 +153,8 @@ void CGUIDialogNetworkSetup::OnInitWindow()
 void CGUIDialogNetworkSetup::OnDeinitWindow(int nextWindowID)
 {
   // clear protocol spinner
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_PROTOCOL);
-  if (pSpin)
-    pSpin->Clear();
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_PROTOCOL);
+  OnMessage(msg);
 
   CGUIDialog::OnDeinitWindow(nextWindowID);
 }
@@ -197,10 +196,10 @@ void CGUIDialogNetworkSetup::OnCancel()
 
 void CGUIDialogNetworkSetup::OnProtocolChange()
 {
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_PROTOCOL);
-  if (!pSpin)
+  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_PROTOCOL);
+  if (!OnMessage(msg))
     return;
-  m_protocol = (NET_PROTOCOL)pSpin->GetValue();
+  m_protocol = (NET_PROTOCOL)msg.GetParam1();
   // set defaults for the port
   if (m_protocol == NET_PROTOCOL_FTP)
     m_port = "21";

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "GUIDialogNetworkSetup.h"
-#include "guilib/GUISpinControlEx.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIEditControl.h"
@@ -113,40 +112,37 @@ void CGUIDialogNetworkSetup::OnInitWindow()
   m_confirmed = false;
 
   CGUIDialog::OnInitWindow();
-  // Add our protocols
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_PROTOCOL);
-  if (!pSpin)
-    return;
 
-  pSpin->Clear();
+  // Add our protocols
+  std::vector< std::pair<std::string, int> > labels;
 #ifdef HAS_FILESYSTEM_SMB
-  pSpin->AddLabel(g_localizeStrings.Get(20171), NET_PROTOCOL_SMB);
+  labels.push_back(make_pair(g_localizeStrings.Get(20171), NET_PROTOCOL_SMB));
 #endif
-  pSpin->AddLabel(g_localizeStrings.Get(20256), NET_PROTOCOL_HTSP);
-  pSpin->AddLabel(g_localizeStrings.Get(20257), NET_PROTOCOL_VTP);
+  labels.push_back(make_pair(g_localizeStrings.Get(20256), NET_PROTOCOL_HTSP));
+  labels.push_back(make_pair(g_localizeStrings.Get(20257), NET_PROTOCOL_VTP));
 #ifdef HAS_MYSQL
-  pSpin->AddLabel(g_localizeStrings.Get(20258), NET_PROTOCOL_MYTH);
+  labels.push_back(make_pair(g_localizeStrings.Get(20258), NET_PROTOCOL_MYTH));
 #endif
-  pSpin->AddLabel(g_localizeStrings.Get(21331), NET_PROTOCOL_TUXBOX);
-  pSpin->AddLabel(g_localizeStrings.Get(20301), NET_PROTOCOL_HTTPS);
-  pSpin->AddLabel(g_localizeStrings.Get(20300), NET_PROTOCOL_HTTP);
-  pSpin->AddLabel(g_localizeStrings.Get(20254), NET_PROTOCOL_DAVS);
-  pSpin->AddLabel(g_localizeStrings.Get(20253), NET_PROTOCOL_DAV);
-  pSpin->AddLabel(g_localizeStrings.Get(20173), NET_PROTOCOL_FTP);
-  pSpin->AddLabel(g_localizeStrings.Get(20174), NET_PROTOCOL_DAAP);
-  pSpin->AddLabel(g_localizeStrings.Get(20175), NET_PROTOCOL_UPNP);
-  pSpin->AddLabel(g_localizeStrings.Get(20304), NET_PROTOCOL_RSS);
+  labels.push_back(make_pair(g_localizeStrings.Get(21331), NET_PROTOCOL_TUXBOX));
+  labels.push_back(make_pair(g_localizeStrings.Get(20301), NET_PROTOCOL_HTTPS));
+  labels.push_back(make_pair(g_localizeStrings.Get(20300), NET_PROTOCOL_HTTP));
+  labels.push_back(make_pair(g_localizeStrings.Get(20254), NET_PROTOCOL_DAVS));
+  labels.push_back(make_pair(g_localizeStrings.Get(20253), NET_PROTOCOL_DAV));
+  labels.push_back(make_pair(g_localizeStrings.Get(20173), NET_PROTOCOL_FTP));
+  labels.push_back(make_pair(g_localizeStrings.Get(20174), NET_PROTOCOL_DAAP));
+  labels.push_back(make_pair(g_localizeStrings.Get(20175), NET_PROTOCOL_UPNP));
+  labels.push_back(make_pair(g_localizeStrings.Get(20304), NET_PROTOCOL_RSS));
 #ifdef HAS_FILESYSTEM_NFS
-  pSpin->AddLabel(g_localizeStrings.Get(20259), NET_PROTOCOL_NFS);
+  labels.push_back(make_pair(g_localizeStrings.Get(20259), NET_PROTOCOL_NFS));
 #endif
 #ifdef HAS_FILESYSTEM_SFTP
-  pSpin->AddLabel(g_localizeStrings.Get(20260), NET_PROTOCOL_SFTP);
+  labels.push_back(make_pair(g_localizeStrings.Get(20260), NET_PROTOCOL_SFTP));
 #endif
 #ifdef HAS_FILESYSTEM_AFP
-  pSpin->AddLabel(g_localizeStrings.Get(20261), NET_PROTOCOL_AFP);
+  labels.push_back(make_pair(g_localizeStrings.Get(20261), NET_PROTOCOL_AFP));
 #endif
 
-  pSpin->SetValue(m_protocol);
+  SET_CONTROL_LABELS(CONTROL_PROTOCOL, m_protocol, &labels);
   OnProtocolChange();
 }
 

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -26,7 +26,6 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "guilib/GUIImage.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -200,8 +199,9 @@ void CGUIDialogProfileSettings::OnWindowLoaded()
 {
   CGUIDialogSettingsManualBase::OnWindowLoaded();
 
-  CGUIImage *image = (CGUIImage*)GetControl(CONTROL_PROFILE_IMAGE);
-  m_defaultImage = image ? image->GetFileName() : "";
+  CGUIMessage msg(GUI_MSG_GET_FILENAME, GetID(), CONTROL_PROFILE_IMAGE);
+  OnMessage(msg);
+  m_defaultImage = msg.GetLabel();
 }
 
 void CGUIDialogProfileSettings::OnSettingChanged(const CSetting *setting)
@@ -259,13 +259,7 @@ void CGUIDialogProfileSettings::OnSettingAction(const CSetting *setting)
       m_needsSaving = true;
       m_thumb = thumb.Equals("thumb://None") ? "" : thumb;
 
-      CGUIImage *image = (CGUIImage*)GetControl(CONTROL_PROFILE_IMAGE);
-      if (image == NULL)
-        return;
-
-      image->SetFileName("");
-      image->SetInvalid();
-      image->SetFileName(!m_thumb.empty() ? m_thumb : m_defaultImage);
+      SET_CONTROL_FILENAME(CONTROL_PROFILE_IMAGE, !m_thumb.empty() ? m_thumb : m_defaultImage);
     }
   }
   else if (settingId == SETTING_PROFILE_DIRECTORY)
@@ -318,9 +312,7 @@ void CGUIDialogProfileSettings::SetupView()
   updateProfileDirectory();
 
   // set the image
-  CGUIImage *image = (CGUIImage*)GetControl(CONTROL_PROFILE_IMAGE);
-  if (image != NULL)
-    image->SetFileName(!m_thumb.empty() ? m_thumb : m_defaultImage);
+  SET_CONTROL_FILENAME(CONTROL_PROFILE_IMAGE, !m_thumb.empty() ? m_thumb : m_defaultImage);
 }
 
 void CGUIDialogProfileSettings::InitializeSettings()

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -507,7 +507,7 @@ void CPVRChannelGroups::FillGroupsGUI(int iWindowId, int iControlId) const
   int iListGroupPtr(0);
   int iSelectedGroupPtr(0);
   CPVRChannelGroupPtr selectedGroup = g_PVRManager.GetPlayingGroup(false);
-  std::vector<CGUIMessage> messages;
+  std::vector< std::pair<std::string, int> > labels;
 
   // fetch all groups
   {
@@ -521,18 +521,13 @@ void CPVRChannelGroups::FillGroupsGUI(int iWindowId, int iControlId) const
       if ((*it)->GroupID() == selectedGroup->GroupID())
         iSelectedGroupPtr = iListGroupPtr;
 
-      CGUIMessage msg(GUI_MSG_LABEL_ADD, iWindowId, iControlId, iListGroupPtr++);
-      msg.SetLabel((*it)->GroupName());
-      messages.push_back(msg);
+      labels.push_back(make_pair((*it)->GroupName(), iListGroupPtr++));
     }
   }
 
-  // send updates
-  for (std::vector<CGUIMessage>::iterator it = messages.begin(); it != messages.end(); it++)
-    g_windowManager.SendMessage(*it);
-
   // selected group
-  CGUIMessage msgSel(GUI_MSG_ITEM_SELECT, iWindowId, iControlId, iSelectedGroupPtr);
+  CGUIMessage msgSel(GUI_MSG_SET_LABELS, iWindowId, iControlId, iSelectedGroupPtr);
+  msgSel.SetPointer(&labels);
   g_windowManager.SendMessage(msgSel);
 }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -288,14 +288,14 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioParentalLocked(CGUIMessage &
 
 bool CGUIDialogPVRChannelManager::OnClickButtonEditName(CGUIMessage &message)
 {
-  CGUIEditControl *pEdit = (CGUIEditControl *)GetControl(EDIT_NAME);
-  if (pEdit)
+  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), EDIT_NAME);
+  if (OnMessage(msg))
   {
     CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
     if (pItem)
     {
       pItem->SetProperty("Changed", true);
-      pItem->SetProperty("Name", pEdit->GetLabel2());
+      pItem->SetProperty("Name", msg.GetLabel());
       m_bContainsChanges = true;
 
       return true;
@@ -667,8 +667,6 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
 
 void CGUIDialogPVRChannelManager::SetData(int iItem)
 {
-  CGUIEditControl        *pEdit;
-
   /* Check file item is in list range and get his pointer */
   if (iItem < 0 || iItem >= (int)m_channelItems->Size()) return;
 
@@ -676,12 +674,9 @@ void CGUIDialogPVRChannelManager::SetData(int iItem)
   if (!pItem)
     return;
 
-  pEdit = (CGUIEditControl *)GetControl(EDIT_NAME);
-  if (pEdit)
-  {
-    pEdit->SetLabel2(pItem->GetProperty("Name").asString());
-    pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TEXT, 19208);
-  }
+  SET_CONTROL_LABEL2(EDIT_NAME, pItem->GetProperty("Name").asString());
+  CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), EDIT_NAME, CGUIEditControl::INPUT_TYPE_TEXT, 19208);
+  OnMessage(msg);
 
   SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_ACTIVE, pItem->GetProperty("ActiveChannel").asBoolean());
   SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_USEEPG, pItem->GetProperty("UseEPG").asBoolean());

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -29,7 +29,6 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIEditControl.h"
-#include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
@@ -735,12 +734,11 @@ void CGUIDialogPVRChannelManager::Update()
     m_channelItems->Add(channelFile);
   }
 
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(SPIN_EPGSOURCE_SELECTION);
-  if (pSpin)
   {
-    pSpin->Clear();
-    pSpin->AddLabel(g_localizeStrings.Get(19210), 0);
+    vector< pair<string, int> > labels;
+    labels.push_back(make_pair(g_localizeStrings.Get(19210), 0));
     /// TODO: Add Labels for EPG scrapers here
+    SET_CONTROL_LABELS(SPIN_EPGSOURCE_SELECTION, 0, &labels);
   }
 
   Renumber();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -29,7 +29,6 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIEditControl.h"
-#include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
@@ -242,14 +241,15 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioTV(CGUIMessage &message)
 
 bool CGUIDialogPVRChannelManager::OnClickButtonRadioActive(CGUIMessage &message)
 {
-  CGUIRadioButtonControl *pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_ACTIVE);
-  if (pRadioButton)
+  CGUIMessage msg(GUI_MSG_IS_SELECTED, GetID(), RADIOBUTTON_ACTIVE);
+  if (OnMessage(msg))
   {
+    bool selected(msg.GetParam1() == 1);
     CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
     if (pItem)
     {
       pItem->SetProperty("Changed", true);
-      pItem->SetProperty("ActiveChannel", pRadioButton->IsSelected());
+      pItem->SetProperty("ActiveChannel", selected);
       m_bContainsChanges = true;
       Renumber();
       return true;
@@ -261,26 +261,27 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioActive(CGUIMessage &message)
 
 bool CGUIDialogPVRChannelManager::OnClickButtonRadioParentalLocked(CGUIMessage &message)
 {
-  CGUIRadioButtonControl *pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_PARENTAL_LOCK);
+  CGUIMessage msg(GUI_MSG_IS_SELECTED, GetID(), RADIOBUTTON_PARENTAL_LOCK);
+  if (!OnMessage(msg))
+    return false;
+
+  bool selected(msg.GetParam1() == 1);
 
   // ask for PIN first
   if (!g_PVRManager.CheckParentalPIN(g_localizeStrings.Get(19262).c_str()))
-  {
-    pRadioButton->SetSelected(!pRadioButton->IsSelected());
+  { // failed - reset to previou
+    SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_PARENTAL_LOCK, !selected);
     return false;
   }
 
-  if (pRadioButton)
+  CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
+  if (pItem)
   {
-    CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
-    if (pItem)
-    {
-      pItem->SetProperty("Changed", true);
-      pItem->SetProperty("ParentalLocked", pRadioButton->IsSelected());
-      m_bContainsChanges = true;
-      Renumber();
-      return true;
-    }
+    pItem->SetProperty("Changed", true);
+    pItem->SetProperty("ParentalLocked", selected);
+    m_bContainsChanges = true;
+    Renumber();
+    return true;
   }
 
   return false;
@@ -366,14 +367,15 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
 
 bool CGUIDialogPVRChannelManager::OnClickButtonUseEPG(CGUIMessage &message)
 {
-  CGUIRadioButtonControl *pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_USEEPG);
-  if (pRadioButton)
+  CGUIMessage msg(GUI_MSG_IS_SELECTED, GetID(), RADIOBUTTON_USEEPG);
+  if (OnMessage(msg))
   {
+    bool selected(msg.GetParam1() == 1);
     CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
     if (pItem)
     {
       pItem->SetProperty("Changed", true);
-      pItem->SetProperty("UseEPG", pRadioButton->IsSelected());
+      pItem->SetProperty("UseEPG", selected);
       m_bContainsChanges = true;
 
       return true;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -66,11 +66,10 @@ CGUIDialogPVRGuideSearch::CGUIDialogPVRGuideSearch(void) :
 void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
 {
   CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_CHANNELS);
-  CGUISpinControlEx *pSpinGroups = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_GROUPS);
-  if (!pSpin || !pSpinGroups)
+  if (!pSpin)
     return;
 
-  int iChannelGroup = pSpinGroups->GetValue();
+  int iChannelGroup = GetSpinValue(CONTROL_SPIN_GROUPS);
 
   pSpin->Clear();
   pSpin->AddLabel(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET);
@@ -249,10 +248,16 @@ bool CGUIDialogPVRGuideSearch::IsRadioSelected(int controlID)
   return (msg.GetParam1() == 1);
 }
 
+int CGUIDialogPVRGuideSearch::GetSpinValue(int controlID)
+{
+  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), controlID);
+  OnMessage(msg);
+  return (int)msg.GetParam1();
+}
+
 void CGUIDialogPVRGuideSearch::OnSearch()
 {
   CStdString              strTmp;
-  CGUISpinControlEx      *pSpin;
   CGUIEditControl        *pEdit;
 
   if (!m_searchFilter)
@@ -269,20 +274,11 @@ void CGUIDialogPVRGuideSearch::OnSearch()
   m_searchFilter->m_bIgnorePresentTimers = IsRadioSelected(CONTROL_BTN_IGNORE_TMR);
   m_searchFilter->m_bPreventRepeats = IsRadioSelected(CONTROL_SPIN_NO_REPEATS);
 
-  pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_GENRE);
-  if (pSpin) m_searchFilter->m_iGenreType = pSpin->GetValue();
-
-  pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_MIN_DURATION);
-  if (pSpin) m_searchFilter->m_iMinimumDuration = pSpin->GetValue();
-
-  pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_MAX_DURATION);
-  if (pSpin) m_searchFilter->m_iMaximumDuration = pSpin->GetValue();
-
-  pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_CHANNELS);
-  if (pSpin) m_searchFilter->m_iChannelNumber = pSpin->GetValue();
-
-  pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_GROUPS);
-  if (pSpin) m_searchFilter->m_iChannelGroup = pSpin->GetValue();
+  m_searchFilter->m_iGenreType = GetSpinValue(CONTROL_SPIN_GENRE);
+  m_searchFilter->m_iMinimumDuration = GetSpinValue(CONTROL_SPIN_MIN_DURATION);
+  m_searchFilter->m_iMaximumDuration = GetSpinValue(CONTROL_SPIN_MAX_DURATION);
+  m_searchFilter->m_iChannelNumber = GetSpinValue(CONTROL_SPIN_CHANNELS);
+  m_searchFilter->m_iChannelGroup = GetSpinValue(CONTROL_SPIN_GROUPS);
 
   pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_TIME);
   if (pEdit) strTmp = pEdit->GetLabel2();

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -231,16 +231,19 @@ int CGUIDialogPVRGuideSearch::GetSpinValue(int controlID)
   return (int)msg.GetParam1();
 }
 
+string CGUIDialogPVRGuideSearch::GetEditValue(int controlID)
+{
+  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), controlID);
+  OnMessage(msg);
+  return msg.GetLabel();
+}
+
 void CGUIDialogPVRGuideSearch::OnSearch()
 {
-  CStdString              strTmp;
-  CGUIEditControl        *pEdit;
-
   if (!m_searchFilter)
     return;
 
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_SEARCH);
-  if (pEdit) m_searchFilter->m_strSearchTerm = pEdit->GetLabel2();
+  m_searchFilter->m_strSearchTerm = GetEditValue(CONTROL_EDIT_SEARCH);
 
   m_searchFilter->m_bSearchInDescription = IsRadioSelected(CONTROL_BTN_INC_DESC);
   m_searchFilter->m_bIsCaseSensitive = IsRadioSelected(CONTROL_BTN_CASE_SENS);
@@ -256,32 +259,21 @@ void CGUIDialogPVRGuideSearch::OnSearch()
   m_searchFilter->m_iChannelNumber = GetSpinValue(CONTROL_SPIN_CHANNELS);
   m_searchFilter->m_iChannelGroup = GetSpinValue(CONTROL_SPIN_GROUPS);
 
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_TIME);
-  if (pEdit) strTmp = pEdit->GetLabel2();
-
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_DATE);
-  if (pEdit) ReadDateTime(pEdit->GetLabel2(), strTmp, m_searchFilter->m_startDateTime);
-  strTmp.clear();
-
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_STOP_TIME);
-  if (pEdit) strTmp = pEdit->GetLabel2();
-
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_STOP_DATE);
-  if (pEdit) ReadDateTime(pEdit->GetLabel2(), strTmp, m_searchFilter->m_endDateTime);
+  CStdString strTmp = GetEditValue(CONTROL_EDIT_START_TIME);
+  ReadDateTime(GetEditValue(CONTROL_EDIT_START_DATE), strTmp, m_searchFilter->m_startDateTime);
+  strTmp = GetEditValue(CONTROL_EDIT_STOP_TIME);
+  ReadDateTime(GetEditValue(CONTROL_EDIT_STOP_DATE), strTmp, m_searchFilter->m_endDateTime);
 }
 
 void CGUIDialogPVRGuideSearch::Update()
 {
-  CGUIEditControl        *pEdit;
-
   if (!m_searchFilter)
     return;
 
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_SEARCH);
-  if (pEdit)
+  SET_CONTROL_LABEL2(CONTROL_EDIT_SEARCH, m_searchFilter->m_strSearchTerm);
   {
-    pEdit->SetLabel2(m_searchFilter->m_strSearchTerm);
-    pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TEXT, 16017);
+    CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), CONTROL_EDIT_SEARCH, CGUIEditControl::INPUT_TYPE_TEXT, 16017);
+    OnMessage(msg);
   }
 
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_CASE_SENS, m_searchFilter->m_bIsCaseSensitive);
@@ -293,29 +285,25 @@ void CGUIDialogPVRGuideSearch::Update()
   SET_CONTROL_SELECTED(GetID(), CONTROL_SPIN_NO_REPEATS, m_searchFilter->m_bPreventRepeats);
 
   /* Set time fields */
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_TIME);
-  if (pEdit)
+  SET_CONTROL_LABEL2(CONTROL_EDIT_START_TIME, m_searchFilter->m_startDateTime.GetAsLocalizedTime("", false));
   {
-    pEdit->SetLabel2(m_searchFilter->m_startDateTime.GetAsLocalizedTime("", false));
-    pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TIME, 14066);
+    CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), CONTROL_EDIT_START_TIME, CGUIEditControl::INPUT_TYPE_TIME, 14066);
+    OnMessage(msg);
   }
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_STOP_TIME);
-  if (pEdit)
+  SET_CONTROL_LABEL2(CONTROL_EDIT_STOP_TIME, m_searchFilter->m_endDateTime.GetAsLocalizedTime("", false));
   {
-    pEdit->SetLabel2(m_searchFilter->m_endDateTime.GetAsLocalizedTime("", false));
-    pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TIME, 14066);
+    CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), CONTROL_EDIT_STOP_TIME, CGUIEditControl::INPUT_TYPE_TIME, 14066);
+    OnMessage(msg);
   }
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_START_DATE);
-  if (pEdit)
+  SET_CONTROL_LABEL2(CONTROL_EDIT_START_DATE, m_searchFilter->m_startDateTime.GetAsDBDate());
   {
-    pEdit->SetLabel2(m_searchFilter->m_startDateTime.GetAsDBDate());
-    pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_DATE, 14067);
+    CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), CONTROL_EDIT_START_DATE, CGUIEditControl::INPUT_TYPE_DATE, 14067);
+    OnMessage(msg);
   }
-  pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_STOP_DATE);
-  if (pEdit)
+  SET_CONTROL_LABEL2(CONTROL_EDIT_STOP_DATE, m_searchFilter->m_endDateTime.GetAsDBDate());
   {
-    pEdit->SetLabel2(m_searchFilter->m_endDateTime.GetAsDBDate());
-    pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_DATE, 14067);
+    CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), CONTROL_EDIT_STOP_DATE, CGUIEditControl::INPUT_TYPE_DATE, 14067);
+    OnMessage(msg);
   }
 
   UpdateDurationSpin();

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -22,7 +22,6 @@
 #include "Application.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIEditControl.h"
-#include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/StringUtils.h"
@@ -243,12 +242,18 @@ void CGUIDialogPVRGuideSearch::ReadDateTime(const CStdString &strDate, const CSt
   dateTime.SetDateTime(dateTime.GetYear(), dateTime.GetMonth(), dateTime.GetDay(), iHours, iMinutes, 0);
 }
 
+bool CGUIDialogPVRGuideSearch::IsRadioSelected(int controlID)
+{
+  CGUIMessage msg(GUI_MSG_IS_SELECTED, GetID(), controlID);
+  OnMessage(msg);
+  return (msg.GetParam1() == 1);
+}
+
 void CGUIDialogPVRGuideSearch::OnSearch()
 {
   CStdString              strTmp;
   CGUISpinControlEx      *pSpin;
   CGUIEditControl        *pEdit;
-  CGUIRadioButtonControl *pRadioButton;
 
   if (!m_searchFilter)
     return;
@@ -256,26 +261,13 @@ void CGUIDialogPVRGuideSearch::OnSearch()
   pEdit = (CGUIEditControl *)GetControl(CONTROL_EDIT_SEARCH);
   if (pEdit) m_searchFilter->m_strSearchTerm = pEdit->GetLabel2();
 
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_INC_DESC);
-  if (pRadioButton) m_searchFilter->m_bSearchInDescription = pRadioButton->IsSelected();
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_CASE_SENS);
-  if (pRadioButton) m_searchFilter->m_bIsCaseSensitive = pRadioButton->IsSelected();
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_FTA_ONLY);
-  if (pRadioButton) m_searchFilter->m_bFTAOnly = pRadioButton->IsSelected();
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_UNK_GENRE);
-  if (pRadioButton) m_searchFilter->m_bIncludeUnknownGenres = pRadioButton->IsSelected();
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_IGNORE_REC);
-  if (pRadioButton) m_searchFilter->m_bIgnorePresentRecordings = pRadioButton->IsSelected();
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_BTN_IGNORE_TMR);
-  if (pRadioButton) m_searchFilter->m_bIgnorePresentTimers = pRadioButton->IsSelected();
-
-  pRadioButton = (CGUIRadioButtonControl *)GetControl(CONTROL_SPIN_NO_REPEATS);
-  if (pRadioButton) m_searchFilter->m_bPreventRepeats = pRadioButton->IsSelected();
+  m_searchFilter->m_bSearchInDescription = IsRadioSelected(CONTROL_BTN_INC_DESC);
+  m_searchFilter->m_bIsCaseSensitive = IsRadioSelected(CONTROL_BTN_CASE_SENS);
+  m_searchFilter->m_bFTAOnly = IsRadioSelected(CONTROL_BTN_FTA_ONLY);
+  m_searchFilter->m_bIncludeUnknownGenres = IsRadioSelected(CONTROL_BTN_UNK_GENRE);
+  m_searchFilter->m_bIgnorePresentRecordings = IsRadioSelected(CONTROL_BTN_IGNORE_REC);
+  m_searchFilter->m_bIgnorePresentTimers = IsRadioSelected(CONTROL_BTN_IGNORE_TMR);
+  m_searchFilter->m_bPreventRepeats = IsRadioSelected(CONTROL_SPIN_NO_REPEATS);
 
   pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_GENRE);
   if (pSpin) m_searchFilter->m_iGenreType = pSpin->GetValue();

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -22,7 +22,6 @@
 #include "Application.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIEditControl.h"
-#include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/StringUtils.h"
 
@@ -65,14 +64,10 @@ CGUIDialogPVRGuideSearch::CGUIDialogPVRGuideSearch(void) :
 
 void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
 {
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_CHANNELS);
-  if (!pSpin)
-    return;
-
   int iChannelGroup = GetSpinValue(CONTROL_SPIN_GROUPS);
 
-  pSpin->Clear();
-  pSpin->AddLabel(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET);
+  vector< pair<string, int> > labels;
+  labels.push_back(make_pair(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET));
 
   int iGroupId = (iChannelGroup == EPG_SEARCH_UNSET) ?
       XBMC_INTERNAL_GROUP_TV :
@@ -88,90 +83,71 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
       continue;
 
     int iChannelNumber = group->GetChannelNumber(*channel->GetPVRChannelInfoTag());
-    pSpin->AddLabel(channel->GetPVRChannelInfoTag()->ChannelName().c_str(), iChannelNumber);
+    labels.push_back(make_pair(channel->GetPVRChannelInfoTag()->ChannelName(), iChannelNumber));
   }
 
-  pSpin->SetValue(m_searchFilter->m_iChannelNumber);
+  SET_CONTROL_LABELS(CONTROL_SPIN_CHANNELS, m_searchFilter->m_iChannelNumber, &labels);
 }
 
 void CGUIDialogPVRGuideSearch::UpdateGroupsSpin(void)
 {
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_GROUPS);
-  if (!pSpin)
-    return;
-
   std::vector<CPVRChannelGroupPtr> group;
   std::vector<CPVRChannelGroupPtr>::const_iterator it;
 
-  pSpin->Clear();
+  vector< pair<string, int> > labels;
 
   /* tv groups */
   group = g_PVRChannelGroups->GetTV()->GetMembers();
   for (it = group.begin(); it != group.end(); ++it)
-    pSpin->AddLabel((*it)->GroupName(), (*it)->GroupID());
+    labels.push_back(make_pair((*it)->GroupName(), (*it)->GroupID()));
 
   /* radio groups */
   group = g_PVRChannelGroups->GetRadio()->GetMembers();
   for (it = group.begin(); it != group.end(); ++it)
-    pSpin->AddLabel((*it)->GroupName(), (*it)->GroupID());
+    labels.push_back(make_pair((*it)->GroupName(), (*it)->GroupID()));
 
-  pSpin->SetValue(m_searchFilter->m_iChannelGroup);
+  SET_CONTROL_LABELS(CONTROL_SPIN_GROUPS, m_searchFilter->m_iChannelGroup, &labels);
 }
 
 void CGUIDialogPVRGuideSearch::UpdateGenreSpin(void)
 {
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_GENRE);
-  if (!pSpin)
-    return;
+  vector< pair<string, int> > labels;
+  labels.push_back(make_pair(g_localizeStrings.Get(593),   EPG_SEARCH_UNSET));
+  labels.push_back(make_pair(g_localizeStrings.Get(19500), EPG_EVENT_CONTENTMASK_MOVIEDRAMA));
+  labels.push_back(make_pair(g_localizeStrings.Get(19516), EPG_EVENT_CONTENTMASK_NEWSCURRENTAFFAIRS));
+  labels.push_back(make_pair(g_localizeStrings.Get(19532), EPG_EVENT_CONTENTMASK_SHOW));
+  labels.push_back(make_pair(g_localizeStrings.Get(19548), EPG_EVENT_CONTENTMASK_SPORTS));
+  labels.push_back(make_pair(g_localizeStrings.Get(19564), EPG_EVENT_CONTENTMASK_CHILDRENYOUTH));
+  labels.push_back(make_pair(g_localizeStrings.Get(19580), EPG_EVENT_CONTENTMASK_MUSICBALLETDANCE));
+  labels.push_back(make_pair(g_localizeStrings.Get(19596), EPG_EVENT_CONTENTMASK_ARTSCULTURE));
+  labels.push_back(make_pair(g_localizeStrings.Get(19612), EPG_EVENT_CONTENTMASK_SOCIALPOLITICALECONOMICS));
+  labels.push_back(make_pair(g_localizeStrings.Get(19628), EPG_EVENT_CONTENTMASK_EDUCATIONALSCIENCE));
+  labels.push_back(make_pair(g_localizeStrings.Get(19644), EPG_EVENT_CONTENTMASK_LEISUREHOBBIES));
+  labels.push_back(make_pair(g_localizeStrings.Get(19660), EPG_EVENT_CONTENTMASK_SPECIAL));
+  labels.push_back(make_pair(g_localizeStrings.Get(19499), EPG_EVENT_CONTENTMASK_USERDEFINED));
 
-  pSpin->Clear();
-  pSpin->AddLabel(g_localizeStrings.Get(593), EPG_SEARCH_UNSET);
-  pSpin->AddLabel(g_localizeStrings.Get(19500), EPG_EVENT_CONTENTMASK_MOVIEDRAMA);
-  pSpin->AddLabel(g_localizeStrings.Get(19516), EPG_EVENT_CONTENTMASK_NEWSCURRENTAFFAIRS);
-  pSpin->AddLabel(g_localizeStrings.Get(19532), EPG_EVENT_CONTENTMASK_SHOW);
-  pSpin->AddLabel(g_localizeStrings.Get(19548), EPG_EVENT_CONTENTMASK_SPORTS);
-  pSpin->AddLabel(g_localizeStrings.Get(19564), EPG_EVENT_CONTENTMASK_CHILDRENYOUTH);
-  pSpin->AddLabel(g_localizeStrings.Get(19580), EPG_EVENT_CONTENTMASK_MUSICBALLETDANCE);
-  pSpin->AddLabel(g_localizeStrings.Get(19596), EPG_EVENT_CONTENTMASK_ARTSCULTURE);
-  pSpin->AddLabel(g_localizeStrings.Get(19612), EPG_EVENT_CONTENTMASK_SOCIALPOLITICALECONOMICS);
-  pSpin->AddLabel(g_localizeStrings.Get(19628), EPG_EVENT_CONTENTMASK_EDUCATIONALSCIENCE);
-  pSpin->AddLabel(g_localizeStrings.Get(19644), EPG_EVENT_CONTENTMASK_LEISUREHOBBIES);
-  pSpin->AddLabel(g_localizeStrings.Get(19660), EPG_EVENT_CONTENTMASK_SPECIAL);
-  pSpin->AddLabel(g_localizeStrings.Get(19499), EPG_EVENT_CONTENTMASK_USERDEFINED);
-  pSpin->SetValue(m_searchFilter->m_iGenreType);
+  SET_CONTROL_LABELS(CONTROL_SPIN_GENRE, m_searchFilter->m_iGenreType, &labels);
 }
 
 void CGUIDialogPVRGuideSearch::UpdateDurationSpin(void)
 {
   /* minimum duration */
-  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_MIN_DURATION);
-  if (!pSpin)
-    return;
+  vector< pair<string, int> > labels;
 
-  pSpin->Clear();
-  pSpin->AddLabel("-", EPG_SEARCH_UNSET);
+  labels.push_back(make_pair("-", EPG_SEARCH_UNSET));
   for (int i = 1; i < 12*60/5; i++)
-  {
-    CStdString string;
-    string = StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i*5);
-    pSpin->AddLabel(string, i*5);
-  }
-  pSpin->SetValue(m_searchFilter->m_iMinimumDuration);
+    labels.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i*5), i*5));
+
+  SET_CONTROL_LABELS(CONTROL_SPIN_MIN_DURATION, m_searchFilter->m_iMinimumDuration, &labels);
 
   /* maximum duration */
-  pSpin = (CGUISpinControlEx *)GetControl(CONTROL_SPIN_MAX_DURATION);
-  if (!pSpin)
-    return;
+  labels.clear();
 
-  pSpin->Clear();
-  pSpin->AddLabel("-", EPG_SEARCH_UNSET);
+  labels.push_back(make_pair("-", EPG_SEARCH_UNSET));
   for (int i = 1; i < 12*60/5; i++)
-  {
-    CStdString string;
-    string = StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i*5);
-    pSpin->AddLabel(string, i*5);
-  }
-  pSpin->SetValue(m_searchFilter->m_iMaximumDuration);
+    labels.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i*5), i*5));
+
+  SET_CONTROL_LABELS(CONTROL_SPIN_MAX_DURATION, m_searchFilter->m_iMaximumDuration, &labels);
 }
 
 bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
@@ -52,6 +52,8 @@ namespace PVR
     void ReadDateTime(const CStdString &strDate, const CStdString &strTime, CDateTime &dateTime) const;
     void Update();
 
+    bool IsRadioSelected(int controlID);
+
     bool m_bConfirmed;
     bool m_bCanceled;
     EPG::EpgSearchFilter *m_searchFilter;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
@@ -54,6 +54,7 @@ namespace PVR
 
     bool IsRadioSelected(int controlID);
     int  GetSpinValue(int controlID);
+    std::string GetEditValue(int controlID);
 
     bool m_bConfirmed;
     bool m_bCanceled;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.h
@@ -53,6 +53,7 @@ namespace PVR
     void Update();
 
     bool IsRadioSelected(int controlID);
+    int  GetSpinValue(int controlID);
 
     bool m_bConfirmed;
     bool m_bCanceled;

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -421,25 +421,26 @@ void CGUIDialogContentSettings::InitializeSettings()
 
 void CGUIDialogContentSettings::FillContentTypes()
 {
-  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_CONTENT_TYPE);
-  g_windowManager.SendMessage(msg);
+  std::vector< std::pair<std::string, int> > labels;
 
   if (m_content == CONTENT_ALBUMS || m_content == CONTENT_ARTISTS)
+  {
     FillContentTypes(m_content);
+    labels.push_back(make_pair(ADDON::TranslateContent(m_content, true), m_content));
+  }
   else
   {
     FillContentTypes(CONTENT_MOVIES);
     FillContentTypes(CONTENT_TVSHOWS);
     FillContentTypes(CONTENT_MUSICVIDEOS);
 
-    // add 'None' to spinner
-    CGUIMessage msg2(GUI_MSG_LABEL_ADD, GetID(), CONTROL_CONTENT_TYPE);
-    msg2.SetLabel(ADDON::TranslateContent(CONTENT_NONE, true));
-    msg2.SetParam1(static_cast<int>(CONTENT_NONE));
-    g_windowManager.SendMessage(msg2);
+    labels.push_back(make_pair(ADDON::TranslateContent(CONTENT_MOVIES, true), CONTENT_MOVIES));
+    labels.push_back(make_pair(ADDON::TranslateContent(CONTENT_TVSHOWS, true), CONTENT_TVSHOWS));
+    labels.push_back(make_pair(ADDON::TranslateContent(CONTENT_MUSICVIDEOS, true), CONTENT_MUSICVIDEOS));
+    labels.push_back(make_pair(ADDON::TranslateContent(CONTENT_NONE, true), CONTENT_NONE));
   }
 
-  CONTROL_SELECT_ITEM(CONTROL_CONTENT_TYPE, static_cast<int>(m_content));
+  SET_CONTROL_LABELS(CONTROL_CONTENT_TYPE, m_content, &labels);
 }
 
 void CGUIDialogContentSettings::FillContentTypes(CONTENT_TYPE content)
@@ -481,12 +482,6 @@ void CGUIDialogContentSettings::FillContentTypes(CONTENT_TYPE content)
       m_scrapers.insert(make_pair(content,vec));
     }
   }
-
-  // add CONTENT type to spinner
-  CGUIMessage msg(GUI_MSG_LABEL_ADD, GetID(), CONTROL_CONTENT_TYPE);
-  msg.SetLabel(ADDON::TranslateContent(content, true));
-  msg.SetParam1(static_cast<int>(content));
-  g_windowManager.SendMessage(msg);
 }
 
 void CGUIDialogContentSettings::FillScraperList()

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -88,7 +88,7 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
       if (iControl == CONTROL_CONTENT_TYPE)
       {
         CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_CONTENT_TYPE);
-        g_windowManager.SendMessage(msg);
+        OnMessage(msg);
         m_content = static_cast<CONTENT_TYPE>(msg.GetParam1());
         SetupView();
       }
@@ -100,7 +100,7 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
           break;
 
         CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_SCRAPER_LIST);
-        g_windowManager.SendMessage(msg);
+        OnMessage(msg);
         int iSelected = msg.GetParam1();
         if (iSelected == m_vecItems->Size() - 1)
         { // Get More... item, path 'addons://more/<content>'

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -30,7 +30,6 @@
 #include "filesystem/PluginDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
-#include "guilib/GUIImage.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/Key.h"
 #include "settings/MediaSettings.h"
@@ -287,12 +286,9 @@ bool CGUIDialogSubtitles::SetService(const std::string &service)
 
     SET_CONTROL_LABEL(CONTROL_NAMELABEL, currentService->GetLabel());
 
-    CGUIImage* image = (CGUIImage*)GetControl(CONTROL_NAMELOGO);
-    if (image)
-    {
-      std::string icon = URIUtils::AddFileToFolder(currentService->GetProperty("Addon.Path").asString(), "logo.png");
-      image->SetFileName(icon);
-    }
+    std::string icon = URIUtils::AddFileToFolder(currentService->GetProperty("Addon.Path").asString(), "logo.png");
+    SET_CONTROL_FILENAME(CONTROL_NAMELOGO, icon);
+
     if (g_application.m_pPlayer->GetSubtitleCount() == 0)
       SET_CONTROL_HIDDEN(CONTROL_SUBSEXIST);
     else

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -298,18 +298,16 @@ int CGUIViewControl::GetView(VIEW_TYPE type, int id) const
 void CGUIViewControl::UpdateViewAsControl(const CStdString &viewLabel)
 {
   // the view as control could be a select/spin/dropdown button
-  CGUIMessage msg(GUI_MSG_LABEL_RESET, m_parentWindow, m_viewAsControl);
-  g_windowManager.SendMessage(msg, m_parentWindow);
+  std::vector< std::pair<std::string, int> > labels;
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
   {
     IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
-    CGUIMessage msg(GUI_MSG_LABEL_ADD, m_parentWindow, m_viewAsControl, i);
-    CStdString label = StringUtils::Format(g_localizeStrings.Get(534).c_str(), view->GetLabel().c_str()); // View: %s
-    msg.SetLabel(label);
-    g_windowManager.SendMessage(msg, m_parentWindow);
+    std::string label = StringUtils::Format(g_localizeStrings.Get(534).c_str(), view->GetLabel().c_str()); // View: %s
+    labels.push_back(make_pair(label, i));
   }
-  CGUIMessage msgSelect(GUI_MSG_ITEM_SELECT, m_parentWindow, m_viewAsControl, m_currentView);
-  g_windowManager.SendMessage(msgSelect, m_parentWindow);
+  CGUIMessage msg(GUI_MSG_SET_LABELS, m_parentWindow, m_viewAsControl, m_currentView);
+  msg.SetPointer(&labels);
+  g_windowManager.SendMessage(msg, m_parentWindow);
 
   // otherwise it's just a normal button
   CStdString label = StringUtils::Format(g_localizeStrings.Get(534).c_str(), viewLabel.c_str()); // View: %s

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -27,7 +27,6 @@
 #include "filesystem/ZipManager.h"
 #include "filesystem/FileDirectoryFactory.h"
 #include "dialogs/GUIDialogContextMenu.h"
-#include "guilib/GUIListContainer.h"
 #include "dialogs/GUIDialogMediaSource.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
@@ -804,10 +803,12 @@ void CGUIWindowFileManager::Refresh()
 
 int CGUIWindowFileManager::GetSelectedItem(int iControl)
 {
-  if (iControl < 0 || iControl > 1) return -1;
-  CGUIListContainer *pControl = (CGUIListContainer *)GetControl(iControl + CONTROL_LEFT_LIST);
-  if (!pControl || !m_vecItems[iControl]->Size()) return -1;
-  return pControl->GetSelectedItem();
+  if (iControl < 0 || iControl > 1 || m_vecItems[iControl]->IsEmpty())
+    return -1;
+  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl + CONTROL_LEFT_LIST);
+  if (OnMessage(msg))
+    return (int)msg.GetParam1();
+  return -1;
 }
 
 void CGUIWindowFileManager::GoParentFolder(int iList)

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -22,7 +22,6 @@
 #include "GUIUserMessages.h"
 #include "dialogs/GUIDialogOK.h"
 #include "GUIWindowWeather.h"
-#include "guilib/GUIImage.h"
 #include "utils/Weather.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/URIUtils.h"
@@ -205,9 +204,7 @@ void CGUIWindowWeather::UpdateButtons()
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_WIND, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_WIND));
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_DEWP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_DEWP) + (CStdString)g_langInfo.GetTempUnitString());
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_HUMI, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_HUMI));
-
-  CGUIImage *pImage = (CGUIImage *)GetControl(WEATHER_IMAGE_CURRENT_ICON);
-  if (pImage) pImage->SetFileName(g_weatherManager.GetInfo(WEATHER_IMAGE_CURRENT_ICON));
+  SET_CONTROL_FILENAME(WEATHER_IMAGE_CURRENT_ICON, g_weatherManager.GetInfo(WEATHER_IMAGE_CURRENT_ICON));
 
   //static labels
   SET_CONTROL_LABEL(CONTROL_STATICTEMP, 401);  //Temperature
@@ -223,8 +220,7 @@ void CGUIWindowWeather::UpdateButtons()
     SET_CONTROL_LABEL(CONTROL_LABELD0HI + (i*10), g_weatherManager.GetForecast(i).m_high + (CStdString)g_langInfo.GetTempUnitString());
     SET_CONTROL_LABEL(CONTROL_LABELD0LOW + (i*10), g_weatherManager.GetForecast(i).m_low + (CStdString)g_langInfo.GetTempUnitString());
     SET_CONTROL_LABEL(CONTROL_LABELD0GEN + (i*10), g_weatherManager.GetForecast(i).m_overview);
-    pImage = (CGUIImage *)GetControl(CONTROL_IMAGED0IMG + (i * 10));
-    if (pImage) pImage->SetFileName(g_weatherManager.GetForecast(i).m_icon);
+    SET_CONTROL_FILENAME(CONTROL_IMAGED0IMG + (i*10), g_weatherManager.GetForecast(i).m_icon);
   }
 }
 

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -23,7 +23,6 @@
 #include "dialogs/GUIDialogOK.h"
 #include "GUIWindowWeather.h"
 #include "utils/Weather.h"
-#include "guilib/GUIWindowManager.h"
 #include "utils/URIUtils.h"
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
@@ -85,7 +84,7 @@ bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_SELECTLOCATION)
       {
         CGUIMessage msg(GUI_MSG_ITEM_SELECTED,GetID(),CONTROL_SELECTLOCATION);
-        g_windowManager.SendMessage(msg);
+        OnMessage(msg);
 
         SetLocation(msg.GetParam1());
       }

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -144,9 +144,8 @@ void CGUIWindowWeather::UpdateLocations()
   if (!IsActive()) return;
   m_maxLocation = strtol(GetProperty("Locations").asString().c_str(),0,10);
   if (m_maxLocation < 1) return;
-  CGUIMessage msg(GUI_MSG_LABEL_RESET,GetID(),CONTROL_SELECTLOCATION);
-  g_windowManager.SendMessage(msg);
-  CGUIMessage msg2(GUI_MSG_LABEL_ADD,GetID(),CONTROL_SELECTLOCATION);
+
+  std::vector< std::pair<std::string, int> > labels;
 
   unsigned int iCurWeather = g_weatherManager.GetArea();
 
@@ -157,35 +156,31 @@ void CGUIWindowWeather::UpdateLocations()
     ClearProperties();
     g_weatherManager.Refresh();
   }
-  
+
   for (unsigned int i = 1; i <= m_maxLocation; i++)
   {
-    CStdString strLabel = g_weatherManager.GetLocation(i);
+    std::string strLabel = g_weatherManager.GetLocation(i);
     if (strLabel.size() > 1) //got the location string yet?
     {
       size_t iPos = strLabel.rfind(", ");
       if (iPos != std::string::npos)
       {
-        CStdString strLabel2(strLabel);
+        std::string strLabel2(strLabel);
         strLabel = strLabel2.substr(0,iPos);
       }
-      msg2.SetParam1(i);
-      msg2.SetLabel(strLabel);
-      g_windowManager.SendMessage(msg2);
+      labels.push_back(make_pair(strLabel, i));
     }
     else
     {
       strLabel = StringUtils::Format("AreaCode %i", i);
-
-      msg2.SetLabel(strLabel);
-      msg2.SetParam1(i);
-      g_windowManager.SendMessage(msg2);
+      labels.push_back(make_pair(strLabel, i));
     }
+    // in case it's a button, set the label
     if (i == iCurWeather)
       SET_CONTROL_LABEL(CONTROL_SELECTLOCATION,strLabel);
   }
 
-  CONTROL_SELECT_ITEM(CONTROL_SELECTLOCATION, iCurWeather);
+  SET_CONTROL_LABELS(CONTROL_SELECTLOCATION, iCurWeather, &labels);
 }
 
 void CGUIWindowWeather::UpdateButtons()


### PR DESCRIPTION
This continues the work of #4731 cleaning up direct access to controls and replacing it with messages.

There's a couple of things to review:
1. The nasty one is d743f93 which adds a method to specify spinner labels via a single message.  Nasty due to the void\* usage, though this is used elsewhere as well.  Ideas welcome.
2. <del>There's a reasonably trivial change in the PVR guide stuff which I think can be clarified.  @xhaggi, @opdenkamp, @Jalle19 please take a look at 0612a4a specifically, though a lot of this applies to the PVR dialog classes.</del>
3. I've introduced GUI_MSG_SET_FILENAME which is essentially identical to GUI_MSG_LABEL_SET.  The only rationale I have is that by using a specific message we don't get the case of the message being sent to the wrong control type.  I could reuse GUI_MSG_LABEL_SET for this though.
4. The use of GUI_MSG_ITEM_SELECT for progress means that you can only set integers rather than floats.  This may be a regression in behaviour, so perhaps an alternate is to attach a variant or some such to the GUIMessage Param?

Assuming 1 is acceped (or a better solution is suggested) I'll go through and redo other spots filling a spinner via the GUI_MSG_LABEL_RESET, GUI_MSG_LABEL_ADD, GUI_MSG_ITEM_SELECT technique which is inefficient as you're looking up the control for each message.
