### PR TITLE
RenderCapture causes double vsync

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -169,7 +169,7 @@ void CXBMCRenderManager::WaitPresentTime(double presenttime)
 
   double clock     = CDVDClock::WaitAbsoluteClock(presenttime * DVD_TIME_BASE) / DVD_TIME_BASE;
   double target    = 0.5;
-  double error     = ( clock - presenttime ) / frametime - target;
+  double error     = ( clock - presenttime ) / frametime - target + 1.0;
 
   m_presenterr     = error;
 

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -1179,7 +1179,8 @@ int CVideoReferenceClock::GetRefreshRate(double* interval /*= NULL*/)
 
 
 //this is called from CDVDClock::WaitAbsoluteClock, which is called from CXBMCRenderManager::WaitPresentTime
-//it waits until a certain timestamp has passed, used for displaying videoframes at the correct moment
+//it waits for a certain timestamp has passed, used for displaying videoframes at the correct moment
+//if vblanks are used as a clock source, this will return between the two vblanks that surround Target
 int64_t CVideoReferenceClock::Wait(int64_t Target)
 {
   int64_t       Now;
@@ -1191,9 +1192,13 @@ int64_t CVideoReferenceClock::Wait(int64_t Target)
   {
     while (m_CurrTime < Target)
     {
+      int64_t NextVblank = TimeOfNextVblank();
+
+      if (Target < NextVblank)
+        break;
+
       //calculate how long to sleep before we should have gotten a signal that a vblank happened
       Now = CurrentHostCounter();
-      int64_t NextVblank = TimeOfNextVblank();
       SleepTime = (int)((NextVblank - Now) * 1000 / m_SystemFrequency);
 
       int64_t CurrTime = m_CurrTime; //save current value of the clock

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -1192,13 +1192,12 @@ int64_t CVideoReferenceClock::Wait(int64_t Target)
   {
     while (m_CurrTime < Target)
     {
-      int64_t NextVblank = TimeOfNextVblank();
-
-      if (Target < NextVblank)
+      if (Target < (m_CurrTime + UpdateInterval()))
         break;
 
       //calculate how long to sleep before we should have gotten a signal that a vblank happened
       Now = CurrentHostCounter();
+      int64_t NextVblank = TimeOfNextVblank();
       SleepTime = (int)((NextVblank - Now) * 1000 / m_SystemFrequency);
 
       int64_t CurrTime = m_CurrTime; //save current value of the clock

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -115,6 +115,10 @@ bool CWinSystemX11GL::PresentRenderImpl(const CDirtyRegionList& dirty)
 
 void CWinSystemX11GL::SetVSyncImpl(bool enable)
 {
+  /* already enabled and a good method determined? */
+  if (enable && (m_iVSyncMode != 0))
+    return;
+
   /* turn of current setting first */
   if(m_glXSwapIntervalEXT)
     m_glXSwapIntervalEXT(m_dpy, m_glWindow, 0);
@@ -127,10 +131,6 @@ void CWinSystemX11GL::SetVSyncImpl(bool enable)
     m_iVSyncMode = 0;
     return;
   }
-
-  /* already determined a good method? */
-  if (m_iVSyncMode != 0)
-    return;
 
   if (m_glXSwapIntervalEXT)
   {

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -126,19 +126,24 @@ void CWinSystemX11GL::SetVSyncImpl(bool enable)
   if(!enable)
     return;
 
-  if (m_glXSwapIntervalEXT && !m_iVSyncMode)
+  /* already determined a good method? */
+  if (m_iVSyncMode != 0)
+    return;
+
+  if (m_glXSwapIntervalEXT)
   {
     m_glXSwapIntervalEXT(m_dpy, m_glWindow, 1);
     m_iVSyncMode = 6;
   }
-  if (m_glXSwapIntervalMESA && !m_iVSyncMode)
+  else if (m_glXSwapIntervalMESA)
   {
     if(m_glXSwapIntervalMESA(1) == 0)
       m_iVSyncMode = 2;
     else
       CLog::Log(LOGWARNING, "%s - glXSwapIntervalMESA failed", __FUNCTION__);
   }
-  if (m_glXWaitVideoSyncSGI && m_glXGetVideoSyncSGI && !m_iVSyncMode)
+
+  if (m_glXWaitVideoSyncSGI && m_glXGetVideoSyncSGI)
   {
     unsigned int count;
     if(m_glXGetVideoSyncSGI(&count) == 0)

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -123,8 +123,10 @@ void CWinSystemX11GL::SetVSyncImpl(bool enable)
 
   m_iVSyncErrors = 0;
 
-  if(!enable)
+  if(!enable) {
+    m_iVSyncMode = 0;
     return;
+  }
 
   /* already determined a good method? */
   if (m_iVSyncMode != 0)

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -83,11 +83,11 @@ bool CWinSystemX11GL::PresentRenderImpl(const CDirtyRegionList& dirty)
     if(m_glXGetVideoSyncSGI(&before) != 0)
       CLog::Log(LOGERROR, "%s - glXGetVideoSyncSGI - Failed to get current retrace count", __FUNCTION__);
 
-    if(m_glXWaitVideoSyncSGI(2, (before+1)%2, &swap) != 0)
-      CLog::Log(LOGERROR, "%s - glXWaitVideoSyncSGI - Returned error", __FUNCTION__);
-
     glXSwapBuffers(m_dpy, m_glWindow);
     glFinish();
+
+    if(m_glXWaitVideoSyncSGI(2, (before+1)%2, &swap) != 0)
+      CLog::Log(LOGERROR, "%s - glXWaitVideoSyncSGI - Returned error", __FUNCTION__);
 
     if(m_glXGetVideoSyncSGI(&after) != 0)
       CLog::Log(LOGERROR, "%s - glXGetVideoSyncSGI - Failed to get current retrace count", __FUNCTION__);


### PR DESCRIPTION
This is somewhat long, but bare with me as it has serious consequences. :smiley: 

First the symptoms; Enabling RenderCapture (e.g. using the boblight plugin) results in the frame rate being limited to half the refresh rate. This is of course bad, but gets unusable when you set XBMC to adapt refresh rate to the frame rate. At 24 fps film will then play at 12 fps.

I confirmed that the limit was clearly following the refresh rate, so it was obviously an extra vblank wait that was happening. I started by reporting a bug against the driver, and doing investigation on that end:

https://bugs.freedesktop.org/show_bug.cgi?id=79223

The gist of it is that some drivers (in my case the r600 gallium driver) will wait for pending swap buffer requests on some rendering commands. This wreaks havoc with how XBMC schedules rendering and buffer swaps. In the normal case, XBMC will do:
1. Render the frame. This causes an unexpected wait for vsync.
2. Wait for the correct time to swap buffers. At this point the time is -0.5 frames. I.e. it won't wait.
3. Schedule a buffer swap.

By dumb luck, this happens to work. But once you enable RenderCapture, it goes south:
1. Render the frame. No delay is seen here.
2. Wait for the correct time to swap buffers. Request time is 0.5 frames, but results in waiting for the next vblank.
3. Schedule a buffer swap.
4. Render the frame again for RenderCapture. This causes another wait for vblank.
5. Notice the next frame is late and drop it.

Hence, since we have two waits for vblank, we get a too restricted frame rate.

Unfortunately it cannot be easily fixed in that end, so I started looking at making xbmc play nice with less capable drivers instead. The commits in this PR are the result of that. There are three fixes:
1. We're waiting too long before swapping buffers. The code is written to expect a delay of 0.5 frames. But the code waits for the optimal time, then the vblank after that. And a swap scheduled just after the vblank won't actually occur until the next vblank. Meaning that we get 1.5 frames of delay instead. The commit makes sure we break one vblank earlier so that we can present the frame with the intended delay.
2. The code for glXWaitVideoSyncSGI() did not work well when glXSwapBuffers() waits for vblank. In that case you'd get first a pointless wait, then the scheduled swap, and then another wait for the swap to occur.
3. Always make use of glXWaitVideoSyncSGI() when available so that the buffer swaps are synchronous. Without this you'll have some variation in XBMC's frame scheduling that isn't desirable.

PR is against master, but it was tested with Gotham.
