### PR TITLE
[rarmanager] do not show the process dialog unless warn size is exceeded

### DIFF
--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -174,9 +174,8 @@ bool CRarManager::CacheRarredFile(CStdString& strPathInCache, const CStdString& 
         }
       }
     }
-    bool bShowProgress=false;
-    if (iSize > 1024*1024 || iSize == -2) // 1MB
-      bShowProgress=true;
+
+    bool bShowProgress = (iSize > EXTRACTION_WARN_SIZE || iSize == -2);
 
     CStdString strDir2 = URIUtils::GetDirectory(strCachedPath);
     URIUtils::RemoveSlashAtEnd(strDir2);


### PR DESCRIPTION
This commit re-uses the already defined warn size of 50MB to determine whether or not to show the process dialog when extracting compressed files from within a rar (eg. subs). Current behavior is to show the process dialog for files > 1 MB. In most cases the process dialog is just shown briefly as the actual extraction task takes less than opening and closing the dialog. This leads to a really bad user experience. 
