### PR TITLE
Fixes and code update for CPUInfo

### DIFF
--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -26,11 +26,11 @@
 #if defined(TARGET_DARWIN)
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#if defined(__ppc__) || defined (TARGET_DARWIN_IOS)
+#include <mach-o/arch.h>
+#endif // defined(__ppc__) || defined (TARGET_DARWIN_IOS)
 #ifdef TARGET_DARWIN_OSX
 #include "osx/smc.h"
-#ifdef __ppc__
-#include <mach-o/arch.h>
-#endif
 #endif
 #endif
 
@@ -120,7 +120,7 @@ CCPUInfo::CCPUInfo(void)
       m_cpuCount = 1;
 
   // The model.
-#ifdef __ppc__
+#if defined(__ppc__) || defined (TARGET_DARWIN_IOS)
   const NXArchInfo *info = NXGetLocalArchInfo();
   if (info != NULL)
     m_cpuModel = info->description;

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -479,15 +479,9 @@ int CCPUInfo::getUsedPercentage()
   idleTicks -= m_idleTicks;
   ioTicks -= m_ioTicks;
 
-#ifdef TARGET_WINDOWS
-  if(userTicks + systemTicks == 0)
-    return m_lastUsedPercentage;
-  int result = (int) (double(userTicks + systemTicks - idleTicks) * 100.0 / double(userTicks + systemTicks) + 0.5);
-#else
   if(userTicks + niceTicks + systemTicks + idleTicks + ioTicks == 0)
     return m_lastUsedPercentage;
   int result = (int) (double(userTicks + niceTicks + systemTicks) * 100.0 / double(userTicks + niceTicks + systemTicks + idleTicks + ioTicks) + 0.5);
-#endif
 
   m_userTicks += userTicks;
   m_niceTicks += niceTicks;
@@ -633,21 +627,13 @@ bool CCPUInfo::readProcStat(unsigned long long& user, unsigned long long& nice,
   FILETIME idleTime;
   FILETIME kernelTime;
   FILETIME userTime;
-  ULARGE_INTEGER ulTime;
-  unsigned long long coreUser, coreSystem, coreIdle;
-  GetSystemTimes( &idleTime, &kernelTime, &userTime );
-  ulTime.HighPart = userTime.dwHighDateTime;
-  ulTime.LowPart = userTime.dwLowDateTime;
-  user = coreUser = ulTime.QuadPart;
+  if (GetSystemTimes(&idleTime, &kernelTime, &userTime) == 0)
+    return false;
 
-  ulTime.HighPart = kernelTime.dwHighDateTime;
-  ulTime.LowPart = kernelTime.dwLowDateTime;
-  system = coreSystem = ulTime.QuadPart;
-
-  ulTime.HighPart = idleTime.dwHighDateTime;
-  ulTime.LowPart = idleTime.dwLowDateTime;
-  idle = coreIdle = ulTime.QuadPart;
-
+  idle = (uint64_t(idleTime.dwHighDateTime) << 32) + uint64_t(idleTime.dwLowDateTime);
+  // returned "kernelTime" includes "idleTime"
+  system = (uint64_t(kernelTime.dwHighDateTime) << 32) + uint64_t(kernelTime.dwLowDateTime) - idle;
+  user = (uint64_t(userTime.dwHighDateTime) << 32) + uint64_t(userTime.dwLowDateTime);
   nice = 0;
   io = 0;
 
@@ -676,12 +662,12 @@ bool CCPUInfo::readProcStat(unsigned long long& user, unsigned long long& nice,
         }
       }
       else
-        curCore.m_fPct = (double(coreUser + coreSystem - coreIdle) * 100.0) / double(coreUser + coreSystem); // use CPU average as fallback
+        curCore.m_fPct = double(m_lastUsedPercentage); // use CPU average as fallback
     }
   }
   else
     for (std::map<int, CoreInfo>::iterator it = m_cores.begin(); it != m_cores.end(); ++it)
-      it->second.m_fPct = (double(coreUser + coreSystem - coreIdle) * 100.0) / double(coreUser + coreSystem); // use CPU average as fallback
+      it->second.m_fPct = double(m_lastUsedPercentage); // use CPU average as fallback
 #elif defined(TARGET_FREEBSD)
   long *cptimes;
   size_t len;


### PR DESCRIPTION
First commit contain some fixes and simplifications for win32 CPU load calculations.
Second commit is fix for CPU identification on iOS as requested by @Memphiz.
