### PR TITLE
[osx] - for osx shortcuts look at the unicode character instead of the k...

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -421,7 +421,16 @@ bool CWinEventsSDL::ProcessOSXShortcuts(SDL_Event& event)
 
   if (cmd && event.key.type == SDL_KEYDOWN)
   {
-    switch(event.key.keysym.sym)
+    char keysymbol = event.key.keysym.sym;
+
+    // if the unicode is in the ascii range
+    // use this instead for getting the real
+    // character based on the used keyboard layout
+    // see http://lists.libsdl.org/pipermail/sdl-libsdl.org/2004-May/043716.html
+    if (!(event.key.keysym.unicode & 0xff80))
+      keysymbol = event.key.keysym.unicode;
+
+    switch(keysymbol)
     {
     case SDLK_q:  // CMD-q to quit
       if (!g_application.m_bStop)


### PR DESCRIPTION
...eysymbol if possible - fixes #15328

This fixes wrong shortcuts when using non qwerty layouts (like dvorak).

Gotham material if there is the aim for 13.3
