### PR TITLE
[dvdplayer] Fix for timestamp correction when no audio or no video

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -105,7 +105,7 @@ public:
   const int        player;
   // stuff to handle starting after seek
   double   startpts;
-  double   correction;
+  double   originaldts;
 
   CCurrentStream(StreamType t, int i)
     : type(t)
@@ -127,7 +127,7 @@ public:
     inited = false;
     started = false;
     startpts  = DVD_NOPTS_VALUE;
-    correction = 0.0;
+    originaldts = DVD_NOPTS_VALUE;
   }
 
   double dts_end()


### PR DESCRIPTION
If audio or video track is missing, we don't have to wait for the other track to have a matching timestamp jump
Also compare dts rather than correction values as suggested by FernetMenta

This aims to fix a bug in https://github.com/xbmc/xbmc/pull/5248 identified by @ace20022.
