### PR TITLE
Fixed mapping for xbmc command "eject" for device "devinput".

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -564,7 +564,8 @@
 		<display>KEY_ZOOM</display>
 		<mute>KEY_MUTE</mute>
 		<power>KEY_POWER</power>
-		<eject>KEY_EJECT</eject>
+		<eject>KEY_EJECTCD</eject>
+		<eject>KEY_EJECTCLOSECD</eject>
 		<menu>KEY_DVD</menu>
 		<menu>KEY_MENU</menu>
 		<myvideo>KEY_VIDEO</myvideo>


### PR DESCRIPTION
KEY_EJECT is not defined in linux/usr/include/input.h but KEY_EJECTCD and KEY_EJECTCLOSECD).

This is a followup to [PR4949](https://github.com/xbmc/xbmc/pull/4949).
