### PR TITLE
X11: fixes

### DIFF
--- a/xbmc/powermanagement/DPMSSupport.cpp
+++ b/xbmc/powermanagement/DPMSSupport.cpp
@@ -174,14 +174,8 @@ bool DPMSSupport::PlatformSpecificDisablePowerSaving()
   DPMSForceLevel(dpy, DPMSModeOn);
   DPMSDisable(dpy);
   XFlush(dpy);
-  // On my ATI, the full-screen window stays blank after waking up from
-  // DPMS, presumably due to being OpenGL. There is something magical about
-  // window expose events (involving the window manager) that solves this
-  // without fail.
-  XUnmapWindow(dpy, g_Windowing.GetWindow());
-  XFlush(dpy);
-  XMapWindow(dpy, g_Windowing.GetWindow());
-  XFlush(dpy);
+
+  g_Windowing.RecreateWindow();
 
   return true;
 }

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -693,7 +693,6 @@ bool CWinSystemX11::Show(bool raise)
 void CWinSystemX11::NotifyXRREvent()
 {
   CLog::Log(LOGDEBUG, "%s - notify display reset event", __FUNCTION__);
-  m_windowDirty = true;
 
   CSingleLock lock(g_graphicsContext);
 
@@ -708,6 +707,15 @@ void CWinSystemX11::NotifyXRREvent()
   {
     UpdateResolutions();
   }
+
+  RecreateWindow();
+}
+
+void CWinSystemX11::RecreateWindow()
+{
+  m_windowDirty = true;
+
+  CSingleLock lock(g_graphicsContext);
 
   XOutput *out = g_xrandr.GetOutput(m_userOutput);
   XMode   mode = g_xrandr.GetCurrentMode(m_userOutput);
@@ -733,7 +741,7 @@ void CWinSystemX11::NotifyXRREvent()
 
   if (!found)
   {
-    CLog::Log(LOGERROR, "CWinSystemX11::RefreshWindow - could not find resolution");
+    CLog::Log(LOGERROR, "CWinSystemX11::RecreateWindow - could not find resolution");
     i = RES_DESKTOP;
   }
 
@@ -741,7 +749,6 @@ void CWinSystemX11::NotifyXRREvent()
     g_graphicsContext.SetVideoResolution((RESOLUTION)i, true);
   else
     g_graphicsContext.SetVideoResolution(RES_WINDOW, true);
-
 }
 
 void CWinSystemX11::OnLostDevice()

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -72,6 +72,7 @@ public:
   void NotifyXRREvent();
   void GetConnectedOutputs(std::vector<CStdString> *outputs);
   bool IsCurrentOutput(CStdString output);
+  void RecreateWindow();
 
 protected:
   bool RefreshGlxContext(bool force);

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -74,7 +74,7 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
   CStdString cmd;
   cmd  = getenv("XBMC_BIN_HOME");
   cmd += "/xbmc-xrandr";
-  cmd = StringUtils::Format("%s -q --screen %d --current", cmd.c_str(), screennum);
+  cmd = StringUtils::Format("%s -q --screen %d", cmd.c_str(), screennum);
 
   FILE* file = popen(cmd.c_str(),"r");
   if (!file)


### PR DESCRIPTION
1) revert  5814e7f which I did on advice of Intel developer Chris Wilson. Looks like the state is not updated as expected. @sraue reported missing modes on system startup.

2) fix wake-up from dpms. With recent Intel drivers the system cursor was visible after wake-up. seems like the state got lost somehow in the driver. the sledge hammer method of recreating the window cures it all.
