### PR TITLE
[videodb] table formatting cleanup

### DIFF
--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -309,7 +309,7 @@ public:
   virtual int  exec() = 0;
   virtual const void* getExecRes()=0;
 /* as open, but with our query exept Sql */
-  virtual bool query(const char *sql) = 0;
+  virtual bool query(const std::string &sql) = 0;
 /* Close SQL Query*/
   virtual void close();
 /* This function looks for field Field_name with value equal Field_value

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1471,7 +1471,7 @@ const void* MysqlDataset::getExecRes() {
 }
 
 
-bool MysqlDataset::query(const char *query) {
+bool MysqlDataset::query(const std::string &query) {
   if(!handle()) throw DbErrors("No Database Connection");
   std::string qry = query;
   int fs = qry.find("select");
@@ -1566,10 +1566,6 @@ bool MysqlDataset::query(const char *query) {
   ds_state = dsSelect;
   this->first();
   return true;
-}
-
-bool MysqlDataset::query(const string &q) {
-  return query(q.c_str());
 }
 
 void MysqlDataset::open(const string &sql) {

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -148,7 +148,6 @@ or insert() operations default = false) */
   virtual int  exec (const std::string &sql);
   virtual const void* getExecRes();
 /* as open, but with our query exept Sql */
-  virtual bool query(const char *query);
   virtual bool query(const std::string &query);
 /* func. closes a query */
   virtual void close(void);

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -638,7 +638,7 @@ const void* SqliteDataset::getExecRes() {
 }
 
 
-bool SqliteDataset::query(const char *query) {
+bool SqliteDataset::query(const std::string &query) {
     if(!handle()) throw DbErrors("No Database Connection");
     std::string qry = query;
     int fs = qry.find("select");
@@ -649,7 +649,7 @@ bool SqliteDataset::query(const char *query) {
   close();
 
   sqlite3_stmt *stmt = NULL;
-  if (db->setErr(sqlite3_prepare_v2(handle(),query,-1,&stmt, NULL),query) != SQLITE_OK)
+  if (db->setErr(sqlite3_prepare_v2(handle(),query.c_str(),-1,&stmt, NULL),query.c_str()) != SQLITE_OK)
     throw DbErrors(db->getErrorMsg());
 
   // column headers
@@ -689,7 +689,7 @@ bool SqliteDataset::query(const char *query) {
     }
     result.records.push_back(res);
   }
-  if (db->setErr(sqlite3_finalize(stmt),query) == SQLITE_OK)
+  if (db->setErr(sqlite3_finalize(stmt),query.c_str()) == SQLITE_OK)
   {
     active = true;
     ds_state = dsSelect;
@@ -700,10 +700,6 @@ bool SqliteDataset::query(const char *query) {
   {
     throw DbErrors(db->getErrorMsg());
   }  
-}
-
-bool SqliteDataset::query(const string &q){
-  return query(q.c_str());
 }
 
 void SqliteDataset::open(const string &sql) {

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -148,7 +148,6 @@ or insert() operations default = false) */
   virtual int  exec (const std::string &sql);
   virtual const void* getExecRes();
 /* as open, but with our query exept Sql */
-  virtual bool query(const char *query);
   virtual bool query(const std::string &query);
 /* func. closes a query */
   virtual void close(void);

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -762,17 +762,17 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
       std::string year;
       if (m_mediaType == "movies")
       {
-        table = "movieview";
+        table = "movie_view";
         year = DatabaseUtils::GetField(FieldYear, MediaTypeMovie, DatabaseQueryPartWhere);
       }
       else if (m_mediaType == "tvshows")
       {
-        table = "tvshowview";
+        table = "tvshow_view";
         year = StringUtils::Format("strftime(\"%%Y\", %s)", DatabaseUtils::GetField(FieldYear, MediaTypeTvShow, DatabaseQueryPartWhere).c_str());
       }
       else if (m_mediaType == "musicvideos")
       {
-        table = "musicvideoview";
+        table = "musicvideo_view";
         year = DatabaseUtils::GetField(FieldYear, MediaTypeMusicVideo, DatabaseQueryPartWhere);
       }
 
@@ -805,7 +805,7 @@ void CGUIDialogMediaFilter::GetRange(const Filter &filter, int &min, int &interv
     {
       std::string field = StringUtils::Format("CAST(strftime(\"%%s\", c%02d) AS INTEGER)", VIDEODB_ID_EPISODE_AIRED);
       
-      GetMinMax("episodeview", field, min, max);
+      GetMinMax("episode_view", field, min, max);
       interval = 60 * 60 * 24 * 7; // 1 week
     }
   }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -742,7 +742,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     table = "movieview";
 
     if (m_field == FieldGenre)
-      query = negate + " EXISTS (SELECT 1 FROM genrelinkmovie JOIN genre ON genre.idGenre=genrelinkmovie.idGenre WHERE genrelinkmovie.idMovie = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
+      query = negate + FormatLinkQuery("genre", "genre", "movie", GetField(FieldId, strType), parameter);
     else if (m_field == FieldDirector)
       query = negate + FormatLinkQuery("director", "actor", "movie", GetField(FieldId, strType), parameter);
     else if (m_field == FieldActor)
@@ -750,9 +750,9 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     else if (m_field == FieldWriter)
       query = negate + FormatLinkQuery("writer", "actor", "movie", GetField(FieldId, strType), parameter);
     else if (m_field == FieldStudio)
-      query = negate + " EXISTS (SELECT 1 FROM studiolinkmovie JOIN studio ON studio.idStudio=studiolinkmovie.idStudio WHERE studiolinkmovie.idMovie = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
+      query = negate + FormatLinkQuery("studio", "studio", "movie", GetField(FieldId, strType), parameter);
     else if (m_field == FieldCountry)
-      query = negate + " EXISTS (SELECT 1 FROM countrylinkmovie JOIN country ON country.idCountry=countrylinkmovie.idCountry WHERE countrylinkmovie.idMovie = " + GetField(FieldId, strType) + " AND country.strCountry" + parameter + ")";
+      query = negate + FormatLinkQuery("country", "country", "movie", GetField(FieldId, strType), parameter);
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
       query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
     else if (m_field == FieldTag)
@@ -763,11 +763,11 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     table = "musicvideoview";
 
     if (m_field == FieldGenre)
-      query = negate + " EXISTS (SELECT 1 FROM genrelinkmusicvideo JOIN genre ON genre.idGenre=genrelinkmusicvideo.idGenre WHERE genrelinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
+      query = negate + FormatLinkQuery("genre", "genre", "musicvideo", GetField(FieldId, strType), parameter);
     else if (m_field == FieldArtist)
       query = negate + FormatLinkQuery("artist", "actor", "musicvideo", GetField(FieldId, strType), parameter);
     else if (m_field == FieldStudio)
-      query = negate + " EXISTS (SELECT 1 FROM studiolinkmusicvideo JOIN studio ON studio.idStudio=studiolinkmusicvideo.idStudio WHERE studiolinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
+      query = negate + FormatLinkQuery("studio", "studio", "musicvideo", GetField(FieldId, strType), parameter);
     else if (m_field == FieldDirector)
       query = negate + FormatLinkQuery("director", "actor", "musicvideo", GetField(FieldId, strType), parameter);
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
@@ -780,13 +780,13 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     table = "tvshowview";
 
     if (m_field == FieldGenre)
-      query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
+      query = negate + FormatLinkQuery("genre", "genre", "tvshow", GetField(FieldId, strType), parameter);
     else if (m_field == FieldDirector)
       query = negate + FormatLinkQuery("director", "actor", "tvshow", GetField(FieldId, strType), parameter);
     else if (m_field == FieldActor)
       query = negate + FormatLinkQuery("actor", "actor", "tvshow", GetField(FieldId, strType), parameter);
     else if (m_field == FieldStudio)
-      query = negate + " (" + GetField(m_field, strType) + parameter + ")";
+      query = negate + FormatLinkQuery("studio", "studio", "tvshow", GetField(FieldId, strType), parameter);
     else if (m_field == FieldMPAA)
       query = negate + " (" + GetField(m_field, strType) + parameter + ")";
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
@@ -801,7 +801,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     table = "episodeview";
 
     if (m_field == FieldGenre)
-      query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + table + ".idShow AND genre.strGenre" + parameter + ")";
+      query = negate + FormatLinkQuery("genre", "genre", "tvshow", (table + ".idShow").c_str(), parameter);
     else if (m_field == FieldDirector)
       query = negate + FormatLinkQuery("director", "actor", "episode", GetField(FieldId, strType), parameter);
     else if (m_field == FieldActor)
@@ -811,7 +811,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
       query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
     else if (m_field == FieldStudio)
-      query = negate + " (" + GetField(m_field, strType) + parameter + ")";
+      query = negate + FormatLinkQuery("studio", "studio", "tvshow", (table + ".idShow").c_str(), parameter);
     else if (m_field == FieldMPAA)
       query = negate + " (" + GetField(m_field, strType) +  parameter + ")";
   }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -756,7 +756,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
       query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
     else if (m_field == FieldTag)
-      query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'movie')";
+      query = negate + FormatLinkQuery("tag", "tag", "movie", GetField(FieldId, strType), parameter);
   }
   else if (strType == "musicvideos")
   {
@@ -773,7 +773,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
       query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
     else if (m_field == FieldTag)
-      query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'musicvideo')";
+      query = negate + FormatLinkQuery("tag", "tag", "musicvideo", GetField(FieldId, strType), parameter);
   }
   else if (strType == "tvshows")
   {
@@ -794,7 +794,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     else if (m_field == FieldPlaycount)
       query = "CASE WHEN COALESCE(" + GetField(FieldNumberOfEpisodes, strType) + " - " + GetField(FieldNumberOfWatchedEpisodes, strType) + ", 0) > 0 THEN 0 ELSE 1 END " + parameter;
     else if (m_field == FieldTag)
-      query = negate + " EXISTS (SELECT 1 FROM taglinks JOIN tag ON tag.idTag = taglinks.idTag WHERE taglinks.idMedia = " + GetField(FieldId, strType) + " AND tag.strTag" + parameter + " AND taglinks.media_type = 'tvshow')";
+      query = negate + FormatLinkQuery("tag", "tag", "tvshow", GetField(FieldId, strType), parameter);
   }
   else if (strType == "episodes")
   {

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -744,11 +744,11 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     if (m_field == FieldGenre)
       query = negate + " EXISTS (SELECT 1 FROM genrelinkmovie JOIN genre ON genre.idGenre=genrelinkmovie.idGenre WHERE genrelinkmovie.idMovie = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
     else if (m_field == FieldDirector)
-      query = negate + " EXISTS (SELECT 1 FROM directorlinkmovie JOIN actors ON actors.idActor=directorlinkmovie.idDirector WHERE directorlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("director", "actor", "movie", GetField(FieldId, strType), parameter);
     else if (m_field == FieldActor)
-      query = negate + " EXISTS (SELECT 1 FROM actorlinkmovie JOIN actors ON actors.idActor=actorlinkmovie.idActor WHERE actorlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("actor", "actor", "movie", GetField(FieldId, strType), parameter);
     else if (m_field == FieldWriter)
-      query = negate + " EXISTS (SELECT 1 FROM writerlinkmovie JOIN actors ON actors.idActor=writerlinkmovie.idWriter WHERE writerlinkmovie.idMovie = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("writer", "actor", "movie", GetField(FieldId, strType), parameter);
     else if (m_field == FieldStudio)
       query = negate + " EXISTS (SELECT 1 FROM studiolinkmovie JOIN studio ON studio.idStudio=studiolinkmovie.idStudio WHERE studiolinkmovie.idMovie = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
     else if (m_field == FieldCountry)
@@ -765,11 +765,11 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     if (m_field == FieldGenre)
       query = negate + " EXISTS (SELECT 1 FROM genrelinkmusicvideo JOIN genre ON genre.idGenre=genrelinkmusicvideo.idGenre WHERE genrelinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
     else if (m_field == FieldArtist)
-      query = negate + " EXISTS (SELECT 1 FROM artistlinkmusicvideo JOIN actors ON actors.idActor=artistlinkmusicvideo.idArtist WHERE artistlinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("artist", "actor", "musicvideo", GetField(FieldId, strType), parameter);
     else if (m_field == FieldStudio)
       query = negate + " EXISTS (SELECT 1 FROM studiolinkmusicvideo JOIN studio ON studio.idStudio=studiolinkmusicvideo.idStudio WHERE studiolinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND studio.strStudio" + parameter + ")";
     else if (m_field == FieldDirector)
-      query = negate + " EXISTS (SELECT 1 FROM directorlinkmusicvideo JOIN actors ON actors.idActor=directorlinkmusicvideo.idDirector WHERE directorlinkmusicvideo.idMVideo = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("director", "actor", "musicvideo", GetField(FieldId, strType), parameter);
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
       query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
     else if (m_field == FieldTag)
@@ -782,9 +782,9 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     if (m_field == FieldGenre)
       query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + GetField(FieldId, strType) + " AND genre.strGenre" + parameter + ")";
     else if (m_field == FieldDirector)
-      query = negate + " EXISTS (SELECT 1 FROM directorlinktvshow JOIN actors ON actors.idActor=directorlinktvshow.idDirector WHERE directorlinktvshow.idShow = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("director", "actor", "tvshow", GetField(FieldId, strType), parameter);
     else if (m_field == FieldActor)
-      query = negate + " EXISTS (SELECT 1 FROM actorlinktvshow JOIN actors ON actors.idActor=actorlinktvshow.idActor WHERE actorlinktvshow.idShow = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("actor", "actor", "tvshow", GetField(FieldId, strType), parameter);
     else if (m_field == FieldStudio)
       query = negate + " (" + GetField(m_field, strType) + parameter + ")";
     else if (m_field == FieldMPAA)
@@ -803,11 +803,11 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     if (m_field == FieldGenre)
       query = negate + " EXISTS (SELECT 1 FROM genrelinktvshow JOIN genre ON genre.idGenre=genrelinktvshow.idGenre WHERE genrelinktvshow.idShow = " + table + ".idShow AND genre.strGenre" + parameter + ")";
     else if (m_field == FieldDirector)
-      query = negate + " EXISTS (SELECT 1 FROM directorlinkepisode JOIN actors ON actors.idActor=directorlinkepisode.idDirector WHERE directorlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("director", "actor", "episode", GetField(FieldId, strType), parameter);
     else if (m_field == FieldActor)
-      query = negate + " EXISTS (SELECT 1 FROM actorlinkepisode JOIN actors ON actors.idActor=actorlinkepisode.idActor WHERE actorlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("actor", "actor", "episode", GetField(FieldId, strType), parameter);
     else if (m_field == FieldWriter)
-      query = negate + " EXISTS (SELECT 1 FROM writerlinkepisode JOIN actors ON actors.idActor=writerlinkepisode.idWriter WHERE writerlinkepisode.idEpisode = " + GetField(FieldId, strType) + " AND actors.strActor" + parameter + ")";
+      query = negate + FormatLinkQuery("writer", "actor", "episode", GetField(FieldId, strType), parameter);
     else if ((m_field == FieldLastPlayed || m_field == FieldDateAdded) && (m_operator == OPERATOR_LESS_THAN || m_operator == OPERATOR_BEFORE || m_operator == OPERATOR_NOT_IN_THE_LAST))
       query = GetField(m_field, strType) + " IS NULL OR " + GetField(m_field, strType) + parameter;
     else if (m_field == FieldStudio)

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -690,6 +690,15 @@ std::string CSmartPlaylistRule::FormatParameter(const std::string &operatorStrin
   return CDatabaseQueryRule::FormatParameter(operatorString, param, db, strType);
 }
 
+std::string CSmartPlaylistRule::FormatLinkQuery(const char *field, const char *table, const char *mediaType, const std::string& mediaField, const std::string& parameter)
+{
+  // NOTE: no need for a PrepareSQL here, as the parameter has already been formatted
+  return StringUtils::Format(" EXISTS (SELECT 1 FROM %s_link"
+                             "         JOIN %s ON %s.%s_id=%s_link.%s_id"
+                             "         WHERE %s_link.media_id=%s AND %s.name %s AND %s_link.media_type = '%s')",
+                             field, table, table, table, field, table, field, mediaField.c_str(), table, parameter.c_str(), field, mediaType);
+}
+
 std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, const std::string &oper, const std::string &param,
                                                  const CDatabase &db, const std::string &strType) const
 {

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -643,22 +643,22 @@ std::string CSmartPlaylistRule::GetBooleanQuery(const std::string &negate, const
   if (strType == "movies")
   {
     if (m_field == FieldInProgress)
-      return "movieview.idFile " + negate + " IN (SELECT DISTINCT idFile FROM bookmark WHERE type = 1)";
+      return "movie_view.idFile " + negate + " IN (SELECT DISTINCT idFile FROM bookmark WHERE type = 1)";
     else if (m_field == FieldTrailer)
       return negate + GetField(m_field, strType) + "!= ''";
   }
   else if (strType == "episodes")
   {
     if (m_field == FieldInProgress)
-      return "episodeview.idFile " + negate + " IN (SELECT DISTINCT idFile FROM bookmark WHERE type = 1)";
+      return "episode_view.idFile " + negate + " IN (SELECT DISTINCT idFile FROM bookmark WHERE type = 1)";
   }
   else if (strType == "tvshows")
   {
     if (m_field == FieldInProgress)
       return negate + " ("
-                          "(tvshowview.watchedcount > 0 AND tvshowview.watchedcount < tvshowview.totalCount) OR "
-                          "(tvshowview.watchedcount = 0 AND EXISTS "
-                            "(SELECT 1 FROM episodeview WHERE episodeview.idShow = " + GetField(FieldId, strType) + " AND episodeview.resumeTimeInSeconds > 0)"
+                          "(tvshow_view.watchedcount > 0 AND tvshow_view.watchedcount < tvshow_view.totalCount) OR "
+                          "(tvshow_view.watchedcount = 0 AND EXISTS "
+                            "(SELECT 1 FROM episode_view WHERE episode_view.idShow = " + GetField(FieldId, strType) + " AND episode_view.resumeTimeInSeconds > 0)"
                           ")"
                        ")";
   }
@@ -739,7 +739,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
   }
   else if (strType == "movies")
   {
-    table = "movieview";
+    table = "movie_view";
 
     if (m_field == FieldGenre)
       query = negate + FormatLinkQuery("genre", "genre", "movie", GetField(FieldId, strType), parameter);
@@ -760,7 +760,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
   }
   else if (strType == "musicvideos")
   {
-    table = "musicvideoview";
+    table = "musicvideo_view";
 
     if (m_field == FieldGenre)
       query = negate + FormatLinkQuery("genre", "genre", "musicvideo", GetField(FieldId, strType), parameter);
@@ -777,7 +777,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
   }
   else if (strType == "tvshows")
   {
-    table = "tvshowview";
+    table = "tvshow_view";
 
     if (m_field == FieldGenre)
       query = negate + FormatLinkQuery("genre", "genre", "tvshow", GetField(FieldId, strType), parameter);
@@ -798,7 +798,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
   }
   else if (strType == "episodes")
   {
-    table = "episodeview";
+    table = "episode_view";
 
     if (m_field == FieldGenre)
       query = negate + FormatLinkQuery("genre", "genre", "tvshow", (table + ".idShow").c_str(), parameter);

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -76,6 +76,7 @@ protected:
 
 private:
   std::string GetVideoResolutionQuery(const std::string &parameter) const;
+  static std::string FormatLinkQuery(const char *field, const char *table, const char *mediaType, const std::string& mediaField, const std::string& parameter);
 };
 
 class CSmartPlaylistRuleCombination : public CDatabaseQueryRuleCombination

--- a/xbmc/utils/DatabaseUtils.cpp
+++ b/xbmc/utils/DatabaseUtils.cpp
@@ -114,22 +114,22 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
   else if (mediaType == MediaTypeMusicVideo)
   {
     CStdString result;
-    if (field == FieldId) return "musicvideoview.idMVideo";
-    else if (field == FieldTitle) result = StringUtils::Format("musicvideoview.c%02d",VIDEODB_ID_MUSICVIDEO_TITLE);
-    else if (field == FieldTime) result = StringUtils::Format("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_RUNTIME);
-    else if (field == FieldDirector) result = StringUtils::Format("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_DIRECTOR);
-    else if (field == FieldStudio) result = StringUtils::Format("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_STUDIOS);
-    else if (field == FieldYear) result = StringUtils::Format("musicvideoview.c%02d",VIDEODB_ID_MUSICVIDEO_YEAR);
-    else if (field == FieldPlot) result = StringUtils::Format("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_PLOT);
-    else if (field == FieldAlbum) result = StringUtils::Format("musicvideoview.c%02d",VIDEODB_ID_MUSICVIDEO_ALBUM);
-    else if (field == FieldArtist) result = StringUtils::Format("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_ARTIST);
-    else if (field == FieldGenre) result = StringUtils::Format("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_GENRE);
-    else if (field == FieldTrackNumber) result = StringUtils::Format("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_TRACK);
-    else if (field == FieldFilename) return "musicvideoview.strFilename";
-    else if (field == FieldPath) return "musicvideoview.strPath";
-    else if (field == FieldPlaycount) return "musicvideoview.playCount";
-    else if (field == FieldLastPlayed) return "musicvideoview.lastPlayed";
-    else if (field == FieldDateAdded) return "musicvideoview.dateAdded";
+    if (field == FieldId) return "musicvideo_view.idMVideo";
+    else if (field == FieldTitle) result = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_TITLE);
+    else if (field == FieldTime) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_RUNTIME);
+    else if (field == FieldDirector) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_DIRECTOR);
+    else if (field == FieldStudio) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_STUDIOS);
+    else if (field == FieldYear) result = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_YEAR);
+    else if (field == FieldPlot) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_PLOT);
+    else if (field == FieldAlbum) result = StringUtils::Format("musicvideo_view.c%02d",VIDEODB_ID_MUSICVIDEO_ALBUM);
+    else if (field == FieldArtist) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_ARTIST);
+    else if (field == FieldGenre) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_GENRE);
+    else if (field == FieldTrackNumber) result = StringUtils::Format("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_TRACK);
+    else if (field == FieldFilename) return "musicvideo_view.strFilename";
+    else if (field == FieldPath) return "musicvideo_view.strPath";
+    else if (field == FieldPlaycount) return "musicvideo_view.playCount";
+    else if (field == FieldLastPlayed) return "musicvideo_view.lastPlayed";
+    else if (field == FieldDateAdded) return "musicvideo_view.dateAdded";
 
     if (!result.empty())
       return result;
@@ -137,43 +137,43 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
   else if (mediaType == MediaTypeMovie)
   {
     CStdString result;
-    if (field == FieldId) return "movieview.idMovie";
+    if (field == FieldId) return "movie_view.idMovie";
     else if (field == FieldTitle)
     {
       // We need some extra logic to get the title value if sorttitle isn't set
       if (queryPart == DatabaseQueryPartOrderBy)
-        result = StringUtils::Format("CASE WHEN length(movieview.c%02d) > 0 THEN movieview.c%02d ELSE movieview.c%02d END", VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
+        result = StringUtils::Format("CASE WHEN length(movie_view.c%02d) > 0 THEN movie_view.c%02d ELSE movie_view.c%02d END", VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
       else
-        result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_TITLE);
+        result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TITLE);
     }
-    else if (field == FieldPlot) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_PLOT);
-    else if (field == FieldPlotOutline) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_PLOTOUTLINE);
-    else if (field == FieldTagline) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_TAGLINE);
-    else if (field == FieldVotes) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_VOTES);
+    else if (field == FieldPlot) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_PLOT);
+    else if (field == FieldPlotOutline) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_PLOTOUTLINE);
+    else if (field == FieldTagline) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TAGLINE);
+    else if (field == FieldVotes) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_VOTES);
     else if (field == FieldRating)
     {
       if (queryPart == DatabaseQueryPartOrderBy)
-        result = StringUtils::Format("CAST(movieview.c%02d as DECIMAL(5,3))", VIDEODB_ID_RATING);
+        result = StringUtils::Format("CAST(movie_view.c%02d as DECIMAL(5,3))", VIDEODB_ID_RATING);
       else
-        result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_RATING);
+        result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_RATING);
     }
-    else if (field == FieldWriter) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_CREDITS);
-    else if (field == FieldYear) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_YEAR);
-    else if (field == FieldSortTitle) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_SORTTITLE);
-    else if (field == FieldTime) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_RUNTIME);
-    else if (field == FieldMPAA) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_MPAA);
-    else if (field == FieldTop250) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_TOP250);
-    else if (field == FieldSet) return "movieview.strSet";
-    else if (field == FieldGenre) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_GENRE);
-    else if (field == FieldDirector) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_DIRECTOR);
-    else if (field == FieldStudio) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_STUDIOS);
-    else if (field == FieldTrailer) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_TRAILER);
-    else if (field == FieldCountry) result = StringUtils::Format("movieview.c%02d", VIDEODB_ID_COUNTRY);
-    else if (field == FieldFilename) return "movieview.strFilename";
-    else if (field == FieldPath) return "movieview.strPath";
-    else if (field == FieldPlaycount) return "movieview.playCount";
-    else if (field == FieldLastPlayed) return "movieview.lastPlayed";
-    else if (field == FieldDateAdded) return "movieview.dateAdded";
+    else if (field == FieldWriter) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_CREDITS);
+    else if (field == FieldYear) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_YEAR);
+    else if (field == FieldSortTitle) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_SORTTITLE);
+    else if (field == FieldTime) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_RUNTIME);
+    else if (field == FieldMPAA) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_MPAA);
+    else if (field == FieldTop250) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TOP250);
+    else if (field == FieldSet) return "movie_view.strSet";
+    else if (field == FieldGenre) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_GENRE);
+    else if (field == FieldDirector) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_DIRECTOR);
+    else if (field == FieldStudio) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_STUDIOS);
+    else if (field == FieldTrailer) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_TRAILER);
+    else if (field == FieldCountry) result = StringUtils::Format("movie_view.c%02d", VIDEODB_ID_COUNTRY);
+    else if (field == FieldFilename) return "movie_view.strFilename";
+    else if (field == FieldPath) return "movie_view.strPath";
+    else if (field == FieldPlaycount) return "movie_view.playCount";
+    else if (field == FieldLastPlayed) return "movie_view.lastPlayed";
+    else if (field == FieldDateAdded) return "movie_view.dateAdded";
 
     if (!result.empty())
       return result;
@@ -181,30 +181,30 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
   else if (mediaType == MediaTypeTvShow)
   {
     CStdString result;
-    if (field == FieldId) return "tvshowview.idShow";
+    if (field == FieldId) return "tvshow_view.idShow";
     else if (field == FieldTitle)
     {
       // We need some extra logic to get the title value if sorttitle isn't set
       if (queryPart == DatabaseQueryPartOrderBy)
-        result = StringUtils::Format("CASE WHEN length(tvshowview.c%02d) > 0 THEN tvshowview.c%02d ELSE tvshowview.c%02d END", VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_TITLE);
+        result = StringUtils::Format("CASE WHEN length(tvshow_view.c%02d) > 0 THEN tvshow_view.c%02d ELSE tvshow_view.c%02d END", VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_SORTTITLE, VIDEODB_ID_TV_TITLE);
       else
-        result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_TITLE);
+        result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_TITLE);
     }
-    else if (field == FieldPlot) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_PLOT);
-    else if (field == FieldTvShowStatus) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_STATUS);
-    else if (field == FieldVotes) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_VOTES);
-    else if (field == FieldRating) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_RATING);
-    else if (field == FieldYear) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_PREMIERED);
-    else if (field == FieldGenre) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_GENRE);
-    else if (field == FieldMPAA) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_MPAA);
-    else if (field == FieldStudio) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_STUDIOS);
-    else if (field == FieldSortTitle) result = StringUtils::Format("tvshowview.c%02d", VIDEODB_ID_TV_SORTTITLE);
-    else if (field == FieldPath) return "tvshowview.strPath";
-    else if (field == FieldDateAdded) return "tvshowview.dateAdded";
-    else if (field == FieldLastPlayed) return "tvshowview.lastPlayed";
-    else if (field == FieldSeason) return "tvshowview.totalSeasons";
-    else if (field == FieldNumberOfEpisodes) return "tvshowview.totalCount";
-    else if (field == FieldNumberOfWatchedEpisodes) return "tvshowview.watchedcount";
+    else if (field == FieldPlot) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_PLOT);
+    else if (field == FieldTvShowStatus) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_STATUS);
+    else if (field == FieldVotes) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_VOTES);
+    else if (field == FieldRating) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_RATING);
+    else if (field == FieldYear) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_PREMIERED);
+    else if (field == FieldGenre) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_GENRE);
+    else if (field == FieldMPAA) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_MPAA);
+    else if (field == FieldStudio) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_STUDIOS);
+    else if (field == FieldSortTitle) result = StringUtils::Format("tvshow_view.c%02d", VIDEODB_ID_TV_SORTTITLE);
+    else if (field == FieldPath) return "tvshow_view.strPath";
+    else if (field == FieldDateAdded) return "tvshow_view.dateAdded";
+    else if (field == FieldLastPlayed) return "tvshow_view.lastPlayed";
+    else if (field == FieldSeason) return "tvshow_view.totalSeasons";
+    else if (field == FieldNumberOfEpisodes) return "tvshow_view.totalCount";
+    else if (field == FieldNumberOfWatchedEpisodes) return "tvshow_view.watchedcount";
 
     if (!result.empty())
       return result;
@@ -212,29 +212,29 @@ std::string DatabaseUtils::GetField(Field field, const MediaType &mediaType, Dat
   else if (mediaType == MediaTypeEpisode)
   {
     CStdString result;
-    if (field == FieldId) return "episodeview.idEpisode";
-    else if (field == FieldTitle) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_TITLE);
-    else if (field == FieldPlot) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_PLOT);
-    else if (field == FieldVotes) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_VOTES);
-    else if (field == FieldRating) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_RATING);
-    else if (field == FieldWriter) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_CREDITS);
-    else if (field == FieldAirDate) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_AIRED);
-    else if (field == FieldTime) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_RUNTIME);
-    else if (field == FieldDirector) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_DIRECTOR);
-    else if (field == FieldSeason) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_SEASON);
-    else if (field == FieldEpisodeNumber) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_EPISODE);
-    else if (field == FieldUniqueId) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_UNIQUEID);
-    else if (field == FieldEpisodeNumberSpecialSort) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_SORTEPISODE);
-    else if (field == FieldSeasonSpecialSort) result = StringUtils::Format("episodeview.c%02d", VIDEODB_ID_EPISODE_SORTSEASON);
-    else if (field == FieldFilename) return "episodeview.strFilename";
-    else if (field == FieldPath) return "episodeview.strPath";
-    else if (field == FieldPlaycount) return "episodeview.playCount";
-    else if (field == FieldLastPlayed) return "episodeview.lastPlayed";
-    else if (field == FieldDateAdded) return "episodeview.dateAdded";
-    else if (field == FieldTvShowTitle) return "episodeview.strTitle";
-    else if (field == FieldYear) return "episodeview.premiered";
-    else if (field == FieldMPAA) return "episodeview.mpaa";
-    else if (field == FieldStudio) return "episodeview.strStudio";
+    if (field == FieldId) return "episode_view.idEpisode";
+    else if (field == FieldTitle) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_TITLE);
+    else if (field == FieldPlot) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_PLOT);
+    else if (field == FieldVotes) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_VOTES);
+    else if (field == FieldRating) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_RATING);
+    else if (field == FieldWriter) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_CREDITS);
+    else if (field == FieldAirDate) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_AIRED);
+    else if (field == FieldTime) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_RUNTIME);
+    else if (field == FieldDirector) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_DIRECTOR);
+    else if (field == FieldSeason) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_SEASON);
+    else if (field == FieldEpisodeNumber) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_EPISODE);
+    else if (field == FieldUniqueId) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_UNIQUEID);
+    else if (field == FieldEpisodeNumberSpecialSort) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_SORTEPISODE);
+    else if (field == FieldSeasonSpecialSort) result = StringUtils::Format("episode_view.c%02d", VIDEODB_ID_EPISODE_SORTSEASON);
+    else if (field == FieldFilename) return "episode_view.strFilename";
+    else if (field == FieldPath) return "episode_view.strPath";
+    else if (field == FieldPlaycount) return "episode_view.playCount";
+    else if (field == FieldLastPlayed) return "episode_view.lastPlayed";
+    else if (field == FieldDateAdded) return "episode_view.dateAdded";
+    else if (field == FieldTvShowTitle) return "episode_view.strTitle";
+    else if (field == FieldYear) return "episode_view.premiered";
+    else if (field == FieldMPAA) return "episode_view.mpaa";
+    else if (field == FieldStudio) return "episode_view.strStudio";
 
     if (!result.empty())
       return result;

--- a/xbmc/utils/EdenVideoArtUpdater.cpp
+++ b/xbmc/utils/EdenVideoArtUpdater.cpp
@@ -198,7 +198,7 @@ void CEdenVideoArtUpdater::Process()
 
     // now episodes...
     CFileItemList items2;
-    db.GetEpisodesByWhere("videodb://tvshows/titles/-1/-1/", db.PrepareSQL("episodeview.idShow=%d", item->GetVideoInfoTag()->m_iDbId), items2);
+    db.GetEpisodesByWhere("videodb://tvshows/titles/-1/-1/", db.PrepareSQL("episode_view.idShow=%d", item->GetVideoInfoTag()->m_iDbId), items2);
     for (int j = 0; j < items2.Size(); j++)
     {
       handle->SetProgress(j, items2.Size());

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -317,14 +317,14 @@ bool CRecentlyAddedJob::UpdateTotal()
   musicdatabase.Close();
  
   videodatabase.Open();
-  int tvShowCount     = atoi(videodatabase.GetSingleValue("tvshowview"     , "count(1)").c_str());
-  int movieTotals     = atoi(videodatabase.GetSingleValue("movieview"      , "count(1)").c_str());
-  int movieWatched    = atoi(videodatabase.GetSingleValue("movieview"      , "count(playCount)").c_str());
-  int MusVidTotals    = atoi(videodatabase.GetSingleValue("musicvideoview" , "count(1)").c_str());
-  int MusVidWatched   = atoi(videodatabase.GetSingleValue("musicvideoview" , "count(playCount)").c_str());
-  int EpWatched       = atoi(videodatabase.GetSingleValue("tvshowview"     , "sum(watchedcount)").c_str());
-  int EpCount         = atoi(videodatabase.GetSingleValue("tvshowview"     , "sum(totalcount)").c_str());
-  int TvShowsWatched  = atoi(videodatabase.GetSingleValue("tvshowview"     , "sum(watchedcount = totalcount)").c_str());
+  int tvShowCount     = atoi(videodatabase.GetSingleValue("tvshow_view"     , "count(1)").c_str());
+  int movieTotals     = atoi(videodatabase.GetSingleValue("movie_view"      , "count(1)").c_str());
+  int movieWatched    = atoi(videodatabase.GetSingleValue("movie_view"      , "count(playCount)").c_str());
+  int MusVidTotals    = atoi(videodatabase.GetSingleValue("musicvideo_view" , "count(1)").c_str());
+  int MusVidWatched   = atoi(videodatabase.GetSingleValue("musicvideo_view" , "count(playCount)").c_str());
+  int EpWatched       = atoi(videodatabase.GetSingleValue("tvshow_view"     , "sum(watchedcount)").c_str());
+  int EpCount         = atoi(videodatabase.GetSingleValue("tvshow_view"     , "sum(totalcount)").c_str());
+  int TvShowsWatched  = atoi(videodatabase.GetSingleValue("tvshow_view"     , "sum(watchedcount = totalcount)").c_str());
   videodatabase.Close();
   
   home->SetProperty("TVShows.Count"         , tvShowCount);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -239,6 +239,21 @@ void CVideoDatabase::CreateTables()
   m_pDS->exec("CREATE TABLE taglinks (idTag integer, idMedia integer, media_type TEXT)");
 }
 
+void CVideoDatabase::CreateLinkIndex(const char *table)
+{
+  m_pDS->exec(PrepareSQL("CREATE UNIQUE INDEX ix_%s_1 ON %s (name(255))", table, table));
+  m_pDS->exec(PrepareSQL("CREATE UNIQUE INDEX ix_%s_link_1 ON %s_link (%s_id, media_type(20), media_id)", table, table, table));
+  m_pDS->exec(PrepareSQL("CREATE UNIQUE INDEX ix_%s_link_2 ON %s_link (media_id, media_type(20), %s_id)", table, table, table));
+  m_pDS->exec(PrepareSQL("CREATE INDEX ix_%s_link_3 ON %s_link (media_type(20))", table, table));
+}
+
+void CVideoDatabase::CreateForeignLinkIndex(const char *table, const char *foreignkey)
+{
+  m_pDS->exec(PrepareSQL("CREATE UNIQUE INDEX ix_%s_link_1 ON %s_link (%s_id, media_type(20), media_id)", table, table, foreignkey));
+  m_pDS->exec(PrepareSQL("CREATE UNIQUE INDEX ix_%s_link_2 ON %s_link (media_id, media_type(20), %s_id)", table, table, foreignkey));
+  m_pDS->exec(PrepareSQL("CREATE INDEX ix_%s_link_3 ON %s_link (media_type(20))", table, table));
+}
+
 void CVideoDatabase::CreateAnalytics()
 {
   /* indexes should be added on any columns that are used in in  */

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -318,8 +318,8 @@ void CVideoDatabase::CreateAnalytics()
 
 void CVideoDatabase::CreateViews()
 {
-  CLog::Log(LOGINFO, "create episodeview");
-  CStdString episodeview = PrepareSQL("CREATE VIEW episodeview AS SELECT "
+  CLog::Log(LOGINFO, "create episode_view");
+  CStdString episodeview = PrepareSQL("CREATE VIEW episode_view AS SELECT "
                                       "  episode.*,"
                                       "  files.strFileName AS strFileName,"
                                       "  path.strPath AS strPath,"
@@ -346,7 +346,7 @@ void CVideoDatabase::CreateViews()
                                       "    bookmark.idFile=episode.idFile AND bookmark.type=1", VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_PREMIERED, VIDEODB_ID_TV_MPAA,VIDEODB_ID_EPISODE_SEASON);
   m_pDS->exec(episodeview.c_str());
 
-  /* NOTE: The tvshowview needs to have "GROUP BY tvshow.idShow" added to any usage if you wish to
+  /* NOTE: The tvshow_view needs to have "GROUP BY tvshow.idShow" added to any usage if you wish to
            avoid duplicates due to multiple paths per tvshow (from the join on tvshowlinkpath) */
   CLog::Log(LOGINFO, "create tvshowcounts");
   CStdString tvshowcounts = PrepareSQL("CREATE VIEW tvshowcounts AS SELECT "
@@ -364,8 +364,8 @@ void CVideoDatabase::CreateViews()
                                        "    GROUP BY tvshow.idShow");
   m_pDS->exec(tvshowcounts.c_str());
 
-  CLog::Log(LOGINFO, "create tvshowview");
-  CStdString tvshowview = PrepareSQL("CREATE VIEW tvshowview AS SELECT "
+  CLog::Log(LOGINFO, "create tvshow_view");
+  CStdString tvshowview = PrepareSQL("CREATE VIEW tvshow_view AS SELECT "
                                      "  tvshow.*,"
                                      "  path.idParentPath AS idParentPath,"
                                      "  path.strPath AS strPath,"
@@ -380,33 +380,33 @@ void CVideoDatabase::CreateViews()
                                      "  tvshow.idShow = tvshowcounts.idShow");
   m_pDS->exec(tvshowview.c_str());
 
-  CLog::Log(LOGINFO, "create seasonview");
-  CStdString seasonview = PrepareSQL("CREATE VIEW seasonview AS SELECT "
+  CLog::Log(LOGINFO, "create season_view");
+  CStdString seasonview = PrepareSQL("CREATE VIEW season_view AS SELECT "
                                      "  seasons.*, "
-                                     "  tvshowview.strPath AS strPath,"
-                                     "  tvshowview.c%02d AS showTitle,"
-                                     "  tvshowview.c%02d AS plot,"
-                                     "  tvshowview.c%02d AS premiered,"
-                                     "  tvshowview.c%02d AS genre,"
-                                     "  tvshowview.c%02d AS studio,"
-                                     "  tvshowview.c%02d AS mpaa,"
-                                     "  count(DISTINCT episodeview.idEpisode) AS episodes,"
+                                     "  tvshow_view.strPath AS strPath,"
+                                     "  tvshow_view.c%02d AS showTitle,"
+                                     "  tvshow_view.c%02d AS plot,"
+                                     "  tvshow_view.c%02d AS premiered,"
+                                     "  tvshow_view.c%02d AS genre,"
+                                     "  tvshow_view.c%02d AS studio,"
+                                     "  tvshow_view.c%02d AS mpaa,"
+                                     "  count(DISTINCT episode_view.idEpisode) AS episodes,"
                                      "  count(files.playCount) AS playCount "
                                      "FROM seasons"
-                                     "  JOIN tvshowview ON"
-                                     "    tvshowview.idShow = seasons.idShow"
-                                     "  JOIN episodeview ON"
-                                     "    episodeview.idShow = seasons.idShow AND episodeview.c%02d = seasons.season"
+                                     "  JOIN tvshow_view ON"
+                                     "    tvshow_view.idShow = seasons.idShow"
+                                     "  JOIN episode_view ON"
+                                     "    episode_view.idShow = seasons.idShow AND episode_view.c%02d = seasons.season"
                                      "  JOIN files ON"
-                                     "    files.idFile = episodeview.idFile "
+                                     "    files.idFile = episode_view.idFile "
                                      "GROUP BY seasons.idSeason",
                                      VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_PLOT, VIDEODB_ID_TV_PREMIERED,
                                      VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA,
                                      VIDEODB_ID_EPISODE_SEASON);
   m_pDS->exec(seasonview.c_str());
 
-  CLog::Log(LOGINFO, "create musicvideoview");
-  m_pDS->exec("CREATE VIEW musicvideoview AS SELECT"
+  CLog::Log(LOGINFO, "create musicvideo_view");
+  m_pDS->exec("CREATE VIEW musicvideo_view AS SELECT"
               "  musicvideo.*,"
               "  files.strFileName as strFileName,"
               "  path.strPath as strPath,"
@@ -423,8 +423,8 @@ void CVideoDatabase::CreateViews()
               "  LEFT JOIN bookmark ON"
               "    bookmark.idFile=musicvideo.idFile AND bookmark.type=1");
 
-  CLog::Log(LOGINFO, "create movieview");
-  m_pDS->exec("CREATE VIEW movieview AS SELECT"
+  CLog::Log(LOGINFO, "create movie_view");
+  m_pDS->exec("CREATE VIEW movie_view AS SELECT"
               "  movie.*,"
               "  sets.strSet AS strSet,"
               "  files.strFileName AS strFileName,"
@@ -1696,36 +1696,36 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
 void CVideoDatabase::GetMoviesByActor(const CStdString& name, CFileItemList& items)
 {
   Filter filter;
-  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=movieview.idMovie AND actor_link.media_type='movie' "
+  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=movie_view.idMovie AND actor_link.media_type='movie' "
                  "LEFT JOIN actor a ON a.actor_id=actor_link.actor_id "
-                 "LEFT JOIN director_link ON director_link.media_id=movieview.idMovie AND director_link.media_type='movie' "
+                 "LEFT JOIN director_link ON director_link.media_id=movie_view.idMovie AND director_link.media_type='movie' "
                  "LEFT JOIN actor d ON d.actor_id=director_link.actor_id";
   filter.where = PrepareSQL("a.name='%s' OR d.name='%s'", name.c_str(), name.c_str());
-  filter.group = "movieview.idMovie";
+  filter.group = "movie_view.idMovie";
   GetMoviesByWhere("videodb://movies/titles/", filter, items);
 }
 
 void CVideoDatabase::GetTvShowsByActor(const CStdString& name, CFileItemList& items)
 {
   Filter filter;
-  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=tvshowview.idShow AND actor_link.media_type='tvshow' "
+  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=tvshow_view.idShow AND actor_link.media_type='tvshow' "
                  "LEFT JOIN actor a ON a.actor_id=actor_link.actor_id "
-                 "LEFT JOIN director_link ON director_link.media_id=tvshowview.idShow AND director_link.media_type='tvshow' "
+                 "LEFT JOIN director_link ON director_link.media_id=tvshow_view.idShow AND director_link.media_type='tvshow' "
                  "LEFT JOIN actor d ON d.actor_id=director_link.actor_id";
   filter.where = PrepareSQL("a.name='%s' OR d.name='%s'", name.c_str(), name.c_str());
-  filter.group = "tvshowview.idShow";
+  filter.group = "tvshow_view.idShow";
   GetTvShowsByWhere("videodb://tvshows/titles/", filter, items);
 }
 
 void CVideoDatabase::GetEpisodesByActor(const CStdString& name, CFileItemList& items)
 {
   Filter filter;
-  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=episodeview.idEpisode AND actor_link.media_type='episode' "
+  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=episode_view.idEpisode AND actor_link.media_type='episode' "
                  "LEFT JOIN actor a ON a.actor_id=actor_link.actor_id "
-                 "LEFT JOIN director_link ON director_link.media_id=episodeview.idEpisode AND director_link.media_type='episode' "
+                 "LEFT JOIN director_link ON director_link.media_id=episode_view.idEpisode AND director_link.media_type='episode' "
                  "LEFT JOIN actor d ON d.actor_id=director_link.actor_id";
   filter.where = PrepareSQL("a.name='%s' OR d.name='%s'", name.c_str(), name.c_str());
-  filter.group = "episodeview.idEpisode";
+  filter.group = "episode_view.idEpisode";
   GetEpisodesByWhere("videodb://tvshows/titles/", filter, items);
 }
 
@@ -1739,9 +1739,9 @@ void CVideoDatabase::GetMusicVideosByArtist(const CStdString& strArtist, CFileIt
 
     CStdString strSQL;
     if (strArtist.empty())  // TODO: SMARTPLAYLISTS what is this here for???
-      strSQL=PrepareSQL("select distinct * from musicvideoview join actor_link on actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id");
+      strSQL=PrepareSQL("select distinct * from musicvideo_view join actor_link on actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id");
     else
-      strSQL=PrepareSQL("select * from musicvideoview join actor_link on actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where actor.name='%s'", strArtist.c_str());
+      strSQL=PrepareSQL("select * from musicvideo_view join actor_link on actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where actor.name='%s'", strArtist.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -1770,7 +1770,7 @@ bool CVideoDatabase::GetMovieInfo(const CStdString& strFilenameAndPath, CVideoIn
       idMovie = GetMovieId(strFilenameAndPath);
     if (idMovie < 0) return false;
 
-    CStdString sql = PrepareSQL("select * from movieview where idMovie=%i", idMovie);
+    CStdString sql = PrepareSQL("select * from movie_view where idMovie=%i", idMovie);
     if (!m_pDS->query(sql.c_str()))
       return false;
     details = GetDetailsForMovie(m_pDS, true);
@@ -1792,7 +1792,7 @@ bool CVideoDatabase::GetTvShowInfo(const CStdString& strPath, CVideoInfoTag& det
       idTvShow = GetTvShowId(strPath);
     if (idTvShow < 0) return false;
 
-    CStdString sql = PrepareSQL("SELECT * FROM tvshowview WHERE idShow=%i GROUP BY idShow", idTvShow);
+    CStdString sql = PrepareSQL("SELECT * FROM tvshow_view WHERE idShow=%i GROUP BY idShow", idTvShow);
     if (!m_pDS->query(sql.c_str()))
       return false;
     details = GetDetailsForTvShow(m_pDS, true, item);
@@ -1858,7 +1858,7 @@ bool CVideoDatabase::GetEpisodeInfo(const CStdString& strFilenameAndPath, CVideo
       idEpisode = GetEpisodeId(strFilenameAndPath);
     if (idEpisode < 0) return false;
 
-    CStdString sql = PrepareSQL("select * from episodeview where idEpisode=%i",idEpisode);
+    CStdString sql = PrepareSQL("select * from episode_view where idEpisode=%i",idEpisode);
     if (!m_pDS->query(sql.c_str()))
       return false;
     details = GetDetailsForEpisode(m_pDS, true);
@@ -1880,7 +1880,7 @@ bool CVideoDatabase::GetMusicVideoInfo(const CStdString& strFilenameAndPath, CVi
       idMVideo = GetMusicVideoId(strFilenameAndPath);
     if (idMVideo < 0) return false;
 
-    CStdString sql = PrepareSQL("select * from musicvideoview where idMVideo=%i", idMVideo);
+    CStdString sql = PrepareSQL("select * from musicvideo_view where idMVideo=%i", idMVideo);
     if (!m_pDS->query(sql.c_str()))
       return false;
     details = GetDetailsForMusicVideo(m_pDS, true);
@@ -2669,7 +2669,7 @@ void CVideoDatabase::GetEpisodesByFile(const CStdString& strFilenameAndPath, vec
 {
   try
   {
-    CStdString strSQL = PrepareSQL("select * from episodeview where idFile=%i order by c%02d, c%02d asc", GetFileId(strFilenameAndPath), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
+    CStdString strSQL = PrepareSQL("select * from episode_view where idFile=%i order by c%02d, c%02d asc", GetFileId(strFilenameAndPath), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
     m_pDS->query(strSQL.c_str());
     while (!m_pDS->eof())
     {
@@ -4948,8 +4948,8 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
       extFilter.fields = PrepareSQL("%s.%s_id, %s.name, path.strPath", type, type, type);
       extFilter.AppendField(extraField);
       extFilter.AppendJoin(PrepareSQL("JOIN %s_link ON %s.%s_id = %s_link.%s_id", type, type, type, type, type));
-      extFilter.AppendJoin(PrepareSQL("JOIN %sview ON %s_link.media_id = %sview.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
-      extFilter.AppendJoin(PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str()));
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_view ON %s_link.media_id = %s_view.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
+      extFilter.AppendJoin(PrepareSQL("JOIN files ON files.idFile = %s_view.idFile", view.c_str()));
       extFilter.AppendJoin("JOIN path ON path.idPath = files.idPath");
     }
     else
@@ -4961,7 +4961,7 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
         view_id    = "idMovie";
         media_type = MediaTypeMovie;
         extraField = "count(1), count(files.playCount)";
-        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %s_view.idFile", view.c_str());
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS)
       {
@@ -4975,7 +4975,7 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
         view_id    = "idMVideo";
         media_type = MediaTypeMusicVideo;
         extraField = "count(1), count(files.playCount)";
-        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %s_view.idFile", view.c_str());
       }
       else
         return false;
@@ -4984,7 +4984,7 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
       extFilter.fields = PrepareSQL("%s.%s_id, %s.name", type, type, type);
       extFilter.AppendField(extraField);
       extFilter.AppendJoin(PrepareSQL("JOIN %s_link ON %s.%s_id = %s_link.%s_id", type, type, type, type, type));
-      extFilter.AppendJoin(PrepareSQL("JOIN %sview ON %s_link.media_id = %sview.%s AND %s_link.media_type='%s'",
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_view ON %s_link.media_id = %s_view.%s AND %s_link.media_type='%s'",
                                       view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
       extFilter.AppendJoin(extraJoin);
       extFilter.AppendGroup(PrepareSQL("%s.%s_id", type, type));
@@ -5121,7 +5121,7 @@ bool CVideoDatabase::GetTagsNav(const CStdString& strBaseDir, CFileItemList& ite
     extFilter.AppendJoin("JOIN tag ON tag.tag_id = tag_link.tag_id");
 
     if (idContent == (int)VIDEODB_CONTENT_MOVIES)
-      extFilter.AppendJoin("JOIN movieview ON movieview.idMovie = tag_link.media_id");
+      extFilter.AppendJoin("JOIN movie_view ON movie_view.idMovie = tag_link.media_id");
 
     extFilter.AppendWhere(PrepareSQL("tag_link.media_type = '%s'", mediaType.c_str()));
     extFilter.AppendGroup("tag_link.tag_id");
@@ -5206,7 +5206,7 @@ bool CVideoDatabase::GetSetsByWhere(const CStdString& strBaseDir, const Filter &
       return false;
 
     Filter setFilter = filter;
-    setFilter.join += " JOIN sets ON movieview.idSet = sets.idSet";
+    setFilter.join += " JOIN sets ON movie_view.idSet = sets.idSet";
     if (!setFilter.order.empty())
       setFilter.order += ",";
     setFilter.order += "sets.idSet";
@@ -5241,21 +5241,21 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
     if (!videoUrl.FromString(strBaseDir))
       return false;
 
-    CStdString strSQL = "select %s from musicvideoview ";
+    CStdString strSQL = "select %s from musicvideo_view ";
     Filter extFilter = filter;
-    extFilter.fields = PrepareSQL("musicvideoview.c%02d, musicvideoview.idMVideo, actor.name", VIDEODB_ID_MUSICVIDEO_ALBUM);
-    extFilter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo'"));
+    extFilter.fields = PrepareSQL("musicvideo_view.c%02d, musicvideo_view.idMVideo, actor.name", VIDEODB_ID_MUSICVIDEO_ALBUM);
+    extFilter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo'"));
     extFilter.AppendJoin(PrepareSQL("JOIN actor ON actor.actor_id = actor_link.actor_id"));
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       extFilter.fields += " path.strPath";
-      extFilter.AppendJoin("join files on files.idFile = musicvideoview.idFile join path on path.idPath = files.idPath");
+      extFilter.AppendJoin("join files on files.idFile = musicvideo_view.idFile join path on path.idPath = files.idPath");
     }
 
     if (idArtist > -1)
       videoUrl.AddOption("artistid", idArtist);
 
-    extFilter.AppendGroup(PrepareSQL("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_ALBUM));
+    extFilter.AppendGroup(PrepareSQL("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_ALBUM));
 
     if (countOnly)
     {
@@ -5442,8 +5442,8 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
       extFilter.fields = "actor.actor_id, actor.name, actor.art_urls, path.strPath";
       extFilter.AppendField(extraField);
       extFilter.AppendJoin(PrepareSQL("JOIN %s_link ON actor.actor_id = %s_link.actor_id", type, type));
-      extFilter.AppendJoin(PrepareSQL("JOIN %sview ON %s_link.media_id = %sview.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
-      extFilter.AppendJoin(PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str()));
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_view ON %s_link.media_id = %s_view.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
+      extFilter.AppendJoin(PrepareSQL("JOIN files ON files.idFile = %s_view.idFile", view.c_str()));
       extFilter.AppendJoin("JOIN path ON path.idPath = files.idPath");
     }
     else
@@ -5455,7 +5455,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
         view_id    = "idMovie";
         media_type = MediaTypeMovie;
         extraField = "count(1), count(files.playCount)";
-        extraJoin  = PrepareSQL(" JOIN files ON files.idFile=%sview.idFile", view.c_str());
+        extraJoin  = PrepareSQL(" JOIN files ON files.idFile=%s_view.idFile", view.c_str());
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS)
       {
@@ -5469,7 +5469,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
         view_id    = "idEpisode";
         media_type = MediaTypeEpisode;
         extraField = "count(1), count(files.playCount)";
-        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %s_view.idFile", view.c_str());
       }
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {
@@ -5477,7 +5477,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
         view_id    = "idMVideo";
         media_type = MediaTypeMusicVideo;
         extraField = "count(1), count(files.playCount)";
-        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %s_view.idFile", view.c_str());
       }
       else
         return false;
@@ -5486,7 +5486,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
       extFilter.fields = "actor.actor_id, actor.name, actor.art_urls";
       extFilter.AppendField(extraField);
       extFilter.AppendJoin(PrepareSQL("JOIN %s_link on actor.actor_id = %s_link.actor_id", type, type));
-      extFilter.AppendJoin(PrepareSQL("JOIN %sview on %s_link.media_id = %sview.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_view on %s_link.media_id = %s_view.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
       extFilter.AppendJoin(extraJoin);
       extFilter.AppendGroup("actor.actor_id");
     }
@@ -5630,18 +5630,18 @@ bool CVideoDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
     {
       if (idContent == VIDEODB_CONTENT_MOVIES)
       {
-        strSQL = PrepareSQL("select movieview.c%02d, path.strPath, files.playCount from movieview ", VIDEODB_ID_YEAR);
-        extFilter.AppendJoin("join files on files.idFile = movieview.idFile join path on files.idPath = path.idPath");
+        strSQL = PrepareSQL("select movie_view.c%02d, path.strPath, files.playCount from movie_view ", VIDEODB_ID_YEAR);
+        extFilter.AppendJoin("join files on files.idFile = movie_view.idFile join path on files.idPath = path.idPath");
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS)
       {
-        strSQL = PrepareSQL("select tvshowview.c%02d, path.strPath from tvshowview ", VIDEODB_ID_TV_PREMIERED);
-        extFilter.AppendJoin("join episodeview on episodeview.idShow = tvshowview.idShow join files on files.idFile = episodeview.idFile join path on files.idPath = path.idPath");
+        strSQL = PrepareSQL("select tvshow_view.c%02d, path.strPath from tvshow_view ", VIDEODB_ID_TV_PREMIERED);
+        extFilter.AppendJoin("join episode_view on episode_view.idShow = tvshow_view.idShow join files on files.idFile = episode_view.idFile join path on files.idPath = path.idPath");
       }
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {
-        strSQL = PrepareSQL("select musicvideoview.c%02d, path.strPath, files.playCount from musicvideoview ", VIDEODB_ID_MUSICVIDEO_YEAR);
-        extFilter.AppendJoin("join files on files.idFile = musicvideoview.idFile join path on files.idPath = path.idPath");
+        strSQL = PrepareSQL("select musicvideo_view.c%02d, path.strPath, files.playCount from musicvideo_view ", VIDEODB_ID_MUSICVIDEO_YEAR);
+        extFilter.AppendJoin("join files on files.idFile = musicvideo_view.idFile join path on files.idPath = path.idPath");
       }
       else
         return false;
@@ -5651,17 +5651,17 @@ bool CVideoDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
       CStdString group;
       if (idContent == VIDEODB_CONTENT_MOVIES)
       {
-        strSQL = PrepareSQL("select movieview.c%02d, count(1), count(files.playCount) from movieview ", VIDEODB_ID_YEAR);
-        extFilter.AppendJoin("join files on files.idFile = movieview.idFile");
-        extFilter.AppendGroup(PrepareSQL("movieview.c%02d", VIDEODB_ID_YEAR));
+        strSQL = PrepareSQL("select movie_view.c%02d, count(1), count(files.playCount) from movie_view ", VIDEODB_ID_YEAR);
+        extFilter.AppendJoin("join files on files.idFile = movie_view.idFile");
+        extFilter.AppendGroup(PrepareSQL("movie_view.c%02d", VIDEODB_ID_YEAR));
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS)
-        strSQL = PrepareSQL("select distinct tvshowview.c%02d from tvshowview", VIDEODB_ID_TV_PREMIERED);
+        strSQL = PrepareSQL("select distinct tvshow_view.c%02d from tvshow_view", VIDEODB_ID_TV_PREMIERED);
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {
-        strSQL = PrepareSQL("select musicvideoview.c%02d, count(1), count(files.playCount) from musicvideoview ", VIDEODB_ID_MUSICVIDEO_YEAR);
-        extFilter.AppendJoin("join files on files.idFile = musicvideoview.idFile");
-        extFilter.AppendGroup(PrepareSQL("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_YEAR));
+        strSQL = PrepareSQL("select musicvideo_view.c%02d, count(1), count(files.playCount) from musicvideo_view ", VIDEODB_ID_MUSICVIDEO_YEAR);
+        extFilter.AppendJoin("join files on files.idFile = musicvideo_view.idFile");
+        extFilter.AppendGroup(PrepareSQL("musicvideo_view.c%02d", VIDEODB_ID_MUSICVIDEO_YEAR));
       }
       else
         return false;
@@ -5805,7 +5805,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
   if (getLinkedMovies && idShow != -1)
   {
     Filter movieFilter;
-    movieFilter.join = PrepareSQL("join movielinktvshow on movielinktvshow.idMovie=movieview.idMovie");
+    movieFilter.join = PrepareSQL("join movielinktvshow on movielinktvshow.idMovie=movie_view.idMovie");
     movieFilter.where = PrepareSQL("movielinktvshow.idShow = %i", idShow);
     CFileItemList movieItems;
     GetMoviesByWhere("videodb://movies/titles/", movieFilter, movieItems);
@@ -5829,7 +5829,7 @@ bool CVideoDatabase::GetSeasonsByWhere(const CStdString& strBaseDir, const Filte
     if (!videoUrl.FromString(strBaseDir))
       return false;
 
-    CStdString strSQL = "SELECT * FROM seasonview ";
+    CStdString strSQL = "SELECT * FROM season_view ";
 
     Filter extFilter = filter;
     if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
@@ -6086,7 +6086,7 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter
 
     int total = -1;
 
-    std::string strSQL = "select %s from movieview ";
+    std::string strSQL = "select %s from movie_view ";
     std::string strSQLExtra;
     if (!CDatabase::BuildSQL(strSQLExtra, extFilter, strSQLExtra))
       return false;
@@ -6189,11 +6189,11 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filte
 
     int total = -1;
     
-    std::string strSQL = "SELECT %s FROM tvshowview ";
+    std::string strSQL = "SELECT %s FROM tvshow_view ";
     CVideoDbUrl videoUrl;
     std::string strSQLExtra;
     Filter extFilter = filter;
-    extFilter.AppendGroup("tvshowview.idShow");
+    extFilter.AppendGroup("tvshow_view.idShow");
     SortDescription sorting = sortDescription;
     if (!BuildSQL(strBaseDir, strSQLExtra, extFilter, strSQLExtra, videoUrl, sorting))
       return false;
@@ -6293,7 +6293,7 @@ bool CVideoDatabase::GetEpisodesNav(const CStdString& strBaseDir, CFileItemList&
   if (idSeason == -1 && idShow != -1)
   { // add any linked movies
     Filter movieFilter;
-    movieFilter.join  = PrepareSQL("join movielinktvshow on movielinktvshow.idMovie=movieview.idMovie");
+    movieFilter.join  = PrepareSQL("join movielinktvshow on movielinktvshow.idMovie=movie_view.idMovie");
     movieFilter.where = PrepareSQL("movielinktvshow.idShow = %i", idShow);
     CFileItemList movieItems;
     GetMoviesByWhere("videodb://movies/titles/", movieFilter, movieItems);
@@ -6317,7 +6317,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filt
 
     int total = -1;
     
-    std::string strSQL = "select %s from episodeview ";
+    std::string strSQL = "select %s from episode_view ";
     CVideoDbUrl videoUrl;
     std::string strSQLExtra;
     Filter extFilter = filter;
@@ -6493,9 +6493,9 @@ bool CVideoDatabase::HasSets() const
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    m_pDS->query("SELECT movieview.idSet,COUNT(1) AS c FROM movieview "
-                 "JOIN sets ON sets.idSet = movieview.idSet "
-                 "GROUP BY movieview.idSet HAVING c>1");
+    m_pDS->query("SELECT movie_view.idSet,COUNT(1) AS c FROM movie_view "
+                 "JOIN sets ON sets.idSet = movie_view.idSet "
+                 "GROUP BY movie_view.idSet HAVING c>1");
 
     bool bResult = (m_pDS->num_rows() > 0);
     m_pDS->close();
@@ -6586,7 +6586,7 @@ int CVideoDatabase::GetMusicVideoCount(const CStdString& strWhere)
     if (NULL == m_pDB.get()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
-    CStdString strSQL = StringUtils::Format("select count(1) as nummovies from musicvideoview where %s",strWhere.c_str());
+    CStdString strSQL = StringUtils::Format("select count(1) as nummovies from musicvideo_view where %s",strWhere.c_str());
     m_pDS->query( strSQL.c_str() );
 
     int iResult = 0;
@@ -6774,7 +6774,7 @@ CStdString CVideoDatabase::GetContentForPath(const CStdString& strPath)
       // 1. if episodes are in the path then we're in episodes.
       // 2. if no episodes are found, and content was set directly on this path, then we're in shows.
       // 3. if no episodes are found, and content was not set directly on this path, we're in seasons (assumes tvshows/seasons/episodes)
-      CStdString sql = PrepareSQL("select count(1) from episodeview where strPath = '%s' limit 1", strPath.c_str());
+      CStdString sql = PrepareSQL("select count(1) from episode_view where strPath = '%s' limit 1", strPath.c_str());
       m_pDS->query( sql.c_str() );
       if (m_pDS->num_rows() && m_pDS->fv(0).get_asInt() > 0)
         return "episodes";
@@ -7169,7 +7169,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filt
 
     int total = -1;
     
-    std::string strSQL = "select %s from musicvideoview ";
+    std::string strSQL = "select %s from musicvideo_view ";
     CVideoDbUrl videoUrl;
     std::string strSQLExtra;
     Filter extFilter = filter;
@@ -7245,7 +7245,7 @@ unsigned int CVideoDatabase::GetMusicVideoIDs(const CStdString& strWhere, vector
     if (NULL == m_pDB.get()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
-    CStdString strSQL = "select distinct idMVideo from musicvideoview " + strWhere;
+    CStdString strSQL = "select distinct idMVideo from musicvideo_view " + strWhere;
     if (!m_pDS->query(strSQL.c_str())) return 0;
     songIDs.clear();
     if (m_pDS->num_rows() == 0)
@@ -7279,7 +7279,7 @@ bool CVideoDatabase::GetRandomMusicVideo(CFileItem* item, int& idSong, const CSt
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted.
-    CStdString strSQL = StringUtils::Format("select * from musicvideoview where %s", strWhere.c_str());
+    CStdString strSQL = StringUtils::Format("select * from musicvideo_view where %s", strWhere.c_str());
     strSQL += PrepareSQL(" order by RANDOM() limit 1");
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
@@ -8249,7 +8249,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
 
     progress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
     // find all movies
-    CStdString sql = "select * from movieview";
+    CStdString sql = "select * from movie_view";
 
     m_pDS->query(sql.c_str());
 
@@ -8382,7 +8382,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
     m_pDS->close();
 
     // find all musicvideos
-    sql = "select * from musicvideoview";
+    sql = "select * from musicvideo_view";
 
     m_pDS->query(sql.c_str());
 
@@ -8477,7 +8477,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
     m_pDS->close();
 
     // repeat for all tvshows
-    sql = "SELECT * FROM tvshowview GROUP BY tvshowview.idShow";
+    sql = "SELECT * FROM tvshow_view GROUP BY tvshow_view.idShow";
     m_pDS->query(sql.c_str());
 
     total = m_pDS->num_rows();
@@ -8596,7 +8596,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
       }
 
       // now save the episodes from this show
-      sql = PrepareSQL("select * from episodeview where idShow=%i order by strFileName, idEpisode",tvshow.m_iDbId);
+      sql = PrepareSQL("select * from episode_view where idShow=%i order by strFileName, idEpisode",tvshow.m_iDbId);
       pDS->query(sql.c_str());
       CStdString showDir(item.GetPath());
 
@@ -9169,7 +9169,7 @@ void CVideoDatabase::AppendIdFilter(const char* field, const char *table, const 
   CUrlOptions::UrlOptions::const_iterator option = options.find((std::string)field + "id");
   if (option != options.end())
   {
-    filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%sview.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType));
+    filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%s_view.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType));
     filter.AppendWhere(PrepareSQL("%s_link.%s_id = %i", field, table, (int)option->second.asInteger()));
   }
 }
@@ -9179,7 +9179,7 @@ void CVideoDatabase::AppendFilter(const char* field, const char *table, const ch
   CUrlOptions::UrlOptions::const_iterator option = options.find(field);
   if (option != options.end())
   {
-    filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%sview.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType));
+    filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%s_view.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType));
     filter.AppendJoin(PrepareSQL("JOIN %s ON %s.%s_id=%s_link.%s_id", table, table, field, table));
     filter.AppendWhere(PrepareSQL("%s.name like '%s'", table, option->second.asString().c_str()));
   }
@@ -9211,18 +9211,18 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
     option = options.find("year");
     if (option != options.end())
-      filter.AppendWhere(PrepareSQL("movieview.c%02d = '%i'", VIDEODB_ID_YEAR, (int)option->second.asInteger()));
+      filter.AppendWhere(PrepareSQL("movie_view.c%02d = '%i'", VIDEODB_ID_YEAR, (int)option->second.asInteger()));
 
     AppendIdFilter("actor", "actor", "movie", "movie", "idMovie", options, filter);
     AppendFilter("actor", "actor", "movie", "movie", "idMovie", options, filter);
 
     option = options.find("setid");
     if (option != options.end())
-      filter.AppendWhere(PrepareSQL("movieview.idSet = %i", (int)option->second.asInteger()));
+      filter.AppendWhere(PrepareSQL("movie_view.idSet = %i", (int)option->second.asInteger()));
 
     option = options.find("set");
     if (option != options.end())
-      filter.AppendWhere(PrepareSQL("movieview.strSet LIKE '%s'i", option->second.asString().c_str()));
+      filter.AppendWhere(PrepareSQL("movie_view.strSet LIKE '%s'i", option->second.asString().c_str()));
 
     AppendIdFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);
     AppendFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);
@@ -9241,7 +9241,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
       option = options.find("year");
       if (option != options.end())
-        filter.AppendWhere(PrepareSQL("tvshowview.c%02d like '%%%i%%'", VIDEODB_ID_TV_PREMIERED, (int)option->second.asInteger()));
+        filter.AppendWhere(PrepareSQL("tvshow_view.c%02d like '%%%i%%'", VIDEODB_ID_TV_PREMIERED, (int)option->second.asInteger()));
 
       AppendIdFilter("actor", "actor", "tvshow", "tvshow", "idShow", options, filter);
       AppendFilter("actor", "actor", "tvshow", "tvshow", "idShow", options, filter);
@@ -9253,7 +9253,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     {
       option = options.find("tvshowid");
       if (option != options.end())
-        filter.AppendWhere(PrepareSQL("seasonview.idShow = %i", (int)option->second.asInteger()));
+        filter.AppendWhere(PrepareSQL("season_view.idShow = %i", (int)option->second.asInteger()));
 
       AppendIdFilter("genre", "genre", "tvshow", "season", "idShow", options, filter);
 
@@ -9261,7 +9261,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
       option = options.find("year");
       if (option != options.end())
-        filter.AppendWhere(PrepareSQL("seasonview.premiered like '%%%i%%'", (int)option->second.asInteger()));
+        filter.AppendWhere(PrepareSQL("season_view.premiered like '%%%i%%'", (int)option->second.asInteger()));
 
       AppendIdFilter("actor", "actor", "tvshow", "season", "idShow", options, filter);
     }
@@ -9291,21 +9291,21 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         if (option != options.end())
         {
           condition = true;
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and episodeview.premiered like '%%%i%%'", idShow, (int)option->second.asInteger()));
+          filter.AppendWhere(PrepareSQL("episode_view.idShow = %i and episode_view.premiered like '%%%i%%'", idShow, (int)option->second.asInteger()));
         }
 
         AppendIdFilter("actor", "actor", "tvshow", "episode", "idShow", options, filter);
         AppendFilter("actor", "actor", "tvshow", "episode", "idShow", options, filter);
 
         if (!condition)
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i", idShow));
+          filter.AppendWhere(PrepareSQL("episode_view.idShow = %i", idShow));
 
         if (season > -1)
         {
           if (season == 0) // season = 0 indicates a special - we grab all specials here (see below)
-            filter.AppendWhere(PrepareSQL("episodeview.c%02d = %i", VIDEODB_ID_EPISODE_SEASON, season));
+            filter.AppendWhere(PrepareSQL("episode_view.c%02d = %i", VIDEODB_ID_EPISODE_SEASON, season));
           else
-            filter.AppendWhere(PrepareSQL("(episodeview.c%02d = %i or (episodeview.c%02d = 0 and (episodeview.c%02d = 0 or episodeview.c%02d = %i)))",
+            filter.AppendWhere(PrepareSQL("(episode_view.c%02d = %i or (episode_view.c%02d = 0 and (episode_view.c%02d = 0 or episode_view.c%02d = %i)))",
               VIDEODB_ID_EPISODE_SEASON, season, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTSEASON, season));
         }
       }
@@ -9313,7 +9313,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       {
         option = options.find("year");
         if (option != options.end())
-          filter.AppendWhere(PrepareSQL("episodeview.premiered like '%%%i%%'", (int)option->second.asInteger()));
+          filter.AppendWhere(PrepareSQL("episode_view.premiered like '%%%i%%'", (int)option->second.asInteger()));
 
         AppendIdFilter("director", "actor", "episode", "episode", "idEpisode", options, filter);
         AppendFilter("director", "actor", "episode", "episode", "idEpisode", options, filter);
@@ -9333,13 +9333,13 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
     option = options.find("year");
     if (option != options.end())
-      filter.AppendWhere(PrepareSQL("musicvideoview.c%02d = '%i'",VIDEODB_ID_MUSICVIDEO_YEAR, (int)option->second.asInteger()));
+      filter.AppendWhere(PrepareSQL("musicvideo_view.c%02d = '%i'",VIDEODB_ID_MUSICVIDEO_YEAR, (int)option->second.asInteger()));
 
     option = options.find("artistid");
     if (option != options.end())
     {
       if (itemType != "albums")
-        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo'"));
+        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo'"));
       filter.AppendWhere(PrepareSQL("actor_link.actor_id = %i", (int)option->second.asInteger()));
     }
 
@@ -9348,7 +9348,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     {
       if (itemType != "albums")
       {
-        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo'"));
+        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo'"));
         filter.AppendJoin(PrepareSQL("JOIN actor ON actor.actor_id=actor_link.actor_id"));
       }
       filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
@@ -9356,7 +9356,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
     option = options.find("albumid");
     if (option != options.end())
-      filter.AppendWhere(PrepareSQL("musicvideoview.c%02d = (select c%02d from musicvideo where idMVideo = %i)", VIDEODB_ID_MUSICVIDEO_ALBUM, VIDEODB_ID_MUSICVIDEO_ALBUM, (int)option->second.asInteger()));
+      filter.AppendWhere(PrepareSQL("musicvideo_view.c%02d = (select c%02d from musicvideo where idMVideo = %i)", VIDEODB_ID_MUSICVIDEO_ALBUM, VIDEODB_ID_MUSICVIDEO_ALBUM, (int)option->second.asInteger()));
 
     AppendIdFilter("tag", "tag", "musicvideo", "musicvideo", "idMVideo", options, filter);
     AppendFilter("tag", "tag", "musicvideo", "musicvideo", "idMVideo", options, filter);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1467,50 +1467,24 @@ void CVideoDatabase::AddLinkToActor(int mediaId, const char *mediaType, int acto
   }
 }
 
-void CVideoDatabase::AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField /* = NULL */, const char *type /* = NULL */)
+void CVideoDatabase::AddToLinkTable(int mediaId, const std::string& mediaType, const std::string& table, int valueId, const char *foreignKey)
 {
-  try
-  {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+  const char *key = foreignKey ? foreignKey : table.c_str();
+  std::string sql = PrepareSQL("SELECT 1 FROM %s_link WHERE %s_id=%i AND media_id=%i AND media_type='%s'", table.c_str(), key, valueId, mediaId, mediaType.c_str());
 
-    CStdString strSQL = PrepareSQL("select * from %s where %s=%i and %s=%i", table, firstField, firstID, secondField, secondID);
-    if (typeField != NULL && type != NULL)
-      strSQL += PrepareSQL(" and %s='%s'", typeField, type);
-    m_pDS->query(strSQL.c_str());
-    if (m_pDS->num_rows() == 0)
-    {
-      // doesnt exists, add it
-      if (typeField == NULL || type == NULL)
-        strSQL = PrepareSQL("insert into %s (%s,%s) values(%i,%i)", table, firstField, secondField, firstID, secondID);
-      else
-        strSQL = PrepareSQL("insert into %s (%s,%s,%s) values(%i,%i,'%s')", table, firstField, secondField, typeField, firstID, secondID, type);
-      m_pDS->exec(strSQL.c_str());
-    }
-    m_pDS->close();
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+  if (GetSingleValue(sql).empty())
+  { // doesnt exists, add it
+    sql = PrepareSQL("INSERT INTO %s_link (%s_id,media_id,media_type) VALUES(%i,%i,'%s')", table.c_str(), key, valueId, mediaId, mediaType.c_str());
+    ExecuteQuery(sql);
   }
 }
 
-void CVideoDatabase::RemoveFromLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField /* = NULL */, const char *type /* = NULL */)
+void CVideoDatabase::RemoveFromLinkTable(int mediaId, const std::string& mediaType, const std::string& table, int valueId, const char *foreignKey)
 {
-  try
-  {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+  const char *key = foreignKey ? foreignKey : table.c_str();
+  std::string sql = PrepareSQL("DELETE FROM %s_link WHERE %s_id=%i AND media_id=%i AND media_type='%s'", table.c_str(), key, valueId, mediaId, mediaType.c_str());
 
-    CStdString strSQL = PrepareSQL("DELETE FROM %s WHERE %s = %i AND %s = %i", table, firstField, firstID, secondField, secondID);
-    if (typeField != NULL && type != NULL)
-      strSQL += PrepareSQL(" AND %s='%s'", typeField, type);
-    m_pDS->exec(strSQL.c_str());
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
+  ExecuteQuery(sql);
 }
 
 void CVideoDatabase::AddLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values)
@@ -1521,7 +1495,7 @@ void CVideoDatabase::AddLinksToItem(int mediaId, const std::string& mediaType, c
     {
       int idValue = AddToTable(field, field + "_id", "name", *i);
       if (idValue > -1)
-        AddToLinkTable((field + "_link").c_str(), (field + "_id").c_str(), idValue, "media_id", mediaId, "media_type", mediaType.c_str());
+        AddToLinkTable(mediaId, mediaType, field, idValue);
     }
   }
 }
@@ -1542,7 +1516,7 @@ void CVideoDatabase::AddActorLinksToItem(int mediaId, const std::string& mediaTy
     {
       int idValue = AddActor(*i, "");
       if (idValue > -1)
-        AddToLinkTable((field + "_link").c_str(), "actor_id", idValue, "media_id", mediaId, "media_type", mediaType.c_str());
+        AddToLinkTable(mediaId, mediaType, field, idValue, "actor");
     }
   }
 }
@@ -1561,7 +1535,7 @@ void CVideoDatabase::AddTagToItem(int media_id, int tag_id, const std::string &t
   if (type.empty())
     return;
 
-  AddToLinkTable("tag_link", "tag_id", tag_id, "media_id", media_id, "media_type", type.c_str());
+  AddToLinkTable(media_id, type, "tag", tag_id);
 }
 
 void CVideoDatabase::RemoveTagFromItem(int media_id, int tag_id, const std::string &type)
@@ -1569,7 +1543,7 @@ void CVideoDatabase::RemoveTagFromItem(int media_id, int tag_id, const std::stri
   if (type.empty())
     return;
 
-  RemoveFromLinkTable("tag_link", "tag_id", tag_id, "media_id", media_id, "media_type", type.c_str());
+  RemoveFromLinkTable(media_id, type, "tag", tag_id);
 }
 
 void CVideoDatabase::RemoveTagsFromItem(int media_id, const std::string &type)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -103,16 +103,12 @@ void CVideoDatabase::CreateTables()
   m_pDS->exec("CREATE TABLE stacktimes (idFile integer, times text)\n");
 
   CLog::Log(LOGINFO, "create genre table");
-  m_pDS->exec("CREATE TABLE genre ( idGenre integer primary key, strGenre text)\n");
-
-  CLog::Log(LOGINFO, "create genrelinkmovie table");
-  m_pDS->exec("CREATE TABLE genrelinkmovie ( idGenre integer, idMovie integer)\n");
+  m_pDS->exec("CREATE TABLE genre ( genre_id integer primary key, name TEXT)\n");
+  m_pDS->exec("CREATE TABLE genre_link (genre_id integer, media_id integer, media_type TEXT)");
 
   CLog::Log(LOGINFO, "create country table");
-  m_pDS->exec("CREATE TABLE country ( idCountry integer primary key, strCountry text)\n");
-
-  CLog::Log(LOGINFO, "create countrylinkmovie table");
-  m_pDS->exec("CREATE TABLE countrylinkmovie ( idCountry integer, idMovie integer)\n");
+  m_pDS->exec("CREATE TABLE country ( country_id integer primary key, name TEXT)");
+  m_pDS->exec("CREATE TABLE country_link (country_id integer, media_id integer, media_type TEXT)");
 
   CLog::Log(LOGINFO, "create movie table");
   CStdString columns = "CREATE TABLE movie ( idMovie integer primary key, idFile integer";
@@ -144,9 +140,6 @@ void CVideoDatabase::CreateTables()
   columns += ")";
   m_pDS->exec(columns.c_str());
 
-  CLog::Log(LOGINFO, "create studiolinktvshow table");
-  m_pDS->exec("CREATE TABLE studiolinktvshow ( idStudio integer, idShow integer)\n");
-
   CLog::Log(LOGINFO, "create episode table");
   columns = "CREATE TABLE episode ( idEpisode integer primary key, idFile integer";
   for (int i = 0; i < VIDEODB_MAX_COLUMNS; i++)
@@ -165,17 +158,12 @@ void CVideoDatabase::CreateTables()
   CLog::Log(LOGINFO, "create tvshowlinkpath table");
   m_pDS->exec("CREATE TABLE tvshowlinkpath (idShow integer, idPath integer)\n");
 
-  CLog::Log(LOGINFO, "create genrelinktvshow table");
-  m_pDS->exec("CREATE TABLE genrelinktvshow ( idGenre integer, idShow integer)\n");
-
   CLog::Log(LOGINFO, "create movielinktvshow table");
   m_pDS->exec("CREATE TABLE movielinktvshow ( idMovie integer, IdShow integer)\n");
 
   CLog::Log(LOGINFO, "create studio table");
-  m_pDS->exec("CREATE TABLE studio ( idStudio integer primary key, strStudio text)\n");
-
-  CLog::Log(LOGINFO, "create studiolinkmovie table");
-  m_pDS->exec("CREATE TABLE studiolinkmovie ( idStudio integer, idMovie integer)\n");
+  m_pDS->exec("CREATE TABLE studio ( studio_id integer primary key, name TEXT)\n");
+  m_pDS->exec("CREATE TABLE studio_link (studio_id integer, media_id integer, media_type TEXT)");
 
   CLog::Log(LOGINFO, "create musicvideo table");
   columns = "CREATE TABLE musicvideo ( idMVideo integer primary key, idFile integer";
@@ -184,12 +172,6 @@ void CVideoDatabase::CreateTables()
 
   columns += ")";
   m_pDS->exec(columns.c_str());
-
-  CLog::Log(LOGINFO, "create genrelinkmusicvideo table");
-  m_pDS->exec("CREATE TABLE genrelinkmusicvideo ( idGenre integer, idMVideo integer)\n");
-
-  CLog::Log(LOGINFO, "create studiolinkmusicvideo table");
-  m_pDS->exec("CREATE TABLE studiolinkmusicvideo ( idStudio integer, idMVideo integer)\n");
 
   CLog::Log(LOGINFO, "create streaminfo table");
   m_pDS->exec("CREATE TABLE streamdetails (idFile integer, iStreamType integer, "
@@ -248,17 +230,9 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE INDEX ix_path2 ON path ( idParentPath )");
   m_pDS->exec("CREATE INDEX ix_files ON files ( idPath, strFilename(255) )");
 
-  m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinkmovie_1 ON genrelinkmovie ( idGenre, idMovie)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinkmovie_2 ON genrelinkmovie ( idMovie, idGenre)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_countrylinkmovie_1 ON countrylinkmovie ( idCountry, idMovie)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_countrylinkmovie_2 ON countrylinkmovie ( idMovie, idCountry)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_movie_file_1 ON movie (idFile, idMovie)");
   m_pDS->exec("CREATE UNIQUE INDEX ix_movie_file_2 ON movie (idMovie, idFile)");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmovie_1 ON studiolinkmovie ( idStudio, idMovie)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmovie_2 ON studiolinkmovie ( idMovie, idStudio)\n");
 
-  m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinktvshow_1 ON studiolinktvshow ( idStudio, idShow)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinktvshow_2 ON studiolinktvshow ( idShow, idStudio)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_tvshowlinkpath_1 ON tvshowlinkpath ( idShow, idPath )\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_tvshowlinkpath_2 ON tvshowlinkpath ( idPath, idShow )\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_movielinktvshow_1 ON movielinktvshow ( idShow, idMovie)\n");
@@ -272,15 +246,9 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec(createColIndex.c_str());
   m_pDS->exec("CREATE INDEX ix_episode_show1 on episode(idEpisode,idShow)");
   m_pDS->exec("CREATE INDEX ix_episode_show2 on episode(idShow,idEpisode)");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinktvshow_1 ON genrelinktvshow ( idGenre, idShow)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinktvshow_2 ON genrelinktvshow ( idShow, idGenre)\n");
 
   m_pDS->exec("CREATE UNIQUE INDEX ix_musicvideo_file_1 on musicvideo (idMVideo, idFile)");
   m_pDS->exec("CREATE UNIQUE INDEX ix_musicvideo_file_2 on musicvideo (idFile, idMVideo)");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinkmusicvideo_1 ON genrelinkmusicvideo ( idGenre, idMVideo)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinkmusicvideo_2 ON genrelinkmusicvideo ( idMVideo, idGenre)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmusicvideo_1 ON studiolinkmusicvideo ( idStudio, idMVideo)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmusicvideo_2 ON studiolinkmusicvideo ( idMVideo, idStudio)\n");
 
   m_pDS->exec("CREATE INDEX ixMovieBasePath ON movie ( c23(12) )");
   m_pDS->exec("CREATE INDEX ixMusicVideoBasePath ON musicvideo ( c14(12) )");
@@ -298,14 +266,17 @@ void CVideoDatabase::CreateAnalytics()
   CreateLinkIndex("actor");
   CreateForeignLinkIndex("director", "actor");
   CreateForeignLinkIndex("writer", "actor");
+  CreateLinkIndex("studio");
+  CreateLinkIndex("genre");
+  CreateLinkIndex("country");
 
   CLog::Log(LOGINFO, "%s - creating triggers", __FUNCTION__);
   m_pDS->exec("CREATE TRIGGER delete_movie AFTER DELETE ON movie FOR EACH ROW BEGIN "
-              "DELETE FROM genrelinkmovie WHERE idMovie=old.idMovie; "
+              "DELETE FROM genre_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM actor_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM director_link WHERE media_id=old.idMovie AND media_type='movie'; "
-              "DELETE FROM studiolinkmovie WHERE idMovie=old.idMovie; "
-              "DELETE FROM countrylinkmovie WHERE idMovie=old.idMovie; "
+              "DELETE FROM studio_link WHERE media_id=old.idMovie AND media_type='movie'; "
+              "DELETE FROM country_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM writer_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM movielinktvshow WHERE idMovie=old.idMovie; "
               "DELETE FROM art WHERE media_id=old.idMovie AND media_type='movie'; "
@@ -315,7 +286,7 @@ void CVideoDatabase::CreateAnalytics()
               "DELETE FROM actor_link WHERE media_id=old.idShow AND media_type='tvshow'; "
               "DELETE FROM director_link WHERE media_id=old.idShow AND media_type='tvshow'; "
               "DELETE FROM tvshowlinkpath WHERE idShow=old.idShow; "
-              "DELETE FROM genrelinktvshow WHERE idShow=old.idShow; "
+              "DELETE FROM genre_link WHERE media_id=old.idShow AND media_type='tvshow'; "
               "DELETE FROM movielinktvshow WHERE idShow=old.idShow; "
               "DELETE FROM seasons WHERE idShow=old.idShow; "
               "DELETE FROM art WHERE media_id=old.idShow AND media_type='tvshow'; "
@@ -324,8 +295,8 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE TRIGGER delete_musicvideo AFTER DELETE ON musicvideo FOR EACH ROW BEGIN "
               "DELETE FROM actor_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "DELETE FROM director_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
-              "DELETE FROM genrelinkmusicvideo WHERE idMVideo=old.idMVideo; "
-              "DELETE FROM studiolinkmusicvideo WHERE idMVideo=old.idMVideo; "
+              "DELETE FROM genre_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
+              "DELETE FROM studio_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "DELETE FROM art WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "DELETE FROM taglinks WHERE idMedia=old.idMVideo AND media_type='musicvideo'; "
               "END");
@@ -362,7 +333,7 @@ void CVideoDatabase::CreateViews()
                                       "  files.lastPlayed AS lastPlayed,"
                                       "  files.dateAdded AS dateAdded,"
                                       "  tvshow.c%02d AS strTitle,"
-                                      "  tvshow.c%02d AS strStudio,"
+                                      "  tvshow.c%02d AS studio,"
                                       "  tvshow.c%02d AS premiered,"
                                       "  tvshow.c%02d AS mpaa,"
                                       "  bookmark.timeInSeconds AS resumeTimeInSeconds, "
@@ -423,7 +394,7 @@ void CVideoDatabase::CreateViews()
                                      "  tvshowview.c%02d AS plot,"
                                      "  tvshowview.c%02d AS premiered,"
                                      "  tvshowview.c%02d AS genre,"
-                                     "  tvshowview.c%02d AS strStudio,"
+                                     "  tvshowview.c%02d AS studio,"
                                      "  tvshowview.c%02d AS mpaa,"
                                      "  count(DISTINCT episodeview.idEpisode) AS episodes,"
                                      "  count(files.playCount) AS playCount "
@@ -1554,21 +1525,16 @@ void CVideoDatabase::AddLinksToItem(int mediaId, const std::string& mediaType, c
   {
     if (!i->empty())
     {
-      int idValue = AddToTable(field, "id" + field, "str" + field, *i);
+      int idValue = AddToTable(field, field + "_id", "name", *i);
       if (idValue > -1)
-      {
-        if (mediaType == "musicvideo") // musicvideos use idMVideo rather than idMusicVideo
-          AddToLinkTable((field + "link" + mediaType).c_str(), ("id" + field).c_str(), idValue, "idMVideo", mediaId);
-        else
-          AddToLinkTable((field + "link" + mediaType).c_str(), ("id" + field).c_str(), idValue, ("id" + mediaType).c_str(), mediaId);
-      }
+        AddToLinkTable((field + "_link").c_str(), (field + "_id").c_str(), idValue, "media_id", mediaId, "media_type", mediaType.c_str());
     }
   }
 }
 
 void CVideoDatabase::UpdateLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values)
 {
-  std::string sql = PrepareSQL("delete from %slink%s where id%s=%i", field.c_str(), mediaType.c_str(), mediaType.c_str(), mediaId);
+  std::string sql = PrepareSQL("DELETE FROM %s_link WHERE media_id=%i AND media_type='%s'", field.c_str(), mediaId, mediaType.c_str());
   m_pDS->exec(sql);
 
   AddLinksToItem(mediaId, mediaType, field, values);
@@ -1728,7 +1694,7 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
     if (NULL == m_pDS.get()) return ;
 
     CStdString strSQL;
-    strSQL=PrepareSQL("delete from genrelinktvshow where idShow=%i", idTvShow);
+    strSQL=PrepareSQL("DELETE from genre_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
     m_pDS->exec(strSQL.c_str());
 
     strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
@@ -1737,7 +1703,7 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
     strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from studiolinktvshow where idShow=%i", idTvShow);
+    strSQL=PrepareSQL("DELETE FROM studio_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
     m_pDS->exec(strSQL.c_str());
 
     // remove all info other than the id
@@ -2974,7 +2940,7 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
     BeginTransaction();
 
     CStdString strSQL;
-    strSQL=PrepareSQL("delete from genrelinkmovie where idMovie=%i", idMovie);
+    strSQL=PrepareSQL("DELETE FROM genre_link WHERE media_id=%i AND media_type='movie'", idMovie);
     m_pDS->exec(strSQL.c_str());
 
     strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='movie'", idMovie);
@@ -2983,10 +2949,10 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
     strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='movie'", idMovie);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from studiolinkmovie where idMovie=%i", idMovie);
+    strSQL=PrepareSQL("DELETE FROM studio_link WHERE media_id=%i AND media_type='movie'", idMovie);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from countrylinkmovie where idMovie=%i", idMovie);
+    strSQL=PrepareSQL("DELETE FROM country_link WHERE media_id=%i AND media_type='movie'", idMovie);
     m_pDS->exec(strSQL.c_str());
 
     strSQL=PrepareSQL("DELETE FROM writer_link WHERE media_id=%i AND media_type='movie'", idMovie);
@@ -3191,7 +3157,7 @@ void CVideoDatabase::DeleteMusicVideo(int idMVideo, bool bKeepId /* = false */)
     BeginTransaction();
 
     CStdString strSQL;
-    strSQL=PrepareSQL("delete from genrelinkmusicvideo where idMVideo=%i", idMVideo);
+    strSQL=PrepareSQL("DELETE FROM genre_link WHERE media_id=%i AND media_type='musicvideo'", idMVideo);
     m_pDS->exec(strSQL.c_str());
 
     strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='musicvideo'", idMVideo);
@@ -3200,7 +3166,7 @@ void CVideoDatabase::DeleteMusicVideo(int idMVideo, bool bKeepId /* = false */)
     strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='musicvideo'", idMVideo);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from studiolinkmusicvideo where idMVideo=%i", idMVideo);
+    strSQL=PrepareSQL("DELETE FROM studio_link WHERE media_id=%i AND media_type='musicvideo'", idMVideo);
     m_pDS->exec(strSQL.c_str());
 
     // keep the music video table entry and bookmarks so we can update data in place
@@ -4629,6 +4595,41 @@ void CVideoDatabase::UpdateTables(int iVersion)
     // music artist
     m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type) SELECT idArtist,idMVideo,'musicvideo' FROM artistlinkmusicvideo");
     m_pDS->exec("DROP TABLE IF EXISTS artistlinkmusicvideo");
+
+    // studios
+    m_pDS->exec("CREATE TABLE studio_link(studio_id INTEGER, media_id INTEGER, media_type TEXT)");
+    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT idStudio,idMovie,'movie' FROM studiolinkmovie");
+    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT idStudio,idShow,'tvshow' FROM studiolinktvshow");
+    m_pDS->exec("INSERT INTO studio_link(studio_id, media_id, media_type) SELECT idStudio,idMVideo,'musicvideo' FROM studiolinkmusicvideo");
+    m_pDS->exec("DROP TABLE IF EXISTS studiolinkmovie");
+    m_pDS->exec("DROP TABLE IF EXISTS studiolinktvshow");
+    m_pDS->exec("DROP TABLE IF EXISTS studiolinkmusicvideo");
+    m_pDS->exec("CREATE TABLE studionew(studio_id INTEGER PRIMARY KEY, name TEXT)");
+    m_pDS->exec("INSERT INTO studionew(studio_id, name) SELECT idStudio,strStudio FROM studio");
+    m_pDS->exec("DROP TABLE IF EXISTS studio");
+    m_pDS->exec("ALTER TABLE studionew RENAME TO studio");
+
+    // genres
+    m_pDS->exec("CREATE TABLE genre_link(genre_id INTEGER, media_id INTEGER, media_type TEXT)");
+    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT idGenre,idMovie,'movie' FROM genrelinkmovie");
+    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT idGenre,idShow,'tvshow' FROM genrelinktvshow");
+    m_pDS->exec("INSERT INTO genre_link(genre_id, media_id, media_type) SELECT idGenre,idMVideo,'musicvideo' FROM genrelinkmusicvideo");
+    m_pDS->exec("DROP TABLE IF EXISTS genrelinkmovie");
+    m_pDS->exec("DROP TABLE IF EXISTS genrelinktvshow");
+    m_pDS->exec("DROP TABLE IF EXISTS genrelinkmusicvideo");
+    m_pDS->exec("CREATE TABLE genrenew(genre_id INTEGER PRIMARY KEY, name TEXT)");
+    m_pDS->exec("INSERT INTO genrenew(genre_id, name) SELECT idGenre,strGenre FROM genre");
+    m_pDS->exec("DROP TABLE IF EXISTS genre");
+    m_pDS->exec("ALTER TABLE genrenew RENAME TO genre");
+
+    // country
+    m_pDS->exec("CREATE TABLE country_link(country_id INTEGER, media_id INTEGER, media_type TEXT)");
+    m_pDS->exec("INSERT INTO country_link(country_id, media_id, media_type) SELECT idCountry,idMovie,'movie' FROM countrylinkmovie");
+    m_pDS->exec("DROP TABLE IF EXISTS countrylinkmovie");
+    m_pDS->exec("CREATE TABLE countrynew(country_id INTEGER PRIMARY KEY, name TEXT)");
+    m_pDS->exec("INSERT INTO countrynew(country_id, name) SELECT idCountry,strCountry FROM country");
+    m_pDS->exec("DROP TABLE IF EXISTS country");
+    m_pDS->exec("ALTER TABLE countrynew RENAME TO country");
   }
 }
 
@@ -4955,7 +4956,7 @@ bool CVideoDatabase::GetStudiosNav(const CStdString& strBaseDir, CFileItemList& 
   return GetNavCommon(strBaseDir, items, "studio", idContent, filter, countOnly);
 }
 
-bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const CStdString &type, int idContent /* = -1 */, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
+bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const char *type, int idContent /* = -1 */, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
 {
   try
   {
@@ -4966,62 +4967,79 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
     Filter extFilter = filter;
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
+      std::string view, view_id, media_type, extraField;
       if (idContent == VIDEODB_CONTENT_MOVIES)
       {
-        strSQL = "select %s " + PrepareSQL("from %s ", type.c_str());
-        extFilter.fields = PrepareSQL("%s.id%s, %s.str%s, path.strPath, files.playCount", type.c_str(), type.c_str(), type.c_str(), type.c_str());
-        extFilter.AppendJoin(PrepareSQL("join %slinkmovie on %s.id%s = %slinkmovie.id%s join movieview on %slinkmovie.idMovie = movieview.idMovie join files on files.idFile = movieview.idFile join path on path.idPath = files.idPath",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeMovie;
+        view_id    = "idMovie";
+        media_type = MediaTypeMovie;
+        extraField = "files.playCount";
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS) //this will not get tvshows with 0 episodes
       {
-        strSQL = "select %s " + PrepareSQL("from %s ", type.c_str());
-        extFilter.fields = PrepareSQL("%s.id%s, %s.str%s, path.strPath", type.c_str(), type.c_str(), type.c_str(), type.c_str());
-        extFilter.AppendJoin(PrepareSQL("join %slinktvshow on %s.id%s = %slinktvshow.id%s join episodeview on %slinktvshow.idShow = episodeview.idShow join files on files.idFile = episodeview.idFile join path on path.idPath = files.idPath",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeEpisode;
+        view_id    = "idShow";
+        media_type = MediaTypeTvShow;
       }
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {
-        strSQL = "select %s " + PrepareSQL("from %s ", type.c_str());
-        extFilter.fields = PrepareSQL("%s.id%s, %s.str%s, path.strPath, files.playCount", type.c_str(), type.c_str(), type.c_str(), type.c_str());
-        extFilter.AppendJoin(PrepareSQL("join %slinkmusicvideo on %s.id%s = %slinkmusicvideo.id%s join musicvideoview on %slinkmusicvideo.idMVideo = musicvideoview.idMVideo join files on files.idFile = musicvideoview.idFile join path on path.idPath = files.idPath",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeMusicVideo;
+        view_id    = "idMVideo";
+        media_type = MediaTypeMusicVideo;
+        extraField = "files.playCount";
       }
       else
         return false;
+
+      strSQL = "SELECT %s " + PrepareSQL("FROM %s ", type);
+      extFilter.fields = PrepareSQL("%s.%s_id, %s.name, path.strPath", type, type, type);
+      extFilter.AppendField(extraField);
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_link ON %s.%s_id = %s_link.%s_id", type, type, type, type, type));
+      extFilter.AppendJoin(PrepareSQL("JOIN %sview ON %s_link.media_id = %sview.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
+      extFilter.AppendJoin(PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str()));
+      extFilter.AppendJoin("JOIN path ON path.idPath = files.idPath");
     }
     else
     {
+      std::string view, view_id, media_type, extraField, extraJoin;
       if (idContent == VIDEODB_CONTENT_MOVIES)
       {
-        strSQL = "select %s " + PrepareSQL("from %s ", type.c_str());
-        extFilter.fields = PrepareSQL("%s.id%s, %s.str%s, count(1), count(files.playCount)", type.c_str(), type.c_str(), type.c_str(), type.c_str());
-        extFilter.AppendJoin(PrepareSQL("join %slinkmovie on %s.id%s = %slinkmovie.id%s join movieview on %slinkmovie.idMovie = movieview.idMovie join files on files.idFile = movieview.idFile",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str()));
-        extFilter.AppendGroup(PrepareSQL("%s.id%s", type.c_str(), type.c_str()));
+        view       = MediaTypeMovie;
+        view_id    = "idMovie";
+        media_type = MediaTypeMovie;
+        extraField = "count(1), count(files.playCount)";
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS)
       {
-        strSQL = "select %s " + PrepareSQL("from %s ", type.c_str());
-        extFilter.fields = PrepareSQL("distinct %s.id%s, %s.str%s", type.c_str(), type.c_str(), type.c_str(), type.c_str());
-        extFilter.AppendJoin(PrepareSQL("join %slinktvshow on %s.id%s = %slinktvshow.id%s join tvshowview on %slinktvshow.idShow = tvshowview.idShow",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeTvShow;
+        view_id    = "idShow";
+        media_type = MediaTypeTvShow;
       }
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {
-        strSQL = "select %s " + PrepareSQL("from %s ", type.c_str());
-        extFilter.fields = PrepareSQL("%s.id%s, %s.str%s, count(1), count(files.playCount)", type.c_str(), type.c_str(), type.c_str(), type.c_str());
-        extFilter.AppendJoin(PrepareSQL("join %slinkmusicvideo on %s.id%s = %slinkmusicvideo.id%s join musicvideoview on %slinkmusicvideo.idMVideo = musicvideoview.idMVideo join files on files.idFile = musicvideoview.idFile",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str(), type.c_str()));
-        extFilter.AppendGroup(PrepareSQL("%s.id%s", type.c_str(), type.c_str()));
+        view       = MediaTypeMusicVideo;
+        view_id    = "idMVideo";
+        media_type = MediaTypeMusicVideo;
+        extraField = "count(1), count(files.playCount)";
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
       }
       else
         return false;
+
+      strSQL = "SELECT %s " + PrepareSQL("FROM %s ", type);
+      extFilter.fields = PrepareSQL("%s.%s_id, %s.name", type, type, type);
+      extFilter.AppendField(extraField);
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_link ON %s.%s_id = %s_link.%s_id", type, type, type, type, type));
+      extFilter.AppendJoin(PrepareSQL("JOIN %sview ON %s_link.media_id = %sview.%s AND %s_link.media_type='%s'",
+                                      view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
+      extFilter.AppendJoin(extraJoin);
+      extFilter.AppendGroup(PrepareSQL("%s.%s_id", type, type));
     }
 
     if (countOnly)
     {
-      extFilter.fields = PrepareSQL("COUNT(DISTINCT %s.id%s)", type.c_str(), type.c_str());
+      extFilter.fields = PrepareSQL("COUNT(DISTINCT %s.%s_id)", type, type);
       extFilter.group.clear();
       extFilter.order.clear();
     }
@@ -6477,12 +6495,12 @@ bool CVideoDatabase::GetRecentlyAddedMusicVideosNav(const CStdString& strBaseDir
 
 CStdString CVideoDatabase::GetGenreById(int id)
 {
-  return GetSingleValue("genre", "strGenre", PrepareSQL("idGenre=%i", id));
+  return GetSingleValue("genre", "name", PrepareSQL("genre_id=%i", id));
 }
 
 CStdString CVideoDatabase::GetCountryById(int id)
 {
-  return GetSingleValue("country", "strCountry", PrepareSQL("idCountry=%i", id));
+  return GetSingleValue("country", "name", PrepareSQL("country_id=%i", id));
 }
 
 CStdString CVideoDatabase::GetSetById(int id)
@@ -6502,7 +6520,7 @@ CStdString CVideoDatabase::GetPersonById(int id)
 
 CStdString CVideoDatabase::GetStudioById(int id)
 {
-  return GetSingleValue("studio", "strStudio", PrepareSQL("idStudio=%i", id));
+  return GetSingleValue("studio", "name", PrepareSQL("studio_id=%i", id));
 }
 
 CStdString CVideoDatabase::GetTvShowTitleById(int id)
@@ -6824,9 +6842,9 @@ void CVideoDatabase::GetMovieGenresByName(const CStdString& strSearch, CFileItem
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL=PrepareSQL("select genre.idGenre,genre.strGenre,path.strPath from genre,genrelinkmovie,movie,path,files where genre.idGenre=genrelinkmovie.idGenre and genrelinkmovie.idMovie=movie.idMovie and files.idFile=movie.idFile and path.idPath=files.idPath and genre.strGenre like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select genre.genre_id,genre.name,path.strPath from genre,genre_link,movie,path,files where genre.genre_id=genre_link.genre_id and genre_link.media_id=movie.idMovie AND genre_link.media_type='movie' and files.idFile=movie.idFile and path.idPath=files.idPath and genre.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL=PrepareSQL("select distinct genre.idGenre,genre.strGenre from genre,genrelinkmovie where genrelinkmovie.idGenre=genre.idGenre and strGenre like '%%%s%%'", strSearch.c_str());
+      strSQL=PrepareSQL("select distinct genre.genre_id,genre.name from genre,genre_link where genre_link.genre_id=genre.genre_id AND genre_link.media_type='movie' and name like '%%%s%%'", strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -6839,8 +6857,8 @@ void CVideoDatabase::GetMovieGenresByName(const CStdString& strSearch, CFileItem
           continue;
         }
 
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("genre.strGenre").get_asString()));
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("genre.idGenre").get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://movies/genres/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
@@ -6864,9 +6882,9 @@ void CVideoDatabase::GetMovieCountriesByName(const CStdString& strSearch, CFileI
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL=PrepareSQL("select country.idCountry,country.strCountry,path.strPath from country,countrylinkmovie,movie,path,files where country.idCountry=countrylinkmovie.idCountry and countrylinkmovie.idMovie=movie.idMovie and files.idFile=movie.idFile and path.idPath=files.idPath and country.strCountry like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select country.country_id,country.name,path.strPath from country,country_link,movie,path,files where country.country_id=country_link.country_id and country_link.media_id=movie.idMovie AND country_link.media_type='movie' and files.idFile=movie.idFile and path.idPath=files.idPath and country.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL=PrepareSQL("select distinct country.idCountry,country.strCountry from country,countrylinkmovie where countrylinkmovie.idCountry=country.idCountry and strCountry like '%%%s%%'", strSearch.c_str());
+      strSQL=PrepareSQL("select distinct country.country_id,country.name from country,country_link where country_link.country_id=country.country_id AND countrlink.media_type='movie' and name like '%%%s%%'", strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -6879,8 +6897,8 @@ void CVideoDatabase::GetMovieCountriesByName(const CStdString& strSearch, CFileI
           continue;
         }
 
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("country.strCountry").get_asString()));
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("country.idCountry").get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://movies/genres/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
@@ -6904,9 +6922,9 @@ void CVideoDatabase::GetTvShowGenresByName(const CStdString& strSearch, CFileIte
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL=PrepareSQL("select genre.idGenre,genre.strGenre,path.strPath from genre,genrelinktvshow,tvshow,path,tvshowlinkpath where genre.idGenre=genrelinktvshow.idGenre and genrelinktvshow.idShow=tvshow.idShow and path.idPath=tvshowlinkpath.idPath and tvshowlinkpath.idShow=tvshow.idShow and genre.strGenre like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select genre.genre_id,genre.name,path.strPath from genre,genre_link,tvshow,path,tvshowlinkpath where genre.genre_id=genre_link.genre_id and genre_link.media_id=tvshow.idShow AND genre_link.media_type='tvshow' and path.idPath=tvshowlinkpath.idPath and tvshowlinkpath.idShow=tvshow.idShow and genre.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL=PrepareSQL("select distinct genre.idGenre,genre.strGenre from genre,genrelinktvshow where genrelinktvshow.idGenre=genre.idGenre and strGenre like '%%%s%%'", strSearch.c_str());
+      strSQL=PrepareSQL("select distinct genre.genre_id,genre.name from genre,genre_link where genre.genre_id=genre_link.genre_id AND genre_link.media_type='tvshow' and name like '%%%s%%'", strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -6918,8 +6936,8 @@ void CVideoDatabase::GetTvShowGenresByName(const CStdString& strSearch, CFileIte
           continue;
         }
 
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("genre.strGenre").get_asString()));
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("genre.idGenre").get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://tvshows/genres/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
@@ -7063,9 +7081,9 @@ void CVideoDatabase::GetMusicVideoGenresByName(const CStdString& strSearch, CFil
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL=PrepareSQL("select genre.idGenre,genre.strGenre,path.strPath from genre,genrelinkmusicvideo,musicvideo,path,files where genre.idGenre=genrelinkmusicvideo.idGenre and genrelinkmusicvideo.idMVideo = musicvideo.idMVideo and files.idFile=musicvideo.idFile and path.idPath=files.idPath and genre.strGenre like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select genre.genre_id,genre.name,path.strPath from genre,genre_link,musicvideo,path,files where genre.genre_id=genre_link.genre_id and genre_link.media_id=musicvideo.idMVideo AND genre_link.media_type='musicvideo' and files.idFile=musicvideo.idFile and path.idPath=files.idPath and genre.strGenre like '%%%s%%'",strSearch.c_str());
     else
-      strSQL=PrepareSQL("select distinct genre.idGenre,genre.strGenre from genre,genrelinkmusicvideo where genrelinkmusicvideo.idGenre=genre.idGenre and genre.strGenre like '%%%s%%'", strSearch.c_str());
+      strSQL=PrepareSQL("select distinct genre.genre_id,genre.name from genre,genre_link where genre_link.genre_id=genre.genre_id AND genre_link.media_type='musicvideo' and genre.name like '%%%s%%'", strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7077,8 +7095,8 @@ void CVideoDatabase::GetMusicVideoGenresByName(const CStdString& strSearch, CFil
           continue;
         }
 
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("genre.strGenre").get_asString()));
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("genre.idGenre").get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://musicvideos/genres/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
@@ -8022,13 +8040,11 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
 
     CLog::Log(LOGDEBUG, "%s: Cleaning genre table", __FUNCTION__);
     sql = "DELETE FROM genre "
-            "WHERE NOT EXISTS (SELECT 1 FROM genrelinkmovie WHERE genrelinkmovie.idGenre = genre.idGenre) "
-              "AND NOT EXISTS (SELECT 1 FROM genrelinktvshow WHERE genrelinktvshow.idGenre = genre.idGenre) "
-              "AND NOT EXISTS (SELECT 1 FROM genrelinkmusicvideo WHERE genrelinkmusicvideo.idGenre = genre.idGenre)";
+            "WHERE NOT EXISTS (SELECT 1 FROM genre_link WHERE genre_link.genre_id = genre.genre_id)";
     m_pDS->exec(sql.c_str());
 
     CLog::Log(LOGDEBUG, "%s: Cleaning country table", __FUNCTION__);
-    sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM countrylinkmovie WHERE countrylinkmovie.idCountry = country.idCountry)";
+    sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM country_link WHERE country_link.country_id = country.country_id)";
     m_pDS->exec(sql.c_str());
 
     CLog::Log(LOGDEBUG, "%s: Cleaning actor table of actors, directors and writers", __FUNCTION__);
@@ -8040,9 +8056,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
 
     CLog::Log(LOGDEBUG, "%s: Cleaning studio table", __FUNCTION__);
     sql = "DELETE FROM studio "
-            "WHERE NOT EXISTS (SELECT 1 FROM studiolinkmovie WHERE studiolinkmovie.idStudio = studio.idStudio) "
-              "AND NOT EXISTS (SELECT 1 FROM studiolinkmusicvideo WHERE studiolinkmusicvideo.idStudio = studio.idStudio) "
-              "AND NOT EXISTS (SELECT 1 FROM studiolinktvshow WHERE studiolinktvshow.idStudio = studio.idStudio)";
+            "WHERE NOT EXISTS (SELECT 1 FROM studio_link WHERE studio_link.studio_id = studio.studio_id)";
     m_pDS->exec(sql.c_str());
 
     CLog::Log(LOGDEBUG, "%s: Cleaning set table", __FUNCTION__);
@@ -9212,43 +9226,43 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     option = options.find("genreid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join genrelinkmovie on genrelinkmovie.idMovie = movieview.idMovie"));
-      filter.AppendWhere(PrepareSQL("genrelinkmovie.idGenre = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=movieview.idMovie AND genre_link.media_type='movie'"));
+      filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("genre");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join genrelinkmovie on genrelinkmovie.idMovie = movieview.idMovie join genre on genre.idGenre = genrelinkmovie.idGenre"));
-      filter.AppendWhere(PrepareSQL("genre.strGenre like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=movieview.idMovie AND genre_link.media_type='movie' JOIN genre ON genre.genre_id=genre_link.genre_id"));
+      filter.AppendWhere(PrepareSQL("genre.name like '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("countryid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join countrylinkmovie on countrylinkmovie.idMovie = movieview.idMovie"));
-      filter.AppendWhere(PrepareSQL("countrylinkmovie.idCountry = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN country_link ON country_link.media_id=movieview.idMovie AND country_link.media_type='movie'"));
+      filter.AppendWhere(PrepareSQL("country_link.country_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("country");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join countrylinkmovie on countrylinkmovie.idMovie = movieview.idMovie join country on country.idCountry = countrylinkmovie.idCountry"));
-      filter.AppendWhere(PrepareSQL("country.strCountry like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN country_link ON country_link.media_id=movieview.idMovie AND country_link.media_type='movie' JOIN country ON country.country_id=country_link.country_id"));
+      filter.AppendWhere(PrepareSQL("country.name like '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("studioid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join studiolinkmovie on studiolinkmovie.idMovie = movieview.idMovie"));
-      filter.AppendWhere(PrepareSQL("studiolinkmovie.idStudio = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=movieview.idMovie AND studio_link.media_type='movie'"));
+      filter.AppendWhere(PrepareSQL("studio_link.studio_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("studio");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join studiolinkmovie on studiolinkmovie.idMovie = movieview.idMovie join studio on studio.idStudio = studiolinkmovie.idStudio"));
-      filter.AppendWhere(PrepareSQL("studio.strStudio like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=movieview.idMovie AND studio_link.media_type='movie' JOIN studio ON studio.studio_id=studio_link.studio_id"));
+      filter.AppendWhere(PrepareSQL("studio.name like '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("directorid");
@@ -9315,29 +9329,29 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       option = options.find("genreid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join genrelinktvshow on genrelinktvshow.idShow = tvshowview.idShow"));
-        filter.AppendWhere(PrepareSQL("genrelinktvshow.idGenre = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=tvshowview.idShow AND genre_link.media_type='tvshow'"));
+        filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
       }
 
       option = options.find("genre");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join genrelinktvshow on genrelinktvshow.idShow = tvshowview.idShow join genre on genre.idGenre = genrelinktvshow.idGenre"));
-        filter.AppendWhere(PrepareSQL("genre.strGenre like '%s'", option->second.asString().c_str()));
+        filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=tvshowview.idShow AND genre_link.media_type='tvshow' JOIN genre ON genre.genre_id=genre_link.genre_id"));
+        filter.AppendWhere(PrepareSQL("genre.name like '%s'", option->second.asString().c_str()));
       }
 
       option = options.find("studioid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join studiolinktvshow on studiolinktvshow.idShow = tvshowview.idShow"));
-        filter.AppendWhere(PrepareSQL("studiolinktvshow.idStudio = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=tvshowview.idShow AND studio_link.media_type='tvshow'"));
+        filter.AppendWhere(PrepareSQL("studio_link.studio_id = %i", (int)option->second.asInteger()));
       }
 
       option = options.find("studio");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join studiolinktvshow on studiolinktvshow.idShow = tvshowview.idShow join studio on studio.idStudio = studiolinktvshow.idStudio"));
-        filter.AppendWhere(PrepareSQL("studio.strStudio like '%s'", option->second.asString().c_str()));
+        filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=tvshowview.idShow AND studio_link.media_type='tvshow' JOIN studio ON studio.studio_id=studio_link.studio_id"));
+        filter.AppendWhere(PrepareSQL("studio.name like '%s'", option->second.asString().c_str()));
       }
 
       option = options.find("directorid");
@@ -9388,8 +9402,8 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       option = options.find("genreid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join genrelinktvshow on genrelinktvshow.idShow = seasonview.idShow"));
-        filter.AppendWhere(PrepareSQL("genrelinktvshow.idGenre = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=seasonview.idShow AND genre_link.media_type='tvshow'"));
+        filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
       }
 
       option = options.find("directorid");
@@ -9430,16 +9444,16 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         if (option != options.end())
         {
           condition = true;
-          filter.AppendJoin(PrepareSQL("join genrelinktvshow on genrelinktvshow.idShow = episodeview.idShow"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and genrelinktvshow.idGenre = %i", idShow, (int)option->second.asInteger()));
+          filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=episodeview.idShow AND genre_link.media_type='tvshow'"));
+          filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
         }
 
         option = options.find("genre");
         if (option != options.end())
         {
           condition = true;
-          filter.AppendJoin(PrepareSQL("join genrelinktvshow on genrelinktvshow.idShow = episodeview.idShow join genre on genre.idGenre = genrelinktvshow.idGenre"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and genre.strGenre like '%s'", idShow, option->second.asString().c_str()));
+          filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=episodeview.idShow AND genre_link.media_type='tvshow' JOIN genre ON genre.genre_id=genre_link.genre_id"));
+          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and genre.name like '%s'", idShow, option->second.asString().c_str()));
         }
 
         option = options.find("directorid");
@@ -9520,29 +9534,29 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     option = options.find("genreid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join genrelinkmusicvideo on genrelinkmusicvideo.idMVideo = musicvideoview.idMVideo"));
-      filter.AppendWhere(PrepareSQL("genrelinkmusicvideo.idGenre = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=musicvideoview.idMVideo AND genre_link.media_type='musicvideo'"));
+      filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("genre");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join genrelinkmusicvideo on genrelinkmusicvideo.idMVideo = musicvideoview.idMVideo join genre on genre.idGenre = genrelinkmusicvideo.idGenre"));
-      filter.AppendWhere(PrepareSQL("genre.strGenre like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=musicvideoview.idMVideo AND genre_link.media_type='musicvideo' JOIN genre ON genre.genre_id=genre_link.genre_id"));
+      filter.AppendWhere(PrepareSQL("genre.name like '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("studioid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join studiolinkmusicvideo on studiolinkmusicvideo.idMVideo = musicvideoview.idMVideo"));
-      filter.AppendWhere(PrepareSQL("studiolinkmusicvideo.idStudio = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=musicvideoview.idMVideo AND studio_link.media_type='musicvideo'"));
+      filter.AppendWhere(PrepareSQL("studio_link.studio_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("studio");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join studiolinkmusicvideo on studiolinkmusicvideo.idMVideo = musicvideoview.idMVideo join studio on studio.idStudio = studiolinkmusicvideo.idStudio"));
-      filter.AppendWhere(PrepareSQL("studio.strStudio like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=musicvideoview.idMVideo AND studio_link.media_type='musicvideo' JOIN studio ON studio.studio_id=studio_link.studio_id"));
+      filter.AppendWhere(PrepareSQL("studio.name like '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("directorid");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9222,10 +9222,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
     option = options.find("set");
     if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("join setlinkmovie on setlinkmovie.idMovie = movieview.idMovie join sets on sets.idSet = setlinkmovie.idSet"));
-      filter.AppendWhere(PrepareSQL("sets.strSet like '%s'", option->second.asString().c_str()));
-    }
+      filter.AppendWhere(PrepareSQL("movieview.strSet LIKE '%s'i", option->second.asString().c_str()));
 
     AppendIdFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);
     AppendFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -123,17 +123,11 @@ void CVideoDatabase::CreateTables()
   columns += ", idSet integer)";
   m_pDS->exec(columns.c_str());
 
-  CLog::Log(LOGINFO, "create actorlinkmovie table");
-  m_pDS->exec("CREATE TABLE actorlinkmovie ( idActor integer, idMovie integer, strRole text, iOrder integer)\n");
-
-  CLog::Log(LOGINFO, "create directorlinkmovie table");
-  m_pDS->exec("CREATE TABLE directorlinkmovie ( idDirector integer, idMovie integer)\n");
-
-  CLog::Log(LOGINFO, "create writerlinkmovie table");
-  m_pDS->exec("CREATE TABLE writerlinkmovie ( idWriter integer, idMovie integer)\n");
-
-  CLog::Log(LOGINFO, "create actors table");
-  m_pDS->exec("CREATE TABLE actors ( idActor integer primary key, strActor text, strThumb text )\n");
+  CLog::Log(LOGINFO, "create actor table");
+  m_pDS->exec("CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT, art_urls TEXT )");
+  m_pDS->exec("CREATE TABLE actor_link(actor_id INTEGER, media_id INTEGER, media_type TEXT, role TEXT, cast_order INTEGER)");
+  m_pDS->exec("CREATE TABLE director_link(actor_id INTEGER, media_id INTEGER, media_type TEXT)");
+  m_pDS->exec("CREATE TABLE writer_link(actor_id INTEGER, media_id INTEGER, media_type TEXT)");
 
   CLog::Log(LOGINFO, "create path table");
   m_pDS->exec("CREATE TABLE path ( idPath integer primary key, strPath text, strContent text, strScraper text, strHash text, scanRecursive integer, useFolderNames bool, strSettings text, noUpdate bool, exclude bool, dateAdded text, idParentPath integer)");
@@ -149,12 +143,6 @@ void CVideoDatabase::CreateTables()
 
   columns += ")";
   m_pDS->exec(columns.c_str());
-
-  CLog::Log(LOGINFO, "create directorlinktvshow table");
-  m_pDS->exec("CREATE TABLE directorlinktvshow ( idDirector integer, idShow integer)\n");
-
-  CLog::Log(LOGINFO, "create actorlinktvshow table");
-  m_pDS->exec("CREATE TABLE actorlinktvshow ( idActor integer, idShow integer, strRole text, iOrder integer)\n");
 
   CLog::Log(LOGINFO, "create studiolinktvshow table");
   m_pDS->exec("CREATE TABLE studiolinktvshow ( idStudio integer, idShow integer)\n");
@@ -177,15 +165,6 @@ void CVideoDatabase::CreateTables()
   CLog::Log(LOGINFO, "create tvshowlinkpath table");
   m_pDS->exec("CREATE TABLE tvshowlinkpath (idShow integer, idPath integer)\n");
 
-  CLog::Log(LOGINFO, "create actorlinkepisode table");
-  m_pDS->exec("CREATE TABLE actorlinkepisode ( idActor integer, idEpisode integer, strRole text, iOrder integer)\n");
-
-  CLog::Log(LOGINFO, "create directorlinkepisode table");
-  m_pDS->exec("CREATE TABLE directorlinkepisode ( idDirector integer, idEpisode integer)\n");
-
-  CLog::Log(LOGINFO, "create writerlinkepisode table");
-  m_pDS->exec("CREATE TABLE writerlinkepisode ( idWriter integer, idEpisode integer)\n");
-
   CLog::Log(LOGINFO, "create genrelinktvshow table");
   m_pDS->exec("CREATE TABLE genrelinktvshow ( idGenre integer, idShow integer)\n");
 
@@ -206,17 +185,11 @@ void CVideoDatabase::CreateTables()
   columns += ")";
   m_pDS->exec(columns.c_str());
 
-  CLog::Log(LOGINFO, "create artistlinkmusicvideo table");
-  m_pDS->exec("CREATE TABLE artistlinkmusicvideo ( idArtist integer, idMVideo integer)\n");
-
   CLog::Log(LOGINFO, "create genrelinkmusicvideo table");
   m_pDS->exec("CREATE TABLE genrelinkmusicvideo ( idGenre integer, idMVideo integer)\n");
 
   CLog::Log(LOGINFO, "create studiolinkmusicvideo table");
   m_pDS->exec("CREATE TABLE studiolinkmusicvideo ( idStudio integer, idMVideo integer)\n");
-
-  CLog::Log(LOGINFO, "create directorlinkmusicvideo table");
-  m_pDS->exec("CREATE TABLE directorlinkmusicvideo ( idDirector integer, idMVideo integer)\n");
 
   CLog::Log(LOGINFO, "create streaminfo table");
   m_pDS->exec("CREATE TABLE streamdetails (idFile integer, iStreamType integer, "
@@ -263,9 +236,9 @@ void CVideoDatabase::CreateAnalytics()
 
   /* order of indexes are important, for an index to be considered all  */
   /* columns up to the column in question have to have been specified   */
-  /* select * from actorlinkmovie where idMovie = 1, can not take       */
-  /* advantage of a index that has been created on ( idGenre, idMovie ) */
-  /*, hower on on ( idMovie, idGenre ) will be considered for use       */
+  /* select * from foolink where foo_id = 1, can not take               */
+  /* advantage of a index that has been created on ( bar_id, foo_id )   */
+  /* however an index on ( foo_id, bar_id ) will be considered for use  */
 
   CLog::Log(LOGINFO, "%s - creating indicies", __FUNCTION__);
   m_pDS->exec("CREATE INDEX ix_bookmark ON bookmark (idFile, type)");
@@ -281,19 +254,9 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE UNIQUE INDEX ix_countrylinkmovie_2 ON countrylinkmovie ( idMovie, idCountry)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_movie_file_1 ON movie (idFile, idMovie)");
   m_pDS->exec("CREATE UNIQUE INDEX ix_movie_file_2 ON movie (idMovie, idFile)");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinkmovie_1 ON actorlinkmovie ( idActor, idMovie )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinkmovie_2 ON actorlinkmovie ( idMovie, idActor )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinkmovie_1 ON directorlinkmovie ( idDirector, idMovie )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinkmovie_2 ON directorlinkmovie ( idMovie, idDirector )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_writerlinkmovie_1 ON writerlinkmovie ( idWriter, idMovie )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_writerlinkmovie_2 ON writerlinkmovie ( idMovie, idWriter )\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmovie_1 ON studiolinkmovie ( idStudio, idMovie)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmovie_2 ON studiolinkmovie ( idMovie, idStudio)\n");
 
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinktvshow_1 ON directorlinktvshow ( idDirector, idShow )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinktvshow_2 ON directorlinktvshow ( idShow, idDirector )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinktvshow_1 ON actorlinktvshow ( idActor, idShow )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinktvshow_2 ON actorlinktvshow ( idShow, idActor )\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinktvshow_1 ON studiolinktvshow ( idStudio, idShow)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinktvshow_2 ON studiolinktvshow ( idShow, idStudio)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_tvshowlinkpath_1 ON tvshowlinkpath ( idShow, idPath )\n");
@@ -309,25 +272,15 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec(createColIndex.c_str());
   m_pDS->exec("CREATE INDEX ix_episode_show1 on episode(idEpisode,idShow)");
   m_pDS->exec("CREATE INDEX ix_episode_show2 on episode(idShow,idEpisode)");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinkepisode_1 ON actorlinkepisode ( idActor, idEpisode )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_actorlinkepisode_2 ON actorlinkepisode ( idEpisode, idActor )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinkepisode_1 ON directorlinkepisode ( idDirector, idEpisode )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinkepisode_2 ON directorlinkepisode ( idEpisode, idDirector )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_writerlinkepisode_1 ON writerlinkepisode ( idWriter, idEpisode )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_writerlinkepisode_2 ON writerlinkepisode ( idEpisode, idWriter )\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinktvshow_1 ON genrelinktvshow ( idGenre, idShow)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinktvshow_2 ON genrelinktvshow ( idShow, idGenre)\n");
 
   m_pDS->exec("CREATE UNIQUE INDEX ix_musicvideo_file_1 on musicvideo (idMVideo, idFile)");
   m_pDS->exec("CREATE UNIQUE INDEX ix_musicvideo_file_2 on musicvideo (idFile, idMVideo)");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_artistlinkmusicvideo_1 ON artistlinkmusicvideo ( idArtist, idMVideo)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_artistlinkmusicvideo_2 ON artistlinkmusicvideo ( idMVideo, idArtist)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinkmusicvideo_1 ON genrelinkmusicvideo ( idGenre, idMVideo)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_genrelinkmusicvideo_2 ON genrelinkmusicvideo ( idMVideo, idGenre)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmusicvideo_1 ON studiolinkmusicvideo ( idStudio, idMVideo)\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_studiolinkmusicvideo_2 ON studiolinkmusicvideo ( idMVideo, idStudio)\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinkmusicvideo_1 ON directorlinkmusicvideo ( idDirector, idMVideo )\n");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_directorlinkmusicvideo_2 ON directorlinkmusicvideo ( idMVideo, idDirector )\n");
 
   m_pDS->exec("CREATE INDEX ixMovieBasePath ON movie ( c23(12) )");
   m_pDS->exec("CREATE INDEX ixMusicVideoBasePath ON musicvideo ( c14(12) )");
@@ -342,21 +295,25 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE UNIQUE INDEX ix_taglinks_2 ON taglinks (idMedia, media_type(20), idTag)");
   m_pDS->exec("CREATE INDEX ix_taglinks_3 ON taglinks (media_type(20))");
 
+  CreateLinkIndex("actor");
+  CreateForeignLinkIndex("director", "actor");
+  CreateForeignLinkIndex("writer", "actor");
+
   CLog::Log(LOGINFO, "%s - creating triggers", __FUNCTION__);
   m_pDS->exec("CREATE TRIGGER delete_movie AFTER DELETE ON movie FOR EACH ROW BEGIN "
               "DELETE FROM genrelinkmovie WHERE idMovie=old.idMovie; "
-              "DELETE FROM actorlinkmovie WHERE idMovie=old.idMovie; "
-              "DELETE FROM directorlinkmovie WHERE idMovie=old.idMovie; "
+              "DELETE FROM actor_link WHERE media_id=old.idMovie AND media_type='movie'; "
+              "DELETE FROM director_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM studiolinkmovie WHERE idMovie=old.idMovie; "
               "DELETE FROM countrylinkmovie WHERE idMovie=old.idMovie; "
-              "DELETE FROM writerlinkmovie WHERE idMovie=old.idMovie; "
+              "DELETE FROM writer_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM movielinktvshow WHERE idMovie=old.idMovie; "
               "DELETE FROM art WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM taglinks WHERE idMedia=old.idMovie AND media_type='movie'; "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_tvshow AFTER DELETE ON tvshow FOR EACH ROW BEGIN "
-              "DELETE FROM actorlinktvshow WHERE idShow=old.idShow; "
-              "DELETE FROM directorlinktvshow WHERE idShow=old.idShow; "
+              "DELETE FROM actor_link WHERE media_id=old.idShow AND media_type='tvshow'; "
+              "DELETE FROM director_link WHERE media_id=old.idShow AND media_type='tvshow'; "
               "DELETE FROM tvshowlinkpath WHERE idShow=old.idShow; "
               "DELETE FROM genrelinktvshow WHERE idShow=old.idShow; "
               "DELETE FROM movielinktvshow WHERE idShow=old.idShow; "
@@ -365,17 +322,17 @@ void CVideoDatabase::CreateAnalytics()
               "DELETE FROM taglinks WHERE idMedia=old.idShow AND media_type='tvshow'; "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_musicvideo AFTER DELETE ON musicvideo FOR EACH ROW BEGIN "
-              "DELETE FROM artistlinkmusicvideo WHERE idMVideo=old.idMVideo; "
-              "DELETE FROM directorlinkmusicvideo WHERE idMVideo=old.idMVideo; "
+              "DELETE FROM actor_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
+              "DELETE FROM director_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "DELETE FROM genrelinkmusicvideo WHERE idMVideo=old.idMVideo; "
               "DELETE FROM studiolinkmusicvideo WHERE idMVideo=old.idMVideo; "
               "DELETE FROM art WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "DELETE FROM taglinks WHERE idMedia=old.idMVideo AND media_type='musicvideo'; "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_episode AFTER DELETE ON episode FOR EACH ROW BEGIN "
-              "DELETE FROM actorlinkepisode WHERE idEpisode=old.idEpisode; "
-              "DELETE FROM directorlinkepisode WHERE idEpisode=old.idEpisode; "
-              "DELETE FROM writerlinkepisode WHERE idEpisode=old.idEpisode; "
+              "DELETE FROM actor_link WHERE media_id=old.idEpisode AND media_type='episode'; "
+              "DELETE FROM director_link WHERE media_id=old.idEpisode AND media_type='episode'; "
+              "DELETE FROM writer_link WHERE media_id=old.idEpisode AND media_type='episode'; "
               "DELETE FROM art WHERE media_id=old.idEpisode AND media_type='episode'; "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_season AFTER DELETE ON seasons FOR EACH ROW BEGIN "
@@ -384,8 +341,8 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE TRIGGER delete_set AFTER DELETE ON sets FOR EACH ROW BEGIN "
               "DELETE FROM art WHERE media_id=old.idSet AND media_type='set'; "
               "END");
-  m_pDS->exec("CREATE TRIGGER delete_person AFTER DELETE ON actors FOR EACH ROW BEGIN "
-              "DELETE FROM art WHERE media_id=old.idActor AND media_type IN ('actor','artist','writer','director'); "
+  m_pDS->exec("CREATE TRIGGER delete_person AFTER DELETE ON actor FOR EACH ROW BEGIN "
+              "DELETE FROM art WHERE media_id=old.actor_id AND media_type IN ('actor','artist','writer','director'); "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_tag AFTER DELETE ON taglinks FOR EACH ROW BEGIN "
               "DELETE FROM tag WHERE idTag=old.idTag AND idTag NOT IN (SELECT DISTINCT idTag FROM taglinks); "
@@ -1508,31 +1465,31 @@ int CVideoDatabase::AddCountry(const CStdString& strCountry)
   return AddToTable("country", "idCountry", "strCountry", strCountry);
 }
 
-int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& thumbURLs, const CStdString &thumb)
+int CVideoDatabase::AddActor(const CStdString& name, const CStdString& thumbURLs, const CStdString &thumb)
 {
   try
   {
     if (NULL == m_pDB.get()) return -1;
     if (NULL == m_pDS.get()) return -1;
     int idActor = -1;
-    CStdString strSQL=PrepareSQL("select idActor from actors where strActor like '%s'", strActor.c_str());
+    CStdString strSQL=PrepareSQL("select actor_id from actor where name like '%s'", name.c_str());
     m_pDS->query(strSQL.c_str());
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
       // doesnt exists, add it
-      strSQL=PrepareSQL("insert into actors (idActor, strActor, strThumb) values( NULL, '%s','%s')", strActor.c_str(),thumbURLs.c_str());
+      strSQL=PrepareSQL("insert into actor (actor_id, name, art_urls) values( NULL, '%s','%s')", name.c_str(),thumbURLs.c_str());
       m_pDS->exec(strSQL.c_str());
       idActor = (int)m_pDS->lastinsertid();
     }
     else
     {
-      idActor = m_pDS->fv("idActor").get_asInt();
+      idActor = m_pDS->fv(0).get_asInt();
       m_pDS->close();
       // update the thumb url's
       if (!thumbURLs.empty())
       {
-        strSQL=PrepareSQL("update actors set strThumb='%s' where idActor=%i",thumbURLs.c_str(),idActor);
+        strSQL=PrepareSQL("update actor set art_urls='%s' where actor_id=%i",thumbURLs.c_str(),idActor);
         m_pDS->exec(strSQL.c_str());
       }
     }
@@ -1543,7 +1500,7 @@ int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& thumb
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, strActor.c_str() );
+    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, name.c_str() );
   }
   return -1;
 }
@@ -1557,13 +1514,12 @@ void CVideoDatabase::AddLinkToActor(const char *table, int actorID, const char *
     if (NULL == m_pDB.get()) return ;
     if (NULL == m_pDS.get()) return ;
 
-    CStdString strSQL=PrepareSQL("select * from actorlink%s where idActor=%i and id%s=%i", table, actorID, field, secondID);
-    m_pDS->query(strSQL.c_str());
+    std::string sql=PrepareSQL("SELECT 1 FROM actor_link WHERE actor_id=%i AND media_id=%i AND media_type='%s'", actorID, secondID, table);
+    m_pDS->query(sql);
     if (m_pDS->num_rows() == 0)
-    {
-      // doesnt exists, add it
-      strSQL=PrepareSQL("insert into actorlink%s (idActor, id%s, strRole, iOrder) values(%i,%i,'%s',%i)", table, field, actorID, secondID, role.c_str(), order);
-      m_pDS->exec(strSQL.c_str());
+    { // doesnt exists, add it
+      sql = PrepareSQL("INSERT INTO actor_link (actor_id, media_id, media_type, role, cast_order) VALUES(%i,%i,'%s','%s',%i)", actorID, secondID, table, role.c_str(), order);
+      m_pDS->exec(sql);
     }
     m_pDS->close();
   }
@@ -1643,19 +1599,14 @@ void CVideoDatabase::AddActorLinksToItem(int mediaId, const std::string& mediaTy
     {
       int idValue = AddActor(*i, "");
       if (idValue > -1)
-      {
-        if (mediaType == "musicvideo") // musicvideo links use idMVideo rather than idMusicVideo
-          AddToLinkTable((field + "link" + mediaType).c_str(), ("id" + field).c_str(), idValue, "idMVideo", mediaId);
-        else
-          AddToLinkTable((field + "link" + mediaType).c_str(), ("id" + field).c_str(), idValue, ("id" + mediaType).c_str(), mediaId);
-      }
+        AddToLinkTable((field + "_link").c_str(), "actor_id", idValue, "media_id", mediaId, "media_type", mediaType.c_str());
     }
   }
 }
 
 void CVideoDatabase::UpdateActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values)
 {
-  std::string sql = PrepareSQL("delete from %slink%s where id%s=%i", field.c_str(), mediaType.c_str(), mediaType.c_str(), mediaId);
+  std::string sql = PrepareSQL("DELETE FROM %s_link WHERE media_id=%i AND media_type='%s'", field.c_str(), mediaId, mediaType.c_str());
   m_pDS->exec(sql);
 
   AddActorLinksToItem(mediaId, mediaType, field, values);
@@ -1835,10 +1786,10 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
     strSQL=PrepareSQL("delete from genrelinktvshow where idShow=%i", idTvShow);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from actorlinktvshow where idShow=%i", idTvShow);
+    strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from directorlinktvshow where idShow=%i", idTvShow);
+    strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
     m_pDS->exec(strSQL.c_str());
 
     strSQL=PrepareSQL("delete from studiolinktvshow where idShow=%i", idTvShow);
@@ -1863,38 +1814,38 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
 }
 
 //********************************************************************************************************************************
-void CVideoDatabase::GetMoviesByActor(const CStdString& strActor, CFileItemList& items)
+void CVideoDatabase::GetMoviesByActor(const CStdString& name, CFileItemList& items)
 {
   Filter filter;
-  filter.join  = "LEFT JOIN actorlinkmovie ON actorlinkmovie.idMovie=movieview.idMovie "
-                 "LEFT JOIN actors a ON a.idActor=actorlinkmovie.idActor "
-                 "LEFT JOIN directorlinkmovie ON directorlinkmovie.idMovie=movieview.idMovie "
-                 "LEFT JOIN actors d ON d.idActor=directorlinkmovie.idDirector";
-  filter.where = PrepareSQL("a.strActor='%s' OR d.strActor='%s'", strActor.c_str(), strActor.c_str());
+  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=movieview.idMovie AND actor_link.media_type='movie' "
+                 "LEFT JOIN actor a ON a.actor_id=actor_link.actor_id "
+                 "LEFT JOIN director_link ON director_link.media_id=movieview.idMovie AND director_link.media_type='movie' "
+                 "LEFT JOIN actor d ON d.actor_id=director_link.actor_id";
+  filter.where = PrepareSQL("a.name='%s' OR d.name='%s'", name.c_str(), name.c_str());
   filter.group = "movieview.idMovie";
   GetMoviesByWhere("videodb://movies/titles/", filter, items);
 }
 
-void CVideoDatabase::GetTvShowsByActor(const CStdString& strActor, CFileItemList& items)
+void CVideoDatabase::GetTvShowsByActor(const CStdString& name, CFileItemList& items)
 {
   Filter filter;
-  filter.join  = "LEFT JOIN actorlinktvshow ON actorlinktvshow.idShow=tvshowview.idShow "
-                 "LEFT JOIN actors a ON a.idActor=actorlinktvshow.idActor "
-                 "LEFT JOIN directorlinktvshow ON directorlinktvshow.idShow=tvshowview.idShow "
-                 "LEFT JOIN actors d ON d.idActor=directorlinktvshow.idDirector";
-  filter.where = PrepareSQL("a.strActor='%s' OR d.strActor='%s'", strActor.c_str(), strActor.c_str());
+  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=tvshowview.idShow AND actor_link.media_type='tvshow' "
+                 "LEFT JOIN actor a ON a.actor_id=actor_link.actor_id "
+                 "LEFT JOIN director_link ON director_link.media_id=tvshowview.idShow AND director_link.media_type='tvshow' "
+                 "LEFT JOIN actor d ON d.actor_id=director_link.actor_id";
+  filter.where = PrepareSQL("a.name='%s' OR d.name='%s'", name.c_str(), name.c_str());
   filter.group = "tvshowview.idShow";
   GetTvShowsByWhere("videodb://tvshows/titles/", filter, items);
 }
 
-void CVideoDatabase::GetEpisodesByActor(const CStdString& strActor, CFileItemList& items)
+void CVideoDatabase::GetEpisodesByActor(const CStdString& name, CFileItemList& items)
 {
   Filter filter;
-  filter.join  = "LEFT JOIN actorlinkepisode ON actorlinkepisode.idEpisode=episodeview.idEpisode "
-                 "LEFT JOIN actors a ON a.idActor=actorlinkepisode.idActor "
-                 "LEFT JOIN directorlinkepisode ON directorlinkepisode.idEpisode=episodeview.idEpisode "
-                 "LEFT JOIN actors d ON d.idActor=directorlinkepisode.idDirector";
-  filter.where = PrepareSQL("a.strActor='%s' OR d.strActor='%s'", strActor.c_str(), strActor.c_str());
+  filter.join  = "LEFT JOIN actor_link ON actor_link.media_id=episodeview.idEpisode AND actor_link.media_type='episode' "
+                 "LEFT JOIN actor a ON a.actor_id=actor_link.actor_id "
+                 "LEFT JOIN director_link ON director_link.media_id=episodeview.idEpisode AND director_link.media_type='episode' "
+                 "LEFT JOIN actor d ON d.actor_id=director_link.actor_id";
+  filter.where = PrepareSQL("a.name='%s' OR d.name='%s'", name.c_str(), name.c_str());
   filter.group = "episodeview.idEpisode";
   GetEpisodesByWhere("videodb://tvshows/titles/", filter, items);
 }
@@ -1909,9 +1860,9 @@ void CVideoDatabase::GetMusicVideosByArtist(const CStdString& strArtist, CFileIt
 
     CStdString strSQL;
     if (strArtist.empty())  // TODO: SMARTPLAYLISTS what is this here for???
-      strSQL=PrepareSQL("select distinct * from musicvideoview join artistlinkmusicvideo on artistlinkmusicvideo.idMVideo=musicvideoview.idMVideo join actors on actors.idActor=artistlinkmusicvideo.idArtist");
+      strSQL=PrepareSQL("select distinct * from musicvideoview join actor_link on actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id");
     else
-      strSQL=PrepareSQL("select * from musicvideoview join artistlinkmusicvideo on artistlinkmusicvideo.idMVideo=musicvideoview.idMVideo join actors on actors.idActor=artistlinkmusicvideo.idArtist where actors.strActor='%s'", strArtist.c_str());
+      strSQL=PrepareSQL("select * from musicvideoview join actor_link on actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where actor.name='%s'", strArtist.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -2661,7 +2612,7 @@ int CVideoDatabase::SetDetailsForMusicVideo(const CStdString& strFilenameAndPath
     vector<int> vecStudios;
     AddGenreAndDirectorsAndStudios(details,vecDirectors,vecGenres,vecStudios);
 
-    AddActorLinksToItem(idMVideo, MediaTypeMusicVideo, "artist", details.m_artist);
+    AddActorLinksToItem(idMVideo, MediaTypeMusicVideo, "actor", details.m_artist);
 
     unsigned int i;
     for (i = 0; i < vecGenres.size(); ++i)
@@ -3129,10 +3080,10 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
     strSQL=PrepareSQL("delete from genrelinkmovie where idMovie=%i", idMovie);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from actorlinkmovie where idMovie=%i", idMovie);
+    strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='movie'", idMovie);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from directorlinkmovie where idMovie=%i", idMovie);
+    strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='movie'", idMovie);
     m_pDS->exec(strSQL.c_str());
 
     strSQL=PrepareSQL("delete from studiolinkmovie where idMovie=%i", idMovie);
@@ -3141,7 +3092,7 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
     strSQL=PrepareSQL("delete from countrylinkmovie where idMovie=%i", idMovie);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from writerlinkmovie where idMovie=%i", idMovie);
+    strSQL=PrepareSQL("DELETE FROM writer_link WHERE media_id=%i AND media_type='movie'", idMovie);
     m_pDS->exec(strSQL.c_str());
 
     // keep the movie table entry, linking to tv shows, and bookmarks
@@ -3299,13 +3250,13 @@ void CVideoDatabase::DeleteEpisode(int idEpisode, bool bKeepId /* = false */)
       AnnounceRemove(MediaTypeEpisode, idEpisode);
 
     CStdString strSQL;
-    strSQL=PrepareSQL("delete from actorlinkepisode where idEpisode=%i", idEpisode);
+    strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='episode'", idEpisode);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from directorlinkepisode where idEpisode=%i", idEpisode);
+    strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='episode'", idEpisode);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from writerlinkepisode where idEpisode=%i", idEpisode);
+    strSQL=PrepareSQL("DELETE FROM writer_link WHERE media_id=%i AND media_type='episode'", idEpisode);
     m_pDS->exec(strSQL.c_str());
 
     // keep episode table entry and bookmarks so we can update the data in place
@@ -3346,10 +3297,10 @@ void CVideoDatabase::DeleteMusicVideo(int idMVideo, bool bKeepId /* = false */)
     strSQL=PrepareSQL("delete from genrelinkmusicvideo where idMVideo=%i", idMVideo);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from artistlinkmusicvideo where idMVideo=%i", idMVideo);
+    strSQL=PrepareSQL("DELETE FROM actor_link WHERE media_id=%i AND media_type='musicvideo'", idMVideo);
     m_pDS->exec(strSQL.c_str());
 
-    strSQL=PrepareSQL("delete from directorlinkmusicvideo where idMVideo=%i", idMVideo);
+    strSQL=PrepareSQL("DELETE FROM director_link WHERE media_id=%i AND media_type='musicvideo'", idMVideo);
     m_pDS->exec(strSQL.c_str());
 
     strSQL=PrepareSQL("delete from studiolinkmusicvideo where idMVideo=%i", idMVideo);
@@ -3706,7 +3657,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
 
   if (getDetails)
   {
-    GetCast("movie", "idMovie", details.m_iDbId, details.m_cast);
+    GetCast(details.m_iDbId, "movie", details.m_cast);
 
     castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
@@ -3772,7 +3723,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
 
   if (getDetails)
   {
-    GetCast("tvshow", "idShow", details.m_iDbId, details.m_cast);
+    GetCast(details.m_iDbId, "tvshow", details.m_cast);
 
     // get tags
     CStdString strSQL = PrepareSQL("SELECT tag.strTag FROM tag, taglinks WHERE taglinks.idMedia = %i AND taglinks.media_type = 'tvshow' AND taglinks.idTag = tag.idTag ORDER BY tag.idTag", idTvShow);
@@ -3841,8 +3792,8 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
 
   if (getDetails)
   {
-    GetCast("episode", "idEpisode", details.m_iDbId, details.m_cast);
-    GetCast("tvshow", "idShow", details.m_iIdShow, details.m_cast);
+    GetCast(details.m_iDbId, "episode", details.m_cast);
+    GetCast(details.m_iIdShow, "tvshow", details.m_cast);
 
     castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
@@ -3907,26 +3858,26 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(const dbiplus::sql_record*
   return details;
 }
 
-void CVideoDatabase::GetCast(const CStdString &table, const CStdString &table_id, int type_id, vector<SActorInfo> &cast)
+void CVideoDatabase::GetCast(int media_id, const std::string &media_type, vector<SActorInfo> &cast)
 {
   try
   {
     if (!m_pDB.get()) return;
     if (!m_pDS2.get()) return;
 
-    CStdString sql = PrepareSQL("SELECT actors.strActor,"
-                                "  actorlink%s.strRole,"
-                                "  actorlink%s.iOrder,"
-                                "  actors.strThumb,"
-                                "  art.url "
-                                "FROM actorlink%s"
-                                "  JOIN actors ON"
-                                "    actorlink%s.idActor=actors.idActor"
-                                "  LEFT JOIN art ON"
-                                "    art.media_id=actors.idActor AND art.media_type='actor' AND art.type='thumb' "
-                                "WHERE actorlink%s.%s=%i "
-                                "ORDER BY actorlink%s.iOrder",table.c_str(), table.c_str(), table.c_str(), table.c_str(), table.c_str(), table_id.c_str(), type_id, table.c_str());
-    m_pDS2->query(sql.c_str());
+    std::string sql = PrepareSQL("SELECT actor.name,"
+                                 "  actor_link.role,"
+                                 "  actor_link.cast_order,"
+                                 "  actor.art_urls,"
+                                 "  art.url "
+                                 "FROM actor_link"
+                                 "  JOIN actor ON"
+                                 "    actor_link.actor_id=actor.actor_id"
+                                 "  LEFT JOIN art ON"
+                                 "    art.media_id=actor.actor_id AND art.media_type='actor' AND art.type='thumb' "
+                                 "WHERE actor_link.media_id=%i AND actor_link.media_type='%s'"
+                                 "ORDER BY actor_link.cast_order", media_id, media_type.c_str());
+    m_pDS2->query(sql);
     while (!m_pDS2->eof())
     {
       SActorInfo info;
@@ -3954,7 +3905,7 @@ void CVideoDatabase::GetCast(const CStdString &table, const CStdString &table_id
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s(%s,%s,%i) failed", __FUNCTION__, table.c_str(), table_id.c_str(), type_id);
+    CLog::Log(LOGERROR, "%s(%i,%s) failed", __FUNCTION__, media_id, media_type.c_str());
   }
 }
 
@@ -4747,6 +4698,41 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec("DELETE from art WHERE media_type='tvshow' AND NOT EXISTS (SELECT 1 FROM tvshow WHERE tvshow.idShow = art.media_id)");
     m_pDS->exec("DELETE from art WHERE media_type='season' AND NOT EXISTS (SELECT 1 FROM seasons WHERE seasons.idSeason = art.media_id)");
   }
+  if (iVersion < 90)
+  { // create actor link table
+    m_pDS->exec("CREATE TABLE actor_link(actor_id INT, media_id INT, media_type TEXT, role TEXT, cast_order INT)");
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idMovie,'movie',strRole,iOrder from actorlinkmovie");
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idShow,'tvshow',strRole,iOrder from actorlinktvshow");
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type, role, cast_order) SELECT idActor,idEpisode,'episode',strRole,iOrder from actorlinkepisode");
+    m_pDS->exec("DROP TABLE IF EXISTS actorlinkmovie");
+    m_pDS->exec("DROP TABLE IF EXISTS actorlinktvshow");
+    m_pDS->exec("DROP TABLE IF EXISTS actorlinkepisode");
+    m_pDS->exec("CREATE TABLE actor(actor_id INTEGER PRIMARY KEY, name TEXT, art_urls TEXT)");
+    m_pDS->exec("INSERT INTO actor(actor_id, name, art_urls) SELECT idActor,strActor,strThumb FROM actors");
+    m_pDS->exec("DROP TABLE IF EXISTS actors");
+
+    // directors
+    m_pDS->exec("CREATE TABLE director_link(actor_id INTEGER, media_id INTEGER, media_type TEXT)");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idMovie,'movie' FROM directorlinkmovie");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idShow,'tvshow' FROM directorlinktvshow");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idEpisode,'episode' FROM directorlinkepisode");
+    m_pDS->exec("INSERT INTO director_link(actor_id, media_id, media_type) SELECT idDirector,idMVideo,'musicvideo' FROM directorlinkmusicvideo");
+    m_pDS->exec("DROP TABLE IF EXISTS directorlinkmovie");
+    m_pDS->exec("DROP TABLE IF EXISTS directorlinktvshow");
+    m_pDS->exec("DROP TABLE IF EXISTS directorlinkepisode");
+    m_pDS->exec("DROP TABLE IF EXISTS directorlinkmusicvideo");
+
+    // writers
+    m_pDS->exec("CREATE TABLE writer_link(actor_id INTEGER, media_id INTEGER, media_type TEXT)");
+    m_pDS->exec("INSERT INTO writer_link(actor_id, media_id, media_type) SELECT idWriter,idMovie,'movie' FROM writerlinkmovie");
+    m_pDS->exec("INSERT INTO writer_link(actor_id, media_id, media_type) SELECT idWriter,idEpisode,'episode' FROM writerlinkepisode");
+    m_pDS->exec("DROP TABLE IF EXISTS writerlinkmovie");
+    m_pDS->exec("DROP TABLE IF EXISTS writerlinkepisode");
+
+    // music artist
+    m_pDS->exec("INSERT INTO actor_link(actor_id, media_id, media_type) SELECT idArtist,idMVideo,'musicvideo' FROM artistlinkmusicvideo");
+    m_pDS->exec("DROP TABLE IF EXISTS artistlinkmusicvideo");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
@@ -5389,9 +5375,9 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
 
     CStdString strSQL = "select %s from musicvideoview ";
     Filter extFilter = filter;
-    extFilter.fields = PrepareSQL("musicvideoview.c%02d, musicvideoview.idMVideo, actors.strActor", VIDEODB_ID_MUSICVIDEO_ALBUM);
-    extFilter.AppendJoin(PrepareSQL("join artistlinkmusicvideo on artistlinkmusicvideo.idMVideo = musicvideoview.idMVideo"));
-    extFilter.AppendJoin(PrepareSQL("join actors on actors.idActor = artistlinkmusicvideo.idArtist"));
+    extFilter.fields = PrepareSQL("musicvideoview.c%02d, musicvideoview.idMVideo, actor.name", VIDEODB_ID_MUSICVIDEO_ALBUM);
+    extFilter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo'"));
+    extFilter.AppendJoin(PrepareSQL("JOIN actor ON actor.actor_id = actor_link.actor_id"));
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       extFilter.fields += " path.strPath";
@@ -5532,7 +5518,7 @@ bool CVideoDatabase::GetActorsNav(const CStdString& strBaseDir, CFileItemList& i
   return false;
 }
 
-bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const CStdString &type, int idContent /* = -1 */, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
+bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const char *type, int idContent /* = -1 */, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
 {
   if (NULL == m_pDB.get()) return false;
   if (NULL == m_pDS.get()) return false;
@@ -5553,72 +5539,88 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
     Filter extFilter = filter;
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
+      std::string view, view_id, media_type, extraField;
       if (idContent == VIDEODB_CONTENT_MOVIES)
       {
-        strSQL = "select %s from actors ";
-        extFilter.fields = "actors.idActor, actors.strActor, actors.strThumb, path.strPath, files.playCount";
-        extFilter.AppendJoin(PrepareSQL("join %slinkmovie on actors.idActor = %slinkmovie.id%s join movieview on %slinkmovie.idMovie = movieview.idMovie join files on files.idFile = movieview.idFile join path on path.idPath = files.idPath",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeMovie;
+        view_id    = "idMovie";
+        media_type = MediaTypeMovie;
+        extraField = "files.playCount";
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS)
       {
-        strSQL = "select %s from actors ";
-        extFilter.fields = "actors.idActor, actors.strActor, actors.strThumb, path.strPath";
-        extFilter.AppendJoin(PrepareSQL("join %slinktvshow on actors.idActor = %slinktvshow.id%s join episodeview on %slinktvshow.idShow = episodeview.idShow join files on files.idFile = episodeview.idFile join path on path.idPath = files.idPath",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeEpisode;
+        view_id    = "idShow";
+        media_type = MediaTypeTvShow;
       }
       else if (idContent == VIDEODB_CONTENT_EPISODES)
       {
-        strSQL = "select %s from actors ";
-        extFilter.fields = "actors.idActor, actors.strActor, actors.strThumb, path.strPath, files.playCount";
-        extFilter.AppendJoin(PrepareSQL("join %slinkepisode on actors.idActor = %slinkepisode.id%s join episodeview on %slinkepisode.idEpisode = episodeview.idEpisode join files on files.idFile = episodeview.idFile join path on path.idPath = files.idPath",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeEpisode;
+        view_id    = "idEpisode";
+        media_type = MediaTypeEpisode;
+        extraField = "files.playCount";
       }
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {
-        strSQL = "select %s from actors ";
-        extFilter.fields = "actors.idActor, actors.strActor, actors.strThumb, path.strPath, files.playCount";
-        extFilter.AppendJoin(PrepareSQL("join %slinkmusicvideo on actors.idActor = %slinkmusicvideo.id%s join musicvideoview on %slinkmusicvideo.idMVideo = musicvideoview.idMVideo join files on files.idFile = musicvideoview.idFile join path on path.idPath = files.idPath",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeMusicVideo;
+        view_id    = "idMVideo";
+        media_type = MediaTypeMusicVideo;
+        extraField = "files.playCount";
       }
       else
         return false;
+
+      strSQL = "SELECT %s FROM actor ";
+      extFilter.fields = "actor.actor_id, actor.name, actor.art_urls, path.strPath";
+      extFilter.AppendField(extraField);
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_link ON actor.actor_id = %s_link.actor_id", type, type));
+      extFilter.AppendJoin(PrepareSQL("JOIN %sview ON %s_link.media_id = %sview.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
+      extFilter.AppendJoin(PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str()));
+      extFilter.AppendJoin("JOIN path ON path.idPath = files.idPath");
     }
     else
     {
+      std::string view, view_id, media_type, extraField, extraJoin;
       if (idContent == VIDEODB_CONTENT_MOVIES)
       {
-        strSQL ="select %s from actors ";
-        extFilter.fields = "actors.idActor, actors.strActor, actors.strThumb, count(1), count(files.playCount)";
-        extFilter.AppendJoin(PrepareSQL("join %slinkmovie on actors.idActor = %slinkmovie.id%s join movieview on %slinkmovie.idMovie = movieview.idMovie join files on files.idFile = movieview.idFile",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str()));
-        extFilter.AppendGroup("actors.idActor");
+        view       = MediaTypeMovie;
+        view_id    = "idMovie";
+        media_type = MediaTypeMovie;
+        extraField = "count(1), count(files.playCount)";
+        extraJoin  = PrepareSQL(" JOIN files ON files.idFile=%sview.idFile", view.c_str());
       }
       else if (idContent == VIDEODB_CONTENT_TVSHOWS)
       {
-        strSQL = "select %s " + PrepareSQL("from actors, %slinktvshow, tvshowview ", type.c_str());
-        extFilter.fields = "distinct actors.idActor, actors.strActor, actors.strThumb";
-        extFilter.AppendWhere(PrepareSQL("actors.idActor = %slinktvshow.id%s and %slinktvshow.idShow = tvshowview.idShow",
-                                         type.c_str(), type.c_str(), type.c_str()));
+        view       = MediaTypeTvShow;
+        view_id    = "idShow";
+        media_type = MediaTypeTvShow;
       }
       else if (idContent == VIDEODB_CONTENT_EPISODES)
       {
-        strSQL = "select %s " + PrepareSQL("from %slinkepisode, actors, episodeview, files ", type.c_str());
-        extFilter.fields = "actors.idActor, actors.strActor, actors.strThumb, count(1), count(files.playCount)";
-        extFilter.AppendWhere(PrepareSQL("actors.idActor = %slinkepisode.id%s and %slinkepisode.idEpisode = episodeview.idEpisode and files.idFile = episodeview.idFile",
-                                         type.c_str(), type.c_str(), type.c_str()));
-        extFilter.AppendGroup("actors.idActor");
+        view       = MediaTypeEpisode;
+        view_id    = "idEpisode";
+        media_type = MediaTypeEpisode;
+        extraField = "count(1), count(files.playCount)";
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
       }
       else if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
       {
-        strSQL = "select %s from actors ";
-        extFilter.fields = "actors.idActor, actors.strActor, actors.strThumb, count(1), count(files.playCount)";
-        extFilter.AppendJoin(PrepareSQL("join %slinkmusicvideo on actors.idActor = %slinkmusicvideo.id%s join musicvideoview on %slinkmusicvideo.idMVideo = musicvideoview.idMVideo join files on files.idFile = musicvideoview.idFile",
-                                        type.c_str(), type.c_str(), type.c_str(), type.c_str()));
-        extFilter.AppendGroup("actors.idActor");
+        view       = MediaTypeMusicVideo;
+        view_id    = "idMVideo";
+        media_type = MediaTypeMusicVideo;
+        extraField = "count(1), count(files.playCount)";
+        extraJoin  = PrepareSQL("JOIN files ON files.idFile = %sview.idFile", view.c_str());
       }
       else
         return false;
+
+      strSQL ="SELECT %s FROM actor ";
+      extFilter.fields = "actor.actor_id, actor.name, actor.art_urls";
+      extFilter.AppendField(extraField);
+      extFilter.AppendJoin(PrepareSQL("JOIN %s_link on actor.actor_id = %s_link.actor_id", type, type));
+      extFilter.AppendJoin(PrepareSQL("JOIN %sview on %s_link.media_id = %sview.%s AND %s_link.media_type='%s'", view.c_str(), type, view.c_str(), view_id.c_str(), type, media_type.c_str()));
+      extFilter.AppendJoin(extraJoin);
+      extFilter.AppendGroup("actor.actor_id");
     }
 
     if (countOnly)
@@ -5685,7 +5687,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
         CFileItemPtr pItem(new CFileItem(it->second.name));
 
         CVideoDbUrl itemUrl = videoUrl;
-        CStdString path = StringUtils::Format("%ld/", it->first);
+        CStdString path = StringUtils::Format("%d/", it->first);
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
@@ -5706,7 +5708,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
           CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
 
           CVideoDbUrl itemUrl = videoUrl;
-          CStdString path = StringUtils::Format("%ld/", m_pDS->fv(0).get_asInt());
+          CStdString path = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
           itemUrl.AppendPath(path);
           pItem->SetPath(itemUrl.ToString());
 
@@ -6598,7 +6600,7 @@ CStdString CVideoDatabase::GetTagById(int id)
 
 CStdString CVideoDatabase::GetPersonById(int id)
 {
-  return GetSingleValue("actors", "strActor", PrepareSQL("idActor=%i", id));
+  return GetSingleValue("actor", "name", PrepareSQL("actor_id=%i", id));
 }
 
 CStdString CVideoDatabase::GetStudioById(int id)
@@ -7044,9 +7046,9 @@ void CVideoDatabase::GetMovieActorsByName(const CStdString& strSearch, CFileItem
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL=PrepareSQL("select actors.idActor,actors.strActor,path.strPath from actorlinkmovie,actors,movie,files,path where actors.idActor=actorlinkmovie.idActor and actorlinkmovie.idMovie=movie.idMovie and files.idFile=movie.idFile and files.idPath=path.idPath and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select actor.actor_id,actor.name,path.strPath from actor_link,actor,movie,files,path where actor.actor_id=actor_link.actor_id and actor_link.media_id=movie.idMovie and actor_link.media_type='movie' and files.idFile=movie.idFile and files.idPath=path.idPath and actor.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL=PrepareSQL("select distinct actors.idActor,actors.strActor from actorlinkmovie,actors,movie where actors.idActor=actorlinkmovie.idActor and actorlinkmovie.idMovie=movie.idMovie and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select distinct actor.actor_id,actor.name from actor_link,actor,movie where actor.actor_id=actor_link.actor_id and actor_link.media_id=movie.idMovie and actor_link.media_type='movie' and actor.name like '%%%s%%'",strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7058,8 +7060,8 @@ void CVideoDatabase::GetMovieActorsByName(const CStdString& strSearch, CFileItem
           continue;
         }
 
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("actors.idActor").get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://movies/actors/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
@@ -7083,9 +7085,9 @@ void CVideoDatabase::GetTvShowsActorsByName(const CStdString& strSearch, CFileIt
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL=PrepareSQL("select actors.idActor,actors.strActor,path.strPath from actorlinktvshow,actors,tvshow,path,tvshowlinkpath where actors.idActor=actorlinktvshow.idActor and actorlinktvshow.idShow=tvshow.idShow and tvshowlinkpath.idPath=tvshow.idShow and tvshowlinkpath.idPath=path.idPath and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select actor.actor_id,actor.name,path.strPath from actor_link,actor,tvshow,path,tvshowlinkpath where actor.actor_id=actor_link.actor_id and actor_link.media_id=tvshow.idShow and actor_link.media_type='tvshow' and tvshowlinkpath.idPath=tvshow.idShow and tvshowlinkpath.idPath=path.idPath and actor.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL=PrepareSQL("select distinct actors.idActor,actors.strActor from actorlinktvshow,actors,tvshow where actors.idActor=actorlinktvshow.idActor and actorlinktvshow.idShow=tvshow.idShow and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL=PrepareSQL("select distinct actor.actor_id,actor.name from actor_link,actor,tvshow where actor.actor_id=actor_link.actor_id and actor_link.media_id=tvshow.idShow and actor_link.media_type='tvshow' and actor.name like '%%%s%%'",strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7097,8 +7099,8 @@ void CVideoDatabase::GetTvShowsActorsByName(const CStdString& strSearch, CFileIt
           continue;
         }
 
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("actors.idActor").get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://tvshows/actors/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
@@ -7123,11 +7125,11 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const CStdString& strSearch, CFi
 
     CStdString strLike;
     if (!strSearch.empty())
-      strLike = "and actors.strActor like '%%%s%%'";
+      strLike = "and actor.name like '%%%s%%'";
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL=PrepareSQL("select actors.idActor,actors.strActor,path.strPath from artistlinkmusicvideo,actors,musicvideo,files,path where actors.idActor=artistlinkmusicvideo.idArtist and artistlinkmusicvideo.idMVideo=musicvideo.idMVideo and files.idFile=musicvideo.idFile and files.idPath=path.idPath "+strLike,strSearch.c_str());
+      strSQL=PrepareSQL("select actor.actor_id,actor.name,path.strPath from actor_link,actor,musicvideo,files,path where actor.actor_id=actor_link.actor.id and actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' and files.idFile=musicvideo.idFile and files.idPath=path.idPath "+strLike,strSearch.c_str());
     else
-      strSQL=PrepareSQL("select distinct actors.idActor,actors.strActor from artistlinkmusicvideo,actors where actors.idActor=artistlinkmusicvideo.idArtist "+strLike,strSearch.c_str());
+      strSQL=PrepareSQL("select distinct actor.actor_id,actor.name from actor_link,actor where actor.actor_id=actor_link.actor_id AND actor_link.media_type='musicvideo' "+strLike,strSearch.c_str());
     m_pDS->query( strSQL.c_str() );
 
     while (!m_pDS->eof())
@@ -7139,8 +7141,8 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const CStdString& strSearch, CFi
           continue;
         }
 
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("actors.idActor").get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
       pItem->SetPath("videodb://musicvideos/artists/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
@@ -7447,16 +7449,16 @@ int CVideoDatabase::GetMatchingMusicVideo(const CStdString& strArtist, const CSt
     if (strAlbum.empty() && strTitle.empty())
     { // we want to return matching artists only
       if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-        strSQL=PrepareSQL("select distinct actors.idActor,path.strPath from artistlinkmusicvideo,actors,musicvideo,files,path where actors.idActor=artistlinkmusicvideo.idArtist and artistlinkmusicvideo.idMVideo=musicvideo.idMVideo and files.idFile=musicvideo.idFile and files.idPath=path.idPath and actors.strActor like '%s'",strArtist.c_str());
+        strSQL=PrepareSQL("select distinct actor.actor_id,path.strPath from actor_link,actor,musicvideo,files,path where actor.actor_id=actor_link.actor_id and actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' and files.idFile=musicvideo.idFile and files.idPath=path.idPath and actor.name like '%s'",strArtist.c_str());
       else
-        strSQL=PrepareSQL("select distinct actors.idActor from artistlinkmusicvideo,actors where actors.idActor=artistlinkmusicvideo.idArtist and actors.strActor like '%s'",strArtist.c_str());
+        strSQL=PrepareSQL("select distinct actor.actor_id from actor_link,actor where actor.actor_id=actor_link.actor_id AND actor_link.media_type='musicvideo' and actor.name like '%s'",strArtist.c_str());
     }
     else
     { // we want to return the matching musicvideo
       if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-        strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo,files,path,artistlinkmusicvideo,actors where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and artistlinkmusicvideo.idMVideo=musicvideo.idMVideo and artistlinkmusicvideo.idArtist=actors.idActor and actors.strActor like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
+        strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo,files,path,actor_link,actor where files.idFile=musicvideo.idFile and files.idPath=path.idPath and musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' and actor_link.actor_id=actor.actor_id and actor.name like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
       else
-        strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo join artistlinkmusicvideo on artistlinkmusicvideo.idMVideo=musicvideo.idMVideo join actors on actors.idActor=artistlinkmusicvideo.idArtist where musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and actors.strActor like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
+        strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo join actor_link on actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and actor.name like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
     }
     m_pDS->query( strSQL.c_str() );
 
@@ -7748,9 +7750,9 @@ void CVideoDatabase::GetMovieDirectorsByName(const CStdString& strSearch, CFileI
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select distinct directorlinkmovie.idDirector,actors.strActor,path.strPath from movie,files,path,actors,directorlinkmovie where files.idFile=movie.idFile and files.idPath=path.idPath and directorlinkmovie.idMovie=movie.idMovie and directorlinkmovie.idDirector=actors.idActor and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL = PrepareSQL("select distinct director_link.actor_id,actor.name,path.strPath from movie,files,path,actor,director_link where files.idFile=movie.idFile and files.idPath=path.idPath and director_link.media_id=movie.idMovie AND director_link.media_type='movie' and director_link.actor_id=actor.actor_id and actor.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL = PrepareSQL("select distinct directorlinkmovie.idDirector,actors.strActor from movie,actors,directorlinkmovie where directorlinkmovie.idMovie=movie.idMovie and directorlinkmovie.idDirector=actors.idActor and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL = PrepareSQL("select distinct director_link.actor_id,actor.name from movie,actor,director_link where director_link.media_id=movie.idMovie AND director_link.media_type='movie' and director_link.actor_id=actor.actor_id and actor.name like '%%%s%%'",strSearch.c_str());
 
     m_pDS->query( strSQL.c_str() );
 
@@ -7763,8 +7765,8 @@ void CVideoDatabase::GetMovieDirectorsByName(const CStdString& strSearch, CFileI
           continue;
         }
 
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("directorlinkmovie.idDirector").get_asInt());
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
 
       pItem->SetPath("videodb://movies/directors/"+ strDir);
       pItem->m_bIsFolder=true;
@@ -7789,9 +7791,9 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const CStdString& strSearch, CFil
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select distinct directorlinktvshow.idDirector,actors.strActor,path.strPath from tvshow,path,actors,directorlinktvshow,tvshowlinkpath where tvshowlinkpath.idPath=path.idPath and tvshowlinkpath.idShow=tvshow.idShow and directorlinktvshow.idShow=tvshow.idShow and directorlinktvshow.idDirector=actors.idActor and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL = PrepareSQL("select distinct director_link.actor_id,actor.name,path.strPath from tvshow,path,actor,director_link,tvshowlinkpath where tvshowlinkpath.idPath=path.idPath and tvshowlinkpath.idShow=tvshow.idShow and director_link.media_id=tvshow.idShow AND director_link.media_type='tvshow' and director_link.actor_id=actor.actor_id and actor.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL = PrepareSQL("select distinct directorlinktvshow.idDirector,actors.strActor from tvshow,actors,directorlinktvshow where directorlinktvshow.idShow=tvshow.idShow and directorlinktvshow.idDirector=actors.idActor and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL = PrepareSQL("select distinct director_link.actor_id,actor.name from tvshow,actor,director_link where director_link.media_id=tvshow.idShow AND director_link.media_type='tvshow' and director_link.actor_id=actor.actor_id and actor.name like '%%%s%%'",strSearch.c_str());
 
     m_pDS->query( strSQL.c_str() );
 
@@ -7804,10 +7806,10 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const CStdString& strSearch, CFil
           continue;
         }
 
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("directorlinktvshow.idDirector").get_asInt());
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
 
-      pItem->SetPath("videodb://tvshows/studios/"+ strDir);
+      pItem->SetPath("videodb://tvshows/directors/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -7830,9 +7832,9 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const CStdString& strSearch, C
     if (NULL == m_pDS.get()) return;
 
     if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
-      strSQL = PrepareSQL("select distinct directorlinkmusicvideo.idDirector,actors.strActor,path.strPath from musicvideo,files,path,actors,directorlinkmusicvideo where files.idFile=musicvideo.idFile and files.idPath=path.idPath and directorlinkmusicvideo.idMVideo=musicvideo.idMVideo and directorlinkmusicvideo.idDirector=actors.idActor and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL = PrepareSQL("select distinct director_link.actor_id,actor.name,path.strPath from musicvideo,files,path,actor,director_link where files.idFile=musicvideo.idFile and files.idPath=path.idPath and director_link.media_id=musicvideo.idMVideo AND director_link.media_type='musicvideo' and director_link.actor_id=actor.actor_id and actor.name like '%%%s%%'",strSearch.c_str());
     else
-      strSQL = PrepareSQL("select distinct directorlinkmusicvideo.idDirector,actors.strActor from musicvideo,actors,directorlinkmusicvideo where directorlinkmusicvideo.idMVideo=musicvideo.idMVideo and directorlinkmusicvideo.idDirector=actors.idActor and actors.strActor like '%%%s%%'",strSearch.c_str());
+      strSQL = PrepareSQL("select distinct director_link.actor_id,actor.name from musicvideo,actor,director_link where director_link.media_id=musicvideo.idMVideo AND director_link.media_type='musicvideo' and director_link.actor_id=actor.actor_id and actor.name like '%%%s%%'",strSearch.c_str());
 
     m_pDS->query( strSQL.c_str() );
 
@@ -7845,8 +7847,8 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const CStdString& strSearch, C
           continue;
         }
 
-      CStdString strDir = StringUtils::Format("%ld/", m_pDS->fv("directorlinkmusicvideo.idDirector").get_asInt());
-      CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
+      CStdString strDir = StringUtils::Format("%d/", m_pDS->fv(0).get_asInt());
+      CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
 
       pItem->SetPath("videodb://musicvideos/albums/"+ strDir);
       pItem->m_bIsFolder=true;
@@ -8133,17 +8135,10 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const se
     m_pDS->exec(sql.c_str());
 
     CLog::Log(LOGDEBUG, "%s: Cleaning actor table of actors, directors and writers", __FUNCTION__);
-    sql = "DELETE FROM actors "
-            "WHERE NOT EXISTS (SELECT 1 FROM actorlinkmovie WHERE actorlinkmovie.idActor = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM directorlinkmovie WHERE directorlinkmovie.idDirector = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM writerlinkmovie WHERE writerlinkmovie.idWriter = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM actorlinktvshow WHERE actorlinktvshow.idActor = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM actorlinkepisode WHERE actorlinkepisode.idActor = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM directorlinktvshow WHERE directorlinktvshow.idDirector = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM directorlinkepisode WHERE directorlinkepisode.idDirector = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM writerlinkepisode WHERE writerlinkepisode.idWriter = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM artistlinkmusicvideo WHERE artistlinkmusicvideo.idArtist = actors.idActor) "
-              "AND NOT EXISTS (SELECT 1 FROM directorlinkmusicvideo WHERE directorlinkmusicvideo.idDirector = actors.idActor)";
+    sql = "DELETE FROM actor "
+            "WHERE NOT EXISTS (SELECT 1 FROM actor_link WHERE actor_link.actor_id = actor.actor_id) "
+              "AND NOT EXISTS (SELECT 1 FROM director_link WHERE director_link.actor_id = actor.actor_id) "
+              "AND NOT EXISTS (SELECT 1 FROM writer_link WHERE writer_link.actor_id = actor.actor_id)";
     m_pDS->exec(sql.c_str());
 
     CLog::Log(LOGDEBUG, "%s: Cleaning studio table", __FUNCTION__);
@@ -9362,15 +9357,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     option = options.find("directorid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join directorlinkmovie on directorlinkmovie.idMovie = movieview.idMovie"));
-      filter.AppendWhere(PrepareSQL("directorlinkmovie.idDirector = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=movieview.idMovie AND director_link.media_type='movie'"));
+      filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("director");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join directorlinkmovie on directorlinkmovie.idMovie = movieview.idMovie join actors on actors.idActor = directorlinkmovie.idDirector"));
-      filter.AppendWhere(PrepareSQL("actors.strActor like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=movieview.idMovie AND director_link.media_type='movie' JOIN actor ON actor.actor_id = director_link.actor_id"));
+      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("year");
@@ -9380,15 +9375,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     option = options.find("actorid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join actorlinkmovie on actorlinkmovie.idMovie = movieview.idMovie"));
-      filter.AppendWhere(PrepareSQL("actorlinkmovie.idActor = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=movieview.idMovie AND actor_link.media_type='movie'"));
+      filter.AppendWhere(PrepareSQL("actor_link.actor_id=%i", (int)option->second.asInteger()));
     }
 
     option = options.find("actor");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join actorlinkmovie on actorlinkmovie.idMovie = movieview.idMovie join actors on actors.idActor = actorlinkmovie.idActor"));
-      filter.AppendWhere(PrepareSQL("actors.strActor like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=movieview.idMovie AND actor_link.media_type='movie' JOIN actor ON actor.actor_id=actor_link.actor_id"));
+      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("setid");
@@ -9451,8 +9446,8 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       option = options.find("directorid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join directorlinktvshow on directorlinktvshow.idShow = tvshowview.idShow"));
-        filter.AppendWhere(PrepareSQL("directorlinktvshow.idDirector = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=tvshowview.idShow AND director_link.media_type='tvshow'"));
+        filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
       }
 
       option = options.find("year");
@@ -9462,15 +9457,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       option = options.find("actorid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join actorlinktvshow on actorlinktvshow.idShow = tvshowview.idShow"));
-        filter.AppendWhere(PrepareSQL("actorlinktvshow.idActor = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = tvshowview.idShow AND actor_link.media_type = 'tvshow'"));
+        filter.AppendWhere(PrepareSQL("actor_link.actor_id = %i", (int)option->second.asInteger()));
       }
 
       option = options.find("actor");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join actorlinktvshow on actorlinktvshow.idShow = tvshowview.idShow join actors on actors.idActor = actorlinktvshow.idActor"));
-        filter.AppendWhere(PrepareSQL("actors.strActor like '%s'", option->second.asString().c_str()));
+        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = tvshowview.idShow AND actor_link.media_type = 'tvshow' JOIN actor ON actor.actor_id = actor_link.actor_id"));
+        filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
       }
 
       option = options.find("tagid");
@@ -9503,8 +9498,8 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       option = options.find("directorid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join directorlinktvshow on directorlinktvshow.idShow = seasonview.idShow"));
-        filter.AppendWhere(PrepareSQL("directorlinktvshow.idDirector = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=seasonview.idShow AND director_link.media_type='tvshow'"));
+        filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
       }
       
       option = options.find("year");
@@ -9514,8 +9509,8 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       option = options.find("actorid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join actorlinktvshow on actorlinktvshow.idShow = seasonview.idShow"));
-        filter.AppendWhere(PrepareSQL("actorlinktvshow.idActor = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = seasonview.idShow AND actor_link.media_type = 'tvshow'"));
+        filter.AppendWhere(PrepareSQL("actor_link.actor_id = %i", (int)option->second.asInteger()));
       }
     }
     else if (itemType == "episodes")
@@ -9554,16 +9549,16 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         if (option != options.end())
         {
           condition = true;
-          filter.AppendJoin(PrepareSQL("join directorlinktvshow on directorlinktvshow.idShow = episodeview.idShow"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and directorlinktvshow.idDirector = %i", idShow, (int)option->second.asInteger()));
+          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idShow AND director_link.media_type='tvshow'"));
+          filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
         }
 
         option = options.find("director");
         if (option != options.end())
         {
           condition = true;
-          filter.AppendJoin(PrepareSQL("join directorlinktvshow on directorlinktvshow.idShow = episodeview.idShow join actors on actors.idActor = directorlinktvshow.idDirector"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and actors.strActor like '%s'", idShow, option->second.asString().c_str()));
+          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idShow AND director_link.media_type='tvshow' JOIN actor ON actor.actor_id = director_link.actor_id"));
+          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and actor.name LIKE '%s'", idShow, option->second.asString().c_str()));
         }
       
         option = options.find("year");
@@ -9577,16 +9572,16 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         if (option != options.end())
         {
           condition = true;
-          filter.AppendJoin(PrepareSQL("join actorlinktvshow on actorlinktvshow.idShow = episodeview.idShow"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and actorlinktvshow.idActor = %i", idShow, (int)option->second.asInteger()));
+          filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = episodeview.idShow AND actor_link.media_type = 'tvshow'"));
+          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i AND actor_link.actor_id = %i", idShow, (int)option->second.asInteger()));
         }
 
         option = options.find("actor");
         if (option != options.end())
         {
           condition = true;
-          filter.AppendJoin(PrepareSQL("join actorlinktvshow on actorlinktvshow.idShow = episodeview.idShow join actors on actors.idActor = actorlinktvshow.idActor"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and actors.strActor = '%s'", idShow, option->second.asString().c_str()));
+          filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = episodeview.idShow AND actor_link.media_type = 'tvshow' JOIN actor ON actor.actor_id = actor_link.actor_id"));
+          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i AND actor.name = '%s'", idShow, option->second.asString().c_str()));
         }
 
         if (!condition)
@@ -9610,15 +9605,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         option = options.find("directorid");
         if (option != options.end())
         {
-          filter.AppendJoin(PrepareSQL("join directorlinkepisode on directorlinkepisode.idEpisode = episodeview.idEpisode"));
-          filter.AppendWhere(PrepareSQL("directorlinkepisode.idDirector = %i", (int)option->second.asInteger()));
+          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idEpisode AND director_link.media_type='episode'"));
+          filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
         }
 
         option = options.find("director");
         if (option != options.end())
         {
-          filter.AppendJoin(PrepareSQL("join directorlinkepisode on directorlinkepisode.idEpisode = episodeview.idEpisode join actors on actors.idActor = directorlinktvshow.idDirector"));
-          filter.AppendWhere(PrepareSQL("actors.strActor = %s", option->second.asString().c_str()));
+          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idEpisode AND director_link.media_type='episode' JOIN actor ON actor.actor_id = director_link.actor_id"));
+          filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
         }
       }
     }
@@ -9656,15 +9651,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     option = options.find("directorid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join directorlinkmusicvideo on directorlinkmusicvideo.idMVideo = musicvideoview.idMVideo"));
-      filter.AppendWhere(PrepareSQL("directorlinkmusicvideo.idDirector = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=musicvideoview.idMVideo AND director_link.media_type='musicvideo'"));
+      filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("director");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join directorlinkmusicvideo on directorlinkmusicvideo.idMVideo = musicvideoview.idMVideo join actors on actors.idActor = directorlinkmusicvideo.idDirector"));
-      filter.AppendWhere(PrepareSQL("actors.strActor like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=musicvideoview.idMVideo AND director_link.media_type='musicvideo' JOIN actor ON actor.actor_id = director_link.actor_id"));
+      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("year");
@@ -9675,8 +9670,8 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     if (option != options.end())
     {
       if (itemType != "albums")
-        filter.AppendJoin(PrepareSQL("join artistlinkmusicvideo on artistlinkmusicvideo.idMVideo = musicvideoview.idMVideo"));
-      filter.AppendWhere(PrepareSQL("artistlinkmusicvideo.idArtist = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo'"));
+      filter.AppendWhere(PrepareSQL("actor_link.actor_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("artist");
@@ -9684,10 +9679,10 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     {
       if (itemType != "albums")
       {
-        filter.AppendJoin(PrepareSQL("join artistlinkmusicvideo on artistlinkmusicvideo.idMVideo = musicvideoview.idMVideo"));
-        filter.AppendJoin(PrepareSQL("join actors on actors.idActor = artistlinkmusicvideo.idArtist"));
+        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideoview.idMVideo AND actor_link.media_type='musicvideo'"));
+        filter.AppendJoin(PrepareSQL("JOIN actor ON actor.actor_id=actor_link.actor_id"));
       }
-      filter.AppendWhere(PrepareSQL("actors.strActor like '%s'", option->second.asString().c_str()));
+      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("albumid");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1507,25 +1507,14 @@ int CVideoDatabase::AddActor(const CStdString& name, const CStdString& thumbURLs
 
 
 
-void CVideoDatabase::AddLinkToActor(const char *table, int actorID, const char *field, int secondID, const CStdString &role, int order)
+void CVideoDatabase::AddLinkToActor(int mediaId, const char *mediaType, int actorId, const CStdString &role, int order)
 {
-  try
-  {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+  std::string sql=PrepareSQL("SELECT 1 FROM actor_link WHERE actor_id=%i AND media_id=%i AND media_type='%s'", actorId, mediaId, mediaType);
 
-    std::string sql=PrepareSQL("SELECT 1 FROM actor_link WHERE actor_id=%i AND media_id=%i AND media_type='%s'", actorID, secondID, table);
-    m_pDS->query(sql);
-    if (m_pDS->num_rows() == 0)
-    { // doesnt exists, add it
-      sql = PrepareSQL("INSERT INTO actor_link (actor_id, media_id, media_type, role, cast_order) VALUES(%i,%i,'%s','%s',%i)", actorID, secondID, table, role.c_str(), order);
-      m_pDS->exec(sql);
-    }
-    m_pDS->close();
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+  if (GetSingleValue(sql).empty())
+  { // doesnt exists, add it
+    sql = PrepareSQL("INSERT INTO actor_link (actor_id, media_id, media_type, role, cast_order) VALUES(%i,%i,'%s','%s',%i)", actorId, mediaId, mediaType, role.c_str(), order);
+    ExecuteQuery(sql);
   }
 }
 
@@ -1638,7 +1627,7 @@ void CVideoDatabase::RemoveTagsFromItem(int idItem, const std::string &type)
 }
 
 //****Actors****
-void CVideoDatabase::AddCast(int idMedia, const char *table, const char *field, const std::vector< SActorInfo > &cast)
+void CVideoDatabase::AddCast(int mediaId, const char *mediaType, const std::vector< SActorInfo > &cast)
 {
   if (cast.empty())
     return;
@@ -1647,7 +1636,7 @@ void CVideoDatabase::AddCast(int idMedia, const char *table, const char *field, 
   for (CVideoInfoTag::iCast it = cast.begin(); it != cast.end(); ++it)
   {
     int idActor = AddActor(it->strName, it->thumbUrl.m_xml, it->thumb);
-    AddLinkToActor(table, idActor, field, idMedia, it->strRole, it->order >= 0 ? it->order : ++order);
+    AddLinkToActor(mediaId, mediaType, idActor, it->strRole, it->order >= 0 ? it->order : ++order);
   }
 }
 
@@ -2172,7 +2161,7 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
     for (unsigned int i = 0; i < vecStudios.size(); ++i)
       AddStudioToMovie(idMovie, vecStudios[i]);
 
-    AddCast(idMovie, "movie", "movie", details.m_cast);
+    AddCast(idMovie, "movie", details.m_cast);
     AddActorLinksToItem(idMovie, MediaTypeMovie, "director", details.m_director);
     AddActorLinksToItem(idMovie, MediaTypeMovie, "writer", details.m_writingCredits);
 
@@ -2410,7 +2399,7 @@ bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, const CVideoInfoTag &d
   vector<int> vecStudios;
   AddGenreAndDirectorsAndStudios(details,vecDirectors,vecGenres,vecStudios);
 
-  AddCast(idTvShow, "tvshow", "show", details.m_cast);
+  AddCast(idTvShow, "tvshow", details.m_cast);
 
   unsigned int i;
   for (i = 0; i < vecGenres.size(); ++i)
@@ -2509,7 +2498,7 @@ int CVideoDatabase::SetDetailsForEpisode(const CStdString& strFilenameAndPath, c
       }
     }
 
-    AddCast(idEpisode, "episode", "episode", details.m_cast);
+    AddCast(idEpisode, "episode", details.m_cast);
     AddActorLinksToItem(idEpisode, MediaTypeEpisode, "director", details.m_director);
     AddActorLinksToItem(idEpisode, MediaTypeEpisode, "writer", details.m_writingCredits);
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4588,7 +4588,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 89;
+  return 90;
 }
 
 bool CVideoDatabase::LookupByFolders(const CStdString &path, bool shows)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9164,6 +9164,27 @@ bool CVideoDatabase::GetItemsForPath(const CStdString &content, const CStdString
   return items.Size() > 0;
 }
 
+void CVideoDatabase::AppendIdFilter(const char* field, const char *table, const char *mediaType, const char *view, const char *viewKey, const CUrlOptions::UrlOptions& options, Filter &filter)
+{
+  CUrlOptions::UrlOptions::const_iterator option = options.find((std::string)field + "id");
+  if (option != options.end())
+  {
+    filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%sview.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType));
+    filter.AppendWhere(PrepareSQL("%s_link.%s_id = %i", field, table, (int)option->second.asInteger()));
+  }
+}
+
+void CVideoDatabase::AppendFilter(const char* field, const char *table, const char *mediaType, const char *view, const char *viewKey, const CUrlOptions::UrlOptions& options, Filter &filter)
+{
+  CUrlOptions::UrlOptions::const_iterator option = options.find(field);
+  if (option != options.end())
+  {
+    filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%sview.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType));
+    filter.AppendJoin(PrepareSQL("JOIN %s ON %s.%s_id=%s_link.%s_id", table, table, field, table));
+    filter.AppendWhere(PrepareSQL("%s.name like '%s'", table, option->second.asString().c_str()));
+  }
+}
+
 bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription &sorting)
 {
   if (!videoUrl.IsValid())
@@ -9176,79 +9197,24 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
   if (type == "movies")
   {
-    option = options.find("genreid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=movieview.idMovie AND genre_link.media_type='movie'"));
-      filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
-    }
+    AppendIdFilter("genre", "genre", "movie", "movie", "idMovie", options, filter);
+    AppendFilter("genre", "genre", "movie", "movie", "idMovie", options, filter);
 
-    option = options.find("genre");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=movieview.idMovie AND genre_link.media_type='movie' JOIN genre ON genre.genre_id=genre_link.genre_id"));
-      filter.AppendWhere(PrepareSQL("genre.name like '%s'", option->second.asString().c_str()));
-    }
+    AppendIdFilter("country", "country", "movie", "movie", "idMovie", options, filter);
+    AppendFilter("country", "country", "movie", "movie", "idMovie", options, filter);
 
-    option = options.find("countryid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN country_link ON country_link.media_id=movieview.idMovie AND country_link.media_type='movie'"));
-      filter.AppendWhere(PrepareSQL("country_link.country_id = %i", (int)option->second.asInteger()));
-    }
+    AppendIdFilter("studio", "studio", "movie", "movie", "idMovie", options, filter);
+    AppendFilter("studio", "studio", "movie", "movie", "idMovie", options, filter);
 
-    option = options.find("country");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN country_link ON country_link.media_id=movieview.idMovie AND country_link.media_type='movie' JOIN country ON country.country_id=country_link.country_id"));
-      filter.AppendWhere(PrepareSQL("country.name like '%s'", option->second.asString().c_str()));
-    }
-
-    option = options.find("studioid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=movieview.idMovie AND studio_link.media_type='movie'"));
-      filter.AppendWhere(PrepareSQL("studio_link.studio_id = %i", (int)option->second.asInteger()));
-    }
-
-    option = options.find("studio");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=movieview.idMovie AND studio_link.media_type='movie' JOIN studio ON studio.studio_id=studio_link.studio_id"));
-      filter.AppendWhere(PrepareSQL("studio.name like '%s'", option->second.asString().c_str()));
-    }
-
-    option = options.find("directorid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=movieview.idMovie AND director_link.media_type='movie'"));
-      filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
-    }
-
-    option = options.find("director");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=movieview.idMovie AND director_link.media_type='movie' JOIN actor ON actor.actor_id = director_link.actor_id"));
-      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
-    }
+    AppendIdFilter("director", "actor", "movie", "movie", "idMovie", options, filter);
+    AppendFilter("director", "actor", "movie", "movie", "idMovie", options, filter);
 
     option = options.find("year");
     if (option != options.end())
       filter.AppendWhere(PrepareSQL("movieview.c%02d = '%i'", VIDEODB_ID_YEAR, (int)option->second.asInteger()));
 
-    option = options.find("actorid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=movieview.idMovie AND actor_link.media_type='movie'"));
-      filter.AppendWhere(PrepareSQL("actor_link.actor_id=%i", (int)option->second.asInteger()));
-    }
-
-    option = options.find("actor");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=movieview.idMovie AND actor_link.media_type='movie' JOIN actor ON actor.actor_id=actor_link.actor_id"));
-      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
-    }
+    AppendIdFilter("actor", "actor", "movie", "movie", "idMovie", options, filter);
+    AppendFilter("actor", "actor", "movie", "movie", "idMovie", options, filter);
 
     option = options.find("setid");
     if (option != options.end())
@@ -9261,90 +9227,30 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       filter.AppendWhere(PrepareSQL("sets.strSet like '%s'", option->second.asString().c_str()));
     }
 
-    option = options.find("tagid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = movieview.idMovie AND tag_link.media_type = 'movie'"));
-      filter.AppendWhere(PrepareSQL("tag_link.tag_id = %i", (int)option->second.asInteger()));
-    }
-
-    option = options.find("tag");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = movieview.idMovie AND tag_link.media_type = 'movie' JOIN tag ON tag.tag_id = tag_link.tag_id"));
-      filter.AppendWhere(PrepareSQL("tag.name like '%s'", option->second.asString().c_str()));
-    }
+    AppendIdFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);
+    AppendFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);
   }
   else if (type == "tvshows")
   {
     if (itemType == "tvshows")
     {
-      option = options.find("genreid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=tvshowview.idShow AND genre_link.media_type='tvshow'"));
-        filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
-      }
+      AppendIdFilter("genre", "genre", "tvshow", "tvshow", "idShow", options, filter);
+      AppendFilter("genre", "genre", "tvshow", "tvshow", "idShow", options, filter);
 
-      option = options.find("genre");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=tvshowview.idShow AND genre_link.media_type='tvshow' JOIN genre ON genre.genre_id=genre_link.genre_id"));
-        filter.AppendWhere(PrepareSQL("genre.name like '%s'", option->second.asString().c_str()));
-      }
+      AppendIdFilter("studio", "studio", "tvshow", "tvshow", "idShow", options, filter);
+      AppendFilter("studio", "studio", "tvshow", "tvshow", "idShow", options, filter);
 
-      option = options.find("studioid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=tvshowview.idShow AND studio_link.media_type='tvshow'"));
-        filter.AppendWhere(PrepareSQL("studio_link.studio_id = %i", (int)option->second.asInteger()));
-      }
-
-      option = options.find("studio");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=tvshowview.idShow AND studio_link.media_type='tvshow' JOIN studio ON studio.studio_id=studio_link.studio_id"));
-        filter.AppendWhere(PrepareSQL("studio.name like '%s'", option->second.asString().c_str()));
-      }
-
-      option = options.find("directorid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=tvshowview.idShow AND director_link.media_type='tvshow'"));
-        filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
-      }
+      AppendIdFilter("director", "actor", "tvshow", "tvshow", "idShow", options, filter);
 
       option = options.find("year");
       if (option != options.end())
         filter.AppendWhere(PrepareSQL("tvshowview.c%02d like '%%%i%%'", VIDEODB_ID_TV_PREMIERED, (int)option->second.asInteger()));
 
-      option = options.find("actorid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = tvshowview.idShow AND actor_link.media_type = 'tvshow'"));
-        filter.AppendWhere(PrepareSQL("actor_link.actor_id = %i", (int)option->second.asInteger()));
-      }
+      AppendIdFilter("actor", "actor", "tvshow", "tvshow", "idShow", options, filter);
+      AppendFilter("actor", "actor", "tvshow", "tvshow", "idShow", options, filter);
 
-      option = options.find("actor");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = tvshowview.idShow AND actor_link.media_type = 'tvshow' JOIN actor ON actor.actor_id = actor_link.actor_id"));
-        filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
-      }
-
-      option = options.find("tagid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = tvshowview.idShow AND tag_link.media_type = 'tvshow'"));
-        filter.AppendWhere(PrepareSQL("tag_link.tag_id = %i", (int)option->second.asInteger()));
-      }
-
-      option = options.find("tag");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = tvshowview.idShow AND tag_link.media_type = 'tvshow' JOIN tag ON tag.tag_id = tag_link.tag_id"));
-        filter.AppendWhere(PrepareSQL("tag.name like '%s'", option->second.asString().c_str()));
-      }
+      AppendIdFilter("tag", "tag", "tvshow", "tvshow", "idShow", options, filter);
+      AppendFilter("tag", "tag", "tvshow", "tvshow", "idShow", options, filter);
     }
     else if (itemType == "seasons")
     {
@@ -9352,30 +9258,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       if (option != options.end())
         filter.AppendWhere(PrepareSQL("seasonview.idShow = %i", (int)option->second.asInteger()));
 
-      option = options.find("genreid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=seasonview.idShow AND genre_link.media_type='tvshow'"));
-        filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
-      }
+      AppendIdFilter("genre", "genre", "tvshow", "season", "idShow", options, filter);
 
-      option = options.find("directorid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=seasonview.idShow AND director_link.media_type='tvshow'"));
-        filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
-      }
-      
+      AppendIdFilter("director", "actor", "tvshow", "season", "idShow", options, filter);
+
       option = options.find("year");
       if (option != options.end())
         filter.AppendWhere(PrepareSQL("seasonview.premiered like '%%%i%%'", (int)option->second.asInteger()));
 
-      option = options.find("actorid");
-      if (option != options.end())
-      {
-        filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = seasonview.idShow AND actor_link.media_type = 'tvshow'"));
-        filter.AppendWhere(PrepareSQL("actor_link.actor_id = %i", (int)option->second.asInteger()));
-      }
+      AppendIdFilter("actor", "actor", "tvshow", "season", "idShow", options, filter);
     }
     else if (itemType == "episodes")
     {
@@ -9393,37 +9284,11 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       {
         bool condition = false;
 
-        option = options.find("genreid");
-        if (option != options.end())
-        {
-          condition = true;
-          filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=episodeview.idShow AND genre_link.media_type='tvshow'"));
-          filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
-        }
+        AppendIdFilter("genre", "genre", "tvshow", "episode", "idShow", options, filter);
+        AppendFilter("genre", "genre", "tvshow", "episode", "idShow", options, filter);
 
-        option = options.find("genre");
-        if (option != options.end())
-        {
-          condition = true;
-          filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=episodeview.idShow AND genre_link.media_type='tvshow' JOIN genre ON genre.genre_id=genre_link.genre_id"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and genre.name like '%s'", idShow, option->second.asString().c_str()));
-        }
-
-        option = options.find("directorid");
-        if (option != options.end())
-        {
-          condition = true;
-          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idShow AND director_link.media_type='tvshow'"));
-          filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
-        }
-
-        option = options.find("director");
-        if (option != options.end())
-        {
-          condition = true;
-          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idShow AND director_link.media_type='tvshow' JOIN actor ON actor.actor_id = director_link.actor_id"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and actor.name LIKE '%s'", idShow, option->second.asString().c_str()));
-        }
+        AppendIdFilter("director", "actor", "tvshow", "episode", "idShow", options, filter);
+        AppendFilter("director", "actor", "tvshow", "episode", "idShow", options, filter);
       
         option = options.find("year");
         if (option != options.end())
@@ -9432,21 +9297,8 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
           filter.AppendWhere(PrepareSQL("episodeview.idShow = %i and episodeview.premiered like '%%%i%%'", idShow, (int)option->second.asInteger()));
         }
 
-        option = options.find("actorid");
-        if (option != options.end())
-        {
-          condition = true;
-          filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = episodeview.idShow AND actor_link.media_type = 'tvshow'"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i AND actor_link.actor_id = %i", idShow, (int)option->second.asInteger()));
-        }
-
-        option = options.find("actor");
-        if (option != options.end())
-        {
-          condition = true;
-          filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id = episodeview.idShow AND actor_link.media_type = 'tvshow' JOIN actor ON actor.actor_id = actor_link.actor_id"));
-          filter.AppendWhere(PrepareSQL("episodeview.idShow = %i AND actor.name = '%s'", idShow, option->second.asString().c_str()));
-        }
+        AppendIdFilter("actor", "actor", "tvshow", "episode", "idShow", options, filter);
+        AppendFilter("actor", "actor", "tvshow", "episode", "idShow", options, filter);
 
         if (!condition)
           filter.AppendWhere(PrepareSQL("episodeview.idShow = %i", idShow));
@@ -9466,65 +9318,21 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         if (option != options.end())
           filter.AppendWhere(PrepareSQL("episodeview.premiered like '%%%i%%'", (int)option->second.asInteger()));
 
-        option = options.find("directorid");
-        if (option != options.end())
-        {
-          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idEpisode AND director_link.media_type='episode'"));
-          filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
-        }
-
-        option = options.find("director");
-        if (option != options.end())
-        {
-          filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=episodeview.idEpisode AND director_link.media_type='episode' JOIN actor ON actor.actor_id = director_link.actor_id"));
-          filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
-        }
+        AppendIdFilter("director", "actor", "episode", "episode", "idEpisode", options, filter);
+        AppendFilter("director", "actor", "episode", "episode", "idEpisode", options, filter);
       }
     }
   }
   else if (type == "musicvideos")
   {
-    option = options.find("genreid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=musicvideoview.idMVideo AND genre_link.media_type='musicvideo'"));
-      filter.AppendWhere(PrepareSQL("genre_link.genre_id = %i", (int)option->second.asInteger()));
-    }
+    AppendIdFilter("genre", "genre", "musicvideo", "musicvideo", "idMVideo", options, filter);
+    AppendFilter("genre", "genre", "musicvideo", "musicvideo", "idMVideo", options, filter);
 
-    option = options.find("genre");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN genre_link ON genre_link.media_id=musicvideoview.idMVideo AND genre_link.media_type='musicvideo' JOIN genre ON genre.genre_id=genre_link.genre_id"));
-      filter.AppendWhere(PrepareSQL("genre.name like '%s'", option->second.asString().c_str()));
-    }
+    AppendIdFilter("studio", "studio", "musicvideo", "musicvideo", "idMVideo", options, filter);
+    AppendFilter("studio", "studio", "musicvideo", "musicvideo", "idMVideo", options, filter);
 
-    option = options.find("studioid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=musicvideoview.idMVideo AND studio_link.media_type='musicvideo'"));
-      filter.AppendWhere(PrepareSQL("studio_link.studio_id = %i", (int)option->second.asInteger()));
-    }
-
-    option = options.find("studio");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN studio_link ON studio_link.media_id=musicvideoview.idMVideo AND studio_link.media_type='musicvideo' JOIN studio ON studio.studio_id=studio_link.studio_id"));
-      filter.AppendWhere(PrepareSQL("studio.name like '%s'", option->second.asString().c_str()));
-    }
-
-    option = options.find("directorid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=musicvideoview.idMVideo AND director_link.media_type='musicvideo'"));
-      filter.AppendWhere(PrepareSQL("director_link.actor_id = %i", (int)option->second.asInteger()));
-    }
-
-    option = options.find("director");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN director_link ON director_link.media_id=musicvideoview.idMVideo AND director_link.media_type='musicvideo' JOIN actor ON actor.actor_id = director_link.actor_id"));
-      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
-    }
+    AppendIdFilter("director", "actor", "musicvideo", "musicvideo", "idMVideo", options, filter);
+    AppendFilter("director", "actor", "musicvideo", "musicvideo", "idMVideo", options, filter);
 
     option = options.find("year");
     if (option != options.end())
@@ -9553,19 +9361,8 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     if (option != options.end())
       filter.AppendWhere(PrepareSQL("musicvideoview.c%02d = (select c%02d from musicvideo where idMVideo = %i)", VIDEODB_ID_MUSICVIDEO_ALBUM, VIDEODB_ID_MUSICVIDEO_ALBUM, (int)option->second.asInteger()));
 
-    option = options.find("tagid");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = musicvideoview.idMVideo AND tag_link.media_type = 'musicvideo'"));
-      filter.AppendWhere(PrepareSQL("tag_link.tag_id = %i", (int)option->second.asInteger()));
-    }
-
-    option = options.find("tag");
-    if (option != options.end())
-    {
-      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = musicvideoview.idMVideo AND tag_link.media_type = 'musicvideo' JOIN tag ON tag.tag_id = tag_link.tag_id"));
-      filter.AppendWhere(PrepareSQL("tag.name like '%s'", option->second.asString().c_str()));
-    }
+    AppendIdFilter("tag", "tag", "musicvideo", "musicvideo", "idMVideo", options, filter);
+    AppendFilter("tag", "tag", "musicvideo", "musicvideo", "idMVideo", options, filter);
   }
   else
     return false;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -188,10 +188,8 @@ void CVideoDatabase::CreateTables()
   m_pDS->exec("CREATE TABLE art(art_id INTEGER PRIMARY KEY, media_id INTEGER, media_type TEXT, type TEXT, url TEXT)");
 
   CLog::Log(LOGINFO, "create tag table");
-  m_pDS->exec("CREATE TABLE tag (idTag integer primary key, strTag text)");
-
-  CLog::Log(LOGINFO, "create taglinks table");
-  m_pDS->exec("CREATE TABLE taglinks (idTag integer, idMedia integer, media_type TEXT)");
+  m_pDS->exec("CREATE TABLE tag (tag_id integer primary key, name TEXT)");
+  m_pDS->exec("CREATE TABLE tag_link (tag_id integer, media_id integer, media_type TEXT)");
 }
 
 void CVideoDatabase::CreateLinkIndex(const char *table)
@@ -258,11 +256,7 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE INDEX ix_seasons ON seasons (idShow, season)");
   m_pDS->exec("CREATE INDEX ix_art ON art(media_id, media_type(20), type(20))");
 
-  m_pDS->exec("CREATE UNIQUE INDEX ix_tag_1 ON tag (strTag(255))");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_taglinks_1 ON taglinks (idTag, media_type(20), idMedia)");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_taglinks_2 ON taglinks (idMedia, media_type(20), idTag)");
-  m_pDS->exec("CREATE INDEX ix_taglinks_3 ON taglinks (media_type(20))");
-
+  CreateLinkIndex("tag");
   CreateLinkIndex("actor");
   CreateForeignLinkIndex("director", "actor");
   CreateForeignLinkIndex("writer", "actor");
@@ -280,7 +274,7 @@ void CVideoDatabase::CreateAnalytics()
               "DELETE FROM writer_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM movielinktvshow WHERE idMovie=old.idMovie; "
               "DELETE FROM art WHERE media_id=old.idMovie AND media_type='movie'; "
-              "DELETE FROM taglinks WHERE idMedia=old.idMovie AND media_type='movie'; "
+              "DELETE FROM tag_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_tvshow AFTER DELETE ON tvshow FOR EACH ROW BEGIN "
               "DELETE FROM actor_link WHERE media_id=old.idShow AND media_type='tvshow'; "
@@ -290,7 +284,7 @@ void CVideoDatabase::CreateAnalytics()
               "DELETE FROM movielinktvshow WHERE idShow=old.idShow; "
               "DELETE FROM seasons WHERE idShow=old.idShow; "
               "DELETE FROM art WHERE media_id=old.idShow AND media_type='tvshow'; "
-              "DELETE FROM taglinks WHERE idMedia=old.idShow AND media_type='tvshow'; "
+              "DELETE FROM tag_link WHERE media_id=old.idShow AND media_type='tvshow'; "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_musicvideo AFTER DELETE ON musicvideo FOR EACH ROW BEGIN "
               "DELETE FROM actor_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
@@ -298,7 +292,7 @@ void CVideoDatabase::CreateAnalytics()
               "DELETE FROM genre_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "DELETE FROM studio_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "DELETE FROM art WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
-              "DELETE FROM taglinks WHERE idMedia=old.idMVideo AND media_type='musicvideo'; "
+              "DELETE FROM tag_link WHERE media_id=old.idMVideo AND media_type='musicvideo'; "
               "END");
   m_pDS->exec("CREATE TRIGGER delete_episode AFTER DELETE ON episode FOR EACH ROW BEGIN "
               "DELETE FROM actor_link WHERE media_id=old.idEpisode AND media_type='episode'; "
@@ -315,8 +309,8 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE TRIGGER delete_person AFTER DELETE ON actor FOR EACH ROW BEGIN "
               "DELETE FROM art WHERE media_id=old.actor_id AND media_type IN ('actor','artist','writer','director'); "
               "END");
-  m_pDS->exec("CREATE TRIGGER delete_tag AFTER DELETE ON taglinks FOR EACH ROW BEGIN "
-              "DELETE FROM tag WHERE idTag=old.idTag AND idTag NOT IN (SELECT DISTINCT idTag FROM taglinks); "
+  m_pDS->exec("CREATE TRIGGER delete_tag AFTER DELETE ON tag_link FOR EACH ROW BEGIN "
+              "DELETE FROM tag WHERE tag_id=old.tag_id AND tag_id NOT IN (SELECT DISTINCT tag_id FROM tag_link); "
               "END");
 
   CreateViews();
@@ -1412,12 +1406,12 @@ int CVideoDatabase::AddSet(const CStdString& strSet)
   return AddToTable("sets", "idSet", "strSet", strSet);
 }
 
-int CVideoDatabase::AddTag(const std::string& tag)
+int CVideoDatabase::AddTag(const std::string& name)
 {
-  if (tag.empty())
+  if (name.empty())
     return -1;
 
-  return AddToTable("tag", "idTag", "strTag", tag);
+  return AddToTable("tag", "tag_id", "name", name);
 }
 
 int CVideoDatabase::AddActor(const CStdString& name, const CStdString& thumbURLs, const CStdString &thumb)
@@ -1562,28 +1556,28 @@ void CVideoDatabase::UpdateActorLinksToItem(int mediaId, const std::string& medi
 }
 
 //****Tags****
-void CVideoDatabase::AddTagToItem(int idMovie, int idTag, const std::string &type)
+void CVideoDatabase::AddTagToItem(int media_id, int tag_id, const std::string &type)
 {
   if (type.empty())
     return;
 
-  AddToLinkTable("taglinks", "idTag", idTag, "idMedia", idMovie, "media_type", type.c_str());
+  AddToLinkTable("tag_link", "tag_id", tag_id, "media_id", media_id, "media_type", type.c_str());
 }
 
-void CVideoDatabase::RemoveTagFromItem(int idItem, int idTag, const std::string &type)
+void CVideoDatabase::RemoveTagFromItem(int media_id, int tag_id, const std::string &type)
 {
   if (type.empty())
     return;
 
-  RemoveFromLinkTable("taglinks", "idTag", idTag, "idMedia", idItem, "media_type", type.c_str());
+  RemoveFromLinkTable("tag_link", "tag_id", tag_id, "media_id", media_id, "media_type", type.c_str());
 }
 
-void CVideoDatabase::RemoveTagsFromItem(int idItem, const std::string &type)
+void CVideoDatabase::RemoveTagsFromItem(int media_id, const std::string &type)
 {
   if (type.empty())
     return;
 
-  m_pDS2->exec(PrepareSQL("DELETE FROM taglinks WHERE idMedia=%d AND media_type='%s'", idItem, type.c_str()));
+  m_pDS2->exec(PrepareSQL("DELETE FROM tag_link WHERE media_id=%d AND media_type='%s'", media_id, type.c_str()));
 }
 
 //****Actors****
@@ -2066,6 +2060,7 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
     AddLinksToItem(idMovie, MediaTypeMovie, "genre", details.m_genre);
     AddLinksToItem(idMovie, MediaTypeMovie, "studio", details.m_studio);
     AddLinksToItem(idMovie, MediaTypeMovie, "country", details.m_country);
+    AddLinksToItem(idMovie, MediaTypeMovie, "tag", details.m_tags);
     AddActorLinksToItem(idMovie, MediaTypeMovie, "director", details.m_director);
     AddActorLinksToItem(idMovie, MediaTypeMovie, "writer", details.m_writingCredits);
 
@@ -2078,13 +2073,6 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
       map<string, string> setArt;
       if (!GetArtForItem(idSet, MediaTypeVideoCollection, setArt))
         SetArtForItem(idSet, MediaTypeVideoCollection, artwork);
-    }
-
-    // add tags...
-    for (unsigned int i = 0; i < details.m_tags.size(); i++)
-    {
-      int idTag = AddTag(details.m_tags[i]);
-      AddTagToItem(idMovie, idTag, MediaTypeMovie);
     }
 
     if (details.HasStreamDetails())
@@ -2152,16 +2140,12 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie, const CVideoInfoTag& deta
       UpdateLinksToItem(idMovie, "movie", "studio", details.m_studio);
     if (updatedDetails.find("country") != updatedDetails.end())
       UpdateLinksToItem(idMovie, "movie", "country", details.m_country);
+    if (updatedDetails.find("tag") != updatedDetails.end())
+      UpdateLinksToItem(idMovie, "movie", "tag", details.m_tags);
     if (updatedDetails.find("director") != updatedDetails.end())
       UpdateActorLinksToItem(idMovie, "movie", "director", details.m_director);
     if (updatedDetails.find("writer") != updatedDetails.end())
       UpdateActorLinksToItem(idMovie, "movie", "writer", details.m_writingCredits);
-    if (updatedDetails.find("tag") != updatedDetails.end())
-    {
-      RemoveTagsFromItem(idMovie, "movie");
-      for (unsigned int i = 0; i < details.m_tags.size(); i++)
-        AddTagToItem(idMovie, AddTag(details.m_tags[i]), "movie");
-    }
     if (updatedDetails.find("art.altered") != updatedDetails.end())
       SetArtForItem(idMovie, "movie", artwork);
 
@@ -2297,14 +2281,8 @@ bool CVideoDatabase::UpdateDetailsForTvShow(int idTvShow, const CVideoInfoTag &d
   AddCast(idTvShow, "tvshow", details.m_cast);
   AddLinksToItem(idTvShow, MediaTypeTvShow, "genre", details.m_genre);
   AddLinksToItem(idTvShow, MediaTypeTvShow, "studio", details.m_studio);
+  AddLinksToItem(idTvShow, MediaTypeTvShow, "tag", details.m_tags);
   AddActorLinksToItem(idTvShow, MediaTypeTvShow, "director", details.m_director);
-
-  // add tags...
-  for (unsigned int i = 0; i < details.m_tags.size(); i++)
-  {
-    int idTag = AddTag(details.m_tags[i]);
-    AddTagToItem(idTvShow, idTag, MediaTypeTvShow);
-  }
 
   // add "all seasons" - the rest are added in SetDetailsForEpisode
   AddSeason(idTvShow, -1);
@@ -2489,13 +2467,7 @@ int CVideoDatabase::SetDetailsForMusicVideo(const CStdString& strFilenameAndPath
     AddActorLinksToItem(idMVideo, MediaTypeMusicVideo, "director", details.m_director);
     AddLinksToItem(idMVideo, MediaTypeMusicVideo, "genre", details.m_genre);
     AddLinksToItem(idMVideo, MediaTypeMusicVideo, "studio", details.m_studio);
-
-    // add tags...
-    for (unsigned int i = 0; i < details.m_tags.size(); i++)
-    {
-      int idTag = AddTag(details.m_tags[i]);
-      AddTagToItem(idMVideo, idTag, MediaTypeMusicVideo);
-    }
+    AddLinksToItem(idMVideo, MediaTypeMusicVideo, "tag", details.m_tags);
 
     if (details.HasStreamDetails())
       SetStreamDetailsForFileId(details.m_streamDetails, GetFileId(strFilenameAndPath));
@@ -3264,7 +3236,7 @@ void CVideoDatabase::DeleteTag(int idTag, VIDEODB_CONTENT_TYPE mediaType)
       return;
 
     CStdString strSQL;
-    strSQL = PrepareSQL("DELETE FROM taglinks WHERE idTag = %i AND media_type = '%s'", idTag, type.c_str());
+    strSQL = PrepareSQL("DELETE FROM tag_link WHERE tag_id = %i AND media_type = '%s'", idTag, type.c_str());
     m_pDS->exec(strSQL.c_str());
   }
   catch (...)
@@ -3521,18 +3493,10 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   if (getDetails)
   {
     GetCast(details.m_iDbId, "movie", details.m_cast);
+    GetTags(details.m_iDbId, MediaTypeMovie, details.m_tags);
 
     castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
-
-    // get tags
-    CStdString strSQL = PrepareSQL("SELECT tag.strTag FROM tag, taglinks WHERE taglinks.idMedia = %i AND taglinks.media_type = 'movie' AND taglinks.idTag = tag.idTag ORDER BY tag.idTag", idMovie);
-    m_pDS2->query(strSQL.c_str());
-    while (!m_pDS2->eof())
-    {
-      details.m_tags.push_back(m_pDS2->fv("tag.strTag").get_asString());
-      m_pDS2->next();
-    }
 
     // create tvshowlink string
     vector<int> links;
@@ -3587,15 +3551,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
   if (getDetails)
   {
     GetCast(details.m_iDbId, "tvshow", details.m_cast);
-
-    // get tags
-    CStdString strSQL = PrepareSQL("SELECT tag.strTag FROM tag, taglinks WHERE taglinks.idMedia = %i AND taglinks.media_type = 'tvshow' AND taglinks.idTag = tag.idTag ORDER BY tag.idTag", idTvShow);
-    m_pDS2->query(strSQL.c_str());
-    while (!m_pDS2->eof())
-    {
-      details.m_tags.push_back(m_pDS2->fv("tag.strTag").get_asString());
-      m_pDS2->next();
-    }
+    GetTags(details.m_iDbId, MediaTypeTvShow, details.m_tags);
 
     castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
@@ -3703,15 +3659,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(const dbiplus::sql_record*
 
   if (getDetails)
   {
-    // get tags
-    CStdString strSQL = PrepareSQL("SELECT tag.strTag FROM tag, taglinks WHERE taglinks.idMedia = %i AND taglinks.media_type = 'musicvideo' AND taglinks.idTag = tag.idTag ORDER BY tag.idTag", idMVideo);
-    m_pDS2->query(strSQL.c_str());
-    while (!m_pDS2->eof())
-    {
-      details.m_tags.push_back(m_pDS2->fv("tag.strTag").get_asString());
-      m_pDS2->next();
-    }
-    m_pDS2->close();
+    GetTags(details.m_iDbId, MediaTypeMusicVideo, details.m_tags);
 
     details.m_strPictureURL.Parse();
 
@@ -3762,6 +3710,28 @@ void CVideoDatabase::GetCast(int media_id, const std::string &media_type, vector
         info.thumb = m_pDS2->fv(4).get_asString();
         cast.push_back(info);
       }
+      m_pDS2->next();
+    }
+    m_pDS2->close();
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s(%i,%s) failed", __FUNCTION__, media_id, media_type.c_str());
+  }
+}
+
+void CVideoDatabase::GetTags(int media_id, const std::string &media_type, std::vector<std::string> &tags)
+{
+  try
+  {
+    if (!m_pDB.get()) return;
+    if (!m_pDS2.get()) return;
+
+    std::string sql = PrepareSQL("SELECT tag.name FROM tag, tag_link WHERE tag_link.media_id = %i AND tag_link.media_type = '%s' AND tag_link.tag_id = tag.tag_id ORDER BY tag.tag_id", media_id, media_type.c_str());
+    m_pDS2->query(sql);
+    while (!m_pDS2->eof())
+    {
+      tags.push_back(m_pDS2->fv(0).get_asString());
       m_pDS2->next();
     }
     m_pDS2->close();
@@ -4630,6 +4600,15 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec("INSERT INTO countrynew(country_id, name) SELECT idCountry,strCountry FROM country");
     m_pDS->exec("DROP TABLE IF EXISTS country");
     m_pDS->exec("ALTER TABLE countrynew RENAME TO country");
+
+    // tags
+    m_pDS->exec("CREATE TABLE tag_link(tag_id INTEGER, media_id INTEGER, media_type TEXT)");
+    m_pDS->exec("INSERT INTO tag_link(tag_id, media_id, media_type) SELECT idTag,idMedia,media_type FROM taglinks");
+    m_pDS->exec("DROP TABLE IF EXISTS taglinks");
+    m_pDS->exec("CREATE TABLE tagnew(tag_id INTEGER PRIMARY KEY, name TEXT)");
+    m_pDS->exec("INSERT INTO tagnew(tag_id, name) SELECT idTag,strTag FROM tag");
+    m_pDS->exec("DROP TABLE IF EXISTS tag");
+    m_pDS->exec("ALTER TABLE tagnew RENAME TO tag");
   }
 }
 
@@ -5161,21 +5140,21 @@ bool CVideoDatabase::GetTagsNav(const CStdString& strBaseDir, CFileItemList& ite
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    CStdString strSQL = "SELECT %s FROM taglinks ";
+    CStdString strSQL = "SELECT %s FROM tag_link ";
 
     Filter extFilter = filter;
-    extFilter.fields = "tag.idTag, tag.strTag";
-    extFilter.AppendJoin("JOIN tag ON tag.idTag = taglinks.idTag");
+    extFilter.fields = "tag.tag_id, tag.name";
+    extFilter.AppendJoin("JOIN tag ON tag.tag_id = tag_link.tag_id");
 
     if (idContent == (int)VIDEODB_CONTENT_MOVIES)
-      extFilter.AppendJoin("JOIN movieview ON movieview.idMovie = taglinks.idMedia");
+      extFilter.AppendJoin("JOIN movieview ON movieview.idMovie = tag_link.media_id");
 
-    extFilter.AppendWhere(PrepareSQL("taglinks.media_type = '%s'", mediaType.c_str()));
-    extFilter.AppendGroup("taglinks.idTag");
+    extFilter.AppendWhere(PrepareSQL("tag_link.media_type = '%s'", mediaType.c_str()));
+    extFilter.AppendGroup("tag_link.tag_id");
 
     if (countOnly)
     {
-      extFilter.fields = "COUNT(DISTINCT taglinks.idTag)";
+      extFilter.fields = "COUNT(DISTINCT tag_link.tag_id)";
       extFilter.group.clear();
       extFilter.order.clear();
     }
@@ -6510,7 +6489,7 @@ CStdString CVideoDatabase::GetSetById(int id)
 
 CStdString CVideoDatabase::GetTagById(int id)
 {
-  return GetSingleValue("tag", "strTag", PrepareSQL("idTag = %i", id));
+  return GetSingleValue("tag", "name", PrepareSQL("tag_id = %i", id));
 }
 
 CStdString CVideoDatabase::GetPersonById(int id)
@@ -9311,15 +9290,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     option = options.find("tagid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join taglinks on taglinks.idMedia = movieview.idMovie AND taglinks.media_type = 'movie'"));
-      filter.AppendWhere(PrepareSQL("taglinks.idTag = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = movieview.idMovie AND tag_link.media_type = 'movie'"));
+      filter.AppendWhere(PrepareSQL("tag_link.tag_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("tag");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join taglinks on taglinks.idMedia = movieview.idMovie AND taglinks.media_type = 'movie' join tag on tag.idTag = taglinks.idTag"));
-      filter.AppendWhere(PrepareSQL("tag.strTag like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = movieview.idMovie AND tag_link.media_type = 'movie' JOIN tag ON tag.tag_id = tag_link.tag_id"));
+      filter.AppendWhere(PrepareSQL("tag.name like '%s'", option->second.asString().c_str()));
     }
   }
   else if (type == "tvshows")
@@ -9382,15 +9361,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
       option = options.find("tagid");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join taglinks on taglinks.idMedia = tvshowview.idShow AND taglinks.media_type = 'tvshow'"));
-        filter.AppendWhere(PrepareSQL("taglinks.idTag = %i", (int)option->second.asInteger()));
+        filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = tvshowview.idShow AND tag_link.media_type = 'tvshow'"));
+        filter.AppendWhere(PrepareSQL("tag_link.tag_id = %i", (int)option->second.asInteger()));
       }
 
       option = options.find("tag");
       if (option != options.end())
       {
-        filter.AppendJoin(PrepareSQL("join taglinks on taglinks.idMedia = tvshowview.idShow AND taglinks.media_type = 'tvshow' join tag on tag.idTag = taglinks.idTag"));
-        filter.AppendWhere(PrepareSQL("tag.strTag like '%s'", option->second.asString().c_str()));
+        filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = tvshowview.idShow AND tag_link.media_type = 'tvshow' JOIN tag ON tag.tag_id = tag_link.tag_id"));
+        filter.AppendWhere(PrepareSQL("tag.name like '%s'", option->second.asString().c_str()));
       }
     }
     else if (itemType == "seasons")
@@ -9603,15 +9582,15 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
     option = options.find("tagid");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join taglinks on taglinks.idMedia = musicvideoview.idMVideo AND taglinks.media_type = 'musicvideo'"));
-      filter.AppendWhere(PrepareSQL("taglinks.idTag = %i", (int)option->second.asInteger()));
+      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = musicvideoview.idMVideo AND tag_link.media_type = 'musicvideo'"));
+      filter.AppendWhere(PrepareSQL("tag_link.tag_id = %i", (int)option->second.asInteger()));
     }
 
     option = options.find("tag");
     if (option != options.end())
     {
-      filter.AppendJoin(PrepareSQL("join taglinks on taglinks.idMedia = musicvideoview.idMVideo AND taglinks.media_type = 'musicvideo' join tag on tag.idTag = taglinks.idTag"));
-      filter.AppendWhere(PrepareSQL("tag.strTag like '%s'", option->second.asString().c_str()));
+      filter.AppendJoin(PrepareSQL("JOIN tag_link ON tag_link.media_id = musicvideoview.idMVideo AND tag_link.media_type = 'musicvideo' JOIN tag ON tag.tag_id = tag_link.tag_id"));
+      filter.AppendWhere(PrepareSQL("tag.name like '%s'", option->second.asString().c_str()));
     }
   }
   else

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -804,15 +804,15 @@ protected:
   int GetMatchingTvShow(const CVideoInfoTag &show);
 
   // link functions - these two do all the work
-  void AddLinkToActor(const char *table, int actorID, const char *secondField, int secondID, const CStdString &role, int order);
+  void AddLinkToActor(int mediaId, const char *mediaType, int actorId, const CStdString &role, int order);
   void AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
   void RemoveFromLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
   void UpdateLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
 
   void AddActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void UpdateActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
-  void AddCast(int idMedia, const char *table, const char *field, const std::vector<SActorInfo> &cast);
 
+  void AddCast(int mediaId, const char *mediaType, const std::vector<SActorInfo> &cast);
   void AddGenreToMovie(int idMovie, int idGenre);
   void AddGenreToTvShow(int idTvShow, int idGenre);
   void AddGenreToMusicVideo(int idMVideo, int idGenre);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -854,6 +854,8 @@ private:
   virtual void CreateTables();
   virtual void CreateAnalytics();
   virtual void UpdateTables(int version);
+  void CreateLinkIndex(const char *table);
+  void CreateForeignLinkIndex(const char *table, const char *foreignkey);
 
   /*! \brief (Re)Create the generic database views for movies, tvshows,
      episodes and music videos

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -802,8 +802,8 @@ protected:
 
   // link functions - these two do all the work
   void AddLinkToActor(int mediaId, const char *mediaType, int actorId, const CStdString &role, int order);
-  void AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
-  void RemoveFromLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
+  void AddToLinkTable(int mediaId, const std::string& mediaType, const std::string& table, int valueId, const char *foreignKey = NULL);
+  void RemoveFromLinkTable(int mediaId, const std::string& mediaType, const std::string& table, int valueId, const char *foreignKey = NULL);
 
   void AddLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void UpdateLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -825,6 +825,7 @@ protected:
   bool GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const char *type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
   bool GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const char *type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
   void GetCast(int media_id, const std::string &media_type, std::vector<SActorInfo> &cast);
+  void GetTags(int media_id, const std::string &media_type, std::vector<std::string> &tags);
 
   void GetDetailsFromDB(std::auto_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -779,10 +779,7 @@ protected:
   int GetFileId(const CStdString& url);
 
   int AddToTable(const CStdString& table, const CStdString& firstField, const CStdString& secondField, const CStdString& value);
-  int AddGenre(const CStdString& strGenre1);
   int AddActor(const CStdString& strActor, const CStdString& thumbURL, const CStdString &thumb = "");
-  int AddCountry(const CStdString& strCountry);
-  int AddStudio(const CStdString& strStudio1);
 
   int AddTvShow();
   int AddMusicVideo(const CStdString& strFilenameAndPath);
@@ -807,23 +804,13 @@ protected:
   void AddLinkToActor(int mediaId, const char *mediaType, int actorId, const CStdString &role, int order);
   void AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
   void RemoveFromLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
-  void UpdateLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
 
+  void AddLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
+  void UpdateLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void AddActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void UpdateActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
 
   void AddCast(int mediaId, const char *mediaType, const std::vector<SActorInfo> &cast);
-  void AddGenreToMovie(int idMovie, int idGenre);
-  void AddGenreToTvShow(int idTvShow, int idGenre);
-  void AddGenreToMusicVideo(int idMVideo, int idGenre);
-
-  void AddStudioToMovie(int idMovie, int idStudio);
-  void AddStudioToTvShow(int idTvShow, int idStudio);
-  void AddStudioToMusicVideo(int idMVideo, int idStudio);
-
-  void AddCountryToMovie(int idMovie, int idCountry);
-
-  void AddGenreAndDirectorsAndStudios(const CVideoInfoTag& details, std::vector<int>& vecDirectors, std::vector<int>& vecGenres, std::vector<int>& vecStudios);
 
   void DeleteStreamDetails(int idFile);
   CVideoInfoTag GetDetailsByTypeAndId(VIDEODB_CONTENT_TYPE type, int id);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -808,17 +808,10 @@ protected:
   void AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
   void RemoveFromLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID, const char *typeField = NULL, const char *type = NULL);
   void UpdateLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
-  void UpdateActorLinkTable(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
 
+  void AddActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
+  void UpdateActorLinksToItem(int mediaId, const std::string& mediaType, const std::string& field, const std::vector<std::string>& values);
   void AddCast(int idMedia, const char *table, const char *field, const std::vector<SActorInfo> &cast);
-  void AddArtistToMusicVideo(int lMVideo, int idArtist);
-
-  void AddDirectorToMovie(int idMovie, int idDirector);
-  void AddDirectorToTvShow(int idTvShow, int idDirector);
-  void AddDirectorToEpisode(int idEpisode, int idDirector);
-  void AddDirectorToMusicVideo(int lMVideo, int idDirector);
-  void AddWriterToEpisode(int idEpisode, int idWriter);
-  void AddWriterToMovie(int idMovie, int idWriter);
 
   void AddGenreToMovie(int idMovie, int idGenre);
   void AddGenreToTvShow(int idTvShow, int idGenre);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -835,9 +835,9 @@ protected:
   CVideoInfoTag GetDetailsForEpisode(const dbiplus::sql_record* const record, bool getDetails = false);
   CVideoInfoTag GetDetailsForMusicVideo(std::auto_ptr<dbiplus::Dataset> &pDS, bool getDetails = false);
   CVideoInfoTag GetDetailsForMusicVideo(const dbiplus::sql_record* const record, bool getDetails = false);
-  bool GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
+  bool GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const char *type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
   bool GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
-  void GetCast(const CStdString &table, const CStdString &table_id, int type_id, std::vector<SActorInfo> &cast);
+  void GetCast(int media_id, const std::string &media_type, std::vector<SActorInfo> &cast);
 
   void GetDetailsFromDB(std::auto_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -823,7 +823,7 @@ protected:
   CVideoInfoTag GetDetailsForMusicVideo(std::auto_ptr<dbiplus::Dataset> &pDS, bool getDetails = false);
   CVideoInfoTag GetDetailsForMusicVideo(const dbiplus::sql_record* const record, bool getDetails = false);
   bool GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const char *type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
-  bool GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
+  bool GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const char *type, int idContent=-1, const Filter &filter = Filter(), bool countOnly = false);
   void GetCast(int media_id, const std::string &media_type, std::vector<SActorInfo> &cast);
 
   void GetDetailsFromDB(std::auto_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -857,6 +857,9 @@ private:
    */
   int RunQuery(const CStdString &sql);
 
+  void AppendIdFilter(const char* field, const char *table, const char *mediaType, const char *view, const char *viewKey, const CUrlOptions::UrlOptions& options, Filter &filter);
+  void AppendFilter(const char* field, const char *table, const char *mediaType, const char *view, const char *viewKey, const CUrlOptions::UrlOptions& options, Filter &filter);
+
   /*! \brief Determine whether the path is using lookup using folders
    \param path the path to check
    \param shows whether this path is from a tvshow (defaults to false)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1586,7 +1586,7 @@ bool CGUIDialogVideoInfo::GetItemsForTag(const CStdString &strHeading, const std
     if (!showAll)
       videoUrl.AddOption("tagid", idTag);
     else
-      filter.where = videodb.PrepareSQL("%sview.%s NOT IN (SELECT taglinks.idMedia FROM taglinks WHERE taglinks.idTag = %d AND taglinks.media_type = '%s')", type.c_str(), idColumn.c_str(), idTag, type.c_str());
+      filter.where = videodb.PrepareSQL("%sview.%s NOT IN (SELECT tag_link.media_type FROM tag_link WHERE tag_link.tag_id = %d AND tag_link.media_type = '%s')", type.c_str(), idColumn.c_str(), idTag, type.c_str());
   }
 
   CFileItemList listItems;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1586,7 +1586,7 @@ bool CGUIDialogVideoInfo::GetItemsForTag(const CStdString &strHeading, const std
     if (!showAll)
       videoUrl.AddOption("tagid", idTag);
     else
-      filter.where = videodb.PrepareSQL("%sview.%s NOT IN (SELECT tag_link.media_type FROM tag_link WHERE tag_link.tag_id = %d AND tag_link.media_type = '%s')", type.c_str(), idColumn.c_str(), idTag, type.c_str());
+      filter.where = videodb.PrepareSQL("%s_view.%s NOT IN (SELECT tag_link.media_type FROM tag_link WHERE tag_link.tag_id = %d AND tag_link.media_type = '%s')", type.c_str(), idColumn.c_str(), idTag, type.c_str());
   }
 
   CFileItemList listItems;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1059,7 +1059,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
     if (localizedType.empty())
       return true;
 
-    if (!videodb.GetSingleValue("tag", "tag.idTag", videodb.PrepareSQL("tag.strTag = '%s' AND tag.idTag IN (SELECT taglinks.idTag FROM taglinks WHERE taglinks.media_type = '%s')", strTag.c_str(), mediaType.c_str())).empty())
+    if (!videodb.GetSingleValue("tag", "tag.tag_id", videodb.PrepareSQL("tag.name = '%s' AND tag.tag_id IN (SELECT tag_link.tag_id FROM tag_link WHERE tag_link.media_type = '%s')", strTag.c_str(), mediaType.c_str())).empty())
     {
       CStdString strError = StringUtils::Format(g_localizeStrings.Get(20463).c_str(), strTag.c_str());
       CGUIDialogOK::ShowAndGetInput(20462, "", strError, "");


### PR DESCRIPTION
This starts the proposed videodb table cleanup, focusing on the link tables (and their sources).  The format used is:

```
table(table_id INTEGER PRIMARY KEY, name TEXT)
table_link(table_id INTEGER, media_id INTEGER, media_type TEXT)
```

In cases where multiple links are defined on the same table, we use

```
field_link(table_id INTEGER, media_id INTEGER, media_type TEXT)
```

i.e. the first field is named after the table that it is sourced from (it's a foreign key after all).

I've also changed the views to be movie_view for consistency, but have not yet renamed their content.  I'm in two minds as to whether to have them use `movie_view.media_id` or `movie_view.movie_id`.  There'd be a minor saving with the former, but mostly where we have the same routines run on multiple media tables (i.e. in format strings).

I've kept a couple of tables as they are: tvshowlinkpath and movielinktvshow.  The latter could conceivably be a `media_link(media_id, media_type, media_id2, media_type2)` style link table.

There is a LOT of duplication in the existing videodatabase - I've cleaned up some minor stuff, but there's 50 line functions left that do the same thing save one or two minor differences.  No point cleaning them up until we get some idea that this is the direction to go in.
