### PR TITLE
Add linebreak between cpu and videoclock info - fixes trac#15389

### DIFF
--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -368,7 +368,7 @@
 				<left>0</left>
 				<top>0</top>
 				<width>1280</width>
-				<height>140</height>
+				<height>155</height>
 				<texture>black-back.png</texture>
 			</control>
 			<control type="label" id="10">
@@ -398,7 +398,7 @@
 				<left>50</left>
 				<top>100</top>
 				<width>1180</width>
-				<height>30</height>
+				<height>45</height>
 				<align>left</align>
 				<aligny>center</aligny>
 				<font>font12</font>

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -601,7 +601,7 @@ void CGUIWindowFullScreen::FrameMove()
                                        , clockspeed - 100.0
                                        , g_renderManager.GetVSyncState().c_str());
 
-      strGeneralFPS = StringUtils::Format("%s\nW( fps:%02.2f %s ) %s"
+      strGeneralFPS = StringUtils::Format("%s\nW( fps:%02.2f %s )\n%s"
                                           , strGeneral.c_str()
                                           , g_infoManager.GetFPS()
                                           , strCores.c_str(), strClock.c_str() );


### PR DESCRIPTION
the video reference clock info was appended to the fps/cpu info line.
on systems with many cores, the label became too long to fit on the screen.

fixes: http://trac.xbmc.org/ticket/15389
