### PR TITLE
[added] Fallback to /proc/cpuinfo...

### DIFF
--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -110,6 +110,7 @@ private:
   FILE* m_fProcStat;
   FILE* m_fProcTemperature;
   FILE* m_fCPUFreq;
+  bool m_cpuInfoForFreq;
 #elif defined(TARGET_WINDOWS)
   PDH_HQUERY m_cpuQueryFreq;
   PDH_HQUERY m_cpuQueryLoad;


### PR DESCRIPTION
To grab cpu frequency if sysfs is not supported

This is for Atom cpus which atm show at 0.00Mhz in sysinfo since they dont support the current method.

Thank you @notspiff for this fix.

Before and after screenshot (tested before pr'ing)

![capture](https://cloud.githubusercontent.com/assets/3521959/3966148/d0b493e4-279f-11e4-87b3-9ed5b719f1b1.JPG)
