### PR TITLE
renderer: allow some lateness within vblank interval

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -378,6 +378,8 @@ void CXBMCRenderManager::FrameFinish()
   if(g_graphicsContext.IsFullScreenVideo())
     WaitPresentTime(m.timestamp);
 
+  m_clock_framefinish = GetPresentTime();
+
   { CSingleLock lock(m_presentlock);
 
     if(m_presentstep == PRESENT_FRAME)
@@ -1029,6 +1031,12 @@ void CXBMCRenderManager::PrepareNextRender()
 
   double clocktime = GetPresentTime();
   double frametime = 1.0 / GetMaximumFPS();
+  double correction = 0.0;
+  int fps = g_VideoReferenceClock.GetRefreshRate();
+  if((fps > 0) && g_graphicsContext.IsFullScreenVideo() && (clocktime != m_clock_framefinish))
+  {
+    correction = frametime;
+  }
 
   /* see if any future queued frames are already due */
   std::deque<int>::reverse_iterator curr, prev;
@@ -1037,8 +1045,8 @@ void CXBMCRenderManager::PrepareNextRender()
   ++prev;
   while (prev != m_queued.rend())
   {
-    if(clocktime > m_Queue[*prev].timestamp                 /* previous frame is late */
-    && clocktime > m_Queue[*curr].timestamp - frametime)    /* selected frame is close to it's display time */
+    if(clocktime > m_Queue[*prev].timestamp + correction                 /* previous frame is late */
+    && clocktime > m_Queue[*curr].timestamp - frametime + correction)    /* selected frame is close to it's display time */
       break;
     ++curr;
     ++prev;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -242,6 +242,7 @@ protected:
   XbmcThreads::ConditionVariable  m_presentevent;
   CCriticalSection m_presentlock;
   CEvent     m_flushEvent;
+  double     m_clock_framefinish;
 
 
   OVERLAY::CRenderer m_overlays;


### PR DESCRIPTION
this prevents renderer from skipping frames which are not really late. vblank might have already accured when entering PrepareNextFrame. Im this case renderer can catch up.

This is follow up from #4856 by @ossman. Fixes fps dropping to 12 fps with RenderCapture engaged.
