### PR TITLE
[python] only add modules listed as dependecy to path

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -780,13 +780,10 @@ AddonPtr CAddonMgr::GetAddonFromDescriptor(const cp_plugin_info_t *info,
   if (!info)
     return AddonPtr();
 
-  if (!info->extensions)
+  if (!info->extensions && type.empty())
   { // no extensions, so we need only the dep information
     return AddonPtr(new CAddon(info));
   }
-
-  // FIXME: If we want to support multiple extension points per addon, we'll need to extend this to not just take
-  //        the first extension point (eg use the TYPE information we pass in)
 
   // grab a relevant extension point, ignoring our xbmc.addon.metadata extension point
   for (unsigned int i = 0; i < info->num_extensions; ++i)

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -188,11 +188,14 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
   URIUtils::RemoveSlashAtEnd(scriptDir);
   addPath(scriptDir);
 
-  // add on any addon modules the user has installed
-  ADDON::VECADDONS addons;
-  ADDON::CAddonMgr::Get().GetAddons(ADDON::ADDON_SCRIPT_MODULE, addons);
-  for (unsigned int i = 0; i < addons.size(); ++i)
-    addPath(CSpecialProtocol::TranslatePath(addons[i]->LibPath()));
+  // add addon module dependecies
+  ADDON::ADDONDEPS deps = m_addon.get()->GetDeps();
+  for (ADDON::ADDONDEPS::const_iterator it = deps.begin(); it != deps.end(); ++it)
+  {
+    ADDON::AddonPtr addon;
+    if (ADDON::CAddonMgr::Get().GetAddon(it->first, addon, ADDON::ADDON_SCRIPT_MODULE))
+      addPath(CSpecialProtocol::TranslatePath(addon->LibPath()));
+  }
 
   // we want to use sys.path so it includes site-packages
   // if this fails, default to using Py_GetPath


### PR DESCRIPTION
For the same reason as #5127, this changes the behavior to only add the modules _explicitly_ listed as dependency to the python path.

This should as far as I know not break any existing add-ons that correctly list it's dependencies.
