### PR TITLE
fix: mapping for xbmc eject on device mceusb

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -61,6 +61,7 @@
 		<teletext>Teletext</teletext>
 
 		<!-- new kernel-based lirc button names -->
+		<eject>KEY_EJECTCD</eject>
 		<left>KEY_LEFT</left>
 		<right>KEY_RIGHT</right>
 		<up>KEY_UP</up>


### PR DESCRIPTION
Follow up to ksooo #4949 and #4979

Devices like http://h10025.www1.hp.com/ewfrf/wc/document?cc=uk&lc=en&docname=c00844678
