### PR TITLE
[pvr] fix sorting for timers window

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -404,10 +404,10 @@ bool CPVRTimers::GetDirectory(const CStdString& strPath, CFileItemList &items) c
   {
     bool bRadio = (dirs.at(2) == "radio");
 
-    CFileItemPtr item;
-    item.reset(new CFileItem("pvr://timers/add.timer", false));
+    CFileItemPtr item(new CFileItem("pvr://timers/add.timer", true));
     item->SetLabel(g_localizeStrings.Get(19026));
     item->SetLabelPreformated(true);
+    item->SortsOnTop();
     items.Add(item);
 
     CSingleLock lock(m_critSection);

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -78,17 +78,17 @@ void CGUIViewStateWindowPVRGuide::SaveViewState(void)
 
 CGUIViewStateWindowPVRTimers::CGUIViewStateWindowPVRTimers(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
 {
-  LoadViewState(items.GetPath(), m_windowId);
-}
-
-void CGUIViewStateWindowPVRTimers::SaveViewState(void)
-{
   AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""));   // FileName, Size | Foldername, empty
   AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
 
   // Default sorting
   SetSortMethod(SortByDate);
 
+  LoadViewState(items.GetPath(), m_windowId);
+}
+
+void CGUIViewStateWindowPVRTimers::SaveViewState(void)
+{
   SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::Get().Get("pvrtimers"));
 }
 


### PR DESCRIPTION
This fixes the broken sorting in timers window  (a stupid c/p) and changes the item "Add timer..." to stay always on top of the list.

@Jalle19 mind taking a look.
