### PR TITLE
[pvr] use Refresh() instead of Update() to refresh directory listing

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -179,7 +179,7 @@ void CGUIWindowPVRBase::SetGroup(CPVRChannelGroupPtr group)
     // we need to register the window to receive changes from the new group
     m_group->RegisterObserver(this);
     g_PVRManager.SetPlayingGroup(m_group);
-    Update();
+    Refresh();
   }
 }
 
@@ -519,7 +519,7 @@ bool CGUIWindowPVRBase::ActionDeleteChannel(CFileItem *item)
     return false;
 
   g_PVRChannelGroups->GetGroupAll(channel->IsRadio())->RemoveFromGroup(*channel);
-  Update();
+  Refresh(true);
 
   return true;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -52,7 +52,7 @@ namespace PVR
   public:
     virtual void OnInitWindow(void);
     virtual bool OnMessage(CGUIMessage& message);
-    virtual bool Update(const std::string &strDirectory = "", bool updateFilterPath = true);
+    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     virtual void UpdateButtons(void);
     virtual bool OnAction(const CAction &action);
     virtual bool OnBack(int actionID);

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -144,7 +144,7 @@ bool CGUIWindowPVRChannels::Update(const std::string &strDirectory, bool updateF
       /* show the visible channels instead */
       m_bShowHiddenChannels = false;
       lock.Leave();
-      Update();
+      Refresh(true);
   }
 
   return bReturn;
@@ -228,7 +228,7 @@ bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
         case ObservableMessageChannelGroupReset:
         {
           if (IsActive())
-            Update();
+            Refresh(true);
           bReturn = true;
           break;
         }
@@ -289,7 +289,7 @@ bool CGUIWindowPVRChannels::OnContextButtonHide(CFileItem *item, CONTEXT_BUTTON 
       return bReturn;
 
     g_PVRManager.GetPlayingGroup(m_bRadio)->RemoveFromGroup(*channel);
-    Update();
+    Refresh(true);
 
     bReturn = true;
   }
@@ -312,7 +312,7 @@ bool CGUIWindowPVRChannels::OnContextButtonLock(CFileItem *item, CONTEXT_BUTTON 
       return bReturn;
 
     group->ToggleChannelLocked(*item);
-    Update();
+    Refresh(true);
 
     bReturn = true;
   }
@@ -351,7 +351,7 @@ bool CGUIWindowPVRChannels::OnContextButtonMove(CFileItem *item, CONTEXT_BUTTON 
     if (newIndex != channel->ChannelNumber())
     {
       g_PVRManager.GetPlayingGroup()->MoveChannel(channel->ChannelNumber(), newIndex);
-      Update();
+      Refresh(true);
     }
 
     bReturn = true;
@@ -434,7 +434,7 @@ bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUT
 
       channelPtr->SetIconPath(strThumb, true);
       channelPtr->Persist();
-      Update();
+      Refresh(true);
     }
 
     bReturn = true;
@@ -450,7 +450,7 @@ bool CGUIWindowPVRChannels::OnContextButtonShowHidden(CFileItem *item, CONTEXT_B
   if (button == CONTEXT_BUTTON_SHOW_HIDDEN)
   {
     m_bShowHiddenChannels = !m_bShowHiddenChannels;
-    Update();
+    Refresh(true);
     bReturn = true;
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -33,7 +33,7 @@ namespace PVR
     bool OnMessage(CGUIMessage& message);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory = "", bool updateFilterPath = true);
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     void UpdateButtons(void);
     void ResetObservers(void);
     void UnregisterObservers(void);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -337,9 +337,6 @@ void CGUIWindowPVRGuide::UpdateViewTimeline()
 
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
-// FIXPVR
-//  if (bUpdateSelectedFile)
-//    SelectPlayingFile();
   
   m_viewControl.SetItems(*m_vecItems);
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -187,7 +187,7 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
       {
         // let's set the view mode first before update
         CGUIWindowPVRBase::OnMessage(message);
-        Update();
+        Refresh(true);
         bReturn = true;
       }
       break;
@@ -202,7 +202,7 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
           m_bUpdateRequired = true;
           /* update the current window if the EPG timeline view is visible */
           if (IsActive() && m_viewControl.GetCurrentControl() == GUIDE_VIEW_TIMELINE)
-            Update();
+            Refresh(true);
           bReturn = true;
           break;
         }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -39,7 +39,7 @@ namespace PVR
     bool OnAction(const CAction &action);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory = "", bool updateFilterPath = true);
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     void ResetObservers(void);
     void UnregisterObservers(void);
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -243,7 +243,7 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
         case ObservableMessageTimersReset:
         {
           if (IsActive())
-            Update();
+            Refresh(true);
           bReturn = true;
           break;
         }
@@ -299,7 +299,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonRename(CFileItem *item, CONTEXT_BUT
     if (CGUIKeyboardFactory::ShowAndGetInput(strNewName, g_localizeStrings.Get(19041), false))
     {
       if (g_PVRRecordings->RenameRecording(*item, strNewName))
-        Update();
+        Refresh(true);
     }
   }
 
@@ -318,7 +318,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &ite
     g_PVRRecordings->SetRecordingsPlayCount(item, 1);
     m_viewControl.SetSelectedItem(newSelection);
 
-    Update();
+    Refresh(true);
   }
 
   if (button == CONTEXT_BUTTON_MARK_UNWATCHED)
@@ -327,7 +327,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &ite
 
     g_PVRRecordings->SetRecordingsPlayCount(item, 0);
 
-    Update();
+    Refresh(true);
   }
 
   return bReturn;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -38,7 +38,7 @@ namespace PVR
     bool OnAction(const CAction &action);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory = "", bool updateFilterPath = true);
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     void UnregisterObservers(void);
     void ResetObservers(void);
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -187,7 +187,7 @@ bool CGUIWindowPVRSearch::OnContextButtonClear(CFileItem *item, CONTEXT_BUTTON b
     m_bSearchConfirmed = false;
     m_searchfilter.Reset();
 
-    Update();
+    Refresh(true);
   }
 
   return bReturn;
@@ -270,6 +270,6 @@ void CGUIWindowPVRSearch::ShowSearchResults()
   if (pDlgInfo->IsConfirmed())
   {
     m_bSearchConfirmed = true;
-    Update();
+    Refresh(true);
   }
 }

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -34,7 +34,7 @@ namespace PVR
     bool OnMessage(CGUIMessage& message);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory = "", bool updateFilterPath = true);
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
 
   private:
     void Search(void);

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -143,7 +143,7 @@ bool CGUIWindowPVRTimers::OnMessage(CGUIMessage &message)
         case ObservableMessageTimersReset:
         {
           if (IsActive())
-            Update();
+            Refresh(true);
           bReturn = true;
           break;
         }

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.h
@@ -33,7 +33,7 @@ namespace PVR
     bool OnMessage(CGUIMessage& message);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
-    bool Update(const std::string &strDirectory = "", bool updateFilterPath = true);
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     void UnregisterObservers(void);
     void ResetObservers(void);
 


### PR DESCRIPTION
To get rid of the default value for strDirectory in Update() and to gain control of whether we want to clear the cache or not, this will use Refresh() instead of Update() in all PVR windows to refresh the directory listing.

@Jalle19 or @opdenkamp for review.
