### PR TITLE
LINUX: Fix compile error.

### DIFF
--- a/xbmc/network/linux/NetworkLinux.h
+++ b/xbmc/network/linux/NetworkLinux.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdio>
 #include "network/Network.h"
 
 class CNetworkLinux;


### PR DESCRIPTION
Removal of utils/StdString.h in 6c3a7b62 lost an indirect include of
stdio.h which defined FILE for this header.

I observed this from a clean build on Ubuntu 14.04.  Presumably jenkins hasn't been failing for the last month and a half, though.  So I'm not sure what build env differences brought this on.  The fix is innocuous enough.
