### PR TITLE
[python] deprecate Monitor.onAbortRequested

### DIFF
--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -148,9 +148,7 @@ namespace XBMCAddon
       virtual void    onCleanFinished(const String library) { XBMC_TRACE; }
 
       /**
-       * onAbortRequested() -- onAbortRequested method.\n
-       * \n
-       * Will be called when XBMC requests Abort\n
+       * onAbortRequested() -- Deprecated, use waitForAbort() to be notified about this event.\n
        */
       virtual void    onAbortRequested() { XBMC_TRACE; }
 


### PR DESCRIPTION
This is almost always used incorrectly causing only confusion believing it will be reliably called when abort is requested. I fail to see any use case for it as it is now.

According to the original PR #1053, it was added so  it could "replace[..] checking for xbmc.abortRequested in a while loop". This could never work since the main thread have to be kept alive and non-blocking to receive callbacks, and for that you will need another mechanism to wait for the callback itself. 
