### PR TITLE
[UX] Play button/action should not pause

### DIFF
--- a/system/keymaps/joystick.AppleRemote.xml
+++ b/system/keymaps/joystick.AppleRemote.xml
@@ -45,7 +45,7 @@
       <!-- hold right -->      <button id="10">Right</button>
 
       <!-- new aluminium remote buttons  -->
-      <!-- play/pause -->      <button id="12">Play</button>
+      <!-- play/pause -->      <button id="12">PlayPause</button>
 
       <!-- Additional buttons via Harmony Apple TV remote profile - these are also the learned buttons on Apple TV 2gen-->
       <!-- pageup     -->      <button id="13">PageUp</button>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -70,7 +70,7 @@
       <altname>MoSart PS3 Remote Keyboard</altname>
       <button id="4">OSD</button>
       <button id="1">Info</button>
-      <button id="2">Play</button>
+      <button id="2">Pause</button>
       <button id="3">Stop</button>
       <hat    id="1" position="left">SkipPrevious</hat>
       <hat    id="1" position="right">SkipNext</hat>
@@ -91,7 +91,7 @@
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>
       <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="2">Play</button>
+      <button id="2">Pause</button>
       <button id="3">Stop</button>
       <button id="4">OSD</button>
       <button id="7">Rewind</button>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -38,7 +38,7 @@
 <keymap>
   <global>
     <remote>
-      <play>Play</play>
+      <play>PlayPause</play>
       <pause>Pause</pause>
       <stop>Stop</stop>
       <forward>FastForward</forward>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2741,36 +2741,33 @@ bool CApplication::OnAction(const CAction &action)
       return true;
     }
 
-    // pause : pauses current audio song
-    if (action.GetID() == ACTION_PAUSE && m_pPlayer->GetPlaySpeed() == 1)
+    // pause : toggle pause action
+    if (action.GetID() == ACTION_PAUSE)
     {
       m_pPlayer->Pause();
-#ifdef HAS_KARAOKE
+      // go back to normal play speed on unpause
+      if (!m_pPlayer->IsPaused() && m_pPlayer->GetPlaySpeed() != 1)
+        m_pPlayer->SetPlaySpeed(1, g_application.m_muted);
+
+      #ifdef HAS_KARAOKE
       m_pKaraokeMgr->SetPaused( m_pPlayer->IsPaused() );
 #endif
-      if (!m_pPlayer->IsPaused())
-      { // unpaused - set the playspeed back to normal
-        m_pPlayer->SetPlaySpeed(1, g_application.m_muted);
-      }
       g_audioManager.Enable(m_pPlayer->IsPaused());
+      return true;
+    }
+    // play: unpause or set playspeed back to normal
+    if (action.GetID() == ACTION_PLAYER_PLAY)
+    {
+      // if currently paused - unpause
+      if (m_pPlayer->IsPaused())
+        return OnAction(CAction(ACTION_PAUSE));
+      // if we do a FF/RW then go back to normal speed
+      if (m_pPlayer->GetPlaySpeed() != 1)
+        m_pPlayer->SetPlaySpeed(1, g_application.m_muted);
       return true;
     }
     if (!m_pPlayer->IsPaused())
     {
-      // if we do a FF/RW in my music then map PLAY action togo back to normal speed
-      // if we are playing at normal speed, then allow play to pause
-      if (action.GetID() == ACTION_PLAYER_PLAY || action.GetID() == ACTION_PAUSE)
-      {
-        if (m_pPlayer->GetPlaySpeed() != 1)
-        {
-          m_pPlayer->SetPlaySpeed(1, g_application.m_muted);
-        }
-        else
-        {
-          m_pPlayer->Pause();
-        }
-        return true;
-      }
       if (action.GetID() == ACTION_PLAYER_FORWARD || action.GetID() == ACTION_PLAYER_REWIND)
       {
         int iPlaySpeed = m_pPlayer->GetPlaySpeed();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2594,10 +2594,10 @@ bool CApplication::OnAction(const CAction &action)
   }
   
   // The action PLAYPAUSE behaves as ACTION_PAUSE if we are currently
-  // playing or ACTION_PLAYER_PLAY if we are not playing.
+  // playing or ACTION_PLAYER_PLAY if we are seeking (FF/RW) or not playing.
   if (action.GetID() == ACTION_PLAYER_PLAYPAUSE)
   {
-    if (m_pPlayer->IsPlaying())
+    if (m_pPlayer->IsPlaying() && m_pPlayer->GetPlaySpeed() == 1)
       return OnAction(CAction(ACTION_PAUSE));
     else
       return OnAction(CAction(ACTION_PLAYER_PLAY));


### PR DESCRIPTION
Currently, the Play action will also pause playback, which is not in the sense of the Play action (see http://forum.xbmc.org/showthread.php?tid=203347 which I have to agree). If a user want's to have the PlayPause behavior mapped to a key/button, then he should use the PlayPause action instead - that's what we have it for. With PR #5244 I already changed the existing keymaps to use the PlayPause action for play_pause keys in our keymaps - so this change should be save to do and not change behavior for correctly done keymaps.

@MilhouseVH mind adding this to the OE testbuilds to get feedback?
@FernetMenta please check if my change to the pause action handling makes sense (always set playspeed to default)
@jmarshallnz please also have a look if you find the time
