### PR TITLE
[addons] extend repo check to 24 hours

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -383,7 +383,7 @@ void CAddonInstaller::UpdateRepos(bool force, bool wait)
     CAddonDatabase database;
     database.Open();
     CDateTime lastUpdate = database.GetRepoTimestamp(addons[i]->ID());
-    if (force || !lastUpdate.IsValid() || lastUpdate + CDateTimeSpan(0,6,0,0) < CDateTime::GetCurrentDateTime())
+    if (force || !lastUpdate.IsValid() || lastUpdate + CDateTimeSpan(0,24,0,0) < CDateTime::GetCurrentDateTime())
     {
       CLog::Log(LOGDEBUG,"Checking repositories for updates (triggered by %s)",addons[i]->Name().c_str());
       m_repoUpdateJob = CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(addons), this);


### PR DESCRIPTION
I know this will it a controversial subject but still.
Since we are now getting more and more users our servers are getting more and more requests if the repo list is still the same. All in all it's only a md5checksum file but still. Besides the increasing amount of users they also keep their boxes running all day. And we are now also combined repos.
So for one users having one box all days this is:
4 repos (frodo/gotham/helix/pvr) x every 6 hours = 16 (sorry made calc error ;) ). Multiple this by the amount of users...
If we look at the actual amount of repo updates we do this is perhaps 3 or 4 times a week at maximum.

Thanks to @wsnipex who changed our repo generation script we now keep older .zip files as well. Now it doesn't really matter any more if the user has an older repo list because that zip file is still available (which was previously deleted on a version bump). After 24 hours he will get the updated repo list any way including the new zip version.

Now Gotham has more stringent dependencies not keeping the older zip file caused issues as well when installing a skin that depended on a addon that was bumped during the day.

These things are now solved and we can now extend repo check time. It will only take a bit longer for users to actually get the updated version (but if they really want they can still do force refresh). Only possible issue i see is for third-party repos which atm not yet keep older addon versions for download. However this is just a matter of properly communicating it to them. 

Note:
if 24 hours would be to much i would certainly at least make it 12 hours.
