### PR TITLE
[bluray] Add a setting for preferred bd playback 

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -6746,7 +6746,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14087"
-msgid "DVDs"
+msgid "Discs"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -6818,7 +6818,25 @@ msgctxt "#14101"
 msgid "Acceleration"
 msgstr ""
 
-#empty strings from id 14102 to 15011
+#. Name of a setting for Blu-ray playback mode
+#: system/settings/settings.xml
+msgctxt "#14102"
+msgid "Blu-ray playback mode"
+msgstr ""
+
+#. Playback mode option for Blu-ray
+#: system/settings/settings.xml
+msgctxt "#14103"
+msgid "Play main movie"
+msgstr ""
+
+#. Playback mode option for Blu-ray
+#: system/settings/settings.xml
+msgctxt "#14104"
+msgid "Show simplified menu"
+msgstr ""
+
+#empty strings from id 14105 to 15011
 
 #: xbmc/video/VideoDatabase.cpp
 msgctxt "#15012"
@@ -12530,9 +12548,11 @@ msgctxt "#25002"
 msgid "Select from all titles ..."
 msgstr ""
 
+#. A Blu-ray playback mode and a option in the simplified Blu-ray menu
 #: xbmc/filesystem/BlurayDirectory.cpp
+#: system/settings/settings.xml
 msgctxt "#25003"
-msgid "Show Blu-ray menus"
+msgid "Show Blu-ray menu"
 msgstr ""
 
 #: xbmc/filesystem/BlurayDirectory.cpp
@@ -15892,4 +15912,10 @@ msgstr ""
 #: system/settings/rbp.xml
 msgctxt "#37030"
 msgid "Unlimited"
+msgstr ""
+
+#. Description of setting #14102 Settings -> Video -> Discs -> Blu-ray playback mode
+#: system/settings/settings.xml
+msgctxt "#37031"
+msgid "Specifies how Blu-rays should be opened/played back. Disc menus are not fully supported yet and may cause problems."
 msgstr ""

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -939,6 +939,7 @@
     <ClInclude Include="..\..\xbmc\settings\dialogs\GUIDialogSettingsBase.h" />
     <ClInclude Include="..\..\xbmc\settings\dialogs\GUIDialogSettingsManagerBase.h" />
     <ClInclude Include="..\..\xbmc\settings\dialogs\GUIDialogSettingsManualBase.h" />
+    <ClInclude Include="..\..\xbmc\settings\DiscSettings.h" />
     <ClInclude Include="..\..\xbmc\settings\DisplaySettings.h" />
     <ClInclude Include="..\..\xbmc\settings\lib\ISetting.h" />
     <ClInclude Include="..\..\xbmc\settings\lib\ISettingCallback.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -6004,6 +6004,9 @@
     <ClInclude Include="..\..\xbmc\utils\MarkWatchedJob.h">
       <Filter>utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\settings\DiscSettings.h">
+      <Filter>settings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1026,6 +1026,20 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="2">
+        <setting id="disc.playback" type="integer" label="14102" help="37031">
+          <level>1</level>
+          <default>0</default> <!-- default -->
+          <constraints>
+            <options>
+              <option label="14104">0</option> <!-- show simplified menu -->
+              <option label="25003">1</option> <!-- show disc menu -->
+              <option label="14103">2</option> <!-- play main movie -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+      </group>
     </category>
     <category id="scrapers" label="0" help="36197">
       <visible>false</visible>

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -41,6 +41,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/windows/GUIWindowVideoBase.h"
 #ifdef HAS_CDDA_RIPPER
 #include "cdrip/CDDARipper.h"
 #endif
@@ -207,6 +208,8 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
 
           g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
           g_playlistPlayer.SetShuffle (PLAYLIST_VIDEO, false);
+          if (!CGUIWindowVideoBase::ShowPlaySelection(item))
+            return false;
           g_playlistPlayer.Add(PLAYLIST_VIDEO, item);
           g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
           g_playlistPlayer.Play(0);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -944,7 +944,7 @@ bool CFileItem::IsDVDFile(bool bVobs /*= true*/, bool bIfos /*= true*/) const
 bool CFileItem::IsBDFile() const
 {
   std::string strFileName = URIUtils::GetFileName(m_strPath);
-  return (StringUtils::EqualsNoCase(strFileName, "index.bdmv"));
+  return (StringUtils::EqualsNoCase(strFileName, "index.bdmv") || StringUtils::EqualsNoCase(strFileName, "MovieObject.bdmv"));
 }
 
 bool CFileItem::IsRAR() const

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -37,6 +37,7 @@
 #include "utils/StringUtils.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/LocalizeStrings.h"
+#include "settings/DiscSettings.h"
 
 #define LIBBLURAY_BYTESEEK 0
 
@@ -349,17 +350,19 @@ bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content
     return false;
   }
 
-  if(StringUtils::EqualsNoCase(filename, "index.bdmv"))
-  {
-    m_navmode = false;
-    m_title = GetTitleLongest();
-  }
-  else if(URIUtils::HasExtension(filename, ".mpls"))
+  int mode = CSettings::Get().GetInt("disc.playback");
+
+  if (URIUtils::HasExtension(filename, ".mpls"))
   {
     m_navmode = false;
     m_title = GetTitleFile(filename);
   }
-  else if(StringUtils::EqualsNoCase(filename, "MovieObject.bdmv"))
+  else if (mode == BD_PLAYBACK_MAIN_TITLE)
+  {
+    m_navmode = false;
+    m_title = GetTitleLongest();
+  }
+  else
   {
     m_navmode = true;
     if (m_navmode && !disc_info->first_play_supported) {
@@ -373,11 +376,6 @@ bool CDVDInputStreamBluray::Open(const char* strFile, const std::string& content
 
     if(!m_navmode)
       m_title = GetTitleLongest();
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - unsupported bluray file selected %s", strPath.c_str());
-    return false;
   }
 
   if(m_navmode)

--- a/xbmc/settings/DiscSettings.h
+++ b/xbmc/settings/DiscSettings.h
@@ -1,0 +1,30 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2014 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+/**
+* Playback settings
+*/
+enum BDPlaybackMode
+{
+  BD_PLAYBACK_SIMPLE_MENU = 0,
+  BD_PLAYBACK_DISC_MENU,
+  BD_PLAYBACK_MAIN_TITLE,
+};

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -779,6 +779,11 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     if (!mediapath.empty())
     {
       CFileItemPtr item(new CFileItem(mediapath, false));
+      if (StringUtils::EndsWithNoCase(mediapath, "index.bdmv"))
+      {
+        if (!ShowPlaySelection(item))
+          return;
+      }
       queuedItems.Add(item);
       return;
     }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -76,6 +76,7 @@
 #include "GUIInfoManager.h"
 #include "utils/GroupUtils.h"
 #include "filesystem/File.h"
+#include "settings/DiscSettings.h"
 
 using namespace std;
 using namespace XFILE;
@@ -1088,13 +1089,16 @@ bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item)
   if (item->m_lStartOffset)
     return true;
 
+  if (CSettings::Get().GetInt("disc.playback") != BD_PLAYBACK_SIMPLE_MENU)
+    return true;
+
   CStdString path;
   if (item->IsVideoDb())
     path = item->GetVideoInfoTag()->m_strFileNameAndPath;
   else
     path = item->GetPath();
 
-  if (URIUtils::GetFileName(path) == "index.bdmv")
+  if (item->IsBDFile())
   {
     CStdString root = URIUtils::GetParentPath(path);
     URIUtils::RemoveSlashAtEnd(root);
@@ -1106,7 +1110,7 @@ bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item)
     }
   }
 
-  if (URIUtils::HasExtension(path, ".iso|.img"))
+  if (item->IsDiscImage())
   {
     CURL url2("udf://");
     url2.SetHostName(item->GetPath());


### PR DESCRIPTION
The options are

~~\* default : current situation: index.bdmv ==> main title, MovieObject.bdmv ==> simplified menu~~
- "play main movie"
- "show disc menu"
- "show simplified menu"

The default option could be dropped.

Furthermore bluray directories are "opend/played" the same way as discs/images (but via context menu)
thx @da-anda and @Voyager1 for the help!
