### PR TITLE
CLog update (alternative)

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -1113,6 +1113,9 @@
 		AE84CB5A15A5B8A600A3810E /* TagLibVFSStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84CB5915A5B8A600A3810E /* TagLibVFSStream.cpp */; };
 		AE89ACA61621DAB800E17DBC /* DVDDemuxBXA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE89ACA41621DAB800E17DBC /* DVDDemuxBXA.cpp */; };
 		AEC0083115ACAC6E0099888C /* TagLoaderTagLib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AEC0083015ACAC6E0099888C /* TagLoaderTagLib.cpp */; };
+		B542632B197D353B00726998 /* PosixInterfaceForCLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5426329197D353B00726998 /* PosixInterfaceForCLog.cpp */; };
+		B542632C197D353B00726998 /* PosixInterfaceForCLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5426329197D353B00726998 /* PosixInterfaceForCLog.cpp */; };
+		B542632D197D353B00726998 /* PosixInterfaceForCLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5426329197D353B00726998 /* PosixInterfaceForCLog.cpp */; };
 		C807114D135DB5CC002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807114B135DB5CC002F601B /* InputOperations.cpp */; };
 		C84828C0156CFCD8005A996F /* PVRClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8482874156CFCD8005A996F /* PVRClient.cpp */; };
 		C84828C1156CFCD8005A996F /* PVRClients.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8482876156CFCD8005A996F /* PVRClients.cpp */; };
@@ -4646,6 +4649,8 @@
 		AEC0083015ACAC6E0099888C /* TagLoaderTagLib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TagLoaderTagLib.cpp; sourceTree = "<group>"; };
 		AEC0083315ACAC7C0099888C /* TagLoaderTagLib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TagLoaderTagLib.h; sourceTree = "<group>"; };
 		B542632E19917D3500726998 /* params_check_macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = params_check_macros.h; sourceTree = "<group>"; };
+		B5426329197D353B00726998 /* PosixInterfaceForCLog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PosixInterfaceForCLog.cpp; sourceTree = "<group>"; };
+		B542632A197D353B00726998 /* PosixInterfaceForCLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PosixInterfaceForCLog.h; sourceTree = "<group>"; };
 		C807114B135DB5CC002F601B /* InputOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputOperations.cpp; sourceTree = "<group>"; };
 		C807114C135DB5CC002F601B /* InputOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InputOperations.h; sourceTree = "<group>"; };
 		C8482874156CFCD8005A996F /* PVRClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRClient.cpp; sourceTree = "<group>"; };
@@ -7928,6 +7933,15 @@
 			path = media;
 			sourceTree = "<group>";
 		};
+		B5426323197D2AB300726998 /* posix */ = {
+			isa = PBXGroup;
+			children = (
+				B5426329197D353B00726998 /* PosixInterfaceForCLog.cpp */,
+				B542632A197D353B00726998 /* PosixInterfaceForCLog.h */,
+			);
+			path = posix;
+			sourceTree = "<group>";
+		};
 		C6859E96029091FE04C91782 /* docs */ = {
 			isa = PBXGroup;
 			children = (
@@ -9811,6 +9825,7 @@
 				AE4E87A617354C4A00D15206 /* XSLTUtils.h */,
 				18B7C9811294385F009E7A26 /* XMLUtils.cpp */,
 				18B7C9821294385F009E7A26 /* XMLUtils.h */,
+				B5426323197D2AB300726998 /* posix */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -10886,6 +10901,7 @@
 				E38E22800D25F9FE00618676 /* MusicInfoScanner.cpp in Sources */,
 				E38E22970D25F9FE00618676 /* NfoFile.cpp in Sources */,
 				E38E22A00D25F9FE00618676 /* PartyModeManager.cpp in Sources */,
+				B542632B197D353B00726998 /* PosixInterfaceForCLog.cpp in Sources */,
 				E38E22A10D25F9FE00618676 /* Picture.cpp in Sources */,
 				E38E22A20D25F9FE00618676 /* PictureInfoLoader.cpp in Sources */,
 				E38E22A30D25F9FE00618676 /* PictureInfoTag.cpp in Sources */,
@@ -11971,6 +11987,7 @@
 				DFF0F19817528350002DA3A4 /* DVDPlayerAudio.cpp in Sources */,
 				DFF0F19917528350002DA3A4 /* DVDPlayerSubtitle.cpp in Sources */,
 				DFF0F19A17528350002DA3A4 /* DVDPlayerTeletext.cpp in Sources */,
+				B542632D197D353B00726998 /* PosixInterfaceForCLog.cpp in Sources */,
 				DFF0F19B17528350002DA3A4 /* DVDPlayerVideo.cpp in Sources */,
 				DFF0F19C17528350002DA3A4 /* DVDStreamInfo.cpp in Sources */,
 				DFF0F19D17528350002DA3A4 /* DVDTSCorrection.cpp in Sources */,
@@ -13206,6 +13223,7 @@
 				E499122B174E5D6100741B6D /* qry_dat.cpp in Sources */,
 				E499122C174E5D6100741B6D /* sqlitedataset.cpp in Sources */,
 				E499122D174E5D6800741B6D /* Epg.cpp in Sources */,
+				B542632C197D353B00726998 /* PosixInterfaceForCLog.cpp in Sources */,
 				E499122E174E5D6800741B6D /* EpgContainer.cpp in Sources */,
 				E499122F174E5D6800741B6D /* EpgDatabase.cpp in Sources */,
 				E4991230174E5D6800741B6D /* EpgInfoTag.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -983,6 +983,7 @@
     <ClInclude Include="..\..\xbmc\utils\Utf8Utils.h" />
     <ClInclude Include="..\..\xbmc\utils\uXstrings.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
+    <ClInclude Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.h" />
     <ClInclude Include="..\..\xbmc\utils\XSLTUtils.h" />
     <ClInclude Include="..\..\xbmc\video\FFmpegVideoDecoder.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\swig.h" />
@@ -1126,6 +1127,7 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\utils\Utf8Utils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Vector.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.cpp" />
     <ClCompile Include="..\..\xbmc\utils\XSLTUtils.cpp" />
     <ClCompile Include="..\..\xbmc\video\PlayerController.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoThumbLoader.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -984,6 +984,7 @@
     <ClInclude Include="..\..\xbmc\utils\uXstrings.h" />
     <ClInclude Include="..\..\xbmc\utils\Vector.h" />
     <ClInclude Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.h" />
+    <ClInclude Include="..\..\xbmc\utils\win32\Win32Log.h" />
     <ClInclude Include="..\..\xbmc\utils\XSLTUtils.h" />
     <ClInclude Include="..\..\xbmc\video\FFmpegVideoDecoder.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\swig.h" />
@@ -1128,6 +1129,7 @@
     <ClCompile Include="..\..\xbmc\utils\Utf8Utils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Vector.cpp" />
     <ClCompile Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\win32\Win32Log.cpp" />
     <ClCompile Include="..\..\xbmc\utils\XSLTUtils.cpp" />
     <ClCompile Include="..\..\xbmc\video\PlayerController.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoThumbLoader.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -319,6 +319,9 @@
     <Filter Include="filesystem\win32">
       <UniqueIdentifier>{901e970d-b3b4-463a-93ab-9af30c6a1139}</UniqueIdentifier>
     </Filter>
+    <Filter Include="utils\win32">
+      <UniqueIdentifier>{3adbba6a-6fbf-4192-b215-108d94bde1e0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -3061,6 +3064,9 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\filesystem\win32\Win32SMBDirectory.cpp">
       <Filter>filesystem\win32</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.cpp">
+      <Filter>utils\win32</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -5985,6 +5991,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\params_check_macros.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.h">
+      <Filter>utils\win32</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3068,6 +3068,9 @@
     <ClCompile Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.cpp">
       <Filter>utils\win32</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\win32\Win32Log.cpp">
+      <Filter>utils\win32</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5993,6 +5996,9 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\win32\Win32InterfaceForCLog.h">
+      <Filter>utils\win32</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\win32\Win32Log.h">
       <Filter>utils\win32</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -848,7 +848,7 @@ bool CApplication::Create()
   CLog::Log(LOGINFO, "load %s language file, from path: %s", strLanguage.c_str(), strLanguagePath.c_str());
   if (!g_localizeStrings.Load(strLanguagePath, strLanguage))
   {
-    CLog::Log(LOGFATAL, "%s: Failed to load %s language file, from path: %s", __FUNCTION__, strLanguage.c_str(), strLanguagePath.c_str());
+    CLog::LogF(LOGFATAL, "Failed to load %s language file, from path: %s", strLanguage.c_str(), strLanguagePath.c_str());
     return false;
   }
 
@@ -2367,7 +2367,7 @@ bool CApplication::OnKey(const CKey& key)
   {
     bool ret = true;
 
-    CLog::Log(LOGDEBUG, "%s: action %s [%d], toggling state of playing device", __FUNCTION__, action.GetName().c_str(), action.GetID());
+    CLog::LogF(LOGDEBUG, "action %s [%d], toggling state of playing device", action.GetName().c_str(), action.GetID());
     // do not wake up the screensaver right after switching off the playing device
     if (StringUtils::StartsWithNoCase(action.GetName(),"CECToggleState"))
       ret = CApplicationMessenger::Get().CECToggleState();
@@ -2382,7 +2382,7 @@ bool CApplication::OnKey(const CKey& key)
   // allow some keys to be processed while the screensaver is active
   if (WakeUpScreenSaverAndDPMS(processKey) && !processKey)
   {
-    CLog::Log(LOGDEBUG, "%s: %s pressed, screen saver/dpms woken up", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str());
+    CLog::LogF(LOGDEBUG, "%s pressed, screen saver/dpms woken up", g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str());
     return true;
   }
 
@@ -2396,7 +2396,7 @@ bool CApplication::OnKey(const CKey& key)
     action = CButtonTranslator::GetInstance().GetAction(iWin, key);
 
     if (!key.IsAnalogButton())
-      CLog::Log(LOGDEBUG, "%s: %s pressed, trying fullscreen info action %s", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetName().c_str());
+      CLog::LogF(LOGDEBUG, "%s pressed, trying fullscreen info action %s", g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetName().c_str());
 
     if (OnAction(action))
       return true;
@@ -2507,7 +2507,7 @@ bool CApplication::OnKey(const CKey& key)
         }
       }
 
-      CLog::Log(LOGDEBUG, "%s: %s pressed, trying keyboard action %x", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetID());
+      CLog::LogF(LOGDEBUG, "%s pressed, trying keyboard action %x", g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetID());
 
       if (OnAction(action))
         return true;
@@ -2522,7 +2522,7 @@ bool CApplication::OnKey(const CKey& key)
       action = CButtonTranslator::GetInstance().GetAction(iWin, key);
   }
   if (!key.IsAnalogButton())
-    CLog::Log(LOGDEBUG, "%s: %s pressed, action is %s", __FUNCTION__, g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetName().c_str());
+    CLog::LogF(LOGDEBUG, "%s pressed, action is %s", g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetName().c_str());
 
   return ExecuteInputAction(action);
 }
@@ -2549,12 +2549,12 @@ bool CApplication::OnAppCommand(const CAction &action)
   // handled this appcommand
   if (!appcmdaction.GetID())
   {
-    CLog::Log(LOGDEBUG, "%s: unknown appcommand %d", __FUNCTION__, appcmd);
+    CLog::LogF(LOGDEBUG, "unknown appcommand %d", appcmd);
     return false;
   }
 
   // Process the appcommand
-  CLog::Log(LOGDEBUG, "%s: appcommand %d, trying action %s", __FUNCTION__, appcmd, appcmdaction.GetName().c_str());
+  CLog::LogF(LOGDEBUG, "appcommand %d, trying action %s", appcmd, appcmdaction.GetName().c_str());
   OnAction(appcmdaction);
 
   // Always return true regardless of whether the action succeeded or not.
@@ -3139,13 +3139,13 @@ bool CApplication::ProcessMouse()
   // handled this mouse action
   if (!mouseaction.GetID())
   {
-    CLog::Log(LOGDEBUG, "%s: unknown mouse command %d", __FUNCTION__, mousekey);
+    CLog::LogF(LOGDEBUG, "unknown mouse command %d", mousekey);
     return false;
   }
 
   // Log mouse actions except for move and noop
   if (mouseaction.GetID() != ACTION_MOUSE_MOVE && mouseaction.GetID() != ACTION_NOOP)
-    CLog::Log(LOGDEBUG, "%s: trying mouse action %s", __FUNCTION__, mouseaction.GetName().c_str());
+    CLog::LogF(LOGDEBUG, "trying mouse action %s", mouseaction.GetName().c_str());
 
   // The action might not be a mouse action. For example wheel moves might
   // be mapped to volume up/down in mouse.xml. In this case we do not want
@@ -3751,18 +3751,18 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
         dbs.Close();
       }
       else
-        CLog::Log(LOGERROR, "%s - Cannot open VideoDatabase", __FUNCTION__);
+        CLog::LogF(LOGERROR, "Cannot open VideoDatabase");
     }
 
     // make sure that the selected part is within the boundaries
     if (selectedFile <= 0)
     {
-      CLog::Log(LOGWARNING, "%s - Selected part %d out of range, playing part 1", __FUNCTION__, selectedFile);
+      CLog::LogF(LOGWARNING, "Selected part %d out of range, playing part 1", selectedFile);
       selectedFile = 1;
     }
     else if (selectedFile > movieList.Size())
     {
-      CLog::Log(LOGWARNING, "%s - Selected part %d out of range, playing part %d", __FUNCTION__, selectedFile, movieList.Size());
+      CLog::LogF(LOGWARNING, "Selected part %d out of range, playing part %d", selectedFile, movieList.Size());
       selectedFile = movieList.Size();
     }
 
@@ -3939,7 +3939,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   //Is TuxBox, this should probably be moved to CTuxBoxFile
   if(item.IsTuxBox())
   {
-    CLog::Log(LOGDEBUG, "%s - TuxBox URL Detected %s",__FUNCTION__, item.GetPath().c_str());
+    CLog::LogF(LOGDEBUG, "TuxBox URL Detected %s",item.GetPath().c_str());
 
     if(g_tuxboxService.IsRunning())
       g_tuxboxService.Stop();
@@ -4099,7 +4099,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
     };
     int dMsgCount = g_windowManager.RemoveThreadMessageByMessageIds(&previousMsgsIgnoredByNewPlaying[0]);
     if (dMsgCount > 0)
-      CLog::Log(LOGDEBUG,"%s : Ignored %d playback thread messages", __FUNCTION__, dMsgCount);
+      CLog::LogF(LOGDEBUG,"Ignored %d playback thread messages", dMsgCount);
   }
 
   // We should restart the player, unless the previous and next tracks are using
@@ -4194,7 +4194,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
     // play state: none, starting; playing; stopped; ended.
     // last 3 states are set by playback callback, they are all ignored during starting,
     // but we recorded the state, here we can make up the callback for the state.
-    CLog::Log(LOGDEBUG,"%s : OpenFile succeed, play state %d", __FUNCTION__, m_ePlayState);
+    CLog::LogF(LOGDEBUG,"OpenFile succeed, play state %d", m_ePlayState);
     switch (m_ePlayState)
     {
       case PLAY_STATE_PLAYING:
@@ -4236,7 +4236,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
 void CApplication::OnPlayBackEnded()
 {
   CSingleLock lock(m_playStateMutex);
-  CLog::Log(LOGDEBUG,"%s : play state was %d, starting %d", __FUNCTION__, m_ePlayState, m_bPlaybackStarting);
+  CLog::LogF(LOGDEBUG,"play state was %d, starting %d", m_ePlayState, m_bPlaybackStarting);
   m_ePlayState = PLAY_STATE_ENDED;
   if(m_bPlaybackStarting)
     return;
@@ -4258,7 +4258,7 @@ void CApplication::OnPlayBackEnded()
 void CApplication::OnPlayBackStarted()
 {
   CSingleLock lock(m_playStateMutex);
-  CLog::Log(LOGDEBUG,"%s : play state was %d, starting %d", __FUNCTION__, m_ePlayState, m_bPlaybackStarting);
+  CLog::LogF(LOGDEBUG,"play state was %d, starting %d", m_ePlayState, m_bPlaybackStarting);
   m_ePlayState = PLAY_STATE_PLAYING;
   if(m_bPlaybackStarting)
     return;
@@ -4276,7 +4276,7 @@ void CApplication::OnPlayBackStarted()
 void CApplication::OnQueueNextItem()
 {
   CSingleLock lock(m_playStateMutex);
-  CLog::Log(LOGDEBUG,"%s : play state was %d, starting %d", __FUNCTION__, m_ePlayState, m_bPlaybackStarting);
+  CLog::LogF(LOGDEBUG,"play state was %d, starting %d", m_ePlayState, m_bPlaybackStarting);
   if(m_bPlaybackStarting)
     return;
   // informs python script currently running that we are requesting the next track
@@ -4292,7 +4292,7 @@ void CApplication::OnQueueNextItem()
 void CApplication::OnPlayBackStopped()
 {
   CSingleLock lock(m_playStateMutex);
-  CLog::Log(LOGDEBUG,"%s : play state was %d, starting %d", __FUNCTION__, m_ePlayState, m_bPlaybackStarting);
+  CLog::LogF(LOGDEBUG, "play state was %d, starting %d", m_ePlayState, m_bPlaybackStarting);
   m_ePlayState = PLAY_STATE_STOPPED;
   if(m_bPlaybackStarting)
     return;
@@ -5049,7 +5049,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr)
     {
       //At this point we have given up to translate, so even though
       //there may be insecure information, we log it.
-      CLog::Log(LOGDEBUG,"%s : Tried translating, but failed to understand %s", __FUNCTION__, in_actionStr.c_str());
+      CLog::LogF(LOGDEBUG,"Tried translating, but failed to understand %s", in_actionStr.c_str());
       return false;
     }
   }
@@ -5613,13 +5613,13 @@ void CApplication::UpdateLibraries()
 {
   if (CSettings::Get().GetBool("videolibrary.updateonstartup"))
   {
-    CLog::Log(LOGNOTICE, "%s - Starting video library startup scan", __FUNCTION__);
+    CLog::LogF(LOGNOTICE, "Starting video library startup scan");
     StartVideoScan("");
   }
 
   if (CSettings::Get().GetBool("musiclibrary.updateonstartup"))
   {
-    CLog::Log(LOGNOTICE, "%s - Starting music library startup scan", __FUNCTION__);
+    CLog::LogF(LOGNOTICE, "Starting music library startup scan");
     StartMusicScan("");
   }
 }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3875,7 +3875,6 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   {
     SaveFileState(true);
 
-    OutputDebugString("new file set audiostream:0\n");
     // Switch to default options
     CMediaSettings::Get().GetCurrentVideoSettings() = CMediaSettings::Get().GetDefaultVideoSettings();
     // see if we have saved options in the database

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -107,7 +107,7 @@ bool CCueDocument::Parse(const CStdString &strFile)
     {
       if (bCurrentFileChanged)
       {
-        OutputDebugString("Track split over multiple files, unsupported ('" + strFile + "')\n");
+        CLog::Log(LOGERROR, "Track split over multiple files, unsupported ('%s')", strFile.c_str());
         return false;
       }
 
@@ -115,7 +115,7 @@ bool CCueDocument::Parse(const CStdString &strFile)
       time = ExtractTimeFromIndex(strLine);
       if (time == -1)
       { // Error!
-        OutputDebugString("Mangled Time in INDEX 0x tag in CUE file!\n");
+        CLog::Log(LOGERROR, "Mangled Time in INDEX 0x tag in CUE file!");
         return false;
       }
       if (m_iTotalTracks > 0)  // Set the end time of the last track
@@ -198,7 +198,7 @@ bool CCueDocument::Parse(const CStdString &strFile)
   if (m_iTotalTracks >= 0)
     m_Track[m_iTotalTracks].iEndTime = 0;
   else
-    OutputDebugString("No INDEX 01 tags in CUE file!\n");
+    CLog::Log(LOGERROR, "No INDEX 01 tags in CUE file!");
   m_file.Close();
   if (m_iTotalTracks >= 0)
   {

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -54,11 +54,7 @@
 #define LOGUPNP     (1 << (LOGMASKBIT + 9))
 #define LOGCEC      (1 << (LOGMASKBIT + 10))
 
-#ifdef __GNUC__
-#define ATTRIB_LOG_FORMAT __attribute__((format(printf,3,4)))
-#else
-#define ATTRIB_LOG_FORMAT
-#endif
+#include "utils/params_check_macros.h"
 
 namespace XbmcCommons
 {
@@ -66,10 +62,9 @@ namespace XbmcCommons
   {
   public:
     virtual ~ILogger() {}
-    void Log(int loglevel, const char *format, ... ) ATTRIB_LOG_FORMAT;
+    void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM3_PRINTF_FORMAT;
 
-    virtual void log(int loglevel, const char* message) = 0;
+    virtual void log(int loglevel, IN_STRING const char* message) = 0;
   };
 }
 
-#undef ATTRIB_LOG_FORMAT

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1274,8 +1274,6 @@ extern "C"
       }
     }
 
-    OutputDebugString(szLine);
-    OutputDebugString("\n");
     CLog::Log(LOGERROR, "%s emulated function failed",  __FUNCTION__);
     return EOF;
   }
@@ -1551,8 +1549,6 @@ extern "C"
       }
     }
 
-    OutputDebugString(tmp);
-    OutputDebugString("\n");
     CLog::Log(LOGERROR, "%s emulated function failed",  __FUNCTION__);
     return strlen(tmp);
   }

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -82,7 +82,6 @@ int callback(void* res_ptr,int ncol, char** reslt,char** cols)
 static int busy_callback(void*, int busyCount)
 {
   Sleep(100);
-  OutputDebugString("SQLite collision\n");
   return 1;
 }
 

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -159,11 +159,8 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
 
   pDir = (struct iso_dirtree *)malloc(sizeof(struct iso_dirtree));
   if (!pDir)
-  {
-    OutputDebugString("out of memory");
-
     return NULL;
-  }
+
   pDir->next = NULL;
   pDir->path = NULL;
   pDir->name = NULL;
@@ -177,15 +174,12 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
 
   pCurr_dir_cache = (char*)malloc( 16*wSectorSize );
   if (!pCurr_dir_cache )
-  {
-    OutputDebugString("out of memory\n");
     return NULL;
-  }
 
   BOOL bResult = ::ReadFile( m_info.ISO_HANDLE, pCurr_dir_cache, wSectorSize, &lpNumberOfBytesRead, NULL );
   if (!bResult || lpNumberOfBytesRead != wSectorSize)
   {
-    OutputDebugString("unable to read\n");
+    CLog::Log(LOGERROR, "%s: unable to read", __FUNCTION__);
     free(pCurr_dir_cache);
     return NULL;
   }
@@ -198,15 +192,13 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
     free( pCurr_dir_cache );
     pCurr_dir_cache = (char*)malloc( 16 * from_733(isodir.size) );
     if (!pCurr_dir_cache )
-    {
-      OutputDebugString("out of memory\n");
       return NULL;
-    }
+
     ::SetFilePointer( m_info.ISO_HANDLE, wSectorSize * sector, 0, FILE_BEGIN );
     bResult = ::ReadFile( m_info.ISO_HANDLE, pCurr_dir_cache , curr_dirSize, &lpNumberOfBytesRead, NULL );
     if (!bResult || lpNumberOfBytesRead != curr_dirSize)
     {
-      OutputDebugString("unable to read\n");
+      CLog::Log(LOGERROR, "%s: unable to read", __FUNCTION__);
       free(pCurr_dir_cache);
       return NULL;
     }
@@ -220,10 +212,8 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
     {
       m_paths = (struct iso_directories *)malloc(sizeof(struct iso_directories));
       if (!m_paths )
-      {
-        OutputDebugString("out of memory\n");
         return NULL;
-      }
+
       m_paths->path = NULL;
       m_paths->dir = NULL;
       m_paths->next = NULL;
@@ -237,20 +227,15 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
   }
   m_lastpath->next = ( struct iso_directories *)malloc( sizeof( struct iso_directories ) );
   if (!m_lastpath->next )
-  {
-    OutputDebugString("out of memory\n");
     return NULL;
-  }
 
   m_lastpath = m_lastpath->next;
   m_lastpath->next = NULL;
   m_lastpath->dir = pDir;
   m_lastpath->path = (char *)malloc(strlen(path) + 1);
   if (!m_lastpath->path )
-  {
-    OutputDebugString("out of memory\n");
     return NULL;
-  }
+
   strcpy( m_lastpath->path, path );
 
   while ( 1 )
@@ -298,27 +283,20 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
 
           pFile_Pointer->next = (struct iso_dirtree *)malloc(sizeof(struct iso_dirtree));
           if (!pFile_Pointer->next)
-          {
-            OutputDebugString("out of memory\n");
             break;
-          }
+
           m_vecDirsAndFiles.push_back(pFile_Pointer->next);
           pFile_Pointer = pFile_Pointer->next;
           pFile_Pointer->next = 0;
           pFile_Pointer->dirpointer = NULL;
           pFile_Pointer->path = (char *)malloc(strlen(path) + 1);
           if (!pFile_Pointer->path)
-          {
-            OutputDebugString("out of memory");
             return NULL;
-          }
+
           strcpy( pFile_Pointer->path, path );
           pFile_Pointer->name = (char *)malloc( temp_text.length() + 1);
           if (!pFile_Pointer->name)
-          {
-            OutputDebugString("out of memory");
             return NULL;
-          }
 
           strcpy( pFile_Pointer->name , temp_text.c_str());
 #ifdef _DEBUG_OUTPUT
@@ -387,10 +365,8 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
 
           pFile_Pointer->next = (struct iso_dirtree *)malloc(sizeof(struct iso_dirtree));
           if (!pFile_Pointer->next)
-          {
-            OutputDebugString("out of memory");
             return NULL;
-          }
+
           m_vecDirsAndFiles.push_back(pFile_Pointer->next);
           pFile_Pointer = pFile_Pointer->next;
           pFile_Pointer->next = 0;
@@ -398,19 +374,13 @@ struct iso_dirtree *iso9660::ReadRecursiveDirFromSector( DWORD sector, const cha
           pFile_Pointer->path = (char *)malloc(strlen(path) + 1);
 
           if (!pFile_Pointer->path)
-          {
-            OutputDebugString("out of memory");
             return NULL;
-          }
 
           strcpy( pFile_Pointer->path, path );
           pFile_Pointer->name = (char *)malloc( temp_text.length() + 1);
 
           if (!pFile_Pointer->name)
-          {
-            OutputDebugString("out of memory");
             return NULL;
-          }
 
           strcpy( pFile_Pointer->name , temp_text.c_str());
 

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -178,8 +178,7 @@ void CTextureMap::Dump() const
   if (!m_referenceCount)
     return;   // nothing to see here
 
-  CStdString strLog = StringUtils::Format("  texture:%s has %i frames %i refcount\n", m_textureName.c_str(), m_texture.m_textures.size(), m_referenceCount);
-  OutputDebugString(strLog.c_str());
+  CLog::Log(LOGDEBUG, "%s: texture:%s has %i frames %i refcount", __FUNCTION__, m_textureName.c_str(), m_texture.m_textures.size(), m_referenceCount);
 }
 
 unsigned int CTextureMap::GetMemoryUsage() const
@@ -388,15 +387,6 @@ const CTextureArray& CGUITextureManager::Load(const CStdString& strTextureName, 
       } // of for (int iImage=0; iImage < iImages; iImage++)
     }
 
-#ifdef _DEBUG
-    int64_t end, freq;
-    end = CurrentHostCounter();
-    freq = CurrentHostFrequency();
-    char temp[200];
-    sprintf(temp, "Load %s: %.1fms%s\n", strPath.c_str(), 1000.f * (end - start) / freq, (bundle >= 0) ? " (bundled)" : "");
-    OutputDebugString(temp);
-#endif
-
     m_vecTextures.push_back(pMap);
     return pMap->GetTexture();
   } // of if (strPath.Right(4).ToLower()==".gif")
@@ -520,8 +510,7 @@ void CGUITextureManager::Cleanup()
 
 void CGUITextureManager::Dump() const
 {
-  CStdString strLog = StringUtils::Format("total texturemaps size:%i\n", m_vecTextures.size());
-  OutputDebugString(strLog.c_str());
+  CLog::Log(LOGDEBUG, "%s: total texturemaps size:%i", __FUNCTION__, m_vecTextures.size());
 
   for (int i = 0; i < (int)m_vecTextures.size(); ++i)
   {

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -758,7 +758,6 @@ bool Xcddb::queryCache( uint32_t discid )
   {
     // Got a cachehit
     char buffer[4096];
-    OutputDebugString ( "cddb local cache hit.\n" );
     file.Read(buffer, 4096);
     file.Close();
     parseData( buffer );
@@ -777,10 +776,9 @@ bool Xcddb::writeCacheFile( const char* pBuffer, uint32_t discid )
   XFILE::CFile file;
   if (file.OpenForWrite(GetCacheFile(discid), true))
   {
-    OutputDebugString ( "Current cd saved to local cddb.\n" );
-    file.Write( (void*) pBuffer, strlen( pBuffer ) + 1 );
+    const bool ret = (file.Write((void*)pBuffer, strlen(pBuffer) + 1) == strlen(pBuffer) + 1);
     file.Close();
-    return true;
+    return ret;
   }
 
   return false;

--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -132,14 +132,14 @@ std::string CNetworkInterfaceWin32::GetCurrentWirelessEssId(void)
               WlanFreeMemory((PVOID*)&pAttributes);
             }
             else
-              OutputDebugString("Can't query wlan interface\n");
+              CLog::Log(LOGERROR, "%s: Can't query wlan interface", __FUNCTION__);
           }
         }
       }
       WlanCloseHandle(&hClientHdl, NULL);
     }
     else
-      OutputDebugString("Can't open wlan handle\n");
+      CLog::Log(LOGERROR, "%s: Can't open wlan handle", __FUNCTION__);
   }
 #endif
   return result;
@@ -200,10 +200,7 @@ void CNetworkWin32::queryInterfaceList()
     free(adapterInfo);
     adapterInfo = (IP_ADAPTER_INFO *) malloc(ulOutBufLen);
     if (adapterInfo == NULL)
-    {
-      OutputDebugString("Error allocating memory needed to call GetAdaptersinfo\n");
       return;
-    }
   }
 
   if ((GetAdaptersInfo(adapterInfo, &ulOutBufLen)) == NO_ERROR)
@@ -228,20 +225,15 @@ std::vector<std::string> CNetworkWin32::GetNameServers(void)
 
   pFixedInfo = (FIXED_INFO *) malloc(sizeof (FIXED_INFO));
   if (pFixedInfo == NULL)
-  {
-    OutputDebugString("Error allocating memory needed to call GetNetworkParams\n");
     return result;
-  }
+
   ulOutBufLen = sizeof (FIXED_INFO);
   if (GetNetworkParams(pFixedInfo, &ulOutBufLen) == ERROR_BUFFER_OVERFLOW)
   {
     free(pFixedInfo);
     pFixedInfo = (FIXED_INFO *) malloc(ulOutBufLen);
     if (pFixedInfo == NULL)
-    {
-      OutputDebugString("Error allocating memory needed to call GetNetworkParams\n");
       return result;
-    }
   }
 
   if (GetNetworkParams(pFixedInfo, &ulOutBufLen) == NO_ERROR)
@@ -427,10 +419,7 @@ void CNetworkInterfaceWin32::GetSettings(NetworkAssignment& assignment, std::str
     free(adapterInfo);
     adapterInfo = (IP_ADAPTER_INFO *) malloc(ulOutBufLen);
     if (adapterInfo == NULL)
-    {
-      OutputDebugString("Error allocating memory needed to call GetAdaptersinfo\n");
       return;
-    }
   }
 
   if ((GetAdaptersInfo(adapterInfo, &ulOutBufLen)) == NO_ERROR)
@@ -500,14 +489,14 @@ void CNetworkInterfaceWin32::GetSettings(NetworkAssignment& assignment, std::str
               WlanFreeMemory((PVOID*)&pAttributes);
             }
             else
-              OutputDebugString("Can't query wlan interface\n");
+              CLog::Log(LOGERROR, "%s: Can't query wlan interface", __FUNCTION__);
           }
         }
       }
       WlanCloseHandle(&hClientHdl, NULL);
     }
     else
-      OutputDebugString("Can't open wlan handle\n");
+      CLog::Log(LOGERROR, "%s: Can't open wlan handle", __FUNCTION__);
   }
   // Todo: get the key (WlanGetProfile, CryptUnprotectData?)
 #endif

--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -48,6 +48,7 @@ extern "C"
   bool        DarwinHasVideoToolboxDecoder(void);
   int         DarwinBatteryLevel(void);
   void        DarwinSetScheduling(int message);
+  void        DarwinPrintDebugString(std::string debugString);
   bool        DarwinCFStringRefToString(CFStringRef source, std::string& destination);
   bool        DarwinCFStringRefToUTF8String(CFStringRef source, std::string& destination);
 #ifdef __cplusplus

--- a/xbmc/osx/DarwinUtils.mm
+++ b/xbmc/osx/DarwinUtils.mm
@@ -564,6 +564,12 @@ bool DarwinCFStringRefToStringWithEncoding(CFStringRef source, std::string &dest
   return true;
 }
 
+void DarwinPrintDebugString(std::string debugString)
+{
+  NSLog(@"Debug Print: %s", debugString.c_str());
+}
+
+
 bool DarwinCFStringRefToString(CFStringRef source, std::string &destination)
 {
   return DarwinCFStringRefToStringWithEncoding(source, destination, CFStringGetSystemEncoding());

--- a/xbmc/storage/IoSupport.cpp
+++ b/xbmc/storage/IoSupport.cpp
@@ -182,7 +182,7 @@ INT CIoSupport::ReadSector(HANDLE hDevice, DWORD dwSector, LPSTR lpczBuffer)
     }
   }
 
-  OutputDebugString("CD Read error\n");
+  CLog::Log(LOGERROR, "%s: CD Read error", __FUNCTION__);
   return -1;
 }
 

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -44,6 +44,7 @@ SRCS += Mime.cpp
 SRCS += Observer.cpp
 SRCS += PerformanceSample.cpp
 SRCS += PerformanceStats.cpp
+SRCS += posix/PosixInterfaceForCLog.cpp
 SRCS += POUtils.cpp
 SRCS += RecentlyAddedJob.cpp
 SRCS += RegExp.cpp

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -110,7 +110,7 @@ void CLog::Log(int loglevel, const char *format, ... )
                                                 m_repeatCount);
       fputs(strPrefix.c_str(), m_file);
       fputs(strData2.c_str(), m_file);
-      OutputDebugString(strData2);
+      PrintDebugString(strData2);
       m_repeatCount = 0;
     }
     
@@ -121,7 +121,7 @@ void CLog::Log(int loglevel, const char *format, ... )
     if (strData.empty())
       return;
     
-    OutputDebugString(strData);
+    PrintDebugString(strData);
 
     /* fixup newline alignment, number of spaces should equal prefix length */
     StringUtils::Replace(strData, "\n", LINE_ENDING"                                            ");
@@ -231,7 +231,7 @@ void CLog::SetExtraLogLevels(int level)
   m_extraLogLevels = level;
 }
 
-void CLog::OutputDebugString(const std::string& line)
+void CLog::PrintDebugString(const std::string& line)
 {
 #if defined(_DEBUG) || defined(PROFILE)
 #if defined(TARGET_WINDOWS)

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -25,7 +25,6 @@
 #include "threads/CriticalSection.h"
 #include "threads/SingleLock.h"
 #include "threads/Thread.h"
-#include "utils/StdString.h"
 #include "utils/StringUtils.h"
 #if defined(TARGET_ANDROID)
 #include "android/activity/XBMCApp.h"
@@ -63,7 +62,7 @@ void CLog::Log(int loglevel, const char *format, ... )
   CSingleLock waitLock(s_globals.critSec);
   if (IsLogLevelLogged(loglevel))
   {
-    CStdString strData;
+    std::string strData;
 
     strData.reserve(16384);
     va_list va;
@@ -78,7 +77,7 @@ void CLog::Log(int loglevel, const char *format, ... )
     }
     else if (s_globals.m_repeatCount)
     {
-      CStdString strData2 = StringUtils::Format("Previous line repeats %d times.",
+      std::string strData2 = StringUtils::Format("Previous line repeats %d times.",
                                                 s_globals.m_repeatCount);
       PrintDebugString(strData2);
       WriteLogString(s_globals.m_repeatLogLevel, strData2);
@@ -105,8 +104,8 @@ bool CLog::Init(const char* path)
   {
     // the log folder location is initialized in the CAdvancedSettings
     // constructor and changed in CApplication::Create()
-    CStdString strLogFile = StringUtils::Format("%sxbmc.log", path);
-    CStdString strLogFileOld = StringUtils::Format("%sxbmc.old.log", path);
+    std::string strLogFile = StringUtils::Format("%sxbmc.log", path);
+    std::string strLogFileOld = StringUtils::Format("%sxbmc.old.log", path);
 
 #if defined(TARGET_WINDOWS)
     // the appdata folder might be redirected to an unc share
@@ -140,13 +139,13 @@ void CLog::MemDump(char *pData, int length)
   Log(LOGDEBUG, "MEM_DUMP: Dumping from %p", pData);
   for (int i = 0; i < length; i+=16)
   {
-    CStdString strLine = StringUtils::Format("MEM_DUMP: %04x ", i);
+    std::string strLine = StringUtils::Format("MEM_DUMP: %04x ", i);
     char *alpha = pData;
     for (int k=0; k < 4 && i + 4*k < length; k++)
     {
       for (int j=0; j < 4 && i + 4*k + j < length; j++)
       {
-        CStdString strFormat = StringUtils::Format(" %02x", (unsigned char)*pData++);
+        std::string strFormat = StringUtils::Format(" %02x", (unsigned char)*pData++);
         strLine += strFormat;
       }
       strLine += " ";

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -58,6 +58,20 @@ void CLog::Log(int loglevel, const char *format, ...)
   }
 }
 
+void CLog::LogFunction(int loglevel, const char* functionName, const char* format, ...)
+{
+  if (IsLogLevelLogged(loglevel))
+  {
+    std::string fNameStr;
+    if (functionName && functionName[0])
+      fNameStr.assign(functionName).append(": ");
+    va_list va;
+    va_start(va, format);
+    LogString(loglevel, fNameStr + StringUtils::FormatV(format, va));
+    va_end(va);
+  }
+}
+
 void CLog::LogString(int logLevel, const std::string& logString)
 {
   CSingleLock waitLock(s_globals.critSec);

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -216,11 +216,7 @@ void CLog::PrintDebugString(const std::string& line)
   else
     ::OutputDebugStringA(line.c_str());
   ::OutputDebugStringW(L"\n");
-#else  // !TARGET_WINDOWS
-  ::OutputDebugString(line.c_str());
-  ::OutputDebugString("\n");
-#endif // !TARGET_WINDOWS
-#if defined(TARGET_ANDROID)
+#elif defined(TARGET_ANDROID)
   //print to adb
   CXBMCApp::android_printf("%s",line.c_str());
 #endif

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -42,7 +42,7 @@
 #define m_logLevel XBMC_GLOBAL_USE(CLog::CLogGlobals).m_logLevel
 #define m_extraLogLevels XBMC_GLOBAL_USE(CLog::CLogGlobals).m_extraLogLevels
 
-static char levelNames[][8] =
+static const char* const levelNames[] =
 {"DEBUG", "INFO", "NOTICE", "WARNING", "ERROR", "SEVERE", "FATAL", "NONE"};
 
 CLog::CLog()

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -64,7 +64,6 @@ void CLog::Log(int loglevel, const char *format, ... )
   {
     std::string strData;
 
-    strData.reserve(16384);
     va_list va;
     va_start(va, format);
     strData = StringUtils::FormatV(format,va);

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -94,11 +94,6 @@ void CLog::Log(int loglevel, const char *format, ... )
     
     PrintDebugString(strData);
 
-
-//print to adb
-#if defined(TARGET_ANDROID) && defined(_DEBUG)
-  CXBMCApp::android_printf("%s%s",strPrefix.c_str(), strData.c_str());
-#endif
     WriteLogString(loglevel, strData);
   }
 }
@@ -225,6 +220,10 @@ void CLog::PrintDebugString(const std::string& line)
   ::OutputDebugString(line.c_str());
   ::OutputDebugString("\n");
 #endif // !TARGET_WINDOWS
+#if defined(TARGET_ANDROID)
+  //print to adb
+  CXBMCApp::android_printf("%s",line.c_str());
+#endif
 #endif // defined(_DEBUG) || defined(PROFILE)
 }
 

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -36,6 +36,10 @@
 static const char* const levelNames[] =
 {"DEBUG", "INFO", "NOTICE", "WARNING", "ERROR", "SEVERE", "FATAL", "NONE"};
 
+// add 1 to level number to get index of name
+static const char* const logLevelNames[] =
+{ "LOG_LEVEL_NONE" /*-1*/, "LOG_LEVEL_NORMAL" /*0*/, "LOG_LEVEL_DEBUG" /*1*/, "LOG_LEVEL_DEBUG_FREEMEM" /*2*/ };
+
 // s_globals is used as static global with CLog global variables
 #define s_globals XBMC_GLOBAL_USE(CLog).m_globalInstance
 
@@ -167,8 +171,13 @@ void CLog::MemDump(char *pData, int length)
 void CLog::SetLogLevel(int level)
 {
   CSingleLock waitLock(s_globals.critSec);
-  s_globals.m_logLevel = level;
-  CLog::Log(LOGNOTICE, "Log level changed to %d", s_globals.m_logLevel);
+  if (level >= LOG_LEVEL_NONE && level <= LOG_LEVEL_MAX)
+  {
+    s_globals.m_logLevel = level;
+    CLog::Log(LOGNOTICE, "Log level changed to \"%s\"", logLevelNames[s_globals.m_logLevel + 1]);
+  }
+  else
+    CLog::Log(LOGERROR, "%s: Invalid log level requested: %d", __FUNCTION__, level);
 }
 
 int CLog::GetLogLevel()

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -66,6 +66,7 @@ private:
     CCriticalSection critSec;
   };
   class CLogGlobals m_globalInstance; // used as static global variable
+  static void LogString(int logLevel, const std::string& logString);
   static bool WriteLogString(int logLevel, const std::string& logString);
 };
 

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -45,6 +45,7 @@ public:
   static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
   static void MemDump(char *pData, int length);
   static bool Init(const std::string& path);
+  static void PrintDebugString(const std::string& line); // universal interface for printing debug strings
   static void SetLogLevel(int level);
   static int  GetLogLevel();
   static void SetExtraLogLevels(int level);
@@ -65,7 +66,6 @@ private:
     CCriticalSection critSec;
   };
   class CLogGlobals m_globalInstance; // used as static global variable
-  static void PrintDebugString(const std::string& line);
   static bool WriteLogString(int logLevel, const std::string& logString);
 };
 

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2014 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -20,8 +20,15 @@
  *
  */
 
-#include <stdio.h>
 #include <string>
+
+#if defined(TARGET_POSIX)
+#include "posix/PosixInterfaceForCLog.h"
+typedef class CPosixInterfaceForCLog PlatformInterfaceForCLog;
+#elif defined(TARGET_WINDOWS)
+#include "win32/Win32InterfaceForCLog.h"
+typedef class CWin32InterfaceForCLog PlatformInterfaceForCLog;
+#endif
 
 #include "commons/ilog.h"
 #include "threads/CriticalSection.h"
@@ -37,7 +44,7 @@ public:
   static void Close();
   static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
   static void MemDump(char *pData, int length);
-  static bool Init(IN_STRING const char* path);
+  static bool Init(const std::string& path);
   static void SetLogLevel(int level);
   static int  GetLogLevel();
   static void SetExtraLogLevels(int level);
@@ -47,9 +54,9 @@ private:
   class CLogGlobals
   {
   public:
-    CLogGlobals(void) : m_file(NULL), m_repeatCount(0), m_repeatLogLevel(-1), m_logLevel(LOG_LEVEL_DEBUG), m_extraLogLevels(0) {}
+    CLogGlobals(void) : m_repeatCount(0), m_repeatLogLevel(-1), m_logLevel(LOG_LEVEL_DEBUG), m_extraLogLevels(0) {}
     ~CLogGlobals() {}
-    FILE*       m_file;
+    PlatformInterfaceForCLog m_platform;
     int         m_repeatCount;
     int         m_repeatLogLevel;
     std::string m_repeatLine;

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -47,7 +47,7 @@ public:
   };
 
   CLog();
-  virtual ~CLog(void);
+  ~CLog(void);
   static void Close();
   static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
   static void MemDump(char *pData, int length);

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -59,6 +59,7 @@ private:
   };
   class CLogGlobals m_globalInstance; // used as static global variable
   static void PrintDebugString(const std::string& line);
+  static bool WriteLogString(int logLevel, const std::string& logString);
 };
 
 

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -60,7 +60,7 @@ public:
   static int  GetLogLevel();
   static void SetExtraLogLevels(int level);
 private:
-  static void OutputDebugString(const std::string& line);
+  static void PrintDebugString(const std::string& line);
 };
 
 #undef ATTRIB_LOG_FORMAT

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -41,6 +41,7 @@ public:
   static void SetLogLevel(int level);
   static int  GetLogLevel();
   static void SetExtraLogLevels(int level);
+  static bool IsLogLevelLogged(int loglevel);
 
 private:
   class CLogGlobals

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -27,11 +27,7 @@
 #include "threads/CriticalSection.h"
 #include "utils/GlobalsHandling.h"
 
-#ifdef __GNUC__
-#define ATTRIB_LOG_FORMAT __attribute__((format(printf,2,3)))
-#else
-#define ATTRIB_LOG_FORMAT
-#endif
+#include "utils/params_check_macros.h"
 
 class CLog
 {
@@ -53,7 +49,7 @@ public:
   CLog();
   virtual ~CLog(void);
   static void Close();
-  static void Log(int loglevel, const char *format, ... ) ATTRIB_LOG_FORMAT;
+  static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
   static void MemDump(char *pData, int length);
   static bool Init(const char* path);
   static void SetLogLevel(int level);
@@ -63,7 +59,6 @@ private:
   static void PrintDebugString(const std::string& line);
 };
 
-#undef ATTRIB_LOG_FORMAT
 
 namespace XbmcUtils
 {
@@ -71,7 +66,7 @@ namespace XbmcUtils
   {
   public:
     virtual ~LogImplementation() {}
-    inline virtual void log(int logLevel, const char* message) { CLog::Log(logLevel,"%s",message); }
+    inline virtual void log(int logLevel, IN_STRING const char* message) { CLog::Log(logLevel, "%s", message); }
   };
 }
 

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -43,6 +43,8 @@ public:
   ~CLog(void);
   static void Close();
   static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
+  static void LogFunction(int loglevel, IN_OPT_STRING const char* functionName, PRINTF_FORMAT_STRING const char* format, ...) PARAM3_PRINTF_FORMAT;
+#define LogF(loglevel,format,...) LogFunction((loglevel),__FUNCTION__,(format),##__VA_ARGS__)
   static void MemDump(char *pData, int length);
   static bool Init(const std::string& path);
   static void PrintDebugString(const std::string& line); // universal interface for printing debug strings

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -53,7 +53,7 @@ public:
   static void SetExtraLogLevels(int level);
   static bool IsLogLevelLogged(int loglevel);
 
-private:
+protected:
   class CLogGlobals
   {
   public:

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -32,11 +32,22 @@
 class CLog
 {
 public:
+  CLog();
+  ~CLog(void);
+  static void Close();
+  static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
+  static void MemDump(char *pData, int length);
+  static bool Init(IN_STRING const char* path);
+  static void SetLogLevel(int level);
+  static int  GetLogLevel();
+  static void SetExtraLogLevels(int level);
 
+private:
   class CLogGlobals
   {
   public:
-    CLogGlobals() : m_file(NULL), m_repeatCount(0), m_repeatLogLevel(-1), m_logLevel(LOG_LEVEL_DEBUG), m_extraLogLevels(0) {}
+    CLogGlobals(void) : m_file(NULL), m_repeatCount(0), m_repeatLogLevel(-1), m_logLevel(LOG_LEVEL_DEBUG), m_extraLogLevels(0) {}
+    ~CLogGlobals() {}
     FILE*       m_file;
     int         m_repeatCount;
     int         m_repeatLogLevel;
@@ -45,17 +56,7 @@ public:
     int         m_extraLogLevels;
     CCriticalSection critSec;
   };
-
-  CLog();
-  ~CLog(void);
-  static void Close();
-  static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
-  static void MemDump(char *pData, int length);
-  static bool Init(const char* path);
-  static void SetLogLevel(int level);
-  static int  GetLogLevel();
-  static void SetExtraLogLevels(int level);
-private:
+  class CLogGlobals m_globalInstance; // used as static global variable
   static void PrintDebugString(const std::string& line);
 };
 
@@ -70,4 +71,4 @@ namespace XbmcUtils
   };
 }
 
-XBMC_GLOBAL_REF(CLog::CLogGlobals,g_log_globals);
+XBMC_GLOBAL_REF(CLog, g_log);

--- a/xbmc/utils/posix/PosixInterfaceForCLog.cpp
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.cpp
@@ -1,0 +1,108 @@
+/*
+ *      Copyright (C) 2014 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PosixInterfaceForCLog.h"
+#include <stdio.h>
+#include <time.h>
+
+#if defined(TARGET_DARWIN)
+#include "DarwinUtils.h"
+#elif defined(TARGET_ANDROID)
+#include "android/activity/XBMCApp.h"
+#endif // TARGET_ANDROID
+
+struct FILEWRAP : public FILE
+{};
+
+
+CPosixInterfaceForCLog::CPosixInterfaceForCLog() :
+  m_file(NULL)
+{ }
+
+CPosixInterfaceForCLog::~CPosixInterfaceForCLog()
+{
+  if (m_file)
+    fclose(m_file);
+}
+
+bool CPosixInterfaceForCLog::OpenLogFile(const std::string &logFilename, const std::string &backupOldLogToFilename)
+{
+  if (m_file)
+    return false; // file was already opened
+
+  (void)remove(backupOldLogToFilename.c_str()); // if it's failed, try to continue
+  (void)rename(logFilename.c_str(), backupOldLogToFilename.c_str()); // if it's failed, try to continue
+
+  m_file = (FILEWRAP*)fopen(logFilename.c_str(), "wb");
+  if (!m_file)
+    return false; // error, can't open log file
+
+  static const unsigned char BOM[3] = { 0xEF, 0xBB, 0xBF };
+  (void)fwrite(BOM, sizeof(BOM), 1, m_file); // write BOM, ignore possible errors
+
+  return true;
+}
+
+void CPosixInterfaceForCLog::CloseLogFile()
+{
+  if (m_file)
+  {
+    fclose(m_file);
+    m_file = NULL;
+  }
+}
+
+bool CPosixInterfaceForCLog::WriteStringToLog(const std::string &logString)
+{
+  if (!m_file)
+    return false;
+
+  const bool ret = (fwrite(logString.data(), logString.size(), 1, m_file) == 1) &&
+                   (fwrite("\n", 1, 1, m_file) == 1);
+  (void)fflush(m_file);
+
+  return ret;
+}
+
+void CPosixInterfaceForCLog::PrintDebugString(const std::string &debugString)
+{
+#ifdef _DEBUG
+#if defined(TARGET_DARWIN)
+  DarwinPrintDebugString(debugString);
+#elif defined(TARGET_ANDROID)
+  //print to adb
+  CXBMCApp::android_printf("Debug Print: %s", debugString.c_str());
+#endif // TARGET_ANDROID
+#endif // _DEBUG
+}
+
+void CPosixInterfaceForCLog::GetCurrentLocalTime(int &hour, int &minute, int &second)
+{
+  time_t curTime;
+  struct tm localTime;
+  if (time(&curTime) != -1 && localtime_r(&curTime, &localTime) != NULL)
+  {
+    hour   = localTime.tm_hour;
+    minute = localTime.tm_min;
+    second = localTime.tm_sec;
+  }
+  else
+    hour = minute = second = 0;
+}

--- a/xbmc/utils/posix/PosixInterfaceForCLog.h
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.h
@@ -1,0 +1,38 @@
+#pragma once
+/*
+ *      Copyright (C) 2014 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+struct FILEWRAP; // forward declaration, wrapper for FILE
+
+class CPosixInterfaceForCLog
+{
+public:
+  CPosixInterfaceForCLog();
+  ~CPosixInterfaceForCLog();
+  bool OpenLogFile(const std::string& logFilename, const std::string& backupOldLogToFilename);
+  void CloseLogFile(void);
+  bool WriteStringToLog(const std::string& logString);
+  void PrintDebugString(const std::string& debugString);
+  static void GetCurrentLocalTime(int& hour, int& minute, int& second);
+private:
+  FILEWRAP* m_file;
+};

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -139,11 +139,7 @@ protected:
   TestRegExpLog(){}
   ~TestRegExpLog()
   {
-    /* Reset globals used by CLog after each test. */
-    g_log_globalsRef->m_file = NULL;
-    g_log_globalsRef->m_repeatCount = 0;
-    g_log_globalsRef->m_repeatLogLevel = -1;
-    g_log_globalsRef->m_logLevel = LOG_LEVEL_DEBUG;
+    CLog::Close();
   }
 };
 

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -34,11 +34,7 @@ protected:
   Testlog(){}
   ~Testlog()
   {
-    /* Reset globals used by CLog after each test. */
-    g_log_globalsRef->m_file = NULL;
-    g_log_globalsRef->m_repeatCount = 0;
-    g_log_globalsRef->m_repeatLogLevel = -1;
-    g_log_globalsRef->m_logLevel = LOG_LEVEL_DEBUG;
+    CLog::Close();
   }
 };
 

--- a/xbmc/utils/win32/Win32InterfaceForCLog.cpp
+++ b/xbmc/utils/win32/Win32InterfaceForCLog.cpp
@@ -1,0 +1,120 @@
+/*
+*      Copyright (C) 2014 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#ifndef TARGET_WINDOWS
+#error This file is for win32 platforms only
+#endif //!TARGET_WINDOWS
+
+#include "Win32InterfaceForCLog.h"
+#include "win32/WIN32Util.h"
+#include "utils/StringUtils.h"
+#include "utils/auto_buffer.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif // WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+CWin32InterfaceForCLog::CWin32InterfaceForCLog() :
+  m_hFile(INVALID_HANDLE_VALUE)
+{ }
+
+CWin32InterfaceForCLog::~CWin32InterfaceForCLog()
+{
+  if (m_hFile != INVALID_HANDLE_VALUE)
+    CloseHandle(m_hFile);
+}
+
+bool CWin32InterfaceForCLog::OpenLogFile(const std::string& logFilename, const std::string& backupOldLogToFilename)
+{
+  if (m_hFile != INVALID_HANDLE_VALUE)
+    return false; // file was already opened
+
+  std::wstring strLogFileW(CWIN32Util::ConvertPathToWin32Form(CWIN32Util::SmbToUnc(logFilename)));
+  std::wstring strLogFileOldW(CWIN32Util::ConvertPathToWin32Form(CWIN32Util::SmbToUnc(backupOldLogToFilename)));
+
+  if (strLogFileW.empty())
+    return false;
+
+  if (!strLogFileOldW.empty())
+  {
+    (void)DeleteFileW(strLogFileOldW.c_str()); // if it's failed, try to continue
+    (void)MoveFileW(strLogFileW.c_str(), strLogFileOldW.c_str()); // if it's failed, try to continue
+  }
+
+  m_hFile = CreateFileW(strLogFileW.c_str(), GENERIC_WRITE, FILE_SHARE_READ, NULL,
+                                  CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+  if (m_hFile == INVALID_HANDLE_VALUE)
+    return false;
+
+  static const unsigned char BOM[3] = { 0xEF, 0xBB, 0xBF };
+  DWORD written;
+  (void)WriteFile(m_hFile, BOM, sizeof(BOM), &written, NULL); // write BOM, ignore possible errors
+
+  return true;
+}
+
+void CWin32InterfaceForCLog::CloseLogFile(void)
+{
+  if (m_hFile != INVALID_HANDLE_VALUE)
+  {
+    CloseHandle(m_hFile);
+    m_hFile = INVALID_HANDLE_VALUE;
+  }
+}
+
+bool CWin32InterfaceForCLog::WriteStringToLog(const std::string& logString)
+{
+  if (m_hFile == INVALID_HANDLE_VALUE)
+    return false;
+
+  std::string strData(logString);
+  StringUtils::Replace(strData, "\n", "\r\n");
+  strData += "\r\n";
+
+  DWORD written;
+  const bool ret = (WriteFile(m_hFile, strData.c_str(), strData.length(), &written, NULL) != 0) && written == strData.length();
+  (void)FlushFileBuffers(m_hFile);
+
+  return ret;
+}
+
+void CWin32InterfaceForCLog::PrintDebugString(const std::string& debugString)
+{
+#ifdef _DEBUG
+  ::OutputDebugStringW(L"Debug Print: ");
+  int bufSize = MultiByteToWideChar(CP_UTF8, 0, debugString.c_str(), debugString.length(), NULL, 0);
+  XUTILS::auto_buffer buf(sizeof(wchar_t) * (bufSize + 1)); // '+1' for extra safety
+  if (MultiByteToWideChar(CP_UTF8, 0, debugString.c_str(), debugString.length(), (wchar_t*)buf.get(), buf.size() / sizeof(wchar_t)) == bufSize)
+    ::OutputDebugStringW(std::wstring((wchar_t*)buf.get(), bufSize).c_str());
+  else
+    ::OutputDebugStringA(debugString.c_str());
+  ::OutputDebugStringW(L"\n");
+#endif // _DEBUG
+}
+
+void CWin32InterfaceForCLog::GetCurrentLocalTime(int& hour, int& minute, int& second)
+{
+  SYSTEMTIME time;
+  GetLocalTime(&time);
+  hour = time.wHour;
+  minute = time.wMinute;
+  second = time.wSecond;
+}

--- a/xbmc/utils/win32/Win32InterfaceForCLog.h
+++ b/xbmc/utils/win32/Win32InterfaceForCLog.h
@@ -1,0 +1,38 @@
+#pragma once
+/*
+*      Copyright (C) 2014 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <string>
+
+typedef void* HANDLE; // forward declaration, to avoid inclusion of whole Windows.h
+
+class CWin32InterfaceForCLog 
+{
+public:
+  CWin32InterfaceForCLog();
+  ~CWin32InterfaceForCLog();
+  bool OpenLogFile(const std::string& logFilename, const std::string& backupOldLogToFilename);
+  void CloseLogFile(void);
+  bool WriteStringToLog(const std::string& logString);
+  void PrintDebugString(const std::string& debugString);
+  static void GetCurrentLocalTime(int& hour, int& minute, int& second);
+private:
+  HANDLE m_hFile;
+};

--- a/xbmc/utils/win32/Win32Log.cpp
+++ b/xbmc/utils/win32/Win32Log.cpp
@@ -1,0 +1,65 @@
+/*
+*      Copyright (C) 2014 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "Win32Log.h"
+#include "utils/StringUtils.h"
+#include "utils/CharsetConverter.h"
+
+void CWin32Log::LogW(int loglevel, const wchar_t* format, ...)
+{
+  if (IsLogLevelLogged(loglevel))
+  {
+    va_list va;
+    va_start(va, format);
+    std::wstring strDataW(StringUtils::FormatV(format, va));
+    va_end(va);
+    if (!strDataW.empty())
+    {
+      std::string strDataUtf8;
+      if (g_charsetConverter.wToUTF8(strDataW, strDataUtf8, false) && !strDataUtf8.empty())
+        LogString(loglevel, strDataUtf8);
+      else
+        PrintDebugString(__FUNCTION__ ": Can't convert log wide string to UTF-8");
+    }
+  }
+}
+
+void CWin32Log::LogFunctionW(int loglevel, const char* functionName, const wchar_t* format, ...)
+{
+  if (IsLogLevelLogged(loglevel))
+  {
+    va_list va;
+    va_start(va, format);
+    std::wstring strDataW(StringUtils::FormatV(format, va));
+    va_end(va);
+    if (!strDataW.empty())
+    {
+      std::string funcNameStr;
+      if (functionName && functionName[0])
+        funcNameStr.assign(functionName).append(": ");
+
+      std::string strDataUtf8;
+      if (g_charsetConverter.wToUTF8(strDataW, strDataUtf8, false) && !strDataUtf8.empty())
+        LogString(loglevel, funcNameStr + strDataUtf8);
+      else
+        PrintDebugString(__FUNCTION__ ": Can't convert log wide string to UTF-8");
+    }
+  }
+}

--- a/xbmc/utils/win32/Win32Log.h
+++ b/xbmc/utils/win32/Win32Log.h
@@ -1,0 +1,40 @@
+#pragma once
+
+/*
+*      Copyright (C) 2014 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "utils/log.h"
+
+#ifndef TARGET_WINDOWS
+#error This file is for Win32 platfrom only
+#endif // TARGET_WINDOWS
+
+
+// CLog version for Win32 with additional widestring logging capabilities
+class CWin32Log : public CLog
+{
+public:
+  static void LogW(int loglevel, PRINTF_FORMAT_STRING const wchar_t *format, ...);
+  static void LogFunctionW(int loglevel, IN_OPT_STRING const char* functionName, PRINTF_FORMAT_STRING const wchar_t* format, ...);
+#define LogFW(loglevel,format,...) LogFunctionW((loglevel),__FUNCTION__,(format),##__VA_ARGS__)
+};
+
+// substitute CWin32Log instead of CLog for Win32
+#define CLog CWin32Log

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -148,9 +148,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
   case ACTION_SHOW_GUI:
     {
       // switch back to the menu
-      OutputDebugString("Switching to GUI\n");
       g_windowManager.PreviousWindow();
-      OutputDebugString("Now in GUI\n");
       return true;
     }
     break;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -688,11 +688,9 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2, boo
         }
 
         // got all movie details :-)
-        OutputDebugString("got details\n");
         pDlgProgress->Close();
 
         // now show the imdb info
-        OutputDebugString("show info\n");
 
         // remove directory caches and reload images
         CUtil::DeleteVideoDatabaseDirectoryCache();


### PR DESCRIPTION
This is an alternative for PR #5044.
- Fix some mess in CLog
- Rework win32 part to work directly with win32 File API instead of some strange `_utf8` wrappers
- Move adb printing to the right place
- [win32] Add LogW() for wide string logging
- Add LogFunctions/LogFunctionsW(win32) and companion macros LogF/LogFW(win32) for quick logging with function name: instead of 

``` C++
CLog::Log(LOGDEBUG, "%s: Return code: %i", __FUNCTION__, ret);
```

use

``` C++
CLog::LogF(LOGDEBUG, "Return code: %i", ret);
```

 this will put exactly the same string to the log.
- Added parameter checking for MSVC
- Removed CStdString
