### PR TITLE
[win32][Fix] Set hDeviceNotify to 0 after a successful UnregisterDeviceN...

### DIFF
--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -434,7 +434,12 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case WM_QUIT:
     case WM_DESTROY:
       if (hDeviceNotify)
-        UnregisterDeviceNotification(hDeviceNotify);
+      {
+        if (UnregisterDeviceNotification(hDeviceNotify))
+          hDeviceNotify = 0;
+        else
+          CLog::Log(LOGNOTICE, "%s: UnregisterDeviceNotification failed (%d)", __FUNCTION__, GetLastError());
+      }
       newEvent.type = XBMC_QUIT;
       m_pEventFunc(newEvent);
       break;


### PR DESCRIPTION
...otification call.

UnregisterDeviceNotification gets called twice on exit ( I have not checked why). The second call fails.
AppVerifier reports "First chance access violation for current stack trace."
GetLastError is `ERROR_INVALID_USER_BUFFER 1784 (0x6F8) The supplied user buffer is not valid for the requested operation.`
