### PR TITLE
FIX: [amlcodec] make FF/RWwork

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1858,10 +1858,21 @@ bool CAMLCodec::GetPicture(DVDVideoPicture *pDvdVideoPicture)
   pDvdVideoPicture->iDuration = (double)(am_private->video_rate * DVD_TIME_BASE) / UNIT_FREQ;
 
   pDvdVideoPicture->dts = DVD_NOPTS_VALUE;
-  pDvdVideoPicture->pts = GetPlayerPtsSeconds() * (double)DVD_TIME_BASE;
-  // video pts cannot be late or dvdplayer goes nuts,
-  // so run it one frame ahead
-  pDvdVideoPicture->pts += 1 * pDvdVideoPicture->iDuration;
+  if (m_speed == DVD_PLAYSPEED_NORMAL)
+  {
+    pDvdVideoPicture->pts = GetPlayerPtsSeconds() * (double)DVD_TIME_BASE;
+    // video pts cannot be late or dvdplayer goes nuts,
+    // so run it one frame ahead
+    pDvdVideoPicture->pts += 1 * pDvdVideoPicture->iDuration;
+  }
+  else
+  {
+    // We are FF/RW; Do not use the Player clock or it just doesn't work
+    if (m_cur_pts == 0)
+      pDvdVideoPicture->pts = (double)m_1st_pts / PTS_FREQ * DVD_TIME_BASE;
+    else
+      pDvdVideoPicture->pts = (double)m_cur_pts / PTS_FREQ * DVD_TIME_BASE;
+  }
 
   return true;
 }


### PR DESCRIPTION
If we use the player clock while FF/RW, the player does not detect the difference between its clock and the picture pts and thus doesn't seek properly, leading to trick mode normal speed and no actual FF/RW.

/cc @davilla @t-nelson 
