### PR TITLE
ActiveAE: fix caching for streams

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1242,7 +1242,10 @@ CActiveAEStream* CActiveAE::CreateStream(MsgStreamNew *streamMsg)
   stream->m_clockId = m_stats.Discontinuity(true);
 
   if (streamMsg->options & AESTREAM_PAUSED)
+  {
     stream->m_paused = true;
+    stream->m_streamIsBuffering = true;
+  }
 
   if (streamMsg->options & AESTREAM_FORCE_RESAMPLE)
     stream->m_forceResampler = true;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -50,7 +50,7 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat *format)
   m_streamDrained = false;
   m_streamFading = false;
   m_streamFreeBuffers = 0;
-  m_streamIsBuffering = true;
+  m_streamIsBuffering = false;
   m_streamSlave = NULL;
   m_leftoverBuffer = new uint8_t[m_format.m_frameSize];
   m_leftoverBytes = 0;


### PR DESCRIPTION
streams not created as PAUSED don't pre-buffer. The flag was not reset which lead to too much data in cache.
