### PR TITLE
[confluence] fix: changing theme breaks background

### DIFF
--- a/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence/720p/IncludesBackgroundBuilding.xml
@@ -8,7 +8,7 @@
 			<width>1280</width>
 			<height>720</height>
 			<aspectratio>scale</aspectratio>
-			<texture>$INFO[Skin.CurrentTheme,special://skin/backgrounds/,.jpg]</texture>
+			<texture>special://skin/backgrounds/SKINDEFAULT.jpg</texture>
 			<visible>![Skin.HasSetting(UseCustomBackground) + !IsEmpty(Skin.String(CustomBackgroundPath))]</visible>
 			<include>VisibleFadeEffect</include>
 		</control>


### PR DESCRIPTION
This fixes http://trac.xbmc.org/ticket/15429 which I opened myself.

The root cause is not fully understood and is probably not fixed.

However with this change the expected behaviour is normal and changing
themes whatever the theme name is no longer breaks the totally unrelated
background with this fix.

If someone feels like investigating and making a proper fix please go
ahead as I dont understand the underlying C++ and skinning is really not
my speciality.

This can probably also be cherry picked into Gotham since it is also affected.

@ronie 
## Edit

Ok it turns out that themes MUST include backgrounds if they dont, there is no working fallback mechanism currently (I couldnt find it) so as a result the issue exists. So this PR will likely not suit as fix. Still here it is, as a reminder that this should be handled more graciously by default.
