### PR TITLE
[UX] keymap fixes - don't overload pause action with something else

### DIFF
--- a/system/keymaps/appcommand.xml
+++ b/system/keymaps/appcommand.xml
@@ -15,7 +15,7 @@
       <next_track>SkipNext</next_track>
       <prev_track>SkipPrevious</prev_track>
       <stop>Stop</stop>
-      <play_pause>Play</play_pause>
+      <play_pause>PlayPause</play_pause>
       <launch_mail/>
       <launch_media_select>XBMC.ActivateWindow(MyMusic)</launch_media_select>
       <launch_app1>ActivateWindow(MyPrograms)</launch_app1>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -118,7 +118,7 @@
       <next_track>SkipNext</next_track>
       <prev_track>SkipPrevious</prev_track>
       <stop>Stop</stop>
-      <play_pause>Pause</play_pause>
+      <play_pause>PlayPause</play_pause>
       <fastforward>FastForward</fastforward>
       <rewind>Rewind</rewind>
       <record/>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -216,7 +216,7 @@
   </MyFiles>
   <MyMusicPlaylist>
     <keyboard>
-      <space>Back</space>
+      <n>Back</n>
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
@@ -231,14 +231,14 @@
   </MyMusicPlaylistEditor>
   <MyMusicFiles>
     <keyboard>
-      <space>Playlist</space>
+      <n>Playlist</n>
       <q>Queue</q>
       <delete>Delete</delete>
     </keyboard>
   </MyMusicFiles>
   <MyMusicLibrary>
     <keyboard>
-      <space>Playlist</space>
+      <n>Playlist</n>
       <q>Queue</q>
     </keyboard>
   </MyMusicLibrary>
@@ -448,20 +448,20 @@
   <MyVideoLibrary>
     <keyboard>
       <delete>Delete</delete>
-      <space>Playlist</space>
+      <n>Playlist</n>
       <w>ToggleWatched</w>
     </keyboard>
   </MyVideoLibrary>
   <MyVideoFiles>
     <keyboard>
-      <space>Playlist</space>
+      <n>Playlist</n>
       <q>Queue</q>
       <w>ToggleWatched</w>
     </keyboard>
   </MyVideoFiles>
   <MyVideoPlaylist>
     <keyboard>
-      <space>Back</space>
+      <n>Back</n>
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>


### PR DESCRIPTION
With current keymap, the `<space>` key is the default for pausing music and videos. But, if something is playing and you're in a music/video window (except fullscreen), then `<space>` is suddenly triggering the playlist and you have NO WAY to pause the currently playing item, because there is no fallback mapping for this.
Also, in other places switching to the playlist is done by pressing the `<n>` key. Having two ways to access the playlists + not being able to pause things anymore I suggest to change the keymaps so that playlists will always be triggered by pressing `<n>`, which also fixes the issue that you couldn't pause playing media anymore.

The second commit is simply triggering the PlayPause action for the `<play_pause>` key (was only Pause before)
