### PR TITLE
fix: Temperature unit alignment

### DIFF
--- a/addons/skin.confluence/720p/MyWeather.xml
+++ b/addons/skin.confluence/720p/MyWeather.xml
@@ -162,13 +162,13 @@
 					<control type="label">
 						<description>current temp Value Units</description>
 						<left>200</left>
-						<top>195</top>
+						<top>206</top>
 						<width>100</width>
 						<height>40</height>
 						<font>font16</font>
 						<align>left</align>
 						<aligny>top</aligny>
-						<label>$INFO[System.TemperatureUnits]</label>
+						<label>[B]$INFO[System.TemperatureUnits][/B]</label>
 						<textcolor>white</textcolor>
 						<shadowcolor>black</shadowcolor>
 					</control>


### PR DESCRIPTION
The Tempunit alignment is off by about 11 pixels this corrects it.

![beforeandafter](https://cloud.githubusercontent.com/assets/3521959/3601609/e270e464-0d02-11e4-83a9-18a4a4e9ef3b.PNG)

@ronie or whoever is looking after this now.
