### PR TITLE
[osx] - only show the fake fullscreen option on snow leopard

### DIFF
--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -8,6 +8,13 @@
         </setting>
       </group>
     </category>
+    <category id="videoscreen" label="21373" help="36603">
+      <group id="1">
+        <setting id="videoscreen.fakefullscreen" type="boolean" parent="videoscreen.screen" label="14083" help="36354">
+          <requirement>OsxIsSnowLeopard</requirement>
+        </setting>
+      </group>
+    </category>
   </section>
   <section id="videos">
     <category id="videoacceleration">

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -34,6 +34,7 @@ extern "C"
   const char *getIosPlatformString(void);
   bool        DarwinIsAppleTV2(void);
   bool        DarwinIsMavericks(void);
+  bool        DarwinIsSnowLeopard(void);
   bool        DarwinHasRetina(void);
   const char *GetDarwinOSReleaseString(void);
   const char *GetDarwinVersionString(void);

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -43,6 +43,14 @@
 #import "AutoPool.h"
 #import "DarwinUtils.h"
 
+#ifndef NSAppKitVersionNumber10_5
+#define NSAppKitVersionNumber10_5 949
+#endif
+
+#ifndef NSAppKitVersionNumber10_6
+#define NSAppKitVersionNumber10_6 1038
+#endif
+
 enum iosPlatform
 {
   iDeviceUnknown = -1,
@@ -187,6 +195,19 @@ bool DarwinIsMavericks(void)
   }
 #endif
   return isMavericks == 1;
+}
+
+bool DarwinIsSnowLeopard(void)
+{
+  static int isSnowLeopard = -1;
+#if defined(TARGET_DARWIN_OSX)
+  if (isSnowLeopard == -1)
+  {
+    double appKitVersion = floor(NSAppKitVersionNumber);
+    isSnowLeopard = (appKitVersion <= NSAppKitVersionNumber10_6 && appKitVersion > NSAppKitVersionNumber10_5) ? 1 : 0;
+  }
+#endif
+  return isSnowLeopard == 1;
 }
 
 bool DarwinHasRetina(void)

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -43,6 +43,9 @@
 #endif // defined(HAS_LIBAMCODEC)
 #include "utils/SystemInfo.h"
 #include "windowing/WindowingFactory.h"
+#if defined(TARGET_DARWIN_OSX)
+#include "osx/DarwinUtils.h"
+#endif// defined(TARGET_DARWIN_OSX)
 
 bool AddonHasSettings(const std::string &condition, const std::string &value, const CSetting *setting)
 {
@@ -257,6 +260,10 @@ void CSettingConditions::Initialize()
 #ifdef TARGET_DARWIN_IOS_ATV2
   if (g_sysinfo.IsAppleTV2())
     m_simpleConditions.insert("isappletv2");
+#endif
+#ifdef TARGET_DARWIN_OSX
+  if (DarwinIsSnowLeopard())
+    m_simpleConditions.insert("osxissnowleopard");
 #endif
 #if defined(TARGET_WINDOWS) && defined(HAS_DX)
   m_simpleConditions.insert("has_dx");


### PR DESCRIPTION
On later OSX versions this setting leads to black screen (deep core sdl issue we don't wanna fix ...). There are some users already who have locked theirselfs out because of this.

Please consider it for Gotham.

@Montellese - i think i got it - but i just wanna ping someone about it :D
