### PR TITLE
[added] Support for screenshot on some mce remotes

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -59,6 +59,7 @@
 		<yellow>Yellow</yellow>
 		<blue>Blue</blue>
 		<teletext>Teletext</teletext>
+		<print>Print</print>
 
 		<!-- new kernel-based lirc button names -->
 		<eject>KEY_EJECTCD</eject>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -88,6 +88,7 @@
       <seven>JumpSMS7</seven>
       <eight>JumpSMS8</eight>
       <nine>JumpSMS9</nine>
+      <print>Screenshot</print>
     </remote>
   </global>
   <Home>

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1330,6 +1330,7 @@ uint32_t CButtonTranslator::TranslateRemoteString(const char *szButton)
   else if (strButton == "subtitle") buttonCode = XINPUT_IR_REMOTE_SUBTITLE;
   else if (strButton == "language") buttonCode = XINPUT_IR_REMOTE_LANGUAGE;
   else if (strButton == "eject") buttonCode = XINPUT_IR_REMOTE_EJECT;
+  else if (strButton == "print") buttonCode = XINPUT_IR_REMOTE_PRINT;
   else CLog::Log(LOGERROR, "Remote Translator: Can't find button %s", strButton.c_str());
   return buttonCode;
 }

--- a/xbmc/input/XBIRRemote.h
+++ b/xbmc/input/XBIRRemote.h
@@ -95,6 +95,8 @@
 
 #define XINPUT_IR_REMOTE_EJECT          235
 
+#define XINPUT_IR_REMOTE_PRINT          240
+
 // Reserved 256 -> ...
 // Key.h
 // KEY_BUTTON_*


### PR DESCRIPTION
Add support print -> screenshot in this example.

Some MCE remotes have such keys as print, eject, slideshow, aspect etc.

e.g http://h10025.www1.hp.com/ewfrf/wc/document?cc=uk&lc=en&docname=c00844678
