### PR TITLE
[linux] Upgrade SDL1.2 to SDL2 for hotpluggable joysticks

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1199,7 +1199,7 @@ AC_SEARCH_LIBS([__dn_expand],resolv)
 # platform dependent libraries
 if test "$host_vendor" = "apple" ; then
   if test "$use_arch" != "arm"; then
-    AC_CHECK_LIB([SDL2],      [main],, AC_MSG_ERROR($missing_library))
+    AC_CHECK_LIB([SDL],      [main],, AC_MSG_ERROR($missing_library))
     AC_DEFINE([HAVE_SDL],[1],["Define to 1 if using sdl"])
     AC_DEFINE([SDL_VERSION],[1],["SDL major version"])
   fi
@@ -2090,7 +2090,7 @@ fi
 
 if test "$use_joystick" = "yes"; then
   final_message="$final_message\n  Joystick:\tYes"
-  SDL_DEFINES="$SDL_DEFINES -DHAS_SDL_JOYSTICK"
+  AC_DEFINE([HAS_SDL_JOYSTICK],[1],["Define to 1 if using SDL joystick"])
 else
   final_message="$final_message\n  Joystick:\tNo"
 fi

--- a/configure.in
+++ b/configure.in
@@ -1036,7 +1036,7 @@ else
     fi
   else
     AC_MSG_RESULT(== WARNING: OpenGL support is disabled. ${APP_NAME} will run VERY slow. ==)
-    AC_CHECK_LIB([SDL_gfx],[main])
+    AC_CHECK_LIB([SDL2_gfx],[main])
   fi
 fi
 
@@ -1199,8 +1199,9 @@ AC_SEARCH_LIBS([__dn_expand],resolv)
 # platform dependent libraries
 if test "$host_vendor" = "apple" ; then
   if test "$use_arch" != "arm"; then
-    AC_CHECK_LIB([SDL],      [main],, AC_MSG_ERROR($missing_library))
+    AC_CHECK_LIB([SDL2],      [main],, AC_MSG_ERROR($missing_library))
     AC_DEFINE([HAVE_SDL],[1],["Define to 1 if using sdl"])
+    AC_DEFINE([SDL_VERSION],[1],["SDL major version"])
   fi
 else
 if test "$target_platform" != "target_android" ; then
@@ -1220,9 +1221,15 @@ else
   AC_MSG_NOTICE($dbus_disabled)
 fi
   if test "x$use_sdl" != "xno"; then
-    PKG_CHECK_MODULES([SDL],   [sdl],
-      [INCLUDES="$INCLUDES $SDL_CFLAGS"; LIBS="$LIBS $SDL_LIBS"],
-      AC_MSG_ERROR($missing_library))
+    PKG_CHECK_MODULES([SDL2],   [sdl2], 
+      [AC_DEFINE([SDL_VERSION],[2],["SDL major version"])
+       INCLUDES="$INCLUDES $SDL2_CFLAGS"; LIBS="$LIBS $SDL2_LIBS";],
+      [PKG_CHECK_MODULES([SDL],   [sdl],
+        [AC_DEFINE([SDL_VERSION],[1],["SDL major version"])
+         INCLUDES="$INCLUDES $SDL_CFLAGS"; LIBS="$LIBS $SDL_LIBS"; use_joystick=no],
+        [AC_MSG_ERROR($missing_library)])
+      ]
+    )
     AC_CHECK_LIB([SDL_image],  [main],, AC_MSG_ERROR($missing_library))
     AC_DEFINE([HAVE_SDL],[1],["Define to 1 if using sdl"])
   fi

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -47,7 +47,9 @@
 <!-- 13              D-Pad Right               -->
 <!-- 14              D-Pad Up                  -->
 <!-- 15              D-Pad Down                -->
-<!-- Axis 6 +1/-1    Triggers - malfunctioning -->
+<!-- Axis 3 +1/-1    Triggers left/right (win) -->
+<!-- Axis 3          Left Trigger (linux)      -->
+<!-- Axis 6          Right Trigger (linux)     -->
 
 <!-- Axis Mappings:                   -->
 <!--                                  -->
@@ -90,6 +92,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <!-- A selects. B goes back. X gets context menu. Y goes fullscreen and back. -->
       <button id="1">Select</button>
       <button id="2">Back</button>
@@ -112,8 +115,8 @@
       <axis id="1" limit="+1">AnalogSeekForward</axis>
       <axis id="2" limit="-1">AnalogSeekForward</axis>
       <axis id="2" limit="+1">AnalogSeekBack</axis>
-      <axis id="3" limit="+1">ScrollUp</axis>
-      <axis id="3" limit="-1">ScrollDown</axis>
+      <axis id="3" trigger="true" limit="+1">ScrollUp</axis>
+      <axis id="3" trigger="true" limit="-1">ScrollDown</axis>
       <!-- Push up on the right stick for volueme up. Push down for volume down. -->
       <axis id="5" limit="-1">VolumeUp</axis>
       <axis id="5" limit="+1">VolumeDown</axis>
@@ -134,6 +137,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="1">Select</button>
       <button id="2">Back</button>
       <button id="3">ContextMenu</button>
@@ -153,12 +157,12 @@
       <axis id="1" limit="+1">AnalogSeekForward</axis>
       <axis id="2" limit="-1">AnalogSeekForward</axis>
       <axis id="2" limit="+1">AnalogSeekBack</axis>
+      <axis id="3" trigger="true" rest="-32768">ScrollUp</axis>
       <axis id="4" limit="-1">VolumeDown</axis>
       <axis id="4" limit="+1">VolumeUp</axis>
       <axis id="5" limit="-1">VolumeUp</axis>
       <axis id="5" limit="+1">VolumeDown</axis>
-      <axis id="6" limit="-1">ScrollUp</axis>
-      <axis id="6" limit="+1">ScrollDown</axis>
+      <axis id="6" trigger="true" rest="-32768">ScrollDown</axis>
       <hat id="1" position="up">Up</hat>
       <hat id="1" position="down">Down</hat>
       <hat id="1" position="left">Left</hat>
@@ -183,6 +187,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="8">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -195,6 +200,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="8">Skin.ToggleSetting(HomeViewToggle)</button>
     </joystick>
   </Home>
@@ -216,6 +222,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="6">Highlight</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -228,6 +235,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="6">Highlight</button>
     </joystick>
   </MyFiles>
@@ -249,6 +257,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="5">Delete</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -261,6 +270,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="5">Delete</button>
     </joystick>
   </MyMusicPlaylist>
@@ -286,6 +296,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <!--
             A pauses and starts the video.
             B stops the video.
@@ -328,6 +339,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="3">OSD</button>
@@ -342,8 +354,8 @@
       <button id="13">StepForward</button>
       <button id="14">ChapterOrBigStepForward</button>
       <button id="15">ChapterOrBigStepBack</button>
-      <axis id="6" limit="-1">AnalogRewind</axis>
-      <axis id="6" limit="+1">AnalogFastForward</axis>
+      <axis id="3">AnalogRewind</axis>
+      <axis id="6">AnalogFastForward</axis>
       <hat id="1" position="up">BigStepForward</hat>
       <hat id="1" position="down">BigStepBack</hat>
       <hat id="1" position="left">StepBack</hat>
@@ -368,6 +380,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="11">ChannelUp</button>
       <button id="12">ChannelDown</button>
       <button id="13">PreviousChannelGroup</button>
@@ -387,6 +400,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="12">PreviousChannelGroup</button>
       <button id="13">NextChannelGroup</button>
       <button id="14">ChannelUp</button>
@@ -462,6 +476,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
       <button id="3">OSD</button>
       <button id="8">Close</button>
@@ -478,11 +493,12 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
       <button id="3">OSD</button>
       <button id="8">Close</button>
-      <axis id="6" limit="+1">AnalogRewind</axis>
-      <axis id="6" limit="-1">AnalogFastForward</axis>
+      <axis id="3">AnalogRewind</axis>
+      <axis id="6">AnalogFastForward</axis>
     </joystick>
   </FullscreenInfo>
   <PlayerControls>
@@ -503,6 +519,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="3">Close</button>
       <button id="9">Close</button>
       <button id="10">Close</button>
@@ -517,6 +534,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="3">Close</button>
       <button id="10">Close</button>
       <button id="11">Close</button>
@@ -540,6 +558,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="3">ActivateWindow(MusicOSD)</button>
@@ -567,6 +586,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="3">ActivateWindow(MusicOSD)</button>
@@ -577,8 +597,8 @@
       <button id="13">NextPreset</button>
       <button id="14">SkipPrevious</button>
       <button id="15">SkipNext</button>
-      <axis id="6" limit="-1">AnalogRewind</axis>
-      <axis id="6" limit="+1">AnalogFastForward</axis>
+      <axis id="3">AnalogRewind</axis>
+      <axis id="6">AnalogFastForward</axis>
       <hat id="1" position="up">SkipNext</hat>
       <hat id="1" position="down">SkipPrevious</hat>
       <hat id="1" position="left">PreviousPreset</hat>
@@ -603,6 +623,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="3">Close</button>
       <button id="6">Info</button>
     </joystick>
@@ -616,6 +637,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="3">Close</button>
       <button id="6">Info</button>
     </joystick>
@@ -638,6 +660,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -650,6 +673,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
     </joystick>
   </VisualisationSettings>
@@ -671,6 +695,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -683,6 +708,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
     </joystick>
   </VisualisationPresetList>
@@ -704,6 +730,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="4">ZoomNormal</button>
@@ -732,6 +759,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="1">Pause</button>
       <button id="2">Stop</button>
       <button id="4">ZoomNormal</button>
@@ -743,8 +771,8 @@
       <button id="15">ZoomOut</button>
       <axis id="1">AnalogMove</axis>
       <axis id="2">AnalogMove</axis>
-      <axis id="6" limit="+1">ZoomOut</axis>
-      <axis id="6" limit="-1">ZoomIn</axis>
+      <axis id="3">ZoomOut</axis>
+      <axis id="6">ZoomIn</axis>
       <hat id="1" position="up">ZoomIn</hat>
       <hat id="1" position="down">ZoomOut</hat>
       <hat id="1" position="left">PreviousPicture</hat>
@@ -769,6 +797,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
@@ -783,6 +812,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
@@ -806,6 +836,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
@@ -820,6 +851,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="3">ResetCalibration</button>
       <button id="5">NextResolution</button>
       <button id="6">NextCalibration</button>
@@ -843,6 +875,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="3">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -855,6 +888,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="3">Close</button>
     </joystick>
   </VideoOSD>
@@ -876,6 +910,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Stop</button>
       <button id="3">OSD</button>
       <button id="5">AspectRatio</button>
@@ -891,6 +926,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Stop</button>
       <button id="3">OSD</button>
       <button id="5">AspectRatio</button>
@@ -915,6 +951,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
@@ -928,6 +965,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
@@ -950,6 +988,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
@@ -963,6 +1002,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="5">AspectRatio</button>
       <button id="3">Close</button>
     </joystick>
@@ -985,6 +1025,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="5">Delete</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -997,6 +1038,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="5">Delete</button>
     </joystick>
   </VideoBookmarks>
@@ -1022,6 +1064,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="5">Delete</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1034,6 +1077,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="5">Delete</button>
     </joystick>
   </MyVideoPlaylist>
@@ -1055,6 +1099,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+	  <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">BackSpace</button>
       <button id="4">Symbols</button>
       <button id="5">Shift</button>
@@ -1072,12 +1117,13 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">BackSpace</button>
       <button id="4">Symbols</button>
       <button id="5">Shift</button>
       <button id="10">Enter</button>
-      <axis id="6" limit="+1">CursorLeft</axis>
-      <axis id="6" limit="-1">CursorRight</axis>
+      <axis id="3">CursorLeft</axis>
+      <axis id="6">CursorRight</axis>
     </joystick>
   </VirtualKeyboard>
   <ContextMenu>
@@ -1098,6 +1144,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
       <button id="3">Close</button>
     </joystick>
@@ -1111,6 +1158,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
       <button id="3">Close</button>
     </joystick>
@@ -1133,6 +1181,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="3">Info</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1145,6 +1194,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="3">Info</button>
     </joystick>
   </Scripts>
@@ -1166,6 +1216,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">PreviousMenu</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1178,6 +1229,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">PreviousMenu</button>
     </joystick>
   </Settings>
@@ -1199,6 +1251,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1211,6 +1264,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
     </joystick>
   </AddonInformation>
@@ -1232,6 +1286,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1244,6 +1299,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
     </joystick>
   </AddonSettings>
@@ -1265,6 +1321,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1277,6 +1334,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
     </joystick>
   </TextViewer>
@@ -1298,6 +1356,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">PreviousMenu</button>
       <button id="9">PreviousMenu</button>
     </joystick>
@@ -1311,6 +1370,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">PreviousMenu</button>
       <button id="10">PreviousMenu</button>
     </joystick>
@@ -1333,6 +1393,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">PreviousMenu</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1345,6 +1406,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">PreviousMenu</button>
     </joystick>
   </submenu>
@@ -1366,6 +1428,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1378,6 +1441,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
     </joystick>
   </MusicInformation>
@@ -1399,6 +1463,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">Close</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1411,6 +1476,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">Close</button>
     </joystick>
   </MovieInformation>
@@ -1432,6 +1498,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">BackSpace</button>
       <button id="9">Enter</button>
     </joystick>
@@ -1445,6 +1512,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">BackSpace</button>
       <button id="10">Enter</button>
     </joystick>
@@ -1467,6 +1535,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="9">Stop</button>
     </joystick>
     <joystick name="Microsoft X-Box 360 pad">
@@ -1479,6 +1548,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="11">Stop</button>
     </joystick>
   </GamepadInput>
@@ -1500,6 +1570,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">PreviousMenu</button>
       <button id="9">Close</button>
     </joystick>
@@ -1513,6 +1584,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">PreviousMenu</button>
       <button id="11">Close</button>
     </joystick>
@@ -1535,6 +1607,7 @@
       <altname>Xbox Receiver for Windows (Wireless Controller)</altname>
       <altname>Xbox wireless receiver for windows (Controller)</altname>
       <altname>Gamepad F310 (Controller)</altname>
+      <altname>Razer Sabertooth Elite (Controller)</altname>
       <button id="2">PreviousMenu</button>
       <button id="9">Close</button>
     </joystick>
@@ -1548,6 +1621,7 @@
       <altname>Pelican PL-3601 'TSZ' Wired Xbox 360 Controller</altname>
       <altname>Xbox 360 Wireless Receiver</altname>
       <altname>Xbox 360 Wireless Receiver (XBOX)</altname>
+      <altname>Razer Sabertooth</altname>
       <button id="2">PreviousMenu</button>
       <button id="11">Close</button>
     </joystick>

--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -37,7 +37,7 @@
 <!--   Coming soon.                                                                           -->
 <keymap>
   <global>
-    <joystick name="Sony PLAYSTATION(R)3 Controller">
+    <joystick name="/Sony PLAYSTATION\(R\)3 Controller.*">
       <altname>PLAYSTATION(R)3 Controller</altname>
       <altname>PS3 Controller</altname>
       <altname>Sony Computer Entertainment Wireless Controller</altname>

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -58,7 +58,7 @@ LINUX_SYSTEM_LIBS=
 ifeq ($(OS),linux)
   #not for raspberry pi
   ifneq ($(TARGET_PLATFORM),raspberry-pi)
-    DEPENDS += libsdl linux-system-libs
+    DEPENDS += libsdl2 linux-system-libs
     LINUX_SYSTEM_LIBS = linux-system-libs
   endif
   DEPENDS += alsa-lib
@@ -98,7 +98,7 @@ openssl: $(ZLIB)
 gnutls: nettle $(ZLIB)
 nettle: gmp
 pythonmodule-pil: $(ZLIB) libjpeg-turbo libpng freetype2 python26
-libsdl: $(LINUX_SYSTEM_LIBS)
+libsdl2: $(LINUX_SYSTEM_LIBS)
 libxslt: libgcrypt
 ffmpeg: $(ICONV) $(ZLIB) bzip2 libvorbis $(FFMPEG_DEPENDS)
 

--- a/tools/depends/target/libsdl2/Makefile
+++ b/tools/depends/target/libsdl2/Makefile
@@ -1,0 +1,41 @@
+include ../../Makefile.include
+DEPS= ../../Makefile.include Makefile
+
+# lib name, version
+LIBNAME=SDL2
+VERSION=2.0.3
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+
+# configuration settings
+CONFIGURE=./configure --prefix=$(PREFIX) --disable-video-directfb
+ifneq ($(OS),linux)
+CONFIGURE += --without-x --disable-video-x11
+endif
+
+LIBDYLIB=$(PLATFORM)/build/.libs/lib$(LIBNAME).a
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); ./autogen.sh
+	cd $(PLATFORM); $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -103,8 +103,10 @@
 #include "input/XBMC_vkeys.h"
 #include "input/MouseStat.h"
 
-#ifdef HAS_SDL
+#if SDL_VERSION == 1
 #include <SDL/SDL.h>
+#elif SDL_VERSION == 2
+#include <SDL2/SDL.h>
 #endif
 
 #if defined(FILESYSTEM) && !defined(TARGET_POSIX)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2969,7 +2969,7 @@ bool CApplication::ProcessGamepad(float frameTime)
     CStdString actionName;
     bool fullrange;
     keymapId = joyId + 1;
-    if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joyName.c_str(), keymapId, JACTIVE_BUTTON, actionID, actionName, fullrange))
+    if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joyName, keymapId, JACTIVE_BUTTON, actionID, actionName, fullrange))
     {
       CAction action(actionID, 1.0f, 0.0f, actionName);
       g_Mouse.SetActive(false);
@@ -2987,7 +2987,7 @@ bool CApplication::ProcessGamepad(float frameTime)
     int actionID;
     CStdString actionName;
     bool fullrange;
-    if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joyName.c_str(), keymapId, JACTIVE_AXIS, actionID, actionName, fullrange))
+    if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joyName, keymapId, JACTIVE_AXIS, actionID, actionName, fullrange))
     {
       ResetScreenSaver();
       if (WakeUpScreenSaverAndDPMS())
@@ -3021,7 +3021,7 @@ bool CApplication::ProcessGamepad(float frameTime)
 
     keymapId = position << 16 | keymapId;
 
-    if (keymapId && CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joyName.c_str(), keymapId, JACTIVE_HAT, actionID, actionName, fullrange))
+    if (keymapId && CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joyName, keymapId, JACTIVE_HAT, actionID, actionName, fullrange))
     {
       CAction action(actionID, 1.0f, 0.0f, actionName);
       g_Mouse.SetActive(false);
@@ -3240,7 +3240,7 @@ bool CApplication::ProcessJoystickEvent(const std::string& joystickName, int wKe
    bool fullRange = false;
 
    // Translate using regular joystick translator.
-   if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joystickName.c_str(), wKeyID, inputType, actionID, actionName, fullRange))
+   if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joystickName, wKeyID, inputType, actionID, actionName, fullRange))
      return ExecuteInputAction( CAction(actionID, fAmount, 0.0f, actionName, holdTime) );
    else
      CLog::Log(LOGDEBUG, "ERROR mapping joystick action. Joystick: %s %i",joystickName.c_str(), wKeyID);

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -33,8 +33,10 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
+#include "utils/RegExp.h"
 #include "XBIRRemote.h"
 #include "Util.h"
+#include <boost/shared_ptr.hpp>
 
 #if defined(TARGET_WINDOWS)
 #include "input/windows/WINJoystick.h"
@@ -759,11 +761,11 @@ int CButtonTranslator::TranslateLircRemoteString(const char* szDevice, const cha
 void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
 {
   string joyname = JOYSTICK_DEFAULT_MAP; // default global map name
-  vector<string> joynames;
+  vector<boost::shared_ptr<CRegExp> > joynames;
   map<int, string> buttonMap;
   map<int, string> axisMap;
   AxesConfig axesConfig;
-  map<int, string> hatMap;
+  ActionMap hatMap;
 
   TiXmlElement *pJoy = pJoystick->ToElement();
   if (pJoy && pJoy->Attribute("name"))
@@ -771,7 +773,14 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
   else
     CLog::Log(LOGNOTICE, "No Joystick name specified, loading default map");
 
-  joynames.push_back(joyname);
+  boost::shared_ptr<CRegExp> re(new CRegExp(true, CRegExp::asciiOnly));
+  if (!re->RegComp(JoynameToRegex(joyname), CRegExp::StudyRegExp))
+  {
+    CLog::Log(LOGNOTICE, "Invalid joystick regex specified: '%s'", joyname.c_str());
+    return;
+  }
+  else 
+    joynames.push_back(re);
 
   // parse map
   TiXmlElement *pButton = pJoystick->FirstChildElement();
@@ -846,18 +855,24 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
         CLog::Log(LOGERROR, "Error reading joystick map element, unknown button type: %s", type.c_str());
     }
     else if (type == "altname")
-      joynames.push_back(action);
+    {
+      boost::shared_ptr<CRegExp> altRe(new CRegExp(true, CRegExp::asciiOnly));
+      if (!altRe->RegComp(JoynameToRegex(action), CRegExp::StudyRegExp))
+        CLog::Log(LOGNOTICE, "Ignoring invalid joystick altname regex: '%s'", action.c_str());
+      else
+        joynames.push_back(altRe);
+    }
     else
       CLog::Log(LOGERROR, "Error reading joystick map element, Invalid id: %d", id);
 
     pButton = pButton->NextSiblingElement();
   }
-  vector<string>::iterator it = joynames.begin();
+  vector<boost::shared_ptr<CRegExp> >::iterator it = joynames.begin();
   while (it!=joynames.end())
   {
-    m_joystickButtonMap[*it][windowID] = buttonMap;
-    m_joystickAxisMap[*it][windowID] = axisMap;
-    m_joystickHatMap[*it][windowID] = hatMap;
+    MergeMap(*it, &m_joystickButtonMap, windowID, buttonMap);
+    MergeMap(*it, &m_joystickAxisMap, windowID, axisMap);
+    MergeMap(*it, &m_joystickHatMap, windowID, hatMap);
     if (windowID == -1) 
       m_joystickAxesConfigs[*it] = axesConfig;
 //    CLog::Log(LOGDEBUG, "Found Joystick map for window %d using %s", windowID, it->c_str());
@@ -865,12 +880,54 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
   }
 }
 
-bool CButtonTranslator::TranslateJoystickString(int window, const char* szDevice, int id, short inputType, int& action, std::string& strAction, bool &fullrange)
+std::string CButtonTranslator::JoynameToRegex(const std::string& joyName) const
+{
+  if (joyName.empty()) 
+    return joyName;
+
+  // names already presented as regex are identified by a leading /
+  else if (joyName[0] == '/') 
+    return joyName.substr(1);
+
+  // the others we'll have to escape
+  return "\\Q" + joyName + "\\E";
+}
+
+void CButtonTranslator::MergeMap(boost::shared_ptr<CRegExp> joyName, JoystickMap *joystick, int windowID, const ActionMap &map)
+{
+  // find or create WindowMap entry, match on pattern equality
+  JoystickMap::iterator jit;
+  for (jit = joystick->begin(); jit != joystick->end(); jit++)
+  {
+    if (jit->first->GetPattern() == joyName->GetPattern())
+      break;
+  }
+  WindowMap* w = (jit == joystick->end()) ? &(*joystick)[joyName] : &jit->second;
+    // find or create ActionMap, and merge it
+  (*w)[windowID].insert(map.begin(), map.end());
+}
+
+CButtonTranslator::JoystickMap::const_iterator CButtonTranslator::FindWindowMap(const std::string& joyName, const JoystickMap &maps) const
+{
+  JoystickMap::const_iterator it;
+  for (it = maps.begin(); it != maps.end(); it++)
+  {
+    if (it->first->RegFind(joyName) >= 0)
+    {
+      // CLog::Log(LOGDEBUG, "Regex %s matches joystick %s", it->first->GetPattern().c_str(), joyName.c_str());
+      break;
+    }
+    // CLog::Log(LOGDEBUG, "No match: %s for joystick %s", it->first->GetPattern().c_str(), joyName.c_str());
+  }
+  return it;
+}
+
+bool CButtonTranslator::TranslateJoystickString(int window, const std::string& joyName, int id, short inputType, int& action, std::string& strAction, bool &fullrange)
 {
   fullrange = false;
 
   // resolve the correct JoystickMap
-  map<string, JoystickMap> *jmap;
+  JoystickMap *jmap;
   if (inputType == JACTIVE_AXIS)
     jmap = &m_joystickAxisMap;
   else if (inputType == JACTIVE_BUTTON)
@@ -883,15 +940,15 @@ bool CButtonTranslator::TranslateJoystickString(int window, const char* szDevice
     return false;
   }
 
-  map<string, JoystickMap>::iterator it = jmap->find(szDevice);
+  JoystickMap::const_iterator it = FindWindowMap(joyName, *jmap);
   if (it==jmap->end())
   {
-    it = jmap->find(JOYSTICK_DEFAULT_MAP); // default global map name
+    it = FindWindowMap(JOYSTICK_DEFAULT_MAP, *jmap); // default global map name
     if (it==jmap->end())
       return false;
   }
 
-  JoystickMap wmap = it->second;
+  WindowMap wmap = it->second;
 
   // try to get the action from the current window
   action = GetActionCode(window, id, wmap, strAction, fullrange);
@@ -948,12 +1005,12 @@ int CButtonTranslator::GetActionCode(int window, int action)
 /*
  * Translates a joystick input to an action code
  */
-int CButtonTranslator::GetActionCode(int window, int id, const JoystickMap &wmap, std::string &strAction, bool &fullrange) const
+int CButtonTranslator::GetActionCode(int window, int id, const WindowMap &wmap, std::string &strAction, bool &fullrange) const
 {
   int action = 0;
   bool found = false;
 
-  JoystickMap::const_iterator it = wmap.find(window);
+  WindowMap::const_iterator it = wmap.find(window);
   if (it != wmap.end())
   {
     const map<int, string> &windowbmap = it->second;

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -762,6 +762,7 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
   vector<string> joynames;
   map<int, string> buttonMap;
   map<int, string> axisMap;
+  AxesConfig axesConfig;
   map<int, string> hatMap;
 
   TiXmlElement *pJoy = pJoystick->ToElement();
@@ -811,6 +812,17 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
           axisMap[id] = action;
           axisMap[-id] = action;
         }
+
+        if (windowID == -1) {
+          // in <global> we can override the rest state value of axes and whether they are triggers
+          bool trigger = false;
+          int restStateValue = 0;
+          pButton->QueryBoolAttribute("trigger", &trigger);
+          pButton->QueryIntAttribute("rest", &restStateValue);
+          // if it deviates from the defaults
+          if (trigger || restStateValue != 0)
+            axesConfig.push_back(AxisConfig(id, trigger, restStateValue));
+        }
       }
       else if (type == "hat")
       {
@@ -846,6 +858,8 @@ void CButtonTranslator::MapJoystickActions(int windowID, TiXmlNode *pJoystick)
     m_joystickButtonMap[*it][windowID] = buttonMap;
     m_joystickAxisMap[*it][windowID] = axisMap;
     m_joystickHatMap[*it][windowID] = hatMap;
+    if (windowID == -1) 
+      m_joystickAxesConfigs[*it] = axesConfig;
 //    CLog::Log(LOGDEBUG, "Found Joystick map for window %d using %s", windowID, it->c_str());
     it++;
   }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -35,6 +35,8 @@
 class CKey;
 class CAction;
 class TiXmlNode;
+struct AxisConfig;
+typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
 
 struct CButtonAction
 {
@@ -94,6 +96,8 @@ public:
   bool TranslateJoystickString(int window, const char* szDevice, int id,
                                short inputType, int& action, std::string& strAction,
                                bool &fullrange);
+
+  const std::map<std::string, AxesConfig>& GetAxesConfigs() { return m_joystickAxesConfigs; };
 #endif
 
   bool TranslateTouchAction(int window, int touchAction, int touchPointers, int &action);
@@ -143,6 +147,7 @@ private:
   std::map<std::string, JoystickMap> m_joystickButtonMap;      // <joy name, button map>
   std::map<std::string, JoystickMap> m_joystickAxisMap;        // <joy name, axis map>
   std::map<std::string, JoystickMap> m_joystickHatMap;        // <joy name, hat map>
+  std::map<std::string, AxesConfig> m_joystickAxesConfigs;     // <joy name, axes config>
 #endif
 
   void MapTouchActions(int windowID, TiXmlNode *pTouch);

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -36,7 +36,9 @@ class CKey;
 class CAction;
 class TiXmlNode;
 struct AxisConfig;
+class CRegExp;
 typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
+namespace boost { template <typename T> class shared_ptr; }
 
 struct CButtonAction
 {
@@ -93,11 +95,11 @@ public:
 
   int TranslateLircRemoteString(const char* szDevice, const char *szButton);
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
-  bool TranslateJoystickString(int window, const char* szDevice, int id,
+  bool TranslateJoystickString(int window, const std::string& szDevice, int id,
                                short inputType, int& action, std::string& strAction,
                                bool &fullrange);
 
-  const std::map<std::string, AxesConfig>& GetAxesConfigs() { return m_joystickAxesConfigs; };
+  const std::map<boost::shared_ptr<CRegExp>, AxesConfig>& GetAxesConfigs() { return m_joystickAxesConfigs; };
 #endif
 
   bool TranslateTouchAction(int window, int touchAction, int touchPointers, int &action);
@@ -113,8 +115,10 @@ private:
   int GetActionCode(int window, int action);
   int GetActionCode(int window, const CKey &key, std::string &strAction) const;
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
-  typedef std::map<int, std::map<int, std::string> > JoystickMap; // <window, <button/axis, action> >
-  int GetActionCode(int window, int id, const JoystickMap &wmap, std::string &strAction, bool &fullrange) const;
+  typedef std::map<int, std::string> ActionMap; // <button/axis, action>
+  typedef std::map<int, ActionMap > WindowMap; // <window, actionMap>
+  typedef std::map<boost::shared_ptr<CRegExp>, WindowMap> JoystickMap; // <joystick, windowMap>
+  int GetActionCode(int window, int id, const WindowMap &wmap, std::string &strAction, bool &fullrange) const;
 #endif
   int GetFallbackWindow(int windowID);
 
@@ -143,11 +147,13 @@ private:
 
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
   void MapJoystickActions(int windowID, TiXmlNode *pJoystick);
-
-  std::map<std::string, JoystickMap> m_joystickButtonMap;      // <joy name, button map>
-  std::map<std::string, JoystickMap> m_joystickAxisMap;        // <joy name, axis map>
-  std::map<std::string, JoystickMap> m_joystickHatMap;        // <joy name, hat map>
-  std::map<std::string, AxesConfig> m_joystickAxesConfigs;     // <joy name, axes config>
+  std::string JoynameToRegex(const std::string& joyName) const;
+  void MergeMap(boost::shared_ptr<CRegExp> joyName, JoystickMap *joystick, int windowID, const ActionMap &actionMap);
+  JoystickMap::const_iterator FindWindowMap(const std::string& joyName, const JoystickMap &maps) const;
+  JoystickMap m_joystickButtonMap;                        // <joy name, button map>
+  JoystickMap m_joystickAxisMap;                          // <joy name, axis map>
+  JoystickMap m_joystickHatMap;                           // <joy name, hat map>
+  std::map<boost::shared_ptr<CRegExp>, AxesConfig> m_joystickAxesConfigs;   // <joy name, axes config>
 #endif
 
   void MapTouchActions(int windowID, TiXmlNode *pTouch);

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -30,22 +30,15 @@
 #include <math.h>
 
 #ifdef HAS_SDL_JOYSTICK
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 
 using namespace std;
 
 CJoystick::CJoystick()
 {
-  Reset(true);
   m_joystickEnabled = false;
-  m_NumAxes = 0;
-  m_AxisId = 0;
-  m_JoyId = 0;
-  m_ButtonId = 0;
-  m_HatId = 0;
-  m_HatState = SDL_HAT_CENTERED;
-  m_ActiveFlags = JACTIVE_NONE;
   SetDeadzone(0);
+  Reset();
 }
 
 void CJoystick::OnSettingChanged(const CSetting *setting)
@@ -56,6 +49,16 @@ void CJoystick::OnSettingChanged(const CSetting *setting)
   const std::string &settingId = setting->GetId();
   if (settingId == "input.enablejoystick")
     SetEnabled(((CSettingBool*)setting)->GetValue() && PERIPHERALS::CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
+}
+
+void CJoystick::Reset()
+{
+  m_AxisIdx = -1;
+  m_ButtonIdx = -1;
+  m_HatIdx = -1;
+  m_HatState = SDL_HAT_CENTERED;
+  for (std::vector<AxisState>::iterator it = m_Axes.begin(); it != m_Axes.end(); ++it)
+    it->reset();
 }
 
 void CJoystick::Initialize()
@@ -69,92 +72,70 @@ void CJoystick::Initialize()
     return;
   }
 
-  // clear old joystick names
-  m_JoystickNames.clear();
-
-  // any open ones? if so, close them.
-  if (m_Joysticks.size()>0)
-  {
-    for(size_t idJoy = 0; idJoy < m_Joysticks.size(); idJoy++)
-    {
-      // any joysticks unplugged?
-      if(SDL_JoystickOpened(idJoy))
-        SDL_JoystickClose(m_Joysticks[idJoy]);
-    }
-    m_Joysticks.clear();
-    m_JoyId = -1;
-  }
+  Reset();
 
   // Set deadzone range
   SetDeadzone(g_advancedSettings.m_controllerDeadzone);
 
-  // any joysticks connected?
-  if (SDL_NumJoysticks()>0)
-  {
-    // load joystick names and open all connected joysticks
-    for (int i = 0 ; i<SDL_NumJoysticks() ; i++)
-    {
-      SDL_Joystick *joy = SDL_JoystickOpen(i);
-
-#if defined(TARGET_DARWIN)
-      // On OS X, the 360 controllers are handled externally, since the SDL code is
-      // really buggy and doesn't handle disconnects.
-      //
-      if (std::string(SDL_JoystickName(i)).find("360") != std::string::npos)
-      {
-        CLog::Log(LOGNOTICE, "Ignoring joystick: %s", SDL_JoystickName(i));
-        continue;
-      }
-#endif
-      if (joy)
-      {
-        // Some (Microsoft) Keyboards are recognized as Joysticks by modern kernels
-        // Don't enumerate them
-        // https://bugs.launchpad.net/ubuntu/+source/linux/+bug/390959
-        // NOTICE: Enabled Joystick: Microsoft Wired Keyboard 600
-        // Details: Total Axis: 37 Total Hats: 0 Total Buttons: 57
-        // NOTICE: Enabled Joystick: Microsoft Microsoft® 2.4GHz Transceiver v6.0
-        // Details: Total Axis: 37 Total Hats: 0 Total Buttons: 57
-        // also checks if we have at least 1 button, fixes 
-        // NOTICE: Enabled Joystick: ST LIS3LV02DL Accelerometer
-        // Details: Total Axis: 3 Total Hats: 0 Total Buttons: 0
-        int num_axis = SDL_JoystickNumAxes(joy);
-        int num_buttons = SDL_JoystickNumButtons(joy);
-        if ((num_axis > 20 && num_buttons > 50) || num_buttons == 0)
-        {
-          CLog::Log(LOGNOTICE, "Ignoring Joystick %s Axis: %d Buttons: %d: invalid device properties",
-           SDL_JoystickName(i), num_axis, num_buttons);
-        }
-        else
-        {
-          m_JoystickNames.push_back(string(SDL_JoystickName(i)));
-          CLog::Log(LOGNOTICE, "Enabled Joystick: %s", SDL_JoystickName(i));
-          CLog::Log(LOGNOTICE, "Details: Total Axis: %d Total Hats: %d Total Buttons: %d",
-            num_axis, SDL_JoystickNumHats(joy), num_buttons);
-          m_Joysticks.push_back(joy);
-        }
-      }
-      else
-      {
-        m_JoystickNames.push_back(string(""));
-      }
-    }
-  }
-  
-  // disable joystick events, since we'll be polling them
-  SDL_JoystickEventState(SDL_DISABLE);
+  // joysticks will be loaded once SDL sees them
 }
 
-void CJoystick::Reset(bool axis /*=false*/)
+void CJoystick::AddJoystick(int joyIndex)
 {
-  if (axis)
+  SDL_Joystick *joy = SDL_JoystickOpen(joyIndex);
+  if (!joy)
+    return;
+
+  std::string joyName = std::string(SDL_JoystickName(joy));
+
+
+  // Some (Microsoft) Keyboards are recognized as Joysticks by modern kernels
+  // Don't enumerate them
+  // https://bugs.launchpad.net/ubuntu/+source/linux/+bug/390959
+  // NOTICE: Enabled Joystick: Microsoft Wired Keyboard 600
+  // Details: Total Axis: 37 Total Hats: 0 Total Buttons: 57
+  // NOTICE: Enabled Joystick: Microsoft Microsoft® 2.4GHz Transceiver v6.0
+  // Details: Total Axis: 37 Total Hats: 0 Total Buttons: 57
+  // also checks if we have at least 1 button, fixes
+  // NOTICE: Enabled Joystick: ST LIS3LV02DL Accelerometer
+  // Details: Total Axis: 3 Total Hats: 0 Total Buttons: 0
+  int num_axis = SDL_JoystickNumAxes(joy);
+  int num_buttons = SDL_JoystickNumButtons(joy);
+  int num_hats = SDL_JoystickNumHats(joy);
+  if ((num_axis > 20 && num_buttons > 50) || num_buttons == 0)
   {
-    SetAxisActive(false);
-    for (int i = 0 ; i<MAX_AXES ; i++)
-    {
-      ResetAxis(i);
-    }
+    CLog::Log(LOGNOTICE, "Ignoring Joystick %s Axis: %d Buttons: %d: invalid device properties",
+      joyName.c_str(), num_axis, num_buttons);
+    return;
   }
+
+  // get details
+  CLog::Log(LOGNOTICE, "Enabled Joystick: %s", joyName.c_str());
+  CLog::Log(LOGNOTICE, "Details: Total Axis: %d Total Hats: %d Total Buttons: %d",
+    num_axis, num_hats, num_buttons);
+
+  // store joystick and its instance id for lookups
+  int id = SDL_JoystickInstanceID(joy);
+  m_Joysticks[id] = joy;
+  m_Axes.resize(m_Axes.size() + num_axis);
+
+  // all indices may have changed in m_Joysticks, so we have to invalidate m_Axes
+  ApplyAxesConfigs();
+  Reset();
+}
+
+void CJoystick::RemoveJoystick(int id)
+{
+  CLog::Log(LOGDEBUG, "Joystick with id %d removed", id);
+
+  // invalidate our current values
+  SDL_Joystick *joy = m_Joysticks[id];
+  m_Axes.resize(m_Axes.size() - SDL_JoystickNumAxes(joy));
+  SDL_JoystickClose(joy);
+  m_Joysticks.erase(id);
+  // all indices may have changed in m_Joysticks, so we have to invalidate m_Axes
+  ApplyAxesConfigs();
+  Reset();
 }
 
 void CJoystick::Update()
@@ -162,116 +143,87 @@ void CJoystick::Update()
   if (!IsEnabled())
     return;
 
-  int buttonId    = -1;
-  int axisId      = -1;
-  int hatId       = -1;
-  int numj        = m_Joysticks.size();
-  if (numj <= 0)
-    return;
-
   // update the state of all opened joysticks
   SDL_JoystickUpdate();
+  int axisNum;
+  int buttonIdx = -1, buttonNum;
+  int hatIdx = -1, hatNum;
 
   // go through all joysticks
-  for (int j = 0; j<numj; j++)
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end(); ++it)
   {
-    SDL_Joystick *joy = m_Joysticks[j];
+    SDL_Joystick *joy = it->second;
     int numb = SDL_JoystickNumButtons(joy);
     int numhat = SDL_JoystickNumHats(joy);
     int numax = SDL_JoystickNumAxes(joy);
-    numax = (numax>MAX_AXES)?MAX_AXES:numax;
-    int axisval;
     uint8_t hatval;
 
-    // get button states first, they take priority over axis
     for (int b = 0 ; b<numb ; b++)
     {
       if (SDL_JoystickGetButton(joy, b))
       {
-        m_JoyId = SDL_JoystickIndex(joy);
-        buttonId = b+1;
-        j = numj-1;
+        buttonIdx = MapButton(joy, b);
         break;
       }
     }
-    
+
     for (int h = 0; h < numhat; h++)
     {
       hatval = SDL_JoystickGetHat(joy, h);
       if (hatval != SDL_HAT_CENTERED)
       {
-        m_JoyId = SDL_JoystickIndex(joy);
-        hatId = h + 1;
+        hatIdx = MapHat(joy, h);
         m_HatState = hatval;
-        j = numj-1;
         break; 
       }
     }
 
     // get axis states
-    m_NumAxes = numax;
     for (int a = 0 ; a<numax ; a++)
     {
-      axisval = SDL_JoystickGetAxis(joy, a);
-      axisId = a+1;
-      if (axisId<=0 || axisId>=MAX_AXES)
-      {
-        CLog::Log(LOGERROR, "Axis Id out of range. Maximum supported axis: %d", MAX_AXES);
-      }
-      else
-      {
-        m_Amount[axisId] = axisval;  //[-32768 to 32767]
-      }
-    }
-    m_AxisId = GetAxisWithMaxAmount();
-    if (m_AxisId)
-    {
-      m_JoyId = SDL_JoystickIndex(joy);
-      j = numj-1;
-      break;
+      int axisIdx = MapAxis(joy, a);
+      m_Axes[axisIdx].val = SDL_JoystickGetAxis(joy, a);
     }
   }
 
-  if(hatId==-1)
+  SDL_Joystick *joy;
+  m_AxisIdx = GetAxisWithMaxAmount();
+  if (m_AxisIdx >= 0)
   {
-    if(m_HatId!=0)
-      CLog::Log(LOGDEBUG, "Joystick %d hat %u Centered", m_JoyId, hatId);
+    MapAxis(m_AxisIdx, joy, axisNum);
+    // CLog::Log(LOGDEBUG, "Joystick %d Axis %d Amount %d", JoystickIndex(joy), axisNum + 1, m_Axes[m_AxisIdx].val);
+  }
+
+  if (hatIdx == -1 && m_HatIdx != -1)
+  {
+    // now centered
+    MapHat(m_HatIdx, joy, hatNum);
+    CLog::Log(LOGDEBUG, "Joystick %d hat %u hat centered", JoystickIndex(joy), hatNum + 1);
     m_pressTicksHat = 0;
-    SetHatActive(false);
-    m_HatId = 0;
   }
-  else
+  else if (hatIdx != m_HatIdx)
   {
-    if(hatId!=m_HatId)
-    {
-      CLog::Log(LOGDEBUG, "Joystick %d hat %u Down", m_JoyId, hatId);
-      m_HatId = hatId;
-      m_pressTicksHat = SDL_GetTicks();
-    }
-    SetHatActive();
+    MapHat(hatIdx, joy, hatNum);
+    CLog::Log(LOGDEBUG, "Joystick %d hat %u value %d", JoystickIndex(joy), hatNum + 1, m_HatState);
+    m_pressTicksHat = SDL_GetTicks();
   }
+  m_HatIdx = hatIdx;
 
-  if (buttonId==-1)
+  if (buttonIdx == -1 && m_ButtonIdx != -1)
   {
-    if (m_ButtonId!=0)
-    {
-      CLog::Log(LOGDEBUG, "Joystick %d button %d Up", m_JoyId, m_ButtonId);
-    }
+    MapButton(m_ButtonIdx, joy, buttonNum);
+    CLog::Log(LOGDEBUG, "Joystick %d button %d Up", JoystickIndex(joy), buttonNum + 1);
     m_pressTicksButton = 0;
-    SetButtonActive(false);
-    m_ButtonId = 0;
+    m_ButtonIdx = -1;
   }
-  else
+  else if (buttonIdx != m_ButtonIdx)
   {
-    if (buttonId!=m_ButtonId)
-    {
-      CLog::Log(LOGDEBUG, "Joystick %d button %d Down", m_JoyId, buttonId);
-      m_ButtonId = buttonId;
-      m_pressTicksButton = SDL_GetTicks();
-    }
-    SetButtonActive();
+    MapButton(buttonIdx, joy, buttonNum);
+    CLog::Log(LOGDEBUG, "Joystick %d button %d Down", JoystickIndex(joy), buttonNum + 1);
+    m_pressTicksButton = SDL_GetTicks();
   }
-
+  m_ButtonIdx = buttonIdx;
 }
 
 void CJoystick::Update(SDL_Event& joyEvent)
@@ -279,185 +231,128 @@ void CJoystick::Update(SDL_Event& joyEvent)
   if (!IsEnabled())
     return;
 
-  int buttonId = -1;
-  int axisId = -1;
-  int joyId = -1;
-  DECLARE_UNUSED(bool,ignore = false)
-  DECLARE_UNUSED(bool,axis = false);
-
   switch(joyEvent.type)
   {
-  case SDL_JOYBUTTONDOWN:
-    m_JoyId = joyId = joyEvent.jbutton.which;
-    m_ButtonId = buttonId = joyEvent.jbutton.button + 1;
-    m_pressTicksButton = SDL_GetTicks();
-    SetButtonActive();
-    CLog::Log(LOGDEBUG, "Joystick %d button %d Down", joyId, buttonId);
+  // we do not handle the button/axis/hat events here because
+  // only Update() is equipped to handle keyrepeats
+  case SDL_JOYDEVICEADDED:
+    AddJoystick(joyEvent.jdevice.which);
     break;
 
-  case SDL_JOYAXISMOTION:
-    joyId = joyEvent.jaxis.which;
-    axisId = joyEvent.jaxis.axis + 1;
-    m_NumAxes = SDL_JoystickNumAxes(m_Joysticks[joyId]);
-    if (axisId<=0 || axisId>=MAX_AXES)
-    {
-      CLog::Log(LOGERROR, "Axis Id out of range. Maximum supported axis: %d", MAX_AXES);
-      ignore = true;
-      break;
-    }
-    axis = true;
-    m_JoyId = joyId;
-    if (joyEvent.jaxis.value==0)
-    {
-      ignore = true;
-      m_Amount[axisId] = 0;
-    }
-    else
-    {
-      m_Amount[axisId] = joyEvent.jaxis.value; //[-32768 to 32767]
-    }
-    m_AxisId = GetAxisWithMaxAmount();
-    CLog::Log(LOGDEBUG, "Joystick %d Axis %d Amount %d", joyId, axisId, m_Amount[axisId]);
-    break;
-
-  case SDL_JOYHATMOTION:
-    m_JoyId = joyId = joyEvent.jbutton.which;
-    m_HatId = joyEvent.jhat.hat + 1;
-    m_pressTicksHat = SDL_GetTicks();
-    m_HatState = joyEvent.jhat.value;
-    SetHatActive(m_HatState != SDL_HAT_CENTERED);
-    CLog::Log(LOGDEBUG, "Joystick %d Hat %d Down with position %d", joyId, buttonId, m_HatState);
-    break;
-
-  case SDL_JOYBALLMOTION:
-    ignore = true;
-    break;
-    
-  case SDL_JOYBUTTONUP:
-    m_pressTicksButton = 0;
-    SetButtonActive(false);
-    CLog::Log(LOGDEBUG, "Joystick %d button %d Up", joyEvent.jbutton.which, m_ButtonId);
-
-  default:
-    ignore = true;
+  case SDL_JOYDEVICEREMOVED:
+    RemoveJoystick(joyEvent.jdevice.which);
     break;
   }
 }
 
-bool CJoystick::GetHat(int &id, int &position,bool consider_repeat) 
+bool CJoystick::GetHat(std::string &joyName, int &id, int &position, bool consider_repeat)
 {
   if (!IsEnabled() || !IsHatActive())
-  {
-    id = position = 0;
     return false;
-  }
+
+  SDL_Joystick *joy;
+  MapHat(m_HatIdx, joy, id);
+  joyName = std::string(SDL_JoystickName(joy));
   position = m_HatState;
-  id = m_HatId;
+
   if (!consider_repeat)
     return true;
 
-  static uint32_t lastPressTicks = 0;
-  static uint32_t lastTicks = 0;
-  static uint32_t nowTicks = 0;
-
-  if ((m_HatId>=0) && m_pressTicksHat)
+  static uint32_t lastPressTicksHat = 0;
+  // allow it if it is the first press
+  if (lastPressTicksHat < m_pressTicksHat)
   {
-    // return the id if it's the first press
-    if (lastPressTicks!=m_pressTicksHat)
-    {
-      lastPressTicks = m_pressTicksHat;
-      return true;
-    }
-    nowTicks = SDL_GetTicks();
-    if ((nowTicks-m_pressTicksHat)<500) // 500ms delay before we repeat
-      return false;
-    if ((nowTicks-lastTicks)<100) // 100ms delay before successive repeats
-      return false;
-
-    lastTicks = nowTicks;
+    lastPressTicksHat = m_pressTicksHat;
+    return true;
   }
+  uint32_t nowTicks = SDL_GetTicks();
+  if (nowTicks - m_pressTicksHat < 500) // 500ms delay before we repeat
+    return false;
+  if (nowTicks - lastPressTicksHat < 100) // 100ms delay before successive repeats
+    return false;
+  lastPressTicksHat = nowTicks;
 
   return true;
-} 
+}
 
-bool CJoystick::GetButton(int &id, bool consider_repeat)
+bool CJoystick::GetButton(std::string &joyName, int& id, bool consider_repeat)
 {
   if (!IsEnabled() || !IsButtonActive())
-  {
-    id = 0;
     return false;
-  }
+
+  SDL_Joystick *joy;
+  MapButton(m_ButtonIdx, joy, id);
+  joyName = SDL_JoystickName(joy);
+
   if (!consider_repeat)
+    return true;
+
+  static uint32_t lastPressTicksButton = 0;
+  // allow it if it is the first press
+  if (lastPressTicksButton < m_pressTicksButton)
   {
-    id = m_ButtonId;
+    lastPressTicksButton = m_pressTicksButton;
     return true;
   }
+  uint32_t nowTicks = SDL_GetTicks();
+  if (nowTicks - m_pressTicksButton < 500) // 500ms delay before we repeat
+    return false;
+  if (nowTicks - lastPressTicksButton < 100) // 100ms delay before successive repeats
+    return false;
 
-  static uint32_t lastPressTicks = 0;
-  static uint32_t lastTicks = 0;
-  static uint32_t nowTicks = 0;
-
-  if ((m_ButtonId>=0) && m_pressTicksButton)
-  {
-    // return the id if it's the first press
-    if (lastPressTicks!=m_pressTicksButton)
-    {
-      lastPressTicks = m_pressTicksButton;
-      id = m_ButtonId;
-      return true;
-    }
-    nowTicks = SDL_GetTicks();
-    if ((nowTicks-m_pressTicksButton)<500) // 500ms delay before we repeat
-    {
-      return false;
-    }
-    if ((nowTicks-lastTicks)<100) // 100ms delay before successive repeats
-    {
-      return false;
-    }
-    lastTicks = nowTicks;
-  }
-  id = m_ButtonId;
+  lastPressTicksButton = nowTicks;
   return true;
 }
 
-bool CJoystick::GetAxis (int &id)
+bool CJoystick::GetAxis(std::string &joyName, int& id) const
 { 
   if (!IsEnabled() || !IsAxisActive()) 
-  {
-    id = 0;
-    return false; 
-  }
-  id = m_AxisId; 
-  return true; 
+    return false;
+
+  SDL_Joystick *joy;
+  MapAxis(m_AxisIdx, joy, id);
+  joyName = std::string(SDL_JoystickName(joy));
+
+  return true;
 }
 
-int CJoystick::GetAxisWithMaxAmount()
+int CJoystick::GetAxisWithMaxAmount() const
 {
-  static int maxAmount;
-  static int axis;
-  axis = 0;
-  maxAmount = 0;
-  int tempf;
-  for (int i = 1 ; i<=m_NumAxes ; i++)
+  int maxAmount= 0, axis = -1;
+  for (size_t i = 0; i < m_Axes.size(); i++)
   {
-    tempf = abs(m_Amount[i]);
-    if (tempf>m_DeadzoneRange && tempf>maxAmount)
+    int deadzone = m_Axes[i].trigger ? 0 : m_DeadzoneRange,
+        amount = abs(m_Axes[i].val - m_Axes[i].rest);
+    if (amount > deadzone && amount > maxAmount)
     {
-      maxAmount = tempf;
+      maxAmount = amount;
       axis = i;
     }
   }
-  SetAxisActive(0 != maxAmount);
   return axis;
 }
 
-float CJoystick::GetAmount(int axis)
+float CJoystick::GetAmount(std::string &joyName, int axisNum) const
 {
-  if (m_Amount[axis] > m_DeadzoneRange)
-    return (float)(m_Amount[axis]-m_DeadzoneRange)/(float)(MAX_AXISAMOUNT-m_DeadzoneRange);
-  if (m_Amount[axis] < -m_DeadzoneRange)
-    return (float)(m_Amount[axis]+m_DeadzoneRange)/(float)(MAX_AXISAMOUNT-m_DeadzoneRange);
+  // find matching SDL_Joystick*
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end(); ++it)
+    if (std::string(SDL_JoystickName(it->second)) == joyName)
+      break;
+
+  if (it == m_Joysticks.end())
+    return 0; // invalid joy name
+
+  int axisIdx = MapAxis(it->second, axisNum);
+  int amount = m_Axes[axisIdx].val - m_Axes[axisIdx].rest;
+  int range = MAX_AXISAMOUNT - m_Axes[axisIdx].rest;
+  // deadzones on axes are undesirable
+  int deadzone = m_Axes[axisIdx].trigger ? 0 : m_DeadzoneRange;
+  if (amount > deadzone)
+    return (float)(amount - deadzone) / (float)(range - deadzone);
+  else if (amount < -deadzone)
+    return (float)(amount + deadzone) / (float)(range - deadzone);
+
   return 0;
 }
 
@@ -485,13 +380,12 @@ float CJoystick::SetDeadzone(float val)
 
 bool CJoystick::ReleaseJoysticks()
 {
+  // close open joysticks
+  for (std::map<int, SDL_Joystick*>::const_iterator it = m_Joysticks.begin(); it != m_Joysticks.end(); ++it)
+    SDL_JoystickClose(it->second);
   m_Joysticks.clear();
-  m_JoystickNames.clear();
-  m_HatId = 0;
-  m_ButtonId = 0;
-  m_HatState = SDL_HAT_CENTERED;
-  m_ActiveFlags = JACTIVE_NONE;
-  Reset(true);
+  m_Axes.clear();
+  Reset();
 
   // Restart SDL joystick subsystem
   SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
@@ -509,6 +403,147 @@ bool CJoystick::Reinitialize()
   Initialize();
 
   return true;
+}
+
+void CJoystick::LoadAxesConfigs(const std::map<std::string, AxesConfig> &axesConfigs)
+{
+  m_AxesConfigs.clear();
+  m_AxesConfigs.insert(axesConfigs.begin(), axesConfigs.end());
+}
+
+void CJoystick::ApplyAxesConfigs()
+{
+  // load axes configuration from keymap
+  int axesCount = 0;
+  for (std::map<int, SDL_Joystick*>::const_iterator it = m_Joysticks.begin(); it != m_Joysticks.end(); it++)
+  {
+    std::string joyName(SDL_JoystickName(it->second));
+    std::map<std::string, AxesConfig>::const_iterator axesConfig = m_AxesConfigs.find(joyName);
+    if (axesConfig != m_AxesConfigs.end())
+    {
+      for (AxesConfig::const_iterator it = axesConfig->second.begin(); it != axesConfig->second.end(); ++it)
+      {
+        int axis = axesCount + it->axis - 1;
+        m_Axes[axis].trigger = it->isTrigger;
+        m_Axes[axis].rest = it->rest;
+      }
+    }
+    axesCount += SDL_JoystickNumAxes(it->second);
+  }
+}
+  
+int CJoystick::JoystickIndex(const std::string &joyName) const
+{
+  int i = 0;
+  for (std::map<int, SDL_Joystick*>::const_iterator it = m_Joysticks.begin(); it != m_Joysticks.end(); ++it)
+  {
+    if (joyName == std::string(SDL_JoystickName(it->second)))
+      return i;
+    i++;
+  }
+  return -1;
+}
+
+int CJoystick::JoystickIndex(SDL_Joystick *joy) const
+{
+  int i = 0;
+  for (std::map<int, SDL_Joystick*>::const_iterator it = m_Joysticks.begin(); it != m_Joysticks.end(); ++it)
+  {
+    if (it->second == joy)
+      return i;
+    i++;
+  }
+  return -1;
+}
+
+int CJoystick::MapAxis(SDL_Joystick *joy, int axisNum) const
+{
+  int idx = 0;
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end() && it->second != joy; ++it)
+    idx += SDL_JoystickNumAxes(it->second);
+  if (it == m_Joysticks.end())
+    return -1;
+  else
+    return idx + axisNum;
+}
+
+void CJoystick::MapAxis(int axisIdx, SDL_Joystick *&joy, int &axisNum) const
+{
+  int axisCount = 0;
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end() && axisCount + SDL_JoystickNumAxes(it->second) <= axisIdx; ++it)
+    axisCount += SDL_JoystickNumAxes(it->second);
+  if (it != m_Joysticks.end())
+  {
+    joy = it->second;
+    axisNum = axisIdx - axisCount;
+  }
+  else
+  {
+    joy = NULL;
+    axisNum = -1;
+  }
+}
+
+int CJoystick::MapButton(SDL_Joystick *joy, int buttonNum) const
+{
+  int idx = 0;
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end() && it->second != joy; ++it)
+    idx += SDL_JoystickNumButtons(it->second);
+  if (it == m_Joysticks.end())
+    return -1;
+  else
+    return idx + buttonNum;
+}
+
+void CJoystick::MapButton(int buttonIdx, SDL_Joystick *&joy, int &buttonNum) const
+{
+  int buttonCount = 0;
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end() && buttonCount + SDL_JoystickNumButtons(it->second) <= buttonIdx; ++it)
+    buttonCount += SDL_JoystickNumButtons(it->second);
+  if (it != m_Joysticks.end())
+  {
+    joy = it->second;
+    buttonNum = buttonIdx - buttonCount;
+  }
+  else
+  {
+    joy = NULL;
+    buttonNum = -1;
+  }
+}
+
+int CJoystick::MapHat(SDL_Joystick *joy, int hatNum) const
+{
+  int idx = 0;
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end() && it->second != joy; ++it)
+    idx += SDL_JoystickNumHats(it->second);
+  if (it == m_Joysticks.end())
+    return -1;
+  else
+    return idx + hatNum;
+}
+
+void CJoystick::MapHat(int hatIdx, SDL_Joystick *&joy, int& hatNum) const
+{
+  int hatCount = 0;
+  std::map<int, SDL_Joystick*>::const_iterator it;
+  for (it = m_Joysticks.begin(); it != m_Joysticks.end() && hatCount + SDL_JoystickNumHats(it->second) <= hatIdx; ++it)
+    hatCount += SDL_JoystickNumHats(it->second);
+  if (it != m_Joysticks.end())
+  {
+    joy = it->second;
+    hatNum = hatIdx - hatCount;
+  }
+  else
+  {
+    joy = NULL;
+    hatNum = -1;
+  }
 }
 
 #endif

--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -25,6 +25,7 @@
 #include "settings/lib/ISettingCallback.h"
 #include <vector>
 #include <string>
+#include <map>
 
 #define JACTIVE_BUTTON 0x00000001
 #define JACTIVE_AXIS   0x00000002
@@ -35,17 +36,36 @@
 #define JACTIVE_HAT_DOWN  0x04
 #define JACTIVE_HAT_LEFT  0x08
 
+#if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+struct AxisConfig {
+  int axis;
+  bool isTrigger;
+  int rest;
+  AxisConfig(int axis, bool isTrigger, int rest) : axis(axis), isTrigger(isTrigger), rest(rest) { }
+};
+typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
+#endif
+
 #ifdef HAS_SDL_JOYSTICK
 
-#include <SDL/SDL_joystick.h>
-#include <SDL/SDL_events.h>
+#include <SDL2/SDL_joystick.h>
+#include <SDL2/SDL_events.h>
 
-#define MAX_AXES 64
 #define MAX_AXISAMOUNT 32768
 
+struct AxisState {
+  int val;
+  int rest;
+  bool trigger;
+  AxisState() : val(0), rest(0), trigger(false) { }
+  void reset() { val = rest; }
+};
+
+namespace boost { template <typename T> class shared_ptr; }
 
 // Class to manage all connected joysticks
-
+// Note: 'index' always refers to indices specific to this class,
+//       whereas 'ids' always refer to SDL instance id's
 class CJoystick : public ISettingCallback
 {
 public:
@@ -54,46 +74,52 @@ public:
   virtual void OnSettingChanged(const CSetting *setting);
 
   void Initialize();
-  void Reset(bool axis=false);
-  void ResetAxis(int axisId) { m_Amount[axisId] = 0; }
+  void Reset();
   void Update();
-  void Update(SDL_Event& event);
-  bool GetButton (int& id, bool consider_repeat=true);
-  bool GetAxis (int &id);
-  bool GetHat (int &id, int &position, bool consider_repeat=true);
-  std::string GetJoystick() { return (m_JoyId>-1)?m_JoystickNames[m_JoyId]:""; }
-  int GetAxisWithMaxAmount();
-  float GetAmount(int axis);
-  float GetAmount() { return GetAmount(m_AxisId); }
+  void Update(SDL_Event& joyEvent);
+  bool GetAxis(std::string &joyName, int &id) const;
+  bool GetButton(std::string &joyName, int &id, bool consider_repeat = true);
+  bool GetHat(std::string &joyName, int &id, int &position, bool consider_repeat = true);
+  float GetAmount(std::string &joyName, int axisNum) const;
   bool IsEnabled() const { return m_joystickEnabled; }
   void SetEnabled(bool enabled = true);
   float SetDeadzone(float val);
   bool Reinitialize();
+  typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
+  void LoadAxesConfigs(const std::map<std::string, AxesConfig>& axesConfigs);
+  void ApplyAxesConfigs();
 
 private:
-  void SetAxisActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_AXIS):(m_ActiveFlags&(~JACTIVE_AXIS)); }
-  void SetButtonActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_BUTTON):(m_ActiveFlags&(~JACTIVE_BUTTON)); }
-  void SetHatActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_HAT):(m_ActiveFlags&(~JACTIVE_HAT)); }
-  bool IsButtonActive() { return (m_ActiveFlags & JACTIVE_BUTTON) == JACTIVE_BUTTON; }
-  bool IsAxisActive() { return (m_ActiveFlags & JACTIVE_AXIS) == JACTIVE_AXIS; }
-  bool IsHatActive() { return (m_ActiveFlags & JACTIVE_HAT) == JACTIVE_HAT; }
+  bool IsButtonActive() const { return m_ButtonIdx != -1; }
+  bool IsAxisActive() const { return m_AxisIdx != -1; }
+  bool IsHatActive() const { return m_HatIdx != -1; }
 
+  void AddJoystick(int joyIndex);
+  void RemoveJoystick(int id);
   bool ReleaseJoysticks();
 
-  int m_Amount[MAX_AXES];
-  int m_AxisId;
-  int m_ButtonId;
-  uint8_t m_HatState;
-  int m_HatId; 
-  int m_JoyId;
-  int m_NumAxes;
+  int GetAxisWithMaxAmount() const;
+  int JoystickIndex(const std::string &joyName) const;
+  int JoystickIndex(SDL_Joystick *joy) const;
+  int MapAxis(SDL_Joystick *joy, int axisNum) const ; // <joy, axis> --> axisIdx
+  void MapAxis(int axisIdx, SDL_Joystick *&joy, int &axisNum) const; // axisIdx --> <joy, axis>
+  int MapButton(SDL_Joystick *joy, int buttonNum) const; // <joy, button> --> buttonIdx
+  void MapButton(int buttonIdx, SDL_Joystick *&joy, int &buttonNum) const; // buttonIdx --> <joy, button>
+  int MapHat(SDL_Joystick *joy, int hatNum) const; // <joy, hat> --> hatIdx
+  void MapHat(int hatIdx, SDL_Joystick *&joy, int &hatNum) const; // hatIdx --> <joy, hat>
+
+  std::vector<AxisState> m_Axes;
+  int m_AxisIdx; // active axis
+  int m_ButtonIdx; // active button
+  uint8_t m_HatState; // state of active hat
+  int m_HatIdx; // active hat
+
   int m_DeadzoneRange;
   bool m_joystickEnabled;
   uint32_t m_pressTicksButton;
   uint32_t m_pressTicksHat;
-  uint8_t m_ActiveFlags;
-  std::vector<SDL_Joystick*> m_Joysticks;
-  std::vector<std::string> m_JoystickNames;
+  std::map<int, SDL_Joystick*> m_Joysticks;
+  std::map<std::string, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
 };
 
 extern CJoystick g_Joystick;

--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -61,6 +61,7 @@ struct AxisState {
   void reset() { val = rest; }
 };
 
+class CRegExp;
 namespace boost { template <typename T> class shared_ptr; }
 
 // Class to manage all connected joysticks
@@ -86,7 +87,7 @@ public:
   float SetDeadzone(float val);
   bool Reinitialize();
   typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
-  void LoadAxesConfigs(const std::map<std::string, AxesConfig>& axesConfigs);
+  void LoadAxesConfigs(const std::map<boost::shared_ptr<CRegExp>, AxesConfig>& axesConfigs);
   void ApplyAxesConfigs();
 
 private:
@@ -119,7 +120,7 @@ private:
   uint32_t m_pressTicksButton;
   uint32_t m_pressTicksHat;
   std::map<int, SDL_Joystick*> m_Joysticks;
-  std::map<std::string, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
+  std::map<boost::shared_ptr<CRegExp>, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
 };
 
 extern CJoystick g_Joystick;

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -53,20 +53,9 @@ extern HWND g_hWnd;
 CJoystick::CJoystick()
 {
   CSingleLock lock(m_critSection);
-  Reset(true);
   m_joystickEnabled = false;
-  m_NumAxes = 0;
-  m_AxisId = 0;
-  m_JoyId = 0;
-  m_ButtonId = 0;
-  m_HatId = 0;
-  m_HatState = SDL_HAT_CENTERED;
-  m_ActiveFlags = JACTIVE_NONE;
   SetDeadzone(0);
-
-  m_pDI = NULL;
-  m_lastPressTicks = 0;
-  m_lastTicks = 0;
+  Reset();
 }
 
 CJoystick::~CJoystick()
@@ -84,6 +73,16 @@ void CJoystick::OnSettingChanged(const CSetting *setting)
     SetEnabled(((CSettingBool*)setting)->GetValue() && PERIPHERALS::CPeripheralImon::GetCountOfImonsConflictWithDInput() == 0);
 }
 
+void CJoystick::Reset()
+{
+  m_AxisIdx = -1;
+  m_ButtonIdx = -1;
+  m_HatIdx = -1;
+  m_HatState = SDL_HAT_CENTERED;
+  for (std::vector<AxisState>::iterator it = m_Axes.begin(); it != m_Axes.end(); ++it)
+    it->reset();
+}
+
 void CJoystick::ReleaseJoysticks()
 {
   CSingleLock lock(m_critSection);
@@ -97,14 +96,9 @@ void CJoystick::ReleaseJoysticks()
   }
   m_pJoysticks.clear();
   m_JoystickNames.clear();
+  m_Axes.clear();
   m_devCaps.clear();
-  m_HatId = 0;
-  m_ButtonId = 0;
-  m_HatState = SDL_HAT_CENTERED;
-  m_ActiveFlags = JACTIVE_NONE;
-  Reset(true);
-  m_lastPressTicks = 0;
-  m_lastTicks = 0;
+  Reset();
   // Release any DirectInput objects.
   SAFE_RELEASE( m_pDI );
 }
@@ -137,8 +131,22 @@ BOOL CALLBACK CJoystick::EnumJoysticksCallback( const DIDEVICEINSTANCE* pdidInst
           CLog::Log(LOGNOTICE, __FUNCTION__" : Enabled Joystick: %s", pdidInstance->tszProductName);
           CLog::Log(LOGNOTICE, __FUNCTION__" : Total Axis: %d Total Hats: %d Total Buttons: %d", diDevCaps.dwAxes, diDevCaps.dwPOVs, diDevCaps.dwButtons);
           p_this->m_pJoysticks.push_back(pJoystick);
-          p_this->m_JoystickNames.push_back(pdidInstance->tszProductName);
+          std::string joyName(pdidInstance->tszProductName);
+          p_this->m_JoystickNames.push_back(joyName);;
+          p_this->m_Axes.resize(p_this->m_Axes.size() + 6); // dinput hardcodes to 6 axes
           p_this->m_devCaps.push_back(diDevCaps);
+
+          // load axes configuration from keymap
+          std::map<std::string, AxesConfig>::const_iterator axesConfig = p_this->m_AxesConfigs.find(joyName);
+          if (axesConfig != p_this->m_AxesConfigs.end())
+          {
+            for (AxesConfig::const_iterator it = axesConfig->second.begin(); it != axesConfig->second.end(); ++it)
+            {
+              int axis = p_this->MapAxis(pJoystick, it->axis - 1);
+              p_this->m_Axes[axis].trigger = it->isTrigger;
+              p_this->m_Axes[axis].rest = it->rest;
+            }
+          }
         }
         else
           CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to GetCapabilities for: %s", pdidInstance->tszProductName);
@@ -223,22 +231,8 @@ void CJoystick::Initialize()
       CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to enumerate objects");
   }
 
-  m_JoyId = -1;
-
   // Set deadzone range
   SetDeadzone(g_advancedSettings.m_controllerDeadzone);
-}
-
-void CJoystick::Reset(bool axis /*=true*/)
-{
-  if (axis)
-  {
-    SetAxisActive(false);
-    for (int i = 0 ; i<MAX_AXES ; i++)
-    {
-      ResetAxis(i);
-    }
-  }
 }
 
 void CJoystick::Update()
@@ -246,24 +240,17 @@ void CJoystick::Update()
   if (!IsEnabled())
     return;
 
-  int buttonId    = -1;
-  int axisId      = -1;
-  int hatId       = -1;
-  int numhat      = -1;
-  int numj        = m_pJoysticks.size();
-  if (numj <= 0)
-    return;
+  int axisNum;
+  int buttonIdx = -1, buttonNum;
+  int hatIdx = -1, hatNum;
 
   // go through all joysticks
-  for (int j = 0; j<numj; j++)
+  for (size_t j = 0; j < m_pJoysticks.size(); j++)
   {
     LPDIRECTINPUTDEVICE8 pjoy = m_pJoysticks[j];
+    DIDEVCAPS caps = m_devCaps[j];
     HRESULT hr;
     DIJOYSTATE2 js;           // DInput joystick state
-
-    m_NumAxes = (m_devCaps[j].dwAxes > MAX_AXES) ? MAX_AXES : m_devCaps[j].dwAxes;
-    numhat    = (m_devCaps[j].dwPOVs > 4) ? 4 : m_devCaps[j].dwPOVs;
-
     hr = pjoy->Poll();
     if( FAILED( hr ) )
     {
@@ -279,217 +266,208 @@ void CJoystick::Update()
       // hr may be DIERR_OTHERAPPHASPRIO or other errors.  This
       // may occur when the app is minimized or in the process of
       // switching, so just try again later
+      Reset();
       return;
     }
 
     // Get the input's device state
     if( FAILED( hr = pjoy->GetDeviceState( sizeof( DIJOYSTATE2 ), &js ) ) )
+    {
+      Reset();
       return; // The device should have been acquired during the Poll()
+    }
 
     // get button states first, they take priority over axis
-    for( int b = 0; b < 128; b++ )
+    for (int b = 0; b < caps.dwButtons; b++)
     {
-      if( js.rgbButtons[b] & 0x80 )
+      if (js.rgbButtons[b] & 0x80)
       {
-        m_JoyId = j;
-        buttonId = b+1;
-        j = numj-1;
+        buttonIdx = MapButton(pjoy, b);
+        j = m_pJoysticks.size();
         break;
       }
     }
 
     // get hat position
-    m_HatState = SDL_HAT_CENTERED;
-    for (int h = 0; h < numhat; h++)
+    for (int h = 0; h < caps.dwPOVs; h++)
     {
-      if((LOWORD(js.rgdwPOV[h]) == 0xFFFF) != true)
+      if ((LOWORD(js.rgdwPOV[h]) == 0xFFFF) != true)
       {
-        m_JoyId = j;
-        hatId = h + 1;
-        j = numj-1;
-        if ( (js.rgdwPOV[0] > JOY_POVLEFT) || (js.rgdwPOV[0] < JOY_POVRIGHT) )
-          m_HatState |= SDL_HAT_UP;
+        uint8_t hatval = SDL_HAT_CENTERED;
 
-        if ( (js.rgdwPOV[0] > JOY_POVFORWARD) && (js.rgdwPOV[0] < JOY_POVBACKWARD) )
-          m_HatState |= SDL_HAT_RIGHT;
+        if ((js.rgdwPOV[0] > JOY_POVLEFT) || (js.rgdwPOV[0] < JOY_POVRIGHT))
+          hatval |= SDL_HAT_UP;
 
-        if ( (js.rgdwPOV[0] > JOY_POVRIGHT) && (js.rgdwPOV[0] < JOY_POVLEFT) )
-          m_HatState |= SDL_HAT_DOWN;
+        if ((js.rgdwPOV[0] > JOY_POVFORWARD) && (js.rgdwPOV[0] < JOY_POVBACKWARD))
+          hatval |= SDL_HAT_RIGHT;
 
-        if ( js.rgdwPOV[0] > JOY_POVBACKWARD )
-          m_HatState |= SDL_HAT_LEFT;
-        break;
+        if ((js.rgdwPOV[0] > JOY_POVRIGHT) && (js.rgdwPOV[0] < JOY_POVLEFT))
+          hatval |= SDL_HAT_DOWN;
+
+        if (js.rgdwPOV[0] > JOY_POVBACKWARD)
+          hatval |= SDL_HAT_LEFT;
+
+        if (hatval != SDL_HAT_CENTERED)
+        {
+          hatIdx = MapHat(pjoy, h);
+          j = m_pJoysticks.size();
+          m_HatState = hatval;
+        }
       }
     }
 
     // get axis states
-    m_Amount[0] = 0;
-    m_Amount[1] = js.lX;
-    m_Amount[2] = js.lY;
-    m_Amount[3] = js.lZ;
-    m_Amount[4] = js.lRx;
-    m_Amount[5] = js.lRy;
-    m_Amount[6] = js.lRz;
-
-    m_AxisId = GetAxisWithMaxAmount();
-    if (m_AxisId)
-    {
-      m_JoyId = j;
-      j = numj-1;
-      break;
-    }
+    int axisIdx = MapAxis(pjoy, 0);
+    m_Axes[axisIdx + 0].val = js.lX;
+    m_Axes[axisIdx + 1].val = js.lY;
+    m_Axes[axisIdx + 2].val = js.lZ;
+    m_Axes[axisIdx + 3].val = js.lRx;
+    m_Axes[axisIdx + 4].val = js.lRy;
+    m_Axes[axisIdx + 5].val = js.lRz;
   }
 
-  if(hatId==-1)
+  LPDIRECTINPUTDEVICE8 pjoy;
+  m_AxisIdx = GetAxisWithMaxAmount();
+  if (m_AxisIdx >= 0)
   {
-    if(m_HatId!=0)
-      CLog::Log(LOGDEBUG, "Joystick %d hat %d Centered", m_JoyId, abs(hatId));
+    MapAxis(m_AxisIdx, pjoy, axisNum);
+    // CLog::Log(LOGDEBUG, "Joystick %d Axis %d Amount %d", JoystickIndex(pjoy), axisNum + 1, m_Axes[m_AxisIdx].val);
+  }
+
+  if (hatIdx == -1 && m_HatIdx != -1)
+  {
+    // now centered
+    MapHat(m_HatIdx, pjoy, hatNum);
+    CLog::Log(LOGDEBUG, "Joystick %d hat %u hat centered", JoystickIndex(pjoy), hatNum + 1);
     m_pressTicksHat = 0;
-    SetHatActive(false);
-    m_HatId = 0;
   }
-  else
+  else if (hatIdx != m_HatIdx)
   {
-    if(hatId!=m_HatId)
-    {
-      CLog::Log(LOGDEBUG, "Joystick %d hat %u Down", m_JoyId, hatId);
-      m_HatId = hatId;
-      m_pressTicksHat = XbmcThreads::SystemClockMillis();
-    }
-    SetHatActive();
+    MapHat(hatIdx, pjoy, hatNum);
+    CLog::Log(LOGDEBUG, "Joystick %d hat %u value %d", JoystickIndex(pjoy), hatNum + 1, m_HatState);
+    m_pressTicksHat = XbmcThreads::SystemClockMillis();
   }
+  m_HatIdx = hatIdx;
 
-  if (buttonId==-1)
+  if (buttonIdx == -1 && m_ButtonIdx != -1)
   {
-    if (m_ButtonId!=0)
-    {
-      CLog::Log(LOGDEBUG, "Joystick %d button %d Up", m_JoyId, m_ButtonId);
-    }
+    MapButton(m_ButtonIdx, pjoy, buttonNum);
+    CLog::Log(LOGDEBUG, "Joystick %d button %d Up", JoystickIndex(pjoy), buttonNum + 1);
     m_pressTicksButton = 0;
-    SetButtonActive(false);
-    m_ButtonId = 0;
+    m_ButtonIdx = -1;
   }
-  else
+  else if (buttonIdx != m_ButtonIdx)
   {
-    if (buttonId!=m_ButtonId)
-    {
-      CLog::Log(LOGDEBUG, "Joystick %d button %d Down", m_JoyId, buttonId);
-      m_ButtonId = buttonId;
-      m_pressTicksButton = XbmcThreads::SystemClockMillis();
-    }
-    SetButtonActive();
+    MapButton(buttonIdx, pjoy, buttonNum);
+    CLog::Log(LOGDEBUG, "Joystick %d button %d Down", JoystickIndex(pjoy), buttonNum + 1);
+    m_pressTicksButton = XbmcThreads::SystemClockMillis();
   }
+  m_ButtonIdx = buttonIdx;
 
 }
 
-bool CJoystick::GetHat(int &id, int &position,bool consider_repeat)
+bool CJoystick::GetHat(std::string &joyName, int &id, int &position, bool consider_repeat)
 {
   if (!IsEnabled() || !IsHatActive())
-  {
-    id = position = 0;
     return false;
-  }
+  LPDIRECTINPUTDEVICE8 joy;
+  MapHat(m_HatIdx, joy, id);
+  joyName = m_JoystickNames[JoystickIndex(joy)];
   position = m_HatState;
-  id = m_HatId;
+
   if (!consider_repeat)
     return true;
 
-  uint32_t nowTicks = 0;
-
-  if ((m_HatId>=0) && m_pressTicksHat)
+  static uint32_t lastPressTicksHat = 0;
+  // allow it if it is the first press
+  if (lastPressTicksHat < m_pressTicksHat)
   {
-    // return the id if it's the first press
-    if (m_lastPressTicks!=m_pressTicksHat)
-    {
-      m_lastPressTicks = m_pressTicksHat;
-      return true;
-    }
-    nowTicks = XbmcThreads::SystemClockMillis();
-    if ((nowTicks-m_pressTicksHat)<500) // 500ms delay before we repeat
-      return false;
-    if ((nowTicks-m_lastTicks)<100) // 100ms delay before successive repeats
-      return false;
-
-    m_lastTicks = nowTicks;
+    lastPressTicksHat = m_pressTicksHat;
+    return true;
   }
+  uint32_t nowTicks = XbmcThreads::SystemClockMillis();
+  if (nowTicks - m_pressTicksHat < 500) // 500ms delay before we repeat
+    return false;
+  if (nowTicks - lastPressTicksHat < 100) // 100ms delay before successive repeats
+    return false;
+  lastPressTicksHat = nowTicks;
 
   return true;
 }
 
-bool CJoystick::GetButton(int &id, bool consider_repeat)
+bool CJoystick::GetButton(std::string &joyName, int &id, bool consider_repeat)
 {
   if (!IsEnabled() || !IsButtonActive())
-  {
-    id = 0;
     return false;
-  }
+
+  LPDIRECTINPUTDEVICE8 joy;
+  MapButton(m_ButtonIdx, joy, id);
+  joyName = m_JoystickNames[JoystickIndex(joy)];
+
   if (!consider_repeat)
+    return true;
+
+  static uint32_t lastPressTicksButton = 0;
+  // allow it if it is the first press
+  if (lastPressTicksButton < m_pressTicksButton)
   {
-    id = m_ButtonId;
+    lastPressTicksButton = m_pressTicksButton;
     return true;
   }
+  uint32_t nowTicks = XbmcThreads::SystemClockMillis();
+  if (nowTicks - m_pressTicksButton < 500) // 500ms delay before we repeat
+    return false;
+  if (nowTicks - lastPressTicksButton < 100) // 100ms delay before successive repeats
+    return false;
 
-  uint32_t nowTicks = 0;
-
-  if ((m_ButtonId>=0) && m_pressTicksButton)
-  {
-    // return the id if it's the first press
-    if (m_lastPressTicks!=m_pressTicksButton)
-    {
-      m_lastPressTicks = m_pressTicksButton;
-      id = m_ButtonId;
-      return true;
-    }
-    nowTicks = XbmcThreads::SystemClockMillis();
-    if ((nowTicks-m_pressTicksButton)<500) // 500ms delay before we repeat
-    {
-      return false;
-    }
-    if ((nowTicks-m_lastTicks)<100) // 100ms delay before successive repeats
-    {
-      return false;
-    }
-    m_lastTicks = nowTicks;
-  }
-  id = m_ButtonId;
+  lastPressTicksButton = nowTicks;
   return true;
 }
 
-bool CJoystick::GetAxis (int &id)
-{ 
-  if (!IsEnabled() || !IsAxisActive()) 
-  {
-    id = 0;
-    return false; 
-  }
-  id = m_AxisId; 
-  return true; 
+bool CJoystick::GetAxis(std::string &joyName, int &id)
+{
+  if (!IsEnabled() || !IsAxisActive())
+    return false;
+
+  LPDIRECTINPUTDEVICE8 joy;
+  MapAxis(m_AxisIdx, joy, id);
+  joyName = m_JoystickNames[JoystickIndex(joy)];
+
+  return true;
 }
 
-int CJoystick::GetAxisWithMaxAmount()
+int CJoystick::GetAxisWithMaxAmount() const
 {
-  int maxAmount = 0;
-  int axis = 0;
-  int tempf;
-  for (int i = 1 ; i<=m_NumAxes ; i++)
+  int maxAmount = 0, axis = -1;
+  for (size_t i = 0; i < m_Axes.size(); i++)
   {
-    tempf = abs(m_Amount[i]);
-    if (tempf>m_DeadzoneRange && tempf>maxAmount)
+    int deadzone = m_Axes[i].trigger ? 0 : m_DeadzoneRange,
+      amount = abs(m_Axes[i].val - m_Axes[i].rest);
+    if (amount > deadzone && amount > maxAmount)
     {
-      maxAmount = tempf;
+      maxAmount = amount;
       axis = i;
     }
   }
-  SetAxisActive(0 != maxAmount);
   return axis;
 }
 
-float CJoystick::GetAmount(int axis)
+float CJoystick::GetAmount(const std::string &joyName, int axisNum) const
 {
-  if (m_Amount[axis] > m_DeadzoneRange)
-    return (float)(m_Amount[axis]-m_DeadzoneRange)/(float)(MAX_AXISAMOUNT-m_DeadzoneRange);
-  if (m_Amount[axis] < -m_DeadzoneRange)
-    return (float)(m_Amount[axis]+m_DeadzoneRange)/(float)(MAX_AXISAMOUNT-m_DeadzoneRange);
+  int joyIdx = JoystickIndex(joyName);
+  if (joyIdx == -1)
+    return 0;
+
+  int axisIdx = MapAxis(m_pJoysticks[joyIdx], axisNum);
+  int amount = m_Axes[axisIdx].val - m_Axes[axisIdx].rest;
+  int range = MAX_AXISAMOUNT - m_Axes[axisIdx].rest;
+  // deadzones on axes are undesirable
+  int deadzone = m_Axes[axisIdx].trigger ? 0 : m_DeadzoneRange;
+  if (amount > deadzone)
+    return (float)(amount - deadzone) / (float)(range - deadzone);
+  else if (amount < -deadzone)
+    return (float)(amount + deadzone) / (float)(range - deadzone);
+
   return 0;
 }
 
@@ -533,5 +511,121 @@ void CJoystick::Acquire()
       if( (*it) )
         (*it)->Acquire();
     }
+  }
+}
+
+void CJoystick::LoadAxesConfigs(const std::map<std::string, AxesConfig> &axesConfigs)
+{
+  m_AxesConfigs.clear();
+  m_AxesConfigs.insert(axesConfigs.begin(), axesConfigs.end());
+}
+
+int CJoystick::JoystickIndex(const std::string &joyName) const
+{
+  for (size_t i = 0; i < m_JoystickNames.size(); ++i)
+  {
+    if (joyName == m_JoystickNames[i])
+      return i;
+  }
+  return -1;
+}
+
+int CJoystick::JoystickIndex(LPDIRECTINPUTDEVICE8 joy) const
+{
+  for (size_t i = 0; i < m_pJoysticks.size(); ++i)
+  {
+    if (joy == m_pJoysticks[i])
+      return i;
+  }
+  return -1;
+}
+
+int CJoystick::MapAxis(LPDIRECTINPUTDEVICE8 joy, int axisNum) const
+{
+  int idx = 0;
+  size_t i;
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy; ++i)
+    idx += m_devCaps[i].dwAxes;
+  if (i == m_pJoysticks.size())
+    return -1;
+  else
+    return idx + axisNum;
+}
+
+void CJoystick::MapAxis(int axisIdx, LPDIRECTINPUTDEVICE8 &joy, int &axisNum) const
+{
+  int axisCount = 0;
+  size_t i;
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && axisCount + m_devCaps[i].dwAxes <= axisIdx; ++i)
+    axisCount += m_devCaps[i].dwAxes;
+  if (i != m_pJoysticks.size())
+  {
+    joy = m_pJoysticks[i];
+    axisNum = axisIdx - axisCount;
+  }
+  else
+  {
+    joy = NULL;
+    axisNum = -1;
+  }
+}
+
+int CJoystick::MapButton(LPDIRECTINPUTDEVICE8 joy, int buttonNum) const
+{
+  int idx = 0;
+  size_t i;
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy; ++i)
+    idx += m_devCaps[i].dwButtons;
+  if (i == m_pJoysticks.size())
+    return -1;
+  else
+    return idx + buttonNum;
+}
+
+void CJoystick::MapButton(int buttonIdx, LPDIRECTINPUTDEVICE8 &joy, int &buttonNum) const
+{
+  int buttonCount = 0;
+  size_t i;
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && buttonCount + m_devCaps[i].dwButtons <= buttonIdx; ++i)
+    buttonCount += m_devCaps[i].dwButtons;
+  if (i != m_pJoysticks.size())
+  {
+    joy = m_pJoysticks[i];
+    buttonNum = buttonIdx - buttonCount;
+  }
+  else
+  {
+    joy = NULL;
+    buttonNum = -1;
+  }
+}
+
+int CJoystick::MapHat(LPDIRECTINPUTDEVICE8 joy, int hatNum) const
+{
+  int idx = 0;
+  size_t i;
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy; ++i)
+    idx += m_devCaps[i].dwPOVs;
+  if (i == m_pJoysticks.size())
+    return -1;
+  else
+    return idx + hatNum;
+}
+
+void CJoystick::MapHat(int hatIdx, LPDIRECTINPUTDEVICE8 &joy, int &hatNum) const
+{
+  int hatCount = 0;
+  size_t i;
+  for (i = 0; i != m_pJoysticks.size() && m_pJoysticks[i] != joy && hatCount + m_devCaps[i].dwPOVs <= hatIdx; ++i)
+    hatCount += m_devCaps[i].dwPOVs;
+  if (i != m_pJoysticks.size())
+  {
+    joy = m_pJoysticks[i];
+    hatNum = hatIdx - hatCount;
+  }
+  else
+  {
+    joy = NULL;
+    hatNum = -1;
   }
 }

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -51,6 +51,8 @@ struct AxisConfig {
 };
 
 typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
+class CRegExp;
+namespace boost { template <typename T> class shared_ptr; }
 
 // Class to manage all connected joysticks
 class CJoystick : public ISettingCallback
@@ -75,7 +77,7 @@ public:
   bool Reinitialize();
   void Acquire();
   typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
-  void LoadAxesConfigs(const std::map<std::string, AxesConfig> &axesConfigs);
+  void LoadAxesConfigs(const std::map<boost::shared_ptr<CRegExp>, AxesConfig> &axesConfigs);
 
 private:
   bool IsButtonActive() const { return m_ButtonIdx != -1; }
@@ -113,7 +115,7 @@ private:
   std::vector<LPDIRECTINPUTDEVICE8> m_pJoysticks;
   std::vector<std::string> m_JoystickNames;
   std::vector<DIDEVCAPS> m_devCaps;
-  std::map<std::string, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
+  std::map<boost::shared_ptr<CRegExp>, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
 };
 
 extern CJoystick g_Joystick;

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 #include <stdint.h>
 #include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
@@ -34,10 +35,24 @@
 #define JACTIVE_HAT_DOWN  0x04
 #define JACTIVE_HAT_LEFT  0x08
 
-#define MAX_AXES 8
+struct AxisState {
+  int val;
+  int rest;
+  bool trigger;
+  AxisState() : val(0), rest(0), trigger(false) { }
+  void reset() { val = rest; }
+};
+
+struct AxisConfig {
+  int axis;
+  bool isTrigger;
+  int rest;
+  AxisConfig(int axis, bool isTrigger, int rest) : axis(axis), isTrigger(isTrigger), rest(rest) { }
+};
+
+typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
 
 // Class to manage all connected joysticks
-
 class CJoystick : public ISettingCallback
 {
 public:
@@ -45,56 +60,60 @@ public:
   ~CJoystick();
 
   virtual void OnSettingChanged(const CSetting *setting);
-
   void Initialize();
-  void Reset(bool axis=false);
-  void ResetAxis(int axisId) { m_Amount[axisId] = 0; }
+  void Reset();
   void Update();
-  bool GetButton (int& id, bool consider_repeat=true);
-  bool GetAxis (int &id);
-  bool GetHat (int &id, int &position, bool consider_repeat=true);
-  std::string GetJoystick() { return (m_JoyId>-1)?m_JoystickNames[m_JoyId]:""; }
-  int GetAxisWithMaxAmount();
-  float GetAmount(int axis);
-  float GetAmount() { return GetAmount(m_AxisId); }
+
+  bool GetButton(std::string &joyName, int &id, bool consider_repeat = true);
+  bool GetAxis(std::string &joyName, int &id);
+  bool GetHat(std::string &joyName, int &id, int &position, bool consider_repeat = true);
+  float GetAmount(const std::string &joyName, int axisNum) const;
+
   bool IsEnabled() const { return m_joystickEnabled; }
   void SetEnabled(bool enabled = true);
   float SetDeadzone(float val);
   bool Reinitialize();
   void Acquire();
+  typedef std::vector<AxisConfig> AxesConfig; // [<axis, isTrigger, rest state value>]
+  void LoadAxesConfigs(const std::map<std::string, AxesConfig> &axesConfigs);
 
 private:
-  void SetAxisActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_AXIS):(m_ActiveFlags&(~JACTIVE_AXIS)); }
-  void SetButtonActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_BUTTON):(m_ActiveFlags&(~JACTIVE_BUTTON)); }
-  void SetHatActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_HAT):(m_ActiveFlags&(~JACTIVE_HAT)); }
-  bool IsButtonActive() { return (m_ActiveFlags & JACTIVE_BUTTON) == JACTIVE_BUTTON; }
-  bool IsAxisActive() { return (m_ActiveFlags & JACTIVE_AXIS) == JACTIVE_AXIS; }
-  bool IsHatActive() { return (m_ActiveFlags & JACTIVE_HAT) == JACTIVE_HAT; }
+  bool IsButtonActive() const { return m_ButtonIdx != -1; }
+  bool IsAxisActive() const { return m_AxisIdx != -1; }
+  bool IsHatActive() const { return m_HatIdx != -1; }
 
   void ReleaseJoysticks();
+
+  int GetAxisWithMaxAmount() const;
+  int JoystickIndex(const std::string &joyName) const;
+  int JoystickIndex(LPDIRECTINPUTDEVICE8 joy) const;
+  int MapAxis(LPDIRECTINPUTDEVICE8 joy, int axisNum) const; // <joy, axis> --> axisIdx
+  void MapAxis(int axisIdx, LPDIRECTINPUTDEVICE8 &joy, int &axisNum) const; // axisIdx --> <joy, axis>
+  int MapButton(LPDIRECTINPUTDEVICE8 joy, int buttonNum) const; // <joy, button> --> buttonIdx
+  void MapButton(int buttonIdx, LPDIRECTINPUTDEVICE8 &joy, int &buttonNum) const; // buttonIdx --> <joy, button>
+  int MapHat(LPDIRECTINPUTDEVICE8 joy, int hatNum) const; // <joy, hat> --> hatIdx
+  void MapHat(int hatIdx, LPDIRECTINPUTDEVICE8 &joy, int &hatNum) const; // hatIdx --> <joy, hat>
+
   static BOOL CALLBACK EnumJoysticksCallback( const DIDEVICEINSTANCE* pdidInstance, VOID* pContext );
   static BOOL CALLBACK EnumObjectsCallback( const DIDEVICEOBJECTINSTANCE* pdidoi, VOID* pContext );
 
-  int m_Amount[MAX_AXES];
-  int m_AxisId;
-  int m_ButtonId;
-  uint8_t m_HatState;
-  int m_HatId;
-  int m_JoyId;
-  int m_NumAxes;
+  std::vector<AxisState> m_Axes;
+  int m_AxisIdx; // active axis
+  int m_ButtonIdx; // active button
+  uint8_t m_HatState; // state of active hat
+  int m_HatIdx; // active hat
+
   int m_DeadzoneRange;
   bool m_joystickEnabled;
   uint32_t m_pressTicksButton;
   uint32_t m_pressTicksHat;
-  uint8_t m_ActiveFlags;
-  uint32_t m_lastPressTicks;
-  uint32_t m_lastTicks;
   CCriticalSection m_critSection;
 
   LPDIRECTINPUT8  m_pDI;
   std::vector<LPDIRECTINPUTDEVICE8> m_pJoysticks;
   std::vector<std::string> m_JoystickNames;
   std::vector<DIDEVCAPS> m_devCaps;
+  std::map<std::string, AxesConfig> m_AxesConfigs; // <joy, <axis num, isTrigger, restState> >
 };
 
 extern CJoystick g_Joystick;

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -34,8 +34,10 @@
 #include "guilib/GraphicContext.h"
 #include "cores/IPlayer.h"
 
-#ifdef HAS_SDL
+#if SDL_VERSION == 1
 #include <SDL/SDL_stdinc.h>
+#elif SDL_VERSION == 2
+#include <SDL2/SDL_stdinc.h>
 #else
 #define SDL_memset4(dst, val, len)		\
 do {						\

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -233,6 +233,8 @@ bool CWinEventsSDL::MessagePump()
       case SDL_JOYAXISMOTION:
       case SDL_JOYBALLMOTION:
       case SDL_JOYHATMOTION:
+      case SDL_JOYDEVICEADDED:
+      case SDL_JOYDEVICEREMOVED:
         g_Joystick.Update(event);
         ret = true;
         break;

--- a/xbmc/windowing/WinEventsSDL.h
+++ b/xbmc/windowing/WinEventsSDL.h
@@ -25,7 +25,11 @@
 #include "system.h"
 
 #ifdef HAS_SDL
+#if SDL_VERSION == 1
 #include <SDL/SDL_events.h>
+#elif SDL_VERSION == 2
+#include <SDL/SDL_events.h>
+#endif
 
 #include "WinEvents.h"
 

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -613,6 +613,8 @@ bool CWinEventsX11Imp::MessagePump()
       case SDL_JOYAXISMOTION:
       case SDL_JOYBALLMOTION:
       case SDL_JOYHATMOTION:
+      case SDL_JOYDEVICEADDED:
+      case SDL_JOYDEVICEREMOVED:
         g_Joystick.Update(event);
         ret = true;
         break;


### PR DESCRIPTION
This is a set of patches that cleans up some of the CJoystick mess and makes it use SDL2 which brings hotplug support without udev hacks.

This PR continues @topfs2' work (in https://github.com/topfs2/xbmc/tree/sdl2) of moving to SDL2 for linux joystick handling. It is also a followup of https://github.com/xbmc/xbmc/pull/5357 which cleans up some of the joystick mess which made the transition to SDL2 less painful.
