### PR TITLE
Video info scanner refactoring

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -64,8 +64,6 @@ namespace VIDEO
     m_handle = NULL;
     m_showDialog = false;
     m_bCanInterrupt = false;
-    m_currentItem = 0;
-    m_itemCount = 0;
     m_bClean = false;
     m_scanAll = false;
   }
@@ -94,10 +92,6 @@ namespace VIDEO
 
       CLog::Log(LOGNOTICE, "VideoInfoScanner: Starting scan ..");
       ANNOUNCEMENT::CAnnouncementManager::Get().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnScanStarted");
-
-      // Reset progress vars
-      m_currentItem = 0;
-      m_itemCount = -1;
 
       SetPriority(GetMinPriority());
 
@@ -167,7 +161,6 @@ namespace VIDEO
 
   void CVideoInfoScanner::Start(const CStdString& strDirectory, bool scanAll)
   {
-    m_strStartDir = strDirectory;
     m_scanAll = scanAll;
     m_pathsToScan.clear();
     m_pathsToClean.clear();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -378,11 +378,7 @@ namespace VIDEO
     if (it != m_pathsToScan.end())
       m_pathsToScan.erase(it);
 
-    // load subfolder
-    CFileItemList items;
     bool foundDirectly = false;
-    bool bSkip = false;
-
     SScanSettings settings;
     ScraperPtr info = m_database.GetScraperForPath(strDirectory, settings, foundDirectly);
     CONTENT_TYPE content = info ? info->Content() : CONTENT_NONE;
@@ -391,7 +387,6 @@ namespace VIDEO
     if (content == CONTENT_NONE || ignoreFolder)
       return true;
 
-    CStdString hash, dbHash;
     if (content == CONTENT_MOVIES ||content == CONTENT_MUSICVIDEOS)
     {
       if (m_handle)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -271,7 +271,7 @@ namespace VIDEO
     {
       if (RetrieveVideoInfo(items, settings.parent_name_root, content))
       {
-        if (!m_bStop && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
+        if (!m_bStop)
         {
           m_database.SetPathHash(strDirectory, hash);
           if (m_bClean)
@@ -286,7 +286,7 @@ namespace VIDEO
         CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
       }
     }
-    else if (hash != dbHash && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
+    else if (hash != dbHash)
     { // update the hash either way - we may have changed the hash to a fast version
       m_database.SetPathHash(strDirectory, hash);
     }
@@ -302,8 +302,7 @@ namespace VIDEO
         break;
 
       // if we have a directory item (non-playlist) we then recurse into that folder
-      // do not recurse for tv shows - we have already looked recursively for episodes
-      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0 && content != CONTENT_TVSHOWS)
+      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0)
       {
         if (!DoScan(pItem->GetPath()))
         {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -328,14 +328,14 @@ namespace VIDEO
       CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
       items.SetPath(strDirectory);
       GetPathHash(items, hash);
-      bSkip = true;
-      if (!m_database.GetPathHash(strDirectory, dbHash) || dbHash != hash)
+
+      if (m_database.GetPathHash(strDirectory, dbHash) && dbHash == hash)
       {
-        m_database.SetPathHash(strDirectory, hash);
-        bSkip = false;
+        bSkip = true;
+        items.Clear();
       }
       else
-        items.Clear();
+        m_database.SetPathHash(strDirectory, hash);
     }
     else
     {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -387,21 +387,15 @@ namespace VIDEO
     if (content == CONTENT_NONE || ignoreFolder)
       return true;
 
+    if (m_handle)
+    {
+      int msg = (content == CONTENT_MOVIES) ? 20317 : (content == CONTENT_MUSICVIDEOS ? 20318 : 20319);
+      m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(msg).c_str(), info->Name().c_str()));
+    }
+
     if (content == CONTENT_MOVIES ||content == CONTENT_MUSICVIDEOS)
-    {
-      if (m_handle)
-      {
-        int str = content == CONTENT_MOVIES ? 20317:20318;
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str).c_str(), info->Name().c_str()));
-      }
       return ScanMovieFolder(strDirectory, settings, content);
-    }
-    else
-    {
-      if (m_handle)
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
-      return ScanTVFolder(strDirectory, settings.parent_name_root, foundDirectly);
-    }
+    return ScanTVFolder(strDirectory, settings.parent_name_root, foundDirectly);
   }
 
   bool CVideoInfoScanner::RetrieveVideoInfo(CFileItemList& items, bool bDirNames, CONTENT_TYPE content, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -212,13 +212,6 @@ namespace VIDEO
     m_bRunning = false;
   }
 
-  static void OnDirectoryScanned(const CStdString& strDirectory)
-  {
-    CGUIMessage msg(GUI_MSG_DIRECTORY_SCANNED, 0, 0, 0);
-    msg.SetStringParam(strDirectory);
-    g_windowManager.SendThreadMessage(msg);
-  }
-
   bool CVideoInfoScanner::ScanMovieFolder(const CStdString& strDirectory, const SScanSettings& settings, CONTENT_TYPE content)
   {
     const vector<string> &regexps = g_advancedSettings.m_moviesExcludeFromScanRegExps;
@@ -291,9 +284,6 @@ namespace VIDEO
       m_database.SetPathHash(strDirectory, hash);
     }
 
-    if (m_handle)
-      OnDirectoryScanned(strDirectory);
-
     for (int i = 0; i < items.Size(); ++i)
     {
       CFileItemPtr pItem = items[i];
@@ -355,9 +345,6 @@ namespace VIDEO
         CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
       }
     }
-
-    if (m_handle)
-      OnDirectoryScanned(strDirectory);
 
     return !m_bStop;
   }
@@ -727,9 +714,6 @@ namespace VIDEO
       if (bSkip)
       {
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '%s' due to no change", CURL::GetRedacted(item->GetPath()).c_str());
-        // update our dialog with our progress
-        if (m_handle)
-          OnDirectoryScanned(item->GetPath());
         return false;
       }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -349,48 +349,17 @@ namespace VIDEO
 
     if (!bSkip)
     {
-      if (RetrieveVideoInfo(items, settings.parent_name_root, CONTENT_TVSHOWS))
-      {
-        if (!m_bStop && (CONTENT_TVSHOWS == CONTENT_MOVIES || CONTENT_TVSHOWS == CONTENT_MUSICVIDEOS))
-        {
-          m_database.SetPathHash(strDirectory, hash);
-          if (m_bClean)
-            m_pathsToClean.insert(m_database.GetPathId(strDirectory));
-          CLog::Log(LOGDEBUG, "VideoInfoScanner: Finished adding information from dir %s", CURL::GetRedacted(strDirectory).c_str());
-        }
-      }
-      else
+      if (!RetrieveVideoInfo(items, settings.parent_name_root, CONTENT_TVSHOWS))
       {
         if (m_bClean)
           m_pathsToClean.insert(m_database.GetPathId(strDirectory));
         CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
       }
     }
-    else if (hash != dbHash && (CONTENT_TVSHOWS == CONTENT_MOVIES || CONTENT_TVSHOWS == CONTENT_MUSICVIDEOS))
-    { // update the hash either way - we may have changed the hash to a fast version
-      m_database.SetPathHash(strDirectory, hash);
-    }
 
     if (m_handle)
       OnDirectoryScanned(strDirectory);
 
-    for (int i = 0; i < items.Size(); ++i)
-    {
-      CFileItemPtr pItem = items[i];
-
-      if (m_bStop)
-        break;
-
-      // if we have a directory item (non-playlist) we then recurse into that folder
-      // do not recurse for tv shows - we have already looked recursively for episodes
-      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0 && CONTENT_TVSHOWS != CONTENT_TVSHOWS)
-      {
-        if (!DoScan(pItem->GetPath()))
-        {
-          m_bStop = true;
-        }
-      }
-    }
     return !m_bStop;
   }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -313,7 +313,7 @@ namespace VIDEO
     return !m_bStop;
   }
 
-  bool CVideoInfoScanner::ScanTVFolder(const CStdString& strDirectory, const SScanSettings& settings, bool foundDirectly)
+  bool CVideoInfoScanner::ScanTVFolder(const CStdString& strDirectory, bool useDirNames, bool foundDirectly)
   {
     const vector<string> &regexps =  g_advancedSettings.m_tvshowExcludeFromScanRegExps;
     if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
@@ -323,7 +323,7 @@ namespace VIDEO
     bool bSkip = false;
     CStdString hash, dbHash;
 
-    if (foundDirectly && !settings.parent_name_root)
+    if (foundDirectly && !useDirNames)
     {
       CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
       items.SetPath(strDirectory);
@@ -348,7 +348,7 @@ namespace VIDEO
 
     if (!bSkip)
     {
-      if (!RetrieveVideoInfo(items, settings.parent_name_root, CONTENT_TVSHOWS))
+      if (!RetrieveVideoInfo(items, useDirNames, CONTENT_TVSHOWS))
       {
         if (m_bClean)
           m_pathsToClean.insert(m_database.GetPathId(strDirectory));
@@ -405,7 +405,7 @@ namespace VIDEO
     {
       if (m_handle)
         m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
-      return ScanTVFolder(strDirectory, settings, foundDirectly);
+      return ScanTVFolder(strDirectory, settings.parent_name_root, foundDirectly);
     }
   }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -402,58 +402,12 @@ namespace VIDEO
       }
       return ScanMovieFolder(strDirectory, settings, content);
     }
-    else if (content == CONTENT_TVSHOWS)
+    else
     {
       if (m_handle)
         m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
       return ScanTVFolder(strDirectory, settings, foundDirectly);
     }
-
-    if (!bSkip)
-    {
-      if (RetrieveVideoInfo(items, settings.parent_name_root, content))
-      {
-        if (!m_bStop && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
-        {
-          m_database.SetPathHash(strDirectory, hash);
-          if (m_bClean)
-            m_pathsToClean.insert(m_database.GetPathId(strDirectory));
-          CLog::Log(LOGDEBUG, "VideoInfoScanner: Finished adding information from dir %s", CURL::GetRedacted(strDirectory).c_str());
-        }
-      }
-      else
-      {
-        if (m_bClean)
-          m_pathsToClean.insert(m_database.GetPathId(strDirectory));
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
-      }
-    }
-    else if (hash != dbHash && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
-    { // update the hash either way - we may have changed the hash to a fast version
-      m_database.SetPathHash(strDirectory, hash);
-    }
-
-    if (m_handle)
-      OnDirectoryScanned(strDirectory);
-
-    for (int i = 0; i < items.Size(); ++i)
-    {
-      CFileItemPtr pItem = items[i];
-
-      if (m_bStop)
-        break;
-
-      // if we have a directory item (non-playlist) we then recurse into that folder
-      // do not recurse for tv shows - we have already looked recursively for episodes
-      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0 && content != CONTENT_TVSHOWS)
-      {
-        if (!DoScan(pItem->GetPath()))
-        {
-          m_bStop = true;
-        }
-      }
-    }
-    return !m_bStop;
   }
 
   bool CVideoInfoScanner::RetrieveVideoInfo(CFileItemList& items, bool bDirNames, CONTENT_TYPE content, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress)

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -126,7 +126,7 @@ namespace VIDEO
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
     bool ScanMovieFolder(const CStdString& strDirectory, const SScanSettings& settings, CONTENT_TYPE content);
-    bool ScanTVFolder(const CStdString& strDirectory, const SScanSettings& settings, bool foundDirectly);
+    bool ScanTVFolder(const CStdString& strDirectory, bool useDirNames, bool foundDirectly);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -245,13 +245,10 @@ namespace VIDEO
 
     bool m_showDialog;
     CGUIDialogProgressBarHandle* m_handle;
-    int m_currentItem;
-    int m_itemCount;
     bool m_bRunning;
     bool m_bCanInterrupt;
     bool m_bClean;
     bool m_scanAll;
-    CStdString m_strStartDir;
     CVideoDatabase m_database;
     std::set<CStdString> m_pathsToScan;
     std::set<CStdString> m_pathsToCount;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -125,6 +125,7 @@ namespace VIDEO
   protected:
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
+    bool ScanMovieFolder(const CStdString& strDirectory, const SScanSettings& settings, CONTENT_TYPE content);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -126,6 +126,7 @@ namespace VIDEO
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
     bool ScanMovieFolder(const CStdString& strDirectory, const SScanSettings& settings, CONTENT_TYPE content);
+    bool ScanTVFolder(const CStdString& strDirectory, const SScanSettings& settings, bool foundDirectly);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);


### PR DESCRIPTION
This is an attempt at untangling this spaghetti. Scanning movie folders vs tv folders hardly have anything in common at this point, making it impossible to follow. Please see individual commits for step-by-step.

If I have done this correctly, there should be no bug fixes or behavior changes in these commits.
