### PR TITLE
[android] Initial Android TV support

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -24,6 +24,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -12,6 +12,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.GET_TASKS" />
+
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 	
     <application android:icon="@drawable/ic_launcher" android:debuggable="true" android:label="@string/app_name" android:hasCode="true">
         <activity


### PR DESCRIPTION
This simply means adding an entry to the TV launcher. The launcher seems to have natively wide non-square icons, but it seems to use our existing icon just fine, showing "XBMC" in the remaining space of the icon.

This adds no other integration. Tested on ADT-1 Android TV device.

Video playback seems to work fine, audio playbacks work with stereo
PCM and basic passthrough. PR #5082 adds 5.1 PCM support.

There are two significant issues that I saw:
- crash on exit, looks like double free at /system/lib/libmedia.so
  (android::spandroid::AudioTrackClientProxy::~sp()+10),
  maybe something to do with threading? or just an Android bug...
  Full log here: http://onse.fi/files/adt-xbmc-exit-crash.txt
  EDIT: and this seems to happen regardless of whether we make any audio related calls via JNI at all. I wasn't able to trace this down, but just e.g. adding g_application.Stop(0); to the beginning of CXBApplicationEx::Run() and dropping significant amounts of CApplication::Create/Initialize code still reproduced this.
- a warning flood on playback of many videos:
  W/art: Attempt to remove local handle scope entry from IRT, ignoring

Both of these look like either general issues introduced with Android L
and/or ART, not Android TV specific issues (but I did not confirm that).

Has anyone tried XBMC on ART and/or on the Android L preview? If so, did one/both of these issues exist there as well?
