### PR TITLE
[python/json/appmessenger] Announce DPMS state change to XBMCMonitor and JSON

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4518,6 +4518,7 @@ bool CApplication::ToggleDPMS(bool manual)
     {
       m_dpmsIsActive = false;
       m_dpmsIsManual = false;
+      CAnnouncementManager::Get().Announce(GUI, "xbmc", "OnDPMSDeactivated");
       return m_dpms->DisablePowerSaving();
     }
     else
@@ -4526,6 +4527,7 @@ bool CApplication::ToggleDPMS(bool manual)
       {
         m_dpmsIsActive = true;
         m_dpmsIsManual = manual;
+        CAnnouncementManager::Get().Announce(GUI, "xbmc", "OnDPMSActivated");
         return true;
       }
     }

--- a/xbmc/interfaces/json-rpc/schema/notifications.json
+++ b/xbmc/interfaces/json-rpc/schema/notifications.json
@@ -343,5 +343,23 @@
       { "name": "data", "type": "null", "required": true }
     ],
     "returns": null
+  },
+  "GUI.OnDPMSActivated": {
+    "type": "notification",
+    "description": "Energy saving/DPMS has been activated.",
+    "params": [
+      { "name": "sender", "type": "string", "required": true },
+      { "name": "data", "type": "null", "required": true }
+    ],
+    "returns": null
+  },
+  "GUI.OnDPMSDeactivated": {
+    "type": "notification",
+    "description": "Energy saving/DPMS has been deactivated.",
+    "params": [
+      { "name": "sender", "type": "string", "required": true },
+      { "name": "data", "type": "null", "required": true }
+    ],
+    "returns": null
   }
 }

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -42,6 +42,8 @@ namespace XBMCAddon
       inline void    OnSettingsChanged() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onSettingsChanged)); }
       inline void    OnScreensaverActivated() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onScreensaverActivated)); }
       inline void    OnScreensaverDeactivated() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onScreensaverDeactivated)); }
+      inline void    OnDPMSActivated() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onDPMSActivated)); }
+      inline void    OnDPMSDeactivated() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onDPMSDeactivated)); }
       inline void    OnScanStarted(const String &library)
       {
 	XBMC_TRACE;
@@ -80,6 +82,20 @@ namespace XBMCAddon
        * Will be called when screensaver goes off\n
        */
       virtual void    onScreensaverDeactivated() { XBMC_TRACE; }
+
+      /**
+       * onDPMSActivated() -- onDPMSActivated method.\n
+       * \n
+       * Will be called when energysaving/DPMS gets active\n
+       */
+      virtual void    onDPMSActivated() { XBMC_TRACE; }
+
+      /**
+       * onDPMSDeactivated() -- onDPMSDeactivated method.\n
+       * \n
+       * Will be called when energysaving/DPMS is turned off\n
+       */
+      virtual void    onDPMSDeactivated() { XBMC_TRACE; }
 
       /**
        * onScanStarted(library) -- onScanStarted method.\n

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -108,6 +108,10 @@ void XBPython::Announce(AnnouncementFlag flag, const char *sender, const char *m
      OnScreensaverDeactivated();
    else if (strcmp(message, "OnScreensaverActivated") == 0)
      OnScreensaverActivated();
+   else if (strcmp(message, "OnDPMSDeactivated") == 0)
+     OnDPMSDeactivated();
+   else if (strcmp(message, "OnDPMSActivated") == 0)
+     OnDPMSActivated();
   }
 
   OnNotification(sender, std::string(ANNOUNCEMENT::AnnouncementFlagToString(flag)) + "." + std::string(message), CJSONVariantWriter::Write(data, g_advancedSettings.m_jsonOutputCompact));
@@ -299,6 +303,28 @@ void XBPython::OnScreensaverDeactivated()
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList,(*it)))
       (*it)->OnScreensaverDeactivated();
+  }
+}
+
+void XBPython::OnDPMSActivated()
+{
+  XBMC_TRACE;
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  for (MonitorCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
+  {
+    if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList,(*it)))
+      (*it)->OnDPMSActivated();
+  }
+}
+
+void XBPython::OnDPMSDeactivated()
+{
+  XBMC_TRACE;
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  for (MonitorCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
+  {
+    if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList,(*it)))
+      (*it)->OnDPMSDeactivated();
   }
 }
 

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -83,6 +83,8 @@ public:
   void OnSettingsChanged(const CStdString &strings);
   void OnScreensaverActivated();
   void OnScreensaverDeactivated();
+  void OnDPMSActivated();
+  void OnDPMSDeactivated();
   void OnScanStarted(const std::string &library);
   void OnScanFinished(const std::string &library);
   void OnAbortRequested(const CStdString &ID="");


### PR DESCRIPTION
Follow-up to https://github.com/xbmc/xbmc/pull/4760, enables addon devs to add onDPMSActivated() and onDPMSDeactivated() methods to their XBMCMonitor classes or just take the JSON notification if they like to be informed if the DPMS state changes (messages are sent from CApplication::ToggleDPMS() ).
