### PR TITLE
upnp: several additions and improvements

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -47,11 +47,13 @@ NPT_SET_LOCAL_LOGGER("platinum.media.server.didl")
 const char* didl_header         = "<DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\""
                                             " xmlns:dc=\"http://purl.org/dc/elements/1.1/\""
                                             " xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\""
-                                            " xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\">";
+                                            " xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\""
+                                            " xmlns:xbmc=\"urn:schemas-xbmc-org:metadata-1-0/\">";
 const char* didl_footer         = "</DIDL-Lite>";
 const char* didl_namespace_dc   = "http://purl.org/dc/elements/1.1/";
 const char* didl_namespace_upnp = "urn:schemas-upnp-org:metadata-1-0/upnp/";
 const char* didl_namespace_dlna = "urn:schemas-dlna-org:metadata-1-0/";
+const char* didl_namespace_xbmc = "urn:schemas-xbmc-org:metadata-1-0/";
 
 /*----------------------------------------------------------------------
 |   PLT_Didl::ConvertFilterToMask
@@ -160,6 +162,14 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_EPISODE_COUNT;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_EPISODE_SEASON, len, true) == 0) {
             mask |= PLT_FILTER_MASK_EPISODE_SEASON;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_DATEADDED, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_XBMC_DATEADDED;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_RATING, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_XBMC_RATING;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_VOTES, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_XBMC_VOTES;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_ARTWORK, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_XBMC_ARTWORK;
         }
 
         if (next_comma < 0) {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -156,7 +156,11 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_RES | PLT_FILTER_MASK_RES_NRAUDIOCHANNELS;
 		} else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES_SAMPLEFREQUENCY, len, true) == 0) {
             mask |= PLT_FILTER_MASK_RES | PLT_FILTER_MASK_RES_SAMPLEFREQUENCY;
-		}
+		} else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_EPISODE_COUNT, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_EPISODE_COUNT;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_EPISODE_SEASON, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_EPISODE_SEASON;
+        }
 
         if (next_comma < 0) {
             return mask;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -135,6 +135,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
             mask |= PLT_FILTER_MASK_EPISODE;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RATING, len, true) == 0) {
             mask |= PLT_FILTER_MASK_RATING;
+        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_PUBLISHER, len, true) == 0) {
+            mask |= PLT_FILTER_MASK_PUBLISHER;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES, len, true) == 0) {
             mask |= PLT_FILTER_MASK_RES;
         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES_DURATION, len, true) == 0 ||

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -90,6 +90,8 @@
 #define PLT_FILTER_MASK_LASTPLAYBACK                NPT_UINT64_C(0x0000000200000000)
 #define PLT_FILTER_MASK_PLAYCOUNT                   NPT_UINT64_C(0x0000000400000000)
 
+#define PLT_FILTER_MASK_PUBLISHER                   NPT_UINT64_C(0x0000000800000000)
+
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
 #define PLT_FILTER_FIELD_DATE                       "dc:date"
@@ -118,6 +120,7 @@
 #define PLT_FILTER_FIELD_CONTAINER_CHILDCOUNT       "container@childCount"
 #define PLT_FILTER_FIELD_CONTAINER_SEARCHABLE       "container@searchable"
 #define PLT_FILTER_FIELD_REFID                      "@refID"
+#define PLT_FILTER_FIELD_PUBLISHER                  "dc:publisher"
 
 #define PLT_FILTER_FIELD_RES                        "res"
 #define PLT_FILTER_FIELD_RES_DURATION               "res@duration"

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -92,6 +92,9 @@
 
 #define PLT_FILTER_MASK_PUBLISHER                   NPT_UINT64_C(0x0000000800000000)
 
+#define PLT_FILTER_MASK_EPISODE_COUNT               NPT_UINT64_C(0x0000001000000000)
+#define PLT_FILTER_MASK_EPISODE_SEASON              NPT_UINT64_C(0x0000002000000000)
+
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
 #define PLT_FILTER_FIELD_DATE                       "dc:date"
@@ -132,6 +135,9 @@
 #define PLT_FILTER_FIELD_RES_BITSPERSAMPLE          "res@bitsPerSample"
 #define PLT_FILTER_FIELD_RES_NRAUDIOCHANNELS        "res@nrAudioChannels"
 #define PLT_FILTER_FIELD_RES_SAMPLEFREQUENCY        "res@sampleFrequency"
+
+#define PLT_FILTER_FIELD_EPISODE_COUNT              "upnp:episodeCount"
+#define PLT_FILTER_FIELD_EPISODE_SEASON             "upnp:episodeSeason"
 
 extern const char* didl_header;
 extern const char* didl_footer;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -95,6 +95,11 @@
 #define PLT_FILTER_MASK_EPISODE_COUNT               NPT_UINT64_C(0x0000001000000000)
 #define PLT_FILTER_MASK_EPISODE_SEASON              NPT_UINT64_C(0x0000002000000000)
 
+#define PLT_FILTER_MASK_XBMC_DATEADDED              NPT_UINT64_C(0x0000100000000000)
+#define PLT_FILTER_MASK_XBMC_RATING                 NPT_UINT64_C(0x0000200000000000)
+#define PLT_FILTER_MASK_XBMC_VOTES                  NPT_UINT64_C(0x0000300000000000)
+#define PLT_FILTER_MASK_XBMC_ARTWORK                NPT_UINT64_C(0x0000400000000000)
+
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
 #define PLT_FILTER_FIELD_DATE                       "dc:date"
@@ -139,11 +144,17 @@
 #define PLT_FILTER_FIELD_EPISODE_COUNT              "upnp:episodeCount"
 #define PLT_FILTER_FIELD_EPISODE_SEASON             "upnp:episodeSeason"
 
+#define PLT_FILTER_FIELD_XBMC_DATEADDED             "xbmc:dateadded"
+#define PLT_FILTER_FIELD_XBMC_RATING                "xbmc:rating"
+#define PLT_FILTER_FIELD_XBMC_VOTES                 "xbmc:votes"
+#define PLT_FILTER_FIELD_XBMC_ARTWORK               "xbmc:artwork"
+
 extern const char* didl_header;
 extern const char* didl_footer;
 extern const char* didl_namespace_dc;
 extern const char* didl_namespace_upnp;
 extern const char* didl_namespace_dlna;
+extern const char* didl_namespace_xbmc;
 
 /*----------------------------------------------------------------------
 |   PLT_Didl

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
@@ -305,6 +305,33 @@ PLT_MediaBrowser::Browse(PLT_DeviceDataReference& device,
 }
 
 /*----------------------------------------------------------------------
+|   PLT_MediaBrowser::GetSearchCapabilities
++---------------------------------------------------------------------*/
+NPT_Result 
+PLT_MediaBrowser::GetSearchCapabilities(PLT_DeviceDataReference& device,
+                                        void*                    userdata)
+{
+    // verify device still in our list
+    PLT_DeviceDataReference device_data;
+    NPT_CHECK_WARNING(FindServer(device->GetUUID(), device_data));
+
+    // create action
+    PLT_ActionReference action;
+    NPT_CHECK_SEVERE(m_CtrlPoint->CreateAction(
+        device, 
+        "urn:schemas-upnp-org:service:ContentDirectory:1",
+        "GetSearchCapabilities",
+        action));
+
+    // invoke the action
+    if (NPT_FAILED(m_CtrlPoint->InvokeAction(action, userdata))) {
+        return NPT_ERROR_INVALID_PARAMETERS;
+    }
+
+    return NPT_SUCCESS;
+}
+
+/*----------------------------------------------------------------------
 |   PLT_MediaBrowser::OnActionResponse
 +---------------------------------------------------------------------*/
 NPT_Result
@@ -322,6 +349,8 @@ PLT_MediaBrowser::OnActionResponse(NPT_Result           res,
         return OnBrowseResponse(res, device, action, userdata);
     } else if (actionName.Compare("Search", true) == 0) {
         return OnSearchResponse(res, device, action, userdata);
+    } else if (actionName.Compare("GetSearchCapabilities", true) == 0) {
+        return OnGetSearchCapabilitiesResponse(res, device, action, userdata);
     }
 
     return NPT_SUCCESS;
@@ -432,6 +461,35 @@ PLT_MediaBrowser::OnSearchResponse(NPT_Result               res,
 
 bad_action:
     m_Delegate->OnSearchResult(NPT_FAILURE, device, NULL, userdata);
+    return NPT_FAILURE;
+}
+
+/*----------------------------------------------------------------------
+|   PLT_MediaBrowser::OnGetSearchCapabilitiesResponse
++---------------------------------------------------------------------*/
+NPT_Result
+PLT_MediaBrowser::OnGetSearchCapabilitiesResponse(NPT_Result               res, 
+                                                  PLT_DeviceDataReference& device, 
+                                                  PLT_ActionReference&     action, 
+                                                  void*                    userdata)
+{
+    NPT_String value;
+
+    if (!m_Delegate) return NPT_SUCCESS;
+
+    if (NPT_FAILED(res) || action->GetErrorCode() != 0) {
+        goto bad_action;
+    }
+
+    if (NPT_FAILED(action->GetArgumentValue("SearchCaps", value)))  {
+        goto bad_action;
+    }
+
+    m_Delegate->OnGetSearchCapabilitiesResult(NPT_SUCCESS, device, value, userdata);
+    return NPT_SUCCESS;
+
+bad_action:
+    m_Delegate->OnGetSearchCapabilitiesResult(NPT_FAILURE, device, value, userdata);
     return NPT_FAILURE;
 }
 

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
@@ -332,6 +332,33 @@ PLT_MediaBrowser::GetSearchCapabilities(PLT_DeviceDataReference& device,
 }
 
 /*----------------------------------------------------------------------
+|   PLT_MediaBrowser::GetSortCapabilities
++---------------------------------------------------------------------*/
+NPT_Result 
+PLT_MediaBrowser::GetSortCapabilities(PLT_DeviceDataReference& device,
+                                      void*                    userdata)
+{
+    // verify device still in our list
+    PLT_DeviceDataReference device_data;
+    NPT_CHECK_WARNING(FindServer(device->GetUUID(), device_data));
+
+    // create action
+    PLT_ActionReference action;
+    NPT_CHECK_SEVERE(m_CtrlPoint->CreateAction(
+        device, 
+        "urn:schemas-upnp-org:service:ContentDirectory:1",
+        "GetSortCapabilities",
+        action));
+
+    // invoke the action
+    if (NPT_FAILED(m_CtrlPoint->InvokeAction(action, userdata))) {
+        return NPT_ERROR_INVALID_PARAMETERS;
+    }
+
+    return NPT_SUCCESS;
+}
+
+/*----------------------------------------------------------------------
 |   PLT_MediaBrowser::OnActionResponse
 +---------------------------------------------------------------------*/
 NPT_Result
@@ -351,6 +378,8 @@ PLT_MediaBrowser::OnActionResponse(NPT_Result           res,
         return OnSearchResponse(res, device, action, userdata);
     } else if (actionName.Compare("GetSearchCapabilities", true) == 0) {
         return OnGetSearchCapabilitiesResponse(res, device, action, userdata);
+    } else if (actionName.Compare("GetSortCapabilities", true) == 0) {
+        return OnGetSortCapabilitiesResponse(res, device, action, userdata);
     }
 
     return NPT_SUCCESS;
@@ -490,6 +519,35 @@ PLT_MediaBrowser::OnGetSearchCapabilitiesResponse(NPT_Result               res,
 
 bad_action:
     m_Delegate->OnGetSearchCapabilitiesResult(NPT_FAILURE, device, value, userdata);
+    return NPT_FAILURE;
+}
+
+/*----------------------------------------------------------------------
+|   PLT_MediaBrowser::OnGetSearchCapabilitiesResponse
++---------------------------------------------------------------------*/
+NPT_Result
+PLT_MediaBrowser::OnGetSortCapabilitiesResponse(NPT_Result               res, 
+                                                PLT_DeviceDataReference& device, 
+                                                PLT_ActionReference&     action, 
+                                                void*                    userdata)
+{
+    NPT_String value;
+
+    if (!m_Delegate) return NPT_SUCCESS;
+
+    if (NPT_FAILED(res) || action->GetErrorCode() != 0) {
+        goto bad_action;
+    }
+
+    if (NPT_FAILED(action->GetArgumentValue("SortCaps", value)))  {
+        goto bad_action;
+    }
+
+    m_Delegate->OnGetSortCapabilitiesResult(NPT_SUCCESS, device, value, userdata);
+    return NPT_SUCCESS;
+
+bad_action:
+    m_Delegate->OnGetSortCapabilitiesResult(NPT_FAILURE, device, value, userdata);
     return NPT_FAILURE;
 }
 

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
@@ -97,6 +97,12 @@ public:
         PLT_DeviceDataReference& /*device*/, 
         NPT_String               /*searchCapabilities*/, 
         void*                    /*userdata*/) {}
+
+	virtual void OnGetSortCapabilitiesResult(
+        NPT_Result               /*res*/,
+        PLT_DeviceDataReference& /*device*/,
+        NPT_String               /*sortCapabilities*/,
+        void*                    /*userdata*/) {}
 };
 
 /*----------------------------------------------------------------------
@@ -133,6 +139,9 @@ public:
     virtual NPT_Result GetSearchCapabilities(PLT_DeviceDataReference& device,
                                              void*                    userdata = NULL);
 
+    virtual NPT_Result GetSortCapabilities(PLT_DeviceDataReference& device,
+                                           void*                    userdata = NULL);
+
     // methods
     virtual const NPT_Lock<PLT_DeviceDataReferenceList>& GetMediaServers() { return m_MediaServers; }
     virtual NPT_Result FindServer(const char* uuid, PLT_DeviceDataReference& device);    
@@ -160,6 +169,11 @@ protected:
                                                      PLT_DeviceDataReference& device, 
                                                      PLT_ActionReference&     action, 
                                                      void*                    userdata);
+
+  virtual NPT_Result OnGetSortCapabilitiesResponse(NPT_Result               res,
+                                                   PLT_DeviceDataReference& device,
+                                                   PLT_ActionReference&     action,
+                                                   void*                    userdata);
     
 protected:
     PLT_CtrlPointReference                m_CtrlPoint;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
@@ -91,6 +91,12 @@ public:
         PLT_DeviceDataReference& /*device*/, 
         PLT_BrowseInfo*          /*info*/, 
         void*                    /*userdata*/) {}
+
+	virtual void OnGetSearchCapabilitiesResult(
+        NPT_Result               /*res*/, 
+        PLT_DeviceDataReference& /*device*/, 
+        NPT_String               /*searchCapabilities*/, 
+        void*                    /*userdata*/) {}
 };
 
 /*----------------------------------------------------------------------
@@ -124,6 +130,9 @@ public:
                               const char*              filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:originalTrackNumber,upnp:album,upnp:artist,upnp:author", // explicitely specify res otherwise WMP won't return a URL!
 						  	  void*                    userdata = NULL);
 
+    virtual NPT_Result GetSearchCapabilities(PLT_DeviceDataReference& device,
+                                             void*                    userdata = NULL);
+
     // methods
     virtual const NPT_Lock<PLT_DeviceDataReferenceList>& GetMediaServers() { return m_MediaServers; }
     virtual NPT_Result FindServer(const char* uuid, PLT_DeviceDataReference& device);    
@@ -146,6 +155,11 @@ protected:
                                         PLT_DeviceDataReference& device, 
                                         PLT_ActionReference&     action, 
                                         void*                    userdata);
+
+  virtual NPT_Result OnGetSearchCapabilitiesResponse(NPT_Result               res, 
+                                                     PLT_DeviceDataReference& device, 
+                                                     PLT_ActionReference&     action, 
+                                                     void*                    userdata);
     
 protected:
     PLT_CtrlPointReference                m_CtrlPoint;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -172,6 +172,7 @@ PLT_MediaObject::Reset()
     m_People.artists.Clear();    
     m_People.authors.Clear();
     m_People.directors.Clear();
+    m_People.publisher.Clear();
 
     m_Affiliation.album     = "";
     m_Affiliation.genres.Clear();
@@ -257,6 +258,20 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
     // director
     if (mask & PLT_FILTER_MASK_DIRECTOR) {
         m_People.directors.ToDidl(didl, "director");
+    }
+
+    // publisher
+    if (mask & PLT_FILTER_MASK_PUBLISHER) {
+        // Add unknown publisher
+        if (m_People.publisher.GetItemCount() == 0)
+            m_People.publisher.Add("Unknown");
+
+        for (NPT_List<NPT_String>::Iterator it =
+             m_People.publisher.GetFirstItem(); it; ++it) {
+            didl += "<dc:publisher>";
+            PLT_Didl::AppendXmlEscape(didl, (*it));
+            didl += "</dc:publisher>";
+        }
     }
 
     // album
@@ -516,6 +531,14 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
     children.Clear();
     PLT_XmlHelper::GetChildren(entry, children, "director", didl_namespace_upnp);
     m_People.directors.FromDidl(children);
+
+    children.Clear();
+    PLT_XmlHelper::GetChildren(entry, children, "publisher", didl_namespace_dc);
+    for (NPT_Cardinal i=0; i<children.GetItemCount(); i++) {
+        if (children[i]->GetText()) {
+          m_People.publisher.Add(*children[i]->GetText());
+        }
+    }
 
     PLT_XmlHelper::GetChildText(entry, "album", m_Affiliation.album, didl_namespace_upnp, 256);
     PLT_XmlHelper::GetChildText(entry, "programTitle", m_Recorded.program_title, didl_namespace_upnp);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -195,6 +195,8 @@ PLT_MediaObject::Reset()
     m_Recorded.program_title  = "";
     m_Recorded.series_title   = "";
     m_Recorded.episode_number = 0;
+    m_Recorded.episode_count = 0;
+    m_Recorded.episode_season = 0;
 
     m_Resources.Clear();
 
@@ -389,6 +391,20 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
         didl += "</upnp:episodeNumber>";
     }
 
+    // episode count
+    if ((mask & PLT_FILTER_MASK_EPISODE_COUNT) && m_Recorded.episode_count > 0) {
+        didl += "<upnp:episodeCount>";
+        didl += NPT_String::FromInteger(m_Recorded.episode_count);
+        didl += "</upnp:episodeCount>";
+    }
+
+    // episode count
+    if ((mask & PLT_FILTER_MASK_EPISODE_SEASON)) {
+        didl += "<upnp:episodeSeason>";
+        didl += NPT_String::FromInteger(m_Recorded.episode_season);
+        didl += "</upnp:episodeSeason>";
+    }
+
 	if ((mask & PLT_FILTER_MASK_TOC) && !m_MiscInfo.toc.IsEmpty()) {
         didl += "<upnp:toc>";
 		PLT_Didl::AppendXmlEscape(didl, m_MiscInfo.toc);
@@ -547,6 +563,12 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
     NPT_UInt32 value;
     if (NPT_FAILED(str.ToInteger(value))) value = 0;
     m_Recorded.episode_number = value;
+    PLT_XmlHelper::GetChildText(entry, "episodeCount", str, didl_namespace_upnp);
+    if (NPT_FAILED(str.ToInteger(value))) value = 0;
+    m_Recorded.episode_count = value;
+    PLT_XmlHelper::GetChildText(entry, "episodeSeason", str, didl_namespace_upnp);
+    if (NPT_FAILED(str.ToInteger(value))) value = -1;
+    m_Recorded.episode_season = value;
 
     children.Clear();
     PLT_XmlHelper::GetChildren(entry, children, "genre", didl_namespace_upnp);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -147,6 +147,8 @@ typedef struct {
     NPT_String program_title;
     NPT_String series_title;
     NPT_UInt32 episode_number;
+    NPT_UInt32 episode_count;
+    NPT_UInt32 episode_season;
 } PLT_RecordedInfo;
 
 /*----------------------------------------------------------------------

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -92,7 +92,7 @@ typedef struct {
     PLT_PersonRoles authors;
     NPT_String      producer; //TODO: can be multiple
     PLT_PersonRoles directors;
-    NPT_String      publisher; //TODO: can be multiple
+    NPT_List<NPT_String> publisher;
     NPT_String      contributor; // should match m_Creator (dc:creator) //TODO: can be multiple
 } PLT_PeopleInfo;
 

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -151,6 +151,26 @@ typedef struct {
     NPT_UInt32 episode_season;
 } PLT_RecordedInfo;
 
+typedef struct {
+    NPT_String type;
+    NPT_String url;
+} PLT_Artwork;
+
+class PLT_Artworks  : public NPT_List<PLT_Artwork>
+{
+public:
+    NPT_Result Add(const NPT_String& type, const NPT_String& url);
+    NPT_Result ToDidl(NPT_String& didl, const NPT_String& tag);
+    NPT_Result FromDidl(const NPT_Array<NPT_XmlElementNode*>& nodes);
+};
+
+typedef struct {
+  NPT_String date_added;
+  NPT_Float rating;
+  NPT_String votes;
+  PLT_Artworks artwork;
+} PLT_XbmcInfo;
+
 /*----------------------------------------------------------------------
 |   PLT_MediaItemResource
 +---------------------------------------------------------------------*/
@@ -228,6 +248,9 @@ public:
 
     /* resources related */
     NPT_Array<PLT_MediaItemResource> m_Resources;
+
+    /* XBMC specific */
+    PLT_XbmcInfo m_XbmcInfo;
 
     /* original DIDL for Control Points to pass to a renderer when invoking SetAVTransportURI */
     NPT_String m_Didl;    

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
@@ -126,6 +126,24 @@ PLT_SyncMediaBrowser::Find(const char* ip, PLT_DeviceDataReference& device)
     return NPT_FAILURE;
 }
 
+static void OnResult(NPT_Result               res, 
+                     PLT_DeviceDataReference& device, 
+                     PLT_BrowseInfo*          info, 
+                     void*                    userdata)
+{
+  NPT_COMPILER_UNUSED(device);
+
+  if (!userdata) return;
+
+  PLT_BrowseDataReference* data = (PLT_BrowseDataReference*) userdata;
+  (*data)->res = res;
+  if (NPT_SUCCEEDED(res) && info) {
+      (*data)->info = *info;
+  }
+  (*data)->shared_var.SetValue(1);
+  delete data;
+}
+
 /*----------------------------------------------------------------------
 |   PLT_SyncMediaBrowser::OnBrowseResult
 +---------------------------------------------------------------------*/
@@ -135,17 +153,19 @@ PLT_SyncMediaBrowser::OnBrowseResult(NPT_Result               res,
                                      PLT_BrowseInfo*          info, 
                                      void*                    userdata)
 {
-    NPT_COMPILER_UNUSED(device);
+  OnResult(res, device, info, userdata);
+}
 
-    if (!userdata) return;
-
-    PLT_BrowseDataReference* data = (PLT_BrowseDataReference*) userdata;
-    (*data)->res = res;
-    if (NPT_SUCCEEDED(res) && info) {
-        (*data)->info = *info;
-    }
-    (*data)->shared_var.SetValue(1);
-    delete data;
+/*----------------------------------------------------------------------
+|   PLT_SyncMediaBrowser::OnSearchResult
++---------------------------------------------------------------------*/
+void
+PLT_SyncMediaBrowser::OnSearchResult(NPT_Result               res, 
+                                     PLT_DeviceDataReference& device, 
+                                     PLT_BrowseInfo*          info, 
+                                     void*                    userdata)
+{
+  OnResult(res, device, info, userdata);
 }
 
 /*----------------------------------------------------------------------
@@ -222,6 +242,38 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_BrowseDataReference& browse_data,
         filter,
         sort,
         new PLT_BrowseDataReference(browse_data));		
+    NPT_CHECK_SEVERE(res);
+
+    return WaitForResponse(browse_data->shared_var);
+}
+
+/*----------------------------------------------------------------------
+|   PLT_SyncMediaBrowser::SearchSync
++---------------------------------------------------------------------*/
+NPT_Result 
+PLT_SyncMediaBrowser::SearchSync(PLT_BrowseDataReference& browse_data,
+                                 PLT_DeviceDataReference& device, 
+                                 const char*              container_id,
+                                 const char*              search_criteria,
+                                 NPT_Int32                index, 
+                                 NPT_Int32                count,
+                                 const char*              filter)
+{
+    NPT_Result res;
+
+    browse_data->shared_var.SetValue(0);
+    browse_data->info.si = index;
+
+    // send off the search packet.  Note that this will
+    // not block.  There is a call to WaitForResponse in order
+    // to block until the response comes back.
+    res = PLT_MediaBrowser::Search(device,
+        container_id,
+        search_criteria,
+        index,
+        count,
+        filter,
+        new PLT_BrowseDataReference(browse_data));
     NPT_CHECK_SEVERE(res);
 
     return WaitForResponse(browse_data->shared_var);
@@ -315,6 +367,84 @@ done:
     // clear entire cache data for device if failed, the device could be gone
     if (NPT_FAILED(res) && cache) m_Cache.Clear(device->GetUUID());
     
+    return res;
+}
+
+/*----------------------------------------------------------------------
+|   PLT_SyncMediaBrowser::SearchSync
++---------------------------------------------------------------------*/
+NPT_Result
+PLT_SyncMediaBrowser::SearchSync(PLT_DeviceDataReference&      device,
+                                 const char*                   container_id,
+                                 const char*                   search_criteria,
+                                 PLT_MediaObjectListReference& list,
+                                 NPT_Int32                     start, /* = 0 */
+                                 NPT_Cardinal                  max_results /* = 0 */)
+{
+    NPT_Result res = NPT_FAILURE;
+    NPT_Int32  index = start;
+    NPT_UInt32 count = 0;
+
+    // reset output params
+    list = NULL;
+
+    do {	
+        PLT_BrowseDataReference browse_data(new PLT_BrowseData(), true);
+
+        // send off the search packet.  Note that this will
+        // not block.  There is a call to WaitForResponse in order
+        // to block until the response comes back.
+        res = SearchSync(
+            browse_data,
+            device,
+            container_id,
+            search_criteria,
+            index,
+            200); // DLNA recommendations for browsing children is no more than 30 at a time
+
+        NPT_CHECK_LABEL_WARNING(res, done);
+        
+        if (NPT_FAILED(browse_data->res)) {
+            res = browse_data->res;
+            NPT_CHECK_LABEL_WARNING(res, done);
+        }
+
+        // server returned no more, bail now
+        if (browse_data->info.nr == 0)
+            break;
+
+        if (browse_data->info.nr != browse_data->info.items->GetItemCount()) {
+            NPT_LOG_WARNING_2("Server returned unexpected number of items (%d vs %d)",
+                              browse_data->info.nr, browse_data->info.items->GetItemCount());
+        }
+        count += std::max<NPT_UInt32>(browse_data->info.nr, browse_data->info.items->GetItemCount());
+
+        if (list.IsNull()) {
+            list = browse_data->info.items;
+        } else {
+            list->Add(*browse_data->info.items);
+            // clear the list items so that the data inside is not
+            // cleaned up by PLT_MediaItemList dtor since we copied
+            // each pointer into the new list.
+            browse_data->info.items->Clear();
+        }
+
+        // stop now if our list contains exactly what the server said it had.
+        // Note that the server could return 0 if it didn't know how many items were
+        // available. In this case we have to continue browsing until
+        // nothing is returned back by the server.
+        // Unless we were told to stop after reaching a certain amount to avoid
+        // length delays
+        // (some servers may return a total matches out of whack at some point too)
+        if ((browse_data->info.tm && browse_data->info.tm <= count) ||
+            (max_results && count >= max_results))
+            break;
+
+        // ask for the next chunk of entries
+        index = count;
+    } while(1);
+
+done:
     return res;
 }
 

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
@@ -169,6 +169,28 @@ PLT_SyncMediaBrowser::OnSearchResult(NPT_Result               res,
 }
 
 /*----------------------------------------------------------------------
+|   PLT_SyncMediaBrowser::OnGetSearchCapabilitiesResult
++---------------------------------------------------------------------*/
+void
+PLT_SyncMediaBrowser::OnGetSearchCapabilitiesResult(NPT_Result               res, 
+                                                    PLT_DeviceDataReference& device, 
+                                                    NPT_String               searchCapabilities, 
+                                                    void*                    userdata)
+{
+  NPT_COMPILER_UNUSED(device);
+
+  if (!userdata) return;
+
+  PLT_CapabilitiesDataReference* data = (PLT_CapabilitiesDataReference*) userdata;
+  (*data)->res = res;
+  if (NPT_SUCCEEDED(res)) {
+      (*data)->capabilities = searchCapabilities;
+  }
+  (*data)->shared_var.SetValue(1);
+  delete data;
+}
+
+/*----------------------------------------------------------------------
 |   PLT_SyncMediaBrowser::OnMSStateVariablesChanged
 +---------------------------------------------------------------------*/
 void 
@@ -277,6 +299,39 @@ PLT_SyncMediaBrowser::SearchSync(PLT_BrowseDataReference& browse_data,
     NPT_CHECK_SEVERE(res);
 
     return WaitForResponse(browse_data->shared_var);
+}
+
+/*----------------------------------------------------------------------
+|   PLT_SyncMediaBrowser::GetSearchCapabilitiesSync
++---------------------------------------------------------------------*/
+NPT_Result
+PLT_SyncMediaBrowser::GetSearchCapabilitiesSync(PLT_DeviceDataReference& device, 
+                                                NPT_String&              searchCapabilities)
+{
+    NPT_Result res;
+
+    PLT_CapabilitiesDataReference capabilities_data(new PLT_CapabilitiesData(), true);
+    capabilities_data->shared_var.SetValue(0);
+
+    // send of the GetSearchCapabilities packet. Note that this will
+    // not block. There is a call to WaitForResponse in order
+    // to block until the response comes back.
+    res = PLT_MediaBrowser::GetSearchCapabilities(device,
+        new PLT_CapabilitiesDataReference(capabilities_data));
+    NPT_CHECK_SEVERE(res);
+
+    res = WaitForResponse(capabilities_data->shared_var);
+    NPT_CHECK_LABEL_WARNING(res, done);
+
+    if (NPT_FAILED(capabilities_data->res)) {
+        res = capabilities_data->res;
+        NPT_CHECK_LABEL_WARNING(res, done);
+    }
+
+    searchCapabilities = capabilities_data->capabilities;
+
+done:
+    return res;
 }
 
 /*----------------------------------------------------------------------

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -61,6 +61,14 @@ typedef struct PLT_BrowseData {
 
 typedef NPT_Reference<PLT_BrowseData> PLT_BrowseDataReference;
 
+typedef struct PLT_CapabilitiesData {
+    NPT_SharedVariable shared_var;
+    NPT_Result         res;
+    NPT_String         capabilities;
+} PLT_CapabilitiesData;
+
+typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
+
 // explicitely specify res otherwise WMP won't return a URL!
 #define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork"
 
@@ -103,6 +111,10 @@ public:
                                 PLT_DeviceDataReference& device, 
                                 PLT_BrowseInfo*          info, 
                                 void*                    userdata);
+    virtual void OnGetSearchCapabilitiesResult(NPT_Result               res, 
+                                               PLT_DeviceDataReference& device, 
+                                               NPT_String               searchCapabilities, 
+                                               void*                    userdata);
 
     // methods
     void       SetContainerListener(PLT_MediaContainerChangesListener* listener) {
@@ -121,6 +133,9 @@ public:
                           PLT_MediaObjectListReference& list,
                           NPT_Int32                     start = 0,
                           NPT_Cardinal                  max_results = 0); // 0 means all
+
+    NPT_Result GetSearchCapabilitiesSync(PLT_DeviceDataReference& device,
+                                         NPT_String&              searchCapabilities);
 
     const NPT_Lock<PLT_DeviceMap>& GetMediaServersMap() const { return m_MediaServers; }
     bool IsCached(const char* uuid, const char* object_id);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -118,7 +118,7 @@ protected:
                           NPT_Int32                index, 
                           NPT_Int32                count,
                           bool                     browse_metadata = false,
-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason", // explicitely specify res otherwise WMP won't return a URL!
+                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork", // explicitely specify res otherwise WMP won't return a URL!
                           const char*              sort = "");
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -118,7 +118,7 @@ protected:
                           NPT_Int32                index, 
                           NPT_Int32                count,
                           bool                     browse_metadata = false,
-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
+                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason", // explicitely specify res otherwise WMP won't return a URL!
                           const char*              sort = "");
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -118,7 +118,7 @@ protected:
                           NPT_Int32                index, 
                           NPT_Int32                count,
                           bool                     browse_metadata = false,
-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
+                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
                           const char*              sort = "");
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -115,6 +115,10 @@ public:
                                                PLT_DeviceDataReference& device, 
                                                NPT_String               searchCapabilities, 
                                                void*                    userdata);
+    virtual void OnGetSortCapabilitiesResult(NPT_Result               res,
+                                             PLT_DeviceDataReference& device,
+                                             NPT_String               sortCapabilities,
+                                             void*                    userdata);
 
     // methods
     void       SetContainerListener(PLT_MediaContainerChangesListener* listener) {
@@ -136,6 +140,9 @@ public:
 
     NPT_Result GetSearchCapabilitiesSync(PLT_DeviceDataReference& device,
                                          NPT_String&              searchCapabilities);
+
+    NPT_Result GetSortCapabilitiesSync(PLT_DeviceDataReference& device,
+                                       NPT_String&              sortCapabilities);
 
     const NPT_Lock<PLT_DeviceMap>& GetMediaServersMap() const { return m_MediaServers; }
     bool IsCached(const char* uuid, const char* object_id);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -118,7 +118,7 @@ protected:
                           NPT_Int32                index, 
                           NPT_Int32                count,
                           bool                     browse_metadata = false,
-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,searchable,childCount", // explicitely specify res otherwise WMP won't return a URL!
+                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
                           const char*              sort = "");
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -61,6 +61,9 @@ typedef struct PLT_BrowseData {
 
 typedef NPT_Reference<PLT_BrowseData> PLT_BrowseDataReference;
 
+// explicitely specify res otherwise WMP won't return a URL!
+#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork"
+
 /*----------------------------------------------------------------------
 |   PLT_MediaContainerListener
 +---------------------------------------------------------------------*/
@@ -96,6 +99,10 @@ public:
                                 PLT_DeviceDataReference& device, 
                                 PLT_BrowseInfo*          info, 
                                 void*                    userdata);
+    virtual void OnSearchResult(NPT_Result               res, 
+                                PLT_DeviceDataReference& device, 
+                                PLT_BrowseInfo*          info, 
+                                void*                    userdata);
 
     // methods
     void       SetContainerListener(PLT_MediaContainerChangesListener* listener) {
@@ -105,6 +112,13 @@ public:
                           const char*                   id, 
                           PLT_MediaObjectListReference& list,
                           bool                          metadata = false,
+                          NPT_Int32                     start = 0,
+                          NPT_Cardinal                  max_results = 0); // 0 means all
+
+    NPT_Result SearchSync(PLT_DeviceDataReference&      device,
+                          const char*                   container_id,
+                          const char*                   search_criteria,
+                          PLT_MediaObjectListReference& list,
                           NPT_Int32                     start = 0,
                           NPT_Cardinal                  max_results = 0); // 0 means all
 
@@ -118,8 +132,17 @@ protected:
                           NPT_Int32                index, 
                           NPT_Int32                count,
                           bool                     browse_metadata = false,
-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork", // explicitely specify res otherwise WMP won't return a URL!
+                          const char*              filter = PLT_DEFAULT_FILTER,
                           const char*              sort = "");
+
+    NPT_Result SearchSync(PLT_BrowseDataReference& browse_data,
+                          PLT_DeviceDataReference& device, 
+                          const char*              container_id,
+                          const char*              search_criteria,
+                          NPT_Int32                index, 
+                          NPT_Int32                count,
+                          const char*              filter = PLT_DEFAULT_FILTER); // explicitely specify res otherwise WMP won't return a URL!
+
 private:
     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);
     NPT_Result WaitForResponse(NPT_SharedVariable& shared_var);

--- a/lib/libUPnP/patches/0024-platinum-add-already-supported-default-filters.patch
+++ b/lib/libUPnP/patches/0024-platinum-add-already-supported-default-filters.patch
@@ -1,0 +1,25 @@
+From bfeb22157a8f6542939b16e444d989181914cee8 Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Thu, 15 May 2014 18:24:46 +0200
+Subject: [PATCH 01/11] platinum: add already supported default filters
+
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index 94f1ab3..9888b88 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -118,7 +118,7 @@ protected:
+                           NPT_Int32                index, 
+                           NPT_Int32                count,
+                           bool                     browse_metadata = false,
+-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,searchable,childCount", // explicitely specify res otherwise WMP won't return a URL!
++                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
+                           const char*              sort = "");
+ private:
+     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);
+-- 
+1.7.11.msysgit.0
+

--- a/lib/libUPnP/patches/0025-platinum-add-proper-support-for-dc-publisher.patch
+++ b/lib/libUPnP/patches/0025-platinum-add-proper-support-for-dc-publisher.patch
@@ -1,0 +1,124 @@
+From 5991b14604febf705150cfc568255d9592e37b07 Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Mon, 19 May 2014 20:38:53 +0200
+Subject: [PATCH 02/11] platinum: add proper support for dc:publisher
+
+---
+ .../Source/Devices/MediaServer/PltDidl.cpp         |  2 ++
+ .../Platinum/Source/Devices/MediaServer/PltDidl.h  |  3 +++
+ .../Source/Devices/MediaServer/PltMediaItem.cpp    | 23 ++++++++++++++++++++++
+ .../Source/Devices/MediaServer/PltMediaItem.h      |  2 +-
+ .../Devices/MediaServer/PltSyncMediaBrowser.h      |  2 +-
+ 5 files changed, 30 insertions(+), 2 deletions(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+index 73f9ed2..3d8c9fd 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+@@ -135,6 +135,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
+             mask |= PLT_FILTER_MASK_EPISODE;
+         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RATING, len, true) == 0) {
+             mask |= PLT_FILTER_MASK_RATING;
++        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_PUBLISHER, len, true) == 0) {
++            mask |= PLT_FILTER_MASK_PUBLISHER;
+         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES, len, true) == 0) {
+             mask |= PLT_FILTER_MASK_RES;
+         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES_DURATION, len, true) == 0 ||
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+index 59d1605..ae67b43 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+@@ -90,6 +90,8 @@
+ #define PLT_FILTER_MASK_LASTPLAYBACK                NPT_UINT64_C(0x0000000200000000)
+ #define PLT_FILTER_MASK_PLAYCOUNT                   NPT_UINT64_C(0x0000000400000000)
+ 
++#define PLT_FILTER_MASK_PUBLISHER                   NPT_UINT64_C(0x0000000800000000)
++
+ #define PLT_FILTER_FIELD_TITLE                      "dc:title"
+ #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
+ #define PLT_FILTER_FIELD_DATE                       "dc:date"
+@@ -118,6 +120,7 @@
+ #define PLT_FILTER_FIELD_CONTAINER_CHILDCOUNT       "container@childCount"
+ #define PLT_FILTER_FIELD_CONTAINER_SEARCHABLE       "container@searchable"
+ #define PLT_FILTER_FIELD_REFID                      "@refID"
++#define PLT_FILTER_FIELD_PUBLISHER                  "dc:publisher"
+ 
+ #define PLT_FILTER_FIELD_RES                        "res"
+ #define PLT_FILTER_FIELD_RES_DURATION               "res@duration"
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index 1728eff..bd55cb5 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -172,6 +172,7 @@ PLT_MediaObject::Reset()
+     m_People.artists.Clear();    
+     m_People.authors.Clear();
+     m_People.directors.Clear();
++    m_People.publisher.Clear();
+ 
+     m_Affiliation.album     = "";
+     m_Affiliation.genres.Clear();
+@@ -259,6 +260,20 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
+         m_People.directors.ToDidl(didl, "director");
+     }
+ 
++    // publisher
++    if (mask & PLT_FILTER_MASK_PUBLISHER) {
++        // Add unknown publisher
++        if (m_People.publisher.GetItemCount() == 0)
++            m_People.publisher.Add("Unknown");
++
++        for (NPT_List<NPT_String>::Iterator it =
++             m_People.publisher.GetFirstItem(); it; ++it) {
++            didl += "<dc:publisher>";
++            PLT_Didl::AppendXmlEscape(didl, (*it));
++            didl += "</dc:publisher>";
++        }
++    }
++
+     // album
+     if ((mask & PLT_FILTER_MASK_ALBUM) && !m_Affiliation.album.IsEmpty()) {
+         didl += "<upnp:album>";
+@@ -517,6 +532,14 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
+     PLT_XmlHelper::GetChildren(entry, children, "director", didl_namespace_upnp);
+     m_People.directors.FromDidl(children);
+ 
++    children.Clear();
++    PLT_XmlHelper::GetChildren(entry, children, "publisher", didl_namespace_dc);
++    for (NPT_Cardinal i=0; i<children.GetItemCount(); i++) {
++        if (children[i]->GetText()) {
++          m_People.publisher.Add(*children[i]->GetText());
++        }
++    }
++
+     PLT_XmlHelper::GetChildText(entry, "album", m_Affiliation.album, didl_namespace_upnp, 256);
+     PLT_XmlHelper::GetChildText(entry, "programTitle", m_Recorded.program_title, didl_namespace_upnp);
+     PLT_XmlHelper::GetChildText(entry, "seriesTitle", m_Recorded.series_title, didl_namespace_upnp);
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+index 2449276..9df90d5 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+@@ -92,7 +92,7 @@ typedef struct {
+     PLT_PersonRoles authors;
+     NPT_String      producer; //TODO: can be multiple
+     PLT_PersonRoles directors;
+-    NPT_String      publisher; //TODO: can be multiple
++    NPT_List<NPT_String> publisher;
+     NPT_String      contributor; // should match m_Creator (dc:creator) //TODO: can be multiple
+ } PLT_PeopleInfo;
+ 
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index 9888b88..c6fc3be 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -118,7 +118,7 @@ protected:
+                           NPT_Int32                index, 
+                           NPT_Int32                count,
+                           bool                     browse_metadata = false,
+-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
++                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
+                           const char*              sort = "");
+ private:
+     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);
+-- 
+1.7.11.msysgit.0
+

--- a/lib/libUPnP/patches/0026-platinum-add-support-for-upnp-episodeCount-and-upnp-.patch
+++ b/lib/libUPnP/patches/0026-platinum-add-support-for-upnp-episodeCount-and-upnp-.patch
@@ -1,0 +1,131 @@
+From f4eef1767e642fd3b46ce18a4daf619903b74d46 Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Tue, 31 Dec 2013 14:06:55 +0100
+Subject: [PATCH 03/11] platinum: add support for upnp:episodeCount and
+ upnp:episodeSeason from ContentDirectory v4
+
+---
+ .../Source/Devices/MediaServer/PltDidl.cpp         |  6 +++++-
+ .../Platinum/Source/Devices/MediaServer/PltDidl.h  |  6 ++++++
+ .../Source/Devices/MediaServer/PltMediaItem.cpp    | 22 ++++++++++++++++++++++
+ .../Source/Devices/MediaServer/PltMediaItem.h      |  2 ++
+ .../Devices/MediaServer/PltSyncMediaBrowser.h      |  2 +-
+ 5 files changed, 36 insertions(+), 2 deletions(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+index 3d8c9fd..0758ad5 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+@@ -156,7 +156,11 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
+             mask |= PLT_FILTER_MASK_RES | PLT_FILTER_MASK_RES_NRAUDIOCHANNELS;
+ 		} else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_RES_SAMPLEFREQUENCY, len, true) == 0) {
+             mask |= PLT_FILTER_MASK_RES | PLT_FILTER_MASK_RES_SAMPLEFREQUENCY;
+-		}
++		} else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_EPISODE_COUNT, len, true) == 0) {
++            mask |= PLT_FILTER_MASK_EPISODE_COUNT;
++        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_EPISODE_SEASON, len, true) == 0) {
++            mask |= PLT_FILTER_MASK_EPISODE_SEASON;
++        }
+ 
+         if (next_comma < 0) {
+             return mask;
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+index ae67b43..2271162 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+@@ -92,6 +92,9 @@
+ 
+ #define PLT_FILTER_MASK_PUBLISHER                   NPT_UINT64_C(0x0000000800000000)
+ 
++#define PLT_FILTER_MASK_EPISODE_COUNT               NPT_UINT64_C(0x0000001000000000)
++#define PLT_FILTER_MASK_EPISODE_SEASON              NPT_UINT64_C(0x0000002000000000)
++
+ #define PLT_FILTER_FIELD_TITLE                      "dc:title"
+ #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
+ #define PLT_FILTER_FIELD_DATE                       "dc:date"
+@@ -133,6 +136,9 @@
+ #define PLT_FILTER_FIELD_RES_NRAUDIOCHANNELS        "res@nrAudioChannels"
+ #define PLT_FILTER_FIELD_RES_SAMPLEFREQUENCY        "res@sampleFrequency"
+ 
++#define PLT_FILTER_FIELD_EPISODE_COUNT              "upnp:episodeCount"
++#define PLT_FILTER_FIELD_EPISODE_SEASON             "upnp:episodeSeason"
++
+ extern const char* didl_header;
+ extern const char* didl_footer;
+ extern const char* didl_namespace_dc;
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index bd55cb5..a8855cc 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -195,6 +195,8 @@ PLT_MediaObject::Reset()
+     m_Recorded.program_title  = "";
+     m_Recorded.series_title   = "";
+     m_Recorded.episode_number = 0;
++    m_Recorded.episode_count = 0;
++    m_Recorded.episode_season = 0;
+ 
+     m_Resources.Clear();
+ 
+@@ -389,6 +391,20 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
+         didl += "</upnp:episodeNumber>";
+     }
+ 
++    // episode count
++    if ((mask & PLT_FILTER_MASK_EPISODE_COUNT) && m_Recorded.episode_count > 0) {
++        didl += "<upnp:episodeCount>";
++        didl += NPT_String::FromInteger(m_Recorded.episode_count);
++        didl += "</upnp:episodeCount>";
++    }
++
++    // episode count
++    if ((mask & PLT_FILTER_MASK_EPISODE_SEASON)) {
++        didl += "<upnp:episodeSeason>";
++        didl += NPT_String::FromInteger(m_Recorded.episode_season);
++        didl += "</upnp:episodeSeason>";
++    }
++
+ 	if ((mask & PLT_FILTER_MASK_TOC) && !m_MiscInfo.toc.IsEmpty()) {
+         didl += "<upnp:toc>";
+ 		PLT_Didl::AppendXmlEscape(didl, m_MiscInfo.toc);
+@@ -547,6 +563,12 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
+     NPT_UInt32 value;
+     if (NPT_FAILED(str.ToInteger(value))) value = 0;
+     m_Recorded.episode_number = value;
++    PLT_XmlHelper::GetChildText(entry, "episodeCount", str, didl_namespace_upnp);
++    if (NPT_FAILED(str.ToInteger(value))) value = 0;
++    m_Recorded.episode_count = value;
++    PLT_XmlHelper::GetChildText(entry, "episodeSeason", str, didl_namespace_upnp);
++    if (NPT_FAILED(str.ToInteger(value))) value = -1;
++    m_Recorded.episode_season = value;
+ 
+     children.Clear();
+     PLT_XmlHelper::GetChildren(entry, children, "genre", didl_namespace_upnp);
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+index 9df90d5..34a69b7 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+@@ -147,6 +147,8 @@ typedef struct {
+     NPT_String program_title;
+     NPT_String series_title;
+     NPT_UInt32 episode_number;
++    NPT_UInt32 episode_count;
++    NPT_UInt32 episode_season;
+ } PLT_RecordedInfo;
+ 
+ /*----------------------------------------------------------------------
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index c6fc3be..3c14dff 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -118,7 +118,7 @@ protected:
+                           NPT_Int32                index, 
+                           NPT_Int32                count,
+                           bool                     browse_metadata = false,
+-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution", // explicitely specify res otherwise WMP won't return a URL!
++                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason", // explicitely specify res otherwise WMP won't return a URL!
+                           const char*              sort = "");
+ private:
+     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);
+-- 
+1.7.11.msysgit.0
+

--- a/lib/libUPnP/patches/0027-platinum-add-support-for-xbmc-specific-fields-datead.patch
+++ b/lib/libUPnP/patches/0027-platinum-add-support-for-xbmc-specific-fields-datead.patch
@@ -1,0 +1,284 @@
+From ac80794eedc6e240671ce3b60ecb4a24c58f84ab Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Mon, 19 May 2014 20:56:25 +0200
+Subject: [PATCH 04/11] platinum: add support for xbmc specific fields
+ dateadded, rating, votes and artwork
+
+xbmc:dateadded to pass dateadded with items and not need to stat upnp resources for that
+xbmc:rating for number-based rating
+xbmc:votes for string-based votes number
+xbmc:artwork for a type-url-based mapping of artwork
+---
+ .../Source/Devices/MediaServer/PltDidl.cpp         |  12 ++-
+ .../Platinum/Source/Devices/MediaServer/PltDidl.h  |  11 +++
+ .../Source/Devices/MediaServer/PltMediaItem.cpp    | 109 +++++++++++++++++++++
+ .../Source/Devices/MediaServer/PltMediaItem.h      |  23 +++++
+ .../Devices/MediaServer/PltSyncMediaBrowser.h      |   2 +-
+ 5 files changed, 155 insertions(+), 2 deletions(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+index 0758ad5..2bb6a04 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+@@ -47,11 +47,13 @@ NPT_SET_LOCAL_LOGGER("platinum.media.server.didl")
+ const char* didl_header         = "<DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\""
+                                             " xmlns:dc=\"http://purl.org/dc/elements/1.1/\""
+                                             " xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\""
+-                                            " xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\">";
++                                            " xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\""
++                                            " xmlns:xbmc=\"urn:schemas-xbmc-org:metadata-1-0/\">";
+ const char* didl_footer         = "</DIDL-Lite>";
+ const char* didl_namespace_dc   = "http://purl.org/dc/elements/1.1/";
+ const char* didl_namespace_upnp = "urn:schemas-upnp-org:metadata-1-0/upnp/";
+ const char* didl_namespace_dlna = "urn:schemas-dlna-org:metadata-1-0/";
++const char* didl_namespace_xbmc = "urn:schemas-xbmc-org:metadata-1-0/";
+ 
+ /*----------------------------------------------------------------------
+ |   PLT_Didl::ConvertFilterToMask
+@@ -160,6 +162,14 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
+             mask |= PLT_FILTER_MASK_EPISODE_COUNT;
+         } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_EPISODE_SEASON, len, true) == 0) {
+             mask |= PLT_FILTER_MASK_EPISODE_SEASON;
++        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_DATEADDED, len, true) == 0) {
++            mask |= PLT_FILTER_MASK_XBMC_DATEADDED;
++        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_RATING, len, true) == 0) {
++            mask |= PLT_FILTER_MASK_XBMC_RATING;
++        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_VOTES, len, true) == 0) {
++            mask |= PLT_FILTER_MASK_XBMC_VOTES;
++        } else if (NPT_String::CompareN(s+i, PLT_FILTER_FIELD_XBMC_ARTWORK, len, true) == 0) {
++            mask |= PLT_FILTER_MASK_XBMC_ARTWORK;
+         }
+ 
+         if (next_comma < 0) {
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+index 2271162..0f7c892 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+@@ -95,6 +95,11 @@
+ #define PLT_FILTER_MASK_EPISODE_COUNT               NPT_UINT64_C(0x0000001000000000)
+ #define PLT_FILTER_MASK_EPISODE_SEASON              NPT_UINT64_C(0x0000002000000000)
+ 
++#define PLT_FILTER_MASK_XBMC_DATEADDED              NPT_UINT64_C(0x0000100000000000)
++#define PLT_FILTER_MASK_XBMC_RATING                 NPT_UINT64_C(0x0000200000000000)
++#define PLT_FILTER_MASK_XBMC_VOTES                  NPT_UINT64_C(0x0000300000000000)
++#define PLT_FILTER_MASK_XBMC_ARTWORK                NPT_UINT64_C(0x0000400000000000)
++
+ #define PLT_FILTER_FIELD_TITLE                      "dc:title"
+ #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
+ #define PLT_FILTER_FIELD_DATE                       "dc:date"
+@@ -139,11 +144,17 @@
+ #define PLT_FILTER_FIELD_EPISODE_COUNT              "upnp:episodeCount"
+ #define PLT_FILTER_FIELD_EPISODE_SEASON             "upnp:episodeSeason"
+ 
++#define PLT_FILTER_FIELD_XBMC_DATEADDED             "xbmc:dateadded"
++#define PLT_FILTER_FIELD_XBMC_RATING                "xbmc:rating"
++#define PLT_FILTER_FIELD_XBMC_VOTES                 "xbmc:votes"
++#define PLT_FILTER_FIELD_XBMC_ARTWORK               "xbmc:artwork"
++
+ extern const char* didl_header;
+ extern const char* didl_footer;
+ extern const char* didl_namespace_dc;
+ extern const char* didl_namespace_upnp;
+ extern const char* didl_namespace_dlna;
++extern const char* didl_namespace_xbmc;
+ 
+ /*----------------------------------------------------------------------
+ |   PLT_Didl
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index a8855cc..5c2ec84 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -110,6 +110,62 @@ PLT_PersonRoles::FromDidl(const NPT_Array<NPT_XmlElementNode*>& nodes)
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_Artworks::Add
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_Artworks::Add(const NPT_String& type, const NPT_String& url)
++{
++    PLT_Artwork artwork;
++    artwork.type = type;
++    artwork.url = url;
++
++    return NPT_List<PLT_Artwork>::Add(artwork);
++}
++
++/*----------------------------------------------------------------------
++|   PLT_Artworks::ToDidl
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_Artworks::ToDidl(NPT_String& didl, const NPT_String& tag)
++{
++    NPT_String tmp;
++    for (NPT_List<PLT_Artwork>::Iterator it =
++         NPT_List<PLT_Artwork>::GetFirstItem(); it; it++) {
++        if (it->type.IsEmpty()) continue;
++
++        tmp += "<xbmc:" + tag;
++        if (!it->type.IsEmpty()) {
++            tmp += " type=\"";
++            PLT_Didl::AppendXmlEscape(tmp, it->type);
++            tmp += "\"";
++        }
++        tmp += ">";
++        PLT_Didl::AppendXmlEscape(tmp, it->url);
++        tmp += "</xbmc:" + tag + ">";
++    }
++
++    didl += tmp;
++    return NPT_SUCCESS;
++}
++
++/*----------------------------------------------------------------------
++|   PLT_Artworks::ToDidl
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_Artworks::FromDidl(const NPT_Array<NPT_XmlElementNode*>& nodes)
++{
++    for (NPT_Cardinal i=0; i<nodes.GetItemCount(); i++) {
++        PLT_Artwork artwork;
++        const NPT_String* url = nodes[i]->GetText();
++        const NPT_String* type = nodes[i]->GetAttribute("type");
++        if (type) artwork.type = *type;
++        if (url) artwork.url = *url;
++        NPT_CHECK(NPT_List<PLT_Artwork>::Add(artwork));
++    }
++    return NPT_SUCCESS;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_MediaItemResource::PLT_MediaItemResource
+ +---------------------------------------------------------------------*/
+ PLT_MediaItemResource::PLT_MediaItemResource()
+@@ -200,6 +256,11 @@ PLT_MediaObject::Reset()
+ 
+     m_Resources.Clear();
+ 
++    m_XbmcInfo.date_added = "";
++    m_XbmcInfo.rating = 0.0f;
++    m_XbmcInfo.votes = "";
++    m_XbmcInfo.artwork.Clear();
++
+     m_Didl = "";
+ 
+     return NPT_SUCCESS;
+@@ -472,6 +533,32 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
+         }
+     }
+ 
++    // xbmc dateadded
++    if ((mask & PLT_FILTER_MASK_XBMC_DATEADDED) && !m_XbmcInfo.date_added.IsEmpty()) {
++        didl += "<xbmc:dateadded>";
++        PLT_Didl::AppendXmlEscape(didl, m_XbmcInfo.date_added);
++        didl += "</xbmc:dateadded>";
++    } 
++
++    // xbmc rating
++    if (mask & PLT_FILTER_MASK_XBMC_RATING) {
++        didl += "<xbmc:rating>";
++        didl += NPT_String::Format("%.1f", m_XbmcInfo.rating);
++        didl += "</xbmc:rating>";
++    }
++
++    // xbmc votes
++    if (mask & PLT_FILTER_MASK_XBMC_VOTES && !m_XbmcInfo.votes.IsEmpty()) {
++        didl += "<xbmc:votes>";
++        PLT_Didl::AppendXmlEscape(didl, m_XbmcInfo.votes);
++        didl += "</xbmc:votes>";
++    }
++
++    // xbmc artwork
++    if (mask & PLT_FILTER_MASK_XBMC_ARTWORK) {
++        m_XbmcInfo.artwork.ToDidl(didl, "artwork");
++    }
++
+     // class is required
+     didl += "<upnp:class";
+ 	if (!m_ObjectClass.friendly_name.IsEmpty()) {
+@@ -672,6 +759,28 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
+         m_Resources.Add(resource);
+     }
+ 
++    PLT_XmlHelper::GetChildText(entry, "dateadded", m_XbmcInfo.date_added, didl_namespace_xbmc, 256);
++    // parse date and make sure it's valid
++    for (int format=0; format<=NPT_DateTime::FORMAT_RFC_1036; format++) {
++        NPT_DateTime date;
++        if (NPT_SUCCEEDED(date.FromString(m_XbmcInfo.date_added, (NPT_DateTime::Format)format))) {
++            parsed_date = date.ToString((NPT_DateTime::Format)format);
++            break;
++        }
++    }
++    m_XbmcInfo.date_added = parsed_date;
++
++    PLT_XmlHelper::GetChildText(entry, "rating", str, didl_namespace_xbmc);
++    NPT_Float floatValue;
++    if (NPT_FAILED(str.ToFloat(floatValue))) floatValue = 0.0;
++    m_XbmcInfo.rating = floatValue;
++
++    PLT_XmlHelper::GetChildText(entry, "votes", m_XbmcInfo.votes, didl_namespace_xbmc, 256);
++
++    children.Clear();
++    PLT_XmlHelper::GetChildren(entry, children, "artwork", didl_namespace_xbmc);
++    m_XbmcInfo.artwork.FromDidl(children);
++
+     // re serialize the entry didl as a we might need to pass it to a renderer
+     // we may have modified the tree to "fix" issues, so as not to break a renderer
+     // (don't write xml prefix as this didl could be part of a larger document)
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+index 34a69b7..56291a7 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+@@ -151,6 +151,26 @@ typedef struct {
+     NPT_UInt32 episode_season;
+ } PLT_RecordedInfo;
+ 
++typedef struct {
++    NPT_String type;
++    NPT_String url;
++} PLT_Artwork;
++
++class PLT_Artworks  : public NPT_List<PLT_Artwork>
++{
++public:
++    NPT_Result Add(const NPT_String& type, const NPT_String& url);
++    NPT_Result ToDidl(NPT_String& didl, const NPT_String& tag);
++    NPT_Result FromDidl(const NPT_Array<NPT_XmlElementNode*>& nodes);
++};
++
++typedef struct {
++  NPT_String date_added;
++  NPT_Float rating;
++  NPT_String votes;
++  PLT_Artworks artwork;
++} PLT_XbmcInfo;
++
+ /*----------------------------------------------------------------------
+ |   PLT_MediaItemResource
+ +---------------------------------------------------------------------*/
+@@ -229,6 +249,9 @@ public:
+     /* resources related */
+     NPT_Array<PLT_MediaItemResource> m_Resources;
+ 
++    /* XBMC specific */
++    PLT_XbmcInfo m_XbmcInfo;
++
+     /* original DIDL for Control Points to pass to a renderer when invoking SetAVTransportURI */
+     NPT_String m_Didl;    
+ };
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index 3c14dff..ffdddda 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -118,7 +118,7 @@ protected:
+                           NPT_Int32                index, 
+                           NPT_Int32                count,
+                           bool                     browse_metadata = false,
+-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason", // explicitely specify res otherwise WMP won't return a URL!
++                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork", // explicitely specify res otherwise WMP won't return a URL!
+                           const char*              sort = "");
+ private:
+     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);
+-- 
+1.7.11.msysgit.0
+

--- a/lib/libUPnP/patches/0028-platinum-add-SearchSync-method-to-SyncMediaBrowser.patch
+++ b/lib/libUPnP/patches/0028-platinum-add-SearchSync-method-to-SyncMediaBrowser.patch
@@ -1,0 +1,254 @@
+From 4d9d36139eed70da5ee922501bcf68443a349b44 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Piechowiak?= <misiek.piechowiak@gmail.com>
+Date: Fri, 2 Aug 2013 18:55:34 +0200
+Subject: [PATCH 05/11] platinum: add SearchSync method to SyncMediaBrowser
+
+---
+ .../Devices/MediaServer/PltSyncMediaBrowser.cpp    | 150 +++++++++++++++++++--
+ .../Devices/MediaServer/PltSyncMediaBrowser.h      |  25 +++-
+ 2 files changed, 164 insertions(+), 11 deletions(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+index 24219ff..96e4121 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+@@ -126,6 +126,24 @@ PLT_SyncMediaBrowser::Find(const char* ip, PLT_DeviceDataReference& device)
+     return NPT_FAILURE;
+ }
+ 
++static void OnResult(NPT_Result               res, 
++                     PLT_DeviceDataReference& device, 
++                     PLT_BrowseInfo*          info, 
++                     void*                    userdata)
++{
++  NPT_COMPILER_UNUSED(device);
++
++  if (!userdata) return;
++
++  PLT_BrowseDataReference* data = (PLT_BrowseDataReference*) userdata;
++  (*data)->res = res;
++  if (NPT_SUCCEEDED(res) && info) {
++      (*data)->info = *info;
++  }
++  (*data)->shared_var.SetValue(1);
++  delete data;
++}
++
+ /*----------------------------------------------------------------------
+ |   PLT_SyncMediaBrowser::OnBrowseResult
+ +---------------------------------------------------------------------*/
+@@ -135,17 +153,19 @@ PLT_SyncMediaBrowser::OnBrowseResult(NPT_Result               res,
+                                      PLT_BrowseInfo*          info, 
+                                      void*                    userdata)
+ {
+-    NPT_COMPILER_UNUSED(device);
+-
+-    if (!userdata) return;
++  OnResult(res, device, info, userdata);
++}
+ 
+-    PLT_BrowseDataReference* data = (PLT_BrowseDataReference*) userdata;
+-    (*data)->res = res;
+-    if (NPT_SUCCEEDED(res) && info) {
+-        (*data)->info = *info;
+-    }
+-    (*data)->shared_var.SetValue(1);
+-    delete data;
++/*----------------------------------------------------------------------
++|   PLT_SyncMediaBrowser::OnSearchResult
+++---------------------------------------------------------------------*/
++void
++PLT_SyncMediaBrowser::OnSearchResult(NPT_Result               res, 
++                                     PLT_DeviceDataReference& device, 
++                                     PLT_BrowseInfo*          info, 
++                                     void*                    userdata)
++{
++  OnResult(res, device, info, userdata);
+ }
+ 
+ /*----------------------------------------------------------------------
+@@ -228,6 +248,38 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_BrowseDataReference& browse_data,
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_SyncMediaBrowser::SearchSync
+++---------------------------------------------------------------------*/
++NPT_Result 
++PLT_SyncMediaBrowser::SearchSync(PLT_BrowseDataReference& browse_data,
++                                 PLT_DeviceDataReference& device, 
++                                 const char*              container_id,
++                                 const char*              search_criteria,
++                                 NPT_Int32                index, 
++                                 NPT_Int32                count,
++                                 const char*              filter)
++{
++    NPT_Result res;
++
++    browse_data->shared_var.SetValue(0);
++    browse_data->info.si = index;
++
++    // send off the search packet.  Note that this will
++    // not block.  There is a call to WaitForResponse in order
++    // to block until the response comes back.
++    res = PLT_MediaBrowser::Search(device,
++        container_id,
++        search_criteria,
++        index,
++        count,
++        filter,
++        new PLT_BrowseDataReference(browse_data));
++    NPT_CHECK_SEVERE(res);
++
++    return WaitForResponse(browse_data->shared_var);
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_SyncMediaBrowser::BrowseSync
+ +---------------------------------------------------------------------*/
+ NPT_Result
+@@ -319,6 +371,84 @@ done:
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_SyncMediaBrowser::SearchSync
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_SyncMediaBrowser::SearchSync(PLT_DeviceDataReference&      device,
++                                 const char*                   container_id,
++                                 const char*                   search_criteria,
++                                 PLT_MediaObjectListReference& list,
++                                 NPT_Int32                     start, /* = 0 */
++                                 NPT_Cardinal                  max_results /* = 0 */)
++{
++    NPT_Result res = NPT_FAILURE;
++    NPT_Int32  index = start;
++    NPT_UInt32 count = 0;
++
++    // reset output params
++    list = NULL;
++
++    do {	
++        PLT_BrowseDataReference browse_data(new PLT_BrowseData(), true);
++
++        // send off the search packet.  Note that this will
++        // not block.  There is a call to WaitForResponse in order
++        // to block until the response comes back.
++        res = SearchSync(
++            browse_data,
++            device,
++            container_id,
++            search_criteria,
++            index,
++            200); // DLNA recommendations for browsing children is no more than 30 at a time
++
++        NPT_CHECK_LABEL_WARNING(res, done);
++        
++        if (NPT_FAILED(browse_data->res)) {
++            res = browse_data->res;
++            NPT_CHECK_LABEL_WARNING(res, done);
++        }
++
++        // server returned no more, bail now
++        if (browse_data->info.nr == 0)
++            break;
++
++        if (browse_data->info.nr != browse_data->info.items->GetItemCount()) {
++            NPT_LOG_WARNING_2("Server returned unexpected number of items (%d vs %d)",
++                              browse_data->info.nr, browse_data->info.items->GetItemCount());
++        }
++        count += std::max<NPT_UInt32>(browse_data->info.nr, browse_data->info.items->GetItemCount());
++
++        if (list.IsNull()) {
++            list = browse_data->info.items;
++        } else {
++            list->Add(*browse_data->info.items);
++            // clear the list items so that the data inside is not
++            // cleaned up by PLT_MediaItemList dtor since we copied
++            // each pointer into the new list.
++            browse_data->info.items->Clear();
++        }
++
++        // stop now if our list contains exactly what the server said it had.
++        // Note that the server could return 0 if it didn't know how many items were
++        // available. In this case we have to continue browsing until
++        // nothing is returned back by the server.
++        // Unless we were told to stop after reaching a certain amount to avoid
++        // length delays
++        // (some servers may return a total matches out of whack at some point too)
++        if ((browse_data->info.tm && browse_data->info.tm <= count) ||
++            (max_results && count >= max_results))
++            break;
++
++        // ask for the next chunk of entries
++        index = count;
++    } while(1);
++
++done:
++    return res;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_SyncMediaBrowser::IsCached
+ +---------------------------------------------------------------------*/
+ bool
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index ffdddda..5ef9f37 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -61,6 +61,9 @@ typedef struct PLT_BrowseData {
+ 
+ typedef NPT_Reference<PLT_BrowseData> PLT_BrowseDataReference;
+ 
++// explicitely specify res otherwise WMP won't return a URL!
++#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork"
++
+ /*----------------------------------------------------------------------
+ |   PLT_MediaContainerListener
+ +---------------------------------------------------------------------*/
+@@ -96,6 +99,10 @@ public:
+                                 PLT_DeviceDataReference& device, 
+                                 PLT_BrowseInfo*          info, 
+                                 void*                    userdata);
++    virtual void OnSearchResult(NPT_Result               res, 
++                                PLT_DeviceDataReference& device, 
++                                PLT_BrowseInfo*          info, 
++                                void*                    userdata);
+ 
+     // methods
+     void       SetContainerListener(PLT_MediaContainerChangesListener* listener) {
+@@ -108,6 +115,13 @@ public:
+                           NPT_Int32                     start = 0,
+                           NPT_Cardinal                  max_results = 0); // 0 means all
+ 
++    NPT_Result SearchSync(PLT_DeviceDataReference&      device,
++                          const char*                   container_id,
++                          const char*                   search_criteria,
++                          PLT_MediaObjectListReference& list,
++                          NPT_Int32                     start = 0,
++                          NPT_Cardinal                  max_results = 0); // 0 means all
++
+     const NPT_Lock<PLT_DeviceMap>& GetMediaServersMap() const { return m_MediaServers; }
+     bool IsCached(const char* uuid, const char* object_id);
+ 
+@@ -118,8 +132,17 @@ protected:
+                           NPT_Int32                index, 
+                           NPT_Int32                count,
+                           bool                     browse_metadata = false,
+-                          const char*              filter = "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork", // explicitely specify res otherwise WMP won't return a URL!
++                          const char*              filter = PLT_DEFAULT_FILTER,
+                           const char*              sort = "");
++
++    NPT_Result SearchSync(PLT_BrowseDataReference& browse_data,
++                          PLT_DeviceDataReference& device, 
++                          const char*              container_id,
++                          const char*              search_criteria,
++                          NPT_Int32                index, 
++                          NPT_Int32                count,
++                          const char*              filter = PLT_DEFAULT_FILTER); // explicitely specify res otherwise WMP won't return a URL!
++
+ private:
+     NPT_Result Find(const char* ip, PLT_DeviceDataReference& device);
+     NPT_Result WaitForResponse(NPT_SharedVariable& shared_var);
+-- 
+1.7.11.msysgit.0
+

--- a/lib/libUPnP/patches/0029-platinum-implement-GetSearchCapabilities-in-media-br.patch
+++ b/lib/libUPnP/patches/0029-platinum-implement-GetSearchCapabilities-in-media-br.patch
@@ -1,0 +1,251 @@
+From 4a35702414b4c3be06d24b5b5c5da86c3f058078 Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Sat, 8 Feb 2014 11:46:11 +0100
+Subject: [PATCH 06/11] platinum: implement GetSearchCapabilities in media
+ browser
+
+---
+ .../Source/Devices/MediaServer/PltMediaBrowser.cpp | 58 ++++++++++++++++++++++
+ .../Source/Devices/MediaServer/PltMediaBrowser.h   | 14 ++++++
+ .../Devices/MediaServer/PltSyncMediaBrowser.cpp    | 55 ++++++++++++++++++++
+ .../Devices/MediaServer/PltSyncMediaBrowser.h      | 15 ++++++
+ 4 files changed, 142 insertions(+)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
+index 266397d..46b6f41 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
+@@ -305,6 +305,33 @@ PLT_MediaBrowser::Browse(PLT_DeviceDataReference& device,
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_MediaBrowser::GetSearchCapabilities
+++---------------------------------------------------------------------*/
++NPT_Result 
++PLT_MediaBrowser::GetSearchCapabilities(PLT_DeviceDataReference& device,
++                                        void*                    userdata)
++{
++    // verify device still in our list
++    PLT_DeviceDataReference device_data;
++    NPT_CHECK_WARNING(FindServer(device->GetUUID(), device_data));
++
++    // create action
++    PLT_ActionReference action;
++    NPT_CHECK_SEVERE(m_CtrlPoint->CreateAction(
++        device, 
++        "urn:schemas-upnp-org:service:ContentDirectory:1",
++        "GetSearchCapabilities",
++        action));
++
++    // invoke the action
++    if (NPT_FAILED(m_CtrlPoint->InvokeAction(action, userdata))) {
++        return NPT_ERROR_INVALID_PARAMETERS;
++    }
++
++    return NPT_SUCCESS;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_MediaBrowser::OnActionResponse
+ +---------------------------------------------------------------------*/
+ NPT_Result
+@@ -322,6 +349,8 @@ PLT_MediaBrowser::OnActionResponse(NPT_Result           res,
+         return OnBrowseResponse(res, device, action, userdata);
+     } else if (actionName.Compare("Search", true) == 0) {
+         return OnSearchResponse(res, device, action, userdata);
++    } else if (actionName.Compare("GetSearchCapabilities", true) == 0) {
++        return OnGetSearchCapabilitiesResponse(res, device, action, userdata);
+     }
+ 
+     return NPT_SUCCESS;
+@@ -436,6 +465,35 @@ bad_action:
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_MediaBrowser::OnGetSearchCapabilitiesResponse
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_MediaBrowser::OnGetSearchCapabilitiesResponse(NPT_Result               res, 
++                                                  PLT_DeviceDataReference& device, 
++                                                  PLT_ActionReference&     action, 
++                                                  void*                    userdata)
++{
++    NPT_String value;
++
++    if (!m_Delegate) return NPT_SUCCESS;
++
++    if (NPT_FAILED(res) || action->GetErrorCode() != 0) {
++        goto bad_action;
++    }
++
++    if (NPT_FAILED(action->GetArgumentValue("SearchCaps", value)))  {
++        goto bad_action;
++    }
++
++    m_Delegate->OnGetSearchCapabilitiesResult(NPT_SUCCESS, device, value, userdata);
++    return NPT_SUCCESS;
++
++bad_action:
++    m_Delegate->OnGetSearchCapabilitiesResult(NPT_FAILURE, device, value, userdata);
++    return NPT_FAILURE;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_MediaBrowser::OnEventNotify
+ +---------------------------------------------------------------------*/
+ NPT_Result
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
+index 2ee032b..023630d 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
+@@ -91,6 +91,12 @@ public:
+         PLT_DeviceDataReference& /*device*/, 
+         PLT_BrowseInfo*          /*info*/, 
+         void*                    /*userdata*/) {}
++
++	virtual void OnGetSearchCapabilitiesResult(
++        NPT_Result               /*res*/, 
++        PLT_DeviceDataReference& /*device*/, 
++        NPT_String               /*searchCapabilities*/, 
++        void*                    /*userdata*/) {}
+ };
+ 
+ /*----------------------------------------------------------------------
+@@ -124,6 +130,9 @@ public:
+                               const char*              filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:originalTrackNumber,upnp:album,upnp:artist,upnp:author", // explicitely specify res otherwise WMP won't return a URL!
+ 						  	  void*                    userdata = NULL);
+ 
++    virtual NPT_Result GetSearchCapabilities(PLT_DeviceDataReference& device,
++                                             void*                    userdata = NULL);
++
+     // methods
+     virtual const NPT_Lock<PLT_DeviceDataReferenceList>& GetMediaServers() { return m_MediaServers; }
+     virtual NPT_Result FindServer(const char* uuid, PLT_DeviceDataReference& device);    
+@@ -146,6 +155,11 @@ protected:
+                                         PLT_DeviceDataReference& device, 
+                                         PLT_ActionReference&     action, 
+                                         void*                    userdata);
++
++  virtual NPT_Result OnGetSearchCapabilitiesResponse(NPT_Result               res, 
++                                                     PLT_DeviceDataReference& device, 
++                                                     PLT_ActionReference&     action, 
++                                                     void*                    userdata);
+     
+ protected:
+     PLT_CtrlPointReference                m_CtrlPoint;
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+index 96e4121..8ae9f72 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+@@ -169,6 +169,28 @@ PLT_SyncMediaBrowser::OnSearchResult(NPT_Result               res,
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_SyncMediaBrowser::OnGetSearchCapabilitiesResult
+++---------------------------------------------------------------------*/
++void
++PLT_SyncMediaBrowser::OnGetSearchCapabilitiesResult(NPT_Result               res, 
++                                                    PLT_DeviceDataReference& device, 
++                                                    NPT_String               searchCapabilities, 
++                                                    void*                    userdata)
++{
++  NPT_COMPILER_UNUSED(device);
++
++  if (!userdata) return;
++
++  PLT_CapabilitiesDataReference* data = (PLT_CapabilitiesDataReference*) userdata;
++  (*data)->res = res;
++  if (NPT_SUCCEEDED(res)) {
++      (*data)->capabilities = searchCapabilities;
++  }
++  (*data)->shared_var.SetValue(1);
++  delete data;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_SyncMediaBrowser::OnMSStateVariablesChanged
+ +---------------------------------------------------------------------*/
+ void 
+@@ -280,6 +302,39 @@ PLT_SyncMediaBrowser::SearchSync(PLT_BrowseDataReference& browse_data,
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_SyncMediaBrowser::GetSearchCapabilitiesSync
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_SyncMediaBrowser::GetSearchCapabilitiesSync(PLT_DeviceDataReference& device, 
++                                                NPT_String&              searchCapabilities)
++{
++    NPT_Result res;
++
++    PLT_CapabilitiesDataReference capabilities_data(new PLT_CapabilitiesData(), true);
++    capabilities_data->shared_var.SetValue(0);
++
++    // send of the GetSearchCapabilities packet. Note that this will
++    // not block. There is a call to WaitForResponse in order
++    // to block until the response comes back.
++    res = PLT_MediaBrowser::GetSearchCapabilities(device,
++        new PLT_CapabilitiesDataReference(capabilities_data));
++    NPT_CHECK_SEVERE(res);
++
++    res = WaitForResponse(capabilities_data->shared_var);
++    NPT_CHECK_LABEL_WARNING(res, done);
++
++    if (NPT_FAILED(capabilities_data->res)) {
++        res = capabilities_data->res;
++        NPT_CHECK_LABEL_WARNING(res, done);
++    }
++
++    searchCapabilities = capabilities_data->capabilities;
++
++done:
++    return res;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_SyncMediaBrowser::BrowseSync
+ +---------------------------------------------------------------------*/
+ NPT_Result
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index 5ef9f37..7054b72 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -61,6 +61,14 @@ typedef struct PLT_BrowseData {
+ 
+ typedef NPT_Reference<PLT_BrowseData> PLT_BrowseDataReference;
+ 
++typedef struct PLT_CapabilitiesData {
++    NPT_SharedVariable shared_var;
++    NPT_Result         res;
++    NPT_String         capabilities;
++} PLT_CapabilitiesData;
++
++typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
++
+ // explicitely specify res otherwise WMP won't return a URL!
+ #define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork"
+ 
+@@ -103,6 +111,10 @@ public:
+                                 PLT_DeviceDataReference& device, 
+                                 PLT_BrowseInfo*          info, 
+                                 void*                    userdata);
++    virtual void OnGetSearchCapabilitiesResult(NPT_Result               res, 
++                                               PLT_DeviceDataReference& device, 
++                                               NPT_String               searchCapabilities, 
++                                               void*                    userdata);
+ 
+     // methods
+     void       SetContainerListener(PLT_MediaContainerChangesListener* listener) {
+@@ -122,6 +134,9 @@ public:
+                           NPT_Int32                     start = 0,
+                           NPT_Cardinal                  max_results = 0); // 0 means all
+ 
++    NPT_Result GetSearchCapabilitiesSync(PLT_DeviceDataReference& device,
++                                         NPT_String&              searchCapabilities);
++
+     const NPT_Lock<PLT_DeviceMap>& GetMediaServersMap() const { return m_MediaServers; }
+     bool IsCached(const char* uuid, const char* object_id);
+ 
+-- 
+1.7.11.msysgit.0
+

--- a/lib/libUPnP/patches/0030-platinum-implement-GetSortCapabilities-in-media-brow.patch
+++ b/lib/libUPnP/patches/0030-platinum-implement-GetSortCapabilities-in-media-brow.patch
@@ -1,0 +1,236 @@
+From bf2fe4c362eaec89257d7649f18af2431dcc544a Mon Sep 17 00:00:00 2001
+From: montellese <montellese@xbmc.org>
+Date: Sat, 8 Feb 2014 15:15:32 +0100
+Subject: [PATCH 07/11] platinum: implement GetSortCapabilities in media
+ browser
+
+---
+ .../Source/Devices/MediaServer/PltMediaBrowser.cpp | 58 ++++++++++++++++++++++
+ .../Source/Devices/MediaServer/PltMediaBrowser.h   | 14 ++++++
+ .../Devices/MediaServer/PltSyncMediaBrowser.cpp    | 55 ++++++++++++++++++++
+ .../Devices/MediaServer/PltSyncMediaBrowser.h      |  7 +++
+ 4 files changed, 134 insertions(+)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
+index 46b6f41..2478441 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.cpp
+@@ -332,6 +332,33 @@ PLT_MediaBrowser::GetSearchCapabilities(PLT_DeviceDataReference& device,
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_MediaBrowser::GetSortCapabilities
+++---------------------------------------------------------------------*/
++NPT_Result 
++PLT_MediaBrowser::GetSortCapabilities(PLT_DeviceDataReference& device,
++                                      void*                    userdata)
++{
++    // verify device still in our list
++    PLT_DeviceDataReference device_data;
++    NPT_CHECK_WARNING(FindServer(device->GetUUID(), device_data));
++
++    // create action
++    PLT_ActionReference action;
++    NPT_CHECK_SEVERE(m_CtrlPoint->CreateAction(
++        device, 
++        "urn:schemas-upnp-org:service:ContentDirectory:1",
++        "GetSortCapabilities",
++        action));
++
++    // invoke the action
++    if (NPT_FAILED(m_CtrlPoint->InvokeAction(action, userdata))) {
++        return NPT_ERROR_INVALID_PARAMETERS;
++    }
++
++    return NPT_SUCCESS;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_MediaBrowser::OnActionResponse
+ +---------------------------------------------------------------------*/
+ NPT_Result
+@@ -351,6 +378,8 @@ PLT_MediaBrowser::OnActionResponse(NPT_Result           res,
+         return OnSearchResponse(res, device, action, userdata);
+     } else if (actionName.Compare("GetSearchCapabilities", true) == 0) {
+         return OnGetSearchCapabilitiesResponse(res, device, action, userdata);
++    } else if (actionName.Compare("GetSortCapabilities", true) == 0) {
++        return OnGetSortCapabilitiesResponse(res, device, action, userdata);
+     }
+ 
+     return NPT_SUCCESS;
+@@ -494,6 +523,35 @@ bad_action:
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_MediaBrowser::OnGetSearchCapabilitiesResponse
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_MediaBrowser::OnGetSortCapabilitiesResponse(NPT_Result               res, 
++                                                PLT_DeviceDataReference& device, 
++                                                PLT_ActionReference&     action, 
++                                                void*                    userdata)
++{
++    NPT_String value;
++
++    if (!m_Delegate) return NPT_SUCCESS;
++
++    if (NPT_FAILED(res) || action->GetErrorCode() != 0) {
++        goto bad_action;
++    }
++
++    if (NPT_FAILED(action->GetArgumentValue("SortCaps", value)))  {
++        goto bad_action;
++    }
++
++    m_Delegate->OnGetSortCapabilitiesResult(NPT_SUCCESS, device, value, userdata);
++    return NPT_SUCCESS;
++
++bad_action:
++    m_Delegate->OnGetSortCapabilitiesResult(NPT_FAILURE, device, value, userdata);
++    return NPT_FAILURE;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_MediaBrowser::OnEventNotify
+ +---------------------------------------------------------------------*/
+ NPT_Result
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
+index 023630d..41ed84e 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
+@@ -97,6 +97,12 @@ public:
+         PLT_DeviceDataReference& /*device*/, 
+         NPT_String               /*searchCapabilities*/, 
+         void*                    /*userdata*/) {}
++
++	virtual void OnGetSortCapabilitiesResult(
++        NPT_Result               /*res*/,
++        PLT_DeviceDataReference& /*device*/,
++        NPT_String               /*sortCapabilities*/,
++        void*                    /*userdata*/) {}
+ };
+ 
+ /*----------------------------------------------------------------------
+@@ -133,6 +139,9 @@ public:
+     virtual NPT_Result GetSearchCapabilities(PLT_DeviceDataReference& device,
+                                              void*                    userdata = NULL);
+ 
++    virtual NPT_Result GetSortCapabilities(PLT_DeviceDataReference& device,
++                                           void*                    userdata = NULL);
++
+     // methods
+     virtual const NPT_Lock<PLT_DeviceDataReferenceList>& GetMediaServers() { return m_MediaServers; }
+     virtual NPT_Result FindServer(const char* uuid, PLT_DeviceDataReference& device);    
+@@ -160,6 +169,11 @@ protected:
+                                                      PLT_DeviceDataReference& device, 
+                                                      PLT_ActionReference&     action, 
+                                                      void*                    userdata);
++
++  virtual NPT_Result OnGetSortCapabilitiesResponse(NPT_Result               res,
++                                                   PLT_DeviceDataReference& device,
++                                                   PLT_ActionReference&     action,
++                                                   void*                    userdata);
+     
+ protected:
+     PLT_CtrlPointReference                m_CtrlPoint;
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+index 8ae9f72..27d81fa 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+@@ -191,6 +191,28 @@ PLT_SyncMediaBrowser::OnGetSearchCapabilitiesResult(NPT_Result               res
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_SyncMediaBrowser::OnGetSortCapabilitiesResult
+++---------------------------------------------------------------------*/
++void
++PLT_SyncMediaBrowser::OnGetSortCapabilitiesResult(NPT_Result               res,
++                                                  PLT_DeviceDataReference& device,
++                                                  NPT_String               sortCapabilities,
++                                                  void*                    userdata)
++{
++  NPT_COMPILER_UNUSED(device);
++
++  if (!userdata) return;
++
++  PLT_CapabilitiesDataReference* data = (PLT_CapabilitiesDataReference*) userdata;
++  (*data)->res = res;
++  if (NPT_SUCCEEDED(res)) {
++      (*data)->capabilities = sortCapabilities;
++  }
++  (*data)->shared_var.SetValue(1);
++  delete data;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_SyncMediaBrowser::OnMSStateVariablesChanged
+ +---------------------------------------------------------------------*/
+ void 
+@@ -335,6 +357,39 @@ done:
+ }
+ 
+ /*----------------------------------------------------------------------
++|   PLT_SyncMediaBrowser::GetSortCapabilitiesSync
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_SyncMediaBrowser::GetSortCapabilitiesSync(PLT_DeviceDataReference& device, 
++                                              NPT_String&              sortCapabilities)
++{
++    NPT_Result res;
++
++    PLT_CapabilitiesDataReference capabilities_data(new PLT_CapabilitiesData(), true);
++    capabilities_data->shared_var.SetValue(0);
++
++    // send of the GetSortCapabilities packet. Note that this will
++    // not block. There is a call to WaitForResponse in order
++    // to block until the response comes back.
++    res = PLT_MediaBrowser::GetSortCapabilities(device,
++        new PLT_CapabilitiesDataReference(capabilities_data));
++    NPT_CHECK_SEVERE(res);
++
++    res = WaitForResponse(capabilities_data->shared_var);
++    NPT_CHECK_LABEL_WARNING(res, done);
++
++    if (NPT_FAILED(capabilities_data->res)) {
++        res = capabilities_data->res;
++        NPT_CHECK_LABEL_WARNING(res, done);
++    }
++
++    sortCapabilities = capabilities_data->capabilities;
++
++done:
++    return res;
++}
++
++/*----------------------------------------------------------------------
+ |   PLT_SyncMediaBrowser::BrowseSync
+ +---------------------------------------------------------------------*/
+ NPT_Result
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+index 7054b72..21f1d28 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -115,6 +115,10 @@ public:
+                                                PLT_DeviceDataReference& device, 
+                                                NPT_String               searchCapabilities, 
+                                                void*                    userdata);
++    virtual void OnGetSortCapabilitiesResult(NPT_Result               res,
++                                             PLT_DeviceDataReference& device,
++                                             NPT_String               sortCapabilities,
++                                             void*                    userdata);
+ 
+     // methods
+     void       SetContainerListener(PLT_MediaContainerChangesListener* listener) {
+@@ -137,6 +141,9 @@ public:
+     NPT_Result GetSearchCapabilitiesSync(PLT_DeviceDataReference& device,
+                                          NPT_String&              searchCapabilities);
+ 
++    NPT_Result GetSortCapabilitiesSync(PLT_DeviceDataReference& device,
++                                       NPT_String&              sortCapabilities);
++
+     const NPT_Lock<PLT_DeviceMap>& GetMediaServersMap() const { return m_MediaServers; }
+     bool IsCached(const char* uuid, const char* object_id);
+ 
+-- 
+1.7.11.msysgit.0
+

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -301,6 +301,9 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     if(object.m_ReferenceID == object.m_ObjectID)
         object.m_ReferenceID = "";
 
+    for (unsigned int index = 0; index < tag.m_studio.size(); index++)
+        object.m_People.publisher.Add(tag.m_studio[index].c_str());
+
     for (unsigned int index = 0; index < tag.m_genre.size(); index++)
       object.m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());
 
@@ -690,6 +693,10 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
         tag.m_premiered    = date;
     }
     tag.m_iYear       = date.GetYear();
+
+    for (unsigned int index = 0; index < object.m_People.publisher.GetItemCount(); index++)
+        tag.m_studio.push_back(object.m_People.publisher.GetItem(index)->GetChars());
+
     for (unsigned int index = 0; index < object.m_Affiliation.genres.GetItemCount(); index++)
     {
       // ignore single "Unknown" genre inserted by Platinum

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -304,6 +304,10 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     for (unsigned int index = 0; index < tag.m_studio.size(); index++)
         object.m_People.publisher.Add(tag.m_studio[index].c_str());
 
+    object.m_XbmcInfo.date_added = tag.m_dateAdded.GetAsDBDate();
+    object.m_XbmcInfo.rating = tag.m_fRating;
+    object.m_XbmcInfo.votes = tag.m_strVotes;
+
     for (unsigned int index = 0; index < tag.m_genre.size(); index++)
       object.m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());
 
@@ -590,9 +594,14 @@ BuildObject(CFileItem&                    item,
         object->m_ExtraInfo.album_arts.Add(art);
     }
 
-    fanart = item.GetArt("fanart");
-    if (upnp_server && !fanart.empty())
-        upnp_server->AddSafeResourceUri(object, rooturi, ips, CTextureUtils::GetWrappedImageURL(fanart), "xbmc.org:*:fanart:*");
+    for (CGUIListItem::ArtMap::const_iterator itArtwork = item.GetArt().begin(); itArtwork != item.GetArt().end(); ++itArtwork) {
+        if (!itArtwork->first.empty() && !itArtwork->second.empty()) {
+            std::string wrappedUrl = CTextureUtils::GetWrappedImageURL(itArtwork->second);
+            object->m_XbmcInfo.artwork.Add(itArtwork->first.c_str(),
+              upnp_server->BuildSafeResourceUri(rooturi, (*ips.GetFirstItem()).ToString(), wrappedUrl.c_str()));
+            upnp_server->AddSafeResourceUri(object, rooturi, ips, wrappedUrl.c_str(), ("xbmc.org:*:" + itArtwork->first + ":*").c_str());
+        }
+    }
 
     return object;
 
@@ -696,6 +705,10 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
 
     for (unsigned int index = 0; index < object.m_People.publisher.GetItemCount(); index++)
         tag.m_studio.push_back(object.m_People.publisher.GetItem(index)->GetChars());
+
+    tag.m_dateAdded.SetFromDateString((const char*)object.m_XbmcInfo.date_added);
+    tag.m_fRating = object.m_XbmcInfo.rating;
+    tag.m_strVotes = object.m_XbmcInfo.votes;
 
     for (unsigned int index = 0; index < object.m_Affiliation.genres.GetItemCount(); index++)
     {
@@ -818,14 +831,10 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry)
   else if(entry->m_Description.icon_uri.GetLength())
     pItem->SetArt("thumb", (const char*) entry->m_Description.icon_uri);
 
-  PLT_ProtocolInfo fanart_mask("xbmc.org", "*", "fanart", "*");
-  for(unsigned i = 0; i < entry->m_Resources.GetItemCount(); ++i) {
-    PLT_MediaItemResource& res = entry->m_Resources[i];
-    if(res.m_ProtocolInfo.Match(fanart_mask)) {
-      pItem->SetArt("fanart", (const char*)res.m_Uri);
-      break;
-    }
-  }
+  for (unsigned int index = 0; index < entry->m_XbmcInfo.artwork.GetItemCount(); index++)
+      pItem->SetArt(entry->m_XbmcInfo.artwork.GetItem(index)->type.GetChars(),
+                    entry->m_XbmcInfo.artwork.GetItem(index)->url.GetChars());
+
   // set the watched overlay, as this will not be set later due to
   // content set on file item list
   if (pItem->HasVideoInfoTag()) {

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -102,7 +102,10 @@ CUPnPServer::SetupServices()
     PLT_Service* service = NULL;
     NPT_Result result = FindServiceById("urn:upnp-org:serviceId:ContentDirectory", service);
     if (service)
+    {
+      service->SetStateVariable("SearchCapabilities", "upnp:class");
       service->SetStateVariable("SortCapabilities", "res@duration,res@size,res@bitrate,dc:date,dc:title,dc:size,upnp:album,upnp:artist,upnp:albumArtist,upnp:episodeNumber,upnp:genre,upnp:originalTrackNumber,upnp:rating");
+    }
 
     m_scanning = true;
     OnScanCompleted(AudioLibrary);

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -104,7 +104,7 @@ CUPnPServer::SetupServices()
     if (service)
     {
       service->SetStateVariable("SearchCapabilities", "upnp:class");
-      service->SetStateVariable("SortCapabilities", "res@duration,res@size,res@bitrate,dc:date,dc:title,dc:size,upnp:album,upnp:artist,upnp:albumArtist,upnp:episodeNumber,upnp:genre,upnp:originalTrackNumber,upnp:rating");
+      service->SetStateVariable("SortCapabilities", "res@duration,res@size,res@bitrate,dc:date,dc:title,dc:size,upnp:album,upnp:artist,upnp:albumArtist,upnp:episodeNumber,upnp:genre,upnp:originalTrackNumber,upnp:rating,upnp:episodeCount,upnp:episodeSeason,xbmc:rating,xbmc:dateadded,xbmc:votes");
     }
 
     m_scanning = true;
@@ -1244,12 +1244,22 @@ CUPnPServer::SortItems(CFileItemList& items, const char* sort_criteria)
       sorting.sortBy = SortByArtist;
     else if (method.Equals("upnp:episodeNumber"))
       sorting.sortBy = SortByEpisodeNumber;
+    else if (method.Equals("upnp:episodeCount"))
+      sorting.sortBy = SortByNumberOfEpisodes;
+    else if (method.Equals("upnp:episodeSeason"))
+      sorting.sortBy = SortBySeason;
     else if (method.Equals("upnp:genre"))
       sorting.sortBy = SortByGenre;
     else if (method.Equals("upnp:originalTrackNumber"))
       sorting.sortBy = SortByTrackNumber;
     else if(method.Equals("upnp:rating"))
       sorting.sortBy = SortByMPAA;
+    else if (method.Equals("xbmc:rating"))
+      sorting.sortBy = SortByRating;
+    else if (method.Equals("xbmc:dateadded"))
+      sorting.sortBy = SortByDateAdded;
+    else if (method.Equals("xbmc:votes"))
+      sorting.sortBy = SortByVotes;
     else {
       CLog::Log(LOGINFO, "UPnP: unsupported sort criteria '%s' passed", method.c_str());
       continue; // needed so unidentified sort methods don't re-sort by label


### PR DESCRIPTION
These are most of the additions to UPnP and the Platinum SDK from my media import work.
- proper support for dc:publisher in Platinum SDK. This is filled with the studio for video items and can later be used to e.g. fill in the label that produced a music album.
- support for upnp:episodeCount and upnp:episodeSeason from ContentDirectory:4 specification in Platinum
- support for xbmc namespace and the properties dateadded, rating, votes and artwork to get additional details to the client
- implementation of the Search() method from ContentDirectory:1 specification in Platinum. This allows to e.g. search for all items of a specific type
- implementation of the GetSearchCapabilities() method from ContentDirectory:1 specification in Platinum. This allows to get a list of supported search fields/properties. Right now we only support "upnp:class" i.e. searching by the type of media item
- implementation of the GetSortCapabilities() method from ContentDirectory:1 specification in Platinum. This allows to get a list of properties by which a list of items can be sorted. Furthermore I've implemented sorting for upnp:episodeCount, upnp:episodeSeason, xbmc:rating, xbmc:dateadded and xbmc:votes
