### PR TITLE
Add keymap for Sony Playstation Dualshock 4 Controller.

### DIFF
--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -40,7 +40,6 @@
     <joystick name="Sony PLAYSTATION(R)3 Controller">
       <altname>PLAYSTATION(R)3 Controller</altname>
       <altname>PS3 Controller</altname>
-      <altname>Sony Computer Entertainment Wireless Controller</altname>
       <button id="15">Select</button>
       <button id="14">Back</button>
       <button id="16">FullScreen</button>

--- a/system/keymaps/joystick.Sony.Playstation.4.Controller.xml
+++ b/system/keymaps/joystick.Sony.Playstation.4.Controller.xml
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file contains the mapping of keys (gamepad, remote, and keyboard) to actions within XBMC -->
+<!-- The <global> section is a fall through - they will only be used if the button is not          -->
+<!-- used in the current window's section.  Note that there is only handling                       -->
+<!-- for a single action per button at this stage.                                                 -->
+<!-- For joystick/gamepad configuration under linux/win32, see below as it differs from xbox       -->
+<!-- gamepads.                                                                                     -->
+
+<!-- The format is:                      -->
+<!--    <device>                         -->
+<!--      <button>action</button>        -->
+<!--    </device>                        -->
+
+<!-- To map keys from other remotes using the RCA protocol, you may add <universalremote> blocks -->
+<!-- In this case, the tags used are <obc#> where # is the original button code (OBC) of the key -->
+<!-- You set it up by adding a <universalremote> block to the window or <global> section:       -->
+<!--    <universalremote>             -->
+<!--       <obc45>Stop</obc45>         -->
+<!--    </universalremote>            -->
+
+<!-- Note that the action can be a built-in function.                 -->
+<!--  eg <B>XBMC.ActivateWindow(MyMusic)</B>                         -->
+<!-- would automatically go to My Music on the press of the B button. -->
+
+<!-- Joysticks / Gamepads:                                                                    -->
+<!--   See the sample PS3 controller configuration below for the format.                      -->
+<!--                                                                                          -->
+<!--  Joystick Name:                                                                          -->
+<!--   Do 'cat /proc/bus/input/devices' or see your xbmc log file  to find the names of       -->
+<!--   detected joysticks. The name used in the configuration should match the detected name. -->
+<!--                                                                                          -->
+<!--  Button Ids:                                                                             -->
+<!--   'id' is the button ID used by SDL. Joystick button ids of connected joysticks appear   -->
+<!--   in xbmc.log when they are pressed. Use your log to map custom buttons to actions.      -->
+<!--                                                                                          -->
+<!--  Axis Ids / Analog Controls                                                              -->
+<!--   Coming soon.                                                                           -->
+
+<!-- Joystick Name: Sony PS4 Controller        -->
+<!-- Button Mappings:                          -->
+<!--                                           -->
+<!-- ID              Button                    -->
+<!--                                           -->
+<!-- 1               Square                    -->
+<!-- 2               Cross                     -->
+<!-- 3               Circle                    -->
+<!-- 4               Triangle                  -->
+<!-- 5               L1                        -->
+<!-- 6               R1                        -->
+<!-- 7               L2                        -->
+<!-- 8               R2                        -->
+<!-- 9               Share     (not used)      -->
+<!-- 10              Options   (not used)      -->
+<!-- 11              L3                        -->
+<!-- 12              R3                        -->
+<!-- 13              PS Button (not used)      -->
+
+<!-- Hat Mappings:                             -->
+<!--                                           -->
+<!-- ID              Button                    -->
+<!--                                           -->
+<!-- 1 up            D-Pad Up                  -->
+<!-- 1 down          D-Pad Down                -->
+<!-- 1 left          D-Pad Left                -->
+<!-- 1 right         D-Pad Right               -->
+
+<!-- Axis Mappings:                            -->
+<!--                                           -->
+<!-- ID              Button                    -->
+<!--                                           -->
+<!-- 1               Left Stick L/R            -->
+<!-- 2               Left Stick U/D            -->
+<!-- 3               Right Stick L/R           -->
+<!-- 4               Right Stick U/D           -->
+
+<keymap>
+  
+  <global>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="2">Select</button>
+      <button id="1">ContextMenu</button>
+      <button id="4">FullScreen</button>
+      <button id="3">Back</button>
+      <button id="5">Queue</button>
+      <button id="6">Playlist</button>
+      <button id="11">PreviousMenu</button>
+      <button id="12">XBMC.ActivateWindow(Home)</button>
+      <hat    id="1" position="left">Left</hat>
+      <hat    id="1" position="right">Right</hat>
+      <hat    id="1" position="up">Up</hat>
+      <hat    id="1" position="down">Down</hat>
+      <axis limit="+1" id="3">AnalogSeekForward</axis>
+      <axis limit="-1" id="3">AnalogSeekBack</axis>
+      <axis limit="-1" id="2">ScrollUp</axis>
+      <axis limit="+1" id="2">ScrollDown</axis>
+    </joystick>
+  </global>
+
+  <Home>
+  </Home>
+
+  <MyFiles>
+  </MyFiles>
+
+  <MyMusicPlaylist>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="5">Delete</button>
+    </joystick>
+  </MyMusicPlaylist>
+
+  <MyMusicFiles>
+  </MyMusicFiles>
+
+  <MyMusicLibrary>
+  </MyMusicLibrary>
+
+  <FullscreenVideo>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="2">Pause</button>
+      <button id="1">OSD</button>
+      <button id="3">Stop</button>
+      <button id="5">AspectRatio</button>
+      <button id="6">ShowSubtitles</button>
+      <button id="11">SmallStepBack</button>
+      <button id="12">Info</button>
+      <hat    id="1" position="left">StepBack</hat>
+      <hat    id="1" position="right">StepForward</hat>
+      <hat    id="1" position="up">BigStepForward</hat>
+      <hat    id="1" position="down">BigStepBack</hat>
+    </joystick>
+  </FullscreenVideo>
+
+  <FullscreenLiveTV>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <hat    id="1" position="up">ChannelUp</hat>
+      <hat    id="1" position="down">ChannelDown</hat>
+      <hat    id="1" position="left">PreviousChannelGroup</hat>
+      <hat    id="1" position="right">NextChannelGroup</hat>
+    </joystick>
+  </FullscreenLiveTV>
+
+  <FullscreenInfo>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="1">OSD</button>
+      <button id="3">Close</button>
+    </joystick>
+  </FullscreenInfo>
+
+  <PlayerControls>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </PlayerControls>
+
+  <Visualisation>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="2">Pause</button>
+      <button id="3">Stop</button>
+      <button id="1">XBMC.ActivateWindow(MusicOSD)</button>
+      <button id="12">Info</button>
+      <button id="6">SkipNext</button>
+      <button id="5">SkipPrevious</button>
+      <button id="7">PreviousPreset</button>
+      <button id="8">NextPreset</button>
+    </joystick>
+  </Visualisation>
+
+  <MusicOSD>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+      <button id="12">Info</button>
+    </joystick>
+  </MusicOSD>
+
+  <VisualisationSettings>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </VisualisationSettings>
+
+  <VisualisationPresetList>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </VisualisationPresetList>
+
+  <SlideShow>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="2">Pause</button>
+      <button id="3">Stop</button>
+      <button id="4">ZoomNormal</button>
+      <button id="5">Rotate</button>
+      <button id="6">CodecInfo</button>
+      <hat    id="1" position="left">PreviousPicture</hat>
+      <hat    id="1" position="right">NextPicture</hat>
+      <axis id="1">AnalogMove</axis>
+      <axis id="2">AnalogMove</axis>
+      <button id="7">ZoomOut</button>
+      <button id="8">ZoomIn</button>
+    </joystick>
+  </SlideShow>
+
+  <ScreenCalibration>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="2">ResetCalibration</button>
+      <button id="5">NextResolution</button>
+      <button id="6">NextCalibration</button>
+    </joystick>
+  </ScreenCalibration>
+
+  <GUICalibration>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="2">ResetCalibration</button>
+      <button id="5">NextResolution</button>
+      <button id="6">NextCalibration</button>
+    </joystick>
+  </GUICalibration>
+
+  <VideoOSD>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="2">Close</button>
+    </joystick>
+  </VideoOSD>
+
+  <VideoMenu>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Stop</button>
+      <button id="2">OSD</button>
+      <button id="5">AspectRatio</button>
+      <button id="12">Info</button>
+    </joystick>
+  </VideoMenu>
+
+  <OSDVideoSettings>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="5">AspectRatio</button>
+      <button id="2">Close</button>
+    </joystick>
+  </OSDVideoSettings>
+
+  <OSDAudioSettings>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="5">AspectRatio</button>
+      <button id="2">Close</button>
+    </joystick>
+  </OSDAudioSettings>
+
+  <VideoBookmarks>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="5">Delete</button>
+    </joystick>
+  </VideoBookmarks>
+
+  <MyVideoLibrary>
+  </MyVideoLibrary>
+
+  <MyVideoFiles>
+  </MyVideoFiles>
+
+  <MyVideoPlaylist>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="5">Delete</button>
+    </joystick>
+  </MyVideoPlaylist>
+
+  <VirtualKeyboard>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">BackSpace</button>
+      <button id="4">Symbols</button>
+      <button id="5">Shift</button>
+      <button id="11">Enter</button>
+      <button id="7">CursorLeft</button>
+      <button id="8">CursorRight</button>
+    </joystick>
+  </VirtualKeyboard>
+
+  <ContextMenu>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </ContextMenu>
+
+  <Scripts>
+  </Scripts>
+
+  <Settings>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">PreviousMenu</button>
+    </joystick>
+  </Settings>
+
+  <AddonInformation>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </AddonInformation>
+
+  <AddonSettings>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </AddonSettings>
+
+  <TextViewer>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </TextViewer>
+
+  <shutdownmenu>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">PreviousMenu</button>
+    </joystick>
+  </shutdownmenu>
+
+  <submenu>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">PreviousMenu</button>
+    </joystick>
+  </submenu>
+
+  <MusicInformation>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </MusicInformation>
+
+  <MovieInformation>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">Close</button>
+    </joystick>
+  </MovieInformation>
+
+  <NumericInput>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">BackSpace</button>
+      <button id="11">Enter</button>
+    </joystick>
+  </NumericInput>
+
+  <GamepadInput>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="11">Stop</button>
+    </joystick>
+  </GamepadInput>
+
+  <LockSettings>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">PreviousMenu</button>
+      <button id="11">Close</button>
+    </joystick>
+  </LockSettings>
+
+  <ProfileSettings>
+    <joystick name="Sony Computer Entertainment Wireless Controller">
+      <altname>Wireless Controller</altname>
+      <button id="3">PreviousMenu</button>
+      <button id="11">Close</button>
+    </joystick>
+  </ProfileSettings>
+
+</keymap>


### PR DESCRIPTION
Add keymap for Sony Playstation Dualshock 4 Controller.

cat /proc/bus/input/devices shows it as "Sony Computer Entertainment Wireless Controller"
This conflicts with the PS3 controller as it is named the same thing.

It is also show as "Wireless Controller" in OpenELEC

I am not quite sure what to do about this as the PS3 controller is labelled the same thing (or so I believe, I don't have a controller to test). So I have removed the duplicate name from the PS3 controller keymap for now.

Before anyone asks, The mappings are different. I have tried to use the PS3 keymap with the PS4 controller but it simply does not work as intended. You can see this from my added PS4 keymap.

I don't know if there is another way to detect names or not but I thought I would just PR this to see what others have to say.
