### PR TITLE
Store audio stream setting only on user action

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -21,6 +21,7 @@
 #include "ApplicationPlayer.h"
 #include "cores/IPlayer.h"
 #include "Application.h"
+#include "settings/MediaSettings.h"
 
 #define VOLUME_MINIMUM 0.0f        // -60dB
 #define VOLUME_MAXIMUM 1.0f        // 0dB
@@ -499,6 +500,7 @@ void CApplicationPlayer::SetAudioStream(int iStream)
     player->SetAudioStream(iStream);
     m_iAudioStream = iStream;
     m_audioStreamUpdate.Set(1000);
+    CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = iStream;
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2748,7 +2748,6 @@ int CDVDPlayer::GetAudioStream()
 
 void CDVDPlayer::SetAudioStream(int iStream)
 {
-  CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = iStream;
   m_messenger.Put(new CDVDMsgPlayerSetAudioStream(iStream));
   SynchronizeDemuxer(100);
 }

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -202,17 +202,15 @@ bool CPlayerController::OnAction(const CAction &action)
         if (g_application.m_pPlayer->GetAudioStreamCount() == 1)
           return true;
 
-        if(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream < 0)
-          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = g_application.m_pPlayer->GetAudioStream();
+        int currentAudio = g_application.m_pPlayer->GetAudioStream();
 
-        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream++;
-        if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream >= g_application.m_pPlayer->GetAudioStreamCount())
-          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream = 0;
-        g_application.m_pPlayer->SetAudioStream(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream);    // Set the audio stream to the one selected
+        if (++currentAudio >= g_application.m_pPlayer->GetAudioStreamCount())
+          currentAudio = 0;
+        g_application.m_pPlayer->SetAudioStream(currentAudio);    // Set the audio stream to the one selected
         CStdString aud;
         CStdString lan;
         SPlayerAudioStreamInfo info;
-        g_application.m_pPlayer->GetAudioStreamInfo(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream, info);
+        g_application.m_pPlayer->GetAudioStreamInfo(currentAudio, info);
         if (!g_LangCodeExpander.Lookup(lan, info.language))
           lan = g_localizeStrings.Get(13205); // Unknown
         if (info.name.empty())

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -434,7 +434,7 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(CSettingGroup *group, cons
       for (int i = 0; i < 3; ++i)
         options.push_back(make_pair(i, 13320 + i));
 
-      m_audioStream = -CMediaSettings::Get().GetCurrentVideoSettings().m_AudioStream - 1;
+      m_audioStream = -g_application.m_pPlayer->GetAudioStream() - 1;
       m_audioStreamStereoMode = true;
       AddSpinner(group, settingId, 460, 0, m_audioStream, options);
       return;


### PR DESCRIPTION
Building on same idea and approach as in #5003, making sure we ask the player which audio stream is played and store the selected audio index only when in CApplicationPlayer::SetAudioStream and nowhere else.

@ace20022 - you will need to rebase #5027 if this one goes in first.
