### PR TITLE
[pvr] workaround a deadlock if no pvr addons exist and you activate the pvr manager

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1142,8 +1142,8 @@ bool CPVRClients::UpdateAddons(void)
     // You need a tuner, backend software, and an add-on for the backend to be able to use PVR.
     // Please visit xbmc.org/pvr to learn more.
     m_bNoAddonWarningDisplayed = true;
-    CSettings::Get().SetBool("pvrmanager.enabled", false);
     CGUIDialogOK::ShowAndGetInput(19271, 19272, 19273, 19274);
+    CSettings::Get().SetBool("pvrmanager.enabled", false);
     CGUIMessage msg(GUI_MSG_UPDATE, WINDOW_SETTINGS_MYPVR, 0);
     g_windowManager.SendThreadMessage(msg, WINDOW_SETTINGS_MYPVR);
   }


### PR DESCRIPTION
Found by @mkortstiege, thanks ;) The modal dialog introduces a deadlock if called after the settings change. We don't know the root cause of this deadlock, but this shift workaround the issue.

Remove all PVR addons and disable/enable the PVR manager and you get the freeze.
