### PR TITLE
[lang] add comment/usage to key "Guide" to clarify its meaning

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -11725,6 +11725,9 @@ msgctxt "#22019"
 msgid "Recordings by title"
 msgstr ""
 
+#. Electronic program guide, used as label in the menu of the PVR section and the MythDirectory
+#: addons/skin/confluence
+#: xbmc/filesystem/MythDirectory.cpp
 msgctxt "#22020"
 msgid "Guide"
 msgstr ""


### PR DESCRIPTION
... because the german translation is "Handbuch" which is wrong in this context. 
There should be no difference between german and english.
