### PR TITLE
don't show "Play using..." for plugins (fixes #15361)

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -703,7 +703,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
         {
           buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 208); // Play
         }
-        else
+        else if (!item->IsPlugin())
         { // check what players we have, if we have multiple display play with option
           VECPLAYERCORES vecCores;
           CPlayerCoreFactory::Get().GetPlayers(*item, vecCores);

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -514,10 +514,13 @@ void CGUIWindowMusicPlayList::GetContextButtons(int itemNumber, CContextButtons 
     else
     { // aren't in a move
       // check what players we have, if we have multiple display play with option
-      VECPLAYERCORES vecCores;
-      CPlayerCoreFactory::Get().GetPlayers(*item, vecCores);
-      if (vecCores.size() > 1)
-        buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213); // Play With...
+      if (!item->IsPlugin())
+      {
+        VECPLAYERCORES vecCores;
+        CPlayerCoreFactory::Get().GetPlayers(*item, vecCores);
+        if (vecCores.size() > 1)
+          buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213); // Play With...
+      }
 
       buttons.Add(CONTEXT_BUTTON_SONG_INFO, 658); // Song Info
       if (XFILE::CFavouritesDirectory::IsFavourite(item.get(), GetID()))

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1237,7 +1237,8 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
         buttons.Add(CONTEXT_BUTTON_INFO,24003); // Add-on info
 
-      if (!item->m_bIsFolder && !(item->IsPlayList() && !g_advancedSettings.m_playlistAsFolders))
+      if (!item->m_bIsFolder && !(item->IsPlayList() && !g_advancedSettings.m_playlistAsFolders) &&
+          !item->IsPlugin())
       { // get players
         VECPLAYERCORES vecCores;
         if (item->IsVideoDb())

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -410,7 +410,7 @@ void CGUIWindowVideoPlaylist::GetContextButtons(int itemNumber, CContextButtons 
         CFileItem item2(item->GetVideoInfoTag()->m_strFileNameAndPath, false);
         CPlayerCoreFactory::Get().GetPlayers(item2, vecCores);
       }
-      else
+      else if (!item->IsPlugin())
         CPlayerCoreFactory::Get().GetPlayers(*item, vecCores);
       if (vecCores.size() > 1)
         buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213); // Play With...


### PR DESCRIPTION
This is a rather simple approach at fixing http://trac.xbmc.org/ticket/15361 where a user tries to play a video from a plugin through UPnP's remote play functionality which is currently not possible. Therefore we shouldn't show the "Play using..." context menu item for plugins.

A better fix would be to improve the logic in CPlayerCoreFactory::GetPlayers() to simply not add UPnP remote players to the list if the item is a plugin but I'm not comfortable with changing that logic as I don't completely understand it and all of the use cases there are.
