### PR TITLE
FIX: [droid] set "remote as keyboard" default to true

### DIFF
--- a/system/settings/android.xml
+++ b/system/settings/android.xml
@@ -37,4 +37,13 @@
       </group>
     </category>
   </section>
+  <section id="system">
+    <category id="input">
+      <group id="2">
+        <setting id="input.remoteaskeyboard">
+          <default>true</default>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>


### PR DESCRIPTION
Gotham only. See https://github.com/xbmc/xbmc/pull/4874 for Helix.

Setting this setting off by default makes no sense for Android.

/cc @davilla @t-nelson 
