### PR TITLE
[pvr] sync selected item between pvr windows

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1274,6 +1274,18 @@ bool CGUIEPGGridContainer::OnMouseWheel(char wheel, const CPoint &point)
   return true;
 }
 
+CPVRChannel* CGUIEPGGridContainer::GetChannel(int iIndex)
+{
+  if (iIndex >= 0 && iIndex < m_channelItems.size())
+  {
+    CFileItemPtr fileItem = boost::static_pointer_cast<CFileItem>(m_channelItems[iIndex]);
+    if (fileItem->HasPVRChannelInfoTag())
+      return fileItem->GetPVRChannelInfoTag();
+  }
+  
+  return NULL;
+}
+
 void CGUIEPGGridContainer::SetSelectedChannel(int channelIndex)
 {
   if (channelIndex < 0)

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -25,6 +25,7 @@
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
 #include "guilib/IGUIContainer.h"
+#include "pvr/channels/PVRChannel.h"
 
 namespace EPG
 {
@@ -66,6 +67,7 @@ namespace EPG
     virtual int GetSelectedItem() const;
     const int GetSelectedChannel() { return m_channelCursor + m_channelOffset; }
     void SetSelectedChannel(int channelIndex);
+    PVR::CPVRChannel* GetChannel(int iIndex);
     virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
 
     virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1085,7 +1085,7 @@ int CPVRChannelGroup::GetEPGNow(CFileItemList &results)
 
     CFileItemPtr entry(new CFileItem(epgNow));
     entry->SetLabel2(epgNow.StartAsLocalTime().GetAsLocalizedTime("", false));
-    entry->SetPath(channel->ChannelName());
+    entry->SetPath(channel->Path());
     entry->SetArt("thumb", channel->IconPath());
     results.Add(entry);
   }
@@ -1111,7 +1111,7 @@ int CPVRChannelGroup::GetEPGNext(CFileItemList &results)
 
     CFileItemPtr entry(new CFileItem(epgNow));
     entry->SetLabel2(epgNow.StartAsLocalTime().GetAsLocalizedTime("", false));
-    entry->SetPath(channel->ChannelName());
+    entry->SetPath(channel->Path());
     entry->SetArt("thumb", channel->IconPath());
     results.Add(entry);
   }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -51,6 +51,7 @@ namespace PVR
   {
   public:
     virtual void OnInitWindow(void);
+    virtual void OnDeinitWindow(int nextWindowID);
     virtual bool OnMessage(CGUIMessage& message);
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) { return false; };
@@ -85,6 +86,8 @@ namespace PVR
     virtual void ShowEPGInfo(CFileItem *item);
     virtual void ShowRecordingInfo(CFileItem *item);
     virtual bool UpdateEpgForChannel(CFileItem *item);
+
+    static std::map<bool, std::string> m_selectedItemPath;
 
     CCriticalSection m_critSection;
     bool m_bRadio;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -35,6 +35,7 @@ namespace PVR
     CGUIWindowPVRGuide(bool bRadio);
     virtual ~CGUIWindowPVRGuide(void);
 
+    void OnDeinitWindow(int nextWindowID);
     bool OnMessage(CGUIMessage& message);
     bool OnAction(const CAction &action);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);


### PR DESCRIPTION
This re-adds the functionality to the PVR windows that the current playing item is selected with the alteration that we do it only if no previous selection exists.

@Jalle19 it's not as easy to sync the selected item between channel and guide window because the guide grid control is different from a normal view control.

I also want to discuss the behavior as it differs a little from what we had before.
