### PR TITLE
[python] add discnumber music info label

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -410,6 +410,8 @@ namespace XBMCAddon
           // TODO: add the rest of the infolabels
           if (key == "tracknumber")
             item->GetMusicInfoTag()->SetTrackNumber(strtol(value.c_str(), NULL, 10));
+          else if (key == "disc")
+            item->GetMusicInfoTag()->SetPartOfSet(strtol(value.c_str(), NULL, 10));
           else if (key == "count")
             item->m_iprogramCount = strtol(value.c_str(), NULL, 10);
           else if (key == "size")

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -229,6 +229,7 @@ namespace XBMCAddon
        *     - dateadded     : string (%Y-%m-%d %h:%m:%s = 2009-04-05 23:16:04)
        * - Music Values:
        *     - tracknumber   : integer (8)
+       *     - disc          : integer (2)
        *     - duration      : integer (245) - duration in seconds
        *     - year          : integer (1998)
        *     - genre         : string (Rock)


### PR DESCRIPTION
Possibilities for backport? Sorting in multi-disc albums is currently broken since there's no way to set the disc number.
