### PR TITLE
fix audio/sub id selection in gui dialog at initial play

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2898,12 +2898,22 @@ bool CDVDPlayer::OpenStream(CCurrentStream& current, int iStream, int source, bo
   {
     case STREAM_AUDIO:
       res = OpenAudioStream(hint, reset);
+      if (res)
+      {
+        current.id = iStream;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = GetAudioStream();
+      }
       break;
     case STREAM_VIDEO:
       res = OpenVideoStream(hint, reset);
       break;
     case STREAM_SUBTITLE:
       res = OpenSubtitleStream(hint);
+      if (res)
+      {
+        current.id = iStream;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = GetSubtitle();
+      }
       break;
     case STREAM_TELETEXT:
       res = OpenTeletextStream(hint);


### PR DESCRIPTION
fixes incomplete and partially correct behavior from https://github.com/FernetMenta/xbmc/commit/30e103633a1d4d0ee573e1ece6af3fed4cd3ebfe

In fact there was an issue with especially DVDs but also MKVs that have default stream(s), that the audio or subtitle stream set through the container (dvd menus, default stream) was not aligned with what the GUI (the selection dialog) is telling.

Trying to revert this commit, I found that the situation was much worse after, but only for non-DVD material. So I understand why the original 'fix' was needed.

I found that the remaining issue was that right the after opening the stream, the stream Id was not set yet in "currentStream", so that GetAudioStream() or GetSubtitle() couldn't find the right stream, and therefore created a mess. 

I fixed it, by setting the currentstream's id prior to the call to GetAudioStream/Subtitle. This enables the IndexOf functions to work properly. And so at least, the GUI is now back in line with the selected stream.
