### PR TITLE
CHG: remove obsucure "remote as keyboard" option; replace with <tab> hotkey

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -169,6 +169,7 @@
   </Home>
   <VirtualKeyboard>
     <keyboard>
+      <tab>ToggleKeyboard</tab>
       <backspace>Backspace</backspace>
     </keyboard>
   </VirtualKeyboard>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2618,11 +2618,6 @@
         </setting>
       </group>
       <group id="2">
-        <setting id="input.remoteaskeyboard" type="boolean" label="21449" help="36376">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <setting id="input.enablemouse" type="boolean" label="21369" help="36377">
           <level>0</level>
           <control type="toggle" />

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -439,6 +439,8 @@ CApplication::CApplication(void)
 
   m_muted = false;
   m_volumeLevel = 1.0f;
+
+  m_bKeyboardMode = false;
 }
 
 CApplication::~CApplication(void)
@@ -2428,12 +2430,12 @@ bool CApplication::OnKey(const CKey& key)
     }
     if (useKeyboard)
     {
-      action = CAction(0); // reset our action
-      if (CSettings::Get().GetBool("input.remoteaskeyboard"))
+      action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key);
+
+      if (action.GetID() == ACTION_TOGGLE_KEYBOARD)
+        m_bKeyboardMode = !m_bKeyboardMode;
+      else if (!m_bKeyboardMode)
       {
-        // users remote is executing keyboard commands, so use the virtualkeyboard section of keymap.xml
-        // and send those rather than actual keyboard presses.  Only for navigation-type commands though
-        action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key);
         if (!(action.GetID() == ACTION_MOVE_LEFT ||
               action.GetID() == ACTION_MOVE_RIGHT ||
               action.GetID() == ACTION_MOVE_UP ||
@@ -2446,14 +2448,17 @@ bool CApplication::OnKey(const CKey& key)
           // the action isn't plain navigation - check for a keyboard-specific keymap
           action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key, false);
           if (!(action.GetID() >= REMOTE_0 && action.GetID() <= REMOTE_9) ||
-                action.GetID() == ACTION_BACKSPACE ||
-                action.GetID() == ACTION_SHIFT ||
-                action.GetID() == ACTION_SYMBOLS ||
-                action.GetID() == ACTION_CURSOR_LEFT ||
-                action.GetID() == ACTION_CURSOR_RIGHT)
+              action.GetID() == ACTION_BACKSPACE ||
+              action.GetID() == ACTION_SHIFT ||
+              action.GetID() == ACTION_SYMBOLS ||
+              action.GetID() == ACTION_CURSOR_LEFT ||
+              action.GetID() == ACTION_CURSOR_RIGHT)
             action = CAction(0); // don't bother with this action
         }
       }
+      else
+        action = CAction(0); // reset our action
+
       if (!action.GetID())
       {
         // keyboard entry - pass the keys through directly

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -424,6 +424,8 @@ protected:
   bool m_bTestMode;
   bool m_bSystemScreenSaverEnable;
 
+  bool m_bKeyboardMode;
+
   VIDEO::CVideoInfoScanner *m_videoInfoScanner;
   MUSIC_INFO::CMusicInfoScanner *m_musicInfoScanner;
 

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -333,6 +333,7 @@
 #define ACTION_SETTINGS_LEVEL_CHANGE  242
 
 #define ACTION_TRIGGER_OSD            243 // show autoclosing OSD. Can b used in videoFullScreen.xml window id=2005
+#define ACTION_TOGGLE_KEYBOARD        244 // Toggle virtual keyboard between "real keyboard" mode and "remote" mode
 
 // touch actions
 #define ACTION_TOUCH_TAP              401

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -265,6 +265,9 @@ static const ActionMapping actions[] =
         {"swipeup"           , ACTION_GESTURE_SWIPE_UP},
         {"swipedown"         , ACTION_GESTURE_SWIPE_DOWN},
 
+        // Keyboard
+        {"togglekeyboard"    , ACTION_TOGGLE_KEYBOARD},
+
         // Do nothing action
         { "noop"             , ACTION_NOOP}
 };


### PR DESCRIPTION
This removes the obscure and troublesome "remote as keyboard" option.

Instead:
- Default is working like if the option was true
- To switch to "real" keyboard way-of-working, an action is created and bound to "tab"

I'm still wondering whether the keyboard toggle status should be saved between sessions...
