### PR TITLE
RFC JSONRPC ZeroMQServer

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -461,6 +461,12 @@ AC_ARG_ENABLE([webserver],
   [use_webserver=$enableval],
   [use_webserver=yes])
 
+AC_ARG_ENABLE([zeromq],
+  [AS_HELP_STRING([--disable-zeromq],
+  [disable zeromq])],
+  [use_zeromq=$enableval],
+  [use_zeromq=yes])
+
 AC_ARG_ENABLE([optical-drive],
   [AS_HELP_STRING([--disable-optical-drive],
   [disable optical drive])],
@@ -1220,6 +1226,11 @@ XB_FIND_SONAME([MPEG2],       [mpeg2])
 # WebServer
 if test "$use_webserver" = "yes"; then
   AC_CHECK_LIB([microhttpd],  [main],, AC_MSG_ERROR($missing_library))
+fi
+
+# ZeroMQ
+if test "$use_zeromq" = "yes"; then
+  AC_CHECK_LIB([zmq],  [main],, AC_MSG_ERROR($missing_library))
 fi
 
 # Optical
@@ -2340,6 +2351,14 @@ else
   USE_WEB_SERVER=0
 fi
 
+if test "$use_zeromq" = "yes"; then
+  final_message="$final_message\n  ZeroMQ:\tYes"
+  USE_ZMQ_SERVER=1
+else
+  final_message="$final_message\n  ZeroMQ:\tNo"
+  USE_ZMQ_SERVER=0
+fi
+
 if test "$use_libssh" != "no"; then
   final_message="$final_message\n  libssh support:\tYes"
 else
@@ -2622,6 +2641,7 @@ AC_SUBST(USE_LIBCEC)
 AC_SUBST(USE_MYSQL)
 AC_SUBST(USE_WAYLAND)
 AC_SUBST(USE_WEB_SERVER)
+AC_SUBST(USE_ZMQ_SERVER)
 AC_SUBST(USE_UPNP)
 AC_SUBST(USE_XKBCOMMON)
 AC_SUBST(USE_OMXLIB)

--- a/xbmc/network/Makefile.in
+++ b/xbmc/network/Makefile.in
@@ -14,6 +14,7 @@ SRCS  = cddb.cpp \
         WebServer.cpp \
         ZeroconfBrowser.cpp \
         Zeroconf.cpp \
+        ZeroMQServer.cpp
 
 ifeq (@USE_AIRPLAY@, 1)
 SRCS += AirPlayServer.cpp

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -46,6 +46,7 @@
 #ifdef HAS_JSONRPC
 #include "interfaces/json-rpc/JSONRPC.h"
 #include "network/TCPServer.h"
+#include "network/ZeroMQServer.h"
 #endif
 
 #ifdef HAS_ZEROCONF
@@ -620,6 +621,9 @@ bool CNetworkServices::StartJSONRPCServer()
   if (!CTCPServer::StartServer(g_advancedSettings.m_jsonTcpPort, CSettings::Get().GetBool("services.esallinterfaces")))
     return false;
 
+  if (!CZeroMQServer::StartServer(5555))
+    return false;
+
 #ifdef HAS_ZEROCONF
   std::vector<std::pair<std::string, std::string> > txt;
   CZeroconf::GetInstance()->PublishService("servers.jsonrpc-tpc", "_xbmc-jsonrpc._tcp", g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME), g_advancedSettings.m_jsonTcpPort, txt);
@@ -645,6 +649,7 @@ bool CNetworkServices::StopJSONRPCServer(bool bWait)
     return true;
 
   CTCPServer::StopServer(bWait);
+  CZeroMQServer::StopServer(bWait);
 
 #ifdef HAS_ZEROCONF
   CZeroconf::GetInstance()->RemoveService("servers.jsonrpc-tcp");

--- a/xbmc/network/ZeroMQServer.cpp
+++ b/xbmc/network/ZeroMQServer.cpp
@@ -1,0 +1,174 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ZeroMQServer.h"
+
+#include "settings/AdvancedSettings.h"
+#include "interfaces/json-rpc/JSONRPC.h"
+#include "interfaces/AnnouncementManager.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+#include "Network.h"
+
+using namespace JSONRPC;
+using namespace ANNOUNCEMENT;
+
+CZeroMQServer *CZeroMQServer::ServerInstance = NULL;
+
+bool CZeroMQServer::StartServer(int port)
+{
+  StopServer(true);
+
+  ServerInstance = new CZeroMQServer(port);
+  if (ServerInstance->Initialize())
+  {
+    ServerInstance->Create();
+    return true;
+  }
+  else
+    return false;
+}
+
+void CZeroMQServer::StopServer(bool bWait)
+{
+  if (ServerInstance)
+  {
+    ServerInstance->StopThread(bWait);
+    if (bWait)
+    {
+      delete ServerInstance;
+      ServerInstance = NULL;
+    }
+  }
+}
+
+bool CZeroMQServer::IsRunning()
+{
+  if (ServerInstance == NULL)
+    return false;
+
+  return ((CThread*)ServerInstance)->IsRunning();
+}
+
+CZeroMQServer::CZeroMQServer(int port) : CThread("ZeroMQServer"), m_port(port), m_context(1), m_repSocket(m_context, ZMQ_REP), m_pubSocket(m_context, ZMQ_PUB)
+{
+}
+
+void CZeroMQServer::Process()
+{
+  m_bStop = false;
+
+  while (!m_bStop)
+  {
+    zmq::message_t request_packet;
+
+    m_repSocket.recv (&request_packet);
+    std::string request = std::string((const char *)request_packet.data(), request_packet.size());
+
+    CZeroMQClient client;
+    std::string response = CJSONRPC::MethodCall(request, this, &client);
+
+    zmq::message_t response_packet (response.size());
+    memcpy ((void *) response_packet.data (), response.c_str(), response.size());
+    m_repSocket.send (response_packet);
+  }
+
+  Deinitialize();
+}
+
+bool CZeroMQServer::PrepareDownload(const char *path, CVariant &details, std::string &protocol)
+{
+  return false;
+}
+
+bool CZeroMQServer::Download(const char *path, CVariant &result)
+{
+  return false;
+}
+
+int CZeroMQServer::GetCapabilities()
+{
+  return Response | Announcing;
+}
+
+void CZeroMQServer::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+{
+  std::string out = IJSONRPCAnnouncer::AnnouncementToJSONRPC(flag, sender, message, data, g_advancedSettings.m_jsonOutputCompact);
+
+  zmq::message_t notification_packet (out.size());
+  memcpy ((void *) notification_packet.data (), out.c_str(), out.size());
+  m_pubSocket.send (notification_packet);
+}
+
+bool CZeroMQServer::Initialize()
+{
+  Deinitialize();
+
+  m_repSocket.bind("tcp://*:5555");
+  m_pubSocket.bind("tcp://*:5556");
+
+  CAnnouncementManager::Get().AddAnnouncer(this);
+  CLog::Log(LOGINFO, "ZeroMQ JSONRPC Server: Successfully initialized");
+  return true;
+}
+
+void CZeroMQServer::Deinitialize()
+{
+  CAnnouncementManager::Get().RemoveAnnouncer(this);
+}
+
+CZeroMQServer::CZeroMQClient::CZeroMQClient()
+{
+  m_new = true;
+  m_announcementflags = ANNOUNCE_ALL;
+}
+
+CZeroMQServer::CZeroMQClient::CZeroMQClient(const CZeroMQClient& client)
+{
+  Copy(client);
+}
+
+CZeroMQServer::CZeroMQClient& CZeroMQServer::CZeroMQClient::operator=(const CZeroMQClient& client)
+{
+  Copy(client);
+  return *this;
+}
+
+int CZeroMQServer::CZeroMQClient::GetPermissionFlags()
+{
+  return OPERATION_PERMISSION_ALL;
+}
+
+int CZeroMQServer::CZeroMQClient::GetAnnouncementFlags()
+{
+  return m_announcementflags;
+}
+
+bool CZeroMQServer::CZeroMQClient::SetAnnouncementFlags(int flags)
+{
+  m_announcementflags = flags;
+  return true;
+}
+
+void CZeroMQServer::CZeroMQClient::Copy(const CZeroMQClient& client)
+{
+  m_new               = client.m_new;
+  m_announcementflags = client.m_announcementflags;
+}

--- a/xbmc/network/ZeroMQServer.h
+++ b/xbmc/network/ZeroMQServer.h
@@ -1,0 +1,86 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <vector>
+#include <zmq.hpp>
+
+#include "interfaces/json-rpc/IClient.h"
+#include "interfaces/json-rpc/IJSONRPCAnnouncer.h"
+#include "interfaces/json-rpc/ITransportLayer.h"
+#include "threads/CriticalSection.h"
+#include "threads/Thread.h"
+#include "websocket/WebSocket.h"
+
+namespace JSONRPC
+{
+  class CZeroMQServer : public ITransportLayer, public JSONRPC::IJSONRPCAnnouncer, public CThread
+  {
+  public:
+    static bool StartServer(int port);
+    static void StopServer(bool bWait);
+    static bool IsRunning();
+
+    virtual bool PrepareDownload(const char *path, CVariant &details, std::string &protocol);
+    virtual bool Download(const char *path, CVariant &result);
+    virtual int GetCapabilities();
+
+    virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
+  protected:
+    void Process();
+  private:
+    CZeroMQServer(int port);
+
+    bool Initialize();
+    void Deinitialize();
+
+    class CZeroMQClient : public IClient
+    {
+    public:
+      CZeroMQClient();
+      //Copying a CCriticalSection is not allowed, so copy everything but that
+      //when adding a member variable, make sure to copy it in CTCPClient::Copy
+      CZeroMQClient(const CZeroMQClient& client);
+      CZeroMQClient& operator=(const CZeroMQClient& client);
+      virtual ~CZeroMQClient() { };
+
+      virtual int  GetPermissionFlags();
+      virtual int  GetAnnouncementFlags();
+      virtual bool SetAnnouncementFlags(int flags);
+
+      virtual bool IsNew() const { return m_new; }
+      virtual bool Closing() const { return false; }
+
+    protected:
+      void Copy(const CZeroMQClient& client);
+    private:
+      bool m_new;
+      int m_announcementflags;
+    };
+
+    unsigned int m_port;
+    zmq::context_t m_context;
+    zmq::socket_t m_repSocket;
+    zmq::socket_t m_pubSocket;
+
+    std::vector<CZeroMQClient*> m_connections;
+    static CZeroMQServer *ServerInstance;
+  };
+}


### PR DESCRIPTION
I'm not sure if this is something we would want? Basically its an alternative to the web and  tcp server which is much easier to use as it both provides framing and is bidirectional.

Some benefits with ZeroMQ
- ZeroMQ supports many transports, both TCP, IPC and in memory. So it could be useful to further extend this for out of process stuff. So a big upside is that we could have IPC enabled by default
- ZeroMQ abstract uses a composite pattern, so its usually transparent if your getting data from many clients or if your sending it to many. So this could be a great start to create a distributed xbmc were we talk lots between different xbmc machines (obviously this is possible with tcp also, its just easier with ZMQ).
- ZeroMQ has libraries for many languages and could provide a simple base for third party were they get the benefits of the TCP server but with a very simple API to send and receive the data, essentially all they need to do is parse and handle the jsons
