### PR TITLE
CHG: [droid] do not h/w decode MP4 SD video (save on support)

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -206,7 +206,18 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
     // amcodec can handle dvd playback.
     if (!hint.software && CSettings::Get().GetBool("videoplayer.useamcodec"))
     {
-      if ( (pCodec = OpenCodec(new CDVDVideoCodecAmlogic(), hint, options)) ) return pCodec;
+      switch(hint.codec)
+      {
+        case AV_CODEC_ID_MPEG4:
+        case AV_CODEC_ID_MSMPEG4V2:
+        case AV_CODEC_ID_MSMPEG4V3:
+          // Avoid h/w decoder for SD; Those files might use features
+          // not supported and can easily be soft-decoded
+          if (hint.width <= 800)
+            break;
+        default:
+          if ( (pCodec = OpenCodec(new CDVDVideoCodecAmlogic(), hint, options)) ) return pCodec;
+      }
     }
 #endif
 
@@ -249,8 +260,19 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
 #if defined(TARGET_ANDROID)
     if (!hint.software && CSettings::Get().GetBool("videoplayer.usemediacodec"))
     {
-      CLog::Log(LOGINFO, "MediaCodec Video Decoder...");
-      if ( (pCodec = OpenCodec(new CDVDVideoCodecAndroidMediaCodec(), hint, options)) ) return pCodec;
+      switch(hint.codec)
+      {
+        case AV_CODEC_ID_MPEG4:
+        case AV_CODEC_ID_MSMPEG4V2:
+        case AV_CODEC_ID_MSMPEG4V3:
+          // Avoid h/w decoder for SD; Those files might use features
+          // not supported and can easily be soft-decoded
+          if (hint.width <= 800)
+            break;
+        default:
+          CLog::Log(LOGINFO, "MediaCodec Video Decoder...");
+          if ( (pCodec = OpenCodec(new CDVDVideoCodecAndroidMediaCodec(), hint, options)) ) return pCodec;
+      }
     }
 #endif
 
@@ -282,19 +304,15 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
     {
       switch(hint.codec)
       {
-        case CODEC_ID_H264:
-        case CODEC_ID_MPEG4:
-        case CODEC_ID_MPEG2VIDEO:
-        case CODEC_ID_VC1:
-        case CODEC_ID_WMV3:
-        case CODEC_ID_VP3:
-        case CODEC_ID_VP6:
-        case CODEC_ID_VP6F:
-        case CODEC_ID_VP8:
-          if ( (pCodec = OpenCodec(new CDVDVideoCodecStageFright(), hint, options)) ) return pCodec;
-          break;
+        case AV_CODEC_ID_MPEG4:
+        case AV_CODEC_ID_MSMPEG4V2:
+        case AV_CODEC_ID_MSMPEG4V3:
+          // Avoid h/w decoder for SD; Those files might use features
+          // not supported and can easily be soft-decoded
+          if (hint.width <= 800)
+            break;
         default:
-          break;
+          if ( (pCodec = OpenCodec(new CDVDVideoCodecStageFright(), hint, options)) ) return pCodec;
       }
     }
 #endif


### PR DESCRIPTION
Just a suggestion.
We can probably save on support by soft decoding mpeg2/mpeg4l2. 
H/W decoding of those does not bring anything (or some milliwatts saving) on modern devices, but quality/capabilities of them vary greatly.

We might add some check to be sure the device has the ponies (bogomips? #cpu?)

/cc @davilla 
