### PR TITLE
settings: a setting should be disabled if its parent setting is disabled

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -149,8 +149,17 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   
 bool CSetting::IsEnabled() const
 {
-  if (m_dependencies.empty())
+  if (m_dependencies.empty() && m_parentSetting.empty())
     return m_enabled;
+
+  // if the setting has a parent setting and that parent setting is disabled
+  // the setting should automatically also be disabled
+  if (!m_parentSetting.empty())
+  {
+    CSetting *parentSetting = m_settingsManager->GetSetting(m_parentSetting);
+    if (parentSetting != NULL && !parentSetting->IsEnabled())
+      return false;
+  }
 
   bool enabled = true;
   for (SettingDependencies::const_iterator depIt = m_dependencies.begin(); depIt != m_dependencies.end(); ++depIt)

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -409,6 +409,7 @@ private:
   bool UpdateSettings(const TiXmlNode *root);
   bool UpdateSetting(const TiXmlNode *node, CSetting *setting, const CSettingUpdate& update);
   void UpdateSettingByDependency(const std::string &settingId, const CSettingDependency &dependency);
+  void UpdateSettingByDependency(const std::string &settingId, SettingDependencyType dependencyType);
 
   typedef enum {
     SettingOptionsFillerTypeNone = 0,
@@ -422,6 +423,7 @@ private:
   typedef struct {
     CSetting *setting;
     SettingDependencyMap dependencies;
+    std::set<std::string> children;
     CallbackSet callbacks;
   } Setting;
 


### PR DESCRIPTION
This adds some logic to the settings system to automatically disable all child settings if the parent setting is disabled. IMO having an enabled child setting if the parent setting is disabled doesn't make much sense and would look odd.
