### PR TITLE
[Fix] Browse into UDF image files.

### DIFF
--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -44,6 +44,7 @@ bool CUDFDirectory::GetDirectory(const CURL& url,
   CURL url2(url);
   if (!url2.IsProtocol("udf"))
   { // path to an image
+    url2.Reset();
     url2.SetProtocol("udf");
     url2.SetHostName(url.Get());
   }
@@ -54,7 +55,7 @@ bool CUDFDirectory::GetDirectory(const CURL& url,
   URIUtils::AddSlashAtEnd(strSub);
 
   udf25 udfIsoReader;
-  if(!udfIsoReader.Open(url.GetHostName().c_str()))
+  if(!udfIsoReader.Open(url2.GetHostName().c_str()))
      return false;
 
   udf_dir_t *dirp = udfIsoReader.OpenDir(strSub.c_str());


### PR DESCRIPTION
@jmarshallnz I think it has to do with the curl changes, but not sure. I guess `strSub` should be the relative path, i.e., everything after `*.extension`, at least a test with `""` and with `"/"` worked.

This does not fix the problem, but only a part of it. (Sorry that I misuse it as a bug ticket)
