### PR TITLE
Drop GetText usage in tinyxml

### DIFF
--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -562,11 +562,11 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
        * Don't use atoll even though it is more correct as it isn't natively supported by
        * Visual Studio.
        *
-       * GetText() returns 0 if there were any problems and will subsequently be rejected in AddCut().
+       * atof() returns 0 if there were any problems and will subsequently be rejected in AddCut().
        */
       Cut cut;
-      cut.start = (int64_t)(atof(pStart->GetText()) / 10000);
-      cut.end = (int64_t)(atof(pEnd->GetText()) / 10000);
+      cut.start = (int64_t)(atof(pStart->FirstChild()->Value()) / 10000);
+      cut.end = (int64_t)(atof(pEnd->FirstChild()->Value()) / 10000);
       cut.action = COMM_BREAK;
       bValid = AddCut(cut);
     }

--- a/xbmc/filesystem/DAVCommon.cpp
+++ b/xbmc/filesystem/DAVCommon.cpp
@@ -70,11 +70,11 @@ std::string CDAVCommon::GetStatusTag(const TiXmlElement *pElement)
 {
   const TiXmlElement *pChild;
 
-  for (pChild = pElement->FirstChild()->ToElement(); pChild != 0; pChild = pChild->NextSibling()->ToElement())
+  for (pChild = pElement->FirstChildElement(); pChild != 0; pChild = pChild->NextSiblingElement())
   {
     if (ValueWithoutNamespace(pChild, "status"))
     {
-      return pChild->GetText();
+      return pChild->NoChildren() ? "" : pChild->FirstChild()->ValueStr();
     }
   }
 

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -113,10 +113,17 @@ static time_t ParseDate(const std::string & strDate)
 }
 static void ParseItem(CFileItem* item, SResources& resources, TiXmlElement* root, const std::string& path);
 
+static std::string GetValue(TiXmlElement *element)
+{
+  if (element && !element->NoChildren())
+    return element->FirstChild()->ValueStr();
+  return "";
+}
+
 static void ParseItemMRSS(CFileItem* item, SResources& resources, TiXmlElement* item_child, const std::string& name, const std::string& xmlns, const std::string& path)
 {
   CVideoInfoTag* vtag = item->GetVideoInfoTag();
-  std::string text = item_child->GetText();
+  std::string text = GetValue(item_child);
 
   if(name == "content")
   {
@@ -140,8 +147,8 @@ static void ParseItemMRSS(CFileItem* item, SResources& resources, TiXmlElement* 
   }
   else if(name == "thumbnail")
   {
-    if(item_child->GetText() && IsPathToThumbnail(item_child->GetText()))
-      item->SetArt("thumb", item_child->GetText());
+    if(!item_child->NoChildren() && IsPathToThumbnail(item_child->FirstChild()->ValueStr()))
+      item->SetArt("thumb", item_child->FirstChild()->ValueStr());
     else
     {
       const char * url = item_child->Attribute("url");
@@ -230,7 +237,7 @@ static void ParseItemMRSS(CFileItem* item, SResources& resources, TiXmlElement* 
 static void ParseItemItunes(CFileItem* item, SResources& resources, TiXmlElement* item_child, const std::string& name, const std::string& xmlns, const std::string& path)
 {
   CVideoInfoTag* vtag = item->GetVideoInfoTag();
-  std::string text = item_child->GetText();
+  std::string text = GetValue(item_child);
 
   if(name == "image")
   {
@@ -254,7 +261,7 @@ static void ParseItemItunes(CFileItem* item, SResources& resources, TiXmlElement
 
 static void ParseItemRSS(CFileItem* item, SResources& resources, TiXmlElement* item_child, const std::string& name, const std::string& xmlns, const std::string& path)
 {
-  std::string text = item_child->GetText();
+  std::string text = GetValue(item_child);
   if (name == "title")
   {
     if(text.length() > item->m_strTitle.length())
@@ -306,7 +313,7 @@ static void ParseItemRSS(CFileItem* item, SResources& resources, TiXmlElement* i
 static void ParseItemVoddler(CFileItem* item, SResources& resources, TiXmlElement* element, const std::string& name, const std::string& xmlns, const std::string& path)
 {
   CVideoInfoTag* vtag = item->GetVideoInfoTag();
-  std::string text = element->GetText();
+  std::string text = GetValue(element);
 
   if(name == "trailer")
   {
@@ -337,7 +344,7 @@ static void ParseItemVoddler(CFileItem* item, SResources& resources, TiXmlElemen
 static void ParseItemBoxee(CFileItem* item, SResources& resources, TiXmlElement* element, const std::string& name, const std::string& xmlns, const std::string& path)
 {
   CVideoInfoTag* vtag = item->GetVideoInfoTag();
-  std::string text = element->GetText();
+  std::string text = GetValue(element);
 
   if     (name == "image")
     item->SetArt("thumb", text);
@@ -362,7 +369,7 @@ static void ParseItemBoxee(CFileItem* item, SResources& resources, TiXmlElement*
 static void ParseItemZink(CFileItem* item, SResources& resources, TiXmlElement* element, const std::string& name, const std::string& xmlns, const std::string& path)
 {
   CVideoInfoTag* vtag = item->GetVideoInfoTag();
-  std::string text = element->GetText();
+  std::string text = GetValue(element);
   if     (name == "episode")
     vtag->m_iEpisode = atoi(text.c_str());
   else if(name == "season")
@@ -381,7 +388,7 @@ static void ParseItemZink(CFileItem* item, SResources& resources, TiXmlElement* 
 
 static void ParseItemSVT(CFileItem* item, SResources& resources, TiXmlElement* element, const std::string& name, const std::string& xmlns, const std::string& path)
 {
-  std::string text = element->GetText();
+  std::string text = GetValue(element);
   if     (name == "xmllink")
   {
     SResource res;

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -777,61 +777,61 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
     if (!pButton->NoChildren())
       action = pButton->FirstChild()->ValueStr();
 
-      if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS) && id>=0 && id<=256)
+    if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS) && id>=0 && id<=256)
+    {
+      if (type == "button")
       {
-        if (type == "button")
+        buttonMap[id] = action;
+      }
+      else if (type == "axis")
+      {
+        int limit = 0;
+        if (pButton->QueryIntAttribute("limit", &limit) == TIXML_SUCCESS)
         {
-          buttonMap[id] = action;
-        }
-        else if (type == "axis")
-        {
-          int limit = 0;
-          if (pButton->QueryIntAttribute("limit", &limit) == TIXML_SUCCESS)
-          {
-            if (limit==-1)
-              axisMap[-id] = action;
-            else if (limit==1)
-              axisMap[id] = action;
-            else if (limit==0)
-              axisMap[id|0xFFFF0000] = action;
-            else
-            {
-              axisMap[id] = action;
-              axisMap[-id] = action;
-              CLog::Log(LOGERROR, "Error in joystick map, invalid limit specified %d for axis %d", limit, id);
-            }
-          }
+          if (limit==-1)
+            axisMap[-id] = action;
+          else if (limit==1)
+            axisMap[id] = action;
+          else if (limit==0)
+            axisMap[id|0xFFFF0000] = action;
           else
           {
             axisMap[id] = action;
             axisMap[-id] = action;
-          }
-        }
-        else if (type == "hat")
-        {
-          string position;
-          if (pButton->QueryValueAttribute("position", &position) == TIXML_SUCCESS)
-          {
-            uint32_t hatID = id|0xFFF00000;
-            if (position.compare("up") == 0)
-              hatMap[(JACTIVE_HAT_UP<<16)|hatID] = action;
-            else if (position.compare("down") == 0)
-              hatMap[(JACTIVE_HAT_DOWN<<16)|hatID] = action;
-            else if (position.compare("right") == 0)
-              hatMap[(JACTIVE_HAT_RIGHT<<16)|hatID] = action;
-            else if (position.compare("left") == 0)
-              hatMap[(JACTIVE_HAT_LEFT<<16)|hatID] = action;
-            else
-              CLog::Log(LOGERROR, "Error in joystick map, invalid position specified %s for axis %d", position.c_str(), id);
+            CLog::Log(LOGERROR, "Error in joystick map, invalid limit specified %d for axis %d", limit, id);
           }
         }
         else
-          CLog::Log(LOGERROR, "Error reading joystick map element, unknown button type: %s", type.c_str());
+        {
+          axisMap[id] = action;
+          axisMap[-id] = action;
+        }
       }
-      else if (type == "altname")
-        joynames.push_back(action);
+      else if (type == "hat")
+      {
+        string position;
+        if (pButton->QueryValueAttribute("position", &position) == TIXML_SUCCESS)
+        {
+          uint32_t hatID = id|0xFFF00000;
+          if (position.compare("up") == 0)
+            hatMap[(JACTIVE_HAT_UP<<16)|hatID] = action;
+          else if (position.compare("down") == 0)
+            hatMap[(JACTIVE_HAT_DOWN<<16)|hatID] = action;
+          else if (position.compare("right") == 0)
+            hatMap[(JACTIVE_HAT_RIGHT<<16)|hatID] = action;
+          else if (position.compare("left") == 0)
+            hatMap[(JACTIVE_HAT_LEFT<<16)|hatID] = action;
+          else
+            CLog::Log(LOGERROR, "Error in joystick map, invalid position specified %s for axis %d", position.c_str(), id);
+        }
+      }
       else
-        CLog::Log(LOGERROR, "Error reading joystick map element, Invalid id: %d", id);
+        CLog::Log(LOGERROR, "Error reading joystick map element, unknown button type: %s", type.c_str());
+    }
+    else if (type == "altname")
+      joynames.push_back(action);
+    else
+      CLog::Log(LOGERROR, "Error reading joystick map element, Invalid id: %d", id);
 
     pButton = pButton->NextSiblingElement();
   }

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -654,7 +654,6 @@ bool CButtonTranslator::LoadKeymap(const std::string &keymapPath)
   return true;
 }
 
-#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
 bool CButtonTranslator::LoadLircMap(const std::string &lircmapPath)
 {
 #ifdef TARGET_POSIX
@@ -748,7 +747,6 @@ int CButtonTranslator::TranslateLircRemoteString(const char* szDevice, const cha
 
   return TranslateRemoteString((*it2).second.c_str());
 }
-#endif
 
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
 void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -26,7 +26,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "system.h" // for HAS_EVENT_SERVER, HAS_SDL_JOYSTICK, HAS_LIRC
+#include "system.h" // for HAS_EVENT_SERVER, HAS_SDL_JOYSTICK
 
 #ifdef HAS_EVENT_SERVER
 #include "network/EventClient.h"
@@ -89,9 +89,7 @@ public:
 
   static bool TranslateActionString(const char *szAction, int &action);
 
-#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   int TranslateLircRemoteString(const char* szDevice, const char *szButton);
-#endif
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
   bool TranslateJoystickString(int window, const char* szDevice, int id,
                                short inputType, int& action, std::string& strAction,
@@ -131,7 +129,6 @@ private:
   void MapAction(uint32_t buttonCode, const char *szAction, buttonMap &map);
 
   bool LoadKeymap(const std::string &keymapPath);
-#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   bool LoadLircMap(const std::string &lircmapPath);
   void ClearLircButtonMapEntries();
 
@@ -139,7 +136,6 @@ private:
 
   typedef std::map<std::string, std::string> lircButtonMap;
   std::map<std::string, lircButtonMap*> lircRemotesMap;
-#endif
 
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
   void MapJoystickActions(int windowID, TiXmlNode *pJoystick);

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -343,9 +343,9 @@ bool CPlayListASX::LoadData(istream& stream)
     while (pElement)
     {
       value = pElement->Value();
-      if (value == "title")
+      if (value == "title" && !pElement->NoChildren())
       {
-        roottitle = pElement->GetText();
+        roottitle = pElement->FirstChild()->ValueStr();
       }
       else if (value == "entry")
       {
@@ -354,8 +354,8 @@ bool CPlayListASX::LoadData(istream& stream)
         TiXmlElement *pRef = pElement->FirstChildElement("ref");
         TiXmlElement *pTitle = pElement->FirstChildElement("title");
 
-        if(pTitle)
-          title = pTitle->GetText();
+        if(pTitle && !pTitle->NoChildren())
+          title = pTitle->FirstChild()->ValueStr();
 
         while (pRef)
         { // multiple references may apear for one entry

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1066,13 +1066,13 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     TiXmlElement* element = pHostEntries->FirstChildElement("entry");
     while(element)
     {
-      CStdString name  = XMLUtils::GetAttribute(element, "name");
-      CStdString value;
-      if(element->GetText())
-        value = element->GetText();
-
-      if(name.length() > 0 && value.length() > 0)
-        CDNSNameCache::Add(name, value);
+      if(!element->NoChildren())
+      {
+        std::string name  = XMLUtils::GetAttribute(element, "name");
+        std::string value = element->FirstChild()->ValueStr();
+        if (!name.empty())
+          CDNSNameCache::Add(name, value);
+      }
       element = element->NextSiblingElement("entry");
     }
   }

--- a/xbmc/utils/Fanart.cpp
+++ b/xbmc/utils/Fanart.cpp
@@ -67,21 +67,24 @@ bool CFanart::Unpack()
     TiXmlElement *fanartThumb = fanart->FirstChildElement("thumb");
     while (fanartThumb)
     {
-      SFanartData data;
-      if (url.empty())
+      if (!fanartThumb->NoChildren())
       {
-        data.strImage = fanartThumb->GetText();
-        data.strPreview = XMLUtils::GetAttribute(fanartThumb, "preview");
+        SFanartData data;
+        if (url.empty())
+        {
+          data.strImage = fanartThumb->FirstChild()->ValueStr();
+          data.strPreview = XMLUtils::GetAttribute(fanartThumb, "preview");
+        }
+        else
+        {
+          data.strImage = URIUtils::AddFileToFolder(url, fanartThumb->FirstChild()->ValueStr());
+          if (fanartThumb->Attribute("preview"))
+            data.strPreview = URIUtils::AddFileToFolder(url, fanartThumb->Attribute("preview"));
+        }
+        data.strResolution = XMLUtils::GetAttribute(fanartThumb, "dim");
+        ParseColors(XMLUtils::GetAttribute(fanartThumb, "colors"), data.strColors);
+        m_fanart.push_back(data);
       }
-      else
-      {
-        data.strImage = URIUtils::AddFileToFolder(url, fanartThumb->GetText());
-        if (fanartThumb->Attribute("preview"))
-          data.strPreview = URIUtils::AddFileToFolder(url, fanartThumb->Attribute("preview"));
-      }
-      data.strResolution = XMLUtils::GetAttribute(fanartThumb, "dim");
-      ParseColors(XMLUtils::GetAttribute(fanartThumb, "colors"), data.strColors);
-      m_fanart.push_back(data);
       fanartThumb = fanartThumb->NextSiblingElement("thumb");
     }
     fanart = fanart->NextSiblingElement("fanart");


### PR DESCRIPTION
The GetText() function of TinyXML internally grabs the child element (if it exists) and returns it's value.  Thus, it can return NULL.  Further, it's not particularly obvious when reading the code that it's doing this.

This PR drops usage of it in favour of the plain `FirstChild()->Value()` or `FirstChild()->ValueStr()`.  This makes the obvious checks of `if (FirstChild())` or `if (!NoChildren())` more transparent.

There's a few potentially changed behaviours here that will need reasonable review, but I believe they're fixes.
1. CDAVCommon::GetStatusTag() had an odd for loop over FirstChild()->ToElement().  Potentially this would be a NULL ptr dereference.  I've changed it to use FirstChildElement() instead.
2. CDAVDirectory similarly iterated over TiXmlNode's while in all branches calling ToElement(), again without NULL checking in some cases.
3. CFanart there's a change of behaviour so that

```
<fanart url="foo">
  <thumb></thumb>
</fanart>
```

now does not return `url`.  This was never the intention.  The URL is always the value in the `<thumb>` tag, potentially with `url` used as a base URL.
4. Keymap reading of XML attributes/elements was previously case-insensitive, now case-sensitive (they're all lower-case anyway).
