### PR TITLE
Added an addEdl function

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -207,6 +207,13 @@ bool CApplicationPlayer::ControlsVolume() const
   return (player && player->ControlsVolume());
 }
 
+void CApplicationPlayer::SetEDL(const std::string& path)
+{
+  boost::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetEDL(path);
+}
+
 void CApplicationPlayer::SetMute(bool bOnOff)
 {
   boost::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -142,6 +142,7 @@ public:
   void  SetAudioStream(int iStream);
   void  SetAVDelay(float fValue = 0.0f);
   void  SetDynamicRangeCompression(long drc);
+  void  SetEDL(const std::string& path);
   void  SetMute(bool bOnOff);
   bool  SetPlayerState(const std::string& state);
   void  SetSubtitle(int iStream);

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -533,6 +533,11 @@ bool CExternalPlayer::CanSeek()
   return false;
 }
 
+
+void CExternalPlayer::SetEDL(const std::string& path)
+{
+}
+
 void CExternalPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 }

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -48,6 +48,7 @@ public:
   virtual void SwitchToNextLanguage();
   virtual void ToggleSubtitles();
   virtual bool CanSeek();
+  virtual void SetEDL(const std::string& path);
   virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual void SeekPercentage(float iPercent);
   virtual float GetPercentage();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -147,6 +147,7 @@ public:
   virtual void SeekPercentage(float fPercent = 0){}
   virtual float GetPercentage(){ return 0;}
   virtual float GetCachePercentage(){ return 0;}
+  virtual void SetEDL(const std::string& path){};
   virtual void SetMute(bool bOnOff){}
   virtual void SetVolume(float volume){}
   virtual bool ControlsVolume(){ return false;}

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3868,6 +3868,24 @@ int CDVDPlayer::AddSubtitleFile(const std::string& filename, const std::string& 
   return m_SelectionStreams.IndexOf(STREAM_SUBTITLE, s.source, s.id);
 }
 
+void CDVDPlayer::SetEDL(const std::string& path)
+{
+  m_Edl.Clear();
+  m_EdlAutoSkipMarkers.Clear();
+  if (m_CurrentVideo.id >= 0 && m_CurrentVideo.hint.fpsrate > 0 && m_CurrentVideo.hint.fpsscale > 0)
+  {
+    m_Edl.SetFullPath(path);
+    float fFramesPerSecond = (float)m_CurrentVideo.hint.fpsrate / (float)m_CurrentVideo.hint.fpsscale;
+    m_Edl.ReadEditDecisionLists(m_filename, fFramesPerSecond, m_CurrentVideo.hint.height);
+    CLog::Log(LOGNOTICE, "CDVDPlayer: new edl set");
+    m_Edl.ClearFullPath();
+  }
+  else
+  {
+    CLog::Log(LOGWARNING, "CDVDPlayer: There was a problem setting the new edl");
+  }
+}
+
 void CDVDPlayer::UpdatePlayState(double timeout)
 {
   if(m_StateInput.timestamp != 0

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -190,6 +190,7 @@ public:
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) { m_dvdPlayerAudio.RegisterAudioCallback(pCallback); }
   virtual void UnRegisterAudioCallback()                        { m_dvdPlayerAudio.UnRegisterAudioCallback(); }
   virtual void SetVolume(float nVolume)                         { m_dvdPlayerAudio.SetVolume(nVolume); }
+  virtual void SetEDL(const std::string& path);
   virtual void SetMute(bool bOnOff)                             { m_dvdPlayerAudio.SetMute(bOnOff); }
   virtual void SetDynamicRangeCompression(long drc)             { m_dvdPlayerAudio.SetDynamicRangeCompression(drc); }
   virtual void GetAudioInfo(std::string& strAudioInfo);

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -187,8 +187,6 @@ public:
   virtual float GetPercentage();
   virtual float GetCachePercentage();
 
-  virtual void RegisterAudioCallback(IAudioCallback* pCallback) { m_dvdPlayerAudio.RegisterAudioCallback(pCallback); }
-  virtual void UnRegisterAudioCallback()                        { m_dvdPlayerAudio.UnRegisterAudioCallback(); }
   virtual void SetVolume(float nVolume)                         { m_dvdPlayerAudio.SetVolume(nVolume); }
   virtual void SetEDL(const std::string& path);
   virtual void SetMute(bool bOnOff)                             { m_dvdPlayerAudio.SetMute(bOnOff); }

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -107,15 +107,15 @@ bool CEdl::ReadEditDecisionLists(const std::string& strMovie, const float fFrame
   bool bFound = false;
 
   /*
-   * Only check for edit decision lists if the movie is on the local hard drive, or accessed over a
-   * network share.
+   * Only check for edit decision lists if the movie is on the local hard drive, accessed over a
+   * network share, or the full path is specified for an internet stream.
    */
   if ((URIUtils::IsHD(strMovie)  || 
        URIUtils::IsSmb(strMovie) || 
        URIUtils::IsNfs(strMovie) || 
+       (URIUtils::IsInternetStream(strMovie) && m_fullPathSet) ||
        URIUtils::IsAfp(strMovie))         &&
-      !URIUtils::IsPVRRecording(strMovie) &&
-      !URIUtils::IsInternetStream(strMovie))
+      !URIUtils::IsPVRRecording(strMovie))
   {
     CLog::Log(LOGDEBUG, "%s - Checking for edit decision lists (EDL) on local drive or remote share for: %s",
               __FUNCTION__, strMovie.c_str());
@@ -171,7 +171,11 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
 {
   Clear();
 
-  std::string edlFilename(URIUtils::ReplaceExtension(strMovie, ".edl"));
+  std::string edlFilename;
+  if (!m_fullPathSet)
+    edlFilename = URIUtils::ReplaceExtension(strMovie, ".edl");
+  else
+    edlFilename = m_fullPath;
   if (!CFile::Exists(edlFilename))
     return false;
 
@@ -340,7 +344,13 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
 {
   Clear();
 
-  std::string comskipFilename(URIUtils::ReplaceExtension(strMovie, ".txt"));
+
+  std::string comskipFilename;
+  if (!m_fullPathSet)
+    comskipFilename = URIUtils::ReplaceExtension(strMovie, ".txt");
+  else
+    comskipFilename = m_fullPath;
+  
   if (!CFile::Exists(comskipFilename))
     return false;
 
@@ -425,7 +435,12 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
    */
 
   Clear();
-  std::string videoReDoFilename(URIUtils::ReplaceExtension(strMovie, ".Vprj"));
+
+  std::string videoReDoFilename;
+  if (!m_fullPathSet)
+    videoReDoFilename = URIUtils::ReplaceExtension(strMovie, ".Vprj");
+  else
+    videoReDoFilename = m_fullPath;
   if (!CFile::Exists(videoReDoFilename))
     return false;
 
@@ -511,7 +526,12 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
 {
   Clear();
 
-  std::string beyondTVFilename(URIUtils::ReplaceExtension(strMovie, URIUtils::GetExtension(strMovie) + ".chapters.xml"));
+  std::string beyondTVFilename;
+  if (!m_fullPathSet)
+    beyondTVFilename = URIUtils::ReplaceExtension(strMovie, URIUtils::GetExtension(strMovie) + ".chapters.xml");
+  else
+    beyondTVFilename = m_fullPath;
+  
   if (!CFile::Exists(beyondTVFilename))
     return false;
 
@@ -1117,4 +1137,17 @@ void CEdl::MergeShortCommBreaks()
     }
   }
   return;
+}
+
+
+void CEdl::SetFullPath(const std::string& path)
+{
+  m_fullPathSet = true;
+  m_fullPath = path;
+}
+
+void CEdl::ClearFullPath()
+{
+  m_fullPathSet = false;
+  m_fullPath.clear();
 }

--- a/xbmc/cores/dvdplayer/Edl.h
+++ b/xbmc/cores/dvdplayer/Edl.h
@@ -54,6 +54,8 @@ public:
   int GetTotalCutTime() const;
   int RemoveCutTime(int iSeek) const;
   int RestoreCutTime(int iClock) const;
+  void SetFullPath(const std::string& path);
+  void ClearFullPath();
 
   bool InCut(int iSeek, Cut *pCut = NULL) const;
 
@@ -66,6 +68,8 @@ private:
   int m_iTotalCutTime; // ms
   std::vector<Cut> m_vecCuts;
   std::vector<int> m_vecSceneMarkers;
+  std::string m_fullPath;
+  bool m_fullPathSet;
 
   bool ReadEdl(const std::string& strMovie, const float fFramesPerSecond);
   bool ReadComskip(const std::string& strMovie, const float fFramesPerSecond);

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -902,6 +902,10 @@ void PAPlayer::Pause()
   }
 }
 
+void PAPlayer::SetEDL(const std::string& path)
+{
+}
+
 void PAPlayer::SetVolume(float volume)
 {
 

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -53,6 +53,7 @@ public:
   virtual bool HasVideo() const { return false; }
   virtual bool HasAudio() const { return true; }
   virtual bool CanSeek();
+  virtual void SetEDL(const std::string& path);
   virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false);
   virtual void SeekPercentage(float fPercent = 0.0f);
   virtual float GetPercentage();

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -379,6 +379,15 @@ namespace XBMCAddon
       g_application.SeekTime( pTime );
     }
 
+    void Player::setEDL(const char* path) throw (PlayerException)
+    {
+      XBMC_TRACE
+      if (!g_application.m_pPlayer->IsPlaying())
+        throw PlayerException("XBMC is not playing any media file");
+
+      g_application.m_pPlayer->SetEDL(path);
+    }
+
     void Player::setSubtitles(const char* cLine)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -245,6 +245,13 @@ namespace XBMCAddon
       // Player_SeekTime
       void seekTime(double seekTime) throw(PlayerException);
 
+
+      /**
+       *setEDL(path) -- set the full path for an edl file and enable it
+       */
+      void setEDL(const char* path) throw (PlayerException);
+
+
       /**
        * setSubtitles() -- set subtitle file and enable subtitlesn
        */

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -506,6 +506,11 @@ void CUPnPPlayer::SeekPercentage(float percent)
     SeekTime((int64_t)(tot * percent / 100));
 }
 
+
+void CUPnPPlayer::SetEDL(const std::string& path)
+{
+}
+
 void CUPnPPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 }

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -47,6 +47,7 @@ public:
   virtual bool IsPaused() const;
   virtual bool HasVideo() const { return false; }
   virtual bool HasAudio() const { return false; }
+  virtual void SetEDL(const std::string& path);
   virtual void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride);
   virtual void SeekPercentage(float fPercent = 0);
   virtual float GetPercentage();


### PR DESCRIPTION
Added:
a function that adds an edl file to a playing video.
stubs in ExternalPlayer, UPnPPlayer, and PAPlayer.
xbmc.player python bindings.

Possible bug: I enabled edls for internet streams. It seems to work most of the time, but seeking throws it off.

C++ isn't my strongest language, so I may have not gotten the pointer/referencing right.
