### PR TITLE
[AE/osxsink] - support multistream devices

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -266,7 +266,8 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   m_latentFrames += m_outputStream.GetNumLatencyFrames();
 
   // update the channel map based on the new stream format
-  devEnum.GetAEChannelMap(format.m_channelLayout, numOutputChannels);
+  if (passthrough == PassthroughModeNone)
+    devEnum.GetAEChannelMap(format.m_channelLayout, numOutputChannels);
    
   /* TODO: Should we use the virtual format to determine our data format? */
   format.m_frameSize     = format.m_channelLayout.Count() * (CAEUtil::DataFormatToBits(format.m_dataFormat) >> 3);
@@ -285,9 +286,9 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   m_buffer = new AERingBuffer(num_buffers * format.m_frames * m_frameSizePerPlane, m_planes);
   CLog::Log(LOGDEBUG, "%s: using buffer size: %u (%f ms)", __FUNCTION__, m_buffer->GetMaxSize(), (float)m_buffer->GetMaxSize() / (m_framesPerSecond * m_frameSizePerPlane));
 
-  if (passthrough != PassthroughModeNone)
+  if (m_outputBitstream)
     format.m_dataFormat = AE_FMT_S16NE;
-  else
+  else if (passthrough == PassthroughModeNone)
     format.m_dataFormat = (m_planes > 1) ? AE_FMT_FLOATP : AE_FMT_FLOAT;
 
   // Register for data request callbacks from the driver and start

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -215,6 +215,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   UInt32 numOutputChannels = 0;
   EPassthroughMode passthrough = PassthroughModeNone;
   m_planes = 1;
+  // after FindSuitableFormatForStream requestedStreamIndex will have a valid index and no INT_MAX anymore ...
   if (devEnum.FindSuitableFormatForStream(requestedStreamIndex, format, outputFormat, passthrough, outputStream))
   {
     numOutputChannels = outputFormat.mChannelsPerFrame;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -56,8 +56,8 @@ static void EnumerateDevices(CADeviceList &list)
       CAEDeviceInfo firstDevice = listForDevice.front().second;
       firstDevice.m_deviceName = "default";
       firstDevice.m_displayName = "Default";
-      firstDevice.m_displayNameExtra = "";
       list.insert(list.begin(), std::make_pair(deviceID, firstDevice));
+      firstDevice.m_displayNameExtra = defaultDeviceName;
     }
 
     deviceIDList.pop_front();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -52,6 +52,7 @@ private:
   CCoreAudioDevice   m_device;
   CCoreAudioStream   m_outputStream;
   unsigned int       m_latentFrames;
+  unsigned int       m_outputBufferIndex;
 
   bool               m_outputBitstream;   ///< true if we're bistreaming into a LinearPCM stream rather than AC3 stream.
   unsigned int       m_planes;            ///< number of audio planes (1 if non-planar)

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -292,7 +292,7 @@ CAEChannelInfo AEDeviceEnumerationOSX::getChannelInfoForStream(UInt32 streamIdx)
   else
   {
     //get channel map to match the devices channel layout as set in audio-midi-setup
-    GetAEChannelMap(channelInfo, m_caDevice.GetTotalOutputChannels());
+    GetAEChannelMap(channelInfo, m_caDevice.GetNumChannelsOfStream(streamIdx));
   }
   return channelInfo;
 }

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -381,20 +381,28 @@ std::string AEDeviceEnumerationOSX::getDeviceNameForStream(UInt32 streamIdx) con
 }
 
 std::string AEDeviceEnumerationOSX::getExtraDisplayNameForStream(UInt32 streamIdx) const
-{
-  std::string extraDisplayName = "";
-  
+{ 
   // for distinguishing the streams inside one device we add
-  // Stream <number> to the extraDisplayName
+  // the corresponding channels to the extraDisplayName
   // planar devices are ignored here as their streams are
   // the channels not different subdevices
   if (m_caStreamInfos.size() > 1 && !m_isPlanar)
   {
-    std::stringstream streamIdxStr;
-    streamIdxStr << streamIdx;
-    extraDisplayName = "Stream " + streamIdxStr.str();
+    // build a string with the channels for this stream
+    UInt32 startChannel = 0;
+    CCoreAudioStream::GetStartingChannelInDevice(m_caStreamInfos[streamIdx].streamID, startChannel);
+    UInt32 numChannels = m_caDevice.GetNumChannelsOfStream(streamIdx);
+    std::stringstream extraName;
+    extraName << "Channels ";
+    extraName << startChannel;
+    extraName << " - ";
+    extraName << startChannel + numChannels - 1;
+    CLog::Log(LOGNOTICE, "%s adding stream %d as pseudo device with start channel %d and %d channels total", __FUNCTION__, (unsigned int)streamIdx, (unsigned int)startChannel, (unsigned int)numChannels);
+    return extraName.str();
   }
-  return extraDisplayName;
+
+  //for all other devices use the datasource as extraname
+  return m_caDevice.GetCurrentDataSourceName();
 }
 
 float AEDeviceEnumerationOSX::scoreSampleRate(Float64 destinationRate, unsigned int sourceRate) const

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h
@@ -22,7 +22,13 @@
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Sinks/osx/CoreAudioDevice.h"
 
-typedef std::vector< std::pair<AudioDeviceID, CAEDeviceInfo> > CADeviceList;
+struct CADeviceInstance
+{
+  AudioDeviceID audioDeviceId;
+  unsigned int streamIndex;
+  unsigned int sourceId;
+};
+typedef std::vector< std::pair<struct CADeviceInstance, CAEDeviceInfo> > CADeviceList;
 
 typedef enum PassthroughMode
 {
@@ -30,7 +36,7 @@ typedef enum PassthroughMode
   PassthroughModeNative,
   PassthroughModeBitstream
 } EPassthroughMode;
-  
+
 //Hirarchy:
 // Device
 //       - 1..n streams

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -321,7 +321,7 @@ UInt32 CCoreAudioDevice::GetTotalOutputChannels() const
   return channels;
 }
 
-UInt32 CCoreAudioDevice::GetNumChannelsOfStream(UInt32 streamIdx)
+UInt32 CCoreAudioDevice::GetNumChannelsOfStream(UInt32 streamIdx) const
 {
   UInt32 channels = 0;
   
@@ -622,7 +622,93 @@ bool CCoreAudioDevice::GetPreferredChannelLayoutForStereo(CCoreAudioChannelLayou
   return (ret == noErr);
 }
 
-bool CCoreAudioDevice::GetDataSources(CoreAudioDataSourceList* pList)
+std::string CCoreAudioDevice::GetCurrentDataSourceName() const
+{
+  UInt32 dataSourceId = 0;
+  std::string dataSourceName = "";
+  if(GetDataSource(dataSourceId))
+  {
+    dataSourceName = GetDataSourceName(dataSourceId);
+  }
+  return dataSourceName;
+}
+
+std::string CCoreAudioDevice::GetDataSourceName(UInt32 dataSourceId) const
+{
+  UInt32 propertySize = 0;
+  CFStringRef dataSourceNameCF;
+  std::string dataSourceName;
+  std::string ret = "";
+  
+  if (!m_DeviceId)
+    return ret;
+  
+  AudioObjectPropertyAddress  propertyAddress;
+  propertyAddress.mScope    = kAudioDevicePropertyScopeOutput;
+  propertyAddress.mElement  = 0;
+  propertyAddress.mSelector = kAudioDevicePropertyDataSourceNameForIDCFString;
+
+  AudioValueTranslation translation;
+  translation.mInputData = &dataSourceId;
+  translation.mInputDataSize = sizeof(UInt32);
+  translation.mOutputData = &dataSourceNameCF;
+  translation.mOutputDataSize = sizeof ( CFStringRef );
+  propertySize = sizeof(AudioValueTranslation);
+  OSStatus status = AudioObjectGetPropertyData(m_DeviceId, &propertyAddress, 0, NULL, &propertySize, &translation);
+
+  if (( status == noErr ) && dataSourceNameCF )
+  {
+    if (DarwinCFStringRefToUTF8String(dataSourceNameCF, dataSourceName))
+    {
+      ret = dataSourceName;
+    }
+    CFRelease ( dataSourceNameCF );
+  }
+
+  return ret;
+}
+
+bool CCoreAudioDevice::GetDataSource(UInt32 &dataSourceId) const
+{
+  bool ret = false;
+  
+  if (!m_DeviceId)
+    return false;
+  
+  AudioObjectPropertyAddress  propertyAddress;
+  propertyAddress.mScope    = kAudioDevicePropertyScopeOutput;
+  propertyAddress.mElement  = 0;
+  propertyAddress.mSelector = kAudioDevicePropertyDataSource;
+  
+  UInt32 size = sizeof(dataSourceId);
+  OSStatus status = AudioObjectGetPropertyData(m_DeviceId, &propertyAddress, 0, NULL, &size, &dataSourceId);
+  if(status == noErr)
+    ret = true;
+  
+  return ret;
+}
+
+bool CCoreAudioDevice::SetDataSource(UInt32 &dataSourceId)
+{
+  bool ret = false;
+  
+  if (!m_DeviceId)
+    return false;
+  
+  AudioObjectPropertyAddress  propertyAddress;
+  propertyAddress.mScope    = kAudioDevicePropertyScopeOutput;
+  propertyAddress.mElement  = 0;
+  propertyAddress.mSelector = kAudioDevicePropertyDataSource;
+  
+  UInt32 size = sizeof(dataSourceId);
+  OSStatus status = AudioObjectSetPropertyData(m_DeviceId, &propertyAddress, 0, NULL, size, &dataSourceId);
+  if(status == noErr)
+    ret = true;
+  
+  return ret;
+}
+
+bool CCoreAudioDevice::GetDataSources(CoreAudioDataSourceList* pList) const
 {
   if (!pList || !m_DeviceId)
     return false;

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -29,7 +29,7 @@
 
 #include <CoreAudio/CoreAudio.h>
 
-typedef std::list<UInt32> CoreAudioDataSourceList;
+typedef std::vector<UInt32> CoreAudioDataSourceList;
 typedef std::list<AudioDeviceID> CoreAudioDeviceList;
 
 class CCoreAudioChannelLayout;
@@ -54,7 +54,7 @@ public:
   bool          IsDigital() const;
   UInt32        GetTransportType() const;
   UInt32        GetTotalOutputChannels() const;
-  UInt32        GetNumChannelsOfStream(UInt32 streamIdx);
+  UInt32        GetNumChannelsOfStream(UInt32 streamIdx) const;
   bool          GetStreams(AudioStreamIdList *pList);
   bool          IsRunning();
   bool          SetHogStatus(bool hog);
@@ -64,7 +64,11 @@ public:
   bool          SetCurrentVolume(Float32 vol);
   bool          GetPreferredChannelLayout(CCoreAudioChannelLayout &layout) const;
   bool          GetPreferredChannelLayoutForStereo(CCoreAudioChannelLayout &layout) const;
-  bool          GetDataSources(CoreAudioDataSourceList *pList);
+  bool          GetDataSources(CoreAudioDataSourceList *pList) const;
+  bool          GetDataSource(UInt32 &dataSourceId) const;
+  bool          SetDataSource(UInt32 &dataSourceId);
+  std::string   GetDataSourceName(UInt32 dataSourceId) const;
+  std::string   GetCurrentDataSourceName() const;
   Float64       GetNominalSampleRate();
   bool          SetNominalSampleRate(Float64 sampleRate);
   UInt32        GetNumLatencyFrames();

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
@@ -142,6 +142,32 @@ bool CCoreAudioStream::IsDigitalOuptut(AudioStreamID id)
           type == kIOAudioDeviceTransportTypeUSB);
 }
 
+bool CCoreAudioStream::GetStartingChannelInDevice(AudioStreamID id, UInt32 &startingChannel)
+{
+  if (!id)
+    return 0;
+  
+  UInt32 i_param_size = sizeof(UInt32);
+  UInt32 i_param;
+  startingChannel = 0;
+  bool ret = false;
+  
+  AudioObjectPropertyAddress propertyAddress; 
+  propertyAddress.mScope    = kAudioObjectPropertyScopeGlobal; 
+  propertyAddress.mElement  = kAudioObjectPropertyElementMaster;
+  propertyAddress.mSelector = kAudioStreamPropertyStartingChannel; 
+  
+  // number of frames of latency in the AudioStream
+  OSStatus status = AudioObjectGetPropertyData(id, &propertyAddress, 0, NULL, &i_param_size, &i_param); 
+  if (status == noErr)
+  {
+    startingChannel = i_param;
+    ret = true;
+  }
+  
+  return ret;
+}
+
 UInt32 CCoreAudioStream::GetTerminalType(AudioStreamID id)
 {
   if (!id)

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.h
@@ -60,6 +60,7 @@ public:
   static bool GetAvailableVirtualFormats(AudioStreamID id, StreamFormatList *pList);
   static bool GetAvailablePhysicalFormats(AudioStreamID id, StreamFormatList *pList);
   static bool IsDigitalOuptut(AudioStreamID id);
+  static bool GetStartingChannelInDevice(AudioStreamID id, UInt32 &startingChannel);
 
 protected:
   static OSStatus HardwareStreamListener(AudioObjectID inObjectID,


### PR DESCRIPTION
This fixes multistream devices like fireface by adding each stream as a single device.
It also addes the audio source names of the devices.
And last but not least it adds a device for each audio source a device has - allowing it for example to choose between multiple AirPlay sinks (instead of just showing "AirPlay" and stream to the sink which is selected by osx). It also allows to select between Builtin Output, Internal Speaker and BuiltIn Output, Headphones if those are plugged in ...

The principle of multistream devices was described here:

http://forum.xbmc.org/showthread.php?tid=195757

This is how the full blown enumeration looks on my test system
System has 3 airplay sources detected in the network
Fireface is an "fake" multistream device which aggregates my internal output and the hdmi
MutliOutput is a mirrored aggregration which puts out to hdmi and internal speaker at the same time (this is a osx feature - nothing to be done for having this work)

Also you see the sources of the other devices (like LG TV or "Internal Speaker").

https://dl.dropboxusercontent.com/u/30371861/enumeration.png

@jmarshallnz - if you want to have anything backported from this - tell me what of it ... :)

Note to myself - the channel map PR needs adaption for working properly with multistream devices ...
