### PR TITLE
[pvr] fix stupid mistake on refactor .Equals() comparator to std equals

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -141,7 +141,7 @@ CPVRChannelGroupPtr CPVRChannelGroups::GetByName(const std::string &strName) con
   CSingleLock lock(m_critSection);
   for (std::vector<CPVRChannelGroupPtr>::const_iterator it = m_groups.begin(); it != m_groups.end(); it++)
   {
-    if ((*it)->GroupName() != strName)
+    if ((*it)->GroupName() == strName)
       return *it;
   }
 


### PR DESCRIPTION
This solves the issue after the CStdString removal that only one channel group is imported from the backends.
