### PR TITLE
[std:string] - fix implicit std::string c'tor with NULL argument

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -634,7 +634,7 @@ std::string CAddonMgr::GetTranslatedString(const cp_cfg_element_t *root, const c
         eng = &child;
     }
   }
-  return (eng) ? eng->value : "";
+  return (eng && eng->value) ? eng->value : "";
 }
 
 AddonPtr CAddonMgr::AddonFromProps(AddonProps& addonProps)


### PR DESCRIPTION
it crashed on addon with empty disclaimer tag in addon.xml.

introduced in ca49c971f622e6fb96ea08159ee32b03f4cb346e
