### PR TITLE
[android] fix extraction of ndk version for 64bit ndk

### DIFF
--- a/tools/depends/configure.in
+++ b/tools/depends/configure.in
@@ -381,7 +381,7 @@ if test "$platform_os" == "android"; then
   if ! test -f "$use_ndk/RELEASE.TXT" ; then
     AC_MSG_ERROR("$use_ndk is not an NDK directory")
   fi
-  use_ndk_ver=0x`cat $use_ndk/RELEASE.TXT | sed 's/^r\([0-9]\+\)\b/r\10/' | sed 's/^r\(.*\)\b.*/\1/'`
+  use_ndk_ver=0x`cat $use_ndk/RELEASE.TXT | sed 's/^r\([[0-9a-z]]\+\)\b.*/\1/'`
 
   if test -z $use_sdk_path; then
     AC_MSG_ERROR("SDK path is required for android")


### PR DESCRIPTION
With existing stuff it outputs "9d (64bit" on 64bit NDK.

I dunno whether the sed'ing is correct or not for in something processed by autoconf ;)

@koying, @t-nelson please take a looksee - thanks!
