### PR TITLE
New feature: Added parameters to skin include directive ($PARAM[Name])

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -21,6 +21,7 @@
 #include "GUIIncludes.h"
 #include "addons/Skin.h"
 #include "GUIInfoManager.h"
+#include "GUIInfoTypes.h"
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
@@ -48,7 +49,7 @@ CGUIIncludes::CGUIIncludes()
   m_constantAttributes.insert("center");
   m_constantAttributes.insert("border");
   m_constantAttributes.insert("repeat");
-  
+
   m_constantNodes.insert("posx");
   m_constantNodes.insert("posy");
   m_constantNodes.insert("left");
@@ -64,7 +65,7 @@ CGUIIncludes::CGUIIncludes()
   m_constantNodes.insert("offsetx");
   m_constantNodes.insert("offsety");
   m_constantNodes.insert("textoffsetx");
-  m_constantNodes.insert("textoffsety");  
+  m_constantNodes.insert("textoffsety");
   m_constantNodes.insert("textwidth");
   m_constantNodes.insert("spinposx");
   m_constantNodes.insert("spinposy");
@@ -132,7 +133,17 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
     if (node->Attribute("name") && node->FirstChild())
     {
       std::string tagName = node->Attribute("name");
-      m_includes.insert(pair<std::string, TiXmlElement>(tagName, *node));
+      // we'll parse and store parameter list with defaults when include definition is first encountered
+      // if there's a <definition> tag only use its body as the actually included part
+      const TiXmlElement *definitionTag = node->FirstChildElement("definition");
+      const TiXmlElement *includeBody = definitionTag ? definitionTag : node;
+      // if there's a <param> tag there also must be a <definition> tag
+      Params defaultParams;
+      bool haveParamTags = GetParameters(node, "default", defaultParams);
+      if (haveParamTags && !definitionTag)
+        CLog::Log(LOGWARNING, "Skin has invalid include definition: %s", tagName.c_str());
+      else
+        m_includes.insert({ tagName, { *includeBody, std::move(defaultParams) } });
     }
     else if (node->Attribute("file"))
     { // load this file in as well
@@ -235,7 +246,7 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::Inf
   }
 
   TiXmlElement *include = node->FirstChildElement("include");
-  while (include && include->FirstChild())
+  while (include)
   {
     // have an include tag - grab it's tag name and replace it with the real tag contents
     const char *file = include->Attribute("file");
@@ -258,20 +269,50 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::Inf
         continue;
       }
     }
-    std::string tagName = include->FirstChild()->Value();
-    map<std::string, TiXmlElement>::const_iterator it = m_includes.find(tagName);
+
+    Params params;
+    std::string tagName;
+    // determine which form of include call we have
+    const char *name = include->Attribute("name");
+    if (name)
+    {
+      // 1. <include name="MyControl" />
+      // 2. <include name="MyControl">
+      //      <param name="posx" value="225" />
+      //      <param name="posy">150</param>
+      //      ...
+      //    </include>
+      tagName = name;
+      GetParameters(include, "value", params);
+    }
+    else
+    {
+      const TiXmlNode *child = include->FirstChild();
+      if (child && child->Type() == TiXmlNode::TINYXML_TEXT)
+      {
+        // 3. <include>MyControl</include>          // old-style includes for backward compatibility
+        tagName = child->ValueStr();
+      }
+    }
+
+    std::map<std::string, std::pair<TiXmlElement, Params>>::const_iterator it = m_includes.find(tagName);
     if (it != m_includes.end())
     { // found the tag(s) to include - let's replace it
-      const TiXmlElement &element = (*it).second;
-      const TiXmlElement *tag = element.FirstChildElement();
+      const TiXmlElement *includeBody = &it->second.first;
+      const Params& defaultParams = it->second.second;
+      const TiXmlElement *tag = includeBody->FirstChildElement();
+      // combine passed include parameters with their default values into a single list (no overwrites)
+      params.insert(defaultParams.begin(), defaultParams.end());
       while (tag)
       {
         // we insert before the <include> element to keep the correct
         // order (we render in the order given in the xml file)
-        node->InsertBeforeChild(include, *tag);
+        TiXmlElement *insertedTag = static_cast<TiXmlElement*>(node->InsertBeforeChild(include, *tag));
+        // after insertion we resolve parameters even if parameter list is empty (to remove param references)
+        ResolveParametersForNode(insertedTag, params);
         tag = tag->NextSiblingElement();
       }
-      // remove the <include>tagName</include> element
+      // remove the include element itself
       node->RemoveChild(include);
       include = node->FirstChildElement("include");
     }
@@ -293,6 +334,136 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::Inf
   // also do the value
   if (node->FirstChild() && node->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT && m_constantNodes.count(node->ValueStr()))
     node->FirstChild()->SetValue(ResolveConstant(node->FirstChild()->ValueStr()));
+}
+
+bool CGUIIncludes::GetParameters(const TiXmlElement *include, const char *valueAttribute, Params& params)
+{
+  bool foundAny = false;
+
+  // collect parameters from include tag
+  // <include name="MyControl">
+  //   <param name="posx" value="225" /> <!-- comments and other tags are ignored here -->
+  //   <param name="posy">150</param>
+  //   ...
+  // </include>
+
+  if (include)
+  {
+    const TiXmlElement *param = include->FirstChildElement("param");
+    foundAny = param != NULL;  // doesn't matter if param isn't entirely valid
+    while (param)
+    {
+      std::string paramName = XMLUtils::GetAttribute(param, "name");
+      if (!paramName.empty())
+      {
+        std::string paramValue;
+
+        // <param name="posx" value="120" />
+        const char *value = param->Attribute(valueAttribute);         // try attribute first
+        if (value)
+          paramValue = value;
+        else
+        {
+          // <param name="posx">120</param>
+          const TiXmlNode *child = param->FirstChild();
+          if (child && child->Type() == TiXmlNode::TINYXML_TEXT)
+            paramValue = child->ValueStr();                           // and then tag value
+        }
+
+        params.insert({ paramName, paramValue });                     // no overwrites
+      }
+      param = param->NextSiblingElement("param");
+    }
+  }
+
+  return foundAny;
+}
+
+void CGUIIncludes::ResolveParametersForNode(TiXmlElement *node, const Params& params)
+{
+  if (!node)
+    return;
+  std::string newValue;
+  // run through this element's attributes, resolving any parameters
+  TiXmlAttribute *attribute = node->FirstAttribute();
+  while (attribute)
+  {
+    ResolveParamsResult result = ResolveParameters(attribute->ValueStr(), newValue, params);
+    if (result == SINGLE_UNDEFINED_PARAM_RESOLVED && strcmp(node->Value(), "param") == 0 &&
+        strcmp(attribute->Name(), "value") == 0 && node->Parent() && strcmp(node->Parent()->Value(), "include") == 0)
+    {
+      // special case: passing <param name="someName" value="$PARAM[undefinedParam]" /> to the nested include
+      // this usually happens when trying to forward a missing parameter from the enclosing include to the nested include
+      // problem: since 'undefinedParam' is not defined, it expands to <param name="someName" value="" /> and overrides any default value set with <param name="someName" default="someValue" /> in the nested include
+      // to prevent this, we'll completely remove this parameter from the nested include call so that the default value can be correctly picked up later
+      node->Parent()->RemoveChild(node);
+      return;
+    }
+    else if (result != NO_PARAMS_FOUND)
+      attribute->SetValue(newValue);
+    attribute = attribute->Next();
+  }
+  // run through this element's value and children, resolving any parameters
+  TiXmlNode *child = node->FirstChild();
+  if (child)
+  {
+    if (child->Type() == TiXmlNode::TINYXML_TEXT)
+    {
+      ResolveParamsResult result = ResolveParameters(child->ValueStr(), newValue, params);
+      if (result == SINGLE_UNDEFINED_PARAM_RESOLVED && strcmp(node->Value(), "param") == 0 &&
+          node->Parent() && strcmp(node->Parent()->Value(), "include") == 0)
+      {
+        // special case: passing <param name="someName">$PARAM[undefinedParam]</param> to the nested include
+        // we'll remove the offending param tag same as above
+        node->Parent()->RemoveChild(node);
+      }
+      else if (result != NO_PARAMS_FOUND)
+        child->SetValue(newValue);
+    }
+    else if (child->Type() == TiXmlNode::TINYXML_ELEMENT)
+    {
+      do
+      {
+        TiXmlElement *next = child->NextSiblingElement();   // save next as current child might be removed from the tree
+        ResolveParametersForNode(static_cast<TiXmlElement *>(child), params);
+        child = next;
+      }
+      while (child);
+    }
+  }
+}
+
+class ParamReplacer
+{
+  const std::map<std::string, std::string>& m_params;
+  // keep some stats so that we know exactly what's been resolved
+  int m_numTotalParams;
+  int m_numUndefinedParams;
+public:
+  ParamReplacer(const std::map<std::string, std::string>& params)
+    : m_params(params), m_numTotalParams(0), m_numUndefinedParams(0) {}
+  int GetNumTotalParams() const { return m_numTotalParams; }
+  int GetNumDefinedParams() const { return m_numTotalParams - m_numUndefinedParams; }
+  int GetNumUndefinedParams() const { return m_numUndefinedParams; }
+
+  std::string operator()(const std::string &paramName)
+  {
+    m_numTotalParams++;
+    std::map<std::string, std::string>::const_iterator it = m_params.find(paramName);
+    if (it != m_params.end())
+      return it->second;
+    m_numUndefinedParams++;
+    return "";
+  }
+};
+
+CGUIIncludes::ResolveParamsResult CGUIIncludes::ResolveParameters(const std::string& strInput, std::string& strOutput, const Params& params)
+{
+  ParamReplacer paramReplacer(params);
+  if (CGUIInfoLabel::ReplaceSpecialKeywordReferences(strInput, "PARAM", std::ref(paramReplacer), strOutput))
+    // detect special input values of the form "$PARAM[undefinedParam]" (with no extra characters around)
+    return paramReplacer.GetNumUndefinedParams() == 1 && paramReplacer.GetNumTotalParams() == 1 && strOutput.empty() ? SINGLE_UNDEFINED_PARAM_RESOLVED : PARAMS_RESOLVED;
+  return NO_PARAMS_FOUND;
 }
 
 std::string CGUIIncludes::ResolveConstant(const std::string &constant) const

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -52,10 +52,21 @@ public:
   const INFO::CSkinVariableString* CreateSkinVariable(const std::string& name, int context);
 
 private:
+  enum ResolveParamsResult
+  {
+    NO_PARAMS_FOUND,
+    PARAMS_RESOLVED,
+    SINGLE_UNDEFINED_PARAM_RESOLVED
+  };
+
   void ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions = NULL);
+  using Params = std::map<std::string, std::string>;
+  static bool GetParameters(const TiXmlElement *include, const char *valueAttribute, Params& params);
+  static void ResolveParametersForNode(TiXmlElement *node, const Params& params);
+  static ResolveParamsResult ResolveParameters(const std::string& strInput, std::string& strOutput, const Params& params);
   std::string ResolveConstant(const std::string &constant) const;
   bool HasIncludeFile(const std::string &includeFile) const;
-  std::map<std::string, TiXmlElement> m_includes;
+  std::map<std::string, std::pair<TiXmlElement, Params>> m_includes;
   std::map<std::string, TiXmlElement> m_defaults;
   std::map<std::string, TiXmlElement> m_skinvariables;
   std::map<std::string, std::string> m_constants;
@@ -65,4 +76,3 @@ private:
   std::set<std::string> m_constantAttributes;
   std::set<std::string> m_constantNodes;
 };
-

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -217,30 +217,52 @@ bool CGUIInfoLabel::IsConstant() const
   return m_info.size() == 0 || (m_info.size() == 1 && m_info[0].m_info == 0);
 }
 
-typedef std::string (*StringReplacerFunc) (const std::string &str);
-
-void ReplaceString(std::string &work, const std::string &str, StringReplacerFunc func)
+bool CGUIInfoLabel::ReplaceSpecialKeywordReferences(const std::string &strInput, const std::string &strKeyword, const StringReplacerFunc &func, std::string &strOutput)
 {
-  // Replace all $str[number] with the real string
-  size_t pos1 = work.find("$" + str + "[");
-  while (pos1 != std::string::npos)
+  // replace all $strKeyword[value] with resolved strings
+  std::string dollarStrPrefix = "$" + strKeyword + "[";
+
+  size_t index = 0;
+  size_t startPos;
+
+  while ((startPos = strInput.find(dollarStrPrefix, index)) != std::string::npos)
   {
-    size_t pos2 = pos1 + str.length() + 2;
-    size_t pos3 = StringUtils::FindEndBracket(work, '[', ']', pos2);
-    if (pos3 != std::string::npos)
+    size_t valuePos = startPos + dollarStrPrefix.size();
+    size_t endPos = StringUtils::FindEndBracket(strInput, '[', ']', valuePos);
+    if (endPos != std::string::npos)
     {
-      std::string left = work.substr(0, pos1);
-      std::string right = work.substr(pos3 + 1);
-      std::string replace = func(work.substr(pos2, pos3 - pos2));
-      work = left + replace + right;
+      if (index == 0)  // first occurrence?
+        strOutput.clear();
+      strOutput += strInput.substr(index, startPos - index);            // append part from the left side
+      strOutput += func(strInput.substr(valuePos, endPos - valuePos));  // resolve and append value part
+      index = endPos + 1;
     }
     else
     {
-      CLog::Log(LOGERROR, "Error parsing label - missing ']' in \"%s\"", work.c_str());
-      return;
+      // if closing bracket is missing, report error and leave incomplete reference in
+      CLog::Log(LOGERROR, "Error parsing value - missing ']' in \"%s\"", strInput.c_str());
+      break;
     }
-    pos1 = work.find("$" + str + "[", pos1);
   }
+
+  if (index)  // if we replaced anything
+  {
+    strOutput += strInput.substr(index);  // append leftover from the right side
+    return true;
+  }
+
+  return false;
+}
+
+bool CGUIInfoLabel::ReplaceSpecialKeywordReferences(std::string &work, const std::string &strKeyword, const StringReplacerFunc &func)
+{
+  std::string output;
+  if (ReplaceSpecialKeywordReferences(work, strKeyword, func, output))
+  {
+    work = output;
+    return true;
+  }
+  return false;
 }
 
 std::string LocalizeReplacer(const std::string &str)
@@ -268,15 +290,15 @@ std::string NumberReplacer(const std::string &str)
 std::string CGUIInfoLabel::ReplaceLocalize(const std::string &label)
 {
   std::string work(label);
-  ReplaceString(work, "LOCALIZE", LocalizeReplacer);
-  ReplaceString(work, "NUMBER", NumberReplacer);
+  ReplaceSpecialKeywordReferences(work, "LOCALIZE", LocalizeReplacer);
+  ReplaceSpecialKeywordReferences(work, "NUMBER", NumberReplacer);
   return work;
 }
 
 std::string CGUIInfoLabel::ReplaceAddonStrings(const std::string &label)
 {
   std::string work(label);
-  ReplaceString(work, "ADDON", AddonReplacer);
+  ReplaceSpecialKeywordReferences(work, "ADDON", AddonReplacer);
   return work;
 }
 

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 #include <stdint.h>
+#include <functional>
 #include "interfaces/info/InfoBool.h"
 
 class CGUIListItem;
@@ -84,7 +85,7 @@ public:
    \param preferImage caller is specifically wanting an image rather than a label. Defaults to false.
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
-   */  
+   */
   const std::string &GetLabel(int contextWindow, bool preferImage = false, std::string *fallback = NULL) const;
 
   /*!
@@ -124,6 +125,27 @@ public:
    \return text with any localized strings filled in.
    */
   static std::string ReplaceAddonStrings(const std::string &label);
+
+  typedef std::function<std::string(const std::string&)> StringReplacerFunc;
+
+  /*!
+   \brief Replaces instances of $strKeyword[value] with the appropriate resolved string
+   \param strInput text to replace
+   \param strKeyword keyword to look for
+   \param func function that does the actual replacement of each bracketed value found
+   \param strOutput the output string
+   \return whether anything has been replaced.
+   */
+  static bool ReplaceSpecialKeywordReferences(const std::string &strInput, const std::string &strKeyword, const StringReplacerFunc &func, std::string &strOutput);
+
+  /*!
+   \brief Replaces instances of $strKeyword[value] with the appropriate resolved string in-place
+   \param work text to replace in-place
+   \param strKeyword keyword to look for
+   \param func function that does the actual replacement of each bracketed value found
+   \return whether anything has been replaced.
+   */
+  static bool ReplaceSpecialKeywordReferences(std::string &work, const std::string &strKeyword, const StringReplacerFunc &func);
 
 private:
   void Parse(const std::string &label, int context);


### PR DESCRIPTION
Skin includes have been enhanced to accept parameters and thus be able to generate dynamic content based on them. Basically, they can now act as "procedures" where needed. This can help clean up XMLs a bit, making skins much easier to read and maintain. It also allows for more component-based modular skin design.

The syntax is as follows:

_include definition_:

``` xml
<include name="MyControl1">
  <!-- parameter list with possible default values is specified here (optional) -->
  <param name="id"/>
  <param name="posx" default="120"/>
  <param name="posy" default="120"/>
  <param name="border" default="5"/>
  <param name="background">foo.png</param> <!-- alternative form -->
  <param name="color"/>
  <definition>
    <!-- include body goes here -->
    <control id="$PARAM[id]" ...>
      <posx>$PARAM[posx]</posx>
      <posy>$PARAM[posy]</posy>
      <control ...>
        ...
        <texture border="$PARAM[border]">$PARAM[background]</texture>
      </control>
      ...
      <!-- nested include call -->
      <include name="MyControl2">
        <param name="label">$INFO[Player.Title]</param>
        <param name="color" value="$PARAM[color]"/> <!-- parameter forwarding -->
      </include>
      ...
    </control>
    ...
  </definition>
</include>
```

_include call_:

``` xml
  <include file="MyControls.xml" name="MyControl1">
    <param name="id" value="60"/>
    <param name="posx" value="225"/>
    <param name="posy" value="150"/>
    <param name="color" value="white"/>
  </include>
```

Rules:
- Parameter list is specified using `<param>` tags in both include calls and definitions.
- Include definition body is enclosed within `<definition>` tag.
- Default values for parameters can be specified within include definition and are used as replacement when parameters are not passed in the include call
- Parameters without default values in include definitions are specified for better readability and documentation purposes only, but are otherwise **not mandatory** and can be omitted.
- If there are no `<param>` tags in include definition, `<definition>` tag can be omitted too.
- Concrete arguments are specified within _include call_ tag
- Actual arguments are a combination of these two, with passed arguments having a higher priority over default ones
- Parameter references of the form `$PARAM[ParamName]` are replaced with actual arguments within include definition body, inside both tag values and attributes
- There can be one or more parameter references specified within a single tag/attribute value, possibly in combination with other characters (e.g. `<param name="debug" value="x:$PARAM[x]; y:$PARAM[y]"/>`)
- Parameter references are resolved before everything else (`$INFO` labels, `$LOCALIZE`, etc.), so these can be passed as arguments too
- Parameter references that refer to missing/undefined parameters are replaced with empty strings; one exception to this rule is when forwarding a missing parameter of the form `<param name="..." value="$PARAM[MissingParamName]"/>` from enclosing include to the nested include, where this parameter, which would normally be expanded to "", won't be passed at all, allowing any default value from the nested include to be correctly picked up and not overriden by ""
- Extra parameters in include call that are passed but not referenced anywhere within include definition are ignored
- Incomplete parameter references (without closing ']') are logged as errors and left as is, rather than resolved to empty strings

This feature was proposed and discussed in more detail here: http://forum.xbmc.org/showthread.php?tid=190135. It requires a change in Wiki documentation which I can help with if it gets accepted.

**EDIT: Originally proposed syntax is given below. Together with the discussion that follows it, it shows the full evolution of the feature for any future reference. This syntax is _NOT_ included in Kodi.**

_include definition_:

``` xml
<!-- default parameter values are specified here -->
<include name="MyControl1" p:posx="120" p:posy="120" p:border="5" p:background="foo.png">
  <control id="$PARAM[id]" ...>
    <posx>$PARAM[posx]</posx>
    <posy>$PARAM[posy]</posy>
    <control ...>
      ...
      <texture border="$PARAM[border]">$PARAM[background]</texture>
    </control>
    ...
    <!-- nested include call -->
    <include p:label="$INFO[Player.Title]" p:color="$PARAM[color]">MyControl2</include>
    ...
  </control>
  ...
</include>
```

_include call_:

``` xml
  <include file="MyControls.xml" p:id="60" p:posx="225" p:posy="150" p:color="white">MyControl1</include>
```
