### PR TITLE
[pvr] fix wrong usage of SortsOnTop() which does not set the special sorting

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -406,7 +406,7 @@ bool CPVRTimers::GetDirectory(const std::string& strPath, CFileItemList &items) 
     CFileItemPtr item(new CFileItem("pvr://timers/addtimer/", true));
     item->SetLabel(g_localizeStrings.Get(19026));
     item->SetLabelPreformated(true);
-    item->SortsOnTop();
+    item->SetSpecialSort(SortSpecialOnTop);
     items.Add(item);
 
     CSingleLock lock(m_critSection);

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -135,7 +135,7 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
   CFileItemPtr item(new CFileItem("pvr://guide/searchresults/search/", true));
   item->SetLabel(g_localizeStrings.Get(19140));
   item->SetLabelPreformated(true);
-  item->SortsOnTop();
+  item->SetSpecialSort(SortSpecialOnTop);
   items.Add(item);
 
   if (m_bSearchConfirmed)


### PR DESCRIPTION
@Montellese thanks for the hint i've thought it set the special sorting for the file item.
