### PR TITLE
ADD: [amlcodec] supports 4K display

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1652,6 +1652,16 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   g_renderManager.RegisterRenderUpdateCallBack((const void*)this, RenderUpdateCallBack);
   g_renderManager.RegisterRenderFeaturesCallBack((const void*)this, RenderFeaturesCallBack);
 
+  m_display_rect = g_graphicsContext.GetViewWindow();
+  if (aml_get_device_type() == AML_DEVICE_TYPE_M8)
+  {
+    char mode[256] = {0};
+    aml_get_sysfs_str("/sys/class/display/mode", mode, 255);
+    RESOLUTION_INFO res;
+    if (aml_mode_to_resolution(mode, &res))
+      m_display_rect = CRect(0, 0, res.iScreenWidth, res.iScreenHeight);
+  }
+
 /*
   // if display is set to 1080xxx, then disable deinterlacer for HD content
   // else bandwidth usage is too heavy and it will slow down video decoder.
@@ -2187,31 +2197,26 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
     return;
   }
 
-  CRect gui, display, dst_rect;
+  CRect gui, dst_rect;
   gui = g_graphicsContext.GetViewWindow();
   // when display is at 1080p, we have freescale enabled
   // and that scales all layers into 1080p display including video,
   // so we have to setup video axis for 720p instead of 1080p... Boooo.
-  display = g_graphicsContext.GetViewWindow();
+
   dst_rect = m_dst_rect;
-  if (gui != display)
+  if (gui != m_display_rect)
   {
-    float xscale = display.Width()  / gui.Width();
-    float yscale = display.Height() / gui.Height();
+    float xscale = m_display_rect.Width()  / gui.Width();
+    float yscale = m_display_rect.Height() / gui.Height();
+    if (m_stereo_mode == RENDER_STEREO_MODE_SPLIT_VERTICAL)
+      xscale /= 2.0;
+    else if (m_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL)
+      yscale /= 2.0;
     dst_rect.x1 *= xscale;
     dst_rect.x2 *= xscale;
     dst_rect.y1 *= yscale;
     dst_rect.y2 *= yscale;
   }
-
-#if 0
-  std::string rectangle = StringUtils::Format("%i,%i,%i,%i",
-    (int)dst_rect.x1, (int)dst_rect.y1,
-    (int)dst_rect.Width(), (int)dst_rect.Height());
-  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:dst_rect(%s)", rectangle.c_str());
-  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:m_stereo_mode(%d)", m_stereo_mode);
-  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:m_stereo_view(%d)", m_stereo_view);
-#endif
 
   if (m_stereo_mode == RENDER_STEREO_MODE_MONO)
   {
@@ -2255,6 +2260,23 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
   {
     SetVideo3dMode(MODE_3D_DISABLE);
   }
+
+#if 0
+  std::string s_dst_rect = StringUtils::Format("%i,%i,%i,%i",
+    (int)dst_rect.x1, (int)dst_rect.y1,
+    (int)dst_rect.Width(), (int)dst_rect.Height());
+  std::string s_display = StringUtils::Format("%i,%i,%i,%i",
+    (int)m_display_rect.x1, (int)m_display_rect.y1,
+    (int)m_display_rect.Width(), (int)m_display_rect.Height());
+  std::string s_gui = StringUtils::Format("%i,%i,%i,%i",
+    (int)gui.x1, (int)gui.y1,
+    (int)gui.Width(), (int)gui.Height());
+  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:display(%s)", s_display.c_str());
+  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:gui(%s)", s_gui.c_str());
+  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:dst_rect(%s)", s_dst_rect.c_str());
+  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:m_stereo_mode(%d)", m_stereo_mode);
+  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect:m_stereo_view(%d)", m_stereo_view);
+#endif
 
   // goofy 0/1 based difference in aml axis coordinates.
   // fix them.

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.h
@@ -81,6 +81,8 @@ private:
   CEvent           m_ready_event;
 
   CRect            m_dst_rect;
+  CRect            m_display_rect;
+
   int              m_view_mode;
   RENDER_STEREO_MODE m_stereo_mode;
   RENDER_STEREO_VIEW m_stereo_view;

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -25,10 +25,12 @@
 #include <fcntl.h>
 #include <string>
 
+#include "AMLUtils.h"
 #include "utils/CPUInfo.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/AMLUtils.h"
+#include "guilib/gui3d.h"
 
 int aml_set_sysfs_str(const char *path, const char *val)
 {
@@ -287,3 +289,146 @@ void aml_probe_hdmi_audio()
     }
   }
 }
+
+bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
+{
+  if (!res)
+    return false;
+
+  res->iWidth = 0;
+  res->iHeight= 0;
+
+  if(!mode)
+    return false;
+
+  CStdString fromMode = mode;
+  StringUtils::Trim(fromMode);
+  // strips, for example, 720p* to 720p
+  // the * indicate the 'native' mode of the display
+  if (StringUtils::EndsWith(fromMode, "*"))
+    fromMode.erase(fromMode.size() - 1);
+
+  if (fromMode.Equals("720p"))
+  {
+    res->iWidth = 1280;
+    res->iHeight= 720;
+    res->iScreenWidth = 1280;
+    res->iScreenHeight= 720;
+    res->fRefreshRate = 60;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("720p50hz"))
+  {
+    res->iWidth = 1280;
+    res->iHeight= 720;
+    res->iScreenWidth = 1280;
+    res->iScreenHeight= 720;
+    res->fRefreshRate = 50;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("1080p"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 1920;
+    res->iScreenHeight= 1080;
+    res->fRefreshRate = 60;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("1080p24hz"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 1920;
+    res->iScreenHeight= 1080;
+    res->fRefreshRate = 24;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("1080p30hz"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 1920;
+    res->iScreenHeight= 1080;
+    res->fRefreshRate = 30;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("1080p50hz"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 1920;
+    res->iScreenHeight= 1080;
+    res->fRefreshRate = 50;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("1080i"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 1920;
+    res->iScreenHeight= 1080;
+    res->fRefreshRate = 60;
+    res->dwFlags = D3DPRESENTFLAG_INTERLACED;
+  }
+  else if (fromMode.Equals("1080i50hz"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 1920;
+    res->iScreenHeight= 1080;
+    res->fRefreshRate = 50;
+    res->dwFlags = D3DPRESENTFLAG_INTERLACED;
+  }
+  else if (fromMode.Equals("4k2ksmpte"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 4096;
+    res->iScreenHeight= 2160;
+    res->fRefreshRate = 24;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("4k2k24hz"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 3840;
+    res->iScreenHeight= 2160;
+    res->fRefreshRate = 24;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("4k2k25hz"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 3840;
+    res->iScreenHeight= 2160;
+    res->fRefreshRate = 25;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else if (fromMode.Equals("4k2k30hz"))
+  {
+    res->iWidth = 1920;
+    res->iHeight= 1080;
+    res->iScreenWidth = 3840;
+    res->iScreenHeight= 2160;
+    res->fRefreshRate = 30;
+    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
+  }
+  else
+  {
+    return false;
+  }
+
+
+  res->iScreen       = 0;
+  res->bFullScreen   = true;
+  res->iSubtitles    = (int)(0.965 * res->iHeight);
+  res->fPixelRatio   = 1.0f;
+  res->strMode       = StringUtils::Format("%dx%d @ %.2f%s - Full Screen", res->iScreenWidth, res->iScreenHeight, res->fRefreshRate,
+    res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+
+  return res->iWidth > 0 && res->iHeight> 0;
+}
+

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include "guilib/Resolution.h"
+
 enum AML_DEVICE_TYPE
 {
   AML_DEVICE_TYPE_UNINIT   = -2,
@@ -42,3 +44,4 @@ enum AML_DEVICE_TYPE aml_get_device_type();
 void aml_cpufreq_min(bool limit);
 void aml_cpufreq_max(bool limit);
 void aml_set_audio_passthrough(bool passthrough);
+bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res);

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -129,7 +129,7 @@ bool CEGLNativeTypeAmlogic::GetNativeResolution(RESOLUTION_INFO *res) const
 {
   char mode[256] = {0};
   aml_get_sysfs_str("/sys/class/display/mode", mode, 255);
-  return ModeToResolution(mode, res);
+  return aml_mode_to_resolution(mode, res);
 }
 
 bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
@@ -188,7 +188,7 @@ bool CEGLNativeTypeAmlogic::ProbeResolutions(std::vector<RESOLUTION_INFO> &resol
   RESOLUTION_INFO res;
   for (std::vector<std::string>::const_iterator i = probe_str.begin(); i != probe_str.end(); ++i)
   {
-    if(ModeToResolution(i->c_str(), &res))
+    if(aml_mode_to_resolution(i->c_str(), &res))
       resolutions.push_back(res);
   }
   return resolutions.size() > 0;
@@ -201,7 +201,7 @@ bool CEGLNativeTypeAmlogic::GetPreferredResolution(RESOLUTION_INFO *res) const
   if (!GetNativeResolution(res))
   {
     // punt to 720p if we get nothing
-    ModeToResolution("720p", res);
+    aml_mode_to_resolution("720p", res);
   }
 
   return true;
@@ -228,112 +228,6 @@ bool CEGLNativeTypeAmlogic::SetDisplayResolution(const char *resolution)
   }
 
   return true;
-}
-
-bool CEGLNativeTypeAmlogic::ModeToResolution(const char *mode, RESOLUTION_INFO *res) const
-{
-  if (!res)
-    return false;
-
-  res->iWidth = 0;
-  res->iHeight= 0;
-
-  if(!mode)
-    return false;
-
-  CStdString fromMode = mode;
-  StringUtils::Trim(fromMode);
-  // strips, for example, 720p* to 720p
-  // the * indicate the 'native' mode of the display
-  if (StringUtils::EndsWith(fromMode, "*"))
-    fromMode.erase(fromMode.size() - 1);
-
-  if (fromMode.Equals("720p"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1280;
-    res->iScreenHeight= 720;
-    res->fRefreshRate = 60;
-    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
-  }
-  else if (fromMode.Equals("720p50hz"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1280;
-    res->iScreenHeight= 720;
-    res->fRefreshRate = 50;
-    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
-  }
-  else if (fromMode.Equals("1080p"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1920;
-    res->iScreenHeight= 1080;
-    res->fRefreshRate = 60;
-    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
-  }
-  else if (fromMode.Equals("1080p24hz"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1920;
-    res->iScreenHeight= 1080;
-    res->fRefreshRate = 24;
-    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
-  }
-  else if (fromMode.Equals("1080p30hz"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1920;
-    res->iScreenHeight= 1080;
-    res->fRefreshRate = 30;
-    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
-  }
-  else if (fromMode.Equals("1080p50hz"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1920;
-    res->iScreenHeight= 1080;
-    res->fRefreshRate = 50;
-    res->dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
-  }
-  else if (fromMode.Equals("1080i"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1920;
-    res->iScreenHeight= 1080;
-    res->fRefreshRate = 60;
-    res->dwFlags = D3DPRESENTFLAG_INTERLACED;
-  }
-  else if (fromMode.Equals("1080i50hz"))
-  {
-    res->iWidth = 1280;
-    res->iHeight= 720;
-    res->iScreenWidth = 1920;
-    res->iScreenHeight= 1080;
-    res->fRefreshRate = 50;
-    res->dwFlags = D3DPRESENTFLAG_INTERLACED;
-  }
-  else
-  {
-    return false;
-  }
-
-
-  res->iScreen       = 0;
-  res->bFullScreen   = true;
-  res->iSubtitles    = (int)(0.965 * res->iHeight);
-  res->fPixelRatio   = 1.0f;
-  res->strMode       = StringUtils::Format("%dx%d @ %.2f%s - Full Screen", res->iScreenWidth, res->iScreenHeight, res->fRefreshRate,
-    res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
-
-  return res->iWidth > 0 && res->iHeight> 0;
 }
 
 void CEGLNativeTypeAmlogic::EnableFreeScale()

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
@@ -49,7 +49,6 @@ public:
 
 protected:
   bool SetDisplayResolution(const char *resolution);
-  bool ModeToResolution(const char *mode, RESOLUTION_INFO *res) const;
   void EnableFreeScale();
   void DisableFreeScale();
 


### PR DESCRIPTION
This allows 4K display on a 1080p framebuffer.
Currently, the vid is scaled to 1080p in a corner.

I also moved ModeToResolution to AMLUtils. It belongs there, imo.

/cc @davilla @t-nelson 
