### PR TITLE
fftfixes

### DIFF
--- a/xbmc/utils/fft.cpp
+++ b/xbmc/utils/fft.cpp
@@ -26,7 +26,7 @@
 
 
 #include <math.h>
-
+#include <algorithm>
 #include "fft.h"
 
 #ifndef M_PI
@@ -37,9 +37,11 @@
 #define M_SQRT2 1.4142135623730950488016887242097
 #endif
 
-
-
-
+// WARNING:
+// Whenever you call that method directly, make sure
+// that you pass in ptr - 1. Also remember this method 
+// has a complex result. You most likely want to have a 
+// realfft only instead
 void fft( float data[], int nn, int isign )
 {
   int n = nn << 1;
@@ -52,8 +54,8 @@ void fft( float data[], int nn, int isign )
   {
     if ( j > i )
     {
-      swap( data[j], data[i] );
-      swap( data[j + 1], data[i + 1] );
+      std::swap( data[j], data[i] );
+      std::swap( data[j + 1], data[i + 1] );
     }
     m = nn;
     while ( m >= 2 && j > m )

--- a/xbmc/utils/test/Testfft.cpp
+++ b/xbmc/utils/test/Testfft.cpp
@@ -255,34 +255,16 @@ TEST(Testfft, fft)
 {
   int i;
   float vardata[REFDATA_NUMELEMENTS];
-  CStdString refstr, varstr;
+  float res;
 
   memcpy(vardata, refdata, sizeof(refdata));
   fft(vardata - 1, REFDATA_NUMELEMENTS/2, 1);
-  for (i = 0; i < REFDATA_NUMELEMENTS; i++)
-  {
-    /* To more consistently test the resulting floating point numbers, they
-     * are converted to strings and the strings are tested for equality.
-     */
-    refstr = StringUtils::Format("%.6f", reffftdata[i]);
-    varstr = StringUtils::Format("%.6f", vardata[i]);
-    EXPECT_STREQ(refstr.c_str(), varstr.c_str());
-  }
-}
-
-TEST(Testfft, fft_inverse)
-{
-  int i;
-  float vardata[REFDATA_NUMELEMENTS];
-  CStdString refstr, varstr;
-
-  memcpy(vardata, refdata, sizeof(refdata));
+  // let's see if it's okay enough
   fft(vardata -1, REFDATA_NUMELEMENTS/2, -1);
   for (i = 0; i < REFDATA_NUMELEMENTS; i++)
   {
-    refstr = StringUtils::Format("%.6f", reffftinversedata[i]);
-    varstr = StringUtils::Format("%.6f", vardata[i]);
-    EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+    res =  vardata[i] / (REFDATA_NUMELEMENTS / 2);
+    EXPECT_NEAR(res, refdata[i], 0.000001);
   }
 }
 

--- a/xbmc/utils/test/Testfft.cpp
+++ b/xbmc/utils/test/Testfft.cpp
@@ -258,7 +258,7 @@ TEST(Testfft, fft)
   CStdString refstr, varstr;
 
   memcpy(vardata, refdata, sizeof(refdata));
-  fft(vardata, REFDATA_NUMELEMENTS/2, 1);
+  fft(vardata - 1, REFDATA_NUMELEMENTS/2, 1);
   for (i = 0; i < REFDATA_NUMELEMENTS; i++)
   {
     /* To more consistently test the resulting floating point numbers, they
@@ -277,7 +277,7 @@ TEST(Testfft, fft_inverse)
   CStdString refstr, varstr;
 
   memcpy(vardata, refdata, sizeof(refdata));
-  fft(vardata, REFDATA_NUMELEMENTS/2, -1);
+  fft(vardata -1, REFDATA_NUMELEMENTS/2, -1);
   for (i = 0; i < REFDATA_NUMELEMENTS; i++)
   {
     refstr = StringUtils::Format("%.6f", reffftinversedata[i]);


### PR DESCRIPTION
This fixes an off by one error when calling fft directly (heap corruption). The test currently is bogus for fft and fft_inverse as both are complex.
