### PR TITLE
[view] fix label for default sort method in CGUIViewState

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2313,6 +2313,7 @@ msgctxt "#550"
 msgid "Sort by: %s"
 msgstr ""
 
+#: xbmc/view/GUIViewState.cpp
 msgctxt "#551"
 msgid "Name"
 msgstr ""

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -257,7 +257,7 @@ int CGUIViewState::GetSortMethodLabel() const
   if (m_currentSortMethod>=0 && m_currentSortMethod<(int)m_sortMethods.size())
     return m_sortMethods[m_currentSortMethod].m_buttonLabel;
 
-  return 103; // Sort By: Name
+  return 551; // default sort method label 'Name'
 }
 
 void CGUIViewState::GetSortMethodLabelMasks(LABEL_MASKS& masks) const


### PR DESCRIPTION
This adjusts the label which is used if no sort method is defined (Sort by: Name) to 'Name' as it's used in all CGUIViewState derivatives.

Also discussed at trac http://trac.xbmc.org/ticket/15045

@jmarshallnz for a quick look
