### PR TITLE
[tagloader] read popm ratings from banshee (closes #15333)

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -449,6 +449,7 @@ bool CTagLoaderTagLib::ParseID3v2Tag(ID3v2::Tag *id3v2, EmbeddedArt *art, CMusic
         else if (tag.GetRating() == '0')
         {
           if (popFrame->email() != "Windows Media Player 9 Series" &&
+              popFrame->email() != "Banshee" &&
               popFrame->email() != "no@email" &&
               popFrame->email() != "quodlibet@lists.sacredchao.net" &&
               popFrame->email() != "rating@winamp.com")


### PR DESCRIPTION
This commit adds support for reading popm ratings from banshee. Ticket @ trac.xbmc.org/ticket/15333.
