### PR TITLE
[testsuite] - Remove unnecessary inclusion of filesystem/NFSFile.h

### DIFF
--- a/xbmc/filesystem/test/TestRarFile.cpp
+++ b/xbmc/filesystem/test/TestRarFile.cpp
@@ -22,7 +22,7 @@
 #ifdef HAS_FILESYSTEM_RAR
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "filesystem/NFSFile.h"
+#include "URL.h"
 #include "utils/URIUtils.h"
 #include "FileItem.h"
 #include "test/TestUtils.h"


### PR DESCRIPTION
Relates to issue #15356

I went over the code, and as far as I can tell this actually has no dependency upon filesystem/NFSFile.h and instead is dependant upon "URL.h" which NFSFile included.

@Memphiz requesting review as you have handled this issue so far.
