### PR TITLE
 [pvr] fix hiding the "go to parent directory" item in the root of the recordings list

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -673,6 +673,7 @@ bool CGUIWindowPVRBase::UpdateEpgForChannel(CFileItem *item)
 
 bool CGUIWindowPVRBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
+  m_vecItems->SetPath(strDirectory);
   return CGUIMediaWindow::Update(strDirectory, updateFilterPath);
 }
 


### PR DESCRIPTION
@Jalle19 I've separated the fix you've done in #5073 to this PR. This adds the m_vecItems->SetPath() to the base class, because it could be possible that we need this in other PVR windows too.
