### PR TITLE
Query stopped stopwatch

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4704,7 +4704,7 @@ void CApplication::CheckScreenSaverAndDPMS()
     return;
   }
 
-  float elapsed = m_screenSaverTimer.GetElapsedSeconds();
+  float elapsed = m_screenSaverTimer.IsRunning() ? m_screenSaverTimer.GetElapsedSeconds() : 0.f;
 
   // DPMS has priority (it makes the screensaver not needed)
   if (maybeDPMS
@@ -4773,7 +4773,8 @@ void CApplication::CheckShutdown()
     return;
   }
 
-  if ( m_shutdownTimer.GetElapsedSeconds() > CSettings::Get().GetInt("powermanagement.shutdowntime") * 60 )
+  float elapsed = m_shutdownTimer.IsRunning() ? m_shutdownTimer.GetElapsedSeconds() : 0.f;
+  if ( elapsed > CSettings::Get().GetInt("powermanagement.shutdowntime") * 60 )
   {
     // Since it is a sleep instead of a shutdown, let's set everything to reset when we wake up.
     m_shutdownTimer.Stop();
@@ -5247,20 +5248,14 @@ void CApplication::ProcessSlow()
 int CApplication::GlobalIdleTime()
 {
   if(!m_idleTimer.IsRunning())
-  {
-    m_idleTimer.Stop();
     m_idleTimer.StartZero();
-  }
   return (int)m_idleTimer.GetElapsedSeconds();
 }
 
 float CApplication::NavigationIdleTime()
 {
   if (!m_navigationTimer.IsRunning())
-  {
-    m_navigationTimer.Stop();
     m_navigationTimer.StartZero();
-  }
   return m_navigationTimer.GetElapsedSeconds();
 }
 
@@ -5466,8 +5461,7 @@ double CApplication::GetTotalTime() const
 
 void CApplication::StopShutdownTimer()
 {
-  if (m_shutdownTimer.IsRunning())
-    m_shutdownTimer.Stop();
+  m_shutdownTimer.Stop();
 }
 
 void CApplication::ResetShutdownTimers()

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -73,7 +73,7 @@ void CGUIBaseContainer::DoProcess(unsigned int currentTime, CDirtyRegionList &di
 {
   CGUIControl::DoProcess(currentTime, dirtyregions);
 
-  if (m_pageChangeTimer.GetElapsedMilliseconds() > 200)
+  if (m_pageChangeTimer.IsRunning() && m_pageChangeTimer.GetElapsedMilliseconds() > 200)
     m_pageChangeTimer.Stop();
   m_wasReset = false;
 
@@ -1044,7 +1044,7 @@ void CGUIBaseContainer::UpdateScrollOffset(unsigned int currentTime)
 {
   if (m_scroller.Update(currentTime))
     MarkDirtyRegion();
-  else if (m_lastScrollStartTimer.GetElapsedMilliseconds() >= SCROLLING_GAP)
+  else if (m_lastScrollStartTimer.IsRunning() && m_lastScrollStartTimer.GetElapsedMilliseconds() >= SCROLLING_GAP)
   {
     m_scrollTimer.Stop();
     m_lastScrollStartTimer.Stop();
@@ -1162,7 +1162,7 @@ bool CGUIBaseContainer::GetCondition(int condition, int data) const
       return layout ? (layout->GetFocusedItem() == (unsigned int)data) : false;
     }
   case CONTAINER_SCROLLING:
-    return (m_scrollTimer.GetElapsedMilliseconds() > std::max(m_scroller.GetDuration(), SCROLLING_THRESHOLD) || m_pageChangeTimer.IsRunning());
+    return ((m_scrollTimer.IsRunning() && m_scrollTimer.GetElapsedMilliseconds() > std::max(m_scroller.GetDuration(), SCROLLING_THRESHOLD)) || m_pageChangeTimer.IsRunning());
   case CONTAINER_ISUPDATING:
     return (m_listProvider) ? m_listProvider->IsUpdating() : false;
   default:

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -396,7 +396,7 @@ void CGUIEditControl::RecalcLabelPosition()
 
 void CGUIEditControl::ProcessText(unsigned int currentTime)
 {
-  if (m_smsTimer.GetElapsedMilliseconds() > smsDelay)
+  if (m_smsTimer.IsRunning() && m_smsTimer.GetElapsedMilliseconds() > smsDelay)
     UpdateText();
 
   if (m_bInvalidated)

--- a/xbmc/utils/AlarmClock.h
+++ b/xbmc/utils/AlarmClock.h
@@ -60,7 +60,7 @@ public:
     std::map<std::string,SAlarmClockEvent>::iterator iter;
     if ((iter=m_event.find(strName)) != m_event.end())
     {
-      return iter->second.m_fSecs-iter->second.watch.GetElapsedSeconds();
+      return iter->second.m_fSecs-(iter->second.watch.IsRunning() ? iter->second.watch.GetElapsedSeconds() : 0.f);
     }
 
     return 0.f;

--- a/xbmc/utils/Stopwatch.cpp
+++ b/xbmc/utils/Stopwatch.cpp
@@ -47,52 +47,6 @@ CStopWatch::~CStopWatch()
 {
 }
 
-bool CStopWatch::IsRunning() const
-{
-  return m_isRunning;
-}
-
-void CStopWatch::StartZero()
-{
-  m_startTick = GetTicks();
-  m_isRunning = true;
-}
-
-void CStopWatch::Start()
-{
-  if (!m_isRunning)
-    m_startTick = GetTicks();
-  m_isRunning = true;
-}
-
-void CStopWatch::Stop()
-{
-  if( m_isRunning )
-  {
-    m_stopTick = GetTicks();
-    m_isRunning = false;
-  }
-}
-
-void CStopWatch::Reset()
-{
-  if (m_isRunning)
-    m_startTick = GetTicks();
-  else
-    m_startTick = m_stopTick;
-}
-
-float CStopWatch::GetElapsedSeconds() const
-{
-  int64_t totalTicks = (m_isRunning ? GetTicks() : m_stopTick) - m_startTick;
-  return (float)totalTicks * m_timerPeriod;
-}
-
-float CStopWatch::GetElapsedMilliseconds() const
-{
-  return GetElapsedSeconds() * 1000.0f;
-}
-
 int64_t CStopWatch::GetTicks() const
 {
   if (m_useFrameTime)

--- a/xbmc/utils/Stopwatch.cpp
+++ b/xbmc/utils/Stopwatch.cpp
@@ -29,6 +29,7 @@ CStopWatch::CStopWatch(bool useFrameTime /*=false*/)
 {
   m_timerPeriod      = 0.0f;
   m_startTick        = 0;
+  m_stopTick         = 0;
   m_isRunning        = false;
   m_useFrameTime     = useFrameTime;
 
@@ -68,7 +69,7 @@ void CStopWatch::Stop()
 {
   if( m_isRunning )
   {
-    m_startTick = 0;
+    m_stopTick = GetTicks();
     m_isRunning = false;
   }
 }
@@ -77,11 +78,13 @@ void CStopWatch::Reset()
 {
   if (m_isRunning)
     m_startTick = GetTicks();
+  else
+    m_startTick = m_stopTick;
 }
 
 float CStopWatch::GetElapsedSeconds() const
 {
-  int64_t totalTicks = m_isRunning ? (GetTicks() - m_startTick) : 0;
+  int64_t totalTicks = (m_isRunning ? GetTicks() : m_stopTick) - m_startTick;
   return (float)totalTicks * m_timerPeriod;
 }
 

--- a/xbmc/utils/Stopwatch.h
+++ b/xbmc/utils/Stopwatch.h
@@ -34,12 +34,19 @@ public:
   void Stop();               ///< Stops clock and sets to zero if running.
   void Reset();              ///< Resets clock to zero - does not alter running state.
 
+  /*!
+    \brief  Retrieve time elapsed between the last call to Start(), StartZero()
+            or Reset() and; if running, now; if stopped, the last call to Stop().
+
+    \return elapsed time, in seconds, as a float.
+  */
   float GetElapsedSeconds() const;
   float GetElapsedMilliseconds() const;
 private:
   int64_t GetTicks() const;
   float m_timerPeriod;        // to save division in GetElapsed...()
   int64_t m_startTick;
+  int64_t m_stopTick;
   bool m_isRunning;
   bool m_useFrameTime;
 };

--- a/xbmc/utils/Stopwatch.h
+++ b/xbmc/utils/Stopwatch.h
@@ -28,20 +28,80 @@ public:
   CStopWatch(bool useFrameTime=false);
   ~CStopWatch();
 
-  bool IsRunning() const;
-  void StartZero();          ///< Resets clock to zero and starts running
-  void Start();              ///< Sets clock to zero if not running and starts running.
-  void Stop();               ///< Stops clock and sets to zero if running.
-  void Reset();              ///< Resets clock to zero - does not alter running state.
+  /*!
+    \brief Retrieve the running state of the stopwatch.
+
+    \return True if stopwatch has been started but not stopped.
+  */
+  inline bool IsRunning() const
+  {
+    return m_isRunning;
+  }
+
+  /*!
+    \brief Record start time and change state to running.
+  */
+  inline void StartZero()
+  {
+    m_startTick = GetTicks();
+    m_isRunning = true;
+  }
+
+  /*!
+    \brief Record start time and change state to running, only if the stopwatch is stopped.
+  */
+  inline void Start()
+  {
+    if (!m_isRunning)
+      StartZero();
+  }
+
+  /*!
+    \brief Record stop time and change state to not running.
+  */
+  inline void Stop()
+  {
+    if(m_isRunning)
+    {
+      m_stopTick = GetTicks();
+      m_isRunning = false;
+    }
+  }
+
+  /*!
+    \brief Set the start time such that time elapsed is now zero.
+  */
+  void Reset()
+  {
+    if (m_isRunning)
+      m_startTick = GetTicks();
+    else
+      m_startTick = m_stopTick;
+  }
 
   /*!
     \brief  Retrieve time elapsed between the last call to Start(), StartZero()
             or Reset() and; if running, now; if stopped, the last call to Stop().
 
-    \return elapsed time, in seconds, as a float.
+    \return Elapsed time, in seconds, as a float.
   */
-  float GetElapsedSeconds() const;
-  float GetElapsedMilliseconds() const;
+  float GetElapsedSeconds() const
+  {
+    int64_t totalTicks = (m_isRunning ? GetTicks() : m_stopTick) - m_startTick;
+    return (float)totalTicks * m_timerPeriod;
+  }
+  
+  /*!
+    \brief  Retrieve time elapsed between the last call to Start(), StartZero()
+            or Reset() and; if running, now; if stopped, the last call to Stop().
+
+    \return Elapsed time, in milliseconds, as a float.
+  */
+  float GetElapsedMilliseconds() const
+  {
+    return GetElapsedSeconds() * 1000.0f;
+  }
+
 private:
   int64_t GetTicks() const;
   float m_timerPeriod;        // to save division in GetElapsed...()

--- a/xbmc/utils/test/TestStopwatch.cpp
+++ b/xbmc/utils/test/TestStopwatch.cpp
@@ -65,8 +65,8 @@ TEST(TestStopWatch, Stop)
 
   a.Stop();
   EXPECT_FALSE(a.IsRunning());
-  EXPECT_EQ(0.0f, a.GetElapsedSeconds());
-  EXPECT_EQ(0.0f, a.GetElapsedMilliseconds());
+  EXPECT_GT(0.0f, a.GetElapsedSeconds());
+  EXPECT_GT(0.0f, a.GetElapsedMilliseconds());
 }
 
 TEST(TestStopWatch, StartZero)


### PR DESCRIPTION
As title.  I'm surprised no one has wanted this functionality before now.

I didn't see any usage abusing the fact that GetElapsed*() returned 0 for a stopwatch that isn't running.
