### PR TITLE
Url protocol compares

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2413,7 +2413,7 @@ void CFileItemList::StackFiles()
     VECCREGEXP::iterator  expr        = stackRegExps.begin();
 
     URIUtils::Split(item1->GetPath(), filePath, file1);
-    if (URIUtils::ProtocolHasEncodedFilename(CURL(filePath).GetProtocol() ) )
+    if (URIUtils::HasEncodedFilename(CURL(filePath)))
       file1 = CURL::Decode(file1);
 
     int j;
@@ -2446,7 +2446,7 @@ void CFileItemList::StackFiles()
 
           CStdString file2, filePath2;
           URIUtils::Split(item2->GetPath(), filePath2, file2);
-          if (URIUtils::ProtocolHasEncodedFilename(CURL(filePath2).GetProtocol() ) )
+          if (URIUtils::HasEncodedFilename(CURL(filePath2)) )
             file2 = CURL::Decode(file2);
 
           if (expr->RegFind(file2, offset) != -1)

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1535,6 +1535,16 @@ const CURL CFileItem::GetURL() const
   return url;
 }
 
+bool CFileItem::IsURL(const CURL& url) const
+{
+  return IsPath(url.Get());
+}
+
+bool CFileItem::IsPath(const std::string& path) const
+{
+  return URIUtils::PathEquals(m_strPath, path);
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 /////
 ///// CFileItemList

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -110,8 +110,10 @@ public:
 
   const CURL GetURL() const;
   void SetURL(const CURL& url);
+  bool IsURL(const CURL& url) const;
   const CStdString &GetPath() const { return m_strPath; };
   void SetPath(const CStdString &path) { m_strPath = path; };
+  bool IsPath(const std::string& path) const;
 
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -703,7 +703,7 @@ bool CURL::IsFullPath(const CStdString &url)
   if (url.size() && url[0] == '/') return true;     //   /foo/bar.ext
   if (url.find("://") != std::string::npos) return true;                 //   foo://bar.ext
   if (url.size() > 1 && url[1] == ':') return true; //   c:\\foo\\bar\\bar.ext
-  if (StringUtils::StartsWith(url, "\\\\")) return true;    //   \\UNC\path\to\file
+  if (URIUtils::PathStarts(url, "\\\\")) return true;    //   \\UNC\path\to\file
   return false;
 }
 

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -149,11 +149,11 @@ void CURL::Parse(const CStdString& strURL1)
   // they are all local protocols and have no server part, port number, special options, etc.
   // this removes the need for special handling below.
   if (
-    m_strProtocol.Equals("stack") ||
-    m_strProtocol.Equals("virtualpath") ||
-    m_strProtocol.Equals("multipath") ||
-    m_strProtocol.Equals("filereader") ||
-    m_strProtocol.Equals("special")
+    IsProtocol("stack") ||
+    IsProtocol("virtualpath") ||
+    IsProtocol("multipath") ||
+    IsProtocol("filereader") ||
+    IsProtocol("special")
     )
   {
     SetFileName(strURL.substr(iPos));
@@ -169,27 +169,27 @@ void CURL::Parse(const CStdString& strURL1)
   const char* sep = NULL;
 
   //TODO fix all Addon paths
-  CStdString strProtocol2 = GetTranslatedProtocol();
-  if(m_strProtocol.Equals("rss") ||
-     m_strProtocol.Equals("rar") ||
-     m_strProtocol.Equals("addons") ||
-     m_strProtocol.Equals("image") ||
-     m_strProtocol.Equals("videodb") ||
-     m_strProtocol.Equals("musicdb") ||
-     m_strProtocol.Equals("androidapp"))
+  std::string strProtocol2 = GetTranslatedProtocol();
+  if(IsProtocol("rss") ||
+     IsProtocol("rar") ||
+     IsProtocol("addons") ||
+     IsProtocol("image") ||
+     IsProtocol("videodb") ||
+     IsProtocol("musicdb") ||
+     IsProtocol("androidapp"))
     sep = "?";
   else
-  if(strProtocol2.Equals("http")
-    || strProtocol2.Equals("https")
-    || strProtocol2.Equals("plugin")
-    || strProtocol2.Equals("addons")
-    || strProtocol2.Equals("hdhomerun")
-    || strProtocol2.Equals("rtsp")
-    || strProtocol2.Equals("apk")
-    || strProtocol2.Equals("zip"))
+  if(  IsProtocolEqual(strProtocol2, "http")
+    || IsProtocolEqual(strProtocol2, "https")
+    || IsProtocolEqual(strProtocol2, "plugin")
+    || IsProtocolEqual(strProtocol2, "addons")
+    || IsProtocolEqual(strProtocol2, "hdhomerun")
+    || IsProtocolEqual(strProtocol2, "rtsp")
+    || IsProtocolEqual(strProtocol2, "apk")
+    || IsProtocolEqual(strProtocol2, "zip"))
     sep = "?;#|";
-  else if(strProtocol2.Equals("ftp")
-       || strProtocol2.Equals("ftps"))
+  else if(IsProtocolEqual(strProtocol2, "ftp")
+       || IsProtocolEqual(strProtocol2, "ftps"))
     sep = "?;|";
 
   if(sep)
@@ -214,7 +214,7 @@ void CURL::Parse(const CStdString& strURL1)
   if(iSlash >= iEnd)
     iSlash = std::string::npos; // was an invalid slash as it was contained in options
 
-  if( !m_strProtocol.Equals("iso9660") )
+  if( !IsProtocol("iso9660") )
   {
     size_t iAlphaSign = strURL.find("@", iPos);
     if (iAlphaSign != std::string::npos && iAlphaSign < iEnd && (iAlphaSign < iSlash || iSlash == std::string::npos))
@@ -223,7 +223,7 @@ void CURL::Parse(const CStdString& strURL1)
       CStdString strUserNamePassword = strURL.substr(iPos, iAlphaSign - iPos);
 
       // first extract domain, if protocol is smb
-      if (m_strProtocol.Equals("smb"))
+      if (IsProtocol("smb"))
       {
         size_t iSemiColon = strUserNamePassword.find(";");
 
@@ -298,12 +298,12 @@ void CURL::Parse(const CStdString& strURL1)
   }
 
   // iso9960 doesnt have an hostname;-)
-  if (m_strProtocol == "iso9660"
-    || m_strProtocol == "musicdb"
-    || m_strProtocol == "videodb"
-    || m_strProtocol == "sources"
-    || m_strProtocol == "pvr"
-    || StringUtils::StartsWith(m_strProtocol, "mem"))
+  if (IsProtocol("iso9660")
+   || IsProtocol("musicdb")
+   || IsProtocol("videodb")
+   || IsProtocol("sources")
+   || IsProtocol("pvr")
+   || StringUtils::StartsWith(m_strProtocol, "mem"))
   {
     if (m_strHostName != "" && m_strFileName != "")
     {
@@ -479,9 +479,9 @@ const CStdString& CURL::GetProtocolOptions() const
 const CStdString CURL::GetFileNameWithoutPath() const
 {
   // *.zip and *.rar store the actual zip/rar path in the hostname of the url
-  if ((m_strProtocol == "rar"  || 
-       m_strProtocol == "zip"  ||
-       m_strProtocol == "apk") &&
+  if ((IsProtocol("rar")  ||
+       IsProtocol("zip")  ||
+       IsProtocol("apk")) &&
        m_strFileName.empty())
     return URIUtils::GetFileName(m_strHostName);
 
@@ -534,7 +534,7 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
 {
   std::string strURL;
 
-  if (m_strProtocol.Equals("stack"))
+  if (IsProtocol("stack"))
   {
     CFileItemList items;
     XFILE::CStackDirectory dir;
@@ -756,6 +756,19 @@ std::string CURL::Encode(const std::string& strURLData)
   }
 
   return strResult;
+}
+
+bool CURL::IsProtocolEqual(const std::string &protocol, const char *type)
+{
+  /*
+   NOTE: We're currently using == here as m_strProtocol is assigned as lower-case in SetProtocol(),
+   and we've assumed all other callers are calling with protocol lower-case otherwise.
+   We possibly shouldn't do this (as CURL(foo).Get() != foo, though there are other reasons for this as well)
+   but it handles the requirements of RFC-1738 which allows the scheme to be case-insensitive.
+   */
+  if (type)
+    return protocol == type;
+  return false;
 }
 
 CStdString CURL::TranslateProtocol(const CStdString& prot)

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -458,7 +458,17 @@ const CStdString& CURL::GetProtocol() const
 
 const CStdString CURL::GetTranslatedProtocol() const
 {
-  return TranslateProtocol(m_strProtocol);
+  if (IsProtocol("shout")
+   || IsProtocol("daap")
+   || IsProtocol("dav")
+   || IsProtocol("tuxbox")
+   || IsProtocol("rss"))
+    return "http";
+
+  if (IsProtocol("davs"))
+    return "https";
+
+  return GetProtocol();
 }
 
 const CStdString& CURL::GetFileType() const
@@ -769,21 +779,6 @@ bool CURL::IsProtocolEqual(const std::string &protocol, const char *type)
   if (type)
     return protocol == type;
   return false;
-}
-
-CStdString CURL::TranslateProtocol(const CStdString& prot)
-{
-  if (prot == "shout"
-   || prot == "daap"
-   || prot == "dav"
-   || prot == "tuxbox"
-   || prot == "rss")
-   return "http";
-
-  if (prot == "davs")
-    return "https";
-
-  return prot;
 }
 
 void CURL::GetOptions(std::map<CStdString, CStdString> &options) const

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -302,8 +302,7 @@ void CURL::Parse(const CStdString& strURL1)
    || IsProtocol("musicdb")
    || IsProtocol("videodb")
    || IsProtocol("sources")
-   || IsProtocol("pvr")
-   || StringUtils::StartsWith(m_strProtocol, "mem"))
+   || IsProtocol("pvr"))
   {
     if (m_strHostName != "" && m_strFileName != "")
     {

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -326,7 +326,7 @@ void CURL::Parse(const CStdString& strURL1)
   SetFileName(m_strFileName);
 
   /* decode urlencoding on this stuff */
-  if(URIUtils::ProtocolHasEncodedHostname(m_strProtocol))
+  if(URIUtils::HasEncodedHostname(*this))
   {
     m_strHostName = Decode(m_strHostName);
     SetHostName(m_strHostName);
@@ -583,12 +583,12 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
   {
     std::string strHostName;
 
-    if (URIUtils::ProtocolHasParentInHostname(m_strProtocol))
+    if (URIUtils::HasParentInHostname(*this))
       strHostName = CURL(m_strHostName).GetWithoutUserDetails();
     else
       strHostName = m_strHostName;
 
-    if (URIUtils::ProtocolHasEncodedHostname(m_strProtocol))
+    if (URIUtils::HasEncodedHostname(*this))
       strURL += Encode(strHostName);
     else
       strURL += strHostName;
@@ -648,7 +648,7 @@ CStdString CURL::GetWithoutFilename() const
 
   if (m_strHostName != "")
   {
-    if( URIUtils::ProtocolHasEncodedHostname(m_strProtocol) )
+    if( URIUtils::HasEncodedHostname(*this) )
       strURL += Encode(m_strHostName);
     else
       strURL += m_strHostName;

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -76,6 +76,26 @@ public:
   static bool IsFullPath(const CStdString &url); ///< return true if the url includes the full path
   static std::string Decode(const std::string& strURLData);
   static std::string Encode(const std::string& strURLData);
+
+  /*! \brief Check whether a URL is a given URL scheme.
+   Comparison is case-insensitive as per RFC1738
+   \param type a lower-case scheme name, e.g. "smb".
+   \return true if the url is of the given scheme, false otherwise.
+   */
+  bool IsProtocol(const char *type) const
+  {
+    return IsProtocolEqual(m_strProtocol, type);
+  }
+
+  /*! \brief Check whether a URL protocol is a given URL scheme.
+   Both parameters MUST be lower-case.  Typically this would be called using
+   the result of TranslateProtocol() which enforces this for protocol.
+   \param protocol a lower-case scheme name, e.g. "ftp"
+   \param type a lower-case scheme name, e.g. "smb".
+   \return true if the url is of the given scheme, false otherwise.
+   */
+  static bool IsProtocolEqual(const std::string& protocol, const char *type);
+
   static CStdString TranslateProtocol(const CStdString& prot);
 
   void GetOptions(std::map<CStdString, CStdString> &options) const;

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -107,8 +107,6 @@ public:
     return m_strFileType == type;
   }
 
-  static CStdString TranslateProtocol(const CStdString& prot);
-
   void GetOptions(std::map<CStdString, CStdString> &options) const;
   bool HasOption(const CStdString &key) const;
   bool GetOption(const CStdString &key, CStdString &value) const;

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -96,6 +96,17 @@ public:
    */
   static bool IsProtocolEqual(const std::string& protocol, const char *type);
 
+  /*! \brief Check whether a URL is a given filetype.
+   Comparison is effectively case-insensitive as both the parameter
+   and m_strFileType are lower-case.
+   \param type a lower-case filetype, e.g. "mp3".
+   \return true if the url is of the given filetype, false otherwise.
+   */
+  bool IsFileType(const char *type) const
+  {
+    return m_strFileType == type;
+  }
+
   static CStdString TranslateProtocol(const CStdString& prot);
 
   void GetOptions(std::map<CStdString, CStdString> &options) const;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -225,7 +225,7 @@ CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */
   else if (StringUtils::StartsWithNoCase(path, "special://videoplaylists"))
     strFilename = g_localizeStrings.Get(136);
 
-  else if (URIUtils::ProtocolHasParentInHostname(url.GetProtocol()) && strFilename.empty())
+  else if (URIUtils::HasParentInHostname(url) && strFilename.empty())
     strFilename = URIUtils::GetFileName(url.GetHostName());
 
   // now remove the extension if needed

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -92,7 +92,7 @@ namespace XFILE
       CStdString File1 = URIUtils::GetFileName(files[0]->GetPath());
       CStdString File2 = URIUtils::GetFileName(files[1]->GetPath());
       // Check if source path uses URL encoding
-      if (URIUtils::ProtocolHasEncodedFilename(CURL(strCommonDir).GetProtocol()))
+      if (URIUtils::HasEncodedFilename(CURL(strCommonDir)))
       {
         File1 = CURL::Decode(File1);
         File2 = CURL::Decode(File2);
@@ -128,7 +128,7 @@ namespace XFILE
                   // got it
                   strStackTitle = Title1 + Ignore1 + Extension1;
                   // Check if source path uses URL encoding
-                  if (URIUtils::ProtocolHasEncodedFilename(CURL(strCommonDir).GetProtocol()))
+                  if (URIUtils::HasEncodedFilename(CURL(strCommonDir)))
                     strStackTitle = CURL::Encode(strStackTitle);
 
                   itRegExp = RegExps.end();

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -318,14 +318,14 @@ bool URIUtils::GetParentPath(const CStdString& strPath, CStdString& strParent)
     CFileItemList items;
     dir.GetDirectory(url, items);
     items[0]->m_strDVDLabel = GetDirectory(items[0]->GetPath());
-    if (StringUtils::StartsWithNoCase(items[0]->m_strDVDLabel, "rar://") || StringUtils::StartsWithNoCase(items[0]->m_strDVDLabel, "zip://"))
+    if (IsProtocol(items[0]->m_strDVDLabel, "rar") || IsProtocol(items[0]->m_strDVDLabel, "zip"))
       GetParentPath(items[0]->m_strDVDLabel, strParent);
     else
       strParent = items[0]->m_strDVDLabel;
     for( int i=1;i<items.Size();++i)
     {
       items[i]->m_strDVDLabel = GetDirectory(items[i]->GetPath());
-      if (StringUtils::StartsWithNoCase(items[0]->m_strDVDLabel, "rar://") || StringUtils::StartsWithNoCase(items[0]->m_strDVDLabel, "zip://"))
+      if (IsProtocol(items[0]->m_strDVDLabel, "rar") || IsProtocol(items[0]->m_strDVDLabel, "zip"))
         items[i]->SetPath(GetParentPath(items[i]->m_strDVDLabel));
       else
         items[i]->SetPath(items[i]->m_strDVDLabel);
@@ -495,6 +495,11 @@ CStdString URIUtils::SubstitutePath(const CStdString& strPath, bool reverse /* =
   return strPath;
 }
 
+bool URIUtils::IsProtocol(const std::string& url, const std::string &type)
+{
+  return StringUtils::StartsWithNoCase(url, type + "://");
+}
+
 bool URIUtils::IsRemote(const CStdString& strFile)
 {
   if (IsCDDA(strFile) || IsISO9660(strFile))
@@ -534,16 +539,16 @@ bool URIUtils::IsOnDVD(const CStdString& strFile)
     return (GetDriveType(strFile.substr(0, 3).c_str()) == DRIVE_CDROM);
 #endif
 
-  if (StringUtils::StartsWith(strFile, "dvd:"))
+  if (IsProtocol(strFile, "dvd"))
     return true;
 
-  if (StringUtils::StartsWith(strFile, "udf:"))
+  if (IsProtocol(strFile, "udf"))
     return true;
 
-  if (StringUtils::StartsWith(strFile, "iso9660:"))
+  if (IsProtocol(strFile, "iso9660"))
     return true;
 
-  if (StringUtils::StartsWith(strFile, "cdda:"))
+  if (IsProtocol(strFile, "cdda"))
     return true;
 
   return false;
@@ -633,7 +638,7 @@ bool URIUtils::IsHostOnLAN(const CStdString& host, bool offLineCheck)
 
 bool URIUtils::IsMultiPath(const CStdString& strPath)
 {
-  return StringUtils::StartsWithNoCase(strPath, "multipath:");
+  return IsProtocol(strPath, "multipath");
 }
 
 bool URIUtils::IsHD(const CStdString& strFileName)
@@ -660,7 +665,7 @@ bool URIUtils::IsDVD(const CStdString& strFile)
     return true;
 
 #if defined(TARGET_WINDOWS)
-  if (StringUtils::StartsWithNoCase(strFile, "dvd://"))
+  if (IsProtocol(strFile, "dvd"))
     return true;
 
   if(strFile.size() < 2 || (strFile.substr(1) != ":\\" && strFile.substr(1) != ":"))
@@ -678,7 +683,7 @@ bool URIUtils::IsDVD(const CStdString& strFile)
 
 bool URIUtils::IsStack(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "stack:");
+  return IsProtocol(strFile, "stack");
 }
 
 bool URIUtils::IsRAR(const CStdString& strFile)
@@ -745,7 +750,7 @@ bool URIUtils::IsSpecial(const CStdString& strFile)
   if (IsStack(strFile))
     strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
 
-  return StringUtils::StartsWithNoCase(strFile2, "special:");
+  return IsProtocol(strFile2, "special");
 }
 
 bool URIUtils::IsPlugin(const CStdString& strFile)
@@ -774,12 +779,12 @@ bool URIUtils::IsSourcesPath(const CStdString& strPath)
 
 bool URIUtils::IsCDDA(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "cdda:");
+  return IsProtocol(strFile, "cdda");
 }
 
 bool URIUtils::IsISO9660(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "iso9660:");
+  return IsProtocol(strFile, "iso9660");
 }
 
 bool URIUtils::IsSmb(const CStdString& strFile)
@@ -789,7 +794,7 @@ bool URIUtils::IsSmb(const CStdString& strFile)
   if (IsStack(strFile))
     strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
 
-  return StringUtils::StartsWithNoCase(strFile2, "smb:");
+  return IsProtocol(strFile2, "smb");
 }
 
 bool URIUtils::IsURL(const CStdString& strFile)
@@ -804,8 +809,8 @@ bool URIUtils::IsFTP(const CStdString& strFile)
   if (IsStack(strFile))
     strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
 
-  return StringUtils::StartsWithNoCase(strFile2, "ftp:")  ||
-         StringUtils::StartsWithNoCase(strFile2, "ftps:");
+  return IsProtocol(strFile2, "ftp")  ||
+         IsProtocol(strFile2, "ftps");
 }
 
 bool URIUtils::IsDAV(const CStdString& strFile)
@@ -815,8 +820,8 @@ bool URIUtils::IsDAV(const CStdString& strFile)
   if (IsStack(strFile))
     strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
 
-  return StringUtils::StartsWithNoCase(strFile2, "dav:")  ||
-         StringUtils::StartsWithNoCase(strFile2, "davs:");
+  return IsProtocol(strFile2, "dav")  ||
+         IsProtocol(strFile2, "davs");
 }
 
 bool URIUtils::IsInternetStream(const std::string &path, bool bStrictCheck /* = false */)
@@ -858,42 +863,42 @@ bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */
 
 bool URIUtils::IsDAAP(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "daap:");
+  return IsProtocol(strFile, "daap");
 }
 
 bool URIUtils::IsUPnP(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "upnp:");
+  return IsProtocol(strFile, "upnp");
 }
 
 bool URIUtils::IsTuxBox(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "tuxbox:");
+  return IsProtocol(strFile, "tuxbox");
 }
 
 bool URIUtils::IsMythTV(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "myth:");
+  return IsProtocol(strFile, "myth");
 }
 
 bool URIUtils::IsHDHomeRun(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "hdhomerun:");
+  return IsProtocol(strFile, "hdhomerun");
 }
 
 bool URIUtils::IsSlingbox(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "sling:");
+  return IsProtocol(strFile, "sling");
 }
 
 bool URIUtils::IsVTP(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "vtp:");
+  return IsProtocol(strFile, "vtp");
 }
 
 bool URIUtils::IsHTSP(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "htsp:");
+  return IsProtocol(strFile, "htsp");
 }
 
 bool URIUtils::IsLiveTV(const CStdString& strFile)
@@ -906,7 +911,7 @@ bool URIUtils::IsLiveTV(const CStdString& strFile)
   || IsHDHomeRun(strFile)
   || IsSlingbox(strFile)
   || IsHTSP(strFile)
-  || StringUtils::StartsWithNoCase(strFile, "sap:")
+  || IsProtocol(strFile, "sap")
   ||(StringUtils::EndsWithNoCase(strFileWithoutSlash, ".pvr") && !StringUtils::StartsWithNoCase(strFileWithoutSlash, "pvr://recordings")))
     return true;
 
@@ -927,7 +932,7 @@ bool URIUtils::IsPVRRecording(const CStdString& strFile)
 
 bool URIUtils::IsMusicDb(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "musicdb:");
+  return IsProtocol(strFile, "musicdb");
 }
 
 bool URIUtils::IsNfs(const CStdString& strFile)
@@ -937,7 +942,7 @@ bool URIUtils::IsNfs(const CStdString& strFile)
   if (IsStack(strFile))
     strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
   
-  return StringUtils::StartsWithNoCase(strFile2, "nfs:");
+  return IsProtocol(strFile2, "nfs");
 }
 
 bool URIUtils::IsAfp(const CStdString& strFile)
@@ -947,23 +952,23 @@ bool URIUtils::IsAfp(const CStdString& strFile)
   if (IsStack(strFile))
     strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
   
-  return StringUtils::StartsWithNoCase(strFile2, "afp:");
+  return IsProtocol(strFile2, "afp");
 }
 
 
 bool URIUtils::IsVideoDb(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "videodb:");
+  return IsProtocol(strFile, "videodb");
 }
 
 bool URIUtils::IsBluray(const CStdString& strFile)
 {
-  return StringUtils::StartsWithNoCase(strFile, "bluray:");
+  return IsProtocol(strFile, "bluray");
 }
 
 bool URIUtils::IsAndroidApp(const CStdString &path)
 {
-  return StringUtils::StartsWithNoCase(path, "androidapp:");
+  return IsProtocol(path, "androidapp");
 }
 
 bool URIUtils::IsLibraryFolder(const CStdString& strFile)
@@ -974,9 +979,9 @@ bool URIUtils::IsLibraryFolder(const CStdString& strFile)
 
 bool URIUtils::IsLibraryContent(const std::string &strFile)
 {
-  return (StringUtils::StartsWith(strFile, "library://") ||
-          StringUtils::StartsWith(strFile, "videodb://") ||
-          StringUtils::StartsWith(strFile, "musicdb://") ||
+  return (IsProtocol(strFile, "library") ||
+          IsProtocol(strFile, "videodb") ||
+          IsProtocol(strFile, "musicdb") ||
           StringUtils::EndsWith(strFile, ".xsp"));
 }
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -500,6 +500,16 @@ bool URIUtils::IsProtocol(const std::string& url, const std::string &type)
   return StringUtils::StartsWithNoCase(url, type + "://");
 }
 
+bool URIUtils::PathStarts(const std::string& url, const char *start)
+{
+  return StringUtils::StartsWith(url, start);
+}
+
+bool URIUtils::PathEquals(const std::string& url, const std::string &start)
+{
+  return url == start;
+}
+
 bool URIUtils::IsRemote(const CStdString& strFile)
 {
   if (IsCDDA(strFile) || IsISO9660(strFile))
@@ -909,7 +919,7 @@ bool URIUtils::IsLiveTV(const CStdString& strFile)
   || IsSlingbox(strFile)
   || IsHTSP(strFile)
   || IsProtocol(strFile, "sap")
-  ||(StringUtils::EndsWithNoCase(strFileWithoutSlash, ".pvr") && !StringUtils::StartsWithNoCase(strFileWithoutSlash, "pvr://recordings")))
+  ||(StringUtils::EndsWithNoCase(strFileWithoutSlash, ".pvr") && !PathStarts(strFileWithoutSlash, "pvr://recordings")))
     return true;
 
   if (IsMythTV(strFile) && CMythDirectory::IsLiveTV(strFile))
@@ -924,7 +934,7 @@ bool URIUtils::IsPVRRecording(const CStdString& strFile)
   RemoveSlashAtEnd(strFileWithoutSlash);
 
   return StringUtils::EndsWithNoCase(strFileWithoutSlash, ".pvr") &&
-         StringUtils::StartsWithNoCase(strFile, "pvr://recordings");
+         PathStarts(strFile, "pvr://recordings");
 }
 
 bool URIUtils::IsMusicDb(const CStdString& strFile)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -90,8 +90,28 @@ public:
    \param url a std::string path.
    \param type a lower-case scheme name, e.g. "smb".
    \return true if the url is of the given scheme, false otherwise.
+   \sa PathStarts, PathEquals
    */
   static bool IsProtocol(const std::string& url, const std::string& type);
+
+  /*! \brief Check whether a path starts with a given start.
+   Comparison is case-sensitive.
+   Use IsProtocol() to compare the protocol portion only.
+   \param path a std::string path.
+   \param start the string the start of the path should be compared against.
+   \return true if the path starts with the given string, false otherwise.
+   \sa IsProtocol, PathEquals
+   */
+  static bool PathStarts(const std::string& path, const char *start);
+
+  /*! \brief Check whether a path equals another path.
+   Comparison is case-sensitive.
+   \param path1 a std::string path.
+   \param path2 the second path the path should be compared against.
+   \return true if the paths are equal, false otherwise.
+   \sa IsProtocol, PathStarts
+   */
+  static bool PathEquals(const std::string& path1, const std::string &path2);
 
   static bool IsAddonsPath(const CStdString& strFile);
   static bool IsSourcesPath(const CStdString& strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -173,9 +173,9 @@ public:
 
   static CStdString AddFileToFolder(const CStdString &strFolder, const CStdString &strFile);
 
-  static bool ProtocolHasParentInHostname(const CStdString& prot);
-  static bool ProtocolHasEncodedHostname(const CStdString& prot);
-  static bool ProtocolHasEncodedFilename(const CStdString& prot);
+  static bool HasParentInHostname(const CURL& url);
+  static bool HasEncodedHostname(const CURL& url);
+  static bool HasEncodedFilename(const CURL& url);
 
   /*!
    \brief Cleans up the given path by resolving "." and ".."

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -85,6 +85,14 @@ public:
   static CURL SubstitutePath(const CURL& url, bool reverse = false);
   static CStdString SubstitutePath(const CStdString& strPath, bool reverse = false);
 
+  /*! \brief Check whether a URL is a given URL scheme.
+   Comparison is case-insensitve as per RFC1738
+   \param url a std::string path.
+   \param type a lower-case scheme name, e.g. "smb".
+   \return true if the url is of the given scheme, false otherwise.
+   */
+  static bool IsProtocol(const std::string& url, const std::string& type);
+
   static bool IsAddonsPath(const CStdString& strFile);
   static bool IsSourcesPath(const CStdString& strFile);
   static bool IsCDDA(const CStdString& strFile);


### PR DESCRIPTION
This small series focuses on the comparing of URL protocols, in particular for determining protocol type.

While paths in XBMC are generally compared case-sensitive (in particular, anything that ends up in a database anywhere) and while protocols are generally lower-case (CURL forces this at the moment) nevertheless, we shouldn't really be comparing protocols all over the show using functions for strings - rather we should have a central place to determine whether a URL has a particular protocol or not.

This is a start on that, dealing only with CURL and URIUtils, where most of this happens.  Note that the comparison here is case-insensitive in CURL, as it's lower-cased there anyway in SetProtocol().

The introduced function URIUtils::PathStart() on the other hand has been made case-sensitive, as that compares longer portions of the path than just the protocol, thus may contain portions that should be compared case-sensitive.

Long-term, moving to using CURL where reasonable rather than converting to/from all the time should be the goal regardless - at least by having a set of functions for the common operations, we don't have to grep the code for string utility functions for finding path compares.

Assuming this is accepted, I'll rebase the stdstring removal series on this as we'll hit a bunch of cases for use of these two functions as we go.  We may also need a few more, but we'll see how we go.

@Karlson2k, @Montellese your thoughts?
