### PR TITLE
[Fix] Store subtitle settings only on user action

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -21,6 +21,7 @@
 #include "ApplicationPlayer.h"
 #include "cores/IPlayer.h"
 #include "Application.h"
+#include "settings/MediaSettings.h"
 
 #define VOLUME_MINIMUM 0.0f        // -60dB
 #define VOLUME_MAXIMUM 1.0f        // 0dB
@@ -525,7 +526,10 @@ void CApplicationPlayer::SetSubtitleVisible(bool bVisible)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();
   if (player)
+  {
     player->SetSubtitleVisible(bVisible);
+    CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = bVisible;
+  }
 }
 
 int  CApplicationPlayer::AddSubtitle(const CStdString& strSubPath)

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -517,6 +517,7 @@ void CApplicationPlayer::SetSubtitle(int iStream)
     player->SetSubtitle(iStream);
     m_iSubtitleStream = iStream;
     m_subtitleStreamUpdate.Set(1000);
+    CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = iStream;
   }
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1665,7 +1665,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     }
     break;
   case VIDEOPLAYER_SUBTITLES_LANG:
-    if(g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
+    if(g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && g_application.m_pPlayer->GetSubtitleVisible())
     {
       SPlayerSubtitleStreamInfo info;
       g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2725,10 +2725,7 @@ bool CDVDPlayer::GetSubtitleVisible()
   if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
   {
     CDVDInputStreamNavigator* pStream = (CDVDInputStreamNavigator*)m_pInputStream;
-    if(pStream->IsInMenu())
-      return CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn;
-    else
-      return pStream->IsSubtitleStreamEnabled();
+    return pStream->IsSubtitleStreamEnabled();
   }
 
   return m_dvdPlayerVideo.IsSubtitleEnabled();
@@ -2736,13 +2733,11 @@ bool CDVDPlayer::GetSubtitleVisible()
 
 void CDVDPlayer::SetSubtitleVisible(bool bVisible)
 {
-  CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = bVisible;
   m_messenger.Put(new CDVDMsgBool(CDVDMsg::PLAYER_SET_SUBTITLESTREAM_VISIBLE, bVisible));
 }
 
 void CDVDPlayer::SetSubtitleVisibleInternal(bool bVisible)
 {
-  CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = bVisible;
   m_dvdPlayerVideo.EnableSubtitle(bVisible);
 
   if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2717,7 +2717,6 @@ void CDVDPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &inf
 
 void CDVDPlayer::SetSubtitle(int iStream)
 {
-  CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = iStream;
   m_messenger.Put(new CDVDMsgPlayerSetSubtitleStream(iStream));
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3289,6 +3289,7 @@ int CDVDPlayer::OnDVDNavResult(void* pData, int iMessage)
         bool visible = !(iStream & 0x80);
 
         SetSubtitleVisibleInternal(visible);
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = visible;
 
         if (iStream >= 0)
           m_dvd.iSelectedSPUStream = (iStream & ~0x80);

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1441,7 +1441,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const CStd
         if (g_application.m_pPlayer->HasPlayer())
         {
           result = CVariant(CVariant::VariantTypeObject);
-          int index = CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream;
+          int index = g_application.m_pPlayer->GetSubtitle();
           if (index >= 0)
           {
             SPlayerSubtitleStreamInfo info;

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -400,7 +400,6 @@ namespace XBMCAddon
       XBMC_TRACE;
       if (g_application.m_pPlayer->HasPlayer())
       {
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = bVisible != 0;
         g_application.m_pPlayer->SetSubtitleVisible(bVisible != 0);
       }
     }
@@ -428,7 +427,6 @@ namespace XBMCAddon
       CLog::Log(LOGWARNING,"'xbmc.Player().disableSubtitles()' is deprecated and will be removed in future releases, please use 'xbmc.Player().showSubtitles(false)' instead");
       if (g_application.m_pPlayer->HasPlayer())
       {
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
         g_application.m_pPlayer->SetSubtitleVisible(false);
       }
     }

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -411,7 +411,7 @@ namespace XBMCAddon
       if (g_application.m_pPlayer->HasPlayer())
       {
         SPlayerSubtitleStreamInfo info;
-        g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
+        g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
 
         if (info.language.length() > 0)
           return info.language;

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -63,7 +63,7 @@ bool CPlayerController::OnAction(const CAction &action)
         if (g_application.m_pPlayer->GetSubtitleCount() == 0)
           return true;
 
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = !CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = !g_application.m_pPlayer->GetSubtitleVisible();
         g_application.m_pPlayer->SetSubtitleVisible(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn);
         CStdString sub, lang;
         if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
@@ -91,14 +91,16 @@ bool CPlayerController::OnAction(const CAction &action)
           return true;
 
         int currentSub = g_application.m_pPlayer->GetSubtitle();
+        bool currentSubVisible = true;
 
-        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
+        if (g_application.m_pPlayer->GetSubtitleVisible())
         {
           if (++currentSub >= g_application.m_pPlayer->GetSubtitleCount())
           {
             currentSub = 0;
             CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
             g_application.m_pPlayer->SetSubtitleVisible(false);
+            currentSubVisible = false;
           }
           g_application.m_pPlayer->SetSubtitle(currentSub);
         }
@@ -109,7 +111,7 @@ bool CPlayerController::OnAction(const CAction &action)
         }
 
         CStdString sub, lang;
-        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
+        if (currentSubVisible)
         {
           SPlayerSubtitleStreamInfo info;
           g_application.m_pPlayer->GetSubtitleStreamInfo(currentSub, info);

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -90,19 +90,17 @@ bool CPlayerController::OnAction(const CAction &action)
         if (g_application.m_pPlayer->GetSubtitleCount() == 0)
           return true;
 
-        if(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream < 0)
-          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = g_application.m_pPlayer->GetSubtitle();
+        int currentSub = g_application.m_pPlayer->GetSubtitle();
 
         if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
         {
-          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream++;
-          if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream >= g_application.m_pPlayer->GetSubtitleCount())
+          if (++currentSub >= g_application.m_pPlayer->GetSubtitleCount())
           {
-            CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream = 0;
+            currentSub = 0;
             CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
             g_application.m_pPlayer->SetSubtitleVisible(false);
           }
-          g_application.m_pPlayer->SetSubtitle(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream);
+          g_application.m_pPlayer->SetSubtitle(currentSub);
         }
         else
         {
@@ -114,7 +112,7 @@ bool CPlayerController::OnAction(const CAction &action)
         if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
         {
           SPlayerSubtitleStreamInfo info;
-          g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
+          g_application.m_pPlayer->GetSubtitleStreamInfo(currentSub, info);
           if (!g_LangCodeExpander.Lookup(lang, info.language))
             lang = g_localizeStrings.Get(13205); // Unknown
 

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -69,7 +69,7 @@ bool CPlayerController::OnAction(const CAction &action)
         if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
         {
           SPlayerSubtitleStreamInfo info;
-          g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
+          g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
           if (!g_LangCodeExpander.Lookup(lang, info.language))
             lang = g_localizeStrings.Get(13205); // Unknown
 
@@ -114,7 +114,7 @@ bool CPlayerController::OnAction(const CAction &action)
         if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
         {
           SPlayerSubtitleStreamInfo info;
-          g_application.m_pPlayer->GetSubtitleStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream, info);
+          g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
           if (!g_LangCodeExpander.Lookup(lang, info.language))
             lang = g_localizeStrings.Get(13205); // Unknown
 

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -63,10 +63,10 @@ bool CPlayerController::OnAction(const CAction &action)
         if (g_application.m_pPlayer->GetSubtitleCount() == 0)
           return true;
 
-        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = !g_application.m_pPlayer->GetSubtitleVisible();
-        g_application.m_pPlayer->SetSubtitleVisible(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn);
+        bool subsOn = !g_application.m_pPlayer->GetSubtitleVisible();
+        g_application.m_pPlayer->SetSubtitleVisible(subsOn);
         CStdString sub, lang;
-        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn)
+        if (subsOn)
         {
           SPlayerSubtitleStreamInfo info;
           g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
@@ -98,7 +98,6 @@ bool CPlayerController::OnAction(const CAction &action)
           if (++currentSub >= g_application.m_pPlayer->GetSubtitleCount())
           {
             currentSub = 0;
-            CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = false;
             g_application.m_pPlayer->SetSubtitleVisible(false);
             currentSubVisible = false;
           }
@@ -106,7 +105,6 @@ bool CPlayerController::OnAction(const CAction &action)
         }
         else
         {
-          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleOn = true;
           g_application.m_pPlayer->SetSubtitleVisible(true);
         }
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -454,7 +454,7 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(CSettingGroup *group, c
   if (group == NULL || settingId.empty())
     return;
 
-  m_subtitleStream = CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleStream;
+  m_subtitleStream = g_application.m_pPlayer->GetSubtitle();
   if (m_subtitleStream < 0)
     m_subtitleStream = 0;
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -86,7 +86,7 @@ void CGUIDialogAudioSubtitleSettings::FrameMove()
     m_settingsManager->SetBool(SETTING_AUDIO_OUTPUT_TO_ALL_SPEAKERS, videoSettings.m_OutputToAllSpeakers);
     m_settingsManager->SetBool(SETTING_AUDIO_PASSTHROUGH, CSettings::Get().GetBool("audiooutput.passthrough"));
 
-    m_settingsManager->SetBool(SETTING_SUBTITLE_ENABLE, videoSettings.m_SubtitleOn);
+    m_settingsManager->SetBool(SETTING_SUBTITLE_ENABLE, g_application.m_pPlayer->GetSubtitleVisible());
     m_settingsManager->SetNumber(SETTING_SUBTITLE_DELAY, videoSettings.m_SubtitleDelay);
     // TODO (needs special handling): m_settingsManager->SetInt(SETTING_SUBTITLE_STREAM, g_application.m_pPlayer->GetSubtitle());
   }


### PR DESCRIPTION
This is a follow-up on PR https://github.com/xbmc/xbmc/pull/4921.
Video settings are now stored **only** on user actions.

Thanks @Voyager1 for your help!
