### PR TITLE
VFS: remove inconsistency for Read/Write return type and parameter type, many added checks

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -28,6 +28,10 @@
 #include <stdarg.h>
 
 #ifdef _WIN32                   // windows
+#ifndef _SSIZE_T_DEFINED
+typedef intptr_t      ssize_t;
+#define _SSIZE_T_DEFINED
+#endif // !_SSIZE_T_DEFINED
 #include "dlfcn-win32.h"
 #define ADDON_DLL               "\\library.xbmc.addon\\libXBMC_addon" ADDON_HELPER_EXT
 #define ADDON_HELPER_EXT        ".dll"
@@ -186,7 +190,7 @@ namespace ADDON
         dlsym(m_libXBMC_addon, "XBMC_open_file_for_write");
       if (XBMC_open_file_for_write == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      XBMC_read_file = (unsigned int (*)(void* HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize))
+      XBMC_read_file = (ssize_t (*)(void* HANDLE, void* CB, void* file, void* lpBuf, size_t uiBufSize))
         dlsym(m_libXBMC_addon, "XBMC_read_file");
       if (XBMC_read_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
@@ -375,9 +379,11 @@ namespace ADDON
      * @param file The file handle to read from.
      * @param lpBuf The buffer to store the data in.
      * @param uiBufSize The size of the buffer.
-     * @return Number of bytes read.
+     * @return number of successfully read bytes if any bytes were read and stored in
+     *         buffer, zero if no bytes are available to read (end of file was reached)
+     *         or undetectable error occur, -1 in case of any explicit error
      */
-    unsigned int ReadFile(void* file, void* lpBuf, int64_t uiBufSize)
+    ssize_t ReadFile(void* file, void* lpBuf, size_t uiBufSize)
     {
       return XBMC_read_file(m_Handle, m_Callbacks, file, lpBuf, uiBufSize);
     }
@@ -562,7 +568,7 @@ namespace ADDON
     void (*XBMC_free_string)(void *HANDLE, void* CB, char* str);
     void* (*XBMC_open_file)(void *HANDLE, void* CB, const char* strFileName, unsigned int flags);
     void* (*XBMC_open_file_for_write)(void *HANDLE, void* CB, const char* strFileName, bool bOverWrite);
-    unsigned int (*XBMC_read_file)(void *HANDLE, void* CB, void* file, void* lpBuf, int64_t uiBufSize);
+    ssize_t (*XBMC_read_file)(void *HANDLE, void* CB, void* file, void* lpBuf, size_t uiBufSize);
     bool (*XBMC_read_file_string)(void *HANDLE, void* CB, void* file, char *szLine, int iLineLength);
     int (*XBMC_write_file)(void *HANDLE, void* CB, void* file, const void* lpBuf, int64_t uiBufSize);
     void (*XBMC_flush_file)(void *HANDLE, void* CB, void* file);

--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -198,7 +198,7 @@ namespace ADDON
         dlsym(m_libXBMC_addon, "XBMC_read_file_string");
       if (XBMC_read_file_string == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      XBMC_write_file = (int (*)(void* HANDLE, void* CB, void* file, const void* lpBuf, int64_t uiBufSize))
+      XBMC_write_file = (ssize_t (*)(void* HANDLE, void* CB, void* file, const void* lpBuf, size_t uiBufSize))
         dlsym(m_libXBMC_addon, "XBMC_write_file");
       if (XBMC_write_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
@@ -405,9 +405,11 @@ namespace ADDON
      * @param file The file handle to write to.
      * @param lpBuf The data to write.
      * @param uiBufSize Size of the data to write.
-     * @return The number of bytes read.
+     * @return number of successfully written bytes if any bytes were written,
+     *         zero if no bytes were written and no detectable error occur,
+     *         -1 in case of any explicit error
      */
-    int WriteFile(void* file, const void* lpBuf, int64_t uiBufSize)
+    ssize_t WriteFile(void* file, const void* lpBuf, size_t uiBufSize)
     {
       return XBMC_write_file(m_Handle, m_Callbacks, file, lpBuf, uiBufSize);
     }
@@ -570,7 +572,7 @@ namespace ADDON
     void* (*XBMC_open_file_for_write)(void *HANDLE, void* CB, const char* strFileName, bool bOverWrite);
     ssize_t (*XBMC_read_file)(void *HANDLE, void* CB, void* file, void* lpBuf, size_t uiBufSize);
     bool (*XBMC_read_file_string)(void *HANDLE, void* CB, void* file, char *szLine, int iLineLength);
-    int (*XBMC_write_file)(void *HANDLE, void* CB, void* file, const void* lpBuf, int64_t uiBufSize);
+    ssize_t(*XBMC_write_file)(void *HANDLE, void* CB, void* file, const void* lpBuf, size_t uiBufSize);
     void (*XBMC_flush_file)(void *HANDLE, void* CB, void* file);
     int64_t (*XBMC_seek_file)(void *HANDLE, void* CB, void* file, int64_t iFilePosition, int iWhence);
     int (*XBMC_truncate_file)(void *HANDLE, void* CB, void* file, int64_t iSize);

--- a/lib/UnrarXLib/file.cpp
+++ b/lib/UnrarXLib/file.cpp
@@ -334,15 +334,12 @@ void File::Write(const void *Data,int Size)
     if (HandleType!=FILE_HANDLENORMAL)
     {
       const int MaxSize=0x4000;
-      for (int I=0;I<Size;I+=MaxSize)
-        //if (!(success=WriteFile(hFile,(byte *)Data+I,Min(Size-I,MaxSize),&Written,NULL) != FALSE))
-        m_File.Write((byte*)Data+I,Min(Size-I,MaxSize));
-        //  break;
+      for (int I = 0; I < Size && success; I += MaxSize)
+        success = m_File.Write((byte*)Data + I, Min(Size - I, MaxSize)) == Min(Size - I, MaxSize);
     }
     else
     {
-      //success=WriteFile(hFile,Data,Size,&Written,NULL) != FALSE;
-      m_File.Write(Data,Size);
+      success = m_File.Write(Data, Size) == Size;
     }
 #else
     success=fwrite(Data,1,Size,hFile)==Size && !ferror(hFile);

--- a/lib/UnrarXLib/file.cpp
+++ b/lib/UnrarXLib/file.cpp
@@ -420,7 +420,7 @@ int File::DirectRead(void *Data,int Size)
   while (Size)
   {
     int nRead = m_File.Read(Data,Size);
-    if (nRead == 0)
+    if (nRead <= 0)
       break;
     Read += nRead;
     Data = (void*)(((char*)Data)+nRead);

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -140,10 +140,10 @@ DLLEXPORT void* XBMC_open_file_for_write(void *hdl, void* cb, const char* strFil
   return ((CB_AddOnLib*)cb)->OpenFileForWrite(((AddonCB*)hdl)->addonData, strFileName, bOverWrite);
 }
 
-DLLEXPORT unsigned int XBMC_read_file(void *hdl, void* cb, void* file, void* lpBuf, int64_t uiBufSize)
+DLLEXPORT ssize_t XBMC_read_file(void *hdl, void* cb, void* file, void* lpBuf, size_t uiBufSize)
 {
   if (cb == NULL)
-    return 0;
+    return -1;
 
   return ((CB_AddOnLib*)cb)->ReadFile(((AddonCB*)hdl)->addonData, file, lpBuf, uiBufSize);
 }

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -156,10 +156,10 @@ DLLEXPORT bool XBMC_read_file_string(void *hdl, void* cb, void* file, char *szLi
   return ((CB_AddOnLib*)cb)->ReadFileString(((AddonCB*)hdl)->addonData, file, szLine, iLineLength);
 }
 
-DLLEXPORT int XBMC_write_file(void *hdl, void* cb, void* file, const void* lpBuf, int64_t uiBufSize)
+DLLEXPORT ssize_t XBMC_write_file(void *hdl, void* cb, void* file, const void* lpBuf, size_t uiBufSize)
 {
   if (cb == NULL)
-    return false;
+    return -1;
 
   return ((CB_AddOnLib*)cb)->WriteFile(((AddonCB*)hdl)->addonData, file, lpBuf, uiBufSize);
 }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -575,12 +575,11 @@ CStdString CUtil::GetFileMD5(const CStdString& strPath)
   {
     XBMC::XBMC_MD5 md5;
     char temp[1024];
-    int pos=0;
-    int read=1;
-    while (read > 0)
+    while (true)
     {
-      read = file.Read(temp,1024);
-      pos += read;
+      ssize_t read = file.Read(temp,1024);
+      if (read <= 0)
+        break;
       md5.append(temp,read);
     }
     result = md5.getDigest();

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -19,10 +19,18 @@
  *
  */
 
+#include <stdint.h>
 #include "cores/dvdplayer/DVDDemuxers/DVDDemuxUtils.h"
 #include "addons/include/xbmc_pvr_types.h"
 #include "addons/include/xbmc_codec_types.h"
 #include "../../addons/library.xbmc.gui/libXBMC_gui.h"
+
+#ifdef TARGET_WINDOWS
+#ifndef _SSIZE_T_DEFINED
+typedef intptr_t ssize_t;
+#define _SSIZE_T_DEFINED
+#endif // !_SSIZE_T_DEFINED
+#endif // TARGET_WINDOWS
 
 typedef void (*AddOnLogCallback)(void *addonData, const ADDON::addon_log_t loglevel, const char *msg);
 typedef void (*AddOnQueueNotification)(void *addonData, const ADDON::queue_msg_t type, const char *msg);
@@ -35,7 +43,7 @@ typedef void (*AddOnFreeString)(const void* addonData, char* str);
 
 typedef void* (*AddOnOpenFile)(const void* addonData, const char* strFileName, unsigned int flags);
 typedef void* (*AddOnOpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite);
-typedef unsigned int (*AddOnReadFile)(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
+typedef ssize_t (*AddOnReadFile)(const void* addonData, void* file, void* lpBuf, size_t uiBufSize);
 typedef bool (*AddOnReadFileString)(const void* addonData, void* file, char *szLine, int iLineLength);
 typedef int (*AddOnWriteFile)(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
 typedef void (*AddOnFlushFile)(const void* addonData, void* file);

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -45,7 +45,7 @@ typedef void* (*AddOnOpenFile)(const void* addonData, const char* strFileName, u
 typedef void* (*AddOnOpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite);
 typedef ssize_t (*AddOnReadFile)(const void* addonData, void* file, void* lpBuf, size_t uiBufSize);
 typedef bool (*AddOnReadFileString)(const void* addonData, void* file, char *szLine, int iLineLength);
-typedef int (*AddOnWriteFile)(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
+typedef ssize_t (*AddOnWriteFile)(const void* addonData, void* file, const void* lpBuf, size_t uiBufSize);
 typedef void (*AddOnFlushFile)(const void* addonData, void* file);
 typedef int64_t (*AddOnSeekFile)(const void* addonData, void* file, int64_t iFilePosition, int iWhence);
 typedef int (*AddOnTruncateFile)(const void* addonData, void* file, int64_t iSize);

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -354,7 +354,7 @@ bool CAddonCallbacksAddon::ReadFileString(const void* addonData, void* file, cha
   return cfile->ReadString(szLine, iLineLength);
 }
 
-int CAddonCallbacksAddon::WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize)
+ssize_t CAddonCallbacksAddon::WriteFile(const void* addonData, void* file, const void* lpBuf, size_t uiBufSize)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper)

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -328,7 +328,7 @@ void* CAddonCallbacksAddon::OpenFileForWrite(const void* addonData, const char* 
   return NULL;
 }
 
-unsigned int CAddonCallbacksAddon::ReadFile(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize)
+ssize_t CAddonCallbacksAddon::ReadFile(const void* addonData, void* file, void* lpBuf, size_t uiBufSize)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper)

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -49,7 +49,7 @@ public:
   static void* OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite);
   static ssize_t ReadFile(const void* addonData, void* file, void* lpBuf, size_t uiBufSize);
   static bool ReadFileString(const void* addonData, void* file, char *szLine, int iLineLength);
-  static int WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
+  static ssize_t WriteFile(const void* addonData, void* file, const void* lpBuf, size_t uiBufSize);
   static void FlushFile(const void* addonData, void* file);
   static int64_t SeekFile(const void* addonData, void* file, int64_t iFilePosition, int iWhence);
   static int TruncateFile(const void* addonData, void* file, int64_t iSize);

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -47,7 +47,7 @@ public:
   // file operations
   static void* OpenFile(const void* addonData, const char* strFileName, unsigned int flags);
   static void* OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite);
-  static unsigned int ReadFile(const void* addonData, void* file, void* lpBuf, int64_t uiBufSize);
+  static ssize_t ReadFile(const void* addonData, void* file, void* lpBuf, size_t uiBufSize);
   static bool ReadFileString(const void* addonData, void* file, char *szLine, int iLineLength);
   static int WriteFile(const void* addonData, void* file, const void* lpBuf, int64_t uiBufSize);
   static void FlushFile(const void* addonData, void* file);

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -161,7 +161,7 @@ int CCDDARipJob::RipChunk(CFile& reader, CEncoder* encoder, int& percent)
   int result = reader.Read(stream, 1024);
 
   // return if rip is done or on some kind of error
-  if (!result)
+  if (result <= 0)
     return 1;
 
   // encode data

--- a/xbmc/cdrip/Encoder.cpp
+++ b/xbmc/cdrip/Encoder.cpp
@@ -105,8 +105,8 @@ int CEncoder::FileWrite(const void *pBuffer, uint32_t iBytes)
   if (!m_file)
     return -1;
 
-  uint32_t dwBytesWritten = m_file->Write(pBuffer, iBytes);
-  if (!dwBytesWritten)
+  ssize_t dwBytesWritten = m_file->Write(pBuffer, iBytes);
+  if (dwBytesWritten <= 0)
     return -1;
 
   return dwBytesWritten;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1214,8 +1214,12 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int iId)
             XFILE::CFile file;
             if(pStream->codec->extradata && file.OpenForWrite(fileName))
             {
-              file.Write(pStream->codec->extradata, pStream->codec->extradata_size);
-              file.Close();
+              if (file.Write(pStream->codec->extradata, pStream->codec->extradata_size) != pStream->codec->extradata_size)
+              {
+                file.Close();
+                XFILE::CFile::Delete(fileName);
+                CLog::Log(LOGDEBUG, "%s: Error saving font file \"%s\"", __FUNCTION__, fileName.c_str());
+              }
             }
           }
         }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -73,7 +73,7 @@ int DllLibbluray::file_eof(BD_FILE_H *file)
 
 int64_t DllLibbluray::file_read(BD_FILE_H *file, uint8_t *buf, int64_t size)
 {
-  return static_cast<CFile*>(file->internal)->Read(buf, size);
+  return static_cast<CFile*>(file->internal)->Read(buf, size); // TODO: fix size cast
 }
 
 int64_t DllLibbluray::file_write(BD_FILE_H *file, const uint8_t *buf, int64_t size)

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -113,10 +113,10 @@ int CDVDInputStreamFile::Read(uint8_t* buf, int buf_size)
 {
   if(!m_pFile) return -1;
 
-  unsigned int ret = m_pFile->Read(buf, buf_size);
+  ssize_t ret = m_pFile->Read(buf, buf_size);
 
   /* we currently don't support non completing reads */
-  if( ret == 0 ) m_eof = true;
+  if( ret <= 0 ) m_eof = true;
 
   return (int)(ret & 0xFFFFFFFF);
 }

--- a/xbmc/cores/paplayer/OggCallback.cpp
+++ b/xbmc/cores/paplayer/OggCallback.cpp
@@ -46,7 +46,10 @@ size_t COggCallback::ReadCallback(void *ptr, size_t size, size_t nmemb, void *da
   if (!pCallback)
     return 0;
 
-  return pCallback->m_file.Read(ptr, size*nmemb);
+  const ssize_t res = pCallback->m_file.Read(ptr, size*nmemb);
+  if (res < 0)
+    return 0;
+  return res;
 }
 
 int COggCallback::SeekCallback(void *datasource, ogg_int64_t offset, int whence)

--- a/xbmc/cores/paplayer/PCMCodec.cpp
+++ b/xbmc/cores/paplayer/PCMCodec.cpp
@@ -73,7 +73,7 @@ int PCMCodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
 {
   *actualsize = 0;
 
-  int iAmountRead = m_file.Read(pBuffer, 2 * (size / 2));
+  ssize_t iAmountRead = m_file.Read(pBuffer, 2 * (size / 2));
   if (iAmountRead > 0)
   {
     uint16_t *buffer = (uint16_t*) pBuffer;

--- a/xbmc/cores/paplayer/SPCCodec.cpp
+++ b/xbmc/cores/paplayer/SPCCodec.cpp
@@ -103,7 +103,7 @@ bool SPCCodec::Init(const std::string &strFile, unsigned int filecache)
     return false;
   }
   m_szBuffer = new char[0x10200];
-  if (!file.Read(m_szBuffer,0x10200))
+  if (file.Read(m_szBuffer,0x10200) <= 0)
   {
     delete[] m_szBuffer;
     m_szBuffer = NULL;

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -530,11 +530,11 @@ int CAFPFile::Stat(const CURL& url, struct __stat64* buffer)
   return iResult;
 }
 
-unsigned int CAFPFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CAFPFile::Read(void *lpBuf, size_t uiBufSize)
 {
   CSingleLock lock(gAfpConnection);
   if (m_pFp == NULL || !m_pAfpVol)
-    return 0;
+    return -1;
 
   if (uiBufSize > AFP_MAX_READ_SIZE)
     uiBufSize = AFP_MAX_READ_SIZE;
@@ -548,7 +548,7 @@ unsigned int CAFPFile::Read(void *lpBuf, int64_t uiBufSize)
 
 #endif
   int eof = 0;
-  int bytesRead = gAfpConnection.GetImpl()->afp_wrap_read(m_pAfpVol,
+  ssize_t bytesRead = gAfpConnection.GetImpl()->afp_wrap_read(m_pAfpVol,
     name, (char *)lpBuf,(size_t)uiBufSize, m_fileOffset, m_pFp, &eof);
   if (bytesRead > 0)
     m_fileOffset += bytesRead;
@@ -556,10 +556,10 @@ unsigned int CAFPFile::Read(void *lpBuf, int64_t uiBufSize)
   if (bytesRead < 0)
   {
     CLog::Log(LOGERROR, "%s - Error( %d, %d, %s )", __FUNCTION__, bytesRead, errno, strerror(errno));
-    return 0;
+    return -1;
   }
 
-  return (unsigned int)bytesRead;
+  return bytesRead;
 }
 
 int64_t CAFPFile::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -610,13 +610,13 @@ void CAFPFile::Close()
   }
 }
 
-int CAFPFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CAFPFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   CSingleLock lock(gAfpConnection);
   if (m_pFp == NULL || !m_pAfpVol)
    return -1;
 
-  int numberOfBytesWritten = 0;
+  ssize_t numberOfBytesWritten = 0;
   uid_t uid;
   gid_t gid;
 
@@ -631,7 +631,7 @@ int CAFPFile::Write(const void* lpBuf, int64_t uiBufSize)
     name = m_pFp->basename;
 #endif
   numberOfBytesWritten = gAfpConnection.GetImpl()->afp_wrap_write(m_pAfpVol,
-    name, (const char *)lpBuf, (size_t)uiBufSize, m_fileOffset, m_pFp, uid, gid);
+    name, (const char *)lpBuf, uiBufSize, m_fileOffset, m_pFp, uid, gid);
 
   if (numberOfBytesWritten > 0)
     m_fileOffset += numberOfBytesWritten;

--- a/xbmc/filesystem/AFPFile.h
+++ b/xbmc/filesystem/AFPFile.h
@@ -100,7 +100,7 @@ public:
   virtual ~CAFPFile();
   virtual void          Close();
   virtual int64_t       Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-  virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t       Read(void* lpBuf, size_t uiBufSize);
   virtual bool          Open(const CURL& url);
   virtual bool          Exists(const CURL& url);
   virtual int           Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/AFPFile.h
+++ b/xbmc/filesystem/AFPFile.h
@@ -107,7 +107,7 @@ public:
   virtual int           Stat(struct __stat64* buffer);
   virtual int64_t       GetLength();
   virtual int64_t       GetPosition();
-  virtual int           Write(const void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t       Write(const void* lpBuf, size_t uiBufSize);
 
   virtual bool          OpenForWrite(const CURL& url, bool bOverWrite = false);
   virtual bool          Delete(const CURL& url);

--- a/xbmc/filesystem/APKFile.cpp
+++ b/xbmc/filesystem/APKFile.cpp
@@ -175,9 +175,12 @@ int64_t CAPKFile::Seek(int64_t iFilePosition, int iWhence)
   return m_file_pos;
 }
 
-unsigned int CAPKFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CAPKFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  int bytes_read = uiBufSize;
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
+  ssize_t bytes_read = uiBufSize;
   if (m_zip_archive && m_zip_file)
   {
     // check for a read pas EOF and clamp it to EOF
@@ -191,7 +194,7 @@ unsigned int CAPKFile::Read(void *lpBuf, int64_t uiBufSize)
       bytes_read = 0;
   }
 
-  return (unsigned int)bytes_read;
+  return bytes_read;
 }
 
 int CAPKFile::Stat(struct __stat64* buffer)

--- a/xbmc/filesystem/APKFile.h
+++ b/xbmc/filesystem/APKFile.h
@@ -37,7 +37,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
 
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     virtual int Stat(struct __stat64* buffer);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
     virtual int64_t GetLength();

--- a/xbmc/filesystem/AndroidAppFile.cpp
+++ b/xbmc/filesystem/AndroidAppFile.cpp
@@ -74,10 +74,11 @@ bool CFileAndroidApp::Exists(const CURL& url)
   return false;
 }
 
-unsigned int CFileAndroidApp::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CFileAndroidApp::Read(void* lpBuf, size_t uiBufSize)
 {
-  CXBMCApp::GetIcon(m_appname, lpBuf, uiBufSize);
-  return uiBufSize;
+  if(CXBMCApp::GetIcon(m_appname, lpBuf, uiBufSize))
+    return uiBufSize; // FIXME: not full buffer may be used
+  return -1;
 }
 
 void CFileAndroidApp::Close()

--- a/xbmc/filesystem/AndroidAppFile.h
+++ b/xbmc/filesystem/AndroidAppFile.h
@@ -37,7 +37,7 @@ public:
   virtual int Stat(const CURL& url, struct __stat64* buffer);
 
   /*! \brief Return 32bit rgba raw bitmap. */
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual void Close();
   virtual int64_t GetLength();
   virtual int64_t Seek(int64_t, int) {return -1;};

--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -114,16 +114,19 @@ int CFileCDDA::Stat(const CURL& url, struct __stat64* buffer)
   return -1;
 }
 
-unsigned int CFileCDDA::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CFileCDDA::Read(void* lpBuf, size_t uiBufSize)
 {
   if (!m_pCdIo || !g_mediaManager.IsDiscInDrive())
-    return 0;
+    return -1;
+
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
 
   // limit number of sectors that fits in buffer by m_iSectorCount
   int iSectorCount = std::min((int)uiBufSize / CDIO_CD_FRAMESIZE_RAW, m_iSectorCount);
 
   if (iSectorCount <= 0)
-    return 0;
+    return -1;
 
   // Are there enough sectors left to read
   if (m_lsnCurrent + iSectorCount > m_lsnEnd)
@@ -150,7 +153,7 @@ unsigned int CFileCDDA::Read(void* lpBuf, int64_t uiBufSize)
     if (iSectorCount <= 10)
     {
       CLog::Log(LOGERROR, "file cdda: Reading %d sectors of audio data starting at lsn %d failed with error code %i", iSectorCount, m_lsnCurrent, iret);
-      return 0;
+      return -1;
     }
 
     iSectorCount = 10;

--- a/xbmc/filesystem/CDDAFile.h
+++ b/xbmc/filesystem/CDDAFile.h
@@ -37,7 +37,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int64_t GetPosition();

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -863,16 +863,14 @@ bool CCurlFile::Download(const std::string& strURL, const std::string& strFileNa
     strFileName.c_str(), GetLastError());
     return false;
   }
-  if (strData.size())
-    file.Write(strData.c_str(), strData.size());
-  file.Close();
+  ssize_t written = 0;
+  if (strData.size() > 0)
+    written = file.Write(strData.c_str(), strData.size());
 
   if (pdwSize != NULL)
-  {
-    *pdwSize = strData.size();
-  }
+    *pdwSize = written > 0 ? written : 0;
 
-  return true;
+  return written == strData.size();
 }
 
 // Detect whether we are "online" or not! Very simple and dirty!

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1388,7 +1388,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   return 0;
 }
 
-unsigned int CCurlFile::CReadState::Read(void* lpBuf, int64_t uiBufSize)
+unsigned int CCurlFile::CReadState::Read(void* lpBuf, size_t uiBufSize)
 {
   /* only request 1 byte, for truncated reads (only if not eof) */
   if((m_fileSize == 0 || m_filePos < m_fileSize) && !FillBuffer(1))
@@ -1408,7 +1408,7 @@ unsigned int CCurlFile::CReadState::Read(void* lpBuf, int64_t uiBufSize)
   if (!m_stillRunning && (m_fileSize == 0 || m_filePos != m_fileSize))
   {
     CLog::Log(LOGWARNING, "%s - Transfer ended before entire file was retrieved pos %" PRId64", size %" PRId64, __FUNCTION__, m_filePos, m_fileSize);
-    return 0;
+    return -1;
   }
 
   return 0;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1027,7 +1027,7 @@ bool CCurlFile::OpenForWrite(const CURL& url, bool bOverWrite)
   return true;
 }
 
-int CCurlFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CCurlFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   if (!(m_opened && m_forWrite) || m_inError)
     return -1;

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -57,7 +57,7 @@ namespace XFILE
       virtual int  Stat(const CURL& url, struct __stat64* buffer);
       virtual void Close();
       virtual bool ReadString(char *szLine, int iLineLength)     { return m_state->ReadString(szLine, iLineLength); }
-      virtual unsigned int Read(void* lpBuf, int64_t uiBufSize)  { return m_state->Read(lpBuf, uiBufSize); }
+      virtual ssize_t Read(void* lpBuf, size_t uiBufSize)        { return m_state->Read(lpBuf, uiBufSize); }
       virtual int Write(const void* lpBuf, int64_t uiBufSize);
       virtual std::string GetMimeType()                           { return m_state->m_httpheader.GetMimeType(); }
       virtual std::string GetContent()                           { return GetMimeType(); }
@@ -138,7 +138,7 @@ namespace XFILE
           size_t HeaderCallback(void *ptr, size_t size, size_t nmemb);
 
           bool         Seek(int64_t pos);
-          unsigned int Read(void* lpBuf, int64_t uiBufSize);
+          unsigned int Read(void* lpBuf, size_t uiBufSize);
           bool         ReadString(char *szLine, int iLineLength);
           bool         FillBuffer(unsigned int want);
           void         SetReadBuffer(const void* lpBuf, int64_t uiBufSize);

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -58,7 +58,7 @@ namespace XFILE
       virtual void Close();
       virtual bool ReadString(char *szLine, int iLineLength)     { return m_state->ReadString(szLine, iLineLength); }
       virtual ssize_t Read(void* lpBuf, size_t uiBufSize)        { return m_state->Read(lpBuf, uiBufSize); }
-      virtual int Write(const void* lpBuf, int64_t uiBufSize);
+      virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
       virtual std::string GetMimeType()                           { return m_state->m_httpheader.GetMimeType(); }
       virtual std::string GetContent()                           { return GetMimeType(); }
       virtual int IoControl(EIoControl request, void* param);

--- a/xbmc/filesystem/DAAPFile.cpp
+++ b/xbmc/filesystem/DAAPFile.cpp
@@ -203,7 +203,7 @@ bool CDAAPFile::Open(const CURL& url)
 
 
 //*********************************************************************************************
-unsigned int CDAAPFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CDAAPFile::Read(void *lpBuf, size_t uiBufSize)
 {
   return m_curl.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/DAAPFile.h
+++ b/xbmc/filesystem/DAAPFile.h
@@ -76,7 +76,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int  IoControl(EIoControl request, void* param);

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -130,10 +130,10 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
       return false;
     }
 
-    int iBufferSize = 128 * 1024;
+    static const int iBufferSize = 128 * 1024;
 
     auto_buffer buffer(iBufferSize);
-    int iRead, iWrite;
+    ssize_t iRead, iWrite;
 
     UINT64 llFileSize = file.GetLength();
     UINT64 llPos = 0;
@@ -499,6 +499,9 @@ unsigned int CFile::Read(void *lpBuf, int64_t uiBufSize)
 {
   if (!m_pFile || !lpBuf)
     return 0;
+
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
 
   if(m_pBuffer)
   {

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -158,7 +158,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
       iWrite = 0;
       while(iWrite < iRead)
       {
-        int iWrite2 = newFile.Write(buffer.get()+iWrite, iRead-iWrite);
+        ssize_t iWrite2 = newFile.Write(buffer.get() + iWrite, iRead - iWrite);
         if(iWrite2 <=0)
           break;
         iWrite+=iWrite2;
@@ -741,7 +741,7 @@ bool CFile::ReadString(char *szLine, int iLineLength)
   return false;
 }
 
-int CFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   if (!m_pFile || !lpBuf)
     return -1;

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -84,7 +84,15 @@ public:
 
   bool Open(const std::string& strFileName, const unsigned int flags = 0);
   bool OpenForWrite(const std::string& strFileName, bool bOverWrite = false);
-  unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  /**
+   * Attempt to read bufSize bytes from currently opened file into buffer bufPtr.
+   * @param bufPtr  pointer to buffer
+   * @param bufSize size of the buffer
+   * @return number of successfully read bytes if any bytes were read and stored in
+   *         buffer, zero if no bytes are available to read (end of file was reached)
+   *         or undetectable error occur, -1 in case of any explicit error
+   */
+  ssize_t Read(void* bufPtr, size_t bufSize);
   bool ReadString(char *szLine, int iLineLength);
   int Write(const void* lpBuf, int64_t uiBufSize);
   void Flush();

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -94,7 +94,15 @@ public:
    */
   ssize_t Read(void* bufPtr, size_t bufSize);
   bool ReadString(char *szLine, int iLineLength);
-  int Write(const void* lpBuf, int64_t uiBufSize);
+  /**
+   * Attempt to write bufSize bytes from buffer bufPtr into currently opened file.
+   * @param bufPtr  pointer to buffer
+   * @param bufSize size of the buffer
+   * @return number of successfully written bytes if any bytes were written,
+   *         zero if no bytes were written and no detectable error occur,
+   *         -1 in case of any explicit error
+   */
+  ssize_t Write(const void* bufPtr, size_t bufSize);
   void Flush();
   int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   int Truncate(int64_t iSize);

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -348,15 +348,18 @@ int CFileCache::Stat(const CURL& url, struct __stat64* buffer)
   return CFile::Stat(url.Get(), buffer);
 }
 
-unsigned int CFileCache::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CFileCache::Read(void* lpBuf, size_t uiBufSize)
 {
   CSingleLock lock(m_sync);
   if (!m_pCache)
   {
     CLog::Log(LOGERROR,"%s - sanity failed. no cache strategy!", __FUNCTION__);
-    return 0;
+    return -1;
   }
   int64_t iRc;
+
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
 
 retry:
   // attempt to read
@@ -378,7 +381,7 @@ retry:
   if (iRc == CACHE_RC_TIMEOUT)
   {
     CLog::Log(LOGWARNING, "%s - timeout waiting for data", __FUNCTION__);
-    return 0;
+    return -1;
   }
 
   if (iRc == 0)
@@ -386,7 +389,7 @@ retry:
 
   // unknown error code
   CLog::Log(LOGERROR, "%s - cache strategy returned unknown error code %d", __FUNCTION__, (int)iRc);
-  return 0;
+  return -1;
 }
 
 int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -264,7 +264,7 @@ void CFileCache::Process()
       }
     }
 
-    int iRead = 0;
+    ssize_t iRead = 0;
     if (!cacheReachEOF)
       iRead = m_source.Read(buffer.get(), m_chunkSize);
     if (iRead == 0)

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -48,7 +48,7 @@ namespace XFILE
     virtual bool          Exists(const CURL& url);
     virtual int           Stat(const CURL& url, struct __stat64* buffer);
 
-    virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t       Read(void* lpBuf, size_t uiBufSize);
 
     virtual int64_t       Seek(int64_t iFilePosition, int iWhence);
     virtual int64_t       GetPosition();

--- a/xbmc/filesystem/FileReaderFile.cpp
+++ b/xbmc/filesystem/FileReaderFile.cpp
@@ -75,7 +75,7 @@ ssize_t CFileReaderFile::Read(void *lpBuf, size_t uiBufSize)
 //*********************************************************************************************
 ssize_t CFileReaderFile::Write(const void *lpBuf, size_t uiBufSize)
 {
-  return 0;
+  return -1;
 }
 
 //*********************************************************************************************

--- a/xbmc/filesystem/FileReaderFile.cpp
+++ b/xbmc/filesystem/FileReaderFile.cpp
@@ -73,7 +73,7 @@ ssize_t CFileReaderFile::Read(void *lpBuf, size_t uiBufSize)
 }
 
 //*********************************************************************************************
-int CFileReaderFile::Write(const void *lpBuf, int64_t uiBufSize)
+ssize_t CFileReaderFile::Write(const void *lpBuf, size_t uiBufSize)
 {
   return 0;
 }

--- a/xbmc/filesystem/FileReaderFile.cpp
+++ b/xbmc/filesystem/FileReaderFile.cpp
@@ -67,7 +67,7 @@ bool CFileReaderFile::OpenForWrite(const CURL& url, bool bOverWrite)
 }
 
 //*********************************************************************************************
-unsigned int CFileReaderFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CFileReaderFile::Read(void *lpBuf, size_t uiBufSize)
 {
   return m_reader.Read(lpBuf,uiBufSize);
 }

--- a/xbmc/filesystem/FileReaderFile.h
+++ b/xbmc/filesystem/FileReaderFile.h
@@ -36,7 +36,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();

--- a/xbmc/filesystem/FileReaderFile.h
+++ b/xbmc/filesystem/FileReaderFile.h
@@ -37,7 +37,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 

--- a/xbmc/filesystem/HDHomeRunFile.cpp
+++ b/xbmc/filesystem/HDHomeRunFile.cpp
@@ -106,8 +106,11 @@ bool CHomeRunFile::Open(const CURL &url)
   return true;
 }
 
-unsigned int CHomeRunFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CHomeRunFile::Read(void* lpBuf, size_t uiBufSize)
 {
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
   size_t datasize;
 
   if(uiBufSize < VIDEO_DATA_PACKET_SIZE)
@@ -125,7 +128,7 @@ unsigned int CHomeRunFile::Read(void* lpBuf, int64_t uiBufSize)
     if(ptr)
     {
       memcpy(lpBuf, ptr, datasize);
-      return (unsigned int)datasize;
+      return datasize;
     }
 
     if(timestamp.IsTimePast())
@@ -133,7 +136,7 @@ unsigned int CHomeRunFile::Read(void* lpBuf, int64_t uiBufSize)
 
     Sleep(64);
   }
-  return (unsigned int)datasize;
+  return datasize;
 }
 
 void CHomeRunFile::Close()

--- a/xbmc/filesystem/HDHomeRunFile.h
+++ b/xbmc/filesystem/HDHomeRunFile.h
@@ -40,7 +40,7 @@ namespace XFILE
 
       virtual bool          Open(const CURL& url);
       virtual void          Close();
-      virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+      virtual ssize_t       Read(void* lpBuf, size_t uiBufSize);
       virtual int           GetChunkSize();
     private:
       struct hdhomerun_device_t* m_device;

--- a/xbmc/filesystem/HTTPFile.cpp
+++ b/xbmc/filesystem/HTTPFile.cpp
@@ -40,7 +40,7 @@ bool CHTTPFile::OpenForWrite(const CURL& url, bool bOverWrite)
   return true;
 }
 
-int CHTTPFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CHTTPFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   // Although we can not verify much, try to catch errors where we can
   if (!m_openedforwrite)
@@ -60,6 +60,6 @@ int CHTTPFile::Write(const void* lpBuf, int64_t uiBufSize)
     return -1;
 
   // Finally (and this is a clumsy hack) return the http response code
-  return (int) m_httpresponse;
+  return m_httpresponse;
 }
 

--- a/xbmc/filesystem/HTTPFile.h
+++ b/xbmc/filesystem/HTTPFile.h
@@ -30,7 +30,7 @@ namespace XFILE
     CHTTPFile(void);
     virtual ~CHTTPFile(void);
     virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
-    virtual int Write(const void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
   private:
     bool            m_openedforwrite;
     CURL            m_urlforwrite;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -29,14 +29,22 @@
 
 #pragma once
 
-#ifdef TARGET_POSIX
-#include "PlatformDefs.h" // for __stat64
-#endif
+#include "PlatformDefs.h" // for __stat64, ssize_t
 
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/stat.h>
 #include <string>
+
+#if !defined(SIZE_MAX) || !defined(SSIZE_MAX)
+#include <limits.h>
+#ifndef SIZE_MAX
+#define SIZE_MAX UINTPTR_MAX
+#endif // ! SIZE_MAX
+#ifndef SSIZE_MAX
+#define SSIZE_MAX INTPTR_MAX
+#endif // ! SSIZE_MAX
+#endif // ! SIZE_MAX || ! SSIZE_MAX
 
 #include "IFileTypes.h"
 
@@ -79,7 +87,15 @@ public:
    * @return zero of success, -1 otherwise.
    */
   virtual int Stat(struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize) = 0;
+  /**
+   * Attempt to read bufSize bytes from currently opened file into buffer bufPtr.
+   * @param bufPtr  pointer to buffer
+   * @param bufSize size of the buffer
+   * @return number of successfully read bytes if any bytes were read and stored in
+   *         buffer, zero if no bytes are available to read (end of file was reached)
+   *         or undetectable error occur, -1 in case of any explicit error
+   */
+  virtual ssize_t Read(void* bufPtr, size_t bufSize) = 0;
   virtual int Write(const void* lpBuf, int64_t uiBufSize) { return -1;};
   virtual bool ReadString(char *szLine, int iLineLength);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) = 0;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -96,7 +96,15 @@ public:
    *         or undetectable error occur, -1 in case of any explicit error
    */
   virtual ssize_t Read(void* bufPtr, size_t bufSize) = 0;
-  virtual int Write(const void* lpBuf, int64_t uiBufSize) { return -1;};
+  /**
+   * Attempt to write bufSize bytes from buffer bufPtr into currently opened file.
+   * @param bufPtr  pointer to buffer
+   * @param bufSize size of the buffer
+   * @return number of successfully written bytes if any bytes were written,
+   *         zero if no bytes were written and no detectable error occur,
+   *         -1 in case of any explicit error
+   */
+  virtual ssize_t Write(const void* bufPtr, size_t bufSize) { return -1;}
   virtual bool ReadString(char *szLine, int iLineLength);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) = 0;
   virtual void Close() = 0;

--- a/xbmc/filesystem/ISOFile.cpp
+++ b/xbmc/filesystem/ISOFile.cpp
@@ -67,9 +67,13 @@ bool CISOFile::Open(const CURL& url)
 }
 
 //*********************************************************************************************
-unsigned int CISOFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CISOFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  if (!m_bOpened) return 0;
+  if (!m_bOpened)
+    return -1;
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
   char *pData = (char *)lpBuf;
 
   if (m_cache.getSize() > 0)
@@ -99,10 +103,8 @@ unsigned int CISOFile::Read(void *lpBuf, int64_t uiBufSize)
     }
     return lTotalBytesRead;
   }
-  int iResult = m_isoReader.ReadFile( m_hFile, (uint8_t*)pData, (long)uiBufSize);
-  if (iResult == -1)
-    return 0;
-  return iResult;
+
+  return m_isoReader.ReadFile( m_hFile, (uint8_t*)pData, (long)uiBufSize);;
 }
 
 //*********************************************************************************************

--- a/xbmc/filesystem/ISOFile.h
+++ b/xbmc/filesystem/ISOFile.h
@@ -45,7 +45,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 protected:

--- a/xbmc/filesystem/ImageFile.cpp
+++ b/xbmc/filesystem/ImageFile.cpp
@@ -85,7 +85,7 @@ int CImageFile::Stat(const CURL& url, struct __stat64* buffer)
   return -1;
 }
 
-unsigned int CImageFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CImageFile::Read(void* lpBuf, size_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/ImageFile.h
+++ b/xbmc/filesystem/ImageFile.h
@@ -33,7 +33,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual void Close();
     virtual int64_t GetPosition();

--- a/xbmc/filesystem/MultiPathFile.cpp
+++ b/xbmc/filesystem/MultiPathFile.cpp
@@ -94,7 +94,7 @@ int CMultiPathFile::Stat(const CURL& url, struct __stat64* buffer)
   return -1;
 }
 
-unsigned int CMultiPathFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CMultiPathFile::Read(void* lpBuf, size_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/MultiPathFile.h
+++ b/xbmc/filesystem/MultiPathFile.h
@@ -33,7 +33,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual void Close();
     virtual int64_t GetPosition();

--- a/xbmc/filesystem/MusicDatabaseFile.cpp
+++ b/xbmc/filesystem/MusicDatabaseFile.cpp
@@ -78,7 +78,7 @@ int CMusicDatabaseFile::Stat(const CURL& url, struct __stat64* buffer)
   return m_file.Stat(TranslateUrl(url), buffer);
 }
 
-unsigned int CMusicDatabaseFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CMusicDatabaseFile::Read(void* lpBuf, size_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/MusicDatabaseFile.h
+++ b/xbmc/filesystem/MusicDatabaseFile.h
@@ -33,7 +33,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
 
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int64_t GetPosition();

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -492,14 +492,17 @@ int64_t CMythFile::GetLength()
   return -1;
 }
 
-unsigned int CMythFile::Read(void* buffer, int64_t size)
+ssize_t CMythFile::Read(void* buffer, size_t size)
 {
   /* check for any events */
   HandleEvents();
 
   /* file might have gotten closed */
   if(!m_recorder && !m_file)
-    return 0;
+    return -1;
+
+  if (size > SSIZE_MAX)
+    size = SSIZE_MAX;
 
   int ret;
   if(m_recorder)
@@ -508,10 +511,8 @@ unsigned int CMythFile::Read(void* buffer, int64_t size)
     ret = m_dll->file_read(m_file, (char*)buffer, (unsigned long)size);
 
   if(ret < 0)
-  {
     CLog::Log(LOGERROR, "%s - cmyth read returned error %d", __FUNCTION__, ret);
-    return 0;
-  }
+
   return ret;
 }
 

--- a/xbmc/filesystem/MythFile.h
+++ b/xbmc/filesystem/MythFile.h
@@ -51,7 +51,7 @@ public:
   virtual int64_t       GetLength();
   virtual int           Stat(const CURL& url, struct __stat64* buffer) { return -1; }
   virtual void          Close();
-  virtual unsigned int  Read(void* buffer, int64_t size);
+  virtual ssize_t       Read(void* buffer, size_t size);
   virtual std::string   GetContent() { return ""; }
   virtual bool          SkipNext();
 

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -720,13 +720,13 @@ void CNFSFile::Close()
 //this was a bitch!
 //for nfs write to work we have to write chunked
 //otherwise this could crash on big files
-int CNFSFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CNFSFile::Write(const void* lpBuf, size_t uiBufSize)
 {
-  int numberOfBytesWritten = 0;
+  size_t numberOfBytesWritten = 0;
   int writtenBytes = 0;
-  int64_t leftBytes = uiBufSize;
+  size_t leftBytes = uiBufSize;
   //clamp max write chunksize to 32kb - fixme - this might be superfluious with future libnfs versions
-  int64_t chunkSize = gNfsConnection.GetMaxWriteChunkSize() > 32768 ? 32768 : gNfsConnection.GetMaxWriteChunkSize();
+  size_t chunkSize = gNfsConnection.GetMaxWriteChunkSize() > 32768 ? 32768 : (size_t)gNfsConnection.GetMaxWriteChunkSize();
   
   CSingleLock lock(gNfsConnection);
   

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -753,7 +753,10 @@ ssize_t CNFSFile::Write(const void* lpBuf, size_t uiBufSize)
     //danger - something went wrong
     if (writtenBytes < 0) 
     {
-      CLog::Log(LOGERROR, "Failed to pwrite(%s) %s\n", m_url.GetFileName().c_str(), gNfsConnection.GetImpl()->nfs_get_error(m_pNfsContext));        
+      CLog::Log(LOGERROR, "Failed to pwrite(%s) %s\n", m_url.GetFileName().c_str(), gNfsConnection.GetImpl()->nfs_get_error(m_pNfsContext));
+      if (numberOfBytesWritten == 0)
+        return -1;
+
       break;
     }     
   }

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -135,7 +135,7 @@ namespace XFILE
     virtual ~CNFSFile();
     virtual void Close();
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     virtual bool Open(const CURL& url);
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -142,7 +142,7 @@ namespace XFILE
     virtual int Stat(struct __stat64* buffer);
     virtual int64_t GetLength();
     virtual int64_t GetPosition();
-    virtual int Write(const void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
     virtual int Truncate(int64_t iSize);
 
     //implement iocontrol for seek_possible for preventing the stat in File class for

--- a/xbmc/filesystem/PVRFile.cpp
+++ b/xbmc/filesystem/PVRFile.cpp
@@ -101,9 +101,12 @@ void CPVRFile::Close()
   g_PVRManager.CloseStream();
 }
 
-unsigned int CPVRFile::Read(void* buffer, int64_t size)
+ssize_t CPVRFile::Read(void* buffer, size_t size)
 {
-  return g_PVRManager.IsStarted() ? g_PVRClients->ReadStream((BYTE*)buffer, size) : 0;
+  if (size > SSIZE_MAX)
+    size = SSIZE_MAX;
+
+  return g_PVRManager.IsStarted() ? g_PVRClients->ReadStream((BYTE*)buffer, size) : -1;
 }
 
 int64_t CPVRFile::GetLength()

--- a/xbmc/filesystem/PVRFile.h
+++ b/xbmc/filesystem/PVRFile.h
@@ -42,7 +42,7 @@ public:
   virtual int64_t       GetLength();
   virtual int           Stat(const CURL& url, struct __stat64* buffer) { return -1; }
   virtual void          Close();
-  virtual unsigned int  Read(void* buffer, int64_t size);
+  virtual ssize_t       Read(void* buffer, size_t size);
   virtual std::string   GetContent()                                   { return ""; }
   virtual bool          SkipNext()                                     { return !m_isPlayRecording; }
 

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -88,13 +88,13 @@ ssize_t CPipeFile::Read(void* lpBuf, size_t uiBufSize)
   return m_pipe->Read((char *)lpBuf,(int)uiBufSize);
 }
 
-int CPipeFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CPipeFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   if (!m_pipe)
     return -1;
   
   // m_pipe->Write return bool. either all was written or not.
-  return m_pipe->Write((const char *)lpBuf,(int)uiBufSize) ? (int)uiBufSize : 0;
+  return m_pipe->Write((const char *)lpBuf,uiBufSize) ? uiBufSize : 0;
 }
 
 void CPipeFile::SetEof()

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -94,7 +94,7 @@ ssize_t CPipeFile::Write(const void* lpBuf, size_t uiBufSize)
     return -1;
   
   // m_pipe->Write return bool. either all was written or not.
-  return m_pipe->Write((const char *)lpBuf,uiBufSize) ? uiBufSize : 0;
+  return m_pipe->Write((const char *)lpBuf,uiBufSize) ? uiBufSize : -1;
 }
 
 void CPipeFile::SetEof()

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -77,11 +77,14 @@ int CPipeFile::Stat(struct __stat64* buffer)
   return 0;
 }
 
-unsigned int CPipeFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CPipeFile::Read(void* lpBuf, size_t uiBufSize)
 {
   if (!m_pipe)
     return -1;
   
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
   return m_pipe->Read((char *)lpBuf,(int)uiBufSize);
 }
 

--- a/xbmc/filesystem/PipeFile.h
+++ b/xbmc/filesystem/PipeFile.h
@@ -51,7 +51,7 @@ public:
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
   virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual void Flush();

--- a/xbmc/filesystem/PipeFile.h
+++ b/xbmc/filesystem/PipeFile.h
@@ -50,7 +50,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
   virtual int Stat(struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();

--- a/xbmc/filesystem/RTVFile.cpp
+++ b/xbmc/filesystem/RTVFile.cpp
@@ -121,12 +121,16 @@ int CRTVFile::Stat(const CURL& url, struct __stat64* buffer)
 }
 
 //*********************************************************************************************
-unsigned int CRTVFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CRTVFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  size_t lenread;
+  ssize_t lenread;
 
   // Don't read if no connection is open!
-  if (!m_bOpened) return 0;
+  if (!m_bOpened)
+    return -1;
+
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
 
   // Read uiBufSize bytes from the m_rtvd connection
   lenread = rtv_read_file(m_rtvd, (char *) lpBuf, (size_t) uiBufSize);
@@ -137,7 +141,7 @@ unsigned int CRTVFile::Read(void *lpBuf, int64_t uiBufSize)
   if(m_filePos + lenread > m_fileSize)
   {
     CLog::Log(LOGWARNING, "%s - RTV library read passed filesize, returning last chunk", __FUNCTION__);
-    lenread = (size_t)(m_fileSize - m_filePos);
+    lenread = (m_fileSize - m_filePos);
     m_filePos = m_fileSize;
     return lenread;
   }

--- a/xbmc/filesystem/RTVFile.h
+++ b/xbmc/filesystem/RTVFile.h
@@ -45,7 +45,7 @@ public:
   bool Open(const std::string& strHostName, const std::string& strFileName, int iport);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 protected:

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -360,11 +360,6 @@ ssize_t CRarFile::Read(void *lpBuf, size_t uiBufSize)
 #endif
 }
 
-unsigned int CRarFile::Write(void *lpBuf, int64_t uiBufSize)
-{
-  return 0;
-}
-
 void CRarFile::Close()
 {
 #ifdef HAS_FILESYSTEM_RAR
@@ -530,7 +525,7 @@ int64_t CRarFile::GetPosition()
   return m_iFilePosition;
 }
 
-int CRarFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CRarFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   return -1;
 }

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -269,11 +269,14 @@ bool CRarFile::OpenForWrite(const CURL& url)
   return false;
 }
 
-unsigned int CRarFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CRarFile::Read(void *lpBuf, size_t uiBufSize)
 {
 #ifdef HAS_FILESYSTEM_RAR
   if (!m_bOpen)
-    return 0;
+    return -1;
+
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
 
   if (m_bUseFile)
     return m_File.Read(lpBuf,uiBufSize);
@@ -284,7 +287,7 @@ unsigned int CRarFile::Read(void *lpBuf, int64_t uiBufSize)
   if( !m_pExtract->GetDataIO().hBufferEmpty->WaitMSec(5000) )
   {
     CLog::Log(LOGERROR, "%s - Timeout waiting for buffer to empty", __FUNCTION__);
-    return 0;
+    return -1;
   }
 
 
@@ -351,7 +354,7 @@ unsigned int CRarFile::Read(void *lpBuf, int64_t uiBufSize)
 
   m_pExtract->GetDataIO().hBufferEmpty->Set();
 
-  return static_cast<unsigned int>(uiBufSize-uicBufSize);
+  return (ssize_t)(uiBufSize-uicBufSize);
 #else
   return 0;
 #endif

--- a/xbmc/filesystem/RarFile.h
+++ b/xbmc/filesystem/RarFile.h
@@ -72,7 +72,7 @@ namespace XFILE
     virtual bool          Exists(const CURL& url);
     virtual int           Stat(const CURL& url, struct __stat64* buffer);
     virtual ssize_t       Read(void* lpBuf, size_t uiBufSize);
-    virtual int           Write(const void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t       Write(const void* lpBuf, size_t uiBufSize);
     virtual int64_t       Seek(int64_t iFilePosition, int iWhence=SEEK_SET);
     virtual void          Close();
     virtual void          Flush();

--- a/xbmc/filesystem/RarFile.h
+++ b/xbmc/filesystem/RarFile.h
@@ -71,7 +71,7 @@ namespace XFILE
     virtual bool          Open(const CURL& url);
     virtual bool          Exists(const CURL& url);
     virtual int           Stat(const CURL& url, struct __stat64* buffer);
-    virtual unsigned int  Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t       Read(void* lpBuf, size_t uiBufSize);
     virtual int           Write(const void* lpBuf, int64_t uiBufSize);
     virtual int64_t       Seek(int64_t iFilePosition, int iWhence=SEEK_SET);
     virtual void          Close();

--- a/xbmc/filesystem/SAPFile.cpp
+++ b/xbmc/filesystem/SAPFile.cpp
@@ -27,6 +27,7 @@
 
 #include <sys/stat.h>
 #include <vector>
+#include <limits>
 
 using namespace std;
 using namespace XFILE;
@@ -111,9 +112,14 @@ int CSAPFile::Stat(const CURL& url, struct __stat64* buffer)
 }
 
 
-unsigned int CSAPFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CSAPFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  return (unsigned int)m_stream.readsome((char*)lpBuf, (streamsize)uiBufSize);
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+  if (uiBufSize > std::numeric_limits<std::streamsize>::max())
+    uiBufSize = (size_t)std::numeric_limits<std::streamsize>::max();
+
+  return (ssize_t)m_stream.readsome((char*)lpBuf, (streamsize)uiBufSize);
 }
 
 void CSAPFile::Close()

--- a/xbmc/filesystem/SAPFile.h
+++ b/xbmc/filesystem/SAPFile.h
@@ -41,7 +41,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 

--- a/xbmc/filesystem/SFTPFile.cpp
+++ b/xbmc/filesystem/SFTPFile.cpp
@@ -637,10 +637,13 @@ int64_t CSFTPFile::Seek(int64_t iFilePosition, int iWhence)
   }
 }
 
-unsigned int CSFTPFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CSFTPFile::Read(void* lpBuf, size_t uiBufSize)
 {
   if (m_session && m_sftp_handle)
   {
+    if (uiBufSize > SSIZE_MAX)
+      uiBufSize = SSIZE_MAX;
+
     int rc = m_session->Read(m_sftp_handle, lpBuf, (size_t)uiBufSize);
 
     if (rc >= 0)

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -107,7 +107,7 @@ namespace XFILE
     virtual ~CSFTPFile();
     virtual void Close();
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     virtual bool Open(const CURL& url);
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -30,7 +30,6 @@
 #define ssize_t SSIZE_T
 #include <libssh/sftp.h>
 #undef ssize_t
-#include "PlatformDefs.h"
 #else  // !TARGET_WINDOWS
 #include <libssh/sftp.h>
 #endif // !TARGET_WINDOWS

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -570,7 +570,7 @@ void CSMBFile::Close()
   m_fd = -1;
 }
 
-int CSMBFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CSMBFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   if (m_fd == -1) return -1;
   DWORD dwNumberOfBytesWritten = 0;
@@ -580,7 +580,7 @@ int CSMBFile::Write(const void* lpBuf, int64_t uiBufSize)
   CSingleLock lock(smb);
   dwNumberOfBytesWritten = smbc_write(m_fd, (void*)lpBuf, (DWORD)uiBufSize);
 
-  return (int)dwNumberOfBytesWritten;
+  return dwNumberOfBytesWritten;
 }
 
 bool CSMBFile::Delete(const CURL& url)

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -508,9 +508,14 @@ int CSMBFile::Truncate(int64_t size)
   return 0;
 }
 
-unsigned int CSMBFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CSMBFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  if (m_fd == -1) return 0;
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
+  if (m_fd == -1)
+    return -1;
+
   CSingleLock lock(smb); // Init not called since it has to be "inited" by now
   smb.SetActivityTime();
   /* work around stupid bug in samba */
@@ -523,7 +528,7 @@ unsigned int CSMBFile::Read(void *lpBuf, int64_t uiBufSize)
   if( uiBufSize >= 64*1024-2 )
     uiBufSize = 64*1024-2;
 
-  int bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
+  ssize_t bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
 
   if ( bytesRead < 0 && errno == EINVAL )
   {
@@ -532,12 +537,9 @@ unsigned int CSMBFile::Read(void *lpBuf, int64_t uiBufSize)
   }
 
   if ( bytesRead < 0 )
-  {
     CLog::Log(LOGERROR, "%s - Error( %d, %d, %s )", __FUNCTION__, bytesRead, errno, strerror(errno));
-    return 0;
-  }
 
-  return (unsigned int)bytesRead;
+  return bytesRead;
 }
 
 int64_t CSMBFile::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -79,7 +79,7 @@ public:
   virtual ~CSMBFile();
   virtual void Close();
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -87,7 +87,7 @@ public:
   virtual int Truncate(int64_t size);
   virtual int64_t GetLength();
   virtual int64_t GetPosition();
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
 
   virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
   virtual bool Delete(const CURL& url);

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -95,8 +95,11 @@ bool CShoutcastFile::Open(const CURL& url)
   return result;
 }
 
-unsigned int CShoutcastFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CShoutcastFile::Read(void* lpBuf, size_t uiBufSize)
 {
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
   if (m_currint >= m_metaint && m_metaint > 0)
   {
     unsigned char header;
@@ -114,13 +117,14 @@ unsigned int CShoutcastFile::Read(void* lpBuf, int64_t uiBufSize)
     m_currint = 0;
   }
 
-  unsigned int toRead;
+  ssize_t toRead;
   if (m_metaint > 0)
-    toRead = std::min((unsigned int)uiBufSize,(unsigned int)m_metaint-m_currint);
+    toRead = std::min<size_t>(uiBufSize,m_metaint-m_currint);
   else
-    toRead = std::min((unsigned int)uiBufSize,(unsigned int)16*255);
+    toRead = std::min<size_t>(uiBufSize,16*255);
   toRead = m_file.Read(lpBuf,toRead);
-  m_currint += toRead;
+  if (toRead > 0)
+    m_currint += toRead;
   return toRead;
 }
 

--- a/xbmc/filesystem/ShoutcastFile.h
+++ b/xbmc/filesystem/ShoutcastFile.h
@@ -44,7 +44,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url) { return true;};
   virtual int Stat(const CURL& url, struct __stat64* buffer) { errno = ENOENT; return -1; };
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   int IoControl(EIoControl request, void* param);

--- a/xbmc/filesystem/SlingboxFile.cpp
+++ b/xbmc/filesystem/SlingboxFile.cpp
@@ -157,16 +157,16 @@ bool CSlingboxFile::Open(const CURL& url)
   return true;
 }
 
-unsigned int CSlingboxFile::Read(void * pBuffer, int64_t iSize)
+ssize_t CSlingboxFile::Read(void * pBuffer, size_t iSize)
 {
+  if (iSize > SSIZE_MAX)
+    iSize = SSIZE_MAX;
+
   // Read the data and check for any errors
-  int iRead = m_pSlingbox->ReadStream(pBuffer, (unsigned int)iSize);
+  ssize_t iRead = m_pSlingbox->ReadStream(pBuffer, (unsigned int)iSize);
   if (iRead < 0)
-  {
     CLog::Log(LOGERROR, "%s - Error reading stream from Slingbox: %s", __FUNCTION__,
       m_sSlingboxSettings.strHostname.c_str());
-    return 0;
-  }
 
   return iRead;
 }

--- a/xbmc/filesystem/SlingboxFile.h
+++ b/xbmc/filesystem/SlingboxFile.h
@@ -33,7 +33,7 @@ namespace XFILE
     CSlingboxFile();
     virtual ~CSlingboxFile();
     virtual bool Open(const CURL& url);
-    virtual unsigned int Read(void * buffer, int64_t size);
+    virtual ssize_t Read(void * buffer, size_t size);
     virtual void Close();
     virtual bool SkipNext();
     

--- a/xbmc/filesystem/SpecialProtocolFile.cpp
+++ b/xbmc/filesystem/SpecialProtocolFile.cpp
@@ -88,7 +88,7 @@ ssize_t CSpecialProtocolFile::Read(void* lpBuf, size_t uiBufSize)
   return m_file.Read(lpBuf, uiBufSize);
 }
   
-int CSpecialProtocolFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CSpecialProtocolFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   return m_file.Write(lpBuf,uiBufSize);
 }

--- a/xbmc/filesystem/SpecialProtocolFile.cpp
+++ b/xbmc/filesystem/SpecialProtocolFile.cpp
@@ -83,7 +83,7 @@ int CSpecialProtocolFile::Stat(struct __stat64* buffer)
   return m_file.Stat(buffer);
 }
 
-unsigned int CSpecialProtocolFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CSpecialProtocolFile::Read(void* lpBuf, size_t uiBufSize)
 {
   return m_file.Read(lpBuf, uiBufSize);
 }

--- a/xbmc/filesystem/SpecialProtocolFile.h
+++ b/xbmc/filesystem/SpecialProtocolFile.h
@@ -38,7 +38,7 @@ public:
   virtual bool Rename(const CURL& url, const CURL& urlnew);
 
   virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
-  virtual int Write(const void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
   virtual int64_t GetPosition();

--- a/xbmc/filesystem/SpecialProtocolFile.h
+++ b/xbmc/filesystem/SpecialProtocolFile.h
@@ -37,7 +37,7 @@ public:
   virtual bool Delete(const CURL& url);
   virtual bool Rename(const CURL& url, const CURL& urlnew);
 
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int Write(const void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();

--- a/xbmc/filesystem/TuxBoxFile.cpp
+++ b/xbmc/filesystem/TuxBoxFile.cpp
@@ -47,9 +47,9 @@ bool CTuxBoxFile::Open(const CURL& url)
   return true;
 }
 
-unsigned int CTuxBoxFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CTuxBoxFile::Read(void* lpBuf, size_t uiBufSize)
 {
-  return 0;
+  return -1;
 }
 
 int64_t CTuxBoxFile::Seek(int64_t iFilePosition, int iWhence)

--- a/xbmc/filesystem/TuxBoxFile.h
+++ b/xbmc/filesystem/TuxBoxFile.h
@@ -34,7 +34,7 @@ namespace XFILE
       virtual void Close();
       virtual bool Exists(const CURL& url);
       virtual int Stat(const CURL& url, struct __stat64* buffer);
-      virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+      virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
       virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     protected:
   };

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -65,15 +65,16 @@ bool CUDFFile::Open(const CURL& url)
 }
 
 //*********************************************************************************************
-unsigned int CUDFFile::Read(void *lpBuf, int64_t uiBufSize)
+ssize_t CUDFFile::Read(void *lpBuf, size_t uiBufSize)
 {
-  if (!m_bOpened) return 0;
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
+  if (!m_bOpened)
+    return -1;
   char *pData = (char *)lpBuf;
 
-  int iResult = m_udfIsoReaderLocal.ReadFile( m_hFile, (unsigned char*)pData, (long)uiBufSize);
-  if (iResult == -1)
-    return 0;
-  return iResult;
+  return m_udfIsoReaderLocal.ReadFile( m_hFile, (unsigned char*)pData, (long)uiBufSize);
 }
 
 //*********************************************************************************************

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -26,6 +26,7 @@
 
 #include <sys/stat.h>
 #include <errno.h>
+#include <limits.h>
 
 using namespace std;
 using namespace XFILE;
@@ -69,6 +70,8 @@ ssize_t CUDFFile::Read(void *lpBuf, size_t uiBufSize)
 {
   if (uiBufSize > SSIZE_MAX)
     uiBufSize = SSIZE_MAX;
+  if (uiBufSize > LONG_MAX)
+    uiBufSize = LONG_MAX;
 
   if (!m_bOpened)
     return -1;

--- a/xbmc/filesystem/UDFFile.h
+++ b/xbmc/filesystem/UDFFile.h
@@ -38,7 +38,7 @@ public:
   virtual bool Open(const CURL& url);
   virtual bool Exists(const CURL& url);
   virtual int Stat(const CURL& url, struct __stat64* buffer);
-  virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
 protected:

--- a/xbmc/filesystem/UPnPFile.h
+++ b/xbmc/filesystem/UPnPFile.h
@@ -32,7 +32,7 @@ namespace XFILE
       virtual bool Exists(const CURL& url);
       virtual int Stat(const CURL& url, struct __stat64* buffer);
       
-      virtual unsigned int Read(void* lpBuf, int64_t uiBufSize) {return -1;}
+      virtual ssize_t Read(void* lpBuf, size_t uiBufSize) {return -1;}
       virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) {return -1;}
       virtual void Close(){}
       virtual int64_t GetPosition() {return -1;}

--- a/xbmc/filesystem/VTPFile.cpp
+++ b/xbmc/filesystem/VTPFile.cpp
@@ -92,10 +92,13 @@ bool CVTPFile::Open(const CURL& url2)
   return true;
 }
 
-unsigned int CVTPFile::Read(void* buffer, int64_t size)
+ssize_t CVTPFile::Read(void* buffer, size_t size)
 {
+  if (size > SSIZE_MAX)
+    size = SSIZE_MAX;
+
   if(m_socket == INVALID_SOCKET)
-    return 0;
+    return -1;
 
   fd_set         set_r, set_e;
   struct timeval tv;
@@ -112,7 +115,7 @@ unsigned int CVTPFile::Read(void* buffer, int64_t size)
   if(res < 0)
   {
     CLog::Log(LOGERROR, "CVTPFile::Read - select failed");
-    return 0;
+    return -1;
   }
   if(res == 0)
   {
@@ -120,17 +123,12 @@ unsigned int CVTPFile::Read(void* buffer, int64_t size)
     return 0;
   }
 
-  res = recv(m_socket, (char*)buffer, (size_t)size, 0);
+  res = recv(m_socket, (char*)buffer, size, 0);
   if(res < 0)
-  {
     CLog::Log(LOGERROR, "CVTPFile::Read - failed");
-    return 0;
-  }
+
   if(res == 0)
-  {
     CLog::Log(LOGERROR, "CVTPFile::Read - eof");
-    return 0;
-  }
 
   return res;
 }

--- a/xbmc/filesystem/VTPFile.h
+++ b/xbmc/filesystem/VTPFile.h
@@ -41,7 +41,7 @@ public:
   virtual int64_t       GetLength()                                    { return -1; }
   virtual int           Stat(const CURL& url, struct __stat64* buffer) { return -1; }
   virtual void          Close();
-  virtual unsigned int  Read(void* buffer, int64_t size);
+  virtual ssize_t       Read(void* buffer, size_t size);
   virtual std::string   GetContent()                                   { return ""; }
   virtual bool          SkipNext()                                     { return m_socket ? true : false; }
 

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -283,8 +283,11 @@ int CZipFile::Stat(const CURL& url, struct __stat64* buffer)
   return 0;
 }
 
-unsigned int CZipFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CZipFile::Read(void* lpBuf, size_t uiBufSize)
 {
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
   if (m_bCached)
     return mFile.Read(lpBuf,uiBufSize);
 
@@ -328,7 +331,7 @@ unsigned int CZipFile::Read(void* lpBuf, int64_t uiBufSize)
       if (iMessage < 0)
       {
         Close();
-        return 0; // READ ERROR
+        return -1; // READ ERROR
       }
 
       m_bFlush = ((iMessage == Z_OK) && (m_ZStream.avail_out == 0))?true:false; // more info in input buffer
@@ -346,13 +349,16 @@ unsigned int CZipFile::Read(void* lpBuf, int64_t uiBufSize)
     {
       return 0; // we are past eof, this shouldn't happen but test anyway
     }
-    unsigned int iResult = mFile.Read(lpBuf,uiBufSize);
-    m_iZipFilePos += iResult;
-    m_iFilePos += iResult;
+    ssize_t iResult = mFile.Read(lpBuf,uiBufSize);
+    if (iResult > 0)
+    {
+      m_iZipFilePos += iResult;
+      m_iFilePos += iResult;
+    }
     return iResult;
   }
   else
-    return false; // shouldn't happen. compression method checked in open
+    return -1; // shouldn't happen. compression method checked in open
 }
 
 void CZipFile::Close()

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -350,11 +350,10 @@ ssize_t CZipFile::Read(void* lpBuf, size_t uiBufSize)
       return 0; // we are past eof, this shouldn't happen but test anyway
     }
     ssize_t iResult = mFile.Read(lpBuf,uiBufSize);
-    if (iResult > 0)
-    {
-      m_iZipFilePos += iResult;
-      m_iFilePos += iResult;
-    }
+    if (iResult < 0)
+      return -1;
+    m_iZipFilePos += iResult;
+    m_iFilePos += iResult;
     return iResult;
   }
   else
@@ -441,9 +440,9 @@ bool CZipFile::ReadString(char* szLine, int iLineLength)
 
 bool CZipFile::FillBuffer()
 {
-  unsigned int sToRead = 65535;
+  ssize_t sToRead = 65535;
   if (m_iZipFilePos+65535 > mZipItem.csize)
-    sToRead = static_cast<int>(mZipItem.csize-m_iZipFilePos);
+    sToRead = mZipItem.csize-m_iZipFilePos;
 
   if (sToRead <= 0)
     return false; // eof!

--- a/xbmc/filesystem/ZipFile.h
+++ b/xbmc/filesystem/ZipFile.h
@@ -59,7 +59,7 @@ namespace XFILE
     char m_szBuffer[65535];     // 64k buffer for compressed data
     char* m_szStringBuffer;
     char* m_szStartOfStringBuffer; // never allocated!
-    int m_iDataInStringBuffer;
+    size_t m_iDataInStringBuffer;
     int m_iRead;
     bool m_bFlush;
     bool m_bCached;

--- a/xbmc/filesystem/ZipFile.h
+++ b/xbmc/filesystem/ZipFile.h
@@ -40,7 +40,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
     virtual int Stat(struct __stat64* buffer);
     virtual int Stat(const CURL& url, struct __stat64* buffer);
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     //virtual bool ReadString(char *szLine, int iLineLength);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual void Close();

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -106,18 +106,18 @@ bool CZipManager::GetZipList(const CURL& url, vector<SZipEntry>& items)
   int extraBlockSize = searchSize % blockSize;
   // Signature is on 4 bytes
   // It could be between 2 blocks, so we need to read 3 extra bytes
-  char *buffer = new char[blockSize+3];
+  auto_buffer buffer(blockSize + 3);
   bool found = false;
 
   // Loop through blocks starting at the end of the file (minus ECDREC_SIZE-1)
   for (int nb=1; !found && (nb <= nbBlock); nb++)
   {
     mFile.Seek(fileSize-ECDREC_SIZE+1-(blockSize*nb),SEEK_SET);
-    if (mFile.Read(buffer, blockSize + 3) != blockSize + 3)
+    if (mFile.Read(buffer.get(), blockSize + 3) != blockSize + 3)
       return false;
     for (int i=blockSize-1; !found && (i >= 0); i--)
     {
-      if ( Endian_SwapLE32(*((unsigned int*)(buffer+i))) == ZIP_END_CENTRAL_HEADER )
+      if ( Endian_SwapLE32(*((unsigned int*)(buffer.get()+i))) == ZIP_END_CENTRAL_HEADER )
       {
         // Set current position to start of end of central directory
         mFile.Seek(fileSize-ECDREC_SIZE+1-(blockSize*nb)+i,SEEK_SET);
@@ -130,11 +130,11 @@ bool CZipManager::GetZipList(const CURL& url, vector<SZipEntry>& items)
   if ( !found && (extraBlockSize > 0) )
   {
     mFile.Seek(fileSize-ECDREC_SIZE+1-searchSize,SEEK_SET);
-    if (mFile.Read(buffer, extraBlockSize + 3) != extraBlockSize + 3)
+    if (mFile.Read(buffer.get(), extraBlockSize + 3) != extraBlockSize + 3)
       return false;
     for (int i=extraBlockSize-1; !found && (i >= 0); i--)
     {
-      if ( Endian_SwapLE32(*((unsigned int*)(buffer+i))) == ZIP_END_CENTRAL_HEADER )
+      if ( Endian_SwapLE32(*((unsigned int*)(buffer.get()+i))) == ZIP_END_CENTRAL_HEADER )
       {
         // Set current position to start of end of central directory
         mFile.Seek(fileSize-ECDREC_SIZE+1-searchSize+i,SEEK_SET);
@@ -143,7 +143,7 @@ bool CZipManager::GetZipList(const CURL& url, vector<SZipEntry>& items)
     }
   }
 
-  delete [] buffer;
+  buffer.clear();
 
   if ( !found )
   {
@@ -181,10 +181,11 @@ bool CZipManager::GetZipList(const CURL& url, vector<SZipEntry>& items)
     }
 
     // Get the filename just after the central file header
-    std::string strName;
-    strName.resize(ze.flength);
-    if (mFile.Read(&strName[0], ze.flength) != ze.flength)
+    auto_buffer bufName(ze.flength);
+    if (mFile.Read(bufName.get(), ze.flength) != ze.flength)
       return false;
+    std::string strName(bufName.get(), bufName.size());
+    strName.clear();
     g_charsetConverter.unknownToUTF8(strName);
     ZeroMemory(ze.name, 255);
     strncpy(ze.name, strName.c_str(), strName.size()>254 ? 254 : strName.size());

--- a/xbmc/filesystem/posix/PosixFile.cpp
+++ b/xbmc/filesystem/posix/PosixFile.cpp
@@ -150,7 +150,7 @@ ssize_t CPosixFile::Read(void* lpBuf, size_t uiBufSize)
   return res;
 }
 
-int CPosixFile::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CPosixFile::Write(const void* lpBuf, size_t uiBufSize)
 {
   assert(lpBuf != NULL);
   if (m_fd < 0 || !m_allowWrite || !lpBuf)

--- a/xbmc/filesystem/posix/PosixFile.cpp
+++ b/xbmc/filesystem/posix/PosixFile.cpp
@@ -111,11 +111,11 @@ void CPosixFile::Close()
 }
 
 
-unsigned int CPosixFile::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CPosixFile::Read(void* lpBuf, size_t uiBufSize)
 {
   assert(lpBuf != NULL);
   if (m_fd < 0 || !lpBuf)
-    return 0; // TODO: return -1
+    return -1;
   
   if (uiBufSize > SSIZE_MAX)
     uiBufSize = SSIZE_MAX;
@@ -124,7 +124,7 @@ unsigned int CPosixFile::Read(void* lpBuf, int64_t uiBufSize)
   if (res < 0)
   {
     Seek(0, SEEK_CUR); // force update file position
-    return 0; // TODO: return -1
+    return -1;
   }
   
   if (m_filePos >= 0)
@@ -147,7 +147,7 @@ unsigned int CPosixFile::Read(void* lpBuf, int64_t uiBufSize)
 #endif
   }
 
-  return (unsigned int) res;
+  return res;
 }
 
 int CPosixFile::Write(const void* lpBuf, int64_t uiBufSize)

--- a/xbmc/filesystem/posix/PosixFile.h
+++ b/xbmc/filesystem/posix/PosixFile.h
@@ -35,7 +35,7 @@ namespace XFILE
     virtual void Close();
     
     virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
-    virtual int Write(const void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual int Truncate(int64_t size);
     virtual int64_t GetPosition();

--- a/xbmc/filesystem/posix/PosixFile.h
+++ b/xbmc/filesystem/posix/PosixFile.h
@@ -34,7 +34,7 @@ namespace XFILE
     virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
     virtual void Close();
     
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     virtual int Write(const void* lpBuf, int64_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual int Truncate(int64_t size);

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -589,13 +589,11 @@ int udf25::GetUDFCache(UDFCacheType type, uint32_t nr, void *data)
 
 int udf25::ReadAt( int64_t pos, size_t len, unsigned char *data )
 {
-  int64_t ret;
-  ret = m_fp->Seek(pos, SEEK_SET);
-  if(ret != pos)
+  if (m_fp->Seek(pos, SEEK_SET) != pos)
     return -1;
 
-  ret = m_fp->Read(data, len);
-  if(ret < (int64_t)len)
+  ssize_t ret = m_fp->Read(data, len);
+  if ( ret < len)
   {
     CLog::Log(LOGERROR, "udf25::ReadFile - less data than requested available!" );
     return (int)ret;

--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -211,7 +211,7 @@ ssize_t CWin32File::Read(void* lpBuf, size_t uiBufSize)
   return read;
 }
 
-int CWin32File::Write(const void* lpBuf, int64_t uiBufSize)
+ssize_t CWin32File::Write(const void* lpBuf, size_t uiBufSize)
 {
   assert(lpBuf != NULL);
   if (m_hFile == INVALID_HANDLE_VALUE || !lpBuf)
@@ -223,8 +223,10 @@ int CWin32File::Write(const void* lpBuf, int64_t uiBufSize)
     return -1;
   }
 
-  // TODO: fail on oversized uiBufSize
-  int written = 0;
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
+  ssize_t written = 0;
   while (uiBufSize > 0)
   {
     DWORD lastWritten = 0;

--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -173,14 +173,16 @@ void CWin32File::Close()
   m_filepathnameW.clear();
 }
 
-unsigned int CWin32File::Read(void* lpBuf, int64_t uiBufSize)
+ssize_t CWin32File::Read(void* lpBuf, size_t uiBufSize)
 {
   assert(lpBuf != NULL);
   if (m_hFile == INVALID_HANDLE_VALUE || !lpBuf)
-    return 0; // TODO: return -1
+    return -1;
 
-  // TODO: Reduce uiBufSize if required/oversized
-  unsigned int read = 0;
+  if (uiBufSize > SSIZE_MAX)
+    uiBufSize = SSIZE_MAX;
+
+  ssize_t read = 0;
 
   // if uiBufSize is larger than ReadFile() can read at one time (larger than DWORD_MAX)
   // repeat ReadFile until buffer is filled
@@ -190,7 +192,7 @@ unsigned int CWin32File::Read(void* lpBuf, int64_t uiBufSize)
     if (!ReadFile(m_hFile, ((BYTE*)lpBuf) + read, (uiBufSize > DWORD_MAX) ? DWORD_MAX : (DWORD)uiBufSize, &lastRead, NULL))
     {
       m_filePos = -1;
-      return 0; // TODO: return -1
+      return -1;
     }
     read += lastRead;
     // if m_filePos is set - update it

--- a/xbmc/filesystem/win32/Win32File.h
+++ b/xbmc/filesystem/win32/Win32File.h
@@ -36,7 +36,7 @@ namespace XFILE
     virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
     virtual void Close();
 
-    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
     virtual int Write(const void* lpBuf, int64_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual int Truncate(int64_t toSize);

--- a/xbmc/filesystem/win32/Win32File.h
+++ b/xbmc/filesystem/win32/Win32File.h
@@ -37,7 +37,7 @@ namespace XFILE
     virtual void Close();
 
     virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
-    virtual int Write(const void* lpBuf, int64_t uiBufSize);
+    virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
     virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
     virtual int Truncate(int64_t toSize);
     virtual int64_t GetPosition();

--- a/xbmc/guilib/DDSImage.cpp
+++ b/xbmc/guilib/DDSImage.cpp
@@ -138,12 +138,10 @@ bool CDDSImage::WriteFile(const std::string &outputFile) const
     return false;
 
   // write the header
-  file.Write("DDS ", 4);
-  file.Write(&m_desc, sizeof(m_desc));
+  return file.Write("DDS ", 4) == 4 &&
+    file.Write(&m_desc, sizeof(m_desc)) == sizeof(m_desc) &&
   // now the data
-  file.Write(m_data, m_desc.linearSize);
-  file.Close();
-  return true;
+    file.Write(m_data, m_desc.linearSize) == m_desc.linearSize;
 }
 
 unsigned int CDDSImage::GetStorageRequirements(unsigned int width, unsigned int height, unsigned int format)

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -526,15 +526,10 @@ bool CJpegIO::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int wid
     delete [] rgbbuf;
 
   XFILE::CFile file;
-  if (file.OpenForWrite(destFile, true))
-  {
-    file.Write(result, outBufSize);
-    file.Close();
-    free(result);
-    return true;
-  }
+  const bool ret = file.OpenForWrite(destFile, true) && file.Write(result, outBufSize) == outBufSize;
   free(result);
-  return false;
+
+  return ret;
 }
 
 // override libjpeg's error function to avoid an exit() call

--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -39,8 +39,8 @@ namespace XBMCAddon
 
       while(ret.remaining() > 0)
       {
-        int bytesRead = file->Read(ret.curPosition(), ret.remaining());
-        if (bytesRead == 0) // we consider this a failure or a EOF, can't tell which,
+        ssize_t bytesRead = file->Read(ret.curPosition(), ret.remaining());
+        if (bytesRead <= 0) // we consider this a failure or a EOF, can't tell which,
         {                   //  return whatever we have already.
           ret.flip();
           return ret;

--- a/xbmc/interfaces/legacy/File.cpp
+++ b/xbmc/interfaces/legacy/File.cpp
@@ -56,7 +56,7 @@ namespace XBMCAddon
       DelayedCallGuard dg(languageHook);
       while (buffer.remaining() > 0)
       {
-        int bytesWritten = file->Write( buffer.curPosition(), buffer.remaining());
+        ssize_t bytesWritten = file->Write( buffer.curPosition(), buffer.remaining());
         if (bytesWritten == 0)       // this could be a failure (see HDFile, and XFileUtils) or
                                      //  it could mean something else when a negative number means an error
                                      //  (see CCurlFile). There is no consistency so we can only assume we're

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5070,7 +5070,8 @@ void CMusicDatabase::ExportKaraokeInfo(const CStdString & outFile, bool asHTML)
       outdoc = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></meta></head>\n"
           "<body>\n<table>\n";
 
-      file.Write( outdoc, outdoc.size() );
+      if (file.Write(outdoc, outdoc.size()) != outdoc.size())
+        return; // error
     }
 
     while (!m_pDS->eof())
@@ -5083,7 +5084,8 @@ void CMusicDatabase::ExportKaraokeInfo(const CStdString & outFile, bool asHTML)
       else
         outdoc = songnum + '\t' + (CStdString)StringUtils::Join(song.artist, g_advancedSettings.m_musicItemSeparator) + '\t' + song.strTitle + '\t' + song.strFileName + "\r\n";
 
-      file.Write( outdoc, outdoc.size() );
+      if (file.Write(outdoc, outdoc.size()) != outdoc.size())
+        return; // error
 
       if ((current % 50) == 0 && progress)
       {
@@ -5105,7 +5107,8 @@ void CMusicDatabase::ExportKaraokeInfo(const CStdString & outFile, bool asHTML)
     if ( asHTML )
     {
       outdoc = "</table>\n</body>\n</html>\n";
-      file.Write( outdoc, outdoc.size() );
+      if (file.Write(outdoc, outdoc.size()) != outdoc.size())
+        return; // error
     }
 
     file.Close();

--- a/xbmc/music/tags/MusicInfoTagLoaderSPC.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderSPC.cpp
@@ -40,27 +40,47 @@ SPC_ID666 *SPC_get_id666FP (CFile& file)
 
   file.Seek(0x23,SEEK_SET);
   char c;
-  file.Read(&c,1);
-  if (c == 27) {
+  if (file.Read(&c,1) != 1 || c == 27) 
+  {
       free(id);
       return NULL;
   }
 
   file.Seek(0x2E,SEEK_SET);
-  file.Read(id->songname,32);
+  if (file.Read(id->songname, 32) != 32)
+  {
+    free(id);
+    return NULL;
+  }
   id->songname[32] = '\0';
 
-  file.Read(id->gametitle,32);
+  if (file.Read(id->gametitle, 32) != 32)
+  {
+    free(id);
+    return NULL;
+  }
   id->gametitle[32] = '\0';
 
-  file.Read(id->dumper,16);
+  if (file.Read(id->dumper, 16) != 16)
+  {
+    free(id);
+    return NULL;
+  }
   id->dumper[16] = '\0';
 
-  file.Read(id->comments,32);
+  if (file.Read(id->comments, 32) != 32)
+  {
+    free(id);
+    return NULL;
+  }
   id->comments[32] = '\0';
 
   file.Seek(0xA9,SEEK_SET);
-  file.Read(playtime_str,3);
+  if (file.Read(playtime_str, 3) != 3)
+  {
+    free(id);
+    return NULL;
+  }
   playtime_str[3] = '\0';
   id->playtime = atoi((char*)playtime_str);
 
@@ -80,7 +100,11 @@ SPC_ID666 *SPC_get_id666FP (CFile& file)
   }
 
   file.Seek(0xB0,SEEK_SET);
-  file.Read(id->author,32);
+  if (file.Read(id->author, 32) != 32)
+  {
+    free(id);
+    return NULL;
+  }
   id->author[32] = '\0';
 
   return id;

--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -76,7 +76,12 @@ FileName TagLibVFSStream::name() const
 ByteVector TagLibVFSStream::readBlock(TagLib::ulong length)
 {
   ByteVector byteVector(static_cast<TagLib::uint>(length));
-  byteVector.resize(m_file.Read(byteVector.data(), length));
+  ssize_t read = m_file.Read(byteVector.data(), length);
+  if (read > 0)
+    byteVector.resize(read);
+  else
+    byteVector.clear();
+
   return byteVector;
 }
 
@@ -142,7 +147,9 @@ void TagLibVFSStream::insert(const ByteVector &data, TagLib::ulong start, TagLib
   // special case.  We're also using File::writeBlock() just for the tag.
   // That's a bit slower than using char *'s so, we're only doing it here.
   seek(readPosition);
-  int bytesRead = m_file.Read(aboutToOverwrite.data(), bufferLength);
+  ssize_t bytesRead = m_file.Read(aboutToOverwrite.data(), bufferLength);
+  if (bytesRead <= 0)
+    return; // error
   readPosition += bufferLength;
 
   seek(writePosition);
@@ -160,6 +167,8 @@ void TagLibVFSStream::insert(const ByteVector &data, TagLib::ulong start, TagLib
     // to overwrite.  Appropriately increment the readPosition.
     seek(readPosition);
     bytesRead = m_file.Read(aboutToOverwrite.data(), bufferLength);
+    if (bytesRead <= 0)
+      return; // error
     aboutToOverwrite.resize(bytesRead);
     readPosition += bufferLength;
 

--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -180,7 +180,8 @@ void TagLibVFSStream::insert(const ByteVector &data, TagLib::ulong start, TagLib
     // Seek to the write position and write our buffer.  Increment the
     // writePosition.
     seek(writePosition);
-    m_file.Write(buffer.data(), buffer.size());
+    if (m_file.Write(buffer.data(), buffer.size()) < buffer.size())
+      return; // error
     writePosition += buffer.size();
 
     buffer = aboutToOverwrite;
@@ -218,7 +219,8 @@ void TagLibVFSStream::removeBlock(TagLib::ulong start, TagLib::ulong length)
       clear();
 
     seek(writePosition);
-    m_file.Write(buffer.data(), bytesRead);
+    if (m_file.Write(buffer.data(), bytesRead) != bytesRead)
+      return; // error
     writePosition += bytesRead;
   }
   truncate(writePosition);

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -171,10 +171,8 @@ void CAirTunesServer::SetCoverArtFromBuffer(const char *buffer, unsigned int siz
     writtenBytes = tmpFile.Write(buffer, size);
     tmpFile.Close();
 
-    if(writtenBytes)
-    {
+    if (writtenBytes > 0)
       RefreshCoverArt();
-    }
   }
 }
 

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -322,12 +322,7 @@ bool CEventClient::OnPacketHELO(CEventPacket *packet)
       break;
     }
     XFILE::CFile file;
-    if (file.OpenForWrite(iconfile, true))
-    {
-      file.Write((const void *)payload, psize);
-      file.Close();
-    }
-    else
+    if (!file.OpenForWrite(iconfile, true) || file.Write((const void *)payload, psize) != psize)
     {
       CLog::Log(LOGERROR, "ES: Could not write icon file");
       m_eLogoType = LT_NONE;
@@ -596,12 +591,7 @@ bool CEventClient::OnPacketNOTIFICATION(CEventPacket *packet)
     }
 
     XFILE::CFile file;
-    if (file.OpenForWrite(iconfile, true))
-    {
-      file.Write((const void *)payload, psize);
-      file.Close();
-    }
-    else
+    if (!file.OpenForWrite(iconfile, true) || file.Write((const void *)payload, psize) != psize)
     {
       CLog::Log(LOGERROR, "ES: Could not write icon file");
       m_eLogoType = LT_NONE;

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -705,8 +705,8 @@ int CWebServer::ContentReaderCallback(void *cls, size_t pos, char *buf, int max)
     context->file->Seek(context->writePosition);
 
   // read data from the file
-  unsigned int res = context->file->Read(buf, maximum);
-  if (res == 0)
+  ssize_t res = context->file->Read(buf, maximum);
+  if (res <= 0)
     return -1;
 
   // add the number of read bytes to the number of written bytes

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -65,17 +65,11 @@ bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width
   }
 
   XFILE::CFile file;
-  if (file.OpenForWrite(thumbFile, true))
-  {
-    file.Write(thumb, thumbsize);
-    file.Close();
-    pImage->ReleaseThumbnailBuffer();
-    delete pImage;
-    return true;
-  }
+  const bool ret = file.OpenForWrite(thumbFile, true) && file.Write(thumb, thumbsize) == thumbsize;
   pImage->ReleaseThumbnailBuffer();
   delete pImage;
-  return false;
+
+  return ret;
 }
 
 CThumbnailWriter::CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const CStdString& thumbFile)

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -200,14 +200,17 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     return;
   }
   std::string strLine = StringUtils::Format("%s\n",M3U_START_MARKER);
-  file.Write(strLine.c_str(),strLine.size());
+  if (file.Write(strLine.c_str(), strLine.size()) != strLine.size())
+    return; // error
+
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     CFileItemPtr item = m_vecItems[i];
     std::string strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
     strLine = StringUtils::Format( "%s:%i,%s\n", M3U_INFO_MARKER, item->GetMusicInfoTag()->GetDuration() / 1000, strDescription.c_str() );
-    file.Write(strLine.c_str(),strLine.size());
+    if (file.Write(strLine.c_str(), strLine.size()) != strLine.size())
+      return; // error
     if (item->m_lStartOffset != 0 || item->m_lEndOffset != 0)
     {
       strLine = StringUtils::Format("%s:%i,%i\n", M3U_OFFSET_MARKER, item->m_lStartOffset, item->m_lEndOffset);
@@ -216,7 +219,8 @@ void CPlayListM3U::Save(const std::string& strFileName) const
     std::string strFileName = ResolveURL(item);
     g_charsetConverter.utf8ToStringCharset(strFileName);
     strLine = StringUtils::Format("%s\n",strFileName.c_str());
-    file.Write(strLine.c_str(),strLine.size());
+    if (file.Write(strLine.c_str(), strLine.size()) != strLine.size())
+      return; // error
   }
   file.Close();
 }

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -377,9 +377,13 @@ void CArchive::FlushBuffer()
 {
   if (m_iMode == store && m_BufferPos != m_pBuffer)
   {
-    m_pFile->Write(m_pBuffer, m_BufferPos - m_pBuffer);
-    m_BufferPos = m_pBuffer;
-    m_BufferRemain = CARCHIVE_BUFFER_MAX;
+    if (m_pFile->Write(m_pBuffer, m_BufferPos - m_pBuffer) != m_BufferPos - m_pBuffer)
+      CLog::Log(LOGERROR, "%s: Error flushing buffer", __FUNCTION__);
+    else
+    {
+      m_BufferPos = m_pBuffer;
+      m_BufferRemain = CARCHIVE_BUFFER_MAX;
+    }
   }
 }
 

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -402,8 +402,12 @@ void CArchive::FillBuffer()
 {
   if (m_iMode == load && m_BufferRemain == 0)
   {
-    m_BufferRemain = m_pFile->Read(m_pBuffer, CARCHIVE_BUFFER_MAX);
-    m_BufferPos = m_pBuffer;
+    ssize_t read = m_pFile->Read(m_pBuffer, CARCHIVE_BUFFER_MAX);
+    if (read > 0)
+    {
+      m_BufferRemain = read;
+      m_BufferPos = m_pBuffer;
+    }
   }
 }
 

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -307,9 +307,8 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
     std::string strCachePath = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
                               "scrapers/" + cacheContext + "/" + scrURL.m_cache);
     XFILE::CFile file;
-    if (file.OpenForWrite(strCachePath,true))
-      file.Write(strHTML.data(),strHTML.size());
-    file.Close();
+    if (!file.OpenForWrite(strCachePath, true) || file.Write(strHTML.data(), strHTML.size()) != strHTML.size())
+      return false;
   }
   return true;
 }

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -122,8 +122,7 @@ bool CXBMCTinyXML::SaveFile(const std::string& filename) const
   {
     TiXmlPrinter printer;
     Accept(&printer);
-    file.Write(printer.CStr(), printer.Size());
-    return true;
+    return file.Write(printer.CStr(), printer.Size()) == printer.Size();
   }
   return false;
 }


### PR DESCRIPTION
To be used in conjunction with PR #4961.

Added many checks for `Read()` and `Write()` results.
Note that currently some of `Read()` implementations may return `-1` which is not always checked as it casted to unsigned value.
