### PR TITLE
[RFC] Subtitle cycle

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -570,7 +570,7 @@
 				<texturenofocus border="25,5,25,5">SubMenuBack-MiddleNF.png</texturenofocus>
 				<pulseonselect>false</pulseonselect>
 				<label>209</label>
-				<onclick>NextSubtitle</onclick>
+				<onclick>CycleSubtitle</onclick>
 				<visible>VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled</visible>
 			</control>
 			<control type="radiobutton" id="404">

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -200,6 +200,8 @@
 #define ACTION_CHAPTER_OR_BIG_STEP_FORWARD       97 // Goto the next chapter, if not available perform a big step forward
 #define ACTION_CHAPTER_OR_BIG_STEP_BACK          98 // Goto the previous chapter, if not available perform a big step back
 
+#define ACTION_CYCLE_SUBTITLE         99 // switch to next subtitle of movie, but will not enable/disable the subtitles. Can be used in videoFullScreen.xml window id=2005
+
 #define ACTION_MOUSE_START            100
 #define ACTION_MOUSE_LEFT_CLICK       100
 #define ACTION_MOUSE_RIGHT_CLICK      101

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -88,6 +88,7 @@ static const ActionMapping actions[] =
         {"osd"               , ACTION_SHOW_OSD},
         {"showsubtitles"     , ACTION_SHOW_SUBTITLES},
         {"nextsubtitle"      , ACTION_NEXT_SUBTITLE},
+        {"cyclesubtitle"     , ACTION_CYCLE_SUBTITLE},
         {"codecinfo"         , ACTION_SHOW_CODEC},
         {"nextpicture"       , ACTION_NEXT_PICTURE},
         {"previouspicture"   , ACTION_PREV_PICTURE},

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -86,6 +86,7 @@ bool CPlayerController::OnAction(const CAction &action)
       }
 
       case ACTION_NEXT_SUBTITLE:
+      case ACTION_CYCLE_SUBTITLE:
       {
         if (g_application.m_pPlayer->GetSubtitleCount() == 0)
           return true;
@@ -99,12 +100,15 @@ bool CPlayerController::OnAction(const CAction &action)
           if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream >= g_application.m_pPlayer->GetSubtitleCount())
           {
             CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = 0;
-            CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
-            g_application.m_pPlayer->SetSubtitleVisible(false);
+            if (action.GetID() == ACTION_NEXT_SUBTITLE)
+            {
+              CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
+              g_application.m_pPlayer->SetSubtitleVisible(false);
+            }
           }
           g_application.m_pPlayer->SetSubtitle(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream);
         }
-        else
+        else if (action.GetID() == ACTION_NEXT_SUBTITLE)
         {
           CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = true;
           g_application.m_pPlayer->SetSubtitleVisible(true);


### PR DESCRIPTION
This is same as #4030
- Added a CycleSubtitle action which cycles subtitles without toggling from disable/enable
- Fixed comment in key.h +cosmetics +spelling
- Squashed + rebased on master

As per @topfs2 comment he didn't have time and forgot about it, inviting someone to cherry-pick and squash + took opportunity to fix up spelling in comment.
