### PR TITLE
[rbp] Make gui limit default to 720 when memory is limited

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -15559,7 +15559,7 @@ msgstr ""
 
 #: system/settings/rbp.xml
 msgctxt "#36548"
-msgid "Limits resolution of GUI to save memory. Does not affect video playback. Use 1080 for unlimited. Requires restart."
+msgid "Limits resolution of GUI to save memory. Does not affect video playback. Requires restart."
 msgstr ""
 
 #empty strings from id 36549 to 36599
@@ -15789,4 +15789,29 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#37025"
 msgid "Configure audio encoder settings such as quality and compression level"
+msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#37026"
+msgid "Auto"
+msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#37027"
+msgid "540"
+msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#37028"
+msgid "720"
+msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#37029"
+msgid "900"
+msgstr ""
+
+#: system/settings/rbp.xml
+msgctxt "#37030"
+msgid "Unlimited"
 msgstr ""

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -39,12 +39,17 @@
         </setting>
         <setting id="videoscreen.limitgui" type="integer" label="37021" help="36548">
           <level>2</level>
-          <default>1080</default>
+          <default>0</default>
           <constraints>
-            <minimum>540</minimum>
-            <step>16</step>
-            <maximum>1080</maximum>
+            <options>
+              <option label="37026">0</option>    <!-- auto -->
+              <option label="37027">540</option>  <!-- 540 -->
+              <option label="37028">720</option>  <!-- 720 -->
+              <option label="37029">900</option>  <!-- 900 -->
+              <option label="37030">1080</option> <!-- unlimited -->
+            </options>
           </constraints>
+          <control type="spinner" format="string" />
           <control type="edit" format="integer" />
         </setting>
       </group>

--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -21,6 +21,7 @@
 #include "RBP.h"
 #if defined(TARGET_RASPBERRY_PI)
 
+#include "settings/Settings.h"
 #include "utils/log.h"
 
 #include "cores/omxplayer/OMXImage.h"
@@ -74,6 +75,10 @@ bool CRBP::Initialize()
 
   if (m_gpu_mem < 128)
     setenv("V3D_DOUBLE_BUFFER", "1", 1);
+
+  m_gui_resolution_limit = CSettings::Get().GetInt("videoscreen.limitgui");
+  if (!m_gui_resolution_limit)
+    m_gui_resolution_limit = m_gpu_mem < 128 ? 720:1080;
 
   g_OMXImage.Initialize();
   m_omx_image_init = true;

--- a/xbmc/linux/RBP.h
+++ b/xbmc/linux/RBP.h
@@ -53,6 +53,7 @@ public:
   bool GetCodecMpg2() { return m_codec_mpg2_enabled; }
   bool GetCodecWvc1() { return m_codec_wvc1_enabled; }
   void GetDisplaySize(int &width, int &height);
+  int GetGUIResolutionLimit() { return m_gui_resolution_limit; }
   // stride can be null for packed output
   unsigned char *CaptureDisplay(int width, int height, int *stride, bool swap_red_blue, bool video_only = true);
   DllOMX *GetDllOMX() { return m_OMX ? m_OMX->GetDll() : NULL; }
@@ -64,6 +65,7 @@ private:
   bool       m_omx_image_init;
   int        m_arm_mem;
   int        m_gpu_mem;
+  int        m_gui_resolution_limit;
   bool       m_codec_mpg2_enabled;
   bool       m_codec_wvc1_enabled;
   COMXCore   *m_OMX;

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 #include "guilib/gui3d.h"
 #include "linux/DllBCM.h"
+#include "linux/RBP.h"
 #include "utils/StringUtils.h"
 #include "settings/Settings.h"
 
@@ -370,7 +371,7 @@ static float get_display_aspect_ratio(SDTV_ASPECT_T aspect)
 
 static bool ClampToGUIDisplayLimits(int &width, int &height)
 {
-  float max_height = (float)CSettings::Get().GetInt("videoscreen.limitgui");
+  float max_height = (float)g_RBP.GetGUIResolutionLimit();
   float default_ar = 16.0f/9.0f;
   if (max_height < 540.0f || max_height > 1080.0f)
     max_height = 1080.0f;


### PR DESCRIPTION
On a 256M Pi, it's safest to default to 720p gui as memory is quite limited.
