### PR TITLE
[addons] swap the section/setting control ID ranges

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -71,8 +71,8 @@ using XFILE::CDirectory;
 #define ID_BUTTON_DEFAULT               12
 #define CONTROL_HEADING_LABEL           20
 
-#define CONTROL_START_SETTING           100
-#define CONTROL_START_SECTION           200
+#define CONTROL_START_SECTION           100
+#define CONTROL_START_SETTING           200
 
 CGUIDialogAddonSettings::CGUIDialogAddonSettings()
    : CGUIDialogBoxBase(WINDOW_DIALOG_ADDON_SETTINGS, "DialogAddonSettings.xml")
@@ -609,6 +609,12 @@ void CGUIDialogAddonSettings::CreateSections()
     if (label.empty())
       label = g_localizeStrings.Get(128);
 
+    if (buttonID >= CONTROL_START_SETTING)
+    {
+      CLog::Log(LOGERROR, "%s - cannot have more than %d categories - simplify your addon!", __FUNCTION__, CONTROL_START_SETTING - CONTROL_START_SECTION);
+      break;
+    }
+
     // add the category button
     if (button && group)
     {
@@ -892,11 +898,6 @@ void CGUIDialogAddonSettings::CreateControls()
 
     setting = setting->NextSiblingElement("setting");
     controlId++;
-    if (controlId >= CONTROL_START_SECTION)
-    {
-      CLog::Log(LOGERROR, "%s - cannot have more than %d controls per category - simplify your addon!", __FUNCTION__, CONTROL_START_SECTION - CONTROL_START_SETTING);
-      break;
-    }
   }
   EnableControls();
 }


### PR DESCRIPTION
It's far more likely to have a limited number of categories than settings per category, particularly when some add-ons use a heap of boolean 'settings' for presenting basically static information.  e.g. see #15326

@ronie, @BigNoid, @Black09 do you know if any skins are relying on the settings or category buttons are in the current ranges (e.g. to do some fancy stuff with hidden controls or whatever?)
