### PR TITLE
[RFC] Subtitle cycle

### DIFF
--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -570,7 +570,7 @@
 				<texturenofocus border="25,5,25,5">SubMenuBack-MiddleNF.png</texturenofocus>
 				<pulseonselect>false</pulseonselect>
 				<label>209</label>
-				<onclick>NextSubtitle</onclick>
+				<onclick>CycleSubtitle</onclick>
 				<visible>VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled</visible>
 			</control>
 			<control type="radiobutton" id="404">

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -200,6 +200,8 @@
 #define ACTION_CHAPTER_OR_BIG_STEP_FORWARD       97 // Goto the next chapter, if not available perform a big step forward
 #define ACTION_CHAPTER_OR_BIG_STEP_BACK          98 // Goto the previous chapter, if not available perform a big step back
 
+#define ACTION_CYCLE_SUBTITLE         99 // switch to next subtitle of movie, but will not enable/disable the subtitles. Can be used in videoFullScreen.xml window id=2005
+
 #define ACTION_MOUSE_START            100
 #define ACTION_MOUSE_LEFT_CLICK       100
 #define ACTION_MOUSE_RIGHT_CLICK      101

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -88,6 +88,7 @@ static const ActionMapping actions[] =
         {"osd"               , ACTION_SHOW_OSD},
         {"showsubtitles"     , ACTION_SHOW_SUBTITLES},
         {"nextsubtitle"      , ACTION_NEXT_SUBTITLE},
+        {"cyclesubtitle"     , ACTION_CYCLE_SUBTITLE},
         {"codecinfo"         , ACTION_SHOW_CODEC},
         {"nextpicture"       , ACTION_NEXT_PICTURE},
         {"previouspicture"   , ACTION_PREV_PICTURE},

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -86,6 +86,7 @@ bool CPlayerController::OnAction(const CAction &action)
       }
 
       case ACTION_NEXT_SUBTITLE:
+      case ACTION_CYCLE_SUBTITLE:
       {
         if (g_application.m_pPlayer->GetSubtitleCount() == 0)
           return true;
@@ -98,12 +99,15 @@ bool CPlayerController::OnAction(const CAction &action)
           if (++currentSub >= g_application.m_pPlayer->GetSubtitleCount())
           {
             currentSub = 0;
-            g_application.m_pPlayer->SetSubtitleVisible(false);
-            currentSubVisible = false;
+            if (action.GetID() == ACTION_NEXT_SUBTITLE)
+            {
+              g_application.m_pPlayer->SetSubtitleVisible(false);
+              currentSubVisible = false;
+            }
           }
           g_application.m_pPlayer->SetSubtitle(currentSub);
         }
-        else
+        else if (action.GetID() == ACTION_NEXT_SUBTITLE)
         {
           g_application.m_pPlayer->SetSubtitleVisible(true);
         }


### PR DESCRIPTION
Next ;) This replaces #4931 which in turn replaces #4030.

> This is a RFC for http://forum.xbmc.org/showthread.php?tid=183437 so to get a bit more eyes on the namings etc.
> 
> Some considerations
> 1) This is very quickly thrown together and I will test it more before final PR
> 2) This PR does not include keymaps being changed (as they should most likely have CycleSubtitle)
> 3) Should we perhaps quick return when only one subtitle is available.
> 
> As an extention to 3) we should perhaps add so skins can hide the "Next subtitle" button when its only one available?
