### PR TITLE
[plugins] drop the RemoveSlashAtEnd() from plugin options

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -101,8 +101,6 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
 
   // get options
   std::string options = url.GetOptions();
-  URIUtils::RemoveSlashAtEnd(options); // This MAY kill some scripts (eg though with a URL ending with a slash), but
-                                    // is needed for all others, as XBMC adds slashes to "folders"
   url.SetOptions(""); // do this because we can then use the url to generate the basepath
                       // which is passed to the plugin (and represents the share)
 
@@ -431,8 +429,6 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath)
 
   // options
   std::string options = url.GetOptions();
-  URIUtils::RemoveSlashAtEnd(options); // This MAY kill some scripts (eg though with a URL ending with a slash), but
-                                    // is needed for all others, as XBMC adds slashes to "folders"
   url.SetOptions(""); // do this because we can then use the url to generate the basepath
                       // which is passed to the plugin (and represents the share)
 


### PR DESCRIPTION
For some weird reason (from ages ago - far enough back that I got bored looking further) we remove the slash at the end of plugin _options_ even though there's no need to do so: Both URIUtils::AddSlashAtEnd, HasSlashAtEnd etc. correctly ignore protocol options when adding or checking for slashes.

Needs extensive testing.

@MartijnKaijser perhaps you could test?
