### PR TITLE
Video info scanner: fix incorrect skipping of directories

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -378,11 +378,7 @@ namespace VIDEO
     if (it != m_pathsToScan.end())
       m_pathsToScan.erase(it);
 
-    // load subfolder
-    CFileItemList items;
     bool foundDirectly = false;
-    bool bSkip = false;
-
     SScanSettings settings;
     ScraperPtr info = m_database.GetScraperForPath(strDirectory, settings, foundDirectly);
     CONTENT_TYPE content = info ? info->Content() : CONTENT_NONE;
@@ -391,7 +387,6 @@ namespace VIDEO
     if (content == CONTENT_NONE || ignoreFolder)
       return true;
 
-    CStdString hash, dbHash;
     if (content == CONTENT_MOVIES ||content == CONTENT_MUSICVIDEOS)
     {
       if (m_handle)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -271,7 +271,7 @@ namespace VIDEO
     {
       if (RetrieveVideoInfo(items, settings.parent_name_root, content))
       {
-        if (!m_bStop && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
+        if (!m_bStop)
         {
           m_database.SetPathHash(strDirectory, hash);
           if (m_bClean)
@@ -286,7 +286,7 @@ namespace VIDEO
         CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
       }
     }
-    else if (hash != dbHash && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
+    else if (hash != dbHash)
     { // update the hash either way - we may have changed the hash to a fast version
       m_database.SetPathHash(strDirectory, hash);
     }
@@ -302,8 +302,7 @@ namespace VIDEO
         break;
 
       // if we have a directory item (non-playlist) we then recurse into that folder
-      // do not recurse for tv shows - we have already looked recursively for episodes
-      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0 && content != CONTENT_TVSHOWS)
+      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0)
       {
         if (!DoScan(pItem->GetPath()))
         {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -328,14 +328,14 @@ namespace VIDEO
       CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
       items.SetPath(strDirectory);
       GetPathHash(items, hash);
-      bSkip = true;
-      if (!m_database.GetPathHash(strDirectory, dbHash) || dbHash != hash)
+
+      if (m_database.GetPathHash(strDirectory, dbHash) && dbHash == hash)
       {
-        m_database.SetPathHash(strDirectory, hash);
-        bSkip = false;
+        bSkip = true;
+        items.Clear();
       }
       else
-        items.Clear();
+        m_database.SetPathHash(strDirectory, hash);
     }
     else
     {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -387,21 +387,15 @@ namespace VIDEO
     if (content == CONTENT_NONE || ignoreFolder)
       return true;
 
+    if (m_handle)
+    {
+      int msg = (content == CONTENT_MOVIES) ? 20317 : (content == CONTENT_MUSICVIDEOS ? 20318 : 20319);
+      m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(msg).c_str(), info->Name().c_str()));
+    }
+
     if (content == CONTENT_MOVIES ||content == CONTENT_MUSICVIDEOS)
-    {
-      if (m_handle)
-      {
-        int str = content == CONTENT_MOVIES ? 20317:20318;
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str).c_str(), info->Name().c_str()));
-      }
       return ScanMovieFolder(strDirectory, settings, content);
-    }
-    else
-    {
-      if (m_handle)
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
-      return ScanTVFolder(strDirectory, settings.parent_name_root, foundDirectly);
-    }
+    return ScanTVFolder(strDirectory, settings.parent_name_root, foundDirectly);
   }
 
   bool CVideoInfoScanner::RetrieveVideoInfo(CFileItemList& items, bool bDirNames, CONTENT_TYPE content, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -349,10 +349,7 @@ namespace VIDEO
 
     if (!bSkip)
     {
-      if (RetrieveVideoInfo(items, settings.parent_name_root, CONTENT_TVSHOWS))
-      {
-      }
-      else
+      if (!RetrieveVideoInfo(items, settings.parent_name_root, CONTENT_TVSHOWS))
       {
         if (m_bClean)
           m_pathsToClean.insert(m_database.GetPathId(strDirectory));

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -321,22 +321,10 @@ namespace VIDEO
       return true;
 
     CFileItemList items;
-    bool bSkip = false;
-    CStdString hash, dbHash;
-
     if (foundDirectly && !useDirNames)
     {
       CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
       items.SetPath(strDirectory);
-      GetPathHash(items, hash);
-
-      if (m_database.GetPathHash(strDirectory, dbHash) && dbHash == hash)
-      {
-        bSkip = true;
-        items.Clear();
-      }
-      else
-        m_database.SetPathHash(strDirectory, hash);
     }
     else
     {
@@ -347,14 +335,11 @@ namespace VIDEO
       items.SetPath(URIUtils::GetParentPath(item->GetPath()));
     }
 
-    if (!bSkip)
+    if (!RetrieveVideoInfo(items, useDirNames, CONTENT_TVSHOWS))
     {
-      if (!RetrieveVideoInfo(items, useDirNames, CONTENT_TVSHOWS))
-      {
-        if (m_bClean)
-          m_pathsToClean.insert(m_database.GetPathId(strDirectory));
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
-      }
+      if (m_bClean)
+        m_pathsToClean.insert(m_database.GetPathId(strDirectory));
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
     }
 
     if (m_handle)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -351,13 +351,6 @@ namespace VIDEO
     {
       if (RetrieveVideoInfo(items, settings.parent_name_root, CONTENT_TVSHOWS))
       {
-        if (!m_bStop && (CONTENT_TVSHOWS == CONTENT_MOVIES || CONTENT_TVSHOWS == CONTENT_MUSICVIDEOS))
-        {
-          m_database.SetPathHash(strDirectory, hash);
-          if (m_bClean)
-            m_pathsToClean.insert(m_database.GetPathId(strDirectory));
-          CLog::Log(LOGDEBUG, "VideoInfoScanner: Finished adding information from dir %s", CURL::GetRedacted(strDirectory).c_str());
-        }
       }
       else
       {
@@ -366,31 +359,10 @@ namespace VIDEO
         CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
       }
     }
-    else if (hash != dbHash && (CONTENT_TVSHOWS == CONTENT_MOVIES || CONTENT_TVSHOWS == CONTENT_MUSICVIDEOS))
-    { // update the hash either way - we may have changed the hash to a fast version
-      m_database.SetPathHash(strDirectory, hash);
-    }
 
     if (m_handle)
       OnDirectoryScanned(strDirectory);
 
-    for (int i = 0; i < items.Size(); ++i)
-    {
-      CFileItemPtr pItem = items[i];
-
-      if (m_bStop)
-        break;
-
-      // if we have a directory item (non-playlist) we then recurse into that folder
-      // do not recurse for tv shows - we have already looked recursively for episodes
-      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0 && CONTENT_TVSHOWS != CONTENT_TVSHOWS)
-      {
-        if (!DoScan(pItem->GetPath()))
-        {
-          m_bStop = true;
-        }
-      }
-    }
     return !m_bStop;
   }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -313,7 +313,7 @@ namespace VIDEO
     return !m_bStop;
   }
 
-  bool CVideoInfoScanner::ScanTVFolder(const CStdString& strDirectory, const SScanSettings& settings, bool foundDirectly)
+  bool CVideoInfoScanner::ScanTVFolder(const CStdString& strDirectory, bool useDirNames, bool foundDirectly)
   {
     const vector<string> &regexps =  g_advancedSettings.m_tvshowExcludeFromScanRegExps;
     if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
@@ -323,7 +323,7 @@ namespace VIDEO
     bool bSkip = false;
     CStdString hash, dbHash;
 
-    if (foundDirectly && !settings.parent_name_root)
+    if (foundDirectly && !useDirNames)
     {
       CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
       items.SetPath(strDirectory);
@@ -348,7 +348,7 @@ namespace VIDEO
 
     if (!bSkip)
     {
-      if (!RetrieveVideoInfo(items, settings.parent_name_root, CONTENT_TVSHOWS))
+      if (!RetrieveVideoInfo(items, useDirNames, CONTENT_TVSHOWS))
       {
         if (m_bClean)
           m_pathsToClean.insert(m_database.GetPathId(strDirectory));
@@ -405,7 +405,7 @@ namespace VIDEO
     {
       if (m_handle)
         m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
-      return ScanTVFolder(strDirectory, settings, foundDirectly);
+      return ScanTVFolder(strDirectory, settings.parent_name_root, foundDirectly);
     }
   }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -402,58 +402,12 @@ namespace VIDEO
       }
       return ScanMovieFolder(strDirectory, settings, content);
     }
-    else if (content == CONTENT_TVSHOWS)
+    else
     {
       if (m_handle)
         m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319).c_str(), info->Name().c_str()));
       return ScanTVFolder(strDirectory, settings, foundDirectly);
     }
-
-    if (!bSkip)
-    {
-      if (RetrieveVideoInfo(items, settings.parent_name_root, content))
-      {
-        if (!m_bStop && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
-        {
-          m_database.SetPathHash(strDirectory, hash);
-          if (m_bClean)
-            m_pathsToClean.insert(m_database.GetPathId(strDirectory));
-          CLog::Log(LOGDEBUG, "VideoInfoScanner: Finished adding information from dir %s", CURL::GetRedacted(strDirectory).c_str());
-        }
-      }
-      else
-      {
-        if (m_bClean)
-          m_pathsToClean.insert(m_database.GetPathId(strDirectory));
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", CURL::GetRedacted(strDirectory).c_str());
-      }
-    }
-    else if (hash != dbHash && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
-    { // update the hash either way - we may have changed the hash to a fast version
-      m_database.SetPathHash(strDirectory, hash);
-    }
-
-    if (m_handle)
-      OnDirectoryScanned(strDirectory);
-
-    for (int i = 0; i < items.Size(); ++i)
-    {
-      CFileItemPtr pItem = items[i];
-
-      if (m_bStop)
-        break;
-
-      // if we have a directory item (non-playlist) we then recurse into that folder
-      // do not recurse for tv shows - we have already looked recursively for episodes
-      if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0 && content != CONTENT_TVSHOWS)
-      {
-        if (!DoScan(pItem->GetPath()))
-        {
-          m_bStop = true;
-        }
-      }
-    }
-    return !m_bStop;
   }
 
   bool CVideoInfoScanner::RetrieveVideoInfo(CFileItemList& items, bool bDirNames, CONTENT_TYPE content, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress)

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -126,7 +126,7 @@ namespace VIDEO
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
     bool ScanMovieFolder(const CStdString& strDirectory, const SScanSettings& settings, CONTENT_TYPE content);
-    bool ScanTVFolder(const CStdString& strDirectory, const SScanSettings& settings, bool foundDirectly);
+    bool ScanTVFolder(const CStdString& strDirectory, bool useDirNames, bool foundDirectly);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -125,6 +125,7 @@ namespace VIDEO
   protected:
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
+    bool ScanMovieFolder(const CStdString& strDirectory, const SScanSettings& settings, CONTENT_TYPE content);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -126,6 +126,7 @@ namespace VIDEO
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
     bool ScanMovieFolder(const CStdString& strDirectory, const SScanSettings& settings, CONTENT_TYPE content);
+    bool ScanTVFolder(const CStdString& strDirectory, const SScanSettings& settings, bool foundDirectly);
 
     INFO_RET RetrieveInfoForTvShow(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, bool fetchEpisodes, CGUIDialogProgress* pDlgProgress);
     INFO_RET RetrieveInfoForMovie(CFileItem *pItem, bool bDirNames, ADDON::ScraperPtr &scraper, bool useLocal, CScraperUrl* pURL, CGUIDialogProgress* pDlgProgress);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1443,10 +1443,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         return false;
 
       if (item->m_bIsFolder)
-      {
-        m_database.SetPathHash(strPath,""); // to force scan
         OnScan(strPath, true);
-      }
       else
         OnInfo(item.get(),info);
 


### PR DESCRIPTION
Continues #5332. This fixes directories incorrectly being skipped when changes only occurring more than 1 level down. Something the hash won't see.

It only (kinda) worked in the first place via the GUI because the hash was forcefully removed from the db before scanning.
