### PR TITLE
Allow larger font size

### DIFF
--- a/addons/skin.confluence/720p/Font.xml
+++ b/addons/skin.confluence/720p/Font.xml
@@ -88,93 +88,92 @@
 		</font>
 	</fontset>
 
-	<fontset id="Massive" idloc="31393" unicode="true">
-        <!-- Normal Fonts -->
-        <font>
-            <name>font10</name>
-            <filename>Roboto-Regular.ttf</filename>
-            <size>14</size>
-        </font>
-        <font>
-            <name>font12</name>
-            <filename>Roboto-Regular.ttf</filename>
-            <size>23</size>
-        </font>
-        <font>
-            <name>font13</name>
-            <filename>Roboto-Regular.ttf</filename>
-            <size>25</size>
-        </font>
-        <font>
-            <name>font14</name>
-            <filename>Roboto-Regular.ttf</filename>
-            <size>25</size>
-        </font>
-        <font>
-            <name>font16</name>
-            <filename>Roboto-Regular.ttf</filename>
-            <size>25</size>
-        </font>
-        <font>
-            <name>font30</name>
-            <filename>Roboto-Regular.ttf</filename>
-            <size>30</size>
-        </font>
-        <font>
-            <name>fontContextMenu</name>
-            <filename>Roboto-Regular.ttf</filename>
-            <size>25</size>
-        </font>
-
-
-        <!-- Title Fonts -->
-        <font>
-            <name>font10_title</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>12</size>
-        </font>
-        <font>
-            <name>font12_title</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>17</size>
-        </font>
-        <font>
-            <name>font13_title</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>20</size>
-        </font>
-        <font>
-            <name>font24_title</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>24</size>
-        </font>
-        <font>
-            <name>font28_title</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>28</size>
-        </font>
-        <font>
-            <name>font30_title</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>30</size>
-        </font>
-        <font>
-            <name>font35_title</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>35</size>
-        </font>
-
-        <font>
-            <name>font_MainMenu</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>40</size>
-        </font>
-        <font>
-            <name>WeatherTemp</name>
-            <filename>Roboto-Bold.ttf</filename>
-            <size>80</size>
-        </font>
-    </fontset>
+	<fontset id="Massive" idloc="15110">
+		<!-- Normal Fonts -->
+		<font>
+			<name>font10</name>
+			<filename>Roboto-Regular.ttf</filename>
+			<size>14</size>
+		</font>
+		<font>
+			<name>font12</name>
+			<filename>Roboto-Regular.ttf</filename>
+			<size>23</size>
+		</font>
+		<font>
+			<name>font13</name>
+			<filename>Roboto-Regular.ttf</filename>
+			<size>25</size>
+		</font>
+		<font>
+			<name>font14</name>
+			<filename>Roboto-Regular.ttf</filename>
+			<size>25</size>
+		</font>
+		<font>
+			<name>font16</name>
+			<filename>Roboto-Regular.ttf</filename>
+			<size>25</size>
+		</font>
+		<font>
+			<name>font30</name>
+			<filename>Roboto-Regular.ttf</filename>
+			<size>30</size>
+		</font>
+		<font>
+			<name>fontContextMenu</name>
+			<filename>Roboto-Regular.ttf</filename>
+			<size>25</size>
+		</font>
+		
+		
+		<!-- Title Fonts -->
+		<font>
+			<name>font10_title</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>12</size>
+		</font>
+		<font>
+			<name>font12_title</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>17</size>
+		</font>
+		<font>
+			<name>font13_title</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>20</size>
+		</font>
+		<font>
+			<name>font24_title</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>24</size>
+		</font>
+		<font>
+			<name>font28_title</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>28</size>
+		</font>
+		<font>
+			<name>font30_title</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>30</size>
+		</font>
+		<font>
+			<name>font35_title</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>35</size>
+		</font>
+		<font>
+			<name>font_MainMenu</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>40</size>
+		</font>
+		<font>
+			<name>WeatherTemp</name>
+			<filename>Roboto-Bold.ttf</filename>
+			<size>80</size>
+		</font>
+	</fontset>
 	
 	<fontset id="DefaultNoCaps" idloc="31391"> 
 		<!-- Normal Fonts -->

--- a/addons/skin.confluence/720p/Font.xml
+++ b/addons/skin.confluence/720p/Font.xml
@@ -88,6 +88,94 @@
 		</font>
 	</fontset>
 
+	<fontset id="Massive" idloc="31393" unicode="true">
+        <!-- Normal Fonts -->
+        <font>
+            <name>font10</name>
+            <filename>Roboto-Regular.ttf</filename>
+            <size>14</size>
+        </font>
+        <font>
+            <name>font12</name>
+            <filename>Roboto-Regular.ttf</filename>
+            <size>23</size>
+        </font>
+        <font>
+            <name>font13</name>
+            <filename>Roboto-Regular.ttf</filename>
+            <size>25</size>
+        </font>
+        <font>
+            <name>font14</name>
+            <filename>Roboto-Regular.ttf</filename>
+            <size>25</size>
+        </font>
+        <font>
+            <name>font16</name>
+            <filename>Roboto-Regular.ttf</filename>
+            <size>25</size>
+        </font>
+        <font>
+            <name>font30</name>
+            <filename>Roboto-Regular.ttf</filename>
+            <size>30</size>
+        </font>
+        <font>
+            <name>fontContextMenu</name>
+            <filename>Roboto-Regular.ttf</filename>
+            <size>25</size>
+        </font>
+
+
+        <!-- Title Fonts -->
+        <font>
+            <name>font10_title</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>12</size>
+        </font>
+        <font>
+            <name>font12_title</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>17</size>
+        </font>
+        <font>
+            <name>font13_title</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>20</size>
+        </font>
+        <font>
+            <name>font24_title</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>24</size>
+        </font>
+        <font>
+            <name>font28_title</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>28</size>
+        </font>
+        <font>
+            <name>font30_title</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>30</size>
+        </font>
+        <font>
+            <name>font35_title</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>35</size>
+        </font>
+
+        <font>
+            <name>font_MainMenu</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>40</size>
+        </font>
+        <font>
+            <name>WeatherTemp</name>
+            <filename>Roboto-Bold.ttf</filename>
+            <size>80</size>
+        </font>
+    </fontset>
+	
 	<fontset id="DefaultNoCaps" idloc="31391"> 
 		<!-- Normal Fonts -->
 		<font>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6878,7 +6878,9 @@ msgctxt "#15109"
 msgid "Skin default"
 msgstr ""
 
-#empty string with id 15110
+msgctxt "#15110"
+msgid "Larger font size"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#15111"


### PR DESCRIPTION
This trick is useful for composite tvs (e.g raspberry pi). With the confluence stock, fonts are all very small and almost unreadable especially the movie descriptions.

Trick source: http://forum.xbmc.org/showthread.php?tid=127671

I don't know if strings.po ID has any order, so I selected some random ID.
