### PR TITLE
CGUIDialogContextMenu: remove "Add source" context menu entry

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -276,8 +276,6 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
     }
     if (!GetDefaultShareNameByType(type).empty())
       buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // Clear Default
-
-    buttons.Add(CONTEXT_BUTTON_ADD_SOURCE, 1026); // Add Source
   }
   if (share && LOCK_MODE_EVERYONE != CProfilesManager::Get().GetMasterProfile().getLockMode())
   {


### PR DESCRIPTION
While running some tests with video sources I noticed that there's an "Add source" context menu entry in every files view even though there always is an "Add source" list item that can be used. IMO "Add source" is not something context-aware and as there's always the "Add source" entry/button it's superfluous. The handling of CONTEXT_BUTTON_ADD_SOURCE is still needed as it is called when pressing the "Add source" list item.
