### PR TITLE
Video info scanner fix: scan the entire subtree of path passed to scanner.

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -172,17 +172,20 @@ namespace VIDEO
     m_pathsToScan.clear();
     m_pathsToClean.clear();
 
+    m_database.Open();
     if (strDirectory.empty())
     { // scan all paths in the database.  We do this by scanning all paths in the db, and crossing them off the list as
       // we go.
-      m_database.Open();
       m_database.GetPaths(m_pathsToScan);
-      m_database.Close();
     }
     else
-    {
-      m_pathsToScan.insert(strDirectory);
+    { // scan all the paths of this subtree that is in the database
+      vector< pair<int, string> > subpaths;
+      m_database.GetSubPaths(m_strStartDir, subpaths);
+      for (vector< pair<int, string> >::iterator it = subpaths.begin(); it < subpaths.end(); ++it)
+        m_pathsToScan.insert(it->second);
     }
+    m_database.Close();
     m_bClean = g_advancedSettings.m_bVideoLibraryCleanOnUpdate;
 
     StopThread();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1444,7 +1444,6 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
       if (item->m_bIsFolder)
       {
-        m_database.SetPathHash(strPath,""); // to force scan
         OnScan(strPath, true);
       }
       else


### PR DESCRIPTION
This fixes JSON-RPC's VideoLibrary.Scan and UpdateLibrary builtin not picking up changes when called with a path as parameter and changes are not visible directly in this directory. It now does the same as the global update function: queuing all known directories and sub-directories for scanning.

Also fixes hashing never getting used when using the 'Scan for new content' function in GUI.
