### PR TITLE
X11-SDL texture fix originally done by koying

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11GLES.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLES.cpp
@@ -27,7 +27,6 @@
 #include "filesystem/SpecialProtocol.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
-#include "settings/DisplaySettings.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/Texture.h"
 #include "windowing/X11/XRandR.h"
@@ -158,11 +157,13 @@ bool CWinSystemX11GLES::CreateNewWindow(const CStdString& name, bool fullScreen,
   if(!SetFullScreen(fullScreen, res, false))
 	return false;
 
-  CTexture iconTexture;
-  iconTexture.LoadFromFile("special://xbmc/media/icon256x256.png");
+  CBaseTexture* iconTexture;
+  iconTexture = CTexture::LoadFromFile("special://xbmc/media/icon256x256.png");
 
-  SDL_WM_SetIcon(SDL_CreateRGBSurfaceFrom(iconTexture.GetPixels(), iconTexture.GetWidth(), iconTexture.GetHeight(), BPP, iconTexture.GetPitch(), 0xff0000, 0x00ff00, 0x0000ff, 0xff000000L), NULL);
+  if (iconTexture)
+    SDL_WM_SetIcon(SDL_CreateRGBSurfaceFrom(iconTexture->GetPixels(), iconTexture->GetWidth(), iconTexture->GetHeight(), BPP, iconTexture->GetPitch(), 0xff0000, 0x00ff00, 0x0000ff, 0xff000000L), NULL);
   SDL_WM_SetCaption("XBMC Media Center", NULL);
+  delete iconTexture;
 
   m_bWindowCreated = true;
 


### PR DESCRIPTION
This was initially done as part of fix for running XBMC under X11 on a mali-based arm board by koying...
Is there anything wrong with upstreaming it?
Also removes the double include.
