### PR TITLE
[airplay] - fix http compliance by always sending the content-length header...

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -507,11 +507,7 @@ void CAirPlayServer::CTCPClient::PushBuffer(CAirPlayServer *host, const char *bu
       response += responseHeader;
     }
 
-    if (responseBody.size() > 0)
-    {
-      response = StringUtils::Format("%sContent-Length: %d\r\n", response.c_str(), responseBody.size());
-    }
-    response += "\r\n";
+    response = StringUtils::Format("%sContent-Length: %d\r\n\r\n", response.c_str(), responseBody.size());
 
     if (responseBody.size() > 0)
     {


### PR DESCRIPTION
This is against Gotham

fixes #15395
