### PR TITLE
fixed: don't hop to first item in list on deleting another one

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -751,6 +751,9 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
     if (!CGUIDialogVideoInfo::DeleteVideoItem(pItem))
       return;
   }
+  int itemNumber = m_viewControl.GetSelectedItem();
+  int select = itemNumber >= m_vecItems->Size()-1 ? itemNumber-1 : itemNumber;
+  m_viewControl.SetSelectedItem(select);
 
   CUtil::DeleteVideoDatabaseDirectoryCache();
 }
@@ -960,6 +963,11 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
           m_viewControl.SetSelectedItem(itemNumber + 1);
 
         Refresh(true);
+        if (ret == CONTEXT_BUTTON_DELETE)
+        {
+          int select = itemNumber >= m_vecItems->Size()-1 ? itemNumber-1:itemNumber;
+          m_viewControl.SetSelectedItem(select);
+        }
       }
       return true;
     }


### PR DESCRIPTION
Quells a regression

See http://forum.xbmc.org/showthread.php?tid=202798 been confirmed and this is a fix. Can go into master and cherry picked into Gotham I suppose.

This is a backport - Thank you @notspiff for fix

@ronie
