### PR TITLE
fixed: keyboard layout blank and double QWERTY entry

### DIFF
--- a/system/keyboardlayouts.xml
+++ b/system/keyboardlayouts.xml
@@ -140,7 +140,7 @@
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="עברית QWERTY">
+  <layout name="Hebrew QWERTY">
     <keyboard>
       <row>1234567890</row>
       <row>קראטוןםפ</row>
@@ -160,7 +160,7 @@
       <row>`~</row>
     </keyboard>
   </layout>
-  <layout name="עברית אבג">
+  <layout name="Hebrew ABC">
     <keyboard>
       <row>0123456789</row>
       <row>יטחזוהדגבא</row>


### PR DESCRIPTION
Since https://github.com/xbmc/xbmc/commit/c68e02a65f644da60d4aeba9091532bc83746c30 there is now a blank entry and a double qwerty entry, because the default fonts dont have these language character support.

There are 3 solutions to this issue

1) @notspiff fix to use a fallback to English with the font13 which is
not what's used in this part of skin.
https://github.com/notspiff/xbmc-cmake/commit/8ca6d81189acb43d1d136935b5013b5f9ae5410c

2) use the modified Roboto fonts I was working on and no longer am, but already has
the Hebrew characters added (correctly or incorrectly idk) /me shrugs.
http://forum.xbmc.org/showthread.php?tid=150067

3) simple, use English names, since default language is English, users
must have some degree of understanding of that and smart enough to know it.

Since I no longer work on that font , nor speak such languages I was
adding characters for and have no desire to extend it from what is done
atm

so 3) This was my solution, both simplest and avoids dealing with niggling issues.
