### PR TITLE
[lirc] preventing multiple connections to the lirc socket (Gotham)

### DIFF
--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -129,7 +129,7 @@ void CRemoteControl::Initialize()
   struct sockaddr_un addr;
   unsigned int now = XbmcThreads::SystemClockMillis();
 
-  if (!m_used || (now - m_lastInitAttempt) < (unsigned int)m_initRetryPeriod)
+  if (m_bInitialized || !m_used || (now - m_lastInitAttempt) < (unsigned int)m_initRetryPeriod)
     return;
   
   m_lastInitAttempt = now;


### PR DESCRIPTION
on @topfs2 recommendation (PR #5268 ): separate PR of this fix for the Gotham tree

Details to this PR also explained in forum:
http://forum.xbmc.org/showthread.php?tid=202592

This fix should prevent that Kodi connects to the same socket multiple times if XBMC.LIRC.Start is called multiple times.
