### PR TITLE
[omxplayer] Don't flush queued data on general reset

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -405,7 +405,6 @@ void OMXPlayerAudio::Process()
       CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::GENERAL_RESET");
       if (m_pAudioCodec)
         m_pAudioCodec->Reset();
-      m_omxAudio.Flush();
       m_started = false;
       m_audioClock = DVD_NOPTS_VALUE;
     }

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -391,7 +391,6 @@ void OMXPlayerVideo::Process()
     else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
       CLog::Log(LOGDEBUG, "COMXPlayerVideo - CDVDMsg::GENERAL_RESET");
-      m_omxVideo.Reset();
       m_started = false;
       m_nextOverlay = DVD_NOPTS_VALUE;
       m_iCurrentPts = DVD_NOPTS_VALUE;


### PR DESCRIPTION
We were flushing the queue of data to gpu (which can be a number of seconds worth) on a general reset.
However this is generated on inoccuous events like a chapter change in dvd playback.

This results in a few seconds loss of audio, and a temporary audio/video sync error
