### PR TITLE
[POSIX] fix mount regexp on FreeBSD

### DIFF
--- a/xbmc/linux/PosixMountProvider.cpp
+++ b/xbmc/linux/PosixMountProvider.cpp
@@ -38,7 +38,7 @@ void CPosixMountProvider::GetDrives(VECSOURCES &drives)
   std::vector<std::string> result;
 
   CRegExp reMount;
-#if defined(TARGET_DARWIN)
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
   reMount.RegComp("on (.+) \\(([^,]+)");
 #else
   reMount.RegComp("on (.+) type ([^ ]+)");


### PR DESCRIPTION
same as OSX
