### PR TITLE
[ios] - support XCode 5.1.1 with iOS SDK 7.1

### DIFF
--- a/docs/README.ios
+++ b/docs/README.ios
@@ -48,20 +48,22 @@ character itself should NOT be typed as part of the command.
 -----------------------------------------------------------------------------
 See point 3.0a below for an updated list of supported Xcode/osx constellations!!!
 
-Install latest Xcode (4.3.2 or 3.2.6 as of the writing). You can download it from 
+Install latest Xcode (5.1.1 as of the writing). You can download it from 
 
-1. Apple's site after registration at http://developer.apple.com/tools/download (Xcode 3.2.6)
-2. In the MacOSX AppStore (Xcode 4.3.x). 
+1. The MacOSX AppStore (Xcode). 
 
 If you are using XCode 4.3.x you also need to install the "Command Line Tools". To do so
 after installing Xcode you have to go to "Xcode->Preferences->Downloads" and install the
-package "Command Line Tools".
+package "Command Line Tools". In later XCode versions as of 5.x those will be installed
+automatically once they are invoked from the cmdline.
 
 Xcode 3.2.6 only runs on 10.6.x (Snow Leopard). 
 Xcode 4.3.x only runs on 10.7.x (Lion).
+Xcode 5.x.x only runs on 10.8.x and later.
+
 
 The preferred iOS SDK Version is 4.3 (when using Xcode 3.2.6) or 5.1 (when using
-Xcode 4.3.x).
+Xcode 4.3.x) or 7.x (when using Xcode 5.x.x)
 
 -----------------------------------------------------------------------------
 3.0a Supported Xcode and OSX constellations
@@ -74,6 +76,7 @@ constellations of Xcode and osx versions (to be updated once we know more):
 3. XCode 4.6 against iOS SDK 4.3, 5.1 and 6.1 on 10.7.x (Lion) and 10.8.x (ML)
 3.a Building against iOS SDK 6.0 will only allow to run on targets with iOS 5.1 and below.
     There is no support for devices running iOS 6.0 for now!
+4. Xcode 5.1.1 against iOS SDK 7.0 and 7.1 on 10.9.x (Mavericks)
 
 -----------------------------------------------------------------------------
 3.1 Install Cross libs and runtime environment
@@ -125,6 +128,9 @@ If you have selected a specific iOS SDK Version in step 3.1 then you might need
 to adapt the active target to use the same iOS SDK version. Else build will fail 
 (you will see alot of errors with at least non-found boost/shared_ptr.hpp).
 
+On XCode5.x apple removed the gcc compiler. On those XCode versions you need to switch the compiler
+of the ATV2 project manually to "default/clang".
+
 -----------------------------------------------------------------------------
 4.2 Using Terminal (command-line)
 -----------------------------------------------------------------------------
@@ -158,9 +164,9 @@ distribution.
    or
    $ cd tools/darwin/packaging/xbmc-ios
 
-  3. $ ./mkdeb-xbmc-atv2.sh release
+  3. $ chmod +x ./mkdeb-xbmc-atv2.sh && ./mkdeb-xbmc-atv2.sh release
      or
-     $ ./mkdeb-xbmc-ios.sh release
+     $ chmod +x ./mkdeb-xbmc-ios.sh && ./mkdeb-xbmc-ios.sh release
      
   4. Use release or debug - you have to be sure that you build the corresponding 
      version before.

--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -20,6 +20,7 @@ OS=@platform_os@
 CROSS_COMPILING=@cross_compiling@
 ARCH_DEFINES=@ARCH_DEFINES@
 TARGET_PLATFORM=@use_platform@
+XCODE_VERSION=@use_xcode@
 
 HAS_ZLIB=@has_zlib@
 NEED_LIBICONV=@need_libiconv@

--- a/tools/depends/configure.in
+++ b/tools/depends/configure.in
@@ -183,7 +183,7 @@ case $host in
       *)
         platform_cc=clang
         platform_cxx=clang++
-        platform_cflags="-fheinous-gnu-extensions -no-cpp-precomp -no-integrated-as"
+        platform_cflags="-fheinous-gnu-extensions -no-cpp-precomp"
         platform_ldflags="-Wl,-search_paths_first"
         platform_cxxflags="-no-cpp-precomp"
         ;;

--- a/tools/depends/target/libffi/Makefile
+++ b/tools/depends/target/libffi/Makefile
@@ -8,7 +8,11 @@ SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
 # configuration settings
-CONFIGURE= ./configure --prefix=$(PREFIX) --disable-shared --disable-builddir
+CONFIGURE= ./configure --prefix=$(PREFIX) --disable-shared --disable-builddir 
+ifeq ($(OS), ios)
+CONFIGURE+=CFLAGS=-no-integrated-as
+endif
+
 
 LIBDYLIB=$(PLATFORM)/.libs/$(LIBNAME).a
 

--- a/tools/depends/target/libmpeg2/06-dont-asm-motion-comp.patch
+++ b/tools/depends/target/libmpeg2/06-dont-asm-motion-comp.patch
@@ -1,0 +1,64 @@
+diff --git a/libmpeg2/Makefile.am b/libmpeg2/Makefile.am
+index a4dd944..c113bf9 100644
+--- a/libmpeg2/Makefile.am
++++ b/libmpeg2/Makefile.am
+@@ -14,7 +14,7 @@
+ 			  motion_comp_vis.c motion_comp_arm.c \
+ 			  cpu_accel.c cpu_state.c
+ if ARCH_ARM
+-libmpeg2arch_la_SOURCES += motion_comp_arm_s.S motion_comp_neon.c
++libmpeg2arch_la_SOURCES += motion_comp_neon.c
+ endif
+ libmpeg2arch_la_CFLAGS = $(OPT_CFLAGS) $(ARCH_OPT_CFLAGS) $(LIBMPEG2_CFLAGS)
+
+--- a/libmpeg2/motion_comp_arm.c
++++ b/libmpeg2/motion_comp_arm.c
+@@ -93,14 +93,21 @@ MC_FUNC (put,y)
+ MC_FUNC (avg,y)
+ MC_FUNC (put,xy)
+ MC_FUNC (avg,xy)
++MC_FUNC (put,o)
++MC_FUNC (put,x)
+ 
+ 
+-extern void MC_put_o_16_arm (uint8_t * dest, const uint8_t * ref,
+-			     int stride, int height);
+-
+-extern void MC_put_x_16_arm (uint8_t * dest, const uint8_t * ref,
+-			     int stride, int height);
++static void MC_put_o_16_arm (uint8_t * dest, const uint8_t * ref,
++			     int stride, int height)
++{
++    MC_put_o_16_c(dest, ref, stride, height);
++}
+ 
++static void MC_put_x_16_arm (uint8_t * dest, const uint8_t * ref,
++			     int stride, int height)
++{
++    MC_put_x_16_c(dest, ref, stride, height);
++}
+ 
+ static void MC_put_y_16_arm (uint8_t * dest, const uint8_t * ref,
+ 			      int stride, int height)
+@@ -114,11 +121,17 @@ static void MC_put_xy_16_arm (uint8_t * dest, const uint8_t * ref,
+     MC_put_xy_16_c(dest, ref, stride, height);
+ }
+ 
+-extern void MC_put_o_8_arm (uint8_t * dest, const uint8_t * ref,
+-			     int stride, int height);
++static void MC_put_o_8_arm (uint8_t * dest, const uint8_t * ref,
++			     int stride, int height)
++{
++    MC_put_o_8_c(dest, ref, stride, height);
++}
+ 
+-extern void MC_put_x_8_arm (uint8_t * dest, const uint8_t * ref,
+-			    int stride, int height);
++static void MC_put_x_8_arm (uint8_t * dest, const uint8_t * ref,
++			    int stride, int height)
++{
++    MC_put_x_8_c(dest, ref, stride, height);
++}
+ 
+ static void MC_put_y_8_arm (uint8_t * dest, const uint8_t * ref,
+ 			     int stride, int height)

--- a/tools/depends/target/libmpeg2/Makefile
+++ b/tools/depends/target/libmpeg2/Makefile
@@ -30,6 +30,13 @@ ifeq ($(OS),ios)
 endif
 	cd $(PLATFORM); patch -p1 < ../04-clang-fix.patch
 	cd $(PLATFORM); patch -p0 < ../05-upstream-motion_comp_arm_s.S-is-not-PIC-enough.patch
+ifeq ($(OS),ios)
+	case $(XCODE_VERSION) in \
+	5.* | 5.*.*) \
+	cd $(PLATFORM); patch -p1 < ../06-dont-asm-motion-comp.patch \
+	;;\
+	esac
+endif
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 

--- a/xbmc/osx/atv2/XBMCAppliance.mm
+++ b/xbmc/osx/atv2/XBMCAppliance.mm
@@ -50,9 +50,6 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-// objc-runtime.h is missing from iPhoneOS4.2SDK but present in iPhoneSimulator4.2.sdk
-// pull it from runtime system for now
-#import "/usr/include/objc/objc-runtime.h"
 
 #import "XBMCAppliance.h"
 #import "XBMCController.h"


### PR DESCRIPTION
This makes XBMC compile on the current dev tools for iOS. (basically the updated clang 503.0.40 was the issue here).

@davilla for review ...

compile tested on jenkins (old xcode/sdk) and runtime tested on ios and atv2 (local compile with current xcode and sdk)...

thx @linusyang for the libmpeg2 patch
