### PR TITLE
[pvr] setting: enable option 'Close channel OSD after switching channels' by default

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1128,7 +1128,7 @@
         </setting>
         <setting id="pvrmenu.closechannelosdonswitch" type="boolean" label="19229" help="36214">
           <level>2</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
       </group>


### PR DESCRIPTION
This PR enables the setting _Close channel OSD after switching channels_ because it is a more user-friendly behavior.
