### PR TITLE
[atv2/packaging] - fix cp error when installing on old ios4.2 versions

### DIFF
--- a/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh
+++ b/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh
@@ -80,6 +80,7 @@ chmod +x $DIRNAME/$PACKAGE/DEBIAN/prerm
 echo "#!/bin/sh"                                  >  $DIRNAME/$PACKAGE/DEBIAN/postinst
 echo "chown -R mobile:mobile /Applications/XBMC.frappliance" >> $DIRNAME/$PACKAGE/DEBIAN/postinst
 echo "cp /Applications/XBMC.frappliance/AppIcon.png /Applications/AppleTV.app/com.apple.frontrow.appliance.xbmc\@720p.png" >> $DIRNAME/$PACKAGE/DEBIAN/postinst
+echo "mkdir -p /private/var/mobile/Library/Caches/AppleTV/MainMenu/" >> $DIRNAME/$PACKAGE/DEBIAN/postinst
 echo "cp /Applications/XBMC.frappliance/AppIcon.png /private/var/mobile/Library/Caches/AppleTV/MainMenu/com.apple.frontrow.appliance.xbmc@720.png" >> $DIRNAME/$PACKAGE/DEBIAN/postinst
 echo "cp /Applications/XBMC.frappliance/AppIcon.png /Applications/XBMC.frappliance/TopRowIcon.png" >> $DIRNAME/$PACKAGE/DEBIAN/postinst
 echo "if [ \"\`uname -r\`\" = \"10.3.1\" ]; then" >> $DIRNAME/$PACKAGE/DEBIAN/postinst


### PR DESCRIPTION
This PR is against Gotham.

thx @amet for reporting...
