### PR TITLE
videoinfoscanner optimizations

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3631,7 +3631,7 @@ bool CApplication::PlayMedia(const CFileItem& item, int iPlaylist)
   if (item.IsSmartPlayList())
   {
     CFileItemList items;
-    CUtil::GetRecursiveListing(item.GetPath(), items, "");
+    CUtil::GetRecursiveListing(item.GetPath(), items, "", DIR_FLAG_NO_FILE_DIRS);
     if (items.Size())
     {
       CSmartPlaylist smartpl;

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -412,7 +412,7 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
           else
             URIUtils::CreateArchivePath(strPath, "rar", pMsg->strParam.c_str(), "");
 
-          CUtil::GetRecursiveListing(strPath, items, g_advancedSettings.m_pictureExtensions);
+          CUtil::GetRecursiveListing(strPath, items, g_advancedSettings.m_pictureExtensions, XFILE::DIR_FLAG_NO_FILE_DIRS);
           if (items.Size() > 0)
           {
             pSlideShow->Reset();

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1363,32 +1363,29 @@ void CUtil::DeleteDirectoryCache(const CStdString &prefix)
 }
 
 
-void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, bool bUseFileDirectories)
+void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, unsigned int flags /* = DIR_FLAG_DEFAULTS */)
 {
   CFileItemList myItems;
-  int flags = DIR_FLAG_DEFAULTS;
-  if (!bUseFileDirectories)
-    flags |= DIR_FLAG_NO_FILE_DIRS;
   CDirectory::GetDirectory(strPath,myItems,strMask,flags);
   for (int i=0;i<myItems.Size();++i)
   {
     if (myItems[i]->m_bIsFolder)
-      CUtil::GetRecursiveListing(myItems[i]->GetPath(),items,strMask,bUseFileDirectories);
+      CUtil::GetRecursiveListing(myItems[i]->GetPath(),items,strMask,flags);
     else
       items.Add(myItems[i]);
   }
 }
 
-void CUtil::GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& item)
+void CUtil::GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& item, unsigned int flags /* = DIR_FLAG_DEFAULTS */)
 {
   CFileItemList myItems;
-  CDirectory::GetDirectory(strPath,myItems,"",DIR_FLAG_NO_FILE_DIRS);
+  CDirectory::GetDirectory(strPath,myItems,"",flags);
   for (int i=0;i<myItems.Size();++i)
   {
     if (myItems[i]->m_bIsFolder && !myItems[i]->GetPath().Equals(".."))
     {
       item.Add(myItems[i]);
-      CUtil::GetRecursiveDirsListing(myItems[i]->GetPath(),item);
+      CUtil::GetRecursiveDirsListing(myItems[i]->GetPath(),item,flags);
     }
   }
 }

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -147,8 +147,8 @@ public:
   static CStdString VideoPlaylistsLocation();
 
   static void GetSkinThemes(std::vector<CStdString>& vecTheme);
-  static void GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, bool bUseFileDirectories=false);
-  static void GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& items);
+  static void GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, unsigned int flags = 0 /* DIR_FLAG_DEFAULTS */);
+  static void GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& items, unsigned int flags = 0 /* DIR_FLAG_DEFAULTS */);
   static void ForceForwardSlashes(CStdString& strPath);
 
   static double AlbumRelevance(const CStdString& strAlbumTemp1, const CStdString& strAlbum1, const CStdString& strArtistTemp1, const CStdString& strArtist1);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -210,6 +210,7 @@ void CAdvancedSettings::Initialize()
   m_moviesExcludeFromScanRegExps.clear();
   m_moviesExcludeFromScanRegExps.push_back("-trailer");
   m_moviesExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
+  m_moviesExcludeFromScanRegExps.push_back("[\\/](proof|subs)[\\/]");
   m_tvshowExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
 
   m_folderStackRegExps.clear();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -641,7 +641,8 @@ namespace VIDEO
   {
     // enumerate episodes
     EPISODELIST files;
-    EnumerateSeriesFolder(item, files);
+    if (!EnumerateSeriesFolder(item, files))
+      return INFO_HAVE_ALREADY;
     if (files.size() == 0) // no update or no files
       return INFO_NOT_NEEDED;
 
@@ -653,30 +654,58 @@ namespace VIDEO
     return OnProcessSeriesFolder(files, scraper, useLocal, showInfo, progress);
   }
 
-  void CVideoInfoScanner::EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList)
+  bool CVideoInfoScanner::EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList)
   {
     CFileItemList items;
+    CStdStringArray regexps = g_advancedSettings.m_tvshowExcludeFromScanRegExps;
+
+    bool bSkip = false;
 
     if (item->m_bIsFolder)
     {
-      CUtil::GetRecursiveListing(item->GetPath(), items, g_advancedSettings.m_videoExtensions, DIR_FLAG_DEFAULTS);
       CStdString hash, dbHash;
-      int numFilesInFolder = GetPathHash(items, hash);
-
-      if (m_database.GetPathHash(item->GetPath(), dbHash) && dbHash == hash)
+      hash = GetRecursiveFastHash(item->GetPath(), regexps);
+      if (m_database.GetPathHash(item->GetPath(), dbHash) && !hash.empty() && dbHash == hash)
       {
-        m_currentItem += numFilesInFolder;
+        // fast hashes match - no need to process anything
+        bSkip = true;
+      }
 
+      // fast hash cannot be computed or we need to rescan. fetch the listing.
+      if (!bSkip)
+      {
+        int flags = DIR_FLAG_DEFAULTS;
+        if (!hash.empty())
+          flags |= DIR_FLAG_NO_FILE_INFO;
+
+        CUtil::GetRecursiveListing(item->GetPath(), items, g_advancedSettings.m_videoExtensions, flags);
+
+        // fast hash failed - compute slow one
+        if (hash.empty())
+        {
+          GetPathHash(items, hash);
+          if (dbHash == hash)
+          {
+            // slow hashes match - no need to process anything
+            bSkip = true;
+          }
+        }
+      }
+
+      if (bSkip)
+      {
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '%s' due to no change", CURL::GetRedacted(item->GetPath()).c_str());
         // update our dialog with our progress
         if (m_handle)
-        {
-          if (m_itemCount>0)
-            m_handle->SetPercentage(m_currentItem*100.f/m_itemCount);
-
           OnDirectoryScanned(item->GetPath());
-        }
-        return;
+        return false;
       }
+
+      if (dbHash.empty())
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Scanning dir '%s' as not in the database", CURL::GetRedacted(item->GetPath()).c_str());
+      else
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Rescanning dir '%s' due to change (%s != %s)", CURL::GetRedacted(item->GetPath()).c_str(), dbHash.c_str(), hash.c_str());
+
       m_pathsToClean.insert(m_database.GetPathId(item->GetPath()));
       m_database.GetPathsForTvShow(m_database.GetTvShowId(item->GetPath()), m_pathsToClean);
       item->SetProperty("hash", hash);
@@ -735,8 +764,6 @@ namespace VIDEO
     }
 
     // enumerate
-    CStdStringArray regexps = g_advancedSettings.m_tvshowExcludeFromScanRegExps;
-
     for (int i=0;i<items.Size();++i)
     {
       if (items[i]->m_bIsFolder)
@@ -762,6 +789,7 @@ namespace VIDEO
       if (!EnumerateEpisodeItem(items[i].get(), episodeList))
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file %s", CURL::GetRedacted(CURL::Decode(items[i]->GetPath())).c_str());
     }
+    return true;
   }
 
   bool CVideoInfoScanner::ProcessItemByVideoInfoTag(const CFileItem *item, EPISODELIST &episodeList)
@@ -1694,6 +1722,44 @@ namespace VIDEO
         md5state.getDigest(pathHash);
         return pathHash;
       }
+    }
+    return "";
+  }
+
+  CStdString CVideoInfoScanner::GetRecursiveFastHash(const CStdString &directory, const CStdStringArray &excludes) const
+  {
+    CFileItemList items;
+    items.Add(CFileItemPtr(new CFileItem(directory, true)));
+    CUtil::GetRecursiveDirsListing(directory, items, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
+
+    XBMC::XBMC_MD5 md5state;
+
+    if (excludes.size())
+      md5state.append(StringUtils::JoinString(excludes, "|"));
+
+    int64_t time = 0;
+    for (int i=0; i < items.Size(); ++i)
+    {
+      int64_t stat_time = 0;
+      struct __stat64 buffer;
+      if (XFILE::CFile::Stat(items[i]->GetPath(), &buffer) == 0)
+      {
+        // TODO: some filesystems may return the mtime/ctime inline, in which case this is
+        // unnecessarily expensive. Consider supporting Stat() in our directory cache?
+        stat_time = buffer.st_mtime ? buffer.st_mtime : buffer.st_ctime;
+        time += stat_time;
+      }
+
+      if (!stat_time)
+        return "";
+    }
+
+    if (time)
+    {
+      md5state.append((unsigned char *)&time, sizeof(time));
+      CStdString pathHash;
+      md5state.getDigest(pathHash);
+      return pathHash;
     }
     return "";
   }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -663,6 +663,15 @@ namespace VIDEO
 
     if (item->m_bIsFolder)
     {
+      /*
+       * Note: DoScan() will not remove this path as it's not recursing for tvshows.
+       * Remove this path from the list we're processing in order to avoid hitting
+       * it twice in the main loop.
+       */
+      set<CStdString>::iterator it = m_pathsToScan.find(item->GetPath());
+      if (it != m_pathsToScan.end())
+        m_pathsToScan.erase(it);
+
       CStdString hash, dbHash;
       hash = GetRecursiveFastHash(item->GetPath(), regexps);
       if (m_database.GetPathHash(item->GetPath(), dbHash) && !hash.empty() && dbHash == hash)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -659,7 +659,7 @@ namespace VIDEO
 
     if (item->m_bIsFolder)
     {
-      CUtil::GetRecursiveListing(item->GetPath(), items, g_advancedSettings.m_videoExtensions, true);
+      CUtil::GetRecursiveListing(item->GetPath(), items, g_advancedSettings.m_videoExtensions, DIR_FLAG_DEFAULTS);
       CStdString hash, dbHash;
       int numFilesInFolder = GetPathHash(items, hash);
 

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -185,19 +185,23 @@ namespace VIDEO
      Performs a stat() on the directory, and uses modified time to create a "fast"
      hash of the folder. If no modified time is available, the create time is used,
      and if neither are available, an empty hash is returned.
+     In case exclude from scan expressions are present, the string array will be appended
+     to the md5 hash to ensure we're doing a re-scan whenever the user modifies those.
      \param directory folder to hash
-     \return the hash of the folder of the form "fast<datetime>"
+     \param excludes string array of exclude expressions
+     \return the md5 hash of the folder"
      */
-    CStdString GetFastHash(const CStdString &directory) const;
+    CStdString GetFastHash(const CStdString &directory, const CStdStringArray &excludes) const;
 
     /*! \brief Decide whether a folder listing could use the "fast" hash
      Fast hashing can be done whenever the folder contains no scannable subfolders, as the
      fast hash technique uses modified time to determine when folder content changes, which
      is generally not propogated up the directory tree.
      \param items the directory listing
+     \param excludes string array of exclude expressions
      \return true if this directory listing can be fast hashed, false otherwise
      */
-    bool CanFastHash(const CFileItemList &items) const;
+    bool CanFastHash(const CFileItemList &items, const CStdStringArray &excludes) const;
 
     /*! \brief Process a series folder, filling in episode details and adding them to the database.
      TODO: Ideally we would return INFO_HAVE_ALREADY if we don't have to update any episodes

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -193,6 +193,18 @@ namespace VIDEO
      */
     CStdString GetFastHash(const CStdString &directory, const CStdStringArray &excludes) const;
 
+    /*! \brief Retrieve a "fast" hash of the given directory recursively (if available)
+     Performs a stat() on the directory, and uses modified time to create a "fast"
+     hash of each folder. If no modified time is available, the create time is used,
+     and if neither are available, an empty hash is returned.
+     In case exclude from scan expressions are present, the string array will be appended
+     to the md5 hash to ensure we're doing a re-scan whenever the user modifies those.
+     \param directory folder to hash (recursively)
+     \param excludes string array of exclude expressions
+     \return the md5 hash of the folder
+     */
+    CStdString GetRecursiveFastHash(const CStdString &directory, const CStdStringArray &excludes) const;
+
     /*! \brief Decide whether a folder listing could use the "fast" hash
      Fast hashing can be done whenever the folder contains no scannable subfolders, as the
      fast hash technique uses modified time to determine when folder content changes, which
@@ -216,7 +228,7 @@ namespace VIDEO
      */
     INFO_RET OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, CGUIDialogProgress* pDlgProgress = NULL);
 
-    void EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList);
+    bool EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList);
     bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
     bool ProcessItemByVideoInfoTag(const CFileItem *item, EPISODELIST &episodeList);
 


### PR DESCRIPTION
This commit series modifies the videoinfoscanner to be less expensive when scanning for new content.

In order to speed up the scan process, I've modified all CDirectory::GetDirectory calls to not stat for additional file information. Note, this is not yet supported by all filesystem implementations. SMB and AFP already honor the dir flag.

Furthermore I've changed the way we're checking whether or not a directory is able to fasthash. This is done by filtering the items based on the appropriate excludefromscan expressions before counting the subfolders. The exclude expressions are appended to the generated md5 hash to ensure we're doing a re-scan whenever the users changes those.

As for series, it now uses a recursive fast hash method for enumerating series folders. This allows us
to determine whether or not new content was added without wasting time stating every single episode.

The last commit in this series fixes an issue that's also present in current master. Due to the nature of DoScan we 
don't recurse for CONTENT == tvshows. In order to avoid hitting paths twice, we have to remove them from the list right after enumerating the series folder.

@jmarshallnz for review please.
