### PR TITLE
Pushed subtitle offset default from +-10s to +-60s

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -128,7 +128,7 @@ void CAdvancedSettings::Initialize()
   m_audioDefaultPlayer = "paplayer";
   m_audioPlayCountMinimumPercent = 90.0f;
 
-  m_videoSubsDelayRange = 10;
+  m_videoSubsDelayRange = 60;
   m_videoAudioDelayRange = 10;
   m_videoSmallStepBackSeconds = 7;
   m_videoSmallStepBackTries = 3;


### PR DESCRIPTION
While this is perfectly doable for anyone via advancedsettings.xml I think it might be valid to make the default a bit larger than 10s. What I've seen when used offset is that either its syncing alright and then +-10s is fine to make it ok for the entire video, or its drifting (not sure why it drifts but) and then 10s is far from enough.
