### PR TITLE
dvdplayer: fix saving incorrect audio stream index

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2715,7 +2715,6 @@ void CDVDPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
 
 void CDVDPlayer::SetSubtitle(int iStream)
 {
-  CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = iStream;
   m_messenger.Put(new CDVDMsgPlayerSetSubtitleStream(iStream));
 }
 
@@ -2922,6 +2921,8 @@ bool CDVDPlayer::OpenStream(CCurrentStream& current, int iStream, int source, bo
 
     if (current.type == STREAM_AUDIO)
       CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = GetAudioStream();
+    else if (current.type == STREAM_SUBTITLE)
+      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = GetSubtitle();
 
     UpdateClockMaster();
   }
@@ -3026,7 +3027,6 @@ bool CDVDPlayer::OpenSubtitleStream(CDVDStreamInfo& hint)
   if(!OpenStreamPlayer(m_CurrentSubtitle, hint, true))
     return false;
 
-  CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = GetSubtitle();
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2760,7 +2760,6 @@ int CDVDPlayer::GetAudioStream()
 
 void CDVDPlayer::SetAudioStream(int iStream)
 {
-  CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = iStream;
   m_messenger.Put(new CDVDMsgPlayerSetAudioStream(iStream));
   SynchronizeDemuxer(100);
 }
@@ -2921,6 +2920,9 @@ bool CDVDPlayer::OpenStream(CCurrentStream& current, int iStream, int source, bo
     if(stream)
       current.changes = stream->changes;
 
+    if (current.type == STREAM_AUDIO)
+      CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = GetAudioStream();
+
     UpdateClockMaster();
   }
   else
@@ -2966,7 +2968,6 @@ bool CDVDPlayer::OpenAudioStream(CDVDStreamInfo& hint, bool reset)
 
   /* audio normally won't consume full cpu, so let it have prio */
   m_dvdPlayerAudio.SetPriority(GetPriority()+1);
-  CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = GetAudioStream();
   return true;
 }
 


### PR DESCRIPTION
this got broken with refactoring of dvdplayer. Setting fields of m_CurrentAudio is delayed now and the structure is not valid after successful completion of OpenAudioStream. As a result GetAudioStream returned invalid values.
