### PR TITLE
VOLUME_MINIMUM and VOLUME_MAXIMUM cleanup

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -442,7 +442,7 @@ CApplication::CApplication(void)
   m_bTestMode = false;
 
   m_muted = false;
-  m_volumeLevel = 1.0f;
+  m_volumeLevel = VOLUME_MAXIMUM;
 }
 
 CApplication::~CApplication(void)

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -22,9 +22,6 @@
 #include "cores/IPlayer.h"
 #include "Application.h"
 
-#define VOLUME_MINIMUM 0.0f        // -60dB
-#define VOLUME_MAXIMUM 1.0f        // 0dB
-
 CApplicationPlayer::CApplicationPlayer()
 {
   m_iPlayerOPSeq = 0;


### PR DESCRIPTION
Removed: defines for VOLUME_MINIMUM and VOLUME_MAXIMUM from ApplicationPlayer.cpp. Already defined in Application.h, which is included by ApplicationPlayer.cpp

Fixed: Initialize CApplication::m_volumeLevel with VOLUME_MAXIMUM, not with hardcoded numeric value.
