### PR TITLE
make must die

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,3 +1,5 @@
 #!/bin/sh
-BOOTSTRAP_STANDALONE=1 make -f bootstrap.mk &&
-BOOTSTRAP_STANDALONE=1 make -f codegenerator.mk
+MAKE=make
+[ "`uname`" = "FreeBSD" ] && MAKE=gmake
+BOOTSTRAP_STANDALONE=1 $MAKE -f bootstrap.mk &&
+BOOTSTRAP_STANDALONE=1 $MAKE -f codegenerator.mk

--- a/codegenerator.mk
+++ b/codegenerator.mk
@@ -73,7 +73,7 @@ $(SWIG):
 
 $(GENERATED_JSON): $(JSON_BUILDER)
 	@echo Jsonbuilder: $(JSON_BUILDER)
-	make -C $(INTERFACES_DIR)/json-rpc $(notdir $@)
+	$(MAKE) -C $(INTERFACES_DIR)/json-rpc $(notdir $@)
 
 $(JSON_BUILDER):
 ifeq ($(BOOTSTRAP_FROM_DEPENDS), yes)
@@ -81,5 +81,5 @@ ifeq ($(BOOTSTRAP_FROM_DEPENDS), yes)
 	@false
 else
 #build json builder - ".." because makefile is in the parent dir of "bin"
-	make -C $(abspath $(dir $@)..)
+	$(MAKE) -C $(abspath $(dir $@)..)
 endif

--- a/tools/TexturePacker/Makefile.in
+++ b/tools/TexturePacker/Makefile.in
@@ -31,7 +31,7 @@ all: $(TARGET)
 
 $(TARGET): $(SRCS) @abs_top_srcdir@/xbmc/guilib/XBTF.h
 # TexturePacker run native on build system, build it with native tools
-	make -C @abs_top_srcdir@/lib/libsquish/ libsquish-native.so
+	$(MAKE) -C @abs_top_srcdir@/lib/libsquish/ libsquish-native.so
 	$(CXX_FOR_BUILD) $(CXXFLAGS_FOR_BUILD) $(DEFINES) $(NATIVE_ARCH) $(SRCS) $(LDFLAGS_FOR_BUILD) -o $(TARGET)
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -46,10 +46,10 @@ DISTCLEAN_FILES=DllPaths_generated.h CompileInfo.cpp
 all: $(SRCS) $(LIB)
 
 CompileInfo.cpp: ../version.txt CompileInfo.cpp.in GitRevision
-	make -f gen-compileinfo.mk
+	$(MAKE) -f gen-compileinfo.mk
 
 GitRevision:
-	make -f gen-compileinfo.mk GitRevision
+	$(MAKE) -f gen-compileinfo.mk GitRevision
 
 include @abs_top_srcdir@/Makefile.include
 -include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))


### PR DESCRIPTION
On FreeBSD, we use gmake (gnu make) instead of make command. So properly use $(MAKE) variable in alll Makefiles.
And detect FreeBSD in bootstrap shell script to use the proper command.
