### PR TITLE
[ios] - backports from linusyang

### DIFF
--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -5,7 +5,7 @@ LIST_BINARY_EXTENSIONS="dylib so 0 vis"
 
 export CODESIGN_ALLOCATE=`xcodebuild -find codesign_allocate`
 
-GEN_ENTITLEMENTS="/Developer/iphoneentitlements401/gen_entitlements.py"
+GEN_ENTITLEMENTS="$XBMC_DEPENDS_ROOT/buildtools-native/bin/gen_entitlements.py"
 
 if [ ! -f ${GEN_ENTITLEMENTS} ]; then
   echo "error: $GEN_ENTITLEMENTS not found. Codesign won't work."

--- a/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh.in
+++ b/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh.in
@@ -50,6 +50,7 @@ PACKAGE=org.xbmc.xbmc-atv2
 VERSION=14.0
 REVISION=0~alpha1
 ARCHIVE=${PACKAGE}_${VERSION}-${REVISION}_iphoneos-arm.deb
+XBMCSIZE="$(du -s -k ${XBMC} | awk '{print $1}')"
 
 echo Creating $PACKAGE package version $VERSION revision $REVISION
 ${SUDO} rm -rf $DIRNAME/$PACKAGE
@@ -63,6 +64,7 @@ echo "Name: XBMC-ATV2"                            >> $DIRNAME/$PACKAGE/DEBIAN/co
 echo "Depends: curl, org.awkwardtv.whitelist, com.nito.updatebegone, org.xbmc.xbmc-seatbeltunlock" >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Version: $VERSION-$REVISION"                >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Architecture: iphoneos-arm"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
+echo "Installed-Size: $XBMCSIZE"                  >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Description: XBMC Multimedia Center for AppleTV 2" >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Homepage: http://xbmc.org/"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Maintainer: Scott Davilla, Edgar Hucek"     >> $DIRNAME/$PACKAGE/DEBIAN/control
@@ -104,8 +106,9 @@ chmod +x $DIRNAME/$PACKAGE/DEBIAN/postinst
 mkdir -p $DIRNAME/$PACKAGE/Applications
 cp -r $XBMC $DIRNAME/$PACKAGE/Applications/
 find $DIRNAME/$PACKAGE/Applications/ -name '.svn' -exec rm -rf {} \;
-find $DIRNAME/$PACKAGE/Applications/ -name '.gitignore' -exec rm -rf {} \;
+find $DIRNAME/$PACKAGE/Applications/ -name '.git*' -exec rm -rf {} \;
 find $DIRNAME/$PACKAGE/Applications/ -name '.DS_Store'  -exec rm -rf {} \;
+find $DIRNAME/$PACKAGE/Applications/ -name '*.xcent'  -exec rm -rf {} \;
 
 # set ownership to root:root
 ${SUDO} chown -R 0:0 $DIRNAME/$PACKAGE
@@ -117,7 +120,7 @@ echo Packaging $PACKAGE
 export COPYFILE_DISABLE=true
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
 #
-${SUDO} dpkg-deb -b $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
+${SUDO} dpkg-deb -bZ lzma $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
 ${SUDO} chown 501:20 $DIRNAME/$ARCHIVE
 dpkg-deb --info $DIRNAME/$ARCHIVE
 dpkg-deb --contents $DIRNAME/$ARCHIVE

--- a/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh.in
+++ b/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh.in
@@ -32,7 +32,9 @@ if [ ! -d $XBMC ]; then
   echo "XBMC.frappliance not found! are you sure you built $1 target?"
   exit 1
 fi
-if [ -f "/usr/libexec/fauxsu/libfauxsu.dylib" ]; then
+if [ -f "$XBMC_DEPENDS_ROOT/buildtools-native/bin/fakeroot" ]; then
+  SUDO="$XBMC_DEPENDS_ROOT/buildtools-native/bin/fakeroot"
+elif [ -f "/usr/libexec/fauxsu/libfauxsu.dylib" ]; then
   export DYLD_INSERT_LIBRARIES=/usr/libexec/fauxsu/libfauxsu.dylib
 elif [ -f "/usr/bin/sudo" ]; then
   SUDO="/usr/bin/sudo"
@@ -115,7 +117,8 @@ echo Packaging $PACKAGE
 export COPYFILE_DISABLE=true
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
 #
-dpkg-deb -b $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
+${SUDO} dpkg-deb -b $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
+${SUDO} chown 501:20 $DIRNAME/$ARCHIVE
 dpkg-deb --info $DIRNAME/$ARCHIVE
 dpkg-deb --contents $DIRNAME/$ARCHIVE
 

--- a/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh.in
+++ b/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh.in
@@ -51,6 +51,7 @@ PACKAGE=org.xbmc.xbmc-ios
 VERSION=14.0
 REVISION=0~alpha1
 ARCHIVE=${PACKAGE}_${VERSION}-${REVISION}_iphoneos-arm.deb
+XBMCSIZE="$(du -s -k ${XBMC} | awk '{print $1}')"
 
 echo Creating $PACKAGE package version $VERSION revision $REVISION
 ${SUDO} rm -rf $DIRNAME/$PACKAGE
@@ -61,15 +62,16 @@ mkdir -p $DIRNAME/$PACKAGE/DEBIAN
 echo "Package: $PACKAGE"                          >  $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Priority: Extra"                            >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Name: XBMC-iOS"                             >> $DIRNAME/$PACKAGE/DEBIAN/control
-echo "Depends: firmware (>= 4.1), curl"           >> $DIRNAME/$PACKAGE/DEBIAN/control
+echo "Depends: firmware (>= 4.1)"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Version: $VERSION-$REVISION"                >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Architecture: iphoneos-arm"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
+echo "Installed-Size: $XBMCSIZE"                  >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Description: XBMC Multimedia Center for 4.x iOS" >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Homepage: http://xbmc.org/"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Maintainer: Scott Davilla, Edgar Hucek"     >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Author: TeamXBMC"                           >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Section: Multimedia"                        >> $DIRNAME/$PACKAGE/DEBIAN/control
-echo "Icon: file:///Applications/Cydia.app/Sources/mirrors.xbmc.org.png" >> $DIRNAME/$PACKAGE/DEBIAN/control
+echo "Icon: file:///Applications/XBMC.app/AppIcon57x57.png" >> $DIRNAME/$PACKAGE/DEBIAN/control
 
 # prerm: called on remove and upgrade - get rid of existing bits.
 echo "#!/bin/sh"                                  >  $DIRNAME/$PACKAGE/DEBIAN/prerm
@@ -85,8 +87,9 @@ chmod +x $DIRNAME/$PACKAGE/DEBIAN/postinst
 mkdir -p $DIRNAME/$PACKAGE/Applications
 cp -r $XBMC $DIRNAME/$PACKAGE/Applications/
 find $DIRNAME/$PACKAGE/Applications/ -name '.svn' -exec rm -rf {} \;
-find $DIRNAME/$PACKAGE/Applications/ -name '.gitignore' -exec rm -rf {} \;
+find $DIRNAME/$PACKAGE/Applications/ -name '.git*' -exec rm -rf {} \;
 find $DIRNAME/$PACKAGE/Applications/ -name '.DS_Store'  -exec rm -rf {} \;
+find $DIRNAME/$PACKAGE/Applications/ -name '*.xcent'  -exec rm -rf {} \;
 
 # set ownership to root:root
 ${SUDO} chown -R 0:0 $DIRNAME/$PACKAGE
@@ -98,7 +101,7 @@ echo Packaging $PACKAGE
 export COPYFILE_DISABLE=true
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
 #
-${SUDO} dpkg-deb -b $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
+${SUDO} dpkg-deb -bZ lzma $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
 ${SUDO} chown 501:20 $DIRNAME/$ARCHIVE
 dpkg-deb --info $DIRNAME/$ARCHIVE
 dpkg-deb --contents $DIRNAME/$ARCHIVE

--- a/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh.in
+++ b/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh.in
@@ -33,7 +33,9 @@ if [ ! -d $XBMC ]; then
   echo "XBMC.app not found! are you sure you built $1 target?"
   exit 1
 fi
-if [ -f "/usr/libexec/fauxsu/libfauxsu.dylib" ]; then
+if [ -f "${XBMC_DEPENDS_ROOT}/buildtools-native/bin/fakeroot" ]; then
+  SUDO="${XBMC_DEPENDS_ROOT}/buildtools-native/bin/fakeroot"
+elif [ -f "/usr/libexec/fauxsu/libfauxsu.dylib" ]; then
   export DYLD_INSERT_LIBRARIES=/usr/libexec/fauxsu/libfauxsu.dylib
 elif [ -f "/usr/bin/sudo" ]; then
   SUDO="/usr/bin/sudo"
@@ -96,7 +98,8 @@ echo Packaging $PACKAGE
 export COPYFILE_DISABLE=true
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
 #
-dpkg-deb -b $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
+${SUDO} dpkg-deb -b $DIRNAME/$PACKAGE $DIRNAME/$ARCHIVE
+${SUDO} chown 501:20 $DIRNAME/$ARCHIVE
 dpkg-deb --info $DIRNAME/$ARCHIVE
 dpkg-deb --contents $DIRNAME/$ARCHIVE
 

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -13,7 +13,7 @@ NATIVE= m4-native gettext-native autoconf-native automake-native \
 
 
 ifeq ($(OS),ios)
-  NATIVE += dpkg-native xz-native tar-native
+  NATIVE += dpkg-native xz-native tar-native fakeroot-native gen_entitlements-native
 endif
 
 ifeq ($(OS),osx)

--- a/tools/depends/native/fakeroot-native/Makefile
+++ b/tools/depends/native/fakeroot-native/Makefile
@@ -1,0 +1,42 @@
+include ../../Makefile.include
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+DEPS= ../../Makefile.include.in Makefile
+
+APPNAME=fakeroot
+VERSION=macosx-v3.3
+SOURCE=$(APPNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+APP_BASE_URL=http://github.com/downloads/mackyle/fakeroot
+
+# configuration settings
+CONFIGURE=./configure --prefix=$(PREFIX) --disable-dependency-tracking --disable-static
+
+APP=$(PLATFORM)/$(APPNAME)
+
+CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(APP_BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); $(CONFIGURE)
+
+$(APP): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)
+
+.installed-$(PLATFORM): $(APP)
+	$(MAKE) -C $(PLATFORM) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm  .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+

--- a/tools/depends/native/gen_entitlements-native/Makefile
+++ b/tools/depends/native/gen_entitlements-native/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.include
+
+GEBIN=$(NATIVEPREFIX)/bin/gen_entitlements.py
+
+all: $(GEBIN)
+
+$(GEBIN):
+	mkdir -p $(NATIVEPREFIX)/bin
+	cp gen_entitlements.py $(GEBIN)
+	chmod 755 $(GEBIN)
+
+clean:
+distclean::
+	rm -f $(GEBIN)

--- a/tools/depends/native/gen_entitlements-native/gen_entitlements.py
+++ b/tools/depends/native/gen_entitlements-native/gen_entitlements.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import sys
+import struct
+
+if len(sys.argv) != 3:
+	print "Usage: %s appname dest_file.xcent" % sys.argv[0]
+	sys.exit(-1)
+
+APPNAME = sys.argv[1]
+DEST = sys.argv[2]
+
+if not DEST.endswith('.xml') and not DEST.endswith('.xcent'):
+	print "Dest must be .xml (for ldid) or .xcent (for codesign)"
+	sys.exit(-1)
+
+entitlements = """
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>application-identifier</key>
+    <string>%s</string>
+    <key>get-task-allow</key>
+    <true/>
+</dict>
+</plist>
+""" % APPNAME
+
+f = open(DEST,'w')
+if DEST.endswith('.xcent'):
+	f.write("\xfa\xde\x71\x71")
+	f.write(struct.pack('>L', len(entitlements) + 8))
+f.write(entitlements)
+f.close()
+

--- a/tools/depends/target/Backrow/Makefile
+++ b/tools/depends/target/Backrow/Makefile
@@ -17,7 +17,7 @@ $(PLATFORM)/$(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
 
 .installed-$(PLATFORM): $(PLATFORM)/$(SOURCE)
 	mkdir -p $(PREFIX)/include
-	cp -rf $(PLATFORM)/$(SOURCE) $(PREFIX)/include/
+	cp -pR $(PLATFORM)/$(SOURCE) $(PREFIX)/include/
 	touch $@
 
 clean:

--- a/tools/depends/target/python26/Makefile
+++ b/tools/depends/target/python26/Makefile
@@ -13,7 +13,7 @@ ARCHIVE=$(SOURCE).tar.bz2
 CONFIGURE=OPT="$(CFLAGS)" \
   LIBS=-lm \
   ./configure --prefix=$(PREFIX) \
-  --disable-toolbox-glue --disable-framework --with-system-ffi \
+  --disable-toolbox-glue --disable-framework --with-system-ffi --without-pymalloc \
 
 LIBDYLIB=$(PLATFORM)/libpython2.6.a
 


### PR DESCRIPTION
This are some nice commits from linusyang' ios64 bit branch. Those are the changes:
1. use lzma for deb package - reduces the size from 56mb to 36mb for ios and atv2
2. provide gen_entitlements which was hardcoded to /Developer/blahblah for now and always needed extra steps for clean build systems
3. add fakeroot to native buildtools and use this during deb creation - this is the alternative to libfauxsu
4. fixes the linker warning about addreses > 4gb
5. Should add the current ios icon to cydia

For review please @davilla and @amet (for the deb changes)

thx to @linusyang
