### PR TITLE
[dxva] Add only valid decoders to the decoders list.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -349,7 +349,7 @@ bool CDXVAContext::EnsureContext(CDXVAContext **ctx, CDecoder *decoder)
   {
     m_context->m_refCount++;
     *ctx = m_context;
-    if (!m_context->IsValidDecoder(decoder))
+    if (m_context->IsValidDecoder(decoder))
       m_context->m_decoders.push_back(decoder);
     return true;
   }


### PR DESCRIPTION
 This fix a c/p error after 82d3aa4464aff8123c5893da79f405ba4ec9e572.
