### PR TITLE
Collect subtitles at the same time to prevent overlap

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -25,6 +25,7 @@
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySpu.h"
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySSA.h"
+#include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayText.h"
 #include "cores/VideoRenderers/RenderManager.h"
 #include "guilib/GraphicContext.h"
 #include "Application.h"
@@ -172,6 +173,7 @@ void CRenderer::Render(int idx)
 
   Release(m_cleanup);
 
+  std::vector<COverlay*> render;
   SElementV& list = m_buffers[idx];
   for(SElementV::iterator it = list.begin(); it != list.end(); ++it)
   {
@@ -184,14 +186,37 @@ void CRenderer::Render(int idx)
 
     if(!o)
       continue;
+ 
+    render.push_back(o);
+  }
 
-    Render(o);
+  float total_height = 0.0f;
+  for (std::vector<COverlay*>::iterator it = render.begin(); it != render.end(); ++it)
+  {
+    COverlay* o = *it;
+    o->PrepareRender();
+    if (o->m_align == COverlay::ALIGN_SUBTITLE)
+      total_height += o->m_height;
+  }
+
+  for (std::vector<COverlay*>::iterator it = render.begin(); it != render.end(); ++it)
+  {
+    COverlay* o = *it;
+
+    float adjust_height = 0.0f;
+    if (o->m_align == COverlay::ALIGN_SUBTITLE)
+    {
+      total_height -= o->m_height;
+      adjust_height = -total_height;
+    }
+
+    Render(o, adjust_height);
 
     o->Release();
   }
 }
 
-void CRenderer::Render(COverlay* o)
+void CRenderer::Render(COverlay* o, float adjust_height)
 {
   CRect rs, rd, rv;
   RESOLUTION_INFO res;
@@ -276,6 +301,7 @@ void CRenderer::Render(COverlay* o)
   }
 
   state.x += GetStereoscopicDepth();
+  state.y += adjust_height;
 
   o->Render(state);
 }

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.h
@@ -50,6 +50,7 @@ namespace OVERLAY {
     virtual COverlay* Acquire();
     virtual long      Release();
     virtual void      Render(SRenderState& state) = 0;
+    virtual void      PrepareRender() {};
 
     enum EType
     { TYPE_NONE
@@ -118,7 +119,7 @@ namespace OVERLAY {
     typedef std::vector<COverlay*>  COverlayV;
     typedef std::vector<SElement>   SElementV;
 
-    void      Render(COverlay* o);
+    void      Render(COverlay* o, float adjust_height);
     COverlay* Convert(CDVDOverlay* o, double pts);
     COverlay* Convert(CDVDOverlaySSA* o, double pts);
 

--- a/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
@@ -147,6 +147,14 @@ COverlayText::~COverlayText()
   delete m_layout;
 }
 
+void COverlayText::PrepareRender()
+{
+  RESOLUTION_INFO res = g_graphicsContext.GetResInfo();
+  float width_max = (float)res.Overscan.right - res.Overscan.left;
+  m_layout->Update(m_text, width_max * 0.9f, false, true); // true to force LTR reading order (most Hebrew subs are this format)
+  m_layout->GetTextExtent(m_width, m_height);
+}
+
 void COverlayText::Render(OVERLAY::SRenderState &state)
 {
   if(m_layout == NULL)
@@ -172,18 +180,15 @@ void COverlayText::Render(OVERLAY::SRenderState &state)
   g_graphicsContext.SetTransform(mat, 1.0f, 1.0f);
 
   float width_max = (float) res.Overscan.right - res.Overscan.left;
-  float width, height;
-  m_layout->Update(m_text, width_max * 0.9f, false, true); // true to force LTR reading order (most Hebrew subs are this format)
-  m_layout->GetTextExtent(width, height);
 
   if (m_subalign == SUBTITLE_ALIGN_MANUAL
   ||  m_subalign == SUBTITLE_ALIGN_TOP_OUTSIDE
   ||  m_subalign == SUBTITLE_ALIGN_BOTTOM_INSIDE)
-    y -= height;
+    y -= m_height;
 
   // clamp inside screen
   y = std::max(y, (float) res.Overscan.top);
-  y = std::min(y, res.Overscan.bottom - height);
+  y = std::min(y, res.Overscan.bottom - m_height);
 
   m_layout->RenderOutline(x, y, 0, 0xFF000000, XBFONT_CENTER_X, width_max);
   g_graphicsContext.RemoveTransform();

--- a/xbmc/cores/VideoRenderers/OverlayRendererGUI.h
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGUI.h
@@ -45,6 +45,7 @@ public:
   COverlayText(CDVDOverlayText* src);
   virtual ~COverlayText();
   virtual void Render(SRenderState& state);
+  virtual void PrepareRender();
 
   CGUITextLayout* m_layout;
   std::string     m_text;


### PR DESCRIPTION
Subtitle overlap in video when the timings overlaps.

Before moving rendering subtitles to overlay renderer, CDVDOverlaySubtitle::GetCurrentSubtitle() function did it.
