### PR TITLE
[win32] automatic versioning of XBMC_PC.rc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -751,6 +751,7 @@ lib/cpluff/stamp-h1
 /xbmc/visualizations/fishBMC/Makefile
 
 #/xbmc/win32/
+/xbmc/win32/XBMC_PC.rc
 # no longer used
 /xbmc/win32/git_rev.h
 

--- a/tools/windows/CompileInfo.bat
+++ b/tools/windows/CompileInfo.bat
@@ -1,16 +1,19 @@
 @ECHO OFF
 
+REM setup all paths
 SET cur_dir=%CD%
-
 SET base_dir=%cur_dir%\..\..
 SET builddeps_dir=%cur_dir%\..\..\project\BuildDependencies
 SET bin_dir=%builddeps_dir%\bin
 SET msys_bin_dir=%builddeps_dir%\msys\bin
 
+REM read the version values from version.txt
 for /f %%i in ('%msys_bin_dir%\awk.exe "/VERSION_MAJOR/ {print $2}" %base_dir%\version.txt') do set major=%%i
 for /f %%i in ('%msys_bin_dir%\awk.exe "/VERSION_MINOR/ {print $2}" %base_dir%\version.txt') do set minor=%%i
 for /f %%i in ('%msys_bin_dir%\awk.exe "/VERSION_TAG/ {print $2}" %base_dir%\version.txt') do set tag=%%i
 for /f %%i in ('%msys_bin_dir%\awk.exe "/ADDON_API/ {print $2}" %base_dir%\version.txt') do set addon_api=%%i
+
+REM create the files with the proper version information
 "%msys_bin_dir%\sed.exe" -e s/@APP_VERSION_MAJOR@/%major%/g -e s/@APP_VERSION_MINOR@/%minor%/g -e s/@APP_VERSION_TAG@/%tag%/g "%base_dir%\xbmc\CompileInfo.cpp.in" > "%base_dir%\xbmc\CompileInfo.cpp"
 "%msys_bin_dir%\sed.exe" s/@APP_ADDON_API@/%addon_api%/g "%base_dir%\addons\xbmc.addon\addon.xml.in" > "%base_dir%\addons\xbmc.addon\addon.xml"
 

--- a/tools/windows/CompileInfo.bat
+++ b/tools/windows/CompileInfo.bat
@@ -8,10 +8,10 @@ SET bin_dir=%builddeps_dir%\bin
 SET msys_bin_dir=%builddeps_dir%\msys\bin
 
 REM read the version values from version.txt
-for /f %%i in ('%msys_bin_dir%\awk.exe "/VERSION_MAJOR/ {print $2}" %base_dir%\version.txt') do set major=%%i
-for /f %%i in ('%msys_bin_dir%\awk.exe "/VERSION_MINOR/ {print $2}" %base_dir%\version.txt') do set minor=%%i
-for /f %%i in ('%msys_bin_dir%\awk.exe "/VERSION_TAG/ {print $2}" %base_dir%\version.txt') do set tag=%%i
-for /f %%i in ('%msys_bin_dir%\awk.exe "/ADDON_API/ {print $2}" %base_dir%\version.txt') do set addon_api=%%i
+FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_MAJOR/ {print $2}" %base_dir%\version.txt') DO SET major=%%i
+FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_MINOR/ {print $2}" %base_dir%\version.txt') DO SET minor=%%i
+FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_TAG/ {print $2}" %base_dir%\version.txt') DO SET tag=%%i
+FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/ADDON_API/ {print $2}" %base_dir%\version.txt') DO SET addon_api=%%i
 
 REM create the files with the proper version information
 "%msys_bin_dir%\sed.exe" -e s/@APP_VERSION_MAJOR@/%major%/g -e s/@APP_VERSION_MINOR@/%minor%/g -e s/@APP_VERSION_TAG@/%tag%/g "%base_dir%\xbmc\CompileInfo.cpp.in" > "%base_dir%\xbmc\CompileInfo.cpp"

--- a/tools/windows/CompileInfo.bat
+++ b/tools/windows/CompileInfo.bat
@@ -13,7 +13,12 @@ FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_MINOR/ {print $2}" %base_dir%\v
 FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/VERSION_TAG/ {print $2}" %base_dir%\version.txt') DO SET tag=%%i
 FOR /f %%i IN ('%msys_bin_dir%\awk.exe "/ADDON_API/ {print $2}" %base_dir%\version.txt') DO SET addon_api=%%i
 
+REM XBMC_PC.rc.in requires a comma-separated version of addon_api
+SET separator=,
+CALL SET file_version=%%addon_api:.=%separator%%%%separator%0
+
 REM create the files with the proper version information
 "%msys_bin_dir%\sed.exe" -e s/@APP_VERSION_MAJOR@/%major%/g -e s/@APP_VERSION_MINOR@/%minor%/g -e s/@APP_VERSION_TAG@/%tag%/g "%base_dir%\xbmc\CompileInfo.cpp.in" > "%base_dir%\xbmc\CompileInfo.cpp"
 "%msys_bin_dir%\sed.exe" s/@APP_ADDON_API@/%addon_api%/g "%base_dir%\addons\xbmc.addon\addon.xml.in" > "%base_dir%\addons\xbmc.addon\addon.xml"
+"%msys_bin_dir%\sed.exe" -e s/@APP_VERSION_MAJOR@/%major%/g -e s/@APP_VERSION_MINOR@/%minor%/g -e s/@APP_VERSION_TAG@/%tag%/g -e s/@FILE_VERSION@/%file_version%/g "%base_dir%\xbmc\win32\XBMC_PC.rc.in" > "%base_dir%\xbmc\win32\XBMC_PC.rc"
 

--- a/xbmc/win32/XBMC_PC.rc.in
+++ b/xbmc/win32/XBMC_PC.rc.in
@@ -53,8 +53,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 13,9,701,0
- PRODUCTVERSION 13,9,701,0
+ FILEVERSION @FILE_VERSION@
+ PRODUCTVERSION @FILE_VERSION@
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -71,12 +71,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Team XBMC"
             VALUE "FileDescription", "XBMC"
-            VALUE "FileVersion", "14.0-ALPHA1"
+            VALUE "FileVersion", "@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@-@APP_VERSION_TAG@"
             VALUE "InternalName", "XBMC.exe"
             VALUE "LegalCopyright", "Copyright (c) Team XBMC.  All rights reserved."
             VALUE "OriginalFilename", "XBMC.exe"
             VALUE "ProductName", "XBMC for Windows"
-            VALUE "ProductVersion", "14.0-ALPHA1"
+            VALUE "ProductVersion", "@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@-@APP_VERSION_TAG@"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
xbmc/win32/XBMC_PC.rc is the last file in our tree that contains versioning information that isn't automatically generated during building. These changes remedy this so that from now on we only need to adjust version.txt.
