### PR TITLE
[rbp] Reduce GPU memory use when limited

### DIFF
--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -72,6 +72,9 @@ bool CRBP::Initialize()
   if (vc_gencmd(response, sizeof response, "codec_enabled WVC1") == 0)
     m_codec_wvc1_enabled = strcmp("WVC1=enabled", response) == 0;
 
+  if (m_gpu_mem < 128)
+    setenv("V3D_DOUBLE_BUFFER", "1", 1);
+
   g_OMXImage.Initialize();
   m_omx_image_init = true;
   return true;


### PR DESCRIPTION
Switching from default triple buffered output to double buffered saves 8M with 1080p GUI.
This may slightly reduce framerate, but is likely to be minimal.

Assume if gpu_mem is set below the default 128M that this memory reduction is wanted
