### PR TITLE
dvdplayer: fix incorrect display of audio channels

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3774,12 +3774,18 @@ void CDVDPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
     return;
 
   if (index == GetAudioStream())
+  {
     info.bitrate = m_dvdPlayerAudio.GetAudioBitrate();
+    info.channels = m_dvdPlayerAudio.GetAudioChannels();
+  }
   else if (m_pDemuxer)
   {
     CDemuxStreamAudio* stream = m_pDemuxer->GetStreamFromAudioId(index);
     if (stream)
+    {
       info.bitrate = stream->iBitRate;
+      info.channels = stream->iChannels;
+    }
   }
 
   SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, index);
@@ -3797,7 +3803,6 @@ void CDVDPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
     CDemuxStreamAudio* stream = static_cast<CDemuxStreamAudio*>(m_pDemuxer->GetStreamFromAudioId(index));
     if (stream)
     {
-      info.channels = stream->iChannels;
       std::string codecName;
       m_pDemuxer->GetStreamCodecName(stream->iId, codecName);
       info.audioCodecName = codecName;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -552,6 +552,8 @@ void CDVDPlayerAudio::Process()
 
       if(!m_dvdAudio.Create(audioframe, m_streaminfo.codec, m_setsynctype == SYNC_RESAMPLE))
         CLog::Log(LOGERROR, "%s - failed to create audio renderer", __FUNCTION__);
+
+      m_streaminfo.channels = audioframe.channel_count;
     }
 
     // Zero out the frame data if we are supposed to silence the audio
@@ -796,6 +798,11 @@ string CDVDPlayerAudio::GetPlayerInfo()
 int CDVDPlayerAudio::GetAudioBitrate()
 {
   return (int)m_audioStats.GetBitrate();
+}
+
+int CDVDPlayerAudio::GetAudioChannels()
+{
+  return m_streaminfo.channels;
 }
 
 bool CDVDPlayerAudio::IsPassthrough() const

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -136,6 +136,7 @@ public:
 
   std::string GetPlayerInfo();
   int GetAudioBitrate();
+  int GetAudioChannels();
 
   // holds stream information for current playing stream
   CDVDStreamInfo m_streaminfo;


### PR DESCRIPTION
ffmpeg demuxer does not update number of audio channels for codecs like AAC. In order to display correct number of channels we have to ask audio player.
