### PR TITLE
[pvr] recover lost functionality for menu hooks and find similar programs

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -133,6 +133,37 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
   return CGUIMediaWindow::OnMessage(message);
 }
 
+bool CGUIWindowPVRBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
+{
+  bool bReturn = false;
+
+  switch(button)
+  {
+    case CONTEXT_BUTTON_MENU_HOOKS:
+      if (itemNumber >= 0 && itemNumber < m_vecItems->Size())
+      {
+        CFileItemPtr item = m_vecItems->Get(itemNumber);
+
+        if (item->IsEPG() && item->GetEPGInfoTag()->HasPVRChannel())
+          g_PVRClients->ProcessMenuHooks(item->GetEPGInfoTag()->ChannelTag()->ClientID(), PVR_MENUHOOK_EPG, item.get());
+        else if (item->IsPVRChannel())
+          g_PVRClients->ProcessMenuHooks(item->GetPVRChannelInfoTag()->ClientID(), PVR_MENUHOOK_CHANNEL, item.get());
+        else if (item->IsPVRRecording())
+          g_PVRClients->ProcessMenuHooks(item->GetPVRRecordingInfoTag()->m_iClientId, PVR_MENUHOOK_RECORDING, item.get());
+        else if (item->IsPVRTimer())
+          g_PVRClients->ProcessMenuHooks(item->GetPVRTimerInfoTag()->m_iClientId, PVR_MENUHOOK_TIMER, item.get());
+
+        bReturn = true;
+      }
+      break;
+
+    default:
+      bReturn = false;
+  }
+
+  return bReturn || CGUIMediaWindow::OnContextButton(itemNumber, button);
+}
+
 void CGUIWindowPVRBase::SetInvalid()
 {
   VECFILEITEMS items = m_vecItems->GetList();

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -156,7 +156,18 @@ bool CGUIWindowPVRBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         bReturn = true;
       }
       break;
-
+    case CONTEXT_BUTTON_FIND:
+    {
+      int windowSearchId = m_bRadio ? WINDOW_RADIO_SEARCH : WINDOW_TV_SEARCH;
+      CGUIWindowPVRBase *windowSearch = (CGUIWindowPVRBase*) g_windowManager.GetWindow(windowSearchId);
+      if (windowSearch && itemNumber >= 0 && itemNumber < m_vecItems->Size())
+      {
+        CFileItemPtr item = m_vecItems->Get(itemNumber);
+        g_windowManager.ActivateWindow(windowSearchId);
+        bReturn = windowSearch->OnContextButton(*item.get(), button);
+      }
+      break;
+    }
     default:
       bReturn = false;
   }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -52,6 +52,7 @@ namespace PVR
   public:
     virtual void OnInitWindow(void);
     virtual bool OnMessage(CGUIMessage& message);
+    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     virtual void UpdateButtons(void);
     virtual bool OnAction(const CAction &action);

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -66,6 +66,7 @@ namespace PVR
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);
     virtual ~CGUIWindowPVRBase(void);
 
+    virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) { return false; };
     virtual std::string GetDirectoryPath(void) { return ""; };
     virtual CPVRChannelGroupPtr GetGroup(void);
     virtual void SetGroup(CPVRChannelGroupPtr group);

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -89,6 +89,39 @@ bool CGUIWindowPVRSearch::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CGUIWindowPVRBase::OnContextButton(itemNumber, button);
 }
 
+bool CGUIWindowPVRSearch::OnContextButton(const CFileItem &item, CONTEXT_BUTTON button)
+{
+  bool bReturn = false;
+
+  switch(button)
+  {
+    case CONTEXT_BUTTON_FIND:
+    {
+      m_searchfilter.Reset();
+      CEpgInfoTag tag;
+
+      // construct the search term
+      if (item.IsEPG())
+        m_searchfilter.m_strSearchTerm = "\"" + item.GetEPGInfoTag()->Title() + "\"";
+      else if (item.IsPVRChannel() && item.GetPVRChannelInfoTag()->GetEPGNow(tag))
+        m_searchfilter.m_strSearchTerm = "\"" + tag.Title() + "\"";
+      else if (item.IsPVRRecording())
+        m_searchfilter.m_strSearchTerm = "\"" + item.GetPVRRecordingInfoTag()->m_strTitle + "\"";
+      else if (item.IsPVRTimer())
+        m_searchfilter.m_strSearchTerm = "\"" + item.GetPVRTimerInfoTag()->m_strTitle + "\"";
+
+      m_bSearchConfirmed = true;
+      Refresh(true);
+      bReturn = true;
+      break;
+    }
+    default:
+      bReturn = false;
+  }
+
+  return bReturn;
+}
+
 bool CGUIWindowPVRSearch::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   CGUIWindowPVRBase::Update(strDirectory);

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -36,6 +36,9 @@ namespace PVR
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     bool Update(const std::string &strDirectory, bool updateFilterPath = true);
 
+  protected:
+    virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button);
+
   private:
     void Search(void);
 


### PR DESCRIPTION
As the title said this adds the lost functionality (after the window rewrite) for the context button actions CONTEXT_BUTTON_MENU_HOOKS and CONTEXT_BUTTON_FIND.

The second commit is RFC .. @Jalle19 or @opdenkamp mind taking a look.
