### PR TITLE
VFS: remove inconsistency for Read/Write return type and parameter type

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -186,7 +186,7 @@ namespace ADDON
         dlsym(m_libXBMC_addon, "XBMC_open_file_for_write");
       if (XBMC_open_file_for_write == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      XBMC_read_file = (unsigned int (*)(void* HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize))
+      XBMC_read_file = (int64_t (*)(void* HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize))
         dlsym(m_libXBMC_addon, "XBMC_read_file");
       if (XBMC_read_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
@@ -377,7 +377,7 @@ namespace ADDON
      * @param uiBufSize The size of the buffer.
      * @return Number of bytes read.
      */
-    unsigned int ReadFile(void* file, void* lpBuf, int64_t uiBufSize)
+    int64_t ReadFile(void* file, void* lpBuf, int64_t uiBufSize)
     {
       return XBMC_read_file(m_Handle, m_Callbacks, file, lpBuf, uiBufSize);
     }
@@ -562,7 +562,7 @@ namespace ADDON
     void (*XBMC_free_string)(void *HANDLE, void* CB, char* str);
     void* (*XBMC_open_file)(void *HANDLE, void* CB, const char* strFileName, unsigned int flags);
     void* (*XBMC_open_file_for_write)(void *HANDLE, void* CB, const char* strFileName, bool bOverWrite);
-    unsigned int (*XBMC_read_file)(void *HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize);
+    int64_t (*XBMC_read_file)(void *HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize);
     bool (*XBMC_read_file_string)(void *HANDLE, void* CB, void* file, char *szLine, int iLineLength);
     int (*XBMC_write_file)(void *HANDLE, void* CB, void* file, const void* lpBuf, int64_t uiBufSize);
     void (*XBMC_flush_file)(void *HANDLE, void* CB, void* file);

--- a/lib/UnrarXLib/file.cpp
+++ b/lib/UnrarXLib/file.cpp
@@ -419,7 +419,7 @@ int File::DirectRead(void *Data,int Size)
   int Read = 0;
   while (Size)
   {
-    int nRead = m_File.Read(Data,Size);
+    int nRead = (int)m_File.Read(Data,Size);
     if (nRead == 0)
       break;
     Read += nRead;

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -140,7 +140,7 @@ DLLEXPORT void* XBMC_open_file_for_write(void *hdl, void* cb, const char* strFil
   return ((CB_AddOnLib*)cb)->OpenFileForWrite(((AddonCB*)hdl)->addonData, strFileName, bOverWrite);
 }
 
-DLLEXPORT unsigned int XBMC_read_file(void *hdl, void* cb, void* file, void* lpBuf, int64_t uiBufSize)
+DLLEXPORT int64_t XBMC_read_file(void *hdl, void* cb, void* file, void* lpBuf, int64_t uiBufSize)
 {
   if (cb == NULL)
     return 0;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -569,14 +569,12 @@ CStdString CUtil::GetFileMD5(const CStdString& strPath)
   {
     XBMC::XBMC_MD5 md5;
     char temp[1024];
-    int pos=0;
-    int read=1;
-    while (read > 0)
+    int read;
+    do
     {
-      read = file.Read(temp,1024);
-      pos += read;
+      read = (int)file.Read(temp,1024);
       md5.append(temp,read);
-    }
+    } while (read > 0);
     md5.getDigest(result);
     file.Close();
   }

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -38,7 +38,7 @@ typedef void* (*AddOnOpenFile)(const void* addonData, const char* strFileName, u
 typedef void* (*AddOnOpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite);
 typedef int64_t (*AddOnReadFile)(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
 typedef bool (*AddOnReadFileString)(const void* addonData, void* file, char *szLine, int iLineLength);
-typedef int (*AddOnWriteFile)(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
+typedef int64_t (*AddOnWriteFile)(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
 typedef void (*AddOnFlushFile)(const void* addonData, void* file);
 typedef int64_t (*AddOnSeekFile)(const void* addonData, void* file, int64_t iFilePosition, int iWhence);
 typedef int (*AddOnTruncateFile)(const void* addonData, void* file, int64_t iSize);

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -36,7 +36,7 @@ typedef void (*AddOnFreeString)(const void* addonData, char* str);
 
 typedef void* (*AddOnOpenFile)(const void* addonData, const char* strFileName, unsigned int flags);
 typedef void* (*AddOnOpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite);
-typedef unsigned int (*AddOnReadFile)(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
+typedef int64_t (*AddOnReadFile)(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
 typedef bool (*AddOnReadFileString)(const void* addonData, void* file, char *szLine, int iLineLength);
 typedef int (*AddOnWriteFile)(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
 typedef void (*AddOnFlushFile)(const void* addonData, void* file);

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -353,7 +353,7 @@ bool CAddonCallbacksAddon::ReadFileString(const void* addonData, void* file, cha
   return cfile->ReadString(szLine, iLineLength);
 }
 
-int CAddonCallbacksAddon::WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize)
+int64_t CAddonCallbacksAddon::WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper)

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -327,7 +327,7 @@ void* CAddonCallbacksAddon::OpenFileForWrite(const void* addonData, const char* 
   return NULL;
 }
 
-unsigned int CAddonCallbacksAddon::ReadFile(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize)
+int64_t CAddonCallbacksAddon::ReadFile(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper)

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -49,7 +49,7 @@ public:
   static void* OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite);
   static int64_t ReadFile(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
   static bool ReadFileString(const void* addonData, void* file, char *szLine, int iLineLength);
-  static int WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
+  static int64_t WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
   static void FlushFile(const void* addonData, void* file);
   static int64_t SeekFile(const void* addonData, void* file, int64_t iFilePosition, int iWhence);
   static int TruncateFile(const void* addonData, void* file, int64_t iSize);

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -47,7 +47,7 @@ public:
   // file operations
   static void* OpenFile(const void* addonData, const char* strFileName, unsigned int flags);
   static void* OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite);
-  static unsigned int ReadFile(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
+  static int64_t ReadFile(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
   static bool ReadFileString(const void* addonData, void* file, char *szLine, int iLineLength);
   static int WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
   static void FlushFile(const void* addonData, void* file);

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -130,7 +130,7 @@ string CRepository::FetchChecksum(const string& url)
       // Transfer-Encoding: chunked servers.
       std::stringstream str;
       char temp[1024];
-      int read;
+      int64_t read;
       while ((read=file.Read(temp, sizeof(temp))) > 0)
         str.write(temp, read);
       return str.str();

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -162,7 +162,7 @@ int CCDDARipJob::RipChunk(CFile& reader, CEncoder* encoder, int& percent)
   uint8_t stream[1024];
 
   // get data
-  int result = reader.Read(stream, 1024);
+  int result = (int)reader.Read(stream, 1024);
 
   // return if rip is done or on some kind of error
   if (!result)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2463,7 +2463,7 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
     delete sound;
     return NULL;
   }
-  int fileSize = sound->GetFileSize();
+  int64_t fileSize = sound->GetFileSize();
 
   fmt_ctx = avformat_alloc_context();
   unsigned char* buffer = (unsigned char*)av_malloc(SOUNDBUFFER_SIZE+FF_INPUT_BUFFER_PADDING_SIZE);
@@ -2541,7 +2541,7 @@ IAESound *CActiveAE::MakeSound(const std::string& file)
       {
         if (!init)
         {
-          int samples = fileSize / av_get_bytes_per_sample(dec_ctx->sample_fmt) / config.channels;
+          int samples = (int)(fileSize / av_get_bytes_per_sample(dec_ctx->sample_fmt) / config.channels);
           config.fmt = dec_ctx->sample_fmt;
           config.bits_per_sample = dec_ctx->bits_per_coded_sample;
           sound->InitSound(true, config, samples);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.cpp
@@ -151,7 +151,7 @@ int CActiveAESound::GetChunkSize()
 int CActiveAESound::Read(void *h, uint8_t* buf, int size)
 {
   CFile *pFile = static_cast<CActiveAESound*>(h)->m_pFile;
-  return pFile->Read(buf, size);
+  return (int)pFile->Read(buf, size);
 }
 
 int64_t CActiveAESound::Seek(void *h, int64_t pos, int whence)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.h
@@ -52,7 +52,7 @@ public:
   bool Prepare();
   void Finish();
   int GetChunkSize();
-  int GetFileSize() { return m_fileSize; }
+  int64_t GetFileSize() { return m_fileSize; }
   bool IsSeekPosible() { return m_isSeekPosible; }
 
   static int Read(void *h, uint8_t* buf, int size);
@@ -62,7 +62,7 @@ protected:
   std::string m_filename;
   XFILE::CFile *m_pFile;
   bool m_isSeekPosible;
-  int m_fileSize;
+  int64_t m_fileSize;
   float m_volume;
 
   CSoundPacket *m_orig_sound;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -113,7 +113,7 @@ int CDVDInputStreamFile::Read(uint8_t* buf, int buf_size)
 {
   if(!m_pFile) return -1;
 
-  unsigned int ret = m_pFile->Read(buf, buf_size);
+  int ret = (int)m_pFile->Read(buf, buf_size);
 
   /* we currently don't support non completing reads */
   if( ret == 0 ) m_eof = true;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.cpp
@@ -93,8 +93,8 @@ void CDVDInputStreamHttp::Close()
 
 int CDVDInputStreamHttp::Read(uint8_t* buf, int buf_size)
 {
-  unsigned int ret = 0;
-  if (m_pFile) ret = m_pFile->Read(buf, buf_size);
+  int ret = 0;
+  if (m_pFile) ret = (int)m_pFile->Read(buf, buf_size);
   else return -1;
 
   if( ret == 0 ) m_eof = true;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -173,7 +173,7 @@ int CDVDInputStreamPVRManager::Read(uint8_t* buf, int buf_size)
   }
   else
   {
-    unsigned int ret = m_pFile->Read(buf, buf_size);
+    int ret = (int) m_pFile->Read(buf, buf_size);
 
     /* we currently don't support non completing reads */
     if( ret == 0 ) m_eof = true;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamTV.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamTV.cpp
@@ -100,7 +100,7 @@ int CDVDInputStreamTV::Read(uint8_t* buf, int buf_size)
 {
   if(!m_pFile) return -1;
 
-  unsigned int ret = m_pFile->Read(buf, buf_size);
+  int ret = (int)m_pFile->Read(buf, buf_size);
 
   /* we currently don't support non completing reads */
   if( ret == 0 ) m_eof = true;

--- a/xbmc/cores/paplayer/OggCallback.cpp
+++ b/xbmc/cores/paplayer/OggCallback.cpp
@@ -46,7 +46,7 @@ size_t COggCallback::ReadCallback(void *ptr, size_t size, size_t nmemb, void *da
   if (!pCallback)
     return 0;
 
-  return pCallback->m_file.Read(ptr, size*nmemb);
+  return (size_t)pCallback->m_file.Read(ptr, size*nmemb);
 }
 
 int COggCallback::SeekCallback(void *datasource, ogg_int64_t offset, int whence)

--- a/xbmc/cores/paplayer/PCMCodec.cpp
+++ b/xbmc/cores/paplayer/PCMCodec.cpp
@@ -73,7 +73,7 @@ int PCMCodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
 {
   *actualsize = 0;
 
-  int iAmountRead = m_file.Read(pBuffer, 2 * (size / 2));
+  int iAmountRead = (int)m_file.Read(pBuffer, 2 * (size / 2));
   if (iAmountRead > 0)
   {
     uint16_t *buffer = (uint16_t*) pBuffer;

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -612,13 +612,13 @@ void CAFPFile::Close()
   }
 }
 
-int CAFPFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CAFPFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   CSingleLock lock(gAfpConnection);
   if (m_pFp == NULL || !m_pAfpVol)
    return -1;
 
-  int numberOfBytesWritten = 0;
+  int64_t numberOfBytesWritten = 0;
   uid_t uid;
   gid_t gid;
 

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -532,7 +532,7 @@ int CAFPFile::Stat(const CURL& url, struct __stat64* buffer)
   return iResult;
 }
 
-unsigned int CAFPFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CAFPFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   CSingleLock lock(gAfpConnection);
   if (m_pFp == NULL || !m_pAfpVol)
@@ -550,7 +550,7 @@ unsigned int CAFPFile::Read(void *lpBuf, int64_t uiBufSize)
 
 #endif
   int eof = 0;
-  int bytesRead = gAfpConnection.GetImpl()->afp_wrap_read(m_pAfpVol,
+  int64_t bytesRead = gAfpConnection.GetImpl()->afp_wrap_read(m_pAfpVol,
     name, (char *)lpBuf,(size_t)uiBufSize, m_fileOffset, m_pFp, &eof);
   if (bytesRead > 0)
     m_fileOffset += bytesRead;
@@ -561,7 +561,7 @@ unsigned int CAFPFile::Read(void *lpBuf, int64_t uiBufSize)
     return 0;
   }
 
-  return (unsigned int)bytesRead;
+  return bytesRead;
 }
 
 int64_t CAFPFile::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/AFPFile.h
+++ b/xbmc/filesystem/AFPFile.h
@@ -100,7 +100,7 @@ public:
   virtual ~CAFPFile();
   virtual void          Close();
   virtual int64_t       Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-  virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t       Read(void* lpBuf, int64_t uiBufSize);
   virtual bool          Open(const CURL& url);
   virtual bool          Exists(const CURL& url);
   virtual int           Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/AFPFile.h
+++ b/xbmc/filesystem/AFPFile.h
@@ -107,7 +107,7 @@ public:
   virtual int           Stat(struct __stat64* buffer);
   virtual int64_t       GetLength();
   virtual int64_t       GetPosition();
-  virtual int           Write(const void* lpBuf, int64_t uiBufSize);
+  virtual int64_t       Write(const void* lpBuf, int64_t uiBufSize);
 
   virtual bool          OpenForWrite(const CURL& url, bool bOverWrite = false);
   virtual bool          Delete(const CURL& url);

--- a/xbmc/filesystem/APKFile.cpp
+++ b/xbmc/filesystem/APKFile.cpp
@@ -175,7 +175,7 @@ int64_t CAPKFile::Seek(int64_t iFilePosition, int iWhence)
   return m_file_pos;
 }
 
-unsigned int CAPKFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CAPKFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   int bytes_read = uiBufSize;
   if (m_zip_archive && m_zip_file)
@@ -191,7 +191,7 @@ unsigned int CAPKFile::Read(void *lpBuf, int64_t uiBufSize)
       bytes_read = 0;
   }
 
-  return (unsigned int)bytes_read;
+  return bytes_read;
 }
 
 int CAPKFile::Stat(struct __stat64* buffer)

--- a/xbmc/filesystem/APKFile.h
+++ b/xbmc/filesystem/APKFile.h
@@ -37,7 +37,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
 
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
     virtual int Stat(struct __stat64* buffer);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
     virtual int64_t GetLength();

--- a/xbmc/filesystem/AndroidAppFile.cpp
+++ b/xbmc/filesystem/AndroidAppFile.cpp
@@ -58,7 +58,7 @@ bool CFileAndroidApp::Exists(const CURL& url)
   return true;
 }
 
-unsigned int CFileAndroidApp::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CFileAndroidApp::Read(void* lpBuf, int64_t uiBufSize)
 {
   CXBMCApp::GetIcon(m_appname, lpBuf, uiBufSize);
   return uiBufSize;

--- a/xbmc/filesystem/AndroidAppFile.h
+++ b/xbmc/filesystem/AndroidAppFile.h
@@ -38,7 +38,7 @@ public:
   virtual int Stat(const CURL& url, struct __stat64* buffer);
 
   /*! \brief Return 32bit rgba raw bitmap. */
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual void Close();
   virtual int64_t GetLength();
   virtual int64_t Seek(int64_t, int) {return -1;};

--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -114,7 +114,7 @@ int CFileCDDA::Stat(const CURL& url, struct __stat64* buffer)
   return -1;
 }
 
-unsigned int CFileCDDA::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CFileCDDA::Read(void* lpBuf, int64_t uiBufSize)
 {
   if (!m_pCdIo || !g_mediaManager.IsDiscInDrive())
     return 0;

--- a/xbmc/filesystem/CDDAFile.h
+++ b/xbmc/filesystem/CDDAFile.h
@@ -37,7 +37,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int64_t GetPosition();

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1015,7 +1015,7 @@ bool CCurlFile::OpenForWrite(const CURL& url, bool bOverWrite)
   return true;
 }
 
-int CCurlFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CCurlFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   if (!(m_opened && m_forWrite) || m_inError)
     return -1;

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -56,7 +56,7 @@ namespace XFILE
       virtual int  Stat(const CURL& url, struct __stat64* buffer);
       virtual void Close();
       virtual bool ReadString(char *szLine, int iLineLength)     { return m_state->ReadString(szLine, iLineLength); }
-      virtual unsigned int Read(void* lpBuf, int64_t uiBufSize)  { return m_state->Read(lpBuf, uiBufSize); }
+      virtual int64_t Read(void* lpBuf, int64_t uiBufSize)       { return m_state->Read(lpBuf, uiBufSize); }
       virtual int Write(const void* lpBuf, int64_t uiBufSize);
       virtual CStdString GetMimeType()                           { return m_state->m_httpheader.GetMimeType(); }
       virtual CStdString GetContent()                            { return GetMimeType(); }
@@ -137,7 +137,7 @@ namespace XFILE
           size_t HeaderCallback(void *ptr, size_t size, size_t nmemb);
 
           bool         Seek(int64_t pos);
-          unsigned int Read(void* lpBuf, int64_t uiBufSize);
+          int64_t      Read(void* lpBuf, int64_t uiBufSize);
           bool         ReadString(char *szLine, int iLineLength);
           bool         FillBuffer(unsigned int want);
           void         SetReadBuffer(const void* lpBuf, int64_t uiBufSize);

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -57,7 +57,7 @@ namespace XFILE
       virtual void Close();
       virtual bool ReadString(char *szLine, int iLineLength)     { return m_state->ReadString(szLine, iLineLength); }
       virtual int64_t Read(void* lpBuf, int64_t uiBufSize)       { return m_state->Read(lpBuf, uiBufSize); }
-      virtual int Write(const void* lpBuf, int64_t uiBufSize);
+      virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
       virtual CStdString GetMimeType()                           { return m_state->m_httpheader.GetMimeType(); }
       virtual CStdString GetContent()                            { return GetMimeType(); }
       virtual int IoControl(EIoControl request, void* param);

--- a/xbmc/filesystem/DAAPFile.cpp
+++ b/xbmc/filesystem/DAAPFile.cpp
@@ -203,7 +203,7 @@ bool CDAAPFile::Open(const CURL& url)
 
 
 //*********************************************************************************************
-unsigned int CDAAPFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CDAAPFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   return m_curl.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/DAAPFile.h
+++ b/xbmc/filesystem/DAAPFile.h
@@ -76,7 +76,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int  IoControl(EIoControl request, void* param);

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -554,7 +554,7 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
   return -1;
 }
 
-unsigned int CFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (!m_pFile || !lpBuf)
     return 0;
@@ -563,7 +563,7 @@ unsigned int CFile::Read(void *lpBuf, int64_t uiBufSize)
   {
     if(m_flags & READ_TRUNCATED)
     {
-      unsigned int nBytes = m_pBuffer->sgetn(
+      int64_t nBytes = m_pBuffer->sgetn(
         (char *)lpBuf, min<streamsize>((streamsize)uiBufSize,
                                                   m_pBuffer->in_avail()));
       if (m_bitStreamStats && nBytes>0)
@@ -572,7 +572,7 @@ unsigned int CFile::Read(void *lpBuf, int64_t uiBufSize)
     }
     else
     {
-      unsigned int nBytes = m_pBuffer->sgetn((char*)lpBuf, uiBufSize);
+      int64_t nBytes = m_pBuffer->sgetn((char*)lpBuf, uiBufSize);
       if (m_bitStreamStats && nBytes>0)
         m_bitStreamStats->AddSampleBytes(nBytes);
       return nBytes;
@@ -583,14 +583,14 @@ unsigned int CFile::Read(void *lpBuf, int64_t uiBufSize)
   {
     if(m_flags & READ_TRUNCATED)
     {
-      unsigned int nBytes = m_pFile->Read(lpBuf, uiBufSize);
+      int64_t nBytes = m_pFile->Read(lpBuf, uiBufSize);
       if (m_bitStreamStats && nBytes>0)
         m_bitStreamStats->AddSampleBytes(nBytes);
       return nBytes;
     }
     else
     {
-      unsigned int done = 0;
+      int64_t done = 0;
       while((uiBufSize-done) > 0)
       {
         int curr = m_pFile->Read((char*)lpBuf+done, uiBufSize-done);

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -792,7 +792,7 @@ bool CFile::ReadString(char *szLine, int iLineLength)
   return false;
 }
 
-int CFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   if (!m_pFile || !lpBuf)
     return -1;

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -110,7 +110,7 @@ public:
   bool OpenForWrite(const CStdString& strFileName, bool bOverWrite = false);
   int64_t Read(void* lpBuf, int64_t uiBufSize);
   bool ReadString(char *szLine, int iLineLength);
-  int Write(const void* lpBuf, int64_t uiBufSize);
+  int64_t Write(const void* lpBuf, int64_t uiBufSize);
   void Flush();
   int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   int Truncate(int64_t iSize);

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -108,7 +108,7 @@ public:
 
   bool Open(const CStdString& strFileName, const unsigned int flags = 0);
   bool OpenForWrite(const CStdString& strFileName, bool bOverWrite = false);
-  unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  int64_t Read(void* lpBuf, int64_t uiBufSize);
   bool ReadString(char *szLine, int iLineLength);
   int Write(const void* lpBuf, int64_t uiBufSize);
   void Flush();

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -264,7 +264,7 @@ void CFileCache::Process()
       }
     }
 
-    int iRead = 0;
+    int64_t iRead = 0;
     if (!cacheReachEOF)
       iRead = m_source.Read(buffer.get(), m_chunkSize);
     if (iRead == 0)
@@ -348,7 +348,7 @@ int CFileCache::Stat(const CURL& url, struct __stat64* buffer)
   return CFile::Stat(url.Get(), buffer);
 }
 
-unsigned int CFileCache::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CFileCache::Read(void* lpBuf, int64_t uiBufSize)
 {
   CSingleLock lock(m_sync);
   if (!m_pCache)
@@ -364,7 +364,7 @@ retry:
   if (iRc > 0)
   {
     m_readPos += iRc;
-    return (int)iRc;
+    return iRc;
   }
 
   if (iRc == CACHE_RC_WOULD_BLOCK)

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -284,11 +284,11 @@ void CFileCache::Process()
     else if (iRead < 0)
       m_bStop = true;
 
-    int iTotalWrite=0;
+    int64_t iTotalWrite = 0;
     while (!m_bStop && (iTotalWrite < iRead))
     {
-      int iWrite = 0;
-      iWrite = m_pCache->WriteToCache(buffer.get()+iTotalWrite, iRead - iTotalWrite);
+      int64_t iWrite = 0;
+      iWrite = m_pCache->WriteToCache(buffer.get()+iTotalWrite, iRead - iTotalWrite); // TODO: properly support large buffer
 
       // write should always work. all handling of buffering and errors should be
       // done inside the cache strategy. only if unrecoverable error happened, WriteToCache would return error and we break.

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -48,7 +48,7 @@ namespace XFILE
     virtual bool          Exists(const CURL& url);
     virtual int           Stat(const CURL& url, struct __stat64* buffer);
 
-    virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t       Read(void* lpBuf, int64_t uiBufSize);
 
     virtual int64_t       Seek(int64_t iFilePosition, int iWhence);
     virtual int64_t       GetPosition();

--- a/xbmc/filesystem/FileReaderFile.cpp
+++ b/xbmc/filesystem/FileReaderFile.cpp
@@ -67,7 +67,7 @@ bool CFileReaderFile::OpenForWrite(const CURL& url, bool bOverWrite)
 }
 
 //*********************************************************************************************
-unsigned int CFileReaderFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CFileReaderFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   return m_reader.Read(lpBuf,uiBufSize);
 }

--- a/xbmc/filesystem/FileReaderFile.cpp
+++ b/xbmc/filesystem/FileReaderFile.cpp
@@ -73,7 +73,7 @@ int64_t CFileReaderFile::Read(void *lpBuf, int64_t uiBufSize)
 }
 
 //*********************************************************************************************
-int CFileReaderFile::Write(const void *lpBuf, int64_t uiBufSize)
+int64_t CFileReaderFile::Write(const void *lpBuf, int64_t uiBufSize)
 {
   return 0;
 }

--- a/xbmc/filesystem/FileReaderFile.h
+++ b/xbmc/filesystem/FileReaderFile.h
@@ -36,7 +36,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();

--- a/xbmc/filesystem/FileReaderFile.h
+++ b/xbmc/filesystem/FileReaderFile.h
@@ -37,7 +37,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 

--- a/xbmc/filesystem/HDFile.cpp
+++ b/xbmc/filesystem/HDFile.cpp
@@ -226,7 +226,7 @@ int64_t CHDFile::Read(void *lpBuf, int64_t uiBufSize)
 }
 
 //*********************************************************************************************
-int CHDFile::Write(const void *lpBuf, int64_t uiBufSize)
+int64_t CHDFile::Write(const void *lpBuf, int64_t uiBufSize)
 {
   if (!m_hFile.isValid())
     return 0;

--- a/xbmc/filesystem/HDFile.cpp
+++ b/xbmc/filesystem/HDFile.cpp
@@ -199,7 +199,7 @@ bool CHDFile::OpenForWrite(const CURL& url, bool bOverWrite)
 }
 
 //*********************************************************************************************
-unsigned int CHDFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CHDFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (!m_hFile.isValid()) return 0;
   DWORD nBytesRead;

--- a/xbmc/filesystem/HDFile.h
+++ b/xbmc/filesystem/HDFile.h
@@ -45,7 +45,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual int Truncate(int64_t size);

--- a/xbmc/filesystem/HDFile.h
+++ b/xbmc/filesystem/HDFile.h
@@ -46,7 +46,7 @@ public:
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
   virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual int Truncate(int64_t size);
   virtual void Close();

--- a/xbmc/filesystem/HDHomeRunFile.cpp
+++ b/xbmc/filesystem/HDHomeRunFile.cpp
@@ -106,7 +106,7 @@ bool CHomeRunFile::Open(const CURL &url)
   return true;
 }
 
-unsigned int CHomeRunFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CHomeRunFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   size_t datasize;
 
@@ -120,7 +120,7 @@ unsigned int CHomeRunFile::Read(void* lpBuf, int64_t uiBufSize)
   XbmcThreads::EndTime timestamp(5000);
   while(1)
   {
-    datasize = (size_t) uiBufSize;
+    datasize = (size_t)uiBufSize; // TODO: properly support large buffer
     uint8_t* ptr = m_pdll->device_stream_recv(m_device, datasize, &datasize);
     if(ptr)
     {
@@ -133,7 +133,7 @@ unsigned int CHomeRunFile::Read(void* lpBuf, int64_t uiBufSize)
 
     Sleep(64);
   }
-  return (unsigned int)datasize;
+  return datasize;
 }
 
 void CHomeRunFile::Close()

--- a/xbmc/filesystem/HDHomeRunFile.h
+++ b/xbmc/filesystem/HDHomeRunFile.h
@@ -40,7 +40,7 @@ namespace XFILE
 
       virtual bool          Open(const CURL& url);
       virtual void          Close();
-      virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+      virtual int64_t       Read(void* lpBuf, int64_t uiBufSize);
       virtual int           GetChunkSize();
     private:
       struct hdhomerun_device_t* m_device;

--- a/xbmc/filesystem/HTTPFile.cpp
+++ b/xbmc/filesystem/HTTPFile.cpp
@@ -40,7 +40,7 @@ bool CHTTPFile::OpenForWrite(const CURL& url, bool bOverWrite)
   return true;
 }
 
-int CHTTPFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CHTTPFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   // Although we can not verify much, try to catch errors where we can
   if (!m_openedforwrite)
@@ -60,6 +60,6 @@ int CHTTPFile::Write(const void* lpBuf, int64_t uiBufSize)
     return -1;
 
   // Finally (and this is a clumsy hack) return the http response code
-  return (int) m_httpresponse;
+  return (int64_t) m_httpresponse;
 }
 

--- a/xbmc/filesystem/HTTPFile.h
+++ b/xbmc/filesystem/HTTPFile.h
@@ -30,7 +30,7 @@ namespace XFILE
     CHTTPFile(void);
     virtual ~CHTTPFile(void);
     virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
-    virtual int Write(const void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
   private:
     bool            m_openedforwrite;
     CURL            m_urlforwrite;

--- a/xbmc/filesystem/IFile.cpp
+++ b/xbmc/filesystem/IFile.cpp
@@ -50,7 +50,7 @@ bool IFile::ReadString(char *szLine, int iLineLength)
   if(Seek(0, SEEK_CUR) < 0) return false;
 
   int64_t iFilePos = GetPosition();
-  int iBytesRead = Read( (unsigned char*)szLine, iLineLength - 1);
+  int64_t iBytesRead = Read((unsigned char*)szLine, iLineLength - 1);
   if (iBytesRead <= 0)
     return false;
 

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -56,7 +56,7 @@ public:
   virtual bool Exists(const CURL& url) = 0;
   virtual int Stat(const CURL& url, struct __stat64* buffer) = 0;
   virtual int Stat(struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize) = 0;
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize) = 0;
   virtual int Write(const void* lpBuf, int64_t uiBufSize) { return -1;};
   virtual bool ReadString(char *szLine, int iLineLength);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) = 0;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -57,7 +57,7 @@ public:
   virtual int Stat(const CURL& url, struct __stat64* buffer) = 0;
   virtual int Stat(struct __stat64* buffer);
   virtual int64_t Read(void* lpBuf, int64_t uiBufSize) = 0;
-  virtual int Write(const void* lpBuf, int64_t uiBufSize) { return -1;};
+  virtual int64_t Write(const void* lpBuf, int64_t uiBufSize) { return -1;};
   virtual bool ReadString(char *szLine, int iLineLength);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) = 0;
   virtual void Close() = 0;

--- a/xbmc/filesystem/ISOFile.cpp
+++ b/xbmc/filesystem/ISOFile.cpp
@@ -67,7 +67,7 @@ bool CISOFile::Open(const CURL& url)
 }
 
 //*********************************************************************************************
-unsigned int CISOFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CISOFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (!m_bOpened) return 0;
   char *pData = (char *)lpBuf;
@@ -90,7 +90,7 @@ unsigned int CISOFile::Read(void *lpBuf, int64_t uiBufSize)
       if (m_cache.getMaxWriteSize() > 5000)
       {
         uint8_t buffer[5000];
-        long lBytesRead = m_isoReader.ReadFile( m_hFile, buffer, sizeof(buffer));
+        int64_t lBytesRead = m_isoReader.ReadFile(m_hFile, buffer, sizeof(buffer));
         if (lBytesRead > 0)
           m_cache.WriteData((char*)buffer, lBytesRead);
         else
@@ -99,7 +99,7 @@ unsigned int CISOFile::Read(void *lpBuf, int64_t uiBufSize)
     }
     return lTotalBytesRead;
   }
-  int iResult = m_isoReader.ReadFile( m_hFile, (uint8_t*)pData, (long)uiBufSize);
+  int64_t iResult = m_isoReader.ReadFile(m_hFile, (uint8_t*)pData, (long)uiBufSize);
   if (iResult == -1)
     return 0;
   return iResult;

--- a/xbmc/filesystem/ISOFile.h
+++ b/xbmc/filesystem/ISOFile.h
@@ -45,7 +45,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 protected:

--- a/xbmc/filesystem/ImageFile.cpp
+++ b/xbmc/filesystem/ImageFile.cpp
@@ -85,7 +85,7 @@ int CImageFile::Stat(const CURL& url, struct __stat64* buffer)
   return -1;
 }
 
-unsigned int CImageFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CImageFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/ImageFile.h
+++ b/xbmc/filesystem/ImageFile.h
@@ -33,7 +33,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual void Close();
     virtual int64_t GetPosition();

--- a/xbmc/filesystem/MultiPathFile.cpp
+++ b/xbmc/filesystem/MultiPathFile.cpp
@@ -94,7 +94,7 @@ int CMultiPathFile::Stat(const CURL& url, struct __stat64* buffer)
   return -1;
 }
 
-unsigned int CMultiPathFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CMultiPathFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/MultiPathFile.h
+++ b/xbmc/filesystem/MultiPathFile.h
@@ -33,7 +33,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual void Close();
     virtual int64_t GetPosition();

--- a/xbmc/filesystem/MusicDatabaseFile.cpp
+++ b/xbmc/filesystem/MusicDatabaseFile.cpp
@@ -78,7 +78,7 @@ int CMusicDatabaseFile::Stat(const CURL& url, struct __stat64* buffer)
   return m_file.Stat(TranslateUrl(url), buffer);
 }
 
-unsigned int CMusicDatabaseFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CMusicDatabaseFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/MusicDatabaseFile.h
+++ b/xbmc/filesystem/MusicDatabaseFile.h
@@ -33,7 +33,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int64_t GetPosition();

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -492,7 +492,7 @@ int64_t CMythFile::GetLength()
   return -1;
 }
 
-unsigned int CMythFile::Read(void* buffer, int64_t size)
+int64_t CMythFile::Read(void* buffer, int64_t size)
 {
   /* check for any events */
   HandleEvents();
@@ -501,7 +501,7 @@ unsigned int CMythFile::Read(void* buffer, int64_t size)
   if(!m_recorder && !m_file)
     return 0;
 
-  int ret;
+  int64_t ret;
   if(m_recorder)
     ret = m_dll->livetv_read(m_recorder, (char*)buffer, (unsigned long)size);
   else

--- a/xbmc/filesystem/MythFile.h
+++ b/xbmc/filesystem/MythFile.h
@@ -51,7 +51,7 @@ public:
   virtual int64_t       GetLength();
   virtual int           Stat(const CURL& url, struct __stat64* buffer) { return -1; }
   virtual void          Close();
-  virtual unsigned int  Read(void* buffer, int64_t size);
+  virtual int64_t       Read(void* buffer, int64_t size);
   virtual CStdString    GetContent() { return ""; }
   virtual bool          SkipNext();
 

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -634,9 +634,9 @@ int CNFSFile::Stat(const CURL& url, struct __stat64* buffer)
   return ret;
 }
 
-unsigned int CNFSFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CNFSFile::Read(void *lpBuf, int64_t uiBufSize)
 {
-  int numberOfBytesRead = 0;
+  int64_t numberOfBytesRead = 0;
   CSingleLock lock(gNfsConnection);
   
   if (m_pFileHandle == NULL || m_pNfsContext == NULL ) return 0;
@@ -653,7 +653,7 @@ unsigned int CNFSFile::Read(void *lpBuf, int64_t uiBufSize)
     CLog::Log(LOGERROR, "%s - Error( %d, %s )", __FUNCTION__, numberOfBytesRead, gNfsConnection.GetImpl()->nfs_get_error(m_pNfsContext));
     return 0;
   }
-  return (unsigned int)numberOfBytesRead;
+  return numberOfBytesRead;
 }
 
 int64_t CNFSFile::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -718,10 +718,10 @@ void CNFSFile::Close()
 //this was a bitch!
 //for nfs write to work we have to write chunked
 //otherwise this could crash on big files
-int CNFSFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CNFSFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
-  int numberOfBytesWritten = 0;
-  int writtenBytes = 0;
+  int64_t numberOfBytesWritten = 0;
+  int64_t writtenBytes = 0;
   int64_t leftBytes = uiBufSize;
   //clamp max write chunksize to 32kb - fixme - this might be superfluious with future libnfs versions
   int64_t chunkSize = gNfsConnection.GetMaxWriteChunkSize() > 32768 ? 32768 : gNfsConnection.GetMaxWriteChunkSize();

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -135,7 +135,7 @@ namespace XFILE
     virtual ~CNFSFile();
     virtual void Close();
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
     virtual bool Open(const CURL& url);
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -142,7 +142,7 @@ namespace XFILE
     virtual int Stat(struct __stat64* buffer);
     virtual int64_t GetLength();
     virtual int64_t GetPosition();
-    virtual int Write(const void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
     virtual int Truncate(int64_t iSize);
 
     //implement iocontrol for seek_possible for preventing the stat in File class for

--- a/xbmc/filesystem/NptXbmcFile.cpp
+++ b/xbmc/filesystem/NptXbmcFile.cpp
@@ -154,7 +154,7 @@ NPT_XbmcFileInputStream::Read(void*     buffer,
                               NPT_Size  bytes_to_read, 
                               NPT_Size* bytes_read)
 {
-    unsigned int nb_read;
+    int64_t nb_read;
 
     // check the parameters
     if (buffer == NULL) {

--- a/xbmc/filesystem/PVRFile.cpp
+++ b/xbmc/filesystem/PVRFile.cpp
@@ -101,7 +101,7 @@ void CPVRFile::Close()
   g_PVRManager.CloseStream();
 }
 
-unsigned int CPVRFile::Read(void* buffer, int64_t size)
+int64_t CPVRFile::Read(void* buffer, int64_t size)
 {
   return g_PVRManager.IsStarted() ? g_PVRClients->ReadStream((BYTE*)buffer, size) : 0;
 }

--- a/xbmc/filesystem/PVRFile.h
+++ b/xbmc/filesystem/PVRFile.h
@@ -42,7 +42,7 @@ public:
   virtual int64_t       GetLength();
   virtual int           Stat(const CURL& url, struct __stat64* buffer) { return -1; }
   virtual void          Close();
-  virtual unsigned int  Read(void* buffer, int64_t size);
+  virtual int64_t       Read(void* buffer, int64_t size);
   virtual CStdString    GetContent()                                   { return ""; }
   virtual bool          SkipNext()                                     { return !m_isPlayRecording; }
 

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -77,7 +77,7 @@ int CPipeFile::Stat(struct __stat64* buffer)
   return 0;
 }
 
-unsigned int CPipeFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CPipeFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   if (!m_pipe)
     return -1;

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -85,7 +85,7 @@ int64_t CPipeFile::Read(void* lpBuf, int64_t uiBufSize)
   return m_pipe->Read((char *)lpBuf,(int)uiBufSize);
 }
 
-int CPipeFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CPipeFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   if (!m_pipe)
     return -1;

--- a/xbmc/filesystem/PipeFile.h
+++ b/xbmc/filesystem/PipeFile.h
@@ -52,7 +52,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();

--- a/xbmc/filesystem/PipeFile.h
+++ b/xbmc/filesystem/PipeFile.h
@@ -53,7 +53,7 @@ public:
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
   virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual void Flush();

--- a/xbmc/filesystem/RTVFile.cpp
+++ b/xbmc/filesystem/RTVFile.cpp
@@ -122,9 +122,9 @@ int CRTVFile::Stat(const CURL& url, struct __stat64* buffer)
 }
 
 //*********************************************************************************************
-unsigned int CRTVFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CRTVFile::Read(void *lpBuf, int64_t uiBufSize)
 {
-  size_t lenread;
+  int64_t lenread;
 
   // Don't read if no connection is open!
   if (!m_bOpened) return 0;
@@ -138,7 +138,7 @@ unsigned int CRTVFile::Read(void *lpBuf, int64_t uiBufSize)
   if(m_filePos + lenread > m_fileSize)
   {
     CLog::Log(LOGWARNING, "%s - RTV library read passed filesize, returning last chunk", __FUNCTION__);
-    lenread = (size_t)(m_fileSize - m_filePos);
+    lenread = (m_fileSize - m_filePos);
     m_filePos = m_fileSize;
     return lenread;
   }

--- a/xbmc/filesystem/RTVFile.h
+++ b/xbmc/filesystem/RTVFile.h
@@ -45,7 +45,7 @@ public:
   bool Open(const char* strHostName, const char* strFileName, int iport);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 protected:

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -357,11 +357,6 @@ int64_t CRarFile::Read(void *lpBuf, int64_t uiBufSize)
 #endif
 }
 
-unsigned int CRarFile::Write(void *lpBuf, int64_t uiBufSize)
-{
-  return 0;
-}
-
 void CRarFile::Close()
 {
 #ifdef HAS_FILESYSTEM_RAR
@@ -527,7 +522,7 @@ int64_t CRarFile::GetPosition()
   return m_iFilePosition;
 }
 
-int CRarFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CRarFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   return -1;
 }

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -269,7 +269,7 @@ bool CRarFile::OpenForWrite(const CURL& url)
   return false;
 }
 
-unsigned int CRarFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CRarFile::Read(void *lpBuf, int64_t uiBufSize)
 {
 #ifdef HAS_FILESYSTEM_RAR
   if (!m_bOpen)
@@ -351,7 +351,7 @@ unsigned int CRarFile::Read(void *lpBuf, int64_t uiBufSize)
 
   m_pExtract->GetDataIO().hBufferEmpty->Set();
 
-  return static_cast<unsigned int>(uiBufSize-uicBufSize);
+  return uiBufSize-uicBufSize;
 #else
   return 0;
 #endif

--- a/xbmc/filesystem/RarFile.h
+++ b/xbmc/filesystem/RarFile.h
@@ -71,7 +71,7 @@ namespace XFILE
     virtual bool          Open(const CURL& url);
     virtual bool          Exists(const CURL& url);
     virtual int           Stat(const CURL& url, struct __stat64* buffer);
-    virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t       Read(void* lpBuf, int64_t uiBufSize);
     virtual int           Write(const void* lpBuf, int64_t uiBufSize);
     virtual int64_t       Seek(int64_t iFilePosition, int iWhence=SEEK_SET);
     virtual void          Close();

--- a/xbmc/filesystem/RarFile.h
+++ b/xbmc/filesystem/RarFile.h
@@ -72,7 +72,7 @@ namespace XFILE
     virtual bool          Exists(const CURL& url);
     virtual int           Stat(const CURL& url, struct __stat64* buffer);
     virtual int64_t       Read(void* lpBuf, int64_t uiBufSize);
-    virtual int           Write(const void* lpBuf, int64_t uiBufSize);
+    virtual int64_t       Write(const void* lpBuf, int64_t uiBufSize);
     virtual int64_t       Seek(int64_t iFilePosition, int iWhence=SEEK_SET);
     virtual void          Close();
     virtual void          Flush();

--- a/xbmc/filesystem/SAPFile.cpp
+++ b/xbmc/filesystem/SAPFile.cpp
@@ -111,9 +111,9 @@ int CSAPFile::Stat(const CURL& url, struct __stat64* buffer)
 }
 
 
-unsigned int CSAPFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CSAPFile::Read(void *lpBuf, int64_t uiBufSize)
 {
-  return (unsigned int)m_stream.readsome((char*)lpBuf, (streamsize)uiBufSize);
+  return m_stream.readsome((char*)lpBuf, (streamsize)uiBufSize);
 }
 
 void CSAPFile::Close()

--- a/xbmc/filesystem/SAPFile.h
+++ b/xbmc/filesystem/SAPFile.h
@@ -41,7 +41,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 

--- a/xbmc/filesystem/SFTPFile.cpp
+++ b/xbmc/filesystem/SFTPFile.cpp
@@ -302,7 +302,7 @@ int CSFTPSession::Seek(sftp_file handle, uint64_t position)
   return sftp_seek64(handle, position);
 }
 
-int CSFTPSession::Read(sftp_file handle, void *buffer, size_t length)
+int64_t CSFTPSession::Read(sftp_file handle, void *buffer, size_t length)
 {
   CSingleLock lock(m_critSect);
   m_LastActive = XbmcThreads::SystemClockMillis();
@@ -637,11 +637,11 @@ int64_t CSFTPFile::Seek(int64_t iFilePosition, int iWhence)
   }
 }
 
-unsigned int CSFTPFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CSFTPFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   if (m_session && m_sftp_handle)
   {
-    int rc = m_session->Read(m_sftp_handle, lpBuf, (size_t)uiBufSize);
+    int64_t rc = m_session->Read(m_sftp_handle, lpBuf, (size_t)uiBufSize);
 
     if (rc >= 0)
       return rc;

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -61,7 +61,7 @@ public:
   bool FileExists(const char *path);
   int Stat(const char *path, struct __stat64* buffer);
   int Seek(sftp_file handle, uint64_t position);
-  int Read(sftp_file handle, void *buffer, size_t length);
+  int64_t Read(sftp_file handle, void *buffer, size_t length);
   int64_t GetPosition(sftp_file handle);
   bool IsIdle();
 private:
@@ -100,7 +100,7 @@ namespace XFILE
     virtual ~CSFTPFile();
     virtual void Close();
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
     virtual bool Open(const CURL& url);
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -95,7 +95,7 @@ bool CShoutcastFile::Open(const CURL& url)
   return result;
 }
 
-unsigned int CShoutcastFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CShoutcastFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   if (m_currint >= m_metaint && m_metaint > 0)
   {
@@ -114,11 +114,11 @@ unsigned int CShoutcastFile::Read(void* lpBuf, int64_t uiBufSize)
     m_currint = 0;
   }
 
-  unsigned int toRead;
+  int64_t toRead;
   if (m_metaint > 0)
-    toRead = std::min((unsigned int)uiBufSize,(unsigned int)m_metaint-m_currint);
+    toRead = std::min<int64_t>(uiBufSize, m_metaint - m_currint);
   else
-    toRead = std::min((unsigned int)uiBufSize,(unsigned int)16*255);
+    toRead = std::min<int64_t>(uiBufSize, 16 * 255);
   toRead = m_file.Read(lpBuf,toRead);
   m_currint += toRead;
   return toRead;
@@ -175,7 +175,7 @@ void CShoutcastFile::ReadTruncated(char* buf2, int size)
   char* buf = buf2;
   while (size > 0)
   {
-    int read = m_file.Read(buf,size);
+    int read = (int)m_file.Read(buf,size);
     size -= read;
     buf += read;
   }

--- a/xbmc/filesystem/ShoutcastFile.h
+++ b/xbmc/filesystem/ShoutcastFile.h
@@ -45,7 +45,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url) { return true;};
   virtual int Stat(const CURL& url, struct __stat64* buffer) { errno = ENOENT; return -1; };
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   int IoControl(EIoControl request, void* param);
@@ -59,7 +59,7 @@ protected:
   std::string m_fileCharset;
   int m_metaint;
   int m_discarded; // data used for tags
-  int m_currint;
+  int64_t m_currint;
   char* m_buffer; // buffer used for tags
   MUSIC_INFO::CMusicInfoTag m_tag;
 

--- a/xbmc/filesystem/SlingboxFile.cpp
+++ b/xbmc/filesystem/SlingboxFile.cpp
@@ -156,10 +156,10 @@ bool CSlingboxFile::Open(const CURL& url)
   return true;
 }
 
-unsigned int CSlingboxFile::Read(void * pBuffer, int64_t iSize)
+int64_t CSlingboxFile::Read(void * pBuffer, int64_t iSize)
 {
   // Read the data and check for any errors
-  int iRead = m_pSlingbox->ReadStream(pBuffer, (unsigned int)iSize);
+  int64_t iRead = m_pSlingbox->ReadStream(pBuffer, (unsigned int)iSize);
   if (iRead < 0)
   {
     CLog::Log(LOGERROR, "%s - Error reading stream from Slingbox: %s", __FUNCTION__,

--- a/xbmc/filesystem/SlingboxFile.h
+++ b/xbmc/filesystem/SlingboxFile.h
@@ -33,7 +33,7 @@ namespace XFILE
     CSlingboxFile();
     virtual ~CSlingboxFile();
     virtual bool Open(const CURL& url);
-    virtual unsigned int Read(void * buffer, int64_t size);
+    virtual int64_t Read(void * buffer, int64_t size);
     virtual void Close();
     virtual bool SkipNext();
     

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -508,7 +508,7 @@ int CSmbFile::Truncate(int64_t size)
   return 0;
 }
 
-unsigned int CSmbFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CSmbFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (m_fd == -1) return 0;
   CSingleLock lock(smb); // Init not called since it has to be "inited" by now
@@ -537,7 +537,7 @@ unsigned int CSmbFile::Read(void *lpBuf, int64_t uiBufSize)
     return 0;
   }
 
-  return (unsigned int)bytesRead;
+  return bytesRead;
 }
 
 int64_t CSmbFile::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -568,7 +568,7 @@ void CSmbFile::Close()
   m_fd = -1;
 }
 
-int CSmbFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CSmbFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   if (m_fd == -1) return -1;
   DWORD dwNumberOfBytesWritten = 0;
@@ -578,7 +578,7 @@ int CSmbFile::Write(const void* lpBuf, int64_t uiBufSize)
   CSingleLock lock(smb);
   dwNumberOfBytesWritten = smbc_write(m_fd, (void*)lpBuf, (DWORD)uiBufSize);
 
-  return (int)dwNumberOfBytesWritten;
+  return (int64_t)dwNumberOfBytesWritten;
 }
 
 bool CSmbFile::Delete(const CURL& url)

--- a/xbmc/filesystem/SmbFile.h
+++ b/xbmc/filesystem/SmbFile.h
@@ -87,7 +87,7 @@ public:
   virtual int Truncate(int64_t size);
   virtual int64_t GetLength();
   virtual int64_t GetPosition();
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
 
   virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
   virtual bool Delete(const CURL& url);

--- a/xbmc/filesystem/SmbFile.h
+++ b/xbmc/filesystem/SmbFile.h
@@ -79,7 +79,7 @@ public:
   virtual ~CSmbFile();
   virtual void Close();
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/SpecialProtocolFile.cpp
+++ b/xbmc/filesystem/SpecialProtocolFile.cpp
@@ -88,7 +88,7 @@ int64_t CSpecialProtocolFile::Read(void* lpBuf, int64_t uiBufSize)
   return m_file.Read(lpBuf, uiBufSize);
 }
   
-int CSpecialProtocolFile::Write(const void* lpBuf, int64_t uiBufSize)
+int64_t CSpecialProtocolFile::Write(const void* lpBuf, int64_t uiBufSize)
 {
   return m_file.Write(lpBuf,uiBufSize);
 }

--- a/xbmc/filesystem/SpecialProtocolFile.cpp
+++ b/xbmc/filesystem/SpecialProtocolFile.cpp
@@ -83,7 +83,7 @@ int CSpecialProtocolFile::Stat(struct __stat64* buffer)
   return m_file.Stat(buffer);
 }
 
-unsigned int CSpecialProtocolFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CSpecialProtocolFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/SpecialProtocolFile.h
+++ b/xbmc/filesystem/SpecialProtocolFile.h
@@ -37,7 +37,7 @@ public:
   virtual bool Delete(const CURL& url);
   virtual bool Rename(const CURL& url, const CURL& urlnew);
 
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();

--- a/xbmc/filesystem/SpecialProtocolFile.h
+++ b/xbmc/filesystem/SpecialProtocolFile.h
@@ -38,7 +38,7 @@ public:
   virtual bool Rename(const CURL& url, const CURL& urlnew);
 
   virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int64_t GetPosition();

--- a/xbmc/filesystem/TuxBoxDirectory.cpp
+++ b/xbmc/filesystem/TuxBoxDirectory.cpp
@@ -111,15 +111,15 @@ bool CTuxBoxDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
       // restore protocol
       url.SetProtocol(protocol);
 
-      int size_read = 0;
-      int size_total = (int)http.GetLength();
-      int data_size = 0;
+      size_t size_read = 0;
+      size_t size_total = (size_t)http.GetLength();
+      size_t data_size = 0;
       CStdString data;
       data.reserve(size_total);
 
       // read response from server into string buffer
       char buffer[16384];
-      while ((size_read = http.Read(buffer, sizeof(buffer)-1)) > 0)
+      while ((size_read = (size_t)http.Read(buffer, sizeof(buffer)-1)) > 0)
       {
         buffer[size_read] = 0;
         data += buffer;

--- a/xbmc/filesystem/TuxBoxFile.cpp
+++ b/xbmc/filesystem/TuxBoxFile.cpp
@@ -47,7 +47,7 @@ bool CTuxBoxFile::Open(const CURL& url)
   return true;
 }
 
-unsigned int CTuxBoxFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CTuxBoxFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   return 0;
 }

--- a/xbmc/filesystem/TuxBoxFile.h
+++ b/xbmc/filesystem/TuxBoxFile.h
@@ -34,7 +34,7 @@ namespace XFILE
       virtual void Close();
       virtual bool Exists(const CURL& url);
       virtual int Stat(const CURL& url, struct __stat64* buffer);
-      virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+      virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
       virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     protected:
   };

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -65,12 +65,12 @@ bool CUDFFile::Open(const CURL& url)
 }
 
 //*********************************************************************************************
-unsigned int CUDFFile::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CUDFFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (!m_bOpened) return 0;
   char *pData = (char *)lpBuf;
 
-  int iResult = m_udfIsoReaderLocal.ReadFile( m_hFile, (unsigned char*)pData, (long)uiBufSize);
+  int64_t iResult = m_udfIsoReaderLocal.ReadFile( m_hFile, (unsigned char*)pData, (long)uiBufSize);
   if (iResult == -1)
     return 0;
   return iResult;

--- a/xbmc/filesystem/UDFFile.h
+++ b/xbmc/filesystem/UDFFile.h
@@ -38,7 +38,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 protected:

--- a/xbmc/filesystem/UPnPFile.h
+++ b/xbmc/filesystem/UPnPFile.h
@@ -32,7 +32,7 @@ namespace XFILE
       virtual bool Exists(const CURL& url);
       virtual int Stat(const CURL& url, struct __stat64* buffer);
       
-      virtual unsigned int Read(void* lpBuf, int64_t uiBufSize) {return -1;}
+      virtual int64_t Read(void* lpBuf, int64_t uiBufSize) {return -1;}
       virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) {return -1;}
       virtual void Close(){}
       virtual int64_t GetPosition() {return -1;}

--- a/xbmc/filesystem/VTPFile.cpp
+++ b/xbmc/filesystem/VTPFile.cpp
@@ -92,7 +92,7 @@ bool CVTPFile::Open(const CURL& url2)
   return true;
 }
 
-unsigned int CVTPFile::Read(void* buffer, int64_t size)
+int64_t CVTPFile::Read(void* buffer, int64_t size)
 {
   if(m_socket == INVALID_SOCKET)
     return 0;

--- a/xbmc/filesystem/VTPFile.h
+++ b/xbmc/filesystem/VTPFile.h
@@ -41,7 +41,7 @@ public:
   virtual int64_t       GetLength()                                    { return -1; }
   virtual int           Stat(const CURL& url, struct __stat64* buffer) { return -1; }
   virtual void          Close();
-  virtual unsigned int  Read(void* buffer, int64_t size);
+  virtual int64_t       Read(void* buffer, int64_t size);
   virtual CStdString    GetContent()                                   { return ""; }
   virtual bool          SkipNext()                                     { return m_socket ? true : false; }
 

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -190,7 +190,7 @@ int64_t CZipFile::Seek(int64_t iFilePosition, int iWhence)
         m_ZStream.total_out = 0;
         while (m_iFilePos < iFilePosition)
         {
-          unsigned int iToRead = (iFilePosition-m_iFilePos)>131072?131072:(int)(iFilePosition-m_iFilePos);
+          int64_t iToRead = (iFilePosition - m_iFilePos)>131072 ? 131072 : (int)(iFilePosition - m_iFilePos);
           if (Read(temp,iToRead) != iToRead)
             return -1;
         }
@@ -209,7 +209,7 @@ int64_t CZipFile::Seek(int64_t iFilePosition, int iWhence)
       iFilePosition += m_iFilePos;
       while (m_iFilePos < iFilePosition)
       {
-        unsigned int iToRead = (iFilePosition-m_iFilePos)>131072?131072:(int)(iFilePosition-m_iFilePos);
+        int64_t iToRead = (iFilePosition - m_iFilePos)>131072 ? 131072 : (int)(iFilePosition - m_iFilePos);
         if (Read(temp,iToRead) != iToRead)
           return -1;
       }
@@ -222,7 +222,7 @@ int64_t CZipFile::Seek(int64_t iFilePosition, int iWhence)
 
       while( (int)m_ZStream.total_out < mZipItem.usize+iFilePosition)
       {
-        unsigned int iToRead = (mZipItem.usize+iFilePosition-m_ZStream.total_out > 131072)?131072:(int)(mZipItem.usize+iFilePosition-m_ZStream.total_out);
+        int64_t iToRead = (mZipItem.usize + iFilePosition - m_ZStream.total_out > 131072) ? 131072 : (int)(mZipItem.usize + iFilePosition - m_ZStream.total_out);
         if (Read(temp,iToRead) != iToRead)
           return -1;
       }
@@ -283,7 +283,7 @@ int CZipFile::Stat(const CURL& url, struct __stat64* buffer)
   return 0;
 }
 
-unsigned int CZipFile::Read(void* lpBuf, int64_t uiBufSize)
+int64_t CZipFile::Read(void* lpBuf, int64_t uiBufSize)
 {
   if (m_bCached)
     return mFile.Read(lpBuf,uiBufSize);
@@ -346,7 +346,7 @@ unsigned int CZipFile::Read(void* lpBuf, int64_t uiBufSize)
     {
       return 0; // we are past eof, this shouldn't happen but test anyway
     }
-    unsigned int iResult = mFile.Read(lpBuf,uiBufSize);
+    int64_t iResult = mFile.Read(lpBuf,uiBufSize);
     m_iZipFilePos += iResult;
     m_iFilePos += iResult;
     return iResult;
@@ -503,7 +503,7 @@ int CZipFile::UnpackFromMemory(string& strDest, const string& strInput, bool isG
       toRead = mZipItem.usize;
     }
     int iCurrResult;
-    while( (iCurrResult=Read(temp,toRead)) > 0)
+    while( (iCurrResult=(int)Read(temp,toRead)) > 0)
     {
       strDest.append(temp,temp+iCurrResult);
       iResult += iCurrResult;

--- a/xbmc/filesystem/ZipFile.h
+++ b/xbmc/filesystem/ZipFile.h
@@ -40,7 +40,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
     virtual int Stat(struct __stat64* buffer);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
     //virtual bool ReadString(char *szLine, int iLineLength);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual void Close();

--- a/xbmc/filesystem/windows/WINFileSMB.cpp
+++ b/xbmc/filesystem/windows/WINFileSMB.cpp
@@ -202,7 +202,7 @@ int64_t CWINFileSMB::Read(void *lpBuf, int64_t uiBufSize)
 }
 
 //*********************************************************************************************
-int CWINFileSMB::Write(const void *lpBuf, int64_t uiBufSize)
+int64_t CWINFileSMB::Write(const void *lpBuf, int64_t uiBufSize)
 {
   if (!m_hFile.isValid())
     return 0;

--- a/xbmc/filesystem/windows/WINFileSMB.cpp
+++ b/xbmc/filesystem/windows/WINFileSMB.cpp
@@ -189,7 +189,7 @@ bool CWINFileSMB::OpenForWrite(const CURL& url, bool bOverWrite)
 }
 
 //*********************************************************************************************
-unsigned int CWINFileSMB::Read(void *lpBuf, int64_t uiBufSize)
+int64_t CWINFileSMB::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (!m_hFile.isValid()) return 0;
   DWORD nBytesRead;

--- a/xbmc/filesystem/windows/WINFileSMB.h
+++ b/xbmc/filesystem/windows/WINFileSMB.h
@@ -44,7 +44,7 @@ public:
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
   virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual int Truncate(int64_t size);
   virtual void Close();

--- a/xbmc/filesystem/windows/WINFileSMB.h
+++ b/xbmc/filesystem/windows/WINFileSMB.h
@@ -43,7 +43,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual int64_t Read(void* lpBuf, int64_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual int Truncate(int64_t size);

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -260,68 +260,14 @@ bool CJpegIO::Open(const CStdString &texturePath, unsigned int minx, unsigned in
   m_texturePath = texturePath;
 
   XFILE::CFile file;
-  if (file.Open(m_texturePath.c_str(), READ_TRUNCATED))
-  {
-    /*
-     GetLength() will typically return values that fall into three cases:
-       1. The real filesize. This is the typical case.
-       2. Zero. This is the case for some http:// streams for example.
-       3. Some value smaller than the real filesize. This is the case for an expanding file.
-
-     In order to handle all three cases, we read the file in chunks, relying on Read()
-     returning 0 at EOF.  To minimize (re)allocation of the buffer, the chunksize in
-     cases 1 and 3 is set to one byte larger** than the value returned by GetLength().
-     The chunksize in case 2 is set to the larger of 64k and GetChunkSize().
-
-     We fill the buffer entirely before reallocation.  Thus, reallocation never occurs in case 1
-     as the buffer is larger than the file, so we hit EOF before we hit the end of buffer.
-
-     To minimize reallocation, we double the chunksize each time up to a maxchunksize of 2MB.
-     */
-    unsigned int filesize = (unsigned int)file.GetLength();
-    unsigned int chunksize = filesize ? (filesize + 1) : std::max(65536U, (unsigned int)file.GetChunkSize());
-    unsigned int maxchunksize = 2048*1024U; /* max 2MB chunksize */
-
-    unsigned int total_read = 0, free_space = 0;
-    while (true)
-    {
-      if (!free_space)
-      { // (re)alloc
-        m_inputBuffSize += chunksize;
-        unsigned char* new_buf = (unsigned char *)realloc(m_inputBuff, m_inputBuffSize);
-        if (!new_buf)
-        {
-          CLog::Log(LOGERROR, "%s unable to allocate buffer of size %u", __FUNCTION__, m_inputBuffSize);
-          free(m_inputBuff);
-          return false;
-        }
-        else
-          m_inputBuff = new_buf;
-
-        free_space = chunksize;
-        chunksize = std::min(chunksize*2, maxchunksize);
-      }
-      unsigned int read = file.Read(m_inputBuff + total_read, free_space);
-      free_space -= read;
-      total_read += read;
-      if (!read)
-        break;
-    }
-    m_inputBuffSize = total_read;
-    file.Close();
-
-    if (m_inputBuffSize == 0)
-      return false;
-  }
-  else
+  XFILE::auto_buffer buf;
+  if (file.LoadFile(texturePath, buf) == 0)
     return false;
 
-  if (!read)
-    return true;
+  m_inputBuffSize = buf.size();
+  m_inputBuff = (unsigned char*)buf.detach();
 
-  if (Read(m_inputBuff, m_inputBuffSize, minx, miny))
-    return true;
-  return false;
+  return Read(m_inputBuff, m_inputBuffSize, minx, miny);
 }
 
 bool CJpegIO::Read(unsigned char* buffer, unsigned int bufSize, unsigned int minx, unsigned int miny)

--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -56,7 +56,7 @@ namespace XBMCAddon
       DelayedCallGuard dg(languageHook);
       while (buffer.remaining() > 0)
       {
-        int bytesWritten = file->Write( buffer.curPosition(), buffer.remaining());
+        size_t bytesWritten = (size_t)file->Write(buffer.curPosition(), buffer.remaining());
         if (bytesWritten == 0)       // this could be a failure (see HDFile, and XFileUtils) or
                                      //  it could mean something else when a negative number means an error
                                      //  (see CCurlFile). There is no consistency so we can only assume we're

--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -39,7 +39,7 @@ namespace XBMCAddon
 
       while(ret.remaining() > 0)
       {
-        int bytesRead = file->Read(ret.curPosition(), ret.remaining());
+        size_t bytesRead = (size_t)file->Read(ret.curPosition(), ret.remaining());
         if (bytesRead == 0) // we consider this a failure or a EOF, can't tell which,
         {                   //  return whatever we have already.
           ret.flip();

--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -76,7 +76,7 @@ FileName TagLibVFSStream::name() const
 ByteVector TagLibVFSStream::readBlock(TagLib::ulong length)
 {
   ByteVector byteVector(static_cast<TagLib::uint>(length));
-  byteVector.resize(m_file.Read(byteVector.data(), length));
+  byteVector.resize((TagLib::ulong)m_file.Read(byteVector.data(), length));
   return byteVector;
 }
 
@@ -142,7 +142,7 @@ void TagLibVFSStream::insert(const ByteVector &data, TagLib::ulong start, TagLib
   // special case.  We're also using File::writeBlock() just for the tag.
   // That's a bit slower than using char *'s so, we're only doing it here.
   seek(readPosition);
-  int bytesRead = m_file.Read(aboutToOverwrite.data(), bufferLength);
+  TagLib::ulong bytesRead = (TagLib::ulong)m_file.Read(aboutToOverwrite.data(), bufferLength);
   readPosition += bufferLength;
 
   seek(writePosition);
@@ -159,7 +159,7 @@ void TagLibVFSStream::insert(const ByteVector &data, TagLib::ulong start, TagLib
     // Seek to the current read position and read the data that we're about
     // to overwrite.  Appropriately increment the readPosition.
     seek(readPosition);
-    bytesRead = m_file.Read(aboutToOverwrite.data(), bufferLength);
+    bytesRead = (TagLib::ulong)m_file.Read(aboutToOverwrite.data(), bufferLength);
     aboutToOverwrite.resize(bytesRead);
     readPosition += bufferLength;
 
@@ -200,7 +200,7 @@ void TagLibVFSStream::removeBlock(TagLib::ulong start, TagLib::ulong length)
   while(bytesRead != 0)
   {
     seek(readPosition);
-    bytesRead = m_file.Read(buffer.data(), bufferLength);
+    bytesRead = (TagLib::ulong)m_file.Read(buffer.data(), bufferLength);
     readPosition += bytesRead;
 
     // Check to see if we just read the last block.  We need to call clear()

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -990,7 +990,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
 
       if (tmpFile.OpenForWrite(tmpFileName, true))
       {
-        int writtenBytes=0;
+        int64_t writtenBytes = 0;
         writtenBytes = tmpFile.Write(m_httpParser->getBody(), m_httpParser->getContentLength());
         tmpFile.Close();
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -155,7 +155,7 @@ void CAirTunesServer::SetCoverArtFromBuffer(const char *buffer, unsigned int siz
   
   if (tmpFile.OpenForWrite(TMP_COVERART_PATH, true))
   {
-    int writtenBytes=0;
+    int64_t writtenBytes = 0;
     writtenBytes = tmpFile.Write(buffer, size);
     tmpFile.Close();
 

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -701,7 +701,7 @@ int CWebServer::ContentReaderCallback(void *cls, size_t pos, char *buf, int max)
     context->file->Seek(context->writePosition);
 
   // read data from the file
-  unsigned int res = context->file->Read(buf, maximum);
+  int64_t res = context->file->Read(buf, maximum);
   if (res == 0)
     return -1;
 

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -402,7 +402,7 @@ void CArchive::FillBuffer()
 {
   if (m_iMode == load && m_BufferRemain == 0)
   {
-    m_BufferRemain = m_pFile->Read(m_pBuffer, CARCHIVE_BUFFER_MAX);
+    m_BufferRemain = (size_t)m_pFile->Read(m_pBuffer, CARCHIVE_BUFFER_MAX);
     m_BufferPos = m_pBuffer;
   }
 }

--- a/xbmc/utils/POUtils.cpp
+++ b/xbmc/utils/POUtils.cpp
@@ -53,7 +53,7 @@ bool CPODocument::LoadFile(const std::string &pofilename)
   m_strBuffer.resize(m_POfilelength+1);
   m_strBuffer[0] = '\n';
 
-  unsigned int readBytes = file.Read(&m_strBuffer[1], m_POfilelength);
+  int64_t readBytes = file.Read(&m_strBuffer[1], m_POfilelength);
   file.Close();
 
   if (readBytes != m_POfilelength)

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -767,8 +767,8 @@ bool CTuxBoxUtil::GetHttpXML(CURL url,CStdString strRequestType)
   http.SetTimeout(20);
   if(http.Open(url))
   {
-    int size_read = 0;
-    int size_total = (int)http.GetLength();
+    size_t size_read = 0;
+    size_t size_total = (size_t)http.GetLength();
 
     if(size_total > 0)
     {
@@ -776,7 +776,7 @@ bool CTuxBoxUtil::GetHttpXML(CURL url,CStdString strRequestType)
       CStdString strTmp;
       strTmp.reserve(size_total);
       char buffer[16384];
-      while( (size_read = http.Read( buffer, sizeof(buffer)-1) ) > 0 )
+      while ((size_read = (size_t)http.Read(buffer, sizeof(buffer) - 1)) > 0)
       {
         buffer[size_read] = 0;
         strTmp += buffer;


### PR DESCRIPTION
Currently Read return unsigned int, Write return int, but both take int64_t as size of the buffer.
This looks pretty strange as functions unable to report number of processed bytes even if all bytes are processed.

As alternative to this PR I suggest to change type of `BufferSize` to `size_t` and return type of Read/Write to `ssize_t`, because it's not possible to access more than `SIZE_MAX` bytes in buffer.
Sizes more the `SSIZE_MAX` can be ignored as it's 2GB even on 32-bit systems.

@jmarshallnz ?
