### PR TITLE
Added support for remote key "eject".

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -60,6 +60,7 @@
       <display>FullScreen</display>
       <start>PreviousMenu</start>
       <record>Record</record>
+      <eject>XBMC.EjectTray()</eject>
       <volumeplus>VolumeUp</volumeplus>
       <volumeminus>VolumeDown</volumeminus>
       <mute>Mute</mute>

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1327,6 +1327,7 @@ uint32_t CButtonTranslator::TranslateRemoteString(const char *szButton)
   else if (strButton.Equals("blue")) buttonCode = XINPUT_IR_REMOTE_BLUE;
   else if (strButton.Equals("subtitle")) buttonCode = XINPUT_IR_REMOTE_SUBTITLE;
   else if (strButton.Equals("language")) buttonCode = XINPUT_IR_REMOTE_LANGUAGE;
+  else if (strButton.Equals("eject")) buttonCode = XINPUT_IR_REMOTE_EJECT;
   else CLog::Log(LOGERROR, "Remote Translator: Can't find button %s", strButton.c_str());
   return buttonCode;
 }

--- a/xbmc/input/XBIRRemote.h
+++ b/xbmc/input/XBIRRemote.h
@@ -93,6 +93,8 @@
 #define XINPUT_IR_REMOTE_LIVE_RADIO     248
 #define XINPUT_IR_REMOTE_EPG_SEARCH     246
 
+#define XINPUT_IR_REMOTE_EJECT          235
+
 // Reserved 256 -> ...
 // Key.h
 // KEY_BUTTON_*

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1030,8 +1030,11 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress &key)
     xbmcKey.iButton = XINPUT_IR_REMOTE_SUBTITLE;
     PushCecKeypress(xbmcKey);
     break;
-  case CEC_USER_CONTROL_CODE_POWER_ON_FUNCTION:
   case CEC_USER_CONTROL_CODE_EJECT:
+    xbmcKey.iButton = XINPUT_IR_REMOTE_EJECT;
+    PushCecKeypress(xbmcKey);
+    break;
+  case CEC_USER_CONTROL_CODE_POWER_ON_FUNCTION:
   case CEC_USER_CONTROL_CODE_INPUT_SELECT:
   case CEC_USER_CONTROL_CODE_INITIAL_CONFIGURATION:
   case CEC_USER_CONTROL_CODE_HELP:


### PR DESCRIPTION
So far, the Eject key neither worked with my HTPC remote control (OriginAE) nor with my TV remote control (Toshiba via Pulse-Eight CEC adapter) due to missing support for this key in XBMC. This PR adds support for the Eject remote key.
