### PR TITLE
Finer grained updates of video database

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -171,5 +171,11 @@ namespace JSONRPC
       CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE, g_windowManager.GetActiveWindow());
       g_windowManager.SendThreadMessage(message);
     }
+    static inline void NotifyItemUpdated(const CVideoInfoTag &info)
+    {
+      CFileItemPtr msgItem(new CFileItem(info));
+      CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);
+      g_windowManager.SendThreadMessage(message);
+    }
   };
 }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -492,13 +492,10 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const std::string &method, ITransp
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   std::set<std::string> removedArtwork;
-  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork);
+  std::set<std::string> updatedDetails;
+  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
-  // we need to manually remove tags/taglinks for now because they aren't replaced
-  // due to scrapers not supporting them
-  videodatabase.RemoveTagsFromItem(id, MediaTypeMovie);
-
-  if (videodatabase.SetDetailsForMovie(infos.m_strFileNameAndPath, infos, artwork, id) <= 0)
+  if (videodatabase.UpdateDetailsForMovie(id, infos, artwork, updatedDetails) <= 0)
     return InternalError;
 
   if (!videodatabase.RemoveArtForItem(infos.m_iDbId, MediaTypeMovie, removedArtwork))
@@ -539,7 +536,8 @@ JSONRPC_STATUS CVideoLibrary::SetMovieSetDetails(const std::string &method, ITra
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   std::set<std::string> removedArtwork;
-  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork);
+  std::set<std::string> updatedDetails;
+  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   if (videodatabase.SetDetailsForMovieSet(infos, artwork, id) <= 0)
     return InternalError;
@@ -571,7 +569,8 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const std::string &method, ITrans
   videodatabase.GetTvShowSeasonArt(infos.m_iDbId, seasonArt);
 
   std::set<std::string> removedArtwork;
-  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork);
+  std::set<std::string> updatedDetails;
+  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   // we need to manually remove tags/taglinks for now because they aren't replaced
   // due to scrapers not supporting them
@@ -608,7 +607,8 @@ JSONRPC_STATUS CVideoLibrary::SetSeasonDetails(const std::string &method, ITrans
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
   std::set<std::string> removedArtwork;
-  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork);
+  std::set<std::string> updatedDetails;
+  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   if (videodatabase.SetDetailsForSeason(infos, artwork, infos.m_iIdShow, id) <= 0)
     return InternalError;
@@ -651,7 +651,8 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const std::string &method, ITran
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   std::set<std::string> removedArtwork;
-  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork);
+  std::set<std::string> updatedDetails;
+  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   if (videodatabase.SetDetailsForEpisode(infos.m_strFileNameAndPath, infos, artwork, tvshowid, id) <= 0)
     return InternalError;
@@ -697,7 +698,8 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const std::string &method, IT
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   std::set<std::string> removedArtwork;
-  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork);
+  std::set<std::string> updatedDetails;
+  UpdateVideoTag(parameterObject, infos, artwork, removedArtwork, updatedDetails);
 
   // we need to manually remove tags/taglinks for now because they aren't replaced
   // due to scrapers not supporting them
@@ -983,7 +985,16 @@ void CVideoLibrary::UpdateResumePoint(const CVariant &parameterObject, CVideoInf
   }
 }
 
-void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork)
+void CVideoLibrary::UpdateVideoTagField(const CVariant& parameterObject, const std::string& fieldName, std::vector<std::string>& fieldValue, std::set<std::string>& updatedDetails)
+{
+  if (ParameterNotNull(parameterObject, fieldName))
+  {
+    CopyStringArray(parameterObject[fieldName], fieldValue);
+    updatedDetails.insert(fieldName);
+  }
+}
+
+void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string> &updatedDetails)
 {
   if (ParameterNotNull(parameterObject, "title"))
     details.m_strTitle = parameterObject["title"].asString();
@@ -991,20 +1002,16 @@ void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTa
     details.m_playCount = (int)parameterObject["playcount"].asInteger();
   if (ParameterNotNull(parameterObject, "runtime"))
     details.m_duration = (int)parameterObject["runtime"].asInteger();
-  if (ParameterNotNull(parameterObject, "director"))
-    CopyStringArray(parameterObject["director"], details.m_director);
-  if (ParameterNotNull(parameterObject, "studio"))
-    CopyStringArray(parameterObject["studio"], details.m_studio);
+  UpdateVideoTagField(parameterObject, "director", details.m_director, updatedDetails);
+  UpdateVideoTagField(parameterObject, "studio", details.m_studio, updatedDetails);
   if (ParameterNotNull(parameterObject, "year"))
     details.m_iYear = (int)parameterObject["year"].asInteger();
   if (ParameterNotNull(parameterObject, "plot"))
     details.m_strPlot = parameterObject["plot"].asString();
   if (ParameterNotNull(parameterObject, "album"))
     details.m_strAlbum = parameterObject["album"].asString();
-  if (ParameterNotNull(parameterObject, "artist"))
-    CopyStringArray(parameterObject["artist"], details.m_artist);
-  if (ParameterNotNull(parameterObject, "genre"))
-    CopyStringArray(parameterObject["genre"], details.m_genre);
+  UpdateVideoTagField(parameterObject, "artist", details.m_artist, updatedDetails);
+  UpdateVideoTagField(parameterObject, "genre", details.m_genre, updatedDetails);
   if (ParameterNotNull(parameterObject, "track"))
     details.m_iTrack = (int)parameterObject["track"].asInteger();
   if (ParameterNotNull(parameterObject, "rating"))
@@ -1035,10 +1042,8 @@ void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTa
     details.m_strTagLine = parameterObject["tagline"].asString();
   if (ParameterNotNull(parameterObject, "plotoutline"))
     details.m_strPlotOutline = parameterObject["plotoutline"].asString();
-  if (ParameterNotNull(parameterObject, "writer"))
-    CopyStringArray(parameterObject["writer"], details.m_writingCredits);
-  if (ParameterNotNull(parameterObject, "country"))
-    CopyStringArray(parameterObject["country"], details.m_country);
+  UpdateVideoTagField(parameterObject, "writer", details.m_writingCredits, updatedDetails);
+  UpdateVideoTagField(parameterObject, "country", details.m_country, updatedDetails);
   if (ParameterNotNull(parameterObject, "top250"))
     details.m_iTop250 = (int)parameterObject["top250"].asInteger();
   if (ParameterNotNull(parameterObject, "sorttitle"))
@@ -1046,22 +1051,33 @@ void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTa
   if (ParameterNotNull(parameterObject, "episodeguide"))
     details.m_strEpisodeGuide = parameterObject["episodeguide"].asString();
   if (ParameterNotNull(parameterObject, "set"))
+  {
     details.m_strSet = parameterObject["set"].asString();
-  if (ParameterNotNull(parameterObject, "showlink"))
-    CopyStringArray(parameterObject["showlink"], details.m_showLink);
+    updatedDetails.insert("set");
+  }
+  UpdateVideoTagField(parameterObject, "showlink", details.m_showLink, updatedDetails);
+  UpdateVideoTagField(parameterObject, "tag", details.m_tags, updatedDetails);
   if (ParameterNotNull(parameterObject, "thumbnail"))
+  {
     artwork["thumb"] = parameterObject["thumbnail"].asString();
+    updatedDetails.insert("art.altered");
+  }
   if (ParameterNotNull(parameterObject, "fanart"))
+  {
     artwork["fanart"] = parameterObject["fanart"].asString();
-  if (ParameterNotNull(parameterObject, "tag"))
-    CopyStringArray(parameterObject["tag"], details.m_tags);
+    updatedDetails.insert("art.altered");
+  }
+
   if (ParameterNotNull(parameterObject, "art"))
   {
     CVariant art = parameterObject["art"];
     for (CVariant::const_iterator_map artIt = art.begin_map(); artIt != art.end_map(); artIt++)
     {
       if (artIt->second.isString() && !artIt->second.asString().empty())
+      {
         artwork[artIt->first] = CTextureUtils::UnwrapImageURL(artIt->second.asString());
+        updatedDetails.insert("art.altered");
+      }
       else if (artIt->second.isNull())
       {
         artwork.erase(artIt->first);

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -511,7 +511,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const std::string &method, ITransp
 
   UpdateResumePoint(parameterObject, infos, videodatabase);
 
-  CJSONRPCUtils::NotifyItemUpdated();
+  CJSONRPCUtils::NotifyItemUpdated(infos);
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -75,7 +75,8 @@ namespace JSONRPC
     static JSONRPC_STATUS GetAdditionalEpisodeDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
     static JSONRPC_STATUS GetAdditionalMusicVideoDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase, bool limit = true);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
-    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork);
+    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag &details, std::map<std::string, std::string> &artwork, std::set<std::string> &removedArtwork, std::set<std::string>& updatedDetails);
+    static void UpdateVideoTagField(const CVariant& parameterObject, const std::string& fieldName, std::vector<std::string>& fieldValue, std::set<std::string>& updatedDetails);
     static void UpdateResumePoint(const CVariant &parameterObject, CVideoInfoTag &details, CVideoDatabase &videodatabase);
   };
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4143,14 +4143,18 @@ void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, cons
     if (artType.find('.') != string::npos)
       return;
 
-    CStdString sql = PrepareSQL("SELECT art_id FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
+    CStdString sql = PrepareSQL("SELECT art_id,url FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str());
     m_pDS->query(sql.c_str());
     if (!m_pDS->eof())
     { // update
       int artId = m_pDS->fv(0).get_asInt();
+      std::string oldUrl = m_pDS->fv(1).get_asString();
       m_pDS->close();
-      sql = PrepareSQL("UPDATE art SET url='%s' where art_id=%d", url.c_str(), artId);
-      m_pDS->exec(sql.c_str());
+      if (oldUrl != url)
+      {
+        sql = PrepareSQL("UPDATE art SET url='%s' where art_id=%d", url.c_str(), artId);
+        m_pDS->exec(sql.c_str());
+      }
     }
     else
     { // insert

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1604,6 +1604,38 @@ void CVideoDatabase::RemoveFromLinkTable(const char *table, const char *firstFie
   }
 }
 
+void CVideoDatabase::UpdateLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values)
+{
+  std::string sql = PrepareSQL("delete from %slink%s where id%s=%i", field.c_str(), mediaType.c_str(), mediaType.c_str(), mediaId);
+  m_pDS->exec(sql);
+
+  for (std::vector<std::string>::const_iterator i = values.begin(); i != values.end(); ++i)
+  {
+    if (!i->empty())
+    {
+      int idValue = AddToTable(field, "id" + field, "str" + field, *i);
+      if (idValue > -1)
+        AddToLinkTable((field + "link" + mediaType).c_str(), ("id" + field).c_str(), idValue, ("id" + mediaType).c_str(), mediaId);
+    }
+  }
+}
+
+void CVideoDatabase::UpdateActorLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values)
+{
+  std::string sql = PrepareSQL("delete from %slink%s where id%s=%i", field.c_str(), mediaType.c_str(), mediaType.c_str(), mediaId);
+  m_pDS->exec(sql);
+
+  for (std::vector<std::string>::const_iterator i = values.begin(); i != values.end(); ++i)
+  {
+    if (!i->empty())
+    {
+      int idValue = AddActor(*i, "");
+      if (idValue > -1)
+        AddToLinkTable((field + "link" + mediaType).c_str(), ("id" + field).c_str(), idValue, ("id" + mediaType).c_str(), mediaId);
+    }
+  }
+}
+
 //****Tags****
 void CVideoDatabase::AddTagToItem(int idMovie, int idTag, const std::string &type)
 {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -485,6 +485,8 @@ public:
   bool SetSingleValue(const std::string &table, const std::string &fieldName, const std::string &strValue,
                       const std::string &conditionName = "", int conditionValue = -1);
 
+  int UpdateDetailsForMovie(int idMovie, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
+
   void DeleteMovie(int idMovie, bool bKeepId = false);
   void DeleteMovie(const CStdString& strFilenameAndPath, bool bKeepId = false);
   void DeleteTvShow(int idTvShow, bool bKeepId = false);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -805,6 +805,8 @@ protected:
   void AddLinkToActor(const char *table, int actorID, const char *secondField, int secondID, const CStdString &role, int order);
   void AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
   void RemoveFromLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
+  void UpdateLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
+  void UpdateActorLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
 
   void AddCast(int idMedia, const char *table, const char *field, const std::vector<SActorInfo> &cast);
   void AddArtistToMusicVideo(int lMVideo, int idArtist);


### PR DESCRIPTION
Here's a simplified version of #4301 that basically only touches the link tables when updating a movie if the link tables need altering.

Note that I have not done extensive (read any) testing.  @MilhouseVH I believe you have an 'easy' way to test this out?

The UpdateLinkTable functions make some assumptions about the link table setup naming, which is correct for the ones I'm using now, but as if we wish to extend to music videos, we'll need to add another param, as the musicvideo table uses idMVideo instead of idMusicVideo.  Though, a better plan might be to just fix up that inconsistency, which is worked around in other places.

The tag link table is also different ofc.  At some point we might want to look at unifying the link tables to this format, at the same time ensuring we have the same naming pattern where possible.  Obviously the actors table is one we can't incorporate using the same functionality, however.

Assuming this is acceptable, I'll look at extending to shows, episodes and music videos.

One other thing @cg110 had that I don't here is that once things are sped up, the notification firing from JSON-RPC to refresh the UI is then problematic.  An idea to fix that is to add a delay to it - not sure how easy that would be - no doubt we have some "delay this function" code somewhere...
