### PR TITLE
ActiveAE: delay creation of viz buffers until they are needed

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1155,7 +1155,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
         m_discardBufferPools.push_back(m_vizBuffersInput);
         m_vizBuffersInput = NULL;
       }
-      if (!m_vizBuffers)
+      if (!m_vizBuffers && m_audioCallback)
       {
         AEAudioFormat vizFormat = m_internalFormat;
         vizFormat.m_channelLayout = AE_CH_LAYOUT_2_0;
@@ -1908,10 +1908,11 @@ bool CActiveAE::RunStages()
         // viz
         {
           CSingleLock lock(m_vizLock);
-          if (m_audioCallback && m_vizBuffers && !m_streams.empty())
+          if (m_audioCallback && !m_streams.empty())
           {
-            if (!m_vizInitialized)
+            if (!m_vizInitialized || !m_vizBuffers)
             {
+              Configure();
               m_audioCallback->OnInitialize(2, m_vizBuffers->m_format.m_sampleRate, 32);
               m_vizInitialized = true;
             }


### PR DESCRIPTION
on platforms like Raspberry Pi the instantiation of a resampler is expensive and can be avoided if no viz is required.

@popcornmix does this work for you?
