### PR TITLE
[rbp] Add config.txt settings to log file

### DIFF
--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -79,11 +79,17 @@ bool CRBP::Initialize()
 
 void CRBP::LogFirmwareVerison()
 {
-  char  response[160];
+  char  response[1024];
   m_DllBcmHost->vc_gencmd(response, sizeof response, "version");
   response[sizeof(response) - 1] = '\0';
   CLog::Log(LOGNOTICE, "Raspberry PI firmware version: %s", response);
   CLog::Log(LOGNOTICE, "ARM mem: %dMB GPU mem: %dMB MPG2:%d WVC1:%d", m_arm_mem, m_gpu_mem, m_codec_mpg2_enabled, m_codec_wvc1_enabled);
+  m_DllBcmHost->vc_gencmd(response, sizeof response, "get_config int");
+  response[sizeof(response) - 1] = '\0';
+  CLog::Log(LOGNOTICE, "Config:\n%s", response);
+  m_DllBcmHost->vc_gencmd(response, sizeof response, "get_config str");
+  response[sizeof(response) - 1] = '\0';
+  CLog::Log(LOGNOTICE, "Config:\n%s", response);
 }
 
 void CRBP::GetDisplaySize(int &width, int &height)


### PR DESCRIPTION
On Pi there are a number of config.txt settings, such as overclock settings, forcing of HDMI modes, overriding the EDID, whether codecs are licensed and various test options that have an effect on running xbmc.

It helps when analysing a debug log file if I know about these settings, so include them in the log.
