### PR TITLE
FIX: [droid] fixup preventing closing when removing keyboard with touchpad

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -58,7 +58,7 @@
         -->
         <activity
             android:name=".Main"
-            android:configChanges="orientation|keyboard|keyboardHidden|navigation"
+            android:configChanges="orientation|keyboard|keyboardHidden|navigation|touchscreen"
             android:finishOnTaskLaunch="true"
             android:label="XBMC"
             android:launchMode="singleInstance"


### PR DESCRIPTION
/cc @Montellese @t-nelson @davilla 
