### PR TITLE
[osx] - only show the fake fullscreen option on snow leopard

### DIFF
--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -8,6 +8,13 @@
         </setting>
       </group>
     </category>
+    <category id="videoscreen" label="21373" help="36603">
+      <group id="1">
+        <setting id="videoscreen.fakefullscreen" type="boolean" parent="videoscreen.screen" label="14083" help="36354">
+          <requirement>OsxIsSnowLeopard</requirement>
+        </setting>
+      </group>
+    </category>
   </section>
   <section id="videos">
     <category id="videoacceleration">

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -33,6 +33,7 @@ extern "C"
 #endif
   bool        DarwinIsAppleTV2(void);
   bool        DarwinIsMavericks(void);
+  bool        DarwinIsSnowLeopard(void);
   bool        DarwinHasRetina(void);
   const char *GetDarwinOSReleaseString(void);
   const char *GetDarwinVersionString(void);

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -43,6 +43,14 @@
 #import "AutoPool.h"
 #import "DarwinUtils.h"
 
+#ifndef NSAppKitVersionNumber10_5
+#define NSAppKitVersionNumber10_5 949
+#endif
+
+#ifndef NSAppKitVersionNumber10_6
+#define NSAppKitVersionNumber10_6 1038
+#endif
+
 enum iosPlatform
 {
   iDeviceUnknown = -1,
@@ -168,6 +176,19 @@ bool DarwinIsMavericks(void)
   }
 #endif
   return isMavericks == 1;
+}
+
+bool DarwinIsSnowLeopard(void)
+{
+  static int isSnowLeopard = -1;
+#if defined(TARGET_DARWIN_OSX)
+  if (isSnowLeopard == -1)
+  {
+    double appKitVersion = floor(NSAppKitVersionNumber);
+    isSnowLeopard = (appKitVersion <= NSAppKitVersionNumber10_6 && appKitVersion > NSAppKitVersionNumber10_5) ? 1 : 0;
+  }
+#endif
+  return isSnowLeopard == 1;
 }
 
 bool DarwinHasRetina(void)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -91,6 +91,10 @@
 #include "utils/AMLUtils.h"
 #endif
 
+#if defined(TARGET_DARWIN_OSX)
+#include "osx/DarwinUtils.h"
+#endif// defined(TARGET_DARWIN_OSX)
+
 #define SETTINGS_XML_FOLDER "special://xbmc/system/settings/"
 #define SETTINGS_XML_ROOT   "settings"
 
@@ -925,6 +929,10 @@ void CSettings::InitializeConditions()
 #ifdef TARGET_DARWIN_IOS_ATV2
   if (g_sysinfo.IsAppleTV2())
     m_settingsManager->AddCondition("isappletv2");
+#endif
+#ifdef TARGET_DARWIN_OSX
+  if (DarwinIsSnowLeopard())
+    m_settingsManager->AddCondition("osxissnowleopard");
 #endif
 #if defined(TARGET_WINDOWS) && defined(HAS_DX)
   m_settingsManager->AddCondition("has_dx");


### PR DESCRIPTION
On later OSX versions this setting leads to black screen (deep core sdl issue we don't wanna fix ...). There are some users already who have locked theirselfs out because of this.

Backport from #4894 - against gotham!
