### PR TITLE
Fix nvidia-settings parser

### DIFF
--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -480,8 +480,8 @@ bool CVideoReferenceClock::ParseNvSettings(int& RefreshRate)
   else if (buffpos > (int)sizeof(Buff) - 1)
   {
     buffpos = sizeof(Buff) - 1;
-    pclose(NvSettings);
   }
+  pclose(NvSettings);
   Buff[buffpos] = 0;
 
   CLog::Log(LOGDEBUG, "CVideoReferenceClock: output of %s: %s", NVSETTINGSCMD, Buff);

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -449,7 +449,7 @@ bool CVideoReferenceClock::ParseNvSettings(int& RefreshRate)
     }
     else if (FD_ISSET(fd, &set))
     {
-      ReturnV = read(fd, Buff + buffpos, (int)sizeof(Buff) - buffpos);
+      ReturnV = read(fd, Buff + buffpos, (int)sizeof(Buff) - buffpos - 1);
       if (ReturnV == -1)
       {
         CLog::Log(LOGDEBUG, "CVideoReferenceClock: read failed on %s: %s", NVSETTINGSCMD, strerror(errno));
@@ -476,10 +476,6 @@ bool CVideoReferenceClock::ParseNvSettings(int& RefreshRate)
     //what should be done instead is fork, call nvidia-settings
     //then kill the process if it hangs
     return false;
-  }
-  else if (buffpos > (int)sizeof(Buff) - 1)
-  {
-    buffpos = sizeof(Buff) - 1;
   }
   pclose(NvSettings);
   Buff[buffpos] = 0;


### PR DESCRIPTION
This is a resubmission of pull req #4430, against Gotham. It avoids leaving nvidia-settings zombies on a refresh rate change, and cleans up some related dead code.
