### PR TITLE
[omxplayer] Make use of audio decode fast paths when downmixing

### DIFF
--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -216,6 +216,20 @@ bool CAEFactory::SupportsSilenceTimeout()
   return false;
 }
 
+bool CAEFactory::HasStereoAudioChannelCount()
+{
+  if(AE)
+    return AE->HasStereoAudioChannelCount();
+  return false;
+}
+
+bool CAEFactory::HasHDAudioChannelCount()
+{
+  if(AE)
+    return AE->HasHDAudioChannelCount();
+  return false;
+}
+
 /**
   * Returns true if current AudioEngine supports at lest two basic quality levels
   * @return true if quality setting is supported, otherwise false

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -54,6 +54,8 @@ public:
   static std::string GetDefaultDevice(bool passthrough);
   static bool SupportsRaw(AEDataFormat format, int samplerate);
   static bool SupportsSilenceTimeout();
+  static bool HasStereoAudioChannelCount();
+  static bool HasHDAudioChannelCount();
 
   /**
    * Returns true if current AudioEngine supports at lest two basic quality levels

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2245,6 +2245,23 @@ bool CActiveAE::SupportsSilenceTimeout()
   return true;
 }
 
+bool CActiveAE::HasStereoAudioChannelCount()
+{
+  std::string device = CSettings::Get().GetString("audiooutput.audiodevice");
+  int numChannels = (m_sink.GetDeviceType(device) == AE_DEVTYPE_IEC958) ? AE_CH_LAYOUT_2_0 : CSettings::Get().GetInt("audiooutput.channels");
+  bool passthrough = CSettings::Get().GetInt("audiooutput.config") == AE_CONFIG_FIXED ? false : CSettings::Get().GetBool("audiooutput.passthrough");
+  return numChannels == AE_CH_LAYOUT_2_0 && ! (passthrough &&
+    CSettings::Get().GetBool("audiooutput.ac3passthrough") &&
+    CSettings::Get().GetBool("audiooutput.ac3transcode"));
+}
+
+bool CActiveAE::HasHDAudioChannelCount()
+{
+  std::string device = CSettings::Get().GetString("audiooutput.audiodevice");
+  int numChannels = (m_sink.GetDeviceType(device) == AE_DEVTYPE_IEC958) ? AE_CH_LAYOUT_2_0 : CSettings::Get().GetInt("audiooutput.channels");
+  return numChannels > AE_CH_LAYOUT_5_1;
+}
+
 bool CActiveAE::SupportsQualityLevel(enum AEQuality level)
 {
   if (level == AE_QUALITY_LOW || level == AE_QUALITY_MID || level == AE_QUALITY_HIGH)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -229,6 +229,8 @@ public:
   virtual std::string GetDefaultDevice(bool passthrough);
   virtual bool SupportsRaw(AEDataFormat format, int samplerate);
   virtual bool SupportsSilenceTimeout();
+  virtual bool HasStereoAudioChannelCount();
+  virtual bool HasHDAudioChannelCount();
   virtual bool SupportsQualityLevel(enum AEQuality level);
   virtual bool IsSettingVisible(const std::string &settingId);
   virtual void KeepConfiguration(unsigned int millis);

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -211,6 +211,18 @@ public:
    */
   virtual bool SupportsSilenceTimeout() { return false; }
 
+  /**
+   * Returns true if the AudioEngine is currently configured for stereo audio
+   * @returns true if the AudioEngine is currently configured for stereo audio
+   */
+  virtual bool HasStereoAudioChannelCount() { return false; }
+
+  /**
+   * Returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
+   * @returns true if the AudioEngine is currently configured for HD audio (more than 5.1)
+   */
+  virtual bool HasHDAudioChannelCount() { return true; }
+
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) {}
 
   virtual void UnregisterAudioCallback() {}

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/AudioEngine/AEFactory.h"
 
 // the size of the audio_render output port buffers
 #define AUDIO_DECODE_OUTPUT_BUFFER (32*1024)
@@ -86,6 +87,15 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
   m_pCodecContext->block_align = hints.blockalign;
   m_pCodecContext->bit_rate = hints.bitrate;
   m_pCodecContext->bits_per_coded_sample = hints.bitspersample;
+  if (hints.codec == AV_CODEC_ID_TRUEHD)
+  {
+    if (CAEFactory::HasStereoAudioChannelCount())
+      m_pCodecContext->request_channel_layout = AV_CH_LAYOUT_STEREO;
+    else if (!CAEFactory::HasHDAudioChannelCount())
+      m_pCodecContext->request_channel_layout = AV_CH_LAYOUT_5POINT1;
+  }
+  if (m_pCodecContext->request_channel_layout)
+    CLog::Log(LOGNOTICE,"COMXAudioCodecOMX::Open() Requesting channel layout of %x", (unsigned)m_pCodecContext->request_channel_layout);
 
   // vorbis has variable sized planar output, so skip concatenation
   if (hints.codec == AV_CODEC_ID_VORBIS)


### PR DESCRIPTION
The TrueHD codec actually works in 3 stages.
It decodes the downmixed stereo.
It then decodes the differences required to produce 5.1.
It then decodes the differences required to produce 7.1.

Many users end up downmixing this 7.1 stream back to 2.0.
Much better to tell the codec we only need the 2.0 stream.

When playing a 94s duration video file on an overclocked Pi, the audio decode took:
7.1 channels: 39.6s
5.1 channels: 36.5s
2.0 channels: 23.0s

So, it's almost twice as fast to decode TrueHD when only stereo is required.

DTS and AC3 also respect request_channel_layout, but I was unable to measure any performance improvement so have only enabled this for TrueHD.
