### PR TITLE
X11: fix multi-monitor setups after recent changes of X servers

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -776,6 +776,8 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
   bool mouseActive = false;
   float mouseX = 0;
   float mouseY = 0;
+  int x0 = 0;
+  int y0 = 0;
 
   if (m_mainWindow && ((m_bFullScreen != fullscreen) || m_currentOutput.compare(output) != 0 || m_windowDirty))
   {
@@ -823,8 +825,6 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
     Colormap cmap;
     XSetWindowAttributes swa;
     XVisualInfo *vi;
-    int x0 = 0;
-    int y0 = 0;
 
     XOutput *out = g_xrandr.GetOutput(output);
     if (!out)
@@ -944,6 +944,10 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
     }
     XMapRaised(m_dpy, m_glWindow);
     XMapRaised(m_dpy, m_mainWindow);
+
+    if (fullscreen)
+      XMoveWindow(m_dpy, m_mainWindow, x0, y0);
+
     XSync(m_dpy,TRUE);
 
     if (changeWindow && mouseActive)


### PR DESCRIPTION
XBMC stopped to appear on the desired monitor (in particular on Intel systems)

was tested by user: http://forum.xbmc.org/showthread.php?tid=201067&pid=1777256#pid1777256

@jmarshallnz - Gotham food
