### PR TITLE
[pvr] invalidate window if using fast channel switch

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -61,7 +61,7 @@ CGUIWindowPVRBase::~CGUIWindowPVRBase(void)
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), msg);
+  CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
   CApplicationMessenger::Get().SendGUIMessage(m);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -131,6 +131,14 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
   return CGUIMediaWindow::OnMessage(message);
 }
 
+void CGUIWindowPVRBase::SetInvalid()
+{
+  VECFILEITEMS items = m_vecItems->GetList();
+  for (VECFILEITEMS::iterator it = items.begin(); it != items.end(); ++it)
+    (*it)->SetInvalid();
+  CGUIMediaWindow::SetInvalid();
+}
+
 bool CGUIWindowPVRBase::OpenGroupSelectionDialog(void)
 {
   CGUIDialogSelect *dialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -59,6 +59,7 @@ namespace PVR
     virtual bool OpenGroupSelectionDialog(void);
     virtual void ResetObservers(void) {};
     virtual void Notify(const Observable &obs, const ObservableMessage msg);
+    virtual void SetInvalid();
 
   protected:
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);


### PR DESCRIPTION
This set the current PVR window to invalid if fast channel switch method is used, so the selected item etc. will shown correctly.
