### PR TITLE
cximage: fix broken cr2 after wrong backport of security fix d13aee8e81b...

### DIFF
--- a/lib/cximage-6.0/raw/libdcr.c
+++ b/lib/cximage-6.0/raw/libdcr.c
@@ -920,6 +920,8 @@ void DCR_CLASS dcr_lossless_jpeg_load_raw(DCRAW* p)
 			}
 			if (p->raw_width == 3984 && (col -= 2) < 0)
 				col += (row--,p->raw_width);
+			if (row > p->raw_height)
+				longjmp (p->failure, 3);
 			if ((unsigned) (row-p->top_margin) < p->height) {
 				if ((unsigned) (col-p->left_margin) < p->width) {
 					BAYER(row-p->top_margin,col-p->left_margin) = val;
@@ -929,8 +931,6 @@ void DCR_CLASS dcr_lossless_jpeg_load_raw(DCRAW* p)
 			}
 			if (++col >= p->raw_width)
 				col = (row++,0);
-			if (row >= p->raw_height)
-				longjmp (p->failure, 3);
 		}
 	}
 	free (jh.row);


### PR DESCRIPTION
fixes broken image decoding of raw formats like cr2 after https://github.com/xbmc/xbmc/commit/d13aee8e81be9032ed78fd707d485fdcb4ed5bd6

@jmarshallnz should be pulled to Gotham branch
