### PR TITLE
[Pydocs] Add info for Player and RenderCapture

### DIFF
--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -219,9 +219,10 @@ namespace XBMCAddon
       bool isPlayingVideo();
 
       /**
-       * getPlayingFile() -- returns the current playing file as a string.
-       * 
-       * Throws: Exception, if player is not playing a file.
+       * getPlayingFile() -- returns the current playing file as a string.\n
+       * Note: For LiveTV, returns a pvr:// url which is not translatable to an OS specific file or external url\n
+       * \n
+       * Throws: Exception, if player is not playing a file.\n
        */
       // Player_GetPlayingFile
       String getPlayingFile() throw (PlayerException);

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -41,12 +41,14 @@ namespace XBMCAddon
       inline virtual ~RenderCapture() { g_renderManager.ReleaseRenderCapture(m_capture); }
 
       /**
-       * getWidth() -- returns width of captured image.
+       * getWidth() -- returns width of captured image as set during\n
+       *     RenderCapture.capture(). Returns 0 prior to calling capture.\n
        */
       inline int getWidth() { return m_capture->GetWidth(); }
 
       /**
-       * getHeight() -- returns height of captured image.
+       * getHeight() -- returns height of captured image as set during\n
+       *     RenderCapture.capture(). Returns 0 prior to calling capture.\n
        */
       inline int getHeight() { return m_capture->GetHeight(); }
 
@@ -61,7 +63,8 @@ namespace XBMCAddon
       inline int getCaptureState() { return m_capture->GetUserState(); }
 
       /**
-       * getAspectRatio() -- returns aspect ratio of currently displayed video.
+       * getAspectRatio() -- returns aspect ratio of currently displayed video.\n
+       *     This may be called prior to calling RenderCapture.capture().\n
        */
       inline float getAspectRatio() { return g_renderManager.GetAspectRatio(); }
 


### PR DESCRIPTION
1) Added information in comments to be pulled into PyDocs describing the
shortcomings when calling xbmc.player.getPlayingFile() for LiveTV.
Specifically that pvr:// url's are not translated into usable filenames
or streams.
2) Added information to xbmc.CapturePlayer regarding the functions
getHeight() and getWidth() which return 0 prior to calling
CapturePlayer.capture(). Also added that getAspectRatio() may be called
prior to issuing a capture() request.
