### PR TITLE
Fix SysInfo test

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1305,7 +1305,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\utils\test\TestSystemInfo.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -465,14 +465,10 @@ bool CSysInfo::GetDiskSpace(const CStdString& drive,int& iTotal, int& iTotalFree
     }
     delete[] pcBuffer;
 #else // for linux and osx
-    static const char *drv_letter[] = { "C:\\", "E:\\", "F:\\", "G:\\", "X:\\", "Y:\\", "Z:\\", NULL };
-    for( int i = 0; drv_letter[i]; i++)
+    if( GetDiskFreeSpaceEx( "/", NULL, &ULTotal, &ULTotalFree ) )
     {
-      if( GetDiskFreeSpaceEx( drv_letter[i], NULL, &ULTotal, &ULTotalFree ) )
-      {
-        ULTotalTmp.QuadPart+= ULTotal.QuadPart;
-        ULTotalFreeTmp.QuadPart+= ULTotalFree.QuadPart;
-      }
+      ULTotalTmp.QuadPart+= ULTotal.QuadPart;
+      ULTotalFreeTmp.QuadPart+= ULTotalFree.QuadPart;
     }
 #endif
     if( ULTotalTmp.QuadPart || ULTotalFreeTmp.QuadPart )

--- a/xbmc/utils/test/TestSystemInfo.cpp
+++ b/xbmc/utils/test/TestSystemInfo.cpp
@@ -35,20 +35,6 @@ protected:
   }
 };
 
-#if defined(TARGET_LINUX)
-TEST_F(TestSystemInfo, GetLinuxDistro)
-{
-  std::cout << "GetLinuxDistro(): " << g_sysinfo.GetLinuxDistro() << std::endl;
-}
-#endif
-
-#ifdef TARGET_POSIX
-TEST_F(TestSystemInfo, GetUnameVersion)
-{
-  std::cout << "GetUnameVersion(): " << g_sysinfo.GetUnameVersion() << std::endl;
-}
-#endif
-
 TEST_F(TestSystemInfo, GetUserAgent)
 {
   std::cout << "GetUserAgent(): " << g_sysinfo.GetUserAgent() << std::endl;
@@ -83,11 +69,6 @@ TEST_F(TestSystemInfo, IsWindowsVersionAtLeast_Vista)
   std::cout << "IsWindowsVersionAtLeast(WindowsVersionVista): " <<
     testing::PrintToString(g_sysinfo.IsWindowsVersionAtLeast(
                                   CSysInfo::WindowsVersionVista)) << std::endl;
-}
-
-TEST_F(TestSystemInfo, GetOsNameWithVersionInfo)
-{
-  std::cout << "GetOsNameWithVersionInfo(): " << CSysInfo::GetOsNameWithVersionInfo() << std::endl;
 }
 
 TEST_F(TestSystemInfo, GetCPUModel)

--- a/xbmc/utils/test/TestSystemInfo.cpp
+++ b/xbmc/utils/test/TestSystemInfo.cpp
@@ -35,59 +35,253 @@ protected:
   }
 };
 
+TEST_F(TestSystemInfo, GetKernelName)
+{
+  EXPECT_FALSE(g_sysinfo.GetKernelName(true).empty()) << "'GetKernelName(true)' must not return empty kernel name";
+  EXPECT_FALSE(g_sysinfo.GetKernelName(false).empty()) << "'GetKernelName(false)' must not return empty kernel name";
+  EXPECT_STRCASENE("Unknown kernel", g_sysinfo.GetKernelName(true).c_str()) << "'GetKernelName(true)' must not return 'Unknown kernel'";
+  EXPECT_STRCASENE("Unknown kernel", g_sysinfo.GetKernelName(false).c_str()) << "'GetKernelName(false)' must not return 'Unknown kernel'";
+  EXPECT_EQ(g_sysinfo.GetBuildTargetPlatformName(), g_sysinfo.GetKernelName(true)) << "'GetKernelName(true)' must match GetBuildTargetPlatformName()";
+  EXPECT_EQ(g_sysinfo.GetBuildTargetPlatformName(), g_sysinfo.GetKernelName(false)) << "'GetKernelName(false)' must match GetBuildTargetPlatformName()";
+#if defined(TARGET_WINDOWS)
+  EXPECT_NE(std::string::npos, g_sysinfo.GetKernelName(true).find("Windows")) << "'GetKernelName(true)' must contain 'Windows'";
+  EXPECT_NE(std::string::npos, g_sysinfo.GetKernelName(false).find("Windows")) << "'GetKernelName(false)' must contain 'Windows'";
+#elif defined(TARGET_FREEBSD)
+  EXPECT_STREQ("FreeBSD", g_sysinfo.GetKernelName(true).c_str()) << "'GetKernelName(true)' must return 'FreeBSD'";
+  EXPECT_STREQ("FreeBSD", g_sysinfo.GetKernelName(false).c_str()) << "'GetKernelName(false)' must return 'FreeBSD'";
+#elif defined(TARGET_DARWIN)
+  EXPECT_STREQ("Darwin", g_sysinfo.GetKernelName(true).c_str()) << "'GetKernelName(true)' must return 'Darwin'";
+  EXPECT_STREQ("Darwin", g_sysinfo.GetKernelName(false).c_str()) << "'GetKernelName(false)' must return 'Darwin'";
+#elif defined(TARGET_LINUX)
+  EXPECT_STREQ("Linux", g_sysinfo.GetKernelName(true).c_str()) << "'GetKernelName(true)' must return 'Linux'";
+  EXPECT_STREQ("Linux", g_sysinfo.GetKernelName(false).c_str()) << "'GetKernelName(false)' must return 'Linux'";
+#endif
+}
+
+TEST_F(TestSystemInfo, GetKernelVersionFull)
+{
+  EXPECT_FALSE(g_sysinfo.GetKernelVersionFull().empty()) << "'GetKernelVersionFull()' must not return empty string";
+  EXPECT_STRNE("0.0.0", g_sysinfo.GetKernelVersionFull().c_str()) << "'GetKernelVersionFull()' must not return '0.0.0'";
+  EXPECT_STRNE("0.0", g_sysinfo.GetKernelVersionFull().c_str()) << "'GetKernelVersionFull()' must not return '0.0'";
+  EXPECT_EQ(0, g_sysinfo.GetKernelVersionFull().find_first_of("0123456789")) << "'GetKernelVersionFull()' must not return version not starting from digit";
+}
+
+TEST_F(TestSystemInfo, GetKernelVersion)
+{
+  EXPECT_FALSE(g_sysinfo.GetKernelVersion().empty()) << "'GetKernelVersion()' must not return empty string";
+  EXPECT_STRNE("0.0.0", g_sysinfo.GetKernelVersion().c_str()) << "'GetKernelVersion()' must not return '0.0.0'";
+  EXPECT_STRNE("0.0", g_sysinfo.GetKernelVersion().c_str()) << "'GetKernelVersion()' must not return '0.0'";
+  EXPECT_EQ(0, g_sysinfo.GetKernelVersion().find_first_of("0123456789")) << "'GetKernelVersion()' must not return version not starting from digit";
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetKernelVersion().find_first_not_of("0123456789.")) << "'GetKernelVersion()' must not return version with not only digits and dots";
+}
+
+TEST_F(TestSystemInfo, GetOsName)
+{
+  EXPECT_FALSE(g_sysinfo.GetOsName(true).empty()) << "'GetOsName(true)' must not return empty OS name";
+  EXPECT_FALSE(g_sysinfo.GetOsName(false).empty()) << "'GetOsName(false)' must not return empty OS name";
+  EXPECT_STRCASENE("Unknown OS", g_sysinfo.GetOsName(true).c_str()) << "'GetOsName(true)' must not return 'Unknown OS'";
+  EXPECT_STRCASENE("Unknown OS", g_sysinfo.GetOsName(false).c_str()) << "'GetOsName(false)' must not return 'Unknown OS'";
+#if defined(TARGET_WINDOWS)
+  EXPECT_NE(std::string::npos, g_sysinfo.GetOsName(true).find("Windows")) << "'GetOsName(true)' must contain 'Windows'";
+  EXPECT_NE(std::string::npos, g_sysinfo.GetOsName(false).find("Windows")) << "'GetOsName(false)' must contain 'Windows'";
+#elif defined(TARGET_FREEBSD)
+  EXPECT_STREQ("FreeBSD", g_sysinfo.GetOsName(true).c_str()) << "'GetOsName(true)' must return 'FreeBSD'";
+  EXPECT_STREQ("FreeBSD", g_sysinfo.GetOsName(false).c_str()) << "'GetOsName(false)' must return 'FreeBSD'";
+#elif defined(TARGET_DARWIN_IOS)
+  EXPECT_STREQ("iOS", g_sysinfo.GetOsName(true).c_str()) << "'GetOsName(true)' must return 'iOS'";
+  EXPECT_STREQ("iOS", g_sysinfo.GetOsName(false).c_str()) << "'GetOsName(false)' must return 'iOS'";
+#elif defined(TARGET_DARWIN_OSX)
+  EXPECT_STREQ("OS X", g_sysinfo.GetOsName(true).c_str()) << "'GetOsName(true)' must return 'OS X'";
+  EXPECT_STREQ("OS X", g_sysinfo.GetOsName(false).c_str()) << "'GetOsName(false)' must return 'OS X'";
+#elif defined(TARGET_ANDROID)
+  EXPECT_STREQ("Android", g_sysinfo.GetOsName(true).c_str()) << "'GetOsName(true)' must return 'Android'";
+  EXPECT_STREQ("Android", g_sysinfo.GetOsName(false).c_str()) << "'GetOsName(false)' must return 'Android'";
+#endif
+}
+
+TEST_F(TestSystemInfo, GetOsVersion)
+{
+  EXPECT_FALSE(g_sysinfo.GetOsVersion().empty()) << "'GetOsVersion()' must not return empty string";
+  EXPECT_STRNE("0.0.0", g_sysinfo.GetOsVersion().c_str()) << "'GetOsVersion()' must not return '0.0.0'";
+  EXPECT_STRNE("0.0", g_sysinfo.GetOsVersion().c_str()) << "'GetOsVersion()' must not return '0.0'";
+  EXPECT_EQ(0, g_sysinfo.GetOsVersion().find_first_of("0123456789")) << "'GetOsVersion()' must not return version not starting from digit";
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetOsVersion().find_first_not_of("0123456789.")) << "'GetOsVersion()' must not return version with not only digits and dots";
+}
+
+TEST_F(TestSystemInfo, GetOsPrettyNameWithVersion)
+{
+  EXPECT_FALSE(g_sysinfo.GetOsPrettyNameWithVersion().empty()) << "'GetOsPrettyNameWithVersion()' must not return empty string";
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetOsPrettyNameWithVersion().find("Unknown")) << "'GetOsPrettyNameWithVersion()' must not contain 'Unknown'";
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetOsPrettyNameWithVersion().find("unknown")) << "'GetOsPrettyNameWithVersion()' must not contain 'unknown'";
+#ifdef TARGET_WINDOWS
+  EXPECT_NE(std::string::npos, g_sysinfo.GetOsPrettyNameWithVersion().find("Windows")) << "'GetOsPrettyNameWithVersion()' must contain 'Windows'";
+#else  // ! TARGET_WINDOWS
+  EXPECT_NE(std::string::npos, g_sysinfo.GetOsPrettyNameWithVersion().find(g_sysinfo.GetOsVersion())) << "'GetOsPrettyNameWithVersion()' must contain OS version";
+#endif // ! TARGET_WINDOWS
+}
+
+TEST_F(TestSystemInfo, GetManufacturerName)
+{
+  EXPECT_STRCASENE("unknown", g_sysinfo.GetManufacturerName().c_str()) << "'GetManufacturerName()' must return empty string instead of 'Unknown'";
+#ifdef TARGET_DARWIN
+  EXPECT_STREQ("Apple", g_sysinfo.GetManufacturerName().c_str()) << "'GetManufacturerName()' must return 'Apple'";
+#endif // TARGET_DARWIN
+}
+
+TEST_F(TestSystemInfo, GetModelName)
+{
+  EXPECT_STRCASENE("unknown", g_sysinfo.GetModelName().c_str()) << "'GetModelName()' must return empty string instead of 'Unknown'";
+}
+
+#ifndef TARGET_WINDOWS
+TEST_F(TestSystemInfo, IsAeroDisabled)
+{
+  EXPECT_FALSE(g_sysinfo.IsAeroDisabled()) << "'IsAeroDisabled()' must return 'false'";
+}
+#endif // ! TARGET_WINDOWS
+
+TEST_F(TestSystemInfo, IsWindowsVersion)
+{
+  EXPECT_FALSE(g_sysinfo.IsWindowsVersion(CSysInfo::WindowsVersionUnknown)) << "'IsWindowsVersion()' must return 'false' for 'WindowsVersionUnknown'";
+#ifndef TARGET_WINDOWS
+  EXPECT_FALSE(g_sysinfo.IsWindowsVersion(CSysInfo::WindowsVersionWin7)) << "'IsWindowsVersion()' must return 'false'";
+#endif // ! TARGET_WINDOWS
+}
+
+TEST_F(TestSystemInfo, IsWindowsVersionAtLeast)
+{
+  EXPECT_FALSE(g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionUnknown)) << "'IsWindowsVersionAtLeast()' must return 'false' for 'WindowsVersionUnknown'";
+  EXPECT_FALSE(g_sysinfo.IsWindowsVersionAtLeast(CSysInfo::WindowsVersionFuture)) << "'IsWindowsVersionAtLeast()' must return 'false' for 'WindowsVersionFuture'";
+#ifndef TARGET_WINDOWS
+  EXPECT_FALSE(g_sysinfo.IsWindowsVersion(CSysInfo::WindowsVersionWin7)) << "'IsWindowsVersionAtLeast()' must return 'false'";
+#endif // ! TARGET_WINDOWS
+}
+
+TEST_F(TestSystemInfo, GetWindowsVersion)
+{
+#ifdef TARGET_WINDOWS
+  EXPECT_NE(CSysInfo::WindowsVersionUnknown, g_sysinfo.GetWindowsVersion()) << "'GetWindowsVersion()' must not return 'WindowsVersionUnknown'";
+  EXPECT_NE(CSysInfo::WindowsVersionFuture, g_sysinfo.GetWindowsVersion()) << "'GetWindowsVersion()' must not return 'WindowsVersionFuture'";
+#else  // ! TARGET_WINDOWS
+  EXPECT_EQ(CSysInfo::WindowsVersionUnknown, g_sysinfo.GetWindowsVersion()) << "'GetWindowsVersion()' must return 'WindowsVersionUnknown'";
+#endif // ! TARGET_WINDOWS
+}
+
+TEST_F(TestSystemInfo, GetKernelBitness)
+{
+  EXPECT_TRUE(g_sysinfo.GetKernelBitness() == 32 || g_sysinfo.GetKernelBitness() == 64) << "'GetKernelBitness()' must return '32' or '64', but not '" << g_sysinfo.GetKernelBitness() << "'";
+  EXPECT_LE(g_sysinfo.GetXbmcBitness(), g_sysinfo.GetKernelBitness()) << "'GetKernelBitness()' must be greater or equal to 'GetXbmcBitness()'";
+}
+
+TEST_F(TestSystemInfo, GetKernelCpuFamily)
+{
+  EXPECT_STRNE("unknown CPU family", g_sysinfo.GetKernelCpuFamily().c_str()) << "'GetKernelCpuFamily()' must not return 'unknown CPU family'";
+#if defined(__thumb__) || defined(_M_ARMT) || defined(__arm__) || defined(_M_ARM) || defined (__aarch64__)
+  EXPECT_STREQ("ARM", g_sysinfo.GetKernelCpuFamily().c_str()) << "'GetKernelCpuFamily()' must return 'ARM'";
+#else  // ! ARM
+  EXPECT_EQ(g_sysinfo.GetBuildTargetCpuFamily(), g_sysinfo.GetKernelCpuFamily()) << "'GetKernelCpuFamily()' must match 'GetBuildTargetCpuFamily()'";
+#endif // ! ARM
+}
+
+TEST_F(TestSystemInfo, GetXbmcBitness)
+{
+  EXPECT_TRUE(g_sysinfo.GetXbmcBitness() == 32 || g_sysinfo.GetXbmcBitness() == 64) << "'GetXbmcBitness()' must return '32' or '64', but not '" << g_sysinfo.GetXbmcBitness() << "'";
+  EXPECT_GE(g_sysinfo.GetKernelBitness(), g_sysinfo.GetXbmcBitness()) << "'GetXbmcBitness()' must be not greater than 'GetKernelBitness()'";
+}
+
 TEST_F(TestSystemInfo, GetUserAgent)
 {
-  std::cout << "GetUserAgent(): " << g_sysinfo.GetUserAgent() << std::endl;
+  EXPECT_STREQ("XBMC/", g_sysinfo.GetUserAgent().substr(0, 5).c_str()) << "'GetUserAgent()' string must start from 'XBMC/'";
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find('(')) << "'GetUserAgent()' must contain brackets around second parameter";
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find(')')) << "'GetUserAgent()' must contain brackets around second parameter";
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find(' '), g_sysinfo.GetUserAgent().find(" (")) << "Second parameter in 'GetUserAgent()' string must be in brackets";
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find(" (") + 1, g_sysinfo.GetUserAgent().find('(')) << "'GetUserAgent()' string must not contain any opening brackets before second parameter";
+  EXPECT_GT(g_sysinfo.GetUserAgent().find(')'), g_sysinfo.GetUserAgent().find('(')) << "'GetUserAgent()' string must not contain any closing brackets before second parameter";
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find(") "), g_sysinfo.GetUserAgent().find(')')) << "'GetUserAgent()' string must not contain any closing brackets before end of second parameter";
+#if defined(TARGET_WINDOWS)
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find('('), g_sysinfo.GetUserAgent().find("(Windows")) << "Second parameter in 'GetUserAgent()' string must start from `Windows`";
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find("Windows")) << "'GetUserAgent()' must contain 'Windows'";
+#elif defined(TARGET_DARWIN_IOS)
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find("like Mac OS X")) << "'GetUserAgent()' must contain ' like Mac OS X'";
+#ifdef TARGET_DARWIN_IOS_ATV2
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find("CPU OS ")) << "'GetUserAgent()' must contain 'CPU OS '";
+#else  // ! TARGET_DARWIN_IOS_ATV2
+  EXPECT_TRUE(g_sysinfo.GetUserAgent().find("CPU OS ") != std::string::npos || g_sysinfo.GetUserAgent().find("CPU iPhone OS ") != std::string::npos) << "'GetUserAgent()' must contain 'CPU OS ' or 'CPU iPhone OS '";
+#endif // ! TARGET_DARWIN_IOS_ATV2
+#elif defined(TARGET_DARWIN_OSX)
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find('('), g_sysinfo.GetUserAgent().find("(Macintosh; ")) << "Second parameter in 'GetUserAgent()' string must start from 'Macintosh; '";
+#elif defined(TARGET_ANDROID)
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find('('), g_sysinfo.GetUserAgent().find("(Linux; Android ")) << "Second parameter in 'GetUserAgent()' string must start from 'Linux; Android '";
+#elif defined(TARGET_POSIX)
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find('('), g_sysinfo.GetUserAgent().find("(X11; ")) << "Second parameter in 'GetUserAgent()' string must start from 'X11; '";
+#if defined(TARGET_FREEBSD)
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find('('), g_sysinfo.GetUserAgent().find("(X11; FreeBSD ")) << "Second parameter in 'GetUserAgent()' string must start from 'X11; FreeBSD '";
+#elif defined(TARGET_LINUX)
+  EXPECT_EQ(g_sysinfo.GetUserAgent().find('('), g_sysinfo.GetUserAgent().find("(X11; Linux ")) << "Second parameter in 'GetUserAgent()' string must start from 'X11; Linux '";
+#endif // defined(TARGET_LINUX)
+#endif // defined(TARGET_POSIX)
+
+#ifdef TARGET_RASPBERRY_PI
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find(" XBMC_HW_RaspberryPi/")) << "'GetUserAgent()' must contain ' XBMC_HW_RaspberryPi/'";
+#endif // TARGET_RASPBERRY_PI
+
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find(" XBMC_BITNESS/")) << "'GetUserAgent()' must contain ' XBMC_BITNESS/'";
+  EXPECT_NE(std::string::npos, g_sysinfo.GetUserAgent().find(" Version/")) << "'GetUserAgent()' must contain ' Version/'";
 }
 
 TEST_F(TestSystemInfo, IsAppleTV2)
 {
-  std::cout << "IsAppleTV2(): " <<
-    testing::PrintToString(g_sysinfo.IsAppleTV2()) << std::endl;
+#ifdef TARGET_DARWIN_IOS_ATV2
+  EXPECT_TRUE(g_sysinfo.IsAppleTV2()) << "'IsAppleTV2()' must return 'true'";
+#else
+  EXPECT_FALSE(g_sysinfo.IsAppleTV2()) << "'IsAppleTV2()' must return 'false'";
+#endif
 }
 
+// FIXME: TARGET_DARWIN_IOS_ATV2?
+#ifndef TARGET_DARWIN
 TEST_F(TestSystemInfo, HasVideoToolBoxDecoder)
 {
-  std::cout << "HasVideoToolBoxDecoder(): " <<
-    testing::PrintToString(g_sysinfo.HasVideoToolBoxDecoder()) << std::endl;
+  EXPECT_FALSE(g_sysinfo.HasVideoToolBoxDecoder()) << "'HasVideoToolBoxDecoder()' must return 'false'";
+}
+#endif
+
+TEST_F(TestSystemInfo, GetBuildTargetPlatformName)
+{
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetBuildTargetPlatformName().find("Unknown")) << "'GetBuildTargetPlatformName()' must not contain 'Unknown', actual value: '" << g_sysinfo.GetBuildTargetPlatformName() << "'";
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetBuildTargetPlatformName().find("unknown")) << "'GetBuildTargetPlatformName()' must not contain 'unknown', actual value: '" << g_sysinfo.GetBuildTargetPlatformName() << "'";
 }
 
-TEST_F(TestSystemInfo, IsAeroDisabled)
+TEST_F(TestSystemInfo, GetBuildTargetPlatformVersion)
 {
-  std::cout << "IsAeroDisabled(): " <<
-    testing::PrintToString(g_sysinfo.IsAeroDisabled()) << std::endl;
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetBuildTargetPlatformVersion().find("Unknown")) << "'GetBuildTargetPlatformVersion()' must not contain 'Unknown', actual value: '" << g_sysinfo.GetBuildTargetPlatformVersion() << "'";
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetBuildTargetPlatformVersion().find("unknown")) << "'GetBuildTargetPlatformVersion()' must not contain 'unknown', actual value: '" << g_sysinfo.GetBuildTargetPlatformVersion() << "'";
 }
 
-TEST_F(TestSystemInfo, IsWindowsVersionAtLeast_Vista)
+TEST_F(TestSystemInfo, GetBuildTargetPlatformVersionDecoded)
 {
-  std::cout << "IsWindowsVersionAtLeast(WindowsVersionVista): " <<
-    testing::PrintToString(g_sysinfo.IsWindowsVersionAtLeast(
-                                  CSysInfo::WindowsVersionVista)) << std::endl;
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetBuildTargetPlatformVersionDecoded().find("Unknown")) << "'GetBuildTargetPlatformVersionDecoded()' must not contain 'Unknown', actual value: '" << g_sysinfo.GetBuildTargetPlatformVersion() << "'";
+  EXPECT_EQ(std::string::npos, g_sysinfo.GetBuildTargetPlatformVersionDecoded().find("unknown")) << "'GetBuildTargetPlatformVersionDecoded()' must not contain 'unknown', actual value: '" << g_sysinfo.GetBuildTargetPlatformVersion() << "'";
+#ifdef TARGET_ANDROID
+  EXPECT_STREQ("API level ", g_sysinfo.GetBuildTargetPlatformVersionDecoded().substr(0, 10).c_str()) << "'GetBuildTargetPlatformVersionDecoded()' must start from 'API level '";
+#else
+  EXPECT_STREQ("version ", g_sysinfo.GetBuildTargetPlatformVersionDecoded().substr(0, 8).c_str()) << "'GetBuildTargetPlatformVersionDecoded()' must start from 'version'";
+#endif
 }
 
-TEST_F(TestSystemInfo, GetCPUModel)
+TEST_F(TestSystemInfo, GetBuildTargetCpuFamily)
 {
-  std::cout << "GetCPUModel(): " << g_sysinfo.GetCPUModel() <<  std::endl;
+  EXPECT_STRNE("unknown CPU family", g_sysinfo.GetBuildTargetCpuFamily().c_str()) << "'GetBuildTargetCpuFamily()' must not return 'unknown CPU family'";
+#if defined(__thumb__) || defined(_M_ARMT) || defined(__arm__) || defined(_M_ARM) || defined (__aarch64__)
+  EXPECT_STREQ("ARM", g_sysinfo.GetBuildTargetCpuFamily().substr(0, 3).c_str()) << "'GetKernelCpuFamily()' string must start from 'ARM'";
+#else  // ! ARM
+  EXPECT_EQ(g_sysinfo.GetKernelCpuFamily(), g_sysinfo.GetBuildTargetCpuFamily()) << "'GetBuildTargetCpuFamily()' must match 'GetKernelCpuFamily()'";
+#endif // ! ARM
 }
 
-TEST_F(TestSystemInfo, GetCPUBogoMips)
+TEST_F(TestSystemInfo, GetUsedCompilerNameAndVer)
 {
-  std::cout << "GetCPUBogoMips(): " << g_sysinfo.GetCPUBogoMips() <<  std::endl;
-}
-
-TEST_F(TestSystemInfo, GetCPUHardware)
-{
-  std::cout << "GetCPUHardware(): " << g_sysinfo.GetCPUHardware() <<  std::endl;
-}
-
-TEST_F(TestSystemInfo, GetCPURevision)
-{
-  std::cout << "GetCPURevision(): " << g_sysinfo.GetCPURevision() <<  std::endl;
-}
-
-TEST_F(TestSystemInfo, GetCPUSerial)
-{
-  std::cout << "GetCPUSerial(): " << g_sysinfo.GetCPUSerial() <<  std::endl;
+  EXPECT_STRNE("unknown compiler", g_sysinfo.GetUsedCompilerNameAndVer().c_str()) << "'GetUsedCompilerNameAndVer()' must not return 'unknown compiler'";
 }
 
 TEST_F(TestSystemInfo, GetDiskSpace)
@@ -95,39 +289,36 @@ TEST_F(TestSystemInfo, GetDiskSpace)
   int iTotal, iTotalFree, iTotalUsed, iPercentFree, iPercentUsed;
 
   iTotal = iTotalFree = iTotalUsed = iPercentFree = iPercentUsed = 0;
+  EXPECT_TRUE(g_sysinfo.GetDiskSpace("*", iTotal, iTotalFree, iTotalUsed, iPercentFree, iPercentUsed)) << "'GetDiskSpace()' return 'false' for disk '*'";
+  EXPECT_NE(0, iTotal) << "'GetDiskSpace()' return zero total space for disk '*'";
+  EXPECT_EQ(iTotal, iTotalFree + iTotalUsed) << "'GetDiskSpace()' return 'TotalFree + TotalUsed' not equal to 'Total' for disk '*'";
+  EXPECT_EQ(100, iPercentFree + iPercentUsed) << "'GetDiskSpace()' return 'PercentFree + PercentUsed' not equal to '100' for disk '*'";
 
-  std::cout << "GetDiskSpace(): " <<
-    testing::PrintToString(g_sysinfo.GetDiskSpace("*", iTotal, iTotalFree,
-                                                  iTotalUsed, iPercentFree,
-                                                  iPercentUsed)) << std::endl;
-  std::cout << "iTotal: " << testing::PrintToString(iTotal) << std::endl;
-  std::cout << "iTotalFree: " << testing::PrintToString(iTotalFree) << std::endl;
-  std::cout << "iTotalUsed: " << testing::PrintToString(iTotalUsed) << std::endl;
-  std::cout << "iPercentFree: " << testing::PrintToString(iPercentFree) << std::endl;
-  std::cout << "iPercentUsed: " << testing::PrintToString(iPercentUsed) << std::endl;
-}
+  iTotal = iTotalFree = iTotalUsed = iPercentFree = iPercentUsed = 0;
+  EXPECT_TRUE(g_sysinfo.GetDiskSpace("", iTotal, iTotalFree, iTotalUsed, iPercentFree, iPercentUsed)) << "'GetDiskSpace()' return 'false' for disk ''";
+  EXPECT_NE(0, iTotal) << "'GetDiskSpace()' return zero total space for disk ''";
+  EXPECT_EQ(iTotal, iTotalFree + iTotalUsed) << "'GetDiskSpace()' return 'TotalFree + TotalUsed' not equal to 'Total' for disk ''";
+  EXPECT_EQ(100, iPercentFree + iPercentUsed) << "'GetDiskSpace()' return 'PercentFree + PercentUsed' not equal to '100' for disk ''";
 
-TEST_F(TestSystemInfo, GetHddSpaceInfo)
-{
-  int percent;
+#ifdef TARGET_WINDOWS
+  char sysDrive[300];
+  DWORD res = GetEnvironmentVariableA("SystemDrive", sysDrive, sizeof(sysDrive) / sizeof(char));
+  std::string sysDriveLtr;
+  if (res != 0 && res <= sizeof(sysDrive) / sizeof(char))
+    sysDriveLtr.assign(sysDrive, 1);
+  else
+    sysDriveLtr = "C"; // fallback
 
-  std::cout << "GetHddSpaceInfo(SYSTEM_FREE_SPACE): " <<
-    g_sysinfo.GetHddSpaceInfo(SYSTEM_FREE_SPACE) << std::endl;
-  std::cout << "GetHddSpaceInfo(SYSTEM_USED_SPACE): " <<
-    g_sysinfo.GetHddSpaceInfo(SYSTEM_USED_SPACE) << std::endl;
-  std::cout << "GetHddSpaceInfo(SYSTEM_TOTAL_SPACE): " <<
-    g_sysinfo.GetHddSpaceInfo(SYSTEM_TOTAL_SPACE) << std::endl;
-  std::cout << "GetHddSpaceInfo(SYSTEM_FREE_SPACE_PERCENT): " <<
-    g_sysinfo.GetHddSpaceInfo(SYSTEM_FREE_SPACE_PERCENT) << std::endl;
-  std::cout << "GetHddSpaceInfo(SYSTEM_USED_SPACE_PERCENT): " <<
-    g_sysinfo.GetHddSpaceInfo(SYSTEM_USED_SPACE_PERCENT) << std::endl;
-
-  percent = 0;
-  std::cout << "GetHddSpaceInfo(percent, SYSTEM_FREE_SPACE, true): " <<
-    g_sysinfo.GetHddSpaceInfo(percent, SYSTEM_FREE_SPACE, true) << std::endl;
-  std::cout << "percent: " << testing::PrintToString(percent) << std::endl;
-  percent = 0;
-  std::cout << "GetHddSpaceInfo(percent, SYSTEM_USED_SPACE, true): " <<
-    g_sysinfo.GetHddSpaceInfo(percent, SYSTEM_USED_SPACE, true) << std::endl;
-  std::cout << "percent: " << testing::PrintToString(percent) << std::endl;
+  iTotal = iTotalFree = iTotalUsed = iPercentFree = iPercentUsed = 0;
+  EXPECT_TRUE(g_sysinfo.GetDiskSpace(sysDriveLtr, iTotal, iTotalFree, iTotalUsed, iPercentFree, iPercentUsed)) << "'GetDiskSpace()' return 'false' for disk '" << sysDriveLtr << ":'";
+  EXPECT_NE(0, iTotal) << "'GetDiskSpace()' return zero total space for disk '" << sysDriveLtr << ":'";
+  EXPECT_EQ(iTotal, iTotalFree + iTotalUsed) << "'GetDiskSpace()' return 'TotalFree + TotalUsed' not equal to 'Total' for disk '" << sysDriveLtr << ":'";
+  EXPECT_EQ(100, iPercentFree + iPercentUsed) << "'GetDiskSpace()' return 'PercentFree + PercentUsed' not equal to '100' for disk '" << sysDriveLtr << ":'";
+#elif defined(TARGET_POSIX)
+  iTotal = iTotalFree = iTotalUsed = iPercentFree = iPercentUsed = 0;
+  EXPECT_TRUE(g_sysinfo.GetDiskSpace("/", iTotal, iTotalFree, iTotalUsed, iPercentFree, iPercentUsed)) << "'GetDiskSpace()' return 'false' for directory '/'";
+  EXPECT_NE(0, iTotal) << "'GetDiskSpace()' return zero total space for directory '/'";
+  EXPECT_EQ(iTotal, iTotalFree + iTotalUsed) << "'GetDiskSpace()' return 'TotalFree + TotalUsed' not equal to 'Total' for directory '/'";
+  EXPECT_EQ(100, iPercentFree + iPercentUsed) << "'GetDiskSpace()' return 'PercentFree + PercentUsed' not equal to '100' for directory '/'";
+#endif
 }

--- a/xbmc/utils/test/TestSystemInfo.cpp
+++ b/xbmc/utils/test/TestSystemInfo.cpp
@@ -29,22 +29,9 @@ class TestSystemInfo : public testing::Test
 protected:
   TestSystemInfo()
   {
-/*    CSettingsCategory* net = CSettings::Get().AddCategory(4, "network", 798);
-    CSettings::Get().AddBool(net, "network.usehttpproxy", 708, false);
-    CSettings::Get().AddString(net, "network.httpproxyserver", 706, "",
-                            EDIT_CONTROL_INPUT);
-    CSettings::Get().AddString(net, "network.httpproxyport", 730, "8080",
-                            EDIT_CONTROL_NUMBER_INPUT, false, 707);
-    CSettings::Get().AddString(net, "network.httpproxyusername", 1048, "",
-                            EDIT_CONTROL_INPUT);
-    CSettings::Get().AddString(net, "network.httpproxypassword", 733, "",
-                            EDIT_CONTROL_HIDDEN_INPUT,true,733);
-    CSettings::Get().AddInt(net, "network.bandwidth", 14041, 0, 0, 512, 100*1024,
-                         SPIN_CONTROL_INT_PLUS, 14048, 351);*/
   }
   ~TestSystemInfo()
   {
-//    CSettings::Get().Clear();
   }
 };
 

--- a/xbmc/utils/test/TestSystemInfo.cpp
+++ b/xbmc/utils/test/TestSystemInfo.cpp
@@ -40,12 +40,6 @@ TEST_F(TestSystemInfo, GetUserAgent)
   std::cout << "GetUserAgent(): " << g_sysinfo.GetUserAgent() << std::endl;
 }
 
-TEST_F(TestSystemInfo, HasInternet)
-{
-  std::cout << "HasInternet(): " <<
-    testing::PrintToString(g_sysinfo.HasInternet()) << std::endl;
-}
-
 TEST_F(TestSystemInfo, IsAppleTV2)
 {
   std::cout << "IsAppleTV2(): " <<


### PR DESCRIPTION
- Fix tests after #4811
- Enable SysInfo tests under win32
- Full rewrite of all SysInfo tests to do real testing
