### PR TITLE
smartplaylists: fix generated SQL query for multi-value rules with a negated parameter (fixes #15313)

### DIFF
--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -370,8 +370,13 @@ std::string CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const std::s
   {
     std::string query = '(' + FormatWhereClause(negate, operatorString, *it, db, strType) + ')';
 
-    if (it+1 != m_parameter.end())
-      query += " OR ";
+    if (it + 1 != m_parameter.end())
+    {
+      if (negate.empty())
+        query += " OR ";
+      else
+        query += " AND ";
+    }
 
     wholeQuery += query;
   }


### PR DESCRIPTION
This fixes the problem described in http://trac.xbmc.org/ticket/15313. When a user defines a smartplaylist rule with multiple values and uses a negated operator like "does not contain" or "does not equal" the resulting SQL query doesn't follow De Morgan's laws and produces something like

```
<field> does not contain <value1> or <field> does not contain <value2>
```

but it should be

```
<field> does not contain <value1> and <field> does not contain <value2>
```

i.e. it needs to use an "AND" operator instead of an "OR" operator.
