### PR TITLE
Added SFTP to the check for internet streams (fixes #15391)

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -842,7 +842,8 @@ bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */
 
   // Special case these
   if (url.IsProtocol("ftp") || url.IsProtocol("ftps")  ||
-      url.IsProtocol("dav") || url.IsProtocol("davs"))
+      url.IsProtocol("dav") || url.IsProtocol("davs")  ||
+      url.IsProtocol("sftp"))
     return bStrictCheck;
 
   std::string protocol = url.GetTranslatedProtocol();


### PR DESCRIPTION
Fixes http://trac.xbmc.org/ticket/15391

Tested it on Debian and the debug log shows that after this change, movies from sftp are played using CFileCache (as opposed to before the change, when it didn't use CFileCache). Of course, this greatly improves the performance and stability when watching a movie over SFTP.
