### PR TITLE
Show singles in the Year nodes in music db

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3003,6 +3003,7 @@ bool CMusicDatabase::GetAlbumsByYear(const CStdString& strBaseDir, CFileItemList
     return false;
 
   musicUrl.AddOption("year", year);
+  musicUrl.AddOption("singles", true); // allow singles to be listed
   
   Filter filter;
   return GetAlbumsByWhere(musicUrl.ToString(), filter, items);
@@ -5599,7 +5600,11 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
                                       option->second.asString().c_str(), option->second.asString().c_str()));
       // no artist given, so exclude any single albums (aka empty tagged albums)
       else
-        filter.AppendWhere("albumview.strAlbum <> ''");
+      {
+        option = options.find("singles");
+        if (option == options.end() || !option->second.asBoolean())
+          filter.AppendWhere("albumview.strAlbum <> ''");
+      }
     }
   }
   else if (type == "songs" || type == "singles")


### PR DESCRIPTION
ATM singles aren't shown by default in album listings where an artistid or artist isn't specified as part of the filter.  This makes a certain amount of sense, but in some cases we definitely want them.

This adds `singles=true` to the URL options parsed when an artistid or artist isn't specified, and allows the singles album item(s) to be returned.

@Montellese: Perhaps `allowsingles` might be a better name?  Any better ideas?  Initially I thought about trying to get rid of the restriction, but I fear that may cause more hassles - not sure.
