### PR TITLE
Use reentrant localtime if available

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -867,7 +867,7 @@ AC_FUNC_STRFTIME
 AC_FUNC_STRTOD
 AC_FUNC_UTIME_NULL
 AC_FUNC_VPRINTF
-AC_CHECK_FUNCS([atexit dup2 fdatasync floor fs_stat_dev ftime ftruncate getcwd gethostbyaddr gethostbyname gethostname getpagesize getpass gettimeofday inet_ntoa lchown localeconv memchr memmove memset mkdir modf munmap pow rmdir select setenv setlocale socket sqrt strcasecmp strchr strcspn strdup strerror strncasecmp strpbrk strrchr strspn strstr strtol strtoul sysinfo tzset utime posix_fadvise])
+AC_CHECK_FUNCS([atexit dup2 fdatasync floor fs_stat_dev ftime ftruncate getcwd gethostbyaddr gethostbyname gethostname getpagesize getpass gettimeofday inet_ntoa lchown localeconv memchr memmove memset mkdir modf munmap pow rmdir select setenv setlocale socket sqrt strcasecmp strchr strcspn strdup strerror strncasecmp strpbrk strrchr strspn strstr strtol strtoul sysinfo tzset utime posix_fadvise localtime_r])
 
 # Check for various sizes
 AC_CHECK_SIZEOF([int])

--- a/xbmc/filesystem/FTPParse.cpp
+++ b/xbmc/filesystem/FTPParse.cpp
@@ -18,6 +18,10 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+  #include "config.h"
+#endif
+
 #if TARGET_WINDOWS
 #define PCRE_STATIC 1
 #ifdef _DEBUG
@@ -148,7 +152,13 @@ void CFTPParse::setTime(string str)
     time_struct.tm_mday = atoi(day.c_str());
 
     time_t t = time(NULL);
-    struct tm *current_time = localtime(&t);
+    struct tm *current_time;
+#ifdef LOCALTIME_R
+    struct tm result = {};
+    current_time = localtime_r(&t, &result);
+#else
+    current_time = localtime(&t);
+#endif
     if (pcrecpp::RE("(\\d{2}):(\\d{2})").FullMatch(year, &hour, &minute))
     {
       /* set the hour and minute */

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -18,6 +18,10 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+  #include "config.h"
+#endif
+
 #include "WebServer.h"
 #ifdef HAS_WEB_SERVER
 #include "URL.h"
@@ -1048,7 +1052,13 @@ bool CWebServer::GetLastModifiedDateTime(XFILE::CFile *file, CDateTime &lastModi
   if (file->Stat(&statBuffer) != 0)
     return false;
 
-  struct tm *time = localtime((time_t *)&statBuffer.st_mtime);
+  struct tm *time;
+#ifdef HAVE_LOCALTIME_R
+  struct tm result = {};
+  time = localtime_r((time_t*)&statBuffer.st_mtime, &result);
+#else
+  time = localtime((time_t *)&statBuffer.st_mtime);
+#endif
   if (time == NULL)
     return false;
 

--- a/xbmc/utils/TimeUtils.cpp
+++ b/xbmc/utils/TimeUtils.cpp
@@ -22,6 +22,10 @@
 #include "XBDateTime.h"
 #include "threads/SystemClock.h"
 
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+  #include "config.h"
+#endif
+
 #if   defined(TARGET_DARWIN)
 #include <mach/mach_time.h>
 #include <CoreVideo/CVHostTime.h>
@@ -93,7 +97,13 @@ CDateTime CTimeUtils::GetLocalTime(time_t time)
 {
   CDateTime result;
 
-  tm *local = localtime(&time); // Conversion to local time
+  tm *local;
+#ifdef HAVE_LOCALTIME_R
+  tm res = {};
+  local = localtime_r(&time, &res); // Conversion to local time
+#else
+  local = localtime(&time); // Conversion to local time
+#endif
   /*
    * Microsoft implementation of localtime returns NULL if on or before epoch.
    * http://msdn.microsoft.com/en-us/library/bf12f0hc(VS.80).aspx

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -18,6 +18,10 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+  #include "config.h"
+#endif
+
 #include "ApplicationMessenger.h"
 #include "threads/SystemClock.h"
 #include "VideoDatabase.h"
@@ -921,7 +925,13 @@ void CVideoDatabase::UpdateFileDateAdded(int idFile, const CStdString& strFileNa
         // make sure the datetime does is not in the future
         if (addedTime <= now)
         {
-          struct tm *time = localtime(&addedTime);
+          struct tm *time;
+#ifdef HAVE_LOCALTIME_R
+          struct tm result = {};
+          time = localtime_r(&addedTime, &result);
+#else
+          time = localtime(&addedTime);
+#endif
           if (time)
             dateAdded = *time;
         }
@@ -1316,7 +1326,13 @@ bool CVideoDatabase::AddPathToTvShow(int idShow, const std::string &path, const 
         // Make sure we have a valid date (i.e. not in the future)
         if ((time_t)buffer.st_ctime <= now)
         {
-          struct tm *time = localtime((const time_t*)&buffer.st_ctime);
+          struct tm *time;
+#ifdef HAVE_LOCALTIME_R
+          struct tm result = {};
+          time = localtime_r((const time_t*)&buffer.st_ctime, &result);
+#else
+          time = localtime((const time_t*)&buffer.st_ctime);
+#endif
           if (time)
             dateAdded = *time;
         }


### PR DESCRIPTION
I've seen some segfaults on android app start up with traces like

```
I/DEBUG   ( 2446): backtrace:
I/DEBUG   ( 2446):     #00  pc 00021c88  /system/lib/libc.so (__findenv+71)
I/DEBUG   ( 2446):     #01  pc 00021cc9  /system/lib/libc.so (getenv+4)
I/DEBUG   ( 2446):     #02  pc 000277d7  /system/lib/libc.so
I/DEBUG   ( 2446):     #03  pc 00027e49  /system/lib/libc.so (localtime_r+10)
I/DEBUG   ( 2446):     #04  pc 00be9c44  /data/app-lib/com.pivos.tofu-1/libtofu.so (GetLocalTime(_SYSTEMTIME*)+36)
I/DEBUG   ( 2446):     #05  pc 003d9fb8  /data/app-lib/com.pivos.tofu-1/libtofu.so (CLog::Log(int, char const*, ...)+116)
```

I'm not _sure_ that this fixes it, but this fixes a rather blatant thread-safety issue.
