### PR TITLE
Addon callbacks for special-case stuff

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -178,6 +178,15 @@ public:
 
   void MarkAsDisabled() { m_enabled = false; }
 
+  /*! \brief callback for when this add-on is disabled.
+   Use to perform any needed actions (e.g. stop a service)
+   */
+  virtual void OnDisabled() {};
+
+  /*! \brief callback for when this add-on is enabled.
+   Use to perform any needed actions (e.g. start a service)
+   */
+  virtual void OnEnabled() {};
 protected:
   friend class CAddonCallbacksAddon;
 

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -195,6 +195,8 @@ public:
   /*! \brief callbacks for special install/uninstall behaviour */
   virtual bool OnPreInstall() { return false; };
   virtual void OnPostInstall(bool restart, bool update) {};
+  virtual void OnPreUnInstall() {};
+  virtual void OnPostUnInstall() {};
   virtual bool CanInstall(const std::string& referer) { return true; }
 protected:
   friend class CAddonCallbacksAddon;

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -187,6 +187,10 @@ public:
    Use to perform any needed actions (e.g. start a service)
    */
   virtual void OnEnabled() {};
+
+  /*! \brief retrieve the running instance of an add-on if it persists while running.
+   */
+  virtual AddonPtr GetRunningInstance() const { return AddonPtr(); }
 protected:
   friend class CAddonCallbacksAddon;
 

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -191,6 +191,8 @@ public:
   /*! \brief retrieve the running instance of an add-on if it persists while running.
    */
   virtual AddonPtr GetRunningInstance() const { return AddonPtr(); }
+
+  virtual bool CanInstall(const std::string& referer) { return true; }
 protected:
   friend class CAddonCallbacksAddon;
 

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -192,6 +192,9 @@ public:
    */
   virtual AddonPtr GetRunningInstance() const { return AddonPtr(); }
 
+  /*! \brief callbacks for special install/uninstall behaviour */
+  virtual bool OnPreInstall() { return false; };
+  virtual void OnPostInstall(bool restart, bool update) {};
   virtual bool CanInstall(const std::string& referer) { return true; }
 protected:
   friend class CAddonCallbacksAddon;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -47,8 +47,6 @@
 #include "Repository.h"
 #include "Skin.h"
 #include "Service.h"
-#include "pvr/PVRManager.h"
-#include "pvr/addons/PVRClients.h"
 #include "Util.h"
 
 using namespace std;
@@ -438,22 +436,18 @@ bool CAddonMgr::GetAddons(const TYPE &type, VECADDONS &addons, bool enabled /* =
     const cp_extension_t *props = exts[i];
     if (IsAddonDisabled(props->plugin->identifier) != enabled)
     {
-      // get a pointer to a running pvrclient if it's already started, or we won't be able to change settings
-      if (TranslateType(props->ext_point_id) == ADDON_PVRDLL &&
-          enabled &&
-          g_PVRManager.IsStarted())
-      {
-        AddonPtr pvrAddon;
-        if (g_PVRClients->GetClient(props->plugin->identifier, pvrAddon))
-        {
-          addons.push_back(pvrAddon);
-          continue;
-        }
-      }
-
       AddonPtr addon(Factory(props));
       if (addon)
+      {
+        if (enabled)
+        {
+          // if the addon has a running instance, grab that
+          AddonPtr runningAddon = addon->GetRunningInstance();
+          if (runningAddon)
+            addon = runningAddon;
+        }
         addons.push_back(addon);
+      }
     }
   }
   m_cpluff->release_info(m_cp_context, exts);
@@ -471,17 +465,15 @@ bool CAddonMgr::GetAddon(const std::string &str, AddonPtr &addon, const TYPE &ty
     addon = GetAddonFromDescriptor(cpaddon, type==ADDON_UNKNOWN?"":TranslateType(type));
     m_cpluff->release_info(m_cp_context, cpaddon);
 
-    if (addon && addon.get())
+    if (addon)
     {
       if (enabledOnly && IsAddonDisabled(addon->ID()))
         return false;
 
-      if (addon->Type() == ADDON_PVRDLL && g_PVRManager.IsStarted())
-      {
-        AddonPtr pvrAddon;
-        if (g_PVRClients->GetClient(addon->ID(), pvrAddon))
-          addon = pvrAddon;
-      }
+      // if the addon has a running instance, grab that
+      AddonPtr runningAddon = addon->GetRunningInstance();
+      if (runningAddon)
+        addon = runningAddon;
     }
     return NULL != addon.get();
   }

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -50,7 +50,6 @@
 #include "Util.h"
 
 using namespace std;
-using namespace PVR;
 using namespace XFILE;
 
 namespace ADDON
@@ -158,7 +157,7 @@ AddonPtr CAddonMgr::Factory(const cp_extension_t *props)
         else if (type == ADDON_PVRDLL)
         {
 #ifdef HAS_PVRCLIENTS
-          return AddonPtr(new CPVRClient(props));
+          return AddonPtr(new PVR::CPVRClient(props));
 #endif
         }
         else if (type == ADDON_AUDIOENCODER)
@@ -663,7 +662,7 @@ AddonPtr CAddonMgr::AddonFromProps(AddonProps& addonProps)
     case ADDON_VIZ_LIBRARY:
       return AddonPtr(new CAddonLibrary(addonProps));
     case ADDON_PVRDLL:
-      return AddonPtr(new CPVRClient(addonProps));
+      return AddonPtr(new PVR::CPVRClient(addonProps));
     case ADDON_AUDIOENCODER:
       return AddonPtr(new CAudioEncoder(addonProps));
     case ADDON_REPOSITORY:

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -118,6 +118,7 @@ namespace ADDON
     virtual void OnDisabled() =0;
     virtual void OnEnabled() =0;
     virtual AddonPtr GetRunningInstance() const=0;
+    virtual bool CanInstall(const std::string& referer) =0;
 
   protected:
     virtual bool LoadSettings(bool bForce = false) =0;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -117,6 +117,7 @@ namespace ADDON
     virtual bool ReloadSettings() =0;
     virtual void OnDisabled() =0;
     virtual void OnEnabled() =0;
+    virtual AddonPtr GetRunningInstance() const=0;
 
   protected:
     virtual bool LoadSettings(bool bForce = false) =0;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -120,6 +120,8 @@ namespace ADDON
     virtual AddonPtr GetRunningInstance() const=0;
     virtual bool OnPreInstall() =0;
     virtual void OnPostInstall(bool restart, bool update) =0;
+    virtual void OnPreUnInstall() =0;
+    virtual void OnPostUnInstall() =0;
     virtual bool CanInstall(const std::string& referer) =0;
 
   protected:

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -115,6 +115,8 @@ namespace ADDON
     virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;
     virtual bool MeetsVersion(const AddonVersion &version) const =0;
     virtual bool ReloadSettings() =0;
+    virtual void OnDisabled() =0;
+    virtual void OnEnabled() =0;
 
   protected:
     virtual bool LoadSettings(bool bForce = false) =0;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -118,6 +118,8 @@ namespace ADDON
     virtual void OnDisabled() =0;
     virtual void OnEnabled() =0;
     virtual AddonPtr GetRunningInstance() const=0;
+    virtual bool OnPreInstall() =0;
+    virtual void OnPostInstall(bool restart, bool update) =0;
     virtual bool CanInstall(const std::string& referer) =0;
 
   protected:

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -28,6 +28,7 @@
 #include "filesystem/PluginDirectory.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
+#include "utils/JobManager.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -207,6 +208,14 @@ VECADDONS CRepository::Parse(const DirInfo& dir)
   }
 
   return result;
+}
+
+void CRepository::OnPostInstall(bool restart, bool update)
+{
+  VECADDONS addons;
+  AddonPtr repo(new CRepository(*this));
+  addons.push_back(repo);
+  CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(addons), &CAddonInstaller::Get());
 }
 
 CRepositoryUpdateJob::CRepositoryUpdateJob(const VECADDONS &repos)

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -218,6 +218,13 @@ void CRepository::OnPostInstall(bool restart, bool update)
   CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(addons), &CAddonInstaller::Get());
 }
 
+void CRepository::OnPostUnInstall()
+{
+  CAddonDatabase database;
+  database.Open();
+  database.DeleteRepository(ID());
+}
+
 CRepositoryUpdateJob::CRepositoryUpdateJob(const VECADDONS &repos)
   : m_repos(repos)
 {

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -26,7 +26,6 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/File.h"
 #include "filesystem/PluginDirectory.h"
-#include "pvr/PVRManager.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -282,10 +281,7 @@ bool CRepositoryUpdateJob::DoWork()
         if (URIUtils::IsInternetStream(newAddon->Path()))
           referer = StringUtils::Format("Referer=%s-%s.zip",addon->ID().c_str(),addon->Version().asString().c_str());
 
-        if (newAddon->Type() == ADDON_PVRDLL &&
-            !PVR::CPVRManager::Get().InstallAddonAllowed(newAddon->ID()))
-          PVR::CPVRManager::Get().MarkAsOutdated(addon->ID(), referer);
-        else
+        if (!newAddon->CanInstall(referer))
           CAddonInstaller::Get().Install(addon->ID(), true, referer);
       }
       else

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -59,6 +59,9 @@ namespace ADDON
 
     static VECADDONS Parse(const DirInfo& dir);
     static std::string FetchChecksum(const std::string& url);
+
+    virtual void OnPostInstall(bool restart, bool update);
+
   private:
     CRepository(const CRepository &rhs);
   };

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -61,6 +61,7 @@ namespace ADDON
     static std::string FetchChecksum(const std::string& url);
 
     virtual void OnPostInstall(bool restart, bool update);
+    virtual void OnPostUnInstall();
 
   private:
     CRepository(const CRepository &rhs);

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -113,4 +113,14 @@ void CService::BuildServiceType()
   }
 }
 
+void CService::OnDisabled()
+{
+  Stop();
+}
+
+void CService::OnEnabled()
+{
+  Start();
+}
+
 }

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -123,4 +123,31 @@ void CService::OnEnabled()
   Start();
 }
 
+bool CService::OnPreInstall()
+{
+  // make sure the addon is stopped
+  AddonPtr localAddon; // need to grab the local addon so we have the correct library path to stop
+  if (CAddonMgr::Get().GetAddon(ID(), localAddon, ADDON_SERVICE, false))
+  {
+    boost::shared_ptr<CService> service = boost::dynamic_pointer_cast<CService>(localAddon);
+    if (service)
+      service->Stop();
+  }
+  return !CAddonMgr::Get().IsAddonDisabled(ID());
+}
+
+void CService::OnPostInstall(bool restart, bool update)
+{
+  if (restart) // reload/start it if it was running
+  {
+    AddonPtr localAddon; // need to grab the local addon so we have the correct library path to stop
+    if (CAddonMgr::Get().GetAddon(ID(), localAddon, ADDON_SERVICE, false))
+    {
+      boost::shared_ptr<CService> service = boost::dynamic_pointer_cast<CService>(localAddon);
+      if (service)
+        service->Start();
+    }
+  }
+}
+
 }

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -150,4 +150,9 @@ void CService::OnPostInstall(bool restart, bool update)
   }
 }
 
+void CService::OnPreUnInstall()
+{
+  Stop();
+}
+
 }

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -51,6 +51,7 @@ namespace ADDON
     virtual void OnEnabled();
     virtual bool OnPreInstall();
     virtual void OnPostInstall(bool restart, bool update);
+    virtual void OnPreUnInstall();
 
   protected:
     void BuildServiceType();

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -49,6 +49,8 @@ namespace ADDON
     START_OPTION GetStartOption() { return m_startOption; }
     virtual void OnDisabled();
     virtual void OnEnabled();
+    virtual bool OnPreInstall();
+    virtual void OnPostInstall(bool restart, bool update);
 
   protected:
     void BuildServiceType();

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -47,6 +47,8 @@ namespace ADDON
     bool Stop();
     TYPE GetServiceType() { return m_type; }
     START_OPTION GetStartOption() { return m_startOption; }
+    virtual void OnDisabled();
+    virtual void OnEnabled();
 
   protected:
     void BuildServiceType();

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -119,6 +119,8 @@ public:
   static void SettingOptionsSkinThemesFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsStartupWindowsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
+  virtual bool OnPreInstall();
+  virtual void OnPostInstall(bool restart, bool update);
 protected:
   /*! \brief Given a resolution, retrieve the corresponding directory name
    \param res RESOLUTION to translate

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -81,6 +81,19 @@ AddonPtr CPVRClient::GetRunningInstance() const
   return CAddon::GetRunningInstance();
 }
 
+bool CPVRClient::OnPreInstall()
+{
+  // stop the pvr manager, so running pvr add-ons are stopped and closed
+  PVR::CPVRManager::Get().Stop();
+  return false;
+}
+
+void CPVRClient::OnPostInstall(bool restart, bool update)
+{
+  // (re)start the pvr manager
+  PVR::CPVRManager::Get().Start(true);
+}
+
 bool CPVRClient::CanInstall(const std::string &referer)
 {
   if (!PVR::CPVRManager::Get().InstallAddonAllowed(ID()))

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -21,6 +21,7 @@
 #include "Application.h"
 #include "PVRClient.h"
 #include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClients.h"
 #include "epg/Epg.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/timers/PVRTimers.h"
@@ -67,6 +68,17 @@ void CPVRClient::OnEnabled()
 {
   // restart the PVR manager if we're enabling a client
   CPVRManager::Get().Start(true);
+}
+
+AddonPtr CPVRClient::GetRunningInstance() const
+{
+  if (g_PVRManager.IsStarted())
+  {
+    AddonPtr pvrAddon;
+    if (g_PVRClients->GetClient(ID(), pvrAddon))
+      return pvrAddon;
+  }
+  return CAddon::GetRunningInstance();
 }
 
 void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -94,6 +94,18 @@ void CPVRClient::OnPostInstall(bool restart, bool update)
   PVR::CPVRManager::Get().Start(true);
 }
 
+void CPVRClient::OnPreUnInstall()
+{
+  // stop the pvr manager, so running pvr add-ons are stopped and closed
+  PVR::CPVRManager::Get().Stop();
+}
+
+void CPVRClient::OnPostUnInstall()
+{
+  if (CSettings::Get().GetBool("pvrmanager.enabled"))
+    PVR::CPVRManager::Get().Start(true);
+}
+
 bool CPVRClient::CanInstall(const std::string &referer)
 {
   if (!PVR::CPVRManager::Get().InstallAddonAllowed(ID()))

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -81,6 +81,16 @@ AddonPtr CPVRClient::GetRunningInstance() const
   return CAddon::GetRunningInstance();
 }
 
+bool CPVRClient::CanInstall(const std::string &referer)
+{
+  if (!PVR::CPVRManager::Get().InstallAddonAllowed(ID()))
+  {
+    PVR::CPVRManager::Get().MarkAsOutdated(ID(), referer);
+    return false;
+  }
+  return CAddon::CanInstall(referer);
+}
+
 void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
 {
   /* initialise members */

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -56,6 +56,19 @@ CPVRClient::~CPVRClient(void)
   SAFE_DELETE(m_pInfo);
 }
 
+void CPVRClient::OnDisabled()
+{
+  // restart the PVR manager if we're disabling a client
+  if (CPVRManager::Get().IsStarted())
+    CPVRManager::Get().Start(true);
+}
+
+void CPVRClient::OnEnabled()
+{
+  // restart the PVR manager if we're enabling a client
+  CPVRManager::Get().Start(true);
+}
+
 void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
 {
   /* initialise members */

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -60,6 +60,7 @@ namespace PVR
 
     virtual void OnDisabled();
     virtual void OnEnabled();
+    virtual ADDON::AddonPtr GetRunningInstance() const;
 
     /** @name PVR add-on methods */
     //@{

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -63,6 +63,8 @@ namespace PVR
     virtual ADDON::AddonPtr GetRunningInstance() const;
     virtual bool OnPreInstall();
     virtual void OnPostInstall(bool restart, bool update);
+    virtual void OnPreUnInstall();
+    virtual void OnPostUnInstall();
     virtual bool CanInstall(const std::string &referer);
 
     /** @name PVR add-on methods */

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -58,6 +58,9 @@ namespace PVR
     CPVRClient(const cp_extension_t *ext);
     ~CPVRClient(void);
 
+    virtual void OnDisabled();
+    virtual void OnEnabled();
+
     /** @name PVR add-on methods */
     //@{
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -61,6 +61,7 @@ namespace PVR
     virtual void OnDisabled();
     virtual void OnEnabled();
     virtual ADDON::AddonPtr GetRunningInstance() const;
+    virtual bool CanInstall(const std::string &referer);
 
     /** @name PVR add-on methods */
     //@{

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -61,6 +61,8 @@ namespace PVR
     virtual void OnDisabled();
     virtual void OnEnabled();
     virtual ADDON::AddonPtr GetRunningInstance() const;
+    virtual bool OnPreInstall();
+    virtual void OnPostInstall(bool restart, bool update);
     virtual bool CanInstall(const std::string &referer);
 
     /** @name PVR add-on methods */


### PR DESCRIPTION
This cleans up some of the `if (addon->Type() == ADDON_FOO)` over the codebase.  Most of it was there for PVR, but there's also service, repo, and skin-specific stuff.

It's not particularly nice to drop a bunch of includes (the skin ones being the worst) into the add-on classes, but it's better I think than having them elsewhere.

@negge, @xhaggi, @opdenkamp for comments on the PVR stuff.

@Montellese I'd appreciate your thoughts as well.

I'll add more doxy if it's accepted.  One thing to consider is the current special-casing that's left in CAddonDatabase::DisableAddon.  Reason it's there is due to the service+plugin+script in one add-on.  We need to know the add-on could be a specific type.  I wonder whether we need to seriously reconsider how we deal with multi-extension point add-ons.
