### PR TITLE
Make python PIL module working on droid

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -77,7 +77,7 @@ shared:
 	mkdir -p assets
 	cp -rfp $(PREFIX)/share/@APP_NAME_LC@/* ./assets
 	find `pwd`/assets/ -depth -name ".git" -exec rm -rf {} \;
-	find `pwd`/assets/system/ -name "*.so" -exec rm {} \;
+	find `pwd`/assets/ -name "*.so" -exec rm {} \;
 	find `pwd`/assets/addons/skin.*/media/* -depth -not -iname "Textures.xbt" -exec rm -rf {} \;
 	find `pwd`/assets/system/keymaps/ -depth -name "joystick*.xml" ! -name "joystick.xml" -exec rm {} \;
 	mv -f `pwd`/assets/system/keymaps/joystick.xml.sample `pwd`/assets/system/keymaps/joystick.xml
@@ -118,6 +118,7 @@ libs: $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so
 	cp -fp $(SRCLIBS) xbmc/obj/local/$(CPU)/
 	cp -fp $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so xbmc/obj/local/$(CPU)/
 	find $(PREFIX)/lib/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;
+	find $(PREFIX)/share/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;
 	find $(PREFIX)/lib/@APP_NAME_LC@/system -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;
 	cd xbmc/obj/local/$(CPU)/; find . -name "*.so" -not -name "lib*.so" | sed "s/\.\///" | xargs -I@ mv @ lib@
 	cp -fp xbmc/obj/local/$(CPU)/*.so xbmc/lib/$(CPU)/

--- a/tools/depends/target/python26/Makefile
+++ b/tools/depends/target/python26/Makefile
@@ -32,6 +32,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../Python-no-export-path.patch
 	cd $(PLATFORM); patch -p1 < ../python-osx-environ-fix.patch
 	cd $(PLATFORM); patch -p0 < ../Python-2.6.5-ffi-static.patch
+	cd $(PLATFORM); patch -p0 < ../python-android-binmodule.patch
 ifeq ($(OS),ios)
 	cd $(PLATFORM); patch -p0 < ../Python-2.6.5-urllib.diff
 endif

--- a/tools/depends/target/python26/python-android-binmodule.patch
+++ b/tools/depends/target/python26/python-android-binmodule.patch
@@ -1,0 +1,31 @@
+--- Python/dynload_shlib.c	2014-08-13 15:13:49.879675283 +0200
++++ Python/dynload_shlib.c	2014-08-13 19:03:57.456363680 +0200
+@@ -112,10 +112,6 @@
+         dlopenflags = PyThreadState_GET()->interp->dlopenflags;
+ #endif
+ 
+-	if (Py_VerboseFlag)
+-		PySys_WriteStderr("dlopen(\"%s\", %x);\n", pathname, 
+-				  dlopenflags);
+-
+ #ifdef __VMS
+ 	/* VMS currently don't allow a pathname, use a logical name instead */
+ 	/* Concatenate 'python_module_' and shortname */
+@@ -125,8 +121,17 @@
+ 	PyOS_snprintf(pathbuf, sizeof(pathbuf), "python_module_%-.200s", 
+ 		      shortname);
+ 	pathname = pathbuf;
++#elif defined(ANDROID)
++	/* Android does not allow a pathname and wants lib*.so */
++	PyOS_snprintf(pathbuf, sizeof(pathbuf), "lib%-.200s.so", 
++		      shortname);
++	pathname = pathbuf;
+ #endif
+ 
++	if (Py_VerboseFlag)
++		PySys_WriteStderr("dlopen(\"%s\", %x);\n", pathname, 
++				  dlopenflags);
++
+ 	handle = dlopen(pathname, dlopenflags);
+ 
+ 	if (handle == NULL) {

--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -2,13 +2,20 @@ include ../../Makefile.include
 DEPS= ../../Makefile.include Makefile Imaging-1.1.7-access.patch \
       Imaging-1.1.7-crosscompiling-0.1.patch Imaging-1.1.7-setuptools-0.1.patch
 
+VERSION.TXT := $(XBMCROOT)/version.txt
+APP_NAME=$(shell awk '/APP_NAME/ {print tolower($$2)}' $(VERSION.TXT))
+
 # lib name, version
 LIBNAME=Imaging
 VERSION=1.1.7
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
+ifeq ($(OS),android)
+CROSSFLAGS=PYTHONXCPREFIX="$(PREFIX)" LDFLAGS="$(LDFLAGS) -L$(PREFIX)/lib/dummy-lib$(APP_NAME)/ -l$(APP_NAME) -lm"
+else
 CROSSFLAGS=PYTHONXCPREFIX="$(PREFIX)" LDFLAGS="$(LDFLAGS)"
+endif
 
 LIBDYLIB=$(PLATFORM)/dist/PIL-$(VERSION)-py2.6-$(OS)-$(CPU).egg
 
@@ -33,9 +40,8 @@ $(LIBDYLIB): $(PLATFORM)
 	cd $(PLATFORM); $(CROSSFLAGS) $(NATIVEPREFIX)/bin/python setup.py build -x bdist_egg --plat-name $(OS)-$(CPU)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	mkdir -p $(PREFIX)/lib/python2.6/site-packages/PIL
-	unzip -oq $(LIBDYLIB) -d $(PREFIX)/lib/python2.6/site-packages/PIL/
-	echo 'PIL' > $(PREFIX)/lib/python2.6/site-packages/PIL.pth
+	mkdir -p $(PREFIX)/share/$(APP_NAME)/addons/script.module.pil/lib/PIL/
+	unzip -oq $(LIBDYLIB) -d $(PREFIX)/share/$(APP_NAME)/addons/script.module.pil/lib/PIL/
 	touch $@
 
 clean:

--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -37,17 +37,18 @@
         "import " MODULE "\n" \
         "xbmc.abortRequested = False\n" \
         "class xbmcout:\n" \
-        "\tdef __init__(self, loglevel=" MODULE ".LOGNOTICE):\n" \
-        "\t\tself.ll=loglevel\n" \
-        "\tdef write(self, data):\n" \
-        "\t\t" MODULE ".log(data,self.ll)\n" \
-        "\tdef close(self):\n" \
-        "\t\t" MODULE ".log('.')\n" \
-        "\tdef flush(self):\n" \
-        "\t\t" MODULE ".log('.')\n" \
+        "  def __init__(self, loglevel=" MODULE ".LOGNOTICE):\n" \
+        "    self.ll=loglevel\n" \
+        "  def write(self, data):\n" \
+        "    " MODULE ".log(data,self.ll)\n" \
+        "  def close(self):\n" \
+        "    " MODULE ".log('.')\n" \
+        "  def flush(self):\n" \
+        "    " MODULE ".log('.')\n" \
         "import sys\n" \
         "sys.stdout = xbmcout()\n" \
-        "sys.stderr = xbmcout(" MODULE ".LOGERROR)\n"
+        "sys.stderr = xbmcout(" MODULE ".LOGERROR)\n" \
+        ""
 
 #define RUNSCRIPT_OVERRIDE_HACK \
         "" \
@@ -70,15 +71,40 @@
         "os.chdir           = chdir_xbmc\n" \
         ""
 
+#define RUNSCRIPT_SETUPTOOLS_HACK \
+  "" \
+  "import imp,sys\n" \
+  "pkg_resources_code = \\\n" \
+  "\"\"\"\n" \
+  "def resource_filename(__name__,__path__):\n" \
+  "  return __path__\n" \
+  "\"\"\"\n" \
+  "pkg_resources = imp.new_module('pkg_resources')\n" \
+  "exec pkg_resources_code in pkg_resources.__dict__\n" \
+  "sys.modules['pkg_resources'] = pkg_resources\n" \
+  ""
+
 #define RUNSCRIPT_POSTSCRIPT \
         "print '-->Python Interpreter Initialized<--'\n" \
         ""
+
+#if defined(TARGET_ANDROID)
+
+#define RUNSCRIPT_BWCOMPATIBLE \
+  RUNSCRIPT_PRAMBLE RUNSCRIPT_OVERRIDE_HACK RUNSCRIPT_SETUPTOOLS_HACK RUNSCRIPT_POSTSCRIPT
+
+#define RUNSCRIPT_COMPLIANT \
+  RUNSCRIPT_PRAMBLE RUNSCRIPT_SETUPTOOLS_HACK RUNSCRIPT_POSTSCRIPT
+
+#else
 
 #define RUNSCRIPT_BWCOMPATIBLE \
   RUNSCRIPT_PRAMBLE RUNSCRIPT_OVERRIDE_HACK RUNSCRIPT_POSTSCRIPT
 
 #define RUNSCRIPT_COMPLIANT \
   RUNSCRIPT_PRAMBLE RUNSCRIPT_POSTSCRIPT
+
+#endif
 
 namespace PythonBindings {
   void initModule_xbmcgui(void);


### PR DESCRIPTION
This is a major PITA ;)

~~The big no-no is that we have to link the PIL module to libxbmc.so, because python is static.~~
I cannot get the module libs to find the python symbols unless I link back.
I _think_ it is due to the fact that libxbmc.so is itself dlopened with RTLD_LOCAL by Android, so the python symbols would not be globally visible unless we explicitly link back, but that's obscure to me.

/cc @jmarshallnz @jimfcarroll @davilla @t-nelson

Notes:
- No setuptools on droid, so I have to stub it because the module libs are wrapped, and the wrapper uses it.
- I just cannot get the droid python to include site-packages in its path, so I just copy the .py\* to the addon dir, win32 style.
