### PR TITLE
VideoReferenceClock: make refresh rate floating point + cleanup

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -159,7 +159,7 @@ static double wrap(double x, double minimum, double maximum)
 void CXBMCRenderManager::WaitPresentTime(double presenttime)
 {
   double frametime;
-  int fps = g_VideoReferenceClock.GetRefreshRate(&frametime);
+  double fps = g_VideoReferenceClock.GetRefreshRate(&frametime);
   if(fps <= 0)
   {
     /* smooth video not enabled */

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -211,14 +211,14 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
     return -1;
 
   //check if the videoreferenceclock is running, will return -1 if not
-  int rate = g_VideoReferenceClock.GetRefreshRate(interval);
+  double rate = g_VideoReferenceClock.GetRefreshRate(interval);
 
   if (rate <= 0)
     return -1;
 
   CSingleLock lock(m_speedsection);
 
-  double weight = (double)rate / (double)MathUtils::round_int(fps);
+  double weight = rate / (double)MathUtils::round_int(fps);
 
   //set the speed of the videoreferenceclock based on fps, refreshrate and maximum speed adjust set by user
   if (m_maxspeedadjust > 0.05)
@@ -227,7 +227,7 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
     &&  weight / MathUtils::round_int(weight) > 1.0 - m_maxspeedadjust / 100.0)
       weight = MathUtils::round_int(weight);
   }
-  double speed = (double)rate / (fps * weight);
+  double speed = rate / (fps * weight);
   lock.Leave();
 
   g_VideoReferenceClock.SetSpeed(speed);

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -400,18 +400,6 @@ bool CVideoReferenceClock::SetupGLX()
   return true;
 }
 
-int CVideoReferenceClock::GetRandRRate()
-{
-  int RefreshRate;
-  XRRScreenConfiguration *CurrInfo;
-
-  CurrInfo = XRRGetScreenInfo(m_Dpy, g_Windowing.GetWindow());
-  RefreshRate = XRRConfigCurrentRate(CurrInfo);
-  XRRFreeScreenConfigInfo(CurrInfo);
-
-  return RefreshRate;
-}
-
 void CVideoReferenceClock::CleanupGLX()
 {
   CLog::Log(LOGDEBUG, "CVideoReferenceClock: Cleaning up GLX");

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -69,10 +69,10 @@ class CVideoReferenceClock : public CThread
     int64_t GetFrequency();
     void    SetSpeed(double Speed);
     double  GetSpeed();
-    int     GetRefreshRate(double* interval = NULL);
+    double  GetRefreshRate(double* interval = NULL);
     int64_t Wait(int64_t Target);
     bool    WaitStarted(int MSecs);
-    bool    GetClockInfo(int& MissedVblanks, double& ClockSpeed, int& RefreshRate);
+    bool    GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate);
     void    SetFineAdjust(double fineadjust);
     void    RefreshChanged() { m_RefreshChanged = 1; }
 
@@ -103,7 +103,7 @@ class CVideoReferenceClock : public CThread
     double  m_fineadjust;
 
     bool    m_UseVblank;         //set to true when vblank is used as clock source
-    int64_t m_RefreshRate;       //current refreshrate
+    double  m_RefreshRate;       //current refreshrate
     int     m_PrevRefreshRate;   //previous refreshrate, used for log printing and getting refreshrate from nvidia-settings
     int     m_MissedVblanks;     //number of clock updates missed by the vblank clock
     int     m_RefreshChanged;    //1 = we changed the refreshrate, 2 = we should check the refreshrate forced

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -128,12 +128,8 @@ class CVideoReferenceClock : public CThread
     XVisualInfo *m_vInfo;
     Window       m_Window;
     GLXContext   m_Context;
-    Pixmap       m_pixmap;
-    GLXPixmap    m_glPixmap;
     bool         m_xrrEvent;
     CEvent       m_releaseEvent, m_resetEvent;
-
-    bool         m_bIsATI;
 
 #elif defined(TARGET_WINDOWS) && defined(HAS_DX)
     bool   SetupD3D();

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -119,7 +119,6 @@ class CVideoReferenceClock : public CThread
     bool SetupGLX();
     void RunGLX();
     void CleanupGLX();
-    int  GetRandRRate();
 
     int  (*m_glXWaitVideoSyncSGI) (int, int, unsigned int*);
     int  (*m_glXGetVideoSyncSGI)  (unsigned int*);

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -590,12 +590,12 @@ void CGUIWindowFullScreen::FrameMove()
       CStdString strCores = g_cpuInfo.GetCoresUsageString();
 #endif
       int    missedvblanks;
-      int    refreshrate;
+      double refreshrate;
       double clockspeed;
       CStdString strClock;
 
       if (g_VideoReferenceClock.GetClockInfo(missedvblanks, clockspeed, refreshrate))
-        strClock = StringUtils::Format("S( refresh:%i missed:%i speed:%+.3f%% %s )"
+        strClock = StringUtils::Format("S( refresh:%.3f missed:%i speed:%+.3f%% %s )"
                                        , refreshrate
                                        , missedvblanks
                                        , clockspeed - 100.0


### PR DESCRIPTION
I am tired of explaining "why does XBMC speed up my video". Users are confused by the rounded value of refresh rate. On Linux refresh rate is detected by 

```
m_RefreshRate = g_graphicsContext.GetFPS()
```

means that GraphicsContext always knows the current refresh rate. Any further detection of refresh rate  in videorefclock is unneeded and messy. 

I encourage other platform devs to do some clean-up too. According to the forums measurement of refresh rate on Windows is utterly broken (g_advancedSettings.m_measureRefreshrate)
