### PR TITLE
Reduce reallocation texture of subtitle font

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGUI.cpp
@@ -62,14 +62,14 @@ static CGUITextLayout* GetFontLayout()
                                                     , 0
                                                     , CSettings::Get().GetInt("subtitles.height")
                                                     , CSettings::Get().GetInt("subtitles.style")
-                                                    , false, 1.0f, 1.0f, &pal, true);
+                                                    , false, 1.0f, 1.0f, &pal, true, true);
     CGUIFont *border_font   = g_fontManager.LoadTTF("__subtitleborder__"
                                                     , font_path
                                                     , 0xFF000000
                                                     , 0
                                                     , CSettings::Get().GetInt("subtitles.height")
                                                     , CSettings::Get().GetInt("subtitles.style")
-                                                    , true, 1.0f, 1.0f, &pal, true);
+                                                    , true, 1.0f, 1.0f, &pal, true, true);
     if (!subtitle_font || !border_font)
       CLog::Log(LOGERROR, "CGUIWindowFullScreen::OnMessage(WINDOW_INIT) - Unable to load subtitle font");
     else

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -91,7 +91,7 @@ static bool CheckFont(CStdString& strPath, const CStdString& newPath,
   return true;
 }
 
-CGUIFont* GUIFontManager::LoadTTF(const CStdString& strFontName, const CStdString& strFilename, color_t textColor, color_t shadowColor, const int iSize, const int iStyle, bool border, float lineSpacing, float aspect, const RESOLUTION_INFO *sourceRes, bool preserveAspect)
+CGUIFont* GUIFontManager::LoadTTF(const CStdString& strFontName, const CStdString& strFilename, color_t textColor, color_t shadowColor, const int iSize, const int iStyle, bool border, float lineSpacing, float aspect, const RESOLUTION_INFO *sourceRes, bool preserveAspect, bool subtitle)
 {
   float originalAspect = aspect;
 
@@ -148,6 +148,9 @@ CGUIFont* GUIFontManager::LoadTTF(const CStdString& strFontName, const CStdStrin
 
       return NULL;
     }
+
+    if (subtitle)
+      pFontFile->KeepGlyphs();
 
     m_vecFontFiles.push_back(pFontFile);
   }

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -64,7 +64,7 @@ public:
 
   void Unload(const CStdString& strFontName);
   void LoadFonts(const std::string &fontSet);
-  CGUIFont* LoadTTF(const CStdString& strFontName, const CStdString& strFilename, color_t textColor, color_t shadowColor, const int iSize, const int iStyle, bool border = false, float lineSpacing = 1.0f, float aspect = 1.0f, const RESOLUTION_INFO *res = NULL, bool preserveAspect = false);
+  CGUIFont* LoadTTF(const CStdString& strFontName, const CStdString& strFilename, color_t textColor, color_t shadowColor, const int iSize, const int iStyle, bool border = false, float lineSpacing = 1.0f, float aspect = 1.0f, const RESOLUTION_INFO *res = NULL, bool preserveAspect = false, bool subtitle = false);
   CGUIFont* GetFont(const CStdString& strFontName, bool fallback = true);
 
   /*! \brief return a default font

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -179,11 +179,7 @@ void CGUIFontTTFBase::RemoveReference()
 
 void CGUIFontTTFBase::ClearCharacterCache()
 {
-  delete(m_texture);
-
-  DeleteHardwareTexture();
-
-  m_texture = NULL;
+  ClearTexture();
   delete[] m_char;
   m_char = new Character[CHAR_CHUNK];
   memset(m_charquick, 0, sizeof(m_charquick));
@@ -192,7 +188,6 @@ void CGUIFontTTFBase::ClearCharacterCache()
   // set the posX and posY so that our texture will be created on first character write.
   m_posX = m_textureWidth;
   m_posY = -(int)GetTextureLineHeight();
-  m_textureHeight = 0;
 }
 
 void CGUIFontTTFBase::Clear()

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -33,12 +33,14 @@ class CBaseTexture;
 struct FT_FaceRec_;
 struct FT_LibraryRec_;
 struct FT_GlyphSlotRec_;
+struct FT_GlyphRec_;
 struct FT_BitmapGlyphRec_;
 struct FT_StrokerRec_;
 
 typedef struct FT_FaceRec_ *FT_Face;
 typedef struct FT_LibraryRec_ *FT_Library;
 typedef struct FT_GlyphSlotRec_ *FT_GlyphSlot;
+typedef struct FT_GlyphRec_ *FT_Glyph;
 typedef struct FT_BitmapGlyphRec_ *FT_BitmapGlyph;
 typedef struct FT_StrokerRec_ *FT_Stroker;
 
@@ -81,6 +83,8 @@ public:
   virtual void End() = 0;
 
   const CStdString& GetFileName() const { return m_strFileName; };
+
+  void KeepGlyphs();
 
 protected:
   struct Character
@@ -125,6 +129,7 @@ protected:
 
   unsigned int m_textureWidth;       // width of our texture
   unsigned int m_textureHeight;      // heigth of our texture
+  unsigned int m_textureHeightMax;
   int m_posX;                        // current position in the texture
   int m_posY;
 
@@ -172,6 +177,8 @@ private:
   CGUIFontTTFBase(const CGUIFontTTFBase&);
   CGUIFontTTFBase& operator=(const CGUIFontTTFBase&);
   int m_referenceCount;
+  bool m_keepGlyphs;
+  std::map<character_t, FT_Glyph> m_glyphs;
 };
 
 #if defined(HAS_GL) || defined(HAS_GLES)

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -115,7 +115,8 @@ protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight) = 0;
   virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2) = 0;
   virtual void DeleteHardwareTexture() = 0;
-
+  virtual void ClearTexture() = 0;
+  
   // modifying glyphs
   void EmboldenGlyph(FT_GlyphSlot slot);
   static void ObliqueGlyph(FT_GlyphSlot slot);

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -328,5 +328,27 @@ void CGUIFontTTFDX::DeleteHardwareTexture()
   
 }
 
+void CGUIFontTTFDX::ClearTexture()
+{
+  LPDIRECT3DTEXTURE9 texture = ((CDXTexture *)m_texture)->GetTextureObject();
+  LPDIRECT3DSURFACE9 target;
+  if (m_speedupTexture)
+    m_speedupTexture->GetSurfaceLevel(0, &target);
+  else
+    texture->GetSurfaceLevel(0, &target);
+
+  D3DLOCKED_RECT lr;
+  HRESULT hr = target->LockRect(&lr, NULL, 0);
+  if (FAILED(hr))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": Failed to lock texture (0x%08X)", hr);
+    return;
+  }
+  
+  memset(lr.pBits, 0, lr.Pitch * m_textureHeight);
+
+  target->UnlockRect();
+}
+
 
 #endif

--- a/xbmc/guilib/GUIFontTTFDX.h
+++ b/xbmc/guilib/GUIFontTTFDX.h
@@ -48,6 +48,7 @@ protected:
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);
   virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2);
   virtual void DeleteHardwareTexture();
+  virtual void ClearTexture();
   CD3DTexture *m_speedupTexture;  // extra texture to speed up reallocations when the main texture is in d3dpool_default.
                                   // that's the typical situation of Windows Vista and above.
   uint16_t* m_index;

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -314,4 +314,10 @@ void CGUIFontTTFGL::DeleteHardwareTexture()
   }
 }
 
+void CGUIFontTTFGL::ClearTexture()
+{
+  if (m_texture)
+    memset(m_texture->GetPixels(), 0, m_textureHeight * m_texture->GetPitch());
+}
+
 #endif

--- a/xbmc/guilib/GUIFontTTFGL.h
+++ b/xbmc/guilib/GUIFontTTFGL.h
@@ -62,6 +62,7 @@ private:
   };
   
   TextureStatus m_textureStatus;
+  virtual void ClearTexture();
 };
 
 #endif


### PR DESCRIPTION
Subtitle character cache texture is initialized for 100 letters.
Actual size is determined by subtitle font size.
Texture will be overwritten if cache is full.

If text length at the same is exceeded 100 letters, texture size will be increased to text length.
But this will not happen normally.

---

Subtitle text have two fonts. (m_font, m_borderFont).
Each font have a texture for font atlas.

When character caches are full, they will reallocate their textures.
Video memory is fragmented by two growing textures.

Defragment is not fast enough to avoid stuttering on some system.
