### PR TITLE
[AE/osxsink] - fix optical usb devices with > 2 channels

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -439,6 +439,10 @@ static void EnumerateDevices(CADeviceList &list)
       }
       else// treat all other digital passthrough devices as optical
         device.m_deviceType = AE_DEVTYPE_IEC958;
+
+      //treat all other digital devices as HDMI to let options open to the user
+      if (device.m_deviceType == AE_DEVTYPE_PCM)
+        device.m_deviceType = AE_DEVTYPE_HDMI;
     }
 
     // devicename based overwrites from former code - maybe FIXME at some point when we


### PR DESCRIPTION
there are usb devices which are basically optical devices but they have also formats with > 2 channels - mark any passthrough devices which are not DisplayPort and not HDMI as optical (not only the ones with 2 channels max) - fixes missing passthrough options for those devices.

Logfile from such a device:

http://xbmclogs.com/show.php?id=234214

Still waiting for feedback but i guess the 6 channel formats are some analog outputs or so. @fernetmenta - not quiet sure if treating such devices as optical is a good idea - or if we better should treat them as HDMI?

Jenkins was fine:

http://jenkins.xbmc.org/job/XBMC-OSX-64/1298/
