### PR TITLE
videodb: fixes for support of temporarily offline sources during library cleaning

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8211,6 +8211,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
       }
 
       parentPathsDeleteDecisions.insert(make_pair(parentPathID, make_pair(parentPathNotExists, del)));
+      pathsDeleteDecisions.insert(make_pair(parentPathID, parentPathNotExists && del));
     }
     // the only reason not to delete the file is if the parent path doesn't
     // exist and the user decided to delete all the items it contained

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -565,6 +565,9 @@ public:
    */
   bool GetSubPaths(const CStdString& basepath, std::vector< std::pair<int, std::string> >& subpaths);
 
+  bool GetSourcePath(const std::string &path, std::string &sourcePath);
+  bool GetSourcePath(const std::string &path, std::string &sourcePath, VIDEO::SScanSettings& settings);
+
   // for music + musicvideo linkups - if no album and title given it will return the artist id, else the id of the matching video
   int GetMatchingMusicVideo(const CStdString& strArtist, const CStdString& strAlbum = "", const CStdString& strTitle = "");
 


### PR DESCRIPTION
After the release of Gotham it has been brought to my attention that there are (at least) two issues with the new logic to not remove items belonging to a temporarily offline source during video library cleaning:
- if a source is temporarily offline and the user chooses not to remove the items from that source (which is also the silent default behaviour when using "clean on update") we would still delete the entry of the source from the path table which results in the source being completely unset in XBMC i.e. the user has to re-assign the media type and the scraper.
- if the folder structure/hierarchy of a movie source contains multiple levels like movies/action/James Bond/Skyfall/Skyfall.mkv (i.e. not just movies/Skyfall/Skyfall.mkv) the current logic uses its parent path (in this example /movies/action/James Bond/) and handles it as if it was the source path which is obviously wrong. I wrote this code under the invalid assumption that the parent path ID stored for movies etc. is the path ID of the source path but it instead is the path ID of the parent path. Therefore we need to find the source path of the missing path (which is done with the new method CVideoDatabase::GetSourcePath()) and use that to check if the whole source is gone or not.

The first commit fixing the first issue should IMO be backported to Gotham if there's another fix release as unsetting a source will result in the library update not picking up any new items once the source is online again.

I'm not 100% sure about backporting the second and third commit fixing the second issue. The issue only results in some additional popup dialogs being thrown in the users face during library cleaning (which is annoying but pretty obvious) so it doesn't really break anything (except usability a bit).

@jmarshallnz for review.
