### PR TITLE
Gotham: backport fix dvdplayer

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -475,8 +475,13 @@ void CDVDPlayerAudio::UpdatePlayerInfo()
 
   s << ", att:" << fixed << setprecision(1) << log(GetCurrentAttenuation()) * 20.0f << " dB";
 
+  SInfo info;
+  info.info        = s.str();
+  info.pts         = m_dvdAudio.GetPlayingPts();
+  info.passthrough = m_pAudioCodec && m_pAudioCodec->NeedPassthrough();
+
   { CSingleLock lock(m_info_section);
-    m_info = s.str();
+    m_info = info;
   }
 }
 
@@ -779,7 +784,7 @@ bool CDVDPlayerAudio::SwitchCodecIfNeeded()
 string CDVDPlayerAudio::GetPlayerInfo()
 {
   CSingleLock lock(m_info_section);
-  return m_info;
+  return m_info.info;
 }
 
 int CDVDPlayerAudio::GetAudioBitrate()
@@ -789,5 +794,6 @@ int CDVDPlayerAudio::GetAudioBitrate()
 
 bool CDVDPlayerAudio::IsPassthrough() const
 {
-  return m_pAudioCodec && m_pAudioCodec->NeedPassthrough();
+  CSingleLock lock(m_info_section);
+  return m_info.passthrough;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -142,7 +142,7 @@ public:
   CPTSOutputQueue m_ptsOutput;
   CPTSInputQueue  m_ptsInput;
 
-  double GetCurrentPts()                            { return m_dvdAudio.GetPlayingPts(); }
+  double GetCurrentPts()                            { CSingleLock lock(m_info_section); return m_info.pts; }
 
   bool IsStalled()                                  { return m_stalled;  }
   bool IsPassthrough() const;
@@ -230,8 +230,19 @@ protected:
   double m_maxspeedadjust;
   double m_resampleratio; //resample ratio when using SYNC_RESAMPLE, used for the codec info
 
+  struct SInfo
+  {
+    SInfo()
+    : pts(DVD_NOPTS_VALUE)
+    , passthrough(false)
+    {}
+
+    std::string      info;
+    double           pts;
+    bool             passthrough;
+  };
 
   CCriticalSection m_info_section;
-  std::string      m_info;
+  SInfo            m_info;
 };
 


### PR DESCRIPTION
That's a follow up of: https://github.com/xbmc/xbmc/commit/9fabae2973792279500586e3b98b522c648ea6a6 which was not PRd (by accident) but also should go into Gotham - 13.2 release.

Warning this one is for Gotham - as it's already in master.
