### PR TITLE
Exynos v4l2 mfc support

### DIFF
--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -210,7 +210,7 @@ public:
   virtual void SetHeight(float height);
   virtual void SetVisible(bool bVisible, bool setVisState = false);
   void SetVisibleCondition(const CStdString &expression, const CStdString &allowHiddenFocus = "");
-  bool HasVisibleCondition() const { return m_visibleCondition; };
+  bool HasVisibleCondition() const { return (bool) m_visibleCondition; };
   void SetEnableCondition(const CStdString &expression);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void SetInitialVisibility();

--- a/xbmc/windowing/X11/WinSystemX11GLES.h
+++ b/xbmc/windowing/X11/WinSystemX11GLES.h
@@ -25,6 +25,7 @@
 #include "windowing/WinSystem.h"
 #include <EGL/egl.h>
 #include <X11/Xlib.h>
+#include <SDL/SDL.h>
 #include "rendering/gles/RenderSystemGLES.h"
 #include "utils/GlobalsHandling.h"
 


### PR DESCRIPTION
fixes 2 issues that would prevent XBMC from compiling on Exynos ARM boards
