### PR TITLE
[osx] build fix for make (tests etc.) on darwin with llvm.

### DIFF
--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -38,12 +38,6 @@
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 
-#if defined(__ppc__) || \
-    defined(__powerpc__) || \
-    defined(__arm__)
-  #define DISABLE_MATHUTILS_ASM_TRUNCATE_INT
-#endif
-
 /*! \brief Math utility class.
  Note that the test() routine should return true for all implementations
 
@@ -164,39 +158,7 @@ namespace MathUtils
   {
     assert(x > static_cast<double>(INT_MIN / 2) - 1.0);
     assert(x < static_cast<double>(INT_MAX / 2) + 1.0);
-
-#if defined(DISABLE_MATHUTILS_ASM_TRUNCATE_INT)
     return x;
-
-#else
-    int i;
-#if defined(TARGET_WINDOWS)
-    const float round_towards_m_i = -0.5f;
-    __asm
-    {
-      fld x
-      fadd st, st (0)
-      fabs
-      fadd round_towards_m_i
-      fistp i
-      sar i, 1
-    }
-
-#else
-    const float round_towards_m_i = -0.5f;
-    __asm__ __volatile__ (
-      "fadd %%st\n\t"
-      "fabs\n\t"
-      "fadd %%st(1)\n\t"
-      "fistpl %0\n\t"
-      "sarl $1, %0\n"
-      : "=m"(i) : "u"(round_towards_m_i), "t"(x) : "st"
-    );
-#endif
-    if (x < 0)
-      i = -i;
-    return (i);
-#endif
   }
 
   inline int64_t abs(int64_t a)


### PR DESCRIPTION
The asm we're using for truncate_int() (largely unused) is no-worky.

Note that this was like this before https://github.com/xbmc/xbmc/pull/3760 was merged.

Ideally we'd have an SSE implementation here, or just kill the ASM which is likely slower than just truncating directly.

@bavison any comment on the speed of the truncate_int() implementation?

(It's only used in GUIFontTTF.cpp, and can probably be removed altogether which is another option).
