### PR TITLE
Incompatible with Curl NSS backend

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -394,7 +394,7 @@ CCurlFile::CCurlFile()
   m_username = "";
   m_password = "";
   m_httpauth = "";
-  m_cipherlist = "DEFAULT";
+  m_cipherlist = "";
   m_proxytype = PROXY_HTTP;
   m_state = new CReadState();
   m_oldState = NULL;
@@ -608,7 +608,8 @@ void CCurlFile::SetCommonOptions(CReadState* state)
     g_curlInterface.easy_setopt(h, CURLOPT_IGNORE_CONTENT_LENGTH, 1);
 
   // Setup allowed TLS/SSL ciphers. New versions of cURL may deprecate things that are still in use.
-  g_curlInterface.easy_setopt(h, CURLOPT_SSL_CIPHER_LIST, m_cipherlist.c_str());
+  if (!m_cipherlist.empty())
+    g_curlInterface.easy_setopt(h, CURLOPT_SSL_CIPHER_LIST, m_cipherlist.c_str());
 }
 
 void CCurlFile::SetRequestHeaders(CReadState* state)


### PR DESCRIPTION
Curl can use NSS as the crypto backend. Unfortunately xbmc hard codes a default cipher list string that is only compatible with OpenSSL and GnuTLS. As there is no common default, we should simply avoid touching the cipher list except when we want something explicit.

Red Hat uses Curl with NSS, so this affects quite a few users.

Branch is against Gotham, not master.
