### PR TITLE
CHG: Refactor ffmpeg MT support

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -587,11 +587,8 @@
           <control type="spinner" format="integer" />
         </setting>
         <setting id="videoplayer.useframemtdec" type="boolean" parent="videoplayer.decodingmethod" label="13440" help="36423">
-          <dependencies>
-            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">0</dependency>
-          </dependencies>
           <level>2</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.useamcodec" type="boolean" label="13438" help="36422">

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -162,7 +162,12 @@ CDVDVideoCodecFFmpeg::CDVDVideoCodecFFmpeg() : CDVDVideoCodec()
   m_iScreenHeight = 0;
   m_iOrientation = 0;
   m_bSoftware = false;
+#if defined(TARGET_ANDROID) || defined(TARGET_DARWIN_IOS)
+  // If we get here on Android or iOS, it's always software
+  m_isSWCodec = true;
+#else
   m_isSWCodec = false;
+#endif
   m_pHardware = NULL;
   m_iLastKeyframe = 0;
   m_dts = DVD_NOPTS_VALUE;
@@ -237,16 +242,8 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   /* Only allow slice threading, since frame threading is more
    * sensitive to changes in frame sizes, and it causes crashes
    * during HW accell - so we unset it in this case.
-   *
-   * When we detect a pure SW codec and user did not disable SWmultithreading
-   * via advancedsettings.xml we keep the ffmpeg default thread type.
    * */
-  if(m_isSWCodec && !g_advancedSettings.m_videoDisableSWMultithreading)
-  {
-    CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading for swcodec: %d",
-                        m_pCodecContext->thread_type);
-  }
-  else if ((EDECODEMETHOD) CSettings::Get().GetInt("videoplayer.decodingmethod") == VS_DECODEMETHOD_SOFTWARE && CSettings::Get().GetBool("videoplayer.useframemtdec"))
+  if (((EDECODEMETHOD) CSettings::Get().GetInt("videoplayer.decodingmethod") == VS_DECODEMETHOD_SOFTWARE || m_isSWCodec) && CSettings::Get().GetBool("videoplayer.useframemtdec"))
   {
     CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading %d by videoplayer.useframemtdec",
                         m_pCodecContext->thread_type);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -175,7 +175,6 @@ void CAdvancedSettings::Initialize()
   m_mediacodecForceSoftwareRendring = false;
 
   m_videoDefaultLatency = 0.0;
-  m_videoDisableSWMultithreading = false;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -587,7 +586,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetFloat(pElement, "nonlinearstretchratio", m_videoNonLinStretchRatio, 0.01f, 1.0f);
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
-    XMLUtils::GetBoolean(pElement,"disableswmultithreading",m_videoDisableSWMultithreading);
     XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
     XMLUtils::GetBoolean(pElement,"vdpauInvTelecine",m_videoVDPAUtelecine);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -193,7 +193,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_DXVANoDeintProcForProgressive;
     int  m_videoFpsDetect;
     int  m_videoBusyDialogDelay_ms;
-    bool m_videoDisableSWMultithreading;
     StagefrightConfig m_stagefrightConfig;
     bool m_mediacodecForceSoftwareRendring;
 


### PR DESCRIPTION
/cc @fritsch 

This adresses 2 issues:
- On Android (and probably ios/osx, @Memphiz ?), the h/w decoders are in specific codecs, so we only get into ffmpeg as a fallback, with sw decoders only. This addresses the fact that it was impossible to specify mt sw decoding for fallback
- The recently added m_videoDisableSWMultithreading is fundamentally a duplicate of videoplayer.useframemtdec. As videoplayer.useframemtdec is specifically for s/w decoding, use this one and allow modification even if H/W decoding is selected, for the fallback case.
