### PR TITLE
[powermanager] clear directory cache on wake up

### DIFF
--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -35,6 +35,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "filesystem/DirectoryCache.h"
 
 #if defined(TARGET_DARWIN)
 #include "osx/CocoaPowerSyscall.h"
@@ -280,6 +281,7 @@ void CPowerManager::OnWake()
 #endif
 
   CAEFactory::Resume();
+  g_directoryCache.Clear();
   g_application.UpdateLibraries();
   g_weatherManager.Refresh();
 


### PR DESCRIPTION
If you use suspend/hibernate mode you never get a fresh view of a fetched directory after wake up, so this will clear the directory cache while XBMC wake up.
