### PR TITLE
More efficient info label assembling

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4994,8 +4994,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr)
   //We don't know if there is unsecure information in this yet, so we
   //postpone any logging
   const std::string in_actionStr(actionStr);
-  CGUIInfoLabel info(actionStr, "");
-  actionStr = info.GetLabel(0);
+  actionStr = CGUIInfoLabel::GetLabel(actionStr);
 
   // user has asked for something to be executed
   if (CBuiltins::HasCommand(actionStr))

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1354,7 +1354,7 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const CStdString &format)
   return TIME_FORMAT_GUESS;
 }
 
-CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fallback)
+CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *fallback)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
     return GetSkinVariableString(info, false);
@@ -3119,7 +3119,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const GUIInfo &info, int conte
 }
 
 /// \brief Examines the multi information sent and returns the string as appropriate
-CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWindow, CStdString *fallback)
+CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWindow, std::string *fallback)
 {
   if (info.m_info == SKIN_STRING)
   {
@@ -3333,7 +3333,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
 }
 
 /// \brief Obtains the filename of the image to show from whichever subsystem is needed
-CStdString CGUIInfoManager::GetImage(int info, int contextWindow, CStdString *fallback)
+CStdString CGUIInfoManager::GetImage(int info, int contextWindow, std::string *fallback)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
     return GetSkinVariableString(info, true);
@@ -4407,7 +4407,7 @@ bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int info)
   return false;
 }
 
-CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdString *fallback)
+CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::string *fallback)
 {
   if (!item) return "";
 
@@ -5076,7 +5076,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdSt
   return "";
 }
 
-CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info, CStdString *fallback)
+CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info, std::string *fallback)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
     return GetSkinVariableString(info, true, item);

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -744,9 +744,9 @@ public:
    \sa GetItemInt, GetMultiInfoInt
    */
   bool GetInt(int &value, int info, int contextWindow = 0, const CGUIListItem *item = NULL) const;
-  CStdString GetLabel(int info, int contextWindow = 0, CStdString *fallback = NULL);
+  CStdString GetLabel(int info, int contextWindow = 0, std::string *fallback = NULL);
 
-  CStdString GetImage(int info, int contextWindow, CStdString *fallback = NULL);
+  CStdString GetImage(int info, int contextWindow, std::string *fallback = NULL);
 
   CStdString GetTime(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
   CStdString GetDate(bool bNumbersOnly = false);
@@ -808,8 +808,8 @@ public:
 
   void ResetCache();
   bool GetItemInt(int &value, const CGUIListItem *item, int info) const;
-  CStdString GetItemLabel(const CFileItem *item, int info, CStdString *fallback = NULL);
-  CStdString GetItemImage(const CFileItem *item, int info, CStdString *fallback = NULL);
+  CStdString GetItemLabel(const CFileItem *item, int info, std::string *fallback = NULL);
+  CStdString GetItemImage(const CFileItem *item, int info, std::string *fallback = NULL);
 
   // Called from tuxbox service thread to update current status
   void UpdateFromTuxBox();
@@ -867,7 +867,7 @@ protected:
 
   bool GetMultiInfoBool(const GUIInfo &info, int contextWindow = 0, const CGUIListItem *item = NULL);
   bool GetMultiInfoInt(int &value, const GUIInfo &info, int contextWindow = 0) const;
-  CStdString GetMultiInfoLabel(const GUIInfo &info, int contextWindow = 0, CStdString *fallback = NULL);
+  CStdString GetMultiInfoLabel(const GUIInfo &info, int contextWindow = 0, std::string *fallback = NULL);
   int TranslateListItem(const Property &info);
   int TranslateMusicPlayerString(const CStdString &info) const;
   TIME_FORMAT TranslateTimeFormat(const CStdString &format);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -559,7 +559,7 @@ bool CGUIControlFactory::GetInfoColor(const TiXmlNode *control, const char *strT
   const TiXmlElement* node = control->FirstChildElement(strTag);
   if (node && node->FirstChild())
   {
-    value.Parse(node->FirstChild()->Value(), parentID);
+    value.Parse(node->FirstChild()->ValueStr(), parentID);
     return true;
   }
   return false;

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -100,9 +100,9 @@ void CGUIImage::AllocateOnDemand()
 void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // check whether our image failed to allocate, and if so drop back to the fallback image
-  if (m_texture.FailedToAlloc() && !m_texture.GetFileName().Equals(m_info.GetFallback()))
+  if (m_texture.FailedToAlloc() && m_texture.GetFileName() != m_info.GetFallback())
   {
-    if (!m_currentFallback.empty() && !m_texture.GetFileName().Equals(m_currentFallback))
+    if (!m_currentFallback.empty() && m_texture.GetFileName() != m_currentFallback)
       m_texture.SetFileName(m_currentFallback);
     else
       m_texture.SetFileName(m_info.GetFallback());

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -117,7 +117,7 @@ protected:
   CGUITexture m_texture;
   std::vector<CFadingTexture *> m_fadingTextures;
   CStdString m_currentTexture;
-  CStdString m_currentFallback;
+  std::string m_currentFallback;
 
   unsigned int m_crossFadeTime;
   unsigned int m_currentFadeTime;

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -141,18 +141,18 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, CStdStri
   bool needsUpdate = m_dirty;
   if (!m_info.empty())
   {
-  for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
-  {
-    if (portion->m_info)
+    for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
     {
-      CStdString infoLabel;
-      if (preferImage)
-        infoLabel = g_infoManager.GetImage(portion->m_info, contextWindow, fallback);
-      if (infoLabel.empty())
-        infoLabel = g_infoManager.GetLabel(portion->m_info, contextWindow, fallback);
-      needsUpdate |= portion->NeedsUpdate(infoLabel);
+      if (portion->m_info)
+      {
+        CStdString infoLabel;
+        if (preferImage)
+          infoLabel = g_infoManager.GetImage(portion->m_info, contextWindow, fallback);
+        if (infoLabel.empty())
+          infoLabel = g_infoManager.GetLabel(portion->m_info, contextWindow, fallback);
+        needsUpdate |= portion->NeedsUpdate(infoLabel);
+      }
     }
-  }
   }
   else
     needsUpdate = !m_label.empty();
@@ -165,18 +165,18 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
   bool needsUpdate = m_dirty;
   if (item->IsFileItem() && !m_info.empty())
   {
-  for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
-  {
-    if (portion->m_info)
+    for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
     {
-      CStdString infoLabel;
-      if (preferImages)
-        infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion->m_info, fallback);
-      else
-        infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion->m_info, fallback);
-      needsUpdate |= portion->NeedsUpdate(infoLabel);
+      if (portion->m_info)
+      {
+        CStdString infoLabel;
+        if (preferImages)
+          infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion->m_info, fallback);
+        else
+          infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion->m_info, fallback);
+        needsUpdate |= portion->NeedsUpdate(infoLabel);
+      }
     }
-  }
   }
   else
     needsUpdate = !m_label.empty();

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -141,21 +141,16 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, CStdStri
   CStdString label;
   for (unsigned int i = 0; i < m_info.size(); i++)
   {
+    CStdString infoLabel;
     const CInfoPortion &portion = m_info[i];
     if (portion.m_info)
     {
-      CStdString infoLabel;
       if (preferImage)
         infoLabel = g_infoManager.GetImage(portion.m_info, contextWindow, fallback);
       if (infoLabel.empty())
         infoLabel = g_infoManager.GetLabel(portion.m_info, contextWindow, fallback);
-      if (!infoLabel.empty())
-        label += portion.GetLabel(infoLabel);
     }
-    else
-    { // no info, so just append the prefix
-      label += portion.m_prefix;
-    }
+    label += portion.GetLabel(infoLabel);
   }
   if (label.empty())  // empty label, use the fallback
     return m_fallback;
@@ -168,21 +163,16 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
   CStdString label;
   for (unsigned int i = 0; i < m_info.size(); i++)
   {
+    CStdString infoLabel;
     const CInfoPortion &portion = m_info[i];
     if (portion.m_info)
     {
-      CStdString infoLabel;
       if (preferImages)
         infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion.m_info, fallback);
       else
         infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion.m_info, fallback);
-      if (!infoLabel.empty())
-        label += portion.GetLabel(infoLabel);
     }
-    else
-    { // no info, so just append the prefix
-      label += portion.m_prefix;
-    }
+    label += portion.GetLabel(infoLabel);
   }
   if (label.empty())
     return m_fallback;
@@ -362,6 +352,10 @@ CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const CStdString &prefix, co
 
 CStdString CGUIInfoLabel::CInfoPortion::GetLabel(const CStdString &info) const
 {
+  if (!m_info)
+    return m_prefix;
+  else if (info.empty())
+    return "";
   CStdString label = m_prefix + info + m_postfix;
   if (m_escaped) // escape all quotes and backslashes, then quote
   {

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -141,15 +141,16 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, CStdStri
   CStdString label;
   for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
   {
-    CStdString infoLabel;
     if (portion->m_info)
     {
+      CStdString infoLabel;
       if (preferImage)
         infoLabel = g_infoManager.GetImage(portion->m_info, contextWindow, fallback);
       if (infoLabel.empty())
         infoLabel = g_infoManager.GetLabel(portion->m_info, contextWindow, fallback);
+      portion->NeedsUpdate(infoLabel);
     }
-    label += portion->GetLabel(infoLabel);
+    label += portion->Get();
   }
   if (label.empty())  // empty label, use the fallback
     return m_fallback;
@@ -162,15 +163,16 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
   CStdString label;
   for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
   {
-    CStdString infoLabel;
     if (portion->m_info)
     {
+      CStdString infoLabel;
       if (preferImages)
         infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion->m_info, fallback);
       else
         infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion->m_info, fallback);
+      portion->NeedsUpdate(infoLabel);
     }
-    label += portion->GetLabel(infoLabel);
+    label += portion->Get();
   }
   if (label.empty())
     return m_fallback;
@@ -348,13 +350,23 @@ CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const CStdString &prefix, co
   StringUtils::Replace(m_postfix, "$LBRACKET", "["); StringUtils::Replace(m_postfix, "$RBRACKET", "]");
 }
 
-CStdString CGUIInfoLabel::CInfoPortion::GetLabel(const CStdString &info) const
+bool CGUIInfoLabel::CInfoPortion::NeedsUpdate(const CStdString &label) const
+{
+  if (m_label != label)
+  {
+    m_label = label;
+    return true;
+  }
+  return false;
+}
+
+CStdString CGUIInfoLabel::CInfoPortion::Get() const
 {
   if (!m_info)
     return m_prefix;
-  else if (info.empty())
+  else if (m_label.empty())
     return "";
-  CStdString label = m_prefix + info + m_postfix;
+  CStdString label = m_prefix + m_label + m_postfix;
   if (m_escaped) // escape all quotes and backslashes, then quote
   {
     StringUtils::Replace(label, "\\", "\\\\");

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -136,7 +136,7 @@ void CGUIInfoLabel::SetLabel(const CStdString &label, const CStdString &fallback
   Parse(label, context);
 }
 
-CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, CStdString *fallback /*= NULL*/) const
+CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, std::string *fallback /*= NULL*/) const
 {
   bool needsUpdate = m_dirty;
   if (!m_info.empty())
@@ -160,7 +160,7 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, CStdStri
   return CacheLabel(needsUpdate);
 }
 
-CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImages, CStdString *fallback /*= NULL*/) const
+CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImages, std::string *fallback /*= NULL*/) const
 {
   bool needsUpdate = m_dirty;
   if (item->IsFileItem() && !m_info.empty())
@@ -184,7 +184,7 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
   return CacheLabel(needsUpdate);
 }
 
-const CStdString &CGUIInfoLabel::CacheLabel(bool rebuild) const
+const std::string &CGUIInfoLabel::CacheLabel(bool rebuild) const
 {
   if (rebuild)
   {

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -139,18 +139,17 @@ void CGUIInfoLabel::SetLabel(const CStdString &label, const CStdString &fallback
 CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, CStdString *fallback /*= NULL*/) const
 {
   CStdString label;
-  for (unsigned int i = 0; i < m_info.size(); i++)
+  for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
   {
     CStdString infoLabel;
-    const CInfoPortion &portion = m_info[i];
-    if (portion.m_info)
+    if (portion->m_info)
     {
       if (preferImage)
-        infoLabel = g_infoManager.GetImage(portion.m_info, contextWindow, fallback);
+        infoLabel = g_infoManager.GetImage(portion->m_info, contextWindow, fallback);
       if (infoLabel.empty())
-        infoLabel = g_infoManager.GetLabel(portion.m_info, contextWindow, fallback);
+        infoLabel = g_infoManager.GetLabel(portion->m_info, contextWindow, fallback);
     }
-    label += portion.GetLabel(infoLabel);
+    label += portion->GetLabel(infoLabel);
   }
   if (label.empty())  // empty label, use the fallback
     return m_fallback;
@@ -161,18 +160,17 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
 {
   if (!item->IsFileItem()) return "";
   CStdString label;
-  for (unsigned int i = 0; i < m_info.size(); i++)
+  for (vector<CInfoPortion>::const_iterator portion = m_info.begin(); portion != m_info.end(); ++portion)
   {
     CStdString infoLabel;
-    const CInfoPortion &portion = m_info[i];
-    if (portion.m_info)
+    if (portion->m_info)
     {
       if (preferImages)
-        infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion.m_info, fallback);
+        infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion->m_info, fallback);
       else
-        infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion.m_info, fallback);
+        infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion->m_info, fallback);
     }
-    label += portion.GetLabel(infoLabel);
+    label += portion->GetLabel(infoLabel);
   }
   if (label.empty())
     return m_fallback;

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -40,7 +40,7 @@ CGUIInfoBool::~CGUIInfoBool()
 {
 }
 
-void CGUIInfoBool::Parse(const CStdString &expression, int context)
+void CGUIInfoBool::Parse(const std::string &expression, int context)
 {
   if (expression == "true")
     m_value = true;
@@ -86,8 +86,8 @@ bool CGUIInfoColor::Update()
     return false; // no infolabel
 
   // Expand the infolabel, and then convert it to a color
-  CStdString infoLabel(g_infoManager.GetLabel(m_info));
-  color_t color = !infoLabel.empty() ? g_colorManager.GetColor(infoLabel.c_str()) : 0;
+  std::string infoLabel(g_infoManager.GetLabel(m_info));
+  color_t color = !infoLabel.empty() ? g_colorManager.GetColor(infoLabel) : 0;
   if (m_color != color)
   {
     m_color = color;
@@ -97,11 +97,11 @@ bool CGUIInfoColor::Update()
     return false;
 }
 
-void CGUIInfoColor::Parse(const CStdString &label, int context)
+void CGUIInfoColor::Parse(const std::string &label, int context)
 {
   // Check for the standard $INFO[] block layout, and strip it if present
-  CStdString label2 = label;
-  if (label.Equals("-", false))
+  std::string label2 = label;
+  if (label == "-")
     return;
 
   if (StringUtils::StartsWithNoCase(label, "$var["))
@@ -125,18 +125,18 @@ CGUIInfoLabel::CGUIInfoLabel() : m_dirty(false)
 {
 }
 
-CGUIInfoLabel::CGUIInfoLabel(const CStdString &label, const CStdString &fallback /*= ""*/, int context /*= 0*/) : m_dirty(false)
+CGUIInfoLabel::CGUIInfoLabel(const std::string &label, const std::string &fallback /*= ""*/, int context /*= 0*/) : m_dirty(false)
 {
   SetLabel(label, fallback, context);
 }
 
-void CGUIInfoLabel::SetLabel(const CStdString &label, const CStdString &fallback, int context /*= 0*/)
+void CGUIInfoLabel::SetLabel(const std::string &label, const std::string &fallback, int context /*= 0*/)
 {
   m_fallback = fallback;
   Parse(label, context);
 }
 
-CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, std::string *fallback /*= NULL*/) const
+const std::string &CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, std::string *fallback /*= NULL*/) const
 {
   bool needsUpdate = m_dirty;
   if (!m_info.empty())
@@ -145,7 +145,7 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, std::str
     {
       if (portion->m_info)
       {
-        CStdString infoLabel;
+        std::string infoLabel;
         if (preferImage)
           infoLabel = g_infoManager.GetImage(portion->m_info, contextWindow, fallback);
         if (infoLabel.empty())
@@ -160,7 +160,7 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, std::str
   return CacheLabel(needsUpdate);
 }
 
-CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImages, std::string *fallback /*= NULL*/) const
+const std::string &CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImages, std::string *fallback /*= NULL*/) const
 {
   bool needsUpdate = m_dirty;
   if (item->IsFileItem() && !m_info.empty())
@@ -169,7 +169,7 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
     {
       if (portion->m_info)
       {
-        CStdString infoLabel;
+        std::string infoLabel;
         if (preferImages)
           infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion->m_info, fallback);
         else
@@ -208,9 +208,9 @@ bool CGUIInfoLabel::IsConstant() const
   return m_info.size() == 0 || (m_info.size() == 1 && m_info[0].m_info == 0);
 }
 
-typedef CStdString (*StringReplacerFunc) (const CStdString &str);
+typedef std::string (*StringReplacerFunc) (const std::string &str);
 
-void ReplaceString(CStdString &work, const std::string &str, StringReplacerFunc func)
+void ReplaceString(std::string &work, const std::string &str, StringReplacerFunc func)
 {
   // Replace all $str[number] with the real string
   size_t pos1 = work.find("$" + str + "[");
@@ -220,9 +220,9 @@ void ReplaceString(CStdString &work, const std::string &str, StringReplacerFunc 
     size_t pos3 = StringUtils::FindEndBracket(work, '[', ']', pos2);
     if (pos3 != std::string::npos)
     {
-      CStdString left = work.substr(0, pos1);
-      CStdString right = work.substr(pos3 + 1);
-      CStdString replace = func(work.substr(pos2, pos3 - pos2));
+      std::string left = work.substr(0, pos1);
+      std::string right = work.substr(pos3 + 1);
+      std::string replace = func(work.substr(pos2, pos3 - pos2));
       work = left + replace + right;
     }
     else
@@ -234,39 +234,39 @@ void ReplaceString(CStdString &work, const std::string &str, StringReplacerFunc 
   }
 }
 
-CStdString LocalizeReplacer(const CStdString &str)
+std::string LocalizeReplacer(const std::string &str)
 {
-  CStdString replace = g_localizeStringsTemp.Get(atoi(str.c_str()));
-  if (replace == "")
+  std::string replace = g_localizeStringsTemp.Get(atoi(str.c_str()));
+  if (replace.empty())
     replace = g_localizeStrings.Get(atoi(str.c_str()));
   return replace;
 }
 
-CStdString AddonReplacer(const CStdString &str)
+std::string AddonReplacer(const std::string &str)
 {
   // assumes "addon.id #####"
   size_t length = str.find(" ");
-  CStdString id = str.substr(0, length);
+  std::string id = str.substr(0, length);
   int stringid = atoi(str.substr(length + 1).c_str());
   return CAddonMgr::Get().GetString(id, stringid);
 }
 
-CStdString NumberReplacer(const CStdString &str)
+std::string NumberReplacer(const std::string &str)
 {
   return str;
 }
 
-CStdString CGUIInfoLabel::ReplaceLocalize(const CStdString &label)
+std::string CGUIInfoLabel::ReplaceLocalize(const std::string &label)
 {
-  CStdString work(label);
+  std::string work(label);
   ReplaceString(work, "LOCALIZE", LocalizeReplacer);
   ReplaceString(work, "NUMBER", NumberReplacer);
   return work;
 }
 
-CStdString CGUIInfoLabel::ReplaceAddonStrings(const CStdString &label)
+std::string CGUIInfoLabel::ReplaceAddonStrings(const std::string &label)
 {
-  CStdString work(label);
+  std::string work(label);
   ReplaceString(work, "ADDON", AddonReplacer);
   return work;
 }
@@ -283,12 +283,12 @@ const static infoformat infoformatmap[] = {{ "$INFO[",    FORMATINFO },
                                            { "$ESCINFO[", FORMATESCINFO},
                                            { "$VAR[",     FORMATVAR}};
 
-void CGUIInfoLabel::Parse(const CStdString &label, int context)
+void CGUIInfoLabel::Parse(const std::string &label, int context)
 {
   m_info.clear();
   m_dirty = true;
   // Step 1: Replace all $LOCALIZE[number] with the real string
-  CStdString work = ReplaceLocalize(label);
+  std::string work = ReplaceLocalize(label);
   // Step 2: Replace all $ADDON[id number] with the real string
   work = ReplaceAddonStrings(work);
   // Step 3: Find all $INFO[info,prefix,postfix] blocks
@@ -319,7 +319,7 @@ void CGUIInfoLabel::Parse(const CStdString &label, int context)
       if (pos2 != std::string::npos)
       {
         // decipher the block
-        CStdString block = work.substr(pos1 + len, pos2 - pos1 - len);
+        std::string block = work.substr(pos1 + len, pos2 - pos1 - len);
         vector<string> params = StringUtils::Split(block, ",");
         if (!params.empty())
         {
@@ -334,7 +334,7 @@ void CGUIInfoLabel::Parse(const CStdString &label, int context)
           }
           else
             info = g_infoManager.TranslateString(params[0]);
-          CStdString prefix, postfix;
+          std::string prefix, postfix;
           if (params.size() > 1)
             prefix = params[1];
           if (params.size() > 2)
@@ -357,7 +357,7 @@ void CGUIInfoLabel::Parse(const CStdString &label, int context)
     m_info.push_back(CInfoPortion(0, work, ""));
 }
 
-CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix, bool escaped /*= false */)
+CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const std::string &prefix, const std::string &postfix, bool escaped /*= false */)
 {
   m_info = info;
   m_prefix = prefix;
@@ -370,7 +370,7 @@ CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const CStdString &prefix, co
   StringUtils::Replace(m_postfix, "$LBRACKET", "["); StringUtils::Replace(m_postfix, "$RBRACKET", "]");
 }
 
-bool CGUIInfoLabel::CInfoPortion::NeedsUpdate(const CStdString &label) const
+bool CGUIInfoLabel::CInfoPortion::NeedsUpdate(const std::string &label) const
 {
   if (m_label != label)
   {
@@ -380,13 +380,13 @@ bool CGUIInfoLabel::CInfoPortion::NeedsUpdate(const CStdString &label) const
   return false;
 }
 
-CStdString CGUIInfoLabel::CInfoPortion::Get() const
+std::string CGUIInfoLabel::CInfoPortion::Get() const
 {
   if (!m_info)
     return m_prefix;
   else if (m_label.empty())
     return "";
-  CStdString label = m_prefix + m_label + m_postfix;
+  std::string label = m_prefix + m_label + m_postfix;
   if (m_escaped) // escape all quotes and backslashes, then quote
   {
     StringUtils::Replace(label, "\\", "\\\\");
@@ -396,7 +396,7 @@ CStdString CGUIInfoLabel::CInfoPortion::Get() const
   return label;
 }
 
-CStdString CGUIInfoLabel::GetLabel(const CStdString &label, int contextWindow /*= 0*/, bool preferImage /*= false */)
+std::string CGUIInfoLabel::GetLabel(const std::string &label, int contextWindow /*= 0*/, bool preferImage /*= false */)
 { // translate the label
   CGUIInfoLabel info(label, "", contextWindow);
   return info.GetLabel(contextWindow, preferImage);

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -83,7 +83,7 @@ public:
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
    */  
-  CStdString GetLabel(int contextWindow, bool preferImage = false, CStdString *fallback = NULL) const;
+  CStdString GetLabel(int contextWindow, bool preferImage = false, std::string *fallback = NULL) const;
 
   /*!
    \brief Gets a label (or image) for a given listitem from the info manager.
@@ -92,12 +92,12 @@ public:
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
    */
-  CStdString GetItemLabel(const CGUIListItem *item, bool preferImage = false, CStdString *fallback = NULL) const;
+  CStdString GetItemLabel(const CGUIListItem *item, bool preferImage = false, std::string *fallback = NULL) const;
 
   bool IsConstant() const;
   bool IsEmpty() const;
 
-  const CStdString GetFallback() const { return m_fallback; };
+  const std::string &GetFallback() const { return m_fallback; };
 
   static CStdString GetLabel(const CStdString &label, int contextWindow = 0, bool preferImage = false);
 
@@ -122,7 +122,7 @@ private:
    \param rebuild whether we need to rebuild the label
    \sa GetLabel, GetItemLabel
    */
-  const CStdString &CacheLabel(bool rebuild) const;
+  const std::string &CacheLabel(bool rebuild) const;
 
   class CInfoPortion
   {
@@ -140,7 +140,7 @@ private:
 
   mutable bool       m_dirty;
   mutable CStdString m_label;
-  CStdString m_fallback;
+  std::string m_fallback;
   std::vector<CInfoPortion> m_info;
 };
 

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -122,10 +122,12 @@ private:
   {
   public:
     CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix, bool escaped = false);
-    CStdString GetLabel(const CStdString &info) const;
+    bool NeedsUpdate(const CStdString &label) const;
+    CStdString Get() const;
     int m_info;
   private:
     bool m_escaped;
+    mutable CStdString m_label;
     CStdString m_prefix;
     CStdString m_postfix;
   };

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -28,7 +28,9 @@
  *
  */
 
-#include "utils/StdString.h"
+#include <string>
+#include <vector>
+#include <stdint.h>
 #include "interfaces/info/InfoBool.h"
 
 class CGUIListItem;
@@ -42,7 +44,7 @@ public:
   operator bool() const { return m_value; };
 
   void Update(const CGUIListItem *item = NULL);
-  void Parse(const CStdString &expression, int context);
+  void Parse(const std::string &expression, int context);
 private:
   INFO::InfoPtr m_info;
   bool m_value;
@@ -60,7 +62,7 @@ public:
   operator color_t() const { return m_color; };
 
   bool Update();
-  void Parse(const CStdString &label, int context);
+  void Parse(const std::string &label, int context);
 
 private:
   color_t GetColor() const;
@@ -72,9 +74,9 @@ class CGUIInfoLabel
 {
 public:
   CGUIInfoLabel();
-  CGUIInfoLabel(const CStdString &label, const CStdString &fallback = "", int context = 0);
+  CGUIInfoLabel(const std::string &label, const std::string &fallback = "", int context = 0);
 
-  void SetLabel(const CStdString &label, const CStdString &fallback, int context = 0);
+  void SetLabel(const std::string &label, const std::string &fallback, int context = 0);
 
   /*!
    \brief Gets a label (or image) for a given window context from the info manager.
@@ -83,7 +85,7 @@ public:
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
    */  
-  CStdString GetLabel(int contextWindow, bool preferImage = false, std::string *fallback = NULL) const;
+  const std::string &GetLabel(int contextWindow, bool preferImage = false, std::string *fallback = NULL) const;
 
   /*!
    \brief Gets a label (or image) for a given listitem from the info manager.
@@ -92,31 +94,31 @@ public:
    \param fallback if non-NULL, is set to an alternate value to use should the actual value be not appropriate. Defaults to NULL.
    \return label (or image).
    */
-  CStdString GetItemLabel(const CGUIListItem *item, bool preferImage = false, std::string *fallback = NULL) const;
+  const std::string &GetItemLabel(const CGUIListItem *item, bool preferImage = false, std::string *fallback = NULL) const;
 
   bool IsConstant() const;
   bool IsEmpty() const;
 
   const std::string &GetFallback() const { return m_fallback; };
 
-  static CStdString GetLabel(const CStdString &label, int contextWindow = 0, bool preferImage = false);
+  static std::string GetLabel(const std::string &label, int contextWindow = 0, bool preferImage = false);
 
   /*!
    \brief Replaces instances of $LOCALIZE[number] with the appropriate localized string
    \param label text to replace
    \return text with any localized strings filled in.
    */
-  static CStdString ReplaceLocalize(const CStdString &label);
+  static std::string ReplaceLocalize(const std::string &label);
 
   /*!
    \brief Replaces instances of $ADDON[id number] with the appropriate localized addon string
    \param label text to replace
    \return text with any localized strings filled in.
    */
-  static CStdString ReplaceAddonStrings(const CStdString &label);
+  static std::string ReplaceAddonStrings(const std::string &label);
 
 private:
-  void Parse(const CStdString &label, int context);
+  void Parse(const std::string &label, int context);
 
   /*! \brief return (and cache) built label from info portions.
    \param rebuild whether we need to rebuild the label
@@ -127,19 +129,19 @@ private:
   class CInfoPortion
   {
   public:
-    CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix, bool escaped = false);
-    bool NeedsUpdate(const CStdString &label) const;
-    CStdString Get() const;
+    CInfoPortion(int info, const std::string &prefix, const std::string &postfix, bool escaped = false);
+    bool NeedsUpdate(const std::string &label) const;
+    std::string Get() const;
     int m_info;
   private:
     bool m_escaped;
-    mutable CStdString m_label;
-    CStdString m_prefix;
-    CStdString m_postfix;
+    mutable std::string m_label;
+    std::string m_prefix;
+    std::string m_postfix;
   };
 
-  mutable bool       m_dirty;
-  mutable CStdString m_label;
+  mutable bool        m_dirty;
+  mutable std::string m_label;
   std::string m_fallback;
   std::vector<CInfoPortion> m_info;
 };

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -124,10 +124,10 @@ private:
     CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix, bool escaped = false);
     CStdString GetLabel(const CStdString &info) const;
     int m_info;
-    CStdString m_prefix;
-    CStdString m_postfix;
   private:
     bool m_escaped;
+    CStdString m_prefix;
+    CStdString m_postfix;
   };
 
   CStdString m_fallback;

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -118,6 +118,12 @@ public:
 private:
   void Parse(const CStdString &label, int context);
 
+  /*! \brief return (and cache) built label from info portions.
+   \param rebuild whether we need to rebuild the label
+   \sa GetLabel, GetItemLabel
+   */
+  const CStdString &CacheLabel(bool rebuild) const;
+
   class CInfoPortion
   {
   public:
@@ -132,6 +138,8 @@ private:
     CStdString m_postfix;
   };
 
+  mutable bool       m_dirty;
+  mutable CStdString m_label;
   CStdString m_fallback;
   std::vector<CInfoPortion> m_info;
 };

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -43,7 +43,7 @@ const CSkinVariableString* CSkinVariable::CreateFromXML(const TiXmlElement& node
         if (condition)
           pair.m_condition = g_infoManager.Register(condition, context);
 
-        pair.m_label = CGUIInfoLabel(valuenode->FirstChild()->Value());
+        pair.m_label = CGUIInfoLabel(valuenode->FirstChild()->ValueStr());
         tmp->m_conditionLabelPairs.push_back(pair);
         if (!pair.m_condition)
           break; // once we reach default value (without condition) break iterating

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include "utils/StdString.h"
 #include "guilib/GUIInfoTypes.h"
 #include "interfaces/info/InfoBool.h"
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -298,10 +298,7 @@ namespace XBMCAddon
       //doesn't seem to be a single InfoTag?
       //try full blown GuiInfoLabel then
       if (ret == 0)
-      {
-        CGUIInfoLabel label(cLine);
-        return label.GetLabel(0);
-      }
+        return CGUIInfoLabel::GetLabel(cLine);
       else
         return g_infoManager.GetLabel(ret);
     }


### PR DESCRIPTION
This is an alternate to #3717

It improves label assembly performance by only building labels when the underlying information contained therein changes.
