### PR TITLE
[strings] move the 'Component-specific logging...' string out of reserved range

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -15404,13 +15404,6 @@ msgctxt "#36509"
 msgid "Monoscopic - 2D"
 msgstr ""
 
-#. Description of setting "System -> Debugging -> Component-specific logging..." with label #668
-#: system/settings/settings.xml
-msgctxt "#36510"
-msgid "Specify additional libraries whose log messages are to be included in the log."
-msgstr ""
-
-#empty strings from id 36511 to 36519
 #reserved strings for 3d modes 36509 - 36520
 
 #: system/settings/settings.xml
@@ -15485,7 +15478,11 @@ msgctxt "#36533"
 msgid "Select how audio is downmixed, for example from 5.1 to 2.0: [Enabled] maintains the dynamic range of the original audio source when downmixed however volume will be lower [Disabled] maintains volume level of the original audio source however the dynamic range is compressed. Note - Dynamic range is the difference between the quietest and loudest sounds in a audio source."
 msgstr ""
 
-#empty string with id 36534
+#. Description of setting "System -> Debugging -> Component-specific logging..." with label #668
+#: system/settings/settings.xml
+msgctxt "#36534"
+msgid "Specify additional libraries whose log messages are to be included in the log."
+msgstr ""
 
 #: guilib/StereoscopicsManager.cpp
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2746,7 +2746,7 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="debug.setextraloglevel" type="list[integer]" parent="debug.extralogging" label="668" help="36510">
+        <setting id="debug.setextraloglevel" type="list[integer]" parent="debug.extralogging" label="668" help="36534">
           <level>1</level>
           <default></default>
           <constraints>


### PR DESCRIPTION
This addresses the problem detailed here:

https://github.com/xbmc/xbmc/commit/f9bfd784bd8e91c751c6c4a3e868fc6d5a1955c3#commitcomment-6753650

@alanwww1 it is proposed that we then change string 36511 to a stereoscopic one.  Will transifex correctly detect that the string definition has changed (so that other languages don't show the debuglogging string if they're not updated?)
