### PR TITLE
Optimize ttf font atlas for Open GL

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -138,7 +138,6 @@ CGUIFontTTFBase::CGUIFontTTFBase(const CStdString& strFileName)
   m_maxChars = 0;
   m_nestedBeginCount = 0;
 
-  m_bTextureLoaded = false;
   m_vertex_size   = 4*1024;
   m_vertex        = (SVertex*)malloc(m_vertex_size * sizeof(SVertex));
 

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -154,7 +154,6 @@ protected:
   float m_originX;
   float m_originY;
 
-  bool m_bTextureLoaded;
   unsigned int m_nTexture;
 
   SVertex* m_vertex;

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -44,6 +44,9 @@ using namespace std;
 CGUIFontTTFGL::CGUIFontTTFGL(const CStdString& strFileName)
 : CGUIFontTTFBase(strFileName)
 {
+  m_updateY1 = 0;
+  m_updateY2 = 0;
+  m_textureStatus = TEXTURE_VOID;
 }
 
 CGUIFontTTFGL::~CGUIFontTTFGL(void)
@@ -54,6 +57,14 @@ void CGUIFontTTFGL::Begin()
 {
   if (m_nestedBeginCount == 0 && m_texture != NULL)
   {
+    if (m_textureStatus == TEXTURE_REALLOCATED)
+    {
+      if (glIsTexture(m_nTexture))
+        g_TextureManager.ReleaseHwTexture(m_nTexture);
+      m_bTextureLoaded = false;
+      m_textureStatus = TEXTURE_VOID;
+    }
+    
     if (!m_bTextureLoaded)
     {
       // Have OpenGL generate a texture object handle for us
@@ -70,10 +81,22 @@ void CGUIFontTTFGL::Begin()
 
       // Set the texture image -- THIS WORKS, so the pixels must be wrong.
       glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, m_texture->GetWidth(), m_texture->GetHeight(), 0,
-                   GL_ALPHA, GL_UNSIGNED_BYTE, m_texture->GetPixels());
-
+                   GL_ALPHA, GL_UNSIGNED_BYTE, 0);
+      
       VerifyGLState();
+      m_textureStatus = TEXTURE_UPDATED;
       m_bTextureLoaded = true;
+    }
+
+    if (m_textureStatus == TEXTURE_UPDATED)
+    {
+      glBindTexture(GL_TEXTURE_2D, m_nTexture);
+      glTexSubImage2D(GL_TEXTURE_2D, 0, 0, m_updateY1, m_texture->GetWidth(), m_updateY2 - m_updateY1, GL_ALPHA, GL_UNSIGNED_BYTE,
+                      m_texture->GetPixels() + m_updateY1 * m_texture->GetPitch());
+      glDisable(GL_TEXTURE_2D);
+        
+      m_updateY1 = m_updateY2 = 0;
+      m_textureStatus = TEXTURE_READY;
     }
 
     // Turn Blending On
@@ -216,6 +239,9 @@ CBaseTexture* CGUIFontTTFGL::ReallocTexture(unsigned int& newHeight)
   memset(newTexture->GetPixels(), 0, m_textureHeight * newTexture->GetPitch());
   if (m_texture)
   {
+    m_updateY1 = 0;
+    m_updateY2 = m_texture->GetHeight();
+
     unsigned char* src = (unsigned char*) m_texture->GetPixels();
     unsigned char* dst = (unsigned char*) newTexture->GetPixels();
     for (unsigned int y = 0; y < m_texture->GetHeight(); y++)
@@ -226,6 +252,8 @@ CBaseTexture* CGUIFontTTFGL::ReallocTexture(unsigned int& newHeight)
     }
     delete m_texture;
   }
+
+  m_textureStatus = TEXTURE_REALLOCATED;
 
   return newTexture;
 }
@@ -243,18 +271,35 @@ bool CGUIFontTTFGL::CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, 
     source += bitmap.width;
     target += m_texture->GetPitch();
   }
-  // THE SOURCE VALUES ARE THE SAME IN BOTH SITUATIONS.
-
-  // Since we have a new texture, we need to delete the old one
-  // the Begin(); End(); stuff is handled by whoever called us
-  if (m_bTextureLoaded)
+  
+  switch (m_textureStatus)
   {
-    g_graphicsContext.BeginPaint();  //FIXME
-    DeleteHardwareTexture();
-    g_graphicsContext.EndPaint();
-    m_bTextureLoaded = false;
-  }
+  case TEXTURE_UPDATED:
+    {
+      m_updateY1 = std::min(m_updateY1, y1);
+      m_updateY2 = std::max(m_updateY2, y2);
+    }
+    break;
+      
+  case TEXTURE_READY:
+    {
+      m_updateY1 = y1;
+      m_updateY2 = y2;
+      m_textureStatus = TEXTURE_UPDATED;
+    }
+    break;
+      
+  case TEXTURE_REALLOCATED:
+    {
+      m_updateY2 = std::max(m_updateY2, y2);
+    }
+    break;
 
+  case TEXTURE_VOID:
+  default:
+    break;
+  }
+  
   return TRUE;
 }
 
@@ -267,6 +312,9 @@ void CGUIFontTTFGL::DeleteHardwareTexture()
       g_TextureManager.ReleaseHwTexture(m_nTexture);
     m_bTextureLoaded = false;
   }
+
+  m_textureStatus = TEXTURE_VOID;
+  m_updateY1 = m_updateY2 = 0;
 }
 
 #endif

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -61,11 +61,10 @@ void CGUIFontTTFGL::Begin()
     {
       if (glIsTexture(m_nTexture))
         g_TextureManager.ReleaseHwTexture(m_nTexture);
-      m_bTextureLoaded = false;
       m_textureStatus = TEXTURE_VOID;
     }
     
-    if (!m_bTextureLoaded)
+    if (m_textureStatus == TEXTURE_VOID)
     {
       // Have OpenGL generate a texture object handle for us
       glGenTextures(1, (GLuint*) &m_nTexture);
@@ -85,7 +84,6 @@ void CGUIFontTTFGL::Begin()
       
       VerifyGLState();
       m_textureStatus = TEXTURE_UPDATED;
-      m_bTextureLoaded = true;
     }
 
     if (m_textureStatus == TEXTURE_UPDATED)
@@ -306,15 +304,14 @@ bool CGUIFontTTFGL::CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, 
 
 void CGUIFontTTFGL::DeleteHardwareTexture()
 {
-  if (m_bTextureLoaded)
+  if (m_textureStatus != TEXTURE_VOID)
   {
     if (glIsTexture(m_nTexture))
       g_TextureManager.ReleaseHwTexture(m_nTexture);
-    m_bTextureLoaded = false;
-  }
 
-  m_textureStatus = TEXTURE_VOID;
-  m_updateY1 = m_updateY2 = 0;
+    m_textureStatus = TEXTURE_VOID;
+    m_updateY1 = m_updateY2 = 0;
+  }
 }
 
 #endif

--- a/xbmc/guilib/GUIFontTTFGL.h
+++ b/xbmc/guilib/GUIFontTTFGL.h
@@ -48,7 +48,20 @@ protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);
   virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2);
   virtual void DeleteHardwareTexture();
-
+    
+private:
+  unsigned int m_updateY1;
+  unsigned int m_updateY2;
+  
+  enum TextureStatus
+  {
+    TEXTURE_VOID = 0,
+    TEXTURE_READY,
+    TEXTURE_REALLOCATED,
+    TEXTURE_UPDATED,
+  };
+  
+  TextureStatus m_textureStatus;
 };
 
 #endif


### PR DESCRIPTION
Removed generating new texture repeatedly during character cache.
Copy valid region only from old texture after ReallocTexture().
As a result, reduced stuttering video playback with subtitle.
