### PR TITLE
CStdString removal part1

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5271,7 +5271,7 @@ void CApplication::Restart(bool bSamePosition)
     m_pPlayer->SetPlayerState(state);
 }
 
-const CStdString& CApplication::CurrentFile()
+const std::string& CApplication::CurrentFile()
 {
   return m_itemCurrentFile->GetPath();
 }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -154,7 +154,7 @@ public:
   void UnloadSkin(bool forReload = false);
   bool LoadUserWindows();
   void ReloadSkin(bool confirm = false);
-  const CStdString& CurrentFile();
+  const std::string& CurrentFile();
   CFileItem& CurrentFileItem();
   CFileItem& CurrentUnstackedItem();
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -60,6 +60,7 @@
 #include "storage/MediaManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "threads/SingleLock.h"
+#include "URL.h"
 
 #include "playlists/PlayList.h"
 
@@ -406,13 +407,13 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
         if (URIUtils::IsZIP(pMsg->strParam) || URIUtils::IsRAR(pMsg->strParam)) // actually a cbz/cbr
         {
           CFileItemList items;
-          CStdString strPath;
+          CURL pathToUrl;
           if (URIUtils::IsZIP(pMsg->strParam))
-            URIUtils::CreateArchivePath(strPath, "zip", pMsg->strParam.c_str(), "");
+            pathToUrl = URIUtils::CreateArchivePath("zip", CURL(pMsg->strParam), "");
           else
-            URIUtils::CreateArchivePath(strPath, "rar", pMsg->strParam.c_str(), "");
+            pathToUrl = URIUtils::CreateArchivePath("rar", CURL(pMsg->strParam), "");
 
-          CUtil::GetRecursiveListing(strPath, items, g_advancedSettings.m_pictureExtensions, XFILE::DIR_FLAG_NO_FILE_DIRS);
+          CUtil::GetRecursiveListing(pathToUrl.Get(), items, g_advancedSettings.m_pictureExtensions, XFILE::DIR_FLAG_NO_FILE_DIRS);
           if (items.Size() > 0)
           {
             pSlideShow->Reset();

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -366,7 +366,7 @@ bool CCueDocument::ResolvePath(CStdString &strPath, const CStdString &strBase)
     CDirectory::GetDirectory(strDirectory,items);
     for (int i=0;i<items.Size();++i)
     {
-      if (items[i]->GetPath().Equals(strPath))
+      if (items[i]->IsPath(strPath))
       {
         strPath = items[i]->GetPath();
         return true;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -84,7 +84,7 @@ CFileItem::CFileItem(const CURL &url, const CAlbum& album)
   SetFromAlbum(album);
 }
 
-CFileItem::CFileItem(const CStdString &path, const CAlbum& album)
+CFileItem::CFileItem(const std::string &path, const CAlbum& album)
 {
   Initialize();
 
@@ -142,8 +142,7 @@ CFileItem::CFileItem(const CPVRChannel& channel)
   SetLabel(channel.ChannelName());
   m_strLabel2 = bHasEpgNow ? epgNow.Title() :
       CSettings::Get().GetBool("epg.hidenoinfoavailable") ?
-        StringUtils::EmptyString :
-        g_localizeStrings.Get(19055); // no information available
+                            "" : g_localizeStrings.Get(19055); // no information available
 
   if (channel.IsRadio())
   {
@@ -252,7 +251,7 @@ CFileItem::CFileItem(void)
   Initialize();
 }
 
-CFileItem::CFileItem(const CStdString& strLabel)
+CFileItem::CFileItem(const std::string& strLabel)
     : CGUIListItem()
 {
   Initialize();
@@ -270,7 +269,7 @@ CFileItem::CFileItem(const CURL& path, bool bIsFolder)
   FillInMimeType(false);
 }
 
-CFileItem::CFileItem(const CStdString& strPath, bool bIsFolder)
+CFileItem::CFileItem(const std::string& strPath, bool bIsFolder)
 {
   Initialize();
   m_strPath = strPath;
@@ -289,7 +288,7 @@ CFileItem::CFileItem(const CMediaSource& share)
   m_strPath = share.strPath;
   if (!IsRSS()) // no slash at end for rss feeds
     URIUtils::AddSlashAtEnd(m_strPath);
-  CStdString label = share.strName;
+  std::string label = share.strName;
   if (!share.strStatus.empty())
     label = StringUtils::Format("%s (%s)", share.strName.c_str(), share.strStatus.c_str());
   SetLabel(label);
@@ -685,7 +684,7 @@ void CFileItem::ToSortable(SortItem &sortable, const Fields &fields) const
 bool CFileItem::Exists(bool bUseCache /* = true */) const
 {
   if (m_strPath.empty()
-   || m_strPath.Equals("add")
+   || IsPath("add")
    || IsInternetStream()
    || IsParentFolder()
    || IsVirtualDirectoryRoot()
@@ -698,7 +697,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
     return dbItem.Exists();
   }
 
-  CStdString strPath = m_strPath;
+  std::string strPath = m_strPath;
 
   if (URIUtils::IsMultiPath(strPath))
     strPath = CMultiPathDirectory::GetFirstPath(strPath);
@@ -728,13 +727,13 @@ bool CFileItem::IsVideo() const
   if (IsHDHomeRun() || IsTuxBox() || URIUtils::IsDVD(m_strPath) || IsSlingbox())
     return true;
 
-  CStdString extension;
+  std::string extension;
   if( StringUtils::StartsWithNoCase(m_mimetype, "application/") )
   { /* check for some standard types */
     extension = m_mimetype.substr(12);
-    if( extension.Equals("ogg")
-     || extension.Equals("mp4")
-     || extension.Equals("mxf") )
+    if( StringUtils::EqualsNoCase(extension, "ogg")
+     || StringUtils::EqualsNoCase(extension, "mp4")
+     || StringUtils::EqualsNoCase(extension, "mxf") )
      return true;
   }
 
@@ -789,10 +788,10 @@ bool CFileItem::IsAudio() const
 
   if( StringUtils::StartsWithNoCase(m_mimetype, "application/") )
   { /* check for some standard types */
-    CStdString extension = m_mimetype.substr(12);
-    if( extension.Equals("ogg")
-     || extension.Equals("mp4")
-     || extension.Equals("mxf") )
+    std::string extension = m_mimetype.substr(12);
+    if( StringUtils::EqualsNoCase(extension, "ogg")
+     || StringUtils::EqualsNoCase(extension, "mp4")
+     || StringUtils::EqualsNoCase(extension, "mxf") )
      return true;
   }
 
@@ -927,15 +926,15 @@ bool CFileItem::IsOpticalMediaFile() const
 
 bool CFileItem::IsDVDFile(bool bVobs /*= true*/, bool bIfos /*= true*/) const
 {
-  CStdString strFileName = URIUtils::GetFileName(m_strPath);
+  std::string strFileName = URIUtils::GetFileName(m_strPath);
   if (bIfos)
   {
-    if (strFileName.Equals("video_ts.ifo")) return true;
+    if (StringUtils::EqualsNoCase(strFileName, "video_ts.ifo")) return true;
     if (StringUtils::StartsWithNoCase(strFileName, "vts_") && StringUtils::EndsWithNoCase(strFileName, "_0.ifo") && strFileName.length() == 12) return true;
   }
   if (bVobs)
   {
-    if (strFileName.Equals("video_ts.vob")) return true;
+    if (StringUtils::EqualsNoCase(strFileName, "video_ts.vob")) return true;
     if (StringUtils::StartsWithNoCase(strFileName, "vts_") && StringUtils::EndsWithNoCase(strFileName, ".vob")) return true;
   }
 
@@ -944,8 +943,8 @@ bool CFileItem::IsDVDFile(bool bVobs /*= true*/, bool bIfos /*= true*/) const
 
 bool CFileItem::IsBDFile() const
 {
-  CStdString strFileName = URIUtils::GetFileName(m_strPath);
-  return (strFileName.Equals("index.bdmv"));
+  std::string strFileName = URIUtils::GetFileName(m_strPath);
+  return (StringUtils::EqualsNoCase(strFileName, "index.bdmv"));
 }
 
 bool CFileItem::IsRAR() const
@@ -1244,7 +1243,7 @@ void CFileItem::RemoveExtension()
 {
   if (m_bIsFolder)
     return;
-  CStdString strLabel = GetLabel();
+  std::string strLabel = GetLabel();
   URIUtils::RemoveExtension(strLabel);
   SetLabel(strLabel);
 }
@@ -1254,13 +1253,13 @@ void CFileItem::CleanString()
   if (IsLiveTV())
     return;
 
-  CStdString strLabel = GetLabel();
-  CStdString strTitle, strTitleAndYear, strYear;
+  std::string strLabel = GetLabel();
+  std::string strTitle, strTitleAndYear, strYear;
   CUtil::CleanString(strLabel, strTitle, strTitleAndYear, strYear, true );
   SetLabel(strTitleAndYear);
 }
 
-void CFileItem::SetLabel(const CStdString &strLabel)
+void CFileItem::SetLabel(const std::string &strLabel)
 {
   if (strLabel=="..")
   {
@@ -1560,7 +1559,7 @@ CFileItemList::CFileItemList()
   m_replaceListing = false;
 }
 
-CFileItemList::CFileItemList(const CStdString& strPath) : CFileItem(strPath, true)
+CFileItemList::CFileItemList(const std::string& strPath) : CFileItem(strPath, true)
 {
   m_fastLookup = false;
   m_cacheToDisc = CACHE_IF_SLOW;
@@ -1583,12 +1582,12 @@ const CFileItemPtr CFileItemList::operator[] (int iItem) const
   return Get(iItem);
 }
 
-CFileItemPtr CFileItemList::operator[] (const CStdString& strPath)
+CFileItemPtr CFileItemList::operator[] (const std::string& strPath)
 {
   return Get(strPath);
 }
 
-const CFileItemPtr CFileItemList::operator[] (const CStdString& strPath) const
+const CFileItemPtr CFileItemList::operator[] (const std::string& strPath) const
 {
   return Get(strPath);
 }
@@ -1611,7 +1610,7 @@ void CFileItemList::SetFastLookup(bool fastLookup)
   m_fastLookup = fastLookup;
 }
 
-bool CFileItemList::Contains(const CStdString& fileName) const
+bool CFileItemList::Contains(const std::string& fileName) const
 {
   CSingleLock lock(m_lock);
 
@@ -1622,7 +1621,7 @@ bool CFileItemList::Contains(const CStdString& fileName) const
   for (unsigned int i = 0; i < m_items.size(); i++)
   {
     const CFileItemPtr pItem = m_items[i];
-    if (pItem->GetPath().Equals(fileName))
+    if (pItem->IsPath(fileName))
       return true;
   }
   return false;
@@ -1790,7 +1789,7 @@ const CFileItemPtr CFileItemList::Get(int iItem) const
   return CFileItemPtr();
 }
 
-CFileItemPtr CFileItemList::Get(const CStdString& strPath)
+CFileItemPtr CFileItemList::Get(const std::string& strPath)
 {
   CSingleLock lock(m_lock);
 
@@ -1806,20 +1805,20 @@ CFileItemPtr CFileItemList::Get(const CStdString& strPath)
   for (unsigned int i = 0; i < m_items.size(); i++)
   {
     CFileItemPtr pItem = m_items[i];
-    if (pItem->GetPath().Equals(strPath))
+    if (pItem->IsPath(strPath))
       return pItem;
   }
 
   return CFileItemPtr();
 }
 
-const CFileItemPtr CFileItemList::Get(const CStdString& strPath) const
+const CFileItemPtr CFileItemList::Get(const std::string& strPath) const
 {
   CSingleLock lock(m_lock);
 
   if (m_fastLookup)
   {
-    map<CStdString, CFileItemPtr>::const_iterator it=m_map.find(strPath);
+    map<std::string, CFileItemPtr>::const_iterator it=m_map.find(strPath);
     if (it != m_map.end())
       return it->second;
 
@@ -1829,7 +1828,7 @@ const CFileItemPtr CFileItemList::Get(const CStdString& strPath) const
   for (unsigned int i = 0; i < m_items.size(); i++)
   {
     CFileItemPtr pItem = m_items[i];
-    if (pItem->GetPath().Equals(strPath))
+    if (pItem->IsPath(strPath))
       return pItem;
   }
 
@@ -1921,7 +1920,7 @@ void CFileItemList::Sort(SortDescription sortDescription)
   {
     CFileItemPtr item = m_items[(int)(*it)->at(FieldId).asInteger()];
     // Set the sort label in the CFileItem
-    item->SetSortLabel(CStdStringW((*it)->at(FieldSort).asWideString()));
+    item->SetSortLabel((*it)->at(FieldSort).asWideString());
 
     sortedFileItems.push_back(item);
   }
@@ -2142,8 +2141,8 @@ void CFileItemList::FilterCueItems()
           // queue the cue sheet and the underlying media file for deletion
           for(std::vector<CStdString>::iterator itMedia = MediaFileVec.begin(); itMedia != MediaFileVec.end(); itMedia++)
           {
-            CStdString strMediaFile = *itMedia;
-            CStdString fileFromCue = strMediaFile; // save the file from the cue we're matching against,
+            std::string strMediaFile = *itMedia;
+            std::string fileFromCue = strMediaFile; // save the file from the cue we're matching against,
                                                    // as we're going to search for others here...
             bool bFoundMediaFile = CFile::Exists(strMediaFile);
             // queue the cue sheet and the underlying media file for deletion
@@ -2416,9 +2415,9 @@ void CFileItemList::StackFiles()
 
     int64_t               size        = 0;
     size_t                offset      = 0;
-    CStdString            stackName;
-    CStdString            file1;
-    CStdString            filePath;
+    std::string           stackName;
+    std::string           file1;
+    std::string           filePath;
     vector<int>           stack;
     VECCREGEXP::iterator  expr        = stackRegExps.begin();
 
@@ -2431,7 +2430,7 @@ void CFileItemList::StackFiles()
     {
       if (expr->RegFind(file1, offset) != -1)
       {
-        CStdString  Title1      = expr->GetMatch(1),
+        std::string Title1      = expr->GetMatch(1),
                     Volume1     = expr->GetMatch(2),
                     Ignore1     = expr->GetMatch(3),
                     Extension1  = expr->GetMatch(4);
@@ -2454,24 +2453,25 @@ void CFileItemList::StackFiles()
             continue;
           }
 
-          CStdString file2, filePath2;
+          std::string file2, filePath2;
           URIUtils::Split(item2->GetPath(), filePath2, file2);
           if (URIUtils::HasEncodedFilename(CURL(filePath2)) )
             file2 = CURL::Decode(file2);
 
           if (expr->RegFind(file2, offset) != -1)
           {
-            CStdString  Title2      = expr->GetMatch(1),
+            std::string  Title2      = expr->GetMatch(1),
                         Volume2     = expr->GetMatch(2),
                         Ignore2     = expr->GetMatch(3),
                         Extension2  = expr->GetMatch(4);
             if (offset)
               Title2 = file2.substr(0, expr->GetSubStart(2));
-            if (Title1.Equals(Title2))
+            if (StringUtils::EqualsNoCase(Title1, Title2))
             {
-              if (!Volume1.Equals(Volume2))
+              if (!StringUtils::EqualsNoCase(Volume1, Volume2))
               {
-                if (Ignore1.Equals(Ignore2) && Extension1.Equals(Extension2))
+                if (StringUtils::EqualsNoCase(Ignore1, Ignore2) &&
+                    StringUtils::EqualsNoCase(Extension1, Extension2))
                 {
                   if (stack.size() == 0)
                   {
@@ -2489,7 +2489,7 @@ void CFileItemList::StackFiles()
                   break;
                 }
               }
-              else if (!Ignore1.Equals(Ignore2)) // False positive, try again with offset
+              else if (!StringUtils::EqualsNoCase(Ignore1, Ignore2)) // False positive, try again with offset
               {
                 offset = expr->GetSubStart(3);
                 break;
@@ -2528,7 +2528,7 @@ void CFileItemList::StackFiles()
       {
         // have a stack, remove the items and add the stacked item
         // dont actually stack a multipart rar set, just remove all items but the first
-        CStdString stackPath;
+        std::string stackPath;
         if (Get(stack[0])->IsRAR())
           stackPath = Get(stack[0])->GetPath();
         else
@@ -2596,7 +2596,7 @@ bool CFileItemList::Save(int windowID)
 
 void CFileItemList::RemoveDiscCache(int windowID) const
 {
-  CStdString cacheFile(GetDiscFileCache(windowID));
+  std::string cacheFile(GetDiscFileCache(windowID));
   if (CFile::Exists(cacheFile))
   {
     CLog::Log(LOGDEBUG,"Clearing cached fileitems [%s]",GetPath().c_str());
@@ -2604,15 +2604,15 @@ void CFileItemList::RemoveDiscCache(int windowID) const
   }
 }
 
-CStdString CFileItemList::GetDiscFileCache(int windowID) const
+std::string CFileItemList::GetDiscFileCache(int windowID) const
 {
-  CStdString strPath(GetPath());
+  std::string strPath(GetPath());
   URIUtils::RemoveSlashAtEnd(strPath);
 
   Crc32 crc;
   crc.ComputeFromLowerCase(strPath);
 
-  CStdString cacheFile;
+  std::string cacheFile;
   if (IsCDDA() || IsOnDVD())
     cacheFile = StringUtils::Format("special://temp/r-%08x.fi", (unsigned __int32)crc);
   else if (IsMusicDb())
@@ -2640,7 +2640,7 @@ bool CFileItemList::AlwaysCache() const
   return false;
 }
 
-CStdString CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, bool fallbackToFolder /* = false */) const
+std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, bool fallbackToFolder /* = false */) const
 {
   if (m_strPath.empty()
    || StringUtils::StartsWithNoCase(m_strPath, "newsmartplaylist://")
@@ -2656,7 +2656,7 @@ CStdString CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, bo
     return "";
 
   // we first check for <filename>.tbn or <foldername>.tbn
-  CStdString fileThumb(GetTBNFile());
+  std::string fileThumb(GetTBNFile());
   if (CFile::Exists(fileThumb))
     return fileThumb;
 
@@ -2673,7 +2673,7 @@ CStdString CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, bo
     vector<string> thumbs = StringUtils::Split(g_advancedSettings.m_musicThumbs, "|");
     for (vector<string>::const_iterator i = thumbs.begin(); i != thumbs.end(); ++i)
     {
-      CStdString folderThumb(GetFolderThumb(*i));
+      std::string folderThumb(GetFolderThumb(*i));
       if (CFile::Exists(folderThumb))
       {
         return folderThumb;
@@ -2687,17 +2687,17 @@ CStdString CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, bo
 // Gets the .tbn filename from a file or folder name.
 // <filename>.ext -> <filename>.tbn
 // <foldername>/ -> <foldername>.tbn
-CStdString CFileItem::GetTBNFile() const
+std::string CFileItem::GetTBNFile() const
 {
-  CStdString thumbFile;
-  CStdString strFile = m_strPath;
+  std::string thumbFile;
+  std::string strFile = m_strPath;
 
   if (IsStack())
   {
-    CStdString strPath, strReturn;
+    std::string strPath, strReturn;
     URIUtils::GetParentPath(m_strPath,strPath);
     CFileItem item(CStackDirectory::GetFirstStackedFile(strFile),false);
-    CStdString strTBNFile = item.GetTBNFile();
+    std::string strTBNFile = item.GetTBNFile();
     strReturn = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
     if (CFile::Exists(strReturn))
       return strReturn;
@@ -2707,8 +2707,8 @@ CStdString CFileItem::GetTBNFile() const
 
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
   {
-    CStdString strPath = URIUtils::GetDirectory(strFile);
-    CStdString strParent;
+    std::string strPath = URIUtils::GetDirectory(strFile);
+    std::string strParent;
     URIUtils::GetParentPath(strPath,strParent);
     strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(m_strPath));
   }
@@ -2747,12 +2747,12 @@ bool CFileItem::SkipLocalArt() const
        || IsDVD());
 }
 
-CStdString CFileItem::FindLocalArt(const std::string &artFile, bool useFolder) const
+std::string CFileItem::FindLocalArt(const std::string &artFile, bool useFolder) const
 {
   if (SkipLocalArt())
     return "";
 
-  CStdString thumb;
+  std::string thumb;
   if (!m_bIsFolder)
   {
     thumb = GetLocalArt(artFile, false);
@@ -2761,35 +2761,35 @@ CStdString CFileItem::FindLocalArt(const std::string &artFile, bool useFolder) c
   }
   if ((useFolder || (m_bIsFolder && !IsFileFolder())) && !artFile.empty())
   {
-    CStdString thumb2 = GetLocalArt(artFile, true);
+    std::string thumb2 = GetLocalArt(artFile, true);
     if (!thumb2.empty() && thumb2 != thumb && CFile::Exists(thumb2))
       return thumb2;
   }
   return "";
 }
 
-CStdString CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) const
+std::string CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) const
 {
   // no retrieving of empty art files from folders
   if (useFolder && artFile.empty())
     return "";
 
-  CStdString strFile = m_strPath;
+  std::string strFile = m_strPath;
   if (IsStack())
   {
 /*    CFileItem item(CStackDirectory::GetFirstStackedFile(strFile),false);
-    CStdString localArt = item.GetLocalArt(artFile);
+    std::string localArt = item.GetLocalArt(artFile);
     return localArt;
     */
-    CStdString strPath;
+    std::string strPath;
     URIUtils::GetParentPath(m_strPath,strPath);
     strFile = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)));
   }
 
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
   {
-    CStdString strPath = URIUtils::GetDirectory(strFile);
-    CStdString strParent;
+    std::string strPath = URIUtils::GetDirectory(strFile);
+    std::string strParent;
     URIUtils::GetParentPath(strPath,strParent);
     strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(strFile));
   }
@@ -2823,9 +2823,9 @@ CStdString CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) co
   return "";
 }
 
-CStdString CFileItem::GetFolderThumb(const CStdString &folderJPG /* = "folder.jpg" */) const
+std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.jpg" */) const
 {
-  CStdString strFolder = m_strPath;
+  std::string strFolder = m_strPath;
 
   if (IsStack() ||
       URIUtils::IsInRAR(strFolder) ||
@@ -2840,7 +2840,7 @@ CStdString CFileItem::GetFolderThumb(const CStdString &folderJPG /* = "folder.jp
   return URIUtils::AddFileToFolder(strFolder, folderJPG);
 }
 
-CStdString CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
+std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
 {
   if (IsLabelPreformated())
     return GetLabel();
@@ -2849,12 +2849,12 @@ CStdString CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
     return m_pvrRecordingInfoTag->m_strTitle;
   else if (CUtil::IsTVRecording(m_strPath))
   {
-    CStdString title = CPVRRecording::GetTitleFromURL(m_strPath);
+    std::string title = CPVRRecording::GetTitleFromURL(m_strPath);
     if (!title.empty())
       return title;
   }
 
-  CStdString strMovieName = GetBaseMoviePath(bUseFolderNames);
+  std::string strMovieName = GetBaseMoviePath(bUseFolderNames);
 
   if (URIUtils::IsStack(strMovieName))
     strMovieName = CStackDirectory::GetStackedTitlePath(strMovieName);
@@ -2864,9 +2864,9 @@ CStdString CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
   return CURL::Decode(URIUtils::GetFileName(strMovieName));
 }
 
-CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
+std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 {
-  CStdString strMovieName = m_strPath;
+  std::string strMovieName = m_strPath;
 
   if (IsMultiPath())
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
@@ -2876,11 +2876,11 @@ CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 
   if ((!m_bIsFolder || URIUtils::IsInArchive(m_strPath)) && bUseFolderNames)
   {
-    CStdString name2(strMovieName);
+    std::string name2(strMovieName);
     URIUtils::GetParentPath(name2,strMovieName);
     if (URIUtils::IsInArchive(m_strPath))
     {
-      CStdString strArchivePath;
+      std::string strArchivePath;
       URIUtils::GetParentPath(strMovieName, strArchivePath);
       strMovieName = strArchivePath;
     }
@@ -2889,7 +2889,7 @@ CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
   return strMovieName;
 }
 
-CStdString CFileItem::GetLocalFanart() const
+std::string CFileItem::GetLocalFanart() const
 {
   if (IsVideoDb())
   {
@@ -2899,24 +2899,24 @@ CStdString CFileItem::GetLocalFanart() const
     return dbItem.GetLocalFanart();
   }
 
-  CStdString strFile2;
-  CStdString strFile = m_strPath;
+  std::string strFile2;
+  std::string strFile = m_strPath;
   if (IsStack())
   {
-    CStdString strPath;
+    std::string strPath;
     URIUtils::GetParentPath(m_strPath,strPath);
     CStackDirectory dir;
-    CStdString strPath2;
+    std::string strPath2;
     strPath2 = dir.GetStackedTitlePath(strFile);
     strFile = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strPath2));
     CFileItem item(dir.GetFirstStackedFile(m_strPath),false);
-    CStdString strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-fanart"));
+    std::string strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-fanart"));
     strFile2 = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(strTBNFile));
   }
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
   {
-    CStdString strPath = URIUtils::GetDirectory(strFile);
-    CStdString strParent;
+    std::string strPath = URIUtils::GetDirectory(strFile);
+    std::string strParent;
     URIUtils::GetParentPath(strPath,strParent);
     strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(m_strPath));
   }
@@ -2933,7 +2933,7 @@ CStdString CFileItem::GetLocalFanart() const
    || m_strPath.empty())
     return "";
 
-  CStdString strDir = URIUtils::GetDirectory(strFile);
+  std::string strDir = URIUtils::GetDirectory(strFile);
 
   if (strDir.empty())
     return "";
@@ -2959,9 +2959,9 @@ CStdString CFileItem::GetLocalFanart() const
   {
     for (int j = 0; j < items.Size(); j++)
     {
-      CStdString strCandidate = URIUtils::GetFileName(items[j]->m_strPath);
+      std::string strCandidate = URIUtils::GetFileName(items[j]->m_strPath);
       URIUtils::RemoveExtension(strCandidate);
-      CStdString strFanart = *i;
+      std::string strFanart = *i;
       URIUtils::RemoveExtension(strFanart);
       if (StringUtils::EqualsNoCase(strCandidate, strFanart))
         return items[j]->m_strPath;
@@ -2971,13 +2971,13 @@ CStdString CFileItem::GetLocalFanart() const
   return "";
 }
 
-CStdString CFileItem::GetLocalMetadataPath() const
+std::string CFileItem::GetLocalMetadataPath() const
 {
   if (m_bIsFolder && !IsFileFolder())
     return m_strPath;
 
-  CStdString parent(URIUtils::GetParentPath(m_strPath));
-  CStdString parentFolder(parent);
+  std::string parent(URIUtils::GetParentPath(m_strPath));
+  std::string parentFolder(parent);
   URIUtils::RemoveSlashAtEnd(parentFolder);
   parentFolder = URIUtils::GetFileName(parentFolder);
   if (StringUtils::EqualsNoCase(parentFolder, "VIDEO_TS") || StringUtils::EqualsNoCase(parentFolder, "BDMV"))
@@ -3024,10 +3024,10 @@ bool CFileItem::LoadMusicTag()
     int iTrack = GetMusicInfoTag()->GetTrackNumber();
     if (iTrack >= 1)
     {
-      CStdString strText = g_localizeStrings.Get(554); // "Track"
+      std::string strText = g_localizeStrings.Get(554); // "Track"
       if (!strText.empty() && strText[strText.size() - 1] != ' ')
         strText += " ";
-      CStdString strTrack = StringUtils::Format(strText + "%i", iTrack);
+      std::string strTrack = StringUtils::Format((strText + "%i").c_str(), iTrack);
       GetMusicInfoTag()->SetTitle(strTrack);
       GetMusicInfoTag()->SetLoaded(true);
       return true;
@@ -3035,7 +3035,7 @@ bool CFileItem::LoadMusicTag()
   }
   else
   {
-    CStdString fileName = URIUtils::GetFileName(m_strPath);
+    std::string fileName = URIUtils::GetFileName(m_strPath);
     URIUtils::RemoveExtension(fileName);
     for (unsigned int i = 0; i < g_advancedSettings.m_musicTagsFromFileFilters.size(); i++)
     {
@@ -3165,26 +3165,26 @@ MUSIC_INFO::CMusicInfoTag* CFileItem::GetMusicInfoTag()
   return m_musicInfoTag;
 }
 
-CStdString CFileItem::FindTrailer() const
+std::string CFileItem::FindTrailer() const
 {
-  CStdString strFile2;
-  CStdString strFile = m_strPath;
+  std::string strFile2;
+  std::string strFile = m_strPath;
   if (IsStack())
   {
-    CStdString strPath;
+    std::string strPath;
     URIUtils::GetParentPath(m_strPath,strPath);
     CStackDirectory dir;
-    CStdString strPath2;
+    std::string strPath2;
     strPath2 = dir.GetStackedTitlePath(strFile);
     strFile = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strPath2));
     CFileItem item(dir.GetFirstStackedFile(m_strPath),false);
-    CStdString strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-trailer"));
+    std::string strTBNFile(URIUtils::ReplaceExtension(item.GetTBNFile(), "-trailer"));
     strFile2 = URIUtils::AddFileToFolder(strPath,URIUtils::GetFileName(strTBNFile));
   }
   if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
   {
-    CStdString strPath = URIUtils::GetDirectory(strFile);
-    CStdString strParent;
+    std::string strPath = URIUtils::GetDirectory(strFile);
+    std::string strParent;
     URIUtils::GetParentPath(strPath,strParent);
     strFile = URIUtils::AddFileToFolder(strParent,URIUtils::GetFileName(m_strPath));
   }
@@ -3198,12 +3198,12 @@ CStdString CFileItem::FindTrailer() const
    || IsDVD())
     return "";
 
-  CStdString strDir = URIUtils::GetDirectory(strFile);
+  std::string strDir = URIUtils::GetDirectory(strFile);
   CFileItemList items;
   CDirectory::GetDirectory(strDir, items, g_advancedSettings.m_videoExtensions, DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO | DIR_FLAG_NO_FILE_DIRS);
   URIUtils::RemoveExtension(strFile);
   strFile += "-trailer";
-  CStdString strFile3 = URIUtils::AddFileToFolder(strDir, "movie-trailer");
+  std::string strFile3 = URIUtils::AddFileToFolder(strDir, "movie-trailer");
 
   // Precompile our REs
   VECCREGEXP matchRegExps;
@@ -3220,10 +3220,10 @@ CStdString CFileItem::FindTrailer() const
     strRegExp++;
   }
 
-  CStdString strTrailer;
+  std::string strTrailer;
   for (int i = 0; i < items.Size(); i++)
   {
-    CStdString strCandidate = items[i]->m_strPath;
+    std::string strCandidate = items[i]->m_strPath;
     URIUtils::RemoveExtension(strCandidate);
     if (StringUtils::EqualsNoCase(strCandidate, strFile) ||
         StringUtils::EqualsNoCase(strCandidate, strFile2) ||

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -90,12 +90,12 @@ public:
   CFileItem(void);
   CFileItem(const CFileItem& item);
   CFileItem(const CGUIListItem& item);
-  explicit CFileItem(const CStdString& strLabel);
+  explicit CFileItem(const std::string& strLabel);
   CFileItem(const CURL& path, bool bIsFolder);
-  CFileItem(const CStdString& strPath, bool bIsFolder);
+  CFileItem(const std::string& strPath, bool bIsFolder);
   CFileItem(const CSong& song);
   CFileItem(const CURL &path, const CAlbum& album);
-  CFileItem(const CStdString &path, const CAlbum& album);
+  CFileItem(const std::string &path, const CAlbum& album);
   CFileItem(const CArtist& artist);
   CFileItem(const CGenre& genre);
   CFileItem(const MUSIC_INFO::CMusicInfoTag& music);
@@ -111,8 +111,8 @@ public:
   const CURL GetURL() const;
   void SetURL(const CURL& url);
   bool IsURL(const CURL& url) const;
-  const CStdString &GetPath() const { return m_strPath; };
-  void SetPath(const CStdString &path) { m_strPath = path; };
+  const std::string &GetPath() const { return m_strPath; };
+  void SetPath(const std::string &path) { m_strPath = path; };
   bool IsPath(const std::string& path) const;
 
   /*! \brief reset class to it's default values as per construction.
@@ -224,7 +224,7 @@ public:
   void CleanString();
   void FillInDefaultIcon();
   void SetFileSizeLabel();
-  virtual void SetLabel(const CStdString &strLabel);
+  virtual void SetLabel(const std::string &strLabel);
   CURL GetAsUrl() const;
   int GetVideoContentType() const; /* return VIDEODB_CONTENT_TYPE, but don't want to include videodb in this header */
   bool IsLabelPreformated() const { return m_bLabelPreformated; }
@@ -334,7 +334,7 @@ public:
    \return path to the local fanart for this item, or empty if none exists
    \sa GetFolderThumb, GetTBNFile
    */
-  CStdString GetLocalFanart() const;
+  std::string GetLocalFanart() const;
 
   /*! \brief Assemble the filename of a particular piece of local artwork for an item.
              No file existence check is typically performed.
@@ -343,7 +343,7 @@ public:
    \return the path to the local artwork.
    \sa FindLocalArt
    */
-  CStdString GetLocalArt(const std::string &artFile, bool useFolder = false) const;
+  std::string GetLocalArt(const std::string &artFile, bool useFolder = false) const;
 
   /*! \brief Assemble the filename of a particular piece of local artwork for an item,
              and check for file existence.
@@ -352,7 +352,7 @@ public:
    \return the path to the local artwork if it exists, empty otherwise.
    \sa GetLocalArt
    */
-  CStdString FindLocalArt(const std::string &artFile, bool useFolder) const;
+  std::string FindLocalArt(const std::string &artFile, bool useFolder) const;
 
   /*! \brief Whether or not to skip searching for local art.
    \return true if local art should be skipped for this item, false otherwise.
@@ -361,11 +361,11 @@ public:
   bool SkipLocalArt() const;
 
   // Gets the .tbn file associated with this item
-  CStdString GetTBNFile() const;
+  std::string GetTBNFile() const;
   // Gets the folder image associated with this item (defaults to folder.jpg)
-  CStdString GetFolderThumb(const CStdString &folderJPG = "folder.jpg") const;
+  std::string GetFolderThumb(const std::string &folderJPG = "folder.jpg") const;
   // Gets the correct movie title
-  CStdString GetMovieName(bool bUseFolderNames = false) const;
+  std::string GetMovieName(bool bUseFolderNames = false) const;
 
   /*! \brief Find the base movie path (i.e. the item the user expects us to use to lookup the movie)
    For folder items, with "use foldernames for lookups" it returns the folder.
@@ -374,10 +374,10 @@ public:
    \param useFolderNames whether we're using foldernames for lookups
    \return the base movie folder
    */
-  CStdString GetBaseMoviePath(bool useFolderNames) const;
+  std::string GetBaseMoviePath(bool useFolderNames) const;
 
   // Gets the user thumb, if it exists
-  CStdString GetUserMusicThumb(bool alwaysCheckRemote = false, bool fallbackToFolder = false) const;
+  std::string GetUserMusicThumb(bool alwaysCheckRemote = false, bool fallbackToFolder = false) const;
 
   /*! \brief Get the path where we expect local metadata to reside.
    For a folder, this is just the existing path (eg tvshow folder)
@@ -391,18 +391,18 @@ public:
 
      \sa URIUtils::GetParentPath
    */
-  CStdString GetLocalMetadataPath() const;
+  std::string GetLocalMetadataPath() const;
 
   // finds a matching local trailer file
-  CStdString FindTrailer() const;
+  std::string FindTrailer() const;
 
   virtual bool LoadMusicTag();
 
   /* Returns the content type of this item if known */
-  const CStdString& GetMimeType() const { return m_mimetype; }
+  const std::string& GetMimeType() const { return m_mimetype; }
 
   /* sets the mime-type if known beforehand */
-  void SetMimeType(const CStdString& mimetype) { m_mimetype = mimetype; } ;
+  void SetMimeType(const std::string& mimetype) { m_mimetype = mimetype; } ;
 
   /*! \brief Resolve the MIME type based on file extension or a web lookup
    If m_mimetype is already set (non-empty), this function has no effect. For
@@ -412,8 +412,8 @@ public:
   void FillInMimeType(bool lookup = true);
 
   /* general extra info about the contents of the item, not for display */
-  void SetExtraInfo(const CStdString& info) { m_extrainfo = info; };
-  const CStdString& GetExtraInfo() const { return m_extrainfo; };
+  void SetExtraInfo(const std::string& info) { m_extrainfo = info; };
+  const std::string& GetExtraInfo() const { return m_extrainfo; };
 
   /*! \brief Update an item with information from another item
    We take metadata information from the given item and supplement the current item
@@ -451,15 +451,15 @@ public:
   int m_iDriveType;     ///< If \e m_bIsShareOrDrive is \e true, use to get the share type. Types see: CMediaSource::m_iDriveType
   CDateTime m_dateTime;             ///< file creation date & time
   int64_t m_dwSize;             ///< file size (0 for folders)
-  CStdString m_strDVDLabel;
-  CStdString m_strTitle;
+  std::string m_strDVDLabel;
+  std::string m_strTitle;
   int m_iprogramCount;
   int m_idepth;
   int m_lStartOffset;
   int m_lStartPartNumber;
   int m_lEndOffset;
   LockType m_iLockMode;
-  CStdString m_strLockCode;
+  std::string m_strLockCode;
   int m_iHasLock; // 0 - no lock 1 - lock, but unlocked 2 - locked
   int m_iBadPwdCount;
 
@@ -470,14 +470,14 @@ private:
    */
   void Initialize();
 
-  CStdString m_strPath;            ///< complete path to item
+  std::string m_strPath;            ///< complete path to item
 
   SortSpecial m_specialSort;
   bool m_bIsParentFolder;
   bool m_bCanQueue;
   bool m_bLabelPreformated;
-  CStdString m_mimetype;
-  CStdString m_extrainfo;
+  std::string m_mimetype;
+  std::string m_extrainfo;
   MUSIC_INFO::CMusicInfoTag* m_musicInfoTag;
   CVideoInfoTag* m_videoInfoTag;
   EPG::CEpgInfoTag* m_epgInfoTag;
@@ -510,19 +510,19 @@ typedef std::vector< CFileItemPtr >::iterator IVECFILEITEMS;
   \brief A map of pointers to CFileItem
   \sa CFileItem
   */
-typedef std::map<CStdString, CFileItemPtr > MAPFILEITEMS;
+typedef std::map<std::string, CFileItemPtr > MAPFILEITEMS;
 
 /*!
   \brief Iterator for MAPFILEITEMS
   \sa MAPFILEITEMS
   */
-typedef std::map<CStdString, CFileItemPtr >::iterator IMAPFILEITEMS;
+typedef std::map<std::string, CFileItemPtr >::iterator IMAPFILEITEMS;
 
 /*!
   \brief Pair for MAPFILEITEMS
   \sa MAPFILEITEMS
   */
-typedef std::pair<CStdString, CFileItemPtr > MAPFILEITEMSPAIR;
+typedef std::pair<std::string, CFileItemPtr > MAPFILEITEMSPAIR;
 
 typedef bool (*FILEITEMLISTCOMPARISONFUNC) (const CFileItemPtr &pItem1, const CFileItemPtr &pItem2);
 typedef void (*FILEITEMFILLFUNC) (CFileItemPtr &item);
@@ -537,13 +537,13 @@ public:
   enum CACHE_TYPE { CACHE_NEVER = 0, CACHE_IF_SLOW, CACHE_ALWAYS };
 
   CFileItemList();
-  explicit CFileItemList(const CStdString& strPath);
+  explicit CFileItemList(const std::string& strPath);
   virtual ~CFileItemList();
   virtual void Archive(CArchive& ar);
   CFileItemPtr operator[] (int iItem);
   const CFileItemPtr operator[] (int iItem) const;
-  CFileItemPtr operator[] (const CStdString& strPath);
-  const CFileItemPtr operator[] (const CStdString& strPath) const;
+  CFileItemPtr operator[] (const std::string& strPath);
+  const CFileItemPtr operator[] (const std::string& strPath) const;
   void Clear();
   void ClearItems();
   void Add(const CFileItemPtr &pItem);
@@ -553,8 +553,8 @@ public:
   CFileItemPtr Get(int iItem);
   const CFileItemPtr Get(int iItem) const;
   const VECFILEITEMS GetList() const { return m_items; }
-  CFileItemPtr Get(const CStdString& strPath);
-  const CFileItemPtr Get(const CStdString& strPath) const;
+  CFileItemPtr Get(const std::string& strPath);
+  const CFileItemPtr Get(const std::string& strPath) const;
   int Size() const;
   bool IsEmpty() const;
   void Append(const CFileItemList& itemlist);
@@ -579,7 +579,7 @@ public:
   void FilterCueItems();
   void RemoveExtensions();
   void SetFastLookup(bool fastLookup);
-  bool Contains(const CStdString& fileName) const;
+  bool Contains(const std::string& fileName) const;
   bool GetFastLookup() const { return m_fastLookup; };
 
   /*! \brief stack a CFileItemList
@@ -652,14 +652,14 @@ public:
   void SetSortIgnoreFolders(bool sort) { m_sortIgnoreFolders = sort; };
   bool GetReplaceListing() const { return m_replaceListing; };
   void SetReplaceListing(bool replace);
-  void SetContent(const CStdString &content) { m_content = content; };
-  const CStdString &GetContent() const { return m_content; };
+  void SetContent(const std::string &content) { m_content = content; };
+  const std::string &GetContent() const { return m_content; };
 
   void ClearSortState();
 private:
   void Sort(FILEITEMLISTCOMPARISONFUNC func);
   void FillSortFields(FILEITEMFILLFUNC func);
-  CStdString GetDiscFileCache(int windowID) const;
+  std::string GetDiscFileCache(int windowID) const;
 
   /*!
    \brief stack files in a CFileItemList
@@ -680,7 +680,7 @@ private:
   bool m_sortIgnoreFolders;
   CACHE_TYPE m_cacheToDisc;
   bool m_replaceListing;
-  CStdString m_content;
+  std::string m_content;
 
   std::vector<SORT_METHOD_DETAILS> m_sortDetails;
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5127,7 +5127,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       if (!g_application.m_strPlayListFile.empty())
       {
         //playlist file that is currently playing or the playlistitem that is currently playing.
-        return g_application.m_strPlayListFile.Equals(((const CFileItem *)item)->GetPath()) || m_currentFile->IsSamePath((const CFileItem *)item);
+        return ((const CFileItem *)item)->IsPath(g_application.m_strPlayListFile) || m_currentFile->IsSamePath((const CFileItem *)item);
       }
       return m_currentFile->IsSamePath((const CFileItem *)item);
     }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1749,7 +1749,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *f
       if (window)
       {
         CURL url(((CGUIMediaWindow*)window)->CurrentDirectory().GetPath());
-        if (url.GetProtocol().Equals("plugin"))
+        if (url.IsProtocol("plugin"))
         {
           strLabel = url.GetFileName();
           URIUtils::RemoveSlashAtEnd(strLabel);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3772,7 +3772,7 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
               StringUtils::EmptyString :
               g_localizeStrings.Get(19055); // no information available
     case VIDEOPLAYER_GENRE:
-      return tag->GetEPGNow(epgTag) ? StringUtils::Join(epgTag.Genre(), g_advancedSettings.m_videoItemSeparator) : StringUtils::EmptyString;
+      return tag->GetEPGNow(epgTag) ? StringUtils::Join(epgTag.Genre(), g_advancedSettings.m_videoItemSeparator) : "";
     case VIDEOPLAYER_PLOT:
       return tag->GetEPGNow(epgTag) ? epgTag.Plot() : StringUtils::EmptyString;
     case VIDEOPLAYER_PLOT_OUTLINE:
@@ -3790,7 +3790,7 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
               StringUtils::EmptyString :
               g_localizeStrings.Get(19055); // no information available
     case VIDEOPLAYER_NEXT_GENRE:
-      return tag->GetEPGNext(epgTag) ? StringUtils::Join(epgTag.Genre(), g_advancedSettings.m_videoItemSeparator) : StringUtils::EmptyString;
+      return tag->GetEPGNext(epgTag) ? StringUtils::Join(epgTag.Genre(), g_advancedSettings.m_videoItemSeparator) : "";
     case VIDEOPLAYER_NEXT_PLOT:
       return tag->GetEPGNext(epgTag) ? epgTag.Plot() : StringUtils::EmptyString;
     case VIDEOPLAYER_NEXT_PLOT_OUTLINE:
@@ -4550,7 +4550,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::s
     if (item->HasPVRChannelInfoTag())
     {
       CEpgInfoTag epgTag;
-      return item->GetPVRChannelInfoTag()->GetEPGNow(epgTag) ? StringUtils::Join(epgTag.Genre(), g_advancedSettings.m_videoItemSeparator) : StringUtils::EmptyString;
+      return item->GetPVRChannelInfoTag()->GetEPGNow(epgTag) ? StringUtils::Join(epgTag.Genre(), g_advancedSettings.m_videoItemSeparator) : "";
     }
     if (item->HasPVRRecordingInfoTag())
       return StringUtils::Join(item->GetPVRRecordingInfoTag()->m_genre, g_advancedSettings.m_videoItemSeparator);

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -98,55 +98,57 @@ void CLangInfo::CRegion::SetDefaults()
   m_strTimeZone.clear();
 }
 
-void CLangInfo::CRegion::SetTempUnit(const CStdString& strUnit)
+void CLangInfo::CRegion::SetTempUnit(const std::string& strUnit)
 {
-  if (strUnit.Equals("F"))
+  std::string unit(strUnit); StringUtils::ToLower(unit);
+  if (unit == "f")
     m_tempUnit=TEMP_UNIT_FAHRENHEIT;
-  else if (strUnit.Equals("K"))
+  else if (unit == "k")
     m_tempUnit=TEMP_UNIT_KELVIN;
-  else if (strUnit.Equals("C"))
+  else if (unit == "c")
     m_tempUnit=TEMP_UNIT_CELSIUS;
-  else if (strUnit.Equals("Re"))
+  else if (unit == "re")
     m_tempUnit=TEMP_UNIT_REAUMUR;
-  else if (strUnit.Equals("Ra"))
+  else if (unit == "ra")
     m_tempUnit=TEMP_UNIT_RANKINE;
-  else if (strUnit.Equals("Ro"))
+  else if (unit == "ro")
     m_tempUnit=TEMP_UNIT_ROMER;
-  else if (strUnit.Equals("De"))
+  else if (unit == "de")
     m_tempUnit=TEMP_UNIT_DELISLE;
-  else if (strUnit.Equals("N"))
+  else if (unit == "n")
     m_tempUnit=TEMP_UNIT_NEWTON;
 }
 
-void CLangInfo::CRegion::SetSpeedUnit(const CStdString& strUnit)
+void CLangInfo::CRegion::SetSpeedUnit(const std::string& strUnit)
 {
-  if (strUnit.Equals("kmh"))
+  std::string unit(strUnit); StringUtils::ToLower(unit);
+  if (unit == "kmh")
     m_speedUnit=SPEED_UNIT_KMH;
-  else if (strUnit.Equals("mpmin"))
+  else if (unit == "mpmin")
     m_speedUnit=SPEED_UNIT_MPMIN;
-  else if (strUnit.Equals("mps"))
+  else if (unit == "mps")
     m_speedUnit=SPEED_UNIT_MPS;
-  else if (strUnit.Equals("fth"))
+  else if (unit == "fth")
     m_speedUnit=SPEED_UNIT_FTH;
-  else if (strUnit.Equals("ftm"))
+  else if (unit == "ftm")
     m_speedUnit=SPEED_UNIT_FTMIN;
-  else if (strUnit.Equals("fts"))
+  else if (unit == "fts")
     m_speedUnit=SPEED_UNIT_FTS;
-  else if (strUnit.Equals("mph"))
+  else if (unit == "mph")
     m_speedUnit=SPEED_UNIT_MPH;
-  else if (strUnit.Equals("kts"))
+  else if (unit == "kts")
     m_speedUnit=SPEED_UNIT_KTS;
-  else if (strUnit.Equals("beaufort"))
+  else if (unit == "beaufort")
     m_speedUnit=SPEED_UNIT_BEAUFORT;
-  else if (strUnit.Equals("inchs"))
+  else if (unit == "inchs")
     m_speedUnit=SPEED_UNIT_INCHPS;
-  else if (strUnit.Equals("yards"))
+  else if (unit == "yards")
     m_speedUnit=SPEED_UNIT_YARDPS;
-  else if (strUnit.Equals("fpf"))
+  else if (unit == "fpf")
     m_speedUnit=SPEED_UNIT_FPF;
 }
 
-void CLangInfo::CRegion::SetTimeZone(const CStdString& strTimeZone)
+void CLangInfo::CRegion::SetTimeZone(const std::string& strTimeZone)
 {
   m_strTimeZone = strTimeZone;
 }
@@ -155,7 +157,7 @@ void CLangInfo::CRegion::SetTimeZone(const CStdString& strTimeZone)
 // sorting & transformations
 void CLangInfo::CRegion::SetGlobalLocale()
 {
-  CStdString strLocale;
+  std::string strLocale;
   if (m_strRegionLocaleName.length() > 0)
   {
     strLocale = m_strLangLocaleName + "_" + m_strRegionLocaleName;
@@ -183,7 +185,7 @@ void CLangInfo::CRegion::SetGlobalLocale()
   locale current_locale = locale::classic(); // C-Locale
   try
   {
-    locale lcl = locale(strLocale);
+    locale lcl = locale(strLocale.c_str());
     strLocale = lcl.name();
     current_locale = current_locale.combine< collate<wchar_t> >(lcl);
     current_locale = current_locale.combine< ctype<wchar_t> >(lcl);
@@ -273,7 +275,7 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
     m_languageCodeGeneral = m_defaultRegion.m_strLangLocaleName;
 #endif
 
-  CStdString tmp;
+  std::string tmp;
   if (g_LangCodeExpander.ConvertToTwoCharCode(tmp, m_defaultRegion.m_strLangLocaleName))
     m_defaultRegion.m_strLangLocaleCodeTwoChar = tmp;
 
@@ -283,17 +285,15 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
     const TiXmlElement *pGui = pCharSets->FirstChildElement("gui");
     if (pGui && !pGui->NoChildren())
     {
-      CStdString strForceUnicodeFont = XMLUtils::GetAttribute(pGui, "unicodefont");
-
-      if (strForceUnicodeFont.Equals("true"))
+      if (StringUtils::EqualsNoCase(XMLUtils::GetAttribute(pGui, "unicodefont"), "true"))
         m_defaultRegion.m_forceUnicodeFont=true;
 
-      m_defaultRegion.m_strGuiCharSet=pGui->FirstChild()->Value();
+      m_defaultRegion.m_strGuiCharSet=pGui->FirstChild()->ValueStr();
     }
 
     const TiXmlNode *pSubtitle = pCharSets->FirstChild("subtitle");
     if (pSubtitle && !pSubtitle->NoChildren())
-      m_defaultRegion.m_strSubtitleCharSet=pSubtitle->FirstChild()->Value();
+      m_defaultRegion.m_strSubtitleCharSet=pSubtitle->FirstChild()->ValueStr();
   }
 
   const TiXmlNode *pDVD = pRootElement->FirstChild("dvd");
@@ -301,15 +301,15 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
   {
     const TiXmlNode *pMenu = pDVD->FirstChild("menu");
     if (pMenu && !pMenu->NoChildren())
-      m_defaultRegion.m_strDVDMenuLanguage=pMenu->FirstChild()->Value();
+      m_defaultRegion.m_strDVDMenuLanguage=pMenu->FirstChild()->ValueStr();
 
     const TiXmlNode *pAudio = pDVD->FirstChild("audio");
     if (pAudio && !pAudio->NoChildren())
-      m_defaultRegion.m_strDVDAudioLanguage=pAudio->FirstChild()->Value();
+      m_defaultRegion.m_strDVDAudioLanguage=pAudio->FirstChild()->ValueStr();
 
     const TiXmlNode *pSubtitle = pDVD->FirstChild("subtitle");
     if (pSubtitle && !pSubtitle->NoChildren())
-      m_defaultRegion.m_strDVDSubtitleLanguage=pSubtitle->FirstChild()->Value();
+      m_defaultRegion.m_strDVDSubtitleLanguage=pSubtitle->FirstChild()->ValueStr();
   }
 
   const TiXmlNode *pRegions = pRootElement->FirstChild("regions");
@@ -337,11 +337,11 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
 
       const TiXmlNode *pDateLong=pRegion->FirstChild("datelong");
       if (pDateLong && !pDateLong->NoChildren())
-        region.m_strDateFormatLong=pDateLong->FirstChild()->Value();
+        region.m_strDateFormatLong=pDateLong->FirstChild()->ValueStr();
 
       const TiXmlNode *pDateShort=pRegion->FirstChild("dateshort");
       if (pDateShort && !pDateShort->NoChildren())
-        region.m_strDateFormatShort=pDateShort->FirstChild()->Value();
+        region.m_strDateFormatShort=pDateShort->FirstChild()->ValueStr();
 
       const TiXmlElement *pTime=pRegion->FirstChildElement("time");
       if (pTime && !pTime->NoChildren())
@@ -353,15 +353,15 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
 
       const TiXmlNode *pTempUnit=pRegion->FirstChild("tempunit");
       if (pTempUnit && !pTempUnit->NoChildren())
-        region.SetTempUnit(pTempUnit->FirstChild()->Value());
+        region.SetTempUnit(pTempUnit->FirstChild()->ValueStr());
 
       const TiXmlNode *pSpeedUnit=pRegion->FirstChild("speedunit");
       if (pSpeedUnit && !pSpeedUnit->NoChildren())
-        region.SetSpeedUnit(pSpeedUnit->FirstChild()->Value());
+        region.SetSpeedUnit(pSpeedUnit->FirstChild()->ValueStr());
 
       const TiXmlNode *pTimeZone=pRegion->FirstChild("timezone");
       if (pTimeZone && !pTimeZone->NoChildren())
-        region.SetTimeZone(pTimeZone->FirstChild()->Value());
+        region.SetTimeZone(pTimeZone->FirstChild()->ValueStr());
 
       m_regions.insert(PAIR_REGIONS(region.m_strName, region));
 
@@ -370,7 +370,7 @@ bool CLangInfo::Load(const std::string& strFileName, bool onlyCheckLanguage /*= 
 
     if (!onlyCheckLanguage)
     {
-      const CStdString& strName = CSettings::Get().GetString("locale.country");
+      const std::string& strName = CSettings::Get().GetString("locale.country");
       SetCurrentRegion(strName);
     }
   }
@@ -388,23 +388,23 @@ bool CLangInfo::CheckLanguage(const std::string& language)
   return li.Load("special://xbmc/language/" + language + "/langinfo.xml", true);
 }
 
-void CLangInfo::LoadTokens(const TiXmlNode* pTokens, vector<CStdString>& vecTokens)
+void CLangInfo::LoadTokens(const TiXmlNode* pTokens, vector<std::string>& vecTokens)
 {
   if (pTokens && !pTokens->NoChildren())
   {
     const TiXmlElement *pToken = pTokens->FirstChildElement("token");
     while (pToken)
     {
-      CStdString strSep= " ._";
+      std::string strSep= " ._";
       if (pToken->Attribute("separators"))
         strSep = pToken->Attribute("separators");
       if (pToken->FirstChild() && pToken->FirstChild()->Value())
       {
         if (strSep.empty())
-          vecTokens.push_back(pToken->FirstChild()->Value());
+          vecTokens.push_back(pToken->FirstChild()->ValueStr());
         else
           for (unsigned int i=0;i<strSep.size();++i)
-            vecTokens.push_back(CStdString(pToken->FirstChild()->Value())+strSep[i]);
+            vecTokens.push_back(pToken->FirstChild()->ValueStr()+strSep[i]);
       }
       pToken = pToken->NextSiblingElement();
     }
@@ -424,9 +424,9 @@ void CLangInfo::SetDefaults()
   m_languageCodeGeneral = "eng";
 }
 
-CStdString CLangInfo::GetGuiCharSet() const
+std::string CLangInfo::GetGuiCharSet() const
 {
-  CStdString strCharSet;
+  std::string strCharSet;
   strCharSet=CSettings::Get().GetString("locale.charset");
   if (strCharSet=="DEFAULT")
     strCharSet=m_currentRegion->m_strGuiCharSet;
@@ -434,9 +434,9 @@ CStdString CLangInfo::GetGuiCharSet() const
   return strCharSet;
 }
 
-CStdString CLangInfo::GetSubtitleCharSet() const
+std::string CLangInfo::GetSubtitleCharSet() const
 {
-  CStdString strCharSet=CSettings::Get().GetString("subtitles.charset");
+  std::string strCharSet=CSettings::Get().GetString("subtitles.charset");
   if (strCharSet=="DEFAULT")
     strCharSet=m_currentRegion->m_strSubtitleCharSet;
 
@@ -466,7 +466,7 @@ bool CLangInfo::CheckLoadLanguage(const std::string &language)
 }
 
 // three char language code (not win32 specific)
-const CStdString& CLangInfo::GetAudioLanguage() const
+const std::string& CLangInfo::GetAudioLanguage() const
 {
   if (!m_audioLanguage.empty())
     return m_audioLanguage;
@@ -484,7 +484,7 @@ void CLangInfo::SetAudioLanguage(const std::string& language)
 }
 
 // three char language code (not win32 specific)
-const CStdString& CLangInfo::GetSubtitleLanguage() const
+const std::string& CLangInfo::GetSubtitleLanguage() const
 {
   if (!m_subtitleLanguage.empty())
     return m_subtitleLanguage;
@@ -504,7 +504,7 @@ void CLangInfo::SetSubtitleLanguage(const std::string& language)
 // two character codes as defined in ISO639
 const std::string CLangInfo::GetDVDMenuLanguage() const
 {
-  CStdString code;
+  std::string code;
   if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_currentRegion->m_strLangLocaleName))
     code = m_currentRegion->m_strDVDMenuLanguage;
   
@@ -514,7 +514,7 @@ const std::string CLangInfo::GetDVDMenuLanguage() const
 // two character codes as defined in ISO639
 const std::string CLangInfo::GetDVDAudioLanguage() const
 {
-  CStdString code;
+  std::string code;
   if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_audioLanguage))
     code = m_currentRegion->m_strDVDAudioLanguage;
   
@@ -524,7 +524,7 @@ const std::string CLangInfo::GetDVDAudioLanguage() const
 // two character codes as defined in ISO639
 const std::string CLangInfo::GetDVDSubtitleLanguage() const
 {
-  CStdString code;
+  std::string code;
   if (!g_LangCodeExpander.ConvertToTwoCharCode(code, m_subtitleLanguage))
     code = m_currentRegion->m_strDVDSubtitleLanguage;
   
@@ -539,13 +539,13 @@ const std::string CLangInfo::GetLanguageLocale(bool twochar /* = false */) const
   return m_currentRegion->m_strLangLocaleName;
 }
 
-const CStdString& CLangInfo::GetRegionLocale() const
+const std::string& CLangInfo::GetRegionLocale() const
 {
   return m_currentRegion->m_strRegionLocaleName;
 }
 
 // Returns the format string for the date of the current language
-const CStdString& CLangInfo::GetDateFormat(bool bLongDate/*=false*/) const
+const std::string& CLangInfo::GetDateFormat(bool bLongDate/*=false*/) const
 {
   if (bLongDate)
     return m_currentRegion->m_strDateFormatLong;
@@ -554,18 +554,18 @@ const CStdString& CLangInfo::GetDateFormat(bool bLongDate/*=false*/) const
 }
 
 // Returns the format string for the time of the current language
-const CStdString& CLangInfo::GetTimeFormat() const
+const std::string& CLangInfo::GetTimeFormat() const
 {
   return m_currentRegion->m_strTimeFormat;
 }
 
-const CStdString& CLangInfo::GetTimeZone() const
+const std::string& CLangInfo::GetTimeZone() const
 {
   return m_currentRegion->m_strTimeZone;
 }
 
 // Returns the AM/PM symbol of the current language
-const CStdString& CLangInfo::GetMeridiemSymbol(MERIDIEM_SYMBOL symbol) const
+const std::string& CLangInfo::GetMeridiemSymbol(MERIDIEM_SYMBOL symbol) const
 {
   return m_currentRegion->m_strMeridiemSymbols[symbol];
 }
@@ -575,7 +575,7 @@ void CLangInfo::GetRegionNames(vector<string>& array)
 {
   for (ITMAPREGIONS it=m_regions.begin(); it!=m_regions.end(); ++it)
   {
-    CStdString strName=it->first;
+    std::string strName=it->first;
     if (strName=="N/A")
       strName=g_localizeStrings.Get(416);
     array.push_back(strName);
@@ -584,7 +584,7 @@ void CLangInfo::GetRegionNames(vector<string>& array)
 
 // Set the current region by its name, names from GetRegionNames() are valid.
 // If the region is not found the first available region is set.
-void CLangInfo::SetCurrentRegion(const CStdString& strName)
+void CLangInfo::SetCurrentRegion(const std::string& strName)
 {
   ITMAPREGIONS it=m_regions.find(strName);
   if (it!=m_regions.end())
@@ -598,7 +598,7 @@ void CLangInfo::SetCurrentRegion(const CStdString& strName)
 }
 
 // Returns the current region set for this language
-const CStdString& CLangInfo::GetCurrentRegion() const
+const std::string& CLangInfo::GetCurrentRegion() const
 {
   return m_currentRegion->m_strName;
 }
@@ -609,7 +609,7 @@ CLangInfo::TEMP_UNIT CLangInfo::GetTempUnit() const
 }
 
 // Returns the temperature unit string for the current language
-const CStdString& CLangInfo::GetTempUnitString() const
+const std::string& CLangInfo::GetTempUnitString() const
 {
   return g_localizeStrings.Get(TEMP_UNIT_STRINGS+m_currentRegion->m_tempUnit);
 }
@@ -620,7 +620,7 @@ CLangInfo::SPEED_UNIT CLangInfo::GetSpeedUnit() const
 }
 
 // Returns the speed unit string for the current language
-const CStdString& CLangInfo::GetSpeedUnitString() const
+const std::string& CLangInfo::GetSpeedUnitString() const
 {
   return g_localizeStrings.Get(SPEED_UNIT_STRINGS+m_currentRegion->m_speedUnit);
 }
@@ -673,10 +673,10 @@ void CLangInfo::SettingOptionsRegionsFiller(const CSetting *setting, std::vector
   bool match = false;
   for (unsigned int i = 0; i < regions.size(); ++i)
   {
-    CStdString region = regions[i];
+    std::string region = regions[i];
     list.push_back(make_pair(region, region));
 
-    if (!match && region.Equals(((CSettingString*)setting)->GetValue().c_str()))
+    if (!match && region == ((CSettingString*)setting)->GetValue())
     {
       match = true;
       current = region;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -20,9 +20,10 @@
  */
 
 #include "settings/lib/ISettingCallback.h"
-#include "utils/StdString.h"
 
 #include <map>
+#include <string>
+#include <vector>
 
 #ifdef TARGET_WINDOWS
 #ifdef GetDateFormat
@@ -45,23 +46,23 @@ public:
 
   bool Load(const std::string& strFileName, bool onlyCheckLanguage = false);
 
-  CStdString GetGuiCharSet() const;
-  CStdString GetSubtitleCharSet() const;
+  std::string GetGuiCharSet() const;
+  std::string GetSubtitleCharSet() const;
 
   // three char language code (not win32 specific)
-  const CStdString& GetLanguageCode() const { return m_languageCodeGeneral; }
+  const std::string& GetLanguageCode() const { return m_languageCodeGeneral; }
 
   bool SetLanguage(const std::string &strLanguage);
   bool CheckLoadLanguage(const std::string &language);
 
-  const CStdString& GetAudioLanguage() const;
+  const std::string& GetAudioLanguage() const;
   // language can either be a two char language code as defined in ISO639
   // or a three char language code
   // or a language name in english (as used by XBMC)
   void SetAudioLanguage(const std::string& language);
   
   // three char language code (not win32 specific)
-  const CStdString& GetSubtitleLanguage() const;
+  const std::string& GetSubtitleLanguage() const;
   // language can either be a two char language code as defined in ISO639
   // or a three char language code
   // or a language name in english (as used by XBMC)
@@ -70,14 +71,14 @@ public:
   const std::string GetDVDMenuLanguage() const;
   const std::string GetDVDAudioLanguage() const;
   const std::string GetDVDSubtitleLanguage() const;
-  const CStdString& GetTimeZone() const;
+  const std::string& GetTimeZone() const;
 
-  const CStdString& GetRegionLocale() const;
+  const std::string& GetRegionLocale() const;
   const std::string GetLanguageLocale(bool twochar = false) const;
 
   bool ForceUnicodeFont() const { return m_currentRegion->m_forceUnicodeFont; }
 
-  const CStdString& GetDateFormat(bool bLongDate=false) const;
+  const std::string& GetDateFormat(bool bLongDate=false) const;
 
   typedef enum _MERIDIEM_SYMBOL
   {
@@ -86,8 +87,8 @@ public:
     MERIDIEM_SYMBOL_MAX
   } MERIDIEM_SYMBOL;
 
-  const CStdString& GetTimeFormat() const;
-  const CStdString& GetMeridiemSymbol(MERIDIEM_SYMBOL symbol) const;
+  const std::string& GetTimeFormat() const;
+  const std::string& GetMeridiemSymbol(MERIDIEM_SYMBOL symbol) const;
 
   typedef enum _TEMP_UNIT
   {
@@ -101,7 +102,7 @@ public:
     TEMP_UNIT_NEWTON
   } TEMP_UNIT;
 
-  const CStdString& GetTempUnitString() const;
+  const std::string& GetTempUnitString() const;
   CLangInfo::TEMP_UNIT GetTempUnit() const;
 
 
@@ -121,16 +122,16 @@ public:
     SPEED_UNIT_FPF // Furlong per Fortnight
   } SPEED_UNIT;
 
-  const CStdString& GetSpeedUnitString() const;
+  const std::string& GetSpeedUnitString() const;
   CLangInfo::SPEED_UNIT GetSpeedUnit() const;
 
   void GetRegionNames(std::vector<std::string>& array);
-  void SetCurrentRegion(const CStdString& strName);
-  const CStdString& GetCurrentRegion() const;
+  void SetCurrentRegion(const std::string& strName);
+  const std::string& GetCurrentRegion() const;
 
   static bool CheckLanguage(const std::string& language);
 
-  static void LoadTokens(const TiXmlNode* pTokens, std::vector<CStdString>& vecTokens);
+  static void LoadTokens(const TiXmlNode* pTokens, std::vector<std::string>& vecTokens);
 
   static void SettingOptionsLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStreamLanguagesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
@@ -146,42 +147,42 @@ protected:
     CRegion();
     virtual ~CRegion();
     void SetDefaults();
-    void SetTempUnit(const CStdString& strUnit);
-    void SetSpeedUnit(const CStdString& strUnit);
-    void SetTimeZone(const CStdString& strTimeZone);
+    void SetTempUnit(const std::string& strUnit);
+    void SetSpeedUnit(const std::string& strUnit);
+    void SetTimeZone(const std::string& strTimeZone);
     void SetGlobalLocale();
-    CStdString m_strGuiCharSet;
-    CStdString m_strSubtitleCharSet;
-    CStdString m_strDVDMenuLanguage;
-    CStdString m_strDVDAudioLanguage;
-    CStdString m_strDVDSubtitleLanguage;
-    CStdString m_strLangLocaleName;
+    std::string m_strGuiCharSet;
+    std::string m_strSubtitleCharSet;
+    std::string m_strDVDMenuLanguage;
+    std::string m_strDVDAudioLanguage;
+    std::string m_strDVDSubtitleLanguage;
+    std::string m_strLangLocaleName;
     std::string m_strLangLocaleCodeTwoChar;
-    CStdString m_strRegionLocaleName;
+    std::string m_strRegionLocaleName;
     bool m_forceUnicodeFont;
-    CStdString m_strName;
-    CStdString m_strDateFormatLong;
-    CStdString m_strDateFormatShort;
-    CStdString m_strTimeFormat;
-    CStdString m_strMeridiemSymbols[MERIDIEM_SYMBOL_MAX];
-    CStdString m_strTimeZone;
+    std::string m_strName;
+    std::string m_strDateFormatLong;
+    std::string m_strDateFormatShort;
+    std::string m_strTimeFormat;
+    std::string m_strMeridiemSymbols[MERIDIEM_SYMBOL_MAX];
+    std::string m_strTimeZone;
 
     TEMP_UNIT m_tempUnit;
     SPEED_UNIT m_speedUnit;
   };
 
 
-  typedef std::map<CStdString, CRegion> MAPREGIONS;
-  typedef std::map<CStdString, CRegion>::iterator ITMAPREGIONS;
-  typedef std::pair<CStdString, CRegion> PAIR_REGIONS;
+  typedef std::map<std::string, CRegion> MAPREGIONS;
+  typedef std::map<std::string, CRegion>::iterator ITMAPREGIONS;
+  typedef std::pair<std::string, CRegion> PAIR_REGIONS;
   MAPREGIONS m_regions;
   CRegion* m_currentRegion; // points to the current region
   CRegion m_defaultRegion; // default, will be used if no region available via langinfo.xml
 
-  CStdString m_audioLanguage;
-  CStdString m_subtitleLanguage;
+  std::string m_audioLanguage;
+  std::string m_subtitleLanguage;
   // this is the general (not win32-specific) three char language code
-  CStdString m_languageCodeGeneral;
+  std::string m_languageCodeGeneral;
 };
 
 

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -320,7 +320,7 @@ bool CTextureCache::Export(const CStdString &image, const CStdString &destinatio
   CStdString cachedImage(GetCachedImage(image, details));
   if (!cachedImage.empty())
   {
-    CStdString dest = destination + URIUtils::GetExtension(cachedImage);
+    CStdString dest = destination + CStdString(URIUtils::GetExtension(cachedImage));
     if (overwrite || !CFile::Exists(dest))
     {
       if (CFile::Copy(cachedImage, dest))

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -167,7 +167,7 @@ CBaseTexture *CTextureCacheJob::LoadImage(const CStdString &image, unsigned int 
   CFileItem file(image, false);
   file.FillInMimeType();
   if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ() ))
-      && !StringUtils::StartsWithNoCase(file.GetMimeType(), "image/") && !file.GetMimeType().Equals("application/octet-stream")) // ignore non-pictures
+      && !StringUtils::StartsWithNoCase(file.GetMimeType(), "image/") && !StringUtils::EqualsNoCase(file.GetMimeType(), "application/octet-stream")) // ignore non-pictures
     return NULL;
 
   CBaseTexture *texture = CBaseTexture::LoadFromFile(image, width, height, CSettings::Get().GetBool("pictures.useexifrotation"), requirePixels, file.GetMimeType());

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -37,7 +37,7 @@
 using namespace std;
 using namespace ADDON;
 
-CURL::CURL(const CStdString& strURL1)
+CURL::CURL(const std::string& strURL1)
 {
   Parse(strURL1);
 }
@@ -68,11 +68,11 @@ void CURL::Reset()
   m_iPort = 0;
 }
 
-void CURL::Parse(const CStdString& strURL1)
+void CURL::Parse(const std::string& strURL1)
 {
   Reset();
   // start by validating the path
-  CStdString strURL = CUtil::ValidatePath(strURL1);
+  std::string strURL = CUtil::ValidatePath(strURL1);
 
   // strURL can be one of the following:
   // format 1: protocol://[username:password]@hostname[:port]/directoryandfile
@@ -81,7 +81,7 @@ void CURL::Parse(const CStdString& strURL1)
   //
   // first need 2 check if this is a protocol or just a normal drive & path
   if (!strURL.size()) return ;
-  if (strURL.Equals("?", true)) return;
+  if (strURL == "?") return;
 
   // form is format 1 or 2
   // format 1: protocol://[domain;][username:password]@hostname[:port]/directoryandfile
@@ -220,7 +220,7 @@ void CURL::Parse(const CStdString& strURL1)
     if (iAlphaSign != std::string::npos && iAlphaSign < iEnd && (iAlphaSign < iSlash || iSlash == std::string::npos))
     {
       // username/password found
-      CStdString strUserNamePassword = strURL.substr(iPos, iAlphaSign - iPos);
+      std::string strUserNamePassword = strURL.substr(iPos, iAlphaSign - iPos);
 
       // first extract domain, if protocol is smb
       if (IsProtocol("smb"))
@@ -258,7 +258,7 @@ void CURL::Parse(const CStdString& strURL1)
   // detect hostname:port/
   if (iSlash == std::string::npos)
   {
-    CStdString strHostNameAndPort = strURL.substr(iPos, iEnd - iPos);
+    std::string strHostNameAndPort = strURL.substr(iPos, iEnd - iPos);
     size_t iColon = strHostNameAndPort.find(":");
     if (iColon != std::string::npos)
     {
@@ -273,7 +273,7 @@ void CURL::Parse(const CStdString& strURL1)
   }
   else
   {
-    CStdString strHostNameAndPort = strURL.substr(iPos, iSlash - iPos);
+    std::string strHostNameAndPort = strURL.substr(iPos, iSlash - iPos);
     size_t iColon = strHostNameAndPort.find(":");
     if (iColon != std::string::npos)
     {
@@ -335,7 +335,7 @@ void CURL::Parse(const CStdString& strURL1)
   m_strPassword = Decode(m_strPassword);
 }
 
-void CURL::SetFileName(const CStdString& strFileName)
+void CURL::SetFileName(const std::string& strFileName)
 {
   m_strFileName = strFileName;
 
@@ -350,28 +350,28 @@ void CURL::SetFileName(const CStdString& strFileName)
   StringUtils::ToLower(m_strFileType);
 }
 
-void CURL::SetHostName(const CStdString& strHostName)
+void CURL::SetHostName(const std::string& strHostName)
 {
   m_strHostName = strHostName;
 }
 
-void CURL::SetUserName(const CStdString& strUserName)
+void CURL::SetUserName(const std::string& strUserName)
 {
   m_strUserName = strUserName;
 }
 
-void CURL::SetPassword(const CStdString& strPassword)
+void CURL::SetPassword(const std::string& strPassword)
 {
   m_strPassword = strPassword;
 }
 
-void CURL::SetProtocol(const CStdString& strProtocol)
+void CURL::SetProtocol(const std::string& strProtocol)
 {
   m_strProtocol = strProtocol;
   StringUtils::ToLower(m_strProtocol);
 }
 
-void CURL::SetOptions(const CStdString& strOptions)
+void CURL::SetOptions(const std::string& strOptions)
 {
   m_strOptions.clear();
   m_options.Clear();
@@ -390,7 +390,7 @@ void CURL::SetOptions(const CStdString& strOptions)
   }
 }
 
-void CURL::SetProtocolOptions(const CStdString& strOptions)
+void CURL::SetProtocolOptions(const std::string& strOptions)
 {
   m_strProtocolOptions.clear();
   m_protocolOptions.Clear();
@@ -420,42 +420,42 @@ int CURL::GetPort() const
 }
 
 
-const CStdString& CURL::GetHostName() const
+const std::string& CURL::GetHostName() const
 {
   return m_strHostName;
 }
 
-const CStdString&  CURL::GetShareName() const
+const std::string&  CURL::GetShareName() const
 {
   return m_strShareName;
 }
 
-const CStdString& CURL::GetDomain() const
+const std::string& CURL::GetDomain() const
 {
   return m_strDomain;
 }
 
-const CStdString& CURL::GetUserName() const
+const std::string& CURL::GetUserName() const
 {
   return m_strUserName;
 }
 
-const CStdString& CURL::GetPassWord() const
+const std::string& CURL::GetPassWord() const
 {
   return m_strPassword;
 }
 
-const CStdString& CURL::GetFileName() const
+const std::string& CURL::GetFileName() const
 {
   return m_strFileName;
 }
 
-const CStdString& CURL::GetProtocol() const
+const std::string& CURL::GetProtocol() const
 {
   return m_strProtocol;
 }
 
-const CStdString CURL::GetTranslatedProtocol() const
+const std::string CURL::GetTranslatedProtocol() const
 {
   if (IsProtocol("shout")
    || IsProtocol("daap")
@@ -470,22 +470,22 @@ const CStdString CURL::GetTranslatedProtocol() const
   return GetProtocol();
 }
 
-const CStdString& CURL::GetFileType() const
+const std::string& CURL::GetFileType() const
 {
   return m_strFileType;
 }
 
-const CStdString& CURL::GetOptions() const
+const std::string& CURL::GetOptions() const
 {
   return m_strOptions;
 }
 
-const CStdString& CURL::GetProtocolOptions() const
+const std::string& CURL::GetProtocolOptions() const
 {
   return m_strProtocolOptions;
 }
 
-const CStdString CURL::GetFileNameWithoutPath() const
+const std::string CURL::GetFileNameWithoutPath() const
 {
   // *.zip and *.rar store the actual zip/rar path in the hostname of the url
   if ((IsProtocol("rar")  ||
@@ -495,7 +495,7 @@ const CStdString CURL::GetFileNameWithoutPath() const
     return URIUtils::GetFileName(m_strHostName);
 
   // otherwise, we've already got the filepath, so just grab the filename portion
-  CStdString file(m_strFileName);
+  std::string file(m_strFileName);
   URIUtils::RemoveSlashAtEnd(file);
   return URIUtils::GetFileName(file);
 }
@@ -510,7 +510,7 @@ char CURL::GetDirectorySeparator() const
     return '/';
 }
 
-CStdString CURL::Get() const
+std::string CURL::Get() const
 {
   unsigned int sizeneed = m_strProtocol.length()
                         + m_strDomain.length()
@@ -522,10 +522,10 @@ CStdString CURL::Get() const
                         + m_strProtocolOptions.length()
                         + 10;
 
-  if (m_strProtocol == "")
+  if (m_strProtocol.empty())
     return m_strFileName;
 
-  CStdString strURL;
+  std::string strURL;
   strURL.reserve(sizeneed);
 
   strURL = GetWithoutFilename();
@@ -572,7 +572,7 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
 
   strURL.reserve(sizeneed);
 
-  if (m_strProtocol == "")
+  if (m_strProtocol.empty())
     return m_strFileName;
 
   strURL = m_strProtocol;
@@ -618,9 +618,9 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
   return strURL;
 }
 
-CStdString CURL::GetWithoutFilename() const
+std::string CURL::GetWithoutFilename() const
 {
-  if (m_strProtocol == "")
+  if (m_strProtocol.empty())
     return "";
 
   unsigned int sizeneed = m_strProtocol.length()
@@ -630,43 +630,39 @@ CStdString CURL::GetWithoutFilename() const
                         + m_strHostName.length()
                         + 10;
 
-  CStdString strURL;
+  std::string strURL;
   strURL.reserve(sizeneed);
 
   strURL = m_strProtocol;
   strURL += "://";
 
-  if (m_strDomain != "")
+  if (!m_strDomain.empty())
   {
     strURL += m_strDomain;
     strURL += ";";
   }
 
-  if (m_strUserName != "")
+  if (!m_strUserName.empty())
   {
     strURL += Encode(m_strUserName);
-    if (m_strPassword != "")
+    if (!m_strPassword.empty())
     {
       strURL += ":";
       strURL += Encode(m_strPassword);
     }
     strURL += "@";
   }
-  else if (m_strDomain != "")
+  else if (!m_strDomain.empty())
     strURL += "@";
 
-  if (m_strHostName != "")
+  if (!m_strHostName.empty())
   {
     if( URIUtils::HasEncodedHostname(*this) )
       strURL += Encode(m_strHostName);
     else
       strURL += m_strHostName;
     if (HasPort())
-    {
-      CStdString strPort = StringUtils::Format("%i", m_iPort);
-      strURL += ":";
-      strURL += strPort;
-    }
+      strURL += ':' + StringUtils::Format("%i", m_iPort);
     strURL += "/";
   }
 
@@ -690,15 +686,17 @@ bool CURL::IsLocal() const
 
 bool CURL::IsLocalHost() const
 {
-  return (m_strHostName.Equals("localhost") || m_strHostName.Equals("127.0.0.1"));
+  // localhost is case-insensitive
+  return (StringUtils::EqualsNoCase(m_strHostName, "localhost") ||
+          m_strHostName == "127.0.0.1");
 }
 
-bool CURL::IsFileOnly(const CStdString &url)
+bool CURL::IsFileOnly(const std::string &url)
 {
-  return url.find_first_of("/\\") == CStdString::npos;
+  return url.find_first_of("/\\") == std::string::npos;
 }
 
-bool CURL::IsFullPath(const CStdString &url)
+bool CURL::IsFullPath(const std::string &url)
 {
   if (url.size() && url[0] == '/') return true;     //   /foo/bar.ext
   if (url.find("://") != std::string::npos) return true;                 //   foo://bar.ext
@@ -780,19 +778,19 @@ bool CURL::IsProtocolEqual(const std::string &protocol, const char *type)
   return false;
 }
 
-void CURL::GetOptions(std::map<CStdString, CStdString> &options) const
+void CURL::GetOptions(std::map<std::string, std::string> &options) const
 {
   CUrlOptions::UrlOptions optionsMap = m_options.GetOptions();
   for (CUrlOptions::UrlOptions::const_iterator option = optionsMap.begin(); option != optionsMap.end(); option++)
     options[option->first] = option->second.asString();
 }
 
-bool CURL::HasOption(const CStdString &key) const
+bool CURL::HasOption(const std::string &key) const
 {
   return m_options.HasOption(key);
 }
 
-bool CURL::GetOption(const CStdString &key, CStdString &value) const
+bool CURL::GetOption(const std::string &key, std::string &value) const
 {
   CVariant valueObj;
   if (!m_options.GetOption(key, valueObj))
@@ -802,40 +800,40 @@ bool CURL::GetOption(const CStdString &key, CStdString &value) const
   return true;
 }
 
-CStdString CURL::GetOption(const CStdString &key) const
+std::string CURL::GetOption(const std::string &key) const
 {
-  CStdString value;
+  std::string value;
   if (!GetOption(key, value))
     return "";
 
   return value;
 }
 
-void CURL::SetOption(const CStdString &key, const CStdString &value)
+void CURL::SetOption(const std::string &key, const std::string &value)
 {
   m_options.AddOption(key, value);
   SetOptions(m_options.GetOptionsString(true));
 }
 
-void CURL::RemoveOption(const CStdString &key)
+void CURL::RemoveOption(const std::string &key)
 {
   m_options.RemoveOption(key);
   SetOptions(m_options.GetOptionsString(true));
 }
 
-void CURL::GetProtocolOptions(std::map<CStdString, CStdString> &options) const
+void CURL::GetProtocolOptions(std::map<std::string, std::string> &options) const
 {
   CUrlOptions::UrlOptions optionsMap = m_protocolOptions.GetOptions();
   for (CUrlOptions::UrlOptions::const_iterator option = optionsMap.begin(); option != optionsMap.end(); option++)
     options[option->first] = option->second.asString();
 }
 
-bool CURL::HasProtocolOption(const CStdString &key) const
+bool CURL::HasProtocolOption(const std::string &key) const
 {
   return m_protocolOptions.HasOption(key);
 }
 
-bool CURL::GetProtocolOption(const CStdString &key, CStdString &value) const
+bool CURL::GetProtocolOption(const std::string &key, std::string &value) const
 {
   CVariant valueObj;
   if (!m_protocolOptions.GetOption(key, valueObj))
@@ -845,22 +843,22 @@ bool CURL::GetProtocolOption(const CStdString &key, CStdString &value) const
   return true;
 }
 
-CStdString CURL::GetProtocolOption(const CStdString &key) const
+std::string CURL::GetProtocolOption(const std::string &key) const
 {
-  CStdString value;
+  std::string value;
   if (!GetProtocolOption(key, value))
     return "";
   
   return value;
 }
 
-void CURL::SetProtocolOption(const CStdString &key, const CStdString &value)
+void CURL::SetProtocolOption(const std::string &key, const std::string &value)
 {
   m_protocolOptions.AddOption(key, value);
   m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);
 }
 
-void CURL::RemoveProtocolOption(const CStdString &key)
+void CURL::RemoveProtocolOption(const std::string &key)
 {
   m_protocolOptions.RemoveOption(key);
   m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -19,7 +19,8 @@
  *
  */
 
-#include "utils/StdString.h"
+#include <stdlib.h>
+#include <string>
 #include "utils/UrlOptions.h"
 
 #ifdef TARGET_WINDOWS
@@ -29,7 +30,7 @@
 class CURL
 {
 public:
-  explicit CURL(const CStdString& strURL);
+  explicit CURL(const std::string& strURL);
   CURL();
   virtual ~CURL(void);
 
@@ -37,43 +38,43 @@ public:
   bool operator==(const std::string &url) const { return Get() == url; }
 
   void Reset();
-  void Parse(const CStdString& strURL);
-  void SetFileName(const CStdString& strFileName);
-  void SetHostName(const CStdString& strHostName);
-  void SetUserName(const CStdString& strUserName);
-  void SetPassword(const CStdString& strPassword);
-  void SetProtocol(const CStdString& strProtocol);
-  void SetOptions(const CStdString& strOptions);
-  void SetProtocolOptions(const CStdString& strOptions);
+  void Parse(const std::string& strURL);
+  void SetFileName(const std::string& strFileName);
+  void SetHostName(const std::string& strHostName);
+  void SetUserName(const std::string& strUserName);
+  void SetPassword(const std::string& strPassword);
+  void SetProtocol(const std::string& strProtocol);
+  void SetOptions(const std::string& strOptions);
+  void SetProtocolOptions(const std::string& strOptions);
   void SetPort(int port);
 
   bool HasPort() const;
 
   int GetPort() const;
-  const CStdString& GetHostName() const;
-  const CStdString& GetDomain() const;
-  const CStdString& GetUserName() const;
-  const CStdString& GetPassWord() const;
-  const CStdString& GetFileName() const;
-  const CStdString& GetProtocol() const;
-  const CStdString GetTranslatedProtocol() const;
-  const CStdString& GetFileType() const;
-  const CStdString& GetShareName() const;
-  const CStdString& GetOptions() const;
-  const CStdString& GetProtocolOptions() const;
-  const CStdString GetFileNameWithoutPath() const; /* return the filename excluding path */
+  const std::string& GetHostName() const;
+  const std::string& GetDomain() const;
+  const std::string& GetUserName() const;
+  const std::string& GetPassWord() const;
+  const std::string& GetFileName() const;
+  const std::string& GetProtocol() const;
+  const std::string GetTranslatedProtocol() const;
+  const std::string& GetFileType() const;
+  const std::string& GetShareName() const;
+  const std::string& GetOptions() const;
+  const std::string& GetProtocolOptions() const;
+  const std::string GetFileNameWithoutPath() const; /* return the filename excluding path */
 
   char GetDirectorySeparator() const;
 
-  CStdString Get() const;
+  std::string Get() const;
   std::string GetWithoutUserDetails(bool redact = false) const;
-  CStdString GetWithoutFilename() const;
+  std::string GetWithoutFilename() const;
   std::string GetRedacted() const;
   static std::string GetRedacted(const std::string& path);
   bool IsLocal() const;
   bool IsLocalHost() const;
-  static bool IsFileOnly(const CStdString &url); ///< return true if there are no directories in the url.
-  static bool IsFullPath(const CStdString &url); ///< return true if the url includes the full path
+  static bool IsFileOnly(const std::string &url); ///< return true if there are no directories in the url.
+  static bool IsFullPath(const std::string &url); ///< return true if the url includes the full path
   static std::string Decode(const std::string& strURLData);
   static std::string Encode(const std::string& strURLData);
 
@@ -107,32 +108,32 @@ public:
     return m_strFileType == type;
   }
 
-  void GetOptions(std::map<CStdString, CStdString> &options) const;
-  bool HasOption(const CStdString &key) const;
-  bool GetOption(const CStdString &key, CStdString &value) const;
-  CStdString GetOption(const CStdString &key) const;
-  void SetOption(const CStdString &key, const CStdString &value);
-  void RemoveOption(const CStdString &key);
+  void GetOptions(std::map<std::string, std::string> &options) const;
+  bool HasOption(const std::string &key) const;
+  bool GetOption(const std::string &key, std::string &value) const;
+  std::string GetOption(const std::string &key) const;
+  void SetOption(const std::string &key, const std::string &value);
+  void RemoveOption(const std::string &key);
 
-  void GetProtocolOptions(std::map<CStdString, CStdString> &options) const;
-  bool HasProtocolOption(const CStdString &key) const;
-  bool GetProtocolOption(const CStdString &key, CStdString &value) const;
-  CStdString GetProtocolOption(const CStdString &key) const;
-  void SetProtocolOption(const CStdString &key, const CStdString &value);
-  void RemoveProtocolOption(const CStdString &key);
+  void GetProtocolOptions(std::map<std::string, std::string> &options) const;
+  bool HasProtocolOption(const std::string &key) const;
+  bool GetProtocolOption(const std::string &key, std::string &value) const;
+  std::string GetProtocolOption(const std::string &key) const;
+  void SetProtocolOption(const std::string &key, const std::string &value);
+  void RemoveProtocolOption(const std::string &key);
 
 protected:
   int m_iPort;
-  CStdString m_strHostName;
-  CStdString m_strShareName;
-  CStdString m_strDomain;
-  CStdString m_strUserName;
-  CStdString m_strPassword;
-  CStdString m_strFileName;
-  CStdString m_strProtocol;
-  CStdString m_strFileType;
-  CStdString m_strOptions;
-  CStdString m_strProtocolOptions;
+  std::string m_strHostName;
+  std::string m_strShareName;
+  std::string m_strDomain;
+  std::string m_strUserName;
+  std::string m_strPassword;
+  std::string m_strFileName;
+  std::string m_strProtocol;
+  std::string m_strFileType;
+  std::string m_strOptions;
+  std::string m_strProtocolOptions;
   CUrlOptions m_options;
   CUrlOptions m_protocolOptions;
 };

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2061,9 +2061,9 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
   // zip only gets the root dir
   if (URIUtils::HasExtension(strArchivePath, ".zip"))
   {
-   CStdString strZipPath;
-   URIUtils::CreateArchivePath(strZipPath,"zip",strArchivePath,"");
-   if (!CDirectory::GetDirectory(strZipPath,ItemList,"",DIR_FLAG_NO_FILE_DIRS))
+   CURL pathToUrl(strArchivePath);
+   CURL zipURL = URIUtils::CreateArchivePath("zip", pathToUrl, "");
+   if (!CDirectory::GetDirectory(zipURL, ItemList, "", DIR_FLAG_NO_FILE_DIRS))
     return false;
   }
   else
@@ -2087,12 +2087,13 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
    // checking for embedded rars, I moved this outside the sub_ext[] loop. We only need to check this once for each file.
    if (URIUtils::IsRAR(strPathInRar) || URIUtils::IsZIP(strPathInRar))
    {
-    CStdString strRarInRar;
+    CURL urlRar;
+    CURL pathToUrl(strArchivePath);
     if (strExt == ".rar")
-      URIUtils::CreateArchivePath(strRarInRar, "rar", strArchivePath, strPathInRar);
+      urlRar = URIUtils::CreateArchivePath("rar", pathToUrl, strPathInRar);
     else
-      URIUtils::CreateArchivePath(strRarInRar, "zip", strArchivePath, strPathInRar);
-    ScanArchiveForSubtitles(strRarInRar,strMovieFileNameNoExt,vecSubtitles);
+      urlRar = URIUtils::CreateArchivePath("zip", pathToUrl, strPathInRar);
+    ScanArchiveForSubtitles(urlRar.Get(), strMovieFileNameNoExt, vecSubtitles);
    }
    // done checking if this is a rar-in-rar
 
@@ -2106,9 +2107,10 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
     {
      if (StringUtils::EqualsNoCase(strExt, sub_exts[iPos]))
      {
+       CURL pathToURL(strArchivePath);
       CStdString strSourceUrl;
       if (URIUtils::HasExtension(strArchivePath, ".rar"))
-       URIUtils::CreateArchivePath(strSourceUrl, "rar", strArchivePath, strPathInRar);
+       strSourceUrl = URIUtils::CreateArchivePath("rar", pathToURL, strPathInRar).Get();
       else
        strSourceUrl = strPathInRar;
       

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1397,7 +1397,7 @@ void CUtil::GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& it
   CDirectory::GetDirectory(strPath,myItems,"",flags);
   for (int i=0;i<myItems.Size();++i)
   {
-    if (myItems[i]->m_bIsFolder && !myItems[i]->GetPath().Equals(".."))
+    if (myItems[i]->m_bIsFolder && !myItems[i]->IsPath(".."))
     {
       item.Add(myItems[i]);
       CUtil::GetRecursiveDirsListing(myItems[i]->GetPath(),item,flags);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1235,7 +1235,7 @@ int CUtil::GetMatchingSource(const CStdString& strPath1, VECSOURCES& VECSOURCES,
     if (share.strPath.substr(0,8) == "shout://")
     {
       CURL url(share.strPath);
-      if (strPath.Equals(url.GetHostName()))
+      if (strPath == url.GetHostName())
         return i;
     }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -240,11 +240,16 @@ CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */
   return strFilename;
 }
 
-void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CStdString& strTitleAndYear, CStdString& strYear, bool bRemoveExtension /* = false */, bool bCleanChars /* = true */)
+void CUtil::CleanString(const std::string& strFileName,
+                        std::string& strTitle,
+                        std::string& strTitleAndYear,
+                        std::string& strYear,
+                        bool bRemoveExtension /* = false */,
+                        bool bCleanChars /* = true */)
 {
   strTitleAndYear = strFileName;
 
-  if (strFileName.Equals(".."))
+  if (strFileName == "..")
    return;
 
   const vector<string> &regexps = g_advancedSettings.m_videoCleanStringRegExps;
@@ -315,7 +320,7 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
     strTitleAndYear += URIUtils::GetExtension(strFileName);
 }
 
-void CUtil::GetQualifiedFilename(const CStdString &strBasePath, CStdString &strFilename)
+void CUtil::GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename)
 {
   // Check if the filename is a fully qualified URL such as protocol://path/to/file
   CURL plItemUrl(strFilename);
@@ -396,7 +401,7 @@ void CUtil::RunShortcut(const char* szShortcutPath)
 {
 }
 
-void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
+void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
 {
   strPath = CEnvironment::getenv(strTarget);
 
@@ -425,7 +430,7 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
 
   if (strPath.empty())
   {
-    CStdString strHomePath = ResolveExecutablePath();
+    std::string strHomePath = ResolveExecutablePath();
 #if defined(TARGET_DARWIN)
     int      result = -1;
     char     given_path[2*MAXPATHLEN];
@@ -465,8 +470,8 @@ void CUtil::GetHomePath(CStdString& strPath, const CStdString& strTarget)
   /* Change strPath accordingly when target is XBMC_HOME and when INSTALL_PATH
    * and BIN_INSTALL_PATH differ
    */
-  CStdString installPath = INSTALL_PATH;
-  CStdString binInstallPath = BIN_INSTALL_PATH;
+  std::string installPath = INSTALL_PATH;
+  std::string binInstallPath = BIN_INSTALL_PATH;
   if (!strTarget.compare("XBMC_HOME") && installPath.compare(binInstallPath))
   {
     int pos = strPath.length() - binInstallPath.length();
@@ -598,7 +603,7 @@ bool CUtil::GetDirectoryName(const CStdString& strFileName, CStdString& strDescr
   return true;
 }
 
-void CUtil::GetDVDDriveIcon( const CStdString& strPath, CStdString& strIcon )
+void CUtil::GetDVDDriveIcon(const std::string& strPath, std::string& strIcon)
 {
   if ( !g_mediaManager.IsDiscInDrive() )
   {
@@ -1036,9 +1041,9 @@ bool CUtil::TestSplitExec()
 }
 #endif
 
-void CUtil::SplitExecFunction(const CStdString &execString, CStdString &function, vector<string> &parameters)
+void CUtil::SplitExecFunction(const std::string &execString, std::string &function, vector<string> &parameters)
 {
-  CStdString paramString;
+  std::string paramString;
 
   size_t iPos = execString.find("(");
   size_t iPos2 = execString.rfind(")");
@@ -1433,7 +1438,7 @@ double CUtil::AlbumRelevance(const CStdString& strAlbumTemp1, const CStdString& 
   return fRelevance;
 }
 
-bool CUtil::MakeShortenPath(CStdString StrInput, CStdString& StrOutput, size_t iTextMaxLength)
+bool CUtil::MakeShortenPath(std::string StrInput, std::string& StrOutput, size_t iTextMaxLength)
 {
   size_t iStrInputSize = StrInput.size();
   if(iStrInputSize <= 0 || iTextMaxLength >= iStrInputSize)
@@ -1470,7 +1475,7 @@ bool CUtil::MakeShortenPath(CStdString StrInput, CStdString& StrOutput, size_t i
     iStrInputSize = StrInput.size();
   }
   // replace any additional /../../ with just /../ if necessary
-  CStdString replaceDots = StringUtils::Format("..%c..", cDelim);
+  std::string replaceDots = StringUtils::Format("..%c..", cDelim);
   while (StrInput.size() > (unsigned int)iTextMaxLength)
     if (!StringUtils::Replace(StrInput, replaceDots, ".."))
       break;
@@ -1535,9 +1540,9 @@ CStdString CUtil::GetDefaultFolderThumb(const CStdString &folderThumb)
   return "";
 }
 
-void CUtil::GetSkinThemes(vector<CStdString>& vecTheme)
+void CUtil::GetSkinThemes(vector<std::string>& vecTheme)
 {
-  CStdString strPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), "media");
+  std::string strPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), "media");
   CFileItemList items;
   CDirectory::GetDirectory(strPath, items);
   // Search for Themes in the Current skin!
@@ -1550,7 +1555,7 @@ void CUtil::GetSkinThemes(vector<CStdString>& vecTheme)
       if ((strExtension == ".xpr" && !StringUtils::EqualsNoCase(pItem->GetLabel(), "Textures.xpr")) ||
           (strExtension == ".xbt" && !StringUtils::EqualsNoCase(pItem->GetLabel(), "Textures.xbt")))
       {
-        CStdString strLabel = pItem->GetLabel();
+        std::string strLabel = pItem->GetLabel();
         vecTheme.push_back(strLabel.substr(0, strLabel.size() - 4));
       }
     }
@@ -1848,7 +1853,7 @@ CStdString CUtil::GetFrameworksPath(bool forPython)
   return strFrameworksPath;
 }
 
-void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CStdString>& vecSubtitles )
+void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles )
 {
   unsigned int startTimer = XbmcThreads::SystemClockMillis();
   
@@ -1867,7 +1872,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     "Subtitle",
     NULL};
   
-  vector<CStdString> vecExtensionsCached;
+  vector<std::string> vecExtensionsCached;
   
   CFileItem item(strMovie, false);
   if ( item.IsInternetStream()
@@ -1878,13 +1883,13 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     || !item.IsVideo())
     return;
   
-  vector<CStdString> strLookInPaths;
+  vector<std::string> strLookInPaths;
   
-  CStdString strMovieFileName;
-  CStdString strPath;
+  std::string strMovieFileName;
+  std::string strPath;
   
   URIUtils::Split(strMovie, strPath, strMovieFileName);
-  CStdString strMovieFileNameNoExt(URIUtils::ReplaceExtension(strMovieFileName, ""));
+  std::string strMovieFileNameNoExt(URIUtils::ReplaceExtension(strMovieFileName, ""));
   strLookInPaths.push_back(strPath);
   
   if (!CMediaSettings::Get().GetAdditionalSubtitleDirectoryChecked() && !CSettings::Get().GetString("subtitles.custompath").empty()) // to avoid checking non-existent directories (network) every time..
@@ -1906,7 +1911,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
   if (StringUtils::StartsWith(strMovie, "rar://")) // <--- if this is found in main path then ignore it!
   {
     CURL url(strMovie);
-    CStdString strArchive = url.GetHostName();
+    std::string strArchive = url.GetHostName();
     URIUtils::Split(strArchive, strPath, strMovieFileName);
     strLookInPaths.push_back(strPath);
   }
@@ -1921,7 +1926,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     // if it's inside a cdX dir, add parent path
     if (directories.size() >= 2 && directories[directories.size()-2].size() == 3 && StringUtils::StartsWithNoCase(directories[directories.size()-2], "cd")) // SplitString returns empty token as last item, hence size-2
     {
-      CStdString strPath2;
+      std::string strPath2;
       URIUtils::GetParentPath(strLookInPaths[i], strPath2);
       strLookInPaths.push_back(strPath2);
     }
@@ -1933,7 +1938,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
   {
     for (int j=0; common_sub_dirs[j]; j++)
     {
-      CStdString strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],common_sub_dirs[j]);
+      std::string strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],common_sub_dirs[j]);
       URIUtils::AddSlashAtEnd(strPath2);
       if (CDirectory::Exists(strPath2))
         strLookInPaths.push_back(strPath2);
@@ -1945,16 +1950,16 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
   iSize = strLookInPaths.size();
   for (int i=0;i<9;++i) // 9 cd's
   {
-    CStdString cdDir = StringUtils::Format("cd%i",i+1);
+    std::string cdDir = StringUtils::Format("cd%i",i+1);
     for (int i=0;i<iSize;++i)
     {
-      CStdString strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],cdDir);
+      std::string strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],cdDir);
       URIUtils::AddSlashAtEnd(strPath2);
       bool pathAlreadyAdded = false;
       for (unsigned int i=0; i<strLookInPaths.size(); i++)
       {
         // if movie file is inside cd-dir, this directory can exist in vector already
-        if (strLookInPaths[i].Equals( strPath2 ) )
+        if (StringUtils::EqualsNoCase(strLookInPaths[i], strPath2))
           pathAlreadyAdded = true;
       }
       if (CDirectory::Exists(strPath2) && !pathAlreadyAdded) 
@@ -1971,9 +1976,9 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     strLookInPaths.push_back(strPath);
   }
   
-  CStdString strLExt;
-  CStdString strDest;
-  CStdString strItem;
+  std::string strLExt;
+  std::string strDest;
+  std::string strItem;
   
   // 2 steps for movie directory and alternate subtitles directory
   CLog::Log(LOGDEBUG,"%s: Searching for subtitles...", __FUNCTION__);
@@ -2053,7 +2058,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
   CLog::Log(LOGDEBUG,"%s: END (total time: %i ms)", __FUNCTION__, (int)(XbmcThreads::SystemClockMillis() - startTimer));
 }
 
-int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStdString& strMovieFileNameNoExt, std::vector<CStdString>& vecSubtitles )
+int CUtil::ScanArchiveForSubtitles( const std::string& strArchivePath, const std::string& strMovieFileNameNoExt, std::vector<std::string>& vecSubtitles )
 {
   int nSubtitlesAdded = 0;
   CFileItemList ItemList;
@@ -2079,8 +2084,8 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
   }
   for (int it= 0 ; it <ItemList.Size();++it)
   {
-   CStdString strPathInRar = ItemList[it]->GetPath();
-   CStdString strExt = URIUtils::GetExtension(strPathInRar);
+   std::string strPathInRar = ItemList[it]->GetPath();
+   std::string strExt = URIUtils::GetExtension(strPathInRar);
    
    CLog::Log(LOGDEBUG, "ScanArchiveForSubtitles:: Found file %s", strPathInRar.c_str());
    // always check any embedded rar archives
@@ -2197,17 +2202,17 @@ void CUtil::GetExternalStreamDetailsFromFilename(const CStdString& strVideo, con
 
 /*! \brief in a vector of subtitles finds the corresponding .sub file for a given .idx file
  */
-bool CUtil::FindVobSubPair( const std::vector<CStdString>& vecSubtitles, const CStdString& strIdxPath, CStdString& strSubPath )
+bool CUtil::FindVobSubPair(const std::vector<std::string>& vecSubtitles, const std::string& strIdxPath, std::string& strSubPath)
 {
   if (URIUtils::HasExtension(strIdxPath, ".idx"))
   {
-    CStdString strIdxFile;
-    CStdString strIdxDirectory;
+    std::string strIdxFile;
+    std::string strIdxDirectory;
     URIUtils::Split(strIdxPath, strIdxDirectory, strIdxFile);
     for (unsigned int j=0; j < vecSubtitles.size(); j++)
     {
-      CStdString strSubFile;
-      CStdString strSubDirectory;
+      std::string strSubFile;
+      std::string strSubDirectory;
       URIUtils::Split(vecSubtitles[j], strSubDirectory, strSubFile);
       if (URIUtils::IsInArchive(vecSubtitles[j]))
         strSubDirectory = CURL::Decode(strSubDirectory);
@@ -2226,19 +2231,19 @@ bool CUtil::FindVobSubPair( const std::vector<CStdString>& vecSubtitles, const C
 
 /*! \brief checks if in the vector of subtitles the given .sub file has a corresponding idx and hence is a vobsub file
  */
-bool CUtil::IsVobSub( const std::vector<CStdString>& vecSubtitles, const CStdString& strSubPath )
+bool CUtil::IsVobSub(const std::vector<std::string>& vecSubtitles, const std::string& strSubPath)
 {
   if (URIUtils::HasExtension(strSubPath, ".sub"))
   {
-    CStdString strSubFile;
-    CStdString strSubDirectory;
+    std::string strSubFile;
+    std::string strSubDirectory;
     URIUtils::Split(strSubPath, strSubDirectory, strSubFile);
     if (URIUtils::IsInArchive(strSubPath))
       strSubDirectory = CURL::Decode(strSubDirectory);
     for (unsigned int j=0; j < vecSubtitles.size(); j++)
     {
-      CStdString strIdxFile;
-      CStdString strIdxDirectory;
+      std::string strIdxFile;
+      std::string strIdxDirectory;
       URIUtils::Split(vecSubtitles[j], strIdxDirectory, strIdxFile);
       if (URIUtils::HasExtension(strIdxFile, ".idx") &&
           (URIUtils::ReplaceExtension(vecSubtitles[j],"").Equals(URIUtils::ReplaceExtension(strSubPath,"")) ||

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -67,12 +67,17 @@ class CUtil
 public:
   CUtil(void);
   virtual ~CUtil(void);
-  static void CleanString(const CStdString& strFileName, CStdString& strTitle, CStdString& strTitleAndYear, CStdString& strYear, bool bRemoveExtension = false, bool bCleanChars = true);
+  static void CleanString(const std::string& strFileName,
+                          std::string& strTitle,
+                          std::string& strTitleAndYear,
+                          std::string& strYear,
+                          bool bRemoveExtension = false,
+                          bool bCleanChars = true);
   static CStdString GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static CStdString GetTitleFromPath(const CStdString& strFileNameAndPath, bool bIsFolder = false);
-  static void GetQualifiedFilename(const CStdString &strBasePath, CStdString &strFilename);
+  static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);
-  static void GetHomePath(CStdString& strPath, const CStdString& strTarget = "XBMC_HOME");
+  static void GetHomePath(std::string& strPath, const std::string& strTarget = "XBMC_HOME");
   static bool IsPVR(const CStdString& strFile);
   static bool IsHTSP(const CStdString& strFile);
   static bool IsLiveTV(const CStdString& strFile);
@@ -89,16 +94,16 @@ public:
    */
   static CStdString GetFileMD5(const CStdString& strPath);
   static bool GetDirectoryName(const CStdString& strFileName, CStdString& strDescription);
-  static void GetDVDDriveIcon( const CStdString& strPath, CStdString& strIcon );
+  static void GetDVDDriveIcon(const std::string& strPath, std::string& strIcon);
   static void RemoveTempFiles();
   static void ClearTempFonts();
 
   static void ClearSubtitles();
-  static void ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CStdString>& vecSubtitles );
-  static int ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStdString& strMovieFileNameNoExt, std::vector<CStdString>& vecSubtitles );
+  static void ScanForExternalSubtitles(const std::string& strMovie, std::vector<std::string>& vecSubtitles );
+  static int ScanArchiveForSubtitles( const std::string& strArchivePath, const std::string& strMovieFileNameNoExt, std::vector<std::string>& vecSubtitles );
   static void GetExternalStreamDetailsFromFilename(const CStdString& strMovie, const CStdString& strSubtitles, ExternalStreamInfo& info); 
-  static bool FindVobSubPair( const std::vector<CStdString>& vecSubtitles, const CStdString& strIdxPath, CStdString& strSubPath );
-  static bool IsVobSub( const std::vector<CStdString>& vecSubtitles, const CStdString& strSubPath );
+  static bool FindVobSubPair( const std::vector<std::string>& vecSubtitles, const std::string& strIdxPath, std::string& strSubPath );
+  static bool IsVobSub(const std::vector<std::string>& vecSubtitles, const std::string& strSubPath);
   static std::string GetVobSubSubFromIdx(const std::string& vobSubIdx);
   static std::string GetVobSubIdxFromSub(const std::string& vobSub);
   static int64_t ToInt64(uint32_t high, uint32_t low);
@@ -140,7 +145,7 @@ public:
    \param parameters the returned parameters
    */
   static void SplitParams(const CStdString &paramString, std::vector<std::string> &parameters);
-  static void SplitExecFunction(const CStdString &execString, CStdString &function, std::vector<std::string> &parameters);
+  static void SplitExecFunction(const std::string &execString, std::string &function, std::vector<std::string> &parameters);
   static int GetMatchingSource(const CStdString& strPath, VECSOURCES& VECSOURCES, bool& bIsSourceName);
   static CStdString TranslateSpecialSource(const CStdString &strSpecial);
   static void DeleteDirectoryCache(const CStdString &prefix = "");
@@ -149,13 +154,13 @@ public:
   static CStdString MusicPlaylistsLocation();
   static CStdString VideoPlaylistsLocation();
 
-  static void GetSkinThemes(std::vector<CStdString>& vecTheme);
+  static void GetSkinThemes(std::vector<std::string>& vecTheme);
   static void GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, unsigned int flags = 0 /* DIR_FLAG_DEFAULTS */);
   static void GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& items, unsigned int flags = 0 /* DIR_FLAG_DEFAULTS */);
   static void ForceForwardSlashes(CStdString& strPath);
 
   static double AlbumRelevance(const CStdString& strAlbumTemp1, const CStdString& strAlbum1, const CStdString& strArtistTemp1, const CStdString& strArtist1);
-  static bool MakeShortenPath(CStdString StrInput, CStdString& StrOutput, size_t iTextMaxLength);
+  static bool MakeShortenPath(std::string StrInput, std::string& StrOutput, size_t iTextMaxLength);
   /*! \brief Checks wether the supplied path supports Write file operations (e.g. Rename, Delete, ...)
 
    \param strPath the path to be checked

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -180,7 +180,7 @@ void CDateTimeSpan::SetDateTimeSpan(int day, int hour, int minute, int second)
   FromULargeInt(time);
 }
 
-void CDateTimeSpan::SetFromTimeString(const CStdString& time) // hh:mm
+void CDateTimeSpan::SetFromTimeString(const std::string& time) // hh:mm
 {
   if (time.size() >= 5 && time[2] == ':')
   {
@@ -230,14 +230,14 @@ int CDateTimeSpan::GetSecondsTotal() const
   return (int)(time.QuadPart/SECONDS_TO_FILETIME);
 }
 
-void CDateTimeSpan::SetFromPeriod(const CStdString &period)
+void CDateTimeSpan::SetFromPeriod(const std::string &period)
 {
   long days = atoi(period.c_str());
   // find the first non-space and non-number
   size_t pos = period.find_first_not_of("0123456789 ", 0);
   if (pos != std::string::npos)
   {
-    CStdString units = period.substr(pos, 3);
+    std::string units = period.substr(pos, 3);
     if (StringUtils::EqualsNoCase(units, "wee"))
       days *= 7;
     else if (StringUtils::EqualsNoCase(units, "mon"))
@@ -688,7 +688,7 @@ void CDateTime::FromULargeInt(const ULARGE_INTEGER& time)
   m_time.dwLowDateTime=time.u.LowPart;
 }
 
-bool CDateTime::SetFromDateString(const CStdString &date)
+bool CDateTime::SetFromDateString(const std::string &date)
 {
   /* TODO:STRING_CLEANUP */
   if (date.empty())
@@ -703,22 +703,22 @@ bool CDateTime::SetFromDateString(const CStdString &date)
   const char* months[] = {"january","february","march","april","may","june","july","august","september","october","november","december",NULL};
   int j=0;
   size_t iDayPos = date.find("day");
-  size_t iPos = date.find(" ");
+  size_t iPos = date.find(' ');
   if (iDayPos < iPos && iDayPos != std::string::npos)
   {
     iDayPos = iPos + 1;
-    iPos = date.find(" ", iPos+1);
+    iPos = date.find(' ', iPos+1);
   }
   else
     iDayPos = 0;
 
-  CStdString strMonth = date.substr(iDayPos, iPos - iDayPos);
+  std::string strMonth = date.substr(iDayPos, iPos - iDayPos);
   if (strMonth.empty())
     return false;
 
   size_t iPos2 = date.find(",");
-  CStdString strDay = (date.size() >= iPos) ? date.substr(iPos, iPos2-iPos) : "";
-  CStdString strYear = date.substr(date.find(" ", iPos2) + 1);
+  std::string strDay = (date.size() >= iPos) ? date.substr(iPos, iPos2-iPos) : "";
+  std::string strYear = date.substr(date.find(' ', iPos2) + 1);
   while (months[j] && stricmp(strMonth.c_str(),months[j]) != 0)
     j++;
   if (!months[j])
@@ -851,7 +851,7 @@ void CDateTime::GetAsTimeStamp(FILETIME& time) const
   ::LocalFileTimeToFileTime(&m_time, &time);
 }
 
-CStdString CDateTime::GetAsDBDate() const
+std::string CDateTime::GetAsDBDate() const
 {
   SYSTEMTIME st;
   GetAsSystemTime(st);
@@ -859,7 +859,7 @@ CStdString CDateTime::GetAsDBDate() const
   return StringUtils::Format("%04i-%02i-%02i", st.wYear, st.wMonth, st.wDay);
 }
 
-CStdString CDateTime::GetAsDBDateTime() const
+std::string CDateTime::GetAsDBDateTime() const
 {
   SYSTEMTIME st;
   GetAsSystemTime(st);
@@ -867,7 +867,7 @@ CStdString CDateTime::GetAsDBDateTime() const
   return StringUtils::Format("%04i-%02i-%02i %02i:%02i:%02i", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
 }
 
-CStdString CDateTime::GetAsSaveString() const
+std::string CDateTime::GetAsSaveString() const
 {
   SYSTEMTIME st;
   GetAsSystemTime(st);
@@ -923,9 +923,9 @@ bool CDateTime::SetFromUTCDateTime(const time_t &dateTime)
   return SetFromUTCDateTime(tmp);
 }
 
-bool CDateTime::SetFromW3CDate(const CStdString &dateTime)
+bool CDateTime::SetFromW3CDate(const std::string &dateTime)
 {
-  CStdString date;
+  std::string date;
 
   size_t posT = dateTime.find("T");
   if(posT != std::string::npos)
@@ -951,16 +951,16 @@ bool CDateTime::SetFromW3CDate(const CStdString &dateTime)
   return IsValid();
 }
 
-bool CDateTime::SetFromW3CDateTime(const CStdString &dateTime, bool ignoreTimezone /* = false */)
+bool CDateTime::SetFromW3CDateTime(const std::string &dateTime, bool ignoreTimezone /* = false */)
 {
-  CStdString date, time, zone;
+  std::string date, time, zone;
 
   size_t posT = dateTime.find("T");
   if(posT != std::string::npos)
   {
     date = dateTime.substr(0, posT);
-    CStdString::size_type posZ = dateTime.find_first_of("+-Z", posT);
-    if(posZ == CStdString::npos)
+    std::string::size_type posZ = dateTime.find_first_of("+-Z", posT);
+    if(posZ == std::string::npos)
       time = dateTime.substr(posT + 1);
     else
     {
@@ -1018,7 +1018,7 @@ bool CDateTime::SetFromW3CDateTime(const CStdString &dateTime, bool ignoreTimezo
   return IsValid();
 }
 
-bool CDateTime::SetFromDBDateTime(const CStdString &dateTime)
+bool CDateTime::SetFromDBDateTime(const std::string &dateTime)
 {
   // assumes format YYYY-MM-DD HH:MM:SS
   if (dateTime.size() == 19)
@@ -1034,7 +1034,7 @@ bool CDateTime::SetFromDBDateTime(const CStdString &dateTime)
   return false;
 }
 
-bool CDateTime::SetFromDBDate(const CStdString &date)
+bool CDateTime::SetFromDBDate(const std::string &date)
 {
   if (date.size() < 10)
     return false;
@@ -1057,7 +1057,7 @@ bool CDateTime::SetFromDBDate(const CStdString &date)
   return SetDate(year, month, day);
 }
 
-bool CDateTime::SetFromDBTime(const CStdString &time)
+bool CDateTime::SetFromDBTime(const std::string &time)
 {
   if (time.size() < 8)
     return false;
@@ -1072,9 +1072,9 @@ bool CDateTime::SetFromDBTime(const CStdString &time)
   return SetTime(hour, minute, second);
 }
 
-bool CDateTime::SetFromRFC1123DateTime(const CStdString &dateTime)
+bool CDateTime::SetFromRFC1123DateTime(const std::string &dateTime)
 {
-  CStdString date = dateTime;
+  std::string date = dateTime;
   StringUtils::Trim(date);
 
   if (date.size() != 29)
@@ -1082,11 +1082,11 @@ bool CDateTime::SetFromRFC1123DateTime(const CStdString &dateTime)
 
   int day  = strtol(date.substr(5, 2).c_str(), NULL, 10);
 
-  CStdString strMonth = date.substr(8, 3);
+  std::string strMonth = date.substr(8, 3);
   int month = 0;
   for (unsigned int index = 0; index < 12; index++)
   {
-    if (strMonth.Equals(MONTH_NAMES[index]))
+    if (strMonth == MONTH_NAMES[index])
     {
       month = index + 1;
       break;
@@ -1104,16 +1104,16 @@ bool CDateTime::SetFromRFC1123DateTime(const CStdString &dateTime)
   return SetDateTime(year, month, day, hour, min, sec);
 }
 
-CStdString CDateTime::GetAsLocalizedTime(const CStdString &format, bool withSeconds) const
+std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSeconds) const
 {
-  CStdString strOut;
-  const CStdString& strFormat = format.empty() ? g_langInfo.GetTimeFormat() : format;
+  std::string strOut;
+  const std::string& strFormat = format.empty() ? g_langInfo.GetTimeFormat() : format;
 
   SYSTEMTIME dateTime;
   GetAsSystemTime(dateTime);
 
   // Prefetch meridiem symbol
-  const CStdString& strMeridiem=g_langInfo.GetMeridiemSymbol(dateTime.wHour > 11 ? CLangInfo::MERIDIEM_SYMBOL_PM : CLangInfo::MERIDIEM_SYMBOL_AM);
+  const std::string& strMeridiem=g_langInfo.GetMeridiemSymbol(dateTime.wHour > 11 ? CLangInfo::MERIDIEM_SYMBOL_PM : CLangInfo::MERIDIEM_SYMBOL_AM);
 
   size_t length = strFormat.size();
   for (size_t i=0; i < length; ++i)
@@ -1127,7 +1127,7 @@ CStdString CDateTime::GetAsLocalizedTime(const CStdString &format, bool withSeco
       while(((pos = strFormat.find(c, pos + 1)) != std::string::npos &&
              pos<strFormat.size()) && strFormat[pos+1]=='\'') {}
 
-      CStdString strPart;
+      std::string strPart;
       if (pos != std::string::npos)
       {
         // Extract string between ' '
@@ -1172,7 +1172,7 @@ CStdString CDateTime::GetAsLocalizedTime(const CStdString &format, bool withSeco
       }
 
       // Format hour string with the length of the mask
-      CStdString str;
+      std::string str;
       if (partLength==1)
         str = StringUtils::Format("%d", hour);
       else
@@ -1199,7 +1199,7 @@ CStdString CDateTime::GetAsLocalizedTime(const CStdString &format, bool withSeco
       }
 
       // Format minute string with the length of the mask
-      CStdString str;
+      std::string str;
       if (partLength==1)
         str = StringUtils::Format("%d", dateTime.wMinute);
       else
@@ -1228,7 +1228,7 @@ CStdString CDateTime::GetAsLocalizedTime(const CStdString &format, bool withSeco
       if (withSeconds)
       {
         // Format seconds string with the length of the mask
-        CStdString str;
+        std::string str;
         if (partLength==1)
           str = StringUtils::Format("%d", dateTime.wSecond);
         else
@@ -1262,14 +1262,14 @@ CStdString CDateTime::GetAsLocalizedTime(const CStdString &format, bool withSeco
   return strOut;
 }
 
-CStdString CDateTime::GetAsLocalizedDate(bool longDate/*=false*/, bool withShortNames/*=true*/) const
+std::string CDateTime::GetAsLocalizedDate(bool longDate/*=false*/, bool withShortNames/*=true*/) const
 {
   return GetAsLocalizedDate(g_langInfo.GetDateFormat(longDate), withShortNames);
 }
 
-CStdString CDateTime::GetAsLocalizedDate(const CStdString &strFormat, bool withShortNames/*=true*/) const
+std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat, bool withShortNames/*=true*/) const
 {
-  CStdString strOut;
+  std::string strOut;
 
   SYSTEMTIME dateTime;
   GetAsSystemTime(dateTime);
@@ -1287,7 +1287,7 @@ CStdString CDateTime::GetAsLocalizedDate(const CStdString &strFormat, bool withS
              pos < strFormat.size()) &&
             strFormat[pos + 1] == '\'') {}
 
-      CStdString strPart;
+      std::string strPart;
       if (pos != std::string::npos)
       {
         // Extract string between ' '
@@ -1321,7 +1321,7 @@ CStdString CDateTime::GetAsLocalizedDate(const CStdString &strFormat, bool withS
       }
 
       // Format string with the length of the mask
-      CStdString str;
+      std::string str;
       if (partLength==1) // single-digit number
         str = StringUtils::Format("%d", dateTime.wDay);
       else if (partLength==2) // two-digit number
@@ -1353,7 +1353,7 @@ CStdString CDateTime::GetAsLocalizedDate(const CStdString &strFormat, bool withS
       }
 
       // Format string with the length of the mask
-      CStdString str;
+      std::string str;
       if (partLength==1) // single-digit number
         str = StringUtils::Format("%d", dateTime.wMonth);
       else if (partLength==2) // two-digit number
@@ -1385,7 +1385,7 @@ CStdString CDateTime::GetAsLocalizedDate(const CStdString &strFormat, bool withS
       }
 
       // Format string with the length of the mask
-      CStdString str = StringUtils::Format("%d", dateTime.wYear); // four-digit number
+      std::string str = StringUtils::Format("%d", dateTime.wYear); // four-digit number
       if (partLength <= 2)
         str.erase(0, 2); // two-digit number
 
@@ -1398,9 +1398,9 @@ CStdString CDateTime::GetAsLocalizedDate(const CStdString &strFormat, bool withS
   return strOut;
 }
 
-CStdString CDateTime::GetAsLocalizedDateTime(bool longDate/*=false*/, bool withSeconds/*=true*/) const
+std::string CDateTime::GetAsLocalizedDateTime(bool longDate/*=false*/, bool withSeconds/*=true*/) const
 {
-  return GetAsLocalizedDate(longDate)+" "+GetAsLocalizedTime("", withSeconds);
+  return GetAsLocalizedDate(longDate) + ' ' + GetAsLocalizedTime("", withSeconds);
 }
 
 CDateTime CDateTime::GetAsUTCDateTime() const
@@ -1410,7 +1410,7 @@ CDateTime CDateTime::GetAsUTCDateTime() const
   return time;
 }
 
-CStdString CDateTime::GetAsRFC1123DateTime() const
+std::string CDateTime::GetAsRFC1123DateTime() const
 {
   CDateTime time(GetAsUTCDateTime());
 
@@ -1430,11 +1430,10 @@ CStdString CDateTime::GetAsRFC1123DateTime() const
   if (month != time.GetMonth())
     CLog::Log(LOGWARNING, "Invalid month %d in %s", time.GetMonth(), time.GetAsDBDateTime().c_str());
 
-  CStdString result = StringUtils::Format("%s, %02i %s %04i %02i:%02i:%02i GMT", DAY_NAMES[weekDay], time.GetDay(), MONTH_NAMES[month - 1], time.GetYear(), time.GetHour(), time.GetMinute(), time.GetSecond());
-  return result;
+  return StringUtils::Format("%s, %02i %s %04i %02i:%02i:%02i GMT", DAY_NAMES[weekDay], time.GetDay(), MONTH_NAMES[month - 1], time.GetYear(), time.GetHour(), time.GetMinute(), time.GetSecond());
 }
 
-CStdString CDateTime::GetAsW3CDate() const
+std::string CDateTime::GetAsW3CDate() const
 {
   SYSTEMTIME st;
   GetAsSystemTime(st);
@@ -1442,7 +1441,7 @@ CStdString CDateTime::GetAsW3CDate() const
   return StringUtils::Format("%04i-%02i-%02i", st.wYear, st.wMonth, st.wDay);
 }
 
-CStdString CDateTime::GetAsW3CDateTime(bool asUtc /* = false */) const
+std::string CDateTime::GetAsW3CDateTime(bool asUtc /* = false */) const
 {
   CDateTime w3cDate = *this;
   if (asUtc)
@@ -1450,7 +1449,7 @@ CStdString CDateTime::GetAsW3CDateTime(bool asUtc /* = false */) const
   SYSTEMTIME st;
   w3cDate.GetAsSystemTime(st);
 
-  CStdString result = StringUtils::Format("%04i-%02i-%02iT%02i:%02i:%02i", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+  std::string result = StringUtils::Format("%04i-%02i-%02iT%02i:%02i:%02i", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
   if (asUtc)
     return result + "Z";
 
@@ -1458,7 +1457,7 @@ CStdString CDateTime::GetAsW3CDateTime(bool asUtc /* = false */) const
   return result + StringUtils::Format("%c%02i:%02i", (bias.GetSecondsTotal() >= 0 ? '+' : '-'), abs(bias.GetHours()), abs(bias.GetMinutes())).c_str();
 }
 
-int CDateTime::MonthStringToMonthNum(const CStdString& month)
+int CDateTime::MonthStringToMonthNum(const std::string& month)
 {
   const char* months[] = {"january","february","march","april","may","june","july","august","september","october","november","december"};
   const char* abr_months[] = {"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"};

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -20,9 +20,9 @@
  *
  */
 
-#include "utils/StdString.h"
 #include "utils/IArchivable.h"
 #include "system.h"
+#include <string>
 
 /*! \brief TIME_FORMAT enum/bitmask used for formatting time strings
  Note the use of bitmasking, e.g.
@@ -67,8 +67,8 @@ public:
   const CDateTimeSpan& operator -=(const CDateTimeSpan& right);
 
   void SetDateTimeSpan(int day, int hour, int minute, int second);
-  void SetFromPeriod(const CStdString &period);
-  void SetFromTimeString(const CStdString& time);
+  void SetFromPeriod(const std::string &period);
+  void SetFromTimeString(const std::string& time);
 
   int GetDays() const;
   int GetHours() const;
@@ -99,11 +99,11 @@ public:
   CDateTime(int year, int month, int day, int hour, int minute, int second);
   virtual ~CDateTime() {}
 
-  bool SetFromDateString(const CStdString &date);
+  bool SetFromDateString(const std::string &date);
 
   static CDateTime GetCurrentDateTime();
   static CDateTime GetUTCDateTime();
-  static int MonthStringToMonthNum(const CStdString& month);
+  static int MonthStringToMonthNum(const std::string& month);
 
   const CDateTime& operator =(const SYSTEMTIME& right);
   const CDateTime& operator =(const FILETIME& right);
@@ -171,18 +171,18 @@ public:
   bool SetDateTime(int year, int month, int day, int hour, int minute, int second);
   bool SetDate(int year, int month, int day);
   bool SetTime(int hour, int minute, int second);
-  bool SetFromDBDate(const CStdString &date);
-  bool SetFromDBTime(const CStdString &time);
-  bool SetFromW3CDate(const CStdString &date);
-  bool SetFromW3CDateTime(const CStdString &date, bool ignoreTimezone = false);
+  bool SetFromDBDate(const std::string &date);
+  bool SetFromDBTime(const std::string &time);
+  bool SetFromW3CDate(const std::string &date);
+  bool SetFromW3CDateTime(const std::string &date, bool ignoreTimezone = false);
   bool SetFromUTCDateTime(const CDateTime &dateTime);
   bool SetFromUTCDateTime(const time_t &dateTime);
-  bool SetFromRFC1123DateTime(const CStdString &dateTime);
+  bool SetFromRFC1123DateTime(const std::string &dateTime);
 
   /*! \brief set from a database datetime format YYYY-MM-DD HH:MM:SS
    \sa GetAsDBDateTime()
    */
-  bool SetFromDBDateTime(const CStdString &dateTime);
+  bool SetFromDBDateTime(const std::string &dateTime);
 
   void GetAsSystemTime(SYSTEMTIME& time) const;
   void GetAsTime(time_t& time) const;
@@ -190,16 +190,16 @@ public:
   void GetAsTimeStamp(FILETIME& time) const;
 
   CDateTime GetAsUTCDateTime() const;
-  CStdString GetAsSaveString() const;
-  CStdString GetAsDBDateTime() const;
-  CStdString GetAsDBDate() const;
-  CStdString GetAsLocalizedDate(bool longDate=false, bool withShortNames=true) const;
-  CStdString GetAsLocalizedDate(const CStdString &strFormat, bool withShortNames=true) const;
-  CStdString GetAsLocalizedTime(const CStdString &format, bool withSeconds=true) const;
-  CStdString GetAsLocalizedDateTime(bool longDate=false, bool withSeconds=true) const;
-  CStdString GetAsRFC1123DateTime() const;
-  CStdString GetAsW3CDate() const;
-  CStdString GetAsW3CDateTime(bool asUtc = false) const;
+  std::string GetAsSaveString() const;
+  std::string GetAsDBDateTime() const;
+  std::string GetAsDBDate() const;
+  std::string GetAsLocalizedDate(bool longDate=false, bool withShortNames=true) const;
+  std::string GetAsLocalizedDate(const std::string &strFormat, bool withShortNames=true) const;
+  std::string GetAsLocalizedTime(const std::string &format, bool withSeconds=true) const;
+  std::string GetAsLocalizedDateTime(bool longDate=false, bool withSeconds=true) const;
+  std::string GetAsRFC1123DateTime() const;
+  std::string GetAsW3CDate() const;
+  std::string GetAsW3CDateTime(bool asUtc = false) const;
 
   void SetValid(bool yesNo);
   bool IsValid() const;

--- a/xbmc/addons/AddonCallbacks.cpp
+++ b/xbmc/addons/AddonCallbacks.cpp
@@ -39,7 +39,7 @@ CAddonCallbacks::CAddonCallbacks(CAddon* addon)
   m_helperPVR   = NULL;
   m_helperCODEC = NULL;
 
-  m_callbacks->libBasePath           = strdup(CSpecialProtocol::TranslatePath("special://xbmcbin/addons"));
+  m_callbacks->libBasePath           = strdup(CSpecialProtocol::TranslatePath("special://xbmcbin/addons").c_str());
   m_callbacks->addonData             = this;
   m_callbacks->AddOnLib_RegisterMe   = CAddonCallbacks::AddOnLib_RegisterMe;
   m_callbacks->AddOnLib_UnRegisterMe = CAddonCallbacks::AddOnLib_UnRegisterMe;

--- a/xbmc/addons/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/AddonCallbacksPVR.cpp
@@ -256,9 +256,9 @@ void CAddonCallbacksPVR::PVRRecording(void *addonData, const char *strName, cons
 
   CStdString strLine1;
   if (bOnOff)
-    strLine1 = StringUtils::Format(g_localizeStrings.Get(19197), client->Name().c_str());
+    strLine1 = StringUtils::Format(g_localizeStrings.Get(19197).c_str(), client->Name().c_str());
   else
-    strLine1 = StringUtils::Format(g_localizeStrings.Get(19198), client->Name().c_str());
+    strLine1 = StringUtils::Format(g_localizeStrings.Get(19198).c_str(), client->Name().c_str());
 
   CStdString strLine2;
   if (strName)

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -282,8 +282,8 @@ bool CAddonInstaller::InstallFromZip(const CStdString &path)
   // grab the descriptive XML document from the zip, and read it in
   CFileItemList items;
   // BUG: some zip files return a single item (root folder) that we think is stored, so we don't use the zip:// protocol
-  CStdString zipDir;
-  URIUtils::CreateArchivePath(zipDir, "zip", path, "");
+  CURL pathToUrl(path);
+  CURL zipDir = URIUtils::CreateArchivePath("zip", pathToUrl, "");
   if (!CDirectory::GetDirectory(zipDir, items) || items.Size() != 1 || !items[0]->m_bIsFolder)
   {
     CGUIDialogKaiToast::QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
@@ -586,8 +586,7 @@ bool CAddonInstallJob::DoWork()
       }
 
       // check the archive as well - should have just a single folder in the root
-      CStdString archive;
-      URIUtils::CreateArchivePath(archive,"zip",package,"");
+      CURL archive = URIUtils::CreateArchivePath("zip",CURL(package),"");
 
       CFileItemList archivedFiles;
       CDirectory::GetDirectory(archive, archivedFiles);

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -268,9 +268,9 @@ bool CAddonMgr::Init()
   // would allow partial unloading of addon framework
   m_cp_context = m_cpluff->create_context(&status);
   assert(m_cp_context);
-  status = m_cpluff->register_pcollection(m_cp_context, CSpecialProtocol::TranslatePath("special://home/addons"));
-  status = m_cpluff->register_pcollection(m_cp_context, CSpecialProtocol::TranslatePath("special://xbmc/addons"));
-  status = m_cpluff->register_pcollection(m_cp_context, CSpecialProtocol::TranslatePath("special://xbmcbin/addons"));
+  status = m_cpluff->register_pcollection(m_cp_context, CSpecialProtocol::TranslatePath("special://home/addons").c_str());
+  status = m_cpluff->register_pcollection(m_cp_context, CSpecialProtocol::TranslatePath("special://xbmc/addons").c_str());
+  status = m_cpluff->register_pcollection(m_cp_context, CSpecialProtocol::TranslatePath("special://xbmcbin/addons").c_str());
   if (status != CP_OK)
   {
     CLog::Log(LOGERROR, "ADDONS: Fatal Error, cp_register_pcollection() returned status: %i", status);

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -215,7 +215,7 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
 
   if (!deps.empty())
   {
-    string line0 = StringUtils::Format(g_localizeStrings.Get(24046), m_localAddon->Name().c_str());
+    string line0 = StringUtils::Format(g_localizeStrings.Get(24046).c_str(), m_localAddon->Name().c_str());
     string line1 = StringUtils::Join(deps, ", ");
     CGUIDialogOK::ShowAndGetInput(heading, line0, line1, line2);
     return true;
@@ -273,7 +273,7 @@ void CGUIDialogAddonInfo::OnSettings()
 void CGUIDialogAddonInfo::OnChangeLog()
 {
   CGUIDialogTextViewer* pDlgInfo = (CGUIDialogTextViewer*)g_windowManager.GetWindow(WINDOW_DIALOG_TEXT_VIEWER);
-  CStdString name;
+  std::string name;
   if (m_addon)
     name = m_addon->Name();
   else if (m_localAddon)

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -315,11 +315,11 @@ static bool FilterVar(bool valid, const CVariant& variant,
   return regions.find(check) == std::string::npos;
 }
 
-bool CGUIWindowAddonBrowser::GetDirectory(const CStdString& strDirectory,
+bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
                                           CFileItemList& items)
 {
   bool result;
-  if (strDirectory.Equals("addons://downloading/"))
+  if (URIUtils::PathEquals(strDirectory, "addons://downloading/"))
   {
     VECADDONS addons;
     CAddonInstaller::Get().GetInstallList(addons);
@@ -396,7 +396,7 @@ void CGUIWindowAddonBrowser::SetItemLabel2(CFileItemPtr item)
   item->SetLabelPreformated(true);
 }
 
-bool CGUIWindowAddonBrowser::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowAddonBrowser::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -525,9 +525,9 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, vect
   return 1;
 }
 
-CStdString CGUIWindowAddonBrowser::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowAddonBrowser::GetStartFolder(const std::string &dir)
 {
-  if (StringUtils::StartsWithNoCase(dir, "addons://"))
+  if (URIUtils::PathStarts(dir, "addons://"))
     return dir;
   return CGUIMediaWindow::GetStartFolder(dir);
 }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -152,7 +152,7 @@ void CGUIWindowAddonBrowser::GetContextButtons(int itemNumber,
                                                CContextButtons& buttons)
 {
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
-  if (pItem->GetPath().Equals("addons://enabled/"))
+  if (!pItem->IsPath("addons://enabled/"))
     buttons.Add(CONTEXT_BUTTON_SCAN,24034);
   
   AddonPtr addon;
@@ -175,7 +175,7 @@ bool CGUIWindowAddonBrowser::OnContextButton(int itemNumber,
                                              CONTEXT_BUTTON button)
 {
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
-  if (pItem->GetPath().Equals("addons://enabled/"))
+  if (pItem->IsPath("addons://enabled/"))
   {
     if (button == CONTEXT_BUTTON_SCAN)
     {
@@ -268,7 +268,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
     CGUIDialogAddonInfo::ShowForItem(item);
     return true;
   }
-  if (item->GetPath().Equals("addons://search/"))
+  if (item->IsPath("addons://search/"))
     return Update(item->GetPath());
 
   return CGUIMediaWindow::OnClick(iItem);

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -62,9 +62,9 @@ protected:
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual bool OnClick(int iItem);
   virtual void UpdateButtons();
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
-  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
-  virtual CStdString GetStartFolder(const CStdString &dir);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
+  virtual std::string GetStartFolder(const std::string &dir);
 private:
   CProgramThumbLoader m_thumbLoader;
 };

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -417,7 +417,7 @@ void CSkinInfo::SettingOptionsSkinThemesFiller(const CSetting *setting, std::vec
   list.push_back(make_pair(g_localizeStrings.Get(15109), "SKINDEFAULT")); // the standard Textures.xpr/xbt will be used
 
   // search for themes in the current skin!
-  vector<CStdString> vecTheme;
+  vector<std::string> vecTheme;
   CUtil::GetSkinThemes(vecTheme);
 
   // sort the themes for GUI and list them

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -238,7 +238,7 @@ CStdString CCDDARipJob::SetupTempFile()
 {
   char tmp[MAX_PATH];
 #ifndef TARGET_POSIX
-  GetTempFileName(CSpecialProtocol::TranslatePath("special://temp/"), "riptrack", 0, tmp);
+  GetTempFileName(CSpecialProtocol::TranslatePath("special://temp/").c_str(), "riptrack", 0, tmp);
 #else
   int fd;
   strncpy(tmp, CSpecialProtocol::TranslatePath("special://temp/riptrackXXXXXX").c_str(), MAX_PATH);

--- a/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
@@ -959,7 +959,7 @@ extern "C" HANDLE WINAPI dllCreateFileA(
     IN HANDLE hTemplateFile
     )
 {
-  return CreateFileA(CSpecialProtocol::TranslatePath(lpFileName), dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+  return CreateFileA(CSpecialProtocol::TranslatePath(lpFileName).c_str(), dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
 }
 
 extern "C" BOOL WINAPI dllLockFile(HANDLE hFile, DWORD dwFileOffsetLow, DWORD dwFileOffsetHigh, DWORD nNumberOffBytesToLockLow, DWORD nNumberOffBytesToLockHigh)

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -839,7 +839,7 @@ extern "C"
     while ((vecDirsOpen[iDirSlot].curr_index != -1) && (iDirSlot<MAX_OPEN_DIRS)) iDirSlot++;
     if (iDirSlot >= MAX_OPEN_DIRS)
       return -1; // no free slots
-    if (url.GetProtocol().Equals("filereader"))
+    if (url.IsProtocol("filereader"))
     {
       CURL url2(url.GetFileName());
       url = url2;
@@ -964,7 +964,7 @@ extern "C"
       return NULL; // no free slots
     }
 
-    if (url.GetProtocol().Equals("filereader"))
+    if (url.IsProtocol("filereader"))
     {
       CURL url2(url.GetFileName());
       url = url2;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -20,7 +20,7 @@
  *
  */
 
-#include "utils/StdString.h"
+#include <string>
 #include "system.h"
 #include "DVDDemuxPacket.h"
 
@@ -344,5 +344,5 @@ public:
   /*
    * return a user-presentable codec name of the given stream
    */
-  virtual void GetStreamCodecName(int iStreamId, CStdString &strName) {};
+  virtual void GetStreamCodecName(int iStreamId, std::string &strName) {};
 };

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxBXA.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxBXA.cpp
@@ -186,7 +186,7 @@ std::string CDVDDemuxBXA::GetFileName()
     return "";
 }
 
-void CDVDDemuxBXA::GetStreamCodecName(int iStreamId, CStdString &strName)
+void CDVDDemuxBXA::GetStreamCodecName(int iStreamId, std::string &strName)
 {
   if (m_stream && iStreamId == 0)
     strName = "BXA";

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxBXA.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxBXA.h
@@ -71,7 +71,7 @@ public:
   CDemuxStream* GetStream(int iStreamId);
   int GetNrOfStreams();
   std::string GetFileName();
-  virtual void GetStreamCodecName(int iStreamId, CStdString &strName);
+  virtual void GetStreamCodecName(int iStreamId, std::string &strName);
 
 protected:
   friend class CDemuxStreamAudioBXA;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCDDA.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCDDA.cpp
@@ -190,7 +190,7 @@ std::string CDVDDemuxCDDA::GetFileName()
     return "";
 }
 
-void CDVDDemuxCDDA::GetStreamCodecName(int iStreamId, CStdString &strName)
+void CDVDDemuxCDDA::GetStreamCodecName(int iStreamId, std::string &strName)
 {
   if (m_stream && iStreamId == 0)
     strName = "pcm";

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCDDA.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxCDDA.h
@@ -49,7 +49,7 @@ public:
   CDemuxStream* GetStream(int iStreamId);
   int GetNrOfStreams();
   std::string GetFileName();
-  virtual void GetStreamCodecName(int iStreamId, CStdString &strName);
+  virtual void GetStreamCodecName(int iStreamId, std::string &strName);
 
 protected:
   friend class CDemuxStreamAudioCDDA;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -528,11 +528,11 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromURL(const CURL &url)
 
   if (protocol.Equals("http") || protocol.Equals("https"))
   {
-    std::map<CStdString, CStdString> protocolOptions;
+    std::map<std::string, std::string> protocolOptions;
     url.GetProtocolOptions(protocolOptions);
     std::string headers;
     bool hasUserAgent = false;
-    for(std::map<CStdString, CStdString>::const_iterator it = protocolOptions.begin(); it != protocolOptions.end(); ++it)
+    for(std::map<std::string, std::string>::const_iterator it = protocolOptions.begin(); it != protocolOptions.end(); ++it)
     {
       const CStdString &name = it->first;
       const CStdString &value = it->second;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1356,7 +1356,7 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
   return SeekTime(DVD_TIME_TO_MSEC(dts), true, startpts);
 }
 
-void CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId, CStdString &strName)
+void CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId, std::string &strName)
 {
   CDemuxStream *stream = GetStream(iStreamId);
   if (stream)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -24,6 +24,7 @@
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 #include <map>
+#include <vector>
 
 extern "C" {
 #include "libavformat/avformat.h"
@@ -108,7 +109,7 @@ public:
   int GetChapterCount();
   int GetChapter();
   void GetChapterName(std::string& strChapterName);
-  virtual void GetStreamCodecName(int iStreamId, CStdString &strName);
+  virtual void GetStreamCodecName(int iStreamId, std::string &strName);
 
   bool Aborted();
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -458,7 +458,7 @@ std::string CDVDDemuxPVRClient::GetFileName()
     return "";
 }
 
-void CDVDDemuxPVRClient::GetStreamCodecName(int iStreamId, CStdString &strName)
+void CDVDDemuxPVRClient::GetStreamCodecName(int iStreamId, std::string &strName)
 {
   CDemuxStream *stream = GetStream(iStreamId);
   if (stream)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
@@ -100,7 +100,7 @@ public:
   CDemuxStream* GetStream(int iStreamId);
   int GetNrOfStreams();
   std::string GetFileName();
-  virtual void GetStreamCodecName(int iStreamId, CStdString &strName);
+  virtual void GetStreamCodecName(int iStreamId, std::string &strName);
 
 protected:
   CDVDInputStream* m_pInput;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -23,6 +23,7 @@
 #include "DVDDemux.h"
 
 #include <memory>
+#include <vector>
 
 class CDVDOverlayCodecFFmpeg;
 class CDVDInputStream;

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -145,7 +145,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
     DemuxerToStreamDetails(pInputStream, pDemuxer, *pStreamDetails, strPath);
 
     //extern subtitles
-    std::vector<CStdString> filenames;
+    std::vector<std::string> filenames;
     CStdString video_path;
     if (strPath.empty())
       video_path = pInputStream->GetFileName();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -136,7 +136,7 @@ int DllLibbluray::dir_read(BD_DIR_H *dir, BD_DIRENT *entry)
     if(state->curr >= state->list.Size())
       return 1;
 
-    strncpy(entry->d_name, state->list[state->curr]->GetLabel(), sizeof(entry->d_name));
+    strncpy(entry->d_name, state->list[state->curr]->GetLabel().c_str(), sizeof(entry->d_name));
     entry->d_name[sizeof(entry->d_name)-1] = 0;
     state->curr++;
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -654,7 +654,7 @@ bool CDVDPlayer::OpenInputStream()
   &&  !m_pInputStream->IsStreamType(DVDSTREAM_TYPE_HTSP))
   {
     // find any available external subtitles
-    std::vector<CStdString> filenames;
+    std::vector<std::string> filenames;
     CUtil::ScanForExternalSubtitles( m_filename, filenames );
 
     // find any upnp subtitles

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -718,7 +718,7 @@ bool COMXPlayer::OpenInputStream()
   &&  !m_pInputStream->IsStreamType(DVDSTREAM_TYPE_HTSP))
   {
     // find any available external subtitles
-    std::vector<CStdString> filenames;
+    std::vector<std::string> filenames;
     CUtil::ScanForExternalSubtitles( m_filename, filenames );
 
     // find any upnp subtitles

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -160,7 +160,7 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
     return dvdcodec; // if we got this far with internet radio - content-type was wrong. gamble on mp3.
   }
 
-  if (urlFile.GetFileType().Equals("wav") || strContent.Equals("audio/wav") || strContent.Equals("audio/x-wav"))
+  if (urlFile.IsFileType("wav") || strContent.Equals("audio/wav") || strContent.Equals("audio/x-wav"))
   {
     //lets see what it contains...
     //this kinda sucks 'cause if it's a plain wav file the file
@@ -178,7 +178,7 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
     return dvdcodec;
 
   }
-  else if (urlFile.GetFileType().Equals("ogg") || urlFile.GetFileType().Equals("oggstream") || urlFile.GetFileType().Equals("oga"))
+  else if (urlFile.IsFileType("ogg") || urlFile.IsFileType("oggstream") || urlFile.IsFileType("oga"))
     return CreateOGGCodec(strFile,filecache);
 
   //default

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -177,7 +177,7 @@ void CPlayerCoreFactory::GetPlayers( const CFileItem& item, VECPLAYERCORES &vecC
   {
     // We no longer force PAPlayer as our default audio player (used to be true):
     bool bAdd = false;
-    if (url.GetProtocol().Equals("mms"))
+    if (url.IsProtocol("mms"))
     {
        bAdd = false;
     }
@@ -192,8 +192,7 @@ void CPlayerCoreFactory::GetPlayers( const CFileItem& item, VECPLAYERCORES &vecC
 
     if (bAdd)
     {
-      if ((url.GetFileType().Equals("ac3"))
-            || (url.GetFileType().Equals("dts")))
+      if (url.IsFileType("ac3") || url.IsFileType("dts"))
       {
         CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding DVDPlayer (%d)", EPC_DVDPLAYER);
         vecCores.push_back(EPC_DVDPLAYER);

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -102,7 +102,7 @@ bool CGUIDialogFileBrowser::OnAction(const CAction &action)
       CFileItemPtr pItem = (*m_vecItems)[iItem];
       for (unsigned int i=0;i<m_shares.size();++i)
       {
-        if (m_shares[i].strName.Equals(pItem->GetLabel()) && m_shares[i].m_ignore)
+        if (StringUtils::EqualsNoCase(m_shares[i].strName, pItem->GetLabel()) && m_shares[i].m_ignore)
           return false;
       }
 

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -586,7 +586,7 @@ void CGUIDialogMediaFilter::UpdateControls()
     else
     {
       CONTROL_ENABLE(control->GetID());
-      label = StringUtils::Format(g_localizeStrings.Get(21470), label.c_str(), size);
+      label = StringUtils::Format(g_localizeStrings.Get(21470).c_str(), label.c_str(), size);
     }
     SET_CONTROL_LABEL(control->GetID(), label);
   }

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -206,12 +206,12 @@ int CGUIDialogSelect::GetSelectedLabel() const
   return m_iSelected;
 }
 
-const CFileItemPtr CGUIDialogSelect::GetSelectedItem()
+const CFileItemPtr CGUIDialogSelect::GetSelectedItem() const
 {
   return m_selectedItems->Size() > 0 ? m_selectedItems->Get(0) : CFileItemPtr(new CFileItem);
 }
 
-const CStdString& CGUIDialogSelect::GetSelectedLabelText()
+const std::string& CGUIDialogSelect::GetSelectedLabelText() const
 {
   return GetSelectedItem()->GetLabel();
 }
@@ -263,7 +263,7 @@ void CGUIDialogSelect::SetSelected(const CStdString &strSelectedLabel)
 
   for (int index = 0; index < m_vecList->Size(); index++)
   {
-    if (strSelectedLabel.Equals(m_vecList->Get(index)->GetLabel()))
+    if (strSelectedLabel == m_vecList->Get(index)->GetLabel())
     {
       SetSelected(index);
       return;

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -42,8 +42,8 @@ public:
   void Add(const CFileItemList& items);
   void SetItems(CFileItemList* items);
   int GetSelectedLabel() const;
-  const CStdString& GetSelectedLabelText();
-  const CFileItemPtr GetSelectedItem();
+  const std::string& GetSelectedLabelText() const;
+  const CFileItemPtr GetSelectedItem() const;
   const CFileItemList& GetSelectedItems() const;
   void EnableButton(bool enable, int string);
   bool IsButtonPressed();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -264,7 +264,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
       CSmartPlaylist playlist;
       // don't list unloadable smartplaylists or any referencable smartplaylists
       // which do not match the type of the current smartplaylist
-      if (!playlist.Load(item->GetPath()) ||
+      if (!playlist.Load((CStdString)item->GetPath()) ||
          (m_rule.m_field == FieldPlaylist &&
          (!CSmartPlaylist::CheckTypeCompatibility(m_type, playlist.GetType()) ||
          (!playlist.GetGroup().empty() || playlist.IsGroupMixed()))))

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -693,7 +693,7 @@ bool CEpg::UpdateFromScraper(time_t start, time_t end)
 
 //@}
 
-const CStdString &CEpg::ConvertGenreIdToString(int iID, int iSubID)
+const std::string &CEpg::ConvertGenreIdToString(int iID, int iSubID)
 {
   unsigned int iLabelId = 19499;
   switch (iID)

--- a/xbmc/epg/Epg.h
+++ b/xbmc/epg/Epg.h
@@ -270,7 +270,7 @@ namespace EPG
      * @param iSubID The genre sub ID.
      * @return A human readable name.
      */
-    static const CStdString &ConvertGenreIdToString(int iID, int iSubID);
+    static const std::string &ConvertGenreIdToString(int iID, int iSubID);
 
     /*!
      * @brief Update an entry in this EPG.

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -211,10 +211,10 @@ void CEpgInfoTag::Serialize(CVariant &value) const
   value["plot"] = m_strPlot;
   value["genre"] = m_genre;
   value["filenameandpath"] = m_strFileNameAndPath;
-  value["starttime"] = m_startTime.IsValid() ? m_startTime.GetAsDBDateTime() : StringUtils::EmptyString;
-  value["endtime"] = m_endTime.IsValid() ? m_endTime.GetAsDBDateTime() : StringUtils::EmptyString;
+  value["starttime"] = m_startTime.IsValid() ? m_startTime.GetAsDBDateTime() : StringUtils::Empty;
+  value["endtime"] = m_endTime.IsValid() ? m_endTime.GetAsDBDateTime() : StringUtils::Empty;
   value["runtime"] = StringUtils::Format("%d", GetDuration() / 60);
-  value["firstaired"] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : StringUtils::EmptyString;
+  value["firstaired"] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : StringUtils::Empty;
   value["progress"] = Progress();
   value["progresspercentage"] = ProgressPercentage();
   value["episodename"] = m_strEpisodeName;

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1337,9 +1337,9 @@ CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset, unsigned int flag)
   return CGUIListItemPtr();
 }
 
-CStdString CGUIEPGGridContainer::GetLabel(int info) const
+std::string CGUIEPGGridContainer::GetLabel(int info) const
 {
-  CStdString label;
+  std::string label;
   switch (info)
   {
   case CONTAINER_NUM_PAGES:
@@ -1600,9 +1600,9 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement *layout)
   }
 }
 
-CStdString CGUIEPGGridContainer::GetDescription() const
+std::string CGUIEPGGridContainer::GetDescription() const
 {
-  CStdString strLabel;
+  std::string strLabel;
   int item = GetSelectedItem();
   if (item >= 0 && item < (int)m_programmeItems.size())
   {

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -61,7 +61,7 @@ namespace EPG
     virtual bool OnMessage(CGUIMessage& message);
     virtual void SetFocus(bool focus);
 
-    virtual CStdString GetDescription() const;
+    virtual std::string GetDescription() const;
     const int GetNumChannels()   { return m_channels; };
     virtual int GetSelectedItem() const;
     const int GetSelectedChannel() { return m_channelCursor + m_channelOffset; }
@@ -75,7 +75,7 @@ namespace EPG
     void LoadContent(TiXmlElement *content);
 
     virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
-    virtual CStdString GetLabel(int info) const;
+    virtual std::string GetLabel(int info) const;
 
     /*! \brief Set the offset of the first item in the container from the container's position
      Useful for lists/panels where the focused item may be larger than the non-focused items and thus

--- a/xbmc/filesystem/AFPFile.cpp
+++ b/xbmc/filesystem/AFPFile.cpp
@@ -193,14 +193,14 @@ CAfpConnection::afpConnnectError CAfpConnection::Connect(const CURL& url)
   m_pLibAfp->afp_default_url(&tmpurl);
 
   // if hostname has changed - assume server changed
-  if (!nonConstUrl.GetHostName().Equals(m_pAfpUrl->servername, false)|| (m_pAfpServer && m_pAfpServer->connect_state == 0))
+  if (nonConstUrl.GetHostName() != m_pAfpUrl->servername || (m_pAfpServer && m_pAfpServer->connect_state == 0))
   {
     serverChanged = true;
     Disconnect();
   }
 
   // if volume changed - also assume server changed (afpclient can't reuse old servobject it seems)
-  if (!nonConstUrl.GetShareName().Equals(m_pAfpUrl->volumename, false))
+  if (nonConstUrl.GetShareName() != m_pAfpUrl->volumename)
   {
    // no reusing of old server object possible with libafpclient it seems...
     serverChanged = true;

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -61,13 +61,13 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   // get info from repository
   bool groupAddons = true;
   bool reposAsFolders = true;
-  if (path.GetHostName().Equals("enabled"))
+  if (path.GetHostName() == "enabled")
   {
     CAddonMgr::Get().GetAllAddons(addons, true);
     items.SetProperty("reponame",g_localizeStrings.Get(24062));
     items.SetLabel(g_localizeStrings.Get(24062));
   }
-  else if (path.GetHostName().Equals("disabled"))
+  else if (path.GetHostName() == "disabled")
   { // grab all disabled addons, including disabled repositories
     reposAsFolders = false;
     groupAddons = false;
@@ -75,7 +75,7 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     items.SetProperty("reponame",g_localizeStrings.Get(24039));
     items.SetLabel(g_localizeStrings.Get(24039));
   }
-  else if (path.GetHostName().Equals("outdated"))
+  else if (path.GetHostName() == "outdated")
   {
     reposAsFolders = false;
     groupAddons = false;
@@ -85,7 +85,7 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     items.SetProperty("reponame",g_localizeStrings.Get(24043));
     items.SetLabel(g_localizeStrings.Get(24043));
   }
-  else if (path.GetHostName().Equals("check"))
+  else if (path.GetHostName() == "check")
   {
     reposAsFolders = false;
     groupAddons = false;
@@ -95,17 +95,17 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     items.SetProperty("reponame",g_localizeStrings.Get(24055));
     items.SetLabel(g_localizeStrings.Get(24055));
   }
-  else if (path.GetHostName().Equals("repos"))
+  else if (path.GetHostName() == "repos")
   {
     groupAddons = false;
     CAddonMgr::Get().GetAddons(ADDON_REPOSITORY,addons,true);
     items.SetLabel(g_localizeStrings.Get(24033)); // Get Add-ons
   }
-  else if (path.GetHostName().Equals("sources"))
+  else if (path.GetHostName() == "sources")
   {
     return GetScriptsAndPlugins(path.GetFileName(), items);
   }
-  else if (path.GetHostName().Equals("all"))
+  else if (path.GetHostName() == "all")
   {
     CAddonDatabase database;
     database.Open();
@@ -113,7 +113,7 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     items.SetProperty("reponame",g_localizeStrings.Get(24032));
     items.SetLabel(g_localizeStrings.Get(24032));
   }
-  else if (path.GetHostName().Equals("search"))
+  else if (path.GetHostName() == "search")
   {
     CStdString search(path.GetFileName());
     if (search.empty() && !GetKeyboardInput(16017, search))
@@ -191,7 +191,7 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   items.SetPath(strPath);
   GenerateListing(path, addons, items, reposAsFolders);
   // check for available updates
-  if (path.GetHostName().Equals("enabled"))
+  if (path.GetHostName() == "enabled")
   {
     CAddonDatabase database;
     database.Open();
@@ -207,14 +207,14 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       }
     }
   }
-  if (path.GetHostName().Equals("repos") && items.Size() > 1)
+  if (path.GetHostName() == "repos" && items.Size() > 1)
   {
     CFileItemPtr item(new CFileItem("addons://all/",true));
     item->SetLabel(g_localizeStrings.Get(24032));
     items.Add(item);
   }
-  else if ((path.GetHostName().Equals("outdated") ||
-            path.GetHostName().Equals("check")) && items.Size() > 1)
+  else if ((path.GetHostName() == "outdated" ||
+            path.GetHostName() == "check") && items.Size() > 1)
   {
     CFileItemPtr item(new CFileItem("addons://update_all/", true));
     item->SetLabel(g_localizeStrings.Get(24122));
@@ -272,7 +272,7 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon, const CS
   CFileItemPtr item(new CFileItem(path, folder));
 
   CStdString strLabel(addon->Name());
-  if (url.GetHostName().Equals("search"))
+  if (url.GetHostName() == "search")
     strLabel = StringUtils::Format("%s - %s", TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
 
   item->SetLabel(strLabel);

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -71,7 +71,7 @@ CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const CS
   buf = StringUtils::Format(label.c_str(), title->playlist);
   item->m_strTitle = buf;
   item->SetLabel(buf);
-  chap = StringUtils::Format(g_localizeStrings.Get(25007), title->chapter_count, StringUtils::SecondsToTimeString(duration).c_str());
+  chap = StringUtils::Format(g_localizeStrings.Get(25007).c_str(), title->chapter_count, StringUtils::SecondsToTimeString(duration).c_str());
   item->SetProperty("Addon.Summary", chap);
   item->m_dwSize = 0;
   item->SetIconImage("DefaultVideo.png");

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -799,21 +799,21 @@ void CCurlFile::SetStreamProxy(const CStdString &proxy, ProxyType type)
   CLog::Log(LOGDEBUG, "Overriding proxy from URL parameter: %s, type %d", m_proxy.c_str(), proxyType2CUrlProxyType[m_proxytype]);
 }
 
-bool CCurlFile::Post(const CStdString& strURL, const CStdString& strPostData, CStdString& strHTML)
+bool CCurlFile::Post(const std::string& strURL, const std::string& strPostData, std::string& strHTML)
 {
   m_postdata = strPostData;
   m_postdataset = true;
   return Service(strURL, strHTML);
 }
 
-bool CCurlFile::Get(const CStdString& strURL, CStdString& strHTML)
+bool CCurlFile::Get(const std::string& strURL, std::string& strHTML)
 {
   m_postdata = "";
   m_postdataset = false;
   return Service(strURL, strHTML);
 }
 
-bool CCurlFile::Service(const CStdString& strURL, CStdString& strHTML)
+bool CCurlFile::Service(const std::string& strURL, std::string& strHTML)
 {
   const CURL pathToUrl(strURL);
   if (Open(pathToUrl))
@@ -828,7 +828,7 @@ bool CCurlFile::Service(const CStdString& strURL, CStdString& strHTML)
   return false;
 }
 
-bool CCurlFile::ReadData(CStdString& strHTML)
+bool CCurlFile::ReadData(std::string& strHTML)
 {
   int size_read = 0;
   int data_size = 0;
@@ -1625,7 +1625,7 @@ bool CCurlFile::GetHttpHeader(const CURL &url, CHttpHeader &headers)
   }
 }
 
-bool CCurlFile::GetMimeType(const CURL &url, CStdString &content, CStdString useragent)
+bool CCurlFile::GetMimeType(const CURL &url, std::string &content, const std::string &useragent)
 {
   CCurlFile file;
   if (!useragent.empty())
@@ -1643,7 +1643,7 @@ bool CCurlFile::GetMimeType(const CURL &url, CStdString &content, CStdString use
     return true;
   }
   CLog::Log(LOGDEBUG, "CCurlFile::GetMimeType - %s -> failed", redactUrl.c_str());
-  content = "";
+  content.clear();
   return false;
 }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -740,17 +740,17 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     m_password = url2.GetPassWord();
 
     // handle any protocol options
-    std::map<CStdString, CStdString> options;
+    std::map<std::string, std::string> options;
     url2.GetProtocolOptions(options);
     if (options.size() > 0)
     {
       // clear protocol options
       url2.SetProtocolOptions("");
       // set xbmc headers
-      for(std::map<CStdString, CStdString>::const_iterator it = options.begin(); it != options.end(); ++it)
+      for (std::map<std::string,std::string>::const_iterator it = options.begin(); it != options.end(); ++it)
       {
-        const CStdString &name = it->first;
-        const CStdString &value = it->second;
+        const CStdString name = it->first;
+        const CStdString value = it->second;
 
         if(name.Equals("auth"))
         {
@@ -907,7 +907,10 @@ bool CCurlFile::Open(const CURL& url)
 
   ASSERT(!(!m_state->m_easyHandle ^ !m_state->m_multiHandle));
   if( m_state->m_easyHandle == NULL )
-    g_curlInterface.easy_aquire(url2.GetProtocol(), url2.GetHostName(), &m_state->m_easyHandle, &m_state->m_multiHandle );
+    g_curlInterface.easy_aquire(url2.GetProtocol().c_str(),
+                                url2.GetHostName().c_str(),
+                                &m_state->m_easyHandle,
+                                &m_state->m_multiHandle);
 
   // setup common curl options
   SetCommonOptions(m_state);
@@ -937,7 +940,7 @@ bool CCurlFile::Open(const CURL& url)
   }
 
   m_multisession = false;
-  if(url2.GetProtocol().Equals("http") || url2.GetProtocol().Equals("https"))
+  if(url2.IsProtocol("http") || url2.IsProtocol("https"))
   {
     m_multisession = true;
     if(m_state->m_httpheader.GetValue("Server").find("Portable SDK for UPnP devices") != std::string::npos)
@@ -954,8 +957,8 @@ bool CCurlFile::Open(const CURL& url)
     m_seekable = false;
   if (m_seekable)
   {
-    if(url2.GetProtocol().Equals("http")
-    || url2.GetProtocol().Equals("https"))
+    if(url2.IsProtocol("http")
+    || url2.IsProtocol("https"))
     {
       // if server says explicitly it can't seek, respect that
       if(StringUtils::EqualsNoCase(m_state->m_httpheader.GetValue("Accept-Ranges"),"none"))
@@ -984,7 +987,10 @@ bool CCurlFile::OpenForWrite(const CURL& url, bool bOverWrite)
   CLog::Log(LOGDEBUG, "CCurlFile::OpenForWrite(%p) %s", (void*)this, CURL::GetRedacted(m_url).c_str());
 
   ASSERT(m_state->m_easyHandle == NULL);
-  g_curlInterface.easy_aquire(url2.GetProtocol(), url2.GetHostName(), &m_state->m_easyHandle, &m_state->m_multiHandle);
+  g_curlInterface.easy_aquire(url2.GetProtocol().c_str(),
+                              url2.GetHostName().c_str(),
+                              &m_state->m_easyHandle,
+                              &m_state->m_multiHandle);
 
     // setup common curl options
   SetCommonOptions(m_state);
@@ -1091,7 +1097,9 @@ bool CCurlFile::Exists(const CURL& url)
   ParseAndCorrectUrl(url2);
 
   ASSERT(m_state->m_easyHandle == NULL);
-  g_curlInterface.easy_aquire(url2.GetProtocol(), url2.GetHostName(), &m_state->m_easyHandle, NULL);
+  g_curlInterface.easy_aquire(url2.GetProtocol().c_str(),
+                              url2.GetHostName().c_str(),
+                              &m_state->m_easyHandle, NULL);
 
   SetCommonOptions(m_state);
   SetRequestHeaders(m_state);
@@ -1169,8 +1177,8 @@ int64_t CCurlFile::Seek(int64_t iFilePosition, int iWhence)
       m_oldState          = m_state;
       m_state             = new CReadState();
       m_state->m_fileSize = m_oldState->m_fileSize;
-      g_curlInterface.easy_aquire(url.GetProtocol(),
-                                  url.GetHostName(),
+      g_curlInterface.easy_aquire(url.GetProtocol().c_str(),
+                                  url.GetHostName().c_str(),
                                   &m_state->m_easyHandle,
                                   &m_state->m_multiHandle );
     }
@@ -1257,7 +1265,9 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   ParseAndCorrectUrl(url2);
 
   ASSERT(m_state->m_easyHandle == NULL);
-  g_curlInterface.easy_aquire(url2.GetProtocol(), url2.GetHostName(), &m_state->m_easyHandle, NULL);
+  g_curlInterface.easy_aquire(url2.GetProtocol().c_str(),
+                              url2.GetHostName().c_str(),
+                              &m_state->m_easyHandle, NULL);
 
   SetCommonOptions(m_state);
   SetRequestHeaders(m_state);
@@ -1655,7 +1665,9 @@ bool CCurlFile::GetCookies(const CURL &url, std::string &cookies)
   XCURL::CURLM*          multiHandle;
 
   // get the cookies list
-  g_curlInterface.easy_aquire(url.GetProtocol(), url.GetHostName(), &easyHandle, &multiHandle);
+  g_curlInterface.easy_aquire(url.GetProtocol().c_str(),
+                              url.GetHostName().c_str(),
+                              &easyHandle, &multiHandle);
   if (CURLE_OK == g_curlInterface.easy_getinfo(easyHandle, CURLINFO_COOKIELIST, &curlCookies))
   {
     // iterate over each cookie and format it into an RFC 2109 formatted Set-Cookie string

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -749,35 +749,35 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
       // set xbmc headers
       for (std::map<std::string,std::string>::const_iterator it = options.begin(); it != options.end(); ++it)
       {
-        const CStdString name = it->first;
-        const CStdString value = it->second;
+        std::string name = it->first; StringUtils::ToLower(name);
+        const std::string &value = it->second;
 
-        if(name.Equals("auth"))
+        if (name == "auth")
         {
           m_httpauth = value;
           if(m_httpauth.empty())
             m_httpauth = "any";
         }
-        else if (name.Equals("Referer"))
+        else if (name == "referer")
           SetReferer(value);
-        else if (name.Equals("User-Agent"))
+        else if (name == "user-agent")
           SetUserAgent(value);
-        else if (name.Equals("Cookie"))
+        else if (name == "cookie")
           SetCookie(value);
-        else if (name.Equals("Encoding"))
+        else if (name == "encoding")
           SetContentEncoding(value);
-        else if (name.Equals("noshout") && value.Equals("true"))
+        else if (name == "noshout" && value == "true")
           m_skipshout = true;
-        else if (name.Equals("seekable") && value.Equals("0"))
+        else if (name == "seekable" && value == "0")
           m_seekable = false;
-        else if (name.Equals("Accept-Charset"))
+        else if (name == "accept-charset")
           SetAcceptCharset(value);
-        else if (name.Equals("HttpProxy"))
+        else if (name == "httpproxy")
           SetStreamProxy(value, PROXY_HTTP);
-        else if (name.Equals("SSLCipherList"))
+        else if (name == "sslcipherlist")
           m_cipherlist = value;
         else
-          SetRequestHeader(name, value);
+          SetRequestHeader(it->first, value);
       }
     }
   }

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -63,9 +63,9 @@ namespace XFILE
       virtual int IoControl(EIoControl request, void* param);
       virtual std::string GetContentCharset(void)                { return GetServerReportedCharset(); }
 
-      bool Post(const CStdString& strURL, const CStdString& strPostData, CStdString& strHTML);
-      bool Get(const CStdString& strURL, CStdString& strHTML);
-      bool ReadData(CStdString& strHTML);
+      bool Post(const std::string& strURL, const std::string& strPostData, std::string& strHTML);
+      bool Get(const std::string& strURL, std::string& strHTML);
+      bool ReadData(std::string& strHTML);
       bool Download(const CStdString& strURL, const CStdString& strFileName, LPDWORD pdwSize = NULL);
       bool IsInternet();
       void Cancel();
@@ -96,7 +96,7 @@ namespace XFILE
 
       /* static function that will get content type of a file */
       static bool GetHttpHeader(const CURL &url, CHttpHeader &headers);
-      static bool GetMimeType(const CURL &url, CStdString &content, CStdString useragent="");
+      static bool GetMimeType(const CURL &url, std::string &content, const std::string &useragent="");
 
       /* static function that will get cookies stored by CURL in RFC 2109 format */
       static bool GetCookies(const CURL &url, std::string &cookies);
@@ -152,7 +152,7 @@ namespace XFILE
       void SetCommonOptions(CReadState* state);
       void SetRequestHeaders(CReadState* state);
       void SetCorrectHeaders(CReadState* state);
-      bool Service(const CStdString& strURL, CStdString& strHTML);
+      bool Service(const std::string& strURL, std::string& strHTML);
 
     protected:
       CReadState*     m_state;

--- a/xbmc/filesystem/DAAPFile.h
+++ b/xbmc/filesystem/DAAPFile.h
@@ -34,6 +34,7 @@
 #include "CurlFile.h"
 #include "URL.h"
 #include "threads/CriticalSection.h"
+#include "utils/StdString.h"
 
 class CDaapClient : public CCriticalSection
 {

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -177,7 +177,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         itemPath += "|" + url2.GetProtocolOptions();
       item.SetPath(itemPath);
 
-      if (!item.GetPath().Equals(url.Get()))
+      if (!item.IsURL(url))
       {
         CFileItemPtr pItem(new CFileItem(item));
         items.Add(pItem);

--- a/xbmc/filesystem/DAVFile.cpp
+++ b/xbmc/filesystem/DAVFile.cpp
@@ -51,7 +51,10 @@ bool CDAVFile::Execute(const CURL& url)
 
   ASSERT(!(!m_state->m_easyHandle ^ !m_state->m_multiHandle));
   if( m_state->m_easyHandle == NULL )
-    g_curlInterface.easy_aquire(url2.GetProtocol(), url2.GetHostName(), &m_state->m_easyHandle, &m_state->m_multiHandle );
+    g_curlInterface.easy_aquire(url2.GetProtocol().c_str(),
+                                url2.GetHostName().c_str(),
+                                &m_state->m_easyHandle,
+                                &m_state->m_multiHandle);
 
   // setup common curl options
   SetCommonOptions(m_state);

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -49,7 +49,7 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
   if (!reader.Open(url))
     return false;
 
-  bool serverNotUseUTF8 = url.GetProtocolOption("utf8").Equals("0");
+  bool serverNotUseUTF8 = url.GetProtocolOption("utf8") == "0";
 
   char buffer[MAX_PATH + 1024];
   while( reader.ReadString(buffer, sizeof(buffer)) )

--- a/xbmc/filesystem/HTTPFile.cpp
+++ b/xbmc/filesystem/HTTPFile.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "HTTPFile.h"
+#include "utils/StdString.h"
 
 using namespace XFILE;
 

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -51,7 +51,7 @@ bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   CLog::Log(LOGDEBUG,"CMultiPathDirectory::GetDirectory(%s)", url.GetRedacted().c_str());
 
-  vector<CStdString> vecPaths;
+  vector<std::string> vecPaths;
   if (!GetPaths(url, vecPaths))
     return false;
 
@@ -118,7 +118,7 @@ bool CMultiPathDirectory::Exists(const CURL& url)
 {
   CLog::Log(LOGDEBUG,"Testing Existence (%s)", url.GetRedacted().c_str());
 
-  vector<CStdString> vecPaths;
+  vector<std::string> vecPaths;
   if (!GetPaths(url, vecPaths))
     return false;
 
@@ -133,7 +133,7 @@ bool CMultiPathDirectory::Exists(const CURL& url)
 
 bool CMultiPathDirectory::Remove(const CURL& url)
 {
-  vector<CStdString> vecPaths;
+  vector<std::string> vecPaths;
   if (!GetPaths(url, vecPaths))
     return false;
 
@@ -146,7 +146,7 @@ bool CMultiPathDirectory::Remove(const CURL& url)
   return success;
 }
 
-CStdString CMultiPathDirectory::GetFirstPath(const CStdString &strPath)
+std::string CMultiPathDirectory::GetFirstPath(const std::string &strPath)
 {
   size_t pos = strPath.find("/", 12);
   if (pos != std::string::npos)
@@ -154,35 +154,13 @@ CStdString CMultiPathDirectory::GetFirstPath(const CStdString &strPath)
   return "";
 }
 
-bool CMultiPathDirectory::GetPaths(const CURL& url, vector<CStdString>& vecPaths)
+bool CMultiPathDirectory::GetPaths(const CURL& url, vector<std::string>& vecPaths)
 {
-  const CStdString pathToUrl(url.Get());
+  const std::string pathToUrl(url.Get());
   return GetPaths(pathToUrl, vecPaths);
 }
 
-bool CMultiPathDirectory::GetPaths(const CStdString& strPath, vector<CStdString>& vecPaths)
-{
-  vecPaths.clear();
-  CStdString strPath1 = strPath;
-
-  // remove multipath:// from path and any trailing / (so that the last path doesn't get any more than it originally had)
-  strPath1 = strPath1.substr(12);
-  URIUtils::RemoveSlashAtEnd(strPath1);
-
-  // split on "/"
-  vector<string> vecTemp = StringUtils::Split(strPath1, "/");
-  if (vecTemp.empty())
-    return false;
-
-  // check each item
-  for (unsigned int i = 0; i < vecTemp.size(); i++)
-  {
-    vecPaths.push_back(CURL::Decode(vecTemp[i]));
-  }
-  return true;
-}
-
-bool CMultiPathDirectory::GetPaths(const std::string& path, vector<string>& paths)
+bool CMultiPathDirectory::GetPaths(const std::string& path, std::vector<std::string>& paths)
 {
   paths.clear();
 
@@ -201,10 +179,10 @@ bool CMultiPathDirectory::GetPaths(const std::string& path, vector<string>& path
   return true;
 }
 
-bool CMultiPathDirectory::HasPath(const CStdString& strPath, const CStdString& strPathToFind)
+bool CMultiPathDirectory::HasPath(const std::string& strPath, const std::string& strPathToFind)
 {
   // remove multipath:// from path and any trailing / (so that the last path doesn't get any more than it originally had)
-  CStdString strPath1 = strPath.substr(12);
+  std::string strPath1 = strPath.substr(12);
   URIUtils::RemoveSlashAtEnd(strPath1);
 
   // split on "/"
@@ -221,12 +199,12 @@ bool CMultiPathDirectory::HasPath(const CStdString& strPath, const CStdString& s
   return false;
 }
 
-CStdString CMultiPathDirectory::ConstructMultiPath(const CFileItemList& items, const vector<int> &stack)
+std::string CMultiPathDirectory::ConstructMultiPath(const CFileItemList& items, const vector<int> &stack)
 {
   // we replace all instances of comma's with double comma's, then separate
   // the paths using " , "
   //CLog::Log(LOGDEBUG, "Building multipath");
-  CStdString newPath = "multipath://";
+  std::string newPath = "multipath://";
   //CLog::Log(LOGDEBUG, "-- adding path: %s", strPath.c_str());
   for (unsigned int i = 0; i < stack.size(); ++i)
     AddToMultiPath(newPath, items[stack[i]]->GetPath());
@@ -235,7 +213,7 @@ CStdString CMultiPathDirectory::ConstructMultiPath(const CFileItemList& items, c
   return newPath;
 }
 
-void CMultiPathDirectory::AddToMultiPath(CStdString& strMultiPath, const CStdString& strPath)
+void CMultiPathDirectory::AddToMultiPath(std::string& strMultiPath, const std::string& strPath)
 {
   URIUtils::AddSlashAtEnd(strMultiPath);
   //CLog::Log(LOGDEBUG, "-- adding path: %s", strPath.c_str());
@@ -243,12 +221,12 @@ void CMultiPathDirectory::AddToMultiPath(CStdString& strMultiPath, const CStdStr
   strMultiPath += "/";
 }
 
-CStdString CMultiPathDirectory::ConstructMultiPath(const vector<string> &vecPaths)
+std::string CMultiPathDirectory::ConstructMultiPath(const vector<string> &vecPaths)
 {
   // we replace all instances of comma's with double comma's, then separate
   // the paths using " , "
   //CLog::Log(LOGDEBUG, "Building multipath");
-  CStdString newPath = "multipath://";
+  std::string newPath = "multipath://";
   //CLog::Log(LOGDEBUG, "-- adding path: %s", strPath.c_str());
   for (vector<string>::const_iterator path = vecPaths.begin(); path != vecPaths.end(); ++path)
     AddToMultiPath(newPath, *path);
@@ -256,9 +234,9 @@ CStdString CMultiPathDirectory::ConstructMultiPath(const vector<string> &vecPath
   return newPath;
 }
 
-CStdString CMultiPathDirectory::ConstructMultiPath(const set<string> &setPaths)
+std::string CMultiPathDirectory::ConstructMultiPath(const set<string> &setPaths)
 {
-  CStdString newPath = "multipath://";
+  std::string newPath = "multipath://";
   for (set<string>::const_iterator path = setPaths.begin(); path != setPaths.end(); ++path)
     AddToMultiPath(newPath, *path);
 
@@ -313,7 +291,7 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
     if (stack.size() > 1)
     {
       // we have a multipath so remove the items and add the new item
-      CStdString newPath = ConstructMultiPath(items, stack);
+      std::string newPath = ConstructMultiPath(items, stack);
       for (unsigned int k = stack.size() - 1; k > 0; --k)
         items.Remove(stack[k]);
       pItem1->SetPath(newPath);
@@ -328,9 +306,9 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
             items.Size(), XbmcThreads::SystemClockMillis() - time);
 }
 
-bool CMultiPathDirectory::SupportsWriteFileOperations(const CStdString &strPath)
+bool CMultiPathDirectory::SupportsWriteFileOperations(const std::string &strPath)
 {
-  vector<CStdString> paths;
+  vector<std::string> paths;
   GetPaths(strPath, paths);
   for (unsigned int i = 0; i < paths.size(); ++i)
     if (CUtil::SupportsWriteFileOperations(paths[i]))

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -273,7 +273,7 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
     do
     {
       CFileItemPtr pItem2 = items.Get(j);
-      if (!pItem2->GetLabel().Equals(pItem1->GetLabel()))
+      if (pItem2->GetLabel() != pItem1->GetLabel())
         break;
 
       // ignore any filefolders which may coincidently have

--- a/xbmc/filesystem/MultiPathDirectory.h
+++ b/xbmc/filesystem/MultiPathDirectory.h
@@ -20,8 +20,8 @@
  */
 
 #include <set>
+#include <string>
 #include "IDirectory.h"
-#include "utils/StdString.h"
 
 namespace XFILE
 {
@@ -35,18 +35,17 @@ public:
   virtual bool Exists(const CURL& url);
   virtual bool Remove(const CURL& url);
 
-  static CStdString GetFirstPath(const CStdString &strPath);
-  static bool SupportsWriteFileOperations(const CStdString &strPath);
-  static bool GetPaths(const CURL& url, std::vector<CStdString>& vecPaths);
-  static bool GetPaths(const CStdString& strPath, std::vector<CStdString>& vecPaths);
+  static std::string GetFirstPath(const std::string &strPath);
+  static bool SupportsWriteFileOperations(const std::string &strPath);
+  static bool GetPaths(const CURL& url, std::vector<std::string>& vecPaths);
   static bool GetPaths(const std::string& path, std::vector<std::string>& paths);
-  static bool HasPath(const CStdString& strPath, const CStdString& strPathToFind);
-  static CStdString ConstructMultiPath(const std::vector<std::string> &vecPaths);
-  static CStdString ConstructMultiPath(const std::set<std::string> &setPaths);
+  static bool HasPath(const std::string& strPath, const std::string& strPathToFind);
+  static std::string ConstructMultiPath(const std::vector<std::string> &vecPaths);
+  static std::string ConstructMultiPath(const std::set<std::string> &setPaths);
 
 private:
   void MergeItems(CFileItemList &items);
-  static void AddToMultiPath(CStdString& strMultiPath, const CStdString& strPath);
-  CStdString ConstructMultiPath(const CFileItemList& items, const std::vector<int> &stack);
+  static void AddToMultiPath(std::string& strMultiPath, const std::string& strPath);
+  std::string ConstructMultiPath(const CFileItemList& items, const std::vector<int> &stack);
 };
 }

--- a/xbmc/filesystem/MultiPathFile.cpp
+++ b/xbmc/filesystem/MultiPathFile.cpp
@@ -39,15 +39,15 @@ CMultiPathFile::~CMultiPathFile(void)
 bool CMultiPathFile::Open(const CURL& url)
 {
   // grab the filename off the url
-  CStdString path, fileName;
+  std::string path, fileName;
   URIUtils::Split(url.Get(), path, fileName);
-  vector<CStdString> vecPaths;
+  vector<std::string> vecPaths;
   if (!CMultiPathDirectory::GetPaths(path, vecPaths))
     return false;
 
   for (unsigned int i = 0; i < vecPaths.size(); i++)
   {
-    CStdString filePath = vecPaths[i];
+    std::string filePath = vecPaths[i];
     filePath = URIUtils::AddFileToFolder(filePath, fileName);
     if (m_file.Open(filePath))
       return true;
@@ -58,15 +58,15 @@ bool CMultiPathFile::Open(const CURL& url)
 bool CMultiPathFile::Exists(const CURL& url)
 {
   // grab the filename off the url
-  CStdString path, fileName;
+  std::string path, fileName;
   URIUtils::Split(url.Get(), path, fileName);
-  vector<CStdString> vecPaths;
+  vector<std::string> vecPaths;
   if (!CMultiPathDirectory::GetPaths(path, vecPaths))
     return false;
 
   for (unsigned int i = 0; i < vecPaths.size(); i++)
   {
-    CStdString filePath = vecPaths[i];
+    std::string filePath = vecPaths[i];
     filePath = URIUtils::AddFileToFolder(filePath, fileName);
     if (CFile::Exists(filePath))
       return true;
@@ -77,15 +77,15 @@ bool CMultiPathFile::Exists(const CURL& url)
 int CMultiPathFile::Stat(const CURL& url, struct __stat64* buffer)
 {
   // grab the filename off the url
-  CStdString path, fileName;
+  std::string path, fileName;
   URIUtils::Split(url.Get(), path, fileName);
-  vector<CStdString> vecPaths;
+  vector<std::string> vecPaths;
   if (!CMultiPathDirectory::GetPaths(path, vecPaths))
     return false;
 
   for (unsigned int i = 0; i < vecPaths.size(); i++)
   {
-    CStdString filePath = vecPaths[i];
+    std::string filePath = vecPaths[i];
     filePath = URIUtils::AddFileToFolder(filePath, fileName);
     int ret = CFile::Stat(filePath, buffer);
     if (ret == 0)

--- a/xbmc/filesystem/MythDirectory.h
+++ b/xbmc/filesystem/MythDirectory.h
@@ -22,6 +22,7 @@
 #include "IDirectory.h"
 #include "MythSession.h"
 #include "XBDateTime.h"
+#include "utils/StdString.h"
 
 namespace XFILE
 {

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -187,7 +187,7 @@ void CMythSession::SetFileItemMetaData(CFileItem &item, cmyth_proginfo_t program
    * would cause it to be shown in a different position if it was indeed strictly sorting by
    * what is displayed in the list).
    */
-  tag->m_strSortTitle = title + " " + item.m_dateTime.GetAsDBDateTime(); // e.g. Mythbusters 2009-12-13 12:23:14
+  tag->m_strSortTitle = title + " " + (CStdString)item.m_dateTime.GetAsDBDateTime(); // e.g. Mythbusters 2009-12-13 12:23:14
 
   /*
    * Set further FileItem and VideoInfoTag meta-data based on whether it is LiveTV or not.

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -199,7 +199,7 @@ void CMythSession::SetFileItemMetaData(CFileItem &item, cmyth_proginfo_t program
      * Prepend the channel number onto the FileItem title for the listing so it's clear what is
      * playing on each channel without using up as much room as the channel name.
      */
-    CStdString number = GetValue(m_dll->proginfo_chanstr(program));
+    std::string number = GetValue(m_dll->proginfo_chanstr(program));
     item.m_strTitle = number + " - " + item.m_strTitle;
 
     /*

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -195,9 +195,9 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if(!gNfsConnection.Connect(url,strDirName))
   {
     //connect has failed - so try to get the exported filesystms if no path is given to the url
-    if(url.GetShareName().Equals(""))
+    if(url.GetShareName().empty())
     {
-      if(url.GetHostName().Equals(""))
+      if(url.GetHostName().empty())
       {
         return GetServerList(items);
       }

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -299,10 +299,10 @@ bool CNfsConnection::Connect(const CURL& url, CStdString &relativePath)
   ret = splitUrlIntoExportAndPath(url, exportPath, relativePath);
   
   if( (ret && (!exportPath.Equals(m_exportPath,true)  || 
-      !url.GetHostName().Equals(m_hostName,false)))    ||
+       url.GetHostName() != m_hostName))    ||
       (XbmcThreads::SystemClockMillis() - m_lastAccessedTime) > CONTEXT_TIMEOUT )
   {
-    int contextRet = getContextForExport(url.GetHostName() + exportPath);
+    int contextRet = getContextForExport((CStdString)url.GetHostName() + exportPath);
     
     if(contextRet == CONTEXT_INVALID)//we need a new context because sharename or hostname has changed
     {
@@ -318,7 +318,7 @@ bool CNfsConnection::Connect(const CURL& url, CStdString &relativePath)
       if(nfsRet != 0) 
       {
         CLog::Log(LOGERROR,"NFS: Failed to mount nfs share: %s (%s)\n", exportPath.c_str(), m_pLibNfs->nfs_get_error(m_pNfsContext));
-        destroyContext(url.GetHostName() + exportPath);
+        destroyContext((CStdString)url.GetHostName() + exportPath);
         return false;
       }
       CLog::Log(LOGDEBUG,"NFS: Connected to server %s and export %s\n", url.GetHostName().c_str(), exportPath.c_str());

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -381,7 +381,7 @@ static void ParseItemZink(CFileItem* item, SResources& resources, TiXmlElement* 
 
 static void ParseItemSVT(CFileItem* item, SResources& resources, TiXmlElement* element, const CStdString& name, const CStdString& xmlns, const CStdString& path)
 {
-  CStdString text = element->GetText();
+  std::string text = element->GetText();
   if     (name == "xmllink")
   {
     SResource res;

--- a/xbmc/filesystem/RTVFile.cpp
+++ b/xbmc/filesystem/RTVFile.cpp
@@ -30,6 +30,7 @@
 #ifdef TARGET_WINDOWS
 #include "PlatformDefs.h" //for PRIdS
 #endif
+#include "utils/StdString.h"
 extern "C"
 {
 #include "lib/libRTV/interface.h"
@@ -107,7 +108,7 @@ bool CRTVFile::Open(const char* strHostName, const char* strFileName, int iport)
 
 bool CRTVFile::Open(const CURL& url)
 {
-  return Open(url.GetHostName(), url.GetFileName(), url.GetPort());
+  return Open((CStdString)url.GetHostName(), (CStdString)url.GetFileName(), url.GetPort());
 }
 
 bool CRTVFile::Exists(const CURL& url)

--- a/xbmc/filesystem/RarDirectory.cpp
+++ b/xbmc/filesystem/RarDirectory.cpp
@@ -61,7 +61,7 @@ namespace XFILE
       {
         if (items[iEntry]->IsParentFolder())
           continue;
-        items[iEntry]->SetPath(URIUtils::AddFileToFolder(strSlashPath,items[iEntry]->GetPath()+strOptions));
+        items[iEntry]->SetPath(URIUtils::AddFileToFolder(strSlashPath,(CStdString)items[iEntry]->GetPath()+strOptions));
         items[iEntry]->m_iDriveType = 0;
         //CLog::Log(LOGDEBUG, "RarXFILE::GetDirectory() retrieved file: %s", items[iEntry]->m_strPath.c_str());
       }

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -448,7 +448,7 @@ void CRarManager::ExtractArchive(const CStdString& strArchive, const CStdString&
 int64_t CRarManager::CheckFreeSpace(const CStdString& strDrive)
 {
   ULARGE_INTEGER lTotalFreeBytes;
-  if (GetDiskFreeSpaceEx(CSpecialProtocol::TranslatePath(strDrive.c_str()), NULL, NULL, &lTotalFreeBytes))
+  if (GetDiskFreeSpaceEx(CSpecialProtocol::TranslatePath(strDrive).c_str(), NULL, NULL, &lTotalFreeBytes))
     return lTotalFreeBytes.QuadPart;
 
   return 0;

--- a/xbmc/filesystem/SAPFile.cpp
+++ b/xbmc/filesystem/SAPFile.cpp
@@ -24,6 +24,7 @@
 #include "SAPDirectory.h"
 #include "threads/SingleLock.h"
 #include "URL.h"
+#include "utils/StdString.h"
 
 #include <sys/stat.h>
 #include <vector>

--- a/xbmc/filesystem/SlingboxFile.cpp
+++ b/xbmc/filesystem/SlingboxFile.cpp
@@ -51,7 +51,7 @@ bool CSlingboxFile::Open(const CURL& url)
     uiPort = (unsigned int)url.GetPort();
   else
     uiPort = 5001;
-  m_pSlingbox->SetAddress(url.GetHostName(), uiPort);
+  m_pSlingbox->SetAddress(url.GetHostName().c_str(), uiPort);
 
   // Prepare to connect to the Slingbox
   bool bAdmin;
@@ -67,7 +67,7 @@ bool CSlingboxFile::Open(const CURL& url)
   }
 
   // Connect to the Slingbox
-  if (m_pSlingbox->Connect(bAdmin, url.GetPassWord()))
+  if (m_pSlingbox->Connect(bAdmin, url.GetPassWord().c_str()))
   {
     CLog::Log(LOGDEBUG, "%s - Successfully connected to Slingbox: %s",
       __FUNCTION__, url.GetHostName().c_str());
@@ -95,12 +95,12 @@ bool CSlingboxFile::Open(const CURL& url)
   // Set correct input
   if (url.GetFileNameWithoutPath() != "")
   {
-    if (m_pSlingbox->SetInput(atoi(url.GetFileNameWithoutPath())))
+    if (m_pSlingbox->SetInput(atoi(url.GetFileNameWithoutPath().c_str())))
       CLog::Log(LOGDEBUG, "%s - Successfully requested change to input %i on Slingbox: %s",
-        __FUNCTION__, atoi(url.GetFileNameWithoutPath()), url.GetHostName().c_str());
+        __FUNCTION__, atoi(url.GetFileNameWithoutPath().c_str()), url.GetHostName().c_str());
     else
       CLog::Log(LOGERROR, "%s - Error requesting change to input %i on Slingbox: %s",
-        __FUNCTION__, atoi(url.GetFileNameWithoutPath()), url.GetHostName().c_str());
+        __FUNCTION__, atoi(url.GetFileNameWithoutPath().c_str()), url.GetHostName().c_str());
   }
 
   // Load the video settings
@@ -142,15 +142,16 @@ bool CSlingboxFile::Open(const CURL& url)
   // Check for correct input
   if (url.GetFileNameWithoutPath() != "")
   {
+    int input = atoi(url.GetFileNameWithoutPath().c_str());
     if (m_pSlingbox->GetInput() == -1)
       CLog::Log(LOGDEBUG, "%s - Unable to confirm change to input %i on Slingbox: %s",
-        __FUNCTION__, atoi(url.GetFileNameWithoutPath()), url.GetHostName().c_str());
-    else if (m_pSlingbox->GetInput() == atoi(url.GetFileNameWithoutPath()))
+        __FUNCTION__, input, url.GetHostName().c_str());
+    else if (m_pSlingbox->GetInput() == input)
       CLog::Log(LOGDEBUG, "%s - Comfirmed change to input %i on Slingbox: %s",
-        __FUNCTION__, atoi(url.GetFileNameWithoutPath()), url.GetHostName().c_str());
+        __FUNCTION__, input, url.GetHostName().c_str());
     else
       CLog::Log(LOGERROR, "%s - Error changing to input %i on Slingbox: %s",
-        __FUNCTION__, atoi(url.GetFileNameWithoutPath()), url.GetHostName().c_str());
+        __FUNCTION__, input, url.GetHostName().c_str());
   }
 
   return true;

--- a/xbmc/filesystem/SmbFile.h
+++ b/xbmc/filesystem/SmbFile.h
@@ -30,6 +30,7 @@
 #include "IFile.h"
 #include "URL.h"
 #include "threads/CriticalSection.h"
+#include "utils/StdString.h"
 
 #define NT_STATUS_CONNECTION_REFUSED long(0xC0000000 | 0x0236)
 #define NT_STATUS_INVALID_HANDLE long(0xC0000000 | 0x0008)

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -87,7 +87,7 @@ std::string CSpecialProtocol::TranslatePath(const std::string &path)
 {
   CURL url(path);
   // check for special-protocol, if not, return
-  if (!url.GetProtocol().Equals("special"))
+  if (!url.IsProtocol("special"))
   {
     return path;
   }
@@ -97,7 +97,7 @@ std::string CSpecialProtocol::TranslatePath(const std::string &path)
 std::string CSpecialProtocol::TranslatePath(const CURL &url)
 {
   // check for special-protocol, if not, return
-  if (!url.GetProtocol().Equals("special"))
+  if (!url.IsProtocol("special"))
   {
 #if defined(TARGET_POSIX) && defined(_DEBUG)
     std::string path(url.Get());

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -35,55 +35,55 @@
 
 using namespace std;
 
-map<CStdString, CStdString> CSpecialProtocol::m_pathMap;
+map<std::string, std::string> CSpecialProtocol::m_pathMap;
 
-void CSpecialProtocol::SetProfilePath(const CStdString &dir)
+void CSpecialProtocol::SetProfilePath(const std::string &dir)
 {
   SetPath("profile", dir);
   CLog::Log(LOGNOTICE, "special://profile/ is mapped to: %s", GetPath("profile").c_str());
 }
 
-void CSpecialProtocol::SetXBMCPath(const CStdString &dir)
+void CSpecialProtocol::SetXBMCPath(const std::string &dir)
 {
   SetPath("xbmc", dir);
 }
 
-void CSpecialProtocol::SetXBMCBinPath(const CStdString &dir)
+void CSpecialProtocol::SetXBMCBinPath(const std::string &dir)
 {
   SetPath("xbmcbin", dir);
 }
 
-void CSpecialProtocol::SetXBMCFrameworksPath(const CStdString &dir)
+void CSpecialProtocol::SetXBMCFrameworksPath(const std::string &dir)
 {
   SetPath("frameworks", dir);
 }
 
-void CSpecialProtocol::SetHomePath(const CStdString &dir)
+void CSpecialProtocol::SetHomePath(const std::string &dir)
 {
   SetPath("home", dir);
 }
 
-void CSpecialProtocol::SetUserHomePath(const CStdString &dir)
+void CSpecialProtocol::SetUserHomePath(const std::string &dir)
 {
   SetPath("userhome", dir);
 }
 
-void CSpecialProtocol::SetMasterProfilePath(const CStdString &dir)
+void CSpecialProtocol::SetMasterProfilePath(const std::string &dir)
 {
   SetPath("masterprofile", dir);
 }
 
-void CSpecialProtocol::SetTempPath(const CStdString &dir)
+void CSpecialProtocol::SetTempPath(const std::string &dir)
 {
   SetPath("temp", dir);
 }
 
-bool CSpecialProtocol::ComparePath(const CStdString &path1, const CStdString &path2)
+bool CSpecialProtocol::ComparePath(const std::string &path1, const std::string &path2)
 {
   return TranslatePath(path1) == TranslatePath(path2);
 }
 
-CStdString CSpecialProtocol::TranslatePath(const CStdString &path)
+std::string CSpecialProtocol::TranslatePath(const std::string &path)
 {
   CURL url(path);
   // check for special-protocol, if not, return
@@ -94,13 +94,13 @@ CStdString CSpecialProtocol::TranslatePath(const CStdString &path)
   return TranslatePath(url);
 }
 
-CStdString CSpecialProtocol::TranslatePath(const CURL &url)
+std::string CSpecialProtocol::TranslatePath(const CURL &url)
 {
   // check for special-protocol, if not, return
   if (!url.GetProtocol().Equals("special"))
   {
 #if defined(TARGET_POSIX) && defined(_DEBUG)
-    CStdString path(url.Get());
+    std::string path(url.Get());
     if (path.length() >= 2 && path[1] == ':')
     {
       CLog::Log(LOGWARNING, "Trying to access old style dir: %s\n", path.c_str());
@@ -111,11 +111,11 @@ CStdString CSpecialProtocol::TranslatePath(const CURL &url)
     return url.Get();
   }
 
-  CStdString FullFileName = url.GetFileName();
+  std::string FullFileName = url.GetFileName();
 
-  CStdString translatedPath;
-  CStdString FileName;
-  CStdString RootDir;
+  std::string translatedPath;
+  std::string FileName;
+  std::string RootDir;
 
   // Split up into the special://root and the rest of the filename
   size_t pos = FullFileName.find('/');
@@ -129,39 +129,39 @@ CStdString CSpecialProtocol::TranslatePath(const CURL &url)
   else
     RootDir = FullFileName;
 
-  if (RootDir.Equals("subtitles"))
+  if (RootDir == "subtitles")
     translatedPath = URIUtils::AddFileToFolder(CSettings::Get().GetString("subtitles.custompath"), FileName);
-  else if (RootDir.Equals("userdata"))
+  else if (RootDir == "userdata")
     translatedPath = URIUtils::AddFileToFolder(CProfilesManager::Get().GetUserDataFolder(), FileName);
-  else if (RootDir.Equals("database"))
+  else if (RootDir == "database")
     translatedPath = URIUtils::AddFileToFolder(CProfilesManager::Get().GetDatabaseFolder(), FileName);
-  else if (RootDir.Equals("thumbnails"))
+  else if (RootDir == "thumbnails")
     translatedPath = URIUtils::AddFileToFolder(CProfilesManager::Get().GetThumbnailsFolder(), FileName);
-  else if (RootDir.Equals("recordings") || RootDir.Equals("cdrips"))
+  else if (RootDir == "recordings" || RootDir == "cdrips")
     translatedPath = URIUtils::AddFileToFolder(CSettings::Get().GetString("audiocds.recordingpath"), FileName);
-  else if (RootDir.Equals("screenshots"))
+  else if (RootDir == "screenshots")
     translatedPath = URIUtils::AddFileToFolder(CSettings::Get().GetString("debug.screenshotpath"), FileName);
-  else if (RootDir.Equals("musicplaylists"))
+  else if (RootDir == "musicplaylists")
     translatedPath = URIUtils::AddFileToFolder(CUtil::MusicPlaylistsLocation(), FileName);
-  else if (RootDir.Equals("videoplaylists"))
+  else if (RootDir == "videoplaylists")
     translatedPath = URIUtils::AddFileToFolder(CUtil::VideoPlaylistsLocation(), FileName);
-  else if (RootDir.Equals("skin"))
+  else if (RootDir == "skin")
     translatedPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), FileName);
-  else if (RootDir.Equals("logpath"))
+  else if (RootDir == "logpath")
     translatedPath = URIUtils::AddFileToFolder(g_advancedSettings.m_logFolder, FileName);
 
 
   // from here on, we have our "real" special paths
-  else if (RootDir.Equals("xbmc") ||
-           RootDir.Equals("xbmcbin") ||
-           RootDir.Equals("home") ||
-           RootDir.Equals("userhome") ||
-           RootDir.Equals("temp") ||
-           RootDir.Equals("profile") ||
-           RootDir.Equals("masterprofile") ||
-           RootDir.Equals("frameworks"))
+  else if (RootDir == "xbmc" ||
+           RootDir == "xbmcbin" ||
+           RootDir == "home" ||
+           RootDir == "userhome" ||
+           RootDir == "temp" ||
+           RootDir == "profile" ||
+           RootDir == "masterprofile" ||
+           RootDir == "frameworks")
   {
-    CStdString basePath = GetPath(RootDir);
+    std::string basePath = GetPath(RootDir);
     if (!basePath.empty())
       translatedPath = URIUtils::AddFileToFolder(basePath, FileName);
     else
@@ -178,9 +178,9 @@ CStdString CSpecialProtocol::TranslatePath(const CURL &url)
   return CUtil::ValidatePath(translatedPath);
 }
 
-CStdString CSpecialProtocol::TranslatePathConvertCase(const CStdString& path)
+std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)
 {
-  CStdString translatedPath = TranslatePath(path);
+  std::string translatedPath = TranslatePath(path);
 
 #ifdef TARGET_POSIX
   if (translatedPath.find("://") != std::string::npos)
@@ -191,10 +191,10 @@ CStdString CSpecialProtocol::TranslatePathConvertCase(const CStdString& path)
   if (stat(translatedPath.c_str(), &stat_buf) == 0)
     return translatedPath;
 
-  CStdString result;
+  std::string result;
   std::vector<std::string> tokens;
   StringUtils::Tokenize(translatedPath, tokens, "/");
-  CStdString file;
+  std::string file;
   DIR* dir;
   struct dirent* de;
 
@@ -255,14 +255,14 @@ void CSpecialProtocol::LogPaths()
 }
 
 // private routines, to ensure we only set/get an appropriate path
-void CSpecialProtocol::SetPath(const CStdString &key, const CStdString &path)
+void CSpecialProtocol::SetPath(const std::string &key, const std::string &path)
 {
   m_pathMap[key] = path;
 }
 
-CStdString CSpecialProtocol::GetPath(const CStdString &key)
+std::string CSpecialProtocol::GetPath(const std::string &key)
 {
-  map<CStdString, CStdString>::iterator it = m_pathMap.find(key);
+  map<std::string, std::string>::iterator it = m_pathMap.find(key);
   if (it != m_pathMap.end())
     return it->second;
   assert(false);

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -20,7 +20,7 @@
  */
 
 #include <map>
-#include "utils/StdString.h"
+#include <string>
 
 // static class for path translation from our special:// URLs.
 
@@ -52,27 +52,27 @@ class CURL;
 class CSpecialProtocol
 {
 public:
-  static void SetProfilePath(const CStdString &path);
-  static void SetXBMCPath(const CStdString &path);
-  static void SetXBMCBinPath(const CStdString &path);
-  static void SetXBMCFrameworksPath(const CStdString &path);
-  static void SetHomePath(const CStdString &path);
-  static void SetUserHomePath(const CStdString &path);
-  static void SetMasterProfilePath(const CStdString &path);
-  static void SetTempPath(const CStdString &path);
+  static void SetProfilePath(const std::string &path);
+  static void SetXBMCPath(const std::string &path);
+  static void SetXBMCBinPath(const std::string &path);
+  static void SetXBMCFrameworksPath(const std::string &path);
+  static void SetHomePath(const std::string &path);
+  static void SetUserHomePath(const std::string &path);
+  static void SetMasterProfilePath(const std::string &path);
+  static void SetTempPath(const std::string &path);
 
-  static bool ComparePath(const CStdString &path1, const CStdString &path2);
+  static bool ComparePath(const std::string &path1, const std::string &path2);
   static void LogPaths();
 
-  static CStdString TranslatePath(const CStdString &path);
-  static CStdString TranslatePath(const CURL &url);
-  static CStdString TranslatePathConvertCase(const CStdString& path);
+  static std::string TranslatePath(const std::string &path);
+  static std::string TranslatePath(const CURL &url);
+  static std::string TranslatePathConvertCase(const std::string& path);
 
 private:
-  static void SetPath(const CStdString &key, const CStdString &path);
-  static CStdString GetPath(const CStdString &key);
+  static void SetPath(const std::string &key, const std::string &path);
+  static std::string GetPath(const std::string &key);
 
-  static std::map<CStdString, CStdString> m_pathMap;
+  static std::map<std::string, std::string> m_pathMap;
 };
 
 #ifdef TARGET_WINDOWS

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -54,7 +54,7 @@ bool CUDFDirectory::GetDirectory(const CURL& url,
   URIUtils::AddSlashAtEnd(strSub);
 
   udf25 udfIsoReader;
-  if(!udfIsoReader.Open(url.GetHostName()))
+  if(!udfIsoReader.Open(url.GetHostName().c_str()))
      return false;
 
   udf_dir_t *dirp = udfIsoReader.OpenDir(strSub);

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -50,10 +50,10 @@ CUDFFile::~CUDFFile()
 //*********************************************************************************************
 bool CUDFFile::Open(const CURL& url)
 {
-  if(!m_udfIsoReaderLocal.Open(url.GetHostName()) || url.GetFileName().empty())
+  if(!m_udfIsoReaderLocal.Open(url.GetHostName().c_str()) || url.GetFileName().empty())
      return false;
 
-  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName());
+  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName().c_str());
   if (m_hFile == INVALID_HANDLE_VALUE)
   {
     m_bOpened = false;
@@ -108,10 +108,10 @@ int64_t CUDFFile::GetPosition()
 
 bool CUDFFile::Exists(const CURL& url)
 {
-  if(!m_udfIsoReaderLocal.Open(url.GetHostName()))
+  if(!m_udfIsoReaderLocal.Open(url.GetHostName().c_str()))
      return false;
 
-  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName());
+  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName().c_str());
   if (m_hFile == INVALID_HANDLE_VALUE)
     return false;
 
@@ -122,7 +122,7 @@ bool CUDFFile::Exists(const CURL& url)
 
 int CUDFFile::Stat(const CURL& url, struct __stat64* buffer)
 {
-  if(!m_udfIsoReaderLocal.Open(url.GetHostName()))
+  if(!m_udfIsoReaderLocal.Open(url.GetHostName().c_str()))
      return -1;
 
   if (url.GetFileName().empty())
@@ -131,7 +131,7 @@ int CUDFFile::Stat(const CURL& url, struct __stat64* buffer)
     return 0;
   }
 
-  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName());
+  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName().c_str());
   if (m_hFile != INVALID_HANDLE_VALUE)
   {
     buffer->st_size = m_udfIsoReaderLocal.GetFileSize(m_hFile);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -57,7 +57,7 @@ CStdString CDirectoryNodeSeasons::GetLocalizedName() const
     return "";
   }
   default:
-    CStdString season = StringUtils::Format(g_localizeStrings.Get(20358), GetID()); // Season <season>
+    CStdString season = StringUtils::Format(g_localizeStrings.Get(20358).c_str(), GetID()); // Season <season>
     return season;
   }
 }

--- a/xbmc/filesystem/posix/PosixDirectory.cpp
+++ b/xbmc/filesystem/posix/PosixDirectory.cpp
@@ -90,7 +90,7 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
     if (!(m_flags & DIR_FLAG_NO_FILE_INFO))
     {
-      if (bStat || stat(pItem->GetPath(), &buffer) == 0)
+      if (bStat || stat(pItem->GetPath().c_str(), &buffer) == 0)
       {
         FILETIME fileTime, localTime;
         TimeTToFileTime(buffer.st_mtime, &fileTime);

--- a/xbmc/filesystem/test/TestDirectory.cpp
+++ b/xbmc/filesystem/test/TestDirectory.cpp
@@ -45,7 +45,7 @@ TEST(TestDirectory, General)
   tmppath3 = tmppath2;
   URIUtils::AddSlashAtEnd(tmppath3);
   itemptr = items[0];
-  EXPECT_STREQ(tmppath3.c_str(), itemptr->GetPath());
+  EXPECT_STREQ(tmppath3.c_str(), itemptr->GetPath().c_str());
   EXPECT_TRUE(XFILE::CDirectory::Remove(tmppath2));
   EXPECT_FALSE(XFILE::CDirectory::Exists(tmppath2));
   EXPECT_TRUE(XFILE::CDirectory::Exists(tmppath1));

--- a/xbmc/filesystem/test/TestRarFile.cpp
+++ b/xbmc/filesystem/test/TestRarFile.cpp
@@ -37,12 +37,12 @@ TEST(TestRarFile, Read)
   XFILE::CFile file;
   char buf[20];
   memset(&buf, 0, sizeof(buf));
-  CStdString reffile, strrarpath, strpathinrar;
+  CStdString reffile, strpathinrar;
   CFileItemList itemlist;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt.rar");
-  URIUtils::CreateArchivePath(strrarpath, "rar", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strrarpath, itemlist, "",
+  CURL rarUrl = URIUtils::CreateArchivePath("rar", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(rarUrl, itemlist, "",
     XFILE::DIR_FLAG_NO_FILE_DIRS));
   strpathinrar = itemlist[0]->GetPath();
   ASSERT_TRUE(file.Open(strpathinrar));
@@ -87,12 +87,12 @@ TEST(TestRarFile, Read)
 
 TEST(TestRarFile, Exists)
 {
-  CStdString reffile, strrarpath, strpathinrar;
+  CStdString reffile, strpathinrar;
   CFileItemList itemlist;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt.rar");
-  URIUtils::CreateArchivePath(strrarpath, "rar", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strrarpath, itemlist, "",
+  CURL rarUrl = URIUtils::CreateArchivePath("rar", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(rarUrl, itemlist, "",
     XFILE::DIR_FLAG_NO_FILE_DIRS));
   strpathinrar = itemlist[0]->GetPath();
 
@@ -102,12 +102,12 @@ TEST(TestRarFile, Exists)
 TEST(TestRarFile, Stat)
 {
   struct __stat64 buffer;
-  CStdString reffile, strrarpath, strpathinrar;
+  CStdString reffile, strpathinrar;
   CFileItemList itemlist;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt.rar");
-  URIUtils::CreateArchivePath(strrarpath, "rar", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strrarpath, itemlist, "",
+  CURL rarUrl = URIUtils::CreateArchivePath("rar", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(rarUrl, itemlist, "",
     XFILE::DIR_FLAG_NO_FILE_DIRS));
   strpathinrar = itemlist[0]->GetPath();
 
@@ -124,7 +124,7 @@ TEST(TestRarFile, CorruptedFile)
   XFILE::CFile *file;
   char buf[16];
   memset(&buf, 0, sizeof(buf));
-  CStdString reffilepath, strrarpath, strpathinrar, str;
+  CStdString reffilepath, strpathinrar, str;
   CFileItemList itemlist;
   unsigned int size, i;
   int64_t count = 0;
@@ -133,8 +133,8 @@ TEST(TestRarFile, CorruptedFile)
   ASSERT_TRUE((file = XBMC_CREATECORRUPTEDFILE(reffilepath, ".rar")) != NULL);
   std::cout << "Reference file generated at '" << XBMC_TEMPFILEPATH(file) << "'" << std::endl;
 
-  URIUtils::CreateArchivePath(strrarpath, "rar", XBMC_TEMPFILEPATH(file), "");
-  if (!XFILE::CDirectory::GetDirectory(strrarpath, itemlist, "",
+  CURL rarUrl = URIUtils::CreateArchivePath("rar", CURL(XBMC_TEMPFILEPATH(file)), "");
+  if (!XFILE::CDirectory::GetDirectory(rarUrl, itemlist, "",
                                        XFILE::DIR_FLAG_NO_FILE_DIRS))
   {
     XBMC_DELETETEMPFILE(file);
@@ -195,13 +195,13 @@ TEST(TestRarFile, StoredRAR)
   XFILE::CFile file;
   char buf[20];
   memset(&buf, 0, sizeof(buf));
-  CStdString reffile, strrarpath, strpathinrar;
+  CStdString reffile, strpathinrar;
   CFileItemList itemlist, itemlistemptydir;
   struct __stat64 stat_buffer;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/refRARstored.rar");
-  URIUtils::CreateArchivePath(strrarpath, "rar", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strrarpath, itemlist));
+  CURL rarUrl = URIUtils::CreateArchivePath("rar", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(rarUrl, itemlist));
   itemlist.Sort(SortByPath, SortOrderAscending);
 
   /* /reffile.txt */
@@ -417,13 +417,13 @@ TEST(TestRarFile, NormalRAR)
   XFILE::CFile file;
   char buf[20];
   memset(&buf, 0, sizeof(buf));
-  CStdString reffile, strrarpath, strpathinrar;
+  CStdString reffile, strpathinrar;
   CFileItemList itemlist, itemlistemptydir;
   struct __stat64 stat_buffer;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/refRARnormal.rar");
-  URIUtils::CreateArchivePath(strrarpath, "rar", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strrarpath, itemlist));
+  CURL rarUrl = URIUtils::CreateArchivePath("rar", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(rarUrl, itemlist));
   itemlist.Sort(SortByPath, SortOrderAscending);
 
   /* /reffile.txt */

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -25,6 +25,7 @@
 #include "FileItem.h"
 #include "settings/Settings.h"
 #include "test/TestUtils.h"
+#include "URL.h"
 
 #include <errno.h>
 
@@ -61,12 +62,12 @@ TEST_F(TestZipFile, Read)
   XFILE::CFile file;
   char buf[20];
   memset(&buf, 0, sizeof(buf));
-  CStdString reffile, strzippath, strpathinzip;
+  CStdString reffile, strpathinzip;
   CFileItemList itemlist;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt.zip");
-  URIUtils::CreateArchivePath(strzippath, "zip", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strzippath, itemlist, "",
+  CURL zipUrl = URIUtils::CreateArchivePath("zip", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(zipUrl, itemlist, "",
     XFILE::DIR_FLAG_NO_FILE_DIRS));
   strpathinzip = itemlist[0]->GetPath();
   ASSERT_TRUE(file.Open(strpathinzip));
@@ -111,12 +112,12 @@ TEST_F(TestZipFile, Read)
 
 TEST_F(TestZipFile, Exists)
 {
-  CStdString reffile, strzippath, strpathinzip;
+  CStdString reffile, strpathinzip;
   CFileItemList itemlist;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt.zip");
-  URIUtils::CreateArchivePath(strzippath, "zip", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strzippath, itemlist, "",
+  CURL zipUrl = URIUtils::CreateArchivePath("zip", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(zipUrl, itemlist, "",
     XFILE::DIR_FLAG_NO_FILE_DIRS));
   strpathinzip = itemlist[0]->GetPath();
 
@@ -126,12 +127,12 @@ TEST_F(TestZipFile, Exists)
 TEST_F(TestZipFile, Stat)
 {
   struct __stat64 buffer;
-  CStdString reffile, strzippath, strpathinzip;
+  CStdString reffile, strpathinzip;
   CFileItemList itemlist;
 
   reffile = XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt.zip");
-  URIUtils::CreateArchivePath(strzippath, "zip", reffile, "");
-  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(strzippath, itemlist, "",
+  CURL zipUrl = URIUtils::CreateArchivePath("zip", CURL(reffile), "");
+  ASSERT_TRUE(XFILE::CDirectory::GetDirectory(zipUrl, itemlist, "",
     XFILE::DIR_FLAG_NO_FILE_DIRS));
   strpathinzip = itemlist[0]->GetPath();
 
@@ -148,7 +149,7 @@ TEST_F(TestZipFile, CorruptedFile)
   XFILE::CFile *file;
   char buf[16];
   memset(&buf, 0, sizeof(buf));
-  CStdString reffilepath, strzippath, strpathinzip, str;
+  CStdString reffilepath, strpathinzip, str;
   CFileItemList itemlist;
   unsigned int size, i;
   int64_t count = 0;
@@ -157,8 +158,8 @@ TEST_F(TestZipFile, CorruptedFile)
   ASSERT_TRUE((file = XBMC_CREATECORRUPTEDFILE(reffilepath, ".zip")) != NULL);
   std::cout << "Reference file generated at '" << XBMC_TEMPFILEPATH(file) << "'" << std::endl;
 
-  URIUtils::CreateArchivePath(strzippath, "zip", XBMC_TEMPFILEPATH(file), "");
-  if (!XFILE::CDirectory::GetDirectory(strzippath, itemlist, "",
+  CURL zipUrl = URIUtils::CreateArchivePath("zip", CURL(reffilepath), "");
+  if (!XFILE::CDirectory::GetDirectory(zipUrl, itemlist, "",
                                        XFILE::DIR_FLAG_NO_FILE_DIRS))
   {
     XBMC_DELETETEMPFILE(file);

--- a/xbmc/filesystem/windows/WINFileSMB.cpp
+++ b/xbmc/filesystem/windows/WINFileSMB.cpp
@@ -53,7 +53,7 @@ CWINFileSMB::~CWINFileSMB()
 std::string CWINFileSMB::GetLocal(const CURL &url)
 {
   std::string path(url.GetFileName());
-  if (url.GetProtocol().Equals("smb", false) && !url.GetHostName().empty())
+  if (url.IsProtocol("smb") && !url.GetHostName().empty())
     path = "\\\\?\\UNC\\" + (std::string&)url.GetHostName() + "\\" + path;
 
   return path;

--- a/xbmc/filesystem/windows/WINSMBDirectory.cpp
+++ b/xbmc/filesystem/windows/WINSMBDirectory.cpp
@@ -52,7 +52,7 @@ CWINSMBDirectory::~CWINSMBDirectory(void)
 std::string CWINSMBDirectory::GetLocal(const CURL& url)
 {
   std::string path(url.GetFileName());
-  if (url.GetProtocol().Equals("smb", false) && !url.GetHostName().empty())
+  if (url.IsProtocol("smb") && !url.GetHostName().empty())
     path = "\\\\?\\UNC\\" + (std::string&)url.GetHostName() + "\\" + path;
 
   return path;

--- a/xbmc/guilib/AnimatedGif.cpp
+++ b/xbmc/guilib/AnimatedGif.cpp
@@ -225,7 +225,7 @@ int CAnimatedGifSet::LoadGIF (const char * szFileName)
   int GraphicExtensionFound = 0;
 
   // OPEN FILE
-  FILE *fd = fopen_utf8(CSpecialProtocol::TranslatePath(szFileName), "rb");
+  FILE *fd = fopen_utf8(CSpecialProtocol::TranslatePath(szFileName).c_str(), "rb");
   if (!fd)
   {
     return 0;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -753,9 +753,9 @@ bool CGUIBaseContainer::OnClick(int actionID)
   return SendWindowMessage(msg);
 }
 
-CStdString CGUIBaseContainer::GetDescription() const
+std::string CGUIBaseContainer::GetDescription() const
 {
-  CStdString strLabel;
+  std::string strLabel;
   int item = GetSelectedItem();
   if (item >= 0 && item < (int)m_items.size())
   {
@@ -1207,9 +1207,9 @@ bool CGUIBaseContainer::HasPreviousPage() const
   return false;
 }
 
-CStdString CGUIBaseContainer::GetLabel(int info) const
+std::string CGUIBaseContainer::GetLabel(int info) const
 {
-  CStdString label;
+  std::string label;
   switch (info)
   {
   case CONTAINER_NUM_PAGES:

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -62,7 +62,7 @@ public:
 
   void SetPageControl(int id);
 
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   virtual void SaveStates(std::vector<CControlState> &states);
   virtual int GetSelectedItem() const;
 
@@ -75,7 +75,7 @@ public:
   virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
 
   virtual bool GetCondition(int condition, int data) const;
-  virtual CStdString GetLabel(int info) const;
+  virtual std::string GetLabel(int info) const;
 
   /*! \brief Set the list provider for this container (for python).
    \param provider the list provider to use for this container.

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -277,9 +277,9 @@ EVENT_RESULT CGUIButtonControl::OnMouseEvent(const CPoint &point, const CMouseEv
   return EVENT_RESULT_UNHANDLED;
 }
 
-CStdString CGUIButtonControl::GetDescription() const
+std::string CGUIButtonControl::GetDescription() const
 {
-  CStdString strLabel(m_info.GetLabel(m_parentID));
+  std::string strLabel(m_info.GetLabel(m_parentID));
   return strLabel;
 }
 

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -66,7 +66,7 @@ public:
   virtual CStdString GetLabel() const { return GetDescription(); };
   virtual CStdString GetLabel2() const;
   void SetSelected(bool bSelected);
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   void SetAlpha(unsigned char alpha);
 
   void PythonSetLabel(const CStdString &strFont, const std::string &strText, color_t textColor, color_t shadowColor, color_t focusedColor);

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -215,7 +215,7 @@ public:
   virtual void SetEnabled(bool bEnable);
   virtual void SetInvalid() { m_bInvalidated = true; };
   virtual void SetPulseOnSelect(bool pulse) { m_pulseOnSelect = pulse; };
-  virtual CStdString GetDescription() const { return ""; };
+  virtual std::string GetDescription() const { return ""; };
 
   void SetAnimations(const std::vector<CAnimation> &animations);
   const std::vector<CAnimation> &GetAnimations() const { return m_animations; };

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -419,11 +419,11 @@ bool CGUIControlFactory::GetAlignmentY(const TiXmlNode* pRootNode, const char* s
   return true;
 }
 
-bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control, CStdString &condition, CStdString &allowHiddenFocus)
+bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control, std::string &condition, std::string &allowHiddenFocus)
 {
   const TiXmlElement* node = control->FirstChildElement("visible");
   if (!node) return false;
-  vector<CStdString> conditions;
+  vector<std::string> conditions;
   while (node)
   {
     const char *hidden = node->Attribute("allowhiddenfocus");
@@ -448,7 +448,7 @@ bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control, CStd
   return true;
 }
 
-bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode *control, CStdString &condition)
+bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode *control, std::string &condition)
 {
   CStdString allowHiddenFocus;
   return GetConditionalVisibility(control, condition, allowHiddenFocus);

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -82,14 +82,14 @@ public:
   static bool GetColor(const TiXmlNode* pRootNode, const char* strTag, color_t &value);
   static bool GetInfoColor(const TiXmlNode* pRootNode, const char* strTag, CGUIInfoColor &value, int parentID);
   static CStdString FilterLabel(const CStdString &label);
-  static bool GetConditionalVisibility(const TiXmlNode* control, CStdString &condition);
+  static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition);
   static bool GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& actions);
   static void GetRectFromString(const CStdString &string, CRect &rect);
   static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect);
   static bool GetScroller(const TiXmlNode *pControlNode, const CStdString &scrollerTag, CScroller& scroller);
 private:
   static CStdString GetType(const TiXmlElement *pControlNode);
-  static bool GetConditionalVisibility(const TiXmlNode* control, CStdString &condition, CStdString &allowHiddenFocus);
+  static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition, std::string &allowHiddenFocus);
   bool GetString(const TiXmlNode* pRootNode, const char* strTag, CStdString& strString);
   static bool GetFloatRange(const TiXmlNode* pRootNode, const char* strTag, float& iMinValue, float& iMaxValue, float& iIntervalValue);
   static bool GetIntRange(const TiXmlNode* pRootNode, const char* strTag, int& iMinValue, int& iMaxValue, int& iIntervalValue);

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -236,7 +236,7 @@ bool CGUIFadeLabelControl::OnMessage(CGUIMessage& message)
   return CGUIControl::OnMessage(message);
 }
 
-CStdString CGUIFadeLabelControl::GetDescription() const
+std::string CGUIFadeLabelControl::GetDescription() const
 {
   return (m_currentLabel < m_infoLabels.size()) ?  m_infoLabels[m_currentLabel].GetLabel(m_parentID) : "";
 }

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -52,7 +52,7 @@ public:
 
 protected:
   virtual bool UpdateColors();
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   void AddLabel(const std::string &label);
 
   /*! \brief retrieve the current label for display

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -394,7 +394,7 @@ unsigned char CGUIImage::GetFadeLevel(unsigned int time) const
   return (unsigned char)(255.0f * (1 - pow(1-alpha, amount))/alpha);
 }
 
-CStdString CGUIImage::GetDescription(void) const
+std::string CGUIImage::GetDescription(void) const
 {
   return GetFileName();
 }

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -89,7 +89,7 @@ public:
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);
   virtual void SetPosition(float posX, float posY);
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   void SetCrossFade(unsigned int time);
 
   const CStdString& GetFileName() const;

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -81,7 +81,7 @@ bool CGUIKeyboardFactory::SendTextToActiveKeyboard(const std::string &aTextStrin
 // Show keyboard with initial value (aTextString) and replace with result string.
 // Returns: true  - successful display and input (empty result may return true or false depending on parameter)
 //          false - unsuccessful display of the keyboard or cancelled editing
-bool CGUIKeyboardFactory::ShowAndGetInput(CStdString& aTextString, const CVariant &heading, bool allowEmptyResult, bool hiddenInput /* = false */, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, const CVariant &heading, bool allowEmptyResult, bool hiddenInput /* = false */, unsigned int autoCloseMs /* = 0 */)
 {
   bool confirmed = false;
   CGUIKeyboard *kb = NULL;
@@ -123,26 +123,26 @@ bool CGUIKeyboardFactory::ShowAndGetInput(CStdString& aTextString, const CVarian
   return confirmed;
 }
 
-bool CGUIKeyboardFactory::ShowAndGetInput(CStdString& aTextString, bool allowEmptyResult, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString, bool allowEmptyResult, unsigned int autoCloseMs /* = 0 */)
 {
   return ShowAndGetInput(aTextString, "", allowEmptyResult, false, autoCloseMs);
 }
 
 // Shows keyboard and prompts for a password.
 // Differs from ShowAndVerifyNewPassword() in that no second verification is necessary.
-bool CGUIKeyboardFactory::ShowAndGetNewPassword(CStdString& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndGetNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
 {
   return ShowAndGetInput(newPassword, heading, allowEmpty, true, autoCloseMs);
 }
 
 // Shows keyboard and prompts for a password.
 // Differs from ShowAndVerifyNewPassword() in that no second verification is necessary.
-bool CGUIKeyboardFactory::ShowAndGetNewPassword(CStdString& newPassword, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndGetNewPassword(std::string& newPassword, unsigned int autoCloseMs /* = 0 */)
 {
   return ShowAndGetNewPassword(newPassword, 12340, false, autoCloseMs);
 }
 
-bool CGUIKeyboardFactory::ShowAndGetFilter(CStdString &filter, bool searching, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndGetFilter(std::string &filter, bool searching, unsigned int autoCloseMs /* = 0 */)
 {
   m_filtering = searching ? FILTERING_SEARCH : FILTERING_CURRENT;
   bool ret = ShowAndGetInput(filter, searching ? 16017 : 16028, true, false, autoCloseMs);
@@ -156,16 +156,16 @@ bool CGUIKeyboardFactory::ShowAndGetFilter(CStdString &filter, bool searching, u
 // \param heading Heading to display
 // \param allowEmpty Whether a blank password is valid or not.
 // \return true if successful display and user input entry/re-entry. false if unsuccessful display, no user input, or canceled editing.
-bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(CStdString& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs /* = 0 */)
 {
   // Prompt user for password input
-  CStdString userInput = "";
+  std::string userInput;
   if (!ShowAndGetInput(userInput, heading, allowEmpty, true, autoCloseMs))
   { // user cancelled, or invalid input
     return false;
   }
   // success - verify the password
-  CStdString checkInput = "";
+  std::string checkInput;
   if (!ShowAndGetInput(checkInput, 12341, allowEmpty, true, autoCloseMs))
   { // user cancelled, or invalid input
     return false;
@@ -186,9 +186,9 @@ bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(CStdString& newPassword, cons
 // \brief Show keyboard twice to get and confirm a user-entered password string.
 // \param strNewPassword Overwritten with user input if return=true.
 // \return true if successful display and user input entry/re-entry. false if unsuccessful display, no user input, or canceled editing.
-bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(CStdString& newPassword, unsigned int autoCloseMs /* = 0 */)
+bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword, unsigned int autoCloseMs /* = 0 */)
 {
-  CStdString heading = g_localizeStrings.Get(12340);
+  std::string heading = g_localizeStrings.Get(12340);
   return ShowAndVerifyNewPassword(newPassword, heading, false, autoCloseMs);
 }
 
@@ -197,9 +197,9 @@ bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(CStdString& newPassword, unsi
 // \param dlgHeading String shown on dialog title. Converts to localized string if contains a positive integer.
 // \param iRetries If greater than 0, shows "Incorrect password, %d retries left" on dialog line 2, else line 2 is blank.
 // \return 0 if successful display and user input. 1 if unsuccessful input. -1 if no user input or canceled editing.
-int CGUIKeyboardFactory::ShowAndVerifyPassword(CStdString& strPassword, const CStdString& strHeading, int iRetries, unsigned int autoCloseMs /* = 0 */)
+int CGUIKeyboardFactory::ShowAndVerifyPassword(std::string& strPassword, const std::string& strHeading, int iRetries, unsigned int autoCloseMs /* = 0 */)
 {
-  CStdString strHeadingTemp;
+  std::string strHeadingTemp;
   if (1 > iRetries && strHeading.size())
     strHeadingTemp = strHeading;
   else
@@ -208,7 +208,7 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(CStdString& strPassword, const CS
                                          CSettings::Get().GetInt("masterlock.maxretries") - iRetries,
                                          g_localizeStrings.Get(12343).c_str());
 
-  CStdString strUserInput = "";
+  std::string strUserInput;
   if (!ShowAndGetInput(strUserInput, strHeadingTemp, false, true, autoCloseMs))  //bool hiddenInput = false/true ? TODO: GUI Setting to enable disable this feature y/n?
     return -1; // user canceled out
 
@@ -217,11 +217,11 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(CStdString& strPassword, const CS
     if (strPassword == strUserInput)
       return 0;
 
-    CStdString md5pword2;
+    std::string md5pword2;
     XBMC::XBMC_MD5 md5state;
     md5state.append(strUserInput);
     md5state.getDigest(md5pword2);
-    if (strPassword.Equals(md5pword2))
+    if (strPassword == md5pword2)
       return 0;     // user entered correct password
     else return 1;  // user must have entered an incorrect password
   }

--- a/xbmc/guilib/GUIKeyboardFactory.h
+++ b/xbmc/guilib/GUIKeyboardFactory.h
@@ -23,6 +23,7 @@
 #include "GUIDialog.h"
 #include "utils/Variant.h"
 #include "GUIKeyboard.h"
+#include <string>
 
 class CGUIKeyboardFactory
 {
@@ -31,14 +32,14 @@ class CGUIKeyboardFactory
     CGUIKeyboardFactory(void);
     virtual ~CGUIKeyboardFactory(void);
 
-    static bool ShowAndGetInput(CStdString& aTextString, bool allowEmptyResult, unsigned int autoCloseMs = 0);
-    static bool ShowAndGetInput(CStdString& aTextString, const CVariant &heading, bool allowEmptyResult, bool hiddenInput = false, unsigned int autoCloseMs = 0);
-    static bool ShowAndGetNewPassword(CStdString& strNewPassword, unsigned int autoCloseMs = 0);
-    static bool ShowAndGetNewPassword(CStdString& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs = 0);
-    static bool ShowAndVerifyNewPassword(CStdString& strNewPassword, unsigned int autoCloseMs = 0);
-    static bool ShowAndVerifyNewPassword(CStdString& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs = 0);
-    static int  ShowAndVerifyPassword(CStdString& strPassword, const CStdString& strHeading, int iRetries, unsigned int autoCloseMs = 0);
-    static bool ShowAndGetFilter(CStdString& aTextString, bool searching, unsigned int autoCloseMs = 0);
+    static bool ShowAndGetInput(std::string& aTextString, bool allowEmptyResult, unsigned int autoCloseMs = 0);
+    static bool ShowAndGetInput(std::string& aTextString, const CVariant &heading, bool allowEmptyResult, bool hiddenInput = false, unsigned int autoCloseMs = 0);
+    static bool ShowAndGetNewPassword(std::string& strNewPassword, unsigned int autoCloseMs = 0);
+    static bool ShowAndGetNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs = 0);
+    static bool ShowAndVerifyNewPassword(std::string& strNewPassword, unsigned int autoCloseMs = 0);
+    static bool ShowAndVerifyNewPassword(std::string& newPassword, const CVariant &heading, bool allowEmpty, unsigned int autoCloseMs = 0);
+    static int  ShowAndVerifyPassword(std::string& strPassword, const std::string& strHeading, int iRetries, unsigned int autoCloseMs = 0);
+    static bool ShowAndGetFilter(std::string& aTextString, bool searching, unsigned int autoCloseMs = 0);
 
     static bool SendTextToActiveKeyboard(const std::string &aTextString, bool closeKeyboard = false);
 

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -337,7 +337,7 @@ void CGUILabelControl::SetSelection(unsigned int start, unsigned int end)
   m_endSelection = end;
 }
 
-CStdString CGUILabelControl::GetDescription() const
+std::string CGUILabelControl::GetDescription() const
 {
   return m_infoLabel.GetLabel(m_parentID);
 }

--- a/xbmc/guilib/GUILabelControl.h
+++ b/xbmc/guilib/GUILabelControl.h
@@ -48,7 +48,7 @@ public:
   virtual void UpdateInfo(const CGUIListItem *item = NULL);
   virtual bool CanFocus() const;
   virtual bool OnMessage(CGUIMessage& message);
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   virtual float GetWidth() const;
   virtual void SetWidth(float width);
   virtual CRect CalcRenderRegion() const;

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -27,7 +27,7 @@
 
 using namespace std;
 
-bool CGUIListItem::icompare::operator()(const CStdString &s1, const CStdString &s2) const
+bool CGUIListItem::icompare::operator()(const std::string &s1, const std::string &s2) const
 {
   return StringUtils::CompareNoCase(s1, s2) < 0;
 }
@@ -52,7 +52,7 @@ CGUIListItem::CGUIListItem(void)
   m_focusedLayout = NULL;
 }
 
-CGUIListItem::CGUIListItem(const CStdString& strLabel)
+CGUIListItem::CGUIListItem(const std::string& strLabel)
 {
   m_bIsFolder = false;
   m_strLabel2 = "";
@@ -70,7 +70,7 @@ CGUIListItem::~CGUIListItem(void)
   FreeMemory();
 }
 
-void CGUIListItem::SetLabel(const CStdString& strLabel)
+void CGUIListItem::SetLabel(const std::string& strLabel)
 {
   if (m_strLabel == strLabel)
     return;
@@ -80,13 +80,13 @@ void CGUIListItem::SetLabel(const CStdString& strLabel)
   SetInvalid();
 }
 
-const CStdString& CGUIListItem::GetLabel() const
+const std::string& CGUIListItem::GetLabel() const
 {
   return m_strLabel;
 }
 
 
-void CGUIListItem::SetLabel2(const CStdString& strLabel2)
+void CGUIListItem::SetLabel2(const std::string& strLabel2)
 {
   if (m_strLabel2 == strLabel2)
     return;
@@ -94,23 +94,23 @@ void CGUIListItem::SetLabel2(const CStdString& strLabel2)
   SetInvalid();
 }
 
-const CStdString& CGUIListItem::GetLabel2() const
+const std::string& CGUIListItem::GetLabel2() const
 {
   return m_strLabel2;
 }
 
-void CGUIListItem::SetSortLabel(const CStdString &label)
+void CGUIListItem::SetSortLabel(const std::string &label)
 {
   g_charsetConverter.utf8ToW(label, m_sortLabel, false);
   // no need to invalidate - this is never shown in the UI
 }
 
-void CGUIListItem::SetSortLabel(const CStdStringW &label)
+void CGUIListItem::SetSortLabel(const std::wstring &label)
 {
   m_sortLabel = label;
 }
 
-const CStdStringW& CGUIListItem::GetSortLabel() const
+const std::wstring& CGUIListItem::GetSortLabel() const
 {
   return m_sortLabel;
 }
@@ -173,7 +173,7 @@ bool CGUIListItem::HasArt(const std::string &type) const
   return !GetArt(type).empty();
 }
 
-void CGUIListItem::SetIconImage(const CStdString& strIcon)
+void CGUIListItem::SetIconImage(const std::string& strIcon)
 {
   if (m_strIcon == strIcon)
     return;
@@ -181,7 +181,7 @@ void CGUIListItem::SetIconImage(const CStdString& strIcon)
   SetInvalid();
 }
 
-const CStdString& CGUIListItem::GetIconImage() const
+const std::string& CGUIListItem::GetIconImage() const
 {
   return m_strIcon;
 }
@@ -195,7 +195,7 @@ void CGUIListItem::SetOverlayImage(GUIIconOverlay icon, bool bOnOff)
   SetInvalid();
 }
 
-CStdString CGUIListItem::GetOverlayImage() const
+std::string CGUIListItem::GetOverlayImage() const
 {
   switch (m_overlayIcon)
   {
@@ -399,7 +399,7 @@ void CGUIListItem::SetInvalid()
   if (m_focusedLayout) m_focusedLayout->SetInvalid();
 }
 
-void CGUIListItem::SetProperty(const CStdString &strKey, const CVariant &value)
+void CGUIListItem::SetProperty(const std::string &strKey, const CVariant &value)
 {
   PropertyMap::iterator iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
@@ -414,7 +414,7 @@ void CGUIListItem::SetProperty(const CStdString &strKey, const CVariant &value)
   }
 }
 
-CVariant CGUIListItem::GetProperty(const CStdString &strKey) const
+CVariant CGUIListItem::GetProperty(const std::string &strKey) const
 {
   PropertyMap::const_iterator iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
@@ -423,7 +423,7 @@ CVariant CGUIListItem::GetProperty(const CStdString &strKey) const
   return iter->second;
 }
 
-bool CGUIListItem::HasProperty(const CStdString &strKey) const
+bool CGUIListItem::HasProperty(const std::string &strKey) const
 {
   PropertyMap::const_iterator iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
@@ -432,7 +432,7 @@ bool CGUIListItem::HasProperty(const CStdString &strKey) const
   return true;
 }
 
-void CGUIListItem::ClearProperty(const CStdString &strKey)
+void CGUIListItem::ClearProperty(const std::string &strKey)
 {
   PropertyMap::iterator iter = m_mapProperties.find(strKey);
   if (iter != m_mapProperties.end())
@@ -451,14 +451,14 @@ void CGUIListItem::ClearProperties()
   }
 }
 
-void CGUIListItem::IncrementProperty(const CStdString &strKey, int nVal)
+void CGUIListItem::IncrementProperty(const std::string &strKey, int nVal)
 {
   int64_t i = GetProperty(strKey).asInteger();
   i += nVal;
   SetProperty(strKey, i);
 }
 
-void CGUIListItem::IncrementProperty(const CStdString &strKey, double dVal)
+void CGUIListItem::IncrementProperty(const std::string &strKey, double dVal)
 {
   double d = GetProperty(strKey).asDouble();
   d += dVal;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -28,8 +28,6 @@
  *
  */
 
-#include "utils/StdString.h"
-
 #include <map>
 #include <string>
 
@@ -59,23 +57,23 @@ public:
 
   CGUIListItem(void);
   CGUIListItem(const CGUIListItem& item);
-  CGUIListItem(const CStdString& strLabel);
+  CGUIListItem(const std::string& strLabel);
   virtual ~CGUIListItem(void);
   virtual CGUIListItem *Clone() const { return new CGUIListItem(*this); };
 
   CGUIListItem& operator =(const CGUIListItem& item);
 
-  virtual void SetLabel(const CStdString& strLabel);
-  const CStdString& GetLabel() const;
+  virtual void SetLabel(const std::string& strLabel);
+  const std::string& GetLabel() const;
 
-  void SetLabel2(const CStdString& strLabel);
-  const CStdString& GetLabel2() const;
+  void SetLabel2(const std::string& strLabel);
+  const std::string& GetLabel2() const;
 
-  void SetIconImage(const CStdString& strIcon);
-  const CStdString& GetIconImage() const;
+  void SetIconImage(const std::string& strIcon);
+  const std::string& GetIconImage() const;
 
   void SetOverlayImage(GUIIconOverlay icon, bool bOnOff=false);
-  CStdString GetOverlayImage() const;
+  std::string GetOverlayImage() const;
 
   /*! \brief Set a particular art type for an item
    \param type type of art to set.
@@ -128,9 +126,9 @@ public:
    */
   bool HasArt(const std::string &type) const;
 
-  void SetSortLabel(const CStdString &label);
-  void SetSortLabel(const CStdStringW &label);
-  const CStdStringW &GetSortLabel() const;
+  void SetSortLabel(const std::string &label);
+  void SetSortLabel(const std::wstring &label);
+  const std::wstring &GetSortLabel() const;
 
   void Select(bool bOnOff);
   bool IsSelected() const;
@@ -151,10 +149,10 @@ public:
 
   bool m_bIsFolder;     ///< is item a folder or a file
 
-  void SetProperty(const CStdString &strKey, const CVariant &value);
+  void SetProperty(const std::string &strKey, const CVariant &value);
 
-  void IncrementProperty(const CStdString &strKey, int nVal);
-  void IncrementProperty(const CStdString &strKey, double dVal);
+  void IncrementProperty(const std::string &strKey, int nVal);
+  void IncrementProperty(const std::string &strKey, double dVal);
 
   void ClearProperties();
 
@@ -168,15 +166,15 @@ public:
   void Archive(CArchive& ar);
   void Serialize(CVariant& value);
 
-  bool       HasProperty(const CStdString &strKey) const;
+  bool       HasProperty(const std::string &strKey) const;
   bool       HasProperties() const { return !m_mapProperties.empty(); };
-  void       ClearProperty(const CStdString &strKey);
+  void       ClearProperty(const std::string &strKey);
 
-  CVariant   GetProperty(const CStdString &strKey) const;
+  CVariant   GetProperty(const std::string &strKey) const;
 
 protected:
-  CStdString m_strLabel2;     // text of column2
-  CStdString m_strIcon;      // filename of icon
+  std::string m_strLabel2;     // text of column2
+  std::string m_strIcon;      // filename of icon
   GUIIconOverlay m_overlayIcon; // type of overlay icon
 
   CGUIListItemLayout *m_layout;
@@ -185,14 +183,14 @@ protected:
 
   struct icompare
   {
-    bool operator()(const CStdString &s1, const CStdString &s2) const;
+    bool operator()(const std::string &s1, const std::string &s2) const;
   };
 
-  typedef std::map<CStdString, CVariant, icompare> PropertyMap;
+  typedef std::map<std::string, CVariant, icompare> PropertyMap;
   PropertyMap m_mapProperties;
 private:
-  CStdStringW m_sortLabel;    // text for sorting. Need to be UTF16 for proper sorting
-  CStdString m_strLabel;      // text of column1
+  std::wstring m_sortLabel;    // text for sorting. Need to be UTF16 for proper sorting
+  std::string m_strLabel;      // text of column1
 
   ArtMap m_art;
   ArtMap m_artFallbacks;

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -284,7 +284,7 @@ void CGUIMultiImage::SetInfo(const CGUIInfoLabel &info)
     m_currentPath = m_texturePath.GetLabel(WINDOW_INVALID);
 }
 
-CStdString CGUIMultiImage::GetDescription() const
+std::string CGUIMultiImage::GetDescription() const
 {
   return m_image.GetDescription();
 }

--- a/xbmc/guilib/GUIMultiImage.h
+++ b/xbmc/guilib/GUIMultiImage.h
@@ -57,7 +57,7 @@ public:
   virtual bool IsDynamicallyAllocated() { return m_bDynamicResourceAlloc; };
   virtual void SetInvalid();
   virtual bool CanFocus() const;
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
 
   void SetInfo(const CGUIInfoLabel &info);
   void SetAspectRatio(const CAspectRatio &ratio);

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -368,11 +368,11 @@ void CGUIMultiSelectTextControl::PositionButtons()
     m_totalWidth += m_label.offsetX;
 }
 
-CStdString CGUIMultiSelectTextControl::GetDescription() const
+std::string CGUIMultiSelectTextControl::GetDescription() const
 {
   // We currently just return the entire string - should we bother returning the
   // particular subitems of this?
-  CStdString strLabel(m_info.GetLabel(m_parentID));
+  std::string strLabel(m_info.GetLabel(m_parentID));
   return strLabel;
 }
 

--- a/xbmc/guilib/GUIMultiSelectText.h
+++ b/xbmc/guilib/GUIMultiSelectText.h
@@ -46,7 +46,7 @@ public:
   virtual bool OnMouseOver(const CPoint &point);
   virtual void UpdateInfo(const CGUIListItem *item = NULL);
 
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   virtual bool CanFocus() const;
 
   void UpdateText(const CStdString &text);

--- a/xbmc/guilib/GUIProgressControl.cpp
+++ b/xbmc/guilib/GUIProgressControl.cpp
@@ -204,7 +204,7 @@ bool CGUIProgressControl::UpdateColors()
   return changed;
 }
 
-CStdString CGUIProgressControl::GetDescription() const
+std::string CGUIProgressControl::GetDescription() const
 {
   return StringUtils::Format("%2.f", m_fPercent);
 }

--- a/xbmc/guilib/GUIProgressControl.h
+++ b/xbmc/guilib/GUIProgressControl.h
@@ -61,7 +61,7 @@ public:
   int GetInfo() const {return m_iInfoCode;};
 
   float GetPercentage() const;
-  CStdString GetDescription() const;
+  std::string GetDescription() const;
   virtual void UpdateInfo(const CGUIListItem *item = NULL);
   bool UpdateLayout(void);
 protected:

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -184,9 +184,9 @@ void CGUIRadioButtonControl::SetHeight(float height)
   SetPosition(GetXPosition(), GetYPosition());
 }
 
-CStdString CGUIRadioButtonControl::GetDescription() const
+std::string CGUIRadioButtonControl::GetDescription() const
 {
-  CStdString strLabel = CGUIButtonControl::GetDescription();
+  std::string strLabel = CGUIButtonControl::GetDescription();
   if (m_bSelected)
     strLabel += " (*)";
   else

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -56,7 +56,7 @@ public:
   virtual void SetPosition(float posX, float posY);
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   void SetRadioDimensions(float posX, float posY, float width, float height);
   void SetToggleSelect(const CStdString &toggleSelect);
   bool IsSelected() const { return m_bSelected; };

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -360,7 +360,7 @@ EVENT_RESULT CGUIScrollBar::OnMouseEvent(const CPoint &point, const CMouseEvent 
   return EVENT_RESULT_UNHANDLED;
 }
 
-CStdString CGUIScrollBar::GetDescription() const
+std::string CGUIScrollBar::GetDescription() const
 {
   return StringUtils::Format("%i/%i", m_offset, m_numItems);
 }

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -59,7 +59,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   void SetValue(int value);
   int GetValue() const;
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   virtual bool IsVisible() const;
 protected:
   virtual bool HitTest(const CPoint &point) const;

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -126,7 +126,7 @@ void CGUISettingsSliderControl::SetEnabled(bool bEnable)
   m_buttonControl.SetEnabled(bEnable);
 }
 
-CStdString CGUISettingsSliderControl::GetDescription() const
+std::string CGUISettingsSliderControl::GetDescription() const
 {
   return m_buttonControl.GetDescription() + " " + CGUISliderControl::GetDescription();
 }

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -60,7 +60,7 @@ public:
   void SetText(const std::string &label) {m_buttonControl.SetLabel(label);};
   virtual float GetXPosition() const { return m_buttonControl.GetXPosition();};
   virtual float GetYPosition() const { return m_buttonControl.GetYPosition();};
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   virtual bool HitTest(const CPoint &point) const { return m_buttonControl.HitTest(point); };
 
 protected:

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -591,7 +591,7 @@ void CGUISliderControl::SetInfo(int iInfo)
   m_iInfoCode = iInfo;
 }
 
-CStdString CGUISliderControl::GetDescription() const
+std::string CGUISliderControl::GetDescription() const
 {
   if (!m_textValue.empty())
     return m_textValue;

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -85,7 +85,7 @@ public:
   void SetIntInterval(int iInterval);
   void SetFloatInterval(float fInterval);
   void SetType(int iType) { m_iType = iType; };
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   void SetTextValue(const CStdString &textValue) { m_textValue = textValue; };
   void SetAction(const CStdString &action);
 protected:

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -946,7 +946,7 @@ EVENT_RESULT CGUISpinControl::OnMouseEvent(const CPoint &point, const CMouseEven
   return EVENT_RESULT_UNHANDLED;
 }
 
-CStdString CGUISpinControl::GetDescription() const
+std::string CGUISpinControl::GetDescription() const
 {
   return StringUtils::Format("%i/%i", 1 + GetValue(), GetMaximum());
 }

--- a/xbmc/guilib/GUISpinControl.h
+++ b/xbmc/guilib/GUISpinControl.h
@@ -85,7 +85,7 @@ public:
   void SetShowRange(bool bOnoff) ;
   void SetShowOnePage(bool showOnePage) { m_showOnePage = showOnePage; };
   void Clear();
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   bool IsFocusedOnUp() const;
 
   virtual bool IsVisible() const;

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -122,7 +122,7 @@ const CStdString CGUISpinControlEx::GetCurrentLabel() const
   return CGUISpinControl::GetLabel();
 }
 
-CStdString CGUISpinControlEx::GetDescription() const
+std::string CGUISpinControlEx::GetDescription() const
 {
   return StringUtils::Format("%s (%s)", m_buttonControl.GetDescription().c_str(), GetLabel().c_str());
 }

--- a/xbmc/guilib/GUISpinControlEx.h
+++ b/xbmc/guilib/GUISpinControlEx.h
@@ -58,7 +58,7 @@ public:
   virtual void SetEnabled(bool bEnable);
   virtual float GetXPosition() const { return m_buttonControl.GetXPosition();};
   virtual float GetYPosition() const { return m_buttonControl.GetYPosition();};
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   virtual bool HitTest(const CPoint &point) const { return m_buttonControl.HitTest(point); };
   void SetSpinPosition(float spinPosX);
 

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -387,7 +387,7 @@ CStdString CGUITextBox::GetLabel(int info) const
   return label;
 }
 
-CStdString CGUITextBox::GetDescription() const
+std::string CGUITextBox::GetDescription() const
 {
   return GetText();
 }

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -62,7 +62,7 @@ public:
   void SetAutoScrolling(const TiXmlNode *node);
   void ResetAutoScrolling();
   CStdString GetLabel(int info) const;
-  CStdString GetDescription() const;
+  std::string GetDescription() const;
 
   void Scroll(unsigned int offset);
 

--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -147,7 +147,7 @@ void CGUIToggleButtonControl::SetAltLabel(const string &label)
     m_selectButton.SetLabel(label);
 }
 
-CStdString CGUIToggleButtonControl::GetDescription() const
+std::string CGUIToggleButtonControl::GetDescription() const
 {
   if (m_bSelected)
     return m_selectButton.GetDescription();

--- a/xbmc/guilib/GUIToggleButtonControl.h
+++ b/xbmc/guilib/GUIToggleButtonControl.h
@@ -53,7 +53,7 @@ public:
   virtual void SetHeight(float height);
   void SetLabel(const std::string& strLabel);
   void SetAltLabel(const std::string& label);
-  virtual CStdString GetDescription() const;
+  virtual std::string GetDescription() const;
   void SetToggleSelect(const CStdString &toggleSelect);
   void SetAltClickActions(const CGUIAction &clickActions);
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -980,7 +980,7 @@ CRect CGUIWindow::GetScaledBounds() const
   return rect;
 }
 
-void CGUIWindow::OnEditChanged(int id, CStdString &text)
+void CGUIWindow::OnEditChanged(int id, std::string &text)
 {
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), id);
   OnMessage(msg);

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -219,7 +219,7 @@ protected:
   virtual void RestoreControlStates();
 
   // methods for updating controls and sending messages
-  void OnEditChanged(int id, CStdString &text);
+  void OnEditChanged(int id, std::string &text);
   bool SendMessage(int message, int id, int param1 = 0, int param2 = 0);
 
   typedef GUIEvent<CGUIMessage&> CLICK_EVENT;

--- a/xbmc/guilib/IGUIContainer.h
+++ b/xbmc/guilib/IGUIContainer.h
@@ -34,7 +34,7 @@ class IGUIContainer : public CGUIControl
 {
 protected:
   VIEW_TYPE m_type;
-  CStdString m_label;
+  std::string m_label;
 public:
   IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height)
    : CGUIControl(parentID, controlID, posX, posY, width, height), m_type(VIEW_TYPE_NONE) {}
@@ -42,13 +42,13 @@ public:
   virtual bool IsContainer() const { return true; };
 
   VIEW_TYPE GetType() const { return m_type; };
-  const CStdString &GetLabel() const { return m_label; };
-  void SetType(VIEW_TYPE type, const CStdString &label)
+  const std::string &GetLabel() const { return m_label; };
+  void SetType(VIEW_TYPE type, const std::string &label)
   {
     m_type = type;
     m_label = label;
   }
 
   virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const = 0;
-  virtual CStdString GetLabel(int info) const                                  = 0;
+  virtual std::string GetLabel(int info) const                                 = 0;
 };

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -28,6 +28,7 @@
 #include "utils/POUtils.h"
 #include "filesystem/Directory.h"
 #include "threads/SingleLock.h"
+#include "utils/StringUtils.h"
 
 CLocalizeStrings::CLocalizeStrings(void)
 {
@@ -39,12 +40,12 @@ CLocalizeStrings::~CLocalizeStrings(void)
 
 }
 
-CStdString CLocalizeStrings::ToUTF8(const CStdString& strEncoding, const CStdString& str)
+std::string CLocalizeStrings::ToUTF8(const std::string& strEncoding, const std::string& str)
 {
   if (strEncoding.empty())
     return str;
 
-  CStdString ret;
+  std::string ret;
   g_charsetConverter.ToUtf8(strEncoding, str, ret);
   return ret;
 }
@@ -55,28 +56,28 @@ void CLocalizeStrings::ClearSkinStrings()
   Clear(31000, 31999);
 }
 
-bool CLocalizeStrings::LoadSkinStrings(const CStdString& path, const CStdString& language)
+bool CLocalizeStrings::LoadSkinStrings(const std::string& path, const std::string& language)
 {
   ClearSkinStrings();
   // load the skin strings in.
-  CStdString encoding;
+  std::string encoding;
   if (!LoadStr2Mem(path, language, encoding))
   {
-    if (language.Equals(SOURCE_LANGUAGE)) // no fallback, nothing to do
+    if (StringUtils::EqualsNoCase(language, SOURCE_LANGUAGE)) // no fallback, nothing to do
       return false;
   }
 
   // load the fallback
-  if (!language.Equals(SOURCE_LANGUAGE))
+  if (!StringUtils::EqualsNoCase(language, SOURCE_LANGUAGE))
     LoadStr2Mem(path, SOURCE_LANGUAGE, encoding);
 
   return true;
 }
 
-bool CLocalizeStrings::LoadStr2Mem(const CStdString &pathname_in, const CStdString &language,
-                                   CStdString &encoding, uint32_t offset /* = 0 */)
+bool CLocalizeStrings::LoadStr2Mem(const std::string &pathname_in, const std::string &language,
+                                   std::string &encoding, uint32_t offset /* = 0 */)
 {
-  CStdString pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in + language);
+  std::string pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in + language);
   if (!XFILE::CDirectory::Exists(pathname))
   {
     CLog::Log(LOGDEBUG,
@@ -86,7 +87,7 @@ bool CLocalizeStrings::LoadStr2Mem(const CStdString &pathname_in, const CStdStri
   }
 
   if (LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), encoding, offset,
-      language.Equals(SOURCE_LANGUAGE)))
+             StringUtils::EqualsNoCase(language, SOURCE_LANGUAGE)))
     return true;
 
   CLog::Log(LOGDEBUG, "LocalizeStrings: no strings.po file exist at %s, fallback to strings.xml",
@@ -94,7 +95,7 @@ bool CLocalizeStrings::LoadStr2Mem(const CStdString &pathname_in, const CStdStri
   return LoadXML(URIUtils::AddFileToFolder(pathname, "strings.xml"), encoding, offset);
 }
 
-bool CLocalizeStrings::LoadPO(const CStdString &filename, CStdString &encoding,
+bool CLocalizeStrings::LoadPO(const std::string &filename, std::string &encoding,
                               uint32_t offset /* = 0 */, bool bSourceLanguage)
 {
   CPODocument PODoc;
@@ -149,7 +150,7 @@ bool CLocalizeStrings::LoadPO(const CStdString &filename, CStdString &encoding,
   return true;
 }
 
-bool CLocalizeStrings::LoadXML(const CStdString &filename, CStdString &encoding, uint32_t offset /* = 0 */)
+bool CLocalizeStrings::LoadXML(const std::string &filename, std::string &encoding, uint32_t offset /* = 0 */)
 {
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(filename))
@@ -160,7 +161,7 @@ bool CLocalizeStrings::LoadXML(const CStdString &filename, CStdString &encoding,
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
   if (!pRootElement || pRootElement->NoChildren() ||
-       pRootElement->ValueStr()!=CStdString("strings"))
+       pRootElement->ValueStr()!="strings")
   {
     CLog::Log(LOGERROR, "%s Doesn't contain <strings>", filename.c_str());
     return false;
@@ -182,11 +183,11 @@ bool CLocalizeStrings::LoadXML(const CStdString &filename, CStdString &encoding,
   return true;
 }
 
-bool CLocalizeStrings::Load(const CStdString& strPathName, const CStdString& strLanguage)
+bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& strLanguage)
 {
-  bool bLoadFallback = !strLanguage.Equals(SOURCE_LANGUAGE);
+  bool bLoadFallback = !StringUtils::EqualsNoCase(strLanguage, SOURCE_LANGUAGE);
 
-  CStdString encoding;
+  std::string encoding;
   CSingleLock lock(m_critSection);
   Clear();
 
@@ -229,14 +230,12 @@ bool CLocalizeStrings::Load(const CStdString& strPathName, const CStdString& str
   return true;
 }
 
-static CStdString szEmptyString = "";
-
-const CStdString& CLocalizeStrings::Get(uint32_t dwCode) const
+const std::string& CLocalizeStrings::Get(uint32_t dwCode) const
 {
   ciStrings i = m_strings.find(dwCode);
   if (i == m_strings.end())
   {
-    return szEmptyString;
+    return StringUtils::Empty;
   }
   return i->second.strTranslated;
 }

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -28,10 +28,11 @@
  *
  */
 
-#include "utils/StdString.h"
 #include "threads/CriticalSection.h"
 
 #include <map>
+#include <string>
+#include <stdint.h>
 
 /*!
  \ingroup strings
@@ -40,22 +41,22 @@
 
 struct LocStr
 {
-CStdString strTranslated; // string to be used in xbmc GUI
-CStdString strOriginal;   // the original English string, the tranlsation is based on
+  std::string strTranslated; // string to be used in xbmc GUI
+  std::string strOriginal;   // the original English string the translation is based on
 };
 
 // The default fallback language is fixed to be English
-const CStdString SOURCE_LANGUAGE = "English";
+const std::string SOURCE_LANGUAGE = "English";
 
 class CLocalizeStrings
 {
 public:
   CLocalizeStrings(void);
   virtual ~CLocalizeStrings(void);
-  bool Load(const CStdString& strPathName, const CStdString& strLanguage);
-  bool LoadSkinStrings(const CStdString& path, const CStdString& language);
+  bool Load(const std::string& strPathName, const std::string& strLanguage);
+  bool LoadSkinStrings(const std::string& path, const std::string& language);
   void ClearSkinStrings();
-  const CStdString& Get(uint32_t code) const;
+  const std::string& Get(uint32_t code) const;
   void Clear();
 protected:
   void Clear(uint32_t start, uint32_t end);
@@ -68,8 +69,8 @@ protected:
    \param offset An offset value to place strings from the id value.
    \return false if no strings.po or strings.xml file was loaded.
    */
-  bool LoadStr2Mem(const CStdString &pathname, const CStdString &language,
-                   CStdString &encoding, uint32_t offset = 0);
+  bool LoadStr2Mem(const std::string &pathname, const std::string &language,
+                   std::string &encoding, uint32_t offset = 0);
 
   /*! \brief Tries to load ids and strings from a strings.po file to m_strings map.
    * It should only be called from the LoadStr2Mem function to have a fallback.
@@ -79,7 +80,7 @@ protected:
    \param bSourceLanguage If we are loading the source English strings.po.
    \return false if no strings.po file was loaded.
    */
-  bool LoadPO(const CStdString &filename, CStdString &encoding, uint32_t offset = 0,
+  bool LoadPO(const std::string &filename, std::string &encoding, uint32_t offset = 0,
               bool bSourceLanguage = false);
 
   /*! \brief Tries to load ids and strings from a strings.xml file to m_strings map.
@@ -89,9 +90,9 @@ protected:
    \param offset An offset value to place strings from the id value.
    \return false if no strings.xml file was loaded.
    */
-  bool LoadXML(const CStdString &filename, CStdString &encoding, uint32_t offset = 0);
+  bool LoadXML(const std::string &filename, std::string &encoding, uint32_t offset = 0);
 
-  static CStdString ToUTF8(const CStdString &encoding, const CStdString &str);
+  static std::string ToUTF8(const std::string &encoding, const std::string &str);
   std::map<uint32_t, LocStr> m_strings;
   typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;
   typedef std::map<uint32_t, LocStr>::iterator       iStrings;

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -469,7 +469,7 @@ void CStereoscopicsManager::OnPlaybackStarted(void)
         
 
       // add choices
-      int idx_preferred = pDlgSelect->Add( g_localizeStrings.Get(36530)
+      int idx_preferred = pDlgSelect->Add((CStdString)g_localizeStrings.Get(36530)
                                      + " ("
                                      + GetLabelForStereoMode(preferred)
                                      + ")");
@@ -479,7 +479,7 @@ void CStereoscopicsManager::OnPlaybackStarted(void)
 
 
       if(playing != RENDER_STEREO_MODE_OFF && g_Windowing.SupportsStereo(playing))
-        idx_playing = pDlgSelect->Add( g_localizeStrings.Get(36532)
+        idx_playing = pDlgSelect->Add((CStdString)g_localizeStrings.Get(36532)
                                     + " ("
                                     + GetLabelForStereoMode(playing)
                                     + ")");

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1168,7 +1168,7 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("skin.theme"))
   {
     // enumerate themes
-    vector<CStdString> vecTheme;
+    vector<std::string> vecTheme;
     CUtil::GetSkinThemes(vecTheme);
 
     int iTheme = -1;
@@ -1180,7 +1180,7 @@ int CBuiltins::Execute(const CStdString& execString)
       {
         CStdString strTmpTheme(CSettings::Get().GetString("lookandfeel.skintheme"));
         URIUtils::RemoveExtension(strTmpTheme);
-        if (vecTheme[i].Equals(strTmpTheme))
+        if (StringUtils::EqualsNoCase(vecTheme[i], strTmpTheme))
         {
           iTheme=i;
           break;

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -575,7 +575,7 @@ void CPythonInvoker::onError()
       }
     }
 
-    desc = StringUtils::Format(g_localizeStrings.Get(2100), script.c_str());
+    desc = StringUtils::Format(g_localizeStrings.Get(2100).c_str(), script.c_str());
     pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(257), desc);
   }
 }

--- a/xbmc/linux/XFileUtils.cpp
+++ b/xbmc/linux/XFileUtils.cpp
@@ -601,11 +601,11 @@ BOOL GetDiskFreeSpaceEx(
 #if defined(TARGET_ANDROID) || defined(TARGET_DARWIN)
   struct statfs fsInfo;
   // is 64-bit on android and darwin (10.6SDK + any iOS)
-  if (statfs(CSpecialProtocol::TranslatePath(lpDirectoryName), &fsInfo) != 0)
+  if (statfs(CSpecialProtocol::TranslatePath(lpDirectoryName).c_str(), &fsInfo) != 0)
     return false;
 #else
   struct statfs64 fsInfo;
-  if (statfs64(CSpecialProtocol::TranslatePath(lpDirectoryName), &fsInfo) != 0)
+  if (statfs64(CSpecialProtocol::TranslatePath(lpDirectoryName).c_str(), &fsInfo) != 0)
     return false;
 #endif
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5078,9 +5078,9 @@ void CMusicDatabase::ExportKaraokeInfo(const CStdString & outFile, bool asHTML)
       CStdString songnum = StringUtils::Format("%06d", song.iKaraokeNumber);
 
       if ( asHTML )
-        outdoc = "<tr><td>" + songnum + "</td><td>" + StringUtils::Join(song.artist, g_advancedSettings.m_musicItemSeparator) + "</td><td>" + song.strTitle + "</td></tr>\r\n";
+        outdoc = "<tr><td>" + songnum + "</td><td>" + (CStdString)StringUtils::Join(song.artist, g_advancedSettings.m_musicItemSeparator) + "</td><td>" + song.strTitle + "</td></tr>\r\n";
       else
-        outdoc = songnum + "\t" + StringUtils::Join(song.artist, g_advancedSettings.m_musicItemSeparator) + "\t" + song.strTitle + "\t" + song.strFileName + "\r\n";
+        outdoc = songnum + '\t' + (CStdString)StringUtils::Join(song.artist, g_advancedSettings.m_musicItemSeparator) + '\t' + song.strTitle + '\t' + song.strFileName + "\r\n";
 
       file.Write( outdoc, outdoc.size() );
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3992,7 +3992,7 @@ int CMusicDatabase::GetSongsCount(const Filter &filter)
   return 0;
 }
 
-bool CMusicDatabase::GetAlbumPath(int idAlbum, CStdString& path)
+bool CMusicDatabase::GetAlbumPath(int idAlbum, std::string& path)
 {
   try
   {
@@ -4001,7 +4001,7 @@ bool CMusicDatabase::GetAlbumPath(int idAlbum, CStdString& path)
 
     path.clear();
 
-    CStdString strSQL=PrepareSQL("select strPath from song join path on song.idPath = path.idPath where song.idAlbum=%ld", idAlbum);
+    std::string strSQL=PrepareSQL("select strPath from song join path on song.idPath = path.idPath where song.idAlbum=%ld", idAlbum);
     if (!m_pDS2->query(strSQL.c_str())) return false;
     int iRowsFound = m_pDS2->num_rows();
     if (iRowsFound == 0)
@@ -4039,7 +4039,7 @@ bool CMusicDatabase::SaveAlbumThumb(int idAlbum, const CStdString& strThumb)
   return true;
 }
 
-bool CMusicDatabase::GetArtistPath(int idArtist, CStdString &basePath)
+bool CMusicDatabase::GetArtistPath(int idArtist, std::string &basePath)
 {
   try
   {
@@ -4047,7 +4047,7 @@ bool CMusicDatabase::GetArtistPath(int idArtist, CStdString &basePath)
     if (NULL == m_pDS2.get()) return false;
 
     // find all albums from this artist, and all the paths to the songs from those albums
-    CStdString strSQL=PrepareSQL("SELECT strPath"
+    std::string strSQL=PrepareSQL("SELECT strPath"
                                  "  FROM album_artist"
                                  "  JOIN song "
                                  "    ON album_artist.idAlbum = song.idAlbum"
@@ -4077,7 +4077,7 @@ bool CMusicDatabase::GetArtistPath(int idArtist, CStdString &basePath)
     basePath.clear();
     while (!m_pDS2->eof())
     {
-      CStdString path = m_pDS2->fv("strPath").get_asString();
+      std::string path = m_pDS2->fv("strPath").get_asString();
       if (basePath.empty())
         basePath = path;
       else

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -272,8 +272,8 @@ public:
   bool GetPaths(std::set<std::string> &paths);
   bool SetPathHash(const CStdString &path, const CStdString &hash);
   bool GetPathHash(const CStdString &path, CStdString &hash);
-  bool GetAlbumPath(int idAlbum, CStdString &path);
-  bool GetArtistPath(int idArtist, CStdString &path);
+  bool GetAlbumPath(int idAlbum, std::string &path);
+  bool GetArtistPath(int idArtist, std::string &path);
 
   /////////////////////////////////////////////////
   // Genres

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -233,7 +233,7 @@ void CGUIDialogMusicInfo::SetDiscography()
     int idAlbum = -1;
     for (vector<int>::const_iterator album = albumsByArtist.begin(); album != albumsByArtist.end(); ++album)
     {
-      if (database.GetAlbumById(*album).Equals(item->GetLabel()))
+      if (database.GetAlbumById(*album).Equals((CStdString)item->GetLabel()))
       {
         idAlbum = *album;
         item->GetMusicInfoTag()->SetDatabaseId(idAlbum, "album");

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -180,7 +180,7 @@ void CMusicInfoScanner::Process()
         if (m_handle)
         {
           float percentage = (float) std::distance(it, m_pathsToScan.end()) / m_pathsToScan.size();
-          m_handle->SetText(StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator) + " - " + album.strAlbum);
+          m_handle->SetText((CStdString)StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator) + " - " + album.strAlbum);
           m_handle->SetPercentage(percentage);
         }
 
@@ -969,7 +969,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
   if (m_handle)
   {
     m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20321), info->Name().c_str()));
-    m_handle->SetText(StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator) + " - " + album.strAlbum);
+    m_handle->SetText((CStdString)StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator) + " - " + album.strAlbum);
   }
 
   // clear our scraper cache

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -968,7 +968,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
 {
   if (m_handle)
   {
-    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20321), info->Name().c_str()));
+    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20321).c_str(), info->Name().c_str()));
     m_handle->SetText((CStdString)StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator) + " - " + album.strAlbum);
   }
 
@@ -1184,7 +1184,7 @@ INFO_RET CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist, const ADDO
 {
   if (m_handle)
   {
-    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20320), info->Name().c_str()));
+    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20320).c_str(), info->Name().c_str()));
     m_handle->SetText(artist.strArtist);
   }
 

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
@@ -168,7 +168,7 @@ void CGUIDialogKaraokeSongSelector::UpdateData()
   if ( m_updateData )
   {
     // Update on-screen labels
-    CStdString message = StringUtils::Format("%06d", m_selectedNumber);
+    std::string message = StringUtils::Format("%06d", m_selectedNumber);
     message = g_localizeStrings.Get(179) + ": " + message; // Translated "Song"
 
     SET_CONTROL_LABEL(CONTROL_LABEL_SONGNUMBER, message);

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -598,7 +598,7 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   value["comment"] = m_strComment;
   value["rating"] = (int)(m_rating - '0');
   value["playcount"] = m_iTimesPlayed;
-  value["lastplayed"] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::EmptyString;
+  value["lastplayed"] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::Empty;
   value["lyrics"] = m_strLyrics;
   value["albumid"] = m_iAlbumId;
   value["compilationartist"] = m_bCompilation;
@@ -626,7 +626,7 @@ void CMusicInfoTag::ToSortable(SortItem& sortable, Field field) const
   case FieldComment:     sortable[FieldComment] = m_strComment; break;
   case FieldRating:      sortable[FieldRating] = (float)(m_rating - '0'); break;
   case FieldPlaycount:   sortable[FieldPlaycount] = m_iTimesPlayed; break;
-  case FieldLastPlayed:  sortable[FieldLastPlayed] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::EmptyString; break;
+  case FieldLastPlayed:  sortable[FieldLastPlayed] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::Empty; break;
   case FieldListeners:   sortable[FieldListeners] = m_listeners; break;
   case FieldId:          sortable[FieldId] = (int64_t)m_iDbId; break;
   default: break;

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -30,6 +30,7 @@ class CArtist;
 #include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
+#include "utils/StdString.h"
 #include "XBDateTime.h"
 
 #define REPLAY_GAIN_HAS_TRACK_INFO 1

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -201,7 +201,7 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
         {
           // is delete allowed?
           // must be at the playlists directory
-          if (m_vecItems->GetPath().Equals("special://musicplaylists/"))
+          if (m_vecItems->IsPath("special://musicplaylists/"))
             OnDeleteItem(iItem);
 
           // or be at the files window and have file deletion enabled

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -911,7 +911,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
   }
 }
 
-void CGUIWindowMusicBase::LoadPlayList(const CStdString& strPlayList)
+void CGUIWindowMusicBase::LoadPlayList(const std::string& strPlayList)
 {
   // if partymode is active, we disable it
   if (g_partyModeManager.IsEnabled())
@@ -1089,7 +1089,7 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
     m_dlgProgress->Close();
 }
 
-bool CGUIWindowMusicBase::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   items.SetArt("thumb", "");
   bool bResult = CGUIMediaWindow::GetDirectory(strDirectory, items);
@@ -1136,9 +1136,9 @@ bool CGUIWindowMusicBase::CheckFilterAdvanced(CFileItemList &items) const
   return false;
 }
 
-bool CGUIWindowMusicBase::CanContainFilter(const CStdString &strDirectory) const
+bool CGUIWindowMusicBase::CanContainFilter(const std::string &strDirectory) const
 {
-  return StringUtils::StartsWithNoCase(strDirectory, "musicdb://");
+  return URIUtils::IsProtocol(strDirectory, "musicdb");
 }
 
 void CGUIWindowMusicBase::OnInitWindow()
@@ -1162,11 +1162,12 @@ void CGUIWindowMusicBase::OnInitWindow()
   }
 }
 
-CStdString CGUIWindowMusicBase::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowMusicBase::GetStartFolder(const std::string &dir)
 {
-  if (dir.Equals("Plugins") || dir.Equals("Addons"))
+  std::string lower(dir); StringUtils::ToLower(lower);
+  if (lower == "plugins" || lower == "addons")
     return "addons://sources/audio/";
-  else if (dir.Equals("$PLAYLISTS") || dir.Equals("Playlists"))
+  else if (lower == "$playlists" || lower == "playlists")
     return "special://musicplaylists/";
   return CGUIMediaWindow::GetStartFolder(dir);
 }

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -63,15 +63,15 @@ protected:
   */
   virtual void UpdateButtons();
 
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void OnRetrieveMusicInfo(CFileItemList& items);
   void AddItemToPlayList(const CFileItemPtr &pItem, CFileItemList &queuedItems);
   virtual void OnScan(int iItem) {};
   void OnRipCD();
-  virtual CStdString GetStartFolder(const CStdString &dir);
+  virtual std::string GetStartFolder(const std::string &dir);
 
   virtual bool CheckFilterAdvanced(CFileItemList &items) const;
-  virtual bool CanContainFilter(const CStdString &strDirectory) const;
+  virtual bool CanContainFilter(const std::string &strDirectory) const;
 
   // new methods
   virtual void PlayItem(int iItem);
@@ -92,7 +92,7 @@ protected:
 
   void OnRipTrack(int iItem);
   void OnSearch();
-  virtual void LoadPlayList(const CStdString& strPlayList);
+  virtual void LoadPlayList(const std::string& strPlayList);
 
   typedef std::vector <CFileItem*>::iterator ivecItems; ///< CFileItem* vector Iterator
   CGUIDialogProgress* m_dlgProgress; ///< Progress dialog

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -276,7 +276,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem)
   return CGUIWindowMusicBase::OnClick(iItem);
 }
 
-bool CGUIWindowMusicNav::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowMusicNav::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -290,7 +290,7 @@ bool CGUIWindowMusicNav::Update(const CStdString &strDirectory, bool updateFilte
   return false;
 }
 
-bool CGUIWindowMusicNav::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   if (m_bDisplayEmptyDatabaseMessage)
     return true;
@@ -357,9 +357,9 @@ bool CGUIWindowMusicNav::GetDirectory(const CStdString &strDirectory, CFileItemL
     else if (node == NODE_TYPE_YEAR)
       items.SetContent("years");
   }
-  else if (strDirectory.Equals("special://musicplaylists/"))
+  else if (URIUtils::PathEquals(strDirectory, "special://musicplaylists/"))
     items.SetContent("playlists");
-  else if (strDirectory.Equals("plugin://music/"))
+  else if (URIUtils::PathEquals(strDirectory, "plugin://music/"))
     items.SetContent("plugins");
   else if (items.IsPlayList())
     items.SetContent("songs");
@@ -748,7 +748,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   return CGUIWindowMusicBase::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowMusicNav::GetSongsFromPlayList(const CStdString& strPlayList, CFileItemList &items)
+bool CGUIWindowMusicNav::GetSongsFromPlayList(const std::string& strPlayList, CFileItemList &items)
 {
   CStdString strParentPath=m_history.GetParentPath();
 
@@ -858,31 +858,32 @@ void CGUIWindowMusicNav::AddSearchFolder()
   }
 }
 
-CStdString CGUIWindowMusicNav::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowMusicNav::GetStartFolder(const std::string &dir)
 {
-  if (dir.Equals("Genres"))
+  std::string lower(dir); StringUtils::ToLower(lower);
+  if (lower == "genres")
     return "musicdb://genres/";
-  else if (dir.Equals("Artists"))
+  else if (lower == "artists")
     return "musicdb://artists/";
-  else if (dir.Equals("Albums"))
+  else if (lower == "albums")
     return "musicdb://albums/";
-  else if (dir.Equals("Singles"))
+  else if (lower == "singles")
     return "musicdb://singles/";
-  else if (dir.Equals("Songs"))
+  else if (lower == "songs")
     return "musicdb://songs/";
-  else if (dir.Equals("Top100"))
+  else if (lower == "top100")
     return "musicdb://top100/";
-  else if (dir.Equals("Top100Songs"))
+  else if (lower == "top100songs")
     return "musicdb://top100/songs/";
-  else if (dir.Equals("Top100Albums"))
+  else if (lower == "top100albums")
     return "musicdb://top100/albums/";
-  else if (dir.Equals("RecentlyAddedAlbums"))
+  else if (lower == "recentlyaddedalbums")
     return "musicdb://recentlyaddedalbums/";
-  else if (dir.Equals("RecentlyPlayedAlbums"))
+  else if (lower == "recentlyplayedalbums")
    return "musicdb://recentlyplayedalbums/";
-  else if (dir.Equals("Compilations"))
+  else if (lower == "compilations")
     return "musicdb://compilations/";
-  else if (dir.Equals("Years"))
+  else if (lower == "years")
     return "musicdb://years/";
   return CGUIWindowMusicBase::GetStartFolder(dir);
 }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -395,7 +395,7 @@ void CGUIWindowMusicNav::UpdateButtons()
   CStdString strLabel;
 
   // "Playlists"
-  if (m_vecItems->GetPath().Equals("special://musicplaylists/"))
+  if (m_vecItems->IsPath("special://musicplaylists/"))
     strLabel = g_localizeStrings.Get(136);
   // "{Playlist Name}"
   else if (m_vecItems->IsPlayList())
@@ -455,8 +455,8 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
   if (item && !StringUtils::StartsWithNoCase(item->GetPath(), "addons://more/"))
   {
     // are we in the playlists location?
-    bool inPlaylists = m_vecItems->GetPath().Equals(CUtil::MusicPlaylistsLocation()) ||
-                       m_vecItems->GetPath().Equals("special://musicplaylists/");
+    bool inPlaylists = m_vecItems->IsPath(CUtil::MusicPlaylistsLocation()) ||
+                       m_vecItems->IsPath("special://musicplaylists/");
 
     CMusicDatabaseDirectory dir;
     // enable music info button on an album or on a song.
@@ -513,9 +513,9 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
          nodetype == NODE_TYPE_OVERVIEW ||
          nodetype == NODE_TYPE_TOP100))
     {
-      if (!item->GetPath().Equals(CSettings::Get().GetString("mymusic.defaultlibview").c_str()))
+      if (!item->IsPath(CSettings::Get().GetString("mymusic.defaultlibview")))
         buttons.Add(CONTEXT_BUTTON_SET_DEFAULT, 13335); // set default
-      if (strcmp(CSettings::Get().GetString("mymusic.defaultlibview").c_str(), ""))
+      if (!CSettings::Get().GetString("mymusic.defaultlibview").empty())
         buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // clear default
     }
     NODE_TYPE childtype = dir.GetDirectoryChildType(item->GetPath());
@@ -715,7 +715,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         content = CONTENT_ARTISTS;
       }
 
-      if (m_vecItems->GetPath().Equals("musicdb://genres/") || item->GetPath().Equals("musicdb://artists/"))
+      if (m_vecItems->IsPath("musicdb://genres/") || item->IsPath("musicdb://artists/"))
       {
         content = CONTENT_ARTISTS;
       }

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -39,17 +39,17 @@ public:
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
   // override base class methods
-  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
   virtual void PlayItem(int iItem);
   virtual void OnWindowLoaded();
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual bool OnClick(int iItem);
-  virtual CStdString GetStartFolder(const CStdString &url);
+  virtual std::string GetStartFolder(const std::string &url);
 
-  bool GetSongsFromPlayList(const CStdString& strPlayList, CFileItemList &items);
+  bool GetSongsFromPlayList(const std::string& strPlayList, CFileItemList &items);
   void DisplayEmptyDatabaseMessage(bool bDisplay);
   CStdString GetQuickpathName(const CStdString& strPath) const;
 

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -478,7 +478,7 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
   }
 }
 
-bool CGUIWindowMusicPlayList::Update(const CStdString& strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowMusicPlayList::Update(const std::string& strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_musicInfoLoader.IsLoading())
     m_musicInfoLoader.StopThread();

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.h
@@ -40,7 +40,7 @@ protected:
   virtual void GoParentFolder() {};
   virtual void UpdateButtons();
   virtual void OnItemLoaded(CFileItem* pItem);
-  virtual bool Update(const CStdString& strDirectory, bool updateFilterPath = true);
+  virtual bool Update(const std::string& strDirectory, bool updateFilterPath = true);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   void OnMove(int iItem, int iAction);

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -138,7 +138,7 @@ bool CGUIWindowMusicPlaylistEditor::OnMessage(CGUIMessage& message)
   return CGUIWindowMusicBase::OnMessage(message);
 }
 
-bool CGUIWindowMusicPlaylistEditor::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIWindowMusicPlaylistEditor::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   items.Clear();
   if (strDirectory.empty())
@@ -218,7 +218,7 @@ void CGUIWindowMusicPlaylistEditor::OnQueueItem(int iItem)
   AppendToPlaylist(newItems);
 }
 
-bool CGUIWindowMusicPlaylistEditor::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowMusicPlaylistEditor::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -368,7 +368,7 @@ void CGUIWindowMusicPlaylistEditor::OnLoadPlaylist()
     LoadPlaylist(playlist);
 }
 
-void CGUIWindowMusicPlaylistEditor::LoadPlaylist(const CStdString &playlist)
+void CGUIWindowMusicPlaylistEditor::LoadPlaylist(const std::string &playlist)
 {
   const CURL pathToUrl(playlist);
   if (pathToUrl.GetProtocol() == "newplaylist")

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
@@ -35,14 +35,14 @@ public:
 
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
-  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual void OnQueueItem(int iItem);
-  virtual CStdString GetStartFolder(const CStdString &dir) { return ""; };
+  virtual std::string GetStartFolder(const std::string &dir) { return ""; };
 
   void OnPlaylistContext();
   int GetCurrentPlaylistItem();
@@ -54,7 +54,7 @@ protected:
   void AppendToPlaylist(CFileItemList &newItems);
   void OnMovePlaylistItem(int item, int direction);
 
-  void LoadPlaylist(const CStdString &playlist);
+  void LoadPlaylist(const std::string &playlist);
 
   // new method
   virtual void PlayItem(int iItem);

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -194,7 +194,7 @@ void CGUIWindowMusicSongs::DoScan(const CStdString &strPath)
   return;
 }
 
-bool CGUIWindowMusicSongs::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIWindowMusicSongs::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   if (!CGUIWindowMusicBase::GetDirectory(strDirectory, items))
     return false;
@@ -461,7 +461,7 @@ void CGUIWindowMusicSongs::PlayItem(int iItem)
     CGUIWindowMusicBase::PlayItem(iItem);
 }
 
-bool CGUIWindowMusicSongs::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowMusicSongs::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -490,7 +490,7 @@ void CGUIWindowMusicSongs::OnRemoveSource(int iItem)
   }
 }
 
-CStdString CGUIWindowMusicSongs::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowMusicSongs::GetStartFolder(const std::string &dir)
 {
   SetupShares();
   VECSOURCES shares;

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -118,7 +118,7 @@ bool CGUIWindowMusicSongs::OnMessage(CGUIMessage& message)
 
       if (iControl == CONTROL_BTNPLAYLISTS)
       {
-        if (!m_vecItems->GetPath().Equals("special://musicplaylists/"))
+        if (!m_vecItems->IsPath("special://musicplaylists/"))
           Update("special://musicplaylists/");
       }
       else if (iControl == CONTROL_BTNSCAN)
@@ -293,8 +293,8 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
   if (item)
   {
     // are we in the playlists location?
-    bool inPlaylists = m_vecItems->GetPath().Equals(CUtil::MusicPlaylistsLocation()) ||
-                       m_vecItems->GetPath().Equals("special://musicplaylists/");
+    bool inPlaylists = m_vecItems->IsPath(CUtil::MusicPlaylistsLocation()) ||
+                       m_vecItems->IsPath("special://musicplaylists/");
 
     if (m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->GetPath() == "sources://music/")
     {
@@ -367,7 +367,7 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
     if (g_application.IsMusicScanning())
       buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353); // Stop Scanning
     else if (!inPlaylists && !m_vecItems->IsInternetStream()           &&
-             !item->GetPath().Equals("add") && !item->IsParentFolder() &&
+             !item->IsPath("add") && !item->IsParentFolder() &&
              !item->IsPlugin()                                         &&
              !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")              &&
             (CProfilesManager::Get().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))

--- a/xbmc/music/windows/GUIWindowMusicSongs.h
+++ b/xbmc/music/windows/GUIWindowMusicSongs.h
@@ -33,15 +33,15 @@ public:
   void DoScan(const CStdString &strPath);
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
-  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
   virtual void OnPrepareFileItems(CFileItemList &items);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual void OnScan(int iItem);
   virtual void OnRemoveSource(int iItem);
-  virtual CStdString GetStartFolder(const CStdString &dir);
+  virtual std::string GetStartFolder(const std::string &dir);
 
   // new method
   virtual void PlayItem(int iItem);

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -370,7 +370,7 @@ bool CWakeOnAccess::WakeUpHost (const CStdString& hostName, const string& custom
 
 bool CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
 {
-  CStdString heading = StringUtils::Format(LOCALIZED(13027), server.host.c_str());
+  CStdString heading = StringUtils::Format(LOCALIZED(13027).c_str(), server.host.c_str());
 
   ProgressDialogHelper dlg (heading);
 
@@ -573,7 +573,7 @@ void CWakeOnAccess::SaveMACDiscoveryResult(const CStdString& host, const CStdStr
       {
         if (IsEnabled()) // show notification only if we have general feature enabled
         {
-          CStdString message = StringUtils::Format(LOCALIZED(13034), host.c_str());
+          CStdString message = StringUtils::Format(LOCALIZED(13034).c_str(), host.c_str());
           CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, heading, message, 4000, true, 3000);
         }
 
@@ -594,7 +594,7 @@ void CWakeOnAccess::SaveMACDiscoveryResult(const CStdString& host, const CStdStr
   CLog::Log(LOGDEBUG, "%s - Create new entry for host '%s'", __FUNCTION__, host.c_str());
   if (IsEnabled()) // show notification only if we have general feature enabled
   {
-    CStdString message = StringUtils::Format(LOCALIZED(13035), host.c_str());
+    CStdString message = StringUtils::Format(LOCALIZED(13035).c_str(), host.c_str());
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, heading, message, 4000, true, 3000);
   }
 
@@ -621,7 +621,7 @@ void CWakeOnAccess::OnJobComplete(unsigned int jobID, bool success, CJob *job)
     if (IsEnabled())
     {
       CStdString heading = LOCALIZED(13033);
-      CStdString message = StringUtils::Format(LOCALIZED(13036), host.c_str());
+      CStdString message = StringUtils::Format(LOCALIZED(13036).c_str(), host.c_str());
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, heading, message, 4000, true, 3000);
     }
   }

--- a/xbmc/network/WakeOnAccess.h
+++ b/xbmc/network/WakeOnAccess.h
@@ -21,6 +21,7 @@
 #include "URL.h"
 #include "XBDateTime.h"
 #include "utils/Job.h"
+#include "utils/StdString.h"
 #include "settings/lib/ISettingsHandler.h"
 
 class CWakeOnAccess : private IJobCallback, public ISettingsHandler

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -173,7 +173,7 @@ GetProtocolInfo(const CFileItem&              item,
 
     /* fixup the protocol just in case nothing was passed */
     if (proto.IsEmpty()) {
-        proto = item.GetAsUrl().GetProtocol();
+        proto = item.GetAsUrl().GetProtocol().c_str();
     }
 
     /*
@@ -416,7 +416,7 @@ BuildObject(CFileItem&                    item,
 
         // if the item is remote, add a direct link to the item
         if (URIUtils::IsRemote((const char*)file_path)) {
-            resource.m_ProtocolInfo = PLT_ProtocolInfo(GetProtocolInfo(item, item.GetAsUrl().GetProtocol(), context));
+            resource.m_ProtocolInfo = PLT_ProtocolInfo(GetProtocolInfo(item, item.GetAsUrl().GetProtocol().c_str(), context));
             resource.m_Uri = file_path;
 
             // if the direct link can be served directly using http, then push it in front

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -245,7 +245,7 @@ PopulateObjectFromTag(CMusicInfoTag&         tag,
     if (object.m_ReferenceID == object.m_ObjectID)
         object.m_ReferenceID = "";
 
-    object.m_MiscInfo.last_time = tag.GetLastPlayed().GetAsW3CDateTime();
+    object.m_MiscInfo.last_time = tag.GetLastPlayed().GetAsW3CDateTime().c_str();
     object.m_MiscInfo.play_count = tag.GetPlayCount();
 
     if (resource) resource->m_Duration = tag.GetDuration();
@@ -275,7 +275,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
         } else if (tag.m_type == MediaTypeMovie) {
           object.m_ObjectClass.type = "object.item.videoItem.movie";
           object.m_Title = tag.m_strTitle;
-          object.m_Date = CDateTime(tag.m_iYear, 0, 0, 0, 0, 0).GetAsW3CDate();
+          object.m_Date = CDateTime(tag.m_iYear, 0, 0, 0, 0, 0).GetAsW3CDate().c_str();
           object.m_ReferenceID = NPT_String::Format("videodb://movies/titles/%i", tag.m_iDbId);
         } else {
           object.m_ObjectClass.type = "object.item.videoItem.videoBroadcast";
@@ -286,7 +286,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
           int season = tag.m_iSeason > 1 ? tag.m_iSeason : 1;
           object.m_Recorded.episode_number = season * 100 + tag.m_iEpisode;
           object.m_Title = object.m_Recorded.series_title + " - " + object.m_Recorded.program_title;
-          object.m_Date = tag.m_firstAired.GetAsW3CDate();
+          object.m_Date = tag.m_firstAired.GetAsW3CDate().c_str();
           if(tag.m_iSeason != -1)
               object.m_ReferenceID = NPT_String::Format("videodb://tvshows/0/%i", tag.m_iDbId);
         }
@@ -301,7 +301,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     for (unsigned int index = 0; index < tag.m_studio.size(); index++)
         object.m_People.publisher.Add(tag.m_studio[index].c_str());
 
-    object.m_XbmcInfo.date_added = tag.m_dateAdded.GetAsDBDate();
+    object.m_XbmcInfo.date_added = tag.m_dateAdded.GetAsDBDate().c_str();
     object.m_XbmcInfo.rating = tag.m_fRating;
     object.m_XbmcInfo.votes = tag.m_strVotes;
 
@@ -322,7 +322,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     object.m_Description.long_description = tag.m_strPlot;
     object.m_Description.rating = tag.m_strMPAARating;
     object.m_MiscInfo.last_position = (NPT_UInt32)tag.m_resumePoint.timeInSeconds;
-    object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsW3CDateTime();
+    object.m_MiscInfo.last_time = tag.m_lastPlayed.GetAsW3CDateTime().c_str();
     object.m_MiscInfo.play_count = tag.m_playCount;
     if (resource) {
         resource->m_Duration = tag.GetDuration();
@@ -407,7 +407,7 @@ BuildObject(CFileItem&                    item,
 
         // set date
         if (object->m_Date.IsEmpty() && item.m_dateTime.IsValid()) {
-            object->m_Date = item.m_dateTime.GetAsDBDate();
+            object->m_Date = item.m_dateTime.GetAsDBDate().c_str();
         }
 
         if (upnp_server) {
@@ -515,7 +515,7 @@ BuildObject(CFileItem&                    item,
                   if(!tag.m_premiered.IsValid() && tag.m_iYear)
                     container->m_Date = NPT_String::FromInteger(tag.m_iYear) + "-01-01";
                   else
-                    container->m_Date = tag.m_premiered.GetAsDBDate();
+                    container->m_Date = tag.m_premiered.GetAsDBDate().c_str();
 
                   for (unsigned int index = 0; index < tag.m_genre.size(); index++)
                     container->m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -350,7 +350,7 @@ BuildObject(CFileItem&                    item,
     PLT_MediaObject*      object = NULL;
     std::string thumb, fanart;
 
-    CLog::Log(LOGDEBUG, "UPnP: Building didl for object '%s'", (const char*)item.GetPath());
+    CLog::Log(LOGDEBUG, "UPnP: Building didl for object '%s'", item.GetPath().c_str());
 
     EClientQuirks quirks = GetClientQuirks(context);
 
@@ -371,7 +371,7 @@ BuildObject(CFileItem&                    item,
 
     if (!item.m_bIsFolder) {
         object = new PLT_MediaItem();
-        object->m_ObjectID = item.GetPath();
+        object->m_ObjectID = item.GetPath().c_str();
 
         /* Setup object type */
         if (item.IsMusicDb() || item.IsAudio()) {
@@ -444,7 +444,7 @@ BuildObject(CFileItem&                    item,
         object = container;
 
         /* Assign a title and id for this container */
-        container->m_ObjectID = item.GetPath();
+        container->m_ObjectID = item.GetPath().c_str();
         container->m_ObjectClass.type = "object.container";
         container->m_ChildrenCount = -1;
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -235,9 +235,9 @@ PopulateObjectFromTag(CMusicInfoTag&         tag,
     }
     object.m_People.artists.Add(StringUtils::Join(!tag.GetAlbumArtist().empty() ? tag.GetAlbumArtist() : tag.GetArtist(), g_advancedSettings.m_musicItemSeparator).c_str(), "AlbumArtist");
     if(tag.GetAlbumArtist().empty())
-        object.m_Creator = StringUtils::Join(tag.GetArtist(), g_advancedSettings.m_musicItemSeparator);
+        object.m_Creator = StringUtils::Join(tag.GetArtist(), g_advancedSettings.m_musicItemSeparator).c_str();
     else
-        object.m_Creator = StringUtils::Join(tag.GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator);
+        object.m_Creator = StringUtils::Join(tag.GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator).c_str();
     object.m_MiscInfo.original_track_number = tag.GetTrackNumber();
     if(tag.GetDatabaseId() >= 0) {
       object.m_ReferenceID = NPT_String::Format("musicdb://songs/%i%s", tag.GetDatabaseId(), URIUtils::GetExtension(tag.GetURL()).c_str());
@@ -269,7 +269,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     if (tag.m_iDbId != -1 ) {
         if (tag.m_type == MediaTypeMusicVideo) {
           object.m_ObjectClass.type = "object.item.videoItem.musicVideoClip";
-          object.m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator);
+          object.m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator).c_str();
           object.m_Title = tag.m_strTitle;
           object.m_ReferenceID = NPT_String::Format("videodb://musicvideos/titles/%i", tag.m_iDbId);
         } else if (tag.m_type == MediaTypeMovie) {
@@ -502,7 +502,7 @@ BuildObject(CFileItem&                    item,
                   break;
                 case VIDEODATABASEDIRECTORY::NODE_TYPE_ACTOR:
                   container->m_ObjectClass.type += ".person.videoArtist";
-                  container->m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator);
+                  container->m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator).c_str();
                   container->m_Title   = tag.m_strTitle;
                   break;
                 case VIDEODATABASEDIRECTORY::NODE_TYPE_SEASONS:

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -272,7 +272,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
         path.TrimRight("/");
         if (path.StartsWith("virtualpath://")) {
             object = new PLT_MediaContainer;
-            object->m_Title = item->GetLabel();
+            object->m_Title = item->GetLabel().c_str();
             object->m_ObjectClass.type = "object.container";
             object->m_ObjectID = path;
 
@@ -290,7 +290,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
     } else {
         // db path handling
         NPT_String file_path, share_name;
-        file_path = item->GetPath();
+        file_path = item->GetPath().c_str();
         share_name = "";
 
         if (path.StartsWith("musicdb://")) {

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -255,7 +255,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
     m_dlgProgress->Close();
 }
 
-bool CGUIWindowPictures::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPictures::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -296,7 +296,7 @@ bool CGUIWindowPictures::OnClick(int iItem)
   return false;
 }
 
-bool CGUIWindowPictures::GetDirectory(const CStdString &strDirectory, CFileItemList& items)
+bool CGUIWindowPictures::GetDirectory(const std::string &strDirectory, CFileItemList& items)
 {
   if (!CGUIMediaWindow::GetDirectory(strDirectory, items))
     return false;
@@ -556,7 +556,7 @@ void CGUIWindowPictures::OnItemLoaded(CFileItem *pItem)
   CPictureThumbLoader::ProcessFoldersAndArchives(pItem);
 }
 
-void CGUIWindowPictures::LoadPlayList(const CStdString& strPlayList)
+void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
 {
   CLog::Log(LOGDEBUG,"CGUIWindowPictures::LoadPlayList()... converting playlist into slideshow: %s", strPlayList.c_str());
   auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
@@ -616,9 +616,10 @@ void CGUIWindowPictures::OnInfo(int itemNumber)
   }
 }
 
-CStdString CGUIWindowPictures::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowPictures::GetStartFolder(const std::string &dir)
 {
-  if (dir.Equals("Plugins") || dir.Equals("Addons"))
+  std::string lower(dir); StringUtils::ToLower(lower);
+  if (lower == "plugins" || lower == "addons")
     return "addons://sources/image/";
 
   SetupShares();

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -75,7 +75,7 @@ void CGUIWindowPictures::OnInitWindow()
     CStdString path;
     if (wndw && wndw->GetCurrentSlide())
       path = URIUtils::GetDirectory(wndw->GetCurrentSlide()->GetPath());
-    if (path.Equals(m_vecItems->GetPath()))
+    if (m_vecItems->IsPath(path))
     {
       if (wndw && wndw->GetCurrentSlide())
         m_viewControl.SetSelectedItem(wndw->GetCurrentSlide()->GetPath());
@@ -208,7 +208,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
   CGUIMediaWindow::OnPrepareFileItems(items);
 
   for (int i=0;i<items.Size();++i )
-    if (items[i]->GetLabel().Equals("folder.jpg"))
+    if (StringUtils::EqualsNoCase(items[i]->GetLabel(), "folder.jpg"))
       items.Remove(i);
 
   if (items.GetFolderCount()==items.Size() || !CSettings::Get().GetBool("pictures.usetags"))

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -281,13 +281,13 @@ bool CGUIWindowPictures::OnClick(int iItem)
 
   if (pItem->IsCBZ() || pItem->IsCBR())
   {
-    CStdString strComicPath;
+    CURL pathToUrl;
     if (pItem->IsCBZ())
-      URIUtils::CreateArchivePath(strComicPath, "zip", pItem->GetPath(), "");
+      pathToUrl = URIUtils::CreateArchivePath("zip", pItem->GetURL(), "");
     else
-      URIUtils::CreateArchivePath(strComicPath, "rar", pItem->GetPath(), "");
+      pathToUrl = URIUtils::CreateArchivePath("rar", pItem->GetURL(), "");
 
-    OnShowPictureRecursive(strComicPath);
+    OnShowPictureRecursive(pathToUrl.Get());
     return true;
   }
   else if (CGUIMediaWindow::OnClick(iItem))

--- a/xbmc/pictures/GUIWindowPictures.h
+++ b/xbmc/pictures/GUIWindowPictures.h
@@ -36,15 +36,15 @@ public:
   virtual void OnInitWindow();
 
 protected:
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList& items);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList& items);
   virtual void OnInfo(int item);
   virtual bool OnClick(int iItem);
   virtual void UpdateButtons();
   virtual void OnPrepareFileItems(CFileItemList& items);
-  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-  virtual CStdString GetStartFolder(const CStdString &dir);
+  virtual std::string GetStartFolder(const std::string &dir);
 
   void OnRegenerateThumbs();
   virtual bool OnPlayMedia(int iItem);
@@ -55,7 +55,7 @@ protected:
   void OnSlideShowRecursive(const CStdString& strPicture);
   void OnSlideShowRecursive();
   virtual void OnItemLoaded(CFileItem* pItem);
-  virtual void LoadPlayList(const CStdString& strPlayList);
+  virtual void LoadPlayList(const std::string& strPlayList);
 
   CGUIDialogProgress* m_dlgProgress;
   DllImageLib m_ImageLib;

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -31,6 +31,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "video/VideoThumbLoader.h"
+#include "URL.h"
 
 using namespace XFILE;
 using namespace std;
@@ -154,20 +155,20 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
   {
     // first check for a folder.jpg
     CStdString thumb = "folder.jpg";
-    CStdString strPath = pItem->GetPath();
+    CURL pathToUrl = pItem->GetURL();
     if (pItem->IsCBR())
     {
-      URIUtils::CreateArchivePath(strPath,"rar",pItem->GetPath(),"");
+      pathToUrl = URIUtils::CreateArchivePath("rar",pItem->GetURL(),"");
       thumb = "cover.jpg";
     }
     if (pItem->IsCBZ())
     {
-      URIUtils::CreateArchivePath(strPath,"zip",pItem->GetPath(),"");
+      pathToUrl = URIUtils::CreateArchivePath("zip",pItem->GetURL(),"");
       thumb = "cover.jpg";
     }
     if (pItem->IsMultiPath())
-      strPath = CMultiPathDirectory::GetFirstPath(pItem->GetPath());
-    thumb = URIUtils::AddFileToFolder(strPath, thumb);
+      pathToUrl = CURL(CMultiPathDirectory::GetFirstPath(pItem->GetPath()));
+    thumb = URIUtils::AddFileToFolder(pathToUrl.Get(), thumb);
     if (CFile::Exists(thumb))
     {
       db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
@@ -182,7 +183,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
       CFileItemList items;
 
-      CDirectory::GetDirectory(strPath, items, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
+      CDirectory::GetDirectory(pathToUrl, items, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
       
       // create the folder thumb by choosing 4 random thumbs within the folder and putting
       // them into one thumb.
@@ -201,7 +202,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       {
         if (pItem->IsCBZ() || pItem->IsCBR())
         {
-          CDirectory::GetDirectory(strPath, items, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
+          CDirectory::GetDirectory(pathToUrl, items, g_advancedSettings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
           for (int i=0;i<items.Size();++i)
           {
             CFileItemPtr item = items[i];

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -151,7 +151,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     }
   }
   if ((pItem->m_bIsFolder || pItem->IsCBR() || pItem->IsCBZ()) && !pItem->m_bIsShareOrDrive
-      && !pItem->IsParentFolder() && !pItem->GetPath().Equals("add"))
+      && !pItem->IsParentFolder() && !pItem->IsPath("add"))
   {
     // first check for a folder.jpg
     CStdString thumb = "folder.jpg";

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/StringUtils.h"
 #include "interfaces/AnnouncementManager.h"
 
 //using namespace std;
@@ -467,7 +468,7 @@ bool CPlayList::Expand(int position)
   // remove any item that points back to itself
   for(int i = 0;i<playlist->size();i++)
   {
-    if( (*playlist)[i]->GetPath().Equals( item->GetPath() ) )
+    if(StringUtils::EqualsNoCase((*playlist)[i]->GetPath(), item->GetPath()))
     {
       playlist->Remove(i);
       i--;
@@ -499,7 +500,7 @@ void CPlayList::UpdateItem(const CFileItem *item)
   }
 }
 
-const CStdString& CPlayList::ResolveURL(const CFileItemPtr &item ) const
+const CStdString CPlayList::ResolveURL(const CFileItemPtr &item ) const
 {
   if (item->IsMusicDb() && item->HasMusicInfoTag())
     return item->GetMusicInfoTag()->GetURL();

--- a/xbmc/playlists/PlayList.h
+++ b/xbmc/playlists/PlayList.h
@@ -68,7 +68,7 @@ public:
 
   void UpdateItem(const CFileItem *item);
 
-  const CStdString& ResolveURL(const CFileItemPtr &item) const;
+  const CStdString ResolveURL(const CFileItemPtr &item) const;
 
 protected:
   int m_id;

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -145,7 +145,7 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   return CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowPrograms::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPrograms::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -172,7 +172,7 @@ bool CGUIWindowPrograms::OnPlayMedia(int iItem)
   return false;
 }
 
-bool CGUIWindowPrograms::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIWindowPrograms::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   if (!CGUIMediaWindow::GetDirectory(strDirectory, items))
     return false;
@@ -190,9 +190,10 @@ bool CGUIWindowPrograms::GetDirectory(const CStdString &strDirectory, CFileItemL
   return true;
 }
 
-CStdString CGUIWindowPrograms::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowPrograms::GetStartFolder(const std::string &dir)
 {
-  if (dir.Equals("Plugins") || dir.Equals("Addons"))
+  std::string lower(dir); StringUtils::ToLower(lower);
+  if (lower == "plugins" || lower == "addons")
     return "addons://sources/executable/";
     
   SetupShares();

--- a/xbmc/programs/GUIWindowPrograms.h
+++ b/xbmc/programs/GUIWindowPrograms.h
@@ -34,12 +34,12 @@ public:
   virtual void OnInfo(int iItem);
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
-  virtual bool Update(const CStdString& strDirectory, bool updateFilterPath = true);
+  virtual bool Update(const std::string& strDirectory, bool updateFilterPath = true);
   virtual bool OnPlayMedia(int iItem);
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-  virtual CStdString GetStartFolder(const CStdString &dir);
+  virtual std::string GetStartFolder(const std::string &dir);
 
   CGUIDialogProgress* m_dlgProgress;
 

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -158,7 +158,7 @@ void CPVRChannel::Serialize(CVariant& value) const
   value["icon"] = m_strIconPath;
   value["channel"]  = m_strChannelName;
   CDateTime lastPlayed(m_iLastWatched);
-  value["lastplayed"] = lastPlayed.IsValid() ? lastPlayed.GetAsDBDate() : StringUtils::EmptyString;
+  value["lastplayed"] = lastPlayed.IsValid() ? lastPlayed.GetAsDBDate() : StringUtils::Empty;
   value["channelnumber"] = m_iCachedChannelNumber;
   
   CEpgInfoTag epg;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -155,7 +155,7 @@ void CGUIDialogPVRGuideSearch::UpdateDurationSpin(void)
   for (int i = 1; i < 12*60/5; i++)
   {
     CStdString string;
-    string = StringUtils::Format(g_localizeStrings.Get(14044), i*5);
+    string = StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i*5);
     pSpin->AddLabel(string, i*5);
   }
   pSpin->SetValue(m_searchFilter->m_iMinimumDuration);
@@ -170,7 +170,7 @@ void CGUIDialogPVRGuideSearch::UpdateDurationSpin(void)
   for (int i = 1; i < 12*60/5; i++)
   {
     CStdString string;
-    string = StringUtils::Format(g_localizeStrings.Get(14044), i*5);
+    string = StringUtils::Format(g_localizeStrings.Get(14044).c_str(), i*5);
     pSpin->AddLabel(string, i*5);
   }
   pSpin->SetValue(m_searchFilter->m_iMaximumDuration);

--- a/xbmc/pvr/windows/GUIWindowPVR.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVR.cpp
@@ -92,7 +92,7 @@ void CGUIWindowPVR::SetActiveView(CGUIWindowPVRCommon *window)
   m_currentSubwindow = window;
 }
 
-bool CGUIWindowPVR::Update(const CStdString &strDirectory, bool updateFilterPath)
+bool CGUIWindowPVR::Update(const std::string &strDirectory, bool updateFilterPath)
 {
   CGUIWindowPVRCommon *view = GetActiveView();
 

--- a/xbmc/pvr/windows/GUIWindowPVR.h
+++ b/xbmc/pvr/windows/GUIWindowPVR.h
@@ -67,7 +67,7 @@ namespace PVR
     virtual void SetLabel(int iControl, const CStdString &strLabel);
     virtual void SetLabel(int iControl, int iLabel);
     virtual void UpdateButtons(void);
-    virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
+    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     virtual bool OnBack(int actionID);
 
   private:

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -284,7 +284,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bVideoScannerIgnoreErrors;
     int m_iVideoLibraryDateAdded;
 
-    std::vector<CStdString> m_vecTokens; // cleaning strings tied to language
+    std::vector<std::string> m_vecTokens; // cleaning strings tied to language
     //TuxBox
     int m_iTuxBoxStreamtsPort;
     bool m_bTuxBoxSubMenuSelection;

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -676,7 +676,7 @@ void CDisplaySettings::SettingOptionsScreensFiller(const CSetting *setting, std:
   for (int idx = 0; idx < g_Windowing.GetNumScreens(); idx++)
   {
     int screen = CDisplaySettings::Get().GetResolutionInfo(RES_DESKTOP + idx).iScreen;
-    list.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(241), screen + 1), screen));
+    list.push_back(make_pair(StringUtils::Format(g_localizeStrings.Get(241).c_str(), screen + 1), screen));
   }
 
   RESOLUTION res = CDisplaySettings::Get().GetDisplayResolution();

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -105,7 +105,7 @@ CXBMCTestUtils &CXBMCTestUtils::Instance()
   return instance;
 }
 
-CStdString CXBMCTestUtils::ReferenceFilePath(CStdString const& path)
+std::string CXBMCTestUtils::ReferenceFilePath(const std::string& path)
 {
   return CSpecialProtocol::TranslatePath("special://xbmc") + path;
 }

--- a/xbmc/test/TestUtils.h
+++ b/xbmc/test/TestUtils.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <string>
 #include "utils/StdString.h"
 
 namespace XFILE
@@ -35,7 +36,7 @@ public:
    * xbmc-test binary. It's assumed the test suite program will only be run
    * with xbmc-test residing in the source tree.
    */
-  CStdString ReferenceFilePath(CStdString const& path);
+  std::string ReferenceFilePath(const std::string& path);
 
   /* Function to set the reference file base path. */
   bool SetReferenceFileBasePath();

--- a/xbmc/utils/EdenVideoArtUpdater.cpp
+++ b/xbmc/utils/EdenVideoArtUpdater.cpp
@@ -341,7 +341,7 @@ CStdString CEdenVideoArtUpdater::GetCachedSeasonThumb(int season, const CStdStri
   else if (season == 0)
     label = g_localizeStrings.Get(20381);
   else
-    label = StringUtils::Format(g_localizeStrings.Get(20358), season);
+    label = StringUtils::Format(g_localizeStrings.Get(20358).c_str(), season);
   return GetThumb("season" + path + label, CProfilesManager::Get().GetVideoThumbFolder(), true);
 }
 

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -86,7 +86,7 @@ bool CFileUtils::RenameFile(const CStdString &strFile)
     CLog::Log(LOGINFO,"FileUtils: rename %s->%s\n", strFileAndPath.c_str(), strPath.c_str());
     if (URIUtils::IsMultiPath(strFileAndPath))
     { // special case for multipath renames - rename all the paths.
-      vector<CStdString> paths;
+      vector<std::string> paths;
       CMultiPathDirectory::GetPaths(strFileAndPath, paths);
       bool success = false;
       for (unsigned int i = 0; i < paths.size(); ++i)

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -71,7 +71,7 @@ void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
   {
     m_mapUser.clear();
 
-    CStdString sShort, sLong;
+    std::string sShort, sLong;
 
     const TiXmlNode* pLangCode = pRootElement->FirstChild("code");
     while (pLangCode)
@@ -90,12 +90,12 @@ void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
   }
 }
 
-bool CLangCodeExpander::Lookup(CStdString& desc, const CStdString& code)
+bool CLangCodeExpander::Lookup(std::string& desc, const std::string& code)
 {
   int iSplit = code.find("-");
   if (iSplit > 0)
   {
-    CStdString strLeft, strRight;
+    std::string strLeft, strRight;
     const bool bLeft = Lookup(strLeft, code.substr(0, iSplit));
     const bool bRight = Lookup(strRight, code.substr(iSplit + 1));
     if (bLeft || bRight)
@@ -131,7 +131,7 @@ bool CLangCodeExpander::Lookup(CStdString& desc, const CStdString& code)
   return false;
 }
 
-bool CLangCodeExpander::Lookup(CStdString& desc, const int code)
+bool CLangCodeExpander::Lookup(std::string& desc, const int code)
 {
 
   char lang[3];
@@ -142,17 +142,17 @@ bool CLangCodeExpander::Lookup(CStdString& desc, const int code)
   return Lookup(desc, lang);
 }
 
-bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool checkWin32Locales /*= false*/)
+bool CLangCodeExpander::ConvertTwoToThreeCharCode(std::string& strThreeCharCode, const std::string& strTwoCharCode, bool checkWin32Locales /*= false*/)
 {       
   if ( strTwoCharCode.length() == 2 )
   {
-    CStdString strTwoCharCodeLower( strTwoCharCode );
+    std::string strTwoCharCodeLower( strTwoCharCode );
     StringUtils::ToLower(strTwoCharCodeLower);
     StringUtils::Trim(strTwoCharCodeLower);
 
     for (unsigned int index = 0; index < sizeof(CharCode2To3) / sizeof(CharCode2To3[0]); ++index)
     {
-      if (strTwoCharCodeLower.Equals(CharCode2To3[index].old))
+      if (strTwoCharCodeLower == CharCode2To3[index].old)
       {
         if (checkWin32Locales && CharCode2To3[index].win_id)
         {
@@ -169,26 +169,27 @@ bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, 
   return false;
 }
 
-bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool checkXbmcLocales /*= true*/, bool checkWin32Locales /*= false*/)
+bool CLangCodeExpander::ConvertToThreeCharCode(std::string& strThreeCharCode, const std::string& strCharCode, bool checkXbmcLocales /*= true*/, bool checkWin32Locales /*= false*/)
 {
   if (strCharCode.size() == 2)
     return g_LangCodeExpander.ConvertTwoToThreeCharCode(strThreeCharCode, strCharCode, checkWin32Locales);
   else if (strCharCode.size() == 3)
   {
+    std::string charCode(strCharCode); StringUtils::ToLower(charCode);
     for (unsigned int index = 0; index < sizeof(CharCode2To3) / sizeof(CharCode2To3[0]); ++index)
     {
-      if (strCharCode.Equals(CharCode2To3[index].id) ||
-           (checkWin32Locales && CharCode2To3[index].win_id != NULL && strCharCode.Equals(CharCode2To3[index].win_id)) )
+      if (charCode == CharCode2To3[index].id ||
+           (checkWin32Locales && CharCode2To3[index].win_id != NULL && charCode == CharCode2To3[index].win_id) )
       {
-        strThreeCharCode = strCharCode;
+        strThreeCharCode = charCode;
         return true;
       }
     }
     for (unsigned int index = 0; index < sizeof(RegionCode2To3) / sizeof(RegionCode2To3[0]); ++index)
     {
-      if (strCharCode.Equals(RegionCode2To3[index].id))
+      if (charCode == RegionCode2To3[index].id)
       {
-        strThreeCharCode = strCharCode;
+        strThreeCharCode = charCode;
         return true;
       }
     }
@@ -219,17 +220,17 @@ bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, con
 }
 
 #ifdef TARGET_WINDOWS
-bool CLangCodeExpander::ConvertLinuxToWindowsRegionCodes(const CStdString& strTwoCharCode, CStdString& strThreeCharCode)
+bool CLangCodeExpander::ConvertLinuxToWindowsRegionCodes(const std::string& strTwoCharCode, std::string& strThreeCharCode)
 {
   if (strTwoCharCode.length() != 2)
     return false;
 
-  CStdString strLower( strTwoCharCode );
+  std::string strLower( strTwoCharCode );
   StringUtils::ToLower(strLower);
   StringUtils::Trim(strLower);
   for (unsigned int index = 0; index < sizeof(RegionCode2To3) / sizeof(RegionCode2To3[0]); ++index)
   {
-    if (strLower.Equals(RegionCode2To3[index].old))
+    if (strLower == RegionCode2To3[index].old)
     {
       strThreeCharCode = RegionCode2To3[index].id;
       return true;
@@ -239,17 +240,17 @@ bool CLangCodeExpander::ConvertLinuxToWindowsRegionCodes(const CStdString& strTw
   return true;
 }
 
-bool CLangCodeExpander::ConvertWindowsToGeneralCharCode(const CStdString& strWindowsCharCode, CStdString& strThreeCharCode)
+bool CLangCodeExpander::ConvertWindowsToGeneralCharCode(const std::string& strWindowsCharCode, std::string& strThreeCharCode)
 {
   if (strWindowsCharCode.length() != 3)
     return false;
 
-  CStdString strLower(strWindowsCharCode);
+  std::string strLower(strWindowsCharCode);
   StringUtils::ToLower(strLower);
   for (unsigned int index = 0; index < sizeof(CharCode2To3) / sizeof(CharCode2To3[0]); ++index)
   {
-    if ((CharCode2To3[index].win_id && strLower.Equals(CharCode2To3[index].win_id)) ||
-         strLower.Equals(CharCode2To3[index].id))
+    if ((CharCode2To3[index].win_id && strLower == CharCode2To3[index].win_id) ||
+         strLower == CharCode2To3[index].id)
     {
       strThreeCharCode = CharCode2To3[index].id;
       return true;
@@ -260,14 +261,14 @@ bool CLangCodeExpander::ConvertWindowsToGeneralCharCode(const CStdString& strWin
 }
 #endif
 
-bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString& lang, bool checkXbmcLocales /*= true*/)
+bool CLangCodeExpander::ConvertToTwoCharCode(std::string& code, const std::string& lang, bool checkXbmcLocales /*= true*/)
 {
   if (lang.empty())
     return false;
 
   if (lang.length() == 2)
   {
-    CStdString tmp;
+    std::string tmp;
     if (Lookup(tmp, lang))
     {
       code = lang;
@@ -276,9 +277,10 @@ bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString&
   }
   else if (lang.length() == 3)
   {
+    std::string lower(lang); StringUtils::ToLower(lower);
     for (unsigned int index = 0; index < sizeof(CharCode2To3) / sizeof(CharCode2To3[0]); ++index)
     {
-      if (lang.Equals(CharCode2To3[index].id) || (CharCode2To3[index].win_id && lang.Equals(CharCode2To3[index].win_id)))
+      if (lower == CharCode2To3[index].id || (CharCode2To3[index].win_id && lower == CharCode2To3[index].win_id))
       {
         code = CharCode2To3[index].old;
         return true;
@@ -287,7 +289,7 @@ bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString&
 
     for (unsigned int index = 0; index < sizeof(RegionCode2To3) / sizeof(RegionCode2To3[0]); ++index)
     {
-      if (lang.Equals(RegionCode2To3[index].id))
+      if (lower == RegionCode2To3[index].id)
       {
         code = RegionCode2To3[index].old;
         return true;
@@ -296,7 +298,7 @@ bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString&
   }
 
   // check if lang is full language name
-  CStdString tmp;
+  std::string tmp;
   if (ReverseLookup(lang, tmp))
   {
     if (tmp.length() == 2)
@@ -319,17 +321,18 @@ bool CLangCodeExpander::ConvertToTwoCharCode(CStdString& code, const CStdString&
   return ConvertToTwoCharCode(code, langInfo.GetLanguageCode(), false);
 }
 
-bool CLangCodeExpander::ReverseLookup(const CStdString& desc, CStdString& code)
+bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code)
 {
   if (desc.empty())
     return false;
 
-  CStdString descTmp(desc);
+  std::string descTmp(desc);
   StringUtils::Trim(descTmp);
+  StringUtils::ToLower(descTmp);
   STRINGLOOKUPTABLE::iterator it;
   for (it = m_mapUser.begin(); it != m_mapUser.end() ; ++it)
   {
-    if (descTmp.Equals(it->second))
+    if (StringUtils::EqualsNoCase(descTmp, it->second))
     {
       code = it->first;
       return true;
@@ -337,7 +340,7 @@ bool CLangCodeExpander::ReverseLookup(const CStdString& desc, CStdString& code)
   }
   for(unsigned int i = 0; i < sizeof(g_iso639_1) / sizeof(LCENTRY); i++)
   {
-    if (descTmp.Equals(g_iso639_1[i].name))
+    if (descTmp == g_iso639_1[i].name)
     {
       CodeToString(g_iso639_1[i].code, code);
       return true;
@@ -345,7 +348,7 @@ bool CLangCodeExpander::ReverseLookup(const CStdString& desc, CStdString& code)
   }
   for(unsigned int i = 0; i < sizeof(g_iso639_2) / sizeof(LCENTRY); i++)
   {
-    if (descTmp.Equals(g_iso639_2[i].name))
+    if (descTmp == g_iso639_2[i].name)
     {
       CodeToString(g_iso639_2[i].code, code);
       return true;
@@ -354,14 +357,14 @@ bool CLangCodeExpander::ReverseLookup(const CStdString& desc, CStdString& code)
   return false;
 }
 
-bool CLangCodeExpander::LookupInMap(CStdString& desc, const CStdString& code)
+bool CLangCodeExpander::LookupInMap(std::string& desc, const std::string& code)
 {
   if (code.empty())
     return false;
 
   STRINGLOOKUPTABLE::iterator it;
   //Make sure we convert to lowercase before trying to find it
-  CStdString sCode(code);
+  std::string sCode(code);
   StringUtils::ToLower(sCode);
   StringUtils::Trim(sCode);
 
@@ -374,13 +377,13 @@ bool CLangCodeExpander::LookupInMap(CStdString& desc, const CStdString& code)
   return false;
 }
 
-bool CLangCodeExpander::LookupInDb(CStdString& desc, const CStdString& code)
+bool CLangCodeExpander::LookupInDb(std::string& desc, const std::string& code)
 {
   if (code.empty())
     return false;
 
   long longcode;
-  CStdString sCode(code);
+  std::string sCode(code);
   StringUtils::ToLower(sCode);
   StringUtils::Trim(sCode);
 
@@ -411,7 +414,7 @@ bool CLangCodeExpander::LookupInDb(CStdString& desc, const CStdString& code)
   return false;
 }
 
-void CLangCodeExpander::CodeToString(long code, CStdString& ret)
+void CLangCodeExpander::CodeToString(long code, std::string& ret)
 {
   ret.clear();
   for (unsigned int j = 0 ; j < 4 ; j++)
@@ -424,12 +427,12 @@ void CLangCodeExpander::CodeToString(long code, CStdString& ret)
   }
 }
 
-bool CLangCodeExpander::CompareFullLangNames(const CStdString& lang1, const CStdString& lang2)
+bool CLangCodeExpander::CompareFullLangNames(const std::string& lang1, const std::string& lang2)
 {
-  if (lang1.Equals(lang2))
+  if (StringUtils::EqualsNoCase(lang1, lang2))
     return true;
 
-  CStdString expandedLang1, expandedLang2, code1, code2;
+  std::string expandedLang1, expandedLang2, code1, code2;
 
   if (!ReverseLookup(lang1, code1))
     return false;
@@ -443,7 +446,7 @@ bool CLangCodeExpander::CompareFullLangNames(const CStdString& lang1, const CStd
 
   Lookup(expandedLang1, code1);
   Lookup(expandedLang2, code2);
-  return expandedLang1.Equals(expandedLang2);
+  return StringUtils::EqualsNoCase(expandedLang1, expandedLang2);
 }
 
 std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format /* = CLangCodeExpander::ISO_639_1 */)
@@ -467,12 +470,12 @@ std::vector<std::string> CLangCodeExpander::GetLanguageNames(LANGFORMATS format 
   return languages;
 }
 
-bool CLangCodeExpander::CompareLangCodes(const CStdString& code1, const CStdString& code2)
+bool CLangCodeExpander::CompareLangCodes(const std::string& code1, const std::string& code2)
 {
-  if (code1.Equals(code2))
+  if (StringUtils::EqualsNoCase(code1, code2))
     return true;
 
-  CStdString expandedLang1, expandedLang2;
+  std::string expandedLang1, expandedLang2;
 
   if (!Lookup(expandedLang1, code1))
     return false;
@@ -480,15 +483,15 @@ bool CLangCodeExpander::CompareLangCodes(const CStdString& code1, const CStdStri
   if (!Lookup(expandedLang2, code2))
     return false;
 
-  return expandedLang1.Equals(expandedLang2);
+  return StringUtils::EqualsNoCase(expandedLang1, expandedLang2);
 }
 
-CStdString CLangCodeExpander::ConvertToISO6392T(const CStdString& lang)
+std::string CLangCodeExpander::ConvertToISO6392T(const std::string& lang)
 {
   if (lang.empty())
     return lang;
 
-  CStdString two, three;
+  std::string two, three;
   if (ConvertToTwoCharCode(two, lang))
   {
     if (ConvertToThreeCharCode(three, two))

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -19,8 +19,9 @@
  *
  */
 
-#include "utils/StdString.h"
 #include <map>
+#include <string>
+#include <vector>
 
 class TiXmlElement;
 
@@ -38,8 +39,8 @@ public:
   CLangCodeExpander(void);
   ~CLangCodeExpander(void);
 
-  bool Lookup(CStdString& desc, const CStdString& code);
-  bool Lookup(CStdString& desc, const int code);
+  bool Lookup(std::string& desc, const std::string& code);
+  bool Lookup(std::string& desc, const int code);
 
   /** \brief Determines if two english language names represent the same language.
   *   \param[in] lang1 The first language string to compare given as english language name.
@@ -47,7 +48,7 @@ public:
   *   \return true if the two language strings represent the same language, false otherwise.
   *   For example "Abkhaz" and "Abkhazian" represent the same language.
   */ 
-  bool CompareFullLangNames(const CStdString& lang1, const CStdString& lang2);
+  bool CompareFullLangNames(const std::string& lang1, const std::string& lang2);
 
   /** \brief Determines if two languages given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B codes represent the same language.
   *   \param[in] code1 The first language to compare given as ISO 639-1, ISO 639-2/T, or ISO 639-2/B code.
@@ -55,7 +56,7 @@ public:
   *   \return true if the two language codes represent the same language, false otherwise.
   *   For example "ger", "deu" and "de" represent the same language.
   */ 
-  bool CompareLangCodes(const CStdString& code1, const CStdString& code2);
+  bool CompareLangCodes(const std::string& code1, const std::string& code2);
 
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),
@@ -65,7 +66,7 @@ public:
   *   \param[in] checkXbmcLocales Try to find in XBMC specific locales
   *   \return true if the conversion succeeded, false otherwise. 
   */ 
-  bool ConvertToTwoCharCode(CStdString& code, const CStdString& lang, bool checkXbmcLocales = true);
+  bool ConvertToTwoCharCode(std::string& code, const std::string& lang, bool checkXbmcLocales = true);
 
   /** \brief Converts a language given as 2-Char (ISO 639-1),
   *          3-Char (ISO 639-2/T or ISO 639-2/B),
@@ -73,13 +74,13 @@ public:
   *   \param[in] lang The language that should be converted.
   *   \return The 3-Char ISO 639-2/T code of lang if that code exists, lang otherwise.
   */
-  CStdString ConvertToISO6392T(const CStdString& lang);
-  static bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool checkWin32Locales = false);
-  static bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool checkXbmcLocales = true, bool checkWin32Locales = false);
+  std::string ConvertToISO6392T(const std::string& lang);
+  static bool ConvertTwoToThreeCharCode(std::string& strThreeCharCode, const std::string& strTwoCharCode, bool checkWin32Locales = false);
+  static bool ConvertToThreeCharCode(std::string& strThreeCharCode, const std::string& strCharCode, bool checkXbmcLocales = true, bool checkWin32Locales = false);
 
 #ifdef TARGET_WINDOWS
-  static bool ConvertLinuxToWindowsRegionCodes(const CStdString& strTwoCharCode, CStdString& strThreeCharCode);
-  static bool ConvertWindowsToGeneralCharCode(const CStdString& strWindowsCharCode, CStdString& strThreeCharCode);
+  static bool ConvertLinuxToWindowsRegionCodes(const std::string& strTwoCharCode, std::string& strThreeCharCode);
+  static bool ConvertWindowsToGeneralCharCode(const std::string& strWindowsCharCode, std::string& strThreeCharCode);
 #endif
 
   void LoadUserCodes(const TiXmlElement* pRootElement);
@@ -93,13 +94,13 @@ protected:
   *   \param[in] code The language code given as a long, see #MAKECODE(a, b, c, d).
   *   \param[out] ret The string representation of the given language code code.
   */ 
-  static void CodeToString(long code, CStdString& ret);
+  static void CodeToString(long code, std::string& ret);
 
-  typedef std::map<CStdString, CStdString> STRINGLOOKUPTABLE;
+  typedef std::map<std::string, std::string> STRINGLOOKUPTABLE;
   STRINGLOOKUPTABLE m_mapUser;
 
-  static bool LookupInDb(CStdString& desc, const CStdString& code);
-  bool LookupInMap(CStdString& desc, const CStdString& code);
+  static bool LookupInDb(std::string& desc, const std::string& code);
+  bool LookupInMap(std::string& desc, const std::string& code);
 
   /** \brief Looks up the ISO 639-1, ISO 639-2/T, or ISO 639-2/B, whichever it finds first,
   *          code of the given english language name.
@@ -107,7 +108,7 @@ protected:
   *   \param[out] code The ISO 639-1, ISO 639-2/T, or ISO 639-2/B code of the given language desc.
   *   \return true if the a code was found, false otherwise.
   */ 
-  bool ReverseLookup(const CStdString& desc, CStdString& code);
+  bool ReverseLookup(const std::string& desc, std::string& code);
 };
 
 extern CLangCodeExpander g_LangCodeExpander;

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -38,14 +38,14 @@
 
 bool CSaveFileStateJob::DoWork()
 {
-  CStdString progressTrackingFile = m_item.GetPath();
+  std::string progressTrackingFile = m_item.GetPath();
 
   if (m_item.HasVideoInfoTag() && StringUtils::StartsWith(m_item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
     progressTrackingFile = m_item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
   else if (m_item.HasProperty("original_listitem_url"))
   {
     // only use original_listitem_url for Python, UPnP and Bluray sources
-    CStdString original = m_item.GetProperty("original_listitem_url").asString();
+    std::string original = m_item.GetProperty("original_listitem_url").asString();
     if (URIUtils::IsPlugin(original) || URIUtils::IsUPnP(original) || URIUtils::IsBluray(m_item.GetPath()))
       progressTrackingFile = original;
   }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -645,11 +645,11 @@ bool StringUtils::EndsWithNoCase(const std::string &str1, const char *s2)
   return true;
 }
 
-CStdString StringUtils::Join(const vector<string> &strings, const CStdString& delimiter)
+std::string StringUtils::Join(const vector<string> &strings, const std::string& delimiter)
 {
-  CStdString result;
+  std::string result;
   for(vector<string>::const_iterator it = strings.begin(); it != strings.end(); it++ )
-    result += (*it) + delimiter.c_str();
+    result += (*it) + delimiter;
   
   if (!result.empty())
     result.erase(result.size() - delimiter.size());
@@ -906,7 +906,7 @@ int StringUtils::asciixdigitvalue(char chr)
 }
 
 
-void StringUtils::RemoveCRLF(CStdString& strLine)
+void StringUtils::RemoveCRLF(std::string& strLine)
 {
   StringUtils::TrimRight(strLine, "\n\r");
 }
@@ -1026,7 +1026,7 @@ int StringUtils::FindEndBracket(const CStdString &str, char opener, char closer,
   return (int)CStdString::npos;
 }
 
-void StringUtils::WordToDigits(CStdString &word)
+void StringUtils::WordToDigits(std::string &word)
 {
   static const char word_to_letter[] = "22233344455566677778889999";
   StringUtils::ToLower(word);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -87,7 +87,7 @@ public:
   static bool EndsWithNoCase(const std::string &str1, const std::string &str2);
   static bool EndsWithNoCase(const std::string &str1, const char *s2);
 
-  static CStdString Join(const std::vector<std::string> &strings, const CStdString& delimiter);
+  static std::string Join(const std::vector<std::string> &strings, const std::string& delimiter);
   /*! \brief Splits the given input string using the given delimiter into separate strings.
 
    If the given input string is empty the result will be an empty array (not
@@ -101,7 +101,7 @@ public:
   static int FindNumber(const CStdString& strInput, const CStdString &strFind);
   static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
   static long TimeStringToSeconds(const CStdString &timeString);
-  static void RemoveCRLF(CStdString& strLine);
+  static void RemoveCRLF(std::string& strLine);
 
   /*! \brief utf8 version of strlen - skips any non-starting bytes in the count, thus returning the number of utf8 characters
    \param s c-string to find the length of.
@@ -162,7 +162,7 @@ public:
   static size_t FindWords(const char *str, const char *wordLowerCase);
   static int FindEndBracket(const CStdString &str, char opener, char closer, int startPos = 0);
   static int DateStringToYYYYMMDD(const CStdString &dateString);
-  static void WordToDigits(CStdString &word);
+  static void WordToDigits(std::string &word);
   static CStdString CreateUUID();
   static bool ValidateUUID(const CStdString &uuid); // NB only validates syntax
   static double CompareFuzzy(const CStdString &left, const CStdString &right);

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -145,7 +145,7 @@ bool CTuxBoxUtil::CreateNewItem(const CFileItem& item, CFileItem& item_new)
   if(g_tuxbox.GetZapUrl(item.GetPath(), item_new))
   {
     if(vVideoSubChannel.mode)
-      vVideoSubChannel.current_name = item_new.GetLabel()+" ("+vVideoSubChannel.current_name+")";
+      vVideoSubChannel.current_name = (CStdString)item_new.GetLabel()+" ("+vVideoSubChannel.current_name+")";
     return true;
   }
   else

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -46,12 +46,12 @@ bool URIUtils::IsInPath(const CStdString &uri, const CStdString &baseURI)
 }
 
 /* returns filename extension including period of filename */
-CStdString URIUtils::GetExtension(const CURL& url)
+std::string URIUtils::GetExtension(const CURL& url)
 {
   return URIUtils::GetExtension(url.GetFileName());
 }
 
-CStdString URIUtils::GetExtension(const CStdString& strFileName)
+std::string URIUtils::GetExtension(const std::string& strFileName)
 {
   if (IsURL(strFileName))
   {
@@ -116,7 +116,7 @@ bool URIUtils::HasExtension(const CStdString& strFileName, const CStdString& str
   return false;
 }
 
-void URIUtils::RemoveExtension(CStdString& strFileName)
+void URIUtils::RemoveExtension(std::string& strFileName)
 {
   if(IsURL(strFileName))
   {
@@ -197,15 +197,6 @@ const CStdString URIUtils::GetFileName(const CStdString& strFileNameAndPath)
   return strFileNameAndPath.substr(slash+1);
 }
 
-void URIUtils::Split(const CStdString& strFileNameAndPath,
-                     CStdString& strPath, CStdString& strFileName)
-{
-  std::string strPathT, strFileNameT;
-  Split(strFileNameAndPath, strPathT, strFileNameT);
-  strPath = strPathT;
-  strFileName = strFileNameT;
-}
-
 void URIUtils::Split(const std::string& strFileNameAndPath,
                      std::string& strPath, std::string& strFileName)
 {
@@ -254,7 +245,7 @@ std::vector<std::string> URIUtils::SplitPath(const CStdString& strPath)
   return dirs;
 }
 
-void URIUtils::GetCommonPath(CStdString& strParent, const CStdString& strPath)
+void URIUtils::GetCommonPath(std::string& strParent, const std::string& strPath)
 {
   // find the common path of parent and path
   unsigned int j = 1;
@@ -294,19 +285,19 @@ bool URIUtils::HasEncodedFilename(const CURL& url)
          CURL::IsProtocolEqual(prot2, "https");
 }
 
-CStdString URIUtils::GetParentPath(const CStdString& strPath)
+std::string URIUtils::GetParentPath(const std::string& strPath)
 {
-  CStdString strReturn;
+  std::string strReturn;
   GetParentPath(strPath, strReturn);
   return strReturn;
 }
 
-bool URIUtils::GetParentPath(const CStdString& strPath, CStdString& strParent)
+bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
 {
-  strParent = "";
+  strParent.clear();
 
   CURL url(strPath);
-  CStdString strFile = url.GetFileName();
+  std::string strFile = url.GetFileName();
   if ( URIUtils::HasParentInHostname(url) && strFile.empty())
   {
     strFile = url.GetHostName();

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -514,7 +514,7 @@ bool URIUtils::IsRemote(const CStdString& strFile)
 
   if(IsMultiPath(strFile))
   { // virtual paths need to be checked separately
-    vector<CStdString> paths;
+    vector<std::string> paths;
     if (CMultiPathDirectory::GetPaths(strFile, paths))
     {
       for (unsigned int i = 0; i < paths.size(); i++)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1200,17 +1200,6 @@ CURL URIUtils::CreateArchivePath(const std::string& type,
   return url;
 }
 
-void URIUtils::CreateArchivePath(CStdString& strUrlPath,
-                                 const CStdString& strType,
-                                 const CStdString& strArchivePath,
-                                 const CStdString& strFilePathInArchive,
-                                 const CStdString& strPwd)
-{
-  const CURL pathToUrl(strArchivePath);
-  CURL url(CreateArchivePath(strType, pathToUrl, strFilePathInArchive, strPwd));
-  strUrlPath = url.Get();
-}
-
 string URIUtils::GetRealPath(const string &path)
 {
   if (path.empty())

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -35,8 +35,8 @@ public:
   static const CStdString GetFileName(const CURL& url);
   static const CStdString GetFileName(const CStdString& strFileNameAndPath);
 
-  static CStdString GetExtension(const CURL& url);
-  static CStdString GetExtension(const CStdString& strFileName);
+  static std::string GetExtension(const CURL& url);
+  static std::string GetExtension(const std::string& strFileName);
 
   /*!
    \brief Check if there is a file extension
@@ -60,18 +60,16 @@ public:
   static bool HasExtension(const CStdString& strFileName, const CStdString& strExtensions);
   static bool HasExtension(const CURL& url, const CStdString& strExtensions);
 
-  static void RemoveExtension(CStdString& strFileName);
+  static void RemoveExtension(std::string& strFileName);
   static CStdString ReplaceExtension(const CStdString& strFile,
                                      const CStdString& strNewExtension);
-  static void Split(const CStdString& strFileNameAndPath, 
-                    CStdString& strPath, CStdString& strFileName);
   static void Split(const std::string& strFileNameAndPath, 
                     std::string& strPath, std::string& strFileName);
   static std::vector<std::string> SplitPath(const CStdString& strPath);
 
-  static void GetCommonPath(CStdString& strPath, const CStdString& strPath2);
-  static CStdString GetParentPath(const CStdString& strPath);
-  static bool GetParentPath(const CStdString& strPath, CStdString& strParent);
+  static void GetCommonPath(std::string& strPath, const std::string& strPath2);
+  static std::string GetParentPath(const std::string& strPath);
+  static bool GetParentPath(const std::string& strPath, std::string& strParent);
 
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -183,12 +183,6 @@ public:
                                 const std::string& pathInArchive = "",
                                 const std::string& password = "");
 
-  static void CreateArchivePath(CStdString& strUrlPath,
-                                const CStdString& strType,
-                                const CStdString& strArchivePath,
-                                const CStdString& strFilePathInArchive,
-                                const CStdString& strPwd="");
-
   static CStdString AddFileToFolder(const CStdString &strFolder, const CStdString &strFile);
 
   static bool HasParentInHostname(const CURL& url);

--- a/xbmc/utils/md5.cpp
+++ b/xbmc/utils/md5.cpp
@@ -42,7 +42,7 @@ void XBMC::XBMC_MD5::append(const void *inBuf, size_t inLen)
   MD5Update(&m_ctx, (md5byte*)inBuf, inLen);
 }
 
-void XBMC::XBMC_MD5::append(const CStdString& str)
+void XBMC::XBMC_MD5::append(const std::string& str)
 {
   append((unsigned char*) str.c_str(), (unsigned int) str.length());
 }
@@ -52,7 +52,7 @@ void XBMC::XBMC_MD5::getDigest(unsigned char digest[16])
   MD5Final(digest, &m_ctx);
 }
 
-void XBMC::XBMC_MD5::getDigest(CStdString& digest)
+void XBMC::XBMC_MD5::getDigest(std::string& digest)
 {
   unsigned char szBuf[16] = {'\0'};
   getDigest(szBuf);
@@ -64,12 +64,12 @@ void XBMC::XBMC_MD5::getDigest(CStdString& digest)
                                szBuf[15]);
 }
 
-CStdString XBMC::XBMC_MD5::GetMD5(const CStdString &text)
+std::string XBMC::XBMC_MD5::GetMD5(const std::string &text)
 {
   if (text.empty())
     return "";
   XBMC_MD5 state;
-  CStdString digest;
+  std::string digest;
   state.append(text);
   state.getDigest(digest);
   return digest;

--- a/xbmc/utils/md5.h
+++ b/xbmc/utils/md5.h
@@ -19,9 +19,10 @@
  */
 
 #ifndef _MD5_H_
-#define _MD5_H_ 1
+#define _MD5_H_
 
-#include "StdString.h"
+#include <string>
+#include <stdint.h>
 
 struct MD5Context {
 	uint32_t buf[4];
@@ -37,15 +38,15 @@ namespace XBMC
     XBMC_MD5(void);
     ~XBMC_MD5(void);
     void append(const void *inBuf, size_t inLen);
-    void append(const CStdString& str);
+    void append(const std::string& str);
     void getDigest(unsigned char digest[16]);
-    void getDigest(CStdString& digest);
+    void getDigest(std::string& digest);
     
     /*! \brief Get the MD5 digest of the given text
      \param text text to compute the MD5 for
      \return MD5 digest
      */
-    static CStdString GetMD5(const CStdString &text);
+    static std::string GetMD5(const std::string &text);
 private:
     MD5Context m_ctx;
   };

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -24,7 +24,7 @@
 
 TEST(TestLangCodeExpander, ConvertTwoToThreeCharCode)
 {
-  CStdString refstr, varstr;
+  std::string refstr, varstr;
 
   refstr = "eng";
   g_LangCodeExpander.ConvertTwoToThreeCharCode(varstr, "en");
@@ -33,7 +33,7 @@ TEST(TestLangCodeExpander, ConvertTwoToThreeCharCode)
 
 TEST(TestLangCodeExpander, ConvertToThreeCharCode)
 {
-  CStdString refstr, varstr;
+  std::string refstr, varstr;
 
   refstr = "eng";
   g_LangCodeExpander.ConvertToThreeCharCode(varstr, "en");

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -25,6 +25,7 @@
 
 #include "utils/RegExp.h"
 #include "utils/log.h"
+#include "utils/StdString.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 
@@ -155,7 +156,7 @@ TEST_F(TestRegExpLog, DumpOvector)
   XFILE::CFile file;
 
   logfile = CSpecialProtocol::TranslatePath("special://temp/") + "xbmc.log";
-  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/")));
+  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 
   EXPECT_TRUE(regex.RegComp("^(?<first>Test)\\s*(?<second>.*)\\."));

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -393,7 +393,7 @@ TEST(TestStringUtils, DateStringToYYYYMMDD)
 
 TEST(TestStringUtils, WordToDigits)
 {
-  CStdString ref, var;
+  std::string ref, var;
 
   ref = "8378 787464";
   var = "test string";

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -494,7 +494,7 @@ TEST_F(TestURIUtils, CreateArchivePath)
   CStdString ref, var;
 
   ref = "zip://%2fpath%2fto%2f/file";
-  URIUtils::CreateArchivePath(var, "zip", "/path/to/", "file");
+  var = URIUtils::CreateArchivePath("zip", CURL("/path/to/"), "file").Get();
   EXPECT_STREQ(ref.c_str(), var.c_str());
 }
 

--- a/xbmc/utils/test/TestXBMCTinyXML.cpp
+++ b/xbmc/utils/test/TestXBMCTinyXML.cpp
@@ -52,7 +52,7 @@ TEST(TestXBMCTinyXML, ParseFromFileHandle)
   bool retval = false;
   // scraper results with unescaped &
   CXBMCTinyXML doc;
-  FILE *f = fopen(XBMC_REF_FILE_PATH("/xbmc/utils/test/CXBMCTinyXML-test.xml"), "r");
+  FILE *f = fopen(XBMC_REF_FILE_PATH("/xbmc/utils/test/CXBMCTinyXML-test.xml").c_str(), "r");
   ASSERT_TRUE(f);
   doc.LoadFile(f);
   fclose(f);

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -22,6 +22,7 @@
 #include "utils/RegExp.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
+#include "utils/StdString.h"
 
 #include "test/TestUtils.h"
 
@@ -50,7 +51,7 @@ TEST_F(Testlog, Log)
   CRegExp regex;
 
   logfile = CSpecialProtocol::TranslatePath("special://temp/") + "xbmc.log";
-  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/")));
+  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 
   CLog::Log(LOGDEBUG, "debug log message");
@@ -104,7 +105,7 @@ TEST_F(Testlog, MemDump)
   char refdata[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
   logfile = CSpecialProtocol::TranslatePath("special://temp/") + "xbmc.log";
-  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/")));
+  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 
   CLog::MemDump(refdata, sizeof(refdata));
@@ -136,7 +137,7 @@ TEST_F(Testlog, SetLogLevel)
   CStdString logfile;
 
   logfile = CSpecialProtocol::TranslatePath("special://temp/") + "xbmc.log";
-  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/")));
+  EXPECT_TRUE(CLog::Init(CSpecialProtocol::TranslatePath("special://temp/").c_str()));
   EXPECT_TRUE(XFILE::CFile::Exists(logfile));
 
   EXPECT_EQ(LOG_LEVEL_DEBUG, CLog::GetLogLevel());

--- a/xbmc/utils/test/Testmd5.cpp
+++ b/xbmc/utils/test/Testmd5.cpp
@@ -25,7 +25,7 @@
 TEST(Testmd5, ZeroLengthString)
 {
   XBMC::XBMC_MD5 a;
-  CStdString refdigest, vardigest;
+  std::string refdigest, vardigest;
 
   refdigest = "D41D8CD98F00B204E9800998ECF8427E";
   a.append("");
@@ -36,7 +36,7 @@ TEST(Testmd5, ZeroLengthString)
 TEST(Testmd5, String1)
 {
   XBMC::XBMC_MD5 a;
-  CStdString refdigest, vardigest;
+  std::string refdigest, vardigest;
 
   refdigest = "9E107D9D372BB6826BD81D3542A419D6";
   a.append("The quick brown fox jumps over the lazy dog");
@@ -47,7 +47,7 @@ TEST(Testmd5, String1)
 TEST(Testmd5, String2)
 {
   XBMC::XBMC_MD5 a;
-  CStdString refdigest, vardigest;
+  std::string refdigest, vardigest;
 
   refdigest = "E4D909C290D0FB1CA068FFADDF22CBD0";
   a.append("The quick brown fox jumps over the lazy dog.");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4188,7 +4188,7 @@ void CVideoDatabase::RemoveContentForPath(const CStdString& strPath, CGUIDialogP
 {
   if(URIUtils::IsMultiPath(strPath))
   {
-    vector<CStdString> paths;
+    vector<std::string> paths;
     CMultiPathDirectory::GetPaths(strPath, paths);
 
     for(unsigned i=0;i<paths.size();i++)
@@ -4269,7 +4269,7 @@ void CVideoDatabase::SetScraperForPath(const CStdString& filePath, const Scraper
   // if we have a multipath, set scraper for all contained paths
   if(URIUtils::IsMultiPath(filePath))
   {
-    vector<CStdString> paths;
+    vector<std::string> paths;
     CMultiPathDirectory::GetPaths(filePath, paths);
 
     for(unsigned i=0;i<paths.size();i++)
@@ -4654,7 +4654,7 @@ bool CVideoDatabase::GetPlayCounts(const CStdString &strPath, CFileItemList &ite
 {
   if(URIUtils::IsMultiPath(strPath))
   {
-    vector<CStdString> paths;
+    vector<std::string> paths;
     CMultiPathDirectory::GetPaths(strPath, paths);
 
     bool ret = false;
@@ -9219,7 +9219,7 @@ bool CVideoDatabase::GetItemsForPath(const CStdString &content, const CStdString
   
   if(URIUtils::IsMultiPath(path))
   {
-    vector<CStdString> paths;
+    vector<std::string> paths;
     CMultiPathDirectory::GetPaths(path, paths);
 
     for(unsigned i=0;i<paths.size();i++)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5861,7 +5861,7 @@ bool CVideoDatabase::GetSeasonsByWhere(const CStdString& strBaseDir, const Filte
         if (iSeason == 0)
           strLabel = g_localizeStrings.Get(20381);
         else
-          strLabel = StringUtils::Format(g_localizeStrings.Get(20358), iSeason);
+          strLabel = StringUtils::Format(g_localizeStrings.Get(20358).c_str(), iSeason);
         CFileItemPtr pItem(new CFileItem(strLabel));
 
         CVideoDbUrl itemUrl = videoUrl;
@@ -8220,7 +8220,7 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
           {
             CURL sourceUrl(sourcePath);
             pDialog->SetHeading(15012);
-            pDialog->SetText(StringUtils::Format(g_localizeStrings.Get(15013), sourceUrl.GetWithoutUserDetails().c_str()));
+            pDialog->SetText(StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str()));
             pDialog->SetChoice(0, 15015);
             pDialog->SetChoice(1, 15014);
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -684,7 +684,7 @@ int CVideoDatabase::AddPath(const CStdString& strPath, const CStdString &parentP
 
     URIUtils::AddSlashAtEnd(strPath1);
 
-    int idParentPath = GetPathId(parentPath.empty() ? URIUtils::GetParentPath(strPath1) : parentPath);
+    int idParentPath = GetPathId(parentPath.empty() ? (CStdString)URIUtils::GetParentPath(strPath1) : parentPath);
 
     // add the path
     if (idParentPath < 0)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8553,7 +8553,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
       {
         if (!singleFiles)
         {
-          CStdString strFileName(StringUtils::Join(movie.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + movie.m_strTitle);
+          CStdString strFileName((CStdString)StringUtils::Join(movie.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + movie.m_strTitle);
           if (movie.m_iYear > 0)
             strFileName += StringUtils::Format("_%i", movie.m_iYear);
           item.SetPath(GetSafeFile(moviesDir, strFileName) + ".avi");
@@ -8965,7 +8965,7 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
         info.Load(movie);
         CFileItem item(info);
         bool useFolders = info.m_basePath.empty() ? LookupByFolders(item.GetPath()) : false;
-        CStdString filename = StringUtils::Join(info.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + info.m_strTitle;
+        CStdString filename = (CStdString)StringUtils::Join(info.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + info.m_strTitle;
         if (info.m_iYear > 0)
           filename += StringUtils::Format("_%i", info.m_iYear);
         CFileItem artItem(item);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -261,7 +261,7 @@ namespace VIDEO
       if (m_handle)
       {
         int str = content == CONTENT_MOVIES ? 20317:20318;
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str), info->Name().c_str()));
+        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str).c_str(), info->Name().c_str()));
       }
 
       CStdString fastHash = GetFastHash(strDirectory, regexps);
@@ -306,7 +306,7 @@ namespace VIDEO
     else if (content == CONTENT_TVSHOWS)
     {
       if (m_handle)
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319), info->Name().c_str()));
+        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
 
       if (foundDirectly && !settings.parent_name_root)
       {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -446,15 +446,15 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   value["originaltitle"] = m_strOriginalTitle;
   value["sorttitle"] = m_strSortTitle;
   value["episodeguide"] = m_strEpisodeGuide;
-  value["premiered"] = m_premiered.IsValid() ? m_premiered.GetAsDBDate() : StringUtils::EmptyString;
+  value["premiered"] = m_premiered.IsValid() ? m_premiered.GetAsDBDate() : StringUtils::Empty;
   value["status"] = m_strStatus;
   value["productioncode"] = m_strProductionCode;
-  value["firstaired"] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : StringUtils::EmptyString;
+  value["firstaired"] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : StringUtils::Empty;
   value["showtitle"] = m_strShowTitle;
   value["album"] = m_strAlbum;
   value["artist"] = m_artist;
   value["playcount"] = m_playCount;
-  value["lastplayed"] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::EmptyString;
+  value["lastplayed"] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::Empty;
   value["top250"] = m_iTop250;
   value["year"] = m_iYear;
   value["season"] = m_iSeason;
@@ -471,7 +471,7 @@ void CVideoInfoTag::Serialize(CVariant& value) const
   resume["total"] = (float)m_resumePoint.totalTimeInSeconds;
   value["resume"] = resume;
   value["tvshowid"] = m_iIdShow;
-  value["dateadded"] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::EmptyString;
+  value["dateadded"] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::Empty;
   value["type"] = m_type;
   value["seasonid"] = m_iIdSeason;
   value["specialsortseason"] = m_iSpecialSortSeason;
@@ -515,12 +515,12 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
   case FieldSortTitle:                sortable[FieldSortTitle] = m_strSortTitle; break;
   case FieldTvShowStatus:             sortable[FieldTvShowStatus] = m_strStatus; break;
   case FieldProductionCode:           sortable[FieldProductionCode] = m_strProductionCode; break;
-  case FieldAirDate:                  sortable[FieldAirDate] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : (m_premiered.IsValid() ? m_premiered.GetAsDBDate() : StringUtils::EmptyString); break;
+  case FieldAirDate:                  sortable[FieldAirDate] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : (m_premiered.IsValid() ? m_premiered.GetAsDBDate() : StringUtils::Empty); break;
   case FieldTvShowTitle:              sortable[FieldTvShowTitle] = m_strShowTitle; break;
   case FieldAlbum:                    sortable[FieldAlbum] = m_strAlbum; break;
   case FieldArtist:                   sortable[FieldArtist] = m_artist; break;
   case FieldPlaycount:                sortable[FieldPlaycount] = m_playCount; break;
-  case FieldLastPlayed:               sortable[FieldLastPlayed] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::EmptyString; break;
+  case FieldLastPlayed:               sortable[FieldLastPlayed] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::Empty; break;
   case FieldTop250:                   sortable[FieldTop250] = m_iTop250; break;
   case FieldYear:                     sortable[FieldYear] = m_iYear; break;
   case FieldSeason:                   sortable[FieldSeason] = m_iSeason; break;
@@ -544,7 +544,7 @@ void CVideoInfoTag::ToSortable(SortItem& sortable, Field field) const
   case FieldSubtitleLanguage:         sortable[FieldSubtitleLanguage] = m_streamDetails.GetSubtitleLanguage(); break;
 
   case FieldInProgress:               sortable[FieldInProgress] = m_resumePoint.IsPartWay(); break;
-  case FieldDateAdded:                sortable[FieldDateAdded] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::EmptyString; break;
+  case FieldDateAdded:                sortable[FieldDateAdded] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::Empty; break;
   case FieldMediaType:                sortable[FieldMediaType] = m_type; break;
   default: break;
   }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -536,7 +536,7 @@ void CGUIDialogVideoInfo::DoSearch(CStdString& strSearch, CFileItemList& items)
   db.GetMusicVideosByArtist(strSearch, movies);
   for (int i = 0; i < movies.Size(); ++i)
   {
-    CStdString label = StringUtils::Join(movies[i]->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator) + " - " + movies[i]->GetVideoInfoTag()->m_strTitle;
+    CStdString label = (CStdString)StringUtils::Join(movies[i]->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator) + " - " + movies[i]->GetVideoInfoTag()->m_strTitle;
     if (movies[i]->GetVideoInfoTag()->m_iYear > 0)
       label += StringUtils::Format(" (%i)", movies[i]->GetVideoInfoTag()->m_iYear);
     movies[i]->SetLabel(label);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -192,7 +192,7 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
       if (IsActive() && message.GetParam1() == GUI_MSG_UPDATE_ITEM && message.GetItem())
       {
         CFileItemPtr item = boost::static_pointer_cast<CFileItem>(message.GetItem());
-        if (item && m_movieItem->GetPath().Equals(item->GetPath()))
+        if (item && m_movieItem->IsPath(item->GetPath()))
         { // Just copy over the stream details and the thumb if we don't already have one
           if (!m_movieItem->HasArt("thumb"))
             m_movieItem->SetArt("thumb", item->GetArt("thumb"));
@@ -973,7 +973,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
   }
   else
   {
-    if (item->GetOverlayImage().Equals("OverlayWatched.png"))
+    if (item->GetOverlayImage() == "OverlayWatched.png")
       buttons.Add(CONTEXT_BUTTON_MARK_UNWATCHED, 16104); //Mark as UnWatched
     else
       buttons.Add(CONTEXT_BUTTON_MARK_WATCHED, 16103);   //Mark as Watched

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1012,8 +1012,8 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
     {
       const std::string &mediaType = videoUrl.GetItemType();
 
-      buttons.Add(CONTEXT_BUTTON_TAGS_ADD_ITEMS, StringUtils::Format(g_localizeStrings.Get(20460), GetLocalizedVideoType(mediaType).c_str()));
-      buttons.Add(CONTEXT_BUTTON_TAGS_REMOVE_ITEMS, StringUtils::Format(g_localizeStrings.Get(20461), GetLocalizedVideoType(mediaType).c_str()));
+      buttons.Add(CONTEXT_BUTTON_TAGS_ADD_ITEMS, StringUtils::Format(g_localizeStrings.Get(20460).c_str(), GetLocalizedVideoType(mediaType).c_str()));
+      buttons.Add(CONTEXT_BUTTON_TAGS_REMOVE_ITEMS, StringUtils::Format(g_localizeStrings.Get(20461).c_str(), GetLocalizedVideoType(mediaType).c_str()));
     }
   }
 
@@ -1257,7 +1257,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
   }
   else
   {
-    pDialog->SetLine(0, StringUtils::Format(g_localizeStrings.Get(433), item->GetLabel().c_str()));
+    pDialog->SetLine(0, StringUtils::Format(g_localizeStrings.Get(433).c_str(), item->GetLabel().c_str()));
     pDialog->SetLine(1, "");
   }
   pDialog->SetLine(2, "");
@@ -1402,7 +1402,7 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
   if (!videodb.Open())
     return false;
 
-  CStdString strHeading = StringUtils::Format(g_localizeStrings.Get(20457));
+  CStdString strHeading = g_localizeStrings.Get(20457);
   CStdString baseDir = StringUtils::Format("videodb://movies/sets/%d", setItem->GetVideoInfoTag()->m_iDbId);
 
   if (!CDirectory::GetDirectory(baseDir, originalMovies) || originalMovies.Size() <= 0) // keep a copy of the original members of the set
@@ -1474,12 +1474,12 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
   if (currentSetId > 0)
   {
     // add clear item
-    CStdString strClear = StringUtils::Format(g_localizeStrings.Get(20467), currentSetLabel.c_str());
+    CStdString strClear = StringUtils::Format(g_localizeStrings.Get(20467).c_str(), currentSetLabel.c_str());
     CFileItemPtr clearItem(new CFileItem(strClear));
     clearItem->GetVideoInfoTag()->m_iDbId = -1; // -1 will be used to clear set
     listItems.AddFront(clearItem, 0);
     // add keep current set item
-    CStdString strKeep = StringUtils::Format(g_localizeStrings.Get(20469), currentSetLabel.c_str());
+    CStdString strKeep = StringUtils::Format(g_localizeStrings.Get(20469).c_str(), currentSetLabel.c_str());
     CFileItemPtr keepItem(new CFileItem(strKeep));
     keepItem->GetVideoInfoTag()->m_iDbId = currentSetId;
     listItems.AddFront(keepItem, 1);
@@ -1489,7 +1489,7 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
   if (dialog == NULL)
     return false;
 
-  CStdString strHeading = StringUtils::Format(g_localizeStrings.Get(20466));
+  CStdString strHeading = g_localizeStrings.Get(20466);
   dialog->Reset();
   dialog->SetHeading(strHeading);
   dialog->SetItems(&listItems);
@@ -1628,7 +1628,7 @@ bool CGUIDialogVideoInfo::AddItemsToTag(const CFileItemPtr &tagItem)
 
   CFileItemList items;
   std::string localizedType = GetLocalizedVideoType(mediaType);
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType.c_str());
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464).c_str(), localizedType.c_str());
   if (!GetItemsForTag(strLabel, mediaType, items, tagItem->GetVideoInfoTag()->m_iDbId))
     return true;
 
@@ -1661,7 +1661,7 @@ bool CGUIDialogVideoInfo::RemoveItemsFromTag(const CFileItemPtr &tagItem)
 
   CFileItemList items;
   std::string localizedType = GetLocalizedVideoType(mediaType);
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType.c_str());
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464).c_str(), localizedType.c_str());
   if (!GetItemsForTag(strLabel, mediaType, items, tagItem->GetVideoInfoTag()->m_iDbId, false))
     return true;
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -639,7 +639,7 @@ void CGUIWindowFullScreen::FrameMove()
       float xscale = (float)res.iScreenWidth  / (float)res.iWidth;
       float yscale = (float)res.iScreenHeight / (float)res.iHeight;
 
-      CStdString strSizing = StringUtils::Format(g_localizeStrings.Get(245),
+      CStdString strSizing = StringUtils::Format(g_localizeStrings.Get(245).c_str(),
                                                  (int)info.SrcRect.Width(),
                                                  (int)info.SrcRect.Height(),
                                                  (int)(info.DestRect.Width() * xscale),

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1648,7 +1648,7 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
     CFileUtils::DeleteItem(item);
 }
 
-void CGUIWindowVideoBase::LoadPlayList(const CStdString& strPlayList, int iPlayList /* = PLAYLIST_VIDEO */)
+void CGUIWindowVideoBase::LoadPlayList(const std::string& strPlayList, int iPlayList /* = PLAYLIST_VIDEO */)
 {
   // if partymode is active, we disable it
   if (g_partyModeManager.IsEnabled())
@@ -1718,7 +1718,7 @@ void CGUIWindowVideoBase::PlayItem(int iItem)
   }
 }
 
-bool CGUIWindowVideoBase::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowVideoBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -1733,7 +1733,7 @@ bool CGUIWindowVideoBase::Update(const CStdString &strDirectory, bool updateFilt
   return true;
 }
 
-bool CGUIWindowVideoBase::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   bool bResult = CGUIMediaWindow::GetDirectory(strDirectory, items);
 
@@ -1828,9 +1828,9 @@ bool CGUIWindowVideoBase::CheckFilterAdvanced(CFileItemList &items) const
   return false;
 }
 
-bool CGUIWindowVideoBase::CanContainFilter(const CStdString &strDirectory) const
+bool CGUIWindowVideoBase::CanContainFilter(const std::string &strDirectory) const
 {
-  return StringUtils::StartsWithNoCase(strDirectory, "videodb://");
+  return URIUtils::IsProtocol(strDirectory, "videodb://");
 }
 
 void CGUIWindowVideoBase::AddToDatabase(int iItem)
@@ -2035,11 +2035,12 @@ void CGUIWindowVideoBase::OnScan(const CStdString& strPath, bool scanAll)
     g_application.StartVideoScan(strPath, scanAll);
 }
 
-CStdString CGUIWindowVideoBase::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowVideoBase::GetStartFolder(const std::string &dir)
 {
-  if (dir.Equals("$PLAYLISTS") || dir.Equals("Playlists"))
+  std::string lower(dir); StringUtils::ToLower(lower);
+  if (lower == "$playlists" || lower == "playlists")
     return "special://videoplaylists/";
-  else if (dir.Equals("Plugins") || dir.Equals("Addons"))
+  else if (lower == "plugins" || lower == "addons")
     return "addons://sources/video/";
   return CGUIMediaWindow::GetStartFolder(dir);
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -525,7 +525,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
     if (!hasDetails && (scrUrl.m_url.size() == 0 || needsRefresh))
     {
       // 4a. show dialog that we're busy querying www.imdb.com
-      CStdString strHeading = StringUtils::Format(g_localizeStrings.Get(197),info->Name().c_str());
+      CStdString strHeading = StringUtils::Format(g_localizeStrings.Get(197).c_str(),info->Name().c_str());
       pDlgProgress->SetHeading(strHeading);
       pDlgProgress->SetLine(0, movieName);
       pDlgProgress->SetLine(1, "");

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -225,7 +225,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
               OnDeleteItem(iItem);
 
             // or be at the video playlists location
-            else if (m_vecItems->GetPath().Equals("special://videoplaylists/"))
+            else if (m_vecItems->IsPath("special://videoplaylists/"))
               OnDeleteItem(iItem);
             else
               return false;
@@ -271,7 +271,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
   if (!pItem)
     return;
 
-  if (pItem->IsParentFolder() || pItem->m_bIsShareOrDrive || pItem->GetPath().Equals("add") ||
+  if (pItem->IsParentFolder() || pItem->m_bIsShareOrDrive || pItem->IsPath("add") ||
      (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
     return;
 
@@ -996,7 +996,7 @@ bool CGUIWindowVideoBase::OnInfo(int iItem)
 
   CFileItemPtr item = m_vecItems->Get(iItem);
 
-  if (item->GetPath().Equals("add") || item->IsParentFolder() ||
+  if (item->IsPath("add") || item->IsParentFolder() ||
      (item->IsPlayList() && !URIUtils::HasExtension(item->GetPath(), ".strm")))
     return false;
 
@@ -1215,7 +1215,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       if (item->IsVideoDb() && item->HasVideoInfoTag())
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
-      if (!item->GetPath().Equals("add") && !item->IsPlugin() &&
+      if (!item->IsPath("add") && !item->IsPlugin() &&
           !item->IsScript() && !item->IsAddonsPath() && !item->IsLiveTV())
       {
         if (URIUtils::IsStack(path))
@@ -1643,7 +1643,7 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
   }
 
   if ((CSettings::Get().GetBool("filelists.allowfiledeletion") ||
-       m_vecItems->GetPath().Equals("special://videoplaylists/")) &&
+       m_vecItems->IsPath("special://videoplaylists/")) &&
       CUtil::SupportsWriteFileOperations(item->GetPath()))
     CFileUtils::DeleteItem(item);
 }
@@ -1798,7 +1798,7 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
     CVideoDatabaseDirectory dir;
     dir.GetQueryParams(items.GetPath(), params);
     VIDEODATABASEDIRECTORY::NODE_TYPE nodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_strFilterPath);
-    if (items.GetContent().Equals("movies") && params.GetSetId() <= 0 &&
+    if (items.GetContent() == "movies" && params.GetSetId() <= 0 &&
         nodeType == NODE_TYPE_TITLE_MOVIES &&
        (CSettings::Get().GetBool("videolibrary.groupmoviesets") || (StringUtils::EqualsNoCase(group, "sets") && mixed)))
     {
@@ -2051,7 +2051,7 @@ void CGUIWindowVideoBase::AppendAndClearSearchItems(CFileItemList &searchItems, 
 
   searchItems.Sort(SortByLabel, SortOrderAscending, CSettings::Get().GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
   for (int i = 0; i < searchItems.Size(); i++)
-    searchItems[i]->SetLabel(prependLabel + searchItems[i]->GetLabel());
+    searchItems[i]->SetLabel(prependLabel + (CStdString)searchItems[i]->GetLabel());
   results.Append(searchItems);
 
   searchItems.Clear();

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -93,13 +93,13 @@ protected:
   void OnScan(const CStdString& strPath, bool scanAll = false);
   virtual void OnInitWindow();
   virtual void UpdateButtons();
-  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void OnItemLoaded(CFileItem* pItem) {};
   virtual void GetGroupedItems(CFileItemList &items);
 
   virtual bool CheckFilterAdvanced(CFileItemList &items) const;
-  virtual bool CanContainFilter(const CStdString &strDirectory) const;
+  virtual bool CanContainFilter(const std::string &strDirectory) const;
 
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
@@ -107,7 +107,7 @@ protected:
   virtual void OnDeleteItem(CFileItemPtr pItem);
   virtual void OnDeleteItem(int iItem);
   virtual void DoSearch(const CStdString& strSearch, CFileItemList& items) {};
-  virtual CStdString GetStartFolder(const CStdString &dir);
+  virtual std::string GetStartFolder(const std::string &dir);
 
   bool OnClick(int iItem);
   bool OnSelect(int iItem);
@@ -128,7 +128,7 @@ protected:
   void PlayItem(int iItem);
   virtual bool OnPlayMedia(int iItem);
   virtual bool OnPlayAndQueueMedia(const CFileItemPtr &item);
-  void LoadPlayList(const CStdString& strPlayList, int iPlayList = PLAYLIST_VIDEO);
+  void LoadPlayList(const std::string& strPlayList, int iPlayList = PLAYLIST_VIDEO);
 
   bool ShowIMDB(CFileItem *item, const ADDON::ScraperPtr& content, bool fromDB);
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -268,7 +268,7 @@ CStdString CGUIWindowVideoNav::GetQuickpathName(const CStdString& strPath) const
   }
 }
 
-bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
@@ -588,7 +588,7 @@ void CGUIWindowVideoNav::UpdateButtons()
   CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsAddonsPath() && !m_vecItems->IsPlugin() && !m_vecItems->IsScript());
 }
 
-bool CGUIWindowVideoNav::GetFilteredItems(const CStdString &filter, CFileItemList &items)
+bool CGUIWindowVideoNav::GetFilteredItems(const std::string &filter, CFileItemList &items)
 {
   bool listchanged = CGUIMediaWindow::GetFilteredItems(filter, items);
   listchanged |= ApplyWatchedFilter(items);
@@ -1087,67 +1087,68 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
   return CGUIWindowVideoBase::OnClick(iItem);
 }
 
-CStdString CGUIWindowVideoNav::GetStartFolder(const CStdString &dir)
+std::string CGUIWindowVideoNav::GetStartFolder(const std::string &dir)
 {
-  if (dir.Equals("MovieGenres"))
+  std::string lower(dir); StringUtils::ToLower(lower);
+  if (lower == "moviegenres")
     return "videodb://movies/genres/";
-  else if (dir.Equals("MovieTitles"))
+  else if (lower == "movietitles")
     return "videodb://movies/titles/";
-  else if (dir.Equals("MovieYears"))
+  else if (lower == "movieyears")
     return "videodb://movies/years/";
-  else if (dir.Equals("MovieActors"))
+  else if (lower == "movieactors")
     return "videodb://movies/actors/";
-  else if (dir.Equals("MovieDirectors"))
+  else if (lower == "moviedirectors")
     return "videodb://movies/directors/";
-  else if (dir.Equals("MovieStudios"))
+  else if (lower == "moviestudios")
     return "videodb://movies/studios/";
-  else if (dir.Equals("MovieSets"))
+  else if (lower == "moviesets")
     return "videodb://movies/sets/";
-  else if (dir.Equals("MovieCountries"))
+  else if (lower == "moviecountries")
     return "videodb://movies/countries/";
-  else if (dir.Equals("MovieTags"))
+  else if (lower == "movietags")
     return "videodb://movies/tags/";
-  else if (dir.Equals("Movies"))
+  else if (lower == "movies")
     return "videodb://movies/";
-  else if (dir.Equals("TvShowGenres"))
+  else if (lower == "tvshowgenres")
     return "videodb://tvshows/genres/";
-  else if (dir.Equals("TvShowTitles"))
+  else if (lower == "tvshowtitles")
     return "videodb://tvshows/titles/";
-  else if (dir.Equals("TvShowYears"))
+  else if (lower == "tvshowyears")
     return "videodb://tvshows/years/";
-  else if (dir.Equals("TvShowActors"))
+  else if (lower == "tvshowactors")
     return "videodb://tvshows/actors/";
-  else if (dir.Equals("TvShowStudios"))
+  else if (lower == "tvshowstudios")
     return "videodb://tvshows/studios/";
-  else if (dir.Equals("TvShowTags"))
+  else if (lower == "tvshowtags")
     return "videodb://tvshows/tags/";
-  else if (dir.Equals("TvShows"))
+  else if (lower == "tvshows")
     return "videodb://tvshows/";
-  else if (dir.Equals("MusicVideoGenres"))
+  else if (lower == "musicvideogenres")
     return "videodb://musicvideos/genres/";
-  else if (dir.Equals("MusicVideoTitles"))
+  else if (lower == "musicvideotitles")
     return "videodb://musicvideos/titles/";
-  else if (dir.Equals("MusicVideoYears"))
+  else if (lower == "musicvideoyears")
     return "videodb://musicvideos/years/";
-  else if (dir.Equals("MusicVideoArtists"))
+  else if (lower == "musicvideoartists")
     return "videodb://musicvideos/artists/";
-  else if (dir.Equals("MusicVideoAlbums"))
+  else if (lower == "musicvideoalbums")
     return "videodb://musicvideos/albums/";
-  else if (dir.Equals("MusicVideoDirectors"))
+  else if (lower == "musicvideodirectors")
     return "videodb://musicvideos/directors/";
-  else if (dir.Equals("MusicVideoStudios"))
+  else if (lower == "musicvideostudios")
     return "videodb://musicvideos/studios/";
-  else if (dir.Equals("MusicVideoTags"))
+  else if (lower == "musicvideotags")
     return "videodb://musicvideos/tags/";
-  else if (dir.Equals("MusicVideos"))
+  else if (lower == "musicvideos")
     return "videodb://musicvideos/";
-  else if (dir.Equals("RecentlyAddedMovies"))
+  else if (lower == "recentlyaddedmovies")
     return "videodb://recentlyaddedmovies/";
-  else if (dir.Equals("RecentlyAddedEpisodes"))
+  else if (lower == "recentlyaddedepisodes")
     return "videodb://recentlyaddedepisodes/";
-  else if (dir.Equals("RecentlyAddedMusicVideos"))
+  else if (lower == "recentlyaddedmusicvideos")
     return "videodb://recentlyaddedmusicvideos/";
-  else if (dir.Equals("Files"))
+  else if (lower == "files")
     return "sources://video/";
   return CGUIWindowVideoBase::GetStartFolder(dir);
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -556,7 +556,7 @@ void CGUIWindowVideoNav::UpdateButtons()
   CStdString strLabel;
 
   // "Playlists"
-  if (m_vecItems->GetPath().Equals("special://videoplaylists/"))
+  if (m_vecItems->IsPath("special://videoplaylists/"))
     strLabel = g_localizeStrings.Get(136);
   // "{Playlist Name}"
   else if (m_vecItems->IsPlayList())
@@ -565,7 +565,7 @@ void CGUIWindowVideoNav::UpdateButtons()
     CStdString strDummy;
     URIUtils::Split(m_vecItems->GetPath(), strDummy, strLabel);
   }
-  else if (m_vecItems->GetPath().Equals("sources://video/"))
+  else if (m_vecItems->IsPath("sources://video/"))
     strLabel = g_localizeStrings.Get(744);
   // everything else is from a videodb:// path
   else if (m_vecItems->IsVideoDb())
@@ -696,10 +696,10 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
 
   if (!m_vecItems->IsVideoDb() && !pItem->IsVideoDb())
   {
-    if (!pItem->GetPath().Equals("newsmartplaylist://video") &&
-        !pItem->GetPath().Equals("special://videoplaylists/") &&
-        !pItem->GetPath().Equals("sources://video/") &&
-        !StringUtils::StartsWithNoCase(pItem->GetPath(), "newtag://"))
+    if (!pItem->IsPath("newsmartplaylist://video") &&
+        !pItem->IsPath("special://videoplaylists/") &&
+        !pItem->IsPath("sources://video/") &&
+        !URIUtils::IsProtocol(pItem->GetPath(), "newtag"))
       CGUIWindowVideoBase::OnDeleteItem(pItem);
   }
   else if (StringUtils::StartsWithNoCase(pItem->GetPath(), "videodb://movies/sets/") &&
@@ -740,8 +740,8 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
       m_database.DeleteTag(params.GetTagId(), (VIDEODB_CONTENT_TYPE)params.GetContentType());
     }
   }
-  else if (m_vecItems->GetPath().Equals(CUtil::VideoPlaylistsLocation()) ||
-           m_vecItems->GetPath().Equals("special://videoplaylists/"))
+  else if (m_vecItems->IsPath(CUtil::VideoPlaylistsLocation()) ||
+           m_vecItems->IsPath("special://videoplaylists/"))
   {
     pItem->m_bIsFolder = false;
     CFileUtils::DeleteItem(pItem);
@@ -773,7 +773,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
   {
     // nothing to do here
   }
-  else if (m_vecItems->GetPath().Equals("sources://video/"))
+  else if (m_vecItems->IsPath("sources://video/"))
   {
     // get the usual shares
     CGUIDialogContextMenu::GetContextButtons("video", item, buttons);
@@ -805,8 +805,8 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
   else
   {
     // are we in the playlists location?
-    bool inPlaylists = m_vecItems->GetPath().Equals(CUtil::VideoPlaylistsLocation()) ||
-                       m_vecItems->GetPath().Equals("special://videoplaylists/");
+    bool inPlaylists = m_vecItems->IsPath(CUtil::VideoPlaylistsLocation()) ||
+                       m_vecItems->IsPath("special://videoplaylists/");
 
     if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_artist.empty())
     {
@@ -866,7 +866,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           }
           else
           {
-            if (item->GetOverlayImage().Equals("OverlayWatched.png"))
+            if (item->GetOverlayImage() == "OverlayWatched.png")
               buttons.Add(CONTEXT_BUTTON_MARK_UNWATCHED, 16104); //Mark as UnWatched
             else
               buttons.Add(CONTEXT_BUTTON_MARK_WATCHED, 16103);   //Mark as Watched

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -603,9 +603,9 @@ bool CGUIWindowVideoNav::GetFilteredItems(const CStdString &filter, CFileItemLis
 void CGUIWindowVideoNav::DoSearch(const CStdString& strSearch, CFileItemList& items)
 {
   CFileItemList tempItems;
-  CStdString strGenre = g_localizeStrings.Get(515); // Genre
-  CStdString strActor = g_localizeStrings.Get(20337); // Actor
-  CStdString strDirector = g_localizeStrings.Get(20339); // Director
+  std::string strGenre = g_localizeStrings.Get(515); // Genre
+  std::string strActor = g_localizeStrings.Get(20337); // Actor
+  std::string strDirector = g_localizeStrings.Get(20339); // Director
 
   //get matching names
   m_database.GetMoviesByName(strSearch, tempItems);
@@ -707,7 +707,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
   {
     CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
     pDialog->SetHeading(432);
-    CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(433),pItem->GetLabel().c_str());
+    CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(433).c_str(),pItem->GetLabel().c_str());
     pDialog->SetLine(1, strLabel);
     pDialog->SetLine(2, "");;
     pDialog->DoModal();
@@ -728,7 +728,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
   {
     CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
     pDialog->SetHeading(432);
-    CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(433), pItem->GetLabel().c_str());
+    CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(433).c_str(), pItem->GetLabel().c_str());
     pDialog->SetLine(1, strLabel);
     pDialog->SetLine(2, "");
     pDialog->DoModal();
@@ -1061,14 +1061,14 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
 
     if (!videodb.GetSingleValue("tag", "tag.idTag", videodb.PrepareSQL("tag.strTag = '%s' AND tag.idTag IN (SELECT taglinks.idTag FROM taglinks WHERE taglinks.media_type = '%s')", strTag.c_str(), mediaType.c_str())).empty())
     {
-      CStdString strError = StringUtils::Format(g_localizeStrings.Get(20463), strTag.c_str());
+      CStdString strError = StringUtils::Format(g_localizeStrings.Get(20463).c_str(), strTag.c_str());
       CGUIDialogOK::ShowAndGetInput(20462, "", strError, "");
       return true;
     }
 
     int idTag = videodb.AddTag(strTag);
     CFileItemList items;
-    CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType.c_str());
+    CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(20464).c_str(), localizedType.c_str());
     if (CGUIDialogVideoInfo::GetItemsForTag(strLabel, mediaType, items, idTag))
     {
       for (int index = 0; index < items.Size(); index++)

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -52,11 +52,11 @@ protected:
   void LoadVideoInfo(CFileItemList &items);
 
   bool ApplyWatchedFilter(CFileItemList &items);
-  virtual bool GetFilteredItems(const CStdString &filter, CFileItemList &items);
+  virtual bool GetFilteredItems(const std::string &filter, CFileItemList &items);
 
   virtual void OnItemLoaded(CFileItem* pItem) {};
   // override base class methods
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   virtual void UpdateButtons();
   virtual void DoSearch(const CStdString& strSearch, CFileItemList& items);
   virtual void PlayItem(int iItem);
@@ -64,7 +64,7 @@ protected:
   virtual void GetContextButtons(int itemNumber, CContextButtons &buttons);
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual bool OnClick(int iItem);
-  virtual CStdString GetStartFolder(const CStdString &dir);
+  virtual std::string GetStartFolder(const std::string &dir);
 
   virtual CStdString GetQuickpathName(const CStdString& strPath) const;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -787,14 +787,14 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
     else if (iWindow == WINDOW_FILES || iWindow == WINDOW_PROGRAMS)
       showLabel = 1026;
   }
-  if (m_vecItems->GetPath().Equals("sources://video/"))
+  if (m_vecItems->IsPath("sources://video/"))
     showLabel = 999;
-  else if (m_vecItems->GetPath().Equals("sources://music/"))
+  else if (m_vecItems->IsPath("sources://music/"))
     showLabel = 998;
-  else if (m_vecItems->GetPath().Equals("sources://pictures/"))
+  else if (m_vecItems->IsPath("sources://pictures/"))
     showLabel = 997;
-  else if (m_vecItems->GetPath().Equals("sources://programs/") ||
-           m_vecItems->GetPath().Equals("sources://files/"))
+  else if (m_vecItems->IsPath("sources://programs/") ||
+           m_vecItems->IsPath("sources://files/"))
     showLabel = 1026;
   if (showLabel && (m_vecItems->Size() == 0 || !m_guiState->DisableAddSourceButtons())) // add 'add source button'
   {
@@ -1211,7 +1211,7 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, CStdStri
     else
     {
       // Other items in virual directory
-      CStdString strPath = pItem->GetPath();
+      std::string strPath = pItem->GetPath();
       URIUtils::RemoveSlashAtEnd(strPath);
 
       strHistoryString = pItem->GetLabel() + strPath;
@@ -1553,9 +1553,9 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
     return;
 
   // TODO: FAVOURITES Conditions on masterlock and localisation
-  if (!item->IsParentFolder() && !item->GetPath().Equals("add") && !item->GetPath().Equals("newplaylist://") &&
-      !StringUtils::StartsWithNoCase(item->GetPath(), "newsmartplaylist://") && !StringUtils::StartsWithNoCase(item->GetPath(), "newtag://") &&
-      !StringUtils::StartsWithNoCase(item->GetPath(), "addons://more/") && !StringUtils::StartsWithNoCase(item->GetPath(), "musicsearch://"))
+  if (!item->IsParentFolder() && !item->IsPath("add") && !item->IsPath("newplaylist://") &&
+      !URIUtils::IsProtocol(item->GetPath(), "newsmartplaylist") && !URIUtils::IsProtocol(item->GetPath(), "newtag") &&
+      !URIUtils::PathStarts(item->GetPath(), "addons://more/") && !URIUtils::IsProtocol(item->GetPath(), "musicsearch"))
   {
     if (XFILE::CFavouritesDirectory::IsFavourite(item.get(), GetID()))
       buttons.Add(CONTEXT_BUTTON_ADD_FAVOURITE, 14077);     // Remove Favourite

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -117,7 +117,7 @@ void CGUIMediaWindow::LoadAdditionalTags(TiXmlElement *root)
   TiXmlElement *element = root->FirstChildElement("views");
   if (element && element->FirstChild())
   { // format is <views>50,29,51,95</views>
-    CStdString allViews = element->FirstChild()->Value();
+    const std::string &allViews = element->FirstChild()->ValueStr();
     vector<string> views = StringUtils::Split(allViews, ",");
     for (vector<string>::const_iterator i = views.begin(); i != views.end(); ++i)
     {
@@ -203,7 +203,7 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
 
   if (action.GetID() >= ACTION_FILTER_SMS2 && action.GetID() <= ACTION_FILTER_SMS9)
   {
-    CStdString filter = StringUtils::Format("%i", (int)(action.GetID() - ACTION_FILTER_SMS2 + 2));
+    std::string filter = StringUtils::Format("%i", (int)(action.GetID() - ACTION_FILTER_SMS2 + 2));
     CGUIMessage message(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_FILTER_ITEMS, 1); // 1 for append
     message.SetStringParam(filter);
     OnMessage(message);
@@ -410,7 +410,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       }
       else if (message.GetParam1() == GUI_MSG_FILTER_ITEMS && IsActive())
       {
-        CStdString filter = GetProperty("filter").asString();
+        std::string filter = GetProperty("filter").asString();
         // check if this is meant for advanced filtering
         if (message.GetParam2() != 10)
         {
@@ -484,7 +484,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     {
       if (m_vecItems->GetPath() == "?")
         m_vecItems->SetPath("");
-      CStdString dir = message.GetStringParam(0);
+      std::string dir = message.GetStringParam(0);
       const std::string &ret = message.GetStringParam(1);
       bool returning = StringUtils::EqualsNoCase(ret, "return");
       if (!dir.empty())
@@ -544,12 +544,12 @@ void CGUIMediaWindow::UpdateButtons()
     else
       CONTROL_ENABLE(CONTROL_BTNSORTBY);
 
-    CStdString sortLabel = StringUtils::Format(g_localizeStrings.Get(550).c_str(),
-                                               g_localizeStrings.Get(m_guiState->GetSortMethodLabel()).c_str());
+    std::string sortLabel = StringUtils::Format(g_localizeStrings.Get(550).c_str(),
+                                                g_localizeStrings.Get(m_guiState->GetSortMethodLabel()).c_str());
     SET_CONTROL_LABEL(CONTROL_BTNSORTBY, sortLabel);
   }
 
-  CStdString items = StringUtils::Format("%i %s", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127).c_str());
+  std::string items = StringUtils::Format("%i %s", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127).c_str());
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   SET_CONTROL_LABEL2(CONTROL_BTN_FILTER, GetProperty("filter").asString());
@@ -638,7 +638,7 @@ void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
   \param strDirectory Path to read
   \param items Fill with items specified in \e strDirectory
   */
-bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList &items)
+bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   const CURL pathToUrl(strDirectory);
 
@@ -646,7 +646,7 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
   if (items.Size())
     items.Clear();
 
-  CStdString strParentPath = m_history.GetParentPath();
+  std::string strParentPath = m_history.GetParentPath();
 
   CLog::Log(LOGDEBUG,"CGUIMediaWindow::GetDirectory (%s)",
             CURL::GetRedacted(strDirectory).c_str());
@@ -718,7 +718,7 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
 // \brief Set window to a specific directory
 // \param strDirectory The directory to be displayed in list/thumb control
 // This function calls OnPrepareFileItems() and OnFinalizeFileItems()
-bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   // TODO: OnInitWindow calls Update() before window path has been set properly.
   if (strDirectory == "?")
@@ -726,7 +726,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
 
   // get selected item
   int iItem = m_viewControl.GetSelectedItem();
-  CStdString strSelectedItem = "";
+  std::string strSelectedItem;
   if (iItem >= 0 && iItem < m_vecItems->Size())
   {
     CFileItemPtr pItem = m_vecItems->Get(iItem);
@@ -736,14 +736,14 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
     }
   }
   
-  CStdString strCurrentDirectory = m_vecItems->GetPath();
+  std::string strCurrentDirectory = m_vecItems->GetPath();
   m_history.SetSelectedItem(strSelectedItem, strCurrentDirectory);
 
-  CStdString directory = strDirectory;
+  std::string directory = strDirectory;
   // check if the path contains a filter and temporarily remove it
   // so that the retrieved list of items is unfiltered
   bool canfilter = CanContainFilter(directory);
-  CStdString filter;
+  std::string filter;
   CURL url(directory);
   if (canfilter && url.HasOption("filter"))
     directory = RemoveParameterFromPath(directory, "filter");
@@ -754,7 +754,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
     CLog::Log(LOGERROR,"CGUIMediaWindow::GetDirectory(%s) failed", url.GetRedacted().c_str());
     // Try to return to the previous directory, if not the same
     // else fallback to root
-    if (strDirectory.Equals(strCurrentDirectory) || !Update(m_history.RemoveParentPath()))
+    if (URIUtils::PathEquals(strDirectory, strCurrentDirectory) || !Update(m_history.RemoveParentPath()))
       Update(""); // Fallback to root
 
     // Return false to be able to eg. show
@@ -798,7 +798,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
     showLabel = 1026;
   if (showLabel && (m_vecItems->Size() == 0 || !m_guiState->DisableAddSourceButtons())) // add 'add source button'
   {
-    CStdString strLabel = g_localizeStrings.Get(showLabel);
+    std::string strLabel = g_localizeStrings.Get(showLabel);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
     pItem->SetIconImage("DefaultAddSource.png");
@@ -848,7 +848,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
     CFileItemPtr pItem = m_vecItems->Get(i);
 
     // Update selected item
-    CStdString strHistory;
+    std::string strHistory;
     GetDirectoryHistoryString(pItem.get(), strHistory);
     if (strHistory == strSelectedItem)
     {
@@ -873,8 +873,8 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
 
 bool CGUIMediaWindow::Refresh(bool clearCache /* = false */)
 {
-  CStdString strCurrentDirectory = m_vecItems->GetPath();
-  if (strCurrentDirectory.Equals("?"))
+  std::string strCurrentDirectory = m_vecItems->GetPath();
+  if (strCurrentDirectory == "?")
     return false;
 
   if (clearCache)
@@ -961,7 +961,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
   {
     if ( pItem->m_bIsShareOrDrive )
     {
-      const CStdString& strLockType=m_guiState->GetLockType();
+      const std::string& strLockType=m_guiState->GetLockType();
       if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         if (!strLockType.empty() && !g_passwordManager.IsItemUnlocked(pItem.get(), strLockType))
             return true;
@@ -991,9 +991,9 @@ bool CGUIMediaWindow::OnClick(int iItem)
 
     // if we have a filtered list, we need to add the filtered
     // path to be able to come back to the filtered view
-    CStdString strCurrentDirectory = m_vecItems->GetPath();
+    std::string strCurrentDirectory = m_vecItems->GetPath();
     if (m_canFilterAdvanced && !m_filter.IsEmpty() &&
-      !m_strFilterPath.Equals(strCurrentDirectory))
+        !URIUtils::PathEquals(m_strFilterPath, strCurrentDirectory))
     {
       m_history.RemoveParentPath();
       m_history.AddPath(strCurrentDirectory, m_strFilterPath);
@@ -1012,7 +1012,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
 #if defined(TARGET_ANDROID)
   else if (pItem->IsAndroidApp())
   {
-    CStdString appName = URIUtils::GetFileName(pItem->GetPath());
+    std::string appName = URIUtils::GetFileName(pItem->GetPath());
     CLog::Log(LOGDEBUG, "CGUIMediaWindow::OnClick Trying to run: %s",appName.c_str());
     return CXBMCApp::StartActivity(appName);
   }
@@ -1082,7 +1082,7 @@ bool CGUIMediaWindow::OnSelect(int item)
 
 // \brief Checks if there is a disc in the dvd drive and whether the
 // network is connected or not.
-bool CGUIMediaWindow::HaveDiscOrConnection(const CStdString& strPath, int iDriveType)
+bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriveType)
 {
   if (iDriveType==CMediaSource::SOURCE_TYPE_DVD)
   {
@@ -1113,7 +1113,7 @@ void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem)
 
   int idMessageText = 0;
   CURL url(pItem->GetPath());
-  const CStdString& strHostName = url.GetHostName();
+  const std::string& strHostName = url.GetHostName();
 
   if (url.GetProtocol() == "smb" && strHostName.empty()) //  smb workgroup
     idMessageText = 15303; // Workgroup not found
@@ -1133,16 +1133,16 @@ void CGUIMediaWindow::GoParentFolder()
   // remove current directory if its on the stack
   // there were some issues due some folders having a trailing slash and some not
   // so just add a trailing slash to all of them for comparison.
-  CStdString strPath = m_vecItems->GetPath();
+  std::string strPath = m_vecItems->GetPath();
   URIUtils::AddSlashAtEnd(strPath);
-  CStdString strParent = m_history.GetParentPath();
+  std::string strParent = m_history.GetParentPath();
   // in case the path history is messed up and the current folder is on
   // the stack more than once, keep going until there's nothing left or they
   // dont match anymore.
   while (!strParent.empty())
   {
     URIUtils::AddSlashAtEnd(strParent);
-    if (strParent.Equals(strPath))
+    if (URIUtils::PathEquals(strParent, strPath))
       m_history.RemoveParentPath();
     else
       break;
@@ -1182,7 +1182,7 @@ void CGUIMediaWindow::GoParentFolder()
 
 // \brief Override the function to change the default behavior on how
 // a selected item history should look like
-void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, CStdString& strHistoryString)
+void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, std::string& strHistoryString)
 {
   if (pItem->m_bIsShareOrDrive)
   {
@@ -1195,7 +1195,7 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, CStdStri
       // Remove disc label from item label
       // and use as history string, m_strPath
       // can change for new discs
-      CStdString strLabel = pItem->GetLabel();
+      std::string strLabel = pItem->GetLabel();
       size_t nPosOpen = strLabel.find('(');
       size_t nPosClose = strLabel.rfind(')');
       if (nPosOpen != std::string::npos &&
@@ -1242,14 +1242,14 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, CStdStri
 
 // \brief Call this function to create a directory history for the
 // path given by strDirectory.
-void CGUIMediaWindow::SetHistoryForPath(const CStdString& strDirectory)
+void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
 {
   // Make sure our shares are configured
   SetupShares();
   if (!strDirectory.empty())
   {
     // Build the directory history for default path
-    CStdString strPath, strParentPath;
+    std::string strPath, strParentPath;
     strPath = strDirectory;
     URIUtils::RemoveSlashAtEnd(strPath);
 
@@ -1263,11 +1263,11 @@ void CGUIMediaWindow::SetHistoryForPath(const CStdString& strDirectory)
       for (int i = 0; i < (int)items.Size(); ++i)
       {
         CFileItemPtr pItem = items[i];
-        CStdString path(pItem->GetPath());
+        std::string path(pItem->GetPath());
         URIUtils::RemoveSlashAtEnd(path);
-        if (path == strPath)
+        if (URIUtils::PathEquals(path, strPath))
         {
-          CStdString strHistory;
+          std::string strHistory;
           GetDirectoryHistoryString(pItem.get(), strHistory);
           m_history.SetSelectedItem(strHistory, "");
           URIUtils::AddSlashAtEnd(strPath);
@@ -1392,7 +1392,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item)
 void CGUIMediaWindow::UpdateFileList()
 {
   int nItem = m_viewControl.GetSelectedItem();
-  CStdString strSelected;
+  std::string strSelected;
   if (nItem >= 0)
     strSelected = m_vecItems->Get(nItem)->GetPath();
 
@@ -1534,8 +1534,8 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
     return;
 
   // user added buttons
-  CStdString label;
-  CStdString action;
+  std::string label;
+  std::string action;
   for (int i = CONTEXT_BUTTON_USER1; i <= CONTEXT_BUTTON_USER10; i++)
   {
     label = StringUtils::Format("contextmenulabel(%i)", i - CONTEXT_BUTTON_USER1);
@@ -1609,7 +1609,7 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_USER9:
   case CONTEXT_BUTTON_USER10:
     {
-      CStdString action = StringUtils::Format("contextmenuaction(%i)", button - CONTEXT_BUTTON_USER1);
+      std::string action = StringUtils::Format("contextmenuaction(%i)", button - CONTEXT_BUTTON_USER1);
       CApplicationMessenger::Get().ExecBuiltIn(m_vecItems->Get(itemNumber)->GetProperty(action).asString());
       return true;
     }
@@ -1656,11 +1656,11 @@ bool CGUIMediaWindow::WaitForNetwork() const
   return true;
 }
 
-void CGUIMediaWindow::UpdateFilterPath(const CStdString &strDirectory, const CFileItemList &items, bool updateFilterPath)
+void CGUIMediaWindow::UpdateFilterPath(const std::string &strDirectory, const CFileItemList &items, bool updateFilterPath)
 {
   bool canfilter = CanContainFilter(strDirectory);
 
-  CStdString filter;
+  std::string filter;
   CURL url(strDirectory);
   if (canfilter && url.HasOption("filter"))
     filter = url.GetOption("filter");
@@ -1705,10 +1705,10 @@ void CGUIMediaWindow::UpdateFilterPath(const CStdString &strDirectory, const CFi
   }
 }
 
-void CGUIMediaWindow::OnFilterItems(const CStdString &filter)
+void CGUIMediaWindow::OnFilterItems(const std::string &filter)
 {
   CFileItemPtr currentItem;
-  CStdString currentItemPath;
+  std::string currentItemPath;
   int item = m_viewControl.GetSelectedItem();
   if (item >= 0 && item < m_vecItems->Size())
   {
@@ -1745,7 +1745,7 @@ void CGUIMediaWindow::OnFilterItems(const CStdString &filter)
   FormatAndSort(*m_vecItems);
 
   // get the "filter" option
-  CStdString filterOption;
+  std::string filterOption;
   CURL filterUrl(m_strFilterPath);
   if (filterUrl.HasOption("filter"))
     filterOption = filterUrl.GetOption("filter");
@@ -1804,13 +1804,13 @@ void CGUIMediaWindow::OnFilterItems(const CStdString &filter)
   UpdateButtons();
 }
 
-bool CGUIMediaWindow::GetFilteredItems(const CStdString &filter, CFileItemList &items)
+bool CGUIMediaWindow::GetFilteredItems(const std::string &filter, CFileItemList &items)
 {
   bool result = false;
   if (m_canFilterAdvanced)
     result = GetAdvanceFilteredItems(items);
 
-  CStdString trimmedFilter(filter);
+  std::string trimmedFilter(filter);
   StringUtils::TrimLeft(trimmedFilter);
   StringUtils::ToLower(trimmedFilter);
   
@@ -1832,7 +1832,7 @@ bool CGUIMediaWindow::GetFilteredItems(const CStdString &filter, CFileItemList &
     // where we are in the library tree.
     // Another idea is tying the filter string to the current level of the tree, so that going deeper disables the filter,
     // but it's re-enabled on the way back out.
-    CStdString match;
+    std::string match;
     /*    if (item->GetFocusedLayout())
      match = item->GetFocusedLayout()->GetAllText();
      else if (item->GetLayout())
@@ -1844,7 +1844,7 @@ bool CGUIMediaWindow::GetFilteredItems(const CStdString &filter, CFileItemList &
       StringUtils::WordToDigits(match);
     
     size_t pos = StringUtils::FindWords(match.c_str(), trimmedFilter.c_str());
-    if (pos != CStdString::npos)
+    if (pos != std::string::npos)
       filteredItems.Add(item);
   }
 
@@ -1867,10 +1867,10 @@ bool CGUIMediaWindow::GetAdvanceFilteredItems(CFileItemList &items)
   XFILE::CSmartPlaylistDirectory::GetDirectory(m_filter, resultItems, m_strFilterPath, true);
 
   // put together a lookup map for faster path comparison
-  map<CStdString, CFileItemPtr> lookup;
+  map<std::string, CFileItemPtr> lookup;
   for (int j = 0; j < resultItems.Size(); j++)
   {
-    CStdString itemPath = RemoveParameterFromPath(resultItems[j]->GetPath(), "filter");
+    std::string itemPath = RemoveParameterFromPath(resultItems[j]->GetPath(), "filter");
     StringUtils::ToLower(itemPath);
 
     lookup[itemPath] = resultItems[j];
@@ -1891,10 +1891,10 @@ bool CGUIMediaWindow::GetAdvanceFilteredItems(CFileItemList &items)
     // check if the item is part of the resultItems list
     // by comparing their paths (but ignoring any special
     // options because they differ from filter to filter)
-    CStdString path = RemoveParameterFromPath(item->GetPath(), "filter");
+    std::string path = RemoveParameterFromPath(item->GetPath(), "filter");
     StringUtils::ToLower(path);
 
-    map<CStdString, CFileItemPtr>::iterator itItem = lookup.find(path);
+    map<std::string, CFileItemPtr>::iterator itItem = lookup.find(path);
     if (itItem != lookup.end())
     {
       // add the item to the list of filtered items
@@ -1938,7 +1938,7 @@ bool CGUIMediaWindow::Filter(bool advanced /* = true */)
     }
     if (GetProperty("filter").empty())
     {
-      CStdString filter = GetProperty("filter").asString();
+      std::string filter = GetProperty("filter").asString();
       CGUIKeyboardFactory::ShowAndGetFilter(filter, false);
       SetProperty("filter", filter);
     }
@@ -1952,14 +1952,15 @@ bool CGUIMediaWindow::Filter(bool advanced /* = true */)
   return true;
 }
 
-CStdString CGUIMediaWindow::GetStartFolder(const CStdString &dir)
+std::string CGUIMediaWindow::GetStartFolder(const std::string &dir)
 {
-  if (dir.Equals("$ROOT") || dir.Equals("Root"))
+  std::string lower(dir); StringUtils::ToLower(lower);
+  if (lower == "$root" || lower == "root")
     return "";
   return dir;
 }
 
-CStdString CGUIMediaWindow::RemoveParameterFromPath(const CStdString &strDirectory, const CStdString &strParameter)
+std::string CGUIMediaWindow::RemoveParameterFromPath(const std::string &strDirectory, const std::string &strParameter)
 {
   CURL url(strDirectory);
   if (url.HasOption(strParameter))

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -69,7 +69,7 @@ protected:
   virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
   virtual void FormatItemLabels(CFileItemList &items, const LABEL_MASKS &labelMasks);
   virtual void UpdateButtons();
-  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
+  virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items);
   /*! \brief Retrieves the items from the given path and updates the list
    \param strDirectory The path to the directory to get the items from
    \param updateFilterPath Whether to update the filter path in m_strFilterPath or not
@@ -78,7 +78,7 @@ protected:
    \sa m_vecItems
    \sa m_strFilterPath
    */
-  virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
+  virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
   /*! \brief Refreshes the current list by retrieving the lists's path
    \return true if the list was successfully refreshed otherwise false
    \sa Update
@@ -103,8 +103,8 @@ protected:
    \param strDirectory Path to check
    \return true if the given path can contain a "filter" parameter otherwise false
    */
-  virtual bool CanContainFilter(const CStdString &strDirectory) const { return false; }
-  virtual void UpdateFilterPath(const CStdString &strDirector, const CFileItemList &items, bool updateFilterPath);
+  virtual bool CanContainFilter(const std::string &strDirectory) const { return false; }
+  virtual void UpdateFilterPath(const std::string &strDirector, const CFileItemList &items, bool updateFilterPath);
   virtual bool Filter(bool advanced = true);
 
   /* \brief Called on response to a GUI_MSG_FILTER_ITEMS message
@@ -112,14 +112,14 @@ protected:
    \param filter the filter to use.
    \sa FilterItems
    */
-  void OnFilterItems(const CStdString &filter);
+  void OnFilterItems(const std::string &filter);
 
   /* \brief Retrieve the filtered item list
    \param filter filter to apply
    \param items CFileItemList to filter
    \sa OnFilterItems
    */
-  virtual bool GetFilteredItems(const CStdString &filter, CFileItemList &items);
+  virtual bool GetFilteredItems(const std::string &filter, CFileItemList &items);
 
   /* \brief Retrieve the advance filtered item list
   \param items CFileItemList to filter
@@ -130,12 +130,12 @@ protected:
   virtual bool GetAdvanceFilteredItems(CFileItemList &items);
 
   // check for a disc or connection
-  virtual bool HaveDiscOrConnection(const CStdString& strPath, int iDriveType);
+  virtual bool HaveDiscOrConnection(const std::string& strPath, int iDriveType);
   void ShowShareErrorMessage(CFileItem* pItem);
 
-  void GetDirectoryHistoryString(const CFileItem* pItem, CStdString& strHistoryString);
-  void SetHistoryForPath(const CStdString& strDirectory);
-  virtual void LoadPlayList(const CStdString& strFileName) {}
+  void GetDirectoryHistoryString(const CFileItem* pItem, std::string& strHistoryString);
+  void SetHistoryForPath(const std::string& strDirectory);
+  virtual void LoadPlayList(const std::string& strFileName) {}
   virtual bool OnPlayMedia(int iItem);
   virtual bool OnPlayAndQueueMedia(const CFileItemPtr &item);
   void UpdateFileList();
@@ -148,14 +148,14 @@ protected:
   /*! \brief Translate the folder to start in from the given quick path
    \param dir the folder the user wants
    \return the resulting path */
-  virtual CStdString GetStartFolder(const CStdString &url);
+  virtual std::string GetStartFolder(const std::string &url);
 
   /*! \brief Utility method to remove the given parameter from a path/URL
    \param strDirectory Path/URL from which to remove the given parameter
    \param strParameter Parameter to remove from the given path/URL
    \return Path/URL without the given parameter
    */
-  static CStdString RemoveParameterFromPath(const CStdString &strDirectory, const CStdString &strParameter);
+  static std::string RemoveParameterFromPath(const std::string &strDirectory, const std::string &strParameter);
 
   XFILE::CVirtualDirectory m_rootDir;
   CGUIViewControl m_viewControl;
@@ -169,7 +169,7 @@ protected:
   // save control state on window exit
   int m_iLastControl;
   int m_iSelectedItem;
-  CStdString m_startDirectory;
+  std::string m_startDirectory;
 
   CSmartPlaylist m_filter;
   bool m_canFilterAdvanced;
@@ -185,5 +185,5 @@ protected:
 
    \sa Update
    */
-  CStdString m_strFilterPath;
+  std::string m_strFilterPath;
 };

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -571,15 +571,13 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
   }
   else if (pItem->IsZIP() || pItem->IsCBZ()) // mount zip archive
   {
-    CStdString strArcivedPath;
-    URIUtils::CreateArchivePath(strArcivedPath, "zip", pItem->GetPath(), "");
-    Update(iList, strArcivedPath);
+    CURL pathToUrl = URIUtils::CreateArchivePath("zip", pItem->GetURL(), "");
+    Update(iList, pathToUrl.Get());
   }
   else if (pItem->IsRAR() || pItem->IsCBR())
   {
-    CStdString strArcivedPath;
-    URIUtils::CreateArchivePath(strArcivedPath, "rar", pItem->GetPath(), "");
-    Update(iList, strArcivedPath);
+    CURL pathToUrl = URIUtils::CreateArchivePath("rar", pItem->GetURL(), "");
+    Update(iList, pathToUrl.Get());
   }
   else
   {

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -322,7 +322,7 @@ void CGUIWindowFileManager::OnSort(int iList)
   for (int i = 0; i < m_vecItems[iList]->Size(); i++)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
-    if (pItem->m_bIsFolder && (!pItem->m_dwSize || pItem->GetPath().Equals("add")))
+    if (pItem->m_bIsFolder && (!pItem->m_dwSize || pItem->IsPath("add")))
       pItem->SetLabel2("");
     else
       pItem->SetFileSizeLabel();

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -159,7 +159,7 @@ void CGUIWindowLoginScreen::FrameMove()
   if (GetFocusedControlID() == CONTROL_BIG_LIST && g_windowManager.GetTopMostModalDialogID() == WINDOW_INVALID)
     if (m_viewControl.HasControl(CONTROL_BIG_LIST))
       m_iSelectedItem = m_viewControl.GetSelectedItem();
-  CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(20114), m_iSelectedItem+1, CProfilesManager::Get().GetNumberOfProfiles());
+  CStdString strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, CProfilesManager::Get().GetNumberOfProfiles());
   SET_CONTROL_LABEL(CONTROL_LABEL_SELECTED_PROFILE,strLabel);
   CGUIWindow::FrameMove();
 }

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -199,11 +199,11 @@ void CGUIWindowWeather::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_LABELUPDATED, g_weatherManager.GetLastUpdateTime());
 
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_COND, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_COND));
-  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_TEMP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_TEMP) + g_langInfo.GetTempUnitString());
-  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_FEEL, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_FEEL) + g_langInfo.GetTempUnitString());
+  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_TEMP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_TEMP) + (CStdString)g_langInfo.GetTempUnitString());
+  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_FEEL, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_FEEL) + (CStdString)g_langInfo.GetTempUnitString());
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_UVID, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_UVID));
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_WIND, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_WIND));
-  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_DEWP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_DEWP) + g_langInfo.GetTempUnitString());
+  SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_DEWP, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_DEWP) + (CStdString)g_langInfo.GetTempUnitString());
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_HUMI, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_HUMI));
 
   CGUIImage *pImage = (CGUIImage *)GetControl(WEATHER_IMAGE_CURRENT_ICON);
@@ -220,8 +220,8 @@ void CGUIWindowWeather::UpdateButtons()
   for (int i = 0; i < NUM_DAYS; i++)
   {
     SET_CONTROL_LABEL(CONTROL_LABELD0DAY + (i*10), g_weatherManager.GetForecast(i).m_day);
-    SET_CONTROL_LABEL(CONTROL_LABELD0HI + (i*10), g_weatherManager.GetForecast(i).m_high + g_langInfo.GetTempUnitString());
-    SET_CONTROL_LABEL(CONTROL_LABELD0LOW + (i*10), g_weatherManager.GetForecast(i).m_low + g_langInfo.GetTempUnitString());
+    SET_CONTROL_LABEL(CONTROL_LABELD0HI + (i*10), g_weatherManager.GetForecast(i).m_high + (CStdString)g_langInfo.GetTempUnitString());
+    SET_CONTROL_LABEL(CONTROL_LABELD0LOW + (i*10), g_weatherManager.GetForecast(i).m_low + (CStdString)g_langInfo.GetTempUnitString());
     SET_CONTROL_LABEL(CONTROL_LABELD0GEN + (i*10), g_weatherManager.GetForecast(i).m_overview);
     pImage = (CGUIImage *)GetControl(CONTROL_IMAGED0IMG + (i * 10));
     if (pImage) pImage->SetFileName(g_weatherManager.GetForecast(i).m_icon);


### PR DESCRIPTION
Righto, round 1 of @notspiff's work.  There's another larger one to come once this is in, which I may split further for review purposes. This one is mostly straight-forward.  Assumptions made primarily are paths are case-sensitive (we use them as such all over the show).

The commits marked REVIEW have some detail that's not completely obvious - most of the rest are pretty obvious.

One thing I'm not sure about is whether URL protocol options, used mainly with CurlFile, but also a couple of other places are case-sensitive or not.  They're certainly mixed-case.  Obviously if we compare two that are of different cases as the entire path they'll be different but this possibly doesn't hurt.  @elupus any idea?

Another thing is there's a settings option fillter that I've made case-sensitive, where perhaps it shouldn't be (the localizestrings commit) - @Montellese?

@Karlson2k Perhaps you could take a quick look through - as I say, the vast majority are not controversial: the goal here is to get rid of it, not to make things optimal or anything like that, so I haven't done that except where there was a very cheap win (hardly ever).  Obviously in some cases we include CStdString in unrelated areas (particularly the include) to keep the impact down: It'll be all gone once the next series are in.
