### PR TITLE
Handle non-zero centered axes (i.e. triggers) more sanely

### DIFF
--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -55,7 +55,7 @@ public:
 
   void Initialize();
   void Reset(bool axis=false);
-  void ResetAxis(int axisId) { m_Amount[axisId] = 0; }
+  void ResetAxis(int axisId) { m_Amount[axisId] = m_RestState[axisId]; }
   void Update();
   void Update(SDL_Event& event);
   bool GetButton (int& id, bool consider_repeat=true);
@@ -81,6 +81,8 @@ private:
   bool ReleaseJoysticks();
 
   int m_Amount[MAX_AXES];
+  int m_RestState[MAX_AXES]; // axis value in rest state (0 for sticks, -32768 for triggers)
+  bool m_IgnoreAxis[MAX_AXES]; // used to ignore triggers until SDL no longer reports 0
   int m_AxisId;
   int m_ButtonId;
   uint8_t m_HatState;


### PR DESCRIPTION
This commit fixes some issues with non-zero centered axes, i.e. triggers, on gamepads. In their resting state, SDL reports them as having value -32768, which if it were a analog stick would indicate the stick is moved fully in one direction.
Additionally, SDL reports all axis initially as having value '0', even though the triggers in their resting state report -32768 (issue confirmed sdl-jstest, with both xpad/xboxdriv - SDL is at fault here). This requires us to ignore these axes until SDL reports them as no longer having value 0. Observed behaviour would be that once you touch the trigger, XBMC will constantly be handling the action associated with the trigger, which basically means the triggers cannot be used at all.

One major remaining problem is that SDL cannot tell us which axes of a joypad are triggers and which are analog sticks. I've used a test against a known number of axes, hats and buttons, along with the joypad having '360' in the name to identify xbox 360 controllers, for which we know we axes are really triggers. Not sure how this can be improved easily.
