### PR TITLE
[PyDocs] Additional Info for getPlayingFile and RenderCapture

### DIFF
--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -219,10 +219,10 @@ namespace XBMCAddon
       bool isPlayingVideo();
 
       /**
-       * getPlayingFile() -- returns the current playing file as a string.
-       * Note: For LiveTV, returns a pvr:// url which is not translatable to an OS specific file or external url
-       * 
-       * Throws: Exception, if player is not playing a file.
+       * getPlayingFile() -- returns the current playing file as a string.\n
+       * Note: For LiveTV, returns a pvr:// url which is not translatable to an OS specific file or external url\n
+       * \n
+       * Throws: Exception, if player is not playing a file.\n
        */
       // Player_GetPlayingFile
       String getPlayingFile() throw (PlayerException);

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -220,6 +220,7 @@ namespace XBMCAddon
 
       /**
        * getPlayingFile() -- returns the current playing file as a string.
+       * Note: For LiveTV, returns a pvr:// url which is not translatable to an OS specific file or external url
        * 
        * Throws: Exception, if player is not playing a file.
        */

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -41,14 +41,14 @@ namespace XBMCAddon
       inline virtual ~RenderCapture() { g_renderManager.ReleaseRenderCapture(m_capture); }
 
       /**
-       * getWidth() -- returns width of captured image as set during
-       *     RenderCapture.capture(). Returns 0 prior to calling capture.
+       * getWidth() -- returns width of captured image as set during\n
+       *     RenderCapture.capture(). Returns 0 prior to calling capture.\n
        */
       inline int getWidth() { return m_capture->GetWidth(); }
 
       /**
-       * getHeight() -- returns height of captured image as set during
-       *     RenderCapture.capture(). Returns 0 prior to calling capture.
+       * getHeight() -- returns height of captured image as set during\n
+       *     RenderCapture.capture(). Returns 0 prior to calling capture.\n
        */
       inline int getHeight() { return m_capture->GetHeight(); }
 
@@ -63,8 +63,8 @@ namespace XBMCAddon
       inline int getCaptureState() { return m_capture->GetUserState(); }
 
       /**
-       * getAspectRatio() -- returns aspect ratio of currently displayed video.
-       *     This may be called prior to calling RenderCapture.capture().
+       * getAspectRatio() -- returns aspect ratio of currently displayed video.\n
+       *     This may be called prior to calling RenderCapture.capture().\n
        */
       inline float getAspectRatio() { return g_renderManager.GetAspectRatio(); }
 

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -41,12 +41,14 @@ namespace XBMCAddon
       inline virtual ~RenderCapture() { g_renderManager.ReleaseRenderCapture(m_capture); }
 
       /**
-       * getWidth() -- returns width of captured image.
+       * getWidth() -- returns width of captured image as set during
+       *     RenderCapture.capture(). Returns 0 prior to calling capture.
        */
       inline int getWidth() { return m_capture->GetWidth(); }
 
       /**
-       * getHeight() -- returns height of captured image.
+       * getHeight() -- returns height of captured image as set during
+       *     RenderCapture.capture(). Returns 0 prior to calling capture.
        */
       inline int getHeight() { return m_capture->GetHeight(); }
 
@@ -62,6 +64,7 @@ namespace XBMCAddon
 
       /**
        * getAspectRatio() -- returns aspect ratio of currently displayed video.
+       *     This may be called prior to calling RenderCapture.capture().
        */
       inline float getAspectRatio() { return g_renderManager.GetAspectRatio(); }
 


### PR DESCRIPTION
1) Added information in comments to be pulled into PyDocs describing the shortcomings when calling xbmc.player.getPlayingFile() for LiveTV. Specifically that pvr:// url's are not translated into usable filenames or streams.
2) Added information to xbmc.CapturePlayer regarding the functions getHeight() and getWidth() which return 0 prior to calling CapturePlayer.capture(). Also added that getAspectRatio() may be called prior to issuing a capture() request.
