### PR TITLE
ADD: Define AndroidApps as a program section

### DIFF
--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -195,6 +195,8 @@ std::string CGUIWindowPrograms::GetStartFolder(const std::string &dir)
   std::string lower(dir); StringUtils::ToLower(lower);
   if (lower == "plugins" || lower == "addons")
     return "addons://sources/executable/";
+  else if (lower == "androidapps")
+    return "androidapp://sources/apps/";
     
   SetupShares();
   VECSOURCES shares;


### PR DESCRIPTION
Allows for ActivateWindow(Programs,AndroidApps) as shorthand for
ActivateWindow(Programs,androidapp://sources/apps/), to open the Android
Apps list directly.
