### PR TITLE
[linux] Make checking for command existence more consistent and POSIX compatible

### DIFF
--- a/tools/Linux/xbmc.sh.in
+++ b/tools/Linux/xbmc.sh.in
@@ -39,6 +39,11 @@ do
     esac
 done
 
+command_exists()
+{
+  command -v $1 >/dev/null 2>&1
+}
+
 single_stacktrace()
 {
   # core filename is either "core.$PID" or "core"
@@ -68,7 +73,7 @@ print_crash_report()
   if [ -f /etc/os-release ]; then
 	  . /etc/os-release
 	  echo $NAME $VERSION >> $FILE
-  elif which lsb_release > /dev/null; then
+  elif command_exists lsb_release; then
     echo >> $FILE
     lsb_release -a 2> /dev/null | sed -e 's/^/    /' >> $FILE
   else
@@ -77,8 +82,8 @@ print_crash_report()
   echo "############## END SYSTEM INFO ##############" >> $FILE
   echo >> $FILE
   echo "############### STACK TRACE #################" >> $FILE
-  if which gdb >/dev/null 2>&1; then
-    if which systemd-coredumpctl &> /dev/null; then
+  if command_exists gdb; then
+    if command_exists systemd-coredumpctl; then
       systemd-coredumpctl dump -o core xbmc.bin &> /dev/null
     fi
     single_stacktrace "$PWD" 1
@@ -120,7 +125,7 @@ if [ $RET -ne 0 ]; then
   exit $RET
 fi
 
-if which gdb >/dev/null 2>&1; then
+if command_exists gdb; then
   # Output warning in case ulimit is unsupported by shell
   eval ulimit -c unlimited
   if [ ! $? = "0" ]; then


### PR DESCRIPTION
The 'which' commands does not return proper exit codes on Ubuntu (and apparently on lots of other distros as well, see [How to check if a program exists from a bash script?](http://stackoverflow.com/a/677212/246263))

So this pull request replaces `which` with `command -v`, which is POSIX compatible and has consistent exit codes on all distros/operating systems.

Additionally, sometimes `which <cmd> > /dev/null` was used and other times `which <cmd> >/dev/null 2>&1` was used. This patch adds a function to check whether a command is available and therefore consistently uses `command -v $1 >/dev/null 2>&1`

I checked this commit on Ubuntu 14.04: without the patch I get an error on this line:

```
systemd-coredumpctl dump -o core xbmc.bin &> /dev/null
```

as I do not have the `system-coredumpctl` command, and after the commit/patch the error is gone, as `system-coredumpcl` is not being called anymore.
As a result my xbmc crashes are properly dumped (again):

```
$ ./xbmc
Running DIL (3.22.0) Version
DtsDeviceOpen: Opening HW in mode 0
DtsDeviceOpen: Create File Failed
Fatal Python error: ceval: orphan tstate
Aborted (core dumped)
Crash report available at /home/xbmc/xbmc_crashlog-20140723_225513.log
```

Soon I will send my initial/actual debug report ;)
