### PR TITLE
fix: Cosmetic OverlayWatched alignment on select

### DIFF
--- a/addons/skin.confluence/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence/720p/ViewsFileMode.xml
@@ -344,7 +344,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="image">
-						<left>180</left>
+						<left>170</left>
 						<top>130</top>
 						<width>30</width>
 						<height>30</height>


### PR DESCRIPTION
When view is Thumbnails and file is selected/unselected the overlay horizontal alignment is slightly off and looks funky.
This fixes that across Thumbnails view.

@ronie
