### PR TITLE
[osx] - handle the VDA HW Acceleration setting same as all others (inste...

### DIFF
--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -9,20 +9,6 @@
       </group>
     </category>
   </section>
-  <section id="videos">
-    <category id="videoacceleration">
-      <group id="3">
-        <setting id="videoplayer.usevda" type="boolean" parent="videoplayer.decodingmethod" label="13429" help="36160">
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
-          </dependencies>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-      </group>
-    </category>
-  </section>
 </settings>
 
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -748,6 +748,15 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.usevda" type="boolean" label="13429" help="36160">
+          <requirement>HasVDA</requirement>
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
     <category id="myvideos" label="14081" help="36601">

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -250,6 +250,9 @@ void CSettingConditions::Initialize()
   if (g_sysinfo.HasVideoToolBoxDecoder())
     m_simpleConditions.insert("hasvideotoolboxdecoder");
 #endif
+#ifdef TARGET_DARWIN_OSX
+  m_simpleConditions.insert("HasVDA");
+#endif
 #ifdef HAS_LIBAMCODEC
   if (aml_present())
     m_simpleConditions.insert("have_amcodec");


### PR DESCRIPTION
...ad of overwriting in darwin_osx.xml - introduce HasVDA dependency and use that one).

Should be straight forward - @Montellese for a second pair of eyes ...
