### PR TITLE
[configure] there are arm boards than run XBMC via X11 and SDL

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -654,11 +654,8 @@ case $host in
   arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
      ARCH="arm"
      use_arch="arm"
-     use_joystick=no
      use_neon=yes
      use_gles=yes
-     use_sdl=no
-     use_x11=no
      use_wayland=no
      USE_STATIC_FFMPEG=1
      ;;


### PR DESCRIPTION
between Frodo and Gotham, default config options for arm linux were set that make no sense, since there are boards that can run XBMC in X11, with SDL and joystick support...
