### PR TITLE
Replace GetProtocol() usage with IsProtocol, drop CFileItem::GetAsUrl() duplicate

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4893,7 +4893,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       CFileItem file(*playlist[iNext]);
       // handle plugin://
       CURL url(file.GetPath());
-      if (url.GetProtocol() == "plugin")
+      if (url.IsProtocol("plugin"))
         XFILE::CPluginDirectory::GetPluginResult(url.Get(), file);
 
 #ifdef HAS_UPNP

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1279,11 +1279,6 @@ void CFileItem::SetFileSizeLabel()
     SetLabel2(StringUtils::SizeToString(m_dwSize));
 }
 
-CURL CFileItem::GetAsUrl() const
-{
-  return CURL(m_strPath);
-}
-
 bool CFileItem::CanQueue() const
 {
   return m_bCanQueue;
@@ -1316,13 +1311,13 @@ void CFileItem::FillInMimeType(bool lookup /*= true*/)
       if (!lookup)
         return;
 
-      CCurlFile::GetMimeType(GetAsUrl(), m_mimetype);
+      CCurlFile::GetMimeType(GetURL(), m_mimetype);
 
       // try to get mime-type again but with an NSPlayer User-Agent
       // in order for server to provide correct mime-type.  Allows us
       // to properly detect an MMS stream
       if (StringUtils::StartsWithNoCase(m_mimetype, "video/x-ms-"))
-        CCurlFile::GetMimeType(GetAsUrl(), m_mimetype, "NSPlayer/11.00.6001.7000");
+        CCurlFile::GetMimeType(GetURL(), m_mimetype, "NSPlayer/11.00.6001.7000");
 
       // make sure there are no options set in mime-type
       // mime-type can look like "video/x-ms-asf ; charset=utf8"

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -225,7 +225,6 @@ public:
   void FillInDefaultIcon();
   void SetFileSizeLabel();
   virtual void SetLabel(const std::string &strLabel);
-  CURL GetAsUrl() const;
   int GetVideoContentType() const; /* return VIDEODB_CONTENT_TYPE, but don't want to include videodb in this header */
   bool IsLabelPreformated() const { return m_bLabelPreformated; }
   void SetLabelPreformated(bool bYesNo) { m_bLabelPreformated=bYesNo; }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -149,11 +149,11 @@ CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */
 
 #ifdef HAS_UPNP
   // UPNP
-  if (url.GetProtocol() == "upnp")
+  if (url.IsProtocol("upnp"))
     strFilename = CUPnPDirectory::GetFriendlyName(url);
 #endif
 
-  if (url.GetProtocol() == "rss")
+  if (url.IsProtocol("rss"))
   {
     CRSSDirectory dir;
     CFileItemList items;
@@ -162,7 +162,7 @@ CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */
   }
 
   // Shoutcast
-  else if (url.GetProtocol() == "shout")
+  else if (url.IsProtocol("shout"))
   {
     const CStdString strFileNameAndPath = url.Get();
     const int genre = strFileNameAndPath.find_first_of('=');
@@ -173,7 +173,7 @@ CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */
   }
 
   // Windows SMB Network (SMB)
-  else if (url.GetProtocol() == "smb" && strFilename.empty())
+  else if (url.IsProtocol("smb") && strFilename.empty())
   {
     if (url.GetHostName().empty())
     {
@@ -185,47 +185,47 @@ CStdString CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */
     }
   }
   // iTunes music share (DAAP)
-  else if (url.GetProtocol() == "daap" && strFilename.empty())
+  else if (url.IsProtocol("daap") && strFilename.empty())
     strFilename = g_localizeStrings.Get(20174);
 
   // HDHomerun Devices
-  else if (url.GetProtocol() == "hdhomerun" && strFilename.empty())
+  else if (url.IsProtocol("hdhomerun") && strFilename.empty())
     strFilename = "HDHomerun Devices";
 
   // Slingbox Devices
-  else if (url.GetProtocol() == "sling")
+  else if (url.IsProtocol("sling"))
     strFilename = "Slingbox";
 
   // ReplayTV Devices
-  else if (url.GetProtocol() == "rtv")
+  else if (url.IsProtocol("rtv"))
     strFilename = "ReplayTV Devices";
 
   // HTS Tvheadend client
-  else if (url.GetProtocol() == "htsp")
+  else if (url.IsProtocol("htsp"))
     strFilename = g_localizeStrings.Get(20256);
 
   // VDR Streamdev client
-  else if (url.GetProtocol() == "vtp")
+  else if (url.IsProtocol("vtp"))
     strFilename = g_localizeStrings.Get(20257);
   
   // MythTV client
-  else if (url.GetProtocol() == "myth")
+  else if (url.IsProtocol("myth"))
     strFilename = g_localizeStrings.Get(20258);
 
   // SAP Streams
-  else if (url.GetProtocol() == "sap" && strFilename.empty())
+  else if (url.IsProtocol("sap") && strFilename.empty())
     strFilename = "SAP Streams";
 
   // Root file views
-  else if (url.GetProtocol() == "sources")
+  else if (url.IsProtocol("sources"))
     strFilename = g_localizeStrings.Get(744);
 
   // Music Playlists
-  else if (StringUtils::StartsWithNoCase(path, "special://musicplaylists"))
+  else if (URIUtils::PathStarts(path, "special://musicplaylists"))
     strFilename = g_localizeStrings.Get(136);
 
   // Video Playlists
-  else if (StringUtils::StartsWithNoCase(path, "special://videoplaylists"))
+  else if (URIUtils::PathStarts(path, "special://videoplaylists"))
     strFilename = g_localizeStrings.Get(136);
 
   else if (URIUtils::HasParentInHostname(url) && strFilename.empty())
@@ -1167,16 +1167,16 @@ int CUtil::GetMatchingSource(const CStdString& strPath1, VECSOURCES& VECSOURCES,
     return 1;
 
   // stack://
-  if (checkURL.GetProtocol() == "stack")
+  if (checkURL.IsProtocol("stack"))
     strPath.erase(0, 8); // remove the stack protocol
 
-  if (checkURL.GetProtocol() == "shout")
+  if (checkURL.IsProtocol("shout"))
     strPath = checkURL.GetHostName();
-  if (checkURL.GetProtocol() == "tuxbox")
+  if (checkURL.IsProtocol("tuxbox"))
     return 1;
-  if (checkURL.GetProtocol() == "plugin")
+  if (checkURL.IsProtocol("plugin"))
     return 1;
-  if (checkURL.GetProtocol() == "multipath")
+  if (checkURL.IsProtocol("multipath"))
     strPath = CMultiPathDirectory::GetFirstPath(strPath);
 
   bIsSourceName = false;

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -159,7 +159,7 @@ ICodec* CodecFactory::CreateCodecDemux(const std::string& strFile, const std::st
     return dvdcodec;
   }
 
-  if (urlFile.GetProtocol() == "shout")
+  if (urlFile.IsProtocol("shout"))
   {
     DVDPlayerCodec *dvdcodec = new DVDPlayerCodec();
     dvdcodec->SetContentType("audio/mp3");

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -81,7 +81,7 @@ bool DVDPlayerCodec::Init(const std::string &strFile, unsigned int filecache)
   std::string strFileToOpen = strFile;
 
   CURL urlFile(strFile);
-  if (urlFile.GetProtocol() == "shout" )
+  if (urlFile.IsProtocol("shout") )
     strFileToOpen.replace(0, 8, "http://");
 
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, strFileToOpen, m_strContentType);

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -526,7 +526,7 @@ vector<string> CGUIDialogMediaSource::GetPaths() const
       // and add the user/pass to the password manager - note, we haven't confirmed that it works
       // at this point, but if it doesn't, the user will get prompted anyway in SMBDirectory.
       CURL url(m_paths->Get(i)->GetPath());
-      if (url.GetProtocol() == "smb")
+      if (url.IsProtocol("smb"))
       {
         CPasswordManager::GetInstance().SaveAuthenticatedURL(url);
         url.SetPassword("");

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -330,10 +330,10 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
     PluginPtr plugin = boost::dynamic_pointer_cast<CPluginSource>(addons[i]);
     if (plugin->ProvidesSeveral())
     {
-      CURL url = item->GetAsUrl();
+      CURL url = item->GetURL();
       std::string opt = StringUtils::Format("?content_type=%s",content.c_str());
       url.SetOptions(opt);
-      item->SetPath(url.Get());
+      item->SetURL(url);
     }
     items.Add(item);
   }

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1109,7 +1109,7 @@ bool CCurlFile::Exists(const CURL& url)
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_NOBODY, 1);
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_WRITEDATA, NULL); /* will cause write failure*/
 
-  if(url2.GetProtocol() == "ftp")
+  if(url2.IsProtocol("ftp"))
   {
     g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_FILETIME, 1);
     // nocwd is less standard, will return empty list for non-existed remote dir on some ftp server, avoid it.
@@ -1278,7 +1278,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_WRITEDATA, NULL); /* will cause write failure*/
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_FILETIME , 1); 
 
-  if(url2.GetProtocol() == "ftp")
+  if(url2.IsProtocol("ftp"))
   {
     // nocwd is less standard, will return empty list for non-existed remote dir on some ftp server, avoid it.
     if (StringUtils::EndsWith(url2.GetFileName(), "/"))
@@ -1331,7 +1331,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   result = g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &length);
   if (result != CURLE_OK || length < 0.0)
   {
-    if (url.GetProtocol() == "ftp")
+    if (url.IsProtocol("ftp"))
     {
       g_curlInterface.easy_release(&m_state->m_easyHandle, NULL);
       CLog::Log(LOGNOTICE, "CCurlFile::Stat - Content length failed: %s(%d) for %s", g_curlInterface.easy_strerror(result), result, url.GetRedacted().c_str());

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -39,7 +39,7 @@ namespace XFILE
 bool CFavouritesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   items.Clear();
-  if (url.GetProtocol() == "favourites")
+  if (url.IsProtocol("favourites"))
   {
     return Load(items); //load the default favourite files
   }
@@ -48,7 +48,7 @@ bool CFavouritesDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
 bool CFavouritesDirectory::Exists(const CURL& url)
 {
-  if (url.GetProtocol() == "favourites")
+  if (url.IsProtocol("favourites"))
   {
     return XFILE::CFile::Exists("special://xbmc/system/favourites.xml") 
         || XFILE::CFile::Exists(URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml"));

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -223,9 +223,9 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
   {
     bool bPathInCache;
     CURL url2(URIUtils::SubstitutePath(file));
-    if (url2.GetProtocol() == "apk")
+    if (url2.IsProtocol("apk"))
       url2.SetOptions("");
-    if (url2.GetProtocol() == "zip")
+    if (url2.IsProtocol("zip"))
       url2.SetOptions("");
     if (!g_directoryCache.FileExists(url2.Get(), bPathInCache) )
     {

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -64,7 +64,7 @@ CFileDirectoryFactory::~CFileDirectoryFactory(void)
 // return NULL + set pItem->m_bIsFolder to remove it completely from list.
 IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem, const std::string& strMask)
 {
-  if (url.GetProtocol() == "stack") // disqualify stack as we need to work with each of the parts instead
+  if (url.IsProtocol("stack")) // disqualify stack as we need to work with each of the parts instead
     return NULL;
 
 #ifdef HAS_FILESYSTEM

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -118,14 +118,11 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   if (!CWakeOnAccess::Get().WakeUpHost(url))
     return NULL;
 
-  std::string strProtocol = url.GetProtocol();
-  StringUtils::ToLower(strProtocol);
-
 #if defined(TARGET_ANDROID)
-  if (strProtocol == "apk") return new CAPKFile();
+  if (url.IsProtocol("apk")) return new CAPKFile();
 #endif
-  if (strProtocol == "zip") return new CZipFile();
-  else if (strProtocol == "rar")
+  if (url.IsProtocol("zip")) return new CZipFile();
+  else if (url.IsProtocol("rar"))
   {
 #ifdef HAS_FILESYSTEM_RAR
     return new CRarFile();
@@ -133,77 +130,77 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
     CLog::Log(LOGWARNING, "%s - Compiled without non-free, rar support is disabled", __FUNCTION__);
 #endif
   }
-  else if (strProtocol == "musicdb") return new CMusicDatabaseFile();
-  else if (strProtocol == "videodb") return NULL;
-  else if (strProtocol == "special") return new CSpecialProtocolFile();
-  else if (strProtocol == "multipath") return new CMultiPathFile();
-  else if (strProtocol == "image") return new CImageFile();
-  else if (strProtocol == "file" || strProtocol.empty()) return new CHDFile();
-  else if (strProtocol == "filereader") return new CFileReaderFile();
+  else if (url.IsProtocol("musicdb")) return new CMusicDatabaseFile();
+  else if (url.IsProtocol("videodb")) return NULL;
+  else if (url.IsProtocol("special")) return new CSpecialProtocolFile();
+  else if (url.IsProtocol("multipath")) return new CMultiPathFile();
+  else if (url.IsProtocol("image")) return new CImageFile();
+  else if (url.IsProtocol("file") || url.GetProtocol().empty()) return new CHDFile();
+  else if (url.IsProtocol("filereader")) return new CFileReaderFile();
 #if defined(HAS_FILESYSTEM_CDDA) && defined(HAS_DVD_DRIVE)
-  else if (strProtocol == "cdda") return new CFileCDDA();
+  else if (url.IsProtocol("cdda")) return new CFileCDDA();
 #endif
 #ifdef HAS_FILESYSTEM
-  else if (strProtocol == "iso9660") return new CISOFile();
+  else if (url.IsProtocol("iso9660")) return new CISOFile();
 #endif
-  else if(strProtocol == "udf") return new CUDFFile();
+  else if(url.IsProtocol("udf")) return new CUDFFile();
 #if defined(TARGET_ANDROID)
-  else if (strProtocol == "androidapp") return new CFileAndroidApp();
+  else if (url.IsProtocol("androidapp")) return new CFileAndroidApp();
 #endif
 
   bool networkAvailable = g_application.getNetwork().IsAvailable();
   if (networkAvailable)
   {
-    if (strProtocol == "ftp"
-    ||  strProtocol == "ftps"
-    ||  strProtocol == "rss") return new CCurlFile();
-    else if (strProtocol == "http" ||  strProtocol == "https") return new CHTTPFile();
-    else if (strProtocol == "dav" || strProtocol == "davs") return new CDAVFile();
+    if (url.IsProtocol("ftp")
+    ||  url.IsProtocol("ftps")
+    ||  url.IsProtocol("rss")) return new CCurlFile();
+    else if (url.IsProtocol("http") ||  url.IsProtocol("https")) return new CHTTPFile();
+    else if (url.IsProtocol("dav") || url.IsProtocol("davs")) return new CDAVFile();
 #ifdef HAS_FILESYSTEM_SFTP
-    else if (strProtocol == "sftp" || strProtocol == "ssh") return new CSFTPFile();
+    else if (url.IsProtocol("sftp") || url.IsProtocol("ssh")) return new CSFTPFile();
 #endif
-    else if (strProtocol == "shout") return new CShoutcastFile();
-    else if (strProtocol == "tuxbox") return new CTuxBoxFile();
-    else if (strProtocol == "hdhomerun") return new CHomeRunFile();
-    else if (strProtocol == "sling") return new CSlingboxFile();
-    else if (strProtocol == "myth") return new CMythFile();
-    else if (strProtocol == "cmyth") return new CMythFile();
+    else if (url.IsProtocol("shout")) return new CShoutcastFile();
+    else if (url.IsProtocol("tuxbox")) return new CTuxBoxFile();
+    else if (url.IsProtocol("hdhomerun")) return new CHomeRunFile();
+    else if (url.IsProtocol("sling")) return new CSlingboxFile();
+    else if (url.IsProtocol("myth")) return new CMythFile();
+    else if (url.IsProtocol("cmyth")) return new CMythFile();
 #ifdef HAS_FILESYSTEM_SMB
 #ifdef TARGET_WINDOWS
-    else if (strProtocol == "smb") return new CWINFileSMB();
+    else if (url.IsProtocol("smb")) return new CWINFileSMB();
 #else
-    else if (strProtocol == "smb") return new CSmbFile();
+    else if (url.IsProtocol("smb")) return new CSmbFile();
 #endif
 #endif
 #ifdef HAS_FILESYSTEM
 #ifdef HAS_FILESYSTEM_RTV
-    else if (strProtocol == "rtv") return new CRTVFile();
+    else if (url.IsProtocol("rtv")) return new CRTVFile();
 #endif
 #ifdef HAS_FILESYSTEM_DAAP
-    else if (strProtocol == "daap") return new CDAAPFile();
+    else if (url.IsProtocol("daap")) return new CDAAPFile();
 #endif
 #endif
 #ifdef HAS_FILESYSTEM_SAP
-    else if (strProtocol == "sap") return new CSAPFile();
+    else if (url.IsProtocol("sap")) return new CSAPFile();
 #endif
 #ifdef HAS_FILESYSTEM_VTP
-    else if (strProtocol == "vtp") return new CVTPFile();
+    else if (url.IsProtocol("vtp")) return new CVTPFile();
 #endif
 #ifdef HAS_PVRCLIENTS
-    else if (strProtocol == "pvr") return new CPVRFile();
+    else if (url.IsProtocol("pvr")) return new CPVRFile();
 #endif
 #ifdef HAS_FILESYSTEM_NFS
-    else if (strProtocol == "nfs") return new CNFSFile();
+    else if (url.IsProtocol("nfs")) return new CNFSFile();
 #endif
 #ifdef HAS_FILESYSTEM_AFP
-    else if (strProtocol == "afp") return new CAFPFile();
+    else if (url.IsProtocol("afp")) return new CAFPFile();
 #endif
-    else if (strProtocol == "pipe") return new CPipeFile();    
+    else if (url.IsProtocol("pipe")) return new CPipeFile();    
 #ifdef HAS_UPNP
-    else if (strProtocol == "upnp") return new CUPnPFile();
+    else if (url.IsProtocol("upnp")) return new CUPnPFile();
 #endif
   }
 
-  CLog::Log(LOGWARNING, "%s - %sunsupported protocol(%s) in %s", __FUNCTION__, networkAvailable ? "" : "Network down or ", strProtocol.c_str(), url.GetRedacted().c_str());
+  CLog::Log(LOGWARNING, "%s - %sunsupported protocol(%s) in %s", __FUNCTION__, networkAvailable ? "" : "Network down or ", url.GetProtocol().c_str(), url.GetRedacted().c_str());
   return NULL;
 }

--- a/xbmc/filesystem/HDFile.cpp
+++ b/xbmc/filesystem/HDFile.cpp
@@ -65,7 +65,7 @@ std::string CHDFile::GetLocal(const CURL &url)
 {
   std::string path(url.GetFileName());
 
-  if(url.GetProtocol() == "file")
+  if(url.IsProtocol("file"))
   {
     // file://drive[:]/path
     // file:///drive:/path

--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -46,7 +46,7 @@ CPVRDirectory::~CPVRDirectory()
 
 bool CPVRDirectory::Exists(const CURL& url)
 {
-  return (url.GetProtocol() == "pvr" && url.GetHostName() == "recordings");
+  return (url.IsProtocol("pvr") && url.GetHostName() == "recordings");
 }
 
 bool CPVRDirectory::GetDirectory(const CURL& url, CFileItemList &items)

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -39,9 +39,9 @@ CPlaylistDirectory::~CPlaylistDirectory()
 bool CPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   int playlistTyp=PLAYLIST_NONE;
-  if (url.GetProtocol()=="playlistmusic")
+  if (url.IsProtocol("playlistmusic"))
     playlistTyp=PLAYLIST_MUSIC;
-  else if (url.GetProtocol()=="playlistvideo")
+  else if (url.IsProtocol("playlistvideo"))
     playlistTyp=PLAYLIST_VIDEO;
 
   if (playlistTyp==PLAYLIST_NONE)

--- a/xbmc/filesystem/RarDirectory.cpp
+++ b/xbmc/filesystem/RarDirectory.cpp
@@ -41,7 +41,7 @@ namespace XFILE
     CURL url(urlOrig);
 
     /* if this isn't a proper archive path, assume it's the path to a archive file */
-    if (urlOrig.GetProtocol() != "rar")
+    if (!urlOrig.IsProtocol("rar"))
       url = URIUtils::CreateArchivePath("rar", urlOrig);
 
     std::string strArchive = url.GetHostName();

--- a/xbmc/filesystem/SAPDirectory.cpp
+++ b/xbmc/filesystem/SAPDirectory.cpp
@@ -487,7 +487,7 @@ namespace XFILE
 
   bool CSAPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   {
-    if(url.GetProtocol() != "sap")
+    if(!url.IsProtocol("sap"))
       return false;
 
     CSingleLock lock(g_sapsessions.m_section);

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -143,7 +143,7 @@ CUPnPDirectory::GetFriendlyName(const CURL& url)
 +---------------------------------------------------------------------*/
 bool CUPnPDirectory::GetResource(const CURL& path, CFileItem &item)
 {
-    if(path.GetProtocol() != "upnp")
+    if(!path.IsProtocol("upnp"))
       return false;
 
     CUPnP* upnp = CUPnP::GetInstance();

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -171,7 +171,7 @@ bool GetDirectoryFromTxtRecords(CZeroconfBrowser::ZeroconfService zeroconf_servi
 
 bool CZeroconfDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  assert(url.GetProtocol() == "zeroconf");
+  assert(url.IsProtocol("zeroconf"));
   std::string strPath = url.Get();
   std::string path = strPath.substr(11, strPath.length());
   URIUtils::RemoveSlashAtEnd(path);

--- a/xbmc/filesystem/ZipDirectory.cpp
+++ b/xbmc/filesystem/ZipDirectory.cpp
@@ -46,7 +46,7 @@ namespace XFILE
     CURL urlZip(urlOrig);
 
     /* if this isn't a proper archive path, assume it's the path to a archive file */
-    if (urlOrig.GetProtocol() != "zip")
+    if (!urlOrig.IsProtocol("zip"))
       urlZip = URIUtils::CreateArchivePath("zip", urlOrig);
 
     CURL url(urlZip);

--- a/xbmc/filesystem/win32/Win32SMBDirectory.cpp
+++ b/xbmc/filesystem/win32/Win32SMBDirectory.cpp
@@ -57,7 +57,7 @@ static bool localGetShares(const std::wstring& serverNameToScan, const std::stri
 // check for empty string, remove trailing slash if any, convert to win32 form
 inline static std::wstring prepareWin32SMBDirectoryName(const CURL& url)
 {
-  assert(url.GetProtocol() == "smb");
+  assert(url.IsProtocol("smb"));
 
   if (url.GetHostName().empty() || url.GetShareName().empty())
     return std::wstring(); // can't use win32 standard file API, return empty string
@@ -77,7 +77,7 @@ CWin32SMBDirectory::~CWin32SMBDirectory(void)
 
 bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
-  assert(url.GetProtocol() == "smb");
+  assert(url.IsProtocol("smb"));
   items.Clear();
 
   if (url.GetShareName().empty())
@@ -198,7 +198,7 @@ bool CWin32SMBDirectory::Create(const CURL& url)
 
 bool CWin32SMBDirectory::RealCreate(const CURL& url, bool tryToConnect)
 {
-  assert(url.GetProtocol() == "smb");
+  assert(url.IsProtocol("smb"));
   if (url.GetHostName().empty() || url.GetShareName().empty() || url.GetFileName() == url.GetShareName())
     return false; // can't create new hosts or shares
 
@@ -245,7 +245,7 @@ bool CWin32SMBDirectory::Exists(const CURL& url)
 // * presence of smb server in network (smb://server)
 bool CWin32SMBDirectory::RealExists(const CURL& url, bool tryToConnect)
 {
-  assert(url.GetProtocol() == "smb");
+  assert(url.IsProtocol("smb"));
 
   if (url.GetHostName().empty())
     return true; // 'root' of network is always exist
@@ -321,7 +321,7 @@ bool CWin32SMBDirectory::RealExists(const CURL& url, bool tryToConnect)
 
 bool CWin32SMBDirectory::Remove(const CURL& url)
 {
-  assert(url.GetProtocol() == "smb");
+  assert(url.IsProtocol("smb"));
   std::wstring nameW(prepareWin32SMBDirectoryName(url));
   if (nameW.empty())
     return false;
@@ -605,7 +605,7 @@ static bool localGetShares(const std::wstring& serverNameToScan, const std::stri
 
 bool CWin32SMBDirectory::ConnectAndAuthenticate(CURL& url, bool allowPromptForCredential /*= false*/)
 {
-  assert(url.GetProtocol() == "smb");
+  assert(url.IsProtocol("smb"));
   if (url.GetHostName().empty())
     return false; // can't connect to empty host name
   

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -178,7 +178,7 @@ CBaseTexture *CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned
 {
 #if defined(TARGET_ANDROID)
   CURL url(texturePath);
-  if (url.GetProtocol() == "androidapp")
+  if (url.IsProtocol("androidapp"))
   {
     XFILE::CFileAndroidApp file;
     if (file.Open(url))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1701,7 +1701,7 @@ bool CMusicDatabase::GetSongByFileName(const CStdString& strFileNameAndPath, CSo
   song.Clear();
   CURL url(strFileNameAndPath);
 
-  if (url.GetProtocol()=="musicdb")
+  if (url.IsProtocol("musicdb"))
   {
     CStdString strFile = URIUtils::GetFileName(strFileNameAndPath);
     URIUtils::RemoveExtension(strFile);
@@ -4458,7 +4458,7 @@ int CMusicDatabase::GetSongIDFromPath(const CStdString &filePath)
 {
   // grab the where string to identify the song id
   CURL url(filePath);
-  if (url.GetProtocol()=="musicdb")
+  if (url.IsProtocol("musicdb"))
   {
     CStdString strFile=URIUtils::GetFileName(filePath);
     URIUtils::RemoveExtension(strFile);

--- a/xbmc/music/MusicDbUrl.cpp
+++ b/xbmc/music/MusicDbUrl.cpp
@@ -38,7 +38,7 @@ CMusicDbUrl::~CMusicDbUrl()
 bool CMusicDbUrl::parse()
 {
   // the URL must start with musicdb://
-  if (m_url.GetProtocol() != "musicdb" || m_url.GetFileName().empty())
+  if (!m_url.IsProtocol("musicdb") || m_url.GetFileName().empty())
     return false;
 
   CStdString path = m_url.Get();

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -371,7 +371,7 @@ void CGUIWindowMusicPlaylistEditor::OnLoadPlaylist()
 void CGUIWindowMusicPlaylistEditor::LoadPlaylist(const std::string &playlist)
 {
   const CURL pathToUrl(playlist);
-  if (pathToUrl.GetProtocol() == "newplaylist")
+  if (pathToUrl.IsProtocol("newplaylist"))
   {
     ClearPlaylist();
     m_strLoadedPlaylist.clear();

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -173,7 +173,7 @@ GetProtocolInfo(const CFileItem&              item,
 
     /* fixup the protocol just in case nothing was passed */
     if (proto.IsEmpty()) {
-        proto = item.GetAsUrl().GetProtocol().c_str();
+        proto = item.GetURL().GetProtocol().c_str();
     }
 
     /*
@@ -416,7 +416,7 @@ BuildObject(CFileItem&                    item,
 
         // if the item is remote, add a direct link to the item
         if (URIUtils::IsRemote((const char*)file_path)) {
-            resource.m_ProtocolInfo = PLT_ProtocolInfo(GetProtocolInfo(item, item.GetAsUrl().GetProtocol().c_str(), context));
+            resource.m_ProtocolInfo = PLT_ProtocolInfo(GetProtocolInfo(item, item.GetURL().GetProtocol().c_str(), context));
             resource.m_Uri = file_path;
 
             // if the direct link can be served directly using http, then push it in front

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -234,7 +234,7 @@ NPT_String CUPnPServer::BuildSafeResourceUri(const NPT_HttpUrl &rooturi,
 
     // determine the filename to provide context to md5'd urls
     CStdString filename;
-    if (url.GetProtocol() == "image")
+    if (url.IsProtocol("image"))
       filename = URIUtils::GetFileName(url.GetHostName());
     else
       filename = URIUtils::GetFileName(file_path);

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -366,14 +366,13 @@ bool CMediaSourceSettings::GetSource(const std::string &category, const TiXmlNod
     for (vector<string>::const_iterator path = vecPaths.begin(); path != vecPaths.end(); ++path)
     {
       CURL url(*path);
-      string protocol = url.GetProtocol();
       bool bIsInvalid = false;
 
       // for my programs
       if (StringUtils::EqualsNoCase(category, "programs") || StringUtils::EqualsNoCase(category, "myprograms"))
       {
         // only allow HD and plugins
-        if (url.IsLocal() || StringUtils::EqualsNoCase(protocol, "plugin"))
+        if (url.IsLocal() || url.IsProtocol("plugin"))
           verifiedPaths.push_back(*path);
         else
           bIsInvalid = true;

--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -544,7 +544,7 @@ string CMime::GetMimeType(const CURL &url, bool lookup)
   
   std::string strMimeType;
 
-  if( url.GetProtocol() == "shout" || url.GetProtocol() == "http" || url.GetProtocol() == "https")
+  if( url.IsProtocol("shout") || url.IsProtocol("http") || url.IsProtocol("https"))
   {
     // If lookup is false, bail out early to leave mime type empty
     if (!lookup)

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -146,7 +146,7 @@ void CRssReader::Process()
     std::string fileCharset;
 
     // we wait for the network to come up
-    if ((url.GetProtocol() == "http" || url.GetProtocol() == "https") &&
+    if ((url.IsProtocol("http") || url.IsProtocol("https")) &&
         !g_application.getNetwork().IsAvailable(true))
     {
       CLog::Log(LOGWARNING, "RSS: No network connection");
@@ -165,7 +165,7 @@ void CRssReader::Process()
         }
         nRetries--;
 
-        if (url.GetProtocol() != "http" && url.GetProtocol() != "https")
+        if (!url.IsProtocol("http") && !url.IsProtocol("https"))
         {
           CFile file;
           auto_buffer buffer;

--- a/xbmc/video/VideoDbUrl.cpp
+++ b/xbmc/video/VideoDbUrl.cpp
@@ -37,7 +37,7 @@ CVideoDbUrl::~CVideoDbUrl()
 bool CVideoDbUrl::parse()
 {
   // the URL must start with videodb://
-  if (m_url.GetProtocol() != "videodb" || m_url.GetFileName().empty())
+  if (!m_url.IsProtocol("videodb") || m_url.GetFileName().empty())
     return false;
 
   CStdString path = m_url.Get();

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -405,7 +405,7 @@ void CGUIDialogSubtitles::Download(const CFileItem &subtitle)
 
   // subtitle URL should be of the form plugin://<addonid>/?param=foo&param=bar
   // we just append (if not already present) the action=download parameter.
-  CURL url(subtitle.GetAsUrl());
+  CURL url(subtitle.GetURL());
   if (url.GetOption("action").empty())
     url.SetOption("action", "download");
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1777,7 +1777,7 @@ bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items)
   return !(items.IsTuxBox()         || items.IsPlugin()  ||
            items.IsAddonsPath()     || items.IsRSS()     ||
            items.IsInternetStream() || items.IsVideoDb() ||
-           url.GetProtocol() == "playlistvideo");
+           url.IsProtocol("playlistvideo"));
 }
 
 void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -75,13 +75,13 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (items.HasSortDetails())
     return new CGUIViewStateFromItems(items);
 
-  if (url.GetProtocol()=="musicdb")
+  if (url.IsProtocol("musicdb"))
     return new CGUIViewStateMusicDatabase(items);
 
-  if (url.GetProtocol()=="musicsearch")
+  if (url.IsProtocol("musicsearch"))
     return new CGUIViewStateMusicSearch(items);
 
-  if (items.IsSmartPlayList() || url.GetProtocol() == "upnp" ||
+  if (items.IsSmartPlayList() || url.IsProtocol("upnp") ||
       items.IsLibraryFolder())
   {
     if (items.GetContent() == "songs" ||
@@ -98,7 +98,7 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
       return new CGUIViewStateVideoMovies(items);
   }
 
-  if (url.GetProtocol() == "library")
+  if (url.IsProtocol("library"))
     return new CGUIViewStateLibrary(items);
 
   if (items.IsPlayList())
@@ -107,7 +107,7 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (items.GetPath() == "special://musicplaylists/")
     return new CGUIViewStateWindowMusicSongs(items);
 
-  if (url.GetProtocol() == "androidapp")
+  if (url.IsProtocol("androidapp"))
     return new CGUIViewStateWindowPrograms(items);
 
   if (windowId==WINDOW_MUSIC_NAV)

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -67,7 +67,7 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (windowId == 0)
     return GetViewState(g_windowManager.GetActiveWindow(),items);
 
-  const CURL url=items.GetAsUrl();
+  const CURL url=items.GetURL();
 
   if (items.IsAddonsPath())
     return new CGUIViewStateAddonBrowser(items);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1111,9 +1111,8 @@ void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem)
 
   int idMessageText = 0;
   CURL url(pItem->GetPath());
-  const std::string& strHostName = url.GetHostName();
 
-  if (url.GetProtocol() == "smb" && strHostName.empty()) //  smb workgroup
+  if (url.IsProtocol("smb") && url.GetHostName().empty()) //  smb workgroup
     idMessageText = 15303; // Workgroup not found
   else if (pItem->m_iDriveType == CMediaSource::SOURCE_TYPE_REMOTE || URIUtils::IsRemote(pItem->GetPath()))
     idMessageText = 15301; // Could not connect to network server

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -814,11 +814,11 @@ int CGUIWindowFileManager::GetSelectedItem(int iControl)
 void CGUIWindowFileManager::GoParentFolder(int iList)
 {
   CURL url(m_Directory[iList]->GetPath());
-  if ((url.GetProtocol() == "rar") || (url.GetProtocol() == "zip"))
+  if (url.IsProtocol("rar") || url.IsProtocol("zip"))
   {
     // check for step-below, if, unmount rar
     if (url.GetFileName().empty())
-      if (url.GetProtocol() == "zip")
+      if (url.IsProtocol("zip"))
         g_ZipManager.release(m_Directory[iList]->GetPath()); // release resources
   }
 
@@ -1164,9 +1164,8 @@ void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)
 {
   int idMessageText = 0;
   CURL url(pItem->GetPath());
-  const CStdString& strHostName = url.GetHostName();
 
-  if (url.GetProtocol() == "smb" && strHostName.empty()) //  smb workgroup
+  if (url.IsProtocol("smb") && url.GetHostName().empty()) //  smb workgroup
     idMessageText = 15303; // Workgroup not found
   else if (pItem->m_iDriveType == CMediaSource::SOURCE_TYPE_REMOTE || URIUtils::IsRemote(pItem->GetPath()))
     idMessageText = 15301; // Could not connect to network server


### PR DESCRIPTION
Cleanup - use IsProtocol() rather than GetProtocol() == "blah" so that the compares are constrained to being within CURL for case-insensitivity later on.
