### PR TITLE
[infoscanner] recursive fast hash for enumerating series folders

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1363,33 +1363,16 @@ void CUtil::DeleteDirectoryCache(const CStdString &prefix)
 }
 
 
-void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, bool bUseFileDirectories)
+void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, unsigned int flags /* = DIR_FLAG_DEFAULTS */)
 {
   CFileItemList myItems;
-  int flags = DIR_FLAG_DEFAULTS;
-  if (!bUseFileDirectories)
-    flags |= DIR_FLAG_NO_FILE_DIRS;
   CDirectory::GetDirectory(strPath,myItems,strMask,flags);
   for (int i=0;i<myItems.Size();++i)
   {
     if (myItems[i]->m_bIsFolder)
-      CUtil::GetRecursiveListing(myItems[i]->GetPath(),items,strMask,bUseFileDirectories);
+      CUtil::GetRecursiveListing(myItems[i]->GetPath(),items,strMask,flags);
     else
       items.Add(myItems[i]);
-  }
-}
-
-void CUtil::GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& item)
-{
-  CFileItemList myItems;
-  CDirectory::GetDirectory(strPath,myItems,"",DIR_FLAG_NO_FILE_DIRS);
-  for (int i=0;i<myItems.Size();++i)
-  {
-    if (myItems[i]->m_bIsFolder && !myItems[i]->GetPath().Equals(".."))
-    {
-      item.Add(myItems[i]);
-      CUtil::GetRecursiveDirsListing(myItems[i]->GetPath(),item);
-    }
   }
 }
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -147,8 +147,7 @@ public:
   static CStdString VideoPlaylistsLocation();
 
   static void GetSkinThemes(std::vector<CStdString>& vecTheme);
-  static void GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, bool bUseFileDirectories=false);
-  static void GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& items);
+  static void GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, unsigned int flags = 0 /* DIR_FLAG_DEFAULTS */);
   static void ForceForwardSlashes(CStdString& strPath);
 
   static double AlbumRelevance(const CStdString& strAlbumTemp1, const CStdString& strAlbum1, const CStdString& strArtistTemp1, const CStdString& strArtist1);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -179,7 +179,7 @@ namespace VIDEO
      */
     void FetchActorThumbs(std::vector<SActorInfo>& actors, const CStdString& strPath);
 
-    static int GetPathHash(const CFileItemList &items, CStdString &hash);
+    int GetPathHash(const CFileItemList &items, CStdString &hash);
 
     /*! \brief Retrieve a "fast" hash of the given directory (if available)
      Performs a stat() on the directory, and uses modified time to create a "fast"
@@ -189,6 +189,15 @@ namespace VIDEO
      \return the hash of the folder of the form "fast<datetime>"
      */
     CStdString GetFastHash(const CStdString &directory) const;
+
+    /*! \brief Retrieve a "fast" hash of the given directory recursively (if available)
+     Performs a stat() on the directory, and uses modified time to create a "fast"
+     hash of the folder. If no modified time is available, the create time is used,
+     and if neither are available, an empty hash is returned.
+     \param directory folder to hash (recursively)
+     \return the hash of the folder of the form "fast<datetime>"
+     */
+    CStdString GetRecursiveFastHash(const CStdString &directory) const;
 
     /*! \brief Decide whether a folder listing could use the "fast" hash
      Fast hashing can be done whenever the folder contains no scannable subfolders, as the


### PR DESCRIPTION
This commit modifies the infoscanner to use a recursive fast hash for enumerating series folders and allows us
to determine whether or not new content was added without wasting time while stating every single episode.
