### PR TITLE
[win32][bluray] Bump libbluray to version 0.6.1

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -11,7 +11,7 @@ doxygen-1.8.2-win32.7z
 gnutls-3.2.3-win32.zip
 jsonschemabuilder-1.0.0-win32-3.7z
 libass-0.10.2-win32.7z
-libbluray-0.4.0-win32.zip
+libbluray-0.6.1-win32.zip
 libiconv-1.13.1_1-win32-vc120.7z
 libjpeg-turbo-1.2.0-win32.7z
 libnfs-1.6.2-win32.7z

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -863,3 +863,23 @@ void CURL::RemoveProtocolOption(const std::string &key)
   m_protocolOptions.RemoveOption(key);
   m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);
 }
+
+#ifdef TARGET_WINDOWS
+std::string CURL::SanitizePath(const CURL& url)
+{
+  std::string filename = url.Get();
+  std::string common_ext[] = { ".iso", ".img", ".nrg" };
+  size_t ext = std::string::npos;
+  for (int i = 0; i < 3; ++i)
+  {
+    if ((ext = filename.rfind(common_ext[i])) != std::string::npos)
+      break;
+  }
+
+  std::string beforeLastDot = filename.substr(0, ext);
+  std::string afterLastDot = filename.substr(ext, filename.length());
+  afterLastDot = CURL::Decode(afterLastDot);
+  afterLastDot = URIUtils::FixSlashesAndDups(afterLastDot, '/', 0);
+  return beforeLastDot.append(afterLastDot);
+}
+#endif

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -122,6 +122,13 @@ public:
   void SetProtocolOption(const std::string &key, const std::string &value);
   void RemoveProtocolOption(const std::string &key);
 
+#ifdef TARGET_WINDOWS
+  /** \brief Replaces \\ with / after the file extension. For example this is necessary
+  *          for udf paths which are retrived by our udf implementation
+  */
+  static std::string SanitizePath(const CURL& url);
+#endif
+
 protected:
   int m_iPort;
   std::string m_strHostName;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -91,8 +91,16 @@ BD_FILE_H * DllLibbluray::file_open(const char* filename, const char *mode)
     file->tell  = file_tell;
     file->eof   = file_eof;
 
+    std::string filename_clean(filename);
+
+#ifdef TARGET_WINDOWS
+    // replace \\ with / after "udf://", because our udf implementation requires this format
+    if (URIUtils::IsProtocol(filename, "udf"))
+      filename_clean = URIUtils::FixSlashesAndDups(filename, '/', 6);
+#endif
+
     CFile* fp = new CFile();
-    if(fp->Open(filename))
+    if (fp->Open(filename_clean))
     {
       file->internal = (void*)fp;
       return file;
@@ -147,6 +155,12 @@ BD_DIR_H *DllLibbluray::dir_open(const char* dirname)
     SDirState *st = new SDirState();
 
     std::string strDirname(dirname);
+
+#ifdef TARGET_WINDOWS
+    // replace \\ with / after "udf://", because our udf implementation requires this format 
+    if (URIUtils::IsProtocol(strDirname, "udf"))
+      strDirname = URIUtils::FixSlashesAndDups(strDirname, '/', 6);
+#endif
 
     if(!CDirectory::GetDirectory(strDirname, st->list))
     {

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -41,7 +41,11 @@ bool CUDFDirectory::GetDirectory(const CURL& url,
                                  CFileItemList &items)
 {
   std::string strRoot, strSub;
+#ifdef TARGET_WINDOWS
+  CURL url2(CURL::SanitizePath(url));
+#else
   CURL url2(url);
+#endif
   if (!url2.IsProtocol("udf"))
   { // path to an image
     url2.Reset();

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -50,10 +50,16 @@ CUDFFile::~CUDFFile()
 //*********************************************************************************************
 bool CUDFFile::Open(const CURL& url)
 {
-  if(!m_udfIsoReaderLocal.Open(url.GetHostName().c_str()) || url.GetFileName().empty())
+#ifdef TARGET_WINDOWS
+  CURL url2(CURL::SanitizePath(url));
+#else
+  CURL url2(url);
+#endif
+
+  if (!m_udfIsoReaderLocal.Open(url2.GetHostName().c_str()) || url2.GetFileName().empty())
      return false;
 
-  m_hFile = m_udfIsoReaderLocal.OpenFile(url.GetFileName().c_str());
+  m_hFile = m_udfIsoReaderLocal.OpenFile(url2.GetFileName().c_str());
   if (m_hFile == INVALID_HANDLE_VALUE)
   {
     m_bOpened = false;


### PR DESCRIPTION
Since libbluray uses \\ as path separator on win32 and or udf reader wants to have / after the extension (i.e. the path inside the image) image playback got broken.
https://github.com/ace20022/xbmc/commit/22c13f25dd7ae4baa9aa34a6aed799c0f4e27dbd and https://github.com/ace20022/xbmc/commit/98c3346ad090fd268b337e59ff4744b8e76eb2a3 are two alternatives to fix that issue. A third option would be to patch libbluray. Any thoughts?

@wsnipex I'm pretty sure that I've done the non win32 part wrong ;)
