### PR TITLE
build: make D-Bus configurable

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -164,6 +164,7 @@ spectrum_disabled="== SPECTRUM disabled =="
 goom_enabled="== GOOM enabled. =="
 goom_disabled="== GOOM disabled. =="
 alsa_disabled="== ALSA support disabled. =="
+dbus_disabled="== DBUS support disabled. =="
 rsxs_enabled="== RSXS enabled. =="
 rsxs_disabled="== RSXS disabled. =="
 fishbmc_enabled="== FishBMC enabled. =="
@@ -376,6 +377,12 @@ AC_ARG_ENABLE([alsa],
   [disable ALSA support (only for linux/freebsd)])],
   [use_alsa=$enableval],
   [use_alsa=yes])
+
+AC_ARG_ENABLE([dbus],
+  [AS_HELP_STRING([--disable-dbus],
+  [disable DBUS support])],
+  [use_dbus=$enableval],
+  [use_dbus=yes])
 
 AC_ARG_ENABLE([pulse],
   [AS_HELP_STRING([--enable-pulse],
@@ -1202,10 +1209,14 @@ if test "x$use_alsa" != "xno"; then
     [INCLUDES="$INCLUDES $ALSA_CFLAGS"; LIBS="$LIBS $ALSA_LIBS"; use_alsa=yes],
     AC_MSG_NOTICE($alsa_not_found); use_alsa=no)
 fi
+if test "x$use_dbus" != "xno"; then
   PKG_CHECK_MODULES([DBUS],    [dbus-1],
     [INCLUDES="$INCLUDES $DBUS_CFLAGS"; LIBS="$LIBS $DBUS_LIBS"; use_dbus=yes]; \
     AC_DEFINE([HAVE_DBUS],[1],["Define to 1 if dbus is installed"]),
     AC_MSG_NOTICE($missing_library); use_dbus=no)
+else
+  AC_MSG_NOTICE($dbus_disabled)
+fi
   if test "x$use_sdl" != "xno"; then
     PKG_CHECK_MODULES([SDL],   [sdl],
       [INCLUDES="$INCLUDES $SDL_CFLAGS"; LIBS="$LIBS $SDL_LIBS"],


### PR DESCRIPTION
Hi,

for better inclusion in buildroot an xbmc configure option to disable D-Bus support, even if the target system contains the D-Bus package, is needed. This PR provides the necessary code.

Please read this thread for the background discussion resulting in this PR:
http://thread.gmane.org/gmane.comp.lib.uclibc.buildroot/92503/focus=92511
