### PR TITLE
[pvr] adjust labels and refactoring for setting 'pvrplayback.startlast'

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8166,6 +8166,7 @@ msgctxt "#19189"
 msgid "Continue last channel on startup"
 msgstr ""
 
+#: system/settings/settings.xml
 msgctxt "#19190"
 msgid "Background"
 msgstr ""
@@ -8595,7 +8596,7 @@ msgctxt "#19286"
 msgid "Searching for channel icons"
 msgstr ""
 
-#: xbmc/pvr/PVRManager.cpp
+#: system/settings/settings.xml
 msgctxt "#19288"
 msgid "Foreground"
 msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8167,7 +8167,7 @@ msgid "Continue last channel on startup"
 msgstr ""
 
 msgctxt "#19190"
-msgid "Minimised"
+msgid "Background"
 msgstr ""
 
 msgctxt "#19191"
@@ -8595,7 +8595,12 @@ msgctxt "#19286"
 msgid "Searching for channel icons"
 msgstr ""
 
-#empty strings from id 19287 to 19498
+#: xbmc/pvr/PVRManager.cpp
+msgctxt "#19288"
+msgid "Foreground"
+msgstr ""
+
+#empty strings from id 19289 to 19498
 
 #: xbmc/epg/Epg.cpp
 msgctxt "#19499"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1240,12 +1240,12 @@
         </setting>
         <setting id="pvrplayback.startlast" type="integer" label="19189" help="36228">
           <level>1</level>
-          <default>0</default> <!-- START_LAST_CHANNEL_OFF -->
+          <default>0</default> <!-- CONTINUE_LAST_CHANNEL_OFF -->
           <constraints>
             <options>
-              <option label="106">0</option>   <!-- START_LAST_CHANNEL_OFF -->
-              <option label="19190">1</option> <!-- START_LAST_CHANNEL_IN_BACKGROUND -->
-              <option label="19288">2</option> <!-- START_LAST_CHANNEL_IN_FOREGROUND -->
+              <option label="106">0</option>   <!-- CONTINUE_LAST_CHANNEL_OFF -->
+              <option label="19190">1</option> <!-- CONTINUE_LAST_CHANNEL_IN_BACKGROUND -->
+              <option label="19288">2</option> <!-- CONTINUE_LAST_CHANNEL_IN_FOREGROUND -->
             </options>
           </constraints>
           <control type="spinner" format="string" />

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1242,10 +1242,11 @@
           <level>1</level>
           <default>0</default> <!-- START_LAST_CHANNEL_OFF -->
           <constraints>
-            <minimum>0</minimum>
-            <step>1</step>
-            <maximum>2</maximum>
-            <options>pvrstartlastchannel</options>
+            <options>
+              <option label="106">0</option>   <!-- START_LAST_CHANNEL_OFF -->
+              <option label="19190">1</option> <!-- START_LAST_CHANNEL_IN_BACKGROUND -->
+              <option label="19288">2</option> <!-- START_LAST_CHANNEL_IN_FOREGROUND -->
+            </options>
           </constraints>
           <control type="spinner" format="string" />
         </setting>

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1544,13 +1544,6 @@ bool CPVRManager::OnAction(const CAction &action)
   return false;
 }
 
-void CPVRManager::SettingOptionsPvrStartLastChannelFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
-{
-  list.push_back(make_pair(g_localizeStrings.Get(106), PVR::START_LAST_CHANNEL_OFF));
-  list.push_back(make_pair(g_localizeStrings.Get(19190), PVR::START_LAST_CHANNEL_IN_BACKGROUND));
-  list.push_back(make_pair(g_localizeStrings.Get(19288), PVR::START_LAST_CHANNEL_IN_FOREGROUND));
-}
-
 bool CPVRChannelSwitchJob::DoWork(void)
 {
   // announce OnStop and delete m_previous when done

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -661,7 +661,7 @@ bool CPVRManager::ChannelUpDown(unsigned int *iNewChannelNumber, bool bPreview, 
 
 bool CPVRManager::ContinueLastChannel(void)
 {
-  if (CSettings::Get().GetInt("pvrplayback.startlast") == START_LAST_CHANNEL_OFF)
+  if (CSettings::Get().GetInt("pvrplayback.startlast") == CONTINUE_LAST_CHANNEL_OFF)
     return false;
 
   CFileItemPtr channel = m_channelGroups->GetLastPlayedChannel();
@@ -669,7 +669,7 @@ bool CPVRManager::ContinueLastChannel(void)
   {
     CLog::Log(LOGNOTICE, "PVRManager - %s - continue playback on channel '%s'", __FUNCTION__, channel->GetPVRChannelInfoTag()->ChannelName().c_str());
     SetPlayingGroup(m_channelGroups->GetLastPlayedGroup());
-    StartPlayback(channel->GetPVRChannelInfoTag(), (CSettings::Get().GetInt("pvrplayback.startlast") == START_LAST_CHANNEL_IN_BACKGROUND));
+    StartPlayback(channel->GetPVRChannelInfoTag(), (CSettings::Get().GetInt("pvrplayback.startlast") == CONTINUE_LAST_CHANNEL_IN_BACKGROUND));
     return true;
   }
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1143,9 +1143,9 @@ bool CPVRManager::UpdateItem(CFileItem& item)
   return false;
 }
 
-bool CPVRManager::StartPlayback(const CPVRChannel *channel, bool bPreview /* = false */)
+bool CPVRManager::StartPlayback(const CPVRChannel *channel, bool bMinimised /* = false */)
 {
-  CMediaSettings::Get().SetVideoStartWindowed(bPreview);
+  CMediaSettings::Get().SetVideoStartWindowed(bMinimised);
   CApplicationMessenger::Get().MediaPlay(CFileItem(*channel));
   CLog::Log(LOGNOTICE, "PVRManager - %s - started playback on channel '%s'",
       __FUNCTION__, channel->ChannelName().c_str());

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -669,7 +669,7 @@ bool CPVRManager::ContinueLastChannel(void)
   {
     CLog::Log(LOGNOTICE, "PVRManager - %s - continue playback on channel '%s'", __FUNCTION__, channel->GetPVRChannelInfoTag()->ChannelName().c_str());
     SetPlayingGroup(m_channelGroups->GetLastPlayedGroup());
-    StartPlayback(channel->GetPVRChannelInfoTag(), (CSettings::Get().GetInt("pvrplayback.startlast") == START_LAST_CHANNEL_MIN));
+    StartPlayback(channel->GetPVRChannelInfoTag(), (CSettings::Get().GetInt("pvrplayback.startlast") == START_LAST_CHANNEL_IN_BACKGROUND));
     return true;
   }
 
@@ -1546,9 +1546,9 @@ bool CPVRManager::OnAction(const CAction &action)
 
 void CPVRManager::SettingOptionsPvrStartLastChannelFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
 {
-  list.push_back(make_pair(g_localizeStrings.Get(106),   PVR::START_LAST_CHANNEL_OFF));
-  list.push_back(make_pair(g_localizeStrings.Get(19190), PVR::START_LAST_CHANNEL_MIN));
-  list.push_back(make_pair(g_localizeStrings.Get(107),   PVR::START_LAST_CHANNEL_ON));
+  list.push_back(make_pair(g_localizeStrings.Get(106), PVR::START_LAST_CHANNEL_OFF));
+  list.push_back(make_pair(g_localizeStrings.Get(19190), PVR::START_LAST_CHANNEL_IN_BACKGROUND));
+  list.push_back(make_pair(g_localizeStrings.Get(19288), PVR::START_LAST_CHANNEL_IN_FOREGROUND));
 }
 
 bool CPVRChannelSwitchJob::DoWork(void)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -552,8 +552,6 @@ namespace PVR
      */
     bool OnAction(const CAction &action);
 
-    static void SettingOptionsPvrStartLastChannelFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
-
     /*!
      * @brief Create EPG tags for all channels in internal channel groups
      * @return True if EPG tags where created successfully, false otherwise

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -448,10 +448,10 @@ namespace PVR
     /*!
      * @brief Start playback on a channel.
      * @param channel The channel to start to play.
-     * @param bPreview If true, open minimised.
+     * @param bMinimised If true, playback starts minimised, otherwise in fullscreen.
      * @return True if playback was started, false otherwise.
      */
-    bool StartPlayback(const CPVRChannel *channel, bool bPreview = false);
+    bool StartPlayback(const CPVRChannel *channel, bool bMinimised = false);
 
     /*!
      * @brief Start playback of the last used channel, and if it fails use first channel in the current channelgroup.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -70,11 +70,11 @@ namespace PVR
     PlaybackTypeRadio
   };
 
-  enum ChannelStartLast
+  enum ContinueLastChannelOnStartup
   {
-    START_LAST_CHANNEL_OFF  = 0,
-    START_LAST_CHANNEL_IN_BACKGROUND,
-    START_LAST_CHANNEL_IN_FOREGROUND
+    CONTINUE_LAST_CHANNEL_OFF  = 0,
+    CONTINUE_LAST_CHANNEL_IN_BACKGROUND,
+    CONTINUE_LAST_CHANNEL_IN_FOREGROUND
   };
 
   #define g_PVRManager       CPVRManager::Get()

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -73,8 +73,8 @@ namespace PVR
   enum ChannelStartLast
   {
     START_LAST_CHANNEL_OFF  = 0,
-    START_LAST_CHANNEL_MIN,
-    START_LAST_CHANNEL_ON
+    START_LAST_CHANNEL_IN_BACKGROUND,
+    START_LAST_CHANNEL_IN_FOREGROUND
   };
 
   #define g_PVRManager       CPVRManager::Get()

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -233,7 +233,6 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("fontheights");
   m_settingsManager->UnregisterSettingOptionsFiller("fonts");
   m_settingsManager->UnregisterSettingOptionsFiller("languages");
-  m_settingsManager->UnregisterSettingOptionsFiller("pvrstartlastchannel");
   m_settingsManager->UnregisterSettingOptionsFiller("refreshchangedelays");
   m_settingsManager->UnregisterSettingOptionsFiller("refreshrates");
   m_settingsManager->UnregisterSettingOptionsFiller("regions");
@@ -579,7 +578,6 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("epgguideviews", PVR::CGUIWindowPVRGuide::SettingOptionsEpgGuideViewFiller);
   m_settingsManager->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("languages", CLangInfo::SettingOptionsLanguagesFiller);
-  m_settingsManager->RegisterSettingOptionsFiller("pvrstartlastchannel", PVR::CPVRManager::SettingOptionsPvrStartLastChannelFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   m_settingsManager->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
   m_settingsManager->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);


### PR DESCRIPTION
I adjust the current used labels _Minimised_ and _Yes_ for the setting _Continue last channel on startup_ to _Background_ and _Foreground_, so they will be more suitable in case a user choose one of this options.

Apart from the label changes, I also change the current implementation for the setting. I removed the filler method and add the option directly to the settings.xml, which saves some lines in PVRManager.
