### PR TITLE
[AE/osxsink] - allow up to 16 channels in osx sink - fixes #15261

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -32,9 +32,17 @@
 
 #include <sstream>
 
-#define CA_MAX_CHANNELS 8
+#define CA_MAX_CHANNELS 16
 static enum AEChannel CAChannelMap[CA_MAX_CHANNELS + 1] = {
   AE_CH_FL , AE_CH_FR , AE_CH_BL , AE_CH_BR , AE_CH_FC , AE_CH_LFE , AE_CH_SL , AE_CH_SR ,
+  AE_CH_UNKNOWN1 ,
+  AE_CH_UNKNOWN2 ,
+  AE_CH_UNKNOWN3 ,
+  AE_CH_UNKNOWN4 ,
+  AE_CH_UNKNOWN5 ,
+  AE_CH_UNKNOWN6 ,
+  AE_CH_UNKNOWN7 ,
+  AE_CH_UNKNOWN8 ,
   AE_CH_NULL
 };
 


### PR DESCRIPTION
This is a temp fix which will be fixed properly once the channel mapping PR is ready. Its ment to be easily backported to Gotham.

Well finally we found a device which had 10 channels in one stream - so the limit to 8 is faulty here (well the limit to 16 is faulty too - as said once the channelmapping PR is ready - this limit will vanish because we will be able to use the real channel map of the device/stream).

Trac ticket for reference:

http://trac.xbmc.org/ticket/15261
