### PR TITLE
[dvdplayer] Allow UpdateCorrection to handle asynchronous audio and video jumping

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -77,6 +77,7 @@ public:
   const int        player;
   // stuff to handle starting after seek
   double   startpts;
+  double   correction;
 
   CCurrentStream(StreamType t, int i)
     : type(t)
@@ -98,6 +99,7 @@ public:
     inited = false;
     started = false;
     startpts  = DVD_NOPTS_VALUE;
+    correction = 0.0;
   }
 
   double dts_end()


### PR DESCRIPTION
This is sequence of timestamps (before correction) from The Grand Budapest Hotel chapter 3.

```
12:07:04 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95502.94 pts:  95502.94 correction:      0.00 size:   46475
12:07:04 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:  95502.80 pts:  95502.80 correction:      0.00 size:    1792
12:07:04 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95502.98 pts:  95502.98 correction:      0.00 size:   47057
12:07:04 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.12 pts:     59.12 correction:      0.00 size:    1792
12:07:04 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.12 pts:     59.12 correction: -95443.72 size:    1792
12:07:04 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95503.03 pts:      0.00 correction: -95443.72 size:   60924
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.15 pts:     59.15 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.18 pts:     59.18 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95503.08 pts:  95503.08 correction: -95443.72 size:   46031
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.21 pts:     59.21 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95503.11 pts:  95503.11 correction: -95443.72 size:   43036
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.25 pts:     59.25 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95503.14 pts:      0.00 correction: -95443.72 size:   59193
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.28 pts:     59.28 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.31 pts:     59.31 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:2 dts:     59.49 pts:     59.49 correction: -95443.72 size:    4868
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.34 pts:     59.34 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.37 pts:     59.37 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95503.19 pts:  95503.19 correction: -95443.72 size:   42475
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.41 pts:     59.41 correction: -95443.72 size:    1792
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:     59.53 pts:     59.56 correction: -95443.72 size:   49850
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:0 dts:  95503.24 pts:  95503.28 correction: -95443.72 size:   49850
12:07:08 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.44 pts:     59.44 correction:-190887.44 size:    1792
12:07:13 T:2730484832   DEBUG: CDVDPlayer::UpdateCorrection - stream:1 dts:     59.47 pts:     59.47 correction:-190887.44 size:    1792
```

Note that audio and video jump at different times.

At the end of this correction should be -95443.72, but it actually jumps twice to double that.

The timestamps arriving at PlayerVideo are not continuous, but jump from 95443 to 190887.

This patch chooses to wait until audio and video have both jumped, and while only one has jumped, it gets timestamps of DVD_NOPTS_VALUE.

This fixes the problem on my dvd, and appears to also fix this issue:
http://forum.xbmc.org/showthread.php?tid=201944
