### PR TITLE
videolibrary: by default sort movies inside a set by year and ascending

### DIFF
--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -287,12 +287,17 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
         const CViewState *viewState = CViewStateSettings::Get().Get("videonavtitles");
         if (params.GetSetId() > -1)
+        {
           SetSortMethod(SortByYear);
+          SetSortOrder(SortOrderAscending);
+        }
         else
+        {
           SetSortMethod(viewState->m_sortDescription);
+          SetSortOrder(viewState->m_sortDescription.sortOrder);
+        }
 
         SetViewAsControl(viewState->m_viewMode);
-        SetSortOrder(viewState->m_sortDescription.sortOrder);
       }
       break;
       case NODE_TYPE_TITLE_MUSICVIDEOS:


### PR DESCRIPTION
I've noticed that by default movie sets are always sorted by year but the sort order depends on the sort order of the current sort order of the movie listing so if the movie listing is sorted by descending rating the movies inside a set are sorted by descending year. IMO that makes absolutely no sense. Therefore I changed the default sort order for movies inside a set to always be ascending unless the user manually changes it.

@jmarshallnz: your thoughts?
