### PR TITLE
[pvr] unify channel info settings + show channel info after channel switch from within channel osd

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8129,10 +8129,7 @@ msgctxt "#19178"
 msgid "Show channel information when switching channels"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#19179"
-msgid "Automatically hide channel information"
-msgstr ""
+#empty string with id 19179
 
 #: system/settings/settings.xml
 msgctxt "#19180"
@@ -8155,11 +8152,6 @@ msgid "Radio"
 msgstr ""
 
 #empty string with id 19184
-
-#: system/settings/settings.xml
-msgctxt "#19184"
-msgid "Channel information duration"
-msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#19185"
@@ -14117,20 +14109,14 @@ msgctxt "#36212"
 msgid "Display programming information when changing channels, such as the current TV show."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36213"
-msgid "Hide the programming information automatically after a few seconds, defined below."
-msgstr ""
+#empty string with id 36213
 
 #: system/settings/settings.xml
 msgctxt "#36214"
 msgid "Close the on screen display controls after switching channels."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36215"
-msgid "How long the programming information is displayed when the 'automatically hide' setting is turned on."
-msgstr ""
+#empty string with id 36215
 
 #: system/settings/settings.xml
 msgctxt "#36216"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1091,40 +1091,17 @@
     </category>
     <category id="pvrmenu" label="19181" help="36211">
       <group id="1">
-        <setting id="pvrmenu.infoswitch" type="boolean" label="19178" help="36212">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="pvrmenu.infotimeout" type="boolean" parent="pvrmenu.infoswitch" label="19179" help="36213">
+        <setting id="pvrmenu.displaychannelinfo" type="integer" label="19178" help="36212">
           <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-          <dependencies>
-            <dependency type="enable">
-              <condition setting="pvrmenu.infoswitch" operator="is">true</condition>
-            </dependency>
-          </dependencies>
-        </setting>
-        <setting id="pvrmenu.infotime" type="integer" parent="pvrmenu.infoswitch" label="19184" help="36215">
-          <level>2</level>
-          <default>5</default>
+          <default>0</default>
           <constraints>
-            <minimum>1</minimum>
+            <minimum label="351">0</minimum>
             <step>1</step>
-            <maximum>10</maximum>
+            <maximum>15</maximum>
           </constraints>
           <control type="spinner" format="string">
             <formatlabel>14045</formatlabel>
           </control>
-          <dependencies>
-            <dependency type="enable">
-              <and>
-                <condition setting="pvrmenu.infoswitch" operator="is">true</condition>
-                <condition setting="pvrmenu.infotimeout" operator="is">true</condition>
-              </and>
-            </dependency>
-          </dependencies>
         </setting>
         <setting id="pvrmenu.closechannelosdonswitch" type="boolean" label="19229" help="36214">
           <level>2</level>

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3388,10 +3388,9 @@ bool CDVDPlayer::ShowPVRChannelInfo(void)
 {
   bool bReturn(false);
 
-  if (CSettings::Get().GetBool("pvrmenu.infoswitch"))
+  if (CSettings::Get().GetInt("pvrmenu.displaychannelinfo") > 0)
   {
-    int iTimeout = CSettings::Get().GetBool("pvrmenu.infotimeout") ? CSettings::Get().GetInt("pvrmenu.infotime") : 0;
-    g_PVRManager.ShowPlayerInfo(iTimeout);
+    g_PVRManager.ShowPlayerInfo(CSettings::Get().GetInt("pvrmenu.displaychannelinfo"));
 
     bReturn = true;
   }

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -3821,10 +3821,9 @@ bool COMXPlayer::ShowPVRChannelInfo(void)
 {
   bool bReturn(false);
 
-  if (CSettings::Get().GetBool("pvrmenu.infoswitch"))
+  if (CSettings::Get().GetInt("pvrmenu.displaychannelinfo") > 0)
   {
-    int iTimeout = CSettings::Get().GetBool("pvrmenu.infotimeout") ? CSettings::Get().GetInt("pvrmenu.infotime") : 0;
-    g_PVRManager.ShowPlayerInfo(iTimeout);
+    g_PVRManager.ShowPlayerInfo(CSettings::Get().GetInt("pvrmenu.displaychannelinfo"));
 
     bReturn = true;
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -217,7 +217,11 @@ void CGUIDialogPVRChannelsOSD::Clear()
 void CGUIDialogPVRChannelsOSD::CloseOrSelect(unsigned int iItem)
 {
   if (CSettings::Get().GetBool("pvrmenu.closechannelosdonswitch"))
+  {
+    if (CSettings::Get().GetInt("pvrmenu.displaychannelinfo") > 0)
+      g_PVRManager.ShowPlayerInfo(CSettings::Get().GetInt("pvrmenu.displaychannelinfo"));
     Close();
+  }
   else
     m_viewControl.SetSelectedItem(iItem);
 }


### PR DESCRIPTION
This unifies the settings 'pvrmenu.infoswitch', 'pvrmenu.infotimeout', 'pvrmenu.infotime' to one new setting 'pvrmenu.displaychannelinfo' which holds the option 'Off' and '1 sec' to '15 sec'.

This also add the behavior for showing the channel info if you switch a channel from within the channel osd.

Both were discussed at http://forum.xbmc.org/showthread.php?tid=200000

@opdenkamp or @Jalle19 for a quick look.
