### PR TITLE
[Fix] When changing subtitles the cached overlays must be cleared.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.cpp
@@ -53,7 +53,7 @@ CDVDPlayerSubtitle::CDVDPlayerSubtitle(CDVDOverlayContainer* pOverlayContainer)
 
 CDVDPlayerSubtitle::~CDVDPlayerSubtitle()
 {
-  CloseStream(false);
+  CloseStream(true);
 }
 
 
@@ -145,7 +145,7 @@ bool CDVDPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, string &filename)
 {
   CSingleLock lock(m_section);
 
-  CloseStream(false);
+  CloseStream(true);
   m_streaminfo = hints;
 
   // okey check if this is a filesubtitle
@@ -155,14 +155,14 @@ bool CDVDPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, string &filename)
     if (!m_pSubtitleFileParser)
     {
       CLog::Log(LOGERROR, "%s - Unable to create subtitle parser", __FUNCTION__);
-      CloseStream(false);
+      CloseStream(true);
       return false;
     }
 
     if (!m_pSubtitleFileParser->Open(hints))
     {
       CLog::Log(LOGERROR, "%s - Unable to init subtitle parser", __FUNCTION__);
-      CloseStream(false);
+      CloseStream(true);
       return false;
     }
     m_pSubtitleFileParser->Reset();
@@ -181,7 +181,7 @@ bool CDVDPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, string &filename)
   return false;
 }
 
-void CDVDPlayerSubtitle::CloseStream(bool flush)
+void CDVDPlayerSubtitle::CloseStream(bool bWaitForBuffers)
 {
   CSingleLock lock(m_section);
 
@@ -194,7 +194,7 @@ void CDVDPlayerSubtitle::CloseStream(bool flush)
 
   m_dvdspus.FlushCurrentPacket();
 
-  if(flush)
+  if (!bWaitForBuffers)
     m_pOverlayContainer->Clear();
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayerSubtitle.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerSubtitle.h
@@ -50,7 +50,7 @@ public:
   void SendMessage(CDVDMsg* pMsg, int priority = 0);
   bool OpenStream(CDVDStreamInfo &hints) { return OpenStream(hints, hints.filename); }
   bool OpenStream(CDVDStreamInfo &hints, std::string& filename);
-  void CloseStream(bool flush);
+  void CloseStream(bool bWaitForBuffers);
 
   bool IsInited() const { return true; }
   bool IsStalled() const { return m_pOverlayContainer->GetSize() == 0; }


### PR DESCRIPTION
This fixes a regression introduced in 6937fd4181b60f3ae20d664d697ec9589603c36f.
The related pr is https://github.com/xbmc/xbmc/pull/4737.

This fixes ticket 15371.
