### PR TITLE
don't include RenderManager.h unless HAS_VIDEO_PLAYBACK is defined

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -42,7 +42,11 @@
 #include "GUIInfoManager.h"
 #include "utils/Splash.h"
 #include "cores/IPlayer.h"
+
+#ifdef HAS_VIDEO_PLAYBACK
 #include "cores/VideoRenderers/RenderManager.h"
+#endif
+
 #include "cores/AudioEngine/AEFactory.h"
 #include "music/tags/MusicInfoTag.h"
 


### PR DESCRIPTION
@FernetMenta there are tons of other places that don't have this check too, what should we do about them? I'm not even sure how to compile with HAS_VIDEO_PLAYBACK disabled so I can't check for any breakage?
