### PR TITLE
[pvr] fix open add timer dialog in timer window

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -308,7 +308,7 @@ std::string CPVRTimerInfoTag::GetStatus() const
 {
   std::string strReturn = g_localizeStrings.Get(305);
   CSingleLock lock(m_critSection);
-  if (m_strFileNameAndPath == "pvr://timers/add.timer")
+  if (URIUtils::PathEquals(m_strFileNameAndPath, "pvr://timers/addtimer/"))
     strReturn = g_localizeStrings.Get(19026);
   else if (m_state == PVR_TIMER_STATE_CANCELLED || m_state == PVR_TIMER_STATE_ABORTED)
     strReturn = g_localizeStrings.Get(13106);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -403,7 +403,7 @@ bool CPVRTimers::GetDirectory(const std::string& strPath, CFileItemList &items) 
   {
     bool bRadio = (dirs.at(2) == "radio");
 
-    CFileItemPtr item(new CFileItem("pvr://timers/add.timer", true));
+    CFileItemPtr item(new CFileItem("pvr://timers/addtimer/", true));
     item->SetLabel(g_localizeStrings.Get(19026));
     item->SetLabelPreformated(true);
     item->SortsOnTop();

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -66,7 +66,7 @@ void CGUIWindowPVRTimers::GetContextButtons(int itemNumber, CContextButtons &but
 
   /* Check for a empty file item list, means only a
      file item with the name "Add timer..." is present */
-  if (pItem->GetPath() == "pvr://timers/add.timer")
+  if (URIUtils::PathEquals(pItem->GetPath(), "pvr://timers/addtimer/"))
   {
     buttons.Add(CONTEXT_BUTTON_ADD, 19056);             /* new timer */
   }
@@ -294,7 +294,7 @@ bool CGUIWindowPVRTimers::ActionShowTimer(CFileItem *item)
   /* Check if "Add timer..." entry is pressed by OK, if yes
      create a new timer and open settings dialog, otherwise
      open settings for selected timer entry */
-  if (item->GetPath() == "pvr://timers/add.timer")
+  if (URIUtils::PathEquals(item->GetPath(), "pvr://timers/addtimer/"))
   {
     bReturn = ShowNewTimerDialog();
   }


### PR DESCRIPTION
After changing the special item 'Add timer...' to be a folder (to always stay on top of the list) the path comparison fails, because the path now ends with a slash.

@jmarshallnz same for the timer window :/ .. i don't validate the functionality after changed to folder.
