### PR TITLE
change: Remove dropped "audiohost" from advancedsettings

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -127,7 +127,6 @@ void CAdvancedSettings::Initialize()
 
   m_audioDefaultPlayer = "paplayer";
   m_audioPlayCountMinimumPercent = 90.0f;
-  m_audioHost = "default";
 
   m_videoSubsDelayRange = 10;
   m_videoAudioDelayRange = 10;
@@ -500,7 +499,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     if (pAudioExcludes)
       GetCustomRegexps(pAudioExcludes, m_audioExcludeFromScanRegExps);
 
-    XMLUtils::GetString(pElement, "audiohost", m_audioHost);
     XMLUtils::GetBoolean(pElement, "applydrc", m_audioApplyDrc);
     XMLUtils::GetBoolean(pElement, "dvdplayerignoredtsinwav", m_dvdplayerIgnoreDTSinWAV);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -176,7 +176,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoBlackBarColour;
     int m_videoIgnoreSecondsAtStart;
     float m_videoIgnorePercentAtEnd;
-    CStdString m_audioHost;
     bool m_audioApplyDrc;
 
     int   m_videoVDPAUScaling;


### PR DESCRIPTION
According to IRC talk

XMLUtils::GetString(pElement, "audiohost", m_audioHost);

Is left over and gone.
also remove references in https://github.com/xbmc/xbmc/blob/cff55a425ad8a610c3781b66ba75a0102d014fe4/xbmc/settings/AdvancedSettings.h#L180
and 
https://github.com/xbmc/xbmc/blob/6afb499a211a0e3ebd9473a3a1425eebebb67c3f/xbmc/settings/AdvancedSettings.cpp#L130

tbh I bit off more than I can chew but at least its here for reference if nothing else right?

@fritsch
