### PR TITLE
[linux] workaround joystick hotplugging bug in SDL via udev and json-rpc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -567,6 +567,11 @@ else
 	@echo "You can run XBMC with the command 'xbmc'"
 endif
 endif
+ifeq ($(findstring linux,@ARCH@), linux)
+	@sed "s|@BINDIR@|$(DESTDIR)$(libdir)/xbmc|g" tools/Linux/98-joystick.rules.in > tools/Linux/98-joystick.rules
+	@install tools/Linux/98-joystick.rules $(DESTDIR)$(datarootdir)/xbmc/98-joystick.rules-Sample
+	@install tools/Linux/joystick-fix.sh $(DESTDIR)$(libdir)/xbmc/joystick-fix.sh
+endif
 
 install-arch:
 	@# Arch dependent files

--- a/tools/Linux/98-joystick.rules.in
+++ b/tools/Linux/98-joystick.rules.in
@@ -1,0 +1,18 @@
+###
+# Workaround for joystick hotplugging
+# NEEDS Json over TCP enabled:
+#   System - Settings - Services - Remote Control - Allow programs on this system to control Kodi
+###
+
+# Xbox 360
+ACTION=="add", KERNEL=="js*", DRIVERS=="xpad", RUN+="@BINDIR@/joystick-fix.sh reload"
+ACTION=="remove", KERNEL=="js*", DRIVERS=="xpad", RUN+="@BINDIR@/joystick-fix.sh disable"
+
+# Sony PS3 sixaxis via USB
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0268", RUN+="@BINDIR@/joystick-fix.sh reload"
+ACTION=="remove", SUBSYSTEMS=="usb", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0268", RUN+="@BINDIR@/joystick-fix.sh disable"
+
+# Sony PS3 sixaxis via Bluetooth and sixad
+ACTION=="add", SUBSYSTEMS=="input", ATTRS{name}=="PLAYSTATION(R)3 Controller (*)", RUN+="@BINDIR@/joystick-fix.sh reload"
+ACTION=="remove", SUBSYSTEMS=="input", ATTRS{name}=="PLAYSTATION(R)3 Controller (*)", RUN+="@BINDIR@/joystick-fix.sh disable"
+

--- a/tools/Linux/joystick-fix.sh
+++ b/tools/Linux/joystick-fix.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+###
+# Workaround for joystick hotplugging
+# Requires
+#  - Json over TCP enabled:
+#   System - Settings - Services - Remote Control - Allow programs on this system to control Kodi
+#  - a udev rule:
+#   /etc/udev/rules.d/98-joystick.rules
+#   see ${prefix}/share/xbmc/98-joystick.rules-Sample
+#  - netcat
+###
+
+command -v nc >/dev/null 2>&1 && NC="nc"
+command -v netcat >/dev/null 2>&1 && NC="netcat"
+[ -z "$NC" ] && echo "nc or netcat not found" && exit 1
+
+ACTION=$1
+
+case "$ACTION" in
+  "enable")
+    echo '{"jsonrpc":"2.0","method":"Settings.SetSettingValue", "params":{"setting":"input.enablejoystick","value":true},"id":1}' | $NC localhost 9090 >/dev/null && exit 0
+    ;;
+  "disable")
+    echo '{"jsonrpc":"2.0","method":"Settings.SetSettingValue", "params":{"setting":"input.enablejoystick","value":false},"id":1}' | $NC localhost 9090 >/dev/null && exit 0
+    ;;
+  "reload")
+    echo '{"jsonrpc":"2.0","method":"Settings.SetSettingValue", "params":{"setting":"input.enablejoystick","value":false},"id":1}' | $NC localhost 9090 >/dev/null && \
+    echo '{"jsonrpc":"2.0","method":"Settings.SetSettingValue", "params":{"setting":"input.enablejoystick","value":true},"id":1}' | $NC localhost 9090 >/dev/null && exit 0
+    ;;
+  *)
+    echo "usage: $0 {enable|disable|reload}"
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
This is a rather ugly workaround for the joystick hotplug issue and should be removed once our input handling is properly fixed.

It uses a udev rule and json-rcp over TCP to toggle joystick support if a controller is plugged in or wakes from sleep.
based on forum user teeedubbs idea: http://forum.xbmc.org/showthread.php?tid=157499&pid=1722549#pid1722549

I could only test this with a PS3 sixaxis controller(via USB), can please anyone test it with Xbox 360.
3rd party controllers probably need additional udev rules, which I'd be happy to add.

@topfs2 ping
