### PR TITLE
Sort audio tracks by track number

### DIFF
--- a/addons/webinterface.default/js/MediaLibrary.js
+++ b/addons/webinterface.default/js/MediaLibrary.js
@@ -395,6 +395,9 @@ MediaLibrary.prototype = {
             'rating',
             'playcount'
           ],
+          'sort': {
+            'method': 'track'
+          },
           'filter': {
             'albumid' : event.data.album.albumid
           }


### PR DESCRIPTION
Currently the web interface displays track ordered in what seems to be the database order. However, when sending the play command, the web interface sends the position of the track in the list rather than the track number.

For consistency's sake, this pull requests adds an RPC parameter to have the web interface order the tracks by track number.
