### PR TITLE
pvr: fix deadlock caused by pollling channel group name

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3829,7 +3829,7 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
     case VIDEOPLAYER_CHANNEL_GROUP:
       {
         if (tag && !tag->IsRadio())
-          return g_PVRManager.GetPlayingGroup(false)->GroupName();
+          return g_PVRManager.GetPlayingTVGroupName();
       }
     }
   }

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -258,6 +258,7 @@ void CPVRGUIInfo::UpdateMisc(void)
   bool       bIsPlayingEncryptedStream = bStarted && g_PVRClients->IsEncrypted();
   bool       bHasTVChannels            = bStarted && g_PVRChannelGroups->GetGroupAllTV()->HasChannels();
   bool       bHasRadioChannels         = bStarted && g_PVRChannelGroups->GetGroupAllRadio()->HasChannels();
+  std::string strPlayingTVGroup        = (bStarted && bIsPlayingTV) ? g_PVRManager.GetPlayingGroup(false)->GroupName() : "";
   
   /* safe to fetch these unlocked, since they're updated from the same thread as this one */
   bool       bHasNonRecordingTimers    = bStarted && m_iTimerAmount - m_iRecordingTimerAmount > 0;
@@ -272,6 +273,7 @@ void CPVRGUIInfo::UpdateMisc(void)
   m_bIsPlayingEncryptedStream = bIsPlayingEncryptedStream;
   m_bHasTVChannels            = bHasTVChannels;
   m_bHasRadioChannels         = bHasRadioChannels;
+  m_strPlayingTVGroup         = strPlayingTVGroup;
 }
 
 bool CPVRGUIInfo::TranslateCharInfo(DWORD dwInfo, std::string &strValue) const
@@ -897,4 +899,9 @@ void CPVRGUIInfo::UpdatePlayingTag(void)
     ResetPlayingTag();
     m_iDuration = recording.GetDuration() * 1000;
   }
+}
+
+std::string CPVRGUIInfo::GetPlayingTVGroup()
+{
+  return m_strPlayingTVGroup;
 }

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -77,6 +77,11 @@ namespace PVR
 
     bool GetPlayingTag(EPG::CEpgInfoTag &tag) const;
 
+    /*!
+    * @brief Get playing TV group.
+    */
+    std::string GetPlayingTVGroup();
+
   private:
     void ResetProperties(void);
     void ClearQualityInfo(PVR_SIGNAL_STATUS &qualityInfo);
@@ -162,6 +167,7 @@ namespace PVR
     bool                            m_bIsPlayingEncryptedStream;
     bool                            m_bHasTVChannels;
     bool                            m_bHasRadioChannels;
+    std::string                     m_strPlayingTVGroup;
     //@}
 
     PVR_SIGNAL_STATUS               m_qualityInfo;       /*!< stream quality information */

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1614,3 +1614,8 @@ bool CPVRManager::CreateChannelEpgs(void)
   m_bEpgsCreated = m_channelGroups->CreateChannelEpgs();
   return m_bEpgsCreated;
 }
+
+std::string CPVRManager::GetPlayingTVGroupName()
+{
+  return IsStarted() && m_guiInfo ? m_guiInfo->GetPlayingTVGroup() : "";
+}

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -548,6 +548,12 @@ namespace PVR
      */
     bool CreateChannelEpgs(void);
 
+    /*!
+    * @brief get the name of the channel group of the current playing channel
+    * @return name of channel if tv channel is playing
+    */
+    std::string GetPlayingTVGroupName();
+
   protected:
     /*!
      * @brief PVR update and control thread.


### PR DESCRIPTION
see title
This is not only a pvr issue. The gui calls into various modules while holding the gfx lock. The methods called should avoid grabbing other locks.

In the long run we should move away from this gui polling model, this also makes video stutter. Components should push/update their infos to some central place the gui and other components can access.

@opdenkamp mind a review?
@fritsch could you test this please
