### PR TITLE
[locale] uClibc is built with 'generic' support for stdc++ locale()

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -172,8 +172,9 @@ void CLangInfo::CRegion::SetGlobalLocale()
   // decimal separator is changed depending of the current language
   // (ie. "," in French or Dutch instead of "."). This breaks atof() and
   // others similar functions.
-#if defined(TARGET_FREEBSD) || defined(TARGET_DARWIN_OSX)
-  // on FreeBSD and darwin libstdc++ is compiled with "generic" locale support
+#if defined(TARGET_FREEBSD) || defined(TARGET_DARWIN_OSX) || defined(__UCLIBC__)
+  // on FreeBSD, darwin and uClibc-based systems libstdc++ is compiled with
+  // "generic" locale support
   if (setlocale(LC_COLLATE, strLocale.c_str()) == NULL
   || setlocale(LC_CTYPE, strLocale.c_str()) == NULL)
   {


### PR DESCRIPTION
Quote from libstdc++-v3/config.log:
configure:15959: checking for C locale to use
configure:15963: result: generic
