### PR TITLE
AESinkALSA: Fix S24NE4MSB incorrectly reported as S24NE4

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -701,9 +701,9 @@ bool CAESinkALSA::InitializeHW(const ALSAConfig &inconfig, ALSAConfig &outconfig
       int bits    = snd_pcm_hw_params_get_sbits(hw_params);
       if (bits != fmtBits)
       {
-        /* if we opened in 32bit and only have 24bits, pack into 24 */
+        /* if we opened in 32bit and only have 24bits, signal it accordingly */
         if (fmtBits == 32 && bits == 24)
-          i = AE_FMT_S24NE4;
+          i = AE_FMT_S24NE4MSB;
         else
           continue;
       }


### PR DESCRIPTION
The ALSA sink reports both S24NE4 (sample in LSB) and 24-bit S32NE
(sample in MSB) as AE_FMT_S24NE4.

Report the latter correctly as AE_FMT_S24NE4MSB instead, otherwise
sample conversion goes wrong resulting in noise.

Addresses http://forum.xbmc.org/showthread.php?tid=203120
