### PR TITLE
DXVA: fixes related to ffmpeg 2nd.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -825,7 +825,7 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
     m_shared = surfaces;
 
   if(avctx->refs > m_refs)
-    m_refs = avctx->refs;
+    m_refs = avctx->refs+2;
 
   if(m_refs == 0)
   {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -349,6 +349,8 @@ bool CDXVAContext::EnsureContext(CDXVAContext **ctx, CDecoder *decoder)
   {
     m_context->m_refCount++;
     *ctx = m_context;
+    if (!m_context->IsValidDecoder(decoder))
+      m_context->m_decoders.push_back(decoder);
     return true;
   }
   m_context = new CDXVAContext();


### PR DESCRIPTION
@ace20022 @afedchin this should fix the issue mentioned here #5335

the first was a c/p error, the 2nd is a temp fix for the video surface handling which we need to touch anyway
