### PR TITLE
Fix libxbmc linux (closes #14914)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -491,6 +491,8 @@ MAINOBJS+=xbmc/main/main.a
 else
 ifeq (@USE_ANDROID@,1)
 MAINOBJS+=xbmc/android/activity/activity.a
+else
+MAINOBJS+=xbmc/main/main.a
 endif # USE_ANDROID
 endif # USE_LIBXBMC
 
@@ -529,7 +531,7 @@ libxbmc.so: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -bundle -o $@ $(MAINOBJS) -Wl,-all_load,-ObjC $(MAINOBJS) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS) -read_only_relocs suppress
 else
-	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ -Wl,--whole-archive $(MAINOBJS) -Wl,--no-whole-archive,--start-group $(MAINOBJS) $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group -Wl,--no-undefined $(NWAOBJSXBMC) $(LIBS)
+	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ -Wl,--whole-archive $(MAINOBJS) -Wl,--no-whole-archive,--start-group $(MAINOBJS) $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--end-group -Wl,--no-undefined $(NWAOBJSXBMC) $(LIBS) -Wl,-Bsymbolic
 endif
 
 xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(MAINOBJS)


### PR DESCRIPTION
This is an attempt at fixing libxbmc.so on _linux_
Its been broken since 7ef9badfde72fac8ad693c45946a00f2dd29c4b4

According to reports on http://forum.xbmc.org/showthread.php?tid=132919&page=48 this patch works 
I'm unsure if -BSymbolic has any side effects, although several distros (e.g. ubuntu) use this per default.
@t-nelson ping

edit: Note this is for gotham, but will probably be needed on master as well
