### PR TITLE
[videodb] we can't use REPLACE INTO when updating values during UpdateTables

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4627,7 +4627,9 @@ void CVideoDatabase::UpdateTables(int iVersion)
       for (vector<string>::const_iterator j = paths.begin(); j != paths.end(); ++j)
       {
         int idPath = AddPath(*j, URIUtils::GetParentPath(*j));
-        m_pDS->exec(PrepareSQL("REPLACE INTO tvshowlinkpath(idShow, idPath) VALUES(%i,%i)", i->show, idPath));
+        /* we can't rely on REPLACE INTO here as analytics (indices) aren't online yet */
+        if (GetSingleValue(PrepareSQL("SELECT 1 FROM tvshowlinkpath WHERE idShow=%i AND idPath=%i", i->show, idPath)).empty())
+          m_pDS->exec(PrepareSQL("INSERT INTO tvshowlinkpath(idShow, idPath) VALUES(%i,%i)", i->show, idPath));
       }
       m_pDS->exec(PrepareSQL("DELETE FROM tvshowlinkpath WHERE idShow=%i AND idPath=%i", i->show, i->pathId));
     }


### PR DESCRIPTION
Reason is analytics aren't in place. Fixes problems where a show path appearing in more than one multipath being duplicated on update (thus failing). 

Fixes #15334

@Montellese mind sanity checking (it's reasonably straight-forward!)
