### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -24,11 +24,7 @@
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
-#ifdef TARGET_POSIX
 #include "stdint.h"
-#else
-#define INT64_C __int64
-#endif
 
 #include "EncoderFFmpeg.h"
 #include "filesystem/File.h"

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -195,7 +195,7 @@ unsigned int CActiveAEStream::GetSpace()
 unsigned int CActiveAEStream::AddData(uint8_t* const *data, unsigned int offset, unsigned int frames, double pts)
 {
   Message *msg;
-  int copied = 0;
+  unsigned int copied = 0;
   int sourceFrames = frames;
   uint8_t* const *buf = data;
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1032,12 +1032,12 @@ void CDVDPlayer::Process()
   {
     if (m_PlayerOptions.startpercent > 0 && m_pDemuxer)
     {
-      int64_t playerStartTime = (int64_t) ( ( (float) m_pDemuxer->GetStreamLength() ) * ( m_PlayerOptions.startpercent/(float)100 ) );
+      int playerStartTime = (int)( ( (float) m_pDemuxer->GetStreamLength() ) * ( m_PlayerOptions.startpercent/(float)100 ) );
       starttime = m_Edl.RestoreCutTime(playerStartTime);
     }
     else
     {
-      starttime = m_Edl.RestoreCutTime((int64_t)m_PlayerOptions.starttime * 1000); // s to ms
+      starttime = m_Edl.RestoreCutTime(m_PlayerOptions.starttime * 1000); // s to ms
     }
     CLog::Log(LOGDEBUG, "%s - Start position set to last stopped position: %d", __FUNCTION__, starttime);
   }
@@ -1883,11 +1883,11 @@ void CDVDPlayer::CheckAutoSceneSkip()
     /*
      * Seeking either goes to the start or the end of the cut depending on the play direction.
      */
-    int64_t seek = GetPlaySpeed() >= 0 ? cut.end : cut.start;
+    int seek = GetPlaySpeed() >= 0 ? cut.end : cut.start;
     /*
      * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
      */
-    m_messenger.Put(new CDVDMsgPlayerSeek((int)seek, true, false, true, false, true));
+    m_messenger.Put(new CDVDMsgPlayerSeek(seek, true, false, true, false, true));
     /*
      * Seek doesn't always work reliably. Last physical seek time is recorded to prevent looping
      * if there was an error with seeking and it landed somewhere unexpected, perhaps back in the
@@ -2036,7 +2036,7 @@ void CDVDPlayer::HandleMessages()
 
         double start = DVD_NOPTS_VALUE;
 
-        int time = msg.GetRestore() ? (int)m_Edl.RestoreCutTime(msg.GetTime()) : msg.GetTime();
+        int time = msg.GetRestore() ? m_Edl.RestoreCutTime(msg.GetTime()) : msg.GetTime();
 
         // if input streams doesn't support seektime we must convert back to clock
         if(dynamic_cast<CDVDInputStream::ISeekTime*>(m_pInputStream) == NULL)
@@ -2562,13 +2562,13 @@ bool CDVDPlayer::SeekScene(bool bPlus)
   if (!bPlus && clock > 5 * 1000) // 5 seconds
     clock -= 5 * 1000;
 
-  int64_t iScenemarker;
+  int iScenemarker;
   if (m_Edl.GetNextSceneMarker(bPlus, clock, &iScenemarker))
   {
     /*
      * Seeking is flushed and inaccurate, just like Seek()
      */
-    m_messenger.Put(new CDVDMsgPlayerSeek((int)iScenemarker, !bPlus, true, false, false));
+    m_messenger.Put(new CDVDMsgPlayerSeek(iScenemarker, !bPlus, true, false, false));
     SynchronizeDemuxer(100);
     return true;
   }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -107,7 +107,7 @@ SelectionStream& CSelectionStreams::Get(StreamType type, int index)
 {
   CSingleLock lock(m_section);
   int count = -1;
-  for(int i=0;i<(int)m_Streams.size();i++)
+  for(size_t i=0;i<m_Streams.size();i++)
   {
     if(m_Streams[i].type != type)
       continue;
@@ -292,7 +292,7 @@ static bool PredicateVideoPriority(const SelectionStream& lh, const SelectionStr
 bool CSelectionStreams::Get(StreamType type, CDemuxStream::EFlags flag, SelectionStream& out)
 {
   CSingleLock lock(m_section);
-  for(int i=0;i<(int)m_Streams.size();i++)
+  for(size_t i=0;i<m_Streams.size();i++)
   {
     if(m_Streams[i].type != type)
       continue;
@@ -308,7 +308,7 @@ int CSelectionStreams::IndexOf(StreamType type, int source, int id) const
 {
   CSingleLock lock(m_section);
   int count = -1;
-  for(int i=0;i<(int)m_Streams.size();i++)
+  for(size_t i=0;i<m_Streams.size();i++)
   {
     if(type && m_Streams[i].type != type)
       continue;
@@ -357,7 +357,7 @@ int CSelectionStreams::Source(StreamSource source, std::string filename)
 {
   CSingleLock lock(m_section);
   int index = source - 1;
-  for(int i=0;i<(int)m_Streams.size();i++)
+  for(size_t i=0;i<m_Streams.size();i++)
   {
     SelectionStream &s = m_Streams[i];
     if(STREAM_SOURCE_MASK(s.source) != source)

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -728,7 +728,7 @@ bool CDVDPlayer::OpenDemuxStream()
   int64_t len = m_pInputStream->GetLength();
   int64_t tim = m_pDemuxer->GetStreamLength();
   if(len > 0 && tim > 0)
-    m_pInputStream->SetReadRate(g_advancedSettings.m_readBufferFactor * len * 1000 / tim);
+    m_pInputStream->SetReadRate((unsigned int) (g_advancedSettings.m_readBufferFactor * len * 1000 / tim));
 
   return true;
 }
@@ -1587,7 +1587,7 @@ void CDVDPlayer::HandlePlaySpeed()
           &&  m_SpeedState.lasttime != GetTime())
     {
       m_SpeedState.lastpts  = m_dvdPlayerVideo.GetCurrentPts();
-      m_SpeedState.lasttime = GetTime();
+      m_SpeedState.lasttime = (double) GetTime();
       // check how much off clock video is when ff/rw:ing
       // a problem here is that seeking isn't very accurate
       // and since the clock will be resynced after seek
@@ -1606,7 +1606,7 @@ void CDVDPlayer::HandlePlaySpeed()
       {
         CLog::Log(LOGDEBUG, "CDVDPlayer::Process - Seeking to catch up");
         int64_t iTime = (int64_t)DVD_TIME_TO_MSEC(m_clock.GetClock() + m_State.time_offset + 500000.0 * m_playSpeed / DVD_PLAYSPEED_NORMAL);
-        m_messenger.Put(new CDVDMsgPlayerSeek(iTime, (GetPlaySpeed() < 0), true, false, false, true));
+        m_messenger.Put(new CDVDMsgPlayerSeek((int) iTime, (GetPlaySpeed() < 0), true, false, false, true));
       }
     }
   }
@@ -2114,7 +2114,7 @@ void CDVDPlayer::HandleMessages()
             {
               m_dvd.iSelectedAudioStream = -1;
               CloseStream(m_CurrentAudio, false);
-              m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true, true, true));
+              m_messenger.Put(new CDVDMsgPlayerSeek((int) GetTime(), true, true, true, true, true));
             }
           }
           else
@@ -2122,7 +2122,7 @@ void CDVDPlayer::HandleMessages()
             CloseStream(m_CurrentAudio, false);
             OpenStream(m_CurrentAudio, st.id, st.source);
             AdaptForcedSubtitles();
-            m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true, true, true));
+            m_messenger.Put(new CDVDMsgPlayerSeek((int) GetTime(), true, true, true, true, true));
           }
         }
       }
@@ -2477,7 +2477,7 @@ void CDVDPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   }
   else
   {
-    float percent;
+    int percent;
     if (bLargeStep)
       percent = bPlus ? g_advancedSettings.m_videoPercentSeekForwardBig : g_advancedSettings.m_videoPercentSeekBackwardBig;
     else
@@ -2652,7 +2652,7 @@ float CDVDPlayer::GetPercentage()
 float CDVDPlayer::GetCachePercentage()
 {
   CSingleLock lock(m_StateSection);
-  return m_StateInput.cache_offset * 100; // NOTE: Percentage returned is relative
+  return (float) (m_StateInput.cache_offset * 100); // NOTE: Percentage returned is relative
 }
 
 void CDVDPlayer::SetAVDelay(float fValue)
@@ -2662,7 +2662,7 @@ void CDVDPlayer::SetAVDelay(float fValue)
 
 float CDVDPlayer::GetAVDelay()
 {
-  return m_dvdPlayerVideo.GetDelay() / (float)DVD_TIME_BASE;
+  return (float) m_dvdPlayerVideo.GetDelay() / (float)DVD_TIME_BASE;
 }
 
 void CDVDPlayer::SetSubTitleDelay(float fValue)
@@ -2672,7 +2672,7 @@ void CDVDPlayer::SetSubTitleDelay(float fValue)
 
 float CDVDPlayer::GetSubTitleDelay()
 {
-  return -m_dvdPlayerVideo.GetSubtitleDelay() / DVD_TIME_BASE;
+  return (float) -m_dvdPlayerVideo.GetSubtitleDelay() / DVD_TIME_BASE;
 }
 
 // priority: 1: libdvdnav, 2: external subtitles, 3: muxed subtitles
@@ -3614,7 +3614,7 @@ bool CDVDPlayer::OnAction(const CAction &action)
       case ACTION_CHANNEL_SWITCH:
       {
         // Offset from key codes back to button number
-        int channel = action.GetAmount();
+        int channel = (int) action.GetAmount();
         m_messenger.Put(new CDVDMsgInt(CDVDMsg::PLAYER_CHANNEL_SELECT_NUMBER, channel));
         g_infoManager.SetDisplayAfterSeek();
         ShowPVRChannelInfo();
@@ -3938,8 +3938,8 @@ void CDVDPlayer::UpdatePlayState(double timeout)
 
   if (m_Edl.HasCut())
   {
-    state.time        = m_Edl.RemoveCutTime(llrint(state.time));
-    state.time_total  = m_Edl.RemoveCutTime(llrint(state.time_total));
+    state.time        = (double) m_Edl.RemoveCutTime(llrint(state.time));
+    state.time_total  = (double) m_Edl.RemoveCutTime(llrint(state.time_total));
   }
 
   if(state.time_total <= 0)
@@ -3987,7 +3987,7 @@ void CDVDPlayer::UpdatePlayState(double timeout)
   {
     state.cache_bytes = status.forward;
     if(state.time_total)
-      state.cache_bytes += m_pInputStream->GetLength() * GetQueueTime() / state.time_total;
+      state.cache_bytes += m_pInputStream->GetLength() * (int64_t) (GetQueueTime() / state.time_total);
   }
   else
     state.cache_bytes = 0;
@@ -4070,7 +4070,7 @@ bool CDVDPlayer::GetStreamDetails(CStreamDetails &details)
 
       int64_t duration = GetTotalTime() / 1000;
       if (duration > 0)
-        ((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_iDuration = duration;
+        ((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_iDuration = (int) duration;
     }
     return result;
   }

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -558,7 +558,7 @@ void CDVDPlayerAudio::Process()
     if (m_silence)
     {
       int size = audioframe.nb_frames * audioframe.framesize * audioframe.channel_count / audioframe.planes;
-      for (int i=0; i<audioframe.planes; i++)
+      for (unsigned int i=0; i<audioframe.planes; i++)
         memset(audioframe.data[i], 0, size);
     }
 

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -755,7 +755,7 @@ bool CEdl::AddCut(Cut& cut)
   return true;
 }
 
-bool CEdl::AddSceneMarker(const int64_t iSceneMarker)
+bool CEdl::AddSceneMarker(const int iSceneMarker)
 {
   Cut cut;
 
@@ -815,12 +815,12 @@ bool CEdl::HasCut()
   return !m_vecCuts.empty();
 }
 
-int64_t CEdl::GetTotalCutTime()
+int CEdl::GetTotalCutTime()
 {
   return m_iTotalCutTime; // ms
 }
 
-int64_t CEdl::RemoveCutTime(int64_t iSeek)
+int CEdl::RemoveCutTime(int iSeek)
 {
   if (!HasCut())
     return iSeek;
@@ -830,7 +830,7 @@ int64_t CEdl::RemoveCutTime(int64_t iSeek)
    * requested is later than the end of the last recorded cut. For example, when calculating the
    * total duration for display.
    */
-  int64_t iCutTime = 0;
+  int iCutTime = 0;
   for (int i = 0; i < (int)m_vecCuts.size(); i++)
   {
     if (m_vecCuts[i].action == CUT)
@@ -844,12 +844,12 @@ int64_t CEdl::RemoveCutTime(int64_t iSeek)
   return iSeek - iCutTime;
 }
 
-int64_t CEdl::RestoreCutTime(int64_t iClock)
+int CEdl::RestoreCutTime(int iClock)
 {
   if (!HasCut())
     return iClock;
 
-  int64_t iSeek = iClock;
+  int iSeek = iClock;
   for (int i = 0; i < (int)m_vecCuts.size(); i++)
   {
     if (m_vecCuts[i].action == CUT && iSeek >= m_vecCuts[i].start)
@@ -898,7 +898,7 @@ std::string CEdl::GetInfo()
   return strInfo.empty() ? "-" : strInfo;
 }
 
-bool CEdl::InCut(const int64_t iSeek, Cut *pCut)
+bool CEdl::InCut(const int iSeek, Cut *pCut)
 {
   for (int i = 0; i < (int)m_vecCuts.size(); i++)
   {
@@ -916,14 +916,14 @@ bool CEdl::InCut(const int64_t iSeek, Cut *pCut)
   return false;
 }
 
-bool CEdl::GetNextSceneMarker(bool bPlus, const int64_t iClock, int64_t *iSceneMarker)
+bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker)
 {
   if (!HasSceneMarker())
     return false;
 
-  int64_t iSeek = RestoreCutTime(iClock);
+  int iSeek = RestoreCutTime(iClock);
 
-  int64_t iDiff = 10 * 60 * 60 * 1000; // 10 hours to ms.
+  int iDiff = 10 * 60 * 60 * 1000; // 10 hours to ms.
   bool bFound = false;
 
   if (bPlus) // Find closest scene forwards
@@ -962,7 +962,7 @@ bool CEdl::GetNextSceneMarker(bool bPlus, const int64_t iClock, int64_t *iSceneM
   return bFound;
 }
 
-std::string CEdl::MillisecondsToTimeString(const int64_t iMilliseconds)
+std::string CEdl::MillisecondsToTimeString(const int iMilliseconds)
 {
   std::string strTimeString = StringUtils::SecondsToTimeString((long)(iMilliseconds / 1000), TIME_FORMAT_HH_MM_SS); // milliseconds to seconds
   strTimeString += StringUtils::Format(".%03i", iMilliseconds % 1000);

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -810,17 +810,17 @@ std::string CEdl::GetMPlayerEdl()
   return MPLAYER_EDL_FILENAME;
 }
 
-bool CEdl::HasCut()
+bool CEdl::HasCut() const
 {
   return !m_vecCuts.empty();
 }
 
-int CEdl::GetTotalCutTime()
+int CEdl::GetTotalCutTime() const
 {
   return m_iTotalCutTime; // ms
 }
 
-int CEdl::RemoveCutTime(int iSeek)
+int CEdl::RemoveCutTime(int iSeek) const
 {
   if (!HasCut())
     return iSeek;
@@ -844,7 +844,7 @@ int CEdl::RemoveCutTime(int iSeek)
   return iSeek - iCutTime;
 }
 
-int CEdl::RestoreCutTime(int iClock)
+int CEdl::RestoreCutTime(int iClock) const
 {
   if (!HasCut())
     return iClock;
@@ -859,12 +859,12 @@ int CEdl::RestoreCutTime(int iClock)
   return iSeek;
 }
 
-bool CEdl::HasSceneMarker()
+bool CEdl::HasSceneMarker() const
 {
   return !m_vecSceneMarkers.empty();
 }
 
-std::string CEdl::GetInfo()
+std::string CEdl::GetInfo() const
 {
   std::string strInfo;
   if (HasCut())
@@ -898,7 +898,7 @@ std::string CEdl::GetInfo()
   return strInfo.empty() ? "-" : strInfo;
 }
 
-bool CEdl::InCut(const int iSeek, Cut *pCut)
+bool CEdl::InCut(const int iSeek, Cut *pCut) const
 {
   for (int i = 0; i < (int)m_vecCuts.size(); i++)
   {
@@ -916,7 +916,7 @@ bool CEdl::InCut(const int iSeek, Cut *pCut)
   return false;
 }
 
-bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker)
+bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker) const
 {
   if (!HasSceneMarker())
     return false;

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -38,7 +38,6 @@ extern "C"
 
 using namespace std;
 
-#define MPLAYER_EDL_FILENAME "special://temp/xbmc.edl"
 #define COMSKIP_HEADER "FILE PROCESSING COMPLETE"
 #define VIDEOREDO_HEADER "<Version>2"
 #define VIDEOREDO_TAG_CUT "<Cut>"
@@ -58,9 +57,6 @@ CEdl::~CEdl()
 
 void CEdl::Clear()
 {
-  if (CFile::Exists(MPLAYER_EDL_FILENAME))
-    CFile::Delete(MPLAYER_EDL_FILENAME);
-
   m_vecCuts.clear();
   m_vecSceneMarkers.clear();
   m_iTotalCutTime = 0;
@@ -166,10 +162,8 @@ bool CEdl::ReadEditDecisionLists(const std::string& strMovie, const float fFrame
   }
 
   if (bFound)
-  {
     MergeShortCommBreaks();
-    WriteMPlayerEdl();
-  }
+
   return bFound;
 }
 
@@ -767,47 +761,6 @@ bool CEdl::AddSceneMarker(const int iSceneMarker)
   m_vecSceneMarkers.push_back(iSceneMarker); // Unsorted
 
   return true;
-}
-
-bool CEdl::WriteMPlayerEdl()
-{
-  if (!HasCut())
-    return false;
-
-  CFile mplayerEdlFile;
-  if (!mplayerEdlFile.OpenForWrite(MPLAYER_EDL_FILENAME, true))
-  {
-    CLog::Log(LOGERROR, "%s - Error opening MPlayer EDL file for writing: %s", __FUNCTION__,
-              MPLAYER_EDL_FILENAME);
-    return false;
-  }
-
-  std::string strBuffer;
-  for (int i = 0; i < (int)m_vecCuts.size(); i++)
-  {
-    /*
-     * MPlayer doesn't understand the scene marker (2) or commercial break (3) identifiers that XBMC
-     * supports in EDL files.
-     *
-     * http://www.mplayerhq.hu/DOCS/HTML/en/edl.html
-     *
-     * Write out mutes (1) directly. Treat commercial breaks as cuts (everything other than MUTES = 0).
-     */
-    strBuffer += StringUtils::Format("%.3f\t%.3f\t%i\n", (float)(m_vecCuts[i].start / 1000),
-                                               (float)(m_vecCuts[i].end / 1000),
-                                               m_vecCuts[i].action == MUTE ? 1 : 0);
-  }
-  mplayerEdlFile.Write(strBuffer.c_str(), strBuffer.size());
-  mplayerEdlFile.Close();
-
-  CLog::Log(LOGDEBUG, "%s - MPlayer EDL file written to: %s", __FUNCTION__, MPLAYER_EDL_FILENAME);
-
-  return true;
-}
-
-std::string CEdl::GetMPlayerEdl()
-{
-  return MPLAYER_EDL_FILENAME;
 }
 
 bool CEdl::HasCut() const

--- a/xbmc/cores/dvdplayer/Edl.h
+++ b/xbmc/cores/dvdplayer/Edl.h
@@ -40,8 +40,8 @@ public:
 
   struct Cut
   {
-    int64_t start; // ms
-    int64_t end;   // ms
+    int start; // ms
+    int end;   // ms
     Action action;
   };
 
@@ -51,23 +51,23 @@ public:
   bool HasCut();
   bool HasSceneMarker();
   std::string GetInfo();
-  int64_t GetTotalCutTime();
-  int64_t RemoveCutTime(int64_t iSeek);
-  int64_t RestoreCutTime(int64_t iClock);
+  int GetTotalCutTime();
+  int RemoveCutTime(int iSeek);
+  int RestoreCutTime(int iClock);
 
-  bool InCut(int64_t iSeek, Cut *pCut = NULL);
+  bool InCut(int iSeek, Cut *pCut = NULL);
 
-  bool GetNextSceneMarker(bool bPlus, const int64_t iClock, int64_t *iSceneMarker);
+  bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
 
   static std::string GetMPlayerEdl();
 
-  static std::string MillisecondsToTimeString(const int64_t iMilliseconds);
+  static std::string MillisecondsToTimeString(const int iMilliseconds);
 
 protected:
 private:
-  int64_t m_iTotalCutTime; // ms
+  int m_iTotalCutTime; // ms
   std::vector<Cut> m_vecCuts;
-  std::vector<int64_t> m_vecSceneMarkers;
+  std::vector<int> m_vecSceneMarkers;
 
   bool ReadEdl(const std::string& strMovie, const float fFramesPerSecond);
   bool ReadComskip(const std::string& strMovie, const float fFramesPerSecond);
@@ -78,7 +78,7 @@ private:
   bool ReadMythCutList(const std::string& strMovie, const float fFramesPerSecond);
 
   bool AddCut(Cut& NewCut);
-  bool AddSceneMarker(const int64_t sceneMarker);
+  bool AddSceneMarker(const int sceneMarker);
 
   bool WriteMPlayerEdl();
 

--- a/xbmc/cores/dvdplayer/Edl.h
+++ b/xbmc/cores/dvdplayer/Edl.h
@@ -48,16 +48,16 @@ public:
   bool ReadEditDecisionLists(const std::string& strMovie, const float fFramesPerSecond, const int iHeight);
   void Clear();
 
-  bool HasCut();
-  bool HasSceneMarker();
-  std::string GetInfo();
-  int GetTotalCutTime();
-  int RemoveCutTime(int iSeek);
-  int RestoreCutTime(int iClock);
+  bool HasCut() const;
+  bool HasSceneMarker() const;
+  std::string GetInfo() const;
+  int GetTotalCutTime() const;
+  int RemoveCutTime(int iSeek) const;
+  int RestoreCutTime(int iClock) const;
 
-  bool InCut(int iSeek, Cut *pCut = NULL);
+  bool InCut(int iSeek, Cut *pCut = NULL) const;
 
-  bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
+  bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker) const;
 
   static std::string GetMPlayerEdl();
 

--- a/xbmc/cores/dvdplayer/Edl.h
+++ b/xbmc/cores/dvdplayer/Edl.h
@@ -59,8 +59,6 @@ public:
 
   bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker) const;
 
-  static std::string GetMPlayerEdl();
-
   static std::string MillisecondsToTimeString(const int iMilliseconds);
 
 protected:
@@ -79,8 +77,6 @@ private:
 
   bool AddCut(Cut& NewCut);
   bool AddSceneMarker(const int sceneMarker);
-
-  bool WriteMPlayerEdl();
 
   void MergeShortCommBreaks();
 };

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -2887,13 +2887,13 @@ bool COMXPlayer::SeekScene(bool bPlus)
   if (!bPlus && clock > 5 * 1000) // 5 seconds
     clock -= 5 * 1000;
 
-  int64_t iScenemarker;
+  int iScenemarker;
   if (m_Edl.GetNextSceneMarker(bPlus, clock, &iScenemarker))
   {
     /*
      * Seeking is flushed and inaccurate, just like Seek()
      */
-    m_messenger.Put(new CDVDMsgPlayerSeek((int)iScenemarker, !bPlus, true, false, false));
+    m_messenger.Put(new CDVDMsgPlayerSeek(iScenemarker, !bPlus, true, false, false));
     SynchronizeDemuxer(100);
     return true;
   }


### PR DESCRIPTION
Follow up to https://github.com/xbmc/xbmc/pull/4867

@FernetMenta this switches EDL to use int (handled +/- 600 hours)  Not sure if we want to go this way or switch the dvdplayer API to int64_t, or even double (the main player API is a mix of int64_t and double).

Am happy to switch around as we deem necessary.

@elupus any thoughts?
