### PR TITLE
Font manager cleanup

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1948,19 +1948,7 @@ bool CApplication::LoadSkin(const SkinPtr& skin)
   CLog::Log(LOGINFO, "  load fonts for skin...");
   g_graphicsContext.SetMediaDir(skin->Path());
   g_directoryCache.ClearSubPaths(skin->Path());
-  if (g_langInfo.ForceUnicodeFont() && !g_fontManager.IsFontSetUnicode(CSettings::Get().GetString("lookandfeel.font")))
-  {
-    CLog::Log(LOGINFO, "    language needs a ttf font, loading first ttf font available");
-    CStdString strFontSet;
-    if (g_fontManager.GetFirstFontSetUnicode(strFontSet))
-    {
-      CLog::Log(LOGINFO, "    new font is '%s'", strFontSet.c_str());
-      CSettings::Get().SetString("lookandfeel.font", strFontSet);
-      CSettings::Get().Save();
-    }
-    else
-      CLog::Log(LOGERROR, "    no ttf font found, but needed for the language %s.", CSettings::Get().GetString("locale.language").c_str());
-  }
+
   g_colorManager.Load(CSettings::Get().GetString("lookandfeel.skincolors"));
 
   g_fontManager.LoadFonts(CSettings::Get().GetString("lookandfeel.font"));
@@ -5822,25 +5810,15 @@ CPerformanceStats &CApplication::GetPerformanceStats()
 bool CApplication::SetLanguage(const CStdString &strLanguage)
 {
   CStdString strPreviousLanguage = CSettings::Get().GetString("locale.language");
-  CStdString strNewLanguage = strLanguage;
-  if (strNewLanguage != strPreviousLanguage)
+  if (strLanguage != strPreviousLanguage)
   {
-    CStdString strLangInfoPath = StringUtils::Format("special://xbmc/language/%s/langinfo.xml", strNewLanguage.c_str());
+    CStdString strLangInfoPath = StringUtils::Format("special://xbmc/language/%s/langinfo.xml", strLanguage.c_str());
     if (!g_langInfo.Load(strLangInfoPath))
       return false;
 
-    if (g_langInfo.ForceUnicodeFont() && !g_fontManager.IsFontSetUnicode())
-    {
-      CLog::Log(LOGINFO, "Language needs a ttf font, loading first ttf font available");
-      CStdString strFontSet;
-      if (g_fontManager.GetFirstFontSetUnicode(strFontSet))
-        strNewLanguage = strFontSet;
-      else
-        CLog::Log(LOGERROR, "No ttf font found but needed: %s", strFontSet.c_str());
-    }
-    CSettings::Get().SetString("locale.language", strNewLanguage);
+    CSettings::Get().SetString("locale.language", strLanguage);
 
-    if (!g_localizeStrings.Load("special://xbmc/language/", strNewLanguage))
+    if (!g_localizeStrings.Load("special://xbmc/language/", strLanguage))
       return false;
 
     // also tell our weather and skin to reload as these are localized

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -24,7 +24,6 @@
 #include "FileItem.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
-#include "guilib/GUIFontManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
@@ -448,14 +447,6 @@ bool CLangInfo::SetLanguage(const std::string &strLanguage)
   string strLangInfoPath = StringUtils::Format("special://xbmc/language/%s/langinfo.xml", strLanguage.c_str());
   if (!Load(strLangInfoPath))
     return false;
-
-  if (ForceUnicodeFont() && !g_fontManager.IsFontSetUnicode())
-  {
-    CLog::Log(LOGINFO, "Language needs a ttf font, loading first ttf font available");
-    CStdString strFontSet;
-    if (!g_fontManager.GetFirstFontSetUnicode(strFontSet))
-      CLog::Log(LOGERROR, "No ttf font found but needed: %s", strFontSet.c_str());
-  }
 
   if (!g_localizeStrings.Load("special://xbmc/language/", strLanguage))
     return false;

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -322,7 +322,7 @@ void CSkinInfo::SettingOptionsSkinColorsFiller(const CSetting *setting, std::vec
 
 void CSkinInfo::SettingOptionsSkinFontsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
 {
-  CStdString settingValue = ((const CSettingString*)setting)->GetValue();
+  std::string settingValue = ((const CSettingString*)setting)->GetValue();
   bool currentValueSet = false;
   std::string strPath = g_SkinInfo->GetSkinPath("Font.xml");
 
@@ -333,52 +333,33 @@ void CSkinInfo::SettingOptionsSkinFontsFiller(const CSetting *setting, std::vect
     return;
   }
 
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-
-  std::string strValue = pRootElement->ValueStr();
-  if (strValue != "fonts")
+  const TiXmlElement* pRootElement = xmlDoc.RootElement();
+  if (!pRootElement || pRootElement->ValueStr() != "fonts")
   {
     CLog::Log(LOGERROR, "FillInSkinFonts: file %s doesn't start with <fonts>", strPath.c_str());
     return;
   }
 
-  const TiXmlNode *pChild = pRootElement->FirstChild();
-  strValue = pChild->ValueStr();
-  if (strValue == "fontset")
+  const TiXmlElement *pChild = pRootElement->FirstChildElement("fontset");
+  while (pChild)
   {
-    while (pChild)
+    const char* idAttr = pChild->Attribute("id");
+    const char* idLocAttr = pChild->Attribute("idloc");
+    if (idAttr != NULL)
     {
-      strValue = pChild->ValueStr();
-      if (strValue == "fontset")
-      {
-        const char* idAttr = ((TiXmlElement*) pChild)->Attribute("id");
-        const char* idLocAttr = ((TiXmlElement*) pChild)->Attribute("idloc");
-        const char* unicodeAttr = ((TiXmlElement*) pChild)->Attribute("unicode");
+      if (idLocAttr)
+        list.push_back(make_pair(g_localizeStrings.Get(atoi(idLocAttr)), idAttr));
+      else
+        list.push_back(make_pair(idAttr, idAttr));
 
-        bool isUnicode = (unicodeAttr && stricmp(unicodeAttr, "true") == 0);
-
-        bool isAllowed = true;
-        if (g_langInfo.ForceUnicodeFont() && !isUnicode)
-          isAllowed = false;
-
-        if (idAttr != NULL && isAllowed)
-        {
-          if (idLocAttr)
-            list.push_back(make_pair(g_localizeStrings.Get(atoi(idLocAttr)), idAttr));
-          else
-            list.push_back(make_pair(idAttr, idAttr));
-
-          if (StringUtils::EqualsNoCase(idAttr, settingValue.c_str()))
-            currentValueSet = true;
-        }
-      }
-
-      pChild = pChild->NextSibling();
+      if (StringUtils::EqualsNoCase(idAttr, settingValue))
+        currentValueSet = true;
     }
+    pChild = pChild->NextSiblingElement("fontset");
   }
-  else
-  {
-    // Since no fontset is defined, there is no selection of a fontset, so disable the component
+
+  if (list.empty())
+  { // Since no fontset is defined, there is no selection of a fontset, so disable the component
     list.push_back(make_pair(g_localizeStrings.Get(13278), ""));
     current = "";
     currentValueSet = true;

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -21,7 +21,6 @@
 #include "guilib/Key.h"
 #include "guilib/GUIControlFactory.h"
 #include "guilib/GUIListItem.h"
-#include "guilib/GUIFontManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/DirtyRegion.h"
 #include <tinyxml.h>

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -337,148 +337,111 @@ void GUIFontManager::Clear()
   m_vecFontInfo.clear();
 }
 
-void GUIFontManager::LoadFonts(const CStdString& strFontSet)
+void GUIFontManager::LoadFonts(const std::string& fontSet)
 {
+  // Get the file to load fonts from:
+  const std::string strPath = g_SkinInfo->GetSkinPath("Font.xml", &m_skinResolution);
+  CLog::Log(LOGINFO, "Loading fonts from %s", strPath.c_str());
+
   CXBMCTinyXML xmlDoc;
-  if (!OpenFontFile(xmlDoc))
+  if (!xmlDoc.LoadFile(strPath))
+  {
+    CLog::Log(LOGERROR, "Couldn't load %s", strPath.c_str());
     return;
+  }
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
-  const TiXmlNode *pChild = pRootElement->FirstChild();
-
-  // If there are no fontset's defined in the XML (old skin format) run in backward compatibility
-  // and ignore the fontset request
-  CStdString strValue = pChild->Value();
-  if (strValue == "fontset")
+  if (!pRootElement || pRootElement->ValueStr() != "fonts")
   {
-    CStdString foundTTF;
-    while (pChild)
+    CLog::Log(LOGERROR, "file %s doesnt start with <fonts>", strPath.c_str());
+    return;
+  }
+
+  // take note of the first font available in case we can't load the one specified
+  std::string firstFont;
+
+  const TiXmlElement *pChild = pRootElement->FirstChildElement("fontset");
+  while (pChild)
+  {
+    const char* idAttr = pChild->Attribute("id");
+    if (idAttr)
     {
-      strValue = pChild->Value();
-      if (strValue == "fontset")
+      if (firstFont.empty())
+        firstFont = idAttr;
+
+      if (StringUtils::EqualsNoCase(fontSet, idAttr))
       {
-        const char* idAttr = ((TiXmlElement*) pChild)->Attribute("id");
-
-        const char* unicodeAttr = ((TiXmlElement*) pChild)->Attribute("unicode");
-
-        if (foundTTF.empty() && idAttr != NULL && unicodeAttr != NULL && stricmp(unicodeAttr, "true") == 0)
-          foundTTF = idAttr;
-
-        // Check if this is the fontset that we want
-        if (idAttr != NULL && stricmp(strFontSet.c_str(), idAttr) == 0)
-        {
-          // Check if this is the a ttf fontset
-          if (unicodeAttr != NULL && stricmp(unicodeAttr, "true") == 0)
-          {
-            LoadFonts(pChild->FirstChild());
-            break;
-          }
-        }
-
+        LoadFonts(pChild->FirstChild("font"));
+        return;
       }
-
-      pChild = pChild->NextSibling();
     }
+    pChild = pChild->NextSiblingElement("fontset");
+  }
 
-    // If no fontset was loaded
-    if (pChild == NULL)
-    {
-      CLog::Log(LOGWARNING, "file doesnt have <fontset> with name '%s', defaulting to first fontset", strFontSet.c_str());
-      if (!foundTTF.empty())
-        LoadFonts(foundTTF);
-    }
+  // no fontset was loaded, try the first
+  if (!firstFont.empty())
+  {
+    CLog::Log(LOGWARNING, "file doesnt have <fontset> with name '%s', defaulting to first fontset", fontSet.c_str());
+    LoadFonts(firstFont);
   }
   else
-  {
-    CLog::Log(LOGERROR, "file doesnt have <fontset> in <fonts>, but rather %s", strValue.c_str());
-    return ;
-  }
+    CLog::Log(LOGERROR, "file '%s' doesnt have a valid <fontset>", strPath.c_str());
 }
 
 void GUIFontManager::LoadFonts(const TiXmlNode* fontNode)
 {
   while (fontNode)
   {
-    CStdString strValue = fontNode->Value();
-    if (strValue == "font")
+    std::string fontName;
+    std::string fileName;
+    int iSize = 20;
+    float aspect = 1.0f;
+    float lineSpacing = 1.0f;
+    color_t shadowColor = 0;
+    color_t textColor = 0;
+    int iStyle = FONT_STYLE_NORMAL;
+
+    XMLUtils::GetString(fontNode, "name", fontName);
+    XMLUtils::GetInt(fontNode, "size", iSize);
+    XMLUtils::GetFloat(fontNode, "linespacing", lineSpacing);
+    XMLUtils::GetFloat(fontNode, "aspect", aspect);
+    CGUIControlFactory::GetColor(fontNode, "shadow", shadowColor);
+    CGUIControlFactory::GetColor(fontNode, "color", textColor);
+    XMLUtils::GetString(fontNode, "filename", fileName);
+    GetStyle(fontNode, iStyle);
+
+    if (!fontName.empty() && URIUtils::HasExtension(fileName, ".ttf"))
     {
-      const TiXmlNode *pNode = fontNode->FirstChild("name");
-      if (pNode)
-      {
-        CStdString strFontName = pNode->FirstChild()->Value();
-        color_t shadowColor = 0;
-        color_t textColor = 0;
-        CGUIControlFactory::GetColor(fontNode, "shadow", shadowColor);
-        CGUIControlFactory::GetColor(fontNode, "color", textColor);
-        const TiXmlNode *pNode = fontNode->FirstChild("filename");
-        if (pNode)
-        {
-          CStdString strFontFileName = pNode->FirstChild()->Value();
-          StringUtils::ToLower(strFontFileName);
-          if (strFontFileName.find(".ttf") != string::npos)
-          {
-            int iSize = 20;
-            int iStyle = FONT_STYLE_NORMAL;
-            float aspect = 1.0f;
-            float lineSpacing = 1.0f;
-
-            XMLUtils::GetInt(fontNode, "size", iSize);
-            if (iSize <= 0) iSize = 20;
-
-            pNode = fontNode->FirstChild("style");
-            if (pNode && pNode->FirstChild())
-            {
-              vector<string> styles = StringUtils::Split(pNode->FirstChild()->ValueStr(), " ");
-              for (vector<string>::iterator i = styles.begin(); i != styles.end(); ++i)
-              {
-                if (*i == "bold")
-                  iStyle |= FONT_STYLE_BOLD;
-                else if (*i == "italics")
-                  iStyle |= FONT_STYLE_ITALICS;
-                else if (*i == "bolditalics") // backward compatibility
-                  iStyle |= (FONT_STYLE_BOLD | FONT_STYLE_ITALICS);
-                else if (*i == "uppercase")
-                  iStyle |= FONT_STYLE_UPPERCASE;
-                else if (*i == "lowercase")
-                  iStyle |= FONT_STYLE_LOWERCASE;
-              }
-            }
-
-            XMLUtils::GetFloat(fontNode, "linespacing", lineSpacing);
-            XMLUtils::GetFloat(fontNode, "aspect", aspect);
-
-            LoadTTF(strFontName, strFontFileName, textColor, shadowColor, iSize, iStyle, false, lineSpacing, aspect);
-          }
-        }
-      }
+      // TODO: Why do we tolower() this shit?
+      CStdString strFontFileName = fileName;
+      StringUtils::ToLower(strFontFileName);
+      LoadTTF(fontName, strFontFileName, textColor, shadowColor, iSize, iStyle, false, lineSpacing, aspect);
     }
-
-    fontNode = fontNode->NextSibling();
+    fontNode = fontNode->NextSibling("font");
   }
 }
 
-bool GUIFontManager::OpenFontFile(CXBMCTinyXML& xmlDoc)
+void GUIFontManager::GetStyle(const TiXmlNode *fontNode, int &iStyle)
 {
-  // Get the file to load fonts from:
-  CStdString strPath = g_SkinInfo->GetSkinPath("Font.xml", &m_skinResolution);
-  CLog::Log(LOGINFO, "Loading fonts from %s", strPath.c_str());
-
-  // first try our preferred file
-  if ( !xmlDoc.LoadFile(strPath) )
+  std::string style;
+  iStyle = FONT_STYLE_NORMAL;
+  if (XMLUtils::GetString(fontNode, "style", style))
   {
-    CLog::Log(LOGERROR, "Couldn't load %s", strPath.c_str());
-    return false;
+    vector<string> styles = StringUtils::Tokenize(style, " ");
+    for (vector<string>::const_iterator i = styles.begin(); i != styles.end(); ++i)
+    {
+      if (*i == "bold")
+        iStyle |= FONT_STYLE_BOLD;
+      else if (*i == "italics")
+        iStyle |= FONT_STYLE_ITALICS;
+      else if (*i == "bolditalics") // backward compatibility
+        iStyle |= (FONT_STYLE_BOLD | FONT_STYLE_ITALICS);
+      else if (*i == "uppercase")
+        iStyle |= FONT_STYLE_UPPERCASE;
+      else if (*i == "lowercase")
+        iStyle |= FONT_STYLE_LOWERCASE;
+    }
   }
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-
-  CStdString strValue = pRootElement->Value();
-  if (strValue != CStdString("fonts"))
-  {
-    CLog::Log(LOGERROR, "file %s doesnt start with <fonts>", strPath.c_str());
-    return false;
-  }
-
-  return true;
 }
 
 void GUIFontManager::SettingOptionsFontsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -42,7 +42,6 @@ using namespace std;
 
 GUIFontManager::GUIFontManager(void)
 {
-  m_fontsetUnicode=false;
   m_canReload = true;
 }
 
@@ -336,7 +335,6 @@ void GUIFontManager::Clear()
   m_vecFonts.clear();
   m_vecFontFiles.clear();
   m_vecFontInfo.clear();
-  m_fontsetUnicode=false;
 }
 
 void GUIFontManager::LoadFonts(const CStdString& strFontSet)
@@ -369,12 +367,8 @@ void GUIFontManager::LoadFonts(const CStdString& strFontSet)
         // Check if this is the fontset that we want
         if (idAttr != NULL && stricmp(strFontSet.c_str(), idAttr) == 0)
         {
-          m_fontsetUnicode=false;
           // Check if this is the a ttf fontset
           if (unicodeAttr != NULL && stricmp(unicodeAttr, "true") == 0)
-            m_fontsetUnicode=true;
-
-          if (m_fontsetUnicode)
           {
             LoadFonts(pChild->FirstChild());
             break;
@@ -485,89 +479,6 @@ bool GUIFontManager::OpenFontFile(CXBMCTinyXML& xmlDoc)
   }
 
   return true;
-}
-
-bool GUIFontManager::GetFirstFontSetUnicode(CStdString& strFontSet)
-{
-  strFontSet.clear();
-
-  // Load our font file
-  CXBMCTinyXML xmlDoc;
-  if (!OpenFontFile(xmlDoc))
-    return false;
-
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-  const TiXmlNode *pChild = pRootElement->FirstChild();
-
-  CStdString strValue = pChild->Value();
-  if (strValue == "fontset")
-  {
-    while (pChild)
-    {
-      strValue = pChild->Value();
-      if (strValue == "fontset")
-      {
-        const char* idAttr = ((TiXmlElement*) pChild)->Attribute("id");
-
-        const char* unicodeAttr = ((TiXmlElement*) pChild)->Attribute("unicode");
-
-        // Check if this is a fontset with a ttf attribute set to true
-        if (unicodeAttr != NULL && stricmp(unicodeAttr, "true") == 0)
-        {
-          //  This is the first ttf fontset
-          strFontSet=idAttr;
-          break;
-        }
-
-      }
-
-      pChild = pChild->NextSibling();
-    }
-
-    // If no fontset was loaded
-    if (pChild == NULL)
-      CLog::Log(LOGWARNING, "file doesnt have <fontset> with attribute unicode=\"true\"");
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "file doesnt have <fontset> in <fonts>, but rather %s", strValue.c_str());
-  }
-
-  return !strFontSet.empty();
-}
-
-bool GUIFontManager::IsFontSetUnicode(const CStdString& strFontSet)
-{
-  CXBMCTinyXML xmlDoc;
-  if (!OpenFontFile(xmlDoc))
-    return false;
-
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-  const TiXmlNode *pChild = pRootElement->FirstChild();
-
-  CStdString strValue = pChild->Value();
-  if (strValue == "fontset")
-  {
-    while (pChild)
-    {
-      strValue = pChild->Value();
-      if (strValue == "fontset")
-      {
-        const char* idAttr = ((TiXmlElement*) pChild)->Attribute("id");
-
-        const char* unicodeAttr = ((TiXmlElement*) pChild)->Attribute("unicode");
-
-        // Check if this is the fontset that we want
-        if (idAttr != NULL && stricmp(strFontSet.c_str(), idAttr) == 0)
-          return (unicodeAttr != NULL && stricmp(unicodeAttr, "true") == 0);
-
-      }
-
-      pChild = pChild->NextSibling();
-    }
-  }
-
-  return false;
 }
 
 void GUIFontManager::SettingOptionsFontsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -63,7 +63,7 @@ public:
   virtual bool OnMessage(CGUIMessage &message);
 
   void Unload(const CStdString& strFontName);
-  void LoadFonts(const CStdString& strFontSet);
+  void LoadFonts(const std::string &fontSet);
   CGUIFont* LoadTTF(const CStdString& strFontName, const CStdString& strFilename, color_t textColor, color_t shadowColor, const int iSize, const int iStyle, bool border = false, float lineSpacing = 1.0f, float aspect = 1.0f, const RESOLUTION_INFO *res = NULL, bool preserveAspect = false);
   CGUIFont* GetFont(const CStdString& strFontName, bool fallback = true);
 
@@ -83,7 +83,7 @@ protected:
   static void RescaleFontSizeAndAspect(float *size, float *aspect, const RESOLUTION_INFO &sourceRes, bool preserveAspect);
   void LoadFonts(const TiXmlNode* fontNode);
   CGUIFontTTFBase* GetFontFile(const CStdString& strFontFile);
-  bool OpenFontFile(CXBMCTinyXML& xmlDoc);
+  static void GetStyle(const TiXmlNode *fontNode, int &iStyle);
 
   std::vector<CGUIFont*> m_vecFonts;
   std::vector<CGUIFontTTFBase*> m_vecFontFiles;

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -76,10 +76,6 @@ public:
   void Clear();
   void FreeFontFile(CGUIFontTTFBase *pFont);
 
-  bool IsFontSetUnicode() const { return m_fontsetUnicode; }
-  bool IsFontSetUnicode(const CStdString& strFontSet);
-  bool GetFirstFontSetUnicode(CStdString& strFontSet);
-
   static void SettingOptionsFontsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
 
 protected:
@@ -92,7 +88,6 @@ protected:
   std::vector<CGUIFont*> m_vecFonts;
   std::vector<CGUIFontTTFBase*> m_vecFontFiles;
   std::vector<OrigFontInfo> m_vecFontInfo;
-  bool m_fontsetUnicode;
   RESOLUTION_INFO m_skinResolution;
   bool m_canReload;
 };

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1007,6 +1007,13 @@ std::string StringUtils::Paramify(const std::string &param)
   return "\"" + result + "\"";
 }
 
+std::vector<std::string> StringUtils::Tokenize(const std::string &input, const std::string &delimiters)
+{
+  std::vector<std::string> tokens;
+  Tokenize(input, tokens, delimiters);
+  return tokens;
+}
+
 void StringUtils::Tokenize(const std::string& input, std::vector<std::string>& tokens, const std::string& delimiters)
 {
   // Tokenize ripped from http://www.linuxselfhelp.com/HOWTO/C++Programming-HOWTO-7.html

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -182,6 +182,15 @@ public:
    \return Escaped/Paramified string
    */
   static std::string Paramify(const std::string &param);
+
+  /*! \brief Split a string by the specified delimiters.
+   Splits a string using one or more delimiting characters, ignoring empty tokens.
+   Differs from Split() in two ways:
+    1. The delimiters are treated as individual characters, rather than a single delimiting string.
+    2. Empty tokens are ignored.
+   \return a vector of tokens
+   */
+  static std::vector<std::string> Tokenize(const std::string& input, const std::string& delimiters);
   static void Tokenize(const std::string& input, std::vector<std::string>& tokens, const std::string& delimiters);
 private:
   static CStdString m_lastUUID;


### PR DESCRIPTION
This cleans up some font manager related stuff.  We only ever loaded fonts that had the unicode='true' set, so all the code to determine whether we had the attribute set was a waste of time.
