### PR TITLE
[pvr] deprecate "All recordings" in favor of a "Group Items" feature

### DIFF
--- a/addons/skin.confluence/720p/IncludesPVR.xml
+++ b/addons/skin.confluence/720p/IncludesPVR.xml
@@ -163,6 +163,15 @@
 					<include>ButtonCommonValues</include>
 					<label>-</label>
 				</control>
+				<control type="radiobutton" id="5">
+					<description>Group recording items by folder structure</description>
+					<left>0</left>
+					<right>40</right>
+					<textwidth>235</textwidth>
+					<include>ButtonCommonValues</include>
+					<label>19270</label>
+					<visible>Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)</visible>
+				</control>
 				<control type="button" id="2">
 					<description>View As button</description>
 					<left>0</left>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8516,8 +8516,10 @@ msgctxt "#19269"
 msgid "Do not show 'connection lost' warnings"
 msgstr ""
 
+#. Label of the option to switch between a grouped recordings list and a non-grouped recordings list.
+#: skin.confluence
 msgctxt "#19270"
-msgid "* All recordings"
+msgid "Group Items"
 msgstr ""
 
 msgctxt "#19271"

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -39,17 +39,14 @@ namespace PVR
     bool                         m_bIsUpdating;
     PVR_RECORDINGMAP             m_recordings;
     unsigned int                 m_iLastId;
+    bool                         m_bGroupItems;
 
     virtual void UpdateFromClients(void);
     virtual std::string TrimSlashes(const std::string &strOrig) const;
     virtual const std::string GetDirectoryFromPath(const std::string &strPath, const std::string &strBase) const;
-    virtual bool IsDirectoryMember(const std::string &strDirectory, const std::string &strEntryDirectory, bool bDirectMember = true) const;
-    virtual void GetContents(const std::string &strDirectory, CFileItemList *results);
+    virtual bool IsDirectoryMember(const std::string &strDirectory, const std::string &strEntryDirectory) const;
     virtual void GetSubDirectories(const std::string &strBase, CFileItemList *results);
 
-    std::string AddAllRecordingsPathExtension(const std::string &strDirectory);
-    std::string RemoveAllRecordingsPathExtension(const std::string &strDirectory);
-    
     /**
      * @brief recursively deletes all recordings in the specified directory
      * @param item the directory
@@ -85,7 +82,6 @@ namespace PVR
     bool RenameRecording(CFileItem &item, std::string &strNewName);
     bool SetRecordingsPlayCount(const CFileItemPtr &item, int count);
 
-    bool IsAllRecordingsDirectory(const CFileItem &item) const;
     bool GetDirectory(const std::string& strPath, CFileItemList &items);
     CFileItemPtr GetByPath(const std::string &path);
     CPVRRecordingPtr GetById(int iClientId, const std::string &strRecordingId) const;
@@ -93,6 +89,7 @@ namespace PVR
     void GetAll(CFileItemList &items);
     CFileItemPtr GetById(unsigned int iId) const;
 
-    bool HasAllRecordingsPathExtension(const std::string &strDirectory) const;
+    void SetGroupItems(bool value) { m_bGroupItems = value; };
+    bool IsGroupItems() const { return m_bGroupItems; };
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -24,6 +24,8 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 
 #define CONTROL_BTNVIEWASICONS            2
+#define CONTROL_BTNSORTBY                 3
+#define CONTROL_BTNSORTASC                4
 #define CONTROL_BTNGROUPITEMS             5
 #define CONTROL_BTNCHANNELGROUPS          28
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -24,6 +24,7 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 
 #define CONTROL_BTNVIEWASICONS            2
+#define CONTROL_BTNGROUPITEMS             5
 #define CONTROL_BTNCHANNELGROUPS          28
 
 #define CONTROL_LABEL_HEADER1             29

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -34,6 +34,7 @@ namespace PVR
 
     static std::string GetResumeString(const CFileItem& item);
 
+    void OnWindowLoaded();
     bool OnMessage(CGUIMessage& message);
     bool OnAction(const CAction &action);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
@@ -44,7 +45,7 @@ namespace PVR
 
   protected:
     std::string GetDirectoryPath(void);
-    virtual void AfterUpdate(CFileItemList& items);
+    void OnPrepareFileItems(CFileItemList &items);
 
   private:
     bool OnContextButtonDelete(CFileItem *item, CONTEXT_BUTTON button);


### PR DESCRIPTION
Currently when the list of recordings contain one or more folders, a magic "\* All recordings" folder is created. This involves some not-quite-obvious path wizardry. This replaces that behavior on favor of a "Flatten list" radio button in the side blade (only visible in the Recordings window).

A couple of issues that are yet to be ironed out:
- I haven't yet checked whether the watched icon overlay works as expected, it was buggy before and I have a feeling it hasn't fixed itself
- `CONTROL_BTNFLATTENLIST` is defined as `500` since there seems to be no convention with regards to how the controls are numbered. If you want me to change this I will.
- The second and third commits are up for discussion. The last one actually fixes something but may be moved to a separate PR if that's what you want

@xhaggi @opdenkamp for review
