### PR TITLE
Support international keyboard layouts in the virtual keyboard

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -1087,6 +1087,9 @@
 		7CF34D9F1930264A00D543C5 /* AudioEncoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF34D9D1930264A00D543C5 /* AudioEncoder.cpp */; };
 		7CF34DA01930264A00D543C5 /* AudioEncoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF34D9D1930264A00D543C5 /* AudioEncoder.cpp */; };
 		7CF34DA11930264A00D543C5 /* AudioEncoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF34D9D1930264A00D543C5 /* AudioEncoder.cpp */; };
+		7CF80DC919710DC2003B2B34 /* KeyboardLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF80DC719710DC2003B2B34 /* KeyboardLayout.cpp */; };
+		7CF80DCA19710DC2003B2B34 /* KeyboardLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF80DC719710DC2003B2B34 /* KeyboardLayout.cpp */; };
+		7CF80DCB19710DC2003B2B34 /* KeyboardLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF80DC719710DC2003B2B34 /* KeyboardLayout.cpp */; };
 		810C9FA90D67D1FB0095F5DD /* MythDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA50D67D1FB0095F5DD /* MythDirectory.cpp */; };
 		810C9FAA0D67D1FB0095F5DD /* MythFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA70D67D1FB0095F5DD /* MythFile.cpp */; };
 		815EE6350E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 815EE6330E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp */; };
@@ -4590,6 +4593,8 @@
 		7CF1FB0A123B1AF000B2CBCB /* Variant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Variant.h; sourceTree = "<group>"; };
 		7CF34D9D1930264A00D543C5 /* AudioEncoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioEncoder.cpp; sourceTree = "<group>"; };
 		7CF34D9E1930264A00D543C5 /* AudioEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioEncoder.h; sourceTree = "<group>"; };
+		7CF80DC719710DC2003B2B34 /* KeyboardLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyboardLayout.cpp; sourceTree = "<group>"; };
+		7CF80DC819710DC2003B2B34 /* KeyboardLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyboardLayout.h; sourceTree = "<group>"; };
 		810C9FA50D67D1FB0095F5DD /* MythDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MythDirectory.cpp; sourceTree = "<group>"; };
 		810C9FA60D67D1FB0095F5DD /* MythDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MythDirectory.h; sourceTree = "<group>"; };
 		810C9FA70D67D1FB0095F5DD /* MythFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MythFile.cpp; sourceTree = "<group>"; };
@@ -6708,6 +6713,8 @@
 				18B7C8CC12942546009E7A26 /* ButtonTranslator.h */,
 				DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */,
 				DFAB049713F8376700B70BFB /* InertialScrollingHandler.h */,
+				7CF80DC719710DC2003B2B34 /* KeyboardLayout.cpp */,
+				7CF80DC819710DC2003B2B34 /* KeyboardLayout.h */,
 				18B7C8CD12942546009E7A26 /* KeyboardLayoutConfiguration.cpp */,
 				18B7C8CE12942546009E7A26 /* KeyboardLayoutConfiguration.h */,
 				18B7C8CF12942546009E7A26 /* KeyboardStat.cpp */,
@@ -11804,6 +11811,7 @@
 				7C525DF5195E2D8100BE3482 /* SaveFileStateJob.cpp in Sources */,
 				7C908894196358A8003D0619 /* auto_buffer.cpp in Sources */,
 				7CF34D9F1930264A00D543C5 /* AudioEncoder.cpp in Sources */,
+				7CF80DC919710DC2003B2B34 /* KeyboardLayout.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12992,6 +13000,7 @@
 				7C525DF7195E2D8100BE3482 /* SaveFileStateJob.cpp in Sources */,
 				7C908896196358A8003D0619 /* auto_buffer.cpp in Sources */,
 				7CF34DA11930264A00D543C5 /* AudioEncoder.cpp in Sources */,
+				7CF80DCB19710DC2003B2B34 /* KeyboardLayout.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14182,6 +14191,7 @@
 				7C525DF6195E2D8100BE3482 /* SaveFileStateJob.cpp in Sources */,
 				7C908895196358A8003D0619 /* auto_buffer.cpp in Sources */,
 				7CF34DA01930264A00D543C5 /* AudioEncoder.cpp in Sources */,
+				7CF80DCA19710DC2003B2B34 /* KeyboardLayout.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/addons/skin.confluence/720p/DialogKeyboard.xml
+++ b/addons/skin.confluence/720p/DialogKeyboard.xml
@@ -4,8 +4,8 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>2</system>
-		<left>255</left>
-		<top>145</top>
+		<left>205</left>
+		<top>120</top>
 	</coordinates>
 	<controls>
 		<control type="group">
@@ -14,7 +14,7 @@
 			<control type="image">
 				<left>0</left>
 				<top>0</top>
-				<width>760</width>
+				<width>860</width>
 				<height>430</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
@@ -22,7 +22,7 @@
 				<description>Dialog Header image</description>
 				<left>40</left>
 				<top>16</top>
-				<width>680</width>
+				<width>780</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
@@ -30,7 +30,7 @@
 				<description>header label</description>
 				<left>40</left>
 				<top>20</top>
-				<width>720</width>
+				<width>820</width>
 				<height>30</height>
 				<font>font13_title</font>
 				<align>center</align>
@@ -40,7 +40,7 @@
 			</control>
 			<control type="button">
 				<description>Close Window button</description>
-				<left>670</left>
+				<left>770</left>
 				<top>15</top>
 				<width>64</width>
 				<height>32</height>
@@ -58,7 +58,7 @@
 			<control type="image">
 				<left>50</left>
 				<top>60</top>
-				<width>660</width>
+				<width>760</width>
 				<height>50</height>
 				<aspectratio>stretch</aspectratio>
 				<texture border="20">KeyboardEditArea.png</texture>
@@ -67,7 +67,7 @@
 				<description>Edit Text</description>
 				<left>55</left>
 				<top>60</top>
-				<width>650</width>
+				<width>750</width>
 				<height>50</height>
 				<font>font13</font>
 				<align>center</align>
@@ -78,7 +78,7 @@
 			<control type="image">
 				<left>130</left>
 				<top>110</top>
-				<width>500</width>
+				<width>600</width>
 				<height>30</height>
 				<aspectratio>stretch</aspectratio>
 				<texture>DialogHeader.png</texture>
@@ -86,788 +86,473 @@
 			<control type="group">
 				<left>30</left>
 				<top>140</top>
-				<control type="button" id="300">
-					<description>DONE button</description>
-					<left>0</left>
-					<top>0</top>
-					<width>200</width>
-					<height>50</height>
-					<label>20177</label>
-					<onleft>57</onleft>
-					<onright>48</onright>
-					<onup>307</onup>
-					<ondown>302</ondown>
-					<texturenofocus border="25,25,5,5">KeyboardCornerTopNF.png</texturenofocus>
-					<texturefocus border="25,25,5,5">KeyboardCornerTop.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+				<!-- 1st row -->
+				<control type="grouplist">
+					<itemgap>0</itemgap>
+					<orientation>horizontal</orientation>
+					<control type="button" id="309">
+						<description>Layout button</description>
+						<width>200</width>
+						<height>50</height>
+						<label>20177</label>
+						<onup>300</onup>
+						<ondown>302</ondown>
+						<texturenofocus border="25,25,5,5">KeyboardCornerTopNF.png</texturenofocus>
+						<texturefocus border="25,25,5,5">KeyboardCornerTop.png</texturefocus>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="button" id="100">
+						<description>(0,0) key button</description>
+						<onup>32</onup>
+						<ondown>120</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="101">
+						<description>(0,1) key button</description>
+						<onup>32</onup>
+						<ondown>121</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="102">
+						<description>(0,2) key button</description>
+						<onup>32</onup>
+						<ondown>122</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="103">
+						<description>(0,3) key button</description>
+						<onup>32</onup>
+						<ondown>123</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="104">
+						<description>(0,4) key button</description>
+						<onup>8</onup>
+						<ondown>124</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="105">
+						<description>(0,5) key button</description>
+						<onup>8</onup>
+						<ondown>125</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="106">
+						<description>(0,6) key button</description>
+						<onup>8</onup>
+						<ondown>126</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="107">
+						<description>(0,7) key button</description>
+						<onup>8</onup>
+						<ondown>127</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="108">
+						<description>(0,8) key button</description>
+						<onup>305</onup>
+						<ondown>128</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="109">
+						<description>(0,9) key button</description>
+						<onup>305</onup>
+						<ondown>129</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="110">
+						<description>(0,10) key button</description>
+						<onup>306</onup>
+						<ondown>130</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="111">
+						<description>(0,11) key button</description>
+						<onup>306</onup>
+						<ondown>131</ondown>
+						<texturenofocus flipx="true" border="5,25,25,5">KeyboardCornerTopNF.png</texturenofocus>
+						<texturefocus flipx="true" border="5,25,25,5">KeyboardCornerTop.png</texturefocus>
+						<include>KeyboardButton</include>
+					</control>
 				</control>
-				<control type="button" id="48">
-					<description>'0' button</description>
-					<left>200</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>300</onleft>
-					<onright>49</onright>
-					<onup>32</onup>
-					<ondown>65</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="49">
-					<description>'1' button</description>
-					<left>250</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>48</onleft>
-					<onright>50</onright>
-					<onup>32</onup>
-					<ondown>66</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="50">
-					<description>'2' button</description>
-					<left>300</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>49</onleft>
-					<onright>51</onright>
-					<onup>32</onup>
-					<ondown>67</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="51">
-					<description>'3' button</description>
-					<left>350</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>50</onleft>
-					<onright>52</onright>
-					<onup>32</onup>
-					<ondown>68</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="52">
-					<description>'4' button</description>
-					<left>400</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>51</onleft>
-					<onright>53</onright>
-					<onup>32</onup>
-					<ondown>69</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="53">
-					<description>'5' button</description>
-					<left>450</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>52</onleft>
-					<onright>54</onright>
-					<onup>32</onup>
-					<ondown>70</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="54">
-					<description>'6' button</description>
-					<left>500</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>53</onleft>
-					<onright>55</onright>
-					<onup>305</onup>
-					<ondown>71</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="55">
-					<description>'7' button</description>
-					<left>550</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>54</onleft>
-					<onright>56</onright>
-					<onup>305</onup>
-					<ondown>72</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="56">
-					<description>'8' button</description>
-					<left>600</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>55</onleft>
-					<onright>57</onright>
-					<onup>306</onup>
-					<ondown>73</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="57">
-					<description>'9' button</description>
-					<left>650</left>
-					<top>0</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>56</onleft>
-					<onright>300</onright>
-					<onup>306</onup>
-					<ondown>74</ondown>
-					<texturenofocus flipx="true" border="5,25,25,5">KeyboardCornerTopNF.png</texturenofocus>
-					<texturefocus flipx="true" border="5,25,25,5">KeyboardCornerTop.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="radiobutton" id="302">
-					<description>SHIFT button</description>
-					<left>0</left>
+					<!-- 2nd row -->
+				<control type="grouplist">
+					<orientation>horizontal</orientation>
 					<top>50</top>
-					<width>200</width>
-					<height>50</height>
-					<label>20178</label>
-					<onleft>74</onleft>
-					<onright>65</onright>
-					<onup>300</onup>
-					<ondown>303</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<radioposy>5</radioposy>
-					<radiowidth>20</radiowidth>
-					<radioheight>20</radioheight>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<itemgap>0</itemgap>
+					<control type="radiobutton" id="302">
+						<description>SHIFT button</description>
+						<width>200</width>
+						<height>50</height>
+						<label>20178</label>
+						<onup>309</onup>
+						<ondown>303</ondown>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<radioposy>5</radioposy>
+						<radiowidth>20</radiowidth>
+						<radioheight>20</radioheight>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="button" id="120">
+						<description>(1,0) key button</description>
+						<onup>100</onup>
+						<ondown>140</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="121">
+						<description>(1,1) key button</description>
+						<onup>101</onup>
+						<ondown>141</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="122">
+						<description>(1,2) key button</description>
+						<onup>102</onup>
+						<ondown>142</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="123">
+						<description>(1,3) key button</description>
+						<onup>103</onup>
+						<ondown>143</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="124">
+						<description>(1,4) key button</description>
+						<onup>104</onup>
+						<ondown>144</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="125">
+						<description>(1,5) key button</description>
+						<onup>105</onup>
+						<ondown>145</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="126">
+						<description>(1,6) key button</description>
+						<onup>106</onup>
+						<ondown>146</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="127">
+						<description>(1,7) key button</description>
+						<onup>107</onup>
+						<ondown>147</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="128">
+						<description>(1,8) key button</description>
+						<onup>108</onup>
+						<ondown>148</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="129">
+						<description>(1,9) key button</description>
+						<onup>109</onup>
+						<ondown>149</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="130">
+						<description>(1,10) key button</description>
+						<onup>110</onup>
+						<ondown>150</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="131">
+						<description>(1,11) key button</description>
+						<onup>111</onup>
+						<ondown>151</ondown>
+						<include>KeyboardButton</include>
+					</control>
 				</control>
-				<control type="button" id="65">
-					<description>'A' button</description>
-					<left>200</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>302</onleft>
-					<onright>66</onright>
-					<onup>48</onup>
-					<ondown>75</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="66">
-					<description>'B' button</description>
-					<left>250</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>65</onleft>
-					<onright>67</onright>
-					<onup>49</onup>
-					<ondown>76</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="67">
-					<description>'C' button</description>
-					<left>300</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>66</onleft>
-					<onright>68</onright>
-					<onup>50</onup>
-					<ondown>77</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="68">
-					<description>'D' button</description>
-					<left>350</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>67</onleft>
-					<onright>69</onright>
-					<onup>51</onup>
-					<ondown>78</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="69">
-					<description>'E' button</description>
-					<left>400</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>68</onleft>
-					<onright>70</onright>
-					<onup>52</onup>
-					<ondown>79</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="70">
-					<description>'F' button</description>
-					<left>450</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>69</onleft>
-					<onright>71</onright>
-					<onup>53</onup>
-					<ondown>80</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="71">
-					<description>'G' button</description>
-					<left>500</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>70</onleft>
-					<onright>72</onright>
-					<onup>54</onup>
-					<ondown>81</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="72">
-					<description>'H' button</description>
-					<left>550</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>71</onleft>
-					<onright>73</onright>
-					<onup>55</onup>
-					<ondown>82</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="73">
-					<description>'I' button</description>
-					<left>600</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>72</onleft>
-					<onright>74</onright>
-					<onup>56</onup>
-					<ondown>83</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="74">
-					<description>'J' button</description>
-					<left>650</left>
-					<top>50</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>73</onleft>
-					<onright>302</onright>
-					<onup>57</onup>
-					<ondown>84</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="radiobutton" id="303">
-					<description>CAPS LOCK button</description>
-					<left>0</left>
+					<!-- 3rd row -->
+				<control type="grouplist">
 					<top>100</top>
-					<width>200</width>
-					<height>50</height>
-					<label>20179</label>
-					<onleft>84</onleft>
-					<onright>75</onright>
-					<onup>302</onup>
-					<ondown>304</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<radioposy>5</radioposy>
-					<radiowidth>20</radiowidth>
-					<radioheight>20</radioheight>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<orientation>horizontal</orientation>
+					<itemgap>0</itemgap>
+					<control type="radiobutton" id="303">
+						<description>CAPS LOCK button</description>
+						<width>200</width>
+						<height>50</height>
+						<label>20179</label>
+						<onup>302</onup>
+						<ondown>307</ondown>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<radioposy>5</radioposy>
+						<radiowidth>20</radiowidth>
+						<radioheight>20</radioheight>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="button" id="140">
+						<description>(2,0) key button</description>
+						<onup>120</onup>
+						<ondown>160</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="141">
+						<description>(2,1) key button</description>
+						<onup>121</onup>
+						<ondown>161</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="142">
+						<description>(2,2) key button</description>
+						<onup>122</onup>
+						<ondown>162</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="143">
+						<description>(2,3) key button</description>
+						<onup>123</onup>
+						<ondown>163</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="144">
+						<description>(2,4) key button</description>
+						<onup>124</onup>
+						<ondown>164</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="145">
+						<description>(2,5) key button</description>
+						<onup>125</onup>
+						<ondown>165</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="146">
+						<description>(2,6) key button</description>
+						<onup>126</onup>
+						<ondown>166</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="147">
+						<description>(2,7) key button</description>
+						<onup>127</onup>
+						<ondown>167</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="148">
+						<description>(2,8) key button</description>
+						<onup>128</onup>
+						<ondown>168</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="149">
+						<description>(2,9) key button</description>
+						<onup>129</onup>
+						<ondown>169</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="150">
+						<description>(2,10) key button</description>
+						<onup>130</onup>
+						<ondown>170</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="151">
+						<description>(2,11) key button</description>
+						<onup>131</onup>
+						<ondown>171</ondown>
+						<include>KeyboardButton</include>
+					</control>
 				</control>
-				<control type="button" id="75">
-					<description>'K' button</description>
-					<left>200</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>303</onleft>
-					<onright>76</onright>
-					<onup>65</onup>
-					<ondown>85</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="76">
-					<description>'L' button</description>
-					<left>250</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>75</onleft>
-					<onright>77</onright>
-					<onup>66</onup>
-					<ondown>86</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="77">
-					<description>'M' button</description>
-					<left>300</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>76</onleft>
-					<onright>78</onright>
-					<onup>67</onup>
-					<ondown>87</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="78">
-					<description>'N' button</description>
-					<left>350</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>77</onleft>
-					<onright>79</onright>
-					<onup>68</onup>
-					<ondown>88</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="79">
-					<description>'O' button</description>
-					<left>400</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>78</onleft>
-					<onright>80</onright>
-					<onup>69</onup>
-					<ondown>89</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="80">
-					<description>'P' button</description>
-					<left>450</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>79</onleft>
-					<onright>81</onright>
-					<onup>70</onup>
-					<ondown>90</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="81">
-					<description>'Q' button</description>
-					<left>500</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>80</onleft>
-					<onright>82</onright>
-					<onup>71</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="82">
-					<description>'R' button</description>
-					<left>550</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>81</onleft>
-					<onright>83</onright>
-					<onup>72</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="83">
-					<description>'S' button</description>
-					<left>600</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>82</onleft>
-					<onright>84</onright>
-					<onup>73</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="84">
-					<description>'T' button</description>
-					<left>650</left>
-					<top>100</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>83</onleft>
-					<onright>303</onright>
-					<onup>74</onup>
-					<ondown>8</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="radiobutton" id="304">
-					<description>Symbols button</description>
-					<left>0</left>
+					<!-- 4th row -->
+				<control type="grouplist">
 					<top>150</top>
-					<width>200</width>
-					<height>50</height>
-					<label>20180</label>
-					<onleft>8</onleft>
-					<onright>85</onright>
-					<onup>303</onup>
-					<ondown>307</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<radioposy>5</radioposy>
-					<radiowidth>20</radiowidth>
-					<radioheight>20</radioheight>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
+					<itemgap>0</itemgap>
+					<orientation>horizontal</orientation>
+					<control type="button" id="307">
+						<description>IP Input button</description>
+						<width>100</width>
+						<height>50</height>
+						<onup>303</onup>
+						<ondown>300</ondown>
+						<label>IP</label>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="radiobutton" id="304">
+						<description>Symbols button</description>
+						<width>100</width>
+						<height>50</height>
+						<label>@#!*   </label>
+						<onup>303</onup>
+						<ondown>300</ondown>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<radioposy>5</radioposy>
+						<radiowidth>20</radiowidth>
+						<radioheight>20</radioheight>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="button" id="160">
+						<description>(3,0) key button</description>
+						<onup>140</onup>
+						<ondown>32</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="161">
+						<description>(3,1) key button</description>
+						<onup>141</onup>
+						<ondown>32</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="162">
+						<description>(3,2) key button</description>
+						<onup>142</onup>
+						<ondown>32</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="163">
+						<description>(3,3) key button</description>
+						<onup>143</onup>
+						<ondown>32</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="164">
+						<description>(3,4) key button</description>
+						<onup>144</onup>
+						<ondown>8</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="165">
+						<description>(3,5) key button</description>
+						<onup>145</onup>
+						<ondown>8</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="166">
+						<description>(3,6) key button</description>
+						<onup>146</onup>
+						<ondown>8</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="167">
+						<description>(3,7) key button</description>
+						<onup>147</onup>
+						<ondown>8</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="168">
+						<description>(3,8) key button</description>
+						<onup>148</onup>
+						<ondown>305</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="169">
+						<description>(3,9) key button</description>
+						<onup>149</onup>
+						<ondown>305</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="170">
+						<description>(3,10) key button</description>
+						<onup>150</onup>
+						<ondown>306</ondown>
+						<include>KeyboardButton</include>
+					</control>
+					<control type="button" id="171">
+						<description>(3,11) key button</description>
+						<onup>151</onup>
+						<ondown>306</ondown>
+						<include>KeyboardButton</include>
+					</control>
 				</control>
-				<control type="button" id="85">
-					<description>'U' button</description>
-					<left>200</left>
-					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>304</onleft>
-					<onright>86</onright>
-					<onup>75</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="86">
-					<description>'V' button</description>
-					<left>250</left>
-					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>85</onleft>
-					<onright>87</onright>
-					<onup>76</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="87">
-					<description>'W' button</description>
-					<left>300</left>
-					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>86</onleft>
-					<onright>88</onright>
-					<onup>77</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="88">
-					<description>'X' button</description>
-					<left>350</left>
-					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>87</onleft>
-					<onright>89</onright>
-					<onup>78</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="89">
-					<description>'Y' button</description>
-					<left>400</left>
-					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>88</onleft>
-					<onright>90</onright>
-					<onup>79</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="90">
-					<description>'Z' button</description>
-					<left>450</left>
-					<top>150</top>
-					<width>50</width>
-					<height>50</height>
-					<onleft>89</onleft>
-					<onright>8</onright>
-					<onup>80</onup>
-					<ondown>32</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="8">
-					<description>BACKSPACE button</description>
-					<left>500</left>
-					<top>150</top>
-					<width>200</width>
-					<height>50</height>
-					<label>20181</label>
-					<onleft>90</onleft>
-					<onright>304</onright>
-					<onup>81</onup>
-					<ondown>305</ondown>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="307">
-					<description>IP Input button</description>
-					<left>0</left>
+					<!-- 5th row -->
+				<control type="grouplist">
 					<top>200</top>
-					<width>200</width>
-					<height>50</height>
-					<texturenofocus border="25,5,25,5">KeyboardCornerBottomNF.png</texturenofocus>
-					<texturefocus border="25,5,25,5">KeyboardCornerBottom.png</texturefocus>
-					<label>1006</label>
-					<font>font13</font>
-					<align>center</align>
-					<aligny>center</aligny>
-					<onleft>306</onleft>
-					<onright>32</onright>
-					<onup>304</onup>
-					<ondown>300</ondown>
-					<focusedcolor>black</focusedcolor>
-				</control>
-				<control type="button" id="32">
-					<description>SPACE button</description>
-					<left>200</left>
-					<top>200</top>
-					<width>300</width>
-					<height>50</height>
-					<label>20182</label>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<align>center</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<focusedcolor>black</focusedcolor>
-					<onleft>307</onleft>
-					<onright>305</onright>
-					<onup>85</onup>
-					<ondown>48</ondown>
-				</control>
-				<control type="button" id="305">
-					<description>previous button</description>
-					<left>500</left>
-					<top>200</top>
-					<width>100</width>
-					<height>50</height>
-					<label>&lt;</label>
-					<align>center</align>
-					<aligny>center</aligny>
-					<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
-					<texturefocus border="5">KeyboardKey.png</texturefocus>
-					<font>font30</font>
-					<focusedcolor>black</focusedcolor>
-					<onleft>32</onleft>
-					<onright>306</onright>
-					<onup>8</onup>
-					<ondown>54</ondown>
-				</control>
-				<control type="button" id="306">
-					<description>next button</description>
-					<left>600</left>
-					<top>200</top>
-					<width>100</width>
-					<height>50</height>
-					<label>&gt;</label>
-					<align>center</align>
-					<aligny>center</aligny>
-					<texturenofocus flipx="true" border="5,5,25,25">KeyboardCornerBottomNF.png</texturenofocus>
-					<texturefocus flipx="true" border="5,5,25,25">KeyboardCornerBottom.png</texturefocus>
-					<font>font30</font>
-					<focusedcolor>black</focusedcolor>
-					<onleft>305</onleft>
-					<onright>307</onright>
-					<onup>8</onup>
-					<ondown>56</ondown>
+					<itemgap>0</itemgap>
+					<orientation>horizontal</orientation>
+					<control type="button" id="300">
+						<description>DONE button</description>
+						<width>200</width>
+						<height>50</height>
+						<texturenofocus border="25,5,25,5">KeyboardCornerBottomNF.png</texturenofocus>
+						<texturefocus border="25,5,25,5">KeyboardCornerBottom.png</texturefocus>
+						<label>20177</label>
+						<font>font13</font>
+						<align>center</align>
+						<aligny>center</aligny>
+						<onup>304</onup>
+						<ondown>309</ondown>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="button" id="32">
+						<description>SPACE button</description>
+						<width>200</width>
+						<height>50</height>
+						<label>20182</label>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+						<onup>161</onup>
+						<ondown>101</ondown>
+					</control>
+					<control type="button" id="8">
+						<description>BACKSPACE button</description>
+						<width>200</width>
+						<height>50</height>
+						<label>20181</label>
+						<onup>165</onup>
+						<ondown>105</ondown>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<align>center</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<focusedcolor>black</focusedcolor>
+					</control>
+					<control type="button" id="305">
+						<description>previous button</description>
+						<width>100</width>
+						<height>50</height>
+						<label>&lt;</label>
+						<align>center</align>
+						<aligny>center</aligny>
+						<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+						<texturefocus border="5">KeyboardKey.png</texturefocus>
+						<font>font30</font>
+						<focusedcolor>black</focusedcolor>
+						<onup>168</onup>
+						<ondown>108</ondown>
+					</control>
+					<control type="button" id="306">
+						<description>next button</description>
+						<width>100</width>
+						<height>50</height>
+						<label>&gt;</label>
+						<align>center</align>
+						<aligny>center</aligny>
+						<texturenofocus flipx="true" border="5,5,25,25">KeyboardCornerBottomNF.png</texturenofocus>
+						<texturefocus flipx="true" border="5,5,25,25">KeyboardCornerBottom.png</texturefocus>
+						<font>font30</font>
+						<focusedcolor>black</focusedcolor>
+						<onup>170</onup>
+						<ondown>110</ondown>
+					</control>
 				</control>
 			</control>
 		</control>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -1240,4 +1240,14 @@
 		<animation effect="fade" time="300">Visible</animation>
 		<animation effect="fade" time="300">Hidden</animation>
 	</include>
+	<include name="KeyboardButton">
+		<width>50</width>
+		<height>50</height>
+		<texturenofocus border="3">KeyboardKeyNF.png</texturenofocus>
+		<texturefocus border="5">KeyboardKey.png</texturefocus>
+		<align>center</align>
+		<aligny>center</aligny>
+		<font>font13</font>
+		<focusedcolor>black</focusedcolor>
+	</include>
 </includes>

--- a/addons/skin.confluence/addon.xml
+++ b/addons/skin.confluence/addon.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="skin.confluence"
-  version="2.5.0"
+  version="2.5.1"
   name="Confluence"
   provider-name="Jezz_X, Team Kodi">
   <requires>
-    <import addon="xbmc.gui" version="5.2.0"/>
+    <import addon="xbmc.gui" version="5.3.0"/>
   </requires>
   <extension
     point="xbmc.gui.skin"

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.2.0" provider-name="Team XBMC">
+<addon id="xbmc.gui" version="5.3.0" provider-name="Team XBMC">
   <backwards-compatibility abi="5.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1300,7 +1300,13 @@ msgctxt "#309"
 msgid "User interface language"
 msgstr ""
 
-#empty strings from id 310 to 311
+#. Setting in international settings
+#: system/settings/settings.xml
+msgctxt "#310"
+msgid "Keyboard layouts"
+msgstr ""
+
+#empty string with id 311
 
 msgctxt "#312"
 msgid "(0=auto)"
@@ -15354,9 +15360,14 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36431"
 msgid "Defines whether video decoding should be performed in software (requires more CPU) or with hardware acceleration where possible."
+
+#. Description for international setting #310: Keyboard layouts
+#: system/settings/settings.xml
+msgctxt "#36432"
+msgid "Select virtual keyboard layouts."
 msgstr ""
 
-#empty strings from id 36432 to 36499
+#empty strings from id 36433 to 36499
 #end reservation
 
 #: system/settings/settings.xml

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -486,6 +486,7 @@
     <ClCompile Include="..\..\xbmc\GUIPassword.cpp" />
     <ClCompile Include="..\..\xbmc\input\ButtonTranslator.cpp" />
     <ClCompile Include="..\..\xbmc\input\InertialScrollingHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\input\KeyboardLayout.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardLayoutConfiguration.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardStat.cpp" />
     <ClCompile Include="..\..\xbmc\input\MouseStat.cpp" />
@@ -1804,6 +1805,7 @@
     <ClInclude Include="..\..\xbmc\GUIUserMessages.h" />
     <ClInclude Include="..\..\xbmc\input\ButtonTranslator.h" />
     <ClInclude Include="..\..\xbmc\input\InertialScrollingHandler.h" />
+    <ClInclude Include="..\..\xbmc\input\KeyboardLayout.h" />
     <ClInclude Include="..\..\xbmc\input\KeyboardLayoutConfiguration.h" />
     <ClInclude Include="..\..\xbmc\input\KeyboardStat.h" />
     <ClInclude Include="..\..\xbmc\input\MouseStat.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1132,6 +1132,9 @@
     <ClCompile Include="..\..\xbmc\input\ButtonTranslator.cpp">
       <Filter>input</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\input\KeyboardLayout.cpp">
+      <Filter>input</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\input\KeyboardLayoutConfiguration.cpp">
       <Filter>input</Filter>
     </ClCompile>
@@ -4027,6 +4030,9 @@
       <Filter>guilib</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\input\ButtonTranslator.h">
+      <Filter>input</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\KeyboardLayout.h">
       <Filter>input</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\input\KeyboardLayoutConfiguration.h">

--- a/system/keyboardlayouts.xml
+++ b/system/keyboardlayouts.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<keyboardlayouts>
+  <layout name="QWERTY">
+    <keyboard>
+      <row>1234567890</row>
+      <row>qwertyuiop</row>
+      <row>asdfghjkl</row>
+      <row>zxcvbnm</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>1234567890</row>
+      <row>QWERTYUIOP</row>
+      <row>ASDFGHJKL</row>
+      <row>ZXCVBNM</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>)!@#$%^&*(</row>
+      <row>[]{}-_=+;:</row>
+      <row>'",.&lt;&gt;/?\|</row>
+      <row>`~</row>
+    </keyboard>
+  </layout>
+  <layout name="ABC">
+    <keyboard>
+      <row>0123456789</row>
+      <row>abcdefghij</row>
+      <row>klmnopqrst</row>
+      <row>uvwxyz</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>0123456789</row>
+      <row>ABCDEFGHIJ</row>
+      <row>KLMNOPQRST</row>
+      <row>UVWXYZ</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>)!@#$%^&*(</row>
+      <row>[]{}-_=+;:</row>
+      <row>'",.&lt;&gt;/?\|</row>
+      <row>`~</row>
+   </keyboard>
+  </layout>
+  <layout name="Русская ЙЦУКЕН">
+    <keyboard>
+      <row>ё1234567890</row>
+      <row>йцукенгшщзхъ</row>
+      <row>фывапролджэ</row>
+      <row>ячсмитьбю</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>Ё1234567890</row>
+      <row>ЙЦУКЕНГШЩЗХЪ</row>
+      <row>ФЫВАПРОЛДЖЭ</row>
+      <row>ЯЧСМИТЬБЮ</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>)!@#$%^&*(</row>
+      <row>[]{}-_=+;:</row>
+      <row>'",.&lt;&gt;/?\|</row>
+      <row>`~</row>
+    </keyboard>
+  </layout>
+  <layout name="Русская АБВ">
+    <keyboard>
+      <row>0123456789</row>
+      <row>абвгдеёжзий</row>
+      <row>клмнопрстуф</row>
+      <row>хцчшщъыьэюя</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>0123456789</row>
+      <row>АБВГДЕЁЖЗИЙ</row>
+      <row>КЛМНОПРСТУФ</row>
+      <row>ХЦЧШЩЪЫЬЭЮЯ</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>)!@#$%^&*(</row>
+      <row>[]{}-_=+;:</row>
+      <row>'",.&lt;&gt;/?\|</row>
+      <row>`~</row>
+    </keyboard>
+  </layout>
+</keyboardlayouts>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -142,6 +142,19 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="locale.keyboardlayouts" type="list[string]" label="310" help="36432">
+          <level>1</level>
+          <default>QWERTY</default>
+          <constraints>
+            <options>keyboardlayouts</options>
+            <delimiter>|</delimiter>
+            <minimumItems>1</minimumItems>
+            <maximumItems>3</maximumItems>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+          </control>
+        </setting>
       </group>
       <group id="2">
         <setting id="locale.timezonecountry" type="string" label="14079" help="36117">

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -21,7 +21,6 @@
 #include "interfaces/AnnouncementManager.h"
 #include "input/XBMC_vkeys.h"
 #include "guilib/GUIEditControl.h"
-#include "guilib/GUILabelControl.h" // for backward compatibility
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
@@ -33,7 +32,6 @@
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "ApplicationMessenger.h"
-#include "addons/Skin.h" // for backward compatibility
 
 #define BUTTON_ID_OFFSET      100
 #define BUTTONS_PER_ROW        20
@@ -50,7 +48,6 @@
 #define CTL_BUTTON_CLEAR      308
 #define CTL_BUTTON_LAYOUT     309
 
-#define CTL_LABEL_EDIT        310 // backward compatibility
 #define CTL_LABEL_HEADING     311
 #define CTL_EDIT              312
 
@@ -75,23 +72,8 @@ CGUIDialogKeyboardGeneric::CGUIDialogKeyboardGeneric()
 
 void CGUIDialogKeyboardGeneric::OnWindowLoaded()
 {
-  CGUIEditControl *edit = (CGUIEditControl *)GetControl(CTL_EDIT);
-  if (!edit && g_SkinInfo && g_SkinInfo->APIVersion() < ADDON::AddonVersion("5.2.0"))
-  {
-    // backward compatibility: convert label to edit control
-    CGUILabelControl *label = (CGUILabelControl *)GetControl(CTL_LABEL_EDIT);
-    if (label && label->GetControlType() == CGUIControl::GUICONTROL_LABEL)
-    {
-      // create a new edit control positioned in the same spot
-      edit = new CGUIEditControl(label->GetParentID(), CTL_EDIT, label->GetXPosition(), label->GetYPosition(),
-                                 label->GetWidth(), label->GetHeight(), CTextureInfo(), CTextureInfo(),
-                                 label->GetLabelInfo(), "");
-      AddControl(edit);
-      m_defaultControl = CTL_EDIT;
-      m_defaultAlways  = true;
-    }
-  }
   // show the cursor always
+  CGUIEditControl *edit = (CGUIEditControl *)GetControl(CTL_EDIT);
   if (edit)
     edit->SetShowCursorAlways(true);
 

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -29,12 +29,15 @@
 #include "GUIDialogNumeric.h"
 #include "GUIDialogOK.h"
 #include "GUIDialogKeyboardGeneric.h"
+#include "settings/Settings.h"
 #include "utils/RegExp.h"
+#include "utils/StringUtils.h"
 #include "ApplicationMessenger.h"
 #include "addons/Skin.h" // for backward compatibility
 
-// Symbol mapping (based on MS virtual keyboard - may need improving)
-static char symbol_map[37] = ")!@#$%^&*([]{}-_=+;:\'\",.<>/?\\|`~    ";
+#define BUTTON_ID_OFFSET      100
+#define BUTTONS_PER_ROW        20
+#define BUTTONS_MAX_ROWS        4
 
 #define CTL_BUTTON_DONE       300
 #define CTL_BUTTON_CANCEL     301
@@ -45,15 +48,14 @@ static char symbol_map[37] = ")!@#$%^&*([]{}-_=+;:\'\",.<>/?\\|`~    ";
 #define CTL_BUTTON_RIGHT      306
 #define CTL_BUTTON_IP_ADDRESS 307
 #define CTL_BUTTON_CLEAR      308
+#define CTL_BUTTON_LAYOUT     309
 
 #define CTL_LABEL_EDIT        310 // backward compatibility
 #define CTL_LABEL_HEADING     311
 #define CTL_EDIT              312
 
 #define CTL_BUTTON_BACKSPACE    8
-
-static char symbolButtons[] = "._-@/\\";
-#define NUM_SYMBOLS sizeof(symbolButtons) - 1
+#define CTL_BUTTON_SPACE       32
 
 #define SEARCH_DELAY         1000
 
@@ -66,6 +68,7 @@ CGUIDialogKeyboardGeneric::CGUIDialogKeyboardGeneric()
   m_bShift = false;
   m_hiddenInput = false;
   m_keyType = LOWER;
+  m_currentLayout = 0;
   m_strHeading = "";
   m_loadType = KEEP_IN_MEMORY;
 }
@@ -100,6 +103,20 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   CGUIDialog::OnInitWindow();
 
   m_bIsConfirmed = false;
+
+  // fill in the keyboard layouts
+  m_currentLayout = 0;
+  m_layouts.clear();
+  std::vector<CKeyboardLayout> keyLayouts = CKeyboardLayout::LoadLayouts();
+  const CSetting *setting = CSettings::Get().GetSetting("locale.keyboardlayouts");
+  std::vector<std::string> layouts;
+  if (setting)
+    layouts = StringUtils::Split(setting->ToString(), "|");
+  for (std::vector<CKeyboardLayout>::const_iterator j = keyLayouts.begin(); j != keyLayouts.end(); ++j)
+  {
+    if (std::find(layouts.begin(), layouts.end(), j->GetName()) != layouts.end())
+      m_layouts.push_back(*j);
+  }
 
   // set alphabetic (capitals)
   UpdateButtons();
@@ -193,6 +210,9 @@ bool CGUIDialogKeyboardGeneric::OnMessage(CGUIMessage& message)
           m_keyType = LOWER;
         UpdateButtons();
         break;
+      case CTL_BUTTON_LAYOUT:
+        OnLayout();
+        break;
       case CTL_BUTTON_SYMBOLS:
         OnSymbols();
         break;
@@ -263,17 +283,16 @@ const std::string &CGUIDialogKeyboardGeneric::GetText() const
   return m_text;
 }
 
-void CGUIDialogKeyboardGeneric::Character(char ch)
+void CGUIDialogKeyboardGeneric::Character(const std::string &ch)
 {
-  if (!ch) return;
+  if (ch.empty()) return;
 
-  std::string character(1, ch);
   // send text to edit control
   CGUIControl *edit = GetControl(CTL_EDIT);
   if (edit)
   {
     CGUIMessage msg(GUI_MSG_INPUT_TEXT, GetID(), CTL_EDIT);
-    msg.SetLabel(character);
+    msg.SetLabel(ch);
     edit->OnMessage(msg);
   }
 }
@@ -292,49 +311,21 @@ void CGUIDialogKeyboardGeneric::OnClickButton(int iButtonControl)
   {
     Backspace();
   }
-  else
-    Character(GetCharacter(iButtonControl));
-}
-
-char CGUIDialogKeyboardGeneric::GetCharacter(int iButton)
-{
-  // First the numbers
-  if (iButton >= 48 && iButton <= 57)
+  else if (iButtonControl == CTL_BUTTON_SPACE)
   {
-    if (m_keyType == SYMBOLS)
+    Character(" ");
+  }
+  else
+  {
+    const CGUIControl* pButton = GetControl(iButtonControl);
+    if (pButton)
     {
-      OnSymbols();
-      return symbol_map[iButton -48];
+      Character(pButton->GetDescription());
+      // reset the shift and symbol keys
+      if (m_bShift) OnShift();
+      if (m_keyType == SYMBOLS) OnSymbols();
     }
-    else
-      return (char)iButton;
   }
-  else if (iButton == 32) // space
-    return (char)iButton;
-  else if (iButton >= 65 && iButton < 91)
-  {
-    if (m_keyType == SYMBOLS)
-    { // symbol
-      OnSymbols();
-      return symbol_map[iButton - 65 + 10];
-    }
-    if ((m_keyType == CAPS && m_bShift) || (m_keyType == LOWER && !m_bShift))
-    { // make lower case
-      iButton += 32;
-    }
-    if (m_bShift)
-    { // turn off the shift key
-      OnShift();
-    }
-    return (char) iButton;
-  }
-  else
-  { // check for symbols
-    for (unsigned int i = 0; i < NUM_SYMBOLS; i++)
-      if (iButton == symbolButtons[i])
-        return (char)iButton;
-  }
-  return 0;
 }
 
 void CGUIDialogKeyboardGeneric::UpdateButtons()
@@ -343,47 +334,35 @@ void CGUIDialogKeyboardGeneric::UpdateButtons()
   SET_CONTROL_SELECTED(GetID(), CTL_BUTTON_CAPS, m_keyType == CAPS);
   SET_CONTROL_SELECTED(GetID(), CTL_BUTTON_SYMBOLS, m_keyType == SYMBOLS);
 
-  char szLabel[2];
-  szLabel[0] = 32;
-  szLabel[1] = 0;
-  std::string aLabel = szLabel;
+  if (m_currentLayout >= m_layouts.size())
+    m_currentLayout = 0;
+  CKeyboardLayout layout = m_layouts.empty() ? CKeyboardLayout() : m_layouts[m_currentLayout];
+  SET_CONTROL_LABEL(CTL_BUTTON_LAYOUT, layout.GetName());
 
-  // set numerals
-  for (int iButton = 48; iButton <= 57; iButton++)
+  unsigned int modifiers = CKeyboardLayout::MODIFIER_KEY_NONE;
+  if ((m_keyType == CAPS && !m_bShift) || (m_keyType == LOWER && m_bShift))
+    modifiers |= CKeyboardLayout::MODIFIER_KEY_SHIFT;
+  if (m_keyType == SYMBOLS)
   {
-    if (m_keyType == SYMBOLS)
-      aLabel[0] = symbol_map[iButton - 48];
-    else
-      aLabel[0] = iButton;
-    SetControlLabel(iButton, aLabel);
+    modifiers |= CKeyboardLayout::MODIFIER_KEY_SYMBOL;
+    if (m_bShift)
+      modifiers |= CKeyboardLayout::MODIFIER_KEY_SHIFT;
   }
 
-  // set correct alphabet characters...
-
-  for (int iButton = 65; iButton <= 90; iButton++)
+  for (unsigned int row = 0; row < BUTTONS_MAX_ROWS; row++)
   {
-    // set the correct case...
-    if ((m_keyType == CAPS && m_bShift) || (m_keyType == LOWER && !m_bShift))
-    { // make lower case
-      aLabel[0] = iButton + 32;
-    }
-    else if (m_keyType == SYMBOLS)
+    for (unsigned int column = 0; column < BUTTONS_PER_ROW; column++)
     {
-      aLabel[0] = symbol_map[iButton - 65 + 10];
+      int buttonID = (row * BUTTONS_PER_ROW) + column + BUTTON_ID_OFFSET;
+      std::string label = layout.GetCharAt(row, column, modifiers);
+      SetControlLabel(buttonID, label);
+      if (!label.empty())
+        SET_CONTROL_VISIBLE(buttonID);
+      else
+        SET_CONTROL_HIDDEN(buttonID);
     }
-    else
-    {
-      aLabel[0] = iButton;
-    }
-    SetControlLabel(iButton, aLabel);
-  }
-  for (unsigned int i = 0; i < NUM_SYMBOLS; i++)
-  {
-    aLabel[0] = symbolButtons[i];
-    SetControlLabel(symbolButtons[i], aLabel);
   }
 }
-
 
 void CGUIDialogKeyboardGeneric::OnDeinitWindow(int nextWindowID)
 {
@@ -400,6 +379,14 @@ void CGUIDialogKeyboardGeneric::MoveCursor(int iAmount)
   CGUIControl *edit = GetControl(CTL_EDIT);
   if (edit)
     edit->OnAction(CAction(iAmount < 0 ? ACTION_CURSOR_LEFT : ACTION_CURSOR_RIGHT));
+}
+
+void CGUIDialogKeyboardGeneric::OnLayout()
+{
+  m_currentLayout++;
+  if (m_currentLayout >= m_layouts.size())
+    m_currentLayout = 0;
+  UpdateButtons();
 }
 
 void CGUIDialogKeyboardGeneric::OnSymbols()

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.h
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.h
@@ -22,9 +22,10 @@
 
 #include "guilib/GUIKeyboard.h"
 #include "guilib/GUIDialog.h"
+#include "input/KeyboardLayout.h"
 #include "utils/Variant.h"
 
-enum KEYBOARD {CAPS, LOWER, SYMBOLS };
+enum KEYBOARD {CAPS, LOWER, SYMBOLS};
 
 class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
 {
@@ -51,6 +52,7 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void SetControlLabel(int id, const std::string &label);
     void OnShift();
     void MoveCursor(int iAmount);
+    void OnLayout();
     void OnSymbols();
     void OnIPAddress();
     void OnOK();
@@ -59,20 +61,21 @@ class CGUIDialogKeyboardGeneric : public CGUIDialog, public CGUIKeyboard
     void OnClickButton(int iButtonControl);
     void UpdateButtons();
     char GetCharacter(int iButton);
-    void Character(char ch);
+    void Character(const std::string &ch);
     void Backspace();
     void SetEditText(const std::string& text);
     void SendSearchMessage();
 
     bool m_bIsConfirmed;
     KEYBOARD m_keyType;
-    int m_iMode;
     bool m_bShift;
     bool m_hiddenInput;
 
+    std::vector<CKeyboardLayout> m_layouts;
+    unsigned int                 m_currentLayout;
+
     std::string m_strHeading;
     std::string m_text;       ///< current text
-
 
     char_callback_t m_pCharCallback;
 };

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "KeyboardLayout.h"
+#include "settings/lib/Setting.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -153,4 +154,14 @@ std::vector<CKeyboardLayout> CKeyboardLayout::LoadLayouts()
     }
   }
   return result;
+}
+
+void CKeyboardLayout::SettingOptionsKeyboardLayoutsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+{
+  std::vector<CKeyboardLayout> layouts = LoadLayouts();
+  for (std::vector<CKeyboardLayout>::const_iterator it = layouts.begin(); it != layouts.end(); it++)
+  {
+    std::string name = it->GetName();
+    list.push_back(make_pair(name, name));
+  }
 }

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -1,0 +1,156 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "KeyboardLayout.h"
+#include "utils/CharsetConverter.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include <set>
+
+#define KEYBOARD_LAYOUTS_XML "special://xbmc/system/keyboardlayouts.xml"
+
+CKeyboardLayout::CKeyboardLayout() : m_name("")
+{
+}
+
+CKeyboardLayout::CKeyboardLayout(const std::string &name, const TiXmlElement &element) : m_name(name)
+{
+  const TiXmlElement *keyboard = element.FirstChildElement("keyboard");
+  while (keyboard)
+  {
+    // parse modifiers keys
+    std::set<unsigned int> modifierKeysSet;
+
+    if (keyboard->Attribute("modifiers"))
+    {
+      std::string modifiers = keyboard->Attribute("modifiers");
+      StringUtils::ToLower(modifiers);
+
+      std::vector<std::string> variants = StringUtils::Split(modifiers, ",");
+      for (std::vector<std::string>::const_iterator itv = variants.begin(); itv != variants.end(); itv++)
+      {
+        unsigned int iKeys = MODIFIER_KEY_NONE;
+        std::vector<std::string> keys = StringUtils::Split(*itv, "+");
+        for (std::vector<std::string>::const_iterator it = keys.begin(); it != keys.end(); it++)
+        {
+          std::string strKey = *it;
+          if (strKey == "shift")
+            iKeys |= MODIFIER_KEY_SHIFT;
+          else if (strKey == "symbol")
+            iKeys |= MODIFIER_KEY_SYMBOL;
+        }
+        modifierKeysSet.insert(iKeys);
+      }
+    }
+
+    // parse keyboard rows
+    const TiXmlNode *row = keyboard->FirstChild("row");
+    while (row)
+    {
+      if (!row->NoChildren())
+      {
+        std::string strRow = row->FirstChild()->ValueStr();
+        std::vector<std::string> chars = BreakCharacters(strRow);
+        if (!modifierKeysSet.empty())
+        {
+          for (std::set<unsigned int>::const_iterator it = modifierKeysSet.begin(); it != modifierKeysSet.end(); it++)
+            m_keyboards[*it].push_back(chars);
+        }
+        else
+          m_keyboards[MODIFIER_KEY_NONE].push_back(chars);
+      }
+      row = row->NextSibling();
+    }
+
+    keyboard = keyboard->NextSiblingElement();
+  }
+}
+
+CKeyboardLayout::~CKeyboardLayout(void)
+{
+
+}
+
+std::string CKeyboardLayout::GetCharAt(unsigned int row, unsigned int column, unsigned int modifiers) const
+{
+  Keyboards::const_iterator mod = m_keyboards.find(modifiers);
+  if (modifiers != MODIFIER_KEY_NONE && mod != m_keyboards.end() && mod->second.empty())
+  {
+    // fallback to basic keyboard
+    mod = m_keyboards.find(MODIFIER_KEY_NONE);
+  }
+
+  if (mod != m_keyboards.end())
+  {
+    if (row < mod->second.size() && column < mod->second[row].size())
+    {
+      std::string ch = mod->second[row][column];
+      if (ch != " ")
+        return ch;
+    }
+  }
+
+  return "";
+}
+
+std::vector<std::string> CKeyboardLayout::BreakCharacters(const std::string &chars)
+{
+  std::vector<std::string> result;
+  // break into utf8 characters
+  std::u32string chars32 = g_charsetConverter.utf8ToUtf32(chars);
+  for (size_t i = 0; i < chars32.size(); i++)
+  {
+    std::u32string char32(1, chars32[i]);
+    result.push_back(g_charsetConverter.utf32ToUtf8(char32));
+  }
+  return result;
+}
+
+CKeyboardLayout CKeyboardLayout::Load(const std::string& layout)
+{
+  std::vector<CKeyboardLayout> layouts = LoadLayouts();
+  for (std::vector<CKeyboardLayout>::const_iterator it = layouts.begin(); it != layouts.end(); it++)
+  {
+    if (it->GetName() == layout)
+      return *it;
+  }
+  return CKeyboardLayout();
+}
+
+std::vector<CKeyboardLayout> CKeyboardLayout::LoadLayouts()
+{
+  std::vector<CKeyboardLayout> result;
+  CXBMCTinyXML xmlDoc;
+  if (xmlDoc.LoadFile(KEYBOARD_LAYOUTS_XML))
+  {
+    const TiXmlElement* root = xmlDoc.RootElement();
+    if (root && root->ValueStr() == "keyboardlayouts")
+    {
+      const TiXmlElement* layout = root->FirstChildElement("layout");
+      while (layout)
+      {
+        if (layout->Attribute("name"))
+          result.push_back(CKeyboardLayout(layout->Attribute("name"), *layout));
+        layout = layout->NextSiblingElement("layout");
+      }
+    }
+  }
+  return result;
+}

--- a/xbmc/input/KeyboardLayout.h
+++ b/xbmc/input/KeyboardLayout.h
@@ -35,6 +35,7 @@
  */
 
 class TiXmlElement;
+class CSetting;
 
 class CKeyboardLayout
 {
@@ -62,6 +63,8 @@ public:
    \return a vector of CKeyboardLayouts with the layout names.
    */
   static std::vector<CKeyboardLayout> LoadLayouts();
+
+  static void SettingOptionsKeyboardLayoutsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void* data);
 
 private:
   static std::vector<std::string> BreakCharacters(const std::string &chars);

--- a/xbmc/input/KeyboardLayout.h
+++ b/xbmc/input/KeyboardLayout.h
@@ -1,0 +1,74 @@
+/*!
+\file KeyboardLayout.h
+\brief
+*/
+
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <map>
+#include <vector>
+
+/*!
+ \ingroup keyboardlayouts
+ \brief
+ */
+
+class TiXmlElement;
+
+class CKeyboardLayout
+{
+public:
+  CKeyboardLayout();
+  CKeyboardLayout(const std::string &name, const TiXmlElement& element);
+  virtual ~CKeyboardLayout(void);
+  const std::string& GetName() const { return m_name; }
+  std::string GetCharAt(unsigned int row, unsigned int column, unsigned int modifiers = 0) const;
+
+  enum MODIFIER_KEYS
+  {
+    MODIFIER_KEY_NONE   = 0x00,
+    MODIFIER_KEY_SHIFT  = 0x01,
+    MODIFIER_KEY_SYMBOL = 0x02
+  };
+
+  /*! \brief helper to load a keyboard layout
+   \param layout the layout to load.
+   \return a CKeyboardLayout.
+   */
+  static CKeyboardLayout Load(const std::string &layout);
+
+  /*! \brief helper to list available keyboard layouts
+   \return a vector of CKeyboardLayouts with the layout names.
+   */
+  static std::vector<CKeyboardLayout> LoadLayouts();
+
+private:
+  static std::vector<std::string> BreakCharacters(const std::string &chars);
+
+  typedef std::vector< std::vector<std::string> > KeyboardRows;
+  typedef std::map<unsigned int, KeyboardRows> Keyboards;
+
+  std::string m_name;
+  Keyboards   m_keyboards;
+};

--- a/xbmc/input/Makefile
+++ b/xbmc/input/Makefile
@@ -1,5 +1,6 @@
 SRCS=ButtonTranslator.cpp \
      InertialScrollingHandler.cpp \
+     KeyboardLayout.cpp \
      KeyboardLayoutConfiguration.cpp \
      KeyboardStat.cpp \
      MouseStat.cpp \

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -36,6 +36,7 @@
 #include "guilib/GUIFontManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
+#include "input/KeyboardLayout.h"
 #include "input/MouseStat.h"
 #if defined(TARGET_WINDOWS)
 #include "input/windows/WINJoystick.h"
@@ -254,6 +255,7 @@ void CSettings::Uninitialize()
   m_settingsManager->UnregisterSettingOptionsFiller("timezones");
 #endif // defined(TARGET_LINUX)
   m_settingsManager->UnregisterSettingOptionsFiller("verticalsyncs");
+  m_settingsManager->UnregisterSettingOptionsFiller("keyboardlayouts");
 
   // unregister ISettingCallback implementations
   m_settingsManager->UnregisterCallback(&g_advancedSettings);
@@ -597,6 +599,7 @@ void CSettings::InitializeOptionFillers()
   m_settingsManager->RegisterSettingOptionsFiller("timezones", CLinuxTimezone::SettingOptionsTimezonesFiller);
 #endif
   m_settingsManager->RegisterSettingOptionsFiller("verticalsyncs", CDisplaySettings::SettingOptionsVerticalSyncsFiller);
+  m_settingsManager->RegisterSettingOptionsFiller("keyboardlayouts", CKeyboardLayout::SettingOptionsKeyboardLayoutsFiller);
   m_settingsManager->RegisterSettingOptionsFiller("loggingcomponents", CAdvancedSettings::SettingOptionsLoggingComponentsFiller);
 }
 


### PR DESCRIPTION
This is a re-hash of #4242 with an attempt to make it simpler and less invasive.

The skin changes are quite a bit (and will need prettying up) but perhaps @vkosh can work with @ronie @Black09 and @BigNoid on this.  We'll also need a skin bump when this goes in.

@vkosh I changed it so that all keyboard layouts are stored in a single file, and the user just selects the one(s) they want.  i.e. it's completely detached from region or language.  IMO this is the better way to go, even if it means a little more playing around for the user to setup initially.

Thoughts/comments/criticisms welcome.
