### PR TITLE
Use File::LoadFile() instead of custom implementaions

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -284,6 +284,9 @@
 		7C8FC6EE1829A4580045153D /* DirectoryProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8FC6EC1829A4580045153D /* DirectoryProvider.cpp */; };
 		7C8FC6EF1829A4580045153D /* DirectoryProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8FC6EC1829A4580045153D /* DirectoryProvider.cpp */; };
 		7C8FC6F01829A4580045153D /* DirectoryProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8FC6EC1829A4580045153D /* DirectoryProvider.cpp */; };
+		7C908894196358A8003D0619 /* auto_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C908892196358A8003D0619 /* auto_buffer.cpp */; };
+		7C908895196358A8003D0619 /* auto_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C908892196358A8003D0619 /* auto_buffer.cpp */; };
+		7C908896196358A8003D0619 /* auto_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C908892196358A8003D0619 /* auto_buffer.cpp */; };
 		7C920CF9181669FF00DA1477 /* TextureOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C920CF7181669FF00DA1477 /* TextureOperations.cpp */; };
 		7C920CFA181669FF00DA1477 /* TextureOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C920CF7181669FF00DA1477 /* TextureOperations.cpp */; };
 		7C920CFB181669FF00DA1477 /* TextureOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C920CF7181669FF00DA1477 /* TextureOperations.cpp */; };
@@ -4206,6 +4209,8 @@
 		7C8AE853189DE47700C33786 /* CoreAudioHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CoreAudioHelpers.h; path = Sinks/osx/CoreAudioHelpers.h; sourceTree = "<group>"; };
 		7C8FC6EC1829A4580045153D /* DirectoryProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DirectoryProvider.cpp; path = xbmc/listproviders/DirectoryProvider.cpp; sourceTree = SOURCE_ROOT; };
 		7C8FC6ED1829A4580045153D /* DirectoryProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DirectoryProvider.h; path = xbmc/listproviders/DirectoryProvider.h; sourceTree = SOURCE_ROOT; };
+		7C908892196358A8003D0619 /* auto_buffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = auto_buffer.cpp; sourceTree = "<group>"; };
+		7C908893196358A8003D0619 /* auto_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = auto_buffer.h; sourceTree = "<group>"; };
 		7C920CF7181669FF00DA1477 /* TextureOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureOperations.cpp; sourceTree = "<group>"; };
 		7C920CF8181669FF00DA1477 /* TextureOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureOperations.h; sourceTree = "<group>"; };
 		7C99B6A2133D342100FC2B16 /* CircularCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CircularCache.cpp; sourceTree = "<group>"; };
@@ -9697,6 +9702,8 @@
 				E38E1E260D25F9FD00618676 /* Archive.h */,
 				F5FDF51C0E7218950005B0A6 /* AsyncFileCopy.cpp */,
 				F5FDF51B0E7218950005B0A6 /* AsyncFileCopy.h */,
+				7C908892196358A8003D0619 /* auto_buffer.cpp */,
+				7C908893196358A8003D0619 /* auto_buffer.h */,
 				F5BDB81F120203C200F0B710 /* AutoPtrHandle.cpp */,
 				F5BDB81E120203C200F0B710 /* AutoPtrHandle.h */,
 				DF52769A151BAEDA00B5B63B /* Base64.cpp */,
@@ -11850,6 +11857,7 @@
 				7CAA469019427AED00008885 /* PosixDirectory.cpp in Sources */,
 				DF033D381946612400BFC82E /* AEDeviceEnumerationOSX.cpp in Sources */,
 				7C525DF5195E2D8100BE3482 /* SaveFileStateJob.cpp in Sources */,
+				7C908894196358A8003D0619 /* auto_buffer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -13043,6 +13051,7 @@
 				7CCDACCC19275D790074CF51 /* NptAppleLogConfig.mm in Sources */,
 				7CAA469219427AED00008885 /* PosixDirectory.cpp in Sources */,
 				7C525DF7195E2D8100BE3482 /* SaveFileStateJob.cpp in Sources */,
+				7C908896196358A8003D0619 /* auto_buffer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14238,6 +14247,7 @@
 				7CCDACCB19275D790074CF51 /* NptAppleLogConfig.mm in Sources */,
 				7CAA469119427AED00008885 /* PosixDirectory.cpp in Sources */,
 				7C525DF6195E2D8100BE3482 /* SaveFileStateJob.cpp in Sources */,
+				7C908895196358A8003D0619 /* auto_buffer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -970,6 +970,7 @@
     <ClInclude Include="..\..\xbmc\settings\windows\GUIWindowSettingsScreenCalibration.h" />
     <ClInclude Include="..\..\xbmc\settings\windows\GUIWindowTestPattern.h" />
     <ClInclude Include="..\..\xbmc\utils\ActorProtocol.h" />
+    <ClInclude Include="..\..\xbmc\utils\auto_buffer.h" />
     <ClInclude Include="..\..\xbmc\utils\BooleanLogic.h" />
     <ClInclude Include="..\..\xbmc\utils\CharsetDetection.h" />
     <ClInclude Include="..\..\xbmc\utils\IRssObserver.h" />
@@ -1111,6 +1112,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\AddonsOperations.h" />
     <ClCompile Include="..\..\xbmc\ThumbLoader.cpp" />
     <ClCompile Include="..\..\xbmc\utils\ActorProtocol.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\auto_buffer.cpp" />
     <ClCompile Include="..\..\xbmc\utils\BooleanLogic.cpp" />
     <ClCompile Include="..\..\xbmc\utils\CharsetDetection.cpp" />
     <ClCompile Include="..\..\xbmc\utils\LegacyPathTranslation.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3071,6 +3071,9 @@
       <Filter>filesystem\win32</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\CompileInfo.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\auto_buffer.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -6016,6 +6019,9 @@
       <Filter>filesystem\win32</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\CompileInfo.h" />
+    <ClInclude Include="..\..\xbmc\utils\auto_buffer.h">
+      <Filter>utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -34,7 +34,7 @@
 class CNfoFile
 {
 public:
-  CNfoFile() : m_doc(NULL), m_headofdoc(NULL), m_type(ADDON::ADDON_UNKNOWN) {}
+  CNfoFile() : m_headPos(0), m_type(ADDON::ADDON_UNKNOWN) {}
   virtual ~CNfoFile() { Close(); }
 
   enum NFOResult
@@ -51,13 +51,11 @@ public:
     bool GetDetails(T& details,const char* document=NULL, bool prioritise=false)
   {
     CXBMCTinyXML doc;
-    CStdString strDoc;
     if (document)
-      strDoc = document;
+      doc.Parse(document, TIXML_ENCODING_UNKNOWN);
     else
-      strDoc = m_headofdoc;
+      doc.Parse(m_doc.substr(m_headPos), TIXML_ENCODING_UNKNOWN);
 
-    doc.Parse(strDoc, TIXML_ENCODING_UNKNOWN);
     return details.Load(doc.RootElement(), true, prioritise);
   }
 
@@ -67,8 +65,8 @@ public:
   const CScraperUrl &ScraperUrl() const { return m_scurl; }
 
 private:
-  char* m_doc;
-  char* m_headofdoc;
+  std::string m_doc;
+  size_t m_headPos;
   ADDON::ScraperPtr m_info;
   ADDON::TYPE m_type;
   CScraperUrl m_scurl;

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -413,15 +413,13 @@ void CGUIDialogAddonInfo::OnJobComplete(unsigned int jobID, bool success,
   else
   {
     CFile file;
-    if (file.Open("special://temp/"+
-      URIUtils::GetFileName(((CFileOperationJob*)job)->GetItems()[0]->GetPath())))
+    XFILE::auto_buffer buf;
+    if (file.LoadFile("special://temp/" +
+      URIUtils::GetFileName(((CFileOperationJob*)job)->GetItems()[0]->GetPath()), buf) > 0)
     {
-      char* temp = new char[(size_t)file.GetLength()+1];
-      file.Read(temp,file.GetLength());
-      temp[file.GetLength()] = '\0';
-      m_item->SetProperty("Addon.Changelog",temp);
-      pDlgInfo->SetText(temp);
-      delete[] temp;
+      std::string str(buf.get(), buf.length());
+      m_item->SetProperty("Addon.Changelog", str);
+      pDlgInfo->SetText(str);
     }
   }
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, WINDOW_DIALOG_TEXT_VIEWER, 0, GUI_MSG_UPDATE);

--- a/xbmc/cores/paplayer/ModplugCodec.cpp
+++ b/xbmc/cores/paplayer/ModplugCodec.cpp
@@ -53,17 +53,14 @@ bool ModplugCodec::Init(const CStdString &strFile, unsigned int filecache)
 
   // Read our file to memory so it can be passed to ModPlug_Load()
   CFile file;
-  if (!file.Open(strFile))
+  XFILE::auto_buffer buf;
+  if (file.LoadFile(strFile, buf) <= 0)
   {
     CLog::Log(LOGERROR,"ModplugCodec: error opening file %s!",strFile.c_str());
     return false;
   }
-  char *data = new char[(unsigned int)file.GetLength()];
-  file.Read(data,file.GetLength());
-
   // Now load the module
-  m_module = m_dll.ModPlug_Load(data,(int)file.GetLength());
-  delete[] data;
+  m_module = m_dll.ModPlug_Load(buf.get(),buf.size());
   if (!m_module)
   {
     CLog::Log(LOGERROR,"ModplugCodec: error loading module file %s!",strFile.c_str());

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -880,17 +880,17 @@ std::string CFile::GetContentCharset(void)
   return m_pFile->GetContentCharset();
 }
 
-unsigned int CFile::LoadFile(const std::string &filename, auto_buffer& outputBuffer)
+ssize_t CFile::LoadFile(const std::string &filename, auto_buffer& outputBuffer)
 {
   const CURL pathToUrl(filename);
   return LoadFile(pathToUrl, outputBuffer);
 }
 
-unsigned int CFile::LoadFile(const CURL& file, auto_buffer& outputBuffer)
+ssize_t CFile::LoadFile(const CURL& file, auto_buffer& outputBuffer)
 {
-  static const unsigned int max_file_size = 0x7FFFFFFF;
-  static const unsigned int min_chunk_size = 64 * 1024U;
-  static const unsigned int max_chunk_size = 2048 * 1024U;
+  static const size_t max_file_size = 0x7FFFFFFF;
+  static const size_t min_chunk_size = 64 * 1024U;
+  static const size_t max_chunk_size = 2048 * 1024U;
 
   outputBuffer.clear();
 
@@ -916,25 +916,30 @@ unsigned int CFile::LoadFile(const CURL& file, auto_buffer& outputBuffer)
   than max_chunk_size.
   */
   int64_t filesize = GetLength();
-  if (filesize > max_file_size)
+  if (filesize > (int64_t)max_file_size)
     return 0; /* file is too large for this function */
 
-  unsigned int chunksize = (filesize > 0) ? (unsigned int)(filesize + 1) : GetChunkSize(GetChunkSize(), min_chunk_size);
-  unsigned int total_read = 0;
+  size_t chunksize = (filesize > 0) ? (size_t)(filesize + 1) : (size_t) GetChunkSize(GetChunkSize(), min_chunk_size);
+  size_t total_read = 0;
   while (true)
   {
     if (total_read == outputBuffer.size())
     { // (re)alloc
-      if (outputBuffer.size() >= max_file_size)
+      if (outputBuffer.size() + chunksize > max_file_size)
       {
         outputBuffer.clear();
-        return 0;
+        return -1;
       }
       outputBuffer.resize(outputBuffer.size() + chunksize);
       if (chunksize < max_chunk_size)
         chunksize *= 2;
     }
-    unsigned int read = Read(outputBuffer.get() + total_read, outputBuffer.size() - total_read);
+    ssize_t read = Read(outputBuffer.get() + total_read, outputBuffer.size() - total_read);
+    if (read < 0)
+    {
+      outputBuffer.clear();
+      return -1;
+    }
     total_read += read;
     if (!read)
       break;

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -69,65 +69,6 @@ CFile::~CFile()
 
 //*********************************************************************************************
 
-auto_buffer::auto_buffer(size_t size) : p(NULL), s(0)
-{
-  if (!size)
-    return;
-
-  p = malloc(size);
-  if (!p)
-    throw std::bad_alloc();
-  s = size;
-}
-
-auto_buffer::~auto_buffer()
-{
-  clear();
-}
-
-auto_buffer& auto_buffer::allocate(size_t size)
-{
-  clear();
-  return resize(size);
-}
-
-auto_buffer& auto_buffer::resize(size_t newSize)
-{
-  void* newPtr = realloc(p, newSize);
-  if (!newPtr && newSize)
-    throw std::bad_alloc();
-  p = newPtr;
-  s = newSize;
-  return *this;
-}
-
-auto_buffer& auto_buffer::clear(void)
-{
-  free(p);
-  p = NULL;
-  s = 0;
-  return *this;
-}
-
-auto_buffer& auto_buffer::attach(void* pointer, size_t size)
-{
-  clear();
-  if ((pointer && size) || (!pointer && !size))
-  {
-    p = pointer;
-    s = size;
-  }
-  return *this;
-}
-
-void* auto_buffer::detach(void)
-{
-  void* returnPtr = p;
-  p = NULL;
-  s = 0;
-  return returnPtr;
-}
-
 bool CFile::Copy(const CStdString& strFileName, const CStdString& strDest, XFILE::IFileCallback* pCallback, void* pContext)
 {
   const CURL pathToUrl(strFileName);

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <iostream>
+#include "utils/auto_buffer.h"
 #include "utils/StdString.h"
 #include "IFileTypes.h"
 #include "PlatformDefs.h"
@@ -40,6 +41,7 @@ class CURL;
 namespace XFILE
 {
 
+using ::XUTILS::auto_buffer;
 class IFile;
 
 class IFileCallback
@@ -68,33 +70,6 @@ public:
 #define READ_MULTI_STREAM 0x20
 
 class CFileStreamBuffer;
-
-class auto_buffer
-{
-public:
-  auto_buffer(void) : p(NULL), s(0)
-  { }
-  explicit auto_buffer(size_t size);
-  ~auto_buffer();
-
-  auto_buffer& allocate(size_t size);
-  auto_buffer& resize(size_t newSize);
-  auto_buffer& clear(void);
-
-  inline char* get(void) const { return static_cast<char*>(p); }
-  inline size_t size(void) const { return s; }
-  inline size_t length(void) const { return s; }
-
-  auto_buffer& attach(void* pointer, size_t size);
-  void* detach(void);
-
-private:
-  auto_buffer(const auto_buffer& other); // disallow copy constructor
-  auto_buffer& operator=(const auto_buffer& other); // disallow assignment
-
-  void* p;
-  size_t s;
-};
 
 class CFile
 {

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -79,7 +79,7 @@ public:
 
   bool Open(const CURL& file, const unsigned int flags = 0);
   bool OpenForWrite(const CURL& file, bool bOverWrite = false);
-  unsigned int LoadFile(const CURL &file, auto_buffer& outputBuffer);
+  ssize_t LoadFile(const CURL &file, auto_buffer& outputBuffer);
 
   bool Open(const CStdString& strFileName, const unsigned int flags = 0);
   bool OpenForWrite(const CStdString& strFileName, bool bOverWrite = false);
@@ -95,7 +95,7 @@ public:
   int GetChunkSize();
   std::string GetContentMimeType(void);
   std::string GetContentCharset(void);
-  unsigned int LoadFile(const std::string &filename, auto_buffer& outputBuffer);
+  ssize_t LoadFile(const std::string &filename, auto_buffer& outputBuffer);
 
 
   // will return a size, that is aligned to chunk size

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -26,7 +26,14 @@
 #include "threads/CriticalSection.h"
 
 #include <libssh/libssh.h>
+#ifdef TARGET_WINDOWS
+#define ssize_t SSIZE_T
 #include <libssh/sftp.h>
+#undef ssize_t
+#include "PlatformDefs.h"
+#else  // !TARGET_WINDOWS
+#include <libssh/sftp.h>
+#endif // !TARGET_WINDOWS
 #include <string>
 #include <map>
 #include <boost/shared_ptr.hpp>

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -434,33 +434,16 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       // load our window
-      XFILE::CFile file;
+      CXBMCTinyXML xmlDoc;
+
       std::string strPathLower = strPath;
       StringUtils::ToLower(strPathLower);
-      if (!file.Open(strPath) && !file.Open(strPathLower) && !file.Open(strLowerPath))
+      if (xmlDoc.LoadFile(strPath) <= 0 && xmlDoc.LoadFile(strPathLower) <= 0 && xmlDoc.LoadFile(strLowerPath) <= 0)
       {
         // fail - can't load the file
         CLog::Log(LOGERROR, "%s: Unable to load skin file %s", __FUNCTION__, strPath.c_str());
         return false;
       }
-
-      CStdString xml;
-      char *buffer = new char[(unsigned int)file.GetLength()+1];
-      if(buffer == NULL)
-        return false;
-      int size = file.Read(buffer, file.GetLength());
-      if (size > 0)
-      {
-        buffer[size] = 0;
-        xml = buffer;
-      }
-      delete[] buffer;
-
-      CXBMCTinyXML xmlDoc;
-      xmlDoc.Parse(xml);
-
-      if (xmlDoc.Error())
-        return false;
 
       return interceptor->Load(xmlDoc.RootElement());
     }

--- a/xbmc/music/karaoke/karaokelyricscdg.cpp
+++ b/xbmc/music/karaoke/karaokelyricscdg.cpp
@@ -542,34 +542,21 @@ bool CKaraokeLyricsCDG::Load()
 
   m_cdgStream.clear();
 
-  if ( !file.Open( m_cdgFile ) )
-    return false;
-
-  unsigned int cdgSize = (unsigned int) file.GetLength();
-
-  if ( !cdgSize )
+  XFILE::auto_buffer buf;
+  if (file.LoadFile(m_cdgFile, buf) <= 0)
   {
-	CLog::Log( LOGERROR, "CDG loader: CDG file %s has zero length", m_cdgFile.c_str() );
+    CLog::Log(LOGERROR, "CDG loader: can't load CDG file \"%s\"", m_cdgFile.c_str());
     return false;
   }
-
-  // Read the file into memory array
-  std::vector<BYTE> cdgdata( cdgSize );
-
-  file.Seek( 0, SEEK_SET );
-
-  // Read the whole file
-  if ( file.Read( &cdgdata[0], cdgSize) != cdgSize )
-    return false; // disk error?
 
   file.Close();
 
   // Parse the CD+G stream
   int buggy_commands = 0;
   
-  for ( unsigned int offset = 0; offset < cdgdata.size(); offset += sizeof( SubCode ) )
+  for (unsigned int offset = 0; offset < buf.size(); offset += sizeof(SubCode))
   {
-	  SubCode * sc = (SubCode *) (&cdgdata[0] + offset);
+    SubCode * sc = (SubCode *)(buf.get() + offset);
 
 	  if ( ( sc->command & CDG_MASK) == CDG_COMMAND )
 	  {

--- a/xbmc/music/karaoke/karaokelyricstextkar.cpp
+++ b/xbmc/music/karaoke/karaokelyricstextkar.cpp
@@ -136,14 +136,12 @@ class MidiTimestamp
 CKaraokeLyricsTextKAR::CKaraokeLyricsTextKAR( const CStdString & midiFile )
   : CKaraokeLyricsText()
 {
-  m_midiData = 0;
   m_midiFile = midiFile;
 }
 
 
 CKaraokeLyricsTextKAR::~CKaraokeLyricsTextKAR()
 {
-  delete[] m_midiData;
 }
 
 
@@ -156,20 +154,7 @@ bool CKaraokeLyricsTextKAR::Load()
   // Clear the lyrics array
   clearLyrics();
 
-  if ( !file.Open( m_midiFile ) )
-    return false;
-
-  m_midiSize = (unsigned int) file.GetLength();
-
-  if ( !m_midiSize )
-    return false;  // shouldn't happen, but
-
-  file.Seek( 0, SEEK_SET );
-
-  m_midiData = new unsigned char [ m_midiSize ];
-
-  // Read the whole file
-  if ( !m_midiData || file.Read( m_midiData, m_midiSize) != m_midiSize )
+  if (file.LoadFile(m_midiFile, m_midiData) <= 0)
     return false;
 
   file.Close();
@@ -185,8 +170,7 @@ bool CKaraokeLyricsTextKAR::Load()
     succeed = false;
   }
 
-  delete [] m_midiData;
-  m_midiData = 0;
+  m_midiData.clear();
   return succeed;
 }
 
@@ -509,33 +493,31 @@ void CKaraokeLyricsTextKAR::parseMIDI()
 
 unsigned char CKaraokeLyricsTextKAR::readByte()
 {
-  if ( m_midiOffset >= m_midiSize )
+  if (m_midiOffset >= m_midiData.size())
     throw( "Cannot read byte: premature end of file" );
 
-  const unsigned char * p = m_midiData + m_midiOffset;
-  m_midiOffset += 1;
-  return p[0];
+  return (unsigned char) m_midiData.get()[m_midiOffset++];
 }
 
 unsigned short CKaraokeLyricsTextKAR::readWord()
 {
-  if ( m_midiOffset + 1 >= m_midiSize )
+  if (m_midiOffset + 1 >= m_midiData.size())
     throw( "Cannot read word: premature end of file" );
 
-  const unsigned char * p = m_midiData + m_midiOffset;
-  m_midiOffset += 2;
-  return p[0] << 8 | p[1];
+  return ((unsigned int)((unsigned char)m_midiData.get()[m_midiOffset++])) << 8 |
+         ((unsigned int)((unsigned char)m_midiData.get()[m_midiOffset++]));
 }
 
 
 unsigned int CKaraokeLyricsTextKAR::readDword()
 {
-  if ( m_midiOffset + 3 >= m_midiSize )
+  if (m_midiOffset + 3 >= m_midiData.size())
     throw( "Cannot read dword: premature end of file" );
 
-  const unsigned char * p = m_midiData + m_midiOffset;
-  m_midiOffset += 4;
-  return p[0] << 24 | p[1] << 16 | p[2] << 8 | p[3];
+  return ((unsigned int)((unsigned char)m_midiData.get()[m_midiOffset++])) << 24 |
+         ((unsigned int)((unsigned char)m_midiData.get()[m_midiOffset++])) << 16 |
+         ((unsigned int)((unsigned char)m_midiData.get()[m_midiOffset++])) << 8 |
+         ((unsigned int)((unsigned char)m_midiData.get()[m_midiOffset++]));
 }
 
 int CKaraokeLyricsTextKAR::readVarLen()

--- a/xbmc/music/karaoke/karaokelyricstextkar.h
+++ b/xbmc/music/karaoke/karaokelyricstextkar.h
@@ -24,6 +24,7 @@
 // C++ Interface: karaokelyricstextkar
 
 #include "karaokelyricstext.h"
+#include "utils/auto_buffer.h"
 
 
 //! This class loads MIDI/KAR format lyrics
@@ -54,9 +55,8 @@ class CKaraokeLyricsTextKAR : public CKaraokeLyricsText
     CStdString     m_midiFile;
 
     // MIDI in-memory information
-    unsigned char *  m_midiData;
-    unsigned int  m_midiOffset;
-    unsigned int  m_midiSize;
+    XUTILS::auto_buffer m_midiData;
+    size_t        m_midiOffset;
     bool          m_reportedInvalidVarField;
 };
 

--- a/xbmc/music/karaoke/karaokelyricstextlrc.cpp
+++ b/xbmc/music/karaoke/karaokelyricstextlrc.cpp
@@ -63,25 +63,12 @@ bool CKaraokeLyricsTextLRC::Load()
   // Clear the lyrics array
   clearLyrics();
 
-  if ( !file.Open( m_lyricsFile ) )
-    return false;
-
-  unsigned int lyricSize = (unsigned int) file.GetLength();
-
-  if ( !lyricSize )
+  XFILE::auto_buffer buf;
+  if (file.LoadFile(m_lyricsFile, buf) <= 0)
   {
-    CLog::Log( LOGERROR, "LRC lyric loader: lyric file %s has zero length", m_lyricsFile.c_str() );
+    CLog::Log(LOGERROR, "%s: can't load \"%s\" file", __FUNCTION__, m_lyricsFile.c_str());
     return false;
   }
-
-  // Read the file into memory array
-  std::vector<char> lyricData( lyricSize );
-
-  file.Seek( 0, SEEK_SET );
-
-  // Read the whole file
-  if ( file.Read( &lyricData[0], lyricSize) != lyricSize )
-    return false; // disk error?
 
   file.Close();
 
@@ -93,23 +80,23 @@ bool CKaraokeLyricsTextLRC::Load()
   CStdString songfilename = getSongFile();
 
   // Skip windoze UTF8 file prefix, if any, and reject UTF16 files
-  if ( lyricSize > 3 )
+  if (buf.size() > 3)
   {
-    if ( (unsigned char)lyricData[0] == 0xFF && (unsigned char)lyricData[1] == 0xFE )
+    if ((unsigned char)buf.get()[0] == 0xFF && (unsigned char)buf.get()[1] == 0xFE)
     {
       CLog::Log( LOGERROR, "LRC lyric loader: lyrics file is in UTF16 encoding, must be in UTF8" );
       return false;
     }
 
     // UTF8 prefix added by some windoze apps
-    if ( (unsigned char)lyricData[0] == 0xEF && (unsigned char)lyricData[1] == 0xBB && (unsigned char)lyricData[2] == 0xBF )
+    if ((unsigned char)buf.get()[0] == 0xEF && (unsigned char)buf.get()[1] == 0xBB && (unsigned char)buf.get()[2] == 0xBF)
       offset = 3;
   }
 
-  if (checkMultiTime(&lyricData[offset], lyricSize - offset))
-    return ParserMultiTime(&lyricData[offset], lyricSize - offset, timing_correction);
+  if (checkMultiTime(buf.get() + offset, buf.size() - offset))
+    return ParserMultiTime(buf.get() + offset, buf.size() - offset, timing_correction);
   else
-    return ParserNormal(&lyricData[offset], lyricSize - offset, timing_correction);
+    return ParserNormal(buf.get() + offset, buf.size() - offset, timing_correction);
 }
 
 bool CKaraokeLyricsTextLRC::checkMultiTime(char *lyricData, unsigned int lyricSize)

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -152,15 +152,3 @@ bool CFileUtils::RemoteAccessAllowed(const CStdString &strPath)
   }
   return false;
 }
-
-
-unsigned int CFileUtils::LoadFile(const std::string &filename, void* &outputBuffer)
-{
-  XFILE::auto_buffer buffer;
-  XFILE::CFile file;
-
-  const unsigned int total_read = file.LoadFile(filename, buffer);
-  outputBuffer = buffer.detach();
-
-  return total_read;
-}

--- a/xbmc/utils/FileUtils.h
+++ b/xbmc/utils/FileUtils.h
@@ -28,5 +28,4 @@ public:
   static bool DeleteItem(const CStdString &strPath, bool force=false);
   static bool RenameFile(const CStdString &strFile);
   static bool RemoteAccessAllowed(const CStdString &strPath);
-  static unsigned int LoadFile(const std::string &filename, void* &outputBuffer);
 };

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -3,6 +3,7 @@ SRCS += AliasShortcutUtils.cpp
 SRCS += Archive.cpp
 SRCS += AsyncFileCopy.cpp
 SRCS += AutoPtrHandle.cpp
+SRCS += auto_buffer.cpp
 SRCS += Base64.cpp
 SRCS += BitstreamConverter.cpp
 SRCS += BitstreamStats.cpp

--- a/xbmc/utils/POUtils.cpp
+++ b/xbmc/utils/POUtils.cpp
@@ -37,31 +37,16 @@ CPODocument::~CPODocument() {}
 bool CPODocument::LoadFile(const std::string &pofilename)
 {
   XFILE::CFile file;
-  if (!file.Open(pofilename))
-    return false;
-
-  int64_t fileLength = file.GetLength();
-  if (fileLength < 18) // at least a size of a minimalistic header
+  XFILE::auto_buffer buf;
+  if (file.LoadFile(pofilename, buf) < 18) // at least a size of a minimalistic header
   {
-    file.Close();
-    CLog::Log(LOGERROR, "POParser: non valid length found for string file: %s", pofilename.c_str());
+    CLog::Log(LOGERROR, "%s: can't load file \"%s\" or file is too small", __FUNCTION__,  pofilename.c_str());
     return false;
   }
-
-  m_POfilelength = static_cast<size_t> (fileLength);
-
-  m_strBuffer.resize(m_POfilelength+1);
-  m_strBuffer[0] = '\n';
-
-  unsigned int readBytes = file.Read(&m_strBuffer[1], m_POfilelength);
-  file.Close();
-
-  if (readBytes != m_POfilelength)
-  {
-    CLog::Log(LOGERROR, "POParser: actual read data differs from file size, for string file: %s",
-              pofilename.c_str());
-    return false;
-  }
+  
+  m_strBuffer = '\n';
+  m_strBuffer.append(buf.get(), buf.size());
+  buf.clear();
 
   ConvertLineEnds(pofilename);
 

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -168,7 +168,7 @@ void CRssReader::Process()
         {
           CFile file;
           auto_buffer buffer;
-          if (file.LoadFile(strUrl, buffer))
+          if (file.LoadFile(strUrl, buffer) > 0)
           {
             strXML.assign(buffer.get(), buffer.length());
             break;

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -210,7 +210,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
     {
       XFILE::CFile file;
       XFILE::auto_buffer buffer;
-      if (file.LoadFile(strCachePath, buffer))
+      if (file.LoadFile(strCachePath, buffer) > 0)
       {
         strHTML.assign(buffer.get(), buffer.length());
         return true;

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -69,7 +69,7 @@ bool CXBMCTinyXML::LoadFile(const std::string& _filename, TiXmlEncoding encoding
   XFILE::CFile file;
   XFILE::auto_buffer buffer;
 
-  if (!file.LoadFile(value, buffer))
+  if (file.LoadFile(value, buffer) <= 0)
   {
     SetError(TIXML_ERROR_OPENING_FILE, NULL, NULL, TIXML_ENCODING_UNKNOWN);
     return false;

--- a/xbmc/utils/auto_buffer.cpp
+++ b/xbmc/utils/auto_buffer.cpp
@@ -1,0 +1,85 @@
+/*
+*      Copyright (C) 2013-2014 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "auto_buffer.h"
+#include <new> // for std::bad_alloc
+#include <stdlib.h> // for malloc(), realloc() and free()
+
+using namespace XUTILS;
+
+auto_buffer::auto_buffer(size_t size) : p(NULL), s(0)
+{
+  if (!size)
+    return;
+
+  p = malloc(size);
+  if (!p)
+    throw std::bad_alloc();
+  s = size;
+}
+
+auto_buffer::~auto_buffer()
+{
+  clear();
+}
+
+auto_buffer& auto_buffer::allocate(size_t size)
+{
+  clear();
+  return resize(size);
+}
+
+auto_buffer& auto_buffer::resize(size_t newSize)
+{
+  void* newPtr = realloc(p, newSize);
+  if (!newPtr && newSize)
+    throw std::bad_alloc();
+  p = newPtr;
+  s = newSize;
+  return *this;
+}
+
+auto_buffer& auto_buffer::clear(void)
+{
+  free(p);
+  p = NULL;
+  s = 0;
+  return *this;
+}
+
+auto_buffer& auto_buffer::attach(void* pointer, size_t size)
+{
+  clear();
+  if ((pointer && size) || (!pointer && !size))
+  {
+    p = pointer;
+    s = size;
+  }
+  return *this;
+}
+
+void* auto_buffer::detach(void)
+{
+  void* returnPtr = p;
+  p = NULL;
+  s = 0;
+  return returnPtr;
+}
+

--- a/xbmc/utils/auto_buffer.cpp
+++ b/xbmc/utils/auto_buffer.cpp
@@ -24,12 +24,12 @@
 
 using namespace XUTILS;
 
-auto_buffer::auto_buffer(size_t size) : p(NULL), s(0)
+auto_buffer::auto_buffer(size_t size) : p(0), s(0)
 {
   if (!size)
     return;
 
-  p = malloc(size);
+  p = malloc(size); // "malloc()" instead of "new" allow to use "realloc()"
   if (!p)
     throw std::bad_alloc();
   s = size;
@@ -37,19 +37,29 @@ auto_buffer::auto_buffer(size_t size) : p(NULL), s(0)
 
 auto_buffer::~auto_buffer()
 {
-  clear();
+  free(p);
 }
 
 auto_buffer& auto_buffer::allocate(size_t size)
 {
   clear();
-  return resize(size);
+  if (size)
+  {
+    p = malloc(size);
+    if (!p)
+      throw std::bad_alloc();
+    s = size;
+  }
+  return *this;
 }
 
 auto_buffer& auto_buffer::resize(size_t newSize)
 {
+  if (!newSize)
+    return clear();
+
   void* newPtr = realloc(p, newSize);
-  if (!newPtr && newSize)
+  if (!newPtr)
     throw std::bad_alloc();
   p = newPtr;
   s = newSize;
@@ -59,7 +69,7 @@ auto_buffer& auto_buffer::resize(size_t newSize)
 auto_buffer& auto_buffer::clear(void)
 {
   free(p);
-  p = NULL;
+  p = 0;
   s = 0;
   return *this;
 }
@@ -78,7 +88,7 @@ auto_buffer& auto_buffer::attach(void* pointer, size_t size)
 void* auto_buffer::detach(void)
 {
   void* returnPtr = p;
-  p = NULL;
+  p = 0;
   s = 0;
   return returnPtr;
 }

--- a/xbmc/utils/auto_buffer.h
+++ b/xbmc/utils/auto_buffer.h
@@ -27,20 +27,72 @@ namespace XUTILS
   class auto_buffer
   {
   public:
-    auto_buffer(void) : p(NULL), s(0)
+    /**
+     * Create buffer with zero size
+     */
+    auto_buffer(void) : p(0), s(0)
     {}
+    /**
+     * Create buffer with specified size
+     * @param size of created buffer
+     */
     explicit auto_buffer(size_t size);
     ~auto_buffer();
 
+    /**
+     * Allocate specified size for buffer, discarding current buffer content
+     * @param size of buffer to allocate
+     * @return reference to itself
+     */
     auto_buffer& allocate(size_t size);
+    /**
+     * Resize current buffer to new size. Buffer will be extended or truncated at the end.
+     * @param newSize of buffer
+     * @return reference to itself
+     */
     auto_buffer& resize(size_t newSize);
+    /**
+     * Reset buffer to zero size
+     * @return reference to itself
+     */
     auto_buffer& clear(void);
 
-    inline char* get(void) const { return static_cast<char*>(p); }
+    /**
+     * Get pointer to buffer content
+     * @return pointer to buffer content or NULL if buffer is zero size
+     */
+    inline char* get(void) { return static_cast<char*>(p); }
+    /**
+     * Get constant pointer to buffer content
+     * @return constant pointer to buffer content
+     */
+    inline const char* get(void) const { return static_cast<char*>(p); }
+    /**
+     * Get size of the buffer
+     * @return size of the buffer
+     */
     inline size_t size(void) const { return s; }
+    /**
+     * Get size of the buffer
+     * @return size of the buffer
+     */
     inline size_t length(void) const { return s; }
 
+    /**
+     * Attach malloc'ed pointer to the buffer, discarding current buffer content
+     * Pointer must be acquired by malloc() or realloc().
+     * Pointer will be automatically freed on destroy of the buffer.
+     * @param pointer to attach
+     * @param size of new memory region pointed by pointer
+     * @return reference to itself
+     */
     auto_buffer& attach(void* pointer, size_t size);
+    /**
+     * Detach current buffer content from the buffer, reset buffer to zero size
+     * Caller is responsible to free memory by calling free() for returned pointer
+     * when pointer in not needed anymore
+     * @return detached from buffer pointer to content
+     */
     void* detach(void);
 
   private:

--- a/xbmc/utils/auto_buffer.h
+++ b/xbmc/utils/auto_buffer.h
@@ -1,0 +1,53 @@
+#pragma once
+/*
+*      Copyright (C) 2013-2014 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <stddef.h> // for size_t
+
+namespace XUTILS
+{
+
+  class auto_buffer
+  {
+  public:
+    auto_buffer(void) : p(NULL), s(0)
+    {}
+    explicit auto_buffer(size_t size);
+    ~auto_buffer();
+
+    auto_buffer& allocate(size_t size);
+    auto_buffer& resize(size_t newSize);
+    auto_buffer& clear(void);
+
+    inline char* get(void) const { return static_cast<char*>(p); }
+    inline size_t size(void) const { return s; }
+    inline size_t length(void) const { return s; }
+
+    auto_buffer& attach(void* pointer, size_t size);
+    void* detach(void);
+
+  private:
+    auto_buffer(const auto_buffer& other); // disallow copy constructor
+    auto_buffer& operator=(const auto_buffer& other); // disallow assignment
+
+    void* p;
+    size_t s;
+  };
+}

--- a/xbmc/win32/PlatformDefs.h
+++ b/xbmc/win32/PlatformDefs.h
@@ -33,7 +33,13 @@ typedef __int64       fpos64_t;
 typedef __int64       __off64_t;
 typedef long          __off_t;
 
-#define ssize_t int
+#if !defined(_SSIZE_T_DEFINED) && !defined(HAVE_SSIZE_T)
+typedef intptr_t      ssize_t;
+#define _SSIZE_T_DEFINED
+#endif // !_SSIZE_T_DEFINED
+#ifndef SSIZE_MAX
+#define SSIZE_MAX INTPTR_MAX
+#endif // !SSIZE_MAX
 
 #define snprintf _snprintf
 #define ftello64 _ftelli64


### PR DESCRIPTION
This PR replace many file loading implementations with call of unified File::LoadFile().
Some of the replaced code parts are incorrect or have unchecked function calls.
Each file in the individual commit for easy revert.
