### PR TITLE
FIX: prevent switching to windowed mode if windowing do not support it

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -330,6 +330,9 @@ bool CDisplaySettings::OnSettingUpdate(CSetting* &setting, const char *oldSettin
 
 void CDisplaySettings::SetCurrentResolution(RESOLUTION resolution, bool save /* = false */)
 {
+  if (resolution == RES_WINDOW && !g_Windowing.CanDoWindowed())
+    resolution = RES_DESKTOP;
+
   if (save)
   {
     string mode = GetStringFromResolution(resolution);

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -339,9 +339,11 @@ void CDisplaySettings::SetCurrentResolution(RESOLUTION resolution, bool save /* 
     CSettings::Get().SetString("videoscreen.screenmode", mode.c_str());
   }
 
-  m_currentResolution = resolution;
-
-  SetChanged();
+  if (resolution != m_currentResolution)
+  {
+    m_currentResolution = resolution;
+    SetChanged();
+  }
 }
 
 RESOLUTION CDisplaySettings::GetDisplayResolution() const

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -96,6 +96,7 @@ public:
   unsigned int GetHeight() { return m_nHeight; }
   virtual int GetNumScreens() { return 0; }
   virtual int GetCurrentScreen() { return 0; }
+  virtual bool CanDoWindowed() { return true; }
   bool IsFullScreen() { return m_bFullScreen; }
   virtual void UpdateResolutions();
   void SetWindowResolution(int width, int height);

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -44,6 +44,7 @@ public:
   virtual bool  SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual void  UpdateResolutions();
   virtual bool  IsExtSupported(const char* extension);
+  virtual bool  CanDoWindowed() { return false; }
 
   virtual void  ShowOSMouse(bool show);
   virtual bool  HasCursor();

--- a/xbmc/windowing/osx/WinSystemIOS.h
+++ b/xbmc/windowing/osx/WinSystemIOS.h
@@ -44,6 +44,7 @@ public:
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop);
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual void UpdateResolutions();
+  virtual bool CanDoWindowed() { return false; }
 
   virtual void ShowOSMouse(bool show);
   virtual bool HasCursor();


### PR DESCRIPTION
Problem is that switching to windowed only displays a scaled display (720x480) on the bot-left on the screen and users can inadvertently switch to window mode by hitting "\" on a keyboard. 

@jmarshallnz There must be a better way, but I cannot find it.
Apparently, there is no provision to deny RES_WINDOW anywhere...
