### PR TITLE
Use pdh function for processor counter math

### DIFF
--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -58,11 +58,10 @@ struct CoreInfo
   unsigned long long m_nice;
   unsigned long long m_system;
   unsigned long long m_io;
+  unsigned long long m_idle;
 #elif defined(TARGET_WINDOWS)
   PDH_HCOUNTER m_coreCounter;
-  unsigned long long m_total;
 #endif
-  unsigned long long m_idle;
   std::string m_strVendor;
   std::string m_strModel;
   std::string m_strBogoMips;
@@ -72,7 +71,7 @@ struct CoreInfo
 #ifdef TARGET_POSIX
   CoreInfo() : m_id(0), m_fSpeed(.0), m_fPct(.0), m_user(0LL), m_nice(0LL), m_system(0LL), m_io(0LL), m_idle(0LL) {}
 #elif defined(TARGET_WINDOWS)
-  CoreInfo() : m_id(0), m_fSpeed(.0), m_fPct(.0), m_coreCounter(NULL), m_total(0LL), m_idle(0LL) {}
+  CoreInfo() : m_id(0), m_fSpeed(.0), m_fPct(.0), m_coreCounter(NULL) {}
 #endif
   bool operator<(const CoreInfo& other) const { return m_id < other.m_id; }
 };


### PR DESCRIPTION
Use PdhGetFormattedCounterValue to do the math on processor usage,
rather than a version that uses processes the raw data.

Also switch to using %Processor Time rather than %Idle Time.  Note that
once in a while %Processor Time can go >100, I believe it's related to
frequency shifting.

This updates the change by @Karlson2k in https://github.com/xbmc/xbmc/commit/bbcc1f8b7740e76306f7a75825d2470de28180c9

@Karlson2k any comments on this?  I'm not sure if there was a reason you were using the raw values rather than using the format routine?
