### PR TITLE
[jenkins/win32] - speed up compilation by activating parallel builds

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -40,7 +40,7 @@ set WORKSPACE=%CD%\..\..
 
   IF EXIST "!NET!" (
 	set msbuildemitsolution=1
-	set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Build /p:Configuration="%buildconfig%" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120"
+	set OPTS_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Build /p:Configuration="%buildconfig%" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120" /m
 	set CLEAN_EXE="..\VS2010Express\XBMC for Windows.sln" /t:Clean /p:Configuration="%buildconfig%" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120"
   )
 

--- a/project/Win32BuildSetup/buildffmpeg.sh
+++ b/project/Win32BuildSetup/buildffmpeg.sh
@@ -46,9 +46,9 @@ fi
 
 if [ $NUMBER_OF_PROCESSORS > 1 ]; then
   if [ $NUMBER_OF_PROCESSORS > 4 ]; then
-    MAKEFLAGS=-j4
+    MAKEFLAGS=-j6
   else
-    MAKEFLAGS=-j$NUMBER_OF_PROCESSORS
+    MAKEFLAGS=-j`expr $NUMBER_OF_PROCESSORS + $NUMBER_OF_PROCESSORS / 2`
   fi
 fi
 

--- a/project/Win32BuildSetup/buildpvraddons.bat
+++ b/project/Win32BuildSetup/buildpvraddons.bat
@@ -17,7 +17,7 @@ SET BUILT_ADDONS_DIR=%SOURCE_DIR%\addons
 
 REM check if MSBuild.exe is used because it requires different command line switches
 IF "%msbuildemitsolution%" == "1" (
-  set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /t:Build /p:Configuration="Release" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120\\"
+  set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /t:Build /p:Configuration="Release" /property:VCTargetsPath="%MSBUILDROOT%Microsoft.Cpp\v4.0\V120\\" /m
 ) ELSE (
   set OPTS_EXE=%SOURCE_DIR%\project\VS2010Express\xbmc-pvr-addons.sln /build Release
 )

--- a/tools/buildsteps/win32/make-mingwlibs.sh
+++ b/tools/buildsteps/win32/make-mingwlibs.sh
@@ -68,7 +68,7 @@ else
 fi
 
 if [ $NUMBER_OF_PROCESSORS > 1 ]; then
-  MAKEFLAGS=-j$NUMBER_OF_PROCESSORS
+  MAKEFLAGS=-j`expr $NUMBER_OF_PROCESSORS + $NUMBER_OF_PROCESSORS / 2`
 fi
 
 # compile our mingw dlls


### PR DESCRIPTION
This activates parallel builds when using MSBuild (like on jenkins) (for main solution and pvr addons). It also increases the number of processes the mingw-make will spawn from NumCpus to NumCpus*1.5 (which is the recommended setting).

@wsoltys i think this gives a couple of minutes speedup on our vm...
