### PR TITLE
Add Linux v4l2 MFC support for ARM Exynos boards

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -536,7 +536,7 @@ AC_ARG_ENABLE([gtest],
 
 AC_ARG_ENABLE([codec],
   [AS_HELP_STRING([--enable-codec],
-  [enable additional codecs from a list of comma separated names, (default is none, choices are amcodec, libstagefright)])],
+  [enable additional codecs from a list of comma separated names, (default is none, choices are amcodec, libstagefright, mfc)])],
   [add_codecs=$enableval],
   [add_codecs=no])
 
@@ -1990,6 +1990,9 @@ for codecs in `echo $add_codecs | sed 's/,/ /g'`; do
     *libstagefright*)
         XB_ADD_CODEC([LIBSTAGEFRIGHT], [libstagefright], [$codecs])
         ;;
+    *mfc*)
+       XB_ADD_CODEC([MFC], [mfc], [$codecs])
+       ;;
     *)
   esac
 done

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -32,6 +32,9 @@
 #if defined(HAVE_VIDEOTOOLBOXDECODER)
 #include "Video/DVDVideoCodecVideoToolBox.h"
 #endif
+#if defined(HAS_MFC)
+#include "Video/DVDVideoCodecMfc.h"
+#endif
 #include "Video/DVDVideoCodecFFmpeg.h"
 #include "Video/DVDVideoCodecOpenMax.h"
 #include "Video/DVDVideoCodecLibMpeg2.h"
@@ -190,6 +193,11 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
 #elif defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
   hwSupport += "VAAPI:no ";
 #endif
+#if defined(HAS_MFC) && defined(_LINUX)
+  hwSupport += "MFC:yes ";
+#elif defined(_LINUX)
+  hwSupport += "MFC:no ";
+#endif
 
   CLog::Log(LOGDEBUG, "CDVDFactoryCodec: compiled in hardware support: %s", hwSupport.c_str());
 
@@ -215,6 +223,10 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
       if ( (pCodec = OpenCodec(new CDVDVideoCodecVDA(), hint, options)) ) return pCodec;
     }
   }
+#endif
+
+#if defined(HAS_MFC) && defined(_LINUX)
+  if( (pCodec = OpenCodec(new CDVDVideoCodecMfc(), hint, options)) ) return pCodec;
 #endif
 
 #if defined(HAVE_VIDEOTOOLBOXDECODER)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
@@ -64,6 +64,7 @@ bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) {
     MFC5 = true;
     MFC6 = false;
     // MFC5 requires FIMC convertor
+    converter = new FimcConverter();
     if (!converter->OpenDevice()) {
       CLog::Log(LOGDEBUG, "%s::%s - FIMC device not found", CLASSNAME, __func__);
       return false;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
@@ -1,0 +1,373 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDVideoCodecMfc.h"
+
+#ifdef CLASSNAME
+#undef CLASSNAME
+#endif
+#define CLASSNAME "CDVDVideoCodecMfc"
+
+CDVDVideoCodecMfc::CDVDVideoCodecMfc() : CDVDVideoCodec() {
+
+  decoder = new MfcDecoder();
+  converter = NULL;
+
+  m_iDecodedWidth = 0;
+  m_iDecodedHeight = 0;
+  m_iConvertedWidth = 0;
+  m_iConvertedHeight = 0;
+
+  m_bDropPictures = false;  
+  memzero(m_videoBuffer);
+}
+
+CDVDVideoCodecMfc::~CDVDVideoCodecMfc() {
+  Dispose();
+  if (converter)
+    delete converter;
+  if (decoder)
+    delete decoder;
+}
+
+bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) {
+
+  if (hints.software) {
+    return false;
+  }
+
+  Dispose();
+
+  if (!decoder->OpenDevice()) {
+    CLog::Log(LOGDEBUG, "%s::%s - MFC device not found", CLASSNAME, __func__);
+    return false;
+  }
+
+  if (!decoder->HasNV12Support()) {
+    MFC5 = true;
+    MFC6 = false;
+    // MFC5 requires FIMC convertor
+    if (!converter->OpenDevice()) {
+      CLog::Log(LOGDEBUG, "%s::%s - FIMC device not found", CLASSNAME, __func__);
+      return false;
+    }
+  } else {
+    MFC5 = false;
+    MFC6 = true;
+  }
+
+  if (!decoder->SetupOutputFormat(hints)) {
+    return false;
+  }
+  
+  if (!decoder->SetupOutputBuffers()) {
+    return false;
+  }
+
+  if (!decoder->QueueHeader(hints)) {
+    return false;
+  }
+
+if (MFC6) {
+  if (!decoder->SetCaptureFormat()) {
+    return false;
+  }
+}
+
+  struct v4l2_format mfc_fmt = {};
+  if (!decoder->GetCaptureFormat(&mfc_fmt)) {
+    return false;
+  }
+
+if (MFC5) {
+  // the output format of FIMC is the input format of MFC
+  if (!converter->SetOutputFormat(&mfc_fmt)) {
+    return false;
+  }  
+}
+
+  if (!decoder->RequestBuffers()) {
+    return false;
+  }
+
+  struct v4l2_crop mfc_crop = {};
+  if (!decoder->GetCaptureCrop(&mfc_crop)) {
+    return false;
+  }
+
+if (MFC5) {
+  m_iDecodedWidth = mfc_crop.c.width;
+  m_iDecodedHeight = mfc_crop.c.height;
+}
+if (MFC6) {
+  m_iDecodedWidth = (mfc_crop.c.width + 15)&~15; // Align width by 16. Required for NV12 to YUV420 converter
+  m_iDecodedHeight = mfc_crop.c.height;
+
+  // FIXME: add this to mfc decoder MFC6
+  decoder->SetOutputBufferPlanes(m_iDecodedWidth, m_iDecodedHeight);
+  //m_v4l2OutputBuffer.cPlane[0] = new BYTE[m_iVideoWidth * m_iVideoHeight];
+  //m_v4l2OutputBuffer.cPlane[1] = new BYTE[m_iVideoWidth * (m_iVideoHeight >> 1)];
+}
+
+  // With no FIMC scaling, resulting picture will be the same size as source
+  int width = m_iDecodedWidth;
+  int height = m_iDecodedHeight;
+
+if (MFC5) {
+  // Set FIMC crop based on MFC crop 
+  if (!converter->SetOutputCrop(&mfc_crop)) {
+    return false;
+  }
+
+  // Calculate FIMC final picture size as scaled to fit screen
+  RESOLUTION_INFO res_info = CDisplaySettings::Get().GetResolutionInfo(g_graphicsContext.GetVideoResolution());
+  double ratio = std::min((double)res_info.iScreenWidth / (double)m_iDecodedWidth, (double)res_info.iScreenHeight / (double)m_iDecodedHeight);
+  width = (int)((double)m_iDecodedWidth * ratio);
+  height = (int)((double)m_iDecodedHeight * ratio);
+  if (width%2) width--;
+  if (height%2) height--;
+}
+  
+  if (!decoder->SetupCaptureBuffers()) {
+    return false;
+  }
+  
+  // with no FIMC we use for converted picture the decoded width and height
+  m_iConvertedWidth = width;
+  m_iConvertedHeight = height;
+if (MFC5) {
+  // with FIMC we override the converted picture width and height
+  if (!converter->RequestBuffers(decoder->GetCaptureBuffersCount())) {
+    return false;
+  }
+
+  struct v4l2_format fimc_fmt = {};
+  fimc_fmt.fmt.pix_mp.width = width;
+  fimc_fmt.fmt.pix_mp.height = height;
+  if (!converter->SetCaptureFormat(&fimc_fmt)) {
+    return false;
+  }
+  m_iConvertedWidth = fimc_fmt.fmt.pix_mp.width;
+  m_iConvertedHeight = fimc_fmt.fmt.pix_mp.height;
+
+  struct v4l2_crop fimc_crop = {};
+  fimc_crop.c.width = m_iConvertedWidth;
+  fimc_crop.c.height = m_iConvertedHeight;
+  if (!converter->SetCaptureCrop(&fimc_crop)) {
+    return false;
+  }
+
+  if (!converter->SetupCaptureBuffers()) {
+    return false;
+  }
+
+  // we dequeue header only on MFC5 (when FIMC is present)
+  // on MFC we just start streaming...
+  if (!decoder->DequeueHeader()) {
+    return false;
+  }
+}
+
+  return true;
+}
+
+
+void CDVDVideoCodecMfc::Dispose() {
+  while(!m_pts.empty())
+    m_pts.pop();
+  while(!m_dts.empty())
+    m_dts.pop();
+
+  m_bDropPictures = false;
+  memzero(m_videoBuffer);
+
+  if (converter)
+    converter->Dispose();
+  if (decoder)
+    decoder->Dispose();
+}
+
+void CDVDVideoCodecMfc::SetDropState(bool bDrop) {
+
+  m_bDropPictures = bDrop;
+
+}
+
+int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts) {
+
+  int ret = -1;
+  size_t index = 0;
+
+  if(pData) {
+    // Find buffer ready to be filled
+    for (index = 0; index < decoder->GetOutputBuffersCount(); index++) {
+      if (decoder->IsOutputBufferEmpty(index))
+        break;
+    }
+
+    if (index == decoder->GetOutputBuffersCount()) { // all input buffers are busy, dequeue needed
+      if (!decoder->DequeueOutputBuffer(&ret)) {
+        return ret;
+      }
+      index = ret;
+    }
+
+    if (!decoder->SendBuffer(index, pData, iSize)) {
+      return VC_ERROR;
+    }
+    m_pts.push(-pts);
+    m_dts.push(-dts);
+  }
+
+if (MFC6) {
+  int buf = 0;
+  if (decoder->GetFirstDecodedCaptureBuffer(&buf)) {
+    if (!decoder->QueueOutputBuffer(buf)) {
+      m_videoBuffer.iFlags      |= DVP_FLAG_DROPPED;
+      m_videoBuffer.iFlags      &= DVP_FLAG_ALLOCATED;
+      return VC_ERROR;
+    }
+    decoder->RemoveFirstDecodedCaptureBuffer();
+  }
+}
+
+  if (!decoder->DequeueDecodedFrame(&ret)) {
+    return ret;
+  }
+  index = ret;
+
+if (MFC6) { 
+  decoder->AddDecodedCaptureBuffer(index);
+}
+
+  if (m_bDropPictures) {
+    m_videoBuffer.iFlags |= DVP_FLAG_DROPPED;
+    CLog::Log(LOGDEBUG, "%s::%s - Dropping frame with index %d", CLASSNAME, __func__, ret);
+  } else {
+if (MFC5) {
+    if (!converter->QueueCaptureBuffer()) {
+      return VC_ERROR;
+    }
+  
+    if (!converter->QueueOutputBuffer(index, decoder->GetCaptureBuffer(index), &ret)) {
+      return VC_ERROR;
+    }
+ 
+    decoder->SetCaptureBufferBusy(ret);
+
+    if (converter->StartConverter()) {
+      return VC_BUFFER; // Queue one more frame for double buffering on FIMC
+    }
+
+    if (!converter->DequeueOutputBuffer(&ret)) {
+      return VC_ERROR;
+    }
+    index = ret;
+
+    decoder->SetCaptureBufferEmpty(ret);
+    
+    if (!converter->DequeueCaptureBuffer(&ret)) {
+      if (ret != 0)
+        return VC_BUFFER;
+      else
+        return VC_ERROR;
+    }
+}
+
+    m_videoBuffer.iFlags          = DVP_FLAG_ALLOCATED;
+    m_videoBuffer.color_range     = 0;
+    m_videoBuffer.color_matrix    = 4;
+
+if (MFC5) {
+    m_videoBuffer.iDisplayWidth   = m_iConvertedWidth;
+    m_videoBuffer.iDisplayHeight  = m_iConvertedHeight;
+    m_videoBuffer.iWidth          = m_iConvertedWidth;
+    m_videoBuffer.iHeight         = m_iConvertedHeight;
+
+    m_videoBuffer.data[0]         = 0;
+    m_videoBuffer.data[1]         = 0;
+    m_videoBuffer.data[2]         = 0;
+    m_videoBuffer.data[3]         = 0;
+    
+    m_videoBuffer.format          = RENDER_FMT_YUV420P;
+    m_videoBuffer.iLineSize[0]    = m_iConvertedWidth;
+    m_videoBuffer.iLineSize[1]    = m_iConvertedWidth >> 1;
+    m_videoBuffer.iLineSize[2]    = m_iConvertedWidth >> 1;
+    m_videoBuffer.iLineSize[3]    = 0;
+    m_videoBuffer.data[0]         = (BYTE*) converter->GetCurrentCaptureBuffer()->cPlane[0];
+    m_videoBuffer.data[1]         = (BYTE*) converter->GetCurrentCaptureBuffer()->cPlane[1];
+    m_videoBuffer.data[2]         = (BYTE*) converter->GetCurrentCaptureBuffer()->cPlane[2];
+}
+if (MFC6) {
+    m_videoBuffer.format          = RENDER_FMT_NV12;
+    m_videoBuffer.iDisplayWidth   = m_iDecodedWidth;
+    m_videoBuffer.iDisplayHeight  = m_iDecodedHeight;
+    m_videoBuffer.iWidth          = m_iDecodedWidth;
+    m_videoBuffer.iHeight         = m_iDecodedHeight;
+
+    m_videoBuffer.iLineSize[0]    = m_iDecodedWidth;
+    m_videoBuffer.iLineSize[1]    = m_iDecodedWidth;
+    m_videoBuffer.iLineSize[2]    = 0;
+    m_videoBuffer.iLineSize[3]    = 0;
+    m_videoBuffer.data[0]         = (BYTE*) decoder->GetCaptureBuffer(index)->cPlane[0];
+    m_videoBuffer.data[1]         = (BYTE*) decoder->GetCaptureBuffer(index)->cPlane[1];
+}
+  }
+
+  // Pop pts/dts only when picture is finally ready to be showed up or skipped
+  if(m_pts.size()) {
+    m_videoBuffer.pts = -m_pts.top(); // MFC always return frames in order and assigning them their pts'es from the input
+                                      // will lead to reshuffle. This will assign least pts in the queue to the frame dequeued.
+    m_videoBuffer.dts = -m_dts.top();
+    
+    m_pts.pop();
+    m_dts.pop();
+  } else {
+    CLog::Log(LOGERROR, "%s::%s - no pts value", CLASSNAME, __func__);
+    m_videoBuffer.pts           = DVD_NOPTS_VALUE;
+    m_videoBuffer.dts           = DVD_NOPTS_VALUE;
+  }
+
+if (MFC5) {
+  // Queue dequeued from FIMC OUPUT frame back to MFC CAPTURE
+  if (!decoder->QueueOutputBuffer(index)) {
+    m_videoBuffer.iFlags      |= DVP_FLAG_DROPPED;
+    m_videoBuffer.iFlags      &= DVP_FLAG_ALLOCATED;
+    return VC_ERROR;
+  }
+}
+  return VC_PICTURE; // Picture is finally ready to be processed further
+
+}
+
+void CDVDVideoCodecMfc::Reset() {
+}
+
+bool CDVDVideoCodecMfc::GetPicture(DVDVideoPicture* pDvdVideoPicture) {
+
+  *pDvdVideoPicture = m_videoBuffer;
+  return true;
+}
+
+bool CDVDVideoCodecMfc::ClearPicture(DVDVideoPicture* pDvdVideoPicture)
+{
+  return CDVDVideoCodec::ClearPicture(pDvdVideoPicture);
+}
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -25,344 +25,390 @@
 #endif
 #define CLASSNAME "CDVDVideoCodecMfc"
 
-CDVDVideoCodecMfc::CDVDVideoCodecMfc() : CDVDVideoCodec() {
+CDVDVideoCodecMfc::CDVDVideoCodecMfc() : CDVDVideoCodec()
+{
+  m_decoder = new Mfc_decoder();
+  m_converter = NULL;
 
-  decoder = new MfcDecoder();
-  converter = NULL;
+  m_iDecodedWidth     = 0;
+  m_iDecodedHeight    = 0;
+  m_iConvertedWidth   = 0;
+  m_iConvertedHeight  = 0;
 
-  m_iDecodedWidth = 0;
-  m_iDecodedHeight = 0;
-  m_iConvertedWidth = 0;
-  m_iConvertedHeight = 0;
-
-  m_bDropPictures = false;  
-  memzero(m_videoBuffer);
+  m_bDropPictures = false;
+  memset(&(m_videoBuffer), 0, sizeof (m_videoBuffer));
 }
 
-CDVDVideoCodecMfc::~CDVDVideoCodecMfc() {
+CDVDVideoCodecMfc::~CDVDVideoCodecMfc()
+{
   Dispose();
-  if (converter)
-    delete converter;
-  if (decoder)
-    delete decoder;
+  delete m_converter;
+  delete m_decoder;
 }
 
-bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) {
-
-  if (hints.software) {
+bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+{
+  if (hints.software)
+  {
     return false;
   }
-
   Dispose();
 
-  if (!decoder->OpenDevice()) {
+  if (!m_decoder->OpenDevice())
+  {
     CLog::Log(LOGDEBUG, "%s::%s - MFC device not found", CLASSNAME, __func__);
     return false;
   }
 
-  if (!decoder->HasNV12Support()) {
-    MFC5 = true;
-    MFC6 = false;
-    // MFC5 requires FIMC convertor
-    converter = new FimcConverter();
-    if (!converter->OpenDevice()) {
+  if (!m_decoder->HasNV12Support())
+  {
+    m_NV12Support = false;
+    // FIMC color convertor required
+    m_converter = new Fimc_converter();
+    if (!m_converter->OpenDevice())
+    {
       CLog::Log(LOGDEBUG, "%s::%s - FIMC device not found", CLASSNAME, __func__);
       return false;
     }
-  } else {
-    MFC5 = false;
-    MFC6 = true;
+  }
+  else
+  {
+    m_NV12Support = true;
   }
 
-  if (!decoder->SetupOutputFormat(hints)) {
+  if (!m_decoder->SetupOutputFormat(hints))
+  {
     return false;
   }
   
-  if (!decoder->SetupOutputBuffers()) {
+  if (!m_decoder->SetupOutputBuffers())
+  {
     return false;
   }
 
-  if (!decoder->QueueHeader(hints)) {
+  if (!m_decoder->QueueHeader(hints))
+  {
     return false;
   }
 
-if (MFC6) {
-  if (!decoder->SetCaptureFormat()) {
-    return false;
+  if (m_NV12Support)
+  {
+    if (!m_decoder->SetCaptureFormat())
+    {
+      return false;
+    }
   }
-}
 
   struct v4l2_format mfc_fmt = {};
-  if (!decoder->GetCaptureFormat(&mfc_fmt)) {
+  if (!m_decoder->GetCaptureFormat(&mfc_fmt))
+  {
     return false;
   }
 
-if (MFC5) {
-  // the output format of FIMC is the input format of MFC
-  if (!converter->SetOutputFormat(&mfc_fmt)) {
-    return false;
-  }  
-}
+  if (!m_NV12Support)
+  {
+    // the output format of FIMC is the input format of MFC
+    if (!m_converter->SetOutputFormat(&mfc_fmt))
+    {
+      return false;
+    }  
+  }
 
-  if (!decoder->RequestBuffers()) {
+  if (!m_decoder->RequestBuffers())
+  {
     return false;
   }
 
   struct v4l2_crop mfc_crop = {};
-  if (!decoder->GetCaptureCrop(&mfc_crop)) {
+  if (!m_decoder->GetCaptureCrop(&mfc_crop))
+  {
     return false;
   }
 
-if (MFC5) {
-  m_iDecodedWidth = mfc_crop.c.width;
-  m_iDecodedHeight = mfc_crop.c.height;
-}
-if (MFC6) {
-  m_iDecodedWidth = (mfc_crop.c.width + 15)&~15; // Align width by 16. Required for NV12 to YUV420 converter
-  m_iDecodedHeight = mfc_crop.c.height;
-
-  // FIXME: add this to mfc decoder MFC6
-  decoder->SetOutputBufferPlanes(m_iDecodedWidth, m_iDecodedHeight);
-  //m_v4l2OutputBuffer.cPlane[0] = new BYTE[m_iVideoWidth * m_iVideoHeight];
-  //m_v4l2OutputBuffer.cPlane[1] = new BYTE[m_iVideoWidth * (m_iVideoHeight >> 1)];
-}
+  if (!m_NV12Support) {
+    m_iDecodedWidth = mfc_crop.c.width;
+    m_iDecodedHeight = mfc_crop.c.height;
+  }
+  else
+  {
+    m_iDecodedWidth = (mfc_crop.c.width + 15)&~15;  // Align width by 16. Required for NV12 to YUV420 converter
+    m_iDecodedHeight = mfc_crop.c.height;
+    // FIXME: maybe we can do this nicer...
+    m_decoder->SetOutputBufferPlanes(m_iDecodedWidth, m_iDecodedHeight);
+  }
 
   // With no FIMC scaling, resulting picture will be the same size as source
-  int width = m_iDecodedWidth;
-  int height = m_iDecodedHeight;
+  int width       = m_iDecodedWidth;
+  int height      = m_iDecodedHeight;
 
-if (MFC5) {
-  // Set FIMC crop based on MFC crop 
-  if (!converter->SetOutputCrop(&mfc_crop)) {
-    return false;
+  if (!m_NV12Support)
+  {
+    // Set FIMC crop based on MFC crop 
+    if (!m_converter->SetOutputCrop(&mfc_crop))
+    {
+      return false;
+    }
+    // Calculate FIMC final picture size as scaled to fit screen
+    RESOLUTION_INFO res_info = CDisplaySettings::Get().GetResolutionInfo(g_graphicsContext.GetVideoResolution());
+    double ratio  = std::min((double)res_info.iScreenWidth / (double)m_iDecodedWidth, (double)res_info.iScreenHeight / (double)m_iDecodedHeight);
+    width         = (int)((double)m_iDecodedWidth * ratio);
+    height        = (int)((double)m_iDecodedHeight * ratio);
+    if (width%2)  width--;
+    if (height%2) height--;
   }
-
-  // Calculate FIMC final picture size as scaled to fit screen
-  RESOLUTION_INFO res_info = CDisplaySettings::Get().GetResolutionInfo(g_graphicsContext.GetVideoResolution());
-  double ratio = std::min((double)res_info.iScreenWidth / (double)m_iDecodedWidth, (double)res_info.iScreenHeight / (double)m_iDecodedHeight);
-  width = (int)((double)m_iDecodedWidth * ratio);
-  height = (int)((double)m_iDecodedHeight * ratio);
-  if (width%2) width--;
-  if (height%2) height--;
-}
   
-  if (!decoder->SetupCaptureBuffers()) {
+  if (!m_decoder->SetupCaptureBuffers())
+  {
     return false;
   }
   
   // with no FIMC we use for converted picture the decoded width and height
   m_iConvertedWidth = width;
   m_iConvertedHeight = height;
-if (MFC5) {
-  // with FIMC we override the converted picture width and height
-  if (!converter->RequestBuffers(decoder->GetCaptureBuffersCount())) {
-    return false;
-  }
+  if (!m_NV12Support)
+  {
+    // with FIMC we override the converted picture width and height
+    if (!m_converter->RequestBuffers(m_decoder->GetCaptureBuffersCount()))
+    {
+      return false;
+    }
 
-  struct v4l2_format fimc_fmt = {};
-  fimc_fmt.fmt.pix_mp.width = width;
-  fimc_fmt.fmt.pix_mp.height = height;
-  if (!converter->SetCaptureFormat(&fimc_fmt)) {
-    return false;
-  }
-  m_iConvertedWidth = fimc_fmt.fmt.pix_mp.width;
-  m_iConvertedHeight = fimc_fmt.fmt.pix_mp.height;
+    struct v4l2_format fimc_fmt = {};
+    fimc_fmt.fmt.pix_mp.width   = width;
+    fimc_fmt.fmt.pix_mp.height  = height;
+    if (!m_converter->SetCaptureFormat(&fimc_fmt))
+    {
+      return false;
+    }
+    m_iConvertedWidth   = fimc_fmt.fmt.pix_mp.width;
+    m_iConvertedHeight  = fimc_fmt.fmt.pix_mp.height;
 
-  struct v4l2_crop fimc_crop = {};
-  fimc_crop.c.width = m_iConvertedWidth;
-  fimc_crop.c.height = m_iConvertedHeight;
-  if (!converter->SetCaptureCrop(&fimc_crop)) {
-    return false;
-  }
+    struct v4l2_crop fimc_crop  = {};
+    fimc_crop.c.width           = m_iConvertedWidth;
+    fimc_crop.c.height          = m_iConvertedHeight;
+    if (!m_converter->SetCaptureCrop(&fimc_crop))
+    {
+      return false;
+    }
 
-  if (!converter->SetupCaptureBuffers()) {
-    return false;
-  }
+    if (!m_converter->SetupCaptureBuffers())
+    {
+      return false;
+    }
 
-  // we dequeue header only on MFC5 (when FIMC is present)
-  // on MFC we just start streaming...
-  if (!decoder->DequeueHeader()) {
-    return false;
+    // we dequeue header only on MFC5 (when FIMC is present)
+    // on MFC we just start streaming...
+    if (!m_decoder->DequeueHeader())
+    {
+      return false;
+    }
   }
-}
 
   return true;
 }
 
 
-void CDVDVideoCodecMfc::Dispose() {
-  while(!m_pts.empty())
+void CDVDVideoCodecMfc::Dispose()
+{
+  while (!m_pts.empty())
     m_pts.pop();
-  while(!m_dts.empty())
+  while (!m_dts.empty())
     m_dts.pop();
 
   m_bDropPictures = false;
-  memzero(m_videoBuffer);
+  memset(&(m_videoBuffer), 0, sizeof (m_videoBuffer));
 
-  if (converter)
-    converter->Dispose();
-  if (decoder)
-    decoder->Dispose();
+  if (m_converter != NULL)
+    m_converter->Dispose();
+  if (m_decoder != NULL)
+    m_decoder->Dispose();
 }
 
-void CDVDVideoCodecMfc::SetDropState(bool bDrop) {
-
+void CDVDVideoCodecMfc::SetDropState(bool bDrop)
+{
   m_bDropPictures = bDrop;
-
 }
 
-int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts) {
+int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
+{
+  int ret       = -1;
+  size_t index  = 0;
 
-  int ret = -1;
-  size_t index = 0;
-
-  if(pData) {
+  if (pData)
+  {
     // Find buffer ready to be filled
-    for (index = 0; index < decoder->GetOutputBuffersCount(); index++) {
-      if (decoder->IsOutputBufferEmpty(index))
+    for (index = 0; index < m_decoder->GetOutputBuffersCount(); index++)
+    {
+      if (m_decoder->IsOutputBufferEmpty(index))
         break;
     }
 
-    if (index == decoder->GetOutputBuffersCount()) { // all input buffers are busy, dequeue needed
-      if (!decoder->DequeueOutputBuffer(&ret)) {
+    if (index == m_decoder->GetOutputBuffersCount())
+    {
+      // all input buffers are busy, dequeue needed
+      if (!m_decoder->DequeueOutputBuffer(&ret))
+      {
         return ret;
       }
       index = ret;
     }
 
-    if (!decoder->SendBuffer(index, pData, iSize)) {
+    if (!m_decoder->SendBuffer(index, pData, iSize))
+    {
       return VC_ERROR;
     }
     m_pts.push(-pts);
     m_dts.push(-dts);
   }
 
-if (MFC6) {
-  int buf = 0;
-  if (decoder->GetFirstDecodedCaptureBuffer(&buf)) {
-    if (!decoder->QueueOutputBuffer(buf)) {
-      m_videoBuffer.iFlags      |= DVP_FLAG_DROPPED;
-      m_videoBuffer.iFlags      &= DVP_FLAG_ALLOCATED;
-      return VC_ERROR;
+  if (m_NV12Support)
+  {
+    int buf = 0;
+    if (m_decoder->GetFirstDecodedCaptureBuffer(&buf))
+    {
+      if (!m_decoder->QueueOutputBuffer(buf))
+      {
+        m_videoBuffer.iFlags      |= DVP_FLAG_DROPPED;
+        m_videoBuffer.iFlags      &= DVP_FLAG_ALLOCATED;
+        return VC_ERROR;
+      }
+      m_decoder->RemoveFirstDecodedCaptureBuffer();
     }
-    decoder->RemoveFirstDecodedCaptureBuffer();
   }
-}
-
-  if (!decoder->DequeueDecodedFrame(&ret)) {
+  
+  if (!m_decoder->DequeueDecodedFrame(&ret))
+  {
     return ret;
   }
   index = ret;
 
-if (MFC6) { 
-  decoder->AddDecodedCaptureBuffer(index);
-}
+  if (m_NV12Support)
+  { 
+    m_decoder->AddDecodedCaptureBuffer(index);
+  }
 
-  if (m_bDropPictures) {
+  if (m_bDropPictures)
+  {
     m_videoBuffer.iFlags |= DVP_FLAG_DROPPED;
     CLog::Log(LOGDEBUG, "%s::%s - Dropping frame with index %d", CLASSNAME, __func__, ret);
-  } else {
-if (MFC5) {
-    if (!converter->QueueCaptureBuffer()) {
-      return VC_ERROR;
-    }
-  
-    if (!converter->QueueOutputBuffer(index, decoder->GetCaptureBuffer(index), &ret)) {
-      return VC_ERROR;
-    }
- 
-    decoder->SetCaptureBufferBusy(ret);
-
-    if (converter->StartConverter()) {
-      return VC_BUFFER; // Queue one more frame for double buffering on FIMC
-    }
-
-    if (!converter->DequeueOutputBuffer(&ret)) {
-      return VC_ERROR;
-    }
-    index = ret;
-
-    decoder->SetCaptureBufferEmpty(ret);
-    
-    if (!converter->DequeueCaptureBuffer(&ret)) {
-      if (ret != 0)
-        return VC_BUFFER;
-      else
+  }
+  else
+  {
+    if (!m_NV12Support)
+    {
+      if (!m_converter->QueueCaptureBuffer())
+      {
         return VC_ERROR;
+      }
+  
+      if (!m_converter->QueueOutputBuffer(index, m_decoder->GetCaptureBuffer(index), &ret))
+      {
+        return VC_ERROR;
+      }
+ 
+      m_decoder->SetCaptureBufferBusy(ret);
+
+      if (m_converter->Startm_converter())
+      {
+        return VC_BUFFER; // Queue one more frame for double buffering on FIMC
+      }
+
+      if (!m_converter->DequeueOutputBuffer(&ret))
+      {
+        return VC_ERROR;
+      }
+      index = ret;
+
+      m_decoder->SetCaptureBufferEmpty(ret);
+    
+      if (!m_converter->DequeueCaptureBuffer(&ret))
+      {
+        if (ret != 0)
+          return VC_BUFFER;
+        else
+          return VC_ERROR;
+      }
     }
-}
 
     m_videoBuffer.iFlags          = DVP_FLAG_ALLOCATED;
     m_videoBuffer.color_range     = 0;
     m_videoBuffer.color_matrix    = 4;
 
-if (MFC5) {
-    m_videoBuffer.iDisplayWidth   = m_iConvertedWidth;
-    m_videoBuffer.iDisplayHeight  = m_iConvertedHeight;
-    m_videoBuffer.iWidth          = m_iConvertedWidth;
-    m_videoBuffer.iHeight         = m_iConvertedHeight;
+    if (!m_NV12Support) {
+      m_videoBuffer.iDisplayWidth   = m_iConvertedWidth;
+      m_videoBuffer.iDisplayHeight  = m_iConvertedHeight;
+      m_videoBuffer.iWidth          = m_iConvertedWidth;
+      m_videoBuffer.iHeight         = m_iConvertedHeight;
 
-    m_videoBuffer.data[0]         = 0;
-    m_videoBuffer.data[1]         = 0;
-    m_videoBuffer.data[2]         = 0;
-    m_videoBuffer.data[3]         = 0;
+      m_videoBuffer.data[0]         = 0;
+      m_videoBuffer.data[1]         = 0;
+      m_videoBuffer.data[2]         = 0;
+      m_videoBuffer.data[3]         = 0;
     
-    m_videoBuffer.format          = RENDER_FMT_YUV420P;
-    m_videoBuffer.iLineSize[0]    = m_iConvertedWidth;
-    m_videoBuffer.iLineSize[1]    = m_iConvertedWidth >> 1;
-    m_videoBuffer.iLineSize[2]    = m_iConvertedWidth >> 1;
-    m_videoBuffer.iLineSize[3]    = 0;
-    m_videoBuffer.data[0]         = (BYTE*) converter->GetCurrentCaptureBuffer()->cPlane[0];
-    m_videoBuffer.data[1]         = (BYTE*) converter->GetCurrentCaptureBuffer()->cPlane[1];
-    m_videoBuffer.data[2]         = (BYTE*) converter->GetCurrentCaptureBuffer()->cPlane[2];
-}
-if (MFC6) {
-    m_videoBuffer.format          = RENDER_FMT_NV12;
-    m_videoBuffer.iDisplayWidth   = m_iDecodedWidth;
-    m_videoBuffer.iDisplayHeight  = m_iDecodedHeight;
-    m_videoBuffer.iWidth          = m_iDecodedWidth;
-    m_videoBuffer.iHeight         = m_iDecodedHeight;
+      m_videoBuffer.format          = RENDER_FMT_YUV420P;
+      m_videoBuffer.iLineSize[0]    = m_iConvertedWidth;
+      m_videoBuffer.iLineSize[1]    = m_iConvertedWidth >> 1;
+      m_videoBuffer.iLineSize[2]    = m_iConvertedWidth >> 1;
+      m_videoBuffer.iLineSize[3]    = 0;
+      m_videoBuffer.data[0]         = (BYTE*) m_converter->GetCurrentCaptureBuffer()->cPlane[0];
+      m_videoBuffer.data[1]         = (BYTE*) m_converter->GetCurrentCaptureBuffer()->cPlane[1];
+      m_videoBuffer.data[2]         = (BYTE*) m_converter->GetCurrentCaptureBuffer()->cPlane[2];
+    }
+    else
+    {
+      m_videoBuffer.format          = RENDER_FMT_NV12;
+      m_videoBuffer.iDisplayWidth   = m_iDecodedWidth;
+      m_videoBuffer.iDisplayHeight  = m_iDecodedHeight;
+      m_videoBuffer.iWidth          = m_iDecodedWidth;
+      m_videoBuffer.iHeight         = m_iDecodedHeight;
 
-    m_videoBuffer.iLineSize[0]    = m_iDecodedWidth;
-    m_videoBuffer.iLineSize[1]    = m_iDecodedWidth;
-    m_videoBuffer.iLineSize[2]    = 0;
-    m_videoBuffer.iLineSize[3]    = 0;
-    m_videoBuffer.data[0]         = (BYTE*) decoder->GetCaptureBuffer(index)->cPlane[0];
-    m_videoBuffer.data[1]         = (BYTE*) decoder->GetCaptureBuffer(index)->cPlane[1];
-}
+      m_videoBuffer.iLineSize[0]    = m_iDecodedWidth;
+      m_videoBuffer.iLineSize[1]    = m_iDecodedWidth;
+      m_videoBuffer.iLineSize[2]    = 0;
+      m_videoBuffer.iLineSize[3]    = 0;
+      m_videoBuffer.data[0]         = (BYTE*) m_decoder->GetCaptureBuffer(index)->cPlane[0];
+      m_videoBuffer.data[1]         = (BYTE*) m_decoder->GetCaptureBuffer(index)->cPlane[1];
+    }
   }
 
   // Pop pts/dts only when picture is finally ready to be showed up or skipped
-  if(m_pts.size()) {
+  if (m_pts.size())
+  {
     m_videoBuffer.pts = -m_pts.top(); // MFC always return frames in order and assigning them their pts'es from the input
                                       // will lead to reshuffle. This will assign least pts in the queue to the frame dequeued.
     m_videoBuffer.dts = -m_dts.top();
-    
+
     m_pts.pop();
     m_dts.pop();
-  } else {
+  }
+  else
+  {
     CLog::Log(LOGERROR, "%s::%s - no pts value", CLASSNAME, __func__);
     m_videoBuffer.pts           = DVD_NOPTS_VALUE;
     m_videoBuffer.dts           = DVD_NOPTS_VALUE;
   }
 
-if (MFC5) {
-  // Queue dequeued from FIMC OUPUT frame back to MFC CAPTURE
-  if (!decoder->QueueOutputBuffer(index)) {
-    m_videoBuffer.iFlags      |= DVP_FLAG_DROPPED;
-    m_videoBuffer.iFlags      &= DVP_FLAG_ALLOCATED;
-    return VC_ERROR;
+  if (!m_NV12Support)
+  {
+    // Queue dequeued from FIMC OUPUT frame back to MFC CAPTURE
+    if (!m_decoder->QueueOutputBuffer(index))
+    {
+      m_videoBuffer.iFlags      |= DVP_FLAG_DROPPED;
+      m_videoBuffer.iFlags      &= DVP_FLAG_ALLOCATED;
+      return VC_ERROR;
+    }
   }
-}
+  
   return VC_PICTURE; // Picture is finally ready to be processed further
-
 }
 
-void CDVDVideoCodecMfc::Reset() {
+void CDVDVideoCodecMfc::Reset()
+{
+  // FIXME: implement Reset - currently skipping back in a stream results in a small stuttering
 }
 
-bool CDVDVideoCodecMfc::GetPicture(DVDVideoPicture* pDvdVideoPicture) {
-
+bool CDVDVideoCodecMfc::GetPicture(DVDVideoPicture* pDvdVideoPicture)
+{
   *pDvdVideoPicture = m_videoBuffer;
   return true;
 }
@@ -371,4 +417,3 @@ bool CDVDVideoCodecMfc::ClearPicture(DVDVideoPicture* pDvdVideoPicture)
 {
   return CDVDVideoCodec::ClearPicture(pDvdVideoPicture);
 }
-

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
@@ -80,7 +80,7 @@ bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   {
     return false;
   }
-  
+
   if (!m_decoder->SetupOutputBuffers())
   {
     return false;
@@ -111,7 +111,7 @@ bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
     if (!m_converter->SetOutputFormat(&mfc_fmt))
     {
       return false;
-    }  
+    }
   }
 
   if (!m_decoder->RequestBuffers())
@@ -143,7 +143,7 @@ bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 
   if (!m_NV12Support)
   {
-    // Set FIMC crop based on MFC crop 
+    // Set FIMC crop based on MFC crop
     if (!m_converter->SetOutputCrop(&mfc_crop))
     {
       return false;
@@ -156,12 +156,12 @@ bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
     if (width%2)  width--;
     if (height%2) height--;
   }
-  
+
   if (!m_decoder->SetupCaptureBuffers())
   {
     return false;
   }
-  
+
   // with no FIMC we use for converted picture the decoded width and height
   m_iConvertedWidth = width;
   m_iConvertedHeight = height;
@@ -275,7 +275,7 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
       m_decoder->RemoveFirstDecodedCaptureBuffer();
     }
   }
-  
+
   if (!m_decoder->DequeueDecodedFrame(&ret))
   {
     return ret;
@@ -283,7 +283,7 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
   index = ret;
 
   if (m_NV12Support)
-  { 
+  {
     m_decoder->AddDecodedCaptureBuffer(index);
   }
 
@@ -300,12 +300,12 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
       {
         return VC_ERROR;
       }
-  
+
       if (!m_converter->QueueOutputBuffer(index, m_decoder->GetCaptureBuffer(index), &ret))
       {
         return VC_ERROR;
       }
- 
+
       m_decoder->SetCaptureBufferBusy(ret);
 
       if (m_converter->Startm_converter())
@@ -320,7 +320,7 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
       index = ret;
 
       m_decoder->SetCaptureBufferEmpty(ret);
-    
+
       if (!m_converter->DequeueCaptureBuffer(&ret))
       {
         if (ret != 0)
@@ -344,7 +344,7 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
       m_videoBuffer.data[1]         = 0;
       m_videoBuffer.data[2]         = 0;
       m_videoBuffer.data[3]         = 0;
-    
+
       m_videoBuffer.format          = RENDER_FMT_YUV420P;
       m_videoBuffer.iLineSize[0]    = m_iConvertedWidth;
       m_videoBuffer.iLineSize[1]    = m_iConvertedWidth >> 1;
@@ -398,7 +398,7 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
       return VC_ERROR;
     }
   }
-  
+
   return VC_PICTURE; // Picture is finally ready to be processed further
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
@@ -27,7 +27,7 @@
 
 CDVDVideoCodecMfc::CDVDVideoCodecMfc() : CDVDVideoCodec()
 {
-  m_decoder = new Mfc_decoder();
+  m_decoder = new MfcDecoder();
   m_converter = NULL;
 
   m_iDecodedWidth     = 0;
@@ -64,7 +64,7 @@ bool CDVDVideoCodecMfc::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   {
     m_NV12Support = false;
     // FIMC color convertor required
-    m_converter = new Fimc_converter();
+    m_converter = new FimcConverter();
     if (!m_converter->OpenDevice())
     {
       CLog::Log(LOGDEBUG, "%s::%s - FIMC device not found", CLASSNAME, __func__);
@@ -308,7 +308,7 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
 
       m_decoder->SetCaptureBufferBusy(ret);
 
-      if (m_converter->Startm_converter())
+      if (m_converter->StartConverter())
       {
         return VC_BUFFER; // Queue one more frame for double buffering on FIMC
       }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.cpp
@@ -399,7 +399,7 @@ int CDVDVideoCodecMfc::Decode(BYTE* pData, int iSize, double dts, double pts)
     }
   }
 
-  return VC_PICTURE; // Picture is finally ready to be processed further
+  return VC_PICTURE | VC_BUFFER; // Picture is finally ready to be processed further
 }
 
 void CDVDVideoCodecMfc::Reset()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -20,12 +20,11 @@
  *
  */
 
-#define memzero(x) memset(&(x), 0, sizeof (x))
-
 #include "MfcDecoder.h"
 #include "FimcConverter.h"
 
 #include "DVDClock.h"
+#include "utils/log.h"
 #include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
 #include <queue>
@@ -33,7 +32,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 #ifdef __cplusplus
 }
 #endif
@@ -51,23 +49,21 @@ public:
   virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual void SetDropState(bool bDrop);
-  virtual const char* GetName() { return decoder->GetOutputName(); };
+  virtual const char* GetName() { return m->decoder != NULL ? m_decoder->GetOutputName() : ""; };
 
 private:
-  MfcDecoder *decoder;
-  FimcConverter *converter;
+  MfcDecoder                   *m_decoder;
+  FimcConverter                *m_converter;
 
-  unsigned int m_iDecodedWidth;
-  unsigned int m_iDecodedHeight;
-  unsigned int m_iConvertedWidth;
-  unsigned int m_iConvertedHeight;
+  unsigned int                  m_iDecodedWidth;
+  unsigned int                  m_iDecodedHeight;
+  unsigned int                  m_iConvertedWidth;
+  unsigned int                  m_iConvertedHeight;
 
-  std::priority_queue<double> m_pts;
-  std::priority_queue<double> m_dts;
+  std::priority_queue<double>   m_pts;
+  std::priority_queue<double>   m_dts;
 
-  bool MFC5;
-  bool MFC6;
-  bool m_bDropPictures;
-  DVDVideoPicture   m_videoBuffer;
+  bool                          m_NV12Support;
+  bool                          m_bDropPictures;
+  DVDVideoPicture               m_videoBuffer;
 };
-

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
@@ -49,7 +49,7 @@ public:
   virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual void SetDropState(bool bDrop);
-  virtual const char* GetName() { return m->decoder != NULL ? m_decoder->GetOutputName() : ""; };
+  virtual const char* GetName() { return m_decoder != NULL ? m_decoder->GetOutputName() : ""; };
 
 private:
   MfcDecoder                   *m_decoder;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
@@ -1,0 +1,73 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define memzero(x) memset(&(x), 0, sizeof (x))
+
+#include "MfcDecoder.h"
+#include "FimcConverter.h"
+
+#include "DVDClock.h"
+#include "guilib/GraphicContext.h"
+#include "settings/DisplaySettings.h"
+#include <queue>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+class CDVDVideoCodecMfc : public CDVDVideoCodec
+{
+public:
+  CDVDVideoCodecMfc();
+  virtual ~CDVDVideoCodecMfc();
+  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
+  virtual void Dispose();
+  virtual int Decode(BYTE* pData, int iSize, double dts, double pts);
+  virtual void Reset();
+  bool GetPictureCommon(DVDVideoPicture* pDvdVideoPicture);
+  virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture);
+  virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
+  virtual void SetDropState(bool bDrop);
+  virtual const char* GetName() { return decoder->GetOutputName(); };
+
+private:
+  MfcDecoder *decoder;
+  FimcConverter *converter;
+
+  unsigned int m_iDecodedWidth;
+  unsigned int m_iDecodedHeight;
+  unsigned int m_iConvertedWidth;
+  unsigned int m_iConvertedHeight;
+
+  std::priority_queue<double> m_pts;
+  std::priority_queue<double> m_dts;
+
+  bool MFC5;
+  bool MFC6;
+  bool m_bDropPictures;
+  DVDVideoPicture   m_videoBuffer;
+};
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMfc.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "DVDCodecs/DVDCodecs.h"
 #include "MfcDecoder.h"
 #include "FimcConverter.h"
 
@@ -27,7 +28,6 @@
 #include "utils/log.h"
 #include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
-#include <queue>
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,8 +41,9 @@ class CDVDVideoCodecMfc : public CDVDVideoCodec
 public:
   CDVDVideoCodecMfc();
   virtual ~CDVDVideoCodecMfc();
-  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
   virtual void Dispose();
+
+  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
   virtual int Decode(BYTE* pData, int iSize, double dts, double pts);
   virtual void Reset();
   bool GetPictureCommon(DVDVideoPicture* pDvdVideoPicture);
@@ -52,18 +53,12 @@ public:
   virtual const char* GetName() { return m_decoder != NULL ? m_decoder->GetOutputName() : ""; };
 
 private:
-  MfcDecoder                   *m_decoder;
-  FimcConverter                *m_converter;
+  MfcDecoder      *m_decoder;
+  FimcConverter   *m_converter;
 
-  unsigned int                  m_iDecodedWidth;
-  unsigned int                  m_iDecodedHeight;
-  unsigned int                  m_iConvertedWidth;
-  unsigned int                  m_iConvertedHeight;
-
-  std::priority_queue<double>   m_pts;
-  std::priority_queue<double>   m_dts;
-
-  bool                          m_NV12Support;
-  bool                          m_bDropPictures;
-  DVDVideoPicture               m_videoBuffer;
+  bool             m_NV12Support;
+  bool             m_bDropPictures;
+  int              m_iDequeuedToPresentBufferNumber;
+  CDVDStreamInfo   m_hints;
+  DVDVideoPicture  m_videoBuffer;
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -23,40 +23,39 @@
 #include <sys/ioctl.h>
 #include <dirent.h>
 
-#define V4L2_CAP_VIDEO_M2M_MPLANE       0x00004000
-
 #ifdef CLASSNAME
 #undef CLASSNAME
 #endif
 #define CLASSNAME "FimcConverter"
 
-FimcConverter::FimcConverter() {
-
+FimcConverter::FimcConverter()
+{
   m_iConverterHandle = -1;
-
+  m_bFIMCStartConverter = true;
   m_FIMCCaptureBuffersCount = 0;
   m_v4l2FIMCCaptureBuffers = NULL;
-
   m_iFIMCCapturePlane1Size = -1;
   m_iFIMCCapturePlane2Size = -1;
   m_iFIMCCapturePlane3Size = -1;
-
-  m_bFIMCStartConverter = true;
   m_iFIMCdequeuedBufferNumber = -1;
-
 }
 
-FimcConverter::~FimcConverter() {
+FimcConverter::~FimcConverter()
+{
   Dispose();
 }
 
-bool FimcConverter::OpenDevice() {
+bool FimcConverter::OpenDevice()
+{
   DIR *dir;
   struct dirent *ent;
 
-  if ((dir = opendir ("/sys/class/video4linux/")) != NULL) {
-    while ((ent = readdir (dir)) != NULL) {
-      if (strncmp(ent->d_name, "video", 5) == 0) {
+  if ((dir = opendir ("/sys/class/video4linux/")) != NULL)
+  {
+    while ((ent = readdir (dir)) != NULL)
+    {
+      if (strncmp(ent->d_name, "video", 5) == 0)
+      {
         char *p;
         char name[64];
         char devname[64];
@@ -69,11 +68,17 @@ bool FimcConverter::OpenDevice() {
         snprintf(name, 64, "/sys/class/video4linux/%s/name", ent->d_name);
 
         FILE* fp = fopen(name, "r");
-        if (fgets(drivername, 32, fp) != NULL) {
+        if (fp == NULL)
+          continue;
+
+        if (fgets(drivername, 32, fp) != NULL)
+        {
           p = strchr(drivername, '\n');
           if (p != NULL)
             *p = '\0';
-        } else {
+        }
+        else
+        {
           fclose(fp);
           continue;
         }
@@ -87,9 +92,10 @@ bool FimcConverter::OpenDevice() {
         if (p == NULL)
           continue;
 
-        sprintf(devname, "/dev/%s", ++p);
+        snprintf(devname, 64, "/dev/%s", ++p);
 
-        if (m_iConverterHandle < 0 && strstr(drivername, "fimc") != NULL && strstr(drivername, "m2m") != NULL) {
+        if (m_iConverterHandle < 0 && strstr(drivername, "fimc") != NULL && strstr(drivername, "m2m") != NULL)
+        {
           struct v4l2_capability cap;
           int fd = open(devname, O_RDWR, 0);
           if (fd > 0) {
@@ -98,7 +104,8 @@ bool FimcConverter::OpenDevice() {
             if (ret == 0)
               if ((cap.capabilities & V4L2_CAP_VIDEO_M2M_MPLANE ||
                 ((cap.capabilities & V4L2_CAP_VIDEO_CAPTURE_MPLANE) && (cap.capabilities & V4L2_CAP_VIDEO_OUTPUT_MPLANE))) &&
-                (cap.capabilities & V4L2_CAP_STREAMING)) {
+                (cap.capabilities & V4L2_CAP_STREAMING))
+              {
                 m_iConverterHandle = fd;
                 CLog::Log(LOGDEBUG, "%s::%s - Found %s %s", CLASSNAME, __func__, drivername, devname);
               }
@@ -115,15 +122,16 @@ bool FimcConverter::OpenDevice() {
   return false;
 }
 
-bool FimcConverter::SetOutputFormat(struct v4l2_format* fmt) {
-
+bool FimcConverter::SetOutputFormat(struct v4l2_format* fmt)
+{
   // Setup FIMC OUTPUT fmt with data from MFC CAPTURE received on previous step
-  fmt->type                                = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
-  fmt->fmt.pix_mp.field                    = V4L2_FIELD_ANY;
-  fmt->fmt.pix_mp.pixelformat              = V4L2_PIX_FMT_NV12MT;
-  fmt->fmt.pix_mp.num_planes               = V4L2_NUM_MAX_PLANES;
+  fmt->type                        = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
+  fmt->fmt.pix_mp.field            = V4L2_FIELD_ANY;
+  fmt->fmt.pix_mp.pixelformat      = V4L2_PIX_FMT_NV12MT;
+  fmt->fmt.pix_mp.num_planes       = V4L2_NUM_MAX_PLANES;
  
-  if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt)) {
+  if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt))
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT S_FMT Failed", CLASSNAME, __func__);
     return false;
   }
@@ -132,11 +140,12 @@ bool FimcConverter::SetOutputFormat(struct v4l2_format* fmt) {
   return true;
 }
 
-bool FimcConverter::SetOutputCrop(struct v4l2_crop* crop) {
-
+bool FimcConverter::SetOutputCrop(struct v4l2_crop* crop)
+{
   // Setup FIMC OUTPUT crop with data from MFC CAPTURE received on previous step
   crop->type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
-  if (ioctl(m_iConverterHandle, VIDIOC_S_CROP, crop)) {
+  if (ioctl(m_iConverterHandle, VIDIOC_S_CROP, crop))
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT S_CROP Failed to set crop information", CLASSNAME, __func__);
     return false;
   }
@@ -145,10 +154,12 @@ bool FimcConverter::SetOutputCrop(struct v4l2_crop* crop) {
   return true;
 }
 
-bool FimcConverter::RequestBuffers(int buffers) {
+bool FimcConverter::RequestBuffers(int buffers)
+{
   // Request FIMC capture buffers
   int ret = CLinuxV4l2::RequestBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, buffers);
-  if (ret == V4L2_ERROR) {
+  if (ret == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT REQBUFS failed", CLASSNAME, __func__);
     return false;
   }
@@ -157,28 +168,32 @@ bool FimcConverter::RequestBuffers(int buffers) {
   return true;
 }
 
-bool FimcConverter::SetCaptureFormat(struct v4l2_format *fmt) {
+bool FimcConverter::SetCaptureFormat(struct v4l2_format *fmt)
+{
   // Setup FIMC capture
-  fmt->fmt.pix_mp.pixelformat = V4L2_PIX_FMT_YUV420M;
-  fmt->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  fmt->fmt.pix_mp.num_planes = V4L2_NUM_MAX_PLANES;
-  fmt->fmt.pix_mp.field = V4L2_FIELD_ANY;
+  fmt->fmt.pix_mp.pixelformat   = V4L2_PIX_FMT_YUV420M;
+  fmt->type                     = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  fmt->fmt.pix_mp.num_planes    = V4L2_NUM_MAX_PLANES;
+  fmt->fmt.pix_mp.field         = V4L2_FIELD_ANY;
 
-  if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt)) {
+  if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt))
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE S_FMT Failed", CLASSNAME, __func__);
     return false;
   }
+
   CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE S_FMT %dx%d", CLASSNAME, __func__, fmt->fmt.pix_mp.width, fmt->fmt.pix_mp.height);
   return true;
 }
 
-bool FimcConverter::SetCaptureCrop(struct v4l2_crop *crop) {
-
+bool FimcConverter::SetCaptureCrop(struct v4l2_crop *crop)
+{
   // Setup FIMC CAPTURE crop
-  crop->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  crop->c.left = 0;
-  crop->c.top = 0;
-  if (ioctl(m_iConverterHandle, VIDIOC_S_CROP, crop)) {
+  crop->type      = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  crop->c.left    = 0;
+  crop->c.top     = 0;
+  if (ioctl(m_iConverterHandle, VIDIOC_S_CROP, crop))
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE S_CROP Failed", CLASSNAME, __func__);
     return false;
   }
@@ -187,12 +202,13 @@ bool FimcConverter::SetCaptureCrop(struct v4l2_crop *crop) {
   return true;
 }
 
-bool FimcConverter::SetupCaptureBuffers() {
-
+bool FimcConverter::SetupCaptureBuffers()
+{
   // Get FIMC produced picture details to adjust output buffer parameters with these values
   struct v4l2_format fmt = {};
-  fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  if (ioctl(m_iConverterHandle, VIDIOC_G_FMT, &fmt)) {
+  fmt.type               = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  if (ioctl(m_iConverterHandle, VIDIOC_G_FMT, &fmt))
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE G_FMT Failed", CLASSNAME, __func__);
     return false;
   }
@@ -203,7 +219,8 @@ bool FimcConverter::SetupCaptureBuffers() {
 
   // Request FIMC capture buffers
   m_FIMCCaptureBuffersCount = CLinuxV4l2::RequestBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, FIMC_CAPTURE_BUFFERS_CNT);
-  if (m_FIMCCaptureBuffersCount == V4L2_ERROR) {
+  if (m_FIMCCaptureBuffersCount == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE REQBUFS failed", CLASSNAME, __func__);
     return false;
   }
@@ -212,32 +229,37 @@ bool FimcConverter::SetupCaptureBuffers() {
 
   // Allocate, Memory Map and queue fimc capture buffers
   m_v4l2FIMCCaptureBuffers = (V4L2Buffer *)calloc(m_FIMCCaptureBuffersCount, sizeof(V4L2Buffer));
-  if (!m_v4l2FIMCCaptureBuffers) {
+  if (!m_v4l2FIMCCaptureBuffers)
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Cannot allocate memory for buffers", CLASSNAME, __func__);
     return false;
   }
-  if(!CLinuxV4l2::MmapBuffers(m_iConverterHandle, m_FIMCCaptureBuffersCount, m_v4l2FIMCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true)) {
+  if(!CLinuxV4l2::MmapBuffers(m_iConverterHandle, m_FIMCCaptureBuffersCount, m_v4l2FIMCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true))
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Cannot mmap for capture buffers", CLASSNAME, __func__);
     return false;
   }
   
-  for (int n = 0; n < m_FIMCCaptureBuffersCount; n++) {
+  for (int n = 0; n < m_FIMCCaptureBuffersCount; n++)
+  {
     m_v4l2FIMCCaptureBuffers[n].iBytesUsed[0] = m_iFIMCCapturePlane1Size;
     m_v4l2FIMCCaptureBuffers[n].iBytesUsed[1] = m_iFIMCCapturePlane2Size;
     m_v4l2FIMCCaptureBuffers[n].iBytesUsed[2] = m_iFIMCCapturePlane3Size;
-    m_v4l2FIMCCaptureBuffers[n].bQueue = true;
+    m_v4l2FIMCCaptureBuffers[n].bQueue        = true;
   }
-  
+
   CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Succesfully allocated, mmapped and queued %d buffers", CLASSNAME, __func__, m_FIMCCaptureBuffersCount);
   return true;
 }
 
-void FimcConverter::Dispose() {
+void FimcConverter::Dispose()
+{
   CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for FIMC buffers", CLASSNAME, __func__);
   if (m_v4l2FIMCCaptureBuffers)
     m_v4l2FIMCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_FIMCCaptureBuffersCount, m_v4l2FIMCCaptureBuffers);
   CLog::Log(LOGDEBUG, "%s::%s - Closing FIMC device", CLASSNAME, __func__);
-  if (m_iConverterHandle >= 0) {
+  if (m_iConverterHandle >= 0)
+  {
     if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
       CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream OFF", CLASSNAME, __func__);
     if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
@@ -249,11 +271,13 @@ void FimcConverter::Dispose() {
   m_iConverterHandle = -1;
 }
 
-
-bool FimcConverter::QueueCaptureBuffer() {
-  if (m_iFIMCdequeuedBufferNumber >= 0 && !m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].bQueue) {
+bool FimcConverter::QueueCaptureBuffer()
+{
+  if (m_iFIMCdequeuedBufferNumber >= 0 && !m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].bQueue)
+  {
     int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].iNumPlanes, m_iFIMCdequeuedBufferNumber, &m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber]);
-    if (ret == V4L2_ERROR) {
+    if (ret == V4L2_ERROR)
+    {
       CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to queue buffer with index %d, errno = %d", CLASSNAME, __func__, m_iFIMCdequeuedBufferNumber, errno);
       return false;
     }
@@ -263,68 +287,92 @@ bool FimcConverter::QueueCaptureBuffer() {
   return true;
 }
 
-bool FimcConverter::StartConverter() {
-  if (m_bFIMCStartConverter) {
+bool FimcConverter::StartConverter()
+{
+  if (m_bFIMCStartConverter)
+  {
     if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMON))
       CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream ON", CLASSNAME, __func__);
     else
       CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to Stream ON", CLASSNAME, __func__);
+
     if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON))
       CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Stream ON", CLASSNAME, __func__);
     else
       CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
+
     m_bFIMCStartConverter = false;
     return true; 
   }
   return false;
 }
 
-bool FimcConverter::QueueOutputBuffer(int index, V4L2Buffer* m_v4l2MFCCaptureBuffer, int *status) {
+bool FimcConverter::QueueOutputBuffer(int index, V4L2Buffer* m_v4l2MFCCaptureBuffer, int *status)
+{
   int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, m_v4l2MFCCaptureBuffer->iNumPlanes, index, m_v4l2MFCCaptureBuffer);
-  if (ret == V4L2_ERROR) {
+  if (ret == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, ret, errno);
     return false;
   }
   *status = ret;
-  return true;
+  return true; // *status contains the queued buffer index
 }
 
-bool FimcConverter::DequeueOutputBuffer(int *status) {
-  int ret = CLinuxV4l2::PollOutput(m_iConverterHandle, 1000/25); // 25 fps
-  if (ret == V4L2_ERROR) {
+bool FimcConverter::DequeueOutputBuffer(int *status)
+{
+  // This is the timeout for FIMC to wait for the new frame to produce.
+  // Initially set to 1000/25 - it is a timedifference between frames at 25 fps.
+  // If no frame would be returned the function will proceed further not having a frame to show.
+  // Something like nonblocking output for FIMC.
+  // FIXME: try setting it to 1000
+  int ret = CLinuxV4l2::PollOutput(m_iConverterHandle, 1000/25);
+  if (ret == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC PollOutput Error", CLASSNAME, __func__);
     return false;
-  } else if (ret == V4L2_READY) {
+  }
+  else
+  if (ret == V4L2_READY)
+  {
     // Dequeue frame from fimc output
     int index = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, V4L2_NUM_MAX_PLANES);
-    if (index < 0) {
+    if (index < 0)
+    {
       CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT error dequeue output buffer, got number %d", CLASSNAME, __func__, index);
       return false;
     }
     *status = index;
-  } else if (ret == V4L2_BUSY) { // buffer is still busy
+  }
+  else
+  if (ret == V4L2_BUSY)
+  { // buffer is still busy
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Buffer is still busy", CLASSNAME, __func__);
     return false;
-  } else {
+  }
+  else
+  {
     CLog::Log(LOGERROR, "%s::%s - FIMC PollOutput error %d, errno %d", CLASSNAME, __func__, ret, errno);
     return false;
   }
   return true; // *status contains the buffer index
 }
 
-bool FimcConverter::DequeueCaptureBuffer(int *status) {
+bool FimcConverter::DequeueCaptureBuffer(int *status)
+{
   m_iFIMCdequeuedBufferNumber = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
-  if (m_iFIMCdequeuedBufferNumber < 0) {
-    if (errno == EAGAIN) {
+  if (m_iFIMCdequeuedBufferNumber < 0)
+  {
+    if (errno == EAGAIN)
+    {
       // Dequeue buffer not ready, need more data on input. EAGAIN = 11
-      *status = 1;
+      *status = 1; // false with status = 1 indicates that we return VC_BUFFER
       return false;
     }
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, m_iFIMCdequeuedBufferNumber, errno);
     *status = 0;
-    return false;
+    return false; // false with status = 0 indicates we return VC_ERROR
   }
   m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].bQueue = false;
   return true;
 }
-

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
@@ -129,13 +129,13 @@ bool FimcConverter::SetOutputFormat(struct v4l2_format* fmt)
   fmt->fmt.pix_mp.field            = V4L2_FIELD_ANY;
   fmt->fmt.pix_mp.pixelformat      = V4L2_PIX_FMT_NV12MT;
   fmt->fmt.pix_mp.num_planes       = V4L2_NUM_MAX_PLANES;
- 
+
   if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt))
   {
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT S_FMT Failed", CLASSNAME, __func__);
     return false;
   }
-  
+
   CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT S_FMT (%dx%d)", CLASSNAME, __func__, fmt->fmt.pix_mp.width, fmt->fmt.pix_mp.height);
   return true;
 }
@@ -149,7 +149,7 @@ bool FimcConverter::SetOutputCrop(struct v4l2_crop* crop)
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT S_CROP Failed to set crop information", CLASSNAME, __func__);
     return false;
   }
-  
+
   CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT S_CROP (%dx%d)", CLASSNAME, __func__, crop->c.width, crop->c.height);
   return true;
 }
@@ -212,7 +212,7 @@ bool FimcConverter::SetupCaptureBuffers()
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE G_FMT Failed", CLASSNAME, __func__);
     return false;
   }
-  
+
   m_iFIMCCapturePlane1Size = fmt.fmt.pix_mp.plane_fmt[0].sizeimage;
   m_iFIMCCapturePlane2Size = fmt.fmt.pix_mp.plane_fmt[1].sizeimage;
   m_iFIMCCapturePlane3Size = fmt.fmt.pix_mp.plane_fmt[2].sizeimage;
@@ -239,7 +239,7 @@ bool FimcConverter::SetupCaptureBuffers()
     CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Cannot mmap for capture buffers", CLASSNAME, __func__);
     return false;
   }
-  
+
   for (int n = 0; n < m_FIMCCaptureBuffersCount; n++)
   {
     m_v4l2FIMCCaptureBuffers[n].iBytesUsed[0] = m_iFIMCCapturePlane1Size;
@@ -302,7 +302,7 @@ bool FimcConverter::StartConverter()
       CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
 
     m_bFIMCStartConverter = false;
-    return true; 
+    return true;
   }
   return false;
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
@@ -1,0 +1,330 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FimcConverter.h"
+
+#include <sys/ioctl.h>
+#include <dirent.h>
+
+#define V4L2_CAP_VIDEO_M2M_MPLANE       0x00004000
+
+#ifdef CLASSNAME
+#undef CLASSNAME
+#endif
+#define CLASSNAME "FimcConverter"
+
+FimcConverter::FimcConverter() {
+
+  m_iConverterHandle = -1;
+
+  m_FIMCCaptureBuffersCount = 0;
+  m_v4l2FIMCCaptureBuffers = NULL;
+
+  m_iFIMCCapturePlane1Size = -1;
+  m_iFIMCCapturePlane2Size = -1;
+  m_iFIMCCapturePlane3Size = -1;
+
+  m_bFIMCStartConverter = true;
+  m_iFIMCdequeuedBufferNumber = -1;
+
+}
+
+FimcConverter::~FimcConverter() {
+  Dispose();
+}
+
+bool FimcConverter::OpenDevice() {
+  DIR *dir;
+  struct dirent *ent;
+
+  if ((dir = opendir ("/sys/class/video4linux/")) != NULL) {
+    while ((ent = readdir (dir)) != NULL) {
+      if (strncmp(ent->d_name, "video", 5) == 0) {
+        char *p;
+        char name[64];
+        char devname[64];
+        char sysname[64];
+        char drivername[32];
+        char target[1024];
+        int ret;
+
+        snprintf(sysname, 64, "/sys/class/video4linux/%s", ent->d_name);
+        snprintf(name, 64, "/sys/class/video4linux/%s/name", ent->d_name);
+
+        FILE* fp = fopen(name, "r");
+        if (fgets(drivername, 32, fp) != NULL) {
+          p = strchr(drivername, '\n');
+          if (p != NULL)
+            *p = '\0';
+        } else {
+          fclose(fp);
+          continue;
+        }
+        fclose(fp);
+
+        ret = readlink(sysname, target, sizeof(target));
+        if (ret < 0)
+          continue;
+        target[ret] = '\0';
+        p = strrchr(target, '/');
+        if (p == NULL)
+          continue;
+
+        sprintf(devname, "/dev/%s", ++p);
+
+        if (m_iConverterHandle < 0 && strstr(drivername, "fimc") != NULL && strstr(drivername, "m2m") != NULL) {
+          struct v4l2_capability cap;
+          int fd = open(devname, O_RDWR, 0);
+          if (fd > 0) {
+            memset(&(cap), 0, sizeof (cap));
+            ret = ioctl(fd, VIDIOC_QUERYCAP, &cap);
+            if (ret == 0)
+              if ((cap.capabilities & V4L2_CAP_VIDEO_M2M_MPLANE ||
+                ((cap.capabilities & V4L2_CAP_VIDEO_CAPTURE_MPLANE) && (cap.capabilities & V4L2_CAP_VIDEO_OUTPUT_MPLANE))) &&
+                (cap.capabilities & V4L2_CAP_STREAMING)) {
+                m_iConverterHandle = fd;
+                CLog::Log(LOGDEBUG, "%s::%s - Found %s %s", CLASSNAME, __func__, drivername, devname);
+              }
+          }
+          if (m_iConverterHandle < 0)
+            close(fd);
+        }
+        if (m_iConverterHandle >= 0)
+          return true;
+      }
+    }
+    closedir (dir);
+  }
+  return false;
+}
+
+bool FimcConverter::SetOutputFormat(struct v4l2_format* fmt) {
+
+  // Setup FIMC OUTPUT fmt with data from MFC CAPTURE received on previous step
+  fmt->type                                = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
+  fmt->fmt.pix_mp.field                    = V4L2_FIELD_ANY;
+  fmt->fmt.pix_mp.pixelformat              = V4L2_PIX_FMT_NV12MT;
+  fmt->fmt.pix_mp.num_planes               = V4L2_NUM_MAX_PLANES;
+ 
+  if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt)) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT S_FMT Failed", CLASSNAME, __func__);
+    return false;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT S_FMT (%dx%d)", CLASSNAME, __func__, fmt->fmt.pix_mp.width, fmt->fmt.pix_mp.height);
+  return true;
+}
+
+bool FimcConverter::SetOutputCrop(struct v4l2_crop* crop) {
+
+  // Setup FIMC OUTPUT crop with data from MFC CAPTURE received on previous step
+  crop->type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
+  if (ioctl(m_iConverterHandle, VIDIOC_S_CROP, crop)) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT S_CROP Failed to set crop information", CLASSNAME, __func__);
+    return false;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT S_CROP (%dx%d)", CLASSNAME, __func__, crop->c.width, crop->c.height);
+  return true;
+}
+
+bool FimcConverter::RequestBuffers(int buffers) {
+  // Request FIMC capture buffers
+  int ret = CLinuxV4l2::RequestBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, buffers);
+  if (ret == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT REQBUFS failed", CLASSNAME, __func__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT REQBUFS Number of buffers is %d", CLASSNAME, __func__, ret);
+  return true;
+}
+
+bool FimcConverter::SetCaptureFormat(struct v4l2_format *fmt) {
+  // Setup FIMC capture
+  fmt->fmt.pix_mp.pixelformat = V4L2_PIX_FMT_YUV420M;
+  fmt->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  fmt->fmt.pix_mp.num_planes = V4L2_NUM_MAX_PLANES;
+  fmt->fmt.pix_mp.field = V4L2_FIELD_ANY;
+
+  if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt)) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE S_FMT Failed", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE S_FMT %dx%d", CLASSNAME, __func__, fmt->fmt.pix_mp.width, fmt->fmt.pix_mp.height);
+  return true;
+}
+
+bool FimcConverter::SetCaptureCrop(struct v4l2_crop *crop) {
+
+  // Setup FIMC CAPTURE crop
+  crop->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  crop->c.left = 0;
+  crop->c.top = 0;
+  if (ioctl(m_iConverterHandle, VIDIOC_S_CROP, crop)) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE S_CROP Failed", CLASSNAME, __func__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE S_CROP (%dx%d)", CLASSNAME, __func__, crop->c.width, crop->c.height);
+  return true;
+}
+
+bool FimcConverter::SetupCaptureBuffers() {
+
+  // Get FIMC produced picture details to adjust output buffer parameters with these values
+  struct v4l2_format fmt = {};
+  fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  if (ioctl(m_iConverterHandle, VIDIOC_G_FMT, &fmt)) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE G_FMT Failed", CLASSNAME, __func__);
+    return false;
+  }
+  
+  m_iFIMCCapturePlane1Size = fmt.fmt.pix_mp.plane_fmt[0].sizeimage;
+  m_iFIMCCapturePlane2Size = fmt.fmt.pix_mp.plane_fmt[1].sizeimage;
+  m_iFIMCCapturePlane3Size = fmt.fmt.pix_mp.plane_fmt[2].sizeimage;
+
+  // Request FIMC capture buffers
+  m_FIMCCaptureBuffersCount = CLinuxV4l2::RequestBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, FIMC_CAPTURE_BUFFERS_CNT);
+  if (m_FIMCCaptureBuffersCount == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE REQBUFS failed", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE REQBUFS Number of buffers is %d", CLASSNAME, __func__, m_FIMCCaptureBuffersCount);
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE buffer parameters: plane[0]=%d plane[1]=%d plane[2]=%d", CLASSNAME, __func__, m_iFIMCCapturePlane1Size, m_iFIMCCapturePlane2Size, m_iFIMCCapturePlane3Size);
+
+  // Allocate, Memory Map and queue fimc capture buffers
+  m_v4l2FIMCCaptureBuffers = (V4L2Buffer *)calloc(m_FIMCCaptureBuffersCount, sizeof(V4L2Buffer));
+  if (!m_v4l2FIMCCaptureBuffers) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Cannot allocate memory for buffers", CLASSNAME, __func__);
+    return false;
+  }
+  if(!CLinuxV4l2::MmapBuffers(m_iConverterHandle, m_FIMCCaptureBuffersCount, m_v4l2FIMCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true)) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Cannot mmap for capture buffers", CLASSNAME, __func__);
+    return false;
+  }
+  
+  for (int n = 0; n < m_FIMCCaptureBuffersCount; n++) {
+    m_v4l2FIMCCaptureBuffers[n].iBytesUsed[0] = m_iFIMCCapturePlane1Size;
+    m_v4l2FIMCCaptureBuffers[n].iBytesUsed[1] = m_iFIMCCapturePlane2Size;
+    m_v4l2FIMCCaptureBuffers[n].iBytesUsed[2] = m_iFIMCCapturePlane3Size;
+    m_v4l2FIMCCaptureBuffers[n].bQueue = true;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Succesfully allocated, mmapped and queued %d buffers", CLASSNAME, __func__, m_FIMCCaptureBuffersCount);
+  return true;
+}
+
+void FimcConverter::Dispose() {
+  CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for FIMC buffers", CLASSNAME, __func__);
+  if (m_v4l2FIMCCaptureBuffers)
+    m_v4l2FIMCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_FIMCCaptureBuffersCount, m_v4l2FIMCCaptureBuffers);
+  CLog::Log(LOGDEBUG, "%s::%s - Closing FIMC device", CLASSNAME, __func__);
+  if (m_iConverterHandle >= 0) {
+    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream OFF", CLASSNAME, __func__);
+    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Stream OFF", CLASSNAME, __func__);
+    close(m_iConverterHandle);
+  }
+  m_FIMCCaptureBuffersCount = 0;
+  m_v4l2FIMCCaptureBuffers = NULL;
+  m_iConverterHandle = -1;
+}
+
+
+bool FimcConverter::QueueCaptureBuffer() {
+  if (m_iFIMCdequeuedBufferNumber >= 0 && !m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].bQueue) {
+    int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].iNumPlanes, m_iFIMCdequeuedBufferNumber, &m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber]);
+    if (ret == V4L2_ERROR) {
+      CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to queue buffer with index %d, errno = %d", CLASSNAME, __func__, m_iFIMCdequeuedBufferNumber, errno);
+      return false;
+    }
+    m_v4l2FIMCCaptureBuffers[ret].bQueue = true;
+    m_iFIMCdequeuedBufferNumber = -1;
+  }
+  return true;
+}
+
+bool FimcConverter::StartConverter() {
+  if (m_bFIMCStartConverter) {
+    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMON))
+      CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream ON", CLASSNAME, __func__);
+    else
+      CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to Stream ON", CLASSNAME, __func__);
+    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON))
+      CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Stream ON", CLASSNAME, __func__);
+    else
+      CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
+    m_bFIMCStartConverter = false;
+    return true; 
+  }
+  return false;
+}
+
+bool FimcConverter::QueueOutputBuffer(int index, V4L2Buffer* m_v4l2MFCCaptureBuffer, int *status) {
+  int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, m_v4l2MFCCaptureBuffer->iNumPlanes, index, m_v4l2MFCCaptureBuffer);
+  if (ret == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, ret, errno);
+    return false;
+  }
+  *status = ret;
+  return true;
+}
+
+bool FimcConverter::DequeueOutputBuffer(int *status) {
+  int ret = CLinuxV4l2::PollOutput(m_iConverterHandle, 1000/25); // 25 fps
+  if (ret == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - FIMC PollOutput Error", CLASSNAME, __func__);
+    return false;
+  } else if (ret == V4L2_READY) {
+    // Dequeue frame from fimc output
+    int index = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, V4L2_NUM_MAX_PLANES);
+    if (index < 0) {
+      CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT error dequeue output buffer, got number %d", CLASSNAME, __func__, index);
+      return false;
+    }
+    *status = index;
+  } else if (ret == V4L2_BUSY) { // buffer is still busy
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Buffer is still busy", CLASSNAME, __func__);
+    return false;
+  } else {
+    CLog::Log(LOGERROR, "%s::%s - FIMC PollOutput error %d, errno %d", CLASSNAME, __func__, ret, errno);
+    return false;
+  }
+  return true; // *status contains the buffer index
+}
+
+bool FimcConverter::DequeueCaptureBuffer(int *status) {
+  m_iFIMCdequeuedBufferNumber = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
+  if (m_iFIMCdequeuedBufferNumber < 0) {
+    if (errno == EAGAIN) {
+      // Dequeue buffer not ready, need more data on input. EAGAIN = 11
+      *status = 1;
+      return false;
+    }
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, m_iFIMCdequeuedBufferNumber, errno);
+    *status = 0;
+    return false;
+  }
+  m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].bQueue = false;
+  return true;
+}
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
@@ -64,8 +64,8 @@ bool FimcConverter::OpenDevice()
         char target[1024];
         int ret;
 
-        snprintf(sysname, 64, "/sys/class/video4linux/%s", ent->d_name);
-        snprintf(name, 64, "/sys/class/video4linux/%s/name", ent->d_name);
+        snprintf(sysname, sizeof(sysname), "/sys/class/video4linux/%s", ent->d_name);
+        snprintf(name, sizeof(name), "/sys/class/video4linux/%s/name", ent->d_name);
 
         FILE* fp = fopen(name, "r");
         if (fp == NULL)
@@ -92,7 +92,7 @@ bool FimcConverter::OpenDevice()
         if (p == NULL)
           continue;
 
-        snprintf(devname, 64, "/dev/%s", ++p);
+        snprintf(devname, sizeof(devname), "/dev/%s", ++p);
 
         if (m_iConverterHandle < 0 && strstr(drivername, "fimc") != NULL && strstr(drivername, "m2m") != NULL)
         {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.cpp
@@ -31,18 +31,32 @@
 FimcConverter::FimcConverter()
 {
   m_iConverterHandle = -1;
-  m_bFIMCStartConverter = true;
   m_FIMCCaptureBuffersCount = 0;
   m_v4l2FIMCCaptureBuffers = NULL;
-  m_iFIMCCapturePlane1Size = -1;
-  m_iFIMCCapturePlane2Size = -1;
-  m_iFIMCCapturePlane3Size = -1;
-  m_iFIMCdequeuedBufferNumber = -1;
 }
 
 FimcConverter::~FimcConverter()
 {
   Dispose();
+}
+
+void FimcConverter::Dispose()
+{
+  CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for FIMC buffers", CLASSNAME, __func__);
+  if (m_v4l2FIMCCaptureBuffers)
+    m_v4l2FIMCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_FIMCCaptureBuffersCount, m_v4l2FIMCCaptureBuffers);
+  CLog::Log(LOGDEBUG, "%s::%s - Closing FIMC device", CLASSNAME, __func__);
+  if (m_iConverterHandle >= 0)
+  {
+    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream OFF", CLASSNAME, __func__);
+    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Stream OFF", CLASSNAME, __func__);
+    close(m_iConverterHandle);
+  }
+  m_FIMCCaptureBuffersCount = 0;
+  m_v4l2FIMCCaptureBuffers = NULL;
+  m_iConverterHandle = -1;
 }
 
 bool FimcConverter::OpenDevice()
@@ -122,14 +136,24 @@ bool FimcConverter::OpenDevice()
   return false;
 }
 
+bool FimcConverter::RequestBuffers(int buffers)
+{
+  // Request FIMC OUTPUT buffers
+  int ret = CLinuxV4l2::RequestBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, buffers);
+  if (ret == V4L2_ERROR)
+  {
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT REQBUFS failed", CLASSNAME, __func__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT REQBUFS Number of buffers is %d", CLASSNAME, __func__, ret);
+  return true;
+}
+
 bool FimcConverter::SetOutputFormat(struct v4l2_format* fmt)
 {
   // Setup FIMC OUTPUT fmt with data from MFC CAPTURE received on previous step
   fmt->type                        = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
-  fmt->fmt.pix_mp.field            = V4L2_FIELD_ANY;
-  fmt->fmt.pix_mp.pixelformat      = V4L2_PIX_FMT_NV12MT;
-  fmt->fmt.pix_mp.num_planes       = V4L2_NUM_MAX_PLANES;
-
   if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt))
   {
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT S_FMT Failed", CLASSNAME, __func__);
@@ -154,26 +178,11 @@ bool FimcConverter::SetOutputCrop(struct v4l2_crop* crop)
   return true;
 }
 
-bool FimcConverter::RequestBuffers(int buffers)
-{
-  // Request FIMC capture buffers
-  int ret = CLinuxV4l2::RequestBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, buffers);
-  if (ret == V4L2_ERROR)
-  {
-    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT REQBUFS failed", CLASSNAME, __func__);
-    return false;
-  }
-
-  CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT REQBUFS Number of buffers is %d", CLASSNAME, __func__, ret);
-  return true;
-}
-
 bool FimcConverter::SetCaptureFormat(struct v4l2_format *fmt)
 {
   // Setup FIMC capture
-  fmt->fmt.pix_mp.pixelformat   = V4L2_PIX_FMT_YUV420M;
+  fmt->fmt.pix_mp.pixelformat   = V4L2_PIX_FMT_NV12M;
   fmt->type                     = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  fmt->fmt.pix_mp.num_planes    = V4L2_NUM_MAX_PLANES;
   fmt->fmt.pix_mp.field         = V4L2_FIELD_ANY;
 
   if (ioctl(m_iConverterHandle, VIDIOC_S_FMT, fmt))
@@ -213,10 +222,6 @@ bool FimcConverter::SetupCaptureBuffers()
     return false;
   }
 
-  m_iFIMCCapturePlane1Size = fmt.fmt.pix_mp.plane_fmt[0].sizeimage;
-  m_iFIMCCapturePlane2Size = fmt.fmt.pix_mp.plane_fmt[1].sizeimage;
-  m_iFIMCCapturePlane3Size = fmt.fmt.pix_mp.plane_fmt[2].sizeimage;
-
   // Request FIMC capture buffers
   m_FIMCCaptureBuffersCount = CLinuxV4l2::RequestBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, FIMC_CAPTURE_BUFFERS_CNT);
   if (m_FIMCCaptureBuffersCount == V4L2_ERROR)
@@ -225,7 +230,6 @@ bool FimcConverter::SetupCaptureBuffers()
     return false;
   }
   CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE REQBUFS Number of buffers is %d", CLASSNAME, __func__, m_FIMCCaptureBuffersCount);
-  CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE buffer parameters: plane[0]=%d plane[1]=%d plane[2]=%d", CLASSNAME, __func__, m_iFIMCCapturePlane1Size, m_iFIMCCapturePlane2Size, m_iFIMCCapturePlane3Size);
 
   // Allocate, Memory Map and queue fimc capture buffers
   m_v4l2FIMCCaptureBuffers = (V4L2Buffer *)calloc(m_FIMCCaptureBuffersCount, sizeof(V4L2Buffer));
@@ -240,76 +244,64 @@ bool FimcConverter::SetupCaptureBuffers()
     return false;
   }
 
-  for (int n = 0; n < m_FIMCCaptureBuffersCount; n++)
-  {
-    m_v4l2FIMCCaptureBuffers[n].iBytesUsed[0] = m_iFIMCCapturePlane1Size;
-    m_v4l2FIMCCaptureBuffers[n].iBytesUsed[1] = m_iFIMCCapturePlane2Size;
-    m_v4l2FIMCCaptureBuffers[n].iBytesUsed[2] = m_iFIMCCapturePlane3Size;
-    m_v4l2FIMCCaptureBuffers[n].bQueue        = true;
-  }
-
   CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Succesfully allocated, mmapped and queued %d buffers", CLASSNAME, __func__, m_FIMCCaptureBuffersCount);
+
+  // STREAMON on FIMC OUTPUT and CAPTURE
+  if (!CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMON))
+  {
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to Stream ON", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream ON", CLASSNAME, __func__);
+  if (!CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON))
+  {
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Stream ON", CLASSNAME, __func__);
+
   return true;
 }
 
-void FimcConverter::Dispose()
+
+V4L2Buffer* FimcConverter::GetCaptureBuffer(int index)
 {
-  CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for FIMC buffers", CLASSNAME, __func__);
-  if (m_v4l2FIMCCaptureBuffers)
-    m_v4l2FIMCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_FIMCCaptureBuffersCount, m_v4l2FIMCCaptureBuffers);
-  CLog::Log(LOGDEBUG, "%s::%s - Closing FIMC device", CLASSNAME, __func__);
-  if (m_iConverterHandle >= 0)
-  {
-    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
-      CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream OFF", CLASSNAME, __func__);
-    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
-      CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Stream OFF", CLASSNAME, __func__);
-    close(m_iConverterHandle);
-  }
-  m_FIMCCaptureBuffersCount = 0;
-  m_v4l2FIMCCaptureBuffers = NULL;
-  m_iConverterHandle = -1;
+  return m_v4l2FIMCCaptureBuffers != NULL && index < m_FIMCCaptureBuffersCount ? &(m_v4l2FIMCCaptureBuffers[index]) : NULL;
 }
 
-bool FimcConverter::QueueCaptureBuffer()
+bool FimcConverter::QueueCaptureBuffer(int index)
 {
-  if (m_iFIMCdequeuedBufferNumber >= 0 && !m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].bQueue)
+  int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, &m_v4l2FIMCCaptureBuffers[index]);
+  if (ret == V4L2_ERROR)
   {
-    int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].iNumPlanes, m_iFIMCdequeuedBufferNumber, &m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber]);
-    if (ret == V4L2_ERROR)
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to queue buffer with index %d, errno = %d", CLASSNAME, __func__, index, errno);
+    return false;
+  }
+  return true;
+}
+
+bool FimcConverter::DequeueCaptureBuffer(int *status, double *timestamp)
+{
+  int index = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, timestamp);
+  if (index < 0)
+  {
+    if (errno == EAGAIN)
     {
-      CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to queue buffer with index %d, errno = %d", CLASSNAME, __func__, m_iFIMCdequeuedBufferNumber, errno);
+      // Dequeue buffer not ready, need more data on input. EAGAIN = 11
+      *status = 1; // false with result = 1 indicates that we return VC_BUFFER
       return false;
     }
-    m_v4l2FIMCCaptureBuffers[ret].bQueue = true;
-    m_iFIMCdequeuedBufferNumber = -1;
+    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, index, errno);
+    *status = 0;
+    return false; // false with result = 0 indicates we return VC_FLUSHED
   }
+  *status = index;
   return true;
-}
-
-bool FimcConverter::StartConverter()
-{
-  if (m_bFIMCStartConverter)
-  {
-    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMON))
-      CLog::Log(LOGDEBUG, "%s::%s - FIMC OUTPUT Stream ON", CLASSNAME, __func__);
-    else
-      CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to Stream ON", CLASSNAME, __func__);
-
-    if (CLinuxV4l2::StreamOn(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON))
-      CLog::Log(LOGDEBUG, "%s::%s - FIMC CAPTURE Stream ON", CLASSNAME, __func__);
-    else
-      CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
-
-    m_bFIMCStartConverter = false;
-    return true;
-  }
-  return false;
 }
 
 bool FimcConverter::QueueOutputBuffer(int index, V4L2Buffer* m_v4l2MFCCaptureBuffer, int *status)
 {
-  int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, m_v4l2MFCCaptureBuffer->iNumPlanes, index, m_v4l2MFCCaptureBuffer);
+  int ret = CLinuxV4l2::QueueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, m_v4l2MFCCaptureBuffer);
   if (ret == V4L2_ERROR)
   {
     CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, ret, errno);
@@ -319,60 +311,20 @@ bool FimcConverter::QueueOutputBuffer(int index, V4L2Buffer* m_v4l2MFCCaptureBuf
   return true; // *status contains the queued buffer index
 }
 
-bool FimcConverter::DequeueOutputBuffer(int *status)
+bool FimcConverter::DequeueOutputBuffer(int *status, double *timestamp)
 {
-  // This is the timeout for FIMC to wait for the new frame to produce.
-  // Initially set to 1000/25 - it is a timedifference between frames at 25 fps.
-  // If no frame would be returned the function will proceed further not having a frame to show.
-  // Something like nonblocking output for FIMC.
-  // FIXME: try setting it to 1000
-  int ret = CLinuxV4l2::PollOutput(m_iConverterHandle, 1000/25);
-  if (ret == V4L2_ERROR)
-  {
-    CLog::Log(LOGERROR, "%s::%s - FIMC PollOutput Error", CLASSNAME, __func__);
-    return false;
-  }
-  else
-  if (ret == V4L2_READY)
-  {
-    // Dequeue frame from fimc output
-    int index = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, V4L2_NUM_MAX_PLANES);
-    if (index < 0)
+  // Dequeue frame from fimc output
+  int index = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_USERPTR, timestamp);
+  if (index < 0) {
+    if (errno == EAGAIN) // Dequeue buffer not ready, need more data on input. EAGAIN = 11
     {
-      CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT error dequeue output buffer, got number %d", CLASSNAME, __func__, index);
+      *status = 1;
       return false;
     }
-    *status = index;
-  }
-  else
-  if (ret == V4L2_BUSY)
-  { // buffer is still busy
-    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT Buffer is still busy", CLASSNAME, __func__);
-    return false;
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "%s::%s - FIMC PollOutput error %d, errno %d", CLASSNAME, __func__, ret, errno);
-    return false;
-  }
-  return true; // *status contains the buffer index
-}
-
-bool FimcConverter::DequeueCaptureBuffer(int *status)
-{
-  m_iFIMCdequeuedBufferNumber = CLinuxV4l2::DequeueBuffer(m_iConverterHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
-  if (m_iFIMCdequeuedBufferNumber < 0)
-  {
-    if (errno == EAGAIN)
-    {
-      // Dequeue buffer not ready, need more data on input. EAGAIN = 11
-      *status = 1; // false with status = 1 indicates that we return VC_BUFFER
-      return false;
-    }
-    CLog::Log(LOGERROR, "%s::%s - FIMC CAPTURE error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, m_iFIMCdequeuedBufferNumber, errno);
+    CLog::Log(LOGERROR, "%s::%s - FIMC OUTPUT error dequeue output buffer, got number %d", CLASSNAME, __func__, index);
     *status = 0;
-    return false; // false with status = 0 indicates we return VC_ERROR
+    return false;
   }
-  m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber].bQueue = false;
+  *status = index; // *status contains the buffer index;
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.h
@@ -1,0 +1,71 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDStreamInfo.h"
+
+#include "xbmc/linux/LinuxV4l2.h"
+
+#define FIMC_CAPTURE_BUFFERS_CNT      3 // 2 begins to be slow.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+class FimcConverter
+{
+public:
+  FimcConverter();
+  ~FimcConverter();
+  void Dispose();
+
+  bool OpenDevice();
+  bool RequestBuffers(int buffers);
+  bool SetOutputFormat(struct v4l2_format* fmt);
+  bool SetOutputCrop(struct v4l2_crop* crop);
+  bool SetCaptureFormat(struct v4l2_format* fmt);
+  bool SetCaptureCrop(struct v4l2_crop* crop);
+  bool SetupCaptureBuffers();
+
+  bool StartConverter();
+  bool QueueCaptureBuffer();
+  bool QueueOutputBuffer(int index, V4L2Buffer* v4l2MFCCaptureBuffer, int *status);
+  bool DequeueOutputBuffer(int *status);
+  bool DequeueCaptureBuffer(int *status);
+  V4L2Buffer* GetCurrentCaptureBuffer() { return &m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber]; };
+private:
+  int m_iConverterHandle;
+
+  int m_FIMCCaptureBuffersCount;
+  V4L2Buffer *m_v4l2FIMCCaptureBuffers;
+
+  int m_iFIMCCapturePlane1Size;
+  int m_iFIMCCapturePlane2Size;
+  int m_iFIMCCapturePlane3Size;
+
+  int m_iFIMCdequeuedBufferNumber;
+  bool m_bFIMCStartConverter;
+};
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -21,6 +21,7 @@
  */
 
 #include "DVDStreamInfo.h"
+#include "utils/log.h"
 
 #include "xbmc/linux/LinuxV4l2.h"
 
@@ -29,7 +30,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 #ifdef __cplusplus
 }
 #endif
@@ -38,34 +38,30 @@ class FimcConverter
 {
 public:
   FimcConverter();
-  ~FimcConverter();
+  virtual ~FimcConverter();
   void Dispose();
 
-  bool OpenDevice();
-  bool RequestBuffers(int buffers);
-  bool SetOutputFormat(struct v4l2_format* fmt);
-  bool SetOutputCrop(struct v4l2_crop* crop);
-  bool SetCaptureFormat(struct v4l2_format* fmt);
-  bool SetCaptureCrop(struct v4l2_crop* crop);
-  bool SetupCaptureBuffers();
+  bool        OpenDevice();
+  bool        RequestBuffers(int buffers);
+  bool        SetOutputFormat(struct v4l2_format* fmt);
+  bool        SetOutputCrop(struct v4l2_crop* crop);
+  bool        SetCaptureFormat(struct v4l2_format* fmt);
+  bool        SetCaptureCrop(struct v4l2_crop* crop);
+  bool        SetupCaptureBuffers();
 
-  bool StartConverter();
-  bool QueueCaptureBuffer();
-  bool QueueOutputBuffer(int index, V4L2Buffer* v4l2MFCCaptureBuffer, int *status);
-  bool DequeueOutputBuffer(int *status);
-  bool DequeueCaptureBuffer(int *status);
+  bool        StartConverter();
+  bool        QueueCaptureBuffer();
+  bool        QueueOutputBuffer(int index, V4L2Buffer* v4l2MFCCaptureBuffer, int *status);
+  bool        DequeueOutputBuffer(int *status);
+  bool        DequeueCaptureBuffer(int *status);
   V4L2Buffer* GetCurrentCaptureBuffer() { return &m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber]; };
 private:
-  int m_iConverterHandle;
-
-  int m_FIMCCaptureBuffersCount;
+  int         m_iConverterHandle;
+  int         m_FIMCCaptureBuffersCount;
   V4L2Buffer *m_v4l2FIMCCaptureBuffers;
-
-  int m_iFIMCCapturePlane1Size;
-  int m_iFIMCCapturePlane2Size;
-  int m_iFIMCCapturePlane3Size;
-
-  int m_iFIMCdequeuedBufferNumber;
-  bool m_bFIMCStartConverter;
+  int         m_iFIMCCapturePlane1Size;
+  int         m_iFIMCCapturePlane2Size;
+  int         m_iFIMCCapturePlane3Size;
+  int         m_iFIMCdequeuedBufferNumber;
+  bool        m_bFIMCStartConverter;
 };
-

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/FimcConverter.h
@@ -48,20 +48,14 @@ public:
   bool        SetCaptureFormat(struct v4l2_format* fmt);
   bool        SetCaptureCrop(struct v4l2_crop* crop);
   bool        SetupCaptureBuffers();
+  V4L2Buffer* GetCaptureBuffer(int index);
 
-  bool        StartConverter();
-  bool        QueueCaptureBuffer();
+  bool        QueueCaptureBuffer(int index);
+  bool        DequeueCaptureBuffer(int *status, double *timestamp);
   bool        QueueOutputBuffer(int index, V4L2Buffer* v4l2MFCCaptureBuffer, int *status);
-  bool        DequeueOutputBuffer(int *status);
-  bool        DequeueCaptureBuffer(int *status);
-  V4L2Buffer* GetCurrentCaptureBuffer() { return &m_v4l2FIMCCaptureBuffers[m_iFIMCdequeuedBufferNumber]; };
+  bool        DequeueOutputBuffer(int *status, double *timestamp);
 private:
   int         m_iConverterHandle;
   int         m_FIMCCaptureBuffersCount;
   V4L2Buffer *m_v4l2FIMCCaptureBuffers;
-  int         m_iFIMCCapturePlane1Size;
-  int         m_iFIMCCapturePlane2Size;
-  int         m_iFIMCCapturePlane3Size;
-  int         m_iFIMCdequeuedBufferNumber;
-  bool        m_bFIMCStartConverter;
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
@@ -38,6 +38,12 @@ ifeq (@USE_LIBSTAGEFRIGHT@,1)
 SRCS += DVDVideoCodecStageFright.cpp
 endif
 
+ifeq (@USE_MFC@,1)
+SRCS += MfcDecoder.cpp
+SRCS += FimcConverter.cpp
+SRCS += DVDVideoCodecMfc.cpp
+endif
+
 LIB=Video.a
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -187,7 +187,7 @@ bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints)
     default:
       return false;
   }
-  
+
   fmt.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
   fmt.fmt.pix_mp.plane_fmt[0].sizeimage = STREAM_BUFFER_SIZE;
   fmt.fmt.pix_mp.num_planes = V4L2_NUM_MAX_PLANES;
@@ -197,7 +197,7 @@ bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints)
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT S_FMT failed", CLASSNAME, __func__);
     return false;
   }
-  
+
   return true;
 }
 
@@ -223,7 +223,7 @@ bool MfcDecoder::SetupOutputBuffers()
   {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT REQBUFS failed", CLASSNAME, __func__);
     return false;
-  } 
+  }
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT REQBUFS Number of MFC buffers is %d (requested %d)", CLASSNAME, __func__, m_MFCOutputBuffersCount, MFC_OUTPUT_BUFFERS_CNT);
 
   // Memory Map mfc output buffers
@@ -238,7 +238,7 @@ bool MfcDecoder::SetupOutputBuffers()
     CLog::Log(LOGERROR, "%s::%s - MFC Cannot mmap OUTPUT buffers", CLASSNAME, __func__);
     return false;
   }
-  
+
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Succesfully mmapped %d buffers", CLASSNAME, __func__, m_MFCOutputBuffersCount);
   return true;
 }
@@ -247,7 +247,7 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints)
 {
   unsigned int extraSize = 0;
   uint8_t *extraData = NULL;
-  
+
   m_bVideoConvert = m_converter.Open(hints.codec, (uint8_t *)hints.extradata, hints.extrasize, true);
   if (m_bVideoConvert)
   {
@@ -265,7 +265,7 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints)
       extraData = (uint8_t*)hints.extradata;
     }
   }
-  
+
   // Prepare header
   m_v4l2MFCOutputBuffers[0].iBytesUsed[0] = extraSize;
   fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[0].cPlane[0], extraData, extraSize);
@@ -286,7 +286,7 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints)
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to Stream ON", CLASSNAME, __func__);
     return false;
   }
-  
+
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Stream ON", CLASSNAME, __func__);
   return true;
 }
@@ -316,7 +316,7 @@ bool MfcDecoder::GetCaptureFormat(struct v4l2_format* fmt)
   }
   m_iMFCCapturePlane1Size = fmt->fmt.pix_mp.plane_fmt[0].sizeimage;
   m_iMFCCapturePlane2Size = fmt->fmt.pix_mp.plane_fmt[1].sizeimage;
-  
+
   CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE G_FMT: fmt (%dx%d), plane[0]=%d plane[1]=%d", CLASSNAME, __func__, fmt->fmt.pix_mp.width, fmt->fmt.pix_mp.height, m_iMFCCapturePlane1Size, m_iMFCCapturePlane2Size);
   return true;
 }
@@ -357,7 +357,7 @@ bool MfcDecoder::SetupCaptureBuffers()
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot mmap memory for buffers", CLASSNAME, __func__);
     return false;
   }
-  
+
   for (int n = 0; n < m_MFCCaptureBuffersCount; n++)
   {
     m_v4l2MFCCaptureBuffers[n].iBytesUsed[0] = m_iMFCCapturePlane1Size;
@@ -372,7 +372,7 @@ bool MfcDecoder::SetupCaptureBuffers()
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
     return false;
   }
-  
+
   CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Stream ON", CLASSNAME, __func__);
   return true;
 }
@@ -386,7 +386,7 @@ bool MfcDecoder::DequeueHeader()
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT error dequeue header, got number %d, errno %d", CLASSNAME, __func__, ret, errno);
     return false;
   }
-  
+
   m_v4l2MFCOutputBuffers[ret].bQueue = false;
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT -> %d header", CLASSNAME, __func__, ret);
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -67,8 +67,8 @@ bool MfcDecoder::OpenDevice()
         char target[1024];
         int ret;
 
-        snprintf(sysname, 64, "/sys/class/video4linux/%s", ent->d_name);
-        snprintf(name, 64, "/sys/class/video4linux/%s/name", ent->d_name);
+        snprintf(sysname, sizeof(sysname), "/sys/class/video4linux/%s", ent->d_name);
+        snprintf(name, sizeof(name), "/sys/class/video4linux/%s/name", ent->d_name);
 
         FILE* fp = fopen(name, "r");
         if (fp == NULL)
@@ -95,7 +95,7 @@ bool MfcDecoder::OpenDevice()
         if (p == NULL)
           continue;
 
-        snprintf(devname, 64, "/dev/%s", ++p);
+        snprintf(devname, sizeof(devname), "/dev/%s", ++p);
 
         if (m_iDecoderHandle < 0 && strncmp(drivername, "s5p-mfc-dec", 11) == 0)
         {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -1,0 +1,486 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MfcDecoder.h"
+
+#include <utils/fastmemcpy.h>
+#include <sys/ioctl.h>
+#include <dirent.h>
+
+#define V4L2_CAP_VIDEO_M2M_MPLANE       0x00004000
+
+#define memzero(x) memset(&(x), 0, sizeof (x))
+
+#ifdef CLASSNAME
+#undef CLASSNAME
+#endif
+#define CLASSNAME "MfcDecoder"
+
+MfcDecoder::MfcDecoder() {
+
+  m_iDecoderHandle = -1;
+  m_bVideoConvert = false;
+
+  m_MFCOutputBuffersCount = 0;
+  m_v4l2MFCOutputBuffers = NULL;
+
+  m_MFCCaptureBuffersCount = 0;
+  m_v4l2MFCCaptureBuffers = NULL;
+
+  m_iMFCCapturePlane1Size = -1;
+  m_iMFCCapturePlane2Size = -1;
+
+  memzero(m_v4l2OutputBuffer);
+
+  hasNV12Support = false;
+  hasNV12MTSupport = false;
+}
+
+MfcDecoder::~MfcDecoder() {
+  Dispose();
+}
+
+bool MfcDecoder::OpenDevice() {
+  DIR *dir;
+  struct dirent *ent;
+
+  if ((dir = opendir ("/sys/class/video4linux/")) != NULL) {
+    while ((ent = readdir (dir)) != NULL) {
+      if (strncmp(ent->d_name, "video", 5) == 0) {
+        char *p;
+        char name[64];
+        char devname[64];
+        char sysname[64];
+        char drivername[32];
+        char target[1024];
+        int ret;
+
+        snprintf(sysname, 64, "/sys/class/video4linux/%s", ent->d_name);
+        snprintf(name, 64, "/sys/class/video4linux/%s/name", ent->d_name);
+
+        FILE* fp = fopen(name, "r");
+        if (fgets(drivername, 32, fp) != NULL) {
+          p = strchr(drivername, '\n');
+          if (p != NULL)
+            *p = '\0';
+        } else {
+          fclose(fp);
+          continue;
+        }
+        fclose(fp);
+
+        ret = readlink(sysname, target, sizeof(target));
+        if (ret < 0)
+          continue;
+        target[ret] = '\0';
+        p = strrchr(target, '/');
+        if (p == NULL)
+          continue;
+
+        sprintf(devname, "/dev/%s", ++p);
+
+        if (m_iDecoderHandle < 0 && strncmp(drivername, "s5p-mfc-dec", 11) == 0) {
+          struct v4l2_capability cap;
+          int fd = open(devname, O_RDWR | O_NONBLOCK, 0);
+          if (fd > 0) {
+            memset(&(cap), 0, sizeof (cap));
+            ret = ioctl(fd, VIDIOC_QUERYCAP, &cap);
+            if (ret == 0)
+              if ((cap.capabilities & V4L2_CAP_VIDEO_M2M_MPLANE ||
+                ((cap.capabilities & V4L2_CAP_VIDEO_CAPTURE_MPLANE) && (cap.capabilities & V4L2_CAP_VIDEO_OUTPUT_MPLANE))) &&
+                (cap.capabilities & V4L2_CAP_STREAMING)) {
+                m_iDecoderHandle = fd;
+                CLog::Log(LOGDEBUG, "%s::%s - Found %s %s", CLASSNAME, __func__, drivername, devname);
+              }
+          }
+          if (m_iDecoderHandle < 0)
+            close(fd);
+        }
+        if (m_iDecoderHandle >= 0) {
+          // we now get the supported formats
+          int index = 0;
+          while (true) {
+            struct v4l2_fmtdesc vid_fmtdesc = {};
+            vid_fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+            vid_fmtdesc.index = index++;
+
+            ret = ioctl(m_iDecoderHandle, VIDIOC_ENUM_FMT, &vid_fmtdesc);
+            if (ret != 0)
+              break;
+            CLog::Log(LOGDEBUG, "%s::%s - Decoder format %d: %c%c%c%c (%s)", CLASSNAME, __func__, vid_fmtdesc.index,
+                vid_fmtdesc.pixelformat & 0xFF, (vid_fmtdesc.pixelformat >> 8) & 0xFF,
+                (vid_fmtdesc.pixelformat >> 16) & 0xFF, (vid_fmtdesc.pixelformat >> 24) & 0xFF,
+                vid_fmtdesc.description);
+            //formats.push_back(vid_fmtdesc);
+            if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12MT)
+              hasNV12MTSupport = true;
+            if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12);
+              hasNV12Support = true;
+          }
+          return hasNV12MTSupport||hasNV12Support;
+        }
+      }
+    }
+    closedir (dir);
+  }
+  return false;
+}
+
+bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints) {
+
+  struct v4l2_format fmt = {};
+  switch (hints.codec) {
+    /*
+    case AV_CODEC_TYPE_VC1_RCV:
+      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_VC1_ANNEX_L;
+      m_name = "mfc-vc1rcv";
+      break;
+    */
+    case AV_CODEC_ID_VC1:
+      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_VC1_ANNEX_G;
+      m_name = "mfc-vc1";
+      break;
+    case AV_CODEC_ID_MPEG1VIDEO:
+      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_MPEG1;
+      m_name = "mfc-mpeg1";
+      break;
+    case AV_CODEC_ID_MPEG2VIDEO:
+      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_MPEG2;
+      m_name = "mfc-mpeg2";
+      break;
+    case AV_CODEC_ID_MPEG4:
+      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_MPEG4;
+      m_name = "mfc-mpeg4";
+      break;
+    case AV_CODEC_ID_H263:
+      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_H263;
+      m_name = "mfc-h263";
+      break;
+    case AV_CODEC_ID_H264:
+      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_H264;
+      m_name = "mfc-h264";
+      break;
+    default:
+      return false;
+  }
+  
+  fmt.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
+  fmt.fmt.pix_mp.plane_fmt[0].sizeimage = STREAM_BUFFER_SIZE;
+  fmt.fmt.pix_mp.num_planes = V4L2_NUM_MAX_PLANES;
+
+  if (ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt) != 0) {
+    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT S_FMT failed", CLASSNAME, __func__);
+    return false;
+  }
+  
+  return true;
+}
+
+bool MfcDecoder::RequestBuffers() {
+  // Get mfc needed number of buffers
+  struct v4l2_control ctrl = {};
+  ctrl.id = V4L2_CID_MIN_BUFFERS_FOR_CAPTURE;
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_CTRL, &ctrl)) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to get the number of buffers required", CLASSNAME, __func__);
+    return false;
+  }
+  m_MFCCaptureBuffersCount = ctrl.value + MFC_CAPTURE_EXTRA_BUFFER_CNT;
+  return true;
+}
+
+bool MfcDecoder::SetupOutputBuffers() {
+  
+  // Request mfc output buffers
+  m_MFCOutputBuffersCount = CLinuxV4l2::RequestBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, MFC_OUTPUT_BUFFERS_CNT);
+  if (m_MFCOutputBuffersCount == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT REQBUFS failed", CLASSNAME, __func__);
+    return false;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT REQBUFS Number of MFC buffers is %d (requested %d)", CLASSNAME, __func__, m_MFCOutputBuffersCount, MFC_OUTPUT_BUFFERS_CNT);
+
+  // Memory Map mfc output buffers
+  m_v4l2MFCOutputBuffers = (V4L2Buffer *) calloc(m_MFCOutputBuffersCount, sizeof(V4L2Buffer));
+  if (!m_v4l2MFCOutputBuffers) {
+    CLog::Log(LOGERROR, "%s::%s - MFC cannot allocate OUTPUT buffers in memory", CLASSNAME, __func__);
+    return false;
+  }
+  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCOutputBuffersCount, m_v4l2MFCOutputBuffers, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, false)) {
+    CLog::Log(LOGERROR, "%s::%s - MFC Cannot mmap OUTPUT buffers", CLASSNAME, __func__);
+    return false;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Succesfully mmapped %d buffers", CLASSNAME, __func__, m_MFCOutputBuffersCount);
+  return true;
+}
+
+
+
+bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints) {
+  
+  unsigned int extraSize = 0;
+  uint8_t *extraData = NULL;
+  
+  m_bVideoConvert = m_converter.Open(hints.codec, (uint8_t *)hints.extradata, hints.extrasize, true);
+  if (m_bVideoConvert) {
+    if(m_converter.GetExtraData() != NULL && m_converter.GetExtraSize() > 0) {
+      extraSize = m_converter.GetExtraSize();
+      extraData = m_converter.GetExtraData();
+    }
+  } else {
+    if(hints.extrasize > 0 && hints.extradata != NULL) {
+      extraSize = hints.extrasize;
+      extraData = (uint8_t*)hints.extradata;
+    }
+  }
+  
+  // Prepare header
+  m_v4l2MFCOutputBuffers[0].iBytesUsed[0] = extraSize;
+  fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[0].cPlane[0], extraData, extraSize);
+
+  // Queue header to mfc output queue
+  int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCOutputBuffers[0].iNumPlanes, 0, &m_v4l2MFCOutputBuffers[0]);
+  if (ret == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - MFC Error queuing header", CLASSNAME, __func__);
+    return false;
+  }
+  m_v4l2MFCOutputBuffers[ret].bQueue = true;
+  CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT <- %d header of size %d", CLASSNAME, __func__, ret, extraSize);
+
+  // STREAMON on mfc OUTPUT
+  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMON)) {
+    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to Stream ON", CLASSNAME, __func__);
+    return false;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Stream ON", CLASSNAME, __func__);
+  return true;
+}
+
+bool MfcDecoder::SetCaptureFormat() {
+  struct v4l2_format fmt = {};
+  fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_NV12M;
+  int ret = ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt);
+  if (ret != 0) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE S_FMT Failed on CAPTURE", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE S_FMT 0x%x",  CLASSNAME, __func__, fmt.fmt.pix_mp.pixelformat);
+  return true;
+}
+
+bool MfcDecoder::GetCaptureFormat(struct v4l2_format* fmt) {
+
+  fmt->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_FMT, fmt)) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_FMT Failed", CLASSNAME, __func__);
+    return false;
+  }
+  m_iMFCCapturePlane1Size = fmt->fmt.pix_mp.plane_fmt[0].sizeimage;
+  m_iMFCCapturePlane2Size = fmt->fmt.pix_mp.plane_fmt[1].sizeimage;
+  
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE G_FMT: fmt (%dx%d), plane[0]=%d plane[1]=%d", CLASSNAME, __func__, fmt->fmt.pix_mp.width, fmt->fmt.pix_mp.height, m_iMFCCapturePlane1Size, m_iMFCCapturePlane2Size);
+  return true;
+}
+
+bool MfcDecoder::GetCaptureCrop(struct v4l2_crop* crop) {
+  
+  crop->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_CROP, crop)) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_CROP Failed to get crop information", CLASSNAME, __func__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE G_CROP (%dx%d)", CLASSNAME, __func__, crop->c.width, crop->c.height);
+  return true;
+}
+
+bool MfcDecoder::SetupCaptureBuffers() {
+  
+  // Request mfc capture buffers
+  m_MFCCaptureBuffersCount = CLinuxV4l2::RequestBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_MFCCaptureBuffersCount);
+  if (m_MFCCaptureBuffersCount == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE REQBUFS failed", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE REQBUFS Number of buffers is %d (extra %d)", CLASSNAME, __func__, m_MFCCaptureBuffersCount, MFC_CAPTURE_EXTRA_BUFFER_CNT);
+
+  // Allocate, Memory Map and queue mfc capture buffers
+  m_v4l2MFCCaptureBuffers = (V4L2Buffer *)calloc(m_MFCCaptureBuffersCount, sizeof(V4L2Buffer));
+  if (!m_v4l2MFCCaptureBuffers) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot allocate memory for buffers", CLASSNAME, __func__);
+    return false;
+  }
+  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true)) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot mmap memory for buffers", CLASSNAME, __func__);
+    return false;
+  }
+  
+  for (int n = 0; n < m_MFCCaptureBuffersCount; n++) {
+    m_v4l2MFCCaptureBuffers[n].iBytesUsed[0] = m_iMFCCapturePlane1Size;
+    m_v4l2MFCCaptureBuffers[n].iBytesUsed[1] = m_iMFCCapturePlane2Size;
+    m_v4l2MFCCaptureBuffers[n].bQueue = true;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Succesfully allocated, mmapped and queued %d buffers", CLASSNAME, __func__, m_MFCCaptureBuffersCount);
+
+  // STREAMON on mfc CAPTURE
+  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON)) {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
+    return false;
+  }
+  
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Stream ON", CLASSNAME, __func__);
+  return true;
+}
+
+bool MfcDecoder::DequeueHeader() {
+  
+  // Dequeue header from MFC, we don't need it anymore
+  int ret = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
+  if (ret < 0) {
+    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT error dequeue header, got number %d, errno %d", CLASSNAME, __func__, ret, errno);
+    return false;
+  }
+  
+  m_v4l2MFCOutputBuffers[ret].bQueue = false;
+  CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT -> %d header", CLASSNAME, __func__, ret);
+
+  CLog::Log(LOGNOTICE, "%s::%s - MFC Setup succesfull, start streaming", CLASSNAME, __func__);
+  return true;
+}
+
+void MfcDecoder::Dispose() {
+  CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for buffers", CLASSNAME, __func__);
+  if (m_v4l2MFCOutputBuffers)
+    m_v4l2MFCOutputBuffers = CLinuxV4l2::FreeBuffers(m_MFCOutputBuffersCount, m_v4l2MFCOutputBuffers);
+  if (m_v4l2MFCCaptureBuffers)
+    m_v4l2MFCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers);
+  CLog::Log(LOGDEBUG, "%s::%s - Closing MFC device", CLASSNAME, __func__);
+  if (m_iDecoderHandle >= 0) {
+    if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Stream OFF", CLASSNAME, __func__);
+    if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Stream OFF", CLASSNAME, __func__);
+    close(m_iDecoderHandle);
+  }
+  m_MFCOutputBuffersCount = 0;
+  m_v4l2MFCOutputBuffers = NULL;
+  m_MFCCaptureBuffersCount = 0;
+  m_v4l2MFCCaptureBuffers = NULL;
+  m_iDecoderHandle = -1;
+}
+
+bool MfcDecoder::DequeueOutputBuffer(int *result) {
+  int ret = CLinuxV4l2::PollOutput(m_iDecoderHandle, 1000); // POLLIN - Capture, POLLOUT - Output
+  if (ret == V4L2_ERROR) {
+    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT PollOutput Error", CLASSNAME, __func__);
+    *result = VC_ERROR;
+    return false;
+  } else if (ret == V4L2_READY) {
+    int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
+    if (index < 0) {
+      CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, index, errno);
+      *result = VC_ERROR;
+      return false;
+    }
+    m_v4l2MFCOutputBuffers[index].bQueue = false;
+    *result = index;
+  } else if (ret == V4L2_BUSY) { // buffer is still busy
+    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT All buffers are queued and busy, no space for new frame to decode. Very broken situation.", CLASSNAME, __func__);
+    // FIXME This should be handled as abnormal situation that should be addressed, otherwise decoding will stuck here forever
+    *result = VC_FLUSHED;
+    return false;
+  } else {
+    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT\e[0m PollOutput error %d, errno %d", CLASSNAME, __func__, ret, errno);
+    *result = VC_ERROR;
+    return false;
+  }
+  return true; // *result contains the buffer index
+}
+
+bool MfcDecoder::SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes) {
+
+  if (m_bVideoConvert) {
+    m_converter.Convert(demuxer_content, demuxer_bytes);
+    demuxer_bytes = m_converter.GetConvertSize();
+    demuxer_content = m_converter.GetConvertBuffer();
+  }
+
+  if (demuxer_bytes < m_v4l2MFCOutputBuffers[index].iSize[0]) {
+    fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[index].cPlane[0], demuxer_content, demuxer_bytes);
+    m_v4l2MFCOutputBuffers[index].iBytesUsed[0] = demuxer_bytes;
+
+    int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCOutputBuffers[index].iNumPlanes, index, &m_v4l2MFCOutputBuffers[index]);
+    if (ret == V4L2_ERROR) {
+      CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, index, errno);
+      return false;
+    }
+    m_v4l2MFCOutputBuffers[index].bQueue = true;
+  } else {
+    CLog::Log(LOGERROR, "%s::%s - Packet to big for streambuffer", CLASSNAME, __func__);
+    return false;
+  }
+  return true;
+}
+
+bool MfcDecoder::GetFirstDecodedCaptureBuffer(int *index) {
+  if (m_MFCDecodedCaptureBuffers.empty())
+    return false;
+  *index = m_MFCDecodedCaptureBuffers.front();
+  return true;
+}
+
+bool MfcDecoder::DequeueDecodedFrame(int *result) {
+  // Dequeue decoded frame
+  int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
+  if (index < 0) {
+    if (errno == EAGAIN) {
+      // Buffer is still busy, queue more
+      *result = VC_BUFFER;
+      return false;
+    }
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, index, errno);
+    *result = VC_ERROR;
+    return false;
+  }
+  m_v4l2MFCCaptureBuffers[index].bQueue = false;
+  *result = index;
+  return true; // *result contains the buffer index
+}
+
+bool MfcDecoder::QueueOutputBuffer(int index) {
+  // Queue dequeued from FIMC OUPUT frame back to MFC CAPTURE
+  if (&m_v4l2MFCCaptureBuffers[index] && !m_v4l2MFCCaptureBuffers[index].bQueue) {
+    int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCCaptureBuffers[index].iNumPlanes, index, &m_v4l2MFCCaptureBuffers[index]);
+    if (ret < 0) {
+      CLog::Log(LOGERROR, "%s::%s - queue output buffer\n", CLASSNAME, __func__);
+      return false;
+    }
+    m_v4l2MFCCaptureBuffers[index].bQueue = true;
+  }
+  return true;
+}
+
+void MfcDecoder::SetOutputBufferPlanes(int m_iDecodedWidth, int m_iDecodedHeight) {
+  m_v4l2OutputBuffer.cPlane[0] = new BYTE[m_iDecodedWidth * m_iDecodedHeight];
+  m_v4l2OutputBuffer.cPlane[1] = new BYTE[m_iDecodedWidth * (m_iDecodedHeight >> 1)];
+}
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -24,46 +24,41 @@
 #include <sys/ioctl.h>
 #include <dirent.h>
 
-#define V4L2_CAP_VIDEO_M2M_MPLANE       0x00004000
-
-#define memzero(x) memset(&(x), 0, sizeof (x))
-
 #ifdef CLASSNAME
 #undef CLASSNAME
 #endif
 #define CLASSNAME "MfcDecoder"
 
-MfcDecoder::MfcDecoder() {
-
+MfcDecoder::MfcDecoder()
+{
   m_iDecoderHandle = -1;
+  hasNV12Support = false;
   m_bVideoConvert = false;
-
   m_MFCOutputBuffersCount = 0;
   m_v4l2MFCOutputBuffers = NULL;
-
   m_MFCCaptureBuffersCount = 0;
   m_v4l2MFCCaptureBuffers = NULL;
-
   m_iMFCCapturePlane1Size = -1;
   m_iMFCCapturePlane2Size = -1;
-
-  memzero(m_v4l2OutputBuffer);
-
-  hasNV12Support = false;
-  hasNV12MTSupport = false;
+  memset(&(m_v4l2OutputBuffer), 0, sizeof (m_v4l2OutputBuffer));
 }
 
-MfcDecoder::~MfcDecoder() {
+MfcDecoder::~MfcDecoder()
+{
   Dispose();
 }
 
-bool MfcDecoder::OpenDevice() {
+bool MfcDecoder::OpenDevice()
+{
   DIR *dir;
   struct dirent *ent;
 
-  if ((dir = opendir ("/sys/class/video4linux/")) != NULL) {
-    while ((ent = readdir (dir)) != NULL) {
-      if (strncmp(ent->d_name, "video", 5) == 0) {
+  if ((dir = opendir ("/sys/class/video4linux/")) != NULL)
+  {
+    while ((ent = readdir (dir)) != NULL)
+    {
+      if (strncmp(ent->d_name, "video", 5) == 0)
+      {
         char *p;
         char name[64];
         char devname[64];
@@ -76,11 +71,17 @@ bool MfcDecoder::OpenDevice() {
         snprintf(name, 64, "/sys/class/video4linux/%s/name", ent->d_name);
 
         FILE* fp = fopen(name, "r");
-        if (fgets(drivername, 32, fp) != NULL) {
+        if (fp == NULL)
+          continue;
+
+        if (fgets(drivername, 32, fp) != NULL)
+        {
           p = strchr(drivername, '\n');
           if (p != NULL)
             *p = '\0';
-        } else {
+        }
+        else
+        {
           fclose(fp);
           continue;
         }
@@ -94,18 +95,21 @@ bool MfcDecoder::OpenDevice() {
         if (p == NULL)
           continue;
 
-        sprintf(devname, "/dev/%s", ++p);
+        snprintf(devname, 64, "/dev/%s", ++p);
 
-        if (m_iDecoderHandle < 0 && strncmp(drivername, "s5p-mfc-dec", 11) == 0) {
+        if (m_iDecoderHandle < 0 && strncmp(drivername, "s5p-mfc-dec", 11) == 0)
+        {
           struct v4l2_capability cap;
           int fd = open(devname, O_RDWR | O_NONBLOCK, 0);
-          if (fd > 0) {
+          if (fd > 0)
+          {
             memset(&(cap), 0, sizeof (cap));
             ret = ioctl(fd, VIDIOC_QUERYCAP, &cap);
             if (ret == 0)
               if ((cap.capabilities & V4L2_CAP_VIDEO_M2M_MPLANE ||
                 ((cap.capabilities & V4L2_CAP_VIDEO_CAPTURE_MPLANE) && (cap.capabilities & V4L2_CAP_VIDEO_OUTPUT_MPLANE))) &&
-                (cap.capabilities & V4L2_CAP_STREAMING)) {
+                (cap.capabilities & V4L2_CAP_STREAMING))
+              {
                 m_iDecoderHandle = fd;
                 CLog::Log(LOGDEBUG, "%s::%s - Found %s %s", CLASSNAME, __func__, drivername, devname);
               }
@@ -113,28 +117,10 @@ bool MfcDecoder::OpenDevice() {
           if (m_iDecoderHandle < 0)
             close(fd);
         }
-        if (m_iDecoderHandle >= 0) {
-          // we now get the supported formats
-          int index = 0;
-          while (true) {
-            struct v4l2_fmtdesc vid_fmtdesc = {};
-            vid_fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-            vid_fmtdesc.index = index++;
-
-            ret = ioctl(m_iDecoderHandle, VIDIOC_ENUM_FMT, &vid_fmtdesc);
-            if (ret != 0)
-              break;
-            CLog::Log(LOGDEBUG, "%s::%s - Decoder format %d: %c%c%c%c (%s)", CLASSNAME, __func__, vid_fmtdesc.index,
-                vid_fmtdesc.pixelformat & 0xFF, (vid_fmtdesc.pixelformat >> 8) & 0xFF,
-                (vid_fmtdesc.pixelformat >> 16) & 0xFF, (vid_fmtdesc.pixelformat >> 24) & 0xFF,
-                vid_fmtdesc.description);
-            //formats.push_back(vid_fmtdesc);
-            if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12MT)
-              hasNV12MTSupport = true;
-            if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12)
-              hasNV12Support = true;
-          }
-          return hasNV12MTSupport||hasNV12Support;
+        if (m_iDecoderHandle >= 0)
+        {
+          // MFC should at least support NV12MT format
+          return HasNV12MTSupport();
         }
       }
     }
@@ -143,16 +129,37 @@ bool MfcDecoder::OpenDevice() {
   return false;
 }
 
-bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints) {
+bool MfcDecoder::HasNV12MTSupport()
+{
+  // we enumerate all the supported formats looking for NV12MT and NV12
+  int index = 0;
+  bool hasNV12MTSupport = false;
+  while (true)
+  {
+    struct v4l2_fmtdesc vid_fmtdesc = {};
+    vid_fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+    vid_fmtdesc.index = index++;
 
-  struct v4l2_format fmt = {};
-  switch (hints.codec) {
-    /*
-    case AV_CODEC_TYPE_VC1_RCV:
-      fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_VC1_ANNEX_L;
-      m_name = "mfc-vc1rcv";
+    ret = ioctl(m_iDecoderHandle, VIDIOC_ENUM_FMT, &vid_fmtdesc);
+    if (ret != 0)
       break;
-    */
+    CLog::Log(LOGDEBUG, "%s::%s - Decoder format %d: %c%c%c%c (%s)", CLASSNAME, __func__, vid_fmtdesc.index,
+        vid_fmtdesc.pixelformat & 0xFF, (vid_fmtdesc.pixelformat >> 8) & 0xFF,
+        (vid_fmtdesc.pixelformat >> 16) & 0xFF, (vid_fmtdesc.pixelformat >> 24) & 0xFF,
+        vid_fmtdesc.description);
+    if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12MT)
+      hasNV12MTSupport = true;
+    if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12)
+      m_hasNV12Support = true;
+  }
+  return hasNV12MTSupport;
+}
+
+bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints)
+{
+  struct v4l2_format fmt = {};
+  switch (hints.codec)
+  {
     case AV_CODEC_ID_VC1:
       fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_VC1_ANNEX_G;
       m_name = "mfc-vc1";
@@ -185,7 +192,8 @@ bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints) {
   fmt.fmt.pix_mp.plane_fmt[0].sizeimage = STREAM_BUFFER_SIZE;
   fmt.fmt.pix_mp.num_planes = V4L2_NUM_MAX_PLANES;
 
-  if (ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt) != 0) {
+  if (ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt) != 0)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT S_FMT failed", CLASSNAME, __func__);
     return false;
   }
@@ -193,11 +201,13 @@ bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints) {
   return true;
 }
 
-bool MfcDecoder::RequestBuffers() {
+bool MfcDecoder::RequestBuffers()
+{
   // Get mfc needed number of buffers
   struct v4l2_control ctrl = {};
   ctrl.id = V4L2_CID_MIN_BUFFERS_FOR_CAPTURE;
-  if (ioctl(m_iDecoderHandle, VIDIOC_G_CTRL, &ctrl)) {
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_CTRL, &ctrl))
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to get the number of buffers required", CLASSNAME, __func__);
     return false;
   }
@@ -205,24 +215,26 @@ bool MfcDecoder::RequestBuffers() {
   return true;
 }
 
-bool MfcDecoder::SetupOutputBuffers() {
-  
+bool MfcDecoder::SetupOutputBuffers()
+{
   // Request mfc output buffers
   m_MFCOutputBuffersCount = CLinuxV4l2::RequestBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, MFC_OUTPUT_BUFFERS_CNT);
-  if (m_MFCOutputBuffersCount == V4L2_ERROR) {
+  if (m_MFCOutputBuffersCount == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT REQBUFS failed", CLASSNAME, __func__);
     return false;
-  }
-  
+  } 
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT REQBUFS Number of MFC buffers is %d (requested %d)", CLASSNAME, __func__, m_MFCOutputBuffersCount, MFC_OUTPUT_BUFFERS_CNT);
 
   // Memory Map mfc output buffers
   m_v4l2MFCOutputBuffers = (V4L2Buffer *) calloc(m_MFCOutputBuffersCount, sizeof(V4L2Buffer));
-  if (!m_v4l2MFCOutputBuffers) {
+  if (!m_v4l2MFCOutputBuffers)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC cannot allocate OUTPUT buffers in memory", CLASSNAME, __func__);
     return false;
   }
-  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCOutputBuffersCount, m_v4l2MFCOutputBuffers, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, false)) {
+  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCOutputBuffersCount, m_v4l2MFCOutputBuffers, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, false))
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC Cannot mmap OUTPUT buffers", CLASSNAME, __func__);
     return false;
   }
@@ -231,21 +243,24 @@ bool MfcDecoder::SetupOutputBuffers() {
   return true;
 }
 
-
-
-bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints) {
-  
+bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints)
+{
   unsigned int extraSize = 0;
   uint8_t *extraData = NULL;
   
   m_bVideoConvert = m_converter.Open(hints.codec, (uint8_t *)hints.extradata, hints.extrasize, true);
-  if (m_bVideoConvert) {
-    if(m_converter.GetExtraData() != NULL && m_converter.GetExtraSize() > 0) {
+  if (m_bVideoConvert)
+  {
+    if(m_converter.GetExtraData() != NULL && m_converter.GetExtraSize() > 0)
+    {
       extraSize = m_converter.GetExtraSize();
       extraData = m_converter.GetExtraData();
     }
-  } else {
-    if(hints.extrasize > 0 && hints.extradata != NULL) {
+  }
+  else
+  {
+    if(hints.extrasize > 0 && hints.extradata != NULL)
+    {
       extraSize = hints.extrasize;
       extraData = (uint8_t*)hints.extradata;
     }
@@ -257,7 +272,8 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints) {
 
   // Queue header to mfc output queue
   int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCOutputBuffers[0].iNumPlanes, 0, &m_v4l2MFCOutputBuffers[0]);
-  if (ret == V4L2_ERROR) {
+  if (ret == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC Error queuing header", CLASSNAME, __func__);
     return false;
   }
@@ -265,7 +281,8 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints) {
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT <- %d header of size %d", CLASSNAME, __func__, ret, extraSize);
 
   // STREAMON on mfc OUTPUT
-  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMON)) {
+  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMON))
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to Stream ON", CLASSNAME, __func__);
     return false;
   }
@@ -274,12 +291,14 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints) {
   return true;
 }
 
-bool MfcDecoder::SetCaptureFormat() {
+bool MfcDecoder::SetCaptureFormat()
+{
   struct v4l2_format fmt = {};
   fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
   fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_NV12M;
   int ret = ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt);
-  if (ret != 0) {
+  if (ret != 0)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE S_FMT Failed on CAPTURE", CLASSNAME, __func__);
     return false;
   }
@@ -287,10 +306,11 @@ bool MfcDecoder::SetCaptureFormat() {
   return true;
 }
 
-bool MfcDecoder::GetCaptureFormat(struct v4l2_format* fmt) {
-
+bool MfcDecoder::GetCaptureFormat(struct v4l2_format* fmt)
+{
   fmt->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  if (ioctl(m_iDecoderHandle, VIDIOC_G_FMT, fmt)) {
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_FMT, fmt))
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_FMT Failed", CLASSNAME, __func__);
     return false;
   }
@@ -301,10 +321,11 @@ bool MfcDecoder::GetCaptureFormat(struct v4l2_format* fmt) {
   return true;
 }
 
-bool MfcDecoder::GetCaptureCrop(struct v4l2_crop* crop) {
-  
+bool MfcDecoder::GetCaptureCrop(struct v4l2_crop* crop)
+{
   crop->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  if (ioctl(m_iDecoderHandle, VIDIOC_G_CROP, crop)) {
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_CROP, crop))
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_CROP Failed to get crop information", CLASSNAME, __func__);
     return false;
   }
@@ -313,11 +334,12 @@ bool MfcDecoder::GetCaptureCrop(struct v4l2_crop* crop) {
   return true;
 }
 
-bool MfcDecoder::SetupCaptureBuffers() {
-  
+bool MfcDecoder::SetupCaptureBuffers()
+{
   // Request mfc capture buffers
   m_MFCCaptureBuffersCount = CLinuxV4l2::RequestBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_MFCCaptureBuffersCount);
-  if (m_MFCCaptureBuffersCount == V4L2_ERROR) {
+  if (m_MFCCaptureBuffersCount == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE REQBUFS failed", CLASSNAME, __func__);
     return false;
   }
@@ -325,16 +347,19 @@ bool MfcDecoder::SetupCaptureBuffers() {
 
   // Allocate, Memory Map and queue mfc capture buffers
   m_v4l2MFCCaptureBuffers = (V4L2Buffer *)calloc(m_MFCCaptureBuffersCount, sizeof(V4L2Buffer));
-  if (!m_v4l2MFCCaptureBuffers) {
+  if (!m_v4l2MFCCaptureBuffers)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot allocate memory for buffers", CLASSNAME, __func__);
     return false;
   }
-  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true)) {
+  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true))
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot mmap memory for buffers", CLASSNAME, __func__);
     return false;
   }
   
-  for (int n = 0; n < m_MFCCaptureBuffersCount; n++) {
+  for (int n = 0; n < m_MFCCaptureBuffersCount; n++)
+  {
     m_v4l2MFCCaptureBuffers[n].iBytesUsed[0] = m_iMFCCapturePlane1Size;
     m_v4l2MFCCaptureBuffers[n].iBytesUsed[1] = m_iMFCCapturePlane2Size;
     m_v4l2MFCCaptureBuffers[n].bQueue = true;
@@ -342,7 +367,8 @@ bool MfcDecoder::SetupCaptureBuffers() {
   CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Succesfully allocated, mmapped and queued %d buffers", CLASSNAME, __func__, m_MFCCaptureBuffersCount);
 
   // STREAMON on mfc CAPTURE
-  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON)) {
+  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON))
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
     return false;
   }
@@ -351,11 +377,12 @@ bool MfcDecoder::SetupCaptureBuffers() {
   return true;
 }
 
-bool MfcDecoder::DequeueHeader() {
-  
+bool MfcDecoder::DequeueHeader()
+{
   // Dequeue header from MFC, we don't need it anymore
   int ret = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
-  if (ret < 0) {
+  if (ret < 0)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT error dequeue header, got number %d, errno %d", CLASSNAME, __func__, ret, errno);
     return false;
   }
@@ -367,14 +394,38 @@ bool MfcDecoder::DequeueHeader() {
   return true;
 }
 
-void MfcDecoder::Dispose() {
+bool MfcDecoder::IsOutputBufferEmpty(int index)
+{
+  return (m_v4l2MFCOutputBuffers != NULL && index < m_MFCOutputBuffersCount ) ? !m_v4l2MFCOutputBuffers[index].bQueue : false;
+}
+
+void MfcDecoder::SetCaptureBufferEmpty(int index)
+{
+  if (m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount)
+    m_v4l2MFCCaptureBuffers[index].bQueue = false;
+}
+
+void MfcDecoder::SetCaptureBufferBusy(int index)
+{
+  if (m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount)
+    m_v4l2MFCCaptureBuffers[index].bQueue = true;
+}
+
+V4L2Buffer* GetCaptureBuffer(int index)
+{
+  return m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount ? &(m_v4l2MFCCaptureBuffers[index]) : NULL;
+}
+
+void MfcDecoder::Dispose()
+{
   CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for buffers", CLASSNAME, __func__);
   if (m_v4l2MFCOutputBuffers)
     m_v4l2MFCOutputBuffers = CLinuxV4l2::FreeBuffers(m_MFCOutputBuffersCount, m_v4l2MFCOutputBuffers);
   if (m_v4l2MFCCaptureBuffers)
     m_v4l2MFCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers);
   CLog::Log(LOGDEBUG, "%s::%s - Closing MFC device", CLASSNAME, __func__);
-  if (m_iDecoderHandle >= 0) {
+  if (m_iDecoderHandle >= 0)
+  {
     if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
       CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Stream OFF", CLASSNAME, __func__);
     if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
@@ -388,27 +439,38 @@ void MfcDecoder::Dispose() {
   m_iDecoderHandle = -1;
 }
 
-bool MfcDecoder::DequeueOutputBuffer(int *result) {
+bool MfcDecoder::DequeueOutputBuffer(int *result)
+{
   int ret = CLinuxV4l2::PollOutput(m_iDecoderHandle, 1000); // POLLIN - Capture, POLLOUT - Output
-  if (ret == V4L2_ERROR) {
+  if (ret == V4L2_ERROR)
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT PollOutput Error", CLASSNAME, __func__);
     *result = VC_ERROR;
     return false;
-  } else if (ret == V4L2_READY) {
+  }
+  else
+  if (ret == V4L2_READY)
+  {
     int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
-    if (index < 0) {
+    if (index < 0)
+    {
       CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, index, errno);
       *result = VC_ERROR;
       return false;
     }
     m_v4l2MFCOutputBuffers[index].bQueue = false;
     *result = index;
-  } else if (ret == V4L2_BUSY) { // buffer is still busy
+  }
+  else
+  if (ret == V4L2_BUSY)
+  { // buffer is still busy
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT All buffers are queued and busy, no space for new frame to decode. Very broken situation.", CLASSNAME, __func__);
-    // FIXME This should be handled as abnormal situation that should be addressed, otherwise decoding will stuck here forever
+    // FIXME This should be handled as abnormal situation that should be addressed, otherwise decoding could stuck here forever
     *result = VC_FLUSHED;
     return false;
-  } else {
+  }
+  else
+  {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT\e[0m PollOutput error %d, errno %d", CLASSNAME, __func__, ret, errno);
     *result = VC_ERROR;
     return false;
@@ -416,43 +478,64 @@ bool MfcDecoder::DequeueOutputBuffer(int *result) {
   return true; // *result contains the buffer index
 }
 
-bool MfcDecoder::SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes) {
-
-  if (m_bVideoConvert) {
+bool MfcDecoder::SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes)
+{
+  if (m_bVideoConvert)
+  {
     m_converter.Convert(demuxer_content, demuxer_bytes);
     demuxer_bytes = m_converter.GetConvertSize();
     demuxer_content = m_converter.GetConvertBuffer();
   }
 
-  if (demuxer_bytes < m_v4l2MFCOutputBuffers[index].iSize[0]) {
+  if (demuxer_bytes < m_v4l2MFCOutputBuffers[index].iSize[0])
+  {
     fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[index].cPlane[0], demuxer_content, demuxer_bytes);
     m_v4l2MFCOutputBuffers[index].iBytesUsed[0] = demuxer_bytes;
 
     int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCOutputBuffers[index].iNumPlanes, index, &m_v4l2MFCOutputBuffers[index]);
-    if (ret == V4L2_ERROR) {
+    if (ret == V4L2_ERROR)
+    {
       CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, index, errno);
       return false;
     }
     m_v4l2MFCOutputBuffers[index].bQueue = true;
-  } else {
+  }
+  else
+  {
     CLog::Log(LOGERROR, "%s::%s - Packet to big for streambuffer", CLASSNAME, __func__);
     return false;
   }
   return true;
 }
 
-bool MfcDecoder::GetFirstDecodedCaptureBuffer(int *index) {
+void MfcDecoder::AddDecodedCaptureBuffer(int index)
+{
+  if (m_MFCDecodedCaptureBuffers != NULL)
+    m_MFCDecodedCaptureBuffers.push(index);
+}
+
+void MfcDecoder::RemoveFirstDecodedCaptureBuffer()
+{
+  if (m_MFCDecodedCaptureBuffers != NULL && !m_MFCDecodedCaptureBuffers.empty())
+    m_MFCDecodedCaptureBuffers.pop();
+}
+
+bool MfcDecoder::GetFirstDecodedCaptureBuffer(int *index)
+{
   if (m_MFCDecodedCaptureBuffers.empty())
     return false;
   *index = m_MFCDecodedCaptureBuffers.front();
-  return true;
+  return true; // *index contains the first decoded buffer
 }
 
-bool MfcDecoder::DequeueDecodedFrame(int *result) {
+bool MfcDecoder::DequeueDecodedFrame(int *result)
+{
   // Dequeue decoded frame
   int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
-  if (index < 0) {
-    if (errno == EAGAIN) {
+  if (index < 0)
+  {
+    if (errno == EAGAIN)
+    {
       // Buffer is still busy, queue more
       *result = VC_BUFFER;
       return false;
@@ -466,11 +549,14 @@ bool MfcDecoder::DequeueDecodedFrame(int *result) {
   return true; // *result contains the buffer index
 }
 
-bool MfcDecoder::QueueOutputBuffer(int index) {
+bool MfcDecoder::QueueOutputBuffer(int index)
+{
   // Queue dequeued from FIMC OUPUT frame back to MFC CAPTURE
-  if (&m_v4l2MFCCaptureBuffers[index] && !m_v4l2MFCCaptureBuffers[index].bQueue) {
+  if (&m_v4l2MFCCaptureBuffers[index] && !m_v4l2MFCCaptureBuffers[index].bQueue)
+  {
     int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCCaptureBuffers[index].iNumPlanes, index, &m_v4l2MFCCaptureBuffers[index]);
-    if (ret < 0) {
+    if (ret < 0)
+    {
       CLog::Log(LOGERROR, "%s::%s - queue output buffer\n", CLASSNAME, __func__);
       return false;
     }
@@ -479,8 +565,8 @@ bool MfcDecoder::QueueOutputBuffer(int index) {
   return true;
 }
 
+// FIXME: maybe this function can be better integrated in DVDVideoCodecMfc...
 void MfcDecoder::SetOutputBufferPlanes(int m_iDecodedWidth, int m_iDecodedHeight) {
   m_v4l2OutputBuffer.cPlane[0] = new BYTE[m_iDecodedWidth * m_iDecodedHeight];
   m_v4l2OutputBuffer.cPlane[1] = new BYTE[m_iDecodedWidth * (m_iDecodedHeight >> 1)];
 }
-

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -131,7 +131,7 @@ bool MfcDecoder::OpenDevice() {
             //formats.push_back(vid_fmtdesc);
             if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12MT)
               hasNV12MTSupport = true;
-            if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12);
+            if (vid_fmtdesc.pixelformat == V4L2_PIX_FMT_NV12)
               hasNV12Support = true;
           }
           return hasNV12MTSupport||hasNV12Support;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -32,7 +32,7 @@
 MfcDecoder::MfcDecoder()
 {
   m_iDecoderHandle = -1;
-  hasNV12Support = false;
+  m_hasNV12Support = false;
   m_bVideoConvert = false;
   m_MFCOutputBuffersCount = 0;
   m_v4l2MFCOutputBuffers = NULL;
@@ -133,6 +133,7 @@ bool MfcDecoder::HasNV12MTSupport()
 {
   // we enumerate all the supported formats looking for NV12MT and NV12
   int index = 0;
+  int ret   = -1;
   bool hasNV12MTSupport = false;
   while (true)
   {
@@ -411,7 +412,7 @@ void MfcDecoder::SetCaptureBufferBusy(int index)
     m_v4l2MFCCaptureBuffers[index].bQueue = true;
 }
 
-V4L2Buffer* GetCaptureBuffer(int index)
+V4L2Buffer* MfcDecoder::GetCaptureBuffer(int index)
 {
   return m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount ? &(m_v4l2MFCCaptureBuffers[index]) : NULL;
 }
@@ -510,13 +511,12 @@ bool MfcDecoder::SendBuffer(int index, uint8_t* demuxer_content, int demuxer_byt
 
 void MfcDecoder::AddDecodedCaptureBuffer(int index)
 {
-  if (m_MFCDecodedCaptureBuffers != NULL)
-    m_MFCDecodedCaptureBuffers.push(index);
+  m_MFCDecodedCaptureBuffers.push(index);
 }
 
 void MfcDecoder::RemoveFirstDecodedCaptureBuffer()
 {
-  if (m_MFCDecodedCaptureBuffers != NULL && !m_MFCDecodedCaptureBuffers.empty())
+  if (!m_MFCDecodedCaptureBuffers.empty())
     m_MFCDecodedCaptureBuffers.pop();
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -191,7 +191,7 @@ bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints)
 
   fmt.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
   fmt.fmt.pix_mp.plane_fmt[0].sizeimage = STREAM_BUFFER_SIZE;
-  fmt.fmt.pix_mp.num_planes = V4L2_NUM_MAX_PLANES;
+  fmt.fmt.pix_mp.num_planes = 1; // should be V4L2_NUM_MAX_PLANES, set to 1 to fix weird MFC5 firmware bug
 
   if (ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt) != 0)
   {
@@ -241,6 +241,11 @@ bool MfcDecoder::SetupOutputBuffers()
   }
 
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Succesfully mmapped %d buffers", CLASSNAME, __func__, m_MFCOutputBuffersCount);
+
+  for (int n = 0; n < m_MFCOutputBuffersCount; n++) {
+    m_v4l2MFCOutputBuffers[n].iNumPlanes = 1; // set to 1 to fix weird MFC5 firmware bug
+  }
+
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -447,7 +447,7 @@ void MfcDecoder::Dispose()
 
 bool MfcDecoder::DequeueOutputBuffer(int *result)
 {
-  int ret = CLinuxV4l2::PollOutput(m_iDecoderHandle, 1000); // POLLIN - Capture, POLLOUT - Output
+  int ret = CLinuxV4l2::PollOutput(m_iDecoderHandle, 1000/20); // POLLIN - Capture, POLLOUT - Output
   if (ret == V4L2_ERROR)
   {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT PollOutput Error", CLASSNAME, __func__);
@@ -471,8 +471,9 @@ bool MfcDecoder::DequeueOutputBuffer(int *result)
   if (ret == V4L2_BUSY)
   { // buffer is still busy
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT All buffers are queued and busy, no space for new frame to decode. Very broken situation.", CLASSNAME, __func__);
-    // FIXME This should be handled as abnormal situation that should be addressed, otherwise decoding could stuck here forever
-    *result = VC_FLUSHED;
+    // FIXME VC_FLUSHED should be handled as abnormal situation that should be addressed, otherwise decoding could stuck here forever
+    // FIXME VC_PICTURE causes the current encoded frame to be lost in void; this has to be fully reworked to queues storing all frames coming in
+    *result = VC_PICTURE;
     return false;
   }
   else

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.cpp
@@ -31,21 +31,41 @@
 
 MfcDecoder::MfcDecoder()
 {
-  m_iDecoderHandle = -1;
-  m_hasNV12Support = false;
-  m_bVideoConvert = false;
-  m_MFCOutputBuffersCount = 0;
-  m_v4l2MFCOutputBuffers = NULL;
+  m_iDecoderHandle         = -1;
+  m_hasNV12Support         = false;
+  m_bVideoConvert          = false;
+  m_MFCOutputBuffersCount  = 0;
+  m_v4l2MFCOutputBuffers   = NULL;
   m_MFCCaptureBuffersCount = 0;
-  m_v4l2MFCCaptureBuffers = NULL;
-  m_iMFCCapturePlane1Size = -1;
-  m_iMFCCapturePlane2Size = -1;
-  memset(&(m_v4l2OutputBuffer), 0, sizeof (m_v4l2OutputBuffer));
+  m_v4l2MFCCaptureBuffers  = NULL;
 }
 
 MfcDecoder::~MfcDecoder()
 {
   Dispose();
+}
+
+void MfcDecoder::Dispose()
+{
+  CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for buffers", CLASSNAME, __func__);
+  if (m_v4l2MFCOutputBuffers)
+    m_v4l2MFCOutputBuffers = CLinuxV4l2::FreeBuffers(m_MFCOutputBuffersCount, m_v4l2MFCOutputBuffers);
+  if (m_v4l2MFCCaptureBuffers)
+    m_v4l2MFCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers);
+  CLog::Log(LOGDEBUG, "%s::%s - Closing MFC device", CLASSNAME, __func__);
+  if (m_iDecoderHandle >= 0)
+  {
+    if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Stream OFF", CLASSNAME, __func__);
+    if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
+      CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Stream OFF", CLASSNAME, __func__);
+    close(m_iDecoderHandle);
+  }
+  m_MFCOutputBuffersCount = 0;
+  m_v4l2MFCOutputBuffers = NULL;
+  m_MFCCaptureBuffersCount = 0;
+  m_v4l2MFCCaptureBuffers = NULL;
+  m_iDecoderHandle = -1;
 }
 
 bool MfcDecoder::OpenDevice()
@@ -191,7 +211,6 @@ bool MfcDecoder::SetupOutputFormat(CDVDStreamInfo &hints)
 
   fmt.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
   fmt.fmt.pix_mp.plane_fmt[0].sizeimage = STREAM_BUFFER_SIZE;
-  fmt.fmt.pix_mp.num_planes = 1; // should be V4L2_NUM_MAX_PLANES, set to 1 to fix weird MFC5 firmware bug
 
   if (ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt) != 0)
   {
@@ -212,7 +231,88 @@ bool MfcDecoder::RequestBuffers()
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to get the number of buffers required", CLASSNAME, __func__);
     return false;
   }
-  m_MFCCaptureBuffersCount = ctrl.value + MFC_CAPTURE_EXTRA_BUFFER_CNT;
+  m_MFCCaptureBuffersCount = (ctrl.value + MFC_CAPTURE_EXTRA_BUFFER_CNT) % 24; // we cap to 24 buffers
+  return true;
+}
+
+bool MfcDecoder::SetupCaptureBuffers()
+{
+  // Request mfc capture buffers
+  m_MFCCaptureBuffersCount = CLinuxV4l2::RequestBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_MFCCaptureBuffersCount);
+  if (m_MFCCaptureBuffersCount == V4L2_ERROR)
+  {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE REQBUFS failed", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE REQBUFS Number of buffers is %d (extra %d)", CLASSNAME, __func__, m_MFCCaptureBuffersCount, MFC_CAPTURE_EXTRA_BUFFER_CNT);
+
+  // Allocate, Memory Map and queue mfc capture buffers
+  m_v4l2MFCCaptureBuffers = (V4L2Buffer *)calloc(m_MFCCaptureBuffersCount, sizeof(V4L2Buffer));
+  if (!m_v4l2MFCCaptureBuffers)
+  {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot allocate memory for buffers", CLASSNAME, __func__);
+    return false;
+  }
+  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true))
+  {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot mmap memory for buffers", CLASSNAME, __func__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Succesfully allocated, mmapped and queued %d buffers", CLASSNAME, __func__, m_MFCCaptureBuffersCount);
+
+  // STREAMON on mfc CAPTURE
+  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON))
+  {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Stream ON", CLASSNAME, __func__);
+  return true;
+}
+
+V4L2Buffer* MfcDecoder::GetCaptureBuffer(int index)
+{
+  return m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount ? &(m_v4l2MFCCaptureBuffers[index]) : NULL;
+}
+
+bool MfcDecoder::SetCaptureFormat()
+{
+  struct v4l2_format fmt = {};
+  fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_NV12M;
+  int ret = ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt);
+  if (ret != 0)
+  {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE S_FMT Failed on CAPTURE", CLASSNAME, __func__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE S_FMT 0x%x",  CLASSNAME, __func__, fmt.fmt.pix_mp.pixelformat);
+  return true;
+}
+
+bool MfcDecoder::GetCaptureFormat(struct v4l2_format* fmt)
+{
+  fmt->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_FMT, fmt))
+  {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_FMT Failed", CLASSNAME, __func__);
+    return false;
+  }
+  return true;
+}
+
+bool MfcDecoder::GetCaptureCrop(struct v4l2_crop* crop)
+{
+  crop->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  if (ioctl(m_iDecoderHandle, VIDIOC_G_CROP, crop))
+  {
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_CROP Failed to get crop information", CLASSNAME, __func__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE G_CROP (%dx%d)", CLASSNAME, __func__, crop->c.width, crop->c.height);
   return true;
 }
 
@@ -239,14 +339,13 @@ bool MfcDecoder::SetupOutputBuffers()
     CLog::Log(LOGERROR, "%s::%s - MFC Cannot mmap OUTPUT buffers", CLASSNAME, __func__);
     return false;
   }
-
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Succesfully mmapped %d buffers", CLASSNAME, __func__, m_MFCOutputBuffersCount);
-
-  for (int n = 0; n < m_MFCOutputBuffersCount; n++) {
-    m_v4l2MFCOutputBuffers[n].iNumPlanes = 1; // set to 1 to fix weird MFC5 firmware bug
-  }
-
   return true;
+}
+
+bool MfcDecoder::IsOutputBufferEmpty(int index)
+{
+  return (m_v4l2MFCOutputBuffers != NULL && index < m_MFCOutputBuffersCount ) ? !m_v4l2MFCOutputBuffers[index].bQueue : false;
 }
 
 bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints)
@@ -277,13 +376,12 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints)
   fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[0].cPlane[0], extraData, extraSize);
 
   // Queue header to mfc output queue
-  int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCOutputBuffers[0].iNumPlanes, 0, &m_v4l2MFCOutputBuffers[0]);
+  int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, &m_v4l2MFCOutputBuffers[0]);
   if (ret == V4L2_ERROR)
   {
     CLog::Log(LOGERROR, "%s::%s - MFC Error queuing header", CLASSNAME, __func__);
     return false;
   }
-  m_v4l2MFCOutputBuffers[ret].bQueue = true;
   CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT <- %d header of size %d", CLASSNAME, __func__, ret, extraSize);
 
   // STREAMON on mfc OUTPUT
@@ -297,157 +395,40 @@ bool MfcDecoder::QueueHeader(CDVDStreamInfo &hints)
   return true;
 }
 
-bool MfcDecoder::SetCaptureFormat()
+bool MfcDecoder::SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes, double pts)
 {
-  struct v4l2_format fmt = {};
-  fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_NV12M;
-  int ret = ioctl(m_iDecoderHandle, VIDIOC_S_FMT, &fmt);
-  if (ret != 0)
+  if (m_bVideoConvert)
   {
-    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE S_FMT Failed on CAPTURE", CLASSNAME, __func__);
+    m_converter.Convert(demuxer_content, demuxer_bytes);
+    demuxer_bytes = m_converter.GetConvertSize();
+    demuxer_content = m_converter.GetConvertBuffer();
+  }
+
+  if (demuxer_bytes < m_v4l2MFCOutputBuffers[index].iSize[0])
+  {
+    fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[index].cPlane[0], demuxer_content, demuxer_bytes);
+    m_v4l2MFCOutputBuffers[index].iBytesUsed[0] = demuxer_bytes;
+    m_v4l2MFCOutputBuffers[index].timestamp = pts;
+
+    int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, &m_v4l2MFCOutputBuffers[index]);
+    if (ret == V4L2_ERROR)
+    {
+      CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, index, errno);
+      return false;
+    }
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s::%s - Packet to big for streambuffer", CLASSNAME, __func__);
     return false;
   }
-  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE S_FMT 0x%x",  CLASSNAME, __func__, fmt.fmt.pix_mp.pixelformat);
   return true;
 }
 
-bool MfcDecoder::GetCaptureFormat(struct v4l2_format* fmt)
+bool MfcDecoder::DequeueOutputBuffer(int *result, double *timestamp)
 {
-  fmt->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  if (ioctl(m_iDecoderHandle, VIDIOC_G_FMT, fmt))
-  {
-    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_FMT Failed", CLASSNAME, __func__);
-    return false;
-  }
-  m_iMFCCapturePlane1Size = fmt->fmt.pix_mp.plane_fmt[0].sizeimage;
-  m_iMFCCapturePlane2Size = fmt->fmt.pix_mp.plane_fmt[1].sizeimage;
-
-  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE G_FMT: fmt (%dx%d), plane[0]=%d plane[1]=%d", CLASSNAME, __func__, fmt->fmt.pix_mp.width, fmt->fmt.pix_mp.height, m_iMFCCapturePlane1Size, m_iMFCCapturePlane2Size);
-  return true;
-}
-
-bool MfcDecoder::GetCaptureCrop(struct v4l2_crop* crop)
-{
-  crop->type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  if (ioctl(m_iDecoderHandle, VIDIOC_G_CROP, crop))
-  {
-    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE G_CROP Failed to get crop information", CLASSNAME, __func__);
-    return false;
-  }
-
-  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE G_CROP (%dx%d)", CLASSNAME, __func__, crop->c.width, crop->c.height);
-  return true;
-}
-
-bool MfcDecoder::SetupCaptureBuffers()
-{
-  // Request mfc capture buffers
-  m_MFCCaptureBuffersCount = CLinuxV4l2::RequestBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_MFCCaptureBuffersCount);
-  if (m_MFCCaptureBuffersCount == V4L2_ERROR)
-  {
-    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE REQBUFS failed", CLASSNAME, __func__);
-    return false;
-  }
-  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE REQBUFS Number of buffers is %d (extra %d)", CLASSNAME, __func__, m_MFCCaptureBuffersCount, MFC_CAPTURE_EXTRA_BUFFER_CNT);
-
-  // Allocate, Memory Map and queue mfc capture buffers
-  m_v4l2MFCCaptureBuffers = (V4L2Buffer *)calloc(m_MFCCaptureBuffersCount, sizeof(V4L2Buffer));
-  if (!m_v4l2MFCCaptureBuffers)
-  {
-    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot allocate memory for buffers", CLASSNAME, __func__);
-    return false;
-  }
-  if (!CLinuxV4l2::MmapBuffers(m_iDecoderHandle, m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, true))
-  {
-    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Cannot mmap memory for buffers", CLASSNAME, __func__);
-    return false;
-  }
-
-  for (int n = 0; n < m_MFCCaptureBuffersCount; n++)
-  {
-    m_v4l2MFCCaptureBuffers[n].iBytesUsed[0] = m_iMFCCapturePlane1Size;
-    m_v4l2MFCCaptureBuffers[n].iBytesUsed[1] = m_iMFCCapturePlane2Size;
-    m_v4l2MFCCaptureBuffers[n].bQueue = true;
-  }
-  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Succesfully allocated, mmapped and queued %d buffers", CLASSNAME, __func__, m_MFCCaptureBuffersCount);
-
-  // STREAMON on mfc CAPTURE
-  if (!CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMON))
-  {
-    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to Stream ON", CLASSNAME, __func__);
-    return false;
-  }
-
-  CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Stream ON", CLASSNAME, __func__);
-  return true;
-}
-
-bool MfcDecoder::DequeueHeader()
-{
-  // Dequeue header from MFC, we don't need it anymore
-  int ret = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
-  if (ret < 0)
-  {
-    CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT error dequeue header, got number %d, errno %d", CLASSNAME, __func__, ret, errno);
-    return false;
-  }
-
-  m_v4l2MFCOutputBuffers[ret].bQueue = false;
-  CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT -> %d header", CLASSNAME, __func__, ret);
-
-  CLog::Log(LOGNOTICE, "%s::%s - MFC Setup succesfull, start streaming", CLASSNAME, __func__);
-  return true;
-}
-
-bool MfcDecoder::IsOutputBufferEmpty(int index)
-{
-  return (m_v4l2MFCOutputBuffers != NULL && index < m_MFCOutputBuffersCount ) ? !m_v4l2MFCOutputBuffers[index].bQueue : false;
-}
-
-void MfcDecoder::SetCaptureBufferEmpty(int index)
-{
-  if (m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount)
-    m_v4l2MFCCaptureBuffers[index].bQueue = false;
-}
-
-void MfcDecoder::SetCaptureBufferBusy(int index)
-{
-  if (m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount)
-    m_v4l2MFCCaptureBuffers[index].bQueue = true;
-}
-
-V4L2Buffer* MfcDecoder::GetCaptureBuffer(int index)
-{
-  return m_v4l2MFCCaptureBuffers != NULL && index < m_MFCCaptureBuffersCount ? &(m_v4l2MFCCaptureBuffers[index]) : NULL;
-}
-
-void MfcDecoder::Dispose()
-{
-  CLog::Log(LOGDEBUG, "%s::%s - Freeing memory allocated for buffers", CLASSNAME, __func__);
-  if (m_v4l2MFCOutputBuffers)
-    m_v4l2MFCOutputBuffers = CLinuxV4l2::FreeBuffers(m_MFCOutputBuffersCount, m_v4l2MFCOutputBuffers);
-  if (m_v4l2MFCCaptureBuffers)
-    m_v4l2MFCCaptureBuffers = CLinuxV4l2::FreeBuffers(m_MFCCaptureBuffersCount, m_v4l2MFCCaptureBuffers);
-  CLog::Log(LOGDEBUG, "%s::%s - Closing MFC device", CLASSNAME, __func__);
-  if (m_iDecoderHandle >= 0)
-  {
-    if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, VIDIOC_STREAMOFF))
-      CLog::Log(LOGDEBUG, "%s::%s - MFC OUTPUT Stream OFF", CLASSNAME, __func__);
-    if (CLinuxV4l2::StreamOn(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, VIDIOC_STREAMOFF))
-      CLog::Log(LOGDEBUG, "%s::%s - MFC CAPTURE Stream OFF", CLASSNAME, __func__);
-    close(m_iDecoderHandle);
-  }
-  m_MFCOutputBuffersCount = 0;
-  m_v4l2MFCOutputBuffers = NULL;
-  m_MFCCaptureBuffersCount = 0;
-  m_v4l2MFCCaptureBuffers = NULL;
-  m_iDecoderHandle = -1;
-}
-
-bool MfcDecoder::DequeueOutputBuffer(int *result)
-{
-  int ret = CLinuxV4l2::PollOutput(m_iDecoderHandle, 1000/20); // POLLIN - Capture, POLLOUT - Output
+  int ret = CLinuxV4l2::PollOutput(m_iDecoderHandle, 1000/3); // Wait up to 1/3 (3 fps) sec for buffer to become available to recieve new encoded frame
+                                                              // POLLIN - Capture, POLLOUT - Output
   if (ret == V4L2_ERROR)
   {
     CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT PollOutput Error", CLASSNAME, __func__);
@@ -457,11 +438,11 @@ bool MfcDecoder::DequeueOutputBuffer(int *result)
   else
   if (ret == V4L2_READY)
   {
-    int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
+    int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, timestamp);
     if (index < 0)
     {
       CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, index, errno);
-      *result = VC_ERROR;
+      *result = VC_FLUSHED;
       return false;
     }
     m_v4l2MFCOutputBuffers[index].bQueue = false;
@@ -485,59 +466,22 @@ bool MfcDecoder::DequeueOutputBuffer(int *result)
   return true; // *result contains the buffer index
 }
 
-bool MfcDecoder::SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes)
+bool MfcDecoder::QueueCaptureBuffer(int index)
 {
-  if (m_bVideoConvert)
+  // Queue dequeued from FIMC OUPUT frame back to MFC CAPTURE
+  int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, &m_v4l2MFCCaptureBuffers[index]);
+  if (ret == V4L2_ERROR)
   {
-    m_converter.Convert(demuxer_content, demuxer_bytes);
-    demuxer_bytes = m_converter.GetConvertSize();
-    demuxer_content = m_converter.GetConvertBuffer();
-  }
-
-  if (demuxer_bytes < m_v4l2MFCOutputBuffers[index].iSize[0])
-  {
-    fast_memcpy((uint8_t *)m_v4l2MFCOutputBuffers[index].cPlane[0], demuxer_content, demuxer_bytes);
-    m_v4l2MFCOutputBuffers[index].iBytesUsed[0] = demuxer_bytes;
-
-    int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCOutputBuffers[index].iNumPlanes, index, &m_v4l2MFCOutputBuffers[index]);
-    if (ret == V4L2_ERROR)
-    {
-      CLog::Log(LOGERROR, "%s::%s - MFC OUTPUT Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, index, errno);
-      return false;
-    }
-    m_v4l2MFCOutputBuffers[index].bQueue = true;
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "%s::%s - Packet to big for streambuffer", CLASSNAME, __func__);
+    CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE Failed to queue buffer with index %d, errno %d", CLASSNAME, __func__, index, errno);
     return false;
   }
   return true;
 }
 
-void MfcDecoder::AddDecodedCaptureBuffer(int index)
-{
-  m_MFCDecodedCaptureBuffers.push(index);
-}
-
-void MfcDecoder::RemoveFirstDecodedCaptureBuffer()
-{
-  if (!m_MFCDecodedCaptureBuffers.empty())
-    m_MFCDecodedCaptureBuffers.pop();
-}
-
-bool MfcDecoder::GetFirstDecodedCaptureBuffer(int *index)
-{
-  if (m_MFCDecodedCaptureBuffers.empty())
-    return false;
-  *index = m_MFCDecodedCaptureBuffers.front();
-  return true; // *index contains the first decoded buffer
-}
-
-bool MfcDecoder::DequeueDecodedFrame(int *result)
+bool MfcDecoder::DequeueDecodedFrame(int *result, double *timestamp)
 {
   // Dequeue decoded frame
-  int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, V4L2_NUM_MAX_PLANES);
+  int index = CLinuxV4l2::DequeueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, timestamp);
   if (index < 0)
   {
     if (errno == EAGAIN)
@@ -547,32 +491,11 @@ bool MfcDecoder::DequeueDecodedFrame(int *result)
       return false;
     }
     CLog::Log(LOGERROR, "%s::%s - MFC CAPTURE error dequeue output buffer, got number %d, errno %d", CLASSNAME, __func__, index, errno);
-    *result = VC_ERROR;
+    *result = VC_FLUSHED;
     return false;
   }
   m_v4l2MFCCaptureBuffers[index].bQueue = false;
+  m_v4l2MFCCaptureBuffers[index].timestamp = *timestamp;
   *result = index;
   return true; // *result contains the buffer index
-}
-
-bool MfcDecoder::QueueOutputBuffer(int index)
-{
-  // Queue dequeued from FIMC OUPUT frame back to MFC CAPTURE
-  if (&m_v4l2MFCCaptureBuffers[index] && !m_v4l2MFCCaptureBuffers[index].bQueue)
-  {
-    int ret = CLinuxV4l2::QueueBuffer(m_iDecoderHandle, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE, V4L2_MEMORY_MMAP, m_v4l2MFCCaptureBuffers[index].iNumPlanes, index, &m_v4l2MFCCaptureBuffers[index]);
-    if (ret < 0)
-    {
-      CLog::Log(LOGERROR, "%s::%s - queue output buffer\n", CLASSNAME, __func__);
-      return false;
-    }
-    m_v4l2MFCCaptureBuffers[index].bQueue = true;
-  }
-  return true;
-}
-
-// FIXME: maybe this function can be better integrated in DVDVideoCodecMfc...
-void MfcDecoder::SetOutputBufferPlanes(int m_iDecodedWidth, int m_iDecodedHeight) {
-  m_v4l2OutputBuffer.cPlane[0] = new BYTE[m_iDecodedWidth * m_iDecodedHeight];
-  m_v4l2OutputBuffer.cPlane[1] = new BYTE[m_iDecodedWidth * (m_iDecodedHeight >> 1)];
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
@@ -1,0 +1,105 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDVideoCodec.h"
+#include "DVDStreamInfo.h"
+#include "utils/BitstreamConverter.h"
+#include <vector>
+#include <queue>
+
+#include "xbmc/linux/LinuxV4l2.h"
+
+#define STREAM_BUFFER_SIZE            1572864	//compressed frame size. 1080p mpeg4 10Mb/s can be un to 786k in size, so this is to make sure frame fits into buffer
+#define MFC_OUTPUT_BUFFERS_CNT        2		//1 doesn't work at all
+#define MFC_CAPTURE_EXTRA_BUFFER_CNT  3		//these are extra buffers, better keep their count as big as going to be simultaneous dequeued buffers number
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+class MfcDecoder
+{
+public:
+  MfcDecoder();
+  ~MfcDecoder();
+  void Dispose();
+
+  bool OpenDevice();
+  //const std::vector<struct v4l2_fmtdesc>& GetFormats() { return formats; };
+  bool HasNV12Support() { return hasNV12Support; };
+  bool SetupOutputFormat(CDVDStreamInfo &hints);
+  const char* GetOutputName() { return m_name.c_str(); };
+  bool RequestBuffers();
+  int  GetCaptureBuffersCount() { return m_MFCCaptureBuffersCount; };
+  int  GetOutputBuffersCount()  { return m_MFCOutputBuffersCount;  };
+  bool SetupOutputBuffers();
+  bool QueueHeader(CDVDStreamInfo &hints);
+  bool GetCaptureFormat(struct v4l2_format* fmt);
+  bool GetCaptureCrop(struct v4l2_crop* crop);
+  bool SetupCaptureBuffers();
+  bool DequeueHeader();
+
+  bool IsOutputBufferEmpty(int index) { return !m_v4l2MFCOutputBuffers[index].bQueue; };
+  void SetCaptureBufferEmpty(int index) { m_v4l2MFCCaptureBuffers[index].bQueue = false; };
+  void SetCaptureBufferBusy(int index)  { m_v4l2MFCCaptureBuffers[index].bQueue = true;  };
+  V4L2Buffer* GetCaptureBuffer(int index) { return &(m_v4l2MFCCaptureBuffers[index]); };
+  bool DequeueOutputBuffer(int *result);
+  bool SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes);
+  bool DequeueDecodedFrame(int *result);
+  bool QueueOutputBuffer(int index);
+
+  void AddDecodedCaptureBuffer(int index) { m_MFCDecodedCaptureBuffers.push(index); };
+  bool GetFirstDecodedCaptureBuffer(int *index);
+  void RemoveFirstDecodedCaptureBuffer() { m_MFCDecodedCaptureBuffers.pop(); };
+  bool SetCaptureFormat();
+
+  void SetOutputBufferPlanes(int m_iDecodedWidth, int m_iDecodedHeight);
+
+private:
+  std::string m_name;
+  int m_iDecoderHandle;
+  bool hasNV12Support;
+  bool hasNV12MTSupport;
+  //std::vector<struct v4l2_fmtdesc> formats;
+
+  int m_MFCOutputBuffersCount;
+  V4L2Buffer *m_v4l2MFCOutputBuffers;
+
+  int m_MFCCaptureBuffersCount;
+  V4L2Buffer *m_v4l2MFCCaptureBuffers;
+
+  int m_iMFCCapturePlane1Size;
+  int m_iMFCCapturePlane2Size;
+
+  bool m_bVideoConvert;
+  CBitstreamConverter m_converter;
+
+  std::queue<int> m_MFCDecodedCaptureBuffers;
+
+  V4L2Buffer m_v4l2OutputBuffer;
+
+};
+

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
@@ -22,20 +22,20 @@
 
 #include "DVDVideoCodec.h"
 #include "DVDStreamInfo.h"
+#include "utils/log.h"
 #include "utils/BitstreamConverter.h"
 #include <vector>
 #include <queue>
 
 #include "xbmc/linux/LinuxV4l2.h"
 
-#define STREAM_BUFFER_SIZE            1572864	//compressed frame size. 1080p mpeg4 10Mb/s can be un to 786k in size, so this is to make sure frame fits into buffer
-#define MFC_OUTPUT_BUFFERS_CNT        2		//1 doesn't work at all
-#define MFC_CAPTURE_EXTRA_BUFFER_CNT  3		//these are extra buffers, better keep their count as big as going to be simultaneous dequeued buffers number
+#define STREAM_BUFFER_SIZE              1572864 // compressed frame size. 1080p mpeg4 10Mb/s can be up to 786k in size, so this is to make sure frame fits into buffer
+#define MFC_OUTPUT_BUFFERS_CNT          2       // 1 doesn't work at all
+#define MFC_CAPTURE_EXTRA_BUFFER_CNT    3       // these are extra buffers, better keep their count as big as going to be simultaneous dequeued buffers number
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 #ifdef __cplusplus
 }
 #endif
@@ -44,62 +44,52 @@ class MfcDecoder
 {
 public:
   MfcDecoder();
-  ~MfcDecoder();
+  virtual ~MfcDecoder();
   void Dispose();
 
-  bool OpenDevice();
-  //const std::vector<struct v4l2_fmtdesc>& GetFormats() { return formats; };
-  bool HasNV12Support() { return hasNV12Support; };
-  bool SetupOutputFormat(CDVDStreamInfo &hints);
-  const char* GetOutputName() { return m_name.c_str(); };
-  bool RequestBuffers();
-  int  GetCaptureBuffersCount() { return m_MFCCaptureBuffersCount; };
-  int  GetOutputBuffersCount()  { return m_MFCOutputBuffersCount;  };
-  bool SetupOutputBuffers();
-  bool QueueHeader(CDVDStreamInfo &hints);
-  bool GetCaptureFormat(struct v4l2_format* fmt);
-  bool GetCaptureCrop(struct v4l2_crop* crop);
-  bool SetupCaptureBuffers();
-  bool DequeueHeader();
+  bool        OpenDevice();
+  bool        HasNV12MTSupport();                            // NV12MT support should be in all MFC versions
+  bool        HasNV12Support() { return m_hasNV12Support; }; // NV12 support should be starting with MFC6
+  bool        SetupOutputFormat(CDVDStreamInfo &hints);
+  const char* GetOutputName() { return m_name != NULL ? m_name.c_str() : ""; };
+  bool        RequestBuffers();
+  int         GetCaptureBuffersCount() { return m_MFCCaptureBuffersCount; };
+  int         GetOutputBuffersCount()  { return m_MFCOutputBuffersCount;  };
+  bool        SetupOutputBuffers();
+  bool        QueueHeader(CDVDStreamInfo &hints);
+  bool        GetCaptureFormat(struct v4l2_format* fmt);
+  bool        GetCaptureCrop(struct v4l2_crop* crop);
+  bool        SetupCaptureBuffers();
+  bool        DequeueHeader();
+  bool        IsOutputBufferEmpty(int index);
+  void        SetCaptureBufferEmpty(int index);
+  void        SetCaptureBufferBusy(int index);
+  V4L2Buffer* GetCaptureBuffer(int index);
 
-  bool IsOutputBufferEmpty(int index) { return !m_v4l2MFCOutputBuffers[index].bQueue; };
-  void SetCaptureBufferEmpty(int index) { m_v4l2MFCCaptureBuffers[index].bQueue = false; };
-  void SetCaptureBufferBusy(int index)  { m_v4l2MFCCaptureBuffers[index].bQueue = true;  };
-  V4L2Buffer* GetCaptureBuffer(int index) { return &(m_v4l2MFCCaptureBuffers[index]); };
-  bool DequeueOutputBuffer(int *result);
-  bool SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes);
-  bool DequeueDecodedFrame(int *result);
-  bool QueueOutputBuffer(int index);
+  bool        DequeueOutputBuffer(int *result);
+  bool        SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes);
+  bool        DequeueDecodedFrame(int *result);
+  bool        QueueOutputBuffer(int index);
 
-  void AddDecodedCaptureBuffer(int index) { m_MFCDecodedCaptureBuffers.push(index); };
-  bool GetFirstDecodedCaptureBuffer(int *index);
-  void RemoveFirstDecodedCaptureBuffer() { m_MFCDecodedCaptureBuffers.pop(); };
-  bool SetCaptureFormat();
+  void        AddDecodedCaptureBuffer(int index);
+  bool        GetFirstDecodedCaptureBuffer(int *index);
+  void        RemoveFirstDecodedCaptureBuffer();
+  bool        SetCaptureFormat();
 
-  void SetOutputBufferPlanes(int m_iDecodedWidth, int m_iDecodedHeight);
+  void        SetOutputBufferPlanes(int m_iDecodedWidth, int m_iDecodedHeight);
 
 private:
-  std::string m_name;
-  int m_iDecoderHandle;
-  bool hasNV12Support;
-  bool hasNV12MTSupport;
-  //std::vector<struct v4l2_fmtdesc> formats;
-
-  int m_MFCOutputBuffersCount;
-  V4L2Buffer *m_v4l2MFCOutputBuffers;
-
-  int m_MFCCaptureBuffersCount;
-  V4L2Buffer *m_v4l2MFCCaptureBuffers;
-
-  int m_iMFCCapturePlane1Size;
-  int m_iMFCCapturePlane2Size;
-
-  bool m_bVideoConvert;
+  int                 m_iDecoderHandle;
+  bool                m_hasNV12Support;
+  std::string         m_name;
+  int                 m_MFCOutputBuffersCount;
+  V4L2Buffer         *m_v4l2MFCOutputBuffers;
+  int                 m_MFCCaptureBuffersCount;
+  V4L2Buffer         *m_v4l2MFCCaptureBuffers;
+  int                 m_iMFCCapturePlane1Size;
+  int                 m_iMFCCapturePlane2Size;
+  bool                m_bVideoConvert;
   CBitstreamConverter m_converter;
-
-  std::queue<int> m_MFCDecodedCaptureBuffers;
-
-  V4L2Buffer m_v4l2OutputBuffer;
-
+  V4L2Buffer          m_v4l2OutputBuffer;
+  std::queue<int>     m_MFCDecodedCaptureBuffers;
 };
-

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
@@ -51,7 +51,7 @@ public:
   bool        HasNV12MTSupport();                            // NV12MT support should be in all MFC versions
   bool        HasNV12Support() { return m_hasNV12Support; }; // NV12 support should be starting with MFC6
   bool        SetupOutputFormat(CDVDStreamInfo &hints);
-  const char* GetOutputName() { return m_name != NULL ? m_name.c_str() : ""; };
+  const char* GetOutputName() { return m_name.c_str(); };
   bool        RequestBuffers();
   int         GetCaptureBuffersCount() { return m_MFCCaptureBuffersCount; };
   int         GetOutputBuffersCount()  { return m_MFCOutputBuffersCount;  };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
@@ -29,7 +29,8 @@
 
 #include "xbmc/linux/LinuxV4l2.h"
 
-#define STREAM_BUFFER_SIZE              1572864 // compressed frame size. 1080p mpeg4 10Mb/s can be up to 786k in size, so this is to make sure frame fits into buffer
+#define STREAM_BUFFER_SIZE              1048576 // compressed frame size. 1080p mpeg4 10Mb/s can be up to 786k in size, so this is to make sure frame fits into buffer
+						// for unknown reason, possibly firmware bug, if set to other values, it corrupts adjacent value in the setup data structure for h264 streams
 #define MFC_OUTPUT_BUFFERS_CNT          2       // 1 doesn't work at all
 #define MFC_CAPTURE_EXTRA_BUFFER_CNT    3       // these are extra buffers, better keep their count as big as going to be simultaneous dequeued buffers number
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
@@ -24,8 +24,6 @@
 #include "DVDStreamInfo.h"
 #include "utils/log.h"
 #include "utils/BitstreamConverter.h"
-#include <vector>
-#include <queue>
 
 #include "xbmc/linux/LinuxV4l2.h"
 
@@ -49,48 +47,35 @@ public:
   void Dispose();
 
   bool        OpenDevice();
-  bool        HasNV12MTSupport();                            // NV12MT support should be in all MFC versions
   bool        HasNV12Support() { return m_hasNV12Support; }; // NV12 support should be starting with MFC6
   bool        SetupOutputFormat(CDVDStreamInfo &hints);
   const char* GetOutputName() { return m_name.c_str(); };
   bool        RequestBuffers();
+  bool        SetupCaptureBuffers();
   int         GetCaptureBuffersCount() { return m_MFCCaptureBuffersCount; };
-  int         GetOutputBuffersCount()  { return m_MFCOutputBuffersCount;  };
-  bool        SetupOutputBuffers();
-  bool        QueueHeader(CDVDStreamInfo &hints);
+  V4L2Buffer* GetCaptureBuffer(int index);
+  bool        SetCaptureFormat();
   bool        GetCaptureFormat(struct v4l2_format* fmt);
   bool        GetCaptureCrop(struct v4l2_crop* crop);
-  bool        SetupCaptureBuffers();
-  bool        DequeueHeader();
+  bool        SetupOutputBuffers();
+  int         GetOutputBuffersCount()  { return m_MFCOutputBuffersCount;  };
   bool        IsOutputBufferEmpty(int index);
-  void        SetCaptureBufferEmpty(int index);
-  void        SetCaptureBufferBusy(int index);
-  V4L2Buffer* GetCaptureBuffer(int index);
 
-  bool        DequeueOutputBuffer(int *result);
-  bool        SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes);
-  bool        DequeueDecodedFrame(int *result);
-  bool        QueueOutputBuffer(int index);
-
-  void        AddDecodedCaptureBuffer(int index);
-  bool        GetFirstDecodedCaptureBuffer(int *index);
-  void        RemoveFirstDecodedCaptureBuffer();
-  bool        SetCaptureFormat();
-
-  void        SetOutputBufferPlanes(int m_iDecodedWidth, int m_iDecodedHeight);
+  bool        QueueHeader(CDVDStreamInfo &hints);
+  bool        SendBuffer(int index, uint8_t* demuxer_content, int demuxer_bytes, double pts);
+  bool        DequeueOutputBuffer(int *result, double *timestamp);
+  bool        QueueCaptureBuffer(int index);
+  bool        DequeueDecodedFrame(int *result, double *timestamp);
 
 private:
   int                 m_iDecoderHandle;
+  bool                HasNV12MTSupport();
   bool                m_hasNV12Support;
   std::string         m_name;
   int                 m_MFCOutputBuffersCount;
   V4L2Buffer         *m_v4l2MFCOutputBuffers;
   int                 m_MFCCaptureBuffersCount;
   V4L2Buffer         *m_v4l2MFCCaptureBuffers;
-  int                 m_iMFCCapturePlane1Size;
-  int                 m_iMFCCapturePlane2Size;
   bool                m_bVideoConvert;
   CBitstreamConverter m_converter;
-  V4L2Buffer          m_v4l2OutputBuffer;
-  std::queue<int>     m_MFCDecodedCaptureBuffers;
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MfcDecoder.h
@@ -32,7 +32,7 @@
 #define STREAM_BUFFER_SIZE              1048576 // compressed frame size. 1080p mpeg4 10Mb/s can be up to 786k in size, so this is to make sure frame fits into buffer
 						// for unknown reason, possibly firmware bug, if set to other values, it corrupts adjacent value in the setup data structure for h264 streams
 #define MFC_OUTPUT_BUFFERS_CNT          2       // 1 doesn't work at all
-#define MFC_CAPTURE_EXTRA_BUFFER_CNT    3       // these are extra buffers, better keep their count as big as going to be simultaneous dequeued buffers number
+#define MFC_CAPTURE_EXTRA_BUFFER_CNT    16      // these are extra buffers, better keep their count as big as going to be simultaneous dequeued buffers number
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/linux/LinuxV4l2.cpp
+++ b/xbmc/linux/LinuxV4l2.cpp
@@ -1,0 +1,301 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+#include "LinuxV4l2.h"
+
+#include "xbmc/utils/log.h"
+
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/mman.h>
+#include <linux/media.h>
+
+#ifdef CLASSNAME
+#undef CLASSNAME
+#endif
+#define CLASSNAME "CLinuxV4l2"
+
+CLinuxV4l2::CLinuxV4l2() 
+{
+}
+
+CLinuxV4l2::~CLinuxV4l2()
+{
+}
+
+int CLinuxV4l2::RequestBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int numBuffers)
+{
+  struct v4l2_requestbuffers reqbuf;
+  int ret = 0;
+
+  if(device < 0)
+    return false;
+
+  memset(&reqbuf, 0, sizeof(struct v4l2_requestbuffers));
+
+  reqbuf.type     = type;
+  reqbuf.memory   = memory;
+  reqbuf.count    = numBuffers;
+
+  ret = ioctl(device, VIDIOC_REQBUFS, &reqbuf);
+  if (ret)
+  {
+    CLog::Log(LOGERROR, "%s::%s - Request buffers", CLASSNAME, __func__);
+    return V4L2_ERROR;
+  }
+
+  return reqbuf.count;
+}
+
+bool CLinuxV4l2::StreamOn(int device, enum v4l2_buf_type type, int onoff)
+{
+  int ret = 0;
+  enum v4l2_buf_type setType = type;
+
+  if(device < 0)
+    return false;
+
+  ret = ioctl(device, onoff, &setType);
+  if(ret)
+    return false;
+
+  return true;
+}
+
+bool CLinuxV4l2::MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enum v4l2_buf_type type, enum v4l2_memory memory, bool queue)
+{
+  struct v4l2_buffer buf;
+  struct v4l2_plane planes[V4L2_NUM_MAX_PLANES];
+  int ret;
+  int i, j;
+
+  if(device < 0 || !v4l2Buffers || count == 0)
+    return false;
+
+  for(i = 0; i < count; i++)
+  {
+    memset(&buf, 0, sizeof(struct v4l2_buffer));
+    memset(&planes, 0, sizeof(struct v4l2_plane) * V4L2_NUM_MAX_PLANES);
+    buf.type      = type;
+    buf.memory    = memory;
+    buf.index     = i;
+    buf.m.planes  = planes;
+    buf.length    = V4L2_NUM_MAX_PLANES;
+
+    ret = ioctl(device, VIDIOC_QUERYBUF, &buf);
+    if (ret)
+    {
+      CLog::Log(LOGERROR, "%s::%s - Query buffer", CLASSNAME, __func__);
+      return false;
+    }
+
+    V4L2Buffer *buffer = &v4l2Buffers[i];
+
+    buffer->iNumPlanes = 0;
+    for (j = 0; j < V4L2_NUM_MAX_PLANES; j++) 
+    {
+      //printf("%s::%s - plane %d %d size %d 0x%08x\n", CLASSNAME, __func__, i, j, buf.m.planes[j].length,
+      //    buf.m.planes[j].m.userptr);
+      buffer->iSize[j]       = buf.m.planes[j].length;
+      buffer->iBytesUsed[j]  = buf.m.planes[j].bytesused;
+      if(buffer->iSize[j])
+      {
+        buffer->cPlane[j] = mmap(NULL, buf.m.planes[j].length, PROT_READ | PROT_WRITE,
+                       MAP_SHARED, device, buf.m.planes[j].m.mem_offset);
+        if(buffer->cPlane[j] == MAP_FAILED)
+        {
+          CLog::Log(LOGERROR, "%s::%s - Mmapping buffer", CLASSNAME, __func__);
+          return false;
+        }
+        memset(buffer->cPlane[j], 0, buf.m.planes[j].length);
+        buffer->iNumPlanes++;
+      }
+    }
+    buffer->iIndex = i;
+
+    if(queue)
+    {
+      ret = ioctl(device, VIDIOC_QBUF, &buf);
+      if (ret)
+      {
+        CLog::Log(LOGERROR, "%s::%s - Queue buffer", CLASSNAME, __func__);
+        return false;
+      }
+      buffer->bQueue = true;
+    }
+  }
+
+  return true;
+}
+
+V4L2Buffer *CLinuxV4l2::FreeBuffers(int count, V4L2Buffer *v4l2Buffers)
+{
+  int i, j;
+
+  if(v4l2Buffers != NULL)
+  {
+    for(i = 0; i < count; i++)
+    {
+      V4L2Buffer *buffer = &v4l2Buffers[i];
+
+      for (j = 0; j < buffer->iNumPlanes; j++)
+      {
+        if(buffer->cPlane[j] && buffer->cPlane[j] != MAP_FAILED)
+        {
+          munmap(buffer->cPlane[j], buffer->iSize[j]);
+          CLog::Log(LOGDEBUG, "%s::%s - unmap convert buffer", CLASSNAME, __func__);
+        }
+      }
+    }
+    free(v4l2Buffers);
+  }
+  return NULL;
+}
+
+int CLinuxV4l2::DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int planes)
+{
+  struct v4l2_buffer vbuf;
+  struct v4l2_plane  vplanes[V4L2_NUM_MAX_PLANES];
+  int ret = 0;
+
+  if(device < 0)
+    return V4L2_ERROR;
+
+  memset(&vplanes, 0, sizeof(struct v4l2_plane) * V4L2_NUM_MAX_PLANES);
+  memset(&vbuf, 0, sizeof(struct v4l2_buffer));
+  vbuf.type     = type;
+  vbuf.memory   = memory;
+  vbuf.m.planes = vplanes;
+  vbuf.length   = planes;
+
+  ret = ioctl(device, VIDIOC_DQBUF, &vbuf);
+  if (ret) {
+    if (errno != EAGAIN)
+      CLog::Log(LOGERROR, "%s::%s - Dequeue buffer", CLASSNAME, __func__);
+    return V4L2_ERROR;
+  }
+  
+  return vbuf.index;
+}
+
+int CLinuxV4l2::QueueBuffer(int device, enum v4l2_buf_type type, 
+    enum v4l2_memory memory, int planes, int index, V4L2Buffer *buffer)
+{
+  struct v4l2_buffer vbuf;
+  struct v4l2_plane  vplanes[V4L2_NUM_MAX_PLANES];
+  int ret = 0;
+
+  if(!buffer || device <0)
+    return V4L2_ERROR;
+
+  memset(&vplanes, 0, sizeof(struct v4l2_plane) * V4L2_NUM_MAX_PLANES);
+  memset(&vbuf, 0, sizeof(struct v4l2_buffer));
+  vbuf.type     = type;
+  vbuf.memory   = memory;
+  vbuf.index    = index;
+  vbuf.m.planes = vplanes;
+  vbuf.length   = buffer->iNumPlanes;
+
+  for (int i = 0; i < buffer->iNumPlanes; i++) 
+  {
+    vplanes[i].m.userptr   = (unsigned long)buffer->cPlane[i];
+    vplanes[i].length      = buffer->iSize[i];
+    vplanes[i].bytesused   = buffer->iBytesUsed[i];
+  }
+
+  ret = ioctl(device, VIDIOC_QBUF, &vbuf);
+  if (ret)
+  {
+    CLog::Log(LOGERROR, "%s::%s - Queue buffer", CLASSNAME, __func__);
+    return V4L2_ERROR;
+  }
+  buffer->bQueue = true;
+
+  return index;
+}
+
+int CLinuxV4l2::PollInput(int device, int timeout)
+{
+  int ret = 0;
+  struct pollfd p;
+  p.fd = device;
+  p.events = POLLIN | POLLERR;
+
+  ret = poll(&p, 1, timeout);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "%s::%s - Polling input", CLASSNAME, __func__);
+    return V4L2_ERROR;
+  }
+  else if (ret == 0)
+  {
+    return V4L2_BUSY;
+  }
+
+  return V4L2_READY;
+}
+
+int CLinuxV4l2::PollOutput(int device, int timeout)
+{
+  int ret = 0;
+  struct pollfd p;
+  p.fd = device;
+  p.events = POLLOUT | POLLERR;
+
+  ret = poll(&p, 1, timeout);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "%s::%s - Polling output", CLASSNAME, __func__);
+    return V4L2_ERROR;
+  }
+  else if (ret == 0)
+  {
+    return V4L2_BUSY;
+  }
+
+  return V4L2_READY;
+}
+
+int CLinuxV4l2::SetControllValue(int device, int id, int value)
+{
+  struct v4l2_control control;
+  int ret;
+
+  control.id    = id;
+  control.value = value;
+
+  ret = ioctl(device, VIDIOC_S_CTRL, &control);
+
+  if(ret < 0) 
+  {
+    CLog::Log(LOGERROR, "%s::%s - Set controll if %d value %d\n", CLASSNAME, __func__, id, value);
+    return V4L2_ERROR;
+  }
+
+  return V4L2_OK;
+}

--- a/xbmc/linux/LinuxV4l2.cpp
+++ b/xbmc/linux/LinuxV4l2.cpp
@@ -20,7 +20,7 @@
 
 #include "system.h"
 #if (defined HAVE_CONFIG_H) && (!defined WIN32)
-  #include "config.h"
+#include "config.h"
 #endif
 #include "LinuxV4l2.h"
 

--- a/xbmc/linux/LinuxV4l2.cpp
+++ b/xbmc/linux/LinuxV4l2.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -40,7 +40,7 @@
 #endif
 #define CLASSNAME "CLinuxV4l2"
 
-CLinuxV4l2::CLinuxV4l2() 
+CLinuxV4l2::CLinuxV4l2()
 {
 }
 
@@ -53,7 +53,7 @@ int CLinuxV4l2::RequestBuffer(int device, enum v4l2_buf_type type, enum v4l2_mem
   struct v4l2_requestbuffers reqbuf;
   int ret = 0;
 
-  if(device < 0)
+  if (device < 0)
     return false;
 
   memset(&reqbuf, 0, sizeof(struct v4l2_requestbuffers));
@@ -77,11 +77,11 @@ bool CLinuxV4l2::StreamOn(int device, enum v4l2_buf_type type, int onoff)
   int ret = 0;
   enum v4l2_buf_type setType = type;
 
-  if(device < 0)
+  if (device < 0)
     return false;
 
   ret = ioctl(device, onoff, &setType);
-  if(ret)
+  if (ret)
     return false;
 
   return true;
@@ -94,10 +94,10 @@ bool CLinuxV4l2::MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enu
   int ret;
   int i, j;
 
-  if(device < 0 || !v4l2Buffers || count == 0)
+  if (device < 0 || !v4l2Buffers || count == 0)
     return false;
 
-  for(i = 0; i < count; i++)
+  for (i = 0; i < count; i++)
   {
     memset(&buf, 0, sizeof(struct v4l2_buffer));
     memset(&planes, 0, sizeof(struct v4l2_plane) * V4L2_NUM_MAX_PLANES);
@@ -117,17 +117,17 @@ bool CLinuxV4l2::MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enu
     V4L2Buffer *buffer = &v4l2Buffers[i];
 
     buffer->iNumPlanes = 0;
-    for (j = 0; j < V4L2_NUM_MAX_PLANES; j++) 
+    for (j = 0; j < V4L2_NUM_MAX_PLANES; j++)
     {
       //printf("%s::%s - plane %d %d size %d 0x%08x\n", CLASSNAME, __func__, i, j, buf.m.planes[j].length,
       //    buf.m.planes[j].m.userptr);
       buffer->iSize[j]       = buf.m.planes[j].length;
       buffer->iBytesUsed[j]  = buf.m.planes[j].bytesused;
-      if(buffer->iSize[j])
+      if (buffer->iSize[j])
       {
         buffer->cPlane[j] = mmap(NULL, buf.m.planes[j].length, PROT_READ | PROT_WRITE,
                        MAP_SHARED, device, buf.m.planes[j].m.mem_offset);
-        if(buffer->cPlane[j] == MAP_FAILED)
+        if (buffer->cPlane[j] == MAP_FAILED)
         {
           CLog::Log(LOGERROR, "%s::%s - Mmapping buffer", CLASSNAME, __func__);
           return false;
@@ -138,7 +138,7 @@ bool CLinuxV4l2::MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enu
     }
     buffer->iIndex = i;
 
-    if(queue)
+    if (queue)
     {
       ret = ioctl(device, VIDIOC_QBUF, &buf);
       if (ret)
@@ -157,15 +157,15 @@ V4L2Buffer *CLinuxV4l2::FreeBuffers(int count, V4L2Buffer *v4l2Buffers)
 {
   int i, j;
 
-  if(v4l2Buffers != NULL)
+  if (v4l2Buffers != NULL)
   {
-    for(i = 0; i < count; i++)
+    for (i = 0; i < count; i++)
     {
       V4L2Buffer *buffer = &v4l2Buffers[i];
 
       for (j = 0; j < buffer->iNumPlanes; j++)
       {
-        if(buffer->cPlane[j] && buffer->cPlane[j] != MAP_FAILED)
+        if (buffer->cPlane[j] && buffer->cPlane[j] != MAP_FAILED)
         {
           munmap(buffer->cPlane[j], buffer->iSize[j]);
           CLog::Log(LOGDEBUG, "%s::%s - unmap convert buffer", CLASSNAME, __func__);
@@ -183,7 +183,7 @@ int CLinuxV4l2::DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_mem
   struct v4l2_plane  vplanes[V4L2_NUM_MAX_PLANES];
   int ret = 0;
 
-  if(device < 0)
+  if (device < 0)
     return V4L2_ERROR;
 
   memset(&vplanes, 0, sizeof(struct v4l2_plane) * V4L2_NUM_MAX_PLANES);
@@ -199,18 +199,18 @@ int CLinuxV4l2::DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_mem
       CLog::Log(LOGERROR, "%s::%s - Dequeue buffer", CLASSNAME, __func__);
     return V4L2_ERROR;
   }
-  
+
   return vbuf.index;
 }
 
-int CLinuxV4l2::QueueBuffer(int device, enum v4l2_buf_type type, 
+int CLinuxV4l2::QueueBuffer(int device, enum v4l2_buf_type type,
     enum v4l2_memory memory, int planes, int index, V4L2Buffer *buffer)
 {
   struct v4l2_buffer vbuf;
   struct v4l2_plane  vplanes[V4L2_NUM_MAX_PLANES];
   int ret = 0;
 
-  if(!buffer || device <0)
+  if (!buffer || device <0)
     return V4L2_ERROR;
 
   memset(&vplanes, 0, sizeof(struct v4l2_plane) * V4L2_NUM_MAX_PLANES);
@@ -221,7 +221,7 @@ int CLinuxV4l2::QueueBuffer(int device, enum v4l2_buf_type type,
   vbuf.m.planes = vplanes;
   vbuf.length   = buffer->iNumPlanes;
 
-  for (int i = 0; i < buffer->iNumPlanes; i++) 
+  for (int i = 0; i < buffer->iNumPlanes; i++)
   {
     vplanes[i].m.userptr   = (unsigned long)buffer->cPlane[i];
     vplanes[i].length      = buffer->iSize[i];
@@ -291,7 +291,7 @@ int CLinuxV4l2::SetControllValue(int device, int id, int value)
 
   ret = ioctl(device, VIDIOC_S_CTRL, &control);
 
-  if(ret < 0) 
+  if (ret < 0)
   {
     CLog::Log(LOGERROR, "%s::%s - Set controll if %d value %d\n", CLASSNAME, __func__, id, value);
     return V4L2_ERROR;

--- a/xbmc/linux/LinuxV4l2.h
+++ b/xbmc/linux/LinuxV4l2.h
@@ -1,0 +1,74 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <linux/videodev2.h>
+
+#define V4L2_ERROR -1
+#define V4L2_BUSY  1
+#define V4L2_READY 2
+#define V4L2_OK    3
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define V4L2_NUM_MAX_PLANES 3
+
+typedef struct V4L2Buffer
+{
+  int   iSize[V4L2_NUM_MAX_PLANES];
+  int   iOffset[V4L2_NUM_MAX_PLANES];
+  int   iBytesUsed[V4L2_NUM_MAX_PLANES];
+  void  *cPlane[V4L2_NUM_MAX_PLANES];
+  int   iNumPlanes;
+  int   iIndex;
+  bool  bQueue;
+} V4L2Buffer;
+
+#ifdef __cplusplus
+}
+#endif
+
+class CLinuxV4l2
+{
+public:
+  CLinuxV4l2();
+  virtual ~CLinuxV4l2();
+
+  static int RequestBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int numBuffers);
+  static bool StreamOn(int device, enum v4l2_buf_type type, int onoff);
+  static bool MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enum v4l2_buf_type type, enum v4l2_memory memory, bool queue = true);
+  static V4L2Buffer *FreeBuffers(int count, V4L2Buffer *v4l2Buffers);
+
+  static int DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int planes);
+  static int QueueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, 
+      int planes, int index, V4L2Buffer *buffer);
+
+  static int PollInput(int device, int timeout);
+  static int PollOutput(int device, int timeout);
+  static int SetControllValue(int device, int id, int value);
+};
+
+inline int v4l2_align(int v, int a) {
+  return ((v + a - 1) / a) * a;
+}
+

--- a/xbmc/linux/LinuxV4l2.h
+++ b/xbmc/linux/LinuxV4l2.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/xbmc/linux/LinuxV4l2.h
+++ b/xbmc/linux/LinuxV4l2.h
@@ -22,23 +22,27 @@
 
 #include <linux/videodev2.h>
 
-#define V4L2_ERROR -1
-#define V4L2_BUSY  1
-#define V4L2_READY 2
-#define V4L2_OK    3
+#define V4L2_ERROR                   -1
+#define V4L2_BUSY                     1
+#define V4L2_READY                    2
+#define V4L2_OK                       3
+
+#define V4L2_NUM_MAX_PLANES           3
+
+#ifndef V4L2_CAP_VIDEO_M2M_MPLANE
+#define V4L2_CAP_VIDEO_M2M_MPLANE     0x00004000
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define V4L2_NUM_MAX_PLANES 3
 
 typedef struct V4L2Buffer
 {
   int   iSize[V4L2_NUM_MAX_PLANES];
   int   iOffset[V4L2_NUM_MAX_PLANES];
   int   iBytesUsed[V4L2_NUM_MAX_PLANES];
-  void  *cPlane[V4L2_NUM_MAX_PLANES];
+  void *cPlane[V4L2_NUM_MAX_PLANES];
   int   iNumPlanes;
   int   iIndex;
   bool  bQueue;
@@ -54,21 +58,19 @@ public:
   CLinuxV4l2();
   virtual ~CLinuxV4l2();
 
-  static int RequestBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int numBuffers);
-  static bool StreamOn(int device, enum v4l2_buf_type type, int onoff);
-  static bool MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enum v4l2_buf_type type, enum v4l2_memory memory, bool queue = true);
-  static V4L2Buffer *FreeBuffers(int count, V4L2Buffer *v4l2Buffers);
+  static int          RequestBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int numBuffers);
+  static bool         StreamOn(int device, enum v4l2_buf_type type, int onoff);
+  static bool         MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enum v4l2_buf_type type, enum v4l2_memory memory, bool queue = true);
+  static V4L2Buffer  *FreeBuffers(int count, V4L2Buffer *v4l2Buffers);
 
-  static int DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int planes);
-  static int QueueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, 
-      int planes, int index, V4L2Buffer *buffer);
+  static int          DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int planes);
+  static int          QueueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int planes, int index, V4L2Buffer *buffer);
 
-  static int PollInput(int device, int timeout);
-  static int PollOutput(int device, int timeout);
-  static int SetControllValue(int device, int id, int value);
+  static int          PollInput(int device, int timeout);
+  static int          PollOutput(int device, int timeout);
+  static int          SetControllValue(int device, int id, int value);
 };
 
 inline int v4l2_align(int v, int a) {
   return ((v + a - 1) / a) * a;
 }
-

--- a/xbmc/linux/LinuxV4l2.h
+++ b/xbmc/linux/LinuxV4l2.h
@@ -39,13 +39,14 @@ extern "C" {
 
 typedef struct V4L2Buffer
 {
-  int   iSize[V4L2_NUM_MAX_PLANES];
-  int   iOffset[V4L2_NUM_MAX_PLANES];
-  int   iBytesUsed[V4L2_NUM_MAX_PLANES];
-  void *cPlane[V4L2_NUM_MAX_PLANES];
-  int   iNumPlanes;
-  int   iIndex;
-  bool  bQueue;
+  int    iSize[V4L2_NUM_MAX_PLANES];
+  int    iOffset[V4L2_NUM_MAX_PLANES];
+  int    iBytesUsed[V4L2_NUM_MAX_PLANES];
+  void  *cPlane[V4L2_NUM_MAX_PLANES];
+  int    iNumPlanes;
+  int    iIndex;
+  bool   bQueue;
+  double timestamp;
 } V4L2Buffer;
 
 #ifdef __cplusplus
@@ -58,17 +59,18 @@ public:
   CLinuxV4l2();
   virtual ~CLinuxV4l2();
 
-  static int          RequestBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int numBuffers);
-  static bool         StreamOn(int device, enum v4l2_buf_type type, int onoff);
-  static bool         MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enum v4l2_buf_type type, enum v4l2_memory memory, bool queue = true);
-  static V4L2Buffer  *FreeBuffers(int count, V4L2Buffer *v4l2Buffers);
+  static int         RequestBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int numBuffers);
+  static bool        StreamOn(int device, enum v4l2_buf_type type, int onoff);
+  static bool        MmapBuffers(int device, int count, V4L2Buffer *v4l2Buffers, enum v4l2_buf_type type, enum v4l2_memory memory, bool queue = true);
+  static V4L2Buffer *FreeBuffers(int count, V4L2Buffer *v4l2Buffers);
 
-  static int          DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int planes);
-  static int          QueueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, int planes, int index, V4L2Buffer *buffer);
+  static int         DequeueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, double *dequeuedTimestamp);
+  static int         QueueBuffer(int device, enum v4l2_buf_type type, enum v4l2_memory memory, V4L2Buffer *buffer);
 
-  static int          PollInput(int device, int timeout);
-  static int          PollOutput(int device, int timeout);
-  static int          SetControllValue(int device, int id, int value);
+  static int         PollInput(int device, int timeout);
+  static int         PollOutput(int device, int timeout);
+  static int         SetControllValue(int device, int id, int value);
+
 };
 
 inline int v4l2_align(int v, int a) {

--- a/xbmc/linux/Makefile.in
+++ b/xbmc/linux/Makefile.in
@@ -7,6 +7,7 @@ SRCS += DBusReserve.cpp
 SRCS += HALManager.cpp
 SRCS += LinuxResourceCounter.cpp
 SRCS += LinuxTimezone.cpp
+SRCS += LinuxV4l2.cpp
 SRCS += PosixMountProvider.cpp
 SRCS += XFileUtils.cpp
 SRCS += XHandle.cpp


### PR DESCRIPTION
Tested successfully with MFC5 (Exynos4) and MFC6 (Exynos5) on ODROID-U2, ODROID-U3 and ODROID-XU.

The codec queries MFC capabilities - MFC6 and above supports NV12, MFC5 supports NV12MT. When MFC5 is found, FIMC converter hardware found in Exynos4 is required. The PR contains V4L2 helper functions, MFC and FIMC code, and the dvdplayer codec.

Code was contributed by @owersun, @vamanea and @mihailescu2m.
