### PR TITLE
Pulseaudio: More Desktop integration

### DIFF
--- a/src/ApplicationMessenger.cpp
+++ b/src/ApplicationMessenger.cpp
@@ -788,6 +788,14 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       }
       break;
 
+    case TMSG_VOLUME_SET:
+      {
+        CAction action(pMsg->param1, *(float*)pMsg->lpVoid);
+        g_application.OnAction(action);
+        delete (float*)pMsg->lpVoid;
+      }
+      break;
+
     case TMSG_VOLUME_SHOW:
       {
         CAction action(pMsg->param1);
@@ -1307,6 +1315,14 @@ vector<bool> CApplicationMessenger::GetInfoBooleans(const vector<string> &proper
   tMsg.lpVoid = (void*)&infoLabels;
   SendMessage(tMsg, true);
   return infoLabels;
+}
+
+void CApplicationMessenger::SetVolume(int action, float amount)
+{
+  ThreadMessage tMsg = {TMSG_VOLUME_SET};
+  tMsg.param1 = action;
+  tMsg.lpVoid = new float(amount);
+  SendMessage(tMsg, false);
 }
 
 void CApplicationMessenger::ShowVolumeBar(bool up)

--- a/src/ApplicationMessenger.h
+++ b/src/ApplicationMessenger.h
@@ -111,6 +111,7 @@ namespace MUSIC_INFO
 
 #define TMSG_VOLUME_SHOW          900
 #define TMSG_SPLASH_MESSAGE       901
+#define TMSG_VOLUME_SET           902
 
 #define TMSG_DISPLAY_SETUP      1000
 #define TMSG_DISPLAY_DESTROY    1001
@@ -247,6 +248,11 @@ public:
 
   std::vector<std::string> GetInfoLabels(const std::vector<std::string> &properties);
   std::vector<bool> GetInfoBooleans(const std::vector<std::string> &properties);
+
+  //! \brief Set the volume
+  //! \param action ACTION_VOLUME_UP or ACTION_VOLUME_DOWN
+  //! \param amount Amount to adjust with
+  void SetVolume(int action, float amount);
 
   void ShowVolumeBar(bool up);
 

--- a/src/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/src/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -22,8 +22,10 @@
 #include "AESinkPULSE.h"
 #include "utils/log.h"
 #include "Util.h"
+#include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 
 using namespace std;
 
@@ -808,10 +810,12 @@ void CAESinkPULSE::UpdateInternalVolume(const pa_cvolume* nVol)
   pa_volume_t o_vol = pa_cvolume_avg(&m_Volume);
   pa_volume_t n_vol = pa_cvolume_avg(nVol);
 
-  if (o_vol != n_vol)
+  if (o_vol != n_vol && n_vol <= PA_VOLUME_NORM)
   {
     pa_cvolume_set(&m_Volume, m_Channels, n_vol);
     m_volume_needs_update = true;
+    int action = n_vol > o_vol ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN;
+    CApplicationMessenger::Get().SetVolume(action, (float) n_vol / PA_VOLUME_NORM);
   }
 }
 


### PR DESCRIPTION
This makes the volume slider in xbmc moving when it is controlled via pavucontrol. 

We are informed by a pulse callback and adjust the internal volume. then a message for the App Messenger is prepared. When application calls us to set the volume - we keep the set volume so that only the volumeBar is presented. In order to not break pulse amplification we ignore higher than 1.0 values.

The AppMessenger needed a straight forward adjustment in order to handle and forward the message for us.
