### PR TITLE
ffmpeg: fix deadlock caused by calling avctx->thread_count after codec_o...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -396,7 +396,6 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
   m_hwaccel->display     = m_display->get();
 
   avctx->hwaccel_context = m_hwaccel;
-  avctx->thread_count    = 1;
   avctx->get_buffer2     = GetBufferS;
   avctx->draw_horiz_band = NULL;
   avctx->slice_flags     = SLICE_FLAG_CODED_ORDER|SLICE_FLAG_ALLOW_FIELD;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -582,7 +582,6 @@ bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat fmt, unsigned 
       avctx->get_buffer2     = CDecoder::FFGetBuffer;
       avctx->slice_flags=SLICE_FLAG_CODED_ORDER|SLICE_FLAG_ALLOW_FIELD;
       avctx->hwaccel_context = &m_hwContext;
-      avctx->thread_count    = 1;
 
       g_Windowing.Register(this);
       return true;


### PR DESCRIPTION
setting thread_count after avcodec_open is not only useless, it does even harm. On close ffmpeg loops over thread_count and does a join for each thread spawned. setting thread_count to 1 after threads have been created will skip the join. some other weird things may also happen.
