### PR TITLE
Add support for ALSA channel mapping API

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -292,9 +292,14 @@ bool CAESinkALSA::InitializeHW(const ALSAConfig &inconfig, ALSAConfig &outconfig
   snd_pcm_hw_params_set_access(m_pcm, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED);
 
   unsigned int sampleRate   = inconfig.sampleRate;
-  unsigned int channelCount = inconfig.channels;
   snd_pcm_hw_params_set_rate_near    (m_pcm, hw_params, &sampleRate, NULL);
-  snd_pcm_hw_params_set_channels_near(m_pcm, hw_params, &channelCount);
+
+  unsigned int channelCount = inconfig.channels;
+  /* select a channel count >=wanted, or otherwise the highest available */
+  if (snd_pcm_hw_params_set_channels_min(m_pcm, hw_params, &channelCount) == 0)
+    snd_pcm_hw_params_set_channels_first(m_pcm, hw_params, &channelCount);
+  else
+    snd_pcm_hw_params_set_channels_last(m_pcm, hw_params, &channelCount);
 
   /* ensure we opened X channels or more */
   if (inconfig.channels > channelCount)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -50,7 +50,22 @@ public:
 
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 private:
-  CAEChannelInfo GetChannelLayout(AEAudioFormat format, unsigned int minChannels, unsigned int maxChannels);
+  CAEChannelInfo GetChannelLayoutRaw(AEDataFormat dataFormat);
+  CAEChannelInfo GetChannelLayoutLegacy(const AEAudioFormat& format, unsigned int minChannels, unsigned int maxChannels);
+  CAEChannelInfo GetChannelLayout(const AEAudioFormat& format, unsigned int channels);
+
+#ifdef SND_CHMAP_API_VERSION
+  static bool AllowALSAMaps();
+  static AEChannel ALSAChannelToAEChannel(unsigned int alsaChannel);
+  static unsigned int AEChannelToALSAChannel(AEChannel aeChannel);
+  static CAEChannelInfo ALSAchmapToAEChannelMap(snd_pcm_chmap_t* alsaMap);
+  static snd_pcm_chmap_t* AEChannelMapToALSAchmap(const CAEChannelInfo& info);
+  static snd_pcm_chmap_t* CopyALSAchmap(snd_pcm_chmap_t* alsaMap);
+  static std::string ALSAchmapToString(snd_pcm_chmap_t* alsaMap);
+  static CAEChannelInfo GetAlternateLayoutForm(const CAEChannelInfo& info);
+  snd_pcm_chmap_t* SelectALSAChannelMap(const CAEChannelInfo& info);
+#endif
+
   void           GetAESParams(const AEAudioFormat format, std::string& params);
   void           HandleError(const char* name, int err);
 

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -289,7 +289,7 @@ bool CAEChannelInfo::HasChannel(const enum AEChannel ch) const
   return false;
 }
 
-bool CAEChannelInfo::ContainsChannels(CAEChannelInfo& rhs) const
+bool CAEChannelInfo::ContainsChannels(const CAEChannelInfo& rhs) const
 {
   for (unsigned int i = 0; i < rhs.m_channelCount; ++i)
   {

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "AEChannelInfo.h"
+#include <limits>
 #include <string.h>
 
 CAEChannelInfo::CAEChannelInfo()
@@ -297,4 +298,69 @@ bool CAEChannelInfo::ContainsChannels(const CAEChannelInfo& rhs) const
       return false;
   }
   return true;
+}
+
+void CAEChannelInfo::ReplaceChannel(const enum AEChannel from, const enum AEChannel to)
+{
+  for (unsigned int i = 0; i < m_channelCount; ++i)
+  {
+    if (m_channels[i] == from)
+    {
+      m_channels[i] = to;
+      break;
+    }
+  }
+}
+
+int CAEChannelInfo::BestMatch(const std::vector<CAEChannelInfo>& dsts, int* score) const
+{
+  CAEChannelInfo availableDstChannels;
+  for (unsigned int i = 0; i < dsts.size(); i++)
+    availableDstChannels.AddMissingChannels(dsts[i]);
+
+  /* if we have channels not existing in any destination layout but that
+   * are remappable (e.g. RC => RL+RR), do those remaps */
+  CAEChannelInfo src(*this);
+  src.ResolveChannels(availableDstChannels);
+
+  bool remapped = (src != *this);
+  /* good enough approximation (does not account for added channels) */
+  int dropped = std::max((int)src.Count() - (int)Count(), 0);
+
+  int bestScore = std::numeric_limits<int>::min();
+  int bestMatch = -1;
+
+  for (unsigned int i = 0; i < dsts.size(); i++)
+  {
+    const CAEChannelInfo& dst = dsts[i];
+    int okChannels = 0;
+
+    for (unsigned int j = 0; j < src.Count(); j++)
+      okChannels += dst.HasChannel(src[j]);
+
+    int missingChannels = src.Count() - okChannels;
+    int extraChannels = dst.Count() - okChannels;
+
+    int curScore = 0 - (missingChannels + dropped) * 1000 - extraChannels * 10 - remapped;
+
+    if (curScore > bestScore)
+    {
+      bestScore = curScore;
+      bestMatch = i;
+      if (curScore == 0)
+        break;
+    }
+  }
+
+  if (score)
+    *score = bestScore;
+
+  return bestMatch;
+}
+
+void CAEChannelInfo::AddMissingChannels(const CAEChannelInfo& rhs)
+{
+  for (unsigned int i = 0; i < rhs.Count(); i++)
+    if (!HasChannel(rhs[i]))
+      *this += rhs[i];
 }

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
@@ -20,6 +20,7 @@
  */
 
 #include <stdint.h>
+#include <vector>
 #include "utils/StdString.h"
 
 /**
@@ -92,6 +93,10 @@ public:
   static const char* GetChName(const enum AEChannel ch);
   bool HasChannel(const enum AEChannel ch) const;
   bool ContainsChannels(const CAEChannelInfo& rhs) const;
+  void ReplaceChannel(const enum AEChannel from, const enum AEChannel to);
+  int BestMatch(const std::vector<CAEChannelInfo>& dsts, int* score = NULL) const;
+  void AddMissingChannels(const CAEChannelInfo& rhs);
+
 private:
   unsigned int   m_channelCount;
   enum AEChannel m_channels[AE_CH_MAX];

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
@@ -91,7 +91,7 @@ public:
   inline unsigned int Count() const { return m_channelCount; }
   static const char* GetChName(const enum AEChannel ch);
   bool HasChannel(const enum AEChannel ch) const;
-  bool ContainsChannels(CAEChannelInfo& rhs) const;
+  bool ContainsChannels(const CAEChannelInfo& rhs) const;
 private:
   unsigned int   m_channelCount;
   enum AEChannel m_channels[AE_CH_MAX];


### PR DESCRIPTION
```
Add support for the ALSA channel mapping API. This functionality
requires alsa-lib v1.0.27.

This allows
1) selection of a best-matching channel layout when multiple layouts are
   available, and
2) reporting the actual layout back to AE, instead of the ALSA default
   legacy layout which is sometimes incorrect.

In practice, this means:

1) Devices that do not use the standard ALSA layout will now have
   correct channel mapping without ALSA configuration tricks. Such
   devices include at least:
    - 1st gen NVIDIA ION
    - some 2.1 laptop speakers
    - many embedded audio devices

2) HDMI output is now possible at "proper" 2.1, 5.0 PCM layouts (and any
   of the more unusual ones, such as 4.1, 3f, 2f+1r) without resorting to
   adding empty channels as such layouts are handled currently. This
   means that the A/V receiver will now see the correct format, instead
   of the "virtual" 5.1/7.1.

3) HDMI output is now configured to use the exact layout given from AE,
   when possible, so that AE does not need to do any remapping if it
   does not want to (the audio hardware will perform that instead).

4) Layouts containing the more unusual channel positions such as
   AE_CH_TFL, AE_CH_TC, etc, are now supported by the ALSA sink.
   However, currently CActiveAE::ApplySettingsToFormat() always
   force-resolves the stream layout to a standard layout, preventing
   the playback of such channels for now.

2,3,4 above require this post-v1.0.27.2 alsa-lib fix in most cases:
http://git.alsa-project.org/?p=alsa-lib.git;a=commitdiff;h=042223c4ee9b17ba8a24bcfc4019f24b69b8310b

Some Linux kernels between 3.7 and 3.12 contain bugs in the HDA HDMI
driver causing incorrect multichannel mapping in some cases. The most
severe issues that affected common channel layouts were fixed in
November 2013 in versions 3.10.20, 3.11.9, 3.12.1, the rest in 3.12.15
and 3.13.

To avoid any regressions, blacklist everything between 3.7 and 3.12.15.
```

@fritsch, @FernetMenta - opinions and suggestions welcome.
