### PR TITLE
[WebServer] Loading image failed with libmicrohttpd 0.9.35 #4821

### DIFF
--- a/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
@@ -36,6 +36,13 @@ int CHTTPImageHandler::HandleHTTPRequest(const HTTPRequest &request)
   {
     m_path = request.url.substr(7);
 
+    /* In old version of libmicrohttpd the path was decoded, this was wrong.
+     * This was fix in version 0.9.35.0 : https://gnunet.org/bugs/view.php?id=3371
+     * The path must be decoded in XBMC */
+#if MHD_VERSION >= 0x00093500
+    m_path = CURL::Decode(m_path);
+#endif
+
     XFILE::CImageFile imageFile;
     if (imageFile.Exists(m_path))
     {

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -39,6 +39,13 @@ int CHTTPVfsHandler::HandleHTTPRequest(const HTTPRequest &request)
   {
     m_path = request.url.substr(5);
 
+    /* In old version of libmicrohttpd the path was decoded, this was wrong.
+     * This was fix in version 0.9.35.0 : https://gnunet.org/bugs/view.php?id=3371
+     * The path must be decoded in XBMC */
+#if MHD_VERSION >= 0x00093500
+    m_path = CURL::Decode(m_path);
+#endif
+
     if (XFILE::CFile::Exists(m_path))
     {
       bool accessible = false;


### PR DESCRIPTION
A bug was fixed inside libmicrohttpd : https://gnunet.org/bugs/view.php?id=3371
The path of the url is no longer decoded by libmicrohttpd in version 0.9.35
This bug fix breaks a lot of HTTP request, like loading images...
Fix it by decoding the path inside XBMC.
