### PR TITLE
[pvr] fix selecting playing item in PVR windows

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -110,7 +110,7 @@ void CGUIWindowPVRBase::OnInitWindow(void)
 
   // use the path of the current playing channel if no previous selection exists
   // to mark the corresponding item in the list as selected
-  if (m_selectedItemPaths.empty() && g_PVRManager.IsPlaying())
+  if (m_selectedItemPaths.at(m_bRadio).empty() && g_PVRManager.IsPlaying())
     m_selectedItemPaths.at(m_bRadio) = g_application.CurrentFile();
 
   CGUIMediaWindow::OnInitWindow();

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -48,14 +48,14 @@
 using namespace PVR;
 using namespace EPG;
 
-std::map<bool, std::string> CGUIWindowPVRBase::m_selectedItemPath;
+std::map<bool, std::string> CGUIWindowPVRBase::m_selectedItemPaths;
 
 CGUIWindowPVRBase::CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile) :
   CGUIMediaWindow(id, xmlFile.c_str()),
   m_bRadio(bRadio)
 {
-  m_selectedItemPath[false] = "";
-  m_selectedItemPath[true] = "";
+  m_selectedItemPaths[false] = "";
+  m_selectedItemPaths[true] = "";
 }
 
 CGUIWindowPVRBase::~CGUIWindowPVRBase(void)
@@ -110,13 +110,13 @@ void CGUIWindowPVRBase::OnInitWindow(void)
 
   // use the path of the current playing channel if no previous selection exists
   // to mark the corresponding item in the list as selected
-  if (m_selectedItemPath.empty() && g_PVRManager.IsPlaying())
-    m_selectedItemPath.at(m_bRadio) = g_application.CurrentFile();
+  if (m_selectedItemPaths.empty() && g_PVRManager.IsPlaying())
+    m_selectedItemPaths.at(m_bRadio) = g_application.CurrentFile();
 
   CGUIMediaWindow::OnInitWindow();
 
   // mark item as selected by channel path
-  m_viewControl.SetSelectedItem(m_selectedItemPath.at(m_bRadio));
+  m_viewControl.SetSelectedItem(m_selectedItemPaths.at(m_bRadio));
 }
 
 void CGUIWindowPVRBase::OnDeinitWindow(int nextWindowID)
@@ -126,7 +126,7 @@ void CGUIWindowPVRBase::OnDeinitWindow(int nextWindowID)
   {
     CFileItemPtr fileItem = m_vecItems->Get(selectedItem);
     if (fileItem)
-      m_selectedItemPath.at(m_bRadio) = fileItem->GetPath();
+      m_selectedItemPaths.at(m_bRadio) = fileItem->GetPath();
   }
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -90,7 +90,7 @@ namespace PVR
     virtual void ShowRecordingInfo(CFileItem *item);
     virtual bool UpdateEpgForChannel(CFileItem *item);
 
-    static std::map<bool, std::string> m_selectedItemPath;
+    static std::map<bool, std::string> m_selectedItemPaths;
 
     CCriticalSection m_critSection;
     bool m_bRadio;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -111,7 +111,7 @@ void CGUIWindowPVRGuide::OnDeinitWindow(int nextWindowID)
     {
       CPVRChannel* channel = epgGridContainer->GetChannel(epgGridContainer->GetSelectedChannel());
       if (channel != NULL)
-        m_selectedItemPath.at(m_bRadio) = channel->Path();
+        m_selectedItemPaths.at(m_bRadio) = channel->Path();
     }
   }
   else
@@ -293,7 +293,7 @@ void CGUIWindowPVRGuide::UpdateViewNow()
   }
 
   m_viewControl.SetItems(*m_vecItems);
-  m_viewControl.SetSelectedItem(m_selectedItemPath.at(m_bRadio));
+  m_viewControl.SetSelectedItem(m_selectedItemPaths.at(m_bRadio));
 }
 
 void CGUIWindowPVRGuide::UpdateViewNext()
@@ -314,7 +314,7 @@ void CGUIWindowPVRGuide::UpdateViewNext()
   }
 
   m_viewControl.SetItems(*m_vecItems);
-  m_viewControl.SetSelectedItem(m_selectedItemPath.at(m_bRadio));
+  m_viewControl.SetSelectedItem(m_selectedItemPaths.at(m_bRadio));
 }
 
 void CGUIWindowPVRGuide::UpdateViewTimeline()
@@ -360,7 +360,7 @@ void CGUIWindowPVRGuide::UpdateViewTimeline()
   
   m_viewControl.SetItems(*m_vecItems);
 
-  epgGridContainer->SetChannel(m_selectedItemPath.at(m_bRadio));
+  epgGridContainer->SetChannel(m_selectedItemPaths.at(m_bRadio));
 }
 
 bool CGUIWindowPVRGuide::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)


### PR DESCRIPTION
As m_selectedItemPaths is a map we need to check if the corresponding map value is empty instead of the whole map.
