### PR TITLE
AESink: AML: If passthrough set latency to 0.00

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -294,7 +294,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
 double CAESinkAUDIOTRACK::GetLatency()
 {
 #if defined(HAS_LIBAMCODEC)
-  if (aml_present())
+  if (aml_present() && !m_passthrough)
     return 0.250;
 #endif
   return 0.0;


### PR DESCRIPTION
If using passthrough, we don't need to pad the audio latency. Returning 0.00 ensures playback is in sync with audio.
