### PR TITLE
use subtitle settings to set ASS/SSA subtitles position

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -16,7 +16,7 @@ freetype-2.4.6-win32-3.7z
 giflib-5.0.5p-win32.7z
 gnutls-3.2.3-win32.zip
 jsonschemabuilder-1.0.0-win32-3.7z
-libass-0.10.2-win32.7z
+libass-0.12.1-win32.7z
 libbluray-0.4.0-win32.zip
 libcdio-0.83-win32-2.7z
 libcec-2.2.0-win32-1.7z

--- a/tools/depends/target/libass/Makefile
+++ b/tools/depends/target/libass/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libass
-VERSION=0.10.1
+VERSION=0.12.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
@@ -31,9 +31,9 @@ $(LIBDYLIB): $(PLATFORM)
 .installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install
 ifeq ($(OS),android)
-	rm -f $(PREFIX)/lib/libass.la $(PREFIX)/lib/libass.so $(PREFIX)/lib/libass.so.4
-	mv -f $(PREFIX)/lib/libass.so.4.1.0 $(PREFIX)/lib/libass.so
-	$(RPL) -e "libass.so.4" "libass.so\x00\x00" $(PREFIX)/lib/libass.so
+	rm -f $(PREFIX)/lib/libass.la $(PREFIX)/lib/libass.so $(PREFIX)/lib/libass.so.5
+	mv -f $(PREFIX)/lib/libass.so.5.1.0 $(PREFIX)/lib/libass.so
+	$(RPL) -e "libass.so.5" "libass.so\x00\x00" $(PREFIX)/lib/libass.so
 	-$(READELF) --dynamic $(PREFIX)/lib/libass.so | grep ibrary
 endif
 	touch $@

--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -306,10 +306,11 @@ float CBaseRenderer::GetAspectRatio() const
   return m_sourceFrameRatio * width / height * m_sourceHeight / m_sourceWidth;
 }
 
-void CBaseRenderer::GetVideoRect(CRect &source, CRect &dest)
+void CBaseRenderer::GetVideoRect(CRect &source, CRect &dest, CRect &view)
 {
   source = m_sourceRect;
   dest = m_destRect;
+  view = m_viewRect;
 }
 
 inline void CBaseRenderer::ReorderDrawPoints()
@@ -567,7 +568,7 @@ void CBaseRenderer::CalculateFrameAspectRatio(unsigned int desired_width, unsign
 
 void CBaseRenderer::ManageDisplay()
 {
-  const CRect view = g_graphicsContext.GetViewWindow();
+  m_viewRect = g_graphicsContext.GetViewWindow();
 
   m_sourceRect.x1 = 0.0f;
   m_sourceRect.y1 = 0.0f;
@@ -614,7 +615,7 @@ void CBaseRenderer::ManageDisplay()
       break;
   }
 
-  CalcNormalDisplayRect(view.x1, view.y1, view.Width(), view.Height(), GetAspectRatio() * CDisplaySettings::Get().GetPixelRatio(), CDisplaySettings::Get().GetZoomAmount(), CDisplaySettings::Get().GetVerticalShift());
+  CalcNormalDisplayRect(m_viewRect.x1, m_viewRect.y1, m_viewRect.Width(), m_viewRect.Height(), GetAspectRatio() * CDisplaySettings::Get().GetPixelRatio(), CDisplaySettings::Get().GetZoomAmount(), CDisplaySettings::Get().GetVerticalShift());
 }
 
 void CBaseRenderer::SetViewMode(int viewMode)

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -80,7 +80,13 @@ public:
 
   void SetViewMode(int viewMode);
   RESOLUTION GetResolution() const;
-  void GetVideoRect(CRect &source, CRect &dest);
+
+  /*! \brief Get video rectangle and view window
+  \param source is original size of the video
+  \param dest is the target rendering area honoring aspect ratio of source
+  \param view is the entire target rendering area for the video (including black bars)
+  */
+  void GetVideoRect(CRect &source, CRect &dest, CRect &view);
   float GetAspectRatio() const;
 
   virtual bool AddVideoPicture(DVDVideoPicture* picture, int index) { return false; }
@@ -139,6 +145,7 @@ protected:
   CRect m_destRect;
   CRect m_oldDestRect; // destrect of the previous frame
   CRect m_sourceRect;
+  CRect m_viewRect;
 
   // rendering flags
   unsigned m_iFlags;

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -325,14 +325,40 @@ bool CRenderer::HasOverlay(int idx)
 
 COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
 {
+  // libass render in a target area which named as frame. the frame size may bigger than video size,
+  // and including margins between video to frame edge. libass allow to render subtitles into the margins.
+  // this has been used to show subtitles in the top or bottom "black bar" between video to frame border.
   CRect src, dst, target;
   g_renderManager.GetVideoRect(src, dst, target);
+  int videoWidth = MathUtils::round_int(dst.Width());
+  int videoHeight = MathUtils::round_int(dst.Height());
+  int targetWidth = MathUtils::round_int(target.Width());
+  int targetHeight = MathUtils::round_int(target.Height());
+  int useMargin;
 
-  int width  = MathUtils::round_int(dst.Width());
-  int height = MathUtils::round_int(dst.Height());
-
+  int subalign = CSettings::Get().GetInt("subtitles.align");
+  if(subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE
+  || subalign == SUBTITLE_ALIGN_TOP_OUTSIDE
+  || subalign == SUBTITLE_ALIGN_MANUAL)
+    useMargin = 1;
+  else
+    useMargin = 0;
+  double position;
+  // position used to call ass_set_line_position, it's vertical line position of subtitles in percent.
+  // value is 0-100: 0 = on the bottom (default), 100 = on top.
+  if(subalign == SUBTITLE_ALIGN_TOP_INSIDE
+  || subalign == SUBTITLE_ALIGN_TOP_OUTSIDE)
+    position = 100.0;
+  else if (subalign == SUBTITLE_ALIGN_MANUAL)
+  {
+    RESOLUTION_INFO res;
+    res = g_graphicsContext.GetResInfo(g_renderManager.GetResolution());
+    position = 100.0 - (res.iSubtitles - res.Overscan.top) * 100 / res.iHeight;
+  }
+  else
+    position = 0.0;
   int changes = 0;
-  ASS_Image* images = o->m_libass->RenderImage(width, height, pts, &changes);
+  ASS_Image* images = o->m_libass->RenderImage(targetWidth, targetHeight, videoWidth, videoHeight, pts, useMargin, position, &changes);
 
   if(o->m_overlay)
   {
@@ -340,12 +366,21 @@ COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
       return o->m_overlay->Acquire();
   }
 
+  COverlay *overlay = NULL;
 #if defined(HAS_GL) || defined(HAS_GLES)
-  return new COverlayGlyphGL(images, width, height);
+  overlay = new COverlayGlyphGL(images, targetWidth, targetHeight);
 #elif defined(HAS_DX)
-  return new COverlayQuadsDX(images, width, height);
+  overlay = new COverlayQuadsDX(images, targetWidth, targetHeight);
 #endif
-  return NULL;
+  // scale to video dimensions
+  if (overlay)
+  {
+    overlay->m_width = (float)targetWidth / videoWidth;
+    overlay->m_height = (float)targetHeight / videoHeight;
+    overlay->m_x = ((float)videoWidth - targetWidth) / 2 / videoWidth;
+    overlay->m_y = ((float)videoHeight - targetHeight) / 2 / videoHeight;
+  }
+  return overlay;
 }
 
 

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -220,8 +220,7 @@ void CRenderer::Render(COverlay* o, float adjust_height)
 {
   CRect rs, rd, rv;
   RESOLUTION_INFO res;
-  g_renderManager.GetVideoRect(rs, rd);
-  rv  = g_graphicsContext.GetViewWindow();
+  g_renderManager.GetVideoRect(rs, rd, rv);
   res = g_graphicsContext.GetResInfo(g_renderManager.GetResolution());
 
   SRenderState state;
@@ -326,8 +325,8 @@ bool CRenderer::HasOverlay(int idx)
 
 COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
 {
-  CRect src, dst;
-  g_renderManager.GetVideoRect(src, dst);
+  CRect src, dst, target;
+  g_renderManager.GetVideoRect(src, dst, target);
 
   int width  = MathUtils::round_int(dst.Width());
   int height = MathUtils::round_int(dst.Height());

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -129,11 +129,11 @@ CXBMCRenderManager::~CXBMCRenderManager()
   m_pRenderer = NULL;
 }
 
-void CXBMCRenderManager::GetVideoRect(CRect &source, CRect &dest)
+void CXBMCRenderManager::GetVideoRect(CRect &source, CRect &dest, CRect &view)
 {
   CSharedLock lock(m_sharedSection);
   if (m_pRenderer)
-    m_pRenderer->GetVideoRect(source, dest);
+    m_pRenderer->GetVideoRect(source, dest, view);
 }
 
 float CXBMCRenderManager::GetAspectRatio()

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -54,7 +54,7 @@ public:
   ~CXBMCRenderManager();
 
   // Functions called from the GUI
-  void GetVideoRect(CRect &source, CRect &dest);
+  void GetVideoRect(CRect &source, CRect &dest, CRect &view);
   float GetAspectRatio();
   void Update();
   void FrameMove();

--- a/xbmc/cores/dvdplayer/DVDOverlayRenderer.cpp
+++ b/xbmc/cores/dvdplayer/DVDOverlayRenderer.cpp
@@ -71,7 +71,7 @@ void CDVDOverlayRenderer::Render(DVDPictureRenderer* pPicture, CDVDOverlaySSA* p
   height = pPicture->height;
   width = pPicture->width;
 
-  ASS_Image* img = pOverlay->m_libass->RenderImage(width, height, pts);
+  ASS_Image* img = pOverlay->m_libass->RenderImage(width, height, width, height, pts);
 
   int depth = OVERLAY::GetStereoscopicDepth();
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3918,8 +3918,8 @@ bool CDVDPlayer::OnAction(const CAction &action)
       case ACTION_MOUSE_MOVE:
       case ACTION_MOUSE_LEFT_CLICK:
         {
-          CRect rs, rd;
-          m_dvdPlayerVideo->GetVideoRect(rs, rd);
+          CRect rs, rd, rv;
+          m_dvdPlayerVideo->GetVideoRect(rs, rd, rv);
           CPoint pt(action.GetAmount(), action.GetAmount(1));
           if (!rd.PtInRect(pt))
             return false; // out of bounds
@@ -4156,7 +4156,8 @@ void CDVDPlayer::GetVideoStreamInfo(SPlayerVideoStreamInfo &info)
   }
   info.videoCodecName = retVal;
   info.videoAspectRatio = m_dvdPlayerVideo->GetAspectRatio();
-  m_dvdPlayerVideo->GetVideoRect(info.SrcRect, info.DestRect);
+  CRect viewRect;
+  m_dvdPlayerVideo->GetVideoRect(info.SrcRect, info.DestRect, viewRect);
   info.stereoMode = m_dvdPlayerVideo->GetStereoMode();
   if (info.stereoMode == "mono")
     info.stereoMode = "";

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -84,7 +84,7 @@ public:
   void EnableFullscreen(bool bEnable)               { m_bAllowFullscreen = bEnable; }
 
 #ifdef HAS_VIDEO_PLAYBACK
-  void GetVideoRect(CRect& SrcRect, CRect& DestRect) const { g_renderManager.GetVideoRect(SrcRect, DestRect); }
+  void GetVideoRect(CRect& SrcRect, CRect& DestRect, CRect& ViewRect) const { g_renderManager.GetVideoRect(SrcRect, DestRect, ViewRect); }
   float GetAspectRatio()                            { return g_renderManager.GetAspectRatio(); }
 #endif
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -154,7 +154,7 @@ bool CDVDSubtitlesLibass::CreateTrack(char* buf, size_t size)
   return true;
 }
 
-ASS_Image* CDVDSubtitlesLibass::RenderImage(int imageWidth, int imageHeight, double pts, int *changes)
+ASS_Image* CDVDSubtitlesLibass::RenderImage(int frameWidth, int frameHeight, int videoWidth, int videoHeight, double pts, int useMargin, double position, int *changes)
 {
   CSingleLock lock(m_section);
   if(!m_renderer || !m_track)
@@ -163,8 +163,13 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(int imageWidth, int imageHeight, dou
     return NULL;
   }
 
-  double storage_aspact = (double)imageWidth / imageHeight;
-  m_dll.ass_set_frame_size(m_renderer, imageWidth, imageHeight);
+  double storage_aspact = (double)frameWidth / frameHeight;
+  m_dll.ass_set_frame_size(m_renderer, frameWidth, frameHeight);
+  int topmargin = (frameHeight - videoHeight) / 2;
+  int leftmargin = (frameWidth - videoWidth) / 2;
+  m_dll.ass_set_margins(m_renderer, topmargin, topmargin, leftmargin, leftmargin);
+  m_dll.ass_set_use_margins(m_renderer, useMargin);
+  m_dll.ass_set_line_position(m_renderer, position);
   m_dll.ass_set_aspect_ratio(m_renderer, storage_aspact / g_graphicsContext.GetResInfo().fPixelRatio, storage_aspact);
   return m_dll.ass_render_frame(m_renderer, m_track, DVD_TIME_TO_MSEC(pts), changes);
 }

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.h
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.h
@@ -32,7 +32,7 @@ public:
   CDVDSubtitlesLibass();
   virtual ~CDVDSubtitlesLibass();
 
-  ASS_Image* RenderImage(int imageWidth, int imageHeight, double pts, int* changes = NULL);
+  ASS_Image* RenderImage(int frameWidth, int frameHeight, int videoWidth, int videoHeight, double pts, int useMargin = 0, double position = 0.0, int* changes = NULL);
   ASS_Event* GetEvents();
 
   int GetNrOfEvents();

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
@@ -49,6 +49,7 @@ public:
   virtual void ass_set_aspect_ratio(ASS_Renderer* priv, double dar, double sar)=0;
   virtual void ass_set_margins(ASS_Renderer* priv, int t, int b, int l, int r)=0;
   virtual void ass_set_use_margins(ASS_Renderer* priv, int use)=0;
+  virtual void ass_set_line_position(ASS_Renderer* priv, double line_position)=0;
   virtual void ass_set_font_scale(ASS_Renderer* priv, double font_scale)=0;
   virtual ASS_Image* ass_render_frame(ASS_Renderer *priv, ASS_Track* track, long long now, int* detect_change)=0;
   virtual ASS_Track* ass_new_track(ASS_Library*)=0;
@@ -77,6 +78,7 @@ class DllLibass : public DllDynamic, DllLibassInterface
   DEFINE_METHOD3(void, ass_set_aspect_ratio, (ASS_Renderer * p1, double p2, double p3))
   DEFINE_METHOD5(void, ass_set_margins, (ASS_Renderer * p1, int p2, int p3, int p4, int p5))
   DEFINE_METHOD2(void, ass_set_use_margins, (ASS_Renderer * p1, int p2))
+  DEFINE_METHOD2(void, ass_set_line_position, (ASS_Renderer * p1, double p2))
   DEFINE_METHOD2(void, ass_set_font_scale, (ASS_Renderer * p1, double p2))
   DEFINE_METHOD4(ASS_Image *, ass_render_frame, (ASS_Renderer * p1, ASS_Track * p2, long long p3, int * p4))
   DEFINE_METHOD1(ASS_Track *, ass_new_track, (ASS_Library * p1))
@@ -99,6 +101,7 @@ class DllLibass : public DllDynamic, DllLibassInterface
     RESOLVE_METHOD(ass_set_aspect_ratio)
     RESOLVE_METHOD(ass_set_margins)
     RESOLVE_METHOD(ass_set_use_margins)
+    RESOLVE_METHOD(ass_set_line_position)
     RESOLVE_METHOD(ass_set_font_scale)
     RESOLVE_METHOD(ass_render_frame)
     RESOLVE_METHOD(ass_new_track)

--- a/xbmc/cores/dvdplayer/IDVDPlayer.h
+++ b/xbmc/cores/dvdplayer/IDVDPlayer.h
@@ -69,7 +69,7 @@ public:
   virtual bool IsSubtitleEnabled() = 0;
   virtual void EnableFullscreen(bool bEnable) = 0;
 #ifdef HAS_VIDEO_PLAYBACK
-  virtual void GetVideoRect(CRect& SrcRect, CRect& DestRect) const = 0;
+  virtual void GetVideoRect(CRect& SrcRect, CRect& DestRect, CRect& ViewRect) const = 0;
   virtual float GetAspectRatio() = 0;
 #endif
   virtual double GetDelay() = 0;

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -124,7 +124,7 @@ public:
   void SetFlags(unsigned flags)                     { m_flags = flags; };
   int GetFreeSpace();
   void  SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
-  void GetVideoRect(CRect& SrcRect, CRect& DestRect) const { g_renderManager.GetVideoRect(SrcRect, DestRect); }
+  void GetVideoRect(CRect& SrcRect, CRect& DestRect, CRect& ViewRect) const { g_renderManager.GetVideoRect(SrcRect, DestRect, ViewRect); }
   static void RenderUpdateCallBack(const void *ctx, const CRect &SrcRect, const CRect &DestRect);
   void ResolutionUpdateCallBack(uint32_t width, uint32_t height, float framerate, float pixel_aspect);
   static void ResolutionUpdateCallBack(void *ctx, uint32_t width, uint32_t height, float framerate, float pixel_aspect);


### PR DESCRIPTION
Many users want to show ass/ssa subtitles on the black screen at the bottom of the video. <s>So add a option to set the location of ASS/SSA subtitles on the screen:
In the video: ASS/SSA subtitles will show the position fit the video
In the screen: ASS/SSA subtitles will show the position fit the screen (use the bottom black bar)
So add a function to set the location of ASS/SSA subtitles on the screen use setting 'subtitles.align'.
SUBTITLE_ALIGN_MANUAL
SUBTITLE_ALIGN_BOTTOM_INSIDE
SUBTITLE_ALIGN_TOP_INSIDE: 
ASS/SSA subtitles will show the position fit the video
SUBTITLE_ALIGN_BOTTOM_OUTSIDE
SUBTITLE_ALIGN_TOP_OUTSIDE: 
ASS/SSA subtitles will show the position fit the screen (use the bottom black bar)</s>
So use ass_set_use_margins and ass_set_line_position to fully support setting  'subtitles.align'.
SUBTITLE_ALIGN_MANUAL / SUBTITLE_ALIGN_BOTTOM_INSIDE:
show subtitles align bottom inside video

SUBTITLE_ALIGN_TOP_INSIDE: 
show subtitles align top inside video

SUBTITLE_ALIGN_BOTTOM_OUTSIDE:
show subtitles align bottom outside video

SUBTITLE_ALIGN_TOP_OUTSIDE: 
show subtitles align top outside video
