### PR TITLE
[pvr] apply the view state handling on a per window basis

### DIFF
--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -35,12 +35,12 @@ CGUIViewStateWindowPVRChannels::CGUIViewStateWindowPVRChannels(const int windowI
   // Default sorting
   SetSortMethod(SortByChannelNumber);
 
-  LoadViewState(items.GetPath(), m_windowId);
+  LoadViewState("pvr://channels/", m_windowId);
 }
 
 void CGUIViewStateWindowPVRChannels::SaveViewState(void)
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::Get().Get("pvrchannels"));
+  SaveViewToDb("pvr://channels/", m_windowId, CViewStateSettings::Get().Get("pvrchannels"));
 }
 
 CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
@@ -53,12 +53,12 @@ CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int win
     // Default sorting
     SetSortMethod(SortByDate);
 
-    LoadViewState(items.GetPath(), m_windowId);
+    LoadViewState("pvr://recordings/", m_windowId);
 }
 
 void CGUIViewStateWindowPVRRecordings::SaveViewState(void)
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::Get().Get("pvrrecordings"));
+  SaveViewToDb("pvr://recordings/", m_windowId, CViewStateSettings::Get().Get("pvrrecordings"));
 }
 
 bool CGUIViewStateWindowPVRRecordings::HideParentDirItems(void)
@@ -68,12 +68,12 @@ bool CGUIViewStateWindowPVRRecordings::HideParentDirItems(void)
 
 CGUIViewStateWindowPVRGuide::CGUIViewStateWindowPVRGuide(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
 {
-  LoadViewState(items.GetPath(), m_windowId);
+  LoadViewState("pvr://guide/", m_windowId);
 }
 
 void CGUIViewStateWindowPVRGuide::SaveViewState(void)
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::Get().Get("pvrguide"));
+  SaveViewToDb("pvr://guide/", m_windowId, CViewStateSettings::Get().Get("pvrguide"));
 }
 
 CGUIViewStateWindowPVRTimers::CGUIViewStateWindowPVRTimers(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
@@ -84,12 +84,12 @@ CGUIViewStateWindowPVRTimers::CGUIViewStateWindowPVRTimers(const int windowId, c
   // Default sorting
   SetSortMethod(SortByDate);
 
-  LoadViewState(items.GetPath(), m_windowId);
+  LoadViewState("pvr://timers/", m_windowId);
 }
 
 void CGUIViewStateWindowPVRTimers::SaveViewState(void)
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::Get().Get("pvrtimers"));
+  SaveViewToDb("pvr://timers/", m_windowId, CViewStateSettings::Get().Get("pvrtimers"));
 }
 
 CGUIViewStateWindowPVRSearch::CGUIViewStateWindowPVRSearch(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
@@ -100,10 +100,10 @@ CGUIViewStateWindowPVRSearch::CGUIViewStateWindowPVRSearch(const int windowId, c
   // Default sorting
   SetSortMethod(SortByDate);
 
-  LoadViewState(items.GetPath(), m_windowId);
+  LoadViewState("pvr://search/", m_windowId);
 }
 
 void CGUIViewStateWindowPVRSearch::SaveViewState(void)
 {
-  SaveViewToDb(m_items.GetPath(), m_windowId, CViewStateSettings::Get().Get("pvrsearch"));
+  SaveViewToDb("pvr://search/", m_windowId, CViewStateSettings::Get().Get("pvrsearch"));
 }


### PR DESCRIPTION
As reported in our forum at http://forum.xbmc.org/showthread.php?tid=175135&pid=1776697#pid1776697 the view state handling depends on the current selected group. This changes the handling to be on a per window basic instead.

@opdenkamp or @Jalle19 mind taking a look.
