### PR TITLE
libcec: Make verbose logging optional

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2866,7 +2866,12 @@ msgctxt "#678"
 msgid "Verbose logging for UPnP components"
 msgstr ""
 
-#empty strings from id 679 to 699
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#679"
+msgid "Verbose logging for CEC library"
+msgstr ""
+
+#empty strings from id 680 to 699
 
 msgctxt "#700"
 msgid "Cleaning up library"

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -52,6 +52,7 @@
 #define LOGAUDIO    (1 << (LOGMASKBIT + 7))
 #define LOGAIRTUNES (1 << (LOGMASKBIT + 8))
 #define LOGUPNP     (1 << (LOGMASKBIT + 9))
+#define LOGCEC      (1 << (LOGMASKBIT + 10))
 
 #ifdef __GNUC__
 #define ATTRIB_LOG_FORMAT __attribute__((format(printf,3,4)))

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -33,6 +33,7 @@
 #include "peripherals/Peripherals.h"
 #include "peripherals/bus/PeripheralBus.h"
 #include "pictures/GUIWindowSlideShow.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
@@ -1181,7 +1182,7 @@ int CPeripheralCecAdapter::CecLogMessage(void *cbParam, const cec_log_message me
     break;
   }
 
-  if (iLevel >= 0)
+  if (iLevel >= CEC_LOG_NOTICE || (iLevel >= 0 && g_advancedSettings.CanLogComponent(LOGCEC)))
     CLog::Log(iLevel, "%s - %s", __FUNCTION__, message.message);
 
   return 1;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1391,6 +1391,9 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(const CSetting *se
 #ifdef HAS_UPNP
   list.push_back(std::make_pair(g_localizeStrings.Get(678), LOGUPNP));
 #endif
+#ifdef HAVE_LIBCEC
+  list.push_back(std::make_pair(g_localizeStrings.Get(679), LOGCEC));
+#endif
 }
 
 void CAdvancedSettings::setExtraLogLevel(const std::vector<CVariant> &components)


### PR DESCRIPTION
On a Pi without a CEC capable TV, you get about 4 log messages a second:

```
17:41:25 11830.849609 T:2930766928   DEBUG: CecLogMessage - >> POLL not sent
17:41:26 11831.850586 T:2930766928   DEBUG: CecLogMessage - << Recorder 1 (1) -> TV (0): POLL
17:41:26 11831.851562 T:2930766928   DEBUG: CecLogMessage - << 10
17:41:26 11831.943359 T:2930766928   DEBUG: CecLogMessage - command 'POLL' was not acked by the controller
```

Disable the verbose messages by default, and allow them to be optionally enabled.
