### PR TITLE
[rar] add a callback class for unrarlib rather than calling into guilib

### DIFF
--- a/lib/UnrarXLib/UnrarX.hpp
+++ b/lib/UnrarXLib/UnrarX.hpp
@@ -34,7 +34,8 @@ typedef struct archivelist
           or NULL for all files.
   libpassword   - Password (for encrypted archives)
 \*-------------------------------------------------------------------------*/
-int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libpassword = NULL, int64_t* iOffset=NULL, bool bShowProgress=false);
+typedef bool (*progress_callback)(void*, int, const char*);
+int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libpassword = NULL, int64_t* iOffset=NULL, progress_callback progress = NULL, void *context = NULL);
 
 /*-------------------------------------------------------------------------*\
   List the files in a RAR file

--- a/lib/UnrarXLib/rar.cpp
+++ b/lib/UnrarXLib/rar.cpp
@@ -1,7 +1,6 @@
 #include "rar.hpp"
 #include "UnrarX.hpp"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogProgress.h"
 #include "filesystem/File.h"
 
 #include "smallfn.cpp"
@@ -142,7 +141,7 @@ int main(int argc, char *argv[])
           or NULL for all files.
   libpassword   - Password (for encrypted archives)
 \*-------------------------------------------------------------------------*/
-int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libpassword, int64_t* iOffset, bool bShowProgress)
+int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libpassword, int64_t* iOffset, progress_callback progress, void *context)
 {
   InitCRC();
   int bRes = 1;
@@ -200,16 +199,8 @@ int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libp
             pExtract->GetDataIO().TotalArcSize+=FD.Size;
           pExtract->ExtractArchiveInit(pCmd.get(),*pArc);
 
-          if (bShowProgress)
-          {
-            pExtract->GetDataIO().m_pDlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
-            if (pExtract->GetDataIO().m_pDlgProgress)
-            {
-              pExtract->GetDataIO().m_pDlgProgress->SetHeading(fileToExtract);
-              pExtract->GetDataIO().m_pDlgProgress->SetCanCancel(false);
-              pExtract->GetDataIO().m_pDlgProgress->StartModal();
-            }
-          }
+          pExtract->GetDataIO().m_progress = progress;
+          pExtract->GetDataIO().m_context = context;
 
           int64_t iOff=0;
           bool bSeeked = false;
@@ -237,8 +228,6 @@ int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libp
             
             if (pExtract->GetDataIO().bQuit) 
             {
-              if (pExtract->GetDataIO().m_pDlgProgress)
-                pExtract->GetDataIO().m_pDlgProgress->Close();
               bRes = 2;
               break;
             }
@@ -269,12 +258,7 @@ int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libp
           }
 
           pExtract->GetDataIO().ProcessedArcSize+=FD.Size;         
-          if (pExtract->GetDataIO().m_pDlgProgress)
-            pExtract->GetDataIO().m_pDlgProgress->ShowProgressBar(false);
         }
-        if (bShowProgress)
-          if (pExtract->GetDataIO().m_pDlgProgress)
-            pExtract->GetDataIO().m_pDlgProgress->Close();
       }
     }
   }

--- a/lib/UnrarXLib/rdwrfn.hpp
+++ b/lib/UnrarXLib/rdwrfn.hpp
@@ -7,7 +7,7 @@ class Unpack;
 #include "system.h"
 #include "threads/Event.h"
 
-class CGUIDialogProgress;
+typedef bool (*progress_callback)(void*, int, const char*);
 
 class ComprDataIO
 {
@@ -90,7 +90,8 @@ class ComprDataIO
     CEvent* hSeek;
     CEvent* hSeekDone;
     CEvent* hQuit;
-    CGUIDialogProgress* m_pDlgProgress;
+    progress_callback m_progress;
+    void*             m_context;
     bool bQuit;
     Int64 m_iSeekTo;
     Int64 m_iStartOfBuffer;

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -50,6 +50,7 @@ public:
 
 protected:
   virtual int GetDefaultLabelID(int controlId) const;
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
   bool m_bCanCancel;
   bool m_bCanceled;
@@ -57,4 +58,5 @@ protected:
   int  m_iCurrent;
   int  m_iMax;
   int m_percentage;
+  bool m_showProgress;
 };


### PR DESCRIPTION
We don't want to call into guilib directly from unrarlib, so this does the same as what we were doing (though with a 200ms delay) via a callback class.

@mkortstiege This should be pretty equivalent to what we already have in master.  i.e. it is useful as a base from which to make further changes, such as increasing the time before display, or switching to busy dialog etc.
