### PR TITLE
Fix wrongly used CFile::Exists() for directories instead of CDirectory::Exists()

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -59,6 +59,7 @@
 #include "SectionLoader.h"
 #include "cores/DllLoader/DllLoaderContainer.h"
 #include "GUIUserMessages.h"
+#include "filesystem/Directory.h"
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/StackDirectory.h"
 #include "filesystem/SpecialProtocol.h"
@@ -1104,11 +1105,11 @@ bool CApplication::InitDirectoriesLinux()
     xbmcPath = xbmcBinPath;
     /* Check if xbmc binaries and arch independent data files are being kept in
      * separate locations. */
-    if (!CFile::Exists(URIUtils::AddFileToFolder(xbmcPath, "language")))
+    if (!CDirectory::Exists(URIUtils::AddFileToFolder(xbmcPath, "language")))
     {
       /* Attempt to locate arch independent data files. */
       CUtil::GetHomePath(xbmcPath);
-      if (!CFile::Exists(URIUtils::AddFileToFolder(xbmcPath, "language")))
+      if (!CDirectory::Exists(URIUtils::AddFileToFolder(xbmcPath, "language")))
       {
         fprintf(stderr, "Unable to find path to XBMC data files!\n");
         exit(1);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -679,7 +679,7 @@ void CUtil::ClearTempFonts()
 {
   CStdString searchPath = "special://temp/fonts/";
 
-  if (!CFile::Exists(searchPath))
+  if (!CDirectory::Exists(searchPath))
     return;
 
   CFileItemList items;
@@ -735,7 +735,7 @@ CStdString CUtil::GetNextPathname(const CStdString &path_template, int max)
   for (int i = 0; i <= max; i++)
   {
     CStdString name = StringUtils::Format(path_template.c_str(), i);
-    if (!CFile::Exists(name))
+    if (!CFile::Exists(name) && !CDirectory::Exists(name))
       return name;
   }
   return "";

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -194,7 +194,7 @@ bool CAddonMgr::CheckUserDirs(const cp_cfg_element_t *settings)
   while (itr != elements.end())
   {
     std::string path = GetExtValue(*itr++, "@path");
-    if (!CFile::Exists(path))
+    if (!CDirectory::Exists(path))
     {
       if (!CUtil::CreateDirectoryEx(path))
       {

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -235,7 +235,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 #if defined(TARGET_ANDROID)
     // add the default android music directory
     std::string path;
-    if (CXBMCApp::GetExternalStorage(path, "music") && !path.empty() && CFile::Exists(path))
+    if (CXBMCApp::GetExternalStorage(path, "music") && !path.empty() && CDirectory::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20240);

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -20,6 +20,7 @@
 
 #include "FavouritesDirectory.h"
 #include "File.h"
+#include "Directory.h"
 #include "Util.h"
 #include "profiles/ProfilesManager.h"
 #include "FileItem.h"
@@ -53,7 +54,7 @@ bool CFavouritesDirectory::Exists(const CURL& url)
     return XFILE::CFile::Exists("special://xbmc/system/favourites.xml") 
         || XFILE::CFile::Exists(URIUtils::AddFileToFolder(CProfilesManager::Get().GetProfileUserDataFolder(), "favourites.xml"));
   }
-  return XFILE::CFile::Exists(url); //directly load the given file
+  return XFILE::CDirectory::Exists(url); //directly load the given file
 }
 
 bool CFavouritesDirectory::Load(CFileItemList &items)

--- a/xbmc/storage/android/AndroidStorageProvider.cpp
+++ b/xbmc/storage/android/AndroidStorageProvider.cpp
@@ -22,6 +22,7 @@
 #include "android/activity/XBMCApp.h"
 #include "guilib/LocalizeStrings.h"
 #include "filesystem/File.h"
+#include "filesystem/Directory.h"
 
 #include "utils/log.h"
 #include "utils/RegExp.h"
@@ -82,7 +83,7 @@ void CAndroidStorageProvider::GetLocalDrives(VECSOURCES &localDrives)
 
   // external directory
   std::string path;
-  if (CXBMCApp::GetExternalStorage(path) && !path.empty()  && XFILE::CFile::Exists(path))
+  if (CXBMCApp::GetExternalStorage(path) && !path.empty()  && XFILE::CDirectory::Exists(path))
   {
     share.strPath = path;
     share.strName = g_localizeStrings.Get(21456);


### PR DESCRIPTION
Cherrypicked from PR #5309.
Intended to fix problem with various VFS, including recently added Win32File.
