### PR TITLE
Delete sound in CActiveAE::DiscardSound

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1369,6 +1369,7 @@ void CActiveAE::DiscardSound(CActiveAESound *sound)
     if ((*it) == sound)
     {
       m_sounds.erase(it);
+      delete sound;
       return;
     }
   }


### PR DESCRIPTION
In pull request #4491, I added the useCached arg to xbmc.playSFX() which when set to false would cause the cached sound to be freed and the same filename loaded again. One assumption that I made was that CAEFactory::FreeSound() actually freed the sound. On further testing this has turned out not to be the case, and using playSFX() in this manner exposes a memory leak. I looked closer and found that FreeSound() ultimately causes a call to CActiveAE::DiscardSound() and while the sound is removed from a map of sounds I couldn't find anywhere where the sound was deleted. This adds that.

While this seems to me like it should be there regardless and greatly reduces the memory leak (by about a factor of 8) there still seems to be a leak. I can't seem to figure out why.

Below is a link to a small testing addon which demonstrates the leak.

http://2ndmind.com/xbmc/test/script.ruuk.testing-0.0.8.zip
