### PR TITLE
[pydocs] remove httpapi not implemented message. 

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -113,12 +113,6 @@ namespace XBMCAddon
       CApplicationMessenger::Get().ExecBuiltIn(function,wait);
     }
 
-    String executehttpapi(const char* httpcommand) 
-    {
-      XBMC_TRACE;
-      THROW_UNIMP("executehttpapi");
-    }
-
     String executeJSONRPC(const char* jsonrpccommand)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -95,11 +95,6 @@ namespace XBMCAddon
     void executebuiltin(const char* function, bool wait = false);
 
     /**
-     * executehttpapi(httpcommand) -- Not implemented anymore.
-     */
-    String executehttpapi(const char* httpcommand);
-
-    /**
      * executeJSONRPC(jsonrpccommand) -- Execute an JSONRPC command.
      * 
      * jsonrpccommand    : string - jsonrpc command to execute.


### PR DESCRIPTION
python module dependency bump makes sure these scripts cannot be installed anymore
