### PR TITLE
FIX: [jni] typo

### DIFF
--- a/xbmc/android/jni/Surface.cpp
+++ b/xbmc/android/jni/Surface.cpp
@@ -56,7 +56,7 @@ bool CJNISurface::isValid()
 
 void CJNISurface::release()
 {
-  call_method<jboolean>(m_object,
+  call_method<void>(m_object,
     "release", "()V");
 }
 


### PR DESCRIPTION
ART being more touchy than DALVIK, this makes XBMC abort/crash.

/cc @t-nelson @jmarshallnz 
