### PR TITLE
dvdplayer: resample/dup improvement

### DIFF
--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -30,67 +30,6 @@
 
 using namespace std;
 
-
-CPTSOutputQueue::CPTSOutputQueue()
-{
-  Flush();
-}
-
-void CPTSOutputQueue::Add(double pts, double delay, double duration, double timestamp)
-{
-  CSingleLock lock(m_sync);
-
-  // don't accept a re-add, since that would cause time moving back
-  double last = m_queue.empty() ? m_current.pts : m_queue.back().pts;
-  if(last == pts)
-    return;
-
-  TPTSItem item;
-  item.pts = pts;
-  item.timestamp = timestamp + delay;
-  item.duration = duration;
-
-  // first one is applied directly
-  if(m_queue.empty() && m_current.pts == DVD_NOPTS_VALUE)
-    m_current = item;
-  else
-    m_queue.push(item);
-
-  // call function to make sure the queue
-  // doesn't grow should nobody call it
-  Current(timestamp);
-}
-void CPTSOutputQueue::Flush()
-{
-  CSingleLock lock(m_sync);
-
-  while( !m_queue.empty() ) m_queue.pop();
-  m_current.pts = DVD_NOPTS_VALUE;
-  m_current.timestamp = 0.0;
-  m_current.duration = 0.0;
-}
-
-double CPTSOutputQueue::Current(double timestamp)
-{
-  CSingleLock lock(m_sync);
-
-  if(!m_queue.empty() && m_current.pts == DVD_NOPTS_VALUE)
-  {
-    m_current = m_queue.front();
-    m_queue.pop();
-  }
-
-  while( !m_queue.empty() && timestamp >= m_queue.front().timestamp )
-  {
-    m_current = m_queue.front();
-    m_queue.pop();
-  }
-
-  if( m_current.timestamp == 0 ) return m_current.pts;
-
-  return m_current.pts + min(m_current.duration, (timestamp - m_current.timestamp));
-}
-
 /** \brief Reallocs the memory block pointed to by src by the size len.
 *   \param[in] src Pointer to a memory block.
 *   \param[in] len New size of the memory block.
@@ -123,6 +62,7 @@ CDVDAudio::CDVDAudio(volatile bool &bStop)
   m_iBitrate = 0;
   m_SecondsPerByte = 0.0;
   m_bPaused = true;
+  m_pts = 0.0;
 }
 
 CDVDAudio::~CDVDAudio()
@@ -194,7 +134,7 @@ void CDVDAudio::Destroy()
   m_iBitsPerSample = 0;
   m_bPassthrough = false;
   m_bPaused = true;
-  m_time.Flush();
+  m_pts = 0.0;
 }
 
 unsigned int CDVDAudio::AddPacketsRenderer(unsigned char* data, unsigned int len, CSingleLock &lock)
@@ -241,6 +181,8 @@ unsigned int CDVDAudio::AddPackets(const DVDAudioFrame &audioframe)
   unsigned int total = len;
   unsigned int copied;
 
+  m_pts = audioframe.pts + audioframe.duration;
+
   if (m_iBufferSize > 0) // See if there are carryover bytes from the last call. need to add them 1st.
   {
     copied = std::min(m_dwPacketSize - m_iBufferSize % m_dwPacketSize, len); // Smaller of either the data provided or the leftover data
@@ -279,11 +221,6 @@ unsigned int CDVDAudio::AddPackets(const DVDAudioFrame &audioframe)
     m_iBufferSize = len;
     memcpy(m_pBuffer, data, len);
   }
-
-  double time_added = DVD_SEC_TO_TIME(m_SecondsPerByte * (data - audioframe.data));
-  double delay      = GetDelay();
-  double timestamp  = CDVDClock::GetAbsoluteClock();
-  m_time.Add(audioframe.pts, delay - time_added, audioframe.duration, timestamp);
 
   return total;
 }
@@ -360,7 +297,6 @@ void CDVDAudio::Pause()
 {
   CSingleLock lock (m_critSection);
   if (m_pAudioStream) m_pAudioStream->Pause();
-  m_time.Flush();
 }
 
 void CDVDAudio::Resume()
@@ -391,7 +327,6 @@ void CDVDAudio::Flush()
     m_pAudioStream->Flush();
   }
   m_iBufferSize = 0;
-  m_time.Flush();
 }
 
 bool CDVDAudio::IsValidFormat(const DVDAudioFrame &audioframe)
@@ -444,13 +379,10 @@ double CDVDAudio::GetCacheTotal()
 void CDVDAudio::SetPlayingPts(double pts)
 {
   CSingleLock lock (m_critSection);
-  m_time.Flush();
-  double delay     = GetDelay();
-  double timestamp = CDVDClock::GetAbsoluteClock();
-  m_time.Add(pts, delay, 0, timestamp);
+  m_pts = pts + GetDelay();
 }
 
 double CDVDAudio::GetPlayingPts()
 {
-  return m_time.Current(CDVDClock::GetAbsoluteClock());
+  return m_pts - GetDelay();
 }

--- a/xbmc/cores/dvdplayer/DVDAudio.h
+++ b/xbmc/cores/dvdplayer/DVDAudio.h
@@ -36,21 +36,6 @@ extern "C" {
 
 typedef struct stDVDAudioFrame DVDAudioFrame;
 
-class CPTSOutputQueue
-{
-private:
-  typedef struct {double pts; double timestamp; double duration;} TPTSItem;
-  TPTSItem m_current;
-  std::queue<TPTSItem> m_queue;
-  CCriticalSection m_sync;
-
-public:
-  CPTSOutputQueue();
-  void Add(double pts, double delay, double duration, double timestamp);
-  void Flush();
-  double Current(double timestamp);
-};
-
 class CSingleLock;
 class IAudioCallback;
 
@@ -86,7 +71,7 @@ public:
 
   IAEStream *m_pAudioStream;
 protected:
-  CPTSOutputQueue m_time;
+  double       m_pts;
   unsigned int AddPacketsRenderer(unsigned char* data, unsigned int len, CSingleLock &lock);
   uint8_t*     m_pBuffer; // should be [m_dwPacketSize]
   unsigned int m_iBufferSize;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -721,8 +721,10 @@ bool CDVDPlayerAudio::OutputPacket(DVDAudioFrame &audioframe)
   }
   else if (m_synctype == SYNC_RESAMPLE)
   {
+    double base_speed = 1.0 / g_VideoReferenceClock.GetSpeed();
     m_dvdAudio.SetResampleRatio(m_resampleratio);
     m_dvdAudio.AddPackets(audioframe);
+    m_errors.Update(-audioframe.duration * (m_resampleratio - base_speed));
   }
 
   return true;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -703,6 +703,7 @@ bool CDVDPlayerAudio::OutputPacket(DVDAudioFrame &audioframe)
       {
         CLog::Log(LOGDEBUG, "CDVDPlayerAudio:: Dropping packet of %d ms", DVD_TIME_TO_MSEC(audioframe.duration));
         m_error += audioframe.duration;
+        m_errors.Update(audioframe.duration);
       }
     }
     else if(m_error > limit)
@@ -711,6 +712,7 @@ bool CDVDPlayerAudio::OutputPacket(DVDAudioFrame &audioframe)
       m_dvdAudio.AddPackets(audioframe);
       m_dvdAudio.AddPackets(audioframe);
       m_error -= audioframe.duration;
+      m_errors.Update(-audioframe.duration);
     }
     else
       m_dvdAudio.AddPackets(audioframe);

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -139,7 +139,6 @@ public:
   // holds stream information for current playing stream
   CDVDStreamInfo m_streaminfo;
 
-  CPTSOutputQueue m_ptsOutput;
   CPTSInputQueue  m_ptsInput;
 
   double GetCurrentPts()                            { return m_dvdAudio.GetPlayingPts(); }

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -69,6 +69,11 @@ public:
     m_count++;
   }
 
+  void    Update(double error)
+  {
+    m_buffer += error * m_count;
+  }
+
   void    Flush()
   {
     m_buffer = 0.0f;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -230,7 +230,7 @@ protected:
   bool   m_syncclock;
 
   double m_integral; //integral correction for resampler
-  bool   m_prevskipped;
+  double m_skipdup_keep;
   double m_maxspeedadjust;
   double m_resampleratio; //resample ratio when using SYNC_RESAMPLE, used for the codec info
 

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -73,7 +73,7 @@ public:
   {
     m_buffer = 0.0f;
     m_count  = 0;
-    m_timer.Set(2000);
+    m_timer.Set(200);
   }
 
   double  Get()


### PR DESCRIPTION
This merge request tries to improve the old resampling/dup/skip code in dvd player audio to better swing in to a state that is synchronous with the clock.

It limits the maximum resampling rate to 20% and re-uses sampling rate adjustment for the drop/dup code.

It drops the old output pts code that is not needed since we don't have stream discontinuities at thus stage.
