### PR TITLE
Relax tv show matching for names without season

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -292,12 +292,14 @@ GTEST_LIBS = $(GTEST_DIR)/lib/.libs/libgtest.a
 CHECK_DIRS = xbmc/addons/test \
              xbmc/filesystem/test \
              xbmc/utils/test \
+             xbmc/video/test \
              xbmc/threads/test \
              xbmc/interfaces/python/test \
              xbmc/test
 CHECK_LIBS = xbmc/addons/test/addonsTest.a \
              xbmc/filesystem/test/filesystemTest.a \
              xbmc/utils/test/utilsTest.a \
+             xbmc/video/test/videoTest.a \
              xbmc/threads/test/threadTest.a \
              xbmc/interfaces/python/test/pythonSwigTest.a \
              xbmc/test/xbmc-test.a

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -226,8 +226,8 @@ void CAdvancedSettings::Initialize()
   m_tvshowEnumRegExps.clear();
   // foo.s01.e01, foo.s01_e01, S01E02 foo, S01 - E02
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"s([0-9]+)[ ._-]*e([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
-  // foo.ep01, foo.EP_01
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\._ -]()ep_?([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
+  // foo.ep01, foo.EP_01, foo.E01
+  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\._ -]()e(?:p[ ._-]?)?([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
   // foo.yyyy.mm.dd.* (byDate=true)
   m_tvshowEnumRegExps.push_back(TVShowRegexp(true,"([0-9]{4})[\\.-]([0-9]{2})[\\.-]([0-9]{2})"));
   // foo.mm.dd.yyyy.* (byDate=true)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -236,8 +236,8 @@ void CAdvancedSettings::Initialize()
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
   // foo.103*, 103 foo
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ -]([0-9]+)([0-9][0-9](?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([\\._ -][^\\\\/]*)$"));
-  // Part I, Pt.VI
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\/._ -]p(?:ar)?t[_. -]()([ivx]+)([._ -][^\\/]*)$"));
+  // Part I, Pt.VI, Part 1
+  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\/._ -]p(?:ar)?t[_. -]()([ivx]+|[0-9]+)([._ -][^\\/]*)$"));
 
   m_tvshowMultiPartEnumRegExp = "^[-_ex]+([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)";
 

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -120,6 +120,8 @@ namespace VIDEO
     static std::string GetImage(CFileItem *pItem, bool useLocal, bool bApplyToDir, const std::string &type = "");
     static std::string GetFanart(CFileItem *pItem, bool useLocal);
 
+    bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
+
   protected:
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
@@ -229,7 +231,6 @@ namespace VIDEO
     INFO_RET OnProcessSeriesFolder(EPISODELIST& files, const ADDON::ScraperPtr &scraper, bool useLocal, const CVideoInfoTag& showInfo, CGUIDialogProgress* pDlgProgress = NULL);
 
     bool EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList);
-    bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
     bool ProcessItemByVideoInfoTag(const CFileItem *item, EPISODELIST &episodeList);
 
     CStdString GetnfoFile(CFileItem *item, bool bGrabAny=false) const;

--- a/xbmc/video/test/Makefile
+++ b/xbmc/video/test/Makefile
@@ -1,0 +1,9 @@
+SRCS= \
+  TestVideoInfoScanner.cpp
+
+LIB=videoTest.a
+
+INCLUDES += -I../../../lib/gtest/include
+
+include ../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/video/test/TestVideoInfoScanner.cpp
+++ b/xbmc/video/test/TestVideoInfoScanner.cpp
@@ -1,0 +1,67 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "video/VideoInfoScanner.h"
+#include "FileItem.h"
+#include "gtest/gtest.h"
+
+using namespace VIDEO;
+using ::testing::Test;
+using ::testing::WithParamInterface;
+using ::testing::ValuesIn;
+
+typedef struct
+{
+  const char* path;
+  int season;
+  int episode;
+} TestEntry;
+
+static const TestEntry TestData[] = {
+  //season+episode
+  {"foo.S02E03.mkv",   2, 3},
+  {"foo.203.mkv",      2, 3},
+  //episode only
+  {"foo.Ep03.mkv",     1, 3},
+  {"foo.Ep_03.mkv",    1, 3},
+  {"foo.Part.III.mkv", 1, 3},
+  {"foo.Part.3.mkv",   1, 3},
+  {"foo.E03.mkv",      1, 3},
+  {"foo.2009.E03.mkv", 1, 3},
+};
+
+class TestVideoInfoScanner : public Test,
+                             public WithParamInterface<TestEntry>
+{
+};
+
+TEST_P(TestVideoInfoScanner, EnumerateEpisodeItem)
+{
+  const TestEntry& entry = GetParam();
+  CVideoInfoScanner scanner;
+  CFileItem item(entry.path, false);
+  EPISODE expected(entry.season, entry.episode, 0, false);
+
+  EPISODELIST result;
+  ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
+  EXPECT_TRUE(expected == result[0]);
+}
+
+INSTANTIATE_TEST_CASE_P(VideoInfoScanner, TestVideoInfoScanner, ValuesIn(TestData));


### PR DESCRIPTION
This allows names on the format `foo.E01` and `foo.Part.1` to be parsed. Both common naming schemes especially for miniseries and such.

This should be added to xbmc because it's not a trivial to do in advancedsettings.xml without copy pasting from source code. I.e to parse foo.E01 properly it _must_ be added after foo.s01.e01 buf before foo.103*, otherwise the year will interfere. Currently, xbmc will incorrectly parse foo.E01.2009 as season 20 episode 9.
