### PR TITLE
DVDVideoCodecAmlogic: Remove throttling of MPEG2 playback

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -69,13 +69,6 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     case AV_CODEC_ID_MPEG1VIDEO:
     case AV_CODEC_ID_MPEG2VIDEO:
     case AV_CODEC_ID_MPEG2VIDEO_XVMC:
-      if (m_hints.width <= 1280)
-      {
-        // amcodec struggles with VOB playback
-        // which can be handled via software
-        return false;
-        break;
-      }
       m_mpeg2_sequence_pts = 0;
       m_mpeg2_sequence = new mpeg2_sequence;
       m_mpeg2_sequence->width  = m_hints.width;


### PR DESCRIPTION
- 56ebbc6 introduced logic in place for playback conditions on the Amlogic
  devices. However, after this commit was merged MPEG2 streams started to
  be HW decoded and thus throwing off the logic put in place to accomodate
  direct .VOB playback.
- Remove the MPEG2 width check and let amcodec handle the playback if all
  else checks out

Signed-off-by: Brandon McAnsh brandonm@matricom.net
