### PR TITLE
videodb: clean tvshows without episodes independent of their configuration as a source

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8019,8 +8019,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     sql = "SELECT tvshow.idShow FROM tvshow "
             "JOIN tvshowlinkpath ON tvshow.idShow = tvshowlinkpath.idShow "
             "JOIN path ON path.idPath = tvshowlinkpath.idPath "
-          "WHERE NOT EXISTS (SELECT 1 FROM episode WHERE episode.idShow = tvshow.idShow) "
-            "AND (path.strContent IS NULL OR path.strContent = '')";
+          "WHERE NOT EXISTS (SELECT 1 FROM episode WHERE episode.idShow = tvshow.idShow)";
     m_pDS->query(sql.c_str());
     while (!m_pDS->eof())
     {


### PR DESCRIPTION
Stumbled upon this while looking into an issue with clean library.

IMO this additional WHERE condition doesn't make sense on the tvshow table (it's perfectly fine on the path table though). What this means is that when you have a video source containing a single tvshow and you delete either all episodes of the tvshow or even the entire tvshow (i.e. the entire source) the tvshow will still be listed in your library but it will be empty.
