### PR TITLE
[Fix] Stale metadata/cover art when using airplay audio mirroring

### DIFF
--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -88,6 +88,19 @@ std::map<std::string, std::string> decodeDMAP(const char *buffer, unsigned int s
   return result;
 }
 
+void CAirTunesServer::ResetMetadata()
+{
+  CSingleLock lock(m_metadataLock);
+
+  XFILE::CFile::Delete(TMP_COVERART_PATH);
+  RefreshCoverArt();
+
+  m_metadata[0] = "";
+  m_metadata[1] = "AirPlay";
+  m_metadata[2] = "";
+  RefreshMetadata();
+}
+
 void CAirTunesServer::RefreshMetadata()
 {
   CSingleLock lock(m_metadataLock);
@@ -229,6 +242,11 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
   m_streamStarted = true;
 
   CApplicationMessenger::Get().PlayFile(item);
+
+  // Not all airplay streams will provide metadata (e.g. if using mirroring,
+  // no metadata will be sent).  If there *is* metadata, it will be received
+  // in a later call to audio_set_metadata/audio_set_coverart.
+  ResetMetadata();
 
   return session;//session
 }

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -57,6 +57,7 @@ private:
   void Deinitialize();
   static void RefreshCoverArt();
   static void RefreshMetadata();
+  static void ResetMetadata();
 
   int m_port;
   static DllLibShairplay *m_pLibShairplay;//the lib


### PR DESCRIPTION
This fixes an issue where stale metadata and cover art is displayed when using airplay audio mirroring.  The following repros the issue:
(1) play a track from iTunes to the xbmc Airplay server
(2) stop play and exit iTunes
(3) enable airplay audio mirroring (option-left click on speaker icon in OS X)
(4) play audio from any other application (ex: Spotify, browser).

At this point, XBMC displays the cached track metadata and cover art from the track played in iTunes regardless of what is being streamed via mirroring.

This change clears the cached data at the start of an airplay stream.  If using an airplay source that provides metadata/cover art (like iTunes), shairplay callbacks will set the proper values for these fields after initialization.
