### PR TITLE
smartplaylists: fix generated SQL query for multi-value rules with a negated parameter (fixes #15313)

### DIFF
--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -377,8 +377,13 @@ CStdString CDatabaseQueryRule::GetWhereClause(const CDatabase &db, const CStdStr
   {
     CStdString query = "(" + FormatWhereClause(negate, operatorString, *it, db, strType) + ")";
 
-    if (it+1 != m_parameter.end())
-      query += " OR ";
+    if (it + 1 != m_parameter.end())
+    {
+      if (negate.empty())
+        query += " OR ";
+      else
+        query += " AND ";
+    }
 
     wholeQuery += query;
   }


### PR DESCRIPTION
This is the backport of #5230 for Gotham. It fixes http://trac.xbmc.org/ticket/15313.
