### PR TITLE
Use one font for subtitles

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -24,6 +24,8 @@
 #include "GUIColorManager.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
+#include "settings/AdvancedSettings.h"
+
 
 using namespace std;
 
@@ -165,7 +167,7 @@ void CGUITextLayout::RenderOutline(float x, float y, color_t color, color_t outl
     y -= m_font->GetTextHeight(m_lines.size()) * 0.5f;;
     alignment &= ~XBFONT_CENTER_Y;
   }
-  if (m_borderFont)
+  if (m_borderFont && !g_advancedSettings.m_pseudoBorder)
   {
     // adjust so the baselines of the fonts align
     float by = y + m_font->GetTextBaseLine() - m_borderFont->GetTextBaseLine();
@@ -209,8 +211,22 @@ void CGUITextLayout::RenderOutline(float x, float y, color_t color, color_t outl
     if (align & XBFONT_JUSTIFIED && string.m_carriageReturn)
       align &= ~XBFONT_JUSTIFIED;
 
+    if (m_borderFont && g_advancedSettings.m_pseudoBorder)
+    {
+      float diff = m_borderFont->GetLineHeight() / 12;
+      m_font->DrawText(x-diff, y-diff, outlineColors, 0, string.m_text, align, 0);
+      m_font->DrawText(x-diff, y+diff, outlineColors, 0, string.m_text, align, 0);
+      m_font->DrawText(x-diff, y,      outlineColors, 0, string.m_text, align, 0);
+      m_font->DrawText(x,      y-diff, outlineColors, 0, string.m_text, align, 0);
+      m_font->DrawText(x,      y+diff, outlineColors, 0, string.m_text, align, 0);
+      m_font->DrawText(x+diff, y-diff, outlineColors, 0, string.m_text, align, 0);
+      m_font->DrawText(x+diff, y+diff, outlineColors, 0, string.m_text, align, 0);
+      m_font->DrawText(x+diff, y,      outlineColors, 0, string.m_text, align, 0);
+    }
+
     // don't pass maxWidth through to the renderer for the reason above.
     m_font->DrawText(x, y, m_colors, 0, string.m_text, align, 0);
+    
     y += m_font->GetLineHeight();
   }
   m_font->End();

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -418,6 +418,8 @@ void CAdvancedSettings::Initialize()
   #endif
 
   m_userAgent = g_sysinfo.GetUserAgent();
+  
+  m_pseudoBorder = false;
 
   m_initialized = true;
 }
@@ -1181,6 +1183,12 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "visualizedirtyregions", m_guiVisualizeDirtyRegions);
     XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
     XMLUtils::GetInt(pElement, "nofliptimeout",             m_guiDirtyRegionNoFlipTimeout);
+  }
+  
+  pElement = pRootElement->FirstChildElement("pseudoborder");
+  if (pElement)
+  {
+    XMLUtils::GetBoolean(pRootElement, "pseudoborder", m_pseudoBorder);
   }
 
   // load in the settings overrides

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -410,6 +410,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     CStdString m_logFolder;
 
     CStdString m_userAgent;
+  
+    bool m_pseudoBorder;
 
   private:
     void setExtraLogLevel(const std::vector<CVariant> &components);


### PR DESCRIPTION
Subtitle text have two fonts. (m_font, m_borderFont).
Each font have a texture for font atlas.

When character caches are full, they will reallocate their textures.
Video memory is fragmented by two growing textures.

Defragment is not fast enough to avoid stuttering on some system.

In this case, I think that the best way is merged into one atlas.
Many codes should be rewritten for that.

Easy way is that subtitles use one font.
Boder is drawn by drawing 8 directions with m_font. 
Of course, border is a ugly.
