### PR TITLE
Some character disappear on mac os x

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -254,11 +254,11 @@ std::string& StringUtils::Trim(std::string &str, const char* const chars)
   return TrimRight(str, chars);
 }
 
-// hack to ensure that std::string::iterator will be dereferenced as _unsigned_ char
-// without this hack "TrimX" functions failed on Win32 with UTF-8 strings
+// hack to check only first byte of UTF-8 character
+// without this hack "TrimX" functions failed on Win32 and OS X with UTF-8 strings
 static int isspace_c(char c)
 {
-  return ::isspace((unsigned char)c);
+  return (c & 0x80) == 0 && ::isspace(c);
 }
 
 std::string& StringUtils::TrimLeft(std::string &str)


### PR DESCRIPTION
std::isspace() of mac os x recognize 0xa0 as whitespace.
I think that it's a bug.
http://en.cppreference.com/w/cpp/string/byte/isspace

'죠' is 0xec, 0xa3, 0xa0
'고' 0xea, 0xb3, 0xa0
Both '죠' and '고' have 0xa0.

Perhaps more character will be affected.
