### PR TITLE
[curl] redact effective URL

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -973,7 +973,10 @@ bool CCurlFile::Open(const CURL& url)
   if (CURLE_OK == g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_EFFECTIVE_URL,&efurl) && efurl)
   {
     if (m_url != efurl)
-      CLog::Log(LOGDEBUG,"CCurlFile::Open - effective URL: <%s>", efurl);
+    {
+      std::string redactEfpath = CURL::GetRedacted(efurl);
+      CLog::Log(LOGDEBUG,"CCurlFile::Open - effective URL: <%s>", redactEfpath.c_str());
+    }
     m_url = efurl;
   }
 


### PR DESCRIPTION
as noted by @topfs2, the original PR failed to redact the URL before logging it.
