### PR TITLE
add support to read frequency output if using intel's pstate driver

### DIFF
--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -267,6 +267,8 @@ CCPUInfo::CCPUInfo(void)
     m_fProcTemperature = fopen("/sys/class/thermal/thermal_zone0/temp", "r");  // On Raspberry PIs
 
   m_fCPUFreq = fopen ("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq", "r");
+  if (m_fCPUFreq == NULL)
+    m_fCPUFreq = fopen ("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq", "r");
   if (!m_fCPUFreq)
   {
     m_cpuInfoForFreq = true;


### PR DESCRIPTION
this had possible fixed @uNiversal 's issue from https://github.com/xbmc/xbmc/pull/5250
Intels pstate driver uses a different path to get the cpu frequency, so use this as a alternative instead using the fallback solution via /proc
