### PR TITLE
Fix unsupported features on paplayer

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -68,6 +68,7 @@ public:
   virtual int64_t GetTime();
   virtual void SeekTime(int64_t iTime = 0);
   virtual bool SkipNext();
+  virtual void GetAudioCapabilities(std::vector<int> &audioCaps) {}
 
   static bool HandlesType(const CStdString &type);
 


### PR DESCRIPTION
Attached change fix a currently not visible fault about supported audio capabilities.

In the moment this virtual function becomes only called over the audio/subtitle dialogue during video playback, which never have PAPlayer in usage.

But if it becomes used on other place with PAPlayer active the GetAudioCapabilities data is wrong.

Found this fault during creation of the audio DSP settings dialogue, which becomes available on all audio stream related types.

Was a visible fault there, but think is independent, that's why I do it this way. Please correct me if I think wrong. 
