### PR TITLE
[python] add xbmc.abortEvent

### DIFF
--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.python" version="2.18.0" provider-name="Team-Kodi">
+<addon id="xbmc.python" version="2.19.0" provider-name="Team-Kodi">
   <backwards-compatibility abi="2.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -60,6 +60,12 @@ namespace XBMCAddon
       return false;
     }
 
+    bool Monitor::abortRequested()
+    {
+      XBMC_TRACE;
+      return abortEvent.Signaled();
+    }
+
     Monitor::~Monitor()
     {
       deallocating();

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -19,12 +19,13 @@
  */
 
 #include "Monitor.h"
+#include <math.h>
 
 namespace XBMCAddon
 {
   namespace xbmc
   {
-    Monitor::Monitor()
+    Monitor::Monitor(): abortEvent(true)
     {
       if (languageHook)
       {
@@ -33,8 +34,34 @@ namespace XBMCAddon
       }
     }
 
+    void Monitor::OnAbortRequested()
+    {
+      XBMC_TRACE;
+      abortEvent.Set();
+      invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onAbortRequested));
+    }
+
+    bool Monitor::waitForAbort(double timeout)
+    {
+      XBMC_TRACE;
+      int timeoutMS = ceil(timeout * 1000);
+      XbmcThreads::EndTime endTime(timeoutMS > 0 ? timeoutMS : XbmcThreads::EndTime::InfiniteValue);
+      while (!endTime.IsTimePast())
+      {
+        {
+          DelayedCallGuard dg(languageHook);
+          unsigned int t = std::min(endTime.MillisLeft(), 100u);
+          if (abortEvent.WaitMSec(t))
+            return true;
+        }
+        if (languageHook)
+          languageHook->MakePendingCalls();
+      }
+      return false;
+    }
+
     Monitor::~Monitor()
-    { 
+    {
       deallocating();
       DelayedCallGuard dg(languageHook);
       // we're shutting down so unregister me.

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -175,6 +175,11 @@ namespace XBMCAddon
        */
       bool waitForAbort(double timeout = -1);
 
+      /**
+       * abortRequested() -- Returns True if abort has been requested.
+       */
+      bool abortRequested();
+
       virtual ~Monitor();
     };
   }

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -35,6 +35,7 @@ namespace XBMCAddon
     class Monitor : public AddonCallback
     {
       String Id;
+      CEvent abortEvent;
     public:
       Monitor();
 
@@ -58,10 +59,11 @@ namespace XBMCAddon
       }
       inline void    OnCleanStarted(const String &library) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onCleanStarted,library)); }
       inline void    OnCleanFinished(const String &library) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onCleanFinished,library)); }
-      inline void    OnAbortRequested() { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onAbortRequested)); }
       inline void    OnNotification(const String &sender, const String &method, const String &data) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String,const String,const String>(this,&Monitor::onNotification,sender,method,data)); }
 
       inline const String& GetId() { return Id; }
+
+      void OnAbortRequested();
 #endif
 
       /**
@@ -162,6 +164,16 @@ namespace XBMCAddon
        * Will be called when XBMC receives or sends a notification\n
        */
       virtual void    onNotification(const String sender, const String method, const String data) { XBMC_TRACE; }
+
+      /**
+       * waitForAbort([timeout]) -- Block until abort is requested, or until timeout occurs. If an
+       *                            abort requested have already been made, return immediately.
+       *
+       * Returns True when abort have been requested, False if a timeout is given and the operation times out.
+       *
+       * timeout : [opt] float - timeout in seconds. Default: no timeout.\n
+       */
+      bool waitForAbort(double timeout = -1);
 
       virtual ~Monitor();
     };

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -824,7 +824,7 @@ namespace PythonBindings
    // constants
    PyModule_AddStringConstant(module, (char*)"__author__", (char*)"Team XBMC <http://xbmc.org>");
    PyModule_AddStringConstant(module, (char*)"__date__", (char*)"${new Date().toString()}");
-   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.18.0");
+   PyModule_AddStringConstant(module, (char*)"__version__", (char*)"2.19.0");
    PyModule_AddStringConstant(module, (char*)"__credits__", (char*)"Team XBMC");
    PyModule_AddStringConstant(module, (char*)"__platform__", (char*)"ALL");
 

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -74,6 +74,9 @@ public:
   inline void Reset() { CSingleLock lock(mutex); signaled = false; }
   void Set();
 
+  /** Returns true if Event has been triggered and not reset, false otherwise. */
+  inline bool Signaled() { CSingleLock lock(mutex); return signaled; }
+
   /**
    * This will wait up to 'milliSeconds' milliseconds for the Event
    *  to be triggered. The method will return 'true' if the Event


### PR DESCRIPTION
~~I intend this as a simple replacement of the boolean property. It allows add-ons to use `xbmc.abortEvent.isSet()` instead, and most importantly `xbmc.abortEvent.wait()`instead of periodically checking.~~

Missing:
~~\- Documentation: surely this is currently done by magic, so I'm hoping at least the abortEvent _attribute_ should be documented.~~
- Deprecation of `abortRequested`: need elaborate hacks in initialization script to do this.
