### PR TITLE
[addons] only prompt for master pin for new add-on installations

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -211,13 +211,16 @@ bool CAddonInstaller::PromptForInstall(const std::string &addonID, AddonPtr &add
 
 bool CAddonInstaller::Install(const std::string &addonID, bool force, const std::string &referer, bool background)
 {
-  if (!g_passwordManager.CheckMenuLock(WINDOW_ADDON_BROWSER))
-    return false;
-
   AddonPtr addon;
   bool addonInstalled = CAddonMgr::Get().GetAddon(addonID, addon, ADDON_UNKNOWN, false);
   if (addonInstalled && !force)
     return true;
+
+  if (referer.empty())
+  {
+    if (!g_passwordManager.CheckMenuLock(WINDOW_ADDON_BROWSER))
+      return false;
+  }
 
   // check whether we have it available in a repository
   CAddonDatabase database;


### PR DESCRIPTION
Do not prompt for master pin In case we're installing an add-on update or add-on dep. Master pin prompting will happen on new add-on installs only. ticket @ http://trac.xbmc.org/ticket/15422
