### PR TITLE
Python API. Rename onDatabaseUpdated and onDatabaseScanStarted

### DIFF
--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -42,8 +42,18 @@ namespace XBMCAddon
       inline void    OnSettingsChanged() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onSettingsChanged)); }
       inline void    OnScreensaverActivated() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onScreensaverActivated)); }
       inline void    OnScreensaverDeactivated() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onScreensaverDeactivated)); }
-      inline void    OnDatabaseUpdated(const String &database) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseUpdated,database)); }
-      inline void    OnDatabaseScanStarted(const String &database) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseScanStarted,database)); }
+      inline void    OnScanStarted(const String &library)
+      {
+	XBMC_TRACE;
+	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onScanStarted,library));
+	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseScanStarted,library));
+      }
+      inline void    OnScanFinished(const String &library)
+      {
+	XBMC_TRACE;
+	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onScanFinished,library));
+	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseUpdated,library));
+      }
       inline void    OnAbortRequested() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onAbortRequested)); }
       inline void    OnNotification(const String &sender, const String &method, const String &data) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String,const String,const String>(this,&Monitor::onNotification,sender,method,data)); }
 
@@ -72,23 +82,33 @@ namespace XBMCAddon
       virtual void    onScreensaverDeactivated() { XBMC_TRACE; }
 
       /**
-       * onDatabaseUpdated(database) -- onDatabaseUpdated method.\n
+       * onScanStarted(library) -- onScanStarted method.\n
+       *\n
+       * library : video/music as string\n
+       *\n
+       * Will be called when library scan has started and return video or music to indicate which library is being scanned\n
+       */
+      virtual void    onScanStarted(const String library) { XBMC_TRACE; }
+
+      /**
+       * onScanFinished(library) -- onScanFinished method.\n
        * \n
-       * database : video/music as string\n
+       * library : video/music as string\n
        * \n
-       * Will be called when database gets updated and return video or music to indicate which DB has been changed\n
+       * Will be called when library scan has ended and return video or music to indicate which library has been scanned\n
+       */
+      virtual void    onScanFinished(const String library) { XBMC_TRACE; }
+
+      /**
+       * onDatabaseScanStarted(database) -- Deprecated, use onScanStarted().
+       */
+      virtual void    onDatabaseScanStarted(const String database) { XBMC_TRACE; }
+
+      /**
+       * onDatabaseUpdated(database) -- Deprecated, use onScanFinished().
        */
       virtual void    onDatabaseUpdated(const String database) { XBMC_TRACE; }
 
-      /**
-       * onDatabaseScanStarted(database) -- onDatabaseScanStarted method.\n
-       *\n
-       * database : video/music as string\n
-       *\n
-       * Will be called when database update starts and return video or music to indicate which DB is being updated\n
-       */
-      virtual void    onDatabaseScanStarted(const String database) { XBMC_TRACE; }
-      
       /**
        * onAbortRequested() -- onAbortRequested method.\n
        * \n

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -91,16 +91,16 @@ void XBPython::Announce(AnnouncementFlag flag, const char *sender, const char *m
   if (flag & VideoLibrary)
   {
    if (strcmp(message, "OnScanFinished") == 0)
-     OnDatabaseUpdated("video");
+     OnScanFinished("video");
    else if (strcmp(message, "OnScanStarted") == 0)
-     OnDatabaseScanStarted("video");
+     OnScanStarted("video");
   }
   else if (flag & AudioLibrary)
   {
    if (strcmp(message, "OnScanFinished") == 0)
-     OnDatabaseUpdated("music");
+     OnScanFinished("music");
    else if (strcmp(message, "OnScanStarted") == 0)
-     OnDatabaseScanStarted("music");
+     OnScanStarted("music");
   }
   else if (flag & GUI)
   {
@@ -302,25 +302,25 @@ void XBPython::OnScreensaverDeactivated()
   }
 }
 
-void XBPython::OnDatabaseUpdated(const std::string &database)
+void XBPython::OnScanStarted(const std::string &library)
 {
   XBMC_TRACE;
   LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
   for (MonitorCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList,(*it)))
-      (*it)->OnDatabaseUpdated(database);
+      (*it)->OnScanStarted(library);
   }
 }
 
-void XBPython::OnDatabaseScanStarted(const std::string &database)
+void XBPython::OnScanFinished(const std::string &library)
 {
   XBMC_TRACE;
   LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
   for (MonitorCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList,(*it)))
-      (*it)->OnDatabaseScanStarted(database);
+      (*it)->OnScanFinished(library);
   }
 }
 

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -83,8 +83,8 @@ public:
   void OnSettingsChanged(const CStdString &strings);
   void OnScreensaverActivated();
   void OnScreensaverDeactivated();
-  void OnDatabaseUpdated(const std::string &database);
-  void OnDatabaseScanStarted(const std::string &database);
+  void OnScanStarted(const std::string &library);
+  void OnScanFinished(const std::string &library);
   void OnAbortRequested(const CStdString &ID="");
   void OnNotification(const std::string &sender, const std::string &method, const std::string &data);
 


### PR DESCRIPTION
If my understanding of these two methods is correct they have nothing to do with the database or anything being updated, but are exactly the same as `OnScanStarted` and `OnScanFinished` in the JSON-RPC API. I have no idea why they were named like this or why the documentation says what it says. Judging from the forums this is already causing a lot of confusion.

This is more a proposal than anything because yes, it will break existing add-ons using these methods.

The first commit contains only corrects to the documentation in case that's a 'no'.
