### PR TITLE
[epg] fix implicit std::string constructor with NULL argument

### DIFF
--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -98,7 +98,30 @@ CEpgInfoTag::CEpgInfoTag(const EPG_TAG &data) :
   CPVRTimerInfoTagPtr emptyTimer;
   m_timer = emptyTimer;
 
-  Update(data);
+  SetStartFromUTC(data.startTime + g_advancedSettings.m_iPVRTimeCorrection);
+  SetEndFromUTC(data.endTime + g_advancedSettings.m_iPVRTimeCorrection);
+  SetGenre(data.iGenreType, data.iGenreSubType, data.strGenreDescription);
+  SetParentalRating(data.iParentalRating);
+  SetUniqueBroadcastID(data.iUniqueBroadcastId);
+  SetNotify(data.bNotify);
+  SetFirstAiredFromUTC(data.firstAired + g_advancedSettings.m_iPVRTimeCorrection);
+  SetEpisodeNum(data.iEpisodeNumber);
+  SetEpisodePart(data.iEpisodePartNumber);
+  SetStarRating(data.iStarRating);
+
+  // explicit NULL check, because there is no implicit NULL constructor for std::string
+  if (data.strTitle)
+    SetTitle(data.strTitle);
+  if (data.strPlotOutline)
+    SetPlotOutline(data.strPlotOutline);
+  if (data.strPlot)
+    SetPlot(data.strPlot);
+  if (data.strEpisodeName)
+    SetEpisodeName(data.strEpisodeName);
+  if (data.strIconPath)
+    SetIcon(data.strIconPath);
+  if (data.strRecordingId)
+    SetRecordingId(data.strRecordingId);
 }
 
 CEpgInfoTag::CEpgInfoTag(const CEpgInfoTag &tag) :
@@ -881,35 +904,6 @@ const PVR::CPVRChannelPtr CEpgInfoTag::ChannelTag(void) const
 {
   CSingleLock lock(m_critSection);
   return m_pvrChannel;
-}
-
-void CEpgInfoTag::Update(const EPG_TAG &tag)
-{
-  CSingleLock lock(m_critSection);
-  SetStartFromUTC(tag.startTime + g_advancedSettings.m_iPVRTimeCorrection);
-  SetEndFromUTC(tag.endTime + g_advancedSettings.m_iPVRTimeCorrection);
-  SetGenre(tag.iGenreType, tag.iGenreSubType, tag.strGenreDescription);
-  SetParentalRating(tag.iParentalRating);
-  SetUniqueBroadcastID(tag.iUniqueBroadcastId);
-  SetNotify(tag.bNotify);
-  SetFirstAiredFromUTC(tag.firstAired + g_advancedSettings.m_iPVRTimeCorrection);
-  SetEpisodeNum(tag.iEpisodeNumber);
-  SetEpisodePart(tag.iEpisodePartNumber);
-  SetStarRating(tag.iStarRating);
-
-  // explicit NULL check, because there is no implicit NULL constructor for std::string
-  if (tag.strTitle)
-    SetTitle(tag.strTitle);
-  if (tag.strPlotOutline)
-    SetPlotOutline(tag.strPlotOutline);
-  if (tag.strPlot)
-    SetPlot(tag.strPlot);
-  if (tag.strEpisodeName)
-    SetEpisodeName(tag.strEpisodeName);
-  if (tag.strIconPath)
-    SetIcon(tag.strIconPath);
-  if (tag.strRecordingId)
-    SetRecordingId(tag.strRecordingId);
 }
 
 bool CEpgInfoTag::Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId /* = true */)

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -888,9 +888,6 @@ void CEpgInfoTag::Update(const EPG_TAG &tag)
   CSingleLock lock(m_critSection);
   SetStartFromUTC(tag.startTime + g_advancedSettings.m_iPVRTimeCorrection);
   SetEndFromUTC(tag.endTime + g_advancedSettings.m_iPVRTimeCorrection);
-  SetTitle(tag.strTitle);
-  SetPlotOutline(tag.strPlotOutline);
-  SetPlot(tag.strPlot);
   SetGenre(tag.iGenreType, tag.iGenreSubType, tag.strGenreDescription);
   SetParentalRating(tag.iParentalRating);
   SetUniqueBroadcastID(tag.iUniqueBroadcastId);
@@ -898,10 +895,21 @@ void CEpgInfoTag::Update(const EPG_TAG &tag)
   SetFirstAiredFromUTC(tag.firstAired + g_advancedSettings.m_iPVRTimeCorrection);
   SetEpisodeNum(tag.iEpisodeNumber);
   SetEpisodePart(tag.iEpisodePartNumber);
-  SetEpisodeName(tag.strEpisodeName);
   SetStarRating(tag.iStarRating);
-  SetIcon(tag.strIconPath);
-  SetRecordingId(tag.strRecordingId);
+
+  // explicit NULL check, because there is no implicit NULL constructor for std::string
+  if (tag.strTitle)
+    SetTitle(tag.strTitle);
+  if (tag.strPlotOutline)
+    SetPlotOutline(tag.strPlotOutline);
+  if (tag.strPlot)
+    SetPlot(tag.strPlot);
+  if (tag.strEpisodeName)
+    SetEpisodeName(tag.strEpisodeName);
+  if (tag.strIconPath)
+    SetIcon(tag.strIconPath);
+  if (tag.strRecordingId)
+    SetRecordingId(tag.strRecordingId);
 }
 
 bool CEpgInfoTag::Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId /* = true */)

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -460,12 +460,6 @@ namespace EPG
     /*!
      * @brief Update the information in this tag with the info in the given tag.
      * @param tag The new info.
-     */
-    void Update(const EPG_TAG &tag);
-
-    /*!
-     * @brief Update the information in this tag with the info in the given tag.
-     * @param tag The new info.
      * @param bUpdateBroadcastId If set to false, the tag BroadcastId (locally unique) will not be chacked/updated
      * @return True if something changed, false otherwise.
      */


### PR DESCRIPTION
@opdenkamp and @Jalle19 should we do it that way, before we change the whole PVR api?
