### PR TITLE
[AirTunes] - don't handle the flush callback from shairplay - we handled

### DIFF
--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -263,12 +263,6 @@ void  CAirTunesServer::AudioOutputFunctions::audio_process(void *cls, void *sess
   }
 }
 
-void  CAirTunesServer::AudioOutputFunctions::audio_flush(void *cls, void *session)
-{
-  XFILE::CPipeFile *pipe=(XFILE::CPipeFile *)cls;
-  pipe->Flush();
-}
-
 void  CAirTunesServer::AudioOutputFunctions::audio_destroy(void *cls, void *session)
 {
   XFILE::CPipeFile *pipe=(XFILE::CPipeFile *)cls;
@@ -445,7 +439,6 @@ bool CAirTunesServer::Initialize(const std::string &password)
     ao.audio_set_metadata   = AudioOutputFunctions::audio_set_metadata;
     ao.audio_set_coverart   = AudioOutputFunctions::audio_set_coverart;
     ao.audio_process        = AudioOutputFunctions::audio_process;
-    ao.audio_flush          = AudioOutputFunctions::audio_flush;
     ao.audio_destroy        = AudioOutputFunctions::audio_destroy;
     m_pLibShairplay->EnableDelayedUnload(false);
     m_pRaop = m_pLibShairplay->raop_init(1, &ao, RSA_KEY);//1 - we handle one client at a time max

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -76,7 +76,6 @@ private:
 	    static void  audio_set_metadata(void *cls, void *session, const void *buffer, int buflen);
 	    static void  audio_set_coverart(void *cls, void *session, const void *buffer, int buflen);
       static void  audio_process(void *cls, void *session, const void *buffer, int buflen);
-      static void  audio_flush(void *cls, void *session);
       static void  audio_destroy(void *cls, void *session);
     };
 };


### PR DESCRIPTION
it wrong and it isn't needed for us (actually this even fixes a race
condition).

Reference:

http://forum.xbmc.org/showthread.php?tid=201355

and upstream comment (line notes):

https://github.com/juhovh/shairplay/commit/fda63ad40b874933e2342a1f2f3d6f4b642d12ff
