### PR TITLE
ffmpeg: adapt depreciated attribute max_analyze_duration

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -52,6 +52,9 @@
 #include "URL.h"
 #include "cores/FFmpeg.h"
 
+extern "C" {
+#include "libavutil/opt.h"
+}
 
 struct StereoModeConversionMap
 {
@@ -400,7 +403,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
   
   // analyse very short to speed up mjpeg playback start
   if (iformat && (strcmp(iformat->name, "mjpeg") == 0) && m_ioContext->seekable == 0)
-    m_pFormatContext->max_analyze_duration = 500000;
+    av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
 
   // we need to know if this is matroska or avi later
   m_bMatroska = strncmp(m_pFormatContext->iformat->name, "matroska", 8) == 0;	// for "matroska.webm"
@@ -410,8 +413,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
   {
     /* too speed up dvd switches, only analyse very short */
     if(m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
-      m_pFormatContext->max_analyze_duration = 500000;
-
+      av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
 
     CLog::Log(LOGDEBUG, "%s - avformat_find_stream_info starting", __FUNCTION__);
     int iErr = avformat_find_stream_info(m_pFormatContext, NULL);


### PR DESCRIPTION
the correct way to set max analyze duration is via AVOptions. with ffmpeg 2.3 direct access of this parameter is depreciated.
