### PR TITLE
[pvr] adds 'Find similar' button to guide info dialog

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
+++ b/addons/skin.confluence/720p/DialogPVRGuideInfo.xml
@@ -5,7 +5,7 @@
 		<system>1</system>
 		<left>20</left>
 		<top>30</top>
-		<origin x="275" y="30">![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</origin>
+		<origin x="245" y="30">![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</origin>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
@@ -14,7 +14,7 @@
 				<description>background image</description>
 				<left>0</left>
 				<top>0</top>
-				<width>730</width>
+				<width>790</width>
 				<height>660</height>
 				<texture border="40">DialogBack2.png</texture>
 				<visible>Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)</visible>
@@ -23,7 +23,7 @@
 				<description>background image</description>
 				<left>0</left>
 				<top>0</top>
-				<width>730</width>
+				<width>790</width>
 				<height>660</height>
 				<texture border="40">DialogBack.png</texture>
 				<visible>![Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)]</visible>
@@ -32,7 +32,7 @@
 				<description>Dialog Header image</description>
 				<left>40</left>
 				<top>16</top>
-				<width>650</width>
+				<width>710</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
@@ -40,7 +40,7 @@
 				<description>header label</description>
 				<left>40</left>
 				<top>20</top>
-				<width>650</width>
+				<width>710</width>
 				<height>30</height>
 				<font>font13_title</font>
 				<label>$LOCALIZE[19047]</label>
@@ -51,7 +51,7 @@
 			</control>
 			<control type="button">
 				<description>Close Window button</description>
-				<left>640</left>
+				<left>700</left>
 				<top>15</top>
 				<width>64</width>
 				<height>32</height>
@@ -70,7 +70,7 @@
 				<description>Title label</description>
 				<left>40</left>
 				<top>70</top>
-				<width>650</width>
+				<width>700</width>
 				<height>30</height>
 				<font>font13_title</font>
 				<label>$INFO[ListItem.Title]</label>
@@ -182,7 +182,7 @@
 					<description>Plot value</description>
 					<left>40</left>
 					<top>275</top>
-					<width>650</width>
+					<width>710</width>
 					<height>285</height>
 					<font>font13</font>
 					<align>justify</align>
@@ -195,7 +195,7 @@
 				<control type="grouplist" id="9000">
 					<left>40</left>
 					<top>590</top>
-					<width>640</width>
+					<width>700</width>
 					<height>40</height>
 					<itemgap>5</itemgap>
 					<align>center</align>
@@ -204,6 +204,11 @@
 					<onright>9000</onright>
 					<onup>60</onup>
 					<ondown>60</ondown>
+					<control type="button" id="4">
+						<description>Find similar</description>
+						<include>ButtonInfoDialogsCommonValues</include>
+						<label>19003</label>
+					</control>
 					<control type="button" id="5">
 						<description>Switch to Channel</description>
 						<include>ButtonInfoDialogsCommonValues</include>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7392,8 +7392,14 @@ msgctxt "#19002"
 msgid "or use phrases to find an exact match, like \"The wizard of Oz\"."
 msgstr ""
 
+#. Label of the button / context menu entry to find similar programs in the PVR EPG data 
+#: skin.confluence
+#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+#: xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+#: xbmc/pvr/windows/GUIWindowPVRTimers.cpp
 msgctxt "#19003"
-msgid "Find similar programs"
+msgid "Find similar"
 msgstr ""
 
 #: xbmc/epg/EpgContainer.cpp

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -31,10 +31,12 @@
 #include "epg/EpgInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
+#include "pvr/windows/GUIWindowPVRBase.h"
 
 using namespace PVR;
 using namespace EPG;
 
+#define CONTROL_BTN_FIND                4
 #define CONTROL_BTN_SWITCH              5
 #define CONTROL_BTN_RECORD              6
 #define CONTROL_BTN_OK                  7
@@ -195,6 +197,29 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonSwitch(CGUIMessage &message)
   return bReturn;
 }
 
+bool CGUIDialogPVRGuideInfo::OnClickButtonFind(CGUIMessage &message)
+{
+  bool bReturn = false;
+
+  if (message.GetSenderId() == CONTROL_BTN_FIND)
+  {
+    const CEpgInfoTag *tag = m_progItem->GetEPGInfoTag();
+    if (tag && tag->HasPVRChannel())
+    {
+      int windowSearchId = tag->ChannelTag()->IsRadio() ? WINDOW_RADIO_SEARCH : WINDOW_TV_SEARCH;
+      CGUIWindowPVRBase *windowSearch = (CGUIWindowPVRBase*) g_windowManager.GetWindow(windowSearchId);
+      if (windowSearch)
+      {
+        Close();
+        g_windowManager.ActivateWindow(windowSearchId);
+        bReturn = windowSearch->OnContextButton(*m_progItem.get(), CONTEXT_BUTTON_FIND);
+      }
+    }
+  }
+
+  return bReturn;
+}
+
 bool CGUIDialogPVRGuideInfo::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
@@ -202,7 +227,8 @@ bool CGUIDialogPVRGuideInfo::OnMessage(CGUIMessage& message)
   case GUI_MSG_CLICKED:
     return OnClickButtonOK(message) ||
            OnClickButtonRecord(message) ||
-           OnClickButtonSwitch(message);
+           OnClickButtonSwitch(message) ||
+           OnClickButtonFind(message);
   }
 
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -50,6 +50,7 @@ namespace PVR
     bool OnClickButtonOK(CGUIMessage &message);
     bool OnClickButtonRecord(CGUIMessage &message);
     bool OnClickButtonSwitch(CGUIMessage &message);
+    bool OnClickButtonFind(CGUIMessage &message);
 
     CFileItemPtr m_progItem;
   };

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -53,6 +53,7 @@ namespace PVR
     virtual void OnInitWindow(void);
     virtual bool OnMessage(CGUIMessage& message);
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
+    virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) { return false; };
     virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true);
     virtual void UpdateButtons(void);
     virtual bool OnAction(const CAction &action);
@@ -66,7 +67,6 @@ namespace PVR
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);
     virtual ~CGUIWindowPVRBase(void);
 
-    virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) { return false; };
     virtual std::string GetDirectoryPath(void) { return ""; };
     virtual CPVRChannelGroupPtr GetGroup(void);
     virtual void SetGroup(CPVRChannelGroupPtr group);

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -35,10 +35,10 @@ namespace PVR
     void OnWindowLoaded();
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
+    bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button);
 
   protected:
     void OnPrepareFileItems(CFileItemList &items);
-    virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button);
 
   private:
     bool OnContextButtonClear(CFileItem *item, CONTEXT_BUTTON button);


### PR DESCRIPTION
This adds a new button 'Find similar programs' to the guide info dialog which will trigger a search for similar programs.

I'm not sure if we should add a new language key for the button because the current label is to long and scrolls within the button.

@Jalle19 or @opdenkamp for review the core part
@ronie or @BigNoid for the changes i made to confluence
