### PR TITLE
[pvr] add ability to delete a whole recordings folder

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -460,7 +460,7 @@ msgstr ""
 
 #: xbmc/windows/GUIWindowFileManager.cpp
 msgctxt "#122"
-msgid "Confirm file delete?"
+msgid "Confirm delete"
 msgstr ""
 
 #: xbmc/windows/GUIWindowFileManager.cpp
@@ -7847,7 +7847,13 @@ msgctxt "#19111"
 msgid "PVR backend error. Check the log for details."
 msgstr ""
 
-#empty strings from id 19112 to 19113
+msgctxt "#19112"
+msgid "Delete this recording?"
+msgstr ""
+
+msgctxt "#19113"
+msgid "Delete all recordings in this folder?"
+msgstr ""
 
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#19114"

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -233,7 +233,7 @@ void CPVRRecordings::GetSubDirectories(const CStdString &strBase, CFileItemList 
   }
 }
 
-bool CPVRRecordings::HasAllRecordingsPathExtension(const CStdString &strDirectory)
+bool CPVRRecordings::HasAllRecordingsPathExtension(const CStdString &strDirectory) const
 {
   CStdString strUseDir = TrimSlashes(strDirectory);
   CStdString strAllRecordingsPathExtension(PVR_ALL_RECORDINGS_PATH_EXTENSION);
@@ -315,6 +315,32 @@ int CPVRRecordings::GetRecordings(CFileItemList* results)
   }
 
   return m_recordings.size();
+}
+
+bool CPVRRecordings::IsAllRecordingsDirectory(const CFileItem& item) const
+{
+  return HasAllRecordingsPathExtension(item.GetPath());
+}
+
+bool CPVRRecordings::Delete(const CFileItem& item)
+{
+  return item.m_bIsFolder ? DeleteDirectory(item) : DeleteRecording(item);
+}
+
+bool CPVRRecordings::DeleteDirectory(const CFileItem& directory)
+{
+  CFileItemList items;
+  CDirectory::GetDirectory(directory.GetPath(), items);
+
+  bool allDeleted = true;
+
+  VECFILEITEMS itemList = items.GetList();
+  CFileItem item;
+  
+  for (VECFILEITEMS::const_iterator it = itemList.begin(); it != itemList.end(); ++it)
+    allDeleted &= Delete(*(it->get()));
+
+  return allDeleted;
 }
 
 bool CPVRRecordings::DeleteRecording(const CFileItem &item)

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -46,6 +46,14 @@ namespace PVR
 
     CStdString AddAllRecordingsPathExtension(const CStdString &strDirectory);
     CStdString RemoveAllRecordingsPathExtension(const CStdString &strDirectory);
+    
+    /**
+     * @brief recursively deletes all recordings in the specified directory
+     * @param item the directory
+     * @return true if all recordings were deleted
+     */
+    bool DeleteDirectory(const CFileItem &item);
+    bool DeleteRecording(const CFileItem &item);
 
   public:
     CPVRRecordings(void);
@@ -64,16 +72,23 @@ namespace PVR
 
     int GetNumRecordings();
     int GetRecordings(CFileItemList* results);
-    bool DeleteRecording(const CFileItem &item);
+    
+    /**
+     * Deletes the item in question, be it a directory or a file
+     * @param item the item to delete
+     * @return whether the item was deleted successfully
+     */
+    bool Delete(const CFileItem &item);
     bool RenameRecording(CFileItem &item, CStdString &strNewName);
     bool SetRecordingsPlayCount(const CFileItemPtr &item, int count);
 
+    bool IsAllRecordingsDirectory(const CFileItem &item) const;
     bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     CFileItemPtr GetByPath(const CStdString &path);
     void SetPlayCount(const CFileItem &item, int iPlayCount);
     void GetAll(CFileItemList &items);
     CFileItemPtr GetById(unsigned int iId) const;
 
-    bool HasAllRecordingsPathExtension(const CStdString &strDirectory);
+    bool HasAllRecordingsPathExtension(const CStdString &strDirectory) const;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -478,18 +478,20 @@ bool CGUIWindowPVRCommon::ActionDeleteRecording(CFileItem *item)
   CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
   if (!pDialog)
     return bReturn;
-  pDialog->SetHeading(122);
-  pDialog->SetLine(0, 19043);
+  
+  pDialog->SetHeading(122); // Confirm delete
+  pDialog->SetLine(0, item->m_bIsFolder ? 19113 : 19112); // Are you sure?
   pDialog->SetLine(1, "");
-  pDialog->SetLine(2, recTag->m_strTitle);
-  pDialog->DoModal();
+  pDialog->SetLine(2, item->GetLabel());
+  pDialog->SetChoice(1, 117); // Delete
 
   /* prompt for the user's confirmation */
+  pDialog->DoModal();
   if (!pDialog->IsConfirmed())
     return bReturn;
 
   /* delete the recording */
-  if (g_PVRRecordings->DeleteRecording(*item))
+  if (g_PVRRecordings->Delete(*item))
   {
     g_PVRManager.TriggerRecordingsUpdate();
     bReturn = true;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -122,8 +122,12 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
       buttons.Add(CONTEXT_BUTTON_MARK_WATCHED, 16103);   /* Mark as Watched */
 
     buttons.Add(CONTEXT_BUTTON_RENAME, 118);      /* Rename this recording */
-    buttons.Add(CONTEXT_BUTTON_DELETE, 117);      /* Delete this recording */
   }
+  
+  // Add delete button for all items except the All recordings directory
+  if (!g_PVRRecordings->IsAllRecordingsDirectory(*pItem.get()))
+    buttons.Add(CONTEXT_BUTTON_DELETE, 117);
+  
   buttons.Add(CONTEXT_BUTTON_SORTBY_NAME, 103);       /* sort by name */
   buttons.Add(CONTEXT_BUTTON_SORTBY_DATE, 104);       /* sort by date */
 
@@ -289,28 +293,7 @@ bool CGUIWindowPVRRecordings::OnClickList(CGUIMessage &message)
 
 bool CGUIWindowPVRRecordings::OnContextButtonDelete(CFileItem *item, CONTEXT_BUTTON button)
 {
-  bool bReturn = false;
-
-  if (button == CONTEXT_BUTTON_DELETE)
-  {
-    bReturn = false;
-
-    CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-    if (!pDialog)
-      return bReturn;
-    pDialog->SetHeading(122);
-    pDialog->SetLine(0, 19043);
-    pDialog->SetLine(1, "");
-    pDialog->SetLine(2, item->GetPVRRecordingInfoTag()->m_strTitle);
-    pDialog->DoModal();
-
-    if (!pDialog->IsConfirmed())
-      return bReturn;
-
-    bReturn = g_PVRRecordings->DeleteRecording(*item);
-  }
-
-  return bReturn;
+  return button == CONTEXT_BUTTON_DELETE ? ActionDeleteRecording(item) : false;
 }
 
 bool CGUIWindowPVRRecordings::OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON button)


### PR DESCRIPTION
Reference: (http://forum.xbmc.org/showthread.php?tid=195849)

Previously if you wanted to delete all recordings from a folder you had to do it one by one. This adds the Delete context button to directory items too (except to the "All recordings" virtual folder) which recursively deletes everything inside that folder.

ping @xhaggi for review
