### PR TITLE
ActiveAE: add advanced setting for forcing multichannel layout

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1446,8 +1446,12 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
     // 2. stereo upmix is selected
     // 3. fixed mode
 
+    // g_advancedSettings.m_audioFixedMultichannelLayout is for e.g.
+    // Anthem Statement D2 audio processor which only supports 2.0 and 5.1 properly
+
     bool useFixedLayout = (m_settings.config == AE_CONFIG_FIXED)
-                       || (settings.stereoupmix && format.m_channelLayout.Count() <= 2);
+                       || (settings.stereoupmix && format.m_channelLayout.Count() <= 2)
+                       || (g_advancedSettings.m_audioFixedMultichannelLayout && format.m_channelLayout.Count() > 2);
 
     if (format.m_channelLayout.Count() > 2 || useFixedLayout)
     {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1440,13 +1440,16 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
   else
   {
     format.m_dataFormat = AE_IS_PLANAR(format.m_dataFormat) ? AE_FMT_FLOATP : AE_FMT_FLOAT;
+
     // consider user channel layout for those cases
     // 1. input stream is multichannel
     // 2. stereo upmix is selected
     // 3. fixed mode
-    if ((format.m_channelLayout.Count() > 2) ||
-         settings.stereoupmix ||
-         (settings.config == AE_CONFIG_FIXED))
+
+    bool useFixedLayout = (m_settings.config == AE_CONFIG_FIXED)
+                       || (settings.stereoupmix && format.m_channelLayout.Count() <= 2);
+
+    if (format.m_channelLayout.Count() > 2 || useFixedLayout)
     {
       CAEChannelInfo stdLayout;
       switch (settings.channels)
@@ -1465,7 +1468,7 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
         case 10: stdLayout = AE_CH_LAYOUT_7_1; break;
       }
 
-      if (m_settings.config == AE_CONFIG_FIXED || (settings.stereoupmix && format.m_channelLayout.Count() <= 2))
+      if (useFixedLayout)
         format.m_channelLayout = stdLayout;
       else if (m_extKeepConfig && (settings.config == AE_CONFIG_AUTO) && (oldMode != MODE_RAW))
         format.m_channelLayout = m_internalFormat.m_channelLayout;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -108,6 +108,7 @@ void CAdvancedSettings::Initialize()
   m_audioHeadRoom = 0;
   m_ac3Gain = 12.0f;
   m_audioApplyDrc = true;
+  m_audioFixedMultichannelLayout = false;
   m_dvdplayerIgnoreDTSinWAV = false;
 
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
@@ -500,6 +501,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
       GetCustomRegexps(pAudioExcludes, m_audioExcludeFromScanRegExps);
 
     XMLUtils::GetBoolean(pElement, "applydrc", m_audioApplyDrc);
+    XMLUtils::GetBoolean(pElement, "fixedmultichannellayout", m_audioFixedMultichannelLayout);
     XMLUtils::GetBoolean(pElement, "dvdplayerignoredtsinwav", m_dvdplayerIgnoreDTSinWAV);
 
     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -177,6 +177,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoIgnoreSecondsAtStart;
     float m_videoIgnorePercentAtEnd;
     bool m_audioApplyDrc;
+    bool m_audioFixedMultichannelLayout;
 
     int   m_videoVDPAUScaling;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
Anthem Statement D2 audio processor only supports 2.0 and 5.1 HDMI
playback properly, causing completely silent output if playback of e.g.
a 4.0 audio stream is being done.

Add "audio.fixedmultichannellayout" advanced setting for forcing the use
of the user-specified layout in audio settings for multichannel streams
in case the user has equipment that does not support all intermediate
layouts properly.
Stereo streams will continue to be played back as stereo and no
resampling is done.

Reported by Grant Warecki (gjwAudio).

@fritsch, @FernetMenta, WDYT? This basically becomes a oneliner in ApplySettingsToFormat() so IMHO it does not pollute the code too badly for a fix for obscure devices...
