### PR TITLE
[videodatabase] use fileid from videoinfotag when available

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -864,7 +864,12 @@ int CVideoDatabase::AddFile(const CStdString& strFileNameAndPath)
 int CVideoDatabase::AddFile(const CFileItem& item)
 {
   if (item.IsVideoDb() && item.HasVideoInfoTag())
-    return AddFile(item.GetVideoInfoTag()->m_strFileNameAndPath);
+  {
+    if (item.GetVideoInfoTag()->m_iFileId != -1)
+      return item.GetVideoInfoTag()->m_iFileId;
+    else
+      return AddFile(item.GetVideoInfoTag()->m_strFileNameAndPath);
+  }
   return AddFile(item.GetPath());
 }
 
@@ -1072,7 +1077,12 @@ int CVideoDatabase::GetFileId(const CStdString& strFilenameAndPath)
 int CVideoDatabase::GetFileId(const CFileItem &item)
 {
   if (item.IsVideoDb() && item.HasVideoInfoTag())
-    return GetFileId(item.GetVideoInfoTag()->m_strFileNameAndPath);
+  {
+    if (item.GetVideoInfoTag()->m_iFileId != -1)
+      return item.GetVideoInfoTag()->m_iFileId;
+    else
+      return GetFileId(item.GetVideoInfoTag()->m_strFileNameAndPath);
+  }
   return GetFileId(item.GetPath());
 }
 


### PR DESCRIPTION
@jmarshallnz as discussed on IRC. Not entirely sure if it's OK to assume we already know about the file in case we have a InfoTag and just return the id in AddFile() though.
