### PR TITLE
Improved musicbrainz matching from tags

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -291,6 +291,7 @@ GTEST_LIBS = $(GTEST_DIR)/lib/.libs/libgtest.a
 
 CHECK_DIRS = xbmc/addons/test \
              xbmc/filesystem/test \
+             xbmc/music/tags/test \
              xbmc/utils/test \
              xbmc/video/test \
              xbmc/threads/test \
@@ -299,6 +300,7 @@ CHECK_DIRS = xbmc/addons/test \
              xbmc/test
 CHECK_LIBS = xbmc/addons/test/addonsTest.a \
              xbmc/filesystem/test/filesystemTest.a \
+             xbmc/music/tags/test/tagsTest.a \
              xbmc/utils/test/utilsTest.a \
              xbmc/video/test/videoTest.a \
              xbmc/threads/test/threadTest.a \

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -40,6 +40,7 @@
 
 #include "TagLibVFSStream.h"
 #include "MusicInfoTag.h"
+#include "utils/RegExp.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -283,10 +284,10 @@ bool CTagLoaderTagLib::ParseASF(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
     else if (it->first == "WM/ArtistSortOrder")          {} // Known unsupported, supress warnings
     else if (it->first == "WM/Script")                   {} // Known unsupported, supress warnings
     else if (it->first == "WM/Year")                     tag.SetYear(atoi(it->second.front().toString().toCString(true)));
-    else if (it->first == "MusicBrainz/Artist Id")       tag.SetMusicBrainzArtistID(GetASFStringList(it->second));
+    else if (it->first == "MusicBrainz/Artist Id")       tag.SetMusicBrainzArtistID(SplitMBID(GetASFStringList(it->second)));
     else if (it->first == "MusicBrainz/Album Id")        tag.SetMusicBrainzAlbumID(it->second.front().toString().to8Bit(true));
     else if (it->first == "MusicBrainz/Album Artist")    SetAlbumArtist(tag, GetASFStringList(it->second));
-    else if (it->first == "MusicBrainz/Album Artist Id") tag.SetMusicBrainzAlbumArtistID(GetASFStringList(it->second));
+    else if (it->first == "MusicBrainz/Album Artist Id") tag.SetMusicBrainzAlbumArtistID(SplitMBID(GetASFStringList(it->second)));
     else if (it->first == "MusicBrainz/Track Id")        tag.SetMusicBrainzTrackID(it->second.front().toString().to8Bit(true));
     else if (it->first == "MusicBrainz/Album Status")    {}
     else if (it->first == "MusicBrainz/Album Type")      {}
@@ -397,9 +398,9 @@ bool CTagLoaderTagLib::ParseID3v2Tag(ID3v2::Tag *id3v2, EmbeddedArt *art, CMusic
         StringList stringList = frame->fieldList(); 
         stringList.erase(stringList.begin());
         String desc = frame->description().upper();
-        if      (desc == "MUSICBRAINZ ARTIST ID")       tag.SetMusicBrainzArtistID(StringListToVectorString(stringList));
+        if      (desc == "MUSICBRAINZ ARTIST ID")       tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(stringList)));
         else if (desc == "MUSICBRAINZ ALBUM ID")        tag.SetMusicBrainzAlbumID(stringList.front().to8Bit(true));
-        else if (desc == "MUSICBRAINZ ALBUM ARTIST ID") tag.SetMusicBrainzAlbumArtistID(StringListToVectorString(stringList));
+        else if (desc == "MUSICBRAINZ ALBUM ARTIST ID") tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(stringList)));
         else if (desc == "MUSICBRAINZ ALBUM ARTIST")    SetAlbumArtist(tag, StringListToVectorString(stringList));
         else if (desc == "REPLAYGAIN_TRACK_GAIN")       tag.SetReplayGainTrackGain((int)(atof(stringList.front().toCString(true)) * 100 + 0.5));
         else if (desc == "REPLAYGAIN_ALBUM_GAIN")       tag.SetReplayGainAlbumGain((int)(atof(stringList.front().toCString(true)) * 100 + 0.5));
@@ -501,8 +502,8 @@ bool CTagLoaderTagLib::ParseAPETag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTa
     else if (it->first == "REPLAYGAIN_ALBUM_GAIN")     tag.SetReplayGainAlbumGain((int)(atof(it->second.toString().toCString(true)) * 100 + 0.5));
     else if (it->first == "REPLAYGAIN_TRACK_PEAK")     tag.SetReplayGainTrackPeak((float)atof(it->second.toString().toCString(true)));
     else if (it->first == "REPLAYGAIN_ALBUM_PEAK")     tag.SetReplayGainAlbumPeak((float)atof(it->second.toString().toCString(true)));
-    else if (it->first == "MUSICBRAINZ_ARTISTID")      tag.SetMusicBrainzArtistID(StringListToVectorString(it->second.toStringList()));
-    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID") tag.SetMusicBrainzAlbumArtistID(StringListToVectorString(it->second.toStringList()));
+    else if (it->first == "MUSICBRAINZ_ARTISTID")      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
+    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID") tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
     else if (it->first == "MUSICBRAINZ_ALBUMARTIST")   SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
     else if (it->first == "MUSICBRAINZ_ALBUMID")       tag.SetMusicBrainzAlbumID(it->second.toString().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_TRACKID")       tag.SetMusicBrainzTrackID(it->second.toString().to8Bit(true));
@@ -542,8 +543,8 @@ bool CTagLoaderTagLib::ParseXiphComment(Ogg::XiphComment *xiph, EmbeddedArt *art
     else if (it->first == "REPLAYGAIN_ALBUM_GAIN")     tag.SetReplayGainAlbumGain((int)(atof(it->second.front().toCString(true)) * 100 + 0.5));
     else if (it->first == "REPLAYGAIN_TRACK_PEAK")     tag.SetReplayGainTrackPeak((float)atof(it->second.front().toCString(true)));
     else if (it->first == "REPLAYGAIN_ALBUM_PEAK")     tag.SetReplayGainAlbumPeak((float)atof(it->second.front().toCString(true)));
-    else if (it->first == "MUSICBRAINZ_ARTISTID")      tag.SetMusicBrainzArtistID(StringListToVectorString(it->second));
-    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID") tag.SetMusicBrainzAlbumArtistID(StringListToVectorString(it->second));
+    else if (it->first == "MUSICBRAINZ_ARTISTID")      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second)));
+    else if (it->first == "MUSICBRAINZ_ALBUMARTISTID") tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second)));
     else if (it->first == "MUSICBRAINZ_ALBUMARTIST")   SetAlbumArtist(tag, StringListToVectorString(it->second));
     else if (it->first == "MUSICBRAINZ_ALBUMID")       tag.SetMusicBrainzAlbumID(it->second.front().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_TRACKID")       tag.SetMusicBrainzTrackID(it->second.front().to8Bit(true));
@@ -633,9 +634,9 @@ bool CTagLoaderTagLib::ParseMP4Tag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTa
     else if (it->first == "----:com.apple.iTunes:replaygain_album_peak")
       tag.SetReplayGainAlbumPeak((float)(atof(it->second.toStringList().front().toCString())));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Artist Id")
-      tag.SetMusicBrainzArtistID(StringListToVectorString(it->second.toStringList()));
+      tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Artist Id")
-      tag.SetMusicBrainzAlbumArtistID(StringListToVectorString(it->second.toStringList()));
+      tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(it->second.toStringList())));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Artist")
       SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Id")
@@ -738,6 +739,26 @@ void CTagLoaderTagLib::SetArtist(CMusicInfoTag &tag, const vector<string> &value
     tag.SetArtist(values[0]);
   else
     tag.SetArtist(values);
+}
+
+const std::vector<std::string> CTagLoaderTagLib::SplitMBID(const std::vector<std::string> &values)
+{
+  if (values.empty() || values.size() > 1)
+    return values;
+
+  // Picard, and other taggers use a heap of different separators.  We use a regexp to detect
+  // MBIDs to make sure we hit them all...
+  std::vector<std::string> ret;
+  std::string value = values[0];
+  StringUtils::ToLower(value);
+  CRegExp reg;
+  if (reg.RegComp("([[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})"))
+  {
+    int pos = -1;
+    while ((pos = reg.RegFind(value, pos+1)) > -1)
+      ret.push_back(reg.GetMatch(1));
+  }
+  return ret;
 }
 
 void CTagLoaderTagLib::SetAlbumArtist(CMusicInfoTag &tag, const vector<string> &values)

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -59,6 +59,8 @@ public:
   virtual bool                   Load(const CStdString& strFileName, MUSIC_INFO::CMusicInfoTag& tag, MUSIC_INFO::EmbeddedArt *art = NULL);
 
   bool                           Load(const CStdString& strFileName, MUSIC_INFO::CMusicInfoTag& tag, const CStdString& fallbackFileExtension, MUSIC_INFO::EmbeddedArt *art = NULL);
+
+  const std::vector<std::string> SplitMBID(const std::vector<std::string> &values);
 private:
   bool                           Open(const std::string& strFileName, bool readOnly);
   const std::vector<std::string> GetASFStringList(const TagLib::List<TagLib::ASF::Attribute>& list);

--- a/xbmc/music/tags/test/Makefile
+++ b/xbmc/music/tags/test/Makefile
@@ -1,0 +1,9 @@
+SRCS= \
+  TestTagLoaderTagLib.cpp
+
+LIB=tagsTest.a
+
+INCLUDES += -I../../../../lib/gtest/include
+
+include ../../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
+++ b/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
@@ -1,0 +1,79 @@
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "music/tags/TagLoaderTagLib.h"
+
+TEST(TestTagLoaderTagLib, SplitMBID)
+{
+  CTagLoaderTagLib lib;
+
+  // SplitMBID should return the vector if it's empty or longer than 1
+  std::vector<std::string> values;
+  EXPECT_TRUE(lib.SplitMBID(values).empty());
+
+  values.push_back("1");
+  values.push_back("2");
+  EXPECT_EQ(values, lib.SplitMBID(values));
+
+  // length 1 and invalid should return empty
+  values.clear();
+  values.push_back("invalid");
+  EXPECT_TRUE(lib.SplitMBID(values).empty());
+
+  // length 1 and valid should return the valid id
+  values.clear();
+  values.push_back("0383dadf-2a4e-4d10-a46a-e9e041da8eb3");
+  EXPECT_EQ(lib.SplitMBID(values), values);
+
+  // case shouldn't matter
+  values.clear();
+  values.push_back("0383DaDf-2A4e-4d10-a46a-e9e041da8eb3");
+  EXPECT_EQ(lib.SplitMBID(values).size(), 1u);
+  EXPECT_STREQ(lib.SplitMBID(values)[0].c_str(), "0383dadf-2a4e-4d10-a46a-e9e041da8eb3");
+
+  // valid with some stuff off the end or start should return valid
+  values.clear();
+  values.push_back("foo0383dadf-2a4e-4d10-a46a-e9e041da8eb3 blah");
+  EXPECT_EQ(lib.SplitMBID(values).size(), 1u);
+  EXPECT_STREQ(lib.SplitMBID(values)[0].c_str(), "0383dadf-2a4e-4d10-a46a-e9e041da8eb3");
+
+  // two valid with various separators
+  values.clear();
+  values.push_back("0383dadf-2a4e-4d10-a46a-e9e041da8eb3;53b106e7-0cc6-42cc-ac95-ed8d30a3a98e");
+  std::vector<std::string> result = lib.SplitMBID(values);
+  EXPECT_EQ(result.size(), 2u);
+  EXPECT_STREQ(result[0].c_str(), "0383dadf-2a4e-4d10-a46a-e9e041da8eb3");
+  EXPECT_STREQ(result[1].c_str(), "53b106e7-0cc6-42cc-ac95-ed8d30a3a98e");
+
+  values.clear();
+  values.push_back("0383dadf-2a4e-4d10-a46a-e9e041da8eb3/53b106e7-0cc6-42cc-ac95-ed8d30a3a98e");
+  result = lib.SplitMBID(values);
+  EXPECT_EQ(result.size(), 2u);
+  EXPECT_STREQ(result[0].c_str(), "0383dadf-2a4e-4d10-a46a-e9e041da8eb3");
+  EXPECT_STREQ(result[1].c_str(), "53b106e7-0cc6-42cc-ac95-ed8d30a3a98e");
+
+  values.clear();
+  values.push_back("0383dadf-2a4e-4d10-a46a-e9e041da8eb3 / 53b106e7-0cc6-42cc-ac95-ed8d30a3a98e; ");
+  result = lib.SplitMBID(values);
+  EXPECT_EQ(result.size(), 2u);
+  EXPECT_STREQ(result[0].c_str(), "0383dadf-2a4e-4d10-a46a-e9e041da8eb3");
+  EXPECT_STREQ(result[1].c_str(), "53b106e7-0cc6-42cc-ac95-ed8d30a3a98e");
+}


### PR DESCRIPTION
Currently various software (e.g. Picard) drops MBIDs into ID3v2.3 tags with various random separators.  I've seen semicolons, semicolons+space, slashes etc.  XBMC doesn't detect this as yet, even though MBIDs take an obvious, known form.

This commit fixes it by using a regexp to detect any MBIDs in the tag regardless of separator.

@night199uk please review and do a few tests - thanks!
