### PR TITLE
[python] add setSubtitles method for ListItem

### DIFF
--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.python" version="2.17.0" provider-name="Team-Kodi">
+<addon id="xbmc.python" version="2.18.0" provider-name="Team-Kodi">
   <backwards-compatibility abi="2.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -656,9 +656,9 @@ bool CDVDPlayer::OpenInputStream()
     std::vector<std::string> filenames;
     CUtil::ScanForExternalSubtitles( m_filename, filenames );
 
-    // find any upnp subtitles
-    std::string key("upnp:subtitle:1");
-    for(unsigned s = 1; m_item.HasProperty(key); key = StringUtils::Format("upnp:subtitle:%u", ++s))
+    // load any subtitles from file item
+    std::string key("subtitle:1");
+    for(unsigned s = 1; m_item.HasProperty(key); key = StringUtils::Format("subtitle:%u", ++s))
       filenames.push_back(m_item.GetProperty(key).asString());
 
     for(unsigned int i=0;i<filenames.size();i++)

--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -720,9 +720,9 @@ bool CDVDPlayer::OpenInputStream()
     std::vector<std::string> filenames;
     CUtil::ScanForExternalSubtitles( m_filename, filenames );
 
-    // find any upnp subtitles
-    std::string key("upnp:subtitle:1");
-    for(unsigned s = 1; m_item.HasProperty(key); key = StringUtils::Format("upnp:subtitle:%u", ++s))
+    // load any subtitles from file item
+    std::string key("subtitle:1");
+    for(unsigned s = 1; m_item.HasProperty(key); key = StringUtils::Format("subtitle:%u", ++s))
       filenames.push_back(m_item.GetProperty(key).asString());
 
     for(unsigned int i=0;i<filenames.size();i++)

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -591,5 +591,16 @@ namespace XBMCAddon
       if (replaceItems)
         item->SetProperty("pluginreplacecontextitems", replaceItems);
     } // end addContextMenuItems
+
+    void ListItem::setSubtitles(const std::vector<String>& paths)
+    {
+      LOCKGUI;
+      unsigned int i = 1;
+      for (std::vector<String>::const_iterator it = paths.begin(); it != paths.end(); ++it, i++)
+      {
+        String property = StringUtils::Format("subtitle:%u", i);
+        item->SetProperty(property, *it);
+      }
+    }
   }
 }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -348,6 +348,14 @@ namespace XBMCAddon
       void setMimeType(const String& mimetype);
 
       /**
+       * setSubtitles() -- Sets subtitles for this listitem.\n
+       *
+       * example:
+       *   - listitem.setSubtitles(['special://temp/example.srt', 'http://example.com/example.srt'])
+       */
+      void setSubtitles(const std::vector<String>& subtitleFiles);
+
+      /**
        * getdescription() -- Returns the description of this PlayListItem.\n
        */
       String getdescription();

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -327,24 +327,6 @@ namespace XBMCAddon
       String getProperty(const char* key);
 
       /**
-       * addContextMenuItems([(label, action,)*], replaceItems) -- Adds item(s) to the context menu for media lists.\n
-       * \n
-       * items               : list - [(label, action,)*] A list of tuples consisting of label and action pairs.
-       *   - label           : string or unicode - item's label.
-       *   - action          : string or unicode - any built-in function to perform.
-       * replaceItems        : [opt] bool - True=only your items will show/False=your items will be added to context menu(Default).
-       * \n
-       * List of functions - http://wiki.xbmc.org/?title=List_of_Built_In_Functions \n
-       * \n
-       * *Note, You can use the above as keywords for arguments and skip certain optional arguments.\n
-       *        Once you use a keyword, all following arguments require the keyword.\n
-       * \n
-       * example:
-       *   - listitem.addContextMenuItems([('Theater Showtimes', 'XBMC.RunScript(special://home/scripts/showtimes/default.py,Iron Man)',)])
-       */
-      //    void addContextMenuItems();
-
-      /**
        * setPath(path) -- Sets the listitem's path.\n
        * \n
        * path           : string or unicode - path, activated when item is clicked.\n

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -824,7 +824,7 @@ namespace PythonBindings
    // constants
    PyModule_AddStringConstant(module, (char*)"__author__", (char*)"Team XBMC <http://xbmc.org>");
    PyModule_AddStringConstant(module, (char*)"__date__", (char*)"${new Date().toString()}");
-   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.17.0");
+   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.18.0");
    PyModule_AddStringConstant(module, (char*)"__credits__", (char*)"Team XBMC");
    PyModule_AddStringConstant(module, (char*)"__platform__", (char*)"ALL");
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -982,7 +982,7 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
     {
       if(info.Match(PLT_ProtocolInfo("*", "*", allowed[type], "*")))
       {
-        CStdString prop = StringUtils::Format("upnp:subtitle:%d", ++subs);
+        CStdString prop = StringUtils::Format("subtitle:%d", ++subs);
         item.SetProperty(prop, (const char*)res.m_Uri);
         break;
       }


### PR DESCRIPTION
This allows subtitles to be set directly to list items _before_ playback instead of going via `Player` and waiting for playback to start. Reuses the existing upnp facility for passing subtitles to the player.
