### PR TITLE
[darwin] Add real manufacturer name detection

### DIFF
--- a/xbmc/osx/DarwinUtils.h
+++ b/xbmc/osx/DarwinUtils.h
@@ -55,4 +55,10 @@ extern "C"
 }
 #endif
 
+class CDarwinUtils
+{
+public:
+  static const std::string&  GetManufacturer(void);
+};
+
 #endif

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -758,7 +758,7 @@ std::string CSysInfo::GetManufacturerName(void)
     int propLen = __system_property_get("ro.product.manufacturer", deviceCStr);
     manufName.assign(deviceCStr, (propLen > 0 && propLen <= PROP_VALUE_MAX) ? propLen : 0);
 #elif defined(TARGET_DARWIN)
-    manufName = "Apple";
+    manufName = CDarwinUtils::GetManufacturer();
 #elif defined(TARGET_WINDOWS)
     HKEY hKey;
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"HARDWARE\\DESCRIPTION\\System\\BIOS", 0, KEY_READ, &hKey) == ERROR_SUCCESS)


### PR DESCRIPTION
This PR will add detection of real manufacturer name for Darwin platform. This will fix funny log strings like "Running on Apple VMware7,1.."
