### PR TITLE
[UX] consistent playback behavior for music and video

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -207,9 +207,19 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         {
           return OnInfo(iItem);
         }
-        else if (iAction == ACTION_PLAYER_PLAY && !g_application.m_pPlayer->IsPlayingVideo())
+        else if (iAction == ACTION_PLAYER_PLAY)
         {
-          return OnResumeItem(iItem);
+          // if playback is paused or playback speed != 1, return
+          if (g_application.m_pPlayer->IsPlayingVideo())
+          {
+            if (g_application.m_pPlayer->IsPausedPlayback())
+              return false;
+            if (g_application.m_pPlayer->GetPlaySpeed() != 1)
+              return false;
+          }
+
+          // not playing video, or playback speed == 1
+          return OnResumeItem(iItem);          
         }
         else if (iAction == ACTION_DELETE_ITEM)
         {


### PR DESCRIPTION
currently the "play" action is handled differently in video and music related windows. This PR is applying the music behavior to videos as well. This is:
- pressing play while nothing is playing -> play selected item
- pressing play while seeking or paused -> continue playback
- (new) press play while something is playing -> play selected item

The PlayPause action is not altered in any way. So pressing PlayPause while something is playing will ofc pause. IMO requires #5244 to go in as well, so that you're able to actually pause videos again which would otherwise be not possible anymore (like it's currently the case in music section - wtf).
