### PR TITLE
fixed: built-in function SetStereoMode not work

### DIFF
--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -313,18 +313,22 @@ std::string CStereoscopicsManager::NormalizeStereoMode(const std::string &mode)
 
 CAction CStereoscopicsManager::ConvertActionCommandToAction(const std::string &command, const std::string &parameter)
 {
-  if (command == "SetStereoMode")
+  std::string cmd = command;
+  std::string para = parameter;
+  StringUtils::ToLower(cmd);
+  StringUtils::ToLower(para);
+  if (cmd == "setstereomode")
   {
     int actionId = -1;
-    if (parameter == "next")
+    if (para == "next")
       actionId = ACTION_STEREOMODE_NEXT;
-    else if (parameter == "previous")
+    else if (para == "previous")
       actionId = ACTION_STEREOMODE_PREVIOUS;
-    else if (parameter == "toggle")
+    else if (para == "toggle")
       actionId = ACTION_STEREOMODE_TOGGLE;
-    else if (parameter == "select")
+    else if (para == "select")
       actionId = ACTION_STEREOMODE_SELECT;
-    else if (parameter == "tomono")
+    else if (para == "tomono")
       actionId = ACTION_STEREOMODE_TOMONO;
 
     // already have a valid actionID return it
@@ -332,8 +336,8 @@ CAction CStereoscopicsManager::ConvertActionCommandToAction(const std::string &c
       return CAction(actionId);
 
     // still no valid action ID, check if parameter is a supported stereomode
-    if (ConvertStringToGuiStereoMode(parameter) > -1)
-      return CAction(ACTION_STEREOMODE_SET, parameter);
+    if (ConvertStringToGuiStereoMode(para) > -1)
+      return CAction(ACTION_STEREOMODE_SET, para);
   }
   return CAction(ACTION_NONE);
 }


### PR DESCRIPTION
built-in function SetStereoMode not work. because execute string is change to lower case in CBuiltins::Execute, but CStereoscopicsManager::ConvertActionCommandToAction compare it with a not lower case name.
