### PR TITLE
[osx/depends] - add a fake Info.plist to target python26 for allowing codesign...

### DIFF
--- a/tools/darwin/Support/copyframeworks-osx.command
+++ b/tools/darwin/Support/copyframeworks-osx.command
@@ -54,15 +54,15 @@ TARGET_NAME=$PRODUCT_NAME
 TARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME/Contents
 
 TARGET_BINARY=$TARGET_CONTENTS/MacOS/XBMC
-TARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks
-DYLIB_NAMEPATH=@executable_path/../Frameworks
+TARGET_FRAMEWORKS=$TARGET_CONTENTS/Libraries
+DYLIB_NAMEPATH=@executable_path/../Libraries
 XBMC_HOME=$TARGET_CONTENTS/Resources/XBMC
 
 mkdir -p "$TARGET_CONTENTS/MacOS"
 mkdir -p "$TARGET_CONTENTS/Resources"
 # start clean so we don't keep old dylibs
-rm -rf "$TARGET_CONTENTS/Frameworks"
-mkdir -p "$TARGET_CONTENTS/Frameworks"
+rm -rf "$TARGET_CONTENTS/Libraries"
+mkdir -p "$TARGET_CONTENTS/Libraries"
 
 echo "Package $TARGET_BUILD_DIR/XBMC"
 cp -f "$TARGET_BUILD_DIR/XBMC" "$TARGET_BINARY"
@@ -82,7 +82,7 @@ for a in $(otool -L "$TARGET_BINARY"  | grep "$EXTERNAL_LIBS" | awk ' { print $1
 done
 
 echo "Package $EXTERNAL_LIBS/lib/python2.6"
-mkdir -p "$TARGET_CONTENTS/Frameworks/lib"
+mkdir -p "$TARGET_CONTENTS/Libraries/lib"
 PYTHONSYNC="rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests"
 ${PYTHONSYNC} "$EXTERNAL_LIBS/lib/python2.6" "$TARGET_FRAMEWORKS/lib/"
 rm -rf "$TARGET_FRAMEWORKS/lib/python2.6/config"

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -328,13 +328,17 @@ int  GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize)
   if (pathname && strstr([pathname UTF8String], "Contents"))
   {
     strcpy(path, [pathname UTF8String]);
-    // Move backwards to last "/" - removes the executable
-    for (int n=strlen(path)-1; path[n] != '/'; n--)
-      path[n] = '\0';
-    // Move backwards to next "/" - removes "MacOS" dir
-    for (int n=strlen(path)-2; path[n] != '/'; n--)
-      path[n] = '\0';
-    strcat(path, "Libraries");
+    // ExectuablePath is <product>.app/Contents/MacOS/<executable>
+    char *lastSlash = strrchr(path, '/');
+    if (lastSlash)
+    {
+      *lastSlash = '\0';//remove /<executable>  
+      lastSlash = strrchr(path, '/');
+      if (lastSlash)
+        *lastSlash = '\0';//remove /MacOS
+    }
+    strcat(path, "/Libraries");//add /Libraries
+    //we should have <product>.app/Contents/Libraries now
     *pathsize = strlen(path);
     //CLog::Log(LOGDEBUG, "DarwinFrameworkPath(d) -> %s", path);
     return 0;

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -324,11 +324,17 @@ int  GetDarwinFrameworkPath(bool forPython, char* path, uint32_t *pathsize)
   }
 
   // d) XBMC application running under OSX
-  pathname = [[NSBundle mainBundle] privateFrameworksPath];
+  pathname = [[NSBundle mainBundle] executablePath];
   if (pathname && strstr([pathname UTF8String], "Contents"))
   {
-    // check for 'Contents' if we are running as real xbmc.app
     strcpy(path, [pathname UTF8String]);
+    // Move backwards to last "/" - removes the executable
+    for (int n=strlen(path)-1; path[n] != '/'; n--)
+      path[n] = '\0';
+    // Move backwards to next "/" - removes "MacOS" dir
+    for (int n=strlen(path)-2; path[n] != '/'; n--)
+      path[n] = '\0';
+    strcat(path, "Libraries");
     *pathsize = strlen(path);
     //CLog::Log(LOGDEBUG, "DarwinFrameworkPath(d) -> %s", path);
     return 0;


### PR DESCRIPTION
As of Mavericks the signing policy of app bundles has changed. 

From now on for being a valid bundle the structure of any private Frameworks in the bundle needs to match. Since we have Frameworks/lib/python2.6 in our bundle this is now treated as a Framework (with version 2.6) - but since python is no Framework this treatment fails and prevents the Firewall service to ad-hoc sign our app bundle (this leads to the firewall popup asking the user to allow incoming connections on each start of XBMC).

This PR fixes the problem by renaming the Frameworks folder to Libraries as suggested for raw dylibs in https://developer.apple.com/library/mac/technotes/tn2206/_index.html
