### PR TITLE
[AE/osxsink] refactor the device enumeration for the osx sink

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -1156,6 +1156,7 @@
 		C8D0B2AF1265A9A800F0C0AC /* SystemGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */; };
 		C8EC5D0E1369519D00CCC10D /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D0C1369519D00CCC10D /* XBMC_keytable.cpp */; };
 		DF00492D162DAEA200A971AD /* PVROperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF00492B162DAEA200A971AD /* PVROperations.cpp */; };
+		DF033D381946612400BFC82E /* AEDeviceEnumerationOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF033D361946612400BFC82E /* AEDeviceEnumerationOSX.cpp */; };
 		DF07252E168734D7008DCAAD /* karaokevideobackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF07252C168734D7008DCAAD /* karaokevideobackground.cpp */; };
 		DF072534168734ED008DCAAD /* FFmpegVideoDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF072532168734ED008DCAAD /* FFmpegVideoDecoder.cpp */; };
 		DF0ABB73183A94A30018445D /* Utf8Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0ABB71183A94A30018445D /* Utf8Utils.cpp */; };
@@ -4758,6 +4759,8 @@
 		C8EC5D0D1369519D00CCC10D /* XBMC_keytable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XBMC_keytable.h; sourceTree = "<group>"; };
 		DF00492B162DAEA200A971AD /* PVROperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVROperations.cpp; sourceTree = "<group>"; };
 		DF00492C162DAEA200A971AD /* PVROperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVROperations.h; sourceTree = "<group>"; };
+		DF033D361946612400BFC82E /* AEDeviceEnumerationOSX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AEDeviceEnumerationOSX.cpp; path = Sinks/osx/AEDeviceEnumerationOSX.cpp; sourceTree = "<group>"; };
+		DF033D371946612400BFC82E /* AEDeviceEnumerationOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AEDeviceEnumerationOSX.h; path = Sinks/osx/AEDeviceEnumerationOSX.h; sourceTree = "<group>"; };
 		DF07252C168734D7008DCAAD /* karaokevideobackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = karaokevideobackground.cpp; sourceTree = "<group>"; };
 		DF07252D168734D7008DCAAD /* karaokevideobackground.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = karaokevideobackground.h; sourceTree = "<group>"; };
 		DF072532168734ED008DCAAD /* FFmpegVideoDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FFmpegVideoDecoder.cpp; sourceTree = "<group>"; };
@@ -7422,6 +7425,8 @@
 		7C8AE7FE189DE3A700C33786 /* osx */ = {
 			isa = PBXGroup;
 			children = (
+				DF033D361946612400BFC82E /* AEDeviceEnumerationOSX.cpp */,
+				DF033D371946612400BFC82E /* AEDeviceEnumerationOSX.h */,
 				7C8AE849189DE3CD00C33786 /* CoreAudioChannelLayout.cpp */,
 				7C8AE844189DE3CD00C33786 /* CoreAudioChannelLayout.h */,
 				7C8AE84A189DE3CD00C33786 /* CoreAudioDevice.cpp */,
@@ -11846,6 +11851,7 @@
 				7CCDACC119275D790074CF51 /* NptAppleAutoreleasePool.mm in Sources */,
 				7CCDACCA19275D790074CF51 /* NptAppleLogConfig.mm in Sources */,
 				7CAA469019427AED00008885 /* PosixDirectory.cpp in Sources */,
+				DF033D381946612400BFC82E /* AEDeviceEnumerationOSX.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2402,6 +2402,9 @@
             <options>audiodevices</options>
           </constraints>
           <control type="list" format="string" />
+          <updates>
+            <update type="change" />
+          </updates>
         </setting>
         <setting id="audiooutput.channels" type="integer" label="34100" help="36362">
           <level>0</level>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1793,6 +1793,21 @@ bool CApplication::OnSettingUpdate(CSetting* &setting, const char *oldSettingId,
     usestagefright->SetValue(false);
   }
 #endif
+#if defined(TARGET_DARWIN_OSX)
+  else if (settingId == "audiooutput.audiodevice")
+  {
+    CSettingString *audioDevice = (CSettingString*)setting;
+    // Gotham and older didn't enumerate audio devices per stream on osx
+    // add stream0 per default which should be ok for all old settings.
+    if (!StringUtils::EqualsNoCase(audioDevice->GetValue(), "DARWINOSX:default") && 
+        StringUtils::FindWords(audioDevice->GetValue().c_str(), ":stream") == std::string::npos)
+    {
+      std::string newSetting = audioDevice->GetValue();
+      newSetting += ":stream0";
+      return audioDevice->SetValue(newSetting);
+    }
+  }
+#endif
 
   return false;
 }

--- a/xbmc/cores/AudioEngine/Makefile.in
+++ b/xbmc/cores/AudioEngine/Makefile.in
@@ -39,6 +39,7 @@ else ifeq ($(findstring ios,@ARCH@),ios)
 SRCS += Sinks/AESinkDARWINIOS.cpp
 else ifeq ($(findstring osx,@ARCH@),osx)
 SRCS += Sinks/AESinkDARWINOSX.cpp
+SRCS += Sinks/osx/AEDeviceEnumerationOSX.cpp
 SRCS += Sinks/osx/CoreAudioChannelLayout.cpp
 SRCS += Sinks/osx/CoreAudioDevice.cpp
 SRCS += Sinks/osx/CoreAudioHardware.cpp

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -20,250 +20,16 @@
 
 #include "cores/AudioEngine/AEFactory.h"
 #include "cores/AudioEngine/Sinks/AESinkDARWINOSX.h"
-#include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/AudioEngine/Utils/AERingBuffer.h"
 #include "cores/AudioEngine/Sinks/osx/CoreAudioHelpers.h"
 #include "cores/AudioEngine/Sinks/osx/CoreAudioHardware.h"
-#include "cores/AudioEngine/Sinks/osx/CoreAudioChannelLayout.h"
-#include "osx/DarwinUtils.h"
+#include "cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
-#include "threads/Condition.h"
-#include "threads/CriticalSection.h"
 #include "utils/TimeUtils.h"
-
-#include <sstream>
-
-#define CA_MAX_CHANNELS 16
-// default channel map - in case it can't be fetched from the device
-static enum AEChannel CAChannelMap[CA_MAX_CHANNELS + 1] = {
-  AE_CH_FL , AE_CH_FR , AE_CH_BL , AE_CH_BR , AE_CH_FC , AE_CH_LFE , AE_CH_SL , AE_CH_SR ,
-  AE_CH_UNKNOWN1 ,
-  AE_CH_UNKNOWN2 ,
-  AE_CH_UNKNOWN3 ,
-  AE_CH_UNKNOWN4 ,
-  AE_CH_UNKNOWN5 ,
-  AE_CH_UNKNOWN6 ,
-  AE_CH_UNKNOWN7 ,
-  AE_CH_UNKNOWN8 ,
-  AE_CH_NULL
-};
-
-// map coraudio channel labels to activeae channel labels
-static enum AEChannel CAChannelToAEChannel(AudioChannelLabel CAChannelLabel)
-{
-  enum AEChannel ret = AE_CH_NULL;
-  static unsigned int unknownChannel = AE_CH_UNKNOWN1;
-  switch(CAChannelLabel)
-  {
-    case kAudioChannelLabel_Left:
-      ret = AE_CH_FL;
-      break;
-    case kAudioChannelLabel_Right:
-      ret = AE_CH_FR;
-      break;
-    case kAudioChannelLabel_Center:
-      ret = AE_CH_FC;
-      break;
-    case kAudioChannelLabel_LFEScreen:
-      ret = AE_CH_LFE;
-      break;
-    case kAudioChannelLabel_LeftSurroundDirect:
-      ret = AE_CH_SL;
-      break;
-    case kAudioChannelLabel_RightSurroundDirect:
-      ret = AE_CH_SR;
-      break;
-    case kAudioChannelLabel_LeftCenter:
-      ret = AE_CH_FLOC;
-      break;
-    case kAudioChannelLabel_RightCenter:
-      ret = AE_CH_FROC;
-      break;
-    case kAudioChannelLabel_CenterSurround:
-      ret = AE_CH_TC;
-      break;
-    case kAudioChannelLabel_LeftSurround:
-      ret = AE_CH_SL;
-      break;
-    case kAudioChannelLabel_RightSurround:
-      ret = AE_CH_SR;
-      break;
-    case kAudioChannelLabel_VerticalHeightLeft:
-      ret = AE_CH_TFL;
-      break;
-    case kAudioChannelLabel_VerticalHeightRight:
-      ret = AE_CH_TFR;
-      break;
-    case kAudioChannelLabel_VerticalHeightCenter:
-      ret = AE_CH_TFC;
-      break;
-    case kAudioChannelLabel_TopCenterSurround:
-      ret = AE_CH_TC;
-      break;
-    case kAudioChannelLabel_TopBackLeft:
-      ret = AE_CH_TBL;
-      break;
-    case kAudioChannelLabel_TopBackRight:
-      ret = AE_CH_TBR;
-      break;
-    case kAudioChannelLabel_TopBackCenter:
-      ret = AE_CH_TBC;
-      break;
-    case kAudioChannelLabel_RearSurroundLeft:
-      ret = AE_CH_BL;
-      break;
-    case kAudioChannelLabel_RearSurroundRight:
-      ret = AE_CH_BR;
-      break;
-    case kAudioChannelLabel_LeftWide:
-      ret = AE_CH_BLOC;
-      break;
-    case kAudioChannelLabel_RightWide:
-      ret = AE_CH_BROC;
-      break;
-    case kAudioChannelLabel_LFE2:
-      ret = AE_CH_LFE;
-      break;
-    case kAudioChannelLabel_LeftTotal:
-      ret = AE_CH_FL;
-      break;
-    case kAudioChannelLabel_RightTotal:
-      ret = AE_CH_FR;
-      break;
-    case kAudioChannelLabel_HearingImpaired:
-      ret = AE_CH_FC;
-      break;
-    case kAudioChannelLabel_Narration:
-      ret = AE_CH_FC;
-      break;
-    case kAudioChannelLabel_Mono:
-      ret = AE_CH_FC;
-      break;
-    case kAudioChannelLabel_DialogCentricMix:
-      ret = AE_CH_FC;
-      break;
-    case kAudioChannelLabel_CenterSurroundDirect:
-      ret = AE_CH_TC;
-      break;
-    case kAudioChannelLabel_Haptic:
-      ret = AE_CH_FC;
-      break;
-    default:
-      ret = (enum AEChannel)unknownChannel++;
-  }
-  if (unknownChannel > AE_CH_UNKNOWN8)
-    unknownChannel = AE_CH_UNKNOWN1;
-    
-  return ret;
-}
-
-//Note: in multichannel mode CA will either pull 2 channels of data (stereo) or 6/8 channels of data
-//(every speaker setup with more then 2 speakers). The difference between the number of real speakers
-//and 6/8 channels needs to be padded with unknown channels so that the sample size fits 6/8 channels
-//
-//device [in] - the device whose channel layout should be used
-//channelMap [in/out] - if filled it will it indicates that we are called from initialize and we log the requested map, out returns the channelMap for device
-//channelsPerFrame [in] - the number of channels this device is configured to (e.x. 2 or 6/8)
-static void GetAEChannelMap(CCoreAudioDevice &device, CAEChannelInfo &channelMap, unsigned int channelsPerFrame)
-{
-  CCoreAudioChannelLayout calayout;
-  bool logMapping = channelMap.Count() > 0; // only log if the engine requests a layout during init
-  bool mapAvailable = false;
-  unsigned int numberChannelsInDeviceLayout = CA_MAX_CHANNELS; // default 8 channels from CAChannelMap
-  AudioChannelLayout *layout = NULL;
-
-  // try to fetch either the multichannel or the stereo channel layout from the device
-  if (channelsPerFrame == 2 || channelMap.Count() == 2)
-    mapAvailable = device.GetPreferredChannelLayoutForStereo(calayout);
-  else
-    mapAvailable = device.GetPreferredChannelLayout(calayout);
-
-  // if a map was fetched - check if it is usable
-  if (mapAvailable)
-  {
-    layout = calayout;
-    if (layout == NULL || layout->mChannelLayoutTag != kAudioChannelLayoutTag_UseChannelDescriptions)
-      mapAvailable = false;// wrong map format
-    else
-      numberChannelsInDeviceLayout = layout->mNumberChannelDescriptions;
-  }
-
-  // start the mapping action
-  // the number of channels to be added to the outgoing channelmap
-  // this is CA_MAX_CHANNELS at max and might be lower for some output devices (channelsPerFrame)
-  unsigned int numChannelsToMap = std::min((unsigned int)CA_MAX_CHANNELS, (unsigned int)channelsPerFrame);
-
-  // if there was a map fetched we force the number of
-  // channels to map to channelsPerFrame (this allows mapping
-  // of more then CA_MAX_CHANNELS if needed)
-  if (mapAvailable)
-    numChannelsToMap = channelsPerFrame;
-
-  std::string layoutStr;
-
-  if (logMapping)
-  {
-    CLog::Log(LOGDEBUG, "%s Engine requests layout %s", __FUNCTION__, ((std::string)channelMap).c_str());
-
-    if (mapAvailable)
-      CLog::Log(LOGDEBUG, "%s trying to map to %s layout: %s", __FUNCTION__, channelsPerFrame == 2 ? "stereo" : "multichannel", calayout.ChannelLayoutToString(*layout, layoutStr));
-    else
-      CLog::Log(LOGDEBUG, "%s no map available - using static multichannel map layout", __FUNCTION__);
-  }
-    
-  channelMap.Reset();// start with an empty map
-
-  for (unsigned int channel = 0; channel < numChannelsToMap; channel++)
-  {
-    // we only try to map channels which are defined in the device layout
-    enum AEChannel currentChannel;
-    if (channel < numberChannelsInDeviceLayout)
-    {
-      // get the channel from the fetched map
-      if (mapAvailable)
-        currentChannel = CAChannelToAEChannel(layout->mChannelDescriptions[channel].mChannelLabel);
-      else// get the channel from the default map
-        currentChannel = CAChannelMap[channel];
-
-    }
-    else// fill with unknown channels
-      currentChannel = CAChannelToAEChannel(kAudioChannelLabel_Unknown);
-
-    if(!channelMap.HasChannel(currentChannel))// only add if not already added
-      channelMap += currentChannel;
-  }
-
-  if (logMapping)
-    CLog::Log(LOGDEBUG, "%s mapped channels to layout %s", __FUNCTION__, ((std::string)channelMap).c_str());
-}
-
-static bool HasSampleRate(const AESampleRateList &list, const unsigned int samplerate)
-{
-  for (size_t i = 0; i < list.size(); ++i)
-  {
-    if (list[i] == samplerate)
-      return true;
-  }
-  return false;
-}
-
-static bool HasDataFormat(const AEDataFormatList &list, const enum AEDataFormat format)
-{
-  for (size_t i = 0; i < list.size(); ++i)
-  {
-    if (list[i] == format)
-      return true;
-  }
-  return false;
-}
-
-typedef std::vector< std::pair<AudioDeviceID, CAEDeviceInfo> > CADeviceList;
 
 static void EnumerateDevices(CADeviceList &list)
 {
-  CAEDeviceInfo device;
-
   std::string defaultDeviceName;
   CCoreAudioHardware::GetOutputDeviceName(defaultDeviceName);
 
@@ -272,200 +38,26 @@ static void EnumerateDevices(CADeviceList &list)
   while (!deviceIDList.empty())
   {
     AudioDeviceID deviceID = deviceIDList.front();
-    CCoreAudioDevice caDevice(deviceID);
 
-    device.m_channels.Reset();
-    device.m_dataFormats.clear();
-    device.m_sampleRates.clear();
+    AEDeviceEnumerationOSX devEnum(deviceID);
+    CADeviceList listForDevice = devEnum.GetDeviceInfoList();
+    for (UInt32 devIdx = 0; devIdx < listForDevice.size(); devIdx++)
+      list.push_back(listForDevice[devIdx]);
 
-    device.m_deviceType = AE_DEVTYPE_PCM;
-    device.m_deviceName = caDevice.GetName();
-    device.m_displayName = device.m_deviceName;
-    device.m_displayNameExtra = "";
-
-    // flag indicating that passthroughformats where added throughout the stream enumeration
-    bool hasPassthroughFormats = false;
-    // the maximum number of channels found in the streams
-    UInt32 numMaxChannels = 0;
-    // the terminal type as reported by ca
-    UInt32 caTerminalType = 0;
-      
-    bool isDigital = caDevice.IsDigital(caTerminalType);
-
-
-    CLog::Log(LOGDEBUG, "EnumerateDevices:Device(%s)" , device.m_deviceName.c_str());
-    AudioStreamIdList streams;
-    if (caDevice.GetStreams(&streams))
-    {
-      for (AudioStreamIdList::iterator j = streams.begin(); j != streams.end(); ++j)
-      {
-        StreamFormatList streamFormats;
-        if (CCoreAudioStream::GetAvailablePhysicalFormats(*j, &streamFormats))
-        {
-          for (StreamFormatList::iterator i = streamFormats.begin(); i != streamFormats.end(); ++i)
-          {
-            AudioStreamBasicDescription desc = i->mFormat;
-            std::string formatString;
-            CLog::Log(LOGDEBUG, "EnumerateDevices:Format(%s)" ,
-                                StreamDescriptionToString(desc, formatString));
-
-            // add stream format info
-            switch (desc.mFormatID)
-            {
-              case kAudioFormatAC3:
-              case kAudioFormat60958AC3:
-                if (!HasDataFormat(device.m_dataFormats, AE_FMT_AC3))
-                  device.m_dataFormats.push_back(AE_FMT_AC3);
-                if (!HasDataFormat(device.m_dataFormats, AE_FMT_DTS))
-                  device.m_dataFormats.push_back(AE_FMT_DTS);
-                hasPassthroughFormats = true;
-                isDigital = true;// sanity - those are always digital devices!
-                break;
-              default:
-                AEDataFormat format = AE_FMT_INVALID;
-                switch(desc.mBitsPerChannel)
-                {
-                  case 16:
-                    if (desc.mFormatFlags & kAudioFormatFlagIsBigEndian)
-                      format = AE_FMT_S16BE;
-                    else
-                    {
-                      // if it is no digital stream per definition
-                      // check if the device name suggests that it is digital
-                      // (some hackintonshs are not so smart in announcing correct
-                      // ca devices ...
-                      if (!isDigital)
-                      {
-                        std::string devNameLower = device.m_deviceName;
-                        StringUtils::ToLower(devNameLower);                       
-                        isDigital = devNameLower.find("digital") != std::string::npos;
-                      }
-
-                      /* Passthrough is possible with a 2ch digital output */
-                      if (desc.mChannelsPerFrame == 2 && isDigital)
-                      {
-                        if (desc.mSampleRate == 48000)
-                        {
-                          if (!HasDataFormat(device.m_dataFormats, AE_FMT_AC3))
-                            device.m_dataFormats.push_back(AE_FMT_AC3);
-                          if (!HasDataFormat(device.m_dataFormats, AE_FMT_DTS))
-                            device.m_dataFormats.push_back(AE_FMT_DTS);
-                          hasPassthroughFormats = true;
-                        }
-                        else if (desc.mSampleRate == 192000)
-                        {
-                          if (!HasDataFormat(device.m_dataFormats, AE_FMT_EAC3))
-                            device.m_dataFormats.push_back(AE_FMT_EAC3);
-                          hasPassthroughFormats = true;
-                        }
-                      }
-                      format = AE_FMT_S16LE;
-                    }
-                    break;
-                  case 24:
-                    if (desc.mFormatFlags & kAudioFormatFlagIsBigEndian)
-                      format = AE_FMT_S24BE3;
-                    else
-                      format = AE_FMT_S24LE3;
-                    break;
-                  case 32:
-                    if (desc.mFormatFlags & kAudioFormatFlagIsFloat)
-                      format = AE_FMT_FLOAT;
-                    else
-                    {
-                      if (desc.mFormatFlags & kAudioFormatFlagIsBigEndian)
-                        format = AE_FMT_S32BE;
-                      else
-                        format = AE_FMT_S32LE;
-                    }
-                    break;
-                }
-                
-                if (numMaxChannels < desc.mChannelsPerFrame)
-                  numMaxChannels = desc.mChannelsPerFrame;
-                
-                if (format != AE_FMT_INVALID && !HasDataFormat(device.m_dataFormats, format))
-                  device.m_dataFormats.push_back(format);
-                break;
-            }
-
-            // add sample rate info
-            // for devices which return kAudioStreamAnyRatee
-            // we add 44.1khz and 48khz - user can use
-            // the "fixed" audio config to force one of them
-            if (desc.mSampleRate == kAudioStreamAnyRate)
-            {
-              CLog::Log(LOGINFO, "%s reported samplerate is kAudioStreamAnyRate adding 44.1khz and 48khz", __FUNCTION__);
-              desc.mSampleRate = 44100;
-              if (!HasSampleRate(device.m_sampleRates, desc.mSampleRate))
-                device.m_sampleRates.push_back(desc.mSampleRate);
-              desc.mSampleRate = 48000;
-            }
-
-            if (!HasSampleRate(device.m_sampleRates, desc.mSampleRate))
-              device.m_sampleRates.push_back(desc.mSampleRate);
-          }
-        }
-      }
-    }
-
-    
-    // flag indicating that the device name "sounds" like HDMI
-    bool hasHdmiName = device.m_deviceName.find("HDMI") != std::string::npos;
-    // flag indicating that the device name "sounds" like DisplayPort
-    bool hasDisplayPortName = device.m_deviceName.find("DisplayPort") != std::string::npos;
-    
-    // decide the type of the device based on the discovered information
-    // in the streams
-    // device defaults to PCM (see start of the while loop)
-    // it can be HDMI, DisplayPort or Optical
-    // for all of those types it needs to support
-    // passthroughformats and needs to be a digital port
-    if (hasPassthroughFormats && isDigital)
-    {
-      // if the max number of channels was more then 2
-      // this can be HDMI or DisplayPort or Thunderbolt
-      if (numMaxChannels > 2)
-      {
-        // either the devicename suggests its HDMI
-        // or CA reported the terminalType as HDMI
-        if (hasHdmiName || caTerminalType == kIOAudioDeviceTransportTypeHdmi)
-          device.m_deviceType = AE_DEVTYPE_HDMI;
-
-        // either the devicename suggests its DisplayPort
-        // or CA reported the terminalType as DisplayPort or Thunderbolt
-        if (hasDisplayPortName || caTerminalType == kIOAudioDeviceTransportTypeDisplayPort || caTerminalType == kIOAudioDeviceTransportTypeThunderbolt)
-          device.m_deviceType = AE_DEVTYPE_DP;
-      }
-      else// treat all other digital passthrough devices as optical
-        device.m_deviceType = AE_DEVTYPE_IEC958;
-
-      //treat all other digital devices as HDMI to let options open to the user
-      if (device.m_deviceType == AE_DEVTYPE_PCM)
-        device.m_deviceType = AE_DEVTYPE_HDMI;
-    }
-
-    // devicename based overwrites from former code - maybe FIXME at some point when we
-    // are sure that the upper detection does its job in all[tm] use cases
-    if (hasHdmiName)
-      device.m_deviceType = AE_DEVTYPE_HDMI;
-    if (hasDisplayPortName)
-      device.m_deviceType = AE_DEVTYPE_DP;
-      
-    //get channel map to match the devices channel layout as set in audio-midi-setup
-    GetAEChannelMap(caDevice, device.m_channels, caDevice.GetTotalOutputChannels());
-    
-    list.push_back(std::make_pair(deviceID, device));
     //in the first place of the list add the default device
     //with name "default" - if this is selected
     //we will output to whatever osx claims to be default
     //(allows transition from headphones to speaker and stuff
-    //like that
-    if(defaultDeviceName == device.m_deviceName)
+    //like that)
+    //fixme taking the first stream device is wrong here
+    //we rather might need the concatination of all streams *sucks*
+    if(defaultDeviceName == devEnum.GetMasterDeviceName())
     {
-      device.m_deviceName = "default";
-      device.m_displayName = "Default";
-      list.insert(list.begin(), std::make_pair(deviceID, device));
+      CAEDeviceInfo firstDevice = listForDevice.front().second;
+      firstDevice.m_deviceName = "default";
+      firstDevice.m_displayName = "Default";
+      firstDevice.m_displayNameExtra = "";
+      list.insert(list.begin(), std::make_pair(deviceID, firstDevice));
     }
 
     deviceIDList.pop_front();
@@ -600,80 +192,6 @@ CAESinkDARWINOSX::~CAESinkDARWINOSX()
   RegisterDeviceChangedCB(false, this);
 }
 
-float scoreSampleRate(Float64 destinationRate, unsigned int sourceRate)
-{
-  float score = 0;
-  double intPortion;
-  double fracPortion = modf(destinationRate / sourceRate, &intPortion);
-
-  score += (1 - fracPortion) * 1000;      // prefer sample rates that are multiples of the source sample rate
-  score += (intPortion == 1.0) ? 500 : 0;   // prefer exact matches over other multiples
-  score += (intPortion > 1 && intPortion < 100) ? (100 - intPortion) / 100 * 100 : 0; // prefer smaller multiples otherwise
-
-  return score;
-}
-
-float ScoreStream(const AudioStreamBasicDescription &desc, const AEAudioFormat &format)
-{
-  float score = 0;
-  if (format.m_dataFormat == AE_FMT_AC3 ||
-      format.m_dataFormat == AE_FMT_DTS)
-  {
-    if (desc.mFormatID == kAudioFormat60958AC3 ||
-        desc.mFormatID == 'IAC3' ||
-        desc.mFormatID == kAudioFormatAC3)
-    {
-      if (desc.mSampleRate == format.m_sampleRate &&
-          desc.mBitsPerChannel == CAEUtil::DataFormatToBits(format.m_dataFormat) &&
-          desc.mChannelsPerFrame == format.m_channelLayout.Count())
-      {
-        // perfect match
-        score = FLT_MAX;
-      }
-    }
-  }
-  if (format.m_dataFormat == AE_FMT_AC3 ||
-      format.m_dataFormat == AE_FMT_DTS ||
-      format.m_dataFormat == AE_FMT_EAC3)
-  { // we should be able to bistreaming in PCM if the samplerate, bitdepth and channels match
-    if (desc.mSampleRate       == format.m_sampleRate                            &&
-        desc.mBitsPerChannel   == CAEUtil::DataFormatToBits(format.m_dataFormat) &&
-        desc.mChannelsPerFrame == format.m_channelLayout.Count()                 &&
-        desc.mFormatID         == kAudioFormatLinearPCM)
-    {
-      score = FLT_MAX / 2;
-    }
-  }
-  else
-  { // non-passthrough, whatever works is fine
-    if (desc.mFormatID == kAudioFormatLinearPCM)
-    {
-      score += scoreSampleRate(desc.mSampleRate, format.m_sampleRate);
-
-      if (desc.mChannelsPerFrame == format.m_channelLayout.Count())
-        score += 5;
-      else if (desc.mChannelsPerFrame > format.m_channelLayout.Count())
-        score += 1;
-
-      //if we get float, regardless of planar or not, prefer the highest bitdepth.
-      //For streams that are non-planar we let AE know in Initialize()
-      if (format.m_dataFormat == AE_FMT_FLOAT || format.m_dataFormat == AE_FMT_FLOATP)
-      { // for float, prefer the highest bitdepth we have
-        if (desc.mBitsPerChannel >= 16)
-          score += (desc.mBitsPerChannel / 8);
-      }
-      else
-      {
-        if (desc.mBitsPerChannel == CAEUtil::DataFormatToBits(format.m_dataFormat))
-          score += 5;
-        else if (desc.mBitsPerChannel == CAEUtil::DataFormatToBits(format.m_dataFormat))
-          score += 1;
-      }
-    }
-  }
-  return score;
-}
-
 bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
 {
   AudioDeviceID deviceID = 0;
@@ -702,75 +220,30 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
     return false;
   }
 
-  m_device.Open(deviceID);
-
-  // Fetch a list of the streams defined by the output device
-  AudioStreamIdList streams;
-  m_device.GetStreams(&streams);
-
-  CLog::Log(LOGDEBUG, "%s: Finding stream for format %s", __FUNCTION__, CAEUtil::DataFormatToStr(format.m_dataFormat));
-
-  bool                        passthrough  = false;
-  UInt32                      outputIndex  = 0;
-  UInt32                      numOutputChannels = 0;
-  float                       outputScore  = 0;
-  AudioStreamBasicDescription outputFormat = {0};
-  AudioStreamID               outputStream = 0;
-
-  /* The theory is to score based on
-   1. Matching passthrough characteristics (i.e. passthrough flag)
-   2. Matching sample rate.
-   3. Matching bits per channel (or higher).
-   4. Matching number of channels (or higher).
-   */
-  UInt32 index = 0;
-  for (AudioStreamIdList::const_iterator i = streams.begin(); i != streams.end(); ++i)
-  {
-    // Probe physical formats
-    StreamFormatList formats;
-    CCoreAudioStream::GetAvailablePhysicalFormats(*i, &formats);
-    for (StreamFormatList::const_iterator j = formats.begin(); j != formats.end(); ++j)
-    {
-      AudioStreamBasicDescription desc = j->mFormat;
-
-      // for devices with kAudioStreamAnyRate
-      // assume that the user uses a fixed config
-      // and knows what he is doing - so we use
-      // the requested samplerate here
-      if (desc.mSampleRate == kAudioStreamAnyRate)
-        desc.mSampleRate = format.m_sampleRate;
-
-      float score = ScoreStream(desc, format);
-
-      std::string formatString;
-      CLog::Log(LOGDEBUG, "%s: Physical Format: %s rated %f", __FUNCTION__, StreamDescriptionToString(desc, formatString), score);
-
-      if (score > outputScore)
-      {
-        passthrough  = score > 10000;
-        outputScore  = score;
-        outputFormat = desc;
-        outputStream = *i;
-        outputIndex  = index;
-      }
-    }
-    index++;
-  }
-
+  AEDeviceEnumerationOSX devEnum(deviceID);
+  AudioStreamBasicDescription outputFormat = { 0 };
+  AudioStreamID outputStream = 0;
+  UInt32 streamIdx = 0;
+  UInt32 numOutputChannels = 0;
+  bool passthrough = false;
   m_planes = 1;
-  numOutputChannels = outputFormat.mChannelsPerFrame;
-  if (streams.size() > 1 && outputFormat.mChannelsPerFrame == 1)
+  if (devEnum.FindSuitableFormatForStream(streamIdx, format, outputFormat, passthrough, outputStream))
   {
-    numOutputChannels = std::min((size_t)format.m_channelLayout.Count(), streams.size());
-    m_planes = numOutputChannels;
-    CLog::Log(LOGDEBUG, "%s Found planar audio with %u channels using %u of them.", __FUNCTION__, (unsigned int)streams.size(), (unsigned int)numOutputChannels);
-  }
+    numOutputChannels = outputFormat.mChannelsPerFrame;
 
-  if (!outputFormat.mFormatID)
+    if (devEnum.IsPlanar())
+    {
+      numOutputChannels = std::min((size_t)format.m_channelLayout.Count(), (size_t)devEnum.GetNumPlanes());
+      m_planes = numOutputChannels;
+      CLog::Log(LOGDEBUG, "%s Found planar audio with %u channels using %u of them.", __FUNCTION__, (unsigned int)devEnum.GetNumPlanes(), (unsigned int)numOutputChannels);
+    }
+  }
+  else
   {
     CLog::Log(LOGERROR, "%s, Unable to find suitable stream", __FUNCTION__);
     return false;
   }
+
 
   /* Update our AE format */
   format.m_sampleRate    = outputFormat.mSampleRate;
@@ -778,7 +251,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   m_outputBitstream   = passthrough && outputFormat.mFormatID == kAudioFormatLinearPCM;
 
   std::string formatString;
-  CLog::Log(LOGDEBUG, "%s: Selected stream[%u] - id: 0x%04X, Physical Format: %s %s", __FUNCTION__, (unsigned int)outputIndex, (unsigned int)outputStream, StreamDescriptionToString(outputFormat, formatString), m_outputBitstream ? "bitstreamed passthrough" : "");
+  CLog::Log(LOGDEBUG, "%s: Selected stream[%u] - id: 0x%04X, Physical Format: %s %s", __FUNCTION__, (unsigned int)0, (unsigned int)outputStream, StreamDescriptionToString(outputFormat, formatString), m_outputBitstream ? "bitstreamed passthrough" : "");
 
   SetHogMode(passthrough);
 
@@ -796,13 +269,13 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   CLog::Log(LOGDEBUG, "%s: New Virtual Format: %s", __FUNCTION__, StreamDescriptionToString(virtualFormat, formatString));
   CLog::Log(LOGDEBUG, "%s: New Physical Format: %s", __FUNCTION__, StreamDescriptionToString(outputFormat, formatString));
 
-  // update the channel map based on the new stream format
-  GetAEChannelMap(m_device, format.m_channelLayout, numOutputChannels);
-
-
+  m_device.Open(deviceID);
   m_latentFrames = m_device.GetNumLatencyFrames();
   m_latentFrames += m_outputStream.GetNumLatencyFrames();
 
+  // update the channel map based on the new stream format
+  devEnum.GetAEChannelMap(format.m_channelLayout, numOutputChannels);
+   
   /* TODO: Should we use the virtual format to determine our data format? */
   format.m_frameSize     = format.m_channelLayout.Count() * (CAEUtil::DataFormatToBits(format.m_dataFormat) >> 3);
   format.m_frames        = m_device.GetBufferSize();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -22,7 +22,6 @@
 #include "cores/AudioEngine/Interfaces/AESink.h"
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Sinks/osx/CoreAudioDevice.h"
-#include "cores/AudioEngine/Sinks/osx/CoreAudioStream.h"
 
 class AERingBuffer;
 class AEDelayStatus;

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -1,0 +1,718 @@
+/*
+ *      Copyright (C) 2014 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "AEDeviceEnumerationOSX.h"
+#include "cores/AudioEngine/Sinks/osx/CoreAudioChannelLayout.h"
+#include "cores/AudioEngine/Sinks/osx/CoreAudioHelpers.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include <sstream>
+
+#define CA_MAX_CHANNELS 16
+// default channel map - in case it can't be fetched from the device
+static enum AEChannel CAChannelMap[CA_MAX_CHANNELS + 1] = {
+  AE_CH_FL , AE_CH_FR , AE_CH_BL , AE_CH_BR , AE_CH_FC , AE_CH_LFE , AE_CH_SL , AE_CH_SR ,
+  AE_CH_UNKNOWN1 ,
+  AE_CH_UNKNOWN2 ,
+  AE_CH_UNKNOWN3 ,
+  AE_CH_UNKNOWN4 ,
+  AE_CH_UNKNOWN5 ,
+  AE_CH_UNKNOWN6 ,
+  AE_CH_UNKNOWN7 ,
+  AE_CH_UNKNOWN8 ,
+  AE_CH_NULL
+};
+
+AEDeviceEnumerationOSX::AEDeviceEnumerationOSX(AudioDeviceID deviceID)
+: m_deviceID(deviceID)
+, m_isPlanar(false)
+, m_caDevice(deviceID)
+{
+  Enumerate();
+}
+
+bool AEDeviceEnumerationOSX::Enumerate()
+{
+  AudioStreamIdList streamList;
+  bool isDigital = isDigitalDevice();
+  bool ret = false;
+  UInt32 transportType = m_caDevice.GetTransportType();
+  m_caStreamInfos.clear();
+  m_isPlanar = true;
+  m_deviceName = m_caDevice.GetName();
+
+  if (m_caDevice.GetStreams(&streamList))
+  {
+    for (UInt32 streamIdx = 0; streamIdx < streamList.size(); streamIdx++)
+    {
+      caStreamInfo info;
+      info.streamID = streamList[streamIdx];
+      info.numChannels = m_caDevice.GetNumChannelsOfStream(streamIdx);
+      // one stream with num channels other then 1 is enough to make this device non-planar
+      if (info.numChannels != 1)
+        m_isPlanar = false;
+
+      CCoreAudioStream::GetAvailablePhysicalFormats(streamList[streamIdx], &info.formatList);
+      
+      hasPassthroughOrDigitalFormats(info.formatList, info.hasPassthroughFormats, info.isDigital);
+
+      info.isDigital |= isDigital;
+      info.deviceType = getDeviceType(hasPassthroughFormats, info.isDigital, info.numChannels, transportType);
+      m_caStreamInfos.push_back(info);
+    }
+    ret = true;
+  }
+
+  return ret;
+}
+
+// device/stream is digital if the transportType is digital
+// or the devicename suggests that it is digital
+bool AEDeviceEnumerationOSX::isDigitalDevice() const
+{
+  bool isDigital = m_caDevice.IsDigital();
+
+  // if it is no digital stream per definition
+  // check if the device name suggests that it is digital
+  // (some hackintonshs are not so smart in announcing correct
+  // ca devices ...
+  if (!isDigital)
+  {
+    std::string devNameLower = m_deviceName;
+    StringUtils::ToLower(devNameLower);                       
+    isDigital = devNameLower.find("digital") != std::string::npos;
+  }
+  return isDigital;
+}
+
+void AEDeviceEnumerationOSX::hasPassthroughOrDigitalFormats(const StreamFormatList &formatList, bool &hasPassthroughFormats, bool &hasDigitalFormat) const
+{
+  hasDigitalFormat = false;
+  hasPassthroughFormats = false;
+
+  for(UInt32 formatIdx = 0; formatIdx < formatList.size(); formatIdx++)
+  {
+    const AudioStreamBasicDescription &desc = formatList[formatIdx].mFormat;
+    if (desc.mFormatID == kAudioFormatAC3 || desc.mFormatID == kAudioFormat60958AC3)
+    {
+      hasDigitalFormat = true;
+      hasPassthroughFormats = true;
+      break;
+    }
+    else
+    {
+      // PassthroughFormat 2ch 16bit LE 48000Hz / 192000Hz */
+      if (desc.mBitsPerChannel == 16 && 
+          !(desc.mFormatFlags & kAudioFormatFlagIsBigEndian) &&
+          desc.mChannelsPerFrame == 2 && 
+          (desc.mSampleRate == 48000 || desc.mSampleRate == 192000))
+      {
+        hasPassthroughFormats = true;
+      }
+    }
+  }
+}
+
+enum AEDeviceType AEDeviceEnumerationOSX::getDeviceType(bool hasPassthroughFormats, 
+                                                        bool isDigital, 
+                                                        UInt32 numChannels,  
+                                                        UInt32 transportType) const
+{
+  // flag indicating that the device name "sounds" like HDMI
+  bool hasHdmiName = m_deviceName.find("HDMI") != std::string::npos;
+  // flag indicating that the device name "sounds" like DisplayPort
+  bool hasDisplayPortName = m_deviceName.find("DisplayPort") != std::string::npos;
+  enum AEDeviceType deviceType = AE_DEVTYPE_PCM;//default    
+  
+  // decide the type of the device based on the discovered information
+  // in the streams
+  // device defaults to PCM (see start of the while loop)
+  // it can be HDMI, DisplayPort or Optical
+  // for all of those types it needs to support
+  // passthroughformats and needs to be a digital port
+  if (hasPassthroughFormats && isDigital)
+  {
+    // if the max number of channels was more then 2
+    // this can be HDMI or DisplayPort or Thunderbolt
+    if (numChannels > 2)
+    {
+      // either the devicename suggests its HDMI
+      // or CA reported the transportType as HDMI
+      if (hasHdmiName || transportType == kIOAudioDeviceTransportTypeHdmi)
+        deviceType = AE_DEVTYPE_HDMI;
+      
+      // either the devicename suggests its DisplayPort
+      // or CA reported the transportType as DisplayPort or Thunderbolt
+      if (hasDisplayPortName || 
+          transportType == kIOAudioDeviceTransportTypeDisplayPort || 
+          transportType == kIOAudioDeviceTransportTypeThunderbolt)
+        deviceType = AE_DEVTYPE_DP;
+    }
+    else// treat all other digital passthrough devices as optical
+      deviceType = AE_DEVTYPE_IEC958;
+
+    //treat all other digital devices as HDMI to let options open to the user
+    if (deviceType == AE_DEVTYPE_PCM)
+      deviceType = AE_DEVTYPE_HDMI;
+  }
+
+  // devicename based overwrites from former code - maybe FIXME at some point when we
+  // are sure that the upper detection does its job in all[tm] use cases
+  if (hasHdmiName)
+    deviceType = AE_DEVTYPE_HDMI;
+  if (hasDisplayPortName)
+    deviceType = AE_DEVTYPE_DP;
+
+  return deviceType;
+}
+
+CADeviceList AEDeviceEnumerationOSX::GetDeviceInfoList() const
+{
+  CADeviceList list;
+  UInt32 numDevices = m_caStreamInfos.size();
+  if (m_isPlanar)
+    numDevices = 1;
+  
+  for (UInt32 streamIdx = 0; streamIdx < numDevices; streamIdx++)
+  {
+    CAEDeviceInfo deviceInfo;
+    
+    deviceInfo.m_deviceName = getDeviceNameForStream(streamIdx);
+    deviceInfo.m_displayName = m_deviceName;
+    deviceInfo.m_displayNameExtra = getExtraDisplayNameForStream(streamIdx);
+    deviceInfo.m_channels = getChannelInfoForStream(streamIdx);
+    deviceInfo.m_sampleRates = getSampleRateListForStream(streamIdx);
+    deviceInfo.m_dataFormats = getFormatListForStream(streamIdx);
+    deviceInfo.m_deviceType = m_caStreamInfos[streamIdx].deviceType;
+    
+    list.push_back(std::make_pair(m_deviceID, deviceInfo));
+  }
+  return list;
+}
+
+unsigned int AEDeviceEnumerationOSX::GetNumPlanes() const
+{
+  if (m_isPlanar)
+    return m_caStreamInfos.size();
+  else
+    return 1;//interlaved - one plane
+}
+
+bool AEDeviceEnumerationOSX::hasSampleRate(const AESampleRateList &list, const unsigned int samplerate) const
+{
+  for (size_t i = 0; i < list.size(); ++i)
+  {
+    if (list[i] == samplerate)
+      return true;
+  }
+  return false;
+}
+
+bool AEDeviceEnumerationOSX::hasDataFormat(const AEDataFormatList &list, const enum AEDataFormat format) const
+{
+  for (size_t i = 0; i < list.size(); ++i)
+  {
+    if (list[i] == format)
+      return true;
+  }
+  return false;
+}
+
+AEDataFormatList AEDeviceEnumerationOSX::getFormatListForStream(UInt32 streamIdx) const
+{
+  AEDataFormatList returnDataFormatList;
+  if (streamIdx >= m_caStreamInfos.size())
+    return returnDataFormatList;
+  
+  // check the streams
+  const StreamFormatList &formatList = m_caStreamInfos[streamIdx].formatList;
+  for(UInt32 formatIdx = 0; formatIdx < formatList.size(); formatIdx++)
+  {
+    AudioStreamBasicDescription formatDesc = formatList[formatIdx].mFormat;
+    AEDataFormatList aeFormatList = caFormatToAE(formatDesc, m_caStreamInfos[streamIdx].isDigital);
+    for (UInt32 formatListIdx = 0; formatListIdx < aeFormatList.size(); formatListIdx++)
+    {
+      if (!hasDataFormat(returnDataFormatList, aeFormatList[formatListIdx]))
+        returnDataFormatList.push_back(aeFormatList[formatListIdx]);
+    }
+  }
+  return returnDataFormatList;
+}
+
+CAEChannelInfo AEDeviceEnumerationOSX::getChannelInfoForStream(UInt32 streamIdx) const
+{
+  CAEChannelInfo channelInfo;
+  if (streamIdx >= m_caStreamInfos.size())
+    return channelInfo;
+  
+  if (m_isPlanar)
+  {
+    //get channel map to match the devices channel layout as set in audio-midi-setup
+    GetAEChannelMap(channelInfo, GetNumPlanes());
+  }
+  else
+  {
+    //get channel map to match the devices channel layout as set in audio-midi-setup
+    GetAEChannelMap(channelInfo, m_caDevice.GetTotalOutputChannels());
+  }
+  return channelInfo;
+}
+
+AEDataFormatList AEDeviceEnumerationOSX::caFormatToAE(const AudioStreamBasicDescription &formatDesc, bool isDigital) const
+{
+  AEDataFormatList formatList;
+  // add stream format info
+  switch (formatDesc.mFormatID)
+  {
+    case kAudioFormatAC3:
+    case kAudioFormat60958AC3:
+      formatList.push_back(AE_FMT_AC3);
+      formatList.push_back(AE_FMT_DTS);
+      break;
+    default:
+      switch(formatDesc.mBitsPerChannel)
+    {
+      case 16:
+        if (formatDesc.mFormatFlags & kAudioFormatFlagIsBigEndian)
+          formatList.push_back(AE_FMT_S16BE);
+        else
+        {
+          /* Passthrough is possible with a 2ch digital output */
+          if (formatDesc.mChannelsPerFrame == 2 && isDigital)
+          {
+            if (formatDesc.mSampleRate == 48000)
+            {
+              formatList.push_back(AE_FMT_AC3);
+              formatList.push_back(AE_FMT_DTS);
+            }
+            else if (formatDesc.mSampleRate == 192000)
+            {
+              formatList.push_back(AE_FMT_EAC3);
+            }
+          }
+          formatList.push_back(AE_FMT_S16LE);
+        }
+        break;
+      case 24:
+        if (formatDesc.mFormatFlags & kAudioFormatFlagIsBigEndian)
+          formatList.push_back(AE_FMT_S24BE3);
+        else
+          formatList.push_back(AE_FMT_S24LE3);
+        break;
+      case 32:
+        if (formatDesc.mFormatFlags & kAudioFormatFlagIsFloat)
+          formatList.push_back(AE_FMT_FLOAT);
+        else
+        {
+          if (formatDesc.mFormatFlags & kAudioFormatFlagIsBigEndian)
+            formatList.push_back(AE_FMT_S32BE);
+          else
+            formatList.push_back(AE_FMT_S32LE);
+        }
+        break;
+    }
+      break;
+  }
+  return formatList;
+}
+
+AESampleRateList AEDeviceEnumerationOSX::getSampleRateListForStream(UInt32 streamIdx) const
+{
+  AESampleRateList returnSampleRateList;
+  if (streamIdx >= m_caStreamInfos.size())
+    return returnSampleRateList;
+  
+  // check the streams
+  const StreamFormatList &formatList = m_caStreamInfos[streamIdx].formatList;
+  for(UInt32 formatIdx = 0; formatIdx < formatList.size(); formatIdx++)
+  {
+    AudioStreamBasicDescription formatDesc = formatList[formatIdx].mFormat;
+    // add sample rate info
+    // for devices which return kAudioStreamAnyRatee
+    // we add 44.1khz and 48khz - user can use
+    // the "fixed" audio config to force one of them
+    if (formatDesc.mSampleRate == kAudioStreamAnyRate)
+    {
+      CLog::Log(LOGINFO, "%s reported samplerate is kAudioStreamAnyRate adding 44.1khz and 48khz", __FUNCTION__);
+      formatDesc.mSampleRate = 44100;
+      if (!hasSampleRate(returnSampleRateList, formatDesc.mSampleRate))
+        returnSampleRateList.push_back(formatDesc.mSampleRate);
+      formatDesc.mSampleRate = 48000;
+    }
+    
+    if (!hasSampleRate(returnSampleRateList, formatDesc.mSampleRate))
+      returnSampleRateList.push_back(formatDesc.mSampleRate);
+  }
+  
+  return returnSampleRateList;
+}
+
+std::string AEDeviceEnumerationOSX::getDeviceNameForStream(UInt32 streamIdx) const
+{
+  std::string deviceName = "";
+  if (m_isPlanar)// planar devices are saved as :stream0
+    deviceName = m_deviceName + ":stream0";
+  else
+  {
+    std::stringstream streamIdxStr;
+    streamIdxStr << streamIdx;
+    deviceName = m_deviceName + ":stream" + streamIdxStr.str();
+  }
+  return deviceName;
+}
+
+std::string AEDeviceEnumerationOSX::getExtraDisplayNameForStream(UInt32 streamIdx) const
+{
+  std::string extraDisplayName = "";
+  
+  // for distinguishing the streams inside one device we add
+  // Stream <number> to the extraDisplayName
+  // planar devices are ignored here as their streams are
+  // the channels not different subdevices
+  if (m_caStreamInfos.size() > 1 && !m_isPlanar)
+  {
+    std::stringstream streamIdxStr;
+    streamIdxStr << streamIdx;
+    extraDisplayName = "Stream " + streamIdxStr.str();
+  }
+  return extraDisplayName;
+}
+
+float AEDeviceEnumerationOSX::scoreSampleRate(Float64 destinationRate, unsigned int sourceRate) const
+{
+  float score = 0;
+  double intPortion;
+  double fracPortion = modf(destinationRate / sourceRate, &intPortion);
+
+  score += (1 - fracPortion) * 1000;      // prefer sample rates that are multiples of the source sample rate
+  score += (intPortion == 1.0) ? 500 : 0;   // prefer exact matches over other multiples
+  score += (intPortion > 1 && intPortion < 100) ? (100 - intPortion) / 100 * 100 : 0; // prefer smaller multiples otherwise
+
+  return score;
+}
+
+float AEDeviceEnumerationOSX::ScoreFormat(const AudioStreamBasicDescription &formatDesc, const AEAudioFormat &format) const
+{
+  float score = 0;
+  if (format.m_dataFormat == AE_FMT_AC3 ||
+      format.m_dataFormat == AE_FMT_DTS)
+  {
+    if (formatDesc.mFormatID == kAudioFormat60958AC3 ||
+        formatDesc.mFormatID == 'IAC3' ||
+        formatDesc.mFormatID == kAudioFormatAC3)
+    {
+      if (formatDesc.mSampleRate == format.m_sampleRate &&
+          formatDesc.mBitsPerChannel == CAEUtil::DataFormatToBits(format.m_dataFormat) &&
+          formatDesc.mChannelsPerFrame == format.m_channelLayout.Count())
+      {
+        // perfect match
+        score = FLT_MAX;
+      }
+    }
+  }
+  if (format.m_dataFormat == AE_FMT_AC3 ||
+      format.m_dataFormat == AE_FMT_DTS ||
+      format.m_dataFormat == AE_FMT_EAC3)
+  { // we should be able to bistreaming in PCM if the samplerate, bitdepth and channels match
+    if (formatDesc.mSampleRate       == format.m_sampleRate                            &&
+        formatDesc.mBitsPerChannel   == CAEUtil::DataFormatToBits(format.m_dataFormat) &&
+        formatDesc.mChannelsPerFrame == format.m_channelLayout.Count()                 &&
+        formatDesc.mFormatID         == kAudioFormatLinearPCM)
+    {
+      score = FLT_MAX / 2;
+    }
+  }
+  else
+  { // non-passthrough, whatever works is fine
+    if (formatDesc.mFormatID == kAudioFormatLinearPCM)
+    {
+      score += scoreSampleRate(formatDesc.mSampleRate, format.m_sampleRate);
+
+      if (formatDesc.mChannelsPerFrame == format.m_channelLayout.Count())
+        score += 5;
+      else if (formatDesc.mChannelsPerFrame > format.m_channelLayout.Count())
+        score += 1;
+      if (format.m_dataFormat == AE_FMT_FLOAT || format.m_dataFormat == AE_FMT_FLOATP)
+      { // for float, prefer the highest bitdepth we have
+        if (formatDesc.mBitsPerChannel >= 16)
+          score += (formatDesc.mBitsPerChannel / 8);
+      }
+      else
+      {
+        if (formatDesc.mBitsPerChannel == CAEUtil::DataFormatToBits(format.m_dataFormat))
+          score += 5;
+        else if (formatDesc.mBitsPerChannel == CAEUtil::DataFormatToBits(format.m_dataFormat))
+          score += 1;
+      }
+    }
+  }
+  return score;
+}
+
+bool AEDeviceEnumerationOSX::FindSuitableFormatForStream(UInt32 &streamIdx, const AEAudioFormat &format, AudioStreamBasicDescription &outputFormat, bool &passthrough, AudioStreamID &outputStream) const
+{
+  CLog::Log(LOGDEBUG, "%s: Finding stream for format %s", __FUNCTION__, CAEUtil::DataFormatToStr(format.m_dataFormat));
+  
+  bool                        formatFound  = false;
+  float                       outputScore  = 0;
+  UInt32                      streamIdxStart = streamIdx;
+  UInt32                      streamIdxEnd   = streamIdx + 1;
+  UInt32                      streamIdxCurrent = streamIdx;
+  
+  if (streamIdx == INT_MAX)
+  {
+    streamIdxStart = 0;
+    streamIdxEnd = m_caStreamInfos.size();
+    streamIdxCurrent = 0;
+  }
+  
+  if (streamIdxCurrent >= m_caStreamInfos.size())
+    return false;
+  
+  // loop over all streams or over given streams (depends on initial value of param streamIdx
+  for(streamIdxCurrent = streamIdxStart; streamIdxCurrent < streamIdxEnd; streamIdxCurrent++)
+  {
+    
+    // Probe physical formats
+    const StreamFormatList &formats = m_caStreamInfos[streamIdxCurrent].formatList;
+    for (StreamFormatList::const_iterator j = formats.begin(); j != formats.end(); ++j)
+    {
+      AudioStreamBasicDescription formatDesc = j->mFormat;
+
+      // for devices with kAudioStreamAnyRate
+      // assume that the user uses a fixed config
+      // and knows what he is doing - so we use
+      // the requested samplerate here
+      if (formatDesc.mSampleRate == kAudioStreamAnyRate)
+        formatDesc.mSampleRate = format.m_sampleRate;
+
+      float score = ScoreFormat(formatDesc, format);
+
+      std::string formatString;
+      CLog::Log(LOGDEBUG, "%s: Physical Format: %s rated %f", __FUNCTION__, StreamDescriptionToString(formatDesc, formatString), score);
+
+      if (score > outputScore)
+      {
+        passthrough  = score > 10000;
+        outputScore  = score;
+        outputFormat = formatDesc;
+        outputStream = m_caStreamInfos[streamIdxCurrent].streamID;
+        streamIdx = streamIdxCurrent;// return the streamIdx for the caller
+        formatFound = true;
+      }
+    }
+  }
+  
+  if (m_isPlanar)
+    outputFormat.mChannelsPerFrame = std::min((size_t)format.m_channelLayout.Count(), m_caStreamInfos.size());
+  
+  return formatFound;
+}
+
+// map coraudio channel labels to activeae channel labels
+enum AEChannel AEDeviceEnumerationOSX::caChannelToAEChannel(const AudioChannelLabel &CAChannelLabel) const
+{
+  enum AEChannel ret = AE_CH_NULL;
+  static unsigned int unknownChannel = AE_CH_UNKNOWN1;
+  switch(CAChannelLabel)
+  {
+    case kAudioChannelLabel_Left:
+      ret = AE_CH_FL;
+      break;
+    case kAudioChannelLabel_Right:
+      ret = AE_CH_FR;
+      break;
+    case kAudioChannelLabel_Center:
+      ret = AE_CH_FC;
+      break;
+    case kAudioChannelLabel_LFEScreen:
+      ret = AE_CH_LFE;
+      break;
+    case kAudioChannelLabel_LeftSurroundDirect:
+      ret = AE_CH_SL;
+      break;
+    case kAudioChannelLabel_RightSurroundDirect:
+      ret = AE_CH_SR;
+      break;
+    case kAudioChannelLabel_LeftCenter:
+      ret = AE_CH_FLOC;
+      break;
+    case kAudioChannelLabel_RightCenter:
+      ret = AE_CH_FROC;
+      break;
+    case kAudioChannelLabel_CenterSurround:
+      ret = AE_CH_TC;
+      break;
+    case kAudioChannelLabel_LeftSurround:
+      ret = AE_CH_SL;
+      break;
+    case kAudioChannelLabel_RightSurround:
+      ret = AE_CH_SR;
+      break;
+    case kAudioChannelLabel_VerticalHeightLeft:
+      ret = AE_CH_TFL;
+      break;
+    case kAudioChannelLabel_VerticalHeightRight:
+      ret = AE_CH_TFR;
+      break;
+    case kAudioChannelLabel_VerticalHeightCenter:
+      ret = AE_CH_TFC;
+      break;
+    case kAudioChannelLabel_TopCenterSurround:
+      ret = AE_CH_TC;
+      break;
+    case kAudioChannelLabel_TopBackLeft:
+      ret = AE_CH_TBL;
+      break;
+    case kAudioChannelLabel_TopBackRight:
+      ret = AE_CH_TBR;
+      break;
+    case kAudioChannelLabel_TopBackCenter:
+      ret = AE_CH_TBC;
+      break;
+    case kAudioChannelLabel_RearSurroundLeft:
+      ret = AE_CH_BL;
+      break;
+    case kAudioChannelLabel_RearSurroundRight:
+      ret = AE_CH_BR;
+      break;
+    case kAudioChannelLabel_LeftWide:
+      ret = AE_CH_BLOC;
+      break;
+    case kAudioChannelLabel_RightWide:
+      ret = AE_CH_BROC;
+      break;
+    case kAudioChannelLabel_LFE2:
+      ret = AE_CH_LFE;
+      break;
+    case kAudioChannelLabel_LeftTotal:
+      ret = AE_CH_FL;
+      break;
+    case kAudioChannelLabel_RightTotal:
+      ret = AE_CH_FR;
+      break;
+    case kAudioChannelLabel_HearingImpaired:
+      ret = AE_CH_FC;
+      break;
+    case kAudioChannelLabel_Narration:
+      ret = AE_CH_FC;
+      break;
+    case kAudioChannelLabel_Mono:
+      ret = AE_CH_FC;
+      break;
+    case kAudioChannelLabel_DialogCentricMix:
+      ret = AE_CH_FC;
+      break;
+    case kAudioChannelLabel_CenterSurroundDirect:
+      ret = AE_CH_TC;
+      break;
+    case kAudioChannelLabel_Haptic:
+      ret = AE_CH_FC;
+      break;
+    default:
+      ret = (enum AEChannel)unknownChannel++;
+  }
+  if (unknownChannel > AE_CH_UNKNOWN8)
+    unknownChannel = AE_CH_UNKNOWN1;
+  
+  return ret;
+}
+
+//Note: in multichannel mode CA will either pull 2 channels of data (stereo) or 6/8 channels of data
+//(every speaker setup with more then 2 speakers). The difference between the number of real speakers
+//and 6/8 channels needs to be padded with unknown channels so that the sample size fits 6/8 channels
+//
+//device [in] - the device whose channel layout should be used
+//channelMap [in/out] - if filled it will it indicates that we are called from initialize and we log the requested map, out returns the channelMap for device
+//channelsPerFrame [in] - the number of channels this device is configured to (e.x. 2 or 6/8)
+void AEDeviceEnumerationOSX::GetAEChannelMap(CAEChannelInfo &channelMap, unsigned int channelsPerFrame) const
+{
+  CCoreAudioChannelLayout calayout;
+  bool logMapping = channelMap.Count() > 0; // only log if the engine requests a layout during init
+  bool mapAvailable = false;
+  unsigned int numberChannelsInDeviceLayout = CA_MAX_CHANNELS; // default 8 channels from CAChannelMap
+  AudioChannelLayout *layout = NULL;
+  
+  // try to fetch either the multichannel or the stereo channel layout from the device
+  if (channelsPerFrame == 2 || channelMap.Count() == 2)
+    mapAvailable = m_caDevice.GetPreferredChannelLayoutForStereo(calayout);
+  else
+    mapAvailable = m_caDevice.GetPreferredChannelLayout(calayout);
+  
+  // if a map was fetched - check if it is usable
+  if (mapAvailable)
+  {
+    layout = calayout;
+    if (layout == NULL || layout->mChannelLayoutTag != kAudioChannelLayoutTag_UseChannelDescriptions)
+      mapAvailable = false;// wrong map format
+    else
+      numberChannelsInDeviceLayout = layout->mNumberChannelDescriptions;
+  }
+  
+  // start the mapping action
+  // the number of channels to be added to the outgoing channelmap
+  // this is CA_MAX_CHANNELS at max and might be lower for some output devices (channelsPerFrame)
+  unsigned int numChannelsToMap = std::min((unsigned int)CA_MAX_CHANNELS, (unsigned int)channelsPerFrame);
+  
+  // if there was a map fetched we force the number of
+  // channels to map to channelsPerFrame (this allows mapping
+  // of more then CA_MAX_CHANNELS if needed)
+  if (mapAvailable)
+    numChannelsToMap = channelsPerFrame;
+  
+  std::string layoutStr;
+  
+  if (logMapping)
+  {
+    CLog::Log(LOGDEBUG, "%s Engine requests layout %s", __FUNCTION__, ((std::string)channelMap).c_str());
+    
+    if (mapAvailable)
+      CLog::Log(LOGDEBUG, "%s trying to map to %s layout: %s", __FUNCTION__, channelsPerFrame == 2 ? "stereo" : "multichannel", calayout.ChannelLayoutToString(*layout, layoutStr));
+    else
+      CLog::Log(LOGDEBUG, "%s no map available - using static multichannel map layout", __FUNCTION__);
+  }
+  
+  channelMap.Reset();// start with an empty map
+  
+  for (unsigned int channel = 0; channel < numChannelsToMap; channel++)
+  {
+    // we only try to map channels which are defined in the device layout
+    enum AEChannel currentChannel;
+    if (channel < numberChannelsInDeviceLayout)
+    {
+      // get the channel from the fetched map
+      if (mapAvailable)
+        currentChannel = caChannelToAEChannel(layout->mChannelDescriptions[channel].mChannelLabel);
+      else// get the channel from the default map
+        currentChannel = CAChannelMap[channel];
+      
+    }
+    else// fill with unknown channels
+      currentChannel = caChannelToAEChannel(kAudioChannelLabel_Unknown);
+    
+    if(!channelMap.HasChannel(currentChannel))// only add if not already added
+      channelMap += currentChannel;
+  }
+  
+  if (logMapping)
+    CLog::Log(LOGDEBUG, "%s mapped channels to layout %s", __FUNCTION__, ((std::string)channelMap).c_str());
+}

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -76,7 +76,7 @@ bool AEDeviceEnumerationOSX::Enumerate()
       hasPassthroughOrDigitalFormats(info.formatList, info.hasPassthroughFormats, info.isDigital);
 
       info.isDigital |= isDigital;
-      info.deviceType = getDeviceType(hasPassthroughFormats, info.isDigital, info.numChannels, transportType);
+      info.deviceType = getDeviceType(info.hasPassthroughFormats, info.isDigital, info.numChannels, transportType);
       m_caStreamInfos.push_back(info);
     }
     ret = true;

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h
@@ -1,0 +1,240 @@
+#pragma once
+/*
+ *      Copyright (C) 2014 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
+#include "cores/AudioEngine/Sinks/osx/CoreAudioDevice.h"
+
+typedef std::vector< std::pair<AudioDeviceID, CAEDeviceInfo> > CADeviceList;
+//Hirarchy:
+// Device
+//       - 1..n streams
+//            1..n formats
+//       - 0..n sources
+//on non planar devices we have numstreams * numsources devices for our list
+//on planar devices we have 1 * numsources devices for our list 
+class AEDeviceEnumerationOSX
+{
+public:
+  /*!
+  * @brief C'tor - initialises the Enumerator and calls Enumerate
+  * @param  deviceID - the CoreAudio Device ID which will be the base of the enumerated device list
+  */
+  AEDeviceEnumerationOSX(AudioDeviceID deviceID);
+  // d'tor
+  ~AEDeviceEnumerationOSX(){};
+  
+  /*!
+  * @brief Gets the device list which was enumerated by the last call to Enumerate 
+  *        (which is also called in c'tor).
+  *
+  * @return Returns the device list.
+  */
+  CADeviceList  GetDeviceInfoList() const;
+  
+  /*!
+  * @brief Fetches all metadata from the CoreAudio device which is needed to generate a proper DeviceList for AE
+  *        This method is always called from C'tor but can be called multiple times if the streams of a device
+  *        changed. This fills m_caStreamInfos.
+  *        After this call - GetDeviceInfoList will reflect the Enumerated metadata.
+  * @return false when streamlist couldn't be fetched from device - else true
+  */
+  bool          Enumerate();
+
+  /*!
+  * @brief Returns the number of Planes for a device. This will be 1 for non-planar devices and > 1 for planar devices.
+  * @return Number of planes for this device.
+  */
+  unsigned int  GetNumPlanes() const;
+
+  /*!
+  * @brief Checks if the m_deviceID belongs to a planar or non-planar device.
+  * @return true if m_deviceID belongs to a planar device - else false.
+  */
+  bool          IsPlanar() const { return m_isPlanar; }
+
+  /*!
+  * @brief Tries to find a suitable CoreAudio format which matches the given AEAudioFormat as close as possible.
+  * @param streamIdx [in/out] - if streamIdx != INT_MAX only formats of the given streamIdx are checked
+  *                             if streamIdx == INT_MAX - formats of all streams in the device are considered
+  *                             On success this parameter returns the selected streamIdx.
+  *
+  * @param format    [in]     - the requested AE format which should be matched to the stream formats of CA
+  * @param outputFormat [out] - the found CA format which matches best to the requested AE format
+  * @param passthrough [out]  - flag indicating that the found CA format is a passthrough format
+  * @param outputStream [out] - the coreaudio streamid which contains the coreaudio format returned in outputFormat
+  * @return true if a matching corea audio format was found - else false
+  */
+  bool          FindSuitableFormatForStream(UInt32 &streamIdx, const AEAudioFormat &format, 
+                                            AudioStreamBasicDescription &outputFormat, bool &passthrough, 
+                                            AudioStreamID &outputStream) const;
+
+  /*!
+  * @brief Returns the device name which belongs to m_deviceID without any stream/source suffixes
+  * @return the CA device name
+  */
+  std::string   GetMasterDeviceName() const { return m_deviceName; }
+
+  /*!
+  * @brief Tries to return a proper channelmap from CA in a format AE understands
+  * @param channelMap [in/out] - returns the found channelmap in AE format
+  *                              if initialised with a map the number of channels is used to determine
+  *                              if stereo or multichannel map should be fetched
+  * @param channelsPerFrame [int] - the number of channels which should be mapped
+  *                                 (also decides if stereo or multichannel map is fetched similar to channelMap param)
+  */
+  void          GetAEChannelMap(CAEChannelInfo &channelMap, unsigned int channelsPerFrame) const;
+
+  /*!
+   * @brief Scores a format based on:
+   *   1. Matching passthrough characteristics (i.e. passthrough flag)
+   *   2. Matching sample rate.
+   *   3. Matching bits per channel (or higher).
+   *   4. Matching number of channels (or higher).
+   *
+   * @param formatDesc   [in] - The CA FormatDescription which should be scored
+   * @param format [in] - the AE format which should be matched as good as possible
+   * @return - the score of formatDesc - higher scores indicate better matching to "format"
+   *          (scores > 10000 indicate passthrough formats)
+   */
+  // public because its used in unit tests ...
+  float             ScoreFormat(const AudioStreamBasicDescription &formatDesc, const AEAudioFormat &format) const;
+
+private:
+  
+  /*!
+  * @brief Checks if this is a digital device based on CA transportType or name
+  * @return - true if this is a digital device - else false.
+  */
+  bool              isDigitalDevice() const;
+  
+  /*!
+  * @brief Checks if there are passthrough formats or digital formats
+  *       (the latter are passthrough formats with dedicated format config like AC3/DTS)
+  * @param formatList [in] - the format list to be evaluated
+  * @param hasPassthroughFormats [out] - true if there were passthrough formats in the list
+  * @param hasDigitalFormat [out] - true if there were dedicated passthrough formats in the list
+  */
+  void              hasPassthroughOrDigitalFormats(const StreamFormatList &formatList, 
+                                                   bool &hasPassthroughFormats, 
+                                                   bool &hasDigitalFormat) const;
+
+  /*!
+  * @brief Gets the AE devicetype for this device based the given criteria
+  * @param hasPassthroughFormats [in] - flag indicating that the device has passthrough formats
+  * @param isDigital [in] - flag indicating that the device is digital
+  * @param numChannels [in] - the number of channels of the device
+  * @param transportType [in] - the transportType of the device
+  * @return the AE devicetype
+  */
+  enum AEDeviceType getDeviceType(bool hasPassthroughFormats, bool isDigital, 
+                                  UInt32 numChannels, UInt32 transportType) const;
+
+  /*!
+  * @brief Fetches all ca streams from the ca device and fills m_channelsPerStream and m_streams
+  */
+  void              fillStreamList();
+
+  /*!
+  * @brief Scores a samplerate based on:
+  * 1. Prefer exact match
+  * 2. Prefer exact multiple of source samplerate and prefer the lowest
+  * 
+  * @param destinationRate [in] - the destination samplerate to score
+  * @param sourceRate [in] - the sourceRate of the audio format - this is the samplerate the score is based on
+  * @return the score
+  */
+  float             scoreSampleRate(Float64 destinationRate, unsigned int sourceRate) const;
+
+  bool              hasSampleRate(const AESampleRateList &list, const unsigned int samplerate) const;
+  bool              hasDataFormat(const AEDataFormatList &list, const enum AEDataFormat format) const;
+
+  /*!
+  * @brief Converts a CA format description to a list of AEFormat desciptions (as one format can result
+  *        in more then 1 AE format - e.x. AC3 ca format results in AC3 and DTS AE format
+  *
+  * @param formatDesc [in] - The CA format description to be converted
+  * @param isDigital  [in] - Flag indicating if the parent stream of formatDesc is digital
+  *                        (for allowing bitstreaming without dedicated AC3 format in CA)
+  * @return The list of converted AE formats.
+  */
+  AEDataFormatList  caFormatToAE(const AudioStreamBasicDescription &formatDesc, bool isDigital) const;
+
+  /*!
+  * @brief Convet a CA channel label to an AE channel.
+  * @param CAChannelLabel - the CA channel label to be converted
+  * @return the corresponding AEChannel
+  */
+  enum AEChannel    caChannelToAEChannel(const AudioChannelLabel &CAChannelLabel) const;
+
+  // for filling out the AEDeviceInfo object based on
+  // the data gathered on the last call to Enumerate()
+  /*!
+  * @brief Returns all AE formats for the CA stream at the given index
+  * @param streamIdx [in] - index into m_caStreamInfos
+  * @return - the list of AE formats in that stream.
+  */
+  AEDataFormatList  getFormatListForStream(UInt32 streamIdx) const;
+
+  /*!
+  * @brief Returns the AE channelinfo/channel map for the CA stream at the given index
+  * @param streamIdx [in] - index into m_caStreamInfos
+  * @return - the of AE channel info for that stream.
+  */
+  CAEChannelInfo    getChannelInfoForStream(UInt32 streamIdx) const;
+
+  /*!
+  * @brief Returns the AE samplerates for the CA stream at the given index
+  * @param streamIdx [in] - index into m_caStreamInfos
+  * @return - the list of AE samplerates for that stream.
+  */
+  AESampleRateList  getSampleRateListForStream(UInt32 streamIdx) const;
+
+  /*!
+  * @brief Returns the AE device name for the CA stream at the given index
+  * @param streamIdx [in] - index into m_caStreamInfos
+  * @return - The devicename for that stream
+  */
+  std::string       getDeviceNameForStream(UInt32 streamIdx) const;
+
+  /*!
+  * @brief - Returns the extra displayname shown to the User in addition to getDisplayNameForStream
+  *          for the CA stream at the given index
+  * @param streamIdx [in] - index into m_caStreamInfos
+  * @return - The extra displayname for that stream (might be empty)
+  */
+  std::string       getExtraDisplayNameForStream(UInt32 streamIdx) const;
+
+  AudioDeviceID     m_deviceID;
+  bool              m_isPlanar;
+  std::string       m_deviceName;
+
+  typedef struct
+  {
+    AudioStreamID streamID;
+    StreamFormatList formatList;
+    UInt32 numChannels;
+    bool isDigital;
+    bool hasPassthroughFormats;
+    enum AEDeviceType deviceType;
+  } caStreamInfo;
+  std::vector<caStreamInfo>       m_caStreamInfos;
+  CCoreAudioDevice                m_caDevice;
+};

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -240,7 +240,7 @@ std::string CCoreAudioDevice::GetName()
   return name;
 }
 
-bool CCoreAudioDevice::IsDigital()
+bool CCoreAudioDevice::IsDigital() const
 {
   bool isDigital = false;
   UInt32 transportType = 0;
@@ -267,7 +267,7 @@ bool CCoreAudioDevice::IsDigital()
   return isDigital;
 }
 
-UInt32 CCoreAudioDevice::GetTransportType()
+UInt32 CCoreAudioDevice::GetTransportType() const
 {
   UInt32 transportType = 0;
   if (!m_DeviceId)
@@ -285,7 +285,7 @@ UInt32 CCoreAudioDevice::GetTransportType()
   return transportType;
 }
 
-UInt32 CCoreAudioDevice::GetTotalOutputChannels()
+UInt32 CCoreAudioDevice::GetTotalOutputChannels() const
 {
   UInt32 channels = 0;
 
@@ -568,7 +568,7 @@ bool CCoreAudioDevice::SetCurrentVolume(Float32 vol)
   return true;
 }
 
-bool CCoreAudioDevice::GetPreferredChannelLayout(CCoreAudioChannelLayout& layout)
+bool CCoreAudioDevice::GetPreferredChannelLayout(CCoreAudioChannelLayout& layout) const
 {
   if (!m_DeviceId)
     return false;
@@ -597,7 +597,7 @@ bool CCoreAudioDevice::GetPreferredChannelLayout(CCoreAudioChannelLayout& layout
   return (ret == noErr);
 }
 
-bool CCoreAudioDevice::GetPreferredChannelLayoutForStereo(CCoreAudioChannelLayout &layout)
+bool CCoreAudioDevice::GetPreferredChannelLayoutForStereo(CCoreAudioChannelLayout &layout) const
 {
   if (!m_DeviceId)
     return false;

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -240,22 +240,17 @@ std::string CCoreAudioDevice::GetName()
   return name;
 }
 
-bool CCoreAudioDevice::IsDigital(UInt32 &transportType)
+bool CCoreAudioDevice::IsDigital()
 {
   bool isDigital = false;
+  UInt32 transportType = 0;
   if (!m_DeviceId)
     return false;
-
-  AudioObjectPropertyAddress  propertyAddress;
-  propertyAddress.mScope    = kAudioDevicePropertyScopeOutput;
-  propertyAddress.mElement  = 0;
-  propertyAddress.mSelector = kAudioDevicePropertyTransportType;
-
-  UInt32 propertySize = sizeof(transportType);
-  OSStatus ret = AudioObjectGetPropertyData(m_DeviceId, &propertyAddress, 0, NULL, &propertySize, &transportType);
-  if (ret != noErr)
-      return false;
     
+  transportType = GetTransportType();
+  if (transportType == INT_MAX)
+    return false;
+
   if (transportType == kIOAudioDeviceTransportTypeFireWire)
     isDigital = true;
   if (transportType == kIOAudioDeviceTransportTypeUSB)
@@ -270,6 +265,24 @@ bool CCoreAudioDevice::IsDigital(UInt32 &transportType)
     isDigital = true;
     
   return isDigital;
+}
+
+UInt32 CCoreAudioDevice::GetTransportType()
+{
+  UInt32 transportType = 0;
+  if (!m_DeviceId)
+    return INT_MAX;
+
+  AudioObjectPropertyAddress  propertyAddress;
+  propertyAddress.mScope    = kAudioDevicePropertyScopeOutput;
+  propertyAddress.mElement  = 0;
+  propertyAddress.mSelector = kAudioDevicePropertyTransportType;
+
+  UInt32 propertySize = sizeof(transportType);
+  OSStatus ret = AudioObjectGetPropertyData(m_DeviceId, &propertyAddress, 0, NULL, &propertySize, &transportType);
+  if (ret != noErr)
+      return INT_MAX;
+  return transportType;
 }
 
 UInt32 CCoreAudioDevice::GetTotalOutputChannels()

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -53,6 +53,7 @@ public:
   std::string   GetName();
   bool          IsDigital(UInt32 &transportType);
   UInt32        GetTotalOutputChannels();
+  UInt32        GetNumChannelsOfStream(UInt32 streamIdx);
   bool          GetStreams(AudioStreamIdList *pList);
   bool          IsRunning();
   bool          SetHogStatus(bool hog);

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -51,7 +51,8 @@ public:
   
   AudioDeviceID GetId() {return m_DeviceId;}
   std::string   GetName();
-  bool          IsDigital(UInt32 &transportType);
+  bool          IsDigital();
+  UInt32        GetTransportType();
   UInt32        GetTotalOutputChannels();
   UInt32        GetNumChannelsOfStream(UInt32 streamIdx);
   bool          GetStreams(AudioStreamIdList *pList);

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -51,9 +51,9 @@ public:
   
   AudioDeviceID GetId() {return m_DeviceId;}
   std::string   GetName();
-  bool          IsDigital();
-  UInt32        GetTransportType();
-  UInt32        GetTotalOutputChannels();
+  bool          IsDigital() const;
+  UInt32        GetTransportType() const;
+  UInt32        GetTotalOutputChannels() const;
   UInt32        GetNumChannelsOfStream(UInt32 streamIdx);
   bool          GetStreams(AudioStreamIdList *pList);
   bool          IsRunning();
@@ -62,8 +62,8 @@ public:
   bool          SetMixingSupport(UInt32 mix);
   bool          GetMixingSupport();
   bool          SetCurrentVolume(Float32 vol);
-  bool          GetPreferredChannelLayout(CCoreAudioChannelLayout &layout);
-  bool          GetPreferredChannelLayoutForStereo(CCoreAudioChannelLayout &layout);
+  bool          GetPreferredChannelLayout(CCoreAudioChannelLayout &layout) const;
+  bool          GetPreferredChannelLayoutForStereo(CCoreAudioChannelLayout &layout) const;
   bool          GetDataSources(CoreAudioDataSourceList *pList);
   Float64       GetNominalSampleRate();
   bool          SetNominalSampleRate(Float64 sampleRate);

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.h
@@ -35,8 +35,8 @@
 #endif
 
 
-typedef std::list<AudioStreamID> AudioStreamIdList;
-typedef std::list<AudioStreamRangedDescription> StreamFormatList;
+typedef std::vector<AudioStreamID> AudioStreamIdList;
+typedef std::vector<AudioStreamRangedDescription> StreamFormatList;
 
 class CCoreAudioStream
 {

--- a/xbmc/cores/AudioEngine/Sinks/test/TestAESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/test/TestAESinkDARWINOSX.cpp
@@ -24,9 +24,8 @@
 #include "cores/AudioEngine/Sinks/osx/CoreAudioHardware.h"
 #include "cores/AudioEngine/Sinks/osx/CoreAudioHelpers.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h"
 #include <vector>
-
-extern float ScoreStream(const AudioStreamBasicDescription &desc, const AEAudioFormat &format);
 
 std::vector<AudioStreamBasicDescription> stereoFormatsWithPassthrough;
 std::vector<AudioStreamBasicDescription> stereoFormatsWithoutPassthrough;
@@ -191,13 +190,14 @@ unsigned int findMatchingFormat(const std::vector<AudioStreamBasicDescription> &
   unsigned int formatIdx = 0;
   float highestScore = 0;
   float currentScore = 0;
+  AEDeviceEnumerationOSX devEnum((AudioDeviceID)0);
 
 //  fprintf(stderr, "%s: Matching streamFormat for source: %s with samplerate: %d\n", __FUNCTION__, CAEUtil::DataFormatToStr(srcFormat.m_dataFormat), srcFormat.m_sampleRate);
   for (unsigned int i = 0; i < formatList.size(); i++)
   {
     AudioStreamBasicDescription desc = formatList[i];
     std::string formatString;
-    currentScore = ScoreStream(desc, srcFormat);
+    currentScore = devEnum.ScoreFormat(desc, srcFormat);
 //    fprintf(stderr, "%s: Physical Format: %s idx: %d rated %f\n", __FUNCTION__, StreamDescriptionToString(desc, formatString), i, currentScore);
 
     if (currentScore > highestScore)


### PR DESCRIPTION
This refactors the device enumeration in the osx sink out into its own class and unrolls that big for loop a bit. This is all for better readability and code cleaning.

This should not alter the behaviour [tm] but now also shows multistream devices as there own device (adding Stream <number> to the extradisplayname) - those are non working yet. Also the format of the devicename saved in guisettings.xml changes (:stream<number> is added).

Thats why i added the settings update mechanism which should migrate old settings.

This is the preparation for finally fixing multi stream devices and multi source devices (like different airplay targets) which will be done in a seperate PR once this one is confirmed.

@jmarshallnz - sorry i had no chance to split this huge thing up into something which is reviewable :( - mostly its copy paste from the former enumeration loop. Maybe the doxy in the enumerator class can calm down the gods a bit.
