### PR TITLE
[contextmenu] don't show duplicate context menu items

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -60,11 +60,17 @@ using namespace std;
 
 void CContextButtons::Add(unsigned int button, const std::string &label)
 {
+  for (const_iterator i = begin(); i != end(); ++i)
+    if (i->first == button)
+      return; // already have this button
   push_back(pair<unsigned int, std::string>(button, label));
 }
 
 void CContextButtons::Add(unsigned int button, int label)
 {
+  for (const_iterator i = begin(); i != end(); ++i)
+    if (i->first == button)
+      return; // already have added this button
   push_back(pair<unsigned int, std::string>(button, g_localizeStrings.Get(label)));
 }
 


### PR DESCRIPTION
Fixes issues with duplicate items in context menus (e.g. duplicate "Check for updates" items for repositories).

An alternative would be to overwrite the entry if found (in case we're using the same button id for a different string).

@Montellese mind taking a look?
