### PR TITLE
dvdplayer: do a seek after having changed subtitle stream

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2151,12 +2151,14 @@ void CDVDPlayer::HandleMessages()
             {
               m_dvd.iSelectedSPUStream = -1;
               CloseStream(m_CurrentSubtitle, false);
+              m_messenger.Put(new CDVDMsgPlayerSeek((int)GetTime(), true, true, true, true, true));
             }
           }
           else
           {
             CloseStream(m_CurrentSubtitle, false);
             OpenStream(m_CurrentSubtitle, st.id, st.source);
+            m_messenger.Put(new CDVDMsgPlayerSeek((int)GetTime(), true, true, true, true, true));
           }
         }
       }


### PR DESCRIPTION
@ace20022 this should fix the missing subs after a change of subtitle stream. It is the same we do when changing audio track.
