### PR TITLE
[woa] dont abort if wait for net fails

### DIFF
--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -379,8 +379,16 @@ bool CWakeOnAccess::WakeUpHost(const WakeUpEntry& server)
 
     if (dlg.ShowAndWait (waitObj, m_netinit_sec, LOCALIZED(13028)) != ProgressDialogHelper::Success)
     {
-      CLog::Log(LOGNOTICE,"WakeOnAccess timeout/cancel while waiting for network");
-      return false; // timedout or canceled
+      if (g_application.getNetwork().IsConnected() && HostToIP(server.host) == INADDR_NONE)
+      {
+        // network connected (at least one interface) but dns-lookup failed (host by name, not ip-address), so dont abort yet
+        CLog::Log(LOGWARNING, "WakeOnAccess timeout/cancel while waiting for network (proceeding anyway)");
+      }
+      else
+      {
+        CLog::Log(LOGNOTICE, "WakeOnAccess timeout/cancel while waiting for network");
+        return false; // timedout or canceled ; give up 
+      }
     }
   }
 


### PR DESCRIPTION
When the 'wake on access' sequence starts, the first thing that is done is to wait for network connectivity (using CNetwork::HasInterfaceForIP()) for the server we need to wake.
If server is given by name, not ipaddress, a dns-lookup is made, but since server is offline that lookup may fail and so the HasInterfaceForIP() fails.
In this situation it is better to not give up (as today) but rather continue to issue a wol and see if the server comes up.

This scenario became clear int this post in this thread ; http://forum.xbmc.org/showthread.php?tid=203098&pid=1783818#pid1783818
