### PR TITLE
[players] Don't hardcode dvdplayer/paplayer

### DIFF
--- a/system/playercorefactory.xml
+++ b/system/playercorefactory.xml
@@ -11,31 +11,32 @@
   </players>
 
   <rules name="system rules">
-    <rule name="rtv" protocols="rtv" player="DVDPlayer" />
-    <rule name="hdhomerun/myth/mms/udp" protocols="hdhomerun|myth|cmyth|mms|mmsh|udp" player="DVDPlayer" />
-    <rule name="lastfm/shout" protocols="lastfm|shout" player="PAPlayer" />
+    <rule name="rtv" protocols="rtv" player="videodefaultplayer" />
+    <rule name="hdhomerun/myth/mms/udp" protocols="hdhomerun|myth|cmyth|mms|mmsh|udp" player="videodefaultplayer" />
+    <rule name="lastfm/shout" protocols="lastfm|shout" player="audiodefaultplayer" />
     <rule name="rtmp" protocols="rtmp" player="videodefaultplayer" />
 
     <!-- dvdplayer can play standard rtsp streams -->
-    <rule name="rtsp" protocols="rtsp" filetypes="!(rm|ra)"  player="PAPlayer" />
+    <rule name="rtsp" protocols="rtsp" filetypes="!(rm|ra)"  player="audiodefaultplayer" />
 
     <!-- Internet streams -->
     <rule name="streams" internetstream="true">
-      <rule name="aacp/sdp" mimetypes="audio/aacp|application/sdp" player="DVDPlayer" />
-      <rule name="mp2" mimetypes="application/octet-stream" filetypes="mp2" player="PAPlayer" />
+      <rule name="aacp/sdp" mimetypes="audio/aacp|application/sdp" player="videodefaultplayer" />
+      <rule name="mp2" mimetypes="application/octet-stream" filetypes="mp2" player="audiodefaultplayer" />
     </rule>
 
     <!-- DVDs -->
-    <rule name="dvd" dvd="true" player="DVDPlayer" />
-    <rule name="dvdimage" dvdimage="true" player="DVDPlayer" />
+    <rule name="dvd" dvd="true" player="videodefaultdvdplayer" />
+    <rule name="dvdfile" dvdfile="true" player="videodefaultdvdplayer" />
+    <rule name="dvdimage" dvdimage="true" player="videodefaultdvdplayer" />
 
     <!-- Only dvdplayer can handle these normally -->
-    <rule name="sdp/asf" filetypes="sdp|asf" player="DVDPlayer" />
+    <rule name="sdp/asf" filetypes="sdp|asf" player="videodefaultplayer" />
 
     <!-- Pass these to dvdplayer as we do not know if they are audio or video -->
-    <rule name="nsv" filetypes="nsv" player="DVDPlayer" />
+    <rule name="nsv" filetypes="nsv" player="videodefaultplayer" />
 
     <!-- pvr radio channels should be played by dvdplayer because they need buffering -->
-    <rule name="radio" filetypes="pvr" filename=".*/radio/.*" player="DVDPlayer" />
+    <rule name="radio" filetypes="pvr" filename=".*/radio/.*" player="videodefaultplayer" />
   </rules>
 </playercorefactory>

--- a/xbmc/cores/playercorefactory/PlayerCoreConfig.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreConfig.h
@@ -88,14 +88,7 @@ public:
     {
       case EPC_MPLAYER:
       // TODO: this hack needs removal until we have a better player selection
-#if defined(HAS_OMXPLAYER)
-      case EPC_DVDPLAYER: 
-        pPlayer = new COMXPlayer(callback); 
-        CLog::Log(LOGINFO, "Created player %s for core %d / OMXPlayer forced as DVDPlayer", "OMXPlayer", m_eCore);
-        break;
-#else
       case EPC_DVDPLAYER: pPlayer = new CDVDPlayer(callback); break;
-#endif
       case EPC_PAPLAYER: pPlayer = new PAPlayer(callback); break;
       case EPC_EXTPLAYER: pPlayer = new CExternalPlayer(callback); break;
 #if defined(HAS_OMXPLAYER)

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -530,7 +530,11 @@ namespace XBMCAddon
     int getPLAYLIST_MUSIC() { return PLAYLIST_MUSIC; }
     int getPLAYLIST_VIDEO() { return PLAYLIST_VIDEO; }
     int getPLAYER_CORE_AUTO() { return EPC_NONE; }
+#ifdef TARGET_RASPBERRY_PI
+    int getPLAYER_CORE_DVDPLAYER() { return EPC_OMXPLAYER; }
+#else
     int getPLAYER_CORE_DVDPLAYER() { return EPC_DVDPLAYER; }
+#endif
     int getPLAYER_CORE_MPLAYER() { return EPC_MPLAYER; }
     int getPLAYER_CORE_PAPLAYER() { return EPC_PAPLAYER; }
     int getTRAY_OPEN() { return TRAY_OPEN; }

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -906,9 +906,11 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       CFileItem fileToPlay(location, false);
       fileToPlay.SetProperty("StartPercent", position*100.0f);
       ServerInstance->AnnounceToClients(EVENT_LOADING);
+#ifndef TARGET_RASPBERRY_PI
       // froce to internal dvdplayer cause it is the only
       // one who will work well with airplay
       g_application.m_eForcedNextPlayer = EPC_DVDPLAYER;
+#endif
       CApplicationMessenger::Get().MediaPlay(fileToPlay);
     }
   }


### PR DESCRIPTION
Currently playercorefactory wrongly maps various stream types to dvdplayer or paplayer.
It should be using videodefaultplayer/audiodefaultplayer.

Because of this we have pretended omxplayer was dvdplayer to avoid unwantedly using dvdplayer in these cases.

But, (optionally) using dvdplayer can be useful on the Pi. We can actually play sd (up to 640x480 MPEG-4 video) video in real time. This is useful for codec variants like DivX3, msmpeg and sorenson spark which we don't currently play with omxplayer.

Unfortunately there are many video add-ons that explicitly request dvdplayer, so there is still a hack to map that to omxplayer on Pi.

These patches are used in Gotham openelec on Pi, and appear to do the right thing.
