### PR TITLE
ScraperParser::Clean: use "UTF-8" instead of GetSearchStringEncoding()

### DIFF
--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -512,10 +512,10 @@ void CScraperParser::Clean(std::string& strDirty)
     {
       strBuffer = strDirty.substr(i+14,i2-i-14);
       std::wstring wbuffer;
-      g_charsetConverter.toW(strBuffer,wbuffer,GetSearchStringEncoding());
+      g_charsetConverter.utf8ToW(strBuffer, wbuffer, false, false, false);
       std::wstring wConverted;
       HTML::CHTMLUtil::ConvertHTMLToW(wbuffer,wConverted);
-      g_charsetConverter.fromW(wConverted,strBuffer,GetSearchStringEncoding());
+      g_charsetConverter.wToUTF8(wConverted, strBuffer, false);
       StringUtils::Trim(strBuffer);
       ConvertJSON(strBuffer);
       strDirty.replace(i, i2-i+14, strBuffer);


### PR DESCRIPTION
as everything is converted to "UTF-8" on input.
Currently code detects encoding of any incoming data and convert everything to UTF-8 **before** any processing.

Can be backported to Gotham.
