### PR TITLE
[python] don't include site-packages in python path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ config.log
 /addons/visualization.waveform/Waveform_win32.vis
 /addons/visualization.itunes/iTunes.mvis
 /addons/visualization.fishbmc/fishbmc.vis
-/addons/script.module.pil/
 /addons/audioencoder.*
 /addons/pvr.*
 /addons/xbmc.addon/addon.xml

--- a/addons/script.module.pil/lib/PIL.py
+++ b/addons/script.module.pil/lib/PIL.py
@@ -1,0 +1,10 @@
+import imp
+import site
+
+fp, path, descr = imp.find_module('PIL', site.getsitepackages())
+try:
+   imp.load_module('PIL', fp, path, descr)
+finally:
+    if fp:
+        fp.close()
+

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -194,25 +194,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
   for (unsigned int i = 0; i < addons.size(); ++i)
     addPath(CSpecialProtocol::TranslatePath(addons[i]->LibPath()));
 
-  // we want to use sys.path so it includes site-packages
-  // if this fails, default to using Py_GetPath
-  PyObject *sysMod(PyImport_ImportModule((char*)"sys")); // must call Py_DECREF when finished
-  PyObject *sysModDict(PyModule_GetDict(sysMod)); // borrowed ref, no need to delete
-  PyObject *pathObj(PyDict_GetItemString(sysModDict, "path")); // borrowed ref, no need to delete
-
-  if (pathObj != NULL && PyList_Check(pathObj))
-  {
-    for (int i = 0; i < PyList_Size(pathObj); i++)
-    {
-      PyObject *e = PyList_GetItem(pathObj, i); // borrowed ref, no need to delete
-      if (e != NULL && PyString_Check(e))
-        addNativePath(PyString_AsString(e)); // returns internal data, don't delete or modify
-    }
-  }
-  else
-    addNativePath(Py_GetPath());
-
-  Py_DECREF(sysMod); // release ref to sysMod
+  addNativePath(Py_GetPath());
 
   // set current directory and python's path.
   if (m_argv != NULL)


### PR DESCRIPTION
This is very error prone as add-on may 'silently work' if required dependence are installed system-wide. It's basically impossible to test if your add-on really works without a clean python install.

I have no idea why site-packages was [added](https://github.com/xbmc/xbmc/commit/c4fd22dd326af8a82c50d6f7d0df85a6518aa14b) in the first place. May completely break something.
