### PR TITLE
RFC: Actor link switch

### DIFF
--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -309,7 +309,7 @@ public:
   virtual int  exec() = 0;
   virtual const void* getExecRes()=0;
 /* as open, but with our query exept Sql */
-  virtual bool query(const char *sql) = 0;
+  virtual bool query(const std::string &sql) = 0;
 /* Close SQL Query*/
   virtual void close();
 /* This function looks for field Field_name with value equal Field_value

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1471,7 +1471,7 @@ const void* MysqlDataset::getExecRes() {
 }
 
 
-bool MysqlDataset::query(const char *query) {
+bool MysqlDataset::query(const std::string &query) {
   if(!handle()) throw DbErrors("No Database Connection");
   std::string qry = query;
   int fs = qry.find("select");
@@ -1566,10 +1566,6 @@ bool MysqlDataset::query(const char *query) {
   ds_state = dsSelect;
   this->first();
   return true;
-}
-
-bool MysqlDataset::query(const string &q) {
-  return query(q.c_str());
 }
 
 void MysqlDataset::open(const string &sql) {

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -148,7 +148,6 @@ or insert() operations default = false) */
   virtual int  exec (const std::string &sql);
   virtual const void* getExecRes();
 /* as open, but with our query exept Sql */
-  virtual bool query(const char *query);
   virtual bool query(const std::string &query);
 /* func. closes a query */
   virtual void close(void);

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -638,7 +638,7 @@ const void* SqliteDataset::getExecRes() {
 }
 
 
-bool SqliteDataset::query(const char *query) {
+bool SqliteDataset::query(const std::string &query) {
     if(!handle()) throw DbErrors("No Database Connection");
     std::string qry = query;
     int fs = qry.find("select");
@@ -649,7 +649,7 @@ bool SqliteDataset::query(const char *query) {
   close();
 
   sqlite3_stmt *stmt = NULL;
-  if (db->setErr(sqlite3_prepare_v2(handle(),query,-1,&stmt, NULL),query) != SQLITE_OK)
+  if (db->setErr(sqlite3_prepare_v2(handle(),query.c_str(),-1,&stmt, NULL),query.c_str()) != SQLITE_OK)
     throw DbErrors(db->getErrorMsg());
 
   // column headers
@@ -689,7 +689,7 @@ bool SqliteDataset::query(const char *query) {
     }
     result.records.push_back(res);
   }
-  if (db->setErr(sqlite3_finalize(stmt),query) == SQLITE_OK)
+  if (db->setErr(sqlite3_finalize(stmt),query.c_str()) == SQLITE_OK)
   {
     active = true;
     ds_state = dsSelect;
@@ -700,10 +700,6 @@ bool SqliteDataset::query(const char *query) {
   {
     throw DbErrors(db->getErrorMsg());
   }  
-}
-
-bool SqliteDataset::query(const string &q){
-  return query(q.c_str());
 }
 
 void SqliteDataset::open(const string &sql) {

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -148,7 +148,6 @@ or insert() operations default = false) */
   virtual int  exec (const std::string &sql);
   virtual const void* getExecRes();
 /* as open, but with our query exept Sql */
-  virtual bool query(const char *query);
   virtual bool query(const std::string &query);
 /* func. closes a query */
   virtual void close(void);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -327,6 +327,10 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE UNIQUE INDEX ix_taglinks_2 ON taglinks (idMedia, media_type(20), idTag)");
   m_pDS->exec("CREATE INDEX ix_taglinks_3 ON taglinks (media_type(20))");
 
+  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinks_1 ON actorlinks (idActor, media_type(20), media_id)");
+  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinks_2 ON actorlinks (media_id, media_type(20), idActor)");
+  m_pDS->exec("CREATE INDEX ix_actorlinks_3 ON actorlinks (media_type(20))");
+
   CLog::Log(LOGINFO, "%s - creating triggers", __FUNCTION__);
   m_pDS->exec("CREATE TRIGGER delete_movie AFTER DELETE ON movie FOR EACH ROW BEGIN "
               "DELETE FROM genrelinkmovie WHERE idMovie=old.idMovie; "
@@ -1549,6 +1553,14 @@ void CVideoDatabase::AddLinkToActor(const char *table, int actorID, const char *
       // doesnt exists, add it
       strSQL=PrepareSQL("insert into actorlink%s (idActor, id%s, strRole, iOrder) values(%i,%i,'%s',%i)", table, field, actorID, secondID, role.c_str(), order);
       m_pDS->exec(strSQL.c_str());
+    }
+    m_pDS->close();
+    std::string sql=PrepareSQL("select 1 from actorlinks where idActor=%i and media_id=%i and media_type='%s'", actorID, secondID, table);
+    m_pDS->query(sql);
+    if (m_pDS->num_rows() == 0)
+    { // doesnt exists, add it
+      sql = PrepareSQL("insert into actorlinks (idActor, media_id, media_type, strRole, iOrder) values(%i,%i,'%s','%s',%i)", actorID, secondID, table, role.c_str(), order);
+      m_pDS->exec(sql);
     }
     m_pDS->close();
   }
@@ -3973,6 +3985,21 @@ void CVideoDatabase::GetCast(const CStdString &table, const CStdString &table_id
                                 "WHERE actorlink%s.%s=%i "
                                 "ORDER BY actorlink%s.iOrder",table.c_str(), table.c_str(), table.c_str(), table.c_str(), table.c_str(), table_id.c_str(), type_id, table.c_str());
     m_pDS2->query(sql.c_str());
+    {
+    std::string sql = PrepareSQL("SELECT actors.strActor,"
+                                 "  actorlinks.strRole,"
+                                 "  actorlinks.iOrder,"
+                                 "  actors.strThumb,"
+                                 "  art.url "
+                                 "FROM actorlinks"
+                                 "  JOIN actors ON"
+                                 "    actorlinks.idActor=actors.idActor"
+                                 "  LEFT JOIN art ON"
+                                 "    art.media_id=actors.idActor AND art.media_type='actor' AND art.type='thumb' "
+                                 "WHERE actorlinks.media_id=%i AND actorlinks.media_type='%s'"
+                                 "ORDER BY actorlinks.iOrder", type_id, table.c_str());
+    m_pDS2->query(sql);
+    }
     while (!m_pDS2->eof())
     {
       SActorInfo info;
@@ -4793,11 +4820,19 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec("DELETE from art WHERE media_type='tvshow' AND NOT EXISTS (SELECT 1 FROM tvshow WHERE tvshow.idShow = art.media_id)");
     m_pDS->exec("DELETE from art WHERE media_type='season' AND NOT EXISTS (SELECT 1 FROM seasons WHERE seasons.idSeason = art.media_id)");
   }
+  if (iVersion < 90)
+  { // test whether a single actor link table is going to be reasonable
+    m_pDS->exec("CREATE TABLE actorlinks (idActor integer, media_id integer, media_type TEXT, strRole text, iOrder integer)");
+    // and fill it
+    m_pDS->exec("INSERT into actorlinks(idActor, media_id, media_type, strRole, iOrder) SELECT idActor,idMovie,'movie',strRole,iOrder from actorlinkmovie");
+    m_pDS->exec("INSERT into actorlinks(idActor, media_id, media_type, strRole, iOrder) SELECT idActor,idShow,'tvshow',strRole,iOrder from actorlinktvshow");
+    m_pDS->exec("INSERT into actorlinks(idActor, media_id, media_type, strRole, iOrder) SELECT idActor,idEpisode,'episode',strRole,iOrder from actorlinkepisode");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 89;
+  return 90;
 }
 
 bool CVideoDatabase::LookupByFolders(const CStdString &path, bool shows)


### PR DESCRIPTION
This switches the actorlink tables to a single actorlinks table similar to taglinks.

Performance is similar on SQLite (on an SSD):  With 1000 repeats per cast, I get:

old: 515.629211 +/- 50.798962 ms
new: 525.454163 +/- 48.952896 ms
diff: 9.825000 +/- 14.802364 ms

Those are 95% confidence intervals, so on SQLite at least, no significant difference.

@MilhouseVH mind testing on mysql?  An easy way is to make sure you have the skin widgets script installed and just monitor the log.  The CI will drop lower as more movies/shows/episodes are fetched ofc.

It has a repeat of 1000 (x2) queries each time GetCast() is called, so another way is to just call the JSON GetMovies/Episodes/Shows requesting the cast on a bunch of movies/shows/episodes and waiting till it does it's thing.

Assuming the timing on MySQL is OK (can't see why it wouldn't be) I'll tidy up, drop the stats and move the rest of the link tables to the same format.

@Montellese: ATM I've used `media_type` and `media_id` which is different to taglinks (idMedia) but I have no preference as long as we're consistent.  I guess we use idMedia elsewhere, and it fits in with idFoo in general.
