### PR TITLE
list enabled repositories in enabled add-ons

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -62,8 +62,9 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   bool groupAddons = true;
   bool reposAsFolders = true;
   if (path.GetHostName() == "enabled")
-  {
-    CAddonMgr::Get().GetAllAddons(addons, true);
+  { // grab all enabled addons, including enabled repositories
+    reposAsFolders = false;
+    CAddonMgr::Get().GetAllAddons(addons, true, true);
     items.SetProperty("reponame",g_localizeStrings.Get(24062));
     items.SetLabel(g_localizeStrings.Get(24062));
   }


### PR DESCRIPTION
This will list repositories in "Enabled add-ons". Personally i see no reason why they are excluded. Also with the increasing amount of third-party repos, and the un-installing method of them is quite hidden, its best to just list them as well so you can easily disable or uninstall them.
