### PR TITLE
[addons] move the 'check for updates' item handling to the onclick handler

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -228,6 +228,14 @@ class UpdateAddons : public IRunnable
   }
 };
 
+class UpdateRepos : public IRunnable
+{
+  virtual void Run()
+  {
+    CAddonInstaller::Get().UpdateRepos(true, true);
+  }
+};
+
 bool CGUIWindowAddonBrowser::OnClick(int iItem)
 {
   CFileItemPtr item = m_vecItems->Get(iItem);
@@ -240,6 +248,14 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
     std::string path;
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041), path))
       CAddonInstaller::Get().InstallFromZip(path);
+    return true;
+  }
+  else if (item->GetPath() == "addons://check/")
+  {
+    // perform the check for updates
+    UpdateRepos updater;
+    if (CGUIDialogBusy::Wait(&updater))
+      Refresh();
     return true;
   }
   if (item->GetPath() == "addons://update_all/")

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -86,16 +86,6 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     items.SetProperty("reponame",g_localizeStrings.Get(24043));
     items.SetLabel(g_localizeStrings.Get(24043));
   }
-  else if (path.GetHostName() == "check")
-  {
-    reposAsFolders = false;
-    groupAddons = false;
-    // force a refresh
-    CAddonInstaller::Get().UpdateRepos(true, true);
-    CAddonMgr::Get().GetAllOutdatedAddons(addons);
-    items.SetProperty("reponame",g_localizeStrings.Get(24055));
-    items.SetLabel(g_localizeStrings.Get(24055));
-  }
   else if (path.GetHostName() == "repos")
   {
     groupAddons = false;
@@ -214,8 +204,7 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     item->SetLabel(g_localizeStrings.Get(24032));
     items.Add(item);
   }
-  else if ((path.GetHostName() == "outdated" ||
-            path.GetHostName() == "check") && items.Size() > 1)
+  else if (path.GetHostName() == "outdated" && items.Size() > 1)
   {
     CFileItemPtr item(new CFileItem("addons://update_all/", true));
     item->SetLabel(g_localizeStrings.Get(24122));


### PR DESCRIPTION
Rather than a fake directory item.  This means addons://check/ isn't called from other spots that are inappropriate (e.g. it isn't the folder that you reside in which then hits an infinite loop as the repo update fires an event to refresh the folder...)

Fixes #15363

Note that this changes the action of this entry - previously it would check, and if updates were found, would show a list thereof.  Now it just checks.

@MartijnKaijser mind checking it does the trick?

@da-anda mind checking the UX with this change?
