### PR TITLE
ActiveAE: fix reset of buffering after 51ff5b6e39a752787547dbe79f6c58206...

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1635,7 +1635,7 @@ bool CActiveAE::RunStages()
     {
       float buftime = (float)(*it)->m_inputBuffers->m_format.m_frames / (*it)->m_inputBuffers->m_format.m_sampleRate;
       time += buftime * (*it)->m_processingSamples.size();
-      while (time < MAX_CACHE_LEVEL && !(*it)->m_inputBuffers->m_freeSamples.empty())
+      while ((time < MAX_CACHE_LEVEL || (*it)->m_streamIsBuffering) && !(*it)->m_inputBuffers->m_freeSamples.empty())
       {
         buffer = (*it)->m_inputBuffers->GetFreeBuffer();
         (*it)->m_processingSamples.push_back(buffer);


### PR DESCRIPTION
...8f035a4

see title. buffering flag was not reset which causes paplayer to hang
fixes: http://trac.xbmc.org/ticket/15273
