### PR TITLE
[pvr] unify channel settings with other video items

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4378,26 +4378,20 @@ void CApplication::SaveFileState(bool bForeground /* = false */)
   if (m_progressTrackingItem->IsPVRChannel() || !CProfilesManager::Get().GetCurrentProfile().canWriteDatabases())
     return;
 
+  CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
+      *m_stackFileItemToUpdate,
+      m_progressTrackingVideoResumeBookmark,
+      m_progressTrackingPlayCountUpdate,
+      CMediaSettings::Get().GetCurrentVideoSettings());
+  
   if (bForeground)
   {
-    CSaveFileStateJob job(*m_progressTrackingItem,
-    *m_stackFileItemToUpdate,
-    m_progressTrackingVideoResumeBookmark,
-    m_progressTrackingPlayCountUpdate,
-    CMediaSettings::Get().GetCurrentVideoSettings());
-
     // Run job in the foreground to make sure it finishes
-    job.DoWork();
+    job->DoWork();
+    delete job;
   }
   else
-  {
-    CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
-        *m_stackFileItemToUpdate,
-        m_progressTrackingVideoResumeBookmark,
-        m_progressTrackingPlayCountUpdate,
-        CMediaSettings::Get().GetCurrentVideoSettings());
     CJobManager::GetInstance().AddJob(job, NULL, CJob::PRIORITY_NORMAL);
-  }
 }
 
 void CApplication::UpdateFileState()

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4375,7 +4375,7 @@ bool CApplication::IsFullScreen()
 
 void CApplication::SaveFileState(bool bForeground /* = false */)
 {
-  if (m_progressTrackingItem->IsPVRChannel() || !CProfilesManager::Get().GetCurrentProfile().canWriteDatabases())
+  if (!CProfilesManager::Get().GetCurrentProfile().canWriteDatabases())
     return;
 
   CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4383,7 +4383,8 @@ void CApplication::SaveFileState(bool bForeground /* = false */)
     CSaveFileStateJob job(*m_progressTrackingItem,
     *m_stackFileItemToUpdate,
     m_progressTrackingVideoResumeBookmark,
-    m_progressTrackingPlayCountUpdate);
+    m_progressTrackingPlayCountUpdate,
+    CMediaSettings::Get().GetCurrentVideoSettings());
 
     // Run job in the foreground to make sure it finishes
     job.DoWork();
@@ -4393,7 +4394,8 @@ void CApplication::SaveFileState(bool bForeground /* = false */)
     CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
         *m_stackFileItemToUpdate,
         m_progressTrackingVideoResumeBookmark,
-        m_progressTrackingPlayCountUpdate);
+        m_progressTrackingPlayCountUpdate,
+        CMediaSettings::Get().GetCurrentVideoSettings());
     CJobManager::GetInstance().AddJob(job, NULL, CJob::PRIORITY_NORMAL);
   }
 }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3864,7 +3864,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
 
   if (!bRestart)
   {
-    SaveCurrentFileSettings();
+    SaveFileState(true);
 
     OutputDebugString("new file set audiostream:0\n");
     // Switch to default options
@@ -5746,26 +5746,6 @@ bool CApplication::ProcessAndStartPlaylist(const CStdString& strPlayList, CPlayL
     return true;
   }
   return false;
-}
-
-void CApplication::SaveCurrentFileSettings()
-{
-  // don't store settings for PVR in video database
-  if (m_itemCurrentFile->IsVideo() && !m_itemCurrentFile->IsPVRChannel())
-  {
-    // save video settings
-    if (CMediaSettings::Get().GetCurrentVideoSettings() != CMediaSettings::Get().GetDefaultVideoSettings())
-    {
-      CVideoDatabase dbs;
-      dbs.Open();
-      dbs.SetVideoSettings(m_itemCurrentFile->GetPath(), CMediaSettings::Get().GetCurrentVideoSettings());
-      dbs.Close();
-    }
-  }
-  else if (m_itemCurrentFile->IsPVRChannel())
-  {
-    g_PVRManager.SaveCurrentChannelSettings();
-  }
 }
 
 bool CApplication::AlwaysProcess(const CAction& action)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4495,9 +4495,6 @@ void CApplication::StopPlaying()
       m_pKaraokeMgr->Stop();
 #endif
 
-    if (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio())
-      g_PVRManager.SaveCurrentChannelSettings();
-
     m_pPlayer->CloseFile();
 
     // turn off visualisation window when stopping

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -450,8 +450,6 @@ protected:
   float NavigationIdleTime();
   static bool AlwaysProcess(const CAction& action);
 
-  void SaveCurrentFileSettings();
-
   bool InitDirectoriesLinux();
   bool InitDirectoriesOSX();
   bool InitDirectoriesWin32();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -174,6 +174,7 @@ public:
   PlayBackRet PlayFile(const CFileItem& item, bool bRestart = false);
   void SaveFileState(bool bForeground = false);
   void UpdateFileState();
+  void LoadVideoSettings(const std::string &path);
   void StopPlaying();
   void Restart(bool bSamePosition = true);
   void DelayedPlayerRestart();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1550,10 +1550,6 @@ void CDVDPlayer::HandlePlaySpeed()
           bGotAudio, m_dvdPlayerAudio.GetLevel(),
           bGotVideo, m_dvdPlayerVideo.GetLevel());
 
-      CFileItem currentItem(g_application.CurrentFileItem());
-      if (currentItem.HasPVRChannelInfoTag())
-        g_PVRManager.LoadCurrentChannelSettings();
-
       caching = CACHESTATE_DONE;
     }
     else

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -1814,10 +1814,6 @@ void COMXPlayer::HandlePlaySpeed()
           bGotAudio, m_omxPlayerAudio.GetLevel(),
           bGotVideo, m_omxPlayerVideo.GetLevel());
 
-      CFileItem currentItem(g_application.CurrentFileItem());
-      if (currentItem.HasPVRChannelInfoTag())
-        g_PVRManager.LoadCurrentChannelSettings();
-
       caching = CACHESTATE_DONE;
     }
     else

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -59,7 +59,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetSchemaVersion() const { return 24; };
+    virtual int GetSchemaVersion() const { return 25; };
 
     /*!
      * @brief Get the default sqlite database filename.
@@ -104,39 +104,6 @@ namespace PVR
      * @return The amount of channels that were added.
      */
     int Get(CPVRChannelGroupInternal &results);
-
-    //@}
-
-    /*! @name Channel settings methods */
-    //@{
-
-    /*!
-     * @brief Remove all channel settings from the database.
-     * @return True if all channels were removed successfully, false if not.
-     */
-    bool DeleteChannelSettings();
-
-    /*!
-     * @brief Remove channel settings from the database.
-     * @return True if channel were removed successfully, false if not.
-     */
-    bool DeleteChannelSettings(const CPVRChannel &channel);
-
-    /*!
-     * @brief Get the channel settings from the database.
-     * @param channel The channel to get the settings for.
-     * @param settings Store the settings in here.
-     * @return True if the settings were fetched successfully, false if not.
-     */
-    bool GetChannelSettings(const CPVRChannel &channel, CVideoSettings &settings);
-
-    /*!
-     * @brief Store channel settings in the database.
-     * @param channel The channel to store the settings for.
-     * @param settings The settings to store.
-     * @return True if the settings were stored successfully, false if not.
-     */
-    bool PersistChannelSettings(const CPVRChannel &channel, const CVideoSettings &settings);
 
     //@}
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -59,6 +59,10 @@
 #include "guilib/Key.h"
 #include "dialogs/GUIDialogPVRChannelManager.h"
 
+#ifdef HAS_VIDEO_PLAYBACK
+#include "cores/VideoRenderers/RenderManager.h"
+#endif
+
 using namespace std;
 using namespace MUSIC_INFO;
 using namespace PVR;
@@ -1056,6 +1060,9 @@ void CPVRManager::CloseStream(void)
       m_channelGroups->SetLastPlayedGroup(group);
 
       bPersistChanges = true;
+      
+      // store channel settings
+      g_application.SaveFileState();
     }
 
     m_addons->CloseStream();
@@ -1265,9 +1272,6 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
     m_channelGroups->SetLastPlayedGroup(GetPlayingGroup(currentChannel->IsRadio()));
   }
 
-  // store channel settings
-  SaveCurrentChannelSettings();
-
   // will be deleted by CPVRChannelSwitchJob::DoWork()
   CFileItem* previousFile = m_currentFile;
   m_currentFile = NULL;
@@ -1293,6 +1297,13 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
     // switch successful
     bSwitched = true;
 
+    // save previous and load new channel's settings
+    g_application.SaveFileState();
+    g_application.LoadVideoSettings(channel.Path());
+    
+    // reload the render manager so view mode gets changed
+    g_renderManager.PreInit();
+    
     CSingleLock lock(m_critSection);
     m_currentFile = new CFileItem(channel);
     m_bIsSwitchingChannels = false;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -43,6 +43,7 @@
 #include "windows/GUIWindowPVRCommon.h"
 #include "utils/JobManager.h"
 #include "interfaces/AnnouncementManager.h"
+#include "video/VideoDatabase.h"
 
 #include "PVRManager.h"
 #include "PVRDatabase.h"
@@ -733,8 +734,16 @@ void CPVRManager::ResetDatabase(bool bResetEPGOnly /* = false */)
       pDlgProgress->SetPercentage(70);
       pDlgProgress->Progress();
 
-      /* delete all channel settings */
-      m_database->DeleteChannelSettings();
+      /* delete all channel and recording settings */
+      CVideoDatabase videoDatabase;
+
+      if (videoDatabase.Open())
+      {
+        videoDatabase.EraseVideoSettings("pvr://channels/");
+        videoDatabase.EraseVideoSettings("pvr://recordings/");
+        videoDatabase.Close();
+      }
+      
       pDlgProgress->SetPercentage(80);
       pDlgProgress->Progress();
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -923,16 +923,6 @@ bool CPVRManager::CheckParentalPIN(const char *strTitle /* = NULL */)
   return bValidPIN;
 }
 
-void CPVRManager::SaveCurrentChannelSettings(void)
-{
-  m_addons->SaveCurrentChannelSettings();
-}
-
-void CPVRManager::LoadCurrentChannelSettings()
-{
-  m_addons->LoadCurrentChannelSettings();
-}
-
 void CPVRManager::SetPlayingGroup(CPVRChannelGroupPtr group)
 {
   if (m_channelGroups && group)
@@ -971,12 +961,6 @@ bool CPVRChannelsUpdateJob::DoWork(void)
 bool CPVRChannelGroupsUpdateJob::DoWork(void)
 {
   return g_PVRChannelGroups->Update(false);
-}
-
-bool CPVRChannelSettingsSaveJob::DoWork(void)
-{
-  g_PVRManager.SaveCurrentChannelSettings();
-  return true;
 }
 
 bool CPVRManager::OpenLiveStream(const CFileItem &channel)
@@ -1497,11 +1481,6 @@ void CPVRManager::TriggerChannelsUpdate(void)
 void CPVRManager::TriggerChannelGroupsUpdate(void)
 {
   QueueJob(new CPVRChannelGroupsUpdateJob());
-}
-
-void CPVRManager::TriggerSaveChannelSettings(void)
-{
-  QueueJob(new CPVRChannelSettingsSaveJob());
 }
 
 void CPVRManager::TriggerSearchMissingChannelIcons(void)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -392,11 +392,6 @@ namespace PVR
     void TriggerChannelGroupsUpdate(void);
 
     /*!
-     * @brief Let the background thread save the current video settings.
-     */
-    void TriggerSaveChannelSettings(void);
-
-    /*!
      * @brief Let the background thread search for missing channel icons.
      */
     void TriggerSearchMissingChannelIcons(void);
@@ -504,16 +499,6 @@ namespace PVR
     void SearchMissingChannelIcons(void);
 
     /*!
-     * @brief Persist the current channel settings in the database.
-     */
-    void SaveCurrentChannelSettings(void);
-
-    /*!
-     * @brief Load the settings for the current channel from the database.
-     */
-    void LoadCurrentChannelSettings(void);
-
-    /*!
      * @brief Check if channel is parental locked. Ask for PIN if neccessary.
      * @param channel The channel to open.
      * @return True if channel is unlocked (by default or PIN unlocked), false otherwise.
@@ -571,7 +556,7 @@ namespace PVR
      * @return If at least one client and all pvr data was loaded, false otherwise.
      */
     bool Load(void);
-
+    
     /*!
      * @brief Update all recordings.
      */
@@ -724,16 +709,6 @@ namespace PVR
     virtual const char *GetType() const { return "pvr-update-channelgroups"; }
 
     virtual bool DoWork();
-  };
-
-  class CPVRChannelSettingsSaveJob : public CJob
-  {
-  public:
-    CPVRChannelSettingsSaveJob(void) {}
-    virtual ~CPVRChannelSettingsSaveJob() {}
-    virtual const char *GetType() const { return "pvr-save-channelsettings"; }
-
-    bool DoWork();
   };
 
   class CPVRChannelSwitchJob : public CJob

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -28,18 +28,12 @@
 #include "pvr/PVRManager.h"
 #include "pvr/PVRDatabase.h"
 #include "guilib/GUIWindowManager.h"
-#include "settings/DisplaySettings.h"
-#include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
 #include "cores/IPlayer.h"
-
-#ifdef HAS_VIDEO_PLAYBACK
-#include "cores/VideoRenderers/RenderManager.h"
-#endif
 
 using namespace std;
 using namespace ADDON;
@@ -50,7 +44,6 @@ CPVRClients::CPVRClients(void) :
     CThread("PVRClient"),
     m_bChannelScanRunning(false),
     m_bIsSwitchingChannels(false),
-    m_bIsValidChannelSettings(false),
     m_playingClientId(-EINVAL),
     m_bIsPlayingLiveTV(false),
     m_bIsPlayingRecording(false),
@@ -339,8 +332,6 @@ bool CPVRClients::SwitchChannel(const CPVRChannel &channel)
   {
     CSingleLock lock(m_critSection);
     m_bIsSwitchingChannels = false;
-    if (bSwitchSuccessful)
-      m_bIsValidChannelSettings = false;
   }
 
   if (!bSwitchSuccessful)
@@ -1034,78 +1025,6 @@ void CPVRClients::ShowDialogNoClientsEnabled(void)
   params.push_back("addons://disabled/xbmc.pvrclient");
   params.push_back("return");
   g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
-}
-
-void CPVRClients::SaveCurrentChannelSettings(void)
-{
-  CPVRChannelPtr channel;
-  {
-    CSingleLock lock(m_critSection);
-    if (!GetPlayingChannel(channel) || !m_bIsValidChannelSettings)
-      return;
-  }
-
-  CPVRDatabase *database = GetPVRDatabase();
-  if (!database)
-    return;
-
-  if (CMediaSettings::Get().GetCurrentVideoSettings() != CMediaSettings::Get().GetDefaultVideoSettings())
-  {
-    CLog::Log(LOGDEBUG, "PVR - %s - persisting custom channel settings for channel '%s'",
-        __FUNCTION__, channel->ChannelName().c_str());
-    database->PersistChannelSettings(*channel, CMediaSettings::Get().GetCurrentVideoSettings());
-  }
-  else
-  {
-    CLog::Log(LOGDEBUG, "PVR - %s - no custom channel settings for channel '%s'",
-        __FUNCTION__, channel->ChannelName().c_str());
-    database->DeleteChannelSettings(*channel);
-  }
-}
-
-void CPVRClients::LoadCurrentChannelSettings(void)
-{
-  CPVRChannelPtr channel;
-  {
-    CSingleLock lock(m_critSection);
-    if (!GetPlayingChannel(channel))
-      return;
-  }
-
-  CPVRDatabase *database = GetPVRDatabase();
-  if (!database)
-    return;
-
-  if (g_application.m_pPlayer->HasPlayer())
-  {
-    /* store the current settings so we can compare if anything has changed */
-    CVideoSettings previousSettings = CMediaSettings::Get().GetCurrentVideoSettings();
-
-    /* load the persisted channel settings and set them as current */
-    CVideoSettings loadedChannelSettings = CMediaSettings::Get().GetDefaultVideoSettings();
-    database->GetChannelSettings(*channel, loadedChannelSettings);
-    CMediaSettings::Get().GetCurrentVideoSettings() = loadedChannelSettings;
-
-    /* update the view mode if it set to custom or differs from the previous mode */
-    if (previousSettings.m_ViewMode != loadedChannelSettings.m_ViewMode || loadedChannelSettings.m_ViewMode == ViewModeCustom)
-      g_renderManager.SetViewMode(loadedChannelSettings.m_ViewMode);
-
-    /* only change the subtitle stream, if it's different */
-    if (previousSettings.m_SubtitleStream != loadedChannelSettings.m_SubtitleStream)
-      g_application.m_pPlayer->SetSubtitle(loadedChannelSettings.m_SubtitleStream);
-
-    /* only change the audio stream if it's different */
-    if (g_application.m_pPlayer->GetAudioStream() != loadedChannelSettings.m_AudioStream && loadedChannelSettings.m_AudioStream >= 0)
-      g_application.m_pPlayer->SetAudioStream(loadedChannelSettings.m_AudioStream);
-
-    g_application.m_pPlayer->SetAVDelay(loadedChannelSettings.m_AudioDelay);
-    g_application.m_pPlayer->SetDynamicRangeCompression((long)(loadedChannelSettings.m_VolumeAmplification * 100));
-    g_application.m_pPlayer->SetSubtitleVisible(loadedChannelSettings.m_SubtitleOn);
-    g_application.m_pPlayer->SetSubTitleDelay(loadedChannelSettings.m_SubtitleDelay);
-
-    /* settings can be saved on next channel switch */
-    m_bIsValidChannelSettings = true;
-  }
 }
 
 bool CPVRClients::UpdateAddons(void)

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -72,16 +72,6 @@ namespace PVR
      */
     void Stop(void);
 
-    /*!
-     * @brief Load the settings for the current channel from the database.
-     */
-    void LoadCurrentChannelSettings(void);
-
-    /*!
-     * @brief Persist the current channel settings in the database.
-     */
-    void SaveCurrentChannelSettings(void);
-
     /*! @name Backend methods */
     //@{
 
@@ -633,7 +623,6 @@ namespace PVR
 
     bool                  m_bChannelScanRunning;      /*!< true when a channel scan is currently running, false otherwise */
     bool                  m_bIsSwitchingChannels;        /*!< true while switching channels */
-    bool                  m_bIsValidChannelSettings;  /*!< true if current channel settings are valid and can be saved */
     int                   m_playingClientId;          /*!< the ID of the client that is currently playing */
     bool                  m_bIsPlayingLiveTV;
     bool                  m_bIsPlayingRecording;

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -124,9 +124,9 @@ bool CSaveFileStateJob::DoWork()
           }
         }
 
-        if (CMediaSettings::Get().GetCurrentVideoSettings() != CMediaSettings::Get().GetDefaultVideoSettings())
+        if (m_videoSettings != CMediaSettings::Get().GetDefaultVideoSettings())
         {
-          videodatabase.SetVideoSettings(progressTrackingFile, CMediaSettings::Get().GetCurrentVideoSettings());
+          videodatabase.SetVideoSettings(progressTrackingFile, m_videoSettings);
         }
 
         if (m_item.HasVideoInfoTag() && m_item.GetVideoInfoTag()->HasStreamDetails())

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -23,6 +23,7 @@
 #include "Job.h"
 #include "FileItem.h"
 #include "video/Bookmark.h"
+#include "settings/VideoSettings.h"
 
 class CSaveFileStateJob : public CJob
 {
@@ -30,15 +31,18 @@ class CSaveFileStateJob : public CJob
   CFileItem m_item_discstack;
   CBookmark m_bookmark;
   bool      m_updatePlayCount;
+  CVideoSettings m_videoSettings;
 public:
                 CSaveFileStateJob(const CFileItem& item,
                                   const CFileItem& item_discstack,
                                   const CBookmark& bookmark,
-                                  bool updatePlayCount)
+                                  bool updatePlayCount,
+                                  const CVideoSettings &videoSettings)
                   : m_item(item),
                     m_item_discstack(item_discstack),
                     m_bookmark(bookmark),
-                    m_updatePlayCount(updatePlayCount) {}
+                    m_updatePlayCount(updatePlayCount),
+                    m_videoSettings(videoSettings) {}
   virtual       ~CSaveFileStateJob() {}
   virtual bool  DoWork();
 };

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -504,7 +504,13 @@ public:
   // per-file video settings
   bool GetVideoSettings(const CStdString &strFilenameAndPath, CVideoSettings &settings);
   void SetVideoSettings(const CStdString &strFilenameAndPath, const CVideoSettings &settings);
-  void EraseVideoSettings();
+  
+  /**
+   * Erases settings for all files beginning with the specified path. Defaults 
+   * to an empty path, meaning all settings will be erased.
+   * @param path partial path, e.g. pvr://channels
+   */
+  void EraseVideoSettings(const std::string &path = "");
 
   bool GetStackTimes(const CStdString &filePath, std::vector<int> &times);
   void SetStackTimes(const CStdString &filePath, std::vector<int> &times);

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -31,7 +31,6 @@
 #include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "profiles/ProfilesManager.h"
-#include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -59,7 +58,6 @@
 #define SETTING_AUDIO_MAKE_DEFAULT             "audio.makedefault"
 
 using namespace std;
-using namespace PVR;
 
 CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_OSD_SETTINGS, "VideoOSDSettings.xml"),
@@ -186,9 +184,6 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(const CSetting *setting)
     m_subtitleStream = videoSettings.m_SubtitleStream = static_cast<const CSettingInt*>(setting)->GetValue();
     g_application.m_pPlayer->SetSubtitle(m_subtitleStream);
   }
-
-  if (g_PVRManager.IsPlayingRadio() || g_PVRManager.IsPlayingTV())
-    g_PVRManager.TriggerSaveChannelSettings();
 }
 
 void CGUIDialogAudioSubtitleSettings::OnSettingAction(const CSetting *setting)

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -29,7 +29,6 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "profiles/ProfilesManager.h"
-#include "pvr/PVRManager.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
@@ -62,7 +61,6 @@
 #define SETTING_VIDEO_CALIBRATION         "video.calibration"
 
 using namespace std;
-using namespace PVR;
 
 CGUIDialogVideoSettings::CGUIDialogVideoSettings()
     : CGUIDialogSettingsManualBase(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "VideoOSDSettings.xml"),
@@ -145,9 +143,6 @@ void CGUIDialogVideoSettings::OnSettingChanged(const CSetting *setting)
     videoSettings.m_StereoMode = static_cast<const CSettingInt*>(setting)->GetValue();
   else if (settingId == SETTING_VIDEO_STEREOSCOPICINVERT)
     videoSettings.m_StereoInvert = static_cast<const CSettingBool*>(setting)->GetValue();
-
-  if (g_PVRManager.IsPlayingRadio() || g_PVRManager.IsPlayingTV())
-    g_PVRManager.TriggerSaveChannelSettings();
 }
 
 void CGUIDialogVideoSettings::OnSettingAction(const CSetting *setting)


### PR DESCRIPTION
Replaces https://github.com/xbmc/xbmc/pull/4333

At the moment the video settings for live TV channels are stored and handled completely separate from all other video items. I don't know why this has been done like this to begin with but it's been causing various issues ever since PVR support was integrated in Frodo. This changes that.

Settings are now saved through the same routines used by other video items. The only difference in logic is that settings are not saved in UpdatePlayState() but instead in PerformChannelSwitch(). This is required since a channel switch is not the same as a file opening and closing so it requires some special treatment.

Since this moves settings handling away from the player completely it'll all work even when `<cacheindvdplayer>` is disabled.

@xhaggi @opdenkamp @FernetMenta can you review?
