### PR TITLE
[pydocs] add comment for renaming/moving files across different filesystems

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.h
@@ -56,6 +56,9 @@ namespace XBMCAddon
      * 
      * file        : file to rename\n
      * newFileName : new filename, including the full path
+     *
+     * *Note, moving files between different filesystem (eg. local to nfs://) is not possible on\n
+     *        all platforms. You may have to do it manually by using the copy and deleteFile functions.\n
      * 
      * example:
      *   - success = xbmcvfs.rename(file,newFileName)


### PR DESCRIPTION
Adds a small note to avoid confusion about renaming/moving files via XBMC's vfs. See #15271 for more information.
