### PR TITLE
[android] Add 5.1 PCM playback support

### DIFF
--- a/xbmc/android/jni/AudioFormat.cpp
+++ b/xbmc/android/jni/AudioFormat.cpp
@@ -25,7 +25,21 @@
 using namespace jni;
 
 int CJNIAudioFormat::ENCODING_PCM_16BIT = 0x00000002;
-int CJNIAudioFormat::CHANNEL_OUT_STEREO = 0x0000000c;
+
+int CJNIAudioFormat::CHANNEL_OUT_STEREO  = 0x0000000c;
+int CJNIAudioFormat::CHANNEL_OUT_5POINT1 = 0x000000fc;
+
+int CJNIAudioFormat::CHANNEL_OUT_FRONT_LEFT            = 0x00000004;
+int CJNIAudioFormat::CHANNEL_OUT_FRONT_LEFT_OF_CENTER  = 0x00000100;
+int CJNIAudioFormat::CHANNEL_OUT_FRONT_CENTER          = 0x00000010;
+int CJNIAudioFormat::CHANNEL_OUT_FRONT_RIGHT_OF_CENTER = 0x00000200;
+int CJNIAudioFormat::CHANNEL_OUT_FRONT_RIGHT           = 0x00000008;
+int CJNIAudioFormat::CHANNEL_OUT_LOW_FREQUENCY         = 0x00000020;
+int CJNIAudioFormat::CHANNEL_OUT_BACK_LEFT             = 0x00000040;
+int CJNIAudioFormat::CHANNEL_OUT_BACK_CENTER           = 0x00000400;
+int CJNIAudioFormat::CHANNEL_OUT_BACK_RIGHT            = 0x00000080;
+
+int CJNIAudioFormat::CHANNEL_INVALID                   = 0x00000000;
 
 void CJNIAudioFormat::PopulateStaticFields()
 {
@@ -36,6 +50,17 @@ void CJNIAudioFormat::PopulateStaticFields()
     CJNIAudioFormat::ENCODING_PCM_16BIT = get_static_field<int>(c, "ENCODING_PCM_16BIT");
     if (sdk >= 5)
       CJNIAudioFormat::CHANNEL_OUT_STEREO = get_static_field<int>(c, "CHANNEL_OUT_STEREO");
+      CJNIAudioFormat::CHANNEL_OUT_5POINT1 = get_static_field<int>(c, "CHANNEL_OUT_5POINT1");
+      CJNIAudioFormat::CHANNEL_OUT_FRONT_LEFT = get_static_field<int>(c, "CHANNEL_OUT_FRONT_LEFT");
+      CJNIAudioFormat::CHANNEL_OUT_FRONT_LEFT_OF_CENTER = get_static_field<int>(c, "CHANNEL_OUT_FRONT_LEFT_OF_CENTER");
+      CJNIAudioFormat::CHANNEL_OUT_FRONT_CENTER = get_static_field<int>(c, "CHANNEL_OUT_FRONT_CENTER");
+      CJNIAudioFormat::CHANNEL_OUT_FRONT_RIGHT_OF_CENTER = get_static_field<int>(c, "CHANNEL_OUT_FRONT_RIGHT_OF_CENTER");
+      CJNIAudioFormat::CHANNEL_OUT_FRONT_RIGHT = get_static_field<int>(c, "CHANNEL_OUT_FRONT_RIGHT");
+      CJNIAudioFormat::CHANNEL_OUT_LOW_FREQUENCY = get_static_field<int>(c, "CHANNEL_OUT_LOW_FREQUENCY");
+      CJNIAudioFormat::CHANNEL_OUT_BACK_LEFT = get_static_field<int>(c, "CHANNEL_OUT_BACK_LEFT");
+      CJNIAudioFormat::CHANNEL_OUT_BACK_CENTER = get_static_field<int>(c, "CHANNEL_OUT_BACK_CENTER");
+      CJNIAudioFormat::CHANNEL_OUT_BACK_RIGHT = get_static_field<int>(c, "CHANNEL_OUT_BACK_RIGHT");
+      CJNIAudioFormat::CHANNEL_INVALID = get_static_field<int>(c, "CHANNEL_INVALID");
   }
 }
 

--- a/xbmc/android/jni/AudioFormat.h
+++ b/xbmc/android/jni/AudioFormat.h
@@ -28,7 +28,21 @@ class CJNIAudioFormat
     static void PopulateStaticFields();
 
     static int ENCODING_PCM_16BIT;
+
     static int CHANNEL_OUT_STEREO;
+    static int CHANNEL_OUT_5POINT1;
+
+    static int CHANNEL_OUT_FRONT_LEFT;
+    static int CHANNEL_OUT_FRONT_LEFT_OF_CENTER;
+    static int CHANNEL_OUT_FRONT_CENTER;
+    static int CHANNEL_OUT_FRONT_RIGHT_OF_CENTER;
+    static int CHANNEL_OUT_FRONT_RIGHT;
+    static int CHANNEL_OUT_LOW_FREQUENCY;
+    static int CHANNEL_OUT_BACK_LEFT;
+    static int CHANNEL_OUT_BACK_CENTER;
+    static int CHANNEL_OUT_BACK_RIGHT;
+
+    static int CHANNEL_INVALID;
 };
 
 };

--- a/xbmc/android/jni/AudioTrack.h
+++ b/xbmc/android/jni/AudioTrack.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include <stdexcept>
+
 #include "JNIBase.h"
 #include "ByteBuffer.h"
 
@@ -30,7 +32,7 @@ class CJNIAudioTrack : public CJNIBase
   jharray m_buffer;
 
   public:
-    CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode);
+    CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) throw(std::invalid_argument);
 
     void  play();
     void  stop();


### PR DESCRIPTION
Tested on ADT-1 Android TV device.

This commits add code for supporting arbitrary channel layouts with the
AudioTrack API. However, at least on ADT-1 any non-5.1 layout gets
downmixed to 2.0, so add a compile-time define for limiting playback to
2.0 and 5.1 (so that e.g. 4.0/5.0 content is played back as 5.1), at
least for now.

Do you think this way (code fully supports everything but disabled for now with LIMIT_TO_STEREO_AND_5POINT1) is OK or should I instead have the absolute minimum code for stereo/5.1 only, i.e. without the channel map stuff? I thought it might be nicer this way, as this allows easily testing for non-5.1 in the future by just toggling the define, instead of having to manually re-add the channel map stuff every time...
