### PR TITLE
Use an edit control in the keyboard dialog

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2574,11 +2574,6 @@
         </setting>
       </group>
       <group id="2">
-        <setting id="input.remoteaskeyboard" type="boolean" label="21449" help="36376">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <setting id="input.enablemouse" type="boolean" label="21369" help="36377">
           <level>0</level>
           <control type="toggle" />

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2465,35 +2465,31 @@ bool CApplication::OnKey(const CKey& key)
     }
     if (useKeyboard)
     {
-      action = CAction(0); // reset our action
-      if (CSettings::Get().GetBool("input.remoteaskeyboard"))
+      // use the virtualkeyboard section of the keymap, and send keyboard-specific or navigation
+      // actions through if that's what they are
+      CAction action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key);
+      if (!(action.GetID() == ACTION_MOVE_LEFT ||
+            action.GetID() == ACTION_MOVE_RIGHT ||
+            action.GetID() == ACTION_MOVE_UP ||
+            action.GetID() == ACTION_MOVE_DOWN ||
+            action.GetID() == ACTION_SELECT_ITEM ||
+            action.GetID() == ACTION_ENTER ||
+            action.GetID() == ACTION_PREVIOUS_MENU ||
+            action.GetID() == ACTION_NAV_BACK))
       {
-        // users remote is executing keyboard commands, so use the virtualkeyboard section of keymap.xml
-        // and send those rather than actual keyboard presses.  Only for navigation-type commands though
-        action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key);
-        if (!(action.GetID() == ACTION_MOVE_LEFT ||
-              action.GetID() == ACTION_MOVE_RIGHT ||
-              action.GetID() == ACTION_MOVE_UP ||
-              action.GetID() == ACTION_MOVE_DOWN ||
-              action.GetID() == ACTION_SELECT_ITEM ||
-              action.GetID() == ACTION_ENTER ||
-              action.GetID() == ACTION_PREVIOUS_MENU ||
-              action.GetID() == ACTION_NAV_BACK))
-        {
-          // the action isn't plain navigation - check for a keyboard-specific keymap
-          action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key, false);
-          if (!(action.GetID() >= REMOTE_0 && action.GetID() <= REMOTE_9) ||
-                action.GetID() == ACTION_BACKSPACE ||
-                action.GetID() == ACTION_SHIFT ||
-                action.GetID() == ACTION_SYMBOLS ||
-                action.GetID() == ACTION_CURSOR_LEFT ||
-                action.GetID() == ACTION_CURSOR_RIGHT)
-            action = CAction(0); // don't bother with this action
-        }
+        // the action isn't plain navigation - check for a keyboard-specific keymap
+        action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key, false);
+        if (!(action.GetID() >= REMOTE_0 && action.GetID() <= REMOTE_9) ||
+              action.GetID() == ACTION_BACKSPACE ||
+              action.GetID() == ACTION_SHIFT ||
+              action.GetID() == ACTION_SYMBOLS ||
+              action.GetID() == ACTION_CURSOR_LEFT ||
+              action.GetID() == ACTION_CURSOR_RIGHT)
+          action = CAction(0); // don't bother with this action
       }
+      // else pass the keys through directly
       if (!action.GetID())
       {
-        // keyboard entry - pass the keys through directly
         if (key.GetFromService())
           action = CAction(key.GetButtonCode() != KEY_INVALID ? key.GetButtonCode() : 0, key.GetUnicode());
         else

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.h
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.h
@@ -36,19 +36,14 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     virtual void Cancel();
     virtual int GetWindowId() const;
 
-    //CGUIDialog Interface
-    virtual void FrameMove();
     void SetHeading(const std::string& heading);
-    void SetText(const std::string& aTextString);
-    void InputText(const std::string& aTextString);
-    void InputTextEditing(const std::string& aTextString, int start, int length);
-    std::string GetText() const;
+    void SetText(const std::string& text);
+    const std::string &GetText() const;
     bool IsConfirmed() { return m_bIsConfirmed; };
     void SetHiddenInput(bool hiddenInput) { m_hiddenInput = hiddenInput; };
-    void Character(WCHAR wch);
-    void OnPasteClipboard(void);
 
   protected:
+    virtual void OnWindowLoaded();
     virtual void OnInitWindow();
     virtual bool OnAction(const CAction &action);
     virtual bool OnMessage(CGUIMessage& message);
@@ -56,29 +51,18 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void SetControlLabel(int id, const std::string &label);
     void OnShift();
     void MoveCursor(int iAmount);
-    void SetCursorPos(int iPos);
-    int GetCursorPos() const;
     void OnSymbols();
     void OnIPAddress();
     void OnOK();
 
   private:
     void OnClickButton(int iButtonControl);
-    void OnRemoteNumberClick(int key);
     void UpdateButtons();
     char GetCharacter(int iButton);
-    void UpdateLabel();
-    void ResetShiftAndSymbols();
+    void Character(char ch);
     void Backspace();
+    void SetEditText(const std::string& text);
     void SendSearchMessage();
-
-    std::wstring m_strEdit;
-    int m_iCursorPos;
-
-    // holds the spelling region of keystrokes/text generated from 'input method'
-    std::wstring m_strEditing;
-    int m_iEditingOffset;
-    int m_iEditingLength;
 
     bool m_bIsConfirmed;
     KEYBOARD m_keyType;
@@ -86,11 +70,8 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     bool m_bShift;
     bool m_hiddenInput;
 
-    unsigned int m_lastRemoteClickTime;
-    WORD m_lastRemoteKeyClicked;
-    int m_indexInSeries;
     std::string m_strHeading;
-    static const char* s_charsSeries[10];
+    std::string m_text;       ///< current text
 
 
     char_callback_t m_pCharCallback;

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -539,13 +539,20 @@ void CGUIEditControl::SetHint(const CGUIInfoLabel& hint)
 CStdStringW CGUIEditControl::GetDisplayedText() const
 {
   CStdStringW text(m_text2);
-  if (!m_edit.empty())
-  {
-    text.insert(m_editOffset, m_edit);
-    // TODO: highlighting
-  }
   if (m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW)
-    text = CStdStringW(text.size(), L'*');
+  {
+    text.clear();
+    if (m_smsTimer.IsRunning())
+    { // using the remove to input, so display the last key input
+      text.append(m_cursorPos - 1, L'*');
+      text.append(1, m_text2[m_cursorPos - 1]);
+      text.append(m_text2.size() - m_cursorPos, L'*');
+    }
+    else
+      text.append(m_text2.size(), L'*');;
+  }
+  else if (!m_edit.empty())
+    text.insert(m_editOffset, m_edit);
   return text;
 }
 

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -563,18 +563,32 @@ bool CGUIEditControl::SetStyledText(const CStdStringW &text)
 
   vecColors colors;
   colors.push_back(m_label.GetLabelInfo().textColor);
+  colors.push_back(m_label.GetLabelInfo().disabledColor);
+  color_t select = m_label.GetLabelInfo().selectedColor;
+  if (!select)
+    select = 0xFFFF0000;
+  colors.push_back(select);
   colors.push_back(0x00FFFFFF);
+
+  unsigned int startHighlight = m_cursorPos;
+  unsigned int endHighlight   = m_cursorPos + m_edit.size();
+  unsigned int startSelection = m_cursorPos + m_editOffset;
+  unsigned int endSelection   = m_cursorPos + m_editOffset + m_editLength;
 
   for (unsigned int i = 0; i < text.size(); i++)
   {
     unsigned int ch = text[i];
+    if (m_editLength > 0 && startSelection <= i && i < endSelection)
+      ch |= (2 << 16); // highlight the letters we're playing with
+    else if (!m_edit.empty() && (i < startHighlight || i >= endHighlight))
+      ch |= (1 << 16); // dim the bits we're not editing
     styled.push_back(ch);
   }
 
   // show the cursor
   unsigned int ch = L'|';
   if ((++m_cursorBlink % 64) > 32)
-    ch |= (1 << 16);
+    ch |= (3 << 16);
   styled.insert(styled.begin() + m_cursorPos, ch);
 
   return m_label2.SetStyledText(styled, colors);

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -141,7 +141,8 @@ bool CGUIEditControl::OnAction(const CAction &action)
       }
       return true;
     }
-    else if (action.GetID() == ACTION_MOVE_LEFT)
+    else if (action.GetID() == ACTION_MOVE_LEFT ||
+             action.GetID() == ACTION_CURSOR_LEFT)
     {
       if (m_cursorPos > 0)
       {
@@ -150,7 +151,8 @@ bool CGUIEditControl::OnAction(const CAction &action)
         return true;
       }
     }
-    else if (action.GetID() == ACTION_MOVE_RIGHT)
+    else if (action.GetID() == ACTION_MOVE_RIGHT ||
+             action.GetID() == ACTION_CURSOR_RIGHT)
     {
       if ((unsigned int) m_cursorPos < m_text2.size())
       {

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -60,6 +60,7 @@ void CGUIEditControl::DefaultConstructor()
   m_textWidth = GetWidth();
   m_cursorPos = 0;
   m_cursorBlink = 0;
+  m_cursorShowAlways = false;
   m_inputHeading = 0;
   m_inputType = INPUT_TYPE_TEXT;
   m_smsLastKey = 0;
@@ -493,7 +494,7 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
 
     CStdStringW text = GetDisplayedText();
     // add the cursor and highlighting if we're focused
-    if (HasFocus() && m_inputType != INPUT_TYPE_READONLY)
+    if ((HasFocus() || m_cursorShowAlways) && m_inputType != INPUT_TYPE_READONLY)
       changed |= SetStyledText(text);
     else
     {

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -85,6 +85,7 @@ public:
   virtual void SetInputValidation(StringValidation::Validator inputValidator, void *data = NULL);
 
 protected:
+  virtual void SetFocus(bool focus);
   virtual void ProcessText(unsigned int currentTime);
   virtual void RenderText();
   virtual CGUILabel::COLOR GetTextColor() const;
@@ -129,6 +130,10 @@ protected:
   unsigned int m_smsKeyIndex;
   unsigned int m_smsLastKey;
   CStopWatch   m_smsTimer;
+
+  std::wstring m_edit;
+  int          m_editOffset;
+  int          m_editLength;
 
   static const char*        smsLetters[10];
   static const unsigned int smsDelay;

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -72,6 +72,8 @@ public:
 
   virtual CStdString GetLabel2() const;
 
+  void SetShowCursorAlways(bool always) { m_cursorShowAlways = always; }
+
   unsigned int GetCursorPosition() const;
   void SetCursorPosition(unsigned int iPosition);
 
@@ -117,6 +119,7 @@ protected:
 
   unsigned int m_cursorPos;
   unsigned int m_cursorBlink;
+  bool         m_cursorShowAlways;
 
   int m_inputHeading;
   INPUT_TYPE m_inputType;

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -90,6 +90,7 @@ protected:
   virtual void RenderText();
   virtual CGUILabel::COLOR GetTextColor() const;
   CStdStringW GetDisplayedText() const;
+  bool SetStyledText(const CStdStringW &text);
   void RecalcLabelPosition();
   void ValidateCursor();
   void UpdateText(bool sendUpdate = true);


### PR DESCRIPTION
This takes care of various bugs/sillies that have been quite long standing (e.g. weirdness with long labels input into the keyboard dialog, masses of duplicate code etc.)

It also means we can drop the silly "remote sends keyboard presses" setting that is confusing to users.

Note that this does not address the numeric dialog, which is a different issue, but could potentially be remedied in a similar manner (thus we need to leave some code around in CGUILabelControl).

@koying: this should mean #4874 shouldn't be needed.
@ronie, @BigNoid, @Black09: needs confluence change, but should be fully backward compatible anyway.

Obviously this needs good testing, particularly on systems without a keyboard.
