### PR TITLE
[pvr][Fix] Unregister observers in the destructor of GUIWindowPVRChannel...

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -50,6 +50,11 @@ CGUIWindowPVRChannels::CGUIWindowPVRChannels(bool bRadio) :
 {
 }
 
+CGUIWindowPVRChannels::~CGUIWindowPVRChannels(void)
+{
+  UnregisterObservers();
+};
+
 void CGUIWindowPVRChannels::ResetObservers(void)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -28,7 +28,7 @@ namespace PVR
   {
   public:
     CGUIWindowPVRChannels(bool bRadio);
-    virtual ~CGUIWindowPVRChannels(void) {};
+    virtual ~CGUIWindowPVRChannels(void);
 
     bool OnMessage(CGUIMessage& message);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);


### PR DESCRIPTION
...s.

This fixes a crash at exit since g_infoManager is destructed after GUIWindowPVRChannels is destructed.

@xhaggi @opdenkamp for review.
