### PR TITLE
Added sort token to Italian language

### DIFF
--- a/language/Italian/langinfo.xml
+++ b/language/Italian/langinfo.xml
@@ -44,6 +44,7 @@
     <token>I</token>
     <token>Gli</token>
     <token>Le</token>
+    <token separators="'">L</token>
     <token>Un</token>
     <token>Uno</token>
     <token>Una</token>


### PR DESCRIPTION
I've added the **L'** article to the list of the sort tokens. It was missing and it's widely used in our language.
