### PR TITLE
[JSON-RPC] FIX: Do not reopen PVR playback when new channel requested

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -593,7 +593,12 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     if (channel == NULL)
       return InvalidParams;
 
-    CApplicationMessenger::Get().MediaPlay(CFileItem(*channel.get()));
+    if ((g_PVRManager.IsPlayingRadio() && channel.get()->IsRadio()) ||
+        (g_PVRManager.IsPlayingTV() && !channel.get()->IsRadio()))
+      g_PVRManager.PerformChannelSwitch(*channel.get(), false);
+    else
+      CApplicationMessenger::Get().MediaPlay(CFileItem(*channel.get()));
+
     return ACK;
   }
   else


### PR DESCRIPTION
I changed the behavior of the JSON-RPC PlayerOperations, to not reopen the whole PVR playback, when a client requests a channel-id to be played and PVR playback is already active.
Not a big contribution, but this makes channel changes from JSON-RPC clients a lot faster.

I'd consider this to be a fix or small improvement. At least this time I'm not messing with the API and would appreciate if this made its way into Helix.
