### PR TITLE
Proper support for "unsorted" behaviour

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2427,7 +2427,9 @@ msgctxt "#570"
 msgid "Date added"
 msgstr ""
 
+#. Sort By: <sort method>
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/utils/SortUtils.cpp
 msgctxt "#571"
 msgid "Default"
 msgstr ""

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1668,7 +1668,7 @@ void CFileItemList::Add(const CFileItemPtr &pItem)
   }
 }
 
-void CFileItemList::AddFront(const CFileItemPtr &pItem, int itemPosition)
+void CFileItemList::Insert(const CFileItemPtr &pItem, int itemPosition)
 {
   CSingleLock lock(m_lock);
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -644,6 +644,7 @@ void CFileItem::ToSortable(SortItem &sortable, Field field) const
   case FieldProgramCount: sortable[FieldProgramCount] = m_iprogramCount; break;
   case FieldBitrate:      sortable[FieldBitrate] = m_dwSize; break;
   case FieldTitle:        sortable[FieldTitle] = m_strTitle; break;
+  case FieldPosition:     sortable[FieldPosition] = m_iPosition; break;
   // If there's ever a need to convert more properties from CGUIListItem it might be
   // worth to make CGUIListItem  implement ISortable as well and call it from here
   default: break;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -461,6 +461,7 @@ public:
   std::string m_strLockCode;
   int m_iHasLock; // 0 - no lock 1 - lock, but unlocked 2 - locked
   int m_iBadPwdCount;
+  unsigned int m_iPosition;
 
 private:
   /*! \brief initialize all members of this class (not CGUIListItem members) to default values.

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -547,7 +547,7 @@ public:
   void Clear();
   void ClearItems();
   void Add(const CFileItemPtr &pItem);
-  void AddFront(const CFileItemPtr &pItem, int itemPosition);
+  void Insert(const CFileItemPtr &pItem, int itemPosition);
   void Remove(CFileItem* pItem);
   void Remove(int iItem);
   CFileItemPtr Get(int iItem);

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -476,7 +476,7 @@ void CPlayListPlayer::SetShuffle(int iPlaylist, bool bYesNo, bool bNotify /* = f
     int iOrder = -1;
     CPlayList &playlist = GetPlaylist(iPlaylist);
     if (m_iCurrentSong >= 0 && m_iCurrentSong < playlist.size())
-      iOrder = playlist[m_iCurrentSong]->m_iprogramCount;
+      iOrder = playlist[m_iCurrentSong]->m_iPosition;
 
     // shuffle or unshuffle as necessary
     if (bYesNo)

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -1466,11 +1466,11 @@ void CGUIAddonWindow::AddItem(CFileItemPtr fileItem, int itemPosition)
   }
   else if (itemPosition <  -1 &&  !(itemPosition-1 < m_vecItems->Size()))
   {
-    m_vecItems->AddFront(fileItem,0);
+    m_vecItems->Insert(fileItem, 0);
   }
   else
   {
-    m_vecItems->AddFront(fileItem,itemPosition);
+    m_vecItems->Insert(fileItem, itemPosition);
   }
   m_viewControl.SetItems(*m_vecItems);
   UpdateButtons();

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -350,9 +350,10 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
     {
       CFileItemPtr pItem(new CFileItem(".."));
       pItem->SetPath(m_history.GetParentPath());
+      pItem->SetSpecialSort(SortSpecialOnTop);
       pItem->m_bIsFolder = true;
       pItem->m_bIsShareOrDrive = false;
-      items.Insert(pItem, 0);
+      items.Add(pItem);
     }
 
   }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -352,7 +352,7 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory,
       pItem->SetPath(m_history.GetParentPath());
       pItem->m_bIsFolder = true;
       pItem->m_bIsShareOrDrive = false;
-      items.AddFront(pItem, 0);
+      items.Insert(pItem, 0);
     }
 
   }

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -381,9 +381,10 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
       {
         CFileItemPtr pItem(new CFileItem(".."));
         pItem->SetPath(strParentPath);
+        pItem->SetSpecialSort(SortSpecialOnTop);
         pItem->m_bIsFolder = true;
         pItem->m_bIsShareOrDrive = false;
-        items.Insert(pItem, 0);
+        items.Add(pItem);
       }
     }
     else
@@ -392,9 +393,10 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
       // add parent path to the virtual directory
       CFileItemPtr pItem(new CFileItem(".."));
       pItem->SetPath("");
+      pItem->SetSpecialSort(SortSpecialOnTop);
       pItem->m_bIsShareOrDrive = false;
       pItem->m_bIsFolder = true;
-      items.Insert(pItem, 0);
+      items.Add(pItem);
       strParentPath = "";
     }
 

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -383,7 +383,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
         pItem->SetPath(strParentPath);
         pItem->m_bIsFolder = true;
         pItem->m_bIsShareOrDrive = false;
-        items.AddFront(pItem, 0);
+        items.Insert(pItem, 0);
       }
     }
     else
@@ -394,7 +394,7 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
       pItem->SetPath("");
       pItem->m_bIsShareOrDrive = false;
       pItem->m_bIsFolder = true;
-      items.AddFront(pItem, 0);
+      items.Insert(pItem, 0);
       strParentPath = "";
     }
 

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -135,11 +135,11 @@ bool CLibraryDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       item->SetLabel(label);
       if (!icon.empty() && g_TextureManager.HasTexture(icon))
         item->SetIconImage(icon);
-      item->m_iprogramCount = order;
       items.Add(item);
+      item->m_iPosition = order;
     }
   }
-  items.Sort(SortByPlaylistOrder, SortOrderAscending);
+  items.Sort(SortByUnsorted, SortOrderAscending);
   return true;
 }
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -360,7 +360,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
     if (g_advancedSettings.m_bMusicLibraryAllItemsOnBottom)
       items.Add(pItem);
     else
-      items.AddFront(pItem, (items.Size() > 0 && items[0]->IsParentFolder()) ? 1 : 0);
+      items.Insert(pItem, (items.Size() > 0 && items[0]->IsParentFolder()) ? 1 : 0);
   }
 }
 

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -55,7 +55,6 @@ bool CPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     CFileItemPtr item = playlist[i];
     item->SetProperty("playlistposition", i);
     item->SetProperty("playlisttype", playlistTyp);
-    //item->m_iprogramCount = i; // the programCount is set as items are added!
     items.Add(item);
   }
 

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -53,7 +53,6 @@ namespace XFILE
       for (int i = 0; i < (int)playlist.size(); ++i)
       {
         CFileItemPtr item = playlist[i];
-        item->m_iprogramCount = i;  // hack for playlist order
         items.Add(item);
       }
     }

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -330,7 +330,7 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const s
       }
     case SORT_METHOD_UNSORTED:
       {
-        dir->m_listItems->AddSortMethod(SortByNone, 571, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByUnsorted, 571, LABEL_MASKS("%T", label2Mask));
         break;
       }
     case SORT_METHOD_NONE:

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -285,13 +285,6 @@ namespace XFILE
     if (items.Size() > 1 && !group.empty())
       items.Sort(SortByLabel, SortOrderAscending, SortAttributeIgnoreArticle);
 
-    // go through and set the playlist order
-    for (int i = 0; i < items.Size(); i++)
-    {
-      CFileItemPtr item = items[i];
-      item->m_iprogramCount = i;  // hack for playlist order
-    }
-
     if (playlist.GetType() == "mixed")
       return success || success2;
     else if (playlist.GetType() == "musicvideos")

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -287,6 +287,8 @@ namespace XBMCAddon
             item->GetVideoInfoTag()->m_iTrack = strtol(value.c_str(), NULL, 10);
           else if (key == "count")
             item->m_iprogramCount = strtol(value.c_str(), NULL, 10);
+          else if (key == "position")
+            item->m_iPosition = strtol(value.c_str(), NULL, 10);
           else if (key == "rating")
             item->GetVideoInfoTag()->m_fRating = (float)strtod(value.c_str(), NULL);
           else if (key == "size")
@@ -412,6 +414,8 @@ namespace XBMCAddon
             item->GetMusicInfoTag()->SetTrackNumber(strtol(value.c_str(), NULL, 10));
           else if (key == "count")
             item->m_iprogramCount = strtol(value.c_str(), NULL, 10);
+          else if (key == "position")
+            item->m_iPosition = strtol(value.c_str(), NULL, 10);
           else if (key == "size")
             item->m_dwSize = (int64_t)strtoll(value.c_str(), NULL, 10);
           else if (key == "duration")
@@ -478,6 +482,8 @@ namespace XBMCAddon
 
           if (key == "count")
             item->m_iprogramCount = strtol(value.c_str(), NULL, 10);
+          else if (key == "position")
+            item->m_iPosition = strtol(value.c_str(), NULL, 10);
           else if (key == "size")
             item->m_dwSize = (int64_t)strtoll(value.c_str(), NULL, 10);
           else if (key == "title")

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -178,11 +178,11 @@ namespace XBMCAddon
           }
           else if (position <  -1 &&  !(position*-1 < A(m_vecItems)->Size()))
           {
-            A(m_vecItems)->AddFront(fileItem,0);
+            A(m_vecItems)->Insert(fileItem, 0);
           }
           else
           {
-            A(m_vecItems)->AddFront(fileItem,position);
+            A(m_vecItems)->Insert(fileItem, position);
           }
           A(m_viewControl).SetItems(*(A(m_vecItems)));
           A(UpdateButtons());

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3499,8 +3499,6 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const Filter &fi
       {
         CFileItemPtr item(new CFileItem);
         GetFileItemFromDataset(record, item.get(), musicUrl);
-        // HACK for sorting by database returned order
-        item->m_iprogramCount = ++count;
         items.Add(item);
       }
       catch (...)

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -466,13 +466,10 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
     }
     else if (pItem->GetLabel() == "") // pls labels come in preformatted
     {
-      // FIXME: get the position of the item in the playlist
-      //        currently it is hacked into m_iprogramCount
-
       // No music info and it's not CDDA so we'll just show the filename
       CStdString str;
       str = CUtil::GetTitleFromPath(pItem->GetPath());
-      str = StringUtils::Format("%02.2i. %s ", pItem->m_iprogramCount, str.c_str());
+      str = StringUtils::Format("%02.2i. %s ", pItem->m_iPosition, str.c_str());
       pItem->SetLabel(str);
     }
   }

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -82,9 +82,9 @@ void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
   if (iPosition < 0 || iPosition >= iOldSize)
     iPosition = iOldSize;
   if (iOrder < 0 || iOrder >= iOldSize)
-    item->m_iprogramCount = iOldSize;
+    item->m_iPosition = iOldSize;
   else
-    item->m_iprogramCount = iOrder;
+    item->m_iPosition = iOrder;
 
   // videodb files are not supported by the filesystem as yet
   if (item->IsVideoDb())
@@ -100,7 +100,7 @@ void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
   // set 'IsPlayable' property - needed for properly handling plugin:// URLs
   item->SetProperty("IsPlayable", true);
 
-  //CLog::Log(LOGDEBUG,"%s item:(%02i/%02i)[%s]", __FUNCTION__, iPosition, item->m_iprogramCount, item->GetPath().c_str());
+  //CLog::Log(LOGDEBUG,"%s item:(%02i/%02i)[%s]", __FUNCTION__, iPosition, item->m_iPosition, item->GetPath().c_str());
   if (iPosition == iOldSize)
     m_vecItems.push_back(item);
   else
@@ -187,10 +187,10 @@ void CPlayList::DecrementOrder(int iOrder)
   while (it != m_vecItems.end())
   {
     CFileItemPtr item = *it;
-    if (item->m_iprogramCount > iOrder)
+    if (item->m_iPosition > iOrder)
     {
-      //CLog::Log(LOGDEBUG,"%s fixing item at order %i", __FUNCTION__, item->m_iprogramCount);
-      item->m_iprogramCount--;
+      //CLog::Log(LOGDEBUG,"%s fixing item at order %i", __FUNCTION__, item->m_iPosition);
+      item->m_iPosition--;
     }
     ++it;
   }
@@ -206,10 +206,10 @@ void CPlayList::IncrementOrder(int iPosition, int iOrder)
   while (it != m_vecItems.end())
   {
     CFileItemPtr item = *it;
-    if (item->m_iprogramCount >= iOrder)
+    if (item->m_iPosition >= iOrder)
     {
-      //CLog::Log(LOGDEBUG,"%s fixing item at order %i", __FUNCTION__, item->m_iprogramCount);
-      item->m_iprogramCount++;
+      //CLog::Log(LOGDEBUG,"%s fixing item at order %i", __FUNCTION__, item->m_iPosition);
+      item->m_iPosition++;
     }
     ++it;
   }
@@ -283,7 +283,7 @@ struct SSortPlayListItem
 {
   static bool PlaylistSort(const CFileItemPtr &left, const CFileItemPtr &right)
   {
-    return (left->m_iprogramCount <= right->m_iprogramCount);
+    return (left->m_iPosition <= right->m_iPosition);
   }
 };
 
@@ -310,7 +310,7 @@ void CPlayList::Remove(const std::string& strFileName)
     CFileItemPtr item = *it;
     if (item->GetPath() == strFileName)
     {
-      iOrder = item->m_iprogramCount;
+      iOrder = item->m_iPosition;
       it = m_vecItems.erase(it);
       AnnounceRemove(position);
       //CLog::Log(LOGDEBUG,"PLAYLIST, removing item at order %i", iPos);
@@ -328,7 +328,7 @@ int CPlayList::FindOrder(int iOrder) const
 {
   for (int i = 0; i < size(); i++)
   {
-    if (m_vecItems[i]->m_iprogramCount == iOrder)
+    if (m_vecItems[i]->m_iPosition == iOrder)
       return i;
   }
   return -1;
@@ -340,7 +340,7 @@ void CPlayList::Remove(int position)
   int iOrder = -1;
   if (position >= 0 && position < (int)m_vecItems.size())
   {
-    iOrder = m_vecItems[position]->m_iprogramCount;
+    iOrder = m_vecItems[position]->m_iPosition;
     m_vecItems.erase(m_vecItems.begin() + position);
   }
   DecrementOrder(iOrder);
@@ -397,8 +397,8 @@ bool CPlayList::Swap(int position1, int position2)
   if (!IsShuffled())
   {
     // swap the ordinals before swapping the items!
-    //CLog::Log(LOGDEBUG,"PLAYLIST swapping items at orders (%i, %i)",m_vecItems[position1]->m_iprogramCount,m_vecItems[position2]->m_iprogramCount);
-    std::swap(m_vecItems[position1]->m_iprogramCount, m_vecItems[position2]->m_iprogramCount);
+    //CLog::Log(LOGDEBUG,"PLAYLIST swapping items at orders (%i, %i)",m_vecItems[position1]->m_iPosition,m_vecItems[position2]->m_iPosition);
+    std::swap(m_vecItems[position1]->m_iPosition, m_vecItems[position2]->m_iPosition);
   }
 
   // swap the items

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -521,7 +521,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel(CGUIMessage &message)
             channel->SetProperty("ClientName", g_localizeStrings.Get(19209));
             channel->SetProperty("ParentalLocked", false);
 
-            m_channelItems->AddFront(channel, m_iSelected);
+            m_channelItems->Insert(channel, m_iSelected);
             m_viewControl.SetItems(*m_channelItems);
             Renumber();
           }

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -229,7 +229,7 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
       if(pItem->m_dateTime < results->Get(i)->m_dateTime)
         pItem->m_dateTime = results->Get(i)->m_dateTime;
     }
-    results->Insert(pItem, 0);
+    results->Add(pItem);
   }
 }
 

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -229,7 +229,7 @@ void CPVRRecordings::GetSubDirectories(const std::string &strBase, CFileItemList
       if(pItem->m_dateTime < results->Get(i)->m_dateTime)
         pItem->m_dateTime = results->Get(i)->m_dateTime;
     }
-    results->AddFront(pItem, 0);
+    results->Insert(pItem, 0);
   }
 }
 

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -149,36 +149,36 @@ TEST(TestFileItemList, PositionAfterAdd)
   EXPECT_EQ(1, items.Get(1)->m_iPosition);
 }
 
-TEST(TestFileItemList, PositionAfterAddFront)
+TEST(TestFileItemList, PositionAfterInsert)
 {
   CFileItemList items;
 
-  // simple AddFront() to index 0
-  items.AddFront(CFileItemPtr(new CFileItem()), 0);
+  // simple Insert() to index 0
+  items.Insert(CFileItemPtr(new CFileItem()), 0);
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
   items.Clear();
 
-  // AddFront() to index 5 (even though there are not 5 items in the list)
-  items.AddFront(CFileItemPtr(new CFileItem()), 5);
+  // Insert() to index 5 (even though there are not 5 items in the list)
+  items.Insert(CFileItemPtr(new CFileItem()), 5);
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
   items.Clear();
 
-  // AddFront() to index -5 (even though there are not 5 items in the list)
-  items.AddFront(CFileItemPtr(new CFileItem()), -5);
+  // Insert() to index -5 (even though there are not 5 items in the list)
+  items.Insert(CFileItemPtr(new CFileItem()), -5);
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
   items.Clear();
 
-  // AddFront() to index 0 moving the existing item to index 1
+  // Insert() to index 0 moving the existing item to index 1
   items.Add(CFileItemPtr(new CFileItem("first")));
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
-  items.AddFront(CFileItemPtr(new CFileItem("second")), 0);
+  items.Insert(CFileItemPtr(new CFileItem("second")), 0);
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
   EXPECT_STREQ("second", items.Get(0)->GetLabel().c_str());
   EXPECT_EQ(1, items.Get(1)->m_iPosition);
   EXPECT_STREQ("first", items.Get(1)->GetLabel().c_str());
 
-  // AddFront() to index 1 leaving the existing item at index 0 and moving the item from index 1 to index 2
-  items.AddFront(CFileItemPtr(new CFileItem("third")), 1);
+  // Insert() to index 1 leaving the existing item at index 0 and moving the item from index 1 to index 2
+  items.Insert(CFileItemPtr(new CFileItem("third")), 1);
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
   EXPECT_STREQ("second", items.Get(0)->GetLabel().c_str());
   EXPECT_EQ(1, items.Get(1)->m_iPosition);
@@ -186,8 +186,8 @@ TEST(TestFileItemList, PositionAfterAddFront)
   EXPECT_EQ(2, items.Get(2)->m_iPosition);
   EXPECT_STREQ("first", items.Get(2)->GetLabel().c_str());
 
-  // AddFront() to index -1 leaving the existing items at index 0 and 1 and moving the item from index 2 to index 3
-  items.AddFront(CFileItemPtr(new CFileItem("fourth")), -1);
+  // Insert() to index -1 leaving the existing items at index 0 and 1 and moving the item from index 2 to index 3
+  items.Insert(CFileItemPtr(new CFileItem("fourth")), -1);
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
   EXPECT_STREQ("second", items.Get(0)->GetLabel().c_str());
   EXPECT_EQ(1, items.Get(1)->m_iPosition);
@@ -197,8 +197,8 @@ TEST(TestFileItemList, PositionAfterAddFront)
   EXPECT_EQ(3, items.Get(3)->m_iPosition);
   EXPECT_STREQ("first", items.Get(3)->GetLabel().c_str());
 
-  // AddFront() to index -4 moving the item from indexes 1-3 to indexes 2-4
-  items.AddFront(CFileItemPtr(new CFileItem("fifth")), -4);
+  // Insert() to index -4 moving the item from indexes 1-3 to indexes 2-4
+  items.Insert(CFileItemPtr(new CFileItem("fifth")), -4);
   EXPECT_EQ(0, items.Get(0)->m_iPosition);
   EXPECT_STREQ("fifth", items.Get(0)->GetLabel().c_str());
   EXPECT_EQ(1, items.Get(1)->m_iPosition);

--- a/xbmc/utils/DatabaseUtils.h
+++ b/xbmc/utils/DatabaseUtils.h
@@ -59,6 +59,7 @@ typedef enum {
   FieldVirtualFolder,
   FieldRandom,
   FieldDateTaken,
+  FieldPosition,
 
   // fields retrievable from the database
   FieldId,

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -56,6 +56,11 @@ string ArrayToString(SortAttribute attributes, const CVariant &variant, const st
   return "";
 }
 
+string ByUnsorted(SortAttribute attributes, const SortItem &values)
+{
+  return values.at(FieldPosition).asString();
+}
+
 string ByLabel(SortAttribute attributes, const SortItem &values)
 {
   if (attributes & SortAttributeIgnoreArticle)
@@ -555,6 +560,7 @@ map<SortBy, SortUtils::SortPreparator> fillPreparators()
   preparators[SortByChannel]                  = ByChannel;
   preparators[SortByChannelNumber]            = ByChannelNumber;
   preparators[SortByDateTaken]                = ByDateTaken;
+  preparators[SortByUnsorted]                 = ByUnsorted;
 
   return preparators;
 }
@@ -628,6 +634,7 @@ map<SortBy, Fields> fillSortingFields()
   sortingFields[SortByChannel].insert(FieldChannelName);
   sortingFields[SortByChannelNumber].insert(FieldChannelNumber);
   sortingFields[SortByDateTaken].insert(FieldDateTaken);
+  sortingFields[SortByUnsorted].insert(FieldPosition);
   sortingFields.insert(pair<SortBy, Fields>(SortByRandom, Fields()));
 
   return sortingFields;
@@ -841,6 +848,7 @@ const sort_map table[] = {
   { SortByChannel,                  SORT_METHOD_CHANNEL_NUMBER,               SortAttributeNone,          549 },
   { SortByDateTaken,                SORT_METHOD_DATE_TAKEN,                   SortAttributeIgnoreFolders, 577 },
   { SortByNone,                     SORT_METHOD_NONE,                         SortAttributeNone,          16018 },
+  { SortByUnsorted,                 SORT_METHOD_UNSORTED,                     SortAttributeIgnoreFolders, 571 },
   // the following have no corresponding SORT_METHOD_*
   { SortByAlbumType,                SORT_METHOD_NONE,                         SortAttributeNone,          564 },
   { SortByVotes,                    SORT_METHOD_NONE,                         SortAttributeNone,          205 },

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -182,8 +182,7 @@ string ByProgramCount(SortAttribute attributes, const SortItem &values)
 
 string ByPlaylistOrder(SortAttribute attributes, const SortItem &values)
 {
-  // TODO: Playlist order is hacked into program count variable (not nice, but ok until 2.0)
-  return ByProgramCount(attributes, values);
+  return ByUnsorted(attributes, values);
 }
 
 string ByGenre(SortAttribute attributes, const SortItem &values)
@@ -600,7 +599,7 @@ map<SortBy, Fields> fillSortingFields()
   sortingFields[SortByVotes].insert(FieldVotes);
   sortingFields[SortByTop250].insert(FieldTop250);
   sortingFields[SortByProgramCount].insert(FieldProgramCount);
-  sortingFields[SortByPlaylistOrder].insert(FieldProgramCount);
+  sortingFields[SortByPlaylistOrder].insert(FieldPosition);
   sortingFields[SortByEpisodeNumber].insert(FieldEpisodeNumber);
   sortingFields[SortByEpisodeNumber].insert(FieldSeason);
   sortingFields[SortByEpisodeNumber].insert(FieldEpisodeNumberSpecialSort);

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -92,7 +92,8 @@ typedef enum {
   SortByRandom,
   SortByChannel,
   SortByChannelNumber,
-  SortByDateTaken
+  SortByDateTaken,
+  SortByUnsorted
 } SortBy;
 
 typedef struct SortDescription {

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1477,12 +1477,12 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPt
     CStdString strClear = StringUtils::Format(g_localizeStrings.Get(20467).c_str(), currentSetLabel.c_str());
     CFileItemPtr clearItem(new CFileItem(strClear));
     clearItem->GetVideoInfoTag()->m_iDbId = -1; // -1 will be used to clear set
-    listItems.AddFront(clearItem, 0);
+    listItems.Insert(clearItem, 0);
     // add keep current set item
     CStdString strKeep = StringUtils::Format(g_localizeStrings.Get(20469).c_str(), currentSetLabel.c_str());
     CFileItemPtr keepItem(new CFileItem(strKeep));
     keepItem->GetVideoInfoTag()->m_iDbId = currentSetId;
-    listItems.AddFront(keepItem, 1);
+    listItems.Insert(keepItem, 1);
   }
 
   CGUIDialogSelect *dialog = (CGUIDialogSelect *)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -683,7 +683,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
     pItem->SetPath(strParentPath);
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
-    items.AddFront(pItem, 0);
+    items.Insert(pItem, 0);
   }
 
   int iWindow = GetID();
@@ -1792,7 +1792,7 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
     pItem->SetPath(m_history.GetParentPath());
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
-    m_vecItems->AddFront(pItem, 0);
+    m_vecItems->Insert(pItem, 0);
   }
 
   // and update our view control + buttons

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -681,9 +681,10 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(strParentPath);
+    pItem->SetSpecialSort(SortSpecialOnTop);
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
-    items.Insert(pItem, 0);
+    items.Add(pItem);
   }
 
   int iWindow = GetID();
@@ -1790,9 +1791,10 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(m_history.GetParentPath());
+    pItem->SetSpecialSort(SortSpecialOnTop);
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
-    m_vecItems->Insert(pItem, 0);
+    m_vecItems->Add(pItem);
   }
 
   // and update our view control + buttons

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -472,9 +472,10 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(m_rootDir.IsSource(strDirectory) ? "" : strParentPath);
+    pItem->SetSpecialSort(SortSpecialOnTop);
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
-    m_vecItems[iList]->Insert(pItem, 0);
+    m_vecItems[iList]->Add(pItem);
   }
 
   m_strParentPath[iList] = (m_rootDir.IsSource(strDirectory) ? "" : strParentPath);

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -474,7 +474,7 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
     pItem->SetPath(m_rootDir.IsSource(strDirectory) ? "" : strParentPath);
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
-    m_vecItems[iList]->AddFront(pItem, 0);
+    m_vecItems[iList]->Insert(pItem, 0);
   }
 
   m_strParentPath[iList] = (m_rootDir.IsSource(strDirectory) ? "" : strParentPath);


### PR DESCRIPTION
This is an initial approach at properly handling sorting the items in a list by the original order they were added to the list. Right now we are abusing CFileItem::m_iprogramCount (what is that one used for anyway?) for this all over the place.

Furthermore the old SORT_METHOD_UNSORTED available to plugins is broken (see http://trac.xbmc.org/ticket/10252) as it is translated to SortByNone which simply does nothing (i.e. keep the items in a list sorted in the same order as the previous sort order which can be anything). Plugins can work around that by properly setting m_iprogramCount and using SORT_METHOD_PLAYLIST but it requires quite a bit of extra work and the knowledge that it's actually required.

Therefore I've added a new member CFileItem::m_iPosition which is automatically set in a CFileItem when it is added to a CFileItemList and updated whenever the items in the list change.

I wasn't sure if we could move some places in the code that use the m_iprogramCount and SortByPlaylist workaround because the sort order might be stored in the database so switching from SortByPlaylist to SortByUnsorted might result in unexpected behaviour with stored views.

Is this something we want or do we want to keep using the m_iprogramCount workaround (and maybe just remove the comments about it being a hack)? Does anyone know if there's an actual use case to CFileItem::m_iprogramCount?
