### PR TITLE
Clocks

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -39,8 +39,7 @@ using namespace ActiveAE;
 void CEngineStats::Reset(unsigned int sampleRate)
 {
   CSingleLock lock(m_lock);
-  m_sinkUpdate = CurrentHostCounter();
-  m_sinkDelay = 0;
+  m_sinkDelay.SetDelay(0.0);
   m_sinkSampleRate = sampleRate;
   m_bufferedSamples = 0;
   m_suspended = false;
@@ -49,8 +48,7 @@ void CEngineStats::Reset(unsigned int sampleRate)
 void CEngineStats::UpdateSinkDelay(const AEDelayStatus& status, int samples)
 {
   CSingleLock lock(m_lock);
-  m_sinkUpdate = status.tick;
-  m_sinkDelay = status.delay;
+  m_sinkDelay = status;
   if (samples > m_bufferedSamples)
   {
     CLog::Log(LOGERROR, "CEngineStats::UpdateSinkDelay - inconsistency in buffer time");
@@ -79,33 +77,21 @@ void CEngineStats::AddSamples(int samples, std::list<CActiveAEStream*> &streams)
   }
 }
 
-float CEngineStats::GetDelay()
+void CEngineStats::GetDelay(AEDelayStatus& status)
 {
   CSingleLock lock(m_lock);
-  int64_t now = CurrentHostCounter();
-  float delay = m_sinkDelay - (double)(now-m_sinkUpdate) / CurrentHostFrequency();
-  delay += (float)m_bufferedSamples / m_sinkSampleRate;
-
-  if (delay < 0)
-    delay = 0.0;
-
-  return delay;
+  status = m_sinkDelay;
+  status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
 }
 
 // this is used to sync a/v so we need to add sink latency here
-float CEngineStats::GetDelay(CActiveAEStream *stream)
+void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
 {
   CSingleLock lock(m_lock);
-  int64_t now = CurrentHostCounter();
-  float delay = m_sinkDelay - (double)(now-m_sinkUpdate) / CurrentHostFrequency();
-  delay += m_sinkLatency;
-  delay += (float)m_bufferedSamples / m_sinkSampleRate;
+  GetDelay(status);
 
-  if (delay < 0)
-    delay = 0.0;
-
-  delay += stream->m_bufferedTime / stream->m_streamResampleRatio;
-  return delay;
+  status.delay += m_sinkLatency;
+  status.delay += stream->m_bufferedTime / stream->m_streamResampleRatio;
 }
 
 float CEngineStats::GetCacheTime(CActiveAEStream *stream)
@@ -589,7 +575,11 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             if (m_extKeepConfig)
               m_extDrainTimer.Set(m_extKeepConfig);
             else
-              m_extDrainTimer.Set(m_stats.GetDelay() * 1000);
+            {
+              AEDelayStatus status;
+              m_stats.GetDelay(status);
+              m_extDrainTimer.Set(status.GetDelay() * 1000);
+            }
             m_extDrain = true;
           }
           m_extTimeout = 0;
@@ -1913,8 +1903,10 @@ bool CActiveAE::RunStages()
             }
             else
               CLog::Log(LOGWARNING,"ActiveAE::%s - viz ran out of free buffers", __FUNCTION__);
+            AEDelayStatus status;
+            m_stats.GetDelay(status);
             unsigned int now = XbmcThreads::SystemClockMillis();
-            unsigned int timestamp = now + m_stats.GetDelay() * 1000;
+            unsigned int timestamp = now + status.GetDelay() * 1000;
             busy |= m_vizBuffers->ResampleBuffers(timestamp);
             while(!m_vizBuffers->m_outputSamples.empty())
             {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -162,8 +162,8 @@ public:
   void Reset(unsigned int sampleRate);
   void UpdateSinkDelay(const AEDelayStatus& status, int samples);
   void AddSamples(int samples, std::list<CActiveAEStream*> &streams);
-  float GetDelay();
-  float GetDelay(CActiveAEStream *stream);
+  void GetDelay(AEDelayStatus& status);
+  void GetDelay(AEDelayStatus& status, CActiveAEStream *stream);
   float GetCacheTime(CActiveAEStream *stream);
   float GetCacheTotal(CActiveAEStream *stream);
   float GetWaterLevel();
@@ -173,12 +173,11 @@ public:
   bool IsSuspended();
   CCriticalSection *GetLock() { return &m_lock; }
 protected:
-  float m_sinkDelay;
   float m_sinkCacheTotal;
   float m_sinkLatency;
   int m_bufferedSamples;
   unsigned int m_sinkSampleRate;
-  int64_t      m_sinkUpdate;
+  AEDelayStatus m_sinkDelay;
   bool m_suspended;
   CCriticalSection m_lock;
 };
@@ -242,7 +241,7 @@ protected:
   void PlaySound(CActiveAESound *sound);
   uint8_t **AllocSoundSample(SampleConfig &config, int &samples, int &bytes_per_sample, int &planes, int &linesize);
   void FreeSoundSample(uint8_t **data);
-  float GetDelay(CActiveAEStream *stream) { return m_stats.GetDelay(stream); }
+  void GetDelay(AEDelayStatus& status, CActiveAEStream *stream) { m_stats.GetDelay(status, stream); }
   float GetCacheTime(CActiveAEStream *stream) { return m_stats.GetCacheTime(stream); }
   float GetCacheTotal(CActiveAEStream *stream) { return m_stats.GetCacheTotal(stream); }
   void FlushStream(CActiveAEStream *stream);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -160,7 +160,7 @@ class CEngineStats
 {
 public:
   void Reset(unsigned int sampleRate);
-  void UpdateSinkDelay(double delay, int samples);
+  void UpdateSinkDelay(const AEDelayStatus& status, int samples);
   void AddSamples(int samples, std::list<CActiveAEStream*> &streams);
   float GetDelay();
   float GetDelay(CActiveAEStream *stream);
@@ -178,7 +178,7 @@ protected:
   float m_sinkLatency;
   int m_bufferedSamples;
   unsigned int m_sinkSampleRate;
-  unsigned int m_sinkUpdate;
+  int64_t      m_sinkUpdate;
   bool m_suspended;
   CCriticalSection m_lock;
 };

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -280,7 +280,9 @@ unsigned int CActiveAEStream::AddData(void *data, unsigned int size)
 
 double CActiveAEStream::GetDelay()
 {
-  return AE.GetDelay(this);
+  AEDelayStatus status;
+  AE.GetDelay(status, this);
+  return status.GetDelay();
 }
 
 bool CActiveAEStream::IsBuffering()

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include "cores/AudioEngine/Interfaces/AE.h" // for typedef's used in derived classes
 #include "cores/AudioEngine/Utils/AEAudioFormat.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 
 class IAESink
 {
@@ -69,6 +70,16 @@ public:
    * @return number of frames consumed by the sink
   */
   virtual unsigned int AddPackets(uint8_t **data, unsigned int frames, unsigned int offset) = 0;
+
+
+  /*!
+   * @brief Return a timestamped status structure with delay and sink info
+   * @param status structure filled with sink status
+  */
+  virtual void GetDelay(AEDelayStatus& status)
+  {
+    status.SetDelay(GetDelay());
+  }
 
   /*
     Drain the sink

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.h
@@ -45,7 +45,8 @@ public:
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
 
-  virtual double       GetDelay        ();
+  virtual double       GetDelay        () { return 0.0; /* unused dummy */ }
+  virtual void         GetDelay(AEDelayStatus& status);
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t **data, unsigned int frames, unsigned int offset);
   virtual void         Drain           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -29,6 +29,7 @@
 #include "utils/StringUtils.h"
 #include "threads/Condition.h"
 #include "threads/CriticalSection.h"
+#include "utils/TimeUtils.h"
 
 #include <sstream>
 
@@ -375,7 +376,9 @@ CAESinkDARWINOSX::CAESinkDARWINOSX()
   m_frameSizePerPlane(0),
   m_framesPerSecond(0),
   m_buffer(NULL),
-  m_started(false)
+  m_started(false),
+  m_render_tick(0),
+  m_render_delay(0.0)
 {
   // By default, kAudioHardwarePropertyRunLoop points at the process's main thread on SnowLeopard,
   // If your process lacks such a run loop, you can set kAudioHardwarePropertyRunLoop to NULL which
@@ -662,17 +665,27 @@ void CAESinkDARWINOSX::Deinitialize()
   m_started = false;
 }
 
-double CAESinkDARWINOSX::GetDelay()
+void CAESinkDARWINOSX::GetDelay(AEDelayStatus& status)
 {
-  if (m_buffer)
+  /* lockless way of guaranteeing consistency of tick/delay/buffer,
+   * this work since render callback is short and quick and higher
+   * priority compared to this thread, unsigned int are assumed
+   * aligned and having atomic read/write */
+  unsigned int size;
+  CAESpinLock lock(m_render_locker);
+  do
   {
-    // Calculate the duration of the data in the cache
-    double delay = (double)m_buffer->GetReadSize() / (double)m_frameSizePerPlane;
-    delay += (double)m_latentFrames;
-    delay /= (double)m_framesPerSecond;
-    return delay;
-  }
-  return 0.0;
+    status.tick  = m_render_tick;
+    status.delay = m_render_delay;
+    if(m_buffer)
+      size = m_buffer->GetReadSize();
+    else
+      size = 0;
+
+  } while(lock.retry());
+
+  status.delay += (double)size / (double)m_frameSizePerPlane / (double)m_framesPerSecond;
+  status.delay += (double)m_latentFrames / (double)m_framesPerSecond;
 }
 
 double CAESinkDARWINOSX::GetCacheTotal()
@@ -760,6 +773,7 @@ OSStatus CAESinkDARWINOSX::renderCallback(AudioDeviceID inDevice, const AudioTim
 {
   CAESinkDARWINOSX *sink = (CAESinkDARWINOSX*)inClientData;
 
+  sink->m_render_locker.enter(); /* grab lock */
   sink->m_started = true;
   if (outOutputData->mNumberBuffers)
   {
@@ -805,5 +819,9 @@ OSStatus CAESinkDARWINOSX::renderCallback(AudioDeviceID inDevice, const AudioTim
     // tell the sink we're good for more data
     condVar.notifyAll();
   }
+
+  sink->m_render_delay = (double)(inOutputTime->mHostTime - inNow->mHostTime) / CurrentHostFrequency();
+  sink->m_render_tick  = inNow->mHostTime;
+  sink->m_render_locker.leave();
   return noErr;
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -25,6 +25,7 @@
 #include "cores/AudioEngine/Sinks/osx/CoreAudioStream.h"
 
 class AERingBuffer;
+class AEDelayStatus;
 
 class CAESinkDARWINOSX : public IAESink
 {
@@ -37,7 +38,8 @@ public:
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
 
-  virtual double       GetDelay        ();
+  virtual double       GetDelay        () { return 0.0; /* unused dummy */ }
+  virtual void         GetDelay(AEDelayStatus& status);
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t **data, unsigned int frames, unsigned int offset);
   virtual void         Drain           ();
@@ -60,4 +62,8 @@ private:
 
   AERingBuffer      *m_buffer;
   volatile bool      m_started;     // set once we get a callback from CoreAudio, which can take a little while.
+
+  CAESpinSection         m_render_locker;
+  volatile int64_t       m_render_tick;
+  volatile double        m_render_delay;
 };

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -242,6 +242,7 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
   memset(&dsbdesc, 0, sizeof(DSBUFFERDESC));
   dsbdesc.dwSize = sizeof(DSBUFFERDESC);
   dsbdesc.dwFlags = DSBCAPS_GETCURRENTPOSITION2 /** Better position accuracy */
+                  | DSBCAPS_TRUEPLAYPOSITION    /** Vista+ accurate position */
                   | DSBCAPS_GLOBALFOCUS;         /** Allows background playing */
 
   dsbdesc.dwBufferBytes = m_dwBufferLen;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -756,7 +756,7 @@ double CAESinkPULSE::GetCacheTotal()
 unsigned int CAESinkPULSE::AddPackets(uint8_t **data, unsigned int frames, unsigned int offset)
 {
   if (!m_IsAllocated)
-    return frames;
+    return 0;
 
   if (m_IsStreamPaused)
   {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -720,11 +720,13 @@ void CAESinkPULSE::Deinitialize()
   }
 }
 
-double CAESinkPULSE::GetDelay()
+void CAESinkPULSE::GetDelay(AEDelayStatus& status)
 {
   if (!m_IsAllocated)
-    return 0;
-
+  {
+    status.SetDelay(0);
+    return;
+  }
   int error = 0;
   pa_usec_t latency = (pa_usec_t) -1;
   pa_threaded_mainloop_lock(m_MainLoop);
@@ -743,7 +745,7 @@ double CAESinkPULSE::GetDelay()
     latency = (pa_usec_t) 0;
 
   pa_threaded_mainloop_unlock(m_MainLoop);
-  return latency / 1000000.0;
+  status.SetDelay(latency / 1000000.0);
 }
 
 double CAESinkPULSE::GetCacheTotal()

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -39,7 +39,8 @@ public:
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();
 
-  virtual double       GetDelay        ();
+  virtual double       GetDelay        () { return 0.0; }
+  virtual void         GetDelay        (AEDelayStatus& status);
   virtual double       GetCacheTotal   ();
   virtual unsigned int AddPackets      (uint8_t **data, unsigned int frames, unsigned int offset);
   virtual void         Drain           ();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -38,7 +38,8 @@ public:
     virtual bool Initialize  (AEAudioFormat &format, std::string &device);
     virtual void Deinitialize();
 
-    virtual double       GetDelay                    ();
+    virtual double       GetDelay()  { return 0.0; }
+    virtual void         GetDelay(AEDelayStatus& status);
     virtual double       GetCacheTotal               ();
     virtual unsigned int AddPackets                  (uint8_t **data, unsigned int frames, unsigned int offset);
     virtual void         Drain                       ();
@@ -57,6 +58,7 @@ private:
     IMMDevice          *m_pDevice;
     IAudioClient       *m_pAudioClient;
     IAudioRenderClient *m_pRenderClient;
+    IAudioClock        *m_pAudioClock;
 
     AEAudioFormat       m_format;
     enum AEDataFormat   m_encodedFormat;
@@ -76,7 +78,8 @@ private:
     unsigned int        m_uiBufferLen;    /* wasapi endpoint buffer size, in frames */
     double              m_avgTimeWaiting; /* time between next buffer of data from SoftAE and driver call for data */
     double              m_sinkLatency;    /* time in seconds of total duration of the two WASAPI buffers */
-    unsigned int        m_lastWriteToBuffer;
+    uint64_t            m_sinkFrames;
+    uint64_t            m_clockFreq;
 
     uint8_t            *m_pBuffer;
     int                 m_bufferPtr;

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -41,6 +41,16 @@ void   AEDelayStatus::SetDelay(double d)
   tick  = CurrentHostCounter();
 }
 
+double AEDelayStatus::GetDelay()
+{
+  double d = delay;
+  d -= (double)(CurrentHostCounter() - tick) / CurrentHostFrequency();
+  if(d < 0)
+    return 0.0;
+  else
+    return d;
+}
+
 CAEChannelInfo CAEUtil::GuessChLayout(const unsigned int channels)
 {
   CLog::Log(LOGWARNING, "CAEUtil::GuessChLayout - "

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -35,6 +35,12 @@ unsigned int CAEUtil::m_seed = (unsigned int)(CurrentHostCounter() / 1000.0f);
   MEMALIGN(16, __m128i CAEUtil::m_sseSeed) = _mm_set_epi32(CAEUtil::m_seed, CAEUtil::m_seed+1, CAEUtil::m_seed, CAEUtil::m_seed+1);
 #endif
 
+void   AEDelayStatus::SetDelay(double d)
+{
+  delay = d;
+  tick  = CurrentHostCounter();
+}
+
 CAEChannelInfo CAEUtil::GuessChLayout(const unsigned int channels)
 {
   CLog::Log(LOGWARNING, "CAEUtil::GuessChLayout - "

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -44,7 +44,8 @@ void   AEDelayStatus::SetDelay(double d)
 double AEDelayStatus::GetDelay()
 {
   double d = delay;
-  d -= (double)(CurrentHostCounter() - tick) / CurrentHostFrequency();
+  if(tick)
+    d -= (double)(CurrentHostCounter() - tick) / CurrentHostFrequency();
   if(d < 0)
     return 0.0;
   else

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -65,6 +65,7 @@ struct AEDelayStatus
   {}
 
   void   SetDelay(double d);
+  double GetDelay();
 
   double       delay;   /*!< delay in sink currently */
   int64_t      tick;    /*!< timestamp when delay was calculated */

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -71,6 +71,64 @@ struct AEDelayStatus
   int64_t      tick;    /*!< timestamp when delay was calculated */
 };
 
+/**
+ * @brief lockless consistency guaranteeer
+ *
+ * Requires write to be a higher priority thread
+ *
+ * use in writer:
+ *   m_locker.enter();
+ *   update_stuff();
+ *   m_locker.leave();
+ *
+ * use in reader:
+ *   CAESpinLock lock(m_locker);
+ *   do {
+ *     get_stuff();
+ *   } while(lock.retry());
+ */
+
+class CAESpinSection
+{
+public:
+  CAESpinSection()
+  : m_enter(0)
+  , m_leave(0)
+  {}
+
+  void enter() { m_enter++; }
+  void leave() { m_leave = m_enter; }
+
+protected:
+  friend class CAESpinLock;
+  volatile unsigned int m_enter;
+  volatile unsigned int m_leave;
+};
+
+class CAESpinLock
+{
+public:
+  CAESpinLock(CAESpinSection& section)
+  : m_section(section)
+  , m_begin(section.m_enter)
+  {}
+
+  bool retry()
+  {
+    if(m_section.m_enter != m_begin
+    || m_section.m_enter != m_section.m_leave)
+    {
+      m_begin = m_section.m_enter;
+      return true;
+    }
+    else
+      return false;
+  }
+
+private:
+  CAESpinSection& m_section;
+  unsigned int    m_begin;
+};
 
 class CAEUtil
 {

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -57,6 +57,20 @@ enum AVSync
   SYNC_RESAMPLE
 };
 
+struct AEDelayStatus
+{
+  AEDelayStatus()
+  : delay(0.0)
+  , tick(0)
+  {}
+
+  void   SetDelay(double d);
+
+  double       delay;   /*!< delay in sink currently */
+  int64_t      tick;    /*!< timestamp when delay was calculated */
+};
+
+
 class CAEUtil
 {
 private:

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -654,7 +654,7 @@ void CVideoReferenceClock::RunD3D()
     if ((RasterStatus.InVBlank && LastLine > 0) || (RasterStatus.ScanLine < LastLine))
     {
       //calculate how many vblanks happened
-      Now = CurrentHostCounter();
+      Now = CurrentHostCounter() - m_SystemFrequency * RasterStatus.ScanLine / (m_Height * m_RefreshRate);
       VBlankTime = (double)(Now - LastVBlankTime) / (double)m_SystemFrequency;
       NrVBlanks = MathUtils::round_int(VBlankTime * (double)m_RefreshRate);
 

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -885,7 +885,7 @@ static CVReturn DisplayLinkCallBack(CVDisplayLinkRef displayLink, const CVTimeSt
   void* pool = Cocoa_Create_AutoReleasePool();
 
   CVideoReferenceClock *VideoReferenceClock = reinterpret_cast<CVideoReferenceClock*>(displayLinkContext);
-  VideoReferenceClock->VblankHandler(inNow->hostTime, fps);
+  VideoReferenceClock->VblankHandler(inOutputTime->hostTime, fps);
 
   // Destroy the autorelease pool
   Cocoa_Destroy_AutoReleasePool(pool);


### PR DESCRIPTION
This improves clock precision of the video reference clock on windows dsound and AE GetDelay() calculations.

Sinks should be updated to new API and drop old GetDelay() functions. This allow them to calculate delay as part of AddPacket when delay is properly known and timestamp this information.

The timestamp should also likely be provided out from the GetDelay() function to players so it can adjust for some of the scheduling errors.
