### PR TITLE
AESinkPULSE: Don't eat frames

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -770,7 +770,10 @@ double CAESinkPULSE::GetCacheTotal()
 unsigned int CAESinkPULSE::AddPackets(uint8_t *data, unsigned int frames, bool hasAudio, bool blocking)
 {
   if (!m_IsAllocated)
-    return frames;
+  {
+    CLog::Log(LOGDEBUG, "AddPackets was called - but sink was not fully up and running");
+    return 0;
+  }
 
   pa_threaded_mainloop_lock(m_MainLoop);
 


### PR DESCRIPTION
I accidently told AE that all frames were eaten prior to the sink was up. This was wrong.

Warning: This is against Gotham branch as the PA fix will come into master via elupus clocks PR
