### PR TITLE
Use CURL in IDirectory et. al.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3895,7 +3895,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   if (URIUtils::IsUPnP(item.GetPath()))
   {
     CFileItem item_new(item);
-    if (XFILE::CUPnPDirectory::GetResource(item.GetPath(), item_new))
+    if (XFILE::CUPnPDirectory::GetResource(item.GetURL(), item_new))
       return PlayFile(item_new, false);
     return PLAYBACK_FAIL;
   }
@@ -4840,7 +4840,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 #ifdef HAS_UPNP
       if (URIUtils::IsUPnP(file.GetPath()))
       {
-        if (!XFILE::CUPnPDirectory::GetResource(file.GetPath(), file))
+        if (!XFILE::CUPnPDirectory::GetResource(file.GetURL(), file))
           return true;
       }
 #endif

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3636,7 +3636,7 @@ bool CApplication::PlayMedia(const CFileItem& item, int iPlaylist)
     {
       CSmartPlaylist smartpl;
       //get name and type of smartplaylist, this will always succeed as GetDirectory also did this.
-      smartpl.OpenAndReadName(item.GetPath());
+      smartpl.OpenAndReadName(item.GetURL());
       CPlayList playlist;
       playlist.Add(items);
       return ProcessAndStartPlaylist(smartpl.GetName(), playlist, (smartpl.GetType() == "songs" || smartpl.GetType() == "albums") ? PLAYLIST_MUSIC:PLAYLIST_VIDEO);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3699,7 +3699,7 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
   {
     CStackDirectory dir;
     CFileItemList movieList;
-    dir.GetDirectory(item.GetPath(), movieList);
+    dir.GetDirectory(item.GetURL(), movieList);
 
     // first assume values passed to the stack
     int selectedFile = item.m_lStartPartNumber;
@@ -3765,7 +3765,7 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
 
     // calculate the total time of the stack
     CStackDirectory dir;
-    dir.GetDirectory(item.GetPath(), *m_currentStack);
+    dir.GetDirectory(item.GetURL(), *m_currentStack);
     long totalTime = 0;
     for (int i = 0; i < m_currentStack->Size(); i++)
     {

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -608,7 +608,7 @@ static void CopyUserDataIfNeeded(const CStdString &strPath, const CStdString &fi
   {
     // need to copy it across
     CStdString srcPath = URIUtils::AddFileToFolder("special://xbmc/userdata/", file);
-    CFile::Cache(srcPath, destPath);
+    CFile::Copy(srcPath, destPath);
   }
 }
 

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -109,7 +109,8 @@ bool CAutorun::PlayDisc(const CStdString& path, bool bypassSettings, bool startF
     mediaPath = g_mediaManager.TranslateDevicePath("");
 #endif
 
-  auto_ptr<IDirectory> pDir ( CDirectoryFactory::Create( mediaPath ));
+  const CURL pathToUrl(mediaPath);
+  auto_ptr<IDirectory> pDir ( CDirectoryFactory::Create( pathToUrl ));
   bool bPlaying = RunDisc(pDir.get(), mediaPath, nAddedToPlaylist, true, bypassSettings, startFromBeginning);
 
   if ( !bPlaying && nAddedToPlaylist > 0 )

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -132,7 +132,8 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
   bool bPlaying(false);
   CFileItemList vecItems;
 
-  if ( !pDir->GetDirectory( strDrive, vecItems ) )
+  const CURL pathToUrl(strDrive);
+  if ( !pDir->GetDirectory( pathToUrl, vecItems ) )
   {
     return false;
   }
@@ -376,7 +377,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
           // TODO: remove this once the app/player is capable of handling stacks immediately
           CStackDirectory dir;
           CFileItemList items;
-          dir.GetDirectory(pItem->GetPath(), items);
+          dir.GetDirectory(pItem->GetURL(), items);
           itemlist.Append(items);
         }
         else

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -71,28 +71,13 @@ using namespace EPG;
 
 CFileItem::CFileItem(const CSong& song)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
-
+  Initialize();
   SetFromSong(song);
 }
 
 CFileItem::CFileItem(const CURL &url, const CAlbum& album)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
 
   m_strPath = url.Get();
   URIUtils::AddSlashAtEnd(m_strPath);
@@ -101,14 +86,7 @@ CFileItem::CFileItem(const CURL &url, const CAlbum& album)
 
 CFileItem::CFileItem(const CStdString &path, const CAlbum& album)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
 
   m_strPath = path;
   URIUtils::AddSlashAtEnd(m_strPath);
@@ -117,14 +95,7 @@ CFileItem::CFileItem(const CStdString &path, const CAlbum& album)
 
 CFileItem::CFileItem(const CMusicInfoTag& music)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
   SetLabel(music.GetTitle());
   m_strPath = music.GetURL();
   m_bIsFolder = URIUtils::HasSlashAtEnd(m_strPath);
@@ -135,29 +106,13 @@ CFileItem::CFileItem(const CMusicInfoTag& music)
 
 CFileItem::CFileItem(const CVideoInfoTag& movie)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
-
+  Initialize();
   SetFromVideoInfoTag(movie);
 }
 
 CFileItem::CFileItem(const CEpgInfoTag& tag)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-
-  Reset();
+  Initialize();
 
   m_strPath = tag.Path();
   m_bIsFolder = false;
@@ -176,15 +131,8 @@ CFileItem::CFileItem(const CEpgInfoTag& tag)
 
 CFileItem::CFileItem(const CPVRChannel& channel)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
+  Initialize();
 
-  Reset();
   CEpgInfoTag epgNow;
   bool bHasEpgNow = channel.GetEPGNow(epgNow);
 
@@ -227,15 +175,7 @@ CFileItem::CFileItem(const CPVRChannel& channel)
 
 CFileItem::CFileItem(const CPVRRecording& record)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag   = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-
-  Reset();
+  Initialize();
 
   m_strPath = record.m_strFileNameAndPath;
   m_bIsFolder = false;
@@ -248,15 +188,7 @@ CFileItem::CFileItem(const CPVRRecording& record)
 
 CFileItem::CFileItem(const CPVRTimerInfoTag& timer)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-
-  Reset();
+  Initialize();
 
   m_strPath = timer.Path();
   m_bIsFolder = false;
@@ -273,14 +205,7 @@ CFileItem::CFileItem(const CPVRTimerInfoTag& timer)
 
 CFileItem::CFileItem(const CArtist& artist)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
   SetLabel(artist.strArtist);
   m_strPath = artist.strArtist;
   m_bIsFolder = true;
@@ -291,14 +216,7 @@ CFileItem::CFileItem(const CArtist& artist)
 
 CFileItem::CFileItem(const CGenre& genre)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
   SetLabel(genre.strGenre);
   m_strPath = genre.strGenre;
   m_bIsFolder = true;
@@ -321,15 +239,8 @@ CFileItem::CFileItem(const CFileItem& item): CGUIListItem()
 
 CFileItem::CFileItem(const CGUIListItem& item)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
-  // not particularly pretty, but it gets around the issue of Reset() defaulting
+  Initialize();
+  // not particularly pretty, but it gets around the issue of Initialize() defaulting
   // parameters in the CGUIListItem base class.
   *((CGUIListItem *)this) = item;
 
@@ -338,40 +249,19 @@ CFileItem::CFileItem(const CGUIListItem& item)
 
 CFileItem::CFileItem(void)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
 }
 
 CFileItem::CFileItem(const CStdString& strLabel)
     : CGUIListItem()
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
   SetLabel(strLabel);
 }
 
 CFileItem::CFileItem(const CURL& path, bool bIsFolder)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
   m_strPath = path.Get();
   m_bIsFolder = bIsFolder;
   // tuxbox urls cannot have a / at end
@@ -382,14 +272,7 @@ CFileItem::CFileItem(const CURL& path, bool bIsFolder)
 
 CFileItem::CFileItem(const CStdString& strPath, bool bIsFolder)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
   m_strPath = strPath;
   m_bIsFolder = bIsFolder;
   // tuxbox urls cannot have a / at end
@@ -400,14 +283,7 @@ CFileItem::CFileItem(const CStdString& strPath, bool bIsFolder)
 
 CFileItem::CFileItem(const CMediaSource& share)
 {
-  m_musicInfoTag = NULL;
-  m_videoInfoTag = NULL;
-  m_epgInfoTag = NULL;
-  m_pvrChannelInfoTag = NULL;
-  m_pvrRecordingInfoTag = NULL;
-  m_pvrTimerInfoTag = NULL;
-  m_pictureInfoTag = NULL;
-  Reset();
+  Initialize();
   m_bIsFolder = true;
   m_bIsShareOrDrive = true;
   m_strPath = share.strPath;
@@ -571,23 +447,20 @@ const CFileItem& CFileItem::operator=(const CFileItem& item)
   return *this;
 }
 
-void CFileItem::Reset()
+void CFileItem::Initialize()
 {
-  m_strLabel2.clear();
-  SetLabel("");
+  m_musicInfoTag = NULL;
+  m_videoInfoTag = NULL;
+  m_epgInfoTag = NULL;
+  m_pvrChannelInfoTag = NULL;
+  m_pvrRecordingInfoTag = NULL;
+  m_pvrTimerInfoTag = NULL;
+  m_pictureInfoTag = NULL;
   m_bLabelPreformated=false;
-  FreeIcons();
-  m_overlayIcon = ICON_OVERLAY_NONE;
-  m_bSelected = false;
   m_bIsAlbum = false;
-  m_strDVDLabel.clear();
-  m_strTitle.clear();
-  m_strPath.clear();
   m_dwSize = 0;
-  m_bIsFolder = false;
   m_bIsParentFolder=false;
   m_bIsShareOrDrive = false;
-  m_dateTime.Reset();
   m_iDriveType = CMediaSource::SOURCE_TYPE_UNKNOWN;
   m_lStartOffset = 0;
   m_lStartPartNumber = 1;
@@ -595,11 +468,28 @@ void CFileItem::Reset()
   m_iprogramCount = 0;
   m_idepth = 1;
   m_iLockMode = LOCK_MODE_EVERYONE;
-  m_strLockCode = "";
   m_iBadPwdCount = 0;
   m_iHasLock = 0;
   m_bCanQueue=true;
-  m_mimetype = "";
+  m_specialSort = SortSpecialNone;
+}
+
+void CFileItem::Reset()
+{
+  // CGUIListItem members...
+  m_strLabel2.clear();
+  SetLabel("");
+  FreeIcons();
+  m_overlayIcon = ICON_OVERLAY_NONE;
+  m_bSelected = false;
+  m_bIsFolder = false;
+
+  m_strDVDLabel.clear();
+  m_strTitle.clear();
+  m_strPath.clear();
+  m_dateTime.Reset();
+  m_strLockCode.clear();
+  m_mimetype.clear();
   delete m_musicInfoTag;
   m_musicInfoTag=NULL;
   delete m_videoInfoTag;
@@ -615,8 +505,9 @@ void CFileItem::Reset()
   delete m_pictureInfoTag;
   m_pictureInfoTag=NULL;
   m_extrainfo.clear();
-  m_specialSort = SortSpecialNone;
   ClearProperties();
+
+  Initialize();
   SetInvalid();
 }
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -83,6 +83,22 @@ CFileItem::CFileItem(const CSong& song)
   SetFromSong(song);
 }
 
+CFileItem::CFileItem(const CURL &url, const CAlbum& album)
+{
+  m_musicInfoTag = NULL;
+  m_videoInfoTag = NULL;
+  m_epgInfoTag = NULL;
+  m_pvrChannelInfoTag = NULL;
+  m_pvrRecordingInfoTag = NULL;
+  m_pvrTimerInfoTag = NULL;
+  m_pictureInfoTag = NULL;
+  Reset();
+
+  m_strPath = url.Get();
+  URIUtils::AddSlashAtEnd(m_strPath);
+  SetFromAlbum(album);
+}
+
 CFileItem::CFileItem(const CStdString &path, const CAlbum& album)
 {
   m_musicInfoTag = NULL;
@@ -344,6 +360,24 @@ CFileItem::CFileItem(const CStdString& strLabel)
   m_pictureInfoTag = NULL;
   Reset();
   SetLabel(strLabel);
+}
+
+CFileItem::CFileItem(const CURL& path, bool bIsFolder)
+{
+  m_musicInfoTag = NULL;
+  m_videoInfoTag = NULL;
+  m_epgInfoTag = NULL;
+  m_pvrChannelInfoTag = NULL;
+  m_pvrRecordingInfoTag = NULL;
+  m_pvrTimerInfoTag = NULL;
+  m_pictureInfoTag = NULL;
+  Reset();
+  m_strPath = path.Get();
+  m_bIsFolder = bIsFolder;
+  // tuxbox urls cannot have a / at end
+  if (m_bIsFolder && !m_strPath.empty() && !IsFileFolder() && !URIUtils::IsTuxBox(m_strPath))
+    URIUtils::AddSlashAtEnd(m_strPath);
+  FillInMimeType(false);
 }
 
 CFileItem::CFileItem(const CStdString& strPath, bool bIsFolder)
@@ -1590,6 +1624,24 @@ std::string CFileItem::GetOpticalMediaPath() const
   }
 #endif
   return dvdPath;
+}
+
+/*
+ TODO: Ideally this (and SetPath) would not be available outside of construction
+ for CFileItem objects, or at least restricted to essentially be equivalent
+ to construction. This would require re-formulating a bunch of CFileItem
+ construction, and also allowing CFileItemList to have it's own (public)
+ SetURL() function, so for now we give direct access.
+ */
+void CFileItem::SetURL(const CURL& url)
+{
+  m_strPath = url.Get();
+}
+
+const CURL CFileItem::GetURL() const
+{
+  CURL url(m_strPath);
+  return url;
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -91,8 +91,10 @@ public:
   CFileItem(const CFileItem& item);
   CFileItem(const CGUIListItem& item);
   CFileItem(const CStdString& strLabel);
+  CFileItem(const CURL& path, bool bIsFolder);
   CFileItem(const CStdString& strPath, bool bIsFolder);
   CFileItem(const CSong& song);
+  CFileItem(const CURL &path, const CAlbum& album);
   CFileItem(const CStdString &path, const CAlbum& album);
   CFileItem(const CArtist& artist);
   CFileItem(const CGenre& genre);
@@ -106,6 +108,8 @@ public:
   virtual ~CFileItem(void);
   virtual CGUIListItem *Clone() const { return new CFileItem(*this); };
 
+  const CURL GetURL() const;
+  void SetURL(const CURL& url);
   const CStdString &GetPath() const { return m_strPath; };
   void SetPath(const CStdString &path) { m_strPath = path; };
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -113,6 +113,10 @@ public:
   const CStdString &GetPath() const { return m_strPath; };
   void SetPath(const CStdString &path) { m_strPath = path; };
 
+  /*! \brief reset class to it's default values as per construction.
+   Free's all allocated memory.
+   \sa Initialize
+   */
   void Reset();
   const CFileItem& operator=(const CFileItem& item);
   virtual void Archive(CArchive& ar);
@@ -458,6 +462,12 @@ public:
   int m_iBadPwdCount;
 
 private:
+  /*! \brief initialize all members of this class (not CGUIListItem members) to default values.
+   Called from constructors, and from Reset()
+   \sa Reset, CGUIListItem
+   */
+  void Initialize();
+
   CStdString m_strPath;            ///< complete path to item
 
   SortSpecial m_specialSort;

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -323,7 +323,7 @@ bool CTextureCache::Export(const CStdString &image, const CStdString &destinatio
     CStdString dest = destination + URIUtils::GetExtension(cachedImage);
     if (overwrite || !CFile::Exists(dest))
     {
-      if (CFile::Cache(cachedImage, dest))
+      if (CFile::Copy(cachedImage, dest))
         return true;
       CLog::Log(LOGERROR, "%s failed exporting '%s' to '%s'", __FUNCTION__, cachedImage.c_str(), dest.c_str());
     }
@@ -337,7 +337,7 @@ bool CTextureCache::Export(const CStdString &image, const CStdString &destinatio
   CStdString cachedImage(GetCachedImage(image, details));
   if (!cachedImage.empty())
   {
-    if (CFile::Cache(cachedImage, destination))
+    if (CFile::Copy(cachedImage, destination))
       return true;
     CLog::Log(LOGERROR, "%s failed exporting '%s' to '%s'", __FUNCTION__, cachedImage.c_str(), destination.c_str());
   }

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -537,10 +537,8 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
   if (m_strProtocol.Equals("stack"))
   {
     CFileItemList items;
-    std::string strURL2;
-    strURL2 = Get();
     XFILE::CStackDirectory dir;
-    dir.GetDirectory(strURL2,items);
+    dir.GetDirectory(*this,items);
     vector<std::string> newItems;
     for (int i=0;i<items.Size();++i)
     {

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -29,9 +29,12 @@
 class CURL
 {
 public:
-  CURL(const CStdString& strURL);
+  explicit CURL(const CStdString& strURL);
   CURL();
   virtual ~CURL(void);
+
+  // explicit equals operator for std::string comparison
+  bool operator==(const std::string &url) const { return Get() == url; }
 
   void Reset();
   void Parse(const CStdString& strURL);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -131,31 +131,37 @@ CUtil::~CUtil(void)
 
 CStdString CUtil::GetTitleFromPath(const CStdString& strFileNameAndPath, bool bIsFolder /* = false */)
 {
+  CURL pathToUrl(strFileNameAndPath);
+  return GetTitleFromPath(pathToUrl, bIsFolder);
+}
+
+CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */)
+{
   // use above to get the filename
-  CStdString path(strFileNameAndPath);
+  CStdString path(url.Get());
   URIUtils::RemoveSlashAtEnd(path);
   CStdString strFilename = URIUtils::GetFileName(path);
 
-  CURL url(strFileNameAndPath);
   CStdString strHostname = url.GetHostName();
 
 #ifdef HAS_UPNP
   // UPNP
   if (url.GetProtocol() == "upnp")
-    strFilename = CUPnPDirectory::GetFriendlyName(strFileNameAndPath.c_str());
+    strFilename = CUPnPDirectory::GetFriendlyName(url);
 #endif
 
   if (url.GetProtocol() == "rss")
   {
     CRSSDirectory dir;
     CFileItemList items;
-    if(dir.GetDirectory(strFileNameAndPath, items) && !items.m_strTitle.empty())
+    if(dir.GetDirectory(url.Get(), items) && !items.m_strTitle.empty())
       return items.m_strTitle;
   }
 
   // Shoutcast
   else if (url.GetProtocol() == "shout")
   {
+    const CStdString strFileNameAndPath = url.Get();
     const int genre = strFileNameAndPath.find_first_of('=');
     if(genre <0)
       strFilename = g_localizeStrings.Get(260);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2042,7 +2042,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
           for (unsigned int k = 0; k < TagConv.m_Langclass.size(); k++)
           {
             strDest = StringUtils::Format("special://temp/subtitle.%s.%d.smi", TagConv.m_Langclass[k].Name.c_str(), i);
-            if (CFile::Cache(vecSubtitles[i], strDest))
+            if (CFile::Copy(vecSubtitles[i], strDest))
             {
               CLog::Log(LOGINFO, " cached subtitle %s->%s\n", vecSubtitles[i].c_str(), strDest.c_str());
               vecSubtitles.push_back(strDest);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -154,7 +154,7 @@ CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */
   {
     CRSSDirectory dir;
     CFileItemList items;
-    if(dir.GetDirectory(url.Get(), items) && !items.m_strTitle.empty())
+    if(dir.GetDirectory(url, items) && !items.m_strTitle.empty())
       return items.m_strTitle;
   }
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -68,6 +68,7 @@ public:
   CUtil(void);
   virtual ~CUtil(void);
   static void CleanString(const CStdString& strFileName, CStdString& strTitle, CStdString& strTitleAndYear, CStdString& strYear, bool bRemoveExtension = false, bool bCleanChars = true);
+  static CStdString GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static CStdString GetTitleFromPath(const CStdString& strFileNameAndPath, bool bIsFolder = false);
   static void GetQualifiedFilename(const CStdString &strBasePath, CStdString &strFilename);
   static void RunShortcut(const char* szPath);

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -172,7 +172,7 @@ bool CAddonDll<TheDll, TheStruct, TheProps>::LoadDll()
     strFileName += "-" + ID() + extension;
 
     if (!CFile::Exists(strFileName))
-      CFile::Cache(LibPath(), strFileName);
+      CFile::Copy(LibPath(), strFileName);
 
     CLog::Log(LOGNOTICE, "ADDON: Loaded virtual child addon %s", strFileName.c_str());
   }

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -120,7 +120,7 @@ bool CCDDARipJob::DoWork()
   if (file.IsRemote() && !cancelled && result == 2)
   {
     // copy the ripped track to the share
-    if (!CFile::Cache(m_output, file.GetPath()))
+    if (!CFile::Copy(m_output, file.GetPath()))
     {
       CLog::Log(LOGERROR, "CDDARipper: Error copying file from %s to %s", 
                 m_output.c_str(), file.GetPath().c_str());

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -106,7 +106,7 @@ bool CCDDARipper::RipCD()
   // get cd cdda contents
   CFileItemList vecItems;
   XFILE::CCDDADirectory directory;
-  directory.GetDirectory("cdda://local/", vecItems);
+  directory.GetDirectory(CURL("cdda://local/"), vecItems);
 
   // get cddb info
   for (int i = 0; i < vecItems.Size(); ++i)

--- a/xbmc/cores/DllLoader/DllLoaderContainer.cpp
+++ b/xbmc/cores/DllLoader/DllLoaderContainer.cpp
@@ -134,7 +134,7 @@ LibraryLoader* DllLoaderContainer::FindModule(const char* sName, const char* sCu
     CURL url(sName);
     CStdString newName = "special://temp/";
     newName += url.GetFileName();
-    CFile::Cache(sName, newName);
+    CFile::Copy(sName, newName);
     return FindModule(newName, sCurrentDir, bLoadSymbols);
   }
 

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -377,6 +377,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
   bool retVal = false;
   details.Reset();
 
+  const CURL pathToUrl(path);
   for (int iStream=0; iStream<pDemux->GetNrOfStreams(); iStream++)
   {
     CDemuxStream *stream = pDemux->GetStream(iStream);
@@ -397,7 +398,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
       {
         CFileItemList files;
         XFILE::CStackDirectory stack;
-        stack.GetDirectory(path, files);
+        stack.GetDirectory(pathToUrl, files);
 
         // skip first path as we already know the duration
         for (int i = 1; i < files.Size(); i++)

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
@@ -55,7 +55,8 @@ bool CDVDInputStreamStack::Open(const char* path, const std::string& content)
   CStackDirectory dir;
   CFileItemList   items;
 
-  if(!dir.GetDirectory(path, items))
+  const CURL pathToUrl(path);
+  if(!dir.GetDirectory(pathToUrl, items))
   {
     CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to get list of stacked items");
     return false;

--- a/xbmc/cores/paplayer/SPCCodec.cpp
+++ b/xbmc/cores/paplayer/SPCCodec.cpp
@@ -65,12 +65,12 @@ bool SPCCodec::Init(const CStdString &strFile, unsigned int filecache)
   // This forces the shared lib loader to load a per-instance copy of SNESAPU.
 #ifdef TARGET_POSIX
   m_loader_name = CUtil::GetNextFilename("special://temp/SNESAPU-%03d.so", 999);
-  XFILE::CFile::Cache(DLL_PATH_SPC_CODEC, m_loader_name);
+  XFILE::CFile::Copy(DLL_PATH_SPC_CODEC, m_loader_name);
 
   m_loader = new SoLoader(m_loader_name);
 #else
   m_loader_name = CUtil::GetNextFilename("special://temp/SNESAPU-%03d.dll", 999);
-  XFILE::CFile::Cache(DLL_PATH_SPC_CODEC, m_loader_name);
+  XFILE::CFile::Copy(DLL_PATH_SPC_CODEC, m_loader_name);
 
   m_loader = new Win32DllLoader(m_loader_name);
 #endif

--- a/xbmc/cores/paplayer/TimidityCodec.cpp
+++ b/xbmc/cores/paplayer/TimidityCodec.cpp
@@ -62,12 +62,12 @@ bool TimidityCodec::Init(const CStdString &strFile, unsigned int filecache)
   {
 #ifdef TARGET_POSIX
     m_loader_name = CUtil::GetNextFilename("special://temp/libtimidity-%03d.so", 999);
-    XFILE::CFile::Cache(DLL_PATH_MID_CODEC, m_loader_name);
+    XFILE::CFile::Copy(DLL_PATH_MID_CODEC, m_loader_name);
 
     m_loader = new SoLoader(m_loader_name.c_str());
 #else
     m_loader_name = CUtil::GetNextFilename("special://temp/libtimidity-%03d.dll", 999);
-    XFILE::CFile::Cache(DLL_PATH_MID_CODEC, m_loader_name);
+    XFILE::CFile::Copy(DLL_PATH_MID_CODEC, m_loader_name);
 
     m_loader = new Win32DllLoader(m_loader_name);
 #endif
@@ -111,7 +111,7 @@ bool TimidityCodec::Init(const CStdString &strFile, unsigned int filecache)
   if (!url.IsLocal())
   {
     CStdString file = CUtil::GetNextFilename("special://temp/midi%03d.mid",999);
-    XFILE::CFile::Cache(strFile,file);
+    XFILE::CFile::Copy(strFile,file);
     url.Parse(file);
   }
 

--- a/xbmc/cores/paplayer/VGMCodec.cpp
+++ b/xbmc/cores/paplayer/VGMCodec.cpp
@@ -43,7 +43,7 @@ bool VGMCodec::Init(const CStdString &strFile, unsigned int filecache)
   m_dll.Init();
 
   //CStdString strFileToLoad = "filereader://"+strFile;
-  XFILE::CFile::Cache(strFile,"special://temp/"+URIUtils::GetFileName(strFile));
+  XFILE::CFile::Copy(strFile,"special://temp/"+URIUtils::GetFileName(strFile));
 
   //m_vgm = m_dll.LoadVGM(strFileToLoad.c_str(),&m_SampleRate,&m_BitsPerSample,&m_Channels);
   m_vgm = m_dll.LoadVGM("special://temp/"+URIUtils::GetFileName(strFile),&m_SampleRate,&m_BitsPerSample,&m_Channels);

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -339,6 +339,8 @@ void CGUIDialogFileBrowser::OnSort()
 
 void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
 {
+  const CURL pathToUrl(strDirectory);
+
   if (m_browsingForImages && m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
   // get selected item
@@ -360,9 +362,9 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
     CFileItemList items;
     CStdString strParentPath;
 
-    if (!m_rootDir.GetDirectory(strDirectory, items,m_useFileDirectories))
+    if (!m_rootDir.GetDirectory(pathToUrl, items, m_useFileDirectories))
     {
-      CLog::Log(LOGERROR,"CGUIDialogFileBrowser::GetDirectory(%s) failed", CURL::GetRedacted(strDirectory).c_str());
+      CLog::Log(LOGERROR,"CGUIDialogFileBrowser::GetDirectory(%s) failed", pathToUrl.GetRedacted().c_str());
 
       // We assume, we can get the parent
       // directory again

--- a/xbmc/filesystem/AFPDirectory.h
+++ b/xbmc/filesystem/AFPDirectory.h
@@ -32,11 +32,11 @@ class CAFPDirectory : public IDirectory
 public:
   CAFPDirectory(void);
   virtual ~CAFPDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual DIR_CACHE_TYPE GetCacheType(const CStdString &strPath) const { return DIR_CACHE_ONCE; };
-  virtual bool Create(const char* strPath);
-  virtual bool Exists(const char* strPath);
-  virtual bool Remove(const char* strPath);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
+  virtual bool Create(const CURL& url);
+  virtual bool Exists(const CURL& url);
+  virtual bool Remove(const CURL& url);
 
   afp_file_info *Open(const CURL &url);
 private:

--- a/xbmc/filesystem/APKDirectory.cpp
+++ b/xbmc/filesystem/APKDirectory.cpp
@@ -34,11 +34,9 @@ using namespace XFILE;
 // Basically the same format as zip.
 // We might want to refactor CZipDirectory someday...
 //////////////////////////////////////////////////////////////////////
-bool CAPKDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CAPKDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // uses a <fully qualified path>/filename.apk/...
-  CURL url(strPath);
-
   CStdString path = url.GetFileName();
   CStdString host = url.GetHostName();
   URIUtils::AddSlashAtEnd(path);
@@ -96,21 +94,20 @@ bool CAPKDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
   return true;
 }
 
-bool CAPKDirectory::ContainsFiles(const CStdString& strPath)
+bool CAPKDirectory::ContainsFiles(const CURL& url)
 {
   // TODO: why might we need this ?
   return false;
 }
 
-DIR_CACHE_TYPE CAPKDirectory::GetCacheType(const CStdString& strPath) const
+DIR_CACHE_TYPE CAPKDirectory::GetCacheType(const CURL& url) const
 {
   return DIR_CACHE_ALWAYS;
 }
 
-bool CAPKDirectory::Exists(const char* strPath)
+bool CAPKDirectory::Exists(const CURL& url)
 {
   // uses a <fully qualified path>/filename.apk/...
   CAPKFile apk;
-  CURL url(strPath);
   return apk.Exists(url);
 }

--- a/xbmc/filesystem/APKDirectory.h
+++ b/xbmc/filesystem/APKDirectory.h
@@ -28,9 +28,9 @@ namespace XFILE
     public:
     CAPKDirectory() {};
     virtual ~CAPKDirectory() {};
-      virtual bool GetDirectory(const  CStdString& strPath, CFileItemList &items);
-      virtual bool ContainsFiles(const CStdString& strPath);
-      virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const;
-      virtual bool Exists(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool ContainsFiles(const CURL& url);
+    virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const;
+    virtual bool Exists(const CURL& url);
   };
 }

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -47,8 +47,9 @@ CAddonsDirectory::CAddonsDirectory(void)
 CAddonsDirectory::~CAddonsDirectory(void)
 {}
 
-bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
+  const CStdString strPath(url.Get());
   CStdString path1(strPath);
   URIUtils::RemoveSlashAtEnd(path1);
   CURL path(path1);

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -37,9 +37,9 @@ namespace XFILE
   public:
     CAddonsDirectory(void);
     virtual ~CAddonsDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Create(const char* strPath) { return true; }
-    virtual bool Exists(const char* strPath) { return true; }
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Create(const CURL& url) { return true; }
+    virtual bool Exists(const CURL& url) { return true; }
     virtual bool AllowAll() const { return true; }
 
     /*! \brief Fetch script and plugin addons of a given content type

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -40,7 +40,7 @@ namespace XFILE
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     virtual bool Create(const char* strPath) { return true; }
     virtual bool Exists(const char* strPath) { return true; }
-    virtual bool IsAllowed(const CStdString& strFile) const { return true; }
+    virtual bool AllowAll() const { return true; }
 
     /*! \brief Fetch script and plugin addons of a given content type
      \param content the content type to fetch

--- a/xbmc/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/filesystem/AndroidAppDirectory.cpp
@@ -42,9 +42,8 @@ CAndroidAppDirectory::~CAndroidAppDirectory(void)
 {
 }
 
-bool CAndroidAppDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CURL url(strPath);
   CStdString dirname = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(dirname);
   CLog::Log(LOGDEBUG, "CAndroidAppDirectory::GetDirectory: %s",dirname.c_str()); 
@@ -72,7 +71,7 @@ bool CAndroidAppDirectory::GetDirectory(const CStdString& strPath, CFileItemList
     return true;
   }
 
-  CLog::Log(LOGERROR, "CAndroidAppDirectory::GetDirectory Failed to open %s",strPath.c_str());
+  CLog::Log(LOGERROR, "CAndroidAppDirectory::GetDirectory Failed to open %s", url.Get().c_str());
   return false;
 }
 

--- a/xbmc/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/filesystem/AndroidAppDirectory.cpp
@@ -76,10 +76,4 @@ bool CAndroidAppDirectory::GetDirectory(const CStdString& strPath, CFileItemList
   return false;
 }
 
-bool CAndroidAppDirectory::IsAllowed(const CStdString& strFile) const
-{
-  // Entries are virtual, so we want them all.
-  return true;
-}
-
 #endif

--- a/xbmc/filesystem/AndroidAppDirectory.h
+++ b/xbmc/filesystem/AndroidAppDirectory.h
@@ -31,8 +31,8 @@ class CAndroidAppDirectory :
 public:
   CAndroidAppDirectory(void);
   virtual ~CAndroidAppDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool Exists(const char* strPath) { return true; };
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual bool Exists(const CURL& url) { return true; };
   virtual bool AllowAll() const { return true; };
 };
 }

--- a/xbmc/filesystem/AndroidAppDirectory.h
+++ b/xbmc/filesystem/AndroidAppDirectory.h
@@ -33,7 +33,7 @@ public:
   virtual ~CAndroidAppDirectory(void);
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
   virtual bool Exists(const char* strPath) { return true; };
-  virtual bool IsAllowed(const CStdString& strFile) const;
+  virtual bool AllowAll() const { return true; };
 };
 }
 #endif

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -145,10 +145,10 @@ void CBlurayDirectory::GetRoot(CFileItemList &items)
     items.Add(item);
 }
 
-bool CBlurayDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
+bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   Dispose();
-  m_url.Parse(path);
+  m_url = url;
   CStdString root = m_url.GetHostName();
   CStdString file = m_url.GetFileName();
   URIUtils::RemoveSlashAtEnd(file);

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -36,7 +36,7 @@ class CBlurayDirectory: public XFILE::IDirectory
 public:
   CBlurayDirectory();
   virtual ~CBlurayDirectory();
-  virtual bool GetDirectory(const CStdString& path, CFileItemList &items);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
 
 private:
 

--- a/xbmc/filesystem/CDDADirectory.cpp
+++ b/xbmc/filesystem/CDDADirectory.cpp
@@ -41,9 +41,10 @@ CCDDADirectory::~CCDDADirectory(void)
 }
 
 
-bool CCDDADirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CCDDADirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // Reads the tracks from an audio cd
+  CStdString strPath = url.Get();
 
   if (!g_mediaManager.IsDiscInDrive(strPath))
     return false;

--- a/xbmc/filesystem/CDDADirectory.h
+++ b/xbmc/filesystem/CDDADirectory.h
@@ -31,6 +31,6 @@ class CCDDADirectory :
 public:
   CCDDADirectory(void);
   virtual ~CCDDADirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
 };
 }

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -816,7 +816,8 @@ bool CCurlFile::Get(const CStdString& strURL, CStdString& strHTML)
 
 bool CCurlFile::Service(const CStdString& strURL, CStdString& strHTML)
 {
-  if (Open(strURL))
+  const CURL pathToUrl(strURL);
+  if (Open(pathToUrl))
   {
     if (ReadData(strHTML))
     {
@@ -875,8 +876,8 @@ bool CCurlFile::Download(const CStdString& strURL, const CStdString& strFileName
 // Detect whether we are "online" or not! Very simple and dirty!
 bool CCurlFile::IsInternet()
 {
-  CStdString strURL = "http://www.google.com";
-  bool found = Exists(strURL);
+  CURL url("http://www.google.com");
+  bool found = Exists(url);
   Close();
 
   return found;

--- a/xbmc/filesystem/DAAPDirectory.cpp
+++ b/xbmc/filesystem/DAAPDirectory.cpp
@@ -400,7 +400,7 @@ void CDAAPDirectory::AddToArtistAlbum(char *artist_s, char *album_s)
   }
 }
 
-int CDAAPDirectory::GetCurrLevel(CStdString strPath)
+int CDAAPDirectory::GetCurrLevel(const std::string &strPath)
 {
   size_t intSPos;
   size_t intEPos;

--- a/xbmc/filesystem/DAAPDirectory.cpp
+++ b/xbmc/filesystem/DAAPDirectory.cpp
@@ -59,11 +59,9 @@ CDAAPDirectory::~CDAAPDirectory(void)
   m_currentSongItems = NULL;
 }
 
-bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CDAAPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CURL url(strPath);
-
-  CStdString strRoot = strPath;
+  CStdString strRoot = url.Get();
   URIUtils::AddSlashAtEnd(strRoot);
 
   CStdString host = url.GetHostName();

--- a/xbmc/filesystem/DAAPDirectory.h
+++ b/xbmc/filesystem/DAAPDirectory.h
@@ -40,7 +40,7 @@ public:
   CDAAPDirectory(void);
   virtual ~CDAAPDirectory(void);
   virtual bool AllowAll() const { return true; }
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
   //virtual void CloseDAAP(void);
   int GetCurrLevel(const std::string &strPath);
 

--- a/xbmc/filesystem/DAAPDirectory.h
+++ b/xbmc/filesystem/DAAPDirectory.h
@@ -39,7 +39,7 @@ class CDAAPDirectory :
 public:
   CDAAPDirectory(void);
   virtual ~CDAAPDirectory(void);
-  virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual bool AllowAll() const { return true; }
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
   //virtual void CloseDAAP(void);
   int GetCurrLevel(const std::string &strPath);

--- a/xbmc/filesystem/DAAPDirectory.h
+++ b/xbmc/filesystem/DAAPDirectory.h
@@ -42,7 +42,7 @@ public:
   virtual bool IsAllowed(const CStdString &strFile) const { return true; };
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
   //virtual void CloseDAAP(void);
-  int GetCurrLevel(CStdString strPath);
+  int GetCurrLevel(const std::string &strPath);
 
 private:
   void free_albums(albumPTR *alb);
@@ -56,8 +56,8 @@ private:
   int m_currLevel;
 
   artistPTR *m_artisthead;
-  CStdString m_selectedPlaylist;
-  CStdString m_selectedArtist;
-  CStdString m_selectedAlbum;
+  std::string m_selectedPlaylist;
+  std::string m_selectedArtist;
+  std::string m_selectedAlbum;
 };
 }

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -109,10 +109,9 @@ void CDAVDirectory::ParseResponse(const TiXmlElement *pElement, CFileItem &item)
   }
 }
 
-bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   CCurlFile dav;
-  CURL url(strPath);
   CStdString strRequest = "PROPFIND";
 
   dav.SetCustomRequest(strRequest);
@@ -132,7 +131,7 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
 
   if (!dav.Open(url))
   {
-    CLog::Log(LOGERROR, "%s - Unable to get dav directory (%s)", __FUNCTION__, CURL::GetRedacted(strPath).c_str());
+    CLog::Log(LOGERROR, "%s - Unable to get dav directory (%s)", __FUNCTION__, url.GetRedacted().c_str());
     return false;
   }
 
@@ -145,7 +144,7 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
 
   if (!davResponse.Parse(strResponse))
   {
-    CLog::Log(LOGERROR, "%s - Unable to process dav directory (%s)", __FUNCTION__, CURL::GetRedacted(strPath).c_str());
+    CLog::Log(LOGERROR, "%s - Unable to process dav directory (%s)", __FUNCTION__, url.GetRedacted().c_str());
     dav.Close();
     return false;
   }
@@ -158,7 +157,7 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
     {
       CFileItem item;
       ParseResponse(pChild->ToElement(), item);
-      CURL url2(strPath);
+      CURL url2(url);
       CURL url3(item.GetPath());
 
       CStdString itemPath(URIUtils::AddFileToFolder(url2.GetWithoutFilename(), url3.GetFileName()));
@@ -178,7 +177,7 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
         itemPath += "|" + url2.GetProtocolOptions();
       item.SetPath(itemPath);
 
-      if (!item.GetPath().Equals(strPath))
+      if (!item.GetPath().Equals(url.Get()))
       {
         CFileItemPtr pItem(new CFileItem(item));
         items.Add(pItem);
@@ -191,10 +190,9 @@ bool CDAVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
   return true;
 }
 
-bool CDAVDirectory::Create(const char* strPath)
+bool CDAVDirectory::Create(const CURL& url)
 {
   CDAVFile dav;
-  CURL url(strPath);
   CStdString strRequest = "MKCOL";
 
   dav.SetCustomRequest(strRequest);
@@ -210,7 +208,7 @@ bool CDAVDirectory::Create(const char* strPath)
   return true;
 }
 
-bool CDAVDirectory::Exists(const char* strPath)
+bool CDAVDirectory::Exists(const CURL& url)
 {
   CCurlFile dav;
 
@@ -220,14 +218,12 @@ bool CDAVDirectory::Exists(const char* strPath)
   dav.SetCustomRequest(strRequest);
   dav.SetRequestHeader("depth", 0);
 
-  CURL url(strPath);
   return dav.Exists(url);
 }
 
-bool CDAVDirectory::Remove(const char* strPath)
+bool CDAVDirectory::Remove(const CURL& url)
 {
   CDAVFile dav;
-  CURL url(strPath);
   CStdString strRequest = "DELETE";
 
   dav.SetCustomRequest(strRequest);

--- a/xbmc/filesystem/DAVDirectory.h
+++ b/xbmc/filesystem/DAVDirectory.h
@@ -30,11 +30,11 @@ namespace XFILE
     public:
       CDAVDirectory(void);
       virtual ~CDAVDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual bool Create(const char* strPath);
-      virtual bool Exists(const char* strPath);
-      virtual bool Remove(const char* strPath);
-      virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual bool Create(const CURL& url);
+      virtual bool Exists(const CURL& url);
+      virtual bool Remove(const CURL& url);
+      virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
     private:
       void ParseResponse(const TiXmlElement *pElement, CFileItem &item);
   };

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -208,13 +208,23 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
     for (int i = 0; i < items.Size(); ++i)
     {
       CFileItemPtr item = items[i];
-      // TODO: we shouldn't be checking the gui setting here;
-      // callers should use getHidden instead
-      if ((!item->m_bIsFolder && !pDirectory->IsAllowed(item->GetPath())) ||
-          (item->GetProperty("file:hidden").asBoolean() && !(hints.flags & DIR_FLAG_GET_HIDDEN) && !CSettings::Get().GetBool("filelists.showhidden")))
+      if (!item->m_bIsFolder && !pDirectory->IsAllowed(item->GetPath()))
       {
         items.Remove(i);
         i--; // don't confuse loop
+      }
+    }
+    // filter hidden files
+    // TODO: we shouldn't be checking the gui setting here, callers should use getHidden instead
+    if (!CSettings::Get().GetBool("filelists.showhidden") && !(hints.flags & DIR_FLAG_GET_HIDDEN))
+    {
+      for (int i = 0; i < items.Size(); ++i)
+      {
+        if (items[i]->GetProperty("file:hidden").asBoolean())
+        {
+          items.Remove(i);
+          i--; // don't confuse loop
+        }
       }
     }
 

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -204,14 +204,17 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
     }
 
     // now filter for allowed files
-    pDirectory->SetMask(hints.mask);
-    for (int i = 0; i < items.Size(); ++i)
+    if (!pDirectory->AllowAll())
     {
-      CFileItemPtr item = items[i];
-      if (!item->m_bIsFolder && !pDirectory->IsAllowed(item->GetPath()))
+      pDirectory->SetMask(hints.mask);
+      for (int i = 0; i < items.Size(); ++i)
       {
-        items.Remove(i);
-        i--; // don't confuse loop
+        CFileItemPtr item = items[i];
+        if (!item->m_bIsFolder && !pDirectory->IsAllowed(item->GetPath()))
+        {
+          items.Remove(i);
+          i--; // don't confuse loop
+        }
       }
     }
     // filter hidden files

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -144,7 +144,7 @@ bool CDirectory::GetDirectory(const CURL& url, CFileItemList &items, const CHint
   try
   {
     CURL realURL = URIUtils::SubstitutePath(url);
-    boost::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL.Get()));
+    boost::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
     if (!pDirectory.get())
       return false;
 
@@ -285,7 +285,7 @@ bool CDirectory::Create(const CURL& url)
   try
   {
     CURL realURL = URIUtils::SubstitutePath(url);
-    auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL.Get()));
+    auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
     if (pDirectory.get())
       if(pDirectory->Create(realURL))
         return true;
@@ -320,7 +320,7 @@ bool CDirectory::Exists(const CURL& url, bool bUseCache /* = true */)
       if (bPathInCache)
         return false;
     }
-    auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL.Get()));
+    auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
     if (pDirectory.get())
       return pDirectory->Exists(realURL);
   }
@@ -344,7 +344,7 @@ bool CDirectory::Remove(const CURL& url)
   try
   {
     CURL realURL = URIUtils::SubstitutePath(url);
-    auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL.Get()));
+    auto_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
     if (pDirectory.get())
       if(pDirectory->Remove(realURL))
       {
@@ -368,7 +368,7 @@ void CDirectory::FilterFileDirectories(CFileItemList &items, const CStdString &m
     CFileItemPtr pItem=items[i];
     if (!pItem->m_bIsFolder && pItem->IsFileFolder(EFILEFOLDER_TYPE_ALWAYS))
     {
-      auto_ptr<IFileDirectory> pDirectory(CFileDirectoryFactory::Create(pItem->GetPath(),pItem.get(),mask));
+      auto_ptr<IFileDirectory> pDirectory(CFileDirectoryFactory::Create(pItem->GetURL(),pItem.get(),mask));
       if (pDirectory.get())
         pItem->m_bIsFolder = true;
       else

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -20,6 +20,7 @@
  */
 
 #include "IDirectory.h"
+#include "utils/StdString.h"
 
 namespace XFILE
 {

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -44,6 +44,21 @@ public:
     int flags;
   };
 
+  static bool GetDirectory(const CURL& url
+                           , CFileItemList &items
+                           , const CStdString &strMask=""
+                           , int flags=DIR_FLAG_DEFAULTS
+                           , bool allowThreads=false);
+
+  static bool GetDirectory(const CURL& url
+                           , CFileItemList &items
+                           , const CHints &hints
+                           , bool allowThreads=false);
+
+  static bool Create(const CURL& url);
+  static bool Exists(const CURL& url, bool bUseCache = true);
+  static bool Remove(const CURL& url);
+
   static bool GetDirectory(const CStdString& strPath
                            , CFileItemList &items
                            , const CStdString &strMask=""

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -126,14 +126,13 @@ using namespace XFILE;
  \return IDirectory object to access the directories on the share.
  \sa IDirectory
  */
-IDirectory* CDirectoryFactory::Create(const CStdString& strPath)
+IDirectory* CDirectoryFactory::Create(const CURL& url)
 {
-  CURL url(strPath);
   if (!CWakeOnAccess::Get().WakeUpHost(url))
     return NULL;
 
-  CFileItem item(strPath, false);
-  IFileDirectory* pDir=CFileDirectoryFactory::Create(strPath, &item);
+  CFileItem item(url.Get(), false);
+  IFileDirectory* pDir=CFileDirectoryFactory::Create(url, &item);
   if (pDir)
     return pDir;
 
@@ -179,7 +178,10 @@ IDirectory* CDirectoryFactory::Create(const CStdString& strPath)
   if (strProtocol == "library") return new CLibraryDirectory();
   if (strProtocol == "favourites") return new CFavouritesDirectory();
   if (strProtocol == "filereader")
-    return CDirectoryFactory::Create(url.GetFileName());
+  {
+    CURL url2(url.GetFileName());
+    return CDirectoryFactory::Create(url2);
+  }
 #if defined(TARGET_ANDROID)
   if (strProtocol == "androidapp") return new CAndroidAppDirectory();
 #endif

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -136,12 +136,12 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
   if (pDir)
     return pDir;
 
-  CStdString strProtocol = url.GetProtocol();
+  const CStdString &strProtocol = url.GetProtocol();
 
 #ifdef TARGET_POSIX
-  if (strProtocol.size() == 0 || strProtocol == "file") return new CPosixDirectory();
+  if (strProtocol.empty() || strProtocol == "file") return new CPosixDirectory();
 #elif defined(TARGET_WINDOWS)
-  if (strProtocol.size() == 0 || strProtocol == "file") return new CWin32Directory();
+  if (strProtocol.empty() || strProtocol == "file") return new CWin32Directory();
 #else
 #error Local directory access is not implemented for this platform
 #endif

--- a/xbmc/filesystem/DirectoryFactory.h
+++ b/xbmc/filesystem/DirectoryFactory.h
@@ -45,6 +45,6 @@ namespace XFILE
 class CDirectoryFactory
 {
 public:
-  static IDirectory* Create(const CStdString& strPath);
+  static IDirectory* Create(const CURL& url);
 };
 }

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -33,11 +33,11 @@ using namespace XFILE;
 CFTPDirectory::CFTPDirectory(void){}
 CFTPDirectory::~CFTPDirectory(void){}
 
-bool CFTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
 {
   CCurlFile reader;
 
-  CURL url(strPath);
+  CURL url(url2);
 
   CStdString path = url.GetFileName();
   if( !path.empty() && !StringUtils::EndsWith(path, "/") )
@@ -110,14 +110,14 @@ bool CFTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
   return true;
 }
 
-bool CFTPDirectory::Exists(const char* strPath)
+bool CFTPDirectory::Exists(const CURL& url)
 {
   // make sure ftp dir ends with slash,
   // curl need to known it's a dir to check ftp directory existence.
-  CStdString file = strPath;
+  CStdString file = url.Get();
   URIUtils::AddSlashAtEnd(file);
 
   CCurlFile ftp;
-  CURL url(file);
-  return ftp.Exists(url);
+  CURL url2(file);
+  return ftp.Exists(url2);
 }

--- a/xbmc/filesystem/FTPDirectory.h
+++ b/xbmc/filesystem/FTPDirectory.h
@@ -28,8 +28,8 @@ namespace XFILE
     public:
       CFTPDirectory(void);
       virtual ~CFTPDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual bool Exists(const char* strPath);
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual bool Exists(const CURL& url);
     private:
   };
 }

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -53,7 +53,7 @@ bool CFavouritesDirectory::Exists(const CURL& url)
     return XFILE::CFile::Exists("special://xbmc/system/favourites.xml") 
         || XFILE::CFile::Exists(URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml"));
   }
-  return XFILE::CFile::Exists(url.Get()); //directly load the given file
+  return XFILE::CFile::Exists(url); //directly load the given file
 }
 
 bool CFavouritesDirectory::Load(CFileItemList &items)

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -36,28 +36,24 @@ namespace XFILE
 {
 
 
-bool CFavouritesDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CFavouritesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   items.Clear();
-  CURL url(strPath);
-
   if (url.GetProtocol() == "favourites")
   {
     return Load(items); //load the default favourite files
   }
-  return LoadFavourites(strPath, items); //directly load the given file
+  return LoadFavourites(url.Get(), items); //directly load the given file
 }
 
-bool CFavouritesDirectory::Exists(const char* strPath)
+bool CFavouritesDirectory::Exists(const CURL& url)
 {
-  CURL url(strPath);
-
   if (url.GetProtocol() == "favourites")
   {
     return XFILE::CFile::Exists("special://xbmc/system/favourites.xml") 
         || XFILE::CFile::Exists(URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml"));
   }
-  return XFILE::CFile::Exists(strPath); //directly load the given file
+  return XFILE::CFile::Exists(url.Get()); //directly load the given file
 }
 
 bool CFavouritesDirectory::Load(CFileItemList &items)

--- a/xbmc/filesystem/FavouritesDirectory.h
+++ b/xbmc/filesystem/FavouritesDirectory.h
@@ -32,8 +32,8 @@ namespace XFILE
   class CFavouritesDirectory : public IDirectory
   {
   public:
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Exists(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Exists(const CURL& url);
     static bool Load(CFileItemList &items);
     static bool LoadFavourites(const CStdString& strPath, CFileItemList& items);
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -132,23 +132,31 @@ void* auto_buffer::detach(void)
 // This *looks* like a copy function, therefor the name "Cache" is misleading
 bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFILE::IFileCallback* pCallback, void* pContext)
 {
+  const CURL pathToUrl(strFileName);
+  const CURL pathToUrlDest(strDest);
+  return Cache(pathToUrl, pathToUrlDest, pCallback, pContext);
+}
+
+bool CFile::Cache(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCallback, void* pContext)
+{
   CFile file;
 
-  if (strFileName.empty() || strDest.empty())
+  const CStdString pathToUrl(dest.Get());
+  if (pathToUrl.empty())
     return false;
 
   // special case for zips - ignore caching
-  CURL url(strFileName);
-  if (URIUtils::IsInZIP(strFileName) || URIUtils::IsInAPK(strFileName))
+  CURL url(url2);
+  if (URIUtils::IsInZIP(url.Get()) || URIUtils::IsInAPK(url.Get()))
     url.SetOptions("?cache=no");
   if (file.Open(url.Get(), READ_TRUNCATED))
   {
 
     CFile newFile;
-    if (URIUtils::IsHD(strDest)) // create possible missing dirs
+    if (URIUtils::IsHD(pathToUrl)) // create possible missing dirs
     {
       vector<std::string> tokens;
-      CStdString strDirectory = URIUtils::GetDirectory(strDest);
+      CStdString strDirectory = URIUtils::GetDirectory(pathToUrl);
       URIUtils::RemoveSlashAtEnd(strDirectory);  // for the test below
       if (!(strDirectory.size() == 2 && strDirectory[1] == ':'))
       {
@@ -175,9 +183,9 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
         }
       }
     }
-    if (CFile::Exists(strDest))
-      CFile::Delete(strDest);
-    if (!newFile.OpenForWrite(strDest, true))  // overwrite always
+    if (CFile::Exists(dest))
+      CFile::Delete(dest);
+    if (!newFile.OpenForWrite(dest, true))  // overwrite always
     {
       file.Close();
       return false;
@@ -202,7 +210,7 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
       if (iRead == 0) break;
       else if (iRead < 0)
       {
-        CLog::Log(LOGERROR, "%s - Failed read from file %s", __FUNCTION__, strFileName.c_str());
+        CLog::Log(LOGERROR, "%s - Failed read from file %s", __FUNCTION__, url.GetRedacted().c_str());
         llFileSize = (uint64_t)-1;
         break;
       }
@@ -219,7 +227,7 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
 
       if (iWrite != iRead)
       {
-        CLog::Log(LOGERROR, "%s - Failed write to file %s", __FUNCTION__, strDest.c_str());
+        CLog::Log(LOGERROR, "%s - Failed write to file %s", __FUNCTION__, dest.GetRedacted().c_str());
         llFileSize = (uint64_t)-1;
         break;
       }
@@ -254,7 +262,7 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
     /* verify that we managed to completed the file */
     if (llFileSize && llPos != llFileSize)
     {
-      CFile::Delete(strDest);
+      CFile::Delete(dest);
       return false;
     }
     return true;
@@ -265,11 +273,17 @@ bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFIL
 //*********************************************************************************************
 bool CFile::Open(const CStdString& strFileName, const unsigned int flags)
 {
+  const CURL pathToUrl(strFileName);
+  return Open(pathToUrl, flags);
+}
+
+bool CFile::Open(const CURL& file, const unsigned int flags)
+{
   m_flags = flags;
   try
   {
     bool bPathInCache;
-    CURL url2(URIUtils::SubstitutePath(strFileName));
+    CURL url2(URIUtils::SubstitutePath(file));
     if (url2.GetProtocol() == "apk")
       url2.SetOptions("");
     if (url2.GetProtocol() == "zip")
@@ -280,11 +294,12 @@ bool CFile::Open(const CStdString& strFileName, const unsigned int flags)
         return false;
     }
 
-    CURL url(URIUtils::SubstitutePath(strFileName));
+    CURL url(URIUtils::SubstitutePath(file));
 
     if (!(m_flags & READ_NO_CACHE))
     {
-      if (URIUtils::IsInternetStream(url, true) && !CUtil::IsPicture(strFileName) )
+      const CStdString pathToUrl(url.Get());
+      if (URIUtils::IsInternetStream(url, true) && !CUtil::IsPicture(pathToUrl) )
         m_flags |= READ_CACHED;
 
       if (m_flags & READ_CACHED)
@@ -311,7 +326,7 @@ bool CFile::Open(const CStdString& strFileName, const unsigned int flags)
     {
       // the file implementation decided this item should use a different implementation.
       // the exception will contain the new implementation.
-      CLog::Log(LOGDEBUG,"File::Open - redirecting implementation for %s", strFileName.c_str());
+      CLog::Log(LOGDEBUG,"File::Open - redirecting implementation for %s", file.GetRedacted().c_str());
       SAFE_DELETE(m_pFile);
       if (pRedirectEx && pRedirectEx->m_pNewFileImp)
       {
@@ -339,7 +354,7 @@ bool CFile::Open(const CStdString& strFileName, const unsigned int flags)
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "File::Open - unknown exception when opening %s", strFileName.c_str());
+      CLog::Log(LOGERROR, "File::Open - unknown exception when opening %s", file.GetRedacted().c_str());
       SAFE_DELETE(m_pFile);
       return false;
     }
@@ -363,22 +378,27 @@ bool CFile::Open(const CStdString& strFileName, const unsigned int flags)
   {
     CLog::Log(LOGERROR, "%s - Unhandled exception", __FUNCTION__);
   }
-  CLog::Log(LOGERROR, "%s - Error opening %s", __FUNCTION__, strFileName.c_str());
+  CLog::Log(LOGERROR, "%s - Error opening %s", __FUNCTION__, file.GetRedacted().c_str());
   return false;
 }
 
 bool CFile::OpenForWrite(const CStdString& strFileName, bool bOverWrite)
 {
+  const CURL pathToUrl(strFileName);
+  return OpenForWrite(pathToUrl, bOverWrite);
+}
+
+bool CFile::OpenForWrite(const CURL& file, bool bOverWrite)
+{
   try
   {
-    CStdString storedFileName = URIUtils::SubstitutePath(strFileName);
-    CURL url(storedFileName);
+    CURL url = URIUtils::SubstitutePath(file);
 
     m_pFile = CFileFactory::CreateLoader(url);
     if (m_pFile && m_pFile->OpenForWrite(url, bOverWrite))
     {
       // add this file to our directory cache (if it's stored)
-      g_directoryCache.AddFile(storedFileName);
+      g_directoryCache.AddFile(url.Get());
       return true;
     }
     return false;
@@ -386,21 +406,24 @@ bool CFile::OpenForWrite(const CStdString& strFileName, bool bOverWrite)
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch(...)
   {
-    CLog::Log(LOGERROR, "%s - Unhandled exception opening %s", __FUNCTION__, strFileName.c_str());
+    CLog::Log(LOGERROR, "%s - Unhandled exception opening %s", __FUNCTION__, file.GetRedacted().c_str());
   }
-  CLog::Log(LOGERROR, "%s - Error opening %s", __FUNCTION__, strFileName.c_str());
+  CLog::Log(LOGERROR, "%s - Error opening %s", __FUNCTION__, file.GetRedacted().c_str());
   return false;
 }
 
 bool CFile::Exists(const CStdString& strFileName, bool bUseCache /* = true */)
 {
-  CURL url(URIUtils::SubstitutePath(strFileName));
-  
+  const CURL pathToUrl(strFileName);
+  return Exists(pathToUrl, bUseCache);
+}
+
+bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
+{
+  CURL url(URIUtils::SubstitutePath(file));
+
   try
   {
-    if (strFileName.empty())
-      return false;
-
     if (bUseCache)
     {
       bool bPathInCache;
@@ -421,7 +444,7 @@ bool CFile::Exists(const CStdString& strFileName, bool bUseCache /* = true */)
   {
     // the file implementation decided this item should use a different implementation.
     // the exception will contain the new implementation and optional a redirected URL.
-    CLog::Log(LOGDEBUG,"File::Exists - redirecting implementation for %s", strFileName.c_str());
+    CLog::Log(LOGDEBUG,"File::Exists - redirecting implementation for %s", file.GetRedacted().c_str());
     if (pRedirectEx && pRedirectEx->m_pNewFileImp)
     {
       auto_ptr<IFile> pImp(pRedirectEx->m_pNewFileImp);
@@ -451,7 +474,7 @@ bool CFile::Exists(const CStdString& strFileName, bool bUseCache /* = true */)
   {
     CLog::Log(LOGERROR, "%s - Unhandled exception", __FUNCTION__);
   }
-  CLog::Log(LOGERROR, "%s - Error checking for %s", __FUNCTION__, strFileName.c_str());
+  CLog::Log(LOGERROR, "%s - Error checking for %s", __FUNCTION__, file.GetRedacted().c_str());
   return false;
 }
 
@@ -479,10 +502,16 @@ bool CFile::SkipNext()
 
 int CFile::Stat(const CStdString& strFileName, struct __stat64* buffer)
 {
+  const CURL pathToUrl(strFileName);
+  return Stat(pathToUrl, buffer);
+}
+
+int CFile::Stat(const CURL& file, struct __stat64* buffer)
+{
   if (!buffer)
     return -1;
 
-  CURL url(URIUtils::SubstitutePath(strFileName));
+  CURL url(URIUtils::SubstitutePath(file));
 
   try
   {
@@ -496,7 +525,7 @@ int CFile::Stat(const CStdString& strFileName, struct __stat64* buffer)
   {
     // the file implementation decided this item should use a different implementation.
     // the exception will contain the new implementation and optional a redirected URL.
-    CLog::Log(LOGDEBUG,"File::Stat - redirecting implementation for %s", strFileName.c_str());
+    CLog::Log(LOGDEBUG,"File::Stat - redirecting implementation for %s", file.GetRedacted().c_str());
     if (pRedirectEx && pRedirectEx->m_pNewFileImp)
     {
       auto_ptr<IFile> pImp(pRedirectEx->m_pNewFileImp);
@@ -523,7 +552,7 @@ int CFile::Stat(const CStdString& strFileName, struct __stat64* buffer)
   {
     CLog::Log(LOGERROR, "%s - Unhandled exception", __FUNCTION__);
   }
-  CLog::Log(LOGERROR, "%s - Error statting %s", __FUNCTION__, strFileName.c_str());
+  CLog::Log(LOGERROR, "%s - Error statting %s", __FUNCTION__, file.GetRedacted().c_str());
   return -1;
 }
 
@@ -784,9 +813,15 @@ int CFile::Write(const void* lpBuf, int64_t uiBufSize)
 
 bool CFile::Delete(const CStdString& strFileName)
 {
+  const CURL pathToUrl(strFileName);
+  return Delete(pathToUrl);
+}
+
+bool CFile::Delete(const CURL& file)
+{
   try
   {
-    CURL url(URIUtils::SubstitutePath(strFileName));
+    CURL url(URIUtils::SubstitutePath(file));
 
     auto_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
@@ -803,17 +838,24 @@ bool CFile::Delete(const CStdString& strFileName)
   {
     CLog::Log(LOGERROR, "%s - Unhandled exception", __FUNCTION__);
   }
-  if (Exists(strFileName))
-    CLog::Log(LOGERROR, "%s - Error deleting file %s", __FUNCTION__, strFileName.c_str());
+  if (Exists(file))
+    CLog::Log(LOGERROR, "%s - Error deleting file %s", __FUNCTION__, file.GetRedacted().c_str());
   return false;
 }
 
 bool CFile::Rename(const CStdString& strFileName, const CStdString& strNewFileName)
 {
+  const CURL pathToUrl(strFileName);
+  const CURL pathToUrlNew(strNewFileName);
+  return Rename(pathToUrl, pathToUrlNew);
+}
+
+bool CFile::Rename(const CURL& file, const CURL& newFile)
+{
   try
   {
-    CURL url(URIUtils::SubstitutePath(strFileName));
-    CURL urlnew(URIUtils::SubstitutePath(strNewFileName));
+    CURL url(URIUtils::SubstitutePath(file));
+    CURL urlnew(URIUtils::SubstitutePath(newFile));
 
     auto_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
@@ -831,15 +873,21 @@ bool CFile::Rename(const CStdString& strFileName, const CStdString& strNewFileNa
   {
     CLog::Log(LOGERROR, "%s - Unhandled exception ", __FUNCTION__);
   }
-  CLog::Log(LOGERROR, "%s - Error renaming file %s", __FUNCTION__, strFileName.c_str());
+  CLog::Log(LOGERROR, "%s - Error renaming file %s", __FUNCTION__, file.GetRedacted().c_str());
   return false;
 }
 
 bool CFile::SetHidden(const CStdString& fileName, bool hidden)
 {
+  const CURL pathToUrl(fileName);
+  return SetHidden(pathToUrl, hidden);
+}
+
+bool CFile::SetHidden(const CURL& file, bool hidden)
+{
   try
   {
-    CURL url(URIUtils::SubstitutePath(fileName));
+    CURL url(URIUtils::SubstitutePath(file));
 
     auto_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
@@ -849,7 +897,7 @@ bool CFile::SetHidden(const CStdString& fileName, bool hidden)
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "%s(%s) - Unhandled exception", __FUNCTION__, fileName.c_str());
+    CLog::Log(LOGERROR, "%s(%s) - Unhandled exception", __FUNCTION__, file.GetRedacted().c_str());
   }
   return false;
 }
@@ -893,18 +941,21 @@ std::string CFile::GetContentCharset(void)
   return m_pFile->GetContentCharset();
 }
 
-
 unsigned int CFile::LoadFile(const std::string &filename, auto_buffer& outputBuffer)
+{
+  const CURL pathToUrl(filename);
+  return LoadFile(pathToUrl, outputBuffer);
+}
+
+unsigned int CFile::LoadFile(const CURL& file, auto_buffer& outputBuffer)
 {
   static const unsigned int max_file_size = 0x7FFFFFFF;
   static const unsigned int min_chunk_size = 64 * 1024U;
   static const unsigned int max_chunk_size = 2048 * 1024U;
 
   outputBuffer.clear();
-  if (filename.empty())
-    return 0;
 
-  if (!Open(filename, READ_TRUNCATED))
+  if (!Open(file, READ_TRUNCATED))
     return 0;
 
   /*
@@ -1093,11 +1144,9 @@ bool CFileStream::Open(const CURL& filename)
 {
   Close();
 
-  // NOTE: This is currently not translated - reason is that all entry points into CFileStream::Open currently
-  //       go from the CStdString version below.  We may have to change this in future, but I prefer not decoding
-  //       the URL and re-encoding, or applying the translation twice.
-  m_file = CFileFactory::CreateLoader(filename);
-  if(m_file && m_file->Open(filename))
+  CURL url(URIUtils::SubstitutePath(filename));
+  m_file = CFileFactory::CreateLoader(url);
+  if(m_file && m_file->Open(url))
   {
     m_buffer.Attach(m_file);
     return true;
@@ -1123,5 +1172,6 @@ void CFileStream::Close()
 
 bool CFileStream::Open(const CStdString& filename)
 {
-  return Open(CURL(URIUtils::SubstitutePath(filename)));
+  const CURL pathToUrl(filename);
+  return Open(pathToUrl);
 }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -394,7 +394,7 @@ bool CFile::OpenForWrite(const CStdString& strFileName, bool bOverWrite)
 
 bool CFile::Exists(const CStdString& strFileName, bool bUseCache /* = true */)
 {
-  CURL url = URIUtils::SubstitutePath(strFileName);
+  CURL url(URIUtils::SubstitutePath(strFileName));
   
   try
   {
@@ -482,12 +482,10 @@ int CFile::Stat(const CStdString& strFileName, struct __stat64* buffer)
   if (!buffer)
     return -1;
 
-  CURL url;
-  
+  CURL url(URIUtils::SubstitutePath(strFileName));
+
   try
   {
-    url = URIUtils::SubstitutePath(strFileName);
-    
     auto_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
       return -1;

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -128,16 +128,14 @@ void* auto_buffer::detach(void)
   return returnPtr;
 }
 
-
-// This *looks* like a copy function, therefor the name "Cache" is misleading
-bool CFile::Cache(const CStdString& strFileName, const CStdString& strDest, XFILE::IFileCallback* pCallback, void* pContext)
+bool CFile::Copy(const CStdString& strFileName, const CStdString& strDest, XFILE::IFileCallback* pCallback, void* pContext)
 {
   const CURL pathToUrl(strFileName);
   const CURL pathToUrlDest(strDest);
-  return Cache(pathToUrl, pathToUrlDest, pCallback, pContext);
+  return Copy(pathToUrl, pathToUrlDest, pCallback, pContext);
 }
 
-bool CFile::Cache(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCallback, void* pContext)
+bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCallback, void* pContext)
 {
   CFile file;
 

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -145,7 +145,7 @@ public:
   static bool Delete(const CURL& file);
   static int  Stat(const CURL& file, struct __stat64* buffer);
   static bool Rename(const CURL& file, const CURL& urlNew);
-  static bool Cache(const CURL& file, const CURL& dest, XFILE::IFileCallback* pCallback = NULL, void* pContext = NULL);
+  static bool Copy(const CURL& file, const CURL& dest, XFILE::IFileCallback* pCallback = NULL, void* pContext = NULL);
   static bool SetHidden(const CURL& file, bool hidden);
 
   // string interface
@@ -154,7 +154,7 @@ public:
   int Stat(struct __stat64 *buffer);
   static bool Delete(const CStdString& strFileName);
   static bool Rename(const CStdString& strFileName, const CStdString& strNewFileName);
-  static bool Cache(const CStdString& strFileName, const CStdString& strDest, XFILE::IFileCallback* pCallback = NULL, void* pContext = NULL);
+  static bool Copy(const CStdString& strFileName, const CStdString& strDest, XFILE::IFileCallback* pCallback = NULL, void* pContext = NULL);
   static bool SetHidden(const CStdString& fileName, bool hidden);
 
 private:

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -102,6 +102,10 @@ public:
   CFile();
   ~CFile();
 
+  bool Open(const CURL& file, const unsigned int flags = 0);
+  bool OpenForWrite(const CURL& file, bool bOverWrite = false);
+  unsigned int LoadFile(const CURL &file, auto_buffer& outputBuffer);
+
   bool Open(const CStdString& strFileName, const unsigned int flags = 0);
   bool OpenForWrite(const CStdString& strFileName, bool bOverWrite = false);
   unsigned int Read(void* lpBuf, int64_t uiBufSize);
@@ -136,6 +140,15 @@ public:
 
   IFile *GetImplemenation() { return m_pFile; }
 
+  // CURL interface
+  static bool Exists(const CURL& file, bool bUseCache = true);
+  static bool Delete(const CURL& file);
+  static int  Stat(const CURL& file, struct __stat64* buffer);
+  static bool Rename(const CURL& file, const CURL& urlNew);
+  static bool Cache(const CURL& file, const CURL& dest, XFILE::IFileCallback* pCallback = NULL, void* pContext = NULL);
+  static bool SetHidden(const CURL& file, bool hidden);
+
+  // string interface
   static bool Exists(const CStdString& strFileName, bool bUseCache = true);
   static int  Stat(const CStdString& strFileName, struct __stat64* buffer);
   int Stat(struct __stat64 *buffer);

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -225,7 +225,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
   { // XBMC Smart playlist - just XML renamed to XSP
     // read the name of the playlist in
     CSmartPlaylist playlist;
-    if (playlist.OpenAndReadName(strPath))
+    if (playlist.OpenAndReadName(url))
     {
       pItem->SetLabel(playlist.GetName());
       pItem->SetLabelPreformated(true);

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -49,6 +49,7 @@
 #include "settings/AdvancedSettings.h"
 #include "FileItem.h"
 #include "utils/StringUtils.h"
+#include "URL.h"
 
 using namespace XFILE;
 using namespace PLAYLIST;
@@ -63,6 +64,7 @@ CFileDirectoryFactory::~CFileDirectoryFactory(void)
 // return NULL + set pItem->m_bIsFolder to remove it completely from list.
 IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileItem* pItem, const CStdString& strMask)
 {
+  const CURL url(strPath);
   if (URIUtils::IsStack(strPath)) // disqualify stack as we need to work with each of the parts instead
     return NULL;
 
@@ -74,7 +76,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
   {
     IFileDirectory* pDir=new COGGFileDirectory;
     //  Has the ogg file more than one bitstream?
-    if (pDir->ContainsFiles(strPath))
+    if (pDir->ContainsFiles(url))
     {
       return pDir; // treat as directory
     }
@@ -86,7 +88,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
   {
     IFileDirectory* pDir=new CNSFFileDirectory;
     //  Has the nsf file more than one track?
-    if (pDir->ContainsFiles(strPath))
+    if (pDir->ContainsFiles(url))
       return pDir; // treat as directory
 
     delete pDir;
@@ -96,7 +98,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
   {
     IFileDirectory* pDir=new CSIDFileDirectory;
     //  Has the sid file more than one track?
-    if (pDir->ContainsFiles(strPath))
+    if (pDir->ContainsFiles(url))
       return pDir; // treat as directory
 
     delete pDir;
@@ -107,7 +109,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
   {
     IFileDirectory* pDir=new CASAPFileDirectory;
     //  Has the asap file more than one track?
-    if (pDir->ContainsFiles(strPath))
+    if (pDir->ContainsFiles(url))
       return pDir; // treat as directory
 
     delete pDir;
@@ -238,7 +240,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
     // for links to http streams etc.
     IFileDirectory *pDir = new CPlaylistFileDirectory();
     CFileItemList items;
-    if (pDir->GetDirectory(strPath, items))
+    if (pDir->GetDirectory(url, items))
     {
       if (items.Size() > 1)
         return pDir;

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -62,12 +62,12 @@ CFileDirectoryFactory::~CFileDirectoryFactory(void)
 {}
 
 // return NULL + set pItem->m_bIsFolder to remove it completely from list.
-IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileItem* pItem, const CStdString& strMask)
+IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem, const CStdString& strMask)
 {
-  const CURL url(strPath);
-  if (URIUtils::IsStack(strPath)) // disqualify stack as we need to work with each of the parts instead
+  if (url.GetProtocol() == "stack") // disqualify stack as we need to work with each of the parts instead
     return NULL;
 
+  const CStdString strPath = url.Get();
   CStdString strExtension=URIUtils::GetExtension(strPath);
   StringUtils::ToLower(strExtension);
 
@@ -84,7 +84,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
     delete pDir;
     return NULL;
   }
-  if (strExtension.Equals(".nsf") && CFile::Exists(strPath))
+  if (strExtension.Equals(".nsf") && CFile::Exists(url))
   {
     IFileDirectory* pDir=new CNSFFileDirectory;
     //  Has the nsf file more than one track?
@@ -94,7 +94,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
     delete pDir;
     return NULL;
   }
-  if (strExtension.Equals(".sid") && CFile::Exists(strPath))
+  if (strExtension.Equals(".sid") && CFile::Exists(url))
   {
     IFileDirectory* pDir=new CSIDFileDirectory;
     //  Has the sid file more than one track?
@@ -105,7 +105,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CStdString& strPath, CFileIt
     return NULL;
   }
 #ifdef HAS_ASAP_CODEC
-  if (ASAPCodec::IsSupportedFormat(strExtension) && CFile::Exists(strPath))
+  if (ASAPCodec::IsSupportedFormat(strExtension) && CFile::Exists(url))
   {
     IFileDirectory* pDir=new CASAPFileDirectory;
     //  Has the asap file more than one track?

--- a/xbmc/filesystem/FileDirectoryFactory.h
+++ b/xbmc/filesystem/FileDirectoryFactory.h
@@ -30,6 +30,6 @@ class CFileDirectoryFactory
 public:
   CFileDirectoryFactory(void);
   virtual ~CFileDirectoryFactory(void);
-  static IFileDirectory* Create(const CStdString& strPath, CFileItem* pItem, const CStdString& strMask="");
+  static IFileDirectory* Create(const CURL& url, CFileItem* pItem, const CStdString& strMask="");
 };
 }

--- a/xbmc/filesystem/HDHomeRunDirectory.cpp
+++ b/xbmc/filesystem/HDHomeRunDirectory.cpp
@@ -44,12 +44,10 @@ CHomeRunDirectory::~CHomeRunDirectory()
   delete m_pdll;
 }
 
-bool CHomeRunDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CHomeRunDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   if(!m_pdll->IsLoaded())
     return false;
-
-  CURL url(strPath);
 
   if(url.GetHostName().empty())
   {

--- a/xbmc/filesystem/HDHomeRunDirectory.h
+++ b/xbmc/filesystem/HDHomeRunDirectory.h
@@ -31,7 +31,7 @@ namespace XFILE
       CHomeRunDirectory(void);
       virtual ~CHomeRunDirectory(void);
       virtual bool AllowAll() const { return true; }
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
     private:
       DllHdHomeRun* m_pdll;
   };

--- a/xbmc/filesystem/HDHomeRunDirectory.h
+++ b/xbmc/filesystem/HDHomeRunDirectory.h
@@ -30,7 +30,7 @@ namespace XFILE
     public:
       CHomeRunDirectory(void);
       virtual ~CHomeRunDirectory(void);
-      virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+      virtual bool AllowAll() const { return true; }
       virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     private:
       DllHdHomeRun* m_pdll;

--- a/xbmc/filesystem/HTSPDirectory.cpp
+++ b/xbmc/filesystem/HTSPDirectory.cpp
@@ -418,10 +418,8 @@ bool CHTSPDirectory::GetTag(const CURL &base, CFileItemList &items)
 }
 
 
-bool CHTSPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CHTSPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CURL                    url(strPath);
-
   CHTSPDirectorySession::Release(m_session);
   if(!(m_session = CHTSPDirectorySession::Acquire(url)))
     return false;
@@ -432,8 +430,9 @@ bool CHTSPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
     CFileItemPtr item;
 
     item.reset(new CFileItem("", true));
-    url.SetFileName("tags/0/");
-    item->SetPath(url.Get());
+    CURL url2(url);
+    url2.SetFileName("tags/0/");
+    item->SetURL(url2);
     item->SetLabel(g_localizeStrings.Get(22018));
     item->SetLabelPreformated(true);
     items.Add(item);
@@ -446,8 +445,9 @@ bool CHTSPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
       label = StringUtils::Format("Tag: %s", it->second.name.c_str());
 
       item.reset(new CFileItem("", true));
-      url.SetFileName(filename);
-      item->SetPath(url.Get());
+      CURL url2(url);
+      url2.SetFileName(filename);
+      item->SetURL(url2);
       item->SetLabel(label);
       item->SetLabelPreformated(true);
       item->SetArt("thumb", it->second.icon);

--- a/xbmc/filesystem/HTSPDirectory.h
+++ b/xbmc/filesystem/HTSPDirectory.h
@@ -82,8 +82,8 @@ namespace XFILE
     public:
       CHTSPDirectory(void);
       virtual ~CHTSPDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
     private:
       bool GetChannels(const CURL& base, CFileItemList &items);
       bool GetChannels(const CURL& base, CFileItemList &items, HTSP::SChannels channels, int tag);

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -36,10 +36,9 @@ using namespace XFILE;
 CHTTPDirectory::CHTTPDirectory(void){}
 CHTTPDirectory::~CHTTPDirectory(void){}
 
-bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   CCurlFile http;
-  CURL url(strPath);
 
   CStdString strName, strLink;
   CStdString strBasePath = url.GetFileName();
@@ -130,9 +129,10 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
       {
         CFileItemPtr pItem(new CFileItem(strNameTemp));
         pItem->SetProperty("IsHTTPDirectory", true);
-        url.SetFileName(strBasePath + strLinkBase);
-        url.SetOptions(strLinkOptions);
-        pItem->SetPath(url.Get());
+        CURL url2(url);
+        url2.SetFileName(strBasePath + strLinkBase);
+        url2.SetOptions(strLinkOptions);
+        pItem->SetURL(url2);
 
         if(URIUtils::HasSlashAtEnd(pItem->GetPath(), true))
           pItem->m_bIsFolder = true;
@@ -219,10 +219,9 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
   return true;
 }
 
-bool CHTTPDirectory::Exists(const char* strPath)
+bool CHTTPDirectory::Exists(const CURL &url)
 {
   CCurlFile http;
-  CURL url(strPath);
   struct __stat64 buffer;
 
   if( http.Stat(url, &buffer) != 0 )

--- a/xbmc/filesystem/HTTPDirectory.h
+++ b/xbmc/filesystem/HTTPDirectory.h
@@ -28,9 +28,9 @@ namespace XFILE
     public:
       CHTTPDirectory(void);
       virtual ~CHTTPDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual bool Exists(const char* strPath);
-      virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual bool Exists(const CURL& url);
+      virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
     private:
   };
 }

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -30,7 +30,6 @@ using namespace XFILE;
 
 IDirectory::IDirectory(void)
 {
-  m_strFileMask = "";
   m_flags = DIR_FLAG_DEFAULTS;
 }
 
@@ -92,7 +91,7 @@ bool IDirectory::IsAllowed(const CStdString& strFile) const
  \endverbatim
  So only *.m4a, *.flac, *.aac files will be retrieved with GetDirectory().
  */
-void IDirectory::SetMask(const CStdString& strMask)
+void IDirectory::SetMask(const std::string& strMask)
 {
   m_strFileMask = strMask;
   // ensure it's completed with a | so that filtering is easy.
@@ -139,7 +138,7 @@ bool IDirectory::ProcessRequirements()
   return false;
 }
 
-bool IDirectory::GetKeyboardInput(const CVariant &heading, CStdString &input)
+bool IDirectory::GetKeyboardInput(const CVariant &heading, std::string &input)
 {
   if (!m_requirements["input"].asString().empty())
   {

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -44,19 +44,19 @@ IDirectory::~IDirectory(void)
        "vts_##_0.ifo". If extension is ".dat", filename format must be
        "AVSEQ##(#).DAT", "ITEM###(#).DAT" or "MUSIC##(#).DAT".
  */
-bool IDirectory::IsAllowed(const CStdString& strFile) const
+bool IDirectory::IsAllowed(const CURL& url) const
 {
-  if (m_strFileMask.empty() || strFile.empty())
+  if (m_strFileMask.empty())
     return true;
 
   // Check if strFile have an allowed extension
-  if (!URIUtils::HasExtension(strFile, m_strFileMask))
+  if (!URIUtils::HasExtension(url, m_strFileMask))
     return false;
 
   // We should ignore all non dvd/vcd related ifo and dat files.
-  if (URIUtils::HasExtension(strFile, ".ifo"))
+  if (URIUtils::HasExtension(url, ".ifo"))
   {
-    CStdString fileName = URIUtils::GetFileName(strFile);
+    CStdString fileName = URIUtils::GetFileName(url);
 
     // Allow filenames of the form video_ts.ifo or vts_##_0.ifo
     
@@ -66,9 +66,9 @@ bool IDirectory::IsAllowed(const CStdString& strFile) const
            StringUtils::EndsWithNoCase(fileName, "_0.ifo"));
   }
   
-  if (URIUtils::HasExtension(strFile, ".dat"))
+  if (URIUtils::HasExtension(url, ".dat"))
   {
-    CStdString fileName = URIUtils::GetFileName(strFile);
+    CStdString fileName = URIUtils::GetFileName(url);
 
     // Allow filenames of the form AVSEQ##(#).DAT, ITEM###(#).DAT
     // and MUSIC##(#).DAT
@@ -161,9 +161,9 @@ void IDirectory::SetErrorDialog(const CVariant &heading, const CVariant &line1, 
   m_requirements["line3"] = line3;
 }
 
-void IDirectory::RequireAuthentication(const CStdString &url)
+void IDirectory::RequireAuthentication(const CURL &url)
 {
   m_requirements.clear();
   m_requirements["type"] = "authenticate";
-  m_requirements["url"] = url;
+  m_requirements["url"] = url.Get();
 }

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -19,10 +19,11 @@
  *
  */
 
-#include "utils/StdString.h"
+#include <string>
 #include "utils/Variant.h"
 
 class CFileItemList;
+class CURL;
 
 namespace XFILE
 {
@@ -62,12 +63,12 @@ public:
   virtual ~IDirectory(void);
   /*!
    \brief Get the \e items of the directory \e strPath.
-   \param strPath Directory to read.
+   \param url Directory to read.
    \param items Retrieves the directory entries.
    \return Returns \e true, if successfull.
    \sa CDirectoryFactory
    */
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items) = 0;
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items) = 0;
   /*!
    \brief Retrieve the progress of the current directory fetch (if possible).
    \return the progress as a float in the range 0..100.
@@ -81,31 +82,31 @@ public:
   virtual void CancelDirectory() { };
   /*!
   \brief Create the directory
-  \param strPath Directory to create.
+  \param url Directory to create.
   \return Returns \e true, if directory is created or if it already exists
   \sa CDirectoryFactory
   */
-  virtual bool Create(const char* strPath) { return false; }
+  virtual bool Create(const CURL& url) { return false; }
   /*!
   \brief Check for directory existence
-  \param strPath Directory to check.
+  \param url Directory to check.
   \return Returns \e true, if directory exists
   \sa CDirectoryFactory
   */
-  virtual bool Exists(const char* strPath) { return false; }
+  virtual bool Exists(const CURL& url) { return false; }
   /*!
   \brief Removes the directory
-  \param strPath Directory to remove.
+  \param url Directory to remove.
   \return Returns \e false if not succesfull
   */
-  virtual bool Remove(const char* strPath) { return false; }
+  virtual bool Remove(const CURL& url) { return false; }
 
   /*!
   \brief Whether this file should be listed
-  \param strFile File to test.
+  \param url File to test.
   \return Returns \e true if the file should be listed
   */
-  virtual bool IsAllowed(const CStdString& strFile) const;
+  virtual bool IsAllowed(const CURL& url) const;
 
   /*! \brief Whether to allow all files/folders to be listed.
    \return Returns \e true if all files/folder should be listed.
@@ -114,10 +115,10 @@ public:
 
   /*!
   \brief How this directory should be cached
-  \param strPath Directory at hand.
+  \param url Directory at hand.
   \return Returns the cache type.
   */
-  virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
+  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
 
   void SetMask(const std::string& strMask);
   void SetFlags(int flags);
@@ -160,7 +161,7 @@ protected:
    \param url the URL to authenticate.
    \sa ProcessRequirements
    */
-  void RequireAuthentication(const CStdString &url);
+  void RequireAuthentication(const CURL& url);
 
   std::string m_strFileMask;  ///< Holds the file mask specified by SetMask()
 

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -107,6 +107,11 @@ public:
   */
   virtual bool IsAllowed(const CStdString& strFile) const;
 
+  /*! \brief Whether to allow all files/folders to be listed.
+   \return Returns \e true if all files/folder should be listed.
+   */
+  virtual bool AllowAll() const { return false; }
+
   /*!
   \brief How this directory should be cached
   \param strPath Directory at hand.

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -114,7 +114,7 @@ public:
   */
   virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
 
-  void SetMask(const CStdString& strMask);
+  void SetMask(const std::string& strMask);
   void SetFlags(int flags);
 
   /*! \brief Process additional requirements before the directory fetch is performed.
@@ -136,7 +136,7 @@ protected:
    \return true if keyboard input has been received. False if it hasn't.
    \sa ProcessRequirements
    */
-  bool GetKeyboardInput(const CVariant &heading, CStdString &input);
+  bool GetKeyboardInput(const CVariant &heading, std::string &input);
 
   /*! \brief Show an error dialog on failure of GetDirectory call
    Call this method from the GetDirectory method to set an error message to be shown to the user
@@ -157,7 +157,7 @@ protected:
    */
   void RequireAuthentication(const CStdString &url);
 
-  CStdString m_strFileMask;  ///< Holds the file mask specified by SetMask()
+  std::string m_strFileMask;  ///< Holds the file mask specified by SetMask()
 
   int m_flags; ///< Directory flags - see DIR_FLAG
 

--- a/xbmc/filesystem/IFileDirectory.h
+++ b/xbmc/filesystem/IFileDirectory.h
@@ -27,7 +27,7 @@ class IFileDirectory : public IDirectory
 {
 public:
   virtual ~IFileDirectory(void) {};
-  virtual bool ContainsFiles(const CStdString& strPath)=0;
+  virtual bool ContainsFiles(const CURL& url)=0;
 };
 
 }

--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -34,16 +34,14 @@ CISO9660Directory::CISO9660Directory(void)
 CISO9660Directory::~CISO9660Directory(void)
 {}
 
-bool CISO9660Directory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CStdString strRoot = strPath;
+  CStdString strRoot = url.Get();
   URIUtils::AddSlashAtEnd(strRoot);
 
   // Scan active disc if not done before
   if (!m_isoReader.IsScanned())
     m_isoReader.Scan();
-
-  CURL url(strPath);
 
   WIN32_FIND_DATA wfd;
   HANDLE hFind;
@@ -108,10 +106,10 @@ bool CISO9660Directory::GetDirectory(const CStdString& strPath, CFileItemList &i
   return true;
 }
 
-bool CISO9660Directory::Exists(const char* strPath)
+bool CISO9660Directory::Exists(const CURL& url)
 {
   CFileItemList items;
-  if (GetDirectory(strPath,items))
+  if (GetDirectory(url,items))
     return true;
 
   return false;

--- a/xbmc/filesystem/ISO9660Directory.h
+++ b/xbmc/filesystem/ISO9660Directory.h
@@ -29,7 +29,7 @@ class CISO9660Directory :
 public:
   CISO9660Directory(void);
   virtual ~CISO9660Directory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool Exists(const char* strPath);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual bool Exists(const CURL& url);
 };
 }

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -45,9 +45,9 @@ CLibraryDirectory::~CLibraryDirectory(void)
 {
 }
 
-bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CLibraryDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  std::string libNode = GetNode(strPath);
+  std::string libNode = GetNode(url);
   if (libNode.empty())
     return false;
 
@@ -99,6 +99,7 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
     return false;
 
   // iterate over our nodes
+  std::string basePath = url.Get();
   for (int i = 0; i < nodes.Size(); i++)
   {
     const TiXmlElement *node = NULL;
@@ -129,7 +130,7 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
       // create item
       URIUtils::RemoveSlashAtEnd(xml);
       CStdString folder = URIUtils::GetFileName(xml);
-      CFileItemPtr item(new CFileItem(URIUtils::AddFileToFolder(strPath, folder), true));
+      CFileItemPtr item(new CFileItem(URIUtils::AddFileToFolder(basePath, folder), true));
 
       item->SetLabel(label);
       if (!icon.empty() && g_TextureManager.HasTexture(icon))
@@ -163,16 +164,13 @@ TiXmlElement *CLibraryDirectory::LoadXML(const std::string &xmlFile)
   return NULL;
 }
 
-bool CLibraryDirectory::Exists(const char* strPath)
+bool CLibraryDirectory::Exists(const CURL& url)
 {
-  if (strPath)
-    return !GetNode(std::string(strPath)).empty();
-  return false;
+  return !GetNode(url).empty();
 }
 
-std::string CLibraryDirectory::GetNode(const std::string &path)
+std::string CLibraryDirectory::GetNode(const CURL& url)
 {
-  CURL url(path);
   CStdString libDir = URIUtils::AddFileToFolder(CProfilesManager::Get().GetLibraryFolder(), url.GetHostName() + "/");
   if (!CDirectory::Exists(libDir))
     libDir = URIUtils::AddFileToFolder("special://xbmc/system/library/", url.GetHostName() + "/");

--- a/xbmc/filesystem/LibraryDirectory.h
+++ b/xbmc/filesystem/LibraryDirectory.h
@@ -31,7 +31,7 @@ namespace XFILE
     virtual ~CLibraryDirectory();
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     virtual bool Exists(const char* strPath);
-    virtual bool IsAllowed(const CStdString& strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
   private:
     /*! \brief parse the given path and return the node corresponding to this path
      \param path the library:// path to parse

--- a/xbmc/filesystem/LibraryDirectory.h
+++ b/xbmc/filesystem/LibraryDirectory.h
@@ -29,15 +29,15 @@ namespace XFILE
   public:
     CLibraryDirectory();
     virtual ~CLibraryDirectory();
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Exists(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Exists(const CURL& url);
     virtual bool AllowAll() const { return true; }
   private:
     /*! \brief parse the given path and return the node corresponding to this path
      \param path the library:// path to parse
      \return path to the XML file or directory corresponding to this path
      */
-    std::string GetNode(const std::string &path);
+    std::string GetNode(const CURL& path);
 
     /*! \brief load the XML file and return a pointer to the <node> root element.
      Checks visible attribute and only returns non-NULL for valid nodes that should be visible.

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -154,6 +154,12 @@ CStdString CMultiPathDirectory::GetFirstPath(const CStdString &strPath)
   return "";
 }
 
+bool CMultiPathDirectory::GetPaths(const CURL& url, vector<CStdString>& vecPaths)
+{
+  const CStdString pathToUrl(url.Get());
+  return GetPaths(pathToUrl, vecPaths);
+}
+
 bool CMultiPathDirectory::GetPaths(const CStdString& strPath, vector<CStdString>& vecPaths)
 {
   vecPaths.clear();

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -47,12 +47,12 @@ CMultiPathDirectory::CMultiPathDirectory()
 CMultiPathDirectory::~CMultiPathDirectory()
 {}
 
-bool CMultiPathDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CLog::Log(LOGDEBUG,"CMultiPathDirectory::GetDirectory(%s)", strPath.c_str());
+  CLog::Log(LOGDEBUG,"CMultiPathDirectory::GetDirectory(%s)", url.GetRedacted().c_str());
 
   vector<CStdString> vecPaths;
-  if (!GetPaths(strPath, vecPaths))
+  if (!GetPaths(url, vecPaths))
     return false;
 
   XbmcThreads::EndTime progressTime(3000); // 3 seconds before showing progress bar
@@ -114,12 +114,12 @@ bool CMultiPathDirectory::GetDirectory(const CStdString& strPath, CFileItemList 
   return true;
 }
 
-bool CMultiPathDirectory::Exists(const char* strPath)
+bool CMultiPathDirectory::Exists(const CURL& url)
 {
-  CLog::Log(LOGDEBUG,"Testing Existence (%s)", strPath);
+  CLog::Log(LOGDEBUG,"Testing Existence (%s)", url.GetRedacted().c_str());
 
   vector<CStdString> vecPaths;
-  if (!GetPaths(strPath, vecPaths))
+  if (!GetPaths(url, vecPaths))
     return false;
 
   for (unsigned int i = 0; i < vecPaths.size(); ++i)
@@ -131,10 +131,10 @@ bool CMultiPathDirectory::Exists(const char* strPath)
   return false;
 }
 
-bool CMultiPathDirectory::Remove(const char* strPath)
+bool CMultiPathDirectory::Remove(const CURL& url)
 {
   vector<CStdString> vecPaths;
-  if (!GetPaths(strPath, vecPaths))
+  if (!GetPaths(url, vecPaths))
     return false;
 
   bool success = false;

--- a/xbmc/filesystem/MultiPathDirectory.h
+++ b/xbmc/filesystem/MultiPathDirectory.h
@@ -19,8 +19,9 @@
  *
  */
 
-#include "IDirectory.h"
 #include <set>
+#include "IDirectory.h"
+#include "utils/StdString.h"
 
 namespace XFILE
 {
@@ -30,9 +31,9 @@ class CMultiPathDirectory :
 public:
   CMultiPathDirectory(void);
   virtual ~CMultiPathDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool Exists(const char* strPath);
-  virtual bool Remove(const char* strPath);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual bool Exists(const CURL& url);
+  virtual bool Remove(const CURL& url);
 
   static CStdString GetFirstPath(const CStdString &strPath);
   static bool SupportsWriteFileOperations(const CStdString &strPath);

--- a/xbmc/filesystem/MultiPathDirectory.h
+++ b/xbmc/filesystem/MultiPathDirectory.h
@@ -36,6 +36,7 @@ public:
 
   static CStdString GetFirstPath(const CStdString &strPath);
   static bool SupportsWriteFileOperations(const CStdString &strPath);
+  static bool GetPaths(const CURL& url, std::vector<CStdString>& vecPaths);
   static bool GetPaths(const CStdString& strPath, std::vector<CStdString>& vecPaths);
   static bool HasPath(const CStdString& strPath, const CStdString& strPathToFind);
   static CStdString ConstructMultiPath(const std::vector<CStdString> &vecPaths);

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -43,9 +43,9 @@ CMusicDatabaseDirectory::~CMusicDatabaseDirectory(void)
 {
 }
 
-bool CMusicDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CMusicDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(url);
   items.SetPath(path);
   auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
@@ -247,9 +247,9 @@ bool CMusicDatabaseDirectory::ContainsSongs(const CStdString &path)
   return false;
 }
 
-bool CMusicDatabaseDirectory::Exists(const char* strPath)
+bool CMusicDatabaseDirectory::Exists(const CURL& url)
 {
-  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  CStdString path = CLegacyPathTranslation::TranslateMusicDbPath(url);
   auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())

--- a/xbmc/filesystem/MusicDatabaseDirectory.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory.h
@@ -30,9 +30,9 @@ namespace XFILE
   public:
     CMusicDatabaseDirectory(void);
     virtual ~CMusicDatabaseDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
     virtual bool AllowAll() const { return true; }
-    virtual bool Exists(const char* strPath);
+    virtual bool Exists(const CURL& url);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryChildType(const CStdString& strPath);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryType(const CStdString& strPath);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryParentType(const CStdString& strPath);

--- a/xbmc/filesystem/MusicDatabaseDirectory.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory.h
@@ -31,7 +31,7 @@ namespace XFILE
     CMusicDatabaseDirectory(void);
     virtual ~CMusicDatabaseDirectory(void);
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
     virtual bool Exists(const char* strPath);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryChildType(const CStdString& strPath);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryType(const CStdString& strPath);

--- a/xbmc/filesystem/MusicFileDirectory.cpp
+++ b/xbmc/filesystem/MusicFileDirectory.cpp
@@ -23,6 +23,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "URL.h"
 
 using namespace MUSIC_INFO;
 using namespace XFILE;
@@ -35,15 +36,15 @@ CMusicFileDirectory::~CMusicFileDirectory(void)
 {
 }
 
-bool CMusicFileDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items)
+bool CMusicFileDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CStdString strPath=strPath1;
+  CStdString strPath=url.Get();
 
   CStdString strFileName;
   strFileName = URIUtils::GetFileName(strPath);
   URIUtils::RemoveExtension(strFileName);
 
-  int iStreams = GetTrackCount(strPath1);
+  int iStreams = GetTrackCount(strPath);
 
   URIUtils::AddSlashAtEnd(strPath);
 
@@ -64,14 +65,15 @@ bool CMusicFileDirectory::GetDirectory(const CStdString& strPath1, CFileItemList
   return true;
 }
 
-bool CMusicFileDirectory::Exists(const char* strPath)
+bool CMusicFileDirectory::Exists(const CURL& url)
 {
   return true;
 }
 
-bool CMusicFileDirectory::ContainsFiles(const CStdString& strPath)
+bool CMusicFileDirectory::ContainsFiles(const CURL &url)
 {
-  if (GetTrackCount(strPath) > 1)
+  const CStdString pathToUrl(url.Get());
+  if (GetTrackCount(pathToUrl) > 1)
     return true;
 
   return false;

--- a/xbmc/filesystem/MusicFileDirectory.h
+++ b/xbmc/filesystem/MusicFileDirectory.h
@@ -30,9 +30,9 @@ namespace XFILE
     public:
       CMusicFileDirectory(void);
       virtual ~CMusicFileDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual bool Exists(const char* strPath);
-      virtual bool ContainsFiles(const CStdString& strPath);
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual bool Exists(const CURL& url);
+      virtual bool ContainsFiles(const CURL& url);
       virtual bool AllowAll() const { return true; }
     protected:
       virtual int GetTrackCount(const CStdString& strPath) = 0;

--- a/xbmc/filesystem/MusicFileDirectory.h
+++ b/xbmc/filesystem/MusicFileDirectory.h
@@ -33,7 +33,7 @@ namespace XFILE
       virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
       virtual bool Exists(const char* strPath);
       virtual bool ContainsFiles(const CStdString& strPath);
-      virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+      virtual bool AllowAll() const { return true; }
     protected:
       virtual int GetTrackCount(const CStdString& strPath) = 0;
       CStdString m_strExt;

--- a/xbmc/filesystem/MusicSearchDirectory.cpp
+++ b/xbmc/filesystem/MusicSearchDirectory.cpp
@@ -37,30 +37,29 @@ CMusicSearchDirectory::~CMusicSearchDirectory(void)
 {
 }
 
-bool CMusicSearchDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CMusicSearchDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // break up our path
   // format is:  musicsearch://<url encoded search string>
-  CURL url(strPath);
   CStdString search(url.GetHostName());
 
   if (search.empty())
     return false;
 
   // and retrieve the search details
-  items.SetPath(strPath);
+  items.SetURL(url);
   unsigned int time = XbmcThreads::SystemClockMillis();
   CMusicDatabase db;
   db.Open();
   db.Search(search, items);
   db.Close();
   CLog::Log(LOGDEBUG, "%s (%s) took %u ms",
-            __FUNCTION__, strPath.c_str(), XbmcThreads::SystemClockMillis() - time);
+            __FUNCTION__, url.GetRedacted().c_str(), XbmcThreads::SystemClockMillis() - time);
   items.SetLabel(g_localizeStrings.Get(137)); // Search
   return true;
 }
 
-bool CMusicSearchDirectory::Exists(const char* strPath)
+bool CMusicSearchDirectory::Exists(const CURL& url)
 {
   return true;
 }

--- a/xbmc/filesystem/MusicSearchDirectory.h
+++ b/xbmc/filesystem/MusicSearchDirectory.h
@@ -28,8 +28,8 @@ namespace XFILE
   public:
     CMusicSearchDirectory(void);
     virtual ~CMusicSearchDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Exists(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Exists(const CURL& url);
     virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/MusicSearchDirectory.h
+++ b/xbmc/filesystem/MusicSearchDirectory.h
@@ -30,6 +30,6 @@ namespace XFILE
     virtual ~CMusicSearchDirectory(void);
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     virtual bool Exists(const char* strPath);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/MythDirectory.cpp
+++ b/xbmc/filesystem/MythDirectory.cpp
@@ -469,7 +469,7 @@ bool CMythDirectory::GetChannels(const CStdString& base, CFileItemList &items)
 
 bool CMythDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
 {
-  m_session = CMythSession::AquireSession(strPath);
+  m_session = CMythSession::AquireSession(CURL(strPath));
   if (!m_session)
     return false;
 

--- a/xbmc/filesystem/MythDirectory.cpp
+++ b/xbmc/filesystem/MythDirectory.cpp
@@ -55,9 +55,8 @@ CMythDirectory::~CMythDirectory()
   Release();
 }
 
-DIR_CACHE_TYPE CMythDirectory::GetCacheType(const CStdString& strPath) const
+DIR_CACHE_TYPE CMythDirectory::GetCacheType(const CURL& url) const
 {
-  CURL url(strPath);
   CStdString fileName = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(fileName);
 
@@ -467,9 +466,9 @@ bool CMythDirectory::GetChannels(const CStdString& base, CFileItemList &items)
   return true;
 }
 
-bool CMythDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CMythDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  m_session = CMythSession::AquireSession(CURL(strPath));
+  m_session = CMythSession::AquireSession(url);
   if (!m_session)
     return false;
 
@@ -477,10 +476,9 @@ bool CMythDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
   if (!m_dll)
     return false;
 
-  CStdString base(strPath);
+  CStdString base(url.Get());
   URIUtils::RemoveSlashAtEnd(base);
 
-  CURL url(strPath);
   CStdString fileName = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(fileName);
 
@@ -544,14 +542,13 @@ bool CMythDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
   return false;
 }
 
-bool CMythDirectory::Exists(const char* strPath)
+bool CMythDirectory::Exists(const CURL& url)
 {
   /*
    * Return true for any virtual folders that are known to exist. Don't check for explicit
    * existence using GetDirectory() as most methods will return true with empty content due to the
    * way they are implemented - by iterating over all programs and filtering out content.
    */
-  CURL url(strPath);
   CStdString fileName = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(fileName);
 

--- a/xbmc/filesystem/MythDirectory.h
+++ b/xbmc/filesystem/MythDirectory.h
@@ -56,8 +56,8 @@ private:
   bool GetTvShowFolders(const CStdString& base, CFileItemList &items);
   bool GetChannels(const CStdString& base, CFileItemList &items);
 
-  CStdString GetValue(char* str)           { return m_session->GetValue(str); }
-  CDateTime  GetValue(cmyth_timestamp_t t) { return m_session->GetValue(t); }
+  std::string GetValue(char* str)           { return m_session->GetValue(str); }
+  CDateTime   GetValue(cmyth_timestamp_t t) { return m_session->GetValue(t); }
   bool IsVisible(const cmyth_proginfo_t program);
   bool IsMovie(const cmyth_proginfo_t program);
   bool IsTvShow(const cmyth_proginfo_t program);

--- a/xbmc/filesystem/MythDirectory.h
+++ b/xbmc/filesystem/MythDirectory.h
@@ -40,10 +40,10 @@ public:
   CMythDirectory();
   virtual ~CMythDirectory();
 
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool Exists(const char* strPath);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual bool Exists(const CURL& url);
   virtual bool AllowAll() const { return true; }
-  virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const;
+  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const;
 
   static bool SupportsWriteFileOperations(const CStdString& strPath);
   static bool IsLiveTV(const CStdString& strPath);

--- a/xbmc/filesystem/MythDirectory.h
+++ b/xbmc/filesystem/MythDirectory.h
@@ -42,7 +42,7 @@ public:
 
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
   virtual bool Exists(const char* strPath);
-  virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual bool AllowAll() const { return true; }
   virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const;
 
   static bool SupportsWriteFileOperations(const CStdString& strPath);

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -120,9 +120,9 @@ CDateTime CMythSession::GetValue(cmyth_timestamp_t t)
   return result;
 }
 
-CStdString CMythSession::GetValue(char *str)
+std::string CMythSession::GetValue(char *str)
 {
-  CStdString result;
+  std::string result;
   if (str)
   {
     result = str;

--- a/xbmc/filesystem/MythSession.h
+++ b/xbmc/filesystem/MythSession.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <string>
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 
@@ -65,7 +66,7 @@ public:
   void             SetFileItemMetaData(CFileItem &item, cmyth_proginfo_t program);
 
   CDateTime        GetValue(cmyth_timestamp_t t);
-  CStdString       GetValue(char* str);
+  std::string      GetValue(char* str);
 
 private:
   CMythSession(const CURL& url);
@@ -82,9 +83,9 @@ private:
   cmyth_conn_t     m_control;
   cmyth_conn_t     m_event;
   cmyth_database_t m_database;
-  CStdString       m_hostname;
-  CStdString       m_username;
-  CStdString       m_password;
+  std::string      m_hostname;
+  std::string      m_username;
+  std::string      m_password;
   int              m_port;
   DllLibCMyth*     m_dll;
   CCriticalSection m_section;

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -182,15 +182,14 @@ bool CNFSDirectory::ResolveSymlink( const CStdString &dirName, struct nfsdirent 
   return retVal;
 }
 
-bool CNFSDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // We accept nfs://server/path[/file]]]]
   int ret = 0;
   FILETIME fileTime, localTime;    
   CSingleLock lock(gNfsConnection); 
-  CURL url(strPath);
   CStdString strDirName="";
-  std::string myStrPath(strPath);
+  std::string myStrPath(url.Get());
   URIUtils::AddSlashAtEnd(myStrPath); //be sure the dir ends with a slash
    
   if(!gNfsConnection.Connect(url,strDirName))
@@ -292,13 +291,13 @@ bool CNFSDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
   return true;
 }
 
-bool CNFSDirectory::Create(const char* strPath)
+bool CNFSDirectory::Create(const CURL& url2)
 {
   int ret = 0;
   bool success=true;
   
   CSingleLock lock(gNfsConnection);
-  CStdString folderName(strPath);
+  CStdString folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//mkdir fails if a slash is at the end!!! 
   CURL url(folderName); 
   folderName = "";
@@ -314,12 +313,12 @@ bool CNFSDirectory::Create(const char* strPath)
   return success;
 }
 
-bool CNFSDirectory::Remove(const char* strPath)
+bool CNFSDirectory::Remove(const CURL& url2)
 {
   int ret = 0;
 
   CSingleLock lock(gNfsConnection);
-  CStdString folderName(strPath);
+  CStdString folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//rmdir fails if a slash is at the end!!!   
   CURL url(folderName);
   folderName = "";
@@ -337,12 +336,12 @@ bool CNFSDirectory::Remove(const char* strPath)
   return true;
 }
 
-bool CNFSDirectory::Exists(const char* strPath)
+bool CNFSDirectory::Exists(const CURL& url2)
 {
   int ret = 0;
 
   CSingleLock lock(gNfsConnection); 
-  CStdString folderName(strPath);  
+  CStdString folderName(url2.Get());
   URIUtils::RemoveSlashAtEnd(folderName);//remove slash at end or URIUtils::GetFileName won't return what we want...
   CURL url(folderName);
   folderName = "";

--- a/xbmc/filesystem/NFSDirectory.h
+++ b/xbmc/filesystem/NFSDirectory.h
@@ -29,11 +29,11 @@ namespace XFILE
     public:
       CNFSDirectory(void);
       virtual ~CNFSDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual DIR_CACHE_TYPE GetCacheType(const CStdString &strPath) const { return DIR_CACHE_ONCE; };
-      virtual bool Create(const char* strPath);
-      virtual bool Exists(const char* strPath);
-      virtual bool Remove(const char* strPath);
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
+      virtual bool Create(const CURL& url);
+      virtual bool Exists(const CURL& url);
+      virtual bool Remove(const CURL& url);
     private:
       bool GetServerList(CFileItemList &items);
       bool GetDirectoryFromExportList(const std::string& strPath, CFileItemList &items);

--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -44,21 +44,16 @@ CPVRDirectory::~CPVRDirectory()
 {
 }
 
-bool CPVRDirectory::Exists(const char* strPath)
+bool CPVRDirectory::Exists(const CURL& url)
 {
-  CStdString directory(strPath);
-  if (directory.substr(0,17) == "pvr://recordings/")
-    return true;
-  else
-    return false;
+  return (url.GetProtocol() == "pvr" && url.GetHostName() == "recordings");
 }
 
-bool CPVRDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CPVRDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CStdString base(strPath);
+  CStdString base(url.Get());
   URIUtils::RemoveSlashAtEnd(base);
 
-  CURL url(strPath);
   CStdString fileName = url.GetFileName();
   URIUtils::RemoveSlashAtEnd(fileName);
   CLog::Log(LOGDEBUG, "CPVRDirectory::GetDirectory(%s)", base.c_str());
@@ -98,15 +93,18 @@ bool CPVRDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
   }
   else if (StringUtils::StartsWith(fileName, "recordings"))
   {
-    return g_PVRRecordings->GetDirectory(strPath, items);
+    const CStdString pathToUrl(url.Get());
+    return g_PVRRecordings->GetDirectory(pathToUrl, items);
   }
   else if (StringUtils::StartsWith(fileName, "channels"))
   {
-    return g_PVRChannelGroups->GetDirectory(strPath, items);
+    const CStdString pathToUrl(url.Get());
+    return g_PVRChannelGroups->GetDirectory(pathToUrl, items);
   }
   else if (StringUtils::StartsWith(fileName, "timers"))
   {
-    return g_PVRTimers->GetDirectory(strPath, items);
+    const CStdString pathToUrl(url.Get());
+    return g_PVRTimers->GetDirectory(pathToUrl, items);
   }
 
   return false;

--- a/xbmc/filesystem/PVRDirectory.h
+++ b/xbmc/filesystem/PVRDirectory.h
@@ -33,7 +33,7 @@ public:
   virtual ~CPVRDirectory();
 
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual bool AllowAll() const { return true; }
 
   static bool SupportsWriteFileOperations(const CStdString& strPath);
   static bool IsLiveTV(const CStdString& strPath);

--- a/xbmc/filesystem/PVRDirectory.h
+++ b/xbmc/filesystem/PVRDirectory.h
@@ -20,6 +20,7 @@
  */
 
 #include "IDirectory.h"
+#include "utils/StdString.h"
 
 class CPVRSession;
 
@@ -32,14 +33,14 @@ public:
   CPVRDirectory();
   virtual ~CPVRDirectory();
 
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
   virtual bool AllowAll() const { return true; }
 
   static bool SupportsWriteFileOperations(const CStdString& strPath);
   static bool IsLiveTV(const CStdString& strPath);
   static bool HasRecordings();
 
-  virtual bool Exists(const char* strPath);
+  virtual bool Exists(const CURL& url);
 
 private:
 };

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -36,10 +36,8 @@ CPlaylistDirectory::~CPlaylistDirectory()
 
 }
 
-bool CPlaylistDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CURL url(strPath);
-
   int playlistTyp=PLAYLIST_NONE;
   if (url.GetProtocol()=="playlistmusic")
     playlistTyp=PLAYLIST_MUSIC;

--- a/xbmc/filesystem/PlaylistDirectory.h
+++ b/xbmc/filesystem/PlaylistDirectory.h
@@ -30,6 +30,6 @@ namespace XFILE
     CPlaylistDirectory(void);
     virtual ~CPlaylistDirectory(void);
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/PlaylistDirectory.h
+++ b/xbmc/filesystem/PlaylistDirectory.h
@@ -29,7 +29,7 @@ namespace XFILE
   public:
     CPlaylistDirectory(void);
     virtual ~CPlaylistDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
     virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -77,7 +77,7 @@ namespace XFILE
 
   bool CPlaylistFileDirectory::Remove(const CURL& url)
   {
-    return XFILE::CFile::Delete(url.Get());
+    return XFILE::CFile::Delete(url);
   }
 }
 

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -22,6 +22,7 @@
 #include "utils/log.h"
 #include "playlists/PlayListFactory.h"
 #include "File.h"
+#include "URL.h"
 #include "playlists/PlayList.h"
 
 using namespace std;
@@ -37,13 +38,14 @@ namespace XFILE
   {
   }
 
-  bool CPlaylistFileDirectory::GetDirectory(const CStdString& strPath, CFileItemList& items)
+  bool CPlaylistFileDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   {
-    auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPath));
+    const CStdString pathToUrl = url.Get();
+    auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(pathToUrl));
     if ( NULL != pPlayList.get())
     {
       // load it
-      if (!pPlayList->Load(strPath))
+      if (!pPlayList->Load(pathToUrl))
         return false; //hmmm unable to load playlist?
 
       CPlayList playlist = *pPlayList;
@@ -58,13 +60,14 @@ namespace XFILE
     return true;
   }
 
-  bool CPlaylistFileDirectory::ContainsFiles(const CStdString& strPath)
+  bool CPlaylistFileDirectory::ContainsFiles(const CURL& url)
   {
-    auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPath));
+    const CStdString pathToUrl = url.Get();
+    auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(pathToUrl));
     if ( NULL != pPlayList.get())
     {
       // load it
-      if (!pPlayList->Load(strPath))
+      if (!pPlayList->Load(pathToUrl))
         return false; //hmmm unable to load playlist?
 
       return (pPlayList->size() > 1);
@@ -72,9 +75,9 @@ namespace XFILE
     return false;
   }
 
-  bool CPlaylistFileDirectory::Remove(const char *strPath)
+  bool CPlaylistFileDirectory::Remove(const CURL& url)
   {
-    return XFILE::CFile::Delete(strPath);
+    return XFILE::CFile::Delete(url.Get());
   }
 }
 

--- a/xbmc/filesystem/PlaylistFileDirectory.h
+++ b/xbmc/filesystem/PlaylistFileDirectory.h
@@ -29,9 +29,9 @@ namespace XFILE
   public:
     CPlaylistFileDirectory();
     ~CPlaylistFileDirectory();
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
-    virtual bool ContainsFiles(const CStdString& strPath);
-    virtual bool Remove(const char *strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items);
+    virtual bool ContainsFiles(const CURL& url);
+    virtual bool Remove(const CURL& url);
     virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/PlaylistFileDirectory.h
+++ b/xbmc/filesystem/PlaylistFileDirectory.h
@@ -32,6 +32,6 @@ namespace XFILE
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
     virtual bool ContainsFiles(const CStdString& strPath);
     virtual bool Remove(const char *strPath);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -405,11 +405,10 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const C
   }
 }
 
-bool CPluginDirectory::GetDirectory(const CStdString& strPath, CFileItemList& items)
+bool CPluginDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
-  CURL url(strPath);
-
-  bool success = StartScript(strPath, true);
+  const CStdString pathToUrl(url.Get());
+  bool success = StartScript(pathToUrl, true);
 
   // append the items to the list
   items.Assign(*m_listItems, true); // true to keep the current items

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -45,7 +45,7 @@ public:
   CPluginDirectory();
   ~CPluginDirectory(void);
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
-  virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual bool AllowAll() const { return true; }
   virtual bool Exists(const char* strPath) { return true; }
   virtual float GetProgress() const;
   virtual void CancelDirectory();

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -44,9 +44,9 @@ class CPluginDirectory : public IDirectory
 public:
   CPluginDirectory();
   ~CPluginDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
+  virtual bool GetDirectory(const CURL& url, CFileItemList& items);
   virtual bool AllowAll() const { return true; }
-  virtual bool Exists(const char* strPath) { return true; }
+  virtual bool Exists(const CURL& url) { return true; }
   virtual float GetProgress() const;
   virtual void CancelDirectory();
   static bool RunScriptWithParams(const CStdString& strPath);

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -77,10 +77,10 @@ CRSSDirectory::~CRSSDirectory()
 {
 }
 
-bool CRSSDirectory::ContainsFiles(const CStdString& strPath)
+bool CRSSDirectory::ContainsFiles(const CURL& url)
 {
   CFileItemList items;
-  if(!GetDirectory(strPath, items))
+  if(!GetDirectory(url, items))
     return false;
 
   return items.Size() > 0;
@@ -557,9 +557,10 @@ static void ParseItem(CFileItem* item, TiXmlElement* root, const CStdString& pat
   }
 }
 
-bool CRSSDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
+bool CRSSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CStdString strPath(path);
+  const CStdString pathToUrl(url.Get());
+  CStdString strPath(pathToUrl);
   URIUtils::RemoveSlashAtEnd(strPath);
   std::map<CStdString,CDateTime>::iterator it;
   items.SetPath(strPath);
@@ -593,7 +594,7 @@ bool CRSSDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
   TiXmlHandle docHandle( &xmlDoc );
   TiXmlElement* channelXmlNode = docHandle.FirstChild( "rss" ).FirstChild( "channel" ).Element();
   if (channelXmlNode)
-    ParseItem(&items, channelXmlNode, path);
+    ParseItem(&items, channelXmlNode, pathToUrl);
   else
     return false;
 
@@ -602,7 +603,7 @@ bool CRSSDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
   {
     // Create new item,
     CFileItemPtr item(new CFileItem());
-    ParseItem(item.get(), child, path);
+    ParseItem(item.get(), child, pathToUrl);
 
     item->SetProperty("isrss", "1");
     // Use channel image if item doesn't have one
@@ -632,9 +633,8 @@ bool CRSSDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
   return true;
 }
 
-bool CRSSDirectory::Exists(const char* strPath)
+bool CRSSDirectory::Exists(const CURL& url)
 {
   CCurlFile rss;
-  CURL url(strPath);
   return rss.Exists(url);
 }

--- a/xbmc/filesystem/RSSDirectory.h
+++ b/xbmc/filesystem/RSSDirectory.h
@@ -33,7 +33,7 @@ namespace XFILE
     virtual ~CRSSDirectory();
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     virtual bool Exists(const char* strPath);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
     virtual bool ContainsFiles(const CStdString& strPath);
     virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
   protected:

--- a/xbmc/filesystem/RSSDirectory.h
+++ b/xbmc/filesystem/RSSDirectory.h
@@ -31,11 +31,11 @@ namespace XFILE
   public:
     CRSSDirectory();
     virtual ~CRSSDirectory();
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Exists(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Exists(const CURL& url);
     virtual bool AllowAll() const { return true; }
-    virtual bool ContainsFiles(const CStdString& strPath);
-    virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
+    virtual bool ContainsFiles(const CURL& url);
+    virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
   protected:
     // key is path, value is cache invalidation date
     static std::map<CStdString,CDateTime> m_cache;

--- a/xbmc/filesystem/RTVDirectory.cpp
+++ b/xbmc/filesystem/RTVDirectory.cpp
@@ -49,11 +49,10 @@ CRTVDirectory::~CRTVDirectory(void)
 }
 
 //*********************************************************************************************
-bool CRTVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CRTVDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
 {
-  CURL url(strPath);
-
-  CStdString strRoot = strPath;
+  CURL url(url2);
+  CStdString strRoot = url.Get();
   URIUtils::AddSlashAtEnd(strRoot);
 
   // Host name is "*" so we try to discover all ReplayTVs.  This requires some trickery but works.

--- a/xbmc/filesystem/RTVDirectory.h
+++ b/xbmc/filesystem/RTVDirectory.h
@@ -33,7 +33,7 @@ class CRTVDirectory :
 public:
   CRTVDirectory(void);
   virtual ~CRTVDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
   virtual bool AllowAll() const { return true; }
 };
 }

--- a/xbmc/filesystem/RTVDirectory.h
+++ b/xbmc/filesystem/RTVDirectory.h
@@ -34,6 +34,6 @@ public:
   CRTVDirectory(void);
   virtual ~CRTVDirectory(void);
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual bool AllowAll() const { return true; }
 };
 }

--- a/xbmc/filesystem/RarDirectory.cpp
+++ b/xbmc/filesystem/RarDirectory.cpp
@@ -36,17 +36,14 @@ namespace XFILE
   {
   }
 
-  bool CRarDirectory::GetDirectory(const CStdString& strPathOrig, CFileItemList& items)
+  bool CRarDirectory::GetDirectory(const CURL& urlOrig, CFileItemList& items)
   {
-    CStdString strPath;
+    CURL url(urlOrig);
 
     /* if this isn't a proper archive path, assume it's the path to a archive file */
-    if( !StringUtils::StartsWithNoCase(strPathOrig, "rar://") )
-      URIUtils::CreateArchivePath(strPath, "rar", strPathOrig, "");
-    else
-      strPath = strPathOrig;
+    if (urlOrig.GetProtocol() != "rar")
+      url = URIUtils::CreateArchivePath("rar", urlOrig);
 
-    CURL url(strPath);
     CStdString strArchive = url.GetHostName();
     CStdString strOptions = url.GetOptions();
     CStdString strPathInArchive = url.GetFileName();
@@ -77,19 +74,20 @@ namespace XFILE
     }
   }
 
-  bool CRarDirectory::Exists(const char* strPath)
+  bool CRarDirectory::Exists(const CURL& url)
   {
     CFileItemList items;
-    if (GetDirectory(strPath,items))
+    if (GetDirectory(url,items))
       return true;
 
     return false;
   }
 
-  bool CRarDirectory::ContainsFiles(const CStdString& strPath)
+  bool CRarDirectory::ContainsFiles(const CURL& url)
   {
     CFileItemList items;
-    if (g_RarManager.GetFilesInRar(items,strPath))
+    const CStdString pathToUrl(url.Get());
+    if (g_RarManager.GetFilesInRar(items, pathToUrl))
     {
       if (items.Size() > 1)
         return true;

--- a/xbmc/filesystem/RarDirectory.h
+++ b/xbmc/filesystem/RarDirectory.h
@@ -29,9 +29,9 @@ namespace XFILE
   public:
     CRarDirectory();
     ~CRarDirectory();
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
-    virtual bool ContainsFiles(const CStdString& strPath);
-    virtual bool Exists(const char* strPath);
-    virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ALWAYS; };
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items);
+    virtual bool ContainsFiles(const CURL& url);
+    virtual bool Exists(const CURL& url);
+    virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ALWAYS; };
   };
 }

--- a/xbmc/filesystem/SAPDirectory.cpp
+++ b/xbmc/filesystem/SAPDirectory.cpp
@@ -485,9 +485,9 @@ namespace XFILE
   {
   }
 
-  bool CSAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+  bool CSAPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   {
-    if(strPath != "sap://")
+    if(url.GetProtocol() != "sap")
       return false;
 
     CSingleLock lock(g_sapsessions.m_section);

--- a/xbmc/filesystem/SAPDirectory.h
+++ b/xbmc/filesystem/SAPDirectory.h
@@ -150,7 +150,7 @@ namespace XFILE
   public:
     CSAPDirectory(void);
     virtual ~CSAPDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
     virtual bool AllowAll() const { return true; }
   };
 

--- a/xbmc/filesystem/SAPDirectory.h
+++ b/xbmc/filesystem/SAPDirectory.h
@@ -151,7 +151,7 @@ namespace XFILE
     CSAPDirectory(void);
     virtual ~CSAPDirectory(void);
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
   };
 
 }

--- a/xbmc/filesystem/SFTPDirectory.cpp
+++ b/xbmc/filesystem/SFTPDirectory.cpp
@@ -33,18 +33,14 @@ CSFTPDirectory::~CSFTPDirectory(void)
 {
 }
 
-bool CSFTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CSFTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CURL url(strPath);
-
   CSFTPSessionPtr session = CSFTPSessionManager::CreateSession(url);
   return session->GetDirectory(url.GetWithoutFilename().c_str(), url.GetFileName().c_str(), items);
 }
 
-bool CSFTPDirectory::Exists(const char* strPath)
+bool CSFTPDirectory::Exists(const CURL& url)
 {
-  CURL url(strPath);
-
   CSFTPSessionPtr session = CSFTPSessionManager::CreateSession(url);
   if (session)
     return session->DirectoryExists(url.GetFileName().c_str());

--- a/xbmc/filesystem/SFTPDirectory.h
+++ b/xbmc/filesystem/SFTPDirectory.h
@@ -34,8 +34,8 @@ namespace XFILE
   public:
     CSFTPDirectory(void);
     virtual ~CSFTPDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Exists(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Exists(const CURL& url);
   };
 }
 #endif

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -69,7 +69,7 @@ CSMBDirectory::~CSMBDirectory(void)
   smb.AddIdleConnection();
 }
 
-bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // We accept smb://[[[domain;]user[:password@]]server[/share[/path[/file]]]]
 
@@ -78,11 +78,8 @@ bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
 
   smb.Init();
 
-  /* we need an url to do proper escaping */
-  CURL url(strPath);
-
   //Separate roots for the authentication and the containing items to allow browsing to work correctly
-  CStdString strRoot = strPath;
+  CStdString strRoot = url.Get();
   CStdString strAuth;
 
   lock.Leave(); // OpenDir is locked
@@ -263,7 +260,7 @@ int CSMBDirectory::OpenDir(const CURL& url, CStdString& strAuth)
     if (errno == EACCES)
     {
       if (m_flags & DIR_FLAG_ALLOW_PROMPT)
-        RequireAuthentication(urlIn.Get());
+        RequireAuthentication(urlIn);
       break;
     }
 
@@ -286,13 +283,13 @@ int CSMBDirectory::OpenDir(const CURL& url, CStdString& strAuth)
   return fd;
 }
 
-bool CSMBDirectory::Create(const char* strPath)
+bool CSMBDirectory::Create(const CURL& url2)
 {
   bool success = true;
   CSingleLock lock(smb);
   smb.Init();
 
-  CURL url(strPath);
+  CURL url(url2);
   CPasswordManager::GetInstance().AuthenticateURL(url);
   CStdString strFileName = smb.URLEncode(url);
 
@@ -304,12 +301,12 @@ bool CSMBDirectory::Create(const char* strPath)
   return success;
 }
 
-bool CSMBDirectory::Remove(const char* strPath)
+bool CSMBDirectory::Remove(const CURL& url2)
 {
   CSingleLock lock(smb);
   smb.Init();
 
-  CURL url(strPath);
+  CURL url(url2);
   CPasswordManager::GetInstance().AuthenticateURL(url);
   CStdString strFileName = smb.URLEncode(url);
 
@@ -324,12 +321,12 @@ bool CSMBDirectory::Remove(const char* strPath)
   return true;
 }
 
-bool CSMBDirectory::Exists(const char* strPath)
+bool CSMBDirectory::Exists(const CURL& url2)
 {
   CSingleLock lock(smb);
   smb.Init();
 
-  CURL url(strPath);
+  CURL url(url2);
   CPasswordManager::GetInstance().AuthenticateURL(url);
   CStdString strFileName = smb.URLEncode(url);
 

--- a/xbmc/filesystem/SMBDirectory.h
+++ b/xbmc/filesystem/SMBDirectory.h
@@ -30,11 +30,11 @@ class CSMBDirectory : public IDirectory
 public:
   CSMBDirectory(void);
   virtual ~CSMBDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual DIR_CACHE_TYPE GetCacheType(const CStdString &strPath) const { return DIR_CACHE_ONCE; };
-  virtual bool Create(const char* strPath);
-  virtual bool Exists(const char* strPath);
-  virtual bool Remove(const char* strPath);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
+  virtual bool Create(const CURL& url);
+  virtual bool Exists(const CURL& url);
+  virtual bool Remove(const CURL& url);
 
   int Open(const CURL &url);
 

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -72,7 +72,7 @@ bool CShoutcastFile::Open(const CURL& url)
   url2.SetProtocolOptions(url2.GetProtocolOptions()+"&noshout=true&Icy-MetaData=1");
   url2.SetProtocol("http");
 
-  bool result = m_file.Open(url2.Get());
+  bool result = m_file.Open(url2);
   if (result)
   {
     m_tag.SetTitle(m_file.GetHttpHeader().GetValue("icy-name"));

--- a/xbmc/filesystem/SlingboxDirectory.cpp
+++ b/xbmc/filesystem/SlingboxDirectory.cpp
@@ -20,6 +20,7 @@
 
 #include "SlingboxDirectory.h"
 #include "FileItem.h"
+#include "URL.h"
 
 using namespace XFILE;
 using namespace std;
@@ -32,10 +33,11 @@ CSlingboxDirectory::~CSlingboxDirectory()
 {
 }
 
-bool CSlingboxDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CSlingboxDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // Create generic Watch Slingbox item
-  CFileItemPtr item(new CFileItem(strPath, false));
+  const CStdString pathToUrl(url.Get());
+  CFileItemPtr item(new CFileItem(pathToUrl, false));
   item->SetLabel("Watch Slingbox");
   item->SetLabelPreformated(true);
   items.Add(item);

--- a/xbmc/filesystem/SlingboxDirectory.h
+++ b/xbmc/filesystem/SlingboxDirectory.h
@@ -31,7 +31,7 @@ namespace XFILE
     CSlingboxDirectory();
     virtual ~CSlingboxDirectory();
     
-    virtual bool IsAllowed(const CStdString &strFile) const    { return true; }
+    virtual bool AllowAll() const { return true; }
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
   };
 }

--- a/xbmc/filesystem/SlingboxDirectory.h
+++ b/xbmc/filesystem/SlingboxDirectory.h
@@ -32,6 +32,6 @@ namespace XFILE
     virtual ~CSlingboxDirectory();
     
     virtual bool AllowAll() const { return true; }
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
   };
 }

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -49,11 +49,11 @@ namespace XFILE
   {
   }
 
-  bool CSmartPlaylistDirectory::GetDirectory(const CStdString& strPath, CFileItemList& items)
+  bool CSmartPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   {
     // Load in the SmartPlaylist and get the WHERE query
     CSmartPlaylist playlist;
-    if (!playlist.Load(strPath))
+    if (!playlist.Load(url.Get()))
       return false;
     bool result = GetDirectory(playlist, items);
     if (result)
@@ -300,7 +300,7 @@ namespace XFILE
       return success;
   }
 
-  bool CSmartPlaylistDirectory::ContainsFiles(const CStdString& strPath)
+  bool CSmartPlaylistDirectory::ContainsFiles(const CURL& url)
   {
     // smart playlists always have files??
     return true;
@@ -338,9 +338,9 @@ namespace XFILE
     return "";
   }
 
-  bool CSmartPlaylistDirectory::Remove(const char *strPath)
+  bool CSmartPlaylistDirectory::Remove(const CURL& url)
   {
-    return XFILE::CFile::Delete(strPath);
+    return XFILE::CFile::Delete(url.Get());
   }
 }
 

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -53,7 +53,7 @@ namespace XFILE
   {
     // Load in the SmartPlaylist and get the WHERE query
     CSmartPlaylist playlist;
-    if (!playlist.Load(url.Get()))
+    if (!playlist.Load(url))
       return false;
     bool result = GetDirectory(playlist, items);
     if (result)
@@ -320,7 +320,7 @@ namespace XFILE
       {
         CFileItemPtr item = list[i];
         CSmartPlaylist playlist;
-        if (playlist.OpenAndReadName(item->GetPath()))
+        if (playlist.OpenAndReadName(item->GetURL()))
         {
           if (StringUtils::EqualsNoCase(playlist.GetName(), name))
             return item->GetPath();

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -340,7 +340,7 @@ namespace XFILE
 
   bool CSmartPlaylistDirectory::Remove(const CURL& url)
   {
-    return XFILE::CFile::Delete(url.Get());
+    return XFILE::CFile::Delete(url);
   }
 }
 

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -85,7 +85,7 @@ namespace XFILE
     for (std::vector<CStdString>::const_iterator virtualFolder = virtualFolders.begin(); virtualFolder != virtualFolders.end(); virtualFolder++)
     {
       CFileItemPtr pItem = CFileItemPtr(new CFileItem(*virtualFolder, true));
-      IFileDirectory *dir = CFileDirectoryFactory::Create(*virtualFolder, pItem.get());
+      IFileDirectory *dir = CFileDirectoryFactory::Create(pItem->GetURL(), pItem.get());
 
       if (dir != NULL)
       {

--- a/xbmc/filesystem/SmartPlaylistDirectory.h
+++ b/xbmc/filesystem/SmartPlaylistDirectory.h
@@ -31,10 +31,10 @@ namespace XFILE
   public:
     CSmartPlaylistDirectory();
     ~CSmartPlaylistDirectory();
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items);
     virtual bool AllowAll() const { return true; }
-    virtual bool ContainsFiles(const CStdString& strPath);
-    virtual bool Remove(const char *strPath);
+    virtual bool ContainsFiles(const CURL& url);
+    virtual bool Remove(const CURL& url);
 
     static bool GetDirectory(const CSmartPlaylist &playlist, CFileItemList& items, const CStdString &strBaseDir = "", bool filter = false);
 

--- a/xbmc/filesystem/SmartPlaylistDirectory.h
+++ b/xbmc/filesystem/SmartPlaylistDirectory.h
@@ -32,7 +32,7 @@ namespace XFILE
     CSmartPlaylistDirectory();
     ~CSmartPlaylistDirectory();
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
     virtual bool ContainsFiles(const CStdString& strPath);
     virtual bool Remove(const char *strPath);
 

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -40,11 +40,10 @@ CSourcesDirectory::~CSourcesDirectory(void)
 {
 }
 
-bool CSourcesDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CSourcesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // break up our path
   // format is:  sources://<type>/
-  CURL url(strPath);
   CStdString type(url.GetFileName());
   URIUtils::RemoveSlashAtEnd(type);
 
@@ -112,7 +111,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
   return true;
 }
 
-bool CSourcesDirectory::Exists(const char* strPath)
+bool CSourcesDirectory::Exists(const CURL& url)
 {
   return true;
 }

--- a/xbmc/filesystem/SourcesDirectory.h
+++ b/xbmc/filesystem/SourcesDirectory.h
@@ -31,9 +31,9 @@ namespace XFILE
   public:
     CSourcesDirectory(void);
     virtual ~CSourcesDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
     bool GetDirectory(const VECSOURCES &sources, CFileItemList &items);
-    virtual bool Exists(const char* strPath);
+    virtual bool Exists(const CURL& url);
     virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/SourcesDirectory.h
+++ b/xbmc/filesystem/SourcesDirectory.h
@@ -34,6 +34,6 @@ namespace XFILE
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     bool GetDirectory(const VECSOURCES &sources, CFileItemList &items);
     virtual bool Exists(const char* strPath);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
   };
 }

--- a/xbmc/filesystem/SpecialProtocolDirectory.cpp
+++ b/xbmc/filesystem/SpecialProtocolDirectory.cpp
@@ -24,6 +24,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "FileItem.h"
+#include "URL.h"
 
 using namespace XFILE;
 
@@ -35,38 +36,38 @@ CSpecialProtocolDirectory::~CSpecialProtocolDirectory(void)
 {
 }
 
-bool CSpecialProtocolDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CSpecialProtocolDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CStdString untranslatedPath = strPath;  // Why do I need a copy??? - the GetDirectory() call below will override strPath???
-  CStdString translatedPath = CSpecialProtocol::TranslatePath(strPath);
+  const CStdString pathToUrl(url.Get());
+  CStdString translatedPath = CSpecialProtocol::TranslatePath(url);
   if (CDirectory::GetDirectory(translatedPath, items, m_strFileMask, m_flags | DIR_FLAG_GET_HIDDEN))
   { // replace our paths as necessary
-    items.SetPath(untranslatedPath);
+    items.SetURL(url);
     for (int i = 0; i < items.Size(); i++)
     {
       CFileItemPtr item = items[i];
       if (StringUtils::StartsWith(item->GetPath(), translatedPath))
-        item->SetPath(URIUtils::AddFileToFolder(untranslatedPath, item->GetPath().substr(translatedPath.size())));
+        item->SetPath(URIUtils::AddFileToFolder(pathToUrl, item->GetPath().substr(translatedPath.size())));
     }
     return true;
   }
   return false;
 }
 
-bool CSpecialProtocolDirectory::Create(const char* strPath)
+bool CSpecialProtocolDirectory::Create(const CURL& url)
 {
-  CStdString translatedPath = CSpecialProtocol::TranslatePath(strPath);
+  CStdString translatedPath = CSpecialProtocol::TranslatePath(url);
   return CDirectory::Create(translatedPath.c_str());
 }
 
-bool CSpecialProtocolDirectory::Remove(const char* strPath)
+bool CSpecialProtocolDirectory::Remove(const CURL& url)
 {
-  CStdString translatedPath = CSpecialProtocol::TranslatePath(strPath);
+  CStdString translatedPath = CSpecialProtocol::TranslatePath(url);
   return CDirectory::Remove(translatedPath.c_str());
 }
 
-bool CSpecialProtocolDirectory::Exists(const char* strPath)
+bool CSpecialProtocolDirectory::Exists(const CURL& url)
 {
-  CStdString translatedPath = CSpecialProtocol::TranslatePath(strPath);
+  CStdString translatedPath = CSpecialProtocol::TranslatePath(url);
   return CDirectory::Exists(translatedPath.c_str());
 }

--- a/xbmc/filesystem/SpecialProtocolDirectory.h
+++ b/xbmc/filesystem/SpecialProtocolDirectory.h
@@ -28,9 +28,9 @@ namespace XFILE
   public:
     CSpecialProtocolDirectory(void);
     virtual ~CSpecialProtocolDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Create(const char* strPath);
-    virtual bool Exists(const char* strPath);
-    virtual bool Remove(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Create(const CURL& url);
+    virtual bool Exists(const CURL& url);
+    virtual bool Remove(const CURL& url);
   };
 }

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -37,11 +37,12 @@ namespace XFILE
   {
   }
 
-  bool CStackDirectory::GetDirectory(const CStdString& strPath, CFileItemList& items)
+  bool CStackDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   {
     items.Clear();
     CStdStringArray files;
-    if (!GetPaths(strPath, files))
+    const CStdString pathToUrl(url.Get());
+    if (!GetPaths(pathToUrl, files))
       return false;   // error in path
 
     for (unsigned int i = 0; i < files.size(); i++)
@@ -82,7 +83,8 @@ namespace XFILE
     CStdString      strStackTitlePath,
                     strCommonDir        = URIUtils::GetParentPath(strPath);
 
-    stack.GetDirectory(strPath, files);
+    const CURL pathToUrl(strPath);
+    stack.GetDirectory(pathToUrl, files);
 
     if (files.Size() > 1)
     {

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -20,6 +20,7 @@
  */
 
 #include "IDirectory.h"
+#include "utils/StdString.h"
 #include "utils/RegExp.h"
 
 namespace XFILE
@@ -29,7 +30,7 @@ namespace XFILE
   public:
     CStackDirectory();
     ~CStackDirectory();
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items);
     virtual bool AllowAll() const { return true; }
     static CStdString GetStackedTitlePath(const CStdString &strPath);
     static CStdString GetStackedTitlePath(const CStdString &strPath, VECCREGEXP& RegExps);

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -30,7 +30,7 @@ namespace XFILE
     CStackDirectory();
     ~CStackDirectory();
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
-    virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
     static CStdString GetStackedTitlePath(const CStdString &strPath);
     static CStdString GetStackedTitlePath(const CStdString &strPath, VECCREGEXP& RegExps);
     static CStdString GetFirstStackedFile(const CStdString &strPath);

--- a/xbmc/filesystem/TuxBoxDirectory.cpp
+++ b/xbmc/filesystem/TuxBoxDirectory.cpp
@@ -41,8 +41,9 @@ CTuxBoxDirectory::~CTuxBoxDirectory(void)
 {
 }
 
-bool CTuxBoxDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CTuxBoxDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
 {
+  const CStdString strPath = url2.Get();
   // so we know that we have enigma2
   static bool enigma2 = false;
   // Detect and delete slash at end

--- a/xbmc/filesystem/TuxBoxDirectory.h
+++ b/xbmc/filesystem/TuxBoxDirectory.h
@@ -32,7 +32,7 @@ namespace XFILE
       CTuxBoxDirectory(void);
       virtual ~CTuxBoxDirectory(void);
       virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+      virtual bool AllowAll() const { return true; }
       virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ALWAYS; };
     private:
       bool GetRootAndChildString(const CStdString strPath, CStdString& strBQRequest, CStdString& strXMLRootString, CStdString& strXMLChildString );

--- a/xbmc/filesystem/TuxBoxDirectory.h
+++ b/xbmc/filesystem/TuxBoxDirectory.h
@@ -20,6 +20,7 @@
  */
 
 #include "IDirectory.h"
+#include "utils/StdString.h"
 
 class CURL;
 class TiXmlElement;
@@ -31,9 +32,9 @@ namespace XFILE
     public:
       CTuxBoxDirectory(void);
       virtual ~CTuxBoxDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
       virtual bool AllowAll() const { return true; }
-      virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ALWAYS; };
+      virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ALWAYS; };
     private:
       bool GetRootAndChildString(const CStdString strPath, CStdString& strBQRequest, CStdString& strXMLRootString, CStdString& strXMLChildString );
       void GetRootAndChildStringEnigma2(CStdString& strBQRequest, CStdString& strXMLRootString, CStdString& strXMLChildString );

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -37,23 +37,18 @@ CUDFDirectory::~CUDFDirectory(void)
 {
 }
 
-bool CUDFDirectory::GetDirectory(const CStdString& strPath,
+bool CUDFDirectory::GetDirectory(const CURL& url,
                                  CFileItemList &items)
 {
   CStdString strRoot, strSub;
-  CURL url;
-  if(StringUtils::StartsWith(strPath, "udf://"))
-  {
-    url.Parse(strPath);
-    CURL url(strPath);
+  CURL url2(url);
+  if (url2.GetProtocol() != "udf")
+  { // path to an image
+    url2.SetProtocol("udf");
+    url2.SetHostName(url.Get());
   }
-  else
-  {
-    url.SetProtocol("udf");
-    url.SetHostName(strPath);
-  }
-  strRoot  = url.Get();
-  strSub   = url.GetFileName();
+  strRoot  = url2.Get();
+  strSub   = url2.GetFileName();
 
   URIUtils::AddSlashAtEnd(strRoot);
   URIUtils::AddSlashAtEnd(strSub);
@@ -100,10 +95,10 @@ bool CUDFDirectory::GetDirectory(const CStdString& strPath,
   return true;
 }
 
-bool CUDFDirectory::Exists(const char* strPath)
+bool CUDFDirectory::Exists(const CURL& url)
 {
   CFileItemList items;
-  if (GetDirectory(strPath,items))
+  if (GetDirectory(url, items))
     return true;
 
   return false;

--- a/xbmc/filesystem/UDFDirectory.h
+++ b/xbmc/filesystem/UDFDirectory.h
@@ -32,9 +32,9 @@ class CUDFDirectory :
 public:
   CUDFDirectory(void);
   virtual ~CUDFDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool Exists(const char* strPath);
-  virtual bool ContainsFiles(const CStdString& strPath) { return true; }
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual bool Exists(const CURL& url);
+  virtual bool ContainsFiles(const CURL& url) { return true; }
 };
 }
 

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -184,7 +184,7 @@ bool CUPnPDirectory::GetResource(const CURL& path, CFileItem &item)
 |   CUPnPDirectory::GetDirectory
 +---------------------------------------------------------------------*/
 bool
-CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+CUPnPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
     CUPnP* upnp = CUPnP::GetInstance();
 
@@ -192,7 +192,7 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
     items.SetCacheToDisc(CFileItemList::CACHE_NEVER);
 
     // We accept upnp://devuuid/[item_id/]
-    NPT_String path = strPath.c_str();
+    NPT_String path = url.Get().c_str();
     if (!path.StartsWith("upnp://", true)) {
         return false;
     }

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -111,9 +111,9 @@ static bool FindDeviceWait(CUPnP* upnp, const char* uuid, PLT_DeviceDataReferenc
 |   CUPnPDirectory::GetFriendlyName
 +---------------------------------------------------------------------*/
 const char*
-CUPnPDirectory::GetFriendlyName(const char* url)
+CUPnPDirectory::GetFriendlyName(const CURL& url)
 {
-    NPT_String path = url;
+    NPT_String path = url.Get().c_str();
     if (!path.EndsWith("/")) path += "/";
 
     if (path.Left(7).Compare("upnp://", true) != 0) {

--- a/xbmc/filesystem/UPnPDirectory.h
+++ b/xbmc/filesystem/UPnPDirectory.h
@@ -42,7 +42,7 @@ public:
     virtual bool IsAllowed(const CStdString& strFile) const { return true; };
 
     // class methods
-    static const char* GetFriendlyName(const char* url);
+    static const char* GetFriendlyName(const CURL& url);
     static bool        GetResource(const CURL &path, CFileItem& item);
 };
 }

--- a/xbmc/filesystem/UPnPDirectory.h
+++ b/xbmc/filesystem/UPnPDirectory.h
@@ -38,7 +38,7 @@ public:
     virtual ~CUPnPDirectory(void) {}
 
     // IDirectory methods
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
     virtual bool AllowAll() const { return true; }
 
     // class methods

--- a/xbmc/filesystem/UPnPDirectory.h
+++ b/xbmc/filesystem/UPnPDirectory.h
@@ -39,7 +39,7 @@ public:
 
     // IDirectory methods
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool IsAllowed(const CStdString& strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
 
     // class methods
     static const char* GetFriendlyName(const CURL& url);

--- a/xbmc/filesystem/UPnPFile.cpp
+++ b/xbmc/filesystem/UPnPFile.cpp
@@ -38,7 +38,7 @@ CUPnPFile::~CUPnPFile()
 bool CUPnPFile::Open(const CURL& url)
 {
   CFileItem item_new;
-  if (CUPnPDirectory::GetResource(url.Get(), item_new))
+  if (CUPnPDirectory::GetResource(url, item_new))
   {
     //CLog::Log(LOGDEBUG,"FileUPnP - file redirect to %s.", item_new.GetPath().c_str());
     IFile *pNewImp = CFileFactory::CreateLoader(item_new.GetPath());    
@@ -55,7 +55,7 @@ bool CUPnPFile::Open(const CURL& url)
 int CUPnPFile::Stat(const CURL& url, struct __stat64* buffer)
 {
   CFileItem item_new;
-  if (CUPnPDirectory::GetResource(url.Get(), item_new))
+  if (CUPnPDirectory::GetResource(url, item_new))
   {
     //CLog::Log(LOGDEBUG,"FileUPnP - file redirect to %s.", item_new.GetPath().c_str());
     IFile *pNewImp = CFileFactory::CreateLoader(item_new.GetPath());
@@ -72,7 +72,7 @@ int CUPnPFile::Stat(const CURL& url, struct __stat64* buffer)
 bool CUPnPFile::Exists(const CURL& url)
 {
   CFileItem item_new;
-  if (CUPnPDirectory::GetResource(url.Get(), item_new))
+  if (CUPnPDirectory::GetResource(url, item_new))
   {
     //CLog::Log(LOGDEBUG,"FileUPnP - file redirect to %s.", item_new.GetPath().c_str());
     IFile *pNewImp = CFileFactory::CreateLoader(item_new.GetPath());

--- a/xbmc/filesystem/VTPDirectory.cpp
+++ b/xbmc/filesystem/VTPDirectory.cpp
@@ -39,7 +39,7 @@ CVTPDirectory::~CVTPDirectory()
   delete m_session;
 }
 
-bool CVTPDirectory::GetChannels(const CStdString& base, CFileItemList &items)
+bool CVTPDirectory::GetChannels(const std::string& base, CFileItemList &items)
 {
   vector<CVTPSession::Channel> channels;
   if(!m_session->GetChannels(channels))
@@ -61,9 +61,9 @@ bool CVTPDirectory::GetChannels(const CStdString& base, CFileItemList &items)
   return true;
 }
 
-bool CVTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CVTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
 {
-  CURL url(strPath);
+  CURL url(url2);
 
   if(url.GetHostName() == "")
     url.SetHostName("localhost");

--- a/xbmc/filesystem/VTPDirectory.h
+++ b/xbmc/filesystem/VTPDirectory.h
@@ -32,11 +32,11 @@ public:
   CVTPDirectory();
   virtual ~CVTPDirectory();
 
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
   virtual bool AllowAll() const { return true; }
 
 private:
-  bool GetChannels  (const CStdString& base, CFileItemList &items);
+  bool GetChannels  (const std::string& base, CFileItemList &items);
 
   CVTPSession* m_session;
 };

--- a/xbmc/filesystem/VTPDirectory.h
+++ b/xbmc/filesystem/VTPDirectory.h
@@ -33,7 +33,7 @@ public:
   virtual ~CVTPDirectory();
 
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual bool AllowAll() const { return true; }
 
 private:
   bool GetChannels  (const CStdString& base, CFileItemList &items);

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -44,9 +44,9 @@ CVideoDatabaseDirectory::~CVideoDatabaseDirectory(void)
 {
 }
 
-bool CVideoDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(url);
   items.SetPath(path);
   auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
@@ -303,9 +303,9 @@ bool CVideoDatabaseDirectory::ContainsMovies(const CStdString &path)
   return false;
 }
 
-bool CVideoDatabaseDirectory::Exists(const char* strPath)
+bool CVideoDatabaseDirectory::Exists(const CURL& url)
 {
-  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(strPath);
+  CStdString path = CLegacyPathTranslation::TranslateVideoDbPath(url);
   auto_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(path));
 
   if (!pNode.get())

--- a/xbmc/filesystem/VideoDatabaseDirectory.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory.h
@@ -30,8 +30,8 @@ namespace XFILE
   public:
     CVideoDatabaseDirectory(void);
     virtual ~CVideoDatabaseDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Exists(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Exists(const CURL& url);
     virtual bool AllowAll() const { return true; }
     static VIDEODATABASEDIRECTORY::NODE_TYPE GetDirectoryChildType(const CStdString& strPath);
     static VIDEODATABASEDIRECTORY::NODE_TYPE GetDirectoryType(const CStdString& strPath);

--- a/xbmc/filesystem/VideoDatabaseDirectory.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory.h
@@ -32,7 +32,7 @@ namespace XFILE
     virtual ~CVideoDatabaseDirectory(void);
     virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     virtual bool Exists(const char* strPath);
-    virtual bool IsAllowed(const CStdString& strFile) const { return true; };
+    virtual bool AllowAll() const { return true; }
     static VIDEODATABASEDIRECTORY::NODE_TYPE GetDirectoryChildType(const CStdString& strPath);
     static VIDEODATABASEDIRECTORY::NODE_TYPE GetDirectoryType(const CStdString& strPath);
     static VIDEODATABASEDIRECTORY::NODE_TYPE GetDirectoryParentType(const CStdString& strPath);

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -21,6 +21,7 @@
 #include "system.h"
 #include "VirtualDirectory.h"
 #include "DirectoryFactory.h"
+#include "URL.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -68,12 +69,13 @@ void CVirtualDirectory::SetSources(const VECSOURCES& vecSources)
     and icons have to be set manually.
  */
 
-bool CVirtualDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CVirtualDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  return GetDirectory(strPath,items,true);
+  return GetDirectory(url,items,true);
 }
-bool CVirtualDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, bool bUseFileDirectories)
+bool CVirtualDirectory::GetDirectory(const CURL& url, CFileItemList &items, bool bUseFileDirectories)
 {
+  CStdString strPath = url.Get();
   int flags = m_flags;
   if (!bUseFileDirectories)
     flags |= DIR_FLAG_NO_FILE_DIRS;

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -34,8 +34,8 @@ namespace XFILE
   public:
     CVirtualDirectory(void);
     virtual ~CVirtualDirectory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items, bool bUseFileDirectories);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    bool GetDirectory(const CURL& url, CFileItemList &items, bool bUseFileDirectories);
     void SetSources(const VECSOURCES& vecSources);
     inline unsigned int GetNumberOfSources() 
     {

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -169,9 +169,10 @@ bool GetDirectoryFromTxtRecords(CZeroconfBrowser::ZeroconfService zeroconf_servi
   return ret;
 }
 
-bool CZeroconfDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+bool CZeroconfDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  assert(strPath.substr(0, 11) == "zeroconf://");
+  assert(url.GetProtocol() == "zeroconf");
+  CStdString strPath = url.Get();
   CStdString path = strPath.substr(11, strPath.length());
   URIUtils::RemoveSlashAtEnd(path);
   if(path.empty())

--- a/xbmc/filesystem/ZeroconfDirectory.h
+++ b/xbmc/filesystem/ZeroconfDirectory.h
@@ -32,8 +32,8 @@ namespace XFILE
     public:
       CZeroconfDirectory(void);
       virtual ~CZeroconfDirectory(void);
-      virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-      virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_NEVER; };
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_NEVER; };
   };
 }
 

--- a/xbmc/filesystem/ZipDirectory.cpp
+++ b/xbmc/filesystem/ZipDirectory.cpp
@@ -41,18 +41,15 @@ namespace XFILE
   {
   }
 
-  bool CZipDirectory::GetDirectory(const CStdString& strPathOrig, CFileItemList& items)
+  bool CZipDirectory::GetDirectory(const CURL& urlOrig, CFileItemList& items)
   {
-    CStdString strPath;
+    CURL urlZip(urlOrig);
 
     /* if this isn't a proper archive path, assume it's the path to a archive file */
-    if( !StringUtils::StartsWithNoCase(strPathOrig, "zip://") )
-      URIUtils::CreateArchivePath(strPath, "zip", strPathOrig, "");
-    else
-      strPath = strPathOrig;
+    if (urlOrig.GetProtocol() != "zip")
+      urlZip = URIUtils::CreateArchivePath("zip", urlOrig);
 
-    CURL url(strPath);
-
+    CURL url(urlZip);
     CStdString strArchive = url.GetHostName();
     CStdString strOptions = url.GetOptions();
     CStdString strPathInZip = url.GetFileName();
@@ -71,7 +68,7 @@ namespace XFILE
     // turn on fast lookups
     bool bWasFast(items.GetFastLookup());
     items.SetFastLookup(true);
-    if (!g_ZipManager.GetZipList(strPath,entries))
+    if (!g_ZipManager.GetZipList(urlZip,entries))
       return false;
 
     vector<std::string> baseTokens;
@@ -142,10 +139,10 @@ namespace XFILE
     return true;
   }
 
-  bool CZipDirectory::ContainsFiles(const CStdString& strPath)
+  bool CZipDirectory::ContainsFiles(const CURL& url)
   {
     vector<SZipEntry> items;
-    g_ZipManager.GetZipList(strPath,items);
+    g_ZipManager.GetZipList(url, items);
     if (items.size())
     {
       if (items.size() > 1)

--- a/xbmc/filesystem/ZipDirectory.h
+++ b/xbmc/filesystem/ZipDirectory.h
@@ -28,8 +28,8 @@ namespace XFILE
   public:
     CZipDirectory();
     ~CZipDirectory();
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
-    virtual bool ContainsFiles(const CStdString& strPath);
-    virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ALWAYS; };
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items);
+    virtual bool ContainsFiles(const CURL& url);
+    virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ALWAYS; };
   };
 }

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -49,8 +49,7 @@ bool CZipFile::Open(const CURL&url)
   CStdString strOpts = url.GetOptions();
   CURL url2(url);
   url2.SetOptions("");
-  CStdString strPath = url2.Get();
-  if (!g_ZipManager.GetZipEntry(strPath,mZipItem))
+  if (!g_ZipManager.GetZipEntry(url2,mZipItem))
     return false;
 
   if ((mZipItem.flags & 64) == 64)
@@ -67,14 +66,14 @@ bool CZipFile::Open(const CURL&url)
 
   if (mZipItem.method != 0 && mZipItem.usize > ZIP_CACHE_LIMIT && strOpts != "?cache=no")
   {
-    if (!CFile::Exists("special://temp/" + URIUtils::GetFileName(strPath)))
+    if (!CFile::Exists("special://temp/" + URIUtils::GetFileName(url2)))
     {
       url2.SetOptions("?cache=no");
-      if (!CFile::Cache(url2.Get(), "special://temp/" + URIUtils::GetFileName(strPath)))
+      if (!CFile::Cache(url2, "special://temp/" + URIUtils::GetFileName(url2)))
         return false;
     }
     m_bCached = true;
-    return mFile.Open("special://temp/" + URIUtils::GetFileName(strPath));
+    return mFile.Open("special://temp/" + URIUtils::GetFileName(url2));
   }
 
   if (!mFile.Open(url.GetHostName())) // this is the zip-file, always open binary
@@ -238,7 +237,7 @@ int64_t CZipFile::Seek(int64_t iFilePosition, int iWhence)
 bool CZipFile::Exists(const CURL& url)
 {
   SZipEntry item;
-  if (g_ZipManager.GetZipEntry(url.Get(),item))
+  if (g_ZipManager.GetZipEntry(url,item))
     return true;
   return false;
 }
@@ -265,7 +264,7 @@ int CZipFile::Stat(struct __stat64 *buffer)
 
 int CZipFile::Stat(const CURL& url, struct __stat64* buffer)
 {
-  if (!g_ZipManager.GetZipEntry(url.Get(),mZipItem))
+  if (!g_ZipManager.GetZipEntry(url, mZipItem))
   {
     if (url.GetFileName().empty() && CFile::Exists(url.GetHostName()))
     { // when accessing the zip "root" recognize it as a directory

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -69,7 +69,8 @@ bool CZipFile::Open(const CURL&url)
     if (!CFile::Exists("special://temp/" + URIUtils::GetFileName(url2)))
     {
       url2.SetOptions("?cache=no");
-      if (!CFile::Cache(url2, "special://temp/" + URIUtils::GetFileName(url2)))
+      const CURL pathToUrl("special://temp/" + URIUtils::GetFileName(url2));
+      if (!CFile::Copy(url2, pathToUrl))
         return false;
     }
     m_bCached = true;

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -262,23 +262,6 @@ bool CZipManager::ExtractArchive(const CURL& archive, const CStdString& strPath)
   return true;
 }
 
-void CZipManager::CleanUp(const CStdString& strArchive, const CStdString& strPath)
-{
-  vector<SZipEntry> entry;
-  CStdString strZipPath;
-  URIUtils::CreateArchivePath(strZipPath, "zip", strArchive, "");
-
-  GetZipList(strZipPath,entry);
-  for (vector<SZipEntry>::iterator it=entry.begin();it != entry.end();++it)
-  {
-    if (it->name[strlen(it->name)-1] == '/') // skip dirs
-      continue;
-    CStdString strFilePath(it->name);
-    CLog::Log(LOGDEBUG,"delete file: %s",(strPath+strFilePath).c_str());
-    CFile::Delete((strPath+strFilePath).c_str());
-  }
-}
-
 // Read local file header
 void CZipManager::readHeader(const char* buffer, SZipEntry& info)
 {

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -45,18 +45,17 @@ CZipManager::~CZipManager()
 
 }
 
-bool CZipManager::GetZipList(const CStdString& strPath, vector<SZipEntry>& items)
+bool CZipManager::GetZipList(const CURL& url, vector<SZipEntry>& items)
 {
-  CLog::Log(LOGDEBUG, "%s - Processing %s", __FUNCTION__, strPath.c_str());
+  CLog::Log(LOGDEBUG, "%s - Processing %s", __FUNCTION__, url.GetRedacted().c_str());
 
-  CURL url(strPath);
   struct __stat64 m_StatData = {};
 
   CStdString strFile = url.GetHostName();
 
   if (CFile::Stat(strFile,&m_StatData))
   {
-    CLog::Log(LOGDEBUG,"CZipManager::GetZipList: failed to stat file %s", strPath.c_str());
+    CLog::Log(LOGDEBUG,"CZipManager::GetZipList: failed to stat file %s", url.GetRedacted().c_str());
     return false;
   }
 
@@ -211,17 +210,15 @@ bool CZipManager::GetZipList(const CStdString& strPath, vector<SZipEntry>& items
   return true;
 }
 
-bool CZipManager::GetZipEntry(const CStdString& strPath, SZipEntry& item)
+bool CZipManager::GetZipEntry(const CURL& url, SZipEntry& item)
 {
-  CURL url(strPath);
-
   CStdString strFile = url.GetHostName();
 
   map<CStdString,vector<SZipEntry> >::iterator it = mZipMap.find(strFile);
   vector<SZipEntry> items;
   if (it == mZipMap.end()) // we need to list the zip
   {
-    GetZipList(strPath,items);
+    GetZipList(url,items);
   }
   else
   {
@@ -242,19 +239,24 @@ bool CZipManager::GetZipEntry(const CStdString& strPath, SZipEntry& item)
 
 bool CZipManager::ExtractArchive(const CStdString& strArchive, const CStdString& strPath)
 {
+  const CURL pathToUrl(strArchive);
+  return ExtractArchive(pathToUrl, strPath);
+}
+
+bool CZipManager::ExtractArchive(const CURL& archive, const CStdString& strPath)
+{
   vector<SZipEntry> entry;
-  CStdString strZipPath;
-  URIUtils::CreateArchivePath(strZipPath, "zip", strArchive, "");
-  GetZipList(strZipPath,entry);
+  CURL url = URIUtils::CreateArchivePath("zip", archive);
+  GetZipList(url, entry);
   for (vector<SZipEntry>::iterator it=entry.begin();it != entry.end();++it)
   {
     if (it->name[strlen(it->name)-1] == '/') // skip dirs
       continue;
     CStdString strFilePath(it->name);
 
-
-    URIUtils::CreateArchivePath(strZipPath, "zip", strArchive, strFilePath);
-    if (!CFile::Cache(strZipPath.c_str(),(strPath+strFilePath).c_str()))
+    CURL zipPath = URIUtils::CreateArchivePath("zip", archive, strFilePath);
+    const CURL pathToUrl(strPath + strFilePath);
+    if (!CFile::Cache(zipPath, pathToUrl))
       return false;
   }
   return true;

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -256,7 +256,7 @@ bool CZipManager::ExtractArchive(const CURL& archive, const CStdString& strPath)
 
     CURL zipPath = URIUtils::CreateArchivePath("zip", archive, strFilePath);
     const CURL pathToUrl(strPath + strFilePath);
-    if (!CFile::Cache(zipPath, pathToUrl))
+    if (!CFile::Copy(zipPath, pathToUrl))
       return false;
   }
   return true;

--- a/xbmc/filesystem/ZipManager.h
+++ b/xbmc/filesystem/ZipManager.h
@@ -35,6 +35,8 @@
 #include <vector>
 #include <map>
 
+class CURL;
+
 struct SZipEntry {
   unsigned int header;
   unsigned short version;
@@ -100,9 +102,10 @@ public:
   CZipManager();
   ~CZipManager();
 
-  bool GetZipList(const CStdString& strPath, std::vector<SZipEntry>& items);
-  bool GetZipEntry(const CStdString& strPath, SZipEntry& item);
+  bool GetZipList(const CURL& url, std::vector<SZipEntry>& items);
+  bool GetZipEntry(const CURL& url, SZipEntry& item);
   bool ExtractArchive(const CStdString& strArchive, const CStdString& strPath);
+  bool ExtractArchive(const CURL& archive, const CStdString& strPath);
   void CleanUp(const CStdString& strArchive, const CStdString& strPath); // deletes extracted archive. use with care!
   void release(const CStdString& strPath); // release resources used by list zip
   static void readHeader(const char* buffer, SZipEntry& info);

--- a/xbmc/filesystem/ZipManager.h
+++ b/xbmc/filesystem/ZipManager.h
@@ -106,7 +106,6 @@ public:
   bool GetZipEntry(const CURL& url, SZipEntry& item);
   bool ExtractArchive(const CStdString& strArchive, const CStdString& strPath);
   bool ExtractArchive(const CURL& archive, const CStdString& strPath);
-  void CleanUp(const CStdString& strArchive, const CStdString& strPath); // deletes extracted archive. use with care!
   void release(const CStdString& strPath); // release resources used by list zip
   static void readHeader(const char* buffer, SZipEntry& info);
   static void readCHeader(const char* buffer, SZipEntry& info);

--- a/xbmc/filesystem/posix/PosixDirectory.h
+++ b/xbmc/filesystem/posix/PosixDirectory.h
@@ -29,9 +29,9 @@ class CPosixDirectory : public IDirectory
 public:
   CPosixDirectory(void);
   virtual ~CPosixDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual bool Create(const char* strPath);
-  virtual bool Exists(const char* strPath);
-  virtual bool Remove(const char* strPath);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual bool Create(const CURL& url);
+  virtual bool Exists(const CURL& url);
+  virtual bool Remove(const CURL& url);
 };
 }

--- a/xbmc/filesystem/test/TestFile.cpp
+++ b/xbmc/filesystem/test/TestFile.cpp
@@ -181,7 +181,7 @@ TEST(TestFile, Rename)
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
 }
 
-TEST(TestFile, Cache)
+TEST(TestFile, Copy)
 {
   XFILE::CFile *file;
   CStdString path1, path2;
@@ -195,7 +195,7 @@ TEST(TestFile, Cache)
   EXPECT_TRUE(XFILE::CFile::Delete(path1));
   EXPECT_FALSE(XFILE::CFile::Exists(path1));
   EXPECT_TRUE(XFILE::CFile::Exists(path2));
-  EXPECT_TRUE(XFILE::CFile::Cache(path2, path1));
+  EXPECT_TRUE(XFILE::CFile::Copy(path2, path1));
   EXPECT_TRUE(XFILE::CFile::Exists(path1));
   EXPECT_TRUE(XFILE::CFile::Exists(path2));
   EXPECT_TRUE(XFILE::CFile::Delete(path1));

--- a/xbmc/filesystem/win32/Win32Directory.h
+++ b/xbmc/filesystem/win32/Win32Directory.h
@@ -29,9 +29,9 @@ namespace XFILE
   public:
     CWin32Directory(void);
     virtual ~CWin32Directory(void);
-    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-    virtual bool Create(const char* strPath);
-    virtual bool Exists(const char* strPath);
-    virtual bool Remove(const char* strPath);
+    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+    virtual bool Create(const CURL& url);
+    virtual bool Exists(const CURL& url);
+    virtual bool Remove(const CURL& url);
   };
 }

--- a/xbmc/filesystem/windows/WINSMBDirectory.cpp
+++ b/xbmc/filesystem/windows/WINSMBDirectory.cpp
@@ -49,9 +49,8 @@ CWINSMBDirectory::~CWINSMBDirectory(void)
 {
 }
 
-std::string CWINSMBDirectory::GetLocal(const std::string& strPath)
+std::string CWINSMBDirectory::GetLocal(const CURL& url)
 {
-  CURL url(strPath);
   std::string path(url.GetFileName());
   if (url.GetProtocol().Equals("smb", false) && !url.GetHostName().empty())
     path = "\\\\?\\UNC\\" + (std::string&)url.GetHostName() + "\\" + path;
@@ -59,13 +58,9 @@ std::string CWINSMBDirectory::GetLocal(const std::string& strPath)
   return path;
 }
 
-bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items)
+bool CWINSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   WIN32_FIND_DATAW wfd;
-
-  std::string strPath=strPath1;
-
-  CURL url(strPath);
 
   if(url.GetShareName().empty())
   {
@@ -95,7 +90,7 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
 
   memset(&wfd, 0, sizeof(wfd));
   //rebuild the URL
-  std::wstring strSearchMask(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)));
+  std::wstring strSearchMask(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)));
   if (!strSearchMask.empty() && strSearchMask[strSearchMask.length() - 1] == '\\')
     strSearchMask += L'*';
   else
@@ -115,9 +110,10 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
       hFind.attach(FindFirstFileW(strSearchMask.c_str(), &wfd));
     }
     else
-      return Exists(strPath1.c_str());
+      return Exists(url);
   }
 
+  CStdString strPath = url.Get();
   if (hFind.isValid())
   {
     do
@@ -164,9 +160,9 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
   return true;
 }
 
-bool CWINSMBDirectory::Create(const char* strPath)
+bool CWINSMBDirectory::Create(const CURL& url)
 {
-  if(::CreateDirectoryW(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)).c_str(), NULL))
+  if(::CreateDirectoryW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str(), NULL))
     return true;
   else if(GetLastError() == ERROR_ALREADY_EXISTS)
     return true;
@@ -174,14 +170,14 @@ bool CWINSMBDirectory::Create(const char* strPath)
   return false;
 }
 
-bool CWINSMBDirectory::Remove(const char* strPath)
+bool CWINSMBDirectory::Remove(const CURL& url)
 {
-  return ::RemoveDirectoryW(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)).c_str()) ? true : false;
+  return ::RemoveDirectoryW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str()) ? true : false;
 }
 
-bool CWINSMBDirectory::Exists(const char* strPath)
+bool CWINSMBDirectory::Exists(const CURL& url)
 {
-  DWORD attributes = GetFileAttributesW(CWIN32Util::ConvertPathToWin32Form(GetLocal(strPath)).c_str());
+  DWORD attributes = GetFileAttributesW(CWIN32Util::ConvertPathToWin32Form(GetLocal(url)).c_str());
   if(attributes == INVALID_FILE_ATTRIBUTES)
     return false;
   if (FILE_ATTRIBUTE_DIRECTORY & attributes)
@@ -360,7 +356,7 @@ bool CWINSMBDirectory::ConnectToShare(const CURL& url)
     {
       CLog::Log(LOGERROR,"Couldn't connect to %s, access denied", strUNC.c_str());
       if (m_flags & DIR_FLAG_ALLOW_PROMPT)
-        RequireAuthentication(urlIn.Get());
+        RequireAuthentication(urlIn);
       break;
     }
     else if(dwRet == ERROR_SESSION_CREDENTIAL_CONFLICT)

--- a/xbmc/filesystem/windows/WINSMBDirectory.h
+++ b/xbmc/filesystem/windows/WINSMBDirectory.h
@@ -31,17 +31,17 @@ class CWINSMBDirectory : public IDirectory
 public:
   CWINSMBDirectory(void);
   virtual ~CWINSMBDirectory(void);
-  virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
-  virtual DIR_CACHE_TYPE GetCacheType(const CStdString &strPath) const { return DIR_CACHE_ONCE; };
-  virtual bool Create(const char* strPath);
-  virtual bool Exists(const char* strPath);
-  virtual bool Remove(const char* strPath);
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; };
+  virtual bool Create(const CURL& url);
+  virtual bool Exists(const CURL& url);
+  virtual bool Remove(const CURL& url);
 
   bool ConnectToShare(const CURL& url);
 private:
   bool m_bHost;
   bool EnumerateFunc(LPNETRESOURCEW lpnr, CFileItemList &items);
-  std::string GetLocal(const std::string& strPath);
+  std::string GetLocal(const CURL &url);
   std::string URLEncode(const CURL &url);
 };
 }

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -34,7 +34,7 @@ namespace XBMCAddon
     bool copy(const String& strSource, const String& strDestnation)
     {
       DelayedCallGuard dg;
-      return XFILE::CFile::Cache(strSource, strDestnation);
+      return XFILE::CFile::Copy(strSource, strDestnation);
     }
 
     // delete a file

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -370,7 +370,8 @@ void CGUIWindowMusicPlaylistEditor::OnLoadPlaylist()
 
 void CGUIWindowMusicPlaylistEditor::LoadPlaylist(const CStdString &playlist)
 {
-  if (playlist.Equals("newplaylist://"))
+  const CURL pathToUrl(playlist);
+  if (pathToUrl.GetProtocol() == "newplaylist")
   {
     ClearPlaylist();
     m_strLoadedPlaylist.clear();
@@ -379,7 +380,7 @@ void CGUIWindowMusicPlaylistEditor::LoadPlaylist(const CStdString &playlist)
 
   XFILE::CPlaylistFileDirectory dir;
   CFileItemList items;
-  if (dir.GetDirectory(playlist, items))
+  if (dir.GetDirectory(pathToUrl, items))
   {
     ClearPlaylist();
     AppendToPlaylist(items);

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -206,7 +206,8 @@ char *session="XBMC-AirTunes";
 void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int channels, int samplerate)
 {
   XFILE::CPipeFile *pipe=(XFILE::CPipeFile *)cls;
-  pipe->OpenForWrite(XFILE::PipesManager::GetInstance().GetUniquePipeName());
+  const CURL pathToUrl(XFILE::PipesManager::GetInstance().GetUniquePipeName());
+  pipe->OpenForWrite(pathToUrl);
   pipe->SetOpenThreashold(300);
 
   Demux_BXA_FmtHeader header;

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -509,7 +509,7 @@ static void AddHostsFromMediaSource(const CMediaSource& source, std::vector<std:
 {
   for (CStdStringArray::const_iterator it = source.vecPaths.begin() ; it != source.vecPaths.end(); it++)
   {
-    CURL url = *it;
+    CURL url(*it);
 
     AddHost (url.GetHostName(), hosts);
   }
@@ -549,7 +549,7 @@ void CWakeOnAccess::QueueMACDiscoveryForAllRemotes()
   // add from path substitutions ..
   for (CAdvancedSettings::StringMapping::iterator i = g_advancedSettings.m_pathSubstitutions.begin(); i != g_advancedSettings.m_pathSubstitutions.end(); ++i)
   {
-    CURL url = i->second;
+    CURL url(i->second);
 
     AddHost (url.GetHostName(), hosts);
   }

--- a/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
@@ -37,7 +37,8 @@ int CHTTPImageHandler::HandleHTTPRequest(const HTTPRequest &request)
     m_path = request.url.substr(7);
 
     XFILE::CImageFile imageFile;
-    if (imageFile.Exists(m_path))
+    const CURL pathToUrl(m_path);
+    if (imageFile.Exists(pathToUrl))
     {
       m_responseCode = MHD_HTTP_OK;
       m_responseType = HTTPFileDownload;

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -132,6 +132,12 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
   return IsPlaylist(item.GetPath());
 }
 
+bool CPlayListFactory::IsPlaylist(const CURL& url)
+{
+  return URIUtils::HasExtension(url,
+                                ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml");
+}
+
 bool CPlayListFactory::IsPlaylist(const CStdString& filename)
 {
   return URIUtils::HasExtension(filename,

--- a/xbmc/playlists/PlayListFactory.h
+++ b/xbmc/playlists/PlayListFactory.h
@@ -22,6 +22,7 @@
 #include "utils/StdString.h"
 
 class CFileItem;
+class CURL;
 
 namespace PLAYLIST
 {
@@ -32,6 +33,7 @@ namespace PLAYLIST
   public:
     static CPlayList* Create(const CStdString& filename);
     static CPlayList* Create(const CFileItem& item);
+    static bool IsPlaylist(const CURL& url);
     static bool IsPlaylist(const CStdString& filename);
     static bool IsPlaylist(const CFileItem& item);
   };

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -950,9 +950,9 @@ CSmartPlaylist::CSmartPlaylist()
   Reset();
 }
 
-bool CSmartPlaylist::OpenAndReadName(const CStdString &path)
+bool CSmartPlaylist::OpenAndReadName(const CURL &url)
 {
-  if (readNameFromPath(path) == NULL)
+  if (readNameFromPath(url) == NULL)
     return false;
 
   return !m_playlistName.empty();
@@ -989,12 +989,12 @@ const TiXmlNode* CSmartPlaylist::readName(const TiXmlNode *root)
   return root;
 }
 
-const TiXmlNode* CSmartPlaylist::readNameFromPath(const CStdString &path)
+const TiXmlNode* CSmartPlaylist::readNameFromPath(const CURL &url)
 {
   CFileStream file;
-  if (!file.Open(path))
+  if (!file.Open(url))
   {
-    CLog::Log(LOGERROR, "Error loading Smart playlist %s (failed to read file)", path.c_str());
+    CLog::Log(LOGERROR, "Error loading Smart playlist %s (failed to read file)", url.GetRedacted().c_str());
     return NULL;
   }
 
@@ -1004,7 +1004,7 @@ const TiXmlNode* CSmartPlaylist::readNameFromPath(const CStdString &path)
   const TiXmlNode *root = readName(m_xmlDoc.RootElement());
   if (m_playlistName.empty())
   {
-    m_playlistName = CUtil::GetTitleFromPath(path);
+    m_playlistName = CUtil::GetTitleFromPath(url.Get());
     if (URIUtils::HasExtension(m_playlistName, ".xsp"))
       URIUtils::RemoveExtension(m_playlistName);
   }
@@ -1040,9 +1040,15 @@ bool CSmartPlaylist::load(const TiXmlNode *root)
   return LoadFromXML(root);
 }
 
+bool CSmartPlaylist::Load(const CURL &url)
+{
+  return load(readNameFromPath(url));
+}
+
 bool CSmartPlaylist::Load(const CStdString &path)
 {
-  return load(readNameFromPath(path));
+  const CURL pathToUrl(path);
+  return load(readNameFromPath(pathToUrl));
 }
 
 bool CSmartPlaylist::Load(const CVariant &obj)

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -28,6 +28,7 @@
 #include "utils/StdString.h"
 #include "utils/XBMCTinyXML.h"
 
+class CURL;
 class CVariant;
 
 class CSmartPlaylistRule : public CDatabaseQueryRule
@@ -88,6 +89,7 @@ public:
   CSmartPlaylist();
   virtual ~CSmartPlaylist() { }
 
+  bool Load(const CURL& url);
   bool Load(const CStdString &path);
   bool Load(const CVariant &obj);
   bool LoadFromXml(const CStdString &xml);
@@ -96,7 +98,7 @@ public:
   bool Save(CVariant &obj, bool full = true) const;
   bool SaveAsJson(CStdString &json, bool full = true) const;
 
-  bool OpenAndReadName(const CStdString &path);
+  bool OpenAndReadName(const CURL &url);
   bool LoadFromXML(const TiXmlNode *root, const CStdString &encoding = "UTF-8");
 
   void Reset();
@@ -156,7 +158,7 @@ private:
   friend class CGUIDialogMediaFilter;
 
   const TiXmlNode* readName(const TiXmlNode *root);
-  const TiXmlNode* readNameFromPath(const CStdString &path);
+  const TiXmlNode* readNameFromPath(const CURL &url);
   const TiXmlNode* readNameFromXml(const CStdString &xml);
   bool load(const TiXmlNode *root);
 

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -152,7 +152,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         // guisettings.xml will be created on first profile use.
         if (CGUIDialogYesNo::ShowAndGetInput(20058,20048,20102,20022,20044,20064))
         {
-          XFILE::CFile::Cache(URIUtils::AddFileToFolder("special://masterprofile/", "guisettings.xml"),
+          XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "guisettings.xml"),
                               URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/guisettings.xml"));
         }
       }
@@ -168,7 +168,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
           // If 'start fresh' (no) is selected, do nothing.
           if (CGUIDialogYesNo::ShowAndGetInput(20058, 20071, 20102, 20022, 20044, 20064))
           {
-            XFILE::CFile::Cache(URIUtils::AddFileToFolder("special://masterprofile/", "sources.xml"),
+            XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "sources.xml"),
                                 URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory + "/sources.xml"));
           }
       }

--- a/xbmc/utils/AsyncFileCopy.cpp
+++ b/xbmc/utils/AsyncFileCopy.cpp
@@ -102,7 +102,7 @@ void CAsyncFileCopy::Process()
 {
   try
   {
-    m_succeeded = XFILE::CFile::Cache(m_from, m_to, this);
+    m_succeeded = XFILE::CFile::Copy(m_from, m_to, this);
   }
   catch (...)
   {

--- a/xbmc/utils/AsyncFileCopy.h
+++ b/xbmc/utils/AsyncFileCopy.h
@@ -33,7 +33,7 @@ public:
   /// \return true if successful, and false if it failed or was cancelled.
   bool Copy(const CStdString &from, const CStdString &to, const CStdString &heading);
 
-  /// \brief callback from CFile::Cache()
+  /// \brief callback from CFile::Copy()
   virtual bool OnFileCallback(void *pContext, int ipercent, float avgSpeed);
 
 protected:

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -263,7 +263,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
     {
       CLog::Log(LOGDEBUG,"FileManager: copy %s -> %s\n", m_strFileA.c_str(), m_strFileB.c_str());
 
-      bResult = CFile::Cache(m_strFileA, m_strFileB, this, &data);
+      bResult = CFile::Copy(m_strFileA, m_strFileB, this, &data);
     }
     break;
     case ActionMove:
@@ -272,7 +272,7 @@ bool CFileOperationJob::CFileOperation::ExecuteOperation(CFileOperationJob *base
 
       if (CanBeRenamed(m_strFileA, m_strFileB))
         bResult = CFile::Rename(m_strFileA, m_strFileB);
-      else if (CFile::Cache(m_strFileA, m_strFileB, this, &data))
+      else if (CFile::Copy(m_strFileA, m_strFileB, this, &data))
         bResult = CFile::Delete(m_strFileA);
       else
         bResult = false;

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -119,7 +119,7 @@ bool CFileOperationJob::DoProcessFolder(FileAction action, const CStdString& str
 {
   // check whether this folder is a filedirectory - if so, we don't process it's contents
   CFileItem item(strPath, false);
-  IFileDirectory *file = CFileDirectoryFactory::Create(strPath, &item);
+  IFileDirectory *file = CFileDirectoryFactory::Create(item.GetURL(), &item);
   if (file)
   {
     delete file;

--- a/xbmc/utils/LegacyPathTranslation.cpp
+++ b/xbmc/utils/LegacyPathTranslation.cpp
@@ -20,6 +20,7 @@
 
 #include "LegacyPathTranslation.h"
 #include "utils/StringUtils.h"
+#include "URL.h"
 
 typedef struct Translator {
   const char *legacyPath;
@@ -79,6 +80,15 @@ static Translator s_musicDbTranslator[] = {
 
 #define MusicDbTranslatorSize sizeof(s_musicDbTranslator) / sizeof(Translator)
 
+std::string CLegacyPathTranslation::TranslateVideoDbPath(const CURL &legacyPath)
+{
+  return TranslatePath(legacyPath.Get(), s_videoDbTranslator, VideoDbTranslatorSize);
+}
+
+std::string CLegacyPathTranslation::TranslateMusicDbPath(const CURL &legacyPath)
+{
+  return TranslatePath(legacyPath.Get(), s_musicDbTranslator, MusicDbTranslatorSize);
+}
 
 std::string CLegacyPathTranslation::TranslateVideoDbPath(const std::string &legacyPath)
 {

--- a/xbmc/utils/LegacyPathTranslation.h
+++ b/xbmc/utils/LegacyPathTranslation.h
@@ -23,6 +23,8 @@
 
 typedef struct Translator Translator;
 
+class CURL;
+
 /*!
  \brief Translates old internal paths into new ones
 
@@ -39,6 +41,7 @@ public:
    \param legacyPath Path in the old videodb:// format using numbers
    \return Path in the new videodb:// format using descriptive strings
    */
+  static std::string TranslateVideoDbPath(const CURL &legacyPath);
   static std::string TranslateVideoDbPath(const std::string &legacyPath);
 
   /*!
@@ -47,6 +50,7 @@ public:
    \param legacyPath Path in the old musicdb:// format using numbers
    \return Path in the new musicdb:// format using descriptive strings
    */
+  static std::string TranslateMusicDbPath(const CURL &legacyPath);
   static std::string TranslateMusicDbPath(const std::string &legacyPath);
 
 private:

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -38,12 +38,6 @@
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 
-#if defined(__ppc__) || \
-    defined(__powerpc__) || \
-    defined(__arm__)
-  #define DISABLE_MATHUTILS_ASM_TRUNCATE_INT
-#endif
-
 /*! \brief Math utility class.
  Note that the test() routine should return true for all implementations
 
@@ -164,39 +158,7 @@ namespace MathUtils
   {
     assert(x > static_cast<double>(INT_MIN / 2) - 1.0);
     assert(x < static_cast<double>(INT_MAX / 2) + 1.0);
-
-#if defined(DISABLE_MATHUTILS_ASM_TRUNCATE_INT)
     return x;
-
-#else
-    int i;
-#if defined(TARGET_WINDOWS)
-    const float round_towards_m_i = -0.5f;
-    __asm
-    {
-      fld x
-      fadd st, st (0)
-      fabs
-      fadd round_towards_m_i
-      fistp i
-      sar i, 1
-    }
-
-#else
-    const float round_towards_m_i = -0.5f;
-    __asm__ __volatile__ (
-      "fadd %%st\n\t"
-      "fabs\n\t"
-      "fadd %%st(1)\n\t"
-      "fistpl %0\n\t"
-      "sarl $1, %0\n"
-      : "=m"(i) : "u"(round_towards_m_i), "t"(x) : "st"
-    );
-#endif
-    if (x < 0)
-      i = -i;
-    return (i);
-#endif
   }
 
   inline int64_t abs(int64_t a)

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -268,7 +268,7 @@ void CScreenShot::TakeScreenshot()
           for (unsigned int i = 0; i < screenShots.size(); i++)
           {
             CStdString file = CUtil::GetNextFilename(URIUtils::AddFileToFolder(newDir, "screenshot%03d.png"), 999);
-            CFile::Cache(screenShots[i], file);
+            CFile::Copy(screenShots[i], file);
           }
           screenShots.clear();
         }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -46,6 +46,11 @@ bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
 }
 
 /* returns filename extension including period of filename */
+CStdString URIUtils::GetExtension(const CURL& url)
+{
+  return URIUtils::GetExtension(url.GetFileName());
+}
+
 CStdString URIUtils::GetExtension(const CStdString& strFileName)
 {
   if (IsURL(strFileName))
@@ -71,6 +76,11 @@ bool URIUtils::HasExtension(const CStdString& strFileName)
 
   size_t iPeriod = strFileName.find_last_of("./\\");
   return iPeriod != string::npos && strFileName[iPeriod] == '.';
+}
+
+bool URIUtils::HasExtension(const CURL& url, const CStdString& strExtensions)
+{
+  return HasExtension(url.GetFileName(), strExtensions);
 }
 
 bool URIUtils::HasExtension(const CStdString& strFileName, const CStdString& strExtensions)
@@ -165,6 +175,11 @@ CStdString URIUtils::ReplaceExtension(const CStdString& strFile,
     strChangedFile += strNewExtension;
   }
   return strChangedFile;
+}
+
+const CStdString URIUtils::GetFileName(const CURL& url)
+{
+  return GetFileName(url.GetFileName());
 }
 
 /* returns a filename given an url */
@@ -438,6 +453,12 @@ std::string URIUtils::ChangeBasePath(const std::string &fromPath, const std::str
     StringUtils::Replace(toFile, "/", "\\");
 
   return AddFileToFolder(toPath, toFile);
+}
+
+CURL URIUtils::SubstitutePath(const CURL& url, bool reverse /* = false */)
+{
+  const CStdString pathToUrl = url.Get();
+  return CURL(SubstitutePath(pathToUrl, reverse));
 }
 
 CStdString URIUtils::SubstitutePath(const CStdString& strPath, bool reverse /* = false */)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -317,7 +317,7 @@ bool URIUtils::GetParentPath(const CStdString& strPath, CStdString& strParent)
   {
     CStackDirectory dir;
     CFileItemList items;
-    dir.GetDirectory(strPath,items);
+    dir.GetDirectory(url, items);
     items[0]->m_strDVDLabel = GetDirectory(items[0]->GetPath());
     if (StringUtils::StartsWithNoCase(items[0]->m_strDVDLabel, "rar://") || StringUtils::StartsWithNoCase(items[0]->m_strDVDLabel, "zip://"))
       GetParentPath(items[0]->m_strDVDLabel, strParent);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -799,6 +799,12 @@ bool URIUtils::IsDAV(const CStdString& strFile)
          StringUtils::StartsWithNoCase(strFile2, "davs:");
 }
 
+bool URIUtils::IsInternetStream(const std::string &path, bool bStrictCheck /* = false */)
+{
+  const CURL pathToUrl(path);
+  return IsInternetStream(pathToUrl, bStrictCheck);
+}
+
 bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */)
 {
   CStdString strProtocol = url.GetProtocol();

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -152,6 +152,11 @@ public:
    */
   static std::string CanonicalizePath(const std::string& path, const char slashCharacter = '\\');
 
+  static CURL CreateArchivePath(const std::string& type,
+                                const CURL& archiveUrl,
+                                const std::string& pathInArchive = "",
+                                const std::string& password = "");
+
   static void CreateArchivePath(CStdString& strUrlPath,
                                 const CStdString& strType,
                                 const CStdString& strArchivePath,

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -94,6 +94,7 @@ public:
   static bool IsHTSP(const CStdString& strFile);
   static bool IsInArchive(const CStdString& strFile);
   static bool IsInRAR(const CStdString& strFile);
+  static bool IsInternetStream(const std::string& path, bool bStrictCheck = false);
   static bool IsInternetStream(const CURL& url, bool bStrictCheck = false);
   static bool IsInAPK(const CStdString& strFile);
   static bool IsInZIP(const CStdString& strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -31,8 +31,11 @@ public:
   static bool IsInPath(const CStdString &uri, const CStdString &baseURI);
 
   static CStdString GetDirectory(const CStdString &strFilePath);
+
+  static const CStdString GetFileName(const CURL& url);
   static const CStdString GetFileName(const CStdString& strFileNameAndPath);
 
+  static CStdString GetExtension(const CURL& url);
   static CStdString GetExtension(const CStdString& strFileName);
 
   /*!
@@ -55,6 +58,7 @@ public:
    \sa GetExtension
    */
   static bool HasExtension(const CStdString& strFileName, const CStdString& strExtensions);
+  static bool HasExtension(const CURL& url, const CStdString& strExtensions);
 
   static void RemoveExtension(CStdString& strFileName);
   static CStdString ReplaceExtension(const CStdString& strFile,
@@ -78,6 +82,7 @@ public:
    */
   static std::string ChangeBasePath(const std::string &fromPath, const std::string &fromFile, const std::string &toPath);
 
+  static CURL SubstitutePath(const CURL& url, bool reverse = false);
   static CStdString SubstitutePath(const CStdString& strPath, bool reverse = false);
 
   static bool IsAddonsPath(const CStdString& strFile);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -493,8 +493,8 @@ TEST_F(TestURIUtils, CreateArchivePath)
 {
   CStdString ref, var;
 
-  ref = "file://%2fpath%2fto%2f/file";
-  URIUtils::CreateArchivePath(var, "file", "/path/to/", "file");
+  ref = "zip://%2fpath%2fto%2f/file";
+  URIUtils::CreateArchivePath(var, "zip", "/path/to/", "file");
   EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2667,7 +2667,8 @@ void CVideoDatabase::GetBookMarksForFile(const CStdString& strFilenameAndPath, V
     {
       CStackDirectory dir;
       CFileItemList fileList;
-      dir.GetDirectory(strFilenameAndPath, fileList);
+      const CURL pathToUrl(strFilenameAndPath);
+      dir.GetDirectory(pathToUrl, fileList);
       if (!bAppend)
         bookmarks.clear();
       for (int i = fileList.Size() - 1; i >= 0; i--) // put the bookmarks of the highest part first in the list
@@ -3498,7 +3499,8 @@ bool CVideoDatabase::GetResumePoint(CVideoInfoTag& tag)
     {
       CStackDirectory dir;
       CFileItemList fileList;
-      dir.GetDirectory(tag.m_strFileNameAndPath, fileList);
+      const CURL pathToUrl(tag.m_strFileNameAndPath);
+      dir.GetDirectory(pathToUrl, fileList);
       tag.m_resumePoint.Reset();
       for (int i = fileList.Size() - 1; i >= 0; i--)
       {

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -503,7 +503,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
     CStdString strDownloadFile = URIUtils::ChangeBasePath(strCurrentFilePath, strSubName, strDownloadPath);
     CStdString strDestFile = strDownloadFile;
 
-    if (!CFile::Cache(strUrl, strDownloadFile))
+    if (!CFile::Copy(strUrl, strDownloadFile))
     {
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strSubName, g_localizeStrings.Get(24113));
       CLog::Log(LOGERROR, "%s - Saving of subtitle %s to %s failed", __FUNCTION__, strUrl.c_str(), strDownloadFile.c_str());
@@ -521,7 +521,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
          * items end up in the same folder
          */
         CLog::Log(LOGDEBUG, "%s - Saving subtitle %s to %s", __FUNCTION__, strDownloadFile.c_str(), strTryDestFile.c_str());
-        if (CFile::Cache(strDownloadFile, strTryDestFile))
+        if (CFile::Copy(strDownloadFile, strTryDestFile))
         {
           CFile::Delete(strDownloadFile);
           strDestFile = strTryDestFile;
@@ -547,7 +547,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
           CStdString strSubNameIdx = StringUtils::Format("%s.%s.idx", strFileName.c_str(), strSubLang.c_str());
           // Handle URL encoding:
           strDestFile = URIUtils::ChangeBasePath(strCurrentFilePath, strSubNameIdx, strDestPath);
-          CFile::Cache(strUrl, strDestFile);
+          CFile::Copy(strUrl, strDestFile);
         }
       }
 

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -410,7 +410,8 @@ void CGUIViewState::AddAndroidSource(const CStdString &content, const CStdString
 {
   CFileItemList items;
   XFILE::CAndroidAppDirectory apps;
-  if (apps.GetDirectory(content, items))
+  const CURL pathToUrl(content);
+  if (apps.GetDirectory(pathToUrl, items))
   {
     CMediaSource source;
     source.strPath = "androidapp://sources/" + content + "/";

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -937,7 +937,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
   if (!pItem->m_bIsFolder && pItem->IsFileFolder(EFILEFOLDER_MASK_ONCLICK))
   {
     XFILE::IFileDirectory *pFileDirectory = NULL;
-    pFileDirectory = XFILE::CFileDirectoryFactory::Create(pItem->GetPath(), pItem.get(), "");
+    pFileDirectory = XFILE::CFileDirectoryFactory::Create(pItem->GetURL(), pItem.get(), "");
     if(pFileDirectory)
       pItem->m_bIsFolder = true;
     else if(pItem->m_bIsFolder)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -641,6 +641,8 @@ void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
   */
 bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
 {
+  const CURL pathToUrl(strDirectory);
+
   // cleanup items
   if (items.Size())
     items.Clear();
@@ -664,7 +666,7 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
     if (strDirectory.empty())
       SetupShares();
 
-    if (!m_rootDir.GetDirectory(strDirectory, items))
+    if (!m_rootDir.GetDirectory(pathToUrl, items))
       return false;
 
     // took over a second, and not normally cached, so cache it
@@ -1253,7 +1255,7 @@ void CGUIMediaWindow::SetHistoryForPath(const CStdString& strDirectory)
     URIUtils::RemoveSlashAtEnd(strPath);
 
     CFileItemList items;
-    m_rootDir.GetDirectory("", items);
+    m_rootDir.GetDirectory(CURL(), items);
 
     m_history.ClearPathHistory();
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -873,7 +873,8 @@ void CGUIWindowFileManager::GetDirectoryHistoryString(const CFileItem* pItem, CS
 
 bool CGUIWindowFileManager::GetDirectory(int iList, const CStdString &strDirectory, CFileItemList &items)
 {
-  return m_rootDir.GetDirectory(strDirectory,items,false);
+  const CURL pathToUrl(strDirectory);
+  return m_rootDir.GetDirectory(pathToUrl, items, false);
 }
 
 bool CGUIWindowFileManager::CanRename(int iList)
@@ -1114,6 +1115,7 @@ bool CGUIWindowFileManager::SelectItem(int list, int &item)
 // recursively calculates the selected folder size
 int64_t CGUIWindowFileManager::CalculateFolderSize(const CStdString &strDirectory, CGUIDialogProgress *pProgress)
 {
+  const CURL pathToUrl(strDirectory);
   if (pProgress)
   { // update our progress control
     pProgress->Progress();
@@ -1126,7 +1128,7 @@ int64_t CGUIWindowFileManager::CalculateFolderSize(const CStdString &strDirector
   CFileItemList items;
   CVirtualDirectory rootDir;
   rootDir.SetSources(*CMediaSourceSettings::Get().GetSources("files"));
-  rootDir.GetDirectory(strDirectory, items, false);
+  rootDir.GetDirectory(pathToUrl, items, false);
   for (int i=0; i < items.Size(); i++)
   {
     if (items[i]->m_bIsFolder && !items[i]->IsParentFolder()) // folder

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -542,7 +542,7 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
   if (!pItem->m_bIsFolder && pItem->IsFileFolder(EFILEFOLDER_MASK_ALL))
   {
     XFILE::IFileDirectory *pFileDirectory = NULL;
-    pFileDirectory = XFILE::CFileDirectoryFactory::Create(pItem->GetPath(), pItem.get(), "");
+    pFileDirectory = XFILE::CFileDirectoryFactory::Create(pItem->GetURL(), pItem.get(), "");
     if(pFileDirectory)
       pItem->m_bIsFolder = true;
     else if(pItem->m_bIsFolder)


### PR DESCRIPTION
This moves to using CURL in IDirectory, to match the usage in IFile.  Plus, in most cases the first thing the directory classes did was wrap to a CURL anyway.

This is a first step to work towards passing CURL around rather than strings for paths.

It should be faster for all filesystems with the exception of the local FS which may be slower (though likely not that much) due to the IsAllowed() change.

A couple of points to mention:
1. I've made the CURL constructor from string explicit, mostly to pick up cases we are relying on the implicit construction.  Turns out there's not that many.
2. Some places involved more refactoring than others.  Fairly confident, though it could do with a good read-through to check I didn't mess up.
3. I made no attempt to optimise things, so some of the wrappers to support CURL are just doing CURL.Get() and passing on.  Where practical I made the CURL implementation the default, and wrapped with a string implementation.
4. The Get/SetURL() to CFileItem are wrappers at this point, though the goal would be that CFileItem would hold a CURL rather than string.

@Karlson2k might be good for review.  Anyone else (@elupus, @arnova ?) for general direction.  Once this one is in I'll open a discussion on how we might move further.
