### PR TITLE
Use pass by ref to construct DVDMsgType

### DIFF
--- a/xbmc/cores/dvdplayer/DVDMessage.h
+++ b/xbmc/cores/dvdplayer/DVDMessage.h
@@ -172,7 +172,7 @@ template <typename T>
 class CDVDMsgType : public CDVDMsg
 {
 public:
-  CDVDMsgType(Message type, T value)
+  CDVDMsgType(Message type, const T &value)
     : CDVDMsg(type)
     , m_value(value)
   {}


### PR DESCRIPTION
This saves doing an extra copy for each call to the constructor, the worst one probably being the PVR channel changes at 168 bytes each.
