### PR TITLE
[pvr] bump add-ons

### DIFF
--- a/project/Win32BuildSetup/buildpvraddons.bat
+++ b/project/Win32BuildSetup/buildpvraddons.bat
@@ -9,7 +9,7 @@ SET DEPS_DIR=..\BuildDependencies
 SET TMP_DIR=%DEPS_DIR%\tmp
 
 SET LIBNAME=xbmc-pvr-addons
-SET VERSION=36eba34cabddce47878872b199fd3f13aafb8125
+SET VERSION=1832e602ce6d6ce43e2abbb497879beb944ab225
 SET SOURCE=%LIBNAME%
 SET GIT_URL=git://github.com/opdenkamp/%LIBNAME%.git
 SET SOURCE_DIR=%TMP_DIR%\%SOURCE%

--- a/tools/depends/target/xbmc-pvr-addons/Makefile
+++ b/tools/depends/target/xbmc-pvr-addons/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.include
 #DEPS= ../../Makefile.include Makefile
 
 LIBNAME=xbmc-pvr-addons
-VERSION=36eba34cabddce47878872b199fd3f13aafb8125
+VERSION=1832e602ce6d6ce43e2abbb497879beb944ab225
 GIT_DIR=$(TARBALLS_LOCATION)/$(LIBNAME).git
 BASE_URL=git://github.com/opdenkamp/$(LIBNAME).git
 DYLIB=$(PLATFORM)/addons/pvr.demo/.libs/libpvrdemo-addon.so


### PR DESCRIPTION
Include latest pvr-addons work in XBMC alpha nightlies
(last pvr update was 14 July)

This includes approx 8 commits including

pvr.wmc versions 3.97/3.98/3.99
pvr.vuplus to 1.9.14
pvr.vnsi to 1.9.12

makefile tidy up
installation permission tidy up on linux
README and VS project updates to facilitate easier debugging/development of pvr addons in XBMC solution
