### PR TITLE
[gui] GUIFontTTF: allow loading fonts from any supported VFS, remove nee...

### DIFF
--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -27,6 +27,8 @@
  *
  */
 
+#include "utils/auto_buffer.h"
+
 // forward definition
 class CBaseTexture;
 
@@ -166,6 +168,7 @@ protected:
   static int justification_word_weight;
 
   CStdString m_strFileName;
+  XUTILS::auto_buffer m_fontFileInMemory; // used only in some cases, see CFreeTypeLibrary::GetFont()
 
 private:
   CGUIFontTTFBase(const CGUIFontTTFBase&);


### PR DESCRIPTION
...d for custom patch for freetype on win32

Primary purpose of this PR is ability to remove custom patch from Freetype on win32 (remove usage of open_utf8()).
As side effect - this allow to use fonts stored on various VFS on any platforms.
