### PR TITLE
videodb: Add column name on GROUP query otherwise sub query returns no r...

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4751,7 +4751,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
         }
       }
       // cleanup duplicate seasons
-      m_pDS->exec("DELETE FROM seasons WHERE idSeason NOT IN (SELECT idSeason FROM (SELECT min(idSeason) FROM seasons GROUP BY idShow,season) AS sub)");
+      m_pDS->exec("DELETE FROM seasons WHERE idSeason NOT IN (SELECT idSeason FROM (SELECT min(idSeason) as idSeason FROM seasons GROUP BY idShow,season) AS sub)");
     }
   }
   if (iVersion < 84)


### PR DESCRIPTION
...ows

Actually, it's not that the query named `sub` returns no rows - in fact it fails with the following error:

```
Error Code: 1054. Unknown column 'idSeason' in 'field list'
```

however this error is silent when it occurs as a sub-query(!).

Fix has been tested only with MySQL.
