### PR TITLE
FIX: Upstream Annex-B bitstream conversion fix for some BD mkv iso rips

### DIFF
--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -627,6 +627,7 @@ pps:
   m_sps_pps_context.sps_pps_data = out;
   m_sps_pps_context.size = total_size;
   m_sps_pps_context.first_idr = 1;
+  m_sps_pps_context.idr_sps_pps_seen = 0;
 
   return true;
 }
@@ -659,8 +660,12 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
     if (buf + nal_size > buf_end || nal_size < 0)
       goto fail;
 
-    // prepend only to the first type 5 NAL unit of an IDR picture
-    if (m_sps_pps_context.first_idr && unit_type == 5)
+    // Don't add sps/pps if the unit already contain them
+    if (m_sps_pps_context.first_idr && (unit_type == 7 || unit_type == 8))
+      m_sps_pps_context.idr_sps_pps_seen = 1;
+
+      // prepend only to the first access unit of an IDR picture, if no sps/pps already present
+    if (m_sps_pps_context.first_idr && unit_type == 5 && !m_sps_pps_context.idr_sps_pps_seen)
     {
       BitstreamAllocAndCopy(poutbuf, poutbuf_size,
         m_sps_pps_context.sps_pps_data, m_sps_pps_context.size, buf, nal_size);
@@ -670,7 +675,10 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
     {
       BitstreamAllocAndCopy(poutbuf, poutbuf_size, NULL, 0, buf, nal_size);
       if (!m_sps_pps_context.first_idr && unit_type == 1)
+      {
           m_sps_pps_context.first_idr = 1;
+          m_sps_pps_context.idr_sps_pps_seen = 0;
+      }
     }
 
     buf += nal_size;

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -185,6 +185,7 @@ protected:
   typedef struct omx_bitstream_ctx {
       uint8_t  length_size;
       uint8_t  first_idr;
+      uint8_t  idr_sps_pps_seen;
       uint8_t *sps_pps_data;
       uint32_t size;
   } omx_bitstream_ctx;


### PR DESCRIPTION
ref https://github.com/FFmpeg/FFmpeg/commit/289b149cecb381522cc9ccdf382825330169c655#diff-0e332ff3db7b093bfee7dda7ed82ce19

Fix a quite bothersome playback issue with a number of, e.g, makemkv, 1-to-1 BD rips

/cc @davilla @t-nelson @jmarshallnz 
