### PR TITLE
dvdplayer: fix incorrectly indicated buffered samples after ae7cda6629c7...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -32,7 +32,6 @@
 
 CDVDAudioCodecFFmpeg::CDVDAudioCodecFFmpeg() : CDVDAudioCodec()
 {
-  m_iBuffered = 0;
   m_pCodecContext = NULL;
   m_bOpenedCodec = false;
 
@@ -115,8 +114,6 @@ void CDVDAudioCodecFFmpeg::Dispose()
     av_free(m_pCodecContext);
     m_pCodecContext = NULL;
   }
-
-  m_iBuffered = 0;
 }
 
 int CDVDAudioCodecFFmpeg::Decode(uint8_t* pData, int iSize)
@@ -144,11 +141,6 @@ int CDVDAudioCodecFFmpeg::Decode(uint8_t* pData, int iSize)
     iBytesUsed = iSize;
   }
 
-  if(iBytesUsed >= 0)
-    m_iBuffered += iBytesUsed;
-  else
-    m_iBuffered = 0;
-  
   return iBytesUsed;
 }
 
@@ -169,7 +161,6 @@ int CDVDAudioCodecFFmpeg::GetData(uint8_t** dst)
 void CDVDAudioCodecFFmpeg::Reset()
 {
   if (m_pCodecContext) avcodec_flush_buffers(m_pCodecContext);
-  m_iBuffered = 0;
   m_gotFrame = 0;
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -44,7 +44,6 @@ public:
   virtual int GetSampleRate();
   virtual enum AEDataFormat GetDataFormat();
   virtual const char* GetName() { return "FFmpeg"; }
-  virtual int GetBufferSize() { return m_iBuffered; }
   virtual int GetBitRate();
 
 protected:
@@ -56,8 +55,6 @@ protected:
   int m_gotFrame;
 
   bool m_bOpenedCodec;
-  int m_iBuffered;
-
   int      m_channels;
   uint64_t m_layout;
 


### PR DESCRIPTION
...180430a25d834ea83ab5d9f47d77

the conversion buffer was removed so this codec does not buffer anymore. fixes broken TRUEHD.

@elupus for review please.
