### PR TITLE
[jenkins] - when cleaning the tree because of changed depends - ensure to do doubleforce

### DIFF
--- a/tools/buildsteps/android/prepare-depends
+++ b/tools/buildsteps/android/prepare-depends
@@ -8,6 +8,6 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi

--- a/tools/buildsteps/androidx86/prepare-depends
+++ b/tools/buildsteps/androidx86/prepare-depends
@@ -8,6 +8,6 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi

--- a/tools/buildsteps/atv2/prepare-depends
+++ b/tools/buildsteps/atv2/prepare-depends
@@ -9,7 +9,7 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi
 

--- a/tools/buildsteps/ios/prepare-depends
+++ b/tools/buildsteps/ios/prepare-depends
@@ -9,6 +9,6 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi

--- a/tools/buildsteps/linux32/prepare-depends
+++ b/tools/buildsteps/linux32/prepare-depends
@@ -8,6 +8,6 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi

--- a/tools/buildsteps/linux64/prepare-depends
+++ b/tools/buildsteps/linux64/prepare-depends
@@ -8,6 +8,6 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi

--- a/tools/buildsteps/osx32/prepare-depends
+++ b/tools/buildsteps/osx32/prepare-depends
@@ -9,6 +9,6 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi

--- a/tools/buildsteps/osx64/prepare-depends
+++ b/tools/buildsteps/osx64/prepare-depends
@@ -9,6 +9,6 @@ cd $WORKSPACE;git clean -xfd -e "tools/depends" -e "addons/pvr.*"
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi

--- a/tools/buildsteps/rbpi/prepare-depends
+++ b/tools/buildsteps/rbpi/prepare-depends
@@ -15,6 +15,6 @@ fi
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   #clean up the rest too
-  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE;git clean -xffd
   cd $WORKSPACE/tools/depends/;./bootstrap
 fi


### PR DESCRIPTION
This PR is against Gotham

When we do git clean -xfd because of changed depends there are some files skipped because they contain ".git" folders. This is true for all binary addons for example. We want those cleaned to.

So this pr changes the prepare-depends step so that it issues a git clean -xffd (doubleforce) that should get rid of those dirs aswell.

This should fix building android when depends changed for example and more maybe.
