### PR TITLE
[pvr] fix the path split-up in CPVRTimers::GetDirectory() which results in no timer is returned

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -399,15 +399,12 @@ bool CPVRTimers::HasActiveTimers(void) const
 
 bool CPVRTimers::GetDirectory(const CStdString& strPath, CFileItemList &items) const
 {
-  CURL url(strPath);
-  CStdString fileName = url.GetFileName();
-  
-  vector<string> dirs = URIUtils::SplitPath(URIUtils::GetDirectory(fileName));
-  if(dirs.size() == 2 && dirs.at(0) == "timers")
+  vector<string> dirs = URIUtils::SplitPath(strPath);
+  if(dirs.size() == 3 && dirs.at(1) == "timers")
   {
-    bool bRadio = (dirs.at(1) == "radio");
-    CFileItemPtr item;
+    bool bRadio = (dirs.at(2) == "radio");
 
+    CFileItemPtr item;
     item.reset(new CFileItem("pvr://timers/add.timer", false));
     item->SetLabel(g_localizeStrings.Get(19026));
     item->SetLabelPreformated(true);


### PR DESCRIPTION
On windows the `URIUtils::SplitPath(URIUtils::GetDirectory(fileName))` don't return the right count of elements which prevents the method to return the exsting timers. The root cause is that `URIUtils::SplitPath()` use the OS dependent directory separator, but the path given to `SplitPath()` holds slashes (/). I've removed the different path preparations and split `strPath` directly which results in a vector -> [0]: pvr://, [1]: timers, [2]: tv or radio.
