### PR TITLE
RefreshContainer(id) built-in function

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -460,6 +460,12 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
       }
       return true;
     }
+    else if (message.GetMessage() == GUI_MSG_REFRESH_CONTAINER)
+    {
+      Reset();
+      m_listProvider->Reset(true);
+      UpdateListProvider(true);
+    }
   }
   return CGUIControl::OnMessage(message);
 }

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -156,6 +156,11 @@
 
 #define GUI_MSG_GET_FILENAME   48
 
+/*
+ \brief A request to refresh a container's list content
+ */
+#define GUI_MSG_REFRESH_CONTAINER 49
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -184,6 +184,7 @@ const BUILT_IN commands[] = {
   { "ExportLibrary",              true,   "Export the video/music library" },
   { "PageDown",                   true,   "Send a page down event to the pagecontrol with given id" },
   { "PageUp",                     true,   "Send a page up event to the pagecontrol with given id" },
+  { "RefreshContainer",           true,   "Refresh list content of a container with given id"},
   { "Container.Refresh",          false,  "Refresh current listing" },
   { "Container.Update",           false,  "Update current listing. Send Container.Update(path,replace) to reset the path history" },
   { "Container.NextViewMode",     false,  "Move to the next view type (and refresh the listing)" },
@@ -1522,6 +1523,11 @@ int CBuiltins::Execute(const std::string& execString)
   else if (execute == "control.move" && params.size() > 1)
   {
     CGUIMessage message(GUI_MSG_MOVE_OFFSET, g_windowManager.GetFocusedWindow(), atoi(params[0].c_str()), atoi(params[1].c_str()));
+    g_windowManager.SendMessage(message);
+  }
+  else if (execute == "refreshcontainer")
+  {
+    CGUIMessage message(GUI_MSG_REFRESH_CONTAINER, g_windowManager.GetActiveWindow(), strtol(parameter.c_str(), NULL, 10));
     g_windowManager.SendMessage(message);
   }
   else if (execute == "container.refresh")


### PR DESCRIPTION
This adds the possibility to refresh a container with dynamic list content manually.

I wanted to use the existing Container.Refresh function but since it seems to take an optional parameter, I had to introduce a new function.
