### PR TITLE
[pvr] fix: directory update infinity loop if GetDirectory() return false

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -103,6 +103,8 @@ void CGUIWindowPVRBase::OnInitWindow(void)
     return;
   }
 
+  m_vecItems->SetPath(GetDirectoryPath());
+
   CGUIMediaWindow::OnInitWindow();
 }
 
@@ -187,7 +189,7 @@ void CGUIWindowPVRBase::SetGroup(CPVRChannelGroupPtr group)
     // we need to register the window to receive changes from the new group
     m_group->RegisterObserver(this);
     g_PVRManager.SetPlayingGroup(m_group);
-    Refresh();
+    Update(GetDirectoryPath());
   }
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -65,6 +65,7 @@ namespace PVR
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);
     virtual ~CGUIWindowPVRBase(void);
 
+    virtual std::string GetDirectoryPath(void) { return ""; };
     virtual CPVRChannelGroupPtr GetGroup(void);
     virtual void SetGroup(CPVRChannelGroupPtr group);
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -108,6 +108,13 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
   }
 }
 
+std::string CGUIWindowPVRChannels::GetDirectoryPath(void)
+{
+  return StringUtils::Format("pvr://channels/%s/%s/",
+      m_bRadio ? "radio" : "tv",
+      m_bShowHiddenChannels ? ".hidden" : GetGroup()->GroupName().c_str());
+}
+
 bool CGUIWindowPVRChannels::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   if (itemNumber < 0 || itemNumber >= (int) m_vecItems->Size())
@@ -132,11 +139,7 @@ bool CGUIWindowPVRChannels::OnContextButton(int itemNumber, CONTEXT_BUTTON butto
 bool CGUIWindowPVRChannels::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   CSingleLock lock(m_critSection);
-
-  string strPath = StringUtils::Format("pvr://channels/%s/%s/",
-                                       m_bRadio ? "radio" : "tv",
-                                       m_bShowHiddenChannels ? ".hidden" : GetGroup()->GroupName().c_str());
-  bool bReturn = CGUIWindowPVRBase::Update(strPath);
+  bool bReturn = CGUIWindowPVRBase::Update(strDirectory);
 
   /* empty list for hidden channels */
   if (m_vecItems->Size() == 0 && m_bShowHiddenChannels)
@@ -144,7 +147,7 @@ bool CGUIWindowPVRChannels::Update(const std::string &strDirectory, bool updateF
       /* show the visible channels instead */
       m_bShowHiddenChannels = false;
       lock.Leave();
-      Refresh(true);
+      Update(GetDirectoryPath());
   }
 
   return bReturn;
@@ -450,7 +453,7 @@ bool CGUIWindowPVRChannels::OnContextButtonShowHidden(CFileItem *item, CONTEXT_B
   if (button == CONTEXT_BUTTON_SHOW_HIDDEN)
   {
     m_bShowHiddenChannels = !m_bShowHiddenChannels;
-    Refresh(true);
+    Update(GetDirectoryPath());
     bReturn = true;
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -39,6 +39,9 @@ namespace PVR
     void UnregisterObservers(void);
     bool OnAction(const CAction &action);
 
+  protected:
+    std::string GetDirectoryPath(void);
+
   private:
     bool OnContextButtonAdd(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonGroupManager(CFileItem *item, CONTEXT_BUTTON button);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -62,6 +62,13 @@ void CGUIWindowPVRRecordings::ResetObservers(void)
   g_infoManager.RegisterObserver(this);
 }
 
+std::string CGUIWindowPVRRecordings::GetDirectoryPath(void)
+{
+  if (StringUtils::StartsWith(m_vecItems->GetPath(), "pvr://recordings/"))
+    return m_vecItems->GetPath();
+  return "pvr://recordings/";
+}
+
 CStdString CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
 {
   CStdString resumeString;
@@ -163,14 +170,9 @@ bool CGUIWindowPVRRecordings::OnContextButton(int itemNumber, CONTEXT_BUTTON but
 
 bool CGUIWindowPVRRecordings::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
-  if (!StringUtils::StartsWith(strDirectory, "pvr://recordings/"))
-    m_vecItems->SetPath("pvr://recordings/");
-  else
-    m_vecItems->SetPath(strDirectory);
-  
   m_thumbLoader.StopThread();
 
-  bool bReturn = CGUIWindowPVRBase::Update(m_vecItems->GetPath());
+  bool bReturn = CGUIWindowPVRBase::Update(strDirectory);
 
   AfterUpdate(*m_unfilteredItems);
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -43,6 +43,7 @@ namespace PVR
     void ResetObservers(void);
 
   protected:
+    std::string GetDirectoryPath(void);
     virtual void AfterUpdate(CFileItemList& items);
 
   private:

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -53,6 +53,11 @@ void CGUIWindowPVRTimers::ResetObservers(void)
   g_PVRTimers->RegisterObserver(this);
 }
 
+std::string CGUIWindowPVRTimers::GetDirectoryPath(void)
+{
+  return StringUtils::Format("pvr://timers/%s/", m_bRadio ? "radio" : "tv");
+}
+
 void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
@@ -94,7 +99,7 @@ bool CGUIWindowPVRTimers::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
 bool CGUIWindowPVRTimers::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
-  return CGUIWindowPVRBase::Update(StringUtils::Format("pvr://timers/%s/", m_bRadio ? "radio" : "tv"));
+  return CGUIWindowPVRBase::Update(strDirectory);
 }
 
 bool CGUIWindowPVRTimers::OnMessage(CGUIMessage &message)

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.h
@@ -37,6 +37,9 @@ namespace PVR
     void UnregisterObservers(void);
     void ResetObservers(void);
 
+  protected:
+    std::string GetDirectoryPath(void);
+
   private:
     bool ActionDeleteTimer(CFileItem *item);
     bool ActionShowTimer(CFileItem *item);

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -142,7 +142,6 @@ protected:
   virtual void OnDeleteItem(int iItem);
   void OnRenameItem(int iItem);
 
-protected:
   bool WaitForNetwork() const;
 
   /*! \brief Translate the folder to start in from the given quick path


### PR DESCRIPTION
This fixes an infinity loop if `GetDirectory()` returns false and `GUIMediaWindow::Update()` wants to return to the previous directory. We override the directory path in each of the `Update()` method in all PVR related windows, so an update with an empty or different `strDirectory` param has no effect (except the recordings window).

I spotted this if I used the the pvr.demo addon which do not support timers and GetDirectory() return false.

@Jalle19 or @opdenkamp for review please.
