### PR TITLE
[PVR][input] allow custom keymaps also for PVR radio

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -118,6 +118,14 @@
       <dpaddown>ChannelDown</dpaddown>
     </gamepad>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <gamepad>
+      <dpadleft>PreviousChannelGroup</dpadleft>
+      <dpadright>NextChannelGroup</dpadright>
+      <dpadup>ChannelUp</dpadup>
+      <dpaddown>ChannelDown</dpaddown>
+    </gamepad>
+  </FullscreenRadio>
   <FullscreenInfo>
     <gamepad>
       <start>OSD</start>

--- a/system/keymaps/joystick.AppleRemote.xml
+++ b/system/keymaps/joystick.AppleRemote.xml
@@ -120,6 +120,14 @@
       <!-- pagedown   -->      <button id="14">ChannelDown</button>
     </joystick>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <joystick name="AppleRemote">
+      <button id="3">ChannelDown</button>
+      <button id="4">ChannelUp</button>
+      <!-- pageup     -->      <button id="13">ChannelUp</button>
+      <!-- pagedown   -->      <button id="14">ChannelDown</button>
+    </joystick>
+  </FullscreenRadio>
   <Visualisation>
     <joystick name="AppleRemote">
       <button id="1">VolumeUp</button>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -181,6 +181,14 @@
       <!-- right      	-->      <button id="4">NextChannelGroup</button>
     </joystick>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <joystick name="Harmony">
+      <!-- up       	-->      <button id="1">ChannelUp</button>
+      <!-- down      	-->      <button id="2">ChannelDown</button>
+      <!-- left       	-->      <button id="3">PreviousChannelGroup</button>
+      <!-- right      	-->      <button id="4">NextChannelGroup</button>
+    </joystick>
+  </FullscreenRadio>
   <FullscreenInfo>
     <joystick name="Harmony">
       <!-- Info  	-->      <button id="31">Back</button>

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -80,6 +80,17 @@
     </joystick>
   </FullscreenLiveTV>
 
+  <FullscreenRadio>
+    <joystick name="Logitech Logitech Cordless RumblePad 2">
+      <altname>Logitech Cordless RumblePad 2</altname>
+      <altname>Logitech RumblePad 2 USB</altname>
+      <hat    id="1" position="left">PreviousChannelGroup</hat>
+      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="up">ChannelUp</hat>
+      <hat    id="1" position="down">ChannelDown</hat>
+    </joystick>
+  </FullscreenRadio>
+
   <Visualisation>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -397,6 +397,53 @@
       <hat id="1" position="right">NextChannelGroup</hat>
     </joystick>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <joystick name="Controller (XBOX 360 For Windows)">
+      <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>
+      <altname>Controller (Gamepad F310)</altname>
+      <altname>Controller (Gamepad for Xbox 360)</altname>
+      <altname>Controller (Rumble Gamepad F510)</altname>
+      <altname>Controller (Wireless Gamepad F710)</altname>
+      <altname>Controller (Xbox 360 Wireless Receiver for Windows)</altname>
+      <altname>Controller (Xbox wireless receiver for windows)</altname>
+      <altname>Controller (XBOX360 GAMEPAD)</altname>
+      <altname>Controller (Batarang wired controller (XBOX))</altname>
+      <altname>Wireless Gamepad F710 (Controller)</altname>
+      <altname>XBOX 360 For Windows</altname>
+      <altname>XBOX 360 For Windows (Controller)</altname>
+      <altname>Xbox 360 Wireless Controller</altname>
+      <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
+      <altname>Xbox wireless receiver for windows (Controller)</altname>
+      <altname>Gamepad F310 (Controller)</altname>
+      <button id="11">ChannelUp</button>
+      <button id="12">ChannelDown</button>
+      <button id="13">PreviousChannelGroup</button>
+      <button id="14">NextChannelGroup</button>
+      <hat id="1" position="up">ChannelUp</hat>
+      <hat id="1" position="down">ChannelDown</hat>
+      <hat id="1" position="left">PreviousChannelGroup</hat>
+      <hat id="1" position="right">NextChannelGroup</hat>
+    </joystick>
+    <joystick name="Microsoft X-Box 360 pad">
+      <altname>BigBen Interactive XBOX 360 Controller</altname>
+      <altname>Generic X-Box pad</altname>
+      <altname>Logitech Chillstream Controller</altname>
+      <altname>Mad Catz Wired Xbox 360 Controller</altname>
+      <altname>Mad Catz Wired Xbox 360 Controller (SFIV)</altname>
+      <altname>Pelican 'TSZ' Wired Xbox 360 Controller</altname>
+      <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
+      <altname>Xbox 360 Wireless Receiver</altname>
+      <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <button id="12">PreviousChannelGroup</button>
+      <button id="13">NextChannelGroup</button>
+      <button id="14">ChannelUp</button>
+      <button id="15">ChannelDown</button>
+      <hat id="1" position="up">ChannelUp</hat>
+      <hat id="1" position="down">ChannelDown</hat>
+      <hat id="1" position="left">PreviousChannelGroup</hat>
+      <hat id="1" position="right">NextChannelGroup</hat>
+    </joystick>
+  </FullscreenRadio>
   <FullscreenInfo>
     <joystick name="Controller (XBOX 360 For Windows)">
       <altname>Afterglow Gamepad for Xbox 360 (Controller)</altname>

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -140,6 +140,17 @@
       <button id="16">PreviousChannelGroup</button>
     </joystick>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <joystick name="Microsoft Xbox Controller S">
+      <altname>Mad Catz MicroCON</altname>
+      <altname>Logitech Xbox Cordless Controller</altname>
+      <altname>Microsoft X-Box pad (Japan)</altname> 
+      <button id="13">ChannelUp</button>
+      <button id="14">NextChannelGroup</button>
+      <button id="15">ChannelDown</button>
+      <button id="16">PreviousChannelGroup</button>
+    </joystick>
+  </FullscreenRadio>
   <FullscreenInfo>
     <joystick name="Microsoft Xbox Controller S">
       <altname>Mad Catz MicroCON</altname>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -112,6 +112,15 @@
     </joystick>
   </FullscreenLiveTV>
 
+  <FullscreenRadio>
+    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
+      <hat    id="1" position="left">PreviousChannelGroup</hat>
+      <hat    id="1" position="right">NextChannelGroup</hat>
+      <hat    id="1" position="up">ChannelUp</hat>
+      <hat    id="1" position="down">ChannelDown</hat>
+    </joystick>
+  </FullscreenRadio>
+
   <VideoOSD>
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>

--- a/system/keymaps/joystick.WiiRemote.xml
+++ b/system/keymaps/joystick.WiiRemote.xml
@@ -107,6 +107,12 @@
       <button id="4">ChannelUp</button>
     </joystick>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <joystick name="WiiRemote">
+      <button id="3">ChannelDown</button>
+      <button id="4">ChannelUp</button>
+    </joystick>
+  </FullscreenRadio>
   <FullscreenInfo>
     <joystick name="WiiRemote">
       <button id="5">CodecInfo</button>

--- a/system/keymaps/joystick.xml.sample
+++ b/system/keymaps/joystick.xml.sample
@@ -134,6 +134,18 @@
       <hat id="1" position="right">NextChannelGroup</hat>
     </joystick>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <joystick>
+      <button id="11">ChannelUp</button>
+      <button id="12">ChannelDown</button>
+      <button id="13">PreviousChannelGroup</button>
+      <button id="14">NextChannelGroup</button>
+      <hat id="1" position="up">ChannelUp</hat>
+      <hat id="1" position="down">ChannelDown</hat>
+      <hat id="1" position="left">PreviousChannelGroup</hat>
+      <hat id="1" position="right">NextChannelGroup</hat>
+    </joystick>
+  </FullscreenRadio>
   <FullscreenInfo>
     <joystick>
       <button id="2">Close</button>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -529,6 +529,14 @@
       <down>ChannelDown</down>
     </keyboard>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <keyboard>
+      <left>PreviousChannelGroup</left>
+      <right>NextChannelGroup</right>
+      <up>ChannelUp</up>
+      <down>ChannelDown</down>
+    </keyboard>
+  </FullscreenRadio>
   <PVROSDChannels>
     <keyboard>
       <backspace>Close</backspace>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -542,6 +542,14 @@
       <down>ChannelDown</down>
     </remote>
   </FullscreenLiveTV>
+  <FullscreenRadio>
+    <remote>
+      <left>StepBack</left>
+      <right>StepForward</right>
+      <up>ChannelUp</up>
+      <down>ChannelDown</down>
+    </remote>
+  </FullscreenRadio>
   <PVROSDChannels>
     <remote>
       <back>Close</back>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2352,7 +2352,7 @@ bool CApplication::OnKey(const CKey& key)
   g_Mouse.SetActive(false);
 
   // get the current active window
-  int iWin = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
+  int iWin = GetActiveWindowID();
 
   // this will be checked for certain keycodes that need
   // special handling if the screensaver is active
@@ -2386,48 +2386,7 @@ bool CApplication::OnKey(const CKey& key)
     return true;
   }
 
-  // change this if we have a dialog up
-  if (g_windowManager.HasModalDialog())
-  {
-    iWin = g_windowManager.GetTopMostModalDialogID() & WINDOW_ID_MASK;
-  }
-  if (iWin == WINDOW_DIALOG_FULLSCREEN_INFO)
-  { // fullscreen info dialog - special case
-    action = CButtonTranslator::GetInstance().GetAction(iWin, key);
-
-    if (!key.IsAnalogButton())
-      CLog::LogF(LOGDEBUG, "%s pressed, trying fullscreen info action %s", g_Keyboard.GetKeyName((int) key.GetButtonCode()).c_str(), action.GetName().c_str());
-
-    if (OnAction(action))
-      return true;
-
-    // fallthrough to the main window
-    iWin = WINDOW_FULLSCREEN_VIDEO;
-  }
-  if (iWin == WINDOW_FULLSCREEN_VIDEO)
-  {
-    // current active window is full screen video.
-    if (g_application.m_pPlayer->IsInMenu())
-    {
-      // if player is in some sort of menu, (ie DVDMENU) map buttons differently
-      action = CButtonTranslator::GetInstance().GetAction(WINDOW_VIDEO_MENU, key);
-    }
-    else if (g_PVRManager.IsStarted() && g_application.CurrentFileItem().HasPVRChannelInfoTag())
-    {
-      // check for PVR specific keymaps in FULLSCREEN_VIDEO window
-      action = CButtonTranslator::GetInstance().GetAction(WINDOW_FULLSCREEN_LIVETV, key, false);
-
-      // if no PVR specific action/mapping is found, fall back to default
-      if (action.GetID() == 0)
-        action = CButtonTranslator::GetInstance().GetAction(iWin, key);
-    }
-    else
-    {
-      // in any other case use the fullscreen window section of keymap.xml to map key->action
-      action = CButtonTranslator::GetInstance().GetAction(iWin, key);
-    }
-  }
-  else
+  if (iWin != WINDOW_FULLSCREEN_VIDEO)
   {
     // current active window isnt the fullscreen window
     // just use corresponding section from keymap.xml

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -521,46 +521,8 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
         actionId = newEvent.touch.action;
       else
       {
-        int iWin = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
-        // change this if we have a dialog up
-        if (g_windowManager.HasModalDialog())
-        {
-          iWin = g_windowManager.GetTopMostModalDialogID() & WINDOW_ID_MASK;
-        }
-        if (iWin == WINDOW_DIALOG_FULLSCREEN_INFO)
-        { // fullscreen info dialog - special case
-          CButtonTranslator::GetInstance().TranslateTouchAction(iWin, newEvent.touch.action, newEvent.touch.pointers, actionId);
-          if (actionId <= 0)
-            iWin = WINDOW_FULLSCREEN_VIDEO;  // fallthrough to the main window
-        }
-        if (actionId <= 0)
-        {
-          if (iWin == WINDOW_FULLSCREEN_VIDEO)
-          {
-            // current active window is full screen video.
-            if (g_application.m_pPlayer->IsInMenu())
-            {
-              // if player is in some sort of menu, (ie DVDMENU) map buttons differently
-              CButtonTranslator::GetInstance().TranslateTouchAction(WINDOW_VIDEO_MENU, newEvent.touch.action, newEvent.touch.pointers, actionId);
-            }
-            else if (g_PVRManager.IsStarted() && g_application.CurrentFileItem().HasPVRChannelInfoTag())
-            {
-              // check for PVR specific keymaps in FULLSCREEN_VIDEO window
-              CButtonTranslator::GetInstance().TranslateTouchAction(WINDOW_FULLSCREEN_LIVETV, newEvent.touch.action, newEvent.touch.pointers, actionId);
-
-              // if no PVR specific action/mapping is found, fall back to default
-              if (actionId <= 0)
-                CButtonTranslator::GetInstance().TranslateTouchAction(iWin, newEvent.touch.action, newEvent.touch.pointers, actionId);
-            }
-            else
-            {
-              // in any other case use the fullscreen window section of keymap.xml to map key->action
-              CButtonTranslator::GetInstance().TranslateTouchAction(iWin, newEvent.touch.action, newEvent.touch.pointers, actionId);
-            }
-          }
-          else  // iWin != WINDOW_FULLSCREEN_VIDEO
-            CButtonTranslator::GetInstance().TranslateTouchAction(iWin, newEvent.touch.action, newEvent.touch.pointers, actionId);
-        }
+        int iWin = g_application.GetActiveWindowID();
+        CButtonTranslator::GetInstance().TranslateTouchAction(iWin, newEvent.touch.action, newEvent.touch.pointers, actionId);
       }
 
       if (actionId <= 0)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3261,6 +3261,9 @@ int CApplication::GetActiveWindowID(void)
     else if (g_PVRManager.IsStarted() && g_application.CurrentFileItem().HasPVRChannelInfoTag())
       iWin = WINDOW_FULLSCREEN_LIVETV;
   }
+  // special casing for PVR radio
+  if (iWin == WINDOW_VISUALISATION && g_PVRManager.IsStarted() && g_application.CurrentFileItem().HasPVRChannelInfoTag())
+    iWin = WINDOW_FULLSCREEN_RADIO;
 
   // Return the window id
   return iWin;

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -136,6 +136,7 @@
 #define WINDOW_RADIO_GUIDE                10622
 #define WINDOW_RADIO_TIMERS               10623
 #define WINDOW_RADIO_SEARCH               10624
+#define WINDOW_FULLSCREEN_RADIO           10625 // virtual window for PVR radio specific keymaps with fallback to WINDOW_VISUALISATION
 
 //#define WINDOW_VIRTUAL_KEYBOARD           11000
 #define WINDOW_DIALOG_SELECT              12000

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -905,7 +905,13 @@ bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int to
 
   action = GetTouchActionCode(window, touchAction);
   if (action <= 0)
-    action = GetTouchActionCode(-1, touchAction);
+  {
+    int fallbackWindow = GetFallbackWindow(window);
+    if (fallbackWindow > -1)
+      action = GetTouchActionCode(fallbackWindow, touchAction);
+    if (action <= 0)
+      action = GetTouchActionCode(-1, touchAction);
+  }
 
   return action > 0;
 }

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -380,6 +380,7 @@ static const ActionMapping windows[] =
         {"textviewer"               , WINDOW_DIALOG_TEXT_VIEWER},
         {"fullscreenvideo"          , WINDOW_FULLSCREEN_VIDEO},
         {"fullscreenlivetv"         , WINDOW_FULLSCREEN_LIVETV}, // virtual window/keymap section for PVR specific bindings in fullscreen playback (which internally uses WINDOW_FULLSCREEN_VIDEO)
+        {"fullscreenradio"          , WINDOW_FULLSCREEN_RADIO}, // virtual window for fullscreen radio, uses WINDOW_VISUALISATION as fallback
         {"visualisation"            , WINDOW_VISUALISATION},
         {"slideshow"                , WINDOW_SLIDESHOW},
         {"filestackingdialog"       , WINDOW_DIALOG_FILESTACKING},
@@ -429,7 +430,8 @@ static const ActionMapping touchcommands[] =
 static const WindowMapping fallbackWindows[] =
 {
   { WINDOW_FULLSCREEN_LIVETV,          WINDOW_FULLSCREEN_VIDEO },
-  { WINDOW_DIALOG_FULLSCREEN_INFO,     WINDOW_FULLSCREEN_VIDEO }
+  { WINDOW_DIALOG_FULLSCREEN_INFO,     WINDOW_FULLSCREEN_VIDEO },
+  { WINDOW_FULLSCREEN_RADIO,           WINDOW_VISUALISATION    }
 };
 
 #ifdef TARGET_WINDOWS


### PR DESCRIPTION
this is an alternative approach for #5254 by simplifying and unifying how fallback windows are handled when resolving keymaps and adding a custom fallback strategy for PVR radio on top of that.

I tested the unification/simplification changes for keyboard keymaps (video_menu, fullscreen_info) and they work just like before (as expected), so same should be the case for touch devices which was just a copy of the cApp::onKey() code.
