### PR TITLE
fixed: show icon for addons installed from zip

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -299,6 +299,7 @@ bool CAddonInstaller::InstallFromZip(const CStdString &path)
   {
     // set the correct path
     addon->Props().path = items[0]->GetPath();
+    addon->Props().icon = URIUtils::AddFileToFolder(items[0]->GetPath(), "icon.png");
 
     // install the addon
     return DoInstall(addon);


### PR DESCRIPTION
This should resolve issue of the kay notification displaying blank icon on installing from zip

Backport from notspiff as per irc

Confirmed fixed issue on Linux
