### PR TITLE
[mmal] Add MMAL decoder and MMAL renderer for Raspberry Pi

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -721,6 +721,7 @@ case $use_platform in
      ARCH="arm"
      AC_DEFINE(HAS_EGLGLES, [1], [Define if supporting EGL based GLES Framebuffer])
      USE_OMXLIB=1; AC_DEFINE([HAVE_OMXLIB],[1],["Define to 1 if OMX libs is enabled"])
+     USE_MMAL=1; AC_DEFINE([HAS_MMAL],[1],["Define to 1 if MMAL libs is enabled"])
      CFLAGS="$CFLAGS"
      CXXFLAGS="$CXXFLAGS"
      ;;
@@ -1010,7 +1011,7 @@ if test "$use_gles" = "yes"; then
       AC_DEFINE([HAVE_LIBEGL],[1],["Define to 1 if you have the `EGL' library (-lEGL)."])
       AC_DEFINE([HAVE_LIBGLESV2],[1],["Define to 1 if you have the `GLESv2' library (-lGLESv2)."])
       AC_MSG_RESULT(== WARNING: OpenGLES support is assumed.)
-      LIBS="$LIBS -lEGL -lGLESv2 -lbcm_host -lvcos -lvchiq_arm"
+      LIBS="$LIBS -lEGL -lGLESv2 -lbcm_host -lvcos -lvchiq_arm -lmmal -lmmal_core -lmmal_util"
     else
       AC_CHECK_LIB([EGL],   [main],, AC_MSG_ERROR($missing_library))
       AC_CHECK_LIB([GLESv2],[main],, AC_MSG_ERROR($missing_library))
@@ -2584,6 +2585,7 @@ AC_SUBST(USE_DOXYGEN)
 AC_SUBST(USE_PVR_ADDONS)
 AC_SUBST(UPNP_DEFINES)
 AC_SUBST(USE_SSE4)
+AC_SUBST(USE_MMAL)
 
 # pushd and popd are not available in other shells besides bash, so implement
 # our own pushd/popd functions

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -15410,7 +15410,19 @@ msgctxt "#36433"
 msgid "If enabled VAAPI render method is prefered. This puts less load on the CPU but driver may hang!"
 msgstr ""
 
-#empty strings from id 36434 to 36499
+#. Description of setting "Videos -> Playback -> Enable MMAL hardware decoding of video files"
+#: system/settings/settings.xml
+msgctxt "#36434"
+msgid "Allow hardware acceleration (MMAL)"
+msgstr ""
+
+#. Description of setting "Videos -> Playback -> Enable MMAL hardware decoding of video files"
+#: system/settings/settings.xml
+msgctxt "#36435"
+msgid "Use DVDPlayer for decoding of video files with MMAL acceleration."
+msgstr ""
+
+#empty strings from id 36436 to 36499
 #end reservation
 
 #. label of a setting for the stereoscopic 3D mode of the GUI that is/should be applied

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -12,6 +12,16 @@
       <group id="1">
         <visible>false</visible>
       </group>
+      <group id="3">
+        <setting id="videoplayer.usemmal" type="boolean" label="36434" help="36435">
+          <dependencies>
+            <dependency type="enable" setting="videoplayer.decodingmethod" operator="is">1</dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
   </section>
 

--- a/xbmc/cores/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.cpp
@@ -1,0 +1,718 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Util.h"
+#include "MMALRenderer.h"
+#include "cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "filesystem/File.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/DisplaySettings.h"
+#include "settings/MediaSettings.h"
+#include "settings/Settings.h"
+#include "threads/SingleLock.h"
+#include "utils/log.h"
+#include "utils/MathUtils.h"
+#include "windowing/WindowingFactory.h"
+#include "cores/dvdplayer/DVDCodecs/Video/MMALCodec.h"
+#include "xbmc/Application.h"
+
+#define CLASSNAME "CMMALRenderer"
+
+#ifdef _DEBUG
+#define MMAL_DEBUG_VERBOSE
+#endif
+
+static void vout_control_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  mmal_buffer_header_release(buffer);
+}
+
+void CMMALRenderer::vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  CMMALVideoBuffer *omvb = (CMMALVideoBuffer *)buffer->user_data;
+
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s port:%p buffer %p (%p), len %d cmd:%x", CLASSNAME, __func__, port, buffer, omvb, buffer->length, buffer->cmd);
+  #endif
+
+  if (m_format == RENDER_FMT_MMAL)
+  {
+    mmal_queue_put(m_release_queue, buffer);
+  }
+  else if (m_format == RENDER_FMT_YUV420P)
+  {
+    mmal_buffer_header_release(buffer);
+  }
+  else assert(0);
+}
+
+static void vout_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  CMMALRenderer *mmal = reinterpret_cast<CMMALRenderer*>(port->userdata);
+  mmal->vout_input_port_cb(port, buffer);
+}
+
+bool CMMALRenderer::init_vout(MMAL_ES_FORMAT_T *format)
+{
+  MMAL_STATUS_T status;
+
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+
+  /* Create video renderer */
+  status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_RENDERER, &m_vout);
+  if(status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to create vout component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_vout->control->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+  status = mmal_port_enable(m_vout->control, vout_control_port_cb);
+  if(status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable vout control port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+  m_vout_input = m_vout->input[0];
+  m_vout_input->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+  mmal_format_full_copy(m_vout_input->format, format);
+  status = mmal_port_format_commit(m_vout_input);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to commit vout input format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_vout_input->buffer_num = m_vout_input->buffer_num_recommended;
+  m_vout_input->buffer_size = m_vout_input->buffer_size_recommended;
+
+  status = mmal_port_enable(m_vout_input, vout_input_port_cb_static);
+  if(status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to vout enable input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  status = mmal_component_enable(m_vout);
+  if(status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable vout component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  if (m_format == RENDER_FMT_YUV420P)
+  {
+    m_vout_input_pool = mmal_pool_create(m_vout_input->buffer_num, m_vout_input->buffer_size);
+    if (!m_vout_input_pool)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed to create pool for decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return false;
+    }
+  }
+  return true;
+}
+
+void CMMALRenderer::Process()
+{
+  MMAL_BUFFER_HEADER_T *buffer;
+  while (buffer = mmal_queue_wait(m_release_queue), buffer)
+  {
+    CMMALVideoBuffer *omvb = (CMMALVideoBuffer *)buffer->user_data;
+    omvb->Release();
+  }
+  m_sync.Set();
+}
+
+CMMALRenderer::CMMALRenderer()
+: CThread("CMMALRenderer")
+{
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+  m_vout = NULL;
+  m_vout_input = NULL;
+  m_vout_input_pool = NULL;
+  memset(m_buffers, 0, sizeof m_buffers);
+  m_release_queue = mmal_queue_create();
+  Create();
+}
+
+CMMALRenderer::~CMMALRenderer()
+{
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+  // shutdown thread
+  mmal_queue_put(m_release_queue, NULL);
+  m_sync.Wait();
+  mmal_queue_destroy(m_release_queue);
+  UnInit();
+}
+
+void CMMALRenderer::AddProcessor(CMMALVideoBuffer *buffer, int index)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s - %p (%p) %i", CLASSNAME, __func__, buffer, buffer->mmal_buffer, index);
+#endif
+
+  YUVBUFFER &buf = m_buffers[index];
+  assert(!buf.MMALBuffer);
+  memset(&buf, 0, sizeof buf);
+  buf.MMALBuffer = buffer->Acquire();
+}
+
+bool CMMALRenderer::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation)
+{
+  ReleaseBuffers();
+
+  m_sourceWidth  = width;
+  m_sourceHeight = height;
+  m_renderOrientation = orientation;
+
+  m_fps = fps;
+  m_iFlags = flags;
+  m_format = format;
+
+  CLog::Log(LOGDEBUG, "%s::%s - %dx%d->%dx%d@%.2f flags:%x format:%d ext:%x orient:%d", CLASSNAME, __func__, width, height, d_width, d_height, fps, flags, format, extended_format, orientation);
+
+  m_RenderUpdateCallBackFn = NULL;
+  m_RenderUpdateCallBackCtx = NULL;
+  if ((m_format == RENDER_FMT_BYPASS) && g_application.GetCurrentPlayer())
+  {
+    m_renderFeatures.clear();
+    m_scalingMethods.clear();
+    m_deinterlaceModes.clear();
+    m_deinterlaceMethods.clear();
+
+    if (m_RenderFeaturesCallBackFn)
+    {
+      (*m_RenderFeaturesCallBackFn)(m_RenderFeaturesCallBackCtx, m_renderFeatures);
+      // after setting up m_renderFeatures, we are done with the callback
+      m_RenderFeaturesCallBackFn = NULL;
+      m_RenderFeaturesCallBackCtx = NULL;
+    }
+    g_application.m_pPlayer->GetRenderFeatures(m_renderFeatures);
+    g_application.m_pPlayer->GetDeinterlaceMethods(m_deinterlaceMethods);
+    g_application.m_pPlayer->GetDeinterlaceModes(m_deinterlaceModes);
+    g_application.m_pPlayer->GetScalingMethods(m_scalingMethods);
+  }
+
+  // calculate the input frame aspect ratio
+  CalculateFrameAspectRatio(d_width, d_height);
+  ChooseBestResolution(fps);
+  m_destWidth = g_graphicsContext.GetResInfo(m_resolution).iWidth;
+  m_destHeight = g_graphicsContext.GetResInfo(m_resolution).iHeight;
+  SetViewMode(CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode);
+  ManageDisplay();
+
+  if (m_format == RENDER_FMT_MMAL|| m_format == RENDER_FMT_YUV420P)
+  {
+    MMAL_ES_FORMAT_T *es_format = mmal_format_alloc();
+    es_format->type = MMAL_ES_TYPE_VIDEO;
+    es_format->es->video.crop.width = m_sourceWidth;
+    es_format->es->video.crop.height = m_sourceHeight;
+
+    if (m_format == RENDER_FMT_MMAL)
+    {
+      es_format->encoding = MMAL_ENCODING_OPAQUE;
+      es_format->es->video.width = m_sourceWidth;
+      es_format->es->video.height = m_sourceHeight;
+    }
+    else if (m_format == RENDER_FMT_YUV420P)
+    {
+      const int pitch = ALIGN_UP(m_sourceWidth, 32);
+      const int aligned_height = ALIGN_UP(m_sourceHeight, 16);
+
+      es_format->encoding = MMAL_ENCODING_I420;
+      es_format->es->video.width = pitch;
+      es_format->es->video.height = aligned_height;
+
+      if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT709)
+        es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT709;
+      else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_BT601)
+        es_format->es->video.color_space = MMAL_COLOR_SPACE_ITUR_BT601;
+      else if (CONF_FLAGS_YUVCOEF_MASK(m_iFlags) == CONF_FLAGS_YUVCOEF_240M)
+        es_format->es->video.color_space = MMAL_COLOR_SPACE_SMPTE240M;
+    }
+    if (m_bConfigured)
+      UnInit();
+    m_bConfigured = init_vout(es_format);
+    mmal_format_free(es_format);
+  }
+  else
+    m_bConfigured = true;
+
+  return m_bConfigured;
+}
+
+int CMMALRenderer::GetImage(YV12Image *image, int source, bool readonly)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s - %p %d %d", CLASSNAME, __func__, image, source, readonly);
+#endif
+  if (!image) return -1;
+
+  if( source < 0)
+    return -1;
+
+  if (m_format == RENDER_FMT_MMAL)
+  {
+  }
+  else if (m_format == RENDER_FMT_YUV420P)
+  {
+    const int pitch = ALIGN_UP(m_sourceWidth, 32);
+    const int aligned_height = ALIGN_UP(m_sourceHeight, 16);
+
+    MMAL_BUFFER_HEADER_T *buffer = mmal_queue_timedwait(m_vout_input_pool->queue, 500);
+    if (!buffer)
+    {
+      CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
+      return -1;
+    }
+
+    mmal_buffer_header_reset(buffer);
+
+    buffer->length = 3 * pitch * aligned_height >> 1;
+    assert(buffer->length <= buffer->alloc_size);
+
+    image->width    = m_sourceWidth;
+    image->height   = m_sourceHeight;
+    image->flags    = 0;
+    image->cshift_x = 1;
+    image->cshift_y = 1;
+    image->bpp      = 1;
+
+    image->stride[0] = pitch;
+    image->stride[1] = image->stride[2] = pitch>>image->cshift_x;
+
+    image->planesize[0] = pitch * aligned_height;
+    image->planesize[1] = image->planesize[2] = (pitch>>image->cshift_x)*(aligned_height>>image->cshift_y);
+
+    image->plane[0] = (uint8_t *)buffer->data;
+    image->plane[1] = image->plane[0] + image->planesize[0];
+    image->plane[2] = image->plane[1] + image->planesize[1];
+
+    CLog::Log(LOGDEBUG, "%s::%s - %p %d", CLASSNAME, __func__, buffer, source);
+    YUVBUFFER &buf = m_buffers[source];
+    memset(&buf, 0, sizeof buf);
+    buf.mmal_buffer = buffer;
+  }
+  else assert(0);
+
+  return source;
+}
+
+void CMMALRenderer::ReleaseBuffer(int idx)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s - %d", CLASSNAME, __func__, idx);
+#endif
+  YUVBUFFER &buf = m_buffers[idx];
+  SAFE_RELEASE(buf.MMALBuffer);
+}
+
+void CMMALRenderer::ReleaseImage(int source, bool preserve)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s - %d %d", CLASSNAME, __func__, source, preserve);
+#endif
+}
+
+void CMMALRenderer::Reset()
+{
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+}
+
+void CMMALRenderer::Flush()
+{
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+}
+
+void CMMALRenderer::Update()
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+#endif
+  if (!m_bConfigured) return;
+  ManageDisplay();
+}
+
+void CMMALRenderer::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s - %d %x %d", CLASSNAME, __func__, clear, flags, alpha);
+#endif
+
+  if (!m_bConfigured) return;
+
+  CSingleLock lock(g_graphicsContext);
+
+  ManageDisplay();
+
+  // if running bypass, then the player might need the src/dst rects
+  // for sizing video playback on a layer other than the gles layer.
+  if (m_RenderUpdateCallBackFn)
+    (*m_RenderUpdateCallBackFn)(m_RenderUpdateCallBackCtx, m_sourceRect, m_destRect);
+
+  SetVideoRect(m_sourceRect, m_destRect);
+
+  CRect old = g_graphicsContext.GetScissors();
+
+  g_graphicsContext.BeginPaint();
+  g_graphicsContext.SetScissors(m_destRect);
+
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glClearColor(0, 0, 0, 0);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  g_graphicsContext.SetScissors(old);
+  g_graphicsContext.EndPaint();
+}
+
+void CMMALRenderer::FlipPage(int source)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s - %d", CLASSNAME, __func__, source);
+#endif
+
+  if (!m_bConfigured || m_format == RENDER_FMT_BYPASS)
+    return;
+
+  YUVBUFFER *buffer = &m_buffers[source];
+  // we only want to upload frames once
+  if (buffer->flipindex++)
+    return;
+  if (m_format == RENDER_FMT_MMAL)
+  {
+    CMMALVideoBuffer *omvb = buffer->MMALBuffer;
+    if (omvb)
+    {
+#if defined(MMAL_DEBUG_VERBOSE)
+      CLog::Log(LOGDEBUG, "%s::%s %p (%p)", CLASSNAME, __func__, omvb, omvb->mmal_buffer);
+#endif
+      omvb->Acquire();
+      mmal_port_send_buffer(m_vout_input, omvb->mmal_buffer);
+    } else assert(0);
+  }
+  else if (m_format == RENDER_FMT_YUV420P)
+  {
+    CLog::Log(LOGDEBUG, "%s::%s - %p %d", CLASSNAME, __func__, buffer->mmal_buffer, source);
+    if (buffer->mmal_buffer)
+      mmal_port_send_buffer(m_vout_input, buffer->mmal_buffer);
+    else assert(0);
+  }
+  else assert(0);
+}
+
+unsigned int CMMALRenderer::PreInit()
+{
+  CSingleLock lock(g_graphicsContext);
+  m_bConfigured = false;
+  UnInit();
+
+  m_iFlags = 0;
+
+  m_resolution = CDisplaySettings::Get().GetCurrentResolution();
+  if ( m_resolution == RES_WINDOW )
+    m_resolution = RES_DESKTOP;
+
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+
+  m_formats.clear();
+  m_formats.push_back(RENDER_FMT_YUV420P);
+  m_formats.push_back(RENDER_FMT_MMAL);
+  m_formats.push_back(RENDER_FMT_BYPASS);
+
+  m_NumYV12Buffers = NUM_BUFFERS;
+
+  return 0;
+}
+
+void CMMALRenderer::ReleaseBuffers()
+{
+  for (int i=0; i<NUM_BUFFERS; i++)
+    ReleaseBuffer(i);
+}
+
+void CMMALRenderer::UnInit()
+{
+  CSingleLock lock(g_graphicsContext);
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+  if (m_vout)
+  {
+    mmal_component_disable(m_vout);
+    mmal_port_disable(m_vout->control);
+  }
+
+  if (m_vout_input)
+  {
+    mmal_port_flush(m_vout_input);
+    mmal_port_disable(m_vout_input);
+    m_vout_input = NULL;
+  }
+
+  if (m_vout_input_pool)
+  {
+    mmal_pool_destroy(m_vout_input_pool);
+    m_vout_input_pool = NULL;
+  }
+
+  if (m_vout)
+  {
+    mmal_component_release(m_vout);
+    m_vout = NULL;
+  }
+  ReleaseBuffers();
+
+  m_RenderUpdateCallBackFn = NULL;
+  m_RenderUpdateCallBackCtx = NULL;
+  m_RenderFeaturesCallBackFn = NULL;
+  m_RenderFeaturesCallBackCtx = NULL;
+
+  m_src_rect.SetRect(0, 0, 0, 0);
+  m_dst_rect.SetRect(0, 0, 0, 0);
+  m_video_stereo_mode = RENDER_STEREO_MODE_OFF;
+  m_display_stereo_mode = RENDER_STEREO_MODE_OFF;
+  m_StereoInvert = false;
+
+  m_bConfigured = false;
+}
+
+bool CMMALRenderer::RenderCapture(CRenderCapture* capture)
+{
+  if (!m_bConfigured)
+    return false;
+
+  CLog::Log(LOGDEBUG, "%s::%s - %p", CLASSNAME, __func__, capture);
+
+  capture->BeginRender();
+  capture->EndRender();
+
+  return true;
+}
+
+//********************************************************************************************************
+// YV12 Texture creation, deletion, copying + clearing
+//********************************************************************************************************
+
+bool CMMALRenderer::Supports(EDEINTERLACEMODE mode)
+{
+  // Player controls render, let it dictate available deinterlace modes
+  if (m_format == RENDER_FMT_BYPASS)
+  {
+    Features::iterator itr = std::find(m_deinterlaceModes.begin(),m_deinterlaceModes.end(), mode);
+    return itr != m_deinterlaceModes.end();
+  }
+
+  if(mode == VS_DEINTERLACEMODE_OFF
+  || mode == VS_DEINTERLACEMODE_AUTO
+  || mode == VS_DEINTERLACEMODE_FORCE)
+    return true;
+
+  return false;
+}
+
+bool CMMALRenderer::Supports(EINTERLACEMETHOD method)
+{
+  // Player controls render, let it dictate available deinterlace methods
+  if (m_format == RENDER_FMT_BYPASS)
+  {
+    Features::iterator itr = std::find(m_deinterlaceMethods.begin(),m_deinterlaceMethods.end(), method);
+    return itr != m_deinterlaceMethods.end();
+  }
+
+  if (method == VS_INTERLACEMETHOD_DEINTERLACE)
+    return true;
+
+  return false;
+}
+
+bool CMMALRenderer::Supports(ERENDERFEATURE feature)
+{
+  // Player controls render, let it dictate available render features
+  if (m_format == RENDER_FMT_BYPASS)
+  {
+    Features::iterator itr = std::find(m_renderFeatures.begin(),m_renderFeatures.end(), feature);
+    return itr != m_renderFeatures.end();
+  }
+
+  if (feature == RENDERFEATURE_STRETCH         ||
+      feature == RENDERFEATURE_ZOOM            ||
+      feature == RENDERFEATURE_ROTATION        ||
+      feature == RENDERFEATURE_VERTICAL_SHIFT  ||
+      feature == RENDERFEATURE_PIXEL_RATIO)
+    return true;
+
+  return false;
+}
+
+bool CMMALRenderer::Supports(ESCALINGMETHOD method)
+{
+  // Player controls render, let it dictate available scaling methods
+  if (m_format == RENDER_FMT_BYPASS)
+  {
+    Features::iterator itr = std::find(m_scalingMethods.begin(),m_scalingMethods.end(), method);
+    return itr != m_scalingMethods.end();
+  }
+  return false;
+}
+
+EINTERLACEMETHOD CMMALRenderer::AutoInterlaceMethod()
+{
+  return VS_INTERLACEMETHOD_DEINTERLACE;
+}
+
+void CMMALRenderer::SetVideoRect(const CRect& InSrcRect, const CRect& InDestRect)
+{
+  // we get called twice a frame for left/right. Can ignore the rights.
+  if (g_graphicsContext.GetStereoView() == RENDER_STEREO_VIEW_RIGHT)
+    return;
+
+  if (!m_vout_input)
+    return;
+
+  CRect SrcRect = InSrcRect, DestRect = InDestRect;
+  RENDER_STEREO_MODE video_stereo_mode = (m_iFlags & CONF_FLAGS_STEREO_MODE_SBS) ? RENDER_STEREO_MODE_SPLIT_VERTICAL :
+                                         (m_iFlags & CONF_FLAGS_STEREO_MODE_TAB) ? RENDER_STEREO_MODE_SPLIT_HORIZONTAL : RENDER_STEREO_MODE_OFF;
+  bool stereo_invert                   = (m_iFlags & CONF_FLAGS_STEREO_CADANCE_RIGHT_LEFT) ? true : false;
+  RENDER_STEREO_MODE display_stereo_mode = g_graphicsContext.GetStereoMode();
+
+  // fix up transposed video
+  if (m_renderOrientation == 90 || m_renderOrientation == 270)
+  {
+    float diff = (DestRect.Height() - DestRect.Width()) * 0.5f;
+    DestRect.x1 -= diff;
+    DestRect.x2 += diff;
+    DestRect.y1 += diff;
+    DestRect.y2 -= diff;
+  }
+
+  // check if destination rect or video view mode has changed
+  if (!(m_dst_rect != DestRect) && !(m_src_rect != SrcRect) && m_video_stereo_mode == video_stereo_mode && m_display_stereo_mode == display_stereo_mode && m_StereoInvert == stereo_invert)
+    return;
+
+  CLog::Log(LOGDEBUG, "%s::%s %d,%d,%d,%d -> %d,%d,%d,%d (o:%d v:%d d:%d i:%d)", CLASSNAME, __func__,
+      (int)SrcRect.x1, (int)SrcRect.y1, (int)SrcRect.x2, (int)SrcRect.y2,
+      (int)DestRect.x1, (int)DestRect.y1, (int)DestRect.x2, (int)DestRect.y2,
+      m_renderOrientation, video_stereo_mode, display_stereo_mode, stereo_invert);
+
+  m_src_rect = SrcRect;
+  m_dst_rect = DestRect;
+  m_video_stereo_mode = video_stereo_mode;
+  m_display_stereo_mode = display_stereo_mode;
+  m_StereoInvert = stereo_invert;
+
+  // might need to scale up m_dst_rect to display size as video decodes
+  // to separate video plane that is at display size.
+  RESOLUTION res = g_graphicsContext.GetVideoResolution();
+  CRect gui(0, 0, CDisplaySettings::Get().GetResolutionInfo(res).iWidth, CDisplaySettings::Get().GetResolutionInfo(res).iHeight);
+  CRect display(0, 0, CDisplaySettings::Get().GetResolutionInfo(res).iScreenWidth, CDisplaySettings::Get().GetResolutionInfo(res).iScreenHeight);
+
+  if (display_stereo_mode != RENDER_STEREO_MODE_OFF && display_stereo_mode != RENDER_STEREO_MODE_MONO)
+  switch (video_stereo_mode)
+  {
+  case RENDER_STEREO_MODE_SPLIT_VERTICAL:
+    // optimisation - use simpler display mode in common case of unscaled 3d with same display mode
+    if (video_stereo_mode == display_stereo_mode && DestRect.x1 == 0.0f && DestRect.x2 * 2.0f == gui.Width() && !stereo_invert)
+    {
+      SrcRect.x2 *= 2.0f;
+      DestRect.x2 *= 2.0f;
+      video_stereo_mode = RENDER_STEREO_MODE_OFF;
+      display_stereo_mode = RENDER_STEREO_MODE_OFF;
+    }
+    else if (display_stereo_mode == RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN || display_stereo_mode == RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA)
+    {
+      SrcRect.x2 *= 2.0f;
+    }
+    break;
+
+  case RENDER_STEREO_MODE_SPLIT_HORIZONTAL:
+    // optimisation - use simpler display mode in common case of unscaled 3d with same display mode
+    if (video_stereo_mode == display_stereo_mode && DestRect.y1 == 0.0f && DestRect.y2 * 2.0f == gui.Height() && !stereo_invert)
+    {
+      SrcRect.y2 *= 2.0f;
+      DestRect.y2 *= 2.0f;
+      video_stereo_mode = RENDER_STEREO_MODE_OFF;
+      display_stereo_mode = RENDER_STEREO_MODE_OFF;
+    }
+    else if (display_stereo_mode == RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN || display_stereo_mode == RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA)
+    {
+      SrcRect.y2 *= 2.0f;
+    }
+    break;
+
+  default: break;
+  }
+
+  if (gui != display)
+  {
+    float xscale = display.Width()  / gui.Width();
+    float yscale = display.Height() / gui.Height();
+    DestRect.x1 *= xscale;
+    DestRect.x2 *= xscale;
+    DestRect.y1 *= yscale;
+    DestRect.y2 *= yscale;
+  }
+
+  MMAL_DISPLAYREGION_T region;
+  memset(&region, 0, sizeof region);
+
+  region.set                 = MMAL_DISPLAY_SET_DEST_RECT|MMAL_DISPLAY_SET_SRC_RECT|MMAL_DISPLAY_SET_FULLSCREEN|MMAL_DISPLAY_SET_NOASPECT|MMAL_DISPLAY_SET_MODE;
+  region.dest_rect.x         = lrintf(DestRect.x1);
+  region.dest_rect.y         = lrintf(DestRect.y1);
+  region.dest_rect.width     = lrintf(DestRect.Width());
+  region.dest_rect.height    = lrintf(DestRect.Height());
+
+  region.src_rect.x          = lrintf(SrcRect.x1);
+  region.src_rect.y          = lrintf(SrcRect.y1);
+  region.src_rect.width      = lrintf(SrcRect.Width());
+  region.src_rect.height     = lrintf(SrcRect.Height());
+
+  region.fullscreen = MMAL_FALSE;
+  region.noaspect = MMAL_TRUE;
+
+  if (m_renderOrientation)
+  {
+    region.set |= MMAL_DISPLAY_SET_TRANSFORM;
+    if (m_renderOrientation == 90)
+      region.transform = MMAL_DISPLAY_ROT90;
+    else if (m_renderOrientation == 180)
+      region.transform = MMAL_DISPLAY_ROT180;
+    else if (m_renderOrientation == 270)
+      region.transform = MMAL_DISPLAY_ROT270;
+    else assert(0);
+  }
+
+  if (video_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL && display_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL)
+    region.mode = MMAL_DISPLAY_MODE_STEREO_TOP_TO_TOP;
+  else if (video_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL && display_stereo_mode == RENDER_STEREO_MODE_SPLIT_VERTICAL)
+    region.mode = MMAL_DISPLAY_MODE_STEREO_TOP_TO_LEFT;
+  else if (video_stereo_mode == RENDER_STEREO_MODE_SPLIT_VERTICAL && display_stereo_mode == RENDER_STEREO_MODE_SPLIT_HORIZONTAL)
+    region.mode = MMAL_DISPLAY_MODE_STEREO_LEFT_TO_TOP;
+  else if (video_stereo_mode == RENDER_STEREO_MODE_SPLIT_VERTICAL && display_stereo_mode == RENDER_STEREO_MODE_SPLIT_VERTICAL)
+    region.mode = MMAL_DISPLAY_MODE_STEREO_LEFT_TO_LEFT;
+  else
+    region.mode = MMAL_DISPLAY_MODE_LETTERBOX;
+
+  MMAL_STATUS_T status = mmal_util_set_display_region(m_vout_input, &region);
+  if (status != MMAL_SUCCESS)
+    CLog::Log(LOGERROR, "%s::%s Failed to set display region (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+
+  CLog::Log(LOGDEBUG, "%s::%s %d,%d,%d,%d -> %d,%d,%d,%d mode:%d", CLASSNAME, __func__,
+      region.src_rect.x, region.src_rect.y, region.src_rect.width, region.src_rect.height,
+      region.dest_rect.x, region.dest_rect.y, region.dest_rect.width, region.dest_rect.height, region.mode);
+}

--- a/xbmc/cores/VideoRenderers/MMALRenderer.h
+++ b/xbmc/cores/VideoRenderers/MMALRenderer.h
@@ -1,0 +1,130 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAS_MMAL
+
+#include "guilib/GraphicContext.h"
+#include "RenderFlags.h"
+#include "RenderFormats.h"
+#include "BaseRenderer.h"
+#include "RenderCapture.h"
+#include "settings/VideoSettings.h"
+#include "cores/dvdplayer/DVDStreamInfo.h"
+#include "guilib/Geometry.h"
+#include "threads/Thread.h"
+#include "BaseRenderer.h"
+
+#include <interface/mmal/mmal.h>
+#include <interface/mmal/util/mmal_util.h>
+#include <interface/mmal/util/mmal_default_components.h>
+#include <interface/mmal/util/mmal_util_params.h>
+
+#define AUTOSOURCE -1
+
+class CBaseTexture;
+class CMMALVideoBuffer;
+
+struct DVDVideoPicture;
+
+class CMMALRenderer : public CBaseRenderer, public CThread
+{
+  struct YUVBUFFER
+  {
+    CMMALVideoBuffer *MMALBuffer; // used for hw decoded buffers
+    MMAL_BUFFER_HEADER_T *mmal_buffer;  // used for sw decoded buffers
+    unsigned flipindex; /* used to decide if this has been uploaded */
+  };
+public:
+  CMMALRenderer();
+  ~CMMALRenderer();
+
+  virtual void Update();
+  virtual void SetupScreenshot() {};
+  virtual void Process();
+
+  bool RenderCapture(CRenderCapture* capture);
+
+  // Player functions
+  virtual bool         Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation);
+  virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
+  virtual void         ReleaseImage(int source, bool preserve = false);
+  virtual void         ReleaseBuffer(int idx);
+  virtual void         FlipPage(int source);
+  virtual unsigned int PreInit();
+  virtual void         UnInit();
+  virtual void         Reset(); /* resets renderer after seek for example */
+  virtual void         Flush();
+  virtual bool         IsConfigured() { return m_bConfigured; }
+  virtual void         AddProcessor(CMMALVideoBuffer *buffer, int index);
+  virtual std::vector<ERenderFormat> SupportedFormats() { return m_formats; }
+
+  virtual bool         Supports(ERENDERFEATURE feature);
+  virtual bool         Supports(EDEINTERLACEMODE mode);
+  virtual bool         Supports(EINTERLACEMETHOD method);
+  virtual bool         Supports(ESCALINGMETHOD method);
+
+  virtual EINTERLACEMETHOD AutoInterlaceMethod();
+
+  void                 RenderUpdate(bool clear, DWORD flags = 0, DWORD alpha = 255);
+
+  virtual void         SetBufferSize(int numBuffers) { m_NumYV12Buffers = numBuffers; }
+  virtual unsigned int GetMaxBufferSize() { return NUM_BUFFERS; }
+  virtual unsigned int GetOptimalBufferSize() { return NUM_BUFFERS; }
+  virtual void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
+
+  void vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+protected:
+  int m_NumYV12Buffers;
+
+  std::vector<ERenderFormat> m_formats;
+
+  YUVBUFFER            m_buffers[NUM_BUFFERS];
+  bool                 m_bConfigured;
+  unsigned int         m_extended_format;
+  unsigned int         m_destWidth;
+  unsigned int         m_destHeight;
+  int                  m_neededBuffers;
+
+  Features m_renderFeatures;
+  Features m_deinterlaceMethods;
+  Features m_deinterlaceModes;
+  Features m_scalingMethods;
+
+  CRect                     m_src_rect;
+  CRect                     m_dst_rect;
+  RENDER_STEREO_MODE        m_video_stereo_mode;
+  RENDER_STEREO_MODE        m_display_stereo_mode;
+  bool                      m_StereoInvert;
+
+  MMAL_COMPONENT_T *m_vout;
+  MMAL_PORT_T *m_vout_input;
+  MMAL_POOL_T *m_vout_input_pool;
+
+  MMAL_QUEUE_T     *m_release_queue;
+  CEvent            m_sync;
+  bool init_vout(MMAL_ES_FORMAT_T *m_format);
+  void ReleaseBuffers();
+};
+
+#else
+#include "LinuxRenderer.h"
+#endif

--- a/xbmc/cores/VideoRenderers/Makefile.in
+++ b/xbmc/cores/VideoRenderers/Makefile.in
@@ -20,6 +20,10 @@ SRCS += LinuxRendererGLES.cpp
 SRCS += OverlayRendererGL.cpp
 endif
 
+ifeq (@USE_MMAL@,1)
+SRCS += MMALRenderer.cpp
+endif
+
 LIB = VideoRenderer.a
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/cores/VideoRenderers/RenderFormats.h
+++ b/xbmc/cores/VideoRenderers/RenderFormats.h
@@ -39,6 +39,7 @@ enum ERenderFormat {
   RENDER_FMT_EGLIMG,
   RENDER_FMT_MEDIACODEC,
   RENDER_FMT_IMXMAP,
+  RENDER_FMT_MMAL,
 };
 
 #endif

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -41,6 +41,8 @@
 
 #if defined(HAS_GL)
   #include "LinuxRendererGL.h"
+#elif defined(HAS_MMAL)
+  #include "MMALRenderer.h"
 #elif HAS_GLES == 2
   #include "LinuxRendererGLES.h"
 #elif defined(HAS_DX)
@@ -421,6 +423,8 @@ unsigned int CXBMCRenderManager::PreInit()
   {
 #if defined(HAS_GL)
     m_pRenderer = new CLinuxRendererGL();
+#elif defined(HAS_MMAL)
+    m_pRenderer = new CMMALRenderer();
 #elif HAS_GLES == 2
     m_pRenderer = new CLinuxRendererGLES();
 #elif defined(HAS_DX)
@@ -955,6 +959,10 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
 #ifdef HAS_IMXVPU
   else if(pic.format == RENDER_FMT_IMXMAP)
     m_pRenderer->AddProcessor(pic.IMXBuffer, index);
+#endif
+#ifdef HAS_MMAL
+  else if(pic.format == RENDER_FMT_MMAL)
+    m_pRenderer->AddProcessor(pic.MMALBuffer, index);
 #endif
 
   m_pRenderer->ReleaseImage(index, false);

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -42,6 +42,7 @@ struct DVDVideoPicture;
 #define ERRORBUFFSIZE 30
 
 class CWinRenderer;
+class CMMALRenderer;
 class CLinuxRenderer;
 class CLinuxRendererGL;
 class CLinuxRendererGLES;
@@ -145,6 +146,8 @@ public:
 
 #ifdef HAS_GL
   CLinuxRendererGL    *m_pRenderer;
+#elif defined(HAS_MMAL)
+  CMMALRenderer       *m_pRenderer;
 #elif HAS_GLES == 2
   CLinuxRendererGLES  *m_pRenderer;
 #elif defined(HAS_DX)

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -39,6 +39,7 @@
 #if defined(HAS_IMXVPU)
 #include "Video/DVDVideoCodecIMX.h"
 #endif
+#include "Video/DVDVideoCodecMMAL.h"
 #include "Video/DVDVideoCodecStageFright.h"
 #if defined(HAS_LIBAMCODEC)
 #include "utils/AMLUtils.h"
@@ -255,6 +256,19 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigne
       if (hint.codec == AV_CODEC_ID_H264 || hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_VC1)
     {
       if ( (pCodec = OpenCodec(new CDVDVideoCodecOpenMax(), hint, options)) ) return pCodec;
+    }
+  }
+#endif
+
+#if defined(HAS_MMAL)
+  if (CSettings::Get().GetBool("videoplayer.usemmal") && !hint.software )
+  {
+    if (hint.codec == AV_CODEC_ID_H264 || hint.codec == AV_CODEC_ID_H263 || hint.codec == AV_CODEC_ID_MPEG4 ||
+        hint.codec == AV_CODEC_ID_MPEG1VIDEO || hint.codec == AV_CODEC_ID_MPEG2VIDEO ||
+        hint.codec == AV_CODEC_ID_VP6 || hint.codec == AV_CODEC_ID_VP6F || hint.codec == AV_CODEC_ID_VP6A || hint.codec == AV_CODEC_ID_VP8 ||
+        hint.codec == AV_CODEC_ID_THEORA || hint.codec == AV_CODEC_ID_MJPEG || hint.codec == AV_CODEC_ID_MJPEGB || hint.codec == AV_CODEC_ID_VC1 || hint.codec == AV_CODEC_ID_WMV3)
+    {
+      if ( (pCodec = OpenCodec(new CDVDVideoCodecMMAL(), hint, options)) ) return pCodec;
     }
   }
 #endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -56,6 +56,7 @@ struct OpenMaxVideoBufferHolder;
 class CDVDVideoCodecStageFright;
 class CDVDMediaCodecInfo;
 class CDVDVideoCodecIMXBuffer;
+class CMMALVideoBuffer;
 typedef void* EGLImageKHR;
 
 
@@ -101,6 +102,10 @@ struct DVDVideoPicture
 
     struct {
       CDVDVideoCodecIMXBuffer *IMXBuffer;
+    };
+
+    struct {
+      CMMALVideoBuffer *MMALBuffer;
     };
 
   };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMMAL.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMMAL.cpp
@@ -1,0 +1,99 @@
+/*
+ *      Copyright (C) 2010-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+  #include "config.h"
+#elif defined(TARGET_WINDOWS)
+#include "system.h"
+#endif
+
+#if defined(HAS_MMAL)
+#include "DVDClock.h"
+#include "DVDStreamInfo.h"
+#include "DVDVideoCodecMMAL.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+
+#define CLASSNAME "CDVDVideoCodecMMAL"
+////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////
+CDVDVideoCodecMMAL::CDVDVideoCodecMMAL()
+ : m_decoder( new CMMALVideo )
+{
+  CLog::Log(LOGDEBUG, "%s::%s %p\n", CLASSNAME, __func__, this);
+}
+
+CDVDVideoCodecMMAL::~CDVDVideoCodecMMAL()
+{
+  CLog::Log(LOGDEBUG, "%s::%s %p\n", CLASSNAME, __func__, this);
+  Dispose();
+}
+
+bool CDVDVideoCodecMMAL::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
+{
+  return m_decoder->Open(hints, options, m_decoder);
+}
+
+const char* CDVDVideoCodecMMAL::GetName(void)
+{
+  return m_decoder ? m_decoder->GetName() : "mmal-xxx";
+}
+
+void CDVDVideoCodecMMAL::Dispose()
+{
+  m_decoder->Dispose();
+}
+
+void CDVDVideoCodecMMAL::SetDropState(bool bDrop)
+{
+  m_decoder->SetDropState(bDrop);
+}
+
+int CDVDVideoCodecMMAL::Decode(uint8_t* pData, int iSize, double dts, double pts)
+{
+  return m_decoder->Decode(pData, iSize, dts, pts);
+}
+
+unsigned CDVDVideoCodecMMAL::GetAllowedReferences()
+{
+  return m_decoder->GetAllowedReferences();
+}
+
+void CDVDVideoCodecMMAL::Reset(void)
+{
+  m_decoder->Reset();
+}
+
+bool CDVDVideoCodecMMAL::GetPicture(DVDVideoPicture* pDvdVideoPicture)
+{
+  return m_decoder->GetPicture(pDvdVideoPicture);
+}
+
+bool CDVDVideoCodecMMAL::ClearPicture(DVDVideoPicture* pDvdVideoPicture)
+{
+  return m_decoder->ClearPicture(pDvdVideoPicture);
+}
+
+bool CDVDVideoCodecMMAL::GetCodecStats(double &pts, int &droppedPics)
+{
+  return m_decoder->GetCodecStats(pts, droppedPics);
+}
+
+#endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMMAL.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecMMAL.h
@@ -1,0 +1,50 @@
+#pragma once
+/*
+ *      Copyright (C) 2010-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(HAS_MMAL)
+
+#include "DVDVideoCodec.h"
+#include "MMALCodec.h"
+
+class CMMALVideo;
+class CDVDVideoCodecMMAL : public CDVDVideoCodec
+{
+public:
+  CDVDVideoCodecMMAL();
+  virtual ~CDVDVideoCodecMMAL();
+
+  // Required overrides
+  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
+  virtual void Dispose(void);
+  virtual int  Decode(uint8_t *pData, int iSize, double dts, double pts);
+  virtual void Reset(void);
+  virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
+  virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
+  virtual unsigned GetAllowedReferences();
+  virtual void SetDropState(bool bDrop);
+  virtual const char* GetName(void);
+  virtual bool GetCodecStats(double &pts, int &droppedPics);
+
+protected:
+  MMALVideoPtr m_decoder;
+};
+
+#endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.cpp
@@ -1,0 +1,1110 @@
+/*
+ *      Copyright (C) 2010-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+  #include "config.h"
+#elif defined(TARGET_WINDOWS)
+#include "system.h"
+#endif
+
+#include "MMALCodec.h"
+
+#include "DVDClock.h"
+#include "DVDStreamInfo.h"
+#include "windowing/WindowingFactory.h"
+#include "DVDVideoCodec.h"
+#include "utils/log.h"
+#include "utils/TimeUtils.h"
+#include "settings/Settings.h"
+#include "settings/MediaSettings.h"
+#include "ApplicationMessenger.h"
+#include "Application.h"
+#include "threads/Atomics.h"
+#include "guilib/GUIWindowManager.h"
+#include "cores/VideoRenderers/RenderFlags.h"
+#include "settings/DisplaySettings.h"
+#include "cores/VideoRenderers/RenderManager.h"
+
+#include "linux/RBP.h"
+
+#ifdef _DEBUG
+#define MMAL_DEBUG_VERBOSE
+#endif
+
+#define CLASSNAME "CMMALVideoBuffer"
+
+CMMALVideoBuffer::CMMALVideoBuffer(CMMALVideo *omv)
+    : m_omv(omv), m_refs(0)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, this);
+#endif
+  mmal_buffer = NULL;
+  width = 0;
+  height = 0;
+  index = 0;
+  m_aspect_ratio = 0.0f;
+  m_changed_count = 0;
+  dts = DVD_NOPTS_VALUE;
+}
+
+CMMALVideoBuffer::~CMMALVideoBuffer()
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, this);
+#endif
+}
+
+
+CMMALVideoBuffer* CMMALVideoBuffer::Acquire()
+{
+  long count = AtomicIncrement(&m_refs);
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p (%p) ref:%ld", CLASSNAME, __func__, this, mmal_buffer, count);
+  #endif
+  (void)count;
+  return this;
+}
+
+long CMMALVideoBuffer::Release()
+{
+  long count = AtomicDecrement(&m_refs);
+#if defined(MMAL_DEBUG_VERBOSE)
+CLog::Log(LOGDEBUG, "%s::%s %p (%p) ref:%ld", CLASSNAME, __func__, this, mmal_buffer, count);
+#endif
+  if (count == 0)
+  {
+    m_omv->ReleaseBuffer(this);
+  }
+  return count;
+}
+
+#undef CLASSNAME
+#define CLASSNAME "CMMALVideo"
+
+CMMALVideo::CMMALVideo()
+{
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, this);
+  #endif
+  pthread_mutex_init(&m_output_mutex, NULL);
+
+  m_drop_state = false;
+  m_decoded_width = 0;
+  m_decoded_height = 0;
+
+  m_finished = false;
+  m_pFormatName = "mmal-xxxx";
+
+  m_interlace_mode = MMAL_InterlaceProgressive;
+  m_interlace_method = VS_INTERLACEMETHOD_NONE;
+  m_startframe = false;
+  m_decoderPts = DVD_NOPTS_VALUE;
+  m_droppedPics = 0;
+  m_decode_frame_number = 1;
+
+  m_dec = NULL;
+  m_dec_input = NULL;
+  m_dec_output = NULL;
+  m_dec_input_pool = NULL;
+  m_dec_output_pool = NULL;
+
+  m_deint = NULL;
+  m_deint_connection = NULL;
+
+  m_codingType = 0;
+
+  m_changed_count = 0;
+  m_changed_count_dec = 0;
+  m_output_busy = 0;
+  m_demux_queue_length = 0;
+  m_es_format = mmal_format_alloc();
+}
+
+CMMALVideo::~CMMALVideo()
+{
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, this);
+  #endif
+  assert(m_finished);
+  Reset();
+
+  pthread_mutex_destroy(&m_output_mutex);
+
+  if (m_deint && m_deint->control && m_deint->control->is_enabled)
+    mmal_port_disable(m_deint->control);
+
+  if (m_dec && m_dec->control && m_dec->control->is_enabled)
+    mmal_port_disable(m_dec->control);
+
+  if (m_dec_input && m_dec_input->is_enabled)
+    mmal_port_disable(m_dec_input);
+  m_dec_input = NULL;
+
+  if (m_dec_output && m_dec_output->is_enabled)
+    mmal_port_disable(m_dec_output);
+  m_dec_output = NULL;
+
+  if (m_deint_connection)
+    mmal_connection_destroy(m_deint_connection);
+  m_deint_connection = NULL;
+
+  if (m_deint && m_deint->is_enabled)
+    mmal_component_disable(m_deint);
+
+  if (m_dec && m_dec->is_enabled)
+      mmal_component_disable(m_dec);
+
+  if (m_dec_input_pool)
+    mmal_pool_destroy(m_dec_input_pool);
+  m_dec_input_pool = NULL;
+
+  if (m_dec_output_pool)
+    mmal_pool_destroy(m_dec_output_pool);
+  m_dec_output_pool = NULL;
+
+  if (m_deint)
+    mmal_component_destroy(m_deint);
+  m_deint = NULL;
+
+  if (m_dec)
+    mmal_component_destroy(m_dec);
+  m_dec = NULL;
+  mmal_format_free(m_es_format);
+  m_es_format = NULL;
+}
+
+void CMMALVideo::PortSettingsChanged(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  MMAL_EVENT_FORMAT_CHANGED_T *fmt = mmal_event_format_changed_get(buffer);
+  mmal_format_copy(m_es_format, fmt->format);
+  m_changed_count++;
+
+  if (m_es_format->es->video.crop.width && m_es_format->es->video.crop.height)
+  {
+    if (m_es_format->es->video.par.num && m_es_format->es->video.par.den)
+      m_aspect_ratio = (float)(m_es_format->es->video.par.num * m_es_format->es->video.crop.width) / (m_es_format->es->video.par.den * m_es_format->es->video.crop.height);
+    m_decoded_width = m_es_format->es->video.crop.width;
+    m_decoded_height = m_es_format->es->video.crop.height;
+    CLog::Log(LOGDEBUG, "%s::%s format changed: %dx%d %.2f frame:%d", CLASSNAME, __func__, m_decoded_width, m_decoded_height, m_aspect_ratio, m_changed_count);
+  }
+  else
+    CLog::Log(LOGERROR, "%s::%s format changed: Unexpected %dx%d", CLASSNAME, __func__, m_es_format->es->video.crop.width, m_es_format->es->video.crop.height);
+}
+
+void CMMALVideo::dec_control_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  MMAL_STATUS_T status;
+
+  if (buffer->cmd == MMAL_EVENT_ERROR)
+  {
+    status = (MMAL_STATUS_T)*(uint32_t *)buffer->data;
+    CLog::Log(LOGERROR, "%s::%s Error (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+  }
+  else if (buffer->cmd == MMAL_EVENT_FORMAT_CHANGED)
+  {
+    CLog::Log(LOGDEBUG, "%s::%s format changed", CLASSNAME, __func__);
+    PortSettingsChanged(port, buffer);
+  }
+  else
+    CLog::Log(LOGERROR, "%s::%s other (cmd:%x data:%x)", CLASSNAME, __func__, buffer->cmd, *(uint32_t *)buffer->data);
+
+  mmal_buffer_header_release(buffer);
+}
+
+static void dec_control_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  CMMALVideo *mmal = reinterpret_cast<CMMALVideo*>(port->userdata);
+  mmal->dec_control_port_cb(port, buffer);
+}
+
+
+static void dec_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s port:%p buffer %p, len %d cmd:%x", CLASSNAME, __func__, port, buffer, buffer->length, buffer->cmd);
+#endif
+  mmal_buffer_header_release(buffer);
+}
+
+
+void CMMALVideo::dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  if (!(buffer->cmd == 0 && buffer->length > 0))
+    CLog::Log(LOGDEBUG, "%s::%s port:%p buffer %p, len %d cmd:%x", CLASSNAME, __func__, port, buffer, buffer->length, buffer->cmd);
+#endif
+  bool kept = false;
+
+  if (buffer->cmd == 0)
+  {
+    if (buffer->length > 0)
+    {
+      assert(!(buffer->flags & MMAL_BUFFER_HEADER_FLAG_DECODEONLY));
+      double dts = DVD_NOPTS_VALUE;
+      if (buffer->flags & MMAL_BUFFER_HEADER_FLAG_USER0)
+      {
+        pthread_mutex_lock(&m_output_mutex);
+        if (!m_dts_queue.empty())
+        {
+          dts = m_dts_queue.front();
+          m_dts_queue.pop();
+        }
+        else assert(0);
+        pthread_mutex_unlock(&m_output_mutex);
+      }
+
+      if (m_drop_state)
+      {
+        CLog::Log(LOGDEBUG, "%s::%s - dropping %p (drop:%d)", CLASSNAME, __func__, buffer, m_drop_state);
+      }
+      else
+      {
+        CMMALVideoBuffer *omvb = new CMMALVideoBuffer(this);
+        m_output_busy++;
+#if defined(MMAL_DEBUG_VERBOSE)
+        CLog::Log(LOGDEBUG, "%s::%s - %p (%p) buffer_size(%u) dts:%.3f pts:%.3f flags:%x:%x frame:%d",
+          CLASSNAME, __func__, buffer, omvb, buffer->length, dts*1e-6, buffer->pts*1e-6, buffer->flags, buffer->type->video.flags, omvb->m_changed_count);
+#endif
+        omvb->mmal_buffer = buffer;
+        buffer->user_data = (void *)omvb;
+        omvb->m_changed_count = m_changed_count;
+        omvb->dts = dts;
+        omvb->width = m_decoded_width;
+        omvb->height = m_decoded_height;
+        omvb->m_aspect_ratio = m_aspect_ratio;
+        pthread_mutex_lock(&m_output_mutex);
+        m_output_ready.push(omvb);
+        pthread_mutex_unlock(&m_output_mutex);
+        kept = true;
+      }
+    }
+  }
+  else if (buffer->cmd == MMAL_EVENT_FORMAT_CHANGED)
+  {
+    PortSettingsChanged(port, buffer);
+  }
+  if (!kept)
+    mmal_buffer_header_release(buffer);
+}
+
+static void dec_output_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+  CMMALVideo *mmal = reinterpret_cast<CMMALVideo*>(port->userdata);
+  mmal->dec_output_port_cb(port, buffer);
+}
+
+bool CMMALVideo::change_dec_output_format()
+{
+  MMAL_STATUS_T status;
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+
+  MMAL_PARAMETER_VIDEO_INTERLACE_TYPE_T interlace_type = {{ MMAL_PARAMETER_VIDEO_INTERLACE_TYPE, sizeof( interlace_type )}};
+  status = mmal_port_parameter_get( m_dec_output, &interlace_type.hdr );
+
+  if (status == MMAL_SUCCESS)
+  {
+    if (m_interlace_mode != interlace_type.eMode)
+    {
+      CLog::Log(LOGDEBUG, "%s::%s Interlace mode %d->%d", CLASSNAME, __func__, m_interlace_mode, interlace_type.eMode);
+      m_interlace_mode = interlace_type.eMode;
+    }
+  }
+  else
+    CLog::Log(LOGERROR, "%s::%s Failed to query interlace type on %s (status=%x %s)", CLASSNAME, __func__, m_dec_output->name, status, mmal_status_to_string(status));
+
+  // todo: if we don't disable/enable we can do this from callback
+  mmal_format_copy(m_dec_output->format, m_es_format);
+  status = mmal_port_format_commit(m_dec_output);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to commit decoder output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+  return true;
+}
+
+bool CMMALVideo::CreateDeinterlace(EINTERLACEMETHOD interlace_method)
+{
+  MMAL_STATUS_T status;
+
+  CLog::Log(LOGDEBUG, "%s::%s method:%d", CLASSNAME, __func__, interlace_method);
+
+  assert(!m_deint);
+  assert(m_dec_output == m_dec->output[0]);
+
+  status = mmal_port_disable(m_dec_output);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to disable decoder output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  /* Create deinterlace filter */
+  status = mmal_component_create("vc.ril.image_fx", &m_deint);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to create deinterlace component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+  MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imfx_param = {{MMAL_PARAMETER_IMAGE_EFFECT_PARAMETERS, sizeof(imfx_param)}, MMAL_PARAM_IMAGEFX_DEINTERLACE_FAST, 1, {3}};
+  status = mmal_port_parameter_set(m_deint->output[0], &imfx_param.hdr);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to set deinterlace parameters (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  MMAL_PORT_T *m_deint_input = m_deint->input[0];
+  m_deint_input->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+
+  // Now connect the decoder output port to deinterlace input port
+  status =  mmal_connection_create(&m_deint_connection, m_dec->output[0], m_deint->input[0], MMAL_CONNECTION_FLAG_TUNNELLING | MMAL_CONNECTION_FLAG_ALLOCATION_ON_INPUT);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to connect deinterlacer component %s (status=%x %s)", CLASSNAME, __func__, m_deint->name, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  status =  mmal_connection_enable(m_deint_connection);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable connection %s (status=%x %s)", CLASSNAME, __func__, m_deint->name, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  mmal_format_copy(m_deint->output[0]->format, m_es_format);
+  status = mmal_port_format_commit(m_deint->output[0]);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to commit deint output format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  status = mmal_component_enable(m_deint);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable deinterlacer component %s (status=%x %s)", CLASSNAME, __func__, m_deint->name, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_deint->output[0]->buffer_size = m_deint->output[0]->buffer_size_min;
+  m_deint->output[0]->buffer_num = m_deint->output[0]->buffer_num_recommended;
+  m_deint->output[0]->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+  status = mmal_port_enable(m_deint->output[0], dec_output_port_cb_static);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable decoder output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec_output = m_deint->output[0];
+  m_interlace_method = interlace_method;
+
+  return true;
+}
+
+bool CMMALVideo::DestroyDeinterlace()
+{
+  MMAL_STATUS_T status;
+
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+
+  assert(m_deint);
+  assert(m_dec_output == m_deint->output[0]);
+
+  status = mmal_port_disable(m_dec_output);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to disable decoder output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  status = mmal_connection_destroy(m_deint_connection);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to destroy deinterlace connection (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+  m_deint_connection = NULL;
+
+  status = mmal_component_disable(m_deint);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to disable deinterlace component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  status = mmal_component_destroy(m_deint);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to destroy deinterlace component (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+  m_deint = NULL;
+
+  m_dec->output[0]->buffer_size = m_dec->output[0]->buffer_size_min;
+  m_dec->output[0]->buffer_num = m_dec->output[0]->buffer_num_recommended;
+  m_dec->output[0]->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+  status = mmal_port_enable(m_dec->output[0], dec_output_port_cb_static);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable decoder output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec_output = m_dec->output[0];
+  m_interlace_method = VS_INTERLACEMETHOD_NONE;
+  return true;
+}
+
+bool CMMALVideo::SendCodecConfigData()
+{
+  MMAL_STATUS_T status;
+  if (!m_dec_input_pool)
+    return true;
+  // send code config data
+  MMAL_BUFFER_HEADER_T *buffer = mmal_queue_timedwait(m_dec_input_pool->queue, 500);
+  if (!buffer)
+  {
+    CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
+    return false;
+  }
+
+  mmal_buffer_header_reset(buffer);
+  buffer->cmd = 0;
+  buffer->length = std::min(m_hints.extrasize, buffer->alloc_size);
+  memcpy(buffer->data, m_hints.extradata, buffer->length);
+  buffer->flags |= MMAL_BUFFER_HEADER_FLAG_FRAME_END | MMAL_BUFFER_HEADER_FLAG_CONFIG;
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s - %-8p %-6d flags:%x", CLASSNAME, __func__, buffer, buffer->length, buffer->flags);
+#endif
+  status = mmal_port_send_buffer(m_dec_input, buffer);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed send buffer to decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+  return true;
+}
+
+bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options, MMALVideoPtr myself)
+{
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d", CLASSNAME, __func__, CSettings::Get().GetBool("videoplayer.usemmal"), hints.software, hints.width, hints.height);
+  #endif
+
+  // we always qualify even if DVDFactoryCodec does this too.
+  if (!CSettings::Get().GetBool("videoplayer.usemmal") || hints.software)
+    return false;
+
+  m_hints = hints;
+  MMAL_STATUS_T status;
+  MMAL_PARAMETER_BOOLEAN_T error_concealment;
+
+  m_myself = myself;
+  m_decoded_width  = hints.width;
+  m_decoded_height = hints.height;
+
+  // use aspect in stream if available
+  if (m_hints.forced_aspect)
+    m_aspect_ratio = m_hints.aspect;
+  else
+    m_aspect_ratio = 0.0;
+
+  switch (hints.codec)
+  {
+    case AV_CODEC_ID_H264:
+      // H.264
+      m_codingType = MMAL_ENCODING_H264;
+      m_pFormatName = "mmal-h264";
+    break;
+    case AV_CODEC_ID_H263:
+    case AV_CODEC_ID_MPEG4:
+      // MPEG-4, DivX 4/5 and Xvid compatible
+      m_codingType = MMAL_ENCODING_MP4V;
+      m_pFormatName = "mmal-mpeg4";
+    break;
+    case AV_CODEC_ID_MPEG1VIDEO:
+    case AV_CODEC_ID_MPEG2VIDEO:
+      // MPEG-2
+      m_codingType = MMAL_ENCODING_MP2V;
+      m_pFormatName = "mmal-mpeg2";
+    break;
+    case AV_CODEC_ID_VP6:
+      // this form is encoded upside down
+      // fall through
+    case AV_CODEC_ID_VP6F:
+    case AV_CODEC_ID_VP6A:
+      // VP6
+      m_codingType = MMAL_ENCODING_VP6;
+      m_pFormatName = "mmal-vp6";
+    break;
+    case AV_CODEC_ID_VP8:
+      // VP8
+      m_codingType = MMAL_ENCODING_VP8;
+      m_pFormatName = "mmal-vp8";
+    break;
+    case AV_CODEC_ID_THEORA:
+      // theora
+      m_codingType = MMAL_ENCODING_THEORA;
+      m_pFormatName = "mmal-theora";
+    break;
+    case AV_CODEC_ID_MJPEG:
+    case AV_CODEC_ID_MJPEGB:
+      // mjpg
+      m_codingType = MMAL_ENCODING_MJPEG;
+      m_pFormatName = "mmal-mjpg";
+    break;
+    case AV_CODEC_ID_VC1:
+    case AV_CODEC_ID_WMV3:
+      // VC-1, WMV9
+      m_codingType = MMAL_ENCODING_WVC1;
+      m_pFormatName = "mmal-vc1";
+      break;
+    default:
+      CLog::Log(LOGERROR, "%s::%s : Video codec unknown: %x", CLASSNAME, __func__, hints.codec);
+      return false;
+    break;
+  }
+
+  if ( (m_codingType == MMAL_ENCODING_MP2V && !g_RBP.GetCodecMpg2() ) ||
+       (m_codingType == MMAL_ENCODING_WVC1 && !g_RBP.GetCodecWvc1() ) )
+  {
+    CLog::Log(LOGWARNING, "%s::%s Codec %s is not supported", CLASSNAME, __func__, m_pFormatName);
+    return false;
+  }
+
+  // initialize mmal.
+  status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_DECODER, &m_dec);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to create MMAL decoder component %s (status=%x %s)", CLASSNAME, __func__, MMAL_COMPONENT_DEFAULT_VIDEO_DECODER, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec->control->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+  status = mmal_port_enable(m_dec->control, dec_control_port_cb_static);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable decoder control port %s (status=%x %s)", CLASSNAME, __func__, MMAL_COMPONENT_DEFAULT_VIDEO_DECODER, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec_input = m_dec->input[0];
+
+  m_dec_input->format->type = MMAL_ES_TYPE_VIDEO;
+  m_dec_input->format->encoding = m_codingType;
+  if (m_hints.width && m_hints.height)
+  {
+    m_dec_input->format->es->video.crop.width = m_hints.width;
+    m_dec_input->format->es->video.crop.height = m_hints.height;
+
+    m_dec_input->format->es->video.width = ALIGN_UP(m_hints.width, 32);
+    m_dec_input->format->es->video.height = ALIGN_UP(m_hints.height, 16);
+  }
+  m_dec_input->format->flags |= MMAL_ES_FORMAT_FLAG_FRAMED;
+
+  error_concealment.hdr.id = MMAL_PARAMETER_VIDEO_DECODE_ERROR_CONCEALMENT;
+  error_concealment.hdr.size = sizeof(MMAL_PARAMETER_BOOLEAN_T);
+  error_concealment.enable = MMAL_FALSE;
+  status = mmal_port_parameter_set(m_dec_input, &error_concealment.hdr);
+  if (status != MMAL_SUCCESS)
+    CLog::Log(LOGERROR, "%s::%s Failed to disable error concealment on %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
+
+  status = mmal_port_parameter_set_uint32(m_dec_input, MMAL_PARAMETER_EXTRA_BUFFERS, NUM_BUFFERS);
+  if (status != MMAL_SUCCESS)
+    CLog::Log(LOGERROR, "%s::%s Failed to enable extra buffers on %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
+
+  status = mmal_port_format_commit(m_dec_input);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to commit format for decoder input port %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
+    return false;
+  }
+  m_dec_input->buffer_size = m_dec_input->buffer_size_recommended;
+  m_dec_input->buffer_num = m_dec_input->buffer_num_recommended;
+
+  m_dec_input->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+  status = mmal_port_enable(m_dec_input, dec_input_port_cb);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable decoder input port %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec_output = m_dec->output[0];
+
+  // set up initial decoded frame format - will likely change from this
+  m_dec_output->format->encoding = MMAL_ENCODING_OPAQUE;
+  mmal_format_copy(m_es_format, m_dec_output->format);
+
+  status = mmal_port_format_commit(m_dec_output);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to commit decoder output format (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec_output->buffer_size = m_dec_output->buffer_size_min;
+  m_dec_output->buffer_num = m_dec_output->buffer_num_recommended;
+  m_dec_output->userdata = (struct MMAL_PORT_USERDATA_T *)this;
+  status = mmal_port_enable(m_dec_output, dec_output_port_cb_static);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable decoder output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  status = mmal_component_enable(m_dec);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to enable decoder component %s (status=%x %s)", CLASSNAME, __func__, m_dec->name, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec_input_pool = mmal_pool_create(m_dec_input->buffer_num, m_dec_input->buffer_size);
+  if (!m_dec_input_pool)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to create pool for decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  m_dec_output_pool = mmal_pool_create(m_dec_output->buffer_num, m_dec_output->buffer_size);
+  if(!m_dec_output_pool)
+  {
+    CLog::Log(LOGERROR, "%s::%s Failed to create pool for decode output port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return false;
+  }
+
+  if (!SendCodecConfigData())
+    return false;
+
+  m_drop_state = false;
+  m_startframe = false;
+
+  return true;
+}
+
+void CMMALVideo::Dispose()
+{
+  // we are happy to exit, but let last shared pointer being deleted trigger the destructor
+  bool done = false;
+  Reset();
+  pthread_mutex_lock(&m_output_mutex);
+  if (!m_output_busy)
+    done = true;
+  m_finished = true;
+  pthread_mutex_unlock(&m_output_mutex);
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s dts_queue(%d) ready_queue(%d) busy_queue(%d) done:%d", CLASSNAME, __func__, m_dts_queue.size(), m_output_ready.size(), m_output_busy, done);
+  #endif
+  if (done)
+  {
+    assert(m_dts_queue.empty());
+    m_myself.reset();
+  }
+}
+
+void CMMALVideo::SetDropState(bool bDrop)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  if (m_drop_state != bDrop)
+    CLog::Log(LOGDEBUG, "%s::%s - m_drop_state(%d)", CLASSNAME, __func__, bDrop);
+#endif
+  m_drop_state = bDrop;
+  if (m_drop_state)
+  {
+    while (1)
+    {
+      CMMALVideoBuffer *buffer = NULL;
+      pthread_mutex_lock(&m_output_mutex);
+      // fetch a output buffer and pop it off the ready list
+      if (!m_output_ready.empty())
+      {
+        buffer = m_output_ready.front();
+        m_output_ready.pop();
+      }
+      pthread_mutex_unlock(&m_output_mutex);
+      if (buffer)
+        ReleaseBuffer(buffer);
+      else
+        break;
+    }
+  }
+}
+
+int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
+{
+  #if defined(MMAL_DEBUG_VERBOSE)
+  //CLog::Log(LOGDEBUG, "%s::%s - %-8p %-6d dts:%.3f pts:%.3f dts_queue(%d) ready_queue(%d) busy_queue(%d)",
+  //   CLASSNAME, __func__, pData, iSize, dts == DVD_NOPTS_VALUE ? 0.0 : dts*1e-6, pts == DVD_NOPTS_VALUE ? 0.0 : pts*1e-6, m_dts_queue.size(), m_output_ready.size(), m_output_busy);
+  #endif
+
+  unsigned int demuxer_bytes = 0;
+  uint8_t *demuxer_content = NULL;
+  MMAL_BUFFER_HEADER_T *buffer;
+  MMAL_STATUS_T status;
+
+  while (buffer = mmal_queue_get(m_dec_output_pool->queue), buffer)
+    Recycle(buffer);
+  // we need to queue then de-queue the demux packet, seems silly but
+  // mmal might not have an input buffer available when we are called
+  // and we must store the demuxer packet and try again later.
+  // try to send any/all demux packets to mmal decoder.
+  unsigned space = mmal_queue_length(m_dec_input_pool->queue) * m_dec_input->buffer_size;
+  if (pData && m_demux_queue.empty() && space >= (unsigned int)iSize)
+  {
+    demuxer_bytes = iSize;
+    demuxer_content = pData;
+  }
+  else if (pData && iSize)
+  {
+    mmal_demux_packet demux_packet;
+    demux_packet.dts = dts;
+    demux_packet.pts = pts;
+    demux_packet.size = iSize;
+    demux_packet.buff = new uint8_t[iSize];
+    memcpy(demux_packet.buff, pData, iSize);
+    m_demux_queue_length += demux_packet.size;
+    m_demux_queue.push(demux_packet);
+  }
+
+  uint8_t *buffer_to_free = NULL;
+
+  while (1)
+  {
+     while (buffer = mmal_queue_get(m_dec_output_pool->queue), buffer)
+       Recycle(buffer);
+
+     space = mmal_queue_length(m_dec_input_pool->queue) * m_dec_input->buffer_size;
+     if (!demuxer_bytes && !m_demux_queue.empty())
+     {
+       mmal_demux_packet &demux_packet = m_demux_queue.front();
+       if (space >= (unsigned int)demux_packet.size)
+       {
+         // need to lock here to retrieve an input buffer and pop the queue
+         m_demux_queue_length -= demux_packet.size;
+         m_demux_queue.pop();
+         demuxer_bytes = (unsigned int)demux_packet.size;
+         demuxer_content = demux_packet.buff;
+         buffer_to_free = demux_packet.buff;
+         dts = demux_packet.dts;
+         pts = demux_packet.pts;
+       }
+     }
+     if (demuxer_content)
+     {
+       // 500ms timeout
+       buffer = mmal_queue_timedwait(m_dec_input_pool->queue, 500);
+       if (!buffer)
+       {
+         CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
+         return VC_ERROR;
+       }
+
+       mmal_buffer_header_reset(buffer);
+       buffer->cmd = 0;
+       if (m_startframe && pts == DVD_NOPTS_VALUE)
+         pts = 0;
+       buffer->pts = pts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : pts;
+       buffer->dts = dts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : dts;
+       buffer->length = demuxer_bytes > buffer->alloc_size ? buffer->alloc_size : demuxer_bytes;
+       buffer->user_data = (void *)m_decode_frame_number;
+       // set a flag so we can identify primary frames from generated frames (deinterlace)
+       buffer->flags = MMAL_BUFFER_HEADER_FLAG_USER0;
+
+       // Request decode only (maintain ref frames, but don't return a picture)
+       if (m_drop_state)
+         buffer->flags |= MMAL_BUFFER_HEADER_FLAG_DECODEONLY;
+
+       memcpy(buffer->data, demuxer_content, buffer->length);
+       demuxer_bytes   -= buffer->length;
+       demuxer_content += buffer->length;
+
+       if (demuxer_bytes == 0)
+         buffer->flags |= MMAL_BUFFER_HEADER_FLAG_FRAME_END;
+
+       #if defined(MMAL_DEBUG_VERBOSE)
+       CLog::Log(LOGDEBUG, "%s::%s - %-8p %-6d/%-6d dts:%.3f pts:%.3f flags:%x dts_queue(%d) ready_queue(%d) busy_queue(%d) demux_queue(%d) space(%d)",
+          CLASSNAME, __func__, buffer, buffer->length, demuxer_bytes, dts == DVD_NOPTS_VALUE ? 0.0 : dts*1e-6, pts == DVD_NOPTS_VALUE ? 0.0 : pts*1e-6, buffer->flags, m_dts_queue.size(), m_output_ready.size(), m_output_busy, m_demux_queue_length, mmal_queue_length(m_dec_input_pool->queue) * m_dec_input->buffer_size);
+       #endif
+       assert((int)buffer->length > 0);
+       status = mmal_port_send_buffer(m_dec_input, buffer);
+       if (status != MMAL_SUCCESS)
+       {
+         CLog::Log(LOGERROR, "%s::%s Failed send buffer to decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+         return VC_ERROR;
+       }
+
+       if (demuxer_bytes == 0)
+       {
+         m_decode_frame_number++;
+         m_startframe = true;
+         if (m_drop_state)
+         {
+           m_droppedPics += m_deint ? 2:1;
+         }
+         else
+         {
+           // only push if we are successful with feeding mmal
+           pthread_mutex_lock(&m_output_mutex);
+           m_dts_queue.push(dts);
+           assert(m_dts_queue.size() < 5000);
+           pthread_mutex_unlock(&m_output_mutex);
+         }
+         if (m_changed_count_dec != m_changed_count)
+         {
+           CLog::Log(LOGDEBUG, "%s::%s format changed frame:%d(%d)", CLASSNAME, __func__, m_changed_count_dec, m_changed_count);
+           m_changed_count_dec = m_changed_count;
+           if (!change_dec_output_format())
+           {
+             CLog::Log(LOGERROR, "%s::%s - change_dec_output_format() failed", CLASSNAME, __func__);
+             return VC_ERROR;
+           }
+         }
+         EDEINTERLACEMODE deinterlace_request = CMediaSettings::Get().GetCurrentVideoSettings().m_DeinterlaceMode;
+         EINTERLACEMETHOD interlace_method = g_renderManager.AutoInterlaceMethod(CMediaSettings::Get().GetCurrentVideoSettings().m_InterlaceMethod);
+
+         bool deinterlace = m_interlace_mode != MMAL_InterlaceProgressive;
+
+         if (deinterlace_request == VS_DEINTERLACEMODE_OFF)
+           deinterlace = false;
+         else if (deinterlace_request == VS_DEINTERLACEMODE_FORCE)
+           deinterlace = true;
+
+         if (((deinterlace && interlace_method != m_interlace_method) || !deinterlace) && m_deint)
+           DestroyDeinterlace();
+         if (deinterlace && !m_deint)
+           CreateDeinterlace(interlace_method);
+
+         if (buffer_to_free)
+         {
+           delete [] buffer_to_free;
+           buffer_to_free = NULL;
+           demuxer_content = NULL;
+           continue;
+         }
+         while (buffer = mmal_queue_get(m_dec_output_pool->queue), buffer)
+           Recycle(buffer);
+       }
+    }
+    if (!demuxer_bytes)
+      break;
+  }
+  int ret = 0;
+  if (!m_output_ready.empty())
+  {
+    #if defined(MMAL_DEBUG_VERBOSE)
+    CLog::Log(LOGDEBUG, "%s::%s -  got output picture:%d", CLASSNAME, __func__, m_output_ready.size());
+    #endif
+    ret |= VC_PICTURE;
+  }
+  if (mmal_queue_length(m_dec_input_pool->queue) > 0 && !m_demux_queue_length)
+  {
+    #if defined(MMAL_DEBUG_VERBOSE)
+    CLog::Log(LOGDEBUG, "%s::%s - got space for output: demux_queue(%d) space(%d)", CLASSNAME, __func__, m_demux_queue_length, mmal_queue_length(m_dec_input_pool->queue) * m_dec_input->buffer_size);
+    #endif
+    ret |= VC_BUFFER;
+  }
+  if (!ret)
+  {
+    CLog::Log(LOGDEBUG, "%s::%s - Nothing to do: dts_queue(%d) ready_queue(%d) busy_queue(%d) demux_queue(%d) space(%d)",
+        CLASSNAME, __func__, m_dts_queue.size(), m_output_ready.size(), m_output_busy, m_demux_queue_length, mmal_queue_length(m_dec_input_pool->queue) * m_dec_input->buffer_size);
+    Sleep(10); // otherwise we busy spin
+  }
+  return ret;
+}
+
+void CMMALVideo::Reset(void)
+{
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
+  #endif
+
+  if (m_dec_input)
+    mmal_port_disable(m_dec_input);
+  if (m_deint_connection)
+    mmal_connection_disable(m_deint_connection);
+  if (m_dec_output)
+    mmal_port_disable(m_dec_output);
+  if (m_dec_input)
+    mmal_port_enable(m_dec_input, dec_input_port_cb);
+  if (m_deint_connection)
+    mmal_connection_enable(m_deint_connection);
+  if (m_dec_output)
+    mmal_port_enable(m_dec_output, dec_output_port_cb_static);
+
+  // blow all ready video frames
+  bool old_drop_state = m_drop_state;
+  SetDropState(true);
+  pthread_mutex_lock(&m_output_mutex);
+  while(!m_dts_queue.empty())
+    m_dts_queue.pop();
+  while (!m_demux_queue.empty())
+    m_demux_queue.pop();
+  m_demux_queue_length = 0;
+  pthread_mutex_unlock(&m_output_mutex);
+  if (!old_drop_state)
+    SetDropState(false);
+
+  SendCodecConfigData();
+
+  m_startframe = false;
+  m_decoderPts = DVD_NOPTS_VALUE;
+  m_droppedPics = 0;
+  m_decode_frame_number = 1;
+}
+
+
+void CMMALVideo::ReturnBuffer(CMMALVideoBuffer *buffer)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p (%d)", CLASSNAME, __func__, buffer, m_output_busy);
+#endif
+
+  mmal_buffer_header_release(buffer->mmal_buffer);
+}
+
+void CMMALVideo::Recycle(MMAL_BUFFER_HEADER_T *buffer)
+{
+#if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, buffer);
+#endif
+
+  MMAL_STATUS_T status;
+  mmal_buffer_header_reset(buffer);
+  buffer->cmd = 0;
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s Send buffer %p from pool to decoder output port %p dts_queue(%d) ready_queue(%d) busy_queue(%d)", CLASSNAME, __func__, buffer, m_dec_output,
+    m_dts_queue.size(), m_output_ready.size(), m_output_busy);
+  #endif
+  status = mmal_port_send_buffer(m_dec_output, buffer);
+  if (status != MMAL_SUCCESS)
+  {
+    CLog::Log(LOGERROR, "%s::%s - Failed send buffer to decoder output port (status=0%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+    return;
+  }
+}
+
+void CMMALVideo::ReleaseBuffer(CMMALVideoBuffer *buffer)
+{
+  // remove from busy list
+  pthread_mutex_lock(&m_output_mutex);
+  assert(m_output_busy > 0);
+  m_output_busy--;
+  pthread_mutex_unlock(&m_output_mutex);
+  ReturnBuffer(buffer);
+  bool done = false;
+  pthread_mutex_lock(&m_output_mutex);
+  if (m_finished && !m_output_busy)
+    done = true;
+  pthread_mutex_unlock(&m_output_mutex);
+  if (done)
+    m_myself.reset();
+  #if defined(MMAL_DEBUG_VERBOSE)
+  CLog::Log(LOGDEBUG, "%s::%s %p (%p) dts_queue(%d) ready_queue(%d) busy_queue(%d) done:%d", CLASSNAME, __func__, buffer, buffer->mmal_buffer, m_dts_queue.size(), m_output_ready.size(), m_output_busy, done);
+  #endif
+  delete buffer;
+}
+
+bool CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
+{
+  if (!m_output_ready.empty())
+  {
+    CMMALVideoBuffer *buffer;
+    // fetch a output buffer and pop it off the ready list
+    pthread_mutex_lock(&m_output_mutex);
+    buffer = m_output_ready.front();
+    m_output_ready.pop();
+    pthread_mutex_unlock(&m_output_mutex);
+
+    assert(buffer->mmal_buffer);
+    memset(pDvdVideoPicture, 0, sizeof *pDvdVideoPicture);
+    pDvdVideoPicture->format = RENDER_FMT_MMAL;
+    pDvdVideoPicture->MMALBuffer = buffer;
+    pDvdVideoPicture->color_range  = 0;
+    pDvdVideoPicture->color_matrix = 4;
+    pDvdVideoPicture->iWidth  = buffer->width ? buffer->width : m_decoded_width;
+    pDvdVideoPicture->iHeight = buffer->height ? buffer->height : m_decoded_height;
+    pDvdVideoPicture->iDisplayWidth  = pDvdVideoPicture->iWidth;
+    pDvdVideoPicture->iDisplayHeight = pDvdVideoPicture->iHeight;
+    //CLog::Log(LOGDEBUG, "%s::%s -  %dx%d %dx%d %dx%d %dx%d %f,%f", CLASSNAME, __func__, pDvdVideoPicture->iWidth, pDvdVideoPicture->iHeight, pDvdVideoPicture->iDisplayWidth, pDvdVideoPicture->iDisplayHeight, m_decoded_width, m_decoded_height, buffer->width, buffer->height, buffer->m_aspect_ratio, m_hints.aspect);
+
+    if (buffer->m_aspect_ratio > 0.0)
+    {
+      pDvdVideoPicture->iDisplayWidth  = ((int)lrint(pDvdVideoPicture->iHeight * buffer->m_aspect_ratio)) & -3;
+      if (pDvdVideoPicture->iDisplayWidth > pDvdVideoPicture->iWidth)
+      {
+        pDvdVideoPicture->iDisplayWidth  = pDvdVideoPicture->iWidth;
+        pDvdVideoPicture->iDisplayHeight = ((int)lrint(pDvdVideoPicture->iWidth / buffer->m_aspect_ratio)) & -3;
+      }
+    }
+
+    // timestamp is in microseconds
+    pDvdVideoPicture->dts = buffer->dts;
+    pDvdVideoPicture->pts = buffer->mmal_buffer->pts == MMAL_TIME_UNKNOWN || buffer->mmal_buffer->pts == 0 ? DVD_NOPTS_VALUE : buffer->mmal_buffer->pts;
+
+    pDvdVideoPicture->MMALBuffer->Acquire();
+    pDvdVideoPicture->iFlags  = DVP_FLAG_ALLOCATED;
+#if defined(MMAL_DEBUG_VERBOSE)
+    CLog::Log(LOGINFO, "%s::%s dts:%.3f pts:%.3f flags:%x:%x MMALBuffer:%p mmal_buffer:%p", CLASSNAME, __func__,
+        pDvdVideoPicture->dts == DVD_NOPTS_VALUE ? 0.0 : pDvdVideoPicture->dts*1e-6, pDvdVideoPicture->pts == DVD_NOPTS_VALUE ? 0.0 : pDvdVideoPicture->pts*1e-6,
+        pDvdVideoPicture->iFlags, buffer->mmal_buffer->flags, pDvdVideoPicture->MMALBuffer, pDvdVideoPicture->MMALBuffer->mmal_buffer);
+#endif
+    assert(!(buffer->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_DECODEONLY));
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "%s::%s - called but m_output_ready is empty", CLASSNAME, __func__);
+    return false;
+  }
+
+  if (pDvdVideoPicture->pts != DVD_NOPTS_VALUE)
+    m_decoderPts = pDvdVideoPicture->pts;
+  else
+    m_decoderPts = pDvdVideoPicture->dts; // xxx is DVD_NOPTS_VALUE better?
+
+  return true;
+}
+
+bool CMMALVideo::ClearPicture(DVDVideoPicture* pDvdVideoPicture)
+{
+  if (pDvdVideoPicture->format == RENDER_FMT_MMAL)
+  {
+#if defined(MMAL_DEBUG_VERBOSE)
+    CLog::Log(LOGDEBUG, "%s::%s - %p (%p)", CLASSNAME, __func__, pDvdVideoPicture->MMALBuffer, pDvdVideoPicture->MMALBuffer->mmal_buffer);
+#endif
+    pDvdVideoPicture->MMALBuffer->Release();
+  }
+  memset(pDvdVideoPicture, 0, sizeof *pDvdVideoPicture);
+  return true;
+}
+
+bool CMMALVideo::GetCodecStats(double &pts, int &droppedPics)
+{
+  pts = m_decoderPts;
+  droppedPics = m_droppedPics;
+  m_droppedPics = 0;
+#if defined(MMAL_DEBUG_VERBOSE)
+  //CLog::Log(LOGDEBUG, "%s::%s - pts:%.0f droppedPics:%d", CLASSNAME, __func__, pts, droppedPics);
+#endif
+  return true;
+}

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/MMALCodec.h
@@ -1,0 +1,159 @@
+#pragma once
+/*
+ *      Copyright (C) 2010-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(HAS_MMAL)
+
+#include <interface/mmal/mmal.h>
+#include <interface/mmal/util/mmal_util.h>
+#include <interface/mmal/util/mmal_default_components.h>
+#include <interface/mmal/util/mmal_util_params.h>
+#include <interface/mmal/util/mmal_connection.h>
+#include <interface/mmal/mmal_parameters.h>
+
+#include "cores/dvdplayer/DVDStreamInfo.h"
+#include "DVDVideoCodec.h"
+#include "threads/Event.h"
+#include "xbmc/settings/VideoSettings.h"
+
+#include <queue>
+#include <semaphore.h>
+#include <boost/shared_ptr.hpp>
+#include "utils/StdString.h"
+#include "guilib/Geometry.h"
+#include "rendering/RenderSystem.h"
+#include "cores/VideoRenderers/BaseRenderer.h"
+
+class CMMALVideo;
+typedef boost::shared_ptr<CMMALVideo> MMALVideoPtr;
+
+// a mmal video frame
+class CMMALVideoBuffer
+{
+public:
+  CMMALVideoBuffer(CMMALVideo *omv);
+  virtual ~CMMALVideoBuffer();
+
+  MMAL_BUFFER_HEADER_T *mmal_buffer;
+  int width;
+  int height;
+  float m_aspect_ratio;
+  int index;
+  double dts;
+  uint32_t m_changed_count;
+  // reference counting
+  CMMALVideoBuffer* Acquire();
+  long              Release();
+  CMMALVideo *m_omv;
+  long m_refs;
+private:
+};
+
+class CMMALVideo
+{
+  typedef struct mmal_demux_packet {
+    uint8_t *buff;
+    int size;
+    double dts;
+    double pts;
+  } mmal_demux_packet;
+
+public:
+  CMMALVideo();
+  virtual ~CMMALVideo();
+
+  // Required overrides
+  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options, MMALVideoPtr myself);
+  virtual void Dispose(void);
+  virtual int  Decode(uint8_t *pData, int iSize, double dts, double pts);
+  virtual void Reset(void);
+  virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
+  virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
+  virtual unsigned GetAllowedReferences() { return NUM_BUFFERS; }
+  virtual void SetDropState(bool bDrop);
+  virtual const char* GetName(void) { return (const char*)m_pFormatName; }
+  virtual bool GetCodecStats(double &pts, int &droppedPics);
+
+  // MMAL decoder callback routines.
+  void ReleaseBuffer(CMMALVideoBuffer *buffer);
+  void Recycle(MMAL_BUFFER_HEADER_T *buffer);
+
+  // MMAL decoder callback routines.
+  void dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+  void dec_control_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+  uint32_t          m_changed_count;
+  uint32_t          m_changed_count_dec;
+
+protected:
+  void QueryCodec(void);
+  void ReturnBuffer(CMMALVideoBuffer *buffer);
+  bool CreateDeinterlace(EINTERLACEMETHOD interlace_method);
+  bool DestroyDeinterlace();
+
+  // Video format
+  bool              m_drop_state;
+  int               m_decoded_width;
+  int               m_decoded_height;
+  unsigned int      m_egl_buffer_count;
+  bool              m_finished;
+  float             m_aspect_ratio;
+  const char        *m_pFormatName;
+  MMALVideoPtr      m_myself;
+
+  std::queue<double> m_dts_queue;
+  std::queue<mmal_demux_packet> m_demux_queue;
+  unsigned           m_demux_queue_length;
+
+  // mmal output buffers (video frames)
+  pthread_mutex_t   m_output_mutex;
+  int m_output_busy;
+  std::queue<CMMALVideoBuffer*> m_output_ready;
+  std::vector<CMMALVideoBuffer*> m_output_buffers;
+
+  // initialize mmal and get decoder component
+  bool Initialize( const CStdString &decoder_name);
+  void PortSettingsChanged(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+  bool SendCodecConfigData();
+
+  CDVDStreamInfo    m_hints;
+  // Components
+  MMAL_INTERLACETYPE_T m_interlace_mode;
+  EINTERLACEMETHOD  m_interlace_method;
+  bool              m_startframe;
+  unsigned int      m_decode_frame_number;
+  double            m_decoderPts;
+  unsigned int      m_droppedPics;
+
+  MMAL_COMPONENT_T *m_dec;
+  MMAL_PORT_T *m_dec_input;
+  MMAL_PORT_T *m_dec_output;
+  MMAL_POOL_T *m_dec_input_pool;
+  MMAL_POOL_T *m_dec_output_pool;
+
+  MMAL_ES_FORMAT_T *m_es_format;
+  MMAL_COMPONENT_T *m_deint;
+  MMAL_CONNECTION_T *m_deint_connection;
+
+  MMAL_FOURCC_T m_codingType;
+  bool change_dec_output_format();
+};
+
+// defined(HAS_MMAL)
+#endif

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/Makefile.in
@@ -37,6 +37,11 @@ ifeq (@USE_LIBSTAGEFRIGHT@,1)
 SRCS += DVDVideoCodecStageFright.cpp
 endif
 
+ifeq (@USE_MMAL@,1)
+SRCS += MMALCodec.cpp
+SRCS += DVDVideoCodecMMAL.cpp
+endif
+
 LIB=Video.a
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -998,6 +998,7 @@ static std::string GetRenderFormatName(ERenderFormat format)
     case RENDER_FMT_BYPASS:    return "BYPASS";
     case RENDER_FMT_MEDIACODEC:return "MEDIACODEC";
     case RENDER_FMT_IMXMAP:    return "IMXMAP";
+    case RENDER_FMT_MMAL:      return "MMAL";
     case RENDER_FMT_NONE:      return "NONE";
   }
   return "UNKNOWN";


### PR DESCRIPTION
While omxplayer is the best performing player on the Pi (and the only option for raw Blu-Rays)
there are some reasons to use dvdplayer on a Pi:

DVDs with menus do not work well with omxplayer
support of software decode for SD codecs like divx3, msmpeg, sorenson spark etc
omxplayer doesn't support alsa, so can't be used with USB and I2S sound cards
dvdplayer may behave better with dodgy timestamps and packet loss, e.g. with live TV

So this PR adds hardware acceleration to dvdplayer using the MMAL api.

There is also a MMAL based video renderer. Compared to using GL, this:
saves the processing cost of YUV->RGB conversion
saves the memory cost of the RGB textures for video frames (1080p = 3MB for YUV and 8MB for RGB)
allows high quality (cubic) scaling
