### PR TITLE
Fix Darwin host identification

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -60,6 +60,7 @@
 /* Platform identification */
 #if defined(TARGET_DARWIN)
 #include <Availability.h>
+#include <mach-o/arch.h>
 #elif defined(TARGET_ANDROID)
 #include <android/api-level.h>
 #include <sys/system_properties.h>
@@ -903,6 +904,12 @@ int CSysInfo::GetKernelBitness(void)
     return 64;
 
   return 0; // Can't detect OS
+#elif defined(TARGET_DARWIN_IOS)
+  // Note: OS X return x86 CPU type without CPU_ARCH_ABI64 flag
+  const NXArchInfo* archInfo = NXGetLocalArchInfo();
+  if (archInfo)
+    return ((archInfo->cputype & CPU_ARCH_ABI64) != 0) ? 64 : 32;
+  return 0; // system information is not available
 #elif defined(TARGET_POSIX)
   struct utsname un;
   if (uname(&un) == 0)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -929,49 +929,54 @@ int CSysInfo::GetKernelBitness(void)
   return kernelBitness;
 }
 
-std::string CSysInfo::GetKernelCpuFamily(void)
+const std::string& CSysInfo::GetKernelCpuFamily(void)
 {
+  static std::string kernelCpuFamily;
+  if (kernelCpuFamily.empty())
+  {
 #ifdef TARGET_WINDOWS
-  SYSTEM_INFO si;
-  GetNativeSystemInfo(&si);
-  if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL ||
-      si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
-    return "x86";
-
-  if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
-    return "ARM";
+    SYSTEM_INFO si;
+    GetNativeSystemInfo(&si);
+    if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL ||
+        si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
+        kernelCpuFamily = "x86";
+    else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
+      kernelCpuFamily = "ARM";
 #elif defined(TARGET_DARWIN)
-  const NXArchInfo* archInfo = NXGetLocalArchInfo();
-  if (archInfo)
-  {
-    const cpu_type_t cpuType = (archInfo->cputype & ~CPU_ARCH_ABI64); // get CPU family without 64-bit ABI flag
-    if (cpuType == CPU_TYPE_I386)
-      return "x86";
-    if (cpuType == CPU_TYPE_ARM)
-      return "ARM";
-    if (cpuType == CPU_TYPE_POWERPC)
-      return "PowerPC";
+    const NXArchInfo* archInfo = NXGetLocalArchInfo();
+    if (archInfo)
+    {
+      const cpu_type_t cpuType = (archInfo->cputype & ~CPU_ARCH_ABI64); // get CPU family without 64-bit ABI flag
+      if (cpuType == CPU_TYPE_I386)
+        kernelCpuFamily = "x86";
+      else if (cpuType == CPU_TYPE_ARM)
+        kernelCpuFamily = "ARM";
+      else if (cpuType == CPU_TYPE_POWERPC)
+        kernelCpuFamily = "PowerPC";
 #ifdef CPU_TYPE_MIPS
-    if (cpuType == CPU_TYPE_MIPS)
-      return "MIPS";
+      else if (cpuType == CPU_TYPE_MIPS)
+        kernelCpuFamily = "MIPS";
 #endif // CPU_TYPE_MIPS
-  }
+    }
 #elif defined(TARGET_POSIX)
-  struct utsname un;
-  if (uname(&un) == 0)
-  {
-    std::string machine(un.machine);
-    if (machine.compare(0, 3, "arm", 3) == 0)
-      return "ARM";
-    if (machine.compare(0, 4, "mips", 4) == 0)
-      return "MIPS";
-    if (machine.compare(0, 4, "i686", 4) == 0 || machine == "i386" || machine == "amd64" ||  machine.compare(0, 3, "x86", 3) == 0)
-      return "x86";
-    if (machine.compare(0, 3, "ppc", 3) == 0 || machine.compare(0, 5, "power", 5) == 0)
-      return "PowerPC";
-  }
+    struct utsname un;
+    if (uname(&un) == 0)
+    {
+      std::string machine(un.machine);
+      if (machine.compare(0, 3, "arm", 3) == 0)
+        kernelCpuFamily = "ARM";
+      else if (machine.compare(0, 4, "mips", 4) == 0)
+        kernelCpuFamily = "MIPS";
+      else if (machine.compare(0, 4, "i686", 4) == 0 || machine == "i386" || machine == "amd64" ||  machine.compare(0, 3, "x86", 3) == 0)
+        kernelCpuFamily = "x86";
+      else if (machine.compare(0, 3, "ppc", 3) == 0 || machine.compare(0, 5, "power", 5) == 0)
+        kernelCpuFamily = "PowerPC";
+    }
 #endif
-  return "unknown CPU family";
+    if (kernelCpuFamily.empty())
+      kernelCpuFamily = "unknown CPU family";
+  }
+  return kernelCpuFamily;
 }
 
 int CSysInfo::GetXbmcBitness(void)

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -937,6 +937,22 @@ std::string CSysInfo::GetKernelCpuFamily(void)
 
   if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
     return "ARM";
+#elif defined(TARGET_DARWIN)
+  const NXArchInfo* archInfo = NXGetLocalArchInfo();
+  if (archInfo)
+  {
+    const cpu_type_t cpuType = (archInfo->cputype & ~CPU_ARCH_ABI64); // get CPU family without 64-bit ABI flag
+    if (cpuType == CPU_TYPE_I386)
+      return "x86";
+    if (cpuType == CPU_TYPE_ARM)
+      return "ARM";
+    if (cpuType == CPU_TYPE_POWERPC)
+      return "PowerPC";
+#ifdef CPU_TYPE_MIPS
+    if (cpuType == CPU_TYPE_MIPS)
+      return "MIPS";
+#endif // CPU_TYPE_MIPS
+  }
 #elif defined(TARGET_POSIX)
   struct utsname un;
   if (uname(&un) == 0)
@@ -950,11 +966,6 @@ std::string CSysInfo::GetKernelCpuFamily(void)
       return "x86";
     if (machine.compare(0, 3, "ppc", 3) == 0 || machine.compare(0, 5, "power", 5) == 0)
       return "PowerPC";
-// ios saves the dev id like AppleTV2,1 in the machine
-// field - all ios devices are ARM - force this here...
-#if defined(TARGET_DARWIN_IOS)
-    return "ARM";
-#endif
   }
 #endif
   return "unknown CPU family";

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -117,7 +117,7 @@ public:
   static WindowsVersion GetWindowsVersion();
   static int GetKernelBitness(void);
   static int GetXbmcBitness(void);
-  static std::string GetKernelCpuFamily(void);
+  static const std::string& GetKernelCpuFamily(void);
   std::string GetCPUModel();
   std::string GetCPUBogoMips();
   std::string GetCPUHardware();

--- a/xbmc/utils/test/TestSystemInfo.cpp
+++ b/xbmc/utils/test/TestSystemInfo.cpp
@@ -35,6 +35,28 @@ protected:
   }
 };
 
+TEST_F(TestSystemInfo, Print_System_Info)
+{
+  std::cout << "'GetKernelName(false)': \"" << g_sysinfo.GetKernelName(true) << "\"\n";
+  std::cout << "'GetKernelVersion()': \"" << g_sysinfo.GetKernelVersion() << "\"\n";
+  std::cout << "'GetKernelVersionFull()': \"" << g_sysinfo.GetKernelVersionFull() << "\"\n";
+  std::cout << "'GetOsPrettyNameWithVersion()': \"" << g_sysinfo.GetOsPrettyNameWithVersion() << "\"\n";
+  std::cout << "'GetOsName(false)': \"" << g_sysinfo.GetOsName(false) << "\"\n";
+  std::cout << "'GetOsVersion()': \"" << g_sysinfo.GetOsVersion() << "\"\n";
+  std::cout << "'GetKernelCpuFamily()': \"" << g_sysinfo.GetKernelCpuFamily() << "\"\n";
+  std::cout << "'GetKernelBitness()': \"" << g_sysinfo.GetKernelBitness() << "\"\n";
+  std::cout << "'GetBuildTargetPlatformName()': \"" << g_sysinfo.GetBuildTargetPlatformName() << "\"\n";
+  std::cout << "'GetBuildTargetPlatformVersionDecoded()': \"" << g_sysinfo.GetBuildTargetPlatformVersionDecoded() << "\"\n";
+  std::cout << "'GetBuildTargetPlatformVersion()': \"" << g_sysinfo.GetBuildTargetPlatformVersion() << "\"\n";
+  std::cout << "'GetBuildTargetCpuFamily()': \"" << g_sysinfo.GetBuildTargetCpuFamily() << "\"\n";
+  std::cout << "'GetXbmcBitness()': \"" << g_sysinfo.GetXbmcBitness() << "\"\n";
+  std::cout << "'GetUsedCompilerNameAndVer()': \"" << g_sysinfo.GetUsedCompilerNameAndVer() << "\"\n";
+  std::cout << "'GetManufacturerName()': \"" << g_sysinfo.GetManufacturerName() << "\"\n";
+  std::cout << "'GetModelName()': \"" << g_sysinfo.GetModelName() << "\"\n";
+  std::cout << "'IsAppleTV2()': \"" << g_sysinfo.IsAppleTV2() << "\"\n";
+  std::cout << "'GetUserAgent()': \"" << g_sysinfo.GetUserAgent() << "\"\n";
+}
+
 TEST_F(TestSystemInfo, GetKernelName)
 {
   EXPECT_FALSE(g_sysinfo.GetKernelName(true).empty()) << "'GetKernelName(true)' must not return empty kernel name";


### PR DESCRIPTION
This PR should replace hardcoded kernel architecture for Darwin iOS with real architecture detection.
Also kernel bitness should be fixed for Darwin iOS.
Additionally `SysInfo::GetKernelBitness` and `SysInfo::GetKernelCpuFamily` now cache values instead of detection each time.
OS X detection was checked locally, iOS detection should work according to http://blog.timac.org/?p=907 and [source code of `NXGetLocalArchInfo()`](http://www.opensource.apple.com/source/cctools/cctools-855/libmacho/arch.c).
It wold be great if some darwin dev will be able to check it on real Arm64 device.

@Memphiz @jmarshallnz ?
